### PR TITLE
fix: handle_unified_send — map message → task / question

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -691,4 +691,37 @@ mod tests {
         // send_to_instance without sender returns identity error
         assert!(result.get("error").is_some());
     }
+
+    /// Regression: handle_unified_send must map `message` → `task` for
+    /// kind=task, parallel to the existing message → summary mapping for
+    /// kind=report. Without this mapping, callers that send the unified-
+    /// schema `message` field hit "missing 'task'" from the inner handler.
+    #[test]
+    fn send_kind_task_maps_message_field_to_task() {
+        let sender = crate::identity::Sender::new("lead2-test").unwrap();
+        let args = json!({"target_instance": "dev", "message": "do X", "request_kind": "task"});
+        let result = handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+        // Whatever error/success we get, it must NOT be "missing 'task'":
+        // that would mean the field-name mapping never happened.
+        let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+        assert_ne!(
+            err, "missing 'task'",
+            "send(kind=task, message=...) should route message → task; got error={err}"
+        );
+    }
+
+    /// Regression: same shape for kind=query — `message` must map to
+    /// `question` so callers using the unified schema do not hit
+    /// "missing 'question'" from `handle_request_information`.
+    #[test]
+    fn send_kind_query_maps_message_field_to_question() {
+        let sender = crate::identity::Sender::new("lead2-test").unwrap();
+        let args = json!({"target_instance": "dev", "message": "what?", "request_kind": "query"});
+        let result = handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+        let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+        assert_ne!(
+            err, "missing 'question'",
+            "send(kind=query, message=...) should route message → question; got error={err}"
+        );
+    }
 }

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -29,20 +29,26 @@ pub(super) fn handle_unified_send(home: &Path, args: &Value, sender: &Option<Sen
         return handle_broadcast(home, &args, sender);
     }
 
-    // Infer kind from request_kind field or args shape
-    let kind = args["request_kind"].as_str().unwrap_or("");
-    match kind {
-        "task" => handle_delegate_task(home, &args, sender),
-        "report" => {
-            // Map message → summary if summary absent (unified schema compat)
-            if args.get("summary").is_none() {
-                if let Some(msg) = args.get("message").cloned() {
-                    args["summary"] = msg;
-                }
+    fn lift_message(args: &mut Value, dst: &str) {
+        if args.get(dst).is_none() {
+            if let Some(msg) = args.get("message").cloned() {
+                args[dst] = msg;
             }
+        }
+    }
+    match args["request_kind"].as_str().unwrap_or("") {
+        "task" => {
+            lift_message(&mut args, "task");
+            handle_delegate_task(home, &args, sender)
+        }
+        "report" => {
+            lift_message(&mut args, "summary");
             handle_report_result(home, &args, sender)
         }
-        "query" => handle_request_information(home, &args, sender),
+        "query" => {
+            lift_message(&mut args, "question");
+            handle_request_information(home, &args, sender)
+        }
         _ => handle_send_to_instance(home, &args, "send", sender),
     }
 }
@@ -690,38 +696,5 @@ mod tests {
         let result = handle_unified_send(&std::env::temp_dir(), &args, &None);
         // send_to_instance without sender returns identity error
         assert!(result.get("error").is_some());
-    }
-
-    /// Regression: handle_unified_send must map `message` → `task` for
-    /// kind=task, parallel to the existing message → summary mapping for
-    /// kind=report. Without this mapping, callers that send the unified-
-    /// schema `message` field hit "missing 'task'" from the inner handler.
-    #[test]
-    fn send_kind_task_maps_message_field_to_task() {
-        let sender = crate::identity::Sender::new("lead2-test").unwrap();
-        let args = json!({"target_instance": "dev", "message": "do X", "request_kind": "task"});
-        let result = handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
-        // Whatever error/success we get, it must NOT be "missing 'task'":
-        // that would mean the field-name mapping never happened.
-        let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
-        assert_ne!(
-            err, "missing 'task'",
-            "send(kind=task, message=...) should route message → task; got error={err}"
-        );
-    }
-
-    /// Regression: same shape for kind=query — `message` must map to
-    /// `question` so callers using the unified schema do not hit
-    /// "missing 'question'" from `handle_request_information`.
-    #[test]
-    fn send_kind_query_maps_message_field_to_question() {
-        let sender = crate::identity::Sender::new("lead2-test").unwrap();
-        let args = json!({"target_instance": "dev", "message": "what?", "request_kind": "query"});
-        let result = handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
-        let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
-        assert_ne!(
-            err, "missing 'question'",
-            "send(kind=query, message=...) should route message → question; got error={err}"
-        );
     }
 }

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1766,3 +1766,37 @@ fn test_isolation_active_after_setup_recorder() {
         "setup_recorder must set AGEND_TEST_ISOLATION=1"
     );
 }
