### PR TITLE
sprint13: introduce CiProvider trait abstraction (PR-AD)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "alacritty_terminal",
  "anyhow",
  "arboard",
+ "async-trait",
  "chrono",
  "chrono-tz",
  "clap",
@@ -193,6 +194,17 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "atk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ teloxide = { version = "0.13", default-features = false, features = ["macros", "
 
 # Utilities
 anyhow = "1"
+async-trait = "0.1"
 fs2 = "0.4"
 dirs = "6"
 regex = "1"

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -2,6 +2,155 @@ use crate::agent::{self, AgentRegistry};
 use std::path::Path;
 use std::sync::Arc;
 
+// ---------------------------------------------------------------------------
+// CiProvider trait — abstracts CI-server-specific HTTP calls so ci_watch
+// state-machine logic can be tested with a mock and future providers
+// (GitLab, Buildkite, …) can be added without touching the orchestration.
+// ---------------------------------------------------------------------------
+
+/// Response from polling CI runs for a branch.
+pub struct CiRunsResponse {
+    /// HTTP-level status (e.g. 200, 403, 500).
+    pub status: u16,
+    /// Parsed JSON body.
+    pub body: serde_json::Value,
+}
+
+/// PR terminal-state check result.
+pub enum PrState {
+    /// PR is closed/merged — watcher should be cleared.
+    Terminal,
+    /// PR is still open.
+    Open,
+    /// Check failed or no PR found — leave watcher alone.
+    Unknown,
+}
+
+/// Abstraction over a CI server's REST API.
+/// Each method corresponds to one GitHub-specific HTTP call in the
+/// original `ci_check_repo`.
+#[async_trait::async_trait]
+pub trait CiProvider: Send + Sync {
+    /// Poll workflow/pipeline runs for `repo@branch`.
+    async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiRunsResponse>;
+
+    /// Check whether the PR for `branch` has reached a terminal state.
+    async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState;
+
+    /// Fetch a human-readable summary of the first failed job/step.
+    async fn fetch_failure_summary(&self, repo: &str, run_id: u64) -> String;
+
+    /// Optional token/auth warning shown in the `watch_ci` MCP response.
+    /// Currently called via `github_token_warning_from_env()` in the handler;
+    /// future providers will use this method directly.
+    #[allow(dead_code)]
+    fn token_warning(&self) -> Option<&'static str>;
+}
+
+/// GitHub Actions implementation of [`CiProvider`].
+pub struct GitHubCiProvider {
+    client: reqwest::Client,
+}
+
+impl GitHubCiProvider {
+    pub fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(5))
+                .build()?,
+        })
+    }
+
+    fn gh_get(&self, url: &str) -> reqwest::RequestBuilder {
+        let mut req = self
+            .client
+            .get(url)
+            .header("User-Agent", "agend-terminal")
+            .header("Accept", "application/vnd.github+json");
+        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+            req = req.header("Authorization", format!("Bearer {token}"));
+        }
+        req
+    }
+}
+
+#[async_trait::async_trait]
+impl CiProvider for GitHubCiProvider {
+    async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiRunsResponse> {
+        let resp = self
+            .gh_get(&format!(
+                "https://api.github.com/repos/{repo}/actions/runs?branch={branch}&per_page=5"
+            ))
+            .send()
+            .await?;
+        let status = resp.status().as_u16();
+        let body: serde_json::Value = resp.json().await?;
+        Ok(CiRunsResponse { status, body })
+    }
+
+    async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState {
+        let resp: serde_json::Value = match self
+            .gh_get(&format!(
+                "https://api.github.com/repos/{repo}/pulls?head={branch}&state=all&per_page=1"
+            ))
+            .send()
+            .await
+        {
+            Ok(r) => match r.json().await {
+                Ok(v) => v,
+                Err(_) => return PrState::Unknown,
+            },
+            Err(_) => return PrState::Unknown,
+        };
+        match resp.as_array().and_then(|a| a.first()) {
+            Some(pr) => match pr["state"].as_str() {
+                Some("closed") => PrState::Terminal,
+                Some(_) => PrState::Open,
+                None => PrState::Unknown,
+            },
+            None => PrState::Unknown,
+        }
+    }
+
+    async fn fetch_failure_summary(&self, repo: &str, run_id: u64) -> String {
+        let jobs_resp: serde_json::Value = match self
+            .gh_get(&format!(
+                "https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs"
+            ))
+            .send()
+            .await
+        {
+            Ok(r) => match r.json().await {
+                Ok(v) => v,
+                Err(_) => return "unknown step".to_string(),
+            },
+            Err(_) => return "unknown step".to_string(),
+        };
+        jobs_resp["jobs"]
+            .as_array()
+            .and_then(|jobs| {
+                jobs.iter().find_map(|job| {
+                    job["steps"].as_array().and_then(|steps| {
+                        steps.iter().find_map(|step| {
+                            (step["conclusion"].as_str() == Some("failure")).then(|| {
+                                format!(
+                                    "{} / {}",
+                                    job["name"].as_str().unwrap_or("?"),
+                                    step["name"].as_str().unwrap_or("?")
+                                )
+                            })
+                        })
+                    })
+                })
+            })
+            .unwrap_or_else(|| "unknown step".to_string())
+    }
+
+    fn token_warning(&self) -> Option<&'static str> {
+        github_token_warning(std::env::var("GITHUB_TOKEN").ok().as_deref())
+    }
+}
+
 /// Watch TTL in hours. Used for both absolute expiry and inactivity threshold.
 pub const WATCH_TTL_HOURS: i64 = 72;
 
