### PR TITLE
sprint9: replace_instance child kill propagation fix (PR-U)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -57,7 +57,12 @@ pub(crate) fn handle_kill(params: &Value, ctx: &HandlerCtx) -> Value {
                 core.state.set_restarting();
             }
             let mut child = crate::sync::lock_poisoned(&handle.child, "api_child");
-            let _ = child.kill();
+            // Kill the process group (not just the leader) to propagate to
+            // child subprocesses (kiro-cli spawns bun/mcp/acp children).
+            if let Some(pid) = child.process_id() {
+                crate::process::kill_process_tree(pid);
+            }
+            let _ = child.kill(); // also kill via PTY handle as fallback
             drop(child);
             drop(reg);
             crate::event_log::log(ctx.home, "kill", name, "killed via API");
@@ -92,6 +97,9 @@ pub(crate) fn handle_delete(params: &Value, ctx: &HandlerCtx) -> Value {
     let mut reg = agent::lock_registry(ctx.registry);
     if let Some(handle) = reg.get(name) {
         let mut child = crate::sync::lock_poisoned(&handle.child, "api_child");
+        if let Some(pid) = child.process_id() {
+            crate::process::kill_process_tree(pid);
+        }
         let _ = child.kill();
         drop(child);
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -742,6 +742,9 @@ fn run_core(
     };
     for (name, child) in &agents_to_kill {
         let mut c = crate::sync::lock_poisoned(child, "child_proc");
+        if let Some(pid) = c.process_id() {
+            crate::process::kill_process_tree(pid);
+        }
         let _ = c.kill();
         tracing::info!(agent = %name, "killed");
     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -60,21 +60,55 @@ pub fn terminate(pid: u32) {
 pub fn kill_process_tree(pid: u32) {
     #[cfg(unix)]
     {
-        // First try SIGTERM to the process group
+        let pgid = -(pid as i32);
+        // SIGTERM the entire process group
         unsafe {
-            libc::kill(-(pid as i32), libc::SIGTERM);
+            libc::kill(pgid, libc::SIGTERM);
         }
-        // Brief grace period, then SIGKILL
+        // Grace period, then unconditional SIGKILL (handles grandchildren
+        // that ignore SIGTERM even if leader already exited).
         std::thread::sleep(std::time::Duration::from_millis(500));
-        if is_pid_alive(pid) {
-            unsafe {
-                libc::kill(-(pid as i32), libc::SIGKILL);
-            }
+        unsafe {
+            libc::kill(pgid, libc::SIGKILL);
         }
+        // ESRCH (no such process) is fine — group already dead.
     }
     #[cfg(windows)]
     {
-        // Windows: TerminateProcess on the leader (process groups work differently)
         terminate(pid);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn test_kill_process_tree_kills_child_subprocess() {
+        use std::os::unix::process::CommandExt;
+        use std::process::Command;
+        // Spawn a shell in its own process group (like PTY agents do).
+        let mut child = unsafe {
+            Command::new("sh")
+                .args(["-c", "sleep 60 & wait"])
+                .pre_exec(|| {
+                    libc::setsid();
+                    Ok(())
+                })
+                .spawn()
+                .expect("spawn sh + sleep")
+        };
+        let pid = child.id();
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(is_pid_alive(pid), "shell must be alive before kill");
+
+        kill_process_tree(pid);
+        let _ = child.wait();
+
+        assert!(
+            !is_pid_alive(pid),
+            "shell must be dead after kill_process_tree"
+        );
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -53,3 +53,28 @@ pub fn terminate(pid: u32) {
         }
     }
 }
+
+/// Kill an entire process group. On Unix, sends SIGTERM to -pgid (all processes
+/// in the group), then waits briefly and escalates to SIGKILL if still alive.
+/// On Windows, falls back to TerminateProcess on the leader.
+pub fn kill_process_tree(pid: u32) {
+    #[cfg(unix)]
+    {
+        // First try SIGTERM to the process group
+        unsafe {
+            libc::kill(-(pid as i32), libc::SIGTERM);
+        }
+        // Brief grace period, then SIGKILL
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        if is_pid_alive(pid) {
+            unsafe {
+                libc::kill(-(pid as i32), libc::SIGKILL);
+            }
+        }
+    }
+    #[cfg(windows)]
+    {
+        // Windows: TerminateProcess on the leader (process groups work differently)
+        terminate(pid);
+    }
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -89,10 +89,12 @@ mod tests {
     fn test_kill_process_tree_kills_child_subprocess() {
         use std::os::unix::process::CommandExt;
         use std::process::Command;
-        // Spawn a shell in its own process group (like PTY agents do).
+        let pid_file =
+            std::env::temp_dir().join(format!("agend-kill-test-{}.pid", std::process::id()));
+        let cmd = format!("sleep 60 & echo $! > {} && wait", pid_file.display());
         let mut child = unsafe {
             Command::new("sh")
-                .args(["-c", "sleep 60 & wait"])
+                .args(["-c", &cmd])
                 .pre_exec(|| {
                     libc::setsid();
                     Ok(())
@@ -100,16 +102,33 @@ mod tests {
                 .spawn()
                 .expect("spawn sh + sleep")
         };
-        let pid = child.id();
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        assert!(is_pid_alive(pid), "shell must be alive before kill");
+        let shell_pid = child.id();
+        // Wait for sleep to start and write its PID
+        for _ in 0..20 {
+            if pid_file.exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        let sleep_pid: u32 = std::fs::read_to_string(&pid_file)
+            .unwrap_or_default()
+            .trim()
+            .parse()
+            .expect("parse sleep PID");
+        assert!(is_pid_alive(shell_pid), "shell must be alive before kill");
+        assert!(
+            is_pid_alive(sleep_pid),
+            "sleep child must be alive before kill"
+        );
 
-        kill_process_tree(pid);
+        kill_process_tree(shell_pid);
         let _ = child.wait();
 
+        assert!(!is_pid_alive(shell_pid), "shell must be dead after kill");
         assert!(
-            !is_pid_alive(pid),
-            "shell must be dead after kill_process_tree"
+            !is_pid_alive(sleep_pid),
+            "sleep child must also be dead after kill_process_tree (group kill)"
         );
+        let _ = std::fs::remove_file(&pid_file);
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -80,6 +80,7 @@ pub fn kill_process_tree(pid: u32) {
 }
 
 #[cfg(test)]
+#[cfg(unix)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Problem
replace_instance on kiro-cli backend only kills the main PID via child.kill(). Child subprocesses (bun, mcp, acp) survive, causing zombie processes and resource leaks. Backlog: t-20260424164128880092-0.

## Solution

### kill_process_tree (process.rs)
- Unix: SIGTERM to -pgid (entire process group), 500ms grace, then SIGKILL if still alive
- Windows: fallback to TerminateProcess on leader

### Kill paths updated (3 sites)
- api/handlers/instance.rs handle_kill: kill_process_tree(pid) before child.kill()
- api/handlers/instance.rs handle_delete: same
- daemon/mod.rs shutdown: same

All paths: get pid from child.process_id(), kill_process_tree(), then child.kill() as PTY fallback.

1019 tests pass, clippy(tray)/fmt clean.