### PR TITLE
ci: Sprint 23 P1 — extend ci.yml to run all anti-bypass invariant tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,17 @@ jobs:
       - name: Unit tests (tray feature)
         run: cargo test --bin agend-terminal --features tray
 
-      - name: Integration tests
-        run: cargo test --test integration
+      # Sprint 23 P1 — anti-bypass invariant tests live in tests/*.rs but
+      # the previous `cargo test --test integration` only ran one file
+      # (integration.rs). Anti-bypass invariants (task_events /
+      # legacy_outbound / spawn_rationale / heartbeat_pair) and
+      # characterization tests (mcp_characterization / mcp_roundtrip /
+      # no_dual_track_drift / self_healing_supervisor) silently passed CI
+      # if their assertions broke. `--tests` covers every `tests/*.rs`
+      # file plus already-covered unit tests; the unit-test repeat is
+      # cheap (cached) and keeps the invariant net fail-loud.
+      - name: Integration tests + anti-bypass invariants
+        run: cargo test --tests
 
       - name: CLI smoke (Phase C.5)
         shell: bash

--- a/tests/heartbeat_pair_atomicity_audit.rs
+++ b/tests/heartbeat_pair_atomicity_audit.rs
@@ -48,10 +48,13 @@ fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn rel_path_str(path: &Path, root: &Path) -> String {
+    // Sprint 23 P1 r2 — normalize Windows backslash to forward-slash for
+    // cross-platform EXEMPTED-list / inline `ends_with("daemon/heartbeat_pair.rs")`
+    // suffix-match. See PR #240 r2.
     path.strip_prefix(root)
         .unwrap_or(path)
         .to_string_lossy()
-        .to_string()
+        .replace('\\', "/")
 }
 
 fn is_exempted(rel_path: &str) -> bool {

--- a/tests/legacy_outbound_path_audit.rs
+++ b/tests/legacy_outbound_path_audit.rs
@@ -58,10 +58,12 @@ fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn rel_path_str(path: &Path, root: &Path) -> String {
+    // Sprint 23 P1 r2 — normalize Windows backslash to forward-slash for
+    // cross-platform EXEMPTED-list suffix-match. See PR #240 r2.
     path.strip_prefix(root)
         .unwrap_or(path)
         .to_string_lossy()
-        .to_string()
+        .replace('\\', "/")
 }
 
 fn is_exempted(rel_path: &str) -> bool {

--- a/tests/spawn_rationale_audit.rs
+++ b/tests/spawn_rationale_audit.rs
@@ -108,10 +108,14 @@ fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn rel_path_str(path: &Path, root: &Path) -> String {
+    // Sprint 23 P1 r2 — normalize Windows backslash to forward-slash so
+    // the EXEMPTED_LEGACY_FILES suffix-match (Unix-shaped paths) works
+    // cross-platform. CI broadening to `cargo test --tests` (PR #240)
+    // first surfaced this latent path-separator bug on windows-latest.
     path.strip_prefix(root)
         .unwrap_or(path)
         .to_string_lossy()
-        .to_string()
+        .replace('\\', "/")
 }
 
 fn is_exempted_file(rel_path: &str) -> bool {

--- a/tests/task_events_invariant.rs
+++ b/tests/task_events_invariant.rs
@@ -55,10 +55,13 @@ fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 fn rel(path: &Path, root: &Path) -> String {
+    // Sprint 23 P1 r2 — normalize Windows backslash to forward-slash for
+    // cross-platform EXEMPTED-list / inline `ends_with` suffix-match.
+    // See PR #240 r2.
     path.strip_prefix(root)
         .unwrap_or(path)
         .to_string_lossy()
-        .to_string()
+        .replace('\\', "/")
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace `cargo test --test integration` (one file) with `cargo test --tests` (all `tests/*.rs` files + unit tests)
- Closes the gap flagged in PR2 #237 known-gap surfacing — every anti-bypass invariant test is now fail-loud on CI
- Future-proof: new test files added under `tests/` are picked up automatically

## Why this matters
Anti-bypass invariants enforce architectural contracts (`task_events_invariant`'s anti-direct-write rule, `legacy_outbound_path_audit`'s legacy-call-site veto, `spawn_rationale_audit`'s `// fire-and-forget:` requirement, `heartbeat_pair_atomicity_audit`'s lock-around-pair pattern). If a future PR violates one of these contracts, the test fails locally — but CI never ran the file, so the violation could ride into main.

## Tests covered post-fix
| File | Tests | Type |
|---|---:|---|
| heartbeat_pair_atomicity_audit | 2 | anti-bypass |
| integration | 9 | integration |
| legacy_outbound_path_audit | 3 | anti-bypass |
| mcp_characterization | 28 | characterization |
| mcp_roundtrip | 33 | characterization |
| no_dual_track_drift | 5 | characterization |
| self_healing_supervisor | 2 | integration |
| spawn_rationale_audit | 2 | anti-bypass |
| task_events_invariant | 1 | anti-bypass |
| (unit tests, repeat) | 1147 | unit |
| **Total** | **1232** |

## Why not Option 2 (explicit enumeration)
Option 2 (`--test integration --test task_events_invariant ...`) is more explicit but requires touching ci.yml on every new test file — anti-pattern. `--tests` is the future-proof primitive cargo provides exactly for this case.

## Cost analysis
The unit tests (1147 of the 1232) are already run by the existing `Unit tests` step (`cargo test --bin agend-terminal`). Re-running them via `--tests` is cheap on cached builds (~5s wall-time addition observed locally). The cost is dominated by the integration tests (~14s) and self_healing_supervisor (~3.6s); total step time post-fix is ~22s on local runs, in line with current CI budget.

## Verification (local)
- `cargo test --tests` runs 1232 / 0 failed / 8 ignored

## Test plan
- [x] Local `cargo test --tests` passes
- [ ] CI green on all 3 platforms (the new step exercises itself)

## References
- PR #237 known-gap surfacing (Sprint 24 P0 PR2 description)
- dev-impl-1 m-20260427074737324019-6
- dev-reviewer-2 PR #237 review concurrence
- Dispatch m-20260427105448925485-74

Closes t-20260427105418160042-2

## Reviewer assignment
- **dev-reviewer single review** (LOW priority repo infra per dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)