### PR TITLE
Stage B-UX PR-B — Telegram fleet renderer + dispatch split

### DIFF
--- a/src/bootstrap/telegram_init.rs
+++ b/src/bootstrap/telegram_init.rs
@@ -2,7 +2,9 @@
 //! submit-keys collection step that `cli::start_with_fleet` and `app::run`
 //! each duplicated.
 
+use crate::channel::sink_registry::registry as ux_sink_registry;
 use crate::channel::telegram::TelegramChannel;
+use crate::channel::ux_event::UxEventSink;
 use crate::channel::Channel;
 use crate::fleet::FleetConfig;
 use std::collections::HashMap;
@@ -12,6 +14,11 @@ use std::sync::Arc;
 /// Initialize Telegram polling when `channel:` is configured and the bot
 /// token env var is set. Returns `None` otherwise (including when the channel
 /// block is missing — not an error).
+///
+/// When the channel comes up, this also registers it as a
+/// [`UxEventSink`] on the process-wide `ux_sink_registry` so Stage B-UX
+/// `FleetEvent`s (emitted by MCP handlers) get rendered into the
+/// configured `fleet_binding` topic. See `docs/DESIGN-stage-b-ux.md` §4.1.
 pub(super) fn init(config: &FleetConfig, home: &Path) -> Option<Arc<dyn Channel>> {
     let submit_keys: HashMap<String, String> = config
         .instances
@@ -24,7 +31,12 @@ pub(super) fn init(config: &FleetConfig, home: &Path) -> Option<Arc<dyn Channel>
         .collect();
     let state = crate::channel::telegram::init_from_config(config, home, submit_keys)?;
     // `init_from_config` already calls `start_polling` on the concrete
-    // state. Wrap in the trait object so downstream code holds only
-    // `Arc<dyn Channel>`.
-    Some(Arc::new(TelegramChannel::new(state)) as Arc<dyn Channel>)
+    // state. Construct `Arc<TelegramChannel>` once and clone-upcast to
+    // BOTH `Arc<dyn Channel>` (returned to the caller, used by dispatch)
+    // AND `Arc<dyn UxEventSink>` (registered for Fleet-event fan-out).
+    // `Arc<dyn Channel>` cannot itself be cast to `Arc<dyn UxEventSink>`
+    // without nightly `trait_upcasting`; the concrete `Arc` is the bridge.
+    let channel_concrete: Arc<TelegramChannel> = Arc::new(TelegramChannel::new(state));
+    ux_sink_registry().register(channel_concrete.clone() as Arc<dyn UxEventSink>);
+    Some(channel_concrete as Arc<dyn Channel>)
 }

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -437,6 +437,51 @@ pub(crate) fn cleanup_deleted_topic(
     unregister_topic(home, tid);
 }
 
+/// Cleanup path for a deleted `fleet_binding` topic. Unlike
+/// [`cleanup_deleted_topic`] — which is instance-oriented and tears down
+/// fleet.yaml / api::DELETE / per-instance state maps — the fleet binding
+/// has no instance to drop, just a sentinel registry row and the
+/// `fleet_binding_topic_id` field.
+///
+/// Only clears `fleet_binding_topic_id` when it still points at `tid`
+/// (defensive — avoids clobbering a fresh binding if a stale error
+/// somehow arrives after re-resolution).
+pub(crate) fn cleanup_fleet_binding(home: &Path, state: &Arc<Mutex<TelegramState>>, tid: i32) {
+    unregister_topic(home, tid);
+    let mut s = lock_state(state);
+    if s.fleet_binding_topic_id == Some(tid) {
+        s.fleet_binding_topic_id = None;
+    }
+}
+
+/// Classify a fleet-binding send error and run [`cleanup_fleet_binding`]
+/// if it matches a topic-deleted error. Returns `true` when the error
+/// was handled (topic gone); the renderer uses that to silence the outer
+/// "send failed" warn since self-heal is the expected outcome, not a
+/// surprise.
+///
+/// Reviewer context (at-dev-4 on PR #56): without this, deleting the
+/// fleet topic once would (a) silently drop every subsequent fleet
+/// emission, and (b) persist the stale `__fleet__` row in `topics.json`
+/// so the next daemon restart happily reused the dead thread id.
+/// Regression pin: [`tests::fleet_binding_self_heals_when_topic_deleted`].
+pub(crate) fn handle_fleet_send_failure(
+    err: &anyhow::Error,
+    home: &Path,
+    state: &Arc<Mutex<TelegramState>>,
+    tid: i32,
+) -> bool {
+    if !is_topic_deleted_error(err) {
+        return false;
+    }
+    tracing::info!(
+        topic_id = tid,
+        "fleet send hit topic_deleted — clearing binding + unregistering sentinel"
+    );
+    cleanup_fleet_binding(home, state, tid);
+    true
+}
+
 /// Classify a send error and run topic-delete cleanup if it matches.
 /// Returns `true` when the error was handled (topic gone); callers may then
 /// silence the outer "send failed" log since cleanup is the expected outcome.
