### PR TITLE
fix: dynamic terminal size for event-loop pane creation (H2)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -589,13 +589,14 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                             .collect();
                         to_add.sort();
                         for name in &to_add {
+                            let (dc, dr) = crossterm::terminal::size().unwrap_or((120, 40));
                             match pane_factory::create_remote_pane(
                                 name,
                                 &home,
                                 &fleet_path,
                                 &mut layout,
-                                pane_cols,
-                                pane_rows,
+                                dc.saturating_sub(2),
+                                dr.saturating_sub(4),
                                 &wakeup_tx,
                             ) {
                                 Ok(pane) => {


### PR DESCRIPTION
## Summary
Replace stale pane size snapshot with dynamic query in event-loop pane creation.

## Code-review fix H2 (NORMAL)
Source: kiro-cli-ea377a code review

## Scope conformance
- Files modified: `src/app/mod.rs` (+2/-2 LOC)
- Code path updated: `run_app` event loop → remote-agent hot-reload path (line ~592). Previously used startup `pane_cols`/`pane_rows`; now queries `crossterm::terminal::size()` dynamically.
- Startup path (lines 243, 270, 285): unchanged — all 3 usages happen before event loop, no resize possible yet.
- Production code change: 1 call site updated (+2/-2 LOC)
- No test added (resize-during-hot-reload requires running daemon + terminal resize simulation)
- Pre-push: clippy --features=tray ✓, clippy ✓, cargo test ✓
- `git diff` verified
- No deviations