### PR TITLE
feat(layout): cross-tab pane move via drag, keyboard, and MCP

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -2,7 +2,7 @@
 
 use super::HandlerCtx;
 use crate::agent;
-use crate::api::{ApiEvent, LayoutHint};
+use crate::api::{ApiEvent, LayoutHint, PaneMoveSplitDir};
 use serde_json::{json, Value};
 
 pub(crate) fn handle_inject(params: &Value, ctx: &HandlerCtx) -> Value {
@@ -188,4 +188,45 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         }
         Err(e) => json!({"ok": false, "error": format!("{e}")}),
     }
+}
+
+/// Relocate the pane currently hosting `agent` into `target_tab`.
+///
+/// If the target tab exists, the moved pane splits the target tab's focused
+/// pane along `split_dir` (default: horizontal). If the target tab does not
+/// exist, a new tab named `target_tab` is created with the moved pane as its
+/// root. `split_dir` is ignored in the new-tab case.
+///
+/// The actual layout mutation happens in the TUI event loop — this handler
+/// only validates inputs and emits `ApiEvent::PaneMoved`. Daemon mode (no
+/// notifier) is a no-op and still returns `{"ok": true}`, matching the
+/// semantics of other layout-affecting MCP methods.
+pub(crate) fn handle_move_pane(params: &Value, ctx: &HandlerCtx) -> Value {
+    let agent_name = match params["agent"].as_str() {
+        Some(n) => n,
+        None => return json!({"ok": false, "error": "missing agent"}),
+    };
+    if let Err(e) = agent::validate_name(agent_name) {
+        return json!({"ok": false, "error": e});
+    }
+    let target_tab = match params["target_tab"].as_str() {
+        Some(t) if !t.is_empty() => t,
+        _ => return json!({"ok": false, "error": "missing target_tab"}),
+    };
+    let split_dir = PaneMoveSplitDir::parse(params["split_dir"].as_str().unwrap_or("horizontal"));
+
+    if let Some(n) = ctx.notifier {
+        n.notify(ApiEvent::PaneMoved {
+            agent: agent_name.to_string(),
+            target_tab: target_tab.to_string(),
+            split_dir,
+        });
+    }
+    crate::event_log::log(
+        ctx.home,
+        "move_pane",
+        agent_name,
+        &format!("target_tab={target_tab} split={split_dir:?}"),
+    );
+    json!({"ok": true})
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -43,6 +43,36 @@ pub enum ApiEvent {
         added: Vec<String>,
         removed: Vec<String>,
     },
+    /// A `move_pane` MCP call asked for the pane displaying `agent` to be
+    /// relocated into `target_tab`. If the target tab exists the pane is
+    /// grouped with it; otherwise a new tab with that name is created. Lets
+    /// agents orchestrate team composition without the user dragging panes
+    /// by hand — e.g. a supervisor adding a freshly-spawned reviewer into
+    /// the existing team's tab.
+    PaneMoved {
+        agent: String,
+        target_tab: String,
+        split_dir: PaneMoveSplitDir,
+    },
+}
+
+/// Direction to split the destination tab's focused pane when the target tab
+/// already exists. Ignored when a new tab is created (the moved pane becomes
+/// the tab's root either way).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PaneMoveSplitDir {
+    #[default]
+    Horizontal,
+    Vertical,
+}
+
+impl PaneMoveSplitDir {
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "vertical" | "v" => Self::Vertical,
+            _ => Self::Horizontal,
+        }
+    }
 }
 
 /// Layout hint for newly created instances. Parsed at the API boundary so
@@ -168,6 +198,7 @@ pub mod method {
     pub const DEREGISTER_EXTERNAL: &str = "deregister_external";
     pub const CREATE_TEAM: &str = "create_team";
     pub const UPDATE_TEAM: &str = "update_team";
+    pub const MOVE_PANE: &str = "move_pane";
     pub const SHUTDOWN: &str = "shutdown";
 }
 
@@ -320,6 +351,7 @@ fn handle_session(
             }
             method::CREATE_TEAM => handlers::team::handle_create_team(params, &ctx),
             method::UPDATE_TEAM => handlers::team::handle_update_team(params, &ctx),
