### PR TITLE
fix(inbox): PTY-inject + inbox metadata broadcast visibility (Sprint 54 layer-5)

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -46,13 +46,35 @@ pub fn fallback_deliver(
 ///
 /// `from: &Sender` guarantees a non-empty originator; callers cannot
 /// accidentally stamp messages with `[from:]` (see `src/identity.rs`).
-pub fn send_to(home: &Path, from: &Sender, target: &str, text: &str, kind: &str) -> Value {
+///
+/// Sprint 54 layer-5: `broadcast_context` is `Some` only when the call
+/// originates from `handle_broadcast` per-target loop — it surfaces in the
+/// recipient's `[AGEND-MSG]` header (`broadcast=N team=NAME`) and inbox
+/// JSON metadata so broadcast is distinguishable from unicast at agent
+/// vantage. Routing behavior is unaffected.
+pub fn send_to(
+    home: &Path,
+    from: &Sender,
+    target: &str,
+    text: &str,
+    kind: &str,
+    broadcast_context: Option<&crate::inbox::BroadcastContext>,
+) -> Value {
     let from_str = from.as_str();
+    let mut params = json!({
+        "from": from_str,
+        "target": target,
+        "text": text,
+        "kind": kind,
+    });
+    if let Some(ctx) = broadcast_context {
+        params["broadcast_context"] = serde_json::to_value(ctx).unwrap_or(Value::Null);
+    }
     match crate::api::call(
         home,
         &json!({
             "method": crate::api::method::SEND,
-            "params": { "from": from_str, "target": target, "text": text, "kind": kind }
+            "params": params,
         }),
     ) {
         Ok(resp) if resp["ok"].as_bool() == Some(true) => {
@@ -77,6 +99,7 @@ pub fn send_to(home: &Path, from: &Sender, target: &str, text: &str, kind: &str)
                 text,
                 &submit_key,
                 None,
+                broadcast_context.cloned(),
             );
             json!({"target": target, "delivery_mode": "inbox_fallback", "note": format!("API unavailable: {e}")})
         }

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -131,6 +131,12 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
             superseded_by: None,
+            // Sprint 54 layer-5: surfaced when caller (handle_broadcast)
+            // is fanning out — None for unicast SEND. Header formatter
+            // emits `broadcast=N team=NAME` from this.
+            broadcast_context: params.get("broadcast_context").and_then(|v| {
+                serde_json::from_value::<crate::inbox::BroadcastContext>(v.clone()).ok()
+            }),
         }
     };
     let _ = crate::inbox::enqueue(ctx.home, target, msg.clone());

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -190,6 +190,7 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
                 in_reply_to_excerpt: None,
                 superseded_by: None,
                 from_id: None,
+                broadcast_context: None,
             },
         );
         // Also notify agent PTY so it picks up the summary
@@ -486,6 +487,7 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         }),
         superseded_by: None,
         from_id: None,
+        broadcast_context: None,
     };
     let _ = inbox::enqueue(&home, &instance_name, msg_obj);
 

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -1001,6 +1001,7 @@ fn fan_out_health_event(
                 in_reply_to_excerpt: None,
                 superseded_by: None,
                 from_id: None,
+                broadcast_context: None,
             },
         );
     }
@@ -1841,6 +1842,7 @@ async fn ci_check_repo(
                         in_reply_to_excerpt: None,
                         superseded_by: None,
                         from_id: None,
+                        broadcast_context: None,
                     },
                 );
             }

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -136,6 +136,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     in_reply_to_excerpt: None,
                     superseded_by: None,
                     from_id: None,
+                    broadcast_context: None,
                 },
             );
             "ok_inbox"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -910,6 +910,7 @@ pub fn run_task_maintenance(home: &Path) {
                 in_reply_to_excerpt: None,
                 superseded_by: None,
                 from_id: None,
+                broadcast_context: None,
             },
         );
     }
@@ -978,6 +979,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     in_reply_to_excerpt: None,
                     superseded_by: None,
                     from_id: None,
