### PR TITLE
chore: Task #9 Option C post-merge polish (closes #26, closes #27)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -472,6 +472,14 @@ mod tests {
             Backend::from_command("/usr/bin/claude"),
             Some(Backend::ClaudeCode)
         );
+        // Alias: the bare "kiro" input (without the `-cli` suffix) must also
+        // resolve to `KiroCli` and round-trip through `preset().command` to
+        // the canonical `"kiro-cli"` executable name. Previously covered by
+        // the `backend_resolves_to_preset_command` test removed in PR #22.
+        assert_eq!(
+            Backend::from_command("kiro").map(|b| b.preset().command),
+            Some("kiro-cli")
+        );
     }
 
     #[test]

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -350,7 +350,8 @@ pub(crate) fn is_topic_deleted_error(err: &anyhow::Error) -> bool {
 /// `state` is `None` for callers that lack access to `TelegramState` (daemon
 /// `notify_telegram`, `try_telegram_reply`). Those paths leave the in-memory
 /// maps stale until the next state-aware send or process restart — acceptable
-/// because `ops::delete_instance`-equivalent disk state is the source of truth.
+/// because the MCP `delete_instance` handler's disk mutation (fleet.yaml
+/// removal + `cleanup_working_dir`) is the source of truth.
 pub(crate) fn cleanup_deleted_topic(
     home: &Path,
     instance_name: &str,

--- a/tests/mcp_characterization.rs
+++ b/tests/mcp_characterization.rs
@@ -370,14 +370,17 @@ fn describe_instance_returns_error_when_daemon_down() {
 }
 
 #[test]
-fn delete_instance_succeeds_via_ops_when_daemon_down() {
+fn delete_instance_succeeds_via_mcp_handler_when_daemon_down() {
     let home = temp_home("del-no-daemon");
     let result = call_tool(&home, "delete_instance", &json!({"name": "nonexistent"}));
-    // delete_instance falls back to ops::delete_instance which touches files only
+    // The MCP `delete_instance` handler's `api::call(DELETE)` fails silently
+    // when the daemon is unreachable; the handler continues via direct disk
+    // operations (fleet.yaml removal + `cleanup_working_dir`) which succeed
+    // regardless of daemon state, so the call still reports success.
     assert_eq!(
         result["name"].as_str(),
         Some("nonexistent"),
-        "delete_instance should succeed via ops fallback, got: {result}"
+        "delete_instance should succeed via MCP handler disk fallback, got: {result}"
     );
     std::fs::remove_dir_all(&home).ok();
 }


### PR DESCRIPTION
## Summary

Resolves the two non-blocking items identified during PR #22 review,
consolidated as the first batch of umbrella issue #29 (Task #9 Option C
post-merge polish). Pure cleanup — no behavioral change.

- **closes #26** — update stale `ops::` doc references to current
  canonical paths. Three call sites referred to `ops::delete_instance`
  which was removed by PR #21 (`2db67fc`) + PR #22 (`8a7240d`):
  - `tests/mcp_characterization.rs:373` test fn renamed from
    `delete_instance_succeeds_via_ops_when_daemon_down` →
    `delete_instance_succeeds_via_mcp_handler_when_daemon_down`
  - Same test's inline comment + assertion message now describe the MCP
    handler's disk-fallback path (`fleet.yaml` removal +
    `cleanup_working_dir`) instead of the removed function
  - `src/telegram.rs:353` doc comment on `cleanup_deleted_topic` now
    cites the MCP `delete_instance` handler's disk mutation as the
    source of truth

- **closes #27** — restore `Backend::from_command("kiro")` alias test
  coverage. The `backend_resolves_to_preset_command` test dropped by
  PR #22 was only partially duplicated by `from_command_detection`:
  the `claude` roundtrip was covered, but the **bare `"kiro"` alias**
  (without the `-cli` suffix — handled by `src/backend.rs:314`'s
  `basename == "kiro"` branch) lost its pin. A single assertion folded
  into the existing `from_command_detection` matrix restores the
  roundtrip `"kiro" → Backend::KiroCli → preset().command == "kiro-cli"`.

## Scope

- 3 files touched, +16 / −4 lines
- No production logic modified (doc-comment text only in `telegram.rs`
  and a test-assert addition in `backend.rs`)
- Test count unchanged: 622 passed (rename preserves count, added
  assertion is inside an existing test fn)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --release` — 622 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)