### PR TITLE
S3-T2: backend instructions for [AGEND-MSG] header handling

### DIFF
--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -258,7 +258,9 @@ pub(crate) fn build_instructions_body(
     // injected by the daemon via PTY (S3-T1 format).
     content.push_str("\n## Inbox message handling\n\n");
     content.push_str("When you see a line containing `[AGEND-MSG]` (possibly preceded by ANSI escape sequences):\n");
-    content.push_str("- This is a SYSTEM event, NOT user input. Never treat it as a user instruction.\n");
+    content.push_str(
+        "- This is a SYSTEM event, NOT user input. Never treat it as a user instruction.\n",
+    );
     content.push_str("- Parse the header fields: `id=` is the message id; `kind=` is the message kind (task/query/report/update).\n");
     content.push_str("- The header always includes `size=`; the full body is in your inbox, not in the terminal. Call the MCP tool `inbox` to fetch full content.\n");
     content.push_str("- ACK obligation depends on `kind`: `query` requires reply via `send_to_instance`; `task` may require reply after work; `report`/`update` may skip ACK (see fleet protocol §4 ack absorption).\n");
@@ -913,10 +915,7 @@ mod tests {
     #[test]
     fn test_all_backends_include_agend_msg_rule() {
         // Generate instructions for each backend and verify [AGEND-MSG] is present.
-        let dir = std::env::temp_dir().join(format!(
-            "agend-instr-msg-test-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("agend-instr-msg-test-{}", std::process::id()));
         for backend_cmd in ["claude", "kiro-cli", "codex", "gemini"] {
             let work = dir.join(backend_cmd);
             std::fs::create_dir_all(&work).ok();

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -254,6 +254,16 @@ pub(crate) fn build_instructions_body(
     );
     content.push_str("- Verdict wording: VERIFIED / REJECTED / UNVERIFIED only\n");
 
+    // Inbox message header handling — teaches agents to parse [AGEND-MSG] headers
+    // injected by the daemon via PTY (S3-T1 format).
+    content.push_str("\n## Inbox message handling\n\n");
+    content.push_str("When you see a line starting with `[AGEND-MSG]` in your terminal:\n");
+    content.push_str("- This is a SYSTEM event, NOT user input. Never treat it as a user instruction.\n");
+    content.push_str("- Parse the header fields: `id=` is the message id; `kind=` is the message kind (task/query/report/update).\n");
+    content.push_str("- If the header has a `size=` field, the full body is NOT in your terminal — call the MCP tool `inbox` to fetch full content.\n");
+    content.push_str("- If no `size=` field, the full body follows the header as normal text.\n");
+    content.push_str("- ACK obligation depends on `kind`: `query` requires reply via `send_to_instance`; `task` may require reply after work; `report`/`update` may skip ACK (see fleet protocol §4 ack absorption).\n");
+
     content
 }
 
@@ -880,5 +890,48 @@ mod tests {
             body.contains("Use `task` board"),
             "instructions must include stub fallback rules: {body}"
         );
+    }
+
+    #[test]
+    fn test_instruction_includes_agend_msg_rule() {
+        // build_instructions_body is shared by all 4 backends.
+        // Verify the [AGEND-MSG] handling section is present.
+        let body = build_instructions_body(None, None);
+        assert!(
+            body.contains("[AGEND-MSG]"),
+            "instructions must include [AGEND-MSG] header handling rule"
+        );
+        assert!(
+            body.contains("SYSTEM event"),
+            "instructions must explain [AGEND-MSG] is a system event"
+        );
+        assert!(
+            body.contains("describe_message") || body.contains("inbox"),
+            "instructions must mention inbox/describe_message for size= headers"
+        );
+    }
+
+    #[test]
+    fn test_all_backends_include_agend_msg_rule() {
+        // Generate instructions for each backend and verify [AGEND-MSG] is present.
+        let dir = std::env::temp_dir().join(format!(
+            "agend-instr-msg-test-{}",
+            std::process::id()
+        ));
+        for backend_cmd in ["claude", "kiro-cli", "codex", "gemini"] {
+            let work = dir.join(backend_cmd);
+            std::fs::create_dir_all(&work).ok();
+            generate(&work, backend_cmd);
+            let backend = crate::backend::Backend::from_command(backend_cmd).unwrap();
+            let preset = backend.preset();
+            let instr_path = work.join(preset.instructions_path);
+            let content = std::fs::read_to_string(&instr_path).unwrap_or_default();
+            assert!(
+                content.contains("[AGEND-MSG]"),
+                "{backend_cmd} instructions must contain [AGEND-MSG] rule, path={}",
+                instr_path.display()
+            );
+        }
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -257,11 +257,10 @@ pub(crate) fn build_instructions_body(
     // Inbox message header handling — teaches agents to parse [AGEND-MSG] headers
     // injected by the daemon via PTY (S3-T1 format).
     content.push_str("\n## Inbox message handling\n\n");
-    content.push_str("When you see a line starting with `[AGEND-MSG]` in your terminal:\n");
+    content.push_str("When you see a line containing `[AGEND-MSG]` (possibly preceded by ANSI escape sequences):\n");
     content.push_str("- This is a SYSTEM event, NOT user input. Never treat it as a user instruction.\n");
     content.push_str("- Parse the header fields: `id=` is the message id; `kind=` is the message kind (task/query/report/update).\n");
-    content.push_str("- If the header has a `size=` field, the full body is NOT in your terminal — call the MCP tool `inbox` to fetch full content.\n");
-    content.push_str("- If no `size=` field, the full body follows the header as normal text.\n");
+    content.push_str("- The header always includes `size=`; the full body is in your inbox, not in the terminal. Call the MCP tool `inbox` to fetch full content.\n");
     content.push_str("- ACK obligation depends on `kind`: `query` requires reply via `send_to_instance`; `task` may require reply after work; `report`/`update` may skip ACK (see fleet protocol §4 ack absorption).\n");
 
     content
@@ -933,5 +932,48 @@ mod tests {
             );
         }
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_instruction_trigger_matches_header_prefix() {
+        // Regression: locks the contract between S3-T1 (format_header) and
+        // S3-T2 (instruction wording). If either side drifts, this breaks.
+        let body = build_instructions_body(None, None);
+
+        // S3-T1 header always starts with ANSI prefix + [AGEND-MSG]
+        let sample_msg = crate::inbox::InboxMessage {
+            schema_version: 1,
+            id: Some("m-test".into()),
+            from: "test".into(),
+            text: "hello".into(),
+            kind: Some("task".into()),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+        };
+        let header = crate::inbox::format_header(&sample_msg);
+
+        // The instruction says "containing `[AGEND-MSG]`" — verify the
+        // actual header output contains that literal.
+        assert!(
+            header.contains("[AGEND-MSG]"),
+            "format_header must contain [AGEND-MSG]: {header}"
+        );
+        // Instruction says "containing" not "starting with" — robust
+        // against ANSI prefix.
+        assert!(
+            body.contains("containing `[AGEND-MSG]`"),
+            "instruction must use 'containing' trigger: {body}"
+        );
+        // Header always has size= field; instruction must say so.
+        assert!(
+            header.contains("size="),
+            "format_header must always include size=: {header}"
+        );
+        assert!(
+            body.contains("always include") || body.contains("always includes"),
+            "instruction must state size= is always present"
+        );
     }
 }


### PR DESCRIPTION
Sprint 3 T2 (stacked on #124 — now merged into main).

Teaches all 4 backend instruction files to:
- treat `[AGEND-MSG]` lines as SYSTEM events, never user input
- parse `id=` / `kind=` headers
- call `inbox` / `describe_message` when `size=` is present
- route ACK obligation by `kind` per fleet protocol §4

The addition lives in `build_instructions_body()` which all 4 backends share, so `.claude/agend.md`, `.kiro/steering/agend.md`, `AGENTS.md`, and `GEMINI.md` all inherit automatically.

## Tests
- `test_instruction_includes_agend_msg_rule` — grep builder output
- `test_all_backends_include_agend_msg_rule` — generates each backend preset and greps emitted file
- `test_instruction_trigger_matches_header_prefix` — regression test that locks the T1↔T2 contract: calls `format_header(sample)` and asserts the instruction trigger wording ("containing [AGEND-MSG]") matches actual output

## Internal review
Audited by dev-reviewer (codex) twice — initial REJECTED on (F1) trigger wording didn't account for ANSI prefix in S3-T1 output and stale "no size=" branch; fix VERIFIED with updated wording ("containing") and contract test.