### PR TITLE
refactor(channel): add create_topic+notify trait methods + collapse 4 leaks (PR-AE3)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -187,12 +187,12 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         size,
     ) {
         Ok(spawn_mode) => {
-            // Every API-level spawn gets a Telegram forum topic (no-op
-            // when the channel isn't configured — resolve_channel_only
-            // returns Err and the helper returns None). Previously only
-            // the MCP `create_instance` wrappers called this, so
-            // deploy_template-spawned agents silently lacked topics.
-            let topic_id = crate::channel::telegram::create_topic_for_instance(ctx.home, name);
+            // Every API-level spawn gets a channel topic (no-op when
+            // no channel is configured). Routes through the Channel trait
+            // so this handler is channel-agnostic.
+            let topic_id = crate::channel::active_channel()
+                .and_then(|ch| ch.create_topic(name).ok())
+                .map(|t| t.id);
             if let Some(n) = ctx.notifier {
                 let layout_hint = LayoutHint::parse(params["layout"].as_str().unwrap_or("tab"));
                 let spawner = params["spawner"]

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -140,11 +140,12 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
         ) {
             Ok(_) => {
                 tracing::info!(team = team_name, member = %inst_name, backend = %backend, "CREATE_TEAM spawn ok");
-                // Mirror handle_spawn: every successful spawn gets a
-                // Telegram topic so deploy_template (which routes team
-                // creation through this handler) doesn't have to know
-                // about topics. No-op when the channel isn't configured.
-                crate::channel::telegram::create_topic_for_instance(ctx.home, inst_name);
+                // Every successful spawn gets a channel topic so
+                // deploy_template doesn't have to know about topics.
+                // No-op when no channel is configured.
+                if let Some(ch) = crate::channel::active_channel() {
+                    let _ = ch.create_topic(inst_name);
+                }
                 spawned.push((inst_name.clone(), backend.clone()));
             }
             Err(e) => {

--- a/src/bootstrap/telegram_init.rs
+++ b/src/bootstrap/telegram_init.rs
@@ -15,10 +15,14 @@ use std::sync::Arc;
 /// token env var is set. Returns `None` otherwise (including when the channel
 /// block is missing — not an error).
 ///
-/// When the channel comes up, this also registers it as a
-/// [`UxEventSink`] on the process-wide `ux_sink_registry` so Stage B-UX
-/// `FleetEvent`s (emitted by MCP handlers) get rendered into the
-/// configured `fleet_binding` topic. See `docs/DESIGN-stage-b-ux.md` §4.1.
+/// When the channel comes up, this also:
+/// - Registers it as a [`UxEventSink`] on the process-wide `ux_sink_registry`
+///   so Stage B-UX `FleetEvent`s get rendered into the configured
+///   `fleet_binding` topic.
+/// - Registers it as the process-wide active channel via
+///   [`crate::channel::register_active_channel`] so call sites outside the
+///   adapter boundary can use trait methods (e.g. `create_topic`, `notify`)
+///   without importing Telegram-specific code.
 pub(super) fn init(config: &FleetConfig, home: &Path) -> Option<Arc<dyn Channel>> {
     let submit_keys: HashMap<String, String> = config
         .instances
@@ -30,13 +34,9 @@ pub(super) fn init(config: &FleetConfig, home: &Path) -> Option<Arc<dyn Channel>
         })
         .collect();
     let state = crate::channel::telegram::init_from_config(config, home, submit_keys)?;
-    // `init_from_config` already calls `start_polling` on the concrete
-    // state. Construct `Arc<TelegramChannel>` once and clone-upcast to
-    // BOTH `Arc<dyn Channel>` (returned to the caller, used by dispatch)
-    // AND `Arc<dyn UxEventSink>` (registered for Fleet-event fan-out).
-    // `Arc<dyn Channel>` cannot itself be cast to `Arc<dyn UxEventSink>`
-    // without nightly `trait_upcasting`; the concrete `Arc` is the bridge.
     let channel_concrete: Arc<TelegramChannel> = Arc::new(TelegramChannel::new(state));
     ux_sink_registry().register(channel_concrete.clone() as Arc<dyn UxEventSink>);
-    Some(channel_concrete as Arc<dyn Channel>)
+    let channel_dyn: Arc<dyn Channel> = channel_concrete as Arc<dyn Channel>;
+    crate::channel::register_active_channel(Arc::clone(&channel_dyn));
+    Some(channel_dyn)
 }

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -48,6 +48,66 @@ pub use ux_event::{select_action, FleetEvent, NoopUxSink, UxAction, UxEvent, UxE
 
 use crate::agent::AgentRegistry;
 use anyhow::Result;
+use std::sync::{Arc, OnceLock};
+
+// ---------------------------------------------------------------------------
+// Supporting types for trait methods added in PR-AE3
+// ---------------------------------------------------------------------------
+
+/// Error type for channel operations that may not be supported.
+#[derive(Debug)]
+pub enum ChannelError {
+    NotSupported(String),
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for ChannelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotSupported(op) => write!(f, "operation not supported: {op}"),
+            Self::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for ChannelError {}
+
+impl From<anyhow::Error> for ChannelError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Other(e)
+    }
+}
+
+/// Reference to a created topic / thread / channel.
+#[derive(Debug, Clone)]
+pub struct TopicRef {
+    pub id: String,
+    pub channel_kind: ChannelKind,
+}
+
+/// Severity level for channel notifications.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotifySeverity {
+    Info,
+    Warn,
+    Error,
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide active channel registry
+// ---------------------------------------------------------------------------
+
+static ACTIVE_CHANNEL: OnceLock<Arc<dyn Channel>> = OnceLock::new();
+
+/// Register the process-wide active channel. Called once during bootstrap.
+pub fn register_active_channel(channel: Arc<dyn Channel>) {
+    let _ = ACTIVE_CHANNEL.set(channel);
+}
+
+/// Get the process-wide active channel, if one has been registered.
+pub fn active_channel() -> Option<&'static Arc<dyn Channel>> {
+    ACTIVE_CHANNEL.get()
+}
 
 /// Typed channel kind — replaces magic strings like `"telegram"`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -124,6 +184,27 @@ pub trait Channel: Send + Sync {
     /// cross-thread round-trip. Two-phase because adapters initialize
     /// during bootstrap (before the registry exists).
     fn attach_registry(&self, registry: AgentRegistry);
+
+    /// Create a per-instance discussion thread (Telegram forum topic /
+    /// Discord thread / Slack channel).
+    /// Default: `Err(ChannelError::NotSupported)` so channels without the
+    /// concept opt out gracefully.
+    fn create_topic(&self, _name: &str) -> std::result::Result<TopicRef, ChannelError> {
+        Err(ChannelError::NotSupported("create_topic".into()))
+    }
+
+    /// Send a notification (stall warning, system event) to an instance's
+    /// channel. `silent` suppresses push/vibrate when the platform supports it.
+    /// Default: `Err(ChannelError::NotSupported)`.
+    fn notify(
+        &self,
+        _instance: &str,
+        _severity: NotifySeverity,
+        _message: &str,
+        _silent: bool,
+    ) -> std::result::Result<(), ChannelError> {
+        Err(ChannelError::NotSupported("notify".into()))
+    }
 }
 
 /// Options passed to `Channel::create_binding`. Platform-specific hints live