+            method::MOVE_PANE => handlers::instance::handle_move_pane(params, &ctx),
             method::SHUTDOWN => {
                 tracing::info!("API shutdown requested");
                 shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -1510,6 +1542,87 @@ mod tests {
         // No spawns → no TeamCreated event
         let events = notifier.take();
         assert_eq!(events.len(), 0, "no spawns should not emit TeamCreated");
+        stop_server(&shutdown, &home);
+    }
+
+    // -----------------------------------------------------------------------
+    // MOVE_PANE dispatch coverage
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_move_pane_missing_agent() {
+        let (port, home, _n, shutdown) = start_test_server("mp-noagent");
+        let resp = api_request(
+            port,
+            &home,
+            &json!({"method": "move_pane", "params": {"target_tab": "t"}}),
+        );
+        assert_eq!(resp["ok"], false);
+        assert!(resp["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("missing agent")));
+        stop_server(&shutdown, &home);
+    }
+
+    #[test]
+    fn dispatch_move_pane_missing_target_tab() {
+        let (port, home, _n, shutdown) = start_test_server("mp-notab");
+        let resp = api_request(
+            port,
+            &home,
+            &json!({"method": "move_pane", "params": {"agent": "a"}}),
+        );
+        assert_eq!(resp["ok"], false);
+        assert!(resp["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("missing target_tab")));
+        stop_server(&shutdown, &home);
+    }
+
+    #[test]
+    fn dispatch_move_pane_emits_pane_moved_default_horizontal() {
+        let (port, home, notifier, shutdown) = start_test_server("mp-emit-h");
+        let resp = api_request(
+            port,
+            &home,
+            &json!({"method": "move_pane", "params": {"agent": "a1", "target_tab": "team-x"}}),
+        );
+        assert_eq!(resp["ok"], true);
+        let events = notifier.take();
+        assert_eq!(events.len(), 1, "expected 1 event, got {events:?}");
+        let ApiEvent::PaneMoved {
+            agent,
+            target_tab,
+            split_dir,
+        } = &events[0]
+        else {
+            panic!("expected PaneMoved, got {:?}", events[0])
+        };
+        assert_eq!(agent, "a1");
+        assert_eq!(target_tab, "team-x");
+        assert_eq!(*split_dir, PaneMoveSplitDir::Horizontal);
+        stop_server(&shutdown, &home);
+    }
+
+    #[test]
+    fn dispatch_move_pane_parses_vertical_split() {
+        let (port, home, notifier, shutdown) = start_test_server("mp-emit-v");
+        let resp = api_request(
+            port,
+            &home,
+            &json!({"method": "move_pane", "params": {
+                "agent": "a2",
+                "target_tab": "team-y",
+                "split_dir": "vertical"
+            }}),
+        );
+        assert_eq!(resp["ok"], true);
+        let events = notifier.take();
+        assert_eq!(events.len(), 1);
+        let ApiEvent::PaneMoved { split_dir, .. } = &events[0] else {
+            panic!("expected PaneMoved");
+        };
+        assert_eq!(*split_dir, PaneMoveSplitDir::Vertical);
         stop_server(&shutdown, &home);
     }
 }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -92,6 +92,34 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
                 selected: ctx.layout.active,
             });
         }
+        Action::MovePaneMenu => {
+            // Anchor the menu to the currently focused pane. Opening the
+            // menu with no focused pane (e.g. empty layout) is a no-op.
+            let source = ctx
+                .layout
+                .active_tab()
+                .and_then(|t| t.focused_pane().map(|p| (t, p.id)));
+            if let Some((_tab, pane_id)) = source {
+                let active = ctx.layout.active;
+                out.new_overlay = Some(Overlay::MovePaneTarget {
+                    // Default selection: first tab that isn't the source, so
+                    // Enter immediately does something useful. Fall back to
+                    // the "New tab" slot (at index == tabs.len()) when the
+                    // source is the only tab.
+                    selected: if ctx.layout.tabs.len() > 1 {
+                        if active == 0 {
+                            1
+                        } else {
+                            0
+                        }
+                    } else {
+                        ctx.layout.tabs.len()
+                    },
+                    source_pane_id: pane_id,
+                    source_tab_idx: active,
+                });
+            }
+        }
         Action::SplitVertical => {
             out.new_overlay = Some(Overlay::SplitMenu {
                 items: super::build_menu_items(ctx.fleet_path, ctx.registry),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -299,6 +299,13 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 Overlay::TabList { selected } => {
                     render::render_tab_list(frame, &layout, *selected);
                 }
+                Overlay::MovePaneTarget {
+                    selected,
+                    source_tab_idx,
+                    ..
+                } => {
+                    render::render_move_pane_target(frame, &layout, *selected, *source_tab_idx);
+                }
                 Overlay::Help => {
                     render::render_help(frame);
                 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -10,7 +10,7 @@ use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
 use crate::agent::AgentRegistry;
-use crate::layout::{Layout, SplitBorderHit, SplitDir};
+use crate::layout::{DragTabTarget, Layout, MovePlacement, SplitBorderHit, SplitDir};
 
 use super::overlay::Overlay;
 
@@ -162,13 +162,37 @@ fn handle_drag(mouse: MouseEvent, layout: &mut Layout, state: &mut MouseState) {
         .active_tab()
         .is_some_and(|t| t.dragging_pane.is_some())
     {
-        let target = layout.active_tab().and_then(|tab| {
-            let source = tab.dragging_pane?;
-            tab.pane_at(mouse.column, mouse.row)
-                .filter(|&id| id != source)
-        });
-        if let Some(tab) = layout.active_tab_mut() {
-            tab.drag_target = target;
+        // Pointer on the tab bar (row 0) is a cross-tab drop intent; pointer
+        // inside the pane area is an intra-tab swap intent. Set exactly one
+        // of `drag_target_tab` / `drag_target` per mouse position so that
+        // render + mouse-up dispatch unambiguously.
+        if mouse.row == 0 {
+            let hit = tab_bar_hit_test(layout, mouse.column);
+            let active_idx = layout.active;
+            let tab_target = match hit {
+                // Hovering over the source's own tab is not a move target —
+                // release on own tab is a no-op, matching Chrome's tab reorder UX.
+                Some(TabBarClick::Tab(idx)) if idx != active_idx => {
+                    Some(DragTabTarget::ExistingTab(idx))
+                }
+                Some(TabBarClick::Tab(_)) => None,
+                Some(TabBarClick::NewTab) => Some(DragTabTarget::NewTab),
+                None => None,
+            };
+            if let Some(tab) = layout.active_tab_mut() {
+                tab.drag_target_tab = tab_target;
+                tab.drag_target = None;
+            }
+        } else {
+            let target = layout.active_tab().and_then(|tab| {
+                let source = tab.dragging_pane?;
+                tab.pane_at(mouse.column, mouse.row)
+                    .filter(|&id| id != source)
+            });
+            if let Some(tab) = layout.active_tab_mut() {
+                tab.drag_target = target;
+                tab.drag_target_tab = None;
+            }
         }
     } else {
         handle_selection(layout, &mouse);
@@ -191,15 +215,66 @@ fn handle_up(
         .is_some_and(|t| t.dragging_pane.is_some())
     {
         let source_id = layout.active_tab().and_then(|t| t.dragging_pane);
-        let target_id = layout.active_tab().and_then(|t| t.drag_target);
-        if let (Some(src), Some(tgt)) = (source_id, target_id) {
+        let target_pane = layout.active_tab().and_then(|t| t.drag_target);
+        let target_tab = layout.active_tab().and_then(|t| t.drag_target_tab);
+        let from_tab_idx = layout.active;
+
+        // Cross-tab drop takes precedence over intra-tab swap — the two are
+        // populated mutually exclusively by `handle_drag`, but check in order
+        // anyway so a stale field can't misfire.
+        if let (Some(src), Some(tab_target)) = (source_id, target_tab) {
+            match tab_target {
+                DragTabTarget::ExistingTab(to_idx) => {
+                    if let Some(new_idx) = layout.move_pane_across_tabs(
+                        from_tab_idx,
+                        src,
+                        MovePlacement::SplitFocused {
+                            to_tab: to_idx,
+                            dir: SplitDir::Horizontal,
+                        },
+                    ) {
+                        out.new_last_tab = Some(from_tab_idx);
+                        // Follow the moved pane: the user's attention is on
+                        // what they just dropped, so jump to its new tab.
+                        layout.goto_tab(new_idx);
+                        out.needs_resize = true;
+                    }
+                }
+                DragTabTarget::NewTab => {
+                    // Name the new tab after the pane's agent for a sensible
+                    // default. User can rename later via `:rename-tab` etc.
+                    let name = layout
+                        .active_tab()
+                        .and_then(|t| t.root().find_pane(src))
+                        .map(|p| p.agent_name.clone())
+                        .unwrap_or_else(|| "new".to_string());
+                    if layout
+                        .move_pane_across_tabs(from_tab_idx, src, MovePlacement::NewTab { name })
+                        .is_some()
+                    {
+                        out.new_last_tab = Some(from_tab_idx);
+                        out.needs_resize = true;
+                    }
+                }
+            }
+            // The tab we cleared might not exist any more (single-pane source
+            // was removed) — guard the clear via the current active tab.
+            if let Some(tab) = layout.active_tab_mut() {
+                tab.clear_drag();
+            }
+        } else if let (Some(src), Some(tgt)) = (source_id, target_pane) {
             if let Some(tab) = layout.active_tab_mut() {
                 crate::layout::swap_panes(tab.root_mut(), src, tgt);
             }
             out.needs_resize = true;
-        }
-        if let Some(tab) = layout.active_tab_mut() {
-            tab.clear_drag();
+            if let Some(tab) = layout.active_tab_mut() {
+                tab.clear_drag();
+            }
+        } else {
+            // Drop with no target: just cancel the drag.
+            if let Some(tab) = layout.active_tab_mut() {
+                tab.clear_drag();
+            }
         }
     } else {
         handle_selection(layout, &mouse);

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -257,24 +257,18 @@ fn handle_up(
                     }
                 }
             }
-            // The tab we cleared might not exist any more (single-pane source
-            // was removed) — guard the clear via the current active tab.
-            if let Some(tab) = layout.active_tab_mut() {
-                tab.clear_drag();
-            }
         } else if let (Some(src), Some(tgt)) = (source_id, target_pane) {
             if let Some(tab) = layout.active_tab_mut() {
                 crate::layout::swap_panes(tab.root_mut(), src, tgt);
             }
             out.needs_resize = true;
-            if let Some(tab) = layout.active_tab_mut() {
-                tab.clear_drag();
-            }
-        } else {
-            // Drop with no target: just cancel the drag.
-            if let Some(tab) = layout.active_tab_mut() {
-                tab.clear_drag();
-            }
+        }
+        // Clear drag state on the *current* active tab — the source tab may
+        // have been removed (single-pane cross-tab move) so we can't clear by
+        // from_tab_idx. No-target and intra-tab branches share this tail;
+        // the cross-tab branch also lands here for the same reason.
+        if let Some(tab) = layout.active_tab_mut() {
+            tab.clear_drag();
         }
     } else {
         handle_selection(layout, &mouse);
@@ -420,5 +414,91 @@ fn copy_to_clipboard(text: &str) {
     match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(text)) {
         Ok(()) => {}
         Err(e) => tracing::warn!(error = %e, "clipboard copy failed"),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::layout::{Pane, PaneSource, Tab};
+    use crate::vterm::VTerm;
+    use crossterm::event::KeyModifiers;
+
+    fn leaf(id: usize, agent: &str) -> Pane {
+        Pane {
+            agent_name: agent.to_string(),
+            vterm: VTerm::new(10, 10),
+            rx: crossbeam::channel::bounded(1).1,
+            id,
+            backend: None,
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            selection: None,
+            source: PaneSource::Local,
+        }
+    }
+
+    fn up_event() -> MouseEvent {
+        // handle_up ignores `mouse` in the dragging_pane branch, so column/row
+        // are placeholders. The Up(Left) kind is what routes the event.
+        MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        }
+    }
+
+    /// Pins the dispatch order in `handle_up`: when both intra-tab swap and
+    /// cross-tab drop targets are populated, cross-tab wins. `handle_drag`
+    /// sets them mutually exclusively today, but this test is the belt to
+    /// that suspender — a future refactor that re-introduces both fields
+    /// simultaneously must not silently downgrade a tab-bar drop into an
+    /// in-place swap.
+    #[test]
+    fn handle_up_cross_tab_drop_wins_over_intra_tab_swap() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("src".to_string(), leaf(1, "a")));
+        layout.tabs[0].split_focused(SplitDir::Vertical, leaf(2, "b"));
+        layout.add_tab(Tab::new("dst".to_string(), leaf(3, "c")));
+        layout.active = 0;
+        layout.tabs[0].focus_id = 2;
+        layout.tabs[0].dragging_pane = Some(2);
+        // Stale intra-tab target — pane 1 lives in the same tab.
+        layout.tabs[0].drag_target = Some(1);
+        // Fresh cross-tab target — release over the "dst" tab label.
+        layout.tabs[0].drag_target_tab = Some(DragTabTarget::ExistingTab(1));
+
+        let mut state = MouseState::default();
+        let mut out = MouseOutcome::default();
+        handle_up(up_event(), &mut layout, &mut state, &mut out);
+
+        // Pane 2 ("b") must have moved into "dst", NOT swapped with pane 1.
+        assert_eq!(layout.tabs.len(), 2);
+        assert_eq!(layout.tabs[0].root().pane_count(), 1);
+        assert!(
+            !layout.tabs[0].root().has_agent("b"),
+            "pane b must leave src tab"
+        );
+        assert!(
+            layout.tabs[0].root().has_agent("a"),
+            "pane a must stay in src (not swapped)"
+        );
+        assert_eq!(layout.tabs[1].root().pane_count(), 2);
+        assert!(
+            layout.tabs[1].root().has_agent("b"),
+            "pane b must land in dst"
+        );
+        // Focus follows the moved pane's new tab.
+        assert_eq!(layout.active, 1);
+        assert!(out.needs_resize);
+        // Drag state cleared on the (now active) dest tab.
+        assert!(layout.tabs[1].dragging_pane.is_none());
+        assert!(layout.tabs[1].drag_target.is_none());
+        assert!(layout.tabs[1].drag_target_tab.is_none());
     }
 }

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -53,6 +53,20 @@ pub(super) enum Overlay {
     TabList {
         selected: usize,
     },
+    /// Move-pane destination picker. Lists all tabs plus a trailing
+    /// "[+] New tab" slot. Enter applies `Layout::move_pane_across_tabs`
+    /// with the focused pane as source.
+    MovePaneTarget {
+        /// 0..tabs.len() → move into that tab. == tabs.len() → new tab.
+        selected: usize,
+        /// Source pane to move. Captured on overlay open so a subsequent
+        /// mouse click that changes focus (while the overlay is modal,
+        /// this shouldn't happen, but be defensive) can't retarget the move.
+        source_pane_id: usize,
+        /// Source tab index at overlay-open time. Same defensive capture as
+        /// `source_pane_id`; `move_pane_across_tabs` re-verifies existence.
+        source_tab_idx: usize,
+    },
     Help,
     /// Keyboard scroll mode (j/k/PgUp/PgDn). Pane's scroll_offset is used directly.
     Scroll,
@@ -372,6 +386,70 @@ pub(super) fn handle_key(
             }
             _ => {}
         },
+        Overlay::MovePaneTarget {
+            ref mut selected,
+            source_pane_id,
+            source_tab_idx,
+        } => {
+            // List length = tabs.len() + 1 (trailing "New tab" entry). The
+            // "New tab" slot is always valid; tab slots other than source
+            // are valid move targets. `selected` can legally equal tabs.len().
+            let list_len = ctx.layout.tabs.len() + 1;
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') if *selected > 0 => {
+                    *selected -= 1;
+                }
+                KeyCode::Down | KeyCode::Char('j') if *selected + 1 < list_len => {
+                    *selected += 1;
+                }
+                KeyCode::Enter => {
+                    let src_pane = *source_pane_id;
+                    let src_tab = *source_tab_idx;
+                    let sel = *selected;
+                    let tabs_count = ctx.layout.tabs.len();
+                    *overlay = Overlay::None;
+                    if sel == tabs_count {
+                        // New tab: name after the pane's agent for a sensible default.
+                        let name = ctx
+                            .layout
+                            .tabs
+                            .get(src_tab)
+                            .and_then(|t| t.root().find_pane(src_pane))
+                            .map(|p| p.agent_name.clone())
+                            .unwrap_or_else(|| "new".to_string());
+                        if ctx
+                            .layout
+                            .move_pane_across_tabs(
+                                src_tab,
+                                src_pane,
+                                crate::layout::MovePlacement::NewTab { name },
+                            )
+                            .is_some()
+                        {
+                            outcome.needs_resize = true;
+                        }
+                    } else if sel != src_tab {
+                        if let Some(new_idx) = ctx.layout.move_pane_across_tabs(
+                            src_tab,
+                            src_pane,
+                            crate::layout::MovePlacement::SplitFocused {
+                                to_tab: sel,
+                                dir: crate::layout::SplitDir::Horizontal,
+                            },
+                        ) {
+                            // Follow the pane — the user just pointed at this tab.
+                            ctx.layout.goto_tab(new_idx);
+                            outcome.needs_resize = true;
+                        }
+                    }
+                    // sel == src_tab: no-op (already in that tab).
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    *overlay = Overlay::None;
+                }
+                _ => {}
+            }
+        }
         Overlay::Help => {
             *overlay = Overlay::None;
         }

--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -5,7 +5,7 @@
 //! the layout accordingly — auto-creating or removing tabs/panes.
 
 use crate::agent::{self, AgentRegistry};
-use crate::layout::{Layout, SplitDir, Tab};
+use crate::layout::{Layout, MovePlacement, SplitDir, Tab};
 
 /// Events sent from the API server to the TUI event loop when agents or teams
 /// are created/deleted via MCP tools. The TUI reacts by auto-creating or
@@ -39,6 +39,15 @@ pub(crate) enum TuiEvent {
         name: String,
         added: Vec<String>,
         removed: Vec<String>,
+    },
+    /// Emitted by the `move_pane` MCP tool. Relocates the pane currently
+    /// displaying `agent` into `target_tab`: if the tab exists, the pane
+    /// splits its focused pane along `split_dir`; otherwise a new tab named
+    /// `target_tab` is created with the moved pane as root (split_dir ignored).
+    PaneMoved {
+        agent: String,
+        target_tab: String,
+        split_dir: SplitDir,
     },
 }
 
@@ -92,6 +101,21 @@ impl crate::api::ApiNotifier for TuiNotifier {
                 added,
                 removed,
             },
+            crate::api::ApiEvent::PaneMoved {
+                agent,
+                target_tab,
+                split_dir,
+            } => {
+                let dir = match split_dir {
+                    crate::api::PaneMoveSplitDir::Horizontal => SplitDir::Horizontal,
+                    crate::api::PaneMoveSplitDir::Vertical => SplitDir::Vertical,
+                };
+                TuiEvent::PaneMoved {
+                    agent,
+                    target_tab,
+                    split_dir: dir,
+                }
+            }
         };
         if let Err(e) = self.tx.try_send(tui_event) {
             tracing::warn!(error = %e, "TUI event send failed");
@@ -137,6 +161,54 @@ pub(super) fn handle_tui_event(
         } => {
             handle_team_members_changed(&name, &added, &removed, layout, registry, wakeup_tx);
         }
+        TuiEvent::PaneMoved {
+            agent,
+            target_tab,
+            split_dir,
+        } => {
+            handle_pane_moved(&agent, &target_tab, split_dir, layout);
+        }
+    }
+}
+
+/// Apply a `PaneMoved` event — find the pane displaying `agent` and relocate
+/// it into `target_tab`. If the target tab exists the moved pane splits its
+/// focused pane along `split_dir`; otherwise a new tab named `target_tab` is
+/// created and the moved pane becomes its root.
+///
+/// No-op if the agent is not displayed anywhere, the source is the only pane
+/// in the only tab (detach would leave layout empty), or the target tab is the
+/// same as the source tab and contains only this pane.
+fn handle_pane_moved(agent: &str, target_tab: &str, split_dir: SplitDir, layout: &mut Layout) {
+    tracing::debug!(
+        agent,
+        target_tab,
+        dir = ?split_dir,
+        "handle_pane_moved"
+    );
+    let (from_idx, pane_id) = match layout.find_agent_pane(agent) {
+        Some(s) => s,
+        None => {
+            tracing::warn!(agent, "handle_pane_moved: agent not displayed, ignored");
+            return;
+        }
+    };
+
+    let placement = match layout.tabs.iter().position(|t| t.name == target_tab) {
+        Some(to_idx) if to_idx == from_idx => return,
+        Some(to_idx) => MovePlacement::SplitFocused {
+            to_tab: to_idx,
+            dir: split_dir,
+        },
+        None => MovePlacement::NewTab {
+            name: target_tab.to_string(),
+        },
+    };
+    if layout
+        .move_pane_across_tabs(from_idx, pane_id, placement)
+        .is_none()
+    {
+        tracing::warn!(agent, target_tab, "handle_pane_moved: move refused");
     }
 }
 
