### PR TITLE
feat: Sprint 46 P3 — ID audit trail in task_events + dispatch_tracking

### DIFF
--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -8,11 +8,17 @@ pub const DISPATCH_WARN_MINUTES: i64 = 15;
 /// Ask threshold: daemon sends query to assignee after this.
 pub const DISPATCH_ASK_MINUTES: i64 = 30;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DispatchEntry {
     pub task_id: Option<String>,
     pub from: String,
     pub to: String,
+    /// Sprint 46 P3: sender's InstanceId for audit trail.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_id: Option<String>,
+    /// Sprint 46 P3: target's InstanceId for audit trail.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_id: Option<String>,
     pub delegated_at: String,
     pub status: String, // "pending" | "completed" | "warned" | "asked"
 }
@@ -166,6 +172,8 @@ mod tests {
                 task_id: Some("t-test".into()),
                 from: "lead".into(),
                 to: "impl".into(),
+                from_id: None,
+                to_id: None,
                 delegated_at: past,
                 status: "pending".into(),
             },
@@ -190,6 +198,8 @@ mod tests {
                 task_id: Some("t-test".into()),
                 from: "lead".into(),
                 to: "reviewer".into(),
+                from_id: None,
+                to_id: None,
                 delegated_at: past,
                 status: "pending".into(),
             },
@@ -214,6 +224,8 @@ mod tests {
                 task_id: Some("t-123".into()),
                 from: "lead".into(),
                 to: "impl".into(),
+                from_id: None,
+                to_id: None,
                 delegated_at: (chrono::Utc::now() - chrono::Duration::minutes(20)).to_rfc3339(),
                 status: "pending".into(),
             },
@@ -237,6 +249,8 @@ mod tests {
                 task_id: Some("t-stuck".into()),
                 from: "lead".into(),
                 to: "reviewer".into(),
+                from_id: None,
+                to_id: None,
                 delegated_at: past,
                 status: "pending".into(),
             },
@@ -263,6 +277,8 @@ mod tests {
                 task_id: Some("t-orphan".into()),
                 from: "lead".into(),
                 to: "worker".into(),
+                from_id: None,
+                to_id: None,
                 delegated_at: old_ts,
                 status: "pending".into(),
             },
@@ -284,6 +300,8 @@ mod tests {
                 task_id: Some("t-old".into()),
                 from: "lead".into(),
                 to: "dev".into(),
+                from_id: None,
+                to_id: None,
                 delegated_at: (chrono::Utc::now() - chrono::Duration::days(31)).to_rfc3339(),
                 status: "completed".into(),
             },
@@ -295,6 +313,8 @@ mod tests {
                 task_id: Some("t-recent".into()),
                 from: "lead".into(),
                 to: "dev".into(),
+                from_id: None,
+                to_id: None,
                 delegated_at: chrono::Utc::now().to_rfc3339(),
                 status: "completed".into(),
             },

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -324,6 +324,12 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                 task_id: task_id.clone(),
                 from: sender.as_str().to_string(),
                 to: target.to_string(),
+                from_id: crate::agent::resolve_instance(home, sender.as_str())
+                    .ok()
+                    .map(|(id, _)| id.full()),
+                to_id: crate::agent::resolve_instance(home, target)
+                    .ok()
+                    .map(|(id, _)| id.full()),
                 delegated_at: chrono::Utc::now().to_rfc3339(),
                 status: "pending".to_string(),
             },

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -361,6 +361,9 @@ pub struct TaskEventEnvelope {
     pub timestamp: String,
     /// Which agent emitted this event.
     pub instance: InstanceName,
+    /// Sprint 46 P3: emitter's InstanceId for audit trail.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emitter_id: Option<String>,
     pub event: TaskEvent,
 }
 
