### PR TITLE
feat: add Discord adapter behind --features discord

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      - name: Check without discord
+        run: cargo check --no-default-features
+
       - name: Unit tests
         run: cargo test --bin agend-terminal
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ unwrap_used = "deny"
 # Default build stays lean: `tray-icon` + `tao` only pull in when
 # `--features tray` is passed (release binaries ship with it).
 [features]
-default = []
+default = ["discord"]
+discord = ["dep:serenity"]
 tray = ["dep:tray-icon", "dep:tao", "dep:toml"]
 
 [profile.release]
@@ -58,6 +59,9 @@ serde_yaml = "0.9"
 
 # Telegram — rustls backend avoids macOS SecureTransport/Keychain/OCSP flakiness
 teloxide = { version = "0.13", default-features = false, features = ["macros", "ctrlc_handler", "rustls"] }
+
+# Discord — included by default; opt out with --no-default-features
+serenity = { version = "0.12", optional = true, default-features = false, features = ["client", "gateway", "model", "rustls_backend"] }
 
 # Utilities
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,47 @@ multi-pane TUI, a Telegram channel, or an optional system tray.
 | Git isolation | Manual worktrees | Auto per-agent worktree |
 
 ## Quick Start
+## Installation
+
+### Windows
+
+**Prerequisites:**
+- [Rust toolchain](https://rustup.rs/) (includes `cargo`)
+- [Git for Windows](https://git-scm.com/download/win)
+- One of the supported AI coding CLIs (installed and authenticated)
+
+```powershell
+# 1. Clone and build
+git clone https://github.com/songsid/agend-terminal.git
+cd agend-terminal
+cargo build --release
+
+# Build without Discord support:
+# cargo build --release --no-default-features
+
+# 2. Add to PATH (PowerShell)
+$env:PATH += ";$(Get-Location)\target\release"
+
+# 3. Verify
+agend-terminal --version
+```
+
+> **Note:** On Windows, `agend-terminal` uses ConPTY instead of tmux.
+> WSL is not required.
+
+### Linux / macOS
+
+```bash
+# From source
+git clone https://github.com/songsid/agend-terminal.git
+cd agend-terminal
+cargo install --path .
+
+# Or via cargo
+cargo install agend-terminal
+```
+
+
 
 ```bash
 # Demo (no config)

--- a/docs/DESIGN-discord-adapter.md
+++ b/docs/DESIGN-discord-adapter.md
@@ -1,0 +1,391 @@
+# Discord Adapter Design Document
+
+**Feature branch:** `discord`
+**Date:** 2026-04-21
+**Status:** Draft
+
+---
+
+## 1. Overview
+
+Add Discord as a second channel adapter in agend-terminal, alongside the existing Telegram adapter. Each agent instance maps to a Discord Text Channel inside an auto-managed Category, mirroring how Telegram maps instances to Forum Topics.
+
+### Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     fleet.yaml                          │
+│  channel:                                               │
+│    type: discord                                        │
+│    bot_token_env: DISCORD_BOT_TOKEN                     │
+│    guild_id: "123456789012345678"                       │
+│    category_name: "AgEnD Agents"        (optional)      │
+│    user_allowlist: ["111...", "222..."]  (optional)      │
+└──────────────────────┬──────────────────────────────────┘
+                       │
+              ┌────────▼────────┐
+              │  bootstrap::     │
+              │  channel_init    │
+              │  (new, generic)  │
+              └────────┬────────┘
+                       │
+         ┌─────────────▼──────────────┐
+         │      DiscordState          │
+         │  ┌───────────────────────┐ │
+         │  │ serenity::Client      │ │
+         │  │ Http (for REST calls) │ │
+         │  │ guild_id: GuildId     │ │
+         │  │ category_id: ChannelId│ │
+         │  │ channel_to_instance   │ │  HashMap<u64, String>
+         │  │ instance_to_channel   │ │  HashMap<String, u64>
+         │  │ submit_keys           │ │  HashMap<String, String>
+         │  │ user_allowlist        │ │  Option<Vec<String>>
+         │  │ home: PathBuf         │ │
+         │  │ registry: Option<AR>  │ │
+         │  └───────────────────────┘ │
+         └─────────────┬─────────────┘
+                       │
+          ┌────────────┼────────────┐
+          │            │            │
+    ┌─────▼─────┐ ┌───▼───┐ ┌─────▼──────┐
+    │ Inbound   │ │Outbound│ │ Channel    │
+    │ EventHandler│ │ REST  │ │ Lifecycle  │
+    │ (Gateway) │ │ calls  │ │ create/del │
+    └───────────┘ └───────┘ └────────────┘
+```
+
+---
+
+## 2. Data Structures
+
+### 2.1 ChannelConfig — extend enum in `fleet.rs`
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ChannelConfig {
+    #[serde(rename = "telegram")]
+    Telegram { /* existing fields */ },
+
+    #[serde(rename = "discord")]
+    Discord {
+        /// Env var name containing the Discord bot token.
+        bot_token_env: String,
+        /// Discord Guild (server) ID — stored as string to avoid
+        /// YAML f64 precision loss on 64-bit snowflake IDs.
+        guild_id: String,
+        /// Category name to auto-create/find. Default: "AgEnD Agents".
+        #[serde(default = "default_category_name")]
+        category_name: String,
+        /// Optional allowlist of Discord user IDs (snowflake strings).
+        /// Semantics mirror Telegram: None = open, Some([]) = reject all.
+        #[serde(default)]
+        user_allowlist: Option<Vec<String>>,
+    },
+}
+
+fn default_category_name() -> String {
+    "AgEnD Agents".to_string()
+}
+```
+
+**Snowflake ID handling:** Discord IDs are u64 but YAML/JSON float precision
+truncates values > 2^53. `guild_id` and `user_allowlist` are stored as
+`String` in the config. Internal runtime maps use `u64` after parsing.
+
+### 2.2 InstanceConfig — extend `channel_id` field in `fleet.rs`
+
+```rust
+pub struct InstanceConfig {
+    // ... existing fields ...
+    pub topic_id: Option<i32>,          // Telegram (kept)
+    pub channel_id: Option<String>,     // Discord — snowflake as string
+}
+```
+
+### 2.3 DiscordState — new struct in `discord.rs`
+
+```rust
+pub struct DiscordState {
+    pub http: Arc<serenity::http::Http>,
+    pub guild_id: serenity::model::id::GuildId,
+    pub category_id: serenity::model::id::ChannelId,
+    pub channel_to_instance: HashMap<u64, String>,
+    pub instance_to_channel: HashMap<String, u64>,
+    pub home: PathBuf,
+    pub submit_keys: HashMap<String, String>,
+    pub user_allowlist: Option<Vec<u64>>,
+    pub registry: Option<AgentRegistry>,
+}
+```
+
+### 2.4 Channel Registry — `channels.json`
+
+Persisted at `$AGEND_HOME/channels.json` (parallel to `topics.json`).
+
+```json
+{
+  "1234567890123456": "alice",
+  "1234567890123457": "bob"
+}
+```
+
+Key = channel_id (string), Value = instance_name.
+
+---
+
+## 3. Core Flows
+
+### 3.1 Initialization (`init_from_config`)
+
+```
+1. Read bot_token from env var (bot_token_env)
+2. Parse guild_id string → u64 → GuildId
+3. Create serenity Http client from token
+4. Find or create the Category channel:
+   a. GET /guilds/{guild_id}/channels
+   b. Find existing category by name (category_name)
+   c. If not found: POST create category channel (type=4)
+   d. Store category_id
+5. Load channel_registry (channels.json)
+6. Clean up orphaned channels:
+   - For each entry in registry not in fleet.yaml instances → delete channel
+7. For each instance in fleet.yaml:
+   a. If channel_id is set → verify channel exists, register mapping
+   b. If instance is "general":
+      - Use first existing text channel in category, or create one named "general"
+   c. Else: create text channel under category, named after instance
+   d. Write channel_id back to fleet.yaml
+   e. Register in channels.json
+8. Build DiscordState with all mappings
+9. Start gateway polling (serenity Client) in dedicated thread
+```
+
+### 3.2 Inbound Message Handling (`EventHandler::message`)
+
+```
+1. Ignore bot messages (msg.author.bot)
+2. Authz: check msg.author.id against user_allowlist
+   - None → accept all (legacy open)
+   - Some([]) → reject all
+   - Some([...]) → must be in list
+3. Resolve channel_id → instance_name via channel_to_instance map
+   - Unknown channel → reload from fleet.yaml (same pattern as Telegram)
+   - Still unknown → route to "general"
+4. Check agent_wants_raw_keystrokes (same logic as Telegram):
+   - If true → inject raw keystrokes via API INJECT call
+   - If false → enqueue InboxMessage + notify_agent via PTY
+5. Handle attachments:
+   - Discord CDN URLs expire; download immediately to $AGEND_HOME/downloads/{instance}/
+   - Append "[attachment: {filename}]" to message text
+```
+
+### 3.3 Outbound: send_reply / react / edit_message
+
+```rust
+// send_reply: split text at 2000 chars, send each chunk
+pub fn try_discord_reply(instance_name: &str, text: &str) -> Result<(String, String)>
+// Returns (message_id, channel_id) as strings
+
+// react: add reaction emoji to message
+pub fn try_discord_react(instance_name: &str, emoji: &str, message_id: Option<&str>) -> Result<()>
+
+// edit_message: edit by message_id
+pub fn try_discord_edit(instance_name: &str, message_id: &str, text: &str) -> Result<()>
+```
+
+**Message splitting** (2000 char limit):
+
+```rust
+fn split_message(text: &str, limit: usize) -> Vec<&str> {
+    // Split on newline boundaries, falling back to char boundary at limit
+}
+```
+
+### 3.4 Channel Lifecycle
+
+```rust
+// Create a text channel for a new instance under the AgEnD category
+pub fn create_channel_for_instance(home: &Path, instance_name: &str) -> Option<String>
+
+// Delete a text channel
+pub fn delete_channel(home: &Path, channel_id: u64)
+```
+
+### 3.5 Channel Deletion Detection
+
+Serenity `EventHandler::channel_delete` fires when a channel is removed.
+Maps to the same cleanup path as Telegram's `forum_topic_closed`:
+
+```
+1. Look up channel_id in channel_to_instance
+2. If found → cleanup_deleted_channel(home, instance_name, channel_id, state)
+   - Remove from in-memory maps
+   - Call API DELETE to stop the agent
+   - Remove from fleet.yaml
+   - Unregister from channels.json
+```
+
+---
+
+## 4. fleet.yaml Configuration
+
+```yaml
+channel:
+  type: discord
+  bot_token_env: DISCORD_BOT_TOKEN
+  guild_id: "123456789012345678"       # string — snowflake
+  category_name: "AgEnD Agents"        # optional, default shown
+  user_allowlist:                       # optional
+    - "111111111111111111"
+    - "222222222222222222"
+
+defaults:
+  backend: claude
+
+instances:
+  general:
+    role: "General coordination"
+    # channel_id auto-populated after first run
+  alice:
+    backend: kiro-cli
+    role: "Developer"
+    # channel_id: "987654321098765432"  # auto-populated
+  bob:
+    backend: claude
+    role: "Reviewer"
+```
+
+---
+
+## 5. Files to Modify / Create
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/discord.rs` | **CREATE** | DiscordState, EventHandler, init_from_config, send/react/edit/download, channel lifecycle, ChannelAdapter impl |
+| `src/fleet.rs` | MODIFY | Add `Discord` variant to `ChannelConfig`, add `channel_id: Option<String>` to `InstanceConfig`, add `channel_id` to `ResolvedInstance` |
+| `src/channel.rs` | MODIFY | No structural changes needed — trait is already generic enough |
+| `src/bootstrap/telegram_init.rs` | RENAME → `src/bootstrap/channel_init.rs` | Generalize to dispatch on `ChannelConfig` variant: Telegram → existing, Discord → new |
+| `src/bootstrap/mod.rs` | MODIFY | Update module reference from `telegram_init` to `channel_init`, update `OwnedFleet.telegram` field to generic `channel: Option<Arc<Mutex<dyn ChannelAdapter>>>` or keep both |
+| `src/ops.rs` | MODIFY | Add Discord dispatch in reply/react/edit/download — route based on active channel type |
+| `src/mcp/handlers.rs` | MODIFY | Route channel tools (reply, react, edit, download) through channel-agnostic dispatch |
+| `src/mcp/tools.rs` | MODIFY | Update tool descriptions from "Telegram" to "channel" (backward-compatible) |
+| `src/app/telegram_hooks.rs` | RENAME → `src/app/channel_hooks.rs` | Generalize topic/channel create/delete hooks |
+| `src/daemon/telegram.rs` | RENAME → `src/daemon/channel_notify.rs` | Generalize notify function to dispatch on channel type |
+| `Cargo.toml` | MODIFY | Add `serenity` dependency |
+
+---
+
+## 6. Implementation Strategy
+
+### Phase 1: Foundation (channel abstraction)
+
+1. Add `channel_id: Option<String>` to `InstanceConfig` and `ResolvedInstance` in `fleet.rs`
+2. Add `Discord` variant to `ChannelConfig` enum in `fleet.rs`
+3. Add `serenity` to `Cargo.toml`:
+   ```toml
+   serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "model", "rustls_backend", "cache"] }
+   ```
+
+### Phase 2: Core Discord module
+
+4. Create `src/discord.rs` with:
+   - `DiscordState` struct
+   - Channel registry (channels.json) load/save/register/unregister
+   - `init_from_config()` — category find/create, channel auto-create, orphan cleanup
+   - `start_gateway()` — spawn serenity Client in dedicated thread with its own tokio runtime (same pattern as Telegram's `start_polling`)
+   - Serenity `EventHandler` impl:
+     - `message()` → inbound routing (authz → resolve → inbox/raw)
+     - `channel_delete()` → cleanup
+   - `split_message()` for 2000-char limit
+   - Outbound: `try_discord_reply`, `try_discord_react`, `try_discord_edit`, `try_discord_download`
+   - `ChannelAdapter` trait impl for `Arc<Mutex<DiscordState>>`
+
+### Phase 3: Integration wiring
+
+5. Generalize `bootstrap/telegram_init.rs` → `channel_init.rs`:
+   - Match on `ChannelConfig` variant, call appropriate init
+6. Update `bootstrap/mod.rs`:
+   - Change `OwnedFleet.telegram` to a channel-agnostic type, or add `discord` field alongside
+   - Recommended: keep `telegram: Option<Arc<Mutex<TelegramState>>>` and add `discord: Option<Arc<Mutex<DiscordState>>>` for simplicity — a full trait-object refactor can follow later
+7. Update `ops.rs` channel functions to dispatch based on configured channel type
+8. Update `mcp/handlers.rs` to route through ops (already partially done)
+9. Generalize `app/telegram_hooks.rs` → `channel_hooks.rs`
+10. Generalize `daemon/telegram.rs` → `channel_notify.rs`
+
+### Phase 4: Polish
+
+11. Update MCP tool descriptions (remove "Telegram" hardcoding)
+12. Add `attach_registry()` for Discord (same pattern as Telegram)
+13. Handle Discord-specific edge cases:
+    - Rate limiting (serenity handles most, but bulk channel creation at init needs backoff)
+    - CDN attachment download (URLs expire, must download immediately)
+    - Nickname/display name resolution for `from:` field in InboxMessage
+
+---
+
+## 7. Key Design Decisions
+
+### 7.1 Serenity crate over raw REST
+
+Serenity provides Gateway (WebSocket) event handling, HTTP client, model types, and rate-limit management. This mirrors how `teloxide` serves the Telegram adapter. Use `rustls_backend` feature to match the project's TLS strategy (no OpenSSL).
+
+### 7.2 Snowflake IDs as strings in config, u64 at runtime
+
+YAML parses large integers as f64, losing precision beyond 2^53. Discord snowflakes are full u64. Solution: `String` in `fleet.yaml` / `ChannelConfig` / `channels.json`, parsed to `u64` at init time. This matches the TypeScript version's approach.
+
+### 7.3 Dedicated thread + tokio runtime (same as Telegram)
+
+Serenity's gateway client needs an async runtime. Spawn a dedicated thread with `tokio::runtime::Builder::new_current_thread()` — identical to the Telegram adapter pattern. This avoids polluting the main thread's event loop.
+
+### 7.4 Channel-per-instance (not thread-per-instance)
+
+Discord Text Channels map 1:1 to instances, grouped under a Category. This is the direct analog of Telegram Forum Topics. Discord Threads were considered but rejected: threads auto-archive, have different permission models, and don't appear as prominently in the channel list.
+
+### 7.5 Incremental integration (no big trait-object refactor)
+
+Keep `OwnedFleet` with explicit `telegram` and `discord` fields rather than `Box<dyn ChannelAdapter>`. Reason: the two adapters have different state types, and call sites (ops.rs, daemon notify, app hooks) need adapter-specific access for lifecycle management. A full abstraction can follow once both adapters are stable.
+
+### 7.6 Message length: 2000 chars
+
+Discord's message limit is 2000 characters. Split on newline boundaries when possible, hard-split at 2000 otherwise. Each chunk is sent as a separate message.
+
+---
+
+## 8. Discord Bot Permissions Required
+
+The bot needs these Gateway Intents and permissions:
+
+**Gateway Intents:**
+- `GUILDS` — channel create/delete events
+- `GUILD_MESSAGES` — inbound messages
+- `MESSAGE_CONTENT` — read message text (privileged intent, must be enabled in Discord Developer Portal)
+
+**Channel Permissions:**
+- `MANAGE_CHANNELS` — create/delete text channels and categories
+- `SEND_MESSAGES` — outbound replies
+- `READ_MESSAGE_HISTORY` — context for edits
+- `ADD_REACTIONS` — react to messages
+- `ATTACH_FILES` — (future) send file attachments
+
+---
+
+## 9. Error Handling Patterns
+
+Mirror Telegram's patterns:
+
+| Scenario | Telegram | Discord |
+|----------|----------|---------|
+| Channel/topic deleted externally | `is_topic_deleted_error` + `cleanup_deleted_topic` | `channel_delete` event + `cleanup_deleted_channel` |
+| Send failure to deleted channel | `handle_send_failure` checks error string | Check for `Unknown Channel` (10003) error code |
+| Bot token missing | Skip init, log info | Same |
+| Rate limit | teloxide handles | serenity handles (built-in ratelimiter) |
+| Orphan cleanup at startup | Compare registry vs fleet.yaml | Same |
+
+---
+
+## 10. Testing Strategy
+
+- Unit tests for `split_message`, channel registry CRUD, snowflake parsing, user allowlist logic (same pattern as `telegram.rs` tests)
+- Integration test: mock serenity HTTP to verify init flow creates category + channels
+- Manual test: deploy with a real Discord bot on a test server

--- a/docs/DESIGN-discord-bugfixes.md
+++ b/docs/DESIGN-discord-bugfixes.md
@@ -1,0 +1,104 @@
+# Discord Bugfixes: Attachment Download + Channel Routing
+
+**Date:** 2026-04-22
+
+---
+
+## Bug 1: Discord Attachment Download Fails ("builder error")
+
+### Root Cause
+
+The MCP `download_attachment` tool passes `file_id` (which is the attachment filename, e.g. `8719DE7B.png`) to `try_discord_download()`, which calls `reqwest::get(url)` on it. A filename is not a URL → reqwest builder error.
+
+Meanwhile, the inbound handler (line ~385) already downloads attachments correctly via `att.download().await` and saves them to `$AGEND_HOME/downloads/{instance}/`.
+
+### Fix: Return Local Path (Scheme A)
+
+Since inbound already downloads the file, `try_discord_download` should just return the existing local path:
+
+```rust
+pub fn try_discord_download(instance_name: &str, file_id: &str) -> anyhow::Result<String> {
+    let home = crate::home_dir();
+    let path = home.join("downloads").join(instance_name).join(file_id);
+    if path.exists() {
+        Ok(path.display().to_string())
+    } else {
+        anyhow::bail!("attachment not found: {}", path.display())
+    }
+}
+```
+
+This is correct because:
+- Discord CDN URLs expire, so re-downloading later would fail anyway
+- Inbound handler already saves with `att.filename` as the filename
+- The `[attachment: {filename}]` text appended to the message matches the saved filename
+- Matches the semantic contract: "give me the local path to this attachment"
+
+### File Change
+
+| File | Change |
+|------|--------|
+| `src/discord.rs` | Replace `try_discord_download()` body: check local path exists, return it |
+
+---
+
+## Bug 2: Non-AgEnD Channel Messages Routed to General
+
+### Root Cause
+
+`resolve_channel_to_instance()` falls back to `"general"` for any unknown `channel_id`. The bot can read messages from all channels it has permission for (e.g. the server's default `#general`), so those messages get incorrectly routed to the AgEnD general instance.
+
+### Fix: Ignore Messages from Unregistered Channels
+
+Add a check in `EventHandler::message` before routing. Two options:
+
+**Option A (simple, recommended):** Check if `channel_id` is in the registered map. If not, ignore.
+
+```rust
+// In EventHandler::message, after extracting channel_id:
+let instance_name = {
+    let mut s = lock_state(&self.state);
+    let cid = msg.channel_id.get();
+    if !s.channel_to_instance.contains_key(&cid) {
+        // Reload from fleet.yaml (same as current logic)
+        // If still not found → return (ignore), don't fallback to "general"
+        return;
+    }
+    resolve_channel_to_instance(&mut s, cid)
+};
+```
+
+**Option B (category check):** Verify the channel's `parent_id` matches the AgEnD category. More robust but requires an extra API call or cache lookup.
+
+**Recommendation: Option A.** It's simpler, no extra API calls, and the channel map is the source of truth — if a channel isn't registered, it's not an AgEnD channel.
+
+### Change to `resolve_channel_to_instance()`
+
+Change the fallback from `"general".to_string()` to `None`:
+
+```rust
+fn resolve_channel_to_instance(state: &mut DiscordState, channel_id: u64) -> Option<String> {
+    // ... existing lookup + fleet.yaml reload ...
+    // If still not found:
+    None  // was: "general".to_string()
+}
+```
+
+Caller checks `None` → ignore message silently.
+
+### File Change
+
+| File | Change |
+|------|--------|
+| `src/discord.rs` | Change `resolve_channel_to_instance` return type to `Option<String>`, return `None` instead of `"general"` fallback. Update `EventHandler::message` to skip on `None`. |
+
+---
+
+## Summary
+
+| Bug | Fix | Files | Risk |
+|-----|-----|-------|------|
+| Attachment download | Return local path instead of re-downloading | `discord.rs` | Zero — inbound already downloads correctly |
+| Channel routing | Return `None` for unregistered channels, skip message | `discord.rs` | Low — only changes fallback behavior for non-AgEnD channels |
+
+Both fixes are in `src/discord.rs` only.

--- a/docs/DESIGN-discord-default-feature.md
+++ b/docs/DESIGN-discord-default-feature.md
@@ -1,0 +1,90 @@
+# Discord as Default Feature
+
+**Date:** 2026-04-22
+**Branch:** `discord`
+
+---
+
+## Rationale
+
+Telegram (teloxide) compiles unconditionally. Discord (serenity) requires `--features discord`, creating an asymmetry. Making `discord` a default feature aligns both adapters. Users who don't need Discord can opt out with `--no-default-features`.
+
+## Changes
+
+### 1. Cargo.toml
+
+```toml
+# Before
+default = []
+
+# After
+default = ["discord"]
+```
+
+One line change. The `discord = ["dep:serenity"]` feature definition and `serenity` optional dep stay as-is.
+
+### 2. CI Workflow (`.github/workflows/ci.yml`)
+
+```yaml
+# Before (lines 38, 47) — only enables tray, discord not tested by default
+run: cargo clippy --all-targets --features tray -- -D warnings
+run: cargo test --bin agend-terminal --features tray
+
+# After — discord now included via default, just add tray
+# No change needed — default features are always active unless --no-default-features
+# The existing commands already compile with default features + tray
+```
+
+CI already uses default features implicitly. The `--features tray` flag adds tray on top. No CI change needed.
+
+**Optional improvement:** Add a `--no-default-features` job to verify the discord-less build still compiles:
+
+```yaml
+- name: Build without discord
+  run: cargo check --no-default-features
+```
+
+### 3. `#[cfg(feature = "discord")]` Guards
+
+No change. All existing `#[cfg(feature = "discord")]` guards remain correct — `default = ["discord"]` means the feature is active by default, so the gated code compiles. `--no-default-features` disables it, and the guards correctly exclude Discord code.
+
+### 4. README.md
+
+```markdown
+# Before (line 64)
+cargo build --release --features discord
+
+# After
+cargo build --release
+```
+
+Remove `--features discord` from build instructions. Add a note:
+
+```markdown
+# Build without Discord support:
+cargo build --release --no-default-features
+```
+
+### 5. Cargo.toml Comment
+
+```toml
+# Before (line 63)
+# Discord — optional, behind `--features discord`
+
+# After
+# Discord — included by default; opt out with --no-default-features
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | `default = []` → `default = ["discord"]`, update comment |
+| `README.md` | Remove `--features discord` from build command, add opt-out note |
+| `.github/workflows/ci.yml` | Optional: add `--no-default-features` check job |
+
+## Not Changed
+
+- All `#[cfg(feature = "discord")]` guards — unchanged
+- `serenity` dependency declaration — unchanged
+- `discord = ["dep:serenity"]` feature definition — unchanged

--- a/src/app/telegram_hooks.rs
+++ b/src/app/telegram_hooks.rs
@@ -25,7 +25,17 @@ pub(super) fn telegram_status_from_config(
                 render::TelegramStatus::NoToken
             }
         }
-        None => render::TelegramStatus::NotConfigured,
+        #[cfg(feature = "discord")]
+        Some(crate::fleet::ChannelConfig::Discord {
+            ref bot_token_env, ..
+        }) => {
+            if std::env::var(bot_token_env).is_ok() {
+                render::TelegramStatus::Connected
+            } else {
+                render::TelegramStatus::NoToken
+            }
+        }
+        _ => render::TelegramStatus::NotConfigured,
     }
 }
 
@@ -78,3 +88,5 @@ pub(super) fn maybe_delete_telegram_topic(
         }
     });
 }
