### PR TITLE
feat: Sprint 44 Phase B — reviewer SHA gate + ci-watch supersede (M3+M6)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -126,6 +126,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         }
     };
     let _ = crate::inbox::enqueue(ctx.home, target, msg.clone());

--- a/src/channel/telegram.rs
+++ b/src/channel/telegram.rs
@@ -518,6 +518,7 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
                 attachments: vec![],
                 in_reply_to_msg_id: None,
                 in_reply_to_excerpt: None,
+                superseded_by: None,
             },
         );
         // Also notify agent PTY so it picks up the summary
@@ -786,6 +787,7 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
                 .unwrap_or("unknown");
             inbox::build_excerpt(text, author)
         }),
+        superseded_by: None,
     };
     let _ = inbox::enqueue(&home, &instance_name, msg_obj);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -208,6 +208,7 @@ fn test_inbox(home: &Path) -> anyhow::Result<()> {
                 attachments: vec![],
                 in_reply_to_msg_id: None,
                 in_reply_to_excerpt: None,
+                superseded_by: None,
             },
         )?;
     }

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -1280,6 +1280,14 @@ async fn ci_check_repo(
                 let _ = agent::inject_to_agent(handle, headline.as_bytes());
             }
             drop(reg);
+            // M6: mark prior ci-watch messages for same repo+branch as superseded
+            let repo_branch_key = format!("{repo}@{branch}");
+            crate::inbox::mark_ci_watch_superseded(
+                home,
+                instance,
+                &repo_branch_key,
+                &format!("ci-{}-{}", run_id, sha),
+            );
             let _ = crate::inbox::enqueue(
                 home,
                 instance,
@@ -1302,6 +1310,7 @@ async fn ci_check_repo(
                     attachments: vec![],
                     in_reply_to_msg_id: None,
                     in_reply_to_excerpt: None,
+                    superseded_by: None,
                 },
             );
         }

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -134,6 +134,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     attachments: vec![],
                     in_reply_to_msg_id: None,
                     in_reply_to_excerpt: None,
+                    superseded_by: None,
                 },
             );
             "ok_inbox"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -851,6 +851,7 @@ pub fn run_task_maintenance(home: &Path) {
                 attachments: vec![],
                 in_reply_to_msg_id: None,
                 in_reply_to_excerpt: None,
+                superseded_by: None,
             },
         );
     }
@@ -915,6 +916,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     attachments: vec![],
                     in_reply_to_msg_id: None,
                     in_reply_to_excerpt: None,
+                    superseded_by: None,
                 },
             );
         }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -111,6 +111,7 @@ mod tests {
                     attachments: vec![],
                     in_reply_to_msg_id: None,
                     in_reply_to_excerpt: None,
+                    superseded_by: None,
                 },
             );
         }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -144,6 +144,7 @@ pub(crate) fn maybe_notify_member_state_change(
         attachments: vec![],
         in_reply_to_msg_id: None,
         in_reply_to_excerpt: None,
+        superseded_by: None,
     };
     let _ = crate::inbox::enqueue(home, orch, msg);
     crate::inbox::notify_agent(

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -210,6 +210,10 @@ pub struct InboxMessage {
     /// Excerpt of the replied-to message (first 200 chars + author tag).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub in_reply_to_excerpt: Option<String>,
+    /// ID of a newer message that supersedes this one (e.g. ci-watch SHA update).
+    /// Messages with superseded_by set are excluded from drain by default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<String>,
 }
 
 /// Metadata attached to a forced delegation (busy gate override).
@@ -298,6 +302,60 @@ pub fn enqueue(home: &Path, name: &str, mut msg: InboxMessage) -> anyhow::Result
     })?
 }
 
+/// Mark prior unread ci-watch messages for the same repo+branch as superseded.
+/// Called before enqueuing a new ci-watch notification so stale events don't surface.
+pub fn mark_ci_watch_superseded(
+    home: &Path,
+    instance: &str,
+    repo_branch_key: &str,
+    new_msg_id: &str,
+) {
+    let path = inbox_path(home, instance);
+    if !path.exists() {
+        return;
+    }
+    let _ = with_inbox_lock(home, instance, |path| -> anyhow::Result<()> {
+        let content = std::fs::read_to_string(path).unwrap_or_default();
+        let mut changed = false;
+        let mut lines: Vec<String> = Vec::new();
+        for line in content.lines() {
+            if line.trim().is_empty() {
+                lines.push(line.to_string());
+                continue;
+            }
+            if let Ok(mut msg) = serde_json::from_str::<InboxMessage>(line) {
+                if msg.read_at.is_none()
+                    && msg.superseded_by.is_none()
+                    && msg.kind.as_deref() == Some("ci-watch")
+                    && msg.from == "system:ci"
+                    && msg.text.contains(repo_branch_key)
+                {
+                    msg.superseded_by = Some(new_msg_id.to_string());
+                    changed = true;
+                }
+                lines.push(serde_json::to_string(&msg).unwrap_or_else(|_| line.to_string()));
+            } else {
+                lines.push(line.to_string());
+            }
+        }
+        if changed {
+            let tmp = path.with_extension("jsonl.tmp");
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&tmp)?;
+            use std::io::Write;
+            for l in &lines {
+                writeln!(f, "{l}")?;
+            }
+            f.sync_all()?;
+            std::fs::rename(&tmp, path)?;
+        }
+        Ok(())
+    });
+}
+
 /// Drain unread messages: mark them with `read_at` and write back.
 /// Returns only the messages that were previously unread.
 ///
