### PR TITLE
release: bump version 0.4.1 → 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project are documented here.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); project follows [SemVer](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] — 2026-05-04
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agend-terminal"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agend-terminal"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.87"
 description = "Agent Process Manager — orchestrate AI coding agents with PTY isolation, fleet management, and 35 MCP tools"


### PR DESCRIPTION
## Version bump

`0.4.1` → `0.5.0` — minor bump for Sprint 44-49 feature accumulation.

## Changes
- `Cargo.toml`: version `0.5.0`
- `Cargo.lock`: version line only (no deps drift)
- `CHANGELOG.md`: `[Unreleased]` → `[0.5.0] — 2026-05-04`

## Verification gates (all pass)
1. `cargo fmt --check` ✅
2. `cargo clippy --all-targets -D warnings` ✅
3. `cargo build --release` ✅
4. `cargo test --bin agend-terminal -- --test-threads=1`: 1419 passed ✅
5. `cargo publish --dry-run --registry crates-io --allow-dirty`: packaged 158 files, verification compile clean ✅

## Note
`cargo publish` itself is NOT in this PR scope — operator runs it manually after merge.