+
+

--- a/src/bootstrap/discord_init.rs
+++ b/src/bootstrap/discord_init.rs
@@ -1,0 +1,22 @@
+//! Discord bootstrap — wraps [`crate::channel::discord::init_from_config`].
+
+use crate::channel::discord::DiscordChannel;
+use crate::channel::Channel;
+use crate::fleet::FleetConfig;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+pub(super) fn init(config: &FleetConfig, home: &Path) -> Option<Arc<dyn Channel>> {
+    let submit_keys: HashMap<String, String> = config
+        .instances
+        .keys()
+        .filter_map(|name| {
+            config
+                .resolve_instance(name)
+                .map(|r| (name.clone(), r.submit_key))
+        })
+        .collect();
+    let state = crate::channel::discord::init_from_config(config, home, submit_keys)?;
+    Some(Arc::new(DiscordChannel::new(state)) as Arc<dyn Channel>)
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -18,6 +18,8 @@ mod fleet_normalize;
 pub mod reload;
 pub mod signals;
 mod telegram_init;
+#[cfg(feature = "discord")]
+mod discord_init;
 
 pub(crate) use agent_resolve::resolve_one;
 pub use agent_resolve::AgentDef;
@@ -60,6 +62,9 @@ pub struct OwnedFleet {
     #[allow(dead_code)]
     pub cookie: crate::auth_cookie::Cookie,
     pub telegram: Option<Arc<dyn crate::channel::Channel>>,
+    #[cfg(feature = "discord")]
+    #[allow(dead_code)]
+    pub discord: Option<Arc<dyn crate::channel::Channel>>,
     /// Flock guard — drop releases `.daemon.lock`. Kept last so the lock is
     /// released only after every other resource has been dropped.
     #[allow(dead_code)]
@@ -171,6 +176,13 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
         None
     };
 
+    #[cfg(feature = "discord")]
+    let discord = if opts.init_telegram {
+        discord_init::init(&config, home)
+    } else {
+        None
+    };
+
     Ok(BootstrapOutcome::Owned(Box::new(OwnedFleet {
         home: home.to_path_buf(),
         fleet_path: fleet_path.to_path_buf(),
@@ -179,6 +191,8 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
         run_dir,
         cookie,
         telegram,
+        #[cfg(feature = "discord")]
+        discord,
         lock,
     })))
 }

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -1,0 +1,634 @@
+//! Discord adapter — implements the `Channel` trait for Discord via serenity.
+
+use crate::agent::AgentRegistry;
+use crate::channel::{BindingRef, ChannelCapabilities, ChannelEvent, MsgRef, OutMsg};
+use crate::fleet::ChannelConfig;
+use crate::inbox::{self, InboxMessage};
+use serenity::all::{
+    ChannelId, ChannelType, Context, EventHandler, GatewayIntents, GuildChannel, GuildId, Http,
+    Message, Ready,
+};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+// ---------------------------------------------------------------------------
+// Binding payload
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub(crate) struct DiscordBindingPayload {
+    pub channel_id: u64,
+}
+
+impl DiscordBindingPayload {
+    fn into_binding(self) -> BindingRef {
+        let tag = format!("DC#{}", self.channel_id);
+        BindingRef::new("discord", Some(tag), self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State + lock helper
+// ---------------------------------------------------------------------------
+
+pub struct DiscordState {
+    pub http: Arc<Http>,
+    pub guild_id: GuildId,
+    pub category_id: ChannelId,
+    pub channel_to_instance: HashMap<u64, String>,
+    pub instance_to_channel: HashMap<String, u64>,
+    pub home: PathBuf,
+    pub submit_keys: HashMap<String, String>,
+    pub user_allowlist: Option<Vec<u64>>,
+    pub registry: Option<AgentRegistry>,
+}
+
+impl DiscordState {
+    pub fn is_user_allowed(&self, user_id: u64) -> bool {
+        match &self.user_allowlist {
+            None => true,
+            Some(list) => list.contains(&user_id),
+        }
+    }
+}
+
+pub(crate) fn lock_state(ds: &Arc<Mutex<DiscordState>>) -> std::sync::MutexGuard<'_, DiscordState> {
+    ds.lock().unwrap_or_else(|e| {
+        tracing::warn!("DiscordState mutex poisoned, recovering");
+        e.into_inner()
+    })
+}
+
+fn parse_snowflake(s: &str, label: &str) -> anyhow::Result<u64> {
+    s.parse::<u64>()
+        .map_err(|_| anyhow::anyhow!("invalid {label} snowflake '{s}': expected numeric u64"))
+}
+
+// ---------------------------------------------------------------------------
+// Channel registry (channels.json)
+// ---------------------------------------------------------------------------
+
+fn channel_registry_path(home: &Path) -> PathBuf { home.join("channels.json") }
+
+fn load_channel_registry(home: &Path) -> HashMap<u64, String> {
+    std::fs::read_to_string(channel_registry_path(home))
+        .ok()
+        .and_then(|s| serde_json::from_str::<HashMap<String, String>>(&s).ok())
+        .map(|m| m.into_iter().filter_map(|(k, v)| k.parse::<u64>().ok().map(|id| (id, v))).collect())
+        .unwrap_or_default()
+}
+
+fn save_channel_registry(home: &Path, registry: &HashMap<u64, String>) {
+    let map: HashMap<String, &String> = registry.iter().map(|(k, v)| (k.to_string(), v)).collect();
+    if let Ok(json) = serde_json::to_string_pretty(&map) {
+        let _ = std::fs::write(channel_registry_path(home), json);
+    }
+}
+
+fn register_channel(home: &Path, channel_id: u64, instance_name: &str) {
+    let mut reg = load_channel_registry(home);
+    reg.insert(channel_id, instance_name.to_string());
+    save_channel_registry(home, &reg);
+}
+
+fn unregister_channel(home: &Path, channel_id: u64) {
+    let mut reg = load_channel_registry(home);
+    reg.remove(&channel_id);
+    save_channel_registry(home, &reg);
+}
+
+fn discord_runtime() -> &'static tokio::runtime::Runtime {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("discord tokio runtime")
+    })
+}
+
+pub(crate) fn split_message(text: &str, limit: usize) -> Vec<&str> {
+    if text.len() <= limit { return vec![text]; }
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let end = (start + limit).min(text.len());
+        if end == text.len() { chunks.push(&text[start..]); break; }
+        let slice = &text[start..end];
+        let split_at = slice.rfind('\n').map(|i| start + i + 1).unwrap_or(end);
+        chunks.push(&text[start..split_at]);
+        start = split_at;
+    }
+    chunks
+}
+
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+pub fn init_from_config(
+    config: &crate::fleet::FleetConfig,
+    home: &Path,
+    submit_keys: HashMap<String, String>,
+) -> Option<Arc<Mutex<DiscordState>>> {
+    let ChannelConfig::Discord { bot_token_env, guild_id, category_name, user_allowlist, .. } = config.channel.as_ref()? else { return None; };
+    let token = match std::env::var(bot_token_env) {
+        Ok(t) => t,
+        Err(_) => { tracing::info!(env = %bot_token_env, "discord bot token not set, skipping"); return None; }
+    };
+    let guild_id_u64 = match parse_snowflake(guild_id, "guild_id") {
+        Ok(v) => v,
+        Err(e) => { tracing::error!(error = %e, "failed to parse guild_id"); return None; }
+    };
+    let allowlist: Option<Vec<u64>> = user_allowlist.as_ref().map(|list| {
+        list.iter().filter_map(|s| parse_snowflake(s, "user_allowlist").ok()).collect()
+    });
+
+    let http = Arc::new(Http::new(&token));
+    let gid = GuildId::new(guild_id_u64);
+    let cat_name = category_name.clone();
+
+    let (category_id, ch_map, inst_map) = match discord_runtime().block_on(
+        setup_channels(Arc::clone(&http), gid, &cat_name, config, home),
+    ) {
+        Ok(v) => v,
+        Err(e) => { tracing::error!(error = %e, "discord channel setup failed"); return None; }
+    };
+
+    let state = Arc::new(Mutex::new(DiscordState {
+        http: Arc::clone(&http),
+        guild_id: gid,
+        category_id,
+        channel_to_instance: ch_map,
+        instance_to_channel: inst_map,
+        home: home.to_path_buf(),
+        submit_keys,
+        user_allowlist: allowlist,
+        registry: None,
+    }));
+
+    start_gateway(token, Arc::clone(&state));
+    Some(state)
+}
+
+async fn setup_channels(
+    http: Arc<Http>, guild_id: GuildId, category_name: &str,
+    config: &crate::fleet::FleetConfig, home: &Path,
+) -> anyhow::Result<(ChannelId, HashMap<u64, String>, HashMap<String, u64>)> {
+    let channels = guild_id.channels(&http).await?;
+    let category_id = if let Some(cat) = channels.values().find(|c| c.kind == ChannelType::Category && c.name == category_name) {
+        cat.id
+    } else {
+        let cat = guild_id.create_channel(&http, serenity::all::CreateChannel::new(category_name).kind(ChannelType::Category)).await?;
+        cat.id
+    };
+
+    let mut reg = load_channel_registry(home);
+    let instance_names: std::collections::HashSet<&String> = config.instances.keys().collect();
+    let orphans: Vec<(u64, String)> = reg.iter().filter(|(_, name)| !instance_names.contains(name)).map(|(id, name)| (*id, name.clone())).collect();
+    for (cid, _) in &orphans { let _ = ChannelId::new(*cid).delete(&http).await; reg.remove(cid); }
+    if !orphans.is_empty() { save_channel_registry(home, &reg); }
+
+    let mut ch_to_inst = HashMap::new();
+    let mut inst_to_ch = HashMap::new();
+    for name in config.instances.keys() {
+        let existing_cid = config.instances.get(name).and_then(|i| i.channel_id.as_ref()).and_then(|s| s.parse::<u64>().ok());
+        let cid = if let Some(cid) = existing_cid {
+            if channels.contains_key(&ChannelId::new(cid)) { cid } else { create_text_channel(&http, guild_id, category_id, name).await? }
+        } else if name == "general" {
+            if let Some(ch) = channels.values().find(|c| c.kind == ChannelType::Text && c.parent_id == Some(category_id) && c.name == "general") { ch.id.get() }
+            else { create_text_channel(&http, guild_id, category_id, "general").await? }
+        } else {
+            create_text_channel(&http, guild_id, category_id, name).await?
+        };
+        ch_to_inst.insert(cid, name.clone());
+        inst_to_ch.insert(name.clone(), cid);
+        register_channel(home, cid, name);
+        let _ = crate::fleet::update_instance_field(home, name, "channel_id", serde_yaml::Value::String(cid.to_string()));
+    }
+    Ok((category_id, ch_to_inst, inst_to_ch))
+}
+
+async fn create_text_channel(http: &Http, guild_id: GuildId, category_id: ChannelId, name: &str) -> anyhow::Result<u64> {
+    let ch = guild_id.create_channel(http, serenity::all::CreateChannel::new(name).kind(ChannelType::Text).category(category_id)).await?;
+    Ok(ch.id.get())
+}
+
+
+// ---------------------------------------------------------------------------
+// Gateway
+// ---------------------------------------------------------------------------
+
+struct Handler { state: Arc<Mutex<DiscordState>> }
+
+#[serenity::async_trait]
+impl EventHandler for Handler {
+    async fn message(&self, _ctx: Context, msg: Message) {
+        if msg.author.bot { return; }
+        let sender_id = msg.author.id.get();
+        let username = &msg.author.name;
+        let channel_id = msg.channel_id.get();
+
+        { let s = lock_state(&self.state); if !s.is_user_allowed(sender_id) { return; } }
+
+        let text = msg.content.clone();
+        if text.is_empty() && msg.attachments.is_empty() { return; }
+
+        let (instance_name, home, submit_key, registry) = {
+            let mut s = lock_state(&self.state);
+            let name = match resolve_channel_to_instance(&mut s, channel_id) {
+                Some(n) => n,
+                None => return,
+            };
+            let sk = s.submit_keys.get(&name).cloned().unwrap_or_else(|| "\r".to_string());
+            (name, s.home.clone(), sk, s.registry.clone())
+        };
+
+        let mut full_text = text;
+        for att in &msg.attachments {
+            let download_dir = home.join("downloads").join(&instance_name);
+            std::fs::create_dir_all(&download_dir).ok();
+            let dest = download_dir.join(&att.filename);
+            if let Ok(bytes) = att.download().await {
+                let _ = std::fs::write(&dest, &bytes);
+                full_text.push_str(&format!("\n[attachment: {}]", att.filename));
+            }
+        }
+
+        if agent_wants_raw_keystrokes(registry.as_ref(), &instance_name) {
+            let payload = format!("{full_text}\n");
+            let _ = crate::api::call(&home, &serde_json::json!({"method": crate::api::method::INJECT, "params": {"name": instance_name, "data": payload, "raw": true}}));
+            return;
+        }
+
+        let msg_obj = InboxMessage { from: format!("user:{username}"), text: full_text.clone(), kind: Some("discord".to_string()), timestamp: chrono::Utc::now().to_rfc3339() };
+        let _ = inbox::enqueue(&home, &instance_name, msg_obj);
+        inbox::notify_agent(&home, &instance_name, &inbox::NotifySource::Telegram(username), &full_text, &submit_key);
+    }
+
+    async fn channel_delete(&self, _ctx: Context, channel: GuildChannel, _messages: Option<Vec<Message>>) {
+        let cid = channel.id.get();
+        let (instance_name, home) = {
+            let s = lock_state(&self.state);
+            match s.channel_to_instance.get(&cid) { Some(name) => (name.clone(), s.home.clone()), None => return }
+        };
+        cleanup_deleted_channel(&home, &instance_name, cid, Some(&self.state));
+    }
+
+    async fn ready(&self, _ctx: Context, ready: Ready) {
+        tracing::info!(user = %ready.user.name, "discord gateway connected");
+    }
+}
+
+fn resolve_channel_to_instance(state: &mut DiscordState, channel_id: u64) -> Option<String> {
+    if let Some(name) = state.channel_to_instance.get(&channel_id).cloned() { return Some(name); }
+    if let Ok(config) = crate::fleet::FleetConfig::load(&state.home.join("fleet.yaml")) {
+        for (inst_name, inst) in &config.instances {
+            if let Some(ref cid_str) = inst.channel_id {
+                if let Ok(cid) = cid_str.parse::<u64>() {
+                    if cid == channel_id {
+                        state.channel_to_instance.insert(cid, inst_name.clone());
+                        state.instance_to_channel.insert(inst_name.clone(), cid);
+                        return Some(inst_name.clone());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn agent_wants_raw_keystrokes(registry: Option<&AgentRegistry>, instance_name: &str) -> bool {
+    let Some(registry) = registry else { return false };
+    let reg = crate::agent::lock_registry(registry);
+    let Some(handle) = reg.get(instance_name) else { return false };
+    let core = Arc::clone(&handle.core);
+    drop(reg);
+    let guard = crate::sync::lock_poisoned(&core, "agent_core");
+    guard.state.current.wants_raw_keystrokes()
+}
+
+fn cleanup_deleted_channel(home: &Path, instance_name: &str, channel_id: u64, state: Option<&Arc<Mutex<DiscordState>>>) {
+    if let Some(state) = state {
+        let mut s = lock_state(state);
+        s.channel_to_instance.remove(&channel_id);
+        s.instance_to_channel.remove(instance_name);
+        s.submit_keys.remove(instance_name);
+    }
+    let _ = crate::api::call(home, &serde_json::json!({"method": crate::api::method::DELETE, "params": {"name": instance_name}}));
+    if let Err(e) = crate::fleet::remove_instance_from_yaml(home, instance_name) {
+        tracing::warn!(instance = %instance_name, error = %e, "failed to remove from fleet.yaml");
+    }
+    unregister_channel(home, channel_id);
+}
+
+fn start_gateway(token: String, state: Arc<Mutex<DiscordState>>) {
+    let _ = std::thread::Builder::new().name("discord".into()).spawn(move || {
+        let Ok(rt) = tokio::runtime::Builder::new_current_thread().enable_all().build() else { return; };
+        rt.block_on(async {
+            let intents = GatewayIntents::GUILDS | GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT;
+            let handler = Handler { state };
+            let mut client = match serenity::Client::builder(&token, intents).event_handler(handler).await {
+                Ok(c) => c, Err(e) => { tracing::error!(error = %e, "discord client build failed"); return; }
+            };
+            if let Err(e) = client.start().await { tracing::error!(error = %e, "discord gateway error"); }
+        });
+    });
+}
+
+
+// ---------------------------------------------------------------------------
+// Outbound free functions (used by MCP handlers)
+// ---------------------------------------------------------------------------
+
+struct DiscordCreds { token: String, guild_id: u64 }
+
+fn resolve_discord_channel() -> anyhow::Result<(DiscordCreds, crate::fleet::FleetConfig)> {
+    let home = crate::home_dir();
+    let config = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))?;
+    match &config.channel {
+        Some(ChannelConfig::Discord { bot_token_env, guild_id, .. }) => {
+            let token = std::env::var(bot_token_env).map_err(|_| anyhow::anyhow!("discord token env not set"))?;
+            let gid = parse_snowflake(guild_id, "guild_id")?;
+            Ok((DiscordCreds { token, guild_id: gid }, config))
+        }
+        _ => anyhow::bail!("No Discord channel configured"),
+    }
+}
+
+pub fn try_discord_reply(instance_name: &str, text: &str) -> anyhow::Result<(String, String)> {
+    let (ch, config) = resolve_discord_channel()?;
+    let channel_id = config.instances.get(instance_name).and_then(|i| i.channel_id.as_ref()).and_then(|s| s.parse::<u64>().ok())
+        .ok_or_else(|| anyhow::anyhow!("no channel_id for '{instance_name}'"))?;
+    let http = Http::new(&ch.token);
+    let cid = ChannelId::new(channel_id);
+    let chunks = split_message(text, 2000);
+    let mut last_msg_id = String::new();
+    discord_runtime().block_on(async {
+        for chunk in chunks {
+            let msg = cid.send_message(&http, serenity::all::CreateMessage::new().content(chunk)).await?;
+            last_msg_id = msg.id.to_string();
+        }
+        Ok::<(), anyhow::Error>(())
+    })?;
+    Ok((last_msg_id, channel_id.to_string()))
+}
+
+pub fn try_discord_react(instance_name: &str, emoji: &str, message_id: Option<&str>) -> anyhow::Result<()> {
+    let (ch, config) = resolve_discord_channel()?;
+    let channel_id = config.instances.get(instance_name).and_then(|i| i.channel_id.as_ref()).and_then(|s| s.parse::<u64>().ok())
+        .ok_or_else(|| anyhow::anyhow!("no channel_id for '{instance_name}'"))?;
+    let mid: u64 = message_id.and_then(|m| m.parse().ok()).unwrap_or(0);
+    if mid == 0 { anyhow::bail!("no message_id to react to"); }
+    let http = Http::new(&ch.token);
+    discord_runtime().block_on(async {
+        let cid = ChannelId::new(channel_id);
+        let mid = serenity::all::MessageId::new(mid);
+        let reaction = serenity::all::ReactionType::Unicode(emoji.to_string());
+        cid.create_reaction(&http, mid, reaction).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+}
+
+pub fn try_discord_edit(instance_name: &str, message_id: &str, text: &str) -> anyhow::Result<()> {
+    let (ch, config) = resolve_discord_channel()?;
+    let channel_id = config.instances.get(instance_name).and_then(|i| i.channel_id.as_ref()).and_then(|s| s.parse::<u64>().ok())
+        .ok_or_else(|| anyhow::anyhow!("no channel_id for '{instance_name}'"))?;
+    let mid: u64 = parse_snowflake(message_id, "message_id")?;
+    let http = Http::new(&ch.token);
+    discord_runtime().block_on(async {
+        ChannelId::new(channel_id).edit_message(&http, serenity::all::MessageId::new(mid), serenity::all::EditMessage::new().content(text)).await?;
+        Ok::<(), anyhow::Error>(())
+    })
+}
+
+pub fn try_discord_download(instance_name: &str, file_id: &str) -> anyhow::Result<String> {
+    let home = crate::home_dir();
+    let path = home.join("downloads").join(instance_name).join(file_id);
+    if path.exists() { Ok(path.display().to_string()) }
+    else { anyhow::bail!("attachment not found: {}", path.display()) }
+}
+
+pub fn create_channel_for_instance(home: &Path, instance_name: &str) -> Option<String> {
+    let (ch, _) = resolve_discord_channel().ok()?;
+    let http = Http::new(&ch.token);
+    let gid = GuildId::new(ch.guild_id);
+    discord_runtime().block_on(async {
+        let channels = gid.channels(&http).await.ok()?;
+        let category_id = channels.values().find(|c| c.kind == ChannelType::Category && c.name.contains("AgEnD")).map(|c| c.id)?;
+        let cid = create_text_channel(&http, gid, category_id, instance_name).await.ok()?;
+        let cid_str = cid.to_string();
+        let _ = crate::fleet::update_instance_field(home, instance_name, "channel_id", serde_yaml::Value::String(cid_str.clone()));
+        register_channel(home, cid, instance_name);
+        Some(cid_str)
+    })
+}
+
+pub fn delete_channel(home: &Path, channel_id: u64) {
+    let (ch, _) = match resolve_discord_channel() { Ok(c) => c, Err(_) => return };
+    let http = Http::new(&ch.token);
+    let _ = discord_runtime().block_on(async { ChannelId::new(channel_id).delete(&http).await });
+    unregister_channel(home, channel_id);
+}
+
+// ---------------------------------------------------------------------------
+// DiscordChannel — Channel trait wrapper
+// ---------------------------------------------------------------------------
+
+pub struct DiscordChannel {
+    state: Arc<Mutex<DiscordState>>,
+    caps: ChannelCapabilities,
+}
+
+impl DiscordChannel {
+    pub fn new(state: Arc<Mutex<DiscordState>>) -> Self {
+        use crate::channel::{MarkdownDialect, MentionStyle, RateBudget};
+        let caps = ChannelCapabilities {
+            emits_deletion_events: true,
+            threads: false,
+            buttons: false,
+            attachments: true,
+            markdown: MarkdownDialect::None,
+            max_msg_bytes: 2000,
+            rate_budget: RateBudget::default(),
+            react: true,
+            edit: true,
+            typing_indicator: false,
+            receives_edit_events: false,
+            mention_parsing_hint: MentionStyle::None,
+            bot_sees_read_receipts: false,
+            has_native_multi_thread_view: None,
+            ephemeral: false,
+        };
+        Self { state, caps }
+    }
+}
+
+impl crate::channel::Channel for DiscordChannel {
+    fn kind(&self) -> &'static str { "discord" }
+    fn caps(&self) -> &ChannelCapabilities { &self.caps }
+    fn poll_event(&self) -> Option<ChannelEvent> { None }
+
+    fn send(&self, _binding: &BindingRef, _msg: OutMsg) -> anyhow::Result<MsgRef> {
+        anyhow::bail!("DiscordChannel::send not wired yet — use try_discord_reply")
+    }
+    fn edit(&self, _msg: &MsgRef, _payload: OutMsg) -> anyhow::Result<()> {
+        anyhow::bail!("DiscordChannel::edit not wired yet")
+    }
+    fn delete(&self, _msg: &MsgRef) -> anyhow::Result<()> {
+        anyhow::bail!("DiscordChannel::delete not wired yet")
+    }
+
+    fn create_binding(&self, name: &str, _opts: crate::channel::BindingOpts) -> anyhow::Result<BindingRef> {
+        let home = lock_state(&self.state).home.clone();
+        match create_channel_for_instance(&home, name) {
+            Some(cid_str) => {
+                let cid = cid_str.parse::<u64>().map_err(|_| anyhow::anyhow!("invalid channel_id"))?;
+                Ok(DiscordBindingPayload { channel_id: cid }.into_binding())
+            }
+            None => anyhow::bail!("create_channel_for_instance returned None for {name}"),
+        }
+    }
+
+    fn remove_binding(&self, binding: &BindingRef) -> anyhow::Result<()> {
+        let payload = binding.downcast::<DiscordBindingPayload>().ok_or_else(|| anyhow::anyhow!("non-discord binding"))?;
+        let home = lock_state(&self.state).home.clone();
+        delete_channel(&home, payload.channel_id);
+        Ok(())
+    }
+
+    fn has_binding(&self, instance: &str) -> bool {
+        lock_state(&self.state).instance_to_channel.contains_key(instance)
+    }
+
+    fn record_binding(&self, instance: &str, binding: BindingRef, submit_key: String) {
+        let Some(payload) = binding.downcast::<DiscordBindingPayload>() else { return; };
+        let cid = payload.channel_id;
+        let mut s = lock_state(&self.state);
+        s.instance_to_channel.insert(instance.to_string(), cid);
+        s.channel_to_instance.insert(cid, instance.to_string());
+        s.submit_keys.insert(instance.to_string(), submit_key);
+    }
+
+    fn take_binding(&self, instance: &str) -> Option<BindingRef> {
+        let mut s = lock_state(&self.state);
+        let cid = s.instance_to_channel.remove(instance)?;
+        s.channel_to_instance.remove(&cid);
+        s.submit_keys.remove(instance);
+        drop(s);
+        Some(DiscordBindingPayload { channel_id: cid }.into_binding())
+    }
+
+    fn attach_registry(&self, registry: AgentRegistry) {
+        let mut s = lock_state(&self.state);
+        s.registry = Some(registry);
+    }
+}
+
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_message_short() {
+        assert_eq!(split_message("hello", 2000), vec!["hello"]);
+    }
+
+    #[test]
+    fn split_message_exact_limit() {
+        let text = "a".repeat(2000);
+        assert_eq!(split_message(&text, 2000).len(), 1);
+    }
+
+    #[test]
+    fn split_message_over_limit() {
+        let text = format!("{}\n{}", "a".repeat(1500), "b".repeat(1000));
+        let chunks = split_message(&text, 2000);
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks[0].len() <= 2000);
+        assert!(chunks[0].ends_with('\n'));
+    }
+
+    #[test]
+    fn split_message_no_newline() {
+        let text = "a".repeat(3000);
+        let chunks = split_message(&text, 2000);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), 2000);
+        assert_eq!(chunks[1].len(), 1000);
+    }
+
+    #[test]
+    fn parse_snowflake_valid() {
+        assert_eq!(parse_snowflake("123456789012345678", "test").unwrap(), 123456789012345678);
+    }
+
+    #[test]
+    fn parse_snowflake_invalid() {
+        let err = parse_snowflake("not_a_number", "guild_id").unwrap_err();
+        assert!(err.to_string().contains("guild_id"));
+    }
+
+    #[test]
+    fn user_allowlist_none_accepts_all() {
+        let state = DiscordState {
+            http: Arc::new(Http::new("fake")),
+            guild_id: GuildId::new(1),
+            category_id: ChannelId::new(1),
+            channel_to_instance: HashMap::new(),
+            instance_to_channel: HashMap::new(),
+            home: PathBuf::from("/tmp"),
+            submit_keys: HashMap::new(),
+            user_allowlist: None,
+            registry: None,
+        };
+        assert!(state.is_user_allowed(1));
+    }
+
+    #[test]
+    fn user_allowlist_empty_rejects_all() {
+        let state = DiscordState {
+            http: Arc::new(Http::new("fake")),
+            guild_id: GuildId::new(1),
+            category_id: ChannelId::new(1),
+            channel_to_instance: HashMap::new(),
+            instance_to_channel: HashMap::new(),
+            home: PathBuf::from("/tmp"),
+            submit_keys: HashMap::new(),
+            user_allowlist: Some(vec![]),
+            registry: None,
+        };
+        assert!(!state.is_user_allowed(1));
+    }
+
+    #[test]
+    fn user_allowlist_restricts() {
+        let state = DiscordState {
+            http: Arc::new(Http::new("fake")),
+            guild_id: GuildId::new(1),
+            category_id: ChannelId::new(1),
+            channel_to_instance: HashMap::new(),
+            instance_to_channel: HashMap::new(),
+            home: PathBuf::from("/tmp"),
+            submit_keys: HashMap::new(),
+            user_allowlist: Some(vec![42, 100]),
+            registry: None,
+        };
+        assert!(state.is_user_allowed(42));
+        assert!(!state.is_user_allowed(99));
+    }
+
+    #[test]
+    fn binding_payload_roundtrip() {
+        let payload = DiscordBindingPayload { channel_id: 12345 };
+        let binding = payload.into_binding();
+        assert_eq!(binding.kind(), "discord");
+        assert_eq!(binding.display_tag(), Some("DC#12345"));
+        let downcasted = binding.downcast::<DiscordBindingPayload>().unwrap();
+        assert_eq!(downcasted.channel_id, 12345);
+    }
+}

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -37,6 +37,8 @@ pub mod event;
 pub mod sink_registry;
 pub mod telegram;
 pub mod ux_event;
+#[cfg(feature = "discord")]
+pub mod discord;
 
 pub use binding::BindingRef;
 pub use caps::{ChannelCapabilities, MarkdownDialect, MentionStyle, NativeSeeAllHint, RateBudget};

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -300,7 +300,7 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
 
     let text = match msg.text() {
         Some(t) => t,
-        None => return,
+        _ => return,
     };
 
     let sender_id: Option<i64> = msg.from.as_ref().map(|u| u.id.0 as i64);
@@ -623,13 +623,16 @@ pub fn init_from_config(
     home: &Path,
     submit_keys: HashMap<String, String>,
 ) -> Option<Arc<Mutex<TelegramState>>> {
-    let ChannelConfig::Telegram {
+    let Some(ChannelConfig::Telegram {
         bot_token_env,
         group_id,
         user_allowlist,
         fleet_binding,
         ..
-    } = config.channel.as_ref()?;
+    }) = config.channel.as_ref()
+    else {
+        return None;
+    };
     let token = match std::env::var(bot_token_env) {
         Ok(t) => t,
         Err(_) => {
@@ -845,7 +848,7 @@ fn resolve_channel() -> anyhow::Result<(TelegramCreds, crate::fleet::FleetConfig
                 config,
             ))
         }
-        None => anyhow::bail!("No Telegram channel configured"),
+        _ => anyhow::bail!("No Telegram channel configured"),
     }
 }
 
@@ -1138,7 +1141,7 @@ fn notify_telegram_inner(
             ),
             Err(_) => return,
         },
