### PR TITLE
feat: Sprint 53 P1-4 — gc_dry_run MCP tool for Phase 4 visibility

### DIFF
--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -181,6 +181,9 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         // --- Daemon-managed worktree release (Sprint 53 P0-X) ---
         "release_worktree" => worktree::handle_release_worktree(&home, args, &sender),
 
+        // --- Phase 4 GC dry-run visibility (Sprint 53 P1-4) ---
+        "gc_dry_run" => worktree::handle_gc_dry_run(&home, args, &sender),
+
         _ => json!({"error": format!("unknown tool: {tool}")}),
     }
 }

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -1,13 +1,11 @@
-//! MCP handler: `release_worktree` — Sprint 53 P0-X.
+//! MCP handlers for daemon-managed worktree lifecycle:
+//! - `release_worktree` (Sprint 53 P0-X) — hard release of an agent's
+//!   worktree + binding via `worktree_pool::release_full`.
+//! - `gc_dry_run` (Sprint 53 P1-4) — operator-callable visibility into
+//!   Phase 4 GC candidates without grepping app.log. Wraps the existing
+//!   `worktree_pool::gc_dry_run`; non-destructive.
 //!
-//! Closes the gap left by P0-1's auto-bind/auto-lease: every PR-merge
-//! transition leaves a stale `.worktrees/<agent>` plus
-//! `runtime/<agent>/binding.json` behind, and the next dispatch trips
-//! P0-1.6's actual-HEAD check. This MCP tool releases the daemon-managed
-//! worktree + clears the binding so the next dispatch can lease cleanly.
-//!
-//! Operator-callable + agent-callable. An agent calling this on itself is
-//! valid — it's the symmetric counterpart of dispatch's auto-bind.
+//! Both tools are operator-callable + agent-callable.
 
 use crate::identity::Sender;
 use serde_json::{json, Value};
@@ -40,6 +38,102 @@ pub(crate) fn handle_release_worktree(
     }
     let outcome = crate::worktree_pool::release_full(home, agent);
     serde_json::to_value(&outcome).unwrap_or_else(|_| json!({"error": "serialize failed"}))
+}
+
+/// MCP tool: `gc_dry_run` (Sprint 53 P1-4).
+///
+/// Operator-callable surface for Phase 4 GC visibility. Wraps the existing
+/// `worktree_pool::gc_dry_run` (which the daemon also runs hourly), enriches
+/// each candidate with `branch` / `leased_at` / `released_at` parsed out of
+/// its `.agend-managed` marker, and formats the result as either a
+/// human-readable string list (default) or a JSON object.
+///
+/// Non-destructive: dry-run only. Phase 4 cutover (actual `git worktree remove`
+/// of candidates) stays behind the separate `AGEND_WORKTREE_GC=1` switch.
+///
+/// Optional arg:
+/// - `format`: `"human"` (default) or `"json"`. Anything else → graceful
+///   error so a typo doesn't silently produce one of the formats.
+pub(crate) fn handle_gc_dry_run(home: &Path, args: &Value, _sender: &Option<Sender>) -> Value {
+    let format = args["format"].as_str().unwrap_or("human");
+    if format != "human" && format != "json" {
+        return json!({
+            "error": format!("invalid 'format': {format:?} — expected 'human' or 'json'")
+        });
+    }
+
+    let candidates = crate::worktree_pool::gc_dry_run(home);
+    let enriched: Vec<Value> = candidates
+        .iter()
+        .map(|c| {
+            let (branch, leased_at, released_at) = read_marker_fields(&c.path);
+            json!({
+                "agent": c.agent,
+                "branch": branch,
+                "path": c.path.display().to_string(),
+                "leased_at": leased_at,
+                "released_at": released_at,
+                "reason": c.reason,
+            })
+        })
+        .collect();
+
+    if format == "json" {
+        return json!({
+            "candidates": enriched,
+            "count": enriched.len(),
+        });
+    }
+
+    // Human format. Empty list still emits a single-line summary so an
+    // operator running the tool always gets visible feedback.
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Worktree GC dry-run candidates: {} found",
+        enriched.len()
+    ));
+    if !enriched.is_empty() {
+        out.push_str("\n\n");
+        for (i, c) in enriched.iter().enumerate() {
+            let agent = c["agent"].as_str().unwrap_or("?");
+            let branch = c["branch"].as_str().unwrap_or("?");
+            let leased = c["leased_at"].as_str().unwrap_or("?");
+            let released = c["released_at"].as_str().unwrap_or("(none)");
+            out.push_str(&format!(
+                "  {n}. {agent} / {branch} — leased {leased}, released {released}\n",
+                n = i + 1,
+            ));
+        }
+    }
+
+    json!({
+        "format": "human",
+        "count": enriched.len(),
+        "text": out,
+    })
+}
+
+/// Parse `branch=`, `leased_at=`, `released_at=` lines out of a worktree's
+/// `.agend-managed` marker file. Missing fields → `None` (rendered as
+/// `null` in JSON, `(none)` in human output). Failed read → all None.
+fn read_marker_fields(wt_path: &Path) -> (Option<String>, Option<String>, Option<String>) {
+    let marker = wt_path.join(".agend-managed");
+    let Ok(content) = std::fs::read_to_string(&marker) else {
+        return (None, None, None);
+    };
+    let mut branch = None;
+    let mut leased = None;
+    let mut released = None;
+    for line in content.lines() {
+        if let Some(v) = line.strip_prefix("branch=") {
+            branch = Some(v.to_string());
+        } else if let Some(v) = line.strip_prefix("leased_at=") {
+            leased = Some(v.to_string());
+        } else if let Some(v) = line.strip_prefix("released_at=") {
+            released = Some(v.to_string());
+        }
+    }
+    (branch, leased, released)
 }
 
 #[cfg(test)]
