### PR TITLE
fix: use platform PATH separator on Windows

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -10,6 +10,7 @@ use crate::vterm::VTerm;
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use std::collections::HashMap;
 use std::io::{Read, Write};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 pub type PtyWriter = Arc<Mutex<Box<dyn Write + Send>>>;
@@ -204,11 +205,16 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         }
     }
 
-    // Add agend-terminal binary to PATH
+    // Add agend-terminal binary to PATH (use platform PATH separator)
     if let Ok(exe) = std::env::current_exe() {
         if let Some(bin_dir) = exe.parent() {
-            let current_path = std::env::var("PATH").unwrap_or_default();
-            cmd.env("PATH", format!("{}:{current_path}", bin_dir.display()));
+            let mut paths: Vec<PathBuf> = vec![bin_dir.to_path_buf()];
+            if let Some(existing) = std::env::var_os("PATH") {
+                paths.extend(std::env::split_paths(&existing));
+            }
+            if let Ok(joined) = std::env::join_paths(paths) {
+                cmd.env("PATH", joined);
+            }
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -384,12 +384,12 @@ pub fn run(home: &Path, agents: Vec<AgentDef>) -> anyhow::Result<()> {
                 if let Ok(mut core) = handle.core.lock() {
                     core.health.maybe_decay();
                     let agent_state = core.state.current;
-                    let last_output = core.state.last_output;
-                    if core.health.check_hang(agent_state, last_output) {
+                    let silent = core.state.last_output.elapsed();
+                    if core.health.check_hang(agent_state, silent) {
                         tracing::warn!(
                             agent = %name,
                             state = agent_state.display_name(),
-                            silent = ?last_output.elapsed(),
+                            silent = ?silent,
                             "hang detected"
                         );
                     }

--- a/src/health.rs
+++ b/src/health.rs
@@ -133,8 +133,11 @@ impl HealthTracker {
     }
 
     /// Check for hang based on agent state and output timeout.
-    pub fn check_hang(&mut self, agent_state: AgentState, last_output: Instant) -> bool {
-        let silent = last_output.elapsed();
+    ///
+    /// Takes `silent` as a plain `Duration` (rather than `Instant::elapsed()`
+    /// internally) so tests can construct arbitrary durations without
+    /// overflowing on platforms where `Instant` is boot-anchored (Windows).
+    pub fn check_hang(&mut self, agent_state: AgentState, silent: Duration) -> bool {
         let is_hang = match agent_state {
             AgentState::Idle => false, // Waiting for input
             AgentState::Starting => silent > Duration::from_secs(120),
@@ -294,18 +297,14 @@ mod tests {
     #[test]
     fn test_hang_idle_exempt() {
         let mut h = HealthTracker::new();
-        let old = Instant::now() - Duration::from_secs(300);
-        assert!(!h.check_hang(AgentState::Idle, old)); // Idle never hangs
+        assert!(!h.check_hang(AgentState::Idle, Duration::from_secs(300))); // Idle never hangs
     }
 
     #[test]
     fn test_hang_thinking_long_timeout() {
         let mut h = HealthTracker::new();
-        let recent = Instant::now() - Duration::from_secs(100);
-        assert!(!h.check_hang(AgentState::Thinking, recent)); // 100s < 600s
-
-        let old = Instant::now() - Duration::from_secs(700);
-        assert!(h.check_hang(AgentState::Thinking, old)); // 700s > 600s
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(100))); // 100s < 600s
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700))); // 700s > 600s
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -461,41 +461,22 @@ mod tests {
     #[test]
     fn starting_hang_120s() {
         let mut h = HealthTracker::new();
-
-        // 119s — no hang
-        let recent = Instant::now() - Duration::from_secs(119);
-        assert!(!h.check_hang(AgentState::Starting, recent));
-
-        // 121s — hang
-        let old = Instant::now() - Duration::from_secs(121);
-        assert!(h.check_hang(AgentState::Starting, old));
+        assert!(!h.check_hang(AgentState::Starting, Duration::from_secs(119)));
+        assert!(h.check_hang(AgentState::Starting, Duration::from_secs(121)));
     }
 
     #[test]
     fn idle_never_hangs() {
         let mut h = HealthTracker::new();
         // Even with 10000s of silence, Idle should never be considered hung.
-        // On Windows `Instant` is anchored to boot time, so plain subtraction
-        // overflows when the runner has been up for less than the offset.
-        // Fall back to `now` (elapsed ≈ 0) on that path — still exercises
-        // the "Idle never hangs" branch, just at a shorter elapsed time.
-        let ancient = Instant::now()
-            .checked_sub(Duration::from_secs(10_000))
-            .unwrap_or_else(Instant::now);
-        assert!(!h.check_hang(AgentState::Idle, ancient));
+        assert!(!h.check_hang(AgentState::Idle, Duration::from_secs(10_000)));
     }
 
     #[test]
     fn thinking_hang_600s() {
         let mut h = HealthTracker::new();
-
-        // 599s — no hang
-        let recent = Instant::now() - Duration::from_secs(599);
-        assert!(!h.check_hang(AgentState::Thinking, recent));
-
-        // 601s — hang
-        let old = Instant::now() - Duration::from_secs(601);
-        assert!(h.check_hang(AgentState::Thinking, old));
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(599)));
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(601)));
     }
 
     // ── P2: Pattern matching ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- On Windows, `PATH` entries are separated by `;`, not `:`. The previous `format!(\"{}:{current_path}\")` in `agent.rs` corrupted PATH when spawning agents, so every PTY child (cmd.exe, claude, codex, ...) ran with a broken PATH.
- Switched to `std::env::split_paths` + `std::env::join_paths` — portable, platform-correct, and handles quoting edge cases.

## Repro (before fix)
On a real Windows machine running the Phase C build:
```
> agend-terminal.exe app
Error: Failed to spawn 'cmd.exe': CreateProcessW \`\"cmd.exe\\0\"\` in cwd \`Some(\"C:\\\\Users\\\\suzuke\\\\.agend\\\\workspace\\\\shell\\0\")\` failed: 系統找不到指定的檔案。 (os error 2)
```

The CI smoke on `windows-latest` didn't catch this because the runner image happens to resolve `cmd.exe` via Windows System32 fallback even when PATH is garbage; a real user environment is stricter.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --bin agend-terminal` (301 passed)
- [ ] CI green on all three platforms
- [ ] Re-run `agend-terminal.exe app` on Windows after merge → should spawn cmd.exe

🤖 Generated with [Claude Code](https://claude.com/claude-code)