### PR TITLE
feat(tui): queue notifications while panes are composing

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -43,7 +43,7 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
         Action::Forward(key) => {
             let bytes = crate::tui::key_to_bytes(key.code, key.modifiers);
             if !bytes.is_empty() {
-                super::write_to_focused(ctx.layout, ctx.registry, &bytes);
+                super::write_to_focused(ctx.home, ctx.layout, ctx.registry, &bytes);
             }
         }
         Action::NewTab => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -766,7 +766,9 @@ fn flush_notifications_for_pane<F>(home: &Path, pane: &mut Pane, mut injector: F
 where
     F: FnMut(&str) -> anyhow::Result<()>,
 {
-    if pane.pending_notification_count == 0 || pane.is_composing() {
+    if pane.pending_notification_count == 0
+        || notification_queue::is_composing(home, &pane.agent_name)
+    {
         return;
     }
     let queued = notification_queue::drain(home, &pane.agent_name);
@@ -883,6 +885,28 @@ mod tests {
         });
         assert_eq!(flushed, vec!["queued".to_string()]);
         assert_eq!(pane.pending_notification_count, 0);
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn flush_respects_disk_compose_state_for_fresh_pane() {
+        let home = tmp_home("flush-compose-disk");
+        let mut pane = pane("agent1");
+        notification_queue::record_input_activity(&home, "agent1");
+        notification_queue::enqueue(&home, "agent1", "queued").expect("queue notification");
+        pane.pending_notification_count = notification_queue::pending_count(&home, "agent1");
+
+        let mut flushed = Vec::new();
+        flush_notifications_for_pane(&home, &mut pane, |text| {
+            flushed.push(text.to_string());
+            Ok(())
+        });
+
+        assert!(
+            flushed.is_empty(),
+            "fresh pane must respect disk compose state"
+        );
+        assert_eq!(pane.pending_notification_count, 1);
         std::fs::remove_dir_all(home).ok();
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,6 +20,7 @@ use crate::agent::{self, AgentRegistry};
 use crate::backend::Backend;
 use crate::keybinds::KeyHandler;
 use crate::layout::{Layout, Pane};
+use crate::notification_queue;
 use crate::render;
 use overlay::{CloseTarget, Overlay, OverlayCtx};
 
@@ -309,6 +310,8 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             render::resize_panes(pane_area, &mut layout, &registry);
             needs_resize = false;
         }
+        sync_notification_state(&home, &mut layout);
+        flush_idle_notifications(&home, &mut layout);
 
         let repeat_mode = key_handler.in_repeat();
 
@@ -460,7 +463,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                                 pane.write_input(&registry, text.as_bytes());
                             }
                             Overlay::None => {
-                                write_to_focused(&layout, &registry, text.as_bytes());
+                                write_to_focused(&home, &mut layout, &registry, text.as_bytes());
                             }
                             _ => {} // ignore paste in non-input overlays
                         }
@@ -725,10 +728,64 @@ fn pane_from_menu_item(
 }
 
 /// Write bytes to the focused pane's PTY (Local) or remote bridge (Remote).