+                    broadcast_context: None,
                 },
             );
         }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -121,6 +121,7 @@ mod tests {
                     in_reply_to_excerpt: None,
                     superseded_by: None,
                     from_id: None,
+                    broadcast_context: None,
                 },
             );
         }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -163,6 +163,7 @@ pub(crate) fn maybe_notify_member_state_change(
         in_reply_to_excerpt: None,
         superseded_by: None,
         from_id: None,
+        broadcast_context: None,
     };
     let _ = crate::inbox::enqueue(home, orch, msg);
     crate::inbox::notify_agent(

--- a/src/hotspot.rs
+++ b/src/hotspot.rs
@@ -144,6 +144,7 @@ pub fn hotspot_warn(home: &Path, agent: &str, file: &Path, last_toucher: &str, s
         in_reply_to_excerpt: None,
         superseded_by: None,
         from_id: None,
+        broadcast_context: None,
     };
     let _ = crate::inbox::enqueue(home, "lead", msg);
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -217,6 +217,14 @@ pub struct InboxMessage {
     /// Sender's instance ID (UUIDv4) for audit trail. Display: name (id8).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub from_id: Option<String>,
+    /// Sprint 54 layer-5 broadcast visibility: populated when this message
+    /// arrived via a `send` broadcast (team / targets / tags fan-out).
+    /// Absent on unicast — same conditional pattern as `attachments`. Lets
+    /// recipient agents distinguish "broadcast to N peers" from a direct
+    /// 1-on-1 message at JSON-metadata vantage; the PTY-inject header
+    /// surfaces the same context via `team=` / `broadcast=` fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub broadcast_context: Option<BroadcastContext>,
 }
 
 /// Metadata attached to a forced delegation (busy gate override).
@@ -228,6 +236,22 @@ pub struct ForceMeta {
     pub reason: String,
     #[serde(alias = "interrupted_at")]
     pub forced_at: String,
+}
+
+/// Sprint 54 layer-5 broadcast visibility: routing-time metadata captured at
+/// `handle_broadcast` and threaded through the SEND path so the recipient
+/// agent can tell broadcast from unicast. `team` is `Some` only for
+/// team-based broadcasts; `targets`/`count` are populated for every fan-out
+/// (including direct `targets=[…]` / `tags=[…]` modes). Routing behavior is
+/// unaffected — this struct is metadata-only.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BroadcastContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team: Option<String>,
+    #[serde(default)]
+    pub targets: Vec<String>,
+    #[serde(default)]
+    pub count: usize,
 }
 
 impl InboxMessage {
@@ -617,6 +641,17 @@ pub fn format_header(msg: &InboxMessage) -> String {
             .collect();
         parts.push(format!("attachments=[{}]", paths.join(",")));
     }
+    // Sprint 54 layer-5 broadcast visibility: surface broadcast routing in
+    // the PTY-inject header so the recipient agent can tell broadcast from
+    // unicast at first glance. `broadcast=N` always emits when context is
+    // present; `team=NAME` only when team-based fan-out (absent for direct
+    // `targets=[…]` / `tags=[…]` modes per qa-test smoke success criteria).
+    if let Some(ref ctx) = msg.broadcast_context {
+        parts.push(format!("broadcast={}", ctx.count));
+        if let Some(ref team) = ctx.team {
+            parts.push(format!("team={}", sanitize_header_value(team)));
+        }
+    }
     if let Some(ref excerpt) = msg.in_reply_to_excerpt {
         parts.push(format!(
             "reply_to_excerpt={}",
@@ -826,6 +861,12 @@ pub fn find_message(home: &Path, msg_id: &str) -> Option<InboxMessage> {
 
 /// Deliver a message: always enqueue to inbox JSONL for persistence,
 /// then inject to PTY (inline or pointer-only depending on feature flag).
+///
+/// Sprint 54 layer-5: `broadcast_context` is `Some` only when the call
+/// originates from a `handle_broadcast` per-target fan-out via the
+/// `agent_ops::send_to` daemon-unavailable fallback. The daemon-available
+/// path goes through `api::handlers::messaging::handle_send` and
+/// constructs its own `InboxMessage` with the same field.
 pub fn deliver(
     home: &Path,
     agent_name: &str,
@@ -833,6 +874,7 @@ pub fn deliver(
     text: &str,
     _submit_key: &str,
     kind: Option<String>,
+    broadcast_context: Option<BroadcastContext>,
 ) {
     let msg = InboxMessage {
         schema_version: 0,
@@ -855,6 +897,7 @@ pub fn deliver(
         in_reply_to_excerpt: None,
         superseded_by: None,
         from_id: None,
+        broadcast_context,
     };
     let _ = enqueue(home, agent_name, msg);
     notify_agent(home, agent_name, source, text);
@@ -1127,6 +1170,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         }
     }
 
@@ -1262,6 +1306,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1286,6 +1331,7 @@ mod tests {
             "short msg",
             "\r",
             None,
+            None,
         );
         let msgs = drain(&home, "agent1");
         assert_eq!(
@@ -1308,6 +1354,7 @@ mod tests {
             &long_text,
             "\r",
             Some("chat".to_string()),
+            None,
         );
         let msgs = drain(&home, "agent1");
         assert_eq!(msgs.len(), 1, "long messages should be enqueued");
@@ -1368,6 +1415,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let json = serde_json::to_string(&msg).expect("serialize");
         let parsed: InboxMessage = serde_json::from_str(&json).expect("deserialize");
@@ -1399,6 +1447,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1993,6 +2042,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let json = serde_json::to_string(&msg).expect("ser");
         assert!(json.contains("thread_id"));
@@ -2045,6 +2095,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("[AGEND-MSG]"));
@@ -2080,6 +2131,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("from=from:agent"));
@@ -2120,6 +2172,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2151,6 +2204,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2196,11 +2250,188 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let header = format_header(&msg);
         assert!(
             header.contains("attachments=[/tmp/a.jpg,/tmp/b.jpg,/tmp/c.jpg]"),
             "multi-attachment paths must be comma-joined: {header}"
+        );
+    }
+
+    /// Sprint 54 layer-5: regression-proof for qa-test smoke
+    /// 2026-05-07 17:55 UTC — `send(team=qa-test, ...)` recipient PTY
+    /// header must surface the team= field so broadcast is
+    /// distinguishable from unicast at agent vantage. Mutate-revert:
+    /// removing the `format_header` broadcast-context branch leaves
+    /// this test failing with header lacking `team=` / `broadcast=`.
+    #[test]
+    fn test_header_format_includes_team_and_broadcast_when_team_broadcast() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "from:lead".into(),
+            text: "ping".into(),
+            kind: Some("query".into()),
+            timestamp: "2026-05-07T18:00:00Z".into(),
+            channel: None,
+            delivery_mode: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            attachments: vec![],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+            superseded_by: None,
+            from_id: None,
+            broadcast_context: Some(BroadcastContext {
+                team: Some("qa-test".to_string()),
+                targets: vec!["kiro-cli-ea377a".into(), "kiro-cli-4e8a78".into()],
+                count: 2,
+            }),
+        };
+        let header = format_header(&msg);
+        assert!(
+            header.contains("broadcast=2"),
+            "team broadcast must surface count: {header}"
+        );
+        assert!(
+            header.contains("team=qa-test"),
+            "team broadcast must surface team name (qa-test smoke success criteria): {header}"
+        );
+    }
+
+    /// Direct `targets=[…]` / `tags=[…]` fan-out has no team — header
+    /// gains `broadcast=N` only, no `team=`.
+    #[test]
+    fn test_header_format_includes_broadcast_only_when_targets_broadcast() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "from:dev".into(),
+            text: "fyi".into(),
+            kind: None,
+            timestamp: "2026-05-07T18:00:00Z".into(),
+            channel: None,
+            delivery_mode: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            attachments: vec![],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+            superseded_by: None,
+            from_id: None,
+            broadcast_context: Some(BroadcastContext {
+                team: None,
+                targets: vec!["a".into(), "b".into(), "c".into()],
+                count: 3,
+            }),
+        };
+        let header = format_header(&msg);
+        assert!(header.contains("broadcast=3"), "{header}");
+        assert!(
+            !header.contains("team="),
+            "no-team broadcast must not emit team= field: {header}"
+        );
+    }
+
+    /// Unicast must NOT surface broadcast/team fields — preserves the
+    /// pre-Sprint-54 header shape for non-broadcast callers (the
+    /// majority of SEND traffic).
+    #[test]
+    fn test_header_format_omits_broadcast_fields_when_unicast() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "from:dev".into(),
+            text: "hi".into(),
+            kind: None,
+            timestamp: "2026-05-07T18:00:00Z".into(),
+            channel: None,
+            delivery_mode: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            attachments: vec![],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+            superseded_by: None,
+            from_id: None,
+            broadcast_context: None,
+        };
+        let header = format_header(&msg);
+        assert!(
+            !header.contains("broadcast="),
+            "unicast must not emit broadcast= field: {header}"
+        );
+        assert!(
+            !header.contains("team="),
+            "unicast must not emit team= field: {header}"
+        );
+    }
+
+    /// Roundtrip: `broadcast_context` survives serde JSON encoding so the
+    /// inbox JSONL projection (visible via `inbox` MCP tool) matches the
+    /// PTY header. Absent field stays absent (no `null` leak).
+    #[test]
+    fn test_inbox_message_broadcast_context_serde_roundtrip() {
+        let with_ctx = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "from:lead".into(),
+            text: "t".into(),
+            kind: None,
+            timestamp: "2026-05-07T18:00:00Z".into(),
+            channel: None,
+            delivery_mode: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            attachments: vec![],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+            superseded_by: None,
+            from_id: None,
+            broadcast_context: Some(BroadcastContext {
+                team: Some("qa-test".to_string()),
+                targets: vec!["a".into(), "b".into()],
+                count: 2,
+            }),
+        };
+        let json = serde_json::to_string(&with_ctx).expect("ser");
+        assert!(json.contains("broadcast_context"));
+        assert!(json.contains("\"team\":\"qa-test\""));
+        let parsed: InboxMessage = serde_json::from_str(&json).expect("deser");
+        let parsed_ctx = parsed.broadcast_context.expect("ctx survived");
+        assert_eq!(parsed_ctx.team.as_deref(), Some("qa-test"));
+        assert_eq!(parsed_ctx.count, 2);
+        assert_eq!(parsed_ctx.targets, vec!["a", "b"]);
+
+        let without_ctx = InboxMessage {
+            broadcast_context: None,
+            ..with_ctx
+        };
+        let json2 = serde_json::to_string(&without_ctx).expect("ser");
+        assert!(
+            !json2.contains("broadcast_context"),
+            "absent field must not serialize as null: {json2}"
         );
     }
 
