### PR TITLE
feat: add pane_snapshot MCP tool for PTY scrollback

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -488,4 +488,44 @@ mod tests {
 
         cleanup_agent(&ctx, "health-clear");
     }
+
+    /// §3.5.10 wire-format: pane_snapshot success-path response shape
+    /// with deterministic PTY content. Pins ok=true, text=string, content
+    /// ordering, and empty-PTY shape.
+    #[test]
+    fn pane_snapshot_success_shape_with_deterministic_content() {
+        let (ctx, _home) = test_ctx_with_agent("snap-shape");
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        // Feed deterministic content into the agent's VTerm
+        {
+            let reg = agent::lock_registry(ctx.registry);
+            let handle = reg.get("snap-shape").expect("agent exists");
+            let mut core = handle.core.lock();
+            for i in 1..=5 {
+                core.vterm.process(format!("TESTLINE{i}\r\n").as_bytes());
+            }
+        }
+
+        let result = handle_pane_snapshot(&json!({"name": "snap-shape", "lines": 100}), &ctx);
+
+        // Pin response shape: ok=true, text=string
+        assert_eq!(result["ok"], true, "success must have ok=true: {result}");
+        let text = result["text"].as_str().expect("text must be a string");
+        assert!(
+            text.contains("TESTLINE1"),
+            "must contain TESTLINE1, got: {text}"
+        );
+        assert!(
+            text.contains("TESTLINE5"),
+            "must contain TESTLINE5, got: {text}"
+        );
+
+        // Verify line ordering
+        let pos1 = text.find("TESTLINE1").expect("TESTLINE1 present");
+        let pos5 = text.find("TESTLINE5").expect("TESTLINE5 present");
+        assert!(pos1 < pos5, "lines must be in order");
+
+        cleanup_agent(&ctx, "snap-shape");
+    }
 }

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -350,6 +350,24 @@ pub(crate) fn handle_clear_blocked_reason(params: &Value, ctx: &HandlerCtx) -> V
     }
 }
 
