### PR TITLE
feat(tray): event loop + daemon bootstrap (PLAN task #4, partial)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
 
+      # tray-icon / tao on Linux link against GTK3 + the ayatana app-
+      # indicator — these come from `libgtk-3-dev` (provides glib-2.0.pc,
+      # gobject-2.0.pc, etc.) and `libayatana-appindicator3-dev`. The
+      # runner image does NOT ship them by default, so the `Clippy (tray
+      # feature)` step fails in gobject-sys' build script on a cache
+      # miss. Pin to Linux only — macOS + Windows use native APIs.
+      - name: Install Linux tray deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
+
       - name: Format check
         run: cargo fmt --check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,24 +21,36 @@ jobs:
           # macOS — both targets build on macos-latest (arm64 host).
           # x86_64 is cross-compiled; deps are pure Rust / FFI-only so no
           # C toolchain needed. Avoids macos-13 Intel runner queue delays.
+          # `tray` feature ships by default on macOS — `tray-icon` + `tao`
+          # use Cocoa, no system-lib runtime surprises.
           - target: x86_64-apple-darwin
             os: macos-latest
             archive: tar.gz
+            features: tray
           - target: aarch64-apple-darwin
             os: macos-latest
             archive: tar.gz
+            features: tray
           # Linux — use native arm64 runner to avoid cross-compile pain with
           # native deps (arboard/x11). Free for public repos since 2025-01.
+          # `tray` is NOT on the release tarball: tray-icon's Linux backend
+          # dynamically links against libgtk-3 + libayatana-appindicator3,
+          # so a GTK-on feature on a headless box would fail to load. Linux
+          # users who want the tray use `cargo install agend-terminal
+          # --features tray` (documented in the README).
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive: tar.gz
+            features: ""
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             archive: tar.gz
-          # Windows x64.
+            features: ""
+          # Windows x64 — native shell APIs, `tray` on by default.
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive: zip
+            features: tray
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -46,10 +58,16 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
+          key: ${{ matrix.target }}-${{ matrix.features }}
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.features }}" ]; then
+            cargo build --release --target ${{ matrix.target }} --features ${{ matrix.features }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
 
       - name: Package (Unix)
         if: matrix.archive == 'tar.gz'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,11 +36,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tao",
  "teloxide",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "tray-icon",
  "unicode-width 0.2.0",
  "which",
  "windows-sys 0.59.0",
@@ -181,7 +183,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -190,6 +192,29 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "atk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
+dependencies = [
+ "atk-sys",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -264,6 +289,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cairo-rs"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+dependencies = [
+ "bitflags 2.11.0",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +336,22 @@ checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -317,7 +383,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -395,6 +461,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,10 +510,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -633,6 +743,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,10 +820,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "dlopen2_derive",
+ "libc",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen2_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dptree"
@@ -810,6 +960,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +1007,33 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -956,13 +1143,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gdkwayland-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gdkx11-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "libc",
+ "system-deps",
+ "x11",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1003,6 +1275,148 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gio"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
+name = "glib"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+dependencies = [
+ "bitflags 2.11.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 2.0.2",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a"
+dependencies = [
+ "atk",
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gio",
+ "glib",
+ "gtk-sys",
+ "gtk3-macros",
+ "libc",
+ "pango",
+ "pkg-config",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk3-macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1256,7 +1670,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1393,7 +1807,7 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "png",
+ "png 0.18.1",
  "tiff",
 ]
 
@@ -1497,6 +1911,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1964,17 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags 2.11.0",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1521,10 +1990,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libappindicator"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
+dependencies = [
+ "glib",
+ "gtk",
+ "gtk-sys",
+ "libappindicator-sys",
+ "log",
+]
+
+[[package]]
+name = "libappindicator-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
+dependencies = [
+ "gtk-sys",
+ "libloading",
+ "once_cell",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libredox"
@@ -1533,6 +2045,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libxdo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
+dependencies = [
+ "libxdo-sys",
+]
+
+[[package]]
+name = "libxdo-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
+dependencies = [
+ "libc",
+ "x11",
 ]
 
 [[package]]
@@ -1599,6 +2130,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +2196,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "muda"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+dependencies = [
+ "crossbeam-channel",
+ "dpi",
+ "gtk",
+ "keyboard-types",
+ "libxdo",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "once_cell",
+ "png 0.17.16",
+ "thiserror 2.0.18",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +2289,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 2.0.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,7 +2336,29 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "objc2",
+ "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -1758,6 +2387,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +2431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1783,6 +2445,49 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1804,6 +2509,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "pango"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,7 +2553,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1891,6 +2621,25 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1973,6 +2722,26 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -2072,7 +2841,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2145,6 +2914,12 @@ dependencies = [
  "unicode-truncate",
  "unicode-width 0.2.0",
 ]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rc-box"
@@ -2429,6 +3204,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2785,7 +3569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2800,6 +3584,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +3607,63 @@ name = "takecell"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
+
+[[package]]
+name = "tao"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "core-foundation 0.10.1",
+ "core-graphics",
+ "crossbeam-channel",
+ "dbus",
+ "dispatch2",
+ "dlopen2",
+ "dpi",
+ "gdkwayland-sys",
+ "gdkx11-sys",
+ "gtk",
+ "jni",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-sys",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "raw-window-handle",
+ "tao-macros",
+ "unicode-segmentation",
+ "url",
+ "windows",
+ "windows-core 0.61.2",
+ "windows-version",
+ "x11-dl",
+]
+
+[[package]]
+name = "tao-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "teloxide"
@@ -3073,44 +3927,48 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
- "winnow 0.7.15",
+ "winnow 0.5.40",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3217,6 +4075,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tray-icon"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e1484378c343c5a9b291188fa58917c7184967683f8cfe4a05461986970553"
+dependencies = [
+ "crossbeam-channel",
+ "dirs",
+ "libappindicator",
+ "muda",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "once_cell",
+ "png 0.18.1",
+ "thiserror 2.0.18",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3327,6 +4206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,6 +4249,16 @@ dependencies = [
  "log",
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3571,10 +4466,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
 
 [[package]]
 name = "windows-core"
@@ -3584,9 +4523,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3613,9 +4563,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -3623,7 +4598,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3632,7 +4616,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3664,11 +4657,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3695,12 +4712,53 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3715,6 +4773,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,6 +4795,18 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3739,10 +4821,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3757,6 +4857,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3767,6 +4879,18 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3781,6 +4905,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3793,19 +4929,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.26"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 dependencies = [
  "memchr",
 ]
@@ -3938,6 +5080,27 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "x11rb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ unwrap_used = "deny"
 # `--features tray` is passed (release binaries ship with it).
 [features]
 default = []
-tray = ["dep:tray-icon", "dep:tao"]
+tray = ["dep:tray-icon", "dep:tao", "dep:toml"]
 
 [profile.release]
 strip = true
@@ -81,9 +81,12 @@ which = "6"
 getrandom = "0.2"
 iana-time-zone = "0.1.65"
 # Menu-bar / system-tray (feature = "tray"). tray-icon loads PNG via
-# Icon::from_rgba natively — do NOT pull the `image` crate.
+# Icon::from_rgba natively — do NOT pull the `image` crate. `toml` is
+# for `$AGEND_HOME/tray.toml`; dev-dependencies already list it, so the
+# runtime entry here only adds it to release graphs when `tray` is on.
 tray-icon = { version = "0.22", optional = true }
 tao = { version = "0.35", optional = true }
+toml = { version = "0.8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ include = [
 unwrap_used = "deny"
 
 # Menu-bar / system-tray resident app (see docs/PLAN-tray-resident.md).
-# Scaffold only — `tray-icon` + `tao` land with PLAN task #4 (event loop).
-# Default build stays lean: no new deps unless `--features tray` is passed.
+# Default build stays lean: `tray-icon` + `tao` only pull in when
+# `--features tray` is passed (release binaries ship with it).
 [features]
 default = []
-tray = []
+tray = ["dep:tray-icon", "dep:tao"]
 
 [profile.release]
 strip = true
@@ -80,6 +80,10 @@ which = "6"
 # Crypto-grade random for API-connection cookie (P1-10)
 getrandom = "0.2"
 iana-time-zone = "0.1.65"
+# Menu-bar / system-tray (feature = "tray"). tray-icon loads PNG via
+# Icon::from_rgba natively — do NOT pull the `image` crate.
+tray-icon = { version = "0.22", optional = true }
+tao = { version = "0.35", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/tray/config.rs
+++ b/src/tray/config.rs
@@ -4,6 +4,8 @@
 //! warn-and-default (the tray must never crash on parse). See
 //! `docs/PLAN-tray-resident.md` §"tray.toml (MVP schema)".
 
+use std::path::Path;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,6 +25,30 @@ impl Default for TrayConfig {
     fn default() -> Self {
         Self {
             terminal: default_terminal(),
+        }
+    }
+}
+
+/// Read `$AGEND_HOME/tray.toml`. PLAN locks this to warn-and-default
+/// on every failure mode — missing file (normal, user never edited),
+/// unreadable file (permissions), or malformed TOML (user typo). The
+/// tray never crashes on parse; a broken config just behaves like
+/// `default()`.
+pub fn load(home: &Path) -> TrayConfig {
+    let path = home.join("tray.toml");
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return TrayConfig::default(),
+        Err(e) => {
+            eprintln!("tray: failed to read {}: {e}", path.display());
+            return TrayConfig::default();
+        }
+    };
+    match toml::from_str(&raw) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("tray: malformed {}: {e}", path.display());
+            TrayConfig::default()
         }
     }
 }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -12,8 +12,9 @@ pub mod config;
 pub mod icon;
 pub mod terminal;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use serde_json::json;
 use tao::event::{Event, StartCause};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
 #[cfg(target_os = "macos")]
@@ -22,6 +23,8 @@ use tray_icon::{
     menu::{Menu, MenuEvent, MenuItem},
     Icon, TrayIcon, TrayIconBuilder,
 };
+
+use crate::{api, bootstrap::daemon_spawn};
 
 /// Events forwarded from tray-icon's global callbacks into the tao
 /// event loop so the loop wakes on every menu click.
@@ -45,18 +48,44 @@ fn placeholder_icon() -> Icon {
     Icon::from_rgba(rgba, W, H).expect("32x32 RGBA buffer is always valid")
 }
 
+/// Probe the daemon via `api::call(LIST)`; if it's not up, spawn a
+/// detached one (blocks up to 5s for readiness). Tray stays usable
+/// even if spawn fails — the user can still Quit.
+fn bootstrap_daemon(home: &Path) {
+    if api::call(home, &json!({"method": api::method::LIST})).is_ok() {
+        // Adopted running daemon.
+        return;
+    }
+    if let Err(e) = daemon_spawn::spawn_detached(home, None) {
+        // Non-fatal: tray still starts so the user can Quit / inspect.
+        // Without a status menu yet (lands in follow-on), surface the
+        // failure on stderr — `agend-terminal tray` is usually run in a
+        // terminal during the MVP phase.
+        eprintln!("tray: daemon spawn failed: {e}");
+    }
+}
+
+/// Tell the daemon to shut down. Best-effort — if it's already gone,
+/// the RPC fails silently. Called from the Quit menu handler.
+fn shutdown_daemon(home: &Path) {
+    let _ = api::call(home, &json!({"method": api::method::SHUTDOWN}));
+}
+
 /// Entry point for `agend-terminal tray`.
 ///
-/// Minimal spike — menu has only "Quit". Daemon lifecycle, status
-/// polling, Open App, and Launch-at-login toggle land in follow-on
-/// commits on this branch.
+/// Probes/spawns the daemon, brings up the tray icon, and runs the
+/// event loop. Quit sends SHUTDOWN before exiting. Status polling,
+/// Open App, and Launch-at-login toggle land in follow-on commits.
 ///
 /// The `unused_*` allows cover the `tray_icon` ownership slot inside
 /// the event loop: dropping a `TrayIcon` removes the icon from the
 /// system bar, so the slot must live for the lifetime of the loop —
 /// but nothing ever reads it back.
 #[allow(unused_assignments, unused_variables)]
-pub fn run(_home: &Path) -> anyhow::Result<()> {
+pub fn run(home: &Path) -> anyhow::Result<()> {
+    bootstrap_daemon(home);
+    let home: PathBuf = home.to_path_buf();
+
     #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
     #[cfg(target_os = "macos")]
@@ -104,6 +133,7 @@ pub fn run(_home: &Path) -> anyhow::Result<()> {
             }
             Event::UserEvent(UserEvent::Menu(ev)) => {
                 if ev.id == quit_id {
+                    shutdown_daemon(&home);
                     *control_flow = ControlFlow::Exit;
                 }
             }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -131,11 +131,9 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
                     }
                 }
             }
-            Event::UserEvent(UserEvent::Menu(ev)) => {
-                if ev.id == quit_id {
-                    shutdown_daemon(&home);
-                    *control_flow = ControlFlow::Exit;
-                }
+            Event::UserEvent(UserEvent::Menu(ev)) if ev.id == quit_id => {
+                shutdown_daemon(&home);
+                *control_flow = ControlFlow::Exit;
             }
             _ => {}
         }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -22,12 +22,13 @@ use tao::event_loop::{ControlFlow, EventLoopBuilder};
 #[cfg(target_os = "macos")]
 use tao::platform::macos::{ActivationPolicy, EventLoopExtMacOS};
 use tray_icon::{
-    menu::{Menu, MenuEvent, MenuItem},
+    menu::{CheckMenuItem, Menu, MenuEvent, MenuItem},
     Icon, TrayIcon, TrayIconBuilder,
 };
 
 use crate::{api, bootstrap::daemon_spawn};
 
+use self::autostart::{Autostart, Platform as AutostartPlatform};
 use self::terminal::{OpenInTerminal, Platform as TerminalPlatform};
 
 /// Status polling cadence. PLAN §"Runtime flow" pins 2s; slower feels
@@ -103,9 +104,10 @@ fn shutdown_daemon(home: &Path) {
 
 /// Entry point for `agend-terminal tray`.
 ///
-/// Probes/spawns the daemon, brings up the tray icon, and runs the
-/// event loop. Quit sends SHUTDOWN before exiting. Status polling,
-/// Open App, and Launch-at-login toggle land in follow-on commits.
+/// Probes/spawns the daemon, brings up the tray icon with status
+/// label / Open App / Launch-at-login / Quit, and runs the event
+/// loop. Quit sends SHUTDOWN before exiting. Status is refreshed
+/// every `POLL_INTERVAL` from a worker thread.
 ///
 /// The `unused_*` allows cover the `tray_icon` ownership slot inside
 /// the event loop: dropping a `TrayIcon` removes the icon from the
@@ -136,17 +138,29 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
     let cfg = config::load(&home);
     let opener = TerminalPlatform::new(cfg.terminal);
 
-    // Menu: disabled status label, separator, Open App, Quit.
-    // Launch-at-login toggle lands in the follow-on commit.
+    // Autostart platform instance + current on-disk state. Probe
+    // failures (e.g. launchctl not in PATH on a minimal runner) are
+    // non-fatal: treat as disabled and keep the tray usable.
+    let autostart = AutostartPlatform::new(home.clone());
+    let autostart_on = autostart.is_enabled().unwrap_or_else(|e| {
+        eprintln!("tray: failed to probe autostart state: {e}");
+        false
+    });
+
+    // Menu: disabled status label, separator, Open App, Launch-at-login
+    // toggle, Quit.
     let menu = Menu::new();
     let status_item = MenuItem::new("starting…", false, None);
     let open_app_item = MenuItem::new("Open App", true, None);
+    let autostart_item = CheckMenuItem::new("Launch at login", true, autostart_on, None);
     let quit_item = MenuItem::new("Quit agend-terminal", true, None);
     menu.append(&status_item)?;
     menu.append(&tray_icon::menu::PredefinedMenuItem::separator())?;
     menu.append(&open_app_item)?;
+    menu.append(&autostart_item)?;
     menu.append(&quit_item)?;
     let open_app_id = open_app_item.id().clone();
+    let autostart_id = autostart_item.id().clone();
     let quit_id = quit_item.id().clone();
 
     // Status poller: every POLL_INTERVAL, probe the daemon and push a
@@ -202,6 +216,23 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
                     // keep the tray alive so the user can retry or Quit.
                     if let Err(e) = opener.open(&["agend-terminal", "app"]) {
                         eprintln!("tray: open app failed: {e}");
+                    }
+                } else if ev.id == autostart_id {
+                    // CheckMenuItem flips its own check state before firing
+                    // the event; read that to learn the user's intent, then
+                    // persist via the Autostart trait. On failure, revert the
+                    // visual to the real on-disk state so the menu never
+                    // shows a lie.
+                    let desired = autostart_item.is_checked();
+                    let result = if desired {
+                        autostart.enable()
+                    } else {
+                        autostart.disable()
+                    };
+                    if let Err(e) = result {
+                        eprintln!("tray: autostart toggle failed: {e}");
+                        let actual = autostart.is_enabled().unwrap_or(!desired);
+                        autostart_item.set_checked(actual);
                     }
                 }
             }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -40,43 +40,81 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 #[derive(Debug)]
 enum UserEvent {
     Menu(MenuEvent),
-    /// Pre-formatted label text from the worker thread. Drained on the
+    /// Distilled daemon status from the worker thread. Drained on the
     /// main thread (tray-icon / muda require main-thread mutation on
-    /// macOS).
-    Status(String),
+    /// macOS); the handler derives label text + icon color from the
+    /// same variant so they can never desync.
+    Status(StatusKind),
 }
 
-/// Render a LIST response into the menu label. First line is what the
-/// user scans: how many agents the daemon has, or "daemon offline" if
-/// the probe errors.
-fn format_status(resp: &Value) -> String {
-    let Some(agents) = resp
-        .get("result")
-        .and_then(|r| r.get("agents"))
-        .and_then(|a| a.as_array())
-    else {
-        return "daemon offline".to_string();
-    };
-    match agents.len() {
-        0 => "no agents".to_string(),
-        1 => "1 agent".to_string(),
-        n => format!("{n} agents"),
+/// The three dial positions the tray icon can show. PLAN §"Layout"
+/// calls for `active / idle / error`; we reuse the same split but
+/// rename `error` → `offline` because the only actual failure mode
+/// today is an unreachable daemon. Real unhealthy-agent signal would
+/// need a sick state on the agent handle, which the current registry
+/// doesn't carry.
+#[derive(Debug, Clone, Copy)]
+enum StatusKind {
+    /// Daemon probe failed — no tray ↔ daemon IPC at all.
+    Offline,
+    /// Daemon up, zero agents registered. Rare outside a fresh
+    /// `$AGEND_HOME`.
+    Idle,
+    /// Daemon up with `N >= 1` agents in the registry.
+    Active(usize),
+}
+
+impl StatusKind {
+    /// Classify a LIST response. Missing / non-array `result.agents`
+    /// means the response shape drifted — treat as offline rather
+    /// than silently showing `Idle` with a misleading green icon.
+    fn from_response(resp: &Value) -> Self {
+        match resp
+            .get("result")
+            .and_then(|r| r.get("agents"))
+            .and_then(|a| a.as_array())
+        {
+            None => Self::Offline,
+            Some(arr) if arr.is_empty() => Self::Idle,
+            Some(arr) => Self::Active(arr.len()),
+        }
+    }
+
+    /// Disabled menu-item text for the status row.
+    fn label(&self) -> String {
+        match *self {
+            Self::Offline => "daemon offline".into(),
+            Self::Idle => "no agents".into(),
+            Self::Active(1) => "1 agent".into(),
+            Self::Active(n) => format!("{n} agents"),
+        }
+    }
+
+    /// 32x32 solid-color icon. Placeholder until designed PNG assets
+    /// are bundled — still useful for dogfooding because the color
+    /// alone is a glanceable daemon-up/down signal without opening
+    /// the menu. Colors picked for visibility in both light and dark
+    /// menu bars.
+    fn icon(&self) -> Icon {
+        let color = match *self {
+            Self::Offline => [0x88, 0x88, 0x88, 0xFF], // neutral gray
+            Self::Idle => [0xD8, 0xAA, 0x3A, 0xFF],    // amber
+            Self::Active(_) => [0x3A, 0xA8, 0x55, 0xFF], // brand green
+        };
+        solid_icon(color)
     }
 }
 
-/// Build a 32x32 solid-color placeholder icon so the spike runs without
-/// bundled PNG assets. Real icon variants (active / idle / error) land
-/// with follow-on polish — `Icon::from_rgba` accepts any RGBA buffer
-/// that satisfies `width * height * 4 == bytes.len()`.
-fn placeholder_icon() -> Icon {
+/// Fill an RGBA buffer with one color and wrap it in an `Icon`.
+/// Factored out so `StatusKind::icon` stays a table of colors.
+fn solid_icon(rgba: [u8; 4]) -> Icon {
     const W: u32 = 32;
     const H: u32 = 32;
-    let mut rgba = Vec::with_capacity((W * H * 4) as usize);
+    let mut buf = Vec::with_capacity((W * H * 4) as usize);
     for _ in 0..(W * H) {
-        // Brand-ish green. Swap for real asset later.
-        rgba.extend_from_slice(&[0x3A, 0xA8, 0x55, 0xFF]);
+        buf.extend_from_slice(&rgba);
     }
-    Icon::from_rgba(rgba, W, H).expect("32x32 RGBA buffer is always valid")
+    Icon::from_rgba(buf, W, H).expect("32x32 RGBA buffer is always valid")
 }
 
 /// Probe the daemon via `api::call(LIST)`; if it's not up, spawn a
@@ -171,11 +209,11 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
     let poll_proxy = event_loop.create_proxy();
     let poll_home = home.clone();
     thread::spawn(move || loop {
-        let text = match api::call(&poll_home, &json!({"method": api::method::LIST})) {
-            Ok(resp) => format_status(&resp),
-            Err(_) => "daemon offline".to_string(),
+        let kind = match api::call(&poll_home, &json!({"method": api::method::LIST})) {
+            Ok(resp) => StatusKind::from_response(&resp),
+            Err(_) => StatusKind::Offline,
         };
-        if poll_proxy.send_event(UserEvent::Status(text)).is_err() {
+        if poll_proxy.send_event(UserEvent::Status(kind)).is_err() {
             break;
         }
         thread::sleep(POLL_INTERVAL);
@@ -193,9 +231,13 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
         match event {
             Event::NewEvents(StartCause::Init) => {
                 if let Some(menu) = menu_slot.take() {
+                    // Boot color is `Offline`'s gray. The poller replaces
+                    // it within `POLL_INTERVAL`; this just avoids leaking
+                    // an always-green look during the first 2s when the
+                    // daemon may or may not be up.
                     match TrayIconBuilder::new()
                         .with_tooltip("agend-terminal")
-                        .with_icon(placeholder_icon())
+                        .with_icon(StatusKind::Offline.icon())
                         .with_menu(Box::new(menu))
                         .build()
                     {
@@ -236,8 +278,15 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
                     }
                 }
             }
-            Event::UserEvent(UserEvent::Status(text)) => {
-                status_item.set_text(text);
+            Event::UserEvent(UserEvent::Status(kind)) => {
+                status_item.set_text(kind.label());
+                if let Some(tray) = tray_icon.as_ref() {
+                    // `set_icon(None)` would remove the tray slot entirely
+                    // on Linux; always pass `Some(...)` when swapping.
+                    if let Err(e) = tray.set_icon(Some(kind.icon())) {
+                        eprintln!("tray: failed to swap icon: {e}");
+                    }
+                }
             }
             _ => {}
         }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -1,12 +1,10 @@
 //! Menu-bar / system-tray resident app.
 //!
-//! Gated behind the `tray` Cargo feature. Scaffold only — this module
-//! currently provides the directory layout, the `Autostart` and
-//! `OpenInTerminal` platform traits, and the `agend-terminal tray`
-//! subcommand entry point. The event loop, icon loading, and daemon
-//! lifecycle land in PLAN task #4 (see `docs/PLAN-tray-resident.md`).
+//! Gated behind the `tray` Cargo feature. See
+//! `docs/PLAN-tray-resident.md` for the full design.
 
-// Scaffold: most items won't be called until later PLAN tasks land.
+// Autostart / terminal modules are wired up incrementally across follow-on
+// tasks; keep the scaffold exports alive without warnings in the meantime.
 #![allow(dead_code)]
 
 pub mod autostart;
@@ -16,15 +14,100 @@ pub mod terminal;
 
 use std::path::Path;
 
+use tao::event::{Event, StartCause};
+use tao::event_loop::{ControlFlow, EventLoopBuilder};
+#[cfg(target_os = "macos")]
+use tao::platform::macos::{ActivationPolicy, EventLoopExtMacOS};
+use tray_icon::{
+    menu::{Menu, MenuEvent, MenuItem},
+    Icon, TrayIcon, TrayIconBuilder,
+};
+
+/// Events forwarded from tray-icon's global callbacks into the tao
+/// event loop so the loop wakes on every menu click.
+#[derive(Debug)]
+enum UserEvent {
+    Menu(MenuEvent),
+}
+
+/// Build a 32x32 solid-color placeholder icon so the spike runs without
+/// bundled PNG assets. Real icon variants (active / idle / error) land
+/// with follow-on polish — `Icon::from_rgba` accepts any RGBA buffer
+/// that satisfies `width * height * 4 == bytes.len()`.
+fn placeholder_icon() -> Icon {
+    const W: u32 = 32;
+    const H: u32 = 32;
+    let mut rgba = Vec::with_capacity((W * H * 4) as usize);
+    for _ in 0..(W * H) {
+        // Brand-ish green. Swap for real asset later.
+        rgba.extend_from_slice(&[0x3A, 0xA8, 0x55, 0xFF]);
+    }
+    Icon::from_rgba(rgba, W, H).expect("32x32 RGBA buffer is always valid")
+}
+
 /// Entry point for `agend-terminal tray`.
 ///
-/// Scaffold stub: emits a banner and exits 0 so the subcommand is wired
-/// end-to-end. The real event loop (tray icon + menu + daemon lifecycle)
-/// lands with PLAN task #4.
+/// Minimal spike — menu has only "Quit". Daemon lifecycle, status
+/// polling, Open App, and Launch-at-login toggle land in follow-on
+/// commits on this branch.
+///
+/// The `unused_*` allows cover the `tray_icon` ownership slot inside
+/// the event loop: dropping a `TrayIcon` removes the icon from the
+/// system bar, so the slot must live for the lifetime of the loop —
+/// but nothing ever reads it back.
+#[allow(unused_assignments, unused_variables)]
 pub fn run(_home: &Path) -> anyhow::Result<()> {
-    eprintln!(
-        "agend-terminal tray: scaffold only — event loop lands with \
-         PLAN task #4 (docs/PLAN-tray-resident.md)"
-    );
-    Ok(())
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
+    let mut event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
+    #[cfg(target_os = "macos")]
+    event_loop.set_activation_policy(ActivationPolicy::Accessory);
+
+    // Forward menu events into the event loop so it wakes on clicks.
+    // tray-icon uses a global crossbeam channel internally; without
+    // this bridge the loop would sleep forever in `ControlFlow::Wait`.
+    let proxy = event_loop.create_proxy();
+    MenuEvent::set_event_handler(Some(move |event| {
+        let _ = proxy.send_event(UserEvent::Menu(event));
+    }));
+
+    // Menu: just "Quit" for the spike.
+    let menu = Menu::new();
+    let quit_item = MenuItem::new("Quit agend-terminal", true, None);
+    menu.append(&quit_item)?;
+    let quit_id = quit_item.id().clone();
+
+    // tray-icon requires creation AFTER the event loop starts on macOS
+    // (prevents fullscreen-app issues, per crate docs). Build inside
+    // `StartCause::Init` rather than before `run()`.
+    let mut tray_icon: Option<TrayIcon> = None;
+    let mut menu_slot: Option<Menu> = Some(menu);
+
+    event_loop.run(move |event, _target, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::NewEvents(StartCause::Init) => {
+                if let Some(menu) = menu_slot.take() {
+                    match TrayIconBuilder::new()
+                        .with_tooltip("agend-terminal")
+                        .with_icon(placeholder_icon())
+                        .with_menu(Box::new(menu))
+                        .build()
+                    {
+                        Ok(t) => tray_icon = Some(t),
+                        Err(e) => {
+                            eprintln!("tray: failed to build icon: {e}");
+                            *control_flow = ControlFlow::Exit;
+                        }
+                    }
+                }
+            }
+            Event::UserEvent(UserEvent::Menu(ev)) => {
+                if ev.id == quit_id {
+                    *control_flow = ControlFlow::Exit;
+                }
+            }
+            _ => {}
+        }
+    });
 }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -13,8 +13,10 @@ pub mod icon;
 pub mod terminal;
 
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
-use serde_json::json;
+use serde_json::{json, Value};
 use tao::event::{Event, StartCause};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
 #[cfg(target_os = "macos")]
@@ -26,11 +28,37 @@ use tray_icon::{
 
 use crate::{api, bootstrap::daemon_spawn};
 
-/// Events forwarded from tray-icon's global callbacks into the tao
-/// event loop so the loop wakes on every menu click.
+/// Status polling cadence. PLAN §"Runtime flow" pins 2s; slower feels
+/// stale, faster is just wasted IPC.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Events forwarded from tray-icon's global callbacks and the status
+/// poller into the tao event loop so the loop wakes on every input.
 #[derive(Debug)]
 enum UserEvent {
     Menu(MenuEvent),
+    /// Pre-formatted label text from the worker thread. Drained on the
+    /// main thread (tray-icon / muda require main-thread mutation on
+    /// macOS).
+    Status(String),
+}
+
+/// Render a LIST response into the menu label. First line is what the
+/// user scans: how many agents the daemon has, or "daemon offline" if
+/// the probe errors.
+fn format_status(resp: &Value) -> String {
+    let Some(agents) = resp
+        .get("result")
+        .and_then(|r| r.get("agents"))
+        .and_then(|a| a.as_array())
+    else {
+        return "daemon offline".to_string();
+    };
+    match agents.len() {
+        0 => "no agents".to_string(),
+        1 => "1 agent".to_string(),
+        n => format!("{n} agents"),
+    }
 }
 
 /// Build a 32x32 solid-color placeholder icon so the spike runs without
@@ -99,11 +127,33 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
         let _ = proxy.send_event(UserEvent::Menu(event));
     }));
 
-    // Menu: just "Quit" for the spike.
+    // Menu: disabled status label at the top, then Quit. Open App /
+    // Launch-at-login land in follow-on commits — they slot above Quit.
     let menu = Menu::new();
+    let status_item = MenuItem::new("starting…", false, None);
     let quit_item = MenuItem::new("Quit agend-terminal", true, None);
+    menu.append(&status_item)?;
+    menu.append(&tray_icon::menu::PredefinedMenuItem::separator())?;
     menu.append(&quit_item)?;
     let quit_id = quit_item.id().clone();
+
+    // Status poller: every POLL_INTERVAL, probe the daemon and push a
+    // pre-formatted label through the event loop. Runs on a worker
+    // thread because tray-icon / muda menu mutation must stay on the
+    // main thread on macOS. The loop exits when `send_event` fails —
+    // which happens once the event loop has shut down (`Quit` clicked).
+    let poll_proxy = event_loop.create_proxy();
+    let poll_home = home.clone();
+    thread::spawn(move || loop {
+        let text = match api::call(&poll_home, &json!({"method": api::method::LIST})) {
+            Ok(resp) => format_status(&resp),
+            Err(_) => "daemon offline".to_string(),
+        };
+        if poll_proxy.send_event(UserEvent::Status(text)).is_err() {
+            break;
+        }
+        thread::sleep(POLL_INTERVAL);
+    });
 
     // tray-icon requires creation AFTER the event loop starts on macOS
     // (prevents fullscreen-app issues, per crate docs). Build inside
@@ -134,6 +184,9 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
             Event::UserEvent(UserEvent::Menu(ev)) if ev.id == quit_id => {
                 shutdown_daemon(&home);
                 *control_flow = ControlFlow::Exit;
+            }
+            Event::UserEvent(UserEvent::Status(text)) => {
+                status_item.set_text(text);
             }
             _ => {}
         }

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -28,6 +28,8 @@ use tray_icon::{
 
 use crate::{api, bootstrap::daemon_spawn};
 
+use self::terminal::{OpenInTerminal, Platform as TerminalPlatform};
+
 /// Status polling cadence. PLAN §"Runtime flow" pins 2s; slower feels
 /// stale, faster is just wasted IPC.
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -127,14 +129,24 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
         let _ = proxy.send_event(UserEvent::Menu(event));
     }));
 
-    // Menu: disabled status label at the top, then Quit. Open App /
-    // Launch-at-login land in follow-on commits — they slot above Quit.
+    // tray.toml is best-effort — absence / parse errors fall back to
+    // defaults (warn-and-default per PLAN). Build the terminal
+    // dispatcher from its `terminal` field so "Open App" clicks route
+    // through the user's chosen emulator.
+    let cfg = config::load(&home);
+    let opener = TerminalPlatform::new(cfg.terminal);
+
+    // Menu: disabled status label, separator, Open App, Quit.
+    // Launch-at-login toggle lands in the follow-on commit.
     let menu = Menu::new();
     let status_item = MenuItem::new("starting…", false, None);
+    let open_app_item = MenuItem::new("Open App", true, None);
     let quit_item = MenuItem::new("Quit agend-terminal", true, None);
     menu.append(&status_item)?;
     menu.append(&tray_icon::menu::PredefinedMenuItem::separator())?;
+    menu.append(&open_app_item)?;
     menu.append(&quit_item)?;
+    let open_app_id = open_app_item.id().clone();
     let quit_id = quit_item.id().clone();
 
     // Status poller: every POLL_INTERVAL, probe the daemon and push a
@@ -181,9 +193,17 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
                     }
                 }
             }
