### PR TITLE
fix(#474): TUI close path triggers deployment reconcile

### DIFF
--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -368,6 +368,12 @@ pub(super) fn handle_key(
                     if !closed.is_empty() {
                         let names: Vec<String> = closed.iter().map(|(n, _)| n.clone()).collect();
                         let _ = crate::fleet::remove_instances_from_yaml(ctx.home, &names);
+                        // Issue #474: TUI close (Ctrl-B x / tab close) bypassed
+                        // deployment teardown, leaving stale entries in
+                        // `deployment list`. Reconcile after fleet.yaml is
+                        // updated: any deployment whose members are all now
+                        // gone gets pruned (entry + team).
+                        let _ = crate::deployments::reconcile_after_close(ctx.home, &names);
                     }
                     if let Some(tab) = ctx.layout.close_tab(idx) {
                         for name in tab.root().agent_names() {
@@ -395,6 +401,14 @@ pub(super) fn handle_key(
                             fleet_name,
                         );
                         let _ = crate::fleet::remove_instance_from_yaml(ctx.home, fleet_name);
+                        // Issue #474: same reconcile hook for single-pane
+                        // close. The reconcile is generic, so even if this
+                        // single instance was the last live member of a
+                        // multi-instance deployment, the entry gets pruned.
+                        let _ = crate::deployments::reconcile_after_close(
+                            ctx.home,
+                            std::slice::from_ref(fleet_name),
+                        );
                     }
                     if let Some(name) = tab.close_focused() {
                         super::kill_agent(ctx.home, ctx.registry, &name);

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -150,6 +150,12 @@ pub(super) fn restore_with_reconciliation(
     if let Some(ref f) = fleet {
         crate::teams::reconcile_teams(home, f);
     }
+    // Issue #474: defensive reconcile — prune deployment-store entries whose
+    // member instances are no longer in fleet.yaml. Catches the case where
+    // a previous session closed the last instance via TUI without going
+    // through `deployment teardown`. Cheap (single store load + fleet
+    // membership scan), runs once per daemon boot.
+    let _ = crate::deployments::reconcile_orphans(home);
     let fleet_names: HashSet<String> = fleet
         .as_ref()
         .map(|f| f.instance_names().into_iter().collect())

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -362,6 +362,114 @@ pub fn list(home: &Path) -> Value {
     serde_json::json!({"deployments": store.deployments})
 }
 
+/// Issue #474: prune deployment entries whose instances no longer exist in
+/// fleet.yaml. Shared core for the close-path hook (`reconcile_after_close`)
+/// and the daemon-startup sweep (`reconcile_orphans`).
+///
+/// For each deployment:
+/// - if NONE of its `instances` are present in fleet.yaml → prune the
+///   deployment entry from the store, delete the associated team, log.
+/// - otherwise → leave the deployment intact (multi-instance deployment
+///   with at least one member still alive).
+///
+/// Returns the names of deployments that were pruned (empty when nothing
+/// changed). The caller decides whether to log/event-report.
+pub(crate) fn reconcile_orphan_deployments(home: &Path) -> Vec<String> {
+    // Same lock as deploy/teardown — load-modify-save must be serialized.
+    let lock_path = store_path(home).with_extension("lock");
+    let _lock = match crate::store::acquire_file_lock(&lock_path) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!(error = %e, "deployments reconcile: lock acquire failed — skipping");
+            return Vec::new();
+        }
+    };
+
+    let mut store = load(home);
+    if store.deployments.is_empty() {
+        return Vec::new();
+    }
+
+    // Snapshot current fleet.yaml instance set. If fleet.yaml fails to load,
+    // bail out with an empty result so a transient parse error doesn't wipe
+    // the deployment store.
+    let fleet_path = home.join("fleet.yaml");
+    let live_instances: std::collections::HashSet<String> = match crate::fleet::FleetConfig::load(
+        &fleet_path,
+    ) {
+        Ok(cfg) => cfg.instance_names().into_iter().collect(),
+        Err(e) => {
+            tracing::warn!(error = %e, "deployments reconcile: fleet.yaml load failed — skipping");
+            return Vec::new();
+        }
+    };
+
+    let mut pruned_names = Vec::new();
+    let mut pruned_teams = Vec::new();
+    store.deployments.retain(|d| {
+        let any_live = d.instances.iter().any(|i| live_instances.contains(i));
+        if any_live {
+            true
+        } else {
+            pruned_names.push(d.name.clone());
+            if let Some(t) = d.team.clone() {
+                pruned_teams.push(t);
+            }
+            false
+        }
+    });
+
+    if pruned_names.is_empty() {
+        return pruned_names;
+    }
+
+    // Persist pruned store first so a crash between save and team-delete
+    // doesn't leave the deployment-store in a more-stale state than the
+    // teams-store; teams without their parent deployment is the safer
+    // failure mode.
+    if let Err(e) = save(home, &mut store) {
+        tracing::warn!(
+            error = %e,
+            pruned = ?pruned_names,
+            "deployments reconcile: save failed — entries may resurface on next load"
+        );
+        return Vec::new();
+    }
+
+    for team in &pruned_teams {
+        let _ = crate::teams::delete(home, &serde_json::json!({"name": team}));
+    }
+
+    tracing::info!(
+        pruned = ?pruned_names,
+        teams = ?pruned_teams,
+        "deployments reconcile: pruned orphan entries"
+    );
+    pruned_names
+}
+
+/// Option 1 (auto-cleanup) hook. Called from the TUI close path AFTER
+/// `fleet::remove_instance(s)_from_yaml`, with the names that were just
+/// removed. Triggers `reconcile_orphan_deployments`, which detects the
+/// "last instance of this deployment was just closed" case generically.
+///
+/// `removed_names` is currently unused — the reconcile pass scans every
+/// deployment against the post-close fleet.yaml, so it doesn't need to
+/// know which specific names were removed. Kept in the signature so a
+/// future optimization can target only deployments touching those names
+/// without changing the call site.
+pub fn reconcile_after_close(home: &Path, removed_names: &[String]) -> Vec<String> {
+    let _ = removed_names;
+    reconcile_orphan_deployments(home)
+}
+
+/// Option 3 (defensive) hook. Called once at daemon startup, before
+/// `auto_start_fleet`, so a stale deployment-store entry left by a
+/// previous unclean shutdown doesn't carry over.
+pub fn reconcile_orphans(home: &Path) -> Vec<String> {
+    reconcile_orphan_deployments(home)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -843,6 +951,181 @@ instances: {}
             !config.instances.contains_key("dev-impl"),
             "teardown must remove fleet entry to prevent respawn"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Issue #474: TUI close path bypassed teardown ──────────────────
+    //
+    // The TUI close overlay (`Ctrl-B x` / tab close) calls
+    // `fleet::remove_instance(s)_from_yaml` + `kill_agent` but doesn't
+    // touch `deployments.json`. Result: stale entries in `deployment list`
+    // after every TUI-triggered close. The fix wires
+    // `deployments::reconcile_after_close` into the same overlay code path
+    // (Option 1, auto-cleanup) and adds `reconcile_orphans` to the daemon
+    // boot path (Option 3, defensive sweep).
+    //
+    // These tests target the production reconcile function that the
+    // overlay calls — they exercise the same code path the TUI close
+    // overlay does, just without the ratatui input boilerplate.
+
+    /// Build a fleet.yaml + deploy a 1-instance template, returning the
+    /// home dir. Used by tests that need a baseline post-deploy state.
+    fn deploy_single_instance_for_test(tag: &str, deploy_name: &str) -> std::path::PathBuf {
+        let home = tmp_home(tag);
+        let yaml = r#"
+templates:
+  tpl:
+    instances:
+      worker:
+        backend: claude
+instances: {}
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({
+                "template": "tpl",
+                "name": deploy_name,
+                "directory": home.display().to_string(),
+            }),
+        );
+        home
+    }
+
+    #[test]
+    fn close_last_instance_prunes_deployment_entry() {
+        // Production smoke for the Issue #474 fix: deploy → simulate the
+        // TUI close path (remove from fleet.yaml + reconcile_after_close)
+        // → deployment store entry gone.
+        let home = deploy_single_instance_for_test("close_last", "tpl");
+        let store = load(&home);
+        assert!(
+            store.deployments.iter().any(|d| d.name == "tpl"),
+            "pre: deployment must exist"
+        );
+
+        // TUI close path mirror: fleet.yaml first, then reconcile.
+        let names: Vec<String> = vec!["tpl-worker".to_string()];
+        let _ = crate::fleet::remove_instances_from_yaml(&home, &names);
+        let pruned = reconcile_after_close(&home, &names);
+
+        assert!(
+            pruned.iter().any(|n| n == "tpl"),
+            "reconcile must prune the empty deployment, got {pruned:?}"
+        );
+        let store = load(&home);
+        assert!(
+            store.deployments.iter().all(|d| d.name != "tpl"),
+            "deployment store must NOT contain 'tpl' post-close"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn close_non_last_instance_keeps_deployment_intact() {
+        // Multi-instance deployment: closing one of three keeps the
+        // deployment entry intact — only when ALL members are gone does
+        // the entry get pruned.
+        let home = tmp_home("close_non_last");
+        let yaml = r#"
+templates:
+  tpl:
+    instances:
+      a:
+        backend: claude
+      b:
+        backend: claude
+      c:
+        backend: claude
+instances: {}
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({
+                "template": "tpl",
+                "name": "tpl",
+                "directory": home.display().to_string(),
+            }),
+        );
+
+        // Close the first instance only.
+        let names: Vec<String> = vec!["tpl-a".to_string()];
+        let _ = crate::fleet::remove_instances_from_yaml(&home, &names);
+        let pruned = reconcile_after_close(&home, &names);
+        assert!(
+            pruned.is_empty(),
+            "reconcile must NOT prune when 2/3 members remain, got {pruned:?}"
+        );
+
+        let store = load(&home);
+        let entry = store
+            .deployments
+            .iter()
+            .find(|d| d.name == "tpl")
+            .expect("deployment must remain in store");
+        // The deployment record's `instances` list is the deploy-time
+        // snapshot; we don't shrink it as members leave. The only
+        // invariant the lint protects is "entry survives if any member
+        // still in fleet.yaml".
+        assert_eq!(
+            entry.instances.len(),
+            3,
+            "instances list unchanged: {entry:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn reconcile_orphans_prunes_stale_entry_at_boot() {
+        // Defensive sweep (Option 3): a stale deployment-store entry left
+        // by an unclean shutdown — fleet.yaml has zero matching members
+        // — gets pruned on next `reconcile_orphans` call.
+        let home = tmp_home("reconcile_orphans");
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "templates:\n  tpl:\n    instances:\n      worker:\n        backend: claude\ninstances: {}\n",
+        )
+        .unwrap();
+
+        // Hand-craft a deployment-store entry with no live members.
+        let mut store = load(&home);
+        store.deployments.push(Deployment {
+            name: "ghost".into(),
+            template: "tpl".into(),
+            instances: vec!["ghost-instance-that-never-was".into()],
+            team: None,
+            directory: home.display().to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+        });
+        save(&home, &mut store).expect("save store");
+
+        let pruned = reconcile_orphans(&home);
+        assert!(
+            pruned.iter().any(|n| n == "ghost"),
+            "boot reconcile must prune stale entry, got {pruned:?}"
+        );
+        let store = load(&home);
+        assert!(
+            store.deployments.iter().all(|d| d.name != "ghost"),
+            "stale entry must be gone from store"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn reconcile_after_close_is_idempotent() {
+        // Repeated reconciles on the same already-clean state must no-op
+        // (no spurious team-delete calls, no panics).
+        let home = deploy_single_instance_for_test("reconcile_idem", "tpl");
+        let names: Vec<String> = vec!["tpl-worker".to_string()];
+        let _ = crate::fleet::remove_instances_from_yaml(&home, &names);
+        let r1 = reconcile_after_close(&home, &names);
+        assert_eq!(r1, vec!["tpl".to_string()], "first reconcile prunes");
+        let r2 = reconcile_after_close(&home, &names);
+        assert!(r2.is_empty(), "second reconcile no-ops, got {r2:?}");
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Summary

Closes #474.

cheerc community report: closing template-deployed instances via the TUI overlay (`Ctrl-B x` for pane close, or tab close) calls `fleet::remove_instance(s)_from_yaml` + `kill_agent` + `cleanup_working_dir`, but bypasses `deployments::teardown`. Result: stale entries in `deployment list` even after every member instance is gone, and the parent team is never deleted.

Same family as #456/#459 (those fixed `deployment teardown`'s own cleanup; this fixes the close-from-TUI path that never invoked teardown at all).

## Fix — Option 1 (auto-cleanup) + Option 3 (defensive sweep)

### Option 1 — `reconcile_after_close` wired into the TUI overlay

`src/app/overlay.rs::Overlay::ConfirmClose` handler — for both `Tab` and `Pane` targets, immediately after the existing `fleet::remove_instance(s)_from_yaml` calls. Reconcile scans every deployment-store entry; entries whose member instances are all gone from `fleet.yaml` get pruned (and their team deleted via `teams::delete`). Idempotent.

### Option 3 — `reconcile_orphans` at boot

`src/app/session.rs::restore_with_reconciliation` — next to the existing `teams::reconcile_teams` call. Catches stale entries left by previous sessions (TUI-close before this PR, or unclean shutdown). Cheap: single store load + fleet membership scan, runs once per boot.

Both routes share `reconcile_orphan_deployments` as the single source of truth — load/lock/save flow + team-deletion ordering live in one place. Public wrappers (`reconcile_after_close`, `reconcile_orphans`) document where each is called from in production.

### Save-before-team-delete ordering

The store is persisted before the team-delete loop runs. A crash between save and delete leaves teams orphaned (parent gone, child intact) — the safer failure mode than "deployment looks gone but team still claims the name" which would block future deploys.

## Tests (4)

`deployments::tests::*`:
- `close_last_instance_prunes_deployment_entry` — **PRODUCTION SMOKE**: deploy + simulate the TUI close path → entry pruned.
- `close_non_last_instance_keeps_deployment_intact` — multi-instance template, close 1 of 3 → entry survives (2 members remain).
- `reconcile_orphans_prunes_stale_entry_at_boot` — defensive sweep: hand-craft a stale entry, run `reconcile_orphans` → pruned.
- `reconcile_after_close_is_idempotent` — repeated reconcile on already-clean → no-op.

## Empirical regression-proof verification

Replaced `store.deployments.retain(...)` body in `reconcile_orphan_deployments` with a no-op, re-ran:

```
test deployments::tests::close_last_instance_prunes_deployment_entry ... FAILED
test deployments::tests::reconcile_after_close_is_idempotent ... FAILED
test deployments::tests::reconcile_orphans_prunes_stale_entry_at_boot ... FAILED
```

`close_non_last_*` still passed (its positive assertion is "no prune", which the no-op trivially satisfies). Restored → 4/4 pass. Confirms the new tests are load-bearing.

## Sprint 49 cushion

- No new `tokio::spawn` / `thread::spawn`.
- No L1/L2 lock acquisition added. Reuses existing `deployments.json.lock` flock that `deploy`/`teardown` already serialize on, so reconcile can't race with manual teardown.
- File size: `src/deployments.rs` +280 LOC; `src/app/overlay.rs` +14; `src/app/session.rs` +6. No `src/mcp/handlers/` files touched, 700-LOC handler invariant unaffected.
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

## "Who calls this in prod" trace

Path A (TUI Ctrl-B x / tab close):
- `tui_events` → keymap `Action::ClosePane`/`CloseTab` → `dispatch::handle_action` → `Overlay::ConfirmClose` → user `y` → overlay handler → `fleet::remove_instance(s)_from_yaml` → **`deployments::reconcile_after_close`** → `kill_agent` → `cleanup_working_dir`.

Path B (daemon boot):
- `app::run_app` → `session::restore_with_reconciliation` → `teams::reconcile_teams` → **`deployments::reconcile_orphans`** → `auto_start_fleet`.

Tests call `reconcile_after_close` / `reconcile_orphans` directly with the same `home` shape production builds.

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [x] cargo test --bin agend-terminal -- deployments::tests → 17/17 pass (13 prior + 4 new)
- [x] cargo test --bin agend-terminal -- --test-threads=1 deployments → 17/17 pass
- [x] cargo test --tests → 1531 passed (no new failures vs origin/main)
- [x] Empirical regression-proof verification (retain commented → 3 FAIL, restored → all PASS)
- [ ] Operator manual smoke: deploy template `dev` → close all panes via Ctrl-B x → `deployment list` empty + workspace dirs cleaned + binding gone (the bug-report reproducer)

## Pre-existing test failures (unchanged from main, not introduced here)

Same 7 pre-existing failures as #467/#469/#470/#471 (admin + claim_verifier + 1 broadcast parallel race). All git-state-dependent in this workspace; none touch `deployments.rs`, `app/overlay.rs`, or `app/session.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)