### PR TITLE
feat(tui): ? help overlay for task board

### DIFF
--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -39,6 +39,7 @@ pub enum TaskBoardMode {
         choices: Vec<(String, String)>,
         selected: usize,
     },
+    Help,
 }
 
 pub(super) enum Overlay {
@@ -588,6 +589,12 @@ pub(super) fn handle_key(
                     }
                     _ => {}
                 },
+                TaskBoardMode::Help => match key.code {
+                    KeyCode::Esc | KeyCode::Char('?') => {
+                        *mode = TaskBoardMode::Board;
+                    }
+                    _ => {}
+                },
                 TaskBoardMode::Board => {
                     let columns = crate::render::task_board_columns(items);
                     match key.code {
@@ -729,6 +736,9 @@ pub(super) fn handle_key(
                                 }
                             }
                         }
+                        KeyCode::Char('?') => {
+                            *mode = TaskBoardMode::Help;
+                        }
                         KeyCode::Esc | KeyCode::Char('q') => {
                             *overlay = Overlay::None;
                         }
@@ -758,4 +768,114 @@ pub(super) fn handle_key(
         Overlay::None => {}
     }
     outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn task_overlay() -> Overlay {
+        Overlay::Tasks {
+            items: Vec::new(),
+            col: 0,
+            row: 0,
+            mode: TaskBoardMode::Board,
+        }
+    }
+
+    fn get_mode(overlay: &Overlay) -> &TaskBoardMode {
+        match overlay {
+            Overlay::Tasks { mode, .. } => mode,
+            _ => panic!("expected Tasks overlay"),
+        }
+    }
+
+    #[test]
+    fn task_board_question_mark_shows_help() {
+        let home = std::env::temp_dir().join("overlay_test_help_show");
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _rx) = crossbeam::channel::unbounded();
+        let mut name_counter = HashMap::new();
+        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
+        let mut layout = crate::layout::Layout::new();
+        let mut ctx = OverlayCtx {
+            layout: &mut layout,
+            registry: &registry,
+            home: &home,
+            fleet_path: &home,
+            wakeup_tx: &tx,
+            name_counter: &mut name_counter,
+            telegram_state: &tg,
+        };
+        let mut overlay = task_overlay();
+        handle_key(&mut overlay, press(KeyCode::Char('?')), &mut ctx);
+        assert!(matches!(get_mode(&overlay), TaskBoardMode::Help));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn task_board_help_esc_returns_to_board() {
+        let home = std::env::temp_dir().join("overlay_test_help_esc");
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _rx) = crossbeam::channel::unbounded();
+        let mut name_counter = HashMap::new();
+        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
+        let mut layout = crate::layout::Layout::new();
+        let mut ctx = OverlayCtx {
+            layout: &mut layout,
+            registry: &registry,
+            home: &home,
+            fleet_path: &home,
+            wakeup_tx: &tx,
+            name_counter: &mut name_counter,
+            telegram_state: &tg,
+        };
+        let mut overlay = Overlay::Tasks {
+            items: Vec::new(),
+            col: 0,
+            row: 0,
+            mode: TaskBoardMode::Help,
+        };
+        handle_key(&mut overlay, press(KeyCode::Esc), &mut ctx);
+        assert!(matches!(get_mode(&overlay), TaskBoardMode::Board));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn task_board_help_question_mark_toggles() {
+        let home = std::env::temp_dir().join("overlay_test_help_toggle");
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _rx) = crossbeam::channel::unbounded();
+        let mut name_counter = HashMap::new();
+        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
+        let mut layout = crate::layout::Layout::new();
+        let mut ctx = OverlayCtx {
+            layout: &mut layout,
+            registry: &registry,
+            home: &home,
+            fleet_path: &home,
+            wakeup_tx: &tx,
+            name_counter: &mut name_counter,
+            telegram_state: &tg,
+        };
+        let mut overlay = Overlay::Tasks {
+            items: Vec::new(),
+            col: 0,
+            row: 0,
+            mode: TaskBoardMode::Help,
+        };
+        handle_key(&mut overlay, press(KeyCode::Char('?')), &mut ctx);
+        assert!(matches!(get_mode(&overlay), TaskBoardMode::Board));
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1422,10 +1422,44 @@ pub fn render_tasks(
             }
             frame.render_widget(Paragraph::new(lines), inner_popup);
         }
+        TaskBoardMode::Help => {
+            let text = vec![
+                Line::from(Span::styled("Task Board Help", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))),
+                Line::from("───────────────"),
+                Line::from("  n           New task"),
+                Line::from("  ↑↓ / j k    Select task in column"),
+                Line::from("  ←→ / h l    Switch column"),
+                Line::from("  H / L       Move task left/right (change status)"),
+                Line::from("  Shift+D     Mark done from any column"),
+                Line::from("  a           Assign to agent or team"),
+                Line::from("  d           Cancel task"),
+                Line::from("  Enter       View task detail"),
+                Line::from("  Esc / q     Close Task Board"),
+                Line::from(""),
+                Line::from(Span::styled("Press ? or Esc to close help", Style::default().fg(Color::DarkGray))),
+            ];
+            let h = (text.len() as u16 + 2).min(inner.height.saturating_sub(2));
+            let w = 52u16.min(inner.width.saturating_sub(4));
+            let popup = Rect::new(
+                inner.x + (inner.width.saturating_sub(w)) / 2,
+                inner.y + (inner.height.saturating_sub(h)) / 2,
+                w,
+                h,
+            );
+            frame.render_widget(Clear, popup);
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Yellow))
+                .title(Span::styled(" ? Help ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)));
+            let inner_popup = block.inner(popup);
+            frame.render_widget(block, popup);
+            frame.render_widget(Paragraph::new(text), inner_popup);
+        }
         _ => {}
     }
 }
-
+/// Sorted by priority desc then created_at asc within each column.
+/// Cancelled tasks are excluded.
 /// Group tasks into 4 kanban columns: Backlog, Open, In Progress, Done.
 /// Sorted by priority desc then created_at asc within each column.
 /// Cancelled tasks are excluded.


### PR DESCRIPTION
## Summary

Add `?` keyboard shortcut in Task Board that opens a help overlay showing all board shortcuts.

## Changes

- **`src/app/overlay.rs`**: Added `TaskBoardMode::Help` variant. `?` in Board → Help mode. `Esc` or `?` in Help → Board mode.
- **`src/render.rs`**: Added Help mode rendering — centered popup with all shortcut descriptions.
- **3 tests**: `task_board_question_mark_shows_help`, `task_board_help_esc_returns_to_board`, `task_board_help_question_mark_toggles`

## Task
`t-20260423001817`

All tests pass. Clippy clean.