### PR TITLE
docs: refresh living reference docs post-Task-#9 Option C

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ cargo clippy -- -D warnings          # must be warning-free
 
 `cargo clippy` enforces `unwrap_used = "deny"` (see `Cargo.toml`). Handle errors with `?` / `anyhow::Result`.
 
-CI mirrors these steps on Ubuntu + macOS (`.github/workflows/ci.yml`). Windows is not yet in the matrix — see `docs/PLAN-windows-support.md`.
+CI mirrors these steps on Ubuntu + macOS + Windows (`.github/workflows/ci.yml`).
 
 ## Workflow
 
@@ -57,13 +57,17 @@ CI mirrors these steps on Ubuntu + macOS (`.github/workflows/ci.yml`). Windows i
 - `cargo clippy -- -D warnings` — fix warnings, don't `#[allow]` them unless the check is genuinely wrong and you leave a one-line comment explaining why.
 - No `unwrap()` / `expect()` in non-test code. Use `?` with `anyhow::Context` for error annotation.
 - No `println!` / `eprintln!` in production code paths. Use `tracing::{info, warn, error, debug}`.
-- Keep module responsibilities tight — `ops.rs` for high-level operations, `api.rs` for wire protocol, `mcp/` for MCP surface, `src/<area>.rs` for domain logic.
+- Keep module responsibilities tight:
+  - `src/agent_ops.rs` — shared helpers (messaging, fleet mutation, branch validation) called by both the daemon API and the MCP handler path. Drop new duplication here rather than inlining it in two places; `tests/no_dual_track_drift.rs` enforces no drift between `src/agent_ops.rs` and `src/mcp/handlers.rs`.
+  - `src/api/` — daemon JSON control API (wire protocol + per-method handlers under `src/api/handlers/`).
+  - `src/mcp/` — MCP surface for agents. `handlers.rs` proxies most tool calls to the daemon API; `start_instance` is handled inline there (no separate `ops.rs` since Task #12).
+  - `src/<area>.rs` — domain logic (agent, fleet, telegram, health, schedules, …).
 
 ## Documentation
 
 - Architectural changes → update `docs/architecture.md`.
 - New CLI command → update `docs/CLI.md` and `README.md` command table.
-- New MCP tool → update `docs/MCP-TOOLS.md` and the "35 MCP Tools" table in `README.md`.
+- New MCP tool → update `docs/MCP-TOOLS.md` and the MCP Tools table in `README.md`.
 - Major user-facing change → add an entry to `CHANGELOG.md` under `## [Unreleased]`.
 - Plan / eval docs (`docs/PLAN-*.md`, `docs/EVAL-*.md`) represent intent at a point in time — when work ships, update status or fold the doc.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -28,8 +28,10 @@ Keybinds: see `src/keybinds.rs`. Prefix `Ctrl+B`, then `c` new tab, `n`/`p` next
 Start the daemon using `fleet.yaml`.
 
 ```
-agend-terminal start
+agend-terminal start [--detached] [--fleet <path>]
 ```
+- `--detached` — background the daemon (stdio → `$AGEND_HOME/daemon.log`); the foreground process exits once the daemon has published its run dir.
+- `--fleet <path>` — override fleet file. Default: `$AGEND_HOME/fleet.yaml`.
 
 On startup: prunes stale git worktrees, auto-creates a `general` instance if a Telegram channel is configured, initializes Telegram, and respawns any crashed agents per `HealthTracker`.
 
@@ -161,6 +163,23 @@ Generate a single text file with diagnostics, recent logs, and redacted config. 
 agend-terminal bugreport
 ```
 
+### `upgrade` (Unix only)
+Hot-upgrade the daemon to a new binary via `agend-supervisor`. Flow: stage new binary → self-test → stop old daemon → start new → wait for ready ping → stabilise for N seconds → commit (or roll back).
+
+```
+agend-terminal upgrade --binary <path> [--to-version <label>] [--yes] \
+                       [--install-supervisor] \
+                       [--stability-secs <N>] [--ready-timeout-secs <N>]
+```
+- `--binary <path>` — path to the new daemon binary (required).
+- `--to-version <label>` — human-visible version label; defaults to the new binary's `--version` output.
+- `--yes` — skip interactive confirmation. Required with `--install-supervisor`.
+- `--install-supervisor` — idempotent bootstrap of the supervisor layout on first upgrade.
+- `--stability-secs <N>` — stability window after switchover, seconds. Default `60`, `0` disables.
+- `--ready-timeout-secs <N>` — ready-ping timeout, seconds. Default `60`, `0` disables.
+
+See `docs/architecture.md` Module 8 for the supervisor design; Windows is not supported (the socket-swap + symlink-rename trick is Unix-only).
+
 ### `completions`
 Print shell completion scripts to stdout.
 
@@ -196,9 +215,9 @@ $AGEND_HOME/
     workspace/<agent>/            # default working dir when none set
     run/<daemon-pid>/
         .daemon                   # pid:start_time
-        api.sock                  # daemon control socket
-        <agent>.sock              # per-agent TUI socket
-        ports.json                # (planned, Windows support)
+        api.port                  # daemon control API TCP port (loopback)
+        api.cookie                # 32-byte auth cookie for api.port (0600 on Unix)
+        <agent>.port              # per-agent TUI bridge TCP port (loopback, cookie-auth)
 ```
 
 Everything under `$AGEND_HOME` (including `fleet.yaml`, `session.json`) is locked via `fs2::FileExt` during mutations — safe against concurrent daemon / CLI usage.

--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -246,10 +246,10 @@ Mount another repo as a read-only worktree in your working directory.
 
 ## How the Tools Are Wired
 
-1. `agend-terminal` daemon exposes a UDS API (`~/.agend/run/{PID}/api.sock`).
+1. `agend-terminal` daemon exposes a JSON control API on TCP loopback; the bound port is published to `~/.agend/run/{PID}/api.port` and authenticated by a 32-byte cookie at `~/.agend/run/{PID}/api.cookie` (0600 on Unix).
 2. For each backend, `src/mcp_config.rs` generates the backend's MCP config file pointing at `agend-terminal mcp` (stdio transport).
-3. `src/mcp/mod.rs` spawns a stdio server per agent, `src/mcp/tools.rs` serves schemas, `src/mcp/handlers.rs` proxies each call to the daemon API.
-4. All tool calls flow: **agent → MCP stdio server → daemon UDS API → `ops.rs` → registry / inbox / fleet**.
+3. `src/mcp/mod.rs` spawns a stdio server per agent, `src/mcp/tools.rs` serves schemas, `src/mcp/handlers.rs` proxies each call to the daemon API. Shared helpers (messaging, fleet mutation, branch validation) live in `src/agent_ops.rs` and are called from both sides; `tests/no_dual_track_drift.rs` enforces no drift between `agent_ops.rs` and `mcp/handlers.rs`.
+4. All tool calls flow: **agent → MCP stdio server → daemon loopback API → `src/api/handlers/*` → registry / inbox / fleet**. `start_instance` is handled inline by `src/mcp/handlers.rs` (no daemon round-trip) since Task #12.
 
 ## Schemas in Code
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -859,7 +859,7 @@ Agent A (blog-writer) runs: `agend-terminal send general "PR ready"`
 - [x] PTY spawn/attach/detach/inject/kill
 - [x] Output capture + ready detection
 - [x] Graceful daemon shutdown
-- [ ] `clap` CLI parsing (replace manual arg parsing)
+- [x] `clap` CLI parsing (`Commands` enum in `src/main.rs`)
 - [ ] Session token (`AGEND_SESSION_ID`)
 
 ### Phase 2: Fleet + Communication
@@ -920,3 +920,21 @@ reqwest = "0.12"             # HTTP client (for webhooks)
 # Phase 4
 rusqlite = "0.32"            # SQLite (schedules, logs)
 ```
+
+---
+
+## Source Layout (reference)
+
+The module design above is aspirational and largely file-agnostic; the table below is the current file-level mapping as of Task #9 Option C / Task #12 (2026-04). See `CONTRIBUTING.md` for the contribution-time style rules.
+
+| Responsibility | File(s) |
+|---|---|
+| Shared helpers (messaging, fleet mutation, branch validation, cleanup) called from both the daemon API and the MCP handler path | `src/agent_ops.rs` |
+| Daemon JSON control API (wire protocol + per-method handlers) over TCP loopback | `src/api/mod.rs`, `src/api/handlers/*.rs` |
+| MCP surface for agents. `start_instance` is handled inline here — no separate `ops.rs` module (deleted in Task #12) | `src/mcp/handlers.rs`, `src/mcp/tools.rs` |
+| Domain logic | `src/agent.rs`, `src/fleet.rs`, `src/telegram.rs`, `src/health.rs`, `src/schedules.rs`, `src/decisions.rs`, … |
+| Supervisor (hot upgrade; Unix only) | `src/supervisor/`, `src/bin/agend-supervisor.rs` |
+
+### Drift enforcement
+
+`tests/no_dual_track_drift.rs` extracts top-level fn bodies from `src/agent_ops.rs` and `src/mcp/handlers.rs` and asserts that any fn sharing a name has an identical body, preventing the kind of silent divergence between MCP and daemon paths that caused the `cleanup_working_dir` Kiro-cleanup gap (14-entry MCP copy vs 19-entry canonical) on main before Task #9 Option C. The detector is parser-hardened against raw-string literals and `extern "ABI" fn` (PR #31).


### PR DESCRIPTION
## Summary

Updates the four living reference docs to reflect current code after Task #9 Option C (agent_ops consolidation + dual-track drift detector) and Task #12 (start_instance relocation + ops.rs deletion).

Scope strictly limited to the 4 files general assigned — no src/ changes, no edits to other `docs/*.md` files (at-dev-1's scope), no README/CHANGELOG changes (at-dev-3's scope).

## Files & corrections

### `CONTRIBUTING.md`
- **L19** — Windows no longer "not yet in the matrix"; CI matrix already runs `ubuntu-latest + macos-latest + windows-latest`. Dropped the dangling reference.
- **L60 (the general-flagged line)** — module map replaced. Old line said \"\`ops.rs\` for high-level operations, \`api.rs\` for wire protocol\"; both claims are stale (ops.rs deleted in PR #22, api.rs is a module dir now). Replaced with a bulleted current map: \`src/agent_ops.rs\` as shared helpers (with the drift-guard xref), \`src/api/\` for the daemon API, \`src/mcp/\` for the MCP surface (noting \`start_instance\` inline), \`src/<area>.rs\` for domain logic.
- **L66** — de-numbered the \"35 MCP Tools\" pointer; actual count is 36 today, and the README is at-dev-3's scope so the number lives there.

### `docs/CLI.md`
- **`start` section** — added the `--detached` and `--fleet <path>` flags that exist on the actual clap subcommand.
- **New `upgrade` section** — the command ships on main (Unix-only per `#[cfg(unix)]`) but was entirely missing. Wrote a section matching `--help` output + cross-linked to `docs/architecture.md` Module 8.
- **On-disk layout** — replaced UDS `api.sock` / `<agent>.sock` with the actual TCP-loopback artifacts (`api.port`, `api.cookie`, `<agent>.port`). Dropped the stale \"ports.json (planned)\" line — no such file exists; the loopback migration was the actual resolution of that plan.

### `docs/MCP-TOOLS.md`
- **L249** — \"UDS API (\`~/.agend/run/{PID}/api.sock\`)\" replaced with the TCP-loopback + cookie reality.
- **L252** — call flow used to end at \`ops.rs\`; rewritten to point at `src/api/handlers/*`. Added the `start_instance` inline note and a reference to the drift-guard test (`tests/no_dual_track_drift.rs`).

### `docs/architecture.md`
- **Module 7 (CLI) Phase 1 checklist** — ticked `[x]` for \`clap\` parsing (general's audit handoff finding — \`Commands\` enum is live in `src/main.rs`).
- **New appendix \"Source Layout (reference)\"** — added at the very end so the conceptual Module 1..8 narrative stays untouched. Table maps responsibilities → current files (agent_ops.rs / api/ / mcp/ / domain logic / supervisor) + short note on drift-guard enforcement. Deliberately minimal — preserves existing voice and structure per general's scope guidance.

## Reality checks performed before writing

- Read `src/main.rs` `Commands` enum for every CLI command + flag.
- Ran `cargo run --bin agend-terminal -- <cmd> --help` for `start`, `mcp`, `fleet`, `upgrade` to verify docs match actual output.
- Counted 36 MCP tools in `src/mcp/tools.rs` (existing `tool_count_at_least_35` unit test provides the floor).
- Verified `src/agent_ops.rs` is the shared helper layer, `src/ops.rs` does not exist, `src/api.rs` does not exist (only `src/api/`), `src/mcp/handlers.rs` imports `crate::agent_ops::{...}`.
- Verified TCP loopback migration: `api.port` / `api.cookie` / per-agent `<agent>.port` via `src/auth_cookie.rs` + `src/ipc.rs` + `src/daemon/tui_bridge.rs`.
- CI matrix: `.github/workflows/ci.yml` matrix line reads `[ubuntu-latest, macos-latest, windows-latest]`.

## Test plan

- [x] `cargo fmt --check` → pass
- [x] `cargo clippy --all-targets -- -D warnings` → pass
- [x] `cargo test --release` → **625 passed, 2 ignored, 0 failed** (matches main baseline — doc-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)