### PR TITLE
feat: remove tool_kill MCP tool + dead supports_fg_pgid

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -350,43 +350,6 @@ pub(crate) fn handle_clear_blocked_reason(params: &Value, ctx: &HandlerCtx) -> V
     }
 }
 
-pub(crate) fn handle_tool_kill(params: &Value, ctx: &HandlerCtx) -> Value {
-    #[cfg(not(unix))]
-    {
-        let _ = (params, ctx);
-        json!({"ok": false, "error": "tool_kill is only supported on Unix (Linux/macOS)"})
-    }
-    #[cfg(unix)]
-    {
-        let name = match params["name"].as_str() {
-            Some(n) => n,
-            None => return json!({"ok": false, "error": "missing 'name'"}),
-        };
-        let reg = agent::lock_registry(ctx.registry);
-        let handle = match reg.get(name) {
-            Some(h) => h,
-            None => return json!({"ok": false, "error": format!("instance '{name}' not found")}),
-        };
-        let master = handle.pty_master.lock();
-        let fd = match master.as_raw_fd() {
-            Some(fd) => fd,
-            None => return json!({"ok": false, "error": "PTY master has no raw fd"}),
-        };
-        let pgid = unsafe { libc::tcgetpgrp(fd) };
-        drop(master);
-        drop(reg);
-        if pgid <= 0 {
-            return json!({"ok": false, "error": format!("tcgetpgrp returned {pgid}")});
-        }
-        let result = unsafe { libc::kill(-pgid, libc::SIGINT) };
-        if result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
-            json!({"ok": true, "pgid": pgid})
-        } else {
-            json!({"ok": false, "error": format!("kill(-{pgid}, SIGINT) failed: {}", std::io::Error::last_os_error())})
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -139,7 +139,6 @@ pub mod method {
     pub const SHUTDOWN: &str = "shutdown";
     pub const SET_BLOCKED_REASON: &str = "set_blocked_reason";
     pub const CLEAR_BLOCKED_REASON: &str = "clear_blocked_reason";
-    pub const TOOL_KILL: &str = "tool_kill";
     pub const MCP_TOOL: &str = "mcp_tool";
     pub const MCP_TOOLS_LIST: &str = "mcp_tools_list";
 }
@@ -319,7 +318,6 @@ fn handle_session(
             method::CLEAR_BLOCKED_REASON => {
                 handlers::instance::handle_clear_blocked_reason(params, &ctx)
             }
-            method::TOOL_KILL => handlers::instance::handle_tool_kill(params, &ctx),
             method::MCP_TOOL => handlers::mcp_proxy::handle_mcp_tool(params, &ctx),
             method::MCP_TOOLS_LIST => handlers::mcp_proxy::handle_mcp_tools_list(params, &ctx),
             method::SHUTDOWN => {

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -52,9 +52,6 @@ pub struct BehavioralConfig {
     /// Whether this backend supports cursor position query (DSR CPR).
     #[allow(dead_code)] // Phase 2 Sprint 28+
     pub supports_cursor_query: bool,
-    /// Whether fg pgid inference is meaningful for this backend.
-    #[allow(dead_code)] // Phase 2 Sprint 28+
-    pub supports_fg_pgid: bool,
 }
 
 impl Default for BehavioralConfig {
@@ -63,7 +60,6 @@ impl Default for BehavioralConfig {
             silence_thinking_ms: 3000,
             silence_idle_ms: 8000,
             supports_cursor_query: false,
-            supports_fg_pgid: false,
         }
     }
 }
@@ -75,31 +71,26 @@ pub fn config_for(backend: &Backend) -> BehavioralConfig {
             silence_thinking_ms: 2000,
             silence_idle_ms: 6000,
             supports_cursor_query: true,
-            supports_fg_pgid: cfg!(unix),
         },
         Backend::KiroCli => BehavioralConfig {
             silence_thinking_ms: 2500,
             silence_idle_ms: 7000,
             supports_cursor_query: true,
-            supports_fg_pgid: cfg!(unix),
         },
         Backend::Codex => BehavioralConfig {
             silence_thinking_ms: 3000,
             silence_idle_ms: 8000,
             supports_cursor_query: false, // bubbletea TUI may not respond to DSR
-            supports_fg_pgid: cfg!(unix),
         },
         Backend::Gemini => BehavioralConfig {
             silence_thinking_ms: 3000,
             silence_idle_ms: 8000,
             supports_cursor_query: false,
-            supports_fg_pgid: cfg!(unix),
         },
         Backend::OpenCode => BehavioralConfig {
             silence_thinking_ms: 3000,
             silence_idle_ms: 8000,
             supports_cursor_query: false,
-            supports_fg_pgid: cfg!(unix),
         },
         Backend::Shell | Backend::Raw(_) => BehavioralConfig::default(),
     }

--- a/src/health.rs
+++ b/src/health.rs
@@ -49,7 +49,7 @@ pub enum HealthState {
     /// Sprint 24 P1 (F-NEW-DAEMON-HEALTH-CLASSIFIER-1): agent is silent
     /// past the hang threshold but **no input is pending past last
     /// response** — typically `Ready` state waiting for next dispatch.
-    /// Cron escalation chains (`interrupt` / `tool_kill` / `replace`)
+    /// Cron escalation chains (`interrupt` / `replace`)
     /// MUST NOT trigger on this state; only `Hung` is escalation-worthy.
     /// Closes the operator 04:00 UTC false-alarm pattern where impl-1's
     /// 30-min idle-waiting was mis-classified as `Hung`.
@@ -207,7 +207,7 @@ impl HealthTracker {
     ///
     /// Returns `true` ONLY when transitioning **into** [`HealthState::Hung`]
     /// (the escalation-worthy state). [`HealthState::IdleLong`] transitions
-    /// return `false` so cron escalation consumers (interrupt / tool_kill
+    /// return `false` so cron escalation consumers (interrupt
     /// / replace) keep their existing semantics — they only act on `Hung`.
     pub fn check_hang(
         &mut self,

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -313,47 +313,6 @@ pub(super) fn handle_interrupt(home: &Path, args: &Value) -> Value {
     }
 }
 
-pub(super) fn handle_tool_kill(home: &Path, args: &Value) -> Value {
-    #[cfg(not(unix))]
-    {
-        let _ = (home, args);
-        json!({"error": "tool_kill is only supported on Unix (Linux/macOS)"})
-    }
-    #[cfg(unix)]
-    {
-        let target = match args["target"].as_str() {
-            Some(t) => t,
-            None => return json!({"error": "missing 'target'"}),
-        };
-        if let Err(e) = crate::agent::validate_name(target) {
-            return json!({"error": e});
-        }
-        let reason = args["reason"].as_str().unwrap_or("");
-        match crate::api::call(
-            home,
-            &json!({
-                "method": crate::api::method::TOOL_KILL,
-                "params": {"name": target}
-            }),
-        ) {
-            Ok(resp) if resp["ok"].as_bool() == Some(true) => {
-                let pgid = resp["pgid"].as_i64().unwrap_or(0) as i32;
-                crate::event_log::log(
-                    home,
-                    "tool_kill_invoked",
-                    target,
-                    &super::build_tool_kill_audit(reason, pgid),
-                );
-                super::build_tool_kill_result(target, pgid, reason)
-            }
-            Ok(resp) => {
-                json!({"error": resp["error"].as_str().unwrap_or("tool_kill failed")})
-            }
-            Err(e) => json!({"error": format!("tool_kill failed: {e}")}),
-        }
-    }
-}
-
 pub(super) fn handle_set_waiting_on(
     home: &Path,
     args: &Value,

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -36,22 +36,6 @@ fn err_needs_identity(tool: &str) -> Value {
     })
 }
 
-/// Pure function: build tool_kill success response.
-#[cfg(unix)]
-pub(crate) fn build_tool_kill_result(target: &str, pgid: i32, reason: &str) -> Value {
-    let mut result = json!({"ok": true, "target": target, "pgid": pgid});
-    if !reason.is_empty() {
-        result["reason"] = json!(reason);
-    }
-    result
-}
-
-/// Pure function: build tool_kill audit log detail string.
-#[cfg(unix)]
-pub(crate) fn build_tool_kill_audit(reason: &str, pgid: i32) -> String {
-    format!("reason={reason}, pgid={pgid}")
-}
-
 /// Build the INJECT API params for an interrupt ESC byte injection.
 /// Extracted for testability — unit tests verify the exact params
 /// without needing a running daemon.
@@ -119,7 +103,6 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         "set_display_name" => instance::handle_set_display_name(&home, args, instance_name),
         "set_description" => instance::handle_set_description(&home, args, instance_name),
         "interrupt" => instance::handle_interrupt(&home, args),
-        "tool_kill" => instance::handle_tool_kill(&home, args),
         "set_waiting_on" => instance::handle_set_waiting_on(&home, args, instance_name, &sender),
         "move_pane" => instance::handle_move_pane(&home, args),
         // Consolidated: health action=report/clear

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1494,48 +1494,6 @@ fn test_old_inbox_json_with_interrupt_meta_deserializes_into_force_meta() {
     assert!(!meta.forced_at.is_empty());
 }
 
-// --- Sprint 11: tool_kill pure function tests ---
-
-#[test]
-#[cfg(unix)]
-fn test_tool_kill_result_includes_pgid_and_target() {
-    let result = build_tool_kill_result("agent1", 12345, "");
-    assert_eq!(result["ok"], true);
-    assert_eq!(result["target"], "agent1");
-    assert_eq!(result["pgid"], 12345);
-    assert!(result["reason"].is_null(), "empty reason must not appear");
-}
-
-#[test]
-#[cfg(unix)]
-fn test_tool_kill_result_includes_reason_when_provided() {
-    let result = build_tool_kill_result("agent1", 12345, "stuck on cargo test");
-    assert_eq!(result["reason"], "stuck on cargo test");
-}
-
-#[test]
-#[cfg(unix)]
-fn test_tool_kill_audit_format() {
-    let audit = build_tool_kill_audit("priority task", 42);
-    assert!(audit.contains("reason=priority task"), "audit: {audit}");
-    assert!(audit.contains("pgid=42"), "audit: {audit}");
-}
-
-#[test]
-fn test_tool_kill_target_not_found_returns_error() {
-    let _g = fleet_test_guard();
-    let home = tmp_home("tool-kill-notfound");
-    std::env::set_var("AGEND_HOME", &home);
-    // No fleet.yaml → target doesn't exist
-    let result = handle_tool("tool_kill", &json!({"target": "ghost"}), "sender");
-    assert!(
-        result.get("error").is_some(),
-        "tool_kill to nonexistent target must error: {result}"
-    );
-    std::env::remove_var("AGEND_HOME");
-    std::fs::remove_dir_all(&home).ok();
-}
-
 // ─── Team auto-attach tests (Sprint 14 PR-AL) ────────────────────
 
 #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -99,11 +99,6 @@ fn instance_tools() -> Vec<Value> {
                 "target": {"type": "string", "description": "Target instance name"},
                 "reason": {"type": "string", "description": "Optional follow-up message to inject after ESC"}
             }, "required": ["target"]}}),
