### PR TITLE
feat: Sprint 45 PR-7 G2 Agent Lifecycle (5 issues)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -516,7 +516,7 @@ fn spawn_instructions_bootstrap(
     // poll loop (returns early on shutdown). JoinHandle dropped because the
     // thread is short-lived and one missed bootstrap on shutdown is cosmetic.
     let spawn_result = std::thread::Builder::new().name(thread_name).spawn(move || {
-        let _census = crate::thread_census::register("pty_reader");
+        let _census = crate::thread_census::register("instr_boot"); // M3: was "pty_reader"
         let deadline = std::time::Instant::now() + timeout;
         let poll_interval = std::time::Duration::from_millis(200);
 
@@ -816,13 +816,25 @@ pub fn try_dismiss_dialog(
             // Delayed write: TUI escape-sequence parsers need time to distinguish
             // \x1b (ESC key) from \x1b[ (CSI start).  Writing immediately causes
             // Ink-based TUIs (kiro-cli) to interpret \x1b as "ESC to cancel".
+            // H2: bounded dismiss — skip if one already in-flight for this agent.
+            // Prevents thread accumulation from rapid dialog re-detection.
+            static DISMISS_IN_FLIGHT: std::sync::LazyLock<
+                parking_lot::Mutex<std::collections::HashSet<String>>,
+            > = std::sync::LazyLock::new(|| {
+                parking_lot::Mutex::new(std::collections::HashSet::new())
+            });
+            {
+                let mut inflight = DISMISS_IN_FLIGHT.lock();
+                if inflight.contains(name) {
+                    return true; // dismiss already pending
+                }
+                inflight.insert(name.to_string());
+            }
             let writer = Arc::clone(pty_writer);
             let keys = key_seq.clone();
             let agent = name.to_string();
             // fire-and-forget: dialog-dismiss keystroke writer is short-lived
-            // (sleep 300ms then write), no shutdown signal needed because the
-            // PTY closes on shutdown which surfaces as a write error inside
-            // the loop. Missing one auto-dismiss on shutdown is acceptable.
+            // (sleep 300ms then write). H2: removes from in-flight set on exit.
             std::thread::spawn(move || {
                 std::thread::sleep(std::time::Duration::from_millis(300));
                 // Send keys in chunks split on \r/\n boundaries with delay between,
@@ -850,6 +862,8 @@ pub fn try_dismiss_dialog(
                     let _ = w.flush();
                 }
                 tracing::debug!(agent = %agent, "dismiss keystrokes sent");
+                // H2: remove from in-flight set
+                DISMISS_IN_FLIGHT.lock().remove(&agent);
             });
             return true;
         }
@@ -887,28 +901,36 @@ pub fn write_to_agent_typed(agent: &AgentHandle, data: &[u8]) -> crate::error::R
 pub fn inject_to_agent(agent: &AgentHandle, text: &[u8]) -> crate::error::Result<()> {
     let prefix = agent.inject_prefix.as_bytes();
     let submit = agent.submit_key.as_bytes();
-    let mut w = agent.pty_writer.lock();
 
-    // Write prefix + text
     if agent.typed_inject {
-        for byte in prefix.iter().chain(text.iter()) {
-            w.write_all(&[*byte])?;
-            w.flush()?;
-            std::thread::sleep(std::time::Duration::from_millis(2));
+        // H1: collect all bytes first, then write in short lock bursts.
+        // Previous pattern held pty_writer lock for 2ms × N bytes (~20s for 10KB).
+        let all_bytes: Vec<u8> = prefix.iter().chain(text.iter()).copied().collect();
+        for chunk in all_bytes.chunks(64) {
+            let mut w = agent.pty_writer.lock();
+            for &byte in chunk {
+                w.write_all(&[byte])?;
+                w.flush()?;
+            }
+            drop(w);
+            std::thread::sleep(std::time::Duration::from_millis(2 * chunk.len() as u64));
         }
     } else {
+        let mut w = agent.pty_writer.lock();
         if !prefix.is_empty() {
             w.write_all(prefix)?;
             w.flush()?;
         }
         w.write_all(text)?;
         w.flush()?;
+        drop(w);
     }
 
     // Delay before submit
     std::thread::sleep(std::time::Duration::from_millis(20));
 
     // Write submit key
+    let mut w = agent.pty_writer.lock();
     w.write_all(submit)?;
     w.flush()?;
     Ok(())

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -114,10 +114,8 @@ pub fn save_metadata(home: &Path, instance_name: &str, key: &str, value: Value) 
         .unwrap_or(json!({}));
     meta[key] = value;
     let content = serde_json::to_string_pretty(&meta).unwrap_or_default();
-    let tmp_path = meta_path.with_extension("json.tmp");
-    if std::fs::write(&tmp_path, &content).is_ok() {
-        let _ = std::fs::rename(&tmp_path, &meta_path);
-    }
+    // M1: atomic write with fsync
+    let _ = crate::store::atomic_write(&meta_path, content.as_bytes());
 }
 
 /// Persist multiple metadata key/value pairs in a single atomic write.
@@ -134,10 +132,8 @@ pub fn save_metadata_batch(home: &Path, instance_name: &str, entries: &[(&str, V
         meta[*key] = value.clone();
     }
     let content = serde_json::to_string_pretty(&meta).unwrap_or_default();
-    let tmp_path = meta_path.with_extension("json.tmp");
-    if std::fs::write(&tmp_path, &content).is_ok() {
-        let _ = std::fs::rename(&tmp_path, &meta_path);
-    }
+    // M1: atomic write with fsync
+    let _ = crate::store::atomic_write(&meta_path, content.as_bytes());
 }
 
 // ---------------------------------------------------------------------------

--- a/src/process.rs
+++ b/src/process.rs
@@ -60,16 +60,18 @@ pub fn terminate(pid: u32) {
 pub fn kill_process_tree(pid: u32) {
     #[cfg(unix)]
     {
-        let pgid = -(pid as i32);
+        // M2: query actual PGID instead of assuming PID==PGID
+        let pgid = unsafe { libc::getpgid(pid as i32) };
+        let kill_pgid = if pgid > 0 { -pgid } else { -(pid as i32) };
         // SIGTERM the entire process group
         unsafe {
-            libc::kill(pgid, libc::SIGTERM);
+            libc::kill(kill_pgid, libc::SIGTERM);
         }
         // Grace period, then unconditional SIGKILL (handles grandchildren
         // that ignore SIGTERM even if leader already exited).
         std::thread::sleep(std::time::Duration::from_millis(500));
         unsafe {
-            libc::kill(pgid, libc::SIGKILL);
+            libc::kill(kill_pgid, libc::SIGKILL);
         }
         // ESRCH (no such process) is fine — group already dead.
     }


### PR DESCRIPTION
## Summary

G2 Agent Lifecycle: 2 HIGH + 3 MEDIUM issues.

| ID | Fix |
|---|---|
| H1 | inject_to_agent: collect-then-release pattern (64-byte chunks, lock released between) |
| H2 | try_dismiss_dialog: thread budget via LazyLock HashSet (skip if dismiss in-flight) |
| M1 | save_metadata: store::atomic_write with fsync (was tmp+rename without fsync) |
| M2 | kill_process_tree: getpgid() query (was assuming PID==PGID) |
| M3 | spawn_instructions_bootstrap: census class 'instr_boot' (was 'pty_reader') |

### Files changed
3 files, +41/-21

### Verification
- cargo test (no filter): 28 binaries all 0 failed
- agent::tests: 16/16 pass (including dismiss tests)
- cargo fmt --check + clippy: clean