### PR TITLE
release: v0.4.1 — fix cargo publish packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ## [Unreleased]
 
+## [0.4.1] — 2026-04-24
+
+### Fixed
+
+- **`cargo install agend-terminal` build failure on 0.4.0** — `src/protocol.rs` does `include_str!("../docs/FLEET-DEV-PROTOCOL-v1.md")` but the file wasn't in the `Cargo.toml` `include` whitelist. The packaged tarball that `cargo publish` ships to crates.io was therefore missing the bundled protocol doc, and verification compile failed with "No such file or directory". GitHub Release binaries (built from the source tree, not the packaged tarball) were unaffected, so v0.4.0's binary downloads still work — but there is no v0.4.0 on crates.io. v0.4.1 is identical to v0.4.0 in source apart from this single packaging fix.
+
 ## [0.4.0] — 2026-04-24
 
 170+ commits since `0.3.2` — multi-agent collaboration plumbing (fleet
@@ -204,7 +210,8 @@ Substantial work has landed on `main` since `0.3.0`. Highlights, grouped by area
 
 ---
 
-[Unreleased]: https://github.com/suzuke/agend-terminal/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/suzuke/agend-terminal/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/suzuke/agend-terminal/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/suzuke/agend-terminal/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/suzuke/agend-terminal/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/suzuke/agend-terminal/compare/85f2bc3...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agend-terminal"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agend-terminal"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Agent Process Manager — orchestrate AI coding agents with PTY isolation, fleet management, and 35 MCP tools"
 license = "MIT"
@@ -15,6 +15,12 @@ include = [
     "src/**/*.rs",
     "build.rs",
     "assets/windows/*",
+    # `src/protocol.rs` does `include_str!("../docs/FLEET-DEV-PROTOCOL-v1.md")`
+    # at compile time. Without this entry, `cargo publish`'s verification
+    # build (which works on the packaged tarball, not the source tree)
+    # fails with "No such file or directory" — caught the hard way during
+    # the v0.4.0 publish attempt. Add any future bundled docs here too.
+    "docs/FLEET-DEV-PROTOCOL-v1.md",
     "Cargo.toml",
     "Cargo.lock",
     "README.md",


### PR DESCRIPTION
## Summary
v0.4.0 shipped to GitHub Release fine but \`cargo publish\` failed verification with:

\`\`\`
error: couldn't read \`src/../docs/FLEET-DEV-PROTOCOL-v1.md\`: No such file or directory
  --> src/protocol.rs:12:32
\`\`\`

\`include_str!(\"../docs/FLEET-DEV-PROTOCOL-v1.md\")\` at compile time, but \`docs/\` not in \`Cargo.toml\` \`include\` whitelist → packaged tarball was missing the file → \`cargo publish\`'s verification compile fails.

GitHub Release binaries (built from source tree) are unaffected — **v0.4.0 binary downloads still work**. There is just no v0.4.0 on crates.io.

## Changes
- Add \`docs/FLEET-DEV-PROTOCOL-v1.md\` to \`include\` (with a comment so future bundled docs don't repeat the mistake)
- Bump \`Cargo.toml\` + \`Cargo.lock\` to \`0.4.1\`
- CHANGELOG \`[0.4.1] — 2026-04-24\` calling out the packaging-only nature

## Test plan
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --bin agend-terminal\` (880 passed)
- [x] \`cargo publish --dry-run --registry crates-io --allow-dirty\` (passes — 114 files, 2.0 MiB tarball, verification compile succeeds)
- [ ] After merge: cut tag v0.4.1 + verify release.yml + run real \`cargo publish\`
🤖 Generated with [Claude Code](https://claude.com/claude-code)