### PR TITLE
fix: remove auto-unbind side-effect from kind=report reply path

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -488,8 +488,17 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
         // Mark dispatch as completed so timeout sweep doesn't false-warn.
         let cid = args["correlation_id"].as_str();
         crate::dispatch_tracking::mark_completed(home, cid, sender.as_str());
-        // Phase 2 git-shim: clear binding on task completion.
-        crate::binding::unbind(home, sender.as_str());
+        // Sprint 53 P0-Y: do NOT auto-unbind here. Every kind=report reply
+        // (progress update OR final done) landed in this handler, so the
+        // prior auto-unbind tore down the binding on the first progress
+        // update — Phase 1 trailer stopped firing on subsequent commits,
+        // P0-X release_worktree refused ("no binding"), Phase 4 GC saw
+        // zero candidates (unbind doesn't write released_at; only
+        // release()/release_full() do), and orphan worktrees accumulated.
+        // `release_worktree` MCP tool is now the single source of truth
+        // for binding lifecycle. Sprint 54 candidates: explicit `task_done`
+        // flag in report envelope, or lifecycle rework with auto
+        // release_full on that explicit signal.
         let task_id = args["correlation_id"]
             .as_str()
             .filter(|s| !s.is_empty())

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -319,6 +319,68 @@ fn report_result_emits_with_correlation_id() {
 }
 
 #[test]
