### PR TITLE
sprint14: response channel matches source channel rule (PR-AJ)

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -306,6 +306,18 @@ This eliminates 1 hop (reviewer → orchestrator → merge → notify).
 | `update` | FYI, notification | no |
 | `query` | question, discussion | yes |
 
+### Response channel matches source channel
+
+Every agent must reply via the same channel the input arrived on:
+
+| Source signal | Reply mechanism |
+|---|---|
+| `(Reply using the reply tool, NOT direct text)` system hint | `reply` MCP tool (telegram) |
+| `[from:OTHER_AGENT_NAME]` prefix | `send_to_instance` MCP tool |
+| **Neither of the above** (operator typed in TUI) | **direct text** — do not use any tool |
+
+**Why**: the daemon does not intercept TUI stdin, so there is no hint. If the agent uses `reply` (telegram) when the operator typed in TUI, the response appears in telegram instead of the terminal — the operator waits forever in TUI. The reverse (direct text when input came from telegram) is equally broken.
+
 ## 5. CI integration
 
 ### Use `watch_ci` instead of manual polling

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -276,6 +276,16 @@ pub(crate) fn build_instructions_body(
     );
     content.push_str("- Verdict wording: VERIFIED / REJECTED / UNVERIFIED only\n");
 
+    // Response channel discipline — match reply mechanism to input source.
+    content.push_str("\n## Response channel discipline\n\n");
+    content.push_str(
+        "Reply via the same channel the input arrived on:\n\
+         - If you see `(Reply using the reply tool, NOT direct text)` → use the `reply` MCP tool\n\
+         - If you see `[from:AGENT_NAME]` prefix → use `send_to_instance`\n\
+         - If **neither hint is present** (operator typed in TUI) → respond with **direct text**, do NOT use any tool\n\n\
+         Mixing channels (e.g. telegram reply when operator typed in TUI) makes the response appear in the wrong place.\n",
+    );
+
     // Inbox message header handling — teaches agents to parse [AGEND-MSG] headers
     // injected by the daemon via PTY (S3-T1 format).
     content.push_str("\n## Inbox message handling\n\n");


### PR DESCRIPTION
## Problem

Operator reports agents replying via telegram when input came from TUI (or vice versa). Daemon cannot intercept TUI stdin to inject hints — this is prompt-level discipline, not infrastructure.

## Solution

Pure docs + template change, zero production code.

### FLEET-DEV-PROTOCOL-v1.md
Added §4 subsection "Response channel matches source channel" with explicit matching table:

| Source signal | Reply mechanism |
|---|---|
| `(Reply using the reply tool...)` hint | `reply` MCP tool (telegram) |
| `[from:AGENT_NAME]` prefix | `send_to_instance` MCP tool |
| **Neither** (TUI input) | **direct text** — no tool |

### src/instructions.rs
Added "Response channel discipline" section to `build_instructions_body` template. All backends pick up the rule on next instructions regen.

## What Changed
- `docs/FLEET-DEV-PROTOCOL-v1.md`: +12 lines (new subsection)
- `src/instructions.rs`: +10 lines (template addition)
- 0 production code changes

## Testing
- 985 passed, 0 failed
- `cargo fmt --check` + `cargo clippy` (default + tray) clean