### PR TITLE
feat: auto-remove instance from teams on delete, auto-delete empty teams

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -528,6 +528,8 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             if let Some(ref wd) = working_dir {
                 cleanup_working_dir(&home, name, wd);
             }
+            // Remove from all teams; auto-delete empty teams
+            crate::teams::remove_member_from_all(&home, name);
             json!({"name": name})
         }
         "start_instance" => {

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -130,6 +130,17 @@ pub fn update(home: &Path, args: &Value) -> Value {
     }
 }
 
+/// Remove an instance from ALL teams. Auto-delete teams that become empty.
+pub fn remove_member_from_all(home: &Path, instance_name: &str) {
+    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut TeamStore| {
+        for team in &mut store.teams {
+            team.members.retain(|m| m != instance_name);
+        }
+        store.teams.retain(|t| !t.members.is_empty());
+        Ok(true)
+    });
+}
+
 /// Get members of a team.
 pub fn get_members(home: &Path, team_name: &str) -> Vec<String> {
     let store = load(home);

--- a/tests/mcp_characterization.rs
+++ b/tests/mcp_characterization.rs
@@ -638,3 +638,62 @@ fn create_team_duplicate_rejects() {
     assert_error_contains(&result, "already exists");
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ---------------------------------------------------------------------------
+// delete_instance team cleanup + replace_instance preservation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn delete_instance_removes_from_team() {
+    let home = temp_home("del_team_member");
+    setup_team(&home, "devs", &["alice", "bob"]);
+    call_tool(&home, "delete_instance", &json!({"name": "alice"}));
+    let listed = call_tool(&home, "list_teams", &json!({}));
+    let teams = listed["teams"].as_array().expect("teams");
+    assert_eq!(teams.len(), 1);
+    let members: Vec<&str> = teams[0]["members"]
+        .as_array()
+        .expect("members")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert_eq!(members, vec!["bob"]);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn delete_last_member_auto_deletes_team() {
+    let home = temp_home("del_last_member");
+    setup_team(&home, "solo", &["only-one"]);
+    call_tool(&home, "delete_instance", &json!({"name": "only-one"}));
+    let listed = call_tool(&home, "list_teams", &json!({}));
+    let teams = listed["teams"].as_array().expect("teams");
+    assert!(teams.is_empty(), "empty team should be auto-deleted");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn replace_instance_preserves_team_membership() {
+    let home = temp_home("replace_team");
+    setup_team(&home, "devs", &["alice"]);
+    // replace_instance kills + respawns same name — team membership stays
+    // because teams.json references by name, not by process identity.
+    // The API call will fail (no daemon), but that's fine — we just verify
+    // teams.json is untouched.
+    call_tool(
+        &home,
+        "replace_instance",
+        &json!({"name": "alice", "reason": "test"}),
+    );
+    let listed = call_tool(&home, "list_teams", &json!({}));
+    let teams = listed["teams"].as_array().expect("teams");
+    assert_eq!(teams.len(), 1);
+    let members: Vec<&str> = teams[0]["members"]
+        .as_array()
+        .expect("members")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert_eq!(members, vec!["alice"]);
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary
- Add `teams::remove_member_from_all()` helper — removes instance from all teams, auto-deletes empty teams
- Hook into `delete_instance` MCP handler for automatic cleanup
- `replace_instance` preserves membership (same name = same identity, no code change needed)

## Tests (3 new)
- `delete_instance_removes_from_team` — create team [a, b] → delete a → team has [b]
- `delete_last_member_auto_deletes_team` — create team [a] → delete a → team gone
- `replace_instance_preserves_team_membership` — create team [a] → replace a → team still has [a]

## Gates
`cargo fmt` ✓ | `cargo clippy` ✓ | `cargo test` ✓

Part of team lifecycle management (PR-2). Ref: task t-20260422161155