### PR TITLE
fix: agend-git-shim app-mode wiring (init functions in bootstrap::prepare)

### DIFF
--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -178,6 +178,13 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
         None
     };
 
+    // agend-git-shim init (shared by daemon + app mode).
+    crate::protocol::extract_default(home);
+    crate::binding::reconcile_hooks(home);
+    crate::binding::symlink_shim(home);
+    crate::binding::reconcile_orphans(home);
+    crate::worktree_pool::reconcile_orphan_leases(home);
+
     Ok(BootstrapOutcome::Owned(Box::new(OwnedFleet {
         home: home.to_path_buf(),
         fleet_path: fleet_path.to_path_buf(),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -178,12 +178,7 @@ pub fn run(home: &Path, agents: Vec<AgentDef>) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("failed to issue API auth cookie: {e}"))?;
     tracing::info!(path = %run.display(), "run dir");
 
-    // Extract embedded fleet protocol to AGEND_HOME/protocol/.default/
-    crate::protocol::extract_default(home);
-    crate::binding::reconcile_hooks(home);
-    crate::binding::symlink_shim(home);
-    crate::binding::reconcile_orphans(home);
-    crate::worktree_pool::reconcile_orphan_leases(home);
+    // agend-git-shim init now in bootstrap::prepare (shared with app mode).
 
     // Check for previous snapshot if fleet.yaml doesn't exist
     if !home.join("fleet.yaml").exists() {

--- a/tests/agend_git_shim_app_mode_wiring.rs
+++ b/tests/agend_git_shim_app_mode_wiring.rs
@@ -1,0 +1,62 @@
+//! Verify agend-git-shim init functions run in both daemon and app mode.
+//!
+//! This test would have caught the original gap where app-mode skipped
+//! the 4 init functions (binding::reconcile_hooks, symlink_shim,
+//! reconcile_orphans, worktree_pool::reconcile_orphan_leases).
+
+/// Verify bootstrap::prepare source contains all 4 init calls.
+/// Source-grep approach (same pattern as sprint52_no_self_ipc).
+#[test]
+fn bootstrap_prepare_contains_all_shim_init_calls() {
+    let src = include_str!("../src/bootstrap/mod.rs");
+    let fn_start = src
+        .find("pub fn prepare(")
+        .expect("prepare function must exist");
+    let rest = &src[fn_start..];
+    let fn_end = rest
+        .find("\n/// ")
+        .or_else(|| rest.find("\npub fn "))
+        .unwrap_or(rest.len());
+    let body = &rest[..fn_end];
+
+    assert!(
+        body.contains("binding::reconcile_hooks("),
+        "bootstrap::prepare must call reconcile_hooks"
+    );
+    assert!(
+        body.contains("binding::symlink_shim("),
+        "bootstrap::prepare must call symlink_shim"
+    );
+    assert!(
+        body.contains("binding::reconcile_orphans("),
+        "bootstrap::prepare must call reconcile_orphans"
+    );
+    assert!(
+        body.contains("worktree_pool::reconcile_orphan_leases("),
+        "bootstrap::prepare must call reconcile_orphan_leases"
+    );
+    assert!(
+        body.contains("protocol::extract_default("),
+        "bootstrap::prepare must call protocol::extract_default"
+    );
+}
+
+/// Verify daemon::run does NOT duplicate the init calls (they're in bootstrap now).
+#[test]
+fn daemon_run_does_not_duplicate_init_calls() {
+    let src = include_str!("../src/daemon/mod.rs");
+    let fn_start = src.find("fn run_core(").expect("run_core must exist");
+    let rest = &src[fn_start..];
+    // Check the first 200 lines of run_core for the old pattern.
+    let check_area = &rest[..rest.len().min(5000)];
+
+    // These should NOT be in daemon::run anymore (moved to bootstrap::prepare).
+    assert!(
+        !check_area.contains("binding::reconcile_hooks(home)"),
+        "daemon::run must not duplicate reconcile_hooks (now in bootstrap)"
+    );
+    assert!(
+        !check_area.contains("binding::symlink_shim(home)"),
+        "daemon::run must not duplicate symlink_shim (now in bootstrap)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes agend-git-shim not working in app mode (all 5 phases were dead code in production).

## Root Cause

4 init functions + protocol::extract_default were only called in `daemon::run` (headless mode). `app::run_app` uses `bootstrap::prepare` which didn't call them.

## Fix

Moved all 5 init calls to `bootstrap::prepare` (shared by both modes). Removed duplicates from `daemon::run`.

## Tests (2)
- `bootstrap_prepare_contains_all_shim_init_calls` — source-grep verifies all 5 calls present
- `daemon_run_does_not_duplicate_init_calls` — verifies no duplication

## Tier
Tier-1 single primary