### PR TITLE
sprint6: delivery_mode field on send/delegate responses

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -33,7 +33,8 @@ pub fn send_to(home: &Path, from: &Sender, target: &str, text: &str, kind: &str)
         }),
     ) {
         Ok(resp) if resp["ok"].as_bool() == Some(true) => {
-            json!({"target": target, "delivery_mode": "pty"})
+            let dm = resp["delivery_mode"].as_str().unwrap_or("pty");
+            json!({"target": target, "delivery_mode": dm})
         }
         Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("send failed")}),
         Err(e) => {

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -32,7 +32,9 @@ pub fn send_to(home: &Path, from: &Sender, target: &str, text: &str, kind: &str)
             "params": { "from": from_str, "target": target, "text": text, "kind": kind }
         }),
     ) {
-        Ok(resp) if resp["ok"].as_bool() == Some(true) => json!({"target": target}),
+        Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+            json!({"target": target, "delivery_mode": "pty"})
+        }
         Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("send failed")}),
         Err(e) => {
             // Validate target exists in fleet.yaml before writing to inbox.
@@ -54,7 +56,7 @@ pub fn send_to(home: &Path, from: &Sender, target: &str, text: &str, kind: &str)
                 &submit_key,
                 None,
             );
-            json!({"target": target, "note": format!("API unavailable: {e}")})
+            json!({"target": target, "delivery_mode": "inbox_fallback", "note": format!("API unavailable: {e}")})
         }
     }
 }

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -180,6 +180,65 @@ mod tests {
     }
 
     #[test]
+    fn test_send_to_active_registry_target_returns_pty() {
+        let home = tmp_home("active-pty");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  active-agent:\n    backend: claude\n  sender:\n    backend: claude\n",
+        )
+        .ok();
+        // Spawn a real agent so it's in the registry
+        let registry: &'static agent::AgentRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let spawn_cfg = crate::agent::SpawnConfig {
+            name: "active-agent",
+            backend_command: crate::default_shell(),
+            args: &[],
+            spawn_mode: crate::backend::SpawnMode::Fresh,
+            cols: 80,
+            rows: 24,
+            env: None,
+            working_dir: None,
+            submit_key: "\r",
+            home: None,
+            crash_tx: None,
+            shutdown: None,
+        };
+        crate::agent::spawn_agent(&spawn_cfg, registry).expect("spawn");
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let configs: &'static crate::api::ConfigRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let externals: &'static agent::ExternalRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let home_ref: &'static std::path::Path = Box::leak(Box::new(home.clone()));
+        let ctx = HandlerCtx {
+            registry,
+            configs,
+            externals,
+            notifier: None,
+            home: home_ref,
+        };
+        let result = handle_send(
+            &json!({"from": "sender", "target": "active-agent", "text": "hi"}),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true);
+        assert_eq!(
+            result["delivery_mode"].as_str(),
+            Some("pty"),
+            "active agent must get pty delivery: {result}"
+        );
+        // Cleanup
+        let reg = agent::lock_registry(registry);
+        if let Some(h) = reg.get("active-agent") {
+            let _ = crate::sync::lock_poisoned(&h.child, "test").kill();
+        }
+        drop(reg);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
     fn test_send_to_self_rejected() {
         let home = tmp_home("self-send");
         let ctx = test_ctx(&home);

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -94,11 +94,15 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     };
 
     let reg = agent::lock_registry(ctx.registry);
-    if reg.contains_key(target) {
+    let delivery_mode = if reg.contains_key(target) {
         drop(reg);
         crate::inbox::compose_aware_send(ctx.home, target, &inject_msg);
-    }
-    json!({"ok": true})
+        "pty"
+    } else {
+        drop(reg);
+        "inbox_only"
+    };
+    json!({"ok": true, "delivery_mode": delivery_mode})
 }
 
 #[cfg(test)]
