### PR TITLE
feat(app): Ctrl+B ~ summons a floating scratch shell overlay

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -2,6 +2,7 @@
 //! layout/overlay/break side-effect. Extracted from `run_app` so the main
 //! loop is pure orchestration.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use crate::agent::AgentRegistry;
@@ -12,12 +13,16 @@ use super::overlay::{CloseTarget, Overlay};
 
 /// Borrowed state dispatch needs. `last_tab` is `&mut usize` because tab-
 /// switch arms read the current active tab into it before moving away.
+/// `wakeup_tx` and `name_counter` are threaded in so actions that spawn
+/// ad-hoc panes (e.g. `ScratchShell`) can call `pane_factory::create_pane`.
 pub(super) struct DispatchCtx<'a> {
     pub layout: &'a mut Layout,
     pub registry: &'a AgentRegistry,
     pub home: &'a Path,
     pub fleet_path: &'a Path,
     pub last_tab: &'a mut usize,
+    pub wakeup_tx: &'a crossbeam::channel::Sender<usize>,
+    pub name_counter: &'a mut HashMap<String, usize>,
 }
 
 /// Signals back to `run_app`. Fields are applied independently — a single
@@ -228,6 +233,55 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
                 crate::layout::resize_focused(tab.root_mut(), area, focus, dir, 0.05);
             }
             out.needs_resize = true;
+        }
+        Action::ScratchShell => {
+            // Mirrors MenuItemKind::Shell (SHELL env → default_shell fallback,
+            // Fresh mode). Size matches render::scratch_shell_rect so the PTY
+            // we spawn here fits the overlay box the renderer will draw.
+            let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+            let box_rect =
+                crate::render::scratch_shell_rect(ratatui::layout::Rect::new(0, 0, cols, rows));
+            let inner_w = box_rect.width.saturating_sub(2);
+            let inner_h = box_rect.height.saturating_sub(2);
+            let shell =
+                std::env::var("SHELL").unwrap_or_else(|_| crate::default_shell().to_string());
+            // Open the scratch shell in the focused pane's working
+            // directory — typically where the user is already thinking /
+            // editing, so sibling commands (git status, ls, etc.) Just Work.
+            // Fall back to a shared `~/.agend-terminal/scratch/` when
+            // there's no focused pane with a cwd (remote-source pane, empty
+            // layout). Both paths stay under `home`, so the
+            // `validate_working_directory` check in agent::spawn_agent
+            // accepts them without needing AGEND_ALLOWED_WORK_ROOTS.
+            let cwd = ctx
+                .layout
+                .active_tab()
+                .and_then(|t| t.focused_pane())
+                .and_then(|p| p.working_dir.clone())
+                .unwrap_or_else(|| ctx.home.join("scratch"));
+            match super::pane_factory::create_pane(
+                ctx.layout,
+                ctx.registry,
+                ctx.home,
+                "scratch",
+                &shell,
+                &[],
+                crate::backend::SpawnMode::Fresh,
+                Some(&cwd),
+                &HashMap::new(),
+                "\r",
+                inner_w,
+                inner_h,
+                ctx.wakeup_tx,
+                ctx.name_counter,
+            ) {
+                Ok(pane) => {
+                    out.new_overlay = Some(Overlay::ScratchShell {
+                        pane: Box::new(pane),
+                    });
+                }
+                Err(e) => tracing::error!(error = %e, "scratch shell spawn failed"),
+            }
         }
         Action::None => {}
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -268,6 +268,17 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             tracing::info!("app: SIGTERM received, exiting main loop");
             break;
         }
