### PR TITLE
test(api): positive-pin for TeamCreated emission via RecordingNotifier

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -942,6 +942,64 @@ mod tests {
         stop_server(&shutdown, &home);
     }
 
+    /// Positive-pin companion to `dispatch_create_team_emits_team_created`:
+    /// uses `true` (resolved via PATH — `/usr/bin/true` on macOS,
+    /// `/bin/true` or `/usr/bin/true` on Linux) as a harmless real
+    /// backend so `spawn_one` actually succeeds, exercising the
+    /// non-empty `spawned` branch of `handle_create_team` and proving
+    /// the `TeamCreated` emission path end-to-end.
+    ///
+    /// Context (see `LESSONS-04-21.md` open items): headless daemon mode
+    /// passes `notifier = None`, so the emission block in
+    /// `handlers/team.rs:153-161` is unreachable by the standard E2E
+    /// smoke. Prior coverage used a three-piece equivalence bracket —
+    /// (a) negative pin via the sibling test above, (b) byte-identical
+    /// refactor verdict from at-dev-3 on the emission block, (c) runtime
+    /// abort-point evidence from smoke logs. This positive pin replaces
+    /// (a)+(c) with a direct in-process assertion that a successful
+    /// spawn results in the expected `ApiEvent::TeamCreated` payload.
+    ///
+    /// `#[cfg(unix)]` — `true(1)` is a universal harmless real backend
+    /// on Unix; Windows lacks a directly equivalent short-lived builtin
+    /// and the LESSONS open item is scoped to a proof-of-concept. A
+    /// Windows-specific positive pin can be added as a follow-up
+    /// without changing this test.
+    #[cfg(unix)]
+    #[test]
+    fn dispatch_create_team_emits_team_created_positive() {
+        let (port, home, notifier, shutdown) = start_test_server("dispatch-team-pos");
+        let resp = api_request(
+            port,
+            &home,
+            &json!({
+                "method": "create_team",
+                "params": {
+                    "name": "positive_pin",
+                    "backend": "true",
+                    "count": 1
+                }
+            }),
+        );
+        assert_eq!(resp["ok"], true, "create_team failed: {resp:?}");
+        assert_eq!(
+            resp["spawned"].as_array().map(|a| a.len()),
+            Some(1),
+            "expected 1 spawned agent, got {resp:?}"
+        );
+        // The notifier emission in `handle_create_team` happens synchronously
+        // before the response is written to the wire (see handlers/team.rs
+        // L153-161), so by the time `api_request` returns, the event is
+        // already in `RecordingNotifier`'s buffer — no polling needed.
+        let events = notifier.take();
+        assert_eq!(events.len(), 1, "expected 1 event, got {events:?}");
+        let ApiEvent::TeamCreated { name, members } = &events[0] else {
+            panic!("expected TeamCreated, got {:?}", events[0])
+        };
+        assert_eq!(name, "positive_pin");
+        assert_eq!(members, &["positive_pin-1"]);
+        stop_server(&shutdown, &home);
+    }
+
     #[test]
     fn dispatch_update_team_emits_members_changed() {
         let (port, home, notifier, shutdown) = start_test_server("dispatch-update-team");


### PR DESCRIPTION
## Summary

Task #9 Option C follow-up #5 — 完成 three-piece equivalence 中的「positive-pin」缺口。

## Why

C2 CREATE_TEAM refactor post-merge obligation 過關靠 three-piece equivalence：
1. Negative in-process pin（`dispatch_create_team_emits_team_created` 驗 0-event 分支）
2. Byte-identical verdict（at-dev-3 逐字核對）
3. Runtime abort-point evidence（smoke log 顯示 gate 已通過）

三者 bracket regression 風險，但第 1 項 negative pin 只驗「spawned empty → 0 event」，沒驗「spawned non-empty → 1 event」這個正向 path。LESSONS-04-21 "Open items" 列此為 pre-existing gap（非 C2 引入）。

## 變更

- `src/api/mod.rs::tests`（`#[cfg(test)]` 區塊 +58 lines）
  - 新 test: `dispatch_create_team_emits_team_created_positive`
  - 使用 existing `RecordingNotifier` (L611-631) 走 `start_test_server` harness
  - Backend string `"true"` — 透過 `which::which("true")` 解析，macOS + Linux 都能 resolve
  - 6 個 assertion：ok flag / spawned count / events count / variant / team name / members formatter

## Why backend="true"

`/bin/true` 在 macOS 上不存在（`/usr/bin/true` 才是，但 path 不一致）。統一用 `"true"` 讓 `which` resolve，跨平台安全。

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release` — 624 passed / 0 failed
- [x] 新 test `dispatch_create_team_emits_team_created_positive` 通過
- [x] 原 negative pin test 仍通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)