### PR TITLE
docs: §3.6.1 — fix duplicate "4." numbering

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -627,7 +627,7 @@ After pushing a PR (whether r1 or r2), impl-agent:
    Scope deviations caught only at review burn an extra cycle. The orchestrator-spec'd scope is the authoritative truth; dev simplifications must surface for orchestrator review at push time. **Canonical examples**: PR #319 (Sprint 32 PR4) r1 omitted auto-archive keepalive; PR #325 r1 deviated from operator-spec'd write-side unification to read-side fallback. Both UNVERIFIED; cycles cost.
 3. **Orchestrator pre-dispatch verification** (2026-04-30 backlog amendment): Orchestrator MUST cross-check that dev's claim language reflects the actual artifact — for example, a "byte-equal verified" claim must be confirmed by reading the test, not by trusting the form text alone. If the claim and artifact diverge, orchestrator returns the dispatch to dev for clarification BEFORE forwarding to reviewer. **Incident source**: PR-B r1 incident, week of 2026-04-29 — dev push notification claimed "round-trip byte-equal verified" but the test was mislabeled and broken; reviewer caught it during review and r1 was REJECTED, costing a full review round.
 4. **Immediately** picks up the next dispatched task from inbox.
-4. Does NOT poll CI status; does NOT wait for reviewer verdict; does NOT block on dev-lead merge.
+5. Does NOT poll CI status; does NOT wait for reviewer verdict; does NOT block on dev-lead merge.
 
 If the PR is later REJECTED or has CI failure, impl receives a return-to-fix dispatch via inbox (queue-priority message). Impl decides when to take it based on current task queue state.
 


### PR DESCRIPTION
## Summary

1-LOC follow-up to PR #343 (backlog protocol amendments batch). reviewer2 RECOMMEND on r2: §3.6.1 has duplicate item "4." after amendment #1 insertion. Renumber the second one to "5.".

## Background

PR #343 added a new \`§3.6.1\` item 3 (Orchestrator pre-dispatch verification) and renumbered the existing item 3 → 4. dev2 missed renumbering the existing item 4 ("Does NOT poll CI...") to 5, leaving two consecutive "4." items.

Markdown renderers tolerate duplicate ordered-list numbering; this is a sourcefile cleanliness issue, not a rendered-doc bug. Deferred to follow-up to preserve reviewer2's \`reviewed_head=3b74b90\` freshness on PR #343 r2.

## Diff

\`\`\`diff
 4. **Immediately** picks up the next dispatched task from inbox.
-4. Does NOT poll CI status; does NOT wait for reviewer verdict; does NOT block on dev-lead merge.
+5. Does NOT poll CI status; does NOT wait for reviewer verdict; does NOT block on dev-lead merge.
\`\`\`

## Test plan

- [x] No \`src/\` change — docs-only, no \`cargo fmt\` / clippy required
- [x] Renumber preserves all original content; no list semantics drift
- [x] Sourcefile diff +1/-1, single line
- [ ] CI green
- [ ] lead2 self-merge per §3.5.5-extended (operator-proxy general m-23 housekeeping batch authorisation)

## Companion housekeeping action (non-PR)

Per general m-23 batch, also closed PR #53 (superseded by Sprint 32 Discord adapter PRs #316-319) via \`gh pr close --comment\`. Closure done before this PR was opened; no PR needed for that admin action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)