### PR TITLE
Sprint 21 Phase 1 — Lifecycle transaction (B1/B2/B3/B5)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -350,11 +350,19 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         })
         .map_err(|e| anyhow::anyhow!("Failed to open PTY: {e}"))?;
 
+    // RAII guard arms the rollback for partial-failure between here and the
+    // commit() at the end of this fn. Sprint 20 F1: previously a take_writer /
+    // try_clone_reader / pty_read_loop spawn failure left an orphan PID (no
+    // registry entry) or a phantom registry entry (no read thread).
+    let mut rollback = crate::daemon::lifecycle::SpawnRollback::new(name, registry);
+
     let child = pair
         .slave
         .spawn_command(cmd)
         .map_err(|e| anyhow::anyhow!("Failed to spawn '{backend_command}': {e}"))?;
     drop(pair.slave);
+    let child_arc: Arc<Mutex<Box<dyn portable_pty::Child + Send>>> = Arc::new(Mutex::new(child));
+    rollback.mark_child_spawned(Arc::clone(&child_arc));
 
     let pty_writer: PtyWriter = Arc::new(Mutex::new(
         pair.master
@@ -385,7 +393,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
                 pty_writer: Arc::clone(&pty_writer),
                 pty_master: Arc::clone(&pty_master),
                 core: Arc::clone(&core),
-                child: Arc::new(Mutex::new(child)),
+                child: Arc::clone(&child_arc),
                 submit_key: submit_key.to_string(),
                 inject_prefix: detected_backend
                     .as_ref()
@@ -398,6 +406,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
             },
         );
     }
+    rollback.mark_registered();
 
     // PTY read thread — feeds VTerm + broadcasts + auto-dismiss trust dialog + session reaper
     let core2 = Arc::clone(&core);
@@ -427,6 +436,10 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         dismiss_patterns: dismiss,
         shutdown: shutdown_for_reaper,
     };
+    // fire-and-forget: pty_read_loop terminates on PTY EOF, which fires when
+    // the child process is killed during shutdown / delete. JoinHandle is
+    // discarded because the loop's exit is signalled via the OS-side PTY
+    // close, not via a stored handle.
     std::thread::Builder::new()
         .name(format!("{n}_pty_read"))
         .spawn(move || {
@@ -474,6 +487,9 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
             }
         }
     }
+
+    // Disarm the rollback guard — all ordered mutations succeeded.
+    rollback.commit();
 
     tracing::info!(agent = name, backend = backend_command, args = %config.args.join(" "), "spawned");
     Ok(())

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -94,20 +94,13 @@ pub(crate) fn handle_delete(params: &Value, ctx: &HandlerCtx) -> Value {
             return json!({"ok": true});
         }
     }
-    let mut reg = agent::lock_registry(ctx.registry);
-    if let Some(handle) = reg.get(name) {
-        let mut child = crate::sync::lock_poisoned(&handle.child, "api_child");
-        if let Some(pid) = child.process_id() {
-            crate::process::kill_process_tree(pid);
-        }
-        let _ = child.kill();
-        drop(child);
-    }
-    reg.remove(name);
-    drop(reg);
-    crate::sync::lock_poisoned(ctx.configs, "api_configs").remove(name);
-    crate::ipc::remove_port(&crate::daemon::run_dir(ctx.home), name);
-    crate::event_log::log(ctx.home, "delete", name, "deleted via API");
+    // delete_transaction kills the process tree, waits up to CHILD_EXIT_TIMEOUT
+    // for actual exit, then removes registry / drops Telegram binding /
+    // removes configs / removes IPC port / emits event log. Sprint 20 F2 fix:
+    // the previous implementation removed the registry entry before the OS
+    // had reaped the PID, exposing PID re-use + concurrent-spawn collision
+    // races.
+    crate::daemon::lifecycle::delete_transaction(ctx.home, name, ctx.registry, Some(ctx.configs));
     if let Some(n) = ctx.notifier {
         tracing::info!(agent = name, "DELETE emitting InstanceDeleted");
         n.notify(ApiEvent::InstanceDeleted {

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -127,7 +127,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                     );
                     let _ = crate::fleet::remove_instance_from_yaml(ctx.home, &fleet_name);
                 }
-                super::kill_agent(ctx.registry, name);
+                super::kill_agent(ctx.home, ctx.registry, name);
                 super::tui_events::remove_agent_pane(name, ctx.layout);
                 return true;
             }
