### PR TITLE
chore: sync Cargo.lock to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agend-terminal"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",


### PR DESCRIPTION
## Summary

#494 bumped Cargo.toml version 0.5.0 → 0.6.0 but didn't update the corresponding entry in Cargo.lock. Single-line correction.

Most local builds auto-regenerate the lock during `cargo build`, but tagging + `cargo publish` require the lock to be in sync on disk. Surfaced by dev during #498 r0 review per general m-49.

## Diff

```
Cargo.lock | 2 +-
1 file changed, 1 insertion(+), 1 deletion(-)
```

Single line: `version = "0.5.0"` → `version = "0.6.0"` for the `agend-terminal` package entry.

## Tier

Tier-1 single primary review per general m-49 lean. Lock-only correction, no functional change.

## Test plan

- [ ] CI green on 3 platforms
- [ ] Reviewer confirms only Cargo.lock changed (no other diff)
- [ ] After merge → operator restart batch smoke (final v0.6.0 release pipeline gate before tag + cargo publish)

## v0.6.0 release timeline

Per operator m- "A" (hold tag, ship Hotfix F gap first):
1. ✅ #498 Hotfix F gap merged
2. 🔧 This PR (Cargo.lock sync) — gates on Tier-1 + CI
3. ⏳ Operator restart batch smoke (P0-5 + P1-7 + #495 + #497 + #498)
4. ⏳ Operator approve tag → cargo publish + git tag v0.6.0