@@ -99,6 +193,147 @@ mod tests {
                 .unwrap_or("")
                 .contains("no binding"),
             "error must indicate no binding: {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 53 P1-4: gc_dry_run handler tests ────────────────────────
+    //
+    // These exercise the production handler. The fixture builders mimic
+    // what `worktree_pool::lease` + `release_full` would produce on the
+    // filesystem so the underlying `gc_candidates` scan + marker parser
+    // see realistic state.
+    //
+    // Regression-proof: stub `worktree_pool::gc_dry_run` to return an empty
+    // Vec → `gc_dry_run_production_smoke_lists_stale_lease` FAILS (count=0
+    // when fixture has 1 candidate). Restore → PASS.
+
+    /// Fixture: build a worktree dir with the `.agend-managed` marker shape
+    /// `lease()` writes, plus a `released_at=` line older than the GC grace
+    /// window (24h) so `gc_candidates` accepts it. No binding is written, so
+    /// the candidate scan's "no active binding" gate passes.
+    fn make_stale_candidate(home: &std::path::Path, agent: &str, branch: &str) {
+        let wt = home
+            .join("workspace")
+            .join("repo")
+            .join(".worktrees")
+            .join(agent);
+        std::fs::create_dir_all(&wt).unwrap();
+        // 48h ago — comfortably past the 24h grace.
+        let leased_at = (chrono::Utc::now() - chrono::Duration::hours(72)).to_rfc3339();
+        let released_at = (chrono::Utc::now() - chrono::Duration::hours(48)).to_rfc3339();
+        std::fs::write(
+            wt.join(".agend-managed"),
+            format!(
+                "agent={agent}\nbranch={branch}\nleased_at={leased_at}\nreleased_at={released_at}\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn gc_dry_run_no_candidates_returns_empty() {
+        // Empty workspace → 0 candidates, both formats render the empty
+        // shape without panicking.
+        let home = tmp_home("gc-empty");
+        let human = handle_gc_dry_run(&home, &json!({}), &None);
+        assert_eq!(human["count"].as_u64(), Some(0), "empty count: {human}");
+        assert_eq!(human["format"].as_str(), Some("human"));
+        assert!(human["text"].as_str().unwrap_or("").contains("0 found"));
+
+        let json_out = handle_gc_dry_run(&home, &json!({"format": "json"}), &None);
+        assert_eq!(json_out["count"].as_u64(), Some(0));
+        assert_eq!(
+            json_out["candidates"].as_array().map(|a| a.len()),
+            Some(0),
+            "json candidates must be empty array: {json_out}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn gc_dry_run_human_format_default() {
+        // No `format` arg → human default. Output text must contain agent
+        // + branch + the "found" summary.
+        let home = tmp_home("gc-human");
+        make_stale_candidate(&home, "agent-foo", "fix/branch-x");
+
+        let result = handle_gc_dry_run(&home, &json!({}), &None);
+        assert_eq!(result["format"].as_str(), Some("human"));
+        assert_eq!(result["count"].as_u64(), Some(1));
+        let text = result["text"].as_str().unwrap_or("");
+        assert!(text.contains("1 found"), "summary: {text}");
+        assert!(text.contains("agent-foo"), "must name agent: {text}");
+        assert!(text.contains("fix/branch-x"), "must name branch: {text}");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn gc_dry_run_json_format_explicit() {
+        // `format=json` → structured candidates array with marker-derived
+        // fields. Asserts the response is itself valid JSON-as-Value.
+        let home = tmp_home("gc-json");
+        make_stale_candidate(&home, "agent-bar", "feat/branch-y");
+
+        let result = handle_gc_dry_run(&home, &json!({"format": "json"}), &None);
+        assert_eq!(result["count"].as_u64(), Some(1));
+        let arr = result["candidates"]
+            .as_array()
+            .expect("candidates must be an array");
+        assert_eq!(arr.len(), 1);
+        let c = &arr[0];
+        assert_eq!(c["agent"], "agent-bar");
+        assert_eq!(c["branch"], "feat/branch-y");
+        assert!(
+            c["leased_at"].as_str().is_some(),
+            "leased_at must be present: {c}"
+        );
+        assert!(
+            c["released_at"].as_str().is_some(),
+            "released_at must be present (this fixture released the lease): {c}"
+        );
+        assert!(c["path"].as_str().is_some());
+        assert!(c["reason"].as_str().is_some());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn gc_dry_run_invalid_format_rejected() {
+        // Typo in format must error gracefully so the operator notices
+        // immediately rather than silently getting one of the formats.
+        let home = tmp_home("gc-bad-format");
+        let result = handle_gc_dry_run(&home, &json!({"format": "xml"}), &None);
+        let err = result["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("invalid 'format'") && err.contains("xml"),
+            "expected invalid-format error mentioning 'xml': {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn gc_dry_run_production_smoke_lists_stale_lease() {
+        // Production smoke: full path through `handle_gc_dry_run` →
+        // `worktree_pool::gc_dry_run` → `gc_candidates` → marker scan.
+        // Exercises the same code paths the MCP layer dispatches `gc_dry_run`
+        // calls into.
+        let home = tmp_home("gc-prod-smoke");
+        make_stale_candidate(&home, "agent-prod", "feat/prod-stale");
+
+        let result = handle_gc_dry_run(&home, &json!({"format": "json"}), &None);
+        assert_eq!(
+            result["count"].as_u64(),
+            Some(1),
+            "production smoke must surface the stale lease via the MCP path"
+        );
+        let candidates = result["candidates"].as_array().expect("candidates array");
+        let agents: Vec<&str> = candidates
+            .iter()
+            .filter_map(|c| c["agent"].as_str())
+            .collect();
+        assert!(
+            agents.contains(&"agent-prod"),
+            "agent-prod must appear in candidates: {agents:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -249,6 +249,13 @@ fn worktree_tools() -> Vec<Value> {
             "inputSchema": {"type": "object", "properties": {
                 "agent": {"type": "string", "description": "Agent name whose worktree + binding to release"}
             }, "required": ["agent"]}}),
+        // Sprint 53 P1-4: operator-callable Phase 4 GC visibility. Wraps
+        // worktree_pool::gc_dry_run; non-destructive (Phase 4 cutover stays
+        // gated behind AGEND_WORKTREE_GC=1).
+        json!({"name": "gc_dry_run", "description": "List Phase 4 GC candidates (released, past-grace, daemon-managed worktrees) without deleting them. Non-destructive. Default human format; pass `format=json` for tooling.",
+        "inputSchema": {"type": "object", "properties": {
+            "format": {"type": "string", "enum": ["human", "json"], "description": "Output format (default: human)"}
+        }}}),
     ]
 }
 
@@ -386,10 +393,11 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            27,
-            "Sprint 53 P0-X tool count = 27 (release_worktree added on top of \
-             pane_snapshot's Sprint 33 baseline of 26). Adding/removing a tool \
-             requires updating this assertion. Current tools: {:?}",
+            28,
+            "Sprint 53 P1-4 tool count = 28 (gc_dry_run added on top of \
+             P0-X's 27, which itself was pane_snapshot's Sprint 33 baseline \
+             of 26 + release_worktree). Adding/removing a tool requires \
+             updating this assertion. Current tools: {:?}",
             tools
                 .iter()
                 .filter_map(|t| t["name"].as_str())


### PR DESCRIPTION
## Summary

Sprint 53 P1-4 — operator-callable wrapper around the existing `worktree_pool::gc_dry_run` so Phase 4 GC candidates are visible without grepping `~/.agend-terminal/app.log`.

- New MCP tool `gc_dry_run` (snake_case per existing convention) wired into `src/mcp/handlers/worktree.rs`.
- Optional `format` arg: `\"human\"` (default) or `\"json\"`. Unknown value → graceful error.
- Default human output: `Worktree GC dry-run candidates: N found` summary plus a numbered list with marker-derived `branch` / `leased_at` / `released_at`.
- JSON output: `{candidates: [...], count: N}` for tooling.
- Non-destructive — Phase 4 cutover (actual deletion of candidates) stays gated behind the separate `AGEND_WORKTREE_GC=1` switch.

## Implementation

`handle_gc_dry_run` (src/mcp/handlers/worktree.rs):
1. Validate `format` arg.
2. Call `worktree_pool::gc_dry_run(home)` (no behavior change to GC).
3. Per-candidate parse `.agend-managed` marker via `read_marker_fields` to surface `branch` / `leased_at` / `released_at` (the marker is the source of truth; `GcCandidate` itself only carries `path` / `agent` / `reason`).
4. Format per `format` arg.

## Tests (5)

`mcp::handlers::worktree::tests::gc_dry_run_*`:
- `_no_candidates_returns_empty` — both formats render the empty shape without panicking.
- `_human_format_default` — has candidate; default human format text contains agent + branch + summary.
- `_json_format_explicit` — `format=json` returns valid structured Value with marker fields.
- `_invalid_format_rejected` — `format=xml` → graceful error mentioning `'xml'`.
- `_production_smoke_lists_stale_lease` — **PRODUCTION SMOKE** through `handle_gc_dry_run` → `worktree_pool::gc_dry_run` → `gc_candidates` → marker scan. Asserts the candidate created via the lease+release fixture surfaces via the MCP layer.

Fixture helper `make_stale_candidate` writes `.agend-managed` shaped exactly like `worktree_pool::lease` + `release()` would produce, with `released_at` 48h past so the 24h grace window accepts it.

## Empirical regression-proof verification

Replaced `let candidates = crate::worktree_pool::gc_dry_run(home);` with an unconditional empty `Vec::new()`, re-ran:

```
test gc_dry_run_human_format_default ... FAILED
test gc_dry_run_json_format_explicit ... FAILED
test gc_dry_run_production_smoke_lists_stale_lease ... FAILED
```

`gc_dry_run_no_candidates_returns_empty` and `gc_dry_run_invalid_format_rejected` continued to pass (both negative controls; the empty-stub trivially satisfies both — desired). Restored real call → 5/5 pass. Confirms the new tests are load-bearing.

## Sprint 49 cushion

- No new `tokio::spawn` / `thread::spawn`. Pure read-side wrapper.
- No L1/L2 lock acquisition. Wraps a read-only `std::fs::read_dir` traversal.
- `src/mcp/handlers/worktree.rs` grew from 105 LOC to ~340 LOC (production: 137; tests: ~200). Production code well under 700 LOC handler invariant.
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

## Tool count invariant

`mcp::tools::tests::tool_definitions_count_invariant_post_sprint_30` asserts `tools.len() == 28` (was 27 with `release_worktree`).

## \"Who calls this in prod\" trace

Operator types `gc_dry_run` (or `gc_dry_run format=json`) → MCP dispatch → `mcp::handlers::handle_tool(\"gc_dry_run\", ...)` → `worktree::handle_gc_dry_run` → `worktree_pool::gc_dry_run` → `gc_candidates` → per-candidate marker parse. Tests call the SAME `handle_gc_dry_run` end-to-end.

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [x] cargo test --bin agend-terminal -- gc_dry_run → 5/5 pass
- [x] cargo test --bin agend-terminal -- mcp::tools::tests::tool_definitions_count → PASS (28)
- [x] cargo test --bin agend-terminal -- handler_ p0x_release → 11/11 still pass (P0-X behavior unchanged)
- [x] cargo test --tests → 1540 passed (no new failures vs origin/main)
- [x] Empirical regression-proof verification (empty-stub → 3 FAIL, restore → all PASS)
- [ ] Operator manual smoke: deploy a template, release one instance, fast-forward grace, call `gc_dry_run` and confirm the candidate appears

## Pre-existing test failures (unchanged from main, not introduced here)

Same 7 pre-existing failures as #467/#469/#470/#471/#475/#477 (admin + claim_verifier + 1 broadcast parallel race). All git-state-dependent in this workspace; none touch worktree_pool or worktree handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)