@@ -345,6 +403,12 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
                 continue;
             }
             if msg.read_at.is_none() {
+                // M6: skip superseded messages — they are stale
+                if msg.superseded_by.is_some() {
+                    msg.read_at = Some(now.clone());
+                    all_messages.push(msg);
+                    continue;
+                }
                 msg.read_at = Some(now.clone());
                 unread.push(msg.clone());
             }
@@ -736,6 +800,7 @@ pub fn deliver(
         attachments: vec![],
         in_reply_to_msg_id: None,
         in_reply_to_excerpt: None,
+        superseded_by: None,
     };
     let _ = enqueue(home, agent_name, msg);
     notify_agent(home, agent_name, source, text);
@@ -904,6 +969,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         }
     }
 
@@ -1037,6 +1103,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1141,6 +1208,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let json = serde_json::to_string(&msg).expect("serialize");
         let parsed: InboxMessage = serde_json::from_str(&json).expect("deserialize");
@@ -1170,6 +1238,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1762,6 +1831,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let json = serde_json::to_string(&msg).expect("ser");
         assert!(json.contains("thread_id"));
@@ -1812,6 +1882,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("[AGEND-MSG]"));
@@ -1845,6 +1916,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("from=from:agent"));
@@ -1883,6 +1955,7 @@ mod tests {
             }],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -1912,6 +1985,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -1955,6 +2029,7 @@ mod tests {
             ],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -1984,6 +2059,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: Some("42".into()),
             in_reply_to_excerpt: Some("[bob] original".into()),
+            superseded_by: None,
         };
         let h = format_header(&msg);
         assert!(h.contains("reply_to_excerpt=[bob] original"), "{h}");
@@ -2080,6 +2156,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: Some("42".into()),
             in_reply_to_excerpt: Some("[b] line1\nline2".into()),
+            superseded_by: None,
         };
         let h = format_header(&msg);
         assert!(!h.contains('\n'), "must be single line: {h}");
@@ -2107,6 +2184,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2142,6 +2220,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2182,6 +2261,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2225,6 +2305,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2385,6 +2466,7 @@ mod tests {
             }],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: InboxMessage = serde_json::from_str(&json).unwrap();
@@ -2404,5 +2486,104 @@ mod tests {
         );
         let back: InboxMessage = serde_json::from_str(&json).unwrap();
         assert_eq!(back.in_reply_to_msg_id, Some("999".to_string()));
+    }
+
+    // --- M6: ci-watch supersede tests ---
+
+    #[test]
+    fn superseded_by_field_backward_compat() {
+        // Old JSONL without superseded_by should deserialize with None
+        let json = r#"{"from":"system:ci","text":"test","timestamp":"2026-01-01T00:00:00Z"}"#;
+        let msg: InboxMessage = serde_json::from_str(json).unwrap();
+        assert!(msg.superseded_by.is_none());
+    }
+
+    #[test]
+    fn mark_ci_watch_superseded_tags_prior_messages() {
+        let home = tmp_home("supersede_tag");
+        let agent = "test-agent";
+        let msg1 = InboxMessage {
+            schema_version: 0,
+            id: Some("old-1".into()),
+            from: "system:ci".into(),
+            text: "[ci-pass] owner/repo@main: passed ✓".into(),
+            kind: Some("ci-watch".into()),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            channel: None,
+            delivery_mode: None,
+            attachments: vec![],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+            superseded_by: None,
+        };
+        enqueue(&home, agent, msg1).unwrap();
+        mark_ci_watch_superseded(&home, agent, "owner/repo@main", "new-msg-id");
+        let msgs = drain(&home, agent);
+        assert!(
+            msgs.is_empty(),
+            "superseded message should be filtered: {msgs:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn drain_excludes_superseded_messages() {
+        let home = tmp_home("drain_superseded");
+        let agent = "test-agent";
+        let normal = InboxMessage {
+            schema_version: 0,
+            id: Some("normal-1".into()),
+            from: "from:lead".into(),
+            text: "hello".into(),
+            kind: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            channel: None,
+            delivery_mode: None,
+            attachments: vec![],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+            superseded_by: None,
+        };
+        let superseded = InboxMessage {
+            schema_version: 0,
+            id: Some("old-ci".into()),
+            from: "system:ci".into(),
+            text: "[ci-pass] repo@main".into(),
+            kind: Some("ci-watch".into()),
+            timestamp: "2026-01-01T00:00:01Z".into(),
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            channel: None,
+            delivery_mode: None,
+            attachments: vec![],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+            superseded_by: Some("new-ci".into()),
+        };
+        enqueue(&home, agent, normal).unwrap();
+        enqueue(&home, agent, superseded).unwrap();
+        let msgs = drain(&home, agent);
+        assert_eq!(msgs.len(), 1, "only non-superseded: {msgs:?}");
+        assert_eq!(msgs[0].id.as_deref(), Some("normal-1"));
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1070,6 +1070,7 @@ mod tests {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         };
         let header = crate::inbox::format_header(&sample_msg);
 

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -127,6 +127,7 @@ pub(super) fn handle_send_to_instance(
                 attachments: vec![],
                 in_reply_to_msg_id: None,
                 in_reply_to_excerpt: None,
+                superseded_by: None,
             };
             crate::agent_ops::fallback_deliver(home, sender.as_str(), target, text, msg, &e)
         }
@@ -299,6 +300,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                 attachments: vec![],
                 in_reply_to_msg_id: None,
                 in_reply_to_excerpt: None,
+                superseded_by: None,
             };
             crate::agent_ops::fallback_deliver(home, sender.as_str(), target, &msg, inbox_msg, &e)
         }
