### PR TITLE
Sprint 19 sub-sweep: PR-AN/AO/AQ test coverage drive-by (5 items, LOW)

### DIFF
--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -717,21 +717,12 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         in_reply_to_msg_id: msg.reply_to_message().map(|r| r.id.0.to_string()),
         in_reply_to_excerpt: msg.reply_to_message().and_then(|r| {
             let text = r.text().or_else(|| r.caption()).unwrap_or("");
-            if text.is_empty() {
-                return None;
-            }
             let author = r
                 .from
                 .as_ref()
                 .and_then(|u| u.username.as_deref())
                 .unwrap_or("unknown");
-            let truncated: String = text.chars().take(200).collect();
-            let ellipsis = if text.chars().count() > 200 {
-                "…"
-            } else {
-                ""
-            };
-            Some(format!("[{author}] {truncated}{ellipsis}"))
+            inbox::build_excerpt(text, author)
         }),
     };
     let _ = inbox::enqueue(&home, &instance_name, msg_obj);

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -1936,7 +1936,11 @@ mod tests {
             thread_id: None,
             parent_id: None,
             task_id: None,
-            attachments: vec![mk_att("/tmp/a.jpg"), mk_att("/tmp/b.jpg"), mk_att("/tmp/c.jpg")],
+            attachments: vec![
+                mk_att("/tmp/a.jpg"),
+                mk_att("/tmp/b.jpg"),
+                mk_att("/tmp/c.jpg"),
+            ],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
         };
