### PR TITLE
fix(agent): scan VTerm-rendered screen for dismiss patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-04-21
+
 Substantial work has landed on `main` since `0.3.0`. Highlights, grouped by area.
 
 ### Added
@@ -40,6 +42,8 @@ Substantial work has landed on `main` since `0.3.0`. Highlights, grouped by area
 - Worktree creation handles empty-repo + set-git-config edge cases.
 - Bugreport redacts `group_id`.
 - Various clippy 1.95 fixes (`collapsible_if`, `type_complexity`, `unwrap_used`, overlay bounds match guards).
+- **Unique instance names on every spawn** — 6-hex suffix against `fleet.yaml` ∪ `workspace/` ∪ `inbox/`; pane close cleans up the workspace and inbox entry so the next spawn cannot accidentally resume a stale agent session.
+- **Codex trust prompt auto-dismiss now works on macOS** — dismiss pattern matching runs against the VTerm-rendered screen (not a hand-rolled strip_ansi over raw bytes), so Ink-style char-by-char cursor-positioned paints still match. Codex dismiss key switched from LF to CR — macOS/openpty does not translate LF→CR on input like ConPTY does, so LF was silently acting as Ctrl+J (move selection down).
 
 ### Removed
 
@@ -92,5 +96,6 @@ Substantial work has landed on `main` since `0.3.0`. Highlights, grouped by area
 
 ---
 
-[Unreleased]: https://github.com/suzuke/agend-terminal/compare/85f2bc3...HEAD
+[Unreleased]: https://github.com/suzuke/agend-terminal/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/suzuke/agend-terminal/compare/85f2bc3...v0.3.1
 [0.3.0]: https://github.com/suzuke/agend-terminal/commit/85f2bc3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agend-terminal"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agend-terminal"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Agent Process Manager — orchestrate AI coding agents with PTY isolation, fleet management, and 35 MCP tools"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ agend-terminal demo
 # Or start with your own agents
 cat > ~/.agend-terminal/fleet.yaml << 'YAML'
 defaults:
-  backend: claude-code
+  backend: claude
 
 instances:
   dev:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ is bidirectional:
 ## Testing
 
 ```bash
-cargo test         # 51 tests (unit + integration + MCP round-trip)
+cargo test         # 561 tests (unit + integration + MCP round-trip)
 cargo clippy       # 0 errors (deny unwrap_used)
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Worktree preserves all code changes.
 agend-terminal demo
 
 # Or start with your own agents
-cat > ~/.agend-terminal/fleet.yaml << 'YAML'
+cat > ~/.agend/fleet.yaml << 'YAML'
 defaults:
   backend: claude
 
@@ -70,16 +70,32 @@ agend-terminal start
 ## Commands
 
 ```
