### PR TITLE
feat(sweep): Sprint 24 P0 PR2 — task auto-close sweep daemon + bridge migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "embed-resource",
  "fs2",
  "getrandom 0.2.17",
+ "hex",
  "iana-time-zone",
  "libc",
  "portable-pty",
@@ -37,6 +38,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "sysinfo",
  "tao",
  "teloxide",
@@ -267,6 +269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -564,6 +575,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +689,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "ctrlc"
@@ -787,6 +817,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1242,6 +1282,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1547,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -3390,6 +3446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4182,6 +4249,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,12 @@ async-trait = "0.1"
 fs2 = "0.4"
 dirs = "6"
 regex = "1"
+# Sprint 24 P0 PR2 — task_sweep forensic api_response_hash on PrSnapshot.
+# SHA-256 crypto-grade hash + hex encoding so reviewers can correlate an
+# event's response_hash against an archived GitHub API response without
+# trusting a non-crypto hash to be collision-resistant.
+sha2 = "0.10"
+hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 cron = "0.15"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod heartbeat_pair;
 pub(crate) mod lifecycle;
 pub(crate) mod poll_reminder;
 pub(crate) mod supervisor;
+pub(crate) mod task_sweep;
 pub(crate) mod ticker;
 mod tui_bridge;
 pub(crate) mod watchdog;
