### PR TITLE
feat: Sprint 45 PR-2 G3 prep — set_var callsite catalog + config injection infra

### DIFF
--- a/docs/SPRINT45-G3-SET-VAR-CATALOG-2026-05-01.md
+++ b/docs/SPRINT45-G3-SET-VAR-CATALOG-2026-05-01.md
@@ -14,10 +14,16 @@
 
 | # | File:Line | Env Var | Purpose | Replacement Strategy |
 |---|---|---|---|---|
-| R1 | `src/inbox.rs:522` | `AGEND_POINTER_ONLY_INJECT` | Feature flag: pointer-only inbox injection | Replace with `DaemonConfig.pointer_only_inject: bool` |
-| R2 | `src/main.rs:80+` | `AGEND_HOME` | Home directory override | Keep — process-wide, read once at startup |
-| R3 | `src/identity.rs:25` | `AGEND_INSTANCE_NAME` | Agent identity for MCP bridge | Keep — set by parent process for child, read once |
-| R4 | `src/mcp/mod.rs:267` | `AGEND_HOME` (comment) | Comment noting env var race risk | No action — comment only |
+| R1 | `src/inbox.rs:522` | `AGEND_POINTER_ONLY_INJECT` | Feature flag: pointer-only inbox injection | Replace with `DaemonConfig.pointer_only_inject` |
+| R2 | `src/main.rs:82` | `AGEND_HOME` | Home directory override | Keep — process-wide, read once at startup |
+| R3 | `src/identity.rs:22` | `AGEND_INSTANCE_NAME` | Agent identity for MCP bridge | Keep — set by parent process for child, read once |
+| R4 | `src/mcp/mod.rs:247` | `AGEND_DAEMON_PID` | Check if running inside daemon process | Replace with `DaemonConfig.daemon_pid` (P2 writer's reader) |
+| R5 | `src/mcp/mod.rs:268` | `AGEND_TEST_ISOLATION` | Skip daemon API calls in tests | Keep — test-only guard, not prod config |
+| R6 | `src/daemon/mod.rs:931` | `AGEND_SPAWN_STAGGER_MS` | Stagger agent spawn timing | Keep — low-frequency startup config, env var acceptable |
+| R7 | `src/daemon/watchdog.rs:9` | `AGEND_WATCHDOG_DRY_RUN` | Watchdog dry-run mode | Keep — debug/test flag, not prod config |
+| R8 | `src/worktree_cleanup.rs:13` | `AGEND_WORKTREE_AUTO_CLEANUP` | Auto-cleanup worktrees flag | Keep — opt-in feature flag, env var acceptable |
+| R9 | `src/agent.rs:603` | `AGEND_DEBUG_PTY_READ` | Debug PTY read logging | Keep — debug flag |
+| R10 | `src/mcp/mod.rs:36,40` | `AGEND_MCP_TOOLS_ALLOW/DENY` | MCP tool allow/deny lists | Keep — startup config, env var acceptable |
 
 ## Test-only `set_var` callsites (excluded from prod scope)
 
@@ -34,7 +40,8 @@
 ## PR-3 plan
 
 PR-3 will:
-1. Swap P2 (`AGEND_DAEMON_PID`) to use `DaemonConfig`
-2. Swap R1 (`AGEND_POINTER_ONLY_INJECT`) to use `DaemonConfig`
-3. Keep P1 (`.env` loader) and R2/R3 (startup-only reads) as-is
-4. Migrate test fixtures to explicit-param where feasible
+1. Swap P2 (`AGEND_DAEMON_PID` writer in `daemon/mod.rs`) to use `DaemonConfig.daemon_pid`
+2. Swap R1 (`AGEND_POINTER_ONLY_INJECT` reader in `inbox.rs`) to use `DaemonConfig.pointer_only_inject`
+3. Swap R4 (`AGEND_DAEMON_PID` reader in `mcp/mod.rs`) to use `DaemonConfig.daemon_pid`
+4. Keep P1 (`.env` loader) and R2/R3/R5-R10 (startup-only reads, debug flags) as-is
+5. Migrate test fixtures to explicit-param where feasible

--- a/docs/SPRINT45-G3-SET-VAR-CATALOG-2026-05-01.md
+++ b/docs/SPRINT45-G3-SET-VAR-CATALOG-2026-05-01.md
@@ -1,0 +1,40 @@
+# Sprint 45 G3 — `std::env::set_var` Callsite Catalog
+
+**Date**: 2026-05-01
+**Purpose**: Machine-readable catalog of all `set_var` usage in production code. Test-only callsites excluded (they use `fleet_test_guard()` mutex or explicit-param patterns per Sprint 44 lessons).
+
+## Production `set_var` callsites
+
+| # | File:Line | Env Var | Purpose | Replacement Strategy |
+|---|---|---|---|---|
+| P1 | `src/main.rs:127` | `*` (from .env) | Load `.env` file key-value pairs into process env | Keep — `.env` loader is intentional process-wide config; runs once at startup before any threads |
+| P2 | `src/daemon/mod.rs:224` | `AGEND_DAEMON_PID` | Publish daemon PID for child processes | Replace with `DaemonConfig.pid` field; children read config instead of env |
+
+## Production env var *readers* (candidates for config injection)
+
+| # | File:Line | Env Var | Purpose | Replacement Strategy |
+|---|---|---|---|---|
+| R1 | `src/inbox.rs:522` | `AGEND_POINTER_ONLY_INJECT` | Feature flag: pointer-only inbox injection | Replace with `DaemonConfig.pointer_only_inject: bool` |
+| R2 | `src/main.rs:80+` | `AGEND_HOME` | Home directory override | Keep — process-wide, read once at startup |
+| R3 | `src/identity.rs:25` | `AGEND_INSTANCE_NAME` | Agent identity for MCP bridge | Keep — set by parent process for child, read once |
+| R4 | `src/mcp/mod.rs:267` | `AGEND_HOME` (comment) | Comment noting env var race risk | No action — comment only |
+
+## Test-only `set_var` callsites (excluded from prod scope)
+
+| File | Count | Env Vars | Pattern |
+|---|---|---|---|
+| `src/mcp/handlers/tests.rs` | ~30 | `AGEND_HOME`, `AGEND_TEST_ISOLATION` | Uses `fleet_test_guard()` mutex |
+| `src/worktree_cleanup.rs` | 5 | `AGEND_WORKTREE_AUTO_CLEANUP` | Test fixtures |
+| `src/inbox.rs` | 2 | `AGEND_POINTER_ONLY_INJECT` | Test fixtures |
+| `src/daemon/watchdog.rs` | 2 | `AGEND_WATCHDOG_DRY_RUN` | Test fixtures |
+| `src/daemon/ci_watch.rs` | 8 | `GITLAB_TOKEN`, `BITBUCKET_TOKEN`, `HOME` | Test fixtures |
+| `src/channel/telegram.rs` | 4 | `PR57_*`, `SPRINT23_*` | Test fixtures |
+| `src/identity.rs` | 1 | `AGEND_INSTANCE_NAME` | Test fixture |
+
+## PR-3 plan
+
+PR-3 will:
+1. Swap P2 (`AGEND_DAEMON_PID`) to use `DaemonConfig`
+2. Swap R1 (`AGEND_POINTER_ONLY_INJECT`) to use `DaemonConfig`
+3. Keep P1 (`.env` loader) and R2/R3 (startup-only reads) as-is
+4. Migrate test fixtures to explicit-param where feasible

--- a/src/daemon_config.rs
+++ b/src/daemon_config.rs
@@ -1,0 +1,67 @@
+//! Process-wide daemon configuration — replaces env var reads with explicit config.
+//!
+//! Sprint 45 G3: `std::env::set_var` is unsafe in multi-threaded contexts
+//! (Rust std docs, recent nightly marks it `unsafe`). This module provides
+//! a thread-safe config singleton that callers read instead of env vars.
+//!
+//! Lifecycle: `init()` once at daemon startup (before spawning threads),
+//! then `get()` from anywhere. Env var fallback preserved for backward compat.
+
+use std::sync::OnceLock;
+
+/// Process-wide daemon configuration.
+#[derive(Debug, Clone)]
+pub struct DaemonConfig {
+    /// Feature flag: pointer-only inbox injection (replaces AGEND_POINTER_ONLY_INJECT env var).
+    pub pointer_only_inject: bool,
+    /// Daemon PID (replaces AGEND_DAEMON_PID env var).
+    pub daemon_pid: u32,
+}
+
+impl Default for DaemonConfig {
+    fn default() -> Self {
+        Self {
+            pointer_only_inject: std::env::var("AGEND_POINTER_ONLY_INJECT")
+                .ok()
+                .map(|v| v == "1")
+                .unwrap_or(false),
+            daemon_pid: std::process::id(),
+        }
+    }
+}
+
+static CONFIG: OnceLock<DaemonConfig> = OnceLock::new();
+
+/// Initialize the global config. Call once at daemon startup.
+/// If not called, `get()` returns env-var-derived defaults.
+pub fn init(config: DaemonConfig) {
+    let _ = CONFIG.set(config);
+}
+
+/// Get the current config. Returns defaults if `init()` was never called.
+pub fn get() -> DaemonConfig {
+    CONFIG.get().cloned().unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_config_default_returns_expected_values() {
+        let cfg = DaemonConfig::default();
+        assert_eq!(cfg.daemon_pid, std::process::id());
+        // pointer_only_inject depends on env var; in test context should be false
+        // unless explicitly set
+    }
+
+    #[test]
+    fn daemon_config_with_overrides() {
+        let cfg = DaemonConfig {
+            pointer_only_inject: true,
+            daemon_pid: 42,
+        };
+        assert!(cfg.pointer_only_inject);
+        assert_eq!(cfg.daemon_pid, 42);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ mod claim_verifier;
 mod cli;
 mod connect;
 mod daemon;
+#[allow(dead_code)] // PR-2 prep: infra ready, callers swap in PR-3
+mod daemon_config;
 mod decisions;
 mod deployments;
 mod dispatch_tracking;


### PR DESCRIPTION
## Summary

G3 prep PR: catalog all `std::env::set_var` callsites + build config injection infrastructure. **No callsite swaps** (reserved for PR-3).

### Deliverables

1. **Callsite catalog** (`docs/SPRINT45-G3-SET-VAR-CATALOG-2026-05-01.md`)
   - 2 production `set_var` callsites with replacement strategy
   - 2 production env var readers (config injection candidates)
   - ~50 test-only callsites (excluded from prod scope)

2. **Config injection infra** (`src/daemon_config.rs`, 67 LOC)
   - `DaemonConfig` struct: `pointer_only_inject`, `daemon_pid`
   - `OnceLock` singleton: `init()` at startup, `get()` from anywhere
   - `Default` impl falls back to env var reads (backward compat)
   - 2 unit tests

### Files changed

3 files, +109 insertions:
- `docs/SPRINT45-G3-SET-VAR-CATALOG-2026-05-01.md` (40 LOC)
- `src/daemon_config.rs` (67 LOC, new)
- `src/main.rs` (+2, module declaration)

### Verification

- `cargo test` (no filter): 28 binaries × 2 modes all 0 failed
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings`: clean
- `#[allow(dead_code)]` on module — infra ready, callers swap in PR-3

Ref: task `t-20260501031749677465-3`