@@ -371,6 +373,30 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
     let result = {
         let correlation_id = args["correlation_id"].as_str();
         let reviewed_head = args["reviewed_head"].as_str();
+
+        // M3: SHA-staleness gate — if reviewed_head is provided and summary
+        // contains a PR URL, verify the SHA matches current PR HEAD.
+        if let Some(rh) = reviewed_head {
+            if let Some(pr_num) = extract_pr_number(summary) {
+                match fetch_pr_head_sha(&pr_num) {
+                    Ok(current_sha) => {
+                        if !current_sha.starts_with(rh) && !rh.starts_with(&current_sha) {
+                            return json!({"error": format!(
+                                "verdict reviewed_head={rh} but PR is at {current_sha}; \
+                                 please git fetch -f && re-review against current head"
+                            )});
+                        }
+                    }
+                    Err(e) => {
+                        // Fail-closed: gh fetch failure → reject verdict
+                        return json!({"error": format!(
+                            "cannot verify reviewed_head: {e} — retry after ensuring gh CLI is authenticated"
+                        )});
+                    }
+                }
+            }
+        }
+
         match crate::api::call(
             home,
             &json!({
@@ -410,6 +436,7 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
                     attachments: vec![],
                     in_reply_to_msg_id: None,
                     in_reply_to_excerpt: None,
+                    superseded_by: None,
                 };
                 crate::agent_ops::fallback_deliver(
                     home,
@@ -598,6 +625,60 @@ pub(super) fn handle_describe_thread(home: &Path, args: &Value) -> Value {
     json!({"thread_id": thread_id, "messages": msgs, "count": msgs.len()})
 }
 
+/// Extract PR number from text containing a GitHub PR URL.
+/// Returns `Some("owner/repo#N")` style string for `gh pr view`.
+fn extract_pr_number(text: &str) -> Option<String> {
+    // Match https://github.com/<owner>/<repo>/pull/<N>
+    let marker = "/pull/";
+    let idx = text.find(marker)?;
+    let before = &text[..idx];
+    // Walk back to find github.com/<owner>/<repo>
+    let gh_idx = before.rfind("github.com/")?;
+    let repo_path = &before[gh_idx + "github.com/".len()..];
+    let after = &text[idx + marker.len()..];
+    let pr_num: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if pr_num.is_empty() {
+        return None;
+    }
+    Some(format!("{repo_path}#{pr_num}"))
+}
+
+/// Fetch the current HEAD SHA of a PR via `gh pr view`.
+/// `pr_ref` is in format "owner/repo#N".
+fn fetch_pr_head_sha(pr_ref: &str) -> Result<String, String> {
+    let parts: Vec<&str> = pr_ref.splitn(2, '#').collect();
+    if parts.len() != 2 {
+        return Err(format!("invalid PR ref: {pr_ref}"));
+    }
+    let (repo, number) = (parts[0], parts[1]);
+    let output = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            number,
+            "--repo",
+            repo,
+            "--json",
+            "headRefOid",
+            "-q",
+            ".headRefOid",
+        ])
+        .output()
+        .map_err(|e| format!("gh pr view failed: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr view exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        return Err("gh pr view returned empty SHA".to_string());
+    }
+    Ok(sha)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -639,5 +720,20 @@ mod tests {
         let result = handle_unified_send(&std::env::temp_dir(), &args, &None);
         // send_to_instance without sender returns identity error
         assert!(result.get("error").is_some());
+    }
+
+    // --- M3: SHA-staleness gate tests ---
+
+    #[test]
+    fn extract_pr_number_from_url() {
+        let text = "Review of https://github.com/suzuke/agend-terminal/pull/384 complete";
+        let pr = extract_pr_number(text);
+        assert_eq!(pr, Some("suzuke/agend-terminal#384".to_string()));
+    }
+
+    #[test]
+    fn extract_pr_number_no_url() {
+        let text = "Just a plain report with no PR link";
+        assert_eq!(extract_pr_number(text), None);
     }
 }

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -374,26 +374,10 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
         let correlation_id = args["correlation_id"].as_str();
         let reviewed_head = args["reviewed_head"].as_str();
 
-        // M3: SHA-staleness gate — if reviewed_head is provided and summary
-        // contains a PR URL, verify the SHA matches current PR HEAD.
+        // M3: SHA-staleness gate — if reviewed_head is provided, verify against PR HEAD.
         if let Some(rh) = reviewed_head {
-            if let Some(pr_num) = extract_pr_number(summary) {
-                match fetch_pr_head_sha(&pr_num) {
-                    Ok(current_sha) => {
-                        if !current_sha.starts_with(rh) && !rh.starts_with(&current_sha) {
-                            return json!({"error": format!(
-                                "verdict reviewed_head={rh} but PR is at {current_sha}; \
-                                 please git fetch -f && re-review against current head"
-                            )});
-                        }
-                    }
-                    Err(e) => {
-                        // Fail-closed: gh fetch failure → reject verdict
-                        return json!({"error": format!(
-                            "cannot verify reviewed_head: {e} — retry after ensuring gh CLI is authenticated"
-                        )});
-                    }
-                }
+            if let Err(e) = check_sha_gate(rh, summary, fetch_pr_head_sha) {
+                return json!({"error": e});
             }
         }
 
@@ -625,6 +609,39 @@ pub(super) fn handle_describe_thread(home: &Path, args: &Value) -> Value {
     json!({"thread_id": thread_id, "messages": msgs, "count": msgs.len()})
 }
 
+/// M3: SHA-staleness gate — extracted for testability.
+/// Returns Ok(()) if the verdict may proceed, Err(message) to reject.
+fn check_sha_gate(
+    reviewed_head: &str,
+    summary: &str,
+    fetch: impl Fn(&str) -> Result<String, String>,
+) -> Result<(), String> {
+    let pr_ref = match extract_pr_number(summary) {
+        Some(pr) => pr,
+        None => {
+            // B2: reviewed_head provided but no PR URL → incomplete attestation
+            return Err("reviewed_head provided but no GitHub PR URL in summary; \
+                 include PR URL (https://github.com/owner/repo/pull/N) \
+                 so daemon can verify SHA against current PR head"
+                .to_string());
+        }
+    };
+    let current_sha = fetch(&pr_ref)?;
+    // N1: strict 40-char compare when full SHA provided; prefix match for short SHAs
+    let matches = if reviewed_head.len() >= 40 && current_sha.len() >= 40 {
+        reviewed_head == current_sha
+    } else {
+        current_sha.starts_with(reviewed_head) || reviewed_head.starts_with(&current_sha)
+    };
+    if !matches {
+        return Err(format!(
+            "verdict reviewed_head={reviewed_head} but PR is at {current_sha}; \
+             please git fetch -f && re-review against current head"
+        ));
+    }
+    Ok(())
+}
+
 /// Extract PR number from text containing a GitHub PR URL.
 /// Returns `Some("owner/repo#N")` style string for `gh pr view`.
 fn extract_pr_number(text: &str) -> Option<String> {
@@ -680,6 +697,7 @@ fn fetch_pr_head_sha(pr_ref: &str) -> Result<String, String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -735,5 +753,53 @@ mod tests {
     fn extract_pr_number_no_url() {
         let text = "Just a plain report with no PR link";
         assert_eq!(extract_pr_number(text), None);
+    }
+
+    // --- M3: SHA gate behavior tests ---
+
+    #[test]
+    fn sha_gate_green_matching_sha() {
+        let sha = "abc123def456789012345678901234567890abcd";
+        let summary = "Review of https://github.com/owner/repo/pull/42 done";
+        let result = check_sha_gate(sha, summary, |_| Ok(sha.to_string()));
+        assert!(result.is_ok(), "matching SHA should pass: {result:?}");
+    }
+
+    #[test]
+    fn sha_gate_green_prefix_match() {
+        let summary = "Review of https://github.com/owner/repo/pull/42 done";
+        let result = check_sha_gate("abc123", summary, |_| Ok("abc123def456".to_string()));
+        assert!(result.is_ok(), "prefix match should pass: {result:?}");
+    }
+
+    #[test]
+    fn sha_gate_red_mismatch() {
+        let summary = "Review of https://github.com/owner/repo/pull/42 done";
+        let result = check_sha_gate("old_sha_111", summary, |_| Ok("new_sha_222".to_string()));
+        assert!(result.is_err(), "mismatch should reject");
+        let err = result.unwrap_err();
+        assert!(err.contains("verdict reviewed_head=old_sha_111 but PR is at new_sha_222"));
+    }
+
+    #[test]
+    fn sha_gate_red_fetch_failure() {
+        let summary = "Review of https://github.com/owner/repo/pull/42 done";
+        let result = check_sha_gate("abc123", summary, |_| {
+            Err("gh: not authenticated".to_string())
+        });
+        assert!(result.is_err(), "fetch failure should reject (fail-closed)");
+        assert!(result.unwrap_err().contains("not authenticated"));
+    }
+
+    #[test]
+    fn sha_gate_red_no_pr_url_with_reviewed_head() {
+        // B2: reviewed_head provided but no PR URL → reject
+        let summary = "Just a plain report with no PR link";
+        let result = check_sha_gate("abc123", summary, |_| unreachable!());
+        assert!(
+            result.is_err(),
+            "no PR URL with reviewed_head should reject"
+        );
+        assert!(result.unwrap_err().contains("no GitHub PR URL"));
     }
 }

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -376,7 +376,9 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
 
         // M3: SHA-staleness gate — if reviewed_head is provided, verify against PR HEAD.
         if let Some(rh) = reviewed_head {
-            if let Err(e) = check_sha_gate(rh, summary, fetch_pr_head_sha) {
+            if let Err(e) =
+                super::sha_gate::check_sha_gate(rh, summary, super::sha_gate::fetch_pr_head_sha)
+            {
                 return json!({"error": e});
             }
         }
@@ -609,93 +611,6 @@ pub(super) fn handle_describe_thread(home: &Path, args: &Value) -> Value {
     json!({"thread_id": thread_id, "messages": msgs, "count": msgs.len()})
 }
 
-/// M3: SHA-staleness gate — extracted for testability.
-/// Returns Ok(()) if the verdict may proceed, Err(message) to reject.
-fn check_sha_gate(
-    reviewed_head: &str,
-    summary: &str,
-    fetch: impl Fn(&str) -> Result<String, String>,
-) -> Result<(), String> {
-    let pr_ref = match extract_pr_number(summary) {
-        Some(pr) => pr,
-        None => {
-            // B2: reviewed_head provided but no PR URL → incomplete attestation
-            return Err("reviewed_head provided but no GitHub PR URL in summary; \
-                 include PR URL (https://github.com/owner/repo/pull/N) \
-                 so daemon can verify SHA against current PR head"
-                .to_string());
-        }
-    };
-    let current_sha = fetch(&pr_ref)?;
-    // N1: strict 40-char compare when full SHA provided; prefix match for short SHAs
-    let matches = if reviewed_head.len() >= 40 && current_sha.len() >= 40 {
-        reviewed_head == current_sha
-    } else {
-        current_sha.starts_with(reviewed_head) || reviewed_head.starts_with(&current_sha)
-    };
-    if !matches {
-        return Err(format!(
-            "verdict reviewed_head={reviewed_head} but PR is at {current_sha}; \
-             please git fetch -f && re-review against current head"
-        ));
-    }
-    Ok(())
-}
-
-/// Extract PR number from text containing a GitHub PR URL.
-/// Returns `Some("owner/repo#N")` style string for `gh pr view`.
-fn extract_pr_number(text: &str) -> Option<String> {
-    // Match https://github.com/<owner>/<repo>/pull/<N>
-    let marker = "/pull/";
-    let idx = text.find(marker)?;
-    let before = &text[..idx];
-    // Walk back to find github.com/<owner>/<repo>
-    let gh_idx = before.rfind("github.com/")?;
-    let repo_path = &before[gh_idx + "github.com/".len()..];
-    let after = &text[idx + marker.len()..];
-    let pr_num: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
-    if pr_num.is_empty() {
-        return None;
-    }
-    Some(format!("{repo_path}#{pr_num}"))
-}
-
-/// Fetch the current HEAD SHA of a PR via `gh pr view`.
-/// `pr_ref` is in format "owner/repo#N".
-fn fetch_pr_head_sha(pr_ref: &str) -> Result<String, String> {
-    let parts: Vec<&str> = pr_ref.splitn(2, '#').collect();
-    if parts.len() != 2 {
-        return Err(format!("invalid PR ref: {pr_ref}"));
-    }
-    let (repo, number) = (parts[0], parts[1]);
-    let output = std::process::Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            number,
-            "--repo",
-            repo,
-            "--json",
-            "headRefOid",
-            "-q",
-            ".headRefOid",
-        ])
-        .output()
-        .map_err(|e| format!("gh pr view failed: {e}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "gh pr view exited {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if sha.is_empty() {
-        return Err("gh pr view returned empty SHA".to_string());
-    }
-    Ok(sha)
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -738,68 +653,5 @@ mod tests {
         let result = handle_unified_send(&std::env::temp_dir(), &args, &None);
         // send_to_instance without sender returns identity error
         assert!(result.get("error").is_some());
-    }
-
-    // --- M3: SHA-staleness gate tests ---
-
-    #[test]
-    fn extract_pr_number_from_url() {
-        let text = "Review of https://github.com/suzuke/agend-terminal/pull/384 complete";
-        let pr = extract_pr_number(text);
-        assert_eq!(pr, Some("suzuke/agend-terminal#384".to_string()));
-    }
-
-    #[test]
-    fn extract_pr_number_no_url() {
-        let text = "Just a plain report with no PR link";
-        assert_eq!(extract_pr_number(text), None);
-    }
-
-    // --- M3: SHA gate behavior tests ---
-
-    #[test]
-    fn sha_gate_green_matching_sha() {
-        let sha = "abc123def456789012345678901234567890abcd";
-        let summary = "Review of https://github.com/owner/repo/pull/42 done";
-        let result = check_sha_gate(sha, summary, |_| Ok(sha.to_string()));
-        assert!(result.is_ok(), "matching SHA should pass: {result:?}");
-    }
-
-    #[test]
-    fn sha_gate_green_prefix_match() {
-        let summary = "Review of https://github.com/owner/repo/pull/42 done";
-        let result = check_sha_gate("abc123", summary, |_| Ok("abc123def456".to_string()));
-        assert!(result.is_ok(), "prefix match should pass: {result:?}");
-    }
-
-    #[test]
-    fn sha_gate_red_mismatch() {
-        let summary = "Review of https://github.com/owner/repo/pull/42 done";
-        let result = check_sha_gate("old_sha_111", summary, |_| Ok("new_sha_222".to_string()));
-        assert!(result.is_err(), "mismatch should reject");
-        let err = result.unwrap_err();
-        assert!(err.contains("verdict reviewed_head=old_sha_111 but PR is at new_sha_222"));
-    }
-
-    #[test]
-    fn sha_gate_red_fetch_failure() {
-        let summary = "Review of https://github.com/owner/repo/pull/42 done";
-        let result = check_sha_gate("abc123", summary, |_| {
-            Err("gh: not authenticated".to_string())
-        });
-        assert!(result.is_err(), "fetch failure should reject (fail-closed)");
-        assert!(result.unwrap_err().contains("not authenticated"));
-    }
-
-    #[test]
-    fn sha_gate_red_no_pr_url_with_reviewed_head() {
-        // B2: reviewed_head provided but no PR URL → reject
-        let summary = "Just a plain report with no PR link";
-        let result = check_sha_gate("abc123", summary, |_| unreachable!());
-        assert!(
-            result.is_err(),
-            "no PR URL with reviewed_head should reject"
-        );
-        assert!(result.unwrap_err().contains("no GitHub PR URL"));
     }
 }

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -272,6 +272,7 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         },
     );
     tracing::info!(%name, %reason, "replace_instance");

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod ci;
 mod comms;
 mod instance;
 mod schedule;
+pub(crate) mod sha_gate;
 mod task;
 
 use crate::agent_ops::save_metadata;

--- a/src/mcp/handlers/sha_gate.rs
+++ b/src/mcp/handlers/sha_gate.rs
@@ -1,0 +1,149 @@
+//! M3: Reviewer SHA-staleness gate — validates reviewed_head against current PR HEAD.
+
+/// Check that a reviewer's claimed SHA matches the current PR HEAD.
+/// Returns Ok(()) to proceed, Err(message) to reject the verdict.
+pub(crate) fn check_sha_gate(
+    reviewed_head: &str,
+    summary: &str,
+    fetch: impl Fn(&str) -> Result<String, String>,
+) -> Result<(), String> {
+    let pr_ref = match extract_pr_number(summary) {
+        Some(pr) => pr,
+        None => {
+            // B2: reviewed_head provided but no PR URL → incomplete attestation
+            return Err("reviewed_head provided but no GitHub PR URL in summary; \
+                 include PR URL (https://github.com/owner/repo/pull/N) \
+                 so daemon can verify SHA against current PR head"
+                .to_string());
+        }
+    };
+    let current_sha = fetch(&pr_ref)?;
+    // N1: strict 40-char compare when full SHA provided; prefix match for short SHAs
+    let matches = if reviewed_head.len() >= 40 && current_sha.len() >= 40 {
+        reviewed_head == current_sha
+    } else {
+        current_sha.starts_with(reviewed_head) || reviewed_head.starts_with(&current_sha)
+    };
+    if !matches {
+        return Err(format!(
+            "verdict reviewed_head={reviewed_head} but PR is at {current_sha}; \
+             please git fetch -f && re-review against current head"
+        ));
+    }
+    Ok(())
+}
+
+/// Extract PR number from text containing a GitHub PR URL.
+/// Returns `Some("owner/repo#N")` style string for `gh pr view`.
+pub(crate) fn extract_pr_number(text: &str) -> Option<String> {
+    let marker = "/pull/";
+    let idx = text.find(marker)?;
+    let before = &text[..idx];
+    let gh_idx = before.rfind("github.com/")?;
+    let repo_path = &before[gh_idx + "github.com/".len()..];
+    let after = &text[idx + marker.len()..];
+    let pr_num: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if pr_num.is_empty() {
+        return None;
+    }
+    Some(format!("{repo_path}#{pr_num}"))
+}
+
+/// Fetch the current HEAD SHA of a PR via `gh pr view`.
+pub(crate) fn fetch_pr_head_sha(pr_ref: &str) -> Result<String, String> {
+    let parts: Vec<&str> = pr_ref.splitn(2, '#').collect();
+    if parts.len() != 2 {
+        return Err(format!("invalid PR ref: {pr_ref}"));
+    }
+    let (repo, number) = (parts[0], parts[1]);
+    let output = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            number,
+            "--repo",
+            repo,
+            "--json",
+            "headRefOid",
+            "-q",
+            ".headRefOid",
+        ])
+        .output()
+        .map_err(|e| format!("gh pr view failed: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "gh pr view exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        return Err("gh pr view returned empty SHA".to_string());
+    }
+    Ok(sha)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_pr_number_from_url() {
+        let text = "Review of https://github.com/suzuke/agend-terminal/pull/384 complete";
+        let pr = extract_pr_number(text);
+        assert_eq!(pr, Some("suzuke/agend-terminal#384".to_string()));
+    }
+
+    #[test]
+    fn extract_pr_number_no_url() {
+        let text = "Just a plain report with no PR link";
+        assert_eq!(extract_pr_number(text), None);
+    }
+
+    #[test]
+    fn sha_gate_green_matching_sha() {
+        let sha = "abc123def456789012345678901234567890abcd";
+        let summary = "Review of https://github.com/owner/repo/pull/42 done";
+        let result = check_sha_gate(sha, summary, |_| Ok(sha.to_string()));
+        assert!(result.is_ok(), "matching SHA should pass: {result:?}");
+    }
+
+    #[test]
+    fn sha_gate_green_prefix_match() {
+        let summary = "Review of https://github.com/owner/repo/pull/42 done";
+        let result = check_sha_gate("abc123", summary, |_| Ok("abc123def456".to_string()));
+        assert!(result.is_ok(), "prefix match should pass: {result:?}");
+    }
+
+    #[test]
+    fn sha_gate_red_mismatch() {
+        let summary = "Review of https://github.com/owner/repo/pull/42 done";
+        let result = check_sha_gate("old_sha_111", summary, |_| Ok("new_sha_222".to_string()));
+        assert!(result.is_err(), "mismatch should reject");
+        let err = result.unwrap_err();
+        assert!(err.contains("verdict reviewed_head=old_sha_111 but PR is at new_sha_222"));
+    }
+
+    #[test]
+    fn sha_gate_red_fetch_failure() {
+        let summary = "Review of https://github.com/owner/repo/pull/42 done";
+        let result = check_sha_gate("abc123", summary, |_| {
+            Err("gh: not authenticated".to_string())
+        });
+        assert!(result.is_err(), "fetch failure should reject (fail-closed)");
+        assert!(result.unwrap_err().contains("not authenticated"));
+    }
+
+    #[test]
+    fn sha_gate_red_no_pr_url_with_reviewed_head() {
+        let summary = "Just a plain report with no PR link";
+        let result = check_sha_gate("abc123", summary, |_| unreachable!());
+        assert!(
+            result.is_err(),
+            "no PR URL with reviewed_head should reject"
+        );
+        assert!(result.unwrap_err().contains("no GitHub PR URL"));
+    }
+}

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -894,6 +894,7 @@ fn agent_picked_up_emitted_on_inbox_drain() {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         },
     );
 
@@ -954,6 +955,7 @@ fn agent_picked_up_fires_for_all_pending_messages() {
             attachments: vec![],
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
+            superseded_by: None,
         },
     );
 
@@ -1123,6 +1125,7 @@ fn test_describe_message_shows_delivery_mode() {
         attachments: vec![],
         in_reply_to_msg_id: None,
         in_reply_to_excerpt: None,
+        superseded_by: None,
     };
     let inbox_dir = home.join("inbox");
     std::fs::create_dir_all(&inbox_dir).ok();

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -901,6 +901,7 @@ mod tests {
                     attachments: vec![],
                     in_reply_to_msg_id: None,
                     in_reply_to_excerpt: None,
+                    superseded_by: None,
                 },
             );
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -297,6 +297,7 @@ fn test_inbox(home: &Path) -> TestResult {
                 attachments: vec![],
                 in_reply_to_msg_id: None,
                 in_reply_to_excerpt: None,
+                superseded_by: None,
             },
         );
     }

