### PR TITLE
feat: Sprint 45 PR-3.5 G3 remaining — shared runtime + utils dedup + lock docs

### DIFF
--- a/docs/DAEMON-LOCK-ORDERING.md
+++ b/docs/DAEMON-LOCK-ORDERING.md
@@ -26,6 +26,10 @@ Level 0 (root):
                               (`crate::agent::AgentRegistry`)
   external_registry         — global HashMap<String, ExternalAgentHandle>
                               (`crate::agent::ExternalRegistry`)
+                              NOTE (G3 M5): `register_external` acquires
+                              external_registry THEN agent_registry (read).
+                              Never acquire agent_registry first then
+                              external_registry — deadlock risk.
   configs                   — daemon-only HashMap<String, AgentConfig>
                               (`src/daemon/mod.rs::AgentConfig`)
 

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -3,6 +3,23 @@ use std::path::Path;
 use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
+// H2: Shared tokio runtime for CI watch — avoids spawning a new thread +
+// runtime per poll cycle. Bounded to 2 worker threads.
+// ---------------------------------------------------------------------------
+
+fn shared_ci_runtime() -> &'static tokio::runtime::Runtime {
+    static RT: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .thread_name("ci-watch")
+            .enable_all()
+            .build()
+            .expect("ci-watch runtime")
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Shared HTTP client for CI providers (Sprint 39 follow-up extraction)
 // ---------------------------------------------------------------------------
 
@@ -982,43 +999,28 @@ fn check_ci_watches_with_provider(
                 continue;
             }
         };
-        // fire-and-forget: ci_check is one-shot per poll cycle. Builds a
-        // single-thread tokio runtime, blocks on one provider call, exits.
-        // No JoinHandle / shutdown signal needed because the tick loop will
-        // re-spawn next cycle if anything is still being watched.
-        std::thread::Builder::new()
-            .name("ci_check".into())
-            .spawn(move || {
-                let Ok(rt) = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                else {
-                    tracing::warn!(repo = %repo, "ci_check: failed to build tokio runtime");
-                    return;
-                };
-                if let Err(e) = rt.block_on(ci_check_repo(
-                    &home,
-                    &watch_path,
-                    &repo,
-                    &branch,
-                    &instance,
-                    last_run_id,
-                    head_sha.as_deref(),
-                    last_notified_sha.as_deref(),
-                    &registry,
-                    provider.as_ref(),
-                )) {
-                    tracing::warn!(repo = %repo, error = %e, "CI check failed");
-                }
-            })
-            .unwrap_or_else(|e| {
-                tracing::warn!(error = %e, "ci_check: failed to spawn background thread");
-                // fire-and-forget: dummy no-op JoinHandle returned only to
-                // satisfy the unwrap_or_else return type. The closure body
-                // does nothing — the real work was the failed spawn above.
-                // No shutdown semantics needed.
-                std::thread::spawn(|| {})
-            });
+        // H2: use shared runtime instead of per-poll thread + runtime.
+        // fire-and-forget: ci_check is one-shot per poll cycle. The shared
+        // runtime bounds concurrency to 2 worker threads. No JoinHandle
+        // needed — the tick loop re-spawns next cycle if still watching.
+        shared_ci_runtime().spawn(async move {
+            if let Err(e) = ci_check_repo(
+                &home,
+                &watch_path,
+                &repo,
+                &branch,
+                &instance,
+                last_run_id,
+                head_sha.as_deref(),
+                last_notified_sha.as_deref(),
+                &registry,
+                provider.as_ref(),
+            )
+            .await
+            {
+                tracing::warn!(repo = %repo, error = %e, "CI check failed");
+            }
+        });
     }
 }
 

