### PR TITLE
feat(channel): Stage B-UX PR-A — FleetEvent producer + UxSinkRegistry

### DIFF
--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -121,6 +121,7 @@ mod tests {
                 group_id: -1,
                 mode: "topic".into(),
                 user_allowlist: None,
+                fleet_binding: None,
             }),
             channels: None,
             templates: None,

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -34,13 +34,15 @@ pub mod binding;
 pub mod caps;
 pub mod contract;
 pub mod event;
+pub mod sink_registry;
 pub mod telegram;
 pub mod ux_event;
 
 pub use binding::BindingRef;
 pub use caps::{ChannelCapabilities, MarkdownDialect, MentionStyle, NativeSeeAllHint, RateBudget};
 pub use event::{ChannelEvent, MsgPayload, MsgRef, OutMsg, RevokeReason, User};
-pub use ux_event::{select_action, NoopUxSink, UxAction, UxEvent, UxEventSink};
+pub use sink_registry::{registry, UxSinkRegistry};
+pub use ux_event::{select_action, FleetEvent, NoopUxSink, UxAction, UxEvent, UxEventSink};
 
 use crate::agent::AgentRegistry;
 use anyhow::Result;

--- a/src/channel/sink_registry.rs
+++ b/src/channel/sink_registry.rs
@@ -1,0 +1,182 @@
+//! Global registry of [`UxEventSink`] implementations.
+//!
+//! The MCP handler layer emits `UxEvent::Fleet(..)` events (Q2 fleet
+//! visibility) through [`registry`]; the daemon boots channel adapters
+//! (e.g. `TelegramChannel`) and registers them once at startup. At emit
+//! time, every registered sink receives a reference to the event.
+//!
+//! ## Why a crate-level singleton
+//!
+//! The registry is deliberately a plain `OnceLock<T>` behind a module
+//! accessor — matching the established pattern in the codebase:
+//! `src/mcp/mod.rs::ACL`, `src/schedules.rs::DETECTED_TZ`,
+//! `src/channel/telegram.rs::RT`, `src/vterm.rs::CACHE`. We do NOT
+//! introduce a DI framework or service-locator abstraction — a small
+//! crate-wide resource handled by the same pattern as its neighbors
+//! beats a bespoke abstraction. Decision: `docs/DESIGN-stage-b-ux.md`
+//! §9 Q3, by general.
+//!
+//! ## Scope of PR-A
+//!
+//! The registry and the producer-side hooks in `src/mcp/handlers.rs`
+//! land here. The Telegram fleet renderer (the sink that actually
+//! formats and forwards Fleet events to the `fleet_binding` topic)
+//! lands in PR-B and will register `TelegramChannel` at bootstrap.
+//! Until then, emissions fan out to whatever sinks tests register;
+//! production runs see zero registered sinks and emissions are
+//! effectively no-ops.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use super::ux_event::{UxEvent, UxEventSink};
+use crate::sync::lock_poisoned;
+
+/// Crate-level singleton. Lazily initialized on first access so neither
+/// the daemon nor tests need an explicit init step.
+static REGISTRY: OnceLock<UxSinkRegistry> = OnceLock::new();
+
+/// Borrow the process-wide [`UxSinkRegistry`]. Callers use this to
+/// either [`UxSinkRegistry::register`] a sink at startup or
+/// [`UxSinkRegistry::emit`] an event from an MCP handler.
+pub fn registry() -> &'static UxSinkRegistry {
+    REGISTRY.get_or_init(UxSinkRegistry::default)
+}
+
+/// Fan-out container for [`UxEventSink`] impls. Registration is
+/// bootstrap-only in production code paths (Telegram adapter registers
+/// itself once) and emit is fire-and-forget, so a plain `Mutex` matches
+/// the rest of the crate's locking style (`src/sync.rs::lock_poisoned`)
+/// — no reason to reach for `RwLock` when there's no contention.
+#[derive(Default)]
+pub struct UxSinkRegistry {
+    sinks: Mutex<Vec<Arc<dyn UxEventSink>>>,
+}
+
+impl UxSinkRegistry {
+    /// Add a sink to receive all future [`emit`](Self::emit) calls.
+    /// Registration order is preserved. Adapters typically register
+    /// themselves once during bootstrap and never deregister.
+    pub fn register(&self, sink: Arc<dyn UxEventSink>) {
+        lock_poisoned(&self.sinks, "ux_sink_registry").push(sink);
+    }
+
+    /// Fan out `event` to every registered sink in insertion order.
+    /// Sinks are expected to be fire-and-forget and must not panic
+    /// (per [`UxEventSink`]'s contract); this loop does not catch or
+    /// propagate per-sink failures.
+    pub fn emit(&self, event: &UxEvent) {
+        // Snapshot under the lock, then release before invoking sinks
+        // so a slow sink can't block registration or other emits. The
+        // `Arc` clone is cheap.
+        let snapshot: Vec<Arc<dyn UxEventSink>> =
+            lock_poisoned(&self.sinks, "ux_sink_registry").clone();
+        for sink in &snapshot {
+            sink.emit(event);
+        }
+    }
+
+    /// Number of currently registered sinks. Exposed for tests that
+    /// need to assert registration state without reaching into
+    /// internals.
+    pub fn len(&self) -> usize {
+        lock_poisoned(&self.sinks, "ux_sink_registry").len()
+    }
+
+    /// True when no sinks are registered. Production callers never
+    /// depend on this — the emit path is oblivious to sink count —
+    /// but tests that exercise the "no sinks registered" fallback
+    /// read cleaner with an `is_empty()` assertion.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Remove every registered sink. Intended for tests that share
+    /// the process-wide singleton across cases and need a clean slate
+    /// between them. Production code has no use for this and should
+    /// not call it.
+    #[cfg(test)]
+    pub fn clear_for_test(&self) {
+        lock_poisoned(&self.sinks, "ux_sink_registry").clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::ux_event::FleetEvent;
+
+    /// Test-only sink that records every event it receives. Used in
+    /// both this module and `src/mcp/handlers.rs` tests to assert that
+    /// MCP handlers emit the expected `UxEvent::Fleet(..)` shape.
+    pub struct RecordingSink {
+        pub events: Mutex<Vec<UxEvent>>,
+    }
+
+    impl RecordingSink {
+        pub fn new() -> Arc<Self> {
+            Arc::new(Self {
+                events: Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    impl UxEventSink for RecordingSink {
+        fn emit(&self, event: &UxEvent) {
+            lock_poisoned(&self.events, "recording_sink").push(event.clone());
+        }
+    }
+
+    fn make_fleet_event() -> UxEvent {
+        UxEvent::Fleet(FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: "hi".into(),
+            task_id: None,
+        })
+    }
+
+    /// Registering a sink and emitting an event propagates the event
+    /// to that sink. Basic wiring pin.
+    #[test]
+    fn register_then_emit_delivers_event() {
+        let reg = UxSinkRegistry::default();
+        let sink = super::tests::RecordingSink::new();
+        reg.register(sink.clone() as Arc<dyn UxEventSink>);
+        reg.emit(&make_fleet_event());
+        assert_eq!(lock_poisoned(&sink.events, "test").len(), 1);
+    }
+
+    /// Multiple sinks all see every emission in insertion order.
+    #[test]
+    fn multiple_sinks_all_receive() {
+        let reg = UxSinkRegistry::default();
+        let s1 = super::tests::RecordingSink::new();
+        let s2 = super::tests::RecordingSink::new();
+        reg.register(s1.clone() as Arc<dyn UxEventSink>);
+        reg.register(s2.clone() as Arc<dyn UxEventSink>);
+        reg.emit(&make_fleet_event());
+        reg.emit(&make_fleet_event());
+        assert_eq!(lock_poisoned(&s1.events, "test").len(), 2);
+        assert_eq!(lock_poisoned(&s2.events, "test").len(), 2);
+    }
+
+    /// An emit into an empty registry is a harmless no-op. This is
+    /// the production state for PR-A (no TelegramChannel registered
+    /// yet) — handlers still emit and must not panic.
+    #[test]
+    fn emit_with_no_sinks_is_noop() {
+        let reg = UxSinkRegistry::default();
+        assert!(reg.is_empty());
+        reg.emit(&make_fleet_event()); // must not panic
+        assert_eq!(reg.len(), 0);
+    }
+
+    /// The `registry()` accessor returns the same instance across
+    /// calls — it's a real singleton, not a lazy-per-call factory.
+    #[test]
+    fn registry_accessor_is_singleton() {
+        let a = registry() as *const UxSinkRegistry;
+        let b = registry() as *const UxSinkRegistry;
+        assert_eq!(a, b);
+    }
+}

--- a/src/channel/ux_event.rs
+++ b/src/channel/ux_event.rs
@@ -9,14 +9,18 @@
 //! trait and, via [`select_action`], pick the strongest primitive their
 //! capabilities support: react > edit > send > noop.
 //!
-//! ## Scope of this file (T3 narrow scope)
+//! ## Scope of this file
 //!
-//! Only the Q1 delivery-confirmation subset is defined here:
-//! [`UxEvent::UserMsgReceived`], [`UxEvent::AgentPickedUp`], and
-//! [`UxEvent::AgentReplied`]. `AgentThinking` / `AgentIdle` /
-//! `AgentRateLimited` / `AgentCrashed` / `AgentRestarted` and the
-//! `Fleet(FleetEvent)` variant are deferred to a follow-up PR — they do
-//! not touch the Telegram send / edit / react paths in Q1, so landing
+//! Q1 delivery-confirmation subset: [`UxEvent::UserMsgReceived`],
+//! [`UxEvent::AgentPickedUp`], and [`UxEvent::AgentReplied`] (T3).
+//! Q2 fleet-visibility subset: [`UxEvent::Fleet`] wrapping a
+//! [`FleetEvent`] — routed by `sink_registry` to any registered sink,
+//! rendered per adapter (PR-B lands the Telegram renderer). Stage B-UX
+//! design: `docs/DESIGN-stage-b-ux.md` §4.
+//!
+//! `AgentThinking` / `AgentIdle` / `AgentRateLimited` / `AgentCrashed` /
+//! `AgentRestarted` (remaining Q1 events) are deferred — they do not
+//! touch the Telegram send / edit / react paths in Q1, so landing
 //! them here would be speculative dead code.
 //!
 //! ## Plan reference
@@ -63,6 +67,61 @@ pub enum UxEvent {
         /// event, so there is no degradation ladder — every capability
         /// combination renders via `send`.
         text: String,
+    },
+    /// Cross-instance fleet activity — delegations, result reports,
+    /// decisions, and broadcasts observed on the daemon's MCP surface.
+    /// Rendered into a separate `fleet_binding` (see plan §6 S2c),
+    /// NOT into the origin user's thread. See [`FleetEvent`] and
+    /// `docs/DESIGN-stage-b-ux.md` §4 for the producer hook table.
+    Fleet(FleetEvent),
+}
+
+/// Cross-instance activity events. These travel from MCP handlers to
+/// `sink_registry::registry()`, which fans them out to every registered
+/// sink. Unlike Q1 events, they have no capability-degradation ladder —
+/// the target is always the configured `fleet_binding`, and rendering is
+/// pure format (see [`select_action`] Fleet arm for why).
+///
+/// The enum shape is locked by `docs/PLAN-channel-ux-layer.md` §4 with
+/// one deviation: `task_id` is `Option<String>` rather than a newtype
+/// `TaskId`. Rationale: the `correlation_id` arg on `report_result` is
+/// an ad-hoc caller-chosen string (e.g. `"AGD-42"`); making it required
+/// with a typed wrapper overstates what the MCP surface actually
+/// guarantees. Renderers display the id when present and omit it
+/// otherwise. Decision: `docs/DESIGN-stage-b-ux.md` §9 Q1, by general.
+#[derive(Debug, Clone)]
+pub enum FleetEvent {
+    /// `delegate_task` MCP call landed.
+    DelegateTask {
+        from: String,
+        to: String,
+        summary: String,
+        task_id: Option<String>,
+    },
+    /// `report_result` MCP call landed. `task_id` mirrors the caller's
+    /// `correlation_id` arg when it was supplied.
+    ReportResult {
+        from: String,
+        to: String,
+        summary: String,
+        task_id: Option<String>,
+    },
+    /// `post_decision` MCP call succeeded. Anonymous posts (no
+    /// `AGEND_INSTANCE_NAME` / explicit `instance_name`) are
+    /// deliberately NOT emitted — fleet provenance requires an
+    /// identified author (see `docs/DESIGN-stage-b-ux.md` §4.3).
+    PostDecision {
+        by: String,
+        title: String,
+        decision_id: String,
+    },
+    /// `broadcast` MCP call completed its fan-out. `recipients` lists
+    /// every instance the broadcast was actually sent to (after
+    /// self-filter).
+    Broadcast {
+        from: String,
+        recipients: Vec<String>,
+        summary: String,
     },
 }
 
@@ -207,6 +266,19 @@ pub fn select_action(event: &UxEvent, caps: &ChannelCapabilities) -> UxAction {
                 binding: binding.clone(),
                 text: text.clone(),
             }
+        }
+        UxEvent::Fleet(_) => {
+            // Fleet events do NOT participate in the Q1 cap-degradation
+            // ladder. They target a configured `fleet_binding`, not the
+            // originating user's thread, and their rendering is a plain
+            // one-liner format (no react / edit option). Adapters that
+            // want to consume Fleet events dispatch on the `UxEvent`
+            // variant *before* calling this function (see
+            // `docs/DESIGN-stage-b-ux.md` §4.4 dispatch-split). Adapters
+            // that ignore Fleet events — or haven't wired a renderer
+            // yet (e.g. PR-A Telegram, where the renderer lands in
+            // PR-B) — correctly no-op via this arm.
+            UxAction::Noop
         }
     }
 }
