### PR TITLE
ci: bump actions to v5 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload binary (Unix)
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: agend-terminal-${{ runner.os }}-${{ runner.arch }}
           path: target/release/agend-terminal
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload binary (Windows)
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: agend-terminal-${{ runner.os }}-${{ runner.arch }}
           path: target/release/agend-terminal.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
             archive: zip
             features: tray
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -90,7 +90,7 @@ jobs:
             -DestinationPath agend-terminal-${{ matrix.target }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: agend-terminal-${{ matrix.target }}
           path: agend-terminal-${{ matrix.target }}.${{ matrix.archive }}
@@ -99,7 +99,7 @@ jobs:
     name: Build AppImage (x86_64)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
 
       # linuxdeploy + plugin-gtk need the same GTK dev libs the tray feature
@@ -188,7 +188,7 @@ jobs:
             --output appimage
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: agend-terminal-x86_64-AppImage
           path: agend-terminal-x86_64.AppImage
@@ -201,7 +201,7 @@ jobs:
     # artifacts (for pre-tag validation) but must not touch the release page.
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary
- GitHub deprecated Node.js 20 for actions runners — Node 24 becomes default 2026-06-02, Node 20 removed 2026-09-16. Every CI run was emitting deprecation annotations.
- Bumps 8 action references across `ci.yml` + `release.yml`: `actions/checkout@v4 → v5`, `actions/upload-artifact@v4 → v5`, `actions/download-artifact@v4 → v5`.

## Compatibility notes
- **checkout@v5**: no input/output changes.
- **upload-artifact@v5**: no input/output changes.
- **download-artifact@v5**: default behaviour changed, but the only call site (`release.yml:204`) already sets `merge-multiple: true` explicitly, so behaviour is preserved.

## Test plan
- [x] CI (ci.yml) runs green on this PR — proves `checkout@v5` + `upload-artifact@v5` work.
- [ ] `release.yml` exercised only on tag push; will be validated at next `v*` tag (or manually via `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)