### PR TITLE
feat(channel): Discord Phase 1 bootstrap channel selection (PR-AS)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ unwrap_used = "deny"
 [features]
 default = []
 tray = ["dep:tray-icon", "dep:tao", "dep:toml"]
+discord = []
 
 [profile.release]
 strip = true

--- a/src/app/telegram_hooks.rs
+++ b/src/app/telegram_hooks.rs
@@ -26,6 +26,7 @@ pub(super) fn telegram_status_from_config(
             }
         }
         None => render::TelegramStatus::NotConfigured,
+        Some(crate::fleet::ChannelConfig::Discord { .. }) => render::TelegramStatus::NotConfigured,
     }
 }
 

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -1,0 +1,8 @@
+//! Discord adapter — Phase 2+ placeholder.
+//!
+//! This module is behind the `discord` feature gate. Phase 1 (PR-AS) only
+//! establishes the bootstrap channel selection path; the actual adapter
+//! implementation lands in Phase 2.
+
+/// Placeholder to ensure the `discord` feature gate compiles clean.
+pub fn _placeholder() {}

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -33,6 +33,8 @@
 pub mod binding;
 pub mod caps;
 pub mod contract;
+#[cfg(feature = "discord")]
+pub mod discord;
 pub mod event;
 pub mod sink_registry;
 pub mod telegram;
@@ -114,7 +116,8 @@ pub fn active_channel() -> Option<&'static Arc<dyn Channel>> {
 #[serde(rename_all = "snake_case")]
 pub enum ChannelKind {
     Telegram,
-    // Future: Discord, Slack, Matrix, ...
+    Discord,
+    // Future: Slack, Matrix, ...
 }
 
 /// Platform-neutral channel trait. Implementations live next to their

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -861,18 +861,32 @@ pub fn init_from_config(
     home: &Path,
     submit_keys: HashMap<String, String>,
 ) -> Option<Arc<Mutex<TelegramState>>> {
-    let ChannelConfig::Telegram {
-        bot_token_env,
-        group_id,
-        user_allowlist,
-        fleet_binding,
-        ..
-    } = config.channel.as_ref()?;
+    let (bot_token_env, group_id, user_allowlist, fleet_binding) = match config.channel.as_ref()? {
+        ChannelConfig::Telegram {
+            bot_token_env,
+            group_id,
+            user_allowlist,
+            fleet_binding,
+            ..
+        } => (bot_token_env, group_id, user_allowlist, fleet_binding),
+        ChannelConfig::Discord { .. } => return None,
+    };
     let token = match std::env::var(bot_token_env) {
         Ok(t) => t,
         Err(_) => {
-            tracing::info!(env = %bot_token_env, "bot token env not set, skipping");
-            return None;
+            // Fallback: legacy AGEND_BOT_TOKEN env var (deprecated).
+            match std::env::var("AGEND_BOT_TOKEN") {
+                Ok(t) => {
+                    tracing::warn!(
+                        "AGEND_BOT_TOKEN is deprecated — migrate to {bot_token_env} in fleet.yaml"
+                    );
+                    t
+                }
+                Err(_) => {
+                    tracing::info!(env = %bot_token_env, "bot token env not set, skipping");
+                    return None;
+                }
+            }
         }
     };
     match user_allowlist {
@@ -1079,6 +1093,15 @@ fn resolve_channel_from(
             ..
         }) => {
             let token = std::env::var(bot_token_env)
+                .or_else(|_| {
+                    let legacy = std::env::var("AGEND_BOT_TOKEN");
+                    if legacy.is_ok() {
+                        tracing::warn!(
+                            "AGEND_BOT_TOKEN is deprecated — migrate to {bot_token_env}"
+                        );
+                    }
+                    legacy
+                })
                 .map_err(|_| anyhow::anyhow!("bot token env '{bot_token_env}' not set"))?;
             Ok((
                 TelegramCreds {
@@ -1087,6 +1110,9 @@ fn resolve_channel_from(
                 },
                 config,
             ))
+        }
+        Some(crate::fleet::ChannelConfig::Discord { .. }) => {
+            anyhow::bail!("Discord channel configured but telegram resolver called")
         }
         None => anyhow::bail!("No Telegram channel configured"),
     }
@@ -1492,6 +1518,7 @@ fn notify_telegram_inner(
             ),
             Err(_) => return,
         },
