### PR TITLE
feat(channel): UxEvent emission + TelegramChannel UxEventSink (T3)

### DIFF
--- a/docs/PLAN-channel-ux-layer.md
+++ b/docs/PLAN-channel-ux-layer.md
@@ -168,6 +168,15 @@ message when no typing-indicator capability exists. Signalling status via
 text messages turns every turn into two-plus messages and creates more noise
 than it relieves. Silence is an acceptable fallback.
 
+**T3 scope narrowing.** The shipped `UxAction` enum covers only
+`React | EditText | SendText | Noop`. The `typing_indicator` column of
+the Q1 table — plus the `AgentThinking` / `AgentRateLimited` rows that
+lean on it — are **deferred to T12** (typing-indicator action + the
+daemon-side dispatcher that ticks `sendChatAction` on a timer). T3 also
+only wires `UserMsgReceived` / `AgentPickedUp` / `AgentReplied`; the
+other rows come online when their producers (inbox dequeue, rate-limit
+gate) land.
+
 ### Q2 — A2A fleet visibility
 
 Split into the two concrete scenarios confirmed as real pain:

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -35,10 +35,12 @@ pub mod caps;
 pub mod contract;
 pub mod event;
 pub mod telegram;
+pub mod ux_event;
 
 pub use binding::BindingRef;
 pub use caps::{ChannelCapabilities, MarkdownDialect, MentionStyle, NativeSeeAllHint, RateBudget};
 pub use event::{ChannelEvent, MsgPayload, MsgRef, OutMsg, RevokeReason, User};
