### PR TITLE
fix(app): new pane should not resume prior session

### DIFF
--- a/docs/PLAN-multica-learnings.md
+++ b/docs/PLAN-multica-learnings.md
@@ -52,7 +52,7 @@
 
 ### 1.5 持久化
 
-- **AgEnD**：全部 JSON/JSONL + fs2 exclusive lock。`snapshot.json`、`tasks.json`、`decisions/*.json`、`inbox/*.jsonl`、`sessions/*.sid`。
+- **AgEnD**：全部 JSON/JSONL + fs2 exclusive lock。`snapshot.json`、`tasks.json`、`decisions/*.json`、`inbox/*.jsonl`。
 - **Multica**：PostgreSQL + sqlc，47 migrations。關鍵表：`user / workspace / member / agent / issue / agent_task_queue / skill + skill_file + agent_skill / chat / projects / autopilot / activity_log`。
 - **pgvector**：Multica Docker image 用 `pgvector/pgvector:pg17`，但 schema 裡**沒有 `CREATE EXTENSION vector` 或 `embedding vector(...)` 欄位**。實際搜尋用 Postgres FTS 索引（migrations 032/033/036/039）。README 寫的是預留，目前等於沒用。
 

--- a/src/app/api_server.rs
+++ b/src/app/api_server.rs
@@ -112,6 +112,8 @@ pub(super) fn auto_start_fleet(
                 rows,
                 wakeup_tx,
                 name_counter,
+                // Auto-start on daemon/app boot — rehydrate prior session.
+                crate::backend::SpawnMode::Resume,
             ) {
                 Ok(pane) => {
                     let tab_name = pane.agent_name.clone();

--- a/src/app/api_server.rs
+++ b/src/app/api_server.rs
@@ -112,7 +112,6 @@ pub(super) fn auto_start_fleet(
                 rows,
                 wakeup_tx,
                 name_counter,
-                // Auto-start on daemon/app boot — rehydrate prior session.
                 crate::backend::SpawnMode::Resume,
             ) {
                 Ok(pane) => {

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -177,8 +177,6 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
 
                 if let Some((backend_cmd, work_dir, display_name, fleet_name)) = pane_info {
                     super::kill_agent(ctx.registry, &name);
-                    let _ =
-                        std::fs::remove_file(ctx.home.join("sessions").join(format!("{name}.sid")));
 
                     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
                     let pc = cols.saturating_sub(2);

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -65,6 +65,9 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                     pr,
                     ctx.wakeup_tx,
                     ctx.name_counter,
+                    // User-initiated new instance — start fresh so the new pane
+                    // does not resume a prior session that happened to share cwd.
+                    crate::backend::SpawnMode::Fresh,
                 )
             } else {
                 let (command, submit_key) = super::pane_factory::resolve_backend(backend_name);
@@ -199,6 +202,9 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                                 pr,
                                 ctx.wakeup_tx,
                                 ctx.name_counter,
+                                // `:restart` preserves the conversation — reattach
+                                // the CLI's prior cwd-scoped session.
+                                crate::backend::SpawnMode::Resume,
                             )
                         } else {
                             let (command, submit_key) =

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -65,8 +65,6 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                     pr,
                     ctx.wakeup_tx,
                     ctx.name_counter,
-                    // User-initiated new instance — start fresh so the new pane
-                    // does not resume a prior session that happened to share cwd.
                     crate::backend::SpawnMode::Fresh,
                 )
             } else {
@@ -200,8 +198,6 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                                 pr,
                                 ctx.wakeup_tx,
                                 ctx.name_counter,
-                                // `:restart` preserves the conversation — reattach
-                                // the CLI's prior cwd-scoped session.
                                 crate::backend::SpawnMode::Resume,
                             )
                         } else {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -624,9 +624,6 @@ fn pane_from_menu_item(
                     rows,
                     wakeup_tx,
                     name_counter,
-                    // User picked a backend from the menu — new instance, start
-                    // fresh so the CLI does not `--continue` into a stale session
-                    // that happens to share this cwd.
                     crate::backend::SpawnMode::Fresh,
                 )
             } else {
@@ -664,8 +661,6 @@ fn pane_from_menu_item(
                 rows,
                 wakeup_tx,
                 name_counter,
-                // User explicitly re-opened an existing fleet instance — resume
-                // its prior session.
                 crate::backend::SpawnMode::Resume,
             )
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -624,6 +624,10 @@ fn pane_from_menu_item(
                     rows,
                     wakeup_tx,
                     name_counter,
+                    // User picked a backend from the menu — new instance, start
+                    // fresh so the CLI does not `--continue` into a stale session
+                    // that happens to share this cwd.
+                    crate::backend::SpawnMode::Fresh,
                 )
             } else {
                 // Preset args are added by spawn_agent; no need to compose here.
@@ -660,6 +664,9 @@ fn pane_from_menu_item(
                 rows,
                 wakeup_tx,
                 name_counter,
+                // User explicitly re-opened an existing fleet instance — resume
+                // its prior session.
+                crate::backend::SpawnMode::Resume,
             )
         }
     }

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -228,6 +228,13 @@ pub(super) fn attach_pane(
 }
 
 /// Create a pane from a fleet ResolvedInstance (full config: env, args, model, etc.).