@@ -174,7 +174,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                 }
 
                 if let Some((backend_cmd, work_dir, display_name, fleet_name)) = pane_info {
-                    super::kill_agent(ctx.registry, &name);
+                    super::kill_agent(ctx.home, ctx.registry, &name);
 
                     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
                     let pc = cols.saturating_sub(2);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -325,7 +325,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             if !agent_is_alive(&registry, &pane.agent_name) {
                 let name = pane.agent_name.clone();
                 overlay = Overlay::None;
-                kill_agent(&registry, &name);
+                kill_agent(&home, &registry, &name);
             }
         }
         if needs_resize {
@@ -614,7 +614,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         // Cleanup: kill all agents
         for tab in &layout.tabs {
             for name in tab.root().agent_names() {
-                kill_agent(&registry, &name);
+                kill_agent(&home, &registry, &name);
             }
         }
     }
@@ -855,14 +855,17 @@ fn scroll_focused(layout: &mut Layout, delta: i32) {
     }
 }
 
-/// Kill an agent and remove from both registry and fleet.yaml.
-fn kill_agent(registry: &AgentRegistry, name: &str) {
-    let mut reg = agent::lock_registry(registry);
-    if let Some(handle) = reg.get(name) {
-        let mut child = crate::sync::lock_poisoned(&handle.child, "app_child");
-        let _ = child.kill();
-    }
-    reg.remove(name);
+/// Kill an agent and remove from registry. Delegates to
+/// [`crate::daemon::lifecycle::delete_transaction`] so app-mode and
+/// daemon-mode share one tear-down path.
+///
+/// Sprint 20 F3 fix: previously called only `child.kill()` (leader-only,
+/// leaving subprocess trees alive on backends like kiro-cli) and skipped
+/// event_log + Telegram binding rollback. The shared transaction now does
+/// `kill_process_tree` + synchronous wait-for-exit + `take_binding` + event
+/// log, matching the API delete path.
+fn kill_agent(home: &Path, registry: &AgentRegistry, name: &str) {
+    crate::daemon::lifecycle::delete_transaction(home, name, registry, None);
 }
 
 /// Whether the agent's child process is still running.

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -369,7 +369,7 @@ pub(super) fn handle_key(
                     }
                     if let Some(tab) = ctx.layout.close_tab(idx) {
                         for name in tab.root().agent_names() {
-                            super::kill_agent(ctx.registry, &name);
+                            super::kill_agent(ctx.home, ctx.registry, &name);
                         }
                     }
                     for (name, wd) in &closed {
@@ -395,7 +395,7 @@ pub(super) fn handle_key(
                         let _ = crate::fleet::remove_instance_from_yaml(ctx.home, fleet_name);
                     }
                     if let Some(name) = tab.close_focused() {
-                        super::kill_agent(ctx.registry, &name);
+                        super::kill_agent(ctx.home, ctx.registry, &name);
                         outcome.needs_resize = true;
                     }
                     if let Some((name, Some(wd))) = closed {
@@ -800,7 +800,7 @@ pub(super) fn handle_key(
                 // overlay.
                 let name = pane.agent_name.clone();
                 *overlay = Overlay::None;
-                super::kill_agent(ctx.registry, &name);
+                super::kill_agent(ctx.home, ctx.registry, &name);
             }
             _ => {
                 let bytes = crate::tui::key_to_bytes(key.code, key.modifiers);

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -1,0 +1,353 @@
+//! Lifecycle transactions for agent spawn / delete / kill flows.
+//!
+//! Centralizes partial-failure rollback so the spawn / delete / kill paths
+//! cannot leak orphan PIDs, phantom registry entries, or stale Telegram
+//! bindings.
+//!
+//! Audit context: Sprint 20 Track B audit (DAEMON.md F1/F2/F3/F5) +
+//! Sprint 20.5 Track A peer-pass cross-validation (Telegram binding leak in F3).
+//!
+//! Two surfaces:
+//! - [`SpawnRollback`] — RAII guard wrapped around `agent::spawn_agent`'s
+//!   ordered mutations; arms on construction, disarms on `commit()`. On Drop
+//!   while armed, undoes whatever steps had marked progress.
+//! - [`delete_transaction`] — synchronous tear-down callable from both API
+//!   `handle_delete` and app-mode `kill_agent`. Waits for child exit (bounded)
+//!   before removing the registry entry, drops the Telegram binding, removes
+//!   configs + IPC port + emits event log.
+
+use crate::agent::AgentRegistry;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Maximum time we wait for a child to actually transition to exited after
+/// kill before force-removing the registry entry. Bounded so a stuck child
+/// doesn't freeze the delete API; force-fallback is logged.
+pub const CHILD_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Poll interval while waiting for child exit. Short enough to be responsive,
+/// long enough to avoid spinning the CPU under contention.
+const CHILD_EXIT_POLL: Duration = Duration::from_millis(50);
+
+type ChildArc = Arc<Mutex<Box<dyn portable_pty::Child + Send>>>;
+
+/// Wait up to [`CHILD_EXIT_TIMEOUT`] for the child to transition to exited.
+/// Returns `true` if the child exited within the budget; `false` if the
+/// timeout fired (caller should force-remove the registry entry anyway and log
+/// a warning).
+pub fn wait_for_child_exit(child: &ChildArc) -> bool {
+    let deadline = std::time::Instant::now() + CHILD_EXIT_TIMEOUT;
+    loop {
+        {
+            let mut guard = match child.lock() {
+                Ok(g) => g,
+                Err(p) => p.into_inner(),
+            };
+            if let Ok(Some(_status)) = guard.try_wait() {
+                return true;
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(CHILD_EXIT_POLL);
+    }
+}
+
+/// Drop the active channel's binding for `name`, if any. Channel-agnostic via
+/// the `Channel` trait `take_binding`. No-op when no channel is registered
+/// (e.g. app mode without Telegram init).
+fn drop_active_binding(name: &str) {
+    if let Some(ch) = crate::channel::active_channel() {
+        let _ = ch.take_binding(name);
+    }
+}
+
+/// Tear down all daemon-side state for an agent: kill child + tree, wait for
+/// exit, remove registry entry, drop active-channel binding, optionally remove
+/// configs entry, remove IPC port, emit event log.
+///
+/// Called by both API `handle_delete` and app-mode `kill_agent` so the two
+/// paths cannot drift in cleanup completeness (Sprint 20 F3 was that drift).
+///
+/// Returns `true` if the cleanup observed the child exiting cleanly; `false`
+/// if [`CHILD_EXIT_TIMEOUT`] fired and we force-removed anyway.
+pub fn delete_transaction(
+    home: &Path,
+    name: &str,
+    registry: &AgentRegistry,
+    configs: Option<&Arc<Mutex<HashMap<String, super::AgentConfig>>>>,
+) -> bool {
+    // Step 1: snapshot the child handle while still holding registry entry,
+    // then release the registry lock before issuing the kill so concurrent
+    // listings aren't blocked while we wait for exit.
+    let child_arc = {
+        let reg = crate::sync::lock_poisoned(registry, "lifecycle_delete_lookup");
+        reg.get(name).map(|h| Arc::clone(&h.child))
+    };
+
+    let waited_ok = if let Some(child_arc) = child_arc {
+        // Step 2: kill process tree first (covers backend child trees like
+        // kiro-cli's bun/mcp/acp), then PTY-side kill as fallback.
+        {
+            let mut child = crate::sync::lock_poisoned(&child_arc, "lifecycle_delete_kill");
+            if let Some(pid) = child.process_id() {
+                crate::process::kill_process_tree(pid);
+            }
+            let _ = child.kill();
+        }
+        // Step 3: synchronous wait for actual exit (Sprint 20 F2 fix —
+        // previously delete returned before the OS had reaped the PID,
+        // exposing PID re-use + concurrent-spawn collision races).
+        wait_for_child_exit(&child_arc)
+    } else {
+        // No registry entry; nothing to wait on.
+        true
+    };
+
+    // Step 4: registry remove (after child exit confirmed or timeout).
+    {
+        let mut reg = crate::sync::lock_poisoned(registry, "lifecycle_delete_remove");
+        reg.remove(name);
+    }
+
+    // Step 5: drop active-channel binding (Sprint 20.5 cross-validation finding).
+    drop_active_binding(name);
+
+    // Step 6: configs cleanup (None when called from app-mode `kill_agent`,
+    // which doesn't track an AgentConfig map — app fleet.yaml is the authority).
+    if let Some(cfgs) = configs {
+        crate::sync::lock_poisoned(cfgs, "lifecycle_delete_configs").remove(name);
+    }
+
+    // Step 7: IPC port cleanup.
+    crate::ipc::remove_port(&super::run_dir(home), name);
+
+    // Step 8: event log.
+    let detail = if waited_ok {
+        "delete: child exited cleanly"
+    } else {
+        "delete: child kill timeout — force-removed registry entry"
+    };
+    crate::event_log::log(home, "delete", name, detail);
+
+    if !waited_ok {
+        tracing::warn!(
+            agent = %name,
+            timeout_secs = CHILD_EXIT_TIMEOUT.as_secs(),
+            "delete_transaction: child did not exit within timeout, force-removed"
+        );
+    }
+
+    waited_ok
+}
+
+/// RAII rollback guard for `agent::spawn_agent`'s ordered mutations.
+///
+/// Constructed early in spawn. As each mutation completes (`mark_child_spawned`,
+/// `mark_registered`), the guard records what to undo. On `commit()`, the
+/// guard disarms and Drop is a no-op. On Drop while armed (caller returned
+/// Err), the guard rolls back in reverse order:
+/// - if registered: remove from registry + drop active-channel binding
+/// - if child spawned: kill process tree + best-effort PTY kill
+///
+/// Rollback does **not** synchronously wait for the child to exit — spawn-side
+/// rollback is best-effort cleanup before reporting Err to the caller, where
+/// blocking the caller would compound the failure.
+pub struct SpawnRollback<'r> {
+    name: String,
+    registry: &'r AgentRegistry,
+    child: Option<ChildArc>,
+    in_registry: bool,
+    armed: bool,
+}
+
+impl<'r> SpawnRollback<'r> {
+    pub fn new(name: &str, registry: &'r AgentRegistry) -> Self {
+        Self {
+            name: name.to_string(),
+            registry,
+            child: None,
+            in_registry: false,
+            armed: true,
+        }
+    }
+
+    /// Record that the OS child has been spawned and stash its handle so the
+    /// guard can kill it on rollback.
+    pub fn mark_child_spawned(&mut self, child: ChildArc) {
+        self.child = Some(child);
+    }
+
+    /// Record that the registry insert has happened.
+    pub fn mark_registered(&mut self) {
+        self.in_registry = true;
+    }
+
+    /// Disarm the rollback. Caller invokes this on the success path.
+    pub fn commit(mut self) {
+        self.armed = false;
+    }
+}
+
+impl<'r> Drop for SpawnRollback<'r> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Rollback in reverse insertion order so observers can't see a
+        // half-cleaned state with a child but no registry entry, etc.
+        if self.in_registry {
+            let mut reg = crate::sync::lock_poisoned(self.registry, "spawn_rollback_registry");
+            reg.remove(&self.name);
+            drop(reg);
+            drop_active_binding(&self.name);
+        }
+        if let Some(child_arc) = self.child.take() {
+            let mut child = crate::sync::lock_poisoned(&child_arc, "spawn_rollback_child");
+            if let Some(pid) = child.process_id() {
+                crate::process::kill_process_tree(pid);
+            }
+            let _ = child.kill();
+        }
+        tracing::warn!(
+            agent = %self.name,
+            "spawn_agent partial failure — rolled back to clean state"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    fn empty_registry() -> AgentRegistry {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-lifecycle-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    #[test]
+    fn spawn_rollback_committed_does_not_remove_registry_entry() {
+        // Pre-seed registry with an arbitrary handle to verify commit() leaves
+        // the entry intact even when the guard is armed mid-flight.
+        let reg = empty_registry();
+        let mut guard = SpawnRollback::new("alpha", &reg);
+        guard.mark_registered();
+        guard.commit();
+        // Drop fires here; armed=false so registry untouched.
+        // We pre-seeded nothing, so the registry should still be empty
+        // (mark_registered is a recorder, not a mutator).
+        assert!(crate::sync::lock_poisoned(&reg, "test")
+            .get("alpha")
+            .is_none());
+    }
+
+    #[test]
+    fn spawn_rollback_armed_drop_removes_registry_entry() {
+        // Insert a placeholder handle so we can observe the rollback removing it.
+        let reg = empty_registry();
+        let placeholder = make_placeholder_handle("beta");
+        crate::sync::lock_poisoned(&reg, "test").insert("beta".into(), placeholder);
+        {
+            let mut guard = SpawnRollback::new("beta", &reg);
+            guard.mark_registered();
+            // No commit — Drop fires armed → registry entry removed.
+        }
+        assert!(crate::sync::lock_poisoned(&reg, "test")
+            .get("beta")
+            .is_none());
+    }
+
+    #[test]
+    fn delete_transaction_no_registry_entry_is_no_op_returns_true() {
+        let home = tmp_home("delete-noop");
+        let reg = empty_registry();
+        // No insert → delete still cleans configs/ipc/event-log; returns true
+        // (no child to wait on, so "exit observed" is vacuously true).
+        let observed_exit = delete_transaction(&home, "ghost", &reg, None);
+        assert!(
+            observed_exit,
+            "missing registry entry → wait is vacuous true"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Build a minimally-valid AgentHandle whose `child` is a real (already-exited)
+    /// process so test assertions about cleanup don't depend on a live PTY.
+    fn make_placeholder_handle(name: &str) -> crate::agent::AgentHandle {
+        use portable_pty::{native_pty_system, PtySize};
+        let pty = native_pty_system();
+        let pair = pty
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+        let mut cmd = portable_pty::CommandBuilder::new("true");
+        cmd.cwd(std::env::temp_dir());
+        let child = pair.slave.spawn_command(cmd).expect("spawn 'true'");
+        drop(pair.slave);
+        let pty_writer: crate::agent::PtyWriter =
+            Arc::new(Mutex::new(pair.master.take_writer().expect("take_writer")));
+        let pty_master: Arc<Mutex<Box<dyn portable_pty::MasterPty + Send>>> =
+            Arc::new(Mutex::new(pair.master));
+        let core = Arc::new(Mutex::new(crate::agent::AgentCore {
+            vterm: crate::vterm::VTerm::with_pty_writer(80, 24, Arc::clone(&pty_writer)),
+            subscribers: Vec::new(),
+            state: crate::state::StateTracker::new(None),
+            health: crate::health::HealthTracker::new(),
+        }));
+        crate::agent::AgentHandle {
+            name: name.to_string(),
+            backend_command: "true".to_string(),
+            pty_writer,
+            pty_master,
+            core,
+            child: Arc::new(Mutex::new(child)),
+            submit_key: "\r".to_string(),
+            inject_prefix: String::new(),
+            typed_inject: false,
+        }
+    }
+
+    #[test]
+    fn delete_transaction_with_exited_child_returns_true() {
+        let home = tmp_home("delete-exited");
+        let reg = empty_registry();
+        let handle = make_placeholder_handle("gamma");
+        crate::sync::lock_poisoned(&reg, "test").insert("gamma".into(), handle);
+        // `true` exits immediately, so wait_for_child_exit should observe
+        // the exit on the first try_wait.
+        let observed_exit = delete_transaction(&home, "gamma", &reg, None);
+        assert!(
+            observed_exit,
+            "exited child must be observed within timeout"
+        );
+        assert!(
+            crate::sync::lock_poisoned(&reg, "test")
+                .get("gamma")
+                .is_none(),
+            "registry entry must be removed after delete"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3,6 +3,7 @@
 
 pub(crate) mod ci_watch;
 pub(crate) mod cron_tick;
+pub(crate) mod lifecycle;
 pub(crate) mod poll_reminder;
 pub(crate) mod supervisor;
 mod tui_bridge;
@@ -1077,9 +1078,25 @@ fn spawn_and_register_agent(
     let rdir = run_dir(home);
     let reg = Arc::clone(registry);
     let n = name.clone();
-    std::thread::Builder::new()
+    // fire-and-forget: serve_agent_tui blocks on UnixListener::accept and
+    // exits when the agent is removed from the registry. JoinHandle is
+    // discarded because shutdown is signalled implicitly by socket-file
+    // removal in delete_transaction.
+    if let Err(e) = std::thread::Builder::new()
         .name(format!("{n}_tui_server"))
-        .spawn(move || serve_agent_tui(&n, &rdir, &reg))?;
+        .spawn(move || serve_agent_tui(&n, &rdir, &reg))
+    {
+        // Sprint 20 F5 fix: previously a TUI server spawn failure left the
+        // agent registered + child running but with no attachable socket.
+        // Roll back the agent we just spawned so retries start clean.
+        tracing::warn!(
+            agent = %name,
+            error = %e,
+            "TUI server thread spawn failed — rolling back agent registration"
+        );
+        lifecycle::delete_transaction(home, name, registry, Some(configs));
+        return Err(e.into());
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## 問題 → 方案

**問題** (Sprint 20 Track B audit DAEMON.md F1/F2/F3/F5 + Sprint 20.5 cross-validation):
- **F1** \`spawn_agent\` partial-failure → orphan PID (\`take_writer\`/\`try_clone_reader\` fail leaves child) or phantom registry entry (pty_read_loop spawn fail leaves registered+child but no reader)
- **F2** delete async-kill registry-mutate-first → race window: registry says agent gone, OS PID still alive, exposes PID re-use + concurrent-spawn collision
- **F3** app-mode \`kill_agent\` SIGKILL leader only → kiro-cli's bun/mcp/acp subprocess tree survives; no event_log; no Telegram binding rollback (cross-validation finding from A peer-pass)
- **F5** TUI server spawn no rollback → agent registered + child running but no attachable socket on Err

**方案** (per Sprint 21 Phase 1 dispatch):

新 module \`src/daemon/lifecycle.rs\` 抽 shared helper. 4 call sites consume helper. **Helper module first in PR diff** so reviewer reads it once, then 4 call-sites are mechanical.

## Helper module (`src/daemon/lifecycle.rs`)

| API | Purpose |
|---|---|
| \`pub fn wait_for_child_exit(child) -> bool\` | bounded poll (\`CHILD_EXIT_TIMEOUT=5s\`) of \`try_wait\` until exited or timeout |
| \`pub fn delete_transaction(home, name, registry, configs) -> bool\` | kill_process_tree → wait → registry remove → drop_active_binding → optional configs remove → IPC port remove → event log; returns observed-exit bool |
| \`pub struct SpawnRollback<'r>\` | RAII guard with \`mark_child_spawned\` / \`mark_registered\` / \`commit\`; armed Drop rolls back in reverse |

## 4 call sites

| ID | File:line | Change |
|---|---|---|
| **B1** | \`src/agent.rs::spawn_agent\` | SpawnRollback armed at fn entry; mark_child_spawned after spawn_command, mark_registered after registry insert; commit() at end |
| **B2** | \`src/api/handlers/instance.rs::handle_delete\` | inline kill+remove → \`delete_transaction(...)\`; preserves notifier + fleet_broadcast |
| **B3** | \`src/app/mod.rs::kill_agent\` | signature gains \`home: &Path\`; delegates to \`delete_transaction(home, name, registry, None)\`; 8 callers updated (2 in app/mod.rs + 3 in overlay.rs + 2 in commands.rs) |
| **B5** | \`src/daemon/mod.rs::spawn_and_register_agent\` | TUI server \`spawn(...)\` Err now calls \`lifecycle::delete_transaction\` to roll back the just-spawned agent before propagating Err |

## Phase 5a invariant test prep

Two existing spawn sites annotated with \`// fire-and-forget: <reason>\` rationale comments per dispatch:
- \`agent.rs:430\` \`<n>_pty_read\` thread — exits on PTY EOF when child killed
- \`daemon/mod.rs:1080\` \`<n>_tui_server\` thread — exits on socket-file removal in delete_transaction

## Critical constraints honored (per dispatch)

- ✅ \`supervisor.rs\` untouched (F6 deferred Sprint 22 per impl-1 #1 — file conflict avoidance)
- ✅ Telegram binding rollback included (cross-validation A peer-pass finding) — via \`drop_active_binding\` channel-trait abstraction
- ✅ Phase 1 closes ONLY lifecycle attack class (NOT auth — Phase 2 owns)
- ✅ Helper module first in PR diff order

## Tests (~120 LOC in lifecycle.rs::tests)

- \`spawn_rollback_committed_does_not_remove_registry_entry\` — commit() disarms Drop
- \`spawn_rollback_armed_drop_removes_registry_entry\` — Drop without commit removes pre-seeded entry
- \`delete_transaction_no_registry_entry_is_no_op_returns_true\` — missing entry path
- \`delete_transaction_with_exited_child_returns_true\` — uses real \`true\` process via portable_pty (already-exited child)

## CI verification (Tier-2 evidence chain)

- \`cargo fmt --check\` → clean
- \`cargo clippy --all-targets --features tray -- -D warnings\` → clean
- \`cargo test --features tray\` → **1134 pass** (1130 baseline + 4 new lifecycle tests), 0 failed

## Test plan

- [x] Helper module first in diff (single PR review-able)
- [x] B1 SpawnRollback covers F1 orphan + phantom windows
- [x] B2 delete_transaction synchronous wait closes F2 race
- [x] B3 app-mode kill_agent now uses kill_process_tree + binding drop + event log (F3 + cross-validation parity)
- [x] B5 TUI server spawn Err triggers delete_transaction rollback (F5)
- [x] supervisor.rs untouched (F6 Sprint 22 deferral)
- [x] All 8 kill_agent callers updated for new signature
- [x] Local CI: fmt clean, clippy clean, 1134 tests pass
- [x] Phase 5a invariant prep: 2 spawn sites annotated with fire-and-forget rationale

## Source

- Dispatch: \`m-20260426235751434989-127\`
- Scope freeze: Sprint 21 final \`d-20260426235704857573-8\` (post-challenge round 10 修正項)
- Audit cross-ref: \`docs/codebase-review-2026-04-27/DAEMON.md\` §1 F1/F2/F3/F5 + §3 JoinHandle inventory + §8 Sprint 20.5 cross-validation

## Reviewer

dev-reviewer-2 single (per dispatch — Phase 1 critical lifecycle).

## Authority

MEDIUM PR — operator review before merge per Sprint 21 risk-tier rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)