+        // Auto-close the scratch shell overlay once its backing process
+        // exits (user ran `exit`, hit Ctrl+D, or the shell crashed). The
+        // 50ms `default` arm of the main `select!` below guarantees this
+        // runs at least every 50ms even without new PTY output.
+        if let Overlay::ScratchShell { pane } = &overlay {
+            if !agent_is_alive(&registry, &pane.agent_name) {
+                let name = pane.agent_name.clone();
+                overlay = Overlay::None;
+                kill_agent(&registry, &name);
+            }
+        }
         if needs_resize {
             let (c, r) = crossterm::terminal::size().unwrap_or((120, 40));
             let pane_area = ratatui::layout::Rect::new(0, 1, c, r.saturating_sub(2));
@@ -279,7 +290,9 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
 
         terminal.draw(|frame| {
             render::render(frame, &mut layout, repeat_mode, &registry, telegram_status);
-            match &overlay {
+            // &mut because ScratchShell needs to drain output and maybe
+            // resize its pane's VTerm/PTY during render.
+            match &mut overlay {
                 Overlay::NewTabMenu { items, selected }
                 | Overlay::SplitMenu {
                     items, selected, ..
@@ -326,6 +339,9 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 Overlay::Tasks { ref items, scroll } => {
                     render::render_tasks(frame, items, *scroll);
                 }
+                Overlay::ScratchShell { pane } => {
+                    render::render_scratch_shell(frame, pane, &registry);
+                }
                 Overlay::None => {}
             }
         })?;
@@ -367,6 +383,8 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                             home: &home,
                             fleet_path: &fleet_path,
                             last_tab: &mut last_tab,
+                            wakeup_tx: &wakeup_tx,
+                            name_counter: &mut name_counter,
                         };
                         let out = dispatch::dispatch(action, &mut dctx);
                         if out.needs_resize {
@@ -408,6 +426,9 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                             | Overlay::RenamePane { ref mut input }
                             | Overlay::Command { ref mut input } => {
                                 input.push_str(&text);
+                            }
+                            Overlay::ScratchShell { pane } => {
+                                pane.write_input(&registry, text.as_bytes());
                             }
                             Overlay::None => {
                                 write_to_focused(&layout, &registry, text.as_bytes());
@@ -704,4 +725,26 @@ fn kill_agent(registry: &AgentRegistry, name: &str) {
         let _ = child.kill();
     }
     reg.remove(name);
+}
+
+/// Whether the agent's child process is still running.
+///
+/// Used by the scratch shell overlay to self-close when the user exits the
+/// shell naturally (`exit`, Ctrl+D) or the process crashes. Returns `false`
+/// if the name is no longer registered (already reaped) or `try_wait`
+/// reports the child has exited. A poisoned child mutex is treated as alive
+/// so a spurious poison doesn't auto-dismiss the overlay — Esc still works.
+fn agent_is_alive(registry: &AgentRegistry, name: &str) -> bool {
+    let reg = agent::lock_registry(registry);
+    let Some(handle) = reg.get(name) else {
+        return false;
+    };
+    // Bind to a local so the child-lock's temporary MutexGuard drops
+    // before `reg` does — returning the match expression directly trips
+    // the borrow checker because temporaries outlive the registry lock.
+    let alive = match handle.child.lock() {
+        Ok(mut child) => !matches!(child.try_wait(), Ok(Some(_))),
+        Err(_) => true,
+    };
+    alive
 }

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use crate::agent::AgentRegistry;
 use crate::backend::Backend;
-use crate::layout::{Layout, SplitDir, Tab};
+use crate::layout::{Layout, Pane, SplitDir, Tab};
 
 /// An item in the new-tab selection menu.
 pub struct MenuItem {
@@ -83,6 +83,11 @@ pub(super) enum Overlay {
     Tasks {
         items: Vec<crate::tasks::Task>,
         scroll: usize,
+    },
+    /// Floating scratch shell (Ctrl+B ~). Esc kills the shell and closes the
+    /// overlay. Pane is boxed because it's much larger than any other variant.
+    ScratchShell {
+        pane: Box<Pane>,
     },
 }
 
@@ -506,6 +511,24 @@ pub(super) fn handle_key(
                 *overlay = Overlay::None;
             }
         }
+        Overlay::ScratchShell { pane } => match key.code {
+            KeyCode::Esc => {
+                // Capture the agent name before dropping the pane so we can
+                // kill the shell process. The registry owns the PTY master;
+                // kill_agent drops it, the forwarder thread sees rx close,
+                // and exits. The pane (and its subscriber rx) drop with the
+                // overlay.
+                let name = pane.agent_name.clone();
+                *overlay = Overlay::None;
+                super::kill_agent(ctx.registry, &name);
+            }
+            _ => {
+                let bytes = crate::tui::key_to_bytes(key.code, key.modifiers);
+                if !bytes.is_empty() {
+                    pane.write_input(ctx.registry, &bytes);
+                }
+            }
+        },
         Overlay::None => {}
     }
     outcome

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -44,6 +44,8 @@ pub enum Action {
     ShowTasks,
     Detach,
     ShowHelp,
+    /// Summon a floating scratch shell overlay (Ctrl+B ~). Esc closes & kills it.
+    ScratchShell,
     None,
 }
 
@@ -178,6 +180,7 @@ fn dispatch_prefix(key: KeyEvent) -> Action {
         KeyCode::Char('T') => Action::ShowTasks,
         KeyCode::Char('d') => Action::Detach,
         KeyCode::Char('?') => Action::ShowHelp,
+        KeyCode::Char('~') => Action::ScratchShell,
 
         _ => Action::None,
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1041,6 +1041,7 @@ pub fn render_help(frame: &mut Frame) {
         "",
         "  Other",
         "    Ctrl+B Ctrl+B  Send Ctrl+B to pane",
+        "    Ctrl+B ~       Scratch shell (Esc to close)",
         "    Ctrl+B d       Detach (exit)",
         "    Ctrl+B ?       This help",
         "",
@@ -1276,6 +1277,68 @@ pub fn render_tasks(frame: &mut Frame, items: &[crate::tasks::Task], scroll: usi
         }
     }
     frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// Centered box sized to 60% of `area`, clamped so a tiny window still gets
+/// a readable box. Shared by the spawn path (`Action::ScratchShell` in
+/// `app::dispatch`) and the render path so both agree on geometry.
+pub fn scratch_shell_rect(area: Rect) -> Rect {
+    let w = ((area.width as u32 * 60 / 100) as u16).max(20);
+    let h = ((area.height as u32 * 60 / 100) as u16).max(8);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    Rect::new(x, y, w, h)
+}
+
+/// Render the scratch shell overlay — a centered floating box (~60% of the
+/// terminal) containing the pane's VTerm output. Drains pending output and
+/// adapts VTerm/PTY size to the current box so a resized window stays usable.
+pub fn render_scratch_shell(
+    frame: &mut Frame,
+    pane: &mut crate::layout::Pane,
+    registry: &AgentRegistry,
+) {
+    let oa = scratch_shell_rect(frame.area());
+    frame.render_widget(Clear, oa);
+
+    let title = format!(" Scratch Shell [{}] | Esc close ", pane.label());
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Magenta))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(oa);
+    frame.render_widget(block, oa);
+
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    // Drain pending shell output before reading VTerm.
+    pane.drain_output();
+
+    // Resize VTerm + PTY if the floating box shape changed. Panes in the
+    // layout go through `render::resize_panes` on Event::Resize; overlay
+    // panes aren't in the layout, so we reconcile here on each draw.
+    if inner.width != pane.vterm.cols() || inner.height != pane.vterm.rows() {
+        pane.vterm.resize(inner.width, inner.height);
+        pane.resize_pty(registry, inner.width, inner.height);
+    }
+
+    pane.vterm
+        .render_to_buffer(frame.buffer_mut(), inner, 0, false);
+
+    // Cursor — overlay is always focused, no scroll.
+    let (cursor_line, cursor_col) = pane.vterm.cursor_pos();
+    let cx = inner.x + cursor_col;
+    let cy = inner.y + cursor_line;
+    if cx < inner.x + inner.width && cy < inner.y + inner.height {
+        frame.set_cursor_position(ratatui::layout::Position::new(cx, cy));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Ctrl+B ~ opens a centered 60%-of-terminal floating shell on top of all panes; Esc closes it and kills the shell.
- Auto-closes when the shell exits naturally (`exit`, Ctrl+D, crash) via a 50ms `try_wait` probe in the main loop.
- Shell inherits the focused pane's working directory (fallback: `~/.agend-terminal/scratch`), so `git status` / `ls` / etc. work in the expected cwd.
- Geometry (60% size, centered, min 20×8) lives in `render::scratch_shell_rect` and is shared by the spawn path (PTY size) and draw path (box rect) — prevents drift.

## Test plan

- [ ] Ctrl+B ~ opens the overlay; typing, editors (`vim`, `less`), and `clear` work inside the box.
- [ ] Esc closes the overlay and the shell process is killed (no zombie in `ps`).
- [ ] `exit` / Ctrl+D inside the shell auto-closes the overlay within ~50ms.
- [ ] Opening the overlay with a focused pane inside a git repo → `pwd` shows the pane's cwd.
- [ ] Opening it with no focused pane cwd → falls back to `~/.agend-terminal/scratch`, no per-invocation `workspace/scratch-N/` directories left behind.
- [ ] Resizing the terminal resizes the overlay box and the underlying PTY (shell prompt reflows correctly).
- [ ] Ctrl+B ~ ~ (second ~ after prefix) does not accidentally fire twice.
- [ ] Help (Ctrl+B ?) shows the new binding.