### PR TITLE
docs: Wave 3 skeleton

### DIFF
--- a/docs/DESIGN-stage-b-ux.md
+++ b/docs/DESIGN-stage-b-ux.md
@@ -1,0 +1,309 @@
+# Stage B-UX — Fleet visibility (Q2) implementation
+
+**Status:** design doc for Wave 3 / Stage B-UX。對應 `PLAN-channel-ux-layer.md`
+§9 Stage B-UX、§6 Q2 (S2c + S2d)、§7 `fleet_binding`、§4 `FleetEvent`。
+派工前 inline-reviewed by general，非 PR 流程。
+
+## 1. Scope
+
+四塊：
+
+1. **Config parsing** — `channels.<name>.fleet_binding`（plan §7）
+2. **FleetEvent producer** — 4 個 MCP handler emit 到 in-process `UxEventSink`
+   registry，包成 `UxEvent::Fleet(FleetEvent)`（plan §4 已鎖 enum 形狀）
+3. **Fleet binding renderer** — TelegramChannel 吃 `UxEvent::Fleet(..)` →
+   format 成 one-liner → 送到 `fleet_binding`（plan §6 S2c）
+4. **S2d provenance injection** — delegate 的 **receive 端**，agent B 的
+   primary binding 收到 `⬅️ from A — DELEGATE brief` system message
+
+**非 scope**（plan §8 + §9 Stage D 排除）：
+- `send_to_instance` / `request_information` mirror（plan §4 + §8 排除）
+- per-event / per-agent / per-kind 過濾、auto-create fleet binding
+- `AgentThinking / Idle / RateLimited / Crashed / Restarted`（Q1 剩餘）
+- typing_indicator action、max_msg_bytes 的 "view full" hook（Stage D-UX）
+- Discord / Slack adapters（本 doc 只寫 Telegram，但 `UxEventSink` trait 對外不鎖 adapter）
+
+## 2. PR split
+
+| PR | Scope | Depends on | LOC budget |
+|---|---|---|---|
+| **PR-A** | §3 config + §4 FleetEvent 線路到 registry + producer tests | main (origin) | ~350 |
+| **PR-B** | §5 TelegramChannel fleet renderer + S2c format + snapshot test | PR-A | ~250 |
+| **PR-C** | §6 S2d provenance injection in delegate_task receive path | main (並行 PR-B) | ~200 |
+
+**依賴順序**：A → B 必須序列（B consume A 建的 UxEventSink registry + FleetEvent）。
+C 正交，走 delegate_task 的 *receive* 端，跟 A/B 的 producer→sink 路徑不重疊，
+可與 B 並行 review。
+
+**PR-A 可驗證性**：PR-A 落地時 sink registry 沒有 fleet renderer（只有 NoopUxSink
++ T3 的 TelegramChannel Q1 路徑），但 unit test 拿一個 recording sink（`Arc<dyn UxEventSink>`
+存 received events）掛進 registry、invoke 每個 MCP handler、assert bus 有對應 FleetEvent。
+不需要 PR-B 才能觀察。
+
+## 3. Config schema
+
+plan §7 already sketched。實作：擴 `ChannelConfig::Telegram` 加 `fleet_binding: Option<FleetBindingConfig>`。
+
+```yaml
+# fleet.yaml
+channels:
+  telegram:
+    type: telegram
+    token_env: TELEGRAM_BOT_TOKEN
+    group_id: -100...
+    fleet_binding:          # 可省略；省略 = 不 mirror
+      type: topic
+      name: "fleet-activity"
+```
+
+**支援兩種 YAML 形狀**（plan §7 exemplar）：
+- struct：`{ type: topic, name: "..." }` → TG topic / Discord channel / Slack thread
+- string shorthand：`"#agend-ops"` → Slack / Discord 用的 channel name（TG 不接受 shorthand，會 warn）
+
+Telegram 的 `fleet_binding` resolved 後產生一個 `BindingRef`（kind="telegram",
+payload=`TelegramBindingPayload { topic_id }`, display_tag=「fleet」）存在
+`TelegramState` 加一欄 `fleet_binding: Option<BindingRef>`。
+
+**Resolution 時機**：bootstrap 時，跟 `instance_to_topic` 一起 resolve。topic 不存在
+就 bail（跟其他 instance binding 一致）。
+
+## 4. FleetEvent producer — 4 個 MCP handler hook
+
+全程走 plan §4 鎖定的 `UxEvent::Fleet(FleetEvent)` wrapper，共用 T3 的 `UxEventSink` trait。
+
+### 4.1 UxEventSink registry
+
+新檔 `src/channel/sink_registry.rs`：
+
+```rust
+use std::sync::{Arc, OnceLock, RwLock};
+use super::ux_event::{UxEvent, UxEventSink};
+
+/// Global registry of UxEventSinks. Follows origin/main's established
+/// singleton pattern — crate-level `static` with `OnceLock<T>`, read by
+/// name at call sites. Examples on main: `src/mcp/mod.rs::ACL`,
+/// `src/schedules.rs::DETECTED_TZ`, `src/channel/telegram.rs::RT`.
+///
+/// We deliberately do NOT introduce a DI framework / service-locator
+/// abstraction — registry singleton is a small thing, matching existing
+/// style beats over-engineering. See general's feedback on PR-A draft.
+static REGISTRY: OnceLock<UxSinkRegistry> = OnceLock::new();
+
+pub fn registry() -> &'static UxSinkRegistry {
+    REGISTRY.get_or_init(UxSinkRegistry::default)
+}
+
+#[derive(Default)]
+pub struct UxSinkRegistry {
+    sinks: RwLock<Vec<Arc<dyn UxEventSink>>>,
+}
+
+impl UxSinkRegistry {
+    pub fn register(&self, sink: Arc<dyn UxEventSink>) {
+        self.sinks.write().unwrap().push(sink);
+    }
+    pub fn emit(&self, event: &UxEvent) {
+        for s in self.sinks.read().unwrap().iter() { s.emit(event); }
+    }
+}
+```
+
+**為何不掛既有 state**：grep 顯示 `resolve_channel()` 每次 call 重讀 `fleet.yaml`，
+沒有 TelegramState singleton。新 `OnceLock<UxSinkRegistry>` 是獨立 resource，
+對齊 `ACL` / `DETECTED_TZ` / `RT` 的 crate-level static 做法。
+
+**註冊時機**：bootstrap TelegramChannel 建構後 `registry().register(channel_arc.clone())`。
+MCP handler 從 `crate::channel::sink_registry::registry()` 拿 `&'static UxSinkRegistry` emit。
+
+### 4.2 FleetEvent enum — 依 plan §4 但 task_id 收窄為 Option
+
+```rust
+// src/channel/ux_event.rs — 新增
+pub enum FleetEvent {
+    // 偏離 plan §4：task_id 從 `TaskId` 改成 `Option<TaskId>`。
+    // 理由：delegate_task / report_result handler 沒有強制 TaskId，
+    // correlation_id 是 ad-hoc string。Option 是對實況的誠實反映，
+    // renderer 有 id 就顯示沒就略。decided by general on design-doc review.
+    DelegateTask { from: String, to: String, summary: String, task_id: Option<TaskId> },
+    ReportResult { from: String, to: String, summary: String, task_id: Option<TaskId> },
+    PostDecision { by: String, title: String, decision_id: DecisionId },
+    Broadcast    { from: String, recipients: Vec<String>, summary: String },
+}
+
+// UxEvent 新增 variant
+pub enum UxEvent {
+    UserMsgReceived { .. }
+    AgentPickedUp { .. }
+    AgentReplied { .. }
+    Fleet(FleetEvent),  // 新增
+}
+```
+
+### 4.3 Hook 點（照 plan §4）
+
+`handlers.rs` 4 個 arm，每個在原 handler 末尾 emit：
+
+| MCP handler | FleetEvent | `from` 來源 | summary 來源 | ID |
+|---|---|---|---|---|
+| `delegate_task` | `DelegateTask` | `sender.as_str()`（既有 gate） | `args["task"]` 截斷 | `None` |
+| `report_result` | `ReportResult` | `sender.as_str()`（既有 gate） | `args["summary"]` | `args["correlation_id"]` parse 成 `Option<TaskId>` |
+| `post_decision` | `PostDecision` | `sender`（見下） | `decisions::post` 回傳 title | `decisions::post` 回傳 id |
+| `broadcast` | `Broadcast` | `sender.as_str()`（既有 gate） | `args["message"]` 截斷 | N/A |
+
+**`post_decision` 的 Sender：skip-emit，不 gate**。
+handler 目前無 `err_needs_identity` gate（anonymous tolerated）。修法：
+`if let Some(sender) = .. { registry.emit(UxEvent::Fleet(PostDecision{..})); }`，
+anonymous 模式不 emit。**anonymous post_decision 不會出現在 fleet_binding — 這是
+intentional：決定 provenance 需要身份。** decided by general on design-doc review
+(不 break decisions 的 anonymous contract)。
+
+### 4.4 dispatch 分流
+
+```rust
+impl UxEventSink for TelegramChannel {
+    fn emit(&self, event: &UxEvent) {
+        match event {
+            UxEvent::UserMsgReceived { .. }
+            | UxEvent::AgentPickedUp { .. }
+            | UxEvent::AgentReplied { .. } => {
+                // Q1 path: select_action + apply to origin binding
+                let action = select_action(event, &self.caps);
+                self.apply_q1_action(action);
+            }
+            UxEvent::Fleet(fe) => {
+                // Q2 path: 不走 select_action；fleet_binding 專用 renderer
+                self.apply_fleet_action(fe);
+            }
+        }
+    }
+}
+```
+
+**為何不走 `select_action`**：fleet 事件沒有 cap-degradation ladder（永遠是 send;
+target 是 configured binding 不是 origin msg）。把 fleet 混進 `select_action` 會污染
+Q1 cap-ladder 語意。未來若真的要 FleetEvent 上 degradation（譬如 fleet_binding 是
+SMS），再新增 `select_fleet_action`；現在不做 speculative。
+
+## 5. PR-B — TelegramChannel fleet renderer
+
+`apply_fleet_action(&self, fe: &FleetEvent)`：
+1. 拿 `self.state.fleet_binding: Option<BindingRef>`。`None` 時直接 return（plan §7
+   "absent block = no fleet sink for that channel"）。
+2. `format_fleet_oneliner(fe, self.caps.max_msg_bytes)` → `String`。
+3. 解析 `fleet_binding` 的 topic_id → `try_telegram_reply_to_topic(topic_id, &text)`
+   （複用現有 send path；不新增 Bot API helper）。
+
+### 5.1 Format（plan §6 S2c）
+
+```
+[at-dev-1 → at-dev-2] DELEGATE  task #9 Option C scoping
+[at-dev-2 → at-dev-1] REPORT    DONE  src/utils.rs consolidation landed (#21)
+[at-dev-3 → *]         BROADCAST  CI green post-rebase
+[at-dev-1 solo]         DECISION  task-board-ownership rules (D-42)
+```
+
+Pure fn `format_fleet_oneliner(fe, max_bytes) -> String`：
+- 截斷 summary 到 max_bytes - 固定 prefix 長度；加 `…` suffix。
+- BROADCAST recipients 多時顯示 `[from → *N]` 或 `[from → a,b,…+2]`（>3 recipients）。
+- DECISION 有 id 就接 `(D-{id})`；DELEGATE/REPORT 有 task_id 就接 `(#{id})`。
+
+Snapshot test 覆蓋 4 variant、截斷邊界、recipients 0/1/3/5 case。
+
+## 6. PR-C — S2d provenance injection
+
+**Trigger 點**：agent B 收到 delegate 訊息時。
+
+**設計選擇**：inject 不在 `inbox::deliver` 裡做（通用 inbox，會污染所有 message 路徑），
+而是在 `delegate_task` handler success 後、於 daemon 本地 call `inject_provenance(target, sender, task)` —
+只 DELEGATE 路徑觸發。
+
+```rust
+// src/channel/telegram.rs
+pub fn inject_provenance(
+    target_instance: &str,
+    from: &str,
+    brief: &str,
+) -> anyhow::Result<()> {
+    // 送到 target_instance 的 primary topic（既有 instance_to_topic lookup）
+    let message = format!("⬅️ from {from} — DELEGATE\n   (brief: \"{brief}\")");
+    try_telegram_reply(target_instance, &message)
+}
+```
+
+handler arm 結尾：
+```rust
+"delegate_task" => {
+    ..
+    let result = send_to(&home, sender, target, &msg, "task");
+    if let Err(e) = crate::channel::telegram::inject_provenance(target, sender.as_str(), task) {
+        tracing::warn!(
+            %e, %target, from = %sender.as_str(),
+            "S2d provenance injection failed — routing may be broken"
+        );
+    }
+    registry.emit(&UxEvent::Fleet(FleetEvent::DelegateTask { .. }));
+    result
+}
+```
+
+**失敗處理：`tracing::warn!`（非 silent debug）**。decided by general on design-doc
+review, overriding initial silent-log bias。理由：provenance 失敗靜默有個風險 —
+實際 routing bug（譬如 B 的 topic_id 錯）會無聲劣化 user 體驗而沒 signal。
+`warn!` level 讓問題浮到 log 面，但不 propagate error 所以不擋主路徑
+（send_to 成功送給 B，user 不受影響；operator 看 log 能察覺 provenance 壞了）。
+Regression 成本低：只是 log level 而非邏輯變化。
+
+## 7. Test strategy
+
+### PR-A
+- `ux_event` 單測：新增 `FleetEvent` 4 variant 建構 test（smoke）。
+- `sink_registry` 單測：register 多個 sink、emit 全體收到、move semantics。
+- `handlers` 接線測試：每個 MCP handler invoked → recording sink 收到對應 FleetEvent
+  + 欄位值（from=sender, summary=args.*, etc）。Recording sink 是 test-only 的
+  `struct Recorder(Arc<Mutex<Vec<UxEvent>>>)`。
+- **Negative pin**：`send_to_instance` handler 不 emit FleetEvent（rg-assert not-called）。
+  plan §10 明列此 pin。
+- **Anonymous pin**：`post_decision` 無 Sender 時 registry 不收到 FleetEvent（§4.3 決定）。
+
+### PR-B
+- `format_fleet_oneliner` pure-fn snapshot test：4 variant × 邊界長度。
+- `apply_fleet_action` unit test：mock Bot API（走 seam 或 env-guard），`fleet_binding=Some`
+  → 觸發 send；`None` → no-op。
+- emit 層 integration：餵 `UxEvent::Fleet(..)` 進 TelegramChannel、assert
+  mock sink 收到正確 payload。
+
+### PR-C
+- `inject_provenance` call 後 `try_telegram_reply` 被以 target + S2d 格式文呼叫（seam 測試）。
+- handler-level：`delegate_task` → recording sink 同時觀察到 FleetEvent::DelegateTask +
+  provenance side-call（順序無關）。
+- **Failure-visibility pin**：`inject_provenance` 失敗路徑被 `tracing::warn!` 記錄
+  （§6 決定），用 `tracing-test` 或 `log_capture` 驗證 warn record 存在。
+
+## 8. Non-goals（明列以免 scope creep）
+
+- `send_to_instance` / `request_information` fleet mirror（plan §4 + §8 排除）
+- Per-event / per-agent / per-kind routing knobs（plan §7 明列）
+- Discord / Slack fleet renderer（Stage B 只寫 Telegram）
+- `max_msg_bytes` "view full" hook（defer Stage D-UX）
+- typing_indicator / AgentThinking / AgentRateLimited（defer T12）
+- Q3 TUI-as-channel（Stage C-UX）
+- Auto-create fleet binding（plan §7 排除）
+- `FleetEvent` degradation ladder（speculative，未來才加）
+
+## 9. Decisions log（design-doc round 決定點）
+
+| # | Question | Decision | By |
+|---|---|---|---|
+| Q1 | `task_id: Option<TaskId>` vs plan §4 `TaskId` | **Option** — plan §4 小偏離，誠實反映 correlation_id 非強制 | general |
+| Q2 | `post_decision` anonymous 模式 | **skip-emit** — `if let Some(sender)..`，不 break decisions anonymous contract | general |
+| Q3 | Registry storage | **crate-level `OnceLock<UxSinkRegistry>`** — 對齊 `ACL`/`DETECTED_TZ`/`RT` 既有 pattern，不發明 DI abstraction | general |
+| Q4 | `inject_provenance` 失敗處理 | **`tracing::warn!`** — silent 會讓 routing bug 無 signal（override 初版 silent-log bias） | general |
+| — | MCP handler 範圍 | **4 個（delegate/report/post_decision/broadcast）**，`send_to_instance` + `request_information` 照 plan §8 排除 | general |
+
+## 10. Open for PR-A（非 blocker，實作時處理）
+
+- `args["correlation_id"]` parse 成 `Option<TaskId>` 的 parse 失敗：silent `None`（bias），
+  或 warn-log？等實作時看 `correlation_id` 實況 format（應該是 "AGD-123" 之類的 string）
+  再決定。PR-A commit 會明註選擇。
+- Registry `RwLock` 順序：現在只 write 於 bootstrap，read 於 emit。若未來 hot-register
+  才需檢查 contention。bootstrap-only write 不會 contend 所以不 block 當前 PR-A。

