### PR TITLE
fix: correct lock-window comment — pair snapshot UNDER core lock

### DIFF
--- a/docs/DAEMON-LOCK-ORDERING.md
+++ b/docs/DAEMON-LOCK-ORDERING.md
@@ -196,9 +196,10 @@ enforces:
   `IdleLong` → `Hung` — catching prompt-injected agents that suppress
   escalation by spam-calling MCP tools without generating real output.
   This cross-check reads `heartbeat_at_ms` from the pair snapshot
-  (Level 3 leaf) and `silent` from `HealthTracker::last_output`
-  (Level 1 core) — no lock-ordering violation because the pair snapshot
-  is taken after core lock is released (Rule 2).
+  (Level 3 leaf) acquired UNDER the core lock (Level 1 → Level 3
+  top-down per Rule 1), with the pair lock acquired+released
+  synchronously by `snapshot_for` so it's not held during subsequent
+  `check_hang` execution (Rule 3).
 
 ---
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -421,13 +421,12 @@ fn run_core(
                     core.health.maybe_decay();
                     let agent_state = core.state.current;
                     let silent = core.state.last_output.elapsed();
-                    // Sprint 24 P1: snapshot heartbeat_pair OUTSIDE the
-                    // core lock-window to honor the leaf-level rule per
-                    // docs/DAEMON-LOCK-ORDERING.md (pair lock never held
-                    // while acquiring another lock). Pair lookup is
-                    // per-instance + cheap; safe to call here because
-                    // core lock is held but pair lock is acquired+released
-                    // synchronously.
+                    // Sprint 24 P1: snapshot heartbeat_pair UNDER the
+                    // core lock (Level 1 → Level 3 top-down per Rule 1
+                    // in docs/DAEMON-LOCK-ORDERING.md). Pair lock is
+                    // acquired+released synchronously by `snapshot_for`
+                    // so it's not held during subsequent `check_hang`
+                    // execution (Rule 3 leaf-level).
                     let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
                     if core.health.check_hang(
                         agent_state,


### PR DESCRIPTION
## Summary

Recurring NIT from dev-reviewer on PR #243 + PR #251: comment said pair snapshot taken 'OUTSIDE the core lock-window' but it's actually INSIDE (Level 1 → Level 3 top-down per Rule 1). Code is correct; only wording was inaccurate.

## Changes

- `src/daemon/mod.rs`: 'OUTSIDE' → 'UNDER the core lock' with Rule 1/3 citation
- `docs/DAEMON-LOCK-ORDERING.md`: 'after core lock is released (Rule 2)' → 'acquired UNDER the core lock (Rule 1)' with Rule 3 leaf-level note
- `src/app/mod.rs`: verified clean (no inaccurate wording)

## LOC

+10 / -10 (2 files, comment-only)

Closes t-20260427135609808368-7