### PR TITLE
feat: Sprint 45 PR-6.0 G4 MCP fixes (H2+M1+M2+M4+M5)

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -13,7 +13,15 @@ impl Sender {
     /// Construct a `Sender`. Returns `None` if the input is empty.
     pub fn new(s: impl Into<String>) -> Option<Self> {
         let s = s.into();
-        (!s.is_empty()).then_some(Self(s))
+        // M2: validate name format — only alphanumeric, dash, underscore, colon
+        if s.is_empty()
+            || !s
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ':')
+        {
+            return None;
+        }
+        Some(Self(s))
     }
 
     /// Read the sender identity from `AGEND_INSTANCE_NAME`. Returns `None`

--- a/src/mcp/handlers/ci.rs
+++ b/src/mcp/handlers/ci.rs
@@ -34,6 +34,18 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
             })
             .unwrap_or_else(|| source.to_string())
     };
+    // H2: validate source_path — reject path traversal and system paths
+    let source_canonical = match std::path::Path::new(&source_path).canonicalize() {
+        Ok(p) => p,
+        Err(e) => return json!({"error": format!("invalid source path: {e}")}),
+    };
+    if source_canonical.starts_with("/etc")
+        || source_canonical.starts_with("/usr")
+        || source_canonical.starts_with("/sys")
+        || source_canonical.starts_with("/proc")
+    {
+        return json!({"error": "source path rejected: system directory"});
+    }
     match std::process::Command::new("git")
         .args([
             "worktree",

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -81,6 +81,9 @@ pub(super) fn handle_create_instance(home: &Path, args: &Value, instance_name: &
                 if let Some(task_text) = task {
                     let home = home.to_path_buf();
                     let names = spawned.clone();
+                    // fire-and-forget: team task injection waits 3s for agents to
+                    // initialize, then injects task text. No JoinHandle needed —
+                    // losing the injection on shutdown is acceptable (M5 §10.5).
                     std::thread::Builder::new()
                         .name("team_task_inject".into())
                         .spawn(move || {
@@ -377,10 +380,12 @@ pub(super) fn handle_pane_snapshot(home: &Path, args: &Value) -> Value {
     if let Err(e) = crate::agent::validate_name(target) {
         return json!({"error": e});
     }
-    let lines = args["lines"].as_u64().unwrap_or(100) as usize;
-    if lines > 10000 {
+    let lines_u64 = args["lines"].as_u64().unwrap_or(100);
+    // M1: explicit bounds check before u64→usize cast (32-bit safety)
+    if lines_u64 > 10000 {
         return json!({"error": "lines must be <= 10000 (scrolling_history limit)"});
     }
+    let lines = lines_u64 as usize;
     match crate::api::call(
         home,
         &json!({"method": crate::api::method::PANE_SNAPSHOT, "params": {"name": target, "lines": lines}}),
@@ -502,8 +507,9 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
         return json!({"error": e});
     }
     let name_owned = {
-        use std::sync::atomic::{AtomicU16, Ordering};
-        static DEDUP_SEQ: AtomicU16 = AtomicU16::new(0);
+        // M4: AtomicU64 prevents 65536 wrap-around collision
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static DEDUP_SEQ: AtomicU64 = AtomicU64::new(0);
 
         let existing: std::collections::HashSet<String> =
             crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
@@ -605,6 +611,7 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
             if let Some(task_text) = task {
                 let h = home.to_path_buf();
                 let n = name.to_string();
+                // fire-and-forget: single-agent task injection (M5 §10.5).
                 std::thread::Builder::new()
                     .name("task_inject".into())
                     .spawn(move || {


### PR DESCRIPTION
## Summary

G4 MCP Layer small fixes (PR-6.0 of 2-way split).

| ID | Fix |
|---|---|
| H2 | checkout_repo: path canonicalize + system-prefix reject (/etc, /usr, /sys, /proc) |
| M1 | pane_snapshot: explicit u64→usize bounds check before cast (32-bit safety) |
| M2 | Sender::new(): name format validation (alphanumeric + dash/underscore/colon) |
| M4 | dedup counter: AtomicU16 → AtomicU64 (prevents 65536 wrap) |
| M5 | team spawn: fire-and-forget §10.5 rationale comments on both inject threads |

### Files changed
3 files, +32/-5

### Verification
- cargo test (no filter): 28 binaries × 2 modes all 0 failed
- cargo fmt --check: clean
- cargo clippy: clean