### PR TITLE
refactor(daemon): crash-respawn notify → active_channel().notify (PR-AE4)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -9,7 +9,7 @@ mod tui_bridge;
 pub(crate) mod watchdog;
 
 use crate::agent::{self, AgentRegistry};
-use crate::channel::telegram::notify_telegram;
+use crate::channel::NotifySeverity;
 use ci_watch::check_ci_watches;
 use cron_tick::check_schedules;
 pub use tui_bridge::serve_agent_tui;
@@ -604,7 +604,11 @@ fn run_core(
             };
             tracing::warn!(agent = %crashed_name, %state, "notifying");
             let msg = format!("[health] {crashed_name}: {state}");
-            notify_telegram(home, &crashed_name, &msg);
+            if let Some(ch) = crate::channel::active_channel() {
+                let _ = ch.notify(&crashed_name, NotifySeverity::Error, &msg, false);
+            } else {
+                tracing::debug!(agent = %crashed_name, "no active channel for crash notification");
+            }
         }
 
         if should_respawn {


### PR DESCRIPTION
## Summary

Follow-up to PR-AE3 (#173) — collapses one remaining sibling leak caught by reviewer-2 during PR-AE3 verify.

### Change

`daemon/mod.rs:607`: `notify_telegram(home, &crashed_name, &msg)` → `active_channel().notify(&crashed_name, NotifySeverity::Error, &msg, false)`

Same pattern as supervisor.rs stall path collapsed in PR-AE3. Severity is `Error` (crash > stall). Graceful fallback to `tracing::debug` when no channel configured.

### Testing
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -- -D warnings` ✅  
- `cargo test --features tray` ✅ (all tests pass)

**1 file, +6/-2**