### PR TITLE
fix(channel): make contract test bot-free (portable on macOS)

### DIFF
--- a/src/channel/contract.rs
+++ b/src/channel/contract.rs
@@ -227,10 +227,13 @@ mod tests {
 
     #[test]
     fn telegram_channel_satisfies_contract() {
-        // Dummy token + empty instance map. None of the invariants run
-        // here touch the teloxide HTTP runtime, so no network is needed.
-        let state = TelegramState::new(
-            "dummy_contract_token",
+        // Bot-free constructor: `TelegramState::new` eagerly runs
+        // `Bot::new`, which initializes reqwest + `system-configuration`
+        // and panics on some macOS setups. None of the contract invariants
+        // touch the `bot` field (see module-level "Scope" doc), so we use
+        // the `#[cfg(test)]` `new_for_contract_test` path to keep this
+        // portable across developer machines and CI.
+        let state = TelegramState::new_for_contract_test(
             -100_1234567890,
             HashMap::new(),
             PathBuf::from("/tmp/agend-contract-home"),

--- a/src/channel/contract.rs
+++ b/src/channel/contract.rs
@@ -243,4 +243,25 @@ mod tests {
         let channel = TelegramChannel::new(Arc::new(Mutex::new(state)));
         run_registry_contract(channel, telegram_make_binding);
     }
+
+    /// Locks in the scope boundary of `new_for_contract_test`: if a future
+    /// contract assertion reaches a transport path (here: `send_reply`),
+    /// the `.expect("telegram bot not initialized")` unwrap must fire
+    /// loudly instead of being silently routed past. This guarantees the
+    /// bot-free constructor cannot be abused to paper over a transport
+    /// call sneaking into the harness.
+    #[test]
+    #[should_panic(expected = "telegram bot not initialized")]
+    fn contract_state_panics_if_transport_reached() {
+        let state = Arc::new(Mutex::new(TelegramState::new_for_contract_test(
+            -100_1234567890,
+            HashMap::new(),
+            PathBuf::from("/tmp/agend-contract-home"),
+            HashMap::new(),
+            None,
+        )));
+        // `send_reply` unwraps `bot` before hitting the tokio runtime, so
+        // this panics without needing a live reactor.
+        let _ = crate::channel::telegram::send_reply(&state, "unknown-instance", "hi");
+    }
 }

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -78,7 +78,11 @@ fn telegram_runtime() -> &'static tokio::runtime::Runtime {
 }
 
 pub struct TelegramState {
-    pub bot: Bot,
+    /// `None` only inside the contract-test harness — production `new`
+    /// always populates it via `Bot::new`. Transport methods unwrap with
+    /// `.expect("telegram bot not initialized")`; contract tests never
+    /// reach those paths (see `src/channel/contract.rs` scope comment).
+    pub bot: Option<Bot>,
     #[allow(dead_code)]
     pub group_id: ChatId,
     pub topic_to_instance: HashMap<i32, String>,
@@ -110,7 +114,39 @@ impl TelegramState {
             .map(|(name, &tid)| (tid, name.clone()))
             .collect();
         Self {
-            bot: Bot::new(token),
+            bot: Some(Bot::new(token)),
+            group_id: ChatId(group_id),
+            topic_to_instance,
+            instance_to_topic: topic_map,
+            home,
+            submit_keys,
+            user_allowlist,
+            registry: None,
+        }
+    }
+
+    /// Build a `TelegramState` without constructing a `teloxide::Bot` —
+    /// used by the `src/channel/contract.rs` harness, which only exercises
+    /// registry-side methods (`kind`, `has_binding`, `take_binding`,
+    /// `record_binding`, `attach_registry`). `Bot::new` eagerly initializes
+    /// reqwest + `system-configuration` proxy state and panics on some
+    /// macOS setups, so the harness must not go through it. If a test
+    /// triggers a transport path (`send_to_topic`, `send_reply`, polling),
+    /// the `.expect("telegram bot not initialized")` unwrap will fire.
+    #[cfg(test)]
+    pub(crate) fn new_for_contract_test(
+        group_id: i64,
+        topic_map: HashMap<String, i32>,
+        home: PathBuf,
+        submit_keys: HashMap<String, String>,
+        user_allowlist: Option<Vec<i64>>,
+    ) -> Self {
+        let topic_to_instance: HashMap<i32, String> = topic_map
+            .iter()
+            .map(|(name, &tid)| (tid, name.clone()))
+            .collect();
+        Self {
+            bot: None,
             group_id: ChatId(group_id),
             topic_to_instance,
             instance_to_topic: topic_map,
@@ -137,7 +173,11 @@ impl TelegramState {
             .instance_to_topic
             .get(instance_name)
             .ok_or_else(|| anyhow::anyhow!("No topic for '{instance_name}'"))?;
-        send_with_topic(&self.bot, self.group_id, Some(*topic_id), text).await
+        let bot = self
+            .bot
+            .as_ref()
+            .expect("telegram bot not initialized (contract-test construction?)");
+        send_with_topic(bot, self.group_id, Some(*topic_id), text).await
     }
 }
 
@@ -176,7 +216,10 @@ pub fn start_polling(state: Arc<Mutex<TelegramState>>) {
                 return;
             };
             rt.block_on(async {
-                let bot = lock_state(&state).bot.clone();
+                let bot = lock_state(&state)
+                    .bot
+                    .clone()
+                    .expect("telegram bot not initialized (polling thread)");
                 let state2 = Arc::clone(&state);
                 let handler = Update::filter_message().endpoint(move |_bot: Bot, msg: Message| {
                     let state = Arc::clone(&state2);
@@ -434,7 +477,9 @@ pub fn send_reply(
 ) -> anyhow::Result<()> {
     let s = lock_state(state);
     let (bot, group_id, topic_id, home) = (
-        s.bot.clone(),
+        s.bot
+            .clone()
+            .expect("telegram bot not initialized (send_reply)"),
         s.group_id,
         s.instance_to_topic.get(instance_name).copied(),
         s.home.clone(),


### PR DESCRIPTION
## Summary

- `TelegramState::new` eagerly runs `Bot::new`, which initializes reqwest + `system-configuration` proxy state. On some macOS setups that panics inside `system-configuration` ("Attempted to create a NULL object"), causing `cargo test telegram_channel_satisfies_contract` to fail on a developer machine before any invariant runs.
- The contract harness's stated scope excludes transport methods (`send`, `edit`, `delete`, `poll_event`, `create_binding`, `remove_binding`). All current assertions (`kind`, `has_binding`, `take_binding`, `record_binding`, `attach_registry`) sit outside that scope and never touch `state.bot`.
- Change `TelegramState.bot: Bot` → `Option<Bot>`. Production `new` still returns `Some(Bot::new(token))` unchanged. Add `#[cfg(test)] new_for_contract_test(...)` that leaves `bot = None`. The three transport sites (`send_to_topic`, polling dispatcher, `send_reply`) unwrap with a loud `.expect("telegram bot not initialized")`, so a future contract test that wanders into a transport path fails fast with a clear message rather than papering over the mistake.

## Test plan

- [ ] `cargo test --bin agend-terminal telegram_channel_satisfies_contract` passes on macOS — verified locally.
- [ ] Full suite (`cargo test`) still green — all 585+ tests pass locally.
- [ ] `cargo clippy --all-targets -- -D warnings` clean.
- [ ] CI reproduces on Linux + Windows runners.
- [ ] Manual smoke: start the daemon with a real Telegram token, confirm bot bring-up path still exercises `Bot::new` (it runs through unchanged production `TelegramState::new`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)