### PR TITLE
fix: handle_send bypasses Phase 2 compose guard

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -54,8 +54,9 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     );
 
     let reg = agent::lock_registry(ctx.registry);
-    if let Some(handle) = reg.get(target) {
-        let _ = agent::inject_to_agent(handle, inject_msg.as_bytes());
+    if reg.contains_key(target) {
+        drop(reg);
+        crate::inbox::compose_aware_inject(ctx.home, target, &inject_msg);
     }
     json!({"ok": true})
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -158,7 +158,15 @@ pub fn notify_agent(home: &Path, agent_name: &str, source: &NotifySource<'_>, te
         text.to_string()
     };
     let notification = format!("[{source}] {display_text}{}", source.reply_hint());
-    let _ = route_notification(home, agent_name, &notification, |msg| {
+    compose_aware_inject(home, agent_name, &notification);
+}
+
+/// Compose-aware notification delivery: checks `is_composing` and enqueues
+/// if the target agent is mid-typing, otherwise injects directly via the API.
+/// Used by both `notify_agent` (Telegram/system path) and `handle_send`
+/// (agent-to-agent MCP path) to ensure a single source of truth.
+pub fn compose_aware_inject(home: &Path, agent_name: &str, notification: &str) {
+    let _ = route_notification(home, agent_name, notification, |msg| {
         inject_notification(home, agent_name, msg)
     });
 }


### PR DESCRIPTION
## Summary

`handle_send` in `src/api/handlers/messaging.rs` called `agent::inject_to_agent` directly, bypassing the Phase 2 compose-state guard (`is_composing` check + notification queue). When the target agent was mid-typing, the notification was injected into the PTY and concatenated with user input.

**Task:** t-20260423022125

## Root Cause

Two inject paths existed:
1. `inbox.rs::notify_agent` → `route_notification` → checks `is_composing` → enqueue or inject ✅
2. `messaging.rs::handle_send` → `agent::inject_to_agent` directly ❌

## Fix

Extract `compose_aware_inject()` as a public helper in `inbox.rs`:
- Checks `is_composing` via `route_notification`
- Enqueues to notification queue if composing, injects directly if idle
- Both `notify_agent` and `handle_send` now use this single source of truth

## Changed Files

- `src/inbox.rs`: Add `compose_aware_inject()`, refactor `notify_agent` to use it
- `src/api/handlers/messaging.rs`: Replace direct `inject_to_agent` with `compose_aware_inject`

## Stats
+12 -3 lines