### PR TITLE
fix(windows): Ctrl+B d detach in attach + daemon Ctrl+C wake

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -326,10 +326,15 @@ pub fn run(home: &Path, agents: Vec<AgentDef>) -> anyhow::Result<()> {
             )
         })?;
 
+    // Shutdown wake channel — ctrlc handler sends on this so the main loop's
+    // select! wakes immediately instead of waiting up to 10s for the next tick.
+    let (shutdown_tx, shutdown_rx) = crossbeam::channel::bounded::<()>(1);
     let shutdown2 = Arc::clone(&shutdown);
     match ctrlc::set_handler(move || {
         tracing::info!("shutting down...");
         shutdown2.store(true, std::sync::atomic::Ordering::Relaxed);
+        // try_send: if already signaled, the flag is enough.
+        let _ = shutdown_tx.try_send(());
     }) {
         Ok(()) => {}
         Err(e) => tracing::warn!(error = %e, "Ctrl+C handler failed, use `stop`"),
@@ -366,7 +371,7 @@ pub fn run(home: &Path, agents: Vec<AgentDef>) -> anyhow::Result<()> {
             break;
         }
 
-        // Block until either a crash event or periodic tick
+        // Block until a crash event, periodic tick, or shutdown signal.
         let crashed_name: Option<String>;
         crossbeam::select! {
             recv(crash_rx) -> msg => {
@@ -374,6 +379,10 @@ pub fn run(home: &Path, agents: Vec<AgentDef>) -> anyhow::Result<()> {
             }
             recv(tick_rx) -> _ => {
                 crashed_name = None;
+            }
+            recv(shutdown_rx) -> _ => {
+                // Re-check flag at top of loop and break.
+                continue;
             }
         }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3,7 +3,7 @@
 //! Ctrl+B d to detach. Agent keeps running.
 
 use crate::framing::{self, PROTOCOL_VERSION, TAG_DATA};
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::terminal;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -70,6 +70,9 @@ pub fn attach(home: &Path, name: &str) -> anyhow::Result<()> {
             continue;
         }
         match event::read() {
+            // Windows emits both Press and Release; ignore Release to keep
+            // prefix state (ctrl_b_pressed) from toggling off immediately.
+            Ok(Event::Key(key)) if key.kind != KeyEventKind::Press => {}
             Ok(Event::Key(KeyEvent {
                 code, modifiers, ..
             })) => {


### PR DESCRIPTION
## Summary
- **`src/tui.rs`** — apply the same `KeyEventKind::Press` filter that PR #3 added to `src/app/mod.rs`. Windows emits both Press and Release events, which was flipping the `ctrl_b_pressed` prefix state off immediately and doubling every keystroke sent to the agent. Fixes "can't input / Ctrl+B d doesn't detach" in attach mode.
- **`src/daemon.rs`** — the main `select!` arm waited up to 10s for the next periodic tick before noticing the shutdown flag. Add a bounded `shutdown_rx` channel so the `ctrlc` handler can wake the select immediately and the daemon exits promptly on Ctrl+C (matching `agend-terminal stop` latency).

## Test plan
- [x] `cargo check` clean
- [x] `cargo test` — 301 unit + 6 integration + 10 mcp passing
- [x] `cargo clippy --bin agend-terminal` clean
- [ ] Windows real-machine: `attach <agent>` accepts typed input without duplicates
- [ ] Windows real-machine: `Ctrl+B d` detaches in attach mode
- [ ] Windows real-machine: `Ctrl+C` on daemon exits within ~1s