### PR TITLE
fix(telegram): collapse topic orphans in delete/replace_instance (PR-AI)

### DIFF
--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -1326,8 +1326,22 @@ pub fn try_telegram_edit(
     })
 }
 
+/// Reverse-lookup a topic_id for an instance from `topics.json`.
+/// Returns `None` if no mapping exists or the file is missing.
+pub fn lookup_topic_for_instance(home: &std::path::Path, instance_name: &str) -> Option<i32> {
+    let reg = load_topic_registry(home);
+    reg.into_iter()
+        .find(|(_, name)| name == instance_name)
+        .map(|(tid, _)| tid)
+}
+
 /// Create a forum topic for a new instance.
 pub fn create_topic_for_instance(home: &std::path::Path, instance_name: &str) -> Option<i32> {
+    // Idempotent: reuse existing topic from topics.json if present.
+    if let Some(tid) = lookup_topic_for_instance(home, instance_name) {
+        tracing::info!(instance = %instance_name, topic_id = tid, "reusing existing topic");
+        return Some(tid);
+    }
     let ch = resolve_channel_only_from(home).ok()?;
     match telegram_runtime().block_on(async {
         let bot = teloxide::Bot::new(&ch.token);
@@ -3091,5 +3105,60 @@ instances:
             err.to_string().contains("telegram bot not initialized"),
             "{err}"
         );
+    }
+
+    // ─── Topic orphan fix tests (Sprint 14 PR-AI) ─────────────────────
+
+    #[test]
+    fn lookup_topic_for_instance_finds_existing() {
+        let home = tmp_home("lookup_existing");
+        register_topic(&home, 42, "alice");
+        register_topic(&home, 99, "bob");
+        assert_eq!(lookup_topic_for_instance(&home, "alice"), Some(42));
+        assert_eq!(lookup_topic_for_instance(&home, "bob"), Some(99));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn lookup_topic_for_instance_returns_none_when_missing() {
+        let home = tmp_home("lookup_missing");
+        register_topic(&home, 42, "alice");
+        assert_eq!(lookup_topic_for_instance(&home, "nonexistent"), None);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn lookup_topic_for_instance_returns_none_when_no_file() {
+        let home = PathBuf::from("/tmp/agend-test-no-topics-json-12345");
+        assert_eq!(lookup_topic_for_instance(&home, "any"), None);
+    }
+
+    /// create_topic_for_instance must reuse an existing topic from
+    /// topics.json instead of creating a new one. Without a live bot
+    /// the API call would fail, so the test seeds topics.json and
+    /// verifies the early return path.
+    #[test]
+    fn create_topic_for_instance_reuses_existing_topic() {
+        let home = tmp_home("create_reuse");
+        register_topic(&home, 77, "reuse-agent");
+        // No fleet.yaml / no bot token → if it tried to create, it would
+        // return None. But the lookup-before-create path should return 77.
+        let result = create_topic_for_instance(&home, "reuse-agent");
+        assert_eq!(
+            result,
+            Some(77),
+            "must reuse existing topic, not create new"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// When no existing topic exists and no channel is configured,
+    /// create_topic_for_instance returns None (no bot to call).
+    #[test]
+    fn create_topic_for_instance_returns_none_without_config() {
+        let home = tmp_home("create_no_config");
+        let result = create_topic_for_instance(&home, "new-agent");
+        assert!(result.is_none(), "no config → no topic creation");
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -822,6 +822,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         .map(|r| (r.topic_id, r.working_directory))
                 })
                 .unwrap_or((None, None));
+            // Fallback: if fleet.yaml doesn't have topic_id (dynamically created
+            // instance), look up from topics.json on disk.
+            let topic_id = topic_id.or_else(|| telegram::lookup_topic_for_instance(&home, name));
 
             let _ = crate::api::call(
                 &home,
@@ -833,6 +836,8 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             // Delete the Telegram topic if one exists
             if let Some(tid) = topic_id {
                 telegram::delete_topic(&home, tid);
+            } else {
+                tracing::warn!(%name, "no topic_id found for delete_instance — possible orphan");
             }
             // Clean up working directory
             if let Some(ref wd) = working_dir {


### PR DESCRIPTION
## Summary

Fixes two independent bugs causing telegram topic orphans during instance lifecycle operations.

### Bug 1: delete_instance topic_id fallback chain
**Before**: Only queried `fleet.yaml` for `topic_id` — dynamically created instances (via MCP `create_instance`) had no `topic_id` in fleet.yaml, so their topics were never deleted.

**After**: Fallback chain: fleet.yaml → `topics.json` reverse lookup → warn if neither found.

### Bug 2: replace_instance topic reuse
**Before**: `create_topic_for_instance` unconditionally created a new topic on every call. After `replace_instance`, the respawned agent got a new topic while the old one remained orphaned.

**After**: `create_topic_for_instance` is now idempotent — checks `topics.json` first and reuses existing topic. Conversation history preserved across replace cycles.

### New helper
`lookup_topic_for_instance(home, name) -> Option<i32>` — reverse lookup from `topics.json` (topic_id → instance_name map).

### Testing
- 5 new unit tests (lookup existing/missing/no-file, create reuse, create no-config)
- All 990 existing tests pass
- fmt ✅ | clippy ✅ (both with and without `--features tray`)

**2 files, +74/-0**
**Scope decision**: d-20260426064522454811-1