@@ -1148,27 +1193,40 @@ impl TelegramChannel {
     /// `fleet_binding` topic. No-op when no binding was resolved at
     /// bootstrap; errors never propagate (logged-only, matching the
     /// `UxEventSink` contract).
+    ///
+    /// On a topic-deleted error the renderer self-heals by routing
+    /// through [`handle_fleet_send_failure`]: the stale
+    /// [`FLEET_BINDING_SENTINEL`] row is stripped from `topics.json` and
+    /// `fleet_binding_topic_id` is cleared to `None`, so subsequent
+    /// emits early-return cleanly and the next bootstrap re-resolves
+    /// (i.e. creates a fresh topic) instead of reusing a dead thread id.
     pub(crate) fn apply_fleet_action(&self, fe: &crate::channel::ux_event::FleetEvent) {
         let Some((chat_id, topic_id)) = self.fleet_send_target() else {
             tracing::debug!(?fe, "fleet renderer: no fleet_binding configured (drop)");
             return;
         };
-        let bot = match lock_state(&self.state).bot.clone() {
-            Some(b) => b,
-            None => {
-                tracing::debug!(?fe, "fleet renderer: no bot (contract-test state, drop)");
-                return;
+        let (bot, home) = {
+            let s = lock_state(&self.state);
+            match s.bot.clone() {
+                Some(b) => (b, s.home.clone()),
+                None => {
+                    tracing::debug!(?fe, "fleet renderer: no bot (contract-test state, drop)");
+                    return;
+                }
             }
         };
         let text = crate::channel::ux_event::format_fleet_oneliner(fe, self.caps.max_msg_bytes);
         if let Err(e) = telegram_runtime()
             .block_on(async { send_with_topic(&bot, chat_id, Some(topic_id), &text).await })
         {
-            tracing::warn!(
-                %e,
-                topic_id,
-                "fleet renderer: send failed"
-            );
+            let handled = handle_fleet_send_failure(&e, &home, &self.state, topic_id);
+            if !handled {
+                tracing::warn!(
+                    %e,
+                    topic_id,
+                    "fleet renderer: send failed"
+                );
+            }
         }
     }
 }
@@ -1638,6 +1696,134 @@ mod tests {
             task_id: None,
         });
         (&channel as &dyn UxEventSink).emit(&fleet_ev);
+    }
+
+    /// Reviewer Contract v0.1 §4 value-source pin — **self-heal**.
+    ///
+    /// Reviewer at-dev-4 on PR #56 flagged: deleting the fleet topic in
+    /// Telegram once left us in a permanently broken state:
+    /// 1. `apply_fleet_action` only logged send failures — no cleanup,
+    ///    so subsequent emissions kept sending against the dead tid.
+    /// 2. `topics.json` still carried the `__fleet__` sentinel row → the
+    ///    next daemon restart happily reused the same dead thread id.
+    ///
+    /// This test seeds the *exact* broken state (stale sentinel row + a
+    /// `fleet_binding_topic_id` pointing at it), fires a topic-deleted
+    /// error through [`handle_fleet_send_failure`], and pins both sides
+    /// of the self-heal:
+    /// - `fleet_binding_topic_id` is cleared to `None` (no more send
+    ///   attempts against the dead tid).
+    /// - The sentinel row is stripped from `topics.json` (next boot's
+    ///   `resolve_fleet_binding` sees no sentinel and re-creates).
+    ///
+    /// Before the fix this test's `fleet_binding_topic_id` assertion
+    /// would fail — the renderer never touched the field. Running the
+    /// test at this commit should pass; reverting
+    /// [`handle_fleet_send_failure`] should reproduce the bug.
+    #[test]
+    fn fleet_binding_self_heals_when_topic_deleted() {
+        let home = tmp_home("fleet-self-heal");
+        // Pre-seed: topics.json has a stale `__fleet__` row pointing at a
+        // tid we assume was just deleted on the TG side.
+        let mut reg = HashMap::new();
+        reg.insert(42, FLEET_BINDING_SENTINEL.to_string());
+        // An unrelated instance row in the same file — self-heal must NOT
+        // touch unrelated rows.
+        reg.insert(100, "at-dev-1".to_string());
+        save_topic_registry(&home, &reg);
+
+        // State mirrors the "post-bootstrap, pre-first-send" shape: the
+        // binding was resolved from the sentinel row and cached in state.
+        let state = Arc::new(Mutex::new(TelegramState::new(
+            "tok",
+            -12345,
+            HashMap::new(),
+            home.clone(),
+            HashMap::new(),
+            None,
+        )));
+        {
+            let mut s = lock_state(&state);
+            s.fleet_binding_topic_id = Some(42);
+        }
+
+        // Simulate the topic-deleted error teloxide returns after the
+        // user removes the fleet topic. This is the same marker string
+        // the other handlers key off — mirror of the existing
+        // `is_topic_deleted_error_matches_thread_not_found` pin.
+        let err = anyhow::anyhow!("Bad Request: message thread not found");
+        let handled = handle_fleet_send_failure(&err, &home, &state, 42);
+
+        assert!(
+            handled,
+            "topic-deleted classifier must match so renderer skips outer warn"
+        );
+
+        // Value-source pin: the cleared field MUST be
+        // `fleet_binding_topic_id` specifically — not `instance_to_topic`
+        // (which cleanup_deleted_topic drains for instances) and not the
+        // `topic_to_instance` reverse map. Pin ensures future refactors
+        // that repurpose the helper can't silently redirect the cleanup.
+        let post = lock_state(&state);
+        assert_eq!(
+            post.fleet_binding_topic_id, None,
+            "fleet_binding_topic_id must be cleared after topic-deleted"
+        );
+
+        let reg_after = load_topic_registry(&home);
+        assert!(
+            !reg_after.values().any(|v| v == FLEET_BINDING_SENTINEL),
+            "sentinel row must be unregistered so next boot re-resolves; reg={reg_after:?}"
+        );
+        // Unrelated instance row survives — cleanup is fleet-scoped.
+        assert_eq!(
+            reg_after.get(&100),
+            Some(&"at-dev-1".to_string()),
+            "unrelated instance rows must survive fleet self-heal"
+        );
+    }
+
+    /// Negative pin: non-topic-deleted errors (network, auth, rate-limit)
+    /// must NOT clear the binding. A transient failure is not grounds to
+    /// tear down the registry state.
+    #[test]
+    fn fleet_binding_self_heal_ignores_unrelated_errors() {
+        let home = tmp_home("fleet-self-heal-neg");
+        let mut reg = HashMap::new();
+        reg.insert(42, FLEET_BINDING_SENTINEL.to_string());
+        save_topic_registry(&home, &reg);
+
+        let state = Arc::new(Mutex::new(TelegramState::new(
+            "tok",
+            -1,
+            HashMap::new(),
+            home.clone(),
+            HashMap::new(),
+            None,
+        )));
+        {
+            let mut s = lock_state(&state);
+            s.fleet_binding_topic_id = Some(42);
+        }
+
+        for msg in [
+            "network timeout",
+            "Too Many Requests: retry after 5",
+            "Forbidden: bot was blocked by the user",
+        ] {
+            let err = anyhow::anyhow!(msg.to_string());
+            assert!(
+                !handle_fleet_send_failure(&err, &home, &state, 42),
+                "classifier must not match unrelated error: {msg}"
+            );
+        }
+        // State untouched after the negative sweep.
+        assert_eq!(lock_state(&state).fleet_binding_topic_id, Some(42));
+        let reg_after = load_topic_registry(&home);
+        assert_eq!(
+            reg_after.get(&42),
+            Some(&FLEET_BINDING_SENTINEL.to_string())
+        );
     }
 
     /// Guards the UX-layer cap values shipped with the Telegram adapter.

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -30,6 +30,14 @@ pub(crate) fn lock_state(
 // so we can detect orphaned topics on daemon restart.
 // ---------------------------------------------------------------------------
 
+/// Reserved pseudo-instance name used in `topics.json` to pin the
+/// `fleet_binding` topic across daemon restarts. Not a real instance —
+/// chosen so it can never collide with a user-configured name
+/// (`fleet.yaml` keys are slugs; underscores-bracketing is reserved).
+/// See [`init_from_config`] orphan-cleanup filter and fleet-binding
+/// resolution.
+const FLEET_BINDING_SENTINEL: &str = "__fleet__";
+
 fn topic_registry_path(home: &Path) -> PathBuf {
     home.join("topics.json")
 }
@@ -98,6 +106,13 @@ pub struct TelegramState {
     /// Wired in post-bootstrap by [`attach_registry`]; lets inbound message
     /// routing read `agent_state` directly instead of via the `LIST` RPC.
     pub registry: Option<AgentRegistry>,
+    /// Resolved `fleet_binding` target for cross-instance fleet activity
+    /// rendering (Stage B-UX, `docs/DESIGN-stage-b-ux.md` §3/§5). `None`
+    /// means no mirror is configured — [`TelegramChannel::apply_fleet_action`]
+    /// returns early. Resolution happens in [`init_from_config`] from the
+    /// config's `fleet_binding` block plus the on-disk topic registry
+    /// sentinel `"__fleet__"`.
+    pub fleet_binding_topic_id: Option<i32>,
 }
 
 impl TelegramState {
@@ -122,6 +137,7 @@ impl TelegramState {
             submit_keys,
             user_allowlist,
             registry: None,
+            fleet_binding_topic_id: None,
         }
     }
 
@@ -154,6 +170,7 @@ impl TelegramState {
             submit_keys,
             user_allowlist,
             registry: None,
+            fleet_binding_topic_id: None,
         }
     }
 
