### PR TITLE
feat: fix thinking patterns for claude/kiro/codex

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -2475,4 +2475,82 @@ mod tests {
             );
         }
     }
+
+    // --- Sprint 34 PR-1: thinking pattern fixture tests ---
+
+    #[test]
+    fn claude_spinner_verb_triggers_thinking() {
+        let mut vt = VTerm::new(80, 24);
+        let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
+        drive(&mut vt, &mut st, b"bypass permissions\r\n");
+        assert_eq!(st.get_state(), AgentState::Ready);
+        // Claude spinner uses random verbs, not "Thinking"
+        drive(&mut vt, &mut st, b"Cogitating\xe2\x80\xa6\r\n");
+        assert_eq!(
+            st.get_state(),
+            AgentState::Thinking,
+            "claude spinner verb 'Cogitating' must trigger Thinking"
+        );
+    }
+
+    #[test]
+    fn claude_thought_for_triggers_thinking() {
+        let mut vt = VTerm::new(80, 24);
+        let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
+        drive(&mut vt, &mut st, b"bypass permissions\r\n");
+        assert_eq!(st.get_state(), AgentState::Ready);
+        // Post-thinking summary line
+        drive(&mut vt, &mut st, b"thought for 12s\r\n");
+        assert_eq!(
+            st.get_state(),
+            AgentState::Thinking,
+            "claude 'thought for Ns' must trigger Thinking"
+        );
+    }
+
+    #[test]
+    fn kiro_working_triggers_thinking() {
+        let mut vt = VTerm::new(80, 24);
+        let mut st = StateTracker::new(Some(&Backend::KiroCli));
+        drive(&mut vt, &mut st, b"Trust All Tools active\r\n");
+        assert_eq!(st.get_state(), AgentState::Ready);
+        // Kiro shows "Kiro is working" during generation
+        drive(&mut vt, &mut st, b"Kiro is working\r\n  esc to cancel\r\n");
+        assert_eq!(
+            st.get_state(),
+            AgentState::Thinking,
+            "kiro 'Kiro is working' must trigger Thinking"
+        );
+    }
+
+    #[test]
+    fn codex_working_triggers_thinking() {
+        let mut vt = VTerm::new(80, 24);
+        let mut st = StateTracker::new(Some(&Backend::Codex));
+        drive(&mut vt, &mut st, b"OpenAI Codex gpt-4.1 left\r\n");
+        assert_eq!(st.get_state(), AgentState::Ready);
+        // Codex shows "Working (Ns • esc to interrupt)"
+        drive(
+            &mut vt,
+            &mut st,
+            b"\xc2\xb7 Working (3s \xe2\x80\xa2 esc to interrupt)\r\n",
+        );
+        assert_eq!(
+            st.get_state(),
+            AgentState::Thinking,
+            "codex 'Working' or 'esc to interrupt' must trigger Thinking"
+        );
+    }
+
+    #[test]
+    fn kiro_literal_thinking_in_chat_does_not_trigger() {
+        // After pattern change, "Thinking" alone should NOT trigger on kiro
+        let patterns = StatePatterns::for_backend(&Backend::KiroCli);
+        let detected = patterns.detect("The agent was Thinking about the problem");
+        assert_ne!(
+            detected,
+            Some(AgentState::Thinking),
+            "literal 'Thinking' in chat must not trigger Thinking on kiro"
+        );
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -159,8 +159,13 @@ impl StatePatterns {
                     r"Esc to cancel · Tab to amend|Do you want to |allow all edits during this session|Allow once|Allow always|approve",
                 ),
                 // [estimated] Ink render during processing
-                (AgentState::Thinking, r"Thinking"),
-                // [measured] Completion glyph `⏺` (U+23FA RECORD) prefixes
+                // [measured] Claude spinner uses random verbs (Cogitating,
+                // Bloviating, Transmuting, etc.) — not "Thinking". The
+                // `thought for Ns` anchor catches post-thinking summary.
+                (
+                    AgentState::Thinking,
+                    r"(?i)(Bloviating|Transmuting|Cogitating|Cooked|Brewed|Worked|Cogitated|Crunched|Brewing)|thought for [0-9]+s",
+                ),
                 // tool-name banners like `⏺ Write(...)` in 2.1.98. Previously
                 // only `●` (U+25CF) was in the class, so `⏺ Write(...)` lines
                 // never matched — see docs/archived/FOLLOWUP-tooluse-pattern-gaps.md.
@@ -220,10 +225,10 @@ impl StatePatterns {
                     AgentState::ToolUse,
                     r"●\s+(Read|Write|Edit|Bash|Grep|Glob|Task|List|Search)\b|execute_bash|fs_read|fs_write",
                 ),
-                // [measured] Kiro prints the word "Thinking" during generation
-                // (captured live 2026-04-20, 23 occurrences in a short session).
-                // Earlier pattern "Generating" never matched real output.
-                (AgentState::Thinking, r"Thinking"),
+                // [measured] Kiro shows "Kiro is working" + "esc to cancel"
+                // during generation. Earlier "Thinking" pattern no longer
+                // matches current kiro-cli versions.
+                (AgentState::Thinking, r"Kiro is working|esc to cancel"),
                 // [measured] Idle prompt
                 (
                     AgentState::Idle,
@@ -285,8 +290,10 @@ impl StatePatterns {
                     AgentState::ToolUse,
                     r"└\s+(Read|Write|Edit|List|Bash|Search|Apply|Ran)\b|•\s+(Explored|Edited|Ran)\b|apply_patch",
                 ),
-                // [estimated] Processing state
-                (AgentState::Thinking, r"Thinking"),
+                // [measured] Codex shows "◦ Working (Ns • esc to interrupt)"
+                // during generation. Both "Working" and "esc to interrupt"
+                // are stable anchors.
+                (AgentState::Thinking, r"Working|esc to interrupt"),
                 // [measured] Prompt symbol + model info in status
                 (AgentState::Idle, r"›"),
                 // [measured] Version + model display
@@ -1994,13 +2001,13 @@ mod tests {
 
     #[test]
     fn pipeline_kiro_thinking_via_vterm() {
-        // Regression for BUG 3: kiro-cli prints the literal word "Thinking"
-        // during generation. The old pattern "Generating" never fired.
+        // Sprint 34 PR-1: kiro-cli now shows "Kiro is working" during
+        // generation, not "Thinking". Updated from old pattern.
         let mut vt = VTerm::new(80, 24);
         let mut st = StateTracker::new(Some(&Backend::KiroCli));
         drive(&mut vt, &mut st, b"ask a question or describe a task\r\n");
         assert_eq!(st.get_state(), AgentState::Idle);
-        drive(&mut vt, &mut st, b"Thinking...\r\n");
+        drive(&mut vt, &mut st, b"Kiro is working\r\n");
         assert_eq!(st.get_state(), AgentState::Thinking);
     }
 


### PR DESCRIPTION
## Summary
Fix thinking state detection for 3 backends whose PTY output doesn't contain the literal word "Thinking".

## Sprint 34 PR-1 (Tier-1)
- PLAN: #327 (merged at c2be409)
- Decision: d-20260429131802690628-0
- Task: t-20260429140412294488-0

## Test-first (§3.5.11)
- RED: 5b702fc — 4 tests fail (patterns don't match new fixtures)
- GREEN: f30aaa8 — all tests pass

## Scope conformance
- Followed PLAN §3.1 spec: claude verb list + `thought for` dual anchor (`(?i)(Bloviating|Transmuting|...)|thought for [0-9]+s`)
- Followed PLAN §3.1 spec: kiro `Kiro is working|esc to cancel`
- Followed PLAN §3.1 spec: codex `Working|esc to interrupt` at line 289
- Followed §3.5.10 with `state::tests::claude_spinner_verb_triggers_thinking`, `claude_thought_for_triggers_thinking`, `kiro_working_triggers_thinking`, `codex_working_triggers_thinking`, `kiro_literal_thinking_in_chat_does_not_trigger`
- Followed §3.5.11 RED-then-GREEN: 5b702fc failed; f30aaa8 passes
- Fixture-gate: `thought for Ns` included as insurance. Best evidence from operator hands-on. Limitation noted in commit message.

## What changed (1 file, +18/-11 LOC)
- `src/state.rs:162`: claude thinking pattern → verb list + thought-for
- `src/state.rs:226`: kiro thinking pattern → Kiro is working|esc to cancel
- `src/state.rs:289`: codex thinking pattern → Working|esc to interrupt
- Updated existing `pipeline_kiro_thinking_via_vterm` test
- 5 new fixture tests