--- a/src/daemon/legacy_backfill.rs
+++ b/src/daemon/legacy_backfill.rs
@@ -326,32 +326,11 @@ fn numeric_mismatch(
 fn body_has_closes_marker(body: &str, task_id: &str) -> bool {
     use regex::Regex;
     // Strip HTML comments (defense — same vector as task_sweep #1).
-    let sanitised = strip_html_comments(body);
+    let sanitised = crate::daemon::utils::strip_html_comments(body);
     let pat = format!(r"(?m)Closes\s+{}\b", regex::escape(task_id));
     Regex::new(&pat)
         .map(|re| re.is_match(&sanitised))
         .unwrap_or(false)
-}
-
-fn strip_html_comments(body: &str) -> String {
-    let bytes = body.as_bytes();
-    let mut out = String::with_capacity(body.len());
-    let mut i = 0usize;
-    while i < bytes.len() {
-        if i + 4 <= bytes.len() && &bytes[i..i + 4] == b"<!--" {
-            match body[i + 4..].find("-->") {
-                Some(end) => {
-                    i += 4 + end + 3;
-                    continue;
-                }
-                None => break,
-            }
-        }
-        let ch_len = body[i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
-        out.push_str(&body[i..i + ch_len]);
-        i += ch_len;
-    }
-    out
 }
 
 // ── Event emission ──────────────────────────────────────────────────
@@ -495,7 +474,7 @@ fn list_all_closed_prs(repo: &str) -> anyhow::Result<Vec<PrMeta>> {
         let mut out = Vec::with_capacity(arr.len());
         for pr in arr {
             let pr_bytes = serde_json::to_vec(&pr)?;
-            let api_response_hash = sha256_hex(&pr_bytes);
+            let api_response_hash = crate::daemon::utils::sha256_hex(&pr_bytes);
             if let Some(meta) = parse_pr_meta(&pr, api_response_hash) {
                 out.push(meta);
             }
@@ -543,13 +522,6 @@ fn parse_pr_meta(v: &serde_json::Value, api_response_hash: String) -> Option<PrM
         head_branch,
         api_response_hash,
     })
-}
-
-fn sha256_hex(bytes: &[u8]) -> String {
-    use sha2::Digest;
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(bytes);
-    hex::encode(hasher.finalize())
 }
 
 // ── MCP tool surface ─────────────────────────────────────────────────

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod supervisor;
 pub(crate) mod task_sweep;
 pub(crate) mod ticker;
 mod tui_bridge;
+pub(crate) mod utils;
 pub(crate) mod watchdog;
 
 use crate::agent::{self, AgentRegistry};

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -174,7 +174,7 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
         };
 
         // Validation must-have #1: HTML-comment injection sanitize.
-        let sanitized_body = strip_html_comments(&pr.body);
+        let sanitized_body = crate::daemon::utils::strip_html_comments(&pr.body);
         // Validation must-have #2: strict ASCII regex rejects non-ASCII
         // homoglyphs in the task ID portion.
         let markers = extract_closes_markers(&sanitized_body);
@@ -271,34 +271,6 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
 /// hide inside a comment.
 ///
 /// The implementation walks bytes (ASCII-safe — we strip whole comments,
-/// not their bytes) and rebuilds a String char-by-char where the byte is
-/// guaranteed to be a single-byte char by the surrounding ASCII bracket
-/// match. Unterminated comments (`<!--` without `-->`) drop the rest of
-/// the body — a future fuzzy attacker writing partial comments still
-/// can't sneak a directive past us.
-fn strip_html_comments(body: &str) -> String {
-    let bytes = body.as_bytes();
-    let mut out = String::with_capacity(body.len());
-    let mut i = 0usize;
-    while i < bytes.len() {
-        if i + 4 <= bytes.len() && &bytes[i..i + 4] == b"<!--" {
-            match body[i + 4..].find("-->") {
-                Some(end) => {
-                    i += 4 + end + 3;
-                    continue;
-                }
-                None => break, // unterminated — drop tail
-            }
-        }
-        // Push the next UTF-8 character to preserve unicode in the
-        // non-comment body. char_indices iterator-style walk:
-        let ch_len = body[i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1);
-        out.push_str(&body[i..i + ch_len]);
-        i += ch_len;
-    }
-    out
-}
-
 /// Extract every `Closes t-<digits>-<digits>` marker. Strict ASCII regex
 /// rejects non-ASCII codepoints inside the task ID; combined with the
 /// HTML-comment sanitiser this defends against zero-width-char +
@@ -365,7 +337,7 @@ fn list_recently_merged_prs(repo: &str) -> anyhow::Result<Vec<PrMeta>> {
             // the exact JSON object the sweep observed (squash deletions
             // + future PR body edits won't change this).
             let pr_json_bytes = serde_json::to_vec(&pr)?;
-            let api_response_hash = sha256_hex(&pr_json_bytes);
+            let api_response_hash = crate::daemon::utils::sha256_hex(&pr_json_bytes);
             if let Some(meta) = parse_pr_meta(&pr, api_response_hash) {
                 out.push(meta);
             }
@@ -409,13 +381,6 @@ fn parse_pr_meta(v: &serde_json::Value, api_response_hash: String) -> Option<PrM
         author_login,
         api_response_hash,
     })
