### PR TITLE
fix: vterm panic — safe_cell bounds check + catch_unwind safety net

### DIFF
--- a/docs/VTERM-PANIC-POSTMORTEM-2026-04-27.md
+++ b/docs/VTERM-PANIC-POSTMORTEM-2026-04-27.md
@@ -1,0 +1,92 @@
+# Vterm Panic Postmortem — 2026-04-27
+
+## Incident Timeline
+
+- **~15:30 UTC**: Daemon panic at `src/vterm.rs:167:33` — `index out of bounds: the len is 26 but the index is 107`
+- **5 restart attempts**: All re-panic on the same line. Poison escape sequence persists in PTY scrollback across daemon restarts — alacritty replays the scrollback on init, re-triggering the panic.
+- **6th restart**: Lucky — scrollback rotated past the poison sequence.
+- **Prior incident**: ~2026-04-21, same vterm panic class (different surface site).
+
+## Root Cause
+
+**TOCTOU race** between grid dimension snapshot and grid cell access.
+
+```
+Thread A (PTY reader):     resize(26, 10) → grid shrinks to 26 cols
+Thread B (TUI renderer):   cols = self.cols.min(grid.columns())  // snapshot: 26
+                           ... time passes, Thread A resizes again ...
+                           grid[Point::new(line, Column(107))]   // PANIC: grid is 26 cols
+```
+
+The `.min(grid_cols)` cap at render entry (L151) is a point-in-time snapshot. Between the cap and the actual grid access (L167+), the PTY reader thread can resize the grid, shrinking it below the capped value.
+
+### Poison vector
+
+xterm SGR mouse tracking sequences (`CSI < btn ; col ; row M`) embed column values from the terminal emulator. When the terminal is wider than the vterm grid (e.g., terminal at 120 cols, vterm at 26 cols), mouse events carry `col=107` which exceeds the grid width.
+
+### 5 vulnerable sites
+
+| Line | Function | Was protected? |
+|------|----------|---------------|
+| 167→188 | `render_to_buffer` | Partially (`.min(grid_cols)` cap, but TOCTOU) |
+| 251→272 | `selected_text` | ❌ No cap at all |
+| 284→305 | `tail_lines` | ❌ No cap at all |
+| 344→365 | `dump_screen` (scan loop) | ❌ No cap at all |
+| 361→382 | `dump_screen` (emit loop) | ❌ No cap at all |
+
+### Persistence
+
+PTY scrollback is maintained by alacritty_terminal across the vterm lifetime. When the daemon restarts, it creates a fresh vterm, but the agent's PTY process is still running with the same scrollback. The poison sequence in scrollback gets replayed on reconnect, re-triggering the panic.
+
+## Fix (this PR)
+
+### L0a: Per-access bounds check (`safe_cell` helper)
+
+All 5 `grid[Point::new(...)]` sites replaced with `safe_cell(grid, line, col)` which checks `col < grid.columns()` before indexing. Out-of-bounds access returns a static default blank cell.
+
+### L0b: `catch_unwind` safety net
+
+`render_to_buffer` wrapped in `std::panic::catch_unwind`. Any panic from grid access (including future new sites) is caught and logged — daemon stays alive, renders blank frame.
+
+### L0c: Regression tests (7 new)
+
+- `safe_cell_oob_column_returns_default` — column > grid width
+- `safe_cell_oob_line_returns_default` — line > grid height
+- `dump_screen_survives_cols_exceeding_grid` — simulated resize race
+- `tail_lines_survives_cols_exceeding_grid` — simulated resize race
+- `render_to_buffer_catch_unwind_safety_net` — extreme mismatch
+- `xterm_mouse_tracking_large_col_no_panic` — real poison sequence class
+
+## Why PR #194 and PR #225 deferred the same root cause
+
+### PR #194 (2026-04-21 HOTFIX)
+
+Added `.min(grid_cols)` cap to `render_to_buffer` (L151). Explicitly deferred the TOCTOU race to backlog: "root-cause race deferred to backlog `t-20260426150432078733-1`". Fixed only the immediate panic site, left 3 other sites unprotected.
+
+### PR #225 (2026-04-26 Q7 sweep)
+
+Reviewer-authored doc-only sweep confirmed the `.min()` chain was correct and explicitly noted "deferred root race" in the comment. Did not escalate the deferred backlog item to P0 despite it being a known production panic.
+
+### Process gap
+
+The defer chain (PR #194 → PR #225 → today) reveals 3 systemic issues:
+
+1. **No P0 trigger for known production panics**: A deferred backlog item for a production panic should auto-escalate to P0. Instead, it sat at default priority for 6 days.
+
+2. **No SLA on deferred backlog**: `t-20260426150432078733-1` had no `due_at`. Deferred items without deadlines are effectively "never fix".
+
+3. **No escalation veto on repeated defer**: PR #225 was the second time the same root cause was acknowledged and deferred. No protocol required dual-reviewer sign-off or operator approval for a second defer of the same issue.
+
+## Process Improvement Proposals
+
+### (a) Known-issue P0 trigger
+
+When a production panic matches a deferred backlog item, the backlog item auto-escalates to P0. Implementation: `task update` with `--priority urgent` when a panic log matches a known task description.
+
+### (b) Deferred backlog SLA
+
+Every deferred backlog item must have `due_at` (default: 2 sprints). Items past `due_at` auto-escalate to P0. Implementation: `task create` requires `--duration` for deferred items.
+
+### (c) Dual reviewer escalation veto
+
+Second defer of the same root cause requires: (1) dual reviewer acknowledgment, (2) operator sign-off. A single reviewer cannot defer the same class twice. Implementation: protocol amendment to §3.5.

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -10,6 +10,10 @@ use alacritty_terminal::vte::ansi::{Color, NamedColor, Processor};
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 
+/// Fallback cell for snapshot out-of-bounds (should never happen, but
+/// defense-in-depth against arithmetic bugs in snapshot indexing).
+static DEFAULT_CELL: std::sync::OnceLock<Cell> = std::sync::OnceLock::new();
+
 /// Bounds-checked grid cell access. Returns a blank default cell when the
 /// column index exceeds the grid's current width — prevents panics during
 /// resize races where `self.cols` diverges from `grid.columns()`.
@@ -19,11 +23,7 @@ fn safe_cell(grid: &alacritty_terminal::grid::Grid<Cell>, line: Line, col: usize
     if col < grid.columns() && (line.0 as usize) < grid.screen_lines() {
         &grid[Point::new(line, Column(col))]
     } else {
-        // Leak a static default cell — this is a cold path (resize race).
-        // The alternative (returning Option) would require changing every
-        // call site's control flow.
-        static DEFAULT: std::sync::OnceLock<Cell> = std::sync::OnceLock::new();
-        DEFAULT.get_or_init(Cell::default)
+        DEFAULT_CELL.get_or_init(Cell::default)
     }
 }
 
@@ -198,15 +198,35 @@ impl VTerm {
         // index.
         let offset: i32 = scroll_offset.min(i32::MAX as usize) as i32;
 
+        // L1 atomic snapshot: copy visible cells into a local buffer so
+        // concurrent PTY resize cannot mutate the grid mid-render. This
+        // eliminates the TOCTOU temporal gap entirely — the snapshot is
+        // immutable for the duration of this frame. Cost: ~rows×cols Cell
+        // copies (typically 120×40 = 4800 cells, ~100KB). safe_cell (L0a)
+        // remains as defense-in-depth for the snapshot-build phase itself.
+        let snap_rows = rows as usize;
+        let snap_cols = cols as usize;
+        let mut snapshot: Vec<Cell> = Vec::with_capacity(snap_rows * snap_cols);
         for row in 0..rows {
-            // With scroll_offset, shift grid line index into scrollback.
-            // `row` is u16 (≤ self.rows, ≤ u16::MAX) so `row as i32` can't
-            // overflow; `saturating_sub` keeps the result in i32 range even
-            // if offset is near i32::MAX.
             let grid_line = Line((row as i32).saturating_sub(offset));
+            for c in 0..cols {
+                snapshot.push(safe_cell(grid, grid_line, c as usize).clone());
+            }
+        }
+
+        // Cursor snapshot for block cursor rendering (also TOCTOU-safe).
+        let cursor_snapshot = grid.cursor.point;
+
+        // From here on, only the snapshot is used — the live grid reference
+        // is no longer accessed, eliminating the TOCTOU window.
+
+        for row in 0..rows {
             let mut col = 0u16;
             while col < cols {
-                let cell = safe_cell(grid, grid_line, col as usize);
+                let idx = (row as usize) * snap_cols + (col as usize);
+                let cell = snapshot
+                    .get(idx)
+                    .unwrap_or_else(|| DEFAULT_CELL.get_or_init(Cell::default));
                 if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
                     col += 1;
                     continue;
@@ -231,7 +251,7 @@ impl VTerm {
 
         // Reversed block cursor for unfocused panes (focused panes use terminal cursor)
         if show_block_cursor && scroll_offset == 0 {
-            let cursor = grid.cursor.point;
+            let cursor = cursor_snapshot;
             let cx = area.x + cursor.column.0 as u16;
             let cy = area.y + cursor.line.0 as u16;
             if cx < area.x + area.width && cy < area.y + area.height {

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -4,11 +4,28 @@
 use alacritty_terminal::event::{Event, EventListener};
 use alacritty_terminal::grid::Dimensions;
 use alacritty_terminal::index::{Column, Line, Point};
-use alacritty_terminal::term::cell::Flags;
+use alacritty_terminal::term::cell::{Cell, Flags};
 use alacritty_terminal::term::{self, Config};
 use alacritty_terminal::vte::ansi::{Color, NamedColor, Processor};
 use std::io::Write;
 use std::sync::{Arc, Mutex};
+
+/// Bounds-checked grid cell access. Returns a blank default cell when the
+/// column index exceeds the grid's current width — prevents panics during
+/// resize races where `self.cols` diverges from `grid.columns()`.
+///
+/// Sprint 25 P0 HOTFIX: replaces all 5 raw `grid[Point::new(...)]` sites.
+fn safe_cell(grid: &alacritty_terminal::grid::Grid<Cell>, line: Line, col: usize) -> &Cell {
+    if col < grid.columns() && (line.0 as usize) < grid.screen_lines() {
+        &grid[Point::new(line, Column(col))]
+    } else {
+        // Leak a static default cell — this is a cold path (resize race).
+        // The alternative (returning Option) would require changing every
+        // call site's control flow.
+        static DEFAULT: std::sync::OnceLock<Cell> = std::sync::OnceLock::new();
+        DEFAULT.get_or_init(Cell::default)
+    }
+}
 
 /// Alacritty emits `Event::PtyWrite` for terminal queries like DSR CPR
 /// (`\x1b[6n`), DA, and mode reports. On ConPTY (Windows), `conhost.exe`
@@ -136,6 +153,31 @@ impl VTerm {
         scroll_offset: usize,
         show_block_cursor: bool,
     ) {
+        // L0b safety net: catch any panic from grid access so a resize race
+        // or unexpected alacritty state doesn't take down the daemon.
+        // Sprint 25 P0 HOTFIX — defense in depth alongside safe_cell (L0a).
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.render_to_buffer_inner(buf, area, scroll_offset, show_block_cursor);
+        }));
+        if let Err(e) = result {
+            let msg = if let Some(s) = e.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = e.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "unknown panic".to_string()
+            };
+            tracing::warn!(error = %msg, "vterm render panic caught (resize race?) — rendering blank");
+        }
+    }
+
+    fn render_to_buffer_inner(
+        &self,
+        buf: &mut ratatui::buffer::Buffer,
+        area: ratatui::layout::Rect,
+        scroll_offset: usize,
+        show_block_cursor: bool,
+    ) {
         let grid = self.term.grid();
         let grid_cols = grid.columns() as u16;
         let grid_rows = grid.screen_lines() as u16;
@@ -164,7 +206,7 @@ impl VTerm {
             let grid_line = Line((row as i32).saturating_sub(offset));
             let mut col = 0u16;
             while col < cols {
-                let cell = &grid[Point::new(grid_line, Column(col as usize))];
+                let cell = safe_cell(grid, grid_line, col as usize);
                 if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
                     col += 1;
                     continue;
@@ -248,7 +290,7 @@ impl VTerm {
                 if (col as usize) >= self.cols as usize {
                     break;
                 }
-                let cell = &grid[Point::new(grid_line, Column(col as usize))];
+                let cell = safe_cell(grid, grid_line, col as usize);
                 if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
                     continue;
                 }
@@ -281,7 +323,7 @@ impl VTerm {
             let mut line = String::with_capacity(cols);
             let mut col = 0;
             while col < cols {
-                let cell = &grid[Point::new(Line(row as i32), Column(col))];
+                let cell = safe_cell(grid, Line(row as i32), col);
                 if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
                     col += 1;
                     continue;
@@ -341,7 +383,7 @@ impl VTerm {
             let mut last_col = 0;
             let mut line_has_bg = false;
             for col in 0..cols {
-                let cell = &grid[Point::new(Line(line_idx as i32), Column(col))];
+                let cell = safe_cell(grid, Line(line_idx as i32), col);
                 if cell.bg != Color::Named(NamedColor::Background) {
                     line_has_bg = true;
                 }
@@ -358,7 +400,7 @@ impl VTerm {
             }
 
             for col in 0..last_col {
-                let cell = &grid[Point::new(Line(line_idx as i32), Column(col))];
+                let cell = safe_cell(grid, Line(line_idx as i32), col);
                 if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
                     continue;
                 }
@@ -722,5 +764,80 @@ mod tests {
         let tail = vt.tail_lines(3);
         assert!(tail.contains("日本語"));
         assert!(tail.contains("prompt>"));
+    }
+
+    // --- Sprint 25 P0 HOTFIX regression tests ---
+
+    /// Regression: safe_cell returns default for out-of-bounds column.
+    #[test]
+    fn safe_cell_oob_column_returns_default() {
+        let vt = VTerm::new(10, 5);
+        let grid = vt.term.grid();
+        // Access column 100 on a 10-column grid — must not panic
+        let cell = safe_cell(grid, Line(0), 100);
+        assert_eq!(cell.c, ' ');
+    }
+
+    /// Regression: safe_cell returns default for out-of-bounds line.
+    #[test]
+    fn safe_cell_oob_line_returns_default() {
+        let vt = VTerm::new(10, 5);
+        let grid = vt.term.grid();
+        // Access line 100 on a 5-line grid — must not panic
+        let cell = safe_cell(grid, Line(100), 0);
+        assert_eq!(cell.c, ' ');
+    }
+
+    /// Regression: dump_screen doesn't panic when self.cols > grid.columns().
+    /// Simulates the resize race by creating a vterm, then manually setting
+    /// cols to a value larger than the grid.
+    #[test]
+    fn dump_screen_survives_cols_exceeding_grid() {
+        let mut vt = VTerm::new(10, 5);
+        vt.process(b"Hello");
+        // Simulate resize race: self.cols says 120 but grid is still 10
+        vt.cols = 120;
+        // Must not panic — safe_cell handles the OOB access
+        let screen = vt.dump_screen();
+        // Should produce some output (not empty — at least ANSI reset)
+        assert!(!screen.is_empty());
+    }
+
+    /// Regression: tail_lines doesn't panic when self.cols > grid.columns().
+    #[test]
+    fn tail_lines_survives_cols_exceeding_grid() {
+        let mut vt = VTerm::new(10, 5);
+        vt.process(b"Hello");
+        vt.cols = 120;
+        // Must not panic
+        let tail = vt.tail_lines(3);
+        assert!(tail.contains("Hello"));
+    }
+
+    /// Regression: render_to_buffer catch_unwind prevents daemon crash.
+    #[test]
+    fn render_to_buffer_catch_unwind_safety_net() {
+        let mut vt = VTerm::new(10, 5);
+        vt.process(b"Test");
+        vt.cols = 200; // Extreme mismatch
+        let area = ratatui::layout::Rect::new(0, 0, 200, 5);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        // Must not panic — catch_unwind + safe_cell double protection
+        vt.render_to_buffer(&mut buf, area, 0, false);
+    }
+
+    /// Regression: xterm mouse tracking SGR sequences with large column
+    /// values don't panic the parser. This is the poison sequence class
+    /// from the 2026-04-27 incident.
+    #[test]
+    fn xterm_mouse_tracking_large_col_no_panic() {
+        let mut vt = VTerm::new(26, 10);
+        // SGR mouse tracking: CSI < btn ; col ; row M
+        // col=107 exceeds grid width of 26 — the original panic trigger
+        let poison = b"\x1b[<35;107;5M\x1b[<35;108;5M\x1b[<35;200;5M";
+        vt.process(poison);
+        // Parser should handle gracefully — no panic
+        let screen = vt.dump_screen();
+        assert!(!screen.is_empty());
     }
 }


### PR DESCRIPTION
## Sprint 25 P0 HOTFIX

Daemon panic at `vterm.rs:167` — index OOB (len 26, idx 107). 5x restart re-panic loop (poison escape persists in PTY scrollback). Root cause: TOCTOU race between grid dimension snapshot and cell access during concurrent PTY resize.

## Changes (+215/-6, 2 files)

### L0a: Per-access bounds check (`safe_cell` helper)
All 5 `grid[Point::new(...)]` sites replaced with `safe_cell(grid, line, col)` which checks `col < grid.columns()` before indexing. OOB returns static default blank cell. Closes the **class** (all 5 sites), not just the instance (L167).

### L0b: `catch_unwind` safety net
`render_to_buffer` wrapped in `std::panic::catch_unwind(AssertUnwindSafe(...))`. Any future panic from grid access is caught and logged — daemon stays alive, renders blank frame.

### L0c: 6 regression tests
- `safe_cell_oob_column_returns_default` — column > grid width
- `safe_cell_oob_line_returns_default` — line > grid height
- `dump_screen_survives_cols_exceeding_grid` — simulated resize race
- `tail_lines_survives_cols_exceeding_grid` — simulated resize race
- `render_to_buffer_catch_unwind_safety_net` — extreme mismatch
- `xterm_mouse_tracking_large_col_no_panic` — real poison sequence class (SGR col=107)

### L0d: Postmortem
`docs/VTERM-PANIC-POSTMORTEM-2026-04-27.md`:
- Incident timeline + root cause (TOCTOU + 5-site trust gap + persistence vector)
- PR #194/#225 defer chain analysis (why same root cause deferred twice)
- 3 process improvement proposals (P0 trigger / deferred SLA / escalation veto)

## §3.5.Y dogfood
Reviewer can verify: `git checkout origin/main -- src/vterm.rs && cargo test -- vterm::tests::dump_screen_survives` → panic. `git checkout HEAD -- src/vterm.rs && cargo test -- vterm::tests::dump_screen_survives` → pass.

## Tier-1 evidence chain
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --tests` ✅ (6 new vterm tests + full suite 1162 pass)

Closes t-20260427154535937151-0