### PR TITLE
fix(bootstrap): probe api.port so stale run dirs can't fake a live daemon

### DIFF
--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -142,6 +142,14 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
         return Ok(BootstrapOutcome::Attached(attached));
     }
 
+    // We hold the exclusive daemon lock, so no one else is attaching or
+    // creating run dirs. Sweep any `~/.agend/run/*` left behind by prior
+    // daemons whose PIDs have since been recycled — otherwise the first
+    // one `find_active_run_dir` visits on a later app launch can lure that
+    // process into attaching to a dead daemon (symptom: input lag from 2s
+    // port-poll hitting closed sockets).
+    crate::daemon::sweep_stale_run_dirs(home);
+
     let run_dir = crate::daemon::run_dir(home);
     std::fs::create_dir_all(&run_dir)
         .with_context(|| format!("create run dir {}", run_dir.display()))?;
@@ -178,10 +186,26 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
 /// Return `Some(AttachedFleet)` if a live daemon owns the run dir, else `None`.
 /// Errors if the cookie file is missing — that would mean a running daemon
 /// without auth, which we refuse to silently join.
+///
+/// Stale-run-dir handling: `find_active_run_dir`'s identity check only
+/// confirms the `.daemon` file's pid matches the dir name (trivially true).
+/// If the original daemon died and Windows recycled its PID for an unrelated
+/// process, `is_pid_alive` returns true and we'd attach to a dead daemon —
+/// every 2s port poll would then retry dead TCP sockets and stall input.
+/// Probe `api.port` to confirm a real daemon is listening; on failure clean
+/// the run_dir so the outer `prepare` can own the fleet.
 fn try_attach(home: &Path, fleet_path: &Path) -> Result<Option<AttachedFleet>> {
     let Some(run_dir) = crate::daemon::find_active_run_dir(home) else {
         return Ok(None);
     };
+    if !crate::ipc::probe_api(&run_dir) {
+        tracing::info!(
+            path = %run_dir.display(),
+            "stale run dir: pid alive but api.port unreachable — cleaning"
+        );
+        let _ = std::fs::remove_dir_all(&run_dir);
+        return Ok(None);
+    }
     let cookie = crate::auth_cookie::read_cookie(&run_dir)
         .with_context(|| format!("existing daemon at {} has no api.cookie", run_dir.display()))?;
     let daemon_pid = crate::daemon::read_daemon_pid(&run_dir).unwrap_or(0);
@@ -230,6 +254,16 @@ mod tests {
         )
         .expect("write fleet.yaml");
         path
+    }
+
+    /// Stand up a loopback listener and write its port as `api.port` inside
+    /// `run_dir`, mimicking a real daemon for `probe_api` purposes. Returns
+    /// the listener so the caller keeps it alive for the duration of the test.
+    fn fake_api_listener(run_dir: &Path) -> std::net::TcpListener {
+        let listener = crate::ipc::bind_loopback().expect("bind");
+        let port = crate::ipc::local_port(&listener);
+        crate::ipc::write_port(run_dir, crate::ipc::API_NAME, port).expect("write api.port");
+        listener
     }
 
     #[test]
