### PR TITLE
fix(tui): Ctrl+J in help + tab drag highlight + persistent selection

### DIFF
--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -25,10 +25,6 @@ pub(super) struct MouseState {
     /// reusing it keeps drag math stable even if the terminal is resized
     /// mid-gesture.
     pub border_drag: Option<(SplitBorderHit, Rect)>,
-    /// Active tab drag for reorder. `Some(idx)` = dragging tab at index.
-    pub dragging_tab: Option<usize>,
-    /// Drop target tab index during tab drag.
-    pub tab_drop_target: Option<usize>,
 }
 
 /// Signals from mouse handling back to `run_app`. Fields are `Option` /
@@ -85,8 +81,8 @@ fn handle_down(
                 layout.goto_tab(idx);
                 out.needs_resize = true;
                 // Start tab drag for reorder
-                state.dragging_tab = Some(idx);
-                state.tab_drop_target = None;
+                layout.tab_reorder_source = Some(idx);
+                layout.tab_reorder_target = None;
             }
             Some(TabBarClick::NewTab) => {
                 out.new_overlay = Some(Overlay::NewTabMenu {
@@ -163,9 +159,9 @@ fn handle_drag(mouse: MouseEvent, layout: &mut Layout, state: &mut MouseState) {
         // but resizing the PTY every mouse cell triggers the backend
         // (Claude/etc.) to reflow its entire UI and floods us with redraw
         // data. Defer the single PTY resize to mouse-up.
-    } else if state.dragging_tab.is_some() && mouse.row == 0 {
+    } else if layout.tab_reorder_source.is_some() && mouse.row == 0 {
         // Tab reorder drag: update drop target
-        state.tab_drop_target = match tab_bar_hit_test(layout, mouse.column) {
+        layout.tab_reorder_target = match tab_bar_hit_test(layout, mouse.column) {
             Some(TabBarClick::Tab(idx)) => Some(idx),
             _ => None,
         };
@@ -217,8 +213,8 @@ fn handle_up(
     out: &mut MouseOutcome,
 ) {
     // Tab reorder: complete drag-to-reorder on mouse up
-    if let Some(from) = state.dragging_tab.take() {
-        if let Some(to) = state.tab_drop_target.take() {
+    if let Some(from) = layout.tab_reorder_source.take() {
+        if let Some(to) = layout.tab_reorder_target.take() {
             if from != to && from < layout.tabs.len() && to < layout.tabs.len() {
                 let tab = layout.tabs.remove(from);
                 layout.tabs.insert(to, tab);
@@ -419,7 +415,7 @@ fn handle_selection(layout: &mut Layout, mouse: &MouseEvent) {
                         copy_to_clipboard(&text);
                     }
                 }
-                pane.selection = None;
+                // Keep selection visible — cleared on next mouse down or keypress.
                 true
             }
             _ => false,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1123,6 +1123,10 @@ pub struct Layout {
     pub tabs: Vec<Tab>,
     pub active: usize,
     next_pane_id: usize,
+    /// Tab being dragged for reorder (index). Set by mouse handler.
+    pub tab_reorder_source: Option<usize>,
+    /// Drop target tab index during tab reorder drag.
+    pub tab_reorder_target: Option<usize>,
 }
 
 impl Layout {
@@ -1131,6 +1135,8 @@ impl Layout {
             tabs: Vec::new(),
             active: 0,
             next_pane_id: 0,
+            tab_reorder_source: None,
+            tab_reorder_target: None,
         }
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -97,11 +97,15 @@ fn render_tab_bar(frame: &mut Frame, area: Rect, layout: &Layout, registry: &Age
         let is_active = i == layout.active;
         let is_drag_drop =
             matches!(drag_tab_target, Some(DragTabTarget::ExistingTab(idx)) if idx == i);
+        // Tab reorder: highlight the drop target during tab-to-tab drag
+        let is_reorder_target = layout
+            .tab_reorder_target
+            .is_some_and(|t| t == i && layout.tab_reorder_source.is_some_and(|s| s != i));
         // Show the highest-priority state across all panes in this tab
         let state = highest_priority_state(tab, registry);
         let sc = state_color(state);
 
-        let style = if is_drag_drop {
+        let style = if is_drag_drop || is_reorder_target {
             // Drop-target highlight wins over active styling so the user sees
             // where the pane will land. Magenta matches the intra-tab
             // drag-swap highlight (see is_drag_target below).
@@ -1040,6 +1044,8 @@ pub fn render_help(frame: &mut Frame) {
         "    Ctrl+B T       Task board",
         "",
         "  Other",
+        "    Ctrl+J         Newline (no submit, works everywhere)",
+        "    Shift+Enter    Newline (requires modern terminal)",
         "    Ctrl+B Ctrl+B  Send Ctrl+B to pane",
         "    Ctrl+B ~       Scratch shell (Esc to close)",
         "    Ctrl+B d       Detach (exit)",


### PR DESCRIPTION
## Three TUI UX improvements

### 1. Keybindings help — Ctrl+J + Shift+Enter listed
Added under Other section. Ctrl+J works everywhere (universal LF), Shift+Enter requires modern terminal with Kitty keyboard protocol.

### 2. Tab drag reorder — visual feedback (t-20260422145024)
Drop target tab highlighted magenta during drag (matches pane drag style). Tab reorder state moved from `MouseState` to `Layout` so render can access it.

### 3. Mouse selection — persistent highlight (t-20260422145026)
Selection highlight stays visible after mouse up (still copies to clipboard on release). Cleared on next mouse down, not on release.

### Gates
`cargo fmt` ✅ / `cargo clippy` ✅ / `cargo test` ✅ (662 lib tests)