+fn bind_persists_across_kind_report_reply() {
+    // Sprint 53 P0-Y: regression guard for the auto-unbind bug general m-42
+    // surfaced. Pre-fix `handle_report_result` ran `binding::unbind(home,
+    // sender)` on every successful kind=report — including progress
+    // updates — tearing down the binding before the agent's next commit
+    // could carry the Phase 1 trailer.
+    //
+    // Post-fix the binding survives the report path entirely and only
+    // `release_worktree` (P0-X MCP tool) clears it.
+    //
+    // Regression-proof: re-add `crate::binding::unbind(home, sender.as_str())`
+    // inside the `if is_ok_result(&result) { ... }` block of
+    // `handle_report_result`, re-run this test → FAIL on the post-condition
+    // assert. Restore (no unbind) → PASS.
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("fleet_report_bind_persists");
+
+    // Pre-condition: agent has an active binding (simulating what
+    // dispatch_auto_bind_lease would have written).
+    crate::binding::bind(&home, "sender", "T-bind-persist", "feat/persist");
+    let pre = crate::binding::read(&home, "sender");
+    assert!(pre.is_some(), "test setup: binding must exist pre-report");
+
+    // Issue a kind=report reply — handle_report_result is the same path
+    // production lands in via handle_unified_send.
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "target",
+            "message": "progress update",
+            "request_kind": "report",
+            "summary": "progress update",
+            "correlation_id": "T-bind-persist",
+        }),
+        "sender",
+    );
+    assert!(
+        is_ok_result(&result),
+        "report_result should succeed: {result}"
+    );
+
+    // Post-condition: binding STILL present. Pre-fix this assertion failed
+    // because of the now-deleted `crate::binding::unbind(home, sender.as_str())`
+    // call.
+    let post = crate::binding::read(&home, "sender");
+    assert!(
+        post.is_some(),
+        "binding must NOT be auto-cleared on kind=report reply — Phase 1 \
+         trailer + P0-X release_worktree both depend on it surviving"
+    );
+    let post = post.expect("post binding");
+    assert_eq!(
+        post["task_id"], "T-bind-persist",
+        "task_id must remain stable, got: {post}"
+    );
+    assert_eq!(post["branch"], "feat/persist", "branch must remain stable");
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
 fn report_result_empty_correlation_id_maps_to_none() {
     let _g = fleet_test_guard();
     let (rec, home) = setup_recorder("fleet_report_empty");


### PR DESCRIPTION
## Summary

Closes general m-42 critical finding. Removes the `binding::unbind` side-effect from `handle_report_result` so the binding survives every progress-report reply — only the explicit `release_worktree` MCP tool (P0-X) clears it.

## Bug

`src/mcp/handlers/comms.rs::handle_report_result` ran `crate::binding::unbind(home, sender.as_str())` inside `if is_ok_result(&result)`. The handler runs on EVERY successful `kind=report` reply (progress updates, not only "task done"), so a single agent dispatched once and replying twice had its binding torn down on the first reply. Downstream:

- **Phase 1 trailer stops firing** post-first-report. The `prepare-commit-msg` hook reads `runtime/<agent>/binding.json`; with the binding gone the hook short-circuits and emits no `Agend-Agent` / `Agend-Branch` / `Agend-Issued-At` trailer.
- **`release_worktree` (P0-X) refuses** with `"no binding for agent X"`, leaving the worktree directory orphaned on disk.
- **Phase 4 GC sees zero candidates** — `binding::unbind` is a single `remove_file` and never writes the `released_at` timestamp into the `.agend-managed` marker. Only `worktree_pool::release()` / `release_full()` mark the worktree as a GC candidate.
- **Orphan worktrees accumulate** because nothing calls `release_full` in the regular dispatch lifecycle.

This is the exact failure mode general's Phase 1 trailer smoke runs (m-29 / m-32) caught — binding silently absent post-dispatch, trailer never fired.

## Fix — operator-approved Option A

Delete the `binding::unbind` call. Preserve `dispatch_tracking::mark_completed` right above it (unrelated — that one stops the timeout-sweep from false-warning on a confirmed dispatch). Replace with a multi-line rationale comment documenting the deletion + the four downstream symptoms + Sprint 54 candidates (explicit `task_done` flag in report envelope; lifecycle rework with auto `release_full` on that signal).

`release_worktree` (P0-X) now becomes the single source of truth for binding lifecycle — operator-driven, explicit, symmetric with auto-bind on dispatch.

## Audit of remaining `binding::unbind` callers

Post-PR call sites:
- `src/worktree_pool.rs:67` — inside `release()` (Phase 3 soft mark). Explicit, legitimate.
- `src/worktree_pool.rs:246` — inside `release_full()` (P0-X hard release MCP tool body). Explicit, legitimate.

No remaining side-effect call sites.

## New test

`bind_persists_across_kind_report_reply` — pre-write a binding, issue a `send` with `request_kind: \"report\"`, assert binding still present + fields unchanged. Exercises the same `handle_report_result` path production takes via `handle_unified_send`.

## Empirical regression-proof verification

Re-added the `crate::binding::unbind(home, sender.as_str())` line, re-ran:

```
test mcp::handlers::tests::bind_persists_across_kind_report_reply ... FAILED
      binding must NOT be auto-cleared on kind=report reply — Phase 1 trailer + P0-X release_worktree both depend on it surviving
```

Removed it again → `test result: ok. 3 passed; 0 failed`. Confirms the new test is load-bearing.

## Verification — no regression in adjacent tests

- `report_result_emits_with_correlation_id` + `report_result_empty_correlation_id_maps_to_none` both pass (correlation_id propagation untouched).
- `p0x_release_*` 8/8 pass (P0-X release_worktree behavior unchanged; `release_full` still calls unbind inside its own body).
- `cargo test --tests` → 1535 passed; 7 pre-existing failures (admin / claim_verifier / broadcast parallel race) unchanged from origin/main.
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

## Sprint 49 cushion

- No new spawn / no self-IPC. Pure deletion of a side-effect call.
- No L1/L2 lock acquisition added. Locking story is strictly simpler post-deletion (one fewer `remove_file` on the report path).
- File size: `comms.rs` net +11 LOC (deleted 1, added 12 lines of comment); `tests.rs` +62 LOC for the new test.

## \"Who calls this in prod\" trace

Production: `app::run_app` / `daemon::run` → MCP `send` → `handle_unified_send` → `request_kind: \"report\"` → `handle_report_result` → (post-fix) NO binding mutation.

Test calls `handle_tool(\"send\", {...request_kind: \"report\"...}, \"sender\")` which lands in the SAME `handle_report_result` via `handle_unified_send`'s match arm.

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [x] cargo test --bin agend-terminal -- mcp::handlers::tests::bind_persists → PASS
- [x] cargo test --bin agend-terminal -- mcp::handlers::tests::report_result → 2/2 still pass
- [x] cargo test --bin agend-terminal -- p0x_release → 8/8 still pass
- [x] cargo test --tests → 1535 passed (no new failures)
- [x] Empirical regression-proof verification (re-add unbind → FAIL, restore → PASS)
- [ ] Operator manual smoke: dispatch → agent sends kind=report progress update → `cat ~/.agend-terminal/runtime/<agent>/binding.json` should still exist (the failure-mode reproducer)

## Pre-existing test failures (unchanged from main, not introduced here)

Same 7 pre-existing failures as #467/#469/#470/#471/#475 (admin + claim_verifier + 1 broadcast parallel race). All git-state-dependent in this workspace; none touch `comms.rs` or the report path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)