### PR TITLE
feat: remove [state] suffix from pane titles

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -2141,6 +2141,32 @@ mod tests {
     }
 
     #[test]
+    fn pane_title_no_state_suffix() {
+        let pane = Pane {
+            agent_name: "agent".to_string(),
+            vterm: VTerm::new(10, 10),
+            rx: crossbeam::channel::bounded(1).1,
+            id: 1,
+            backend: Some(crate::backend::Backend::ClaudeCode),
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
+            selection: None,
+            source: PaneSource::Local,
+        };
+        let segments = pane_title_segments(&pane, AgentState::Idle, Style::default());
+        let joined: String = segments.iter().map(|(t, _)| t.as_str()).collect();
+        assert!(
+            !joined.contains("[idle]"),
+            "pane title must not contain state suffix, got: {joined}"
+        );
+    }
+
+    #[test]
     fn main_tui_footer_shows_help_hint() {
         let backend = ratatui::backend::TestBackend::new(100, 3);
         let mut terminal =

--- a/src/render.rs
+++ b/src/render.rs
@@ -536,7 +536,7 @@ fn render_pane(
         (s, s, 1u8)
     };
 
-    let title_segments = pane_title_segments(pane, state, title_style);
+    let title_segments = pane_title_segments(pane, title_style);
 
     // Inner (content) area = outer shrunk 1 cell on every side, matching the
     // former Block::ALL inner. Borders are drawn later in `render_border_grid`
@@ -603,17 +603,9 @@ fn render_pane(
     }
 }
 
-fn pane_title_segments(
-    pane: &crate::layout::Pane,
-    state: AgentState,
-    title_style: Style,
-) -> Vec<(String, Style)> {
+fn pane_title_segments(pane: &crate::layout::Pane, title_style: Style) -> Vec<(String, Style)> {
     let mut segments = Vec::new();
-    let base = if pane.backend.is_some() {
-        format!(" {} [{}]", pane.label(), state.display_name())
-    } else {
-        format!(" {}", pane.label())
-    };
+    let base = format!(" {}", pane.label());
     segments.push((base, title_style));
     if pane.pending_notification_count > 0 {
         segments.push((
@@ -2132,7 +2124,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
         };
-        let segments = pane_title_segments(&pane, AgentState::Idle, Style::default());
+        let segments = pane_title_segments(&pane, Style::default());
         let joined = segments
             .into_iter()
             .map(|(text, _)| text)
@@ -2158,7 +2150,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
         };
-        let segments = pane_title_segments(&pane, AgentState::Idle, Style::default());
+        let segments = pane_title_segments(&pane, Style::default());
         let joined: String = segments.iter().map(|(t, _)| t.as_str()).collect();
         assert!(
             !joined.contains("[idle]"),


### PR DESCRIPTION
## Summary
Remove the AgentState display_name suffix (e.g. `[idle]`, `[ready]`) from pane title bars. Drop the now-unused `state` parameter from `pane_title_segments()`. Border color still reflects state via `state_color()`.

## Sprint 33 PR-1
- PLAN: #320 (merged at 4cc1898)
- Decision: d-20260429101041254472-0
- Task: t-20260429103440013789-3

## Test-first
- RED: 04aaad8 — `pane_title_no_state_suffix` fails with `got: agent [idle]`
- GREEN: cde5a6f — suffix removed, test passes

## What changed
- `src/render.rs`: removed `[state]` format from `pane_title_segments`, dropped `state: AgentState` param
- ~15 LOC net change

## What was NOT touched
- `state_color()` (border coloring)
- `transient_state_badge()` (tab bar crashed/restarting badges)
- `AgentState::display_name()` (10+ other callers)