### PR TITLE
S3-T3: idle poll-reminder via collect_poll_reminders + format_event_header

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3,6 +3,7 @@
 
 pub(crate) mod ci_watch;
 pub(crate) mod cron_tick;
+pub(crate) mod poll_reminder;
 pub(crate) mod supervisor;
 mod tui_bridge;
 pub(crate) mod watchdog;
@@ -481,6 +482,18 @@ fn run_core(
             {
                 crate::inbox::sweep_expired(home);
                 crate::inbox::check_disk_space(home);
+            }
+        }
+
+        // Poll-reminder: nudge idle agents with unread inbox (every 30 ticks)
+        {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static POLL_COUNTER: AtomicU64 = AtomicU64::new(0);
+            if POLL_COUNTER
+                .fetch_add(1, Ordering::Relaxed)
+                .is_multiple_of(30)
+            {
+                poll_reminder::poll_reminder_pass(home, &registry);
             }
         }
 

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -74,6 +74,7 @@ pub fn poll_reminder_pass(home: &Path, registry: &AgentRegistry) {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::agent::{AgentCore, AgentHandle};

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -85,12 +85,8 @@ mod tests {
         use std::sync::atomic::{AtomicU32, Ordering};
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!(
-            "agend-poll-{}-{}-{}",
-            std::process::id(),
-            tag,
-            id
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("agend-poll-{}-{}-{}", std::process::id(), tag, id));
         std::fs::create_dir_all(&dir).ok();
         dir
     }
@@ -119,9 +115,17 @@ mod tests {
         use portable_pty::{CommandBuilder, PtySize};
         let pty_system = native_pty_system();
         let pair = pty_system
-            .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
             .expect("openpty");
-        let child = pair.slave.spawn_command(CommandBuilder::new("true")).expect("spawn");
+        let child = pair
+            .slave
+            .spawn_command(CommandBuilder::new("true"))
+            .expect("spawn");
         let writer = pair.master.take_writer().expect("writer");
         let mut st = StateTracker::new(None);
         st.current = state;
@@ -185,7 +189,10 @@ mod tests {
         assert_eq!(v1.len(), 1);
 
         let v2 = collect_poll_reminders(&home, &registry);
-        assert!(v2.is_empty(), "second call with same count must be suppressed by dedup");
+        assert!(
+            v2.is_empty(),
+            "second call with same count must be suppressed by dedup"
+        );
 
         std::fs::remove_dir_all(&home).ok();
     }
@@ -206,7 +213,11 @@ mod tests {
         seed_unread(&home, agent, 2);
         let v2 = collect_poll_reminders(&home, &registry);
         assert_eq!(v2.len(), 1, "count changed → should re-notify");
-        assert!(v2[0].1.contains("unread=5"), "must reflect new count, got: {}", v2[0].1);
+        assert!(
+            v2[0].1.contains("unread=5"),
+            "must reflect new count, got: {}",
+            v2[0].1
+        );
 
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -25,49 +25,50 @@ fn should_notify_and_record(name: &str, count: usize) -> bool {
     true
 }
 
-/// Run one poll-reminder pass. Called from daemon tick every N ticks.
-///
-/// For each managed agent: if Idle + unread > 0 + count changed since
-/// last notification → inject a single-line reminder to PTY.
-pub fn poll_reminder_pass(home: &Path, registry: &AgentRegistry) {
-    let mut to_notify: Vec<(String, String)> = Vec::new();
-    {
-        let reg = agent::lock_registry(registry);
-        for (name, handle) in reg.iter() {
-            let agent_state = match handle.core.lock() {
-                Ok(c) => c.state.current,
-                Err(_) => continue,
-            };
-            if agent_state != AgentState::Idle {
-                continue;
-            }
-            let (count, oldest) = crate::inbox::unread_count(home, name);
-            if count == 0 {
-                continue;
-            }
-            if !should_notify_and_record(name, count) {
-                continue;
-            }
-
-            let age_str = match oldest {
-                Some(ts) => {
-                    let mins = chrono::Utc::now()
-                        .signed_duration_since(ts)
-                        .num_minutes()
-                        .max(0);
-                    format!("{mins}m")
-                }
-                None => "?".to_string(),
-            };
-            let count_str = count.to_string();
-            let reminder = crate::inbox::format_event_header(
-                "poll-reminder",
-                &[("unread", &count_str), ("oldest", &age_str)],
-            );
-            to_notify.push((name.clone(), reminder));
+/// Pure collector: returns (agent_name, reminder_string) for each agent
+/// that should be nudged. No side effects — does not inject into PTY.
+pub fn collect_poll_reminders(home: &Path, registry: &AgentRegistry) -> Vec<(String, String)> {
+    let mut result = Vec::new();
+    let reg = agent::lock_registry(registry);
+    for (name, handle) in reg.iter() {
+        let agent_state = match handle.core.lock() {
+            Ok(c) => c.state.current,
+            Err(_) => continue,
+        };
+        if agent_state != AgentState::Idle {
+            continue;
         }
+        let (count, oldest) = crate::inbox::unread_count(home, name);
+        if count == 0 {
+            continue;
+        }
+        if !should_notify_and_record(name, count) {
+            continue;
+        }
+        let age_str = match oldest {
+            Some(ts) => {
+                let mins = chrono::Utc::now()
+                    .signed_duration_since(ts)
+                    .num_minutes()
+                    .max(0);
+                format!("{mins}m")
+            }
+            None => "?".to_string(),
+        };
+        let count_str = count.to_string();
+        let reminder = crate::inbox::format_event_header(
+            "poll-reminder",
+            &[("unread", &count_str), ("oldest", &age_str)],
+        );
+        result.push((name.clone(), reminder));
     }
-    for (name, reminder) in to_notify {
+    result
+}
+
+/// Run one poll-reminder pass. Called from daemon tick every N ticks.
+/// Collects reminders via [`collect_poll_reminders`] then injects each.
+pub fn poll_reminder_pass(home: &Path, registry: &AgentRegistry) {
+    for (name, reminder) in collect_poll_reminders(home, registry) {
         crate::inbox::compose_aware_inject(home, &name, &reminder);
     }
 }
@@ -101,7 +102,7 @@ mod tests {
                 agent,
                 crate::inbox::InboxMessage {
                     schema_version: 1,
-                    id: Some(format!("m-{i}")),
+                    id: Some(format!("m-{agent}-{i}")),
                     from: "test".into(),
                     text: format!("msg {i}"),
                     kind: None,
@@ -114,32 +115,20 @@ mod tests {
         }
     }
 
-    /// Build a minimal AgentRegistry with one agent at the given state.
-    /// The PTY/writer are real but unused — we only inspect inbox side effects.
     fn mock_registry(name: &str, state: AgentState) -> AgentRegistry {
         use portable_pty::{CommandBuilder, PtySize};
         let pty_system = native_pty_system();
         let pair = pty_system
-            .openpty(PtySize {
-                rows: 24,
-                cols: 80,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
+            .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
             .expect("openpty");
-        let child = pair
-            .slave
-            .spawn_command(CommandBuilder::new("true"))
-            .expect("spawn");
-
+        let child = pair.slave.spawn_command(CommandBuilder::new("true")).expect("spawn");
         let writer = pair.master.take_writer().expect("writer");
-        let mut state_tracker = StateTracker::new(None);
-        state_tracker.current = state;
-
+        let mut st = StateTracker::new(None);
+        st.current = state;
         let core = AgentCore {
             vterm: crate::vterm::VTerm::new(24, 80),
             subscribers: Vec::new(),
-            state: state_tracker,
+            state: st,
             health: crate::health::HealthTracker::new(),
         };
         let handle = AgentHandle {
@@ -158,64 +147,80 @@ mod tests {
         reg
     }
 
+    /// Reset dedup state for a specific agent to allow fresh test runs.
+    fn reset_dedup(name: &str) {
+        let mut guard = LAST_NOTIFIED.lock().unwrap();
+        if let Some(map) = guard.as_mut() {
+            map.remove(name);
+        }
+    }
+
     #[test]
-    fn test_poll_reminder_pass_injects_when_idle_with_unread() {
-        let home = tmp_home("pass-inject");
-        // Use a unique agent name to avoid dedup interference from other tests
-        let agent = "poll-inject-agent";
+    fn test_collect_poll_reminders_returns_reminder_when_idle_with_unread() {
+        let home = tmp_home("collect-idle");
+        let agent = "collect-idle-agent";
         seed_unread(&home, agent, 3);
         let registry = mock_registry(agent, AgentState::Idle);
+        reset_dedup(agent);
 
-        // Reset dedup state for this agent
-        should_notify_and_record(agent, 0);
-
-        poll_reminder_pass(&home, &registry);
-
-        // Verify: dedup state updated to 3
-        assert!(!should_notify_and_record(agent, 3), "dedup should block same count");
+        let v = collect_poll_reminders(&home, &registry);
+        assert_eq!(v.len(), 1, "should produce 1 reminder");
+        assert_eq!(v[0].0, agent);
+        assert!(v[0].1.contains("[AGEND-MSG]"), "must contain header prefix");
+        assert!(v[0].1.contains("kind=poll-reminder"), "must contain kind");
+        assert!(v[0].1.contains("unread=3"), "must contain unread count");
 
         std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn test_poll_reminder_pass_dedupes_same_count() {
-        let home = tmp_home("pass-dedup");
-        let agent = "poll-dedup-agent";
-        seed_unread(&home, agent, 2);
+    fn test_collect_poll_reminders_dedupes_same_count() {
+        let home = tmp_home("collect-dedup");
+        let agent = "collect-dedup-agent";
+        seed_unread(&home, agent, 3);
         let registry = mock_registry(agent, AgentState::Idle);
+        reset_dedup(agent);
 
-        // Reset dedup
-        should_notify_and_record(agent, 0);
+        let v1 = collect_poll_reminders(&home, &registry);
+        assert_eq!(v1.len(), 1);
 
-        // First pass: should notify (count changed 0→2)
-        poll_reminder_pass(&home, &registry);
-        // Second pass: same count → should NOT notify (dedup blocks)
-        assert!(!should_notify_and_record(agent, 2));
-
-        // Add more unread → count changes → should notify again
-        seed_unread(&home, agent, 1); // now 3 total
-        assert!(should_notify_and_record(agent, 3));
+        let v2 = collect_poll_reminders(&home, &registry);
+        assert!(v2.is_empty(), "second call with same count must be suppressed by dedup");
 
         std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn test_poll_reminder_pass_skips_when_busy() {
-        let home = tmp_home("pass-busy");
-        let agent = "poll-busy-agent";
+    fn test_collect_poll_reminders_re_notifies_on_count_change() {
+        let home = tmp_home("collect-renotify");
+        let agent = "collect-renotify-agent";
+        seed_unread(&home, agent, 3);
+        let registry = mock_registry(agent, AgentState::Idle);
+        reset_dedup(agent);
+
+        let v1 = collect_poll_reminders(&home, &registry);
+        assert_eq!(v1.len(), 1);
+        assert!(v1[0].1.contains("unread=3"));
+
+        // Add 2 more unread → count changes to 5
+        seed_unread(&home, agent, 2);
+        let v2 = collect_poll_reminders(&home, &registry);
+        assert_eq!(v2.len(), 1, "count changed → should re-notify");
+        assert!(v2[0].1.contains("unread=5"), "must reflect new count, got: {}", v2[0].1);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_collect_poll_reminders_skips_when_busy() {
+        let home = tmp_home("collect-busy");
+        let agent = "collect-busy-agent";
         seed_unread(&home, agent, 5);
         let registry = mock_registry(agent, AgentState::Thinking);
+        reset_dedup(agent);
 
-        // Reset dedup
-        should_notify_and_record(agent, 0);
-
-        poll_reminder_pass(&home, &registry);
-
-        // Dedup state should NOT have been updated (agent was busy, skipped)
-        assert!(
-            should_notify_and_record(agent, 5),
-            "busy agent should not have been recorded in dedup"
-        );
+        let v = collect_poll_reminders(&home, &registry);
+        assert!(v.is_empty(), "busy agent must not get reminder");
 
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -1,0 +1,162 @@
+//! Poll-reminder: nudge idle agents that have unread inbox messages.
+
+use crate::agent::{self, AgentRegistry};
+use crate::state::AgentState;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+
+/// Per-agent de-dup state: last notified unread count.
+static LAST_NOTIFIED: Mutex<Option<HashMap<String, usize>>> = Mutex::new(None);
+
+fn get_last(name: &str) -> usize {
+    LAST_NOTIFIED
+        .lock()
+        .ok()
+        .and_then(|g| g.as_ref()?.get(name).copied())
+        .unwrap_or(0)
+}
+
+fn set_last(name: &str, count: usize) {
+    let mut guard = match LAST_NOTIFIED.lock() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    let map = guard.get_or_insert_with(HashMap::new);
+    map.insert(name.to_string(), count);
+}
+
+/// Run one poll-reminder pass. Called from daemon tick every N ticks.
+///
+/// For each managed agent: if Idle + unread > 0 + count changed since
+/// last notification → inject a single-line reminder to PTY.
+pub fn poll_reminder_pass(home: &Path, registry: &AgentRegistry) {
+    let mut to_notify: Vec<(String, String)> = Vec::new();
+    {
+        let reg = agent::lock_registry(registry);
+        for (name, handle) in reg.iter() {
+            let agent_state = match handle.core.lock() {
+                Ok(c) => c.state.current,
+                Err(_) => continue,
+            };
+            if agent_state != AgentState::Idle {
+                continue;
+            }
+            let (count, oldest) = crate::inbox::unread_count(home, name);
+            if count == 0 {
+                continue;
+            }
+            if get_last(name) == count {
+                continue;
+            }
+            set_last(name, count);
+
+            let age_str = match oldest {
+                Some(ts) => {
+                    let mins = chrono::Utc::now()
+                        .signed_duration_since(ts)
+                        .num_minutes()
+                        .max(0);
+                    format!("{mins}m")
+                }
+                None => "?".to_string(),
+            };
+            let reminder = format!(
+                "{} kind=poll-reminder unread={count} oldest={age_str}",
+                crate::inbox::HEADER_PREFIX,
+            );
+            to_notify.push((name.clone(), reminder));
+        }
+    }
+    for (name, reminder) in to_notify {
+        crate::inbox::compose_aware_inject(home, &name, &reminder);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::health::HealthTracker;
+    use crate::state::AgentState;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-poll-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn seed_unread(home: &Path, agent: &str, count: usize) {
+        for i in 0..count {
+            let _ = crate::inbox::enqueue(
+                home,
+                agent,
+                crate::inbox::InboxMessage {
+                    schema_version: 1,
+                    id: Some(format!("m-{i}")),
+                    from: "test".into(),
+                    text: format!("msg {i}"),
+                    kind: None,
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    read_at: None,
+                    thread_id: None,
+                    parent_id: None,
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn test_poll_reminder_injects_when_idle_with_unread() {
+        let home = tmp_home("inject");
+        seed_unread(&home, "agent1", 3);
+        let (count, oldest) = crate::inbox::unread_count(&home, "agent1");
+        assert_eq!(count, 3);
+        assert!(oldest.is_some());
+
+        // Verify the reminder format
+        let age_mins = chrono::Utc::now()
+            .signed_duration_since(oldest.unwrap())
+            .num_minutes()
+            .max(0);
+        let reminder = format!(
+            "{} kind=poll-reminder unread=3 oldest={age_mins}m",
+            crate::inbox::HEADER_PREFIX,
+        );
+        assert!(reminder.contains("[AGEND-MSG]"));
+        assert!(reminder.contains("unread=3"));
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_poll_reminder_dedupes_same_count() {
+        // set_last + get_last should prevent re-notification
+        set_last("dedup-agent", 5);
+        assert_eq!(get_last("dedup-agent"), 5);
+        // Same count → would skip in poll_reminder_pass
+        // Different count → would notify
+        set_last("dedup-agent", 7);
+        assert_eq!(get_last("dedup-agent"), 7);
+    }
+
+    #[test]
+    fn test_poll_reminder_skips_when_busy() {
+        // AgentState != Idle should be skipped
+        for state in [
+            AgentState::Thinking,
+            AgentState::ToolUse,
+            AgentState::Starting,
+            AgentState::Ready,
+        ] {
+            assert_ne!(state, AgentState::Idle, "{state:?} must not be Idle");
+        }
+    }
+}

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -9,21 +9,20 @@ use std::sync::Mutex;
 /// Per-agent de-dup state: last notified unread count.
 static LAST_NOTIFIED: Mutex<Option<HashMap<String, usize>>> = Mutex::new(None);
 
-fn get_last(name: &str) -> usize {
-    LAST_NOTIFIED
-        .lock()
-        .ok()
-        .and_then(|g| g.as_ref()?.get(name).copied())
-        .unwrap_or(0)
-}
-
-fn set_last(name: &str, count: usize) {
+/// Atomic check-and-record: returns true if count changed (should notify),
+/// and records the new count in the same lock scope.
+fn should_notify_and_record(name: &str, count: usize) -> bool {
     let mut guard = match LAST_NOTIFIED.lock() {
         Ok(g) => g,
-        Err(_) => return,
+        Err(_) => return false,
     };
     let map = guard.get_or_insert_with(HashMap::new);
+    let prev = map.get(name).copied().unwrap_or(0);
+    if prev == count {
+        return false;
+    }
     map.insert(name.to_string(), count);
+    true
 }
 
 /// Run one poll-reminder pass. Called from daemon tick every N ticks.
@@ -46,10 +45,9 @@ pub fn poll_reminder_pass(home: &Path, registry: &AgentRegistry) {
             if count == 0 {
                 continue;
             }
-            if get_last(name) == count {
+            if !should_notify_and_record(name, count) {
                 continue;
             }
-            set_last(name, count);
 
             let age_str = match oldest {
                 Some(ts) => {
@@ -61,9 +59,10 @@ pub fn poll_reminder_pass(home: &Path, registry: &AgentRegistry) {
                 }
                 None => "?".to_string(),
             };
-            let reminder = format!(
-                "{} kind=poll-reminder unread={count} oldest={age_str}",
-                crate::inbox::HEADER_PREFIX,
+            let count_str = count.to_string();
+            let reminder = crate::inbox::format_event_header(
+                "poll-reminder",
+                &[("unread", &count_str), ("oldest", &age_str)],
             );
             to_notify.push((name.clone(), reminder));
         }
@@ -76,8 +75,10 @@ pub fn poll_reminder_pass(home: &Path, registry: &AgentRegistry) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::health::HealthTracker;
-    use crate::state::AgentState;
+    use crate::agent::{AgentCore, AgentHandle};
+    use crate::state::StateTracker;
+    use portable_pty::native_pty_system;
+    use std::sync::{Arc, Mutex as StdMutex};
 
     fn tmp_home(tag: &str) -> std::path::PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};
@@ -113,50 +114,109 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_poll_reminder_injects_when_idle_with_unread() {
-        let home = tmp_home("inject");
-        seed_unread(&home, "agent1", 3);
-        let (count, oldest) = crate::inbox::unread_count(&home, "agent1");
-        assert_eq!(count, 3);
-        assert!(oldest.is_some());
+    /// Build a minimal AgentRegistry with one agent at the given state.
+    /// The PTY/writer are real but unused — we only inspect inbox side effects.
+    fn mock_registry(name: &str, state: AgentState) -> AgentRegistry {
+        use portable_pty::{CommandBuilder, PtySize};
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+        let child = pair
+            .slave
+            .spawn_command(CommandBuilder::new("true"))
+            .expect("spawn");
 
-        // Verify the reminder format
-        let age_mins = chrono::Utc::now()
-            .signed_duration_since(oldest.unwrap())
-            .num_minutes()
-            .max(0);
-        let reminder = format!(
-            "{} kind=poll-reminder unread=3 oldest={age_mins}m",
-            crate::inbox::HEADER_PREFIX,
-        );
-        assert!(reminder.contains("[AGEND-MSG]"));
-        assert!(reminder.contains("unread=3"));
+        let writer = pair.master.take_writer().expect("writer");
+        let mut state_tracker = StateTracker::new(None);
+        state_tracker.current = state;
+
+        let core = AgentCore {
+            vterm: crate::vterm::VTerm::new(24, 80),
+            subscribers: Vec::new(),
+            state: state_tracker,
+            health: crate::health::HealthTracker::new(),
+        };
+        let handle = AgentHandle {
+            name: name.to_string(),
+            backend_command: "test".to_string(),
+            pty_writer: Arc::new(StdMutex::new(writer)),
+            pty_master: Arc::new(StdMutex::new(pair.master)),
+            core: Arc::new(StdMutex::new(core)),
+            child: Arc::new(StdMutex::new(child)),
+            submit_key: "\r".to_string(),
+            inject_prefix: String::new(),
+            typed_inject: false,
+        };
+        let reg: AgentRegistry = Arc::new(StdMutex::new(HashMap::new()));
+        reg.lock().unwrap().insert(name.to_string(), handle);
+        reg
+    }
+
+    #[test]
+    fn test_poll_reminder_pass_injects_when_idle_with_unread() {
+        let home = tmp_home("pass-inject");
+        // Use a unique agent name to avoid dedup interference from other tests
+        let agent = "poll-inject-agent";
+        seed_unread(&home, agent, 3);
+        let registry = mock_registry(agent, AgentState::Idle);
+
+        // Reset dedup state for this agent
+        should_notify_and_record(agent, 0);
+
+        poll_reminder_pass(&home, &registry);
+
+        // Verify: dedup state updated to 3
+        assert!(!should_notify_and_record(agent, 3), "dedup should block same count");
 
         std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn test_poll_reminder_dedupes_same_count() {
-        // set_last + get_last should prevent re-notification
-        set_last("dedup-agent", 5);
-        assert_eq!(get_last("dedup-agent"), 5);
-        // Same count → would skip in poll_reminder_pass
-        // Different count → would notify
-        set_last("dedup-agent", 7);
-        assert_eq!(get_last("dedup-agent"), 7);
+    fn test_poll_reminder_pass_dedupes_same_count() {
+        let home = tmp_home("pass-dedup");
+        let agent = "poll-dedup-agent";
+        seed_unread(&home, agent, 2);
+        let registry = mock_registry(agent, AgentState::Idle);
+
+        // Reset dedup
+        should_notify_and_record(agent, 0);
+
+        // First pass: should notify (count changed 0→2)
+        poll_reminder_pass(&home, &registry);
+        // Second pass: same count → should NOT notify (dedup blocks)
+        assert!(!should_notify_and_record(agent, 2));
+
+        // Add more unread → count changes → should notify again
+        seed_unread(&home, agent, 1); // now 3 total
+        assert!(should_notify_and_record(agent, 3));
+
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn test_poll_reminder_skips_when_busy() {
-        // AgentState != Idle should be skipped
-        for state in [
-            AgentState::Thinking,
-            AgentState::ToolUse,
-            AgentState::Starting,
-            AgentState::Ready,
-        ] {
-            assert_ne!(state, AgentState::Idle, "{state:?} must not be Idle");
-        }
+    fn test_poll_reminder_pass_skips_when_busy() {
+        let home = tmp_home("pass-busy");
+        let agent = "poll-busy-agent";
+        seed_unread(&home, agent, 5);
+        let registry = mock_registry(agent, AgentState::Thinking);
+
+        // Reset dedup
+        should_notify_and_record(agent, 0);
+
+        poll_reminder_pass(&home, &registry);
+
+        // Dedup state should NOT have been updated (agent was busy, skipped)
+        assert!(
+            should_notify_and_record(agent, 5),
+            "busy agent should not have been recorded in dedup"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -435,6 +435,19 @@ pub fn format_header(msg: &InboxMessage) -> String {
     parts.join(" ")
 }
 
+/// Format a single-line event header (non-message events like poll-reminder).
+/// Uses the same ANSI prefix as [`format_header`] for visual consistency.
+pub fn format_event_header(kind: &str, fields: &[(&str, &str)]) -> String {
+    let mut parts = vec![
+        HEADER_PREFIX.to_string(),
+        format!("kind={}", sanitize_header_value(kind)),
+    ];
+    for (k, v) in fields {
+        parts.push(format!("{}={}", k, sanitize_header_value(v)));
+    }
+    parts.join(" ")
+}
+
 /// Sweep expired messages from all inbox files.
 /// - read_at.is_some() && elapsed > 7 days → delete
 /// - read_at.is_none() && elapsed > 30 days → delete

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -387,7 +387,7 @@ pub fn unread_count(home: &Path, name: &str) -> (usize, Option<chrono::DateTime<
                 count += 1;
                 if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&msg.timestamp) {
                     let ts_utc = ts.with_timezone(&chrono::Utc);
-                    if oldest.is_none() || oldest.unwrap() > ts_utc {
+                    if oldest.is_none_or(|t| t > ts_utc) {
                         oldest = Some(ts_utc);
                     }
                 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -1710,4 +1710,23 @@ mod tests {
             "size must be char count (100), not byte count (300): {header}"
         );
     }
+
+    #[test]
+    fn test_format_event_header_basic() {
+        let h = format_event_header("poll-reminder", &[("unread", "3"), ("oldest", "5m")]);
+        assert!(h.contains("[AGEND-MSG]"), "must have prefix");
+        assert!(h.contains("kind=poll-reminder"), "must have kind");
+        assert!(h.contains("unread=3"), "must have unread field");
+        assert!(h.contains("oldest=5m"), "must have oldest field");
+        assert!(!h.contains('\n'), "must be single line");
+    }
+
+    #[test]
+    fn test_format_event_header_sanitizes_fields() {
+        let h = format_event_header("evil\nkind", &[("key", "val\r\nue")]);
+        assert!(!h.contains('\n'), "newlines in kind must be sanitized: {h:?}");
+        assert!(!h.contains('\r'), "CR in value must be sanitized: {h:?}");
+        assert!(h.contains("kind=evil kind"));
+        assert!(h.contains("key=val  ue"));
+    }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -372,6 +372,31 @@ fn read_drain_file(tmp: &Path) -> Vec<InboxMessage> {
 
 pub const INLINE_THRESHOLD: usize = 500;
 
+/// Count unread messages (read_at == None) for an agent.
+pub fn unread_count(home: &Path, name: &str) -> (usize, Option<chrono::DateTime<chrono::Utc>>) {
+    let path = inbox_path(home, name);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return (0, None),
+    };
+    let mut count = 0usize;
+    let mut oldest: Option<chrono::DateTime<chrono::Utc>> = None;
+    for line in content.lines() {
+        if let Ok(msg) = serde_json::from_str::<InboxMessage>(line) {
+            if msg.read_at.is_none() {
+                count += 1;
+                if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&msg.timestamp) {
+                    let ts_utc = ts.with_timezone(&chrono::Utc);
+                    if oldest.is_none() || oldest.unwrap() > ts_utc {
+                        oldest = Some(ts_utc);
+                    }
+                }
+            }
+        }
+    }
+    (count, oldest)
+}
+
 /// Size threshold for header-only PTY injection. Messages with body > this
 /// value inject only a structured header line; the full body stays in inbox.
 pub const HEADER_SIZE_THRESHOLD: usize = 300;

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -1724,7 +1724,10 @@ mod tests {
     #[test]
     fn test_format_event_header_sanitizes_fields() {
         let h = format_event_header("evil\nkind", &[("key", "val\r\nue")]);
-        assert!(!h.contains('\n'), "newlines in kind must be sanitized: {h:?}");
+        assert!(
+            !h.contains('\n'),
+            "newlines in kind must be sanitized: {h:?}"
+        );
         assert!(!h.contains('\r'), "CR in value must be sanitized: {h:?}");
         assert!(h.contains("kind=evil kind"));
         assert!(h.contains("key=val  ue"));


### PR DESCRIPTION
Sprint 3 T3 (stacked on #124 — now in main). Introduces proactive inbox reminders so agents that are idle with unread messages get nudged without needing to poll.

## What changes
- New `inbox::format_event_header(kind, fields)` — shared formatter for event-style headers (non-message events like poll-reminder, compared to message InboxMessage). Uses same `HEADER_PREFIX` + `sanitize_header_value` infrastructure from S3-T1.
- New pure fn `daemon::poll_reminder::collect_poll_reminders(home, registry) -> Vec<(String, String)>` — test seam returning (agent_name, reminder_string) for each idle agent with unread > 0.
- `poll_reminder_pass(home, registry)` — production wrapper: calls collect then `compose_aware_inject` each result.
- `should_notify_and_record(name, count) -> bool` — atomic check-and-record in one Mutex scope (no get+set race).
- Wired in `daemon/mod.rs` tick loop, every 30 ticks.

Emits: `[AGEND-MSG] kind=poll-reminder unread=N oldest=Xm` via `format_event_header`.

## Tests
- `returns_reminder_when_idle_with_unread` — asserts reminder string contains `[AGEND-MSG]` + `kind=poll-reminder` + `unread=3`
- `dedupes_same_count` — calls collector twice with same count, second returns empty vec (真驗 dedup via production path)
- `re_notifies_on_count_change` — 3→5 unread, re-notify, reminder contains `unread=5`
- `skips_when_busy` — Thinking state → empty vec
- `format_event_header_basic` / `sanitizes_fields` — unit coverage for the new shared helper

## Internal review
Audited by dev-reviewer (codex) **three times** — REJECTED on (F1) hand-built header not going through format_header, (F2) non-atomic dedup, (F3) tests that called poll_reminder_pass but didn't verify actual injection content; final VERIFIED after pure collector refactor for test seam.