### PR TITLE
S2-T2: MCP report_health + clear_blocked_reason tools

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -280,3 +280,200 @@ pub(crate) fn handle_move_pane(params: &Value, ctx: &HandlerCtx) -> Value {
     );
     json!({"ok": true})
 }
+
+pub(crate) fn handle_set_blocked_reason(params: &Value, ctx: &HandlerCtx) -> Value {
+    let name = match params["name"].as_str() {
+        Some(n) => n,
+        None => return json!({"ok": false, "error": "missing 'name'"}),
+    };
+    let reason_str = match params["reason"].as_str() {
+        Some(r) => r,
+        None => return json!({"ok": false, "error": "missing 'reason'"}),
+    };
+    let reason = match reason_str {
+        "rate_limit" => crate::health::BlockedReason::RateLimit {
+            retry_after_secs: params["retry_after_secs"].as_u64(),
+        },
+        "quota_exceeded" => crate::health::BlockedReason::QuotaExceeded,
+        "awaiting_operator" => crate::health::BlockedReason::AwaitingOperator,
+        "permission_prompt" => crate::health::BlockedReason::PermissionPrompt,
+        "hang" => crate::health::BlockedReason::Hang,
+        "crash" => crate::health::BlockedReason::Crash,
+        _ => return json!({"ok": false, "error": format!("unknown reason: {reason_str}")}),
+    };
+    let reg = agent::lock_registry(ctx.registry);
+    match reg.get(name) {
+        Some(handle) => {
+            if let Ok(mut core) = handle.core.lock() {
+                let state = core.state.get_state().display_name().to_string();
+                core.health.set_blocked_reason(reason);
+                json!({"ok": true, "status": "reason_set", "reason": reason_str, "current_state": state})
+            } else {
+                json!({"ok": false, "error": "agent core lock failed"})
+            }
+        }
+        None => json!({"ok": false, "error": format!("instance '{name}' not found")}),
+    }
+}
+
+pub(crate) fn handle_clear_blocked_reason(params: &Value, ctx: &HandlerCtx) -> Value {
+    let name = match params["name"].as_str() {
+        Some(n) => n,
+        None => return json!({"ok": false, "error": "missing 'name'"}),
+    };
+    let filter_reason = params["reason"].as_str();
+    let reg = agent::lock_registry(ctx.registry);
+    match reg.get(name) {
+        Some(handle) => {
+            if let Ok(mut core) = handle.core.lock() {
+                let was = core.health.current_reason.as_ref().map(|r| {
+                    serde_json::to_value(r).unwrap_or_default()
+                });
+                // If a reason filter is specified, only clear if it matches
+                if let Some(filter) = filter_reason {
+                    let matches = core.health.current_reason.as_ref().map_or(false, |r| {
+                        let kind = match r {
+                            crate::health::BlockedReason::RateLimit { .. } => "rate_limit",
+                            crate::health::BlockedReason::QuotaExceeded => "quota_exceeded",
+                            crate::health::BlockedReason::AwaitingOperator => "awaiting_operator",
+                            crate::health::BlockedReason::PermissionPrompt => "permission_prompt",
+                            crate::health::BlockedReason::Hang => "hang",
+                            crate::health::BlockedReason::Crash => "crash",
+                        };
+                        kind == filter
+                    });
+                    if !matches {
+                        return json!({"ok": false, "error": "reason mismatch", "current": was});
+                    }
+                }
+                core.health.clear_blocked_reason();
+                json!({"ok": true, "status": "cleared", "instance": name, "was": was})
+            } else {
+                json!({"ok": false, "error": "agent core lock failed"})
+            }
+        }
+        None => json!({"ok": false, "error": format!("instance '{name}' not found")}),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn test_ctx_with_agent(name: &str) -> (HandlerCtx<'static>, Box<std::path::PathBuf>) {
+        let home = Box::new(
+            std::env::temp_dir().join(format!("agend-api-inst-test-{}-{}", name, std::process::id())),
+        );
+        std::fs::create_dir_all(home.as_ref()).ok();
+
+        // Leak the registries so they live for 'static — acceptable in tests.
+        let registry: &'static agent::AgentRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let configs: &'static crate::api::ConfigRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let externals: &'static agent::ExternalRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+
+        // Spawn a real shell agent so the registry has an entry with a HealthTracker.
+        let spawn_cfg = agent::SpawnConfig {
+            name,
+            backend_command: crate::default_shell(),
+            args: &[],
+            spawn_mode: crate::backend::SpawnMode::Fresh,
+            cols: 80,
+            rows: 24,
+            env: None,
+            working_dir: None,
+            submit_key: "\r",
+            home: None,
+            crash_tx: None,
+            shutdown: None,
+        };
+        agent::spawn_agent(&spawn_cfg, registry).expect("spawn test agent");
+
+        let home_ref: &'static std::path::Path = Box::leak(home.clone());
+        let ctx = HandlerCtx {
+            registry,
+            configs,
+            externals,
+            notifier: None,
+            home: home_ref,
+        };
+        (ctx, home)
+    }
+
+    fn cleanup_agent(ctx: &HandlerCtx, name: &str) {
+        let reg = agent::lock_registry(ctx.registry);
+        if let Some(h) = reg.get(name) {
+            let _ = crate::sync::lock_poisoned(&h.child, "test_child").kill();
+        }
+    }
+
+    #[test]
+    fn test_report_health_sets_reason_on_caller() {
+        let (ctx, _home) = test_ctx_with_agent("health-set");
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let result = handle_set_blocked_reason(
+            &json!({"name": "health-set", "reason": "rate_limit", "retry_after_secs": 60}),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true);
+        assert_eq!(result["status"], "reason_set");
+        assert_eq!(result["reason"], "rate_limit");
+
+        // Verify the reason is actually set on the HealthTracker
+        let reg = agent::lock_registry(ctx.registry);
+        let handle = reg.get("health-set").expect("agent exists");
+        let core = handle.core.lock().expect("lock");
+        assert!(core.health.current_reason.is_some());
+        match &core.health.current_reason {
+            Some(crate::health::BlockedReason::RateLimit { retry_after_secs }) => {
+                assert_eq!(*retry_after_secs, Some(60));
+            }
+            other => panic!("expected RateLimit, got {:?}", other),
+        }
+        drop(core);
+        drop(reg);
+
+        cleanup_agent(&ctx, "health-set");
+    }
+
+    #[test]
+    fn test_clear_blocked_reason_by_operator() {
+        let (ctx, _home) = test_ctx_with_agent("health-clear");
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        // First set a reason
+        let set_result = handle_set_blocked_reason(
+            &json!({"name": "health-clear", "reason": "quota_exceeded"}),
+            &ctx,
+        );
+        assert_eq!(set_result["ok"], true);
+
+        // Clear it
+        let clear_result = handle_clear_blocked_reason(
+            &json!({"name": "health-clear"}),
+            &ctx,
+        );
+        assert_eq!(clear_result["ok"], true);
+        assert_eq!(clear_result["status"], "cleared");
+        assert_eq!(clear_result["instance"], "health-clear");
+        // "was" should contain the previous reason
+        assert!(clear_result["was"].is_object());
+
+        // Verify it's actually cleared
+        let reg = agent::lock_registry(ctx.registry);
+        let handle = reg.get("health-clear").expect("agent exists");
+        let core = handle.core.lock().expect("lock");
+        assert!(core.health.current_reason.is_none());
+        drop(core);
+        drop(reg);
+
+        cleanup_agent(&ctx, "health-clear");
+    }
+}

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -326,12 +326,14 @@ pub(crate) fn handle_clear_blocked_reason(params: &Value, ctx: &HandlerCtx) -> V
     match reg.get(name) {
         Some(handle) => {
             if let Ok(mut core) = handle.core.lock() {
-                let was = core.health.current_reason.as_ref().map(|r| {
-                    serde_json::to_value(r).unwrap_or_default()
-                });
+                let was = core
+                    .health
+                    .current_reason
+                    .as_ref()
+                    .map(|r| serde_json::to_value(r).unwrap_or_default());
                 // If a reason filter is specified, only clear if it matches
                 if let Some(filter) = filter_reason {
-                    let matches = core.health.current_reason.as_ref().map_or(false, |r| {
+                    let matches = core.health.current_reason.as_ref().is_some_and(|r| {
                         let kind = match r {
                             crate::health::BlockedReason::RateLimit { .. } => "rate_limit",
                             crate::health::BlockedReason::QuotaExceeded => "quota_exceeded",
@@ -365,9 +367,11 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     fn test_ctx_with_agent(name: &str) -> (HandlerCtx<'static>, Box<std::path::PathBuf>) {
-        let home = Box::new(
-            std::env::temp_dir().join(format!("agend-api-inst-test-{}-{}", name, std::process::id())),
-        );
+        let home = Box::new(std::env::temp_dir().join(format!(
+            "agend-api-inst-test-{}-{}",
+            name,
+            std::process::id()
+        )));
         std::fs::create_dir_all(home.as_ref()).ok();
 
         // Leak the registries so they live for 'static — acceptable in tests.
@@ -456,10 +460,7 @@ mod tests {
         assert_eq!(set_result["ok"], true);
 
         // Clear it
-        let clear_result = handle_clear_blocked_reason(
-            &json!({"name": "health-clear"}),
-            &ctx,
-        );
+        let clear_result = handle_clear_blocked_reason(&json!({"name": "health-clear"}), &ctx);
         assert_eq!(clear_result["ok"], true);
         assert_eq!(clear_result["status"], "cleared");
         assert_eq!(clear_result["instance"], "health-clear");

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -200,6 +200,8 @@ pub mod method {
     pub const UPDATE_TEAM: &str = "update_team";
     pub const MOVE_PANE: &str = "move_pane";
     pub const SHUTDOWN: &str = "shutdown";
+    pub const SET_BLOCKED_REASON: &str = "set_blocked_reason";
+    pub const CLEAR_BLOCKED_REASON: &str = "clear_blocked_reason";
 }
 
 /// Start API socket server (blocks calling thread).
@@ -352,6 +354,8 @@ fn handle_session(
             method::CREATE_TEAM => handlers::team::handle_create_team(params, &ctx),
             method::UPDATE_TEAM => handlers::team::handle_update_team(params, &ctx),
             method::MOVE_PANE => handlers::instance::handle_move_pane(params, &ctx),
+            method::SET_BLOCKED_REASON => handlers::instance::handle_set_blocked_reason(params, &ctx),
+            method::CLEAR_BLOCKED_REASON => handlers::instance::handle_clear_blocked_reason(params, &ctx),
             method::SHUTDOWN => {
                 tracing::info!("API shutdown requested");
                 shutdown.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -354,8 +354,12 @@ fn handle_session(
             method::CREATE_TEAM => handlers::team::handle_create_team(params, &ctx),
             method::UPDATE_TEAM => handlers::team::handle_update_team(params, &ctx),
             method::MOVE_PANE => handlers::instance::handle_move_pane(params, &ctx),
-            method::SET_BLOCKED_REASON => handlers::instance::handle_set_blocked_reason(params, &ctx),
-            method::CLEAR_BLOCKED_REASON => handlers::instance::handle_clear_blocked_reason(params, &ctx),
+            method::SET_BLOCKED_REASON => {
+                handlers::instance::handle_set_blocked_reason(params, &ctx)
+            }
+            method::CLEAR_BLOCKED_REASON => {
+                handlers::instance::handle_clear_blocked_reason(params, &ctx)
+            }
             method::SHUTDOWN => {
                 tracing::info!("API shutdown requested");
                 shutdown.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -871,6 +871,65 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             json!({"repo": repo, "watching": false})
         }
 
+        // --- Health reporting ---
+        "report_health" => {
+            let Some(_) = sender.as_ref() else {
+                return err_needs_identity(tool);
+            };
+            let reason = match args["reason"].as_str() {
+                Some(r) => r,
+                None => return json!({"error": "missing 'reason'"}),
+            };
+            match crate::api::call(
+                &home,
+                &json!({
+                    "method": crate::api::method::SET_BLOCKED_REASON,
+                    "params": {
+                        "name": instance_name,
+                        "reason": reason,
+                        "retry_after_secs": args.get("retry_after_secs")
+                    }
+                }),
+            ) {
+                Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+                    json!({
+                        "status": "reason_set",
+                        "reason": reason,
+                        "current_state": resp["current_state"]
+                    })
+                }
+                Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("set_blocked_reason failed")}),
+                Err(e) => json!({"error": format!("{e}")}),
+            }
+        }
+        "clear_blocked_reason" => {
+            let instance = match args["instance"].as_str() {
+                Some(n) => n,
+                None => return json!({"error": "missing 'instance'"}),
+            };
+            let mut params = json!({"name": instance});
+            if let Some(r) = args["reason"].as_str() {
+                params["reason"] = json!(r);
+            }
+            match crate::api::call(
+                &home,
+                &json!({
+                    "method": crate::api::method::CLEAR_BLOCKED_REASON,
+                    "params": params
+                }),
+            ) {
+                Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+                    json!({
+                        "status": "cleared",
+                        "instance": instance,
+                        "was": resp["was"]
+                    })
+                }
+                Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("clear_blocked_reason failed")}),
+                Err(e) => json!({"error": format!("{e}")}),
+            }
+        }
+
         _ => json!({"error": format!("unknown tool: {tool}")}),
     }
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -2065,3 +2065,4 @@ instances:
         std::fs::remove_dir_all(&home).ok();
     }
 }
+

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -898,7 +898,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         "current_state": resp["current_state"]
                     })
                 }
-                Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("set_blocked_reason failed")}),
+                Ok(resp) => {
+                    json!({"error": resp["error"].as_str().unwrap_or("set_blocked_reason failed")})
+                }
                 Err(e) => json!({"error": format!("{e}")}),
             }
         }
