### PR TITLE
fix: move metadata cleanup to spawn_one (covers team-spawn)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -156,11 +156,6 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         .filter(|s| !s.is_empty());
     super::prepare_instructions(ctx.home, name, command, &work_dir, explicit_role);
 
-    // Sprint 34 PR-5: clear stale metadata from a previous instance with
-    // the same name. No legitimate pause/resume case exists for metadata
-    // surviving across instance lifetimes (structural review confirmed).
-    let _ = std::fs::remove_file(ctx.home.join("metadata").join(format!("{name}.json")));
-
     match crate::api::spawn_one(
         ctx.home,
         ctx.registry,

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -582,4 +582,53 @@ mod tests {
 
         cleanup_agent(&ctx, "meta-fresh");
     }
+
+    /// §3.5.10: spawn_one (team-spawn path) also clears stale metadata.
+    #[test]
+    fn spawn_one_clears_stale_metadata_for_team_path() {
+        let (ctx, home) = test_ctx_with_agent("team-meta");
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        cleanup_agent(&ctx, "team-meta");
+        {
+            let mut reg = agent::lock_registry(ctx.registry);
+            reg.remove("team-meta");
+        }
+
+        // Pre-seed stale metadata
+        let meta_dir = home.join("metadata");
+        std::fs::create_dir_all(&meta_dir).ok();
+        let meta_path = meta_dir.join("team-meta.json");
+        std::fs::write(
+            &meta_path,
+            r#"{"last_heartbeat":"2025-01-01T00:00:00Z","stale":true}"#,
+        )
+        .expect("write stale metadata");
+
+        // Call spawn_one directly (team-spawn path bypasses handle_spawn)
+        let size = (80u16, 24u16);
+        let work_dir = home.join("workspace").join("team-meta");
+        std::fs::create_dir_all(&work_dir).ok();
+        let result = crate::api::spawn_one(
+            ctx.home,
+            ctx.registry,
+            "team-meta",
+            crate::default_shell(),
+            &[],
+            crate::backend::SpawnMode::Fresh,
+            &work_dir,
+            size,
+        );
+        assert!(result.is_ok(), "spawn_one must succeed: {result:?}");
+
+        // Assert stale metadata is gone
+        if meta_path.exists() {
+            let content = std::fs::read_to_string(&meta_path).unwrap_or_default();
+            assert!(
+                !content.contains("2025-01-01"),
+                "stale metadata must be cleared via spawn_one, got: {content}"
+            );
+        }
+
+        cleanup_agent(&ctx, "team-meta");
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -398,6 +398,10 @@ fn spawn_one(
     size: (u16, u16),
 ) -> anyhow::Result<crate::backend::SpawnMode> {
     std::fs::create_dir_all(work_dir).ok();
+    // Sprint 34: clear stale metadata from a previous instance with the
+    // same name. spawn_one is the true choke point — both handle_spawn
+    // (direct) and team.rs (team-spawn) flow through here.
+    let _ = std::fs::remove_file(home.join("metadata").join(format!("{name}.json")));
     let preset_submit_key = crate::backend::Backend::from_command(backend)
         .map(|b| b.preset().submit_key)
         .unwrap_or("\r");


### PR DESCRIPTION
## Summary
Move stale metadata cleanup from `handle_spawn` to `spawn_one` — the true choke point covering both direct-spawn and team-spawn paths.

## Context
PR #335 cross-vantage review found team-spawn path in `src/api/handlers/team.rs` calls `spawn_one` directly, bypassing `handle_spawn`.

## Test-first (§3.5.11)
- RED: f205567 — `spawn_one_clears_stale_metadata_for_team_path` fails
- GREEN: HEAD — all tests pass

## Scope conformance
- Followed Option A (Move) — chose Move because `handle_spawn` always delegates to `spawn_one`, making `spawn_one` the true single choke point. No path uses `spawn_one` differently.
- Verified `spawn_one` is the actual choke point covering `handle_spawn` (line 164) + `src/api/handlers/team.rs:120`
- Followed §3.5.10 with `spawn_one_clears_stale_metadata_for_team_path` (team-spawn persistence-replay)
- Followed §3.5.11 RED→GREEN: f205567 failed; HEAD passes
- Existing `spawn_clears_stale_metadata_for_same_name` test still passes (handle_spawn → spawn_one)