### PR TITLE
fix(tui): 4 UX fixes — Shift+Enter / tab drag reorder / pane drag hit area / single-pane drag

### DIFF
--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -25,6 +25,10 @@ pub(super) struct MouseState {
     /// reusing it keeps drag math stable even if the terminal is resized
     /// mid-gesture.
     pub border_drag: Option<(SplitBorderHit, Rect)>,
+    /// Active tab drag for reorder. `Some(idx)` = dragging tab at index.
+    pub dragging_tab: Option<usize>,
+    /// Drop target tab index during tab drag.
+    pub tab_drop_target: Option<usize>,
 }
 
 /// Signals from mouse handling back to `run_app`. Fields are `Option` /
@@ -80,6 +84,9 @@ fn handle_down(
                 out.new_last_tab = Some(layout.active);
                 layout.goto_tab(idx);
                 out.needs_resize = true;
+                // Start tab drag for reorder
+                state.dragging_tab = Some(idx);
+                state.tab_drop_target = None;
             }
             Some(TabBarClick::NewTab) => {
                 out.new_overlay = Some(Overlay::NewTabMenu {
@@ -111,12 +118,10 @@ fn handle_down(
     if let Some(pane_id) = title_hit {
         if let Some(tab) = layout.active_tab_mut() {
             tab.focus_id = pane_id;
-            // Only start a drag when there's a possible swap target;
-            // otherwise the source pane briefly flashes magenta for a no-op.
-            if tab.root().pane_count() > 1 {
-                tab.dragging_pane = Some(pane_id);
-                tab.drag_target = None;
-            }
+            // Allow drag even for single-pane tabs — the user can
+            // cross-tab drag to move the pane to another tab.
+            tab.dragging_pane = Some(pane_id);
+            tab.drag_target = None;
         }
     } else if !zoomed {
         let hit = layout.active_tab().and_then(|tab| {
@@ -158,6 +163,12 @@ fn handle_drag(mouse: MouseEvent, layout: &mut Layout, state: &mut MouseState) {
         // but resizing the PTY every mouse cell triggers the backend
         // (Claude/etc.) to reflow its entire UI and floods us with redraw
         // data. Defer the single PTY resize to mouse-up.
+    } else if state.dragging_tab.is_some() && mouse.row == 0 {
+        // Tab reorder drag: update drop target
+        state.tab_drop_target = match tab_bar_hit_test(layout, mouse.column) {
+            Some(TabBarClick::Tab(idx)) => Some(idx),
+            _ => None,
+        };
     } else if layout
         .active_tab()
         .is_some_and(|t| t.dragging_pane.is_some())
@@ -205,6 +216,17 @@ fn handle_up(
     state: &mut MouseState,
     out: &mut MouseOutcome,
 ) {
+    // Tab reorder: complete drag-to-reorder on mouse up
+    if let Some(from) = state.dragging_tab.take() {
+        if let Some(to) = state.tab_drop_target.take() {
+            if from != to && from < layout.tabs.len() && to < layout.tabs.len() {
+                let tab = layout.tabs.remove(from);
+                layout.tabs.insert(to, tab);
+                layout.active = to;
+                out.needs_resize = true;
+            }
+        }
+    }
     if state.border_drag.is_some() {
         state.border_drag = None;
         // Ratio was updated live during drag but PTY resizes were deferred

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -6,7 +6,6 @@ use crate::bridge_client::BridgeClient;
 use crate::vterm::VTerm;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use unicode_width::UnicodeWidthStr;
 
 /// How a pane's input/resize is delivered to the underlying process.
 ///
@@ -1010,15 +1009,12 @@ impl Tab {
             if row != py {
                 continue;
             }
-            let Some(pane) = self.root().find_pane(id) else {
+            if self.root().find_pane(id).is_none() {
                 continue;
-            };
-            // Rendered title is ` {label} ` — measure with terminal cell
-            // width (not char count) so CJK / emoji labels hit correctly.
-            let title_width = UnicodeWidthStr::width(pane.label()) as u16 + 2;
-            let start = px + 1;
-            let end = (start + title_width).min(px + pw);
-            if col >= start && col < end {
+            }
+            // Hit area covers the full pane-width title bar row (not just
+            // the text label) so the entire colored region is draggable.
+            if col >= px && col < px + pw {
                 return Some(id);
             }
         }
@@ -1299,6 +1295,7 @@ impl Layout {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use unicode_width::UnicodeWidthStr;
 
     // --- ratio_bounds invariants (covers Round A #3 + #6) ---
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -127,6 +127,7 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Vec<u8> {
             let mut b = [0u8; 4];
             c.encode_utf8(&mut b).as_bytes().to_vec()
         }
+        KeyCode::Enter if modifiers.contains(KeyModifiers::SHIFT) => b"\x1b[13;2u".to_vec(),
         KeyCode::Enter => vec![b'\r'],
         KeyCode::Backspace => vec![0x7f],
         KeyCode::Tab => vec![b'\t'],


### PR DESCRIPTION
## 4 TUI bug fixes

### 1. Shift+Enter newline (t-20260422140006)
`key_to_bytes` now sends CSI u sequence (`\x1b[13;2u`) for Shift+Enter, matching external terminal behavior.

### 2. Tab drag reorder (t-20260422140011)
Mouse down on tab initiates drag. Dragging to another tab position swaps them on mouse up. New `dragging_tab`/`tab_drop_target` fields in `MouseState`.

### 3. Pane drag hit area (t-20260422140011)
Title bar hit detection extended from text-only to full pane width — the entire colored region is now draggable.

### 4. Single-pane cross-tab drag (t-20260422140016)
Removed `pane_count() > 1` guard so single-pane tabs can initiate drag for cross-tab moves.

### Files (35 insertions, 15 deletions)
- `src/tui.rs` — Shift+Enter
- `src/app/mouse.rs` — tab drag + single-pane drag
- `src/layout.rs` — pane hit area

### Gates
`cargo fmt` ✅ / `cargo clippy` ✅ / `cargo test` ✅ (662 lib tests)