### PR TITLE
docs(protocol): fix delegate_task → send(request_kind: task) at line 196 (operator m-2 closeout)

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -193,7 +193,7 @@ The orchestrator may then reassign the review instead of waiting.
 
 A reviewer may have at most one active review task unless an incoming task is explicitly marked `interrupt=true` with a reason.
 
-A review task becomes active when the reviewer reads or accepts the delegate_task, and remains active until `send(request_kind: report)` is sent.
+A review task becomes active when the reviewer reads or accepts the `send(request_kind: task)`, and remains active until `send(request_kind: report)` is sent.
 
 New review dispatches to an active reviewer are queued, not implicitly preemptive. The reviewer must finish and report the active task before starting another, unless:
 


### PR DESCRIPTION
## Final wave PR #3 — line 196 alias-removal completion

Per dispatch m-5 (operator m-2 closeout).

### Fix

`docs/FLEET-DEV-PROTOCOL-v1.md:196`:

- Before: \`A review task becomes active when the reviewer reads or accepts the **delegate_task**, and remains active until \`send(request_kind: report)\` is sent.\`
- After: \`A review task becomes active when the reviewer reads or accepts the \`send(request_kind: task)\`, and remains active until \`send(request_kind: report)\` is sent.\`

PR #298 alias removal updated the `report_result` side but missed the `delegate_task` side. This 1-LOC fix unifies both halves to the post-Sprint-30 unified `send(request_kind: ...)` form.

### Tier

§3.5.5 LOW (Path A — docs-only, 1 LOC). Net diff: 1 file, +1/-1 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)