### PR TITLE
ci: merge redundant clippy/test steps, bump checkout v5

### DIFF
--- a/.github/workflows/behavioral-nightly-real.yml
+++ b/.github/workflows/behavioral-nightly-real.yml
@@ -25,7 +25,7 @@ jobs:
     name: Real backend spawn (${{ github.event.inputs.backends }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Run backend harness tests
         run: cargo test -- --ignored backend_harness

--- a/.github/workflows/behavioral-nightly.yml
+++ b/.github/workflows/behavioral-nightly.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --bin agend-terminal -- e2e_
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,42 +46,24 @@ jobs:
         timeout-minutes: 5
         run: cargo fmt --check
 
-      - name: Clippy
-        timeout-minutes: 10
-        run: cargo clippy -- -D warnings
-
-      # Tray feature gate (docs/archived/PLAN-tray-resident.md). Release binaries
-      # still ship default-only until PLAN task #4 pulls in tray-icon/tao;
-      # this step just guarantees the feature code compiles on all three
-      # platforms so per-OS regressions surface before the event loop lands.
-      - name: Clippy (tray feature)
-        timeout-minutes: 10
+      # Single clippy pass with --all-targets --features tray is a superset
+      # of the default-feature check — catches both default and tray code
+      # paths in one compilation, saving a full rebuild.
+      - name: Clippy (all targets + tray)
+        timeout-minutes: 15
         run: cargo clippy --all-targets --features tray -- -D warnings
 
       - name: Build
         timeout-minutes: 20
         run: cargo build --release
 
-      - name: Unit tests
-        timeout-minutes: 20
-        run: cargo test --bin agend-terminal
-
-      - name: Unit tests (tray feature)
-        timeout-minutes: 20
-        run: cargo test --bin agend-terminal --features tray
-
-      # Sprint 23 P1 — anti-bypass invariant tests live in tests/*.rs but
-      # the previous `cargo test --test integration` only ran one file
-      # (integration.rs). Anti-bypass invariants (task_events /
-      # legacy_outbound / spawn_rationale / heartbeat_pair) and
-      # characterization tests (mcp_characterization / mcp_roundtrip /
-      # no_dual_track_drift / self_healing_supervisor) silently passed CI
-      # if their assertions broke. `--tests` covers every `tests/*.rs`
-      # file plus already-covered unit tests; the unit-test repeat is
-      # cheap (cached) and keeps the invariant net fail-loud.
-      - name: Integration tests + anti-bypass invariants
+      # `--tests` covers unit tests (--bin) + every tests/*.rs integration
+      # file. `--features tray` ensures tray-gated code is tested too.
+      # Previously this was 3 separate steps (unit, unit+tray, integration)
+      # which triggered 2 extra recompilations from feature-flag switching.
+      - name: Tests (unit + integration + tray)
         timeout-minutes: 30
-        run: cargo test --tests
+        run: cargo test --tests --features tray
 
       - name: CLI smoke (Phase C.5)
         timeout-minutes: 10


### PR DESCRIPTION
## Changes

**ci.yml — eliminate redundant compilations:**
- Clippy: merge 2 steps (default, tray) → 1 (`--all-targets --features tray`). The tray superset already checks default code paths.
- Tests: merge 3 steps (unit, unit+tray, integration) → 1 (`--tests --features tray`). Eliminates 2 recompilations from feature-flag switching.
- Net: 5 steps → 2 steps, estimated 3-5 min savings on Windows.

**Nightly workflows — version consistency:**
- `behavioral-nightly.yml`: checkout@v4 → v5
- `behavioral-nightly-real.yml`: checkout@v4 → v5

## What's NOT changed
- Build step (`cargo build --release`) stays as-is — release profile is separate from test/clippy.
- CLI smoke test unchanged.
- Release workflow unchanged.

## Testing
CI on this PR validates the merged steps work on all 3 platforms.