### PR TITLE
feat: Sprint 45 PR-4.0 G7 pure fixes — split_chunks + flush throttle + key_to_bytes

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -358,7 +358,26 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             needs_resize = false;
         }
         sync_notification_state(&home, &mut layout);
-        flush_idle_notifications(&home, &mut layout);
+        // H3: throttle flush to ≥1s intervals (was every 50ms tick → disk I/O storm)
+        {
+            static LAST_FLUSH: std::sync::Mutex<Option<std::time::Instant>> =
+                std::sync::Mutex::new(None);
+            let now = std::time::Instant::now();
+            let should_flush = LAST_FLUSH
+                .lock()
+                .map(|guard| {
+                    guard
+                        .map(|t| now.duration_since(t).as_secs() >= 1)
+                        .unwrap_or(true)
+                })
+                .unwrap_or(true);
+            if should_flush {
+                flush_idle_notifications(&home, &mut layout);
+                if let Ok(mut guard) = LAST_FLUSH.lock() {
+                    *guard = Some(now);
+                }
+            }
+        }
 
         let repeat_mode = key_handler.in_repeat();
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -246,7 +246,8 @@ pub(crate) fn split_chunks(area: Rect, dir: &SplitDir, ratio: f32) -> [Rect; 2] 
     match dir {
         SplitDir::Horizontal => {
             let second_y = area.y + first_size.saturating_sub(overlap);
-            let second_h = area.height + overlap - first_size;
+            // H4: saturating_sub prevents underflow on tiny terminals
+            let second_h = (area.height + overlap).saturating_sub(first_size).max(1);
             [
                 Rect::new(area.x, area.y, area.width, first_size),
                 Rect::new(area.x, second_y, area.width, second_h),
@@ -254,7 +255,8 @@ pub(crate) fn split_chunks(area: Rect, dir: &SplitDir, ratio: f32) -> [Rect; 2] 
         }
         SplitDir::Vertical => {
             let second_x = area.x + first_size.saturating_sub(overlap);
-            let second_w = area.width + overlap - first_size;
+            // H4: saturating_sub prevents underflow on tiny terminals
+            let second_w = (area.width + overlap).saturating_sub(first_size).max(1);
             [
                 Rect::new(area.x, area.y, first_size, area.height),
                 Rect::new(second_x, area.y, second_w, area.height),
@@ -2357,5 +2359,26 @@ mod tests {
             std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
         let result = highest_priority_state(&tab, &registry);
         assert_eq!(result, AgentState::Idle);
+    }
+
+    // H4: split_chunks must not underflow on tiny terminals
+    #[test]
+    fn split_chunks_tiny_terminal_no_underflow() {
+        use ratatui::layout::Rect;
+        // 1x1 terminal — extreme case
+        let area = Rect::new(0, 0, 1, 1);
+        let [_a, b] = split_chunks(area, &crate::layout::SplitDir::Horizontal, 0.9);
+        // Should not panic; second chunk should have min height 1
+        assert!(
+            b.height >= 1,
+            "second chunk height must be ≥1, got {}",
+            b.height
+        );
+        let [_c, d] = split_chunks(area, &crate::layout::SplitDir::Vertical, 0.9);
+        assert!(
+            d.width >= 1,
+            "second chunk width must be ≥1, got {}",
+            d.width
+        );
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -131,9 +131,22 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Vec<u8> {
     }
     match code {
         KeyCode::Char(c) if ctrl => {
-            vec![(c.to_ascii_lowercase() as u8)
-                .wrapping_sub(b'a')
-                .wrapping_add(1)]
+            // M2: correct Ctrl mapping for both letters and special chars
+            let byte = c.to_ascii_lowercase() as u8;
+            if byte.is_ascii_lowercase() {
+                vec![byte - b'a' + 1] // Ctrl+A=1 .. Ctrl+Z=26
+            } else {
+                // Ctrl+[ = ESC (0x1b), Ctrl+\ = 0x1c, Ctrl+] = 0x1d, etc.
+                match c {
+                    '[' | '{' => vec![0x1b],
+                    '\\' | '|' => vec![0x1c],
+                    ']' | '}' => vec![0x1d],
+                    '^' | '~' => vec![0x1e],
+                    '_' | '?' => vec![0x1f],
+                    '@' | ' ' => vec![0x00],
+                    _ => vec![], // unknown Ctrl combo — swallow
+                }
+            }
         }
         KeyCode::Char(c) if alt => {
             let mut v = vec![0x1b];
@@ -209,5 +222,18 @@ mod tests {
     fn plain_char_forwards_normally() {
         let bytes = key_to_bytes(KeyCode::Char('c'), KeyModifiers::NONE);
         assert_eq!(bytes, vec![b'c']);
+    }
+
+    // M2: Ctrl+non-letter key mapping tests
+    #[test]
+    fn ctrl_bracket_is_escape() {
+        let bytes = key_to_bytes(KeyCode::Char('['), KeyModifiers::CONTROL);
+        assert_eq!(bytes, vec![0x1b], "Ctrl+[ should be ESC");
+    }
+
+    #[test]
+    fn ctrl_backslash_is_0x1c() {
+        let bytes = key_to_bytes(KeyCode::Char('\\'), KeyModifiers::CONTROL);
+        assert_eq!(bytes, vec![0x1c], "Ctrl+\\ should be 0x1c");
     }
 }


### PR DESCRIPTION
## Summary

G7 TUI/App pure bug fixes (PR-4.0 of 3-way split).

### H4: split_chunks underflow on tiny terminals
`saturating_sub` + `.max(1)` guard on second chunk dimensions. Prevents panic on 1x1 terminals.

### H3: flush_idle_notifications throttle
Static `Mutex<Option<Instant>>` throttles to ≥1s intervals. Was running every 50ms tick causing disk I/O storm.

### M2: key_to_bytes Ctrl+non-letter fix
Letters: standard Ctrl code (`byte - 'a' + 1`). Non-letters: explicit mapping (`Ctrl+[` = ESC, `Ctrl+\` = 0x1c, `Ctrl+]` = 0x1d, etc.).

### Tests (+3)
- `split_chunks_tiny_terminal_no_underflow`: H4 1x1 terminal
- `ctrl_bracket_is_escape`: M2 Ctrl+[ = ESC
- `ctrl_backslash_is_0x1c`: M2 Ctrl+\\ = 0x1c

### Files changed
3 files, +74/-6

### Verification
- `cargo test` (no filter): 28 binaries × 2 modes all 0 failed
- `cargo fmt` + `cargo clippy`: clean