### PR TITLE
fix: expire stale ToolUse/Thinking states via periodic tick

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -522,6 +522,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     for (_name, handle) in reg.iter() {
                         if let Ok(mut core) = handle.core.lock() {
                             core.health.maybe_decay();
+                            core.state.tick();
                             let agent_state = core.state.current;
                             let silent = core.state.last_output.elapsed();
                             core.health.check_hang(agent_state, silent);

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -68,6 +68,10 @@ fn tick(home: &std::path::Path, registry: &AgentRegistry) {
                 core.state.update_heartbeat(age);
             }
 
+            // Expire stale latched states (ToolUse/Thinking) that feed()
+            // can't reach when the agent goes quiet (no PTY output).
+            core.state.tick();
+
             // §4.4 stale decay: clear waiting_on when heartbeat is stale.
             clear_waiting_on_if_stale(home, &name, !core.state.is_heartbeat_fresh());
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -618,6 +618,13 @@ impl StateTracker {
         self.current
     }
 
+    /// Periodic tick — expire stale latched states without requiring new PTY
+    /// output. Called from supervisor and app mode tick loops so idle agents
+    /// don't stay stuck on ToolUse/Thinking indefinitely.
+    pub(crate) fn tick(&mut self) {
+        self.maybe_expire_latched_state();
+    }
+
     /// Force state to Restarting (called by reaper on crash).
     pub fn set_restarting(&mut self) {
         self.current = AgentState::Restarting;
@@ -848,6 +855,44 @@ mod tests {
         let mut t = tracker_at(&Backend::ClaudeCode, AgentState::PermissionPrompt, 120);
         t.feed("nothing matches here");
         assert_eq!(t.get_state(), AgentState::PermissionPrompt);
+    }
+
+    // ── tick() regression pins (t-20260423040613) ───────────────────────
+
+    #[test]
+    fn tick_expires_stale_tool_use_without_feed() {
+        // ToolUse held > 30s with no PTY output. tick() must expire it
+        // to Ready without requiring feed() (which needs new screen text).
+        let mut t = tracker_at(&Backend::ClaudeCode, AgentState::ToolUse, 35);
+        t.tick();
+        assert_eq!(t.get_state(), AgentState::Ready);
+    }
+
+    #[test]
+    fn tick_does_not_expire_fresh_tool_use() {
+        // ToolUse held < 30s should NOT be expired by tick().
+        let mut t = tracker_at(&Backend::ClaudeCode, AgentState::ToolUse, 10);
+        t.tick();
+        assert_eq!(t.get_state(), AgentState::ToolUse);
+    }
+
+    #[test]
+    fn tick_does_not_expire_permission_prompt() {
+        // PermissionPrompt requires operator action, never auto-expires.
+        let mut t = tracker_at(&Backend::ClaudeCode, AgentState::PermissionPrompt, 120);
+        t.tick();
+        assert_eq!(t.get_state(), AgentState::PermissionPrompt);
+    }
+
+    #[test]
+    fn tick_called_twice_still_expires() {
+        // Verify tick() works on repeated calls (no hash-based early return).
+        let mut t = tracker_at(&Backend::ClaudeCode, AgentState::ToolUse, 35);
+        t.tick();
+        assert_eq!(t.get_state(), AgentState::Ready);
+        // Second tick on Ready is a no-op (Ready is not expiring).
+        t.tick();
+        assert_eq!(t.get_state(), AgentState::Ready);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`agent_state` gets stuck on `tool_use` when agents go idle. The 30s expiry mechanism (`maybe_expire_latched_state`) was only reachable through `feed()`, which requires new PTY output. Quiet agents never trigger it.

**Task:** t-20260423040613

## Root Cause

`maybe_expire_latched_state()` (state.rs:609) transitions stale ToolUse/Thinking → Ready after 30s. But it's only called inside `feed()` (state.rs:586), which is only invoked on new PTY output (agent.rs:626). The hash-based early return (`if self.last_screen_hash == Some(hash) { return; }`) also prevents expiry when the screen hasn't changed.

When an agent finishes tool use and goes quiet: no output → no `feed()` → no expiry → ToolUse latched indefinitely.

## Fix

Add `StateTracker::tick()` — calls `maybe_expire_latched_state()` without requiring screen text. Called from:
1. Supervisor tick (10s) — `daemon/supervisor.rs`
2. App mode maintenance tick (10s) — `app/mod.rs` (PR #100)

+50 lines, 3 files changed.

## Tests

4 regression pins:
- `tick_expires_stale_tool_use_without_feed` — ToolUse >30s → tick() → Ready
- `tick_does_not_expire_fresh_tool_use` — ToolUse <30s → tick() → stays ToolUse
- `tick_does_not_expire_permission_prompt` — PermissionPrompt never auto-expires
- `tick_called_twice_still_expires` — no hash-based early return blocking repeated ticks

## Deployment

`cargo build --release` + restart daemon.