### PR TITLE
feat(tray): scaffold + autostart + OpenInTerminal (PLAN tasks #1-3 + CI gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,21 @@ jobs:
       - name: Clippy
         run: cargo clippy -- -D warnings
 
+      # Tray feature gate (docs/PLAN-tray-resident.md). Release binaries
+      # still ship default-only until PLAN task #4 pulls in tray-icon/tao;
+      # this step just guarantees the feature code compiles on all three
+      # platforms so per-OS regressions surface before the event loop lands.
+      - name: Clippy (tray feature)
+        run: cargo clippy --all-targets --features tray -- -D warnings
+
       - name: Build
         run: cargo build --release
 
       - name: Unit tests
         run: cargo test --bin agend-terminal
+
+      - name: Unit tests (tray feature)
+        run: cargo test --bin agend-terminal --features tray
 
       - name: Integration tests
         run: cargo test --test integration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,13 @@ include = [
 [lints.clippy]
 unwrap_used = "deny"
 
+# Menu-bar / system-tray resident app (see docs/PLAN-tray-resident.md).
+# Scaffold only — `tray-icon` + `tao` land with PLAN task #4 (event loop).
+# Default build stays lean: no new deps unless `--features tray` is passed.
+[features]
+default = []
+tray = []
+
 [profile.release]
 strip = true
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ iana-time-zone = "0.1.65"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_System_Console", "Win32_Foundation"] }
+windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_System_Console", "Win32_Foundation", "Win32_System_Registry"] }
 
 [target.'cfg(windows)'.build-dependencies]
 embed-resource = "2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,8 @@ mod sync;
 mod tasks;
 mod teams;
 mod telegram;
+#[cfg(feature = "tray")]
+mod tray;
 mod tui;
 mod verify;
 mod vterm;
@@ -256,6 +258,12 @@ enum Commands {
     },
     /// Health check
     Doctor,
+    /// Menu-bar / system-tray resident app (requires `--features tray`).
+    ///
+    /// Scaffold only in this build — real event loop lands with
+    /// `docs/PLAN-tray-resident.md` task #4.
+    #[cfg(feature = "tray")]
+    Tray,
     /// Interactive demo — experience multi-agent orchestration in 30 seconds
     Demo,
     /// Interactive setup — detect backends, configure Telegram, generate fleet.yaml
@@ -587,6 +595,8 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Test { suite }) => cli::run_tests(&suite, &home)?,
         Some(Commands::Verify { json, backend }) => verify::run(&home, json, backend.as_deref())?,
         Some(Commands::Doctor) => cli::run_doctor(&home)?,
+        #[cfg(feature = "tray")]
+        Some(Commands::Tray) => tray::run(&home)?,
         Some(Commands::Demo) => cli::run_demo()?,
         Some(Commands::Quickstart) => quickstart::run(&home)?,
         Some(Commands::Bugreport) => bugreport::run(&home)?,

--- a/src/tray/autostart/linux.rs
+++ b/src/tray/autostart/linux.rs
@@ -1,0 +1,20 @@
+//! Linux autostart: XDG `.desktop` at
+//! `~/.config/autostart/agend-terminal.desktop`. PLAN task #2.
+
+use super::Autostart;
+
+pub struct LinuxAutostart;
+
+impl Autostart for LinuxAutostart {
+    fn enable(&self) -> anyhow::Result<()> {
+        anyhow::bail!("tray autostart (Linux): not yet implemented — PLAN task #2")
+    }
+
+    fn disable(&self) -> anyhow::Result<()> {
+        anyhow::bail!("tray autostart (Linux): not yet implemented — PLAN task #2")
+    }
+
+    fn is_enabled(&self) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+}

--- a/src/tray/autostart/linux.rs
+++ b/src/tray/autostart/linux.rs
@@ -1,20 +1,89 @@
-//! Linux autostart: XDG `.desktop` at
-//! `~/.config/autostart/agend-terminal.desktop`. PLAN task #2.
+//! Linux autostart via XDG `.desktop`.
+//!
+//! Writes `~/.config/autostart/agend-terminal.desktop`. Works across
+//! GNOME, KDE, XFCE, Cinnamon, MATE, LXQt — the XDG spec is uniform
+//! where the systemd-user-unit path is not.
+
+use std::{fs, path::PathBuf};
 
 use super::Autostart;
 
 pub struct LinuxAutostart;
 
+impl LinuxAutostart {
+    pub fn new(_home: PathBuf) -> Self {
+        Self
+    }
+
+    fn desktop_path() -> anyhow::Result<PathBuf> {
+        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot resolve $HOME"))?;
+        Ok(home.join(".config/autostart/agend-terminal.desktop"))
+    }
+
+    fn render(exe: &std::path::Path) -> String {
+        // Exec quoting: `.desktop` files use a restricted quoting grammar
+        // (§Exec in the XDG Desktop Entry spec). A plain absolute path
+        // with no whitespace is the common case; if the path contains
+        // spaces, wrap in double quotes per the spec.
+        let exe_str = exe.to_string_lossy();
+        let exec = if exe_str.contains(' ') {
+            format!("\"{exe_str}\" tray")
+        } else {
+            format!("{exe_str} tray")
+        };
+        format!(
+            "[Desktop Entry]\n\
+             Type=Application\n\
+             Name=Agend Terminal\n\
+             Exec={exec}\n\
+             Terminal=false\n\
+             Icon=agend-terminal\n\
+             X-GNOME-Autostart-enabled=true\n",
+        )
+    }
+}
+
 impl Autostart for LinuxAutostart {
     fn enable(&self) -> anyhow::Result<()> {
-        anyhow::bail!("tray autostart (Linux): not yet implemented — PLAN task #2")
+        let path = Self::desktop_path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let exe = std::env::current_exe()?.canonicalize()?;
+        fs::write(&path, Self::render(&exe))?;
+        Ok(())
     }
 
     fn disable(&self) -> anyhow::Result<()> {
-        anyhow::bail!("tray autostart (Linux): not yet implemented — PLAN task #2")
+        let path = Self::desktop_path()?;
+        if path.exists() {
+            fs::remove_file(&path)?;
+        }
+        Ok(())
     }
 
     fn is_enabled(&self) -> anyhow::Result<bool> {
-        Ok(false)
+        Ok(Self::desktop_path()?.exists())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn desktop_file_contains_required_keys() {
+        let content = LinuxAutostart::render(&PathBuf::from("/usr/local/bin/agend-terminal"));
+        assert!(content.contains("Type=Application"));
+        assert!(content.contains("Exec=/usr/local/bin/agend-terminal tray"));
+        assert!(content.contains("Terminal=false"));
+        assert!(content.contains("X-GNOME-Autostart-enabled=true"));
+    }
+
+    #[test]
+    fn exec_line_quotes_paths_with_spaces() {
+        let content = LinuxAutostart::render(&PathBuf::from("/opt/with space/agend-terminal"));
+        assert!(content.contains(r#"Exec="/opt/with space/agend-terminal" tray"#));
     }
 }

--- a/src/tray/autostart/macos.rs
+++ b/src/tray/autostart/macos.rs
@@ -1,21 +1,169 @@
-//! macOS autostart: LaunchAgent plist at
-//! `~/Library/LaunchAgents/io.github.suzuke.agend-terminal.plist` +
-//! `launchctl bootstrap gui/$UID`. PLAN task #2.
+//! macOS autostart via a per-user LaunchAgent.
+//!
+//! Writes `~/Library/LaunchAgents/io.github.suzuke.agend-terminal.plist`
+//! and registers it with `launchctl bootstrap gui/$UID`. Disable removes
+//! the plist and calls `bootout`.
+//!
+//! Label choice is locked by PLAN — a future signed `.app` bundle must
+//! reuse it as `CFBundleIdentifier` so Login Items entries don't split.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use super::Autostart;
 
-pub struct MacAutostart;
+/// LaunchAgent label + file stem. Reverse-DNS form documented in PLAN.
+const LABEL: &str = "io.github.suzuke.agend-terminal";
+
+pub struct MacAutostart {
+    home: PathBuf,
+}
+
+impl MacAutostart {
+    pub fn new(home: PathBuf) -> Self {
+        Self { home }
+    }
+
+    fn plist_path() -> anyhow::Result<PathBuf> {
+        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot resolve $HOME"))?;
+        Ok(home
+            .join("Library/LaunchAgents")
+            .join(format!("{LABEL}.plist")))
+    }
+
+    /// `gui/<uid>` — launchd's modern per-user domain. `load` is deprecated;
+    /// `bootstrap` needs this explicit domain target.
+    fn launchctl_domain() -> String {
+        // SAFETY: getuid() is thread-safe and always returns a valid uid.
+        let uid = unsafe { libc::getuid() };
+        format!("gui/{uid}")
+    }
+
+    fn render_plist(&self, exe: &Path) -> String {
+        let log_path = self.home.join("tray.log");
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key>             <string>{label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{exe}</string>
+    <string>tray</string>
+  </array>
+  <key>RunAtLoad</key>         <true/>
+  <key>KeepAlive</key>         <dict><key>SuccessfulExit</key><false/></dict>
+  <key>ProcessType</key>       <string>Interactive</string>
+  <key>StandardOutPath</key>   <string>{log}</string>
+  <key>StandardErrorPath</key> <string>{log}</string>
+  <key>EnvironmentVariables</key>
+  <dict><key>AGEND_HOME</key>  <string>{home}</string></dict>
+</dict></plist>
+"#,
+            label = LABEL,
+            exe = xml_escape(&exe.to_string_lossy()),
+            log = xml_escape(&log_path.to_string_lossy()),
+            home = xml_escape(&self.home.to_string_lossy()),
+        )
+    }
+}
+
+/// XML-escape the five characters that matter inside `<string>` bodies.
+/// Paths seldom contain these, but a user with `&` in their home path
+/// would otherwise produce a malformed plist.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
 
 impl Autostart for MacAutostart {
     fn enable(&self) -> anyhow::Result<()> {
-        anyhow::bail!("tray autostart (macOS): not yet implemented — PLAN task #2")
+        let path = Self::plist_path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let exe = std::env::current_exe()?.canonicalize()?;
+        fs::write(&path, self.render_plist(&exe))?;
+
+        // bootstrap fails if the label is already loaded; bootout first
+        // so `enable()` stays idempotent. Ignore bootout's exit status —
+        // "not loaded" is the common and acceptable case.
+        let domain = Self::launchctl_domain();
+        let target = format!("{domain}/{LABEL}");
+        let _ = Command::new("launchctl")
+            .args(["bootout", &target])
+            .output();
+        let out = Command::new("launchctl")
+            .args(["bootstrap", &domain])
+            .arg(&path)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "launchctl bootstrap {domain} failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Ok(())
     }
 
     fn disable(&self) -> anyhow::Result<()> {
-        anyhow::bail!("tray autostart (macOS): not yet implemented — PLAN task #2")
+        let path = Self::plist_path()?;
+        let target = format!("{}/{LABEL}", Self::launchctl_domain());
+        // Best effort — if not loaded, bootout returns non-zero; we still
+        // want to remove the file below.
+        let _ = Command::new("launchctl")
+            .args(["bootout", &target])
+            .output();
+        if path.exists() {
+            fs::remove_file(&path)?;
+        }
+        Ok(())
     }
 
     fn is_enabled(&self) -> anyhow::Result<bool> {
-        Ok(false)
+        Ok(Self::plist_path()?.exists())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plist_renders_well_formed_xml_with_required_keys() {
+        let auto = MacAutostart::new(PathBuf::from("/tmp/agend-home"));
+        let exe = PathBuf::from("/opt/homebrew/bin/agend-terminal");
+        let plist = auto.render_plist(&exe);
+
+        assert!(plist.contains("<string>io.github.suzuke.agend-terminal</string>"));
+        assert!(plist.contains("<string>/opt/homebrew/bin/agend-terminal</string>"));
+        assert!(plist.contains("<string>tray</string>"));
+        assert!(plist.contains("<string>/tmp/agend-home/tray.log</string>"));
+        assert!(plist.contains("<key>AGEND_HOME</key>"));
+        assert!(plist.contains("<string>/tmp/agend-home</string>"));
+        assert!(plist.contains("<key>KeepAlive</key>"));
+    }
+
+    #[test]
+    fn xml_escape_handles_the_five_classes() {
+        assert_eq!(
+            xml_escape("a&b<c>d\"e'f"),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
+    }
+
+    #[test]
+    fn plist_escapes_paths_with_xml_special_chars() {
+        let auto = MacAutostart::new(PathBuf::from("/tmp/a&b"));
+        let exe = PathBuf::from("/tmp/<weird>/agend-terminal");
+        let plist = auto.render_plist(&exe);
+        assert!(plist.contains("/tmp/a&amp;b"));
+        assert!(plist.contains("/tmp/&lt;weird&gt;/agend-terminal"));
     }
 }

--- a/src/tray/autostart/macos.rs
+++ b/src/tray/autostart/macos.rs
@@ -1,0 +1,21 @@
+//! macOS autostart: LaunchAgent plist at
+//! `~/Library/LaunchAgents/io.github.suzuke.agend-terminal.plist` +
+//! `launchctl bootstrap gui/$UID`. PLAN task #2.
+
+use super::Autostart;
+
+pub struct MacAutostart;
+
+impl Autostart for MacAutostart {
+    fn enable(&self) -> anyhow::Result<()> {
+        anyhow::bail!("tray autostart (macOS): not yet implemented — PLAN task #2")
+    }
+
+    fn disable(&self) -> anyhow::Result<()> {
+        anyhow::bail!("tray autostart (macOS): not yet implemented — PLAN task #2")
+    }
+
+    fn is_enabled(&self) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+}

--- a/src/tray/autostart/mod.rs
+++ b/src/tray/autostart/mod.rs
@@ -3,7 +3,11 @@
 //! Each platform writes its own entry pointing at
 //! `std::env::current_exe()?.canonicalize()?` so `cargo install --force`
 //! upgrades are picked up on next login with no re-configuration.
-//! Implementations land with PLAN task #2.
+//!
+//! Construct via `Platform::new(home)`. `home` is required by macOS (the
+//! plist's `AGEND_HOME` env var + `StandardOutPath`); Linux and Windows
+//! ignore it, but the uniform signature spares the caller from `cfg`
+//! branches at the construction site.
 
 pub trait Autostart {
     /// Install the platform-specific autostart entry (idempotent).

--- a/src/tray/autostart/mod.rs
+++ b/src/tray/autostart/mod.rs
@@ -1,0 +1,36 @@
+//! Launch-at-login persistence.
+//!
+//! Each platform writes its own entry pointing at
+//! `std::env::current_exe()?.canonicalize()?` so `cargo install --force`
+//! upgrades are picked up on next login with no re-configuration.
+//! Implementations land with PLAN task #2.
+
+pub trait Autostart {
+    /// Install the platform-specific autostart entry (idempotent).
+    fn enable(&self) -> anyhow::Result<()>;
+    /// Remove the entry (idempotent — missing is success).
+    fn disable(&self) -> anyhow::Result<()>;
+    /// Query current state by inspecting the on-disk entry.
+    fn is_enabled(&self) -> anyhow::Result<bool>;
+}
+
+// `Platform` is re-exported but not yet consumed — the tray event loop
+// (PLAN task #4) is what calls `Platform::enable()` etc. Suppress the
+// scaffold-window warning rather than gating the re-export itself.
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+#[allow(unused_imports)]
+pub use macos::MacAutostart as Platform;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+#[allow(unused_imports)]
+pub use linux::LinuxAutostart as Platform;
+
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+#[allow(unused_imports)]
+pub use windows::WindowsAutostart as Platform;

--- a/src/tray/autostart/windows.rs
+++ b/src/tray/autostart/windows.rs
@@ -1,0 +1,24 @@
+//! Windows autostart: HKCU\Software\Microsoft\Windows\CurrentVersion\Run
+//! value `AgendTerminal` via `windows-sys`. PLAN task #2.
+//!
+//! When wiring this up: add `Win32_System_Registry` to the **existing**
+//! `windows-sys` features list in `Cargo.toml` — do not declare a second
+//! entry (PLAN gotcha).
+
+use super::Autostart;
+
+pub struct WindowsAutostart;
+
+impl Autostart for WindowsAutostart {
+    fn enable(&self) -> anyhow::Result<()> {
+        anyhow::bail!("tray autostart (Windows): not yet implemented — PLAN task #2")
+    }
+
+    fn disable(&self) -> anyhow::Result<()> {
+        anyhow::bail!("tray autostart (Windows): not yet implemented — PLAN task #2")
+    }
+
+    fn is_enabled(&self) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+}

--- a/src/tray/autostart/windows.rs
+++ b/src/tray/autostart/windows.rs
@@ -1,24 +1,119 @@
-//! Windows autostart: HKCU\Software\Microsoft\Windows\CurrentVersion\Run
-//! value `AgendTerminal` via `windows-sys`. PLAN task #2.
+//! Windows autostart via `HKCU\...\Run`.
 //!
-//! When wiring this up: add `Win32_System_Registry` to the **existing**
-//! `windows-sys` features list in `Cargo.toml` — do not declare a second
-//! entry (PLAN gotcha).
+//! Sets the `AgendTerminal` value under
+//! `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`. Same mechanism
+//! Ollama uses on Windows. `HKCU` needs no admin rights.
+
+use std::{os::windows::ffi::OsStrExt, path::PathBuf, ptr};
+
+use windows_sys::Win32::{
+    Foundation::ERROR_FILE_NOT_FOUND,
+    System::Registry::{
+        RegCloseKey, RegDeleteValueW, RegOpenKeyExW, RegQueryValueExW, RegSetValueExW, HKEY,
+        HKEY_CURRENT_USER, KEY_READ, KEY_WRITE, REG_SZ,
+    },
+};
 
 use super::Autostart;
 
+const RUN_KEY: &str = r"Software\Microsoft\Windows\CurrentVersion\Run";
+const VALUE_NAME: &str = "AgendTerminal";
+
 pub struct WindowsAutostart;
+
+impl WindowsAutostart {
+    pub fn new(_home: PathBuf) -> Self {
+        Self
+    }
+}
+
+/// NUL-terminated UTF-16 buffer as required by the -W registry APIs.
+fn wide(s: &str) -> Vec<u16> {
+    std::ffi::OsStr::new(s)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
 
 impl Autostart for WindowsAutostart {
     fn enable(&self) -> anyhow::Result<()> {
-        anyhow::bail!("tray autostart (Windows): not yet implemented — PLAN task #2")
+        let exe = std::env::current_exe()?.canonicalize()?;
+        // Quoting the exe path handles "Program Files" and friends; the
+        // Run key treats the whole value as a command line.
+        let value = format!("\"{}\" tray", exe.display());
+        let key_w = wide(RUN_KEY);
+        let name_w = wide(VALUE_NAME);
+        let value_w = wide(&value);
+        let byte_len: u32 = (value_w.len() * std::mem::size_of::<u16>())
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("registry value too large"))?;
+
+        // SAFETY: all pointers are into stack-owned buffers that outlive
+        // each call; hkey is closed before return on every path.
+        unsafe {
+            let mut hkey: HKEY = ptr::null_mut();
+            let rc = RegOpenKeyExW(HKEY_CURRENT_USER, key_w.as_ptr(), 0, KEY_WRITE, &mut hkey);
+            if rc != 0 {
+                anyhow::bail!("RegOpenKeyExW(HKCU\\{RUN_KEY}) failed: {rc}");
+            }
+            let rc = RegSetValueExW(
+                hkey,
+                name_w.as_ptr(),
+                0,
+                REG_SZ,
+                value_w.as_ptr().cast::<u8>(),
+                byte_len,
+            );
+            RegCloseKey(hkey);
+            if rc != 0 {
+                anyhow::bail!("RegSetValueExW({VALUE_NAME}) failed: {rc}");
+            }
+        }
+        Ok(())
     }
 
     fn disable(&self) -> anyhow::Result<()> {
-        anyhow::bail!("tray autostart (Windows): not yet implemented — PLAN task #2")
+        let key_w = wide(RUN_KEY);
+        let name_w = wide(VALUE_NAME);
+
+        // SAFETY: same invariants as enable().
+        unsafe {
+            let mut hkey: HKEY = ptr::null_mut();
+            let rc = RegOpenKeyExW(HKEY_CURRENT_USER, key_w.as_ptr(), 0, KEY_WRITE, &mut hkey);
+            if rc != 0 {
+                // Run key itself absent — treat as already disabled.
+                return Ok(());
+            }
+            let rc = RegDeleteValueW(hkey, name_w.as_ptr());
+            RegCloseKey(hkey);
+            if rc != 0 && rc != ERROR_FILE_NOT_FOUND {
+                anyhow::bail!("RegDeleteValueW({VALUE_NAME}) failed: {rc}");
+            }
+        }
+        Ok(())
     }
 
     fn is_enabled(&self) -> anyhow::Result<bool> {
-        Ok(false)
+        let key_w = wide(RUN_KEY);
+        let name_w = wide(VALUE_NAME);
+
+        // SAFETY: same invariants as enable().
+        unsafe {
+            let mut hkey: HKEY = ptr::null_mut();
+            let rc = RegOpenKeyExW(HKEY_CURRENT_USER, key_w.as_ptr(), 0, KEY_READ, &mut hkey);
+            if rc != 0 {
+                return Ok(false);
+            }
+            let rc = RegQueryValueExW(
+                hkey,
+                name_w.as_ptr(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+            );
+            RegCloseKey(hkey);
+            Ok(rc == 0)
+        }
     }
 }

--- a/src/tray/config.rs
+++ b/src/tray/config.rs
@@ -1,0 +1,28 @@
+//! `$AGEND_HOME/tray.toml` schema.
+//!
+//! MVP: single `terminal` key. Missing file → defaults. Malformed →
+//! warn-and-default (the tray must never crash on parse). See
+//! `docs/PLAN-tray-resident.md` §"tray.toml (MVP schema)".
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrayConfig {
+    /// `"default"` auto-detects per platform. Any other value names a
+    /// terminal emulator — either a known handler (e.g. `"iTerm"`,
+    /// `"wt"`, `"gnome-terminal"`) or an executable in `PATH`.
+    #[serde(default = "default_terminal")]
+    pub terminal: String,
+}
+
+fn default_terminal() -> String {
+    "default".to_string()
+}
+
+impl Default for TrayConfig {
+    fn default() -> Self {
+        Self {
+            terminal: default_terminal(),
+        }
+    }
+}

--- a/src/tray/icon.rs
+++ b/src/tray/icon.rs
@@ -1,0 +1,6 @@
+//! Embedded PNG icon assets for the tray.
+//!
+//! Placeholder — real icons (active / idle / error variants) are bundled
+//! via `include_bytes!` from `assets/tray/` when PLAN task #4 lands.
+//! `tray-icon` loads PNGs natively via `Icon::from_rgba`; do not pull the
+//! `image` crate.

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -1,0 +1,30 @@
+//! Menu-bar / system-tray resident app.
+//!
+//! Gated behind the `tray` Cargo feature. Scaffold only — this module
+//! currently provides the directory layout, the `Autostart` and
+//! `OpenInTerminal` platform traits, and the `agend-terminal tray`
+//! subcommand entry point. The event loop, icon loading, and daemon
+//! lifecycle land in PLAN task #4 (see `docs/PLAN-tray-resident.md`).
+
+// Scaffold: most items won't be called until later PLAN tasks land.
+#![allow(dead_code)]
+
+pub mod autostart;
+pub mod config;
+pub mod icon;
+pub mod terminal;
+
+use std::path::Path;
+
+/// Entry point for `agend-terminal tray`.
+///
+/// Scaffold stub: emits a banner and exits 0 so the subcommand is wired
+/// end-to-end. The real event loop (tray icon + menu + daemon lifecycle)
+/// lands with PLAN task #4.
+pub fn run(_home: &Path) -> anyhow::Result<()> {
+    eprintln!(
+        "agend-terminal tray: scaffold only — event loop lands with \
+         PLAN task #4 (docs/PLAN-tray-resident.md)"
+    );
+    Ok(())
+}

--- a/src/tray/terminal/linux.rs
+++ b/src/tray/terminal/linux.rs
@@ -4,7 +4,7 @@
 
 use std::{path::Path, process::Command};
 
-use super::OpenInTerminal;
+use super::{spawn_detached, OpenInTerminal};
 
 pub struct LinuxTerminal {
     terminal: String,
@@ -53,11 +53,10 @@ impl OpenInTerminal for LinuxTerminal {
                 c.arg("-e").args(cmd);
             }
         }
-        let status = c.status()?;
-        if !status.success() {
-            anyhow::bail!("{term} failed with {status}");
-        }
-        Ok(())
+        // Must detach — xterm/kitty/alacritty/many konsole setups stay
+        // foreground, so .status() would freeze the tray event loop for
+        // the lifetime of the spawned terminal window.
+        spawn_detached(c)
     }
 }
 

--- a/src/tray/terminal/linux.rs
+++ b/src/tray/terminal/linux.rs
@@ -1,0 +1,12 @@
+//! Linux: `$TERMINAL` → `x-terminal-emulator` → PATH fallback chain.
+//! PLAN task #3.
+
+use super::OpenInTerminal;
+
+pub struct LinuxTerminal;
+
+impl OpenInTerminal for LinuxTerminal {
+    fn open(&self, _cmd: &[&str]) -> anyhow::Result<()> {
+        anyhow::bail!("tray OpenInTerminal (Linux): not yet implemented — PLAN task #3")
+    }
+}

--- a/src/tray/terminal/linux.rs
+++ b/src/tray/terminal/linux.rs
@@ -1,12 +1,148 @@
-//! Linux: `$TERMINAL` → `x-terminal-emulator` → PATH fallback chain.
-//! PLAN task #3.
+//! Linux: resolve terminal via config → `$TERMINAL` →
+//! `x-terminal-emulator` → PATH-scan; dispatch with the invocation shape
+//! for the chosen emulator.
+
+use std::{path::Path, process::Command};
 
 use super::OpenInTerminal;
 
-pub struct LinuxTerminal;
+pub struct LinuxTerminal {
+    terminal: String,
+}
+
+impl LinuxTerminal {
+    pub fn new(terminal: String) -> Self {
+        Self { terminal }
+    }
+
+    /// Config > `$TERMINAL` > `x-terminal-emulator` > PATH fallback.
+    fn resolve(&self) -> anyhow::Result<String> {
+        if self.terminal != "default" {
+            return Ok(self.terminal.clone());
+        }
+        if let Ok(t) = std::env::var("TERMINAL") {
+            if !t.is_empty() {
+                return Ok(t);
+            }
+        }
+        if which::which("x-terminal-emulator").is_ok() {
+            return Ok("x-terminal-emulator".to_string());
+        }
+        for candidate in FALLBACK_CHAIN {
+            if which::which(candidate).is_ok() {
+                return Ok((*candidate).to_string());
+            }
+        }
+        anyhow::bail!("no terminal emulator found — set `terminal` in $AGEND_HOME/tray.toml")
+    }
+}
 
 impl OpenInTerminal for LinuxTerminal {
-    fn open(&self, _cmd: &[&str]) -> anyhow::Result<()> {
-        anyhow::bail!("tray OpenInTerminal (Linux): not yet implemented — PLAN task #3")
+    fn open(&self, cmd: &[&str]) -> anyhow::Result<()> {
+        if cmd.is_empty() {
+            anyhow::bail!("OpenInTerminal::open: empty cmd");
+        }
+        let term = self.resolve()?;
+        let mut c = Command::new(&term);
+        let bin = basename(&term);
+        match invocation_shape(bin) {
+            InvocationShape::DoubleDash => {
+                c.arg("--").args(cmd);
+            }
+            InvocationShape::DashE => {
+                c.arg("-e").args(cmd);
+            }
+        }
+        let status = c.status()?;
+        if !status.success() {
+            anyhow::bail!("{term} failed with {status}");
+        }
+        Ok(())
+    }
+}
+
+const FALLBACK_CHAIN: &[&str] = &[
+    "gnome-terminal",
+    "konsole",
+    "xfce4-terminal",
+    "kitty",
+    "alacritty",
+    "xterm",
+];
+
+/// How this emulator takes a command to run.
+///
+/// `gnome-terminal` and `xfce4-terminal` use `--` (args after it are the
+/// program); everything else (and the Debian `x-terminal-emulator`
+/// alternative) accepts `-e program args...`.
+#[derive(Debug, PartialEq, Eq)]
+enum InvocationShape {
+    DoubleDash,
+    DashE,
+}
+
+fn invocation_shape(bin: &str) -> InvocationShape {
+    match bin {
+        "gnome-terminal" | "xfce4-terminal" => InvocationShape::DoubleDash,
+        _ => InvocationShape::DashE,
+    }
+}
+
+/// Like `Path::file_name().to_str()` but without `.unwrap()` sprinkled
+/// anywhere (`unwrap_used` is a workspace deny).
+fn basename(term: &str) -> &str {
+    Path::new(term)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(term)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gnome_and_xfce_use_double_dash() {
+        assert_eq!(
+            invocation_shape("gnome-terminal"),
+            InvocationShape::DoubleDash
+        );
+        assert_eq!(
+            invocation_shape("xfce4-terminal"),
+            InvocationShape::DoubleDash
+        );
+    }
+
+    #[test]
+    fn others_use_dash_e_including_xterm_unknown() {
+        for bin in [
+            "konsole",
+            "xterm",
+            "kitty",
+            "alacritty",
+            "x-terminal-emulator",
+            "unknown-term",
+        ] {
+            assert_eq!(invocation_shape(bin), InvocationShape::DashE, "bin = {bin}");
+        }
+    }
+
+    #[test]
+    fn basename_strips_directory() {
+        assert_eq!(basename("/usr/bin/gnome-terminal"), "gnome-terminal");
+        assert_eq!(basename("konsole"), "konsole");
+    }
+
+    #[test]
+    fn config_terminal_wins_without_consulting_env() {
+        // `resolve()` returns early when config is non-"default", so it
+        // never reads `$TERMINAL` or hits PATH. Test without mutating
+        // process env (races with other parallel tests — see commit
+        // 5c9ca65 for the lesson the project already paid for).
+        let t = LinuxTerminal::new("my-custom-term".to_string());
+        let got = t
+            .resolve()
+            .expect("resolve should return config value as-is");
+        assert_eq!(got, "my-custom-term");
     }
 }

--- a/src/tray/terminal/macos.rs
+++ b/src/tray/terminal/macos.rs
@@ -3,7 +3,7 @@
 
 use std::process::Command;
 
-use super::OpenInTerminal;
+use super::{spawn_detached, OpenInTerminal};
 
 pub struct MacTerminal {
     terminal: String,
@@ -32,32 +32,24 @@ impl OpenInTerminal for MacTerminal {
 /// `open -na <app> --args <cmd...>` — Terminal.app interprets the trailing
 /// args as the command to run in the new window.
 fn run_open(app: &str, cmd: &[&str]) -> anyhow::Result<()> {
-    let status = Command::new("open")
-        .arg("-na")
-        .arg(app)
-        .arg("--args")
-        .args(cmd)
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("open -na {app} failed with {status}");
-    }
-    Ok(())
+    let mut c = Command::new("open");
+    c.arg("-na").arg(app).arg("--args").args(cmd);
+    // `open` is already fire-and-forget — routing through
+    // `spawn_detached` keeps behaviour uniform with the Linux path so
+    // this trait never blocks the tray event loop (see mod.rs).
+    spawn_detached(c)
 }
 
 /// `open -na Ghostty --args -e '<shell-quoted cmd>'` — Ghostty treats `-e`
 /// as a shell command string.
 fn run_open_dash_e(app: &str, cmd: &[&str]) -> anyhow::Result<()> {
-    let status = Command::new("open")
-        .arg("-na")
+    let mut c = Command::new("open");
+    c.arg("-na")
         .arg(app)
         .arg("--args")
         .arg("-e")
-        .arg(shell_quote(cmd))
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("open -na {app} -e failed with {status}");
-    }
-    Ok(())
+        .arg(shell_quote(cmd));
+    spawn_detached(c)
 }
 
 /// iTerm2 ignores `open --args` on an already-running instance, so we
@@ -70,11 +62,9 @@ fn run_iterm(cmd: &[&str]) -> anyhow::Result<()> {
     create window with default profile command "{cmd_str}"
 end tell"#
     );
-    let status = Command::new("osascript").arg("-e").arg(&script).status()?;
-    if !status.success() {
-        anyhow::bail!("osascript (iTerm2) failed with {status}");
-    }
-    Ok(())
+    let mut c = Command::new("osascript");
+    c.arg("-e").arg(&script);
+    spawn_detached(c)
 }
 
 /// Minimal POSIX-style shell quoting. Used for terminals that take a

--- a/src/tray/terminal/macos.rs
+++ b/src/tray/terminal/macos.rs
@@ -1,11 +1,130 @@
-//! macOS: `open -na <Terminal|iTerm|Ghostty> --args ...`. PLAN task #3.
+//! macOS: dispatch through `open(1)` for .app bundles, osascript for
+//! iTerm2 (which ignores `--args` because it reuses sessions).
+
+use std::process::Command;
 
 use super::OpenInTerminal;
 
-pub struct MacTerminal;
+pub struct MacTerminal {
+    terminal: String,
+}
+
+impl MacTerminal {
+    pub fn new(terminal: String) -> Self {
+        Self { terminal }
+    }
+}
 
 impl OpenInTerminal for MacTerminal {
-    fn open(&self, _cmd: &[&str]) -> anyhow::Result<()> {
-        anyhow::bail!("tray OpenInTerminal (macOS): not yet implemented — PLAN task #3")
+    fn open(&self, cmd: &[&str]) -> anyhow::Result<()> {
+        if cmd.is_empty() {
+            anyhow::bail!("OpenInTerminal::open: empty cmd");
+        }
+        match self.terminal.as_str() {
+            "default" | "Terminal" => run_open("Terminal", cmd),
+            "iTerm" => run_iterm(cmd),
+            "Ghostty" => run_open_dash_e("Ghostty", cmd),
+            other => run_open(other, cmd),
+        }
+    }
+}
+
+/// `open -na <app> --args <cmd...>` — Terminal.app interprets the trailing
+/// args as the command to run in the new window.
+fn run_open(app: &str, cmd: &[&str]) -> anyhow::Result<()> {
+    let status = Command::new("open")
+        .arg("-na")
+        .arg(app)
+        .arg("--args")
+        .args(cmd)
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("open -na {app} failed with {status}");
+    }
+    Ok(())
+}
+
+/// `open -na Ghostty --args -e '<shell-quoted cmd>'` — Ghostty treats `-e`
+/// as a shell command string.
+fn run_open_dash_e(app: &str, cmd: &[&str]) -> anyhow::Result<()> {
+    let status = Command::new("open")
+        .arg("-na")
+        .arg(app)
+        .arg("--args")
+        .arg("-e")
+        .arg(shell_quote(cmd))
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("open -na {app} -e failed with {status}");
+    }
+    Ok(())
+}
+
+/// iTerm2 ignores `open --args` on an already-running instance, so we
+/// drive it via AppleScript. `create window with default profile command
+/// "..."` opens a new window running the given shell command.
+fn run_iterm(cmd: &[&str]) -> anyhow::Result<()> {
+    let cmd_str = shell_quote(cmd).replace('"', "\\\"");
+    let script = format!(
+        r#"tell application "iTerm2"
+    create window with default profile command "{cmd_str}"
+end tell"#
+    );
+    let status = Command::new("osascript").arg("-e").arg(&script).status()?;
+    if !status.success() {
+        anyhow::bail!("osascript (iTerm2) failed with {status}");
+    }
+    Ok(())
+}
+
+/// Minimal POSIX-style shell quoting. Used for terminals that take a
+/// single command string (iTerm2, Ghostty). Characters that need no
+/// quoting are passed through; everything else is single-quoted with
+/// `'\''` escaping.
+pub(super) fn shell_quote(cmd: &[&str]) -> String {
+    cmd.iter()
+        .map(|arg| quote_one(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_one(arg: &str) -> String {
+    if !arg.is_empty()
+        && arg.chars().all(|c| {
+            c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '/' | '.' | '=' | ',' | ':')
+        })
+    {
+        arg.to_string()
+    } else {
+        format!("'{}'", arg.replace('\'', r"'\''"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_passes_safe_args_through() {
+        assert_eq!(
+            shell_quote(&["agend-terminal", "app"]),
+            "agend-terminal app"
+        );
+    }
+
+    #[test]
+    fn shell_quote_wraps_args_with_spaces_or_specials() {
+        assert_eq!(shell_quote(&["echo", "hi there"]), "echo 'hi there'");
+        assert_eq!(shell_quote(&["run", "$VAR"]), "run '$VAR'");
+    }
+
+    #[test]
+    fn shell_quote_escapes_embedded_single_quotes() {
+        assert_eq!(shell_quote(&["say", "it's fine"]), r"say 'it'\''s fine'");
+    }
+
+    #[test]
+    fn empty_string_is_quoted() {
+        assert_eq!(shell_quote(&[""]), "''");
     }
 }

--- a/src/tray/terminal/macos.rs
+++ b/src/tray/terminal/macos.rs
@@ -1,0 +1,11 @@
+//! macOS: `open -na <Terminal|iTerm|Ghostty> --args ...`. PLAN task #3.
+
+use super::OpenInTerminal;
+
+pub struct MacTerminal;
+
+impl OpenInTerminal for MacTerminal {
+    fn open(&self, _cmd: &[&str]) -> anyhow::Result<()> {
+        anyhow::bail!("tray OpenInTerminal (macOS): not yet implemented — PLAN task #3")
+    }
+}

--- a/src/tray/terminal/mod.rs
+++ b/src/tray/terminal/mod.rs
@@ -1,0 +1,33 @@
+//! "Open App" terminal dispatcher.
+//!
+//! Given a command (`["agend-terminal", "app"]`), open it in the user's
+//! configured terminal emulator. Resolution rules live in
+//! `docs/PLAN-tray-resident.md` §"OpenInTerminal per platform".
+//! Implementations land with PLAN task #3.
+
+pub trait OpenInTerminal {
+    /// Launch `cmd` in a new terminal window/tab. `cmd[0]` is the
+    /// executable, rest are args.
+    fn open(&self, cmd: &[&str]) -> anyhow::Result<()>;
+}
+
+// `Platform` is re-exported but not yet consumed — the tray event loop
+// (PLAN task #4) is what calls `Platform::open()`. Suppress the
+// scaffold-window warning rather than gating the re-export itself.
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+#[allow(unused_imports)]
+pub use macos::MacTerminal as Platform;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+#[allow(unused_imports)]
+pub use linux::LinuxTerminal as Platform;
+
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+#[allow(unused_imports)]
+pub use windows::WindowsTerminal as Platform;

--- a/src/tray/terminal/mod.rs
+++ b/src/tray/terminal/mod.rs
@@ -3,7 +3,9 @@
 //! Given a command (`["agend-terminal", "app"]`), open it in the user's
 //! configured terminal emulator. Resolution rules live in
 //! `docs/PLAN-tray-resident.md` §"OpenInTerminal per platform".
-//! Implementations land with PLAN task #3.
+//!
+//! Construct via `Platform::new(terminal)` where `terminal` is the
+//! `terminal` field from `tray.toml` (`"default"` if unset).
 
 pub trait OpenInTerminal {
     /// Launch `cmd` in a new terminal window/tab. `cmd[0]` is the

--- a/src/tray/terminal/mod.rs
+++ b/src/tray/terminal/mod.rs
@@ -13,6 +13,33 @@ pub trait OpenInTerminal {
     fn open(&self, cmd: &[&str]) -> anyhow::Result<()>;
 }
 
+/// Spawn a launcher process and return immediately, detaching stdio.
+///
+/// Every platform impl funnels through this. Critical for Linux, where
+/// `xterm` / `kitty` / `alacritty` / many `konsole` setups stay in the
+/// foreground — calling `Command::status()` there would block the tray
+/// event loop for the entire lifetime of the user's terminal window.
+/// Windows bare-exe dispatch has the same shape and the same fix;
+/// macOS's `open(1)` and `osascript` return quickly regardless, but
+/// routing them through the same helper avoids future drift.
+///
+/// Post-fork failures (bad iTerm script, unknown `--args` to `open`,
+/// etc.) are deliberately not surfaced — there is no error UI on the
+/// tray yet. Pre-fork failures (binary not on PATH) still propagate
+/// because `spawn()?` catches them at the execve boundary.
+///
+/// The returned `Child` is dropped, which on Unix leaves a zombie
+/// until the tray process exits (or task #4 installs a SIGCHLD
+/// reaper). For a menu click cadence that's a non-issue.
+pub(super) fn spawn_detached(mut cmd: std::process::Command) -> anyhow::Result<()> {
+    use std::process::Stdio;
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    Ok(())
+}
+
 // `Platform` is re-exported but not yet consumed — the tray event loop
 // (PLAN task #4) is what calls `Platform::open()`. Suppress the
 // scaffold-window warning rather than gating the re-export itself.

--- a/src/tray/terminal/windows.rs
+++ b/src/tray/terminal/windows.rs
@@ -8,7 +8,7 @@
 
 use std::process::Command;
 
-use super::OpenInTerminal;
+use super::{spawn_detached, OpenInTerminal};
 
 pub struct WindowsTerminal {
     terminal: String,
@@ -34,11 +34,9 @@ impl OpenInTerminal for WindowsTerminal {
 }
 
 fn run_wt(cmd: &[&str]) -> anyhow::Result<()> {
-    let status = Command::new("wt.exe").args(cmd).status()?;
-    if !status.success() {
-        anyhow::bail!("wt.exe failed with {status}");
-    }
-    Ok(())
+    let mut c = Command::new("wt.exe");
+    c.args(cmd);
+    spawn_detached(c)
 }
 
 fn run_conhost(cmd: &[&str]) -> anyhow::Result<()> {
@@ -46,16 +44,9 @@ fn run_conhost(cmd: &[&str]) -> anyhow::Result<()> {
     // conhost window. The quoted "title" is consumed by `start` as the
     // new window title — skipping it would make start treat prog as a
     // title instead. (Documented gotcha in cmd.exe.)
-    let status = Command::new("cmd")
-        .arg("/c")
-        .arg("start")
-        .arg("agend-terminal")
-        .args(cmd)
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("cmd /c start failed with {status}");
-    }
-    Ok(())
+    let mut c = Command::new("cmd");
+    c.arg("/c").arg("start").arg("agend-terminal").args(cmd);
+    spawn_detached(c)
 }
 
 /// PLAN contract: "other | treated as executable, invoked with `app` as
@@ -64,10 +55,12 @@ fn run_conhost(cmd: &[&str]) -> anyhow::Result<()> {
 /// name) as its argv. Power users who configure `alacritty.exe` etc.
 /// will probably want `-e` style dispatch — revisit in task #4 after
 /// real usage signal.
+///
+/// Must detach — if `other` is a real foreground terminal emulator
+/// (alacritty.exe, wezterm-gui.exe), `.status()` would block the tray
+/// for the window's full lifetime (same class as the Linux bug).
 fn run_other(exe: &str, cmd: &[&str]) -> anyhow::Result<()> {
-    let status = Command::new(exe).args(&cmd[1..]).status()?;
-    if !status.success() {
-        anyhow::bail!("{exe} failed with {status}");
-    }
-    Ok(())
+    let mut c = Command::new(exe);
+    c.args(&cmd[1..]);
+    spawn_detached(c)
 }

--- a/src/tray/terminal/windows.rs
+++ b/src/tray/terminal/windows.rs
@@ -1,0 +1,15 @@
+//! Windows: `wt.exe` with `conhost` fallback. PLAN task #3.
+//!
+//! The exact `wt.exe` flag form differs between cold-start and
+//! already-running sessions — prototype on Windows before pinning the
+//! command string (PLAN gotcha).
+
+use super::OpenInTerminal;
+
+pub struct WindowsTerminal;
+
+impl OpenInTerminal for WindowsTerminal {
+    fn open(&self, _cmd: &[&str]) -> anyhow::Result<()> {
+        anyhow::bail!("tray OpenInTerminal (Windows): not yet implemented — PLAN task #3")
+    }
+}

--- a/src/tray/terminal/windows.rs
+++ b/src/tray/terminal/windows.rs
@@ -1,15 +1,73 @@
-//! Windows: `wt.exe` with `conhost` fallback. PLAN task #3.
+//! Windows: `wt.exe` for the default/`wt` case, `cmd /c start` for
+//! `conhost`, bare-executable otherwise.
 //!
-//! The exact `wt.exe` flag form differs between cold-start and
-//! already-running sessions — prototype on Windows before pinning the
-//! command string (PLAN gotcha).
+//! PLAN flags the cold-start vs running-instance `wt.exe` flag ambiguity
+//! as a prototype-on-Windows task — the shape below matches the
+//! cold-start form (`wt.exe <cmd> <args...>`). If an already-running wt
+//! eats these differently we'll adjust in task #4 smoke testing.
+
+use std::process::Command;
 
 use super::OpenInTerminal;
 
-pub struct WindowsTerminal;
+pub struct WindowsTerminal {
+    terminal: String,
+}
+
+impl WindowsTerminal {
+    pub fn new(terminal: String) -> Self {
+        Self { terminal }
+    }
+}
 
 impl OpenInTerminal for WindowsTerminal {
-    fn open(&self, _cmd: &[&str]) -> anyhow::Result<()> {
-        anyhow::bail!("tray OpenInTerminal (Windows): not yet implemented — PLAN task #3")
+    fn open(&self, cmd: &[&str]) -> anyhow::Result<()> {
+        if cmd.is_empty() {
+            anyhow::bail!("OpenInTerminal::open: empty cmd");
+        }
+        match self.terminal.as_str() {
+            "default" | "wt" => run_wt(cmd),
+            "conhost" => run_conhost(cmd),
+            other => run_other(other, cmd),
+        }
     }
+}
+
+fn run_wt(cmd: &[&str]) -> anyhow::Result<()> {
+    let status = Command::new("wt.exe").args(cmd).status()?;
+    if !status.success() {
+        anyhow::bail!("wt.exe failed with {status}");
+    }
+    Ok(())
+}
+
+fn run_conhost(cmd: &[&str]) -> anyhow::Result<()> {
+    // `cmd /c start "<title>" prog [args...]` detaches prog in a new
+    // conhost window. The quoted "title" is consumed by `start` as the
+    // new window title — skipping it would make start treat prog as a
+    // title instead. (Documented gotcha in cmd.exe.)
+    let status = Command::new("cmd")
+        .arg("/c")
+        .arg("start")
+        .arg("agend-terminal")
+        .args(cmd)
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("cmd /c start failed with {status}");
+    }
+    Ok(())
+}
+
+/// PLAN contract: "other | treated as executable, invoked with `app` as
+/// arg". The caller hands us `["agend-terminal", "app"]`; we invoke the
+/// configured emulator with `cmd[1..]` (everything after the binary
+/// name) as its argv. Power users who configure `alacritty.exe` etc.
+/// will probably want `-e` style dispatch — revisit in task #4 after
+/// real usage signal.
+fn run_other(exe: &str, cmd: &[&str]) -> anyhow::Result<()> {
+    let status = Command::new(exe).args(&cmd[1..]).status()?;
+    if !status.success() {
+        anyhow::bail!("{exe} failed with {status}");
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary

First three tasks of `docs/PLAN-tray-resident.md`, plus the CI gate the
PLAN's acceptance criteria require.

- **#1 Scaffold** — `src/tray/` module layout, empty `tray` Cargo feature, `agend-terminal tray` subcommand stub (hidden from `--help` unless `--features tray`). No new deps; `tray-icon` + `tao` land with task #4 when the event loop actually needs them.
- **#2 Autostart** — three `Autostart` impls: macOS LaunchAgent plist + `launchctl bootstrap gui/<uid>`, Linux XDG `.desktop`, Windows `HKCU\...\Run` via `windows-sys`. All three resolve the binary with `current_exe()?.canonicalize()?` so `cargo install --force` upgrades are picked up on next login. Adds `Win32_System_Registry` to the existing `windows-sys` features (PLAN gotcha).
- **#3 OpenInTerminal** — three platform dispatchers. macOS: `open -na` for Terminal/Ghostty, osascript for iTerm2, minimal POSIX shell-quoter. Linux: config → `$TERMINAL` → `x-terminal-emulator` → PATH fallback with a `DoubleDash` vs `DashE` invocation shape table. Windows: `wt.exe` for default/wt, `cmd /c start "title"` for conhost, bare dispatch otherwise.
- **CI gate** — `cargo clippy --all-targets --features tray -- -D warnings` and `cargo test --features tray` now run on all three OS matrix entries. Without this step, the XDG `.desktop` writer (Linux-only cfg) and the `windows-sys` registry calls (Windows-only cfg) would never have been compiled in CI. Release `cargo build --release` stays default-only until task #4 pulls in `tray-icon`/`tao`.

PLAN tasks #4 (event loop), #5 (Homebrew tap), #6 (Linux AppImage) are out of scope for this PR.

## Test plan

- [x] Local: `cargo clippy --all-targets -- -D warnings` green (default)
- [x] Local: `cargo clippy --all-targets --features tray -- -D warnings` green
- [x] Local: `cargo test --features tray tray::` → 7 passed on macOS (3 plist + 4 shell_quote)
- [x] Local: `agend-terminal tray` prints scaffold banner and exits 0 (with feature)
- [x] Local: `agend-terminal --help` hides the `tray` subcommand when the feature is off
- [ ] CI: three-OS matrix check passes (Linux `.desktop` + Linux `invocation_shape` tests, Windows registry + wt dispatch compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)