@@ -647,6 +650,11 @@ pub fn append_batch(
     let mut seqs: Vec<u64> = Vec::with_capacity(count);
     let now = chrono::Utc::now().to_rfc3339();
 
+    // Sprint 46 P3: resolve emitter's InstanceId for audit trail.
+    let emitter_id = crate::agent::resolve_instance(home, instance.as_str())
+        .ok()
+        .map(|(id, _)| id.full());
+
     crate::event_log::append_lines_under_lock(home, LOG_NAME, |log_path| {
         let start_seq = max_seq_for_instance(log_path, &instance)? + 1;
         let mut lines = Vec::with_capacity(count);
@@ -658,6 +666,7 @@ pub fn append_batch(
                 seq,
                 timestamp: now.clone(),
                 instance: instance.clone(),
+                emitter_id: emitter_id.clone(),
                 event,
             };
             lines.push(serde_json::to_string(&envelope)?);
@@ -1001,6 +1010,7 @@ mod tests {
                 seq: i as u64,
                 timestamp: format!("2026-04-27T{:02}:00:00Z", i % 24),
                 instance: inst.clone(),
+                emitter_id: None,
                 event: TaskEvent::Unblocked {
                     task_id: format!("t-{i}").as_str().into(),
                 },
@@ -1228,6 +1238,7 @@ mod tests {
             seq: 1,
             timestamp: "2026-04-27T01:00:00+09:00".into(),
             instance: InstanceName::from("u"),
+            emitter_id: None,
             event: sample_event("t-TZ"),
         };
         let env_b = TaskEventEnvelope {
@@ -1235,6 +1246,7 @@ mod tests {
             seq: 2,
             timestamp: "2026-04-27T00:00:00Z".into(),
             instance: InstanceName::from("u"),
+            emitter_id: None,
             event: TaskEvent::Done {
                 task_id: "t-TZ".into(),
                 by: "u".into(),
@@ -1275,6 +1287,7 @@ mod tests {
                 seq: 2,
                 timestamp: "2026-04-27T00:00:02Z".into(),
                 instance: InstanceName::from("u"),
+                emitter_id: None,
                 event: TaskEvent::Claimed {
                     task_id: "t-O".into(),
                     by: "u".into(),
@@ -1285,6 +1298,7 @@ mod tests {
                 seq: 1,
                 timestamp: "2026-04-27T00:00:01Z".into(),
                 instance: InstanceName::from("u"),
+                emitter_id: None,
                 event: sample_event("t-O"),
             },
         ];
@@ -1652,6 +1666,7 @@ mod tests {
                 seq: 1,
                 timestamp: "2026-04-27T00:00:01Z".into(),
                 instance: inst.clone(),
+                emitter_id: None,
                 event: TaskEvent::Created {
                     task_id: TaskId::from("t-S1"),
                     title: "s1".into(),
@@ -1672,6 +1687,7 @@ mod tests {
                 seq: 1,
                 timestamp: "2026-04-27T00:00:03Z".into(),
                 instance: sweep.clone(),
+                emitter_id: None,
                 event: TaskEvent::Linked {
                     task_id: TaskId::from("t-S1"),
                     pr_id: PrId(42),
@@ -1691,6 +1707,7 @@ mod tests {
                 seq: 2,
                 timestamp: "2026-04-27T00:00:02Z".into(),
                 instance: inst.clone(),
+                emitter_id: None,
                 event: TaskEvent::Claimed {
                     task_id: TaskId::from("t-S1"),
                     by: inst.clone(),
@@ -1701,6 +1718,7 @@ mod tests {
                 seq: 2,
                 timestamp: "2026-04-27T00:00:04Z".into(),
                 instance: sweep.clone(),
+                emitter_id: None,
                 event: TaskEvent::Done {
                     task_id: TaskId::from("t-S1"),
                     by: inst.clone(),
@@ -1740,5 +1758,45 @@ mod tests {
         );
         fs::remove_dir_all(&home_a).ok();
         fs::remove_dir_all(&home_b).ok();
+    }
+
+    // ── Sprint 46 P3: audit trail round-trip tests ──────────────────
+
+    #[test]
+    fn emitter_id_round_trips_through_serde() {
+        let env = TaskEventEnvelope {
+            schema_version: SCHEMA_VERSION,
+            seq: 1,
+            timestamp: "2026-05-04T00:00:00Z".into(),
+            instance: InstanceName::from("dev"),
+            emitter_id: Some("a1b2c3d4-e5f6-7890-abcd-ef1234567890".into()),
+            event: sample_event("t-rt"),
+        };
+        let json = serde_json::to_string(&env).expect("serialize");
+        assert!(json.contains("a1b2c3d4"));
+        let deser: TaskEventEnvelope = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            deser.emitter_id.as_deref(),
+            Some("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        );
+    }
+
+    #[test]
+    fn emitter_id_none_omitted_from_json() {
+        let env = TaskEventEnvelope {
+            schema_version: SCHEMA_VERSION,
+            seq: 1,
+            timestamp: "2026-05-04T00:00:00Z".into(),
+            instance: InstanceName::from("dev"),
+            emitter_id: None,
+            event: sample_event("t-rt2"),
+        };
+        let json = serde_json::to_string(&env).expect("serialize");
+        assert!(
+            !json.contains("emitter_id"),
+            "None emitter_id must be omitted"
+        );
+        let deser: TaskEventEnvelope = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deser.emitter_id, None);
     }
 }


### PR DESCRIPTION
## Summary

Add InstanceId audit trail fields to task events and dispatch tracking. Display layer unchanged — name remains primary for human-readable output; IDs are additive for audit/debugging.

## Changes

- `task_events.rs`: `emitter_id: Option<String>` on `TaskEventEnvelope`, populated from `resolve_instance` in `append_batch`
- `dispatch_tracking.rs`: `from_id`/`to_id: Option<String>` on `DispatchEntry`, populated in `handle_delegate_task`
- Both fields use `#[serde(skip_serializing_if = "Option::is_none")]` for backward compat
- 2 round-trip tests (serialize/deserialize preservation + None omission)

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -D warnings` ✅
- `cargo test -- --test-threads=1` ✅
- `cargo test` (parallel) ✅
- `comms.rs` LOC = 675 ✅