### PR TITLE
fix(platform): use default_shell() instead of hard-coded /bin/bash on Windows

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -14,7 +14,8 @@ pub enum Backend {
     OpenCode,
     Gemini,
     /// Generic shell (bash/zsh/sh). No preset wiring — inject/ready/resume are
-    /// all no-ops. Command defaults to `$SHELL` or `/bin/sh`.
+    /// all no-ops. Command defaults to `$SHELL` or the platform default
+    /// (`/bin/bash` on Unix, `cmd.exe` on Windows).
     Shell,
     /// Arbitrary executable path. No preset behavior; the stored string is the
     /// command to spawn verbatim.
@@ -54,8 +55,9 @@ impl Backend {
     }
 
     /// Actual command path to spawn. For [`Backend::Shell`] resolves to
-    /// `$SHELL` (with `/bin/sh` as fallback). For [`Backend::Raw`] returns the
-    /// literal stored path. For presets returns the static preset command.
+    /// `$SHELL` (falling back to the platform default — `/bin/bash` on Unix,
+    /// `cmd.exe` on Windows). For [`Backend::Raw`] returns the literal stored
+    /// path. For presets returns the static preset command.
     #[allow(dead_code)] // Call sites migrate in follow-up commits.
     pub fn command_string(&self) -> String {
         match self {
@@ -64,7 +66,9 @@ impl Backend {
             | Backend::Codex
             | Backend::OpenCode
             | Backend::Gemini => self.preset().command.to_string(),
-            Backend::Shell => std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string()),
+            Backend::Shell => {
+                std::env::var("SHELL").unwrap_or_else(|_| crate::default_shell().to_string())
+            }
             Backend::Raw(path) => path.clone(),
         }
     }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -626,15 +626,19 @@ mod tests {
         // Whatever $SHELL is in test env, result must be non-empty.
         let cmd = Backend::Shell.command_string();
         assert!(!cmd.is_empty());
-        // Unix: `/bin/bash`, `/bin/zsh`, etc.; fallback `/bin/sh`. Windows
+        // Unix: `/bin/bash`, `/bin/zsh`, etc.; fallback `/bin/bash`. Windows
         // under Git Bash translates POSIX SHELL into a Win32 path like
         // `C:\Program Files\Git\bin\bash.exe` before the child sees it, so
-        // accept drive-letter paths too. CI's plain PowerShell doesn't do
-        // the translation, which is why this test was green on windows-latest
-        // but failed when run locally through Git Bash.
+        // accept drive-letter paths too. CI's plain PowerShell has no $SHELL
+        // at all, so the Windows fallback is the bare `cmd.exe` name (PATH
+        // resolution handled by the shell spawn later).
         let unixish = cmd.starts_with('/');
         let winish = cmd.chars().nth(1) == Some(':') && cmd.chars().nth(2) == Some('\\');
-        assert!(unixish || winish, "unexpected shell path shape: {cmd:?}");
+        let bare_exe = cmd.ends_with(".exe") && !cmd.contains(['/', '\\']);
+        assert!(
+            unixish || winish || bare_exe,
+            "unexpected shell path shape: {cmd:?}"
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,7 +118,7 @@ fn test_attach(_home: &Path) -> anyhow::Result<()> {
     agent::spawn_agent(
         &agent::SpawnConfig {
             name: "test-attach",
-            backend_command: "/bin/bash",
+            backend_command: crate::default_shell(),
             args: &args,
             spawn_mode: backend::SpawnMode::Fresh,
             cols: 80,
@@ -326,11 +326,12 @@ pub fn run_demo() -> anyhow::Result<()> {
 
     let (crash_tx, _rx) = crossbeam::channel::unbounded::<String>();
     let args: Vec<String> = vec![];
+    let shell = crate::default_shell();
     for name in &["alice", "bob"] {
         agent::spawn_agent(
             &agent::SpawnConfig {
                 name,
-                backend_command: "/bin/bash",
+                backend_command: shell,
                 args: &args,
                 spawn_mode: backend::SpawnMode::Fresh,
                 cols: 60,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -43,11 +43,11 @@ impl TestResult {
     }
 }
 
-/// Create a default SpawnConfig for test agents (bash).
+/// Create a default SpawnConfig for test agents (platform shell).
 fn test_spawn_config<'a>(name: &'a str, home: Option<&'a Path>) -> agent::SpawnConfig<'a> {
     agent::SpawnConfig {
         name,
-        backend_command: "/bin/bash",
+        backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
         cols: 80,
@@ -388,7 +388,7 @@ fn test_send(home: &Path) -> TestResult {
 fn test_create_delete(home: &Path) -> TestResult {
     if api::call(
         home,
-        &json!({"method": api::method::SPAWN, "params": {"name": "verify-dynamic", "backend": "/bin/bash"}}),
+        &json!({"method": api::method::SPAWN, "params": {"name": "verify-dynamic", "backend": crate::default_shell()}}),
     )
     .is_err()
     {

--- a/tests/mcp_roundtrip.rs
+++ b/tests/mcp_roundtrip.rs
@@ -4,6 +4,15 @@
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+
+/// Platform-default shell used as a dummy `command` in create_instance
+/// payloads. The daemon isn't running in these tests, so the shell is never
+/// actually spawned — but we still match real paths so any future validation
+/// layer doesn't reject Windows runs on a missing `/bin/bash`.
+#[cfg(windows)]
+const SHELL_CMD: &str = "cmd.exe";
+#[cfg(not(windows))]
+const SHELL_CMD: &str = "/bin/bash";
 fn binary() -> PathBuf {
     let mut path = std::env::current_exe().expect("current_exe");
     path.pop();
@@ -403,11 +412,15 @@ fn test_create_delete_instance_lifecycle() {
     // create_instance/delete_instance need a running daemon (they call API spawn/delete).
     // We use list_instances which falls back to scanning fleet.yaml when API is unavailable.
     // So we verify the fleet.yaml persistence side.
+    let create_call = format!(
+        r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"create_instance","arguments":{{"name":"test-dynamic","command":"{}"}}}}}}"#,
+        SHELL_CMD
+    );
     let responses = mcp_session(&[
         // 1: initialize
         r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
         // 2: create_instance (will fail API call since no daemon, but tests the path)
-        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create_instance","arguments":{"name":"test-dynamic","command":"/bin/bash"}}}"#,
+        &create_call,
         // 3: list_instances (will show from fleet.yaml fallback)
         r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_instances","arguments":{}}}"#,
         // 4: delete_instance


### PR DESCRIPTION
## Summary

- `agend-terminal demo` on Windows crashed with `` `CreateProcessW` `/bin/bash` … 系統找不到指定的路徑 (os error 3) `` because `run_demo` passed a literal `/bin/bash` to `spawn_agent`.
- Same hard-coding in `test_attach`, `verify::test_spawn_config`, `verify::test_create_delete`, and `Backend::Shell`'s fallback. All replaced with `crate::default_shell()` (existing helper at `src/main.rs:54`, which returns `cmd.exe` on Windows and `/bin/bash` elsewhere — already used in `app/mod.rs` and `app/session.rs`).
- `Backend::Shell::command_string()` is `#[allow(dead_code)]` today so the fallback is latent — fixed regardless to avoid a future landmine.

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` clean
- [ ] `.\target\release\agend-terminal.exe demo` runs end-to-end on Windows
- [ ] `agend-terminal verify` passes on Windows
- [ ] CI green on Linux/macOS (no behavior change on those platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)