### PR TITLE
Sprint 24 P1 — F-NEW-DAEMON-HEALTH-CLASSIFIER-1 (IdleLong vs Hung discriminator, ~210 LOC)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -528,13 +528,22 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 crate::daemon::ci_watch::check_ci_watches(&home, &registry);
                 {
                     let reg = crate::agent::lock_registry(&registry);
-                    for (_name, handle) in reg.iter() {
+                    for (name, handle) in reg.iter() {
                         if let Ok(mut core) = handle.core.lock() {
                             core.health.maybe_decay();
                             core.state.tick();
                             let agent_state = core.state.current;
                             let silent = core.state.last_output.elapsed();
-                            core.health.check_hang(agent_state, silent);
+                            // Sprint 24 P1: pair snapshot for input-aware
+                            // hang discrimination (matches daemon/mod.rs
+                            // pattern).
+                            let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
+                            core.health.check_hang(
+                                agent_state,
+                                silent,
+                                pair.last_input_at_ms,
+                                pair.heartbeat_at_ms,
+                            );
                         }
                     }
                 }

--- a/src/daemon/heartbeat_pair.rs
+++ b/src/daemon/heartbeat_pair.rs
@@ -39,14 +39,33 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 /// Paired in-memory heartbeat state — readers see consistent snapshot at
 /// lock acquisition time.
+///
+/// Sprint 24 P1 (F-NEW-DAEMON-HEALTH-CLASSIFIER-1) extended the pair with
+/// `last_input_at_ms` so the daemon health classifier can distinguish
+/// "idle waiting (no input pending)" from "hung unresponsive (input
+/// pending but no response)". Operator 04:00 UTC false-alarm scenario:
+/// dev-impl-1 idle 30 min in `Ready` was flagged `Hung` because the
+/// classifier only knew silence — adding the input-vs-heartbeat delta
+/// fixes the discrimination without breaking existing `Hung`-state
+/// consumers.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct HeartbeatPair {
     /// Last heartbeat timestamp, epoch ms. `0` = never recorded (agent
-    /// just spawned, or pre-Sprint 23 backfill not applied).
+    /// just spawned, or pre-Sprint 23 backfill not applied). Updated by
+    /// every MCP tool call (implicit heartbeat) and by
+    /// `set_waiting_on` set-side.
     pub heartbeat_at_ms: u64,
     /// When the agent's current `waiting_on` started, epoch ms. `None` =
     /// not waiting (cleared OR never set).
     pub waiting_on_since_ms: Option<u64>,
+    /// Sprint 24 P1: last time the daemon delivered input/inbox
+    /// notification to this agent's PTY, epoch ms. `0` = never (agent
+    /// just spawned). Drives the
+    /// [`crate::health::HealthTracker::check_hang`] discriminator
+    /// between `IdleLong` (no input pending → not escalation-worthy)
+    /// and `Hung` (input pending past response → real hung). Updated by
+    /// `inbox::notify_agent` central inject site.
+    pub last_input_at_ms: u64,
 }
 
 /// Per-instance lock registry. Keys are agent names (per

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -421,7 +421,20 @@ fn run_core(
                     core.health.maybe_decay();
                     let agent_state = core.state.current;
                     let silent = core.state.last_output.elapsed();
-                    if core.health.check_hang(agent_state, silent) {
+                    // Sprint 24 P1: snapshot heartbeat_pair OUTSIDE the
+                    // core lock-window to honor the leaf-level rule per
+                    // docs/DAEMON-LOCK-ORDERING.md (pair lock never held
+                    // while acquiring another lock). Pair lookup is
+                    // per-instance + cheap; safe to call here because
+                    // core lock is held but pair lock is acquired+released
+                    // synchronously.
+                    let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
+                    if core.health.check_hang(
+                        agent_state,
+                        silent,
+                        pair.last_input_at_ms,
+                        pair.heartbeat_at_ms,
+                    ) {
                         tracing::warn!(
                             agent = %name,
                             state = agent_state.display_name(),

--- a/src/health.rs
+++ b/src/health.rs
@@ -46,6 +46,14 @@ pub enum HealthState {
     Failed,
     Hung,
     ErrorLoop,
+    /// Sprint 24 P1 (F-NEW-DAEMON-HEALTH-CLASSIFIER-1): agent is silent
+    /// past the hang threshold but **no input is pending past last
+    /// response** — typically `Ready` state waiting for next dispatch.
+    /// Cron escalation chains (`interrupt` / `tool_kill` / `replace`)
+    /// MUST NOT trigger on this state; only `Hung` is escalation-worthy.
+    /// Closes the operator 04:00 UTC false-alarm pattern where impl-1's
+    /// 30-min idle-waiting was mis-classified as `Hung`.
+    IdleLong,
 }
 
 impl HealthState {
@@ -57,6 +65,7 @@ impl HealthState {
             Self::Failed => "failed",
             Self::Hung => "hung",
             Self::ErrorLoop => "error_loop",
+            Self::IdleLong => "idle_long",
         }
     }
 }
@@ -187,7 +196,26 @@ impl HealthTracker {
     /// Takes `silent` as a plain `Duration` (rather than `Instant::elapsed()`
     /// internally) so tests can construct arbitrary durations without
     /// overflowing on platforms where `Instant` is boot-anchored (Windows).
-    pub fn check_hang(&mut self, agent_state: AgentState, silent: Duration) -> bool {
+    ///
+    /// **Sprint 24 P1 (F-NEW-DAEMON-HEALTH-CLASSIFIER-1)** added the
+    /// `last_input_at_ms` + `last_heartbeat_at_ms` parameters from the
+    /// per-instance [`crate::daemon::heartbeat_pair::HeartbeatPair`]
+    /// snapshot to discriminate "idle waiting (no input pending)" from
+    /// "hung unresponsive (input pending past last response)". Pass `0`
+    /// for both in test contexts where the caller only wants legacy
+    /// silence-based hang detection (back-compat with existing tests).
+    ///
+    /// Returns `true` ONLY when transitioning **into** [`HealthState::Hung`]
+    /// (the escalation-worthy state). [`HealthState::IdleLong`] transitions
+    /// return `false` so cron escalation consumers (interrupt / tool_kill
+    /// / replace) keep their existing semantics — they only act on `Hung`.
+    pub fn check_hang(
+        &mut self,
+        agent_state: AgentState,
+        silent: Duration,
+        last_input_at_ms: u64,
+        last_heartbeat_at_ms: u64,
+    ) -> bool {
         // Race mutex: skip hang check when agent is blocked for a known
         // reason that legitimately suppresses output.
         if let Some(ref reason) = self.current_reason {
@@ -201,19 +229,65 @@ impl HealthTracker {
             }
         }
 
-        let is_hang = match agent_state {
-            AgentState::Idle => false, // Waiting for input
+        let silence_exceeds_threshold = match agent_state {
+            AgentState::Idle => false, // Waiting for input — never hangs
             AgentState::Starting => silent > Duration::from_secs(120),
             AgentState::Thinking | AgentState::ToolUse => silent > Duration::from_secs(600),
             _ => silent > Duration::from_secs(120),
         };
 
-        if is_hang && self.state != HealthState::Hung {
-            self.state = HealthState::Hung;
-            return true; // First hang detection
+        if !silence_exceeds_threshold {
+            // Recovering from a previous Hung/IdleLong → back to Healthy.
+            if matches!(self.state, HealthState::Hung | HealthState::IdleLong) {
+                self.state = HealthState::Healthy;
+            }
+            return false;
         }
-        if !is_hang && self.state == HealthState::Hung {
-            self.state = HealthState::Healthy;
+
+        // Sprint 24 P1 discriminator: input pending past last response
+        // (heartbeat) → real Hung. Otherwise (no input pending OR input
+        // already responded to) → IdleLong (no escalation).
+        //
+        // Grace window prevents flapping when input arrives 1-tick before
+        // the heartbeat write completes. 5s mirrors typical MCP roundtrip
+        // upper-bound for a non-busy agent.
+        const INPUT_RESPONSE_GRACE_MS: u64 = 5_000;
+        let input_pending_past_response = last_input_at_ms > 0
+            && last_input_at_ms > last_heartbeat_at_ms.saturating_add(INPUT_RESPONSE_GRACE_MS);
+
+        if input_pending_past_response {
+            // Real hung: input was delivered but agent has not responded
+            // (no MCP call to refresh heartbeat). Operator-facing log
+            // includes delta diagnostic per self-diagnostic pattern (PR #241
+            // praise pattern transfer).
+            let delta_ms = last_input_at_ms.saturating_sub(last_heartbeat_at_ms);
+            tracing::warn!(
+                last_input_at_ms,
+                last_heartbeat_at_ms,
+                input_response_delta_ms = delta_ms,
+                silent_secs = silent.as_secs(),
+                agent_state = ?agent_state,
+                "agent classified Hung — input pending {delta_ms}ms past last heartbeat (escalation-worthy)"
+            );
+            if self.state != HealthState::Hung {
+                self.state = HealthState::Hung;
+                return true; // First hang detection — caller escalates
+            }
+            return false;
+        }
+
+        // No input pending past response → idle waiting (operator 04:00
+        // UTC false-alarm pattern). Mark IdleLong so consumers can
+        // distinguish from Hung but cron escalation MUST NOT trigger.
+        if self.state != HealthState::IdleLong {
+            tracing::debug!(
+                last_input_at_ms,
+                last_heartbeat_at_ms,
+                silent_secs = silent.as_secs(),
+                agent_state = ?agent_state,
+                "agent classified IdleLong — silent past threshold but no input pending (no escalation)"
+            );
+            self.state = HealthState::IdleLong;
         }
         false
     }
@@ -374,14 +448,16 @@ mod tests {
     #[test]
     fn test_hang_idle_exempt() {
         let mut h = HealthTracker::new();
-        assert!(!h.check_hang(AgentState::Idle, Duration::from_secs(300))); // Idle never hangs
+        assert!(!h.check_hang(AgentState::Idle, Duration::from_secs(300), 1_000_000, 0));
+        // Idle never hangs
     }
 
     #[test]
     fn test_hang_thinking_long_timeout() {
         let mut h = HealthTracker::new();
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(100))); // 100s < 600s
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700))); // 700s > 600s
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(100), 1_000_000, 0)); // 100s < 600s
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        // 700s > 600s
     }
 
     #[test]
@@ -476,22 +552,22 @@ mod tests {
             retry_after_secs: Some(60),
         });
         // Thinking + 700s silence would normally trigger hang
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
         assert_ne!(h.state, HealthState::Hung);
 
         // Also test QuotaExceeded and AwaitingOperator
         h.clear_blocked_reason();
         h.set_blocked_reason(BlockedReason::QuotaExceeded);
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
 
         h.clear_blocked_reason();
         h.set_blocked_reason(BlockedReason::AwaitingOperator);
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
 
         // PermissionPrompt does NOT suppress hang check
         h.clear_blocked_reason();
         h.set_blocked_reason(BlockedReason::PermissionPrompt);
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
     }
 
     #[test]