@@ -135,4 +216,116 @@ pub struct BindingOpts {
     pub display_name: Option<String>,
     /// Free-form platform hints. The adapter decides what keys it honors.
     pub extra: std::collections::HashMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mock channel that hits the default `Err(NotSupported)` for both
+    /// `create_topic` and `notify`. Exercises the opt-out path that
+    /// channels without topic/notify support follow.
+    struct MockChannel {
+        caps: ChannelCapabilities,
+    }
+
+    impl MockChannel {
+        fn new() -> Self {
+            Self {
+                caps: ChannelCapabilities::default(),
+            }
+        }
+    }
+
+    impl Channel for MockChannel {
+        fn kind(&self) -> &'static str {
+            "mock"
+        }
+        fn caps(&self) -> &ChannelCapabilities {
+            &self.caps
+        }
+        fn poll_event(&self) -> Option<ChannelEvent> {
+            None
+        }
+        fn send(&self, _: &BindingRef, _: OutMsg) -> Result<MsgRef> {
+            anyhow::bail!("mock")
+        }
+        fn edit(&self, _: &MsgRef, _: OutMsg) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn delete(&self, _: &MsgRef) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn create_binding(&self, _: &str, _: BindingOpts) -> Result<BindingRef> {
+            anyhow::bail!("mock")
+        }
+        fn remove_binding(&self, _: &BindingRef) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn has_binding(&self, _: &str) -> bool {
+            false
+        }
+        fn record_binding(&self, _: &str, _: BindingRef, _: String) {}
+        fn take_binding(&self, _: &str) -> Option<BindingRef> {
+            None
+        }
+        fn attach_registry(&self, _: crate::agent::AgentRegistry) {}
+    }
+
+    #[test]
+    fn default_create_topic_returns_not_supported() {
+        let ch = MockChannel::new();
+        let err = ch.create_topic("test").expect_err("should be NotSupported");
+        assert!(
+            matches!(err, ChannelError::NotSupported(_)),
+            "expected NotSupported, got: {err}"
+        );
+        assert!(err.to_string().contains("create_topic"));
+    }
+
+    #[test]
+    fn default_notify_returns_not_supported() {
+        let ch = MockChannel::new();
+        let err = ch
+            .notify("inst", NotifySeverity::Warn, "msg", false)
+            .expect_err("should be NotSupported");
+        assert!(
+            matches!(err, ChannelError::NotSupported(_)),
+            "expected NotSupported, got: {err}"
+        );
+        assert!(err.to_string().contains("notify"));
+    }
+
+    #[test]
+    fn channel_error_display() {
+        let ns = ChannelError::NotSupported("op".into());
+        assert_eq!(ns.to_string(), "operation not supported: op");
+
+        let other = ChannelError::Other(anyhow::anyhow!("boom"));
+        assert_eq!(other.to_string(), "boom");
+    }
+
+    #[test]
+    fn channel_error_from_anyhow() {
+        let err: ChannelError = anyhow::anyhow!("test").into();
+        assert!(matches!(err, ChannelError::Other(_)));
+    }
+
+    #[test]
+    fn topic_ref_fields() {
+        let tr = TopicRef {
+            id: "42".into(),
+            channel_kind: ChannelKind::Telegram,
+        };
+        assert_eq!(tr.id, "42");
+        assert_eq!(tr.channel_kind, ChannelKind::Telegram);
+    }
+
+    #[test]
+    fn notify_severity_variants() {
+        // Ensure all variants exist and are distinct.
+        assert_ne!(NotifySeverity::Info, NotifySeverity::Warn);
+        assert_ne!(NotifySeverity::Warn, NotifySeverity::Error);
+        assert_ne!(NotifySeverity::Info, NotifySeverity::Error);
+    }
 }

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -1596,6 +1596,38 @@ impl crate::channel::Channel for TelegramChannel {
         let mut s = lock_state(&self.state);
         s.registry = Some(registry);
     }
