### PR TITLE
Sprint 17 PR-AW: MCP task status enum extension (in_progress + verified) — v1.2 prereq

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -171,7 +171,7 @@ fn task_tools() -> Vec<Value> {
                 "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
                 "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}},
                 "id": {"type": "string"}, "result": {"type": "string"},
-                "status": {"type": "string", "enum": ["open", "claimed", "done", "blocked", "cancelled"]},
+                "status": {"type": "string", "enum": ["open", "claimed", "in_progress", "blocked", "verified", "done", "cancelled"]},
                 "filter_assignee": {"type": "string"}, "filter_status": {"type": "string"},
                 "due_at": {"type": "string", "description": "ISO 8601 deadline for the task"},
                 "duration": {"type": "string", "description": "Human duration until deadline (e.g. 30m, 1h, 2d)"}


### PR DESCRIPTION
## Problem

v1.2 protocol §10.3 prescribes `in_progress` / `verified` task status, but MCP tool schema only allows `[open, claimed, done, blocked, cancelled]`. Agents following v1.2 doc get input-validation rejection. Found by dev-reviewer-2 during PR-AU review.

## Solution

1-line change: extend status enum in `src/mcp/tools.rs:174`:
`[open, claimed, in_progress, blocked, verified, done, cancelled]`

Handler (`tasks.rs:382-383`) already stores arbitrary status strings — no handler change needed.

## Gate

PR-AU (v1.2 doc) merge blocked until this ships — ensures doc + daemon are in sync.

## Testing
1011 passed, 0 failed. fmt + clippy clean.