### PR TITLE
Wire fleet instructions through template, daemon, and app spawn paths

### DIFF
--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -64,15 +64,14 @@ pub(crate) fn prepare_instructions(
             let role = explicit_role
                 .map(str::to_string)
                 .or_else(|| fleet.instances.get(name).and_then(|c| c.role.clone()));
-            // Resolve extra instructions file relative to fleet.yaml dir.
-            let extra_instr = fleet
-                .instances
-                .get(name)
-                .and_then(|c| c.instructions.as_deref())
-                .and_then(|p| {
-                    let resolved = fleet_path.parent().unwrap_or(home).join(p);
-                    std::fs::read_to_string(resolved).ok()
-                });
+            let fleet_dir = fleet_path.parent().unwrap_or(home);
+            let extra_instr = crate::instructions::resolve_extra_from_path(
+                fleet
+                    .instances
+                    .get(name)
+                    .and_then(|c| c.instructions.as_deref()),
+                fleet_dir,
+            );
             let ctx = crate::instructions::AgentContext {
                 name,
                 role: role.as_deref(),

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -99,6 +99,7 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
                         backend: Some(be.clone()),
                         working_directory: Some(wd.display().to_string()),
                         role: None,
+                        instructions: None,
                     },
                 )
             })

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -47,6 +47,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                     backend: Some(backend_name.to_string()),
                     working_directory: None,
                     role: None,
+                    instructions: None,
                 },
             ) {
                 tracing::warn!(name = %inst_name, error = %e, "failed to write fleet.yaml");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -779,6 +779,7 @@ fn pane_from_menu_item(
                     backend: Some(backend.name().to_string()),
                     working_directory: None,
                     role: None,
+                    instructions: None,
                 },
             ) {
                 tracing::warn!(error = %e, "failed to write fleet.yaml");

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -280,12 +280,16 @@ pub(super) fn create_pane_from_resolved(
             orchestrator: t.orchestrator.as_deref(),
             members: t.members.as_slice(),
         });
+    let extra_instructions = resolved
+        .instructions
+        .as_deref()
+        .and_then(|p| std::fs::read_to_string(fleet_path.parent().unwrap_or(home).join(p)).ok());
     let ctx = crate::instructions::AgentContext {
         name: fleet_name,
         role: resolved.role.as_deref(),
         fleet_peers: &peers,
         team: team_ctx.as_ref(),
-        extra_instructions: None, // App mode doesn't resolve fleet.yaml instructions
+        extra_instructions: extra_instructions.as_deref(),
     };
 
     let mut pane = create_pane(

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -280,10 +280,8 @@ pub(super) fn create_pane_from_resolved(
             orchestrator: t.orchestrator.as_deref(),
             members: t.members.as_slice(),
         });
-    let extra_instructions = resolved
-        .instructions
-        .as_deref()
-        .and_then(|p| std::fs::read_to_string(fleet_path.parent().unwrap_or(home).join(p)).ok());
+    let extra_instructions =
+        crate::instructions::resolve_extra_for(resolved, fleet_path.parent().unwrap_or(home));
     let ctx = crate::instructions::AgentContext {
         name: fleet_name,
         role: resolved.role.as_deref(),

--- a/src/bootstrap/agent_resolve.rs
+++ b/src/bootstrap/agent_resolve.rs
@@ -20,17 +20,25 @@ pub type AgentDef = (
     String,
 );
 
+struct ResolveContext<'a> {
+    fleet_dir: &'a Path,
+    peers: Vec<(String, Option<String>)>,
+}
+
 /// Resolve every instance in `config` into a spawn-ready [`AgentDef`].
 pub(super) fn resolve(config: &FleetConfig, fleet_dir: &Path) -> Vec<AgentDef> {
-    let peers: Vec<(String, Option<String>)> = config
-        .instances
-        .iter()
-        .map(|(n, c)| (n.clone(), c.role.clone()))
-        .collect();
+    let ctx = ResolveContext {
+        fleet_dir,
+        peers: config
+            .instances
+            .iter()
+            .map(|(n, c)| (n.clone(), c.role.clone()))
+            .collect(),
+    };
     config
         .instance_names()
         .into_iter()
-        .filter_map(|name| resolve_one(config, fleet_dir, &peers, &name))
+        .filter_map(|name| resolve_one(config, &ctx, &name))
         .collect()
 }
 
