### PR TITLE
refactor(worktree): consolidate validate_branch to crate::agent_ops

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -293,6 +293,27 @@ mod tests {
         assert!(!validate_branch("main\ninjected"));
     }
 
+    // Migrated from `src/worktree.rs::tests` as part of Task #9 Option C
+    // epilogue (worktree.rs no longer holds its own `validate_branch` copy).
+
+    #[test]
+    fn test_validate_branch_valid() {
+        assert!(validate_branch("main"));
+        assert!(validate_branch("feature/my-branch"));
+        assert!(validate_branch("agend/agent-1"));
+        assert!(validate_branch("v1.0.0"));
+    }
+
+    #[test]
+    fn test_validate_branch_rejects() {
+        assert!(!validate_branch(""));
+        assert!(!validate_branch(".."));
+        assert!(!validate_branch("foo/../bar"));
+        assert!(!validate_branch("-starts-with-dash"));
+        assert!(!validate_branch("has spaces"));
+        assert!(!validate_branch("has;semicolon"));
+    }
+
     // --- merge_metadata (2 from ops.rs) ---
 
     #[test]

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -2,6 +2,7 @@
 //!
 //! Rule: if working_directory is set and is a git repo, create a worktree.
 
+use crate::agent_ops::validate_branch;
 use std::path::{Path, PathBuf};
 
 /// Info about a created worktree.
@@ -41,16 +42,6 @@ fn has_commits(repo_dir: &Path) -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
-}
-
-/// Validate a git branch name. Only allows [a-zA-Z0-9/_.-], rejects ".." and leading "-".
-fn validate_branch(branch: &str) -> bool {
-    !branch.is_empty()
-        && !branch.contains("..")
-        && !branch.starts_with('-')
-        && branch
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '/' || c == '_' || c == '-' || c == '.')
 }
 
 /// Create a worktree for an instance. Returns WorktreeInfo if created,
@@ -393,21 +384,8 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    #[test]
-    fn test_validate_branch_valid() {
-        assert!(validate_branch("main"));
-        assert!(validate_branch("feature/my-branch"));
-        assert!(validate_branch("agend/agent-1"));
-        assert!(validate_branch("v1.0.0"));
-    }
-
-    #[test]
-    fn test_validate_branch_rejects() {
-        assert!(!validate_branch(""));
-        assert!(!validate_branch(".."));
-        assert!(!validate_branch("foo/../bar"));
-        assert!(!validate_branch("-starts-with-dash"));
-        assert!(!validate_branch("has spaces"));
-        assert!(!validate_branch("has;semicolon"));
-    }
+    // `test_validate_branch_valid` + `test_validate_branch_rejects` migrated
+    // to `src/agent_ops.rs::tests` as part of Task #9 Option C epilogue — the
+    // `validate_branch` fn itself lives in `agent_ops.rs` now, so tests are
+    // colocated with their subject.
 }


### PR DESCRIPTION
## Summary

Task #9 Option C follow-up #1 — 移除 `src/worktree.rs:47` 的第 3 份 `validate_branch` inline 定義，改 import `crate::agent_ops::validate_branch`（canonical 版本）。

## 背景

PR #18 (Task #9 Option C) 把 6/7 utility 從 ops.rs 搬到 agent_ops.rs，當時 scoping 列出 6 個 byte-identical utility。事後複查發現 `src/worktree.rs:47` 還有第 3 份 `validate_branch`（ops + mcp/handlers 在 PR #18 已合併到 agent_ops，但 worktree.rs 獨立複製 slipped through）。

## 變更

- `src/worktree.rs`: `use crate::agent_ops::validate_branch;` 取代 inline `fn validate_branch`
- 刪除 doc comment 指向 agent_ops module（tests 已指向 agent_ops::tests）

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release` — 全綠
- [x] 手動驗證 `validate_branch` 單一 source of truth @ `agent_ops`

🤖 Generated with [Claude Code](https://claude.com/claude-code)