### PR TITLE
refactor: extract ToolExecutor service boundary (mcp::execute_tool)

### DIFF
--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -55,7 +55,7 @@ pub(crate) fn handle_mcp_tool(params: &Value, _ctx: &HandlerCtx) -> Value {
     let handle = std::thread::Builder::new()
         .name(format!("mcp_tool_{tool_owned}"))
         .spawn(move || {
-            let result = crate::mcp::handlers::handle_tool(&tool_owned, &args, &instance);
+            let result = crate::mcp::execute_tool(&tool_owned, &args, &instance);
             let _ = tx.send(result);
         });
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -11,6 +11,13 @@ use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::io::{self, BufRead, BufReader, Write};
 
+/// Service boundary: single public entry point for MCP tool execution.
+/// API layer calls this instead of reaching into `handlers::handle_tool`
+/// directly, keeping timeout policy in API and execution in MCP.
+pub fn execute_tool(tool_name: &str, args: &Value, instance_name: &str) -> Value {
+    handlers::handle_tool(tool_name, args, instance_name)
+}
+
 /// Tool authz: returns `(allow, deny)` sets parsed from
 /// `AGEND_MCP_TOOLS_ALLOW` / `AGEND_MCP_TOOLS_DENY` (comma-separated,
 /// whitespace-tolerant). An empty allow-set means "allow all" (legacy

--- a/tests/mcp_proxy_parity.rs
+++ b/tests/mcp_proxy_parity.rs
@@ -10,13 +10,13 @@
 //! 2. The response wrapping is consistent (ok + result shape)
 //! 3. The 5 representative tools are routed correctly
 
-/// Verify the mcp_proxy handler source calls handle_tool directly.
+/// Verify the mcp_proxy handler source calls execute_tool via service boundary.
 #[test]
 fn proxy_handler_calls_handle_tool_directly() {
     let src = std::fs::read_to_string("src/api/handlers/mcp_proxy.rs").expect("read mcp_proxy.rs");
     assert!(
-        src.contains("crate::mcp::handlers::handle_tool("),
-        "mcp_proxy must call handle_tool"
+        src.contains("crate::mcp::execute_tool("),
+        "mcp_proxy must call execute_tool (service boundary)"
     );
 }
 


### PR DESCRIPTION
## Summary
Extract `crate::mcp::execute_tool()` as the single public entry point for MCP tool execution. API layer calls this instead of reaching into `handlers::handle_tool` directly.

## Sprint 40 T-4 (Tier-1)
- PLAN: #349, Decision: d-20260430021844853836-2

## Scope conformance
- Followed PLAN T-4 spec: B3 boundary extraction. Option chosen: **B (fn)**. Rationale: no other API path needs to swap implementations; trait would be over-abstraction per KISS.
- Files modified:
  1. `src/mcp/mod.rs` — added `pub fn execute_tool()` (+7 LOC)
  2. `src/api/handlers/mcp_proxy.rs` — changed call from `handlers::handle_tool` to `mcp::execute_tool` (+1/-1)
  3. `tests/mcp_proxy_parity.rs` — updated parity assertion to match new boundary (+3/-3)
- Diff stat: +11 / -4, 3 files
- Behaviour-preserving: existing `mcp_proxy::tests::default_tools_get_30s` / `fast_tools_get_short_timeout` / `slow_tools_get_long_timeout` + `bridge_client_handshake::*` all pass without modification
- RED-then-GREEN: §3.5.11 #2 pure-refactor exemption (byte-equivalence preserved)
- No deviations. No additive scope.