### PR TITLE
feat: add RateLimit expiry (5 min self-recovery)

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -574,6 +574,11 @@ impl StateTracker {
     /// operator-reported `dev-reviewer 卡在互動 prompt` false positive.
     const INTERACTIVE_EXPIRY: Duration = Duration::from_secs(120);
 
+    /// Max time `RateLimit` may stay latched. Real rate limits typically
+    /// clear in seconds to minutes; 5 min covers aggressive throttling
+    /// while preventing hours-long false positives (PR #319 incident).
+    const RATE_LIMIT_EXPIRY: Duration = Duration::from_secs(300);
+
     /// If the last MCP heartbeat is within this window, the agent is
     /// considered alive and `PermissionPrompt` detection is suppressed.
     const HEARTBEAT_FRESH_WINDOW: Duration = Duration::from_secs(120);
@@ -772,6 +777,13 @@ impl StateTracker {
         // LATCHED_STATE_EXPIRY is almost always stale.
         let short_expiring = matches!(self.current, AgentState::Thinking | AgentState::ToolUse);
         if short_expiring && self.since.elapsed() >= Self::LATCHED_STATE_EXPIRY {
+            self.transition(AgentState::Ready);
+            return;
+        }
+        // RateLimit expires on its own 5-minute window. Real rate limits
+        // clear in seconds-to-minutes; stuck for hours is a false positive.
+        let rate_limit_expiring = matches!(self.current, AgentState::RateLimit);
+        if rate_limit_expiring && self.since.elapsed() >= Self::RATE_LIMIT_EXPIRY {
             self.transition(AgentState::Ready);
             return;
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2602,4 +2602,28 @@ mod tests {
             "chat content with glyph + distant tool name must NOT trigger ToolUse"
         );
     }
+
+    // --- Sprint 34 PR-3: RateLimit expiry tests ---
+
+    #[test]
+    fn rate_limit_expires_after_300s_window() {
+        let mut t = tracker_at(&Backend::ClaudeCode, AgentState::RateLimit, 301);
+        t.tick();
+        assert_eq!(
+            t.get_state(),
+            AgentState::Ready,
+            "RateLimit must expire to Ready after 300s"
+        );
+    }
+
+    #[test]
+    fn rate_limit_remains_sticky_before_300s() {
+        let mut t = tracker_at(&Backend::ClaudeCode, AgentState::RateLimit, 250);
+        t.tick();
+        assert_eq!(
+            t.get_state(),
+            AgentState::RateLimit,
+            "RateLimit must stay sticky before 300s window"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Add separate `RATE_LIMIT_EXPIRY = 300s` constant. RateLimit now self-recovers to Ready after 5 minutes.

## Sprint 34 PR-3 (Tier-1)
- PLAN: #327, Decision: d-20260429131802690628-0
- Task: t-20260429144622755805-3

## Test-first (§3.5.11)
- RED: 1aad337 — `rate_limit_expires_after_300s_window` fails
- GREEN: HEAD — all tests pass

## Scope conformance
- Followed PLAN §3.3 + §13 Q2: separate `RATE_LIMIT_EXPIRY = 300s` constant, NOT added to `long_expiring`
- Followed §3.5.10 with `rate_limit_expires_after_300s_window` (positive) + `rate_limit_remains_sticky_before_300s` (negative)
- Followed §3.5.11 RED→GREEN: 1aad337 failed; HEAD passes
- No deviations