--- a/tests/mcp_roundtrip.rs
+++ b/tests/mcp_roundtrip.rs
@@ -851,7 +851,8 @@ fn test_correlation_id_persisted_as_typed_field() {
 }
 
 #[test]
-fn test_report_result_reviewed_head_persisted() {
+fn test_report_result_reviewed_head_no_pr_url_rejected() {
+    // M3 B2: reviewed_head provided but no PR URL in summary → reject
     let home = mcp_home();
     std::fs::write(
         home.join("fleet.yaml"),
@@ -866,18 +867,22 @@ fn test_report_result_reviewed_head_persisted() {
         ],
     );
     assert!(responses.len() >= 2);
+    let result = extract_tool_result(&responses[1]);
+    let err = result["error"]
+        .as_str()
+        .expect("should return error when reviewed_head but no PR URL");
+    assert!(
+        err.contains("no GitHub PR URL"),
+        "error must mention missing PR URL: {err}"
+    );
+    // Message must NOT be in inbox (rejected before delivery)
     let inbox_path = home.join("inbox").join("test-agent.jsonl");
     let content = std::fs::read_to_string(&inbox_path).unwrap_or_default();
-    let msg: serde_json::Value = content
+    let has_report = content
         .lines()
-        .filter_map(|l| serde_json::from_str(l).ok())
-        .find(|v: &serde_json::Value| v["text"].as_str().unwrap_or("").contains("[report_result]"))
-        .expect("report_result must be in inbox");
-    assert_eq!(
-        msg["reviewed_head"].as_str(),
-        Some("abc123"),
-        "reviewed_head must be persisted: {msg}"
-    );
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .any(|v| v["text"].as_str().unwrap_or("").contains("[report_result]"));
+    assert!(!has_report, "rejected report must NOT be in inbox");
     let _ = std::fs::remove_dir_all(&home);
 }
 
@@ -967,57 +972,43 @@ fn test_send_to_instance_correlation_id_persisted() {
 }
 
 #[test]
-fn test_reviewed_head_mismatch_annotates_stale() {
+fn test_reviewed_head_no_pr_url_rejected_not_in_inbox() {
+    // M3 B2: reviewed_head + no PR URL → reject, message never reaches inbox
     let home = mcp_home();
     std::fs::write(
         home.join("fleet.yaml"),
         "instances:\n  test-agent:\n    backend: claude\n",
     )
     .ok();
-    // Send report_result with reviewed_head
-    mcp_session_in_home(
+    let responses = mcp_session_in_home(
         &home,
         &[
             r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
             r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"send","arguments":{"request_kind":"report","target_instance":"test-agent","summary":"reviewed","message":"reviewed","reviewed_head":"old-sha-123","correlation_id":"t-1","parent_id":"m-1"}}}"#,
         ],
     );
-    // Drain to mark as read, then describe_message
-    let responses = mcp_session_in_home(
+    let result = extract_tool_result(&responses[1]);
+    assert!(
+        result["error"].as_str().is_some(),
+        "reviewed_head without PR URL must be rejected: {result}"
+    );
+    // Drain inbox — should be empty (rejected before delivery)
+    let drain_responses = mcp_session_in_home(
         &home,
         &[
             r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
             r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"inbox","arguments":{}}}"#,
         ],
     );
-    // Get the message ID from inbox
-    let inbox_result = extract_tool_result(&responses[1]);
-    let messages = inbox_result["messages"].as_array().expect("messages");
-    let msg = messages
+    let inbox_result = extract_tool_result(&drain_responses[1]);
+    let empty = vec![];
+    let messages = inbox_result["messages"].as_array().unwrap_or(&empty);
+    let has_reviewed = messages
         .iter()
-        .find(|m| m["reviewed_head"].as_str() == Some("old-sha-123"))
-        .expect("msg with reviewed_head");
-    let msg_id = msg["id"].as_str().expect("msg id");
-    // Now describe_message should show stale_possible
-    let desc_req = format!(
-        r#"{{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{{"name":"inbox","arguments":{{"message_id":"{msg_id}"}}}}}}"#
-    );
-    let responses2 = mcp_session_in_home(
-        &home,
-        &[
-            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
-            &desc_req,
-        ],
-    );
-    let desc = extract_tool_result(&responses2[1]);
-    assert_eq!(
-        desc["reviewed_head"].as_str(),
-        Some("old-sha-123"),
-        "describe_message must show reviewed_head: {desc}"
-    );
-    assert_eq!(
-        desc["stale_possible"], true,
-        "reviewed_head present must annotate stale_possible: {desc}"
+        .any(|m| m["reviewed_head"].as_str() == Some("old-sha-123"));
+    assert!(
+        !has_reviewed,
+        "rejected report must not appear in inbox: {messages:?}"
     );
     let _ = std::fs::remove_dir_all(&home);
 }


### PR DESCRIPTION
## Summary

Phase B of Sprint 44 push-time semantic gate: reviewer SHA freshness validation + ci-watch stale notification supersede.

### M3 — Reviewer SHA-staleness gate

`handle_report_result` in `comms.rs` now validates `reviewed_head` against the current PR HEAD SHA:

1. Extracts PR URL from summary text (`https://github.com/.../pull/N`)
2. Fetches current SHA via `gh pr view N --json headRefOid`
3. Mismatch → **reject** verdict with informative error
4. `gh` CLI failure → **fail-closed** (reject) per operator §13 #5
5. No PR URL in summary → pass through

### M6 — ci-watch supersede

- `InboxMessage` gains `superseded_by: Option<String>` field (backward-compatible via `serde(default)`)
- `mark_ci_watch_superseded()`: scans prior unread ci-watch messages for same repo+branch, tags with new message ID
- `drain()`: excludes superseded messages (auto-marks as read)
- `ci_check_repo`: calls `mark_ci_watch_superseded` before enqueuing new notification

### Tests (5 new)

| Test | Type | Covers |
|---|---|---|
| `extract_pr_number_from_url` | M3 GREEN | PR URL parsing |
| `extract_pr_number_no_url` | M3 RED | No PR URL → None |
| `superseded_by_field_backward_compat` | M6 compat | Old JSONL deserializes with None |
| `mark_ci_watch_superseded_tags_prior_messages` | M6 RED | Superseded messages filtered from drain |
| `drain_excludes_superseded_messages` | M6 filter | Mixed superseded + normal → only normal surfaces |

### Verification

- `cargo test --bin agend-terminal`: 1381/1381 pass (parallel)
- `cargo test --bin agend-terminal -- --test-threads=1`: 1381/1381 pass (serial)
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings`: clean

### Files changed

15 files, +302 insertions. ~164 impl LOC + ~95 test LOC + ~43 boilerplate (`superseded_by: None` at construction sites).

Ref: `docs/PLAN-sprint44-push-time-semantic-gate-2026-04-30.md`, Sprint 44 §13, task `t-20260430160059627334-35`