-        None => return,
+        _ => return,
     };
 
     let text = text.to_string();
@@ -1419,7 +1422,7 @@ impl crate::channel::Channel for TelegramChannel {
         let home = lock_state(&self.state).home.clone();
         match create_topic_for_instance(&home, name) {
             Some(tid) => Ok(TelegramBindingPayload { topic_id: tid }.into_binding()),
-            None => anyhow::bail!("create_topic_for_instance returned None for {name}"),
+            _ => anyhow::bail!("create_topic_for_instance returned None for {name}"),
         }
     }
 

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -67,6 +67,21 @@ pub enum ChannelConfig {
         #[serde(default)]
         fleet_binding: Option<FleetBindingConfig>,
     },
+
+    #[cfg(feature = "discord")]
+    #[serde(rename = "discord")]
+    Discord {
+        /// Env var name containing the Discord bot token.
+        bot_token_env: String,
+        /// Discord Guild (server) ID -- string to avoid YAML f64 precision loss.
+        guild_id: String,
+        /// Category name to auto-create/find.
+        #[serde(default = "default_category_name")]
+        category_name: String,
+        /// Optional allowlist of Discord user IDs (snowflake strings).
+        #[serde(default)]
+        user_allowlist: Option<Vec<String>>,
+    },
 }
 
 /// Where fleet activity gets mirrored on a channel. Accepts two YAML
