### PR TITLE
feat(fleet_broadcast): role-changed live via hot-reload

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -756,8 +756,28 @@ fn apply_fleet_reload(
     for name in &diff.working_dir_changed {
         tracing::warn!(agent = %name, "fleet.yaml working_directory changed — requires manual restart");
     }
+    // Role changes get a live broadcast — every running agent has the
+    // old role in its `## Fleet Peers` (or `## Team`) block, so the
+    // `<fleet-update kind="role-changed">` marker lets them update
+    // their mental model without waiting for a respawn. The subject
+    // itself also receives the marker so its own `## Identity` Role
+    // line stays accurate. Closes the "log-and-skip" TODO in
+    // bootstrap/reload.rs line 10-14.
     for name in &diff.role_changed {
-        tracing::info!(agent = %name, "fleet.yaml role changed — won't be reflected until agent respawns");
+        let new_role = new_config.instances.get(name).and_then(|c| c.role.clone());
+        tracing::info!(
+            agent = %name,
+            new_role = ?new_role,
+            "fleet.yaml role changed — broadcasting to running agents"
+        );
+        crate::fleet_broadcast::broadcast(
+            home,
+            registry,
+            &crate::fleet_broadcast::FleetUpdate::RoleChanged {
+                name: name.clone(),
+                new_role,
+            },
+        );
     }
     for name in &diff.topic_id_changed {
         tracing::info!(agent = %name, "fleet.yaml topic_id changed — won't be reflected until agent respawns");

--- a/src/fleet_broadcast.rs
+++ b/src/fleet_broadcast.rs
@@ -56,6 +56,15 @@ pub enum FleetUpdate {
         added: Vec<String>,
         removed: Vec<String>,
     },
+    /// An instance's `role` field in fleet.yaml was edited. Emitted by
+    /// the daemon hot-reload path (`apply_fleet_reload` consuming
+    /// `ReloadDiff::role_changed`) — operators editing fleet.yaml
+    /// directly previously left running agents unaware of the change
+    /// until respawn.
+    RoleChanged {
+        name: String,
+        new_role: Option<String>,
+    },
 }
 
 impl FleetUpdate {
@@ -100,6 +109,11 @@ impl FleetUpdate {
                 "added": added,
                 "removed": removed,
             }),
+            FleetUpdate::RoleChanged { name, new_role } => json!({
+                "kind": "role-changed",
+                "name": name,
+                "role": new_role,
+            }),
         };
         format!("<fleet-update>\n{payload}\n</fleet-update>\n")
     }
@@ -138,10 +152,14 @@ pub fn compute_targets(
             }
             all.into_iter().collect()
         }
-        // Fleet-wide events: everyone currently registered.
-        FleetUpdate::InstanceCreated { .. } | FleetUpdate::InstanceDeleted { .. } => {
-            registered_names.to_vec()
-        }
+        // Fleet-wide events: everyone currently registered. RoleChanged
+        // also goes fleet-wide — the subject's own agend.md already
+        // carries the new role (we re-read fleet.yaml at spawn), but
+        // every *other* agent has a stale `<peer> — <old role>` line
+        // that the marker lets them update.
+        FleetUpdate::InstanceCreated { .. }
+        | FleetUpdate::InstanceDeleted { .. }
+        | FleetUpdate::RoleChanged { .. } => registered_names.to_vec(),
     };
 
     // Self-exclusion. For InstanceCreated the new agent's own agend.md
@@ -339,6 +357,89 @@ instances:
             targets,
             vec!["a".to_string(), "b".to_string(), "c".to_string()],
             "InstanceDeleted must reach every survivor, got {targets:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn render_marker_role_changed_includes_new_role() {
