### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-04-24
+
 170+ commits since `0.3.2` — multi-agent collaboration plumbing (fleet
 protocol v1.1, correlation threads, health reporting), inbox resilience
 + correlation, task-board dependencies + deadlines, a `watch_ci`
@@ -202,7 +204,8 @@ Substantial work has landed on `main` since `0.3.0`. Highlights, grouped by area
 
 ---
 
-[Unreleased]: https://github.com/suzuke/agend-terminal/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/suzuke/agend-terminal/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/suzuke/agend-terminal/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/suzuke/agend-terminal/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/suzuke/agend-terminal/compare/85f2bc3...v0.3.1
 [0.3.0]: https://github.com/suzuke/agend-terminal/commit/85f2bc3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agend-terminal"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agend-terminal"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "Agent Process Manager — orchestrate AI coding agents with PTY isolation, fleet management, and 35 MCP tools"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump \`Cargo.toml\` + \`Cargo.lock\` from \`0.3.2\` → \`0.4.0\`
- Promote CHANGELOG \`[Unreleased]\` → \`[0.4.0] — 2026-04-24\`
- Add empty new \`[Unreleased]\` placeholder for future work

## Highlights of 0.4.0 (170+ commits)
See CHANGELOG for full list. Major themes:
- **Fleet Development Protocol v1 + v1.1** formalized
- **Live \`<fleet-update>\` injection** on fleet mutations (#113, #123)
- **MCP correlation threads** (\`thread_id\`/\`parent_id\`/\`describe_thread\`)
- **Health reporting + watchdog dry-run** with \`BlockedReason\` race mutex
- **Task board: dependencies + deadlines + mutation integrity** (Sprint 4 + 5)
- **Inbox resilience** (disk, flock, half-write recovery, TTL sweep)
- **PTY header injection** for messages > 300 chars + **idle poll-reminder**
- **\`watch_ci\` reliability overhaul** (head_sha, multi-run scan, rate-limit detection, \`GITHUB_TOKEN\` warning)
- **TUI**: vsplit mouse resize tolerance (#139), split-direction picker (#37)
- **Spawn lifecycle**: Resume → Fresh downgrade for idle Claude panes (#130)

## Release flow after merge
1. Cut tag \`v0.4.0\` on the merge commit → triggers \`release.yml\`
2. \`release.yml\` builds 5 platforms (macOS x86/arm64, Linux x86/arm64, Windows) + AppImage → GitHub Release with binaries
3. Manual \`cargo publish\` to crates.io after GitHub Release succeeds

## Test plan
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --bin agend-terminal\` (880 passed)
- [x] \`Cargo.lock\` regenerated by \`cargo build\` after version bump
- [ ] After merge: cut tag + verify release.yml succeeds
- [ ] After release: \`cargo publish --dry-run\` then \`cargo publish\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)