### PR TITLE
fix(app): ignore KeyEventKind::Release on Windows

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,7 +15,7 @@ use crate::layout::{Layout, Pane, SplitDir, Tab};
 use crate::render;
 
 use anyhow::Result;
-use crossterm::event::{self, Event, KeyCode, MouseEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, MouseEventKind};
 use ratatui::layout::Rect;
 use ratatui::DefaultTerminal;
 use std::collections::HashMap;
@@ -354,6 +354,10 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     Err(_) => break,
                 };
                 match ev {
+                    // Windows crossterm emits both Press and Release events for every key;
+                    // Unix only emits Press. Ignoring non-Press avoids every keystroke
+                    // firing the handler twice (breaks Ctrl+B prefix state, etc.).
+                    Event::Key(key) if key.kind != KeyEventKind::Press => {}
                     Event::Key(key) => {
                         // Overlay input handling
                         if !matches!(overlay, Overlay::None) {


### PR DESCRIPTION
## Summary
On Windows, crossterm emits both \`KeyEventKind::Press\` and \`KeyEventKind::Release\` for every keypress. Unix only emits \`Press\`.

Without filtering, every key fires the TUI handler twice. For the tmux-style \`Ctrl+B\` prefix keybindings, the Release event resets the prefix-waiting state immediately after Press sets it — so the follow-up key (c, %, :, ?, d, …) never matches, and all bindings silently no-op.

Mouse events don't have this duplication, which matched the reported symptom: clicking the tab+ button works, Ctrl+B bindings don't.

## Fix
Add a guard arm before the main \`Event::Key\` handler to skip non-Press events:
\`\`\`rust
Event::Key(key) if key.kind != KeyEventKind::Press => {}
Event::Key(key) => { /* existing handler */ }
\`\`\`

## Test plan
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -- -D warnings\`
- [x] \`cargo test --bin agend-terminal\` (301 passed)
- [ ] CI green on all three platforms
- [ ] On Windows: \`agend-terminal.exe app\` → \`Ctrl+B\` \`c\` should open new-tab menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)