### PR TITLE
sprint7: pointer-only injection (feature flag) + fix deliver enqueue bug (A2)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -78,7 +78,9 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     };
     let _ = crate::inbox::enqueue(ctx.home, target, msg.clone());
 
-    let inject_msg = if text.chars().count() > crate::inbox::HEADER_SIZE_THRESHOLD {
+    let inject_msg = if crate::inbox::pointer_only_inject()
+        || text.chars().count() > crate::inbox::HEADER_SIZE_THRESHOLD
+    {
         format!("{} (use inbox tool)", crate::inbox::format_header(&msg))
     } else {
         let display_text = if text.chars().count() > 200 {

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -660,6 +660,16 @@ pub fn deliver(
 }
 
 pub fn notify_agent(home: &Path, agent_name: &str, source: &NotifySource<'_>, text: &str) {
+    if pointer_only_inject() {
+        // Pointer-only mode: inject a minimal header directing agent to call inbox.
+        let notification = format!(
+            "[{source}] [AGEND-MSG] size={} (use inbox tool){}",
+            text.len(),
+            source.reply_hint()
+        );
+        compose_aware_inject(home, agent_name, &notification);
+        return;
+    }
     let display_text = if text.chars().count() > 200 {
         let truncated: String = text.chars().take(200).collect();
         format!("{truncated}... (run: agend-terminal agent inbox)")
@@ -1832,9 +1842,12 @@ mod tests {
         assert!(h.contains("key=val  ue"));
     }
 
+    /// Serialize tests that mutate AGEND_POINTER_ONLY_INJECT env var.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_pointer_only_feature_flag() {
-        // AGEND_POINTER_ONLY_INJECT=1 → pointer_only_inject() returns true
+        let _lock = ENV_LOCK.lock().unwrap();
         std::env::set_var("AGEND_POINTER_ONLY_INJECT", "1");
         assert!(pointer_only_inject(), "flag=1 must enable pointer-only");
         std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
@@ -1842,11 +1855,63 @@ mod tests {
 
     #[test]
     fn test_pointer_only_disabled_default() {
-        // Unset → pointer_only_inject() returns false (default behaviour)
+        let _lock = ENV_LOCK.lock().unwrap();
         std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
         assert!(!pointer_only_inject(), "unset flag must default to false");
         std::env::set_var("AGEND_POINTER_ONLY_INJECT", "0");
         assert!(!pointer_only_inject(), "flag=0 must be disabled");
         std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
+    }
+
+    #[test]
+    fn test_notify_agent_pointer_only_emits_header_not_body() {
+        // Flag=1 → notify_agent must NOT inject the message body into PTY.
+        // We verify by checking that compose_aware_inject receives a
+        // pointer-format string (contains [AGEND-MSG] + size=) not the body.
+        let _lock = ENV_LOCK.lock().unwrap();
+        let home = tmp_home("notify-pointer");
+        std::env::set_var("AGEND_POINTER_ONLY_INJECT", "1");
+
+        // notify_agent will try to inject via API (fails, no daemon) — that's ok.
+        // We verify the enqueued message + the fact that the function doesn't panic.
+        // The real assertion: deliver enqueues the full body, but notify_agent
+        // in pointer mode doesn't include the body text in the PTY injection.
+        deliver(
+            &home,
+            "agent1",
+            &NotifySource::Agent("sender"),
+            "secret body text",
+            "\r",
+            None,
+        );
+        // Message must be in inbox (enqueued by deliver)
+        let msgs = drain(&home, "agent1");
+        assert_eq!(msgs.len(), 1, "deliver must enqueue even in pointer mode");
+        assert_eq!(msgs[0].text, "secret body text", "full body in inbox");
+
+        std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_notify_agent_default_inline_behavior() {
+        // Flag unset → deliver enqueues AND notify_agent uses inline text.
+        let _lock = ENV_LOCK.lock().unwrap();
+        let home = tmp_home("notify-inline");
+        std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
+
+        deliver(
+            &home,
+            "agent1",
+            &NotifySource::Agent("sender"),
+            "inline text",
+            "\r",
+            None,
+        );
+        let msgs = drain(&home, "agent1");
+        assert_eq!(msgs.len(), 1, "deliver must enqueue in default mode too");
+        assert_eq!(msgs[0].text, "inline text");
+
+        fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -408,6 +408,16 @@ pub fn unread_count(home: &Path, name: &str) -> (usize, Option<chrono::DateTime<
 /// value inject only a structured header line; the full body stays in inbox.
 pub const HEADER_SIZE_THRESHOLD: usize = 300;
 
+/// Returns true when the `AGEND_POINTER_ONLY_INJECT` feature flag is set to "1".
+/// When enabled, PTY injection uses header-only format for all messages,
+/// forcing agents to call `inbox` to read content (solves dispatch non-FIFO).
+pub fn pointer_only_inject() -> bool {
+    std::env::var("AGEND_POINTER_ONLY_INJECT")
+        .ok()
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
 /// ANSI-colored header prefix for visual distinction in terminal.
 pub const HEADER_PREFIX: &str = "\x1b[44;97m[AGEND-MSG]\x1b[0m";
 
@@ -622,8 +632,8 @@ pub fn find_message(home: &Path, msg_id: &str) -> Option<InboxMessage> {
     None
 }
 
-/// Deliver a message: short messages (≤500 chars) inject directly to PTY,
-/// long messages store to inbox + inject truncated notification.
+/// Deliver a message: always enqueue to inbox JSONL for persistence,
+/// then inject to PTY (inline or pointer-only depending on feature flag).
 pub fn deliver(
     home: &Path,
     agent_name: &str,
@@ -632,25 +642,21 @@ pub fn deliver(
     _submit_key: &str,
     kind: Option<String>,
 ) {
-    if text.chars().count() <= INLINE_THRESHOLD {
-        notify_agent(home, agent_name, source, text);
-    } else {
-        let msg = InboxMessage {
-            schema_version: 0,
-            id: None,
-            read_at: None,
-            thread_id: None,
-            parent_id: None,
-            task_id: None,
-            from: source.to_string(),
-            text: text.to_string(),
-            kind,
-            timestamp: chrono::Utc::now().to_rfc3339(),
-            delivery_mode: None,
-        };
-        let _ = enqueue(home, agent_name, msg);
-        notify_agent(home, agent_name, source, text);
-    }
+    let msg = InboxMessage {
+        schema_version: 0,
+        id: None,
+        read_at: None,
+        thread_id: None,
+        parent_id: None,
+        task_id: None,
+        from: source.to_string(),
+        text: text.to_string(),
+        kind,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        delivery_mode: None,
+    };
+    let _ = enqueue(home, agent_name, msg);
+    notify_agent(home, agent_name, source, text);
 }
 
 pub fn notify_agent(home: &Path, agent_name: &str, source: &NotifySource<'_>, text: &str) {
@@ -918,10 +924,10 @@ mod tests {
     }
 
     #[test]
-    fn deliver_short_message_does_not_enqueue() {
+    fn deliver_short_message_also_enqueues() {
         let home = tmp_home("deliver-short");
-        // deliver with short text — should NOT write to inbox file
-        // (notify_agent will fail because no daemon, but enqueue should not be called)
+        // deliver with short text — must enqueue to inbox for persistence
+        // (previously skipped enqueue for ≤500 chars, causing data loss)
         deliver(
             &home,
             "agent1",
@@ -931,7 +937,11 @@ mod tests {
             None,
         );
         let msgs = drain(&home, "agent1");
-        assert!(msgs.is_empty(), "short messages bypass inbox");
+        assert_eq!(
+            msgs.len(),
+            1,
+            "short messages must be enqueued for persistence"
+        );
 
         fs::remove_dir_all(&home).ok();
     }
@@ -1820,5 +1830,23 @@ mod tests {
         assert!(!h.contains('\r'), "CR in value must be sanitized: {h:?}");
         assert!(h.contains("kind=evil kind"));
         assert!(h.contains("key=val  ue"));
+    }
+
+    #[test]
+    fn test_pointer_only_feature_flag() {
+        // AGEND_POINTER_ONLY_INJECT=1 → pointer_only_inject() returns true
+        std::env::set_var("AGEND_POINTER_ONLY_INJECT", "1");
+        assert!(pointer_only_inject(), "flag=1 must enable pointer-only");
+        std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
+    }
+
+    #[test]
+    fn test_pointer_only_disabled_default() {
+        // Unset → pointer_only_inject() returns false (default behaviour)
+        std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
+        assert!(!pointer_only_inject(), "unset flag must default to false");
+        std::env::set_var("AGEND_POINTER_ONLY_INJECT", "0");
+        assert!(!pointer_only_inject(), "flag=0 must be disabled");
+        std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
     }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -659,24 +659,32 @@ pub fn deliver(
     notify_agent(home, agent_name, source, text);
 }
 
-pub fn notify_agent(home: &Path, agent_name: &str, source: &NotifySource<'_>, text: &str) {
-    if pointer_only_inject() {
-        // Pointer-only mode: inject a minimal header directing agent to call inbox.
-        let notification = format!(
+/// Pure function: build the notification string that will be injected to PTY.
+/// `pointer_only=true` → header-only (no body); `false` → inline text.
+pub fn format_notification_for_inject(
+    pointer_only: bool,
+    source: &NotifySource<'_>,
+    text: &str,
+) -> String {
+    if pointer_only {
+        format!(
             "[{source}] [AGEND-MSG] size={} (use inbox tool){}",
             text.len(),
             source.reply_hint()
-        );
-        compose_aware_inject(home, agent_name, &notification);
-        return;
-    }
-    let display_text = if text.chars().count() > 200 {
-        let truncated: String = text.chars().take(200).collect();
-        format!("{truncated}... (run: agend-terminal agent inbox)")
+        )
     } else {
-        text.to_string()
-    };
-    let notification = format!("[{source}] {display_text}{}", source.reply_hint());
+        let display_text = if text.chars().count() > 200 {
+            let truncated: String = text.chars().take(200).collect();
+            format!("{truncated}... (run: agend-terminal agent inbox)")
+        } else {
+            text.to_string()
+        };
+        format!("[{source}] {display_text}{}", source.reply_hint())
+    }
+}
+
+pub fn notify_agent(home: &Path, agent_name: &str, source: &NotifySource<'_>, text: &str) {
+    let notification = format_notification_for_inject(pointer_only_inject(), source, text);
     compose_aware_inject(home, agent_name, &notification);
 }
 
@@ -1865,53 +1873,37 @@ mod tests {
 
     #[test]
     fn test_notify_agent_pointer_only_emits_header_not_body() {
-        // Flag=1 → notify_agent must NOT inject the message body into PTY.
-        // We verify by checking that compose_aware_inject receives a
-        // pointer-format string (contains [AGEND-MSG] + size=) not the body.
-        let _lock = ENV_LOCK.lock().unwrap();
-        let home = tmp_home("notify-pointer");
-        std::env::set_var("AGEND_POINTER_ONLY_INJECT", "1");
-
-        // notify_agent will try to inject via API (fails, no daemon) — that's ok.
-        // We verify the enqueued message + the fact that the function doesn't panic.
-        // The real assertion: deliver enqueues the full body, but notify_agent
-        // in pointer mode doesn't include the body text in the PTY injection.
-        deliver(
-            &home,
-            "agent1",
-            &NotifySource::Agent("sender"),
-            "secret body text",
-            "\r",
-            None,
+        // Pure function test: pointer_only=true → output contains [AGEND-MSG]
+        // + size= but NOT the body text.
+        let source = NotifySource::Agent("sender");
+        let s = format_notification_for_inject(true, &source, "secret body text");
+        assert!(
+            s.contains("[AGEND-MSG]"),
+            "pointer mode must contain [AGEND-MSG]: {s}"
         );
-        // Message must be in inbox (enqueued by deliver)
-        let msgs = drain(&home, "agent1");
-        assert_eq!(msgs.len(), 1, "deliver must enqueue even in pointer mode");
-        assert_eq!(msgs[0].text, "secret body text", "full body in inbox");
-
-        std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
-        fs::remove_dir_all(&home).ok();
+        assert!(s.contains("size="), "pointer mode must contain size=: {s}");
+        assert!(
+            !s.contains("secret body text"),
+            "pointer mode must NOT contain body: {s}"
+        );
+        assert!(
+            s.contains("use inbox tool"),
+            "pointer mode must direct to inbox: {s}"
+        );
     }
 
     #[test]
     fn test_notify_agent_default_inline_behavior() {
-        // Flag unset → deliver enqueues AND notify_agent uses inline text.
-        let _lock = ENV_LOCK.lock().unwrap();
-        let home = tmp_home("notify-inline");
-        std::env::remove_var("AGEND_POINTER_ONLY_INJECT");
-
-        deliver(
-            &home,
-            "agent1",
-            &NotifySource::Agent("sender"),
-            "inline text",
-            "\r",
-            None,
+        // Pure function test: pointer_only=false → output contains the body text.
+        let source = NotifySource::Agent("sender");
+        let s = format_notification_for_inject(false, &source, "inline text");
+        assert!(
+            s.contains("inline text"),
+            "default mode must contain body: {s}"
         );
-        let msgs = drain(&home, "agent1");
-        assert_eq!(msgs.len(), 1, "deliver must enqueue in default mode too");
-        assert_eq!(msgs[0].text, "inline text");
-
-        fs::remove_dir_all(&home).ok();
+        assert!(
+            !s.contains("[AGEND-MSG]"),
+            "default mode must NOT contain [AGEND-MSG] header: {s}"
+        );
     }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -377,7 +377,7 @@ fn read_drain_file(tmp: &Path) -> Vec<InboxMessage> {
     messages
 }
 
-pub const INLINE_THRESHOLD: usize = 500;
+// INLINE_THRESHOLD removed — deliver() now always enqueues regardless of length.
 
 /// Count unread messages (read_at == None) for an agent.
 pub fn unread_count(home: &Path, name: &str) -> (usize, Option<chrono::DateTime<chrono::Utc>>) {
@@ -949,7 +949,7 @@ mod tests {
     #[test]
     fn deliver_long_message_enqueues() {
         let home = tmp_home("deliver-long");
-        let long_text: String = "x".repeat(INLINE_THRESHOLD + 100);
+        let long_text: String = "x".repeat(600);
         deliver(
             &home,
             "agent1",


### PR DESCRIPTION
Fixes A2 dispatch non-FIFO + deliver data loss bug.

1. AGEND_POINTER_ONLY_INJECT=1 forces header-only PTY injection (agents call inbox for content)
2. deliver() now always enqueues to JSONL regardless of message length (fixes data loss for <=500 char messages)
3. Default behaviour unchanged (flag off)

Tests: deliver_short_message_also_enqueues, pointer_only_feature_flag, pointer_only_disabled_default. 967 tests pass.