+
+    fn create_topic(
+        &self,
+        name: &str,
+    ) -> std::result::Result<crate::channel::TopicRef, crate::channel::ChannelError> {
+        let home = lock_state(&self.state).home.clone();
+        match create_topic_for_instance(&home, name) {
+            Some(tid) => Ok(crate::channel::TopicRef {
+                id: tid.to_string(),
+                channel_kind: crate::channel::ChannelKind::Telegram,
+            }),
+            None => Err(crate::channel::ChannelError::Other(anyhow::anyhow!(
+                "failed to create topic for {name}"
+            ))),
+        }
+    }
+
+    fn notify(
+        &self,
+        instance: &str,
+        _severity: crate::channel::NotifySeverity,
+        message: &str,
+        silent: bool,
+    ) -> std::result::Result<(), crate::channel::ChannelError> {
+        let home = lock_state(&self.state).home.clone();
+        if silent {
+            notify_telegram_silent(&home, instance, message);
+        } else {
+            notify_telegram(&home, instance, message);
+        }
+        Ok(())
+    }
 }
 
 // ─── UxEventSink: capability-gated degradation ────────────────────────
@@ -2640,5 +2672,71 @@ instances:
 
         std::env::remove_var("PR57_ROUND2_FAKE_TOKEN");
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// TelegramChannel::create_topic delegates to `create_topic_for_instance`.
+    /// Without a fleet.yaml the helper returns None → the trait method
+    /// returns `ChannelError::Other`. This exercises the wiring without
+    /// needing a live bot.
+    #[test]
+    fn telegram_channel_create_topic_returns_error_without_config() {
+        use crate::channel::Channel;
+        let home = tmp_home("create_topic_no_config");
+        let state = TelegramState::new_for_contract_test(
+            -1,
+            HashMap::new(),
+            home.clone(),
+            HashMap::new(),
+            None,
+        );
+        let channel = TelegramChannel::new(Arc::new(Mutex::new(state)));
+        let result = channel.create_topic("test-agent");
+        assert!(result.is_err(), "create_topic must fail without fleet.yaml");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// TelegramChannel::notify delegates to `notify_telegram` /
+    /// `notify_telegram_silent`. Without a fleet.yaml the notify helpers
+    /// return early (no-op). The trait method returns Ok(()) because the
+    /// underlying helpers are fire-and-forget.
+    #[test]
+    fn telegram_channel_notify_succeeds_without_config() {
+        use crate::channel::{Channel, NotifySeverity};
+        let home = tmp_home("notify_no_config");
+        let state = TelegramState::new_for_contract_test(
+            -1,
+            HashMap::new(),
+            home.clone(),
+            HashMap::new(),
+            None,
+        );
+        let channel = TelegramChannel::new(Arc::new(Mutex::new(state)));
+        // notify delegates to fire-and-forget helpers that silently no-op
+        // when fleet.yaml is missing — so the trait method returns Ok.
+        let result = channel.notify("test-agent", NotifySeverity::Warn, "stall", false);
+        assert!(result.is_ok(), "notify should succeed (fire-and-forget)");
+        let result_silent = channel.notify("test-agent", NotifySeverity::Info, "recovered", true);
+        assert!(result_silent.is_ok(), "silent notify should succeed");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Verify that TelegramChannel's create_topic returns a TopicRef with
+    /// the correct channel_kind when it would succeed. We can't test the
+    /// happy path without a live bot, but we can verify the type shape
+    /// via the trait signature.
+    #[test]
+    fn telegram_channel_trait_methods_are_object_safe() {
+        let state = TelegramState::new_for_contract_test(
+            -1,
+            HashMap::new(),
+            PathBuf::from("/tmp"),
+            HashMap::new(),
+            None,
+        );
+        let channel = TelegramChannel::new(Arc::new(Mutex::new(state)));
+        // Verify the channel can be used as a trait object with the new methods.
+        let dyn_channel: &dyn crate::channel::Channel = &channel;
+        let _ = dyn_channel.create_topic("test");
+        let _ = dyn_channel.notify("test", crate::channel::NotifySeverity::Warn, "msg", false);
     }
 }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1,5 +1,5 @@
 //! Per-agent supervisor loop — detects pre-ready interactive stalls and
-//! pushes a vterm tail to the agent's Telegram topic.
+//! pushes a vterm tail to the agent's channel topic.
 //!
 //! Runs as a background thread spawned from both daemon mode
 //! (`start_daemon`) and app mode (`app::run`). Both call paths create agents
@@ -9,10 +9,10 @@
 //!
 //! Detection logic lives in `health::HealthTracker::check_awaiting_operator`
 //! and the transition in `state::StateTracker::set_awaiting_operator`. This
-//! module is the plumbing that glues them to Telegram notifications.
+//! module is the plumbing that glues them to channel notifications.
 
 use crate::agent::{self, AgentRegistry};
-use crate::channel::telegram::{notify_telegram, notify_telegram_silent};
+use crate::channel::NotifySeverity;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
@@ -123,11 +123,19 @@ fn tick(home: &std::path::Path, registry: &AgentRegistry) {
         match action {
             Some(NoticeAction::Stall { tail, silent_secs }) => {
                 let msg = format_stall_notice(&name, &tail, silent_secs);
-                notify_telegram(home, &name, &msg);
+                if let Some(ch) = crate::channel::active_channel() {
+                    let _ = ch.notify(&name, NotifySeverity::Warn, &msg, false);
+                } else {
+                    tracing::debug!(agent = %name, "no active channel — stall notice dropped");
+                }
             }
             Some(NoticeAction::Recovered) => {
                 let msg = format_recovery_notice(&name);
-                notify_telegram_silent(home, &name, &msg);
+                if let Some(ch) = crate::channel::active_channel() {
+                    let _ = ch.notify(&name, NotifySeverity::Info, &msg, true);
+                } else {
+                    tracing::debug!(agent = %name, "no active channel — recovery notice dropped");
+                }
             }
             None => {}
         }


### PR DESCRIPTION
## Summary

Sprint 13 channel-extension Phase 1 part (c) — adds Channel trait methods and collapses remaining outside-boundary leaks.

### Changes

**New trait methods on `Channel`:**
- `create_topic(name) -> Result<TopicRef, ChannelError>` — create a per-instance discussion thread
- `notify(instance, severity, message, silent) -> Result<(), ChannelError>` — send a notification to an instance's channel

Both have default `Err(ChannelError::NotSupported)` so channels without the concept opt out gracefully.

**Supporting types:**
- `ChannelError` — `NotSupported(String)` + `Other(anyhow::Error)`
- `TopicRef` — `{ id: String, channel_kind: ChannelKind }`
- `NotifySeverity` — `Info` / `Warn` / `Error`

**Process-wide channel registry:**
- `register_active_channel()` / `active_channel()` via `OnceLock` — enables channel access outside adapter boundary without threading references through every call site

**TelegramChannel impl:**
- `create_topic` delegates to existing `create_topic_for_instance`
- `notify` delegates to existing `notify_telegram` / `notify_telegram_silent`

**4 outside-boundary leaks collapsed:**
1. `api/handlers/instance.rs` — `crate::channel::telegram::create_topic_for_instance` → `active_channel().create_topic()`
2. `api/handlers/team.rs` — same pattern
3. `bootstrap/telegram_init.rs` — now registers channel via `register_active_channel()` during init
4. `daemon/supervisor.rs` — `notify_telegram`/`notify_telegram_silent` → `active_channel().notify()` with graceful fallback to `tracing::debug`

### Testing
- Unit tests for MockChannel default NotSupported behavior
- Unit tests for ChannelError display/conversion
- TelegramChannel create_topic/notify tests (no-config graceful failure)
- Object safety verification (dyn Channel with new methods)
- All existing tests pass (968 unit + 9 integration + 28 MCP char + 33 MCP roundtrip)
- `cargo fmt --check` clean
- `cargo clippy --all-targets --features tray -- -D warnings` clean

### Scope
- ✅ Trait methods + supporting types
- ✅ TelegramChannel impl
- ✅ 4 leak collapse
- ✅ Unit tests
- ❌ ChannelCapabilities trait (Phase 4)
- ❌ Discord/Slack impl
- ❌ Inbound/outbound media

**Strategic decision:** d-20260425101114174249-11
**Audit ref:** docs/CHANNEL-AUDIT-COMMS.md
**Base:** main (57c2f3d, includes PR-AE2 1c2133e)