+        Some(crate::fleet::ChannelConfig::Discord { .. }) => return,
         None => return,
     };
 

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -37,7 +37,10 @@ pub struct FleetConfig {
 pub enum ChannelConfig {
     #[serde(rename = "telegram")]
     Telegram {
-        /// Env var name containing the bot token.
+        /// Env var name containing the bot token. Defaults to
+        /// `AGEND_TELEGRAM_BOT_TOKEN`; falls back to legacy `AGEND_BOT_TOKEN`
+        /// with a deprecation warning.
+        #[serde(default = "default_telegram_bot_token_env")]
         bot_token_env: String,
         /// Telegram group chat ID.
         group_id: i64,
@@ -66,6 +69,16 @@ pub enum ChannelConfig {
         /// `docs/DESIGN-stage-b-ux.md` §3 and §5).
         #[serde(default)]
         fleet_binding: Option<FleetBindingConfig>,
+    },
+    /// Discord adapter (Phase 2+). Bootstrap selection lands in Phase 1;
+    /// actual adapter implementation is behind the `discord` feature gate.
+    #[serde(rename = "discord")]
+    Discord {
+        /// Env var name containing the Discord bot token.
+        #[serde(default = "default_discord_bot_token_env")]
+        bot_token_env: String,
+        /// Discord guild (server) ID.
+        guild_id: u64,
     },
 }
 
@@ -103,6 +116,14 @@ pub enum FleetBindingStruct {
 
 fn default_mode() -> String {
     "topic".to_string()
+}
+
+fn default_telegram_bot_token_env() -> String {
+    "AGEND_TELEGRAM_BOT_TOKEN".to_string()
+}
+
+fn default_discord_bot_token_env() -> String {
+    "AGEND_DISCORD_BOT_TOKEN".to_string()
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -725,6 +746,7 @@ instances:
                 assert_eq!(mode, "topic");
             }
             None => panic!("channel should be Some"),
+            Some(crate::fleet::ChannelConfig::Discord { .. }) => panic!("unexpected discord"),
         }
 
         fs::remove_dir_all(&dir).ok();
@@ -760,6 +782,7 @@ instances: {}
                 assert_eq!(group_id, -100999);
             }
             None => panic!("plural channels: should populate singular channel field"),
+            Some(crate::fleet::ChannelConfig::Discord { .. }) => panic!("unexpected discord"),
         }
         // Plural is still preserved on the struct for later consumers.
         assert!(config.channels.is_some());
@@ -805,6 +828,7 @@ instances: {}
                 );
             }
             None => panic!("channel should be populated"),
+            Some(crate::fleet::ChannelConfig::Discord { .. }) => panic!("unexpected discord"),
         }
         fs::remove_dir_all(&dir).ok();
     }
@@ -837,6 +861,7 @@ instances: {}
                 ref bot_token_env, ..
             }) => assert_eq!(bot_token_env, "SINGULAR_TOKEN"),
             None => panic!("singular channel field must be preserved"),
+            Some(crate::fleet::ChannelConfig::Discord { .. }) => panic!("unexpected discord"),
         }
         fs::remove_dir_all(&dir).ok();
     }
@@ -879,6 +904,7 @@ instances: {}
                 assert_eq!(mode, "topic", "default mode should be 'topic'");
             }
             None => panic!("channel should be Some"),
+            Some(crate::fleet::ChannelConfig::Discord { .. }) => panic!("unexpected discord"),
         }
 
         fs::remove_dir_all(&dir).ok();

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -137,6 +137,7 @@ impl fmt::Display for NotifySource<'_> {
             Self::Channel(user, kind) => {
                 let kind_str = match kind {
                     crate::channel::ChannelKind::Telegram => "telegram",
+                    crate::channel::ChannelKind::Discord => "discord",
                 };
                 write!(f, "user:{user} via {kind_str}")
             }


### PR DESCRIPTION
## Summary

Phase 1 of Discord adapter — establishes bootstrap channel selection path for Phase 2.

### Changes

**Config**: `ChannelConfig::Discord` variant added (`bot_token_env` + `guild_id`)

**Env var migration**:
- `bot_token_env` default changed to `AGEND_TELEGRAM_BOT_TOKEN`
- `AGEND_BOT_TOKEN` preserved as fallback with deprecation warning
- Fallback applied in both `init_from_config` and `resolve_channel_from`

**Feature gate**: `Cargo.toml` adds `discord = []` feature; `src/channel/discord.rs` placeholder module behind `#[cfg(feature = "discord")]`

**`ChannelKind::Discord`** added to typed enum

**Match exhaustiveness**: All match sites on `ChannelConfig` handle Discord variant (return early / bail gracefully)

### Operator migration
```bash
# Old (still works with deprecation warn):
export AGEND_BOT_TOKEN=xxx

# New:
export AGEND_TELEGRAM_BOT_TOKEN=xxx
```

### Testing
- All 1004 tests pass
- Compiled clean with: no features, `--features tray`, `--features "tray discord"`
- fmt ✅ | clippy ✅ (all 3 combos)

**7 files, +78/-11**
**Scope decision**: d-20260426114044284092-3