### PR TITLE
fix: persist topic_id to fleet.yaml on create_instance (#415)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -207,6 +207,16 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
             let mut result = json!({"name": name});
             if let Some(tid) = topic_id {
                 result["topic_id"] = json!(tid);
+                // Persist topic_id to fleet.yaml so daemon can route messages
+                // to this instance's topic on restart (#415).
+                if let Ok(tid_num) = tid.parse::<i32>() {
+                    let _ = crate::fleet::update_instance_field(
+                        ctx.home,
+                        name,
+                        "topic_id",
+                        serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(tid_num)),
+                    );
+                }
             }
             json!({"ok": true, "result": result})
         }
@@ -627,5 +637,32 @@ mod tests {
         }
 
         cleanup_agent(&ctx, "team-meta");
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn topic_id_persists_to_fleet_yaml_via_update_instance_field() {
+        // Regression test for #415: topic_id must round-trip through fleet.yaml.
+        let home = std::env::temp_dir().join(format!("agend-topic-persist-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "instances:\n  agent1:\n    backend: claude\n",
+        )
+        .unwrap();
+        crate::fleet::update_instance_field(
+            &home,
+            "agent1",
+            "topic_id",
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(42)),
+        )
+        .unwrap();
+        let cfg = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        assert_eq!(
+            cfg.instances.get("agent1").and_then(|i| i.topic_id),
+            Some(42),
+            "topic_id must be persisted to fleet.yaml"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -214,6 +214,15 @@ pub(super) fn handle_describe_instance(home: &Path, args: &Value) -> Value {
                 Some(agent) => {
                     let mut info = agent.clone();
                     merge_metadata(home, name, &mut info);
+                    // Surface topic_id from fleet.yaml for debugging (#415).
+                    if info.get("topic_id").is_none() {
+                        if let Some(tid) = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+                            .ok()
+                            .and_then(|c| c.instances.get(name)?.topic_id)
+                        {
+                            info["topic_id"] = json!(tid);
+                        }
+                    }
                     json!({"instance": info})
                 }
                 None => json!({"error": format!("Instance '{name}' not found")}),


### PR DESCRIPTION
Closes #415

## Problem
`create_instance` creates a Telegram topic and returns `topic_id` in the response, but never persists it to `fleet.yaml`. On daemon restart, the topic is orphaned and messages fall back to the general topic.

## Fix
- `api/handlers/instance.rs`: After topic creation, call `update_instance_field` to write `topic_id` to fleet.yaml
- `mcp/handlers/instance.rs`: `describe_instance` now surfaces `topic_id` from fleet.yaml
- Regression test: `topic_id_persists_to_fleet_yaml_via_update_instance_field`

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -D warnings` ✅
- 1419 tests pass (1418 baseline + 1 new) ✅

Thanks to cheerc for reporting the issue.