### PR TITLE
test(ci): harden dual-track drift detector — raw strings + extern ABI (closes #28)

### DIFF
--- a/tests/no_dual_track_drift.rs
+++ b/tests/no_dual_track_drift.rs
@@ -16,12 +16,38 @@
 //! Scope is intentionally narrow — only these two files. Macro-generated
 //! fn and non-top-level definitions (inside `mod tests`, `impl`, etc.) are
 //! deliberately ignored per Task #9 Option C epilogue spec.
+//!
+//! Parser hardening (issue #28 — robustness epilogue):
+//! - `extern "ABI" fn` / `pub extern "C" fn` now strip the ABI clause, so
+//!   FFI exports register for drift detection. Previously only bare
+//!   `extern fn` (no ABI literal) matched — a silent miss.
+//! - Raw string literals (`r"..."` / `r#"..."#`) inside extracted top-level
+//!   fn bodies fail loudly rather than silently mis-parse. `skip_string`
+//!   uses bare `"` as delimiter; it is incompatible with raw-string
+//!   termination (`"#`). The guard is scoped to bodies that the parser
+//!   actually extracts — raw strings inside `mod tests {...}` or other
+//!   indented blocks (which `detect_fn_name` never enters) do not false-
+//!   fail. "Fail loud, don't over-engineer" — upgrade `skip_string` to
+//!   real raw-string support if/when a top-level fn needs it.
+//! - An unparseable top-level fn body (raw-string-induced miscount or
+//!   malformed source) panics with a fix-it hint rather than silently
+//!   dropping the fn from the drift map.
 
 use std::collections::HashMap;
 use std::path::Path;
 
 /// Extract (fn_name → normalized_body) map from a Rust source file.
 /// Only considers fn definitions at indentation column 0 (top-level).
+///
+/// Panics (issue #28 hardening) rather than silently dropping a fn:
+/// - No opening `{` found after a detected fn name → source likely
+///   malformed or fn is a forward declaration at column 0 (unusual).
+/// - `match_balanced_brace` returns None → brace count never reached 0,
+///   usually because a raw string literal inside the body desynced
+///   `skip_string`.
+/// - Extracted body contains a raw string literal (`r"..."` /
+///   `r#"..."#`) at token boundary → parser cannot reliably count
+///   braces across raw-string delimiters; refuse rather than guess.
 fn extract_top_level_fns(src: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
     let mut cursor = 0;
@@ -34,14 +60,42 @@ fn extract_top_level_fns(src: &str) -> HashMap<String, String> {
         let line = &src[cursor..line_end];
 
         if let Some(name) = detect_fn_name(line) {
-            if let Some(open) = find_body_brace(src, cursor) {
-                if let Some(close) = match_balanced_brace(src, open) {
-                    let body = &src[open..=close];
-                    map.insert(name.to_string(), normalize(body));
-                    cursor = close + 1;
-                    continue;
-                }
+            let open = find_body_brace(src, cursor).unwrap_or_else(|| {
+                panic!(
+                    "PARSER LIMITATION: top-level fn `{name}` detected at column 0, \
+                     but no opening `{{` found before EOF. Likely causes: \
+                     (1) forward declaration `fn {name}();` at column 0 (uncommon — \
+                     trait/extern decls are usually indented), \
+                     (2) truncated source."
+                )
+            });
+            let close = match_balanced_brace(src, open).unwrap_or_else(|| {
+                panic!(
+                    "PARSER LIMITATION: top-level fn `{name}` body could not be \
+                     brace-balanced. Most likely cause: a raw string literal \
+                     (`r\"...\"` or `r#\"...\"#`) inside the body — `skip_string` \
+                     uses bare `\"` as delimiter, which desyncs on raw strings \
+                     and lets `{{` / `}}` inside the literal corrupt the depth \
+                     counter. Fix: either (a) move the raw string out of the \
+                     top-level fn, or (b) upgrade `skip_string` to handle raw \
+                     strings (and delete this guard)."
+                )
+            });
+            let body = &src[open..=close];
+            if body_contains_raw_string_token(body) {
+                panic!(
+                    "PARSER LIMITATION: top-level fn `{name}` body contains a raw \
+                     string literal (`r\"...\"` or `r#\"...\"#`). The detector \
+                     does not parse raw-string delimiters — brace counting past \
+                     them is unreliable, so drift results would be silently \
+                     wrong. Fix: either (a) move the raw string out of the \
+                     top-level fn, or (b) upgrade `skip_string` to handle raw \
+                     strings (and delete this guard)."
+                )
             }
+            map.insert(name.to_string(), normalize(body));
+            cursor = close + 1;
+            continue;
         }
 
         cursor = line_end + 1;
@@ -50,8 +104,9 @@ fn extract_top_level_fns(src: &str) -> HashMap<String, String> {
     map
 }
 
-/// Strip known qualifier prefixes (pub, pub(crate), async, const, unsafe)
-/// from a column-0 line, then require `fn NAME` to follow. Returns NAME.
+/// Strip known qualifier prefixes (pub, pub(crate), async, const, unsafe,
+/// extern, extern "ABI") from a column-0 line, then require `fn NAME` to
+/// follow. Returns NAME.
 fn detect_fn_name(line: &str) -> Option<&str> {
     let mut rest = line;
     loop {
@@ -62,7 +117,7 @@ fn detect_fn_name(line: &str) -> Option<&str> {
             .or_else(|| rest.strip_prefix("async "))
             .or_else(|| rest.strip_prefix("const "))
             .or_else(|| rest.strip_prefix("unsafe "))
-            .or_else(|| rest.strip_prefix("extern "));
+            .or_else(|| strip_extern_maybe_abi(rest));
         match next {
             Some(r) => rest = r,
             None => break,
@@ -73,6 +128,20 @@ fn detect_fn_name(line: &str) -> Option<&str> {
         .find(|c: char| c == '(' || c == '<' || c.is_whitespace())
         .unwrap_or(rest.len());
     (end > 0).then(|| &rest[..end])
+}
+
+/// Strip `extern ` optionally followed by an ABI clause `"..." `.
+/// Handles `extern fn`, `extern "C" fn`, `extern "Rust" fn`, etc.
+/// Returns the remainder after the clause (and any trailing whitespace).
+fn strip_extern_maybe_abi(rest: &str) -> Option<&str> {
+    let after = rest.strip_prefix("extern ")?;
+    match after.strip_prefix('"') {
+        Some(after_open_quote) => {
+            let end = after_open_quote.find('"')?;
+            Some(after_open_quote[end + 1..].trim_start())
+        }
+        None => Some(after),
+    }
 }
 
 /// Scan forward from `from` (inclusive) until the first unescaped `{`,
@@ -177,6 +246,57 @@ fn skip_block_comment(bytes: &[u8], start: usize) -> usize {
         i += 1;
     }
     i + 2
+}
+
+fn is_ident_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Walk `body` using the same string/char/comment skippers as
+/// `match_balanced_brace` and return `true` if a raw-string literal
+/// (`r"..."` / `r#"..."#` / `r##"..."##` / ...) is encountered at
+/// a token boundary (i.e., not inside a regular string, char literal,
+/// or comment, and not a suffix of an identifier like `foo_r`).
+///
+/// Scoped to an extracted top-level fn body, not the whole source, so
+/// raw strings inside `mod tests {...}` or other indented definitions
+/// (which the parser never enters) do not trigger a false positive.
+fn body_contains_raw_string_token(body: &str) -> bool {
+    let bytes = body.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => i = skip_string(bytes, i),
+            b'\'' => i = skip_char_lit(bytes, i),
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                i = skip_line_comment(bytes, i);
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i = skip_block_comment(bytes, i);
+            }
+            b'r' => {
+                let at_boundary = i == 0 || !is_ident_char(bytes[i - 1]);
+                if at_boundary {
+                    let rest = i + 1;
+                    if rest < bytes.len() && bytes[rest] == b'"' {
+                        return true;
+                    }
+                    if rest < bytes.len() && bytes[rest] == b'#' {
+                        let mut j = rest;
+                        while j < bytes.len() && bytes[j] == b'#' {
+                            j += 1;
+                        }
+                        if j < bytes.len() && bytes[j] == b'"' {
+                            return true;
+                        }
+                    }
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    false
 }
 
 /// Collapse whitespace to single spaces so fmt-cosmetic diffs don't
@@ -292,5 +412,81 @@ fn handles_missing_ops_rs_gracefully() {
     assert!(
         ident.is_empty(),
         "missing handlers.rs must not yield identical-dup list"
+    );
+}
+
+#[test]
+#[should_panic(expected = "raw string literal")]
+fn raw_string_in_top_level_fn_fails_loudly() {
+    // Issue #28 robustness pin: a top-level fn body containing a raw
+    // string literal must fail loudly rather than silently mis-parse.
+    // `skip_string` treats bare `"` as delimiter, so the closing `"#`
+    // of a raw string can be mis-identified — `{` / `}` inside the
+    // literal would then corrupt the brace depth counter and either
+    // drop the fn from the map (silent miss) or extract a wrong body
+    // (silent drift false-positive/negative).
+    let src = "pub fn example() -> &'static str {\n    r#\"hello { world\"#\n}\n";
+    let _ = compare_fns_from_sources(src, "");
+}
+
+#[test]
+fn raw_string_in_indented_block_is_ignored() {
+    // Scope pin: raw strings inside indented definitions (`#[test]` fns
+    // inside `mod tests {}`, impl blocks, extern C blocks, etc.) are
+    // invisible to the drift detector — `detect_fn_name` only matches
+    // column-0 lines, so the parser never enters those bodies. This
+    // pins that behavior so the raw-string guard does not false-fail
+    // on source files that legitimately use raw strings in test modules
+    // (e.g. `src/mcp/handlers.rs` L787/L833 on 2026-04-22).
+    let src = "\
+pub fn real_fn() {
+    let _ = 0;
+}
+mod tests {
+    #[test]
+    fn test_with_raw_string() {
+        let _ = r#\"abc{def\"#;
+    }
+}
+";
+    let (div, ident) = compare_fns_from_sources(src, src);
+    assert!(
+        ident.contains(&"real_fn".to_string()),
+        "real_fn (outside indented block) must register: {ident:?}"
+    );
+    assert!(
+        div.is_empty(),
+        "identical sources must not produce divergent: {div:?}"
+    );
+}
+
+#[test]
+fn extern_abi_fn_detected() {
+    // Issue #28 parser extension: `extern "C" fn` / `extern "Rust" fn`
+    // at column 0 must strip both `extern ` and the quoted ABI clause
+    // so the fn name registers in the drift map. Prior to this fix,
+    // `detect_fn_name` only recognized bare `extern ` (no ABI literal)
+    // and silently dropped any `extern "ABI" fn` — a particularly
+    // dangerous blind spot for FFI exports, which are exactly the
+    // kind of boundary code where drift between two files would be
+    // most damaging.
+    let src_ops = "pub extern \"C\" fn ffi_entry() {\n    let _ = 0;\n}\n";
+    let src_hdl = "pub extern \"C\" fn ffi_entry() {\n    let _ = 1;\n}\n";
+    let (div, _) = compare_fns_from_sources(src_ops, src_hdl);
+    assert_eq!(
+        div,
+        vec!["ffi_entry".to_string()],
+        "extern \"C\" fn must register for drift detection: {div:?}"
+    );
+
+    // Also verify `extern "Rust" fn` (another valid ABI spelling) —
+    // guards against accidental over-specialization to `"C"`.
+    let src_a = "extern \"Rust\" fn helper() {\n    let _ = 0;\n}\n";
+    let src_b = "extern \"Rust\" fn helper() {\n    let _ = 0;\n}\n";
+    let (_, ident) = compare_fns_from_sources(src_a, src_b);
+    assert_eq!(
+        ident,
+        vec!["helper".to_string()],
+        "extern \"Rust\" fn must register: {ident:?}"
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #23 (Task #9 Option C epilogue lint). Closes **#28** (dual-track lint future-proofing — raw strings + extern fn). Part of umbrella **#29** (Task #9 Option C post-merge polish).

Addresses two parser gaps identified in at-dev-1's PR #23 review. Both were flagged as non-blockers with no current offenders; this lands the robustness cleanly before they become active drift.

## Gaps closed

### 1. Raw string literals (`r"..."` / `r#"..."#`) in top-level fn bodies

`skip_string` uses bare `"` as delimiter, incompatible with raw-string termination (`"#`). A raw string containing `{` or `}` could silently corrupt brace counting — dropping the fn from the drift map (silent miss) or extracting a wrong body (silent drift false-result).

**Fix — Option B (fail-loud, not full raw-string support):**
- New `body_contains_raw_string_token` scans each extracted body with the same string/char/comment skippers as `match_balanced_brace`, panics on raw-string prefix at a token boundary.
- Scoped to *extracted* top-level fn bodies (Refinement 1), not whole-file — so raw strings inside `mod tests {...}` / impl blocks / etc. that the column-0 parser never enters do **not** false-fail. `src/mcp/handlers.rs` L787/L833 (both inside `mod tests`) cleanly skipped.
- Panic message points at the fix path: either move the raw string out, or upgrade `skip_string` and remove this guard.

### 2. `extern "C" fn` / `extern "Rust" fn` / any quoted-ABI variant

Existing qualifier stripper only matched bare `extern ` — any `extern "ABI" fn` at column 0 was silently dropped. Particularly dangerous since FFI exports are where drift between two files causes the most damage.

**Fix:** new `strip_extern_maybe_abi` replaces the bare-`extern` prefix strip. Consumes `extern ` plus the optional quoted ABI clause.

## Defense-in-depth: panic on silent drop

If `find_body_brace` or `match_balanced_brace` returns None *after* `detect_fn_name` already matched, the detector now panics with a parser-limitation hint. Covers the pathological case where raw-string miscount corrupts brace counting so badly that no closing `}` is found at all (guard #1 wouldn't fire because the extracted body range may be truncated). Prior behavior: silently advance line-by-line.

## Tests (3 new)

| Test | Purpose |
|------|---------|
| `raw_string_in_top_level_fn_fails_loudly` | `#[should_panic(expected = "raw string literal")]` — pins the fail-loud contract. |
| `raw_string_in_indented_block_is_ignored` | Scope pin: raw strings inside `mod tests {...}` do NOT trigger. Prevents regression on `src/mcp/handlers.rs` L787/L833. |
| `extern_abi_fn_detected` | `extern "C" fn` + `extern "Rust" fn` both register; divergent bodies detected correctly. |

## Scope discipline

- Raw-string support itself is **not** implemented (Option A deferred). Guard docstring points future authors at the upgrade path if a top-level fn ever needs a raw string.
- Refinement 1 (body-scope scan) picked over whole-file scan specifically to avoid false-fail on `src/mcp/handlers.rs` tests.
- Follows Task #9 Option C's "closed loop, don't over-engineer" basis.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release` — **625 passed / 0 failed** across 10 test binaries
- [x] `tests/no_dual_track_drift.rs`: **5/5 pass** (2 existing + 3 new), including `#[should_panic]` verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)