### PR TITLE
feat: Sprint 45 PR-3 G3 set_var removal + poll_reminder cleanup

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -98,6 +98,8 @@ pub(crate) fn handle_delete(params: &Value, ctx: &HandlerCtx) -> Value {
     // had reaped the PID, exposing PID re-use + concurrent-spawn collision
     // races.
     crate::daemon::lifecycle::delete_transaction(ctx.home, name, ctx.registry, Some(ctx.configs));
+    // H3: clean up poll_reminder dedup state for deleted agent
+    crate::daemon::poll_reminder::remove_agent(name);
     if let Some(n) = ctx.notifier {
         tracing::info!(agent = name, "DELETE emitting InstanceDeleted");
         n.notify(ApiEvent::InstanceDeleted {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -221,7 +221,8 @@ fn run_core(
     // Sprint 25 P0 Option F: mark this process as the daemon so
     // `mcp::is_running_inside_daemon_process()` can short-circuit
     // tool calls without TCP round-trip.
-    std::env::set_var("AGEND_DAEMON_PID", std::process::id().to_string());
+    // G3 H1: replaced set_var with DaemonConfig init (thread-safe).
+    crate::daemon_config::init(crate::daemon_config::DaemonConfig::default());
 
     // Sprint 24 P0 PR2 — bridge-phase legacy migration. Walks tasks.json
     // and emits canonical Created (+ status transition) events into

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -22,6 +22,14 @@ fn should_notify_and_record(name: &str, count: usize) -> bool {
     true
 }
 
+/// H3: Remove agent from dedup state when deleted (prevents unbounded growth).
+pub fn remove_agent(name: &str) {
+    let mut guard = LAST_NOTIFIED.lock();
+    if let Some(map) = guard.as_mut() {
+        map.remove(name);
+    }
+}
+
 /// Pure collector: returns (agent_name, reminder_string) for each agent
 /// that should be nudged. No side effects — does not inject into PTY.
 pub fn collect_poll_reminders(home: &Path, registry: &AgentRegistry) -> Vec<(String, String)> {

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -519,10 +519,8 @@ pub const HEADER_SIZE_THRESHOLD: usize = 300;
 /// When enabled, PTY injection uses header-only format for all messages,
 /// forcing agents to call `inbox` to read content (solves dispatch non-FIFO).
 pub fn pointer_only_inject() -> bool {
-    std::env::var("AGEND_POINTER_ONLY_INJECT")
-        .ok()
-        .map(|v| v == "1")
-        .unwrap_or(false)
+    // G3 H1: read DaemonConfig instead of env var (thread-safe)
+    crate::daemon_config::get().pointer_only_inject
 }
 
 /// ANSI-colored header prefix for visual distinction in terminal.

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ mod claim_verifier;
 mod cli;
 mod connect;
 mod daemon;
-#[allow(dead_code)] // PR-2 prep: infra ready, callers swap in PR-3
 mod daemon_config;
 mod decisions;
 mod deployments;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -243,12 +243,8 @@ pub(crate) fn is_running_inside_daemon_process() -> bool {
     *IS_DAEMON.get_or_init(|| {
         // Primary signal: ACTIVE_CHANNEL is only registered in daemon process
         crate::channel::active_channel().is_some()
-        // Fallback: check if we're the daemon by PID match
-        || std::env::var("AGEND_DAEMON_PID")
-            .ok()
-            .and_then(|v| v.parse::<u32>().ok())
-            .map(|pid| pid == std::process::id())
-            .unwrap_or(false)
+        // G3 H1: read DaemonConfig instead of env var (thread-safe)
+        || crate::daemon_config::get().daemon_pid == std::process::id()
     })
 }
 


### PR DESCRIPTION
## Summary

G3 callsite swaps: replace `std::env::set_var` / `env::var` with `DaemonConfig` API (thread-safe). Plus H3 poll_reminder leak fix.

### G3 H1: set_var → DaemonConfig swaps

| Callsite | Before | After |
|---|---|---|
| P2 `daemon/mod.rs:224` | `set_var("AGEND_DAEMON_PID", ...)` | `daemon_config::init(Default::default())` |
| R4 `mcp/mod.rs:247` | `env::var("AGEND_DAEMON_PID")` | `daemon_config::get().daemon_pid` |
| R1 `inbox.rs:522` | `env::var("AGEND_POINTER_ONLY_INJECT")` | `daemon_config::get().pointer_only_inject` |

### G3 H3: poll_reminder leak fix

- Added `remove_agent()` to clean up dedup HashMap on agent deletion
- Hooked into `handle_delete` in `api/handlers/instance.rs`

### Grep verification

```
0 prod set_var(AGEND_DAEMON_PID) remaining
0 prod env::var(AGEND_DAEMON_PID) remaining  
0 prod env::var(AGEND_POINTER_ONLY_INJECT) remaining (only daemon_config default fallback)
```

### Files changed

6 files, +16/-12 (net +4 LOC)

### Verification

- `cargo test` (no filter): 28 binaries × 2 modes all 0 failed
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings`: clean

Ref: task `t-20260501094320`