### PR TITLE
feat(ci-health): agent-visible CI health surface (Sprint 54 P0-5)

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -151,6 +151,17 @@ it appears in a session — it is operator-actionable guidance, not a
 log line. Suggested phrasing: "CI watch responded: <setup_warning>".
 Subsequent occurrences within the same session may be deduplicated.
 
+**Health surface (Sprint 54 P0-5)**. The `ci(action: watch)` response
+and the new `ci(action: status)` aggregator both carry `rate_limit_active`,
+`rate_limit_until`, and `next_poll_eta` so agents can tell whether CI
+polling is healthy without reading watch files. The daemon also
+fans out two inbox event kinds when polling stalls behind a rate-limit
+window: `ci-watch-stalled` after 3 consecutive missed polls (exactly
+once per stall window) and `ci-watch-resumed` on the first successful
+poll afterward. Both events go to every subscriber via the P0-1 fan-out
+contract — no last-write-wins. Surface stalled events promptly; resumed
+events confirm recovery and may be acknowledged silently.
+
 ## §8. Progress Visibility
 
 Task state changes emit to Telegram. Instance lifecycle events (non-fleet.yaml origin) broadcast with `origin` field. `create_instance` defaults to isolated workspace (`~/.agend-terminal/workspace/<name>`).

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -811,6 +811,173 @@ impl CiProvider for BitbucketCiProvider {
 /// Watch TTL in hours. Used for both absolute expiry and inactivity threshold.
 pub const WATCH_TTL_HOURS: i64 = 72;
 
+/// Sprint 54 P0-5 (sub-scope B): consecutive rate-limited skips before a
+/// `[ci-watch-stalled]` notification fires. Picked low (3) so a watch
+/// stuck behind a multi-minute reset window surfaces quickly without
+/// over-paging on a one-tick blip.
+pub(crate) const STALL_THRESHOLD: u64 = 3;
+
+/// Sprint 54 P0-5 helper: read existing `consecutive_skips`, increment,
+/// persist, and (if we just crossed `STALL_THRESHOLD` and haven't yet
+/// notified for this window) fan out a `[ci-watch-stalled]` inbox event
+/// to every subscriber. The notify step reuses the P0-1 fan-out
+/// contract — one inbox enqueue per subscriber.
+///
+/// Atomicity: the increment + `stalled_notified` flag move in a single
+/// atomic_write so the next tick can't observe a "skips ≥ threshold,
+/// flag still false" intermediate state and fire a duplicate event.
+fn bump_consecutive_skips_and_maybe_notify(
+    home: &Path,
+    watch_path: &Path,
+    repo: &str,
+    branch: &str,
+    subscribers: &[String],
+    reset_epoch: u64,
+) {
+    let mut watch: serde_json::Value = match std::fs::read_to_string(watch_path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+    {
+        Some(v) => v,
+        None => return,
+    };
+    let prev_skips = watch["consecutive_skips"].as_u64().unwrap_or(0);
+    let next_skips = prev_skips.saturating_add(1);
+    watch["consecutive_skips"] = serde_json::json!(next_skips);
+
+    let already_notified = watch["stalled_notified"].as_bool().unwrap_or(false);
+    let should_notify = next_skips >= STALL_THRESHOLD && !already_notified;
+    if should_notify {
+        watch["stalled_notified"] = serde_json::json!(true);
+        // Stamp `stalled_since_ms` only on the first stall write — gives
+        // operators a stable anchor in the inbox payload.
+        if watch["stalled_since_ms"].as_i64().is_none() {
+            watch["stalled_since_ms"] = serde_json::json!(chrono::Utc::now().timestamp_millis());
+        }
+    }
+    let _ = crate::store::atomic_write(
+        watch_path,
+        serde_json::to_string_pretty(&watch)
+            .unwrap_or_default()
+            .as_bytes(),
+    );
+
+    if should_notify {
+        let stalled_since_ms = watch["stalled_since_ms"].as_i64();
+        // next_poll_eta = reset_epoch_ms (skip lifts at reset, then
+        // adaptive backoff applies — but reset is the user-visible
+        // "stalled until" moment).
+        let next_poll_eta = (reset_epoch as i64).saturating_mul(1000);
+        let setup_warning = crate::github_token::cached_setup_warning();
+        let body = build_stalled_body(repo, branch, stalled_since_ms, next_poll_eta, setup_warning);
+        fan_out_health_event(home, repo, branch, subscribers, "ci-watch-stalled", body);
+    }
+}
+
+/// Sprint 54 P0-5 helper: clear the stall state on the first successful
+/// poll after a stall window. Fans out `[ci-watch-resumed]` exactly
+/// once per resume — symmetry with the stalled path.
+fn clear_stall_and_maybe_notify_resumed(
+    home: &Path,
+    watch_path: &Path,
+    repo: &str,
+    branch: &str,
+    subscribers: &[String],
+) {
+    let mut watch: serde_json::Value = match std::fs::read_to_string(watch_path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+    {
+        Some(v) => v,
+        None => return,
+    };
+    let was_stalled = watch["stalled_notified"].as_bool().unwrap_or(false);
+    let had_skips = watch["consecutive_skips"].as_u64().unwrap_or(0) > 0;
+    if !was_stalled && !had_skips {
+        return; // common case — no stall in flight, nothing to write.
+    }
+    watch["consecutive_skips"] = serde_json::json!(0);
+    watch["stalled_notified"] = serde_json::json!(false);
+    watch["stalled_since_ms"] = serde_json::Value::Null;
+    let _ = crate::store::atomic_write(
+        watch_path,
+        serde_json::to_string_pretty(&watch)
+            .unwrap_or_default()
+            .as_bytes(),
+    );
+    if was_stalled {
+        let body =
+            format!("[ci-watch-resumed] {repo}@{branch}: poll resumed after rate-limit backoff");
+        fan_out_health_event(home, repo, branch, subscribers, "ci-watch-resumed", body);
+    }
+}
+
+fn build_stalled_body(
+    repo: &str,
+    branch: &str,
+    stalled_since_ms: Option<i64>,
+    next_poll_eta_ms: i64,
+    setup_warning: Option<&'static str>,
+) -> String {
+    let mut s = format!("[ci-watch-stalled] {repo}@{branch}: rate-limit backoff in effect");
+    if let Some(ts) = stalled_since_ms {
+        if let Some(dt) = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ts) {
+            s.push_str(&format!("\nStalled since: {}", dt.to_rfc3339()));
+        }
+    }
+    if let Some(eta) = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(next_poll_eta_ms) {
+        s.push_str(&format!("\nNext poll ETA: {}", eta.to_rfc3339()));
+    }
+    if let Some(w) = setup_warning {
+        s.push_str(&format!("\nSetup hint: {w}"));
+    }
+    s
+}
+
+/// Sprint 54 P0-5: fan out a CI health event to every subscriber.
+/// Mirrors the P0-1 terminal-notify loop — one inbox enqueue per
+/// subscriber so multi-caller watches don't get last-write-wins.
+fn fan_out_health_event(
+    home: &Path,
+    repo: &str,
+    branch: &str,
+    subscribers: &[String],
+    kind: &str,
+    body: String,
+) {
+    let repo_branch_key = format!("{repo}@{branch}");
+    let supersede_token = format!("{kind}-{}", chrono::Utc::now().timestamp_millis());
+    for sub in subscribers {
+        crate::inbox::mark_ci_watch_superseded(home, sub, &repo_branch_key, &supersede_token);
+        let _ = crate::inbox::enqueue(
+            home,
+            sub,
+            crate::inbox::InboxMessage {
+                schema_version: 0,
+                id: None,
+                read_at: None,
+                thread_id: None,
+                parent_id: None,
+                task_id: None,
+                force_meta: None,
+                correlation_id: None,
+                reviewed_head: None,
+                from: "system:ci".to_string(),
+                text: body.clone(),
+                kind: Some(kind.to_string()),
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                channel: None,
+                delivery_mode: None,
+                attachments: vec![],
+                in_reply_to_msg_id: None,
+                in_reply_to_excerpt: None,
+                superseded_by: None,
+                from_id: None,
+            },
+        );
+    }
+}
+
 /// Read the list of subscribed instances from a watch JSON value.
 ///
 /// Schema migration (Sprint 54 P0-1): the canonical source is the
@@ -1135,6 +1302,19 @@ fn check_ci_watches_with_provider(
         // Rate-limit backoff: skip polling until X-RateLimit-Reset time.
         if let Some(reset_epoch) = watch["rate_limit_until"].as_u64() {
             if (chrono::Utc::now().timestamp() as u64) < reset_epoch {
+                // Sprint 54 P0-5 (sub-scope B): increment consecutive_skips
+                // on each rate-limited tick so subscribers see a
+                // `[ci-watch-stalled]` event after STALL_THRESHOLD
+                // consecutive misses. Persist atomically with `stalled_notified`
+                // so the dispatch is exactly-once per stall window.
+                bump_consecutive_skips_and_maybe_notify(
+                    home,
+                    &path,
+                    &repo,
+                    &branch,
+                    &subscribers,
+                    reset_epoch,
+                );
                 continue;
             }
         }
@@ -1524,6 +1704,12 @@ async fn ci_check_repo(
                     }
                 }
             }
+            // Sprint 54 P0-5 (sub-scope B): a successful poll clears
+            // any in-flight stall state. If we previously fired
+            // `[ci-watch-stalled]`, the symmetrical
+            // `[ci-watch-resumed]` event fans out to subscribers
+            // exactly once.
+            clear_stall_and_maybe_notify_resumed(home, watch_path, repo, branch, subscribers);
             if runs.is_empty() {
                 return Ok(());
             }
@@ -3756,5 +3942,207 @@ mod tests {
     fn parse_subscribers_empty_when_no_data() {
         let watch = serde_json::json!({});
         assert!(parse_subscribers(&watch).is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // Sprint 54 P0-5 (sub-scope B) — consecutive_skips tracking +
+    // stalled/resumed inbox fan-out. Each test pins one of the four
+    // contract gates from dispatch m-20260507045729197032-16.
+    //
+    // EMPIRICAL REGRESSION-PROOF ANCHOR: if the
+    // `if next_skips >= STALL_THRESHOLD && !already_notified` guard
+    // in `bump_consecutive_skips_and_maybe_notify` is dropped, the
+    // "fires exactly once" assertion in
+    // `stalled_event_fires_exactly_once_at_threshold` fails because
+    // every subsequent skip would re-enqueue. PR description carries
+    // the captured FAIL signature.
+    // -----------------------------------------------------------------
+
+    fn p05_temp_home(tag: &str) -> std::path::PathBuf {
+        let dir = tmp_dir(tag);
+        std::fs::create_dir_all(dir.join("ci-watches")).ok();
+        std::fs::create_dir_all(dir.join("inbox")).ok();
+        dir
+    }
+
+    fn p05_write_watch(
+        home: &Path,
+        repo: &str,
+        branch: &str,
+        watch: serde_json::Value,
+    ) -> std::path::PathBuf {
+        let path = home.join("ci-watches").join(watch_filename(repo, branch));
+        std::fs::write(&path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        path
+    }
+
+    fn p05_read_inbox_lines(home: &Path, instance: &str) -> Vec<String> {
+        let path = home.join("inbox").join(format!("{instance}.jsonl"));
+        std::fs::read_to_string(&path)
+            .unwrap_or_default()
+            .lines()
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn consecutive_skips_increments_on_rate_limited_skip() {
+        // Gate 1: each rate-limited skip bumps the counter atomically.
+        let home = p05_temp_home("p05_skip_inc");
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-07T00:00:00Z"}],
+            "consecutive_skips": 0,
+        });
+        let path = p05_write_watch(&home, "o/r", "feat", watch);
+        let subscribers = vec!["lead".to_string()];
+
+        let future_reset = (chrono::Utc::now().timestamp() as u64) + 3600;
+        bump_consecutive_skips_and_maybe_notify(
+            &home,
+            &path,
+            "o/r",
+            "feat",
+            &subscribers,
+            future_reset,
+        );
+        bump_consecutive_skips_and_maybe_notify(
+            &home,
+            &path,
+            "o/r",
+            "feat",
+            &subscribers,
+            future_reset,
+        );
+        let watch: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(watch["consecutive_skips"].as_u64(), Some(2));
+        // Below threshold: stalled_notified is either absent (None) or
+        // false — both mean "no notify fired yet".
+        let notified = watch["stalled_notified"].as_bool().unwrap_or(false);
+        assert!(!notified, "below threshold ⇒ no notify yet");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn stalled_event_fires_exactly_once_at_threshold() {
+        // Gate 2: at N=3 a [ci-watch-stalled] enqueues; further
+        // tick-skips don't re-fire. This is the regression-proof
+        // anchor — collapsing the guard reveals duplicates.
+        let home = p05_temp_home("p05_stalled_once");
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-07T00:00:00Z"}],
+            "consecutive_skips": 0,
+        });
+        let path = p05_write_watch(&home, "o/r", "feat", watch);
+        let subscribers = vec!["lead".to_string()];
+        let future_reset = (chrono::Utc::now().timestamp() as u64) + 3600;
+
+        for _ in 0..5 {
+            bump_consecutive_skips_and_maybe_notify(
+                &home,
+                &path,
+                "o/r",
+                "feat",
+                &subscribers,
+                future_reset,
+            );
+        }
+
+        let lines = p05_read_inbox_lines(&home, "lead");
+        let stalled_count = lines
+            .iter()
+            .filter(|l| l.contains("ci-watch-stalled"))
+            .count();
+        assert_eq!(
+            stalled_count, 1,
+            "exactly one stalled event per stall window (got {stalled_count})"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn resumed_event_fires_on_first_successful_clear() {
+        // Gate 3: resume helper fires [ci-watch-resumed] exactly once
+        // and clears the stall state.
+        let home = p05_temp_home("p05_resumed");
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-07T00:00:00Z"}],
+            "consecutive_skips": 5,
+            "stalled_notified": true,
+            "stalled_since_ms": 1700000000000_i64,
+        });
+        let path = p05_write_watch(&home, "o/r", "feat", watch);
+        let subscribers = vec!["lead".to_string()];
+
+        clear_stall_and_maybe_notify_resumed(&home, &path, "o/r", "feat", &subscribers);
+        // Second call must be a silent no-op (state already cleared).
+        clear_stall_and_maybe_notify_resumed(&home, &path, "o/r", "feat", &subscribers);
+
+        let watch: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(watch["consecutive_skips"].as_u64(), Some(0));
+        assert_eq!(watch["stalled_notified"].as_bool(), Some(false));
+        assert!(watch["stalled_since_ms"].is_null());
+
+        let lines = p05_read_inbox_lines(&home, "lead");
+        let resumed = lines
+            .iter()
+            .filter(|l| l.contains("ci-watch-resumed"))
+            .count();
+        assert_eq!(resumed, 1, "exactly one resumed event per recovery");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn stalled_and_resumed_fan_out_to_all_subscribers() {
+        // Gate 4: both event types reach every subscriber per the
+        // P0-1 fan-out contract.
+        let home = p05_temp_home("p05_fanout");
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [
+                {"instance": "lead", "subscribed_at": "2026-05-07T00:00:00Z"},
+                {"instance": "dev",  "subscribed_at": "2026-05-07T00:00:01Z"}
+            ],
+            "consecutive_skips": 0,
+        });
+        let path = p05_write_watch(&home, "o/r", "feat", watch);
+        let subscribers = vec!["lead".to_string(), "dev".to_string()];
+        let future_reset = (chrono::Utc::now().timestamp() as u64) + 3600;
+
+        for _ in 0..STALL_THRESHOLD {
+            bump_consecutive_skips_and_maybe_notify(
+                &home,
+                &path,
+                "o/r",
+                "feat",
+                &subscribers,
+                future_reset,
+            );
+        }
+        for sub in ["lead", "dev"] {
+            let lines = p05_read_inbox_lines(&home, sub);
+            assert!(
+                lines.iter().any(|l| l.contains("ci-watch-stalled")),
+                "{sub} must receive stalled event (fan-out regression)"
+            );
+        }
+
+        clear_stall_and_maybe_notify_resumed(&home, &path, "o/r", "feat", &subscribers);
+        for sub in ["lead", "dev"] {
+            let lines = p05_read_inbox_lines(&home, sub);
+            assert!(
+                lines.iter().any(|l| l.contains("ci-watch-resumed")),
+                "{sub} must receive resumed event"
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -254,10 +254,25 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
             .unwrap_or_default()
             .as_bytes(),
     );
+    // Sprint 54 P0-5 (sub-scope A): response enrichment — agents see
+    // CI health without polling the watch file. Read state freshly
+    // from `watch` JSON we just composed; populate diagnostic fields
+    // when the data is available, leave as `null` otherwise.
+    let now_secs = chrono::Utc::now().timestamp();
+    let rate_limit_until = watch["rate_limit_until"].as_i64();
+    let rate_limit_active = match rate_limit_until {
+        Some(reset) => reset > now_secs,
+        None => false,
+    };
+    let next_poll_eta = compute_next_poll_eta(&watch);
+
     let mut resp = json!({
         "repo": repo,
         "watching": true,
         "subscribers": subscribers,
+        "rate_limit_active": rate_limit_active,
+        "rate_limit_until": rate_limit_until,
+        "next_poll_eta": next_poll_eta,
     });
     // Sprint 54 P0-4: surface `setup_warning` (canonical field name per
     // FLEET-DEV-PROTOCOL §X) so agents can advise users to install
@@ -267,6 +282,22 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
         resp["setup_warning"] = json!(w);
     }
     resp
+}
+
+/// Sprint 54 P0-5 helper: estimate the next poll's epoch-millis tick
+/// from `last_polled_at` + `effective_interval_secs` (or `interval_secs`
+/// when adaptive backoff hasn't been computed yet). Returns `None` for
+/// fresh watches that haven't polled yet.
+///
+/// Pure function — no IO, no global state. Same input shape used by
+/// the `ci status` aggregator below so the two surfaces never disagree.
+fn compute_next_poll_eta(watch: &Value) -> Option<i64> {
+    let last_polled_at = watch["last_polled_at"].as_i64()?;
+    let interval_secs = watch["effective_interval_secs"]
+        .as_u64()
+        .or_else(|| watch["interval_secs"].as_u64())
+        .unwrap_or(60);
+    Some(last_polled_at + (interval_secs as i64) * 1000)
 }
 
 /// `ci unwatch` action: unsubscribe the caller from `repo@branch`.
@@ -349,6 +380,90 @@ pub(super) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
         "watching": true,
         "subscribers": subscribers,
     })
