### PR TITLE
Sprint 21 Phase 1 — Outbound notify gate (A1)

### DIFF
--- a/src/channel/auth.rs
+++ b/src/channel/auth.rs
@@ -1,0 +1,93 @@
+//! Channel auth predicates — fail-closed gates for inbound + outbound.
+//!
+//! Phase 1 (Sprint 21) introduces these predicates and applies the
+//! outbound gate at daemon notify call sites. Phase 2 will refactor
+//! `TelegramState::is_user_allowed` to use [`is_authorized_recipient`],
+//! reversing the legacy `None` → accept-all semantics to fail-closed.
+//!
+//! Single-source-of-truth for "operator allowlist configured" semantics
+//! so Phase 1 outbound gate and Phase 2 inbound gate stay aligned (per
+//! Sprint 21 challenge round impl-1 #6 "operator perception risk":
+//! both gates closing the same attack class via the same predicate
+//! makes the cascade-closed boundary explicit).
+
+/// Inbound auth predicate: is the given user authorised to send commands?
+/// Fail-closed: returns `false` when `allowlist` is `None` (unconfigured)
+/// or when `user_id` is absent from the configured list.
+///
+/// **Phase 1 usage**: not yet wired. `TelegramState::is_user_allowed`
+/// (`src/channel/telegram.rs:199-204`) retains legacy `None` → `true`
+/// semantics until Phase 2 swaps to this fn. Introducing the predicate
+/// in Phase 1 lets the outbound gate and the future inbound reform
+/// share one definition of "authorised user" rather than two parallel
+/// implementations.
+pub fn is_authorized_recipient(allowlist: &Option<Vec<i64>>, user_id: i64) -> bool {
+    match allowlist {
+        Some(list) => list.contains(&user_id),
+        None => false,
+    }
+}
+
+/// Outbound notify gate: returns `true` iff an explicit non-empty
+/// operator allowlist is configured.
+///
+/// When this returns `false`, [`super::gated_notify`] drops outbound
+/// info-bearing notifications to avoid leaking PTY tails (40 lines per
+/// stall, plus full crash error output, plus CI rate-limit run urls)
+/// to anyone added to a bound Telegram group that has not been
+/// auth-configured.
+///
+/// Closes the Sprint 20.5 cross-validation outbound info-leak finding
+/// (Track B peer-pass to Track A `DAEMON.md` §7 critique 1).
+pub fn is_outbound_authorized(allowlist: &Option<Vec<i64>>) -> bool {
+    matches!(allowlist, Some(list) if !list.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_authorized_recipient_fail_closed_on_none() {
+        // Unconfigured allowlist must reject all users (Phase 2 reform
+        // direction; not yet active in inbound path).
+        assert!(!is_authorized_recipient(&None, 42));
+    }
+
+    #[test]
+    fn is_authorized_recipient_rejects_unlisted_user() {
+        assert!(!is_authorized_recipient(&Some(vec![1, 2, 3]), 42));
+    }
+
+    #[test]
+    fn is_authorized_recipient_accepts_listed_user() {
+        assert!(is_authorized_recipient(&Some(vec![1, 42, 3]), 42));
+    }
+
+    #[test]
+    fn is_authorized_recipient_empty_list_rejects_all() {
+        // `Some([])` semantically equivalent to "explicitly no users
+        // allowed" (different from `None` = unconfigured, but observable
+        // outcome is the same: nobody passes).
+        assert!(!is_authorized_recipient(&Some(vec![]), 42));
+    }
+
+    #[test]
+    fn is_outbound_authorized_fails_closed_on_none() {
+        // Legacy unconfigured deployment: outbound disabled, no leak.
+        assert!(!is_outbound_authorized(&None));
+    }
+
+    #[test]
+    fn is_outbound_authorized_fails_closed_on_empty() {
+        // Operator explicitly cleared the allowlist — outbound also off.
+        assert!(!is_outbound_authorized(&Some(vec![])));
+    }
+
+    #[test]
+    fn is_outbound_authorized_passes_on_non_empty() {
+        // Operator opted in by configuring at least one authorised user.
+        // Outbound notifications now permitted to the bound group.
+        assert!(is_outbound_authorized(&Some(vec![1])));
+    }
+}

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -30,6 +30,7 @@
 // on the `pub use` re-exports below.
 #![allow(dead_code, unused_imports)]
 
+pub mod auth;
 pub mod binding;
 pub mod caps;
 pub mod contract;
@@ -208,6 +209,53 @@ pub trait Channel: Send + Sync {
     ) -> std::result::Result<(), ChannelError> {
         Err(ChannelError::NotSupported("notify".into()))
     }
+
+    /// Outbound notify gate predicate: returns `true` iff the channel
+    /// has been configured with an explicit non-empty operator
+    /// allowlist (i.e. the operator has opted in to receiving
+    /// info-bearing notifications via this channel).
+    ///
+    /// Default: `false` (fail-closed for adapters without an allowlist
+    /// concept). Concrete adapters override to expose their
+    /// configuration state.
+    ///
+    /// Consumed by [`gated_notify`] — daemon notify call sites should
+    /// route through that helper rather than calling [`Self::notify`]
+    /// directly so the gate cannot be bypassed.
+    fn outbound_authorized(&self) -> bool {
+        false
+    }
+}
+
+/// Outbound notify gate — only forwards to [`Channel::notify`] when the
+/// channel reports [`Channel::outbound_authorized`] = `true`. When the
+/// channel is unauthorised (no allowlist configured), the call is
+/// dropped with a `tracing::debug!` log.
+///
+/// Closes the Sprint 20.5 cross-validation outbound info-leak finding:
+/// daemon stall / recovery / crash / CI notices were calling
+/// `ch.notify()` directly, which on Telegram pushes the message to the
+/// bound group regardless of allowlist state — leaking PTY tails (40
+/// lines per stall) to anyone added to an unconfigured group. The gate
+/// fails-closed so legacy deployments with `user_allowlist == None`
+/// stop emitting outbound info; operators must explicitly configure
+/// `user_allowlist: [...]` (a Phase-2-aligned action) to opt in.
+pub fn gated_notify(
+    channel: &dyn Channel,
+    instance: &str,
+    severity: NotifySeverity,
+    message: &str,
+    silent: bool,
+) -> std::result::Result<(), ChannelError> {
+    if !channel.outbound_authorized() {
+        tracing::debug!(
+            instance,
+            kind = channel.kind(),
+            "outbound notify dropped — channel not authorised (fail-closed; configure user_allowlist to opt in)"
+        );
+        return Ok(());
+    }
+    channel.notify(instance, severity, message, silent)
 }
 
 /// Options passed to `Channel::create_binding`. Platform-specific hints live