+        let u = FleetUpdate::RoleChanged {
+            name: "dev-lead".into(),
+            new_role: Some("Senior architect".into()),
+        };
+        let s = u.render_marker();
+        let inner = s
+            .trim_start_matches("<fleet-update>\n")
+            .trim_end_matches("</fleet-update>\n")
+            .trim();
+        let v: serde_json::Value = serde_json::from_str(inner).unwrap();
+        assert_eq!(v["kind"], "role-changed");
+        assert_eq!(v["name"], "dev-lead");
+        assert_eq!(v["role"], "Senior architect");
+    }
+
+    #[test]
+    fn render_marker_role_changed_serialises_null_role() {
+        // Clearing a role in fleet.yaml (removing the field) lands as
+        // new_role=None — the marker must faithfully carry null so
+        // agents know to drop the Role line, not emit "null" as a role.
+        let u = FleetUpdate::RoleChanged {
+            name: "dev-lead".into(),
+            new_role: None,
+        };
+        let s = u.render_marker();
+        let inner = s
+            .trim_start_matches("<fleet-update>\n")
+            .trim_end_matches("</fleet-update>\n")
+            .trim();
+        let v: serde_json::Value = serde_json::from_str(inner).unwrap();
+        assert!(v["role"].is_null());
+    }
+
+    #[test]
+    fn compute_targets_role_changed_hits_all_including_subject() {
+        // Unlike InstanceCreated (subject's agend.md already covers its
+        // own existence), RoleChanged must also reach the subject —
+        // the subject's own Identity line was stamped at spawn with the
+        // old role, so they need the marker too.
+        let home = tempdir();
+        let registered: Vec<String> = vec!["dev-lead".into(), "dev-impl-1".into()];
+        let update = FleetUpdate::RoleChanged {
+            name: "dev-lead".into(),
+            new_role: Some("Senior architect".into()),
+        };
+        let mut targets = compute_targets(&home, &registered, &update);
+        targets.sort();
+        assert_eq!(
+            targets,
+            vec!["dev-impl-1".to_string(), "dev-lead".to_string()],
+            "RoleChanged must reach both subject and peers, got {targets:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn compute_targets_role_changed_honours_opt_out() {
+        let home = tempdir();
+        let fleet_yaml = r#"
+instances:
+  general:
+    backend: claude
+    receive_fleet_updates: false
+  dev-lead:
+    backend: claude
+"#;
+        std::fs::write(home.join("fleet.yaml"), fleet_yaml).unwrap();
+        let registered: Vec<String> = vec!["general".into(), "dev-lead".into()];
+        let update = FleetUpdate::RoleChanged {
+            name: "dev-lead".into(),
+            new_role: Some("Senior architect".into()),
+        };
+        let targets = compute_targets(&home, &registered, &update);
+        assert_eq!(
+            targets,
+            vec!["dev-lead".to_string()],
+            "opt-out agents must be excluded from role-changed broadcast too"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -235,6 +235,11 @@ pub(crate) fn build_instructions_body(
     content.push_str(
         "- `team-members-changed` — your team roster changed (fields: `team`, `added`, `removed`)\n",
     );
+    content.push_str(
+        "- `role-changed` — a peer (possibly you) had their role re-edited in fleet.yaml \
+         (fields: `name`, `role`); update your peer-role knowledge, and if `name` is your own, \
+         treat `role` as your new Role\n",
+    );
 
     // Protocol injection — path + minimal stub fallback
     content.push_str("\n## Fleet Protocol\n\n");


### PR DESCRIPTION
## Summary
Closes the log-and-skip TODO in \`src/bootstrap/reload.rs\` lines 10-14 by wiring the existing \`ReloadDiff::role_changed\` into \`fleet_broadcast\`. When an operator edits a role field in fleet.yaml, running agents learn about the change within a daemon tick (≤10 s) — no respawn needed.

## How the pieces fit
The infrastructure was already there:

| Piece | Where | Status before |
|---|---|---|
| File watching | \`FleetWatcher\` (bootstrap/reload.rs) | ✅ done |
| Schema diff | \`compute_diff\` → \`ReloadDiff::role_changed\` | ✅ done |
| Broadcast helper | \`fleet_broadcast::broadcast\` | ✅ done (PR #113) |
| **Role-changed event emission** | \`apply_fleet_reload\` | ❌ log-and-skip |
| **FleetUpdate::RoleChanged variant** | \`fleet_broadcast\` | ❌ |

This PR fills the two missing pieces. No new crates, no new watching, no schema migrations.

## Target selection
RoleChanged is **fleet-wide** including the subject. \`InstanceCreated\` excludes the subject because \`prepare_instructions\` just wrote its agend.md. \`RoleChanged\` does the opposite — the subject's Identity line was stamped with the *old* role at spawn, so the marker is exactly what tells them the role was re-edited.

Opt-out (\`receive_fleet_updates: false\`) still works — \`compute_targets\` filters after candidate selection, same as other kinds.

## agend.md contract
The \`## Fleet Updates\` section gains a fourth kind:

\`\`\`
- \`role-changed\` — a peer (possibly you) had their role re-edited in
  fleet.yaml (fields: \`name\`, \`role\`); update your peer-role knowledge,
  and if \`name\` is your own, treat \`role\` as your new Role
\`\`\`

## Test plan
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] 807 lib + 28 mcp_char + 16 mcp_roundtrip + 9 deployments + 5 drift + 2 supervisor — all pass
- [x] New unit tests: marker format (set + null role), target resolution (fleet-wide with subject, opt-out honoured)
- [ ] Smoke after merge: deploy dev team, edit \`dev-lead\`'s role in fleet.yaml, confirm \`<fleet-update kind="role-changed">\` appears in every running pane within 10 s

## Explicitly out of scope
- \`topic_id_changed\` — cosmetic, Telegram-specific, agents don't care
- \`command_changed\` / \`args_changed\` / \`working_dir_changed\` — these already warn \"requires manual restart\"; broadcast would be misleading since the running agent can't adopt the new config without respawn
- \`receive_fleet_updates\` toggled — the flag is read on each broadcast, no stamp needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)