-fn write_to_focused(layout: &Layout, registry: &AgentRegistry, bytes: &[u8]) {
-    if let Some(pane) = layout.active_tab().and_then(|t| t.focused_pane()) {
+fn write_to_focused(home: &Path, layout: &mut Layout, registry: &AgentRegistry, bytes: &[u8]) {
+    if let Some(pane) = layout.active_tab_mut().and_then(|t| t.focused_pane_mut()) {
+        notification_queue::record_input_activity(home, &pane.agent_name);
         pane.write_input(registry, bytes);
     }
+}
+
+fn sync_notification_state(home: &Path, layout: &mut Layout) {
+    for tab in &mut layout.tabs {
+        let pane_ids = tab.root().pane_ids();
+        for pane_id in pane_ids {
+            if let Some(pane) = tab.root_mut().find_pane_mut(pane_id) {
+                pane.pending_notification_count =
+                    notification_queue::pending_count(home, &pane.agent_name);
+            }
+        }
+    }
+}
+
+fn flush_idle_notifications(home: &Path, layout: &mut Layout) {
+    for tab in &mut layout.tabs {
+        let pane_ids = tab.root().pane_ids();
+        for pane_id in pane_ids {
+            let Some(pane) = tab.root_mut().find_pane_mut(pane_id) else {
+                continue;
+            };
+            let agent_name = pane.agent_name.clone();
+            flush_notifications_for_pane(home, pane, |text| {
+                crate::inbox::inject_notification(home, &agent_name, text)
+            });
+        }
+    }
+}
+
+fn flush_notifications_for_pane<F>(home: &Path, pane: &mut Pane, mut injector: F)
+where
+    F: FnMut(&str) -> anyhow::Result<()>,
+{
+    if pane.pending_notification_count == 0 || pane.is_composing() {
+        return;
+    }
+    let queued = notification_queue::drain(home, &pane.agent_name);
+    if queued.is_empty() {
+        pane.pending_notification_count = 0;
+        return;
+    }
+
+    let mut failed_at = None;
+    for (idx, notification) in queued.iter().enumerate() {
+        if injector(&notification.text).is_err() {
+            failed_at = Some(idx);
+            break;
+        }
+    }
+    if let Some(idx) = failed_at {
+        notification_queue::requeue_all(home, &pane.agent_name, &queued[idx..]);
+    }
+    pane.pending_notification_count = notification_queue::pending_count(home, &pane.agent_name);
 }
 
 /// Adjust scroll offset of the focused pane by `delta` lines (positive = up, negative = down).
@@ -776,4 +833,56 @@ fn agent_is_alive(registry: &AgentRegistry, name: &str) -> bool {
         Err(_) => true,
     };
     alive
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::PaneSource;
+    use crate::vterm::VTerm;
+
+    fn tmp_home(suffix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-app-phase2-{}-{}",
+            suffix,
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn pane(name: &str) -> Pane {
+        Pane {
+            agent_name: name.to_string(),
+            vterm: VTerm::new(10, 10),
+            rx: crossbeam::channel::bounded(1).1,
+            id: 1,
+            backend: None,
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
+            selection: None,
+            source: PaneSource::Local,
+        }
+    }
+
+    #[test]
+    fn flush_drains_queue_on_idle() {
+        let home = tmp_home("flush");
+        let mut pane = pane("agent1");
+        notification_queue::enqueue(&home, "agent1", "queued").expect("queue notification");
+        pane.pending_notification_count = notification_queue::pending_count(&home, "agent1");
+        let mut flushed = Vec::new();
+        flush_notifications_for_pane(&home, &mut pane, |text| {
+            flushed.push(text.to_string());
+            Ok(())
+        });
+        assert_eq!(flushed, vec!["queued".to_string()]);
+        assert_eq!(pane.pending_notification_count, 0);
+        std::fs::remove_dir_all(home).ok();
+    }
 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -455,6 +455,8 @@ mod tests {
             scroll_offset: 0,
             has_notification: false,
             fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
             selection: None,
             source: PaneSource::Local,
         }

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -163,6 +163,8 @@ pub(super) fn create_pane(
         scroll_offset: 0,
         has_notification: false,
         fleet_instance_name: None,
+        last_input_at: None,
+        pending_notification_count: 0,
         selection: None,
         source: crate::layout::PaneSource::Local,
     })
@@ -222,6 +224,8 @@ pub(super) fn attach_pane(
         scroll_offset: 0,
         has_notification: false,
         fleet_instance_name: Some(name.to_string()),
+        last_input_at: None,
+        pending_notification_count: 0,
         selection: None,
         source: crate::layout::PaneSource::Local,
     })
@@ -354,6 +358,8 @@ pub(super) fn create_remote_pane(
         scroll_offset: 0,
         has_notification: false,
         fleet_instance_name: Some(name.to_string()),
+        last_input_at: None,
+        pending_notification_count: 0,
         selection: None,
         source: crate::layout::PaneSource::Remote(Arc::new(Mutex::new(client))),
     })

