### PR TITLE
feat: Sprint 45 PR-3.6 G3 final — CI watch atomicity + reserved names proposal

### DIFF
--- a/docs/SPRINT45-G3-M3-RESERVED-NAMES-PROPOSAL.md
+++ b/docs/SPRINT45-G3-M3-RESERVED-NAMES-PROPOSAL.md
@@ -1,0 +1,44 @@
+# Sprint 45 G3 M3 — Reserved Instance Names Design Proposal
+
+**Date**: 2026-05-01
+**Status**: Proposal — awaiting operator decision
+
+## Problem
+
+The team isolation gate in `src/api/handlers/messaging.rs` treats `general` as a cross-team bus: any message from/to an instance named `general` bypasses team isolation checks. If a user creates an agent instance named `general`, it inherits bus privileges unintentionally.
+
+## Current reserved names (implicit, from code)
+
+| Name | Where | Privilege |
+|---|---|---|
+| `general` | `messaging.rs:52` | Cross-team bus bypass |
+| `system:auto_close` | `tasks.rs` SYSTEM_IDENTITIES | ACL bypass for task mutation |
+| `system:overdue_sweep` | `tasks.rs` SYSTEM_IDENTITIES | ACL bypass for task mutation |
+| `system:task_sweep` | `tasks.rs` SYSTEM_IDENTITIES | ACL bypass for task mutation |
+
+## Proposal options
+
+### Option A: Warn on creation (recommended, minimal)
+- `agent::validate_name()` logs a warning when name matches a reserved pattern
+- Does NOT block creation — backward compatible with existing fleets
+- Warning text: "instance name 'general' has special routing privileges"
+
+### Option B: Block reserved names on creation
+- `agent::validate_name()` rejects reserved names
+- Breaking change for existing fleets that have `general` instance
+- Requires migration path
+
+### Option C: Namespace prefix convention
+- Reserved names use `system:` prefix (already in use for SYSTEM_IDENTITIES)
+- `general` renamed to `system:general` in fleet.yaml
+- Breaking change, requires fleet.yaml migration
+
+## Recommendation
+
+Option A for now — warn but don't block. Operator can decide to escalate to Option B/C in a future sprint.
+
+## Operator decision needed
+
+- [ ] Accept Option A (warn only)?
+- [ ] Escalate to Option B (block) or C (namespace)?
+- [ ] Add other names to reserved list?

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -984,9 +984,12 @@ fn check_ci_watches_with_provider(
         // throttle.
         let mut watch_with_stamp = watch.clone();
         watch_with_stamp["last_polled_at"] = serde_json::json!(now_ms);
-        let _ = std::fs::write(
+        // M1: atomic write
+        let _ = crate::store::atomic_write(
             &path,
-            serde_json::to_string_pretty(&watch_with_stamp).unwrap_or_default(),
+            serde_json::to_string_pretty(&watch_with_stamp)
+                .unwrap_or_default()
+                .as_bytes(),
         );
 
         let home = home.to_path_buf();
@@ -1198,9 +1201,12 @@ async fn ci_check_repo(
                 if let Ok(content) = std::fs::read_to_string(watch_path) {
                     if let Ok(mut watch) = serde_json::from_str::<serde_json::Value>(&content) {
                         watch["rate_limit_until"] = serde_json::json!(reset_epoch);
-                        let _ = std::fs::write(
+                        // M1: atomic write
+                        let _ = crate::store::atomic_write(
                             watch_path,
-                            serde_json::to_string_pretty(&watch).unwrap_or_default(),
+                            serde_json::to_string_pretty(&watch)
+                                .unwrap_or_default()
+                                .as_bytes(),
                         );
                     }
                 }
@@ -1350,9 +1356,12 @@ fn update_watch_state_with_notify(
                 watch["last_notified_head_sha"] = serde_json::json!(sha);
             }
             watch["last_terminal_seen_at"] = serde_json::json!(chrono::Utc::now().to_rfc3339());
-            let _ = std::fs::write(
+            // M1: atomic write to prevent partial-file on crash
+            let _ = crate::store::atomic_write(
                 watch_path,
-                serde_json::to_string_pretty(&watch).unwrap_or_default(),
+                serde_json::to_string_pretty(&watch)
+                    .unwrap_or_default()
+                    .as_bytes(),
             );
         }
     }

--- a/src/daemon/tui_bridge.rs
+++ b/src/daemon/tui_bridge.rs
@@ -88,6 +88,8 @@ pub fn serve_agent_tui(name: &str, run_dir: &Path, registry: &AgentRegistry) {
         // the broadcast subscriber rx drops (agent removed via
         // delete_transaction) or when frame write fails (client disconnect).
         // No graceful join needed — each client connection is independent.
+        // M4 analysis: no leak — write_frame failure on disconnect breaks
+        // the loop immediately; rx.recv() Err on agent deletion also exits.
         if let Err(e) = std::thread::Builder::new()
             .name(format!("{n}_tui_out"))
             .spawn(move || {


### PR DESCRIPTION
## Summary

G3 final: CI watch state file atomicity (M1), reserved names design proposal (M3), tui_bridge leak verification (M4).

### M1: CI watch state file atomicity
Replaced 3 `std::fs::write` calls on watch files with `crate::store::atomic_write` (temp+fsync+rename). No schema rework needed — atomic_write works on raw JSON values.

### M3: Reserved instance names
Design proposal in `docs/SPRINT45-G3-M3-RESERVED-NAMES-PROPOSAL.md`. 3 options (warn/block/namespace). Awaiting operator decision. No code change.

### M4: tui_bridge thread lifecycle
Verified: no leak. Output thread exits on write_frame failure (client disconnect). Input thread exits on read_tagged_frame error. Added analysis comment. No fix needed.

### Files changed
3 files, +61/-6:
- `src/daemon/ci_watch.rs` (+17/-6): atomic_write for 3 write sites
- `src/daemon/tui_bridge.rs` (+2): M4 analysis comment
- `docs/SPRINT45-G3-M3-RESERVED-NAMES-PROPOSAL.md` (44 LOC, new)

### Verification
- `cargo test` (no filter): 28 binaries × 2 modes all 0 failed
- `cargo fmt` + `cargo clippy`: clean