### PR TITLE
docs(protocol): default PR open ready not draft (Sprint 54)

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -142,6 +142,22 @@ Use `send` for all inter-agent messaging:
 
 Use `ci(action: watch)`, not manual polling. Clean up worktree + branch after merge.
 
+**PR open semantics (Sprint 54)**. Implementers MUST open feature PRs as
+**ready** for review by default. The `--draft` flag is reserved for
+exactly three scenarios:
+
+1. **Smoke / verification PRs** that will not be merged (e.g. CI
+   notification path tests). Title prefixes `[smoke]` / `chore: smoke`.
+2. **Explicit work-in-progress** where the implementer needs to push
+   midway and is not yet asking for review. Move to ready before
+   pinging lead/reviewer.
+3. **External-PR patches** where lead is augmenting a community
+   contribution before the upstream PR is merged.
+
+A draft PR is hidden from GitHub's default UI filters, so operator and
+reviewer miss it without explicit checks. Default-ready keeps the
+review pipeline visible.
+
 **Setup-warning surfacing (Sprint 54 P0-4)**. CI-related MCP responses
 may include a top-level `setup_warning` string when no GitHub token is
 reachable (env unset AND `gh` unavailable/unauthed). The daemon polls


### PR DESCRIPTION
## Summary

Per operator m-14 directive (via general): dev default `gh pr create --draft` hides PRs from operator + reviewer's GitHub UI filters. Default-ready keeps the review pipeline visible without an extra mark-ready round-trip.

## Reserved scenarios for --draft (3 only)

1. **Smoke / verification PRs** that won't be merged (e.g. Sprint 53 #480 #482 ci-notification verification, title prefixes `[smoke]` / `chore: smoke`)
2. **Explicit work-in-progress** where dev needs to push midway and isn't asking for review yet
3. **External-PR augmentation** where lead is patching a community contribution before the upstream PR merges

## Where

`docs/FLEET-DEV-PROTOCOL-v1.md` §7 CI, just before the existing setup-warning surfacing block. 16 lines added.

## Why §7 CI

PR semantics are the bridge between IMPL completion and CI/review gates — natural fit alongside the CI watch + setup-warning guidance already in this section. (Could also have lived in §3 Review Protocol; chose §7 for adjacency to the operational mechanics rather than the review-vantage discussion.)

## Tier

Tier-1 single primary review per general m-14. Doc-only.

## Test plan

- [ ] Reviewer Tier-1 reads §7 amendment for clarity + scope
- [ ] No code changes, no smoke gate
- [ ] Operator confirms default-ready preference holds (m-14 already gave consent)

## Eating own dogfood

This PR opens **ready** (not draft) per the new policy.