### PR TITLE
docs(protocol): §6 dispatch milestone updates + §7 no-poll rule

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -134,6 +134,14 @@ Use `send` for all inter-agent messaging:
 
 **Routing**: `target_instance` (single) or `targets` / `team` / `tags` (broadcast)
 
+**Dispatch milestone updates** — when you accept a `task` dispatch, send `kind=update` to the dispatcher at each of these milestones without being asked:
+
+1. **r0 ready** — PR opened (or work artifact handed off), with verbatim links / heads.
+2. **CI all-green** — every CI gate the PR runs has reported success. The `[ci-pass]` watch broadcast does NOT substitute — confirm via your own update so the dispatcher's loop closer fires regardless of their channel state.
+3. **Reviewer verdict received** — VERIFIED / REJECTED / UNVERIFIED, with the reviewer's identity and key finding summary.
+
+Re-review cycles (r1, r2, …) repeat the same three milestones. The dispatcher relies on these as the loop closer; missing any forces them to poll, which is anti-pattern (see §7).
+
 - Pure ack → use `react` (emoji), not `send`
 - Response channel must match source channel
 - **Router-layer channel discipline (Sprint 52)**: daemon auto-mirrors agent direct text to the corresponding channel. Agent does not need to force `reply` tool — infrastructure handles routing.
@@ -141,6 +149,23 @@ Use `send` for all inter-agent messaging:
 ## §7. CI
 
 Use `ci(action: watch)`, not manual polling. Clean up worktree + branch after merge.
+
+**No manual orchestrator polling**. Orchestrators (lead, general,
+operator-in-the-loop) MUST NOT manually poll PR / CI state via
+`gh pr view`, `gh run list`, repeated `cargo test`, or equivalent.
+Rely on:
+
+1. The dispatchee's `kind=update` milestones (§6) — r0 ready, CI
+   all-green, reviewer verdict.
+2. `ci(action: watch)` fan-out — `[ci-pass]` / `[ci-fail]` /
+   `[ci-watch-stalled]` arrive automatically.
+
+Manual polling masks broken dispatch communication and burns cache /
+rate-limit budget unnecessarily. If a milestone is missing past a
+reasonable window, the correct response is to message the dispatchee
+asking why, not to poll. Polling is also a smell that the dispatch
+brief itself didn't enumerate the expected milestones — fix the
+dispatch, not the symptom.
 
 **PR open semantics (Sprint 54)**. Implementers MUST open feature PRs as
 **ready** for review by default. The `--draft` flag is reserved for


### PR DESCRIPTION
## Summary

Closes general dispatch `m-20260507164649032098-25`. Pure docs amendment to `docs/FLEET-DEV-PROTOCOL-v1.md`. No code, no behavior change.

Tier-1 single primary review per dispatch (docs only, low risk). Pinned to v0.6.0 ship per operator `m-25` plan B (avoid back-to-back protocol bump immediately post-release).

## Triggering cycle

PR #503 r0/r1/r2: the dispatchee (this agent) confirmed CI-pass only via text reply, not `kind=update`. The orchestrator (general) had to fall back to `gh pr view` polling to learn the state, which masked the protocol gap until operator `m-23` noticed and `m-25` routed plan B (codify in protocol + ship with v0.6.0).

The fix is two additive blocks — no rewrites of existing wording.

## §6 Communication — new "Dispatch milestone updates" block

Three milestones the dispatchee MUST `kind=update` without being asked:

1. **r0 ready** — PR opened, with verbatim links / heads.
2. **CI all-green** — every CI gate has reported success. The `[ci-pass]` watch broadcast does NOT substitute — explicit `kind=update` is the loop closer.
3. **Reviewer verdict received** — VERIFIED / REJECTED / UNVERIFIED, with reviewer identity + key finding.

Re-review cycles (r1, r2, …) repeat the same three.

## §7 CI — new "No manual orchestrator polling" rule

Orchestrators (lead, general, operator-in-the-loop) MUST NOT `gh pr view` / `gh run list` / repeated `cargo test`. Rely on:

1. Dispatchee's `kind=update` milestones (§6).
2. `ci(action: watch)` fan-out.

Missing milestone → message dispatchee asking why, don't poll. Polling is also a smell that the dispatch brief itself didn't enumerate expected milestones — fix the dispatch, not the symptom.

## Files changed

- `docs/FLEET-DEV-PROTOCOL-v1.md` — +25 LOC (single hunk per section, additive).

## Dogfood

The dispatchee for this PR will send `kind=update` at all three milestones per the new rule:

- [x] r0 ready (this PR opened)
- [ ] CI all-green
- [ ] Reviewer verdict received

## v0.6.0 inclusion

Per operator `m-25` plan B: ship protocol amendment with v0.6.0.

## Test plan

- [ ] CI green (no code change, but cargo fmt / clippy etc. still run).
- [ ] Reviewer (codex) Tier-1 single primary VERIFIED.
- [ ] Three milestones dogfooded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)