### PR TITLE
S2-T4: Watchdog dry-run mode (daemon-side PTY classification)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -342,6 +342,11 @@ fn run_core(
         rx
     };
 
+    // Watchdog dry-run mode: log classifications without mutating health state.
+    let watchdog_dry_run = std::env::var("AGEND_WATCHDOG_DRY_RUN")
+        .map(|v| matches!(v.as_str(), "1" | "true"))
+        .unwrap_or(false);
+
     // Main loop: event-driven via select on crash channel + periodic tick
     loop {
         if shutdown.load(std::sync::atomic::Ordering::Relaxed) {
@@ -382,6 +387,33 @@ fn run_core(
                             silent = ?silent,
                             "hang detected"
                         );
+                    }
+                }
+            }
+        }
+
+        // Watchdog: classify PTY output → BlockedReason
+        {
+            let reg = agent::lock_registry(&registry);
+            for (name, handle) in reg.iter() {
+                let backend = match crate::backend::Backend::from_command(&handle.backend_command) {
+                    Some(b) => b,
+                    None => continue,
+                };
+                if let Ok(mut core) = handle.core.lock() {
+                    let rows = core.vterm.rows() as usize;
+                    let screen = core.vterm.tail_lines(rows);
+                    if let Some(reason) = crate::state::classify_pty_output(&backend, &screen) {
+                        if watchdog_dry_run {
+                            crate::event_log::log(
+                                home,
+                                "watchdog_dry_run",
+                                name,
+                                &format!("{reason:?}"),
+                            );
+                        } else {
+                            core.health.set_blocked_reason(reason);
+                        }
                     }
                 }
             }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod ci_watch;
 pub(crate) mod cron_tick;
 pub(crate) mod supervisor;
 mod tui_bridge;
+pub(crate) mod watchdog;
 
 use crate::agent::{self, AgentRegistry};
 use crate::channel::telegram::notify_telegram;
@@ -403,18 +404,14 @@ fn run_core(
                 if let Ok(mut core) = handle.core.lock() {
                     let rows = core.vterm.rows() as usize;
                     let screen = core.vterm.tail_lines(rows);
-                    if let Some(reason) = crate::state::classify_pty_output(&backend, &screen) {
-                        if watchdog_dry_run {
-                            crate::event_log::log(
-                                home,
-                                "watchdog_dry_run",
-                                name,
-                                &format!("{reason:?}"),
-                            );
-                        } else {
-                            core.health.set_blocked_reason(reason);
-                        }
-                    }
+                    watchdog::run_watchdog_pass(
+                        home,
+                        name,
+                        &backend,
+                        &screen,
+                        &mut core.health,
+                        watchdog_dry_run,
+                    );
                 }
             }
         }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -344,9 +344,7 @@ fn run_core(
     };
 
     // Watchdog dry-run mode: log classifications without mutating health state.
-    let watchdog_dry_run = std::env::var("AGEND_WATCHDOG_DRY_RUN")
-        .map(|v| matches!(v.as_str(), "1" | "true"))
-        .unwrap_or(false);
+    let watchdog_dry_run = watchdog::watchdog_dry_run_from_env();
 
     // Main loop: event-driven via select on crash channel + periodic tick
     loop {

--- a/src/daemon/watchdog.rs
+++ b/src/daemon/watchdog.rs
@@ -4,6 +4,13 @@ use crate::backend::Backend;
 use crate::health::HealthTracker;
 use std::path::Path;
 
+/// Parse `AGEND_WATCHDOG_DRY_RUN` env var. Returns true for "1"/"true"/"TRUE"/"True".
+pub fn watchdog_dry_run_from_env() -> bool {
+    std::env::var("AGEND_WATCHDOG_DRY_RUN")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"))
+        .unwrap_or(false)
+}
+
 /// Run one watchdog pass for a single agent. Called from the daemon tick loop.
 ///
 /// - Classifies `screen` text against backend-specific error patterns.
@@ -135,5 +142,43 @@ mod tests {
         assert!(!log.contains("watchdog"), "healthy output must not write watchdog log");
 
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn test_watchdog_env_true_returns_true() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        for val in ["1", "true", "TRUE", "True"] {
+            std::env::set_var("AGEND_WATCHDOG_DRY_RUN", val);
+            assert!(
+                super::watchdog_dry_run_from_env(),
+                "AGEND_WATCHDOG_DRY_RUN={val} should return true"
+            );
+        }
+        std::env::remove_var("AGEND_WATCHDOG_DRY_RUN");
+    }
+
+    #[test]
+    fn test_watchdog_env_false_returns_false() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        for val in ["0", "false", "FALSE", "no", ""] {
+            std::env::set_var("AGEND_WATCHDOG_DRY_RUN", val);
+            assert!(
+                !super::watchdog_dry_run_from_env(),
+                "AGEND_WATCHDOG_DRY_RUN={val} should return false"
+            );
+        }
+        std::env::remove_var("AGEND_WATCHDOG_DRY_RUN");
+    }
+
+    #[test]
+    fn test_watchdog_env_unset_returns_false() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("AGEND_WATCHDOG_DRY_RUN");
+        assert!(
+            !super::watchdog_dry_run_from_env(),
+            "unset AGEND_WATCHDOG_DRY_RUN should return false"
+        );
     }
 }

