### PR TITLE
feat(telegram): reply excerpt in inbox header (Sprint 15 PR-AQ)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -82,6 +82,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             delivery_mode: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         }
     };
     let _ = crate::inbox::enqueue(ctx.home, target, msg.clone());

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -639,6 +639,24 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         delivery_mode: None,
         attachments,
         in_reply_to_msg_id: msg.reply_to_message().map(|r| r.id.0.to_string()),
+        in_reply_to_excerpt: msg.reply_to_message().and_then(|r| {
+            let text = r.text().or_else(|| r.caption()).unwrap_or("");
+            if text.is_empty() {
+                return None;
+            }
+            let author = r
+                .from
+                .as_ref()
+                .and_then(|u| u.username.as_deref())
+                .unwrap_or("unknown");
+            let truncated: String = text.chars().take(200).collect();
+            let ellipsis = if text.chars().count() > 200 {
+                "…"
+            } else {
+                ""
+            };
+            Some(format!("[{author}] {truncated}{ellipsis}"))
+        }),
     };
     let _ = inbox::enqueue(&home, &instance_name, msg_obj);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -209,6 +209,7 @@ fn test_inbox(home: &Path) -> anyhow::Result<()> {
                 delivery_mode: None,
                 attachments: vec![],
                 in_reply_to_msg_id: None,
+                in_reply_to_excerpt: None,
             },
         )?;
     }

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -655,6 +655,7 @@ async fn ci_check_repo(
                     delivery_mode: None,
                     attachments: vec![],
                     in_reply_to_msg_id: None,
+                    in_reply_to_excerpt: None,
                 },
             );
         }

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -133,6 +133,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     delivery_mode: None,
                     attachments: vec![],
                     in_reply_to_msg_id: None,
+                    in_reply_to_excerpt: None,
                 },
             );
             "ok_inbox"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -936,6 +936,7 @@ pub fn run_task_maintenance(home: &Path) {
                 reviewed_head: None,
                 attachments: vec![],
                 in_reply_to_msg_id: None,
+                in_reply_to_excerpt: None,
             },
         );
     }
@@ -999,6 +1000,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     task_id: None,
                     attachments: vec![],
                     in_reply_to_msg_id: None,
+                    in_reply_to_excerpt: None,
                 },
             );
         }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -115,6 +115,7 @@ mod tests {
                     task_id: None,
                     attachments: vec![],
                     in_reply_to_msg_id: None,
+                    in_reply_to_excerpt: None,
                 },
             );
         }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -206,6 +206,9 @@ pub struct InboxMessage {
     /// If the user replied to a specific bot message, this is that message's id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub in_reply_to_msg_id: Option<String>,
+    /// Excerpt of the replied-to message (first 200 chars + author tag).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_reply_to_excerpt: Option<String>,
 }
 
 /// Metadata attached to a forced delegation (busy gate override).
@@ -496,6 +499,12 @@ pub fn format_header(msg: &InboxMessage) -> String {
             .collect();
         parts.push(format!("attachments=[{}]", paths.join(",")));
     }
+    if let Some(ref excerpt) = msg.in_reply_to_excerpt {
+        parts.push(format!(
+            "reply_to_excerpt={}",
+            sanitize_header_value(excerpt)
+        ));
+    }
     parts.join(" ")
 }
 
@@ -707,6 +716,7 @@ pub fn deliver(
         delivery_mode: None,
         attachments: vec![],
         in_reply_to_msg_id: None,
+        in_reply_to_excerpt: None,
     };
     let _ = enqueue(home, agent_name, msg);
     notify_agent(home, agent_name, source, text);
@@ -862,6 +872,7 @@ mod tests {
             delivery_mode: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         }
     }
 
