### PR TITLE
fix(channel): wire Q1 UxEvent producers — UserMsgReceived + AgentPickedUp

### DIFF
--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -373,6 +373,28 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         return;
     }
 
+    // Persist the inbound message ID so the UX layer can resolve the
+    // origin message when emitting AgentPickedUp (channel-agnostic).
+    crate::agent_ops::save_metadata(
+        &home,
+        &instance_name,
+        "last_channel_msg_id",
+        serde_json::json!(msg.id.0.to_string()),
+    );
+    crate::agent_ops::save_metadata(
+        &home,
+        &instance_name,
+        "last_channel_kind",
+        serde_json::json!("telegram"),
+    );
+    // Also store as last_message_id for the `react` MCP tool's fallback.
+    crate::agent_ops::save_metadata(
+        &home,
+        &instance_name,
+        "last_message_id",
+        serde_json::json!(msg.id.0),
+    );
+
     // Enqueue in inbox
     let msg_obj = InboxMessage {
         from: format!("user:{username}"),
@@ -390,6 +412,21 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         text,
         &submit_key,
     );
+
+    // Emit UxEvent::UserMsgReceived so the channel adapter can react 👀.
+    {
+        use crate::channel::binding::BindingRef;
+        use crate::channel::event::MsgRef;
+        use crate::channel::ux_event::UxEvent;
+        let origin_msg = MsgRef {
+            binding: BindingRef::new("telegram", Some(instance_name.clone()), ()),
+            id: msg.id.0.to_string(),
+        };
+        crate::channel::sink_registry::registry().emit(&UxEvent::UserMsgReceived {
+            origin_msg,
+            agent: instance_name,
+        });
+    }
 }
 
 /// Classify a send error as "the bound topic was deleted out from under us".

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -308,6 +308,44 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         }
         "inbox" => {
             let messages = crate::inbox::drain(&home, instance_name);
+            // Emit AgentPickedUp so channel adapters can confirm pickup
+            // (e.g. Telegram ✅ reaction). Channel-agnostic: reads the
+            // origin msg coordinates from metadata written by whichever
+            // adapter delivered the inbound message.
+            if !messages.is_empty() {
+                let meta_path = home.join("metadata").join(format!("{instance_name}.json"));
+                if let Some(meta) = std::fs::read_to_string(&meta_path)
+                    .ok()
+                    .and_then(|c| serde_json::from_str::<Value>(&c).ok())
+                {
+                    let kind_str = meta["last_channel_kind"].as_str().unwrap_or("");
+                    let msg_id = meta["last_channel_msg_id"].as_str().unwrap_or("");
+                    // Map to &'static str for BindingRef::new.
+                    let kind: &'static str = match kind_str {
+                        "telegram" => "telegram",
+                        "discord" => "discord",
+                        "slack" => "slack",
+                        _ => "",
+                    };
+                    if !kind.is_empty() && !msg_id.is_empty() {
+                        use crate::channel::binding::BindingRef;
+                        use crate::channel::event::MsgRef;
+                        use crate::channel::ux_event::UxEvent;
+                        let origin_msg = MsgRef {
+                            binding: BindingRef::new(
+                                kind,
+                                Some(instance_name.to_string()),
+                                (),
+                            ),
+                            id: msg_id.to_string(),
+                        };
+                        crate::channel::sink_registry::registry().emit(&UxEvent::AgentPickedUp {
+                            origin_msg,
+                            agent: instance_name.to_string(),
+                        });
+                    }
+                }
+            }
             json!({"messages": messages})
         }
 


### PR DESCRIPTION
## Problem

T3 (#49) landed the **consumer side** of Q1 delivery confirmation — `select_action` capability-ladder, `TelegramChannel::emit` with react/edit/send degradation — and Stage B landed the **FleetEvent producers**. But the Q1 producer-side emission (`UserMsgReceived` 👀 / `AgentPickedUp` ✅) was deferred to a "dispatcher PR" (noted in `ux_event.rs` line 47-48, 58) that never shipped. The events were fully defined, capability-gated, and test-covered on the consumer path, but never emitted in production.

Additionally, `try_telegram_react` (the `react` MCP tool) falls back to reading `last_message_id` from metadata when the agent omits `message_id`, but `handle_message` never persisted it — so the tool always bailed with `"No message_id to react to"`.

## Root cause

Scope gap between T3 (consumer-only) and Stage B (Q2 fleet events only). The Q1 producers fell through the cracks between the two PRs.

## Changes

### 1. `telegram.rs` — persist inbound message coordinates

`handle_message` now writes three metadata keys after authz + before enqueue:
- `last_channel_kind` (`"telegram"`) — channel-agnostic key for the inbox handler
- `last_channel_msg_id` (string) — channel-agnostic message ID
- `last_message_id` (integer) — Telegram-specific, for the `react` MCP tool fallback

### 2. `telegram.rs` — emit `UserMsgReceived`

After enqueue + PTY notify, emits `UxEvent::UserMsgReceived` through `sink_registry`. The registered `TelegramChannel` sink walks `select_action` → `React { emoji: "👀" }` → `try_telegram_react` on the user's original message.

### 3. `mcp/handlers.rs` — emit `AgentPickedUp`

When the `inbox` tool drains messages, reads `last_channel_kind` + `last_channel_msg_id` from metadata and emits `UxEvent::AgentPickedUp`. Channel-agnostic: future adapters (Discord, Slack) only need to persist the two metadata keys in their inbound path to get ✅ pickup confirmation for free.

## Design alignment with channel abstraction

- `UserMsgReceived` is emitted in the adapter (`telegram.rs`) — the inbound entry point is inherently adapter-specific.
- `AgentPickedUp` is emitted in the MCP handler — channel-agnostic, reads adapter-written metadata coordinates.
- Both events flow through the existing `sink_registry` → `UxEventSink::emit` → `select_action` capability-ladder, respecting the abstraction layer established in T3.

## References

- T3 consumer: #49 (`UxEvent` + `TelegramChannel::emit`)
- Stage B producers: #51 (PR-A, `FleetEvent` + `UxSinkRegistry`), #56 (PR-B, fleet renderer)
- Plan: `docs/PLAN-channel-ux-layer.md` §4 / §6 Q1 table
- Design: `docs/DESIGN-stage-b-ux.md` §4.4 dispatch split