### PR TITLE
docs: ARCHITECTURE-QUICK-START — fix stale invariant-test reference

### DIFF
--- a/docs/ARCHITECTURE-QUICK-START.md
+++ b/docs/ARCHITECTURE-QUICK-START.md
@@ -38,7 +38,7 @@ PTY children are children of the daemon. Daemon dies → PTY dies → all agents
 | **`task` / `decision` / `team` / `schedule` / `ci` / `repo` / `health` / `deployment`** | Action-based CRUD per domain |
 | Direct daemon API | TUI sessions, supervisor (gone), bridges |
 
-26 MCP tools after Sprint 30 consolidation. `src/mcp/tools.rs` is the registry; an invariant test (`tests/mcp_tools_count.rs`) pins the count to catch silent drift.
+26 MCP tools after Sprint 30 consolidation. `src/mcp/tools.rs` is the registry; an inline invariant test `tool_definitions_count_invariant_post_sprint_30` (in the same file's `mod tests`) pins the count to catch silent drift.
 
 ## Where to start reading
 


### PR DESCRIPTION
## Summary

Bonus PR-A from Sprint 33 PLAN review (PR #320 §5 + operator-added bonus scope at 2026-04-29T10:32Z). The "26 MCP tools" line cited `tests/mcp_tools_count.rs`, which **does not exist** — `git log --all --diff-filter=A -- tests/mcp_tools_count.rs` returns empty (per reviewer2 prior-art finding in PR #320). The actual invariant lives inline at `src/mcp/tools.rs::tool_definitions_count_invariant_post_sprint_30` (introduced in commit `4c326a5`).

Citing the function name rather than a line range guards against line-number drift the next time the test moves within the file.

## Test plan

- [x] No `src/` changes — docs-only, `cargo fmt` / `clippy` not required
- [x] Function name cited (not line numbers) so future drift won't re-stale this reference
- [x] Verified `tool_definitions_count_invariant_post_sprint_30` exists in `src/mcp/tools.rs` (currently at L370)
- [ ] Operator review via general (translates to operator) — single-reviewer LOW docs-only self-merge per §3.5.5-extended path used by PR #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)