### PR TITLE
HOTFIX: vterm.rs OOB panic — cap render by grid dimensions

### DIFF
--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -137,8 +137,10 @@ impl VTerm {
         show_block_cursor: bool,
     ) {
         let grid = self.term.grid();
-        let rows = self.rows.min(area.height);
-        let cols = self.cols.min(area.width);
+        let grid_cols = grid.columns() as u16;
+        let grid_rows = grid.screen_lines() as u16;
+        let rows = self.rows.min(area.height).min(grid_rows);
+        let cols = self.cols.min(area.width).min(grid_cols);
         // `scroll_offset` is usize; `as i32` wraps on 64-bit hosts when the
         // caller somehow passes > i32::MAX. Clamp instead so an unreasonable
         // offset degrades to "deepest scrollback" rather than flipping sign


### PR DESCRIPTION
## Problem (operator blocked)

`vterm.rs:157` panics: `index out of bounds: len is 23 but index is 41`. App crashes on launch. Resize race: ratatui area larger than alacritty grid.

## Solution

Cap render loop bounds by actual grid dimensions:
```rust
let grid_cols = grid.columns() as u16;
let grid_rows = grid.screen_lines() as u16;
let rows = self.rows.min(area.height).min(grid_rows);
let cols = self.cols.min(area.width).min(grid_cols);
```

+4/-2 lines. Defensive guard — resize sync root cause deferred.

## Testing
1011 passed, 0 failed. fmt + clippy clean.