### PR TITLE
fix(windows): strip \?\ verbatim prefix so cmd.exe accepts spawn cwd

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -65,13 +65,37 @@ pub fn validate_working_directory(
     }
     for root in &roots {
         if resolved.starts_with(root) {
-            return Ok(resolved);
+            return Ok(strip_verbatim_prefix(resolved));
         }
     }
     anyhow::bail!(
         "working_directory '{}' escapes allowed roots (set AGEND_ALLOWED_WORK_ROOTS to widen)",
         resolved.display()
     )
+}
+
+/// On Windows, `std::fs::canonicalize` returns `\\?\C:\...` (the Win32
+/// extended-length path form). PTY spawn hands this straight to `cmd.exe` as
+/// its cwd, and cmd bails with "UNC paths are not supported" before ever
+/// running — codex surfaces this as "default directory is Windows".
+/// Strip the verbatim prefix when it names a plain drive so the returned path
+/// is what cmd expects. UNC shares (`\\?\UNC\server\share`) are left alone —
+/// cmd can't cd into those regardless, and a caller that needs UNC semantics
+/// should see the failure explicitly rather than get a subtly-rewritten path.
+///
+/// No-op on Unix.
+fn strip_verbatim_prefix(path: std::path::PathBuf) -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        let s = path.to_string_lossy();
+        if let Some(rest) = s.strip_prefix(r"\\?\") {
+            // `\\?\C:\...` → `C:\...`, but leave `\\?\UNC\...` alone.
+            if !rest.starts_with(r"UNC\") {
+                return std::path::PathBuf::from(rest.to_string());
+            }
+        }
+    }
+    path
 }
 
 /// API method name constants — single source of truth for the NDJSON protocol.
@@ -911,8 +935,68 @@ mod tests {
         let ok = home.join("workspace").join("agent");
         let resolved =
             validate_working_directory(&ok, &home).expect("path under home must validate");
-        assert!(resolved.starts_with(std::fs::canonicalize(&home).unwrap()));
+        // Returned path has any `\\?\` verbatim prefix stripped (see
+        // `strip_verbatim_prefix`), so compare against the stripped form
+        // of canonical home.
+        let home_simplified = strip_verbatim_prefix(std::fs::canonicalize(&home).unwrap());
+        assert!(
+            resolved.starts_with(&home_simplified),
+            "resolved {} should start with {}",
+            resolved.display(),
+            home_simplified.display()
+        );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Regression guard for the "cmd.exe: UNC paths are not supported" bug.
+    /// `std::fs::canonicalize` on Windows returns `\\?\C:\...` and handing
+    /// that to a PTY makes cmd.exe refuse to launch. `validate_working_directory`
+    /// must strip the verbatim prefix before returning so the resolved path
+    /// round-trips through a Command spawn.
+    #[test]
+    fn validate_work_dir_strips_verbatim_prefix_from_return() {
+        let home = tmp_home("validate_verbatim");
+        let ok = home.join("project");
+        let resolved = validate_working_directory(&ok, &home).expect("validate");
+        #[cfg(windows)]
+        {
+            let s = resolved.to_string_lossy();
+            assert!(
+                !s.starts_with(r"\\?\"),
+                "verbatim prefix must be stripped, got: {s}"
+            );
+        }
+        // On Unix strip_verbatim_prefix is a no-op — just sanity that the
+        // function still returns something that starts with home.
+        #[cfg(unix)]
+        {
+            let home_canon = std::fs::canonicalize(&home).unwrap();
+            assert!(resolved.starts_with(&home_canon));
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strip_verbatim_prefix_handles_drive_and_leaves_unc() {
+        use std::path::PathBuf;
+        // `\\?\C:\...` → `C:\...`
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"\\?\C:\Users\alice")),
+            PathBuf::from(r"C:\Users\alice")
+        );
+        // `\\?\UNC\server\share` must be preserved — simplifying to
+        // `\\server\share` doesn't help cmd, and silently rewriting a share
+        // path would be surprising.
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"\\?\UNC\server\share\dir")),
+            PathBuf::from(r"\\?\UNC\server\share\dir")
+        );
+        // Regular drive path unaffected.
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"C:\plain\path")),
+            PathBuf::from(r"C:\plain\path")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`validate_working_directory` returned `std::fs::canonicalize`'s output directly. On Windows that's the Win32 extended-length form `\?\C:\...`, which `cmd.exe` refuses as cwd ("UNC paths are not supported"). Codex inherited cmd and surfaced this as "the default directory is the Windows directory", then failed to load its config.toml because it was looking in `C:\WINDOWS` instead of the project.

Fix: new `strip_verbatim_prefix` helper. `\?\C:\...` → `C:\...` on the return value only; the internal `starts_with(root)` check still uses the verbatim form, so the AGEND_HOME / AGEND_ALLOWED_WORK_ROOTS security boundary is unchanged. `\?\UNC\share\...` is preserved (simplifying doesn't help cmd and silently rewriting a share path would be surprising). No-op on Unix.

## Test plan

- [x] `cargo test --bin agend-terminal verbatim` — 2 new tests pass.
- [x] `cargo test --bin agend-terminal validate_work_dir` — 5 tests (updated `allows_under_home` for the new return shape).
- [x] `cargo build --release` clean.
- [ ] Manual on Windows box: restart daemon with new binary, verify codex launches cleanly with `C:\Users\suzuke\.agend\workspace\codex` as cwd (not `\?\C:\Users\...`).

## Not in scope

- Doesn't touch `supervisor::cli.rs`' other `canonicalize` calls — those paths are binary paths for self-update, not spawn cwd.
- Doesn't add a UNC-share happy path; if a user really does need UNC cwd, cmd.exe fundamentally can't do it and the caller should see the error explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)