### PR TITLE
test: overlay scroll + pane_factory config resolution (8 tests)

### DIFF
--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -1193,4 +1193,50 @@ mod tests {
         }
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // --- Sprint 41 T-4: handle_list_scroll logic coverage ---
+
+    #[test]
+    fn list_scroll_up_decrements() {
+        let mut scroll = 5;
+        let consumed = handle_list_scroll(KeyCode::Up, &mut scroll, 10);
+        assert!(consumed);
+        assert_eq!(scroll, 4);
+    }
+
+    #[test]
+    fn list_scroll_up_at_zero_stays_zero() {
+        let mut scroll = 0;
+        handle_list_scroll(KeyCode::Up, &mut scroll, 10);
+        assert_eq!(scroll, 0);
+    }
+
+    #[test]
+    fn list_scroll_down_increments() {
+        let mut scroll = 3;
+        let consumed = handle_list_scroll(KeyCode::Down, &mut scroll, 10);
+        assert!(consumed);
+        assert_eq!(scroll, 4);
+    }
+
+    #[test]
+    fn list_scroll_down_at_end_stays() {
+        let mut scroll = 9;
+        handle_list_scroll(KeyCode::Down, &mut scroll, 10);
+        assert_eq!(scroll, 9);
+    }
+
+    #[test]
+    fn list_scroll_esc_returns_false() {
+        let mut scroll = 5;
+        let consumed = handle_list_scroll(KeyCode::Esc, &mut scroll, 10);
+        assert!(!consumed, "Esc must return false (close overlay)");
+    }
+
+    #[test]
+    fn list_scroll_page_down_jumps_10() {
+        let mut scroll = 0;
+        handle_list_scroll(KeyCode::PageDown, &mut scroll, 50);
+        assert_eq!(scroll, 10);
+    }
 }

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -524,4 +524,26 @@ mod tests {
         assert_eq!(name, "codex-2");
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // --- Sprint 41 T-4: resolve_backend config resolution ---
+
+    #[test]
+    fn resolve_backend_known_preset_returns_command() {
+        let (cmd, submit) = resolve_backend("claude");
+        assert!(
+            !cmd.is_empty(),
+            "known backend must resolve to non-empty command"
+        );
+        assert_eq!(submit, "\r", "claude submit key must be \\r");
+    }
+
+    #[test]
+    fn resolve_backend_unknown_returns_passthrough() {
+        let (cmd, submit) = resolve_backend("my-custom-cli");
+        assert_eq!(cmd, "my-custom-cli", "unknown backend must pass through");
+        assert_eq!(
+            submit, "\r",
+            "unknown backend default submit key must be \\r"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
8 new tests for overlay scroll logic + pane_factory backend resolution.

## Sprint 41 T-4 (Tier-1)
- PLAN: #361

## Scope conformance
- Files modified:
  1. `src/app/overlay.rs` — 6 handle_list_scroll tests (+42 LOC)
  2. `src/app/pane_factory.rs` — 2 resolve_backend tests (+16 LOC)
- Test enumeration (8 tests, all class: **logic-outcome**):
  1. `list_scroll_up_decrements`
  2. `list_scroll_up_at_zero_stays_zero`
  3. `list_scroll_down_increments`
  4. `list_scroll_down_at_end_stays`
  5. `list_scroll_esc_returns_false`
  6. `list_scroll_page_down_jumps_10`
  7. `resolve_backend_known_preset_returns_command`
  8. `resolve_backend_unknown_returns_passthrough`
- Test counts: overlay.rs 8→14, pane_factory.rs 5→7
- Production code changes: **0**
- tui_events EXCLUDED per PLAN Q2 — confirmed NOT added
- Pre-push: `cargo clippy --all-targets --features=tray` ✓ AND `cargo clippy --all-targets` ✓ AND `cargo test` ✓
- No deviations