@@ -2227,6 +2458,7 @@ mod tests {
             in_reply_to_excerpt: Some("[bob] original".into()),
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let h = format_header(&msg);
         assert!(h.contains("reply_to_excerpt=[bob] original"), "{h}");
@@ -2325,6 +2557,7 @@ mod tests {
             in_reply_to_excerpt: Some("[b] line1\nline2".into()),
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let h = format_header(&msg);
         assert!(!h.contains('\n'), "must be single line: {h}");
@@ -2354,6 +2587,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2391,6 +2625,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2433,6 +2668,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2478,6 +2714,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2640,6 +2877,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: InboxMessage = serde_json::from_str(&json).unwrap();
@@ -2696,6 +2934,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         enqueue(&home, agent, msg1).unwrap();
         mark_ci_watch_superseded(&home, agent, "owner/repo@main", "new-msg-id");
@@ -2732,6 +2971,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         };
         let superseded = InboxMessage {
             schema_version: 0,
@@ -2754,6 +2994,7 @@ mod tests {
             in_reply_to_excerpt: None,
             superseded_by: Some("new-ci".into()),
             from_id: None,
+            broadcast_context: None,
         };
         enqueue(&home, agent, normal).unwrap();
         enqueue(&home, agent, superseded).unwrap();
@@ -2786,6 +3027,7 @@ mod tests {
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
             superseded_by: None,
+            broadcast_context: None,
         };
         let json = serde_json::to_string(&msg).expect("serialize");
         let parsed: InboxMessage = serde_json::from_str(&json).expect("deserialize");

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1107,6 +1107,7 @@ mod tests {
             in_reply_to_msg_id: None,
             in_reply_to_excerpt: None,
             superseded_by: None,
+            broadcast_context: None,
             from_id: None,
         };
         let header = crate::inbox::format_header(&sample_msg);

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -129,6 +129,7 @@ pub(super) fn handle_send_to_instance(
                 in_reply_to_excerpt: None,
                 superseded_by: None,
                 from_id: None,
+                broadcast_context: None,
             };
             crate::agent_ops::fallback_deliver(home, sender.as_str(), target, text, msg, &e)
         }
@@ -330,6 +331,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                 in_reply_to_excerpt: None,
                 superseded_by: None,
                 from_id: None,
+                broadcast_context: None,
             };
             crate::agent_ops::fallback_deliver(home, sender.as_str(), target, &msg, inbox_msg, &e)
         }
