### PR TITLE
Sprint 14 PR-AN: stable unassigned agent order in fleet view

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -1645,11 +1645,12 @@ pub fn build_fleet_view_lines(
             lines.push(format!("  {symbol} {member}{task_info}"));
         }
     }
-    let unassigned: Vec<&str> = all_instances
+    let mut unassigned: Vec<&str> = all_instances
         .iter()
         .filter(|n| !assigned.contains(n.as_str()))
         .map(String::as_str)
         .collect();
+    unassigned.sort_unstable();
     if !unassigned.is_empty() {
         lines.push("═══ unassigned ═══".to_string());
         for name in &unassigned {


### PR DESCRIPTION
## Problem

Fleet view unassigned agents section shows agents in HashMap iteration order, which jumps between renders.

## Solution

`unassigned.sort_unstable()` — alphabetical order. 1 line change.

## Testing
- `test_fleet_view_content` passes. fmt + clippy clean.