### PR TITLE
feat: Sprint 53 P0-X — release_worktree MCP tool closes auto-bind/lease gap

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -9,16 +9,31 @@ use std::path::Path;
 /// Write a binding for an agent (task assigned).
 #[allow(dead_code)] // Used by tests + auto-watch dispatch path
 pub fn bind(home: &Path, agent: &str, task_id: &str, branch: &str) {
-    bind_full(home, agent, task_id, branch, std::path::Path::new(""));
+    bind_full(
+        home,
+        agent,
+        task_id,
+        branch,
+        std::path::Path::new(""),
+        std::path::Path::new(""),
+    );
 }
 
-/// Write a full binding including worktree path (Phase 3).
+/// Write a full binding including worktree + source-repo paths.
+///
+/// `source_repo` is the parent repo that owns the worktree, persisted as a
+/// schema field so `worktree_pool::release_full` (Sprint 53 P0-X r1) can run
+/// `git worktree remove --force` from the owning repo's cwd. Without this,
+/// the git registry leaves a stale prunable entry after a manual `remove_dir_all`
+/// fallback. Pass an empty path when unknown — `release_full` falls back to
+/// deriving the source from the worktree path's `.worktrees/<agent>` ancestor.
 pub fn bind_full(
     home: &Path,
     agent: &str,
     task_id: &str,
     branch: &str,
     worktree: &std::path::Path,
+    source_repo: &std::path::Path,
 ) {
     let dir = home.join("runtime").join(agent);
     std::fs::create_dir_all(&dir).ok();
@@ -26,6 +41,7 @@ pub fn bind_full(
     let lock_path = dir.join(".binding.json.lock");
     let _lock = crate::store::acquire_file_lock(&lock_path);
     let wt_str = worktree.display().to_string();
+    let src_str = source_repo.display().to_string();
     let mut binding = json!({
         "version": 1,
         "agent": agent,
@@ -35,6 +51,9 @@ pub fn bind_full(
     });
     if !wt_str.is_empty() {
         binding["worktree"] = json!(wt_str);
+    }
+    if !src_str.is_empty() {
+        binding["source_repo"] = json!(src_str);
     }
     let body = serde_json::to_string_pretty(&binding).unwrap_or_default();
     let _ = crate::store::atomic_write(&path, body.as_bytes());

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -43,8 +43,10 @@ pub(crate) fn dispatch_auto_bind_lease(
     // Lease errors REJECT the dispatch (Q2 + §3.3).
     let lease = crate::worktree_pool::lease(home, &source_repo, target, branch)?;
 
-    // Bind with worktree path. Bind file write error stays graceful (Q1).
-    crate::binding::bind_full(home, target, task_id, branch, &lease.path);
+    // Bind with worktree + source-repo paths. Bind file write error stays graceful (Q1).
+    // source_repo persistence (P0-X r1): release_full uses it to run
+    // `git worktree remove` from the owning repo's cwd.
+    crate::binding::bind_full(home, target, task_id, branch, &lease.path, &source_repo);
     tracing::info!(
         %target, %branch, path = %lease.path.display(),
         "dispatch auto-bind + lease OK"

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -8,6 +8,15 @@ mod instance;
 mod schedule;
 pub(crate) mod sha_gate;
 mod task;
+mod worktree;
+
+/// Test-only thin shim into `release_worktree`'s production handler. Used by
+/// `worktree_pool::tests::p0x_release_full_via_handle_release_worktree_end_to_end`
+/// to exercise the full MCP dispatch path without setting up a sender.
+#[cfg(test)]
+pub(crate) fn worktree_test_release(home: &std::path::Path, args: &Value) -> Value {
+    worktree::handle_release_worktree(home, args, &None)
+}
 
 use crate::agent_ops::save_metadata;
 use crate::identity::Sender;
@@ -168,6 +177,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             "unwatch" => ci::handle_unwatch_ci(&home, args),
             other => json!({"error": format!("unknown ci action: {other}")}),
         },
+
+        // --- Daemon-managed worktree release (Sprint 53 P0-X) ---
+        "release_worktree" => worktree::handle_release_worktree(&home, args, &sender),
 
         _ => json!({"error": format!("unknown tool: {tool}")}),
     }

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -1,0 +1,105 @@
+//! MCP handler: `release_worktree` — Sprint 53 P0-X.
+//!
+//! Closes the gap left by P0-1's auto-bind/auto-lease: every PR-merge
+//! transition leaves a stale `.worktrees/<agent>` plus
+//! `runtime/<agent>/binding.json` behind, and the next dispatch trips
+//! P0-1.6's actual-HEAD check. This MCP tool releases the daemon-managed
+//! worktree + clears the binding so the next dispatch can lease cleanly.
+//!
+//! Operator-callable + agent-callable. An agent calling this on itself is
+//! valid — it's the symmetric counterpart of dispatch's auto-bind.
+
+use crate::identity::Sender;
+use serde_json::{json, Value};
+use std::path::Path;
+
+/// MCP tool: `release_worktree`.
+///
+/// Required arg: `agent` (string).
+///
+/// Returns:
+/// - `released`: `true` when the binding was cleared (worktree may still
+///   exist if removal was skipped or partially failed — see `error`).
+/// - `worktree_removed`: `true` when the worktree directory was actually
+///   removed via `git worktree remove --force` (or fallback).
+/// - `binding_removed`: `true` when `runtime/<agent>/binding.json` was
+///   deleted.
+/// - `error`: optional human-readable error. Idempotent second call returns
+///   `released: false, error: "no binding for agent X"` per spec.
+pub(crate) fn handle_release_worktree(
+    home: &Path,
+    args: &Value,
+    _sender: &Option<Sender>,
+) -> Value {
+    let agent = match args["agent"].as_str() {
+        Some(a) if !a.is_empty() => a,
+        _ => return json!({"error": "missing 'agent'"}),
+    };
+    if let Err(e) = crate::agent::validate_name(agent) {
+        return json!({"error": e});
+    }
+    let outcome = crate::worktree_pool::release_full(home, agent);
+    serde_json::to_value(&outcome).unwrap_or_else(|_| json!({"error": "serialize failed"}))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(suffix: &str) -> std::path::PathBuf {
+        let h = std::env::temp_dir().join(format!(
+            "agend-p0x-handler-{}-{}",
+            std::process::id(),
+            suffix
+        ));
+        std::fs::create_dir_all(&h).ok();
+        h
+    }
+
+    #[test]
+    fn handler_rejects_missing_agent() {
+        let home = tmp_home("no-agent");
+        let result = handle_release_worktree(&home, &json!({}), &None);
+        assert_eq!(
+            result["error"].as_str(),
+            Some("missing 'agent'"),
+            "missing agent must surface clear error: {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn handler_rejects_invalid_agent_name() {
+        let home = tmp_home("bad-name");
+        // Agent names with `..` are rejected by validate_name.
+        let result = handle_release_worktree(&home, &json!({"agent": "../etc/passwd"}), &None);
+        assert!(
+            result.get("error").is_some(),
+            "invalid agent name must error: {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn handler_idempotent_no_binding_returns_released_false() {
+        // Production-smoke: handler called via the same path the MCP layer
+        // uses (`handle_release_worktree`). With no binding, must return
+        // released:false and error indicating no binding — not panic.
+        let home = tmp_home("idem-no-binding");
+        let result = handle_release_worktree(&home, &json!({"agent": "ghost"}), &None);
+        assert_eq!(
+            result["released"].as_bool(),
+            Some(false),
+            "missing binding must report released=false: {result}"
+        );
+        assert!(
+            result["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("no binding"),
+            "error must indicate no binding: {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -15,6 +15,7 @@ pub fn tool_definitions() -> Value {
     tools.extend(deploy_tools());
     tools.extend(ci_tools());
     tools.extend(health_tools());
+    tools.extend(worktree_tools());
     json!({"tools": tools})
 }
 
@@ -238,6 +239,19 @@ fn repo_tools() -> Vec<Value> {
     ]
 }
 
+fn worktree_tools() -> Vec<Value> {
+    vec![
+        // Sprint 53 P0-X: release a daemon-managed worktree + clear binding
+        // for `agent`. Idempotent. Only removes worktrees that carry the
+        // `.agend-managed` marker (R14 safety — operator-created worktrees
+        // are left alone). Operator- and agent-callable.
+        json!({"name": "release_worktree", "description": "Release the daemon-managed worktree and clear the binding for the given agent. Idempotent. Only removes worktrees carrying the `.agend-managed` marker — operator-created worktrees are left alone.",
+            "inputSchema": {"type": "object", "properties": {
+                "agent": {"type": "string", "description": "Agent name whose worktree + binding to release"}
+            }, "required": ["agent"]}}),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -372,10 +386,10 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            25 + 1,
-            "Sprint 33 tool count = 26 (pane_snapshot added). \
-             Adding/removing a tool requires updating this assertion. \
-             Current tools: {:?}",
+            27,
+            "Sprint 53 P0-X tool count = 27 (release_worktree added on top of \
+             pane_snapshot's Sprint 33 baseline of 26). Adding/removing a tool \
+             requires updating this assertion. Current tools: {:?}",
             tools
                 .iter()
                 .filter_map(|t| t["name"].as_str())

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -84,6 +84,134 @@ pub fn is_daemon_managed(worktree_path: &Path) -> bool {
     worktree_path.join(MANAGED_MARKER).exists()
 }
 
+/// Outcome of a hard release — emitted by `release_full` and serialized
+/// directly into the `release_worktree` MCP tool response.
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct ReleaseOutcome {
+    pub released: bool,
+    pub worktree_removed: bool,
+    pub binding_removed: bool,
+    pub error: Option<String>,
+}
+
+/// Hard-release an agent's daemon-managed worktree + binding.
+///
+/// Sprint 53 P0-X: closes the gap left by P0-1's auto-bind/auto-lease.
+/// Without this path, every PR-merge transition leaves a stale
+/// `.worktrees/<agent>` plus `runtime/<agent>/binding.json` behind, and the
+/// next dispatch trips P0-1.6's actual-HEAD check (worktree exists on prior
+/// branch). Operator manually `git worktree remove`-d for every transition;
+/// this function lets the `release_worktree` MCP tool do it instead.
+///
+/// Differs from `release()` (Phase 3 soft mark) by actually removing the
+/// worktree directory via `git worktree remove --force`.
+///
+/// Safety: only removes worktrees carrying the `.agend-managed` marker.
+/// Operator-created worktrees without the marker are left alone — surfaced
+/// as `released: false, error: "...no .agend-managed marker..."`.
+///
+/// Idempotent: second call on the same agent sees no binding, returns
+/// `released: false, error: "no binding for agent X"` (per spec — not a
+/// fatal error).
+///
+/// Partial cleanup: if the worktree path is missing or `git worktree remove`
+/// fails, the binding is still cleared so the agent is not stuck in a
+/// half-released state.
+pub fn release_full(home: &Path, agent: &str) -> ReleaseOutcome {
+    let mut out = ReleaseOutcome::default();
+
+    let Some(binding) = crate::binding::read(home, agent) else {
+        // Idempotent no-op on second call. Per spec: not fatal.
+        out.error = Some(format!("no binding for agent '{agent}'"));
+        return out;
+    };
+
+    // Worktree removal: gated on (a) path present in binding, (b) path exists
+    // on disk, (c) carries .agend-managed marker (R14 safety).
+    let wt_path_str = binding["worktree"].as_str().unwrap_or("");
+    if !wt_path_str.is_empty() {
+        let wt_path = Path::new(wt_path_str);
+        if !wt_path.exists() {
+            tracing::info!(
+                agent,
+                path = %wt_path.display(),
+                "release: worktree path already absent — clearing binding only"
+            );
+        } else if !is_daemon_managed(wt_path) {
+            // R14 safety: never touch operator-created worktrees.
+            tracing::warn!(
+                agent,
+                path = %wt_path.display(),
+                "release skipped: no .agend-managed marker — worktree left alone"
+            );
+            out.error = Some(format!(
+                "worktree at {} has no .agend-managed marker — refusing to remove (binding NOT cleared)",
+                wt_path.display()
+            ));
+            return out;
+        } else {
+            // git worktree remove --force, then fall through to binding clear.
+            // AGEND_GIT_BYPASS=1 because the shim denies `git worktree`.
+            let cmd = std::process::Command::new("git")
+                .args([
+                    "worktree",
+                    "remove",
+                    "--force",
+                    &wt_path.display().to_string(),
+                ])
+                .env("AGEND_GIT_BYPASS", "1")
+                .output();
+            match cmd {
+                Ok(o) if o.status.success() => {
+                    out.worktree_removed = true;
+                }
+                Ok(o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
+                    tracing::warn!(
+                        agent,
+                        error = %stderr,
+                        path = %wt_path.display(),
+                        "git worktree remove failed — falling back to remove_dir_all"
+                    );
+                    // Fallback: best-effort manual remove. If it succeeds, count as removed.
+                    let _ = std::fs::remove_dir_all(wt_path);
+                    if !wt_path.exists() {
+                        out.worktree_removed = true;
+                    } else {
+                        out.error = Some(format!("git worktree remove failed: {stderr}"));
+                        // Still clear binding (partial cleanup per spec).
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(agent, error = %e, "git command failed for release");
+                    out.error = Some(format!("git command failed: {e}"));
+                    // Still clear binding (partial cleanup per spec).
+                }
+            }
+        }
+    }
+
+    // Always clear the binding (partial cleanup OK per spec — except when we
+    // bailed early on the unmanaged-worktree safety gate above).
+    crate::binding::unbind(home, agent);
+    out.binding_removed = true;
+    out.released = true;
+
+    crate::event_log::log(
+        home,
+        "worktree_released_full",
+        agent,
+        &format!(
+            "wt_removed={} binding_removed={} error={}",
+            out.worktree_removed,
+            out.binding_removed,
+            out.error.as_deref().unwrap_or("")
+        ),
+    );
+
+    out
+}
+
 /// Pin a worktree (operator override — prevents GC in Phase 4).
 pub fn pin(worktree_path: &Path) {
     let pin_file = worktree_path.join(".agend-pinned");
@@ -348,6 +476,186 @@ mod tests {
         let l = lease(&home, &repo, "agent-4", "feat/idem").expect("lease");
         release(&home, &l);
         release(&home, &l); // second release — no panic
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    // ── Sprint 53 P0-X: release_full (hard release) tests ───────────────
+    //
+    // These call the production function `release_full`, which in turn is
+    // the body of the `release_worktree` MCP tool. The MCP layer test in
+    // `src/mcp/handlers/worktree.rs` covers the handler contract; here we
+    // focus on the filesystem semantics.
+    //
+    // Regression-proof: comment out the `git worktree remove` block in
+    // `release_full` and `p0x_release_full_happy_path_removes_worktree_and_binding`
+    // FAILS (`worktree_removed` stays false; `l.path.exists()` stays true).
+    // Restore → PASS. See commit message §regression-proof.
+
+    #[test]
+    fn p0x_release_full_happy_path_removes_worktree_and_binding() {
+        let home = tmp_home("p0x-happy");
+        let repo = tmp_repo("p0x-happy-repo");
+        let l = lease(&home, &repo, "agent-h", "feat/happy").expect("lease");
+        // Pre-condition: lease created both binding + worktree.
+        assert!(l.path.exists(), "pre: worktree must exist");
+        assert!(crate::binding::read(&home, "agent-h").is_some());
+        assert!(is_daemon_managed(&l.path));
+
+        let outcome = release_full(&home, "agent-h");
+
+        assert!(outcome.released, "happy path must report released");
+        assert!(outcome.worktree_removed, "worktree must be removed");
+        assert!(outcome.binding_removed, "binding must be removed");
+        assert!(outcome.error.is_none(), "no error: {:?}", outcome.error);
+        assert!(!l.path.exists(), "worktree dir must be gone post-release");
+        assert!(crate::binding::read(&home, "agent-h").is_none());
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn p0x_release_full_idempotent_second_call_noop() {
+        let home = tmp_home("p0x-idem");
+        let repo = tmp_repo("p0x-idem-repo");
+        lease(&home, &repo, "agent-i", "feat/idem").expect("lease");
+        let r1 = release_full(&home, "agent-i");
+        assert!(r1.released, "first call must release");
+        let r2 = release_full(&home, "agent-i");
+        assert!(!r2.released, "second call must report no release");
+        assert!(
+            r2.error.as_deref().unwrap_or("").contains("no binding"),
+            "second call error must indicate no binding: {:?}",
+            r2.error
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn p0x_release_full_missing_binding_graceful() {
+        let home = tmp_home("p0x-missing-binding");
+        // No lease, no binding written. Calling release on a fresh agent.
+        let outcome = release_full(&home, "ghost-agent");
+        assert!(!outcome.released);
+        assert!(!outcome.worktree_removed);
+        assert!(!outcome.binding_removed);
+        assert!(
+            outcome
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("no binding"),
+            "missing binding must surface clear error: {:?}",
+            outcome.error
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn p0x_release_full_missing_worktree_path_clears_binding_anyway() {
+        // Binding exists but the worktree directory was deleted out from
+        // under us (manual cleanup, daemon restart races, etc.). Spec:
+        // "still remove binding (partial cleanup ok)".
+        let home = tmp_home("p0x-missing-wt");
+        let repo = tmp_repo("p0x-missing-wt-repo");
+        let l = lease(&home, &repo, "agent-mw", "feat/mw").expect("lease");
+        // Manually remove the worktree dir behind the daemon's back, but
+        // leave the binding pointing at the now-stale path.
+        std::fs::remove_dir_all(&l.path).ok();
+        assert!(!l.path.exists(), "pre: worktree must be gone");
+        assert!(crate::binding::read(&home, "agent-mw").is_some());
+
+        let outcome = release_full(&home, "agent-mw");
+        assert!(outcome.released, "must still release: {:?}", outcome);
+        assert!(outcome.binding_removed, "binding must be cleared");
+        assert!(
+            !outcome.worktree_removed,
+            "worktree wasn't removed by us (it was already gone)"
+        );
+        assert!(crate::binding::read(&home, "agent-mw").is_none());
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn p0x_release_full_unmanaged_worktree_skipped_safely() {
+        // R14 safety: if the binding points at a worktree that lacks the
+        // .agend-managed marker (operator-created, not daemon-leased), the
+        // release MUST NOT remove it. Binding is also kept so the operator
+        // can investigate the inconsistency rather than be left half-cleaned.
+        let home = tmp_home("p0x-unmanaged");
+        let unmanaged_wt = tmp_home("p0x-unmanaged-wt-target");
+        // Hand-craft a binding pointing at an unmanaged path.
+        std::fs::create_dir_all(home.join("runtime").join("agent-u")).ok();
+        let binding = serde_json::json!({
+            "version": 1,
+            "agent": "agent-u",
+            "task_id": "T-1",
+            "branch": "feat/manual",
+            "issued_at": chrono::Utc::now().to_rfc3339(),
+            "worktree": unmanaged_wt.display().to_string(),
+        });
+        std::fs::write(
+            home.join("runtime").join("agent-u").join("binding.json"),
+            serde_json::to_string_pretty(&binding).unwrap(),
+        )
+        .unwrap();
+        // Sanity: no marker.
+        assert!(!is_daemon_managed(&unmanaged_wt));
+
+        let outcome = release_full(&home, "agent-u");
+        assert!(
+            !outcome.released,
+            "unmanaged worktree must NOT be released: {:?}",
+            outcome
+        );
+        assert!(
+            !outcome.binding_removed,
+            "binding must be preserved when worktree is unmanaged (operator visibility)"
+        );
+        assert!(
+            outcome
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains(".agend-managed"),
+            "error must explain the marker check: {:?}",
+            outcome.error
+        );
+        assert!(unmanaged_wt.exists(), "operator-created dir must survive");
+        assert!(
+            crate::binding::read(&home, "agent-u").is_some(),
+            "binding kept for operator visibility"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&unmanaged_wt).ok();
+    }
+
+    #[test]
+    fn p0x_release_full_via_handle_release_worktree_end_to_end() {
+        // Production smoke (§5): exercise the full MCP path —
+        // `handle_release_worktree(home, args, sender)` — the same function
+        // the daemon dispatches `release_worktree` calls into. Asserts that
+        // a leased agent + worktree gets fully cleaned up via the MCP layer.
+        let home = tmp_home("p0x-prod-smoke");
+        let repo = tmp_repo("p0x-prod-smoke-repo");
+        let l = lease(&home, &repo, "agent-prod", "feat/prod").expect("lease");
+        assert!(l.path.exists());
+
+        let result = crate::mcp::handlers::worktree_test_release(
+            &home,
+            &serde_json::json!({"agent": "agent-prod"}),
+        );
+        assert_eq!(result["released"].as_bool(), Some(true), "{result}");
+        assert_eq!(result["worktree_removed"].as_bool(), Some(true), "{result}");
+        assert_eq!(result["binding_removed"].as_bool(), Some(true), "{result}");
+        assert!(!l.path.exists(), "worktree must be removed by MCP path");
+        assert!(crate::binding::read(&home, "agent-prod").is_none());
+
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();
     }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -47,8 +47,11 @@ pub fn lease(
         ),
     );
 
-    // Write full binding with worktree path.
-    crate::binding::bind_full(home, agent, "", branch, &info.path);
+    // Write full binding with worktree + source-repo paths.
+    // source_repo persistence (P0-X r1): release_full reads this back to run
+    // `git worktree remove --force` from the owning repo's cwd, which
+    // prevents stale registry entries that would block re-lease.
+    crate::binding::bind_full(home, agent, "", branch, &info.path, source_repo);
 
     Ok(WorktreeLease {
         agent: agent.to_string(),
@@ -131,12 +134,41 @@ pub fn release_full(home: &Path, agent: &str) -> ReleaseOutcome {
     let wt_path_str = binding["worktree"].as_str().unwrap_or("");
     if !wt_path_str.is_empty() {
         let wt_path = Path::new(wt_path_str);
+
+        // Source-repo: read from binding (P0-X r1 schema field), else derive
+        // from the daemon's worktree convention `<source>/.worktrees/<agent>`.
+        // Without a correct cwd, `git worktree remove` may fail and the
+        // fallback `remove_dir_all` would leak a stale registry entry.
+        let source_repo: PathBuf = binding["source_repo"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .or_else(|| {
+                // Derive: parent of `.worktrees/<agent>` is the source repo.
+                wt_path
+                    .parent()
+                    .filter(|p| p.file_name().and_then(|n| n.to_str()) == Some(".worktrees"))
+                    .and_then(|p| p.parent())
+                    .map(PathBuf::from)
+            })
+            .unwrap_or_else(PathBuf::new);
+
         if !wt_path.exists() {
             tracing::info!(
                 agent,
                 path = %wt_path.display(),
-                "release: worktree path already absent — clearing binding only"
+                "release: worktree path already absent — pruning registry + clearing binding"
             );
+            // Prune registry in case the source repo still lists this path.
+            // Safe even when source_repo is empty — git just errors out and
+            // we ignore the result.
+            if !source_repo.as_os_str().is_empty() {
+                let _ = std::process::Command::new("git")
+                    .current_dir(&source_repo)
+                    .args(["worktree", "prune"])
+                    .env("AGEND_GIT_BYPASS", "1")
+                    .output();
+            }
         } else if !is_daemon_managed(wt_path) {
             // R14 safety: never touch operator-created worktrees.
             tracing::warn!(
@@ -150,18 +182,22 @@ pub fn release_full(home: &Path, agent: &str) -> ReleaseOutcome {
             ));
             return out;
         } else {
-            // git worktree remove --force, then fall through to binding clear.
-            // AGEND_GIT_BYPASS=1 because the shim denies `git worktree`.
-            let cmd = std::process::Command::new("git")
-                .args([
-                    "worktree",
-                    "remove",
-                    "--force",
-                    &wt_path.display().to_string(),
-                ])
-                .env("AGEND_GIT_BYPASS", "1")
-                .output();
-            match cmd {
+            // git worktree remove --force, run from the OWNING repo's cwd
+            // so the registry entry is cleaned up alongside the directory.
+            // AGEND_GIT_BYPASS=1 bypasses the shim's worktree-deny matrix.
+            let mut cmd = std::process::Command::new("git");
+            cmd.args([
+                "worktree",
+                "remove",
+                "--force",
+                &wt_path.display().to_string(),
+            ])
+            .env("AGEND_GIT_BYPASS", "1");
+            if !source_repo.as_os_str().is_empty() {
+                cmd.current_dir(&source_repo);
+            }
+            let result = cmd.output();
+            match result {
                 Ok(o) if o.status.success() => {
                     out.worktree_removed = true;
                 }
@@ -173,9 +209,23 @@ pub fn release_full(home: &Path, agent: &str) -> ReleaseOutcome {
                         path = %wt_path.display(),
                         "git worktree remove failed — falling back to remove_dir_all"
                     );
-                    // Fallback: best-effort manual remove. If it succeeds, count as removed.
+                    // Fallback: best-effort manual remove + registry prune.
                     let _ = std::fs::remove_dir_all(wt_path);
                     if !wt_path.exists() {
+                        // Prune the registry so `git worktree list` doesn't
+                        // keep advertising the (now-deleted) path. Without
+                        // this the next lease re-attempt sees the entry,
+                        // detects it as "checked out", and rejects.
+                        if !source_repo.as_os_str().is_empty() {
+                            let prune = std::process::Command::new("git")
+                                .current_dir(&source_repo)
+                                .args(["worktree", "prune"])
+                                .env("AGEND_GIT_BYPASS", "1")
+                                .output();
+                            if let Err(e) = prune {
+                                tracing::warn!(agent, error = %e, "git worktree prune failed");
+                            }
+                        }
                         out.worktree_removed = true;
                     } else {
                         out.error = Some(format!("git worktree remove failed: {stderr}"));
@@ -633,6 +683,92 @@ mod tests {
 
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&unmanaged_wt).ok();
+    }
+
+    /// Helper: assert `git worktree list --porcelain` from `repo` does NOT
+    /// emit any `prunable` line (registry leak indicator).
+    fn assert_no_prunable_registry(repo: &Path, scenario: &str) {
+        let output = std::process::Command::new("git")
+            .current_dir(repo)
+            .args(["worktree", "list", "--porcelain"])
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git worktree list");
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        assert!(
+            !stdout.contains("prunable"),
+            "[{scenario}] git worktree registry must be clean — found `prunable` entry. Output:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn p0x_release_full_clears_git_worktree_registry() {
+        // r1 reviewer (PR #470): the prior IMPL didn't pass `.current_dir(source_repo)`
+        // and the `remove_dir_all` fallback didn't `git worktree prune`, so
+        // `git worktree list --porcelain` kept emitting `prunable` entries
+        // that would block re-lease (registry vs filesystem skew).
+        //
+        // Scenario A: happy path — `release_full` invokes `git worktree
+        // remove --force` from the owning repo's cwd. Registry must be clean.
+        let home = tmp_home("p0x-registry-happy");
+        let repo = tmp_repo("p0x-registry-happy-repo");
+        let _l = lease(&home, &repo, "agent-r", "feat/registry").expect("lease");
+
+        let outcome = release_full(&home, "agent-r");
+        assert!(outcome.released);
+        assert!(outcome.worktree_removed);
+        assert_no_prunable_registry(&repo, "happy-path");
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn p0x_release_full_prunes_registry_after_external_dir_removal() {
+        // Reviewer's exact failure mode: the worktree dir gets removed
+        // externally (daemon crash mid-op, manual `rm`), so when `release_full`
+        // runs the dir is already gone but the git registry still lists the
+        // path as `prunable`. Without the explicit `git worktree prune` call
+        // in the missing-path branch, the next lease re-attempt fails because
+        // the registry sees the path as still claimed.
+        //
+        // This is the load-bearing regression-proof for the r1 fix:
+        // commenting out the `git worktree prune` block in `release_full`'s
+        // missing-path branch makes this test FAIL on the post-release
+        // assertion. Restore → PASS.
+        let home = tmp_home("p0x-registry-prune");
+        let repo = tmp_repo("p0x-registry-prune-repo");
+        let l = lease(&home, &repo, "agent-rm", "feat/prune").expect("lease");
+
+        // Simulate the leak: yank the worktree dir behind git's back.
+        std::fs::remove_dir_all(&l.path).ok();
+        assert!(!l.path.exists(), "test setup: dir must be gone");
+
+        // Pre-condition sanity: registry MUST list the now-missing entry as
+        // `prunable` before release_full runs. If git's behavior changes and
+        // this assertion no longer holds, the test setup is no longer
+        // exercising the bug — flag it via panic in the assertion.
+        let pre_output = std::process::Command::new("git")
+            .current_dir(&repo)
+            .args(["worktree", "list", "--porcelain"])
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git worktree list pre");
+        let pre_stdout = String::from_utf8_lossy(&pre_output.stdout).to_string();
+        assert!(
+            pre_stdout.contains("prunable"),
+            "test setup invariant: dir-removed worktree must show as prunable pre-release. Output:\n{pre_stdout}"
+        );
+
+        let outcome = release_full(&home, "agent-rm");
+        assert!(outcome.released);
+        assert!(outcome.binding_removed);
+
+        // Post-condition: prune must have run, registry is clean.
+        assert_no_prunable_registry(&repo, "post-external-rm");
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Sprint 53 P0-X — symmetric counterpart to P0-1's auto-bind/auto-lease.

- New MCP tool `release_worktree(agent)` removes the daemon-managed worktree + clears the binding.
- New `worktree_pool::release_full` does the actual hard release (vs existing `release()` which is a Phase 3 GC mark).
- R14 safety: only removes worktrees carrying the `.agend-managed` marker. Operator-created worktrees are left alone.
- Idempotent + graceful — missing binding / missing worktree path / failed `git worktree remove` all handled per spec.

## Why

P0-1 wired auto-bind + auto-lease (#464) so every dispatch lands a worktree + binding pair. There was no symmetric release path, so every PR-merge transition left a stale `.worktrees/<agent>` plus `runtime/<agent>/binding.json`. The next dispatch tripped P0-1.6's actual-HEAD check (worktree exists on prior branch) and rejected with "dispatch rejected: lease conflict". Lead manually `git worktree remove`'d for every PR-merge transition — this very dispatch's first attempt was rejected for that reason and lead manually cleaned `.worktrees/dev` before retrying.

## Spec implementation

```text
release_worktree(agent: str) -> { released, worktree_removed, binding_removed, error? }
```

1. Read `home/runtime/<agent>/binding.json`. Missing → `released: false, error: "no binding for agent X"`.
2. If binding's `worktree` field points at a directory carrying `.agend-managed`, run `git worktree remove --force` (with `AGEND_GIT_BYPASS=1`).
3. If marker missing (operator-created worktree): R14 safety — refuse + preserve binding so the operator can investigate.
4. If `git worktree remove` fails: fall back to `remove_dir_all` (best effort) and surface the git stderr in `error`. Binding still cleared (partial cleanup OK).
5. Idempotent: second call → no-op.

## Tests (9)

`worktree_pool::tests::p0x_release_full_*` (6):
- `_happy_path_removes_worktree_and_binding`
- `_idempotent_second_call_noop`
- `_missing_binding_graceful`
- `_missing_worktree_path_clears_binding_anyway`
- `_unmanaged_worktree_skipped_safely` — R14 safety, refuses to touch unmanaged dirs AND preserves binding
- `_via_handle_release_worktree_end_to_end` — **PRODUCTION SMOKE** end-to-end through `handle_release_worktree`

`mcp::handlers::worktree::tests::handler_*` (3):
- `_rejects_missing_agent`
- `_rejects_invalid_agent_name` (path-traversal guard via `validate_name`)
- `_idempotent_no_binding_returns_released_false`

## Empirical regression-proof verification

Commented out the `git worktree remove --force` block in `release_full` (lines 153–192) and re-ran:

```
test worktree_pool::tests::p0x_release_full_happy_path_removes_worktree_and_binding ... FAILED
test worktree_pool::tests::p0x_release_full_via_handle_release_worktree_end_to_end ... FAILED
```

Restored → `test result: ok. 9 passed`. Confirms the new tests are load-bearing.

## Auto-trigger research (Sprint 54 scope — defer IMPL)

Should `kind=report` auto-trigger release?

- ❌ Agents send progress reports during work, not only on done. Auto-releasing on every report would yank the worktree out from under in-flight commits.
- ❌ "Task done" semantics are not currently encoded in the report envelope — no flag distinguishing progress vs final done.
- ✅ Lease conflicts arise when the SECOND dispatch lands. Releasing eagerly on report risks flapping if work continues post-report.

**Recommendation for Sprint 54**: introduce an explicit `task_done` flag in the report envelope (or piggyback on `task` action `done`) and tie auto-release to that signal — not the report kind itself.

## Sprint 49 cushion

- No new `tokio::spawn` / `thread::spawn`. Sync FS ops on the MCP handler thread.
- No L1/L2 lock acquisition. `binding::unbind` is `std::fs::remove_file`; `git worktree remove` is a child process — both safe from the dispatch parser thread.
- New `mcp/handlers/worktree.rs` = 105 LOC (well under 700 invariant). `worktree_pool.rs` grew to 802 LOC but isn't under `src/mcp/handlers/` so the handler invariant doesn't apply.
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

## Tool count invariant

`mcp::tools::tests::tool_definitions_count_invariant_post_sprint_30` updated 26 → 27 to admit `release_worktree`.

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [x] cargo test --bin agend-terminal -- p0x_release worktree::tests handler_ → 20/20 pass
- [x] cargo test --bin agend-terminal -- --test-threads=1 worktree_pool → 19/19 pass
- [x] cargo test --bin agend-terminal -- mcp::tools::tests → all pass (count invariant updated)
- [x] cargo test --test file_size_invariant → 1/1 pass
- [x] Empirical regression-proof verification (worktree-remove block commented → 2 FAIL, restored → all PASS)
- [ ] Operator manual smoke: dispatch → operator calls `release_worktree dev` → re-dispatch → confirm no lease conflict (the friction signal that motivated this PR)

## Pre-existing test failures (unchanged from main, not introduced here)

Same pattern as #467/#469 — 7 `admin::tests::analyze_detects_worktree_branch` + `claim_verifier::tests::*_red` failures (git-state-dependent, fail consistently on `origin/main` HEAD in this workspace) plus 1 parallel race in `broadcast_emits_with_resolved_recipients`. None touch `worktree_pool.rs`, `mcp/handlers/worktree.rs`, or `mcp/tools.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)