### PR TITLE
docs: SHIPPED banners + living-doc status markers (post-audit)

### DIFF
--- a/docs/EVAL-cross-platform.md
+++ b/docs/EVAL-cross-platform.md
@@ -1,5 +1,7 @@
 # Cross-Platform Compatibility Evaluation
 
+> **Status update (2026-04-22):** Windows Phase A/B/C all shipped on `main`; IPC blocker in §2.1 resolved. Sections below are kept as the original evaluation-time snapshot — see `PLAN-windows-support.md` and `HANDOVER-windows-conpty-nested.md` for the current state.
+
 > Date: 2026-04-17 (rev. — reflects current Cargo.toml and src/ tree)
 > Status: Unix-only (macOS + Linux) at runtime. Compiles on Windows for everything except IPC (UDS) — that remaining blocker is tracked in `PLAN-windows-support.md`.
 

--- a/docs/FOLLOWUP-permission-pattern-gaps.md
+++ b/docs/FOLLOWUP-permission-pattern-gaps.md
@@ -1,5 +1,7 @@
 # FOLLOWUP: PermissionPrompt pattern coverage gaps (Stage 2b finding)
 
+> **Status: SHIPPED** — implementation landed on `main` (commits `de2b197 ⇢ 4aa1dbf`, rebased to `5c95982 ⇢ 24ff0e0`). Doc retained for historical/provenance.
+
 **Filed**: 2026-04-20
 **Status**: Closed 2026-04-20 — claude + codex PermissionPrompt patterns fixed on `main` (commits `de2b197 ⇢ 4aa1dbf`, rebased to `5c95982 ⇢ 24ff0e0`)
 **Origin**: `docs/PLAN-state-replay-fixture-expansion.md` Stage 2b recording run

--- a/docs/FOLLOWUP-telegram-efficiency.md
+++ b/docs/FOLLOWUP-telegram-efficiency.md
@@ -1,5 +1,7 @@
 # Follow-up: Telegram routing efficiency + type safety — RESOLVED
 
+> **Status: SHIPPED** — implementation landed on `main` (branch `feature/telegram-efficiency-followups`, 2026-04-20). Doc retained for historical/provenance.
+
 Status: **all three items closed 2026-04-20** on branch
 `feature/telegram-efficiency-followups`.
 

--- a/docs/FOLLOWUP-tooluse-pattern-gaps.md
+++ b/docs/FOLLOWUP-tooluse-pattern-gaps.md
@@ -1,5 +1,7 @@
 # FOLLOWUP: ToolUse pattern coverage gaps (Stage 2a finding)
 
+> **Status: SHIPPED** — implementation landed on `main` (commits `f65d295 ⇢ 24ff0e0`, 2026-04-20). Doc retained for historical/provenance.
+
 **Filed**: 2026-04-20
 **Status**: Closed 2026-04-20 — all 5 backends' ToolUse patterns fixed on `main` (commits `f65d295 ⇢ 24ff0e0`)
 **Origin**: `docs/PLAN-state-replay-fixture-expansion.md` Stage 2a recording run

--- a/docs/HANDOVER-windows-conpty-nested.md
+++ b/docs/HANDOVER-windows-conpty-nested.md
@@ -1,5 +1,7 @@
 # Handover — Windows ConPTY nested spawn silent hang
 
+> **Status: SHIPPED** — implementation landed on `main` (Session 4, 2026-04-19). Doc retained for historical/provenance.
+
 **Status**: **resolved (Session 4, 2026-04-19)**. The symptom was real, but the root causes were agend-side, not an OS/ConPTY regression. Two fixes landed on `main`:
 - `src/vterm.rs` — replace `NoopListener` with `PtyWriteListener` so the DSR-CPR `\x1b[6n` reply that ConPTY blocks on actually reaches the child.
 - `src/daemon.rs` — call `SetConsoleCtrlHandler(None, 0)` before `ctrlc::set_handler` so the daemon doesn't inherit an ignore-CTRL+C flag.

--- a/docs/HANDOVER-windows-phase-c.md
+++ b/docs/HANDOVER-windows-phase-c.md
@@ -1,5 +1,7 @@
 # Handover: Windows Port — Phase C
 
+> **Status: SHIPPED** — Windows Phase C landed on `main`. Doc retained for historical/provenance.
+
 > Date: 2026-04-17
 > Prereq: Read `docs/PLAN-windows-support.md` and `docs/EVAL-cross-platform.md`.
 

--- a/docs/PLAN-awaiting-operator.md
+++ b/docs/PLAN-awaiting-operator.md
@@ -1,5 +1,7 @@
 # PLAN: AwaitingOperator — 啟動卡住的泛用救援機制
 
