### PR TITLE
sprint13: inbound media handling for telegram (PR-AF)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -80,6 +80,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             timestamp: chrono::Utc::now().to_rfc3339(),
             channel: None,
             delivery_mode: None,
+            attachments: vec![],
         }
     };
     let _ = crate::inbox::enqueue(ctx.home, target, msg.clone());

--- a/src/channel/event.rs
+++ b/src/channel/event.rs
@@ -84,7 +84,7 @@ pub struct MsgPayload {
 /// Outbound message — the payload passed to `Channel::send` / `Channel::edit`.
 /// TODO: expand with buttons, attachments, reply-to once adapters consume it.
 /// Kind of media attachment.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AttachmentKind {
     Photo,
@@ -105,6 +105,8 @@ pub struct Attachment {
     pub caption: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_filename: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -165,6 +167,7 @@ mod tests {
             mime: Some("image/jpeg".into()),
             caption: Some("test photo".into()),
             size_bytes: Some(12345),
+            original_filename: None,
         };
         let msg = OutMsg {
             text: "see attached".into(),

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -319,9 +319,68 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
     }
 
     let text = match msg.text() {
-        Some(t) => t,
-        None => return,
+        Some(t) => t.to_string(),
+        None => msg.caption().unwrap_or("").to_string(),
     };
+
+    // Extract inbound attachment metadata (photo/voice/document/video/sticker).
+    // Download happens later after topic resolution provides instance_name.
+    struct InboundFile<'a> {
+        file_id: &'a str,
+        kind: crate::channel::event::AttachmentKind,
+        mime: Option<String>,
+        size: Option<u64>,
+        filename: Option<String>,
+    }
+    let inbound_file: Option<InboundFile<'_>> = {
+        use crate::channel::event::AttachmentKind;
+        if let Some(sizes) = msg.photo() {
+            sizes.last().map(|p| InboundFile {
+                file_id: p.file.id.as_str(),
+                kind: AttachmentKind::Photo,
+                mime: None,
+                size: Some(p.file.size as u64),
+                filename: None,
+            })
+        } else if let Some(doc) = msg.document() {
+            Some(InboundFile {
+                file_id: doc.file.id.as_str(),
+                kind: AttachmentKind::Document,
+                mime: doc.mime_type.as_ref().map(|m| m.to_string()),
+                size: Some(doc.file.size as u64),
+                filename: doc.file_name.clone(),
+            })
+        } else if let Some(voice) = msg.voice() {
+            Some(InboundFile {
+                file_id: voice.file.id.as_str(),
+                kind: AttachmentKind::Voice,
+                mime: voice.mime_type.as_ref().map(|m| m.to_string()),
+                size: Some(voice.file.size as u64),
+                filename: None,
+            })
+        } else if let Some(video) = msg.video() {
+            Some(InboundFile {
+                file_id: video.file.id.as_str(),
+                kind: AttachmentKind::Video,
+                mime: video.mime_type.as_ref().map(|m| m.to_string()),
+                size: Some(video.file.size as u64),
+                filename: video.file_name.clone(),
+            })
+        } else {
+            msg.sticker().map(|sticker| InboundFile {
+                file_id: sticker.file.id.as_str(),
+                kind: AttachmentKind::Sticker,
+                mime: None,
+                size: Some(sticker.file.size as u64),
+                filename: None,
+            })
+        }
+    };
+
+    // If no text and no attachment, nothing to process.
+    if text.is_empty() && inbound_file.is_none() {
+        return;
+    }
 
     let sender_id: Option<i64> = msg.from.as_ref().map(|u| u.id.0 as i64);
     let username = msg
@@ -432,6 +491,26 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         serde_json::json!(msg.id.0),
     );
 
+    // Download inbound attachment if present.
+    let attachments: Vec<crate::channel::event::Attachment> = if let Some(f) = inbound_file {
+        match try_download_attachment(&home, &instance_name, f.file_id) {
+            Ok(local_path) => vec![crate::channel::event::Attachment {
+                kind: f.kind,
+                path: std::path::PathBuf::from(&local_path),
+                mime: f.mime,
+                caption: msg.caption().map(String::from),
+                size_bytes: f.size,
+                original_filename: f.filename,
+            }],
+            Err(e) => {
+                tracing::warn!(file_id = f.file_id, error = %e, "inbound attachment download failed");
+                vec![]
+            }
+        }
+    } else {
+        vec![]
+    };
+
     // Enqueue in inbox
     let msg_obj = InboxMessage {
         schema_version: 0,
@@ -449,6 +528,7 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         timestamp: chrono::Utc::now().to_rfc3339(),
         channel: Some(crate::channel::ChannelKind::Telegram),
         delivery_mode: None,
+        attachments,
     };
     let _ = inbox::enqueue(&home, &instance_name, msg_obj);
 
@@ -457,7 +537,7 @@ fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         &home,
         &instance_name,
         &inbox::NotifySource::Channel(username, crate::channel::ChannelKind::Telegram),
