### PR TITLE
fix: handle_send must auto-submit via inject_to_agent, not raw write

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -56,7 +56,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     let reg = agent::lock_registry(ctx.registry);
     if reg.contains_key(target) {
         drop(reg);
-        crate::inbox::compose_aware_inject(ctx.home, target, &inject_msg);
+        crate::inbox::compose_aware_send(ctx.home, target, &inject_msg);
     }
     json!({"ok": true})
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -163,12 +163,42 @@ pub fn notify_agent(home: &Path, agent_name: &str, source: &NotifySource<'_>, te
 
 /// Compose-aware notification delivery: checks `is_composing` and enqueues
 /// if the target agent is mid-typing, otherwise injects directly via the API.
-/// Used by both `notify_agent` (Telegram/system path) and `handle_send`
-/// (agent-to-agent MCP path) to ensure a single source of truth.
+/// Used by `notify_agent` (Telegram/system path) for passive notifications
+/// that should NOT auto-submit (raw write, no submit_key).
 pub fn compose_aware_inject(home: &Path, agent_name: &str, notification: &str) {
     let _ = route_notification(home, agent_name, notification, |msg| {
         inject_notification(home, agent_name, msg)
     });
+}
+
+/// Compose-aware message delivery with auto-submit: checks `is_composing`
+/// and enqueues if mid-typing, otherwise injects via `inject_to_agent` which
+/// appends `submit_key`. Used by `handle_send` (agent-to-agent MCP path)
+/// for explicit messages that must be submitted to the target's CLI.
+pub fn compose_aware_send(home: &Path, agent_name: &str, message: &str) {
+    let _ = route_notification(home, agent_name, message, |msg| {
+        inject_with_submit(home, agent_name, msg)
+    });
+}
+
+fn inject_with_submit(home: &Path, agent_name: &str, message: &str) -> anyhow::Result<()> {
+    let resp = crate::api::call(
+        home,
+        &serde_json::json!({
+            "method": crate::api::method::INJECT,
+            "params": {"name": agent_name, "data": message}
+        }),
+    )?;
+    if resp["ok"].as_bool() == Some(true) {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "{}",
+            resp["error"]
+                .as_str()
+                .unwrap_or("inject with submit failed")
+        );
+    }
 }
 
 pub fn inject_notification(


### PR DESCRIPTION
## Summary

PR #96 regressed submit for `handle_send` by routing through `inject_notification` which uses `raw: true` → `write_to_agent` (no submit_key). Messages land in the target's input buffer but never submit. Gemini surfaced this first; kiro-cli masked it because embedded newlines in the notification text happen to trigger submission.

**Task:** t-20260423025028

## Root Cause

Two semantically different inject operations were conflated:
1. **Passive notifications** (`notify_agent`): should NOT auto-submit (PR #81 intentionally removed submit_key to avoid racing with user typing)
2. **Explicit messages** (`handle_send`): MUST auto-submit because the message is an intentional agent-to-agent communication

PR #96 made both use `compose_aware_inject` → `inject_notification` (raw write), breaking case 2.

## Fix

Split into two compose-aware functions sharing `route_notification` for compose guard:

| Function | Inject method | Submit? | Used by |
|---|---|---|---|
| `compose_aware_inject` | `inject_notification` (raw: true → `write_to_agent`) | No | `notify_agent` (passive) |
| `compose_aware_send` | `inject_with_submit` (raw: false → `inject_to_agent`) | Yes | `handle_send` (explicit) |

## Changed Files

- `src/inbox.rs`: Add `compose_aware_send()` + `inject_with_submit()`; clarify `compose_aware_inject` docstring
- `src/api/handlers/messaging.rs`: `handle_send` uses `compose_aware_send` instead of `compose_aware_inject`

## Stats
+33 -3 lines