### PR TITLE
feat(discord): PR2 inbound MessageIn + outbound send + notify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4180,6 +4180,7 @@ dependencies = [
  "futures-sink",
  "http 1.4.0",
  "httparse",
+ "ring",
  "rustls-native-certs",
  "rustls-pki-types",
  "sha1_smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,8 +108,8 @@ toml = { version = "0.8", optional = true }
 # WS shard lifecycle, http for REST, model for typed Discord API structs.
 # Pin to 0.16 series (Discord API v10). rustls-native-roots avoids
 # macOS SecureTransport flakiness (same rationale as teloxide rustls).
-twilight-gateway = { version = "0.16", optional = true, default-features = false, features = ["rustls-native-roots"] }
-twilight-http = { version = "0.16", optional = true, default-features = false, features = ["rustls-native-roots"] }
+twilight-gateway = { version = "0.16", optional = true, default-features = false, features = ["rustls-native-roots", "rustls-ring"] }
+twilight-http = { version = "0.16", optional = true, default-features = false, features = ["rustls-native-roots", "rustls-ring"] }
 twilight-model = { version = "0.16", optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -194,6 +194,49 @@ pub(crate) fn map_ready_to_connected(
     }
 }
 
+/// Map a twilight `Message` (from MESSAGE_CREATE dispatch) to
+/// `ChannelEvent::MessageIn`.
+pub(crate) fn map_message_create_to_message_in(
+    msg: &twilight_model::channel::Message,
+) -> ChannelEvent {
+    use crate::channel::event::{MsgPayload, User};
+    ChannelEvent::MessageIn {
+        binding: BindingRef::new(
+            "discord",
+            Some(format!("DC#{}", msg.channel_id)),
+            DiscordBindingPayload {
+                channel_id: msg.channel_id.get(),
+            },
+        ),
+        from: User {
+            id: msg.author.id.to_string(),
+            handle: Some(msg.author.name.clone()),
+        },
+        payload: MsgPayload {
+            text: msg.content.clone(),
+        },
+        ts: chrono::DateTime::parse_from_rfc3339(&msg.timestamp.iso_8601().to_string())
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::Utc::now()),
+    }
+}
+
+/// Map a twilight `Message` (from REST response) to `MsgRef`.
+pub(crate) fn map_message_to_msg_ref(
+    msg: &twilight_model::channel::Message,
+) -> crate::channel::MsgRef {
+    crate::channel::MsgRef {
+        binding: BindingRef::new(
+            "discord",
+            Some(format!("DC#{}", msg.channel_id)),
+            DiscordBindingPayload {
+                channel_id: msg.channel_id.get(),
+            },
+        ),
+        id: msg.id.to_string(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Channel trait impl
 // ---------------------------------------------------------------------------
@@ -211,16 +254,33 @@ impl crate::channel::Channel for DiscordChannel {
         self.event_rx.lock().try_recv().ok()
     }
 
-    fn send(&self, _binding: &BindingRef, _msg: OutMsg) -> anyhow::Result<MsgRef> {
-        anyhow::bail!("discord send not yet implemented (PR2)")
+    fn send(&self, binding: &BindingRef, msg: OutMsg) -> anyhow::Result<MsgRef> {
+        let payload = binding
+            .downcast::<DiscordBindingPayload>()
+            .ok_or_else(|| anyhow::anyhow!("non-discord binding passed to send"))?;
+        // PR2: text-only send. Attachment support deferred to PR3.
+        if msg.text.is_empty() {
+            anyhow::bail!("OutMsg has no text (attachment-only sends deferred to PR3)");
+        }
+        // In production, this would call twilight-http create_message.
+        // For now, return a synthetic MsgRef with the channel_id so
+        // callers can chain edit/delete later.
+        Ok(MsgRef {
+            binding: BindingRef::new(
+                "discord",
+                Some(format!("DC#{}", payload.channel_id)),
+                *payload,
+            ),
+            id: "0".to_string(), // placeholder until HTTP client wired
+        })
     }
 
     fn edit(&self, _msg: &MsgRef, _payload: OutMsg) -> anyhow::Result<()> {
-        anyhow::bail!("discord edit not yet implemented (PR2)")
+        anyhow::bail!("discord edit not yet implemented (PR3)")
     }
 
     fn delete(&self, _msg: &MsgRef) -> anyhow::Result<()> {
-        anyhow::bail!("discord delete not yet implemented (PR2)")
+        anyhow::bail!("discord delete not yet implemented (PR3)")
     }
 
     fn create_binding(
@@ -274,6 +334,53 @@ impl crate::channel::Channel for DiscordChannel {
 
     fn outbound_authorized(&self) -> bool {
         crate::channel::auth::is_outbound_authorized(&self.state.lock().user_allowlist)
+    }
+
+    fn notify(
+        &self,
+        instance: &str,
+        _severity: crate::channel::NotifySeverity,
+        message: &str,
+        _silent: bool, // Discord has no per-message notification suppression
+    ) -> std::result::Result<(), ChannelError> {
+        let cid = self.state.lock().instance_to_channel.get(instance).copied();
+        let cid = cid.ok_or_else(|| {
+            ChannelError::Other(anyhow::anyhow!("no discord binding for '{instance}'"))
+        })?;
+        let binding = BindingRef::new(
+            "discord",
+            Some(format!("DC#{cid}")),
+            DiscordBindingPayload { channel_id: cid },
+        );
+        self.send(&binding, OutMsg::text(message))
+            .map_err(ChannelError::Other)?;
+        Ok(())
+    }
+
+    fn send_from_agent(
+        &self,
+        agent: &str,
+        op: crate::channel::AgentOutboundOp,
+    ) -> std::result::Result<MsgRef, ChannelError> {
+        // Only Reply is implemented in PR2; other ops defer to PR3.
+        match op {
+            crate::channel::AgentOutboundOp::Reply { text } => {
+                let cid = self.state.lock().instance_to_channel.get(agent).copied();
+                let cid = cid.ok_or_else(|| {
+                    ChannelError::Other(anyhow::anyhow!("no discord binding for '{agent}'"))
+                })?;
+                let binding = BindingRef::new(
+                    "discord",
+                    Some(format!("DC#{cid}")),
+                    DiscordBindingPayload { channel_id: cid },
+                );
+                self.send(&binding, OutMsg::text(text))
+                    .map_err(ChannelError::Other)
+            }
+            _ => Err(ChannelError::NotSupported(
+                "only Reply implemented in PR2".into(),
+            )),
+        }
     }
 }
 
@@ -491,8 +598,7 @@ mod tests {
     #[test]
     fn discord_message_create_emits_message_in() {
         let fixture = include_str!("../../tests/fixtures/discord-gateway-message-create.json");
-        let frame: serde_json::Value =
-            serde_json::from_str(fixture).expect("fixture must parse");
+        let frame: serde_json::Value = serde_json::from_str(fixture).expect("fixture must parse");
         let d = frame.get("d").expect("d field");
         let msg: twilight_model::channel::Message =
             serde_json::from_value(d.clone()).expect("Message");
@@ -543,9 +649,7 @@ mod tests {
         let result = crate::channel::Channel::send_from_agent(
             &ch,
             "unknown-agent",
-            crate::channel::AgentOutboundOp::Reply {
-                text: "hi".into(),
-            },
+            crate::channel::AgentOutboundOp::Reply { text: "hi".into() },
         );
         assert!(result.is_err(), "unbound instance must error");
     }

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -267,6 +267,20 @@ pub(crate) fn map_message_to_msg_ref(
 }
 
 // ---------------------------------------------------------------------------
+// Outbound request body construction
+// ---------------------------------------------------------------------------
+
+/// Build the JSON body for `POST /channels/{id}/messages` per Discord spec.
+/// Ref: https://discord.com/developers/docs/resources/message#create-message-jsonform-params
+///
+/// This is the canonical shape our adapter transmits. The test suite
+/// asserts this against the spec-quoted example (§3.5.10 outbound
+/// request boundary).
+pub(crate) fn build_create_message_body(text: &str) -> serde_json::Value {
+    serde_json::json!({ "content": text })
+}
+
+// ---------------------------------------------------------------------------
 // Channel trait impl
 // ---------------------------------------------------------------------------
 
@@ -739,5 +753,43 @@ mod tests {
             false,
         );
         assert!(result.is_err(), "notify on unbound instance must error");
+    }
+
+    // ── F3 fix: §3.5.10 outbound request body shape assertion ────────
+
+    /// §3.5.10 wire-format: outbound POST /channels/{id}/messages request
+    /// body matches Discord spec JSON/Form Params shape.
+    /// Ref: https://discord.com/developers/docs/resources/message#create-message-jsonform-params
+    ///
+    /// The spec-quoted minimal payload is `{"content": "<text>"}`.
+    /// Our `build_create_message_body` must produce exactly this shape.
+    #[test]
+    fn discord_create_message_request_body_matches_spec() {
+        let body = super::build_create_message_body("Hello, World!");
+
+        // Spec-quoted from Discord API docs — the minimal JSON body for
+        // POST /channels/{id}/messages with text content only.
+        let spec_quoted: serde_json::Value =
+            serde_json::from_str(r#"{"content": "Hello, World!"}"#)
+                .expect("spec fixture must parse");
+
+        assert_eq!(
+            body, spec_quoted,
+            "outbound request body must match Discord spec shape"
+        );
+
+        // Verify field-level: only "content" key present (no extra fields).
+        let obj = body.as_object().expect("body must be object");
+        assert_eq!(obj.len(), 1, "minimal body has exactly 1 field");
+        assert!(obj.contains_key("content"), "must have 'content' key");
+    }
+
+    /// Edge case: empty text produces `{"content": ""}` — still valid
+    /// per Discord spec (though our send() rejects empty text before
+    /// reaching the HTTP call).
+    #[test]
+    fn discord_create_message_request_body_empty_text() {
+        let body = super::build_create_message_body("");
+        assert_eq!(body["content"], "");
     }
 }

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -131,6 +131,28 @@ impl DiscordChannel {
         };
         (ch, tx)
     }
+
+    /// Test-only constructor with a custom twilight HTTP client (for
+    /// mock-server tests that exercise the real send path).
+    #[cfg(test)]
+    pub(crate) fn new_for_test_with_http(
+        http: std::sync::Arc<twilight_http::Client>,
+    ) -> (Self, mpsc::Sender<ChannelEvent>) {
+        let (tx, rx) = mpsc::channel();
+        let ch = Self {
+            state: Mutex::new(DiscordState {
+                instance_to_channel: HashMap::new(),
+                channel_to_instance: HashMap::new(),
+                submit_keys: HashMap::new(),
+                registry: None,
+                user_allowlist: Some(vec![1]),
+                http_client: Some(http),
+            }),
+            caps: discord_caps(),
+            event_rx: Mutex::new(rx),
+        };
+        (ch, tx)
+    }
 }
 
 /// Build the Discord capability matrix (pinned by S5 analysis).
@@ -756,40 +778,94 @@ mod tests {
     }
 
     // ── F3 fix: §3.5.10 outbound request body shape assertion ────────
+    //
+    // Production-path-coupled: exercises the real Channel::send() →
+    // twilight_http::create_message() path against a mock HTTP server.
+    // The mock captures the request body twilight actually transmits
+    // and asserts it matches the Discord spec shape.
 
     /// §3.5.10 wire-format: outbound POST /channels/{id}/messages request
-    /// body matches Discord spec JSON/Form Params shape.
-    /// Ref: https://discord.com/developers/docs/resources/message#create-message-jsonform-params
+    /// body transmitted by twilight-http matches Discord spec shape.
     ///
-    /// The spec-quoted minimal payload is `{"content": "<text>"}`.
-    /// Our `build_create_message_body` must produce exactly this shape.
+    /// Uses a raw TCP listener as mock Discord API server. The twilight
+    /// client is pointed at it via `proxy()`. Channel::send() exercises
+    /// the real production code path.
     #[test]
-    fn discord_create_message_request_body_matches_spec() {
-        let body = super::build_create_message_body("Hello, World!");
+    fn discord_send_outbound_body_matches_spec() {
+        use crate::channel::Channel;
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
 
-        // Spec-quoted from Discord API docs — the minimal JSON body for
-        // POST /channels/{id}/messages with text content only.
-        let spec_quoted: serde_json::Value =
-            serde_json::from_str(r#"{"content": "Hello, World!"}"#)
-                .expect("spec fixture must parse");
+        // Step 1: Start a mock HTTP server on an ephemeral port.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
 
-        assert_eq!(
-            body, spec_quoted,
-            "outbound request body must match Discord spec shape"
+        // Step 2: Spawn a thread to handle one request.
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+        let captured_clone = captured.clone();
+        // fire-and-forget: test mock server thread — lives only for this test
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = vec![0u8; 8192];
+            let n = stream.read(&mut buf).expect("read");
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+
+            // Extract body after the \r\n\r\n header separator.
+            if let Some(idx) = request.find("\r\n\r\n") {
+                let body = &request[idx + 4..];
+                *captured_clone.lock().expect("lock") = Some(body.to_string());
+            }
+
+            // Respond with a minimal valid Discord Message JSON.
+            let response_body =
+                include_str!("../../tests/fixtures/discord-rest-create-message-response.json");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream.write_all(response.as_bytes()).expect("write");
+        });
+
+        // Step 3: Create twilight client pointed at mock server.
+        let client = twilight_http::Client::builder()
+            .proxy(format!("127.0.0.1:{port}"), true)
+            .build();
+        let client = std::sync::Arc::new(client);
+
+        // Step 4: Create DiscordChannel with this client + a recorded binding.
+        let (ch, _tx) = super::DiscordChannel::new_for_test_with_http(client);
+        let binding = crate::channel::BindingRef::new(
+            "discord",
+            Some("DC#290926798999357250".into()),
+            super::DiscordBindingPayload {
+                channel_id: 290926798999357250,
+            },
+        );
+        ch.record_binding("test-agent", binding.clone(), "\r".into());
+
+        // Step 5: Call the real production send() path.
+        let result = crate::channel::Channel::send(
+            &ch,
+            &binding,
+            crate::channel::OutMsg::text("Hello, World!"),
         );
 
-        // Verify field-level: only "content" key present (no extra fields).
-        let obj = body.as_object().expect("body must be object");
-        assert_eq!(obj.len(), 1, "minimal body has exactly 1 field");
-        assert!(obj.contains_key("content"), "must have 'content' key");
-    }
+        handle.join().expect("mock server thread");
 
-    /// Edge case: empty text produces `{"content": ""}` — still valid
-    /// per Discord spec (though our send() rejects empty text before
-    /// reaching the HTTP call).
-    #[test]
-    fn discord_create_message_request_body_empty_text() {
-        let body = super::build_create_message_body("");
-        assert_eq!(body["content"], "");
+        // Step 6: Assert the request body twilight transmitted.
+        assert!(result.is_ok(), "send must succeed: {:?}", result.err());
+        let body_str = captured
+            .lock()
+            .expect("lock")
+            .take()
+            .expect("body captured");
+        let actual: serde_json::Value =
+            serde_json::from_str(&body_str).expect("body must be valid JSON");
+        let expected: serde_json::Value = serde_json::json!({"content": "Hello, World!"});
+        assert_eq!(
+            actual, expected,
+            "outbound body must match Discord spec create-message shape"
+        );
     }
 }

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -483,4 +483,84 @@ mod tests {
         let event = super::map_ready_to_connected(&ready_payload);
         assert!(matches!(event, ChannelEvent::Connected { .. }));
     }
+
+    // ── PR2 tests: MessageIn + send + notify ─────────────────────────
+
+    /// §3.5.10 wire-format fixture: MESSAGE_CREATE gateway event
+    /// parsed into `ChannelEvent::MessageIn`.
+    #[test]
+    fn discord_message_create_emits_message_in() {
+        let fixture = include_str!("../../tests/fixtures/discord-gateway-message-create.json");
+        let frame: serde_json::Value =
+            serde_json::from_str(fixture).expect("fixture must parse");
+        let d = frame.get("d").expect("d field");
+        let msg: twilight_model::channel::Message =
+            serde_json::from_value(d.clone()).expect("Message");
+
+        let event = super::map_message_create_to_message_in(&msg);
+
+        match event {
+            ChannelEvent::MessageIn {
+                binding,
+                from,
+                payload,
+                ts,
+            } => {
+                assert_eq!(binding.kind(), "discord");
+                assert_eq!(from.id, "82198898841029460");
+                assert_eq!(from.handle.as_deref(), Some("testoperator"));
+                assert_eq!(payload.text, "hello from discord");
+                // ts should be parseable (not epoch-zero)
+                assert!(ts.timestamp() > 0);
+            }
+            other => panic!("expected MessageIn, got: {other:?}"),
+        }
+    }
+
+    /// §3.5.10 wire-format fixture: outbound POST /channels/{id}/messages
+    /// response parsed into `MsgRef`.
+    #[test]
+    fn discord_create_message_response_parses_to_msg_ref() {
+        let fixture =
+            include_str!("../../tests/fixtures/discord-rest-create-message-response.json");
+        let msg: twilight_model::channel::Message =
+            serde_json::from_str(fixture).expect("response must parse as Message");
+
+        let msg_ref = super::map_message_to_msg_ref(&msg);
+
+        assert_eq!(msg_ref.id, "444385199974967099");
+        assert_eq!(msg_ref.binding.kind(), "discord");
+    }
+
+    /// send_from_agent(Reply) on an authorized channel with a recorded
+    /// binding should call the send path. We test the dispatch logic
+    /// without hitting the network by verifying the method routes
+    /// correctly and returns the expected error for unbound instances.
+    #[test]
+    fn send_from_agent_reply_errors_on_unbound_instance() {
+        let (ch, _rx) = super::DiscordChannel::new_for_test();
+        // No binding recorded for "unknown-agent" → should error.
+        let result = crate::channel::Channel::send_from_agent(
+            &ch,
+            "unknown-agent",
+            crate::channel::AgentOutboundOp::Reply {
+                text: "hi".into(),
+            },
+        );
+        assert!(result.is_err(), "unbound instance must error");
+    }
+
+    /// notify on an unbound instance should error gracefully.
+    #[test]
+    fn notify_errors_on_unbound_instance() {
+        let (ch, _rx) = super::DiscordChannel::new_for_test();
+        let result = crate::channel::Channel::notify(
+            &ch,
+            "unknown-agent",
+            crate::channel::NotifySeverity::Info,
+            "test notification",
+            false,
+        );
+        assert!(result.is_err(), "notify on unbound instance must error");
+    }
 }

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -138,20 +138,20 @@ fn discord_caps() -> ChannelCapabilities {
 /// Used by the gateway reader to dispatch on frame type before
 /// deserializing the inner `d` payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct GatewayFrame {
-    pub op: u8,
+pub(crate) struct GatewayFrame {
+    pub(crate) op: u8,
 }
 
 /// Parse the opcode from a raw gateway JSON frame.
 /// Returns `None` if the frame is not valid JSON or lacks an `op` field.
-pub fn parse_gateway_opcode(raw: &str) -> Option<GatewayFrame> {
+pub(crate) fn parse_gateway_opcode(raw: &str) -> Option<GatewayFrame> {
     let v: serde_json::Value = serde_json::from_str(raw).ok()?;
     let op = v.get("op")?.as_u64()? as u8;
     Some(GatewayFrame { op })
 }
 
 /// Parse a HELLO frame (opcode 10) and return the heartbeat interval in ms.
-pub fn parse_hello_interval(raw: &str) -> Option<u64> {
+pub(crate) fn parse_hello_interval(raw: &str) -> Option<u64> {
     let v: serde_json::Value = serde_json::from_str(raw).ok()?;
     let d = v.get("d")?;
     let hello: twilight_model::gateway::payload::incoming::Hello =
@@ -161,7 +161,7 @@ pub fn parse_hello_interval(raw: &str) -> Option<u64> {
 
 /// Build the IDENTIFY payload our adapter sends to the gateway.
 /// Returns the full JSON frame (op=2 + d={token, intents, properties}).
-pub fn build_identify_payload(
+pub(crate) fn build_identify_payload(
     token: &str,
     intents: twilight_model::gateway::Intents,
 ) -> serde_json::Value {
@@ -180,12 +180,12 @@ pub fn build_identify_payload(
 }
 
 /// Returns `true` if the frame is a HEARTBEAT_ACK (opcode 11).
-pub fn is_heartbeat_ack(raw: &str) -> bool {
+pub(crate) fn is_heartbeat_ack(raw: &str) -> bool {
     parse_gateway_opcode(raw).map_or(false, |f| f.op == 11)
 }
 
 /// Map a twilight `Ready` payload to `ChannelEvent::Connected`.
-pub fn map_ready_to_connected(
+pub(crate) fn map_ready_to_connected(
     ready: &twilight_model::gateway::payload::incoming::Ready,
 ) -> ChannelEvent {
     ChannelEvent::Connected {

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -52,6 +52,9 @@ pub struct DiscordState {
     pub registry: Option<AgentRegistry>,
     /// User allowlist (Discord user snowflakes). `None` = fail-closed.
     pub user_allowlist: Option<Vec<i64>>,
+    /// twilight HTTP client for REST API calls. `None` only in test
+    /// harness — production `new` always populates it.
+    pub http_client: Option<std::sync::Arc<twilight_http::Client>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -70,7 +73,11 @@ pub struct DiscordChannel {
 impl DiscordChannel {
     /// Production constructor. `event_rx` is the receiving end of the
     /// mpsc channel fed by the gateway reader task.
-    pub fn new(event_rx: mpsc::Receiver<ChannelEvent>, user_allowlist: Option<Vec<i64>>) -> Self {
+    pub fn new(
+        event_rx: mpsc::Receiver<ChannelEvent>,
+        user_allowlist: Option<Vec<i64>>,
+        http_client: std::sync::Arc<twilight_http::Client>,
+    ) -> Self {
         Self {
             state: Mutex::new(DiscordState {
                 instance_to_channel: HashMap::new(),
@@ -78,6 +85,7 @@ impl DiscordChannel {
                 submit_keys: HashMap::new(),
                 registry: None,
                 user_allowlist,
+                http_client: Some(http_client),
             }),
             caps: discord_caps(),
             event_rx: Mutex::new(event_rx),
@@ -96,6 +104,27 @@ impl DiscordChannel {
                 submit_keys: HashMap::new(),
                 registry: None,
                 user_allowlist: None,
+                http_client: None,
+            }),
+            caps: discord_caps(),
+            event_rx: Mutex::new(rx),
+        };
+        (ch, tx)
+    }
+
+    /// Test-only constructor with a configured allowlist so
+    /// `outbound_authorized()` returns `true`.
+    #[cfg(test)]
+    pub(crate) fn new_for_test_authorized() -> (Self, mpsc::Sender<ChannelEvent>) {
+        let (tx, rx) = mpsc::channel();
+        let ch = Self {
+            state: Mutex::new(DiscordState {
+                instance_to_channel: HashMap::new(),
+                channel_to_instance: HashMap::new(),
+                submit_keys: HashMap::new(),
+                registry: None,
+                user_allowlist: Some(vec![1]),
+                http_client: None,
             }),
             caps: discord_caps(),
             event_rx: Mutex::new(rx),
@@ -241,6 +270,17 @@ pub(crate) fn map_message_to_msg_ref(
 // Channel trait impl
 // ---------------------------------------------------------------------------
 
+/// Shared tokio runtime for Discord sync→async calls.
+fn discord_runtime() -> &'static tokio::runtime::Runtime {
+    static RT: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("discord tokio runtime")
+    })
+}
+
 impl crate::channel::Channel for DiscordChannel {
     fn kind(&self) -> &'static str {
         "discord"
@@ -258,20 +298,25 @@ impl crate::channel::Channel for DiscordChannel {
         let payload = binding
             .downcast::<DiscordBindingPayload>()
             .ok_or_else(|| anyhow::anyhow!("non-discord binding passed to send"))?;
-        // PR2: text-only send. Attachment support deferred to PR3.
         if msg.text.is_empty() {
             anyhow::bail!("OutMsg has no text (attachment-only sends deferred to PR3)");
         }
-        // In production, this would call twilight-http create_message.
-        // For now, return a synthetic MsgRef with the channel_id so
-        // callers can chain edit/delete later.
-        Ok(MsgRef {
-            binding: BindingRef::new(
-                "discord",
-                Some(format!("DC#{}", payload.channel_id)),
-                *payload,
-            ),
-            id: "0".to_string(), // placeholder until HTTP client wired
+        let http = self
+            .state
+            .lock()
+            .http_client
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("discord http client not initialized"))?;
+        let channel_id = twilight_model::id::Id::new(payload.channel_id);
+        let text = msg.text;
+        let cp = *payload;
+        discord_runtime().block_on(async {
+            let response = http.create_message(channel_id).content(&text).await?;
+            let sent = response.model().await?;
+            Ok(MsgRef {
+                binding: BindingRef::new("discord", Some(format!("DC#{}", cp.channel_id)), cp),
+                id: sent.id.to_string(),
+            })
         })
     }
 
@@ -362,7 +407,14 @@ impl crate::channel::Channel for DiscordChannel {
         agent: &str,
         op: crate::channel::AgentOutboundOp,
     ) -> std::result::Result<MsgRef, ChannelError> {
-        // Only Reply is implemented in PR2; other ops defer to PR3.
+        // Step 1: adapter-level allowlist gate (PR #216 contract).
+        if !self.outbound_authorized() {
+            return Err(ChannelError::Other(anyhow::anyhow!(
+                "outbound disabled — channel.user_allowlist not configured"
+            )));
+        }
+
+        // Step 2: dispatch. Only Reply in PR2; other ops defer to PR3.
         match op {
             crate::channel::AgentOutboundOp::Reply { text } => {
                 let cid = self.state.lock().instance_to_channel.get(agent).copied();
@@ -638,20 +690,41 @@ mod tests {
         assert_eq!(msg_ref.binding.kind(), "discord");
     }
 
-    /// send_from_agent(Reply) on an authorized channel with a recorded
-    /// binding should call the send path. We test the dispatch logic
-    /// without hitting the network by verifying the method routes
-    /// correctly and returns the expected error for unbound instances.
+    /// send_from_agent(Reply) on an authorized channel with no binding
+    /// for the agent should error with "no discord binding".
     #[test]
     fn send_from_agent_reply_errors_on_unbound_instance() {
-        let (ch, _rx) = super::DiscordChannel::new_for_test();
-        // No binding recorded for "unknown-agent" → should error.
+        let (ch, _rx) = super::DiscordChannel::new_for_test_authorized();
+        // Authorized but no binding → should error about binding.
         let result = crate::channel::Channel::send_from_agent(
             &ch,
             "unknown-agent",
             crate::channel::AgentOutboundOp::Reply { text: "hi".into() },
         );
         assert!(result.is_err(), "unbound instance must error");
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("no discord binding"),
+            "error must mention binding, got: {err_msg}"
+        );
+    }
+
+    /// F2 fix: send_from_agent must check outbound_authorized() gate.
+    /// When user_allowlist is None (unconfigured), the gate drops the call.
+    #[test]
+    fn send_from_agent_blocked_by_outbound_gate() {
+        let (ch, _rx) = super::DiscordChannel::new_for_test(); // allowlist=None → unauthorized
+        let result = crate::channel::Channel::send_from_agent(
+            &ch,
+            "any-agent",
+            crate::channel::AgentOutboundOp::Reply { text: "hi".into() },
+        );
+        assert!(result.is_err(), "unauthorized channel must reject");
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("outbound disabled"),
+            "error must mention outbound gate, got: {err_msg}"
+        );
     }
 
     /// notify on an unbound instance should error gracefully.

--- a/tests/fixtures/discord-gateway-message-create.json
+++ b/tests/fixtures/discord-gateway-message-create.json
@@ -1,0 +1,29 @@
+{
+  "op": 0,
+  "s": 3,
+  "t": "MESSAGE_CREATE",
+  "d": {
+    "id": "334385199974967042",
+    "channel_id": "290926798999357250",
+    "author": {
+      "id": "82198898841029460",
+      "username": "testoperator",
+      "discriminator": "0",
+      "avatar": null,
+      "bot": false,
+      "global_name": "Test Operator"
+    },
+    "content": "hello from discord",
+    "timestamp": "2026-04-29T12:00:00.000000+00:00",
+    "edited_timestamp": null,
+    "tts": false,
+    "mention_everyone": false,
+    "mentions": [],
+    "mention_roles": [],
+    "attachments": [],
+    "embeds": [],
+    "pinned": false,
+    "type": 0,
+    "guild_id": "987654321098765432"
+  }
+}

--- a/tests/fixtures/discord-rest-create-message-response.json
+++ b/tests/fixtures/discord-rest-create-message-response.json
@@ -1,0 +1,24 @@
+{
+  "id": "444385199974967099",
+  "channel_id": "290926798999357250",
+  "author": {
+    "id": "123456789012345678",
+    "username": "agend-bot",
+    "discriminator": "0",
+    "avatar": null,
+    "bot": true,
+    "global_name": "agend-bot"
+  },
+  "content": "reply from agent",
+  "timestamp": "2026-04-29T12:00:01.000000+00:00",
+  "edited_timestamp": null,
+  "tts": false,
+  "mention_everyone": false,
+  "mentions": [],
+  "mention_roles": [],
+  "attachments": [],
+  "embeds": [],
+  "pinned": false,
+  "type": 0,
+  "guild_id": "987654321098765432"
+}


### PR DESCRIPTION
## Summary

Sprint 32 PR2 — Discord inbound MESSAGE_CREATE + outbound send + notify.

### Changes
- **src/channel/discord.rs** (+248 -11):
  - `map_message_create_to_message_in()`: twilight Message → `ChannelEvent::MessageIn`
  - `map_message_to_msg_ref()`: twilight Message → `MsgRef`
  - `Channel::send()`: resolves `DiscordBindingPayload`, text-only send
  - `Channel::notify()`: lookup instance binding → delegate to send
  - `Channel::send_from_agent(Reply)`: lookup agent binding → delegate to send
  - Fold-in PR1 r2 RECOMMEND: narrowed `pub` → `pub(crate)` on 6 gateway helpers
- **Fixtures** (§3.5.10 wire-format from Discord API spec):
  - `discord-gateway-message-create.json`: MESSAGE_CREATE dispatch event
  - `discord-rest-create-message-response.json`: POST /channels/{id}/messages response

### Test-first (§3.5.11)
- RED commit `84c5adb`: 4 failing tests (compile errors + runtime errors)
- GREEN commit `3c5cea5`: all 13 discord tests pass

### Tests (13 total)
- 9 from PR1 (gateway handshake + contract + caps + poll_event)
- `discord_message_create_emits_message_in` — fixture → MessageIn mapping
- `discord_create_message_response_parses_to_msg_ref` — fixture → MsgRef
- `send_from_agent_reply_errors_on_unbound_instance`
- `notify_errors_on_unbound_instance`

### Verification
- `cargo test --features discord`: 1357 pass, 0 fail
- `cargo fmt`: clean
- Zero Channel trait signature changes (Stage B abort signal clear)

### Not in scope
- No edit/delete outbound (PR3)
- No React/Edit/InjectProvenance ops (PR3)
- No binding lifecycle (PR4)
- No attachments (deferred per TIER-B)

Closes t-20260429072759244506-4