### PR TITLE
fix(mcp): bridge replies in NDJSON, matching Claude Code's actual framing

### DIFF
--- a/src/bin/agend-mcp-bridge.rs
+++ b/src/bin/agend-mcp-bridge.rs
@@ -249,7 +249,7 @@ fn read_message(reader: &mut impl BufRead) -> Result<Option<String>, Box<dyn std
 }
 
 fn write_message(stdout: &mut io::Stdout, json: &str) -> io::Result<()> {
-    write!(stdout, "Content-Length: {}\r\n\r\n{}", json.len(), json)?;
+    writeln!(stdout, "{json}")?;
     stdout.flush()
 }
 

--- a/tests/mcp_bridge_client_handshake.rs
+++ b/tests/mcp_bridge_client_handshake.rs
@@ -1,0 +1,152 @@
+//! Regression test: bridge must complete an MCP handshake with Claude Code's
+//! real-world `initialize` request frame and respond fast enough that the
+//! client doesn't hit its 30s connection timeout.
+//!
+//! Background: PR #250 shipped the bridge with Content-Length response framing,
+//! which Claude Code 2.x ignores — every reconnect timed out at 30s and the
+//! `agend-terminal` MCP server stayed permanently disconnected. PR #253's
+//! behavioral parity suite framed both request and response with Content-Length
+//! and so passed despite the bug. This test fixes the gap by exercising the
+//! exact payload Claude Code sends across a freshly spawned bridge.
+//!
+//! Failure here means MCP tool/list never returns in real Claude Code sessions.
+
+#![allow(clippy::unwrap_used)]
+
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// Real `initialize` payload captured from Claude Code 2.1.119 in
+/// `~/.agend-terminal/bridge-trace-<pid>.log` during the PR debugging session.
+/// Note: `protocolVersion` "2025-11-25" intentionally does NOT match the
+/// bridge's hard-coded reply — the bridge must still respond, the client
+/// reconciles versions itself.
+const CLAUDE_CODE_INIT: &str = r#"{"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"roots":{},"elicitation":{}},"clientInfo":{"name":"claude-code","title":"Claude Code","version":"2.1.119","description":"Anthropic's agentic coding tool","websiteUrl":"https://claude.com/claude-code"}},"jsonrpc":"2.0","id":0}"#;
+
+fn bridge_binary() -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_BIN_EXE_agend-mcp-bridge"));
+    assert!(
+        path.exists(),
+        "bridge binary missing at {} — run `cargo build --bin agend-mcp-bridge` first",
+        path.display()
+    );
+    path
+}
+
+/// Spawn the bridge, send Claude Code's real init frame, expect an NDJSON
+/// response within a few seconds (real client times out at 30s).
+#[test]
+fn bridge_replies_to_claude_code_initialize_within_5s() {
+    let bridge = bridge_binary();
+    // Empty AGEND_HOME so the bridge cannot reach a real daemon — initialize
+    // is handled locally and must succeed regardless.
+    let tmp_home =
+        std::env::temp_dir().join(format!("agend-bridge-handshake-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp_home).unwrap();
+
+    let mut child = Command::new(&bridge)
+        .env("AGEND_HOME", &tmp_home)
+        .env("AGEND_INSTANCE_NAME", "test-handshake")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bridge");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+
+    writeln!(stdin, "{CLAUDE_CODE_INIT}").expect("write init");
+    stdin.flush().expect("flush");
+
+    // Read response line on a background thread so the assertion can time out
+    // independently of pipe blocking.
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        if reader.read_line(&mut line).is_ok() {
+            let _ = tx.send(line);
+        }
+    });
+
+    let line = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("bridge must reply to initialize within 5s (real client times out at 30s)");
+
+    let resp: Value = serde_json::from_str(line.trim())
+        .unwrap_or_else(|e| panic!("response must be NDJSON (raw JSON + \\n), got {line:?}: {e}"));
+
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], 0);
+    assert!(
+        resp["result"]["capabilities"].is_object(),
+        "initialize response must include capabilities, got: {resp}"
+    );
+    assert!(
+        resp["result"]["serverInfo"]["name"].is_string(),
+        "initialize response must include serverInfo.name, got: {resp}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&tmp_home);
+}
+
+/// Defense-in-depth: the response line must be raw JSON, not Content-Length
+/// framed. A regression that re-introduces Content-Length would still parse
+/// as JSON above (after `read_line` strips the header line) only by accident,
+/// so check explicitly.
+#[test]
+fn bridge_response_is_raw_ndjson_not_content_length_framed() {
+    let bridge = bridge_binary();
+    let tmp_home =
+        std::env::temp_dir().join(format!("agend-bridge-framing-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp_home).unwrap();
+
+    let mut child = Command::new(&bridge)
+        .env("AGEND_HOME", &tmp_home)
+        .env("AGEND_INSTANCE_NAME", "test-framing")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bridge");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+
+    writeln!(stdin, "{CLAUDE_CODE_INIT}").expect("write init");
+    stdin.flush().expect("flush");
+
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        if reader.read_line(&mut line).is_ok() {
+            let _ = tx.send(line);
+        }
+    });
+
+    let line = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("bridge must reply within 5s");
+
+    let trimmed = line.trim_start();
+    assert!(
+        trimmed.starts_with('{'),
+        "response must start with '{{' (NDJSON), not a header. Got: {line:?}"
+    );
+    assert!(
+        !line.contains("Content-Length"),
+        "response must not be Content-Length framed (Claude Code 2.x doesn't read it). Got: {line:?}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&tmp_home);
+}

--- a/tests/mcp_proxy_behavioral_parity.rs
+++ b/tests/mcp_proxy_behavioral_parity.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::unwrap_used)]
 
 use serde_json::{json, Value};
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -125,36 +125,22 @@ fn bridge_binary() -> PathBuf {
     path
 }
 
