### PR TITLE
fix(release): AppImage custom AppRun for tray default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,14 +170,21 @@ jobs:
 
       # APPIMAGE_EXTRACT_AND_RUN bypasses FUSE — GitHub runners don't ship it.
       # OUTPUT pins the filename so the upload step + release files list match.
+      # --custom-apprun installs our own AppRun that forces `tray` subcommand
+      # when no args are passed (default AppRun ignores the .desktop `Exec=`,
+      # so double-click would fall into help-and-exit interactive CLI mode).
+      # Our AppRun still sources apprun-hooks/*.sh so GTK env from plugin-gtk
+      # stays effective.
       - name: Build AppImage
         env:
           APPIMAGE_EXTRACT_AND_RUN: "1"
           OUTPUT: agend-terminal-x86_64.AppImage
         run: |
+          chmod +x assets/appimage/AppRun
           ./linuxdeploy-x86_64.AppImage \
             --appdir AppDir \
             --plugin gtk \
+            --custom-apprun assets/appimage/AppRun \
             --output appimage
 
       - name: Upload artifact

--- a/assets/appimage/AppRun
+++ b/assets/appimage/AppRun
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Custom AppRun for agend-terminal AppImage.
+#
+# Why: linuxdeploy's default AppRun execs $APPDIR/usr/bin/agend-terminal with
+# the caller's argv verbatim and ignores the `Exec=` line in the .desktop
+# file. Double-click or bare invocation would fall into interactive CLI mode
+# (print help and exit), so the tray icon would never appear. We force the
+# `tray` subcommand here; explicit args from the CLI still win via "$@"
+# fallthrough for power users who want `agend-terminal-x86_64.AppImage list`.
+#
+# apprun-hooks/ is the directory linuxdeploy plugins drop env-setup snippets
+# into (e.g., linuxdeploy-plugin-gtk's GDK_BACKEND / GI_TYPELIB_PATH exports).
+# The default AppRun sources these; we must too, otherwise the bundled GTK3
+# libs won't be found at runtime.
+
+HERE="$(dirname "$(readlink -f "$0")")"
+
+for hook in "$HERE"/apprun-hooks/*.sh; do
+    [ -e "$hook" ] && . "$hook"
+done
+
+if [ "$#" -eq 0 ]; then
+    exec "$HERE/usr/bin/agend-terminal" tray
+else
+    exec "$HERE/usr/bin/agend-terminal" "$@"
+fi


### PR DESCRIPTION
## Summary
First in-the-wild test of PR #19's AppImage on Ubuntu confirmed what its test plan flagged as open: **linuxdeploy's default AppRun ignores the `.desktop` `Exec=` line**. Symptoms exactly matched the failure mode:

- `./agend-terminal-x86_64.AppImage` → prints `--help` and exits
- Double-click → same, but output is swallowed by the desktop → no tray icon, nothing happens
- No process in `ps -ef` after double-click

## Fix
Custom AppRun (`assets/appimage/AppRun`) that:
1. Sources `apprun-hooks/*.sh` so linuxdeploy-plugin-gtk's GTK env-setup stays active (`GDK_BACKEND`, `GI_TYPELIB_PATH`, etc.).
2. Defaults to `exec agend-terminal tray` when no args.
3. Falls through to user args (`exec agend-terminal "$@"`) so `./agend-terminal-x86_64.AppImage list` still works for CLI users.

Installed via linuxdeploy's `--custom-apprun` flag.

## Test plan
- [ ] `workflow_dispatch` produces artifact without error (run 24755681739 pending)
- [ ] Download artifact, \`chmod +x\`, run from terminal — should NOT print help; tray process stays alive
- [ ] Double-click — tray icon appears (Ubuntu GNOME has AppIndicator by default)
- [ ] \`ps -ef | grep agend-terminal\` shows \`agend-terminal tray\`
- [ ] \`./agend-terminal-x86_64.AppImage list\` still works as CLI (fallthrough check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)