### PR TITLE
sprint9: delegate_task second_reviewer flag schema + validation (Gap 5)

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -248,6 +248,15 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 }
             }
 
+            // Second reviewer flag validation (§3.5 dual review)
+            let second_reviewer = args["second_reviewer"].as_bool().unwrap_or(false);
+            if second_reviewer {
+                let sr_reason = args["second_reviewer_reason"].as_str().unwrap_or("");
+                if sr_reason.is_empty() {
+                    return json!({"error": "second_reviewer=true requires non-empty second_reviewer_reason"});
+                }
+            }
+
             let mut msg = format!("[delegate_task] {task}");
             if interrupt {
                 if let Some(r) = reason {
@@ -2655,6 +2664,91 @@ instances:
         assert!(
             result.get("busy").is_none(),
             "idle target must not return busy: {result}"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // --- Sprint 9 Gap 5: second_reviewer flag ---
+
+    #[test]
+    fn test_delegate_task_second_reviewer_flag_requires_reason() {
+        let _g = fleet_test_guard();
+        let home = tmp_home("sr-no-reason");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
+        )
+        .ok();
+        std::env::set_var("AGEND_HOME", &home);
+        let result = handle_tool(
+            "delegate_task",
+            &json!({"target_instance": "target", "task": "review PR", "second_reviewer": true}),
+            "sender",
+        );
+        assert!(
+            result["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("second_reviewer_reason"),
+            "second_reviewer=true without reason must error: {result}"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_delegate_task_second_reviewer_with_reason_ok() {
+        let _g = fleet_test_guard();
+        let home = tmp_home("sr-with-reason");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
+        )
+        .ok();
+        std::env::set_var("AGEND_HOME", &home);
+        let result = handle_tool(
+            "delegate_task",
+            &json!({
+                "target_instance": "target",
+                "task": "review PR",
+                "second_reviewer": true,
+                "second_reviewer_reason": "high-risk protocol change"
+            }),
+            "sender",
+        );
+        assert!(
+            result.get("error").is_none()
+                || !result["error"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("second_reviewer"),
+            "second_reviewer with reason must not error on flag: {result}"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_delegate_task_no_second_reviewer_flag_default_behavior() {
+        let _g = fleet_test_guard();
+        let home = tmp_home("sr-default");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
+        )
+        .ok();
+        std::env::set_var("AGEND_HOME", &home);
+        let result = handle_tool(
+            "delegate_task",
+            &json!({"target_instance": "target", "task": "normal work"}),
+            "sender",
+        );
+        // No second_reviewer flag → no error related to it
+        let err = result["error"].as_str().unwrap_or("");
+        assert!(
+            !err.contains("second_reviewer"),
+            "default (no flag) must not error on second_reviewer: {result}"
         );
         std::env::remove_var("AGEND_HOME");
         std::fs::remove_dir_all(&home).ok();

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -48,7 +48,9 @@ fn comm_tools() -> Vec<Value> {
                 "task_id": {"type": "string", "description": "Task board ID for correlation"},
                 "thread_id": {"type": "string"}, "parent_id": {"type": "string"},
                 "interrupt": {"type": "boolean", "description": "Override busy gate (requires reason)"},
-                "reason": {"type": "string", "description": "Reason for interrupt (required when interrupt=true)"}
+                "reason": {"type": "string", "description": "Reason for interrupt (required when interrupt=true)"},
+                "second_reviewer": {"type": "boolean", "description": "Signal that this dispatch requests dual review (§3.5)"},
+                "second_reviewer_reason": {"type": "string", "description": "Reason for dual review (required when second_reviewer=true)"}
             }, "required": ["target_instance", "task"]}}),
         json!({"name": "report_result", "description": "Report results back to the delegating instance.",
             "inputSchema": {"type": "object", "properties": {


### PR DESCRIPTION
## Problem
dev-lead signals dual review intent via prose — unstructured, easy to miss.

## Solution
Add second_reviewer + second_reviewer_reason fields to delegate_task tool schema. Handler validates reason is non-empty when flag is true. Backwards-compatible (old callers unaffected).

### Tests (3)
- flag=true without reason → error
- flag=true with reason → normal delivery
- no flag (default) → unchanged behavior

Wire-up: tools.rs schema + handlers.rs validation. Primary reviewer only.