### PR TITLE
feat: Sprint 45 PR-4.5 G7 lifecycle — forwarder docs + overlay state fix + hit-test analysis

### DIFF
--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -301,6 +301,9 @@ enum TabBarClick {
 
 /// Hit-test the tab bar at the given column.
 /// SYNC: layout math must match render_tab_bar() in render.rs.
+/// M4: This is O(n_tabs) string-width scan, not a full layout re-render.
+/// Caching tab positions would save ~5 iterations but adds invalidation
+/// complexity. Kept as-is — n_tabs is typically 1-5.
 fn tab_bar_hit_test(layout: &Layout, col: u16) -> Option<TabBarClick> {
     use unicode_width::UnicodeWidthStr;
     let mut x: u16 = 0;

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -452,7 +452,7 @@ pub(super) fn handle_key(
                     let sel = *selected;
                     let dir = *split_dir;
                     let tabs_count = ctx.layout.tabs.len();
-                    *overlay = Overlay::None;
+                    // H5: overlay clear moved to after move logic (was before — fragile)
                     if sel == tabs_count {
                         // New tab: name after the pane's agent for a sensible default.
                         let name = ctx

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -138,12 +138,16 @@ pub(super) fn create_pane(
     let tx = wakeup_tx.clone();
     let pane_rx = {
         let (fwd_tx, fwd_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        // fire-and-forget: forwarder exits when fwd_tx.send() fails (pane
+        // dropped → fwd_rx dropped → send returns Err) or rx.recv() fails
+        // (agent removed → broadcast sender dropped). H1: lifecycle is
+        // correct — pane drop triggers forwarder exit via channel close.
         std::thread::Builder::new()
             .name(format!("{name}_fwd"))
             .spawn(move || {
                 while let Ok(data) = rx.recv() {
                     if fwd_tx.send(data).is_err() {
-                        break;
+                        break; // H1: pane closed, fwd_rx dropped
                     }
                     let _ = tx.send(pane_id);
                 }
@@ -199,12 +203,13 @@ pub(super) fn attach_pane(
     let pane_rx = {
         let n = name.to_string();
         let (fwd_tx, fwd_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        // fire-and-forget: same lifecycle as create_pane forwarder (H1).
         std::thread::Builder::new()
             .name(format!("{n}_fwd"))
             .spawn(move || {
                 while let Ok(data) = rx.recv() {
                     if fwd_tx.send(data).is_err() {
-                        break;
+                        break; // H1: pane closed, fwd_rx dropped
                     }
                     let _ = tx.send(pane_id);
                 }


### PR DESCRIPTION
## Summary

G7 lifecycle fixes (PR-4.5 of 3-way split).

### H1: Forwarder thread lifecycle
Documented in pane_factory.rs. Both create_pane and attach_pane forwarders exit when fwd_tx.send() fails (pane dropped) or rx.recv() fails (agent removed). Lifecycle is correct — no zombie accumulation. Added fire-and-forget rationale comments per §10.5.

### H5: overlay MovePaneTarget state machine
Removed early `*overlay = Overlay::None` before move logic. Values were captured into locals so data was safe, but the pattern was fragile. Now only post-move clear remains.

### M4: tab_bar_hit_test efficiency
Function is O(n_tabs) string-width scan, not a full layout re-render. n_tabs typically 1-5. Caching adds invalidation complexity for negligible gain. Documented with comment.

### Files changed
3 files, +11/-3

### Verification
- cargo test (no filter): 28 binaries × 2 modes all 0 failed
- cargo fmt + clippy: clean