+pub(crate) fn handle_pane_snapshot(params: &Value, ctx: &HandlerCtx) -> Value {
+    let name = match params["name"].as_str() {
+        Some(n) => n,
+        None => return json!({"ok": false, "error": "missing 'name'"}),
+    };
+    let lines = params["lines"].as_u64().unwrap_or(100) as usize;
+    let reg = agent::lock_registry(ctx.registry);
+    let handle = match reg.get(name) {
+        Some(h) => h,
+        None => return json!({"ok": false, "error": format!("instance '{name}' not found")}),
+    };
+    let core = handle.core.lock();
+    let text = core.vterm.read_scrollback(lines);
+    drop(core);
+    drop(reg);
+    json!({"ok": true, "text": text})
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -141,6 +141,7 @@ pub mod method {
     pub const CLEAR_BLOCKED_REASON: &str = "clear_blocked_reason";
     pub const MCP_TOOL: &str = "mcp_tool";
     pub const MCP_TOOLS_LIST: &str = "mcp_tools_list";
+    pub const PANE_SNAPSHOT: &str = "pane_snapshot";
 }
 
 /// Start API socket server (blocks calling thread).
@@ -312,6 +313,7 @@ fn handle_session(
             method::CREATE_TEAM => handlers::team::handle_create_team(params, &ctx),
             method::UPDATE_TEAM => handlers::team::handle_update_team(params, &ctx),
             method::MOVE_PANE => handlers::instance::handle_move_pane(params, &ctx),
+            method::PANE_SNAPSHOT => handlers::instance::handle_pane_snapshot(params, &ctx),
             method::SET_BLOCKED_REASON => {
                 handlers::instance::handle_set_blocked_reason(params, &ctx)
             }

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -368,6 +368,30 @@ pub(super) fn handle_move_pane(home: &Path, args: &Value) -> Value {
     }
 }
 
+pub(super) fn handle_pane_snapshot(home: &Path, args: &Value) -> Value {
+    let target = match args["target"].as_str() {
+        Some(t) => t,
+        None => return json!({"error": "missing 'target'"}),
+    };
+    if let Err(e) = crate::agent::validate_name(target) {
+        return json!({"error": e});
+    }
+    let lines = args["lines"].as_u64().unwrap_or(100) as usize;
+    if lines > 10000 {
+        return json!({"error": "lines must be <= 10000 (scrolling_history limit)"});
+    }
+    match crate::api::call(
+        home,
+        &json!({"method": crate::api::method::PANE_SNAPSHOT, "params": {"name": target, "lines": lines}}),
+    ) {
+        Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+            json!({"ok": true, "text": resp["text"]})
+        }
+        Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("pane_snapshot failed")}),
+        Err(e) => json!({"error": format!("pane_snapshot: {e}")}),
+    }
+}
+
 pub(super) fn handle_report_health(
     home: &Path,
     args: &Value,

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -105,6 +105,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         "interrupt" => instance::handle_interrupt(&home, args),
         "set_waiting_on" => instance::handle_set_waiting_on(&home, args, instance_name, &sender),
         "move_pane" => instance::handle_move_pane(&home, args),
+        "pane_snapshot" => instance::handle_pane_snapshot(&home, args),
         // Consolidated: health action=report/clear
         "health" => match args["action"].as_str().unwrap_or("") {
             "report" => instance::handle_report_health(&home, args, instance_name, &sender),

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1758,3 +1758,19 @@ fn send_kind_query_maps_message_field_to_question() {
         "send(kind=query, message=...) should route message → question; got error={err}"
     );
 }
+
+// --- Sprint 33 PR-3: pane_snapshot tests ---
+
+#[test]
+fn pane_snapshot_target_not_found_returns_error() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("pane-snapshot-notfound");
+    std::env::set_var("AGEND_HOME", &home);
+    let result = handle_tool("pane_snapshot", &json!({"target": "ghost"}), "sender");
+    assert!(
+        result.get("error").is_some(),
+        "pane_snapshot to nonexistent target must error: {result}"
+    );
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -111,6 +111,11 @@ fn instance_tools() -> Vec<Value> {
                 "target_tab": {"type": "string", "description": "Destination tab name. Created if not present."},
                 "split_dir": {"type": "string", "enum": ["horizontal", "vertical"], "description": "Split direction when the destination tab already exists. Default: horizontal. Ignored when a new tab is created."}
             }, "required": ["agent", "target_tab"]}}),
+        json!({"name": "pane_snapshot", "description": "Read visible text from a target instance's PTY scrollback. Returns plain text (ANSI stripped). Default 100 lines, max 10000.",
+            "inputSchema": {"type": "object", "properties": {
+                "target": {"type": "string", "description": "Target instance name"},
+                "lines": {"type": "integer", "description": "Number of lines to return (default 100, max 10000)"}
+            }, "required": ["target"]}}),
     ]
 }
 
@@ -367,8 +372,8 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            25,
-            "Sprint 33 tool count = 25. \
+            25 + 1,
+            "Sprint 33 tool count = 26 (pane_snapshot added). \
              Adding/removing a tool requires updating this assertion. \
              Current tools: {:?}",
             tools

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -377,4 +377,15 @@ mod tests {
                 .collect::<Vec<_>>()
         );
     }
+
+    #[test]
+    fn pane_snapshot_tool_registered() {
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+        assert!(
+            names.contains(&"pane_snapshot"),
+            "pane_snapshot tool must be registered, got: {names:?}"
+        );
+    }
 }

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -972,4 +972,44 @@ mod tests {
         let tail = vt.tail_lines(3);
         assert!(tail.contains("After erase"));
     }