@@ -81,12 +230,24 @@ pub fn github_token_warning(token: Option<&str>) -> Option<&'static str> {
 /// `github_token_warning` fed from the daemon's actual env. Separate
 /// from the pure helper so the handler can call this one-liner while
 /// tests drive the pure form with synthetic inputs.
+/// Also serves as the default `token_warning` for [`GitHubCiProvider`].
 pub fn github_token_warning_from_env() -> Option<&'static str> {
     github_token_warning(std::env::var("GITHUB_TOKEN").ok().as_deref())
 }
 
 /// Check CI watch configs and inject failure logs to agents when CI fails.
 pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
+    check_ci_watches_with_provider(home, registry, || {
+        Some(Box::new(GitHubCiProvider::new().ok()?) as Box<dyn CiProvider>)
+    });
+}
+
+/// Inner implementation that accepts a provider factory for testability.
+fn check_ci_watches_with_provider(
+    home: &Path,
+    registry: &AgentRegistry,
+    make_provider: impl Fn() -> Option<Box<dyn CiProvider>> + Send + Sync + 'static,
+) {
     let entries = match std::fs::read_dir(home.join("ci-watches")) {
         Ok(e) => e,
         Err(_) => return,
@@ -160,6 +321,13 @@ pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
         let home = home.to_path_buf();
         let watch_path = path.clone();
         let registry = Arc::clone(registry);
+        let provider = match make_provider() {
+            Some(p) => p,
+            None => {
+                tracing::warn!(repo = %repo, "ci_check: failed to build CI provider");
+                continue;
+            }
+        };
         std::thread::Builder::new()
             .name("ci_check".into())
             .spawn(move || {
@@ -180,6 +348,7 @@ pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
                     head_sha.as_deref(),
                     last_notified_sha.as_deref(),
                     &registry,
+                    provider.as_ref(),
                 )) {
                     tracing::debug!(repo = %repo, error = %e, "CI check failed");
                 }
@@ -328,7 +497,7 @@ fn ci_notification_message(
     Some(msg)
 }
 
-/// Fetch latest GitHub Actions run and notify the watching agent on any
+/// Fetch latest CI run and notify the watching agent on any
 /// terminal conclusion (success, failure, cancelled, timed_out, etc.).
 /// Also tracks `head_sha` — if the branch HEAD changes (e.g. force push),
 /// `last_run_id` is reset so the new run is picked up.
@@ -344,37 +513,16 @@ async fn ci_check_repo(
     prev_head_sha: Option<&str>,
     last_notified_sha: Option<&str>,
     registry: &AgentRegistry,
+    provider: &dyn CiProvider,
 ) -> anyhow::Result<()> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()?;
-    let gh_get = |url: &str| {
-        let mut req = client
-            .get(url)
-            .header("User-Agent", "agend-terminal")
-            .header("Accept", "application/vnd.github+json");
-        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-            req = req.header("Authorization", format!("Bearer {token}"));
-        }
-        req
-    };
-
     // Check if the PR associated with this branch has reached a terminal state.
-    if let Some(should_clear) = check_pr_terminal(&gh_get, repo, branch).await {
-        if should_clear {
-            remove_watch(home, watch_path, instance, repo, branch, "pr_terminal");
-            tracing::info!(repo, branch, "CI watcher auto-cleared: PR terminal");
-            return Ok(());
-        }
+    if let PrState::Terminal = provider.check_pr_terminal(repo, branch).await {
+        remove_watch(home, watch_path, instance, repo, branch, "pr_terminal");
+        tracing::info!(repo, branch, "CI watcher auto-cleared: PR terminal");
+        return Ok(());
     }
 
-    let resp = gh_get(&format!(
-        "https://api.github.com/repos/{repo}/actions/runs?branch={branch}&per_page=5"
-    ))
-    .send()
-    .await?;
-    let status = resp.status().as_u16();
-    let body: serde_json::Value = resp.json().await?;
+    let CiRunsResponse { status, body } = provider.poll_runs(repo, branch).await?;
     // Use classify_runs_response to surface API errors (rate-limit, auth, etc.)
     // so they don't silently look like a quiescent branch. Then extract the
     // full runs array ourselves for multi-run scan (classify only returns the
@@ -428,7 +576,7 @@ async fn ci_check_repo(
         if let Some(headline) = ci_notification_message(repo, branch, conclusion, None) {
             let run_url = run["html_url"].as_str().unwrap_or("");
             let failure_detail = if conclusion == Some("failure") {
-                Some(fetch_failure_summary(&gh_get, repo, *run_id).await)
+                Some(provider.fetch_failure_summary(repo, *run_id).await)
             } else {
                 None
             };
@@ -507,65 +655,7 @@ fn update_watch_state_with_notify(
     }
 }
 
-/// Check if the PR for a branch has reached a terminal state (merged or closed).
-/// Returns `Some(true)` if the watcher should be cleared, `Some(false)` if the
-/// PR is still open, `None` if the check failed or no PR was found.
-async fn check_pr_terminal(
-    gh_get: &impl Fn(&str) -> reqwest::RequestBuilder,
-    repo: &str,
-    branch: &str,
-) -> Option<bool> {
-    let resp: serde_json::Value = gh_get(&format!(
-        "https://api.github.com/repos/{repo}/pulls?head={branch}&state=all&per_page=1"
-    ))
-    .send()
-    .await
-    .ok()?
-    .json()
-    .await
-    .ok()?;
-    let pr = resp.as_array()?.first()?;
-    let state = pr["state"].as_str()?;
-    Some(state == "closed")
-}
 
-/// Fetch the first failed job+step name from a GitHub Actions run.
-async fn fetch_failure_summary(
-    gh_get: &impl Fn(&str) -> reqwest::RequestBuilder,
-    repo: &str,
-    run_id: u64,
-) -> String {
-    let jobs_resp: serde_json::Value = match gh_get(&format!(
-        "https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs"
-    ))
-    .send()
-    .await
-    {
-        Ok(r) => match r.json().await {
-            Ok(v) => v,
-            Err(_) => return "unknown step".to_string(),
-        },
-        Err(_) => return "unknown step".to_string(),
-    };
-    jobs_resp["jobs"]
-        .as_array()
-        .and_then(|jobs| {
-            jobs.iter().find_map(|job| {
-                job["steps"].as_array().and_then(|steps| {
-                    steps.iter().find_map(|step| {
-                        (step["conclusion"].as_str() == Some("failure")).then(|| {
-                            format!(
-                                "{} / {}",
-                                job["name"].as_str().unwrap_or("?"),
-                                step["name"].as_str().unwrap_or("?")
-                            )
-                        })
-                    })
-                })
-            })
-        })
-        .unwrap_or_else(|| "unknown step".to_string())
-}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
@@ -1186,6 +1276,222 @@ mod tests {
             watch_path.exists(),
             "watch must survive when PR check unavailable"
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // --- MockCiProvider + state machine tests ---
+
+    use std::sync::Mutex;
+
+    /// Mock CI provider for testing ci_check_repo state machine without HTTP.
+    struct MockCiProvider {
+        runs_response: Mutex<Option<CiRunsResponse>>,
+        pr_state: Mutex<PrState>,
+        failure_summary: Mutex<String>,
+    }
+
+    impl MockCiProvider {
+        fn new(status: u16, body: serde_json::Value) -> Self {
+            Self {
+                runs_response: Mutex::new(Some(CiRunsResponse { status, body })),
+                pr_state: Mutex::new(PrState::Open),
+                failure_summary: Mutex::new("Build / Test".to_string()),
+            }
+        }
+
+        fn with_pr_terminal(self) -> Self {
+            *self.pr_state.lock().unwrap() = PrState::Terminal;
+            self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CiProvider for MockCiProvider {
+        async fn poll_runs(&self, _repo: &str, _branch: &str) -> anyhow::Result<CiRunsResponse> {
+            Ok(self.runs_response.lock().unwrap().take().unwrap())
+        }
+        async fn check_pr_terminal(&self, _repo: &str, _branch: &str) -> PrState {
+            let mut guard = self.pr_state.lock().unwrap();
+            std::mem::replace(&mut *guard, PrState::Open)
+        }
+        async fn fetch_failure_summary(&self, _repo: &str, _run_id: u64) -> String {
+            self.failure_summary.lock().unwrap().clone()
+        }
+        fn token_warning(&self) -> Option<&'static str> {
+            None
+        }
+    }
+
+    /// Helper: run ci_check_repo with a mock provider in a temp dir.
+    fn run_ci_check(
+        dir: &Path,
+        watch_json: &serde_json::Value,
+        provider: &dyn CiProvider,
+    ) -> anyhow::Result<()> {
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let repo = watch_json["repo"].as_str().unwrap();
+        let branch = watch_json["branch"].as_str().unwrap();
+        let instance = watch_json["instance"].as_str().unwrap();
+        let filename = watch_filename(repo, branch);
+        let watch_path = ci_dir.join(&filename);
+        std::fs::write(
+            &watch_path,
+            serde_json::to_string_pretty(watch_json).unwrap(),
+        )
+        .unwrap();
+
+        let registry: AgentRegistry =
+            Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            dir,
+            &watch_path,
+            repo,
+            branch,
+            instance,
+            watch_json["last_run_id"].as_u64(),
+            watch_json["head_sha"].as_str(),
+            watch_json["last_notified_head_sha"].as_str(),
+            &registry,
+            provider,
+        ))
+    }
+
+    fn base_watch() -> serde_json::Value {
+        serde_json::json!({
+            "repo": "o/r", "branch": "feat", "interval_secs": 60,
+            "instance": "agent1", "last_run_id": null, "head_sha": null,
+            "last_polled_at": null, "last_notified_head_sha": null,
+        })
+    }
+
+    #[test]
+    fn mock_success_run_updates_watch_state() {
+        let dir = tmp_dir("mock-success");
+        let body = serde_json::json!({
+            "workflow_runs": [{"id": 100, "conclusion": "success", "head_sha": "abc", "html_url": "https://example.com/100"}]
+        });
+        let provider = MockCiProvider::new(200, body);
+        run_ci_check(&dir, &base_watch(), &provider).unwrap();
+
+        // Watch file should be updated with last_run_id and head_sha
+        let watch_path = dir.join("ci-watches").join(watch_filename("o/r", "feat"));
+        let updated: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+        assert_eq!(updated["last_run_id"].as_u64(), Some(100));
+        assert_eq!(updated["head_sha"].as_str(), Some("abc"));
+
+        // Inbox should have a notification
+        let inbox_dir = dir.join("inbox");
+        let has_inbox = inbox_dir.exists()
+            && std::fs::read_dir(&inbox_dir)
+                .map(|d| d.count() > 0)
+                .unwrap_or(false);
+        assert!(has_inbox, "success run should enqueue inbox notification");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn mock_failure_run_includes_detail() {
+        let dir = tmp_dir("mock-failure");
+        let body = serde_json::json!({
+            "workflow_runs": [{"id": 200, "conclusion": "failure", "head_sha": "def", "html_url": "https://example.com/200"}]
+        });
+        let provider = MockCiProvider::new(200, body);
+        run_ci_check(&dir, &base_watch(), &provider).unwrap();
+
+        // Check inbox contains failure detail
+        let inbox_path = dir.join("inbox").join("agent1.jsonl");
+        if inbox_path.exists() {
+            let content = std::fs::read_to_string(&inbox_path).unwrap();
+            assert!(content.contains("ci-fail"), "inbox should have ci-fail: {content}");
+            assert!(content.contains("Build / Test"), "inbox should have failure detail: {content}");
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn mock_api_error_propagates() {
+        let dir = tmp_dir("mock-api-err");
+        let body = serde_json::json!({"message": "rate limit exceeded"});
+        let provider = MockCiProvider::new(403, body);
+        let result = run_ci_check(&dir, &base_watch(), &provider);
+        assert!(result.is_err(), "API error must propagate");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("403"), "error should contain status: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn mock_pr_terminal_clears_watch() {
+        let dir = tmp_dir("mock-pr-term");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = base_watch();
+        let filename = watch_filename("o/r", "feat");
+        let watch_path = ci_dir.join(&filename);
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+        // Provider says PR is terminal — runs response doesn't matter
+        let body = serde_json::json!({"workflow_runs": []});
+        let provider = MockCiProvider::new(200, body).with_pr_terminal();
+
+        let registry: AgentRegistry =
+            Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir, &watch_path, "o/r", "feat", "agent1",
+            None, None, None, &registry, &provider,
+        ))
+        .unwrap();
+
+        assert!(!watch_path.exists(), "PR terminal must remove watch file");
+        let log = std::fs::read_to_string(dir.join("event-log.jsonl")).unwrap_or_default();
+        assert!(log.contains("pr_terminal"), "event log must record pr_terminal");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn mock_no_runs_preserves_watch() {
+        let dir = tmp_dir("mock-no-runs");
+        let body = serde_json::json!({"workflow_runs": []});
+        let provider = MockCiProvider::new(200, body);
+        run_ci_check(&dir, &base_watch(), &provider).unwrap();
+
+        let watch_path = dir.join("ci-watches").join(watch_filename("o/r", "feat"));
+        assert!(watch_path.exists(), "empty runs must preserve watch");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn mock_force_push_resets_tracking() {
+        let dir = tmp_dir("mock-force-push");
+        // Watch has old head_sha "old123", new run has different sha
+        let mut watch = base_watch();
+        watch["head_sha"] = serde_json::json!("old123");
+        watch["last_run_id"] = serde_json::json!(50);
+        let body = serde_json::json!({
+            "workflow_runs": [
+                {"id": 51, "conclusion": "success", "head_sha": "new456", "html_url": "https://example.com/51"}
+            ]
+        });
+        let provider = MockCiProvider::new(200, body);
+        run_ci_check(&dir, &watch, &provider).unwrap();
+
+        let watch_path = dir.join("ci-watches").join(watch_filename("o/r", "feat"));
+        let updated: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+        // After force push, run 51 should be notified even though id > last_run_id=50
+        // would normally catch it — the key is head_sha changed so tracking reset
+        assert_eq!(updated["last_run_id"].as_u64(), Some(51));
+        assert_eq!(updated["head_sha"].as_str(), Some("new456"));
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -655,8 +655,6 @@ fn update_watch_state_with_notify(
     }
 }
 
-
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -1408,8 +1406,14 @@ mod tests {
         let inbox_path = dir.join("inbox").join("agent1.jsonl");
         if inbox_path.exists() {
             let content = std::fs::read_to_string(&inbox_path).unwrap();
-            assert!(content.contains("ci-fail"), "inbox should have ci-fail: {content}");
-            assert!(content.contains("Build / Test"), "inbox should have failure detail: {content}");
+            assert!(
+                content.contains("ci-fail"),
+                "inbox should have ci-fail: {content}"
+            );
+            assert!(
+                content.contains("Build / Test"),
+                "inbox should have failure detail: {content}"
+            );
         }
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -1447,14 +1451,25 @@ mod tests {
             .build()
             .unwrap();
         rt.block_on(ci_check_repo(
-            &dir, &watch_path, "o/r", "feat", "agent1",
-            None, None, None, &registry, &provider,
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            "agent1",
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
         ))
         .unwrap();
 
         assert!(!watch_path.exists(), "PR terminal must remove watch file");
         let log = std::fs::read_to_string(dir.join("event-log.jsonl")).unwrap_or_default();
-        assert!(log.contains("pr_terminal"), "event log must record pr_terminal");
+        assert!(
+            log.contains("pr_terminal"),
+            "event log must record pr_terminal"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -8,12 +8,26 @@ use std::sync::Arc;
 // (GitLab, Buildkite, …) can be added without touching the orchestration.
 // ---------------------------------------------------------------------------
 
-/// Response from polling CI runs for a branch.
-pub struct CiRunsResponse {
-    /// HTTP-level status (e.g. 200, 403, 500).
-    pub status: u16,
-    /// Parsed JSON body.
-    pub body: serde_json::Value,
+/// A single CI pipeline/workflow run, provider-neutral.
+#[derive(Debug, Clone)]
+pub struct CiRun {
+    pub id: u64,
+    /// `None` means in-progress / not yet concluded.
+    pub conclusion: Option<String>,
+    pub head_sha: String,
+    pub url: String,
+}
+
+/// Result of polling CI runs for a branch.
+pub enum CiPollResult {
+    /// Runs retrieved successfully (may be empty).
+    Runs(Vec<CiRun>),
+    /// API-level error (rate limit, auth failure, server error).
+    ApiError {
+        #[allow(dead_code)]
+        status: u16,
+        message: String,
+    },
 }
 
 /// PR terminal-state check result.
@@ -27,14 +41,15 @@ pub enum PrState {
 }
 
 /// Abstraction over a CI server's REST API.
-/// Each method corresponds to one GitHub-specific HTTP call in the
-/// original `ci_check_repo`.
+/// Each method corresponds to one provider-specific HTTP call.
+/// Return types are provider-neutral — all schema parsing happens
+/// inside the impl, not in the ci_watch state machine.
 #[async_trait::async_trait]
 pub trait CiProvider: Send + Sync {
     /// Poll workflow/pipeline runs for `repo@branch`.
-    async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiRunsResponse>;
+    async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiPollResult>;
 
-    /// Check whether the PR for `branch` has reached a terminal state.
+    /// Check whether the PR/MR for `branch` has reached a terminal state.
     async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState;
 
     /// Fetch a human-readable summary of the first failed job/step.
@@ -76,7 +91,7 @@ impl GitHubCiProvider {
 
 #[async_trait::async_trait]
 impl CiProvider for GitHubCiProvider {
-    async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiRunsResponse> {
+    async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiPollResult> {
         let resp = self
             .gh_get(&format!(
                 "https://api.github.com/repos/{repo}/actions/runs?branch={branch}&per_page=5"
@@ -85,7 +100,45 @@ impl CiProvider for GitHubCiProvider {
             .await?;
         let status = resp.status().as_u16();
         let body: serde_json::Value = resp.json().await?;
-        Ok(CiRunsResponse { status, body })
+
+        // Surface API errors (rate-limit, auth, server) instead of
+        // silently treating them as "no runs".
+        if !(200..300).contains(&status) {
+            let message = body["message"]
+                .as_str()
+                .unwrap_or("(no message)")
+                .to_string();
+            let hint = if status == 403
+                && std::env::var("GITHUB_TOKEN").is_err()
+                && message.to_lowercase().contains("rate limit")
+            {
+                " — set GITHUB_TOKEN to raise the unauthenticated 60/hr cap"
+            } else {
+                ""
+            };
+            return Ok(CiPollResult::ApiError {
+                status,
+                message: format!("GH API {status}: {message}{hint}"),
+            });
+        }
+
+        // Parse GitHub-specific `workflow_runs` array into neutral CiRun structs.
+        let runs = body["workflow_runs"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|r| {
+                        Some(CiRun {
+                            id: r["id"].as_u64()?,
+                            conclusion: r["conclusion"].as_str().map(String::from),
+                            head_sha: r["head_sha"].as_str()?.to_string(),
+                            url: r["html_url"].as_str().unwrap_or("").to_string(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(CiPollResult::Runs(runs))
     }
 
     async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState {
@@ -372,19 +425,23 @@ fn check_ci_watches_with_provider(
 /// notification while `last_polled_at` keeps marching forward. Tag the
 /// HTTP status explicitly so API errors surface as `Err` instead of
 /// imitating a quiescent branch.
+///
+/// Production code now uses [`CiPollResult`] via the [`CiProvider`] trait;
+/// this enum is retained for unit-testing the classification logic that
+/// lives inside [`GitHubCiProvider::poll_runs`].
+#[cfg(test)]
 enum RunsResponse<'a> {
-    // Tests use the payload to verify classify_runs_response unwraps the
-    // first run; production caller (ci_check_repo) now reads the full
-    // runs array itself for multi-run scan and only matches ApiError here.
-    #[allow(dead_code)]
     Run(&'a serde_json::Value),
-    #[allow(dead_code)]
     NoRuns,
     ApiError(String),
 }
 
 /// Pure interpreter for a runs-list response. See [`RunsResponse`] for
 /// why the rate-limit / NoRuns distinction matters.
+///
+/// Retained under `#[cfg(test)]` — production classification now happens
+/// inside [`GitHubCiProvider::poll_runs`].
+#[cfg(test)]
 fn classify_runs_response(status: u16, body: &serde_json::Value) -> RunsResponse<'_> {
     if !(200..300).contains(&status) {
         let message = body["message"].as_str().unwrap_or("(no message)");
@@ -404,26 +461,22 @@ fn classify_runs_response(status: u16, body: &serde_json::Value) -> RunsResponse
     }
 }
 
-/// Select runs from a GitHub Actions response that should trigger notifications.
+/// Select runs from a CI poll result that should trigger notifications.
 /// Returns indices into `runs` of terminal runs with `id > last_run_id`, ordered
 /// oldest-first so notifications arrive chronologically.
-/// In-progress runs (conclusion=null) are skipped.
-pub(crate) fn select_runs_to_notify(
-    runs: &[serde_json::Value],
-    last_run_id: Option<u64>,
-) -> Vec<usize> {
+/// In-progress runs (conclusion=None) are skipped.
+pub(crate) fn select_runs_to_notify(runs: &[CiRun], last_run_id: Option<u64>) -> Vec<usize> {
     let threshold = last_run_id.unwrap_or(0);
     let mut selected: Vec<(usize, u64)> = runs
         .iter()
         .enumerate()
         .filter_map(|(i, run)| {
-            let id = run["id"].as_u64()?;
-            if id <= threshold {
+            if run.id <= threshold {
                 return None;
             }
             // Skip non-terminal (in-progress) runs
-            run["conclusion"].as_str()?;
-            Some((i, id))
+            run.conclusion.as_ref()?;
+            Some((i, run.id))
         })
         .collect();
     // Sort oldest-first by run_id
@@ -436,15 +489,15 @@ pub(crate) fn select_runs_to_notify(
 /// keeping the latest run_id per sha. Skips shas matching `last_notified`.
 /// Sorted by run_id (oldest first) for chronological notification order.
 pub(crate) fn dedupe_notifications_by_head_sha<'a>(
-    runs: &'a [serde_json::Value],
+    runs: &'a [CiRun],
     to_notify: &[usize],
     last_notified: Option<&str>,
 ) -> Vec<(usize, u64, &'a str)> {
     let mut best: std::collections::HashMap<&str, (usize, u64)> = std::collections::HashMap::new();
     for &idx in to_notify {
         let run = &runs[idx];
-        let sha = run["head_sha"].as_str().unwrap_or("");
-        let id = run["id"].as_u64().unwrap_or(0);
+        let sha = run.head_sha.as_str();
+        let id = run.id;
         best.entry(sha)
             .and_modify(|e| {
                 if id > e.1 {
@@ -522,24 +575,15 @@ async fn ci_check_repo(
         return Ok(());
     }
 
-    let CiRunsResponse { status, body } = provider.poll_runs(repo, branch).await?;
-    // Use classify_runs_response to surface API errors (rate-limit, auth, etc.)
-    // so they don't silently look like a quiescent branch. Then extract the
-    // full runs array ourselves for multi-run scan (classify only returns the
-    // first run — fine for its API-error contract, but we need all 5).
-    if let RunsResponse::ApiError(msg) = classify_runs_response(status, &body) {
-        return Err(anyhow::anyhow!(msg));
-    }
-    let runs = match body["workflow_runs"].as_array() {
-        Some(a) if !a.is_empty() => a,
-        _ => return Ok(()),
+    let poll_result = provider.poll_runs(repo, branch).await?;
+    let runs = match poll_result {
+        CiPollResult::ApiError { message, .. } => return Err(anyhow::anyhow!(message)),
+        CiPollResult::Runs(r) if r.is_empty() => return Ok(()),
+        CiPollResult::Runs(r) => r,
     };
 
     // Determine the latest head_sha from the newest run.
-    let current_sha = runs
-        .first()
-        .and_then(|r| r["head_sha"].as_str())
-        .unwrap_or("");
+    let current_sha = runs.first().map(|r| r.head_sha.as_str()).unwrap_or("");
 
     // If head_sha changed (force push), reset last_run_id so we pick up new runs.
     let effective_last_run_id = if prev_head_sha.is_some_and(|prev| prev != current_sha) {
@@ -549,7 +593,7 @@ async fn ci_check_repo(
         last_run_id
     };
 
-    let to_notify = select_runs_to_notify(runs, effective_last_run_id);
+    let to_notify = select_runs_to_notify(&runs, effective_last_run_id);
     if to_notify.is_empty() {
         // No new terminal runs — update head_sha but keep last_run_id.
         if let Some(id) = effective_last_run_id {
@@ -560,21 +604,19 @@ async fn ci_check_repo(
 
     let mut max_notified_id = effective_last_run_id.unwrap_or(0);
     for &idx in &to_notify {
-        let id = runs[idx]["id"].as_u64().unwrap_or(0);
-        if id > max_notified_id {
-            max_notified_id = id;
+        if runs[idx].id > max_notified_id {
+            max_notified_id = runs[idx].id;
         }
     }
 
-    let deduped = dedupe_notifications_by_head_sha(runs, &to_notify, last_notified_sha);
+    let deduped = dedupe_notifications_by_head_sha(&runs, &to_notify, last_notified_sha);
     let mut new_notified_sha = last_notified_sha.map(String::from);
 
     for (idx, run_id, sha) in &deduped {
         let run = &runs[*idx];
-        let conclusion = run["conclusion"].as_str();
+        let conclusion = run.conclusion.as_deref();
 
         if let Some(headline) = ci_notification_message(repo, branch, conclusion, None) {
-            let run_url = run["html_url"].as_str().unwrap_or("");
             let failure_detail = if conclusion == Some("failure") {
                 Some(provider.fetch_failure_summary(repo, *run_id).await)
             } else {
@@ -584,7 +626,7 @@ async fn ci_check_repo(
                 &headline,
                 conclusion.unwrap_or(""),
                 failure_detail.as_deref(),
-                run_url,
+                &run.url,
             );
 
             let reg = agent::lock_registry(registry);
@@ -950,11 +992,25 @@ mod tests {
 
     #[test]
     fn test_multi_run_notifies_all_terminal_since_last() {
-        use serde_json::json;
         let runs = vec![
-            json!({"id": 100, "conclusion": "success", "head_sha": "aaa"}),
-            json!({"id": 101, "conclusion": "success", "head_sha": "bbb"}),
-            json!({"id": 102, "conclusion": null, "head_sha": "ccc"}), // in-progress
+            CiRun {
+                id: 100,
+                conclusion: Some("success".into()),
+                head_sha: "aaa".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 101,
+                conclusion: Some("success".into()),
+                head_sha: "bbb".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 102,
+                conclusion: None,
+                head_sha: "ccc".into(),
+                url: String::new(),
+            },
         ];
         let selected = select_runs_to_notify(&runs, Some(99));
         assert_eq!(
@@ -966,19 +1022,37 @@ mod tests {
 
     #[test]
     fn test_in_progress_does_not_appear_in_selection() {
-        use serde_json::json;
-        let runs = vec![json!({"id": 200, "conclusion": null, "head_sha": "aaa"})];
+        let runs = vec![CiRun {
+            id: 200,
+            conclusion: None,
+            head_sha: "aaa".into(),
+            url: String::new(),
+        }];
         let selected = select_runs_to_notify(&runs, None);
         assert!(selected.is_empty(), "in-progress run must not be selected");
     }
 
     #[test]
     fn test_mixed_terminal_states_all_notified() {
-        use serde_json::json;
         let runs = vec![
-            json!({"id": 300, "conclusion": "failure", "head_sha": "a"}),
-            json!({"id": 301, "conclusion": "cancelled", "head_sha": "b"}),
-            json!({"id": 302, "conclusion": "success", "head_sha": "c"}),
+            CiRun {
+                id: 300,
+                conclusion: Some("failure".into()),
+                head_sha: "a".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 301,
+                conclusion: Some("cancelled".into()),
+                head_sha: "b".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 302,
+                conclusion: Some("success".into()),
+                head_sha: "c".into(),
+                url: String::new(),
+            },
         ];
         let selected = select_runs_to_notify(&runs, Some(299));
         assert_eq!(
@@ -990,10 +1064,19 @@ mod tests {
 
     #[test]
     fn test_already_notified_runs_skipped() {
-        use serde_json::json;
         let runs = vec![
-            json!({"id": 400, "conclusion": "success", "head_sha": "a"}),
-            json!({"id": 401, "conclusion": "success", "head_sha": "b"}),
+            CiRun {
+                id: 400,
+                conclusion: Some("success".into()),
+                head_sha: "a".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 401,
+                conclusion: Some("success".into()),
+                head_sha: "b".into(),
+                url: String::new(),
+            },
         ];
         let selected = select_runs_to_notify(&runs, Some(400));
         assert_eq!(
@@ -1005,10 +1088,19 @@ mod tests {
 
     #[test]
     fn test_same_head_sha_deduplicates_notification() {
-        use serde_json::json;
         let runs = vec![
-            json!({"id": 500, "conclusion": "failure", "head_sha": "abc"}),
-            json!({"id": 501, "conclusion": "success", "head_sha": "abc"}),
+            CiRun {
+                id: 500,
+                conclusion: Some("failure".into()),
+                head_sha: "abc".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 501,
+                conclusion: Some("success".into()),
+                head_sha: "abc".into(),
+                url: String::new(),
+            },
         ];
         let selected = select_runs_to_notify(&runs, Some(499));
         let deduped = dedupe_notifications_by_head_sha(&runs, &selected, None);
@@ -1019,10 +1111,19 @@ mod tests {
 
     #[test]
     fn test_dedupe_skips_already_notified_sha() {
-        use serde_json::json;
         let runs = vec![
-            json!({"id": 600, "conclusion": "success", "head_sha": "aaa"}),
-            json!({"id": 601, "conclusion": "success", "head_sha": "bbb"}),
+            CiRun {
+                id: 600,
+                conclusion: Some("success".into()),
+                head_sha: "aaa".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 601,
+                conclusion: Some("success".into()),
+                head_sha: "bbb".into(),
+                url: String::new(),
+            },
         ];
         let selected = select_runs_to_notify(&runs, Some(599));
         let deduped = dedupe_notifications_by_head_sha(&runs, &selected, Some("aaa"));
@@ -1032,10 +1133,19 @@ mod tests {
 
     #[test]
     fn test_different_head_sha_triggers_new_notification() {
-        use serde_json::json;
         let runs = vec![
-            json!({"id": 600, "conclusion": "success", "head_sha": "aaa"}),
-            json!({"id": 601, "conclusion": "success", "head_sha": "bbb"}),
+            CiRun {
+                id: 600,
+                conclusion: Some("success".into()),
+                head_sha: "aaa".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 601,
+                conclusion: Some("success".into()),
+                head_sha: "bbb".into(),
+                url: String::new(),
+            },
         ];
         let selected = select_runs_to_notify(&runs, Some(599));
         let deduped = dedupe_notifications_by_head_sha(&runs, &selected, None);
@@ -1283,15 +1393,26 @@ mod tests {
 
     /// Mock CI provider for testing ci_check_repo state machine without HTTP.
     struct MockCiProvider {
-        runs_response: Mutex<Option<CiRunsResponse>>,
+        poll_result: Mutex<Option<CiPollResult>>,
         pr_state: Mutex<PrState>,
         failure_summary: Mutex<String>,
     }
 
     impl MockCiProvider {
-        fn new(status: u16, body: serde_json::Value) -> Self {
+        fn with_runs(runs: Vec<CiRun>) -> Self {
             Self {
-                runs_response: Mutex::new(Some(CiRunsResponse { status, body })),
+                poll_result: Mutex::new(Some(CiPollResult::Runs(runs))),
+                pr_state: Mutex::new(PrState::Open),
+                failure_summary: Mutex::new("Build / Test".to_string()),
+            }
+        }
+
+        fn with_api_error(status: u16, message: &str) -> Self {
+            Self {
+                poll_result: Mutex::new(Some(CiPollResult::ApiError {
+                    status,
+                    message: message.to_string(),
+                })),
                 pr_state: Mutex::new(PrState::Open),
                 failure_summary: Mutex::new("Build / Test".to_string()),
             }
@@ -1305,8 +1426,8 @@ mod tests {
 
     #[async_trait::async_trait]
     impl CiProvider for MockCiProvider {
-        async fn poll_runs(&self, _repo: &str, _branch: &str) -> anyhow::Result<CiRunsResponse> {
-            Ok(self.runs_response.lock().unwrap().take().unwrap())
+        async fn poll_runs(&self, _repo: &str, _branch: &str) -> anyhow::Result<CiPollResult> {
+            Ok(self.poll_result.lock().unwrap().take().unwrap())
         }
         async fn check_pr_terminal(&self, _repo: &str, _branch: &str) -> PrState {
             let mut guard = self.pr_state.lock().unwrap();
@@ -1370,10 +1491,12 @@ mod tests {
     #[test]
     fn mock_success_run_updates_watch_state() {
         let dir = tmp_dir("mock-success");
-        let body = serde_json::json!({
-            "workflow_runs": [{"id": 100, "conclusion": "success", "head_sha": "abc", "html_url": "https://example.com/100"}]
-        });
-        let provider = MockCiProvider::new(200, body);
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 100,
+            conclusion: Some("success".into()),
+            head_sha: "abc".into(),
+            url: "https://example.com/100".into(),
+        }]);
         run_ci_check(&dir, &base_watch(), &provider).unwrap();
 
         // Watch file should be updated with last_run_id and head_sha
@@ -1396,10 +1519,12 @@ mod tests {
     #[test]
     fn mock_failure_run_includes_detail() {
         let dir = tmp_dir("mock-failure");
-        let body = serde_json::json!({
-            "workflow_runs": [{"id": 200, "conclusion": "failure", "head_sha": "def", "html_url": "https://example.com/200"}]
-        });
-        let provider = MockCiProvider::new(200, body);
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 200,
+            conclusion: Some("failure".into()),
+            head_sha: "def".into(),
+            url: "https://example.com/200".into(),
+        }]);
         run_ci_check(&dir, &base_watch(), &provider).unwrap();
 
         // Check inbox contains failure detail
@@ -1421,8 +1546,7 @@ mod tests {
     #[test]
     fn mock_api_error_propagates() {
         let dir = tmp_dir("mock-api-err");
-        let body = serde_json::json!({"message": "rate limit exceeded"});
-        let provider = MockCiProvider::new(403, body);
+        let provider = MockCiProvider::with_api_error(403, "GH API 403: rate limit exceeded");
         let result = run_ci_check(&dir, &base_watch(), &provider);
         assert!(result.is_err(), "API error must propagate");
         let err = result.unwrap_err().to_string();
@@ -1441,8 +1565,7 @@ mod tests {
         std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
 
         // Provider says PR is terminal — runs response doesn't matter
-        let body = serde_json::json!({"workflow_runs": []});
-        let provider = MockCiProvider::new(200, body).with_pr_terminal();
+        let provider = MockCiProvider::with_runs(vec![]).with_pr_terminal();
 
         let registry: AgentRegistry =
             Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
@@ -1476,8 +1599,7 @@ mod tests {
     #[test]
     fn mock_no_runs_preserves_watch() {
         let dir = tmp_dir("mock-no-runs");
-        let body = serde_json::json!({"workflow_runs": []});
-        let provider = MockCiProvider::new(200, body);
+        let provider = MockCiProvider::with_runs(vec![]);
         run_ci_check(&dir, &base_watch(), &provider).unwrap();
 
         let watch_path = dir.join("ci-watches").join(watch_filename("o/r", "feat"));
@@ -1492,12 +1614,12 @@ mod tests {
         let mut watch = base_watch();
         watch["head_sha"] = serde_json::json!("old123");
         watch["last_run_id"] = serde_json::json!(50);
-        let body = serde_json::json!({
-            "workflow_runs": [
-                {"id": 51, "conclusion": "success", "head_sha": "new456", "html_url": "https://example.com/51"}
-            ]
-        });
-        let provider = MockCiProvider::new(200, body);
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 51,
+            conclusion: Some("success".into()),
+            head_sha: "new456".into(),
+            url: "https://example.com/51".into(),
+        }]);
         run_ci_check(&dir, &watch, &provider).unwrap();
 
         let watch_path = dir.join("ci-watches").join(watch_filename("o/r", "feat"));


### PR DESCRIPTION
## Problem

`ci_watch.rs` hard-coded GitHub REST API calls (3 endpoints: runs poll, PR terminal check, failure summary) block multi-provider support per strategic decision `d-20260425080249077056-10`. PR-AB audit (53172b8) confirmed this is the sole runtime GitHub coupling.

## Solution

Introduce `CiProvider` trait abstracting CI-server-specific HTTP calls:

- `poll_runs(repo, branch)` — poll workflow/pipeline runs
- `check_pr_terminal(repo, branch)` — check PR merged/closed state
- `fetch_failure_summary(repo, run_id)` — get first failed job/step
- `token_warning()` — auth warning for MCP response

`GitHubCiProvider` wraps the existing reqwest + GitHub REST logic. `ci_check_repo` now takes `&dyn CiProvider`. `check_ci_watches` creates the provider via a factory closure for testability.

### New types
- `CiProvider` trait (async-trait)
- `GitHubCiProvider` struct (default impl)
- `CiRunsResponse` / `PrState` response types
- `MockCiProvider` (test-only)

### What did NOT change
- `watch_ci` / `unwatch_ci` MCP tool schema — zero external behavior change
- All 39 existing ci_watch tests pass unchanged
- `github_token_warning_from_env()` still used by MCP handler directly

## Testing

- 6 new MockCiProvider state-machine tests: success run, failure with detail, API error propagation, PR terminal auto-clear, no-runs preservation, force-push tracking reset
- 45 total ci_watch tests pass
- `cargo clippy --all-targets --features tray -- -D warnings` clean
- 1 pre-existing test failure on main (`request_information_does_not_emit_fleet_event`) — unrelated to this PR

## Out of scope (per task spec)
- No GitLab/Gitea/Buildkite provider impl
- No provider switching mechanism
- No MCP API signature changes