### PR TITLE
sprint9: interrupt MCP tool (PTY ESC byte injection)

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -910,6 +910,35 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             save_metadata(&home, instance_name, "description", json!(desc));
             json!({"description": desc})
         }
+        "interrupt" => {
+            let target = match args["target"].as_str() {
+                Some(t) => t,
+                None => return json!({"error": "missing 'target'"}),
+            };
+            if let Err(e) = crate::agent::validate_name(target) {
+                return json!({"error": e});
+            }
+            // Inject ESC byte (0x1b) to interrupt current LLM generation turn
+            match crate::api::call(
+                &home,
+                &json!({
+                    "method": crate::api::method::INJECT,
+                    "params": {"name": target, "data": "\x1b", "raw": true}
+                }),
+            ) {
+                Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+                    // Optionally inject follow-up reason message
+                    if let Some(reason) = args["reason"].as_str() {
+                        let header =
+                            crate::inbox::format_event_header("interrupt", &[("reason", reason)]);
+                        crate::inbox::compose_aware_inject(&home, target, &header);
+                    }
+                    json!({"ok": true, "target": target})
+                }
+                Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("inject failed")}),
+                Err(e) => json!({"error": format!("API unavailable: {e}")}),
+            }
+        }
         "set_waiting_on" => {
             let Some(_) = sender.as_ref() else {
                 return err_needs_identity(tool);

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -919,13 +919,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 return json!({"error": e});
             }
             // Inject ESC byte (0x1b) to interrupt current LLM generation turn
-            match crate::api::call(
-                &home,
-                &json!({
-                    "method": crate::api::method::INJECT,
-                    "params": {"name": target, "data": "\x1b", "raw": true}
-                }),
-            ) {
+            match crate::api::call(&home, &interrupt_esc_params(target)) {
                 Ok(resp) if resp["ok"].as_bool() == Some(true) => {
                     // Optionally inject follow-up reason message
                     if let Some(reason) = args["reason"].as_str() {
@@ -1264,6 +1258,16 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
 }
 
 /// Spawn a single instance (the non-team path of create_instance).
+/// Build the INJECT API params for an interrupt ESC byte injection.
+/// Extracted for testability — unit tests verify the exact params
+/// without needing a running daemon.
+pub fn interrupt_esc_params(target: &str) -> Value {
+    json!({
+        "method": crate::api::method::INJECT,
+        "params": {"name": target, "data": "\x1b", "raw": true}
+    })
+}
+
 fn spawn_single_instance(home: &std::path::Path, instance_name: &str, args: &Value) -> Value {
     let raw_name = match args["name"].as_str() {
         Some(n) => n,
@@ -2782,6 +2786,60 @@ instances:
             "default (no flag) must not error on second_reviewer: {result}"
         );
         std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── interrupt tool tests ──
+
+    #[test]
+    fn test_interrupt_esc_params_contains_exact_esc_byte() {
+        let params = super::interrupt_esc_params("my-agent");
+        assert_eq!(params["method"], "inject");
+        assert_eq!(params["params"]["name"], "my-agent");
+        // Verify the data field is exactly the ESC byte (0x1b)
+        let data = params["params"]["data"]
+            .as_str()
+            .expect("data must be string");
+        assert_eq!(data.len(), 1, "ESC byte must be exactly 1 byte");
+        assert_eq!(data.as_bytes()[0], 0x1b, "data must be ESC byte (0x1b)");
+        assert_eq!(params["params"]["raw"], true, "must be raw inject");
+    }
+
+    #[test]
+    fn test_interrupt_reason_header_format() {
+        let header = crate::inbox::format_event_header("interrupt", &[("reason", "priority task")]);
+        assert!(header.contains("[AGEND-MSG]"), "must have header prefix");
+        assert!(
+            header.contains("kind=interrupt"),
+            "must have interrupt kind"
+        );
+        assert!(
+            header.contains("reason=priority task"),
+            "must contain reason"
+        );
+        assert!(!header.contains('\n'), "must be single line");
+    }
+
+    #[test]
+    fn test_interrupt_handler_validates_target() {
+        let home = tmp_home("interrupt-validate");
+        std::env::set_var("AGEND_HOME", &home);
+
+        // Missing target
+        let r = handle_tool("interrupt", &json!({}), "caller");
+        assert!(r["error"].as_str().unwrap().contains("missing"));
+
+        // Invalid target name
+        let r = handle_tool("interrupt", &json!({"target": "../escape"}), "caller");
+        assert!(r.get("error").is_some());
+
+        // Valid target but no daemon → reaches inject path
+        let r = handle_tool("interrupt", &json!({"target": "valid-agent"}), "caller");
+        let err = r["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("not reachable") || err.contains("API unavailable"),
+            "valid target must reach inject path: {err}"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -936,7 +936,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                     json!({"ok": true, "target": target})
                 }
                 Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("inject failed")}),
-                Err(e) => json!({"error": format!("API unavailable: {e}")}),
+                Err(e) => {
+                    json!({"error": format!("interrupt failed — agent '{target}' not reachable (API unavailable: {e})")})
+                }
             }
         }
         "set_waiting_on" => {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -113,6 +113,11 @@ fn instance_tools() -> Vec<Value> {
             "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}),
         json!({"name": "replace_instance", "description": "Replace an instance with a fresh one.",
             "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}, "reason": {"type": "string"}}, "required": ["name"]}}),
+        json!({"name": "interrupt", "description": "Send ESC byte to target agent's PTY to interrupt current LLM turn. Context preserved, agent accepts next prompt.",
+            "inputSchema": {"type": "object", "properties": {
+                "target": {"type": "string", "description": "Target instance name"},
+                "reason": {"type": "string", "description": "Optional follow-up message to inject after ESC"}
+            }, "required": ["target"]}}),
         json!({"name": "set_display_name", "description": "Set your display name.",
             "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}),
         json!({"name": "set_description", "description": "Set a description for this instance.",

--- a/tests/mcp_roundtrip.rs
+++ b/tests/mcp_roundtrip.rs
@@ -1057,20 +1057,6 @@ fn test_report_result_persists_parent_and_thread() {
 }
 
 #[test]
-fn test_interrupt_target_not_exist() {
-    let responses = mcp_session(&[
-        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
-        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"interrupt","arguments":{"target":"nonexistent-agent"}}}"#,
-    ]);
-    assert!(responses.len() >= 2);
-    let result = extract_tool_result(&responses[1]);
-    assert!(
-        result.get("error").is_some(),
-        "unknown target must return error: {result}"
-    );
-}
-
-#[test]
 fn test_interrupt_missing_target() {
     let responses = mcp_session(&[
         r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
@@ -1095,5 +1081,40 @@ fn test_interrupt_invalid_target_name() {
     assert!(
         result.get("error").is_some(),
         "invalid name must error: {result}"
+    );
+}
+
+#[test]
+fn test_interrupt_without_reason_reaches_inject_path() {
+    // Without daemon, API inject fails — but the handler must reach the inject
+    // path (not fail on validation). Error message should mention "not reachable"
+    // not "missing" or "invalid".
+    let responses = mcp_session(&[
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"interrupt","arguments":{"target":"valid-agent"}}}"#,
+    ]);
+    assert!(responses.len() >= 2);
+    let result = extract_tool_result(&responses[1]);
+    let err = result["error"].as_str().unwrap_or("");
+    // Must reach inject path (API unavailable), not fail on validation
+    assert!(
+        err.contains("not reachable") || err.contains("API unavailable"),
+        "valid target must reach inject path, got: {err}"
+    );
+    assert!(!err.contains("missing"), "must not be a validation error");
+}
+
+#[test]
+fn test_interrupt_with_reason_reaches_inject_path() {
+    let responses = mcp_session(&[
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"interrupt","arguments":{"target":"valid-agent","reason":"priority task incoming"}}}"#,
+    ]);
+    assert!(responses.len() >= 2);
+    let result = extract_tool_result(&responses[1]);
+    let err = result["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("not reachable") || err.contains("API unavailable"),
+        "with reason must also reach inject path, got: {err}"
     );
 }

--- a/tests/mcp_roundtrip.rs
+++ b/tests/mcp_roundtrip.rs
@@ -1055,3 +1055,45 @@ fn test_report_result_persists_parent_and_thread() {
     );
     let _ = std::fs::remove_dir_all(&home);
 }
+
+#[test]
+fn test_interrupt_target_not_exist() {
+    let responses = mcp_session(&[
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"interrupt","arguments":{"target":"nonexistent-agent"}}}"#,
+    ]);
+    assert!(responses.len() >= 2);
+    let result = extract_tool_result(&responses[1]);
+    assert!(
+        result.get("error").is_some(),
+        "unknown target must return error: {result}"
+    );
+}
+
+#[test]
+fn test_interrupt_missing_target() {
+    let responses = mcp_session(&[
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"interrupt","arguments":{}}}"#,
+    ]);
+    assert!(responses.len() >= 2);
+    let result = extract_tool_result(&responses[1]);
+    assert!(
+        result["error"].as_str().unwrap_or("").contains("missing"),
+        "missing target must error: {result}"
+    );
+}
+
+#[test]
+fn test_interrupt_invalid_target_name() {
+    let responses = mcp_session(&[
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"interrupt","arguments":{"target":"../escape"}}}"#,
+    ]);
+    assert!(responses.len() >= 2);
+    let result = extract_tool_result(&responses[1]);
+    assert!(
+        result.get("error").is_some(),
+        "invalid name must error: {result}"
+    );
+}


### PR DESCRIPTION
**Problem:** No way to interrupt an agent's current LLM generation turn without killing the process. Operator/orchestrator needs to cancel a running generation to redirect the agent.

**Solution:** New `interrupt(target, reason?)` MCP tool that injects ESC byte (`0x1b`) to the target agent's PTY. All CLI backends (Claude/Codex/Kiro/Gemini) treat ESC as 'stop current generation, keep session'. Optional `reason` parameter injects a follow-up `[AGEND-MSG] kind=interrupt` header.

### Implementation (~30 lines)
- Tool schema in `tools.rs`
- Handler in `handlers.rs`: validate target → inject `\x1b` via API INJECT (raw=true) → optionally inject reason header
- Target validation reuses existing Sprint 5 pattern

### Tests (3)
- `test_interrupt_target_not_exist`: unknown target → error
- `test_interrupt_missing_target`: no target arg → error  
- `test_interrupt_invalid_target_name`: path traversal → error