### PR TITLE
fix(cargo): include `assets/hooks/*` so cargo publish verify step builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,14 @@ include = [
     "src/**/*.rs",
     "build.rs",
     "assets/windows/*",
+    # `src/binding.rs` does `include_str!("../assets/hooks/prepare-commit-msg")`
+    # + `.../prepare-commit-msg.ps1` (Sprint 53 #446 Phase 1 trailer hook).
+    # Same lesson as the `docs/FLEET-DEV-PROTOCOL-v1.md` entry below: the
+    # `cargo publish` verify step builds from the packaged tarball, so
+    # every `include_str!` target must appear here. v0.6.0 publish-blocker
+    # hotfix (silent-drop class 5th instance — human comment alone didn't
+    # prevent a second occurrence; Phase 2 invariant test deferred to v0.6.1).
+    "assets/hooks/*",
     # `src/protocol.rs` does `include_str!("../docs/FLEET-DEV-PROTOCOL-v1.md")`
     # at compile time. Without this entry, `cargo publish`'s verification
     # build (which works on the packaged tarball, not the source tree)


### PR DESCRIPTION
## Summary

Closes v0.6.0 publish blocker per lead dispatch `m-20260507172456287204-33` + general `m-32` RCA. Single-line `Cargo.toml` fix.

Tier-1 single primary review per dispatch (low risk, dry-run smoke is the unique signal).

## Root cause

`Cargo.toml`'s `include = [...]` whitelist had `assets/windows/*` and `docs/FLEET-DEV-PROTOCOL-v1.md` but did NOT have `assets/hooks/*`. `src/binding.rs:113,123` does `include_str!` on `../assets/hooks/prepare-commit-msg` and the `.ps1` variant (Sprint 53 #446 Phase 1 trailer hook). Local `cargo build` works because the assets exist on disk; `cargo publish`'s verify step builds from the packaged tarball, where the missing whitelist entry meant the files were stripped — verify fails to compile with `couldn't read 'src/../assets/hooks/prepare-commit-msg': No such file or directory`.

Same class as the v0.4.0 `docs/FLEET-DEV-PROTOCOL-v1.md` miss documented inline in Cargo.toml. **5th concrete instance** of the silent-drop class — a human "remember to add new assets" comment alone didn't prevent the second occurrence. Phase 2 (invariant test that greps `include_str!` targets against the include list) deferred to Sprint 55 / v0.6.1 per dispatch.

## Fix

Single Cargo.toml edit: add `"assets/hooks/*",` to `include`, with a comment block explaining the same lesson the existing `docs/FLEET-DEV-PROTOCOL-v1.md` entry teaches.

## Phase 3 production smoke (verbatim)

`cargo publish --dry-run --registry crates-io --allow-dirty` (`--allow-dirty` because the only diff is Cargo.toml itself):

\`\`\`
   Compiling agend-terminal v0.6.0 (/.../target/package/agend-terminal-0.6.0)
   ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 59.53s
   Uploading agend-terminal v0.6.0 (/Users/suzuke/.agend-terminal/...)
warning: aborting upload due to dry run
\`\`\`

Verify step compiled all the way through. The `Uploading` + `aborting upload due to dry run` pair is the success signal — the previous state errored out before reaching this point.

## Empirical regression-proof — captured

**Mutation**: revert the `"assets/hooks/*",` line.

**Result** (verbatim):

\`\`\`
error: couldn't read `src/../assets/hooks/prepare-commit-msg`: No such file or directory (os error 2)
   --> src/binding.rs:113:21
    |
113 |     let bash_hook = include_str!(\"../assets/hooks/prepare-commit-msg\");
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: couldn't read `src/../assets/hooks/prepare-commit-msg.ps1`: No such file or directory (os error 2)
   --> src/binding.rs:123:19
    |
123 |     let ps_hook = include_str!(\"../assets/hooks/prepare-commit-msg.ps1\");
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `agend-terminal` (bin \"agend-terminal\") due to 2 previous errors
error: failed to verify package tarball
\`\`\`

Matches general `m-32` RCA verbatim. Restore → dry-run passes again.

## Out of scope

- Phase 2 invariant test (deferred to Sprint 55 / v0.6.1).
- Other Cargo.toml polish.
- Re-organizing `assets/`.

## v0.6.0 release impact

**Critical**: without this hotfix, `cargo publish` for v0.6.0 fails at the verify step. This unblocks the crates.io ship.

## Test plan

- [ ] CI green (no code change, but cargo fmt / clippy etc. still run).
- [ ] Reviewer (codex) Tier-1 single primary VERIFIED.
- [ ] Operator runs `cargo publish --dry-run` post-merge to confirm green path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)