### PR TITLE
feat(channel): Sprint 23 P1 — reverse outbound_capabilities default to open

### DIFF
--- a/docs/MIGRATION-OUTBOUND-CAPS.md
+++ b/docs/MIGRATION-OUTBOUND-CAPS.md
@@ -1,67 +1,66 @@
-# Migration: `outbound_capabilities` (Sprint 22 P0 → Sprint 23 hard-cut)
+# Migration: `outbound_capabilities` (Sprint 22 P0 fail-closed → Sprint 23 P1 default-open reversal)
 
-**Status**: Sprint 22 P0 transition window — operators MUST add `outbound_capabilities` to user-authored instances in `fleet.yaml` before Sprint 23 ships, or `agend-terminal start` will refuse to load fleet.yaml.
+**Status (Sprint 23 P1)**: **default-open**. Missing `outbound_capabilities` field permits all ops; declare the field only if you want to opt out (`[]`) or restrict (selective list). The Sprint 22 P0 hard-cut described in earlier revisions of this doc is **reversed** per operator philosophy override.
 
-## TL;DR
+## TL;DR (Sprint 23 P1 onward)
 
-For every instance in your `fleet.yaml` that you authored (anything not auto-injected as `general`):
+You don't need to add `outbound_capabilities` to anything. Existing fleets work. If you want to restrict an instance:
 
 ```yaml
 instances:
   <your-instance-name>:
     backend: claude
-    outbound_capabilities: [reply, react, edit, inject_provenance]   # ← ADD THIS
-    # … other existing fields …
+    outbound_capabilities: [reply]      # only `reply` permitted; everything else rejected
 ```
 
-For inbound-only / relay agents that should NOT emit MCP→Channel ops:
+Or block all agent outbound (relay / read-only roles):
 
 ```yaml
-    outbound_capabilities: []                                          # ← explicit "no outbound"
+instances:
+  <your-instance-name>:
+    backend: claude
+    outbound_capabilities: []           # explicit "no agent outbound"
 ```
 
-## What changed
+## Sprint 23 P1 reversal — why
 