--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -638,6 +638,8 @@ mod tests {
             scroll_offset: 0,
             has_notification: false,
             fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
             selection: None,
             source: PaneSource::Local,
         }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -158,15 +158,49 @@ pub fn notify_agent(home: &Path, agent_name: &str, source: &NotifySource<'_>, te
         text.to_string()
     };
     let notification = format!("[{source}] {display_text}{}", source.reply_hint());
+    let _ = route_notification(home, agent_name, &notification, |msg| {
+        inject_notification(home, agent_name, msg)
+    });
+}
 
-    // Use API socket to inject (doesn't kick attach clients)
-    let _ = crate::api::call(
+pub fn inject_notification(
+    home: &Path,
+    agent_name: &str,
+    notification: &str,
+) -> anyhow::Result<()> {
+    let resp = crate::api::call(
         home,
         &serde_json::json!({
             "method": crate::api::method::INJECT,
-            "params": {"name": agent_name, "data": notification}
+            "params": {"name": agent_name, "data": notification, "raw": true}
         }),
-    );
+    )?;
+    if resp["ok"].as_bool() == Some(true) {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "{}",
+            resp["error"]
+                .as_str()
+                .unwrap_or("notification inject failed")
+        );
+    }
+}
+
+fn route_notification<F>(
+    home: &Path,
+    agent_name: &str,
+    notification: &str,
+    mut injector: F,
+) -> anyhow::Result<()>
+where
+    F: FnMut(&str) -> anyhow::Result<()>,
+{
+    if crate::notification_queue::is_composing(home, agent_name) {
+        crate::notification_queue::enqueue(home, agent_name, notification)?;
+        return Ok(());
+    }
+    injector(notification)
 }
 
 #[cfg(test)]
@@ -188,6 +222,18 @@ mod tests {
             kind: None,
             timestamp: "2025-01-01T00:00:00Z".to_string(),
         }
+    }
+
+    fn mark_composing(home: &Path, agent: &str) {
+        std::fs::create_dir_all(home.join("metadata")).ok();
+        std::fs::write(
+            home.join("metadata").join(format!("{agent}.json")),
+            format!(
+                "{{\"last_input_epoch_ms\":{}}}",
+                chrono::Utc::now().timestamp_millis()
+            ),
+        )
+        .ok();
     }
 
     #[test]