@@ -219,6 +220,24 @@ fn run_core(
     initial_digest: Option<HashMap<String, crate::bootstrap::reload::InstanceDigest>>,
     telegram: Option<Arc<dyn crate::channel::Channel>>,
 ) -> anyhow::Result<()> {
+    // Sprint 24 P0 PR2 — bridge-phase legacy migration. Walks tasks.json
+    // and emits canonical Created (+ status transition) events into
+    // task_events.jsonl. Idempotent: re-run is a no-op via tail-scan
+    // against the existing event log. Runs synchronously BEFORE any MCP
+    // tool registration / agent spawn so operators never observe a "list
+    // empty" race. Fail-loud: any error aborts daemon startup so the
+    // operator sees the failure rather than silently inconsistent state.
+    match crate::tasks::migrate_legacy_tasks_json_to_event_log(home) {
+        Ok(rep) => tracing::info!(
+            migrated = rep.migrated,
+            skipped = rep.skipped,
+            "task_events: legacy tasks.json bridge migration complete"
+        ),
+        Err(e) => {
+            return Err(anyhow::anyhow!("task_events: legacy migration failed: {e}"));
+        }
+    }
+
     let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
     if let Some(tg) = telegram.as_ref() {
         tg.attach_registry(Arc::clone(&registry));
@@ -287,6 +306,14 @@ fn run_core(
         &format!("{} agents", agents.len()),
     );
     tracing::info!("running, Ctrl+C or `agend-terminal stop` to stop");
+
+    // Sprint 24 P0 PR2 — task auto-close sweep daemon. Holds the
+    // ticker handle for the duration of run_core so the spawned thread
+    // observes the shared shutdown atomic; drop is a no-op per the
+    // current daemon fire-and-forget convention. Sweep no-ops until the
+    // operator configures `repo` via the `task_sweep_config` MCP tool.
+    let _task_sweep =
+        crate::daemon::task_sweep::TaskSweep::spawn(home.to_path_buf(), Arc::clone(&shutdown));
 
     // Ready ping → agend-supervisor (if we were started under one, i.e.
     // `AGEND_SUPERVISOR_SOCK` env is set). Must come after agents are up

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -1,0 +1,682 @@
+//! Sprint 24 P0 PR2 — task auto-close sweep daemon.
+//!
+//! Periodically polls GitHub for recently merged PRs in a configured repo
+//! and emits canonical `TaskEvent::Linked` + `TaskEvent::Done` events for
+//! every valid `Closes t-XXX-N` marker observed. Mutations route through
+//! [`crate::task_events::append_batch`]; the legacy `tasks.json` is **not**
+//! touched by this module — sweep is forward-only by design (PR3 retires
+//! `tasks.json` and the read path moves to `task_events::replay`).
+//!
+//! ## Sweep validation pipeline (5 dev-reviewer-2 must-haves)
+//! 1. **HTML-comment injection sanitize** — `<!-- Closes t-victim -->`
+//!    rejected (the regex never sees the directive).
+//! 2. **Non-ASCII codepoint reject** on task-ID match — strict ASCII-digit
+//!    regex `(?m)Closes\s+(t-[0-9]+-[0-9]+)` defeats zero-width-char
+//!    homoglyph attacks.
+//! 3. **PR.user.login authorship ONLY** (not git trailer co-author) —
+//!    defends the pre-PR-220 `update_decision` bug class.
+//! 4. **GitHub API schema-mismatch fail-closed** — missing required
+//!    fields (`merge_commit_sha`, `merged_at`, `user.login`) cause the
+//!    sweep to skip the PR rather than emit a half-formed event.
+//! 5. **Squash-merge SHA captured at decision-time** — recorded inside
+//!    `DoneSource::PrMerged.merge_sha` + `PrSnapshot.merge_sha` so the
+//!    decision survives squash deletion / PR description edits.
+//!
+//! ## DaemonTicker integration
+//! Spawned via [`crate::daemon::ticker::DaemonTicker`] with the standard
+//! drop-on-shutdown contract. Forward-compat with Sprint 25+ graceful-
+//! join refactor (caller can switch to `join_on_shutdown()` without
+//! changing the spawn site).
+
+#![allow(dead_code)]
+
+use crate::daemon::ticker::DaemonTicker;
+use crate::task_events::{
+    self, DoneSource, InstanceName, LinkSource, PrId, PrSnapshot, TaskEvent, TaskId,
+};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Default sweep tick interval. Operator can override via the
+/// `task_sweep_config` MCP tool (`interval_secs`); the next tick after
+/// the config save observes the new interval.
+const DEFAULT_SWEEP_TICK_SECS: u64 = 300;
+
+/// Emitter identity stamped on sweep-driven events. Distinct from any
+/// real fleet instance so audit queries can filter sweep contributions
+/// from operator manual transitions.
+const SWEEP_EMITTER: &str = "system:task_sweep";
+
+/// Per-tick PR list size. 30 is GitHub's default; we sort by `updated`
+/// desc so recent merges land first.
+const PR_LIST_LIMIT: u32 = 30;
+
+/// Configuration persisted at `<home>/task_sweep.json`. Operator mutates
+/// via the `task_sweep_config` MCP tool; sweep tick reads on each invocation.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct SweepConfig {
+    /// `owner/repo` GitHub identifier (e.g. `"suzuke/agend-terminal"`).
+    /// `None` = sweep disabled (tick is a no-op).
+    pub repo: Option<String>,
+    /// `true` = tick body short-circuits with no-op.
+    #[serde(default)]
+    pub paused: bool,
+    /// `true` = log decisions but do not emit events.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+fn config_path(home: &Path) -> PathBuf {
+    home.join("task_sweep.json")
+}
+
+fn load_config(home: &Path) -> SweepConfig {
+    crate::store::load(&config_path(home))
+}
+
+fn save_config(home: &Path, cfg: &SweepConfig) -> anyhow::Result<()> {
+    crate::store::save_atomic(&config_path(home), cfg)
+}
+
+/// Holding-handle for the spawned sweep ticker. Drop is the existing
+/// daemon "fire-and-forget" convention (the thread exits via the
+/// shutdown atomic). Sprint 25+ graceful-join callers can switch to
+/// `DaemonTicker::join_on_shutdown` without changing the spawn site.
+pub struct TaskSweep {
+    _ticker: DaemonTicker,
+}
+
+impl TaskSweep {
+    /// Spawn the sweep tick thread. Reads `<home>/task_sweep.json` each
+    /// tick; if `repo` is unset or `paused == true`, the body is a no-op.
+    /// `body` is invoked once immediately at thread start (per
+    /// [`DaemonTicker`] contract) — the operator sees an immediate sweep
+    /// after enabling rather than waiting `tick_dur`.
+    pub fn spawn(home: PathBuf, shutdown: Arc<AtomicBool>) -> Self {
+        let ticker = DaemonTicker::spawn(
+            "task_sweep",
+            Duration::from_secs(DEFAULT_SWEEP_TICK_SECS),
+            shutdown,
+            move || {
+                if let Err(e) = sweep_tick(&home) {
+                    tracing::warn!(error = %e, "task_sweep tick failed");
+                }
+            },
+        );
+        Self { _ticker: ticker }
+    }
+}
+
+// ── Tick body ───────────────────────────────────────────────────────
+
+fn sweep_tick(home: &Path) -> anyhow::Result<()> {
+    let cfg = load_config(home);
+    if cfg.paused {
+        return Ok(());
+    }
+    let repo = match &cfg.repo {
+        Some(r) if !r.is_empty() => r.clone(),
+        _ => return Ok(()),
+    };
+
+    let prs = list_recently_merged_prs(&repo)?;
+    if prs.is_empty() {
+        return Ok(());
+    }
+
+    // Snapshot of currently-open tasks. Read from tasks::list_all (the
+    // PR2 bridge-phase legacy reader); PR3 cutover switches this to
+    // `task_events::replay` derived view.
+    let open_tasks = crate::tasks::list_all(home);
+    let open_ids: std::collections::HashMap<String, &crate::tasks::Task> = open_tasks
+        .iter()
+        .filter(|t| matches!(t.status.as_str(), "open" | "claimed" | "in_progress"))
+        .map(|t| (t.id.clone(), t))
+        .collect();
+    if open_ids.is_empty() {
+        return Ok(());
+    }
+
+    let emitter = InstanceName::from(SWEEP_EMITTER);
+    let sweep_id = format!("sweep-{}", chrono::Utc::now().to_rfc3339());
+
+    for pr in &prs {
+        if !pr.merged {
+            continue;
+        }
+        // Validation must-have #4: GitHub API schema-mismatch fail-closed
+        // — a merged PR without merge_commit_sha or merged_at is malformed
+        // (or the API contract changed); skip rather than emit a half-
+        // formed event that downstream auditors would have to reverse-
+        // engineer.
+        let merge_sha = match pr.merge_commit_sha.as_deref() {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                tracing::warn!(
+                    pr = pr.number,
+                    "sweep: merged PR with empty merge_commit_sha — schema mismatch, skip"
+                );
+                continue;
+            }
+        };
+        let merged_at = match pr.merged_at.as_deref() {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                tracing::warn!(
+                    pr = pr.number,
+                    "sweep: merged PR with empty merged_at — schema mismatch, skip"
+                );
+                continue;
+            }
+        };
+
+        // Validation must-have #1: HTML-comment injection sanitize.
+        let sanitized_body = strip_html_comments(&pr.body);
+        // Validation must-have #2: strict ASCII regex rejects non-ASCII
+        // homoglyphs in the task ID portion.
+        let markers = extract_closes_markers(&sanitized_body);
+        if markers.is_empty() {
+            continue;
+        }
+
+        for marker in markers {
+            let task = match open_ids.get(&marker) {
+                Some(t) => t,
+                None => {
+                    // Marker doesn't reference a currently-open task —
+                    // either typo, already-closed task, or attacker
+                    // referencing a non-existent ID.
+                    tracing::debug!(pr = pr.number, marker = %marker, "sweep: marker doesn't match any open task");
+                    continue;
+                }
+            };
+            // Validation must-have #3: PR.user.login authorship ONLY —
+            // task creator OR assignee must match. Defends pre-PR-220
+            // `update_decision` bug class where a malicious PR body could
+            // close another agent's task.
+            let creator = task.created_by.as_str();
+            let assignee = task.assignee.as_deref();
+            let author_ok = pr.author_login.eq_ignore_ascii_case(creator)
+                || assignee
+                    .map(|a| pr.author_login.eq_ignore_ascii_case(a))
+                    .unwrap_or(false);
+            if !author_ok {
+                tracing::warn!(
+                    pr = pr.number,
+                    marker = %marker,
+                    pr_author = %pr.author_login,
+                    task_creator = creator,
+                    task_assignee = ?assignee,
+                    "sweep: PR.user.login not authorised to close — rejected"
+                );
+                continue;
+            }
+
+            if cfg.dry_run {
+                tracing::info!(
+                    pr = pr.number,
+                    marker = %marker,
+                    "sweep dry-run: would auto-close (no event emitted)"
+                );
+                continue;
+            }
+
+            // Validation must-have #5: capture squash-merge SHA at
+            // decision-time so the audit survives squash deletion / PR
+            // body edits.
+            let snapshot = PrSnapshot {
+                pr_state: pr.state.clone(),
+                merge_sha: Some(merge_sha.to_string()),
+                api_response_hash: pr.api_response_hash.clone(),
+                captured_at: chrono::Utc::now().to_rfc3339(),
+            };
+            let events = vec![
+                TaskEvent::Linked {
+                    task_id: TaskId(marker.clone()),
+                    pr_id: PrId(pr.number),
+                    source: LinkSource::SweepDiscovery {
+                        sweep_id: sweep_id.clone(),
+                    },
+                    snapshot: snapshot.clone(),
+                },
+                TaskEvent::Done {
+                    task_id: TaskId(marker.clone()),
+                    by: InstanceName(pr.author_login.clone()),
+                    source: DoneSource::PrMerged {
+                        pr_id: PrId(pr.number),
+                        merge_sha: merge_sha.to_string(),
+                        merged_at: merged_at.to_string(),
+                        snapshot,
+                    },
+                },
+            ];
+            task_events::append_batch(home, &emitter, events)?;
+            tracing::info!(
+                pr = pr.number,
+                marker = %marker,
+                "sweep: auto-closed (Linked + Done emitted)"
+            );
+        }
+    }
+    Ok(())
+}
+
+// ── PR body sanitisation + marker extraction ─────────────────────────
+
+/// Strip every `<!-- ... -->` HTML comment. Pre-validation step so the
+/// `Closes t-XXX` regex never observes a directive an adversary tried to
+/// hide inside a comment.
+///
+/// The implementation walks bytes (ASCII-safe — we strip whole comments,
+/// not their bytes) and rebuilds a String char-by-char where the byte is
+/// guaranteed to be a single-byte char by the surrounding ASCII bracket
+/// match. Unterminated comments (`<!--` without `-->`) drop the rest of
+/// the body — a future fuzzy attacker writing partial comments still
+/// can't sneak a directive past us.
+fn strip_html_comments(body: &str) -> String {
+    let bytes = body.as_bytes();
+    let mut out = String::with_capacity(body.len());
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if i + 4 <= bytes.len() && &bytes[i..i + 4] == b"<!--" {
+            match body[i + 4..].find("-->") {
+                Some(end) => {
+                    i += 4 + end + 3;
+                    continue;
+                }
+                None => break, // unterminated — drop tail
+            }
+        }
+        // Push the next UTF-8 character to preserve unicode in the
+        // non-comment body. char_indices iterator-style walk:
+        let ch_len = body[i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+        out.push_str(&body[i..i + ch_len]);
+        i += ch_len;
+    }
+    out
+}
+
+/// Extract every `Closes t-<digits>-<digits>` marker. Strict ASCII regex
+/// rejects non-ASCII codepoints inside the task ID; combined with the
+/// HTML-comment sanitiser this defends against zero-width-char +
+/// HTML-injection adversary surface.
+fn extract_closes_markers(body: &str) -> Vec<String> {
+    static MARKER: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let re = MARKER.get_or_init(|| {
+        // Multi-line; case-sensitive on `Closes` to match GitHub's
+        // closing-keyword convention.
+        regex::Regex::new(r"(?m)Closes\s+(t-[0-9]+-[0-9]+)\b").expect("static regex must compile")
+    });
+    re.captures_iter(body)
+        .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
+        .collect()
+}
+
+// ── GitHub API ──────────────────────────────────────────────────────
+
+/// PR metadata captured from the GitHub list-pulls response. Fields
+/// chosen to satisfy the 5 sweep validation must-haves; intermediate
+/// JSON parsing in [`parse_pr_meta`] flags schema mismatches.
+struct PrMeta {
+    number: u64,
+    state: String,
+    merged: bool,
+    merge_commit_sha: Option<String>,
+    merged_at: Option<String>,
+    body: String,
+    author_login: String,
+    /// SHA-256 of the per-PR JSON object (hex). Forensic correlation
+    /// fingerprint stamped onto the resulting `PrSnapshot`.
+    api_response_hash: String,
+}
+
+fn list_recently_merged_prs(repo: &str) -> anyhow::Result<Vec<PrMeta>> {
+    // Build a per-tick current-thread runtime so the sync DaemonTicker
+    // body can call async reqwest. Pattern lifted from `ci_watch.rs`.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .user_agent("agend-terminal/task-sweep")
+            .build()?;
+        let url = format!(
+            "https://api.github.com/repos/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page={PR_LIST_LIMIT}"
+        );
+        let mut req = client
+            .get(&url)
+            .header("Accept", "application/vnd.github+json");
+        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+            req = req.header("Authorization", format!("Bearer {token}"));
+        }
+        let resp = req.send().await?;
+        if !resp.status().is_success() {
+            anyhow::bail!("GitHub list-pulls {} for {url}", resp.status());
+        }
+        let body = resp.text().await?;
+        let arr: Vec<serde_json::Value> = serde_json::from_str(&body)?;
+        let mut out = Vec::with_capacity(arr.len());
+        for pr in arr {
+            // Per-PR response hash so each event's PrSnapshot fingerprints
+            // the exact JSON object the sweep observed (squash deletions
+            // + future PR body edits won't change this).
+            let pr_json_bytes = serde_json::to_vec(&pr)?;
+            let api_response_hash = sha256_hex(&pr_json_bytes);
+            if let Some(meta) = parse_pr_meta(&pr, api_response_hash) {
+                out.push(meta);
+            }
+        }
+        Ok(out)
+    })
+}
+
+fn parse_pr_meta(v: &serde_json::Value, api_response_hash: String) -> Option<PrMeta> {
+    let number = v.get("number")?.as_u64()?;
+    let state = v.get("state")?.as_str()?.to_string();
+    let merged = v.get("merged_at").map(|x| !x.is_null()).unwrap_or(false);
+    let merge_commit_sha = v
+        .get("merge_commit_sha")
+        .and_then(|x| x.as_str())
+        .map(String::from);
+    let merged_at = v
+        .get("merged_at")
+        .and_then(|x| x.as_str())
+        .map(String::from);
+    let body = v
+        .get("body")
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string();
+    // Validation must-have #3 — PR.user.login is the authorship anchor.
+    // Missing user.login = malformed PR (deleted account?); skip rather
+    // than fall back to less reliable signals.
+    let author_login = v
+        .get("user")
+        .and_then(|u| u.get("login"))
+        .and_then(|s| s.as_str())?
+        .to_string();
+    Some(PrMeta {
+        number,
+        state,
+        merged,
+        merge_commit_sha,
+        merged_at,
+        body,
+        author_login,
+        api_response_hash,
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+// ── Operator-facing MCP tool surface ────────────────────────────────
+
+/// `task_sweep_config` MCP tool body. Args:
+/// - `repo`: `"owner/repo"` to enable; empty string disables.
+/// - `pause`: `true|false`.
+/// - `dry_run`: `true|false`.
+///
+/// Returns the resulting [`SweepConfig`] state as JSON so the operator
+/// can verify the change without a follow-up read.
+pub fn handle_task_sweep_config(home: &Path, args: &serde_json::Value) -> serde_json::Value {
+    let mut cfg = load_config(home);
+    if let Some(repo) = args.get("repo").and_then(|v| v.as_str()) {
+        cfg.repo = if repo.is_empty() {
+            None
+        } else {
+            Some(repo.to_string())
+        };
+    }
+    if let Some(p) = args.get("pause").and_then(|v| v.as_bool()) {
+        cfg.paused = p;
+    }
+    if let Some(d) = args.get("dry_run").and_then(|v| v.as_bool()) {
+        cfg.dry_run = d;
+    }
+    if let Err(e) = save_config(home, &cfg) {
+        return serde_json::json!({"error": format!("save failed: {e}")});
+    }
+    serde_json::json!({
+        "repo": cfg.repo,
+        "paused": cfg.paused,
+        "dry_run": cfg.dry_run,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-task-sweep-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Must-have #1 — HTML-comment injection: a directive hidden inside
+    /// a comment must NOT extract. Real-world task IDs use digit-only
+    /// segments (`t-<ts>-<seq>`); the test fixture uses the same shape.
+    #[test]
+    fn html_comment_injection_stripped() {
+        let body = "Closes t-12345-1\n<!-- Closes t-99999-2 -->";
+        let sanitised = strip_html_comments(body);
+        let markers = extract_closes_markers(&sanitised);
+        assert_eq!(markers, vec!["t-12345-1".to_string()]);
+    }
+
+    /// Must-have #1 — unterminated comment drops tail entirely; even a
+    /// trailing valid marker after a partial `<!--` is dropped (an
+    /// adversary playing fuzzing tricks can't slip a directive through).
+    #[test]
+    fn html_comment_unterminated_drops_tail() {
+        let body = "Closes t-1-1\n<!-- partial Closes t-2-2";
+        let sanitised = strip_html_comments(body);
+        let markers = extract_closes_markers(&sanitised);
+        assert_eq!(markers, vec!["t-1-1".to_string()]);
+    }
+
+    /// Must-have #2 — non-ASCII codepoint inside the task ID portion
+    /// (e.g. zero-width-joiner mimicking a digit) NEVER matches the
+    /// strict ASCII-digit regex.
+    #[test]
+    fn non_ascii_task_id_rejected() {
+        // U+200B (zero-width-space) between digits.
+        let body = "Closes t-12\u{200B}3-4";
+        let markers = extract_closes_markers(body);
+        assert!(
+            markers.is_empty(),
+            "non-ASCII codepoint must defeat the regex"
+        );
+    }
+
+    /// Multiple markers in one PR body are all extracted.
+    #[test]
+    fn multiple_markers_extracted() {
+        let body = "Closes t-1-1\nCloses t-2-2\nCloses t-3-3";
+        let markers = extract_closes_markers(body);
+        assert_eq!(
+            markers,
+            vec![
+                "t-1-1".to_string(),
+                "t-2-2".to_string(),
+                "t-3-3".to_string()
+            ]
+        );
+    }
+
+    /// `parse_pr_meta` rejects the PR if `user.login` is missing — our
+    /// authorship anchor (must-have #3) requires it. Better to drop the
+    /// PR than fall back to git trailer (the bug class we're defending).
+    #[test]
+    fn parse_rejects_missing_user_login() {
+        let v = serde_json::json!({
+            "number": 1,
+            "state": "closed",
+            "merge_commit_sha": "abc",
+            "merged_at": "2026-04-27T00:00:00Z",
+            "body": "",
+            "user": {} // login missing
+        });
+        assert!(parse_pr_meta(&v, "h".into()).is_none());
+    }
+
+    /// Must-have #5 — `parse_pr_meta` carries the merge SHA so callers
+    /// can stamp it onto `PrSnapshot.merge_sha` at decision-time.
+    #[test]
+    fn parse_carries_merge_sha() {
+        let v = serde_json::json!({
+            "number": 42,
+            "state": "closed",
+            "merge_commit_sha": "abcdef1234",
+            "merged_at": "2026-04-27T00:00:00Z",
+            "body": "Closes t-1-1",
+            "user": {"login": "dev-impl-1"}
+        });
+        let meta = parse_pr_meta(&v, "fakehash".into()).unwrap();
+        assert_eq!(meta.merge_commit_sha.as_deref(), Some("abcdef1234"));
+        assert_eq!(meta.author_login, "dev-impl-1");
+        assert!(meta.merged); // merged_at non-null
+    }
+
+    /// `task_sweep_config` MCP tool round-trip — operator sets repo, then
+    /// pauses, then disables dry-run; final state matches.
+    #[test]
+    fn config_tool_round_trip() {
+        let home = tmp_home("config_rt");
+        let r1 =
+            handle_task_sweep_config(&home, &serde_json::json!({"repo": "suzuke/agend-terminal"}));
+        assert_eq!(r1["repo"], "suzuke/agend-terminal");
+        assert_eq!(r1["paused"], false);
+
+        let r2 = handle_task_sweep_config(&home, &serde_json::json!({"pause": true}));
+        assert_eq!(r2["paused"], true);
+        assert_eq!(r2["repo"], "suzuke/agend-terminal");
+
+        let r3 = handle_task_sweep_config(&home, &serde_json::json!({"dry_run": true}));
+        assert_eq!(r3["dry_run"], true);
+        assert_eq!(r3["paused"], true);
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// `task_sweep_config` empty-string `repo` disables sweep (sets to
+    /// `None`) — operator's escape hatch when the repo identifier is
+    /// wrong and they want to clear it without `unsetenv`.
+    #[test]
+    fn config_tool_empty_repo_disables() {
+        let home = tmp_home("config_empty");
+        handle_task_sweep_config(&home, &serde_json::json!({"repo": "x/y"}));
+        let r = handle_task_sweep_config(&home, &serde_json::json!({"repo": ""}));
+        assert_eq!(r["repo"], serde_json::Value::Null);
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// `sweep_tick` short-circuits when the config is missing or has no
+    /// repo set. Operator sees a no-op rather than a noisy GitHub call.
+    #[test]
+    fn tick_no_op_when_repo_unconfigured() {
+        let home = tmp_home("tick_no_op");
+        // No config file written. Tick must complete without error and
+        // without writing to task_events.jsonl.
+        sweep_tick(&home).unwrap();
+        assert!(!home.join("task_events.jsonl").exists());
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// `sha256_hex` produces a 64-char hex string. Forensic hash
+    /// fingerprint must be a deterministic crypto-grade digest so a
+    /// later auditor can correlate against an archived API response.
+    #[test]
+    fn sha256_hex_is_deterministic_64_hex() {
+        let h1 = sha256_hex(b"hello");
+        let h2 = sha256_hex(b"hello");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64);
+        assert!(h1.chars().all(|c| c.is_ascii_hexdigit()));
+        let h3 = sha256_hex(b"world");
+        assert_ne!(h1, h3);
+    }
+
+    /// REJECT criteria (per dev-reviewer m-25) — exercise the
+    /// closes-marker extractor against the **actual `Closes t-` commit
+    /// messages on origin/main**. Defends against three failure modes
+    /// the unit-test fixtures alone can't catch:
+    ///
+    /// 1. Real PR descriptions contain prose around the marker that
+    ///    might trip the regex if the boundary check is loose.
+    /// 2. A future contributor edits a PR description AFTER merge to
+    ///    add a malicious `Closes t-victim`; this real-repo audit lets
+    ///    a subsequent CI run surface the regression.
+    /// 3. The on-main commit messages prove that PR1 + the wider Sprint
+    ///    24 P0 wave actually used the marker convention sweep depends
+    ///    on, not just the unit-test mocks.
+    ///
+    /// Skipped (with diagnostic stderr) when `git` binary unavailable or
+    /// the cwd isn't a git repo. Tests should never *fail* due to env
+    /// shape — operator-run CI on a fresh checkout always has both.
+    #[test]
+    fn closes_markers_extract_cleanly_from_actual_main() {
+        let output = match std::process::Command::new("git")
+            .args([
+                "log",
+                "origin/main",
+                "--grep=Closes t-",
+                "--format=%B",
+                "--all-match",
+            ])
+            .output()
+        {
+            Ok(o) => o,
+            Err(e) => {
+                eprintln!("skip: git binary unavailable: {e}");
+                return;
+            }
+        };
+        if !output.status.success() {
+            eprintln!(
+                "skip: `git log` failed (likely no `origin/main` ref locally): exit={:?}",
+                output.status.code()
+            );
+            return;
+        }
+        let text = String::from_utf8_lossy(&output.stdout).to_string();
+        if text.trim().is_empty() {
+            eprintln!("skip: no `Closes t-` commits on origin/main yet");
+            return;
+        }
+        let markers = extract_closes_markers(&text);
+        // Every extracted marker MUST conform to strict format. A
+        // regression where the extractor accepts (e.g.) `t-foo-1`
+        // surfaces here.
+        let strict = regex::Regex::new(r"^t-[0-9]+-[0-9]+$").unwrap();
+        for m in &markers {
+            assert!(
+                strict.is_match(m),
+                "marker `{m}` extracted from real-main commit but fails strict format check"
+            );
+        }
+        eprintln!(
+            "real-repo audit: extracted {} markers from {} bytes of `Closes t-` commit messages on origin/main",
+            markers.len(),
+            text.len()
+        );
+    }
+}

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -1171,6 +1171,13 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         // --- Task board ---
         "task" => crate::tasks::handle(&home, instance_name, args),
 
+        // --- Task sweep config (Sprint 24 P0 PR2) ---
+        // Operator-facing config for the GitHub-PR auto-close sweep daemon.
+        // Reading is a stat call to `<home>/task_sweep.json`; writing
+        // updates the file via atomic save. Sweep tick re-reads on each
+        // 5-min iteration, so changes propagate without daemon restart.
+        "task_sweep_config" => crate::daemon::task_sweep::handle_task_sweep_config(&home, args),
+
         // --- Teams ---
         "create_team" => {
             // Route through the API so the handler emits a TeamCreated TUI

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -176,6 +176,13 @@ fn task_tools() -> Vec<Value> {
                 "due_at": {"type": "string", "description": "ISO 8601 deadline for the task"},
                 "duration": {"type": "string", "description": "Human duration until deadline (e.g. 30m, 1h, 2d)"}
             }, "required": ["action"]}}),
+        json!({"name": "task_sweep_config",
+        "description": "Configure GitHub-PR auto-close sweep daemon. Sweep polls merged PRs and emits Done events for `Closes t-XXX-N` markers (validated by 5-must-have pipeline).",
+        "inputSchema": {"type": "object", "properties": {
+            "repo": {"type": "string", "description": "GitHub `owner/repo` to sweep (empty string disables)"},
+            "pause": {"type": "boolean", "description": "Pause/resume the sweep tick"},
+            "dry_run": {"type": "boolean", "description": "Log decisions without emitting events"}
+        }}}),
     ]
 }
 

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -1054,4 +1054,414 @@ mod tests {
         assert_eq!(task.status, TaskStatus::Claimed);
         fs::remove_dir_all(&home).ok();
     }
+
+    // ── Sprint 24 P0 PR2 — F1 (deferred from PR1 r2) + Invariant #5 ──
+
+    /// Build a fresh `(home, instance)` test fixture seeded with a single
+    /// `Created` event so subsequent transitions have a task to mutate.
+    fn fixture_with_seeded_task(tag: &str) -> (PathBuf, InstanceName, TaskId) {
+        let home = tmp_home(tag);
+        let inst = InstanceName::from("u");
+        let tid = TaskId::from("t-FIX");
+        append(
+            &home,
+            &inst,
+            TaskEvent::Created {
+                task_id: tid.clone(),
+                title: "fixture".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+            },
+        )
+        .unwrap();
+        (home, inst, tid)
+    }
+
+    /// **F1 (PR1 r2 deferred to PR2)** — exhaustive state-machine table.
+    /// 7 statuses × 10 events = 70 cells; not all are interesting (Created
+    /// on an existing task is a documented no-op via `or_insert_with`),
+    /// but the test covers every cell explicitly so a future apply()
+    /// regression on any status × event pair fails-loud.
+    #[test]
+    fn state_machine_exhaustive_transitions() {
+        // Helper: prime task into a target status by sequencing prior
+        // events. Returns (home, instance, task_id) post-priming.
+        fn prime(target: TaskStatus, tag: &str) -> (PathBuf, InstanceName, TaskId) {
+            let (home, inst, tid) = fixture_with_seeded_task(tag);
+            let priming: Vec<TaskEvent> = match target {
+                TaskStatus::Open => vec![],
+                TaskStatus::Claimed => vec![TaskEvent::Claimed {
+                    task_id: tid.clone(),
+                    by: inst.clone(),
+                }],
+                TaskStatus::InProgress => vec![TaskEvent::InProgress {
+                    task_id: tid.clone(),
+                    by: inst.clone(),
+                }],
+                TaskStatus::Verified => vec![TaskEvent::Verified {
+                    task_id: tid.clone(),
+                    by_reviewer: inst.clone(),
+                    verdict: "verified".into(),
+                }],
+                TaskStatus::Done => vec![TaskEvent::Done {
+                    task_id: tid.clone(),
+                    by: inst.clone(),
+                    source: DoneSource::OperatorManual {
+                        authored_at: chrono::Utc::now().to_rfc3339(),
+                        result: None,
+                    },
+                }],
+                TaskStatus::Cancelled => vec![TaskEvent::Cancelled {
+                    task_id: tid.clone(),
+                    by: inst.clone(),
+                    reason: "test".into(),
+                }],
+                TaskStatus::Blocked => vec![TaskEvent::Blocked {
+                    task_id: tid.clone(),
+                    reason: "test".into(),
+                }],
+            };
+            for e in priming {
+                append(&home, &inst, e).unwrap();
+            }
+            (home, inst, tid)
+        }
+
+        // Helper: emit one event for the candidate transition.
+        fn emit(home: &Path, inst: &InstanceName, tid: &TaskId, kind: &str) {
+            let event = match kind {
+                // Created on an existing task is a documented no-op via
+                // `entry().or_insert_with` — applying it doesn't mutate
+                // status. We still exercise the path here to pin the
+                // invariant.
+                "Created" => TaskEvent::Created {
+                    task_id: tid.clone(),
+                    title: "dup".into(),
+                    description: String::new(),
+                    priority: "normal".into(),
+                    owner: None,
+                },
+                "Claimed" => TaskEvent::Claimed {
+                    task_id: tid.clone(),
+                    by: inst.clone(),
+                },
+                "InProgress" => TaskEvent::InProgress {
+                    task_id: tid.clone(),
+                    by: inst.clone(),
+                },
+                "Verified" => TaskEvent::Verified {
+                    task_id: tid.clone(),
+                    by_reviewer: inst.clone(),
+                    verdict: "v".into(),
+                },
+                "Done" => TaskEvent::Done {
+                    task_id: tid.clone(),
+                    by: inst.clone(),
+                    source: DoneSource::OperatorManual {
+                        authored_at: chrono::Utc::now().to_rfc3339(),
+                        result: None,
+                    },
+                },
+                "Cancelled" => TaskEvent::Cancelled {
+                    task_id: tid.clone(),
+                    by: inst.clone(),
+                    reason: "t".into(),
+                },
+                "Linked" => TaskEvent::Linked {
+                    task_id: tid.clone(),
+                    pr_id: PrId(1),
+                    source: LinkSource::Explicit {
+                        authored_at: chrono::Utc::now().to_rfc3339(),
+                    },
+                    snapshot: PrSnapshot {
+                        pr_state: "merged".into(),
+                        merge_sha: Some("aaaa".into()),
+                        api_response_hash: "h".into(),
+                        captured_at: chrono::Utc::now().to_rfc3339(),
+                    },
+                },
+                "Blocked" => TaskEvent::Blocked {
+                    task_id: tid.clone(),
+                    reason: "t".into(),
+                },
+                "Unblocked" => TaskEvent::Unblocked {
+                    task_id: tid.clone(),
+                },
+                "Reopened" => TaskEvent::Reopened {
+                    task_id: tid.clone(),
+                    reason: "t".into(),
+                    source_evidence: "t".into(),
+                },
+                _ => unreachable!(),
+            };
+            append(home, inst, event).unwrap();
+        }
+
+        // Full 7×10 expectation table. Each row asserts the post-event
+        // status. Created/Linked never change status. Unblocked only
+        // moves Blocked → Open. Reopened always normalises to Open.
+        // Other events overwrite to their own target status (replay-side
+        // is permissive per F3 contract).
+        let table: &[(TaskStatus, &str, TaskStatus)] = &[
+            // (current_status, event_kind, expected_next_status)
+            (TaskStatus::Open, "Created", TaskStatus::Open),
+            (TaskStatus::Open, "Claimed", TaskStatus::Claimed),
+            (TaskStatus::Open, "InProgress", TaskStatus::InProgress),
+            (TaskStatus::Open, "Verified", TaskStatus::Verified),
+            (TaskStatus::Open, "Done", TaskStatus::Done),
+            (TaskStatus::Open, "Cancelled", TaskStatus::Cancelled),
+            (TaskStatus::Open, "Linked", TaskStatus::Open),
+            (TaskStatus::Open, "Blocked", TaskStatus::Blocked),
+            (TaskStatus::Open, "Unblocked", TaskStatus::Open),
+            (TaskStatus::Open, "Reopened", TaskStatus::Open),
+            (TaskStatus::Claimed, "Created", TaskStatus::Claimed),
+            (TaskStatus::Claimed, "Claimed", TaskStatus::Claimed),
+            (TaskStatus::Claimed, "InProgress", TaskStatus::InProgress),
+            (TaskStatus::Claimed, "Verified", TaskStatus::Verified),
+            (TaskStatus::Claimed, "Done", TaskStatus::Done),
+            (TaskStatus::Claimed, "Cancelled", TaskStatus::Cancelled),
+            (TaskStatus::Claimed, "Linked", TaskStatus::Claimed),
+            (TaskStatus::Claimed, "Blocked", TaskStatus::Blocked),
+            (TaskStatus::Claimed, "Unblocked", TaskStatus::Claimed),
+            (TaskStatus::Claimed, "Reopened", TaskStatus::Open),
+            (TaskStatus::InProgress, "Created", TaskStatus::InProgress),
+            (TaskStatus::InProgress, "Claimed", TaskStatus::Claimed),
+            (TaskStatus::InProgress, "InProgress", TaskStatus::InProgress),
+            (TaskStatus::InProgress, "Verified", TaskStatus::Verified),
+            (TaskStatus::InProgress, "Done", TaskStatus::Done),
+            (TaskStatus::InProgress, "Cancelled", TaskStatus::Cancelled),
+            (TaskStatus::InProgress, "Linked", TaskStatus::InProgress),
+            (TaskStatus::InProgress, "Blocked", TaskStatus::Blocked),
+            (TaskStatus::InProgress, "Unblocked", TaskStatus::InProgress),
+            (TaskStatus::InProgress, "Reopened", TaskStatus::Open),
+            (TaskStatus::Verified, "Created", TaskStatus::Verified),
+            (TaskStatus::Verified, "Claimed", TaskStatus::Claimed),
+            (TaskStatus::Verified, "InProgress", TaskStatus::InProgress),
+            (TaskStatus::Verified, "Verified", TaskStatus::Verified),
+            (TaskStatus::Verified, "Done", TaskStatus::Done),
+            (TaskStatus::Verified, "Cancelled", TaskStatus::Cancelled),
+            (TaskStatus::Verified, "Linked", TaskStatus::Verified),
+            (TaskStatus::Verified, "Blocked", TaskStatus::Blocked),
+            (TaskStatus::Verified, "Unblocked", TaskStatus::Verified),
+            (TaskStatus::Verified, "Reopened", TaskStatus::Open),
+            (TaskStatus::Done, "Created", TaskStatus::Done),
+            (TaskStatus::Done, "Claimed", TaskStatus::Claimed),
+            (TaskStatus::Done, "InProgress", TaskStatus::InProgress),
+            (TaskStatus::Done, "Verified", TaskStatus::Verified),
+            (TaskStatus::Done, "Done", TaskStatus::Done),
+            (TaskStatus::Done, "Cancelled", TaskStatus::Cancelled),
+            (TaskStatus::Done, "Linked", TaskStatus::Done),
+            (TaskStatus::Done, "Blocked", TaskStatus::Blocked),
+            (TaskStatus::Done, "Unblocked", TaskStatus::Done),
+            (TaskStatus::Done, "Reopened", TaskStatus::Open),
+            (TaskStatus::Cancelled, "Created", TaskStatus::Cancelled),
+            (TaskStatus::Cancelled, "Claimed", TaskStatus::Claimed),
+            (TaskStatus::Cancelled, "InProgress", TaskStatus::InProgress),
+            (TaskStatus::Cancelled, "Verified", TaskStatus::Verified),
+            (TaskStatus::Cancelled, "Done", TaskStatus::Done),
+            (TaskStatus::Cancelled, "Cancelled", TaskStatus::Cancelled),
+            (TaskStatus::Cancelled, "Linked", TaskStatus::Cancelled),
+            (TaskStatus::Cancelled, "Blocked", TaskStatus::Blocked),
+            (TaskStatus::Cancelled, "Unblocked", TaskStatus::Cancelled),
+            (TaskStatus::Cancelled, "Reopened", TaskStatus::Open),
+            (TaskStatus::Blocked, "Created", TaskStatus::Blocked),
+            (TaskStatus::Blocked, "Claimed", TaskStatus::Claimed),
+            (TaskStatus::Blocked, "InProgress", TaskStatus::InProgress),
+            (TaskStatus::Blocked, "Verified", TaskStatus::Verified),
+            (TaskStatus::Blocked, "Done", TaskStatus::Done),
+            (TaskStatus::Blocked, "Cancelled", TaskStatus::Cancelled),
+            (TaskStatus::Blocked, "Linked", TaskStatus::Blocked),
+            (TaskStatus::Blocked, "Blocked", TaskStatus::Blocked),
+            (TaskStatus::Blocked, "Unblocked", TaskStatus::Open),
+            (TaskStatus::Blocked, "Reopened", TaskStatus::Open),
+        ];
+
+        for (i, (start, evt, expected)) in table.iter().enumerate() {
+            let (home, inst, tid) = prime(*start, &format!("sm_{i}"));
+            emit(&home, &inst, &tid, evt);
+            let state = replay(&home).unwrap();
+            let actual = state.tasks.get(&tid).unwrap().status;
+            assert_eq!(
+                actual, *expected,
+                "({:?}, {}) expected → {:?}, got {:?}",
+                start, evt, expected, actual
+            );
+            fs::remove_dir_all(&home).ok();
+        }
+    }
+
+    /// **Replay-determinism invariant #5 (PR1 r2 deferred to PR2)** —
+    /// sweep-replay associativity: applying sweep events on top of an
+    /// existing log produces the same fold as inserting them anywhere
+    /// chronologically before the rest. Defends the future "sweep
+    /// daemon emits Linked/Done events while the operator emits manual
+    /// transitions" interleaving.
+    #[test]
+    fn invariant_5_sweep_replay_associativity() {
+        let inst = InstanceName::from("u");
+        let sweep = InstanceName::from("system:task_sweep");
+
+        // Scenario A: replay(operator events) then add sweep events on top.
+        let home_a = tmp_home("assoc_a");
+        append(
+            &home_a,
+            &inst,
+            TaskEvent::Created {
+                task_id: TaskId::from("t-S1"),
+                title: "s1".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+            },
+        )
+        .unwrap();
+        append(
+            &home_a,
+            &inst,
+            TaskEvent::Claimed {
+                task_id: TaskId::from("t-S1"),
+                by: inst.clone(),
+            },
+        )
+        .unwrap();
+        // Sweep emits Linked + Done on top.
+        append(
+            &home_a,
+            &sweep,
+            TaskEvent::Linked {
+                task_id: TaskId::from("t-S1"),
+                pr_id: PrId(42),
+                source: LinkSource::SweepDiscovery {
+                    sweep_id: "sw1".into(),
+                },
+                snapshot: PrSnapshot {
+                    pr_state: "merged".into(),
+                    merge_sha: Some("abc".into()),
+                    api_response_hash: "h".into(),
+                    captured_at: chrono::Utc::now().to_rfc3339(),
+                },
+            },
+        )
+        .unwrap();
+        append(
+            &home_a,
+            &sweep,
+            TaskEvent::Done {
+                task_id: TaskId::from("t-S1"),
+                by: inst.clone(),
+                source: DoneSource::PrMerged {
+                    pr_id: PrId(42),
+                    merge_sha: "abc".into(),
+                    merged_at: chrono::Utc::now().to_rfc3339(),
+                    snapshot: PrSnapshot {
+                        pr_state: "merged".into(),
+                        merge_sha: Some("abc".into()),
+                        api_response_hash: "h".into(),
+                        captured_at: chrono::Utc::now().to_rfc3339(),
+                    },
+                },
+            },
+        )
+        .unwrap();
+        let state_a = replay(&home_a).unwrap();
+
+        // Scenario B: same events but interleaved differently — sweep
+        // events appear in the middle, not at the end. Replay's
+        // chronological+seq sort canonicalises ordering, so the fold
+        // result must match scenario A.
+        let home_b = tmp_home("assoc_b");
+        let log_b = home_b.join("task_events.jsonl");
+        // Hand-craft the envelope sequence in a different file order:
+        let envs = vec![
+            TaskEventEnvelope {
+                schema_version: SCHEMA_VERSION,
+                seq: 1,
+                timestamp: "2026-04-27T00:00:01Z".into(),
+                instance: inst.clone(),
+                event: TaskEvent::Created {
+                    task_id: TaskId::from("t-S1"),
+                    title: "s1".into(),
+                    description: String::new(),
+                    priority: "normal".into(),
+                    owner: None,
+                },
+            },
+            // Sweep Linked appears BEFORE operator Claimed in file order
+            // but with later timestamp — replay sort still applies it
+            // after Claimed because the sort key is timestamp.
+            TaskEventEnvelope {
+                schema_version: SCHEMA_VERSION,
+                seq: 1,
+                timestamp: "2026-04-27T00:00:03Z".into(),
+                instance: sweep.clone(),
+                event: TaskEvent::Linked {
+                    task_id: TaskId::from("t-S1"),
+                    pr_id: PrId(42),
+                    source: LinkSource::SweepDiscovery {
+                        sweep_id: "sw1".into(),
+                    },
+                    snapshot: PrSnapshot {
+                        pr_state: "merged".into(),
+                        merge_sha: Some("abc".into()),
+                        api_response_hash: "h".into(),
+                        captured_at: "2026-04-27T00:00:03Z".into(),
+                    },
+                },
+            },
+            TaskEventEnvelope {
+                schema_version: SCHEMA_VERSION,
+                seq: 2,
+                timestamp: "2026-04-27T00:00:02Z".into(),
+                instance: inst.clone(),
+                event: TaskEvent::Claimed {
+                    task_id: TaskId::from("t-S1"),
+                    by: inst.clone(),
+                },
+            },
+            TaskEventEnvelope {
+                schema_version: SCHEMA_VERSION,
+                seq: 2,
+                timestamp: "2026-04-27T00:00:04Z".into(),
+                instance: sweep.clone(),
+                event: TaskEvent::Done {
+                    task_id: TaskId::from("t-S1"),
+                    by: inst.clone(),
+                    source: DoneSource::PrMerged {
+                        pr_id: PrId(42),
+                        merge_sha: "abc".into(),
+                        merged_at: "2026-04-27T00:00:04Z".into(),
+                        snapshot: PrSnapshot {
+                            pr_state: "merged".into(),
+                            merge_sha: Some("abc".into()),
+                            api_response_hash: "h".into(),
+                            captured_at: "2026-04-27T00:00:04Z".into(),
+                        },
+                    },
+                },
+            },
+        ];
+        let mut content = String::new();
+        for e in &envs {
+            content.push_str(&serde_json::to_string(e).unwrap());
+            content.push('\n');
+        }
+        fs::write(&log_b, content).unwrap();
+        let state_b = replay(&home_b).unwrap();
+
+        // Final task status & linked PRs identical regardless of file
+        // order. Histories may differ in absolute timestamps but the
+        // ordered status transition is the invariant.
+        assert_eq!(
+            state_a.tasks.get(&TaskId::from("t-S1")).unwrap().status,
+            state_b.tasks.get(&TaskId::from("t-S1")).unwrap().status,
+            "associativity: operator-then-sweep == interleaved"
+        );
+        assert_eq!(
+            state_a.tasks.get(&TaskId::from("t-S1")).unwrap().linked_prs,
+            state_b.tasks.get(&TaskId::from("t-S1")).unwrap().linked_prs
+        );
+        fs::remove_dir_all(&home_a).ok();
+        fs::remove_dir_all(&home_b).ok();
+    }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -184,6 +184,123 @@ pub fn sweep_overdue_claimed(home: &Path) -> Vec<String> {
     unclaimed
 }
 
+/// Result of [`migrate_legacy_tasks_json_to_event_log`]. Reported back to
+/// daemon startup logs so operators see how many legacy tasks crossed the
+/// PR2 bridge into the canonical event log.
+#[derive(Debug, Clone)]
+pub struct MigrationReport {
+    pub migrated: usize,
+    pub skipped: usize,
+}
+
+/// Sprint 24 P0 PR2 — bridge-phase migration. Walks the legacy
+/// `tasks.json` and emits canonical `TaskEvent`s into `task_events.jsonl`
+/// for every task whose `task_id` doesn't already appear in the event
+/// log. Idempotent: re-running on already-migrated state is a no-op.
+///
+/// Runs synchronously at daemon startup before the first MCP tool call
+/// so operators never observe a "list empty during migration" race.
+///
+/// **Bridge phase note**: PR2 keeps `tasks.json` writes (via dual-write
+/// in [`handle`]). PR3 retires `tasks.json` entirely; this migration is
+/// the one-shot that ensures replay() at PR3 cutover sees every legacy
+/// task. Re-running after PR3 cutover (when `tasks.json` is gone) is a
+/// no-op via the empty-store branch.
+pub fn migrate_legacy_tasks_json_to_event_log(home: &Path) -> anyhow::Result<MigrationReport> {
+    let store = load(home);
+    if store.tasks.is_empty() {
+        return Ok(MigrationReport {
+            migrated: 0,
+            skipped: 0,
+        });
+    }
+    let state = crate::task_events::replay(home).unwrap_or_default();
+    let migrator = crate::task_events::InstanceName::from("system:legacy_migration");
+    let mut events: Vec<crate::task_events::TaskEvent> = Vec::new();
+    let mut migrated = 0usize;
+    let mut skipped = 0usize;
+
+    for t in &store.tasks {
+        let tid = crate::task_events::TaskId(t.id.clone());
+        if state.tasks.contains_key(&tid) {
+            // Already in event log — idempotent skip.
+            skipped += 1;
+            continue;
+        }
+        events.push(crate::task_events::TaskEvent::Created {
+            task_id: tid.clone(),
+            title: t.title.clone(),
+            description: t.description.clone(),
+            priority: t.priority.clone(),
+            owner: t
+                .assignee
+                .as_ref()
+                .map(|s| crate::task_events::InstanceName(s.clone())),
+        });
+        // Emit the minimum status-transition events to bring the task to
+        // its current legacy status. The replay-derived view post-PR3
+        // cutover sees the same final state as the legacy tasks.json.
+        match t.status.as_str() {
+            "claimed" => {
+                if let Some(by) = &t.assignee {
+                    events.push(crate::task_events::TaskEvent::Claimed {
+                        task_id: tid.clone(),
+                        by: crate::task_events::InstanceName(by.clone()),
+                    });
+                }
+            }
+            "in_progress" => {
+                if let Some(by) = &t.assignee {
+                    events.push(crate::task_events::TaskEvent::Claimed {
+                        task_id: tid.clone(),
+                        by: crate::task_events::InstanceName(by.clone()),
+                    });
+                    events.push(crate::task_events::TaskEvent::InProgress {
+                        task_id: tid.clone(),
+                        by: crate::task_events::InstanceName(by.clone()),
+                    });
+                }
+            }
+            "done" => {
+                let by = t
+                    .assignee
+                    .as_deref()
+                    .unwrap_or(t.created_by.as_str())
+                    .to_string();
+                events.push(crate::task_events::TaskEvent::Done {
+                    task_id: tid.clone(),
+                    by: crate::task_events::InstanceName(by),
+                    source: crate::task_events::DoneSource::OperatorManual {
+                        authored_at: t.updated_at.clone(),
+                        result: t.result.clone(),
+                    },
+                });
+            }
+            "cancelled" => {
+                events.push(crate::task_events::TaskEvent::Cancelled {
+                    task_id: tid.clone(),
+                    by: crate::task_events::InstanceName(t.created_by.clone()),
+                    reason: "migrated from legacy tasks.json (status was cancelled)".to_string(),
+                });
+            }
+            "blocked" => {
+                events.push(crate::task_events::TaskEvent::Blocked {
+                    task_id: tid.clone(),
+                    reason: "migrated from legacy tasks.json (status was blocked)".to_string(),
+                });
+            }
+            // "open" or unknown: Created already left the task at Open.
+            _ => {}
+        }
+        migrated += 1;
+    }
+
+    if !events.is_empty() {
+        crate::task_events::append_batch(home, &migrator, events)?;
+    }
+    Ok(MigrationReport { migrated, skipped })
+}
+
 fn parse_due_at(args: &Value) -> Option<String> {
     if let Some(due) = args["due_at"].as_str() {
         if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(due) {
@@ -261,7 +378,26 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 updated_at: now,
                 due_at: parse_due_at(args),
             };
+            // Sprint 24 P0 PR2 — double-write bridge: canonical event log
+            // first, tasks.json second. PR3 cutover removes the tasks.json
+            // write (read path also moves to replay()). Emitting inside
+            // `mutate_versioned`'s closure means a failed event log write
+            // bails before the tasks.json mutation persists, preserving
+            // consistency on failure.
+            let event = crate::task_events::TaskEvent::Created {
+                task_id: crate::task_events::TaskId(id.clone()),
+                title: task.title.clone(),
+                description: task.description.clone(),
+                priority: task.priority.clone(),
+                owner: task
+                    .assignee
+                    .as_ref()
+                    .map(|s| crate::task_events::InstanceName(s.clone())),
+            };
+            let emitter = crate::task_events::InstanceName::from(instance_name);
             match crate::store::mutate_versioned(&store_path(home), |store: &mut TaskStore| {
+                crate::task_events::append(home, &emitter, event)
+                    .map_err(|e| anyhow::anyhow!("event log append failed: {e}"))?;
                 store.tasks.push(task);
                 Ok(())
             }) {
@@ -309,6 +445,8 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             if !instance_exists(home, &iname) {
                 return serde_json::json!({"error": format!("instance '{iname}' not found in fleet.yaml")});
             }
+            let emitter = crate::task_events::InstanceName::from(instance_name);
+            let event_id = crate::task_events::TaskId(id.clone());
             match crate::store::mutate_versioned(&store_path(home), |store: &mut TaskStore| {
                 match store.tasks.iter_mut().find(|t| t.id == id) {
                     Some(task) => {
@@ -321,6 +459,16 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                                 task.status
                             );
                         }
+                        // Canonical event log first; tasks.json second.
+                        crate::task_events::append(
+                            home,
+                            &emitter,
+                            crate::task_events::TaskEvent::Claimed {
+                                task_id: event_id,
+                                by: crate::task_events::InstanceName::from(iname.as_str()),
+                            },
+                        )
+                        .map_err(|e| anyhow::anyhow!("event log append failed: {e}"))?;
                         task.status = "claimed".to_string();
                         task.assignee = Some(iname.clone());
                         task.routed_to = None;
@@ -344,6 +492,9 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             };
             let result_text = args["result"].as_str().map(String::from);
             let caller = instance_name.to_string();
+            let emitter = crate::task_events::InstanceName::from(instance_name);
+            let event_id = crate::task_events::TaskId(id.clone());
+            let result_for_event = result_text.clone();
             match crate::store::mutate_versioned(&store_path(home), |store: &mut TaskStore| {
                 match store.tasks.iter_mut().find(|t| t.id == id) {
                     Some(task) => {
@@ -353,6 +504,23 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                                 task.assignee.as_deref().unwrap_or("unassigned")
                             );
                         }
+                        // `by` field — the assignee at done-time is the
+                        // worker; if no assignee, fall back to caller (who
+                        // by `can_mutate_task` is the orchestrator).
+                        let by = task.assignee.clone().unwrap_or_else(|| caller.clone());
+                        crate::task_events::append(
+                            home,
+                            &emitter,
+                            crate::task_events::TaskEvent::Done {
+                                task_id: event_id,
+                                by: crate::task_events::InstanceName(by),
+                                source: crate::task_events::DoneSource::OperatorManual {
+                                    authored_at: chrono::Utc::now().to_rfc3339(),
+                                    result: result_for_event,
+                                },
+                            },
+                        )
+                        .map_err(|e| anyhow::anyhow!("event log append failed: {e}"))?;
                         task.status = "done".to_string();
                         task.result.clone_from(&result_text);
                         task.updated_at = chrono::Utc::now().to_rfc3339();
@@ -385,6 +553,8 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 None
             };
             let caller = instance_name.to_string();
+            let emitter = crate::task_events::InstanceName::from(instance_name);
+            let event_id = crate::task_events::TaskId(id.clone());
             match crate::store::mutate_versioned(&store_path(home), |store: &mut TaskStore| {
                 match store.tasks.iter_mut().find(|t| t.id == id) {
                     Some(task) => {
@@ -394,7 +564,66 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                                 task.assignee.as_deref().unwrap_or("unassigned")
                             );
                         }
+                        // Translate explicit status transition to a
+                        // canonical TaskEvent. Priority / assignee changes
+                        // without status change have no v1 event variant —
+                        // PR3 introduces a metadata event when the read
+                        // path also moves to replay(). For PR2 phase reads
+                        // come from tasks.json, so the gap doesn't surface.
                         if let Some(ref s) = new_status {
+                            let prev_status = task.status.clone();
+                            let event_for_transition = match (prev_status.as_str(), s.as_str()) {
+                                (_, "claimed") => Some(crate::task_events::TaskEvent::Claimed {
+                                    task_id: event_id.clone(),
+                                    by: crate::task_events::InstanceName::from(
+                                        task.assignee.as_deref().unwrap_or(caller.as_str()),
+                                    ),
+                                }),
+                                (_, "in_progress") => {
+                                    Some(crate::task_events::TaskEvent::InProgress {
+                                        task_id: event_id.clone(),
+                                        by: crate::task_events::InstanceName::from(
+                                            task.assignee.as_deref().unwrap_or(caller.as_str()),
+                                        ),
+                                    })
+                                }
+                                (_, "done") => Some(crate::task_events::TaskEvent::Done {
+                                    task_id: event_id.clone(),
+                                    by: crate::task_events::InstanceName::from(
+                                        task.assignee.as_deref().unwrap_or(caller.as_str()),
+                                    ),
+                                    source: crate::task_events::DoneSource::OperatorManual {
+                                        authored_at: chrono::Utc::now().to_rfc3339(),
+                                        result: task.result.clone(),
+                                    },
+                                }),
+                                (_, "cancelled") => {
+                                    Some(crate::task_events::TaskEvent::Cancelled {
+                                        task_id: event_id.clone(),
+                                        by: crate::task_events::InstanceName::from(caller.as_str()),
+                                        reason: "operator update".to_string(),
+                                    })
+                                }
+                                (_, "blocked") => Some(crate::task_events::TaskEvent::Blocked {
+                                    task_id: event_id.clone(),
+                                    reason: "operator update".to_string(),
+                                }),
+                                ("blocked", "open") => {
+                                    Some(crate::task_events::TaskEvent::Unblocked {
+                                        task_id: event_id.clone(),
+                                    })
+                                }
+                                (_, "open") => Some(crate::task_events::TaskEvent::Reopened {
+                                    task_id: event_id.clone(),
+                                    reason: "operator update".to_string(),
+                                    source_evidence: format!("status {prev_status} → open"),
+                                }),
+                                _ => None,
+                            };
+                            if let Some(ev) = event_for_transition {
+                                crate::task_events::append(home, &emitter, ev)
+                                    .map_err(|e| anyhow::anyhow!("event log append failed: {e}"))?;
+                            }
                             task.status = s.clone();
                             // Release claim: setting status=open clears ownership
                             if s == "open" {
@@ -1697,6 +1926,126 @@ mod tests {
         let listed = handle(&home, "a", &serde_json::json!({"action": "list"}));
         let tasks = listed["tasks"].as_array().unwrap();
         assert_eq!(tasks.len(), 2, "non-done tasks must always appear");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 24 P0 PR2 — bridge-phase migration tests ─────────────
+
+    /// Migration helper imports every legacy `tasks.json` task into the
+    /// event log: open / claimed / done / cancelled / blocked all reach
+    /// the same final status under replay() that they had on disk.
+    #[test]
+    fn migration_imports_legacy_tasks_to_event_log() {
+        let home = tmp_home("migration_import");
+        // Seed a legacy tasks.json with one task per status branch.
+        crate::store::mutate_versioned(&store_path(&home), |store: &mut TaskStore| {
+            for (id, status, assignee) in [
+                ("t-mig-open", "open", None),
+                ("t-mig-claimed", "claimed", Some("agent-a")),
+                ("t-mig-in-prog", "in_progress", Some("agent-b")),
+                ("t-mig-done", "done", Some("agent-c")),
+                ("t-mig-cancelled", "cancelled", None),
+                ("t-mig-blocked", "blocked", None),
+            ] {
+                store.tasks.push(Task {
+                    id: id.into(),
+                    title: format!("title {id}"),
+                    description: "legacy".into(),
+                    status: status.into(),
+                    priority: "normal".into(),
+                    assignee: assignee.map(String::from),
+                    routed_to: None,
+                    created_by: "operator".into(),
+                    depends_on: Vec::new(),
+                    result: if status == "done" {
+                        Some("completed".into())
+                    } else {
+                        None
+                    },
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                    updated_at: chrono::Utc::now().to_rfc3339(),
+                    due_at: None,
+                });
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        let report = migrate_legacy_tasks_json_to_event_log(&home).unwrap();
+        assert_eq!(report.migrated, 6, "all 6 legacy tasks imported");
+        assert_eq!(report.skipped, 0);
+
+        // Replay should observe 6 tasks at their pre-migration statuses.
+        let state = crate::task_events::replay(&home).unwrap();
+        assert_eq!(state.tasks.len(), 6);
+        let lookup = |id: &str| {
+            state
+                .tasks
+                .get(&crate::task_events::TaskId::from(id))
+                .map(|t| t.status)
+                .unwrap()
+        };
+        assert_eq!(lookup("t-mig-open"), crate::task_events::TaskStatus::Open);
+        assert_eq!(
+            lookup("t-mig-claimed"),
+            crate::task_events::TaskStatus::Claimed
+        );
+        assert_eq!(
+            lookup("t-mig-in-prog"),
+            crate::task_events::TaskStatus::InProgress
+        );
+        assert_eq!(lookup("t-mig-done"), crate::task_events::TaskStatus::Done);
+        assert_eq!(
+            lookup("t-mig-cancelled"),
+            crate::task_events::TaskStatus::Cancelled
+        );
+        assert_eq!(
+            lookup("t-mig-blocked"),
+            crate::task_events::TaskStatus::Blocked
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Migration is idempotent: re-running on already-migrated state is a
+    /// no-op (every task_id already in the event log → skipped).
+    #[test]
+    fn migration_idempotent_on_second_run() {
+        let home = tmp_home("migration_idempotent");
+        crate::store::mutate_versioned(&store_path(&home), |store: &mut TaskStore| {
+            store.tasks.push(Task {
+                id: "t-idp-1".into(),
+                title: "idem".into(),
+                description: String::new(),
+                status: "open".into(),
+                priority: "normal".into(),
+                assignee: None,
+                routed_to: None,
+                created_by: "op".into(),
+                depends_on: Vec::new(),
+                result: None,
+                created_at: chrono::Utc::now().to_rfc3339(),
+                updated_at: chrono::Utc::now().to_rfc3339(),
+                due_at: None,
+            });
+            Ok(())
+        })
+        .unwrap();
+
+        let first = migrate_legacy_tasks_json_to_event_log(&home).unwrap();
+        assert_eq!(first.migrated, 1);
+        assert_eq!(first.skipped, 0);
+
+        let second = migrate_legacy_tasks_json_to_event_log(&home).unwrap();
+        assert_eq!(
+            second.migrated, 0,
+            "second run finds task_id in event log → no new emit"
+        );
+        assert_eq!(second.skipped, 1);
+
+        // Replay confirms exactly one TaskRecord (no duplicate Created
+        // event accumulated across the two migration runs).
+        let state = crate::task_events::replay(&home).unwrap();
+        assert_eq!(state.tasks.len(), 1);
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Summary
- **Task auto-close sweep daemon** — polls GitHub for recently merged PRs, emits canonical `Linked` + `Done` events for valid `Closes t-XXX-N` markers (validated by 5-must-have pipeline)
- **Bridge-phase migration** at daemon startup — walks legacy `tasks.json` → emits canonical Created (+ status-transition) events into `task_events.jsonl`, idempotent
- **Double-write forward path** — 5 mutation arms in `tasks::handle` emit events first then write tasks.json (canonical event log first; consistency-on-failure)
- **F1 state-machine 7×10 exhaustive table test** + **Invariant #5 sweep-replay associativity** (PR1 r2 deferred items absorbed per agreement)
- **CI integration test** against real `origin/main` commit messages (`git log --grep="Closes t-"` exercise)
- **`task_sweep_config` MCP tool** for operator-facing config (`repo` / `pause` / `dry_run`)

## Lineage / dependencies
- PR1 #236 (task_events substrate) — uses `task_events::append_batch` / `replay`
- Sprint 23 P0 #235 — uses `daemon::ticker::DaemonTicker` primitive
- Both merged on `main`; this branch builds on top.

## Reviewer-2 must-haves (5/5 implemented + tested)
| # | Must-have | Implementation | Test |
|---|---|---|---|
| 1 | HTML-comment injection sanitize | `strip_html_comments` walks bytes, drops every `<!-- ... -->` (and unterminated tail) | `html_comment_injection_stripped` + `html_comment_unterminated_drops_tail` |
| 2 | Non-ASCII codepoint reject | strict ASCII regex `(?m)Closes\s+(t-[0-9]+-[0-9]+)\b` | `non_ascii_task_id_rejected` |
| 3 | PR.user.login authorship | `parse_pr_meta` returns `None` if `user.login` missing; sweep validates author == creator OR assignee | `parse_rejects_missing_user_login` |
| 4 | GitHub API schema-mismatch fail-closed | merged PR with empty `merge_commit_sha` / `merged_at` → log + skip | covered by `parse_carries_merge_sha` |
| 5 | Squash-merge SHA captured | recorded into both `DoneSource::PrMerged.merge_sha` AND `PrSnapshot.merge_sha` at decision-time | covered by `parse_carries_merge_sha` |

## Architectural decision (double-write bridge)
After 30 min of impl on the original event-sourced-read-through path, scope reality check (m-41) showed +50-80 LOC was an underestimate. dev-lead reverted to **Option 4 — double-write bridge with retire-schedule-for-PR3** (m-43). Rationale:
- Single source of truth IS the destination, but in 2 hops not 1
- Bridge phase short-lived (PR2 → PR3 same sprint)
- Coherence risk during double-write: both writes in `mutate_versioned`'s closure (atomic per-call)
- Explicit retire schedule (PR3) prevents eternal double-write tech debt

## PR3 scope (deferred items)
- Read cutover (`list_all` / `task_board_columns` / `evaluate_dependency_status` → `task_events::replay`)
- Drop tasks.json writes (single source of truth from PR3 onward)
- `Released` event variant (claim release; clears owner — distinct from `Reopened` which preserves owner for done→open re-work)
- `sweep_overdue_claimed` migration to emit `Released` events
- `apply_dependency_eval` refactor: in-memory derived (no event emission)
- 28-PR legacy backfill auto-close (confidence ≥0.8 AND ≥2 signals per synthesis)
- Branch dual-signal matching (signal 1 exact-suffix + signal 2 jaccard-fuzzy)
- Retire `tasks.json` (delete + remove tasks.rs internal references)
- Schema bump v1→v2 (Released variant)

## F1 state-machine table (deferred from PR1 r2)
70-cell exhaustive `[(prev_status, event, expected_next_status)]` table in `task_events::tests::state_machine_exhaustive_transitions`. Pins replay-side permissiveness contract (per F3 doc-comment landed in PR1 r2): replay accepts any valid envelope; emit-side validates `(current_status, event)` legitimacy at the MCP handler / sweep daemon boundary.

## Invariant #5 — sweep-replay associativity
`task_events::tests::invariant_5_sweep_replay_associativity` — sweep events fold same regardless of file order vs interleaving. Defends the future "sweep emits while operator emits" interleaving.

## CI integration test (REJECT criteria)
`closes_markers_extract_cleanly_from_actual_main` shells out to `git log origin/main --grep="Closes t-" --format=%B` and asserts every extracted marker conforms to the strict ASCII format. Skips with stderr diagnostic when `git` binary unavailable (graceful in non-CI environments).

## Verification
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --bin agend-terminal` — **1119 pass** (1091 baseline + 28 new)
- `cargo test --test integration` — 9 pass (no regression)
- `cargo test --test task_events_invariant` — 1 pass (anti-bypass intact)

## LOC budget
Dispatch budgeted ~530-580 LOC; actual diff +879 (incl. ~210 LOC F1 table + ~270 LOC sweep validation tests + ~120 LOC migration tests + ~150 LOC Invariant #5). Production code closer to ~450 LOC, within budget.

## Deps added
- `sha2 = "0.10"` + `hex = "0.4"` for `PrSnapshot.api_response_hash` SHA-256 forensic fingerprint. Crypto-grade so reviewers can correlate against archived API responses without trusting non-crypto collision properties.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Unit tests pass (1119/1119)
- [x] Integration tests pass (9/9)
- [x] Anti-bypass invariant test passes
- [x] CI integration test passes against real `origin/main`
- [ ] CI green on all 3 platforms (ubuntu / macos / windows)

## References
- `docs/TASK-BOARD-AUTO-CLOSE-REDESIGN.md` (PR #234, 4-perspective synthesis)
- Dispatch `m-20260427082246557076-37` (Sprint 24 P0 PR2)
- Override-then-revert thread `m-20260427083631503540-43` (double-write bridge agreement)
- PR1 r1/r2 reviews — F1 + Invariant #5 origin

Closes t-20260427064903377171-2

## Reviewer assignment
Per dispatch:
- **dev-reviewer-2** main reviewer (adversarial continuation)
- **dev-reviewer** cross-vantage second-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)