+> **Status: SHIPPED** — `AwaitingOperator` state live in `src/telegram.rs`, `src/health.rs`, `src/app/mod.rs`, `src/vterm.rs`. Doc retained for historical/provenance.
+
 **Branch:** `feat/awaiting-operator`
 **Worktree:** `/Users/suzuke/Documents/Hack/agend-terminal-awaiting-op`
 **Date:** 2026-04-19

--- a/docs/PLAN-codebase-review-fixes.md
+++ b/docs/PLAN-codebase-review-fixes.md
@@ -1,5 +1,7 @@
 # Codebase Review Fix Plan — COMPLETE
 
+> **Status: SHIPPED** — all 8 stages merged + pushed to `origin/main` (2026-04-21). Doc retained for historical/provenance.
+
 **Date:** 2026-04-21
 **Completed:** 2026-04-21
 **Scope:** Full codebase review → 17 findings, 11 actionable items across 3 phases

--- a/docs/PLAN-daemon-resident.md
+++ b/docs/PLAN-daemon-resident.md
@@ -1,5 +1,7 @@
 # Plan: daemon-resident bootstrap (tmux-style)
 
+> **Status: SHIPPED** — Stages 1/2/3 + hot-reload Phase A/B/C/D all landed on `main`. Doc retained for historical/provenance.
+
 Status: Stages 1 & 2 shipped on main (commits `8a1107e..ece0933`, 2026-04-20,
 pushed). Stage 3 complete through §3.6 — see §3.
 

--- a/docs/PLAN-schedule-crossplatform-oneshot.md
+++ b/docs/PLAN-schedule-crossplatform-oneshot.md
@@ -1,5 +1,7 @@
 # Schedule — Cross-platform Timezone + One-shot Support
 
+> **Status: SHIPPED** — `Trigger` enum live in `src/schedules.rs`, `iana-time-zone` in `Cargo.toml`. Doc retained for historical/provenance.
+
 > Date: 2026-04-20
 > Branch: `worktree-schedule-xplatform-oneshot`
 > Status: in progress

--- a/docs/PLAN-split-app-rs.md
+++ b/docs/PLAN-split-app-rs.md
@@ -1,5 +1,7 @@
 # Plan: decompose src/app.rs and backfill layout.rs / state.rs tests
 
+> **Status: SHIPPED** — landed on `main` (commits `726562e`, `88a0d74`, 2026-04-18). Doc retained for historical/provenance.
+
 > **Status: DONE 2026-04-18** — landed on `main` via commits `726562e` (PRs 1-4 + layout tests) and `88a0d74` (PRs 5-9). All 9 planned submodules exist under `src/app/` (mod.rs + session.rs + commands.rs + dispatch.rs + mouse.rs + overlay.rs + pane_factory.rs + telegram_hooks.rs + tui_events.rs + api_server.rs); `src/app/mod.rs` is ~700 LOC (down from 2,552). Kept below as historical design record.
 
 Worktree: `/Users/suzuke/Documents/Hack/agend-refactor-split-app`

--- a/docs/PLAN-telegram-topic-delete-sync.md
+++ b/docs/PLAN-telegram-topic-delete-sync.md
@@ -1,5 +1,7 @@
 # PLAN: Telegram topic delete → App pane sync
 
+> **Status: SHIPPED** — `cleanup_deleted_topic` live in `src/telegram.rs`. Doc retained for historical/provenance.
+
 **Branch:** `feat/telegram-topic-delete-sync` (to be created when implementation starts)
 **Date:** 2026-04-20
 

--- a/docs/PLAN-terminal-app.md
+++ b/docs/PLAN-terminal-app.md
@@ -1,5 +1,7 @@
 # AgEnD Terminal — Terminal Emulator 實作計劃
 
+> **Status: SHIPPED** — all phases landed on `main`. Doc retained for historical/provenance.
+
 > Status: **DONE** — all phases shipped to `main`. Kept as historical / design reference.
 > For the post-merge review and follow-up punch list, see `docs/REVIEW-auto-pane.md`.
 >

--- a/docs/PLAN-tray-resident.md
+++ b/docs/PLAN-tray-resident.md
@@ -1,6 +1,8 @@
 # Plan: tray-resident (menu-bar icon + autostart)
 
-Status: not started (2026-04-21).
+> **Status: SHIPPED** — tray implementation on `main` (commits `ea7f036`, `fe51bcb`, `306010e`, `d75b95c`, `c3acb7f`, `23b40f8`). Doc retained for historical/provenance.
+
+Status: SHIPPED on `main` (commits `ea7f036`, `fe51bcb`, `306010e`, `d75b95c`, `c3acb7f`, `23b40f8`; earlier header incorrectly said "not started").
 Prereq: `docs/PLAN-daemon-resident.md` §3.4 — Attached app opens one
 `PaneSource::Remote` per agent. That is what makes tray "Open App" work
 against a live daemon.

