### PR TITLE
S3-T1: PTY header injection + thread/parent schema + Unicode-correct threshold

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -34,7 +34,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
         crate::inbox::InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None,
+            read_at: None, thread_id: None, parent_id: None,
             from: format!("from:{from}"),
             text: text.to_string(),
             kind: params

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -28,33 +28,35 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     if from == target {
         return json!({"ok": false, "error": "cannot send to self"});
     }
-    let _ = crate::inbox::enqueue(
-        ctx.home,
-        target,
-        crate::inbox::InboxMessage {
-            schema_version: 0,
-            id: None,
-            read_at: None, thread_id: None, parent_id: None,
-            from: format!("from:{from}"),
-            text: text.to_string(),
-            kind: params
-                .get("kind")
-                .and_then(|v| v.as_str())
-                .map(String::from),
-            timestamp: chrono::Utc::now().to_rfc3339(),
-        },
-    );
-    let display_text = if text.chars().count() > 200 {
-        format!(
-            "{}... (use inbox tool)",
-            text.chars().take(200).collect::<String>()
-        )
-    } else {
-        text.to_string()
+    let msg = crate::inbox::InboxMessage {
+        schema_version: 0,
+        id: None,
+        read_at: None, thread_id: None, parent_id: None,
+        from: format!("from:{from}"),
+        text: text.to_string(),
+        kind: params
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        timestamp: chrono::Utc::now().to_rfc3339(),
     };
-    let inject_msg = format!(
-        "[from:{from}] {display_text} (Reply using send_to_instance MCP tool, NOT direct text)"
-    );
+    let _ = crate::inbox::enqueue(ctx.home, target, msg.clone());
+
+    let inject_msg = if text.len() > crate::inbox::HEADER_SIZE_THRESHOLD {
+        format!("{} (use inbox tool)", crate::inbox::format_header(&msg))
+    } else {
+        let display_text = if text.chars().count() > 200 {
+            format!(
+                "{}... (use inbox tool)",
+                text.chars().take(200).collect::<String>()
+            )
+        } else {
+            text.to_string()
+        };
+        format!(
+            "[from:{from}] {display_text} (Reply using send_to_instance MCP tool, NOT direct text)"
+        )
+    };
 
     let reg = agent::lock_registry(ctx.registry);
     if reg.contains_key(target) {

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -42,7 +42,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     };
     let _ = crate::inbox::enqueue(ctx.home, target, msg.clone());
 
-    let inject_msg = if text.len() > crate::inbox::HEADER_SIZE_THRESHOLD {
+    let inject_msg = if text.chars().count() > crate::inbox::HEADER_SIZE_THRESHOLD {
         format!("{} (use inbox tool)", crate::inbox::format_header(&msg))
     } else {
         let display_text = if text.chars().count() > 200 {

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -31,7 +31,9 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     let msg = crate::inbox::InboxMessage {
         schema_version: 0,
         id: None,
-        read_at: None, thread_id: None, parent_id: None,
+        read_at: None,
+        thread_id: None,
+        parent_id: None,
         from: format!("from:{from}"),
         text: text.to_string(),
         kind: params

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -436,7 +436,7 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
     let msg_obj = InboxMessage {
         schema_version: 0,
         id: None,
-        read_at: None,
+        read_at: None, thread_id: None, parent_id: None,
         from: format!("user:{username}"),
         text: text.to_string(),
         kind: Some("telegram".to_string()),

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -436,7 +436,9 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
     let msg_obj = InboxMessage {
         schema_version: 0,
         id: None,
-        read_at: None, thread_id: None, parent_id: None,
+        read_at: None,
+        thread_id: None,
+        parent_id: None,
         from: format!("user:{username}"),
         text: text.to_string(),
         kind: Some("telegram".to_string()),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,7 +194,7 @@ fn test_inbox(home: &Path) -> anyhow::Result<()> {
             inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None,
+                read_at: None, thread_id: None, parent_id: None,
                 from: format!("tester-{i}"),
                 text: format!("Message {i}"),
                 kind: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,7 +194,9 @@ fn test_inbox(home: &Path) -> anyhow::Result<()> {
             inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None, thread_id: None, parent_id: None,
+                read_at: None,
+                thread_id: None,
+                parent_id: None,
                 from: format!("tester-{i}"),
                 text: format!("Message {i}"),
                 kind: None,

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -226,7 +226,9 @@ async fn ci_check_repo(
             crate::inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None, thread_id: None, parent_id: None,
+                read_at: None,
+                thread_id: None,
+                parent_id: None,
                 from: "system:ci".to_string(),
                 text: msg,
                 kind: Some("ci-watch".to_string()),

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -226,7 +226,7 @@ async fn ci_check_repo(
             crate::inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None,
+                read_at: None, thread_id: None, parent_id: None,
                 from: "system:ci".to_string(),
                 text: msg,
                 kind: Some("ci-watch".to_string()),

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -118,7 +118,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                 crate::inbox::InboxMessage {
                     schema_version: 0,
                     id: None,
-                    read_at: None,
+                    read_at: None, thread_id: None, parent_id: None,
                     from: "system:schedule".to_string(),
                     text: message.to_string(),
                     kind: Some("schedule".to_string()),

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -118,7 +118,9 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                 crate::inbox::InboxMessage {
                     schema_version: 0,
                     id: None,
-                    read_at: None, thread_id: None, parent_id: None,
+                    read_at: None,
+                    thread_id: None,
+                    parent_id: None,
                     from: "system:schedule".to_string(),
                     text: message.to_string(),
                     kind: Some("schedule".to_string()),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -831,7 +831,9 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     text: message.to_string(),
                     kind: Some("schedule_replay".to_string()),
                     timestamp: now.to_rfc3339(),
-                    read_at: None, thread_id: None, parent_id: None,
+                    read_at: None,
+                    thread_id: None,
+                    parent_id: None,
                 },
             );
         }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -831,7 +831,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     text: message.to_string(),
                     kind: Some("schedule_replay".to_string()),
                     timestamp: now.to_rfc3339(),
-                    read_at: None,
+                    read_at: None, thread_id: None, parent_id: None,
                 },
             );
         }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -536,7 +536,9 @@ pub fn deliver(
         let msg = InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None, thread_id: None, parent_id: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
             from: source.to_string(),
             text: text.to_string(),
             kind,
@@ -664,7 +666,9 @@ mod tests {
         InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None, thread_id: None, parent_id: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
             from: from.to_string(),
             text: text.to_string(),
             kind: None,
@@ -786,7 +790,9 @@ mod tests {
         let msg = InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None, thread_id: None, parent_id: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
             from: "sender".to_string(),
             text: "body text".to_string(),
             kind: Some("notification".to_string()),
@@ -875,7 +881,9 @@ mod tests {
         let msg = InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None, thread_id: None, parent_id: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
             from: "test".to_string(),
             text: "hello \"world\"".to_string(),
             kind: None,
@@ -893,7 +901,9 @@ mod tests {
         let msg = InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None, thread_id: None, parent_id: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
             from: "user".to_string(),
             text: "line1\nline2\ttab".to_string(),
             kind: Some("special".to_string()),
@@ -1497,7 +1507,9 @@ mod tests {
 
         // None fields should be omitted from serialization (skip_serializing_if)
         let msg_no_thread = InboxMessage {
-            thread_id: None, parent_id: None, ..msg.clone()
+            thread_id: None,
+            parent_id: None,
+            ..msg.clone()
         };
         let json2 = serde_json::to_string(&msg_no_thread).expect("ser");
         assert!(!json2.contains("thread_id"));
@@ -1564,8 +1576,14 @@ mod tests {
             parent_id: None,
         };
         let header = format_header(&msg);
-        assert!(!header.contains('\n'), "header must not contain newline: {header:?}");
-        assert!(!header.contains('\r'), "header must not contain CR: {header:?}");
+        assert!(
+            !header.contains('\n'),
+            "header must not contain newline: {header:?}"
+        );
+        assert!(
+            !header.contains('\r'),
+            "header must not contain CR: {header:?}"
+        );
         assert!(header.contains("from=from:evil agent"));
         assert!(header.contains("kind=task  injection"));
     }
@@ -1584,8 +1602,10 @@ mod tests {
             parent_id: None,
         };
         let header = format_header(&msg);
-        assert!(!header.chars().any(|c| c.is_control() && c != '\x1b'),
-            "header must not contain control chars (except ANSI escape): {header:?}");
+        assert!(
+            !header.chars().any(|c| c.is_control() && c != '\x1b'),
+            "header must not contain control chars (except ANSI escape): {header:?}"
+        );
     }
 
     #[test]
@@ -1613,7 +1633,10 @@ mod tests {
             parent_id: None,
         };
         let header = format_header(&msg);
-        assert!(header.len() < HEADER_SIZE_THRESHOLD, "header must be compact");
+        assert!(
+            header.len() < HEADER_SIZE_THRESHOLD,
+            "header must be compact"
+        );
         assert!(header.contains(&format!("size={}", HEADER_SIZE_THRESHOLD + 1)));
     }
 
@@ -1624,7 +1647,7 @@ mod tests {
         let cjk = "你".repeat(100);
         assert_eq!(cjk.chars().count(), 100);
         assert_eq!(cjk.len(), 300); // bytes
-        // 100 chars < HEADER_SIZE_THRESHOLD (300) → should be short path
+                                    // 100 chars < HEADER_SIZE_THRESHOLD (300) → should be short path
         assert!(cjk.chars().count() <= HEADER_SIZE_THRESHOLD);
 
         // 301 CJK chars = 301 chars → should be long path
@@ -1644,6 +1667,9 @@ mod tests {
             parent_id: None,
         };
         let header = format_header(&msg);
-        assert!(header.contains("size=100"), "size must be char count (100), not byte count (300): {header}");
+        assert!(
+            header.contains("size=100"),
+            "size must be char count (100), not byte count (300): {header}"
+        );
     }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -167,6 +167,10 @@ pub struct InboxMessage {
     pub timestamp: String,
     #[serde(default)]
     pub read_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
 }
 
 impl InboxMessage {
@@ -494,7 +498,7 @@ pub fn deliver(
         let msg = InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None,
+            read_at: None, thread_id: None, parent_id: None,
             from: source.to_string(),
             text: text.to_string(),
             kind,
@@ -622,7 +626,7 @@ mod tests {
         InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None,
+            read_at: None, thread_id: None, parent_id: None,
             from: from.to_string(),
             text: text.to_string(),
             kind: None,
@@ -744,7 +748,7 @@ mod tests {
         let msg = InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None,
+            read_at: None, thread_id: None, parent_id: None,
             from: "sender".to_string(),
             text: "body text".to_string(),
             kind: Some("notification".to_string()),
@@ -833,7 +837,7 @@ mod tests {
         let msg = InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None,
+            read_at: None, thread_id: None, parent_id: None,
             from: "test".to_string(),
             text: "hello \"world\"".to_string(),
             kind: None,
@@ -851,7 +855,7 @@ mod tests {
         let msg = InboxMessage {
             schema_version: 0,
             id: None,
-            read_at: None,
+            read_at: None, thread_id: None, parent_id: None,
             from: "user".to_string(),
             text: "line1\nline2\ttab".to_string(),
             kind: Some("special".to_string()),
@@ -1424,5 +1428,41 @@ mod tests {
         );
 
         fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_inbox_msg_thread_parent_fields_roundtrip() {
+        // New fields with #[serde(default)] must round-trip and be absent from legacy
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "a".into(),
+            text: "t".into(),
+            kind: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: Some("thread-42".into()),
+            parent_id: Some("m-0".into()),
+        };
+        let json = serde_json::to_string(&msg).expect("ser");
+        assert!(json.contains("thread_id"));
+        assert!(json.contains("parent_id"));
+        let parsed: InboxMessage = serde_json::from_str(&json).expect("deser");
+        assert_eq!(parsed.thread_id.as_deref(), Some("thread-42"));
+        assert_eq!(parsed.parent_id.as_deref(), Some("m-0"));
+
+        // Legacy JSON without these fields → None (forward compat)
+        let legacy = r#"{"from":"x","text":"y","timestamp":"2026-01-01T00:00:00Z"}"#;
+        let parsed: InboxMessage = serde_json::from_str(legacy).expect("legacy deser");
+        assert!(parsed.thread_id.is_none());
+        assert!(parsed.parent_id.is_none());
+
+        // None fields should be omitted from serialization (skip_serializing_if)
+        let msg_no_thread = InboxMessage {
+            thread_id: None, parent_id: None, ..msg.clone()
+        };
+        let json2 = serde_json::to_string(&msg_no_thread).expect("ser");
+        assert!(!json2.contains("thread_id"));
+        assert!(!json2.contains("parent_id"));
     }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -1616,4 +1616,34 @@ mod tests {
         assert!(header.len() < HEADER_SIZE_THRESHOLD, "header must be compact");
         assert!(header.contains(&format!("size={}", HEADER_SIZE_THRESHOLD + 1)));
     }
+
+    #[test]
+    fn test_threshold_uses_char_count_not_bytes() {
+        // 100 CJK chars = 100 chars but 300 bytes (3 bytes each in UTF-8).
+        // Must be treated as short (100 < 300 threshold), not long.
+        let cjk = "你".repeat(100);
+        assert_eq!(cjk.chars().count(), 100);
+        assert_eq!(cjk.len(), 300); // bytes
+        // 100 chars < HEADER_SIZE_THRESHOLD (300) → should be short path
+        assert!(cjk.chars().count() <= HEADER_SIZE_THRESHOLD);
+
+        // 301 CJK chars = 301 chars → should be long path
+        let long_cjk = "你".repeat(HEADER_SIZE_THRESHOLD + 1);
+        assert!(long_cjk.chars().count() > HEADER_SIZE_THRESHOLD);
+
+        // format_header size= should report char count, not byte count
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: None,
+            from: "from:x".into(),
+            text: cjk,
+            kind: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+        };
+        let header = format_header(&msg);
+        assert!(header.contains("size=100"), "size must be char count (100), not byte count (300): {header}");
+    }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -379,27 +379,34 @@ pub const HEADER_SIZE_THRESHOLD: usize = 300;
 /// ANSI-colored header prefix for visual distinction in terminal.
 pub const HEADER_PREFIX: &str = "\x1b[44;97m[AGEND-MSG]\x1b[0m";
 
+/// Sanitize a value for header inclusion: replace control chars with space.
+fn sanitize_header_value(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect()
+}
+
 /// Format a single-line structured header for PTY injection.
 /// Fields: from / id / kind / thread / parent / size.
 /// Optional fields (thread/parent) omitted when None.
 pub fn format_header(msg: &InboxMessage) -> String {
     let mut parts = vec![
         HEADER_PREFIX.to_string(),
-        format!("from={}", msg.from),
+        format!("from={}", sanitize_header_value(&msg.from)),
     ];
     if let Some(ref id) = msg.id {
-        parts.push(format!("id={id}"));
+        parts.push(format!("id={}", sanitize_header_value(id)));
     }
     if let Some(ref kind) = msg.kind {
-        parts.push(format!("kind={kind}"));
+        parts.push(format!("kind={}", sanitize_header_value(kind)));
     }
     if let Some(ref thread) = msg.thread_id {
-        parts.push(format!("thread={thread}"));
+        parts.push(format!("thread={}", sanitize_header_value(thread)));
     }
     if let Some(ref parent) = msg.parent_id {
-        parts.push(format!("parent={parent}"));
+        parts.push(format!("parent={}", sanitize_header_value(parent)));
     }
-    parts.push(format!("size={}", msg.text.len()));
+    parts.push(format!("size={}", msg.text.chars().count()));
     parts.join(" ")
 }
 
@@ -1541,6 +1548,44 @@ mod tests {
         assert!(!header.contains("thread="));
         assert!(!header.contains("parent="));
         assert!(header.contains("size=5"));
+    }
+
+    #[test]
+    fn test_format_header_escapes_newlines() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "from:evil\nagent".into(),
+            text: "hello".into(),
+            kind: Some("task\r\ninjection".into()),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: Some("t\n1".into()),
+            parent_id: None,
+        };
+        let header = format_header(&msg);
+        assert!(!header.contains('\n'), "header must not contain newline: {header:?}");
+        assert!(!header.contains('\r'), "header must not contain CR: {header:?}");
+        assert!(header.contains("from=from:evil agent"));
+        assert!(header.contains("kind=task  injection"));
+    }
+
+    #[test]
+    fn test_format_header_escapes_control_chars() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: None,
+            from: "from:\x00null\x07bell".into(),
+            text: "t".into(),
+            kind: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+        };
+        let header = format_header(&msg);
+        assert!(!header.chars().any(|c| c.is_control() && c != '\x1b'),
+            "header must not contain control chars (except ANSI escape): {header:?}");
     }
 
     #[test]

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -372,6 +372,37 @@ fn read_drain_file(tmp: &Path) -> Vec<InboxMessage> {
 
 pub const INLINE_THRESHOLD: usize = 500;
 
+/// Size threshold for header-only PTY injection. Messages with body > this
+/// value inject only a structured header line; the full body stays in inbox.
+pub const HEADER_SIZE_THRESHOLD: usize = 300;
+
+/// ANSI-colored header prefix for visual distinction in terminal.
+pub const HEADER_PREFIX: &str = "\x1b[44;97m[AGEND-MSG]\x1b[0m";
+
+/// Format a single-line structured header for PTY injection.
+/// Fields: from / id / kind / thread / parent / size.
+/// Optional fields (thread/parent) omitted when None.
+pub fn format_header(msg: &InboxMessage) -> String {
+    let mut parts = vec![
+        HEADER_PREFIX.to_string(),
+        format!("from={}", msg.from),
+    ];
+    if let Some(ref id) = msg.id {
+        parts.push(format!("id={id}"));
+    }
+    if let Some(ref kind) = msg.kind {
+        parts.push(format!("kind={kind}"));
+    }
+    if let Some(ref thread) = msg.thread_id {
+        parts.push(format!("thread={thread}"));
+    }
+    if let Some(ref parent) = msg.parent_id {
+        parts.push(format!("parent={parent}"));
+    }
+    parts.push(format!("size={}", msg.text.len()));
+    parts.join(" ")
+}
+
 /// Sweep expired messages from all inbox files.
 /// - read_at.is_some() && elapsed > 7 days → delete
 /// - read_at.is_none() && elapsed > 30 days → delete
@@ -1464,5 +1495,80 @@ mod tests {
         let json2 = serde_json::to_string(&msg_no_thread).expect("ser");
         assert!(!json2.contains("thread_id"));
         assert!(!json2.contains("parent_id"));
+    }
+
+    #[test]
+    fn test_header_format_all_fields_present() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-42".into()),
+            from: "from:dev-lead".into(),
+            text: "x".repeat(500),
+            kind: Some("task".into()),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: Some("t-100".into()),
+            parent_id: Some("m-41".into()),
+        };
+        let header = format_header(&msg);
+        assert!(header.contains("[AGEND-MSG]"));
+        assert!(header.contains("from=from:dev-lead"));
+        assert!(header.contains("id=m-42"));
+        assert!(header.contains("kind=task"));
+        assert!(header.contains("thread=t-100"));
+        assert!(header.contains("parent=m-41"));
+        assert!(header.contains("size=500"));
+        assert!(!header.contains('\n'), "header must be single line");
+    }
+
+    #[test]
+    fn test_header_format_omits_none_fields() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "from:agent".into(),
+            text: "hello".into(),
+            kind: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+        };
+        let header = format_header(&msg);
+        assert!(header.contains("from=from:agent"));
+        assert!(header.contains("id=m-1"));
+        assert!(!header.contains("kind="));
+        assert!(!header.contains("thread="));
+        assert!(!header.contains("parent="));
+        assert!(header.contains("size=5"));
+    }
+
+    #[test]
+    fn test_short_msg_below_threshold() {
+        // Messages <= HEADER_SIZE_THRESHOLD should NOT use header format
+        let short = "a".repeat(HEADER_SIZE_THRESHOLD);
+        assert!(short.len() <= HEADER_SIZE_THRESHOLD);
+    }
+
+    #[test]
+    fn test_long_msg_above_threshold() {
+        // Messages > HEADER_SIZE_THRESHOLD should use header-only injection
+        let long = "a".repeat(HEADER_SIZE_THRESHOLD + 1);
+        assert!(long.len() > HEADER_SIZE_THRESHOLD);
+        // format_header produces a compact single-line representation
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "from:x".into(),
+            text: long,
+            kind: Some("task".into()),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+        };
+        let header = format_header(&msg);
+        assert!(header.len() < HEADER_SIZE_THRESHOLD, "header must be compact");
+        assert!(header.contains(&format!("size={}", HEADER_SIZE_THRESHOLD + 1)));
     }
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -631,7 +631,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 crate::inbox::InboxMessage {
                     schema_version: 0,
                     id: None,
-                    read_at: None,
+                    read_at: None, thread_id: None, parent_id: None,
                     from: "system:replace".to_string(),
                     text: format!("[handover] {handover}"),
                     kind: Some("handover".to_string()),
@@ -1980,7 +1980,7 @@ instances:
             crate::inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None,
+                read_at: None, thread_id: None, parent_id: None,
                 from: "user:test".to_string(),
                 text: "hello".to_string(),
                 kind: Some("telegram".to_string()),
@@ -2029,7 +2029,7 @@ instances:
             crate::inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None,
+                read_at: None, thread_id: None, parent_id: None,
                 from: "user:test".to_string(),
                 text: "burst".to_string(),
                 kind: Some("telegram".to_string()),

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -631,7 +631,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 crate::inbox::InboxMessage {
                     schema_version: 0,
                     id: None,
-                    read_at: None, thread_id: None, parent_id: None,
+                    read_at: None,
+                    thread_id: None,
+                    parent_id: None,
                     from: "system:replace".to_string(),
                     text: format!("[handover] {handover}"),
                     kind: Some("handover".to_string()),
@@ -1980,7 +1982,9 @@ instances:
             crate::inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None, thread_id: None, parent_id: None,
+                read_at: None,
+                thread_id: None,
+                parent_id: None,
                 from: "user:test".to_string(),
                 text: "hello".to_string(),
                 kind: Some("telegram".to_string()),
@@ -2029,7 +2033,9 @@ instances:
             crate::inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None, thread_id: None, parent_id: None,
+                read_at: None,
+                thread_id: None,
+                parent_id: None,
                 from: "user:test".to_string(),
                 text: "burst".to_string(),
                 kind: Some("telegram".to_string()),

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -890,6 +890,8 @@ mod tests {
                     kind: Some("schedule_replay".to_string()),
                     timestamp: chrono::Utc::now().to_rfc3339(),
                     read_at: None,
+                    thread_id: None,
+                    parent_id: None,
                 },
             );
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -287,7 +287,7 @@ fn test_inbox(home: &Path) -> TestResult {
             inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None,
+                read_at: None, thread_id: None, parent_id: None,
                 from: format!("test-{i}"),
                 text: format!("msg {i}"),
                 kind: None,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -287,7 +287,9 @@ fn test_inbox(home: &Path) -> TestResult {
             inbox::InboxMessage {
                 schema_version: 0,
                 id: None,
-                read_at: None, thread_id: None, parent_id: None,
+                read_at: None,
+                thread_id: None,
+                parent_id: None,
                 from: format!("test-{i}"),
                 text: format!("msg {i}"),
                 kind: None,


### PR DESCRIPTION
Sprint 3 T1 (base of stack). Replaces the original MCP notifications plan (spike-verified unsupported in 4/4 backends — see decision d-20260423153635457135-6) with a **PTY header-only injection** path.

## What changes

- \`InboxMessage\` gains \`thread_id\` / \`parent_id\` fields (Option<String>, serde default, schema_version stays 1 — forward/backward compatible). Sprint 4 correlation will fill these.
- New constant \`HEADER_SIZE_THRESHOLD = 300\` (Unicode chars, not bytes).
- New fn \`format_header(msg)\` emits a single line: \`[AGEND-MSG] from=X id=Y kind=Z thread=T parent=P size=N\`, with ANSI color wrap \`\x1b[44;97m...\x1b[0m\` (blue bg / white fg) for terminal visual separation from user input.
- Header field values are sanitized: any control character (newline/CR/etc) is replaced with a space so the header is guaranteed single-line even with hostile input.
- \`handle_send\` branches on \`text.chars().count() > 300\`:
  - long path → inject header-only (body lives in inbox JSONL, agent fetches via \`inbox\` / \`describe_message\` MCP tool)
  - short path → legacy full-text injection preserved
- Inbox JSONL **always** contains full body regardless of path.

## Tests
- \`test_inbox_msg_thread_parent_fields_roundtrip\` — schema migration (legacy JSON without fields → None)
- \`test_format_header_escapes_newlines\` / \`test_format_header_escapes_control_chars\` — single-line guarantee
- \`test_threshold_uses_char_count_not_bytes\` — 100 CJK chars (300 bytes) correctly stays on short path
- Plus existing header format/threshold unit coverage
- Full \`cargo test\` — 805+ passing

## Commits
- \`b7a8bd2\` feat(inbox): add thread_id/parent_id fields
- \`215b000\` feat(inbox): PTY header-only injection over 300 chars
- \`4c6a201\` fix(inbox): sanitize header field values against newlines/control chars
- \`25aa529\` fix(inbox): threshold + size use char count (Unicode-correct)

## Internal review
Audited by dev-reviewer (codex backend) twice — initially REJECTED on (F1) unsanitized field values allowing multi-line headers and (F2) byte vs char threshold; both fixes VERIFIED in commits 4c6a201 + 25aa529.

## Stack
Base of a 3-PR Sprint 3 stack: S3-T2 adds agent instructions, S3-T3 adds idle poll-reminder. Drafted separately once this lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)