### PR TITLE
sprint6: delegate_task typed task_id field

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -65,6 +65,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             read_at: None,
             thread_id,
             parent_id,
+            task_id: params["task_id"].as_str().map(String::from),
             from: format!("from:{from}"),
             text: text.to_string(),
             kind: params

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -439,6 +439,7 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         read_at: None,
         thread_id: None,
         parent_id: None,
+        task_id: None,
         from: format!("user:{username}"),
         text: text.to_string(),
         kind: Some("telegram".to_string()),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -197,6 +197,7 @@ fn test_inbox(home: &Path) -> anyhow::Result<()> {
                 read_at: None,
                 thread_id: None,
                 parent_id: None,
+                task_id: None,
                 from: format!("tester-{i}"),
                 text: format!("Message {i}"),
                 kind: None,

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -348,6 +348,7 @@ async fn ci_check_repo(
                         read_at: None,
                         thread_id: None,
                         parent_id: None,
+                        task_id: None,
                         from: "system:ci".to_string(),
                         text: msg,
                         kind: Some("ci-watch".to_string()),

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -121,6 +121,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     read_at: None,
                     thread_id: None,
                     parent_id: None,
+                    task_id: None,
                     from: "system:schedule".to_string(),
                     text: message.to_string(),
                     kind: Some("schedule".to_string()),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -883,6 +883,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     read_at: None,
                     thread_id: None,
                     parent_id: None,
+                    task_id: None,
                 },
             );
         }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -108,6 +108,7 @@ mod tests {
                     read_at: None,
                     thread_id: None,
                     parent_id: None,
+                    task_id: None,
                 },
             );
         }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -176,6 +176,8 @@ pub struct InboxMessage {
     /// Absent on legacy messages; backwards-compatible via `#[serde(default)]`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delivery_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
 }
 
 impl InboxMessage {
@@ -639,6 +641,7 @@ pub fn deliver(
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
             from: source.to_string(),
             text: text.to_string(),
             kind,
@@ -770,6 +773,7 @@ mod tests {
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
             from: from.to_string(),
             text: text.to_string(),
             kind: None,
@@ -895,6 +899,7 @@ mod tests {
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
             from: "sender".to_string(),
             text: "body text".to_string(),
             kind: Some("notification".to_string()),
@@ -987,6 +992,7 @@ mod tests {
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
             from: "test".to_string(),
             text: "hello \"world\"".to_string(),
             kind: None,
@@ -1008,6 +1014,7 @@ mod tests {
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
             from: "user".to_string(),
             text: "line1\nline2\ttab".to_string(),
             kind: Some("special".to_string()),
@@ -1597,6 +1604,7 @@ mod tests {
             read_at: None,
             thread_id: Some("thread-42".into()),
             parent_id: Some("m-0".into()),
+            task_id: None,
         };
         let json = serde_json::to_string(&msg).expect("ser");
         assert!(json.contains("thread_id"));
@@ -1615,6 +1623,7 @@ mod tests {
         let msg_no_thread = InboxMessage {
             thread_id: None,
             parent_id: None,
+            task_id: None,
             ..msg.clone()
         };
         let json2 = serde_json::to_string(&msg_no_thread).expect("ser");
@@ -1635,6 +1644,7 @@ mod tests {
             read_at: None,
             thread_id: Some("t-100".into()),
             parent_id: Some("m-41".into()),
+            task_id: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("[AGEND-MSG]"));
@@ -1660,6 +1670,7 @@ mod tests {
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("from=from:agent"));
@@ -1683,6 +1694,7 @@ mod tests {
             read_at: None,
             thread_id: Some("t\n1".into()),
             parent_id: None,
+            task_id: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -1710,6 +1722,7 @@ mod tests {
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -1742,6 +1755,7 @@ mod tests {
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -1777,6 +1791,7 @@ mod tests {
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
         };
         let header = format_header(&msg);
         assert!(

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -956,6 +956,7 @@ mod tests {
             read_at: None,
             thread_id: None,
             parent_id: None,
+            task_id: None,
         };
         let header = crate::inbox::format_header(&sample_msg);
 

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -165,6 +165,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         read_at: None,
                         thread_id: resolved_thread,
                         parent_id: resolved_parent,
+                        task_id: None,
                         from: format!("from:{}", sender.as_str()),
                         text: text.to_string(),
                         kind: None,
@@ -214,9 +215,56 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             if let Some(ctx) = args["context"].as_str() {
                 msg.push_str(&format!("\n\nContext: {ctx}"));
             }
-            let result = send_to(&home, sender, target, &msg, "task");
+            let task_id_str = args["task_id"].as_str();
+            let result = match crate::api::call(
+                &home,
+                &json!({
+                    "method": crate::api::method::SEND,
+                    "params": {
+                        "from": sender.as_str(),
+                        "target": target,
+                        "text": msg,
+                        "kind": "task",
+                        "task_id": task_id_str,
+                    }
+                }),
+            ) {
+                Ok(resp) if resp["ok"].as_bool() == Some(true) => json!({"target": target}),
+                Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("send failed")}),
+                Err(e) => {
+                    // Fallback: direct delivery with task_id
+                    let in_fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+                        .ok()
+                        .map(|c| c.instances.contains_key(target))
+                        .unwrap_or(false);
+                    if !in_fleet {
+                        return json!({"error": format!("target instance '{target}' not found in fleet.yaml (API unavailable: {e})")});
+                    }
+                    let inbox_msg = crate::inbox::InboxMessage {
+                        schema_version: 0,
+                        id: None,
+                        read_at: None,
+                        thread_id: None,
+                        parent_id: None,
+                        task_id: task_id_str.map(String::from),
+                        delivery_mode: Some("inbox_fallback".to_string()),
+                        from: format!("from:{}", sender.as_str()),
+                        text: msg.clone(),
+                        kind: Some("task".to_string()),
+                        timestamp: chrono::Utc::now().to_rfc3339(),
+                    };
+                    let _ = crate::inbox::enqueue(&home, target, inbox_msg);
+                    crate::inbox::notify_agent(
+                        &home,
+                        target,
+                        &crate::inbox::NotifySource::Agent(sender.as_str()),
+                        &msg,
+                    );
+                    json!({"target": target, "note": format!("API unavailable: {e}")})
+                }
+            };
             if is_ok_result(&result) {
-                let task_id = args["task_id"].as_str().map(str::to_string);
+                let task_id = task_id_str.map(str::to_string);
                 ux_sink_registry().emit(&UxEvent::Fleet(FleetEvent::DelegateTask {
                     from: sender.as_str().to_string(),
                     to: target.to_string(),
@@ -687,6 +735,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                     read_at: None,
                     thread_id: None,
                     parent_id: None,
+                    task_id: None,
                     from: "system:replace".to_string(),
                     text: format!("[handover] {handover}"),
                     kind: Some("handover".to_string()),
@@ -2063,6 +2112,7 @@ instances:
                 read_at: None,
                 thread_id: None,
                 parent_id: None,
+                task_id: None,
                 from: "user:test".to_string(),
                 text: "hello".to_string(),
                 kind: Some("telegram".to_string()),
@@ -2115,6 +2165,7 @@ instances:
                 read_at: None,
                 thread_id: None,
                 parent_id: None,
+                task_id: None,
                 from: "user:test".to_string(),
                 text: "burst".to_string(),
                 kind: Some("telegram".to_string()),
@@ -2281,6 +2332,7 @@ instances:
             thread_id: None,
             parent_id: None,
             delivery_mode: Some("inbox_fallback".into()),
+            task_id: None,
         };
         let inbox_dir = home.join("inbox");
         std::fs::create_dir_all(&inbox_dir).ok();

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -205,6 +205,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 None => return json!({"error": "missing 'task'"}),
             };
             let mut msg = format!("[delegate_task] {task}");
+            if let Some(tid) = args["task_id"].as_str() {
+                msg.push_str(&format!(" (task id: {tid})"));
+            }
             if let Some(criteria) = args["success_criteria"].as_str() {
                 msg.push_str(&format!("\n\nSuccess criteria: {criteria}"));
             }
@@ -213,15 +216,12 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             }
             let result = send_to(&home, sender, target, &msg, "task");
             if is_ok_result(&result) {
-                // Fleet visibility (plan §4 `DelegateTask`, design §4.3).
-                // `task_id: None` — MCP `delegate_task` has no typed id
-                // slot; correlation appears later via `report_result`'s
-                // `correlation_id`. Renderer omits id when None.
+                let task_id = args["task_id"].as_str().map(str::to_string);
                 ux_sink_registry().emit(&UxEvent::Fleet(FleetEvent::DelegateTask {
                     from: sender.as_str().to_string(),
                     to: target.to_string(),
                     summary: task.to_string(),
-                    task_id: None,
+                    task_id,
                 }));
                 // S2d provenance injection (DESIGN §6). Only DELEGATE
                 // triggers this: the receiving agent's topic gets a

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -45,6 +45,7 @@ fn comm_tools() -> Vec<Value> {
             "inputSchema": {"type": "object", "properties": {
                 "target_instance": {"type": "string"}, "task": {"type": "string"},
                 "success_criteria": {"type": "string"}, "context": {"type": "string"},
+                "task_id": {"type": "string", "description": "Task board ID for correlation"},
                 "thread_id": {"type": "string"}, "parent_id": {"type": "string"}
             }, "required": ["target_instance", "task"]}}),
         json!({"name": "report_result", "description": "Report results back to the delegating instance.",

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -893,6 +893,7 @@ mod tests {
                     read_at: None,
                     thread_id: None,
                     parent_id: None,
+                    task_id: None,
                 },
             );
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -290,6 +290,7 @@ fn test_inbox(home: &Path) -> TestResult {
                 read_at: None,
                 thread_id: None,
                 parent_id: None,
+                task_id: None,
                 from: format!("test-{i}"),
                 text: format!("msg {i}"),
                 kind: None,

--- a/tests/mcp_roundtrip.rs
+++ b/tests/mcp_roundtrip.rs
@@ -766,19 +766,22 @@ fn test_delegate_task_persists_task_id() {
         &home,
         &[
             r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
-            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delegate_task","arguments":{"target_instance":"test-agent","task":"implement feature X","task_id":"t-sprint6-42","success_criteria":"all tests pass with full coverage","context":"This is a test of the typed task_id field in delegate_task. The message needs to be long enough to exceed the inline threshold of five hundred characters so it gets enqueued to the inbox JSONL file where we can verify the task_id was persisted. Adding sufficient padding text to reliably cross the 500 char boundary for this integration test of the delegate_task typed task_id correlation feature in the agend-terminal daemon."}}}"#,
-            r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"inbox","arguments":{}}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delegate_task","arguments":{"target_instance":"test-agent","task":"implement feature X","task_id":"t-sprint6-42","success_criteria":"all tests pass with full coverage","context":"This is a test of the typed task_id field in delegate_task. The message needs to be long enough to exceed the inline threshold of five hundred characters so it gets enqueued to the inbox JSONL file where we can verify the task_id was persisted as a typed field. Adding sufficient padding text to reliably cross the 500 char boundary for this integration test of the delegate_task typed task_id correlation feature in the agend-terminal daemon."}}}"#,
         ],
     );
-    assert!(responses.len() >= 3);
-    let inbox_result = extract_tool_result(&responses[2]);
-    let messages = inbox_result["messages"].as_array().expect("messages");
-    let found = messages
-        .iter()
-        .any(|m| m["text"].as_str().unwrap_or("").contains("t-sprint6-42"));
-    assert!(
-        found,
-        "task_id must appear in inbox message text: {messages:?}"
+    assert!(responses.len() >= 2);
+    // Deserialize inbox JSONL and verify typed task_id field
+    let inbox_path = home.join("inbox").join("test-agent.jsonl");
+    let content = std::fs::read_to_string(&inbox_path).expect("inbox file must exist");
+    let msg: serde_json::Value = content
+        .lines()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .find(|v: &serde_json::Value| v["text"].as_str().unwrap_or("").contains("[delegate_task]"))
+        .expect("delegate_task message must be in inbox");
+    assert_eq!(
+        msg["task_id"].as_str(),
+        Some("t-sprint6-42"),
+        "typed task_id field must be persisted in InboxMessage JSON: {msg}"
     );
     let _ = std::fs::remove_dir_all(&home);
 }
@@ -795,20 +798,20 @@ fn test_delegate_task_no_task_id_remains_none() {
         &home,
         &[
             r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
-            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delegate_task","arguments":{"target_instance":"test-agent","task":"implement feature Y without any task_id parameter provided at all","success_criteria":"verify that when no task_id is given the message text does not contain a parenthetical task id reference","context":"This delegate_task call intentionally omits the task_id field entirely. The combined message body including task description plus success criteria plus this context string needs to exceed five hundred characters total to be enqueued to the inbox JSONL file by the deliver function. We verify that when task_id is not provided by the caller, the formatted message text does not contain a parenthetical task id reference. This padding ensures we reliably cross the five hundred character threshold boundary for the test."}}}"#,
-            r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"inbox","arguments":{}}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delegate_task","arguments":{"target_instance":"test-agent","task":"implement feature Y without any task_id parameter provided at all","success_criteria":"verify that when no task_id is given the typed field is absent from the serialized JSON","context":"This delegate_task call intentionally omits the task_id field entirely. The combined message body including task description plus success criteria plus this context string needs to exceed five hundred characters total to be enqueued to the inbox JSONL file by the deliver function. We verify that when task_id is not provided by the caller, the InboxMessage JSON does not contain a task_id field. This padding ensures we reliably cross the five hundred character threshold boundary for the test."}}}"#,
         ],
     );
-    assert!(responses.len() >= 3);
-    let inbox_result = extract_tool_result(&responses[2]);
-    let messages = inbox_result["messages"].as_array().expect("messages");
-    let found = messages.iter().any(|m| {
-        let text = m["text"].as_str().unwrap_or("");
-        text.contains("[delegate_task]") && !text.contains("(task id:")
-    });
+    assert!(responses.len() >= 2);
+    let inbox_path = home.join("inbox").join("test-agent.jsonl");
+    let content = std::fs::read_to_string(&inbox_path).expect("inbox file must exist");
+    let msg: serde_json::Value = content
+        .lines()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .find(|v: &serde_json::Value| v["text"].as_str().unwrap_or("").contains("[delegate_task]"))
+        .expect("delegate_task message must be in inbox");
     assert!(
-        found,
-        "delegate_task without task_id must not contain '(task id:' in text: {messages:?}"
+        msg.get("task_id").is_none() || msg["task_id"].is_null(),
+        "task_id must be absent or null when not provided: {msg}"
     );
     let _ = std::fs::remove_dir_all(&home);
 }

--- a/tests/mcp_roundtrip.rs
+++ b/tests/mcp_roundtrip.rs
@@ -753,3 +753,62 @@ fn test_parent_id_auto_inherits_thread() {
     );
     let _ = std::fs::remove_dir_all(&home);
 }
+
+#[test]
+fn test_delegate_task_persists_task_id() {
+    let home = mcp_home();
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "instances:\n  test-agent:\n    backend: claude\n",
+    )
+    .ok();
+    let responses = mcp_session_in_home(
+        &home,
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delegate_task","arguments":{"target_instance":"test-agent","task":"implement feature X","task_id":"t-sprint6-42","success_criteria":"all tests pass with full coverage","context":"This is a test of the typed task_id field in delegate_task. The message needs to be long enough to exceed the inline threshold of five hundred characters so it gets enqueued to the inbox JSONL file where we can verify the task_id was persisted. Adding sufficient padding text to reliably cross the 500 char boundary for this integration test of the delegate_task typed task_id correlation feature in the agend-terminal daemon."}}}"#,
+            r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"inbox","arguments":{}}}"#,
+        ],
+    );
+    assert!(responses.len() >= 3);
+    let inbox_result = extract_tool_result(&responses[2]);
+    let messages = inbox_result["messages"].as_array().expect("messages");
+    let found = messages
+        .iter()
+        .any(|m| m["text"].as_str().unwrap_or("").contains("t-sprint6-42"));
+    assert!(
+        found,
+        "task_id must appear in inbox message text: {messages:?}"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn test_delegate_task_no_task_id_remains_none() {
+    let home = mcp_home();
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "instances:\n  test-agent:\n    backend: claude\n",
+    )
+    .ok();
+    let responses = mcp_session_in_home(
+        &home,
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delegate_task","arguments":{"target_instance":"test-agent","task":"implement feature Y without any task_id parameter provided at all","success_criteria":"verify that when no task_id is given the message text does not contain a parenthetical task id reference","context":"This delegate_task call intentionally omits the task_id field entirely. The combined message body including task description plus success criteria plus this context string needs to exceed five hundred characters total to be enqueued to the inbox JSONL file by the deliver function. We verify that when task_id is not provided by the caller, the formatted message text does not contain a parenthetical task id reference. This padding ensures we reliably cross the five hundred character threshold boundary for the test."}}}"#,
+            r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"inbox","arguments":{}}}"#,
+        ],
+    );
+    assert!(responses.len() >= 3);
+    let inbox_result = extract_tool_result(&responses[2]);
+    let messages = inbox_result["messages"].as_array().expect("messages");
+    let found = messages.iter().any(|m| {
+        let text = m["text"].as_str().unwrap_or("");
+        text.contains("[delegate_task]") && !text.contains("(task id:")
+    });
+    assert!(
+        found,
+        "delegate_task without task_id must not contain '(task id:' in text: {messages:?}"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}


### PR DESCRIPTION
Add optional `task_id` parameter to `delegate_task` MCP tool, replacing the previous hardcoded `task_id: None` in the FleetEvent.

- MCP schema: `task_id?: string` added to delegate_task tool definition
- Handler: reads `task_id` from args, includes in message text as `(task id: t-xxx)`
- FleetEvent: passes typed `task_id` for UX visibility
- Backward compatible: omitting `task_id` produces no `(task id:` in text

2 MCP roundtrip integration tests verify actual inbox content.