-        text,
+        &text,
     );
 
     // Emit UxEvent::UserMsgReceived so the channel adapter can react 👀.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -207,6 +207,7 @@ fn test_inbox(home: &Path) -> anyhow::Result<()> {
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 channel: None,
                 delivery_mode: None,
+                attachments: vec![],
             },
         )?;
     }

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -653,6 +653,7 @@ async fn ci_check_repo(
                     timestamp: chrono::Utc::now().to_rfc3339(),
                     channel: None,
                     delivery_mode: None,
+                    attachments: vec![],
                 },
             );
         }

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -131,6 +131,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     timestamp: now_utc.to_rfc3339(),
                     channel: None,
                     delivery_mode: None,
+                    attachments: vec![],
                 },
             );
             "ok_inbox"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -930,6 +930,7 @@ pub fn run_task_maintenance(home: &Path) {
                 force_meta: None,
                 correlation_id: None,
                 reviewed_head: None,
+                attachments: vec![],
             },
         );
     }
@@ -991,6 +992,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     thread_id: None,
                     parent_id: None,
                     task_id: None,
+                    attachments: vec![],
                 },
             );
         }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -113,6 +113,7 @@ mod tests {
                     thread_id: None,
                     parent_id: None,
                     task_id: None,
+                    attachments: vec![],
                 },
             );
         }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -199,6 +199,10 @@ pub struct InboxMessage {
     pub correlation_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reviewed_head: Option<String>,
+    /// Inbound media attachments (additive). Channel adapters download media
+    /// to a local path before enqueue. Empty for text-only messages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<crate::channel::event::Attachment>,
 }
 
 /// Metadata attached to a forced delegation (busy gate override).
@@ -690,6 +694,7 @@ pub fn deliver(
         timestamp: chrono::Utc::now().to_rfc3339(),
         channel: None,
         delivery_mode: None,
+        attachments: vec![],
     };
     let _ = enqueue(home, agent_name, msg);
     notify_agent(home, agent_name, source, text);
@@ -843,6 +848,7 @@ mod tests {
             timestamp: "2025-01-01T00:00:00Z".to_string(),
             channel: None,
             delivery_mode: None,
+            attachments: vec![],
         }
     }
 
@@ -973,6 +979,7 @@ mod tests {
             timestamp: "2025-06-15T12:30:00Z".to_string(),
             channel: None,
             delivery_mode: None,
+            attachments: vec![],
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1074,6 +1081,7 @@ mod tests {
             timestamp: "2025-01-01T00:00:00Z".to_string(),
             channel: None,
             delivery_mode: None,
+            attachments: vec![],
         };
         let json = serde_json::to_string(&msg).expect("serialize");
         let parsed: InboxMessage = serde_json::from_str(&json).expect("deserialize");
@@ -1100,6 +1108,7 @@ mod tests {
             timestamp: "2025-01-01T00:00:00Z".to_string(),
             channel: None,
             delivery_mode: None,
+            attachments: vec![],
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1689,6 +1698,7 @@ mod tests {
             thread_id: Some("thread-42".into()),
             parent_id: Some("m-0".into()),
             task_id: None,
+            attachments: vec![],
         };
         let json = serde_json::to_string(&msg).expect("ser");
         assert!(json.contains("thread_id"));
@@ -1736,6 +1746,7 @@ mod tests {
             thread_id: Some("t-100".into()),
             parent_id: Some("m-41".into()),
             task_id: None,
+            attachments: vec![],
         };
         let header = format_header(&msg);
         assert!(header.contains("[AGEND-MSG]"));
@@ -1766,6 +1777,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            attachments: vec![],
         };
         let header = format_header(&msg);
         assert!(header.contains("from=from:agent"));
@@ -1794,6 +1806,7 @@ mod tests {
             thread_id: Some("t\n1".into()),
             parent_id: None,
             task_id: None,
+            attachments: vec![],
         };
         let header = format_header(&msg);
         assert!(
@@ -1826,6 +1839,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            attachments: vec![],
         };
         let header = format_header(&msg);
         assert!(
@@ -1863,6 +1877,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            attachments: vec![],
         };
         let header = format_header(&msg);
         assert!(
@@ -1903,6 +1918,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            attachments: vec![],
         };
         let header = format_header(&msg);
         assert!(
@@ -2012,5 +2028,49 @@ mod tests {
             r#"{"schema_version":1,"from":"x","text":"y","timestamp":"2026-01-01T00:00:00Z"}"#;
         let legacy_msg: InboxMessage = serde_json::from_str(legacy).unwrap();
         assert_eq!(legacy_msg.channel, None);
+    }
+
+    #[test]
+    fn legacy_inbox_message_without_attachments_deserializes() {
+        // Old messages (pre-PR-AF) have no `attachments` field.
+        // serde(default) must fill Vec::new() so deserialization succeeds.
+        let legacy = r#"{"from":"user:op","text":"hello","timestamp":"2026-04-26T00:00:00Z"}"#;
+        let msg: InboxMessage = serde_json::from_str(legacy).unwrap();
+        assert!(msg.attachments.is_empty());
+    }
+
+    #[test]
+    fn inbox_message_with_attachment_roundtrips() {
+        use crate::channel::event::{Attachment, AttachmentKind};
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            from: "user:op".into(),
+            text: "see photo".into(),
+            kind: None,
+            timestamp: "2026-04-26T00:00:00Z".into(),
+            channel: None,
+            delivery_mode: None,
+            attachments: vec![Attachment {
+                kind: AttachmentKind::Photo,
+                path: "/tmp/photo.jpg".into(),
+                mime: Some("image/jpeg".into()),
+                caption: Some("test".into()),
+                size_bytes: Some(1234),
+                original_filename: None,
+            }],
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let back: InboxMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.attachments.len(), 1);
+        assert_eq!(back.attachments[0].kind, AttachmentKind::Photo);
+        assert_eq!(back.attachments[0].size_bytes, Some(1234));
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -978,6 +978,7 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
+            attachments: vec![],
         };
         let header = crate::inbox::format_header(&sample_msg);
 

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -191,6 +191,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         timestamp: chrono::Utc::now().to_rfc3339(),
                         channel: None,
                         delivery_mode: Some("inbox_fallback".to_string()),
+                        attachments: vec![],
                     };
                     let _ = crate::inbox::enqueue(&home, target, msg);
                     crate::inbox::notify_agent(
@@ -351,6 +352,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         kind: Some("task".to_string()),
                         timestamp: chrono::Utc::now().to_rfc3339(),
                         channel: None,
+                        attachments: vec![],
                     };
                     let _ = crate::inbox::enqueue(&home, target, inbox_msg);
                     crate::inbox::notify_agent(
@@ -472,6 +474,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                             kind: Some("report".to_string()),
                             timestamp: chrono::Utc::now().to_rfc3339(),
                             channel: None,
+                            attachments: vec![],
                         };
                         let _ = crate::inbox::enqueue(&home, target, inbox_msg);
                         crate::inbox::notify_agent(
@@ -934,6 +937,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                     timestamp: chrono::Utc::now().to_rfc3339(),
                     channel: None,
                     delivery_mode: None,
+                    attachments: vec![],
                 },
             );
             tracing::info!(%name, %reason, "replace_instance");
