### PR TITLE
chore(fmt): apply cargo fmt across src/app + backend + fleet

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -174,7 +174,8 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
 
                 if let Some((backend_cmd, work_dir, display_name, fleet_name)) = pane_info {
                     super::kill_agent(ctx.registry, &name);
-                    let _ = std::fs::remove_file(ctx.home.join("sessions").join(format!("{name}.sid")));
+                    let _ =
+                        std::fs::remove_file(ctx.home.join("sessions").join(format!("{name}.sid")));
 
                     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
                     let pc = cols.saturating_sub(2);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -544,4 +544,3 @@ fn kill_agent(registry: &AgentRegistry, name: &str) {
     }
     reg.remove(name);
 }
-

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -158,7 +158,10 @@ fn handle_drag(mouse: MouseEvent, layout: &mut Layout, state: &mut MouseState) {
         // but resizing the PTY every mouse cell triggers the backend
         // (Claude/etc.) to reflow its entire UI and floods us with redraw
         // data. Defer the single PTY resize to mouse-up.
-    } else if layout.active_tab().is_some_and(|t| t.dragging_pane.is_some()) {
+    } else if layout
+        .active_tab()
+        .is_some_and(|t| t.dragging_pane.is_some())
+    {
         let target = layout.active_tab().and_then(|tab| {
             let source = tab.dragging_pane?;
             tab.pane_at(mouse.column, mouse.row)
@@ -183,7 +186,10 @@ fn handle_up(
         // Ratio was updated live during drag but PTY resizes were deferred
         // — fire one now.
         out.needs_resize = true;
-    } else if layout.active_tab().is_some_and(|t| t.dragging_pane.is_some()) {
+    } else if layout
+        .active_tab()
+        .is_some_and(|t| t.dragging_pane.is_some())
+    {
         let source_id = layout.active_tab().and_then(|t| t.dragging_pane);
         let target_id = layout.active_tab().and_then(|t| t.drag_target);
         if let (Some(src), Some(tgt)) = (source_id, target_id) {

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -141,8 +141,7 @@ pub(super) fn handle_key(
             KeyCode::Enter => {
                 let sel = *selected;
                 let (c, r) = crossterm::terminal::size().unwrap_or((120, 40));
-                if let Overlay::NewTabMenu { items, .. } =
-                    std::mem::replace(overlay, Overlay::None)
+                if let Overlay::NewTabMenu { items, .. } = std::mem::replace(overlay, Overlay::None)
                 {
                     if let Some(item) = items.into_iter().nth(sel) {
                         let pc = c.saturating_sub(2);

--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -215,7 +215,8 @@ fn handle_team_created(
     let mut attached = 1usize;
 
     for member in &running[1..] {
-        match super::pane_factory::attach_pane(member, registry, cols, pane_rows, wakeup_tx, layout) {
+        match super::pane_factory::attach_pane(member, registry, cols, pane_rows, wakeup_tx, layout)
+        {
             Ok(pane) => {
                 tab.split_focused(SplitDir::Horizontal, pane);
                 attached += 1;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -64,9 +64,7 @@ impl Backend {
             | Backend::Codex
             | Backend::OpenCode
             | Backend::Gemini => self.preset().command.to_string(),
-            Backend::Shell => {
-                std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
-            }
+            Backend::Shell => std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string()),
             Backend::Raw(path) => path.clone(),
         }
     }
@@ -562,10 +560,7 @@ mod tests {
             Backend::parse_str("/opt/custom/tool"),
             Backend::Raw("/opt/custom/tool".to_string())
         );
-        assert_eq!(
-            Backend::parse_str("vim"),
-            Backend::Raw("vim".to_string())
-        );
+        assert_eq!(Backend::parse_str("vim"), Backend::Raw("vim".to_string()));
         assert_eq!(
             Backend::parse_str("/usr/bin/my-agent"),
             Backend::Raw("/usr/bin/my-agent".to_string())
@@ -614,8 +609,14 @@ mod tests {
         for b in [Backend::Shell, Backend::Raw("/opt/x".to_string())] {
             let p = b.preset();
             assert!(p.args.is_empty(), "{b:?} should have empty args");
-            assert!(p.ready_pattern.is_empty(), "{b:?} should have no ready pattern");
-            assert!(p.dismiss_patterns.is_empty(), "{b:?} should have no dismiss patterns");
+            assert!(
+                p.ready_pattern.is_empty(),
+                "{b:?} should have no ready pattern"
+            );
+            assert!(
+                p.dismiss_patterns.is_empty(),
+                "{b:?} should have no dismiss patterns"
+            );
             assert!(matches!(p.resume_mode, ResumeMode::NotSupported));
         }
     }

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -1028,7 +1028,10 @@ instances:
             Some(Backend::Raw("/bin/bash".to_string()))
         );
         assert_eq!(
-            config.instances.get("worker").and_then(|i| i.backend.clone()),
+            config
+                .instances
+                .get("worker")
+                .and_then(|i| i.backend.clone()),
             Some(Backend::Raw("/opt/custom/tool".to_string()))
         );
         fs::remove_dir_all(&dir).ok();
@@ -1082,7 +1085,10 @@ instances:
         );
         let config = FleetConfig::load(&path).expect("load");
         assert_eq!(
-            config.instances.get("bash_pane").and_then(|i| i.backend.clone()),
+            config
+                .instances
+                .get("bash_pane")
+                .and_then(|i| i.backend.clone()),
             Some(Backend::Shell)
         );
         fs::remove_dir_all(&dir).ok();
@@ -1101,7 +1107,10 @@ instances:
         );
         let config = FleetConfig::load(&path).expect("load");
         assert_eq!(
-            config.instances.get("custom").and_then(|i| i.backend.clone()),
+            config
+                .instances
+                .get("custom")
+                .and_then(|i| i.backend.clone()),
             Some(Backend::Raw("/opt/foo/bar".to_string()))
         );
         fs::remove_dir_all(&dir).ok();
@@ -1129,7 +1138,9 @@ instances:
         assert_eq!(resolved.backend_command, "/opt/claude-v2/my-claude");
         // Preset args ARE applied because backend is explicitly claude.
         assert!(
-            resolved.args.contains(&"--dangerously-skip-permissions".to_string()),
+            resolved
+                .args
+                .contains(&"--dangerously-skip-permissions".to_string()),
             "expected claude preset args, got {:?}",
             resolved.args
         );


### PR DESCRIPTION
## Summary
Purely mechanical `cargo fmt` pass. No behavior change. Unblocks CI which was failing on fmt check due to leftover formatting from the app.rs decomposition and Backend Phase 1 refactors.

## Test plan
- [x] `cargo fmt --check` clean locally
- [x] `cargo check` still passes
- [ ] CI green on all three platforms