### PR TITLE
docs: slim README + fill CHANGELOG [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ## [Unreleased]
 
+Post-`0.3.1` work on `main`. 48 commits over the tray-resident arc,
+Task #9 Option C dual-track elimination, codebase-review correctness
+fixes, and performance hotspots.
+
+### Added
+
+- **System tray integration (`agend-terminal tray`, Cargo `--features tray`)** — native menu-bar / system-tray support on all three platforms. Status-keyed icon color (offline / idle / active), 2s status polling, disabled status label at top of menu, "Open App" launches the configured terminal emulator, Autostart (launch-at-login) toggle. Linux ships as an AppImage bundling GTK + AppIndicator libs with a custom AppRun that forces the tray subcommand on launch; macOS + Windows release tarballs include the feature by default.
+- **Dual-track fn drift detector** (`tests/no_dual_track_drift.rs`) — integration test scans top-level fn definitions in `src/ops.rs` and `src/mcp/handlers.rs`, panics on body divergence and warns on byte-identical duplicates. Hardened (#31) against raw string literals inside top-level fn bodies (fail-loud; guard scoped to extracted bodies so tests/impl blocks do not false-fail), `extern "C" fn` / `extern "Rust" fn` prefix handling, and silent-drop panic when `match_balanced_brace` cannot close a detected fn.
+- **Positive-pin CREATE_TEAM dispatch test** — `RecordingNotifier`-based in-process assertion that `spawn_one` success emits exactly one `ApiEvent::TeamCreated` with the expected payload, completing the three-piece equivalence bracket from C2 and closing a LESSONS-04-21 open item.
+
+### Changed
+
+- **Task #9 Option C — dual-track elimination** — shared helpers consolidated into `src/agent_ops.rs`; `src/api.rs` decomposed into per-tool handler modules (`handlers/instance.rs`, `handlers/team.rs`, `handlers/*`); `src/ops.rs` reduced to a single `start_instance` wrapper (Task #12 then deleted it entirely, inlining into the MCP dispatcher); 21 dead CLI-wrapper fns pruned and the crate-level `#![allow(dead_code)]` attribute removed. `validate_branch` also migrated out of `src/worktree.rs` into `agent_ops`.
+- **MCP tool ACL cached via `OnceLock`** — parsed once at startup instead of on every tool call.
+- **Layout pane-id enumeration** — new `collect_pane_ids()` avoids recursive allocation in the layout traversal hotspot.
+- **`spawn_agent` decomposed** — `build_command()` extracted for clarity and unit-testability.
+
+### Fixed
+
+- **Invalid state regex now panics** instead of silently degrading state detection.
+- **`strip_ansi` no longer inserts a phantom space on cursor-move sequences**, which was corrupting captured output.
+- **MCP stdio framing** returns `None` on EOF during `Content-Length` error recovery instead of hanging the loop.
+- **Cron schedule robustness** — `parse_run_at` rejects invalid timezones (previously fell back to UTC); schedule skipped instead of mis-fired on bad tz; `.schedule_last_check` written atomically.
+- **Fleet `ready_pattern` hardening** — regex validated at resolve time with a size ceiling, closing a ReDoS surface.
+- **Tray "Open App" no longer freezes the tray** — terminal launches are detached.
+
 ## [0.3.1] — 2026-04-21
 
 Substantial work has landed on `main` since `0.3.0`. Highlights, grouped by area.

--- a/README.md
+++ b/README.md
@@ -13,26 +13,12 @@ agend-terminal demo    # Try it in 30 seconds
 
 ## What It Does
 
-**Run 3 Claude agents working on the same repo in parallel:**
-```bash
-agend-terminal start    # reads fleet.yaml, spawns agents with git worktree isolation
-agend-terminal status   # see all agents and their health
-agend-terminal attach dev  # watch one agent work (Ctrl+B d to detach)
-```
-
-**Agents talk to each other — no glue code:**
-```
-Agent A finds a bug outside its scope → delegates to Agent B via MCP tool.
-Agent B fixes it → reports back with commit hash.
-Agent A continues with the fix applied.
-```
-
-**Survive crashes without losing context:**
-```
-Agent crashes → auto-respawned with exponential backoff.
-System message tells the new agent what happened.
-Worktree preserves all code changes.
-```
+Spawns AI coding agents (Claude Code, Codex, Kiro, OpenCode, Gemini) as
+long-lived PTY processes, each in its own git worktree. A built-in MCP
+server lets agents talk to each other — delegate work, request info,
+broadcast updates — without glue code. Crashes are survived by auto-
+respawn with context handover. Drive the fleet through a multi-tab /
+multi-pane TUI, a Telegram channel, or an optional system tray.
 
 ## Why Not tmux?
 
@@ -47,14 +33,16 @@ Worktree preserves all code changes.
 ## Quick Start
 
 ```bash
-# Try the demo (no config needed)
+# Demo (no config)
 agend-terminal demo
 
-# Or start with your own agents
+# Interactive setup — detects backends, wires Telegram, writes fleet.yaml
+agend-terminal quickstart
+
+# Or hand-write:
 cat > ~/.agend/fleet.yaml << 'YAML'
 defaults:
   backend: claude
-
 instances:
   dev:
     role: "Developer"
@@ -63,89 +51,8 @@ instances:
     role: "Code reviewer"
     working_directory: ~/my-project
 YAML
-
 agend-terminal start
 ```
-
-## Commands
-
-```
-Get started
-  agend-terminal app                   Launch multi-tab/pane TUI
-  agend-terminal demo                  30-second interactive demo
-  agend-terminal quickstart            Interactive setup — detect backends, wire Telegram, generate fleet.yaml
-  agend-terminal doctor                Health check backends
-
-Run a fleet
-  agend-terminal start                 Start daemon with fleet.yaml
-  agend-terminal daemon [name:cmd …]   Start daemon with explicit agents
-  agend-terminal stop                  Stop daemon
-  agend-terminal upgrade --binary <path>
-                                       Hot-upgrade daemon via supervisor (Unix only)
-
-Interact
-  agend-terminal attach <name>         Attach to agent (Ctrl+B d to detach)
-  agend-terminal inject <name> <text>  Send input to agent's PTY
-  agend-terminal list                  List running agents
-  agend-terminal status                Detailed agent status (state, health)
-  agend-terminal kill <name>           Kill an agent
-  agend-terminal connect <name>        Register an external agent with the running daemon
-  agend-terminal fleet …               Fleet management subcommands
-
-Integration
-  agend-terminal mcp                   MCP stdio server (agent-to-agent coordination)
-  agend-terminal completions <shell>   Generate shell completions (bash/zsh/fish/elvish/powershell)
-  agend-terminal bugreport             One-file diagnostic export
-```
-
-## 35 MCP Tools
-
-Agents get these tools automatically via MCP:
-
-| Category | Tools |
-|----------|-------|
-| Talk to users | reply, react, edit_message, download_attachment |
-| Talk to agents | send_to_instance, delegate_task, report_result, request_information, broadcast, inbox |
-| Manage agents | list/create/delete/start/describe/replace_instance, set_display_name, set_description |
-| Track decisions | post_decision, list_decisions, update_decision |
-| Track tasks | task (create/list/claim/done/update) |
-| Organize teams | create/delete/list/update_team |
-| Schedule work | create/list/update/delete_schedule |
-| Deploy fleets | deploy_template, teardown_deployment, list_deployments |
-| Share code | checkout_repo, release_repo |
-
-## Git Worktree Isolation
-
-Agents pointing to git repos automatically get isolated worktrees:
-
-```
-~/my-project/               ← original repo (untouched)
-~/my-project/.worktrees/
-  dev/                       ← agent "dev" works here (branch agend/dev)
-  reviewer/                  ← agent "reviewer" works here (branch agend/reviewer)
-```
-
-No configuration needed. `.worktrees` auto-added to `.gitignore`.
-
-## Health Monitoring
-
-- Auto-respawn with exponential backoff (5s → 300s)
-- State detection: Idle, Thinking, ToolUse, RateLimit, Crashed, Restarting
-- Crash notifications via Telegram
-- 30-minute stability window prevents permanent failure from occasional crashes
-
-## Telegram Integration
-
-Each agent gets its own forum topic; messages route by topic. Topic lifecycle
-is bidirectional:
-
-- **Delete a pane in app → topic is deleted in Telegram** (immediate).
-- **Close topic in Telegram → pane is removed in app** (immediate, via the
-  `forum_topic_closed` service message).
-- **Delete topic in Telegram → pane is removed in app** (lazy, on the next
-  agent send to that topic). Telegram Bot API does not emit a deletion event,
-  so the cleanup fires the first time a send returns
-  `message thread not found`. Prefer Close if you want immediate cleanup.
 
 ## Backends
 
@@ -157,12 +64,13 @@ is bidirectional:
 | OpenCode | `opencode` | Tested |
 | Gemini CLI | `gemini` | Tested |
 
-## Testing
+## Learn More
 
-```bash
-cargo test         # 561 tests (unit + integration + MCP round-trip)
-cargo clippy       # 0 errors (deny unwrap_used)
-```
+- **Commands** — [`docs/CLI.md`](docs/CLI.md) for the full subcommand reference.
+- **MCP tools** — [`docs/MCP-TOOLS.md`](docs/MCP-TOOLS.md) for the 35 agent-to-agent coordination tools.
+- **Architecture** — [`docs/architecture.md`](docs/architecture.md) covers git worktree isolation, health monitoring + auto-respawn, Telegram topic lifecycle, and daemon-resident design.
+- **Contributing** — [`CONTRIBUTING.md`](CONTRIBUTING.md).
+- **Release history** — [`CHANGELOG.md`](CHANGELOG.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

Per user directive (「README.md只保留最重要的資訊」): aggressively trim README and populate the empty CHANGELOG `[Unreleased]` section with post-0.3.1 landings.

## README — 169 → 77 lines (-92, -54%)

**Kept** (everything that differentiates or onboards):
- Hero tagline + pre-alpha warning
- 30-sec install/demo block
- One-paragraph "what it does" (collapsed from three code-block snippets)
- Why-not-tmux table — the core differentiator
- Minimal Quick Start with demo / quickstart / hand-write branches
- Backends table
- License

**Cut with pointers** (no information loss):
| Removed section | Lives at |
|---|---|
| Full subcommand list | [`docs/CLI.md`](docs/CLI.md) |
| 35 MCP tool table | [`docs/MCP-TOOLS.md`](docs/MCP-TOOLS.md) |
| Git worktree isolation | [`docs/architecture.md`](docs/architecture.md) |
| Health monitoring | [`docs/architecture.md`](docs/architecture.md) |
| Telegram topic lifecycle | [`docs/architecture.md`](docs/architecture.md) |
| Testing (`561 tests` line) | dropped (current count: 625, but README should not encode test count that drifts each release) |

## CHANGELOG — `[Unreleased]` populated (13 bullets)

Verified against `git log v0.3.1..main --oneline` (48 commits). Grouped per existing 0.3.1 style:

### Added (3)
- System tray (macOS / Windows / Linux AppImage)
- Dual-track fn drift detector + #31 hardening
- Positive-pin CREATE_TEAM dispatch test

### Changed (4)
- Task #9 Option C dual-track elimination
- MCP ACL `OnceLock` cache
- Layout `collect_pane_ids()` allocation fix
- `spawn_agent` → `build_command()` decomposition

### Fixed (6)
- State regex invalid→panic (was silent degradation)
- `strip_ansi` phantom-space on cursor-move
- MCP Content-Length EOF recovery
- Cron timezone rejection + atomic writes
- Fleet `ready_pattern` ReDoS + size limit
- Tray "Open App" detached launch (was freezing tray)

## Scope discipline

- **No changes** to `docs/architecture.md`, `docs/CLI.md`, `docs/MCP-TOOLS.md`, `CONTRIBUTING.md` — at-dev-2 owns those in parallel.
- **No other `docs/` files** touched — at-dev-1 audits those.
- Only `README.md` + `CHANGELOG.md` modified.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| README.md | 169 | 77 | -92 (-54%) |
| CHANGELOG.md | 102 | 128 | +26 |

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release` — **625 passed / 0 failed** across 10 binaries
- [x] All doc links resolve: `docs/CLI.md`, `docs/MCP-TOOLS.md`, `docs/architecture.md`, `CONTRIBUTING.md`, `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)