### PR TITLE
feat: fleet.yaml teams: section + daemon/app startup reconcile

### DIFF
--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -139,6 +139,10 @@ pub(super) fn restore_with_reconciliation(
     rows: u16,
 ) -> bool {
     let fleet = fleet::FleetConfig::load(fleet_path).ok();
+    // Reconcile fleet.yaml teams: section → teams.json (additive only)
+    if let Some(ref f) = fleet {
+        crate::teams::reconcile_teams(home, f);
+    }
     let fleet_names: HashSet<String> = fleet
         .as_ref()
         .map(|f| f.instance_names().into_iter().collect())

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -202,6 +202,8 @@ pub fn run_with_prepared(mut prepared: Box<crate::bootstrap::OwnedFleet>) -> any
     // avoids re-reading + re-parsing fleet.yaml inside run_core.
     let initial_digest = crate::bootstrap::reload::digest_from_config(&prepared.config);
     let telegram = prepared.telegram.clone();
+    // Reconcile fleet.yaml teams: section → teams.json (additive only)
+    crate::teams::reconcile_teams(&home, &prepared.config);
     let _owned = prepared;
     run_core(&home, agents, Some(initial_digest), telegram)
 }

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FleetConfig {
     #[serde(default)]
     pub defaults: InstanceDefaults,
@@ -150,6 +150,8 @@ pub struct InstanceConfig {
 pub struct TeamConfig {
     #[serde(default)]
     pub members: Vec<String>,
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 impl FleetConfig {

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -141,6 +141,33 @@ pub fn remove_member_from_all(home: &Path, instance_name: &str) {
     });
 }
 
+/// Reconcile teams from fleet.yaml seed config. Additive only — runtime-added
+/// members are preserved; only missing seed members are added.
+pub fn reconcile_teams(home: &Path, fleet: &crate::fleet::FleetConfig) {
+    for (name, seed) in &fleet.teams {
+        let existing = get_members(home, name);
+        if existing.is_empty() {
+            create(
+                home,
+                &serde_json::json!({
+                    "name": name,
+                    "members": seed.members,
+                    "description": seed.description,
+                }),
+            );
+        } else {
+            let missing: Vec<&String> = seed
+                .members
+                .iter()
+                .filter(|m| !existing.contains(m))
+                .collect();
+            if !missing.is_empty() {
+                update(home, &serde_json::json!({ "name": name, "add": missing }));
+            }
+        }
+    }
+}
+
 /// Get members of a team.
 pub fn get_members(home: &Path, team_name: &str) -> Vec<String> {
     let store = load(home);
@@ -223,6 +250,64 @@ mod tests {
         let home = tmp_home("del_nonexistent");
         let r = delete(&home, &serde_json::json!({"name": "nope"}));
         assert!(r["error"].as_str().is_some());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    fn make_fleet(teams: &[(&str, &[&str])]) -> crate::fleet::FleetConfig {
+        let mut map = std::collections::HashMap::new();
+        for (name, members) in teams {
+            map.insert(
+                name.to_string(),
+                crate::fleet::TeamConfig {
+                    members: members.iter().map(|s| s.to_string()).collect(),
+                    description: None,
+                },
+            );
+        }
+        crate::fleet::FleetConfig {
+            teams: map,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn fleet_yaml_teams_creates_on_startup() {
+        let home = tmp_home("reconcile_create");
+        let fleet = make_fleet(&[("devs", &["alice", "bob"])]);
+        reconcile_teams(&home, &fleet);
+        let members = get_members(&home, "devs");
+        assert_eq!(members, vec!["alice", "bob"]);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn fleet_yaml_teams_additive_reconcile() {
+        let home = tmp_home("reconcile_additive");
+        // Pre-create team with an extra runtime member
+        create(
+            &home,
+            &serde_json::json!({"name": "devs", "members": ["alice", "runtime-extra"]}),
+        );
+        let fleet = make_fleet(&[("devs", &["alice", "bob"])]);
+        reconcile_teams(&home, &fleet);
+        let members = get_members(&home, "devs");
+        // runtime-extra preserved, bob added
+        assert!(members.contains(&"alice".to_string()));
+        assert!(members.contains(&"bob".to_string()));
+        assert!(members.contains(&"runtime-extra".to_string()));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn fleet_yaml_teams_idempotent() {
+        let home = tmp_home("reconcile_idempotent");
+        let fleet = make_fleet(&[("devs", &["alice"])]);
+        reconcile_teams(&home, &fleet);
+        reconcile_teams(&home, &fleet);
+        let listed = list(&home);
+        let teams = listed["teams"].as_array().expect("teams");
+        assert_eq!(teams.len(), 1, "should not duplicate team");
+        assert_eq!(get_members(&home, "devs"), vec!["alice"]);
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Summary
fleet.yaml `teams:` section is now parsed and reconciled on startup in both daemon and app modes.

```yaml
teams:
  at-dev:
    members: [general, at-dev-2, at-dev-4]
    description: Core working team
```

### Design: Additive-only reconcile
- fleet.yaml defines **seed** members
- Runtime-added members are **preserved** (not removed)
- Missing seed members are **added**
- Idempotent — safe to run on every startup

## Changes (4 files, +94 lines)
1. `src/fleet.rs` — add `description` to `TeamConfig`, add `Default` derive to `FleetConfig`
2. `src/teams.rs` — add `reconcile_teams(home, fleet)` shared function
3. `src/daemon/mod.rs` — call reconcile in `run_with_prepared()`
4. `src/app/session.rs` — call reconcile in `restore_with_reconciliation()`

## Tests (3 new)
- `fleet_yaml_teams_creates_on_startup` — fleet.yaml teams → teams.json ✓
- `fleet_yaml_teams_additive_reconcile` — runtime member preserved, seed member added ✓
- `fleet_yaml_teams_idempotent` — double reconcile = no duplicate ✓

## Gates
`cargo fmt` ✓ | `cargo clippy` ✓ | `cargo test` ✓

Part of team lifecycle management (PR-3). Ref: task t-20260422161156