### PR TITLE
feat(watch_ci): warn in MCP response when GITHUB_TOKEN is unset

### DIFF
--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -33,6 +33,37 @@ fn watch_is_due(last_polled_at: Option<i64>, interval_secs: u64, now_ms: i64) ->
     }
 }
 
+/// Preventive warning shown in the `watch_ci` MCP response when the
+/// daemon's environment doesn't carry a usable `GITHUB_TOKEN`.
+///
+/// The daemon reads `GITHUB_TOKEN` on every poll to authenticate against
+/// the GitHub REST API (`ci_check_repo`). Without it, the process falls
+/// back to the unauthenticated 60-requests/hour cap — shared across
+/// every active watch. Five watches on 60-second intervals push ~300
+/// req/hr, so a silent 403 storm is easy to trigger without ever
+/// hitting a single fetch explicitly.
+///
+/// Split as a pure helper so unit tests don't have to serialize over a
+/// shared `std::env` mutation (cf. `watchdog::ENV_LOCK`).
+pub fn github_token_warning(token: Option<&str>) -> Option<&'static str> {
+    match token.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(_) => None,
+        None => Some(
+            "GITHUB_TOKEN not set — daemon polls GitHub unauthenticated \
+             (60 req/hr, shared by all active watches). \
+             Export GITHUB_TOKEN (e.g. `export GITHUB_TOKEN=$(gh auth token)`) \
+             and restart the daemon so it inherits the value.",
+        ),
+    }
+}
+
+/// `github_token_warning` fed from the daemon's actual env. Separate
+/// from the pure helper so the handler can call this one-liner while
+/// tests drive the pure form with synthetic inputs.
+pub fn github_token_warning_from_env() -> Option<&'static str> {
+    github_token_warning(std::env::var("GITHUB_TOKEN").ok().as_deref())
+}
+
 /// Check CI watch configs and inject failure logs to agents when CI fails.
 pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
     let entries = match std::fs::read_dir(home.join("ci-watches")) {
@@ -586,6 +617,36 @@ mod tests {
             classify_runs_response(200, &body),
             RunsResponse::NoRuns
         ));
+    }
+
+    // --- github_token_warning: preventive watch_ci response hint ---
+
+    #[test]
+    fn github_token_warning_none_when_token_present() {
+        assert!(github_token_warning(Some("ghp_realtokenhere")).is_none());
+    }
+
+    #[test]
+    fn github_token_warning_set_when_absent() {
+        let msg = github_token_warning(None).expect("missing token must warn");
+        assert!(
+            msg.contains("GITHUB_TOKEN"),
+            "message must name the env var: {msg}"
+        );
+        assert!(
+            msg.contains("unauthenticated") || msg.contains("60"),
+            "message must explain the cost: {msg}"
+        );
+    }
+
+    #[test]
+    fn github_token_warning_treats_empty_and_whitespace_as_absent() {
+        // `std::env::var("GITHUB_TOKEN")` returns `Ok("")` when the var is
+        // exported-but-empty — a distinct case from "unset" but equally
+        // unusable. Whitespace-only should be treated the same.
+        assert!(github_token_warning(Some("")).is_some());
+        assert!(github_token_warning(Some("   ")).is_some());
+        assert!(github_token_warning(Some("\t\n")).is_some());
     }
 
     #[test]

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -901,7 +901,16 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 &watch_path,
                 serde_json::to_string_pretty(&watch).unwrap_or_default(),
             );
-            json!({"repo": repo, "watching": true})
+            // Surface the unauthenticated-polling gotcha in the response
+            // itself so the calling agent can relay it to the operator
+            // immediately, rather than waiting for a silent rate-limit
+            // storm to drop notifications. See
+            // `ci_watch::github_token_warning` for the full rationale.
+            let mut resp = json!({"repo": repo, "watching": true});
+            if let Some(w) = crate::daemon::ci_watch::github_token_warning_from_env() {
+                resp["warning"] = json!(w);
+            }
+            resp
         }
         "unwatch_ci" => {
             let repo = match args["repo"].as_str() {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -231,7 +231,7 @@ fn deploy_tools() -> Vec<Value> {
 
 fn ci_tools() -> Vec<Value> {
     vec![
-        json!({"name": "watch_ci", "description": "Watch GitHub Actions CI for a repo. When CI completes (success, failure, or any terminal state), a notification is automatically injected to this agent.",
+        json!({"name": "watch_ci", "description": "Watch GitHub Actions CI for a repo. When CI completes (success, failure, or any terminal state), a notification is automatically injected to this agent. If GITHUB_TOKEN is not set in the daemon's environment, the response includes a `warning` field — the daemon is falling back to unauthenticated polling (60 req/hr, shared by all watches) and notifications will silently drop once the cap is hit.",
             "inputSchema": {"type": "object", "properties": {
                 "repo": {"type": "string", "description": "GitHub repo (owner/repo)"},
                 "branch": {"type": "string", "description": "Branch to watch (default: main)"},


### PR DESCRIPTION
## Summary
- When an agent calls the \`watch_ci\` MCP tool, the response now carries a top-level \`warning\` field if the daemon's env has no usable \`GITHUB_TOKEN\`. The agent sees it synchronously and can relay the issue to the operator in the same turn — no more silently watching rate-limited notifications disappear.
- Pure helper \`ci_watch::github_token_warning(token: Option<&str>)\` + thin \`github_token_warning_from_env()\` wrapper. Unit tests drive the helper with synthetic inputs, no \`std::env\` mutation needed.
- \`watch_ci\`'s tool description mentions the \`warning\` field so LLM callers know to look for it.

## Relationship to prior work
Completes the three-way coverage on the ci_watch silent-failure class:
- [t-20260424002255087687-6](task): \`per_page=5\` multi-run scan + \`tracing::debug!\` → \`warn!\` — retroactive visibility in daemon logs.
- PR #131 (merged): \`classify_runs_response\` — stops GH API errors from impersonating a quiescent branch.
- **This PR**: preventive — surfaces the token gotcha in the tool response itself, so for most users the problem never happens.

## Why this shape
Extracted as a pure helper mirroring \`watchdog::watchdog_dry_run_from_env\` (see memory / PR #120). That pattern is the sanctioned way to keep env-gated logic unit-testable without fighting Rust's global \`std::env\` from parallel tests.

Scope intentionally narrow:
- No auto-fetch from \`gh auth token\` at daemon startup
- No daemon-startup warning path

Both reasonable follow-ups but would expand beyond the \`watch_ci\` tool's response contract and warrant separate design.

## Test plan
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --bin agend-terminal\` (851 passed) / integration tests green
- [x] 3 new unit tests: token present → None, token absent → warning naming GITHUB_TOKEN + cost, empty/whitespace treated as absent
- [x] Wire-up grep confirms non-test caller at \`handlers.rs:910\`
- [ ] Manual: call \`watch_ci\` with/without \`GITHUB_TOKEN\` set, observe \`warning\` field presence
🤖 Generated with [Claude Code](https://claude.com/claude-code)