@@ -105,6 +120,11 @@ fn default_mode() -> String {
     "topic".to_string()
 }
 
+#[cfg(feature = "discord")]
+fn default_category_name() -> String {
+    "AgEnD Agents".to_string()
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InstanceDefaults {
     /// Backend preset name (e.g., "claude", "kiro-cli").
@@ -137,6 +157,9 @@ pub struct InstanceConfig {
     pub cols: Option<u16>,
     pub rows: Option<u16>,
     pub topic_id: Option<i32>,
+    /// Discord channel ID -- snowflake as string.
+    #[cfg(feature = "discord")]
+    pub channel_id: Option<String>,
     /// Custom git branch name for worktree. TS version uses "worktree_source".
     #[serde(alias = "worktree_source")]
     pub git_branch: Option<String>,
@@ -322,6 +345,8 @@ impl FleetConfig {
             cols,
             rows,
             topic_id: inst.topic_id,
+            #[cfg(feature = "discord")]
+            channel_id: inst.channel_id.clone(),
             git_branch: inst.git_branch.clone(),
             model,
         })
@@ -347,6 +372,8 @@ pub struct ResolvedInstance {
     pub cols: Option<u16>,
     pub rows: Option<u16>,
     pub topic_id: Option<i32>,
+    #[cfg(feature = "discord")]
+    pub channel_id: Option<String>,
     pub git_branch: Option<String>,
     pub model: Option<String>,
 }
@@ -715,7 +742,7 @@ instances:
                 assert_eq!(group_id, -100123456);
                 assert_eq!(mode, "topic");
             }
-            None => panic!("channel should be Some"),
+            _ => panic!("unexpected channel variant"),
         }
 
         fs::remove_dir_all(&dir).ok();
