### PR TITLE
fix: mouse selection white block + Cmd+C types 'c' into PTY

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -289,6 +289,20 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
             }
         }
         Action::None => {}
+        Action::CopySelection => {
+            if let Some(tab) = ctx.layout.active_tab() {
+                if let Some(pane) = tab.root().find_pane(tab.focus_id) {
+                    if let Some(ref sel) = pane.selection {
+                        let text = pane
+                            .vterm
+                            .extract_text(sel.start, sel.end, pane.scroll_offset);
+                        if !text.is_empty() {
+                            super::mouse::copy_to_clipboard(&text);
+                        }
+                    }
+                }
+            }
+        }
     }
     out
 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -408,11 +408,17 @@ fn handle_selection(layout: &mut Layout, mouse: &MouseEvent) {
             }
             MouseEventKind::Up(MouseButton::Left) => {
                 if let Some(ref sel) = pane.selection {
-                    let text = pane
-                        .vterm
-                        .extract_text(sel.start, sel.end, pane.scroll_offset);
-                    if !text.is_empty() {
-                        copy_to_clipboard(&text);
+                    if sel.start == sel.end {
+                        // Click without drag — clear the zero-width selection
+                        // to avoid a 1-cell white block artifact.
+                        pane.selection = None;
+                    } else {
+                        let text = pane
+                            .vterm
+                            .extract_text(sel.start, sel.end, pane.scroll_offset);
+                        if !text.is_empty() {
+                            copy_to_clipboard(&text);
+                        }
                     }
                 }
                 // Keep selection visible — cleared on next mouse down or keypress.
@@ -428,7 +434,7 @@ fn handle_selection(layout: &mut Layout, mouse: &MouseEvent) {
 }
 
 /// Copy text to system clipboard (macOS / Linux / Windows).
-fn copy_to_clipboard(text: &str) {
+pub(super) fn copy_to_clipboard(text: &str) {
     match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(text)) {
         Ok(()) => {}
         Err(e) => tracing::warn!(error = %e, "clipboard copy failed"),

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -46,6 +46,8 @@ pub enum Action {
     ShowHelp,
     /// Summon a floating scratch shell overlay (Ctrl+B ~). Esc closes & kills it.
     ScratchShell,
+    /// Copy the focused pane's selection to clipboard (Cmd+C).
+    CopySelection,
     None,
 }
 
@@ -84,6 +86,10 @@ impl KeyHandler {
                 if key.code == KeyCode::Char('b') && key.modifiers.contains(KeyModifiers::CONTROL) {
                     self.state = PrefixState::WaitingFirst;
                     return Action::None;
+                }
+                // Cmd+C (macOS) → copy selection to clipboard
+                if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::SUPER) {
+                    return Action::CopySelection;
                 }
                 Action::Forward(key)
             }
@@ -216,10 +222,19 @@ fn is_repeatable(action: &Action) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 
     fn prefix_action(code: KeyCode, modifiers: KeyModifiers) -> Action {
         dispatch_prefix(KeyEvent::new(code, modifiers))
+    }
+
+    fn key(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
     }
 
     // --- Shift+L: ResizeRight (not LastTab) ---
@@ -326,5 +341,30 @@ mod tests {
             prefix_action(KeyCode::Char('K'), KeyModifiers::empty()),
             Action::ResizeUp
         );
+    }
+
+    // --- Cmd+C / Normal mode ---
+
+    #[test]
+    fn cmd_c_returns_copy_selection() {
+        let mut handler = KeyHandler::new();
+        let action = handler.handle(key(KeyCode::Char('c'), KeyModifiers::SUPER));
+        assert_eq!(action, Action::CopySelection);
+    }
+
+    #[test]
+    fn ctrl_b_still_enters_prefix() {
+        let mut handler = KeyHandler::new();
+        let action = handler.handle(key(KeyCode::Char('b'), KeyModifiers::CONTROL));
+        assert_eq!(action, Action::None);
+        let action2 = handler.handle(key(KeyCode::Char('n'), KeyModifiers::NONE));
+        assert_eq!(action2, Action::NextTab);
+    }
+
+    #[test]
+    fn plain_c_forwards() {
+        let mut handler = KeyHandler::new();
+        let action = handler.handle(key(KeyCode::Char('c'), KeyModifiers::NONE));
+        assert!(matches!(action, Action::Forward(_)));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -123,6 +123,12 @@ pub fn attach(home: &Path, name: &str) -> anyhow::Result<()> {
 pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Vec<u8> {
     let ctrl = modifiers.contains(KeyModifiers::CONTROL);
     let alt = modifiers.contains(KeyModifiers::ALT);
+    // SUPER (Cmd on macOS) keys are OS-level shortcuts, never forwarded to
+    // the child process. Cmd+C is handled separately in dispatch for
+    // clipboard copy; all other SUPER combos are silently swallowed.
+    if modifiers.contains(KeyModifiers::SUPER) {
+        return vec![];
+    }
     match code {
         KeyCode::Char(c) if ctrl => {
             vec![(c.to_ascii_lowercase() as u8)
@@ -172,5 +178,36 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Vec<u8> {
             _ => vec![],
         },
         _ => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    #[test]
+    fn super_modifier_does_not_forward_to_pty() {
+        // Any SUPER+key must return empty bytes (not forwarded to PTY).
+        for c in ['c', 'v', 'a', 'x', 'z', 'f'] {
+            let bytes = key_to_bytes(KeyCode::Char(c), KeyModifiers::SUPER);
+            assert!(
+                bytes.is_empty(),
+                "SUPER+{c} must not produce PTY bytes, got {bytes:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ctrl_c_still_sends_sigint_0x03() {
+        // Ctrl+C must still produce 0x03 (SIGINT) — not swallowed by SUPER guard.
+        let bytes = key_to_bytes(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert_eq!(bytes, vec![0x03], "Ctrl+C must send 0x03");
+    }
+
+    #[test]
+    fn plain_char_forwards_normally() {
+        let bytes = key_to_bytes(KeyCode::Char('c'), KeyModifiers::NONE);
+        assert_eq!(bytes, vec![b'c']);
     }
 }


### PR DESCRIPTION
## Summary

Two coupled TUI bugs related to PR #72 (keyboard enhancement) and PR #74 (persistent selection).

**Task:** t-20260423022113

## Bug A: 1-char white block after click

Click without drag created `Selection{start==end}` on MouseDown. PR #74's persistent selection kept it visible as a 1-cell white block.

Fix: On MouseUp, if `start == end` (no drag), clear the selection. Actual drag selections still persist per PR #74 intent.

## Bug B: Cmd+C inserts 'c'

`key_to_bytes` handled CONTROL and ALT but not SUPER (Cmd on macOS). With PR #72's keyboard enhancement flags, Cmd+C reported as `Char('c') + SUPER` fell through to the plain `Char(c)` arm → literal 'c' to PTY.

Fix:
- `key_to_bytes`: return empty bytes for all SUPER+key (OS-level shortcuts)
- Keybind handler: intercept Cmd+C → `CopySelection` action
- Dispatch: copy focused pane's selection to clipboard without clearing it (macOS convention)

## Tests (6 regression pins)

- `super_modifier_does_not_forward_to_pty` — all SUPER+char → empty bytes
- `ctrl_c_still_sends_sigint_0x03` — Ctrl+C unaffected (0x03)
- `plain_char_forwards_normally` — regular chars still work
- `cmd_c_returns_copy_selection` — Cmd+C → CopySelection action
- `ctrl_b_still_enters_prefix` — prefix mode unaffected
- `plain_c_forwards` — plain 'c' still forwarded

## Stats
+108 -6 lines, 4 files changed