+pub use ux_event::{select_action, NoopUxSink, UxAction, UxEvent, UxEventSink};
 
 use crate::agent::AgentRegistry;
 use anyhow::Result;

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -1117,46 +1117,57 @@ impl crate::channel::ux_event::UxEventSink for TelegramChannel {
         // All transport errors are logged, not propagated — a failed
         // reaction is never a reason to crash the daemon.
         match action {
-            UxAction::React { msg, emoji } => {
-                // `try_telegram_react` takes `instance_name` so it can
-                // resolve the origin msg from on-disk metadata when
-                // `message_id` is None. We always supply the id from
-                // `MsgRef`, so the instance name is only used for the
-                // log context / fallback — pass the binding's display
-                // tag as best-effort identification.
-                let instance = msg.binding.display_tag().unwrap_or("(unknown)");
-                if let Err(e) = try_telegram_react(instance, emoji, Some(&msg.id)) {
+            UxAction::React {
+                instance,
+                msg,
+                emoji,
+            } => {
+                // `instance` is the fleet instance name, sourced from
+                // the event's `agent` field by `select_action`. Today
+                // `try_telegram_react` only uses it as a metadata
+                // fallback when `message_id` is None (we always pass
+                // `Some`), but routing through the real instance name
+                // keeps the contract stable if that fallback ever runs.
+                if let Err(e) = try_telegram_react(&instance, emoji, Some(&msg.id)) {
                     tracing::warn!(
                         %e,
+                        instance = %instance,
                         msg_id = %msg.id,
                         emoji,
                         "UxEventSink: react failed"
                     );
                 }
             }
-            UxAction::EditText { msg, text } => {
-                let instance = msg.binding.display_tag().unwrap_or("(unknown)");
-                if let Err(e) = try_telegram_edit(instance, &msg.id, &text) {
+            UxAction::EditText {
+                instance,
+                msg,
+                text,
+            } => {
+                if let Err(e) = try_telegram_edit(&instance, &msg.id, &text) {
                     tracing::warn!(
                         %e,
+                        instance = %instance,
                         msg_id = %msg.id,
                         "UxEventSink: edit failed"
                     );
                 }
             }
-            UxAction::SendText { binding, text } => {
-                // `try_telegram_reply` keys on instance name to look up
-                // the topic id. The binding's `display_tag` carries
-                // e.g. "TG#229"; we extract the instance name from
-                // whatever the daemon recorded on record_binding. For
-                // T3 we keep the fallback path simple — the instance
-                // name is the display tag. Future dispatcher PR will
-                // route through a proper instance-resolution step.
-                let instance = binding.display_tag().unwrap_or("(unknown)");
-                if let Err(e) = try_telegram_reply(instance, &text) {
+            UxAction::SendText {
+                instance,
+                binding: _binding,
+                text,
+            } => {
+                // `try_telegram_reply` calls `config.instances.get(instance_name)`
+                // to resolve the routing topic. `instance` MUST be the
+                // fleet key (agent name) — NOT `binding.display_tag()`,
+                // which is a human-readable label like "TG#229" and
+                // would silently bail the fleet lookup. See
+                // `ux_event::agent_replied_instance_comes_from_agent_not_display_tag`
+                // for the pin.
+                if let Err(e) = try_telegram_reply(&instance, &text) {
                     tracing::warn!(
                         %e,
-                        instance,
+                        instance = %instance,
                         "UxEventSink: send failed"
                     );
                 }

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -982,6 +982,18 @@ impl TelegramChannel {
     pub(crate) fn state(&self) -> &Arc<Mutex<TelegramState>> {
         &self.state
     }
+
+    /// Test-only constructor that lets unit tests exercise the
+    /// `UxEventSink` impl under arbitrary cap combinations (e.g.
+    /// caps-neither to hit the Noop branch without going to the
+    /// Bot API).
+    #[cfg(test)]
+    pub(crate) fn with_caps(
+        state: Arc<Mutex<TelegramState>>,
+        caps: crate::channel::ChannelCapabilities,
+    ) -> Self {
+        Self { state, caps }
+    }
 }
 
 impl crate::channel::Channel for TelegramChannel {
@@ -1081,6 +1093,81 @@ impl crate::channel::Channel for TelegramChannel {
     fn attach_registry(&self, registry: AgentRegistry) {
         let mut s = lock_state(&self.state);
         s.registry = Some(registry);
+    }
+}
+
+// ─── UxEventSink: capability-gated degradation ────────────────────────
+//
+// `TelegramChannel` consumes UxEvents and renders them via whichever
+// primitive its caps support. The pure decision lives in
+// `crate::channel::ux_event::select_action`; this impl just executes
+// the chosen action against the existing free-fn Bot API helpers
+// (`try_telegram_reply` / `try_telegram_edit` / `try_telegram_react`).
+//
+// Why free fns not `Channel::send/edit/delete`? Those trait methods are
+// still `bail!` stubs (lines above); the real dispatcher wiring lands
+// in a later PR. Keeping the UxEventSink path on free fns lets T3 ship
+// without blowing scope into the dispatcher cut-over. The two paths
+// collapse once the dispatcher arrives. See PR body for the full
+// rationale (reviewer: at-dev-4 flagged this shape up-front).
+impl crate::channel::ux_event::UxEventSink for TelegramChannel {
+    fn emit(&self, event: &crate::channel::ux_event::UxEvent) {
+        use crate::channel::ux_event::{select_action, UxAction};
+        let action = select_action(event, &self.caps);
+        // All transport errors are logged, not propagated — a failed
+        // reaction is never a reason to crash the daemon.
+        match action {
+            UxAction::React { msg, emoji } => {
+                // `try_telegram_react` takes `instance_name` so it can
+                // resolve the origin msg from on-disk metadata when
+                // `message_id` is None. We always supply the id from
+                // `MsgRef`, so the instance name is only used for the
+                // log context / fallback — pass the binding's display
+                // tag as best-effort identification.
+                let instance = msg.binding.display_tag().unwrap_or("(unknown)");
+                if let Err(e) = try_telegram_react(instance, emoji, Some(&msg.id)) {
+                    tracing::warn!(
+                        %e,
+                        msg_id = %msg.id,
+                        emoji,
+                        "UxEventSink: react failed"
+                    );
+                }
+            }
+            UxAction::EditText { msg, text } => {
+                let instance = msg.binding.display_tag().unwrap_or("(unknown)");
+                if let Err(e) = try_telegram_edit(instance, &msg.id, &text) {
+                    tracing::warn!(
+                        %e,
+                        msg_id = %msg.id,
+                        "UxEventSink: edit failed"
+                    );
+                }
+            }
+            UxAction::SendText { binding, text } => {
+                // `try_telegram_reply` keys on instance name to look up
+                // the topic id. The binding's `display_tag` carries
+                // e.g. "TG#229"; we extract the instance name from
+                // whatever the daemon recorded on record_binding. For
+                // T3 we keep the fallback path simple — the instance
+                // name is the display tag. Future dispatcher PR will
+                // route through a proper instance-resolution step.
+                let instance = binding.display_tag().unwrap_or("(unknown)");
+                if let Err(e) = try_telegram_reply(instance, &text) {
+                    tracing::warn!(
+                        %e,
+                        instance,
+                        "UxEventSink: send failed"
+                    );
+                }
+            }
+            UxAction::Noop => {
+                // Plan §6: silence is an acceptable fallback. Record
+                // that we intentionally dropped the event so future
+                // debugging knows it wasn't a bug.
+                tracing::debug!(?event, "UxEventSink: Noop (caps do not support)");
+            }
+        }
     }
 }
 
@@ -1205,6 +1292,46 @@ mod tests {
         assert_eq!(map_emoji_name("thumbs_down"), "👎");
         assert_eq!(map_emoji_name("tada"), "🎉");
         assert_eq!(map_emoji_name("party"), "🎉");
+    }
+
+    /// Exercises the `UxEventSink` impl down the Noop branch — the only
+    /// cap combo that does not touch the Bot API. Asserts the impl
+    /// compiles, is dyn-safe, and does not panic when the adapter's
+    /// caps reject the event. Full-path React / Edit / Send branches
+    /// need a live Bot API and are exercised via integration tests
+    /// (out of scope for T3).
+    #[test]
+    fn telegram_channel_emit_noop_when_caps_reject() {
+        use crate::channel::{
+            ux_event::{UxEvent, UxEventSink},
+            BindingRef, ChannelCapabilities, MsgRef,
+        };
+        // Caps-neither: no react, no edit → AgentPickedUp degrades to Noop.
+        let caps = ChannelCapabilities {
+            react: false,
+            edit: false,
+            ..Default::default()
+        };
+        let state = TelegramState::new(
+            "tok",
+            -1,
+            HashMap::new(),
+            PathBuf::from("/tmp"),
+            HashMap::new(),
+            None,
+        );
+        let channel = TelegramChannel::with_caps(Arc::new(Mutex::new(state)), caps);
+
+        let origin = MsgRef {
+            binding: BindingRef::new("telegram", Some("test-agent".into()), ()),
+            id: "1".into(),
+        };
+        let ev = UxEvent::AgentPickedUp {
+            origin_msg: origin,
+            agent: "test-agent".into(),
+        };
+        // Must not panic. Noop branch only logs via tracing::debug.
+        (&channel as &dyn UxEventSink).emit(&ev);
     }
 
     /// Guards the UX-layer cap values shipped with the Telegram adapter.

--- a/src/channel/ux_event.rs
+++ b/src/channel/ux_event.rs
@@ -76,11 +76,35 @@ pub enum UxEvent {
 #[derive(Debug, Clone)]
 pub enum UxAction {
     /// Apply a reaction emoji on an existing message.
-    React { msg: MsgRef, emoji: &'static str },
-    /// Edit an existing message to a new text body.
-    EditText { msg: MsgRef, text: String },
-    /// Send a new text message to a binding.
-    SendText { binding: BindingRef, text: String },
+    ///
+    /// `instance` is the receiving agent's name — the key used by
+    /// `try_telegram_*` helpers to resolve the routing topic. It is
+    /// copied from the originating `UxEvent`'s `agent` field, NOT
+    /// derived from `BindingRef::display_tag` (which is a
+    /// human-readable label like "TG#229", not a lookup key — see
+    /// `config.instances.get(instance_name)` in
+    /// `channel::telegram::try_telegram_reply`).
+    React {
+        instance: String,
+        msg: MsgRef,
+        emoji: &'static str,
+    },
+    /// Edit an existing message to a new text body. See `React` for
+    /// `instance` semantics.
+    EditText {
+        instance: String,
+        msg: MsgRef,
+        text: String,
+    },
+    /// Send a new text message to a binding. See `React` for
+    /// `instance` semantics — this is the variant where getting it
+    /// wrong matters: `try_telegram_reply` bails if the instance
+    /// name does not match a fleet entry.
+    SendText {
+        instance: String,
+        binding: BindingRef,
+        text: String,
+    },
     /// Do nothing — the adapter's capability matrix has no way to
     /// express this event without resorting to a noisier fallback the
     /// plan explicitly forbids (plan §6 anti-feature on status text).
@@ -119,14 +143,16 @@ impl UxEventSink for NoopUxSink {
 /// (`PLAN-channel-ux-layer.md` §6) against the code 1-to-1.
 pub fn select_action(event: &UxEvent, caps: &ChannelCapabilities) -> UxAction {
     match event {
-        UxEvent::UserMsgReceived { origin_msg, .. } => {
+        UxEvent::UserMsgReceived { origin_msg, agent } => {
             if caps.react {
                 UxAction::React {
+                    instance: agent.clone(),
                     msg: origin_msg.clone(),
                     emoji: "👀",
                 }
             } else if caps.edit {
                 UxAction::EditText {
+                    instance: agent.clone(),
                     msg: origin_msg.clone(),
                     text: "[delivered]".to_string(),
                 }
@@ -135,20 +161,23 @@ pub fn select_action(event: &UxEvent, caps: &ChannelCapabilities) -> UxAction {
                 // binding. `origin_msg.binding` is the right target
                 // because the ack is a reply into the user's thread.
                 UxAction::SendText {
+                    instance: agent.clone(),
                     binding: origin_msg.binding.clone(),
                     text: "✓ delivered".to_string(),
                 }
             }
         }
-        UxEvent::AgentPickedUp { origin_msg, .. } => {
+        UxEvent::AgentPickedUp { origin_msg, agent } => {
             if caps.react {
                 UxAction::React {
+                    instance: agent.clone(),
                     msg: origin_msg.clone(),
                     // Plan §6: "stack ✅ on origin" alongside the earlier 👀.
                     emoji: "✅",
                 }
             } else if caps.edit {
                 UxAction::EditText {
+                    instance: agent.clone(),
                     msg: origin_msg.clone(),
                     text: "[read]".to_string(),
                 }
@@ -159,12 +188,22 @@ pub fn select_action(event: &UxEvent, caps: &ChannelCapabilities) -> UxAction {
                 UxAction::Noop
             }
         }
-        UxEvent::AgentReplied { binding, text, .. } => {
+        UxEvent::AgentReplied {
+            agent,
+            binding,
+            text,
+        } => {
             // No degradation: the reply text *is* the primitive, and
             // every capability combination renders it as a send. This
             // arm exists explicitly so the outer match is exhaustive
             // and reviewers can see the "never degraded" decision.
+            //
+            // `instance` comes from `agent` (the fleet instance key),
+            // NOT from `binding.display_tag()` — the latter is a
+            // human-readable label and will miss the `config.instances`
+            // lookup in `try_telegram_reply`.
             UxAction::SendText {
+                instance: agent.clone(),
                 binding: binding.clone(),
                 text: text.clone(),
             }
@@ -220,10 +259,20 @@ mod tests {
         ChannelCapabilities::default() // both false.
     }
 
-    // Helper: assert React action with expected message-id + emoji.
-    fn assert_react(action: &UxAction, expected_msg_id: &str, expected_emoji: &str) {
+    // Helper: assert React action with expected instance + message-id + emoji.
+    fn assert_react(
+        action: &UxAction,
+        expected_instance: &str,
+        expected_msg_id: &str,
+        expected_emoji: &str,
+    ) {
         match action {
-            UxAction::React { msg, emoji } => {
+            UxAction::React {
+                instance,
+                msg,
+                emoji,
+            } => {
+                assert_eq!(instance, expected_instance, "instance");
                 assert_eq!(msg.id, expected_msg_id, "msg id");
                 assert_eq!(*emoji, expected_emoji, "emoji");
             }
@@ -231,10 +280,20 @@ mod tests {
         }
     }
 
-    // Helper: assert EditText action with expected message-id + body.
-    fn assert_edit(action: &UxAction, expected_msg_id: &str, expected_text: &str) {
+    // Helper: assert EditText action with expected instance + message-id + body.
+    fn assert_edit(
+        action: &UxAction,
+        expected_instance: &str,
+        expected_msg_id: &str,
+        expected_text: &str,
+    ) {
         match action {
-            UxAction::EditText { msg, text } => {
+            UxAction::EditText {
+                instance,
+                msg,
+                text,
+            } => {
+                assert_eq!(instance, expected_instance, "instance");
                 assert_eq!(msg.id, expected_msg_id, "msg id");
                 assert_eq!(text, expected_text, "edit text");
             }
@@ -242,10 +301,20 @@ mod tests {
         }
     }
 
-    // Helper: assert SendText action with expected binding-tag + text.
-    fn assert_send(action: &UxAction, expected_tag: &str, expected_text: &str) {
+    // Helper: assert SendText action with expected instance + binding-tag + text.
+    fn assert_send(
+        action: &UxAction,
+        expected_instance: &str,
+        expected_tag: &str,
+        expected_text: &str,
+    ) {
         match action {
-            UxAction::SendText { binding, text } => {
+            UxAction::SendText {
+                instance,
+                binding,
+                text,
+            } => {
+                assert_eq!(instance, expected_instance, "instance");
                 assert_eq!(binding.display_tag(), Some(expected_tag), "binding tag");
                 assert_eq!(text, expected_text, "send text");
             }
@@ -261,7 +330,12 @@ mod tests {
             origin_msg: msg("tg#1", "42"),
             agent: "agent-a".into(),
         };
-        assert_react(&select_action(&ev, &caps_react_only()), "42", "👀");
+        assert_react(
+            &select_action(&ev, &caps_react_only()),
+            "agent-a",
+            "42",
+            "👀",
+        );
     }
 
     #[test]
@@ -270,7 +344,12 @@ mod tests {
             origin_msg: msg("tg#1", "42"),
             agent: "agent-a".into(),
         };
-        assert_edit(&select_action(&ev, &caps_edit_only()), "42", "[delivered]");
+        assert_edit(
+            &select_action(&ev, &caps_edit_only()),
+            "agent-a",
+            "42",
+            "[delivered]",
+        );
     }
 
     #[test]
@@ -279,7 +358,12 @@ mod tests {
             origin_msg: msg("tg#1", "42"),
             agent: "agent-a".into(),
         };
-        assert_send(&select_action(&ev, &caps_neither()), "tg#1", "✓ delivered");
+        assert_send(
+            &select_action(&ev, &caps_neither()),
+            "agent-a",
+            "tg#1",
+            "✓ delivered",
+        );
     }
 
     #[test]
@@ -302,7 +386,12 @@ mod tests {
             origin_msg: msg("tg#1", "42"),
             agent: "agent-a".into(),
         };
-        assert_react(&select_action(&ev, &caps_react_only()), "42", "✅");
+        assert_react(
+            &select_action(&ev, &caps_react_only()),
+            "agent-a",
+            "42",
+            "✅",
+        );
     }
 
     #[test]
@@ -311,7 +400,12 @@ mod tests {
             origin_msg: msg("tg#1", "42"),
             agent: "agent-a".into(),
         };
-        assert_edit(&select_action(&ev, &caps_edit_only()), "42", "[read]");
+        assert_edit(
+            &select_action(&ev, &caps_edit_only()),
+            "agent-a",
+            "42",
+            "[read]",
+        );
     }
 
     #[test]
@@ -354,7 +448,76 @@ mod tests {
             caps_edit_only(),
             caps_react_and_edit(),
         ] {
-            assert_send(&select_action(&ev, &caps), "tg#1", "hello");
+            assert_send(&select_action(&ev, &caps), "agent-a", "tg#1", "hello");
+        }
+    }
+
+    /// Regression for the PR #49 review finding: `UxAction::SendText`
+    /// was sourcing `instance` from `binding.display_tag()`, which is
+    /// a human-readable label like "TG#42" and will fail the
+    /// `config.instances.get(instance_name)` lookup in
+    /// `try_telegram_reply`. This test pins that `instance` MUST come
+    /// from the event's `agent` field regardless of what the binding
+    /// renders as.
+    #[test]
+    fn agent_replied_instance_comes_from_agent_not_display_tag() {
+        let ev = UxEvent::AgentReplied {
+            agent: "instance-a".into(),
+            // display_tag deliberately does NOT match `agent` — a
+            // legacy render string that would fail a fleet lookup.
+            binding: binding("TG#42"),
+            text: "hi".into(),
+        };
+        match select_action(&ev, &ChannelCapabilities::default()) {
+            UxAction::SendText {
+                instance, binding, ..
+            } => {
+                assert_eq!(instance, "instance-a", "instance must be the agent name");
+                assert_ne!(
+                    instance,
+                    binding.display_tag().unwrap_or_default(),
+                    "instance must NOT equal display_tag — that was the bug"
+                );
+            }
+            other => panic!("expected SendText, got {other:?}"),
+        }
+    }
+
+    /// Same pin for the degradation paths: when UserMsgReceived falls
+    /// through to the SendText ack column, `instance` must still be
+    /// the agent name, not a display-tag scrape.
+    #[test]
+    fn user_msg_received_send_ack_instance_comes_from_agent() {
+        let ev = UxEvent::UserMsgReceived {
+            origin_msg: msg("TG#42", "100"),
+            agent: "instance-a".into(),
+        };
+        match select_action(&ev, &caps_neither()) {
+            UxAction::SendText { instance, .. } => {
+                assert_eq!(instance, "instance-a");
+            }
+            other => panic!("expected SendText, got {other:?}"),
+        }
+    }
+
+    /// And for react/edit — even though today's `try_telegram_react`
+    /// uses `instance_name` only as a metadata fallback when
+    /// `message_id` is None (we always pass Some), the field should
+    /// still carry the agent name so future call sites that DO rely
+    /// on the lookup don't regress.
+    #[test]
+    fn react_and_edit_instance_comes_from_agent() {
+        let ev = UxEvent::UserMsgReceived {
+            origin_msg: msg("TG#42", "100"),
+            agent: "instance-a".into(),
+        };
+        match select_action(&ev, &caps_react_only()) {
+            UxAction::React { instance, .. } => assert_eq!(instance, "instance-a"),
+            other => panic!("expected React, got {other:?}"),
+        }
+        match select_action(&ev, &caps_edit_only()) {
+            UxAction::EditText { instance, .. } => assert_eq!(instance, "instance-a"),
+            other => panic!("expected EditText, got {other:?}"),
         }
     }
 

--- a/src/channel/ux_event.rs
+++ b/src/channel/ux_event.rs
@@ -1,0 +1,380 @@
+//! Outbound semantic events — emitted by the daemon, consumed by channel
+//! adapters, translated into platform actions via capability-gated
+//! degradation.
+//!
+//! Per `docs/PLAN-channel-ux-layer.md` §4 + §6, `UxEvent` is what the daemon
+//! observes about user ↔ agent interaction (message received, picked up,
+//! replied). It is NOT a Telegram / Discord / Slack API return — the trigger
+//! is a daemon-side state change. Adapters sit behind the [`UxEventSink`]
+//! trait and, via [`select_action`], pick the strongest primitive their
+//! capabilities support: react > edit > send > noop.
+//!
+//! ## Scope of this file (T3 narrow scope)
+//!
+//! Only the Q1 delivery-confirmation subset is defined here:
+//! [`UxEvent::UserMsgReceived`], [`UxEvent::AgentPickedUp`], and
+//! [`UxEvent::AgentReplied`]. `AgentThinking` / `AgentIdle` /
+//! `AgentRateLimited` / `AgentCrashed` / `AgentRestarted` and the
+//! `Fleet(FleetEvent)` variant are deferred to a follow-up PR — they do
+//! not touch the Telegram send / edit / react paths in Q1, so landing
+//! them here would be speculative dead code.
+//!
+//! ## Plan reference
+//!
+//! The Q1 rendering table comes straight from `PLAN-channel-ux-layer.md`
+//! §6:
+//!
+//! | Event            | `react`  | `edit` only        | None         |
+//! |------------------|----------|--------------------|--------------|
+//! | UserMsgReceived  | 👀 on origin | edit origin → `[delivered]` | `✓ delivered` |
+//! | AgentPickedUp    | stack ✅ on origin | edit origin → `[read]` | no-op        |
+//! | AgentReplied     | send reply | send reply     | send reply  |
+//!
+//! `typing_indicator` is not part of T3 (no `AgentThinking` variant here).
+
+use super::{BindingRef, ChannelCapabilities, MsgRef};
+
+/// Semantic event describing what the daemon just observed. Adapters
+/// consume these via [`UxEventSink::emit`] and render into a
+/// platform-specific action picked by [`select_action`].
+#[derive(Debug, Clone)]
+pub enum UxEvent {
+    /// A user message was received and routed to an agent. Trigger site:
+    /// dispatcher ingress (not yet wired in T3; emission-producing code
+    /// lands with the dispatcher PR).
+    UserMsgReceived {
+        /// Reference to the user's original message, so the adapter can
+        /// react / edit against it.
+        origin_msg: MsgRef,
+        /// Receiving agent's name — carried for logging / renderer
+        /// context; not required by the Q1 table itself.
+        agent: String,
+    },
+    /// The agent's inbox dequeued the message. Trigger site: per-agent
+    /// dispatcher (also out of scope for T3 wiring).
+    AgentPickedUp { origin_msg: MsgRef, agent: String },
+    /// The agent produced a reply intended for a specific binding.
+    /// Trigger site: agent output path.
+    AgentReplied {
+        agent: String,
+        /// Binding the reply is destined for (e.g. the user's topic).
+        binding: BindingRef,
+        /// Rendered reply text. The content *is* the primitive for this
+        /// event, so there is no degradation ladder — every capability
+        /// combination renders via `send`.
+        text: String,
+    },
+}
+
+/// Platform-agnostic action chosen by [`select_action`] given a
+/// `(UxEvent × ChannelCapabilities)` pair. Adapters match on this and
+/// call their own native primitive.
+///
+/// Note: no `PartialEq` derive — `BindingRef` and `MsgRef` are
+/// deliberately opaque (payload is `Arc<dyn Any>`). Tests assert via
+/// pattern-matching and field-by-field checks instead.
+#[derive(Debug, Clone)]
+pub enum UxAction {
+    /// Apply a reaction emoji on an existing message.
+    React { msg: MsgRef, emoji: &'static str },
+    /// Edit an existing message to a new text body.
+    EditText { msg: MsgRef, text: String },
+    /// Send a new text message to a binding.
+    SendText { binding: BindingRef, text: String },
+    /// Do nothing — the adapter's capability matrix has no way to
+    /// express this event without resorting to a noisier fallback the
+    /// plan explicitly forbids (plan §6 anti-feature on status text).
+    Noop,
+}
+
+/// Sink trait any consumer of `UxEvent` implements. `TelegramChannel`
+/// is the only real impl in T3; the daemon-wide sink registry / merged
+/// stream of sinks is a follow-up PR once there's a real producer.
+pub trait UxEventSink: Send + Sync {
+    /// Fire-and-forget delivery. Impls must not panic; transport errors
+    /// are logged, not propagated (a failed reaction is never a reason
+    /// to crash the daemon).
+    fn emit(&self, event: &UxEvent);
+}
+
+/// Default sink that records events to `tracing::debug!` only. Used
+/// by tests / early wiring where no real adapter is present.
+pub struct NoopUxSink;
+
+impl UxEventSink for NoopUxSink {
+    fn emit(&self, event: &UxEvent) {
+        tracing::debug!(?event, "NoopUxSink::emit (drop)");
+    }
+}
+
+/// Pure decision function: given an event and the adapter's caps,
+/// pick the strongest primitive the adapter can express.
+///
+/// Caller is cap-blind by design (plan §6 anti-feature: "never mirror
+/// AgentThinking into a text 'agent is typing...' message when no
+/// typing-indicator capability exists"). The silence fallback is the
+/// adapter's call; this function is where that call is made.
+///
+/// Exhaustive on the event axis so reviewers can diff the Q1 table
+/// (`PLAN-channel-ux-layer.md` §6) against the code 1-to-1.
+pub fn select_action(event: &UxEvent, caps: &ChannelCapabilities) -> UxAction {
+    match event {
+        UxEvent::UserMsgReceived { origin_msg, .. } => {
+            if caps.react {
+                UxAction::React {
+                    msg: origin_msg.clone(),
+                    emoji: "👀",
+                }
+            } else if caps.edit {
+                UxAction::EditText {
+                    msg: origin_msg.clone(),
+                    text: "[delivered]".to_string(),
+                }
+            } else {
+                // Plan §6 last column: short ack message to the same
+                // binding. `origin_msg.binding` is the right target
+                // because the ack is a reply into the user's thread.
+                UxAction::SendText {
+                    binding: origin_msg.binding.clone(),
+                    text: "✓ delivered".to_string(),
+                }
+            }
+        }
+        UxEvent::AgentPickedUp { origin_msg, .. } => {
+            if caps.react {
+                UxAction::React {
+                    msg: origin_msg.clone(),
+                    // Plan §6: "stack ✅ on origin" alongside the earlier 👀.
+                    emoji: "✅",
+                }
+            } else if caps.edit {
+                UxAction::EditText {
+                    msg: origin_msg.clone(),
+                    text: "[read]".to_string(),
+                }
+            } else {
+                // Plan §6 last column: "no-op (already acked)" — the
+                // UserMsgReceived render already put a `✓ delivered`
+                // message in the thread; a second one would be noise.
+                UxAction::Noop
+            }
+        }
+        UxEvent::AgentReplied { binding, text, .. } => {
+            // No degradation: the reply text *is* the primitive, and
+            // every capability combination renders it as a send. This
+            // arm exists explicitly so the outer match is exhaustive
+            // and reviewers can see the "never degraded" decision.
+            UxAction::SendText {
+                binding: binding.clone(),
+                text: text.clone(),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::{binding::BindingRef, caps::ChannelCapabilities};
+
+    fn binding(tag: &str) -> BindingRef {
+        BindingRef::new(
+            "test",
+            Some(tag.to_string()),
+            // Payload shape is irrelevant for select_action.
+            (),
+        )
+    }
+
+    fn msg(tag: &str, id: &str) -> MsgRef {
+        MsgRef {
+            binding: binding(tag),
+            id: id.to_string(),
+        }
+    }
+
+    /// Caps combos we exercise. Matches the Q1 table columns.
+    fn caps_react_only() -> ChannelCapabilities {
+        ChannelCapabilities {
+            react: true,
+            edit: false,
+            ..Default::default()
+        }
+    }
+    fn caps_edit_only() -> ChannelCapabilities {
+        ChannelCapabilities {
+            react: false,
+            edit: true,
+            ..Default::default()
+        }
+    }
+    fn caps_react_and_edit() -> ChannelCapabilities {
+        // react wins the ladder.
+        ChannelCapabilities {
+            react: true,
+            edit: true,
+            ..Default::default()
+        }
+    }
+    fn caps_neither() -> ChannelCapabilities {
+        ChannelCapabilities::default() // both false.
+    }
+
+    // Helper: assert React action with expected message-id + emoji.
+    fn assert_react(action: &UxAction, expected_msg_id: &str, expected_emoji: &str) {
+        match action {
+            UxAction::React { msg, emoji } => {
+                assert_eq!(msg.id, expected_msg_id, "msg id");
+                assert_eq!(*emoji, expected_emoji, "emoji");
+            }
+            other => panic!("expected React, got {other:?}"),
+        }
+    }
+
+    // Helper: assert EditText action with expected message-id + body.
+    fn assert_edit(action: &UxAction, expected_msg_id: &str, expected_text: &str) {
+        match action {
+            UxAction::EditText { msg, text } => {
+                assert_eq!(msg.id, expected_msg_id, "msg id");
+                assert_eq!(text, expected_text, "edit text");
+            }
+            other => panic!("expected EditText, got {other:?}"),
+        }
+    }
+
+    // Helper: assert SendText action with expected binding-tag + text.
+    fn assert_send(action: &UxAction, expected_tag: &str, expected_text: &str) {
+        match action {
+            UxAction::SendText { binding, text } => {
+                assert_eq!(binding.display_tag(), Some(expected_tag), "binding tag");
+                assert_eq!(text, expected_text, "send text");
+            }
+            other => panic!("expected SendText, got {other:?}"),
+        }
+    }
+
+    // ─── UserMsgReceived row ─────────────────────────────────────────
+
+    #[test]
+    fn user_msg_received_react_emits_eyes_reaction() {
+        let ev = UxEvent::UserMsgReceived {
+            origin_msg: msg("tg#1", "42"),
+            agent: "agent-a".into(),
+        };
+        assert_react(&select_action(&ev, &caps_react_only()), "42", "👀");
+    }
+
+    #[test]
+    fn user_msg_received_edit_only_annotates_origin() {
+        let ev = UxEvent::UserMsgReceived {
+            origin_msg: msg("tg#1", "42"),
+            agent: "agent-a".into(),
+        };
+        assert_edit(&select_action(&ev, &caps_edit_only()), "42", "[delivered]");
+    }
+
+    #[test]
+    fn user_msg_received_neither_cap_sends_short_ack() {
+        let ev = UxEvent::UserMsgReceived {
+            origin_msg: msg("tg#1", "42"),
+            agent: "agent-a".into(),
+        };
+        assert_send(&select_action(&ev, &caps_neither()), "tg#1", "✓ delivered");
+    }
+
+    #[test]
+    fn user_msg_received_react_beats_edit_when_both() {
+        let ev = UxEvent::UserMsgReceived {
+            origin_msg: msg("tg#1", "42"),
+            agent: "agent-a".into(),
+        };
+        assert!(matches!(
+            select_action(&ev, &caps_react_and_edit()),
+            UxAction::React { .. }
+        ));
+    }
+
+    // ─── AgentPickedUp row ───────────────────────────────────────────
+
+    #[test]
+    fn agent_picked_up_react_emits_check_reaction() {
+        let ev = UxEvent::AgentPickedUp {
+            origin_msg: msg("tg#1", "42"),
+            agent: "agent-a".into(),
+        };
+        assert_react(&select_action(&ev, &caps_react_only()), "42", "✅");
+    }
+
+    #[test]
+    fn agent_picked_up_edit_only_annotates_origin() {
+        let ev = UxEvent::AgentPickedUp {
+            origin_msg: msg("tg#1", "42"),
+            agent: "agent-a".into(),
+        };
+        assert_edit(&select_action(&ev, &caps_edit_only()), "42", "[read]");
+    }
+
+    #[test]
+    fn agent_picked_up_neither_cap_is_noop() {
+        let ev = UxEvent::AgentPickedUp {
+            origin_msg: msg("tg#1", "42"),
+            agent: "agent-a".into(),
+        };
+        assert!(matches!(
+            select_action(&ev, &caps_neither()),
+            UxAction::Noop
+        ));
+    }
+
+    #[test]
+    fn agent_picked_up_react_beats_edit_when_both() {
+        let ev = UxEvent::AgentPickedUp {
+            origin_msg: msg("tg#1", "42"),
+            agent: "agent-a".into(),
+        };
+        assert!(matches!(
+            select_action(&ev, &caps_react_and_edit()),
+            UxAction::React { .. }
+        ));
+    }
+
+    // ─── AgentReplied row — never degraded ───────────────────────────
+
+    #[test]
+    fn agent_replied_always_sends_regardless_of_caps() {
+        let ev = UxEvent::AgentReplied {
+            agent: "agent-a".into(),
+            binding: binding("tg#1"),
+            text: "hello".into(),
+        };
+        // Every cap combo must return the same SendText shape.
+        for caps in [
+            caps_neither(),
+            caps_react_only(),
+            caps_edit_only(),
+            caps_react_and_edit(),
+        ] {
+            assert_send(&select_action(&ev, &caps), "tg#1", "hello");
+        }
+    }
+
+    // ─── Sink trait sanity ───────────────────────────────────────────
+
+    #[test]
+    fn noop_sink_does_not_panic_on_any_variant() {
+        let sink = NoopUxSink;
+        sink.emit(&UxEvent::UserMsgReceived {
+            origin_msg: msg("tg#1", "1"),
+            agent: "a".into(),
+        });
+        sink.emit(&UxEvent::AgentPickedUp {
+            origin_msg: msg("tg#1", "1"),
+            agent: "a".into(),
+        });
+        sink.emit(&UxEvent::AgentReplied {
+            agent: "a".into(),
+            binding: binding("tg#1"),
+            text: "x".into(),
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Wires the Q1 subset of `PLAN-channel-ux-layer.md` §4 / §6 — `UserMsgReceived`, `AgentPickedUp`, `AgentReplied` — as `UxEvent` variants a daemon-side producer emits to `UxEventSink` consumers. `TelegramChannel` is the first real consumer: `emit()` delegates to a pure `select_action` fn that walks the capability-ladder (React > EditText > SendText > Noop) and picks the right platform primitive. The adapter then executes through the existing free-fn Bot API helpers.

Follow-up to #45 / #47 — closes the T3 slot of `PLAN-channel-abstraction.md` staging.

## Round-2 fixes (reviewer REJECTED PR #49 first round)

- **[HIGH] Wiring bug fixed.** `UxAction::{React, EditText, SendText}` now carry `instance: String`, threaded from the event's `agent` field by `select_action`. `TelegramChannel::emit` passes `&instance` to `try_telegram_*`, no longer scraping `BindingRef::display_tag()` (a human-readable label that would miss `config.instances.get(instance_name)` in `try_telegram_reply`).
- **[HIGH] Regression pinned.** Three new tests in `channel::ux_event`: `agent_replied_instance_comes_from_agent_not_display_tag` explicitly constructs an event where `agent != display_tag` and asserts `SendText.instance == agent`. Companion pins for the UserMsgReceived SendText ack path and React/EditText.
- **[MEDIUM] Plan doc updated.** `docs/PLAN-channel-ux-layer.md` §6 Q1 table has a T3-scope note: `UxAction = React|EditText|SendText|Noop`, `typing_indicator` action + `AgentThinking`/`AgentRateLimited` rows deferred to T12.
- **[COMMENT] Test count corrected** (see verification points below) — 13 ux_event tests (10 from round 1 + 3 new regressions), not "12/13".

## Design plan reference

Design plan was approved by general before code. Key decisions locked in:

- **Interpretation:** daemon emits `UxEvent`, adapter consumes via `UxEventSink`. Caller is cap-blind by design (plan §6 anti-feature).
- **Scope:** Q1 subset only (3 variants). `AgentThinking/Idle/RateLimited/Crashed/Restarted` and `Fleet(FleetEvent)` deferred.
- **Two send paths coexist intentionally** (see below).
- **Degradation lives inside the adapter**, not the caller.

## Two send paths — intentional, not scope creep

The `UxEventSink::emit` impl on `TelegramChannel` routes through the existing free functions (`try_telegram_reply` / `try_telegram_edit` / `try_telegram_react`), **not** through the `Channel::send/edit/delete` trait methods. Those trait methods remain `bail!` stubs — they are the dispatcher PR's concern, not T3's.

The two paths **collapse** once the dispatcher lands. Reviewer should see:
- `Channel::send/edit/delete` — still `bail!` stubs (unchanged from main)
- `impl UxEventSink for TelegramChannel` — new path, uses free fns

## Artifact verification points

| Claim | Where | How to verify |
| --- | --- | --- |
| `UxEvent` enum = Q1 subset only (3 variants) | `src/channel/ux_event.rs` — `enum UxEvent` | shows exactly `UserMsgReceived`, `AgentPickedUp`, `AgentReplied` |
| `UxAction` variants carry `instance: String` (round-2 fix) | `src/channel/ux_event.rs` — `enum UxAction` | React/EditText/SendText each have `instance` field with doc-comment pinning contract |
| `select_action` threads `agent` -> `instance` | `src/channel/ux_event.rs` — `pub fn select_action` | all three event arms clone `agent` into `instance` |
| Emit path uses `&instance`, not `display_tag` | `src/channel/telegram.rs` — `impl UxEventSink for TelegramChannel` | no `.display_tag()` call inside `emit` arms |
| Wiring-bug regression pinned | `src/channel/ux_event.rs::tests` | `agent_replied_instance_comes_from_agent_not_display_tag` constructs `agent="instance-a"` + `display_tag="TG#42"` and asserts `SendText.instance == "instance-a"` |
| Q1 table rows map 1:1 to tests | `src/channel/ux_event.rs::tests` | `cargo test --bin agend-terminal channel::ux_event` — 13 tests (10 table coverage + 3 regression pins) |
| TelegramChannel impls `UxEventSink` (dyn-safe) | `src/channel/telegram.rs` | test `telegram_channel_emit_noop_when_caps_reject` casts to `&dyn UxEventSink` |
| Noop branch hits no I/O | `src/channel/telegram.rs` — `UxAction::Noop` arm | arm body is just `tracing::debug!` |
| `Channel::send/edit/delete` trait stubs untouched | `src/channel/telegram.rs` | `git diff main..HEAD -- src/channel/telegram.rs` shows no change to those three fns |
| Plan doc T3-scope note added | `docs/PLAN-channel-ux-layer.md` §6 | paragraph under Q1 table beginning "T3 scope narrowing." |
| No regressions | full suite | `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` |

## Verification commands

```bash
# Round-2 regression pins (NEW)
cargo test --bin agend-terminal channel::ux_event::tests::agent_replied_instance_comes_from_agent_not_display_tag
cargo test --bin agend-terminal channel::ux_event::tests::user_msg_received_send_ack_instance_comes_from_agent
cargo test --bin agend-terminal channel::ux_event::tests::react_and_edit_instance_comes_from_agent

# Correctness
cargo test --bin agend-terminal channel::ux_event
cargo test --bin agend-terminal channel::telegram::tests::telegram_channel_emit_noop_when_caps_reject

# Whole-suite sanity
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test
```

All green locally at HEAD.

## Out of scope (intentional)

- Daemon-wide `UxEventSink` registry / merged stream — needs a real producer.
- Producer-side emission from dispatcher / agent lifecycle / agent output.
- Remaining `UxEvent` variants (`AgentThinking/Idle/RateLimited/Crashed/Restarted`) + `FleetEvent`.
- `Channel::send/edit/delete` trait-stub fill-in — dispatcher PR.
- Integration tests hitting live Bot API for the React / Edit / Send branches of the Telegram emit path.
- `typing_indicator` UxAction + `AgentThinking` / `AgentRateLimited` rows — deferred to T12.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test channel::ux_event` — 13 tests (10 Q1-table coverage + 3 round-2 regression pins) pass
- [x] `cargo test channel::telegram::tests::telegram_channel_emit_noop_when_caps_reject` passes
- [x] `cargo test` full suite passes
- [ ] Reviewer confirms Q1 table <-> tests mapping is 1:1
- [ ] Reviewer confirms the "two send paths coexist" trade-off is acceptable and scoped correctly
- [ ] Reviewer confirms round-2 wiring fix: `agent` is the sole source of `instance`, `display_tag` is not consulted on any emit path