@@ -422,56 +494,32 @@ fn handle_team_members_changed(
         return;
     }
 
-    // Strip each incoming member from any other tab first — a pane can only
-    // live in one place, and split_focused would otherwise leave the old pane
-    // subscribed. Skip the team tab itself to preserve an already-grouped pane.
-    for member in &to_attach {
-        let already_in_team = layout
-            .tabs
-            .iter()
-            .any(|tab| tab.name == team_name && tab.root().has_agent(member));
-        if already_in_team {
-            continue;
-        }
-        // Remove from every other tab (there should be at most one, but loop
-        // to stay safe if dedup ever slips).
-        loop {
-            let target = layout.tabs.iter().enumerate().find_map(|(tab_idx, tab)| {
-                if tab.name == team_name {
-                    None
-                } else {
-                    tab.root()
-                        .find_pane_id_by_agent(member)
-                        .map(|pane_id| (tab_idx, pane_id))
-                }
-            });
-            let (tab_idx, pane_id) = match target {
-                Some(t) => t,
-                None => break,
-            };
-            if layout.tabs[tab_idx].root().pane_count() <= 1 {
-                layout.close_tab(tab_idx);
-            } else {
-                layout.tabs[tab_idx].close_pane_by_id(pane_id);
-            }
-        }
-    }
-
-    // Attach each new member to the team tab. If the team tab doesn't exist
-    // yet (e.g. add into a freshly-created empty team), build it from the
-    // first member.
+    // Add phase: move each incoming member into the team tab. Prefer MOVING
+    // an existing pane (preserves VTerm scrollback and PTY subscription) over
+    // rebuilding via attach_pane. The team tab may not exist yet — establish
+    // it lazily from the first successful incoming member.
     let mut team_tab_idx = layout.tabs.iter().position(|tab| tab.name == team_name);
     let mut iter = to_attach.iter();
     if team_tab_idx.is_none() {
-        // Find first member we can actually attach. `by_ref` keeps the
-        // remaining members available for the split loop below.
         for member in iter.by_ref() {
+            if let Some((from_idx, pane_id)) = layout.find_agent_pane(member) {
+                if let Some(new_idx) = layout.move_pane_across_tabs(
+                    from_idx,
+                    pane_id,
+                    MovePlacement::NewTab {
+                        name: team_name.to_string(),
+                    },
+                ) {
+                    team_tab_idx = Some(new_idx);
+                    break;
+                }
+            }
+            // Member is registered but not displayed — synthesize a fresh pane.
             match super::pane_factory::attach_pane(
                 member, registry, cols, pane_rows, wakeup_tx, layout,
             ) {
                 Ok(pane) => {
-                    let tab = Tab::new(team_name.to_string(), pane);
-                    layout.add_tab(tab);
+                    layout.add_tab(Tab::new(team_name.to_string(), pane));
                     team_tab_idx = Some(layout.tabs.len() - 1);
                     break;
                 }
@@ -481,7 +529,7 @@ fn handle_team_members_changed(
             }
         }
     }
-    let tab_idx = match team_tab_idx {
+    let mut tab_idx = match team_tab_idx {
         Some(i) => i,
         None => {
             tracing::warn!(
@@ -496,6 +544,26 @@ fn handle_team_members_changed(
         if layout.tabs[tab_idx].root().has_agent(member) {
             continue;
         }
+        // Source must live in a different tab; otherwise `has_agent` above
+        // would have caught it.
+        let source = layout.tabs.iter().enumerate().find_map(|(i, t)| {
+            (i != tab_idx)
+                .then(|| t.root().find_pane_id_by_agent(member).map(|p| (i, p)))
+                .flatten()
+        });
+        if let Some((from_idx, pane_id)) = source {
+            if let Some(new_idx) = layout.move_pane_across_tabs(
+                from_idx,
+                pane_id,
+                MovePlacement::SplitFocused {
+                    to_tab: tab_idx,
+                    dir: SplitDir::Horizontal,
+                },
+            ) {
+                tab_idx = new_idx;
+            }
+            continue;
+        }
         match super::pane_factory::attach_pane(member, registry, cols, pane_rows, wakeup_tx, layout)
         {
             Ok(pane) => {
@@ -506,12 +574,6 @@ fn handle_team_members_changed(
             }
         }
     }
-
-    tracing::info!(
-        team = team_name,
-        tabs_after = layout.tabs.len(),
-        "handle_team_members_changed end"
-    );
 }
 
 /// Remove ALL panes for the given agent from every tab. Cleans up empty tabs.

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -35,6 +35,8 @@ pub enum Action {
     NextLayout,
     RenameTab,
     RenamePane,
+    /// Open the move-pane target menu (cross-tab relocation of the focused pane).
+    MovePaneMenu,
     ListTabs,
     ScrollMode,
     CommandPalette,
@@ -147,6 +149,10 @@ fn dispatch_prefix(key: KeyEvent) -> Action {
         KeyCode::Char('z') => Action::ToggleZoom,
         KeyCode::Char(' ') => Action::NextLayout,
         KeyCode::Char('.') => Action::RenamePane,
+        // tmux uses `!` for break-pane (split pane to new window). We reuse
+        // the same key, but open a menu that lets the user pick an EXISTING
+        // tab OR spawn a new one — covering both move-pane and break-pane.
+        KeyCode::Char('!') => Action::MovePaneMenu,
 
         // Directional pane focus (plain arrows) / resize (Alt+arrows).
         // Alt+Arrow encoding depends on the terminal (macOS Terminal, Ghostty,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -119,7 +119,7 @@ impl Pane {
 }
 
 /// Split direction.
-#[derive(Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum SplitDir {
     Horizontal,
     Vertical,
@@ -786,6 +786,19 @@ pub enum Direction {
     Right,
 }
 
+/// Where a title-bar drag is currently hovering on the tab bar. Distinct from
+/// `drag_target` (which names a pane in the *current* tab for intra-tab swap):
+/// this field represents a cross-tab drop intent that will be realized on
+/// mouse-up via `Layout::move_pane_across_tabs`.
+#[derive(Clone, Copy, PartialEq)]
+pub enum DragTabTarget {
+    /// Pointer is over the tab at this index. On drop, move the pane into that tab.
+    ExistingTab(usize),
+    /// Pointer is past the last tab / over the `[+]` button area. On drop,
+    /// create a new tab named after the pane's agent.
+    NewTab,
+}
+
 /// A tab containing a tree of panes.
 pub struct Tab {
     pub name: String,
@@ -799,8 +812,12 @@ pub struct Tab {
     pub last_layout: Option<LayoutPreset>,
     /// Pane currently being dragged by title bar (drag-to-swap).
     pub dragging_pane: Option<usize>,
-    /// Drop target pane during title bar drag.
+    /// Drop target pane during title bar drag (intra-tab swap).
     pub drag_target: Option<usize>,
+    /// Cross-tab drop target during title bar drag. Set when the pointer is
+    /// over the tab bar while a pane is being dragged; mutually exclusive with
+    /// `drag_target` (each mouse move picks one based on pointer position).
+    pub drag_target_tab: Option<DragTabTarget>,
 }
 
 impl Tab {
@@ -816,6 +833,7 @@ impl Tab {
             last_layout: None,
             dragging_pane: None,
             drag_target: None,
+            drag_target_tab: None,
         }
     }
 
@@ -832,6 +850,7 @@ impl Tab {
             last_layout: None,
             dragging_pane: None,
             drag_target: None,
+            drag_target_tab: None,
         }
     }
 
@@ -1006,10 +1025,11 @@ impl Tab {
         None
     }
 
-    /// Reset both drag fields after a title-bar drag completes or aborts.
+    /// Reset all drag fields after a title-bar drag completes or aborts.
     pub fn clear_drag(&mut self) {
         self.dragging_pane = None;
         self.drag_target = None;
+        self.drag_target_tab = None;
     }
 
     /// Clear all in-progress UI state (selection tracking + drag tracking).
@@ -1019,6 +1039,7 @@ impl Tab {
         self.selecting_pane = None;
         self.dragging_pane = None;
         self.drag_target = None;
+        self.drag_target_tab = None;
     }
 
     /// Close the focused pane. Returns the removed pane's agent_name.
@@ -1047,6 +1068,58 @@ impl Tab {
         }
         removed.map(|p| p.agent_name)
     }
+
+    /// Detach a pane from this tab's tree without destroying its VTerm or PTY
+    /// subscription, returning the full `Pane` so the caller can reinsert it
+    /// into another tab. Returns `None` when `pane_id` is not in this tab, or
+    /// when it is the sole pane (the tab would be left empty — callers moving
+    /// the last pane must consume the whole tab via `Layout::move_pane_across_tabs`
+    /// which handles source-tab removal).
+    pub fn detach_pane(&mut self, pane_id: usize) -> Option<Pane> {
+        if self.root().pane_count() <= 1 {
+            return None;
+        }
+        self.root().find_pane(pane_id)?;
+        let ids = self.root().pane_ids();
+        let next_id = ids
+            .iter()
+            .find(|&&id| id != pane_id)
+            .copied()
+            .unwrap_or(pane_id);
+
+        let root = self.root.take().expect("root is always Some");
+        let (new_root, removed) = remove_from_tree(root, pane_id);
+        self.root = Some(new_root);
+        if self.focus_id == pane_id {
+            self.focus_id = next_id;
+        }
+        // Clear transient UI state referencing the departing pane so a
+        // half-finished drag/select doesn't resume against a pane that
+        // no longer lives here. `drag_target_tab` is cleared alongside
+        // `dragging_pane` because a cross-tab drop intent without a source
+        // pane is meaningless.
+        if self.dragging_pane == Some(pane_id) {
+            self.dragging_pane = None;
+            self.drag_target_tab = None;
+        }
+        if self.drag_target == Some(pane_id) {
+            self.drag_target = None;
+        }
+        if self.selecting_pane == Some(pane_id) {
+            self.selecting_pane = None;
+        }
+        removed
+    }
+}
+
+/// Where a moved pane should land in its new tab.
+pub enum MovePlacement {
+    /// Split the destination tab's focused pane in the given direction.
+    /// Used by team-update auto-grouping and the keyboard move-pane command.
+    SplitFocused { to_tab: usize, dir: SplitDir },
+    /// Create a brand-new tab whose sole pane is the moved pane. Used when
+    /// dragging a pane onto the tab bar's empty trailing area.
+    NewTab { name: String },
 }
 
 /// Top-level layout.
@@ -1128,6 +1201,93 @@ impl Layout {
             self.switch_active(self.tabs.len() - 1);
         }
         Some(tab)
+    }
+
+    /// Move a pane from one tab to another, preserving its VTerm, scrollback,
+    /// and PTY subscription (unlike close + attach, which rebuilds state).
+    ///
+    /// Behavior:
+    ///   - If `from_tab` has a single pane, the whole tab is removed and its
+    ///     lone pane is inserted into the destination (index-adjusted).
+    ///   - Otherwise the pane is detached in place via `Tab::detach_pane`.
+    ///   - `focus_id` of the destination tab is set to the moved pane. The
+    ///     active tab index is NOT changed — callers drive focus-switching
+    ///     explicitly.
+    ///
+    /// Returns `Some(new_dest_idx)` on success — the final index of the
+    /// destination tab after any source-tab removal. Returns `None` (and
+    /// leaves layout unchanged) for invalid indices, when source == dest,
+    /// or when the pane is missing from the source tab.
+    pub fn move_pane_across_tabs(
+        &mut self,
+        from_tab: usize,
+        pane_id: usize,
+        placement: MovePlacement,
+    ) -> Option<usize> {
+        if from_tab >= self.tabs.len() {
+            return None;
+        }
+        let split_target = match &placement {
+            MovePlacement::SplitFocused { to_tab, .. } => {
+                if *to_tab >= self.tabs.len() || *to_tab == from_tab {
+                    return None;
+                }
+                Some(*to_tab)
+            }
+            MovePlacement::NewTab { .. } => None,
+        };
+        self.tabs[from_tab].root().find_pane(pane_id)?;
+
+        let source_count = self.tabs[from_tab].root().pane_count();
+        let (pane, adjusted_to_tab) = if source_count == 1 {
+            let mut src = self.tabs.remove(from_tab);
+            let root = src.root.take().expect("root is always Some");
+            let pane = match root {
+                PaneNode::Leaf(boxed) => *boxed,
+                PaneNode::Split { .. } => {
+                    unreachable!("pane_count == 1 must be a Leaf root")
+                }
+            };
+            let adjusted_to = split_target.map(|t| if t > from_tab { t - 1 } else { t });
+            // Keep `active` pointing somewhere sensible after the removal.
+            if self.active == from_tab {
+                self.active = adjusted_to
+                    .unwrap_or(self.tabs.len())
+                    .min(self.tabs.len().saturating_sub(1));
+            } else if self.active > from_tab {
+                self.active -= 1;
+            }
+            (pane, adjusted_to)
+        } else {
+            let pane = self.tabs[from_tab]
+                .detach_pane(pane_id)
+                .expect("pre-checked find_pane + pane_count > 1");
+            (pane, split_target)
+        };
+
+        let moved_id = pane.id;
+        match placement {
+            MovePlacement::SplitFocused { dir, .. } => {
+                let dest = adjusted_to_tab.expect("SplitFocused always yields a dest index");
+                self.tabs[dest].split_focused(dir, pane);
+                self.tabs[dest].focus_id = moved_id;
+                Some(dest)
+            }
+            MovePlacement::NewTab { name } => {
+                self.add_tab(Tab::new(name, pane));
+                Some(self.tabs.len() - 1)
+            }
+        }
+    }
+
+    /// Find the `(tab_idx, pane_id)` hosting `agent`, if any. First match wins
+    /// — duplicates are a bug elsewhere (agent-name uniqueness is enforced by
+    /// the registry).
+    pub fn find_agent_pane(&self, agent: &str) -> Option<(usize, usize)> {
+        self.tabs
+            .iter()
+            .enumerate()
+            .find_map(|(i, t)| t.root().find_pane_id_by_agent(agent).map(|p| (i, p)))
     }
 }
 
@@ -1507,5 +1667,158 @@ mod tests {
             first_id,
             "last slot now holds the first pane"
         );
+    }
+
+    // --- detach_pane / move_pane_across_tabs ---
+
+    #[test]
+    fn detach_pane_refuses_sole_pane() {
+        // A lone pane can't be detached in-place because it would leave the
+        // tab with an empty root. Callers must consume the whole tab via
+        // Layout::move_pane_across_tabs instead.
+        let mut tab = Tab::new("t".to_string(), leaf(1, "a"));
+        assert!(tab.detach_pane(1).is_none());
+        assert_eq!(tab.root().pane_count(), 1);
+    }
+
+    #[test]
+    fn detach_pane_missing_id_returns_none() {
+        // Unknown pane id leaves the tree untouched.
+        let mut tab = Tab::new("t".to_string(), leaf(1, "a"));
+        assert!(tab.split_focused(SplitDir::Vertical, leaf(2, "b")));
+        assert!(tab.detach_pane(999).is_none());
+        assert_eq!(tab.root().pane_count(), 2);
+    }
+
+    #[test]
+    fn detach_pane_returns_pane_and_moves_focus() {
+        // Detaching the focused pane hands it back to the caller and moves
+        // focus to the sibling so subsequent input isn't orphaned.
+        let mut tab = Tab::new("t".to_string(), leaf(1, "a"));
+        assert!(tab.split_focused(SplitDir::Vertical, leaf(2, "b")));
+        tab.focus_id = 1;
+        let detached = tab.detach_pane(1).expect("pane 1 should detach");
+        assert_eq!(detached.agent_name, "a");
+        assert_eq!(tab.root().pane_count(), 1);
+        assert_eq!(tab.focus_id, 2, "focus must move to the sibling pane");
+    }
+
+    #[test]
+    fn detach_pane_clears_transient_state() {
+        // Drag/selection state that names the departing pane must be reset
+        // so a half-finished interaction doesn't resume against a gone pane.
+        let mut tab = Tab::new("t".to_string(), leaf(1, "a"));
+        assert!(tab.split_focused(SplitDir::Vertical, leaf(2, "b")));
+        tab.dragging_pane = Some(1);
+        tab.drag_target = Some(1);
+        tab.selecting_pane = Some(1);
+        let _ = tab.detach_pane(1).expect("detaches");
+        assert!(tab.dragging_pane.is_none());
+        assert!(tab.drag_target.is_none());
+        assert!(tab.selecting_pane.is_none());
+    }
+
+    #[test]
+    fn move_pane_across_tabs_same_tab_rejected() {
+        // from == to would collapse into an in-place move; swap_panes covers
+        // intra-tab reorder, so the cross-tab API refuses.
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("t0".to_string(), leaf(1, "a")));
+        layout.tabs[0].split_focused(SplitDir::Vertical, leaf(2, "b"));
+        assert!(layout
+            .move_pane_across_tabs(
+                0,
+                1,
+                MovePlacement::SplitFocused {
+                    to_tab: 0,
+                    dir: SplitDir::Vertical
+                }
+            )
+            .is_none());
+        assert_eq!(layout.tabs[0].root().pane_count(), 2);
+    }
+
+    #[test]
+    fn move_pane_across_tabs_split_focused_preserves_both_tabs() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("src".to_string(), leaf(1, "a")));
+        layout.tabs[0].split_focused(SplitDir::Vertical, leaf(2, "b"));
+        layout.add_tab(Tab::new("dst".to_string(), leaf(3, "c")));
+
+        let dest = layout
+            .move_pane_across_tabs(
+                0,
+                2,
+                MovePlacement::SplitFocused {
+                    to_tab: 1,
+                    dir: SplitDir::Horizontal,
+                },
+            )
+            .expect("move succeeds");
+        assert_eq!(dest, 1);
+        assert_eq!(layout.tabs.len(), 2);
+        assert_eq!(layout.tabs[0].root().pane_count(), 1);
+        assert!(!layout.tabs[0].root().has_agent("b"));
+        assert_eq!(layout.tabs[1].root().pane_count(), 2);
+        assert!(layout.tabs[1].root().has_agent("b"));
+        assert_eq!(layout.tabs[1].focus_id, 2);
+    }
+
+    #[test]
+    fn move_pane_across_tabs_single_pane_source_removes_tab() {
+        // Source tab disappears; returned dest index reflects the shift.
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("solo".to_string(), leaf(1, "a")));
+        layout.add_tab(Tab::new("dst".to_string(), leaf(2, "b")));
+        let dest = layout
+            .move_pane_across_tabs(
+                0,
+                1,
+                MovePlacement::SplitFocused {
+                    to_tab: 1,
+                    dir: SplitDir::Horizontal,
+                },
+            )
+            .expect("move succeeds");
+        assert_eq!(dest, 0, "destination shifted left after source removed");
+        assert_eq!(layout.tabs.len(), 1);
+        assert_eq!(layout.tabs[0].name, "dst");
+        assert_eq!(layout.tabs[0].root().pane_count(), 2);
+        assert!(layout.tabs[0].root().has_agent("a"));
+    }
+
+    #[test]
+    fn move_pane_across_tabs_new_tab_placement() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("src".to_string(), leaf(1, "a")));
+        layout.tabs[0].split_focused(SplitDir::Vertical, leaf(2, "b"));
+
+        let dest = layout
+            .move_pane_across_tabs(
+                0,
+                2,
+                MovePlacement::NewTab {
+                    name: "popped".to_string(),
+                },
+            )
+            .expect("move succeeds");
+        assert_eq!(dest, 1);
+        assert_eq!(layout.tabs.len(), 2);
+        assert_eq!(layout.tabs[1].name, "popped");
+        assert_eq!(layout.tabs[1].root().pane_count(), 1);
+        assert!(layout.tabs[1].root().has_agent("b"));
+        assert_eq!(layout.active, 1);
+    }
+
+    #[test]
+    fn find_agent_pane_returns_location() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("t0".to_string(), leaf(1, "a")));
+        layout.add_tab(Tab::new("t1".to_string(), leaf(2, "b")));
+        layout.tabs[1].split_focused(SplitDir::Vertical, leaf(3, "c"));
+
+        assert_eq!(layout.find_agent_pane("a"), Some((0, 1)));
+        assert_eq!(layout.find_agent_pane("c"), Some((1, 3)));
+        assert_eq!(layout.find_agent_pane("ghost"), None);
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1250,6 +1250,11 @@ impl Layout {
             };
             let adjusted_to = split_target.map(|t| if t > from_tab { t - 1 } else { t });
             // Keep `active` pointing somewhere sensible after the removal.
