### PR TITLE
Sprint 16 PR-AT: visibility status page spike — telegram keyword + TUI panel

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -209,6 +209,16 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
         Action::ShowHelp => {
             out.new_overlay = Some(Overlay::Help);
         }
+        Action::ShowStatus => {
+            let items = crate::tasks::list_all(ctx.home);
+            out.new_overlay = Some(Overlay::Tasks {
+                items,
+                col: 0,
+                row: 0,
+                mode: super::overlay::TaskBoardMode::Board,
+                view: super::overlay::BoardView::Status,
+            });
+        }
         Action::Detach => {
             out.should_break = true;
         }

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -47,6 +47,7 @@ pub enum TaskBoardMode {
 pub enum BoardView {
     Tasks,
     Fleet,
+    Status,
 }
 
 pub(super) enum Overlay {
@@ -550,7 +551,8 @@ pub(super) fn handle_key(
             if key.code == KeyCode::Tab && matches!(mode, TaskBoardMode::Board) {
                 *view = match view {
                     BoardView::Tasks => BoardView::Fleet,
-                    BoardView::Fleet => BoardView::Tasks,
+                    BoardView::Fleet => BoardView::Status,
+                    BoardView::Status => BoardView::Tasks,
                 };
                 return outcome;
             }
@@ -1140,7 +1142,11 @@ mod tests {
         }
         handle_key(&mut overlay, press(KeyCode::Tab), &mut ctx);
         if let Overlay::Tasks { view, .. } = &overlay {
-            assert_eq!(*view, BoardView::Tasks, "Tab must switch back to Tasks");
+            assert_eq!(*view, BoardView::Status, "Tab must switch to Status");
+        }
+        handle_key(&mut overlay, press(KeyCode::Tab), &mut ctx);
+        if let Overlay::Tasks { view, .. } = &overlay {
+            assert_eq!(*view, BoardView::Tasks, "Tab must cycle back to Tasks");
         }
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -427,6 +427,56 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         None => msg.caption().unwrap_or("").to_string(),
     };
 
+    // Status keyword detection — surface summary to the resolved instance's inbox.
+    // The agent (typically general) sees the summary and can relay to operator.
+    if crate::status_summary::is_status_keyword(&text) {
+        let thread_id = msg.thread_id.map(|ThreadId(MessageId(id))| id);
+        let instance_name = {
+            let mut s = lock_state(state);
+            resolve_topic(&mut s, thread_id)
+        };
+        let home = lock_state(state).home.clone();
+        let summary = crate::status_summary::build_summary(&home);
+        tracing::info!(to = %instance_name, "status keyword detected, injecting summary");
+        let _ = crate::inbox::enqueue(
+            &home,
+            &instance_name,
+            crate::inbox::InboxMessage {
+                schema_version: 0,
+                id: None,
+                read_at: None,
+                thread_id: None,
+                parent_id: None,
+                task_id: None,
+                force_meta: None,
+                correlation_id: None,
+                reviewed_head: None,
+                from: "system:status".to_string(),
+                text: summary,
+                kind: Some("status-summary".to_string()),
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                channel: Some(crate::channel::ChannelKind::Telegram),
+                delivery_mode: None,
+                attachments: vec![],
+                in_reply_to_msg_id: None,
+                in_reply_to_excerpt: None,
+            },
+        );
+        // Also notify agent PTY so it picks up the summary
+        let username = msg
+            .from
+            .as_ref()
+            .and_then(|u| u.username.as_deref())
+            .unwrap_or("unknown");
+        crate::inbox::notify_agent(
+            &home,
+            &instance_name,
+            &crate::inbox::NotifySource::Channel(username, crate::channel::ChannelKind::Telegram),
+            "[status-summary] check inbox for status overview",
+        );
+        return;
+    }
+
     // Extract inbound attachment metadata (photo/voice/document/video/sticker).
     // Download happens later after topic resolution provides instance_name.
     struct InboundFile<'a> {

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -42,6 +42,7 @@ pub enum Action {
     CommandPalette,
     ShowDecisions,
     ShowTasks,
+    ShowStatus,
     Detach,
     ShowHelp,
     /// Summon a floating scratch shell overlay (Ctrl+B ~). Esc closes & kills it.
@@ -191,6 +192,7 @@ fn dispatch_prefix(key: KeyEvent) -> Action {
         KeyCode::Char(':') => Action::CommandPalette,
         KeyCode::Char('D') => Action::ShowDecisions,
         KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::SHIFT) => Action::ShowDecisions,
+        KeyCode::Char('s') => Action::ShowStatus,
         KeyCode::Char('T') | KeyCode::Char('t') => Action::ShowTasks,
         KeyCode::Char('d') if !key.modifiers.contains(KeyModifiers::SHIFT) => Action::Detach,
         KeyCode::Char('?') => Action::ShowHelp,

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod render;
 mod schedules;
 mod snapshot;
 mod state;
+mod status_summary;
 mod store;
 mod sync;
 mod tasks;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1255,11 +1255,24 @@ pub fn render_tasks(
     use crate::app::{BoardView, TaskBoardMode};
     let count = items.len();
     let view_tabs = match view {
-        BoardView::Tasks => "[t] tasks  [f] fleet",
-        BoardView::Fleet => " [t] tasks [f] fleet",
+        BoardView::Tasks => "[t] tasks  [f] fleet  [s] status",
+        BoardView::Fleet => " [t] tasks [f] fleet  [s] status",
+        BoardView::Status => " [t] tasks  [f] fleet [s] status",
     };
     let title = format!(" Board ({count}) | {view_tabs} | Tab switch | q close ");
     let inner = render_overlay_frame(frame, Color::Blue, &title);
+
+    if matches!(view, BoardView::Status) {
+        let summary = crate::status_summary::build_summary(home);
+        let lines: Vec<ratatui::text::Line> = summary
+            .lines()
+            .map(|l| ratatui::text::Line::from(l.to_string()))
+            .collect();
+        let para =
+            ratatui::widgets::Paragraph::new(lines).wrap(ratatui::widgets::Wrap { trim: false });
+        frame.render_widget(para, inner);
+        return;
+    }
 
     if matches!(view, BoardView::Fleet) {
         render_fleet_view(frame, items, inner, home);

--- a/src/status_summary.rs
+++ b/src/status_summary.rs
@@ -1,0 +1,115 @@
+//! Visibility status summary — shared builder for telegram keyword + TUI panel.
+
+use std::path::Path;
+
+/// Build a human-readable status summary from task board + decisions.
+pub fn build_summary(home: &Path) -> String {
+    let tasks = crate::tasks::list_all(home);
+    let decisions = crate::decisions::list_all(home);
+
+    let claimed: Vec<_> = tasks.iter().filter(|t| t.status == "claimed").collect();
+    let open: Vec<_> = tasks.iter().filter(|t| t.status == "open").collect();
+    let blocked: Vec<_> = tasks.iter().filter(|t| t.status == "blocked").collect();
+    let done_recent: Vec<_> = tasks
+        .iter()
+        .filter(|t| t.status == "done")
+        .take(5)
+        .collect();
+
+    let mut lines = Vec::new();
+    lines.push("═══ Status Summary ═══".to_string());
+
+    // In-progress
+    if claimed.is_empty() {
+        lines.push("▸ In progress: (none)".to_string());
+    } else {
+        lines.push(format!("▸ In progress: {}", claimed.len()));
+        for t in &claimed {
+            let who = t.assignee.as_deref().unwrap_or("?");
+            lines.push(format!("  🟠 {} — {} [{}]", t.title, who, t.id));
+        }
+    }
+
+    // Blocked
+    if !blocked.is_empty() {
+        lines.push(format!("▸ Blocked: {}", blocked.len()));
+        for t in &blocked {
+            lines.push(format!("  🔴 {} [{}]", t.title, t.id));
+        }
+    }
+
+    // Open (backlog)
+    if !open.is_empty() {
+        lines.push(format!("▸ Open (backlog): {}", open.len()));
+        for t in open.iter().take(5) {
+            lines.push(format!("  ⚪ {} [{}]", t.title, t.id));
+        }
+        if open.len() > 5 {
+            lines.push(format!("  ... +{} more", open.len() - 5));
+        }
+    }
+
+    // Recent done
+    if !done_recent.is_empty() {
+        lines.push(format!("▸ Recently done: {}", done_recent.len()));
+        for t in &done_recent {
+            lines.push(format!("  ✅ {}", t.title));
+        }
+    }
+
+    // Active decisions
+    let active_decisions: Vec<_> = decisions.iter().take(3).collect();
+    if !active_decisions.is_empty() {
+        lines.push(format!("▸ Active decisions: {}", decisions.len()));
+        for d in &active_decisions {
+            lines.push(format!("  📋 {} [{}]", d.title, d.id));
+        }
+    }
+
+    lines.join("\n")
+}
+
+/// Check if a message text is a status keyword trigger.
+/// Returns true for exact matches like "狀況", "summary", "現在", "進度", "status".
+/// Does NOT match partial strings like "進度比上週好".
+pub fn is_status_keyword(text: &str) -> bool {
+    let trimmed = text.trim();
+    matches!(
+        trimmed,
+        "狀況" | "summary" | "現在" | "進度" | "status" | "進度？" | "狀況？"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyword_positive_matches() {
+        assert!(is_status_keyword("狀況"));
+        assert!(is_status_keyword("summary"));
+        assert!(is_status_keyword("現在"));
+        assert!(is_status_keyword("進度"));
+        assert!(is_status_keyword("status"));
+        assert!(is_status_keyword("  狀況  ")); // trimmed
+        assert!(is_status_keyword("進度？"));
+    }
+
+    #[test]
+    fn keyword_negative_no_partial() {
+        assert!(!is_status_keyword("進度比上週好"));
+        assert!(!is_status_keyword("summary of changes"));
+        assert!(!is_status_keyword("what is the status of PR"));
+        assert!(!is_status_keyword("hello"));
+        assert!(!is_status_keyword(""));
+    }
+
+    #[test]
+    fn build_summary_does_not_panic_on_empty_home() {
+        let dir = std::env::temp_dir().join(format!("agend-summary-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        let summary = build_summary(&dir);
+        assert!(summary.contains("Status Summary"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}


### PR DESCRIPTION
## Problem

Operator repeatedly asks "進度?" / "什麼狀況" via telegram — no self-serve visibility surface exists. Visibility tactical track Phase A (1-day spike).

## Solution

Two surfaces sharing one summary builder (`src/status_summary.rs`):

### (a) Telegram keyword detect
- `handle_message` checks `is_status_keyword(text)` — exact match on 狀況/summary/現在/進度/status
- On match: builds summary, injects into target agent's inbox as `kind: status-summary`
- Boundary: "進度比上週好" does NOT trigger (exact match only)

### (b) TUI overlay panel
- `Ctrl+B s` → `Action::ShowStatus` → `BoardView::Status` panel
- Tab cycles: Tasks → Fleet → Status → Tasks
- Renders `build_summary(home)` as paragraph in overlay

### Summary content
- In-progress tasks (claimed) with assignee
- Blocked tasks
- Open backlog (top 5)
- Recently done (top 5)
- Active decisions (top 3)

## Testing
- `keyword_positive_matches` / `keyword_negative_no_partial` — 7 positive + 5 negative cases
- `build_summary_does_not_panic_on_empty_home` — empty task board
- `test_board_overlay_tab_toggles_view` — updated for 3-way cycle
- 1011 passed, 0 failed. fmt + clippy clean.

## Spike observation
Merge → observe 1 day — does operator still ask "進度?" via telegram? If frequency drops → Phase B/C. If not → redesign surface.