### PR TITLE
docs: worktree branch policy — never check out main into a worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,30 @@ Hooks are per-clone. After a fresh `git clone`, install with:
 scripts/install-hooks.sh
 ```
 
+## Worktree branch policy
+
+When creating a worktree, **always use `-b <dedicated-branch>`** to create a
+fresh branch. **Never** check out `main` (or any other long-lived shared
+branch) directly into a worktree:
+
+```bash
+# Good — dedicated branch
+git worktree add ../path -b feat/short-name origin/main
+
+# Bad — locks main checkout, blocks operator/CI build
+git worktree add ../path main
+```
+
+A worktree that holds `main` makes the canonical repo go `detached HEAD` (or
+errors on `git switch main`) and breaks `cargo build --release` for operator
+and tooling. The fix is `cd <worktree> && git switch -c <dedicated-branch>`,
+but it is far cheaper to never take main in the first place.
+
+This applies to fleet agents (lead/dev/reviewer) and to the MCP `repo` tool —
+when calling `mcp__agend-terminal__repo action=checkout`, pass a non-main
+`branch` argument (the daemon honours it verbatim and will not derive a fresh
+branch for you).
+
 ## Release
 
 Tags matching `v*` trigger `.github/workflows/release.yml`, which builds 5

--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -1056,12 +1056,16 @@ Three rules to eliminate idle time. Operator-authorized 2026-04-26.
 
 **Worktree naming convention:**
 ```
-git worktree add ../agend-terminal.worktrees/<branch-name> <branch-name>
+git worktree add -b <new-branch> ../agend-terminal.worktrees/<branch-name> origin/main
 ```
 Or for reviewers:
 ```
-git worktree add /tmp/agend-prNNN-review <branch-name>
+git worktree add /tmp/agend-prNNN-review origin/<branch-name>
 ```
+
+The `-b <new-branch>` form (or `origin/<existing-branch>` for review) is
+mandatory: never write `git worktree add <path> main`, as that locks the
+main checkout into the worktree and breaks operator/CI builds (see E4.5).
 
 **Exceptions:**
 - **dev-lead**: merge operations + read-only queries may use the main repo (atomic merge is safe).
@@ -1075,6 +1079,7 @@ git worktree add /tmp/agend-prNNN-review <branch-name>
 | E4.2 | **Cleanup after merge.** `git worktree remove <path>` + `git branch -d <branch>` after PR merge. Stale worktrees waste disk and confuse `git worktree list`. |
 | E4.3 | **Consistent with CLAUDE.md.** This rule formalizes the existing CLAUDE.md global rule "never commit directly to main; always use worktree + branch" into the fleet protocol. |
 | E4.4 | **Pipeline + worktree.** Rule 1 pipeline dispatch naturally requires worktrees — you cannot have two branches checked out in one working tree. Worktree mandatory is the mechanical prerequisite for pipeline to work safely. |
+| E4.5 | **Never check out main into a worktree.** `git worktree add <path> main` makes the canonical repo `detached HEAD` (or errors on `git switch main`), breaking operator `cargo build --release`. Always use `-b <new-branch>` to create a fresh branch, or check out an existing non-main branch via `origin/<name>`. The MCP `repo` tool's `branch` argument is honoured verbatim — pass a non-main name. Recovery if you slip: `cd <worktree> && git switch -c <dedicated-branch>` releases the main reference. (Origin: 2026-05-05 incident — lead daemon worktree took main, blocked operator binary build.) |
 
 ### 10.5 Spawn site rationale (v1.2 amendment)
 

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -268,7 +268,7 @@ pub(crate) fn build_instructions_body(
         "- Review dispatch expects: source of truth, scope boundary, freshness boundary\n",
     );
     content.push_str("- Verdict wording: VERIFIED / REJECTED / UNVERIFIED only\n");
-    content.push_str("- **Worktree mandatory** (§10.4): always work in a git worktree, never the main repo working tree. Use `git worktree add` per branch.\n");
+    content.push_str("- **Worktree mandatory** (§10.4): always work in a git worktree, never the main repo working tree. Use `git worktree add -b <dedicated-branch> <path> origin/main` per branch — **never** `git worktree add <path> main` (locking main into a worktree blocks operator/CI build).\n");
     content.push_str("- **Spawn site rationale** (§10.5): every `tokio::spawn` / `thread::spawn` site MUST carry `// fire-and-forget: <reason>` comment OR explicitly store JoinHandle for graceful join. Tests exempt; trait-method spawns inherit caller rationale. Phase 5b invariant test enforces.\n");
 
     // Response channel discipline — match reply mechanism to input source.


### PR DESCRIPTION
## Summary

Codify the rule that worktrees must use `-b <dedicated-branch>` and never check out `main` directly. Adds the rule in three places agents/contributors look:
- CLAUDE.md "Worktree branch policy" section with good/bad examples
- src/instructions.rs daemon-injected "Worktree mandatory" line spells out `-b` form
- docs/FLEET-DEV-PROTOCOL-v1.md §10.4 naming convention + new E4.5 documenting the incident + MCP repo tool's verbatim-branch behaviour

## Incident

Lead daemon-managed worktree at `/Users/suzuke/.agend-terminal/worktrees/lead-_Users_suzuke_Documents_Hack_agend-terminal` took the main checkout (created via earlier MCP `repo action=checkout branch=main` call). Operator's canonical repo went detached HEAD and `git switch main` errored, blocking `cargo build --release`.

Recovery: `cd <worktree> && git switch -c lead-workspace` released the main reference.

## Scope

Pure docs — no code change. instructions.rs only modifies the embedded protocol string compiled into the binary.

## Test plan

- [x] cargo build --release clean
- [x] cargo fmt --check clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [ ] Reviewer Tier-1 verify
- [ ] Self-merge after green