### PR TITLE
feat(tui): Shift+D mark-done shortcut for task board

### DIFF
--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -634,6 +634,22 @@ pub(super) fn handle_key(
                                 *row = (*row).min(new_cols[*col].len().saturating_sub(1));
                             }
                         }
+                        // D (Shift+D) — mark task done from any column
+                        KeyCode::Char('D') if !columns[*col].is_empty() => {
+                            if let Some(task) = columns[*col].get(*row) {
+                                crate::tasks::handle(
+                                    ctx.home,
+                                    "user",
+                                    &serde_json::json!({
+                                        "action": "done",
+                                        "id": task.id,
+                                    }),
+                                );
+                                *items = crate::tasks::list_all(ctx.home);
+                                let new_cols = crate::render::task_board_columns(items);
+                                *row = (*row).min(new_cols[*col].len().saturating_sub(1));
+                            }
+                        }
                         // a — assign
                         KeyCode::Char('a') if !columns[*col].is_empty() => {
                             let mut choices: Vec<(String, String)> = Vec::new();

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -485,17 +485,35 @@ mod tests {
 
     #[test]
     fn task_board_shift_d_marks_done() {
-        let home = tmp_home("board_shift_d");
-        handle(
-            &home,
-            "user",
-            &serde_json::json!({"action": "create", "title": "finish me", "priority": "low"}),
-        );
-        let id = list_all(&home)[0].id.clone();
-        // Task starts in backlog (low priority) — Shift+D should mark done from any column
-        let r = handle(&home, "user", &serde_json::json!({"action": "done", "id": id}));
-        assert_eq!(r["status"], "done");
-        assert_eq!(list_all(&home)[0].status, "done");
-        std::fs::remove_dir_all(&home).ok();
+        // Test Shift+D (done action) from all 3 non-done columns
+        for (label, setup) in [
+            ("backlog", vec![("create", r#"{"action":"create","title":"t","priority":"low"}"#)]),
+            ("open", vec![("create", r#"{"action":"create","title":"t","priority":"normal"}"#)]),
+            (
+                "in_progress",
+                vec![
+                    ("create", r#"{"action":"create","title":"t","priority":"normal"}"#),
+                    ("claim", r#"{"action":"claim","id":"__ID__"}"#),
+                ],
+            ),
+        ] {
+            let home = tmp_home(&format!("shift_d_{label}"));
+            let mut id = String::new();
+            for (_, json_str) in &setup {
+                let json_str = json_str.replace("__ID__", &id);
+                let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+                let r = handle(&home, "user", &v);
+                if let Some(i) = r["id"].as_str() {
+                    id = i.to_string();
+                }
+            }
+            if id.is_empty() {
+                id = list_all(&home)[0].id.clone();
+            }
+            let r = handle(&home, "user", &serde_json::json!({"action": "done", "id": id}));
+            assert_eq!(r["status"], "done", "failed for {label}");
+            assert_eq!(list_all(&home)[0].status, "done", "failed for {label}");
+            std::fs::remove_dir_all(&home).ok();
+        }
     }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -482,4 +482,20 @@ mod tests {
         assert_eq!(total, 0, "cancelled task should not appear in any column");
         std::fs::remove_dir_all(&home).ok();
     }
+
+    #[test]
+    fn task_board_shift_d_marks_done() {
+        let home = tmp_home("board_shift_d");
+        handle(
+            &home,
+            "user",
+            &serde_json::json!({"action": "create", "title": "finish me", "priority": "low"}),
+        );
+        let id = list_all(&home)[0].id.clone();
+        // Task starts in backlog (low priority) — Shift+D should mark done from any column
+        let r = handle(&home, "user", &serde_json::json!({"action": "done", "id": id}));
+        assert_eq!(r["status"], "done");
+        assert_eq!(list_all(&home)[0].status, "done");
+        std::fs::remove_dir_all(&home).ok();
+    }
 }


### PR DESCRIPTION
## Summary

Add `D` (Shift+D) keyboard shortcut in Task Board overlay that marks the selected task as done from any column (backlog, open, in-progress).

## Changes

- **`src/app/overlay.rs`**: Added `KeyCode::Char('D')` handler in `TaskBoardMode::Board` between `d` (cancel) and `a` (assign). Calls `tasks::handle` with `done` action, refreshes items, adjusts cursor.
- **`src/tasks.rs`**: Added `task_board_shift_d_marks_done` test — creates a low-priority task, marks done via `done` action, asserts status.

## Task
`t-20260422232546`

All tests pass (`cargo test` green).