@@ -539,5 +611,117 @@ mod tests {
             binding: binding("tg#1"),
             text: "x".into(),
         });
+        sink.emit(&UxEvent::Fleet(FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: "s".into(),
+            task_id: None,
+        }));
+    }
+
+    // ─── FleetEvent ──────────────────────────────────────────────────
+
+    /// Fleet variants construct and carry data correctly. This is a
+    /// smoke test — the producer wiring that fills these fields lives
+    /// in `src/mcp/handlers.rs` and is tested there against a
+    /// `RecordingSink`.
+    #[test]
+    fn fleet_event_variants_construct() {
+        let delegate = FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: "pick this up".into(),
+            task_id: Some("AGD-7".into()),
+        };
+        match delegate {
+            FleetEvent::DelegateTask {
+                from,
+                to,
+                summary,
+                task_id,
+            } => {
+                assert_eq!(from, "a");
+                assert_eq!(to, "b");
+                assert_eq!(summary, "pick this up");
+                assert_eq!(task_id.as_deref(), Some("AGD-7"));
+            }
+            _ => panic!("wrong variant"),
+        }
+
+        // `task_id: None` is the default reflecting the MCP handlers'
+        // actual contract — correlation_id is optional on delegate_task.
+        let delegate_anon = FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: "anon".into(),
+            task_id: None,
+        };
+        assert!(matches!(
+            delegate_anon,
+            FleetEvent::DelegateTask { task_id: None, .. }
+        ));
+
+        let report = FleetEvent::ReportResult {
+            from: "b".into(),
+            to: "a".into(),
+            summary: "done".into(),
+            task_id: Some("AGD-7".into()),
+        };
+        assert!(matches!(report, FleetEvent::ReportResult { .. }));
+
+        let decision = FleetEvent::PostDecision {
+            by: "a".into(),
+            title: "use X".into(),
+            decision_id: "d-123".into(),
+        };
+        if let FleetEvent::PostDecision {
+            by,
+            title,
+            decision_id,
+        } = decision
+        {
+            assert_eq!(by, "a");
+            assert_eq!(title, "use X");
+            assert_eq!(decision_id, "d-123");
+        } else {
+            panic!();
+        }
+
+        let broadcast = FleetEvent::Broadcast {
+            from: "a".into(),
+            recipients: vec!["b".into(), "c".into()],
+            summary: "ship it".into(),
+        };
+        if let FleetEvent::Broadcast { recipients, .. } = broadcast {
+            assert_eq!(recipients.len(), 2);
+        } else {
+            panic!();
+        }
+    }
+
+    /// Pin Fleet events out of the Q1 cap-degradation ladder:
+    /// [`select_action`] must return [`UxAction::Noop`] for any Fleet
+    /// payload, regardless of caps. Dispatch-split callers (see
+    /// `DESIGN-stage-b-ux.md` §4.4) steer Fleet events to a separate
+    /// renderer before reaching this function; this arm guarantees
+    /// naive callers that forget to dispatch-split don't accidentally
+    /// render a Fleet event into the origin user's thread as a react /
+    /// edit / send.
+    #[test]
+    fn select_action_fleet_is_always_noop_regardless_of_caps() {
+        let fleet = UxEvent::Fleet(FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: "x".into(),
+            task_id: None,
+        });
+        for caps in [
+            caps_neither(),
+            caps_react_only(),
+            caps_edit_only(),
+            caps_react_and_edit(),
+        ] {
+            assert!(matches!(select_action(&fleet, &caps), UxAction::Noop));
+        }
     }
 }

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -55,7 +55,50 @@ pub enum ChannelConfig {
         ///   dropped with a warn log.
         #[serde(default)]
         user_allowlist: Option<Vec<i64>>,
+        /// Optional fleet-activity binding — where cross-instance
+        /// `FleetEvent`s (delegate / report / decision / broadcast) are
+        /// mirrored as one-liner log rows. Omitted = no fleet sink for
+        /// this channel; the producer registry in `src/mcp/handlers.rs`
+        /// still emits events, but nothing routes them to Telegram.
+        ///
+        /// PR-A lands the schema only; resolution into a concrete
+        /// `BindingRef` and the rendering pipeline land with PR-B (see
+        /// `docs/DESIGN-stage-b-ux.md` §3 and §5).
+        #[serde(default)]
+        fleet_binding: Option<FleetBindingConfig>,
     },