-            Event::UserEvent(UserEvent::Menu(ev)) if ev.id == quit_id => {
-                shutdown_daemon(&home);
-                *control_flow = ControlFlow::Exit;
+            Event::UserEvent(UserEvent::Menu(ev)) => {
+                if ev.id == quit_id {
+                    shutdown_daemon(&home);
+                    *control_flow = ControlFlow::Exit;
+                } else if ev.id == open_app_id {
+                    // Best-effort: surface PATH / spawn errors on stderr but
+                    // keep the tray alive so the user can retry or Quit.
+                    if let Err(e) = opener.open(&["agend-terminal", "app"]) {
+                        eprintln!("tray: open app failed: {e}");
+                    }
+                }
             }
             Event::UserEvent(UserEvent::Status(text)) => {
                 status_item.set_text(text);


### PR DESCRIPTION
## Summary

First half of PLAN task #4 (docs/PLAN-tray-resident.md §"Runtime flow"):
tray icon actually renders, daemon lifecycle is wired, menu Quit works
end-to-end. Status polling + Open App + Launch-at-login menu entries
will follow as additional commits / a follow-up PR.

### What lands

- **`tray-icon 0.22` + `tao 0.35`** behind the existing `tray` feature
  (`tray = ["dep:tray-icon", "dep:tao"]`). Default build unchanged —
  both crates stay out of the dep graph unless `--features tray` is
  passed. `image` transitive comes via the pre-existing `arboard`
  dependency, not from tray-icon (PLAN gotcha respected).
- **Event loop** (`src/tray/mod.rs::run`):
  - `tao::EventLoop` with a `UserEvent` channel.
  - `MenuEvent::set_event_handler` forwards menu clicks to the loop via
    `EventLoopProxy::send_event` — without this bridge the loop would
    sleep forever in `ControlFlow::Wait`.
  - macOS `ActivationPolicy::Accessory` — menu-bar only, no Dock, no
    Cmd-Tab (matches Ollama).
  - Icon built inside `StartCause::Init` per `tray-icon` docs (avoids
    macOS fullscreen-app fallout).
  - 32×32 solid-green RGBA placeholder via `Icon::from_rgba`. Real
    active/idle/error PNG assets land with follow-on polish.
- **Daemon bootstrap** (`bootstrap_daemon`): on entry, probe
  `api::call(LIST)`; on failure, `bootstrap::daemon_spawn::spawn_detached`
  (5s readiness wait inherited). Spawn failures are non-fatal — the
  tray still starts so the user can Quit / inspect.
- **Quit semantics**: the Quit menu item calls `api::call(SHUTDOWN)`
  before `ControlFlow::Exit`. Best-effort — if the daemon is already
  gone, the RPC errors and we ignore it.

### Out of scope (follow-up)

- Status polling worker + dynamic menu label (PLAN §"Runtime flow"
  `every 2s → api::call(LIST), rebuild status label`).
- "Open App" menu entry (wires `tray::terminal::Platform::open`).
- "Launch at login" toggle + checkbox (wires `tray::autostart::Platform`).
- `release.yml` flip to ship `--features tray` on tagged releases.
- Bundled PNG icon variants.

### Scope vs PLAN acceptance criteria

| Criterion | Status |
|---|---|
| `cargo check --all-targets` (default) unchanged | ✅ |
| `cargo check --all-targets --features tray` green | ✅ (macOS local; CI proves Linux/Windows) |
| `cargo clippy --all-targets --features tray -- -D warnings` | ✅ |
| 1. `agend-terminal tray` → menu-bar icon appears, no Dock | ✅ (verified on macOS) |
| 2. Status label updates within 2s of inject | ⏳ follow-up |
| 3. "Open App" opens configured terminal | ⏳ follow-up |
| 4. Launch-at-login toggle | ⏳ follow-up |
| 5. "Quit" → daemon down, tray gone, exit 0 | ✅ (verified: `list` returns "No running daemon found" after Quit) |
| 6. Tray respawn via launchd after kill -9 | ⏳ requires criterion 4 |

## Test plan

- [x] Local: `cargo clippy --all-targets -- -D warnings` (default) green
- [x] Local: `cargo clippy --all-targets --features tray -- -D warnings` green
- [x] Local: `cargo test --bin agend-terminal --features tray` — 527 passed, 0 failed
- [x] Local: `cargo fmt --check` clean
- [x] Manual: fresh `$AGEND_HOME=/tmp/...` → `tray` spawns daemon, icon renders as green square in menu bar
- [x] Manual: Quit → tray exits 0, `list` reports no daemon
- [ ] CI: three-OS matrix tray feature gate passes (CI already enforces from PR #16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)