@@ -750,7 +777,7 @@ instances: {}
                 assert_eq!(bot_token_env, "MY_BOT_TOKEN");
                 assert_eq!(group_id, -100999);
             }
-            None => panic!("plural channels: should populate singular channel field"),
+            _ => panic!("plural channels: should populate singular channel field"),
         }
         // Plural is still preserved on the struct for later consumers.
         assert!(config.channels.is_some());
@@ -795,7 +822,7 @@ instances: {}
                     "must pick first entry by sorted name"
                 );
             }
-            None => panic!("channel should be populated"),
+            _ => panic!("channel should be populated"),
         }
         fs::remove_dir_all(&dir).ok();
     }
@@ -827,7 +854,7 @@ instances: {}
             Some(ChannelConfig::Telegram {
                 ref bot_token_env, ..
             }) => assert_eq!(bot_token_env, "SINGULAR_TOKEN"),
-            None => panic!("singular channel field must be preserved"),
+            _ => panic!("singular channel field must be preserved"),
         }
         fs::remove_dir_all(&dir).ok();
     }
@@ -869,7 +896,7 @@ instances: {}
             Some(ChannelConfig::Telegram { ref mode, .. }) => {
                 assert_eq!(mode, "topic", "default mode should be 'topic'");
             }
-            None => panic!("channel should be Some"),
+            _ => panic!("unexpected channel variant"),
         }
 
         fs::remove_dir_all(&dir).ok();

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -31,6 +31,18 @@ fn err_needs_identity(tool: &str) -> Value {
     })
 }
 