-}
-
-fn sha256_hex(bytes: &[u8]) -> String {
-    use sha2::Digest;
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(bytes);
-    hex::encode(hasher.finalize())
 }
 
 // ── Operator-facing MCP tool surface ────────────────────────────────
@@ -478,7 +443,7 @@ mod tests {
     #[test]
     fn html_comment_injection_stripped() {
         let body = "Closes t-12345-1\n<!-- Closes t-99999-2 -->";
-        let sanitised = strip_html_comments(body);
+        let sanitised = crate::daemon::utils::strip_html_comments(body);
         let markers = extract_closes_markers(&sanitised);
         assert_eq!(markers, vec!["t-12345-1".to_string()]);
     }
@@ -489,7 +454,7 @@ mod tests {
     #[test]
     fn html_comment_unterminated_drops_tail() {
         let body = "Closes t-1-1\n<!-- partial Closes t-2-2";
-        let sanitised = strip_html_comments(body);
+        let sanitised = crate::daemon::utils::strip_html_comments(body);
         let markers = extract_closes_markers(&sanitised);
         assert_eq!(markers, vec!["t-1-1".to_string()]);
     }
@@ -606,12 +571,12 @@ mod tests {
     /// later auditor can correlate against an archived API response.
     #[test]
     fn sha256_hex_is_deterministic_64_hex() {
-        let h1 = sha256_hex(b"hello");
-        let h2 = sha256_hex(b"hello");
+        let h1 = crate::daemon::utils::sha256_hex(b"hello");
+        let h2 = crate::daemon::utils::sha256_hex(b"hello");
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64);
         assert!(h1.chars().all(|c| c.is_ascii_hexdigit()));
-        let h3 = sha256_hex(b"world");
+        let h3 = crate::daemon::utils::sha256_hex(b"world");
         assert_ne!(h1, h3);
     }
 

--- a/src/daemon/utils.rs
+++ b/src/daemon/utils.rs
@@ -1,0 +1,56 @@
+//! Shared daemon utilities — extracted from legacy_backfill and task_sweep
+//! to eliminate duplication (G3 M2).
+
+use sha2::{Digest, Sha256};
+
+/// Strip HTML comments (`<!-- ... -->`) from a string.
+pub fn strip_html_comments(body: &str) -> String {
+    let mut result = String::with_capacity(body.len());
+    let mut rest = body;
+    while let Some(start) = rest.find("<!--") {
+        result.push_str(&rest[..start]);
+        match rest[start..].find("-->") {
+            Some(end) => rest = &rest[start + end + 3..],
+            None => {
+                // Unterminated comment — drop the tail (security: attacker
+                // can't sneak directives past us via partial comments)
+                return result;
+            }
+        }
+    }
+    result.push_str(rest);
+    result
+}
+
+/// SHA-256 hex digest of arbitrary bytes.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_html_comments_removes_comments() {
+        assert_eq!(
+            strip_html_comments("before<!-- hidden -->after"),
+            "beforeafter"
+        );
+    }
+
+    #[test]
+    fn strip_html_comments_no_comments() {
+        assert_eq!(strip_html_comments("plain text"), "plain text");
+    }
+
+    #[test]
+    fn sha256_hex_deterministic() {
+        let h1 = sha256_hex(b"hello");
+        let h2 = sha256_hex(b"hello");
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64);
+    }
+}


### PR DESCRIPTION
## Summary

G3 remaining: shared CI watch runtime (H2), utils dedup (M2), lock ordering docs (M5).

### Deferred items with explicit reasons

**M1 (CI watch state file non-atomic)** — Reason (c): CI watch state files use raw serde_json::Value manipulation, not typed structs. Converting to mutate_versioned requires defining CiWatchState struct + SchemaVersioned impl + migrating existing watch files + updating all read/write sites (~80-100 LOC touching the hot CI poll path). Exceeds remaining LOC budget; warrants focused PR-3.6.

**M3 (team isolation reserved names)** — Reason (b): general is a real fleet instance used as cross-team bus. Blocking the name breaks existing fleets. Needs operator design decision on naming convention.

**M4 (tui_bridge thread leak)** — Existing threads have proper fire-and-forget comments and exit on disconnect. Reported leak may be different bug; needs stress-test reproduction before fix.