+            // NewTab branch (adjusted_to == None): this clamp is a transient
+            // stop-gap — `add_tab` below will reset `active` to the new tab,
+            // overriding whatever we put here. The clamp exists only so the
+            // layout is never in an invalid state between `remove` and
+            // `add_tab` (e.g. if future code adds fallible steps in between).
             if self.active == from_tab {
                 self.active = adjusted_to
                     .unwrap_or(self.tabs.len())

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -481,6 +481,22 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             save_metadata(&home, &instance_name, "description", json!(desc));
             json!({"description": desc})
         }
+        "move_pane" => {
+            // Route through the API so the running TUI receives a PaneMoved
+            // event and relocates the pane. If no daemon is reachable there's
+            // no TUI to notify, so returning the API error directly matches
+            // behaviour of other TUI-visible tools like `update_team`.
+            match crate::api::call(
+                &home,
+                &json!({"method": crate::api::method::MOVE_PANE, "params": args}),
+            ) {
+                Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+                    json!({"ok": true, "agent": args["agent"], "target_tab": args["target_tab"]})
+                }
+                Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("move_pane failed")}),
+                Err(e) => json!({"error": format!("move_pane: {e}")}),
+            }
+        }
 
         // --- Decisions ---
         "post_decision" => crate::decisions::post(&home, &instance_name, args),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -97,6 +97,12 @@ fn instance_tools() -> Vec<Value> {
             "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}),
         json!({"name": "set_description", "description": "Set a description for this instance.",
             "inputSchema": {"type": "object", "properties": {"description": {"type": "string"}}, "required": ["description"]}}),
+        json!({"name": "move_pane", "description": "Move an instance's pane into a different tab in the TUI. If `target_tab` names an existing tab, the pane splits that tab's focused pane; otherwise a new tab with that name is created and the pane becomes its root. Preserves scrollback and PTY state (unlike delete + create).",
+            "inputSchema": {"type": "object", "properties": {
+                "agent": {"type": "string", "description": "Instance name whose pane should be moved."},
+                "target_tab": {"type": "string", "description": "Destination tab name. Created if not present."},
+                "split_dir": {"type": "string", "enum": ["horizontal", "vertical"], "description": "Split direction when the destination tab already exists. Default: horizontal. Ignored when a new tab is created."}
+            }, "required": ["agent", "target_tab"]}}),
     ]
 }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,7 +2,7 @@
 
 use crate::agent::{self, AgentRegistry};
 use crate::app::MenuItem;
