### PR TITLE
feat: Sprint 45 PR-4.6 G7 sync — fleet sync guard + assign by task ID + run_app docs

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -121,6 +121,15 @@ pub fn run(fleet_path_override: Option<&str>) -> Result<()> {
     result
 }
 
+/// Main event loop for the TUI app.
+///
+/// M5 note: this function is 550+ lines with 15+ locals. Extraction to
+/// `app/event_loop.rs` deferred — the function is a single coherent event
+/// loop with no natural split point that wouldn't increase coupling.
+/// Locals are all loop-scoped state (layout, registry, overlay, etc.)
+/// that the event loop needs in every iteration. Splitting would require
+/// passing all state as a context struct, adding complexity without
+/// reducing cognitive load. Revisit if the function grows further.
 fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Result<()> {
     let home = crate::home_dir();
     let fleet_path = fleet_override

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -38,6 +38,8 @@ pub enum TaskBoardMode {
         /// (display_label, assignee_value)
         choices: Vec<(String, String)>,
         selected: usize,
+        /// M3: captured task ID to avoid col/row index drift
+        task_id: String,
     },
     Help,
 }
@@ -590,6 +592,7 @@ pub(super) fn handle_key(
                 TaskBoardMode::Assign {
                     ref choices,
                     ref mut selected,
+                    ref task_id,
                 } => match key.code {
                     KeyCode::Up | KeyCode::Char('k') if *selected > 0 => {
                         *selected -= 1;
@@ -598,20 +601,18 @@ pub(super) fn handle_key(
                         *selected += 1;
                     }
                     KeyCode::Enter if !choices.is_empty() => {
-                        let columns = crate::render::task_board_columns(items);
-                        if let Some(task) = columns[*col].get(*row) {
-                            let assignee = &choices[*selected].1;
-                            crate::tasks::handle(
-                                ctx.home,
-                                "user",
-                                &serde_json::json!({
-                                    "action": "update",
-                                    "id": task.id,
-                                    "assignee": assignee,
-                                }),
-                            );
-                            *items = crate::tasks::list_all(ctx.home);
-                        }
+                        // M3: use captured task_id instead of col/row indices
+                        let assignee = &choices[*selected].1;
+                        crate::tasks::handle(
+                            ctx.home,
+                            "user",
+                            &serde_json::json!({
+                                "action": "update",
+                                "id": task_id,
+                                "assignee": assignee,
+                            }),
+                        );
+                        *items = crate::tasks::list_all(ctx.home);
                         *mode = TaskBoardMode::Board;
                     }
                     KeyCode::Esc => {
@@ -697,6 +698,11 @@ pub(super) fn handle_key(
                         }
                         // a — assign
                         KeyCode::Char('a') if !columns[*col].is_empty() => {
+                            // M3: capture task_id now to avoid col/row drift
+                            let target_task_id = columns[*col]
+                                .get(*row)
+                                .map(|t| t.id.clone())
+                                .unwrap_or_default();
                             let mut choices: Vec<(String, String)> = Vec::new();
                             let mut seen = std::collections::HashSet::new();
                             // Teams
@@ -729,6 +735,7 @@ pub(super) fn handle_key(
                             *mode = TaskBoardMode::Assign {
                                 choices,
                                 selected: 0,
+                                task_id: target_task_id,
                             };
                         }
                         // Shift+← / Shift+→ — move task status

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -69,6 +69,13 @@ pub(super) fn sync_fleet_yaml(home: &Path, layout: &Layout) {
         }
     }
 
+    // H2: guard — if no panes have fleet_instance_name, the layout wasn't
+    // populated from fleet.yaml (crash recovery / fresh start). Skip sync
+    // to avoid deleting all fleet entries.
+    if active_fleet_names.is_empty() {
+        return;
+    }
+
     // Batch-remove fleet entries not in any pane (single atomic write)
     if let Some(ref f) = fleet {
         let to_remove: Vec<String> = f

--- a/src/render.rs
+++ b/src/render.rs
@@ -1483,7 +1483,7 @@ pub fn render_tasks(
                 inner_popup,
             );
         }
-        TaskBoardMode::Assign { choices, selected } => {
+        TaskBoardMode::Assign { choices, selected, .. } => {
             let h = (choices.len() as u16 + 2).min(inner.height.saturating_sub(2));
             let w = 40u16.min(inner.width.saturating_sub(4));
             let popup = Rect::new(

--- a/src/render.rs
+++ b/src/render.rs
@@ -1483,7 +1483,9 @@ pub fn render_tasks(
                 inner_popup,
             );
         }
-        TaskBoardMode::Assign { choices, selected, .. } => {
+        TaskBoardMode::Assign {
+            choices, selected, ..
+        } => {
             let h = (choices.len() as u16 + 2).min(inner.height.saturating_sub(2));
             let w = 40u16.min(inner.width.saturating_sub(4));
             let popup = Rect::new(


### PR DESCRIPTION
## Summary

G7 final (PR-4.6 of 3-way split): sync/structural fixes.

### H2: sync_fleet_yaml post-crash guard
Skip sync when no panes have `fleet_instance_name` set — indicates layout wasn't populated from fleet.yaml (crash recovery / fresh start). Prevents deleting all fleet entries.

### M3: Task board Assign mode by task ID
Captures `task_id` when entering Assign mode ('a' key) instead of using col/row indices at Enter time. Prevents assigning to wrong task if board layout changes between keystrokes.

### M5: run_app structural documentation
550+ line function with 15+ locals. Extraction to `event_loop.rs` deferred — single coherent event loop with no natural split point. Splitting would require context struct adding complexity without reducing cognitive load. Documented with rationale comment.

### Files changed
4 files, +38/-15

### Verification
- cargo test (no filter): 28 binaries × 2 modes all 0 failed
- cargo fmt + clippy: clean