### PR TITLE
feat: fix claude ToolUse pattern — line-anchored

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -174,7 +174,7 @@ impl StatePatterns {
                 // the completion banner — covered by the alternation below.
                 (
                     AgentState::ToolUse,
-                    r"[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✓●⏺].*(Read|Bash|Edit|Write|Grep|Glob|Listing|Reading|Writing|Searching|Editing)",
+                    r"(?m)^[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✓●⏺]\s+(Read|Bash|Edit|Write|Grep|Glob|Listing|Reading|Writing|Searching|Editing)\b",
                 ),
                 // [measured] Prompt symbol in idle state
                 (AgentState::Idle, r"❯"),
@@ -1330,7 +1330,8 @@ mod tests {
     #[test]
     fn claude_tooluse_spinner_match() {
         let patterns = StatePatterns::for_backend(&Backend::ClaudeCode);
-        let detected = patterns.detect("⠋Read file.txt");
+        // Real claude format: spinner glyph + space + tool name
+        let detected = patterns.detect("⠋ Read file.txt");
         assert_eq!(detected, Some(AgentState::ToolUse));
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -2560,4 +2560,45 @@ mod tests {
             "literal 'Thinking' in chat must not trigger Thinking on kiro"
         );
     }
+
+    // --- Sprint 34 PR-2: ToolUse anchor fixture tests ---
+
+    #[test]
+    fn claude_tool_banner_at_line_start_triggers_tooluse() {
+        let patterns = StatePatterns::for_backend(&Backend::ClaudeCode);
+        assert_eq!(
+            patterns.detect("⏺ Bash(echo hi)"),
+            Some(AgentState::ToolUse),
+            "line-start tool banner must trigger ToolUse"
+        );
+        assert_eq!(
+            patterns.detect("⏺ Read(README.md)"),
+            Some(AgentState::ToolUse),
+            "line-start Read banner must trigger ToolUse"
+        );
+        assert_eq!(
+            patterns.detect("● Listing files..."),
+            Some(AgentState::ToolUse),
+            "spinner + in-flight verb must trigger ToolUse"
+        );
+    }
+
+    #[test]
+    fn claude_chat_with_glyph_does_not_trigger_tooluse() {
+        let mut vt = VTerm::new(80, 24);
+        let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
+        drive(&mut vt, &mut st, b"bypass permissions\r\n");
+        assert_eq!(st.get_state(), AgentState::Ready);
+        // Chat content with glyph + tool name elsewhere on the line
+        drive(
+            &mut vt,
+            &mut st,
+            "⏺ 已拒絕 general 的請求並回報原因：該指令違反 Bash 工具規範\r\n".as_bytes(),
+        );
+        assert_ne!(
+            st.get_state(),
+            AgentState::ToolUse,
+            "chat content with glyph + distant tool name must NOT trigger ToolUse"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Replace greedy `.*` in claude ToolUse regex with `(?m)^` line-start anchor + `\s+` space + `\b` word boundary. Prevents false-positive ToolUse from chat content.

## Sprint 34 PR-2 (Tier-1)
- PLAN: #327, Decision: d-20260429131802690628-0
- Task: t-20260429142950849159-1

## Test-first (§3.5.11)
- RED: 5050828 — negative test fails (greedy .* matches chat as ToolUse)
- GREEN: HEAD — all tests pass

## Scope conformance
- Followed PLAN §3.2 spec: `(?m)^[glyph]\s+(tools)\b` at src/state.rs:175-178
- Followed §3.5.10 with `claude_tool_banner_at_line_start_triggers_tooluse` (positive) + `claude_chat_with_glyph_does_not_trigger_tooluse` (negative)
- Followed §3.5.11 RED-then-GREEN: 5050828 failed; HEAD passes
- Updated existing `claude_tooluse_spinner_match` to use space (matches real format)
- No deviations