+}
+
+/// Where fleet activity gets mirrored on a channel. Accepts two YAML
+/// forms for operator ergonomics:
+///
+/// - **Struct** — `{ type: topic, name: "fleet-activity" }`. Canonical
+///   form. `type` picks the platform primitive (Telegram forum topic,
+///   Discord channel, Slack thread, …) and `name` is the
+///   human-readable identifier.
+/// - **String shorthand** — `"#agend-ops"`. Convenience form for
+///   Discord / Slack where the binding is simply "this named channel".
+///   Telegram does not use the shorthand today (topics are created by
+///   name, not by `#tag`), so the Telegram adapter will warn and
+///   ignore string-form bindings when it tries to resolve them in
+///   PR-B.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FleetBindingConfig {
+    /// Canonical struct form — platform-tagged binding descriptor.
+    Struct(FleetBindingStruct),
+    /// Shorthand: a bare channel / tag string. Non-Telegram adapters
+    /// (Discord, Slack) interpret this as the target channel name.
+    Shorthand(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum FleetBindingStruct {
+    /// Telegram forum topic / Discord channel-equivalent. `name` is the
+    /// display name used to find or create the topic; resolution (map
+    /// name → topic_id) happens at bootstrap, not at parse time.
+    Topic { name: String },
 }
 
 fn default_mode() -> String {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -4,9 +4,21 @@ use crate::agent_ops::{
     cleanup_working_dir, get_submit_key, list_agents, merge_metadata, save_metadata, send_to,
     validate_branch,
 };
+use crate::channel::sink_registry::registry as ux_sink_registry;
 use crate::channel::telegram;
+use crate::channel::ux_event::{FleetEvent, UxEvent};
 use crate::identity::Sender;
 use serde_json::{json, Value};
+
+/// True iff the MCP handler output should be treated as a success for
+/// `FleetEvent` emission purposes. Handlers that wrap `send_to` return
+/// `{"target": …}` (API path) or `{"target": …, "note": …}` (fallback
+/// path) on success, and `{"error": …}` on failure; we mirror that
+/// check here so a failed delegate_task / broadcast doesn't pollute
+/// the fleet_binding with events that never actually left the daemon.
+fn is_ok_result(value: &Value) -> bool {
+    value.get("error").is_none()
+}
 
 /// Error payload for cross-instance tools invoked without a resolvable
 /// `AGEND_INSTANCE_NAME`. Without this guard the message would land at the
@@ -150,7 +162,20 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             if let Some(ctx) = args["context"].as_str() {
                 msg.push_str(&format!("\n\nContext: {ctx}"));
             }
-            send_to(&home, sender, target, &msg, "task")
+            let result = send_to(&home, sender, target, &msg, "task");
+            if is_ok_result(&result) {
+                // Fleet visibility (plan §4 `DelegateTask`, design §4.3).
+                // `task_id: None` — MCP `delegate_task` has no typed id
+                // slot; correlation appears later via `report_result`'s
+                // `correlation_id`. Renderer omits id when None.
+                ux_sink_registry().emit(&UxEvent::Fleet(FleetEvent::DelegateTask {
+                    from: sender.as_str().to_string(),
+                    to: target.to_string(),
+                    summary: task.to_string(),
+                    task_id: None,
+                }));
+            }
+            result
         }
         "report_result" => {
             let Some(sender) = sender.as_ref() else {
@@ -174,7 +199,23 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             if let Some(artifacts) = args["artifacts"].as_str() {
                 msg.push_str(&format!("\nArtifacts: {artifacts}"));
             }
-            send_to(&home, sender, target, &msg, "report")
+            let result = send_to(&home, sender, target, &msg, "report");
+            if is_ok_result(&result) {
+                // Fleet visibility. `correlation_id` is caller-chosen
+                // (e.g. "AGD-42"); an empty string collapses to `None`
+                // so the renderer omits the id rather than showing "()".
+                let task_id = args["correlation_id"]
+                    .as_str()
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                ux_sink_registry().emit(&UxEvent::Fleet(FleetEvent::ReportResult {
+                    from: sender.as_str().to_string(),
+                    to: target.to_string(),
+                    summary: summary.to_string(),
+                    task_id,
+                }));
+            }
+            result
         }
         "request_information" => {
             let Some(sender) = sender.as_ref() else {
@@ -224,6 +265,16 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             for target in &targets {
                 let _ = send_to(&home, sender, target, message, kind);
                 sent.push(target.clone());
+            }
+            // Fleet visibility. Skip-emit on empty fan-out — a broadcast
+            // to an empty target set didn't actually surface anywhere
+            // and showing "[a → *0]" in fleet_binding is pure noise.
+            if !sent.is_empty() {
+                ux_sink_registry().emit(&UxEvent::Fleet(FleetEvent::Broadcast {
+                    from: sender.as_str().to_string(),
+                    recipients: sent.clone(),
+                    summary: message.to_string(),
+                }));
             }
             json!({"sent_to": sent, "count": sent.len()})
         }
@@ -525,7 +576,30 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         }
 
         // --- Decisions ---
-        "post_decision" => crate::decisions::post(&home, instance_name, args),
+        "post_decision" => {
+            let result = crate::decisions::post(&home, instance_name, args);
+            // Fleet visibility. `post_decision` is anonymous-tolerant
+            // (no `err_needs_identity` gate), so we deliberately
+            // **skip-emit** when no `Sender` was resolved: an
+            // anonymous decision has no identifiable author and
+            // landing a blank "[⬛ solo] DECISION ..." row would
+            // erode the "who decided" signal that fleet_binding
+            // readers rely on. This is by design — decisions'
+            // anonymous contract is preserved; only fleet mirroring
+            // requires identity. See `docs/DESIGN-stage-b-ux.md` §4.3.
+            if let (Some(id), Some(title), Some(sender)) = (
+                result.get("id").and_then(|v| v.as_str()),
+                args["title"].as_str(),
+                sender.as_ref(),
+            ) {
+                ux_sink_registry().emit(&UxEvent::Fleet(FleetEvent::PostDecision {
+                    by: sender.as_str().to_string(),
+                    title: title.to_string(),
+                    decision_id: id.to_string(),
+                }));
+            }
+            result
+        }
         "list_decisions" => crate::decisions::list(&home, args),
         "update_decision" => crate::decisions::update(&home, args),
 
@@ -982,6 +1056,393 @@ instances:
         let fake = std::path::PathBuf::from("/tmp/nonexistent-agend-test-dir");
         // Should not panic
         cleanup_working_dir(&home, "agent1", &fake);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ---------------------------------------------------------------------
+    // FleetEvent emission tests (Stage B-UX PR-A, design §2)
+    //
+    // These tests share two pieces of global state: (1) `AGEND_HOME` env
+    // var, read by `crate::home_dir()` inside `handle_tool`; (2) the
+    // crate-wide `ux_sink_registry()` singleton. Both are process-scoped,
+    // so the tests serialize through `fleet_test_guard()` and swap in a
+    // `RecordingSink` per case via `clear_for_test`.
+    //
+    // Each positive test carries at least one pin (Reviewer Contract v0.1
+    // §4) on the _source_ of the captured field — e.g. `task_id` must come
+    // from the handler's `correlation_id` arg, `decision_id` must come
+    // from `decisions::post`'s return, `recipients` must come from the
+    // filtered `sent` vec — not from the caller's raw args.
+    // ---------------------------------------------------------------------
+
+    use crate::channel::sink_registry::registry as ux_sink_registry;
+    use crate::channel::ux_event::{FleetEvent, UxEvent, UxEventSink};
+    use crate::sync::lock_poisoned;
+    use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
+
+    fn fleet_test_guard() -> MutexGuard<'static, ()> {
+        static GUARD: StdMutex<()> = StdMutex::new(());
+        lock_poisoned(&GUARD, "fleet_test_guard")
+    }
+
+    struct Recorder {
+        events: StdMutex<Vec<UxEvent>>,
+    }
+
+    impl Recorder {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                events: StdMutex::new(Vec::new()),
+            })
+        }
+
+        fn snapshot(&self) -> Vec<UxEvent> {
+            lock_poisoned(&self.events, "recorder").clone()
+        }
+    }
+
+    impl UxEventSink for Recorder {
+        fn emit(&self, event: &UxEvent) {
+            lock_poisoned(&self.events, "recorder").push(event.clone());
+        }
+    }
+
+    /// Set `AGEND_HOME` to a fresh temp dir with a minimal fleet.yaml
+    /// (so `get_submit_key` fallbacks resolve), wipe the global sink
+    /// registry, and register a fresh `Recorder`. Returns the recorder
+    /// and the temp-home path so callers can clean up.
+    fn setup_recorder(tag: &str) -> (Arc<Recorder>, std::path::PathBuf) {
+        let home = tmp_home(tag);
+        std::env::set_var("AGEND_HOME", &home);
+        // Minimal fleet so send_to's `get_submit_key` lookup resolves
+        // (fallback path on unreachable daemon still needs submit_key).
+        let yaml = "defaults:\n  backend: claude\ninstances:\n  target:\n    role: Test\n  sender:\n    role: Test\n";
+        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        let rec = Recorder::new();
+        ux_sink_registry().clear_for_test();
+        ux_sink_registry().register(rec.clone() as Arc<dyn UxEventSink>);
+        (rec, home)
+    }
+
+    #[test]
+    fn delegate_task_emits_fleet_event() {
+        let _g = fleet_test_guard();
+        let (rec, home) = setup_recorder("fleet_delegate");
+
+        let result = handle_tool(
+            "delegate_task",
+            &json!({"target_instance": "target", "task": "do the thing"}),
+            "sender",
+        );
+        // Must have succeeded (API-path or fallback); both populate "target".
+        assert!(
+            is_ok_result(&result),
+            "delegate_task should succeed: {result}"
+        );
+
+        let events = rec.snapshot();
+        assert_eq!(events.len(), 1, "expected one FleetEvent: {events:?}");
+        match &events[0] {
+            UxEvent::Fleet(FleetEvent::DelegateTask {
+                from,
+                to,
+                summary,
+                task_id,
+            }) => {
+                assert_eq!(from, "sender");
+                assert_eq!(to, "target");
+                assert_eq!(summary, "do the thing");
+                // Pin: `delegate_task` has no id slot; correlation surfaces
+                // later via `report_result.correlation_id`. Must be None.
+                assert!(task_id.is_none(), "task_id must be None for delegate");
+            }
+            other => panic!("expected DelegateTask, got {other:?}"),
+        }
+
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn report_result_emits_with_correlation_id() {
+        let _g = fleet_test_guard();
+        let (rec, home) = setup_recorder("fleet_report");
+
+        // Pin: task_id must source from the `correlation_id` arg, not
+        // any other string field. Use a distinctive value so a stray
+        // field aliasing bug would fail the assert below.
+        let result = handle_tool(
+            "report_result",
+            &json!({
+                "target_instance": "target",
+                "summary": "done",
+                "correlation_id": "AGD-42",
+            }),
+            "sender",
+        );
+        assert!(
+            is_ok_result(&result),
+            "report_result should succeed: {result}"
+        );
+
+        let events = rec.snapshot();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            UxEvent::Fleet(FleetEvent::ReportResult {
+                from,
+                to,
+                summary,
+                task_id,
+            }) => {
+                assert_eq!(from, "sender");
+                assert_eq!(to, "target");
+                assert_eq!(summary, "done");
+                assert_eq!(
+                    task_id.as_deref(),
+                    Some("AGD-42"),
+                    "task_id must come from correlation_id arg"
+                );
+            }
+            other => panic!("expected ReportResult, got {other:?}"),
+        }
+
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn report_result_empty_correlation_id_maps_to_none() {
+        let _g = fleet_test_guard();
+        let (rec, home) = setup_recorder("fleet_report_empty");
+
+        // Pin: empty `correlation_id` must collapse to None so the
+        // renderer omits the id rather than showing "()" — filter-empty
+        // is the specified normalization.
+        let _ = handle_tool(
+            "report_result",
+            &json!({
+                "target_instance": "target",
+                "summary": "done",
+                "correlation_id": "",
+            }),
+            "sender",
+        );
+
+        let events = rec.snapshot();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            UxEvent::Fleet(FleetEvent::ReportResult { task_id, .. }) => {
+                assert!(
+                    task_id.is_none(),
+                    "empty correlation_id must normalize to None, got {task_id:?}"
+                );
+            }
+            other => panic!("expected ReportResult, got {other:?}"),
+        }
+
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn post_decision_with_sender_emits_fleet_event() {
+        let _g = fleet_test_guard();
+        let (rec, home) = setup_recorder("fleet_decision");
+
+        let result = handle_tool(
+            "post_decision",
+            &json!({"title": "use X over Y", "content": "because Z"}),
+            "sender",
+        );
+        let posted_id = result["id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("post_decision must return id: {result}"))
+            .to_string();
+
+        let events = rec.snapshot();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            UxEvent::Fleet(FleetEvent::PostDecision {
+                by,
+                title,
+                decision_id,
+            }) => {
+                assert_eq!(by, "sender");
+                assert_eq!(title, "use X over Y");
+                // Pin: decision_id must come from `decisions::post`'s
+                // returned id (authoritative, nanosecond-stamped), NOT
+                // from any args the caller passed. Args have no id.
+                assert_eq!(
+                    decision_id, &posted_id,
+                    "decision_id must source from decisions::post result"
+                );
+            }
+            other => panic!("expected PostDecision, got {other:?}"),
+        }
+
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn post_decision_anonymous_does_not_emit_fleet_event() {
+        let _g = fleet_test_guard();
+        let (rec, home) = setup_recorder("fleet_decision_anon");
+
+        // Ensure no AGEND_INSTANCE_NAME fallback kicks in for the handler.
+        std::env::remove_var("AGEND_INSTANCE_NAME");
+
+        // Anonymous call — `instance_name` empty, no env fallback.
+        // Decisions module itself must still succeed (anonymous contract),
+        // only fleet mirroring is suppressed. Pin: absence of emission.
+        let result = handle_tool(
+            "post_decision",
+            &json!({"title": "anon call", "content": "no author"}),
+            "",
+        );
+        assert!(
+            result["id"].as_str().is_some(),
+            "post_decision still succeeds anonymously: {result}"
+        );
+
+        let events = rec.snapshot();
+        assert!(
+            events.is_empty(),
+            "anonymous post_decision must NOT emit: {events:?}"
+        );
+
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn broadcast_emits_with_resolved_recipients() {
+        let _g = fleet_test_guard();
+        let (rec, home) = setup_recorder("fleet_broadcast");
+
+        // `targets: ["target", "sender"]` — handler must self-filter
+        // `sender` out before computing the recipient set. Pin: the
+        // emitted `recipients` field comes from the filtered `sent`
+        // vec, NOT from the raw `args["targets"]`.
+        let result = handle_tool(
+            "broadcast",
+            &json!({
+                "message": "heads up",
+                "targets": ["target", "sender"],
+            }),
+            "sender",
+        );
+        // broadcast always returns {"sent_to": [...], "count": ...}
+        assert_eq!(result["count"].as_u64(), Some(1));
+
+        let events = rec.snapshot();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            UxEvent::Fleet(FleetEvent::Broadcast {
+                from,
+                recipients,
+                summary,
+            }) => {
+                assert_eq!(from, "sender");
+                assert_eq!(summary, "heads up");
+                assert_eq!(
+                    recipients,
+                    &vec!["target".to_string()],
+                    "recipients must be the self-filtered `sent` vec"
+                );
+            }
+            other => panic!("expected Broadcast, got {other:?}"),
+        }
+
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn broadcast_empty_targets_does_not_emit() {
+        let _g = fleet_test_guard();
+        let (rec, home) = setup_recorder("fleet_broadcast_empty");
+
+        // `targets: ["sender"]` — all recipients are the sender itself,
+        // so the self-filter leaves `sent` empty. Pin: skip-emit on
+        // empty fan-out so fleet_binding isn't spammed with "a → *0".
+        let result = handle_tool(
+            "broadcast",
+            &json!({
+                "message": "alone",
+                "targets": ["sender"],
+            }),
+            "sender",
+        );
+        assert_eq!(result["count"].as_u64(), Some(0));
+
+        let events = rec.snapshot();
+        assert!(
+            events.is_empty(),
+            "empty-recipient broadcast must NOT emit: {events:?}"
+        );
+
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn send_to_instance_does_not_emit_fleet_event() {
+        // Negative pin (design §8 exclusion): routine `send_to_instance`
+        // is a point-to-point DM and intentionally NOT mirrored into
+        // fleet_binding. If a future refactor accidentally routes it
+        // through `FleetEvent`, this test fails.
+        let _g = fleet_test_guard();
+        let (rec, home) = setup_recorder("fleet_send_to_excluded");
+
+        // send_to_instance takes `instance_name` (or `target`), not
+        // `target_instance` — use the real arg shape so the negative
+        // pin actually exercises the success path.
+        let result = handle_tool(
+            "send_to_instance",
+            &json!({"instance_name": "target", "message": "hi"}),
+            "sender",
+        );
+        assert!(
+            is_ok_result(&result),
+            "send_to_instance should succeed: {result}"
+        );
+
+        let events = rec.snapshot();
+        assert!(
+            events.is_empty(),
+            "send_to_instance must NOT emit FleetEvent (design §8 exclusion): {events:?}"
+        );
+
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn request_information_does_not_emit_fleet_event() {
+        // Negative pin (design §8 exclusion): `request_information` is
+        // a point-to-point query, not a fleet-visible coordination
+        // action. Guards against over-eager emission by future edits.
+        let _g = fleet_test_guard();
+        let (rec, home) = setup_recorder("fleet_request_info_excluded");
+
+        let result = handle_tool(
+            "request_information",
+            &json!({"target_instance": "target", "question": "what is X?"}),
+            "sender",
+        );
+        assert!(
+            is_ok_result(&result),
+            "request_information should succeed: {result}"
+        );
+
+        let events = rec.snapshot();
+        assert!(
+            events.is_empty(),
+            "request_information must NOT emit FleetEvent (design §8 exclusion): {events:?}"
+        );
+
+        std::env::remove_var("AGEND_HOME");
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -964,13 +964,21 @@ mod tests {
     fn codex_config_idempotent_across_reruns() {
         // Re-running configure twice must leave the file byte-identical —
         // no duplicated headers, no drifting whitespace.
+        //
+        // Use `_with_home(scratch)` rather than `configure_codex` so the
+        // emitted `AGEND_HOME = ...` value is fixed for both runs.
+        // `configure_codex` reads `home_path()` (global `AGEND_HOME` env
+        // var), which races with any other test in the process that
+        // mutates that env — e.g. the `mcp::handlers::tests` Fleet
+        // emission tests — and caused this test to drift across reruns.
         let dir = tmp_dir("codex_cfg_idem");
         std::fs::create_dir_all(dir.join(".codex")).expect("create .codex");
+        let scratch_home = "/tmp/agend-test-home-codex-idem";
 
-        configure_codex(&dir).expect("first");
+        configure_codex_with_home(&dir, scratch_home).expect("first");
         let after_first =
             std::fs::read_to_string(dir.join(".codex/config.toml")).expect("read first");
-        configure_codex(&dir).expect("second");
+        configure_codex_with_home(&dir, scratch_home).expect("second");
         let after_second =
             std::fs::read_to_string(dir.join(".codex/config.toml")).expect("read second");
 


### PR DESCRIPTION
## Summary

Producer side of Stage B-UX fleet visibility. Scope anchored at [`docs/DESIGN-stage-b-ux.md` §2](docs/DESIGN-stage-b-ux.md). Review against [Reviewer Contract v0.1](docs/REVIEWER-CONTRACT-v0.1.md).

- `UxEvent::Fleet(FleetEvent)` wrapper emitted from 4 MCP coordination tools (`delegate_task`, `report_result`, `post_decision`, `broadcast`).
- Crate-level `UxSinkRegistry` singleton (`Mutex` + `lock_poisoned`, matches `ACL` / `DETECTED_TZ` / `RT` / `CACHE` pattern — design §9 Q3).
- Config schema: `fleet_binding: Option<FleetBindingConfig>` on `ChannelConfig::Telegram`, `#[serde(untagged)]` struct-or-shorthand.
- Consumer side (Telegram fleet_binding renderer) lands in PR-B. Until then, production runs have zero registered sinks and emissions are harmless no-ops.

## Scope deferred to PR-B
- §4.4 dispatch-split refactor (`TelegramChannel` as `UxEventSink`).
- Bootstrap resolution of `fleet_binding` config into a `TelegramState` field.

## Design-locked behaviour
- **`is_ok_result` gating** — absence of `error` key emits; both API-success `{"target"}` and fallback-success `{"target","note"}` emit; `{"error"}` suppresses.
- **Anonymous `post_decision` skip-emit** (Q2) — preserves decisions' anonymous contract; only fleet mirroring requires identity.
- **Empty-fan-out `broadcast` skip-emit** — avoids `"a → *0"` noise rows.
- **Empty `correlation_id` → None** — renderer omits rather than showing `()`.
- **`task_id: Option<String>`** (Q1) — correlation_id is caller-chosen ad-hoc string, not a typed newtype.

## Regression pins (Reviewer Contract v0.1 §4 — implementor responsibility)

Per contract: implementor MUST carry ≥1 pin proving the change actually runs, not just compile-passes. Pins are on value _source_, not just final output:

| Test | Pins |
|------|------|
| `delegate_task_emits_fleet_event` | `task_id` is None (no id slot) |
| `report_result_emits_with_correlation_id` | `task_id` sources from `correlation_id` arg |
| `report_result_empty_correlation_id_maps_to_none` | filter-empty normalization |
| `post_decision_with_sender_emits_fleet_event` | `decision_id` sources from `decisions::post` return, not args |
| `post_decision_anonymous_does_not_emit_fleet_event` | anonymous skip-emit |
| `broadcast_emits_with_resolved_recipients` | `recipients` from self-filtered `sent` vec |
| `broadcast_empty_targets_does_not_emit` | skip-emit on empty fan-out |
| `send_to_instance_does_not_emit_fleet_event` | §8 exclusion negative pin |
| `request_information_does_not_emit_fleet_event` | §8 exclusion negative pin |

## Drive-by fix

`codex_config_idempotent_across_reruns` called `configure_codex` (which reads global `AGEND_HOME`) and raced with any test mutating that env. The codebase had already split `configure_codex_with_home` explicitly for this reason — switched the idempotency test to that variant. My Fleet emission tests legitimately set `AGEND_HOME` and exposed the latent race.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (including `-D clippy::unwrap-used`)
- [x] `cargo test --all-targets` — all pass (620 bin unittests + 9 integration + 14 mcp_roundtrip + 20 api + 5 no_dual_track_drift + 2 self_healing_supervisor)
- [x] 9 new Fleet emission tests in `src/mcp/handlers.rs::tests`
- [x] 4 internal tests in `src/channel/sink_registry.rs::tests`
- [x] 2 tests in `src/channel/ux_event.rs::tests` for `FleetEvent` variant + `select_action` Fleet-arm

🤖 Generated with [Claude Code](https://claude.com/claude-code)