### PR TITLE
fix(render): right-align help hint in status bar

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -174,8 +174,7 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
             // returns Err and the helper returns None). Previously only
             // the MCP `create_instance` wrappers called this, so
             // deploy_template-spawned agents silently lacked topics.
-            let topic_id =
-                crate::channel::telegram::create_topic_for_instance(ctx.home, name);
+            let topic_id = crate::channel::telegram::create_topic_for_instance(ctx.home, name);
             if let Some(n) = ctx.notifier {
                 let layout_hint = LayoutHint::parse(params["layout"].as_str().unwrap_or("tab"));
                 let spawner = params["spawner"]

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -205,10 +205,8 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
     // when building the AgentContext for its agend.md. Single lock take
     // for the whole batch.
     if !yaml_entries.is_empty() {
-        let refs: Vec<(&str, &crate::fleet::InstanceYamlEntry)> = yaml_entries
-            .iter()
-            .map(|(n, e)| (n.as_str(), e))
-            .collect();
+        let refs: Vec<(&str, &crate::fleet::InstanceYamlEntry)> =
+            yaml_entries.iter().map(|(n, e)| (n.as_str(), e)).collect();
         if let Err(e) = crate::fleet::add_instances_to_yaml(home, &refs) {
             tracing::warn!(error = %e, "failed to persist deployment to fleet.yaml");
         }
@@ -496,7 +494,11 @@ templates:
 
         let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
         let lead = reloaded.instances.get("dev-lead").expect("dev-lead");
-        assert!(lead.role.is_none(), "unset role must stay None, got {:?}", lead.role);
+        assert!(
+            lead.role.is_none(),
+            "unset role must stay None, got {:?}",
+            lead.role
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -631,7 +633,6 @@ templates:
         std::fs::remove_dir_all(&home).ok();
     }
 
-    #[test]
     #[test]
     fn deploy_gives_each_member_its_own_workdir() {
         // Regression: same-backend teammates used to share `directory` when

--- a/src/render.rs
+++ b/src/render.rs
@@ -4,7 +4,7 @@ use crate::agent::{self, AgentRegistry};
 use crate::app::MenuItem;
 use crate::layout::{DragTabTarget, Layout, PaneNode, SplitDir};
 use crate::state::AgentState;
-use ratatui::layout::{Constraint, Direction, Rect};
+use ratatui::layout::{Alignment, Constraint, Direction, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
@@ -788,13 +788,32 @@ fn render_status_bar(frame: &mut Frame, area: Rect, layout: &Layout, telegram: T
         TelegramStatus::NotConfigured => {}
     }
 
-    spans.push(Span::styled(
-        " | Ctrl+B c new | : cmd | n/p switch | d detach | Ctrl+B ? help ",
-        Style::default().fg(Color::DarkGray),
-    ));
+    // Left side: agent / pane / layout / TG status (the spans above).
+    // Right side: keybinding cheatsheet ending in the help hotkey so it
+    // hugs the bottom-right corner regardless of terminal width. Rendered
+    // as a separate right-aligned Paragraph over the same area — when
+    // the terminal is narrow enough that the two overlap, the right hint
+    // wins (kept short specifically for that case), so the user never
+    // loses the "how do I open help?" affordance.
+    let left_bar = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::DarkGray));
+    frame.render_widget(left_bar, area);
 
-    let bar = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::DarkGray));
-    frame.render_widget(bar, area);
+    let right_hint = Line::from(vec![
+        Span::styled(
+            "Ctrl+B c new | : cmd | n/p switch | d detach | ",
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(
+            "Ctrl+B ? help ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]);
+    let right_bar = Paragraph::new(right_hint)
+        .alignment(Alignment::Right)
+        .style(Style::default().bg(Color::DarkGray));
+    frame.render_widget(right_bar, area);
 }
 
 // --- Overlay renderers ---

--- a/tests/mcp_characterization.rs
+++ b/tests/mcp_characterization.rs
@@ -689,7 +689,7 @@ instances:
   survivor:
     backend: claude
 "#;
-    std::fs::write(home.join("fleet.yaml"), fleet_yaml).unwrap();
+    std::fs::write(home.join("fleet.yaml"), fleet_yaml).expect("write fleet.yaml");
 
     let result = call_tool(&home, "delete_instance", &json!({"name": "zombie"}));
     assert!(
@@ -719,7 +719,7 @@ instances:
   survivor:
     backend: claude
 "#;
-    std::fs::write(home.join("fleet.yaml"), fleet_yaml).unwrap();
+    std::fs::write(home.join("fleet.yaml"), fleet_yaml).expect("write fleet.yaml");
 
     let result = call_tool(&home, "delete_instance", &json!({"name": "survivor"}));
     let err = result["error"].as_str().unwrap_or_default();


### PR DESCRIPTION
## Summary
- Bottom-right of the TUI now always shows \`Ctrl+B ? help\` in bold yellow so first-time users can find the help page independent of terminal width.
- Split \`render_status_bar\` into two overlapping Paragraphs — left paragraph keeps the agent / pane / layout / TG spans, new right-aligned paragraph carries the keybinding cheatsheet ending in the help hotkey.

## Why
Previously the cheatsheet was appended left-aligned after the status spans, so on narrow terminals the help hint got pushed off the visible area. A user who couldn't see the hint also couldn't discover the way into the help overlay.

## Test plan
- [x] \`cargo build\` green
- [x] \`cargo test\` — 749 lib + 27 mcp_characterization + 14 mcp_roundtrip + 5 no_dual_track_drift + 2 self_healing_supervisor + 9 integration + 19 supervisor all pass
- [x] \`render::tests::main_tui_footer_shows_help_hint\` + \`render::tests::task_board_footer_shows_help_hint\` still green (they check for the \`Ctrl+B ? help\` substring, which the new code still emits)
- [ ] Visual check at a narrow (≤80 col) terminal width to confirm the hint hugs the right edge rather than getting clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)