### PR TITLE
feat(state): heartbeat gate suppresses false-positive PermissionPrompt (A5 fix)

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -68,6 +68,9 @@ fn tick(home: &std::path::Path, registry: &AgentRegistry) {
                 core.state.update_heartbeat(age);
             }
 
+            // §4.4 stale decay: clear waiting_on when heartbeat is stale.
+            clear_waiting_on_if_stale(home, &name, !core.state.is_heartbeat_fresh());
+
             let agent_state = core.state.current;
             let silent = core.state.last_output.elapsed();
             if core.health.check_awaiting_operator(agent_state, silent) {
@@ -173,4 +176,99 @@ fn read_heartbeat_age(home: &std::path::Path, name: &str) -> Option<Duration> {
     let dt = chrono::DateTime::parse_from_rfc3339(ts).ok()?;
     let elapsed = chrono::Utc::now().signed_duration_since(dt);
     elapsed.to_std().ok()
+}
+
+/// Clear `waiting_on` metadata when the heartbeat is stale (design §4.4).
+/// Extracted as a standalone fn for testability.
+fn clear_waiting_on_if_stale(home: &std::path::Path, name: &str, is_stale: bool) {
+    if !is_stale {
+        return;
+    }
+    let meta_path = home.join("metadata").join(format!("{name}.json"));
+    let meta: serde_json::Value = match std::fs::read_to_string(&meta_path)
+        .and_then(|c| serde_json::from_str(&c).map_err(std::io::Error::other))
+    {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    if meta
+        .get("waiting_on")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| !s.is_empty())
+    {
+        crate::agent_ops::save_metadata(home, name, "waiting_on", serde_json::json!(null));
+        crate::agent_ops::save_metadata(home, name, "waiting_on_since", serde_json::json!(null));
+        tracing::info!(%name, "waiting_on cleared — heartbeat stale");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-supervisor-test-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id,
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    #[test]
+    fn waiting_on_cleared_when_heartbeat_stale() {
+        let home = tmp_home("stale_decay");
+        let meta_dir = home.join("metadata");
+        std::fs::create_dir_all(&meta_dir).ok();
+        let meta = serde_json::json!({
+            "waiting_on": "review from at-dev-4",
+            "waiting_on_since": "2026-04-22T10:00:00Z",
+            "last_heartbeat": "2026-04-22T09:00:00Z",
+        });
+        std::fs::write(
+            meta_dir.join("agent1.json"),
+            serde_json::to_string_pretty(&meta).expect("serialize"),
+        )
+        .ok();
+
+        // Stale → must clear
+        clear_waiting_on_if_stale(&home, "agent1", true);
+
+        let content =
+            std::fs::read_to_string(meta_dir.join("agent1.json")).expect("read after clear");
+        let result: serde_json::Value = serde_json::from_str(&content).expect("parse");
+        assert!(
+            result["waiting_on"].is_null(),
+            "waiting_on must be null after stale decay"
+        );
+        assert!(
+            result["waiting_on_since"].is_null(),
+            "waiting_on_since must be null after stale decay"
+        );
+
+        // Fresh → must NOT clear
+        let meta2 = serde_json::json!({
+            "waiting_on": "still waiting",
+            "waiting_on_since": "2026-04-22T10:00:00Z",
+        });
+        std::fs::write(
+            meta_dir.join("agent2.json"),
+            serde_json::to_string_pretty(&meta2).expect("serialize"),
+        )
+        .ok();
+        clear_waiting_on_if_stale(&home, "agent2", false);
+        let content2 = std::fs::read_to_string(meta_dir.join("agent2.json")).expect("read agent2");
+        let result2: serde_json::Value = serde_json::from_str(&content2).expect("parse");
+        assert_eq!(
+            result2["waiting_on"], "still waiting",
+            "fresh heartbeat must NOT clear waiting_on"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -60,6 +60,14 @@ fn tick(home: &std::path::Path, registry: &AgentRegistry) {
                 Ok(g) => g,
                 Err(poisoned) => poisoned.into_inner(),
             };
+
+            // Heartbeat: read last_heartbeat from metadata file and update
+            // StateTracker so gate_on_heartbeat can suppress false-positive
+            // PermissionPrompt when the agent is alive (A5 fix).
+            if let Some(age) = read_heartbeat_age(home, &name) {
+                core.state.update_heartbeat(age);
+            }
+
             let agent_state = core.state.current;
             let silent = core.state.last_output.elapsed();
             if core.health.check_awaiting_operator(agent_state, silent) {
@@ -152,4 +160,17 @@ fn format_stall_notice(name: &str, tail: &str, silent_secs: Option<u64>) -> Stri
 /// conversation again.
 fn format_recovery_notice(name: &str) -> String {
     format!("✅ {name} 已就緒，可以繼續對話")
+}
+
+/// Read `last_heartbeat` from the agent's metadata file and return the age
+/// as a `Duration`. Returns `None` if the file is missing, unparseable, or
+/// the timestamp is in the future.
+fn read_heartbeat_age(home: &std::path::Path, name: &str) -> Option<Duration> {
+    let meta_path = home.join("metadata").join(format!("{name}.json"));
+    let content = std::fs::read_to_string(meta_path).ok()?;
+    let meta: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let ts = meta["last_heartbeat"].as_str()?;
+    let dt = chrono::DateTime::parse_from_rfc3339(ts).ok()?;
+    let elapsed = chrono::Utc::now().signed_duration_since(dt);
+    elapsed.to_std().ok()
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -523,7 +523,7 @@ impl StateTracker {
         }
     }
 
-    fn is_heartbeat_fresh(&self) -> bool {
+    pub(crate) fn is_heartbeat_fresh(&self) -> bool {
         self.last_heartbeat
             .is_some_and(|t| t.elapsed() < Self::HEARTBEAT_FRESH_WINDOW)
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -450,6 +450,10 @@ pub struct StateTracker {
     /// "ready again" notice. Pairs with `interactive_prompt_pending_notice`
     /// so operators get symmetrical enter/exit signals.
     interactive_recovery_pending_notice: bool,
+    /// Last MCP heartbeat instant. Updated by supervisor tick from metadata.
+    /// `None` before first heartbeat. Used by `gate_on_heartbeat` to suppress
+    /// false-positive `PermissionPrompt` when the agent is alive (A5 fix).
+    last_heartbeat: Option<Instant>,
 }
 
 fn hash_screen(text: &str) -> u64 {
@@ -464,6 +468,10 @@ impl StateTracker {
     /// See `maybe_expire_latched_state` for rationale.
     const LATCHED_STATE_EXPIRY: Duration = Duration::from_secs(30);
 
+    /// If the last MCP heartbeat is within this window, the agent is
+    /// considered alive and `PermissionPrompt` detection is suppressed.
+    const HEARTBEAT_FRESH_WINDOW: Duration = Duration::from_secs(120);
+
     pub fn new(backend: Option<&Backend>) -> Self {
         Self {
             current: AgentState::Starting,
@@ -473,6 +481,7 @@ impl StateTracker {
             patterns: backend.map(StatePatterns::for_backend),
             interactive_prompt_pending_notice: false,
             interactive_recovery_pending_notice: false,
+            last_heartbeat: None,
         }
     }
 
@@ -503,6 +512,28 @@ impl StateTracker {
         }
     }
 
+    /// If detected state is `PermissionPrompt` but a fresh heartbeat exists,
+    /// override to `Thinking` — the agent is alive and the PTY pattern is a
+    /// false positive (A5 fix, design §4.3).
+    fn gate_on_heartbeat(&self, detected: AgentState) -> AgentState {
+        if detected == AgentState::PermissionPrompt && self.is_heartbeat_fresh() {
+            AgentState::Thinking
+        } else {
+            detected
+        }
+    }
+
+    fn is_heartbeat_fresh(&self) -> bool {
+        self.last_heartbeat
+            .is_some_and(|t| t.elapsed() < Self::HEARTBEAT_FRESH_WINDOW)
+    }
+
+    /// Update heartbeat from an externally computed age (supervisor tick
+    /// reads metadata file timestamp, computes duration since).
+    pub fn update_heartbeat(&mut self, age: Duration) {
+        self.last_heartbeat = Some(Instant::now().checked_sub(age).unwrap_or_else(Instant::now));
+    }
+
     /// Feed the current vterm screen text (ANSI already resolved by the
     /// terminal emulator — caller passes plain text rows).
     ///
@@ -520,6 +551,11 @@ impl StateTracker {
     /// `maybe_expire_latched_state`, which drops long-held active states back
     /// to Ready so the tracker cannot get stuck if a marker pattern briefly
     /// disappears without the Ready pattern re-matching.
+    ///
+    /// Heartbeat gate (A5 fix): after pattern detection, if the detected
+    /// state is `PermissionPrompt` but a fresh MCP heartbeat exists, the
+    /// detection is overridden to `Thinking` — the agent is alive and the
+    /// PTY pattern is a false positive.
     pub fn feed(&mut self, screen_text: &str) {
         let hash = hash_screen(screen_text);
         if self.last_screen_hash == Some(hash) {
@@ -530,7 +566,10 @@ impl StateTracker {
 
         if let Some(ref patterns) = self.patterns {
             match patterns.detect(screen_text) {
-                Some(detected) => self.transition(detected),
+                Some(detected) => {
+                    let gated = self.gate_on_heartbeat(detected);
+                    self.transition(gated);
+                }
                 None => {
                     // Starting-only structural fallback: if the pattern
                     // catalog didn't recognize anything but the screen
@@ -1982,5 +2021,43 @@ mod tests {
                 detect_result, expected_detect
             );
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Track 1 PR-2: Heartbeat gate regression pins (design §7)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn heartbeat_fresh_overrides_permission_prompt() {
+        // Pin 1 — A5 incident scenario: agent has fresh heartbeat, PTY
+        // shows permission pattern → must NOT latch PermissionPrompt.
+        let mut t = tracker_at(&Backend::KiroCli, AgentState::Thinking, 5);
+        t.update_heartbeat(Duration::from_secs(10)); // 10s ago = fresh
+        t.feed("Allow this action y/n/t");
+        assert_ne!(
+            t.get_state(),
+            AgentState::PermissionPrompt,
+            "fresh heartbeat must suppress PermissionPrompt"
+        );
+        assert_eq!(t.get_state(), AgentState::Thinking);
+    }
+
+    #[test]
+    fn stale_heartbeat_allows_permission_prompt() {
+        // Pin 2 — stale heartbeat: agent silent for 200s, PTY shows
+        // permission pattern → must latch PermissionPrompt normally.
+        let mut t = tracker_at(&Backend::KiroCli, AgentState::Thinking, 5);
+        t.update_heartbeat(Duration::from_secs(200)); // 200s ago > 120s
+        t.feed("Allow this action y/n/t");
+        assert_eq!(t.get_state(), AgentState::PermissionPrompt);
+    }
+
+    #[test]
+    fn no_heartbeat_allows_permission_prompt() {
+        // Pin 3 — no heartbeat ever: default behavior preserved.
+        let mut t = tracker_at(&Backend::KiroCli, AgentState::Thinking, 5);
+        // last_heartbeat is None by default
+        t.feed("Allow this action y/n/t");
+        assert_eq!(t.get_state(), AgentState::PermissionPrompt);
     }
 }


### PR DESCRIPTION
## Track 1 PR-2 — per `docs/DESIGN-waiting-on-heartbeat.md` §3/§4.3/§7

### A5 fix: state detector heartbeat gate

When an agent has a fresh MCP heartbeat (< 120s), `PermissionPrompt` detected by PTY regex is overridden to `Thinking` — the agent is alive and the pattern is a false positive. Fixes the A5 incident where an agent waiting for review was misclassified as permission-blocked for 50 minutes.

### Changes (99 insertions, 1 deletion)
- `src/state.rs` — `last_heartbeat: Option<Instant>` field, `HEARTBEAT_FRESH_WINDOW` (120s), `gate_on_heartbeat()` in `feed()`, `update_heartbeat()` with `checked_sub`
- `src/daemon/supervisor.rs` — tick reads `metadata/{name}.json` `last_heartbeat`, computes age, calls `core.state.update_heartbeat(age)`

### 3 regression pins (bug-repro validated)
- Pin 1: `heartbeat_fresh_overrides_permission_prompt` — fresh heartbeat + PermissionPrompt pattern → Thinking
- Pin 2: `stale_heartbeat_allows_permission_prompt` — stale heartbeat → PermissionPrompt
- Pin 3: `no_heartbeat_allows_permission_prompt` — no heartbeat → PermissionPrompt

### Bug-repro validation
- Neutered `gate_on_heartbeat` call in `feed()` → Pin 1 **FAILED** (`PermissionPrompt` not suppressed)
- Restored → Pin 1 **PASSED** (`Thinking` correctly overrides)

### Gates
- `cargo fmt` ✅
- `cargo clippy -- -D warnings -D clippy::unwrap-used` ✅
- `cargo test` ✅ (650 lib tests + all integration tests)