### PR TITLE
feat(mcp): inbox subsumes describe_message + describe_thread (Sprint 30 PR-4)

### DIFF
--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -104,9 +104,18 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         "report_result" => comms::handle_report_result(&home, args, &sender),
         "request_information" => comms::handle_request_information(&home, args, &sender),
         "broadcast" => comms::handle_broadcast(&home, args, &sender),
-        "inbox" => comms::handle_inbox(&home, instance_name),
-        "describe_message" => comms::handle_describe_message(&home, args, instance_name),
-        "describe_thread" => comms::handle_describe_thread(&home, args),
+        // Sprint 30 PR-4: inbox subsumes describe_message + describe_thread.
+        // Old names kept as aliases for 1-sprint migration window per
+        // operator m-203 #4 (consolidation alias retention pattern).
+        "inbox" | "describe_message" | "describe_thread" => {
+            if args.get("message_id").and_then(|v| v.as_str()).is_some() {
+                comms::handle_describe_message(&home, args, instance_name)
+            } else if args.get("thread_id").and_then(|v| v.as_str()).is_some() {
+                comms::handle_describe_thread(&home, args)
+            } else {
+                comms::handle_inbox(&home, instance_name)
+            }
+        }
 
         // --- Instance management ---
         "list_instances" => instance::handle_list_instances(&home, instance_name),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -73,18 +73,12 @@ fn comm_tools() -> Vec<Value> {
                 "task_summary": {"type": "string"}, "request_kind": {"type": "string", "enum": ["query", "task", "update"]},
                 "requires_reply": {"type": "boolean"}
             }, "required": ["message"]}}),
-        json!({"name": "inbox", "description": "Check pending messages.",
-            "inputSchema": {"type": "object", "properties": {}}}),
-        json!({"name": "describe_message", "description": "Look up an inbox message status by ID. Returns ReadAt (with timestamp), UnreadExpired, or NotFound.",
-            "inputSchema": {"type": "object", "properties": {
-                "message_id": {"type": "string", "description": "The message ID to look up"},
-                "instance": {"type": "string", "description": "Target instance name (defaults to caller)"}
-            }, "required": ["message_id"]}}),
-        json!({"name": "describe_thread", "description": "Get all messages in a conversation thread, ordered by timestamp.",
-            "inputSchema": {"type": "object", "properties": {
-                "thread_id": {"type": "string", "description": "The thread ID to look up"},
-                "instance": {"type": "string", "description": "Filter to a specific instance's inbox (optional, scans all if omitted)"}
-            }, "required": ["thread_id"]}}),
+        json!({"name": "inbox", "description": "Check pending messages, OR look up a single message by ID, OR fetch a thread's messages. No params = drain pending. With message_id = describe message status (read/unread/expired/notfound). With thread_id = fetch all messages in thread ordered by timestamp.",
+        "inputSchema": {"type": "object", "properties": {
+            "message_id": {"type": "string", "description": "Look up message status by ID"},
+            "thread_id": {"type": "string", "description": "Fetch all messages in a thread"},
+            "instance": {"type": "string", "description": "For message_id: target instance (defaults to caller). For thread_id: filter to a specific instance's inbox (optional, scans all if omitted)"}
+        }}}),
     ]
 }
 


### PR DESCRIPTION
## Sprint 30 PR-4 — `inbox` subsumes `describe_message` + `describe_thread`

Per Sprint 30 MCP tool consolidation operator m-203 GO + dispatch m-189 + operator m-208 scope correction (download_attachment NOT folded into inbox; deferred to Sprint 31+ explicit design plan).

### Changes

Folds `describe_message` + `describe_thread` access paths into the existing `inbox` tool via optional `message_id` / `thread_id` / `instance` params:

| Args | Behavior |
|---|---|
| (none) | Drain pending messages (current behavior, unchanged) |
| `message_id` present | Describe message status (read / unread / expired / notfound) |
| `thread_id` present | Fetch all messages in thread, ordered by timestamp |

### Alias retention

Old tool names (`describe_message`, `describe_thread`) retained as dispatch aliases for 1-sprint migration window per operator m-203 #4 consolidation alias retention pattern. Schemas removed from tool list (LLM only sees the unified `inbox`); old-name calls still route correctly.

### Files touched

- `src/mcp/tools.rs`: inbox schema extended with optional `message_id` + `thread_id` + `instance` params; `describe_message` + `describe_thread` schemas deleted
- `src/mcp/handlers/mod.rs`: 3 dispatch arms (inbox + describe_message + describe_thread) consolidated into single arm with arg-based routing preserving alias support

Internal handlers `handle_describe_message` + `handle_describe_thread` kept (per dispatch "handlers may keep internal fns if used elsewhere") — they're called via the consolidated dispatch routing.

### §3.5.11 attestation

§3.5.11 #6 pure-deletion exemption **N/A** — this is consolidation, not pure deletion (inbox schema extended).

§3.5.11 #2 pure refactor exemption applies — behavior preserved across all 3 access paths via arg-based routing; existing internal handlers unchanged.

Verified: 28 mcp_characterization tests + 1182 lib tests pass at HEAD. Behavior preserved per access path.

### Tool count

PR-4 alone: -2 (describe_message + describe_thread schemas removed; inbox extended)
Cumulative Sprint 30 PR-3 + PR-4: 30 → 28 → 26

### Tier

§3.5.5 LOW (Path A — refactor + docs). Net diff: 2 files, +17/-14 LOC.

### Verification

- `cargo build --tests` clean
- `cargo test --bin agend-terminal --lib` → 1182 passed
- `cargo test --test mcp_characterization` → 28 passed

### Operator UX migration

Existing agent prompts referencing `describe_message` / `describe_thread` continue to work for the migration window (alias dispatch). Steering docs (PR-5 my authorship later) will teach new unified `inbox(message_id=...)` / `inbox(thread_id=...)` patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)