### PR TITLE
feat: TUI task board CRUD — new/move/assign/cancel + two-step assign selector

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -201,7 +201,7 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
                 items,
                 col: 0,
                 row: 0,
-                detail: false,
+                mode: super::overlay::TaskBoardMode::Board,
             });
         }
         Action::ShowHelp => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -13,7 +13,7 @@ mod session;
 mod telegram_hooks;
 mod tui_events;
 
-pub use overlay::{MenuItem, MenuItemKind};
+pub use overlay::{MenuItem, MenuItemKind, TaskBoardMode};
 pub(crate) use tui_events::{TuiEvent, TuiEventSender, TuiNotifier};
 
 use crate::agent::{self, AgentRegistry};
@@ -364,9 +364,9 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     ref items,
                     col,
                     row,
-                    detail,
+                    ref mode,
                 } => {
-                    render::render_tasks(frame, items, *col, *row, *detail);
+                    render::render_tasks(frame, items, *col, *row, mode);
                 }
                 Overlay::ScratchShell { pane } => {
                     render::render_scratch_shell(frame, pane, &registry);

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -28,6 +28,18 @@ pub(super) enum CloseTarget {
     Tab,
 }
 
+pub enum TaskBoardMode {
+    Board,
+    Detail,
+    NewTask {
+        input: String,
+    },
+    Assign {
+        choices: Vec<String>,
+        selected: usize,
+    },
+}
+
 pub(super) enum Overlay {
     None,
     /// New tab selection menu.
@@ -79,15 +91,15 @@ pub(super) enum Overlay {
         items: Vec<crate::decisions::Decision>,
         scroll: usize,
     },
-    /// Task board overlay — 4-column kanban view.
+    /// Task board overlay — 4-column kanban view with CRUD.
     Tasks {
         items: Vec<crate::tasks::Task>,
         /// Currently focused column (0=Backlog, 1=Open, 2=InProgress, 3=Done).
         col: usize,
         /// Currently focused row within the column.
         row: usize,
-        /// Whether detail view is expanded for the selected task.
-        detail: bool,
+        /// Sub-mode: None=board, Detail, NewTask(input), Assign(selected).
+        mode: TaskBoardMode,
     },
     /// Floating scratch shell (Ctrl+B ~). Esc kills the shell and closes the
     /// overlay. Pane is boxed because it's much larger than any other variant.
@@ -509,45 +521,195 @@ pub(super) fn handle_key(
             }
         }
         Overlay::Tasks {
-            ref items,
+            ref mut items,
             ref mut col,
             ref mut row,
-            ref mut detail,
+            ref mut mode,
         } => {
-            if *detail {
-                // In detail view, Esc goes back to board
-                if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
-                    *detail = false;
-                } else {
-                    // ignore other keys in detail view
+            match mode {
+                TaskBoardMode::Detail => {
+                    if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
+                        *mode = TaskBoardMode::Board;
+                    }
                 }
-            } else {
-                let columns = crate::render::task_board_columns(items);
-                match key.code {
-                    KeyCode::Left | KeyCode::Char('h') if *col > 0 => {
-                        *col -= 1;
-                        *row = (*row).min(columns[*col].len().saturating_sub(1));
+                TaskBoardMode::NewTask { ref mut input } => match key.code {
+                    KeyCode::Enter if !input.is_empty() => {
+                        crate::tasks::handle(
+                            ctx.home,
+                            "user",
+                            &serde_json::json!({
+                                "action": "create",
+                                "title": input.as_str(),
+                                "priority": "normal",
+                            }),
+                        );
+                        *items = crate::tasks::list_all(ctx.home);
+                        *mode = TaskBoardMode::Board;
                     }
-                    KeyCode::Right | KeyCode::Char('l') if *col < 3 => {
-                        *col += 1;
-                        *row = (*row).min(columns[*col].len().saturating_sub(1));
+                    KeyCode::Char(c) => input.push(c),
+                    KeyCode::Backspace => {
+                        input.pop();
                     }
-                    KeyCode::Up | KeyCode::Char('k') if *row > 0 => {
-                        *row -= 1;
-                    }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        let col_len = columns[*col].len();
-                        if *row + 1 < col_len {
-                            *row += 1;
-                        }
-                    }
-                    KeyCode::Enter if !columns[*col].is_empty() => {
-                        *detail = true;
-                    }
-                    KeyCode::Esc | KeyCode::Char('q') => {
-                        *overlay = Overlay::None;
+                    KeyCode::Esc => {
+                        *mode = TaskBoardMode::Board;
                     }
                     _ => {}
+                },
+                TaskBoardMode::Assign {
+                    ref choices,
+                    ref mut selected,
+                } => match key.code {
+                    KeyCode::Up | KeyCode::Char('k') if *selected > 0 => {
+                        *selected -= 1;
+                    }
+                    KeyCode::Down | KeyCode::Char('j') if *selected + 1 < choices.len() => {
+                        *selected += 1;
+                    }
+                    KeyCode::Enter if !choices.is_empty() => {
+                        let columns = crate::render::task_board_columns(items);
+                        if let Some(task) = columns[*col].get(*row) {
+                            let assignee = &choices[*selected];
+                            crate::tasks::handle(
+                                ctx.home,
+                                "user",
+                                &serde_json::json!({
+                                    "action": "update",
+                                    "id": task.id,
+                                    "assignee": assignee,
+                                }),
+                            );
+                            *items = crate::tasks::list_all(ctx.home);
+                        }
+                        *mode = TaskBoardMode::Board;
+                    }
+                    KeyCode::Esc => {
+                        *mode = TaskBoardMode::Board;
+                    }
+                    _ => {}
+                },
+                TaskBoardMode::Board => {
+                    let columns = crate::render::task_board_columns(items);
+                    match key.code {
+                        KeyCode::Left | KeyCode::Char('h') if *col > 0 => {
+                            *col -= 1;
+                            *row = (*row).min(columns[*col].len().saturating_sub(1));
+                        }
+                        KeyCode::Right | KeyCode::Char('l') if *col < 3 => {
+                            *col += 1;
+                            *row = (*row).min(columns[*col].len().saturating_sub(1));
+                        }
+                        KeyCode::Up | KeyCode::Char('k') if *row > 0 => {
+                            *row -= 1;
+                        }
+                        KeyCode::Down | KeyCode::Char('j') => {
+                            let col_len = columns[*col].len();
+                            if *row + 1 < col_len {
+                                *row += 1;
+                            }
+                        }
+                        KeyCode::Enter if !columns[*col].is_empty() => {
+                            *mode = TaskBoardMode::Detail;
+                        }
+                        // n — new task
+                        KeyCode::Char('n') => {
+                            *mode = TaskBoardMode::NewTask {
+                                input: String::new(),
+                            };
+                        }
+                        // d — cancel task
+                        KeyCode::Char('d') if !columns[*col].is_empty() => {
+                            if let Some(task) = columns[*col].get(*row) {
+                                crate::tasks::handle(
+                                    ctx.home,
+                                    "user",
+                                    &serde_json::json!({
+                                        "action": "update",
+                                        "id": task.id,
+                                        "status": "cancelled",
+                                    }),
+                                );
+                                *items = crate::tasks::list_all(ctx.home);
+                                let new_cols = crate::render::task_board_columns(items);
+                                *row = (*row).min(new_cols[*col].len().saturating_sub(1));
+                            }
+                        }
+                        // a — assign
+                        KeyCode::Char('a') if !columns[*col].is_empty() => {
+                            // Build choices: teams + agents from teams.json members
+                            let team_list = crate::teams::list(ctx.home);
+                            let mut choices: Vec<String> = Vec::new();
+                            if let Some(teams) = team_list["teams"].as_array() {
+                                for t in teams {
+                                    if let Some(name) = t["name"].as_str() {
+                                        choices.push(format!("🏷 {name}"));
+                                    }
+                                    if let Some(members) = t["members"].as_array() {
+                                        for m in members {
+                                            if let Some(n) = m.as_str() {
+                                                if !choices.contains(&n.to_string()) {
+                                                    choices.push(n.to_string());
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            if choices.is_empty() {
+                                choices.push("(no agents/teams)".to_string());
+                            }
+                            *mode = TaskBoardMode::Assign {
+                                choices,
+                                selected: 0,
+                            };
+                        }
+                        // Shift+← / Shift+→ — move task status
+                        KeyCode::Char('H') if !columns[*col].is_empty() && *col > 0 => {
+                            if let Some(task) = columns[*col].get(*row) {
+                                let update = match *col {
+                                    1 => Some(("priority", "low")),   // Open → Backlog
+                                    2 => Some(("status", "open")),    // InProgress → Open
+                                    3 => Some(("status", "claimed")), // Done → InProgress
+                                    _ => None,
+                                };
+                                if let Some((field, val)) = update {
+                                    crate::tasks::handle(
+                                        ctx.home,
+                                        "user",
+                                        &serde_json::json!({"action": "update", "id": task.id, field: val}),
+                                    );
+                                    *items = crate::tasks::list_all(ctx.home);
+                                    *col -= 1;
+                                    let new_cols = crate::render::task_board_columns(items);
+                                    *row = (*row).min(new_cols[*col].len().saturating_sub(1));
+                                }
+                            }
+                        }
+                        KeyCode::Char('L') if !columns[*col].is_empty() && *col < 3 => {
+                            if let Some(task) = columns[*col].get(*row) {
+                                let update = match *col {
+                                    0 => Some(("priority", "normal")), // Backlog → Open
+                                    1 => Some(("status", "claimed")),  // Open → InProgress
+                                    2 => Some(("status", "done")),     // InProgress → Done
+                                    _ => None,
+                                };
+                                if let Some((field, val)) = update {
+                                    crate::tasks::handle(
+                                        ctx.home,
+                                        "user",
+                                        &serde_json::json!({"action": "update", "id": task.id, field: val}),
+                                    );
+                                    *items = crate::tasks::list_all(ctx.home);
+                                    *col += 1;
+                                    let new_cols = crate::render::task_board_columns(items);
+                                    *row = (*row).min(new_cols[*col].len().saturating_sub(1));
+                                }
+                            }
+                        }
+                        KeyCode::Esc | KeyCode::Char('q') => {
+                            *overlay = Overlay::None;
+                        }
+                        _ => {}
+                    }
                 }
             }
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1208,10 +1208,11 @@ pub fn render_tasks(
     items: &[crate::tasks::Task],
     sel_col: usize,
     sel_row: usize,
-    detail: bool,
+    mode: &crate::app::TaskBoardMode,
 ) {
+    use crate::app::TaskBoardMode;
     let count = items.len();
-    let title = format!(" Task Board ({count}) | ←→ column | ↑↓ select | Enter detail | q close ");
+    let title = format!(" Task Board ({count}) | ←→ move | n new | a assign | d cancel | q close ");
     let inner = render_overlay_frame(frame, Color::Blue, &title);
 
     if items.is_empty() {
@@ -1225,7 +1226,7 @@ pub fn render_tasks(
     let columns = task_board_columns(items);
 
     // Detail view for selected task
-    if detail {
+    if matches!(mode, TaskBoardMode::Detail) {
         if let Some(task) = columns[sel_col].get(sel_row) {
             let mut lines = vec![
                 Line::from(Span::styled(
@@ -1336,6 +1337,72 @@ pub fn render_tasks(
             lines.push(Line::from(Span::styled(text, style)));
         }
         frame.render_widget(Paragraph::new(lines), block_inner);
+    }
+
+    // Overlay sub-modes rendered on top of the kanban
+    match mode {
+        TaskBoardMode::NewTask { input } => {
+            let w = 50u16.min(inner.width.saturating_sub(4));
+            let popup = Rect::new(
+                inner.x + (inner.width.saturating_sub(w)) / 2,
+                inner.y + inner.height / 3,
+                w,
+                3,
+            );
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Green))
+                .title(Span::styled(
+                    " New Task ",
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            let inner_popup = block.inner(popup);
+            frame.render_widget(block, popup);
+            let cursor = format!("{input}▏");
+            frame.render_widget(
+                Paragraph::new(cursor).style(Style::default().fg(Color::White)),
+                inner_popup,
+            );
+        }
+        TaskBoardMode::Assign { choices, selected } => {
+            let h = (choices.len() as u16 + 2).min(inner.height.saturating_sub(2));
+            let w = 40u16.min(inner.width.saturating_sub(4));
+            let popup = Rect::new(
+                inner.x + (inner.width.saturating_sub(w)) / 2,
+                inner.y + (inner.height.saturating_sub(h)) / 2,
+                w,
+                h,
+            );
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(Span::styled(
+                    " Assign to ",
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            let inner_popup = block.inner(popup);
+            frame.render_widget(block, popup);
+            let mut lines: Vec<Line> = Vec::new();
+            for (i, name) in choices.iter().enumerate() {
+                let style = if i == *selected {
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                lines.push(Line::from(Span::styled(name.as_str(), style)));
+            }
+            frame.render_widget(Paragraph::new(lines), inner_popup);
+        }
+        _ => {}
     }
 }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -253,4 +253,103 @@ mod tests {
         assert!(r["error"].as_str().is_some());
         std::fs::remove_dir_all(&home).ok();
     }
+
+    #[test]
+    fn task_board_create_via_handle() {
+        let home = tmp_home("board_create");
+        let r = handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "create", "title": "new feature", "priority": "normal"}),
+        );
+        assert_eq!(r["status"], "created");
+        let tasks = list_all(&home);
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].title, "new feature");
+        assert_eq!(tasks[0].status, "open");
+        assert_eq!(tasks[0].priority, "normal");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn task_board_move_status() {
+        let home = tmp_home("board_move");
+        // Create a low-priority task (Backlog)
+        handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "create", "title": "item", "priority": "low"}),
+        );
+        let tasks = list_all(&home);
+        let id = &tasks[0].id;
+
+        // Backlog → Open: change priority low → normal
+        handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "update", "id": id, "priority": "normal"}),
+        );
+        let t = &list_all(&home)[0];
+        assert_eq!(t.priority, "normal");
+        assert_eq!(t.status, "open");
+
+        // Open → In Progress: change status → claimed
+        handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "update", "id": id, "status": "claimed"}),
+        );
+        assert_eq!(list_all(&home)[0].status, "claimed");
+
+        // In Progress → Done: change status → done
+        handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "update", "id": id, "status": "done"}),
+        );
+        assert_eq!(list_all(&home)[0].status, "done");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn task_board_assign_agent() {
+        let home = tmp_home("board_assign");
+        handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "create", "title": "fix bug"}),
+        );
+        let id = &list_all(&home)[0].id.clone();
+        handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "update", "id": id, "assignee": "at-dev-2"}),
+        );
+        assert_eq!(list_all(&home)[0].assignee.as_deref(), Some("at-dev-2"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn task_board_cancel() {
+        let home = tmp_home("board_cancel");
+        handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "create", "title": "remove me"}),
+        );
+        let id = &list_all(&home)[0].id.clone();
+        handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "update", "id": id, "status": "cancelled"}),
+        );
+        assert_eq!(list_all(&home)[0].status, "cancelled");
+        // Cancelled tasks excluded from kanban columns
+        let all = list_all(&home);
+        let columns = crate::render::task_board_columns(&all);
+        let total: usize = columns.iter().map(|c| c.len()).sum();
+        assert_eq!(total, 0, "cancelled task should not appear in any column");
+        std::fs::remove_dir_all(&home).ok();
+    }
 }


