### PR TITLE
docs(steering): Sprint 30 PR-5 — instructions.rs rewrite for unified send + 7 CRUD + inbox absorbed

### DIFF
--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -198,13 +198,39 @@ pub(crate) fn build_instructions_body(
 
     content.push_str("## Communication (v3-mcp)\n\n");
     content.push_str("Use these MCP tools to collaborate:\n\n");
-    content.push_str("- `send_to_instance` — send a message to a specific agent\n");
-    content.push_str("- `broadcast` — send to multiple agents\n");
-    content.push_str("- `inbox` — check your inbox for unread messages\n");
-    content.push_str("- `delegate_task` — assign work to another agent\n");
-    content.push_str("- `report_result` — reply with task results\n");
-    content.push_str("- `request_information` — ask another agent a question\n");
-    content.push_str("- `list_instances` — see all running agents\n\n");
+    content.push_str("**Primary inter-agent communication**:\n");
+    content
+        .push_str("- `send` — unified send to one or many agents. Required: `message`. Routing:\n");
+    content.push_str("  - `target_instance` (single recipient) OR `targets` / `team` / `tags` (broadcast mode)\n");
+    content.push_str("  - `request_kind`: `task` (delegation, expects report back) / `report` (results back) / `query` (question, expects reply) / `update` (status) / omit (plain message)\n");
+    content.push_str("  - Task-mode optional fields: `success_criteria`, `task_id`, `force` + `force_reason`, `second_reviewer` + `second_reviewer_reason`, `branch`, `working_directory`\n");
+    content.push_str(
+        "  - Report-mode optional fields: `correlation_id`, `reviewed_head`, `artifacts`\n",
+    );
+    content.push_str("  - Threading: `thread_id`, `parent_id`\n");
+    content.push_str("- `inbox` — check pending OR query specific. No params = drain pending. With `message_id` = describe message status. With `thread_id` = fetch thread messages.\n");
+    content.push_str("- `react` — emoji reaction on a previously-observed message (lightweight ack, no inbox message on recipient)\n");
+    content.push_str("- `reply` — reply to operator/user via the active channel (NOT for inter-agent — use `send`)\n");
+    content.push_str("- `list_instances` — see all running agents\n");
+    content.push_str("- `download_attachment` — download a telegram multimedia attachment (images / audio / documents) by `file_id`. Use when an inbox message contains `attachments=[...]` and you need the actual media bytes.\n\n");
+    content.push_str("**Action-based CRUD tools** (each takes `action` param):\n");
+    content.push_str("- `decision` — actions: `post` / `list` / `update` (record scope decisions and corrections)\n");
+    content.push_str(
+        "- `task` — actions: `create` / `list` / `claim` / `update` / `done` (shared task board)\n",
+    );
+    content.push_str("- `team` — actions: `create` / `delete` / `list` / `update`\n");
+    content.push_str(
+        "- `schedule` — actions: `create` / `list` / `update` / `delete` (cron-style routines)\n",
+    );
+    content.push_str(
+        "- `deployment` — actions: `deploy` / `teardown` / `list` (template deployments)\n",
+    );
+    content.push_str("- `repo` — actions: `checkout` / `release` (repo mounts)\n");
+    content.push_str("- `ci` — actions: `watch` / `unwatch` (GitHub Actions monitoring)\n");
+    content.push_str(
+        "- `health` — actions: `report` / `clear_blocked_reason` (instance health state)\n\n",
+    );
+    content.push_str("**Migration note (Sprint 30)**: old tool names from before consolidation are retained as 1-sprint aliases — `send_to_instance`, `delegate_task`, `report_result`, `request_information`, `broadcast` route to `send`; `describe_message` + `describe_thread` route to `inbox`; the 17 CRUD aliases (e.g. `post_decision`, `create_team`, `watch_ci`) still work. Prefer the new unified names; aliases will be removed in Sprint 31.\n\n");
     content.push_str(
         "Reply obligation depends on `kind`:\n\
          - `query` — requires reply (other instance is waiting)\n\
@@ -212,11 +238,11 @@ pub(crate) fn build_instructions_body(
          - `report` / `update` — do NOT reply unless you have new information to add\n\n\
          For acknowledgement without triggering a reply loop, use the `react` MCP tool \
          (emoji reaction; no inbox message on recipient side). \
-         Pure ack messages (\"收到\", \"OK\", \"👍\") should use `react`, not `send_to_instance`.\n\
+         Pure ack messages (\"收到\", \"OK\", \"👍\") should use `react`, not `send`.\n\
          When sending kind=report, include `parent_id` (the message you're replying to) \
          and `correlation_id` (the task board ID) for correlation tracking.\n\
-         If you receive a delegate_task while already working on an active review or task, \
-         respond with a structured BUSY message:\n\
+         If you receive a `send` with kind=task while already working on an active review \
+         or task, respond with a structured BUSY message:\n\
          ```\n\
          BUSY\n\
          current: <task id or message id you are working on>\n\
@@ -269,7 +295,7 @@ pub(crate) fn build_instructions_body(
     content.push_str(
         "- Use `task` board for all work tracking (create/claim/done), not local task lists\n",
     );
-    content.push_str("- Use `post_decision` to record scope decisions and corrections\n");
+    content.push_str("- Use `decision` (action: post) to record scope decisions and corrections — old name `post_decision` still works as alias\n");
     content.push_str("- Use `set_waiting_on` to declare blockers\n");
     content.push_str(
         "- Review dispatch expects: source of truth, scope boundary, freshness boundary\n",
@@ -287,7 +313,7 @@ pub(crate) fn build_instructions_body(
     content.push_str(
         "Reply via the same channel the input arrived on. Look at the message prefix:\n\
          - If message has `[user:NAME via telegram]` prefix → use the `reply` MCP tool\n\
-         - If message has `[from:AGENT_NAME]` prefix → use `send_to_instance`\n\
+         - If message has `[from:AGENT_NAME]` prefix → use `send` (alias `send_to_instance` also works)\n\
          - If **neither prefix present** (operator typed in TUI directly) → respond with **direct text**, do NOT use any tool\n\n\
          The daemon also appends a parenthetical hint after the prefix (e.g. `(Reply using the reply tool — do NOT respond with direct text)`) — this is supplemental confirmation, but the prefix is the authoritative signal.\n\n\
          Mixing channels (e.g. telegram reply when operator typed in TUI directly) makes the response appear in the wrong place — the operator-typed TUI input has no associated channel binding, so a `reply` MCP call returns \"no active channel\" error.\n",
@@ -303,7 +329,8 @@ pub(crate) fn build_instructions_body(
     content.push_str("- Parse the header fields: `id=` is the message id; `kind=` is the message kind (task/query/report/update).\n");
     content.push_str("- The header always includes `size=`; the full body is in your inbox, not in the terminal. Call the MCP tool `inbox` to fetch full content.\n");
     content.push_str("- If the header contains `attachments=[path1,path2,...]`, the message includes media files. Call `inbox` for full metadata, then use your file-reading tools to inspect the files.\n");
-    content.push_str("- ACK obligation depends on `kind`: `query` requires reply via `send_to_instance`; `task` may require reply after work; `report`/`update` may skip ACK (see fleet protocol §4 ack absorption).\n");
+    content.push_str("- If the header contains `attachments=[...]` of telegram media types, call `download_attachment` with the relevant `file_id` to retrieve the bytes locally before processing.\n");
+    content.push_str("- ACK obligation depends on `kind`: `query` requires reply via `send` (kind=report); `task` may require reply after work; `report`/`update` may skip ACK (see fleet protocol §4 ack absorption).\n");
 
     content
 }


### PR DESCRIPTION
## Sprint 30 PR-5 (last in wave-1) — Steering doc rewrite

Per Sprint 30 wave-1 closeout (PR-1 #292 + PR-3 #291 + PR-4 #294 + PR-2 #293 all merged) + operator m-203 #5 + operator m-208 explicit download_attachment use case.

### Wave-1 ship status

- ✅ PR-1 #292 MERGED `f448e1d` (send 5→1 unified)
- ✅ PR-3 #291 MERGED `f65a87c` (delete 2: edit_message + task_legacy_backfill_run)
- ✅ PR-4 #294 MERGED `5bad7f3` (inbox absorbs describe_message + describe_thread)
- ✅ PR-2 #293 MERGED `3b7ccc2` (7 CRUD action-based)
- 🔄 PR-5 (this) — steering rewrite to align template with new 28-tool surface

### Changes

`src/instructions.rs` (system prompt template) rewritten:

**Primary inter-agent communication** section leads with:
- `send` — unified send (replaces 5 separate tools); routing via `request_kind` + recipient fields (target_instance / targets / team / tags); kind-specific optional params documented
- `inbox` — drain pending OR query specific via message_id / thread_id (absorbed describe_message + describe_thread per PR-4)
- `react` — emoji ack
- `reply` — operator-facing only (NOT inter-agent)
- `list_instances` — fleet roster
- **`download_attachment`** — **explicit telegram multimedia use case** (images / audio / documents) per operator m-208 — documents the real use case to prevent future reviewer from attempting deletion without context

**Action-based CRUD tools** section enumerates the 7 unified tools per PR-2:
- `decision` / `task` / `team` / `schedule` / `deployment` / `repo` / `ci` / `health` (each with `action` param)

**Migration note**: 1-sprint alias retention from Sprint 30 documented; old names (`send_to_instance`, `delegate_task`, `report_result`, `request_information`, `broadcast`, `describe_message`, `describe_thread`, 17 CRUD aliases) still work but are scheduled for Sprint 31 removal.

Reply-obligation, response-channel-discipline, and inbox-message-handling sections updated to reference unified `send` (with alias parenthetical for backward compat).

### §3.5.11 #2 pure refactor exemption attestation

Behavior preserved across all communication paths via 1-sprint alias retention from Sprint 30 wave-1; existing internal handlers unchanged. 35 instructions tests pass at HEAD (existing string assertions like `content.contains("send_to_instance")` satisfied via the migration note text — the canonical guidance teaches new unified `send` while alias mention preserves test contract).

### Tier

§3.5.5 LOW (Path A — docs+template refactor). Net diff: 1 file, +40/-13 LOC.

### Files touched

| File | Change |
|---|---|
| `src/instructions.rs` | §Communication / §Fleet Protocol / §Response channel discipline / §Inbox message handling sections rewritten to teach unified send + 7 CRUD + download_attachment use case + migration note |
| `README.md` | No tool-list mentions to update (only "broadcast" in unrelated crash-recovery context) |

### Verification

- `cargo build --tests` clean
- `cargo test --bin agend-terminal instructions` → 35 passed (all backends include AGEND-MSG / attachments / channel-detection rules; existing string assertions satisfied by migration note)
- `cargo fmt --check` ✅

### Operator UX

Existing agent prompts referencing old tool names continue to work for the migration window (alias dispatch from PR-1/2/4). Sprint 31 alias removal scheduled per operator m-203 #4. Future agent sessions will learn unified `send` / `inbox` / 7 CRUD pattern from this template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)