### PR TITLE
feat: Sprint 49 — channel discipline correction (inject-only nudge)

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -233,6 +233,12 @@ fn tick(
             // §4.4 stale decay: clear waiting_on when heartbeat is stale.
             clear_waiting_on_if_stale(home, &name, !core.state.is_heartbeat_fresh());
 
+            // Sprint 49: channel discipline — inject nudge when agent
+            // completes a response without using the reply tool.
+            if core.state.take_response_complete() {
+                check_channel_discipline(home, &name);
+            }
+
             let agent_state = core.state.current;
             let silent = core.state.last_output.elapsed();
             if core.health.check_awaiting_operator(agent_state, silent) {
@@ -351,6 +357,60 @@ fn format_stall_notice(name: &str, tail: &str, silent_secs: Option<u64>) -> Stri
 /// conversation again.
 fn format_recovery_notice(name: &str) -> String {
     format!("✅ {name} 已就緒，可以繼續對話")
+}
+
+/// Sprint 49: channel discipline — inject nudge when agent completes a
+/// response without using the `reply` tool after receiving inbound input.
+fn check_channel_discipline(home: &std::path::Path, name: &str) {
+    use serde_json::json;
+
+    let meta_path = crate::agent_ops::metadata_path_resolved(home, name);
+    let meta: serde_json::Value = std::fs::read_to_string(&meta_path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or(json!({}));
+
+    // Skip if agent already used reply tool this input cycle.
+    if meta["reply_tool_called_since_input"].as_bool() == Some(true) {
+        return;
+    }
+    // Skip if no inbound channel tracked (TUI direct or no input yet).
+    let channel = match meta["last_input_channel"].as_str() {
+        Some(ch @ ("telegram" | "agent_peer")) => ch,
+        _ => return,
+    };
+    // Cooldown: max 2 injects per input cycle.
+    let count = meta["inject_count_since_input"].as_u64().unwrap_or(0);
+    if count >= 2 {
+        return;
+    }
+    // Cooldown: 30s minimum between injects.
+    let last_inject = meta["last_inject_at_ms"].as_i64().unwrap_or(0);
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    if now_ms - last_inject < 30_000 {
+        return;
+    }
+
+    let tool_name = if channel == "telegram" {
+        "reply"
+    } else {
+        "send"
+    };
+    let msg = format!(
+        "[CHANNEL DISCIPLINE] You received input from {channel} but your last response \
+         went to direct text. Please re-send using the `{tool_name}` MCP tool so the \
+         operator/peer sees it."
+    );
+    crate::inbox::compose_aware_send(home, name, &msg);
+    crate::agent_ops::save_metadata_batch(
+        home,
+        name,
+        &[
+            ("inject_count_since_input", json!(count + 1)),
+            ("last_inject_at_ms", json!(now_ms)),
+        ],
+    );
+    tracing::info!(agent = %name, %channel, inject_count = count + 1, "channel discipline inject fired");
 }
 
 /// Read `last_heartbeat` from the agent's metadata file and return the age
@@ -715,5 +775,111 @@ mod tests {
             Some("15:14".to_string())
         );
         assert_eq!(super::parse_unlock_at("no time here"), None);
+    }
+
+    // ── Sprint 49: channel discipline tests ─────────────────────────
+
+    fn cd_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static CTR: AtomicU32 = AtomicU32::new(0);
+        let d = std::env::temp_dir().join(format!(
+            "agend-cd-{}-{}-{}",
+            std::process::id(),
+            tag,
+            CTR.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&d).ok();
+        d
+    }
+
+    #[test]
+    fn channel_discipline_no_inject_when_reply_tool_used() {
+        let home = cd_home("reply-ok");
+        crate::agent_ops::save_metadata_batch(
+            &home,
+            "a",
+            &[
+                ("last_input_channel", serde_json::json!("telegram")),
+                ("reply_tool_called_since_input", serde_json::json!(true)),
+                ("inject_count_since_input", serde_json::json!(0)),
+            ],
+        );
+        super::check_channel_discipline(&home, "a");
+        // No inject should have fired — compose_aware_send not called.
+        // Verify inject_count unchanged.
+        let meta: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(crate::agent_ops::metadata_path_resolved(&home, "a"))
+                .unwrap_or_default(),
+        )
+        .unwrap_or_default();
+        assert_eq!(meta["inject_count_since_input"], 0);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn channel_discipline_inject_fires_on_direct_text() {
+        let home = cd_home("direct-text");
+        crate::agent_ops::save_metadata_batch(
+            &home,
+            "a",
+            &[
+                ("last_input_channel", serde_json::json!("telegram")),
+                ("reply_tool_called_since_input", serde_json::json!(false)),
+                ("inject_count_since_input", serde_json::json!(0)),
+            ],
+        );
+        super::check_channel_discipline(&home, "a");
+        let meta: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(crate::agent_ops::metadata_path_resolved(&home, "a"))
+                .unwrap_or_default(),
+        )
+        .unwrap_or_default();
+        assert_eq!(meta["inject_count_since_input"], 1);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn channel_discipline_tui_input_skipped() {
+        let home = cd_home("tui-skip");
+        crate::agent_ops::save_metadata_batch(
+            &home,
+            "a",
+            &[
+                ("last_input_channel", serde_json::json!("tui")),
+                ("reply_tool_called_since_input", serde_json::json!(false)),
+                ("inject_count_since_input", serde_json::json!(0)),
+            ],
+        );
+        super::check_channel_discipline(&home, "a");
+        let meta: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(crate::agent_ops::metadata_path_resolved(&home, "a"))
+                .unwrap_or_default(),
+        )
+        .unwrap_or_default();
+        assert_eq!(meta["inject_count_since_input"], 0);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn channel_discipline_cooldown_caps_at_2() {
+        let home = cd_home("cooldown");
+        crate::agent_ops::save_metadata_batch(
+            &home,
+            "a",
+            &[
+                ("last_input_channel", serde_json::json!("telegram")),
+                ("reply_tool_called_since_input", serde_json::json!(false)),
+                ("inject_count_since_input", serde_json::json!(2)),
+            ],
+        );
+        super::check_channel_discipline(&home, "a");
+        let meta: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(crate::agent_ops::metadata_path_resolved(&home, "a"))
+                .unwrap_or_default(),
+        )
+        .unwrap_or_default();
+        // Should still be 2 — cooldown prevents further injects.
+        assert_eq!(meta["inject_count_since_input"], 2);
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -402,6 +402,19 @@ fn check_channel_discipline(home: &std::path::Path, name: &str) {
          operator/peer sees it."
     );
     crate::inbox::compose_aware_send(home, name, &msg);
+    // Sprint 49 §13.4: log first inject per cycle to decision board.
+    if count == 0 {
+        crate::decisions::post(
+            home,
+            "system:channel-discipline",
+            &serde_json::json!({
+                "title": format!("channel discipline inject — {name}"),
+                "content": format!("last input from {channel}, agent emitted direct text"),
+                "scope": "project",
+                "tags": ["channel-discipline"]
+            }),
+        );
+    }
     crate::agent_ops::save_metadata_batch(
         home,
         name,

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -477,7 +477,33 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
 
         unread
     }) {
-        Ok(msgs) => msgs,
+        Ok(msgs) => {
+            // Sprint 49: track input channel on dequeue for channel discipline.
+            if !msgs.is_empty() {
+                let channel_tag = msgs.iter().find_map(|m| {
+                    if m.from.contains("via telegram") || m.from.contains("via discord") {
+                        Some("telegram")
+                    } else if m.from.starts_with("from:") {
+                        Some("agent_peer")
+                    } else {
+                        None
+                    }
+                });
+                if let Some(tag) = channel_tag {
+                    crate::agent_ops::save_metadata_batch(
+                        home,
+                        name,
+                        &[
+                            ("last_input_channel", serde_json::json!(tag)),
+                            ("reply_tool_called_since_input", serde_json::json!(false)),
+                            ("inject_count_since_input", serde_json::json!(0)),
+                            ("last_inject_at_ms", serde_json::json!(0)),
+                        ],
+                    );
+                }
+            }
+            msgs
+        }
         Err(e) => {
             tracing::warn!(error = %e, "inbox drain lock failed");
             Vec::new()
@@ -842,23 +868,6 @@ pub fn deliver(
         from_id: None,
     };
     let _ = enqueue(home, agent_name, msg);
-    // Sprint 49: track input channel for channel discipline correction.
-    let channel_tag = match source {
-        NotifySource::Channel(_, _) => Some("telegram"),
-        NotifySource::Agent(_) => Some("agent_peer"),
-        NotifySource::System(_) => None,
-    };
-    if let Some(tag) = channel_tag {
-        crate::agent_ops::save_metadata_batch(
-            home,
-            agent_name,
-            &[
-                ("last_input_channel", serde_json::json!(tag)),
-                ("reply_tool_called_since_input", serde_json::json!(false)),
-                ("inject_count_since_input", serde_json::json!(0)),
-            ],
-        );
-    }
     notify_agent(home, agent_name, source, text);
 }
 

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -842,6 +842,23 @@ pub fn deliver(
         from_id: None,
     };
     let _ = enqueue(home, agent_name, msg);
+    // Sprint 49: track input channel for channel discipline correction.
+    let channel_tag = match source {
+        NotifySource::Channel(_, _) => Some("telegram"),
+        NotifySource::Agent(_) => Some("agent_peer"),
+        NotifySource::System(_) => None,
+    };
+    if let Some(tag) = channel_tag {
+        crate::agent_ops::save_metadata_batch(
+            home,
+            agent_name,
+            &[
+                ("last_input_channel", serde_json::json!(tag)),
+                ("reply_tool_called_since_input", serde_json::json!(false)),
+                ("inject_count_since_input", serde_json::json!(0)),
+            ],
+        );
+    }
     notify_agent(home, agent_name, source, text);
 }
 

--- a/src/mcp/handlers/channel.rs
+++ b/src/mcp/handlers/channel.rs
@@ -16,7 +16,16 @@ pub(super) fn handle_reply(home: &Path, args: &Value, instance_name: &str) -> Va
         instance_name,
         crate::channel::AgentOutboundOp::Reply { text },
     ) {
-        Ok(msg) => json!({ "message_id": msg.id }),
+        Ok(msg) => {
+            // Sprint 49: mark that agent used reply tool (channel discipline).
+            crate::agent_ops::save_metadata(
+                home,
+                instance_name,
+                "reply_tool_called_since_input",
+                json!(true),
+            );
+            json!({ "message_id": msg.id })
+        }
         Err(e) => json!({"error": format!("{e}")}),
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -559,6 +559,9 @@ pub struct StateTracker {
     instance_name: String,
     /// Backend name for telemetry logging.
     backend_name: String,
+    /// Sprint 49: armed when agent transitions from Thinking/ToolUse to
+    /// Idle/Ready — signals response completion for channel discipline check.
+    response_complete_pending: bool,
 }
 
 fn hash_screen(text: &str) -> u64 {
@@ -617,6 +620,7 @@ impl StateTracker {
             behavioral_config: backend.map(crate::behavioral::config_for),
             instance_name: String::new(),
             backend_name: backend.map(|b| b.name().to_string()).unwrap_or_default(),
+            response_complete_pending: false,
         }
     }
 
@@ -893,6 +897,20 @@ impl StateTracker {
         {
             self.interactive_recovery_pending_notice = true;
         }
+
+        // Sprint 49: arm channel discipline check when agent finishes
+        // generating (Thinking/ToolUse → Idle/Ready).
+        if matches!(prev, AgentState::Thinking | AgentState::ToolUse)
+            && matches!(self.current, AgentState::Idle | AgentState::Ready)
+            && prev != self.current
+        {
+            self.response_complete_pending = true;
+        }
+    }
+
+    /// Sprint 49: returns true once per response completion, then clears.
+    pub fn take_response_complete(&mut self) -> bool {
+        std::mem::replace(&mut self.response_complete_pending, false)
     }
 }
 


### PR DESCRIPTION
## Summary

Daemon-side channel discipline enforcement. When an agent receives input from Telegram/peer but responds via direct text (without `reply` MCP tool), the daemon injects a correction prompt.

## Hook sites (4 files, ~55 LOC)

| File | Change | LOC |
|------|--------|-----|
| `inbox.rs` | Write `last_input_channel` + reset flags on deliver | ~15 |
| `state.rs` | `response_complete_pending` flag on Thinking/ToolUse → Idle/Ready | ~15 |
| `mcp/handlers/channel.rs` | Mark `reply_tool_called_since_input` on reply | ~10 |
| `daemon/supervisor.rs` | Mismatch detect + inject nudge + cooldown | ~20 |

## Cooldown
- Max 2 injects per input cycle
- 30s minimum between injects
- Counter resets on next inbox deliver (new input cycle)

## Tests (4 new)
- No inject when reply tool used ✅
- Inject fires on direct text ✅
- TUI input skipped ✅
- Cooldown caps at 2 ✅

## Verification
- 1423 tests (1419 baseline + 4 new) ✅
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -D warnings` ✅
- `comms.rs` 675 LOC ✅