-`outbound_capabilities` is a per-instance gate for **agent-callable** outbound MCP→Channel operations (`reply` / `react` / `edit_message` / `delegate_task` provenance side-channel). The field shipped declaratively in [PR #223](https://github.com/suzuke/agend-terminal/pull/223) but defaulted to permissive when absent. Sprint 22 P0 (this sprint) starts the 2-stage hard-cut transition.
+**Original Sprint 22 P0 design**: fail-closed default with FATAL warn ("operator MUST declare outbound_capabilities or daemon refuses to load fleet.yaml"). The intent was to defend against a cascade attack chain where a compromised agent in the fleet could emit MCP→Channel ops freely.
 
-### Two-stage transition
+**Operator philosophy override (Sprint 23 P1)**: the cascade-attack-chain defence is over-spec for the actual single-operator threat model. The TUI is already full machine access; if an agent in the fleet is compromised, the operator already has bigger problems than gated MCP outbound ops. Operator explicitly accepts the security trade-off (telegram 11:00 UTC routed via `general` m-20260427115706155870-88, dispatch m-20260427115825059656-89, task t-20260427115754474312-3).
 
-| State | Sprint 22 P0 | Sprint 23 |
-|---|---|---|
-| `Some([reply, …])` | only listed ops permitted | same |
-| `Some([])` | fail-closed (no agent outbound; explicit) | same |
-| `None` (absent) | **FATAL warn-but-permit one daemon cycle** + migration template logged | **hard parse error** |
+**What changed in code**:
+- `src/channel/auth.rs::evaluate_outbound_capability` — `None` (missing field) now returns `OutboundCapabilityDecision::OpenDefault` instead of `PermissiveLegacyMissing`.
+- `OutboundCapabilityDecision::PermissiveLegacyMissing` variant renamed to `OpenDefault` (no longer a transitional grace).
+- `warn_once_outbound_capabilities_missing` helper retired entirely. Missing field is silent — no FATAL log, no operator-actionable migration template, no friction.
+- `bootstrap::fleet_normalize::auto_create_general` no longer auto-injects an explicit cap list onto `general`. Built-ins inherit default-open like operator-authored instances do.
 
-### Built-in instances
+**What stayed the same**:
+- `Some([reply, …])` — selective allow-list still works.
+- `Some([])` — explicit opt-out still rejects everything (operator can still actively block agent outbound).
+- `channel.user_allowlist` (PR #216) — **still fail-closed**. Different threat model: notification fan-out to the operator's bound group. Missing allowlist drops every daemon-driven notification (stall / crash / CI alerts) silently. The `warn_once_user_allowlist_unconfigured` helper from Sprint 22 P1.5 remains active and surfaces a FATAL log.
 
-`general` (and any future auto-created coordinator) get auto-injected `[reply, react, edit, inject_provenance]` via `bootstrap::fleet_normalize::auto_create_general` — operator never has to author this field for first-class fleet members.
+## Decision matrix (current contract)
 
-### Independence from `user_allowlist`
+| State | Behaviour |
+|---|---|
+| field absent | **all ops permitted** |
+| `[reply, react, edit, inject_provenance]` | only listed ops permitted |
+| `[reply]` | only `reply` permitted; `react`/`edit`/`inject_provenance` rejected |
+| `[]` (explicit empty) | **all ops rejected** (operator opt-out) |
 
-`outbound_capabilities` only gates **agent-callable** MCP→Channel ops (the four MCP tools above). The `channel.user_allowlist` field continues to gate inbound message acceptance + daemon-internal stall/recovery/CI notifications (per [PR #216](https://github.com/suzuke/agend-terminal/pull/216) outbound fail-closed default at the daemon notify call sites). The two gates compose — both must be satisfied for an agent's reply to actually reach the bound Telegram group.
+## Built-in instances
 
-## Why this matters (security)
+`general` (and any future auto-created coordinator) inherits default-open — no auto-injected list. The persisted `fleet.yaml` for a fresh `general` no longer carries an `outbound_capabilities:` line.
 
-Without the per-instance gate, any agent in the fleet could emit any MCP→Channel op to the bound Telegram group. The Sprint 20.5 cross-validation audit (see `docs/codebase-review-2026-04-27/SYNTHESIS.md`) flagged this as a per-instance authorization hole even after PR #216 closed the daemon-side outbound info-leak.
+## Migration from Sprint 22 P0
 
-The fix is to require operators to declare per-instance outbound intent explicitly. The Sprint 22 P0 transition window (warn-but-permit) gives operators time to update fleet.yaml without breaking running deployments; Sprint 23 closes the hole completely.
+If you previously added `outbound_capabilities: [reply, react, edit, inject_provenance]` to an instance to silence the FATAL log: you can remove that line and the instance still works. Or keep it — it's now equivalent to default-open.
 
-## What you'll see during the transition
+If you set `outbound_capabilities: []` to opt out: that still works as expected.
 
-On the first agent outbound call from an instance missing `outbound_capabilities`, daemon logs (at `error` level for visibility):
+## Independence from `user_allowlist` (unchanged)
 
-```
-ERROR: FATAL (warn-but-permit one daemon cycle): instance '<name>' \
-       outbound_capabilities NOT SET. Sprint 22 P0 grants this <op> call \
-       under gradual-migration grace. Sprint 23 will fail-closed (hard \
-       parse error on missing field). Add to fleet.yaml NOW:
-  instances.<name>.outbound_capabilities: [reply, react, edit, inject_provenance]
-See docs/USAGE.md "Channel: Telegram" + docs/MIGRATION-OUTBOUND-CAPS.md for details.
-```
-
-The op is permitted this cycle (no operator-visible breaking) but the warn is rate-limited to **once per instance per process lifetime** so you'll see one error per instance per daemon restart — not log spam.
-
-In Sprint 23, the same fleet.yaml will fail to load with a `serde` parse error pointing back to this migration doc.
+`outbound_capabilities` only gates **agent-callable** MCP→Channel ops (`reply` / `react` / `edit_message` / `delegate_task` provenance). The `channel.user_allowlist` field continues to gate inbound message acceptance + daemon-internal notifications. **It is still fail-closed**, and the `warn_once_user_allowlist_unconfigured` helper still emits a FATAL log when missing. The two gates compose independently.
 
 ## ChannelOpKind enum reference
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -168,41 +168,35 @@ To restore outbound notifications, add your operator user_id(s) to `user_allowli
 
 If you previously relied on legacy "anyone in the group can command the fleet" behaviour, the inbound side still accepts all users until Phase 2 lands; configure `user_allowlist` now to close both sides simultaneously.
 
-### `outbound_capabilities` semantics (Sprint 22 P0 — 2-stage hard-cut)
+### `outbound_capabilities` semantics (Sprint 23 P1 — default-open)
 
-Per-instance gate for **agent-callable** outbound MCP→Channel ops (`reply` / `react` / `edit_message` / `delegate_task` provenance). Independent of `user_allowlist` (which gates inbound + daemon-internal notifications).
+Per-instance gate for **agent-callable** outbound MCP→Channel ops (`reply` / `react` / `edit_message` / `delegate_task` provenance). Independent of `user_allowlist` (which gates inbound + daemon-internal notifications and is still **fail-closed**).
 
-| `outbound_capabilities` value | Sprint 22 P0 behaviour | Sprint 23 (planned) |
-|---|---|---|
-| `[reply, react, edit, inject_provenance]` | Only listed ops permitted | Same |
-| `[]` (explicit empty) | Fail-closed — no agent outbound | Same |
-| field absent | **FATAL warn-but-permit one daemon cycle** + migration template logged | **Hard parse error** (daemon refuses to load fleet.yaml) |
+| `outbound_capabilities` value | Behaviour |
+|---|---|
+| field absent | **Default-open — all ops permitted** |
+| `[reply, react, edit, inject_provenance]` | Only listed ops permitted |
+| `[]` (explicit empty) | All ops rejected (operator opt-out, retained) |
 
-Built-in instances (`general` and any future auto-created coordinator) get auto-injected `[reply, react, edit, inject_provenance]` via `bootstrap::fleet_normalize` — operator never has to author this field for first-class fleet members.
+**Why default-open?** Single-operator threat model. The TUI is already full machine access; the cascade-attack-chain defence from Sprint 22 P0 was over-spec for the actual deployment shape. Operator explicitly accepts the security trade-off (Sprint 23 P1 reversal).
 
-### Migration: adding `outbound_capabilities` (Sprint 22 P0 → Sprint 23)
+Built-in instances (`general` and any future auto-created coordinator) inherit default-open — no auto-injected list needed (was the case in Sprint 22 P0 PR #230 and is now retired).
 
-For every **user-authored** instance in `fleet.yaml` (i.e. anything you spawned that isn't `general`), add an explicit `outbound_capabilities` field NOW. The Sprint 22 P0 transition window emits the following error log on first agent outbound call:
+### Restricting / opting out
 
-```
-ERROR: FATAL (warn-but-permit one daemon cycle): instance '<name>' \
-       outbound_capabilities NOT SET. Sprint 22 P0 grants this <op> call \
-       under gradual-migration grace. Sprint 23 will fail-closed (hard \
-       parse error on missing field). Add to fleet.yaml NOW:
-  instances.<name>.outbound_capabilities: [reply, react, edit, inject_provenance]
-```
+Default-open is the recommended posture for single-operator deployments. Two opt-out shapes if you want the gate active:
 
-Copy the suggested stanza into your `fleet.yaml`:
+**Restrict to a subset of ops** (e.g. allow `reply` only):
 
 ```yaml
 instances:
   my-worker:
     backend: claude
-    outbound_capabilities: [reply, react, edit, inject_provenance]
+    outbound_capabilities: [reply]
     # … other fields …
 ```
 
-For an instance that should be **inbound-only** (relay / read-only roles), set the field to an empty list:
+**Block all agent outbound** (relay / read-only roles):
 
 ```yaml
 instances:
@@ -211,7 +205,7 @@ instances:
     outbound_capabilities: []                # explicit "no agent outbound"
 ```
 
-See `docs/MIGRATION-OUTBOUND-CAPS.md` for the operator-facing transition guide and the full `ChannelOpKind` enum reference.
+See `docs/MIGRATION-OUTBOUND-CAPS.md` for the full transition guide (Sprint 22 P0 fail-closed → Sprint 23 P1 default-open reversal section) and the `ChannelOpKind` enum reference.
 
 ## Other Commands
 

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -10,24 +10,18 @@
 //! normalize in memory without touching disk.
 
 use crate::backend::Backend;
-use crate::channel::auth::ChannelOpKind;
 use crate::fleet::{self, FleetConfig, InstanceConfig, InstanceYamlEntry};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-/// Default outbound capability set granted to built-in (auto-injected)
-/// fleet instances. Sprint 22 P0 (Phase 5b): `general` and any future
-/// auto-created coordinator gets the full set so the operator never has
-/// to author outbound_capabilities for first-class fleet members.
-fn default_built_in_outbound_capabilities() -> Vec<ChannelOpKind> {
-    vec![
-        ChannelOpKind::Reply,
-        ChannelOpKind::React,
-        ChannelOpKind::Edit,
-        ChannelOpKind::InjectProvenance,
-    ]
-}
+// Sprint 23 P1 (default-open reversal) — `default_built_in_outbound_capabilities`
+// retired. Built-in instances (`general` + future auto-created coordinators)
+// no longer need an explicit cap list because the missing-field default is
+// now OPEN. Removing the explicit Vec keeps the auto-created entry minimal
+// (matches what an operator would typically write — i.e. nothing) and avoids
+// emitting noise in the persisted fleet.yaml. Operators can still opt out
+// or restrict via the standard `outbound_capabilities: []` / selective list.
 
 /// Normalize in-memory, optionally persisting fleet.yaml side effects.
 pub(super) fn normalize(config: &mut FleetConfig, home: &Path, persist: bool) {
@@ -51,12 +45,13 @@ fn auto_create_general(config: &mut FleetConfig, home: &Path, persist: bool) {
             backend: Some(default_backend),
             working_directory: None,
             topic_id: Some(1),
-            // Sprint 22 P0 (Phase 5b): built-in instances get auto-injected
-            // outbound capabilities so the operator never has to think about
-            // the field for first-class fleet members. User-yaml entries
-            // remain forced-explicit (the warn-then-permit / hard-cut
-            // transition applies only to operator-authored instances).
-            outbound_capabilities: Some(default_built_in_outbound_capabilities()),
+            // Sprint 23 P1 reversal: missing `outbound_capabilities` now
+            // means default-open (was Sprint 22 P0 fail-closed with FATAL
+            // warn). Auto-created built-ins inherit default-open the same
+            // way operator-authored instances do — no explicit list
+            // needed. The single-operator threat model (TUI = full machine
+            // access) makes the cascade-attack-chain defense irrelevant.
+            outbound_capabilities: None,
             ..Default::default()
         },
     );

--- a/src/channel/auth.rs
+++ b/src/channel/auth.rs
@@ -90,19 +90,34 @@ impl ChannelOpKind {
 }
 
 /// Decision returned by [`evaluate_outbound_capability`] — explicit enum so
-/// callers can distinguish "permitted (configured)" from "permitted under
-/// gradual-migration grace" (the latter must emit the deprecation warn).
+/// callers can distinguish "permitted by explicit allow-list" from
+/// "permitted by default-open" (the latter is now the canonical default,
+/// not a transitional grace).
+///
+/// **Sprint 23 P1 (per operator philosophy override)** — semantics
+/// inverted from Sprint 22 P0's fail-closed default:
+/// - `outbound_capabilities` field absent → `OpenDefault` (PERMIT)
+/// - `outbound_capabilities: []` → `Rejected` (explicit opt-out, retained)
+/// - `outbound_capabilities: [reply]` → `Allowed`/`Rejected` per-op
+///
+/// The `PermissiveLegacyMissing` variant from Sprint 22 P0's hard-cut
+/// transition is renamed to `OpenDefault` to reflect that default-open is
+/// no longer a "grace" — it is the canonical posture for the single-
+/// operator threat model. Cascade attack chain doesn't apply (TUI = full
+/// machine access; operator explicit ack of the security trade-off via
+/// telegram 11:00 UTC routed through `general` m-20260427115706155870-88).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutboundCapabilityDecision {
     /// `outbound_capabilities` includes the requested op — proceed normally.
     Allowed,
     /// `outbound_capabilities` is set but does NOT include the op — reject.
+    /// Triggered by `Some(non_empty_list_without_op)` and by the explicit
+    /// `Some(empty_list)` opt-out.
     Rejected,
-    /// `outbound_capabilities` is `None` (config absent) — Phase 5b
-    /// gradual-migration permissive default. Caller MUST emit the
-    /// once-per-instance deprecation warn so operators see the migration
-    /// template before Sprint 22's hard-cut.
-    PermissiveLegacyMissing,
+    /// `outbound_capabilities` is `None` (field absent in fleet.yaml) —
+    /// default-open per Sprint 23 P1 reversal. Operator declares the
+    /// field only to opt out (`[]`) or restrict (selective list).
+    OpenDefault,
 }
 
 /// Pure decision: given the configured `outbound_capabilities` Vec for an
@@ -118,54 +133,22 @@ pub fn evaluate_outbound_capability(
     match capabilities {
         Some(caps) if caps.contains(&requested) => OutboundCapabilityDecision::Allowed,
         Some(_) => OutboundCapabilityDecision::Rejected,
-        None => OutboundCapabilityDecision::PermissiveLegacyMissing,
+        None => OutboundCapabilityDecision::OpenDefault,
     }
 }
 
-/// Once-per-instance deprecation-warn guard — `Channel::send_from_agent`
-/// impls call this on every `PermissiveLegacyMissing` decision; the first
-/// call per instance emits the migration template, subsequent calls log
-/// at debug level.
-///
-/// Backed by a global `Mutex<HashSet<String>>` so the once-per-process
-/// guarantee is per-instance-name, not per-call.
-pub fn warn_once_outbound_capabilities_missing(instance: &str, op: ChannelOpKind) {
-    use std::sync::Mutex;
-    static SEEN: std::sync::OnceLock<Mutex<std::collections::HashSet<String>>> =
-        std::sync::OnceLock::new();
-    let seen = SEEN.get_or_init(|| Mutex::new(std::collections::HashSet::new()));
-    let first_time = match seen.lock() {
-        Ok(mut set) => set.insert(instance.to_string()),
-        // Poisoned lock — fall through to "log every time" rather than
-        // silently drop the migration warn (deprecation visibility wins
-        // over log spam).
-        Err(_) => true,
-    };
-    if first_time {
-        // Sprint 22 P0 (Phase 5b hard-cut, 2-stage transition per
-        // d-20260427042738203707-13): elevated to `error!` for FATAL
-        // visibility — Sprint 23 will switch to a hard parse error.
-        // Operator MUST add the field this sprint window.
-        tracing::error!(
-            instance,
-            op = op.as_str(),
-            "FATAL (warn-but-permit one daemon cycle): instance '{instance}' \
-             outbound_capabilities NOT SET. Sprint 22 P0 grants this {op_str} call \
-             under gradual-migration grace. Sprint 23 will fail-closed (hard parse \
-             error on missing field). Add to fleet.yaml NOW:\n  \
-             instances.{instance}.outbound_capabilities: \
-             [reply, react, edit, inject_provenance]\nSee docs/USAGE.md \"Channel: \
-             Telegram\" + docs/MIGRATION-OUTBOUND-CAPS.md for details.",
-            op_str = op.as_str()
-        );
-    } else {
-        tracing::debug!(
-            instance,
-            op = op.as_str(),
-            "outbound_capabilities still not set (already warned once)"
-        );
-    }
-}
+// `warn_once_outbound_capabilities_missing` retired — Sprint 23 P1
+// reversal: missing `outbound_capabilities` is the **default-open posture**,
+// no longer a deprecation-warned migration grace. The previous Sprint 22 P0
+// FATAL `tracing::error!` line became misleading after the philosophy
+// override (operator hits the warn on every restart of a fresh fleet,
+// implying breakage where there is none). Removed entirely; the
+// [`OutboundCapabilityDecision::OpenDefault`] branch is now silent.
+//
+// Sister helper [`warn_once_user_allowlist_unconfigured`] is kept — the
+// channel-level allowlist gate is still fail-closed (different threat
+// model: notification fan-out to operator; missing allowlist drops all
+// notifications, surfacing as silent operator regression).
 
 /// Sprint 22 P1.5 (Candidate 4) — sibling of
 /// [`warn_once_outbound_capabilities_missing`] for the *channel-level*
@@ -230,26 +213,28 @@ pub fn warn_once_user_allowlist_unconfigured(channel_kind: &str, instance: &str)
     }
 }
 
-/// Sprint 22 P0 — shared `gate_outbound_for_agent` helper consumed by every
+/// Sprint 22 P0 (introduced) + Sprint 23 P1 (default-open inversion) —
+/// shared `gate_outbound_for_agent` helper consumed by every
 /// `Channel::send_from_agent` impl (Telegram + future Discord/Slack/Teams).
 ///
 /// Centralises the per-agent capability check so:
 /// 1. Future channel adapters cannot accidentally bypass the gate by
 ///    forgetting to call `evaluate_outbound_capability` in their impl.
-/// 2. The `PermissiveLegacyMissing` deprecation warn is consistent across
-///    adapters (one helper, one warn line, one migration message).
-/// 3. The (PermissiveLegacyMissing → permit + warn) branch is testable in
-///    isolation without spinning up a real channel.
+/// 2. The default-open semantic is consistent across adapters (one helper,
+///    one decision matrix, one set of error messages).
+/// 3. The (OpenDefault → permit) branch is testable in isolation without
+///    spinning up a real channel.
 ///
-/// Returns `Ok(())` when the agent is permitted to emit `op` (either
-/// explicitly listed OR under gradual-migration grace). Returns
+/// Returns `Ok(())` when the agent is permitted to emit `op` (explicitly
+/// listed OR field absent → default-open). Returns
 /// `Err(ChannelError::Other)` with a typed error message when explicitly
-/// rejected (capability list set but does NOT include `op`).
+/// rejected (capability list set but does NOT include `op`, including the
+/// `[]` opt-out).
 ///
 /// IO note: reads `<home>/fleet.yaml` on each call. For per-call frequency
 /// in production this is acceptable (operator config rarely changes
 /// mid-flight); a future hot-reload optimisation is tracked in dispatch
-/// d-20260427042738203707-13 deferred items (Sprint 23+ candidate).
+/// d-20260427042738203707-13 deferred items.
 pub fn gate_outbound_for_agent(
     home: &std::path::Path,
     agent: &str,
@@ -260,14 +245,11 @@ pub fn gate_outbound_for_agent(
         OutboundCapabilityDecision::Allowed => Ok(()),
         OutboundCapabilityDecision::Rejected => Err(super::ChannelError::Other(anyhow::anyhow!(
             "instance '{agent}' outbound_capabilities does not include '{op_str}' \
-             — add to fleet.yaml or remove the explicit list to opt into the \
-             gradual-migration permissive default",
+             — either add the op to the list, remove the entire field for default-open, \
+             or change the empty list to declare the desired ops",
             op_str = op.as_str()
         ))),
-        OutboundCapabilityDecision::PermissiveLegacyMissing => {
-            warn_once_outbound_capabilities_missing(agent, op);
-            Ok(())
-        }
+        OutboundCapabilityDecision::OpenDefault => Ok(()),
     }
 }
 
@@ -379,12 +361,26 @@ mod tests {
     }
 
     #[test]
-    fn evaluate_outbound_capability_permissive_legacy_when_missing() {
-        // No config: gradual-migration permissive grace. Sprint 22
-        // hard-cut PR will flip this to Rejected.
+    fn evaluate_outbound_capability_open_default_when_missing() {
+        // **Sprint 23 P1 reversal** — missing `outbound_capabilities`
+        // field is the default-open posture (was `PermissiveLegacyMissing`
+        // in Sprint 22 P0 with FATAL warn). Operator declares the field
+        // only to opt out (`[]`) or restrict (selective list).
         assert_eq!(
             evaluate_outbound_capability(None, ChannelOpKind::Reply),
-            OutboundCapabilityDecision::PermissiveLegacyMissing
+            OutboundCapabilityDecision::OpenDefault
+        );
+        assert_eq!(
+            evaluate_outbound_capability(None, ChannelOpKind::React),
+            OutboundCapabilityDecision::OpenDefault
+        );
+        assert_eq!(
+            evaluate_outbound_capability(None, ChannelOpKind::Edit),
+            OutboundCapabilityDecision::OpenDefault
+        );
+        assert_eq!(
+            evaluate_outbound_capability(None, ChannelOpKind::InjectProvenance),
+            OutboundCapabilityDecision::OpenDefault
         );
     }
 
@@ -430,15 +426,9 @@ mod tests {
         assert_eq!(reparsed, parsed);
     }
 
-    #[test]
-    fn warn_once_outbound_capabilities_missing_does_not_panic() {
-        // Smoke test: helper must be re-entrant + survive concurrent calls.
-        // The actual once-per-instance behaviour is verified by reading
-        // tracing output (operator-visible), not by this unit test.
-        warn_once_outbound_capabilities_missing("test_agent_phase5b", ChannelOpKind::Reply);
-        warn_once_outbound_capabilities_missing("test_agent_phase5b", ChannelOpKind::React);
-        warn_once_outbound_capabilities_missing("another_agent", ChannelOpKind::Edit);
-    }
+    // `warn_once_outbound_capabilities_missing_does_not_panic` removed —
+    // the helper itself is gone (Sprint 23 P1 reversal: missing field is
+    // the canonical default, not a deprecation-warned grace).
 
     #[test]
     fn warn_once_user_allowlist_unconfigured_does_not_panic() {
@@ -457,5 +447,115 @@ mod tests {
         // Different channel_kind same instance is a distinct key — must
         // also not panic (covers future Discord / Slack adapter shape).
         warn_once_user_allowlist_unconfigured("discord", "test_agent_p1_5");
+    }
+
+    // ── Sprint 23 P1 — gate_outbound_for_agent default-open contract ──
+
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn write_fleet_yaml(home: &std::path::Path, body: &str) {
+        std::fs::create_dir_all(home).expect("create test home dir");
+        std::fs::write(home.join("fleet.yaml"), body).expect("write fleet.yaml fixture");
+    }
+
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-auth-gate-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).expect("create tmp dir");
+        dir
+    }
+
+    /// Sprint 23 P1 — missing `outbound_capabilities` field permits
+    /// every op (default-open per operator philosophy override).
+    #[test]
+    fn gate_outbound_for_agent_missing_field_returns_permitted() {
+        let home = tmp_home("gate_missing");
+        write_fleet_yaml(
+            &home,
+            r#"
+instances:
+  alpha:
+    backend: claude
+"#,
+        );
+        for op in [
+            ChannelOpKind::Reply,
+            ChannelOpKind::React,
+            ChannelOpKind::Edit,
+            ChannelOpKind::InjectProvenance,
+        ] {
+            assert!(
+                gate_outbound_for_agent(&home, "alpha", op).is_ok(),
+                "default-open: missing outbound_capabilities must permit {op:?}"
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Sprint 23 P1 — explicit `outbound_capabilities: []` rejects all
+    /// ops (operator opt-out preserved). Distinct from missing field.
+    #[test]
+    fn gate_outbound_for_agent_empty_list_rejects_all_ops() {
+        let home = tmp_home("gate_empty");
+        write_fleet_yaml(
+            &home,
+            r#"
+instances:
+  alpha:
+    backend: claude
+    outbound_capabilities: []
+"#,
+        );
+        for op in [
+            ChannelOpKind::Reply,
+            ChannelOpKind::React,
+            ChannelOpKind::Edit,
+            ChannelOpKind::InjectProvenance,
+        ] {
+            let err = gate_outbound_for_agent(&home, "alpha", op).err();
+            assert!(
+                err.is_some(),
+                "explicit empty list opt-out must reject {op:?}, got Ok"
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Sprint 23 P1 — explicit selective list permits only the listed
+    /// ops; everything else rejected.
+    #[test]
+    fn gate_outbound_for_agent_selective_list_permits_only_listed() {
+        let home = tmp_home("gate_selective");
+        write_fleet_yaml(
+            &home,
+            r#"
+instances:
+  alpha:
+    backend: claude
+    outbound_capabilities: [reply]
+"#,
+        );
+        assert!(
+            gate_outbound_for_agent(&home, "alpha", ChannelOpKind::Reply).is_ok(),
+            "selective list must permit listed op"
+        );
+        for op in [
+            ChannelOpKind::React,
+            ChannelOpKind::Edit,
+            ChannelOpKind::InjectProvenance,
+        ] {
+            assert!(
+                gate_outbound_for_agent(&home, "alpha", op).is_err(),
+                "selective list must reject unlisted op {op:?}"
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -237,14 +237,12 @@ pub trait Channel: Send + Sync {
     ///
     /// Implementations must:
     /// 1. Check [`Self::outbound_authorized`] (PR #216 allowlist gate).
-    /// 2. Look up the per-agent `outbound_capabilities` config from
-    ///    `fleet.yaml` and consult
-    ///    [`auth::evaluate_outbound_capability`].
-    /// 3. On `PermissiveLegacyMissing`, call
-    ///    [`auth::warn_once_outbound_capabilities_missing`] (gradual
-    ///    migration: permit + warn; Sprint 22 hard-cut PR flips to
-    ///    reject).
-    /// 4. Dispatch to the platform-specific send.
+    /// 2. Call [`auth::gate_outbound_for_agent`] which loads per-agent
+    ///    `outbound_capabilities` from fleet.yaml and resolves the
+    ///    decision (Allowed / Rejected / OpenDefault per Sprint 23 P1
+    ///    default-open semantics — missing field permits all ops, `[]`
+    ///    rejects all, selective list permits only listed).
+    /// 3. Dispatch to the platform-specific send.
     ///
     /// Default: `Err(NotSupported)` so adapters that haven't opted in
     /// fail closed.
@@ -327,10 +325,12 @@ pub fn gated_notify(
         // `RUST_LOG=info` so operators didn't see the gate firing when
         // stall / crash / CI notices were silently dropped.
         // `warn_once_user_allowlist_unconfigured` upgrades to FATAL
-        // (`error!`) once-per-channel:instance pair, mirroring P0's
-        // `warn_once_outbound_capabilities_missing` shape so operators
-        // see the same operator-actionable copy-paste fleet.yaml
-        // stanza regardless of which gate fired.
+        // (`error!`) once-per-channel:instance pair so operators see an
+        // operator-actionable copy-paste fleet.yaml stanza when the
+        // allowlist is unconfigured. Sprint 23 P1 retired the
+        // outbound-caps sister helper because that gate is now default-
+        // open; the channel-level allowlist gate is still fail-closed
+        // (different threat model — silent notification fan-out).
         auth::warn_once_user_allowlist_unconfigured(channel.kind(), instance);
         return Ok(());
     }

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -2157,14 +2157,14 @@ impl crate::channel::Channel for TelegramChannel {
     ///    if the operator has not configured `user_allowlist`, drop
     ///    everything (PR #216 contract).
     /// 2. Per-agent capability lookup —
-    ///    [`crate::channel::auth::evaluate_outbound_capability`]:
-    ///    - `Allowed` → dispatch to internal `try_telegram_*_from`
-    ///    - `Rejected` → return `Err(ChannelError::Other)` with
-    ///      operator-readable message
-    ///    - `PermissiveLegacyMissing` → emit once-per-instance
-    ///      deprecation warn via
-    ///      [`crate::channel::auth::warn_once_outbound_capabilities_missing`],
-    ///      then proceed (Sprint 22 hard-cut PR will flip).
+    ///    [`crate::channel::auth::gate_outbound_for_agent`]:
+    ///    - `OutboundCapabilityDecision::Allowed` → dispatch
+    ///    - `OutboundCapabilityDecision::Rejected` → typed error
+    ///    - `OutboundCapabilityDecision::OpenDefault` → dispatch (Sprint
+    ///      23 P1 default-open: missing `outbound_capabilities` is the
+    ///      canonical posture for the single-operator threat model;
+    ///      operator declares the field only to opt out via `[]` or
+    ///      restrict via selective list).
     fn send_from_agent(
         &self,
         agent: &str,

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -171,35 +171,35 @@ pub struct InstanceConfig {
     /// proxies like `general` where broadcast markers read as noise.
     pub receive_fleet_updates: Option<bool>,
     /// Per-instance agent-callable outbound operations gate
-    /// (Sprint 21 Phase 5b → Sprint 22 P0 hard-cut transition).
+    /// (Sprint 21 Phase 5b → Sprint 22 P0 hard-cut → **Sprint 23 P1
+    /// default-open reversal** per operator philosophy override).
     ///
-    /// **2-stage transition** (per dispatch d-20260427042738203707-13):
+    /// **Current contract** (Sprint 23 P1):
     ///
-    /// | State | Sprint 22 P0 (this sprint) | Sprint 23 (planned) |
-    /// |---|---|---|
-    /// | `Some([reply, …])` | only listed ops permitted | same |
-    /// | `Some([])` | fail-closed (no agent outbound; explicit) | same |
-    /// | `None` (absent) | **FATAL warn-then-permit one daemon cycle** | hard parse error |
+    /// | State | Behaviour |
+    /// |---|---|
+    /// | `Some([reply, …])` | only listed ops permitted |
+    /// | `Some([])` | all ops rejected (explicit opt-out, retained) |
+    /// | `None` (absent) | **default-open: all ops permitted** |
     ///
-    /// **Built-in instances** (`general` and future auto-created coordinators)
-    /// receive `[reply, react, edit, inject_provenance]` automatically via
-    /// `bootstrap::fleet_normalize::auto_create_general` — operator never
-    /// has to author this field for first-class fleet members.
+    /// **Why default-open**: single-operator threat model. The TUI is
+    /// already full machine access; the cascade-attack-chain defence
+    /// from Sprint 22 P0 was over-spec for the actual deployment shape.
+    /// Operator explicitly accepts the security trade-off (telegram 11:00
+    /// UTC routed via general m-20260427115706155870-88 →
+    /// `t-20260427115754474312-3`).
     ///
-    /// **User-yaml entries** (any instance not auto-injected) are forced
-    /// explicit. The Sprint 22 transition window emits a FATAL log via
-    /// `crate::channel::auth::warn_once_outbound_capabilities_missing`
-    /// when the field is absent — operators MUST add the field this sprint
-    /// or Sprint 23 will refuse to load fleet.yaml.
-    ///
-    /// **Migration**: see `docs/MIGRATION-OUTBOUND-CAPS.md` for operator-
-    /// facing transition guide and `docs/USAGE.md` "Channel: Telegram"
-    /// section for fleet.yaml stanza examples.
+    /// **Migration**: see `docs/MIGRATION-OUTBOUND-CAPS.md` for the
+    /// operator-facing transition guide (now includes the Sprint 23 P1
+    /// reversal section) and `docs/USAGE.md` "Channel: Telegram"
+    /// section for fleet.yaml stanza examples (opt-out / restrict).
     ///
     /// **Daemon notify** (PR #216 fail-closed gate at supervisor.rs /
-    /// ci_watch.rs notify call sites) remains independent of this field —
-    /// `outbound_capabilities` only gates **agent-callable** MCP→Channel
-    /// ops, not daemon-internal stall/recovery/CI notifications.
+    /// ci_watch.rs notify call sites) remains fail-closed — different
+    /// threat model: notification fan-out to operator. Missing
+    /// `user_allowlist` still drops every notification, surfacing as a
+    /// silent operator regression unless `warn_once_user_allowlist_unconfigured`
+    /// fires.
     #[serde(default)]
     pub outbound_capabilities: Option<Vec<crate::channel::auth::ChannelOpKind>>,
 }


### PR DESCRIPTION
## Summary
**URGENT** — operator daily workflow blocked by Sprint 22 P0 PR #230's fail-closed default. Operator hit \"no active channel\" reply/react errors on a fresh fleet because no instance declared `outbound_capabilities`. Per operator philosophy override (telegram 11:00 UTC routed via general m-20260427115706155870-88), this PR reverses the default to **default-open** for the single-operator threat model.

## Decision matrix (current contract)
| `outbound_capabilities` value | Behaviour |
|---|---|
| field absent | **all ops permitted** (default-open) |
| `[reply, react, edit, inject_provenance]` | only listed ops permitted |
| `[]` (explicit empty) | all ops rejected (operator opt-out, retained) |

## Why default-open is the right call
The Sprint 22 P0 cascade-attack-chain defence was over-spec for the actual deployment shape. Single-operator threat model: the TUI is already full machine access; if an agent in the fleet is compromised, the operator already has bigger problems than gated MCP outbound ops. Operator explicitly accepts the security trade-off.

## Code changes
- **`src/channel/auth.rs`**:
  - `OutboundCapabilityDecision::PermissiveLegacyMissing` → `OpenDefault` (rename — no longer a transitional grace, this IS the canonical posture)
  - `evaluate_outbound_capability` returns `OpenDefault` on `None`
  - `gate_outbound_for_agent` permits `OpenDefault` silently
  - **`warn_once_outbound_capabilities_missing` helper REMOVED entirely** (no FATAL log on every fresh-fleet restart)
  - `warn_once_user_allowlist_unconfigured` (sister helper) RETAINED — different threat model, channel-level allowlist is still fail-closed
- **`src/bootstrap/fleet_normalize.rs`**:
  - `default_built_in_outbound_capabilities` Vec retired
  - `auto_create_general` no longer auto-injects an explicit cap list; built-ins inherit default-open
- **`src/channel/mod.rs`** + **`src/channel/telegram.rs`** + **`src/fleet.rs`** doc-comments updated

## Tests
- **3 new `gate_outbound_for_agent` tests**:
  - `gate_outbound_for_agent_missing_field_returns_permitted` (default-open)
  - `gate_outbound_for_agent_empty_list_rejects_all_ops` (opt-out preserved)
  - `gate_outbound_for_agent_selective_list_permits_only_listed`
- `evaluate_outbound_capability_permissive_legacy_when_missing` → `evaluate_outbound_capability_open_default_when_missing` (renamed + asserts ALL 4 ops return `OpenDefault`)
- `warn_once_outbound_capabilities_missing_does_not_panic` removed (helper is gone)

## Docs
- `docs/USAGE.md` \"outbound_capabilities semantics\" section rewritten (default-open contract + opt-out shapes)
- `docs/MIGRATION-OUTBOUND-CAPS.md` Sprint 23 P1 reversal section added (rationale + migration-from-Sprint-22-P0 guidance + retained fail-closed `user_allowlist` separation)

## Anti-bypass invariant intact
`tests/legacy_outbound_path_audit.rs` (Sprint 22 P0 anti-bypass) STILL PASSES — the structural defense (gate-only-call-site contract) is independent of the gate's policy semantics. The gate is still the single source of truth; only its decision matrix flipped.

## Verification
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --tests` — **1234 pass, 0 failed, 8 ignored** across all 9 anti-bypass + integration + characterization test files (Sprint 23 P1 PR #240 ci.yml broadening now ensures every file runs on CI)

## Cross-team coordination
ts-lead `docs/migration-to-agend-terminal.md` describes fail-closed semantics — heads-up message will be sent after PR push for parallel doc revision.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] All tests pass (1234 / 0 failed / 8 ignored)
- [x] Anti-bypass invariant `legacy_outbound_path_audit` still passes
- [ ] CI green on all 3 platforms
- [ ] Operator-confirms reply/react actually works on the live fleet (post-merge)

## References
- Operator design philosophy decision via general m-20260427115706155870-88
- Dispatch m-20260427115825059656-89
- Sprint 22 P0 PR #230 (the design being reversed)

Closes t-20260427115754474312-3

## Reviewer assignment
- **dev-reviewer-2** main reviewer (adversarial continuation — verified the Sprint 22 P0 fail-closed; now verify the reversal preserves explicit-opt-out + selective semantics + structural defense)
- **dev-reviewer** cross-vantage second-pass (REJECT criteria carryover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)