@@ -254,6 +300,35 @@ mod tests {
             assert_eq!(msgs[0].from, format!("t{i}"));
         }
 
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn notify_queues_when_composing() {
+        let home = tmp_home("notify-queue");
+        mark_composing(&home, "agent1");
+        let mut injected = false;
+        route_notification(&home, "agent1", "queued", |_| {
+            injected = true;
+            Ok(())
+        })
+        .expect("route should queue");
+        assert!(!injected);
+        assert_eq!(crate::notification_queue::pending_count(&home, "agent1"), 1);
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn notify_injects_when_idle() {
+        let home = tmp_home("notify-idle");
+        let mut injected = Vec::new();
+        route_notification(&home, "agent1", "sent", |msg| {
+            injected.push(msg.to_string());
+            Ok(())
+        })
+        .expect("route should inject");
+        assert_eq!(injected, vec!["sent".to_string()]);
+        assert_eq!(crate::notification_queue::pending_count(&home, "agent1"), 0);
         fs::remove_dir_all(&home).ok();
     }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -69,8 +69,9 @@ impl Pane {
 
     #[cfg(test)]
     pub fn is_composing(&self) -> bool {
-        self.last_input_at
-            .is_some_and(|instant| instant.elapsed() < COMPOSE_IDLE_TIMEOUT)
+        self.last_input_at.is_some_and(|instant| {
+            instant.elapsed() < crate::notification_queue::COMPOSE_IDLE_TIMEOUT
+        })
     }
 
     /// Drain pending output into the local VTerm.
@@ -1585,8 +1586,11 @@ mod tests {
     #[test]
     fn pane_not_composing_after_idle() {
         let mut pane = leaf(1, "agent");
-        pane.last_input_at =
-            Some(Instant::now() - COMPOSE_IDLE_TIMEOUT - std::time::Duration::from_millis(1));
+        pane.last_input_at = Some(
+            Instant::now()
+                - crate::notification_queue::COMPOSE_IDLE_TIMEOUT
+                - std::time::Duration::from_millis(1),
+        );
         assert!(!pane.is_composing());
     }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -8,7 +8,6 @@ use crate::vterm::VTerm;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use unicode_width::UnicodeWidthStr;
 
 /// How a pane's input/resize is delivered to the underlying process.
 ///

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -68,6 +68,7 @@ impl Pane {
         self.last_input_at = Some(Instant::now());
     }
 
+    #[cfg(test)]
     pub fn is_composing(&self) -> bool {
         self.last_input_at
             .is_some_and(|instant| instant.elapsed() < COMPOSE_IDLE_TIMEOUT)

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,7 +3,6 @@
 use crate::agent::{self, AgentRegistry};
 use crate::backend::Backend;
 use crate::bridge_client::BridgeClient;
-use crate::notification_queue::COMPOSE_IDLE_TIMEOUT;
 use crate::vterm::VTerm;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -1323,6 +1322,7 @@ impl Layout {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::notification_queue::COMPOSE_IDLE_TIMEOUT;
     use unicode_width::UnicodeWidthStr;
 
     // --- ratio_bounds invariants (covers Round A #3 + #6) ---

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1323,7 +1323,6 @@ impl Layout {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::notification_queue::COMPOSE_IDLE_TIMEOUT;
     use unicode_width::UnicodeWidthStr;
 
     // --- ratio_bounds invariants (covers Round A #3 + #6) ---

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,9 +3,12 @@
 use crate::agent::{self, AgentRegistry};
 use crate::backend::Backend;
 use crate::bridge_client::BridgeClient;
+use crate::notification_queue::COMPOSE_IDLE_TIMEOUT;
 use crate::vterm::VTerm;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use unicode_width::UnicodeWidthStr;
 
 /// How a pane's input/resize is delivered to the underlying process.
 ///
@@ -36,6 +39,10 @@ pub struct Pane {
     pub has_notification: bool,
     /// Fleet instance name (key in fleet.yaml). None for shell panes.
     pub fleet_instance_name: Option<String>,
+    /// Last time the user typed into this pane from the TUI.
+    pub last_input_at: Option<Instant>,
+    /// Count of pending queued notifications for this pane.
+    pub pending_notification_count: usize,
     /// Active text selection (grid coordinates within this pane's VTerm).
     pub selection: Option<Selection>,
     /// Whether input/resize go to a local PTY (via registry) or a remote
@@ -58,6 +65,15 @@ impl Pane {
         self.display_name.as_deref().unwrap_or(&self.agent_name)
     }
 
+    pub fn mark_input_activity(&mut self) {
+        self.last_input_at = Some(Instant::now());
+    }
+
+    pub fn is_composing(&self) -> bool {
+        self.last_input_at
+            .is_some_and(|instant| instant.elapsed() < COMPOSE_IDLE_TIMEOUT)
+    }
+
     /// Drain pending output into the local VTerm.
     pub fn drain_output(&mut self) {
         while let Ok(data) = self.rx.try_recv() {
@@ -78,7 +94,8 @@ impl Pane {
     /// through the pane's BridgeClient. Errors are swallowed — a broken pane
     /// surfaces via its output channel closing, which the app handles at the
     /// next drain.
-    pub fn write_input(&self, registry: &AgentRegistry, bytes: &[u8]) {
+    pub fn write_input(&mut self, registry: &AgentRegistry, bytes: &[u8]) {
+        self.mark_input_activity();
         match &self.source {
             PaneSource::Local => {
                 let reg = agent::lock_registry(registry);
@@ -865,6 +882,11 @@ impl Tab {
         self.root().find_pane(self.focus_id)
     }
 
+    pub fn focused_pane_mut(&mut self) -> Option<&mut Pane> {
+        let focus_id = self.focus_id;
+        self.root_mut().find_pane_mut(focus_id)
+    }
+
     pub fn cycle_focus(&mut self) {
         let ids = self.root().pane_ids();
         if let Some(pos) = ids.iter().position(|&id| id == self.focus_id) {
@@ -1411,6 +1433,8 @@ mod tests {
                 scroll_offset: 0,
                 has_notification: false,
                 fleet_instance_name: None,
+                last_input_at: None,
+                pending_notification_count: 0,
                 selection: None,
                 source: PaneSource::Local,
             }))),
@@ -1425,6 +1449,8 @@ mod tests {
                 scroll_offset: 0,
                 has_notification: false,
                 fleet_instance_name: None,
+                last_input_at: None,
+                pending_notification_count: 0,
                 selection: None,
                 source: PaneSource::Local,
             }))),
@@ -1458,6 +1484,8 @@ mod tests {
                 scroll_offset: 0,
                 has_notification: false,
                 fleet_instance_name: None,
+                last_input_at: None,
+                pending_notification_count: 0,
                 selection: None,
                 source: PaneSource::Local,
             }))),
@@ -1472,6 +1500,8 @@ mod tests {
                 scroll_offset: 0,
                 has_notification: false,
                 fleet_instance_name: None,
+                last_input_at: None,
+                pending_notification_count: 0,
                 selection: None,
                 source: PaneSource::Local,
             }))),
@@ -1532,6 +1562,8 @@ mod tests {
             scroll_offset: 0,
             has_notification: false,
             fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
             selection: None,
             source: PaneSource::Local,
         }
@@ -1541,6 +1573,21 @@ mod tests {
         let mut p = leaf(id, name);
         p.backend = Some(Backend::ClaudeCode);
         p
+    }
+
+    #[test]
+    fn pane_composing_after_input() {
+        let mut pane = leaf(1, "agent");
+        pane.mark_input_activity();
+        assert!(pane.is_composing());
+    }
+
+    #[test]
+    fn pane_not_composing_after_idle() {
+        let mut pane = leaf(1, "agent");
+        pane.last_input_at =
+            Some(Instant::now() - COMPOSE_IDLE_TIMEOUT - std::time::Duration::from_millis(1));
+        assert!(!pane.is_composing());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod keybinds;
 mod layout;
 mod mcp;
 mod mcp_config;
+mod notification_queue;
 mod process;
 mod protocol;
 mod quickstart;

--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -1,0 +1,149 @@
+use crate::agent_ops;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+pub const COMPOSE_IDLE_TIMEOUT: Duration = Duration::from_secs(3);
+const COMPOSE_METADATA_KEY: &str = "last_input_epoch_ms";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueuedNotification {
+    pub text: String,
+    pub timestamp: String,
+}
+
+fn queue_path(home: &Path, agent_name: &str) -> PathBuf {
+    home.join("notification-queue")
+        .join(format!("{agent_name}.jsonl"))
+}
+
+fn draining_path(home: &Path, agent_name: &str) -> PathBuf {
+    queue_path(home, agent_name).with_extension("draining")
+}
+
+pub fn record_input_activity(home: &Path, agent_name: &str) {
+    agent_ops::save_metadata(
+        home,
+        agent_name,
+        COMPOSE_METADATA_KEY,
+        json!(chrono::Utc::now().timestamp_millis()),
+    );
+}
+
+pub fn is_composing(home: &Path, agent_name: &str) -> bool {
+    let meta_path = home.join("metadata").join(format!("{agent_name}.json"));
+    let meta = match std::fs::read_to_string(meta_path) {
+        Ok(content) => content,
+        Err(_) => return false,
+    };
+    let value: serde_json::Value = match serde_json::from_str(&meta) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let Some(last_input_ms) = value[COMPOSE_METADATA_KEY].as_i64() else {
+        return false;
+    };
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    now_ms.saturating_sub(last_input_ms) < COMPOSE_IDLE_TIMEOUT.as_millis() as i64
+}
+
+pub fn enqueue(home: &Path, agent_name: &str, text: &str) -> anyhow::Result<()> {
+    let path = queue_path(home, agent_name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let msg = QueuedNotification {
+        text: text.to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    writeln!(file, "{}", serde_json::to_string(&msg)?)?;
+    Ok(())
+}
+
+pub fn pending_count(home: &Path, agent_name: &str) -> usize {
+    let mut count = 0;
+    for path in [
+        queue_path(home, agent_name),
+        draining_path(home, agent_name),
+    ] {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        count += content.lines().count();
+    }
+    count
+}
+
+pub fn drain(home: &Path, agent_name: &str) -> Vec<QueuedNotification> {
+    let path = queue_path(home, agent_name);
+    let tmp = draining_path(home, agent_name);
+    if tmp.exists() {
+        return read_drain_file(&tmp);
+    }
+    if !path.exists() {
+        return Vec::new();
+    }
+    if std::fs::rename(&path, &tmp).is_err() {
+        return Vec::new();
+    }
+    read_drain_file(&tmp)
+}
+
+pub fn requeue_all(home: &Path, agent_name: &str, notifications: &[QueuedNotification]) {
+    for notification in notifications {
+        let _ = enqueue(home, agent_name, &notification.text);
+    }
+}
+
+fn read_drain_file(path: &Path) -> Vec<QueuedNotification> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let notifications = content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<QueuedNotification>(line).ok())
+        .collect::<Vec<_>>();
+    let _ = std::fs::remove_file(path);
+    notifications
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(suffix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-notification-queue-{}-{}",
+            suffix,
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    #[test]
+    fn pending_count_tracks_enqueued_notifications() {
+        let home = tmp_home("count");
+        enqueue(&home, "agent1", "a").expect("enqueue a");
+        enqueue(&home, "agent1", "b").expect("enqueue b");
+        assert_eq!(pending_count(&home, "agent1"), 2);
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn drain_roundtrip() {
+        let home = tmp_home("drain");
+        enqueue(&home, "agent1", "a").expect("enqueue a");
+        enqueue(&home, "agent1", "b").expect("enqueue b");
+        let drained = drain(&home, "agent1");
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].text, "a");
+        assert_eq!(pending_count(&home, "agent1"), 0);
+        std::fs::remove_dir_all(home).ok();
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -398,8 +398,7 @@ fn render_node(
 struct PaneBorderInfo {
     area: Rect,
     border_style: Style,
-    title: String,
-    title_style: Style,
+    title_segments: Vec<(String, Style)>,
     priority: u8,
 }
 
@@ -468,11 +467,7 @@ fn render_pane(
         (s, s, 1u8)
     };
 
-    let title = if pane.backend.is_some() {
-        format!(" {} [{}] ", pane.label(), state.display_name())
-    } else {
-        format!(" {} ", pane.label())
-    };
+    let title_segments = pane_title_segments(pane, state, title_style);
 
     // Inner (content) area = outer shrunk 1 cell on every side, matching the
     // former Block::ALL inner. Borders are drawn later in `render_border_grid`
@@ -489,8 +484,7 @@ fn render_pane(
         return PaneBorderInfo {
             area,
             border_style,
-            title,
-            title_style,
+            title_segments,
             priority,
         };
     }
@@ -535,10 +529,34 @@ fn render_pane(
     PaneBorderInfo {
         area,
         border_style,
-        title,
-        title_style,
+        title_segments,
         priority,
     }
+}
+
+fn pane_title_segments(
+    pane: &crate::layout::Pane,
+    state: AgentState,
+    title_style: Style,
+) -> Vec<(String, Style)> {
+    let mut segments = Vec::new();
+    let base = if pane.backend.is_some() {
+        format!(" {} [{}]", pane.label(), state.display_name())
+    } else {
+        format!(" {}", pane.label())
+    };
+    segments.push((base, title_style));
+    if pane.pending_notification_count > 0 {
+        segments.push((
+            format!(" [{}]", pane.pending_notification_count),
+            Style::default()
+                .bg(Color::Yellow)
+                .fg(Color::Black)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    segments.push((" ".to_string(), title_style));
+    segments
 }
 
 // --- Pane border grid (joined box-drawing across shared edges) ---
@@ -686,34 +704,36 @@ fn render_pane_titles(frame: &mut Frame, infos: &[PaneBorderInfo]) {
         let buf_right = buf_area.x.saturating_add(buf_area.width);
         let buf_bottom = buf_area.y.saturating_add(buf_area.height);
         let mut x = area.x.saturating_add(1);
-        for g in info.title.chars() {
-            // Unicode width fits in a `u8` in practice; clamp to u16 so a
-            // future width > 65535 would still terminate the loop safely.
-            let w = u16::try_from(UnicodeWidthChar::width(g).unwrap_or(0)).unwrap_or(u16::MAX);
-            if w == 0 {
-                continue;
-            }
-            if x.saturating_add(w) > last_usable_x {
-                break;
-            }
-            if x >= buf_right || y >= buf_bottom {
-                break;
-            }
-            let cell = &mut buf[(x, y)];
-            cell.set_char(g);
-            cell.set_style(info.title_style);
-            // For wide chars, blank out the trailing cells so residual border
-            // glyphs don't peek through.
-            for off in 1..w {
-                let tx = x.saturating_add(off);
-                if tx >= buf_right {
+        for (segment, style) in &info.title_segments {
+            for g in segment.chars() {
+                // Unicode width fits in a `u8` in practice; clamp to u16 so a
+                // future width > 65535 would still terminate the loop safely.
+                let w = u16::try_from(UnicodeWidthChar::width(g).unwrap_or(0)).unwrap_or(u16::MAX);
+                if w == 0 {
+                    continue;
+                }
+                if x.saturating_add(w) > last_usable_x {
                     break;
                 }
-                let trail = &mut buf[(tx, y)];
-                trail.set_char(' ');
-                trail.set_style(info.title_style);
+                if x >= buf_right || y >= buf_bottom {
+                    break;
+                }
+                let cell = &mut buf[(x, y)];
+                cell.set_char(g);
+                cell.set_style(*style);
+                // For wide chars, blank out the trailing cells so residual border
+                // glyphs don't peek through.
+                for off in 1..w {
+                    let tx = x.saturating_add(off);
+                    if tx >= buf_right {
+                        break;
+                    }
+                    let trail = &mut buf[(tx, y)];
+                    trail.set_char(' ');
+                    trail.set_style(*style);
+                }
+                x = x.saturating_add(w);
             }
-            x = x.saturating_add(w);
         }
     }
 }
@@ -1516,14 +1536,15 @@ pub fn render_scratch_shell(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::layout::{Pane, PaneSource};
+    use crate::vterm::VTerm;
     use std::collections::HashMap;
 
     fn info(x: u16, y: u16, w: u16, h: u16) -> PaneBorderInfo {
         PaneBorderInfo {
             area: Rect::new(x, y, w, h),
             border_style: Style::default(),
-            title: String::new(),
-            title_style: Style::default(),
+            title_segments: Vec::new(),
             priority: 1,
         }
     }
@@ -1675,5 +1696,31 @@ mod tests {
         assert_eq!(open[1].title, "high-old", "high second");
         assert_eq!(open[2].title, "normal-old", "normal oldest third");
         assert_eq!(open[3].title, "normal-new", "normal newest last");
+    }
+
+    #[test]
+    fn badge_shows_pending_count() {
+        let pane = Pane {
+            agent_name: "agent".to_string(),
+            vterm: VTerm::new(10, 10),
+            rx: crossbeam::channel::bounded(1).1,
+            id: 1,
+            backend: None,
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 3,
+            selection: None,
+            source: PaneSource::Local,
+        };
+        let segments = pane_title_segments(&pane, AgentState::Idle, Style::default());
+        let joined = segments
+            .into_iter()
+            .map(|(text, _)| text)
+            .collect::<String>();
+        assert!(joined.contains("[3]"));
     }
 }


### PR DESCRIPTION
## Summary
- track per-pane compose state from recent user input and persist activity to metadata
- queue notifications to disk while a target pane is actively composing, then flush them once the pane goes idle
- show pending notification counts as pane-title badges and add regression tests for compose, queue, flush, and badge behavior

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
