### PR TITLE
feat: 13-fixture e2e + divergence dashboard + nightly CI (Sprint 27 PR-B)

### DIFF
--- a/.github/workflows/behavioral-nightly-real.yml
+++ b/.github/workflows/behavioral-nightly-real.yml
@@ -1,0 +1,33 @@
+name: Behavioral Nightly (Real Backend)
+
+on:
+  workflow_dispatch:
+    inputs:
+      backends:
+        description: 'Comma-separated backends to test (claude,kiro-cli,codex,gemini,opencode)'
+        required: false
+        default: 'claude'
+
+# Real-backend tests require CLI binaries installed on the runner.
+# Use workflow_dispatch to trigger manually on a machine with backends.
+#
+# Prerequisites:
+#   - Install target backend CLIs (claude, kiro-cli, codex, etc.)
+#   - Ensure AGEND_TELEGRAM_BOT_TOKEN is NOT set (avoids real Telegram traffic)
+#   - Run: gh workflow run behavioral-nightly-real.yml --field backends=claude,kiro-cli
+#
+# Tests run:
+#   cargo test -- --ignored backend_harness
+#   (requires real CLI binaries in PATH)
+
+jobs:
+  real-backend:
+    name: Real backend spawn (${{ github.event.inputs.backends }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run backend harness tests
+        run: cargo test -- --ignored backend_harness
+        env:
+          RUST_LOG: debug

--- a/.github/workflows/behavioral-nightly.yml
+++ b/.github/workflows/behavioral-nightly.yml
@@ -1,0 +1,31 @@
+name: Behavioral Nightly
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC daily
+  workflow_dispatch:  # manual trigger
+
+jobs:
+  fixture-replay:
+    name: Fixture replay (13 captures)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --bin agend-terminal -- e2e_
+        env:
+          RUST_LOG: debug
+
+  # Real-backend tests require CLI installations — run on self-hosted
+  # runner with claude/kiro-cli/codex/gemini/opencode installed.
+  # Uncomment when self-hosted runner is available.
+  # real-backend:
+  #   name: Real backend spawn
+  #   runs-on: self-hosted
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - run: cargo test -- --ignored backend_harness

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -168,6 +168,18 @@ pub struct DivergenceStats {
     pub diverge: u64,
 }
 
+impl DivergenceStats {
+    /// Divergence rate as percentage (0.0–100.0).
+    /// Sprint 27 condition #1: ≤5% gate for behavioral promotion.
+    pub fn divergence_rate(&self) -> f64 {
+        if self.total_ticks == 0 {
+            0.0
+        } else {
+            self.diverge as f64 / self.total_ticks as f64 * 100.0
+        }
+    }
+}
+
 /// Global divergence accumulator — keyed by backend name.
 static DIVERGENCE: parking_lot::Mutex<Option<std::collections::HashMap<String, DivergenceStats>>> =
     parking_lot::Mutex::new(None);
@@ -184,7 +196,7 @@ pub fn record_divergence(backend: &str, behavioral: BehavioralSignal, regex_stat
         BehavioralSignal::SilenceIdle => "idle",
         BehavioralSignal::None => regex_state, // no signal = agree by default
     };
-    if behavioral_implies == regex_state || behavioral == BehavioralSignal::None {
+    if behavioral_implies == regex_state {
         stats.agree += 1;
     } else {
         stats.diverge += 1;
@@ -192,7 +204,12 @@ pub fn record_divergence(backend: &str, behavioral: BehavioralSignal, regex_stat
 }
 
 /// Get divergence report for all backends.
-#[allow(dead_code)] // Used by tests + future CLI command
+/// Reset divergence stats (test isolation).
+#[allow(dead_code)]
+pub fn reset_divergence() {
+    *DIVERGENCE.lock() = None;
+}
+
 pub fn divergence_report() -> Vec<(String, DivergenceStats)> {
     let guard = DIVERGENCE.lock();
     match guard.as_ref() {
@@ -213,8 +230,9 @@ pub fn divergence_report() -> Vec<(String, DivergenceStats)> {
     }
 }
 
-#[cfg(test)]
+#[allow(dead_code)]
 #[allow(clippy::unwrap_used)]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -156,6 +156,63 @@ pub fn log_shadow_telemetry(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Divergence dashboard — accumulates behavioral vs regex state comparisons
+// ---------------------------------------------------------------------------
+
+/// Per-backend divergence counter for shadow-mode telemetry.
+#[derive(Debug, Default)]
+pub struct DivergenceStats {
+    pub total_ticks: u64,
+    pub agree: u64,
+    pub diverge: u64,
+}
+
+/// Global divergence accumulator — keyed by backend name.
+static DIVERGENCE: parking_lot::Mutex<Option<std::collections::HashMap<String, DivergenceStats>>> =
+    parking_lot::Mutex::new(None);
+
+/// Record a tick where behavioral and regex states are compared.
+pub fn record_divergence(backend: &str, behavioral: BehavioralSignal, regex_state: &str) {
+    let mut guard = DIVERGENCE.lock();
+    let map = guard.get_or_insert_with(std::collections::HashMap::new);
+    let stats = map.entry(backend.to_string()).or_default();
+    stats.total_ticks += 1;
+    // Divergence: behavioral says thinking/idle but regex says something else
+    let behavioral_implies = match behavioral {
+        BehavioralSignal::SilenceThinking => "thinking",
+        BehavioralSignal::SilenceIdle => "idle",
+        BehavioralSignal::None => regex_state, // no signal = agree by default
+    };
+    if behavioral_implies == regex_state || behavioral == BehavioralSignal::None {
+        stats.agree += 1;
+    } else {
+        stats.diverge += 1;
+    }
+}
+
+/// Get divergence report for all backends.
+#[allow(dead_code)] // Used by tests + future CLI command
+pub fn divergence_report() -> Vec<(String, DivergenceStats)> {
+    let guard = DIVERGENCE.lock();
+    match guard.as_ref() {
+        Some(map) => map
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    DivergenceStats {
+                        total_ticks: v.total_ticks,
+                        agree: v.agree,
+                        diverge: v.diverge,
+                    },
+                )
+            })
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -363,6 +420,39 @@ mod tests {
     fn e2e_opencode_thinking() {
         e2e_fixture_behavioral("opencode-thinking.raw", &Backend::OpenCode);
     }
+    // Sprint 27 PR-B: extend e2e to all 13 fixtures
+    #[test]
+    fn e2e_claude_tooluse() {
+        e2e_fixture_behavioral("claude-tooluse.raw", &Backend::ClaudeCode);
+    }
+    #[test]
+    fn e2e_claude_perm() {
+        e2e_fixture_behavioral("claude-perm.raw", &Backend::ClaudeCode);
+    }
+    #[test]
+    fn e2e_codex_tooluse() {
+        e2e_fixture_behavioral("codex-tooluse.raw", &Backend::Codex);
+    }
+    #[test]
+    fn e2e_codex_update() {
+        e2e_fixture_behavioral("codex-update.raw", &Backend::Codex);
+    }
+    #[test]
+    fn e2e_codex_perm() {
+        e2e_fixture_behavioral("codex-perm.raw", &Backend::Codex);
+    }
+    #[test]
+    fn e2e_gemini_tooluse() {
+        e2e_fixture_behavioral("gemini-tooluse.raw", &Backend::Gemini);
+    }
+    #[test]
+    fn e2e_kiro_tooluse() {
+        e2e_fixture_behavioral("kiro-tooluse.raw", &Backend::KiroCli);
+    }
+    #[test]
+    fn e2e_opencode_tooluse() {
+        e2e_fixture_behavioral("opencode-tooluse.raw", &Backend::OpenCode);
+    }
 
     #[test]
     fn fixture_replay_claude_tooluse() {
@@ -515,6 +605,45 @@ mod tests {
         assert!(
             tracker.has_behavioral_config(),
             "StateTracker must have behavioral_config for managed backends"
+        );
+    }
+
+    // --- Sprint 27 PR-B: divergence dashboard tests ---
+
+    #[test]
+    fn divergence_record_and_report() {
+        // Record some ticks
+        record_divergence(
+            "test-backend",
+            BehavioralSignal::SilenceThinking,
+            "thinking",
+        );
+        record_divergence("test-backend", BehavioralSignal::SilenceThinking, "idle"); // diverge
+        record_divergence("test-backend", BehavioralSignal::None, "ready"); // agree (None = no signal)
+
+        let report = divergence_report();
+        let entry = report.iter().find(|(k, _)| k == "test-backend");
+        assert!(entry.is_some(), "report must contain test-backend");
+        let (_, stats) = entry.unwrap();
+        assert!(stats.total_ticks >= 3, "must have at least 3 ticks");
+        assert!(stats.diverge >= 1, "must have at least 1 divergence");
+    }
+
+    #[test]
+    fn divergence_e2e_through_state_tracker() {
+        // Feed a fixture through StateTracker → divergence accumulator should record
+        let fixture = std::fs::read("tests/fixtures/state-replay/claude-thinking.raw").unwrap();
+        let mut tracker = crate::state::StateTracker::new(Some(&Backend::ClaudeCode));
+        tracker.set_instance_name("test-divergence");
+        tracker.feed(&String::from_utf8_lossy(&fixture));
+        std::thread::sleep(Duration::from_millis(2200));
+        tracker.feed("_");
+
+        let report = divergence_report();
+        let entry = report.iter().find(|(k, _)| k == "claude");
+        assert!(
+            entry.is_some(),
+            "divergence report must contain claude after feed"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,8 @@ enum Commands {
     },
     /// Health check
     Doctor,
+    /// Show behavioral vs regex state divergence report
+    StateDivergenceReport,
     /// Menu-bar / system-tray resident app (requires `--features tray`).
     #[cfg(feature = "tray")]
     Tray,
@@ -644,6 +646,28 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Test { suite }) => cli::run_tests(&suite, &home)?,
         Some(Commands::Verify { json, backend }) => verify::run(&home, json, backend.as_deref())?,
         Some(Commands::Doctor) => cli::run_doctor(&home)?,
+        Some(Commands::StateDivergenceReport) => {
+            let report = behavioral::divergence_report();
+            if report.is_empty() {
+                println!("No divergence data collected yet. Run the daemon with agents to accumulate data.");
+            } else {
+                println!(
+                    "{:<15} {:>10} {:>10} {:>10} {:>8}",
+                    "Backend", "Total", "Agree", "Diverge", "Rate%"
+                );
+                println!("{}", "-".repeat(58));
+                for (backend, stats) in &report {
+                    println!(
+                        "{:<15} {:>10} {:>10} {:>10} {:>7.1}%",
+                        backend,
+                        stats.total_ticks,
+                        stats.agree,
+                        stats.diverge,
+                        stats.divergence_rate()
+                    );
+                }
+            }
+        }
         #[cfg(feature = "tray")]
         Some(Commands::Tray) => tray::run(&home)?,
         Some(Commands::Demo) => cli::run_demo()?,

--- a/src/state.rs
+++ b/src/state.rs
@@ -725,6 +725,12 @@ impl StateTracker {
                 self.current.display_name(),
                 signal,
             );
+            // Sprint 27 PR-B: accumulate divergence stats for dashboard
+            crate::behavioral::record_divergence(
+                &self.backend_name,
+                signal,
+                self.current.display_name(),
+            );
         }
     }
 


### PR DESCRIPTION
## Sprint 27 PR-B: Real-backend test + divergence dashboard

### §3.5.11 split
RED `535d7de` (divergence_e2e fails — state.rs hook absent) → GREEN `17af1a3` (hook wired)

### 13-fixture e2e behavioral telemetry
All 13 `.raw` fixtures now have e2e tests via rolled-own tracing subscriber:
- 5 thinking (PR-A) + 3 tooluse + 2 perm + 1 update + 2 more tooluse = 13 total
- Each: real fixture → StateTracker::feed → sleep 3.1s → feed → capture silence_thinking

### Divergence dashboard
- `DivergenceStats`: per-backend tick counter (total/agree/diverge)
- `record_divergence()`: called in state.rs shadow hook alongside telemetry
- `divergence_report()`: returns per-backend stats for operator CLI
- 2 tests: unit record+report + e2e through StateTracker

### Nightly CI workflow
`.github/workflows/behavioral-nightly.yml`: daily 03:00 UTC cron + manual dispatch. Runs 13 e2e fixture tests on 3 platforms.

### Test count: +10 new (8 e2e + 2 divergence)

## Tier-1 evidence
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --tests` ✅