--- a/src/daemon/watchdog.rs
+++ b/src/daemon/watchdog.rs
@@ -36,6 +36,7 @@ pub fn run_watchdog_pass(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::health::BlockedReason;

--- a/src/daemon/watchdog.rs
+++ b/src/daemon/watchdog.rs
@@ -1,0 +1,139 @@
+//! Watchdog: classify PTY output into BlockedReason per daemon tick.
+
+use crate::backend::Backend;
+use crate::health::HealthTracker;
+use std::path::Path;
+
+/// Run one watchdog pass for a single agent. Called from the daemon tick loop.
+///
+/// - Classifies `screen` text against backend-specific error patterns.
+/// - `dry_run=true`: logs to event_log only, does not mutate health state.
+/// - `dry_run=false`: sets `BlockedReason` on the health tracker.
+pub fn run_watchdog_pass(
+    home: &Path,
+    agent_name: &str,
+    backend: &Backend,
+    screen: &str,
+    health: &mut HealthTracker,
+    dry_run: bool,
+) {
+    let reason = match crate::state::classify_pty_output(backend, screen) {
+        Some(r) => r,
+        None => return,
+    };
+    if dry_run {
+        crate::event_log::log(
+            home,
+            "watchdog_dry_run",
+            agent_name,
+            &format!("{reason:?}"),
+        );
+    } else {
+        health.set_blocked_reason(reason);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::health::BlockedReason;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-watchdog-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn read_event_log(home: &Path) -> String {
+        std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default()
+    }
+
+    #[test]
+    fn test_watchdog_dry_run_env_logs_to_event_log() {
+        let home = tmp_home("dry-run");
+        let mut health = HealthTracker::new();
+        let backend = Backend::KiroCli;
+
+        run_watchdog_pass(
+            &home,
+            "test-agent",
+            &backend,
+            "ThrottlingError: Too Many Requests",
+            &mut health,
+            true, // dry_run
+        );
+
+        assert!(
+            health.current_reason.is_none(),
+            "dry-run must not set current_reason"
+        );
+        let log = read_event_log(&home);
+        assert!(log.contains("watchdog_dry_run"), "must log dry-run entry, got: {log}");
+        assert!(log.contains("RateLimit"), "must log reason, got: {log}");
+        assert!(log.contains("test-agent"), "must log agent name, got: {log}");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_watchdog_live_env_unset_sets_reason() {
+        let home = tmp_home("live");
+        let mut health = HealthTracker::new();
+        let backend = Backend::KiroCli;
+
+        run_watchdog_pass(
+            &home,
+            "test-agent",
+            &backend,
+            "ServiceQuotaExceededException: You have exceeded your quota",
+            &mut health,
+            false, // live
+        );
+
+        assert!(
+            matches!(health.current_reason, Some(BlockedReason::QuotaExceeded)),
+            "live mode must set current_reason, got: {:?}",
+            health.current_reason
+        );
+        let log = read_event_log(&home);
+        assert!(
+            !log.contains("watchdog_dry_run"),
+            "live mode must not write dry-run log"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_watchdog_healthy_output_no_action() {
+        let home = tmp_home("healthy");
+        let mut health = HealthTracker::new();
+        let backend = Backend::KiroCli;
+
+        run_watchdog_pass(
+            &home,
+            "test-agent",
+            &backend,
+            "Thinking about your request...\n● Read src/main.rs",
+            &mut health,
+            false,
+        );
+
+        assert!(
+            health.current_reason.is_none(),
+            "healthy output must not set reason"
+        );
+        let log = read_event_log(&home);
+        assert!(!log.contains("watchdog"), "healthy output must not write watchdog log");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/watchdog.rs
+++ b/src/daemon/watchdog.rs
@@ -29,12 +29,7 @@ pub fn run_watchdog_pass(
         None => return,
     };
     if dry_run {
-        crate::event_log::log(
-            home,
-            "watchdog_dry_run",
-            agent_name,
-            &format!("{reason:?}"),
-        );
+        crate::event_log::log(home, "watchdog_dry_run", agent_name, &format!("{reason:?}"));
     } else {
         health.set_blocked_reason(reason);
     }
@@ -83,9 +78,15 @@ mod tests {
             "dry-run must not set current_reason"
         );
         let log = read_event_log(&home);
-        assert!(log.contains("watchdog_dry_run"), "must log dry-run entry, got: {log}");
+        assert!(
+            log.contains("watchdog_dry_run"),
+            "must log dry-run entry, got: {log}"
+        );
         assert!(log.contains("RateLimit"), "must log reason, got: {log}");
-        assert!(log.contains("test-agent"), "must log agent name, got: {log}");
+        assert!(
+            log.contains("test-agent"),
+            "must log agent name, got: {log}"
+        );
 
         std::fs::remove_dir_all(&home).ok();
     }
@@ -139,7 +140,10 @@ mod tests {
             "healthy output must not set reason"
         );
         let log = read_event_log(&home);
-        assert!(!log.contains("watchdog"), "healthy output must not write watchdog log");
+        assert!(
+            !log.contains("watchdog"),
+            "healthy output must not write watchdog log"
+        );
 
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/health.rs
+++ b/src/health.rs
@@ -540,7 +540,10 @@ mod tests {
 
         // Dry-run: do NOT call set_blocked_reason
         // (in production, daemon checks AGEND_WATCHDOG_DRY_RUN)
-        assert!(h.current_reason.is_none(), "dry-run must not mutate health state");
+        assert!(
+            h.current_reason.is_none(),
+            "dry-run must not mutate health state"
+        );
 
         // check_hang should still fire (no reason set)
         assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
@@ -583,6 +586,9 @@ mod tests {
         h.set_blocked_reason(BlockedReason::QuotaExceeded);
         assert!(h.current_reason.is_some());
         h.reset();
-        assert!(h.current_reason.is_none(), "reset must clear current_reason");
+        assert!(
+            h.current_reason.is_none(),
+            "reset must clear current_reason"
+        );
     }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -303,6 +303,7 @@ impl HealthTracker {
         self.crash_times.clear();
         self.total_crashes = 0;
         self.error_events.clear();
+        self.current_reason = None;
     }
 }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -527,4 +527,52 @@ mod tests {
             assert_eq!(parsed, reason, "round-trip failed for {json}");
         }
     }
+
+    #[test]
+    fn test_watchdog_dry_run_logs_but_no_state_change() {
+        // Simulate dry-run: classify returns Some(RateLimit), but we only log, don't set.
+        let mut h = HealthTracker::new();
+        let backend = crate::backend::Backend::ClaudeCode;
+        let output = "Error: 429 overloaded";
+        let reason = crate::state::classify_pty_output(&backend, output);
+        assert!(reason.is_some(), "should classify as blocked");
+
+        // Dry-run: do NOT call set_blocked_reason
+        // (in production, daemon checks AGEND_WATCHDOG_DRY_RUN)
+        assert!(h.current_reason.is_none(), "dry-run must not mutate health state");
+
+        // check_hang should still fire (no reason set)
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+    }
+
+    #[test]
+    fn test_watchdog_live_sets_reason() {
+        // Simulate live mode: classify returns Some, set_blocked_reason called.
+        let mut h = HealthTracker::new();
+        let backend = crate::backend::Backend::KiroCli;
+        let output = "ThrottlingError: Too Many Requests";
+        if let Some(reason) = crate::state::classify_pty_output(&backend, output) {
+            h.set_blocked_reason(reason);
+        }
+        assert!(
+            matches!(h.current_reason, Some(BlockedReason::RateLimit { .. })),
+            "live mode must set current_reason, got: {:?}",
+            h.current_reason
+        );
+        // check_hang should be suppressed
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+    }
+
+    #[test]
+    fn test_watchdog_ignores_classify_none() {
+        // Healthy output → classify returns None → no change.
+        let mut h = HealthTracker::new();
+        let backend = crate::backend::Backend::ClaudeCode;
+        let output = "Thinking about your request...";
+        let reason = crate::state::classify_pty_output(&backend, output);
+        assert!(reason.is_none(), "healthy output should not classify");
+        assert!(h.current_reason.is_none());
+        // check_hang still works normally
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+    }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -576,4 +576,13 @@ mod tests {
         // check_hang still works normally
         assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
     }
+
+    #[test]
+    fn test_reset_clears_current_reason() {
+        let mut h = HealthTracker::new();
+        h.set_blocked_reason(BlockedReason::QuotaExceeded);
+        assert!(h.current_reason.is_some());
+        h.reset();
+        assert!(h.current_reason.is_none(), "reset must clear current_reason");
+    }
 }


### PR DESCRIPTION
Sprint 2 T4 — replaces #114. Last of the S2 stack. Wires classify_pty_output (#118) into daemon tick with AGEND_WATCHDOG_DRY_RUN kill switch; also bundles reset() → clear current_reason followup.