### PR TITLE
sprint10: protocol §3.5.8 cross-backend claims rule (PR-Y)

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -255,7 +255,7 @@ Reassign only when:
 
 A reassigned re-audit must reference the finding task ID and must not broaden scope unless the dispatch explicitly says so.
 
-### 3.5.8 Cross-backend behavior claims
+#### 3.5.8 Cross-backend behavior claims
 
 Any PR body claim of cross-backend behavior—e.g. "All CLI backends do X", "supports Y across kiro/Codex/Claude/Gemini", "behavior consistent on Linux/macOS/Windows"—**must** be either:
 
@@ -267,13 +267,13 @@ Any PR body claim of cross-backend behavior—e.g. "All CLI backends do X", "sup
    - PR body must contain phrase `unverified cross-backend claim` plus task ID
    - Backlog task must describe how/when verification will run
 
-#### Reviewer enforcement
+##### Reviewer enforcement
 
 When reviewing a PR with cross-backend claims:
 - Check PR body for both evidence (option 1) and unverified mark (option 2)
 - If neither present, output `REJECTED` with finding "unverified cross-backend claim — must add per-backend test evidence or mark as unverified with backlog reference"
 
-#### Rationale
+##### Rationale
 
 Sprint 9 PR #159 (`interrupt` MCP tool) merged with PR body claim "All CLI backends treat ESC as stop generation". No per-backend test verified this; the claim was inferred from documentation. Operator caught the gap post-merge. Sprint 10 PR-X (backend harness) added transport verification but explicitly left semantics `Unverified`.
 

--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -255,6 +255,30 @@ Reassign only when:
 
 A reassigned re-audit must reference the finding task ID and must not broaden scope unless the dispatch explicitly says so.
 
+### 3.5.8 Cross-backend behavior claims
+
+Any PR body claim of cross-backend behavior—e.g. "All CLI backends do X", "supports Y across kiro/Codex/Claude/Gemini", "behavior consistent on Linux/macOS/Windows"—**must** be either:
+
+1. **Backed by per-backend test evidence** (preferred). Either:
+   - Real backend spawn test (e.g. `#[ignore]` or cargo feature gated)
+   - Capability matrix entry referenced in PR body with `verified: true` per backend
+
+2. **Marked explicitly as `unverified claim`** with backlog task reference for verification:
+   - PR body must contain phrase `unverified cross-backend claim` plus task ID
+   - Backlog task must describe how/when verification will run
+
+#### Reviewer enforcement
+
+When reviewing a PR with cross-backend claims:
+- Check PR body for both evidence (option 1) and unverified mark (option 2)
+- If neither present, output `REJECTED` with finding "unverified cross-backend claim — must add per-backend test evidence or mark as unverified with backlog reference"
+
+#### Rationale
+
+Sprint 9 PR #159 (`interrupt` MCP tool) merged with PR body claim "All CLI backends treat ESC as stop generation". No per-backend test verified this; the claim was inferred from documentation. Operator caught the gap post-merge. Sprint 10 PR-X (backend harness) added transport verification but explicitly left semantics `Unverified`.
+
+This rule prevents the pattern where reviewer-merged PRs ship documentation claims that were never tested. Either prove with evidence or transparently flag as future work.
+
 ## 4. Communication rules
 
 ### Hop reduction


### PR DESCRIPTION
## Problem
Sprint 9 PR #159 merged with unverified cross-backend claim ('All CLI backends treat ESC as stop generation'). No per-backend test existed. Operator caught post-merge.

## Solution
Protocol addendum §3.5.8: cross-backend behavior claims in PR body must be either (1) backed by per-backend test evidence or (2) explicitly marked as 'unverified cross-backend claim' with backlog task reference. Reviewer enforcement rule included.

Pure docs change (~30 lines markdown). Dual reviewer mandated (§3.5.5 protocol change exception).