-use crate::layout::{Layout, PaneNode, SplitDir};
+use crate::layout::{DragTabTarget, Layout, PaneNode, SplitDir};
 use crate::state::AgentState;
 use ratatui::layout::{Constraint, Direction, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -87,13 +87,29 @@ fn highest_priority_state(tab: &crate::layout::Tab, registry: &AgentRegistry) ->
 fn render_tab_bar(frame: &mut Frame, area: Rect, layout: &Layout, registry: &AgentRegistry) {
     let mut spans = Vec::new();
 
+    // Cross-tab drag drop target (if the active tab is currently dragging a
+    // pane over the tab bar). Used to highlight the hovered tab / `[+]`.
+    let drag_tab_target = layout
+        .active_tab()
+        .and_then(|t| t.dragging_pane.and(t.drag_target_tab));
+
     for (i, tab) in layout.tabs.iter().enumerate() {
         let is_active = i == layout.active;
+        let is_drag_drop =
+            matches!(drag_tab_target, Some(DragTabTarget::ExistingTab(idx)) if idx == i);
         // Show the highest-priority state across all panes in this tab
         let state = highest_priority_state(tab, registry);
         let sc = state_color(state);
 
-        let style = if is_active {
+        let style = if is_drag_drop {
+            // Drop-target highlight wins over active styling so the user sees
+            // where the pane will land. Magenta matches the intra-tab
+            // drag-swap highlight (see is_drag_target below).
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Magenta)
+                .add_modifier(Modifier::BOLD)
+        } else if is_active {
             Style::default()
                 .fg(Color::Black)
                 .bg(Color::White)
@@ -131,9 +147,20 @@ fn render_tab_bar(frame: &mut Frame, area: Rect, layout: &Layout, registry: &Age
         spans.push(Span::styled(label, style));
     }
 
-    // fg must differ from the tab bar's bg (also DarkGray) — use Gray to match
-    // the unselected-tab label color.
-    spans.push(Span::styled(" [+] ", Style::default().fg(Color::Gray)));
+    // `[+]` doubles as the "drop here to spawn a new tab" zone during a
+    // cross-tab drag. Highlight it so the user sees that releasing here is
+    // a meaningful action, not a miss.
+    let new_tab_style = if matches!(drag_tab_target, Some(DragTabTarget::NewTab)) {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Magenta)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        // fg must differ from the tab bar's bg (also DarkGray) — use Gray to match
+        // the unselected-tab label color.
+        Style::default().fg(Color::Gray)
+    };
+    spans.push(Span::styled(" [+] ", new_tab_style));
     let tabs = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::DarkGray));
     frame.render_widget(tabs, area);
 }
