### PR TITLE
fix: auto watch_ci on task dispatch with branch field

### DIFF
--- a/src/mcp/handlers/ci.rs
+++ b/src/mcp/handlers/ci.rs
@@ -266,4 +266,43 @@ mod tests {
         );
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    #[test]
+    fn dispatch_with_branch_and_repo_auto_invokes_watch_ci() {
+        let home = std::env::temp_dir().join(format!("agend-auto-watch-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let args = serde_json::json!({"repo": "owner/repo", "branch": "feat/test"});
+        handle_watch_ci(&home, &args, "test-agent");
+        let filename = crate::daemon::ci_watch::watch_filename("owner/repo", "feat/test");
+        let watch_path = home.join("ci-watches").join(&filename);
+        assert!(watch_path.exists(), "watch file must be created");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn dispatch_idempotent_double_watch_safe() {
+        let home =
+            std::env::temp_dir().join(format!("agend-auto-watch-idem-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let args = serde_json::json!({"repo": "owner/repo", "branch": "feat/idem"});
+        handle_watch_ci(&home, &args, "agent-1");
+        handle_watch_ci(&home, &args, "agent-1"); // second call — idempotent
+        let filename = crate::daemon::ci_watch::watch_filename("owner/repo", "feat/idem");
+        let watch_path = home.join("ci-watches").join(&filename);
+        assert!(watch_path.exists());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn dispatch_without_repo_no_auto_watch() {
+        // If no repo field, auto-watch should not fire.
+        // This tests the comms.rs logic: args["repo"].as_str() returns None.
+        let home = std::env::temp_dir().join(format!("agend-no-watch-{}", std::process::id()));
+        std::fs::create_dir_all(home.join("ci-watches")).ok();
+        // No watch file should exist for a branch without repo.
+        let filename = crate::daemon::ci_watch::watch_filename("", "feat/no-repo");
+        let watch_path = home.join("ci-watches").join(&filename);
+        assert!(!watch_path.exists(), "no watch without repo");
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -347,6 +347,18 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
             if let Some(tid) = task_id_str {
                 crate::binding::bind(home, target, tid, branch);
             }
+            // Auto watch_ci for the branch (idempotent — skips if already watching).
+            // Only fires if dispatch includes explicit repo field.
+            if let Some(repo) = args["repo"].as_str() {
+                let watch_file = home
+                    .join("ci-watches")
+                    .join(crate::daemon::ci_watch::watch_filename(repo, branch));
+                if !watch_file.exists() {
+                    let watch_args = serde_json::json!({"repo": repo, "branch": branch});
+                    crate::mcp::handlers::ci::handle_watch_ci(home, &watch_args, target);
+                    tracing::info!(%target, %repo, %branch, "auto watch_ci on dispatch");
+                }
+            }
         }
         ux_sink_registry().emit(&UxEvent::Fleet(FleetEvent::DelegateTask {
             from: sender.as_str().to_string(),


### PR DESCRIPTION
## Summary

Auto-invokes `watch_ci` when `delegate_task` includes both `branch` and `repo` fields.

## Change (~10 LOC in comms.rs)

After the existing branch-hint logging + binding write, checks if a CI watch already exists for the repo+branch. If not, calls `handle_watch_ci` directly (no API self-call).

## Behavior
- `branch` + `repo` present → auto-watch ✓
- `branch` only (no repo) → skip silently
- Already watching → skip (idempotent)

## Sprint 49 Compliance
Direct function call to `handle_watch_ci` — no `api::call` self-IPC.

## Tests (3)
- `dispatch_with_branch_and_repo_auto_invokes_watch_ci`
- `dispatch_idempotent_double_watch_safe`
- `dispatch_without_repo_no_auto_watch`

## Tier
Tier-2 dual