### PR TITLE
Sprint 21 F-NEW1 — agent.rs PTY EOF kill_process_tree (Phase 1 extension lifecycle hygiene, ~10 LOC + test)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -664,6 +664,24 @@ fn pty_read_loop(pty_reader: &mut dyn Read, ctx: &PtyReadContext) {
     }
 }
 
+/// Sprint 21 F-NEW1: kill the process tree rooted at the agent's child PID,
+/// if still registered. Looks up the PID through the registry → child mutex
+/// chain, then delegates to [`crate::process::kill_process_tree`] (PR-U #158).
+///
+/// No-op if the agent is not in the registry (already cleaned up) or if the
+/// child has no live PID (already reaped). Idempotent on dead PIDs — safe to
+/// call multiple times during the same crash-detection sequence.
+fn sweep_child_tree(name: &str, registry: &AgentRegistry) {
+    let pid: Option<u32> = {
+        let reg = crate::sync::lock_poisoned(registry, "agent_registry");
+        reg.get(name)
+            .and_then(|h| h.child.lock().ok().and_then(|c| c.process_id()))
+    };
+    if let Some(pid) = pid {
+        crate::process::kill_process_tree(pid);
+    }
+}
+
 /// Handle PTY close: determine if crash, graceful exit, or daemon shutdown.
 fn handle_pty_close(
     name: &str,
@@ -732,6 +750,15 @@ fn handle_pty_close(
             true
         }
     };
+
+    // Sprint 21 F-NEW1: sweep the child process tree before respawn fires so
+    // any leaked grandchildren (kiro-cli's bun + acp etc.) don't survive across
+    // the respawn boundary and collide with the new process tree's port/file
+    // locks. PR-U #158 added kill_process_tree to handle_kill / handle_delete /
+    // run_core but missed this PTY-EOF crash-detection path. Covers both branches:
+    // try_wait succeeded (graceful or crash exit may still leave grandchildren
+    // orphaned to PID 1) and the 2s timeout (leader still alive).
+    sweep_child_tree(name, registry);
 
     // In daemon mode, ALL unexpected exits trigger respawn — even exit 0.
     // An agent exiting on its own (not via `kill` or shutdown) is unexpected.
@@ -1045,5 +1072,124 @@ mod tests {
         let screen = vt.tail_lines(24);
         let patterns = vec![("Do you trust".to_string(), b"\n".to_vec())];
         assert!(try_dismiss_dialog("t", &screen, &test_writer(), &patterns));
+    }
+
+    /// Sprint 21 F-NEW1: verify that `sweep_child_tree` reaches grandchild
+    /// processes spawned via the agent's PTY. Mirrors the kiro-cli pattern
+    /// where the leader shell forks bun/mcp/acp grandchildren — the regression
+    /// PR-U #158 fixed for explicit kill paths but missed for PTY-EOF crash
+    /// detection.
+    #[test]
+    #[cfg(unix)]
+    fn sweep_child_tree_kills_grandchild_via_process_group() {
+        use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+
+        let pty = native_pty_system();
+        let pair = pty
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+        let pid_file =
+            std::env::temp_dir().join(format!("agend-sweep-test-{}.pid", std::process::id()));
+        let _ = std::fs::remove_file(&pid_file);
+        // sh forks `sleep` into the background; sleep PID is recorded so the
+        // test can verify it dies with the leader (group kill semantics).
+        let cmd_str = format!("sleep 60 & echo $! > {} && wait", pid_file.display());
+        let mut cmd = CommandBuilder::new("sh");
+        cmd.args(["-c", &cmd_str]);
+        cmd.cwd(std::env::temp_dir());
+        let child = pair.slave.spawn_command(cmd).expect("spawn sh + sleep");
+        drop(pair.slave);
+        let shell_pid = child.process_id().expect("shell process_id");
+
+        // Build a minimal AgentHandle so sweep_child_tree's registry-lookup
+        // path is exercised end-to-end (not just kill_process_tree directly).
+        let pty_writer: PtyWriter =
+            Arc::new(Mutex::new(pair.master.take_writer().expect("take_writer")));
+        let pty_master: Arc<Mutex<Box<dyn portable_pty::MasterPty + Send>>> =
+            Arc::new(Mutex::new(pair.master));
+        let core = Arc::new(Mutex::new(AgentCore {
+            vterm: crate::vterm::VTerm::with_pty_writer(80, 24, Arc::clone(&pty_writer)),
+            subscribers: Vec::new(),
+            state: StateTracker::new(None),
+            health: HealthTracker::new(),
+        }));
+        let handle = AgentHandle {
+            name: "sweep-test".to_string(),
+            backend_command: "sh".to_string(),
+            pty_writer,
+            pty_master,
+            core,
+            child: Arc::new(Mutex::new(child)),
+            submit_key: "\r".to_string(),
+            inject_prefix: String::new(),
+            typed_inject: false,
+        };
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        crate::sync::lock_poisoned(&registry, "test").insert("sweep-test".to_string(), handle);
+
+        // Wait for sleep grandchild to start and write its PID
+        for _ in 0..40 {
+            if pid_file.exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        let sleep_pid: u32 = std::fs::read_to_string(&pid_file)
+            .unwrap_or_default()
+            .trim()
+            .parse()
+            .expect("parse sleep grandchild PID");
+        assert!(
+            crate::process::is_pid_alive(shell_pid),
+            "shell leader must be alive before sweep"
+        );
+        assert!(
+            crate::process::is_pid_alive(sleep_pid),
+            "sleep grandchild must be alive before sweep"
+        );
+
+        // Invoke the new helper. Should kill the entire process group.
+        sweep_child_tree("sweep-test", &registry);
+
+        // Reap the shell child so kill(pid, 0) doesn't see it as a zombie.
+        // Without wait(), the shell shows as "alive" even after SIGKILL
+        // because we are its parent and never collected its exit status.
+        {
+            let reg = crate::sync::lock_poisoned(&registry, "test");
+            if let Some(h) = reg.get("sweep-test") {
+                if let Ok(mut c) = h.child.lock() {
+                    let _ = c.wait();
+                }
+            }
+        }
+
+        assert!(
+            !crate::process::is_pid_alive(shell_pid),
+            "shell leader must be dead (reaped) after sweep"
+        );
+        assert!(
+            !crate::process::is_pid_alive(sleep_pid),
+            "sleep grandchild must die with the group (kill_process_tree semantics)"
+        );
+        let _ = std::fs::remove_file(&pid_file);
+    }
+
+    #[test]
+    fn sweep_child_tree_unregistered_name_is_no_op() {
+        // Sprint 21 F-NEW1: registry lookup miss must not panic. The PTY-EOF
+        // path may race against an explicit handle_delete that already cleaned
+        // up the registry entry — sweep should simply find nothing to kill.
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        // Should not panic, should not error.
+        sweep_child_tree("does-not-exist", &registry);
     }
 }