@@ -869,6 +896,81 @@ pub fn render_tab_list(frame: &mut Frame, layout: &Layout, selected: usize) {
     frame.render_widget(Paragraph::new(lines), inner);
 }
 
+/// Render the move-pane destination picker. Lists all tabs plus a trailing
+/// "[+] New tab" option. `selected == layout.tabs.len()` corresponds to the
+/// new-tab slot; `source_tab_idx` is dimmed as an invalid target so the user
+/// knows releasing Enter there is a no-op.
+pub fn render_move_pane_target(
+    frame: &mut Frame,
+    layout: &Layout,
+    selected: usize,
+    source_tab_idx: usize,
+) {
+    let area = frame.area();
+    let list_len = layout.tabs.len() + 1; // tabs + "New tab"
+    let h = (list_len as u16 + 4).min(area.height - 2);
+    let w = 54u16.min(area.width - 4);
+    let x = (area.width.saturating_sub(w)) / 2;
+    let y = (area.height.saturating_sub(h)) / 2;
+    let la = Rect::new(x, y, w, h);
+    frame.render_widget(Clear, la);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Magenta))
+        .title(Span::styled(
+            " Move pane to... (Enter, Esc) ",
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(la);
+    frame.render_widget(block, la);
+
+    let mut lines: Vec<Line> = Vec::with_capacity(list_len);
+    for (i, tab) in layout.tabs.iter().enumerate() {
+        let is_sel = i == selected;
+        let is_source = i == source_tab_idx;
+        let style = if is_sel {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Magenta)
+                .add_modifier(Modifier::BOLD)
+        } else if is_source {
+            // Source tab is not a meaningful target — dim it so selection
+            // visually skips past without needing a hard-disable.
+            Style::default().fg(Color::DarkGray)
+        } else {
+            Style::default().fg(Color::White)
+        };
+        let marker = if is_source { "(source)" } else { "" };
+        let pc = tab.root().pane_count();
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {i}: "), style),
+            Span::styled(tab.name.as_str(), style),
+            Span::styled(
+                format!(
+                    "  ({pc} pane{s}) {marker}",
+                    s = if pc > 1 { "s" } else { "" }
+                ),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+    // Trailing "New tab" slot.
+    let new_sel = selected == layout.tabs.len();
+    let style = if new_sel {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Magenta)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Green)
+    };
+    lines.push(Line::from(vec![Span::styled(" [+] New tab", style)]));
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
 pub fn render_confirm(frame: &mut Frame, message: &str) {
     let area = frame.area();
     let w = (message.len() as u16 + 4).min(area.width - 4);
@@ -911,10 +1013,12 @@ pub fn render_help(frame: &mut Frame) {
         "    Ctrl+B H/J/K/L Resize pane (portable)",
         "    Drag border    Resize pane",
         "    Drag title     Swap pane position",
+        "    Drag → tab bar Move pane across tabs (drop on tab or [+])",
         "    Ctrl+B x       Close pane",
         "    Ctrl+B z       Toggle zoom",
         "    Ctrl+B Space   Next layout preset",
         "    Ctrl+B .       Rename pane",
+        "    Ctrl+B !       Move pane to another tab (menu)",
         "",
         "  Scroll",
         "    Mouse wheel    Scroll focused pane",


### PR DESCRIPTION
## Summary
- New cross-tab pane movement without rebuilding VTerm/PTY state. Three entry points: drag onto tab bar (existing tab or `[+]` for a new tab), keyboard `Ctrl+B !` overlay, and the new `move_pane` MCP tool.
- `handle_team_members_changed` now moves existing panes into the team tab instead of close+attach, preserving scrollback during `update_team` calls. The returned destination index threads through the add-loop so the team tab stays valid across source-tab removals.
- Infra: `Tab::detach_pane`, `Layout::move_pane_across_tabs(from, pane, placement) -> Option<usize>` with `MovePlacement::{SplitFocused { to_tab, dir }, NewTab { name }}`, and `Layout::find_agent_pane` helper. Single-pane source tabs are removed and indices are adjusted so callers don't have to guess.

## Test plan
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 570 unit passing (635 total incl. integration), 0 failed
- [ ] Manual: Ctrl+B ! menu navigation + Enter on existing/new tab
- [ ] Manual: drag pane onto another tab's label (split) and onto `[+]` (new tab)
- [ ] Manual: `move_pane` MCP tool with target_tab existing vs. new, split_dir horizontal vs. vertical
- [ ] Manual: `update_team` add member — verify VTerm scrollback preserved in the migrated pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)