### PR TITLE
release: bump to v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agend-terminal"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agend-terminal"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Agent Process Manager — orchestrate AI coding agents with PTY isolation, fleet management, and 35 MCP tools"
 license = "MIT"


### PR DESCRIPTION
## Summary
Version bump to set up the first release since the tray arc landed. Tagging `v0.3.2` after this merges will trigger `release.yml` to publish:

- macOS x86_64 + aarch64 tarballs with `--features tray`
- Windows x86_64 tarball with `--features tray`
- Linux x86_64 + aarch64 tarballs (no tray — tray on Linux ships via AppImage or `cargo install --features tray`)
- Linux x86_64 AppImage (bundles GTK3, custom AppRun defaults to `tray` on double-click)
- `SHA256SUMS`

## Context — what's in this release
- PR #17 (3d48452) — tray event loop + daemon bootstrap + status polling + Open App + Launch-at-login
- PR #18 (4ddb446) — API handler decoupling + agent_ops extraction
- PR #19 (64eee52) — Linux AppImage job with pinned linuxdeploy supply chain
- PR #25 (6fef3fa) — custom AppRun so double-click defaults to `tray` subcommand

## Test plan
- [x] CI green on this PR
- [ ] After merge, tag `v0.3.2` and verify release.yml publishes all six artifacts
- [ ] Homebrew tap formula PR follows in `suzuke/homebrew-tap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)