@@ -500,10 +576,10 @@ mod tests {
         h.set_blocked_reason(BlockedReason::RateLimit {
             retry_after_secs: None,
         });
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
 
         h.clear_blocked_reason();
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
         assert_eq!(h.state, HealthState::Hung);
     }
 
@@ -546,7 +622,7 @@ mod tests {
         );
 
         // check_hang should still fire (no reason set)
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
     }
 
     #[test]
@@ -564,7 +640,7 @@ mod tests {
             h.current_reason
         );
         // check_hang should be suppressed
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
     }
 
     #[test]
@@ -577,7 +653,7 @@ mod tests {
         assert!(reason.is_none(), "healthy output should not classify");
         assert!(h.current_reason.is_none());
         // check_hang still works normally
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700)));
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
     }
 
     #[test]
@@ -590,5 +666,127 @@ mod tests {
             h.current_reason.is_none(),
             "reset must clear current_reason"
         );
+    }
+
+    // Sprint 24 P1 (F-NEW-DAEMON-HEALTH-CLASSIFIER-1) — IdleLong vs Hung
+    // discriminator tests. Closes operator 04:00 UTC false-alarm pattern.
+
+    #[test]
+    fn classifier_returns_hung_when_input_pending_past_response() {
+        // Real hung: input delivered at T+5s, agent has not responded
+        // (heartbeat still at T+0). Silence exceeds threshold. Classifier
+        // must return true (escalation-worthy) and set state = Hung.
+        let mut h = HealthTracker::new();
+        // last_input_at_ms past last_heartbeat_at_ms by > 5s grace.
+        let result = h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(180), // > 120s threshold
+            10_000,                   // input delivered at T+10s
+            0,                        // no heartbeat (or T-0)
+        );
+        assert!(result, "input pending past response → Hung, return true");
+        assert_eq!(h.state, HealthState::Hung);
+    }
+
+    #[test]
+    fn classifier_returns_idle_long_when_no_input_pending() {
+        // Operator 04:00 UTC pattern: agent silent past threshold but NO
+        // input was delivered (last_input_at_ms == 0). Classifier must
+        // mark IdleLong (no escalation) and return false.
+        let mut h = HealthTracker::new();
+        let result = h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(180), // > 120s threshold
+            0,                        // no input ever delivered
+            5_000,                    // heartbeat at T+5s (some past activity)
+        );
+        assert!(!result, "no input pending → IdleLong, no escalation");
+        assert_eq!(
+            h.state,
+            HealthState::IdleLong,
+            "must be IdleLong, NOT Hung — operator 04:00 UTC false-alarm pattern"
+        );
+    }
+
+    #[test]
+    fn classifier_returns_idle_long_when_input_already_responded_to() {
+        // Input delivered at T+0, agent responded at T+8s (heartbeat
+        // refreshed). Silence then accrues. Last_input < last_heartbeat
+        // → no input pending → IdleLong (NOT Hung).
+        let mut h = HealthTracker::new();
+        let result = h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(180),
+            0,     // input at T+0
+            8_000, // heartbeat at T+8s (already responded)
+        );
+        assert!(!result, "input already responded → IdleLong");
+        assert_eq!(h.state, HealthState::IdleLong);
+    }
+
+    #[test]
+    fn classifier_returns_healthy_when_silence_below_threshold() {
+        // Fresh agent: silent < threshold. Classifier returns Healthy
+        // regardless of input/heartbeat data.
+        let mut h = HealthTracker::new();
+        let result = h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(60), // < 120s threshold
+            10_000,
+            0,
+        );
+        assert!(!result);
+        assert_eq!(h.state, HealthState::Healthy);
+    }
+
+    #[test]
+    fn classifier_idle_long_recovers_to_healthy_when_activity_resumes() {
+        // Agent enters IdleLong at T+180s silent. Then activity resumes
+        // (silent drops below threshold). State must transition back to
+        // Healthy so future cron consumers don't see stale IdleLong.
+        let mut h = HealthTracker::new();
+        h.check_hang(AgentState::Ready, Duration::from_secs(180), 0, 5_000);
+        assert_eq!(h.state, HealthState::IdleLong);
+        // Activity resumes → silence < threshold.
+        let result = h.check_hang(AgentState::Ready, Duration::from_secs(30), 0, 5_000);
+        assert!(!result);
+        assert_eq!(
+            h.state,
+            HealthState::Healthy,
+            "IdleLong must recover to Healthy when silence drops"
+        );
+    }
+
+    #[test]
+    fn classifier_grace_window_prevents_flap() {
+        // last_input at T+5s, last_heartbeat at T+0. Delta = 5_000ms = exactly
+        // the grace window. Must NOT flag Hung — within grace.
+        let mut h = HealthTracker::new();
+        let result = h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(180),
+            5_000, // input
+            0,     // heartbeat — delta exactly 5_000ms
+        );
+        assert!(
+            !result,
+            "delta == grace window → not yet Hung (boundary inclusive)"
+        );
+        // delta = 5_001 > grace → Hung
+        let result2 = h.check_hang(AgentState::Ready, Duration::from_secs(180), 5_001, 0);
+        assert!(result2, "delta > grace → Hung");
+    }
+
+    #[test]
+    fn classifier_hung_state_returns_false_on_subsequent_calls() {
+        // First Hung detection returns true (caller escalates). Second
+        // call with same state must return false (already escalated;
+        // avoid duplicate escalation).
+        let mut h = HealthTracker::new();
+        assert!(h.check_hang(AgentState::Ready, Duration::from_secs(180), 10_000, 0));
+        assert_eq!(h.state, HealthState::Hung);
+        // Same conditions next tick → no re-escalation.
+        assert!(!h.check_hang(AgentState::Ready, Duration::from_secs(180), 10_000, 0));
+        assert_eq!(h.state, HealthState::Hung);
     }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -766,6 +766,18 @@ pub fn format_notification_for_inject(
 }
 
 pub fn notify_agent(home: &Path, agent_name: &str, source: &NotifySource<'_>, text: &str) {
+    // Sprint 24 P1 (F-NEW-DAEMON-HEALTH-CLASSIFIER-1): record this
+    // central inject point so the daemon health classifier can
+    // distinguish "idle waiting (no input pending)" from "hung
+    // unresponsive (input pending past last response)". This hook
+    // intentionally lives here — `notify_agent` is the single PTY-inject
+    // entry consumed by every input source (channel notify, agent send,
+    // inbox compose-aware inject). No-daemon-context callers (tests
+    // wiring `notify_agent` outside daemon mode) still pay a cheap
+    // mutex acquire but don't observe behavioural change.
+    crate::daemon::heartbeat_pair::update_with(agent_name, |p| {
+        p.last_input_at_ms = crate::daemon::heartbeat_pair::now_ms();
+    });
     let notification = format_notification_for_inject(pointer_only_inject(), source, text);
     compose_aware_inject(home, agent_name, &notification);
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1208,22 +1208,22 @@ mod tests {
     #[test]
     fn starting_hang_120s() {
         let mut h = HealthTracker::new();
-        assert!(!h.check_hang(AgentState::Starting, Duration::from_secs(119)));
-        assert!(h.check_hang(AgentState::Starting, Duration::from_secs(121)));
+        assert!(!h.check_hang(AgentState::Starting, Duration::from_secs(119), 1_000_000, 0));
+        assert!(h.check_hang(AgentState::Starting, Duration::from_secs(121), 1_000_000, 0));
     }
 
     #[test]
     fn idle_never_hangs() {
         let mut h = HealthTracker::new();
         // Even with 10000s of silence, Idle should never be considered hung.
-        assert!(!h.check_hang(AgentState::Idle, Duration::from_secs(10_000)));
+        assert!(!h.check_hang(AgentState::Idle, Duration::from_secs(10_000), 1_000_000, 0));
     }
 
     #[test]
     fn thinking_hang_600s() {
         let mut h = HealthTracker::new();
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(599)));
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(601)));
+        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(599), 1_000_000, 0));
+        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(601), 1_000_000, 0));
     }
 
     // ── P2: Pattern matching ────────────────────────────────────────────