@@ -994,6 +1005,7 @@ mod tests {
             delivery_mode: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1097,6 +1109,7 @@ mod tests {
             delivery_mode: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let json = serde_json::to_string(&msg).expect("serialize");
         let parsed: InboxMessage = serde_json::from_str(&json).expect("deserialize");
@@ -1125,6 +1138,7 @@ mod tests {
             delivery_mode: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1716,6 +1730,7 @@ mod tests {
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let json = serde_json::to_string(&msg).expect("ser");
         assert!(json.contains("thread_id"));
@@ -1765,6 +1780,7 @@ mod tests {
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("[AGEND-MSG]"));
@@ -1797,6 +1813,7 @@ mod tests {
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("from=from:agent"));
@@ -1834,6 +1851,7 @@ mod tests {
                 original_filename: None,
             }],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -1862,12 +1880,77 @@ mod tests {
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let header = format_header(&msg);
         assert!(
             !header.contains("attachments"),
             "empty attachments must not appear in header: {header}"
         );
+    }
+
+    #[test]
+    fn test_header_reply_excerpt_present() {
+        let mut msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "u".into(),
+            text: "reply".into(),
+            kind: None,
+            timestamp: "t".into(),
+            channel: None,
+            delivery_mode: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            attachments: vec![],
+            in_reply_to_msg_id: Some("42".into()),
+            in_reply_to_excerpt: Some("[bob] original".into()),
+        };
+        let h = format_header(&msg);
+        assert!(h.contains("reply_to_excerpt=[bob] original"), "{h}");
+        msg.in_reply_to_excerpt = None;
+        assert!(!format_header(&msg).contains("reply_to_excerpt"));
+    }
+
+    #[test]
+    fn test_reply_excerpt_long_truncated() {
+        let long: String = "x".repeat(300);
+        let trunc: String = long.chars().take(200).collect();
+        assert_eq!(trunc.len(), 200);
+        let excerpt = format!("[a] {trunc}…");
+        assert!(excerpt.contains("…"));
+    }
+
+    #[test]
+    fn test_reply_excerpt_newline_escaped() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "u".into(),
+            text: "r".into(),
+            kind: None,
+            timestamp: "t".into(),
+            channel: None,
+            delivery_mode: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            attachments: vec![],
+            in_reply_to_msg_id: Some("42".into()),
+            in_reply_to_excerpt: Some("[b] line1\nline2".into()),
+        };
+        let h = format_header(&msg);
+        assert!(!h.contains('\n'), "must be single line: {h}");
+        assert!(h.contains("reply_to_excerpt="), "{h}");
     }
 
     #[test]
@@ -1890,6 +1973,7 @@ mod tests {
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -1924,6 +2008,7 @@ mod tests {
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -1963,6 +2048,7 @@ mod tests {
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2005,6 +2091,7 @@ mod tests {
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2153,6 +2240,7 @@ mod tests {
                 original_filename: None,
             }],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: InboxMessage = serde_json::from_str(&json).unwrap();

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -991,6 +991,7 @@ mod tests {
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let header = crate::inbox::format_header(&sample_msg);
 

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -193,6 +193,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         delivery_mode: Some("inbox_fallback".to_string()),
                         attachments: vec![],
                         in_reply_to_msg_id: None,
+                        in_reply_to_excerpt: None,
                     };
                     let _ = crate::inbox::enqueue(&home, target, msg);
                     crate::inbox::notify_agent(
@@ -355,6 +356,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                         channel: None,
                         attachments: vec![],
                         in_reply_to_msg_id: None,
+                        in_reply_to_excerpt: None,
                     };
                     let _ = crate::inbox::enqueue(&home, target, inbox_msg);
                     crate::inbox::notify_agent(
@@ -478,6 +480,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                             channel: None,
                             attachments: vec![],
                             in_reply_to_msg_id: None,
+                            in_reply_to_excerpt: None,
                         };
                         let _ = crate::inbox::enqueue(&home, target, inbox_msg);
                         crate::inbox::notify_agent(
@@ -947,6 +950,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
                     delivery_mode: None,
                     attachments: vec![],
                     in_reply_to_msg_id: None,
+                    in_reply_to_excerpt: None,
                 },
             );
             tracing::info!(%name, %reason, "replace_instance");
@@ -2449,6 +2453,7 @@ instances:
                 delivery_mode: None,
                 attachments: vec![],
                 in_reply_to_msg_id: None,
+                in_reply_to_excerpt: None,
             },
         );
 
@@ -2508,6 +2513,7 @@ instances:
                 delivery_mode: None,
                 attachments: vec![],
                 in_reply_to_msg_id: None,
+                in_reply_to_excerpt: None,
             },
         );
 
@@ -2676,6 +2682,7 @@ instances:
             task_id: None,
             attachments: vec![],
             in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
         };
         let inbox_dir = home.join("inbox");
         std::fs::create_dir_all(&inbox_dir).ok();

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -900,6 +900,7 @@ mod tests {
                     task_id: None,
                     attachments: vec![],
                     in_reply_to_msg_id: None,
+                    in_reply_to_excerpt: None,
                 },
             );
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -302,6 +302,7 @@ fn test_inbox(home: &Path) -> TestResult {
                 delivery_mode: None,
                 attachments: vec![],
                 in_reply_to_msg_id: None,
+                in_reply_to_excerpt: None,
             },
         );
     }


### PR DESCRIPTION
## Summary

Agents can now see the content of the message being replied to in Telegram.

### Changes

- **`InboxMessage.in_reply_to_excerpt`**: new `Option<String>` field (`serde(default)` for schema compat)
- **`telegram.rs handle_message`**: extracts `reply_to_message()` text/caption + author username, capped at 200 chars with ellipsis
- **`format_header`**: exposes `reply_to_excerpt=` in `[AGEND-MSG]` header (newlines sanitized via existing `sanitize_header_value`)
- All existing `InboxMessage` construction sites updated with `in_reply_to_excerpt: None`

### Testing
- 3 unit tests: has_reply + no_reply, long_message_truncated, newline_escaped
- All 1002 tests pass | fmt ✅ | clippy ✅

**12 files, +123/-0** (most files are mechanical `in_reply_to_excerpt: None` additions)

**Scope decision**: d-20260426101812512198-1