+}
+
+/// `ci status` MCP action (Sprint 54 P0-5 sub-scope C). Returns a
+/// snapshot of every CI watch the caller subscribes to, with full
+/// health diagnostics inlined. Optional `repo` / `branch` args narrow
+/// the result; both must match when both are provided.
+///
+/// Caller filtering: agents only see watches they're subscribed to —
+/// avoids leaking lead's polling targets to every dev. The empty
+/// instance name (anonymous CLI) sees all watches.
+pub(super) fn handle_status_ci(home: &Path, args: &Value, instance_name: &str) -> Value {
+    let filter_repo = args["repo"].as_str();
+    let filter_branch = args["branch"].as_str();
+    let ci_dir = home.join("ci-watches");
+    let entries = match std::fs::read_dir(&ci_dir) {
+        Ok(e) => e,
+        Err(_) => return json!({"watches": Vec::<Value>::new()}),
+    };
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let now_secs = chrono::Utc::now().timestamp();
+
+    let mut out: Vec<Value> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let watch: Value = match std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| serde_json::from_str(&c).ok())
+        {
+            Some(v) => v,
+            None => continue,
+        };
+        let repo = match watch["repo"].as_str() {
+            Some(r) => r,
+            None => continue,
+        };
+        let branch = watch["branch"].as_str().unwrap_or("main");
+        if let Some(want) = filter_repo {
+            if repo != want {
+                continue;
+            }
+        }
+        if let Some(want) = filter_branch {
+            if branch != want {
+                continue;
+            }
+        }
+        let subscribers = crate::daemon::ci_watch::parse_subscribers(&watch);
+        // Caller scoping: an agent with a name sees only the watches
+        // they're a subscriber of. Anonymous calls (empty instance)
+        // see everything — useful for operator triage via the CLI.
+        if !instance_name.is_empty() && !subscribers.iter().any(|s| s == instance_name) {
+            continue;
+        }
+        let rate_limit_until = watch["rate_limit_until"].as_i64();
+        let rate_limit_active = match rate_limit_until {
+            Some(reset) => reset > now_secs,
+            None => false,
+        };
+        let _ = now_ms; // anchor: keep timestamp-millis consistency with response enrichment
+        out.push(json!({
+            "repo": repo,
+            "branch": branch,
+            "subscribers": subscribers,
+            "rate_limit_active": rate_limit_active,
+            "rate_limit_until": rate_limit_until,
+            "rate_limit_remaining": watch["rate_limit_remaining"].as_u64(),
+            "rate_limit_limit": watch["rate_limit_limit"].as_u64(),
+            "effective_interval_secs": watch["effective_interval_secs"].as_u64(),
+            "interval_secs": watch["interval_secs"].as_u64().unwrap_or(60),
+            "next_poll_eta": compute_next_poll_eta(&watch),
+            "consecutive_skips": watch["consecutive_skips"].as_u64().unwrap_or(0),
+            "stalled_notified": watch["stalled_notified"].as_bool().unwrap_or(false),
+            "stalled_since_ms": watch["stalled_since_ms"].as_i64(),
+            "last_polled_at": watch["last_polled_at"].as_i64(),
+            "last_terminal_seen_at": watch["last_terminal_seen_at"].as_str(),
+            "head_sha": watch["head_sha"].as_str(),
+            "expires_at": watch["expires_at"].as_str(),
+        }));
+    }
+    let mut resp = json!({"watches": out});
+    if let Some(w) = crate::daemon::ci_watch::github_token_warning_from_env() {
+        resp["setup_warning"] = json!(w);
+    }
+    resp
 }
 
 #[cfg(test)]

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -347,3 +347,160 @@ fn ci_unwatch_unknown_caller_is_noop_keeps_watch() {
     assert_eq!(subs, vec!["lead"]);
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ---------------------------------------------------------------------
+// Sprint 54 P0-5 — Agent-visible CI health surface. Tests cover all
+// three sub-scopes from dispatch m-20260507045729197032-16:
+//
+//   A. handle_watch_ci response enrichment (rate_limit_active +
+//      rate_limit_until + next_poll_eta)
+//   B. consecutive_skips tracking + stalled/resumed inbox events live
+//      in the daemon-side `bump_consecutive_skips_and_maybe_notify` /
+//      `clear_stall_and_maybe_notify_resumed` helpers; their tests
+//      live in `src/daemon/ci_watch.rs` (this handler doesn't drive
+//      the tick-loop schema).
+//   C. ci status MCP action — caller-scoped + filter semantics +
+//      empty-state shape.
+// ---------------------------------------------------------------------
+
+#[test]
+fn watch_ci_response_includes_health_fields_when_state_populated() {
+    // Sub-scope A gate 1: response carries the new diagnostic fields
+    // even on the first watch. Fresh watches have null poll state, so
+    // `next_poll_eta` is null and `rate_limit_active` is false — but
+    // the FIELDS must exist so agents can pattern-match without
+    // optional-field ladders.
+    let home = std::env::temp_dir().join(format!("agend-p05-A1-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let resp = handle_watch_ci(&home, &args, "lead");
+
+    assert_eq!(resp["watching"].as_bool(), Some(true));
+    assert!(
+        resp.get("rate_limit_active").is_some(),
+        "rate_limit_active must always be present"
+    );
+    assert_eq!(resp["rate_limit_active"].as_bool(), Some(false));
+    assert!(resp["rate_limit_until"].is_null());
+    assert!(resp["next_poll_eta"].is_null());
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn watch_ci_rate_limit_active_when_until_in_future() {
+    // Sub-scope A gate 2: rate_limit_until > now ⇒ rate_limit_active
+    // surfaces true. Hand-craft state to simulate a tick loop having
+    // just stamped rate_limit_until.
+    let home = std::env::temp_dir().join(format!("agend-p05-A2-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    handle_watch_ci(&home, &args, "lead");
+
+    let path = watch_path_for(&home, "owner/repo", "main");
+    let mut watch = read_watch(&path);
+    let future_secs = chrono::Utc::now().timestamp() + 3600;
+    watch["rate_limit_until"] = serde_json::json!(future_secs);
+    watch["last_polled_at"] = serde_json::json!(chrono::Utc::now().timestamp_millis());
+    watch["effective_interval_secs"] = serde_json::json!(120);
+    std::fs::write(&path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+    // Re-call watch_ci (idempotent re-subscribe) — response should
+    // reflect the new state.
+    let resp = handle_watch_ci(&home, &args, "lead");
+    assert_eq!(resp["rate_limit_active"].as_bool(), Some(true));
+    assert_eq!(resp["rate_limit_until"].as_i64(), Some(future_secs));
+    assert!(resp["next_poll_eta"].as_i64().is_some());
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn watch_ci_next_poll_eta_null_for_fresh_watch() {
+    // Sub-scope A gate 3: a fresh watch (no last_polled_at yet) has
+    // null next_poll_eta — agents shouldn't be lied to about "when's
+    // the next poll" when no poll has happened yet.
+    let home = std::env::temp_dir().join(format!("agend-p05-A3-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let resp = handle_watch_ci(&home, &args, "lead");
+    assert!(resp["next_poll_eta"].is_null());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---- Sub-scope C: ci status MCP tool ----
+
+#[test]
+fn ci_status_returns_caller_subscribed_watches() {
+    // Sub-scope C gate 1: caller scoping — only watches that include
+    // the caller in `subscribers` come back. A second watch the
+    // caller didn't subscribe to is filtered out.
+    let home = std::env::temp_dir().join(format!("agend-p05-C1-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    handle_watch_ci(
+        &home,
+        &serde_json::json!({"repo": "o/r1", "branch": "main"}),
+        "lead",
+    );
+    handle_watch_ci(
+        &home,
+        &serde_json::json!({"repo": "o/r2", "branch": "main"}),
+        "dev",
+    );
+
+    let resp = handle_status_ci(&home, &serde_json::json!({}), "lead");
+    let watches = resp["watches"].as_array().unwrap();
+    assert_eq!(watches.len(), 1, "lead sees only their watch");
+    assert_eq!(watches[0]["repo"].as_str(), Some("o/r1"));
+    assert!(watches[0]
+        .get("rate_limit_active")
+        .and_then(|v| v.as_bool())
+        .is_some());
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn ci_status_filter_by_repo_returns_subset() {
+    // Sub-scope C gate 2: optional repo filter narrows to a single
+    // watch even when caller has multiple subscriptions.
+    //
+    // EMPIRICAL REGRESSION-PROOF ANCHOR: if `handle_status_ci`
+    // accidentally drops the `filter_repo` check (e.g. early-return
+    // before the comparison), this test fails because both
+    // subscribed watches surface. PR description captures the FAIL
+    // signature.
+    let home = std::env::temp_dir().join(format!("agend-p05-C2-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    handle_watch_ci(
+        &home,
+        &serde_json::json!({"repo": "o/alpha", "branch": "main"}),
+        "lead",
+    );
+    handle_watch_ci(
+        &home,
+        &serde_json::json!({"repo": "o/beta", "branch": "main"}),
+        "lead",
+    );
+
+    let resp = handle_status_ci(&home, &serde_json::json!({"repo": "o/alpha"}), "lead");
+    let watches = resp["watches"].as_array().unwrap();
+    assert_eq!(watches.len(), 1, "filter must narrow to o/alpha only");
+    assert_eq!(watches[0]["repo"].as_str(), Some("o/alpha"));
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn ci_status_no_watches_returns_empty_array_not_error() {
+    // Sub-scope C gate 3: empty-state shape is `{"watches": []}`,
+    // never an error. Agents that pattern-match on `watches.length`
+    // shouldn't have to handle a separate not-found code.
+    let home = std::env::temp_dir().join(format!("agend-p05-C3-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    let resp = handle_status_ci(&home, &serde_json::json!({}), "lead");
+    assert!(resp.get("error").is_none());
+    let watches = resp["watches"].as_array().expect("watches array");
+    assert!(watches.is_empty());
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -175,6 +175,8 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         "ci" => match args["action"].as_str().unwrap_or("") {
             "watch" => ci::handle_watch_ci(&home, args, instance_name),
             "unwatch" => ci::handle_unwatch_ci(&home, args),
+            // Sprint 54 P0-5 (sub-scope C): aggregate health snapshot.
+            "status" => ci::handle_status_ci(&home, args, instance_name),
             other => json!({"error": format!("unknown ci action: {other}")}),
         },
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -205,13 +205,13 @@ fn deploy_tools() -> Vec<Value> {
 
 fn ci_tools() -> Vec<Value> {
     vec![
-        json!({"name": "ci", "description": "Manage CI watching. Actions: watch, unwatch.",
+        json!({"name": "ci", "description": "Manage CI watching. Actions: watch, unwatch, status.",
             "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["watch", "unwatch"]},
-                "repo": {"type": "string", "description": "GitHub repo (owner/repo)"},
-                "branch": {"type": "string", "description": "Branch to watch (default: main)"},
+                "action": {"type": "string", "enum": ["watch", "unwatch", "status"]},
+                "repo": {"type": "string", "description": "GitHub repo (owner/repo). Required for watch/unwatch; optional filter for status."},
+                "branch": {"type": "string", "description": "Branch to watch (default: main); optional filter for status."},
                 "interval_secs": {"type": "number", "description": "Poll interval in seconds (default: 60)"}
-            }, "required": ["action", "repo"]}}),
+            }, "required": ["action"]}}),
     ]
 }
 


### PR DESCRIPTION
## Summary

Closes Sprint 54 P0-5 spec from dispatch `m-20260507045729197032-16`. Three sub-scopes that turn ci_watch from "polls in the background and hopes someone notices the inbox event" into "agents can see CI health on demand and get notified the moment polling stalls".

Tier-2 dual review (lead VERIFIED + reviewer VERIFIED). Sub-scopes B + C are Path A — strict smoke pre-merge per PLAN §5.1.

## Sub-scope A — `ci watch` response enrichment (Path C)

`handle_watch_ci` response gains:
- `rate_limit_active: bool` — `true` iff `rate_limit_until > now`.
- `rate_limit_until: Option<i64>` — epoch seconds.
- `next_poll_eta: Option<i64>` — `last_polled_at + effective_interval_secs * 1000`. Null for fresh watches.

Existing `subscribers` (P0-1) + `setup_warning` (P0-4) preserved.

## Sub-scope B — inbox stalled/resumed events (Path A)

Watch JSON gains `consecutive_skips: u64` + `stalled_notified: bool` + `stalled_since_ms: Option<i64>`.

- `bump_consecutive_skips_and_maybe_notify` — invoked on every `rate_limit_until > now` skip in the tick loop. Increments the counter atomically with the `stalled_notified` flag write, so concurrent ticks can never observe a "skips ≥ threshold, flag still false" intermediate state. Fires `[ci-watch-stalled]` exactly once when crossing `STALL_THRESHOLD` (=3).
- `clear_stall_and_maybe_notify_resumed` — invoked from `ci_check_repo`'s `Runs` arm before the empty-runs early return. Clears the counters + flag, fires `[ci-watch-resumed]` exactly once if a stall was in flight.
- Both events fan out via the P0-1 subscriber contract — one `inbox::enqueue` per subscriber, plus `mark_ci_watch_superseded` to collapse stale prior events.

Body includes `stalled_since`, `next_poll_eta`, and the P0-4 `setup_warning` text when applicable.

## Sub-scope C — `ci status` MCP action (Path A)

New `ci(action: status)` aggregator. Schema:

\`\`\`json
{
  "watches": [
    {
      "repo": "...",
      "branch": "...",
      "subscribers": ["lead", "dev"],
      "rate_limit_active": false,
      "rate_limit_until": null,
      "rate_limit_remaining": 4500,
      "rate_limit_limit": 5000,
      "effective_interval_secs": 60,
      "interval_secs": 60,
      "next_poll_eta": 1778116000000,
      "consecutive_skips": 0,
      "stalled_notified": false,
      "stalled_since_ms": null,
      "last_polled_at": ...,
      "last_terminal_seen_at": "...",
      "head_sha": "abc...",
      "expires_at": "..."
    }
  ],
  "setup_warning": "..."
}
\`\`\`

**Caller scoping**: agents only see watches they're subscribed to (avoids leaking lead's targets to every dev). Anonymous CLI calls see all watches — operator triage path.

**Filters**: optional `repo` / `branch` args narrow the result; both must match when both are provided.

`mcp::tools` schema: `ci`'s `action` enum gains `"status"` and `repo` moves out of the `required` array (status doesn't need it).

## Files changed

| File | Purpose |
|---|---|
| `src/daemon/ci_watch.rs` (+388/-1) | `STALL_THRESHOLD` const, `bump_consecutive_skips_and_maybe_notify`, `clear_stall_and_maybe_notify_resumed`, `build_stalled_body`, `fan_out_health_event` helpers; tick-loop wiring; 4 new tests. |
| `src/mcp/handlers/ci/mod.rs` (+115) | `compute_next_poll_eta` helper; A response enrichment; new `handle_status_ci`. |
| `src/mcp/handlers/ci/tests.rs` (+157) | 6 new tests (3 A + 3 C). |
| `src/mcp/handlers/mod.rs` (+2) | `"status"` action dispatch. |
| `src/mcp/tools.rs` (+5/-5) | Schema update for `ci` tool. |
| `docs/FLEET-DEV-PROTOCOL-v1.md` (+11) | §7 health surface guidance for agents. |

## Hard contract — 10 unit tests

| Sub | Test | Behavior |
|---|---|---|
| A | `watch_ci_response_includes_health_fields_when_state_populated` | new fields always present |
| A | `watch_ci_rate_limit_active_when_until_in_future` | `rate_limit_until > now` ⇒ `rate_limit_active=true` |
| A | `watch_ci_next_poll_eta_null_for_fresh_watch` | `null` when no poll has happened |
| B | `consecutive_skips_increments_on_rate_limited_skip` | counter bumps on each skip |
| B | `stalled_event_fires_exactly_once_at_threshold` | one event per stall window — **regression-proof anchor** |
| B | `resumed_event_fires_on_first_successful_clear` | one resumed event per recovery; second clear silent |
| B | `stalled_and_resumed_fan_out_to_all_subscribers` | both events reach every subscriber |
| C | `ci_status_returns_caller_subscribed_watches` | caller scoping narrows to subscribed watches |
| C | `ci_status_filter_by_repo_returns_subset` | repo filter narrows further — **regression-proof anchor** |
| C | `ci_status_no_watches_returns_empty_array_not_error` | empty state is `{"watches": []}` not error |

## Empirical regression-proof — 2 anchors captured

**Anchor B** — drop the `&& !already_notified` guard in `bump_consecutive_skips_and_maybe_notify`:

\`\`\`
thread '...stalled_event_fires_exactly_once_at_threshold' panicked at
src/daemon/ci_watch.rs:4061:9:
assertion \`left == right\` failed: exactly one stalled event per stall window (got 3)
  left: 3
 right: 1
\`\`\`

**Anchor C** — drop the `filter_repo` / `filter_branch` checks in `handle_status_ci`:

\`\`\`
thread '...ci_status_filter_by_repo_returns_subset' panicked at
src/mcp/handlers/ci/tests.rs:488:5:
assertion \`left == right\` failed: filter must narrow to o/alpha only
  left: 2
 right: 1
\`\`\`

Restore → all 10 PASS.

## Test results

- `cargo test --bin agend-terminal mcp::handlers::ci`: **23 passed**.
- `cargo test --bin agend-terminal daemon::ci_watch`: **90 passed** (+4 from P0-2's 86).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test --test file_size_invariant`: ✓ (`ci/mod.rs` at 471 LOC).
- Full bin suite: **1579 passed** (+10 from P0-2's 1569). Same 7 pre-existing flakies (PLAN §1.2 #16 / P2-7).

## Production-smoke gate (PENDING — Path A for B + C)

Runs on operator daemon restart to PR HEAD `43f7e13`:

1. **A**: `ci(action: watch, repo: "owner/repo", branch: "main")` → response has `rate_limit_active: false`, `rate_limit_until: null`, `next_poll_eta: null` for fresh watch; after first poll, response shows populated fields.
2. **B**: rotate token to invalid (or trigger 403), wait 3 poll cycles → `[ci-watch-stalled]` arrives in subscribers' inboxes; watch JSON shows `stalled_notified: true`; recover (valid token) → `[ci-watch-resumed]` fires; watch JSON resets to `consecutive_skips: 0, stalled_notified: false`.
3. **C**: `ci(action: status)` → returns active watches.
4. **C** with filter: `ci(action: status, repo: "...")` → narrows correctly.

## Out of scope (defer Sprint 55+)

- Rate-limit prediction beyond `X-RateLimit-Remaining`.
- Multi-channel CI status (Slack/Telegram explicit dispatch).
- Historical health time-series.

## Test plan

- [ ] CI green on `dev/sprint-54-p0-5-agent-visible-ci-health-surface`.
- [ ] Operator runs the 4-step production-smoke gate post-restart.
- [ ] Reviewer (codex) Tier-2 dual VERIFIED.
- [ ] Both regression-proof anchors reproducible by reviewer (mutation + restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)