### PR TITLE
sprint8: delegate_task busy gate + interrupt=true + timeout stuck detection (PR-I)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -66,7 +66,9 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             thread_id,
             parent_id,
             task_id: params["task_id"].as_str().map(String::from),
-            interrupt_meta: None,
+            interrupt_meta: params.get("interrupt_meta").and_then(|v| {
+                serde_json::from_value::<crate::inbox::InterruptMeta>(v.clone()).ok()
+            }),
             from: format!("from:{from}"),
             text: text.to_string(),
             kind: params

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -66,6 +66,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             thread_id,
             parent_id,
             task_id: params["task_id"].as_str().map(String::from),
+            interrupt_meta: None,
             from: format!("from:{from}"),
             text: text.to_string(),
             kind: params

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -440,6 +440,7 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         thread_id: None,
         parent_id: None,
         task_id: None,
+        interrupt_meta: None,
         from: format!("user:{username}"),
         text: text.to_string(),
         kind: Some("telegram".to_string()),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,6 +198,7 @@ fn test_inbox(home: &Path) -> anyhow::Result<()> {
                 thread_id: None,
                 parent_id: None,
                 task_id: None,
+                interrupt_meta: None,
                 from: format!("tester-{i}"),
                 text: format!("Message {i}"),
                 kind: None,

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -454,6 +454,7 @@ async fn ci_check_repo(
                     thread_id: None,
                     parent_id: None,
                     task_id: None,
+                    interrupt_meta: None,
                     from: "system:ci".to_string(),
                     text: body,
                     kind: Some("ci-watch".to_string()),

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -122,6 +122,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     thread_id: None,
                     parent_id: None,
                     task_id: None,
+                    interrupt_meta: None,
                     from: "system:schedule".to_string(),
                     text: message.to_string(),
                     kind: Some("schedule".to_string()),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -828,7 +828,7 @@ fn apply_fleet_reload(
 /// Replay missed one-shot schedules on daemon startup.
 /// Calls `schedules::replay_missed_oneshots` and fires each returned
 /// schedule through the same path as `cron_tick::check_schedules`.
-/// Sweep overdue claimed tasks and log events.
+/// Sweep overdue claimed tasks and stuck dispatches, log events.
 pub fn run_task_maintenance(home: &Path) {
     let unclaimed = crate::tasks::sweep_overdue_claimed(home);
     for tid in &unclaimed {
@@ -839,6 +839,30 @@ pub fn run_task_maintenance(home: &Path) {
             "due_at expired, status → open",
         );
         tracing::info!(task_id = %tid, "task overdue, unclaimed");
+    }
+    // Dispatch timeout detection
+    let (warns, asks) = crate::dispatch_tracking::sweep_stuck(home);
+    for w in &warns {
+        crate::event_log::log(
+            home,
+            "dispatch_stuck_warn",
+            &w.to,
+            &format!(
+                "no report_result after {}min",
+                crate::dispatch_tracking::DISPATCH_WARN_MINUTES
+            ),
+        );
+    }
+    for a in &asks {
+        crate::event_log::log(
+            home,
+            "dispatch_stuck_ask",
+            &a.to,
+            &format!(
+                "no report_result after {}min, querying assignee",
+                crate::dispatch_tracking::DISPATCH_ASK_MINUTES
+            ),
+        );
     }
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -863,6 +863,29 @@ pub fn run_task_maintenance(home: &Path) {
                 crate::dispatch_tracking::DISPATCH_ASK_MINUTES
             ),
         );
+        let tid = a.task_id.as_deref().unwrap_or("unknown");
+        let query = format!(
+            "dispatch stuck check: still working on task_id={tid} (dispatched {}min ago)?",
+            crate::dispatch_tracking::DISPATCH_ASK_MINUTES
+        );
+        let _ = crate::inbox::enqueue(
+            home,
+            &a.to,
+            crate::inbox::InboxMessage {
+                schema_version: 0,
+                id: None,
+                read_at: None,
+                thread_id: None,
+                parent_id: None,
+                task_id: None,
+                from: "system:dispatch".to_string(),
+                text: query,
+                kind: Some("query".to_string()),
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                delivery_mode: None,
+                interrupt_meta: None,
+            },
+        );
     }
 }
 
@@ -904,6 +927,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     kind: Some("schedule_replay".to_string()),
                     timestamp: now.to_rfc3339(),
                     delivery_mode: None,
+                    interrupt_meta: None,
                     read_at: None,
                     thread_id: None,
                     parent_id: None,

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -105,6 +105,7 @@ mod tests {
                     kind: None,
                     timestamp: chrono::Utc::now().to_rfc3339(),
                     delivery_mode: None,
+                    interrupt_meta: None,
                     read_at: None,
                     thread_id: None,
                     parent_id: None,

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -128,7 +128,10 @@ mod tests {
         );
         let (warns, asks) = sweep_stuck(&home);
         // 31min → jumps straight to ask (skips warn since ask threshold met)
-        assert!(warns.is_empty(), "31min should go straight to ask, not warn");
+        assert!(
+            warns.is_empty(),
+            "31min should go straight to ask, not warn"
+        );
         assert_eq!(asks.len(), 1, "31min old dispatch must ask");
         assert_eq!(asks[0].to, "reviewer");
         std::fs::remove_dir_all(&home).ok();

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -1,0 +1,135 @@
+//! Dispatch tracking — monitors delegated tasks for timeout/stuck detection.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Warn threshold: dispatcher gets notified if no report_result after this.
+pub const DISPATCH_WARN_MINUTES: i64 = 15;
+/// Ask threshold: daemon sends query to assignee after this.
+pub const DISPATCH_ASK_MINUTES: i64 = 30;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DispatchEntry {
+    pub task_id: Option<String>,
+    pub from: String,
+    pub to: String,
+    pub delegated_at: String,
+    pub status: String, // "pending" | "completed" | "warned" | "asked"
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct DispatchStore {
+    #[serde(default)]
+    schema_version: u32,
+    entries: Vec<DispatchEntry>,
+}
+
+impl crate::store::SchemaVersioned for DispatchStore {
+    const CURRENT: u32 = 1;
+    fn version_mut(&mut self) -> &mut u32 {
+        &mut self.schema_version
+    }
+}
+
+fn store_path(home: &Path) -> std::path::PathBuf {
+    crate::store::store_path(home, "dispatch_tracking.json")
+}
+
+/// Record a new delegation.
+pub fn track_dispatch(home: &Path, entry: DispatchEntry) {
+    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+        store.entries.push(entry);
+        Ok(())
+    });
+}
+
+/// Sweep for stuck dispatches. Returns (warn_list, ask_list).
+pub fn sweep_stuck(home: &Path) -> (Vec<DispatchEntry>, Vec<DispatchEntry>) {
+    let now = chrono::Utc::now();
+    let mut warns = Vec::new();
+    let mut asks = Vec::new();
+
+    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+        for entry in store.entries.iter_mut() {
+            if entry.status == "completed" {
+                continue;
+            }
+            let delegated = match chrono::DateTime::parse_from_rfc3339(&entry.delegated_at) {
+                Ok(dt) => dt.with_timezone(&chrono::Utc),
+                Err(_) => continue,
+            };
+            let age_min = now.signed_duration_since(delegated).num_minutes();
+
+            if age_min >= DISPATCH_ASK_MINUTES && entry.status != "asked" {
+                entry.status = "asked".to_string();
+                asks.push(entry.clone());
+            } else if age_min >= DISPATCH_WARN_MINUTES && entry.status == "pending" {
+                entry.status = "warned".to_string();
+                warns.push(entry.clone());
+            }
+        }
+        Ok(())
+    });
+    (warns, asks)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-dispatch-test-{}-{}",
+            tag,
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    #[test]
+    fn test_dispatch_warn_after_15min() {
+        let home = tmp_home("warn-15");
+        let past = (chrono::Utc::now() - chrono::Duration::minutes(16)).to_rfc3339();
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-test".into()),
+                from: "lead".into(),
+                to: "impl".into(),
+                delegated_at: past,
+                status: "pending".into(),
+            },
+        );
+        let (warns, asks) = sweep_stuck(&home);
+        assert_eq!(warns.len(), 1, "16min old dispatch must warn");
+        assert!(asks.is_empty());
+        // Verify event_log integration
+        crate::event_log::log(&home, "dispatch_stuck_warn", &warns[0].to, "test");
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert!(log.contains("dispatch_stuck_warn"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_dispatch_ask_after_30min() {
+        let home = tmp_home("ask-30");
+        let past = (chrono::Utc::now() - chrono::Duration::minutes(31)).to_rfc3339();
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-test".into()),
+                from: "lead".into(),
+                to: "reviewer".into(),
+                delegated_at: past,
+                status: "pending".into(),
+            },
+        );
+        let (warns, asks) = sweep_stuck(&home);
+        // 31min → jumps straight to ask (skips warn)
+        assert_eq!(asks.len(), 1, "31min old dispatch must ask");
+        assert_eq!(asks[0].to, "reviewer");
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -127,7 +127,8 @@ mod tests {
             },
         );
         let (warns, asks) = sweep_stuck(&home);
