### PR TITLE
refactor(ci-watch): throttle state in schema, drop mtime hack

### DIFF
--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -14,6 +14,25 @@ pub fn watch_filename(repo: &str, branch: &str) -> String {
     format!("{:016x}.json", h.finish())
 }
 
+/// Pure throttle decision for a CI watch. Returns `true` when the watch
+/// is due for a GitHub poll given its `last_polled_at` (epoch millis,
+/// `None` for a fresh watch), its configured `interval_secs`, and the
+/// current wall-clock time.
+///
+/// Extracted from `check_ci_watches` so the first-poll-immediate rule
+/// can be unit-tested without filesystem IO — the previous mtime-based
+/// throttle was testable only via external side effects on file
+/// modification time.
+fn watch_is_due(last_polled_at: Option<i64>, interval_secs: u64, now_ms: i64) -> bool {
+    match last_polled_at {
+        // Never-polled watches (freshly registered, or pre-schema files
+        // that don't carry the field) fire on the first check. The
+        // handler writes `last_polled_at: null` to signal this.
+        None => true,
+        Some(ts) => now_ms.saturating_sub(ts) >= (interval_secs as i64) * 1000,
+    }
+}
+
 /// Check CI watch configs and inject failure logs to agents when CI fails.
 pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
     let entries = match std::fs::read_dir(home.join("ci-watches")) {
@@ -38,21 +57,28 @@ pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
         let last_run_id = watch["last_run_id"].as_u64();
         let head_sha = watch["head_sha"].as_str().map(String::from);
 
-        // Throttle via mtime
-        if let Ok(meta) = std::fs::metadata(&path) {
-            if meta
-                .modified()
-                .ok()
-                .and_then(|m| m.elapsed().ok())
-                .map(|age| age.as_secs() < interval)
-                .unwrap_or(false)
-            {
-                continue;
-            }
+        // Throttle from a dedicated `last_polled_at` (epoch millis) in the
+        // watch file itself, not file mtime. mtime conflates "when this
+        // file was touched" with "when we last polled" and broke whenever
+        // another writer (migration, hand-edit, freshly created watch)
+        // stamped the file — the handler used to backdate mtime manually
+        // to work around that. Schema-local state removes both the
+        // first-poll-lag quirk and the external-writer fragility.
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        if !watch_is_due(watch["last_polled_at"].as_i64(), interval, now_ms) {
+            continue;
         }
+        // Stamp `last_polled_at` BEFORE spawning the GH request so a slow
+        // GH response doesn't let the next tick re-enter for the same
+        // watch. The spawned thread updates last_run_id / head_sha on a
+        // terminal conclusion; non-terminal polls leave those fields
+        // alone but the `last_polled_at` stamp already keeps them in
+        // throttle.
+        let mut watch_with_stamp = watch.clone();
+        watch_with_stamp["last_polled_at"] = serde_json::json!(now_ms);
         let _ = std::fs::write(
             &path,
-            serde_json::to_string_pretty(&watch).unwrap_or_default(),
+            serde_json::to_string_pretty(&watch_with_stamp).unwrap_or_default(),
         );
 
         let home = home.to_path_buf();
@@ -293,6 +319,49 @@ async fn fetch_failure_summary(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn watch_is_due_null_last_polled_at_fires_immediately() {
+        // A freshly-registered watch (or a pre-schema file missing the
+        // last_polled_at field) must be due on the first tick. This is
+        // the condition that makes the next daemon tick actually poll
+        // GitHub instead of waiting ~interval_secs.
+        assert!(watch_is_due(None, 60, 1_700_000_000_000));
+    }
+
+    #[test]
+    fn watch_is_due_within_interval_is_throttled() {
+        // Polled 30 s ago, interval 60 s ⇒ still throttled. Prevents
+        // back-to-back polls from hammering the GitHub API during
+        // daemon ticks (10 s cadence) or concurrent callers.
+        let now_ms = 1_700_000_000_000_i64;
+        let recent = now_ms - 30_000; // 30 s ago
+        assert!(!watch_is_due(Some(recent), 60, now_ms));
+    }
+
+    #[test]
+    fn watch_is_due_past_interval_fires_again() {
+        // Polled 61 s ago, interval 60 s ⇒ due. Equality case
+        // (elapsed == interval) is also treated as due — boundary
+        // matches the `>=` in the throttle.
+        let now_ms = 1_700_000_000_000_i64;
+        let stale = now_ms - 61_000;
+        assert!(watch_is_due(Some(stale), 60, now_ms));
+        let exact = now_ms - 60_000;
+        assert!(watch_is_due(Some(exact), 60, now_ms));
+    }
+
+    #[test]
+    fn watch_is_due_future_timestamp_is_throttled() {
+        // Defensive: a clock going backwards (or a hand-edited file
+        // with a bogus future timestamp) should not flood GH. The
+        // saturating_sub makes elapsed non-negative, and 0 < interval
+        // ⇒ throttled. We'd rather be quietly silent on a weird clock
+        // than burn rate limit.
+        let now_ms = 1_700_000_000_000_i64;
+        let future = now_ms + 10_000; // 10 s in the future
+        assert!(!watch_is_due(Some(future), 60, now_ms));
+    }
 
     #[test]
     fn ci_watch_success_notifies() {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -848,9 +848,19 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             let interval = args["interval_secs"].as_u64().unwrap_or(60);
             let ci_dir = home.join("ci-watches");
             std::fs::create_dir_all(&ci_dir).ok();
+            // `last_polled_at: null` signals "never polled" to
+            // check_ci_watches, which fires on the next daemon tick
+            // (≤10 s) instead of waiting `interval_secs`. Throttle state
+            // lives in the schema, not on the filesystem — this is the
+            // elegant replacement for PR #119's mtime-backdate kludge.
             let watch = json!({
-                "repo": repo, "branch": branch, "interval_secs": interval,
-                "instance": instance_name, "last_run_id": null, "head_sha": null
+                "repo": repo,
+                "branch": branch,
+                "interval_secs": interval,
+                "instance": instance_name,
+                "last_run_id": null,
+                "head_sha": null,
+                "last_polled_at": null,
             });
             let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
             let watch_path = ci_dir.join(&filename);
@@ -858,18 +868,6 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 &watch_path,
                 serde_json::to_string_pretty(&watch).unwrap_or_default(),
             );
-            // Backdate the mtime past the throttle window so the next
-            // daemon tick (≤10 s later) actually polls GitHub, instead of
-            // waiting the full `interval_secs` before the first check —
-            // the lag the operator observed with PR #115's watch, where
-            // the ci-pass notification didn't arrive until long after CI
-            // had finished. The +1 buys a margin over clock-skew between
-            // the write call and the subsequent `elapsed()` read.
-            let backdate =
-                std::time::SystemTime::now() - std::time::Duration::from_secs(interval + 1);
-            if let Ok(f) = std::fs::File::options().write(true).open(&watch_path) {
-                let _ = f.set_modified(backdate);
-            }
             json!({"repo": repo, "watching": true})
         }
         "unwatch_ci" => {

--- a/tests/mcp_characterization.rs
+++ b/tests/mcp_characterization.rs
@@ -756,16 +756,17 @@ fn replace_instance_preserves_team_membership() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// Regression pin: watch_ci must backdate the file mtime past the
-/// caller's `interval_secs` so the next daemon tick actually polls
-/// GitHub, instead of waiting ~interval_secs before the first check.
-/// Before this fix the mtime-based throttle in check_ci_watches saw a
-/// freshly-created watch (mtime = now) and skipped it until the
-/// interval fully elapsed — visible as PR #115's ci-pass notification
-/// arriving long after the run had actually finished.
+/// Regression pin: a freshly-created watch must record
+/// `last_polled_at: null` so `check_ci_watches` treats it as
+/// "never polled" and fires on the next daemon tick rather than
+/// waiting the full `interval_secs`. PR #119 solved the same lag by
+/// backdating file mtime — that was a workaround; the elegant fix
+/// moves throttle state into the schema itself so external writers
+/// (migration, hand-edit) can't silently re-introduce the lag by
+/// stamping the mtime.
 #[test]
-fn watch_ci_backdates_mtime_past_interval_for_prompt_first_poll() {
-    let home = temp_home("watch-ci-backdate");
+fn watch_ci_writes_null_last_polled_at_for_prompt_first_poll() {
+    let home = temp_home("watch-ci-polled-null");
     let resp = call_tool(
         &home,
         "watch_ci",
@@ -777,8 +778,7 @@ fn watch_ci_backdates_mtime_past_interval_for_prompt_first_poll() {
     );
     assert_eq!(resp["watching"], true, "watch_ci must succeed: {resp:?}");
 
-    // Find the watch file — the handler writes under a hashed filename
-    // via ci_watch::watch_filename, so we enumerate rather than guess.
+    // Handler writes under a hashed filename — enumerate rather than guess.
     let entries: Vec<_> = std::fs::read_dir(home.join("ci-watches"))
         .expect("ci-watches dir must exist")
         .filter_map(|e| e.ok())
@@ -788,19 +788,13 @@ fn watch_ci_backdates_mtime_past_interval_for_prompt_first_poll() {
         1,
         "expected exactly one watch file, got {entries:?}"
     );
-    let watch_path = entries[0].path();
-
-    let metadata = std::fs::metadata(&watch_path).expect("watch file metadata");
-    let elapsed = metadata
-        .modified()
-        .expect("mtime")
-        .elapsed()
-        .expect("mtime must be in the past (post-backdate)");
+    let content = std::fs::read_to_string(entries[0].path()).expect("watch file must be readable");
+    let watch: serde_json::Value =
+        serde_json::from_str(&content).expect("watch file must parse as JSON");
     assert!(
-        elapsed.as_secs() > 60,
-        "mtime must be backdated past the 60s interval so the next tick polls \
-         immediately, elapsed={:?}",
-        elapsed
+        watch["last_polled_at"].is_null(),
+        "freshly-created watch must record last_polled_at: null (drives \
+         first-poll-immediate in check_ci_watches), got: {watch:?}"
     );
     std::fs::remove_dir_all(&home).ok();
 }


### PR DESCRIPTION
## Summary
Replaces PR #119's \`File::set_modified\` workaround with a schema-local throttle field. The operator specifically asked to avoid workarounds — \"不要 workaround, 有需要就用最優雅一勞永逸的作法.\"

## What was wrong with PR #119
\`check_ci_watches\` used **file mtime** as throttle state. Freshly-created watches had \`mtime = now\`, which made the first \`interval_secs\` worth of ticks skip the GitHub poll. PR #119 patched this by having \`handle_watch_ci\` backdate the file's mtime after writing it — effective, but:
1. External writers (migration, hand-edit, snapshot restore) silently stamp mtime and re-introduce the lag.
2. mtime conflates \"when the file was touched\" with \"when we last polled\" — two unrelated facts.
3. The backdate is spooky action on the filesystem from an unrelated layer.

## What this PR does
Move the throttle state into the watch JSON itself:

\`\`\`diff
 {
   \"repo\": \"...\",
   \"branch\": \"...\",
   \"interval_secs\": 60,
   \"instance\": \"...\",
   \"last_run_id\": null,
   \"head_sha\": null,
+  \"last_polled_at\": null
 }
\`\`\`

- \`handle_watch_ci\` writes \`last_polled_at: null\`. Drops the \`File::set_modified\` kludge from PR #119.
- \`check_ci_watches\` uses a new pure helper \`watch_is_due(last_polled_at, interval_secs, now_ms)\` — null ⇒ fire immediately, else elapsed ≥ interval ⇒ fire.
- Stamp \`last_polled_at = now_ms\` **before** spawning the GH request so slow GH responses don't let the next tick re-enter the same watch.

## Migration
Existing watch files without the field deserialise as \`last_polled_at: null\` (serde_json missing-key is null) ⇒ treated as fresh ⇒ fire on next tick. No explicit migration.

## Test plan
- [x] New pure-function unit tests (5) on \`watch_is_due\`: null fires, within throttle, past interval, boundary, future-timestamp defensive
- [x] Updated MCP regression pin: \`watch_ci_writes_null_last_polled_at_for_prompt_first_poll\` (replaces the mtime-elapsed check from PR #119's test)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] 787 lib + 28 mcp_char + 16 mcp_roundtrip + 9 deployments + 5 drift + 2 supervisor — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)