@@ -925,7 +927,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         "was": resp["was"]
                     })
                 }
-                Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("clear_blocked_reason failed")}),
+                Ok(resp) => {
+                    json!({"error": resp["error"].as_str().unwrap_or("clear_blocked_reason failed")})
+                }
                 Err(e) => json!({"error": format!("{e}")}),
             }
         }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -14,6 +14,7 @@ pub fn tool_definitions() -> Value {
     tools.extend(repo_tools());
     tools.extend(deploy_tools());
     tools.extend(ci_tools());
+    tools.extend(health_tools());
     json!({"tools": tools})
 }
 
@@ -230,6 +231,22 @@ fn ci_tools() -> Vec<Value> {
             "inputSchema": {"type": "object", "properties": {
                 "repo": {"type": "string"}
             }, "required": ["repo"]}}),
+    ]
+}
+
+fn health_tools() -> Vec<Value> {
+    vec![
+        json!({"name": "report_health", "description": "Report a health condition (rate limit, quota exceeded, etc.) on the calling agent. Prevents false hang detection.",
+            "inputSchema": {"type": "object", "properties": {
+                "reason": {"type": "string", "enum": ["rate_limit", "quota_exceeded", "awaiting_operator"], "description": "Blocked reason kind"},
+                "retry_after_secs": {"type": "integer", "description": "Seconds until retry (for rate_limit)"},
+                "note": {"type": "string", "description": "Optional human-readable note"}
+            }, "required": ["reason"]}}),
+        json!({"name": "clear_blocked_reason", "description": "Clear a blocked reason on a specific instance. Used by operators to resume after quota refill etc.",
+            "inputSchema": {"type": "object", "properties": {
+                "instance": {"type": "string", "description": "Target instance name"},
+                "reason": {"type": "string", "description": "Only clear if current reason matches (optional)"}
+            }, "required": ["instance"]}}),
     ]
 }
 


