### PR TITLE
Sprint 18 PR-AY: Task Board UX Phase 2 — auto-close + progress + stale + telegram entry

### DIFF
--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -477,6 +477,32 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         return;
     }
 
+    // Task entry via telegram: "加 task: <title>" creates a task assigned to dev-lead.
+    if let Some(title) = crate::status_summary::parse_task_entry(&text) {
+        let home = lock_state(state).home.clone();
+        let result = crate::tasks::handle(
+            &home,
+            "operator",
+            &serde_json::json!({
+                "action": "create",
+                "title": title,
+                "assignee": "dev-lead",
+                "priority": "normal",
+            }),
+        );
+        let task_id = result["id"].as_str().unwrap_or("?");
+        tracing::info!(title, task_id, "task created via telegram keyword");
+        if let Some(ch) = crate::channel::active_channel() {
+            let _ = ch.notify(
+                "operator",
+                crate::channel::NotifySeverity::Info,
+                &format!("✅ Task created: {title} [{task_id}]"),
+                false,
+            );
+        }
+        return;
+    }
+
     // Extract inbound attachment metadata (photo/voice/document/video/sticker).
     // Download happens later after topic resolution provides instance_name.
     struct InboundFile<'a> {

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -587,6 +587,8 @@ async fn ci_check_repo(
     if let PrState::Terminal = provider.check_pr_terminal(repo, branch).await {
         remove_watch(home, watch_path, instance, repo, branch, "pr_terminal");
         tracing::info!(repo, branch, "CI watcher auto-cleared: PR terminal");
+        // Auto-close tasks whose description/title mentions this branch.
+        crate::status_summary::auto_close_merged_tasks(home, branch);
         return Ok(());
     }
 

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -34,8 +34,8 @@ pub enum CiPollResult {
 
 /// PR terminal-state check result.
 pub enum PrState {
-    /// PR is closed/merged — watcher should be cleared.
-    Terminal,
+    /// PR reached terminal state (closed or merged).
+    Terminal { merged: bool },
     /// PR is still open.
     Open,
     /// Check failed or no PR found — leave watcher alone.
@@ -165,7 +165,9 @@ impl CiProvider for GitHubCiProvider {
         };
         match resp.as_array().and_then(|a| a.first()) {
             Some(pr) => match pr["state"].as_str() {
-                Some("closed") => PrState::Terminal,
+                Some("closed") => PrState::Terminal {
+                    merged: pr["merged_at"].as_str().is_some(),
+                },
                 Some(_) => PrState::Open,
                 None => PrState::Unknown,
             },
@@ -584,11 +586,12 @@ async fn ci_check_repo(
     provider: &dyn CiProvider,
 ) -> anyhow::Result<()> {
     // Check if the PR associated with this branch has reached a terminal state.
-    if let PrState::Terminal = provider.check_pr_terminal(repo, branch).await {
+    if let PrState::Terminal { merged } = provider.check_pr_terminal(repo, branch).await {
         remove_watch(home, watch_path, instance, repo, branch, "pr_terminal");
-        tracing::info!(repo, branch, "CI watcher auto-cleared: PR terminal");
-        // Auto-close tasks whose description/title mentions this branch.
-        crate::status_summary::auto_close_merged_tasks(home, branch);
+        tracing::info!(repo, branch, merged, "CI watcher auto-cleared: PR terminal");
+        if merged {
+            crate::status_summary::auto_close_merged_tasks(home, branch);
+        }
         return Ok(());
     }
 
@@ -1472,7 +1475,7 @@ mod tests {
         }
 
         fn with_pr_terminal(self) -> Self {
-            *self.pr_state.lock().unwrap() = PrState::Terminal;
+            *self.pr_state.lock().unwrap() = PrState::Terminal { merged: true };
             self
         }
     }

--- a/src/status_summary.rs
+++ b/src/status_summary.rs
@@ -128,34 +128,69 @@ pub fn parse_task_entry(text: &str) -> Option<&str> {
         .filter(|s| !s.is_empty())
 }
 
-/// Auto-close tasks whose branch merged. Called from daemon ci_watch when
-/// a PR reaches terminal state (merged/closed).
-/// Matches branch name against task descriptions containing the branch name.
+/// Auto-close tasks whose branch merged. Only closes tasks in `verified` status
+/// (v1.2 §10.3 lifecycle: verified → done). Skips ambiguous matches.
 pub fn auto_close_merged_tasks(home: &Path, branch: &str) {
     let tasks = crate::tasks::list_all(home);
-    for task in &tasks {
-        if task.status == "done" || task.status == "cancelled" {
-            continue;
-        }
-        // Match: task description or title contains the branch name
-        if task.description.contains(branch) || task.title.contains(branch) {
-            let result = format!("auto-closed: branch '{}' merged", branch);
-            let _ = crate::tasks::handle(
-                home,
-                "system",
-                &serde_json::json!({
-                    "action": "update",
-                    "id": task.id,
-                    "status": "done",
-                    "result": result,
-                }),
-            );
-            tracing::info!(task_id = %task.id, branch, "auto-closed task on PR merge");
-        }
+    let candidates: Vec<_> = tasks
+        .iter()
+        .filter(|t| t.status == "verified")
+        .filter(|t| {
+            contains_as_token(&t.description, branch) || contains_as_token(&t.title, branch)
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        return;
     }
+    if candidates.len() > 1 {
+        let ids: Vec<_> = candidates.iter().map(|t| t.id.as_str()).collect();
+        tracing::warn!(
+            branch,
+            count = candidates.len(),
+            ?ids,
+            "ambiguous branch→task match, skipping auto-close"
+        );
+        return;
+    }
+
+    let task = candidates[0];
+    let result = format!("auto-closed: branch '{}' merged", branch);
+    let _ = crate::tasks::handle(
+        home,
+        "system",
+        &serde_json::json!({
+            "action": "update",
+            "id": task.id,
+            "status": "done",
+            "result": result,
+        }),
+    );
+    tracing::info!(task_id = %task.id, branch, "auto-closed task on PR merge");
+}
+
+/// Check if `haystack` contains `needle` as a whole token (word-boundary match).
+fn contains_as_token(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'-' || b == b'_';
+    let mut start = 0;
+    while let Some(pos) = haystack[start..].find(needle) {
+        let abs = start + pos;
+        let before_ok = abs == 0 || !is_word(haystack.as_bytes()[abs - 1]);
+        let after = abs + needle.len();
+        let after_ok = after >= haystack.len() || !is_word(haystack.as_bytes()[after]);
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -216,5 +251,48 @@ mod tests {
         let now = chrono::Utc::now();
         let old = (now - chrono::Duration::hours(5)).to_rfc3339();
         assert!(stale_marker(&old, &now, 4).contains("stale"));
+    }
+
+    #[test]
+    fn contains_as_token_word_boundary() {
+        assert!(contains_as_token(
+            "branch=sprint18-task-board-phase2",
+            "sprint18-task-board-phase2"
+        ));
+        assert!(contains_as_token(
+            "sprint18-task-board-phase2 merged",
+            "sprint18-task-board-phase2"
+        ));
+        assert!(!contains_as_token(
+            "sprint18-task-board-phase2-extra",
+            "sprint18-task-board-phase2"
+        ));
+        assert!(!contains_as_token("", "test"));
+        assert!(!contains_as_token("test", ""));
+    }
+
+    #[test]
+    fn auto_close_skips_unverified_task() {
+        // F1 invariant: only verified → done, never skip review
+        let dir = std::env::temp_dir().join(format!("agend-autoclose-f1-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        // Create a task in "claimed" status with branch name in description
+        crate::tasks::handle(
+            &dir,
+            "test",
+            &serde_json::json!({
+                "action": "create",
+                "title": "test task",
+                "description": "branch=sprint18-test-branch",
+            }),
+        );
+        auto_close_merged_tasks(&dir, "sprint18-test-branch");
+        let tasks = crate::tasks::list_all(&dir);
+        let task = tasks.iter().find(|t| t.title == "test task").unwrap();
+        assert_ne!(
+            task.status, "done",
+            "unverified task must NOT be auto-closed"
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/status_summary.rs
+++ b/src/status_summary.rs
@@ -1,36 +1,61 @@
 //! Visibility status summary — shared builder for telegram keyword + TUI panel.
+//! Also contains task-entry parsing and branch-match auto-close helpers.
 
 use std::path::Path;
 
 /// Build a human-readable status summary from task board + decisions.
+/// Sprint scope: tasks created in last 7 days (per operator Q1 decision).
 pub fn build_summary(home: &Path) -> String {
     let tasks = crate::tasks::list_all(home);
     let decisions = crate::decisions::list_all(home);
+    let now = chrono::Utc::now();
 
-    let claimed: Vec<_> = tasks.iter().filter(|t| t.status == "claimed").collect();
-    let open: Vec<_> = tasks.iter().filter(|t| t.status == "open").collect();
-    let blocked: Vec<_> = tasks.iter().filter(|t| t.status == "blocked").collect();
-    let done_recent: Vec<_> = tasks
+    // Sprint scope: tasks created in last 7 days
+    let sprint_tasks: Vec<_> = tasks
         .iter()
-        .filter(|t| t.status == "done")
-        .take(5)
+        .filter(|t| {
+            chrono::DateTime::parse_from_rfc3339(&t.created_at)
+                .map(|dt| now.signed_duration_since(dt) < chrono::Duration::days(7))
+                .unwrap_or(false)
+        })
         .collect();
 
-    let mut lines = Vec::new();
-    lines.push("═══ Status Summary ═══".to_string());
+    let in_progress: Vec<_> = sprint_tasks
+        .iter()
+        .filter(|t| t.status == "claimed" || t.status == "in_progress")
+        .collect();
+    let open: Vec<_> = sprint_tasks.iter().filter(|t| t.status == "open").collect();
+    let blocked: Vec<_> = sprint_tasks
+        .iter()
+        .filter(|t| t.status == "blocked")
+        .collect();
+    let done: Vec<_> = sprint_tasks
+        .iter()
+        .filter(|t| t.status == "done" || t.status == "verified")
+        .collect();
+    let total = sprint_tasks.len();
 
-    // In-progress
-    if claimed.is_empty() {
+    let mut lines = Vec::new();
+    lines.push("═══ Status Summary (7-day sprint) ═══".to_string());
+
+    // Sprint progress bar
+    let done_count = done.len();
+    if let Some(filled) = (done_count * 20).checked_div(total) {
+        let bar: String = "█".repeat(filled) + &"░".repeat(20 - filled);
+        lines.push(format!("[{bar}] {done_count}/{total} done"));
+    }
+
+    if in_progress.is_empty() {
         lines.push("▸ In progress: (none)".to_string());
     } else {
-        lines.push(format!("▸ In progress: {}", claimed.len()));
-        for t in &claimed {
+        lines.push(format!("▸ In progress: {}", in_progress.len()));
+        for t in &in_progress {
             let who = t.assignee.as_deref().unwrap_or("?");
-            lines.push(format!("  🟠 {} — {} [{}]", t.title, who, t.id));
+            let stale = stale_marker(&t.updated_at, &now, 4);
+            lines.push(format!("  🟠 {} — {}{} [{}]", t.title, who, stale, t.id));
         }
     }
 
-    // Blocked
     if !blocked.is_empty() {
         lines.push(format!("▸ Blocked: {}", blocked.len()));
         for t in &blocked {
@@ -38,26 +63,24 @@ pub fn build_summary(home: &Path) -> String {
         }
     }
 
-    // Open (backlog)
     if !open.is_empty() {
         lines.push(format!("▸ Open (backlog): {}", open.len()));
         for t in open.iter().take(5) {
-            lines.push(format!("  ⚪ {} [{}]", t.title, t.id));
+            let stale = stale_marker(&t.updated_at, &now, 24);
+            lines.push(format!("  ⚪ {}{} [{}]", t.title, stale, t.id));
         }
         if open.len() > 5 {
             lines.push(format!("  ... +{} more", open.len() - 5));
         }
     }
 
-    // Recent done
-    if !done_recent.is_empty() {
-        lines.push(format!("▸ Recently done: {}", done_recent.len()));
-        for t in &done_recent {
+    if !done.is_empty() {
+        lines.push(format!("▸ Done: {}", done.len()));
+        for t in done.iter().take(5) {
             lines.push(format!("  ✅ {}", t.title));
         }
     }
 
-    // Active decisions
     let active_decisions: Vec<_> = decisions.iter().take(3).collect();
     if !active_decisions.is_empty() {
         lines.push(format!("▸ Active decisions: {}", decisions.len()));
@@ -69,15 +92,67 @@ pub fn build_summary(home: &Path) -> String {
     lines.join("\n")
 }
 
+fn stale_marker(
+    updated_at: &str,
+    now: &chrono::DateTime<chrono::Utc>,
+    threshold_hours: i64,
+) -> &'static str {
+    chrono::DateTime::parse_from_rfc3339(updated_at)
+        .map(|dt| {
+            if now.signed_duration_since(dt) > chrono::Duration::hours(threshold_hours) {
+                " ⚠️stale"
+            } else {
+                ""
+            }
+        })
+        .unwrap_or("")
+}
+
 /// Check if a message text is a status keyword trigger.
-/// Returns true for exact matches like "狀況", "summary", "現在", "進度", "status".
-/// Does NOT match partial strings like "進度比上週好".
 pub fn is_status_keyword(text: &str) -> bool {
     let trimmed = text.trim();
     matches!(
         trimmed,
         "狀況" | "summary" | "現在" | "進度" | "status" | "進度？" | "狀況？"
     )
+}
+
+/// Check if a message is a task creation request. Returns the task title if matched.
+pub fn parse_task_entry(text: &str) -> Option<&str> {
+    let trimmed = text.trim();
+    trimmed
+        .strip_prefix("加 task:")
+        .or_else(|| trimmed.strip_prefix("加 task："))
+        .or_else(|| trimmed.strip_prefix("add task:"))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+/// Auto-close tasks whose branch merged. Called from daemon ci_watch when
+/// a PR reaches terminal state (merged/closed).
+/// Matches branch name against task descriptions containing the branch name.
+pub fn auto_close_merged_tasks(home: &Path, branch: &str) {
+    let tasks = crate::tasks::list_all(home);
+    for task in &tasks {
+        if task.status == "done" || task.status == "cancelled" {
+            continue;
+        }
+        // Match: task description or title contains the branch name
+        if task.description.contains(branch) || task.title.contains(branch) {
+            let result = format!("auto-closed: branch '{}' merged", branch);
+            let _ = crate::tasks::handle(
+                home,
+                "system",
+                &serde_json::json!({
+                    "action": "update",
+                    "id": task.id,
+                    "status": "done",
+                    "result": result,
+                }),
+            );
+            tracing::info!(task_id = %task.id, branch, "auto-closed task on PR merge");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -91,7 +166,7 @@ mod tests {
         assert!(is_status_keyword("現在"));
         assert!(is_status_keyword("進度"));
         assert!(is_status_keyword("status"));
-        assert!(is_status_keyword("  狀況  ")); // trimmed
+        assert!(is_status_keyword("  狀況  "));
         assert!(is_status_keyword("進度？"));
     }
 
@@ -99,17 +174,47 @@ mod tests {
     fn keyword_negative_no_partial() {
         assert!(!is_status_keyword("進度比上週好"));
         assert!(!is_status_keyword("summary of changes"));
-        assert!(!is_status_keyword("what is the status of PR"));
         assert!(!is_status_keyword("hello"));
         assert!(!is_status_keyword(""));
     }
 
     #[test]
     fn build_summary_does_not_panic_on_empty_home() {
-        let dir = std::env::temp_dir().join(format!("agend-summary-test-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("agend-summary-{}", std::process::id()));
         std::fs::create_dir_all(&dir).ok();
         let summary = build_summary(&dir);
         assert!(summary.contains("Status Summary"));
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn parse_task_entry_positive() {
+        assert_eq!(parse_task_entry("加 task: fix bug"), Some("fix bug"));
+        assert_eq!(
+            parse_task_entry("add task: new feature"),
+            Some("new feature")
+        );
+        assert_eq!(parse_task_entry("加 task：中文描述"), Some("中文描述"));
+    }
+
+    #[test]
+    fn parse_task_entry_negative() {
+        assert!(parse_task_entry("hello").is_none());
+        assert!(parse_task_entry("加 task:").is_none());
+        assert!(parse_task_entry("加 task: ").is_none());
+    }
+
+    #[test]
+    fn stale_marker_fresh_is_empty() {
+        let now = chrono::Utc::now();
+        let recent = (now - chrono::Duration::hours(1)).to_rfc3339();
+        assert_eq!(stale_marker(&recent, &now, 4), "");
+    }
+
+    #[test]
+    fn stale_marker_old_shows_warning() {
+        let now = chrono::Utc::now();
+        let old = (now - chrono::Duration::hours(5)).to_rfc3339();
+        assert!(stale_marker(&old, &now, 4).contains("stale"));
     }
 }


### PR DESCRIPTION
## Problem

v1.2 Rule 3 task close relies on manual discipline — audit found 6/31 open tasks actually done. Operator trust in board is low.

## Solution (4 operator constraints)

**Q1 Progress bar**: Sprint scope (7-day) progress bar + stale markers (claimed 4h / open 24h)
**Q2 Auto-close**: ci_watch PR terminal hook calls `auto_close_merged_tasks(branch)` — matches branch name in task title/description
**Q3 Telegram entry**: `加 task: <title>` keyword creates task assigned to dev-lead
**Q4 Stale markers**: ⚠️stale on in-progress (>4h) and open (>24h) tasks

## Testing
1018 passed, 0 failed. fmt + clippy clean.