### PR TITLE
fix(ci-watch): first poll immediate after watch_ci registration

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -853,10 +853,23 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 "instance": instance_name, "last_run_id": null, "head_sha": null
             });
             let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
+            let watch_path = ci_dir.join(&filename);
             let _ = std::fs::write(
-                ci_dir.join(&filename),
+                &watch_path,
                 serde_json::to_string_pretty(&watch).unwrap_or_default(),
             );
+            // Backdate the mtime past the throttle window so the next
+            // daemon tick (≤10 s later) actually polls GitHub, instead of
+            // waiting the full `interval_secs` before the first check —
+            // the lag the operator observed with PR #115's watch, where
+            // the ci-pass notification didn't arrive until long after CI
+            // had finished. The +1 buys a margin over clock-skew between
+            // the write call and the subsequent `elapsed()` read.
+            let backdate =
+                std::time::SystemTime::now() - std::time::Duration::from_secs(interval + 1);
+            if let Ok(f) = std::fs::File::options().write(true).open(&watch_path) {
+                let _ = f.set_modified(backdate);
+            }
             json!({"repo": repo, "watching": true})
         }
         "unwatch_ci" => {

--- a/tests/mcp_characterization.rs
+++ b/tests/mcp_characterization.rs
@@ -755,3 +755,52 @@ fn replace_instance_preserves_team_membership() {
     assert_eq!(members, vec!["alice"]);
     std::fs::remove_dir_all(&home).ok();
 }
+
+/// Regression pin: watch_ci must backdate the file mtime past the
+/// caller's `interval_secs` so the next daemon tick actually polls
+/// GitHub, instead of waiting ~interval_secs before the first check.
+/// Before this fix the mtime-based throttle in check_ci_watches saw a
+/// freshly-created watch (mtime = now) and skipped it until the
+/// interval fully elapsed — visible as PR #115's ci-pass notification
+/// arriving long after the run had actually finished.
+#[test]
+fn watch_ci_backdates_mtime_past_interval_for_prompt_first_poll() {
+    let home = temp_home("watch-ci-backdate");
+    let resp = call_tool(
+        &home,
+        "watch_ci",
+        &json!({
+            "repo": "owner/repo",
+            "branch": "main",
+            "interval_secs": 60
+        }),
+    );
+    assert_eq!(resp["watching"], true, "watch_ci must succeed: {resp:?}");
+
+    // Find the watch file — the handler writes under a hashed filename
+    // via ci_watch::watch_filename, so we enumerate rather than guess.
+    let entries: Vec<_> = std::fs::read_dir(home.join("ci-watches"))
+        .expect("ci-watches dir must exist")
+        .filter_map(|e| e.ok())
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected exactly one watch file, got {entries:?}"
+    );
+    let watch_path = entries[0].path();
+
+    let metadata = std::fs::metadata(&watch_path).expect("watch file metadata");
+    let elapsed = metadata
+        .modified()
+        .expect("mtime")
+        .elapsed()
+        .expect("mtime must be in the past (post-backdate)");
+    assert!(
+        elapsed.as_secs() > 60,
+        "mtime must be backdated past the 60s interval so the next tick polls \
+         immediately, elapsed={:?}",
+        elapsed
+    );
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary
- Followup from the \`positive_pin\` investigation — operator reported the CI notification lag separately (task 22).
- Backdate the watch file's mtime past \`interval_secs\` in \`watch_ci\` so the first poll fires on the next daemon tick (≤10 s) instead of waiting the full throttle window.

## Root cause
\`check_ci_watches\` uses file mtime as its throttle:

\`\`\`rust
if meta.modified().elapsed() < interval_secs { skip }
\`\`\`

A freshly-created watch file has \`mtime = now\`, so the first ~\`interval_secs\` ticks all skip without calling GitHub. If CI finishes during that window the ci-pass/ci-fail notification waits for the next poll — another \`interval_secs\` away. That matches exactly what the operator saw with PR #115's watch (notification arrived much later than the actual run completion).

## Fix
After the \`std::fs::write\` in \`handle_watch_ci\`, reopen the file and \`File::set_modified\` to \`now - (interval_secs + 1)\`. Throttle sees the mtime as already-aged on the next tick, issues the first GitHub poll, and updates mtime back to \`now\` (normal flow resumes from there).

## Why backdate in the handler, not in check_ci_watches
- \`check_ci_watches\` only knows about files as a generic iteration — teaching it \"this is a first poll\" requires schema state (a \`first_poll_done\` flag or similar). The handler already owns the creation act and can stamp the mtime at the same time with no schema change.
- Subsequent polls naturally work because \`check_ci_watches\` already rewrites the file before spawning the GH request, bumping the mtime to \`now\`.

## Test plan
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] New regression pin: \`watch_ci_backdates_mtime_past_interval_for_prompt_first_poll\` — calls \`watch_ci\` via MCP subprocess, asserts the watch file's mtime elapsed is already > interval_secs on return.
- [x] 780 lib + 28 mcp_char + 16 mcp_roundtrip + 9 deployments + 5 drift + 2 supervisor — all pass.
- [ ] Smoke after merge: open a PR, call \`watch_ci\`, verify the ci-pass notification arrives within ~10 s of CI completing (vs minutes before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)