### PR TITLE
feat: add OpenCode provider error pattern (ApiError)

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -2638,4 +2638,31 @@ mod tests {
             "RateLimit must stay sticky before 300s window"
         );
     }
+
+    // --- Sprint 34 PR-4: OpenCode provider error tests ---
+
+    #[test]
+    fn opencode_provider_error_triggers_error_state() {
+        let patterns = StatePatterns::for_backend(&Backend::OpenCode);
+        assert_eq!(
+            patterns.detect("Error from provider: Anthropic API error: 39 validation errors"),
+            Some(AgentState::ApiError),
+            "provider error must trigger ApiError state"
+        );
+        assert_eq!(
+            patterns.detect("request validation errors for tools[0]"),
+            Some(AgentState::ApiError),
+            "request validation errors must trigger ApiError state"
+        );
+    }
+
+    #[test]
+    fn opencode_normal_pane_does_not_trigger_error() {
+        let patterns = StatePatterns::for_backend(&Backend::OpenCode);
+        assert_ne!(
+            patterns.detect("Ask anything  tab agents"),
+            Some(AgentState::ApiError),
+            "normal opencode pane must not trigger ApiError"
+        );
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -304,6 +304,12 @@ impl StatePatterns {
                 // [docs] HTTP error handling
                 // Sprint 31+ #4: word-boundary `429` per Claude pattern.
                 (AgentState::RateLimit, r"rate.?limit|\b429\b"),
+                // [measured] Provider-side validation errors (e.g. MiniMax
+                // M2.5 rejecting eager_input_streaming in tool spec).
+                (
+                    AgentState::ApiError,
+                    r"Error from provider:|request validation errors",
+                ),
                 // [docs] Context overflow
                 (AgentState::ContextFull, r"ContextOverflow"),
                 // [docs] Permission UI


### PR DESCRIPTION
## Summary
Add provider-side validation error detection for OpenCode backend using existing `AgentState::ApiError`.

## Sprint 34 PR-4 (Tier-1)
- PLAN: #327, Decision: d-20260429131802690628-0

## Test-first (§3.5.11)
- RED: 42ba973 — `opencode_provider_error_triggers_error_state` fails
- GREEN: HEAD — all tests pass

## Scope conformance
- Followed PLAN §3.7 + §13 Q4: existing state variant, no new enum variant
- **Deviation**: PLAN said `AgentState::Error` but no `Error` variant exists in the enum. Used `AgentState::ApiError` which is the correct existing variant for provider-side errors.
- Followed §3.5.10 with `opencode_provider_error_triggers_error_state` (positive) + `opencode_normal_pane_does_not_trigger_error` (negative)
- Followed §3.5.11 RED→GREEN: 42ba973 failed; HEAD passes