### PR TITLE
refactor: abstract away magic row==0 for tab-bar hit test (#38)

### DIFF
--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -74,7 +74,7 @@ fn handle_down(
     registry: &AgentRegistry,
     out: &mut MouseOutcome,
 ) {
-    if layout.is_tab_bar_row(mouse.row) {
+    if crate::layout::is_tab_bar_row(mouse.row) {
         match tab_bar_hit_test(layout, mouse.column) {
             Some(TabBarClick::Tab(idx)) => {
                 out.new_last_tab = Some(layout.active);
@@ -159,7 +159,7 @@ fn handle_drag(mouse: MouseEvent, layout: &mut Layout, state: &mut MouseState) {
         // but resizing the PTY every mouse cell triggers the backend
         // (Claude/etc.) to reflow its entire UI and floods us with redraw
         // data. Defer the single PTY resize to mouse-up.
-    } else if layout.tab_reorder_source.is_some() && layout.is_tab_bar_row(mouse.row) {
+    } else if layout.tab_reorder_source.is_some() && crate::layout::is_tab_bar_row(mouse.row) {
         // Tab reorder drag: update drop target
         layout.tab_reorder_target = match tab_bar_hit_test(layout, mouse.column) {
             Some(TabBarClick::Tab(idx)) => Some(idx),
@@ -173,7 +173,7 @@ fn handle_drag(mouse: MouseEvent, layout: &mut Layout, state: &mut MouseState) {
         // inside the pane area is an intra-tab swap intent. Set exactly one
         // of `drag_target_tab` / `drag_target` per mouse position so that
         // render + mouse-up dispatch unambiguously.
-        if layout.is_tab_bar_row(mouse.row) {
+        if crate::layout::is_tab_bar_row(mouse.row) {
             let hit = tab_bar_hit_test(layout, mouse.column);
             let active_idx = layout.active;
             let tab_target = match hit {

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -74,7 +74,7 @@ fn handle_down(
     registry: &AgentRegistry,
     out: &mut MouseOutcome,
 ) {
-    if mouse.row == 0 {
+    if layout.is_tab_bar_row(mouse.row) {
         match tab_bar_hit_test(layout, mouse.column) {
             Some(TabBarClick::Tab(idx)) => {
                 out.new_last_tab = Some(layout.active);
@@ -159,7 +159,7 @@ fn handle_drag(mouse: MouseEvent, layout: &mut Layout, state: &mut MouseState) {
         // but resizing the PTY every mouse cell triggers the backend
         // (Claude/etc.) to reflow its entire UI and floods us with redraw
         // data. Defer the single PTY resize to mouse-up.
-    } else if layout.tab_reorder_source.is_some() && mouse.row == 0 {
+    } else if layout.tab_reorder_source.is_some() && layout.is_tab_bar_row(mouse.row) {
         // Tab reorder drag: update drop target
         layout.tab_reorder_target = match tab_bar_hit_test(layout, mouse.column) {
             Some(TabBarClick::Tab(idx)) => Some(idx),
@@ -173,7 +173,7 @@ fn handle_drag(mouse: MouseEvent, layout: &mut Layout, state: &mut MouseState) {
         // inside the pane area is an intra-tab swap intent. Set exactly one
         // of `drag_target_tab` / `drag_target` per mouse position so that
         // render + mouse-up dispatch unambiguously.
-        if mouse.row == 0 {
+        if layout.is_tab_bar_row(mouse.row) {
             let hit = tab_bar_hit_test(layout, mouse.column);
             let active_idx = layout.active;
             let tab_target = match hit {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1151,6 +1151,15 @@ pub struct Layout {
     pub tab_reorder_target: Option<usize>,
 }
 
+pub const TAB_BAR_HEIGHT: u16 = 1;
+
+impl Layout {
+    /// True if the given screen row is within the tab bar area.
+    pub fn is_tab_bar_row(&self, row: u16) -> bool {
+        row < TAB_BAR_HEIGHT
+    }
+}
+
 impl Layout {
     pub fn new() -> Self {
         Self {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1153,11 +1153,9 @@ pub struct Layout {
 
 pub const TAB_BAR_HEIGHT: u16 = 1;
 
-impl Layout {
-    /// True if the given screen row is within the tab bar area.
-    pub fn is_tab_bar_row(&self, row: u16) -> bool {
-        row < TAB_BAR_HEIGHT
-    }
+/// True if the given screen row is within the tab bar area.
+pub fn is_tab_bar_row(row: u16) -> bool {
+    row < TAB_BAR_HEIGHT
 }
 
 impl Layout {

--- a/src/render.rs
+++ b/src/render.rs
@@ -56,7 +56,7 @@ pub fn render(
     let chunks = ratatui::layout::Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),
+            Constraint::Length(crate::layout::TAB_BAR_HEIGHT),
             Constraint::Min(1),
             Constraint::Length(1),
         ])


### PR DESCRIPTION
This PR removes magic number usage for tab-bar hit testing.
- Added `TAB_BAR_HEIGHT` constant and `is_tab_bar_row` method to `Layout`.
- Refactored `src/app/mouse.rs` to use the new abstraction.
- Updated `src/render.rs` to use the constant for TUI layout constraints.