### PR TITLE
sprint11: tool_kill MCP tool — SIGINT to PTY foreground pgid (PR-AA)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -370,7 +370,7 @@ pub(crate) fn handle_tool_kill(params: &Value, ctx: &HandlerCtx) -> Value {
     #[cfg(not(unix))]
     {
         let _ = (params, ctx);
-        return json!({"ok": false, "error": "tool_kill is only supported on Unix (Linux/macOS)"});
+        json!({"ok": false, "error": "tool_kill is only supported on Unix (Linux/macOS)"})
     }
     #[cfg(unix)]
     {
@@ -387,7 +387,6 @@ pub(crate) fn handle_tool_kill(params: &Value, ctx: &HandlerCtx) -> Value {
             Ok(m) => m,
             Err(_) => return json!({"ok": false, "error": "PTY master lock failed"}),
         };
-        use portable_pty::MasterPty;
         let fd = match master.as_raw_fd() {
             Some(fd) => fd,
             None => return json!({"ok": false, "error": "PTY master has no raw fd"}),

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -366,6 +366,47 @@ pub(crate) fn handle_clear_blocked_reason(params: &Value, ctx: &HandlerCtx) -> V
     }
 }
 
+pub(crate) fn handle_tool_kill(params: &Value, ctx: &HandlerCtx) -> Value {
+    #[cfg(not(unix))]
+    {
+        let _ = (params, ctx);
+        return json!({"ok": false, "error": "tool_kill is only supported on Unix (Linux/macOS)"});
+    }
+    #[cfg(unix)]
+    {
+        let name = match params["name"].as_str() {
+            Some(n) => n,
+            None => return json!({"ok": false, "error": "missing 'name'"}),
+        };
+        let reg = agent::lock_registry(ctx.registry);
+        let handle = match reg.get(name) {
+            Some(h) => h,
+            None => return json!({"ok": false, "error": format!("instance '{name}' not found")}),
+        };
+        let master = match handle.pty_master.lock() {
+            Ok(m) => m,
+            Err(_) => return json!({"ok": false, "error": "PTY master lock failed"}),
+        };
+        use portable_pty::MasterPty;
+        let fd = match master.as_raw_fd() {
+            Some(fd) => fd,
+            None => return json!({"ok": false, "error": "PTY master has no raw fd"}),
+        };
+        let pgid = unsafe { libc::tcgetpgrp(fd) };
+        drop(master);
+        drop(reg);
+        if pgid <= 0 {
+            return json!({"ok": false, "error": format!("tcgetpgrp returned {pgid}")});
+        }
+        let result = unsafe { libc::kill(-pgid, libc::SIGINT) };
+        if result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+            json!({"ok": true, "pgid": pgid})
+        } else {
+            json!({"ok": false, "error": format!("kill(-{pgid}, SIGINT) failed: {}", std::io::Error::last_os_error())})
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -202,6 +202,7 @@ pub mod method {
     pub const SHUTDOWN: &str = "shutdown";
     pub const SET_BLOCKED_REASON: &str = "set_blocked_reason";
     pub const CLEAR_BLOCKED_REASON: &str = "clear_blocked_reason";
+    pub const TOOL_KILL: &str = "tool_kill";
 }
 
 /// Start API socket server (blocks calling thread).
@@ -360,6 +361,7 @@ fn handle_session(
             method::CLEAR_BLOCKED_REASON => {
                 handlers::instance::handle_clear_blocked_reason(params, &ctx)
             }
+            method::TOOL_KILL => handlers::instance::handle_tool_kill(params, &ctx),
             method::SHUTDOWN => {
                 tracing::info!("API shutdown requested");
                 shutdown.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -32,6 +32,7 @@ fn err_needs_identity(tool: &str) -> Value {
 }
 
 /// Pure function: build tool_kill success response.
+#[cfg(unix)]
 pub(crate) fn build_tool_kill_result(target: &str, pgid: i32, reason: &str) -> Value {
     let mut result = json!({"ok": true, "target": target, "pgid": pgid});
     if !reason.is_empty() {
@@ -41,6 +42,7 @@ pub(crate) fn build_tool_kill_result(target: &str, pgid: i32, reason: &str) -> V
 }
 
 /// Pure function: build tool_kill audit log detail string.
+#[cfg(unix)]
 pub(crate) fn build_tool_kill_audit(reason: &str, pgid: i32) -> String {
     format!("reason={reason}, pgid={pgid}")
 }
@@ -971,7 +973,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         "tool_kill" => {
             #[cfg(not(unix))]
             {
-                return json!({"error": "tool_kill is only supported on Unix (Linux/macOS)"});
+                json!({"error": "tool_kill is only supported on Unix (Linux/macOS)"})
             }
             #[cfg(unix)]
             {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -954,6 +954,49 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                 }
             }
         }
+        "tool_kill" => {
+            #[cfg(not(unix))]
+            {
+                return json!({"error": "tool_kill is only supported on Unix (Linux/macOS)"});
+            }
+            #[cfg(unix)]
+            {
+                let target = match args["target"].as_str() {
+                    Some(t) => t,
+                    None => return json!({"error": "missing 'target'"}),
+                };
+                if let Err(e) = crate::agent::validate_name(target) {
+                    return json!({"error": e});
+                }
+                let reason = args["reason"].as_str().unwrap_or("");
+                match crate::api::call(
+                    &home,
+                    &json!({
+                        "method": crate::api::method::TOOL_KILL,
+                        "params": {"name": target}
+                    }),
+                ) {
+                    Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+                        crate::event_log::log(
+                            &home,
+                            "tool_kill_invoked",
+                            target,
+                            &format!("reason={reason}, pgid={}", resp["pgid"]),
+                        );
+                        let mut result =
+                            json!({"ok": true, "target": target, "pgid": resp["pgid"]});
+                        if !reason.is_empty() {
+                            result["reason"] = json!(reason);
+                        }
+                        result
+                    }
+                    Ok(resp) => {
+                        json!({"error": resp["error"].as_str().unwrap_or("tool_kill failed")})
+                    }
+                    Err(e) => json!({"error": format!("tool_kill failed: {e}")}),
+                }
+            }
+        }
         "set_waiting_on" => {
             let Some(_) = sender.as_ref() else {
                 return err_needs_identity(tool);

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -2981,6 +2981,7 @@ instances:
     // --- Sprint 11: tool_kill pure function tests ---
 
     #[test]
+    #[cfg(unix)]
     fn test_tool_kill_result_includes_pgid_and_target() {
         let result = build_tool_kill_result("agent1", 12345, "");
         assert_eq!(result["ok"], true);
@@ -2990,12 +2991,14 @@ instances:
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_tool_kill_result_includes_reason_when_provided() {
         let result = build_tool_kill_result("agent1", 12345, "stuck on cargo test");
         assert_eq!(result["reason"], "stuck on cargo test");
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_tool_kill_audit_format() {
         let audit = build_tool_kill_audit("priority task", 42);
         assert!(audit.contains("reason=priority task"), "audit: {audit}");

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -31,6 +31,20 @@ fn err_needs_identity(tool: &str) -> Value {
     })
 }
 
+/// Pure function: build tool_kill success response.
+pub(crate) fn build_tool_kill_result(target: &str, pgid: i32, reason: &str) -> Value {
+    let mut result = json!({"ok": true, "target": target, "pgid": pgid});
+    if !reason.is_empty() {
+        result["reason"] = json!(reason);
+    }
+    result
+}
+
+/// Pure function: build tool_kill audit log detail string.
+pub(crate) fn build_tool_kill_audit(reason: &str, pgid: i32) -> String {
+    format!("reason={reason}, pgid={pgid}")
+}
+
 pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
     let home = crate::home_dir();
     // Explicit arg beats env var. Cross-instance arms require `Some`;
@@ -977,18 +991,14 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                     }),
                 ) {
                     Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+                        let pgid = resp["pgid"].as_i64().unwrap_or(0) as i32;
                         crate::event_log::log(
                             &home,
                             "tool_kill_invoked",
                             target,
-                            &format!("reason={reason}, pgid={}", resp["pgid"]),
+                            &build_tool_kill_audit(reason, pgid),
                         );
-                        let mut result =
-                            json!({"ok": true, "target": target, "pgid": resp["pgid"]});
-                        if !reason.is_empty() {
-                            result["reason"] = json!(reason);
-                        }
-                        result
+                        build_tool_kill_result(target, pgid, reason)
                     }
                     Ok(resp) => {
                         json!({"error": resp["error"].as_str().unwrap_or("tool_kill failed")})
@@ -2964,5 +2974,44 @@ instances:
         assert!(meta.forced, "interrupted=true must map to forced=true");
         assert_eq!(meta.reason, "legacy");
         assert!(!meta.forced_at.is_empty());
+    }
+
+    // --- Sprint 11: tool_kill pure function tests ---
+
+    #[test]
+    fn test_tool_kill_result_includes_pgid_and_target() {
+        let result = build_tool_kill_result("agent1", 12345, "");
+        assert_eq!(result["ok"], true);
+        assert_eq!(result["target"], "agent1");
+        assert_eq!(result["pgid"], 12345);
+        assert!(result["reason"].is_null(), "empty reason must not appear");
+    }
+
+    #[test]
+    fn test_tool_kill_result_includes_reason_when_provided() {
+        let result = build_tool_kill_result("agent1", 12345, "stuck on cargo test");
+        assert_eq!(result["reason"], "stuck on cargo test");
+    }
+
+    #[test]
+    fn test_tool_kill_audit_format() {
+        let audit = build_tool_kill_audit("priority task", 42);
+        assert!(audit.contains("reason=priority task"), "audit: {audit}");
+        assert!(audit.contains("pgid=42"), "audit: {audit}");
+    }
+
+    #[test]
+    fn test_tool_kill_target_not_found_returns_error() {
+        let _g = fleet_test_guard();
+        let home = tmp_home("tool-kill-notfound");
+        std::env::set_var("AGEND_HOME", &home);
+        // No fleet.yaml → target doesn't exist
+        let result = handle_tool("tool_kill", &json!({"target": "ghost"}), "sender");
+        assert!(
+            result.get("error").is_some(),
+            "tool_kill to nonexistent target must error: {result}"
+        );
+        std::env::remove_var("AGEND_HOME");
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -120,6 +120,11 @@ fn instance_tools() -> Vec<Value> {
                 "target": {"type": "string", "description": "Target instance name"},
                 "reason": {"type": "string", "description": "Optional follow-up message to inject after ESC"}
             }, "required": ["target"]}}),
+        json!({"name": "tool_kill", "description": "Send SIGINT to target agent's PTY foreground process group, cancelling active tool subprocess while preserving agent session. Unix only.",
+            "inputSchema": {"type": "object", "properties": {
+                "target": {"type": "string", "description": "Target instance name"},
+                "reason": {"type": "string", "description": "Optional reason for audit log"}
+            }, "required": ["target"]}}),
         json!({"name": "set_display_name", "description": "Set your display name.",
             "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}),
         json!({"name": "set_description", "description": "Set a description for this instance.",


### PR DESCRIPTION
## Problem
No way to cancel an agent's active tool subprocess (e.g. long-running cargo test) without killing the entire agent session.

## Solution
New MCP tool tool_kill(target, reason?) sends SIGINT to the PTY foreground process group via tcgetpgrp + kill(-pgid, SIGINT). Preserves agent session while cancelling active subprocess.

### Mechanism (from PR-S spike)
1. API handler gets PTY master fd from agent registry
2. tcgetpgrp(fd) → foreground pgid
3. kill(-pgid, SIGINT) → cancels tool subprocess
4. ESRCH treated as benign (already dead)

### Cross-platform
- Unix only (Linux/macOS). Windows returns unimplemented error.

### §3.5.8 compliance
Per-backend semantics (how each CLI reacts to SIGINT on foreground pgid) is an unverified cross-backend claim. Backlog: t-20260425040356199333-6 (PR-Z backend measurement).

### Audit
event_log tool_kill_invoked entry per invocation.

936 tests pass (1 pre-existing flaky), clippy(tray)/fmt clean.