### PR TITLE
test: commands.rs parsing + dispatch.rs routing (8 tests)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -323,3 +323,76 @@ fn lookup_fleet_name(layout: &Layout, agent_name: &str) -> Option<String> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::{Layout, Pane, PaneSource, Tab};
+    use crate::vterm::VTerm;
+
+    fn test_pane(id: usize, agent: &str, fleet_name: Option<&str>) -> Pane {
+        Pane {
+            agent_name: agent.to_string(),
+            vterm: VTerm::new(10, 10),
+            rx: crossbeam_channel::bounded(1).1,
+            id,
+            backend: None,
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: fleet_name.map(String::from),
+            last_input_at: None,
+            pending_notification_count: 0,
+            selection: None,
+            source: PaneSource::Local,
+        }
+    }
+
+    #[test]
+    fn lookup_fleet_name_found() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new(
+            "t".to_string(),
+            test_pane(1, "dev", Some("dev-a1b2c3")),
+        ));
+        assert_eq!(
+            lookup_fleet_name(&layout, "dev"),
+            Some("dev-a1b2c3".to_string())
+        );
+    }
+
+    #[test]
+    fn lookup_fleet_name_not_found() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new(
+            "t".to_string(),
+            test_pane(1, "dev", Some("dev-x")),
+        ));
+        assert_eq!(lookup_fleet_name(&layout, "ghost"), None);
+    }
+
+    #[test]
+    fn lookup_fleet_name_no_fleet_name_returns_none() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("t".to_string(), test_pane(1, "dev", None)));
+        assert_eq!(lookup_fleet_name(&layout, "dev"), None);
+    }
+
+    #[test]
+    fn command_parsing_splits_at_most_3_parts() {
+        // Pin the parsing shape: splitn(3, ' ') means at most 3 parts
+        let parts: Vec<&str> = "send target hello world".trim().splitn(3, ' ').collect();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0], "send");
+        assert_eq!(parts[1], "target");
+        assert_eq!(parts[2], "hello world"); // remainder preserved
+    }
+
+    #[test]
+    fn command_parsing_empty_input() {
+        let parts: Vec<&str> = "".trim().splitn(3, ' ').collect();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0], "");
+    }
+}

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -328,3 +328,123 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::{Layout, Pane, PaneSource, Tab};
+    use crate::vterm::VTerm;
+    use std::collections::HashMap;
+
+    fn test_pane(id: usize, name: &str) -> Pane {
+        Pane {
+            agent_name: name.to_string(),
+            vterm: VTerm::new(10, 10),
+            rx: crossbeam_channel::bounded(1).1,
+            id,
+            backend: None,
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
+            selection: None,
+            source: PaneSource::Local,
+        }
+    }
+
+    fn make_ctx<'a>(
+        layout: &'a mut Layout,
+        registry: &'a AgentRegistry,
+        home: &'a Path,
+        last_tab: &'a mut usize,
+        wakeup_tx: &'a crossbeam_channel::Sender<usize>,
+        name_counter: &'a mut HashMap<String, usize>,
+    ) -> DispatchCtx<'a> {
+        DispatchCtx {
+            layout,
+            registry,
+            home,
+            fleet_path: home,
+            last_tab,
+            wakeup_tx,
+            name_counter,
+        }
+    }
+
+    #[test]
+    fn next_tab_advances_active() {
+        let registry: AgentRegistry = std::sync::Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = std::env::temp_dir();
+        let (tx, _rx) = crossbeam_channel::bounded(1);
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("a".to_string(), test_pane(1, "a")));
+        layout.add_tab(Tab::new("b".to_string(), test_pane(2, "b")));
+        layout.active = 0;
+        let mut last_tab = 0;
+        let mut names = HashMap::new();
+        let mut ctx = make_ctx(
+            &mut layout,
+            &registry,
+            &home,
+            &mut last_tab,
+            &tx,
+            &mut names,
+        );
+        let result = dispatch(Action::NextTab, &mut ctx);
+        assert!(result.needs_resize);
+        assert_eq!(ctx.layout.active, 1);
+    }
+
+    #[test]
+    fn prev_tab_decrements_active() {
+        let registry: AgentRegistry = std::sync::Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = std::env::temp_dir();
+        let (tx, _rx) = crossbeam_channel::bounded(1);
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("a".to_string(), test_pane(1, "a")));
+        layout.add_tab(Tab::new("b".to_string(), test_pane(2, "b")));
+        layout.active = 1;
+        let mut last_tab = 0;
+        let mut names = HashMap::new();
+        let mut ctx = make_ctx(
+            &mut layout,
+            &registry,
+            &home,
+            &mut last_tab,
+            &tx,
+            &mut names,
+        );
+        let result = dispatch(Action::PrevTab, &mut ctx);
+        assert!(result.needs_resize);
+        assert_eq!(ctx.layout.active, 0);
+    }
+
+    #[test]
+    fn goto_tab_sets_active_and_last() {
+        let registry: AgentRegistry = std::sync::Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = std::env::temp_dir();
+        let (tx, _rx) = crossbeam_channel::bounded(1);
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("a".to_string(), test_pane(1, "a")));
+        layout.add_tab(Tab::new("b".to_string(), test_pane(2, "b")));
+        layout.add_tab(Tab::new("c".to_string(), test_pane(3, "c")));
+        layout.active = 0;
+        let mut last_tab = 0;
+        let mut names = HashMap::new();
+        let mut ctx = make_ctx(
+            &mut layout,
+            &registry,
+            &home,
+            &mut last_tab,
+            &tx,
+            &mut names,
+        );
+        let result = dispatch(Action::GotoTab(2), &mut ctx);
+        assert!(result.needs_resize);
+        assert_eq!(ctx.layout.active, 2);
+        assert_eq!(*ctx.last_tab, 0);
+    }
+}


### PR DESCRIPTION
## Summary
8 new tests for command parsing logic + dispatch action routing.

## Sprint 41 T-2 (Tier-1)
- PLAN: #361

## Scope conformance
- Files modified:
  1. `src/app/commands.rs` — 5 tests (+68 LOC)
  2. `src/app/dispatch.rs` — 3 tests (+103 LOC)
- Test enumeration (8 tests, all class: **logic-outcome**):
  1. `lookup_fleet_name_found`
  2. `lookup_fleet_name_not_found`
  3. `lookup_fleet_name_no_fleet_name_returns_none`
  4. `command_parsing_splits_at_most_3_parts`
  5. `command_parsing_empty_input`
  6. `next_tab_advances_active`
  7. `prev_tab_decrements_active`
  8. `goto_tab_sets_active_and_last`
- Test counts: commands.rs 0→5, dispatch.rs 0→3
- Production code changes: **0**
- Logic-outcome narrowing: zero string-format assertions, zero column-count assertions ✓
- Pre-push: `cargo clippy --all-targets --features=tray` ✓ AND base ✓ AND `cargo test` ✓
- **Deviation surfaced**: commands.rs `execute()` has no separable parse function (deeply coupled to CommandCtx). Tested `lookup_fleet_name` (pure logic) + parsing shape (`splitn` invariant) instead. dispatch.rs tested tab-navigation actions (minimal DispatchCtx). Same class as T-4 catalog-inaccuracy — PRIOR-ART listed 'command parsing' as separable but actual code is a monolithic match on CommandCtx.