### PR TITLE
fix: panic hook restores terminal on TUI panic (C2 URGENT)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -80,7 +80,28 @@ pub fn run(fleet_path_override: Option<&str>) -> Result<()> {
     )
     .ok();
 
+    // Panic hook: restore terminal on panic so the user doesn't get stuck
+    // in raw mode with mouse capture enabled. Chains the original hook so
+    // panic messages still print.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = crossterm::execute!(
+            std::io::stderr(),
+            crossterm::event::PopKeyboardEnhancementFlags,
+        );
+        ratatui::restore();
+        let _ = crossterm::execute!(
+            std::io::stderr(),
+            crossterm::event::DisableMouseCapture,
+            crossterm::event::DisableBracketedPaste,
+        );
+        original_hook(info);
+    }));
+
     let result = run_app(&mut terminal, fleet_path.as_deref());
+
+    // Restore default panic hook before normal cleanup (avoid double-restore).
+    drop(std::panic::take_hook());
 
     // Pop before leaving alternate screen (symmetric with push).
     crossterm::execute!(


### PR DESCRIPTION
## Summary
Install panic hook that restores terminal state before printing panic message.

## Code-review fix C2 (URGENT)
Source: kiro-cli-ea377a code review

## Scope conformance
- Files modified: `src/app/mod.rs` (+16 LOC)
- Hook chain: `take_hook()` → `set_hook()` preserving original hook
- Cleanup sequence: PopKeyboardEnhancement → ratatui::restore() → DisableMouseCapture + DisableBracketedPaste → original_hook(info)
- Post-run_app: `drop(take_hook())` restores default hook before normal cleanup
- Production code change: panic hook installation (16 LOC)
- No test added (panic hook testing structurally awkward — would need to trigger panic inside TUI context; surfaced explicitly)
- Pre-push: clippy --features=tray ✓, clippy ✓, cargo test ✓
- `git diff` verified
- No deviations