### PR TITLE
fix(vterm): scrollback renders blank — safe_cell rejects negative Line

### DIFF
--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -21,7 +21,8 @@ static DEFAULT_CELL: std::sync::OnceLock<Cell> = std::sync::OnceLock::new();
 ///
 /// Sprint 25 P0 HOTFIX: replaces all 5 raw `grid[Point::new(...)]` sites.
 fn safe_cell(grid: &alacritty_terminal::grid::Grid<Cell>, line: Line, col: usize) -> &Cell {
-    if col < grid.columns() && (line.0 as usize) < grid.screen_lines() {
+    use alacritty_terminal::grid::Dimensions;
+    if col < grid.columns() && line >= grid.topmost_line() && line <= grid.bottommost_line() {
         &grid[Point::new(line, Column(col))]
     } else {
         DEFAULT_CELL.get_or_init(Cell::default)


### PR DESCRIPTION
## Problem

TUI scrollback (scroll up) shows only blank lines. Only the current visible page has content.

## Root Cause

`safe_cell` bounds-checks the line index with:

```rust
(line.0 as usize) < grid.screen_lines()
```

In alacritty's grid, scrollback history uses **negative** `Line` values (`Line(-1)`, `Line(-2)`, ...). Casting `-5i32 as usize` produces `4294967291` on 64-bit, which always fails the `< screen_lines()` check, so every scrollback row falls through to `DEFAULT_CELL` (blank).

## Fix

Use alacritty's canonical bounds API:

```rust
line >= grid.topmost_line() && line <= grid.bottommost_line()
```

This correctly admits negative Line values within the scrollback ring buffer.

## Testing

All 35 vterm tests pass.