### PR TITLE
sprint8: fleet view overlay + tab routing (PR-N)

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -203,6 +203,7 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
                 col: 0,
                 row: 0,
                 mode: super::overlay::TaskBoardMode::Board,
+                view: super::overlay::BoardView::Tasks,
             });
         }
         Action::ShowHelp => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -400,7 +400,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     ref mode,
                     ref view,
                 } => {
-                    render::render_tasks(frame, items, *col, *row, mode, *view);
+                    render::render_tasks(frame, items, *col, *row, mode, *view, &home);
                 }
                 Overlay::ScratchShell { pane } => {
                     render::render_scratch_shell(frame, pane, &registry);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -13,7 +13,7 @@ mod session;
 mod telegram_hooks;
 mod tui_events;
 
-pub use overlay::{MenuItem, MenuItemKind, TaskBoardMode};
+pub use overlay::{BoardView, MenuItem, MenuItemKind, TaskBoardMode};
 pub(crate) use tui_events::{TuiEvent, TuiEventSender, TuiNotifier};
 
 use crate::agent::{self, AgentRegistry};
@@ -398,8 +398,9 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     col,
                     row,
                     ref mode,
+                    ref view,
                 } => {
-                    render::render_tasks(frame, items, *col, *row, mode);
+                    render::render_tasks(frame, items, *col, *row, mode, *view);
                 }
                 Overlay::ScratchShell { pane } => {
                     render::render_scratch_shell(frame, pane, &registry);

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -42,6 +42,13 @@ pub enum TaskBoardMode {
     Help,
 }
 
+/// Which view is active in the board overlay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoardView {
+    Tasks,
+    Fleet,
+}
+
 pub(super) enum Overlay {
     None,
     /// New tab selection menu.
@@ -104,6 +111,8 @@ pub(super) enum Overlay {
         row: usize,
         /// Sub-mode: None=board, Detail, NewTask(input), Assign(selected).
         mode: TaskBoardMode,
+        /// Active view: Tasks (kanban) or Fleet (agent dashboard).
+        view: BoardView,
     },
     /// Floating scratch shell (Ctrl+B ~). Esc kills the shell and closes the
     /// overlay. Pane is boxed because it's much larger than any other variant.
@@ -535,7 +544,16 @@ pub(super) fn handle_key(
             ref mut col,
             ref mut row,
             ref mut mode,
+            ref mut view,
         } => {
+            // Tab switches between Tasks and Fleet views
+            if key.code == KeyCode::Tab && matches!(mode, TaskBoardMode::Board) {
+                *view = match view {
+                    BoardView::Tasks => BoardView::Fleet,
+                    BoardView::Fleet => BoardView::Tasks,
+                };
+                return outcome;
+            }
             match mode {
                 TaskBoardMode::Detail => {
                     if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
@@ -809,6 +827,7 @@ mod tests {
             col: 0,
             row: 0,
             mode: TaskBoardMode::Board,
+            view: BoardView::Tasks,
         }
     }
 
@@ -866,6 +885,7 @@ mod tests {
             col: 0,
             row: 0,
             mode: TaskBoardMode::Help,
+            view: BoardView::Tasks,
         };
         handle_key(&mut overlay, press(KeyCode::Esc), &mut ctx);
         assert!(matches!(get_mode(&overlay), TaskBoardMode::Board));
@@ -895,6 +915,7 @@ mod tests {
             col: 0,
             row: 0,
             mode: TaskBoardMode::Help,
+            view: BoardView::Tasks,
         };
         handle_key(&mut overlay, press(KeyCode::Char('?')), &mut ctx);
         assert!(matches!(get_mode(&overlay), TaskBoardMode::Board));
@@ -964,6 +985,7 @@ mod tests {
             col: 1,
             row: 0,
             mode: TaskBoardMode::Board,
+            view: BoardView::Tasks,
         };
 
         // Kitty protocol: Shift+L → KeyCode::Char('l') + SHIFT
@@ -1006,6 +1028,7 @@ mod tests {
                 col: 1,
                 row: 0,
                 mode: TaskBoardMode::Board,
+                view: BoardView::Tasks,
             };
 
             let mut ctx = make_ctx(&home, &mut layout, &registry, &tx, &mut name_counter, &tg);
@@ -1060,6 +1083,7 @@ mod tests {
             col: 1,
             row: 0,
             mode: TaskBoardMode::Board,
+            view: BoardView::Tasks,
         };
 
         let mut ctx = make_ctx(&home, &mut layout, &registry, &tx, &mut name_counter, &tg);

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -1104,4 +1104,80 @@ mod tests {
 
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // --- Sprint 8 PR-N: Tab routing ---
+
+    #[test]
+    fn test_board_overlay_tab_toggles_view() {
+        let home = std::env::temp_dir().join("overlay_test_tab_toggle");
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _rx) = crossbeam::channel::unbounded();
+        let mut name_counter = HashMap::new();
+        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
+        let mut layout = crate::layout::Layout::new();
+        let mut ctx = OverlayCtx {
+            layout: &mut layout,
+            registry: &registry,
+            home: &home,
+            fleet_path: &home,
+            wakeup_tx: &tx,
+            name_counter: &mut name_counter,
+            telegram_state: &tg,
+        };
+        let mut overlay = Overlay::Tasks {
+            items: Vec::new(),
+            col: 0,
+            row: 0,
+            mode: TaskBoardMode::Board,
+            view: BoardView::Tasks,
+        };
+        handle_key(&mut overlay, press(KeyCode::Tab), &mut ctx);
+        if let Overlay::Tasks { view, .. } = &overlay {
+            assert_eq!(*view, BoardView::Fleet, "Tab must switch to Fleet");
+        } else {
+            panic!("overlay must still be Tasks");
+        }
+        handle_key(&mut overlay, press(KeyCode::Tab), &mut ctx);
+        if let Overlay::Tasks { view, .. } = &overlay {
+            assert_eq!(*view, BoardView::Tasks, "Tab must switch back to Tasks");
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_non_board_mode_ignores_tab() {
+        let home = std::env::temp_dir().join("overlay_test_tab_ignore");
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _rx) = crossbeam::channel::unbounded();
+        let mut name_counter = HashMap::new();
+        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
+        let mut layout = crate::layout::Layout::new();
+        let mut ctx = OverlayCtx {
+            layout: &mut layout,
+            registry: &registry,
+            home: &home,
+            fleet_path: &home,
+            wakeup_tx: &tx,
+            name_counter: &mut name_counter,
+            telegram_state: &tg,
+        };
+        let mut overlay = Overlay::Tasks {
+            items: Vec::new(),
+            col: 0,
+            row: 0,
+            mode: TaskBoardMode::Help,
+            view: BoardView::Tasks,
+        };
+        handle_key(&mut overlay, press(KeyCode::Tab), &mut ctx);
+        if let Overlay::Tasks { view, .. } = &overlay {
+            assert_eq!(
+                *view,
+                BoardView::Tasks,
+                "Tab in Help mode must not switch view"
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1249,11 +1249,21 @@ pub fn render_tasks(
     sel_col: usize,
     sel_row: usize,
     mode: &crate::app::TaskBoardMode,
+    view: crate::app::BoardView,
 ) {
-    use crate::app::TaskBoardMode;
+    use crate::app::{BoardView, TaskBoardMode};
     let count = items.len();
-    let title = format!(" Task Board ({count}) | ←→ move | n new | a assign | d cancel | q close ");
+    let view_tabs = match view {
+        BoardView::Tasks => "[t] tasks  [f] fleet",
+        BoardView::Fleet => " [t] tasks [f] fleet",
+    };
+    let title = format!(" Board ({count}) | {view_tabs} | Tab switch | q close ");
     let inner = render_overlay_frame(frame, Color::Blue, &title);
+
+    if matches!(view, BoardView::Fleet) {
+        render_fleet_view(frame, items, inner);
+        return;
+    }
 
     if items.is_empty() {
         frame.render_widget(
@@ -1594,6 +1604,101 @@ pub fn task_board_columns(items: &[crate::tasks::Task]) -> [Vec<&crate::tasks::T
     [backlog, open, in_progress, done]
 }
 
+/// Render the Fleet View — agent-centric dashboard grouped by team.
+fn render_fleet_view(frame: &mut Frame, tasks: &[crate::tasks::Task], area: Rect) {
+    // Build agent → claimed task mapping
+    let mut agent_tasks: std::collections::HashMap<&str, Vec<&crate::tasks::Task>> =
+        std::collections::HashMap::new();
+    for t in tasks {
+        if t.status == "claimed" {
+            if let Some(ref a) = t.assignee {
+                agent_tasks.entry(a.as_str()).or_default().push(t);
+            }
+        }
+    }
+
+    // Load teams for grouping
+    let home = crate::home_dir();
+    let teams = crate::teams::list_all(&home);
+    let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
+    let all_instances: Vec<String> = fleet.map(|c| c.instance_names()).unwrap_or_default();
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Group by team
+    let mut assigned_agents: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for team in &teams {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "═══ {} (orchestrator: {}) ═══",
+                team.name,
+                team.orchestrator.as_deref().unwrap_or("none")
+            ),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for member in &team.members {
+            assigned_agents.insert(member.as_str());
+            let symbol = if agent_tasks.contains_key(member.as_str()) {
+                "🟠"
+            } else {
+                "🟢"
+            };
+            let task_info = agent_tasks
+                .get(member.as_str())
+                .and_then(|ts| ts.first())
+                .map(|t| format!(" → {} ({})", t.title, t.id))
+                .unwrap_or_else(|| " idle".to_string());
+            lines.push(Line::from(Span::styled(
+                format!("  {symbol} {member}{task_info}"),
+                Style::default().fg(Color::White),
+            )));
+        }
+        lines.push(Line::from(""));
+    }
+
+    // Unassigned agents
+    let unassigned: Vec<&str> = all_instances
+        .iter()
+        .filter(|n| !assigned_agents.contains(n.as_str()))
+        .map(String::as_str)
+        .collect();
+    if !unassigned.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "═══ unassigned ═══",
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for name in &unassigned {
+            let symbol = if agent_tasks.contains_key(name) {
+                "🟠"
+            } else {
+                "🟢"
+            };
+            let task_info = agent_tasks
+                .get(name)
+                .and_then(|ts| ts.first())
+                .map(|t| format!(" → {} ({})", t.title, t.id))
+                .unwrap_or_else(|| " idle".to_string());
+            lines.push(Line::from(Span::styled(
+                format!("  {symbol} {name}{task_info}"),
+                Style::default().fg(Color::White),
+            )));
+        }
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No agents configured. Add instances to fleet.yaml.",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
 /// Centered box sized to 60% of `area`, clamped so a tiny window still gets
 /// a readable box. Shared by the spawn path (`Action::ScratchShell` in
 /// `app::dispatch`) and the render path so both agree on geometry.
@@ -1892,7 +1997,7 @@ mod tests {
             due_at: None,
         }];
         terminal
-            .draw(|frame| render_tasks(frame, &tasks, 0, 0, mode))
+            .draw(|frame| render_tasks(frame, &tasks, 0, 0, mode, crate::app::BoardView::Tasks))
             .expect("test terminal draw should succeed");
         let buf = terminal.backend().buffer().clone();
         let mut out = String::new();

--- a/src/render.rs
+++ b/src/render.rs
@@ -1250,6 +1250,7 @@ pub fn render_tasks(
     sel_row: usize,
     mode: &crate::app::TaskBoardMode,
     view: crate::app::BoardView,
+    home: &std::path::Path,
 ) {
     use crate::app::{BoardView, TaskBoardMode};
     let count = items.len();
@@ -1261,7 +1262,7 @@ pub fn render_tasks(
     let inner = render_overlay_frame(frame, Color::Blue, &title);
 
     if matches!(view, BoardView::Fleet) {
-        render_fleet_view(frame, items, inner);
+        render_fleet_view(frame, items, inner, home);
         return;
     }
 
@@ -1605,7 +1606,12 @@ pub fn task_board_columns(items: &[crate::tasks::Task]) -> [Vec<&crate::tasks::T
 }
 
 /// Render the Fleet View — agent-centric dashboard grouped by team.
-fn render_fleet_view(frame: &mut Frame, tasks: &[crate::tasks::Task], area: Rect) {
+fn render_fleet_view(
+    frame: &mut Frame,
+    tasks: &[crate::tasks::Task],
+    area: Rect,
+    home: &std::path::Path,
+) {
     // Build agent → claimed task mapping
     let mut agent_tasks: std::collections::HashMap<&str, Vec<&crate::tasks::Task>> =
         std::collections::HashMap::new();
@@ -1618,8 +1624,7 @@ fn render_fleet_view(frame: &mut Frame, tasks: &[crate::tasks::Task], area: Rect
     }
 
     // Load teams for grouping
-    let home = crate::home_dir();
-    let teams = crate::teams::list_all(&home);
+    let teams = crate::teams::list_all(home);
     let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
     let all_instances: Vec<String> = fleet.map(|c| c.instance_names()).unwrap_or_default();
 
@@ -1997,7 +2002,17 @@ mod tests {
             due_at: None,
         }];
         terminal
-            .draw(|frame| render_tasks(frame, &tasks, 0, 0, mode, crate::app::BoardView::Tasks))
+            .draw(|frame| {
+                render_tasks(
+                    frame,
+                    &tasks,
+                    0,
+                    0,
+                    mode,
+                    crate::app::BoardView::Tasks,
+                    std::path::Path::new("/tmp"),
+                )
+            })
             .expect("test terminal draw should succeed");
         let buf = terminal.backend().buffer().clone();
         let mut out = String::new();

--- a/src/render.rs
+++ b/src/render.rs
@@ -1606,6 +1606,69 @@ pub fn task_board_columns(items: &[crate::tasks::Task]) -> [Vec<&crate::tasks::T
 }
 
 /// Render the Fleet View — agent-centric dashboard grouped by team.
+/// Pure function: build fleet view text lines for testing.
+/// Returns plain-text lines (no styling) representing the fleet view content.
+pub fn build_fleet_view_lines(
+    tasks: &[crate::tasks::Task],
+    teams: &[crate::teams::Team],
+    all_instances: &[String],
+) -> Vec<String> {
+    let mut agent_tasks: std::collections::HashMap<&str, Vec<&crate::tasks::Task>> =
+        std::collections::HashMap::new();
+    for t in tasks {
+        if t.status == "claimed" {
+            if let Some(ref a) = t.assignee {
+                agent_tasks.entry(a.as_str()).or_default().push(t);
+            }
+        }
+    }
+    let mut lines = Vec::new();
+    let mut assigned: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for team in teams {
+        lines.push(format!(
+            "═══ {} (orchestrator: {}) ═══",
+            team.name,
+            team.orchestrator.as_deref().unwrap_or("none")
+        ));
+        for member in &team.members {
+            assigned.insert(member.as_str());
+            let symbol = if agent_tasks.contains_key(member.as_str()) {
+                "🟠"
+            } else {
+                "🟢"
+            };
+            let task_info = agent_tasks
+                .get(member.as_str())
+                .and_then(|ts| ts.first())
+                .map(|t| format!(" → {} ({})", t.title, t.id))
+                .unwrap_or_else(|| " idle".to_string());
+            lines.push(format!("  {symbol} {member}{task_info}"));
+        }
+    }
+    let unassigned: Vec<&str> = all_instances
+        .iter()
+        .filter(|n| !assigned.contains(n.as_str()))
+        .map(String::as_str)
+        .collect();
+    if !unassigned.is_empty() {
+        lines.push("═══ unassigned ═══".to_string());
+        for name in &unassigned {
+            let symbol = if agent_tasks.contains_key(name) {
+                "🟠"
+            } else {
+                "🟢"
+            };
+            let task_info = agent_tasks
+                .get(name)
+                .and_then(|ts| ts.first())
+                .map(|t| format!(" → {} ({})", t.title, t.id))
+                .unwrap_or_else(|| " idle".to_string());
+            lines.push(format!("  {symbol} {name}{task_info}"));
+        }
+    }
+    lines
+}
+
 fn render_fleet_view(
     frame: &mut Frame,
     tasks: &[crate::tasks::Task],
@@ -2040,6 +2103,68 @@ mod tests {
         assert!(
             !output.contains("? help"),
             "Help mode should NOT show '? help' hint, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn test_fleet_view_content() {
+        let teams = vec![crate::teams::Team {
+            name: "dev".to_string(),
+            members: vec!["dev-lead".to_string(), "dev-impl".to_string()],
+            orchestrator: Some("dev-lead".to_string()),
+            description: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        }];
+        let tasks = vec![crate::tasks::Task {
+            id: "t-1".to_string(),
+            title: "busy work".to_string(),
+            description: String::new(),
+            status: "claimed".to_string(),
+            priority: "normal".to_string(),
+            assignee: Some("dev-impl".to_string()),
+            routed_to: None,
+            created_by: "lead".to_string(),
+            depends_on: vec![],
+            result: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            due_at: None,
+        }];
+        let all_instances = vec![
+            "dev-lead".to_string(),
+            "dev-impl".to_string(),
+            "general".to_string(),
+        ];
+        let lines = build_fleet_view_lines(&tasks, &teams, &all_instances);
+        // Team header
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("dev") && l.contains("orchestrator: dev-lead")),
+            "must have team header: {lines:?}"
+        );
+        // Busy member with task
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("🟠") && l.contains("dev-impl") && l.contains("busy work")),
+            "busy member must show task: {lines:?}"
+        );
+        // Idle member
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("🟢") && l.contains("dev-lead") && l.contains("idle")),
+            "idle member must show idle: {lines:?}"
+        );
+        // Unassigned group
+        assert!(
+            lines.iter().any(|l| l.contains("unassigned")),
+            "must have unassigned group: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("general")),
+            "unassigned agent must appear: {lines:?}"
         );
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1675,95 +1675,39 @@ fn render_fleet_view(
     area: Rect,
     home: &std::path::Path,
 ) {
-    // Build agent → claimed task mapping
-    let mut agent_tasks: std::collections::HashMap<&str, Vec<&crate::tasks::Task>> =
-        std::collections::HashMap::new();
-    for t in tasks {
-        if t.status == "claimed" {
-            if let Some(ref a) = t.assignee {
-                agent_tasks.entry(a.as_str()).or_default().push(t);
-            }
-        }
-    }
-
-    // Load teams for grouping
     let teams = crate::teams::list_all(home);
-    let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
-    let all_instances: Vec<String> = fleet.map(|c| c.instance_names()).unwrap_or_default();
+    let all_instances: Vec<String> = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+        .ok()
+        .map(|c| c.instance_names())
+        .unwrap_or_default();
+    let text_lines = build_fleet_view_lines(tasks, &teams, &all_instances);
 
-    let mut lines: Vec<Line> = Vec::new();
-
-    // Group by team
-    let mut assigned_agents: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    for team in &teams {
-        lines.push(Line::from(Span::styled(
-            format!(
-                "═══ {} (orchestrator: {}) ═══",
-                team.name,
-                team.orchestrator.as_deref().unwrap_or("none")
-            ),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )));
-        for member in &team.members {
-            assigned_agents.insert(member.as_str());
-            let symbol = if agent_tasks.contains_key(member.as_str()) {
-                "🟠"
-            } else {
-                "🟢"
-            };
-            let task_info = agent_tasks
-                .get(member.as_str())
-                .and_then(|ts| ts.first())
-                .map(|t| format!(" → {} ({})", t.title, t.id))
-                .unwrap_or_else(|| " idle".to_string());
-            lines.push(Line::from(Span::styled(
-                format!("  {symbol} {member}{task_info}"),
-                Style::default().fg(Color::White),
-            )));
-        }
-        lines.push(Line::from(""));
-    }
-
-    // Unassigned agents
-    let unassigned: Vec<&str> = all_instances
-        .iter()
-        .filter(|n| !assigned_agents.contains(n.as_str()))
-        .map(String::as_str)
-        .collect();
-    if !unassigned.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "═══ unassigned ═══",
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        )));
-        for name in &unassigned {
-            let symbol = if agent_tasks.contains_key(name) {
-                "🟠"
-            } else {
-                "🟢"
-            };
-            let task_info = agent_tasks
-                .get(name)
-                .and_then(|ts| ts.first())
-                .map(|t| format!(" → {} ({})", t.title, t.id))
-                .unwrap_or_else(|| " idle".to_string());
-            lines.push(Line::from(Span::styled(
-                format!("  {symbol} {name}{task_info}"),
-                Style::default().fg(Color::White),
-            )));
-        }
-    }
-
-    if lines.is_empty() {
-        lines.push(Line::from(Span::styled(
+    let lines: Vec<Line> = if text_lines.is_empty() {
+        vec![Line::from(Span::styled(
             "No agents configured. Add instances to fleet.yaml.",
             Style::default().fg(Color::DarkGray),
-        )));
-    }
-
+        ))]
+    } else {
+        text_lines
+            .iter()
+            .map(|l| {
+                let style = if l.starts_with('═') {
+                    if l.contains("unassigned") {
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD)
+                    }
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                Line::from(Span::styled(l.as_str(), style))
+            })
+            .collect()
+    };
     frame.render_widget(Paragraph::new(lines), area);
 }
 

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -145,6 +145,11 @@ pub fn delete(home: &Path, args: &Value) -> Value {
     }
 }
 
+/// Return all teams as typed structs.
+pub fn list_all(home: &Path) -> Vec<Team> {
+    load(home).teams
+}
+
 pub fn list(home: &Path) -> Value {
     let store = load(home);
     let teams: Vec<Value> = store


### PR DESCRIPTION
## Problem
No agent-centric dashboard. Asking 'who is working on what / who is idle' requires manual fleet.yaml + query.

## Solution

### BoardView enum + Tab routing (app/overlay.rs)
- New BoardView::Tasks | Fleet enum on Tasks overlay
- Tab key switches between task board and fleet view (only in Board mode)
- Title bar shows [t] tasks [f] fleet with current mode indicator

### Fleet View (render.rs)
- Agent rows grouped by team (team header with orchestrator)
- Each row: state symbol + name + current claimed task or 'idle'
- Unassigned agents in separate group
- Read-only (no direct agent operations)

### Ctrl+B t hotkey
Already bound via `keybinds.rs:194` (`Char('T')|Char('t') => Action::ShowTasks`). Opens overlay in Task mode; Tab switches to Fleet View. No new keymap needed.

### Infrastructure
- teams::list_all() typed accessor
- All existing Overlay::Tasks constructions updated with view field

995 tests pass, clippy(tray)/fmt clean.