### PR TITLE
fix(tui): enable keyboard enhancement flags for Shift+Enter disambiguation

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -61,6 +61,9 @@ pub fn run(fleet_path_override: Option<&str>) -> Result<()> {
         std::io::stdout(),
         crossterm::event::EnableMouseCapture,
         crossterm::event::EnableBracketedPaste,
+        crossterm::event::PushKeyboardEnhancementFlags(
+            crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+        ),
     )
     .ok();
 
@@ -72,6 +75,7 @@ pub fn run(fleet_path_override: Option<&str>) -> Result<()> {
         std::io::stdout(),
         crossterm::event::DisableMouseCapture,
         crossterm::event::DisableBracketedPaste,
+        crossterm::event::PopKeyboardEnhancementFlags,
     )
     .ok();
     result

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -15,6 +15,11 @@ use std::path::Path;
 struct RawModeGuard;
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
+        crossterm::execute!(
+            std::io::stdout(),
+            crossterm::event::PopKeyboardEnhancementFlags,
+        )
+        .ok();
         terminal::disable_raw_mode().ok();
     }
 }
@@ -25,6 +30,13 @@ pub fn attach(home: &Path, name: &str) -> anyhow::Result<()> {
     let mut bridge = BridgeClient::connect(home, name, cols, rows)?;
 
     terminal::enable_raw_mode()?;
+    crossterm::execute!(
+        std::io::stdout(),
+        crossterm::event::PushKeyboardEnhancementFlags(
+            crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+        ),
+    )
+    .ok();
     let _guard = RawModeGuard;
 
     let reader = bridge
@@ -127,7 +139,9 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Vec<u8> {
             let mut b = [0u8; 4];
             c.encode_utf8(&mut b).as_bytes().to_vec()
         }
-        KeyCode::Enter if modifiers.contains(KeyModifiers::SHIFT) => vec![b'\n'],
+        KeyCode::Enter if modifiers.intersects(KeyModifiers::SHIFT | KeyModifiers::ALT) => {
+            vec![b'\n']
+        }
         KeyCode::Enter => vec![b'\r'],
         KeyCode::Backspace => vec![0x7f],
         KeyCode::Tab => vec![b'\t'],


### PR DESCRIPTION
## Root cause fix for Shift+Enter

Without crossterm's `DISAMBIGUATE_ESCAPE_CODES` flag, the terminal reports Shift+Enter and Enter as identical byte sequences. Previous fixes (Repeat mode bypass + LF byte) were correct but unreachable.

### Changes
- `src/app/mod.rs`: `PushKeyboardEnhancementFlags(DISAMBIGUATE_ESCAPE_CODES)` on startup, `PopKeyboardEnhancementFlags` on exit
- `src/tui.rs`: same push/pop in thin client (`RawModeGuard` drop)
- `src/tui.rs`: Alt+Enter also sends LF (`intersects(SHIFT | ALT)`)

`.ok()` on push so unsupported terminals silently fall back to original behavior.

### Verification note
Build compiles clean. Interactive verification requires TUI session — user should test Shift+Enter / Alt+Enter / plain Enter after merge.

### Gates
`cargo fmt` ✅ / `cargo clippy` ✅ / `cargo test` ✅ (662 lib tests)

Task: t-20260422145211