### PR DESCRIPTION
## 問題 → 方案

Operator 04:00 UTC false-alarm: dev-impl-1 idle 30 min in \`Ready\` waiting for next dispatch → daemon classifier flagged \`health_state=hung\`. general interrupted impl-1 → reported alive (false alarm). Cron escalation chains (interrupt / tool_kill / replace) on healthy idle agents = noise + risk.

**Root cause**: \`check_hang\` only knew silence. No way to distinguish \"idle waiting (no input pending)\" from \"hung unresponsive (input pending past last response)\".

## Design call: Candidate 3 (combination)

Per dispatch design space (3 candidates), I picked **combination**:
1. \`last_input_at_ms\` field tracking when daemon last delivered input
2. New \`IdleLong\` variant alongside existing \`Hung\` — preserves cron escalation consumers checking \`state == Hung\` semantics (no breaking change)
3. Discriminator combining both

## Changes (~210 LOC across 6 files)

| File | Change |
|---|---|
| \`src/daemon/heartbeat_pair.rs\` | Extend \`HeartbeatPair\` with \`last_input_at_ms\` (no new lock — reuses PR #235 F6 leaf-level pair lock) |
| \`src/inbox.rs::notify_agent\` | Single-point hook updates \`last_input_at_ms\` on every PTY-inject |
| \`src/health.rs\` | \`HealthState::IdleLong\` variant + \`check_hang\` discriminator + operator-facing self-diagnostic log |
| \`src/daemon/mod.rs\` + \`src/app/mod.rs\` | 2 production callers snapshot pair + pass to \`check_hang\` |
| \`src/state.rs\` | 5 existing test calls updated to new signature |

## Discriminator logic

```
silent ≤ threshold                                  → Healthy (existing behavior)
silent > threshold + input_pending_past_response    → Hung (returns true, escalate)
silent > threshold + no input pending past response → IdleLong (no escalation)
```

\`INPUT_RESPONSE_GRACE_MS = 5_000\` prevents flapping when input arrives 1-tick before heartbeat write completes.

## Self-diagnostic pattern transfer (PR #241 praise)

Operator-facing log on \`Hung\` classification embeds delta diagnostic:
- \`last_input_at_ms\`
- \`last_heartbeat_at_ms\`
- \`input_response_delta_ms\`
- \`silent_secs\`
- \`agent_state\`

Helps future cron escalation operator-debug \"why did daemon flag this hung?\" — diagnostic vs opaque.

## Backward compatibility

- ✅ \`HealthState::Hung\` consumers unchanged (semantics tighten to \"real unresponsive\" but variant name + serde form unchanged)
- ✅ \`IdleLong\` is additive (Rust compile guarantee for exhaustive matches)
- ✅ F6 lock-around-pair leaf-level rule honored — no \`DAEMON-LOCK-ORDERING.md\` update needed
- ✅ Existing 17 \`check_hang\` test call sites updated with synthetic input-pending pair data preserving legacy semantics

## Tests

7 new classifier tests covering all branches:

- \`classifier_returns_hung_when_input_pending_past_response\` (real hung)
- \`classifier_returns_idle_long_when_no_input_pending\` ← **operator 04:00 UTC pattern**
- \`classifier_returns_idle_long_when_input_already_responded_to\`
- \`classifier_returns_healthy_when_silence_below_threshold\`
- \`classifier_idle_long_recovers_to_healthy_when_activity_resumes\`
- \`classifier_grace_window_prevents_flap\` (boundary inclusive at 5_000ms)
- \`classifier_hung_state_returns_false_on_subsequent_calls\` (no duplicate escalation)

## CI verification (Tier-2 evidence chain)

- \`cargo fmt --check\` → clean
- \`cargo clippy --all-targets --features tray -- -D warnings\` → clean
- \`cargo test --features tray\` → **1247 tests pass** (1240 baseline + 7 new), 0 failed

## Test plan

- [x] All 3 branches (Hung / IdleLong / Healthy) covered by unit tests
- [x] Recovery path tested (IdleLong → Healthy on activity resume)
- [x] Grace window boundary tested (5_000ms inclusive, 5_001ms fires)
- [x] No duplicate escalation (Hung returns false on subsequent calls in same state)
- [x] Existing 17 test call sites updated, all pass
- [x] F6 lock-around-pair leaf-level rule honored (production callers snapshot pair before check_hang)
- [x] Operator-facing log embeds delta diagnostic for self-debug

## Source

- Dispatch: \`m-20260427120907191389-99\` + correlation_id supplement \`m-20260427120842924683-4\`
- correlation_id: \`t-20260427120842924683-4\`
- Predecessors: PR #235 (F6 lock-around-pair + DaemonTicker + can_mutate_task pub), PR #237 (sweep daemon), PR #241 (self-diagnostic pattern transfer)
- Operator evidence: general \`m-20260427040529383849-303\` (04:00 UTC false-alarm)
- Ownership: impl-1 \`m-20260427064212822688-19\` recommendation

## Reviewer

- dev-reviewer Tier-2 main (likely auto-Critical on src/health.rs daemon lifecycle path)
- dev-reviewer-2 cross-vantage second-pass (architectural state-machine soundness)
- Both VERIFY → dev-lead self-merge per dispatch authority

🤖 Generated with [Claude Code](https://claude.com/claude-code)