-/// Send an MCP JSON-RPC request via Content-Length framing and read the response.
+/// Send an MCP JSON-RPC request as NDJSON and read the NDJSON response.
+///
+/// Mirrors how Claude Code (the real client we ship for) frames messages:
+/// raw JSON terminated by a single newline. The bridge must respond in
+/// the same shape, otherwise the client hits its connection timeout.
 fn mcp_roundtrip(
     stdin: &mut std::process::ChildStdin,
     stdout: &mut BufReader<std::process::ChildStdout>,
     request: &Value,
 ) -> Value {
-    let body = request.to_string();
-    write!(stdin, "Content-Length: {}\r\n\r\n{}", body.len(), body).expect("write request");
+    writeln!(stdin, "{request}").expect("write request");
     stdin.flush().expect("flush");
 
-    // Read Content-Length header
-    let mut header = String::new();
-    stdout.read_line(&mut header).expect("read header");
-    let len: usize = header
-        .trim()
-        .strip_prefix("Content-Length:")
-        .or_else(|| header.trim().strip_prefix("Content-Length: "))
-        .expect("Content-Length header")
-        .trim()
-        .parse()
-        .expect("parse length");
-
-    // Read blank line separator
-    let mut sep = String::new();
-    stdout.read_line(&mut sep).expect("read separator");
-
-    // Read body
-    let mut body = vec![0u8; len];
-    stdout.read_exact(&mut body).expect("read body");
-    serde_json::from_slice(&body).expect("parse response")
+    let mut line = String::new();
+    stdout.read_line(&mut line).expect("read response line");
+    serde_json::from_str(line.trim()).expect("parse NDJSON response")
 }
 
 /// Extract the tool result text from an MCP tools/call response.
@@ -202,10 +188,9 @@ fn bridge_tools_call_returns_expected_results_for_five_tools() {
         "initialize must return capabilities"
     );
 
-    // Send initialized notification (no response expected)
+    // Send initialized notification (no response expected) — NDJSON
     let notif = json!({"jsonrpc": "2.0", "method": "notifications/initialized"});
-    let body = notif.to_string();
-    write!(stdin, "Content-Length: {}\r\n\r\n{}", body.len(), body).expect("write notif");
+    writeln!(stdin, "{notif}").expect("write notif");
     stdin.flush().expect("flush");
 
     // Test 5 tools


### PR DESCRIPTION
## Summary
- Bridge now writes JSON-RPC responses as NDJSON (`writeln!(stdout, "{json}")`) instead of `Content-Length`-framed, matching what Claude Code 2.x actually reads.
- Reproduced live on operator's machine: every `/mcp` reconnect for `agend-terminal` timed out at 30 s after PR #250 shipped; the bridge subprocess sat blocked on stdin while Claude Code waited for an NDJSON line that never came.
- Added `tests/mcp_bridge_client_handshake.rs` with Claude Code 2.1.119's real `initialize` payload (captured from a temporary stdin trace during debugging) and flipped `mcp_proxy_behavioral_parity.rs` to NDJSON. Tests fail without the framing fix.

## Why PR #253 didn't catch this
PR #253's behavioral parity suite framed both request and response with `Content-Length`. The two halves were internally consistent so the suite went green, but no real client speaks Content-Length to the bridge. The new handshake test exercises the actual wire format Claude Code uses, which is the only thing that matters for the operator-visible bug.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --release --all-targets -- -D warnings`
- [x] `cargo test --release --test mcp_bridge_client_handshake` — 2/2 pass; both fail before this patch
- [x] `cargo test --release --test mcp_proxy_behavioral_parity` — 2/2 pass after switch to NDJSON
- [x] All other `mcp_*` test files pass: characterization (28), proxy_lifecycle (2), proxy_parity (5), roundtrip (33), subprocess_is_zero_state (5)
- [x] Live verification: rebuilt + redeployed bridge, operator's `/mcp` reconnect now reports `Reconnected to agend-terminal`; reply tool back online

🤖 Generated with [Claude Code](https://claude.com/claude-code)