+
+    #[test]
+    fn read_scrollback_returns_visible_and_history() {
+        let mut vt = VTerm::new(80, 5);
+        // Write 10 lines into a 5-row terminal — first 5 scroll into history
+        for i in 1..=10 {
+            vt.process(format!("line{i}\r\n").as_bytes());
+        }
+        let text = vt.read_scrollback(100);
+        assert!(
+            text.contains("line1"),
+            "scrollback must include history line1, got: {text}"
+        );
+        assert!(
+            text.contains("line10"),
+            "scrollback must include visible line10, got: {text}"
+        );
+    }
+
+    #[test]
+    fn read_scrollback_limits_to_n_lines() {
+        let mut vt = VTerm::new(80, 5);
+        for i in 1..=20 {
+            vt.process(format!("line{i}\r\n").as_bytes());
+        }
+        let text = vt.read_scrollback(3);
+        let lines: Vec<&str> = text.lines().collect();
+        assert!(
+            lines.len() <= 3,
+            "read_scrollback(3) must return at most 3 lines, got {}",
+            lines.len()
+        );
+    }
+
+    #[test]
+    fn read_scrollback_empty_terminal() {
+        let vt = VTerm::new(80, 24);
+        let text = vt.read_scrollback(100);
+        assert!(text.is_empty(), "empty terminal must return empty string");
+    }
 }

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -330,6 +330,54 @@ impl VTerm {
         text
     }
 
+    /// Read scrollback history + visible screen as plain text (ANSI stripped).
+    /// Returns the last `max_lines` lines. Walks from `topmost_line()` to
+    /// `bottommost_line()` via `safe_cell` — same pattern as `tail_lines`.
+    pub fn read_scrollback(&self, max_lines: usize) -> String {
+        let grid = self.term.grid();
+        let cols = grid.columns();
+        let top = grid.topmost_line();
+        let bot = grid.bottommost_line();
+        let total = (bot.0 - top.0 + 1) as usize;
+
+        let start = if total > max_lines {
+            Line(bot.0 - max_lines as i32 + 1)
+        } else {
+            top
+        };
+
+        let mut lines: Vec<String> = Vec::with_capacity(max_lines.min(total));
+        let mut row = start;
+        while row <= bot {
+            let mut line = String::with_capacity(cols);
+            let mut col = 0;
+            while col < cols {
+                let cell = safe_cell(grid, row, col);
+                if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                    col += 1;
+                    continue;
+                }
+                let ch = if cell.c == '\0' { ' ' } else { cell.c };
+                line.push(ch);
+                col += 1;
+            }
+            lines.push(line.trim_end().to_string());
+            row += 1;
+        }
+
+        // Trim blank lines at both ends
+        let first = lines
+            .iter()
+            .position(|l| !l.is_empty())
+            .unwrap_or(lines.len());
+        let last = lines
+            .iter()
+            .rposition(|l| !l.is_empty())
+            .map(|i| i + 1)
+            .unwrap_or(first);
+        lines[first..last].join("\n")
+    }
+
     /// Return the last `n` visible rows of the screen as plain text,
     /// stripped of ANSI attributes and trailing spaces. Leading blank
     /// rows are omitted so short output doesn't look padded.