--- a/docs/PLAN-windows-support.md
+++ b/docs/PLAN-windows-support.md
@@ -1,5 +1,7 @@
 # Windows Support — Implementation Plan
 
+> **Status: SHIPPED** — Phase A/B/C all landed on `main`. Doc retained for historical/provenance.
+
 > Date: 2026-04-17 (rev. 2026-04-20 — all phases folded into `main`; the 26200 "ConPTY regression" was re-diagnosed as agend-side and fixed in Session 4).
 > Prereq: Read `docs/EVAL-cross-platform.md` for the state-of-play.
 > Remaining effort: **none** — Phase A/B/C are all on `main`. The 26200 nested-ConPTY symptom turned out to be the CPR-reply + ignore-Ctrl+C bugs documented in `docs/HANDOVER-windows-conpty-nested.md` (see "Session 4 correction" section). Both fixes landed.

--- a/docs/REVIEW-2026-04-18.md
+++ b/docs/REVIEW-2026-04-18.md
@@ -1,5 +1,7 @@
 # Codebase Review 2026-04-18
 
+> **Status (2026-04-22):** All 8 fix stages MERGED and pushed to `origin/main`. See `Fix stage plan` table below — each row's status marker is authoritative.
+
 **Scope**: full src/ (~22k LOC, 40 modules) + tests + docs.
 **Method**: 8 parallel Explore sub-agents, one per subsystem. Top P0/P1 claims re-verified by direct file read before inclusion.
 

--- a/docs/REVIEW-auto-pane.md
+++ b/docs/REVIEW-auto-pane.md
@@ -1,5 +1,7 @@
 # Code Review: Auto Tab/Pane for MCP-Spawned Instances
 
+> **Status: SHIPPED** — review cycle closed, feature live on `main` (commit `36dc537`). Doc retained for historical/provenance.
+
 **Commit:** `36dc537` feat: auto tab/pane for MCP-spawned instances and teams
 **Date:** 2026-04-17
 **Scope:** 18 files, +864/-307


### PR DESCRIPTION
## Summary

Mechanical follow-up from the docs/ triage audit (`workspace/general/recovery/at-dev-1-doc-audit-04-22.md`):

- **15 SHIPPED banners** added to intent/review docs whose implementation has landed on `main`. Banners are additive — they sit under H1 without rewriting the original body.
- **1 header correction**: `docs/PLAN-tray-resident.md` top-of-file said "not started (2026-04-21)", but tray code is live on `main` (commits `ea7f036`, `fe51bcb`, `306010e`, `d75b95c`, `c3acb7f`, `23b40f8`). Loudest false-claim in the docs tree.
- **2 LIVING surgical edits** (no body rewrites, just status notes):
  - `docs/EVAL-cross-platform.md` — prepend 2026-04-22 status note clarifying Windows Phase A/B/C all shipped and §2.1 IPC blocker resolved.
  - `docs/REVIEW-2026-04-18.md` — prepend 2026-04-22 status note confirming all 8 fix stages merged + pushed to `origin/main`.

## Files changed (17)

**SHIPPED banners (15):**

- docs/FOLLOWUP-permission-pattern-gaps.md
- docs/FOLLOWUP-telegram-efficiency.md
- docs/FOLLOWUP-tooluse-pattern-gaps.md
- docs/HANDOVER-windows-conpty-nested.md
- docs/HANDOVER-windows-phase-c.md
- docs/PLAN-awaiting-operator.md
- docs/PLAN-codebase-review-fixes.md
- docs/PLAN-daemon-resident.md
- docs/PLAN-schedule-crossplatform-oneshot.md
- docs/PLAN-split-app-rs.md
- docs/PLAN-telegram-topic-delete-sync.md
- docs/PLAN-terminal-app.md
- docs/PLAN-tray-resident.md (banner + header fix)
- docs/PLAN-windows-support.md
- docs/REVIEW-auto-pane.md

**LIVING status notes (2):**

- docs/EVAL-cross-platform.md
- docs/REVIEW-2026-04-18.md

## Out of scope

Explicitly left for parallel agents per delegation:
- architecture.md, CLI.md, MCP-TOOLS.md, CONTRIBUTING.md (at-dev-2)
- README.md, CHANGELOG.md (at-dev-3)
- 8 STILL-INTENT docs (untouched — they track open work)

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 625 tests pass
- [x] No non-docs files touched (`git diff --stat` confirms 17 files in docs/)
- [x] Banners are additive, not destructive — original author intent preserved