+///
+/// `spawn_mode` reflects caller intent — system rehydrate (daemon restart, session
+/// restore, crash respawn) passes `Resume` to reattach the CLI's prior conversation
+/// in that cwd; user-initiated new creation (backend picker, `:spawn`) passes
+/// `Fresh` so the new instance does not inherit a leftover session. Callers that
+/// explicitly reattach an existing fleet instance (fleet-instance picker, `:restart`)
+/// also pass `Resume`.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn create_pane_from_resolved(
     fleet_name: &str,
@@ -239,6 +246,7 @@ pub(super) fn create_pane_from_resolved(
     rows: u16,
     wakeup_tx: &crossbeam::channel::Sender<usize>,
     name_counter: &mut HashMap<String, usize>,
+    spawn_mode: crate::backend::SpawnMode,
 ) -> Result<Pane> {
     // Build fleet peer list for agent instructions
     let fleet_path = home.join("fleet.yaml");
@@ -263,9 +271,7 @@ pub(super) fn create_pane_from_resolved(
         fleet_name,
         &resolved.backend_command,
         &resolved.args,
-        // Fleet entries reattach to their prior CLI session — the working_dir
-        // persists across daemon restarts, so ask the backend to resume.
-        crate::backend::SpawnMode::Resume,
+        spawn_mode,
         resolved.working_directory.as_deref(),
         &resolved.env,
         &resolved.submit_key,

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -187,6 +187,8 @@ pub(super) fn restore_with_reconciliation(
                         rows,
                         wakeup_tx,
                         name_counter,
+                        // Session restore — rehydrate prior conversation.
+                        crate::backend::SpawnMode::Resume,
                     ) {
                         let tab_name = pane.agent_name.clone();
                         layout.add_tab(Tab::new(tab_name, pane));
@@ -255,6 +257,8 @@ fn restore_node_reconciled(
                         rows,
                         wakeup_tx,
                         name_counter,
+                        // Session restore — rehydrate prior conversation.
+                        crate::backend::SpawnMode::Resume,
                     )
                     .ok()?;
                     pane.display_name = sp.display_name.clone();

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -187,7 +187,6 @@ pub(super) fn restore_with_reconciliation(
                         rows,
                         wakeup_tx,
                         name_counter,
-                        // Session restore — rehydrate prior conversation.
                         crate::backend::SpawnMode::Resume,
                     ) {
                         let tab_name = pane.agent_name.clone();
@@ -257,7 +256,6 @@ fn restore_node_reconciled(
                         rows,
                         wakeup_tx,
                         name_counter,
-                        // Session restore — rehydrate prior conversation.
                         crate::backend::SpawnMode::Resume,
                     )
                     .ok()?;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -461,15 +461,6 @@ fn run_core(
         tracing::warn!(agent = %crashed_name, "crashed");
         crate::event_log::log(home, "crash", &crashed_name, "agent crashed");
 
-        // Clear stale session ID — if agent crashed with --resume, the session
-        // may no longer exist. Removing the .sid file ensures the next respawn
-        // starts fresh instead of crash-looping on "No conversation found".
-        let sid_file = home.join("sessions").join(format!("{crashed_name}.sid"));
-        if sid_file.exists() {
-            tracing::info!(agent = %crashed_name, "clearing stale session ID");
-            let _ = std::fs::remove_file(&sid_file);
-        }
-
         // Get config for respawn
         let config = crate::sync::lock_poisoned(&configs, "configs")
             .get(&crashed_name)

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -852,14 +852,9 @@ fn cleanup_working_dir(home: &std::path::Path, name: &str, working_dir: &std::pa
         }
     }
 
-    // Always clean up metadata + session (regardless of workspace vs user dir)
-    // Remove metadata
+    // Always clean up metadata (regardless of workspace vs user dir)
     let meta = home.join("metadata").join(format!("{name}.json"));
     let _ = std::fs::remove_file(&meta);
-
-    // Remove session ID
-    let sid = home.join("sessions").join(format!("{name}.sid"));
-    let _ = std::fs::remove_file(&sid);
 }
 
 /// Validate a git branch name. Only allows [a-zA-Z0-9/_.-], rejects ".." and leading "-".
@@ -1064,21 +1059,17 @@ instances:
     }
 
     #[test]
-    fn cleanup_removes_metadata_and_session() {
+    fn cleanup_removes_metadata() {
         let home = tmp_home("cleanup_meta");
         let ws = home.join("workspace").join("agent1");
         std::fs::create_dir_all(&ws).ok();
 
-        // Create metadata + session files
         std::fs::create_dir_all(home.join("metadata")).ok();
         std::fs::write(home.join("metadata/agent1.json"), "{}").ok();
-        std::fs::create_dir_all(home.join("sessions")).ok();
-        std::fs::write(home.join("sessions/agent1.sid"), "abc123").ok();
 
         cleanup_working_dir(&home, "agent1", &ws);
 
         assert!(!home.join("metadata/agent1.json").exists());
-        assert!(!home.join("sessions/agent1.sid").exists());
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -668,14 +668,9 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
         }
     }
 
-    // Always clean up metadata + session (regardless of workspace vs user dir)
-    // Remove metadata
+    // Always clean up metadata (regardless of workspace vs user dir)
     let meta = home.join("metadata").join(format!("{name}.json"));
     let _ = std::fs::remove_file(&meta);
-
-    // Remove session ID
-    let sid = home.join("sessions").join(format!("{name}.sid"));
-    let _ = std::fs::remove_file(&sid);
 }
 
 /// Internal helper: send a message to a target instance via API, falling back to direct inbox delivery.
@@ -830,17 +825,14 @@ mod tests {
     }
 
     #[test]
-    fn cleanup_metadata_and_session() {
+    fn cleanup_metadata() {
         let home = tmp_home("cms");
         let ws = home.join("workspace/a");
         std::fs::create_dir_all(&ws).ok();
         std::fs::create_dir_all(home.join("metadata")).ok();
         std::fs::write(home.join("metadata/a.json"), "{}").ok();
-        std::fs::create_dir_all(home.join("sessions")).ok();
-        std::fs::write(home.join("sessions/a.sid"), "x").ok();
         cleanup_working_dir(&home, "a", &ws);
         assert!(!home.join("metadata/a.json").exists());
-        assert!(!home.join("sessions/a.sid").exists());
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
## Summary

- `create_pane_from_resolved` hard-coded `SpawnMode::Resume`, so fleet panes always asked the CLI to `--continue` — even when the user just picked a backend from the menu to start a *new* instance. The CLI then resumed the most recent session in the (often shared) cwd, surfacing a conversation the user had already closed.
- Threaded `SpawnMode` through the helper so callers state intent explicitly: rehydrate paths (session restore, auto-start on boot, `:restart`, fleet-instance re-open) pass `Resume`; user-initiated new creation (backend picker, `:spawn`/`:vsplit`/`:hsplit`) passes `Fresh`.
- Dropped dead `.sid` session-id plumbing. `d6d35d4` already switched every backend to cwd-scoped resume; nothing writes `.sid` in production anymore, so the remaining `remove_file` calls (crash handler, `:restart`, `delete_instance`) were no-ops kept alive by inertia. Their tests wrote dummy `.sid` files just to assert cleanup paths that no longer matter.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (506 lib + 25 integration tests pass)
- [ ] Manual smoke: open pane → close → reopen same backend from picker → should NOT resume prior conversation
- [ ] Manual smoke: session restore on app restart → should still resume existing fleet panes
- [ ] Manual smoke: `:restart` on a fleet pane → should still pick up the prior conversation