### PR DESCRIPTION
## 問題 → 方案

**問題** (general 4-26 \`replace_instance\` dev-impl-1 卡 \`[restarting]\` root cause investigation):
- PR-U #158 (af76783) 加 \`kill_process_tree(pid)\` 只 cover **3 explicit kill paths** (\`handle_kill\` / \`handle_delete\` / \`run_core\`).
- **4th path 漏: pty_read_loop crash detection** (\`src/agent.rs::handle_pty_close\`).
- daemon PTY EOF → 2s \`try_wait\` → mark crash → fire \`crash_tx\` → respawn — 但**殘留 child process tree never killed**.
- kiro-cli's bun + acp grandchildren (4-26 incident: PIDs 49777 + 49799) leak across respawn.
- Respawn tries spawn fresh bun → port/file lock collision → fail → 卡 \`[restarting]\`.

**方案** (~10 LOC + 2 tests):
- New helper \`agent::sweep_child_tree(name, registry)\` — registry → child mutex → \`process_id()\` → \`crate::process::kill_process_tree(pid)\`.
- Called from \`handle_pty_close\` immediately before \`set_restarting\` / \`crash_tx.send\`. Covers **BOTH branches**:
  - \`try_wait\` succeeded (graceful exit may leave grandchildren orphaned to PID 1)
  - 2s timeout (leader still alive)
- Idempotent on dead PIDs. No-op when registry lookup misses.

## Each-phase-attack-class statement (per Sprint 21 dispatch)

- ✅ **Phase 1 extension lifecycle hygiene** — F1-F5 family + 4th kill path
- ✅ **NOT auth** (Phase 2 owns)
- ✅ **NOT \`supervisor.rs\`** (F6 deferred Sprint 22)
- ✅ **NOT replace flow / record_crash backoff / respawn flow** (operator out-of-scope clear)
- ✅ **NOT amend PR #217** (already merged) — independent PR
- ✅ **NOT touch \`lifecycle.rs\` helper** (per dispatch — pure agent.rs PTY EOF path patch)

## Tests

| Test | Purpose |
|---|---|
| \`sweep_child_tree_kills_grandchild_via_process_group\` (Unix-only) | spawns \`sh\` → \`sleep\` grandchild via \`portable_pty\`, asserts both die after sweep. Reuses PR-U #158 test pattern; reaps shell with \`child.wait()\` to avoid zombie false-positive in \`is_pid_alive\` check. |
| \`sweep_child_tree_unregistered_name_is_no_op\` | registry lookup miss must not panic (race with concurrent \`handle_delete\`) |

## CI verification (Tier-2 evidence chain)

- \`cargo fmt --check\` → clean
- \`cargo clippy --all-targets --features tray -- -D warnings\` → clean
- \`cargo test --features tray\` → **1146 pass** (1144 baseline incl. PR #217 + 2 new sweep tests), 0 failed

## Test plan

- [x] \`sweep_child_tree\` helper extracted with single-responsibility (registry lookup + kill_process_tree delegation)
- [x] \`handle_pty_close\` calls sweep before set_restarting / crash_tx.send (covers both try_wait succeeded + 2s timeout branches)
- [x] Unit test verifies grandchild dies via process group kill semantics (kiro-cli bootstrap pattern)
- [x] Unit test verifies missing registry entry is no-op (race-safe)
- [x] \`supervisor.rs\` untouched
- [x] \`lifecycle.rs\` (PR #217 author = me) untouched
- [x] No replace flow / respawn flow changes
- [x] Local CI: fmt clean, clippy clean, all 1146 tests pass

## Source

- Dispatch: \`m-20260427010004062025-163\`
- Scope freeze: Sprint 21 F-NEW1 mini \`d-20260427005912079981-9\`
- Root cause investigation: general 2026-04-26 \`replace_instance\` dev-impl-1 \`[restarting]\` incident (PIDs 49777 + 49799 grandchildren leak)
- Cross-ref: PR-U #158 (af76783) — original \`kill_process_tree\` introduction
- Phase 1 PR #217 (b44668e) — lifecycle.rs helper module (untouched here)

## Reviewer

dev-reviewer single (per dispatch — LOW ~10 LOC + test, ~5 min review).

## Authority

LOW — dev-lead self-merge after VERIFIED + CI green per dispatch authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)