### PR TITLE
Sprint 22 P2a — F7 atomic clear via save_metadata_batch + M1 invariant scope ext (~40 LOC)

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -231,8 +231,24 @@ fn clear_waiting_on_if_stale(home: &std::path::Path, name: &str, is_stale: bool)
         .and_then(|v| v.as_str())
         .is_some_and(|s| !s.is_empty())
     {
-        crate::agent_ops::save_metadata(home, name, "waiting_on", serde_json::json!(null));
-        crate::agent_ops::save_metadata(home, name, "waiting_on_since", serde_json::json!(null));
+        // Sprint 22 P2a F7 fix (Sprint 20 DAEMON.md §1 Critical F7): single
+        // atomic write replaces two sequential `save_metadata` calls. The
+        // pre-fix code had a partial-write window where a daemon crash
+        // between the two writes left disk state inconsistent
+        // (waiting_on=null + waiting_on_since=set), and `set_waiting_on`'s
+        // freshness logic on restart would interpret a non-null `since`
+        // as "agent is currently waiting" without a `waiting_on` value —
+        // divergent state. `save_metadata_batch` (added Sprint 5
+        // commit 33135ee, regression tests added Sprint 21 PR #227) does
+        // one read-modify-write cycle.
+        crate::agent_ops::save_metadata_batch(
+            home,
+            name,
+            &[
+                ("waiting_on", serde_json::json!(null)),
+                ("waiting_on_since", serde_json::json!(null)),
+            ],
+        );
         tracing::info!(%name, "waiting_on cleared — heartbeat stale");
     }
 }