@@ -330,5 +378,115 @@ mod tests {
         assert_ne!(NotifySeverity::Info, NotifySeverity::Warn);
         assert_ne!(NotifySeverity::Warn, NotifySeverity::Error);
         assert_ne!(NotifySeverity::Info, NotifySeverity::Error);
+    }
+
+    /// Mock channel that records every `notify` call so tests can pin
+    /// the gate's pass / drop semantics. Used by the [`gated_notify`]
+    /// tests below.
+    struct RecordingChannel {
+        caps: ChannelCapabilities,
+        outbound_ok: bool,
+        notify_count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl RecordingChannel {
+        fn new(outbound_ok: bool) -> Self {
+            Self {
+                caps: ChannelCapabilities::default(),
+                outbound_ok,
+                notify_count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+        fn count(&self) -> usize {
+            self.notify_count.load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+
+    impl Channel for RecordingChannel {
+        fn kind(&self) -> &'static str {
+            "recording"
+        }
+        fn caps(&self) -> &ChannelCapabilities {
+            &self.caps
+        }
+        fn poll_event(&self) -> Option<ChannelEvent> {
+            None
+        }
+        fn send(&self, _: &BindingRef, _: OutMsg) -> Result<MsgRef> {
+            anyhow::bail!("mock")
+        }
+        fn edit(&self, _: &MsgRef, _: OutMsg) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn delete(&self, _: &MsgRef) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn create_binding(&self, _: &str, _: BindingOpts) -> Result<BindingRef> {
+            anyhow::bail!("mock")
+        }
+        fn remove_binding(&self, _: &BindingRef) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn has_binding(&self, _: &str) -> bool {
+            false
+        }
+        fn record_binding(&self, _: &str, _: BindingRef, _: String) {}
+        fn take_binding(&self, _: &str) -> Option<BindingRef> {
+            None
+        }
+        fn attach_registry(&self, _: crate::agent::AgentRegistry) {}
+        fn outbound_authorized(&self) -> bool {
+            self.outbound_ok
+        }
+        fn notify(
+            &self,
+            _instance: &str,
+            _severity: NotifySeverity,
+            _message: &str,
+            _silent: bool,
+        ) -> std::result::Result<(), ChannelError> {
+            self.notify_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn gated_notify_drops_when_channel_unauthorized() {
+        // Fail-closed default: trait method returns false, gate drops
+        // the call; underlying `notify` must NOT be invoked.
+        let ch = RecordingChannel::new(false);
+        let result = gated_notify(&ch, "agent1", NotifySeverity::Warn, "leak-bait", false);
+        assert!(matches!(result, Ok(())), "drop must be Ok, got {result:?}");
+        assert_eq!(
+            ch.count(),
+            0,
+            "unauthorized channel must NOT receive notify call"
+        );
+    }
+
+    #[test]
+    fn gated_notify_forwards_when_channel_authorized() {
+        // Operator opted in (allowlist configured) → channel reports
+        // outbound_authorized=true → gate forwards to notify.
+        let ch = RecordingChannel::new(true);
+        let result = gated_notify(&ch, "agent1", NotifySeverity::Info, "ok", true);
+        assert!(result.is_ok(), "authorised forward must succeed");
+        assert_eq!(
+            ch.count(),
+            1,
+            "authorised channel must receive exactly 1 notify call"
+        );
+    }
+
+    #[test]
+    fn default_outbound_authorized_is_fail_closed() {
+        // Trait default is `false` so an adapter forgetting to opt in
+        // doesn't accidentally pass the gate.
+        let ch = MockChannel::new();
+        assert!(
+            !ch.outbound_authorized(),
+            "default trait method must fail-closed"
+        );
     }
 }

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -1990,6 +1990,15 @@ impl crate::channel::Channel for TelegramChannel {
         }
         Ok(())
     }
+
+    /// Adapter-side outbound gate: returns `true` iff `user_allowlist`
+    /// is `Some(non-empty)`. Reuses [`crate::channel::auth::is_outbound_authorized`]
+    /// so the same predicate is the source of truth across both the
+    /// trait-level [`gated_notify`](crate::channel::gated_notify) helper
+    /// and Phase 2's pending inbound auth reform.
+    fn outbound_authorized(&self) -> bool {
+        crate::channel::auth::is_outbound_authorized(&lock_state(&self.state).user_allowlist)
+    }
 }
 
 // ─── UxEventSink: capability-gated degradation ────────────────────────

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -619,8 +619,13 @@ async fn ci_check_repo(
                 ),
                 None => format!("[ci-warn] {repo}@{branch}: {message}"),
             };
+            // Outbound info-leak gate (Sprint 21 Phase 1): `notify_msg`
+            // carries CI run url + repo name; legacy `None`-allowlist
+            // deployments must opt in to receive these via
+            // `user_allowlist: [...]`.
             if let Some(ch) = crate::channel::active_channel() {
-                let _ = ch.notify(
+                let _ = crate::channel::gated_notify(
+                    ch.as_ref(),
                     instance,
                     crate::channel::NotifySeverity::Warn,
                     &notify_msg,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -605,8 +605,17 @@ fn run_core(
             };
             tracing::warn!(agent = %crashed_name, %state, "notifying");
             let msg = format!("[health] {crashed_name}: {state}");
+            // Outbound info-leak gate (Sprint 21 Phase 1): crash
+            // notification carries the agent state name; gated_notify
+            // drops when the channel is unauthorised.
             if let Some(ch) = crate::channel::active_channel() {
-                let _ = ch.notify(&crashed_name, NotifySeverity::Error, &msg, false);
+                let _ = crate::channel::gated_notify(
+                    ch.as_ref(),
+                    &crashed_name,
+                    NotifySeverity::Error,
+                    &msg,
+                    false,
+                );
             } else {
                 tracing::debug!(agent = %crashed_name, "no active channel for crash notification");
             }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -123,8 +123,20 @@ fn tick(home: &std::path::Path, registry: &AgentRegistry) {
         match action {
             Some(NoticeAction::Stall { tail, silent_secs }) => {
                 let msg = format_stall_notice(&name, &tail, silent_secs);
+                // Outbound info-leak gate (Sprint 21 Phase 1): `tail`
+                // carries 40 lines of PTY output — must not leak to a
+                // bound group with no operator allowlist configured.
+                // `gated_notify` drops the call when the channel is
+                // unauthorised; legacy `None`-allowlist deployments
+                // require explicit opt-in via `user_allowlist: [...]`.
                 if let Some(ch) = crate::channel::active_channel() {
-                    let _ = ch.notify(&name, NotifySeverity::Warn, &msg, false);
+                    let _ = crate::channel::gated_notify(
+                        ch.as_ref(),
+                        &name,
+                        NotifySeverity::Warn,
+                        &msg,
+                        false,
+                    );
                 } else {
                     tracing::debug!(agent = %name, "no active channel — stall notice dropped");
                 }
@@ -132,7 +144,13 @@ fn tick(home: &std::path::Path, registry: &AgentRegistry) {
             Some(NoticeAction::Recovered) => {
                 let msg = format_recovery_notice(&name);
                 if let Some(ch) = crate::channel::active_channel() {
-                    let _ = ch.notify(&name, NotifySeverity::Info, &msg, true);
+                    let _ = crate::channel::gated_notify(
+                        ch.as_ref(),
+                        &name,
+                        NotifySeverity::Info,
+                        &msg,
+                        true,
+                    );
                 } else {
                     tracing::debug!(agent = %name, "no active channel — recovery notice dropped");
                 }


### PR DESCRIPTION
## Summary

Sprint 21 Phase 1 — closes the outbound info-leak attack class identified in Sprint 20.5 cross-validation (Track B peer-pass to Track A `DAEMON.md` §7 critique 1). Daemon stall / recovery / crash / CI notices were calling `ch.notify()` on the active channel without an allowlist gate, leaking PTY tails (40 lines per stall) to anyone added to a bound Telegram group.

Per scope freeze `d-20260426235704857573-8` + dispatch `m-20260426235814966895-128`.

## 問題 → 方案

**問題**: `supervisor::tick:127/135` + `ci_watch.rs:623` + `daemon/mod.rs:609` push notices via `ch.notify(...)` to bound Telegram group with no allowlist gate. C1-A inbound `is_user_allowed` legacy `None`-accept-all does not close this — outbound is a separate surface.

**方案 (Phase 1)**:
1. New `src/channel/auth.rs` — single-source-of-truth allowlist predicates:
   - `is_authorized_recipient(allowlist, user_id)` — fail-closed; Phase 2 will swap `TelegramState::is_user_allowed` to use it
   - `is_outbound_authorized(allowlist)` — true iff `Some(non-empty)`
2. New `Channel::outbound_authorized(&self) -> bool { false }` trait method (default fail-closed for adapters without allowlist concept).
3. TelegramChannel overrides `outbound_authorized` to call `is_outbound_authorized` against `TelegramState::user_allowlist`.
4. New `channel::gated_notify(channel, instance, sev, msg, silent)` helper wraps `ch.notify(...)` with the gate; `tracing::debug!` logs the drop reason when the channel is unauthorised.
5. 4 daemon notify call sites switched to `gated_notify`:
   - `src/daemon/supervisor.rs:127` (Stall, Warn, !silent — primary leak path: 40-line PTY tail)
   - `src/daemon/supervisor.rs:135` (Recovered, Info, silent)
   - `src/daemon/ci_watch.rs:623` (CI rate-limit, Warn)
   - `src/daemon/mod.rs:609` (Crash, Error, !silent — secondary leak path: agent state)

## Each-Phase-attack-class (per impl-1 challenge round #6)

- **Phase 1 closes ONLY outbound info-leak** attack class. Inbound cascade (legacy `None`-accept-all in `is_user_allowed`) remains open until Phase 2.
- `gated_notify` is adapter-aware via `outbound_authorized` trait method — future Discord adapter inherits the fail-closed default and must explicitly opt in.
- Phase 1 + Phase 2 must both land before operator can declare cascade closed.

## Out-of-scope (REJECT)

- `src/agent.rs`, `src/api/handlers/instance.rs` — impl-2 lifecycle Phase 1 parallel work (file conflict avoidance per impl-1 challenge round #1)
- `supervisor::F6` heartbeat race — deferred Sprint 22
- `is_user_allowed` inbound reform — Phase 2 owns
- `src/channel/telegram.rs:496` self-call (telegram-side `add task:` keyword confirmation) — Phase 1 daemon-side per dispatch list; Phase 2 inbound reform closes this transitively

## Tests added (10)

- 7 in `src/channel/auth.rs`: `is_authorized_recipient` × 4 (None / unlisted / listed / empty) + `is_outbound_authorized` × 3 (None / empty / non-empty)
- 3 in `src/channel/mod.rs::tests`: `gated_notify_drops_when_channel_unauthorized` + `gated_notify_forwards_when_channel_authorized` + `default_outbound_authorized_is_fail_closed` (uses new `RecordingChannel` test fixture)

## v1.2 §3 evidence chain (Tier-2 full per dispatch)

- **reviewed_head**: `cda08af` (this commit)
- **scope_source**: `d-20260426235704857573-8`
- **audit_mode**: impl-self
- **commands**: `cargo fmt --check` + `cargo clippy --all-targets --features tray -- -D warnings` + `cargo test --features tray`
- **files**: `src/channel/auth.rs` (new) + `src/channel/mod.rs` (trait method + helper + tests) + `src/channel/telegram.rs` (override) + `src/daemon/{supervisor,ci_watch,mod}.rs` (4 call site patches)

## Test plan

- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets --features tray -- -D warnings` ✓
- [x] `cargo test --features tray` ✓ (1044 lib + 10 new + integration; 0 failed)
- [x] Backward compat: legacy `None`-allowlist deployments now drop outbound (intentional fail-closed). Operators must add `user_allowlist: [user_id, ...]` to `fleet.yaml` to opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)