@@ -511,6 +528,7 @@ pub fn init_from_config(
         bot_token_env,
         group_id,
         user_allowlist,
+        fleet_binding,
         ..
     } = config.channel.as_ref()?;
     let token = match std::env::var(bot_token_env) {
@@ -539,7 +557,9 @@ pub fn init_from_config(
     let instance_names: std::collections::HashSet<&String> = config.instances.keys().collect();
     let mut orphan_count = 0;
     for (tid, inst_name) in reg.clone() {
-        if tid != 1 && !instance_names.contains(&inst_name) {
+        // `FLEET_BINDING_SENTINEL` marks the `fleet_binding` topic so it
+        // survives orphan cleanup — it's not an instance name.
+        if tid != 1 && inst_name != FLEET_BINDING_SENTINEL && !instance_names.contains(&inst_name) {
             tracing::info!(topic_id = tid, instance = %inst_name, "orphaned topic, deleting");
             delete_topic(home, tid); // also removes from registry
             orphan_count += 1;
@@ -593,16 +613,87 @@ pub fn init_from_config(
         tracing::info!("updated fleet.yaml with topic_ids");
     }
 
-    let state = Arc::new(Mutex::new(TelegramState::new(
+    // Resolve `fleet_binding` → topic_id. See docs/DESIGN-stage-b-ux.md §3/§5.
+    // Persistence uses the `FLEET_BINDING_SENTINEL` row in `topics.json` so
+    // the same topic is reused across daemon restarts without touching
+    // fleet.yaml schema. Shorthand is warned + ignored (TG has no
+    // channel-tag primitive — only thread_id routing).
+    let fleet_binding_topic_id =
+        resolve_fleet_binding(&bot, chat_id, home, &mut reg, fleet_binding);
+
+    let mut raw_state = TelegramState::new(
         &token,
         *group_id,
         topic_map,
         home.to_path_buf(),
         submit_keys,
         allowlist,
-    )));
+    );
+    raw_state.fleet_binding_topic_id = fleet_binding_topic_id;
+    let state = Arc::new(Mutex::new(raw_state));
     start_polling(Arc::clone(&state));
     Some(state)
+}
+
+/// Resolve the `fleet_binding` block from `ChannelConfig::Telegram` to a
+/// concrete Telegram forum topic id. Returns `None` for "no mirror":
+///
+/// - Field absent in config → `None`.
+/// - `Shorthand("#name")` → warn + `None` (Telegram has no channel-tag
+///   primitive; topics route by `message_thread_id`, not by tag).
+/// - `Struct(Topic { name })` → look up existing tid in the topic
+///   registry under [`FLEET_BINDING_SENTINEL`]; create a new forum topic
+///   via `createForumTopic` if absent and persist the sentinel row.
+///
+/// Mutates `reg` (registry snapshot) + writes it back on create so the
+/// caller can pass a fresh `reg` clone into subsequent logic.
+fn resolve_fleet_binding(
+    bot: &teloxide::Bot,
+    chat_id: teloxide::types::ChatId,
+    home: &Path,
+    reg: &mut HashMap<i32, String>,
+    fleet_binding: &Option<crate::fleet::FleetBindingConfig>,
+) -> Option<i32> {
+    let name = match fleet_binding.as_ref()? {
+        crate::fleet::FleetBindingConfig::Struct(crate::fleet::FleetBindingStruct::Topic {
+            name,
+        }) => name.clone(),
+        crate::fleet::FleetBindingConfig::Shorthand(raw) => {
+            tracing::warn!(
+                shorthand = %raw,
+                "telegram channel.fleet_binding shorthand ignored — Telegram requires \
+                 `{{type: topic, name: ...}}` (shorthand is Discord/Slack only). \
+                 Fleet events will not be mirrored on this channel."
+            );
+            return None;
+        }
+    };
+
+    // Fast path: previously-resolved topic still present in registry.
+    for (tid, inst) in reg.iter() {
+        if inst == FLEET_BINDING_SENTINEL {
+            tracing::info!(topic_id = *tid, %name, "reusing existing fleet_binding topic");
+            return Some(*tid);
+        }
+    }
+
+    // Slow path: create the forum topic once and pin it into the registry.
+    tracing::info!(%name, "creating fleet_binding topic");
+    match telegram_runtime()
+        .block_on(async { bot.create_forum_topic(chat_id, &name, 0x6FB9F0, "").await })
+    {
+        Ok(topic) => {
+            let tid = topic.thread_id.0 .0;
+            tracing::info!(topic_id = tid, %name, "created fleet_binding topic");
+            reg.insert(tid, FLEET_BINDING_SENTINEL.to_string());
+            save_topic_registry(home, reg);
+            Some(tid)
+        }
+        Err(e) => {
+            tracing::error!(error = %e, %name, "failed to create fleet_binding topic");
+            None
+        }
+    }
 }
 
 /// Map emoji name to Unicode character.
@@ -1039,6 +1130,47 @@ impl TelegramChannel {
     ) -> Self {
         Self { state, caps }
     }
+
+    /// Lookup the fleet-binding send target under one lock. Returns
+    /// `(group_chat_id, fleet_topic_id)` iff the channel was booted with
+    /// a resolved `fleet_binding` (see [`init_from_config`]'s
+    /// [`resolve_fleet_binding`] call). Extracted so the
+    /// [`apply_fleet_action`](Self::apply_fleet_action) renderer can be
+    /// unit-tested without reaching the teloxide send path, and so tests
+    /// can pin *which* field feeds the topic id (regression contract v0.1
+    /// §4 — value-source pin).
+    pub(crate) fn fleet_send_target(&self) -> Option<(ChatId, i32)> {
+        let s = lock_state(&self.state);
+        s.fleet_binding_topic_id.map(|tid| (s.group_id, tid))
+    }
+
+    /// Render a cross-instance fleet event into the configured
+    /// `fleet_binding` topic. No-op when no binding was resolved at
+    /// bootstrap; errors never propagate (logged-only, matching the
+    /// `UxEventSink` contract).
+    pub(crate) fn apply_fleet_action(&self, fe: &crate::channel::ux_event::FleetEvent) {
+        let Some((chat_id, topic_id)) = self.fleet_send_target() else {
+            tracing::debug!(?fe, "fleet renderer: no fleet_binding configured (drop)");
+            return;
+        };
+        let bot = match lock_state(&self.state).bot.clone() {
+            Some(b) => b,
+            None => {
+                tracing::debug!(?fe, "fleet renderer: no bot (contract-test state, drop)");
+                return;
+            }
+        };
+        let text = crate::channel::ux_event::format_fleet_oneliner(fe, self.caps.max_msg_bytes);
+        if let Err(e) = telegram_runtime()
+            .block_on(async { send_with_topic(&bot, chat_id, Some(topic_id), &text).await })
+        {
+            tracing::warn!(
+                %e,
+                topic_id,
+                "fleet renderer: send failed"
+            );
+        }
+    }
 }
 
 impl crate::channel::Channel for TelegramChannel {
@@ -1157,7 +1289,17 @@ impl crate::channel::Channel for TelegramChannel {
 // rationale (reviewer: at-dev-4 flagged this shape up-front).
 impl crate::channel::ux_event::UxEventSink for TelegramChannel {
     fn emit(&self, event: &crate::channel::ux_event::UxEvent) {
-        use crate::channel::ux_event::{select_action, UxAction};
+        use crate::channel::ux_event::{select_action, UxAction, UxEvent};
+        // Dispatch split per docs/DESIGN-stage-b-ux.md §4.4: Fleet events
+        // never flow through the Q1 `select_action` cap-degradation ladder —
+        // their target is the configured `fleet_binding`, not the origin
+        // user's thread, and rendering is a plain one-liner with no
+        // react/edit degradation. Q1 events (UserMsgReceived /
+        // AgentPickedUp / AgentReplied) keep the existing ladder path.
+        if let UxEvent::Fleet(fe) = event {
+            self.apply_fleet_action(fe);
+            return;
+        }
         let action = select_action(event, &self.caps);
         // All transport errors are logged, not propagated — a failed
         // reaction is never a reason to crash the daemon.
@@ -1388,6 +1530,114 @@ mod tests {
         };
         // Must not panic. Noop branch only logs via tracing::debug.
         (&channel as &dyn UxEventSink).emit(&ev);
+    }
+
+    // ─── Stage B-UX fleet renderer pins ────────────────────────────────
+    //
+    // These tests cover the wiring between `TelegramState.fleet_binding_topic_id`
+    // (set at bootstrap by `init_from_config::resolve_fleet_binding`) and
+    // `TelegramChannel::apply_fleet_action` (invoked via the UxEventSink
+    // dispatch split from docs/DESIGN-stage-b-ux.md §4.4).
+
+    /// Value-source pin per Reviewer Contract v0.1 §4.
+    ///
+    /// `fleet_send_target()` MUST read the topic id from the dedicated
+    /// `fleet_binding_topic_id` field — NOT from `instance_to_topic`
+    /// (which would make fleet events land in `general`'s topic or a
+    /// random instance topic) and NOT from some implicit default.
+    ///
+    /// This test constructs state where `instance_to_topic` holds an
+    /// entry (topic 1 = "general") *and* `fleet_binding_topic_id` holds
+    /// 42, then asserts the target is 42 — so a future refactor that
+    /// regresses to "whichever topic id the code saw first" trips here
+    /// instead of silently mis-routing every fleet event into the
+    /// `general` thread.
+    #[test]
+    fn fleet_send_target_reads_fleet_binding_topic_id_not_general() {
+        let mut topic_map = HashMap::new();
+        topic_map.insert("general".to_string(), 1);
+        topic_map.insert("at-dev-1".to_string(), 100);
+        let mut state = TelegramState::new(
+            "tok",
+            -12345,
+            topic_map,
+            PathBuf::from("/tmp"),
+            HashMap::new(),
+            None,
+        );
+        state.fleet_binding_topic_id = Some(42);
+        let channel = TelegramChannel::new(Arc::new(Mutex::new(state)));
+
+        let (chat_id, topic_id) = channel
+            .fleet_send_target()
+            .expect("fleet_binding_topic_id=Some → Some(target)");
+        assert_eq!(
+            topic_id, 42,
+            "value must come from `fleet_binding_topic_id`, NOT `instance_to_topic[\"general\"]` (=1) or any instance topic"
+        );
+        assert_ne!(topic_id, 1, "regression: general topic leak");
+        assert_ne!(topic_id, 100, "regression: first-instance leak");
+        assert_eq!(chat_id, ChatId(-12345), "chat id must thread through");
+    }
+
+    /// Inverse pin: no fleet_binding configured → no target → renderer
+    /// early-returns and never hits the send path. Protects the
+    /// "absent block = no fleet sink" contract from PLAN §7.
+    #[test]
+    fn fleet_send_target_is_none_when_binding_unresolved() {
+        let state = TelegramState::new(
+            "tok",
+            -1,
+            HashMap::new(),
+            PathBuf::from("/tmp"),
+            HashMap::new(),
+            None,
+        );
+        // Default: fleet_binding_topic_id = None.
+        let channel = TelegramChannel::new(Arc::new(Mutex::new(state)));
+        assert!(
+            channel.fleet_send_target().is_none(),
+            "no fleet_binding → no target"
+        );
+    }
+
+    /// Dispatch-split pin per DESIGN §4.4: Fleet events take the fleet
+    /// renderer path, NOT `select_action`. Concretely:
+    ///
+    /// - Fleet variants with `fleet_binding_topic_id=None` → silent drop
+    ///   (apply_fleet_action early-returns; no panic, no Bot API call)
+    /// - Q1 variants with `caps.react=caps.edit=false` → `Noop` via the
+    ///   `select_action` ladder
+    ///
+    /// If a refactor regresses to routing Fleet through `select_action`,
+    /// Fleet events would silently be `Noop`'d inside select_action and
+    /// the renderer would never run — so this test also exercises the
+    /// "no panic" side-channel (contract-test state has `bot=None`, so
+    /// any accidental send would panic via `.expect`).
+    #[test]
+    fn emit_fleet_event_does_not_panic_without_binding_or_bot() {
+        use crate::channel::{
+            ux_event::{FleetEvent, UxEvent, UxEventSink},
+            ChannelCapabilities,
+        };
+        // Contract-test state: bot=None. If dispatch went through a path
+        // that calls `bot.as_ref().expect(..)`, this test would panic.
+        let state = TelegramState::new_for_contract_test(
+            -1,
+            HashMap::new(),
+            PathBuf::from("/tmp"),
+            HashMap::new(),
+            None,
+        );
+        let channel =
+            TelegramChannel::with_caps(Arc::new(Mutex::new(state)), ChannelCapabilities::default());
+        let fleet_ev = UxEvent::Fleet(FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: "s".into(),
+            task_id: None,
+        });
+        (&channel as &dyn UxEventSink).emit(&fleet_ev);
     }
 
     /// Guards the UX-layer cap values shipped with the Telegram adapter.

--- a/src/channel/ux_event.rs
+++ b/src/channel/ux_event.rs
@@ -170,6 +170,148 @@ pub enum UxAction {
     Noop,
 }
 
+/// Render a [`FleetEvent`] into the one-liner log shape defined in
+/// `docs/DESIGN-stage-b-ux.md` §5.1 (which in turn mirrors the `S2c`
+/// exemplars in `docs/PLAN-channel-ux-layer.md` §6). Pure fn — no I/O,
+/// no time, snapshot-testable.
+///
+/// Format shape by variant:
+///
+/// ```text
+/// [from → to]         DELEGATE   <summary> (#<task_id>)
+/// [from → to]         REPORT     <summary> (#<task_id>)
+/// [by solo]           DECISION   <title> (D-<decision_id>)
+/// [from → *N]         BROADCAST  <summary>            // N recipients, compact
+/// [from → a,b,c]      BROADCAST  <summary>            // ≤3 recipients, named
+/// [from → a,b,…+N]    BROADCAST  <summary>            // >3 recipients, elided
+/// ```
+///
+/// - The prefix (everything up to and including the trailing double space
+///   before `<summary>`) is reserved for the bracket tag and verb column.
+///   Summary is truncated to `max_bytes - prefix_len` and an ellipsis
+///   `…` is appended; `max_bytes = 0` is treated as "no cap" because
+///   Telegram's actual cap (4096 bytes) is always plenty for a one-liner
+///   and the 0-case is easier for callers than `Option<usize>`.
+/// - `task_id` / `decision_id` suffixes are appended *after* truncation so
+///   provenance ids never get eaten by the summary cap; in practice the
+///   combined length is always far below `max_bytes`.
+pub fn format_fleet_oneliner(fe: &FleetEvent, max_bytes: usize) -> String {
+    // Render the `[from → to]` / `[by solo]` / `[from → recipients]`
+    // bracket tag. Kept inline (not a separate fn) because the verb +
+    // ID-suffix shape differs per variant and splitting would just push
+    // noise back up.
+    let (tag, verb, body, suffix) = match fe {
+        FleetEvent::DelegateTask {
+            from,
+            to,
+            summary,
+            task_id,
+        } => (
+            format!("[{from} → {to}]"),
+            "DELEGATE",
+            summary.clone(),
+            task_id
+                .as_deref()
+                .map(|id| format!(" (#{id})"))
+                .unwrap_or_default(),
+        ),
+        FleetEvent::ReportResult {
+            from,
+            to,
+            summary,
+            task_id,
+        } => (
+            format!("[{from} → {to}]"),
+            "REPORT",
+            summary.clone(),
+            task_id
+                .as_deref()
+                .map(|id| format!(" (#{id})"))
+                .unwrap_or_default(),
+        ),
+        FleetEvent::PostDecision {
+            by,
+            title,
+            decision_id,
+        } => (
+            format!("[{by} solo]"),
+            "DECISION",
+            title.clone(),
+            format!(" (D-{decision_id})"),
+        ),
+        FleetEvent::Broadcast {
+            from,
+            recipients,
+            summary,
+        } => {
+            let tag = format_broadcast_tag(from, recipients);
+            (tag, "BROADCAST", summary.clone(), String::new())
+        }
+    };
+
+    // `tag  VERB  <summary>`: verb column is separated by two spaces on
+    // each side to keep the §5.1 exemplars diff-visible.
+    let prefix = format!("{tag}  {verb}  ");
+    let prefix_len = prefix.len();
+    let available = if max_bytes == 0 {
+        usize::MAX
+    } else {
+        max_bytes.saturating_sub(prefix_len + suffix.len())
+    };
+    let body_rendered = truncate_with_ellipsis(&body, available);
+    format!("{prefix}{body_rendered}{suffix}")
+}
+
+/// Render the broadcast recipient tag. Extracted to keep the variant
+/// arm of [`format_fleet_oneliner`] focused on shape; the rules below
+/// map the §5.1 exemplar table:
+///
+/// - empty        → `[from → *]`  (matches the "DECISION solo" feel —
+///   nothing to fan out to; kept parallel to `[from → *N]` so no broadcast
+///   tag ever reads like a bare `[from → ]` with a dangling arrow)
+/// - ≤3 named     → `[from → a,b,c]`
+/// - >3 named     → `[from → a,b,…+N]`
+fn format_broadcast_tag(from: &str, recipients: &[String]) -> String {
+    match recipients.len() {
+        0 => format!("[{from} → *]"),
+        n if n <= 3 => format!("[{from} → {}]", recipients.join(",")),
+        n => {
+            let head = recipients[..2].join(",");
+            let rest = n - 2;
+            format!("[{from} → {head},…+{rest}]")
+        }
+    }
+}
+
+/// Truncate `body` to fit in `max_bytes`, appending a single `…` (which
+/// itself costs 3 bytes in UTF-8). Zero-cost when `body` already fits.
+/// `body` is sliced on a UTF-8 char boundary walked from the left to
+/// avoid ever producing invalid UTF-8 in the output.
+fn truncate_with_ellipsis(body: &str, max_bytes: usize) -> String {
+    if body.len() <= max_bytes {
+        return body.to_string();
+    }
+    const ELLIPSIS: &str = "…";
+    // Reserve space for the ellipsis suffix. If `max_bytes` is
+    // itself < 3 bytes (no room even for the ellipsis), just emit
+    // the ellipsis; prefix + suffix already consumed the budget and
+    // losing the body entirely is preferable to panicking.
+    if max_bytes < ELLIPSIS.len() {
+        return ELLIPSIS.to_string();
+    }
+    let budget = max_bytes - ELLIPSIS.len();
+    // Walk char boundaries from the left so we never split in the
+    // middle of a multi-byte codepoint.
+    let mut end = 0;
+    for (i, _) in body.char_indices() {
+        if i > budget {
+            break;
+        }
+        end = i;
+    }
+    format!("{}{ELLIPSIS}", &body[..end])
+}
+
 /// Sink trait any consumer of `UxEvent` implements. `TelegramChannel`
 /// is the only real impl in T3; the daemon-wide sink registry / merged
 /// stream of sinks is a follow-up PR once there's a real producer.
@@ -723,5 +865,186 @@ mod tests {
         ] {
             assert!(matches!(select_action(&fleet, &caps), UxAction::Noop));
         }
+    }
+
+    // ─── format_fleet_oneliner — snapshot / shape pins ───────────────
+    //
+    // These are structural pins on the §5.1 exemplars. They do not use
+    // an external snapshot tool (e.g. insta) — the substrings are small
+    // enough to inline-assert, which keeps the test file self-contained
+    // and diff-readable.
+
+    #[test]
+    fn format_fleet_oneliner_delegate_with_task_id() {
+        let fe = FleetEvent::DelegateTask {
+            from: "at-dev-1".into(),
+            to: "at-dev-2".into(),
+            summary: "task #9 Option C scoping".into(),
+            task_id: Some("AGD-7".into()),
+        };
+        let out = format_fleet_oneliner(&fe, 4096);
+        assert_eq!(
+            out,
+            "[at-dev-1 → at-dev-2]  DELEGATE  task #9 Option C scoping (#AGD-7)"
+        );
+    }
+
+    #[test]
+    fn format_fleet_oneliner_delegate_without_task_id_omits_suffix() {
+        let fe = FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: "pick up".into(),
+            task_id: None,
+        };
+        let out = format_fleet_oneliner(&fe, 4096);
+        assert_eq!(out, "[a → b]  DELEGATE  pick up");
+        assert!(!out.contains("(#"), "task_id=None must not emit (#…)");
+    }
+
+    #[test]
+    fn format_fleet_oneliner_report_with_task_id() {
+        let fe = FleetEvent::ReportResult {
+            from: "at-dev-2".into(),
+            to: "at-dev-1".into(),
+            summary: "DONE  src/utils.rs consolidation landed".into(),
+            task_id: Some("21".into()),
+        };
+        let out = format_fleet_oneliner(&fe, 4096);
+        assert_eq!(
+            out,
+            "[at-dev-2 → at-dev-1]  REPORT  DONE  src/utils.rs consolidation landed (#21)"
+        );
+    }
+
+    #[test]
+    fn format_fleet_oneliner_decision_appends_d_id() {
+        let fe = FleetEvent::PostDecision {
+            by: "at-dev-1".into(),
+            title: "task-board-ownership rules".into(),
+            decision_id: "42".into(),
+        };
+        let out = format_fleet_oneliner(&fe, 4096);
+        assert_eq!(
+            out,
+            "[at-dev-1 solo]  DECISION  task-board-ownership rules (D-42)"
+        );
+    }
+
+    #[test]
+    fn format_fleet_oneliner_broadcast_empty_recipients_uses_star() {
+        let fe = FleetEvent::Broadcast {
+            from: "at-dev-3".into(),
+            recipients: vec![],
+            summary: "CI green post-rebase".into(),
+        };
+        let out = format_fleet_oneliner(&fe, 4096);
+        assert_eq!(out, "[at-dev-3 → *]  BROADCAST  CI green post-rebase");
+    }
+
+    #[test]
+    fn format_fleet_oneliner_broadcast_one_recipient() {
+        let fe = FleetEvent::Broadcast {
+            from: "a".into(),
+            recipients: vec!["b".into()],
+            summary: "hi".into(),
+        };
+        let out = format_fleet_oneliner(&fe, 4096);
+        assert_eq!(out, "[a → b]  BROADCAST  hi");
+    }
+
+    #[test]
+    fn format_fleet_oneliner_broadcast_three_named() {
+        let fe = FleetEvent::Broadcast {
+            from: "a".into(),
+            recipients: vec!["b".into(), "c".into(), "d".into()],
+            summary: "s".into(),
+        };
+        let out = format_fleet_oneliner(&fe, 4096);
+        assert_eq!(out, "[a → b,c,d]  BROADCAST  s");
+    }
+
+    #[test]
+    fn format_fleet_oneliner_broadcast_five_elides_with_plus_n() {
+        let fe = FleetEvent::Broadcast {
+            from: "a".into(),
+            recipients: vec!["b".into(), "c".into(), "d".into(), "e".into(), "f".into()],
+            summary: "s".into(),
+        };
+        let out = format_fleet_oneliner(&fe, 4096);
+        // First 2 named, then "…+3" for the remaining 3.
+        assert_eq!(out, "[a → b,c,…+3]  BROADCAST  s");
+    }
+
+    /// Truncation pin: a summary longer than the available budget is
+    /// truncated on a char boundary with an ellipsis appended. Fixed
+    /// provenance suffix (`(#id)` / `(D-id)`) is preserved — the truncator
+    /// only eats into the summary.
+    #[test]
+    fn format_fleet_oneliner_truncates_long_summary_preserving_suffix() {
+        let long_summary = "x".repeat(500);
+        let fe = FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: long_summary,
+            task_id: Some("AGD-7".into()),
+        };
+        // Budget 80 bytes → total output must fit, suffix `(#AGD-7)` still present.
+        let out = format_fleet_oneliner(&fe, 80);
+        assert!(
+            out.len() <= 80,
+            "expected ≤80 bytes, got {}: {out}",
+            out.len()
+        );
+        assert!(
+            out.ends_with(" (#AGD-7)"),
+            "provenance suffix must survive truncation: {out}"
+        );
+        assert!(
+            out.contains('…'),
+            "truncated body must carry an ellipsis: {out}"
+        );
+    }
+
+    /// Zero `max_bytes` is treated as "no cap" so callers can skip the
+    /// cap when it's not meaningful (e.g. TUI renderer). The internal
+    /// `usize::MAX` branch is exercised here so any future refactor
+    /// that changes the zero-semantics trips this pin.
+    #[test]
+    fn format_fleet_oneliner_max_bytes_zero_means_no_cap() {
+        let fe = FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: "x".repeat(10_000),
+            task_id: None,
+        };
+        let out = format_fleet_oneliner(&fe, 0);
+        // 10k "x"s plus prefix, no ellipsis.
+        assert!(!out.contains('…'), "no cap → no truncation");
+        assert!(out.len() > 10_000);
+    }
+
+    /// Char-boundary pin: truncation walks `char_indices` from the left,
+    /// so a multi-byte codepoint that would straddle the byte budget is
+    /// dropped rather than split in half. Without this walk the output
+    /// would be invalid UTF-8 when the budget lands mid-codepoint.
+    #[test]
+    fn format_fleet_oneliner_truncates_on_char_boundary() {
+        // Summary contains a 3-byte '〇' glyph. Budget forces a boundary
+        // inside the glyph if we sliced by bytes.
+        let fe = FleetEvent::DelegateTask {
+            from: "a".into(),
+            to: "b".into(),
+            summary: "x〇yz".into(),
+            task_id: None,
+        };
+        // Prefix is "[a → b]  DELEGATE  " — compute a small cap so body
+        // budget is only a few bytes, mid-codepoint.
+        let prefix_len = "[a → b]  DELEGATE  ".len();
+        let out = format_fleet_oneliner(&fe, prefix_len + 5);
+        assert!(
+            std::str::from_utf8(out.as_bytes()).is_ok(),
+            "output must remain valid UTF-8: {out:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Consumer side of Stage B-UX. Renders `UxEvent::Fleet(FleetEvent)` (landed by PR-A in #51) into the configured `fleet_binding` topic as a one-liner per §5.1 of `docs/DESIGN-stage-b-ux.md`. Scope anchored at §5 (renderer) + §4.4 (dispatch split).

## Three pieces

1. **Config bootstrap resolution** — `init_from_config` now destructures `fleet_binding` and resolves to a topic id. Persistence uses a `FLEET_BINDING_SENTINEL` row in the existing `topics.json` registry so the same topic survives daemon restarts without touching fleet.yaml schema. Orphan-cleanup filter skips the sentinel. Shorthand logs a warn (TG has no channel-tag primitive).
2. **Telegram fleet renderer** — new pure fn `format_fleet_oneliner(&FleetEvent, max_bytes)` in `src/channel/ux_event.rs` implements the §5.1 exemplar shapes. `TelegramChannel::apply_fleet_action` reads `fleet_binding_topic_id`, formats, and sends — no-op when no binding was resolved.
3. **Dispatch split** — `UxEventSink::emit` outer-matches the event: `Fleet(fe)` bypasses `select_action` and goes to `apply_fleet_action`; Q1 events keep the existing cap-degradation ladder path. Keeping Fleet out of `select_action` preserves the Q1 ladder semantics (Fleet has no react/edit fallback — target is the fleet_binding, not the origin thread).

## Regression pin (Reviewer Contract v0.1 §4)

`channel::telegram::tests::fleet_send_target_reads_fleet_binding_topic_id_not_general` constructs state with:
- `instance_to_topic["general"] = 1` (a plausible wrong source)
- `instance_to_topic["at-dev-1"] = 100` (another plausible wrong source)
- `fleet_binding_topic_id = Some(42)` (the correct source)

…then asserts the resolver returns 42 — so a future regression to "whichever topic id the code saw first" trips here instead of silently mis-routing every fleet event into the `general` thread. Complementary inverse pin `fleet_send_target_is_none_when_binding_unresolved` guards the "absent block = no fleet sink" contract from PLAN §7.

Dispatch pin `emit_fleet_event_does_not_panic_without_binding_or_bot` uses `new_for_contract_test` (bot=None) — any accidental routing through the Q1 send path would panic via `.expect("bot")`, so a dispatch-split regression fails loudly.

## Renderer structural pins (11 tests)

All in `channel::ux_event::tests::format_fleet_*`:
- 4 variants (Delegate / Report / PostDecision / Broadcast) × task_id present/absent
- Broadcast recipient counts 0 / 1 / 3 / 5 (covers `*`, named list, `…+N` elision)
- Truncation preserving the `(#id)` / `(D-id)` suffix
- `max_bytes = 0` = "no cap" branch
- UTF-8 char-boundary walk (multi-byte codepoint must not be split)

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` full suite: 19 lib + 634 bin + 9 + 20 + 14 + 5 + 2 integration all pass
- [x] All new `format_fleet_oneliner_*` / `fleet_send_target_*` / `emit_fleet_event_*` tests pass
- [x] Existing Q1 tests (`user_msg_received_*`, `agent_picked_up_*`, `agent_replied_*`) still pass — dispatch split did not regress the ladder path
- [x] Existing TelegramState tests (`telegram_state_new_builds_reverse_map`, `is_user_allowed_*`, `resolve_topic_*`, `topic_registry_*`) still pass with the new field

## File-level references

- `src/channel/telegram.rs` — `TelegramState.fleet_binding_topic_id`, `resolve_fleet_binding`, `TelegramChannel::{fleet_send_target, apply_fleet_action}`, `UxEventSink::emit` dispatch split, new `FLEET_BINDING_SENTINEL`.
- `src/channel/ux_event.rs` — `format_fleet_oneliner`, `format_broadcast_tag`, `truncate_with_ellipsis`.
- `src/bootstrap/telegram_init.rs` — sink registration at channel bootstrap.

Depends on: #51 (merged, 89716ef).

🤖 Generated with [Claude Code](https://claude.com/claude-code)