### PR TITLE
sprint13: OutMsg.attachment field + adapter skeleton (PR-AE1)

### DIFF
--- a/src/channel/event.rs
+++ b/src/channel/event.rs
@@ -83,16 +83,46 @@ pub struct MsgPayload {
 
 /// Outbound message — the payload passed to `Channel::send` / `Channel::edit`.
 /// TODO: expand with buttons, attachments, reply-to once adapters consume it.
-#[derive(Debug, Clone, Default)]
+/// Kind of media attachment.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentKind {
+    Photo,
+    Voice,
+    Document,
+    Video,
+    Sticker,
+}
+
+/// Media attachment for outbound/inbound messages.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Attachment {
+    pub kind: AttachmentKind,
+    pub path: std::path::PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caption: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct OutMsg {
     pub text: String,
-    // TODO(T1b+): buttons, attachments, reply_to, parse mode override.
+    /// Optional media attachment. When present, adapters that support media
+    /// will send the attachment; others fall back to text-only with a warning.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attachment: Option<Attachment>,
 }
 
 impl OutMsg {
     /// Shorthand for a plain-text outbound message.
     pub fn text(t: impl Into<String>) -> Self {
-        Self { text: t.into() }
+        Self {
+            text: t.into(),
+            attachment: None,
+        }
     }
 }
 
@@ -124,5 +154,46 @@ mod tests {
     fn out_msg_text_helper() {
         let m = OutMsg::text("hello");
         assert_eq!(m.text, "hello");
+        assert!(m.attachment.is_none());
+    }
+
+    #[test]
+    fn out_msg_with_attachment_roundtrip() {
+        let attachment = Attachment {
+            kind: AttachmentKind::Photo,
+            path: std::path::PathBuf::from("/tmp/photo.jpg"),
+            mime: Some("image/jpeg".into()),
+            caption: Some("test photo".into()),
+            size_bytes: Some(12345),
+        };
+        let msg = OutMsg {
+            text: "see attached".into(),
+            attachment: Some(attachment),
+        };
+        let json = serde_json::to_string(&msg).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed["text"], "see attached");
+        assert_eq!(parsed["attachment"]["kind"], "photo");
+        assert_eq!(parsed["attachment"]["path"], "/tmp/photo.jpg");
+        assert_eq!(parsed["attachment"]["mime"], "image/jpeg");
+    }
+
+    #[test]
+    fn out_msg_without_attachment_backwards_compat() {
+        // Old JSONL without attachment field must deserialize with attachment=None
+        let old_json = r#"{"text":"hello"}"#;
+        let msg: OutMsg = serde_json::from_str(old_json).expect("deserialize old format");
+        assert_eq!(msg.text, "hello");
+        assert!(msg.attachment.is_none());
+    }
+
+    #[test]
+    fn out_msg_text_only_skips_attachment_in_serialization() {
+        let msg = OutMsg::text("plain");
+        let json = serde_json::to_string(&msg).expect("serialize");
+        assert!(
+            !json.contains("attachment"),
+            "None attachment must be skipped: {json}"
+        );
     }
 }

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -1509,8 +1509,14 @@ impl crate::channel::Channel for TelegramChannel {
     fn send(
         &self,
         _binding: &crate::channel::BindingRef,
-        _msg: crate::channel::OutMsg,
+        msg: crate::channel::OutMsg,
     ) -> anyhow::Result<crate::channel::MsgRef> {
+        // TODO(Phase 3): wire real sendPhoto/sendVoice/sendDocument when attachment present
+        if msg.attachment.is_some() {
+            tracing::warn!(
+                "attachment not yet wired for channel telegram; falling back to text path"
+            );
+        }
         // Current call sites still use the `try_telegram_reply` free fn.
         // The trait-based send path lands with the dispatcher in T2.
         anyhow::bail!("TelegramChannel::send not wired yet — use try_telegram_reply")


### PR DESCRIPTION
## Problem
Per d-20260425101114174249-11 channel-extension strategic, OutMsg is text-only blocking outbound media support; PR-AC audit (8a3b9cf) confirmed OutMsg.text only with no attachment field.

## Solution
Introduce Attachment struct + AttachmentKind enum; add OutMsg.attachment Option field with serde backwards compat (default + skip_if_none); adapters log warn + fall back to text path when attachment present (Phase 3 will wire real sendPhoto/sendVoice/sendDocument).

### Attachment struct
AttachmentKind: Photo/Voice/Document/Video/Sticker (typed enum, not magic string)
Fields: kind, path, mime?, caption?, size_bytes?

### Tests (3)
- out_msg_with_attachment_roundtrip: serialize + deserialize with attachment
- out_msg_without_attachment_backwards_compat: old JSONL without field → None
- out_msg_text_only_skips_attachment_in_serialization: None not serialized

944 tests pass (1 pre-existing flaky), clippy(tray)/fmt clean.