### PR TITLE
fix(#468): dismiss patterns regex-anchored, no longer auto-inject from scrollback

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1044,32 +1044,45 @@ fn handle_pty_close(
 /// Issue #468: dismiss patterns must match anchored regex (line start +
 /// optional TUI prefix), not bare substring. Compiles once per unique pattern
 /// string and reuses the `Arc<Regex>` thereafter so the screen-update hot
-/// loop never re-compiles. Compile errors are logged once and the offending
-/// pattern is skipped — a typo in a backend preset must not crash dispatch.
-fn compile_dismiss_regex(pattern: &str) -> Option<std::sync::Arc<regex::Regex>> {
-    static CACHE: std::sync::LazyLock<
-        parking_lot::Mutex<std::collections::HashMap<String, std::sync::Arc<regex::Regex>>>,
-    > = std::sync::LazyLock::new(|| parking_lot::Mutex::new(std::collections::HashMap::new()));
+/// loop never re-compiles.
+///
+/// r1 fix (PR #469 reviewer): both successful AND failed compiles are cached.
+/// The cache value is `Option<Arc<Regex>>` — `None` records that the pattern
+/// is permanently invalid, so subsequent lookups skip the compile + log path
+/// entirely. Without this, a typo in a backend preset would re-compile and
+/// re-emit a warn line on every screen-update tick. The warn (not error —
+/// invalid patterns are configurer mistakes, not runtime faults) fires once
+/// per unique bad pattern over the process lifetime.
+static DISMISS_REGEX_CACHE: std::sync::LazyLock<
+    parking_lot::Mutex<std::collections::HashMap<String, Option<std::sync::Arc<regex::Regex>>>>,
+> = std::sync::LazyLock::new(|| parking_lot::Mutex::new(std::collections::HashMap::new()));
 
-    let mut cache = CACHE.lock();
-    if let Some(re) = cache.get(pattern) {
-        return Some(std::sync::Arc::clone(re));
+fn compile_dismiss_regex(pattern: &str) -> Option<std::sync::Arc<regex::Regex>> {
+    let mut cache = DISMISS_REGEX_CACHE.lock();
+    if let Some(slot) = cache.get(pattern) {
+        return slot.as_ref().map(std::sync::Arc::clone);
     }
-    match regex::Regex::new(pattern) {
-        Ok(re) => {
-            let arc = std::sync::Arc::new(re);
-            cache.insert(pattern.to_string(), std::sync::Arc::clone(&arc));
-            Some(arc)
-        }
+    let result = match regex::Regex::new(pattern) {
+        Ok(re) => Some(std::sync::Arc::new(re)),
         Err(e) => {
-            tracing::error!(
+            tracing::warn!(
                 pattern,
                 error = %e,
                 "dismiss regex compile failed — pattern ignored"
             );
             None
         }
-    }
+    };
+    cache.insert(pattern.to_string(), result.clone());
+    result
+}
+
+/// Test-only inspection of the dismiss regex cache. Used by the
+/// `invalid_regex_cached_no_relog` test to assert that bad patterns get
+/// cached after first failure (rather than re-compiling on every call).
+#[cfg(test)]
+fn dismiss_regex_cache_contains(pattern: &str) -> bool {
+    DISMISS_REGEX_CACHE.lock().contains_key(pattern)
 }
 
 /// Strip the standard line-anchor prefix to recover the literal hint from a
@@ -1508,6 +1521,49 @@ I see it in the docs but I'm not sure when Gemini shows it.
         assert!(
             try_dismiss_dialog("t", &screen, &test_writer(), &patterns),
             "VTerm-rendered Gemini dialog must match production regex. Screen:\n{screen}"
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn invalid_regex_cached_no_relog() {
+        // r1 fix (PR #469 reviewer): a typo in a backend dismiss pattern must
+        // not re-compile + re-log on every screen-update tick. Negative-cache
+        // failed compiles so the warn fires once per unique bad pattern.
+
+        // Use a pattern that the `regex` crate rejects. Unclosed group is
+        // syntactically invalid in every regex flavor.
+        let bad = "(?P<unclosed";
+        // Pre-condition: not yet cached.
+        assert!(
+            !super::dismiss_regex_cache_contains(bad),
+            "test invariant: cache must not pre-contain '{bad}'"
+        );
+
+        let r1 = super::compile_dismiss_regex(bad);
+        assert!(
+            r1.is_none(),
+            "first call on invalid pattern must return None"
+        );
+        assert!(
+            super::dismiss_regex_cache_contains(bad),
+            "first call must populate the negative cache"
+        );
+
+        let r2 = super::compile_dismiss_regex(bad);
+        assert!(
+            r2.is_none(),
+            "second call must also return None (from cache)"
+        );
+
+        // tracing-test capture: the warn must have fired (at least once).
+        // Asserting "exactly once" is brittle across test-runner concurrency,
+        // but the cache assertion above proves the second call did not
+        // re-attempt compile — so the warn cannot have fired again from the
+        // second invocation.
+        assert!(
+            logs_contain("dismiss regex compile failed"),
+            "compile failure must be logged at warn level"
         );
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1039,6 +1039,51 @@ fn handle_pty_close(
 /// Try to auto-dismiss dialogs using backend-configurable patterns. Returns true if dismissed.
 /// `screen` is the VTerm-rendered view the user sees — not raw PTY bytes —
 /// so Ink-style TUIs that paint char-by-char with cursor positioning still match.
+/// Cached regex compilation for dismiss patterns.
+///
+/// Issue #468: dismiss patterns must match anchored regex (line start +
+/// optional TUI prefix), not bare substring. Compiles once per unique pattern
+/// string and reuses the `Arc<Regex>` thereafter so the screen-update hot
+/// loop never re-compiles. Compile errors are logged once and the offending
+/// pattern is skipped — a typo in a backend preset must not crash dispatch.
+fn compile_dismiss_regex(pattern: &str) -> Option<std::sync::Arc<regex::Regex>> {
+    static CACHE: std::sync::LazyLock<
+        parking_lot::Mutex<std::collections::HashMap<String, std::sync::Arc<regex::Regex>>>,
+    > = std::sync::LazyLock::new(|| parking_lot::Mutex::new(std::collections::HashMap::new()));
+
+    let mut cache = CACHE.lock();
+    if let Some(re) = cache.get(pattern) {
+        return Some(std::sync::Arc::clone(re));
+    }
+    match regex::Regex::new(pattern) {
+        Ok(re) => {
+            let arc = std::sync::Arc::new(re);
+            cache.insert(pattern.to_string(), std::sync::Arc::clone(&arc));
+            Some(arc)
+        }
+        Err(e) => {
+            tracing::error!(
+                pattern,
+                error = %e,
+                "dismiss regex compile failed — pattern ignored"
+            );
+            None
+        }
+    }
+}
+
+/// Strip the standard line-anchor prefix to recover the literal hint from a
+/// dismiss regex. Used by Step 4 (false-positive operator visibility logging).
+/// Returns the input unchanged when no known prefix is present so callers
+/// don't accidentally compare an entire regex against `screen.contains`.
+const DISMISS_REGEX_PREFIX: &str = r"(?m)^[│║|>\s]*";
+
+fn dismiss_literal_hint(pattern: &str) -> &str {
+    pattern
+        .strip_prefix(DISMISS_REGEX_PREFIX)
+        .unwrap_or(pattern)
+}
+
 pub fn try_dismiss_dialog(
     name: &str,
     screen: &str,
@@ -1050,7 +1095,14 @@ pub fn try_dismiss_dialog(
     }
 
     for (pattern, key_seq) in dismiss_patterns {
-        if screen.contains(pattern.as_str()) {
+        // Issue #468: regex match anchored to line start + optional TUI prefix.
+        // Substring match (the prior behavior) auto-injected `2\n` / `3\n`
+        // whenever the phrase appeared anywhere on screen — including in agent
+        // output and scrollback — sending input the user never authorized.
+        let Some(re) = compile_dismiss_regex(pattern) else {
+            continue;
+        };
+        if re.is_match(screen) {
             tracing::info!(agent = name, pattern, "auto-dismissing dialog");
             // Delayed write: TUI escape-sequence parsers need time to distinguish
             // \x1b (ESC key) from \x1b[ (CSI start).  Writing immediately causes
@@ -1105,6 +1157,19 @@ pub fn try_dismiss_dialog(
                 DISMISS_IN_FLIGHT.lock().remove(&agent);
             });
             return true;
+        }
+        // Step 4 (Issue #468): operator-visibility log when the literal hint
+        // would have triggered the old substring path but the new regex
+        // anchor declined — surfaces realistic false positives (mid-paragraph
+        // matches, scrollback echoes) without auto-injecting bytes.
+        let literal = dismiss_literal_hint(pattern);
+        if literal != pattern.as_str() && !literal.is_empty() && screen.contains(literal) {
+            tracing::debug!(
+                agent = name,
+                pattern,
+                literal,
+                "dismiss substring seen but regex didn't match — likely false positive"
+            );
         }
     }
 
@@ -1348,6 +1413,128 @@ mod tests {
         let screen = vt.tail_lines(24);
         let patterns = vec![("Do you trust".to_string(), b"\n".to_vec())];
         assert!(try_dismiss_dialog("t", &screen, &test_writer(), &patterns));
+    }
+
+    // ── Issue #468: dismiss precision regression tests ─────────────────
+    //
+    // Hotfix #468 replaces `screen.contains(pattern)` substring match with
+    // an anchored regex (`(?m)^[│║|>\s]*<text>`) so user input and
+    // scrollback content containing the dialog phrase mid-paragraph cannot
+    // trigger an unauthorized auto-dismiss.
+    //
+    // Production-realistic patterns: these tests use the EXACT regex strings
+    // from `BackendPreset::dismiss_patterns` (Backend::Gemini) so a future
+    // refactor that diverges the test pattern from prod would still trigger
+    // these assertions on the prod string.
+    //
+    // Regression-proof: revert `try_dismiss_dialog` to use
+    // `screen.contains(pattern.as_str())` (bare substring match) and the
+    // false-positive tests below FAIL. Restore the regex match → PASS.
+
+    /// Production dismiss regex for Gemini's MCP-tool dialog (Issue #468).
+    const GEMINI_MCP_TOOL_REGEX: &str = r"(?m)^[│║|>\s]*Allow execution of MCP tool";
+    /// Production dismiss regex for Gemini's shell-execution dialog (Issue #468).
+    const GEMINI_SHELL_REGEX: &str = r"(?m)^[│║|>\s]*Allow execution of:";
+
+    #[test]
+    fn issue_468_true_positive_gemini_mcp_dialog() {
+        // Realistic Gemini Ink TUI render: dialog body is wrapped in box-drawing
+        // chars, lines start with `│ ` (vertical bar + space).
+        let screen = "\
+╭─────────────────────────────────────────────╮
+│ Allow execution of MCP tool: ripgrep?       │
+│                                             │
+│ [1] Allow once                              │
+│ [2] Allow for session                       │
+│ [3] Allow always (this server)              │
+│ [4] Reject                                  │
+╰─────────────────────────────────────────────╯
+";
+        let patterns = vec![(GEMINI_MCP_TOOL_REGEX.to_string(), b"3\n".to_vec())];
+        assert!(
+            try_dismiss_dialog("t", screen, &test_writer(), &patterns),
+            "true Gemini dialog (TUI prefix `│ `) must match anchored regex"
+        );
+    }
+
+    #[test]
+    fn issue_468_false_positive_mid_paragraph_user_text() {
+        // User-typed message containing the dialog phrase mid-paragraph.
+        // Substring match would auto-inject `2\n`; anchored regex must not.
+        let screen = "\
+Could you explain what \"Allow execution of: bash\" actually means?
+I see it in the docs but I'm not sure when Gemini shows it.
+";
+        let patterns = vec![(GEMINI_SHELL_REGEX.to_string(), b"2\n".to_vec())];
+        assert!(
+            !try_dismiss_dialog("t", screen, &test_writer(), &patterns),
+            "Issue #468: user text with phrase mid-paragraph must NOT trigger dismiss"
+        );
+    }
+
+    #[test]
+    fn issue_468_false_positive_scrollback_agent_output() {
+        // Agent's prior output explains the dialog format — phrase appears
+        // embedded in a longer line. Substring match would auto-fire mid-stream.
+        let screen = "\
+[ai] When the tool is invoked, you'll see a prompt: Allow execution of MCP tool — pick option 3 to always allow.
+[user] thanks!
+[ai] Anything else?
+";
+        let patterns = vec![(GEMINI_MCP_TOOL_REGEX.to_string(), b"3\n".to_vec())];
+        assert!(
+            !try_dismiss_dialog("t", screen, &test_writer(), &patterns),
+            "Issue #468: agent scrollback explaining the phrase must NOT trigger dismiss"
+        );
+    }
+
+    #[test]
+    fn issue_468_production_smoke_vterm_rendered_dialog() {
+        // Production-smoke gate (§5): drive VTerm with the ANSI byte stream
+        // a real Gemini TUI emits, then run try_dismiss_dialog against the
+        // rendered screen. Asserts injected bytes only happen when the actual
+        // dialog renders — the same failure mode the user reported.
+        let mut vt = crate::vterm::VTerm::new(80, 24);
+        // Synthesize a minimal Gemini-style dialog frame: top border, body line
+        // with `│ Allow execution of MCP tool: ...`, choice rows, bottom border.
+        vt.process(b"\x1b[2J\x1b[H"); // clear + home
+        vt.process("╭───────────────────────────────────────╮\r\n".as_bytes());
+        vt.process("│ Allow execution of MCP tool: gh?      │\r\n".as_bytes());
+        vt.process("│                                       │\r\n".as_bytes());
+        vt.process("│ [3] Allow always                      │\r\n".as_bytes());
+        vt.process("╰───────────────────────────────────────╯\r\n".as_bytes());
+        let screen = vt.tail_lines(24);
+        let patterns = vec![(GEMINI_MCP_TOOL_REGEX.to_string(), b"3\n".to_vec())];
+        assert!(
+            try_dismiss_dialog("t", &screen, &test_writer(), &patterns),
+            "VTerm-rendered Gemini dialog must match production regex. Screen:\n{screen}"
+        );
+    }
+
+    #[test]
+    fn issue_468_logs_substring_near_miss_for_operator_visibility() {
+        // Step 4 (Issue #468): when the literal hint would have triggered
+        // the old substring path but the new regex declined, emit a debug
+        // log so the operator can see realistic false positives.
+        // Test asserts behavior: try_dismiss_dialog returns false (no
+        // injection) but the regex compile + literal extraction path is
+        // exercised. The log itself is observed indirectly via the no-op
+        // outcome (the actual log line is captured by tracing-test in
+        // dedicated integration suites elsewhere; keeping this test free
+        // of subscriber setup avoids per-test global-state collisions).
+        let screen = "user said: Allow execution of: please?";
+        let patterns = vec![(GEMINI_SHELL_REGEX.to_string(), b"2\n".to_vec())];
+        let fired = try_dismiss_dialog("t", screen, &test_writer(), &patterns);
+        assert!(
+            !fired,
+            "Step 4: literal-hint near-miss must NOT inject keystrokes"
+        );
+        // dismiss_literal_hint should recover the bare phrase from the prod regex.
+        assert_eq!(
+            super::dismiss_literal_hint(GEMINI_SHELL_REGEX),
+            "Allow execution of:",
+            "literal hint must strip the standard line-anchor prefix"
+        );
     }
 
     /// Sprint 21 F-NEW1: verify that `sweep_child_tree` reaches grandchild

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -201,9 +201,13 @@ impl Backend {
                 instructions_shared: false,
                 inject_instructions_on_ready: false,
                 ready_timeout_secs: 30,
+                // Issue #468: regex anchored to line start + optional TUI prefix
+                // ([│║|>\s]*) instead of bare substring, so user-typed text or
+                // scrollback containing the phrase mid-line cannot trigger an
+                // unauthorized auto-dismiss.
                 dismiss_patterns: &[
-                    ("Yes, I trust", b"\x1b[A\x1b[A\r"),
-                    ("Yes, proceed", b"\x1b[A\x1b[A\r"),
+                    (r"(?m)^[│║|>\s]*Yes, I trust", b"\x1b[A\x1b[A\r"),
+                    (r"(?m)^[│║|>\s]*Yes, proceed", b"\x1b[A\x1b[A\r"),
                 ],
                 fresh_args: None, // same as args (no resume in preset)
             },
@@ -227,7 +231,8 @@ impl Backend {
                     // Trust-all-tools confirmation: cursor defaults to "No, exit"
                     // Down moves to "Yes, I accept", Enter confirms
                     // Keys sent with per-byte delay in try_dismiss_dialog
-                    ("No, exit", b"\x1b[B\r"),
+                    // Issue #468: anchored regex (see ClaudeCode comment above).
+                    (r"(?m)^[│║|>\s]*No, exit", b"\x1b[B\r"),
                 ],
                 fresh_args: None, // same as args
             },
@@ -253,9 +258,10 @@ impl Backend {
                     // CR (\r), not LF — Ink's keyboard reader treats CR as Enter.
                     // macOS openpty doesn't translate LF→CR on input (ConPTY does),
                     // so LF here would silently no-op on mac.
-                    ("Do you trust", b"\r"),
+                    // Issue #468: anchored regex (see ClaudeCode comment above).
+                    (r"(?m)^[│║|>\s]*Do you trust", b"\r"),
                     // Auto-update prompt: "Please restart Codex" → Enter
-                    ("Please restart", b"\r"),
+                    (r"(?m)^[│║|>\s]*Please restart", b"\r"),
                 ],
                 // Codex: "resume --last" → fresh start drops the resume subcommand
                 fresh_args: Some(&["--dangerously-bypass-approvals-and-sandbox"]),
@@ -274,10 +280,11 @@ impl Backend {
                 inject_instructions_on_ready: false,
                 ready_timeout_secs: 45,
                 dismiss_patterns: &[
-                    ("Update Available", b"\r"),
-                    ("Skip  Confirm", b"\r"),
-                    ("Update Complete", b"\r"),
-                    ("Please restart", b"\r"),
+                    // Issue #468: anchored regex (see ClaudeCode comment above).
+                    (r"(?m)^[│║|>\s]*Update Available", b"\r"),
+                    (r"(?m)^[│║|>\s]*Skip  Confirm", b"\r"),
+                    (r"(?m)^[│║|>\s]*Update Complete", b"\r"),
+                    (r"(?m)^[│║|>\s]*Please restart", b"\r"),
                 ],
                 fresh_args: None, // same as args (resume is in resume_mode, not args)
             },
@@ -297,10 +304,16 @@ impl Backend {
                 inject_instructions_on_ready: false,
                 ready_timeout_secs: 20,
                 // Auto-approve: MCP tools ("3" = all server tools for session),
-                // shell commands ("2" = allow for session)
+                // shell commands ("2" = allow for session).
+                // Issue #468: anchored regex (line start + optional TUI prefix
+                // [│║|>\s]*). Substring match was false-positiving on user
+                // input and scrollback content that contained the phrase
+                // mid-paragraph, auto-injecting `2\n` / `3\n` without consent.
+                // Gemini's Ink-based TUI renders dialogs with `│ ` prefix at
+                // line start, which the anchor accepts.
                 dismiss_patterns: &[
-                    ("Allow execution of MCP tool", b"3\n"),
-                    ("Allow execution of:", b"2\n"),
+                    (r"(?m)^[│║|>\s]*Allow execution of MCP tool", b"3\n"),
+                    (r"(?m)^[│║|>\s]*Allow execution of:", b"2\n"),
                 ],
                 fresh_args: None, // same as args (resume is in resume_mode, not args)
             },


### PR DESCRIPTION
## Summary

Closes #468.

- Replace `screen.contains(pattern)` substring match in `try_dismiss_dialog` with `regex::Regex::is_match`, anchored to line start with optional TUI prefix `[│║|>\s]*`.
- Update all backend dismiss patterns (ClaudeCode, KiroCli, Codex, OpenCode, Gemini) to the regex form. The prior substring path was a uniform false-positive surface across all backends, not just Gemini.
- Cache compiled regexes in a process-wide `LazyLock<Mutex<HashMap>>` so the screen-update hot loop never re-compiles after first hit.
- Step 4 operator visibility: when the regex declines but the literal hint is still in screen, emit a `tracing::debug!` line so realistic false positives are surfaced without auto-acting.

## Bug (from cheerc community report, Issue #468)

User reported a Gemini tab kept receiving `3<newline>` injections while no dialog was on screen. Root cause: substring match auto-fired whenever the literal "Allow execution of MCP tool" or "Allow execution of:" appeared anywhere — including in agent log output, scrollback echoes, and user-typed messages. The user never authorized those injections.

## Decision against Step 3 (cooldown)

The existing `DISMISS_IN_FLIGHT` HashSet (src/agent.rs:1060) already gates concurrent dispatches per agent. With the regex tightening, the remaining trigger surface is the actual dialog itself — which fires once then disappears from screen. A post-dismiss cooldown would not change the failure mode the user reported. Skipped to keep the codebase simple; lead's r0 dispatch noted "Lead defers to dev judgment" on this.

## Tests

Five production-realistic tests in `agent::tests::issue_468_*`:
- `_true_positive_gemini_mcp_dialog` — Ink-drawn box dialog → matches, fires.
- `_false_positive_mid_paragraph_user_text` — phrase mid-paragraph in user text → no match, no inject.
- `_false_positive_scrollback_agent_output` — phrase embedded in scrollback line → no match, no inject.
- `_production_smoke_vterm_rendered_dialog` — drives a real `VTerm` with ANSI bytes a Gemini dialog emits, then runs `try_dismiss_dialog` against the rendered screen (production path).
- `_logs_substring_near_miss_for_operator_visibility` — verifies the Step 4 near-miss path + `dismiss_literal_hint` correctness.

Existing 4 dismiss tests still pass — bare literal patterns compile as basic regexes that accept any substring, so their contract is preserved.

## Empirical regression-proof verification

Temporarily reverted `if re.is_match(screen)` to `if screen.contains(dismiss_literal_hint(pattern))` and re-ran:

```
test agent::tests::issue_468_false_positive_mid_paragraph_user_text ... FAILED
test agent::tests::issue_468_false_positive_scrollback_agent_output ... FAILED
test agent::tests::issue_468_logs_substring_near_miss_for_operator_visibility ... FAILED
```

Restored the regex check → `test result: ok. 9 passed; 0 failed`. Confirms the new tests fail under the old behavior — not trivially passing.

## Sprint 49 cushion

- No new `tokio::spawn` / `thread::spawn`. Existing fire-and-forget keystroke spawn unchanged.
- Regex compile is hot-path-safe: `parking_lot::Mutex<HashMap>` cache, only touched on first hit per pattern. No L1/L2 lock acquisition.
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

## "Who calls this in prod" trace

Production: `agent::run` → screen-update loop → `try_dismiss_dialog(name, &screen, pty_writer, dismiss_patterns)` (src/agent.rs:792). Tests call the SAME function with patterns lifted verbatim from the Gemini preset, exercising the production string path end-to-end.

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [x] cargo test --bin agend-terminal -- agent::tests::issue_468 → 5/5 pass
- [x] cargo test --bin agend-terminal -- agent::tests::dismiss → 4/4 existing pass
- [x] cargo test --bin agend-terminal -- --test-threads=1 agent backend → 150/150 pass
- [x] cargo test --test file_size_invariant → 1/1 pass
- [x] Empirical regression-proof verification (substring revert → 3 FAIL, restore → all PASS)
- [ ] Operator/lead manual smoke: spawn a Gemini agent, type a message containing "Allow execution of:", confirm no auto-inject (the bug-report reproducer)

## Pre-existing test failures (unchanged from main, not introduced here)

Same 7 pre-existing failures as #467 (Sprint 53 P0-2): `admin::tests::analyze_detects_worktree_branch` + 6 `claim_verifier::tests::*_red` — all git-state-dependent, fail consistently on `origin/main` HEAD in this workspace. Plus 1 parallel race (`broadcast_emits_with_resolved_recipients`) that passes serial. None touch `agent.rs` or `backend.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)