@@ -304,6 +320,102 @@ mod tests {
             "fresh heartbeat must NOT clear waiting_on"
         );
 
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Sprint 22 P2a F7 regression — both `waiting_on` and `waiting_on_since`
+    /// must land in a single atomic disk write so a crash mid-clear cannot
+    /// leave divergent state (waiting_on=null + waiting_on_since=set, which
+    /// `set_waiting_on` freshness logic interprets on restart as "agent is
+    /// currently waiting" without a `waiting_on` value).
+    ///
+    /// The pre-fix code had two sequential `save_metadata` calls; this test
+    /// pins the contract that the call site delegates to
+    /// `agent_ops::save_metadata_batch` (single read-modify-write cycle).
+    /// Source-grep verifies the two-call regression cannot reappear:
+    /// `clear_waiting_on_if_stale` must contain `save_metadata_batch` and
+    /// must NOT contain two adjacent `save_metadata(` calls.
+    #[test]
+    fn waiting_on_clear_uses_atomic_batch_write() {
+        // Source-grep guard: pin that the impl uses save_metadata_batch
+        // (closes F7 race window). Future regression to two-call form
+        // would fail-loud here.
+        let src = include_str!("supervisor.rs");
+        let body_start = src
+            .find("fn clear_waiting_on_if_stale(")
+            .expect("clear_waiting_on_if_stale must exist");
+        // Bound the search to the function body (next top-level fn).
+        let rest = &src[body_start..];
+        let body_end = rest
+            .find("\nfn ")
+            .or_else(|| rest.find("\npub fn "))
+            .or_else(|| rest.find("\n#[cfg(test)]"))
+            .unwrap_or(rest.len());
+        let body = &rest[..body_end];
+
+        assert!(
+            body.contains("save_metadata_batch("),
+            "clear_waiting_on_if_stale must use `save_metadata_batch` for atomic \
+             multi-field write (Sprint 22 P2a F7 fix). Found body:\n{body}"
+        );
+        // Sanity check: the legacy two-call pattern must NOT reappear.
+        // We check that the body contains at most ONE `save_metadata(`
+        // substring — `save_metadata_batch(` matches separately because
+        // we look for the open paren after `metadata` not `metadata_batch`.
+        let single_calls = body.matches("save_metadata(").count();
+        assert!(
+            single_calls == 0,
+            "clear_waiting_on_if_stale must NOT call individual `save_metadata` \
+             — F7 race fix requires `save_metadata_batch` (single atomic write). \
+             Found {single_calls} `save_metadata(` call(s) in body:\n{body}"
+        );
+    }
+
+    /// Sprint 22 P2a F7 behavioural regression — verify the atomic batch
+    /// write produces the expected on-disk state when both fields land
+    /// together. Pairs with the source-grep guard above; this test catches
+    /// a regression where the helper signature changes but the call site
+    /// still compiles.
+    #[test]
+    fn waiting_on_clear_writes_both_nulls_atomically() {
+        let home = tmp_home("f7_atomic");
+        let meta_dir = home.join("metadata");
+        std::fs::create_dir_all(&meta_dir).ok();
+        // Pre-populate with active wait state + an unrelated field that
+        // must survive the batch write (read-modify-write contract).
+        let meta = serde_json::json!({
+            "waiting_on": "review from at-dev-4",
+            "waiting_on_since": "2026-04-27T05:00:00Z",
+            "last_heartbeat": "2026-04-27T04:55:00Z",
+            "role": "dev-impl-2",
+        });
+        std::fs::write(
+            meta_dir.join("agent_atomic.json"),
+            serde_json::to_string_pretty(&meta).expect("serialize"),
+        )
+        .ok();
+
+        clear_waiting_on_if_stale(&home, "agent_atomic", true);
+
+        let raw = std::fs::read_to_string(meta_dir.join("agent_atomic.json"))
+            .expect("metadata file present");
+        let v: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON");
+        assert!(
+            v["waiting_on"].is_null(),
+            "waiting_on must be null after F7 atomic clear"
+        );
+        assert!(
+            v["waiting_on_since"].is_null(),
+            "waiting_on_since must be null after F7 atomic clear (paired with waiting_on)"
+        );
+        assert_eq!(
+            v["last_heartbeat"], "2026-04-27T04:55:00Z",
+            "unrelated `last_heartbeat` must survive the batch write"
+        );
+        assert_eq!(
+            v["role"], "dev-impl-2",
+            "unrelated `role` must survive the batch write"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/tests/legacy_outbound_path_audit.rs
+++ b/tests/legacy_outbound_path_audit.rs
@@ -124,49 +124,73 @@ fn legacy_try_telegram_fns_unreachable_outside_telegram_impl() {
     );
 }
 
-/// Sprint 22 P0 reviewer-2 must-have — MCP instance-mutating handlers
-/// must NOT accept `outbound_capabilities` from agent-API args. Operator
-/// grants happen via fleet.yaml on disk; agent-API grants would defeat
-/// the per-instance capability gate.
+/// Sprint 22 P0 reviewer-2 must-have + Sprint 22 P2a M1 fold-in — MCP
+/// instance-mutating handlers AND their dispatch chain must NOT accept
+/// `outbound_capabilities` from agent-API args. Operator grants happen
+/// via fleet.yaml on disk; agent-API grants would defeat the per-instance
+/// capability gate.
 ///
-/// Grep-based check: scan `src/mcp/handlers.rs` for any reference to
-/// `args["outbound_capabilities"]` or `args.get("outbound_capabilities")`
-/// inside the four instance-mutating handler arms. Today: 0 hits expected.
-/// Future regression (someone wires through the arg): test fails-loud.
+/// Sprint 22 P0 dev-reviewer M1 finding (NON-BLOCKING): the original
+/// scope of this test only covered `src/mcp/handlers.rs`, missing the
+/// `deploy_template` arm at `handlers.rs:1201` which dispatches to
+/// `crate::deployments::deploy(...)`. Today's `src/deployments.rs` has
+/// 0 production hits (manually verified Sprint 22 P0 review), but a
+/// future regression there would not trip this test.
+///
+/// Sprint 22 P2a (this PR) extends the scan to cover the dispatch chain
+/// from each instance-mutating MCP arm — closes the M1 invariant gap.
 #[test]
 fn mcp_handlers_do_not_accept_outbound_capabilities_arg() {
     let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-    let handlers_path = src_root.join("mcp/handlers.rs");
-    let content = std::fs::read_to_string(&handlers_path).expect("src/mcp/handlers.rs must exist");
-
-    // Cut off at #[cfg(test)] so unit-test fixtures don't trip.
-    let cutoff_byte = content.find("#[cfg(test)]").unwrap_or(content.len());
-    let prod = &content[..cutoff_byte];
+    // Sprint 22 P2a M1 fold-in: extend scan to every file in the dispatch
+    // chain from instance-mutating MCP handlers. New entries here as the
+    // chain grows (e.g. future MCP handlers that dispatch into new
+    // sub-modules with instance-config mutation surfaces).
+    let scanned_files: &[&str] = &[
+        "mcp/handlers.rs", // top-level MCP dispatch (Sprint 22 P0 original scope)
+        "deployments.rs",  // `deploy_template` arm dispatches here (Sprint 22 P0 M1 finding)
+    ];
 
     let mut violations: Vec<String> = Vec::new();
-    for (idx, line) in prod.lines().enumerate() {
-        let trim = line.trim_start();
-        if trim.starts_with("//") || trim.starts_with("///") {
+    for rel_suffix in scanned_files {
+        let path = src_root.join(rel_suffix);
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            // File missing — don't fail the test (allows the dispatch
+            // chain to evolve). The scanned_files list is a manual audit
+            // surface; missing files surface via PR review of this test.
             continue;
-        }
-        let lowered = line.to_ascii_lowercase();
-        // Match: `args["outbound_capabilities"]` / `args.get("outbound_capabilities")`
-        // / any direct extraction of the field from the MCP args bag.
-        if (lowered.contains("args[\"outbound_capabilities\"")
-            || lowered.contains("args.get(\"outbound_capabilities\")"))
-            && !lowered.contains("// allowed:")
-        {
-            violations.push(format!(
-                "  src/mcp/handlers.rs:{}: MCP handler extracts `outbound_capabilities` from agent args — defeats per-instance capability gate\n      offending line: {}",
-                idx + 1,
-                line.trim()
-            ));
+        };
+
+        // Cut off at #[cfg(test)] so unit-test fixtures don't trip.
+        let cutoff_byte = content.find("#[cfg(test)]").unwrap_or(content.len());
+        let prod = &content[..cutoff_byte];
+
+        for (idx, line) in prod.lines().enumerate() {
+            let trim = line.trim_start();
+            if trim.starts_with("//") || trim.starts_with("///") {
+                continue;
+            }
+            let lowered = line.to_ascii_lowercase();
+            // Match: `args["outbound_capabilities"]` / `args.get("outbound_capabilities")`
+            // / any direct extraction of the field from the MCP args bag
+            // OR from a downstream handler's args param.
+            if (lowered.contains("args[\"outbound_capabilities\"")
+                || lowered.contains("args.get(\"outbound_capabilities\")"))
+                && !lowered.contains("// allowed:")
+            {
+                violations.push(format!(
+                    "  src/{}:{}: handler extracts `outbound_capabilities` from agent args — defeats per-instance capability gate\n      offending line: {}",
+                    rel_suffix,
+                    idx + 1,
+                    line.trim()
+                ));
+            }
         }
     }
 
     assert!(
         violations.is_empty(),
-        "Sprint 22 P0 reviewer-2 must-have violations — {} MCP handler(s) accept `outbound_capabilities` from agent args.\n\nFix: remove the args extraction. Operator grants outbound capabilities ONLY via fleet.yaml on disk. Agent-API grants defeat the per-instance gate.\n\nIf this is intentional (operator-only caller), add `// allowed: <reason>` inline comment for documented exemption.\n\nViolations:\n{}",
+        "Sprint 22 P0 reviewer-2 must-have + P2a M1 fold-in violations — {} handler(s) accept `outbound_capabilities` from agent args across MCP dispatch chain.\n\nFix: remove the args extraction. Operator grants outbound capabilities ONLY via fleet.yaml on disk. Agent-API grants defeat the per-instance gate.\n\nIf this is intentional (operator-only caller), add `// allowed: <reason>` inline comment for documented exemption.\n\nIf a NEW dispatch-chain file is added (another sub-module that mutates instance config), extend the `scanned_files` list in this test.\n\nViolations:\n{}",
         violations.len(),
         violations.join("\n")
     );


### PR DESCRIPTION
## 問題 → 方案

Sprint 22 P2a = mechanical helper-swap closes F7 race window from Sprint 20 Track B audit. Real graceful-join + F6 heartbeat coordination defer Sprint 23 architectural design refactor track per dev-lead synthesis (Option C+ accepted).

## 3 in-scope items shipped (~40 LOC)

| # | Item | File(s) | LOC |
|---|---|---|---|
| 1 | **F7 mechanical fix** — `save_metadata × 2` → `save_metadata_batch × 1` (single atomic read-modify-write) | \`src/daemon/supervisor.rs\` | ~12 |
| 2 | **F7 regression tests** — source-grep guard + behavioural atomic-write verification | \`src/daemon/supervisor.rs::tests\` | ~95 |
| 3 | **M1 fold-in** — extend invariant scan to dispatch chain (\`src/deployments.rs\`) | \`tests/legacy_outbound_path_audit.rs\` | ~25 |

## F7 race window closed

Sprint 20 DAEMON.md §1 Critical F7: \`clear_waiting_on_if_stale\` had two sequential \`save_metadata\` calls for \`waiting_on\` + \`waiting_on_since\`. Daemon crash between writes left disk state inconsistent (\`waiting_on=null\` + \`waiting_on_since=set\`), and \`set_waiting_on\` freshness logic on restart interpreted the non-null \`since\` as "agent currently waiting" without a \`waiting_on\` value — divergent state.

Fix: single \`save_metadata_batch\` call (helper from Sprint 5 commit 33135ee, regression tests added by me Sprint 21 PR #227). This is the helper's first consumer site outside \`src/mcp/handlers.rs\` — primitive validates in production.

## M1 invariant scope extended

Sprint 22 P0 dev-reviewer M1 finding (NON-BLOCKING): \`mcp_handlers_do_not_accept_outbound_capabilities_arg\` originally only scanned \`src/mcp/handlers.rs\`, missing the \`deploy_template\` arm dispatch chain. Today \`src/deployments.rs\` has 0 production hits (manually verified Sprint 22 P0 review), but a future regression there would NOT have tripped the test pre-fix.

Sprint 22 P2a fold-in extends \`scanned_files\` list to include \`deployments.rs\`. Pattern is extensible — adding new dispatch-chain files (sub-modules with instance-config mutation surfaces) just requires extending the list.

## Deferred Sprint 23 (decision-record-link \`d-20260427040650778876-12\`)

- **F6 heartbeat coordination race** (architectural — supervisor↔main-loop heartbeat snapshot semantics; NOT \`save_metadata\`-related — dispatch text initially conflated F6 with F7, clarified in P2a scope critique)
- **Real graceful-join refactor** for supervisor + other 14 spawn inventory sites (architectural — shutdown signal plumbing across fleet-wide spawn pattern)

## CI verification (Tier-2 evidence chain)

- \`cargo fmt --check\` → clean
- \`cargo clippy --all-targets --features tray -- -D warnings\` → clean
- \`cargo test --features tray\` → **1186 tests pass** (incl. 2 new F7 tests + extended invariant test), 0 failed
- F7 source-grep guard verified live (test fails-loud if \`save_metadata_batch\` regresses)

## Test plan

- [x] F7 fix uses \`save_metadata_batch\` (single atomic write); two-call legacy form pinned-against-regression by source-grep guard
- [x] F7 atomic write produces correct on-disk state (both nulls land + unrelated fields survive read-modify-write contract)
- [x] M1 invariant test now scans \`src/deployments.rs\` in addition to \`src/mcp/handlers.rs\`; missing-file branch handled (allows dispatch chain to evolve without test maintenance)
- [x] Existing \`waiting_on_cleared_when_heartbeat_stale\` regression test still passes (semantic equivalence preserved by helper swap)
- [x] No supervisor.rs spawn site / loop / heartbeat read changes (F6 + graceful-join deferred per dispatch)

## Source

- Dispatch: \`m-20260427052035438629-395\` (correction \`m-20260427052050…\` for task ID)
- Scope freeze: \`d-20260427040650778876-12\` (Sprint 21 close deferred items + Sprint 22 P2a finalized)
- correlation_id: \`t-20260427052004935411-32\`
- Predecessors: PR #227 (Sprint 21 Phase 5 — \`save_metadata_batch\` regression tests), PR #229 (Sprint 22 P1 — F1 cosmetic alignment), PR #230 (Sprint 22 P0 — Phase 5b hard-cut)

## Reviewer

dev-reviewer single Tier-2 (race-fix correctness + invariant-scope-extension audit). NOT auto-Critical (mechanical helper swap, no path-keyword auto trigger).

## Authority

dev-lead self-merge after VERIFIED + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)