-        json!({"name": "tool_kill", "description": "Send SIGINT to target agent's PTY foreground process group, cancelling active tool subprocess while preserving agent session. Unix only.",
-            "inputSchema": {"type": "object", "properties": {
-                "target": {"type": "string", "description": "Target instance name"},
-                "reason": {"type": "string", "description": "Optional reason for audit log"}
-            }, "required": ["target"]}}),
         json!({"name": "set_display_name", "description": "Set your display name.",
             "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}),
         json!({"name": "set_description", "description": "Set a description for this instance.",
@@ -372,8 +367,8 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            26,
-            "Sprint 30 wave-1 final tool count = 26 unified. \
+            25,
+            "Sprint 33 tool count = 25. \
              Adding/removing a tool requires updating this assertion. \
              Current tools: {:?}",
             tools


### PR DESCRIPTION
## Summary
Remove the `tool_kill` MCP tool, its API handler, dispatch arms, helper functions, tests, and the dead `supports_fg_pgid` metadata field.

## Sprint 33 PR-2
- PLAN: #320 (merged at 4cc1898)
- Decision: d-20260429101041254472-0
- Task: t-20260429105544649849-4

## Pure deletion (§3.5.11 #6)
No test-first RED commit needed — this is a pure removal with grep-verifiable 0-hit attestation:
- `grep -rn 'tool_kill|TOOL_KILL|build_tool_kill' src/ → 0 hits`
- `grep -rn 'supports_fg_pgid' src/ → 0 hits`

## What was removed (8 files, -157 LOC net)
- `src/mcp/tools.rs`: tool definition + count invariant 26→25
- `src/mcp/handlers/mod.rs`: build_tool_kill_result/audit helpers + dispatch arm
- `src/mcp/handlers/instance.rs`: handle_tool_kill MCP handler
- `src/mcp/handlers/tests.rs`: 4 tool_kill tests
- `src/api/mod.rs`: TOOL_KILL const + dispatch arm
- `src/api/handlers/instance.rs`: handle_tool_kill API handler (libc::kill(-pgid, SIGINT))
- `src/behavioral.rs`: supports_fg_pgid field + 6 backend initializers
- `src/health.rs`: doc comment references (text only)

## What was kept (not tool_kill-specific)
- `verify_tcgetpgrp` in backend_harness.rs (behavioral test utility)
- `process.rs` killpg/SIGTERM (shutdown)
- `connect.rs`/`signals.rs` SIGINT/SIGTERM handlers
- `api/mod.rs:348` kill(pid, 0) liveness check