### PR TITLE
fix(tui): Shift+Enter newline (Repeat mode + LF) + keybindings panel width

### DIFF
--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -105,7 +105,9 @@ impl KeyHandler {
             }
             PrefixState::Repeat { since } => {
                 // Enter or Esc exits repeat mode immediately
-                if key.code == KeyCode::Enter || key.code == KeyCode::Esc {
+                if (key.code == KeyCode::Enter && !key.modifiers.contains(KeyModifiers::SHIFT))
+                    || key.code == KeyCode::Esc
+                {
                     self.state = PrefixState::Normal;
                     return Action::None;
                 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1049,7 +1049,8 @@ pub fn render_help(frame: &mut Frame) {
     ];
     let area = frame.area();
     let h = (help.len() as u16 + 2).min(area.height.saturating_sub(2));
-    let w = 48u16.min(area.width.saturating_sub(4));
+    let content_w = help.iter().map(|l| l.len() as u16).max().unwrap_or(48) + 2;
+    let w = content_w.min(area.width.saturating_sub(4));
     let x = (area.width.saturating_sub(w)) / 2;
     let y = (area.height.saturating_sub(h)) / 2;
     let ha = Rect::new(x, y, w, h);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -127,7 +127,7 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Vec<u8> {
             let mut b = [0u8; 4];
             c.encode_utf8(&mut b).as_bytes().to_vec()
         }
-        KeyCode::Enter if modifiers.contains(KeyModifiers::SHIFT) => b"\x1b[13;2u".to_vec(),
+        KeyCode::Enter if modifiers.contains(KeyModifiers::SHIFT) => vec![b'\n'],
         KeyCode::Enter => vec![b'\r'],
         KeyCode::Backspace => vec![0x7f],
         KeyCode::Tab => vec![b'\t'],


### PR DESCRIPTION
## Two fixes

### 1. Shift+Enter (t-20260422143649)
- **keybinds.rs**: Repeat mode exit check now skips Shift+Enter (`!modifiers.contains(SHIFT)`)
- **tui.rs**: Shift+Enter sends `\n` (LF) instead of CSI u (`\x1b[13;2u`) for broader CLI compatibility

### 2. Keybindings panel width (t-20260422143651)
- **render.rs**: Help panel width auto-fits content (`max line length + 2`) instead of hardcoded 48 columns

### Gates
`cargo fmt` ✅ / `cargo clippy` ✅ / `cargo test` ✅ (662 lib tests)