@@ -2394,6 +2398,7 @@ instances:
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 channel: None,
                 delivery_mode: None,
+                attachments: vec![],
             },
         );
 
@@ -2451,6 +2456,7 @@ instances:
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 channel: None,
                 delivery_mode: None,
+                attachments: vec![],
             },
         );
 
@@ -2617,6 +2623,7 @@ instances:
             correlation_id: None,
             reviewed_head: None,
             task_id: None,
+            attachments: vec![],
         };
         let inbox_dir = home.join("inbox");
         std::fs::create_dir_all(&inbox_dir).ok();

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -898,6 +898,7 @@ mod tests {
                     thread_id: None,
                     parent_id: None,
                     task_id: None,
+                    attachments: vec![],
                 },
             );
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -300,6 +300,7 @@ fn test_inbox(home: &Path) -> TestResult {
                 timestamp: "2024-01-01T00:00:00Z".into(),
                 channel: None,
                 delivery_mode: None,
+                attachments: vec![],
             },
         );
     }


### PR DESCRIPTION
## Problem

Per `docs/CHANNEL-AUDIT-COMMS.md` inbound media gap: telegram inbound photo/voice/document/video/sticker silently dropped at `handle_message` (line 321-324 early return on `msg.text() == None`). Operator daily uses telegram — media loss is direct UX gap.

## Solution

Typed `InboundAttachment` metadata via the existing `Attachment` struct (reused from PR-AE1). Telegram `handle_message` now extracts file_id from photo/voice/document/video/sticker, downloads to local path via existing `try_download_attachment`, and builds typed attachment in `InboxMessage`.

**Supersedes PR #54** text-append approach (`[attachment: file_id -> path]`) with typed metadata.

### Media kinds handled

| Kind | Source | Metadata extracted |
|---|---|---|
| Photo | `msg.photo().last()` | file_id, size |
| Document | `msg.document()` | file_id, mime, size, original_filename |
| Voice | `msg.voice()` | file_id, mime, size |
| Video | `msg.video()` | file_id, mime, size, original_filename |
| Sticker | `msg.sticker()` | file_id, size |

### Struct changes (all additive)

- `Attachment`: added `original_filename: Option<String>` (serde-default)
- `AttachmentKind`: added `PartialEq, Eq` derives
- `InboxMessage`: added `attachments: Vec<Attachment>` (serde-default, skip_serializing_if empty)

### Backwards compat

- Old `InboxMessage` JSON without `attachments` field deserializes fine (`#[serde(default)]`)
- Old `Attachment` JSON without `original_filename` deserializes fine
- Text-only messages: zero behavior change (`attachments: vec![]`)

## Testing

- 2 new tests: `legacy_inbox_message_without_attachments_deserializes` + `inbox_message_with_attachment_roundtrips`
- 970 passed, 0 failed
- `cargo fmt --check` + `cargo clippy --all-targets --features tray -- -D warnings` clean

## Out of scope

- Outbound media wiring (Phase 3)
- Discord/Slack adapters
- Album/multi-attachment per message