@@ -462,6 +464,7 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
                     in_reply_to_excerpt: None,
                     superseded_by: None,
                     from_id: None,
+                    broadcast_context: None,
                 };
                 crate::agent_ops::fallback_deliver(
                     home,
@@ -536,7 +539,7 @@ pub(super) fn handle_request_information(
     if let Some(ctx) = args["context"].as_str() {
         msg.push_str(&format!("\n\nContext: {ctx}"));
     }
-    send_to(home, sender, target, &msg, "query")
+    send_to(home, sender, target, &msg, "query", None)
 }
 
 pub(super) fn handle_broadcast(home: &Path, args: &Value, sender: &Option<Sender>) -> Value {
@@ -548,7 +551,8 @@ pub(super) fn handle_broadcast(home: &Path, args: &Value, sender: &Option<Sender
         None => return json!({"error": "missing 'message'"}),
     };
     // Resolve targets: team > targets > tags > all
-    let targets: Vec<String> = if let Some(team) = args["team"].as_str() {
+    let team_name = args["team"].as_str().map(String::from);
+    let targets: Vec<String> = if let Some(team) = team_name.as_deref() {
         crate::teams::get_members(home, team)
     } else if let Some(t) = args["targets"].as_array() {
         t.iter()
@@ -562,9 +566,18 @@ pub(super) fn handle_broadcast(home: &Path, args: &Value, sender: &Option<Sender
         .filter(|t| *sender != t.as_str())
         .collect();
     let kind = args["request_kind"].as_str().unwrap_or("update");
+    // Sprint 54 layer-5 broadcast visibility: build context once for the
+    // whole fan-out so each recipient's PTY header gets `broadcast=N`
+    // (and `team=NAME` when team-based) and inbox JSON gets the same
+    // metadata. Routing behavior unchanged.
+    let broadcast_ctx = crate::inbox::BroadcastContext {
+        team: team_name,
+        targets: targets.clone(),
+        count: targets.len(),
+    };
     let mut sent = Vec::new();
     for target in &targets {
-        let _ = send_to(home, sender, target, message, kind);
+        let _ = send_to(home, sender, target, message, kind, Some(&broadcast_ctx));
         sent.push(target.clone());
     }
     if !sent.is_empty() {

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -316,6 +316,7 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         },
     );
     tracing::info!(%name, %reason, "replace_instance");

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -961,6 +961,7 @@ fn agent_picked_up_emitted_on_inbox_drain() {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         },
     );
 
@@ -1023,6 +1024,7 @@ fn agent_picked_up_fires_for_all_pending_messages() {
             in_reply_to_excerpt: None,
             superseded_by: None,
             from_id: None,
+            broadcast_context: None,
         },
     );
 
@@ -1198,6 +1200,7 @@ fn test_describe_message_shows_delivery_mode() {
         in_reply_to_excerpt: None,
         superseded_by: None,
         from_id: None,
+        broadcast_context: None,
     };
     let inbox_dir = home.join("inbox");
     std::fs::create_dir_all(&inbox_dir).ok();

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -907,6 +907,7 @@ mod tests {
                     in_reply_to_excerpt: None,
                     superseded_by: None,
                     from_id: None,
+                    broadcast_context: None,
                 },
             );
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -322,6 +322,7 @@ fn test_inbox(home: &Path) -> TestResult {
                 in_reply_to_excerpt: None,
                 superseded_by: None,
                 from_id: None,
+                broadcast_context: None,
             },
         );
     }


