### PR TITLE
fix(worktree): verify actual HEAD before reuse — P0-1.6

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -95,11 +95,23 @@ fn read_binding(home: &str, agent: &str) -> Binding {
         Ok(v) => v,
         Err(_) => return Binding::default(), // parse failure = unbound (fail-safe)
     };
-    Binding {
+    let b = Binding {
         task_id: v["task_id"].as_str().map(String::from),
         branch: v["branch"].as_str().map(String::from),
         worktree: v["worktree"].as_str().map(String::from),
+    };
+    // P0-1.6: orphan binding defense.
+    // If binding points to a worktree path that no longer exists (e.g. operator
+    // ran `git worktree remove` after the daemon wrote the binding, or a stale
+    // binding survived a daemon restart), treat the agent as unbound rather
+    // than letting chdir fatal at exec time. Daemon-side reconcile will
+    // eventually clean the stale file; this guard is only a fail-safe.
+    if let Some(ref wt) = b.worktree {
+        if !std::path::Path::new(wt).exists() {
+            return Binding::default();
+        }
     }
+    b
 }
 
 fn is_bound(binding: &Binding) -> bool {

--- a/src/mcp/handlers/dispatch_hook.rs
+++ b/src/mcp/handlers/dispatch_hook.rs
@@ -349,4 +349,100 @@ mod tests {
 
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ── P0-1.6: same agent + different branch must reject ────────────
+    //
+    // Pre-fix scenario: agent-x leased feat/A, then operator (or another
+    // dispatcher) sent a second task with feat/B. worktree::create silently
+    // reused the existing .worktrees/agent-x dir and echoed feat/B back as
+    // the lease branch. dispatch_auto_bind_lease saw Ok and proceeded; the
+    // smoke message landed in agent-x's inbox even though the worktree was
+    // still on feat/A.
+    //
+    // Post-fix: worktree::create runs `git branch --show-current` on the
+    // existing dir; mismatch returns None → lease fails → dispatch rejects
+    // with "dispatch rejected: ..." and the message never reaches the inbox.
+
+    #[test]
+    fn same_agent_different_branch_rejects() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-p01-6-{}-same-agent-diff-branch",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).ok();
+        setup_test_repo(&home, "agent-x");
+
+        // First lease establishes the worktree on feat/A.
+        let r1 = super::dispatch_auto_bind_lease(&home, "agent-x", "T-1", "feat/A");
+        assert!(r1.is_ok(), "first lease must succeed: {r1:?}");
+
+        // Second dispatch with a DIFFERENT branch must reject.
+        let r2 = super::dispatch_auto_bind_lease(&home, "agent-x", "T-2", "feat/B");
+        assert!(
+            r2.is_err(),
+            "same-agent different-branch dispatch must reject (P0-1.6): {r2:?}"
+        );
+
+        // Binding still reflects feat/A (T-1) — the rejected dispatch must
+        // not have overwritten it.
+        let binding = home.join("runtime").join("agent-x").join("binding.json");
+        let content = std::fs::read_to_string(&binding).expect("read binding");
+        let v: serde_json::Value = serde_json::from_str(&content).expect("parse binding");
+        assert_eq!(
+            v["branch"], "feat/A",
+            "rejected dispatch must NOT overwrite binding to feat/B"
+        );
+        assert_eq!(v["task_id"], "T-1", "task_id must remain T-1");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn delegate_task_same_agent_different_branch_without_delivering() {
+        use crate::identity::Sender;
+
+        let home = std::env::temp_dir().join(format!(
+            "agend-p01-6-integration-{}-same-agent-diff-branch",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).ok();
+        setup_test_repo(&home, "agent-x");
+
+        // Seed: agent-x already leased on feat/A.
+        let r1 = super::dispatch_auto_bind_lease(&home, "agent-x", "T-1", "feat/A");
+        assert!(r1.is_ok(), "first lease must succeed: {r1:?}");
+
+        // Production-realistic: a second delegate_task targeting agent-x with
+        // a different branch must trip the gate before SEND, not deliver the
+        // [delegate_task] message to the inbox.
+        let args = serde_json::json!({
+            "target_instance": "agent-x",
+            "task": "implement feature B",
+            "task_id": "T-2",
+            "branch": "feat/B",
+        });
+        let sender = Some(Sender::new("lead").expect("sender"));
+        let result = super::super::comms::handle_delegate_task(&home, &args, &sender);
+
+        assert!(
+            result.get("error").is_some(),
+            "handle_delegate_task must error on same-agent different-branch: {result}"
+        );
+        assert!(
+            result["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("dispatch rejected"),
+            "error must indicate dispatch rejection: {result}"
+        );
+
+        let inbox_path = home.join("inbox").join("agent-x.jsonl");
+        let inbox_content = std::fs::read_to_string(&inbox_path).unwrap_or_default();
+        assert!(
+            !inbox_content.contains("implement feature B"),
+            "rejected dispatch must NOT deliver to agent-x inbox. Got: {inbox_content}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -98,12 +98,41 @@ pub fn create(
 
     let wt_dir = repo_dir.join(".worktrees").join(instance_name);
 
-    // Already exists — reuse
+    // Already exists — verify actual HEAD before reuse.
+    // P0-1.6: pre-fix this branch echoed `branch` back without verifying the
+    // worktree's actual HEAD. dispatch_auto_bind_lease therefore could not
+    // distinguish "reuse on same branch" (idempotent) from "reuse on different
+    // branch" (lease conflict). Smoke test 2 caught it: a second dispatch with
+    // a different branch silently passed and the message was delivered.
     if wt_dir.exists() {
+        let actual = std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args(["branch", "--show-current"])
+            .current_dir(&wt_dir)
+            .output()
+            .ok()
+            .and_then(|o| {
+                if o.status.success() {
+                    Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+                } else {
+                    None
+                }
+            });
+        if actual.as_deref() != Some(branch.as_str()) {
+            tracing::warn!(
+                instance = instance_name,
+                requested = %branch,
+                actual = ?actual,
+                path = %wt_dir.display(),
+                "lease conflict: worktree exists on a different branch — rejecting"
+            );
+            return None;
+        }
         tracing::info!(
             instance = instance_name,
             path = %wt_dir.display(),
-            "reusing existing worktree"
+            branch = %branch,
+            "reusing existing worktree (branch verified)"
         );
         return Some(WorktreeInfo {
             path: wt_dir,
@@ -503,5 +532,37 @@ mod tests {
         assert_eq!(branch, "feat/test-branch");
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── P0-1.6: actual HEAD verification on reuse ─────────────────────
+
+    /// Smoke test 2 regression: same agent, different branch → must reject.
+    /// Pre-fix this returned Some with `branch = requested`, falsely echoing
+    /// the requested branch back even though the worktree HEAD was unchanged.
+    #[test]
+    fn reuse_rejects_when_branch_mismatch() {
+        let repo = tmp_repo("reuse-mismatch");
+        let first = create(&repo, "agent1", Some("feat/A")).expect("first lease");
+        assert!(first.path.exists());
+        // Second lease, same instance, DIFFERENT branch → must return None.
+        let second = create(&repo, "agent1", Some("feat/B"));
+        assert!(
+            second.is_none(),
+            "lease must reject when worktree exists on a different branch"
+        );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// Idempotent path: same agent, same custom branch → reuse OK.
+    /// Confirms the actual-HEAD check does not break the idempotent re-lease
+    /// semantics that P0-1.5 relies on.
+    #[test]
+    fn reuse_idempotent_same_custom_branch() {
+        let repo = tmp_repo("reuse-idem");
+        let first = create(&repo, "agent1", Some("feat/X")).expect("first lease");
+        let second = create(&repo, "agent1", Some("feat/X")).expect("second lease idempotent");
+        assert_eq!(first.path, second.path);
+        assert_eq!(second.branch, "feat/X");
+        std::fs::remove_dir_all(&repo).ok();
     }
 }


### PR DESCRIPTION
## Summary

- **Primary fix** (`src/worktree.rs:99-113`): worktree::create now runs `git branch --show-current` against the existing dir on the reuse branch and returns None on mismatch. Closes the silent-lie that let same-agent + different-branch dispatches pass `dispatch_auto_bind_lease` and deliver to the target inbox (caught by general's smoke test 2).
- **Secondary fix** (`src/bin/agend-git.rs read_binding`): orphan binding defense — if binding.json points to a deleted worktree path, the shim falls back to unbound mode instead of fatal-on-chdir. Real-world reproduction hit by P0-1.6 pre-cleanup itself (operator removed the worktree dir, prior dispatch's binding survived).
- Closes the same-agent / different-branch coverage gap that #465's central lease registry cannot address (registry only blocks cross-agent collisions).

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bin agend-terminal worktree` — 38/38 pass (incl. new `reuse_rejects_when_branch_mismatch`, `reuse_idempotent_same_custom_branch`)
- [x] `cargo test --bin agend-terminal dispatch_hook` — 9/9 pass (incl. new `same_agent_different_branch_rejects`, `delegate_task_same_agent_different_branch_without_delivering`)
- [ ] Lead pre-review audit (Tier-2 dual: codex primary + lead cross-vantage diff)
- [ ] Reviewer Tier-2 dual VERIFIED
- [ ] General final smoke (production-realistic dispatch X then Y on a fleet agent)

## Notes

Bug origin predates Phase 1-5 — `worktree::create` reuse semantics were never re-examined when Sprint 53 wired the lease gate on top. Tier-2 dual review for both Phase 3 and Sprint 53 P0-1 stopped at `worktree_pool::lease`; neither traced into `worktree.rs`. Worth flagging for future review-surface discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)