-agend-terminal demo                      30-second interactive demo
-agend-terminal start                     Start daemon + fleet
-agend-terminal daemon [name:cmd ...]     Start with explicit agents
-agend-terminal attach <name>             Attach to agent (Ctrl+B d)
-agend-terminal inject <name> <text>      Send input
-agend-terminal list / status             Show agents
-agend-terminal kill <name>               Kill agent
-agend-terminal stop                      Stop daemon
-agend-terminal doctor                    Check backends
-agend-terminal mcp                       MCP stdio server
+Get started
+  agend-terminal app                   Launch multi-tab/pane TUI
+  agend-terminal demo                  30-second interactive demo
+  agend-terminal quickstart            Interactive setup — detect backends, wire Telegram, generate fleet.yaml
+  agend-terminal doctor                Health check backends
+
+Run a fleet
+  agend-terminal start                 Start daemon with fleet.yaml
+  agend-terminal daemon [name:cmd …]   Start daemon with explicit agents
+  agend-terminal stop                  Stop daemon
+  agend-terminal upgrade --binary <path>
+                                       Hot-upgrade daemon via supervisor (Unix only)
+
+Interact
+  agend-terminal attach <name>         Attach to agent (Ctrl+B d to detach)
+  agend-terminal inject <name> <text>  Send input to agent's PTY
+  agend-terminal list                  List running agents
+  agend-terminal status                Detailed agent status (state, health)
+  agend-terminal kill <name>           Kill an agent
+  agend-terminal connect <name>        Register an external agent with the running daemon
+  agend-terminal fleet …               Fleet management subcommands
+
+Integration
+  agend-terminal mcp                   MCP stdio server (agent-to-agent coordination)
+  agend-terminal completions <shell>   Generate shell completions (bash/zsh/fish/elvish/powershell)
+  agend-terminal bugreport             One-file diagnostic export
 ```
 
 ## 35 MCP Tools

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -565,7 +565,6 @@ fn pty_read_loop(pty_reader: &mut dyn Read, ctx: &PtyReadContext) {
         shutdown,
     } = ctx;
     let mut buf = [0u8; 8192];
-    let mut detect_buf = Vec::with_capacity(4096);
     let mut dismiss_cooldown_until: Option<std::time::Instant> = None;
     let debug_reads = std::env::var("AGEND_DEBUG_PTY_READ").is_ok();
     let mut read_count: u64 = 0;
@@ -602,29 +601,27 @@ fn pty_read_loop(pty_reader: &mut dyn Read, ctx: &PtyReadContext) {
                 }
                 let data = &buf[..n_bytes];
 
-                // Auto-dismiss trust/update dialogs (cooldown: 10s after last dismiss)
-                let in_cooldown = dismiss_cooldown_until
-                    .map(|t| std::time::Instant::now() < t)
-                    .unwrap_or(false);
-                if !in_cooldown
-                    && try_dismiss_dialog(name, data, &mut detect_buf, pty_writer, dismiss_patterns)
-                {
-                    dismiss_cooldown_until =
-                        Some(std::time::Instant::now() + std::time::Duration::from_secs(10));
-                }
-
-                // Feed VTerm + state detection + broadcast (under same lock = atomic)
-                {
+                // Feed VTerm + state detection + broadcast (under same lock = atomic),
+                // then scan the rendered screen for dismiss patterns. Scanning
+                // post-render means we match what the user actually sees —
+                // Ink-style TUIs that draw char-by-char with cursor positioning
+                // won't defeat us (VTerm resolves the geometry). Cooldown: 10s.
+                let screen = {
                     let mut c = crate::sync::lock_poisoned(core, "agent_core");
                     c.vterm.process(data);
-                    // Detection runs against the current vterm screen. The
-                    // grid already has ANSI resolved, so state.feed() gets
-                    // plain user-visible text. Hash-dedup inside feed()
-                    // skips cycles where the screen didn't change.
                     let rows = c.vterm.rows() as usize;
                     let screen = c.vterm.tail_lines(rows);
                     c.state.feed(&screen);
                     c.subscribers.retain(|tx| tx.send(data.to_vec()).is_ok());
+                    screen
+                };
+
+                let in_cooldown = dismiss_cooldown_until
+                    .map(|t| std::time::Instant::now() < t)
+                    .unwrap_or(false);
+                if !in_cooldown && try_dismiss_dialog(name, &screen, pty_writer, dismiss_patterns) {
+                    dismiss_cooldown_until =
+                        Some(std::time::Instant::now() + std::time::Duration::from_secs(10));
                 }
             }
             Err(e) => {
@@ -739,25 +736,20 @@ fn handle_pty_close(
 }
 
 /// Try to auto-dismiss dialogs using backend-configurable patterns. Returns true if dismissed.
+/// `screen` is the VTerm-rendered view the user sees — not raw PTY bytes —
+/// so Ink-style TUIs that paint char-by-char with cursor positioning still match.
 pub fn try_dismiss_dialog(
     name: &str,
-    data: &[u8],
-    detect_buf: &mut Vec<u8>,
+    screen: &str,
     pty_writer: &PtyWriter,
     dismiss_patterns: &[(String, Vec<u8>)],
 ) -> bool {
     if dismiss_patterns.is_empty() {
         return false;
     }
-    detect_buf.extend_from_slice(data);
-    if detect_buf.len() > 8192 {
-        let d = detect_buf.len() - 8192;
-        detect_buf.drain(..d);
-    }
-    let clean = strip_ansi(&String::from_utf8_lossy(detect_buf));
 
     for (pattern, key_seq) in dismiss_patterns {
-        if clean.contains(pattern.as_str()) {
+        if screen.contains(pattern.as_str()) {
             tracing::info!(agent = name, pattern, "auto-dismissing dialog");
             // Delayed write: TUI escape-sequence parsers need time to distinguish
             // \x1b (ESC key) from \x1b[ (CSI start).  Writing immediately causes
@@ -793,7 +785,6 @@ pub fn try_dismiss_dialog(
                 }
                 tracing::debug!(agent = %agent, "dismiss keystrokes sent");
             });
-            detect_buf.clear();
             return true;
         }
     }
@@ -972,5 +963,50 @@ mod tests {
         assert!(!is_sensitive_env_key("LANG"));
         assert!(!is_sensitive_env_key("TERM"));
         assert!(!is_sensitive_env_key("PROMPT_OVERRIDE"));
+    }
+
+    fn test_writer() -> PtyWriter {
+        Arc::new(Mutex::new(Box::new(Vec::<u8>::new())))
+    }
+
+    #[test]
+    fn dismiss_fires_when_pattern_in_screen() {
+        let patterns = vec![("Do you trust".to_string(), b"\n".to_vec())];
+        let hit = try_dismiss_dialog(
+            "t",
+            "Do you trust the contents of this directory?",
+            &test_writer(),
+            &patterns,
+        );
+        assert!(hit);
+    }
+
+    #[test]
+    fn dismiss_skips_when_pattern_absent() {
+        let patterns = vec![("Do you trust".to_string(), b"\n".to_vec())];
+        let hit = try_dismiss_dialog("t", "unrelated screen content", &test_writer(), &patterns);
+        assert!(!hit);
+    }
+
+    #[test]
+    fn dismiss_skips_when_no_patterns() {
+        assert!(!try_dismiss_dialog("t", "anything", &test_writer(), &[]));
+    }
+
+    #[test]
+    fn dismiss_matches_ink_style_cursor_painted_prompt() {
+        // Regression for macOS: Ink-based TUIs (codex) paint text by
+        // positioning the cursor before each segment. VTerm resolves this
+        // into a clean screen; the old raw-byte strip_ansi path was fragile
+        // on such streams. Drive VTerm with BSU + cursor positioning and
+        // confirm the rendered screen still contains the pattern literally.
+        let mut vt = crate::vterm::VTerm::new(80, 24);
+        vt.process(b"\x1b[?2026h"); // begin synchronized update
+        vt.process(b"\x1b[5;2HDo you trust"); // row 5 col 2
+        vt.process(b"\x1b[5;15H the contents of this directory?");
+        vt.process(b"\x1b[?2026l"); // end synchronized update
+        let screen = vt.tail_lines(24);
+        let patterns = vec![("Do you trust".to_string(), b"\n".to_vec())];
+        assert!(try_dismiss_dialog("t", &screen, &test_writer(), &patterns));
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -220,10 +220,13 @@ impl Backend {
                 inject_instructions_on_ready: false,
                 ready_timeout_secs: 20,
                 dismiss_patterns: &[
-                    // Trust directory prompt: "Yes, continue" is pre-selected → Enter
-                    ("Do you trust", b"\n"),
+                    // Trust directory prompt: "Yes, continue" is pre-selected → Enter.
+                    // CR (\r), not LF — Ink's keyboard reader treats CR as Enter.
+                    // macOS openpty doesn't translate LF→CR on input (ConPTY does),
+                    // so LF here would silently no-op on mac.
+                    ("Do you trust", b"\r"),
                     // Auto-update prompt: "Please restart Codex" → Enter
-                    ("Please restart", b"\n"),
+                    ("Please restart", b"\r"),
                 ],
                 // Codex: "resume --last" → fresh start drops the resume subcommand
                 fresh_args: Some(&["--dangerously-bypass-approvals-and-sandbox"]),


### PR DESCRIPTION
## Summary
- Auto-dismiss pattern matching now reads the VTerm-rendered screen instead of hand-rolled `strip_ansi(raw PTY bytes)`. On macOS/openpty, codex (Ink-based TUI) paints the trust prompt with cursor-positioning + synchronized-update escapes, which the hand-rolled stripper didn't normalize — so \"Do you trust\" never matched and the prompt sat there waiting for Enter. Windows/ConPTY happened to emit simpler byte streams so the bug was macOS-only.
- `try_dismiss_dialog` now takes `screen: &str` (already computed for `state.feed`) instead of `data + detect_buf`. Same lock cycle, no extra allocation.
- `strip_ansi` / `strip_ansi_pub` kept — still used by `cli.rs` capture and `verify.rs` dump.
- Regression test drives VTerm with BSU + `\x1b[R;CH` cursor positioning to reproduce the Ink paint pattern.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 561 pass / 2 ignored
- [ ] Manual mac: open fresh codex pane, trust prompt auto-dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)