### PR TITLE
test(hygiene): add fleet_test_guard() to env-sensitive tests

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -2898,6 +2898,7 @@ instances:
 
     #[test]
     fn test_interrupt_handler_validates_target() {
+        let _g = fleet_test_guard();
         let home = tmp_home("interrupt-validate");
         std::env::set_var("AGEND_HOME", &home);
 
@@ -2916,6 +2917,7 @@ instances:
             err.contains("not reachable") || err.contains("API unavailable"),
             "valid target must reach inject path: {err}"
         );
+        std::env::remove_var("AGEND_HOME");
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
## Problem

PR #171 fixed `request_information_does_not_emit_fleet_event` but the broader AGEND_HOME env var race pattern still affects `test_interrupt_handler_validates_target` (flagged by reviewer in PR-AE1 verdict).

## Solution

Audited all 34 tests in `mcp::handlers::tests` that touch AGEND_HOME. Found **1 test** missing `fleet_test_guard()`:

| Test | Issue | Fix |
|---|---|---|
| `test_interrupt_handler_validates_target` (line 2900) | Sets `AGEND_HOME` without guard; races with parallel fleet tests | Added `fleet_test_guard()` + `AGEND_HOME` cleanup |

All other 33 env-sensitive tests already had `fleet_test_guard()`. No tests in `src/api/handlers/` touch `AGEND_HOME`.

## What Changed

- `src/mcp/handlers.rs`: 1 test modified (+2 lines), zero production code change

## Testing

- Target test: 5/5 stable
- Module (`mcp::handlers::tests`): 3/3 stable (49 pass each)
- Full suite (`cargo test --features tray`): 2/2 stable (958 pass, 0 fail each)
- `cargo fmt --check` + `cargo clippy --all-targets --features tray -- -D warnings` clean