### PR DESCRIPTION
## Summary
- Sprint 54 silent-drop class 6th instance (UX gap layer-5) — qa-test smoke 2026-05-07 17:55 UTC: `send(team=qa-test, ...)` correctly fan-out to 2 kiro recipients but `[AGEND-MSG]` header had no `team=` field and inbox JSON had no `broadcast_context` → broadcast indistinguishable from unicast at agent vantage.
- Same architectural shape as #501 (info correct at routing layer, dropped at PTY-inject formatter / inbox metadata projection); same precedent template (`src/inbox.rs`, additive struct field, conditional header field).
- Tier-1 single primary review (codex). Decision: `d-20260507180126194604-1`. Task: `t-20260507180159625181-1`.

## What changed
1. **`BroadcastContext { team, targets, count }` struct** in `src/inbox.rs` — additive serde, `team: Option<String>` (None for direct `targets=[…]` / `tags=[…]` modes).
2. **`InboxMessage.broadcast_context: Option<BroadcastContext>` field** — additive, `#[serde(default, skip_serializing_if = "Option::is_none")]`, mirroring `attachments` / `force_meta` / `correlation_id` / `reviewed_head` precedent.
3. **`format_header` (`src/inbox.rs`)** emits `broadcast=N` (when context Some) + `team=NAME` (only when team-based). Unicast unchanged. Same conditional pattern as #501 `attachments=[…]`.
4. **Plumbing**: `agent_ops::send_to` gains `Option<&BroadcastContext>` last arg; `mcp::handlers::comms::handle_broadcast` builds context once + threads it through per-target loop; `api::handlers::messaging::handle_send` reads `broadcast_context` from params + stamps `InboxMessage`.

