### PR TITLE
feat: thread census counter — lightweight thread lifecycle tracking

### DIFF
--- a/docs/DAEMON-LOCK-ORDERING.md
+++ b/docs/DAEMON-LOCK-ORDERING.md
@@ -57,6 +57,11 @@ Level 3 (leaf-level):
                               (`crate::channel::telegram::lock_state`)
   channel sink registry      — `Mutex<Vec<Arc<dyn UxEventSink>>>`
                               (`crate::channel::sink_registry`)
+  thread census              — `Mutex<HashMap<&'static str, AtomicU32>>`
+                              (`crate::thread_census::census`).
+                              Sprint 26 PR-B counter-only registry; brief
+                              acquire on register/Drop/snapshot, never held
+                              during nested acquisitions.
 ```
 
 ## Hierarchy rules

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -515,6 +515,7 @@ fn spawn_instructions_bootstrap(
     // poll loop (returns early on shutdown). JoinHandle dropped because the
     // thread is short-lived and one missed bootstrap on shutdown is cosmetic.
     let spawn_result = std::thread::Builder::new().name(thread_name).spawn(move || {
+        let _census = crate::thread_census::register("pty_reader");
         let deadline = std::time::Instant::now() + timeout;
         let poll_interval = std::time::Duration::from_millis(200);
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -272,6 +272,7 @@ pub fn serve(
         std::thread::Builder::new()
             .name("api_handler".into())
             .spawn(move || {
+                let _census = crate::thread_census::register("api_handler");
                 handle_session(
                     stream,
                     &reg,
@@ -439,12 +440,15 @@ fn spawn_peer_pid_watcher(pid: u32, stream: std::net::TcpStream) {
     // returns an error that we silently ignore.
     std::thread::Builder::new()
         .name(format!("pid_watch_{pid}"))
-        .spawn(move || loop {
-            std::thread::sleep(std::time::Duration::from_secs(2));
-            if !is_process_alive(pid) {
-                tracing::info!(peer_pid = pid, "peer process dead — closing API session");
-                let _ = stream.shutdown(std::net::Shutdown::Both);
-                return;
+        .spawn(move || {
+            let _census = crate::thread_census::register("pid_watcher");
+            loop {
+                std::thread::sleep(std::time::Duration::from_secs(2));
+                if !is_process_alive(pid) {
+                    tracing::info!(peer_pid = pid, "peer process dead — closing API session");
+                    let _ = stream.shutdown(std::net::Shutdown::Both);
+                    return;
+                }
             }
         })
         .ok();

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -384,6 +384,7 @@ pub fn start_polling(state: Arc<Mutex<TelegramState>>) {
     if let Err(e) = std::thread::Builder::new()
         .name("telegram".into())
         .spawn(move || {
+            let _census = crate::thread_census::register("telegram_poll");
             let Ok(rt) = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -1685,6 +1686,7 @@ fn notify_telegram_inner(
     std::thread::Builder::new()
         .name("tg_notify".into())
         .spawn(move || {
+            let _census = crate::thread_census::register("tg_notify");
             let Ok(rt) = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -304,6 +304,16 @@ pub fn run_doctor(home: &Path) -> anyhow::Result<()> {
         println!("    (none)");
     }
 
+    println!("\n  Thread census:");
+    let census = crate::thread_census::snapshot();
+    if census.is_empty() {
+        println!("    (no registered threads — daemon not running in this process)");
+    } else {
+        for (kind, count) in &census {
+            println!("    {kind}: {count}");
+        }
+    }
+
     println!("\n  Backend binaries:");
     for b in backend::Backend::all() {
         let (name, cmd) = (b.name(), b.preset().command);

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ mod sync;
 mod task_events;
 mod tasks;
 mod teams;
+mod thread_census;
 #[cfg(feature = "tray")]
 mod tray;
 mod tui;

--- a/src/thread_census.rs
+++ b/src/thread_census.rs
@@ -1,0 +1,77 @@
+//! Thread census — lightweight counter-only thread lifecycle tracking.
+//!
+//! Sprint 26 PR-B: per operator pick A (counter-only, not JoinHandle root).
+
+// Stub — impl lands in next commit.
+
+/// Register a thread of the given kind. Returns a guard that decrements
+/// the count on drop.
+pub fn register(_kind: &'static str) -> ThreadGuard {
+    todo!("thread census register not yet implemented")
+}
+
+/// Snapshot of current thread counts by kind.
+pub fn snapshot() -> Vec<(&'static str, u32)> {
+    todo!("thread census snapshot not yet implemented")
+}
+
+/// RAII guard — decrements the census count for its kind on drop.
+pub struct ThreadGuard;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_increments_and_drop_decrements() {
+        let guard = register("test_register");
+        let snap = snapshot();
+        let count = snap
+            .iter()
+            .find(|(k, _)| *k == "test_register")
+            .map(|(_, v)| *v)
+            .unwrap_or(0);
+        assert!(count >= 1, "register must increment");
+        drop(guard);
+        let snap2 = snapshot();
+        let count2 = snap2
+            .iter()
+            .find(|(k, _)| *k == "test_register")
+            .map(|(_, v)| *v)
+            .unwrap_or(0);
+        assert!(count2 < count, "drop must decrement");
+    }
+
+    #[test]
+    fn multi_thread_census_accurate() {
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(4));
+        let mut handles = vec![];
+        for _ in 0..3 {
+            let b = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                let _guard = register("test_multi");
+                b.wait();
+                b.wait();
+            }));
+        }
+        barrier.wait();
+        let snap = snapshot();
+        let count = snap
+            .iter()
+            .find(|(k, _)| *k == "test_multi")
+            .map(|(_, v)| *v)
+            .unwrap_or(0);
+        assert_eq!(count, 3, "3 threads registered");
+        barrier.wait();
+        for h in handles {
+            h.join().expect("join");
+        }
+        let snap2 = snapshot();
+        let count2 = snap2
+            .iter()
+            .find(|(k, _)| *k == "test_multi")
+            .map(|(_, v)| *v)
+            .unwrap_or(0);
+        assert_eq!(count2, 0, "all threads exited");
+    }
+}

--- a/src/thread_census.rs
+++ b/src/thread_census.rs
@@ -1,22 +1,49 @@
 //! Thread census — lightweight counter-only thread lifecycle tracking.
 //!
 //! Sprint 26 PR-B: per operator pick A (counter-only, not JoinHandle root).
+//! Doctor/bugreport reports active thread counts by kind.
 
-// Stub — impl lands in next commit.
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+fn census() -> &'static Mutex<HashMap<&'static str, AtomicU32>> {
+    static CENSUS: OnceLock<Mutex<HashMap<&'static str, AtomicU32>>> = OnceLock::new();
+    CENSUS.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 /// Register a thread of the given kind. Returns a guard that decrements
-/// the count on drop.
-pub fn register(_kind: &'static str) -> ThreadGuard {
-    todo!("thread census register not yet implemented")
+/// the count on drop. Call at the start of a spawned thread's body.
+pub fn register(kind: &'static str) -> ThreadGuard {
+    let mut map = census().lock().unwrap_or_else(|e| e.into_inner());
+    map.entry(kind)
+        .or_insert_with(|| AtomicU32::new(0))
+        .fetch_add(1, Ordering::Relaxed);
+    ThreadGuard { kind }
 }
 
 /// Snapshot of current thread counts by kind.
 pub fn snapshot() -> Vec<(&'static str, u32)> {
-    todo!("thread census snapshot not yet implemented")
+    let map = census().lock().unwrap_or_else(|e| e.into_inner());
+    map.iter()
+        .map(|(k, v)| (*k, v.load(Ordering::Relaxed)))
+        .filter(|(_, count)| *count > 0)
+        .collect()
 }
 
 /// RAII guard — decrements the census count for its kind on drop.
-pub struct ThreadGuard;
+pub struct ThreadGuard {
+    kind: &'static str,
+}
+
+impl Drop for ThreadGuard {
+    fn drop(&mut self) {
+        let map = census().lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(counter) = map.get(self.kind) {
+            counter.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -50,11 +77,11 @@ mod tests {
             let b = barrier.clone();
             handles.push(std::thread::spawn(move || {
                 let _guard = register("test_multi");
-                b.wait();
-                b.wait();
+                b.wait(); // all 3 threads alive
+                b.wait(); // wait for main to snapshot
             }));
         }
-        barrier.wait();
+        barrier.wait(); // all 3 alive
         let snap = snapshot();
         let count = snap
             .iter()
@@ -62,7 +89,7 @@ mod tests {
             .map(|(_, v)| *v)
             .unwrap_or(0);
         assert_eq!(count, 3, "3 threads registered");
-        barrier.wait();
+        barrier.wait(); // release threads
         for h in handles {
             h.join().expect("join");
         }


### PR DESCRIPTION
## Summary

Sprint 26 PR-B: per operator pick A (counter-only). Lightweight RAII thread census for doctor/bugreport.

## Changes

- `src/thread_census.rs` (NEW): `register(kind)` → `ThreadGuard` (RAII decrement) + `snapshot()`
- 5 registration sites: api_handler, pid_watcher, telegram_poll, tg_notify, pty_reader
- `src/cli.rs`: doctor thread census section

## Tests

- `register_increments_and_drop_decrements`: unit test
- `multi_thread_census_accurate`: §3.5.10 concurrent-state (3 real threads + barrier sync)

## LOC

+128 / -6 (6 files)

## Tier-1

fmt ✅ | clippy ✅ | all tests pass ✅