### PR TITLE
fix: attach error message distinguishes not-found from not-attachable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -453,8 +453,28 @@ fn main() -> anyhow::Result<()> {
                     || err.contains("connectionreset")
                     || err.contains("connection reset")
                 {
-                    eprintln!("Agent '{name}' not found.");
-                    list_running_agents(&home);
+                    // Distinguish not-found from not-attachable by checking registry.
+                    let agent_exists =
+                        api::call(&home, &serde_json::json!({"method": api::method::LIST}))
+                            .ok()
+                            .and_then(|r| r["result"]["agents"].as_array().cloned())
+                            .is_some_and(|agents| {
+                                agents.iter().any(|a| a["name"].as_str() == Some(&name))
+                            });
+
+                    if agent_exists {
+                        eprintln!("Agent '{name}' exists but is not attachable.");
+                        eprintln!("Possible reasons:");
+                        eprintln!("  - Already attached (only one attach session per agent)");
+                        eprintln!(
+                            "  - tui_bridge port not listening (daemon partially restarted?)"
+                        );
+                        eprintln!("  - Stale port file");
+                        eprintln!("Run 'agend-terminal list' to confirm agent state.");
+                    } else {
+                        eprintln!("Agent '{name}' not found.");
+                        list_running_agents(&home);
+                    }
                 } else {
                     return Err(e);
                 }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -116,3 +116,26 @@ fn completions_emits_for_zsh_fish_bash() {
         "zsh and bash completions must differ"
     );
 }
+
+/// `agend attach <nonexistent>` without daemon shows daemon hint, not "not found".
+#[test]
+fn attach_without_daemon_shows_daemon_hint() {
+    let output = cmd()
+        .env(
+            "AGEND_HOME",
+            std::env::temp_dir().join("agend-attach-test-nodaemon"),
+        )
+        .arg("attach")
+        .arg("ghost-agent")
+        .assert()
+        .success();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(
+        stderr.contains("not running") || stderr.contains("Start it with"),
+        "attach without daemon must hint about daemon, got stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("not found"),
+        "must not say 'not found' when daemon isn't running"
+    );
+}


### PR DESCRIPTION
## Summary

`agend-terminal attach <name>` now correctly distinguishes between an agent that doesn't exist vs one that exists but can't be connected to.

## Before
All connection errors showed: `Agent '<name>' not found.`

## After
- **Agent not in registry**: `Agent '<name>' not found.` + list running agents
- **Agent in registry but connection fails**: `Agent '<name>' exists but is not attachable.` + diagnostic reasons

## Changes (2 files)
- `src/main.rs`: Two-branch dispatch in Attach handler — checks registry via API LIST before categorizing error
- `tests/cli_smoke.rs`: `attach_without_daemon_shows_daemon_hint` test

## Tier
Tier-1 single primary