### PR DESCRIPTION
## Summary
Sprint 2 T2 (stacked on #110 / \`feat/blocked-reason-enum\`). Adds two MCP tools for agent self-reporting and operator recovery (TEAM-REVIEW-REPORT §3 §A + CH-2 Edge3 — Quota 無恢復路徑).

## Change (+277 / 4 files)
- **\`report_health\`** MCP tool: agent calls it with \`{reason, retry_after_secs?, note?}\`. Uses caller's instance name from MCP context (no explicit \`instance\` arg), routes through API \`SET_BLOCKED_REASON\` to the caller's \`HealthTracker::set_blocked_reason\`.
- **\`clear_blocked_reason\`** MCP tool: operator calls with \`{instance, reason?}\`. Optional \`reason\` acts as a check — won't clear if current reason doesn't match, to avoid racing a legitimate block.
- **API layer**: new \`SET_BLOCKED_REASON\` / \`CLEAR_BLOCKED_REASON\` methods operating on the registry's \`HealthTracker\`.
- **Tool schema** registered in \`mcp/tools.rs\`.

## Wire-up
- \`grep -rn set_blocked_reason src/ | grep -v test\` — hits \`src/mcp/handlers.rs\` + \`src/api/handlers/instance.rs\` ✅
- \`grep -rn clear_blocked_reason src/ | grep -v test\` — hits \`src/mcp/handlers.rs\` + \`src/api/handlers/instance.rs\` ✅

## Tests
- \`test_report_health_sets_reason_on_caller\` — API sets \`RateLimit{retry_after_secs:60}\`, verify HealthTracker state.
- \`test_clear_blocked_reason_by_operator\` — set → clear roundtrip, verify \`was\` in response + reason actually cleared.
- Full \`cargo test\` — 830 pass / 0 fail.

## Stack
Depends on #110 (\`feat/blocked-reason-enum\` / S2-T1 BlockedReason enum). Marked draft — once #110 merges this will rebase to \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)