### PR TITLE
fix: M5 self-route bug — handle_delegate_task pre-check sender==target

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -162,6 +162,17 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
         Err(e) => return json!({"error": e}),
     };
     let target = resolved_target.as_str();
+    // M5: reject if team-orchestrator resolution collapsed target to sender.
+    // Only fires when resolution actually changed the target (raw_target !=
+    // resolved_target), so plain self-sends still hit the API-layer check
+    // with its own error message.
+    if *sender == target && raw_target != target {
+        return json!({"error": format!(
+            "task target '{}' resolved to sender '{}' (team orchestrator loop) \
+             — verify target_instance name does not collide with a team template name",
+            raw_target, sender.as_str()
+        )});
+    }
     let task = match args["task"].as_str() {
         Some(t) => t,
         None => return json!({"error": "missing 'task'"}),

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2385,3 +2385,58 @@ fn describe_instance_response_shape_has_required_keys() {
     std::env::remove_var("AGEND_HOME");
     std::fs::remove_dir_all(&home).ok();
 }
+
+#[test]
+fn delegate_task_rejects_team_orchestrator_self_route() {
+    // M5: when target_instance name collides with a team template name whose
+    // orchestrator is the sender, handle_delegate_task must reject with an
+    // informative error — not fall through to the API-layer generic
+    // "cannot send to self".
+    let _g = fleet_test_guard();
+    let home = tmp_home("m5_self_route");
+    std::env::set_var("AGEND_HOME", &home);
+    std::env::set_var("AGEND_TEST_ISOLATION", "1");
+    // Fleet: instance "dev" exists, sender is "lead".
+    let yaml = "defaults:\n  backend: claude\ninstances:\n  dev:\n    role: Test\n  lead:\n    role: Test\n";
+    std::fs::write(home.join("fleet.yaml"), yaml).ok();
+    // Team fixture: team named "dev" with orchestrator "lead".
+    // This causes resolve_team_orchestrator("dev") → Some("lead").
+    let teams = serde_json::json!({
+        "schema_version": 1,
+        "teams": [{
+            "name": "dev",
+            "members": ["lead", "dev"],
+            "orchestrator": "lead",
+            "description": null,
+            "created_at": "2026-04-30T00:00:00Z"
+        }]
+    });
+    std::fs::write(
+        home.join("teams.json"),
+        serde_json::to_string_pretty(&teams).unwrap(),
+    )
+    .ok();
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "dev",
+            "request_kind": "task",
+            "message": "do something"
+        }),
+        "lead", // sender — same as team "dev" orchestrator
+    );
+
+    let err = result["error"].as_str().expect("should return error");
+    assert!(
+        err.contains("team orchestrator loop"),
+        "error must mention orchestrator loop, got: {err}"
+    );
+    assert!(
+        !err.contains("cannot send to self"),
+        "must NOT hit generic self-send error: {err}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary

Fix `kind=task` self-route bug in `handle_delegate_task` where `resolve_team_orchestrator` collapses target to sender when instance name collides with a team template name.

**Root cause**: `resolve_team_orchestrator(home, raw_target)` resolves team name → orchestrator. When `target_instance` name matches a team template name whose orchestrator is the sender, `resolved_target` becomes the sender → API-layer `from == target` check fires with generic "cannot send to self" error.

**Fix**: Add pre-check after `resolve_team_orchestrator` in `handle_delegate_task`: if `*sender == target && raw_target != target`, return informative error about team orchestrator loop. The `raw_target != target` guard ensures plain self-sends still hit the API-layer check with its own error.

**Reproduce**: `send target_instance=dev request_kind=task` where team "dev" has orchestrator = sender.

Ref: Sprint 44 PLAN §1 (PR #382), task `t-20260430135832086289-30`, operator §13 #7 GO.

## What was tested

- `cargo fmt` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- All 14 unit + 3 integration delegate_task tests pass
- New test `delegate_task_rejects_team_orchestrator_self_route`: sets up team "dev" with orchestrator "lead", sends `kind=task` from "lead" to "dev" → expects informative orchestrator loop error

## Diff

2 files changed, 66 insertions(+), 0 deletions:
- `src/mcp/handlers/comms.rs`: 11-line pre-check (8 LOC + 3 comment lines)
- `src/mcp/handlers/tests.rs`: 55-line test case

No unrelated changes.