@@ -2020,7 +2024,10 @@ mod tests {
         assert_eq!(cjk.len(), 250 * 3);
 
         let out = build_excerpt(&cjk, "carol").expect("non-empty text returns Some");
-        assert!(std::str::from_utf8(out.as_bytes()).is_ok(), "output must be valid UTF-8");
+        assert!(
+            std::str::from_utf8(out.as_bytes()).is_ok(),
+            "output must be valid UTF-8"
+        );
         let body = out
             .strip_prefix("[carol] ")
             .and_then(|s| s.strip_suffix('…'))
@@ -2034,7 +2041,10 @@ mod tests {
         // Boundary: 200 chars exactly should NOT get truncated marker.
         let exact: String = "y".repeat(200);
         let out = build_excerpt(&exact, "dan").expect("non-empty text returns Some");
-        assert!(!out.contains('…'), "200-char input must not get ellipsis: {out}");
+        assert!(
+            !out.contains('…'),
+            "200-char input must not get ellipsis: {out}"
+        );
     }
 
     #[test]

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -509,6 +509,24 @@ pub fn format_header(msg: &InboxMessage) -> String {
     parts.join(" ")
 }
 
+/// Build the `in_reply_to_excerpt` value for inbound replies.
+///
+/// Returns `None` when `text` is empty so callers can `and_then` over an
+/// optional reply target. Otherwise truncates to 200 chars (Unicode-safe via
+/// `chars().take(...)`) and appends `…` if the original exceeded 200 chars.
+pub(crate) fn build_excerpt(text: &str, author: &str) -> Option<String> {
+    if text.is_empty() {
+        return None;
+    }
+    let truncated: String = text.chars().take(200).collect();
+    let ellipsis = if text.chars().count() > 200 {
+        "…"
+    } else {
+        ""
+    };
+    Some(format!("[{author}] {truncated}{ellipsis}"))
+}
+
 /// Format a single-line event header (non-message events like poll-reminder).
 /// Uses the same ANSI prefix as [`format_header`] for visual consistency.
 pub fn format_event_header(kind: &str, fields: &[(&str, &str)]) -> String {
@@ -1891,6 +1909,45 @@ mod tests {
     }
 
     #[test]
+    fn test_header_format_joins_multiple_attachments_with_comma() {
+        // Locks the `paths.join(",")` separator contract — future refactor that
+        // changes the separator (e.g. to ";" or " ") must update this test.
+        let mk_att = |p: &str| crate::channel::event::Attachment {
+            kind: crate::channel::event::AttachmentKind::Photo,
+            path: std::path::PathBuf::from(p),
+            mime: None,
+            caption: None,
+            size_bytes: None,
+            original_filename: None,
+        };
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "from:user".into(),
+            text: "multi".into(),
+            kind: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            channel: None,
+            delivery_mode: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            attachments: vec![mk_att("/tmp/a.jpg"), mk_att("/tmp/b.jpg"), mk_att("/tmp/c.jpg")],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+        };
+        let header = format_header(&msg);
+        assert!(
+            header.contains("attachments=[/tmp/a.jpg,/tmp/b.jpg,/tmp/c.jpg]"),
+            "multi-attachment paths must be comma-joined: {header}"
+        );
+    }
+
+    #[test]
     fn test_header_reply_excerpt_present() {
         let mut msg = InboxMessage {
             schema_version: 1,
@@ -1925,6 +1982,59 @@ mod tests {
         assert_eq!(trunc.len(), 200);
         let excerpt = format!("[a] {trunc}…");
         assert!(excerpt.contains("…"));
+    }
+
+    #[test]
+    fn test_build_excerpt_empty_returns_none() {
+        assert_eq!(build_excerpt("", "alice"), None);
+    }
+
+    #[test]
+    fn test_build_excerpt_short_text_no_ellipsis() {
+        let out = build_excerpt("hello", "alice").expect("non-empty text returns Some");
+        assert_eq!(out, "[alice] hello");
+        assert!(!out.contains('…'));
+    }
+
+    #[test]
+    fn test_build_excerpt_long_text_truncates_to_200_with_ellipsis() {
+        let long: String = "x".repeat(250);
+        let out = build_excerpt(&long, "bob").expect("non-empty text returns Some");
+        assert!(out.starts_with("[bob] "));
+        assert!(out.ends_with('…'));
+        // Body between "[bob] " prefix and trailing "…" must be 200 chars.
+        let body = out
+            .strip_prefix("[bob] ")
+            .and_then(|s| s.strip_suffix('…'))
+            .expect("expected `[bob] {200 chars}…` shape");
+        assert_eq!(body.chars().count(), 200);
+    }
+
+    #[test]
+    fn test_build_excerpt_cjk_truncated_to_200_chars() {
+        // 250 CJK chars (each is 3 bytes UTF-8). Verifies char-based
+        // truncation, not byte-based — a byte-based take(200) would slice
+        // mid-codepoint and produce invalid UTF-8.
+        let cjk: String = "一".repeat(250);
+        assert_eq!(cjk.chars().count(), 250);
+        assert_eq!(cjk.len(), 250 * 3);
+
+        let out = build_excerpt(&cjk, "carol").expect("non-empty text returns Some");
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok(), "output must be valid UTF-8");
+        let body = out
+            .strip_prefix("[carol] ")
+            .and_then(|s| s.strip_suffix('…'))
+            .expect("expected `[carol] {200 CJK chars}…` shape");
+        assert_eq!(body.chars().count(), 200);
+        assert_eq!(body.len(), 200 * 3, "200 CJK chars = 600 UTF-8 bytes");
+    }
+
+    #[test]
+    fn test_build_excerpt_exactly_200_no_ellipsis() {
+        // Boundary: 200 chars exactly should NOT get truncated marker.
+        let exact: String = "y".repeat(200);
+        let out = build_excerpt(&exact, "dan").expect("non-empty text returns Some");
+        assert!(!out.contains('…'), "200-char input must not get ellipsis: {out}");
     }
 
     #[test]
@@ -2211,6 +2321,17 @@ mod tests {
         let legacy = r#"{"from":"user:op","text":"hello","timestamp":"2026-04-26T00:00:00Z"}"#;
         let msg: InboxMessage = serde_json::from_str(legacy).unwrap();
         assert!(msg.attachments.is_empty());
+    }
+
+    #[test]
+    fn legacy_inbox_message_without_excerpt_deserializes() {
+        // Old messages (pre-PR-AQ) have no `in_reply_to_excerpt` field.
+        // serde(default) must fill `None` so deserialization succeeds — locks
+        // schema backward-compatibility for on-disk JSONL written before PR-AQ.
+        let legacy = r#"{"from":"user:op","text":"hello","timestamp":"2026-04-26T00:00:00Z"}"#;
+        let msg: InboxMessage = serde_json::from_str(legacy).unwrap();
+        assert_eq!(msg.in_reply_to_excerpt, None);
+        assert_eq!(msg.in_reply_to_msg_id, None);
     }
 
     #[test]

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -968,6 +968,31 @@ mod tests {
     }
 
     #[test]
+    fn test_all_backends_include_attachments_rule() {
+        // PR-AO header rule propagation: every backend's generated instructions
+        // must mention the `attachments=[...]` header field so agents know to
+        // call `inbox` for media metadata. Mirrors the pattern of
+        // `test_all_backends_include_agend_msg_rule`.
+        let dir =
+            std::env::temp_dir().join(format!("agend-instr-attach-test-{}", std::process::id()));
+        for backend_cmd in ["claude", "kiro-cli", "codex", "gemini"] {
+            let work = dir.join(backend_cmd);
+            std::fs::create_dir_all(&work).ok();
+            generate(&work, backend_cmd);
+            let backend = crate::backend::Backend::from_command(backend_cmd).unwrap();
+            let preset = backend.preset();
+            let instr_path = work.join(preset.instructions_path);
+            let content = std::fs::read_to_string(&instr_path).unwrap_or_default();
+            assert!(
+                content.contains("attachments="),
+                "{backend_cmd} instructions must mention `attachments=` header rule, path={}",
+                instr_path.display()
+            );
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn test_instruction_trigger_matches_header_prefix() {
         // Regression: locks the contract between S3-T1 (format_header) and
         // S3-T2 (instruction wording). If either side drifts, this breaks.


### PR DESCRIPTION
## 問題 → 方案

**問題**：Sprint 14 PR-AN/AO + Sprint 15 PR-AQ reviewer-flagged coverage gaps；dev-reviewer-2 Track D batch verdict 12:23 UTC ([m-20260426122354357000-72](#)) 合併建議集中一張 sweep。

**方案**：5 sub-items 一張 PR (~150 行 test + 1 helper extraction)。

## 5 sub-items

| # | Test | Lock |
|---|---|---|
| 1 | `test_header_format_joins_multiple_attachments_with_comma` | `paths.join(",")` separator contract for multi-attachment headers |
| 2 | `test_all_backends_include_attachments_rule` | per-backend instructions mention `attachments=` header rule (mirrors existing `test_all_backends_include_agend_msg_rule`) |
| 3 | `test_build_excerpt_*` (4 tests: empty / short / long / exactly-200) | extracted `pub(crate) fn build_excerpt(text, author) -> Option<String>` helper from inline closure |
| 4 | `legacy_inbox_message_without_excerpt_deserializes` | pre-PR-AQ JSONL backward compat — `in_reply_to_excerpt` / `in_reply_to_msg_id` missing → `None` |
| 5 | `test_build_excerpt_cjk_truncated_to_200_chars` | char-based truncation isn't mid-codepoint byte-slice (250 CJK chars → body 200 chars, 600 bytes, valid UTF-8) |

## Production change

- Extract `pub(crate) fn build_excerpt(text: &str, author: &str) -> Option<String>` from inline closure in `src/channel/telegram.rs` `handle_message` into `src/inbox.rs`. **Logic unchanged**; pure refactor for testability per dispatch sub-item #3.
- `src/channel/telegram.rs` `handle_message` now calls `inbox::build_excerpt(text, author)`.

## CI verification (Tier-2 evidence chain)

- `cargo clippy --all-targets --features tray -- -D warnings` → clean (exit 0).
- `cargo test --features tray` → 1130+ tests pass, 0 failed (exit 0).

## Test plan

- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean.
- [x] `cargo test --features tray` all pass (incl. 6 new tests targeting items 1-5).
- [x] No production logic change beyond `build_excerpt` extraction (verified by reading the diff: same `text.chars().take(200)` truncation, same `…` ellipsis condition, same `[author] ` prefix format).
- [x] `inbox::build_excerpt(text, author)` call site in `telegram.rs` covers the same `r.text().or_else(|| r.caption()).unwrap_or("")` and `unwrap_or("unknown")` author fallback as before.

## Source

- Dispatch: `m-20260426173609533144-39`.
- Backlog task: `t-20260426083541166855-4` (PR-AN/AO/AQ Track D batch verdict).
- Scope freeze: Sprint 19 umbrella decision `d-20260426170025804519-3`.

## Reviewer

dev-reviewer-2 single (continuity — she split + scoped this sweep originally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)