### PR TITLE
fix: add Connection: close to test mock servers for Windows CI

### DIFF
--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -2424,7 +2424,7 @@ mod tests {
             *captured_clone.lock().expect("lock") = Some((path, request));
 
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
                 body.len(),
                 body
             );
@@ -2753,7 +2753,7 @@ mod tests {
                 } else {
                     "error line 1\nerror line 2\n"
                 };
-                let resp = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}", body.len(), body);
+                let resp = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}", body.len(), body);
                 stream.write_all(resp.as_bytes()).expect("write");
             }
         });


### PR DESCRIPTION
## Problem

Bitbucket ci_watch tests hang for 60+ seconds on Windows CI:
- `bitbucket_fetch_failure_summary_finds_failed_step`
- `bitbucket_poll_runs_parses_pipelines`
- `bitbucket_token_warning_when_no_token`

## Root Cause

The raw TCP mock servers (`gitlab_mock_server` and the inline mock in `bitbucket_fetch_failure_summary`) don't send `Connection: close`. reqwest uses HTTP/1.1 keep-alive by default, so after reading the response body it waits for more data on the same connection.

On Linux/macOS, the mock thread ending drops the socket and the client sees EOF immediately. On Windows, TCP close propagation is delayed, so the client hangs until the 5-second reqwest timeout fires per request.

## Fix

Add `Connection: close` header to both mock server response templates. This tells reqwest to close the connection after reading the response body, eliminating the keep-alive wait.

## Testing

- `cargo check` passes locally
- CI will validate on Windows