### PR TITLE
Sprint 21 Phase 1 follow-up: quickstart.md user_allowlist + migration (LOW doc-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ instances:
   reviewer:
     role: "Code reviewer"
     working_directory: ~/my-project
+
+# Optional: bind the fleet to a Telegram group for remote control + alerts.
+# `user_allowlist` is REQUIRED to receive outbound notifications (stall /
+# crash / CI alerts). Without it, the fleet runs but the bound group is
+# muted (fail-closed default — see docs/USAGE.md "Channel: Telegram").
+# channel:
+#   type: telegram
+#   bot_token_env: AGEND_BOT_TOKEN
+#   group_id: YOUR_GROUP_ID
+#   user_allowlist: [YOUR_TELEGRAM_USER_ID]   # message @userinfobot to get yours
 YAML
 agend-terminal start
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -116,6 +116,58 @@ agend-terminal tray (menu-bar resident)
   └── Auto-starts daemon → click "Open App" → launches TUI
 ```
 
+## Channel: Telegram
+
+Bind the fleet to a Telegram group for remote control (send messages to
+agents from your phone) and outbound notifications (stall / crash / CI
+alerts pushed back to the group).
+
+### Minimum config
+
+```yaml
+channel:
+  type: telegram
+  bot_token_env: AGEND_BOT_TOKEN          # env var holding the bot token
+  group_id: -1001234567890                # Telegram chat id of the group
+  user_allowlist: [123456789]             # operator Telegram user_id(s)
+```
+
+Then export the bot token before `agend-terminal start`:
+
+```bash
+export AGEND_BOT_TOKEN="123456:abcdef..."
+```
+
+### How to get values
+
+- **Bot token** (`AGEND_BOT_TOKEN`): create a bot via [@BotFather](https://t.me/BotFather), copy the token it returns.
+- **Group id**: add your bot to the target group, then send any message and inspect the bot's `getUpdates` API (`https://api.telegram.org/bot<TOKEN>/getUpdates`) — the `chat.id` is your `group_id` (negative for groups / supergroups).
+- **User id**: message [@userinfobot](https://t.me/userinfobot) on Telegram and it replies with your numeric user id. Add every operator who should be allowed to command the fleet.
+
+### `user_allowlist` semantics (Sprint 21 fail-closed default)
+
+| `user_allowlist` value | Inbound (sender filter) | Outbound (notification gate) |
+|---|---|---|
+| `[123, 456]` (≥ 1 entry) | Listed users only — others rejected | ✅ Notifications delivered |
+| `[]` (empty list) | Everyone rejected | 🔇 Notifications dropped (fail-closed) |
+| field absent / `null` | Legacy: everyone accepted (deprecated) | 🔇 Notifications dropped (fail-closed) |
+
+The outbound gate landed in [PR #216](https://github.com/suzuke/agend-terminal/pull/216) (Sprint 21 Phase 1) to close the
+[Sprint 20.5 cross-validation](codebase-review-2026-04-27/SYNTHESIS.md) outbound info-leak finding (40-line PTY tails were leaking to anyone added to a bound group regardless of inbound auth state). Inbound fail-closed is being landed in Phase 2.
+
+### Migration: upgrading from < Sprint 21
+
+If your `fleet.yaml` previously had a `channel.telegram` block **without** `user_allowlist`, the fleet still runs after upgrading but **outbound notifications now drop silently** (fail-closed). You will see:
+
+```
+WARN: telegram channel.user_allowlist is not set — any group member can command the fleet. \
+      Set `user_allowlist: [123, 456]` in fleet.yaml to lock this down.
+```
+
+To restore outbound notifications, add your operator user_id(s) to `user_allowlist`. This is the **only required migration step**; bot token and group id remain unchanged.
+
+If you previously relied on legacy "anyone in the group can command the fleet" behaviour, the inbound side still accepts all users until Phase 2 lands; configure `user_allowlist` now to close both sides simultaneously.
+
 ## Other Commands
 
 | Command | Purpose |


### PR DESCRIPTION
## Summary

PR #216 (Sprint 21 Phase 1 outbound notify gate) shipped fail-closed default — deployments without `user_allowlist` configured now drop stall / crash / CI alerts (intentional). Without doc updates, new users following the README quickstart and existing operators upgrading would silently lose outbound notifications.

Per operator request (telegram 22:09 UTC «fleet.yaml 加 user_allowlist，那是不是quickstart也要一併幫忙加？») + dispatch `m-20260427002521393545-145`.

## 問題 → 方案

**問題**: `docs/quickstart.md` does not exist; the canonical "quickstart" entry is `README.md ## Quick Start`. New users hand-writing fleet.yaml from the README example get a config without `channel:` (so no Telegram surface) — and even when they add Telegram via the interactive `agend-terminal quickstart` command, the generated config emits `channel:` block **without** `user_allowlist`, leaving them silently muted post PR #216.

**方案**:
1. **README.md `## Quick Start`**: extend the hand-written fleet.yaml example with an optional commented `channel:` block including `user_allowlist`, with a pointer to the USAGE.md section for full details.
2. **docs/USAGE.md**: new `## Channel: Telegram` section covering:
   - Minimum config example with `user_allowlist`
   - How to obtain bot token (`@BotFather`), group_id (`getUpdates` API), user_id (`@userinfobot`)
   - `user_allowlist` semantics table covering inbound + outbound for `[u1, u2]` / `[]` / absent (3 rows)
   - Migration note for upgrading from < Sprint 21 (deprecation warn log + fix steps)
   - Cross-ref PR #216 + Sprint 20.5 SYNTHESIS

## Out-of-scope (REJECTED per dispatch)

- Production code (`src/quickstart.rs:250-257` still emits `channel:` without `user_allowlist`; flagged as observation in commit message — operator may file backlog task to update interactive quickstart prompt).
- `fleet.yaml` schema changes (settled in PR #216).
- Protocol doc edits (Phase 5a Q6 territory).

## v1.2 §3 evidence chain (Tier-1 minimal per challenge #8 mechanical doc edit)

- **reviewed_head**: `8bbf0a5`
- **scope_source**: dispatch `m-20260427002521393545-145` + Sprint 21 final scope `d-20260426235704857573-8`

## Test plan

- [x] `cargo fmt --check` ✓ (no Rust changes)
- [x] `cargo clippy --all-targets --features tray -- -D warnings` ✓
- [x] Diff: 2 files changed, +62 / -0 lines (README +10, USAGE +52)

🤖 Generated with [Claude Code](https://claude.com/claude-code)