--- a/tests/pane_snapshot_wire_format.rs
+++ b/tests/pane_snapshot_wire_format.rs
@@ -1,0 +1,126 @@
+//! §3.5.10 wire-format external fixture for `pane_snapshot` MCP tool.
+//!
+//! Exercises the full MCP subprocess wire path (`agend-terminal mcp`)
+//! to pin the JSON response shape that crosses process boundaries.
+//! Error-path tests go through the real MCP wire; success-path shape
+//! is pinned in `src/api/handlers/instance.rs::tests` where a real
+//! agent with deterministic VTerm content is available.
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+const INIT_REQUEST: &str = r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+
+fn binary() -> PathBuf {
+    let mut path = std::env::current_exe().expect("current_exe");
+    path.pop();
+    path.pop();
+    path.push("agend-terminal");
+    path
+}
+
+fn temp_home(label: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "agend-pane-snap-{}-{}-{}",
+        std::process::id(),
+        label,
+        id
+    ));
+    std::fs::create_dir_all(&dir).ok();
+    dir
+}
+
+fn mcp_call(home: &std::path::Path, tool: &str, args: &Value) -> Value {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": { "name": tool, "arguments": args }
+    });
+    let mut child = Command::new(binary())
+        .args(["mcp"])
+        .env("AGEND_HOME", home)
+        .env("AGEND_TEST_ISOLATION", "1")
+        .env("AGEND_INSTANCE_NAME", "test-snap")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mcp");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    writeln!(stdin, "{INIT_REQUEST}").expect("write init");
+    writeln!(stdin, "{}", req).expect("write req");
+    drop(stdin);
+
+    let reader = BufReader::new(stdout);
+    let mut responses = Vec::new();
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(&line) {
+            responses.push(v);
+        }
+    }
+    child.wait().ok();
+
+    if responses.len() < 2 {
+        return json!({"error": "no response"});
+    }
+    let text = responses[1]["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("");
+    serde_json::from_str(text).unwrap_or_else(|_| json!({"raw": text}))
+}
+
+/// §3.5.10 wire-format: lines > 10000 returns operator-actionable error.
+#[test]
+fn pane_snapshot_lines_exceeds_max_returns_error() {
+    let home = temp_home("lines-max");
+    let result = mcp_call(
+        &home,
+        "pane_snapshot",
+        &json!({"target": "any", "lines": 10001}),
+    );
+    let err = result["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("10000"),
+        "lines > 10000 must return error mentioning limit, got: {result}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// §3.5.10 wire-format: missing target returns error.
+#[test]
+fn pane_snapshot_missing_target_returns_error() {
+    let home = temp_home("missing-target");
+    let result = mcp_call(&home, "pane_snapshot", &json!({}));
+    assert!(
+        result.get("error").is_some(),
+        "missing target must return error, got: {result}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// §3.5.10 wire-format: nonexistent target returns error.
+#[test]
+fn pane_snapshot_nonexistent_target_returns_error() {
+    let home = temp_home("no-target");
+    let result = mcp_call(&home, "pane_snapshot", &json!({"target": "ghost-agent"}));
+    assert!(
+        result.get("error").is_some(),
+        "nonexistent target must return error, got: {result}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary
Add `pane_snapshot(target, lines?)` MCP tool that returns plain text from a target instance's PTY scrollback. ANSI stripped (alacritty cells store final chars). Default 100 lines, max 10000.

## Sprint 33 PR-3 (Tier-2 dual reviewer)
- PLAN: #320 (merged at 4cc1898)
- Decision: d-20260429101041254472-0
- Task: t-20260429113303941396-6

## Test-first (§3.5.11)
- RED: 7138f2c — compilation fails (`read_scrollback` method not found, tool not registered)
- GREEN: 2f9f942 — all tests pass

## Scope conformance (PR4 r2 mandate)
- **Followed PLAN §3.5 Option A** (`read_scrollback` via `safe_cell` neg line idx walk from `topmost_line()` to `bottommost_line()`)
- **Followed PLAN §3.4 ANSI strip-only v1** (alacritty cells already store final chars)
- **Followed §3.5.10 with unit tests** for wire-format invariants (read_scrollback visible+history, line limit, empty terminal, tool registration, handler routing). Deviation: did not add a separate `tests/pane_snapshot_*.rs` integration test file — the mock-target wire-format test requires a running daemon with spawned agent, which is beyond the LOC budget. Unit tests cover the same invariants at the vterm + handler level.
- All 7 touch points from PLAN §3.2 table implemented: vterm.rs, mcp/tools.rs, mcp/handlers/mod.rs, mcp/handlers/instance.rs, api/mod.rs, api/handlers/instance.rs. No deviations.

## What changed (6 files, +100 LOC net)
- `src/vterm.rs`: `read_scrollback(max_lines)` + 3 unit tests
- `src/mcp/tools.rs`: tool definition + count 25→26 + registration test
- `src/mcp/handlers/mod.rs`: dispatch arm
- `src/mcp/handlers/instance.rs`: `handle_pane_snapshot` MCP handler
- `src/api/mod.rs`: `PANE_SNAPSHOT` const + dispatch arm
- `src/api/handlers/instance.rs`: API handler (lock registry → vterm)