## Header shape rationale
Chosen: `broadcast=N` always when context Some, plus `team=NAME` when team set.
- qa-test smoke success criteria explicitly says \"header carries team= field for broadcast (absent for unicast)\" — covered.
- `broadcast=N` adds the count even for direct-targets-mode broadcasts (no team) so agents know fan-out happened.
- Unicast: neither field — pre-Sprint-54 shape preserved for the majority of SEND traffic.

## Scope guardrail (per decision body)
- DO change: visibility-only metadata propagation.
- DO NOT change: `send` API surface routing behaviour; agent policy difference between broadcast vs unicast (visibility only); #501 layer-4 attachment indicator.

## Test plan
- [x] 4 new unit tests in src/inbox.rs (team broadcast / targets-only broadcast / unicast omits / serde roundtrip)
- [x] All 1616 binary unit tests pass; integration tests pass; cargo fmt + clippy --all-targets -D warnings clean
- [ ] **Phase 5 smoke (post-merge)**: `send(team=core-dev, ...)` self-broadcast — verify dev + reviewer PTY headers carry `team=core-dev` field

## Sprint 54 silent-drop class lineage
1. #495 daemon-state MCP silent fallback / 2. #497 telegram image-download / 3. #498 ci_watch malformed head / 4. #501 PTY-inject attachment-only ignored / 5. reserved / 6. **THIS** broadcast context dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)