### PR TITLE
sprint5: validate send_to_instance/delegate_task target (fixes #7 #1)

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -35,6 +35,16 @@ pub fn send_to(home: &Path, from: &Sender, target: &str, text: &str, kind: &str)
         Ok(resp) if resp["ok"].as_bool() == Some(true) => json!({"target": target}),
         Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("send failed")}),
         Err(e) => {
+            // Validate target exists in fleet.yaml before writing to inbox.
+            // Without this, daemon-down + ghost target silently creates an
+            // unread inbox file — the exact silent-failure this PR eliminates.
+            let in_fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+                .ok()
+                .map(|c| c.instances.contains_key(target))
+                .unwrap_or(false);
+            if !in_fleet {
+                return json!({"error": format!("target instance '{target}' not found in fleet.yaml (API unavailable: {e})")});
+            }
             let submit_key = get_submit_key(home, target);
             crate::inbox::deliver(
                 home,

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -86,6 +86,26 @@ pub fn save_metadata(home: &Path, instance_name: &str, key: &str, value: Value) 
     }
 }
 
+/// Persist multiple metadata key/value pairs in a single atomic write.
+/// Avoids the race condition where two sequential `save_metadata` calls
+/// can interleave on Windows (the second read-modify-write reads stale data).
+pub fn save_metadata_batch(home: &Path, instance_name: &str, entries: &[(&str, Value)]) {
+    let meta_dir = home.join("metadata");
+    std::fs::create_dir_all(&meta_dir).ok();
+    let meta_path = meta_dir.join(format!("{instance_name}.json"));
+    let mut meta: Value = std::fs::read_to_string(&meta_path)
+        .map(|c| serde_json::from_str(&c).unwrap_or(json!({})))
+        .unwrap_or(json!({}));
+    for (key, value) in entries {
+        meta[*key] = value.clone();
+    }
+    let content = serde_json::to_string_pretty(&meta).unwrap_or_default();
+    let tmp_path = meta_path.with_extension("json.tmp");
+    if std::fs::write(&tmp_path, &content).is_ok() {
+        let _ = std::fs::rename(&tmp_path, &meta_path);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Fleet
 // ---------------------------------------------------------------------------

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -28,6 +28,23 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     if from == target {
         return json!({"ok": false, "error": "cannot send to self"});
     }
+
+    // Validate target exists: check runtime registry OR fleet.yaml definitions.
+    // Messages to non-existent targets would silently land in an unread inbox file.
+    {
+        let reg = agent::lock_registry(ctx.registry);
+        let in_registry = reg.contains_key(target);
+        drop(reg);
+        if !in_registry {
+            let in_fleet = crate::fleet::FleetConfig::load(&ctx.home.join("fleet.yaml"))
+                .ok()
+                .map(|c| c.instances.contains_key(target))
+                .unwrap_or(false);
+            if !in_fleet {
+                return json!({"ok": false, "error": format!("target instance '{target}' not found (not in registry or fleet.yaml)")});
+            }
+        }
+    }
     let msg = {
         let mut thread_id = params["thread_id"].as_str().map(String::from);
         let parent_id = params["parent_id"].as_str().map(String::from);
@@ -81,4 +98,86 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
         crate::inbox::compose_aware_send(ctx.home, target, &inject_msg);
     }
     json!({"ok": true})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn test_ctx(home: &std::path::Path) -> HandlerCtx<'_> {
+        // Leak registries for 'static — acceptable in tests.
+        let registry: &'static agent::AgentRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let configs: &'static crate::api::ConfigRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let externals: &'static agent::ExternalRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        HandlerCtx {
+            registry,
+            configs,
+            externals,
+            notifier: None,
+            home,
+        }
+    }
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("agend-msg-test-{}-{}", tag, std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    #[test]
+    fn test_send_to_nonexistent_target_returns_error() {
+        let home = tmp_home("nonexist");
+        // No fleet.yaml → target not in registry or fleet
+        let ctx = test_ctx(&home);
+        let result = handle_send(
+            &json!({"from": "sender", "target": "ghost", "text": "hi"}),
+            &ctx,
+        );
+        assert_eq!(result["ok"], false);
+        assert!(
+            result["error"].as_str().unwrap_or("").contains("not found"),
+            "must return not-found error for nonexistent target: {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_send_to_fleet_defined_instance_succeeds() {
+        let home = tmp_home("fleet-defined");
+        // Define instance in fleet.yaml but don't start it
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  offline-agent:\n    backend: claude\n",
+        )
+        .ok();
+        let ctx = test_ctx(&home);
+        let result = handle_send(
+            &json!({"from": "sender", "target": "offline-agent", "text": "hi"}),
+            &ctx,
+        );
+        assert_eq!(
+            result["ok"], true,
+            "fleet.yaml-defined instance must be accepted: {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_send_to_self_rejected() {
+        let home = tmp_home("self-send");
+        let ctx = test_ctx(&home);
+        let result = handle_send(
+            &json!({"from": "agent1", "target": "agent1", "text": "hi"}),
+            &ctx,
+        );
+        assert_eq!(result["ok"], false);
+        assert!(result["error"].as_str().unwrap_or("").contains("self"));
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1140,6 +1140,12 @@ mod tests {
     #[test]
     fn dispatch_send_delivers_to_inbox() {
         let (port, home, _notifier, shutdown) = start_test_server("send-char");
+        // Target must exist in fleet.yaml for validation to pass.
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  receiver:\n    backend: claude\n",
+        )
+        .ok();
         let resp = api_request(
             port,
             &home,

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -175,13 +175,20 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             let Some(sender) = sender.as_ref() else {
                 return err_needs_identity(tool);
             };
-            let target = match args["target_instance"].as_str() {
+            let raw_target = match args["target_instance"].as_str() {
                 Some(t) => t,
                 None => return json!({"error": "missing 'target_instance'"}),
             };
-            if let Err(e) = crate::agent::validate_name(target) {
+            if let Err(e) = crate::agent::validate_name(raw_target) {
                 return json!({"error": e});
             }
+            // Resolve team name → orchestrator (align with task create behaviour).
+            let resolved_target = match crate::teams::resolve_team_orchestrator(&home, raw_target) {
+                Ok(Some(orch)) => orch,
+                Ok(None) => raw_target.to_string(), // not a team, use as-is
+                Err(e) => return json!({"error": e}),
+            };
+            let target = resolved_target.as_str();
             let task = match args["task"].as_str() {
                 Some(t) => t,
                 None => return json!({"error": "missing 'task'"}),
@@ -2121,6 +2128,66 @@ instances:
         );
 
         std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // --- Sprint 5: target validation + team routing ---
+
+    #[test]
+    fn test_send_to_nonexistent_target_returns_error() {
+        // #7 fix: sending to a typo/nonexistent instance must return error.
+        let home = tmp_home("send-nonexist");
+        // No fleet.yaml, no registry → target doesn't exist anywhere.
+        let result = handle_tool(
+            "send_to_instance",
+            &json!({"instance_name": "ghost-agent", "message": "hello"}),
+            "sender",
+        );
+        // The MCP handler calls send_to → api::call which will fail
+        // (no daemon). The fallback path in agent_ops::send_to delivers
+        // via inbox. To test the API-level validation, we test handle_send
+        // directly below.
+        // For MCP level: at minimum, the tool should not panic.
+        assert!(
+            result.is_object(),
+            "send_to_instance must return a JSON object"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_delegate_task_resolves_team_to_orchestrator() {
+        // #1 fix: delegate_task to a team name should resolve to orchestrator.
+        let home = tmp_home("delegate-team");
+        // Create a team in fleet.yaml
+        let fleet_yaml = r#"
+instances:
+  dev-lead:
+    backend: claude
+  dev-impl:
+    backend: claude
+teams:
+  dev:
+    members: [dev-lead, dev-impl]
+    orchestrator: dev-lead
+"#;
+        std::fs::write(home.join("fleet.yaml"), fleet_yaml).ok();
+
+        // delegate_task to "dev" (team name) — should resolve to dev-lead.
+        // Without a running daemon, send_to will fallback to inbox delivery.
+        let result = handle_tool(
+            "delegate_task",
+            &json!({"target_instance": "dev", "task": "test task"}),
+            "dev-impl",
+        );
+        // The result should target dev-lead (resolved from team), not "dev".
+        // Since no daemon is running, the fallback path delivers to inbox.
+        // Check that it didn't error with "missing target" — the team was resolved.
+        let err = result["error"].as_str().unwrap_or("");
+        assert!(
+            !err.contains("not found") && !err.contains("missing"),
+            "delegate_task to team name should resolve, got error: {err}"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -139,6 +139,14 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 }
                 Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("send failed")}),
                 Err(e) => {
+                    // Validate target exists in fleet.yaml before fallback delivery.
+                    let in_fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+                        .ok()
+                        .map(|c| c.instances.contains_key(target))
+                        .unwrap_or(false);
+                    if !in_fleet {
+                        return json!({"error": format!("target instance '{target}' not found (API unavailable: {e})")});
+                    }
                     // Resolve thread inheritance for direct delivery
                     let mut resolved_thread = thread_id.map(String::from);
                     let resolved_parent = parent_id.map(String::from);
@@ -2147,60 +2155,74 @@ instances:
     // --- Sprint 5: target validation + team routing ---
 
     #[test]
-    fn test_send_to_nonexistent_target_returns_error() {
-        // #7 fix: sending to a typo/nonexistent instance must return error.
+    fn test_send_to_nonexistent_target_returns_error_and_no_inbox() {
+        // F1+F2: daemon down + ghost target → error, NO inbox file created.
+        let _g = fleet_test_guard();
         let home = tmp_home("send-nonexist");
-        // No fleet.yaml, no registry → target doesn't exist anywhere.
+        std::env::set_var("AGEND_HOME", &home);
+        // No fleet.yaml → target doesn't exist anywhere.
         let result = handle_tool(
             "send_to_instance",
             &json!({"instance_name": "ghost-agent", "message": "hello"}),
             "sender",
         );
-        // The MCP handler calls send_to → api::call which will fail
-        // (no daemon). The fallback path in agent_ops::send_to delivers
-        // via inbox. To test the API-level validation, we test handle_send
-        // directly below.
-        // For MCP level: at minimum, the tool should not panic.
         assert!(
-            result.is_object(),
-            "send_to_instance must return a JSON object"
+            result.get("error").is_some(),
+            "send to nonexistent target must return error, got: {result}"
         );
+        let ghost_inbox = home.join("inbox").join("ghost-agent.jsonl");
+        assert!(
+            !ghost_inbox.exists(),
+            "inbox file must NOT be created for nonexistent target"
+        );
+        std::env::remove_var("AGEND_HOME");
         std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn test_delegate_task_resolves_team_to_orchestrator() {
-        // #1 fix: delegate_task to a team name should resolve to orchestrator.
+    fn test_delegate_task_resolves_team_to_orchestrator_inbox() {
+        // F3: delegate_task to team name → resolved to orchestrator,
+        // verify the actual inbox recipient is the orchestrator.
+        let _g = fleet_test_guard();
         let home = tmp_home("delegate-team");
-        // Create a team in fleet.yaml
-        let fleet_yaml = r#"
-instances:
-  dev-lead:
-    backend: claude
-  dev-impl:
-    backend: claude
-teams:
-  dev:
-    members: [dev-lead, dev-impl]
-    orchestrator: dev-lead
-"#;
-        std::fs::write(home.join("fleet.yaml"), fleet_yaml).ok();
+        // fleet.yaml for instance validation, teams.json for team resolution
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  dev-lead:\n    backend: claude\n  dev-impl:\n    backend: claude\n",
+        )
+        .ok();
+        // teams.json is the runtime store used by resolve_team_orchestrator
+        std::fs::write(
+            home.join("teams.json"),
+            r#"{"schema_version":1,"teams":[{"name":"dev","members":["dev-lead","dev-impl"],"orchestrator":"dev-lead","description":null,"created_at":"2026-01-01T00:00:00Z"}]}"#,
+        )
+        .ok();
+        std::env::set_var("AGEND_HOME", &home);
 
-        // delegate_task to "dev" (team name) — should resolve to dev-lead.
-        // Without a running daemon, send_to will fallback to inbox delivery.
         let result = handle_tool(
             "delegate_task",
             &json!({"target_instance": "dev", "task": "test task"}),
             "dev-impl",
         );
-        // The result should target dev-lead (resolved from team), not "dev".
-        // Since no daemon is running, the fallback path delivers to inbox.
-        // Check that it didn't error with "missing target" — the team was resolved.
+        // Should not error — team resolved to dev-lead.
         let err = result["error"].as_str().unwrap_or("");
         assert!(
-            !err.contains("not found") && !err.contains("missing"),
+            !err.contains("not found"),
             "delegate_task to team name should resolve, got error: {err}"
         );
+        // Result should target dev-lead (orchestrator), not "dev" (team).
+        assert_eq!(
+            result["target"].as_str().unwrap_or(""),
+            "dev-lead",
+            "delegate_task must resolve team to orchestrator in result"
+        );
+        // No inbox for the team name itself.
+        let team_inbox = home.join("inbox").join("dev.jsonl");
+        assert!(
+            !team_inbox.exists(),
+            "inbox must NOT be created for team name 'dev'"
+        );
+        std::env::remove_var("AGEND_HOME");
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -1837,12 +1837,22 @@ instances:
         );
         assert_eq!(result["waiting_on"], "review from at-dev-4");
 
-        // Value-source pin: return value `since` must match metadata file
+        // Value-source pin: return value `since` must match metadata file.
+        // On Windows, two sequential save_metadata calls (waiting_on then
+        // waiting_on_since) can race with the file system cache, so we
+        // retry the read once after a short sleep.
         let returned_since = result["since"].as_str().expect("since in return");
-        let meta: Value = serde_json::from_str(
-            &std::fs::read_to_string(home.join("metadata/sender.json")).expect("read meta"),
-        )
-        .expect("parse meta");
+        let read_meta = || -> Value {
+            serde_json::from_str(
+                &std::fs::read_to_string(home.join("metadata/sender.json")).expect("read meta"),
+            )
+            .expect("parse meta")
+        };
+        let mut meta = read_meta();
+        if meta["waiting_on_since"].is_null() {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            meta = read_meta();
+        }
         assert_eq!(meta["waiting_on"], "review from at-dev-4");
         assert_eq!(
             meta["waiting_on_since"].as_str().expect("since in file"),

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -1,7 +1,8 @@
 //! MCP tool dispatch — handle_tool() routes tool calls to implementations.
 
 use crate::agent_ops::{
-    cleanup_working_dir, list_agents, merge_metadata, save_metadata, send_to, validate_branch,
+    cleanup_working_dir, list_agents, merge_metadata, save_metadata, save_metadata_batch, send_to,
+    validate_branch,
 };
 use crate::channel::sink_registry::registry as ux_sink_registry;
 use crate::channel::telegram;
@@ -697,13 +698,25 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             };
             let condition = args["condition"].as_str().unwrap_or("");
             if condition.is_empty() {
-                save_metadata(&home, instance_name, "waiting_on", json!(null));
-                save_metadata(&home, instance_name, "waiting_on_since", json!(null));
+                save_metadata_batch(
+                    &home,
+                    instance_name,
+                    &[
+                        ("waiting_on", json!(null)),
+                        ("waiting_on_since", json!(null)),
+                    ],
+                );
                 json!({"cleared": true})
             } else {
                 let now = chrono::Utc::now().to_rfc3339();
-                save_metadata(&home, instance_name, "waiting_on", json!(condition));
-                save_metadata(&home, instance_name, "waiting_on_since", json!(&now));
+                save_metadata_batch(
+                    &home,
+                    instance_name,
+                    &[
+                        ("waiting_on", json!(condition)),
+                        ("waiting_on_since", json!(&now)),
+                    ],
+                );
                 json!({"waiting_on": condition, "since": now})
             }
         }
@@ -1838,21 +1851,11 @@ instances:
         assert_eq!(result["waiting_on"], "review from at-dev-4");
 
         // Value-source pin: return value `since` must match metadata file.
-        // On Windows, two sequential save_metadata calls (waiting_on then
-        // waiting_on_since) can race with the file system cache, so we
-        // retry the read once after a short sleep.
         let returned_since = result["since"].as_str().expect("since in return");
-        let read_meta = || -> Value {
-            serde_json::from_str(
-                &std::fs::read_to_string(home.join("metadata/sender.json")).expect("read meta"),
-            )
-            .expect("parse meta")
-        };
-        let mut meta = read_meta();
-        if meta["waiting_on_since"].is_null() {
-            std::thread::sleep(std::time::Duration::from_millis(50));
-            meta = read_meta();
-        }
+        let meta: Value = serde_json::from_str(
+            &std::fs::read_to_string(home.join("metadata/sender.json")).expect("read meta"),
+        )
+        .expect("parse meta");
         assert_eq!(meta["waiting_on"], "review from at-dev-4");
         assert_eq!(
             meta["waiting_on_since"].as_str().expect("since in file"),

--- a/tests/mcp_characterization.rs
+++ b/tests/mcp_characterization.rs
@@ -335,6 +335,12 @@ fn list_instances_falls_back_when_daemon_down() {
 #[test]
 fn send_to_instance_falls_back_when_daemon_down() {
     let home = temp_home("send-fallback");
+    // Target must exist in fleet.yaml for validation to pass.
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "instances:\n  other-agent:\n    backend: claude\n  sender:\n    backend: claude\n",
+    )
+    .ok();
     let result = call_tool_as(
         &home,
         "sender",

--- a/tests/mcp_roundtrip.rs
+++ b/tests/mcp_roundtrip.rs
@@ -29,6 +29,12 @@ fn mcp_home() -> PathBuf {
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
     let home = std::env::temp_dir().join(format!("agend-mcp-test-{}-{}", std::process::id(), id));
     std::fs::create_dir_all(&home).ok();
+    // Seed fleet.yaml so target validation passes for test-agent.
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "instances:\n  test-agent:\n    backend: claude\n  other-agent:\n    backend: claude\n",
+    )
+    .ok();
     home
 }
 


### PR DESCRIPTION
## Changes

### Part 1 — #7 target validation (silent message loss fix)
- `handle_send` (api/handlers/messaging.rs) now validates target exists in registry OR fleet.yaml before enqueuing
- Previously returned `{ok: true}` for non-existent targets, silently dropping messages into unread inbox files

### Part 2 — #1 delegate_task team routing
- `delegate_task` handler (mcp/handlers.rs) now calls `resolve_team_orchestrator` to resolve team names to orchestrator, aligning with `task create` behaviour
- Previously passed team names directly to `send_to`, which would deliver to a phantom inbox

### Tests
- API-level: `test_send_to_nonexistent_target_returns_error`, `test_send_to_fleet_defined_instance_succeeds`, `test_send_to_self_rejected`
- MCP-level: `test_send_to_nonexistent_target_returns_error`, `test_delegate_task_resolves_team_to_orchestrator`
- Existing test `dispatch_send_delivers_to_inbox` updated to include fleet.yaml fixture