+
+// --- Sprint 33 Bonus PR-B: handle_unified_send field-name mapping ---
+
+/// Regression: handle_unified_send must map `message` → `task` for
+/// kind=task, parallel to the existing message → summary mapping for
+/// kind=report. Without this mapping, callers using the unified-schema
+/// `message` field hit "missing 'task'" from `handle_delegate_task`.
+#[test]
+fn send_kind_task_maps_message_field_to_task() {
+    let sender = crate::identity::Sender::new("lead2-test").expect("valid sender name");
+    let args = json!({"target_instance": "dev", "message": "do X", "request_kind": "task"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    // Whatever error/success we observe, it must NOT be the field-name bug:
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert_ne!(
+        err, "missing 'task'",
+        "send(kind=task, message=...) should route message → task; got error={err}"
+    );
+}
+
+/// Regression: same shape for kind=query — `message` must map to
+/// `question` so callers using the unified schema do not hit
+/// "missing 'question'" from `handle_request_information`.
+#[test]
+fn send_kind_query_maps_message_field_to_question() {
+    let sender = crate::identity::Sender::new("lead2-test").expect("valid sender name");
+    let args = json!({"target_instance": "dev", "message": "what?", "request_kind": "query"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert_ne!(
+        err, "missing 'question'",
+        "send(kind=query, message=...) should route message → question; got error={err}"
+    );
+}


### PR DESCRIPTION
## Summary

Bonus PR-B from Sprint 33 PLAN review (PR #320 §5 + operator-added bonus scope). Two MCP `request_kind` paths required the unified-schema `message` field but didn't auto-map it the way `kind=report` already did — callers using the documented `send` schema hit `"missing 'task'"` / `"missing 'question'"` from inner handlers.

This was the second-system bug pattern: PR #315 §5 documented the `kind=task` half from the lead2 side; PR #320 §4.4 surfaced the same root pattern for `kind=query` during dispatch of dev2 + reviewer2.

## Changes

`src/mcp/handlers/comms.rs::handle_unified_send`:

- Adds `lift_message(args, dst)` private fn that mirrors the existing `kind=report` mapping pattern.
- Routes `kind=task` through `lift_message(&mut args, "task")` before delegating.
- Routes `kind=query` through `lift_message(&mut args, "question")` before delegating.
- Refactors the existing `kind=report` summary fill to use the same helper for consistency. Behaviour is byte-identical for that path.

Tests live in `src/mcp/handlers/tests.rs` (skipped by `tests/file_size_invariant.rs`'s 700-LOC budget for handler files):

- `send_kind_task_maps_message_field_to_task` — RED-then-GREEN per §3.5.11.
- `send_kind_query_maps_message_field_to_question` — same pattern.

§3.5.11 test-first sequence:
- Commit `c44658e` (RED): tests in `comms.rs` mod tests, fail with `"missing 'task'"` / `"missing 'question'"`.
- Commit `491e86e` (GREEN): impl + move tests to `tests.rs` to keep `comms.rs` under 700-LOC invariant.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` 1226 passed, 0 failed, 6 ignored
- [x] `tests/file_size_invariant.rs` `mcp_handler_files_under_500_loc` passes (`comms.rs` at 700 LOC = max)
- [x] §3.5.11 test-first verifiable: `git checkout c44658e && cargo test send_kind` fails; `git checkout 491e86e && cargo test send_kind` passes
- [ ] CI green on 3 platforms
- [ ] Reviewer attestation per §3.5.13 (single-reviewer Tier-1)
- [ ] Self-merge per operator authorisation

## Path

§3.5.10 wire-format scope (file is in `src/mcp/`). Wire format itself unchanged — the `message` field is already documented in the unified `send` schema; this fix makes the documented path actually work. No new tool, no count invariant change.

§3.5.11 test-first applies (bug fix). RED → GREEN ordering preserved as separate commits in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)