### PR TITLE
sprint8: task board done TTL filter + overlay enhancements (PR-M)

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -1325,6 +1325,18 @@ pub fn render_tasks(
     .split(inner);
 
     let col_titles = ["Backlog", "Open", "In Progress", "Done"];
+    let done_visible = columns.get(3).map(|c| c.len()).unwrap_or(0);
+    let col_title_strs: Vec<String> = col_titles
+        .iter()
+        .enumerate()
+        .map(|(i, t)| {
+            if i == 3 {
+                format!(" {} ({}/14d) ", t, done_visible)
+            } else {
+                format!(" {} ({}) ", t, columns.get(i).map(|c| c.len()).unwrap_or(0))
+            }
+        })
+        .collect();
     let col_colors = [Color::Gray, Color::Green, Color::Yellow, Color::DarkGray];
 
     for (ci, (tasks, area)) in columns.iter().zip(col_areas.iter()).enumerate() {
@@ -1338,7 +1350,7 @@ pub fn render_tasks(
             .borders(Borders::ALL)
             .border_style(Style::default().fg(border_color))
             .title(Span::styled(
-                format!(" {} ({}) ", col_titles[ci], tasks.len()),
+                &col_title_strs[ci],
                 Style::default()
                     .fg(if is_active {
                         Color::Blue

--- a/src/render.rs
+++ b/src/render.rs
@@ -1391,6 +1391,31 @@ pub fn render_tasks(
         frame.render_widget(Paragraph::new(lines), block_inner);
     }
 
+    // Status line: active/idle agent summary from In Progress column
+    if inner.height > 2 && inner.width > 10 {
+        let active_agents: std::collections::HashSet<&str> = columns[2]
+            .iter()
+            .filter_map(|t| t.assignee.as_deref())
+            .collect();
+        let status_text = if active_agents.is_empty() {
+            "all idle".to_string()
+        } else {
+            let names: Vec<&str> = active_agents.into_iter().collect();
+            format!("active: {}", names.join(", "))
+        };
+        let status_y = inner.y + inner.height.saturating_sub(1);
+        let status_area = Rect::new(
+            inner.x + 1,
+            status_y,
+            inner.width.saturating_sub(2).min(status_text.len() as u16),
+            1,
+        );
+        frame.render_widget(
+            Paragraph::new(Span::styled(status_text, Style::default().fg(Color::Cyan))),
+            status_area,
+        );
+    }
+
     // Help hint at bottom-right (hidden in Help mode)
     if !matches!(mode, TaskBoardMode::Help) && inner.height > 1 && inner.width > 6 {
         let hint = "? help";
@@ -1557,6 +1582,13 @@ pub fn task_board_columns(items: &[crate::tasks::Task]) -> [Vec<&crate::tasks::T
     sort_col(&mut backlog);
     sort_col(&mut open);
     sort_col(&mut in_progress);
+    // Secondary sort: group In Progress by assignee for visual grouping
+    in_progress.sort_by(|a, b| {
+        a.assignee
+            .as_deref()
+            .unwrap_or("")
+            .cmp(b.assignee.as_deref().unwrap_or(""))
+    });
     sort_col(&mut done);
 
     [backlog, open, in_progress, done]

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -263,11 +263,24 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             let store = load(home);
             let filter_assignee = args["filter_assignee"].as_str();
             let filter_status = args["filter_status"].as_str();
+            let now = chrono::Utc::now();
+            let done_ttl = chrono::Duration::days(14);
             let filtered: Vec<_> = store
                 .tasks
                 .iter()
                 .filter(|t| filter_assignee.is_none_or(|a| t.assignee.as_deref() == Some(a)))
                 .filter(|t| filter_status.is_none_or(|s| t.status == s))
+                .filter(|t| {
+                    // When no explicit status filter, hide done tasks older than 14d
+                    if filter_status.is_some() || t.status != "done" {
+                        return true;
+                    }
+                    chrono::DateTime::parse_from_rfc3339(&t.updated_at)
+                        .map(|dt| {
+                            now.signed_duration_since(dt.with_timezone(&chrono::Utc)) < done_ttl
+                        })
+                        .unwrap_or(true)
+                })
                 .collect();
             serde_json::json!({"tasks": filtered})
         }
@@ -1406,6 +1419,154 @@ mod tests {
             r["error"].as_str().unwrap().contains("not authorized"),
             "non-owner must not update assigned task: {r}"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // --- Sprint 8 PR-M: Done TTL filter ---
+
+    #[test]
+    fn test_list_default_hides_done_older_than_14d() {
+        let home = tmp_home("done-ttl-hide");
+        // Create two tasks, mark both done
+        let r1 = handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "create", "title": "old done"}),
+        );
+        let id1 = r1["id"].as_str().unwrap().to_string();
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "claim", "id": id1}),
+        );
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "done", "id": id1, "result": "ok"}),
+        );
+
+        let r2 = handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "create", "title": "recent done"}),
+        );
+        let id2 = r2["id"].as_str().unwrap().to_string();
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "claim", "id": id2}),
+        );
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "done", "id": id2, "result": "ok"}),
+        );
+
+        // Backdate the first task's updated_at to 15 days ago
+        let _ = crate::store::mutate_versioned(
+            &crate::store::store_path(&home, "tasks.json"),
+            |store: &mut TaskStore| {
+                if let Some(t) = store.tasks.iter_mut().find(|t| t.id == id1) {
+                    t.updated_at = (chrono::Utc::now() - chrono::Duration::days(15)).to_rfc3339();
+                }
+                Ok(())
+            },
+        );
+
+        // Default list (no filter_status) should hide the old done task
+        let listed = handle(&home, "a", &serde_json::json!({"action": "list"}));
+        let tasks = listed["tasks"].as_array().unwrap();
+        assert_eq!(tasks.len(), 1, "old done task must be hidden");
+        assert_eq!(tasks[0]["title"], "recent done");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_list_done_filter_returns_all() {
+        let home = tmp_home("done-ttl-all");
+        let r1 = handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "create", "title": "old"}),
+        );
+        let id1 = r1["id"].as_str().unwrap().to_string();
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "claim", "id": id1}),
+        );
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "done", "id": id1, "result": "ok"}),
+        );
+
+        let r2 = handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "create", "title": "new"}),
+        );
+        let id2 = r2["id"].as_str().unwrap().to_string();
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "claim", "id": id2}),
+        );
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "done", "id": id2, "result": "ok"}),
+        );
+
+        let _ = crate::store::mutate_versioned(
+            &crate::store::store_path(&home, "tasks.json"),
+            |store: &mut TaskStore| {
+                if let Some(t) = store.tasks.iter_mut().find(|t| t.id == id1) {
+                    t.updated_at = (chrono::Utc::now() - chrono::Duration::days(15)).to_rfc3339();
+                }
+                Ok(())
+            },
+        );
+
+        // Explicit filter_status=done returns ALL done tasks regardless of age
+        let listed = handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "list", "filter_status": "done"}),
+        );
+        let tasks = listed["tasks"].as_array().unwrap();
+        assert_eq!(
+            tasks.len(),
+            2,
+            "filter_status=done must return all done tasks"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_list_non_done_always_returns() {
+        let home = tmp_home("done-ttl-nondone");
+        // Create open + claimed tasks — they should always appear
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "create", "title": "open task"}),
+        );
+        let r2 = handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "create", "title": "claimed task"}),
+        );
+        let id2 = r2["id"].as_str().unwrap().to_string();
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "claim", "id": id2}),
+        );
+
+        let listed = handle(&home, "a", &serde_json::json!({"action": "list"}));
+        let tasks = listed["tasks"].as_array().unwrap();
+        assert_eq!(tasks.len(), 2, "non-done tasks must always appear");
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Problem
1. 50+ done tasks clutter task list — operator scrolls to find active work
2. In Progress column lacks assignee grouping — can't see who's working on what at a glance
3. No active/idle agent summary

## Solution

### Done TTL filter (tasks.rs)
- Default list hides done tasks older than 14 days
- Explicit filter_status=done still returns all (preserves debug ability)

### Task Board overlay enhancements (render.rs)
- In Progress column: sorted by assignee for visual grouping
- Bottom status line: active agent names (cyan) or 'all idle'
- DONE column header: Done (N/14d) showing visible count + TTL

### Tests (3)
- test_list_default_hides_done_older_than_14d
- test_list_done_filter_returns_all
- test_list_non_done_always_returns

Fleet View + Tab + Ctrl+B t hotkey deferred to PR-N (Sprint 8).