@@ -282,10 +316,14 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Refuse to silently attach to a daemon that has no `api.cookie`. The
-    /// alternative — treat cookie-less run dirs as Attached — would mean a
-    /// client could land in a state where it thinks a daemon is live but has
-    /// no way to authenticate against its API.
+    /// Refuse to silently attach to a daemon that has a live api port but
+    /// no `api.cookie`. The alternative — treat cookie-less run dirs as
+    /// Attached — would mean a client could land in a state where it thinks
+    /// a daemon is live but has no way to authenticate against its API.
+    ///
+    /// Note: a run dir with no listener on api.port is now treated as stale
+    /// and swept, not as a cookie-less daemon (that case is covered by
+    /// `prepare_sweeps_run_dir_with_dead_api`).
     #[test]
     fn attach_fails_when_cookie_missing() {
         let home = tmp_home("no_cookie");
@@ -293,9 +331,9 @@ mod tests {
         let run = crate::daemon::run_dir(&home);
         std::fs::create_dir_all(&run).expect("mkdir run");
         crate::daemon::write_daemon_id(&run);
-        // Deliberately DO NOT call auth_cookie::issue. find_active_run_dir
-        // will see the live-looking run dir, try_attach will then bail on
-        // read_cookie, and prepare returns Err.
+        let _listener = fake_api_listener(&run);
+        // Deliberately DO NOT call auth_cookie::issue. probe_api will pass
+        // (listener is alive), try_attach will then bail on read_cookie.
 
         let opts = PrepareOptions {
             mutate_fleet_yaml: false,
@@ -316,13 +354,14 @@ mod tests {
 
     #[test]
     fn prepare_attaches_when_run_dir_alive() {
-        // Simulate a live daemon by creating a run dir with current PID + cookie.
+        // Simulate a live daemon: current PID + cookie + bound api port.
         let home = tmp_home("attached");
         let fleet = write_minimal_fleet(&home);
         let run = crate::daemon::run_dir(&home);
         std::fs::create_dir_all(&run).expect("mkdir run");
         crate::daemon::write_daemon_id(&run);
         let _ = crate::auth_cookie::issue(&run).expect("issue cookie for fake daemon");
+        let _listener = fake_api_listener(&run);
 
         let opts = PrepareOptions {
             mutate_fleet_yaml: false,
@@ -339,6 +378,85 @@ mod tests {
                 panic!("expected Attached when live daemon owns run_dir")
             }
         }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Regression for the "lag from attached to dead daemon" bug.
+    ///
+    /// A previous daemon died; Windows recycled its PID for an unrelated
+    /// process so `is_pid_alive` keeps returning true. Without a port probe
+    /// bootstrap would Attach to a run dir where nothing is listening — the
+    /// TUI's 2-second port poll would then spin on failing TCP connects and
+    /// starve the input loop.
+    ///
+    /// Expectation: the stale run dir is swept, `prepare` returns Owned with
+    /// a fresh run dir for the current process, and the old `.daemon` /
+    /// `api.cookie` files are gone.
+    #[test]
+    fn prepare_sweeps_run_dir_with_dead_api() {
+        let home = tmp_home("dead_api");
+        let fleet = write_minimal_fleet(&home);
+        // Use a dir name = current pid so is_pid_alive returns true, but
+        // never open a listener — probe_api must fail.
+        let run = crate::daemon::run_dir(&home);
+        std::fs::create_dir_all(&run).expect("mkdir run");
+        crate::daemon::write_daemon_id(&run);
+        let stale_cookie_bytes = crate::auth_cookie::issue(&run).expect("issue cookie");
+
+        let opts = PrepareOptions {
+            mutate_fleet_yaml: false,
+            init_telegram: false,
+            resolve_agents: false,
+        };
+        let outcome = prepare(&home, &fleet, opts).expect("prepare");
+        match outcome {
+            BootstrapOutcome::Owned(o) => {
+                // run_dir is pid-keyed so the path may be the same, but the
+                // stale state must have been wiped and re-issued fresh.
+                assert_ne!(
+                    o.cookie, stale_cookie_bytes,
+                    "fresh cookie must differ from the stale one we planted"
+                );
+                let fresh = crate::auth_cookie::read_cookie(&o.run_dir).expect("read");
+                assert_eq!(fresh, o.cookie);
+            }
+            BootstrapOutcome::Attached(_) => {
+                panic!("must not Attach to a run dir whose api.port is dead");
+            }
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Sweep removes a pid-named dir whose `api.port` has no listener, even
+    /// when `is_pid_alive` still returns true (PID reuse). Non-pid siblings
+    /// (stray files, lock files written later) must be left alone.
+    #[test]
+    fn sweep_stale_run_dirs_removes_dead_api_entries() {
+        let home = tmp_home("sweep");
+        let run_base = home.join("run");
+        std::fs::create_dir_all(&run_base).expect("mkdir run");
+
+        // Use our own pid for the stale dir name: is_pid_alive returns true
+        // (we're running), but no listener is bound so probe_api returns
+        // false — the combination that used to leak across sessions.
+        let our_pid = std::process::id().to_string();
+        let stale = run_base.join(&our_pid);
+        std::fs::create_dir_all(&stale).expect("mkdir stale");
+        std::fs::write(stale.join(".daemon"), format!("{our_pid}:0")).expect("write .daemon");
+        // Non-pid sibling — sweep must leave it alone.
+        let non_pid = run_base.join("not-a-pid");
+        std::fs::create_dir_all(&non_pid).expect("mkdir non-pid");
+
+        crate::daemon::sweep_stale_run_dirs(&home);
+
+        assert!(
+            !stale.exists(),
+            "stale pid-named dir with dead api must be swept"
+        );
+        assert!(
+            non_pid.exists(),
+            "non-pid-named sibling must be left intact"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -73,6 +73,39 @@ pub fn find_active_run_dir(home: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Remove every `~/.agend/run/<pid>/` whose daemon is not reachable.
+///
+/// `find_active_run_dir` cleans only the one entry it visits before returning
+/// the first alive-PID match, so a second (or third) stale dir whose PID has
+/// been recycled by an unrelated OS process survives indefinitely. On the next
+/// `agend-terminal app` launch the bootstrap probe might pick any of them; the
+/// losers stay on disk and keep accumulating. This runs once at the winning
+/// daemon's startup (after the exclusive lock) and clears the backlog.
+///
+/// An entry survives only if BOTH `is_pid_alive` returns true AND `probe_api`
+/// can reach its `api.port`. Missing/malformed `.daemon` or `api.port` counts
+/// as stale.
+pub fn sweep_stale_run_dirs(home: &Path) {
+    let run = home.join("run");
+    let Ok(entries) = std::fs::read_dir(&run) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let pid_str = entry.file_name().to_string_lossy().into_owned();
+        let Ok(pid) = pid_str.parse::<u32>() else {
+            continue;
+        };
+        let alive = crate::process::is_pid_alive(pid) && crate::ipc::probe_api(&entry.path());
+        if !alive {
+            tracing::info!(
+                path = %entry.path().display(),
+                "sweeping stale run dir"
+            );
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
 /// Write daemon identity file for PID reuse detection.
 pub(crate) fn write_daemon_id(run_dir: &Path) {
     let pid = std::process::id();

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -110,6 +110,24 @@ pub fn probe_agent(run: &Path, name: &str) -> bool {
     }
 }
 
+/// Probe whether a run_dir's daemon API is reachable. Used to distinguish a
+/// live daemon from a stale run_dir whose PID has been reused: `is_pid_alive`
+/// may say true, but only a real agend daemon answers on the api port.
+///
+/// 200ms timeout matches `probe_agent`. A refused connection on a loopback
+/// port returns much faster than the timeout, so this is cheap in the common
+/// "dead daemon" case.
+pub fn probe_api(run: &Path) -> bool {
+    match read_port(run, API_NAME) {
+        Some(port) => TcpStream::connect_timeout(
+            &SocketAddr::from((LOOPBACK, port)),
+            Duration::from_millis(200),
+        )
+        .is_ok(),
+        None => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,6 +185,32 @@ mod tests {
         write_port(&dir, "a", 1).expect("write");
         remove_port(&dir, "a");
         assert_eq!(read_port(&dir, "a"), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn probe_api_matches_api_port_listener() {
+        // probe_api is the gatekeeper that distinguishes a live daemon from
+        // a stale run dir whose PID got recycled. It must return true when
+        // api.port points at an actual listener and false when the file is
+        // missing (stale daemon, port never written, or written but daemon
+        // exited so the OS released the port).
+        let dir = tmp_dir("probe_api");
+        let listener = bind_loopback().expect("bind");
+        let port = local_port(&listener);
+        write_port(&dir, API_NAME, port).expect("write api.port");
+
+        let handle = std::thread::spawn(move || {
+            let _ = listener.accept();
+        });
+        assert!(probe_api(&dir), "must succeed while listener is live");
+        handle.join().ok();
+
+        remove_port(&dir, API_NAME);
+        assert!(
+            !probe_api(&dir),
+            "must fail once api.port file is gone (stale run dir)"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
## Summary

- `ipc::probe_api(run_dir)` — TCP+timeout probe against `api.port`, same shape as the existing `probe_agent`.
- `bootstrap::try_attach` now probes before attaching; a stale dir whose PID was recycled by some other OS process is swept instead of being returned as "alive".
- `daemon::sweep_stale_run_dirs(home)` called from `prepare` after the exclusive `.daemon.lock` — catches any siblings that `find_active_run_dir`'s early-return would have left behind.

## Why

`agend-terminal app` had 1–2 s input lag per keystroke on Windows when `~/.agend/run/<old-pid>/` survived a previous daemon exit and the OS later reused that PID for an unrelated process. The app would run in Attached mode pointing at the dead run dir, and the 2-second `*.port` poll kept opening TCP connections to refused ports — the slow Windows `connect()` retries starved the crossterm input loop.

Root cause was that `find_active_run_dir`'s identity check compared the `.daemon` file's pid to the directory name (always equal by construction) and the recorded start_time was discarded via `_`. PID reuse was therefore undetected. This PR proves liveness by probing the port instead of trusting PID state.

## Test plan

- [x] `cargo test --bin agend-terminal probe` — new unit test for `probe_api`.
- [x] `cargo test --bin agend-terminal prepare_sweeps_run_dir_with_dead_api` — end-to-end: live PID + cookie but no listener ⇒ swept ⇒ Owned with a fresh cookie.
- [x] `cargo test --bin agend-terminal sweep_stale_run_dirs_removes_dead_api_entries` — pid-named dir swept, non-pid sibling preserved.
- [x] Updated `prepare_attaches_when_run_dir_alive` and `attach_fails_when_cookie_missing` to bind a real loopback listener so the probe passes.
- [ ] Manual re-verification on the Windows box (user to confirm post-merge that input lag is gone after a daemon/app restart cycle).

## Not in scope / caveats

- Three pre-existing unit-test failures in `instructions` / `worktree` reproduce on `fa7797d` without this patch — they're environmental (tests use `std::env::temp_dir()` and pick up ambient `.git` state). Not touched here.
- Does not add OS-specific process start-time comparison (a stronger PID-reuse check). The port probe is simpler and catches the same class of bugs, plus the "daemon alive but hung" case as a bonus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)