-        // 31min → jumps straight to ask (skips warn)
+        // 31min → jumps straight to ask (skips warn since ask threshold met)
+        assert!(warns.is_empty(), "31min should go straight to ask, not warn");
         assert_eq!(asks.len(), 1, "31min old dispatch must ask");
         assert_eq!(asks[0].to, "reviewer");
         std::fs::remove_dir_all(&home).ok();

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -44,17 +44,17 @@ pub fn track_dispatch(home: &Path, entry: DispatchEntry) {
 }
 
 /// Mark a dispatch as completed (matched by task_id or to-instance).
-pub fn mark_completed(home: &Path, correlation_id: Option<&str>, to: &str) {
+pub fn mark_completed(home: &Path, correlation_id: Option<&str>, _to: &str) {
+    let cid = match correlation_id {
+        Some(c) if !c.is_empty() => c,
+        _ => return, // No correlation_id → can't match, let sweep continue tracking
+    };
     let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
         for entry in store.entries.iter_mut() {
             if entry.status == "completed" {
                 continue;
             }
-            let matches = correlation_id
-                .and_then(|cid| entry.task_id.as_deref().map(|tid| tid == cid))
-                .unwrap_or(false)
-                || entry.to == to;
-            if matches {
+            if entry.task_id.as_deref() == Some(cid) {
                 entry.status = "completed".to_string();
             }
         }

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -43,6 +43,25 @@ pub fn track_dispatch(home: &Path, entry: DispatchEntry) {
     });
 }
 
+/// Mark a dispatch as completed (matched by task_id or to-instance).
+pub fn mark_completed(home: &Path, correlation_id: Option<&str>, to: &str) {
+    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+        for entry in store.entries.iter_mut() {
+            if entry.status == "completed" {
+                continue;
+            }
+            let matches = correlation_id
+                .and_then(|cid| entry.task_id.as_deref().map(|tid| tid == cid))
+                .unwrap_or(false)
+                || entry.to == to;
+            if matches {
+                entry.status = "completed".to_string();
+            }
+        }
+        Ok(())
+    });
+}
+
 /// Sweep for stuck dispatches. Returns (warn_list, ask_list).
 pub fn sweep_stuck(home: &Path) -> (Vec<DispatchEntry>, Vec<DispatchEntry>) {
     let now = chrono::Utc::now();
@@ -134,6 +153,54 @@ mod tests {
         );
         assert_eq!(asks.len(), 1, "31min old dispatch must ask");
         assert_eq!(asks[0].to, "reviewer");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_report_result_marks_dispatch_completed() {
+        let home = tmp_home("mark-complete");
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-123".into()),
+                from: "lead".into(),
+                to: "impl".into(),
+                delegated_at: (chrono::Utc::now() - chrono::Duration::minutes(20)).to_rfc3339(),
+                status: "pending".into(),
+            },
+        );
+        // Mark completed (simulates report_result handler calling this)
+        mark_completed(&home, Some("t-123"), "impl");
+        // Sweep should find nothing — entry is completed
+        let (warns, asks) = sweep_stuck(&home);
+        assert!(warns.is_empty(), "completed dispatch must not warn");
+        assert!(asks.is_empty(), "completed dispatch must not ask");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_dispatch_ask_sends_query_to_inbox() {
+        let home = tmp_home("ask-inbox");
+        let past = (chrono::Utc::now() - chrono::Duration::minutes(31)).to_rfc3339();
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-stuck".into()),
+                from: "lead".into(),
+                to: "reviewer".into(),
+                delegated_at: past,
+                status: "pending".into(),
+            },
+        );
+        // Run the daemon maintenance path
+        crate::daemon::run_task_maintenance(&home);
+        // Verify reviewer got a query in inbox
+        let msgs = crate::inbox::drain(&home, "reviewer");
+        assert!(
+            msgs.iter().any(|m| m.text.contains("dispatch stuck check")),
+            "reviewer must receive stuck query in inbox: {:?}",
+            msgs.iter().map(|m| &m.text).collect::<Vec<_>>()
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -178,6 +178,17 @@ pub struct InboxMessage {
     pub delivery_mode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
+    /// Interrupt metadata — set when delegate_task used interrupt=true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interrupt_meta: Option<InterruptMeta>,
+}
+
+/// Metadata attached to an interrupted delegation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterruptMeta {
+    pub interrupted: bool,
+    pub reason: String,
+    pub interrupted_at: String,
 }
 
 impl InboxMessage {
@@ -649,6 +660,7 @@ pub fn deliver(
         thread_id: None,
         parent_id: None,
         task_id: None,
+        interrupt_meta: None,
         from: source.to_string(),
         text: text.to_string(),
         kind,
@@ -798,6 +810,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            interrupt_meta: None,
             from: from.to_string(),
             text: text.to_string(),
             kind: None,
@@ -924,6 +937,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            interrupt_meta: None,
             from: "sender".to_string(),
             text: "body text".to_string(),
             kind: Some("notification".to_string()),
@@ -1021,6 +1035,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            interrupt_meta: None,
             from: "test".to_string(),
             text: "hello \"world\"".to_string(),
             kind: None,
@@ -1043,6 +1058,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            interrupt_meta: None,
             from: "user".to_string(),
             text: "line1\nline2\ttab".to_string(),
             kind: Some("special".to_string()),
@@ -1629,6 +1645,7 @@ mod tests {
             kind: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
             delivery_mode: None,
+            interrupt_meta: None,
             read_at: None,
             thread_id: Some("thread-42".into()),
             parent_id: Some("m-0".into()),
@@ -1652,6 +1669,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            interrupt_meta: None,
             ..msg.clone()
         };
         let json2 = serde_json::to_string(&msg_no_thread).expect("ser");
@@ -1669,6 +1687,7 @@ mod tests {
             kind: Some("task".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
             delivery_mode: None,
+            interrupt_meta: None,
             read_at: None,
             thread_id: Some("t-100".into()),
             parent_id: Some("m-41".into()),
@@ -1695,6 +1714,7 @@ mod tests {
             kind: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
             delivery_mode: None,
+            interrupt_meta: None,
             read_at: None,
             thread_id: None,
             parent_id: None,
@@ -1719,6 +1739,7 @@ mod tests {
             kind: Some("task\r\ninjection".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
             delivery_mode: None,
+            interrupt_meta: None,
             read_at: None,
             thread_id: Some("t\n1".into()),
             parent_id: None,
@@ -1747,6 +1768,7 @@ mod tests {
             kind: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
             delivery_mode: None,
+            interrupt_meta: None,
             read_at: None,
             thread_id: None,
             parent_id: None,
@@ -1780,6 +1802,7 @@ mod tests {
             kind: Some("task".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
             delivery_mode: None,
+            interrupt_meta: None,
             read_at: None,
             thread_id: None,
             parent_id: None,
@@ -1816,6 +1839,7 @@ mod tests {
             kind: None,
             timestamp: "2026-01-01T00:00:00Z".into(),
             delivery_mode: None,
+            interrupt_meta: None,
             read_at: None,
             thread_id: None,
             parent_id: None,

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -960,6 +960,7 @@ mod tests {
             kind: Some("task".into()),
             timestamp: "2026-01-01T00:00:00Z".into(),
             delivery_mode: None,
+            interrupt_meta: None,
             read_at: None,
             thread_id: None,
             parent_id: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod connect;
 mod daemon;
 mod decisions;
 mod deployments;
+mod dispatch_tracking;
 mod error;
 mod event_log;
 mod fleet;

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -166,6 +166,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         thread_id: resolved_thread,
                         parent_id: resolved_parent,
                         task_id: None,
+                        interrupt_meta: None,
                         from: format!("from:{}", sender.as_str()),
                         text: text.to_string(),
                         kind: None,
@@ -238,6 +239,11 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             }
 
             let mut msg = format!("[delegate_task] {task}");
+            if interrupt {
+                if let Some(r) = reason {
+                    msg.push_str(&format!("\n\n⚠️ INTERRUPT (reason: {r})"));
+                }
+            }
             if let Some(tid) = args["task_id"].as_str() {
                 msg.push_str(&format!(" (task id: {tid})"));
             }
@@ -279,6 +285,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         thread_id: None,
                         parent_id: None,
                         task_id: task_id_str.map(String::from),
+                        interrupt_meta: None,
                         delivery_mode: Some("inbox_fallback".to_string()),
                         from: format!("from:{}", sender.as_str()),
                         text: msg.clone(),
@@ -359,6 +366,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             }
             let result = send_to(&home, sender, target, &msg, "report");
             if is_ok_result(&result) {
+                // Mark dispatch as completed so timeout sweep doesn't false-warn.
+                let cid = args["correlation_id"].as_str();
+                crate::dispatch_tracking::mark_completed(&home, cid, sender.as_str());
                 // Fleet visibility. `correlation_id` is caller-chosen
                 // (e.g. "AGD-42"); an empty string collapses to `None`
                 // so the renderer omits the id rather than showing "()".
@@ -779,6 +789,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                     thread_id: None,
                     parent_id: None,
                     task_id: None,
+                    interrupt_meta: None,
                     from: "system:replace".to_string(),
                     text: format!("[handover] {handover}"),
                     kind: Some("handover".to_string()),
@@ -2159,6 +2170,7 @@ instances:
                 thread_id: None,
                 parent_id: None,
                 task_id: None,
+                interrupt_meta: None,
                 from: "user:test".to_string(),
                 text: "hello".to_string(),
                 kind: Some("telegram".to_string()),
@@ -2212,6 +2224,7 @@ instances:
                 thread_id: None,
                 parent_id: None,
                 task_id: None,
+                interrupt_meta: None,
                 from: "user:test".to_string(),
                 text: "burst".to_string(),
                 kind: Some("telegram".to_string()),
@@ -2378,6 +2391,7 @@ instances:
             thread_id: None,
             parent_id: None,
             delivery_mode: Some("inbox_fallback".into()),
+            interrupt_meta: None,
             task_id: None,
         };
         let inbox_dir = home.join("inbox");

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -253,6 +253,15 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             if let Some(ctx) = args["context"].as_str() {
                 msg.push_str(&format!("\n\nContext: {ctx}"));
             }
+            let interrupt_meta_json = if interrupt {
+                Some(json!({
+                    "interrupted": true,
+                    "reason": reason.unwrap_or(""),
+                    "interrupted_at": chrono::Utc::now().to_rfc3339()
+                }))
+            } else {
+                None
+            };
             let task_id_str = args["task_id"].as_str();
             let result = match crate::api::call(
                 &home,
@@ -264,6 +273,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         "text": msg,
                         "kind": "task",
                         "task_id": task_id_str,
+                        "interrupt_meta": interrupt_meta_json,
                     }
                 }),
             ) {
@@ -285,7 +295,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         thread_id: None,
                         parent_id: None,
                         task_id: task_id_str.map(String::from),
-                        interrupt_meta: None,
+                        interrupt_meta: interrupt_meta_json.as_ref().and_then(|v| {
+                            serde_json::from_value::<crate::inbox::InterruptMeta>(v.clone()).ok()
+                        }),
                         delivery_mode: Some("inbox_fallback".to_string()),
                         from: format!("from:{}", sender.as_str()),
                         text: msg.clone(),
@@ -2490,6 +2502,19 @@ instances:
                 || !result["error"].as_str().unwrap_or("").contains("busy"),
             "must not error on busy: {result}"
         );
+        // Verify interrupt_meta persisted in receiver's inbox
+        let msgs = crate::inbox::drain(&home, "target");
+        assert!(!msgs.is_empty(), "target must have inbox message");
+        let msg = &msgs[0];
+        assert!(
+            msg.interrupt_meta.is_some(),
+            "interrupt_meta must be set on inbox message: {:?}",
+            msg.interrupt_meta
+        );
+        let meta = msg.interrupt_meta.as_ref().unwrap();
+        assert!(meta.interrupted);
+        assert_eq!(meta.reason, "critical bug");
+        assert!(!meta.interrupted_at.is_empty());
         std::env::remove_var("AGEND_HOME");
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -205,6 +205,38 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 Some(t) => t,
                 None => return json!({"error": "missing 'task'"}),
             };
+
+            // Busy gate: check if target has claimed tasks on the task board.
+            let interrupt = args["interrupt"].as_bool().unwrap_or(false);
+            let reason = args["reason"].as_str();
+            let claimed_tasks: Vec<_> = crate::tasks::list_all(&home)
+                .into_iter()
+                .filter(|t| t.assignee.as_deref() == Some(target) && t.status == "claimed")
+                .collect();
+            if !claimed_tasks.is_empty() {
+                if interrupt {
+                    if reason.is_none() || reason == Some("") {
+                        return json!({"error": "interrupt=true requires a non-empty 'reason'"});
+                    }
+                } else {
+                    let current = &claimed_tasks[0];
+                    let age_secs = chrono::DateTime::parse_from_rfc3339(&current.updated_at)
+                        .ok()
+                        .map(|dt| {
+                            chrono::Utc::now()
+                                .signed_duration_since(dt.with_timezone(&chrono::Utc))
+                                .num_seconds()
+                        })
+                        .unwrap_or(0);
+                    return json!({
+                        "busy": true,
+                        "current_task": {"id": current.id, "title": current.title, "age_seconds": age_secs},
+                        "options": ["interrupt=true (with reason)", "queue=true"],
+                        "suggestion": format!("target busy on task {} ({}s old). Use interrupt=true with reason to override.", current.id, age_secs)
+                    });
+                }
+            }
+
             let mut msg = format!("[delegate_task] {task}");
             if let Some(tid) = args["task_id"].as_str() {
                 msg.push_str(&format!(" (task id: {tid})"));
@@ -265,6 +297,17 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             };
             if is_ok_result(&result) {
                 let task_id = task_id_str.map(str::to_string);
+                // Track dispatch for timeout detection
+                crate::dispatch_tracking::track_dispatch(
+                    &home,
+                    crate::dispatch_tracking::DispatchEntry {
+                        task_id: task_id.clone(),
+                        from: sender.as_str().to_string(),
+                        to: target.to_string(),
+                        delegated_at: chrono::Utc::now().to_rfc3339(),
+                        status: "pending".to_string(),
+                    },
+                );
                 ux_sink_registry().emit(&UxEvent::Fleet(FleetEvent::DelegateTask {
                     from: sender.as_str().to_string(),
                     to: target.to_string(),
@@ -2354,6 +2397,140 @@ instances:
             result["delivery_mode"].as_str(),
             Some("inbox_fallback"),
             "describe_message must show delivery_mode: {result}"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // --- Sprint 8: busy gate + interrupt ---
+
+    #[test]
+    fn test_delegate_task_busy_returns_structured_response() {
+        let _g = fleet_test_guard();
+        let home = tmp_home("busy-gate");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
+        )
+        .ok();
+        std::env::set_var("AGEND_HOME", &home);
+        // Create and claim a task for target
+        crate::tasks::handle(
+            &home,
+            "target",
+            &json!({"action": "create", "title": "busy work"}),
+        );
+        let tasks = crate::tasks::handle(&home, "target", &json!({"action": "list"}));
+        let tid = tasks["tasks"][0]["id"].as_str().unwrap();
+        crate::tasks::handle(&home, "target", &json!({"action": "claim", "id": tid}));
+
+        let result = handle_tool(
+            "delegate_task",
+            &json!({"target_instance": "target", "task": "new work"}),
+            "sender",
+        );
+        assert_eq!(result["busy"], true, "must return busy: {result}");
+        assert!(
+            result["current_task"]["id"].is_string(),
+            "must have current_task.id: {result}"
+        );
+        assert!(result["options"].is_array(), "must have options: {result}");
+        assert!(
+            result["suggestion"].is_string(),
+            "must have suggestion: {result}"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_delegate_task_interrupt_true_bypasses_busy_gate() {
+        let _g = fleet_test_guard();
+        let home = tmp_home("interrupt-bypass");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
+        )
+        .ok();
+        std::env::set_var("AGEND_HOME", &home);
+        crate::tasks::handle(
+            &home,
+            "target",
+            &json!({"action": "create", "title": "busy"}),
+        );
+        let tasks = crate::tasks::handle(&home, "target", &json!({"action": "list"}));
+        let tid = tasks["tasks"][0]["id"].as_str().unwrap();
+        crate::tasks::handle(&home, "target", &json!({"action": "claim", "id": tid}));
+
+        let result = handle_tool(
+            "delegate_task",
+            &json!({"target_instance": "target", "task": "urgent", "interrupt": true, "reason": "critical bug"}),
+            "sender",
+        );
+        assert!(
+            result.get("busy").is_none(),
+            "interrupt=true must bypass busy gate: {result}"
+        );
+        assert!(
+            result.get("error").is_none()
+                || !result["error"].as_str().unwrap_or("").contains("busy"),
+            "must not error on busy: {result}"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_delegate_task_interrupt_true_without_reason_rejected() {
+        let _g = fleet_test_guard();
+        let home = tmp_home("interrupt-no-reason");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
+        )
+        .ok();
+        std::env::set_var("AGEND_HOME", &home);
+        crate::tasks::handle(
+            &home,
+            "target",
+            &json!({"action": "create", "title": "busy"}),
+        );
+        let tasks = crate::tasks::handle(&home, "target", &json!({"action": "list"}));
+        let tid = tasks["tasks"][0]["id"].as_str().unwrap();
+        crate::tasks::handle(&home, "target", &json!({"action": "claim", "id": tid}));
+
+        let result = handle_tool(
+            "delegate_task",
+            &json!({"target_instance": "target", "task": "urgent", "interrupt": true}),
+            "sender",
+        );
+        assert!(
+            result["error"].as_str().unwrap_or("").contains("reason"),
+            "interrupt without reason must error: {result}"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_delegate_task_idle_target_normal_delivery() {
+        let _g = fleet_test_guard();
+        let home = tmp_home("idle-target");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
+        )
+        .ok();
+        std::env::set_var("AGEND_HOME", &home);
+        // No claimed tasks for target
+        let result = handle_tool(
+            "delegate_task",
+            &json!({"target_instance": "target", "task": "normal work"}),
+            "sender",
+        );
+        assert!(
+            result.get("busy").is_none(),
+            "idle target must not return busy: {result}"
         );
         std::env::remove_var("AGEND_HOME");
         std::fs::remove_dir_all(&home).ok();

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -46,7 +46,9 @@ fn comm_tools() -> Vec<Value> {
                 "target_instance": {"type": "string"}, "task": {"type": "string"},
                 "success_criteria": {"type": "string"}, "context": {"type": "string"},
                 "task_id": {"type": "string", "description": "Task board ID for correlation"},
-                "thread_id": {"type": "string"}, "parent_id": {"type": "string"}
+                "thread_id": {"type": "string"}, "parent_id": {"type": "string"},
+                "interrupt": {"type": "boolean", "description": "Override busy gate (requires reason)"},
+                "reason": {"type": "string", "description": "Reason for interrupt (required when interrupt=true)"}
             }, "required": ["target_instance", "task"]}}),
         json!({"name": "report_result", "description": "Report results back to the delegating instance.",
             "inputSchema": {"type": "object", "properties": {

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -890,6 +890,7 @@ mod tests {
                     kind: Some("schedule_replay".to_string()),
                     timestamp: chrono::Utc::now().to_rfc3339(),
                     delivery_mode: None,
+                    interrupt_meta: None,
                     read_at: None,
                     thread_id: None,
                     parent_id: None,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -291,6 +291,7 @@ fn test_inbox(home: &Path) -> TestResult {
                 thread_id: None,
                 parent_id: None,
                 task_id: None,
+                interrupt_meta: None,
                 from: format!("test-{i}"),
                 text: format!("msg {i}"),
                 kind: None,


### PR DESCRIPTION
## Design

### Busy gate
- Uses task board state (not agent_state) to detect busy targets
- Structured response with current_task info + options (not hard reject)
- interrupt=true + mandatory reason bypasses gate

### Dispatch tracking
- New dispatch_tracking.rs store (dispatch_tracking.json)
- 15min warn + 30min ask thresholds (event_log)
- Wired to daemon tick via run_task_maintenance
- PR-J can inherit this store for correlation match

### Tests (6)
- busy structured response, interrupt bypass, interrupt without reason rejected
- idle target normal delivery, 15min warn, 30min ask

990 tests pass, clippy(tray)/fmt clean.