### PR TITLE
fix(ci-watch): owner-prefix GitHub head query + defensive head.ref check (Hotfix F gap)

### DIFF
--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -294,10 +294,20 @@ impl CiProvider for GitHubCiProvider {
     }
 
     async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState {
+        // Sprint 54 Hotfix F gap fix: GitHub's `head=` query parameter
+        // requires `user:ref-name` format. Sending bare `head=feat/foo`
+        // makes the API silently drop the filter and return the most
+        // recently created PR in the repo regardless of branch — that
+        // behavior masked Hotfix F's freshness check (the misrouted PR
+        // was usually fresh enough to pass the 1-hour window) and
+        // produced false `Terminal{merged}` for any branch that had
+        // never had a PR opened. Per GitHub docs:
+        // https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
+        let owner = repo.split('/').next().unwrap_or("");
         let resp: serde_json::Value = match self
             .http
             .get(&format!(
-                "repos/{repo}/pulls?head={branch}&state=all&per_page=1"
+                "repos/{repo}/pulls?head={owner}:{branch}&state=all&per_page=1"
             ))
             .send()
             .await
@@ -309,28 +319,46 @@ impl CiProvider for GitHubCiProvider {
             Err(_) => return PrState::Unknown,
         };
         match resp.as_array().and_then(|a| a.first()) {
-            Some(pr) => match pr["state"].as_str() {
-                Some("closed") => {
-                    // Verify this PR was updated recently (not a stale PR from
-                    // a previous use of the same branch name). If closed_at is
-                    // older than 1 hour, treat as stale → Unknown (pending).
-                    if let Some(closed_at) = pr["closed_at"].as_str() {
-                        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(closed_at) {
-                            let age = chrono::Utc::now()
-                                .signed_duration_since(dt.with_timezone(&chrono::Utc));
-                            if age > chrono::Duration::hours(1) {
-                                // Stale PR from previous branch use — not terminal.
-                                return PrState::Unknown;
+            Some(pr) => {
+                // Sprint 54 Hotfix F gap fix (defensive): even with the
+                // correct query format, GitHub may return a PR whose
+                // `head.ref` doesn't match what we asked for (cross-fork
+                // edge cases, schema drift, future API quirks). Treat
+                // mismatch as Unknown rather than trusting the response
+                // — the cost of an extra polling tick is far smaller
+                // than a false auto-clear.
+                if pr["head"]["ref"].as_str() != Some(branch) {
+                    tracing::debug!(
+                        repo,
+                        branch,
+                        returned_ref = ?pr["head"]["ref"].as_str(),
+                        "check_pr_terminal: response head.ref mismatch — returning Unknown"
+                    );
+                    return PrState::Unknown;
+                }
+                match pr["state"].as_str() {
+                    Some("closed") => {
+                        // Verify this PR was updated recently (not a stale PR from
+                        // a previous use of the same branch name). If closed_at is
+                        // older than 1 hour, treat as stale → Unknown (pending).
+                        if let Some(closed_at) = pr["closed_at"].as_str() {
+                            if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(closed_at) {
+                                let age = chrono::Utc::now()
+                                    .signed_duration_since(dt.with_timezone(&chrono::Utc));
+                                if age > chrono::Duration::hours(1) {
+                                    // Stale PR from previous branch use — not terminal.
+                                    return PrState::Unknown;
+                                }
                             }
                         }
+                        PrState::Terminal {
+                            merged: pr["merged_at"].as_str().is_some(),
+                        }
                     }
-                    PrState::Terminal {
-                        merged: pr["merged_at"].as_str().is_some(),
-                    }
+                    Some(_) => PrState::Open,
+                    None => PrState::Unknown,
                 }
-                Some(_) => PrState::Open,
-                None => PrState::Unknown,
-            },
+            }
             None => PrState::Unknown,
         }
     }
@@ -4144,5 +4172,150 @@ mod tests {
             );
         }
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 54 Hotfix F gap: malformed GitHub head query ─────────────
+    //
+    // Per RCA m-46: `check_pr_terminal` was sending bare `head=feat/foo`
+    // instead of `head=owner:feat/foo`. GitHub silently dropped the
+    // filter → returned the most recent PR in the repo → Hotfix F's
+    // freshness check passed → false `Terminal{merged}` for fresh-no-PR
+    // branches. The malformed-query swallow is the third concrete
+    // instance of the silent-drop class systematic prevention pattern
+    // (decision `d-20260507100609264367-2`).
+    //
+    // EMPIRICAL REGRESSION-PROOF ANCHOR: dropping the `{owner}:` prefix
+    // from the URL format string trips
+    // `github_check_pr_terminal_uses_owner_prefix_in_head_query`. PR
+    // description carries the verbatim FAIL signature.
+
+    /// Reuse the gitlab_mock_server scaffolding — it's just an HTTP
+    /// listener returning a fixed body, content-type agnostic. Renaming
+    /// to `mock_server` would touch dozens of call sites; sharing the
+    /// fn under a Hotfix-F-specific helper avoids that churn.
+    fn github_mock_server(response_body: &str) -> (u16, std::thread::JoinHandle<()>, MockCapture) {
+        gitlab_mock_server(response_body)
+    }
+
+    #[test]
+    fn github_check_pr_terminal_uses_owner_prefix_in_head_query() {
+        // Hotfix F gap gate 1 (regression-proof anchor): the production
+        // URL must carry `head={owner}:{branch}` per GitHub docs. Empty
+        // PR list is fine — the test only inspects the captured URL.
+        let (port, handle, captured) = github_mock_server("[]");
+        let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+            .expect("provider");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        let _ = rt.block_on(provider.check_pr_terminal("acme/widgets", "feat/foo"));
+
+        handle.join().expect("mock");
+        let (path, _request) = captured.lock().expect("lock").take().expect("captured");
+
+        assert!(
+            path.contains("/repos/acme/widgets/pulls"),
+            "URL must target the repo's pulls endpoint: {path}"
+        );
+        assert!(
+            path.contains("head=acme:feat/foo"),
+            "URL must use `head={{owner}}:{{branch}}` per GitHub docs (Hotfix F gap fix); got: {path}"
+        );
+        // Defensive: also ensure the legacy bare form is GONE — a
+        // future edit that re-introduced `head={branch}` without the
+        // owner prefix should trip this.
+        assert!(
+            !path.contains("head=feat/foo&"),
+            "URL must NOT use bare `head={{branch}}` (the silent-drop bug); got: {path}"
+        );
+    }
+
+    #[test]
+    fn github_check_pr_terminal_returns_unknown_on_head_ref_mismatch() {
+        // Hotfix F gap gate 2 (defensive): even with the correct URL,
+        // GitHub may return a PR whose head.ref doesn't match what we
+        // asked. The defensive check returns Unknown so we don't
+        // misclassify the asked branch as Terminal based on someone
+        // else's PR data.
+        let mismatched = r#"[{
+            "state": "closed",
+            "closed_at": "2099-01-01T00:00:00Z",
+            "merged_at": "2099-01-01T00:00:00Z",
+            "head": {"ref": "different-branch"}
+        }]"#;
+        let (port, handle, captured) = github_mock_server(mismatched);
+        let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+            .expect("provider");
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        let state = rt.block_on(provider.check_pr_terminal("acme/widgets", "feat/foo"));
+        handle.join().expect("mock");
+        let _ = captured;
+
+        assert!(
+            matches!(state, super::PrState::Unknown),
+            "head.ref mismatch must return Unknown (defensive); got: {state:?}"
+        );
+    }
+
+    #[test]
+    fn github_check_pr_terminal_returns_unknown_on_empty_pr_list() {
+        // Hotfix F gap gate 3 (production-realistic): the bug surfaced
+        // for fresh-no-PR branches, where GitHub correctly returns []
+        // once the head query is well-formed. The state machine must
+        // map empty → Unknown so the auto-clear path doesn't fire.
+        let (port, handle, captured) = github_mock_server("[]");
+        let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+            .expect("provider");
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        let state = rt.block_on(provider.check_pr_terminal("acme/widgets", "fresh-branch-no-pr"));
+        handle.join().expect("mock");
+        let _ = captured;
+
+        assert!(
+            matches!(state, super::PrState::Unknown),
+            "fresh-no-PR branch must return Unknown; got: {state:?}"
+        );
+    }
+
+    #[test]
+    fn github_check_pr_terminal_terminal_on_matching_head_ref_and_recent_close() {
+        // Hotfix F gap gate 4: the happy path still works post-fix —
+        // a closed-and-merged PR matching the head.ref returns
+        // Terminal{merged: true}. Defensive head.ref check + Hotfix F
+        // freshness check both pass.
+        let recent_close = chrono::Utc::now() - chrono::Duration::minutes(5);
+        let body = format!(
+            r#"[{{
+                "state": "closed",
+                "closed_at": "{}",
+                "merged_at": "{}",
+                "head": {{"ref": "feat/foo"}}
+            }}]"#,
+            recent_close.to_rfc3339(),
+            recent_close.to_rfc3339()
+        );
+        let (port, handle, captured) = github_mock_server(&body);
+        let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+            .expect("provider");
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        let state = rt.block_on(provider.check_pr_terminal("acme/widgets", "feat/foo"));
+        handle.join().expect("mock");
+        let _ = captured;
+
+        assert!(
+            matches!(state, super::PrState::Terminal { merged: true }),
+            "matching head.ref + recent merged_at must be Terminal(merged); got: {state:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes Hotfix F gap from RCA `m-46` + general `m-47` approval. Decision: `d-20260507100609264367-2`. Closes silent-drop class systematic-prevention pattern, **third instance**.

Tier-2 dual review (lead VERIFIED + reviewer VERIFIED). Path A — strict smoke pre-merge per PLAN §5.1.

## Root cause

`GitHubCiProvider::check_pr_terminal` was sending bare `head=feat/foo` to GitHub's `GET /repos/{owner}/{repo}/pulls`. GitHub's docs require `user:ref-name` format; without the owner prefix, the API silently drops the filter and returns the most recently created PR in the repo regardless of branch.

That misrouted PR was usually fresh enough to pass Hotfix F's 1-hour `closed_at` freshness check, producing false `Terminal{merged}` for any branch that had never had a PR opened. **Hotfix F (#461) was correct for its scope but protected the wrong layer** — the upstream query was broken, and Hotfix F's freshness gate would never see the truly-stale case.

## Two-pronged fix

1. **Primary — correct query format** (per GitHub REST docs):

   \`\`\`rust
   let owner = repo.split('/').next().unwrap_or("");
   .get(&format!(
       "repos/{repo}/pulls?head={owner}:{branch}&state=all&per_page=1"
   ))
   \`\`\`

2. **Defensive — verify response shape**: even with the correct format, GitHub may return a PR whose `head.ref` doesn't match what we asked (cross-fork edge cases, schema drift, future API quirks). The defensive check returns `PrState::Unknown` on mismatch so we don't misclassify based on someone else's data.

   The cost of an extra polling tick is far smaller than a false auto-clear that strands a watching agent.

## Hard contract — 4 unit tests

| # | Test | Behavior |
|---|---|---|
| 1 | `github_check_pr_terminal_uses_owner_prefix_in_head_query` | URL contains `head={owner}:{branch}` per GitHub docs — **regression-proof anchor** |
| 2 | `github_check_pr_terminal_returns_unknown_on_head_ref_mismatch` | Defensive: PR with mismatched `head.ref` → `Unknown` |
| 3 | `github_check_pr_terminal_returns_unknown_on_empty_pr_list` | Production-realistic: fresh-no-PR branch → correctly-formed query → `[]` → `Unknown` (the original bug's correct outcome) |
| 4 | `github_check_pr_terminal_terminal_on_matching_head_ref_and_recent_close` | Happy path still works post-fix: matching `head.ref` + recent merge → `Terminal{merged: true}` |

Tests reuse the existing `gitlab_mock_server` HTTP listener (named locally `github_mock_server`) — content-type-agnostic; sharing avoids touching dozens of call sites.

## Empirical regression-proof — captured

**Mutation**: drop the owner prefix from the URL format string:

\`\`\`rust
let owner = repo.split('/').next().unwrap_or("");
let _ = owner;
.get(&format!("repos/{repo}/pulls?head={branch}&state=all&per_page=1"))
\`\`\`

**Result**:

\`\`\`
thread '...github_check_pr_terminal_uses_owner_prefix_in_head_query'
panicked at src/daemon/ci_watch.rs:4226:9:
URL must use \`head={owner}:{branch}\` per GitHub docs (Hotfix F gap fix);
got: /repos/acme/widgets/pulls?head=feat/foo&state=all&per_page=1
\`\`\`

Restore → **4 PASS**.

## Test results

- `cargo test --bin agend-terminal daemon::ci_watch::tests::github_check_pr_terminal`: **4 passed**.
- `cargo test --bin agend-terminal daemon::ci_watch`: **94 passed** (+4 from baseline 90).
- `cargo clippy --all-targets -- -D warnings`: clean.
- Full bin suite: **1597–1598 passed** (+4 net new). Same 7 pre-existing flakies (PLAN §1.2 #16 / P2-7); one occasional 8th parallel-race flake (`deps_unchanged_green`, passes in isolation; not introduced by this PR).

## Production-smoke gate (PENDING — Path A required pre-merge)

Runs on operator daemon restart to PR HEAD `c265c53`:

1. Restart daemon to PR HEAD binary.
2. Dispatch fresh branch via `delegate_task` with `branch` field — no PR opened on the branch yet.
3. Tail `app.log` → confirm `CI watcher auto-cleared: PR terminal` does NOT fire on the first poll. (Look for either `skipping PR-terminal auto-clear` OR no auto-clear log at all.)
4. Open a real PR for the branch → verify normal classification kicks in (Open state detected, polling continues).

This exact smoke procedure would've caught the original bug — Sprint 53 §1.4 + Sprint 54 §5.1 hard learning baked into protocol.

## Sprint 54 silent-drop precedent

> Pattern: silent malformed-query swallowing — tests with mock provider bypass real query format validation. Fix: correct query + defensive verify on response shape.
>
> This is the **third concrete instance** of the silent-drop class systematic prevention pattern (decision `d-20260507100609264367-2`). First was #495 (#488 daemon-state MCP silent fallback); second was #497 (telegram image-download silent drop). Future silent-drop audits will reference all three PRs as templates.

## Out of scope

- Changing the `closed_at` freshness check (Hotfix F is correct for its scope, just protected the wrong layer).
- Refactoring `CiProvider` trait beyond what the fix requires.
- Other providers (GitLab/Bitbucket) — different head query semantics, separate phase if needed.
- `Cargo.lock` 0.5.0 → 0.6.0 sync (pre-existing inconsistency from #494; deliberately excluded from this PR's diff to keep scope focused — separate fix).

## v0.6.0 release impact

Per general `m-47`: operator `m-45` leans Option A (hold tag, fix then release). This Hotfix F gap fix → smoke verified → tag v0.6.0.

## Test plan

- [ ] CI green on `dev/hotfix-f-gap-head-query-format`.
- [ ] Operator runs the 4-step production-smoke gate post-restart.
- [ ] Reviewer (codex) Tier-2 dual VERIFIED.
- [ ] Regression-proof anchor reproducible by reviewer (mutation + restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)