### PR TITLE
fix(telegram): thread home through react/edit/download helpers

### DIFF
--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -1068,13 +1068,18 @@ fn inject_provenance_from(
 }
 
 /// React to a message with an emoji.
+///
+/// `home` scopes the `fleet.yaml` + metadata lookups so callers on
+/// alternate homes (tests, multi-tenant daemons) can't accidentally
+/// leak into the operator's real Telegram channel — same class of fix
+/// as `create_topic_for_instance`.
 pub fn try_telegram_react(
+    home: &std::path::Path,
     instance_name: &str,
     emoji: &str,
     message_id: Option<&str>,
 ) -> anyhow::Result<()> {
-    let ch = resolve_channel_only()?;
-    let home = crate::home_dir();
+    let ch = resolve_channel_only_from(home)?;
     let mid: i32 = message_id.and_then(|m| m.parse().ok()).unwrap_or_else(|| {
         let meta_path = home.join("metadata").join(format!("{instance_name}.json"));
         std::fs::read_to_string(&meta_path)
@@ -1099,9 +1104,16 @@ pub fn try_telegram_react(
     })
 }
 
-/// Edit a previously sent message.
-pub fn try_telegram_edit(_instance_name: &str, message_id: &str, text: &str) -> anyhow::Result<()> {
-    let ch = resolve_channel_only()?;
+/// Edit a previously sent message. `home` scopes credential resolution
+/// so this helper can't silently reach the operator's real channel
+/// from a test or alt-home context.
+pub fn try_telegram_edit(
+    home: &std::path::Path,
+    _instance_name: &str,
+    message_id: &str,
+    text: &str,
+) -> anyhow::Result<()> {
+    let ch = resolve_channel_only_from(home)?;
     let mid: i32 = message_id
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid message_id: {message_id}"))?;
@@ -1168,10 +1180,15 @@ pub fn delete_topic(home: &std::path::Path, topic_id: i32) {
     tracing::info!(topic_id, "deleted topic");
 }
 
-/// Download an attachment by file_id.
-pub fn try_download_attachment(instance_name: &str, file_id: &str) -> anyhow::Result<String> {
-    let ch = resolve_channel_only()?;
-    let home = crate::home_dir();
+/// Download an attachment by file_id. `home` scopes credential +
+/// download-directory lookups so test runs don't drop files into the
+/// operator's real `~/.agend-terminal/downloads/`.
+pub fn try_download_attachment(
+    home: &std::path::Path,
+    instance_name: &str,
+    file_id: &str,
+) -> anyhow::Result<String> {
+    let ch = resolve_channel_only_from(home)?;
     telegram_runtime().block_on(async {
         let bot = teloxide::Bot::new(&ch.token);
         let file = bot.get_file(file_id).await?;
@@ -1591,6 +1608,10 @@ impl crate::channel::ux_event::UxEventSink for TelegramChannel {
             self.apply_fleet_action(fe);
             return;
         }
+        // Snapshot home from state for the scoped helper calls below —
+        // cloning the PathBuf is cheap and avoids holding the mutex
+        // across the network calls inside the match.
+        let home = lock_state(&self.state).home.clone();
         let action = select_action(event, &self.caps);
         // All transport errors are logged, not propagated — a failed
         // reaction is never a reason to crash the daemon.
@@ -1606,7 +1627,7 @@ impl crate::channel::ux_event::UxEventSink for TelegramChannel {
                 // fallback when `message_id` is None (we always pass
                 // `Some`), but routing through the real instance name
                 // keeps the contract stable if that fallback ever runs.
-                if let Err(e) = try_telegram_react(&instance, emoji, Some(&msg.id)) {
+                if let Err(e) = try_telegram_react(&home, &instance, emoji, Some(&msg.id)) {
                     tracing::warn!(
                         %e,
                         instance = %instance,
@@ -1621,7 +1642,7 @@ impl crate::channel::ux_event::UxEventSink for TelegramChannel {
                 msg,
                 text,
             } => {
-                if let Err(e) = try_telegram_edit(&instance, &msg.id, &text) {
+                if let Err(e) = try_telegram_edit(&home, &instance, &msg.id, &text) {
                     tracing::warn!(
                         %e,
                         instance = %instance,

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -69,7 +69,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         "react" => {
             let emoji = args["emoji"].as_str().unwrap_or("");
             let message_id = args["message_id"].as_str();
-            match telegram::try_telegram_react(instance_name, emoji, message_id) {
+            match telegram::try_telegram_react(&home, instance_name, emoji, message_id) {
                 Ok(()) => json!({"emoji": emoji}),
                 Err(e) => json!({"error": format!("{e}")}),
             }
@@ -83,7 +83,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 Some(t) => t,
                 None => return json!({"error": "missing 'text'"}),
             };
-            match telegram::try_telegram_edit(instance_name, message_id, text) {
+            match telegram::try_telegram_edit(&home, instance_name, message_id, text) {
                 Ok(()) => json!({"message_id": message_id}),
                 Err(e) => json!({"error": format!("{e}")}),
             }
@@ -93,7 +93,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 Some(f) => f,
                 None => return json!({"error": "missing 'file_id'"}),
             };
-            match telegram::try_download_attachment(instance_name, file_id) {
+            match telegram::try_download_attachment(&home, instance_name, file_id) {
                 Ok(path) => json!({"path": path}),
                 Err(e) => json!({"error": format!("{e}")}),
             }


### PR DESCRIPTION
## Summary
- Follow-up to PR #115 — audit of the remaining \`resolve_channel_only()\` call sites.
- Three helpers (\`try_telegram_react\`, \`try_telegram_edit\`, \`try_download_attachment\`) had the same home-ignoring pattern as \`create_topic_for_instance\`. Now all of them take \`home: &Path\` and resolve credentials via \`resolve_channel_only_from(home)\`.

## Context
PR #115 fixed the user-visible leak (stray \`positive_pin-1\` Telegram topics from \`cargo test\`). But the same anti-pattern lived in three other public helpers. They're reached only via MCP/daemon paths under the real home today, so no current leak — this PR closes the design hole before another test / multi-tenant scenario trips it.

## Callers updated
- \`src/mcp/handlers.rs\` react / edit_message / download_attachment branches — reuse the \`home\` already bound at the top of \`handle_tool\`.
- \`src/channel/telegram.rs\` \`UxEventSink::emit\` — snapshot \`home\` off the locked state before entering the action match (no new long-held lock).

## Test plan
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] 757 lib + 27 mcp_char + 14 mcp_roundtrip + 9 deployments + 5 drift + 2 supervisor — all pass
- [x] Existing regression pins from PR #115 still pass (\`create_topic_for_instance_uses_passed_home_not_real_home\`, \`delete_topic_uses_passed_home_not_real_home\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)