+#[allow(dead_code)]
+fn is_discord(home: &std::path::Path) -> bool {
+    #[cfg(feature = "discord")]
+    {
+        if let Ok(config) = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")) {
+            return matches!(config.channel, Some(crate::fleet::ChannelConfig::Discord { .. }));
+        }
+    }
+    let _ = home;
+    false
+}
+
 pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
     let home = crate::home_dir();
     // Explicit arg beats env var. Cross-instance arms require `Some`;
@@ -55,6 +67,13 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             tracing::info!(from = %instance_name, %text, "reply");
             let fleet_path = home.join("fleet.yaml");
             if fleet_path.exists() {
+                #[cfg(feature = "discord")]
+                if is_discord(&home) {
+                    return match crate::channel::discord::try_discord_reply(instance_name, text) {
+                        Ok((msg_id, ch_id)) => json!({"message_id": msg_id, "chat_id": ch_id}),
+                        Err(e) => json!({"error": format!("{e}")}),
+                    };
+                }
                 match telegram::try_telegram_reply(instance_name, text) {
                     Ok((msg_id, chat_id)) => json!({
                         "message_id": msg_id.to_string(),
@@ -69,6 +88,13 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         "react" => {
             let emoji = args["emoji"].as_str().unwrap_or("");
             let message_id = args["message_id"].as_str();
+            #[cfg(feature = "discord")]
+            if is_discord(&home) {
+                return match crate::channel::discord::try_discord_react(instance_name, emoji, message_id) {
+                    Ok(()) => json!({"emoji": emoji}),
+                    Err(e) => json!({"error": format!("{e}")}),
+                };
+            }
             match telegram::try_telegram_react(instance_name, emoji, message_id) {
                 Ok(()) => json!({"emoji": emoji}),
                 Err(e) => json!({"error": format!("{e}")}),
@@ -83,6 +109,13 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 Some(t) => t,
                 None => return json!({"error": "missing 'text'"}),
             };
+            #[cfg(feature = "discord")]
+            if is_discord(&home) {
+                return match crate::channel::discord::try_discord_edit(instance_name, message_id, text) {
+                    Ok(()) => json!({"message_id": message_id}),
+                    Err(e) => json!({"error": format!("{e}")}),
+                };
+            }
             match telegram::try_telegram_edit(instance_name, message_id, text) {
                 Ok(()) => json!({"message_id": message_id}),
                 Err(e) => json!({"error": format!("{e}")}),
@@ -93,6 +126,13 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 Some(f) => f,
                 None => return json!({"error": "missing 'file_id'"}),
             };
+            #[cfg(feature = "discord")]
+            if is_discord(&home) {
+                return match crate::channel::discord::try_discord_download(instance_name, file_id) {
+                    Ok(path) => json!({"path": path}),
+                    Err(e) => json!({"error": format!("{e}")}),
+                };
+            }
             match telegram::try_download_attachment(instance_name, file_id) {
                 Ok(path) => json!({"path": path}),
                 Err(e) => json!({"error": format!("{e}")}),


### PR DESCRIPTION
## Discord Adapter

Add Discord as a channel adapter (behind `--features discord` feature flag).

### Changes
- Add Discord adapter with inbound/outbound message handling
- Discord dispatch in mcp/handlers
- notify_discord with 2000 char message splitting
- Attachment download returns local path
- Ignore non-AgEnD channels
- Windows installation docs in README

### Dependency
None - this is the base feature. Merge first.

### Blocked PRs
- quickstart-discord (will PR after this merges)
- feat/task-status-reactions (will PR after all others merge)