### PR TITLE
refactor: relocate TelegramStatus to channel module

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use tui_events::{TuiEvent, TuiEventSender, TuiNotifier};
 
 use crate::agent::{self, AgentRegistry};
 use crate::backend::Backend;
+use crate::channel::TelegramStatus;
 use crate::keybinds::KeyHandler;
 use crate::layout::{Layout, Pane};
 use crate::notification_queue;
@@ -126,7 +127,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             Ok(crate::bootstrap::BootstrapOutcome::Owned(prepared)) => {
                 let telegram = prepared.telegram.clone();
                 let status = if telegram.is_some() {
-                    render::TelegramStatus::Connected
+                    TelegramStatus::Connected
                 } else {
                     telegram_hooks::telegram_status_from_config(&prepared.config)
                 };
@@ -147,7 +148,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 (
                     api_server::noop_guard(),
                     None,
-                    render::TelegramStatus::NotConfigured,
+                    TelegramStatus::NotConfigured,
                 )
             }
             Err(e) => {
@@ -155,7 +156,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 (
                     api_server::noop_guard(),
                     None,
-                    render::TelegramStatus::NotConfigured,
+                    TelegramStatus::NotConfigured,
                 )
             }
         };

--- a/src/app/telegram_hooks.rs
+++ b/src/app/telegram_hooks.rs
@@ -4,29 +4,26 @@
 //! Telegram API calls run on background threads to avoid blocking the TUI event loop.
 
 use crate::agent::{self, AgentRegistry};
-use crate::channel::{BindingOpts, Channel};
+use crate::channel::{BindingOpts, Channel, TelegramStatus};
 use crate::layout::Pane;
-use crate::render;
 
 use std::path::Path;
 use std::sync::Arc;
 
 /// Derive Telegram status from an already-loaded FleetConfig (no disk I/O).
-pub(super) fn telegram_status_from_config(
-    config: &crate::fleet::FleetConfig,
-) -> render::TelegramStatus {
+pub(super) fn telegram_status_from_config(config: &crate::fleet::FleetConfig) -> TelegramStatus {
     match config.channel {
         Some(crate::fleet::ChannelConfig::Telegram {
             ref bot_token_env, ..
         }) => {
             if std::env::var(bot_token_env).is_ok() {
-                render::TelegramStatus::Connected
+                TelegramStatus::Connected
             } else {
-                render::TelegramStatus::NoToken
+                TelegramStatus::NoToken
             }
         }
-        None => render::TelegramStatus::NotConfigured,
-        Some(crate::fleet::ChannelConfig::Discord { .. }) => render::TelegramStatus::NotConfigured,
+        None => TelegramStatus::NotConfigured,
+        Some(crate::fleet::ChannelConfig::Discord { .. }) => TelegramStatus::NotConfigured,
     }
 }
 

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -57,6 +57,17 @@ use std::sync::{Arc, OnceLock};
 // Supporting types for trait methods added in PR-AE3
 // ---------------------------------------------------------------------------
 
+/// Telegram connection status for status bar display.
+#[derive(Clone, Copy)]
+pub enum TelegramStatus {
+    /// No Telegram channel config in fleet.yaml.
+    NotConfigured,
+    /// Configured but token env var is missing.
+    NoToken,
+    /// Configured and token present (polling should be active).
+    Connected,
+}
+
 /// Error type for channel operations that may not be supported.
 #[derive(Debug)]
 pub enum ChannelError {

--- a/src/render.rs
+++ b/src/render.rs
@@ -11,16 +11,7 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-/// Telegram connection status for status bar display.
-#[derive(Clone, Copy)]
-pub enum TelegramStatus {
-    /// No Telegram channel config in fleet.yaml.
-    NotConfigured,
-    /// Configured but token env var is missing.
-    NoToken,
-    /// Configured and token present (polling should be active).
-    Connected,
-}
+use crate::channel::TelegramStatus;
 
 /// Clamp a desired overlay dimension by the available space minus padding,
 /// using saturating arithmetic so a tiny terminal renders a clipped overlay


### PR DESCRIPTION
## Summary
Move `TelegramStatus` enum from `render.rs` to `channel/mod.rs`.

## Sprint 41 T-5 (Tier-1)
- PLAN: #361

## Scope conformance
- Files modified:
  1. `src/channel/mod.rs` — added `TelegramStatus` enum (+10 LOC)
  2. `src/render.rs` — removed enum, added import (-8/+1 LOC)
  3. `src/app/telegram_hooks.rs` — updated import path (+1/-2 LOC)
  4. `src/app/mod.rs` — updated import path (+1/-0 LOC, 3 use-site changes)
- TelegramStatus use sites verified unchanged: render.rs (5 sites), app/mod.rs (3 sites), telegram_hooks.rs (5 sites), channel/mod.rs (1 definition)
- Invariant CLASS table: byte-equivalence only. Zero new tests, zero modified tests, zero warn/error site changes.
- §3.5.11 #2 byte-equivalence exemption
- No deviations.