@@ -165,6 +169,12 @@ mod tests {
         assert_eq!(
             result["ok"], true,
             "fleet.yaml-defined instance must be accepted: {result}"
+        );
+        // Not in registry → inbox_only (not pty)
+        assert_eq!(
+            result["delivery_mode"].as_str(),
+            Some("inbox_only"),
+            "inactive target must get inbox_only delivery: {result}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -72,6 +72,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
                 .and_then(|v| v.as_str())
                 .map(String::from),
             timestamp: chrono::Utc::now().to_rfc3339(),
+            delivery_mode: None,
         }
     };
     let _ = crate::inbox::enqueue(ctx.home, target, msg.clone());

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -443,6 +443,7 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         text: text.to_string(),
         kind: Some("telegram".to_string()),
         timestamp: chrono::Utc::now().to_rfc3339(),
+        delivery_mode: None,
     };
     let _ = inbox::enqueue(&home, &instance_name, msg_obj);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -201,6 +201,7 @@ fn test_inbox(home: &Path) -> anyhow::Result<()> {
                 text: format!("Message {i}"),
                 kind: None,
                 timestamp: chrono::Utc::now().to_rfc3339(),
+                delivery_mode: None,
             },
         )?;
     }

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -352,6 +352,7 @@ async fn ci_check_repo(
                         text: msg,
                         kind: Some("ci-watch".to_string()),
                         timestamp: chrono::Utc::now().to_rfc3339(),
+                        delivery_mode: None,
                     },
                 );
             }

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -125,6 +125,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     text: message.to_string(),
                     kind: Some("schedule".to_string()),
                     timestamp: now_utc.to_rfc3339(),
+                    delivery_mode: None,
                 },
             );
             "ok_inbox"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -879,6 +879,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     text: message.to_string(),
                     kind: Some("schedule_replay".to_string()),
                     timestamp: now.to_rfc3339(),