@@ -40,12 +48,7 @@ pub(super) fn resolve(config: &FleetConfig, fleet_dir: &Path) -> Vec<AgentDef> {
 /// resolved. Side effects (worktree creation, instruction generation) mirror
 /// [`resolve`] so hot-reload-added agents are set up identically to ones
 /// materialized at startup.
-pub(crate) fn resolve_one(
-    config: &FleetConfig,
-    fleet_dir: &Path,
-    peers: &[(String, Option<String>)],
-    name: &str,
-) -> Option<AgentDef> {
+fn resolve_one(config: &FleetConfig, ctx: &ResolveContext<'_>, name: &str) -> Option<AgentDef> {
     let mut resolved = config.resolve_instance(name)?;
 
     if let Some(ref base_dir) = resolved.working_directory {
@@ -87,14 +90,11 @@ pub(crate) fn resolve_one(
     }
 
     if let Some(ref dir) = resolved.working_directory {
-        let extra_instructions = resolved
-            .instructions
-            .as_deref()
-            .and_then(|p| std::fs::read_to_string(fleet_dir.join(p)).ok());
+        let extra_instructions = crate::instructions::resolve_extra_for(&resolved, ctx.fleet_dir);
         let ctx = crate::instructions::AgentContext {
             name,
             role: resolved.role.as_deref(),
-            fleet_peers: peers,
+            fleet_peers: &ctx.peers,
             team: None,
             extra_instructions: extra_instructions.as_deref(),
         };
@@ -167,7 +167,11 @@ mod tests {
             .iter()
             .map(|(n, c)| (n.clone(), c.role.clone()))
             .collect();
-        let result = resolve_one(&config, &dir, &peers, "test-agent");
+        let ctx = ResolveContext {
+            fleet_dir: &dir,
+            peers,
+        };
+        let result = resolve_one(&config, &ctx, "test-agent");
         assert!(
             result.is_some(),
             "resolve_one must succeed with worktree:false"
@@ -193,7 +197,11 @@ mod tests {
             .iter()
             .map(|(n, c)| (n.clone(), c.role.clone()))
             .collect();
-        let result = resolve_one(&config, &dir, &peers, "test-agent");
+        let ctx = ResolveContext {
+            fleet_dir: &dir,
+            peers,
+        };
+        let result = resolve_one(&config, &ctx, "test-agent");
         assert!(result.is_some());
         let (_, _, _, _, work_dir, _) = result.unwrap();
         let wd = work_dir.unwrap();
@@ -224,7 +232,11 @@ mod tests {
             .iter()
             .map(|(n, c)| (n.clone(), c.role.clone()))
             .collect();
-        let result = resolve_one(&config, &dir, &peers, "test-agent");
+        let ctx = ResolveContext {
+            fleet_dir: &dir,
+            peers,
+        };
+        let result = resolve_one(&config, &ctx, "test-agent");
         assert!(result.is_some(), "resolve_one must succeed after prune");
         // Verify prune was attempted — worktree dir should be removed
         // (or at minimum, resolve_one returned the base dir, not the worktree)
@@ -258,7 +270,11 @@ mod tests {
             .iter()
             .map(|(n, c)| (n.clone(), c.role.clone()))
             .collect();
-        let result = resolve_one(&config, &dir, &peers, "test-agent");
+        let ctx = ResolveContext {
+            fleet_dir: &dir,
+            peers,
+        };
+        let result = resolve_one(&config, &ctx, "test-agent");
         assert!(result.is_some(), "resolve_one should succeed");
         let (_, _, _, _, wd, _) = result.unwrap();
         let generated = std::fs::read_to_string(wd.unwrap().join(".claude/agend.md"))

--- a/src/bootstrap/agent_resolve.rs
+++ b/src/bootstrap/agent_resolve.rs
@@ -7,7 +7,7 @@
 use crate::backend;
 use crate::fleet::FleetConfig;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Agent spawn tuple consumed by `daemon::run_with_prepared`. Matches the
 /// shape of `daemon::AgentDef`.
@@ -21,11 +21,16 @@ pub type AgentDef = (
 );
 
 /// Resolve every instance in `config` into a spawn-ready [`AgentDef`].
-pub(super) fn resolve(config: &FleetConfig) -> Vec<AgentDef> {
+pub(super) fn resolve(config: &FleetConfig, fleet_dir: &Path) -> Vec<AgentDef> {
+    let peers: Vec<(String, Option<String>)> = config
+        .instances
+        .iter()
+        .map(|(n, c)| (n.clone(), c.role.clone()))
+        .collect();
     config
         .instance_names()
         .into_iter()
-        .filter_map(|name| resolve_one(config, &name))
+        .filter_map(|name| resolve_one(config, fleet_dir, &peers, &name))
         .collect()
 }
 
@@ -35,7 +40,12 @@ pub(super) fn resolve(config: &FleetConfig) -> Vec<AgentDef> {
 /// resolved. Side effects (worktree creation, instruction generation) mirror
 /// [`resolve`] so hot-reload-added agents are set up identically to ones
 /// materialized at startup.
-pub(crate) fn resolve_one(config: &FleetConfig, name: &str) -> Option<AgentDef> {
+pub(crate) fn resolve_one(
+    config: &FleetConfig,
+    fleet_dir: &Path,
+    peers: &[(String, Option<String>)],
+    name: &str,
+) -> Option<AgentDef> {
     let mut resolved = config.resolve_instance(name)?;
 
     if let Some(ref base_dir) = resolved.working_directory {
@@ -77,7 +87,18 @@ pub(crate) fn resolve_one(config: &FleetConfig, name: &str) -> Option<AgentDef> 
     }
 
     if let Some(ref dir) = resolved.working_directory {
-        crate::instructions::generate(dir, &resolved.backend_command);
+        let extra_instructions = resolved
+            .instructions
+            .as_deref()
+            .and_then(|p| std::fs::read_to_string(fleet_dir.join(p)).ok());
+        let ctx = crate::instructions::AgentContext {
+            name,
+            role: resolved.role.as_deref(),
+            fleet_peers: peers,
+            team: None,
+            extra_instructions: extra_instructions.as_deref(),
+        };
+        crate::instructions::generate_with_context(dir, &resolved.backend_command, Some(&ctx));
     }
 
     let mut args = resolved.args;
@@ -141,7 +162,12 @@ mod tests {
         let dir = tmp_dir("wt-false-skip");
         init_git_repo(&dir);
         let config = make_config(&dir, Some(false));
-        let result = resolve_one(&config, "test-agent");
+        let peers: Vec<(String, Option<String>)> = config
+            .instances
+            .iter()
+            .map(|(n, c)| (n.clone(), c.role.clone()))
+            .collect();
+        let result = resolve_one(&config, &dir, &peers, "test-agent");
         assert!(
             result.is_some(),
             "resolve_one must succeed with worktree:false"
@@ -162,7 +188,12 @@ mod tests {
         let dir = tmp_dir("wt-default");
         init_git_repo(&dir);
         let config = make_config(&dir, None); // default = true
-        let result = resolve_one(&config, "test-agent");
+        let peers: Vec<(String, Option<String>)> = config
+            .instances
+            .iter()
+            .map(|(n, c)| (n.clone(), c.role.clone()))
+            .collect();
+        let result = resolve_one(&config, &dir, &peers, "test-agent");
         assert!(result.is_some());
         let (_, _, _, _, work_dir, _) = result.unwrap();
         let wd = work_dir.unwrap();
@@ -188,7 +219,12 @@ mod tests {
         assert!(wt_dir.exists(), "worktree must exist before prune");
 
         let config = make_config(&dir, Some(false));
-        let result = resolve_one(&config, "test-agent");
+        let peers: Vec<(String, Option<String>)> = config
+            .instances
+            .iter()
+            .map(|(n, c)| (n.clone(), c.role.clone()))
+            .collect();
+        let result = resolve_one(&config, &dir, &peers, "test-agent");
         assert!(result.is_some(), "resolve_one must succeed after prune");
         // Verify prune was attempted — worktree dir should be removed
         // (or at minimum, resolve_one returned the base dir, not the worktree)
@@ -198,6 +234,38 @@ mod tests {
             !wd.to_string_lossy().contains(".worktrees"),
             "worktree:false must NOT use .worktrees/ path, got: {}",
             wd.display()
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_one_appends_instance_extra_instructions() {
+        let dir = tmp_dir("extra-instructions");
+        let work_dir = dir.join("work");
+        std::fs::create_dir_all(dir.join("instructions")).unwrap();
+        std::fs::write(
+            dir.join("instructions").join("dev.md"),
+            "# Extra\nAlways mention deployment checklist.",
+        )
+        .unwrap();
+        let yaml = format!(
+            "defaults:\n  backend: claude\ninstances:\n  test-agent:\n    command: claude\n    working_directory: {}\n    instructions: ./instructions/dev.md\n",
+            work_dir.display()
+        );
+        let config: FleetConfig = serde_yaml_ng::from_str(&yaml).unwrap();
+        let peers: Vec<(String, Option<String>)> = config
+            .instances
+            .iter()
+            .map(|(n, c)| (n.clone(), c.role.clone()))
+            .collect();
+        let result = resolve_one(&config, &dir, &peers, "test-agent");
+        assert!(result.is_some(), "resolve_one should succeed");
+        let (_, _, _, _, wd, _) = result.unwrap();
+        let generated = std::fs::read_to_string(wd.unwrap().join(".claude/agend.md"))
+            .expect("generated instructions file");
+        assert!(
+            generated.contains("Always mention deployment checklist."),
+            "extra instructions must be appended in daemon bootstrap path"
         );
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -56,6 +56,7 @@ fn auto_create_general(config: &mut FleetConfig, home: &Path, persist: bool) {
             .map(|b| b.name().to_string()),
         working_directory: None,
         role: Some("Fleet coordinator — routes tasks between agents".to_string()),
+        instructions: None,
     };
     if let Err(e) = fleet::add_instance_to_yaml(home, "general", &entry) {
         tracing::warn!(error = %e, "failed to persist general instance");

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -270,6 +270,24 @@ mod tests {
         path
     }
 
+    fn write_fleet_with_extra_instructions(home: &Path) -> PathBuf {
+        let path = home.join("fleet.yaml");
+        let instructions_dir = home.join("instructions");
+        std::fs::create_dir_all(&instructions_dir).expect("mkdir instructions");
+        std::fs::write(
+            instructions_dir.join("dev.md"),
+            "# Extra Instructions\nAlways include rollout checklist.",
+        )
+        .expect("write instructions file");
+        let work_dir = home.join("workspace").join("worker");
+        let yaml = format!(
+            "defaults:\n  backend: claude\ninstances:\n  worker:\n    backend: claude\n    working_directory: {}\n    instructions: ./instructions/dev.md\n",
+            work_dir.display()
+        );
+        std::fs::write(&path, yaml).expect("write fleet with instructions");
+        path
+    }
+
     /// Stand up a loopback listener and write its port as `api.port` inside
     /// `run_dir`, mimicking a real daemon for `probe_api` purposes. Returns
     /// the listener so the caller keeps it alive for the duration of the test.
@@ -438,6 +456,28 @@ mod tests {
                 panic!("must not Attach to a run dir whose api.port is dead");
             }
         }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn prepare_resolve_agents_applies_extra_instructions_to_generated_file() {
+        let home = tmp_home("resolve_extra_instructions");
+        let fleet = write_fleet_with_extra_instructions(&home);
+        let opts = PrepareOptions {
+            mutate_fleet_yaml: false,
+            init_telegram: false,
+            resolve_agents: true,
+        };
+        let outcome = prepare(&home, &fleet, opts).expect("prepare");
+        let BootstrapOutcome::Owned(_owned) = outcome else {
+            panic!("expected Owned for fresh temp home");
+        };
+        let generated = std::fs::read_to_string(home.join("workspace/worker/.claude/agend.md"))
+            .expect("generated .claude/agend.md");
+        assert!(
+            generated.contains("Always include rollout checklist."),
+            "generated instructions must include extra file content"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -167,7 +167,8 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     doctor::emit_diagnostics(&diags);
 
     let agents = if opts.resolve_agents {
-        agent_resolve::resolve(&config)
+        let fleet_dir = fleet_path.parent().unwrap_or(home);
+        agent_resolve::resolve(&config, fleet_dir)
     } else {
         Vec::new()
     };

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -154,6 +154,12 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(String::from);
+        let instructions = inst_val
+            .get("instructions")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from);
 
         // Every member gets its own `<directory>/<inst_name>` subdir —
         // same-backend teammates would otherwise clobber each other's
@@ -201,6 +207,7 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
                 backend: Some(command.to_string()),
                 working_directory: Some(work_dir),
                 role,
+                instructions,
             },
         ));
         created.push(inst_name);
@@ -488,6 +495,33 @@ templates:
                 .and_then(|i| i.role.clone())
                 .as_deref(),
             Some("orchestrator via alias")
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn deploy_persists_instructions_into_fleet_yaml() {
+        let home = tmp_home("instructions_persist");
+        let yaml = r#"
+templates:
+  dev:
+    instances:
+      lead:
+        backend: claude
+        instructions: ./instructions/lead.md
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+
+        let args = serde_json::json!({"template": "dev", "directory": home.display().to_string()});
+        let _ = deploy(&home, "caller", &args);
+
+        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        assert_eq!(
+            reloaded
+                .instances
+                .get("dev-lead")
+                .and_then(|i| i.instructions.as_deref()),
+            Some("./instructions/lead.md")
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -374,6 +374,7 @@ impl FleetConfig {
             git_branch: inst.git_branch.clone(),
             model,
             worktree: inst.worktree,
+            instructions: inst.instructions.clone(),
         })
     }
 
@@ -434,6 +435,7 @@ pub struct ResolvedInstance {
     pub git_branch: Option<String>,
     pub model: Option<String>,
     pub worktree: Option<bool>,
+    pub instructions: Option<String>,
 }
 
 fn dirs_home() -> Option<PathBuf> {
@@ -445,6 +447,7 @@ pub struct InstanceYamlEntry {
     pub backend: Option<String>,
     pub working_directory: Option<String>,
     pub role: Option<String>,
+    pub instructions: Option<String>,
 }
 
 /// Atomically write a serde_yaml_ng::Value back to fleet.yaml using temp + fsync + rename.
@@ -515,6 +518,7 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
                 ("backend", &config.backend),
                 ("working_directory", &config.working_directory),
                 ("role", &config.role),
+                ("instructions", &config.instructions),
             ] {
                 if let Some(ref v) = val {
                     inst.insert(key.into(), serde_yaml_ng::Value::String(v.clone()));
@@ -702,6 +706,7 @@ instances:
             backend: Some("claude".to_string()),
             working_directory: Some("/tmp/work".to_string()),
             role: Some("developer".to_string()),
+            instructions: Some("./instructions/dev.md".to_string()),
         };
         add_instance_to_yaml(&dir, "new-agent", &entry).expect("add");
         let config = FleetConfig::load(&path).expect("load after add");
@@ -710,6 +715,7 @@ instances:
         assert_eq!(inst.backend, Some(crate::backend::Backend::ClaudeCode));
         assert_eq!(inst.working_directory.as_deref(), Some("/tmp/work"));
         assert_eq!(inst.role.as_deref(), Some("developer"));
+        assert_eq!(inst.instructions.as_deref(), Some("./instructions/dev.md"));
         // existing instance should still be there
         assert!(config.instances.contains_key("existing"));
 
@@ -746,6 +752,7 @@ instances:
             backend: Some("claude".to_string()),
             working_directory: None,
             role: None,
+            instructions: None,
         };
         add_instance_to_yaml(&dir, "first", &entry).expect("add to new");
         let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
@@ -1024,6 +1031,7 @@ instances:
             backend: Some("claude".to_string()),
             working_directory: None,
             role: Some("tester".to_string()),
+            instructions: None,
         };
         add_instance_to_yaml(&dir, "temp-agent", &entry).expect("add");
 

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -32,6 +32,22 @@ pub struct TeamContext<'a> {
     pub members: &'a [String],
 }
 
+/// Resolve extra instructions content from a fleet-relative path string.
+///
+/// Resolution rule is intentionally simple and shared: `fleet_dir.join(path)`.
+/// Missing/unreadable files stay silent and return `None`.
+pub fn resolve_extra_from_path(path: Option<&str>, fleet_dir: &Path) -> Option<String> {
+    path.and_then(|p| std::fs::read_to_string(fleet_dir.join(p)).ok())
+}
+
+/// Resolve extra instructions content for a fully-resolved instance.
+pub fn resolve_extra_for(
+    resolved: &crate::fleet::ResolvedInstance,
+    fleet_dir: &Path,
+) -> Option<String> {
+    resolve_extra_from_path(resolved.instructions.as_deref(), fleet_dir)
+}
+
 /// Minimal .gitignore written on fresh git init: lists agend runtime artifacts
 /// that are per-session state rather than source-controlled content.
 const AGEND_GITIGNORE: &str = "\

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -613,6 +613,7 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
                     .or_else(|| Some(command.to_string())),
                 working_directory: Some(work_dir.clone()),
                 role,
+                instructions: None,
             };
             if let Err(e) = crate::fleet::add_instance_to_yaml(home, name, &entry) {
                 tracing::warn!(error = %e, "failed to persist to fleet.yaml");


### PR DESCRIPTION
Hi! Thanks for building this project.

I wanted to share a small implementation that tries to complete the existing `fleet.yaml` `instructions:` route end-to-end.

From code comments/tests it looked like this behavior was already intended, but in my local runs the field only took effect on some spawn paths. This PR aims to make the behavior consistent across the main lifecycle paths.

## What this changes
- Persist `instructions` when materializing template instances into `instances.*`.
- Carry `instructions` through `ResolvedInstance` / `InstanceYamlEntry`.
- Apply extra instructions during daemon bootstrap (`start` path) via `generate_with_context`.
- Apply extra instructions during app pane creation path as well.

## Why
Without this, `instructions:` could appear to work in API spawn flows but be skipped in:
- daemon bootstrap (`agend-terminal start`)
- app/pane rehydrate flows
- template-based deploys (because template `instructions` was not persisted into instances)

## Validation
I ran:
- `cargo test -q bootstrap::agent_resolve::tests::resolve_one_appends_instance_extra_instructions -- --exact`
- `cargo test -q deployments::tests::deploy_persists_instructions_into_fleet_yaml -- --exact`
- `cargo test -q fleet::tests::test_add_instance_to_yaml -- --exact`
- `cargo check -q`

If this overlaps with planned design constraints I may have missed, I’m very happy to revise or split this into smaller PRs. Thanks for taking a look.
