### PR TITLE
fix(app): unique instance names + cleanup workspace on pane close

### DIFF
--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -290,52 +290,65 @@ pub(super) fn handle_key(
                 *overlay = Overlay::None;
                 if is_tab {
                     let idx = ctx.layout.active;
-                    // Collect fleet names before closing tab
-                    let fleet_names: Vec<String> = ctx
+                    let closed: Vec<(String, Option<std::path::PathBuf>)> = ctx
                         .layout
                         .tabs
                         .get(idx)
                         .into_iter()
                         .flat_map(|t| {
                             t.root().pane_ids().into_iter().filter_map(|id| {
-                                t.root()
-                                    .find_pane(id)
-                                    .and_then(|p| p.fleet_instance_name.clone())
+                                t.root().find_pane(id).and_then(|p| {
+                                    p.fleet_instance_name
+                                        .clone()
+                                        .map(|name| (name, p.working_dir.clone()))
+                                })
                             })
                         })
                         .collect();
-                    for fname in &fleet_names {
+                    for (name, _) in &closed {
                         super::telegram_hooks::maybe_delete_telegram_topic(
                             ctx.telegram_state,
                             ctx.home,
-                            fname,
+                            name,
                         );
                     }
-                    if !fleet_names.is_empty() {
-                        let _ = crate::fleet::remove_instances_from_yaml(ctx.home, &fleet_names);
+                    if !closed.is_empty() {
+                        let names: Vec<String> = closed.iter().map(|(n, _)| n.clone()).collect();
+                        let _ = crate::fleet::remove_instances_from_yaml(ctx.home, &names);
                     }
                     if let Some(tab) = ctx.layout.close_tab(idx) {
                         for name in tab.root().agent_names() {
                             super::kill_agent(ctx.registry, &name);
                         }
                     }
+                    for (name, wd) in &closed {
+                        if let Some(wd) = wd {
+                            crate::ops::cleanup_working_dir(ctx.home, name, wd);
+                        }
+                    }
                     outcome.needs_resize = true;
                 } else if let Some(tab) = ctx.layout.active_tab_mut() {
-                    // Remove from fleet.yaml before closing pane
                     let fid = tab.focus_id;
-                    if let Some(pane) = tab.root().find_pane(fid) {
-                        if let Some(ref fleet_name) = pane.fleet_instance_name {
-                            super::telegram_hooks::maybe_delete_telegram_topic(
-                                ctx.telegram_state,
-                                ctx.home,
-                                fleet_name,
-                            );
-                            let _ = crate::fleet::remove_instance_from_yaml(ctx.home, fleet_name);
-                        }
+                    let closed: Option<(String, Option<std::path::PathBuf>)> =
+                        tab.root().find_pane(fid).and_then(|p| {
+                            p.fleet_instance_name
+                                .clone()
+                                .map(|name| (name, p.working_dir.clone()))
+                        });
+                    if let Some((ref fleet_name, _)) = closed {
+                        super::telegram_hooks::maybe_delete_telegram_topic(
+                            ctx.telegram_state,
+                            ctx.home,
+                            fleet_name,
+                        );
+                        let _ = crate::fleet::remove_instance_from_yaml(ctx.home, fleet_name);
                     }
                     if let Some(name) = tab.close_focused() {
                         super::kill_agent(ctx.registry, &name);
                         outcome.needs_resize = true;
+                    }
+                    if let Some((name, Some(wd))) = closed {
+                        crate::ops::cleanup_working_dir(ctx.home, &name, &wd);
                     }
                 }
             }

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -381,6 +381,14 @@ pub(super) fn resolve_backend(backend_name: &str) -> (String, String) {
 /// opening another never silently reuses `workspace/codex/` with its leftover
 /// `.codex/`, `AGENTS.md`, and git state.
 pub(super) fn unique_fleet_name(home: &Path, base: &str) -> String {
+    unique_fleet_name_with(home, base, std::iter::from_fn(|| Some(short_id())))
+}
+
+/// Testable core of [`unique_fleet_name`]: takes the suffix iterator as input
+/// so tests can inject a deterministic sequence and actually exercise the
+/// collision-skip path (a random `short_id()` lands in a pre-seeded collision
+/// bucket with probability ~10⁻⁷, so the tests would otherwise be vacuous).
+fn unique_fleet_name_with(home: &Path, base: &str, mut ids: impl Iterator<Item = u32>) -> String {
     let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
     let taken = |name: &str| -> bool {
         if fleet
@@ -398,12 +406,13 @@ pub(super) fn unique_fleet_name(home: &Path, base: &str) -> String {
         false
     };
     for _ in 0..100 {
-        let candidate = format!("{base}-{:06x}", short_id());
+        let id = ids.next().unwrap_or(0);
+        let candidate = format!("{base}-{id:06x}");
         if !taken(&candidate) {
             return candidate;
         }
     }
-    // Extremely unlikely fallback when 100 random suffixes all collide
+    // Extremely unlikely fallback when 100 suffixes all collide
     (2..)
         .map(|n| format!("{base}-{n}"))
         .find(|c| !taken(c))
@@ -462,25 +471,37 @@ mod tests {
     #[test]
     fn unique_name_skips_workspace_collision() {
         let home = tmp_home("ws");
-        // Pre-create a workspace whose name could plausibly be minted; since
-        // the suffix is random we just assert the returned name isn't that
-        // directory.
-        let blocked = "codex-000000";
-        std::fs::create_dir_all(home.join("workspace").join(blocked)).expect("create workspace");
-        let name = unique_fleet_name(&home, "codex");
-        assert_ne!(name, blocked);
+        std::fs::create_dir_all(home.join("workspace/codex-000001")).expect("seed 1");
+        std::fs::create_dir_all(home.join("workspace/codex-000002")).expect("seed 2");
+        // Feed id sequence that hits both collisions then succeeds on 3
+        let name = unique_fleet_name_with(&home, "codex", [0x1u32, 0x2, 0x3].into_iter());
+        assert_eq!(name, "codex-000003");
         std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
     fn unique_name_skips_inbox_collision() {
         let home = tmp_home("ib");
-        let blocked = "codex-000000";
         std::fs::create_dir_all(home.join("inbox")).expect("create inbox");
-        std::fs::write(home.join("inbox").join(format!("{blocked}.jsonl")), "")
-            .expect("write inbox file");
-        let name = unique_fleet_name(&home, "codex");
-        assert_ne!(name, blocked);
+        std::fs::write(home.join("inbox/codex-000001.jsonl"), "").expect("seed 1");
+        std::fs::write(home.join("inbox/codex-000002.jsonl"), "").expect("seed 2");
+        let name = unique_fleet_name_with(&home, "codex", [0x1u32, 0x2, 0x3].into_iter());
+        assert_eq!(name, "codex-000003");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn unique_name_falls_back_after_100_collisions() {
+        let home = tmp_home("fallback");
+        // Seed the exact 100 suffixes the iterator will produce
+        for n in 1..=100u32 {
+            std::fs::create_dir_all(home.join("workspace").join(format!("codex-{n:06x}")))
+                .expect("seed");
+        }
+        let name =
+            unique_fleet_name_with(&home, "codex", (1u32..=100).collect::<Vec<_>>().into_iter());
+        // Fallback path uses `-N` counter starting at 2
+        assert_eq!(name, "codex-2");
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -369,17 +369,118 @@ pub(super) fn resolve_backend(backend_name: &str) -> (String, String) {
     }
 }
 
-/// Dedup a base name against fleet.yaml. Returns `base` if free, else `base-2`, `base-3`…
+/// Mint a unique fleet instance name like `base-a3f2c1`.
+///
+/// Suffix is 6 hex chars derived from the current subsecond nanos XORed with a
+/// process-local counter, so two spawns in the same nanosecond still differ.
+/// Collision probability against fleet.yaml ∪ `workspace/` ∪ `inbox/` is
+/// checked and retried up to 100 times before falling back to `-N`.
+///
+/// Always adding a suffix (vs. returning bare `base` when free) is deliberate:
+/// each spawn gets a fresh workspace directory, so closing "codex" and
+/// opening another never silently reuses `workspace/codex/` with its leftover
+/// `.codex/`, `AGENTS.md`, and git state.
 pub(super) fn unique_fleet_name(home: &Path, base: &str) -> String {
-    let Some(fleet) = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok() else {
-        return base.to_string();
+    let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
+    let taken = |name: &str| -> bool {
+        if fleet
+            .as_ref()
+            .is_some_and(|f| f.instances.contains_key(name))
+        {
+            return true;
+        }
+        if home.join("workspace").join(name).exists() {
+            return true;
+        }
+        if crate::inbox::inbox_path(home, name).exists() {
+            return true;
+        }
+        false
     };
-    if !fleet.instances.contains_key(base) {
-        return base.to_string();
+    for _ in 0..100 {
+        let candidate = format!("{base}-{:06x}", short_id());
+        if !taken(&candidate) {
+            return candidate;
+        }
     }
-    // Infinite iterator over 2.. always finds a unique name
+    // Extremely unlikely fallback when 100 random suffixes all collide
     (2..)
         .map(|n| format!("{base}-{n}"))
-        .find(|c| !fleet.instances.contains_key(c))
+        .find(|c| !taken(c))
         .expect("infinite iterator")
+}
+
+/// 24-bit id derived from the current subsecond nanos XORed with a process-
+/// local counter. Same-nanosecond callers still differ via the counter.
+fn short_id() -> u32 {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    (nanos ^ seq) & 0xFF_FFFF
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("agend_unique_{tag}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).expect("create tmp home");
+        p
+    }
+
+    #[test]
+    fn unique_name_always_suffixed() {
+        let home = tmp_home("always");
+        let name = unique_fleet_name(&home, "codex");
+        assert!(name.starts_with("codex-"), "name was {name}");
+        let suffix = &name["codex-".len()..];
+        assert_eq!(suffix.len(), 6, "expected 6-hex suffix, got {name}");
+        assert!(
+            suffix.chars().all(|c| c.is_ascii_hexdigit()),
+            "non-hex suffix in {name}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn unique_name_successive_calls_differ() {
+        let home = tmp_home("diff");
+        let a = unique_fleet_name(&home, "codex");
+        // Realize `a` as a workspace so the next call must not collide with it.
+        std::fs::create_dir_all(home.join("workspace").join(&a)).expect("create a");
+        let b = unique_fleet_name(&home, "codex");
+        assert_ne!(a, b);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn unique_name_skips_workspace_collision() {
+        let home = tmp_home("ws");
+        // Pre-create a workspace whose name could plausibly be minted; since
+        // the suffix is random we just assert the returned name isn't that
+        // directory.
+        let blocked = "codex-000000";
+        std::fs::create_dir_all(home.join("workspace").join(blocked)).expect("create workspace");
+        let name = unique_fleet_name(&home, "codex");
+        assert_ne!(name, blocked);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn unique_name_skips_inbox_collision() {
+        let home = tmp_home("ib");
+        let blocked = "codex-000000";
+        std::fs::create_dir_all(home.join("inbox")).expect("create inbox");
+        std::fs::write(home.join("inbox").join(format!("{blocked}.jsonl")), "")
+            .expect("write inbox file");
+        let name = unique_fleet_name(&home, "codex");
+        assert_ne!(name, blocked);
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -53,7 +53,7 @@ pub struct InboxMessage {
     pub timestamp: String,
 }
 
-fn inbox_path(home: &Path, name: &str) -> PathBuf {
+pub(crate) fn inbox_path(home: &Path, name: &str) -> PathBuf {
     home.join("inbox").join(format!("{name}.jsonl"))
 }
 


### PR DESCRIPTION
## Summary

Closing a pane removed the fleet.yaml entry but left `workspace/<name>/` intact, so opening a new pane with the same backend silently inherited the prior instance's `.codex/`, `AGENTS.md`, and git state. User observed this as codex panes appearing to resume old sessions even after Ctrl+B x + Ctrl+B c.

Two coordinated fixes:

- **`unique_fleet_name`** now always appends a 6-hex suffix (e.g. `codex-a3f2c1`) derived from subsecond nanos XORed with a process-local counter. Collision set extended from fleet.yaml alone to fleet.yaml ∪ `workspace/` ∪ `inbox/`, so stale directories also trigger a fresh name. Falls back to `-N` after 100 retries (practically unreachable).
- **Pane/tab close path** (`overlay.rs`) calls `crate::ops::cleanup_working_dir` after `kill_agent`, mirroring the MCP delete path (`ops.rs:341`). Managed workspace dirs under `$AGEND_HOME/workspace/` are fully removed; user-specified working dirs only lose agend-generated files.

Belt-and-suspenders: normal close cleans the workspace → next spawn name could safely reuse; if anything leaks, the suffix scheme guarantees no silent reuse.

## Test plan

- [x] `cargo fmt` / `cargo clippy --all-targets -- -D warnings`
- [x] Full `cargo test` (lib + bin + integration) green
- [x] 4 new unit tests: always suffixed, successive calls differ, workspace collision skipped, inbox collision skipped
- [ ] Manual: Ctrl+B c codex → conversation → Ctrl+B x → Ctrl+B c codex → confirm fresh trust prompt and new workspace dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)