--- a/docs/REVIEWER-CONTRACT-v0.1.md
+++ b/docs/REVIEWER-CONTRACT-v0.1.md
@@ -1,0 +1,326 @@
+# Reviewer Contract v0.1
+
+> AgEnD multi-agent cross-review 協議。首次試跑於 Wave 2（2026-04-22），
+> PR #47 與 PR #49 各走完一輪 REJECTED → fix → VERIFIED → merge。
+> 本文件固化該協議供新 reviewer agent 加入時引用。
+
+---
+
+## 目錄
+
+1. [三態 Verdict](#三態-verdict)
+2. [Reviewer 必做動作](#reviewer-必做動作)
+3. [Metadata Schema](#metadata-schema)
+4. [Implementer 責任](#implementer-責任)
+5. [Orchestrator 責任](#orchestrator-責任)
+6. [為什麼 Reviewer 要跨 Backend](#為什麼-reviewer-要跨-backend)
+7. [Anti-patterns](#anti-patterns)
+8. [Wave 2 案例](#wave-2-案例)
+9. [適用範圍](#適用範圍)
+10. [版本演進](#版本演進)
+
+---
+
+## 三態 Verdict
+
+| Verdict | 意義 | 後續動作 |
+|---------|------|----------|
+| **VERIFIED** | Claims 皆可 cross-check；scope 無問題 | Orchestrator merge |
+| **REJECTED** (= REQUEST_CHANGES) | 發現實質問題 | 附 findings + fix direction → implementer 修 |
+| **UNVERIFIED** | 某 claim 無法獨立驗證（缺 tooling / 環境 / access） | 不 block merge，但顯式聲明 epistemic gap；escalate 給 orchestrator 決定 |
+
+### 為什麼不是二態
+
+二態 pass/fail 讓 reviewer 在「不確定」時預設 pass，製造橡皮圖章。
+三態留中性出口——reviewer 可以誠實說「這部分我沒辦法驗」，
+把決策權交回 orchestrator，而不是被迫在 pass 和 fail 之間賭一個。
+
+---
+
+## Reviewer 必做動作
+
+### 1. 先讀 diff，再形成意見
+
+打開 PR 後第一件事是 `git diff <base>...<head>`。
+不要先讀 PR description、不要先讀 prior conversation。
+先看 code，形成獨立判斷，再對照 author 的 claim。
+
+**為什麼：** PR description 是 framing。先讀 framing 會讓你用 author 的視角看 code，
+而不是用 code 的事實看 claim。PR #47 的 `receives_edit_events: true` 就是
+PR body 沒提、但 diff 裡靜悄悄改了語意的例子。
+
+### 2. 至少一個獨立 verification command
+
+不能只靠 PR body / prompt 內 claim 相信。必須自己跑至少一個驗證指令：
+
+```bash
+# 典型 verification commands
+git diff <base>...<head>
+rg -n "<claim-keyword>" src/
+cargo test <module> -q
+grep -n "<symbol>" src/**/*.rs
+```
+
+PR #49 案例：reviewer 用 `rg -n "display_tag" src/` 發現
+`SendText` arm 傳的是人眼標籤而非 instance name，
+單靠讀 PR body 不會發現這個 wiring 錯誤。
+
+### 3. Scope guard
+
+Re-review 時明確聲明：
+
+> "Only re-audited the N prior findings; did not broaden review."
+
+防止 round 2 不斷擴大範圍。reviewer 的工作是確認 fix 有效，
+不是趁機做 full review。Scope creep 會拖慢迭代、消耗 implementer 信任。
+
+### 4. 回傳 structured metadata
+
+每次 review 結果必須包含下節定義的 metadata schema。
+非結構化的「看起來沒問題」不算 review。
+
+---
+
+## Metadata Schema
+
+每次 review 回 `report_result` 時必須包含以下結構：
+
+```yaml
+reviewed_files:
+  - <path>
+  - <path>
+
+verification_commands:
+  - `<command>`
+  - `<command>`
+
+verdict: VERIFIED | REQUEST_CHANGES | UNVERIFIED
+
+stale_if:
+  - <condition that would invalidate this review>
+  - <condition>
+
+# 僅 REQUEST_CHANGES 時
+findings:
+  - [high|medium|low] <finding description + fix direction>
+  - ...
+
+# 僅 re-review 且 VERIFIED 時
+findings_audited:
+  - <original finding>: addressed. <evidence path:line>
+  - ...
+
+# 選填
+notes:
+  - <scope boundary statement, etc.>
+```
+
+### 欄位說明
+
+- **reviewed_files** — 實際看過的檔案。沒列的就是沒看，不要假裝全看了。
+- **verification_commands** — 跑過的指令。這是 audit trail，也是讓下一個 reviewer 能重現你的驗證。
+- **verdict** — 三態之一，不接受其他值。
+- **stale_if** — 什麼條件下這份 review 失效。例:「若 `src/ux/sink.rs` 在 merge 前被其他 PR 改動」。讓 orchestrator 知道何時需要 re-review。
+- **findings** — 每條標 severity（high/medium/low）+ fix direction。不只說「這裡有問題」，要說「建議怎麼修」。
+- **findings_audited** — re-review 時逐條對照原 finding，附 evidence（檔案路徑 + 行號）。
+- **notes** — scope boundary、已知限制、或其他 reviewer 想留的備註。
+
+---
+
+## Implementer 責任
+
+### Fix 時加 regression pin
+
+不只修 bug，要加測試 pin 住 wiring 邏輯——「值從哪來 / 誰呼叫誰」。
+
+**案例（PR #49）：** `UxAction::SendText` 的 `instance` 欄位來源是 `event.agent`，
+不是 `binding.display_tag()`。Fix 加了 3 個 value-source regression pin：
+
+```rust
+// 顯式 assert SendText.instance 來源是 agent 不是 display_tag
+assert_eq!(action.instance, "test-agent");  // not "TG#229"
+```
+
+這種 pin 的價值：未來 refactor 動到這個欄位的 source 會立刻炸，
+不會像原本那樣單測 pass 但 integration 斷層。
+
+### Fix 後 ping orchestrator，不要直接 ping reviewer
+
+Push-notify 的 ownership 在 orchestrator。Implementer fix 完後：
+
+```
+report_result → orchestrator (general)
+```
+
+由 orchestrator 決定何時、派誰做 re-review。
+直接 ping reviewer 會繞過 orchestrator 的排程，製造混亂。
+
+---
+
+## Orchestrator 責任
+
+### Dispatch 時傳完整 context
+
+Re-review dispatch 必須包含：
+- 原 findings 列表
+- Fix commit hash
+- Re-review scope 限定（「只看這 N 個 finding 是否 addressed」）
+
+不要讓 reviewer 自己去翻歷史拼湊 context。
+
+### Verdict 後的動作
+
+| Verdict | Orchestrator 動作 |
+|---------|-------------------|
+| VERIFIED | Merge |
+| REJECTED | 轉 implementer，附 findings |
+| UNVERIFIED | 視 claim 性質：補證據 or 升級給人類 |
+
+### 不兼任 reviewer
+
+Orchestrator 分配任務後傾向認為任務被正確完成（confirmation bias）。
+獨立 reviewer agent 是必要的，不是奢侈品。
+
+---
+
+## 為什麼 Reviewer 要跨 Backend
+
+Wave 2 的配對是 claude implementer（at-dev-2）+ codex reviewer（at-dev-4）。
+這個配對不是隨機，而是針對 **systematic blind spots**：同一 backend 的兩個 agent
+容易在相同類型的錯誤上同時失手（譬如同款 prompt 結構下誤讀 cap 語意、
+或同款訓練資料產生的 framing bias）。跨 backend 讓 reviewer 的盲點跟 implementer
+不重疊。
+
+不是說 same-backend review 無效，而是 cross-backend 對 systematic error
+更有抗性。Wave 2 兩次 REQUEST_CHANGES（`receives_edit_events` 語意 drift、
+`display_tag` wiring bug）都是 implementer 自己跟 orchestrator（都是 claude）
+一起漏掉、codex reviewer 抓到的——這是具體 evidence。
+
+---
+
+## Anti-patterns
+
+### 1. Rubber-stamp review
+
+「看起來沒問題」，無 verification command。
+**偵測：** metadata 裡 `verification_commands` 為空或只有 `git diff`。
+**後果：** PR #47 的 `receives_edit_events` 語意 drift 就是這樣漏掉的。
+
+### 2. Snapshot decay
+
+Review 基於記憶中的 code 狀態，而非當前 main。
+**偵測：** `stale_if` 條件已觸發但沒有 re-review。
+**防範：** merge 前檢查 `stale_if` 條件。
+
+### 3. Scope creep
+
+Re-review 時擴大到 non-prior-finding 的範圍。
+**後果：** 迭代無限延長，implementer 信任崩潰。
+**防範：** re-review 開頭必須聲明 scope guard。
+
+### 4. Silent UNVERIFIED
+
+不說哪裡沒驗就回 VERIFIED。
+**後果：** 假裝全驗了，但其實有 epistemic gap 被藏起來。
+**防範：** metadata schema 強制列 `reviewed_files`——沒列的就是沒看。
+
+---
+
+## Wave 2 案例
+
+以下兩個案例是本協議首次完整試跑的實證記錄。
+
+### Case A — PR #47：Telegram UX Capabilities
+
+**Round 1：REQUEST_CHANGES**
+
+- **[high]** `receives_edit_events: true` 過度聲明。
+  Telegram adapter ingress 只做 `Update::filter_message()`，
+  edited messages 未被消費。PR 靜悄悄把欄位語意從
+  「adapter 實際 emits」改成「platform 理論能」。
+- **[comment]** 48-hour Bot API edit window 措辭錯誤
+  （該限制適用 business messages，非 bot-sent 一般 edits）。
+
+**Fix `d356ecc`：**
+- `receives_edit_events: false`
+- Comment 指名缺的 ingress handler
+- Revert caps.rs doc 改動
+- 移除 48h 措辭
+
+**Round 2：VERIFIED**（scope held）→ Merge `9da4371`
+
+**Learning：** capability 值 vs adapter 實作的 gap 是典型
+「平台理論 vs adapter 實況」drift。需要跨 module grep 驗證才能抓到。
+
+### Case B — PR #49：UxEventSink
+
+**Round 1：REQUEST_CHANGES**
+
+- **[high]** `UxAction::SendText` arm 傳 `binding.display_tag()`
+  （格式 `TG#<topic_id>`，人眼標籤）給 `try_telegram_reply`，
+  但該函式期待 `instance_name` 去 `config.instances.get()` 查 topic_id。
+  Runtime 會 bail `No topic_id for TG#229`。
+  `select_action` 單測 pass 但 integration 層沒 cover 這個 wiring。
+- **[medium]** Plan §6 Q1 table 的 `typing_indicator` column
+  在實作中 silently dropped，doc 未更新。
+- **[comment]** PR body 測試數 12/13 與實際 10 不符。
+
+**Fix `993c609`：**
+- `UxAction` 三個 variant 加 `instance: String` 欄位
+- `select_action` 從 `event.agent` 填入
+- 3 個 value-source regression pin
+  （顯式 assert `SendText.instance` 來源是 agent 不是 display_tag）
+
+**Round 2：VERIFIED**（scope held）→ Merge `4b7e4a2`
+
+**Learning：** 單元測試 vs integration 斷層是典型盲點。
+Reviewer 從 field source 語意切入（display_tag = 人眼標籤不是 lookup key）
+發現的 bug。Value-source pin 寫法讓未來 refactor 動到這個欄位會立刻炸。
+
+---
+
+## 適用範圍
+
+### 適用
+
+- Multi-agent 協作的 PR，特別是跨 agent 產出需要 cross-check 的場景
+- 涉及 capability 聲明、interface contract、跨 module wiring 的變更
+- 任何 implementer 和 reviewer 是不同 agent 的情況
+
+### 不適用
+
+- **Hotfix：** 緊急修復可以 orchestrator 直接 merge，事後補 review
+- **Single-author trivial PR：** 純 typo fix、comment 更新、CI config 調整
+  不需要走完整 review protocol
+- **文件類 PR（docs-skip-PR）：** 如本文件本身，由 orchestrator 審過直接 commit
+
+### 灰色地帶
+
+不確定是否需要 full review 時，orchestrator 決定。
+寧可多 review 一次，不要事後才發現該 review 沒 review。
+
+---
+
+## 版本演進
+
+**v0.1 是 minimal viable protocol。**
+
+基於 Wave 2 兩個 PR 的實戰經驗制定，覆蓋了最基本的：
+- 三態 verdict
+- Reviewer / implementer / orchestrator 三方責任
+- Structured metadata
+- Anti-patterns 警告
+
+**未來迭代方向（不鎖死）：**
+
+- **Reviewer 品質追蹤：** 定期交叉審核同一份產出，比對兩個 reviewer 的 findings
+- **Max iteration cap：** 連續 REJECTED 超過 N 次自動 escalate 人類（目前靠 convention）
+- **stale_if 自動化：** 讓 CI 檢查 review 的 stale_if 條件是否被觸發
+- **reply_to convention：** `delegate_task` / `request_information` context 裡明確寫 `reply_to: <instance>`，解決臨時 review team 的 routing 問題（side-tab reviewer discussion incident 引出的議題；`c68bf4c` 已部分修 empty `from:` symptom，middleman routing 仍待解）
+
+每次迭代基於實戰反饋，不做預測性設計。
+協議改動需要至少一個實際案例支撐，不接受純理論修訂。
+
+---
+
+*v0.1 — 2026-04-22 · 基於 Wave 2 (PR #47, #49) 實戰經驗*


### PR DESCRIPTION
## Summary

Adds two docs that seed Wave 3:

- `docs/DESIGN-stage-b-ux.md` — implementation design for Stage B-UX
  (fleet visibility). `fleet_binding` config + FleetEvent producer
  (registry/enum/hook-table/dispatch split) + TelegramChannel fleet
  renderer + S2d provenance injection. Split into PR-A/B/C with LOC
  budgets (~350 / ~250 / ~200). §9 decision log captures Q1-Q4 from
  design-doc review: `Option<TaskId>`, anonymous `post_decision`
  skip-emit, `OnceLock` registry (aligns with existing
  `ACL`/`DETECTED_TZ`/`RT`/`CACHE`), `tracing::warn!` on provenance
  failure.
- `docs/REVIEWER-CONTRACT-v0.1.md` — multi-agent cross-review protocol
  derived from Wave 2 PR #47 / #49 experience. Three-state verdict
  (VERIFIED / REJECTED / UNVERIFIED), structured metadata schema,
  cross-backend reviewer rationale, anti-patterns.

Both are docs-only (`docs/` only; no `src/`, `tests/`, `Cargo.*` touch)
— skip CI ceremony per `feedback_docs_skip_pr.md`.

## Test plan

- [x] No source changes; no runtime behavior
- [x] Intended for immediate squash-merge without CI wait (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)