### PR DESCRIPTION
## Summary
Full CRUD operations for the kanban task board overlay.

### Keyboard shortcuts
| Key | Action |
|-----|--------|
| `n` | New task (inline input popup) |
| `H` / `L` | Move task left/right between columns |
| `a` | Assign (two-step popup: teams 🏷 + agents) |
| `d` | Cancel task (disappears from board) |
| `Enter` | Detail view (read-only) |
| `↑↓` / `jk` | Navigate within column |
| `←→` / `hl` | Switch column focus |
| `Esc` / `q` | Close overlay / back from sub-mode |

### Column transitions (H/L)
| Move | Effect |
|------|--------|
| Backlog → Open | priority: low → normal |
| Open → In Progress | status: open → claimed |
| In Progress → Done | status: claimed → done |
| Reverse also supported | |

### Architecture
- `TaskBoardMode` enum: Board / Detail / NewTask / Assign
- All mutations via `tasks::handle` (file-locked atomic writes)
- Items reloaded after every mutation (concurrent-safe)
- Assign popup lists teams (🏷 prefix) + team members

### Changes (5 files, +366/-38)
1. `src/app/overlay.rs` — TaskBoardMode enum + full CRUD keyboard handler
2. `src/app/dispatch.rs` — updated overlay creation
3. `src/app/mod.rs` — re-export TaskBoardMode, updated render call
4. `src/render.rs` — NewTask input popup + Assign selector popup
5. `src/tasks.rs` — 4 new CRUD tests

### Tests (4 new)
- `task_board_create_via_handle` ✓
- `task_board_move_status` — Backlog→Open→InProgress→Done ✓
- `task_board_assign_agent` ✓
- `task_board_cancel` — cancelled excluded from columns ✓

### Gates
`cargo fmt` ✓ | `cargo clippy` ✓ | `cargo test` ✓ (681 bin tests)

Ref: task t-20260422170836. This completes the Task Board + Team v2 feature set.