### PR TITLE
fix: spawn_one uses backend preset submit_key instead of hardcoded \r

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -379,6 +379,9 @@ fn spawn_one(
     size: (u16, u16),
 ) -> anyhow::Result<()> {
     std::fs::create_dir_all(work_dir).ok();
+    let preset_submit_key = crate::backend::Backend::from_command(backend)
+        .map(|b| b.preset().submit_key)
+        .unwrap_or("\r");
     agent::spawn_agent(
         &agent::SpawnConfig {
             name,
@@ -389,7 +392,7 @@ fn spawn_one(
             rows: size.1,
             env: None,
             working_dir: Some(work_dir),
-            submit_key: "\r",
+            submit_key: preset_submit_key,
             home: Some(home),
             crash_tx: None,
             shutdown: None,
@@ -1638,5 +1641,37 @@ mod tests {
         };
         assert_eq!(*split_dir, PaneMoveSplitDir::Vertical);
         stop_server(&shutdown, &home);
+    }
+
+    // -----------------------------------------------------------------------
+    // spawn_one preset resolution — regression pin for gemini submit_key
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn spawn_one_resolves_preset_submit_key() {
+        // Verify that Backend::from_command returns the correct preset
+        // submit_key for each known backend. spawn_one uses this to avoid
+        // hardcoding "\r" (which broke gemini's "\n\r" requirement).
+        use crate::backend::Backend;
+        let cases = [
+            ("claude", "\r"),
+            ("kiro-cli", "\r"),
+            ("codex", "\r"),
+            ("gemini", "\n\r"),
+        ];
+        for (cmd, expected) in cases {
+            let key = Backend::from_command(cmd)
+                .map(|b| b.preset().submit_key)
+                .unwrap_or("\r");
+            assert_eq!(
+                key, expected,
+                "backend '{cmd}' should have submit_key {expected:?}, got {key:?}"
+            );
+        }
+        // Unknown backend falls back to "\r"
+        let unknown = Backend::from_command("unknown-backend")
+            .map(|b| b.preset().submit_key)
+            .unwrap_or("\r");
+        assert_eq!(unknown, "\r");
     }
 }


### PR DESCRIPTION
## Summary

`spawn_one()` in `src/api/mod.rs` hardcoded `submit_key: "\r"` for all backends, ignoring the backend preset. Gemini requires `"\n\r"` but MCP `create_instance` (which uses `spawn_one`) gave it `"\r"`, causing injected messages to land in the input buffer without submitting.

**Task:** t-20260423025028

## Root Cause

`spawn_one` is the spawn path for MCP `create_instance` and `create_team` (spawn mode). It hardcoded `submit_key: "\r"` in `SpawnConfig` instead of resolving from the backend preset.

The fleet.yaml daemon spawn path was unaffected — it correctly resolves `preset.submit_key` via `fleet.rs:295`.

**Why only gemini manifested:** All other backends (claude, kiro-cli, codex) have `submit_key: "\r"` in their preset, matching the hardcoded value. Gemini is the only backend with `submit_key: "\n\r"`.

## Fix

Resolve `submit_key` from `Backend::from_command(backend).preset()` with fallback to `"\r"` for unknown backends.

## Test

`spawn_one_resolves_preset_submit_key`: verifies all known backends (claude, kiro-cli, codex, gemini) get their correct preset submit_key, plus unknown backend fallback.

## Deployment

After merging:
1. `cargo build --release`
2. Restart daemon
3. Delete and recreate `at-dev-gemini` (existing instance has wrong `submit_key` in metadata; fix only affects new spawns)

## Stats
+36 -1 lines, 1 file changed