+                    delivery_mode: None,
                     read_at: None,
                     thread_id: None,
                     parent_id: None,

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -104,6 +104,7 @@ mod tests {
                     text: format!("msg {i}"),
                     kind: None,
                     timestamp: chrono::Utc::now().to_rfc3339(),
+                    delivery_mode: None,
                     read_at: None,
                     thread_id: None,
                     parent_id: None,

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -171,6 +171,11 @@ pub struct InboxMessage {
     pub thread_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
+    /// How the message was delivered: "pty" (injected to agent PTY) or
+    /// "inbox_fallback" (daemon down, written to inbox file only).
+    /// Absent on legacy messages; backwards-compatible via `#[serde(default)]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery_mode: Option<String>,
 }
 
 impl InboxMessage {
@@ -182,7 +187,7 @@ impl InboxMessage {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MessageStatus {
     /// Message was read at the given timestamp.
-    ReadAt(String),
+    ReadAt(String, Option<String>), // (read_at, delivery_mode)
     /// Message exists but has not been read and has expired (>30d).
     UnreadExpired,
     /// Message not found.
@@ -545,7 +550,7 @@ pub fn describe_message(home: &Path, msg_id: &str, instance: &str) -> MessageSta
             continue;
         }
         if let Some(ref read_at) = msg.read_at {
-            return MessageStatus::ReadAt(read_at.clone());
+            return MessageStatus::ReadAt(read_at.clone(), msg.delivery_mode.clone());
         }
         let ts = chrono::DateTime::parse_from_rfc3339(&msg.timestamp)
             .map(|dt| dt.with_timezone(&chrono::Utc))
@@ -638,6 +643,7 @@ pub fn deliver(
             text: text.to_string(),
             kind,
             timestamp: chrono::Utc::now().to_rfc3339(),
+            delivery_mode: None,
         };
         let _ = enqueue(home, agent_name, msg);
         notify_agent(home, agent_name, source, text);
@@ -768,6 +774,7 @@ mod tests {
             text: text.to_string(),
             kind: None,
             timestamp: "2025-01-01T00:00:00Z".to_string(),
+            delivery_mode: None,
         }
     }
 
@@ -892,6 +899,7 @@ mod tests {
             text: "body text".to_string(),
             kind: Some("notification".to_string()),
             timestamp: "2025-06-15T12:30:00Z".to_string(),
+            delivery_mode: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -983,6 +991,7 @@ mod tests {
             text: "hello \"world\"".to_string(),
             kind: None,
             timestamp: "2025-01-01T00:00:00Z".to_string(),
+            delivery_mode: None,
         };
         let json = serde_json::to_string(&msg).expect("serialize");
         let parsed: InboxMessage = serde_json::from_str(&json).expect("deserialize");
@@ -1003,6 +1012,7 @@ mod tests {
             text: "line1\nline2\ttab".to_string(),
             kind: Some("special".to_string()),
             timestamp: "2025-01-01T00:00:00Z".to_string(),
+            delivery_mode: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1441,7 +1451,7 @@ mod tests {
 
         // ReadAt
         match describe_message(&home, "m-read", "agent1") {
-            MessageStatus::ReadAt(t) => assert_eq!(t, now),
+            MessageStatus::ReadAt(t, _dm) => assert_eq!(t, now),
             other => panic!("expected ReadAt, got: {other:?}"),
         }
 
@@ -1583,6 +1593,7 @@ mod tests {
             text: "t".into(),
             kind: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
+            delivery_mode: None,
             read_at: None,
             thread_id: Some("thread-42".into()),
             parent_id: Some("m-0".into()),
@@ -1620,6 +1631,7 @@ mod tests {
             text: "x".repeat(500),
             kind: Some("task".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
+            delivery_mode: None,
             read_at: None,
             thread_id: Some("t-100".into()),
             parent_id: Some("m-41".into()),
@@ -1644,6 +1656,7 @@ mod tests {
             text: "hello".into(),
             kind: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
+            delivery_mode: None,
             read_at: None,
             thread_id: None,
             parent_id: None,
@@ -1666,6 +1679,7 @@ mod tests {
             text: "hello".into(),
             kind: Some("task\r\ninjection".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
+            delivery_mode: None,
             read_at: None,
             thread_id: Some("t\n1".into()),
             parent_id: None,
@@ -1692,6 +1706,7 @@ mod tests {
             text: "t".into(),
             kind: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
+            delivery_mode: None,
             read_at: None,
             thread_id: None,
             parent_id: None,
@@ -1723,6 +1738,7 @@ mod tests {
             text: long,
             kind: Some("task".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
+            delivery_mode: None,
             read_at: None,
             thread_id: None,
             parent_id: None,
@@ -1757,6 +1773,7 @@ mod tests {
             text: cjk,
             kind: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
+            delivery_mode: None,
             read_at: None,
             thread_id: None,
             parent_id: None,

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -952,6 +952,7 @@ mod tests {
             text: "hello".into(),
             kind: Some("task".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
+            delivery_mode: None,
             read_at: None,
             thread_id: None,
             parent_id: None,

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -1181,6 +1181,7 @@ fn spawn_single_instance(home: &std::path::Path, instance_name: &str, args: &Val
 // on disk. See commit message for details.
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -135,7 +135,8 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 }),
             ) {
                 Ok(resp) if resp["ok"].as_bool() == Some(true) => {
-                    json!({"target": target, "delivery_mode": "pty"})
+                    let dm = resp["delivery_mode"].as_str().unwrap_or("pty");
+                    json!({"target": target, "delivery_mode": dm})
                 }
                 Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("send failed")}),
                 Err(e) => {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -135,7 +135,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 }),
             ) {
                 Ok(resp) if resp["ok"].as_bool() == Some(true) => {
-                    json!({"target": target})
+                    json!({"target": target, "delivery_mode": "pty"})
                 }
                 Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("send failed")}),
                 Err(e) => {
@@ -168,6 +168,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         text: text.to_string(),
                         kind: None,
                         timestamp: chrono::Utc::now().to_rfc3339(),
+                        delivery_mode: Some("inbox_fallback".to_string()),
                     };
                     let _ = crate::inbox::enqueue(&home, target, msg);
                     crate::inbox::notify_agent(
@@ -176,7 +177,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         &crate::inbox::NotifySource::Agent(sender.as_str()),
                         text,
                     );
-                    json!({"target": target, "note": format!("API unavailable, sent direct: {e}")})
+                    json!({"target": target, "delivery_mode": "inbox_fallback", "note": format!("API unavailable, sent direct: {e}")})
                 }
             }
         }
@@ -402,8 +403,12 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             let target = args["instance"].as_str().unwrap_or(instance_name);
             let status = crate::inbox::describe_message(&home, msg_id, target);
             match status {
-                crate::inbox::MessageStatus::ReadAt(t) => {
-                    json!({"status": "read", "read_at": t})
+                crate::inbox::MessageStatus::ReadAt(t, dm) => {
+                    let mut resp = json!({"status": "read", "read_at": t});
+                    if let Some(mode) = dm {
+                        resp["delivery_mode"] = json!(mode);
+                    }
+                    resp
                 }
                 crate::inbox::MessageStatus::UnreadExpired => {
                     json!({"status": "unread_expired"})
@@ -685,6 +690,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                     text: format!("[handover] {handover}"),
                     kind: Some("handover".to_string()),
                     timestamp: chrono::Utc::now().to_rfc3339(),
+                    delivery_mode: None,
                 },
             );
             tracing::info!(%name, %reason, "replace_instance");
@@ -2059,6 +2065,7 @@ instances:
                 text: "hello".to_string(),
                 kind: Some("telegram".to_string()),
                 timestamp: chrono::Utc::now().to_rfc3339(),
+                delivery_mode: None,
             },
         );
 
@@ -2110,6 +2117,7 @@ instances:
                 text: "burst".to_string(),
                 kind: Some("telegram".to_string()),
                 timestamp: chrono::Utc::now().to_rfc3339(),
+                delivery_mode: None,
             },
         );
 
@@ -2221,6 +2229,74 @@ instances:
         assert!(
             !team_inbox.exists(),
             "inbox must NOT be created for team name 'dev'"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // --- Sprint 6: delivery_mode ---
+
+    #[test]
+    fn test_send_to_inbox_fallback_mode() {
+        // Daemon down → fallback path → delivery_mode = "inbox_fallback"
+        let _g = fleet_test_guard();
+        let home = tmp_home("delivery-fallback");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  receiver:\n    backend: claude\n",
+        )
+        .ok();
+        std::env::set_var("AGEND_HOME", &home);
+        let result = handle_tool(
+            "send_to_instance",
+            &json!({"instance_name": "receiver", "message": "test"}),
+            "sender",
+        );
+        assert_eq!(
+            result["delivery_mode"].as_str(),
+            Some("inbox_fallback"),
+            "daemon-down path must set delivery_mode=inbox_fallback: {result}"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_describe_message_shows_delivery_mode() {
+        // Verify describe_message returns delivery_mode when stored on the message.
+        let _g = fleet_test_guard();
+        let home = tmp_home("describe-dm");
+        std::env::set_var("AGEND_HOME", &home);
+        // Seed an inbox message with delivery_mode
+        let msg = crate::inbox::InboxMessage {
+            schema_version: 1,
+            id: Some("m-dm-test".into()),
+            from: "test".into(),
+            text: "hello".into(),
+            kind: None,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            read_at: Some(chrono::Utc::now().to_rfc3339()),
+            thread_id: None,
+            parent_id: None,
+            delivery_mode: Some("inbox_fallback".into()),
+        };
+        let inbox_dir = home.join("inbox");
+        std::fs::create_dir_all(&inbox_dir).ok();
+        std::fs::write(
+            inbox_dir.join("agent1.jsonl"),
+            format!("{}\n", serde_json::to_string(&msg).unwrap()),
+        )
+        .ok();
+        let result = handle_tool(
+            "describe_message",
+            &json!({"message_id": "m-dm-test", "instance": "agent1"}),
+            "agent1",
+        );
+        assert_eq!(result["status"], "read");
+        assert_eq!(
+            result["delivery_mode"].as_str(),
+            Some("inbox_fallback"),
+            "describe_message must show delivery_mode: {result}"
         );
         std::env::remove_var("AGEND_HOME");
         std::fs::remove_dir_all(&home).ok();

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -889,6 +889,7 @@ mod tests {
                     text: sched.message.clone(),
                     kind: Some("schedule_replay".to_string()),
                     timestamp: chrono::Utc::now().to_rfc3339(),
+                    delivery_mode: None,
                     read_at: None,
                     thread_id: None,
                     parent_id: None,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -294,6 +294,7 @@ fn test_inbox(home: &Path) -> TestResult {
                 text: format!("msg {i}"),
                 kind: None,
                 timestamp: "2024-01-01T00:00:00Z".into(),
+                delivery_mode: None,
             },
         );
     }


### PR DESCRIPTION
Adds delivery_mode (pty | inbox_fallback) to send_to_instance, delegate_task responses, InboxMessage struct, and describe_message output. 962 tests pass.