### PR TITLE
feat: allow choosing split direction in MovePaneTarget menu (#37)

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -122,6 +122,7 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
                     },
                     source_pane_id: pane_id,
                     source_tab_idx: active,
+                    split_dir: crate::layout::SplitDir::Horizontal,
                 });
             }
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -365,9 +365,10 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 Overlay::MovePaneTarget {
                     selected,
                     source_tab_idx,
+                    split_dir,
                     ..
                 } => {
-                    render::render_move_pane_target(frame, &layout, *selected, *source_tab_idx);
+                    render::render_move_pane_target(frame, &layout, *selected, *source_tab_idx, *split_dir);
                 }
                 Overlay::Help => {
                     render::render_help(frame);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -368,7 +368,13 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     split_dir,
                     ..
                 } => {
-                    render::render_move_pane_target(frame, &layout, *selected, *source_tab_idx, *split_dir);
+                    render::render_move_pane_target(
+                        frame,
+                        &layout,
+                        *selected,
+                        *source_tab_idx,
+                        *split_dir,
+                    );
                 }
                 Overlay::Help => {
                     render::render_help(frame);

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -441,6 +441,7 @@ pub(super) fn handle_key(
                     let sel = *selected;
                     let dir = *split_dir;
                     let tabs_count = ctx.layout.tabs.len();
+                    *overlay = Overlay::None;
                     if sel == tabs_count {
                         // New tab: name after the pane's agent for a sensible default.
                         let name = ctx

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -80,6 +80,8 @@ pub(super) enum Overlay {
         /// Source tab index at overlay-open time. Same defensive capture as
         /// `source_pane_id`; `move_pane_across_tabs` re-verifies existence.
         source_tab_idx: usize,
+        /// Target split direction when moving into an existing tab.
+        split_dir: crate::layout::SplitDir,
     },
     Help,
     /// Keyboard scroll mode (j/k/PgUp/PgDn). Pane's scroll_offset is used directly.
@@ -412,6 +414,7 @@ pub(super) fn handle_key(
         },
         Overlay::MovePaneTarget {
             ref mut selected,
+            ref mut split_dir,
             source_pane_id,
             source_tab_idx,
         } => {
@@ -420,6 +423,12 @@ pub(super) fn handle_key(
             // are valid move targets. `selected` can legally equal tabs.len().
             let list_len = ctx.layout.tabs.len() + 1;
             match key.code {
+                KeyCode::Tab | KeyCode::Char('s') => {
+                    *split_dir = match split_dir {
+                        crate::layout::SplitDir::Horizontal => crate::layout::SplitDir::Vertical,
+                        crate::layout::SplitDir::Vertical => crate::layout::SplitDir::Horizontal,
+                    };
+                }
                 KeyCode::Up | KeyCode::Char('k') if *selected > 0 => {
                     *selected -= 1;
                 }
@@ -430,8 +439,8 @@ pub(super) fn handle_key(
                     let src_pane = *source_pane_id;
                     let src_tab = *source_tab_idx;
                     let sel = *selected;
+                    let dir = *split_dir;
                     let tabs_count = ctx.layout.tabs.len();
-                    *overlay = Overlay::None;
                     if sel == tabs_count {
                         // New tab: name after the pane's agent for a sensible default.
                         let name = ctx
@@ -458,7 +467,7 @@ pub(super) fn handle_key(
                             src_pane,
                             crate::layout::MovePlacement::SplitFocused {
                                 to_tab: sel,
-                                dir: crate::layout::SplitDir::Horizontal,
+                                dir: dir,
                             },
                         ) {
                             // Follow the pane — the user just pointed at this tab.
@@ -467,6 +476,7 @@ pub(super) fn handle_key(
                         }
                     }
                     // sel == src_tab: no-op (already in that tab).
+                    *overlay = Overlay::None;
                 }
                 KeyCode::Esc | KeyCode::Char('q') => {
                     *overlay = Overlay::None;

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -465,10 +465,7 @@ pub(super) fn handle_key(
                         if let Some(new_idx) = ctx.layout.move_pane_across_tabs(
                             src_tab,
                             src_pane,
-                            crate::layout::MovePlacement::SplitFocused {
-                                to_tab: sel,
-                                dir: dir,
-                            },
+                            crate::layout::MovePlacement::SplitFocused { to_tab: sel, dir },
                         ) {
                             // Follow the pane — the user just pointed at this tab.
                             ctx.layout.goto_tab(new_idx);

--- a/src/render.rs
+++ b/src/render.rs
@@ -948,6 +948,7 @@ pub fn render_move_pane_target(
     layout: &Layout,
     selected: usize,
     source_tab_idx: usize,
+    split_dir: crate::layout::SplitDir,
 ) {
     let area = frame.area();
     let list_len = layout.tabs.len() + 1; // tabs + "New tab"
@@ -961,7 +962,7 @@ pub fn render_move_pane_target(
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Magenta))
         .title(Span::styled(
-            " Move pane to... (Enter, Esc) ",
+            format!(" Move pane to... (Split: {:?}) (Tab to toggle) ", split_dir),
             Style::default()
                 .fg(Color::Magenta)
                 .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
This PR adds the ability to choose the split direction when moving a pane to an existing tab using `Ctrl+B !`.
- Added `split_dir` to `Overlay::MovePaneTarget`.
- Press `Tab` or `s` to toggle between Horizontal and Vertical split.
- The UI now shows the current split direction in the title.
- Updated `move_pane_across_tabs` call to respect the chosen direction.