### PR TITLE
refactor(teams): fleet.yaml teams unification — drop teams.json runtime store (Sprint 54)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -386,37 +386,25 @@ mod tests {
 
     // --- Sprint 37: team isolation gate tests ---
 
-    /// Set up fleet.yaml with given instances and teams.json with given teams.
+    /// Set up fleet.yaml with given instances and teams. Sprint 54
+    /// fleet-yaml unification: teams now live in the `teams:` block of
+    /// fleet.yaml directly (was: separate teams.json runtime store).
     fn setup_team_env(home: &std::path::Path, fleet_instances: &[&str], teams: &[(&str, &[&str])]) {
-        let fleet_yaml = fleet_instances
-            .iter()
-            .map(|n| format!("  {n}:\n    backend: claude"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        std::fs::write(
-            home.join("fleet.yaml"),
-            format!("instances:\n{fleet_yaml}\n"),
-        )
-        .ok();
-
-        if !teams.is_empty() {
-            let team_objs: Vec<serde_json::Value> = teams
-                .iter()
-                .map(|(name, members)| {
-                    json!({
-                        "name": name,
-                        "members": members,
-                        "created_at": "2026-01-01T00:00:00Z"
-                    })
-                })
-                .collect();
-            let store = json!({"schema_version": 1, "teams": team_objs});
-            std::fs::write(
-                home.join("teams.json"),
-                serde_json::to_string_pretty(&store).expect("json"),
-            )
-            .ok();
+        let mut yaml = String::from("instances:\n");
+        for n in fleet_instances {
+            yaml.push_str(&format!("  {n}:\n    backend: claude\n"));
         }
+        if !teams.is_empty() {
+            yaml.push_str("teams:\n");
+            for (name, members) in teams {
+                yaml.push_str(&format!("  {name}:\n    members:\n"));
+                for m in members.iter() {
+                    yaml.push_str(&format!("      - {m}\n"));
+                }
+                yaml.push_str("    created_at: \"2026-01-01T00:00:00Z\"\n");
+            }
+        }
+        std::fs::write(home.join("fleet.yaml"), yaml).ok();
     }
 
     fn audit_log_contains(home: &std::path::Path, kind: &str) -> bool {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -926,10 +926,10 @@ mod tests {
     fn dispatch_update_team_emits_members_changed() {
         let (port, home, notifier, shutdown) = start_test_server("dispatch-update-team");
         // First create a team via the teams store
-        let store_path = home.join("teams.json");
+        // Sprint 54 fleet-yaml unification: teams live in fleet.yaml.
         std::fs::write(
-            &store_path,
-            r#"{"schema_version":1,"teams":[{"name":"t1","members":["m1"],"created_at":"2026-01-01T00:00:00Z"}]}"#,
+            home.join("fleet.yaml"),
+            "teams:\n  t1:\n    members: [m1]\n    created_at: \"2026-01-01T00:00:00Z\"\n",
         )
         .unwrap();
 
@@ -1315,10 +1315,10 @@ mod tests {
     fn dispatch_update_team_remove_member() {
         let (port, home, notifier, shutdown) = start_test_server("ut-remove");
         // Pre-create team with members
-        let store_path = home.join("teams.json");
+        // Sprint 54 fleet-yaml unification: teams live in fleet.yaml.
         std::fs::write(
-            &store_path,
-            r#"{"schema_version":1,"teams":[{"name":"t1","members":["m1","m2"],"created_at":"2026-01-01T00:00:00Z"}]}"#,
+            home.join("fleet.yaml"),
+            "teams:\n  t1:\n    members: [m1, m2]\n    created_at: \"2026-01-01T00:00:00Z\"\n",
         )
         .unwrap();
 
@@ -1348,10 +1348,10 @@ mod tests {
     fn dispatch_update_team_noop_no_event() {
         let (port, home, notifier, shutdown) = start_test_server("ut-noop");
         // Pre-create team
-        let store_path = home.join("teams.json");
+        // Sprint 54 fleet-yaml unification: teams live in fleet.yaml.
         std::fs::write(
-            &store_path,
-            r#"{"schema_version":1,"teams":[{"name":"t1","members":["m1"],"created_at":"2026-01-01T00:00:00Z"}]}"#,
+            home.join("fleet.yaml"),
+            "teams:\n  t1:\n    members: [m1]\n    created_at: \"2026-01-01T00:00:00Z\"\n",
         )
         .unwrap();
 

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -145,11 +145,15 @@ pub(super) fn restore_with_reconciliation(
     cols: u16,
     rows: u16,
 ) -> bool {
-    let fleet = fleet::FleetConfig::load(fleet_path).ok();
-    // Reconcile fleet.yaml teams: section → teams.json (additive only)
-    if let Some(ref f) = fleet {
-        crate::teams::reconcile_teams(home, f);
+    // Sprint 54 fleet-yaml unification: one-shot migrate legacy
+    // teams.json runtime store into fleet.yaml `teams:` block. Runs
+    // before fleet.yaml load below so the merged `teams:` section is
+    // visible on first read. Idempotent — no-op once
+    // teams.json.migrated marker exists.
+    if let Err(e) = crate::fleet::migrate_teams_json_to_yaml(home) {
+        tracing::warn!(error = %e, "teams.json migration failed at session startup");
     }
+    let fleet = fleet::FleetConfig::load(fleet_path).ok();
     // Issue #474: defensive reconcile — prune deployment-store entries whose
     // member instances are no longer in fleet.yaml. Catches the case where
     // a previous session closed the last instance via TUI without going

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -208,8 +208,14 @@ pub fn run_with_prepared(mut prepared: Box<crate::bootstrap::OwnedFleet>) -> any
     let home = prepared.home.clone();
     let agents = std::mem::take(&mut prepared.agents);
     let telegram = prepared.telegram.clone();
-    // Reconcile fleet.yaml teams: section → teams.json (additive only)
-    crate::teams::reconcile_teams(&home, &prepared.config);
+    // Sprint 54 fleet-yaml unification: one-shot migrate legacy
+    // teams.json runtime store into fleet.yaml `teams:` block, then
+    // rename teams.json → teams.json.migrated (idempotent — no-op once
+    // .migrated exists). Post-migration, fleet.yaml IS the canonical
+    // store; no separate reconcile step needed.
+    if let Err(e) = crate::fleet::migrate_teams_json_to_yaml(&home) {
+        tracing::warn!(error = %e, "teams.json migration failed at daemon startup");
+    }
     let _owned = prepared;
     run_core(&home, agents, telegram)
 }

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -188,6 +188,12 @@ pub struct TeamConfig {
     pub orchestrator: Option<String>,
     #[serde(default)]
     pub description: Option<String>,
+    /// Sprint 54 fleet-yaml unification: team creation timestamp, preserved
+    /// from the runtime `teams.json` lineage. Optional so existing
+    /// fleet.yaml templates without the field still parse — runtime team
+    /// creation stamps it; operator-edited fleet.yaml entries may omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 impl FleetConfig {
@@ -578,6 +584,204 @@ pub fn update_instance_field(
     })
 }
 
+/// Sprint 54 fleet-yaml teams unification: serialize a `TeamConfig` to a
+/// `serde_yaml_ng::Mapping` for round-trip-safe insertion into the
+/// `teams:` block. Mirrors `add_instance_to_yaml`'s manual-mapping
+/// approach (avoids `to_value` re-roundtrip churn that could shift key
+/// ordering between writes).
+fn team_config_to_mapping(config: &TeamConfig) -> serde_yaml_ng::Mapping {
+    let mut team = serde_yaml_ng::Mapping::new();
+    let members_seq: Vec<serde_yaml_ng::Value> = config
+        .members
+        .iter()
+        .map(|m| serde_yaml_ng::Value::String(m.clone()))
+        .collect();
+    team.insert(
+        "members".into(),
+        serde_yaml_ng::Value::Sequence(members_seq),
+    );
+    if let Some(ref orch) = config.orchestrator {
+        team.insert(
+            "orchestrator".into(),
+            serde_yaml_ng::Value::String(orch.clone()),
+        );
+    }
+    if let Some(ref desc) = config.description {
+        team.insert(
+            "description".into(),
+            serde_yaml_ng::Value::String(desc.clone()),
+        );
+    }
+    if let Some(ref ts) = config.created_at {
+        team.insert(
+            "created_at".into(),
+            serde_yaml_ng::Value::String(ts.clone()),
+        );
+    }
+    team
+}
+
+/// Add a new team entry to fleet.yaml `teams:` block. Idempotent on
+/// caller side: returns `Ok(false)` if a team with this name already
+/// exists (so callers can surface the duplicate error to the user
+/// without losing the existing entry); returns `Ok(true)` on insert.
+/// Uses file lock + atomic write — same precedent as `add_instance_to_yaml`.
+pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<bool> {
+    let mut inserted = false;
+    mutate_fleet_yaml(home, "teams: {}\n", |doc| {
+        if doc.get("teams").is_none() {
+            doc["teams"] = serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new());
+        }
+        let teams = doc
+            .get_mut("teams")
+            .and_then(|v| v.as_mapping_mut())
+            .context("teams is not a mapping")?;
+        let key = serde_yaml_ng::Value::String(name.to_string());
+        if teams.contains_key(&key) {
+            return Ok(());
+        }
+        teams.insert(
+            key,
+            serde_yaml_ng::Value::Mapping(team_config_to_mapping(config)),
+        );
+        inserted = true;
+        tracing::info!(%name, "added team to fleet.yaml");
+        Ok(())
+    })?;
+    Ok(inserted)
+}
+
+/// Remove a team entry from fleet.yaml. Returns whether a team was
+/// actually removed (false when no such team existed). Uses file lock
+/// + atomic write — same precedent as `remove_instance_from_yaml`.
+pub fn remove_team_from_yaml(home: &Path, name: &str) -> Result<bool> {
+    let mut removed = false;
+    mutate_fleet_yaml(home, "", |doc| {
+        if let Some(teams) = doc.get_mut("teams").and_then(|v| v.as_mapping_mut()) {
+            if teams
+                .remove(serde_yaml_ng::Value::String(name.to_string()))
+                .is_some()
+            {
+                removed = true;
+                tracing::info!(%name, "removed team from fleet.yaml");
+            }
+        }
+        Ok(())
+    })?;
+    Ok(removed)
+}
+
+/// Replace an existing team's full config in fleet.yaml. Returns
+/// whether the team existed (false when no-op).
+///
+/// Used by `teams::update` + `teams::remove_member_from_all` after
+/// building the desired post-mutation state in memory — single
+/// round-trip, no field-level micro-mutation churn.
+pub fn update_team_in_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<bool> {
+    let mut existed = false;
+    mutate_fleet_yaml(home, "", |doc| {
+        if let Some(teams) = doc.get_mut("teams").and_then(|v| v.as_mapping_mut()) {
+            let key = serde_yaml_ng::Value::String(name.to_string());
+            if teams.contains_key(&key) {
+                teams.insert(
+                    key,
+                    serde_yaml_ng::Value::Mapping(team_config_to_mapping(config)),
+                );
+                existed = true;
+            }
+        }
+        Ok(())
+    })?;
+    Ok(existed)
+}
+
+/// Sprint 54 fleet-yaml teams unification: one-shot migration from the
+/// legacy `teams.json` runtime store into fleet.yaml's `teams:` block.
+/// Idempotent — re-running is a safe no-op once `teams.json.migrated`
+/// exists. Behavior:
+///
+/// - `teams.json` absent → no-op (already migrated, or fresh install)
+/// - `teams.json` present → load it, merge each team into fleet.yaml
+///   (skip teams already present in fleet.yaml — operator hand-edits win
+///   over runtime store), rename `teams.json` → `teams.json.migrated`
+///   (one-cycle safety, not deletion, per decision body).
+///
+/// Called from daemon startup before any team-touching path runs, so
+/// post-migration `teams::list` / `find_team_for` etc. read the unified
+/// fleet.yaml view.
+pub fn migrate_teams_json_to_yaml(home: &Path) -> Result<()> {
+    let teams_json = home.join("teams.json");
+    if !teams_json.exists() {
+        return Ok(());
+    }
+    let content = std::fs::read_to_string(&teams_json)
+        .with_context(|| format!("read teams.json: {}", teams_json.display()))?;
+    // Defensive parse: empty / malformed file → log + leave file in place,
+    // operator inspects manually rather than losing data.
+    #[derive(Deserialize)]
+    struct LegacyTeamStore {
+        #[serde(default)]
+        teams: Vec<LegacyTeam>,
+    }
+    #[derive(Deserialize)]
+    struct LegacyTeam {
+        name: String,
+        #[serde(default)]
+        members: Vec<String>,
+        #[serde(default)]
+        orchestrator: Option<String>,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default)]
+        created_at: Option<String>,
+    }
+    let store: LegacyTeamStore = match serde_json::from_str(&content) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %teams_json.display(),
+                "teams.json migration: parse failed, leaving file in place");
+            return Ok(());
+        }
+    };
+    if store.teams.is_empty() {
+        // Empty store — still rename so the no-op-on-rerun branch
+        // catches future startups instantly.
+        let migrated = home.join("teams.json.migrated");
+        std::fs::rename(&teams_json, &migrated)
+            .with_context(|| format!("rename {} → {}", teams_json.display(), migrated.display()))?;
+        tracing::info!("teams.json migration: empty store, renamed to .migrated");
+        return Ok(());
+    }
+    for team in &store.teams {
+        let cfg = TeamConfig {
+            members: team.members.clone(),
+            orchestrator: team.orchestrator.clone(),
+            description: team.description.clone(),
+            created_at: team.created_at.clone(),
+        };
+        // add_team_to_yaml is no-op when team already in fleet.yaml —
+        // operator hand-edits win, runtime store loses on conflict.
+        match add_team_to_yaml(home, &team.name, &cfg) {
+            Ok(true) => tracing::info!(name = %team.name, "migrated team to fleet.yaml"),
+            Ok(false) => tracing::info!(name = %team.name,
+                "team already in fleet.yaml, skipping migration entry"),
+            Err(e) => {
+                tracing::warn!(name = %team.name, error = %e,
+                    "team migration failed, leaving teams.json in place");
+                return Err(e);
+            }
+        }
+    }
+    let migrated = home.join("teams.json.migrated");
+    std::fs::rename(&teams_json, &migrated)
+        .with_context(|| format!("rename {} → {}", teams_json.display(), migrated.display()))?;
+    tracing::info!(
+        count = store.teams.len(),
+        "teams.json migration complete, renamed to .migrated"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -782,6 +986,207 @@ instances:
         let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
         assert_eq!(config.instances["agent1"].topic_id, Some(42));
 
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    // ─── Sprint 54 fleet-yaml teams unification ─────────────────────────
+
+    fn tmp_dir(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let id = C.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-team-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    #[test]
+    fn add_team_to_yaml_creates_entry_and_returns_true() {
+        let dir = tmp_dir("add_team");
+        let cfg = TeamConfig {
+            members: vec!["alice".into(), "bob".into()],
+            orchestrator: Some("alice".into()),
+            description: Some("dev squad".into()),
+            created_at: Some("2026-05-07T00:00:00Z".into()),
+        };
+        let inserted = add_team_to_yaml(&dir, "devs", &cfg).expect("add");
+        assert!(inserted);
+        let loaded = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        let team = loaded.teams.get("devs").expect("team present");
+        assert_eq!(team.members, vec!["alice", "bob"]);
+        assert_eq!(team.orchestrator.as_deref(), Some("alice"));
+        assert_eq!(team.created_at.as_deref(), Some("2026-05-07T00:00:00Z"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn add_team_to_yaml_duplicate_returns_false_without_overwrite() {
+        let dir = tmp_dir("dup");
+        let cfg1 = TeamConfig {
+            members: vec!["alice".into()],
+            orchestrator: Some("alice".into()),
+            description: None,
+            created_at: Some("2026-05-07T00:00:00Z".into()),
+        };
+        assert!(add_team_to_yaml(&dir, "devs", &cfg1).expect("first"));
+        let cfg2 = TeamConfig {
+            members: vec!["bob".into()],
+            orchestrator: Some("bob".into()),
+            description: None,
+            created_at: Some("2026-05-08T00:00:00Z".into()),
+        };
+        let inserted = add_team_to_yaml(&dir, "devs", &cfg2).expect("dup");
+        assert!(!inserted, "duplicate must report false (no insert)");
+        let loaded = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        let team = loaded.teams.get("devs").expect("team present");
+        assert_eq!(
+            team.members,
+            vec!["alice"],
+            "first writer wins — original entry preserved"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn remove_team_from_yaml_returns_whether_existed() {
+        let dir = tmp_dir("rm_team");
+        let cfg = TeamConfig {
+            members: vec!["alice".into()],
+            orchestrator: Some("alice".into()),
+            description: None,
+            created_at: None,
+        };
+        add_team_to_yaml(&dir, "devs", &cfg).expect("add");
+        assert!(remove_team_from_yaml(&dir, "devs").expect("rm"));
+        let loaded = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        assert!(loaded.teams.is_empty());
+        // Second remove → false
+        assert!(!remove_team_from_yaml(&dir, "devs").expect("rm-again"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn update_team_in_yaml_replaces_full_config() {
+        let dir = tmp_dir("upd_team");
+        let cfg = TeamConfig {
+            members: vec!["alice".into(), "bob".into()],
+            orchestrator: Some("alice".into()),
+            description: None,
+            created_at: Some("2026-05-07T00:00:00Z".into()),
+        };
+        add_team_to_yaml(&dir, "devs", &cfg).expect("add");
+        // Drop bob, reassign orch to alice (no-op), add carol.
+        let new_cfg = TeamConfig {
+            members: vec!["alice".into(), "carol".into()],
+            orchestrator: Some("alice".into()),
+            description: Some("post-update".into()),
+            created_at: cfg.created_at.clone(),
+        };
+        assert!(update_team_in_yaml(&dir, "devs", &new_cfg).expect("upd"));
+        let loaded = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        let team = loaded.teams.get("devs").expect("team present");
+        assert_eq!(team.members, vec!["alice", "carol"]);
+        assert_eq!(team.description.as_deref(), Some("post-update"));
+        // Update on missing team → false (no insert)
+        let new_cfg2 = TeamConfig {
+            members: vec!["x".into()],
+            orchestrator: None,
+            description: None,
+            created_at: None,
+        };
+        assert!(!update_team_in_yaml(&dir, "nonexistent", &new_cfg2).expect("upd-miss"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn migrate_teams_json_to_yaml_moves_teams_and_renames_marker() {
+        let dir = tmp_dir("migrate_present");
+        // Seed legacy teams.json
+        let legacy = r#"{"schema_version":1,"teams":[
+            {"name":"devs","members":["alice","bob"],"orchestrator":"alice","description":"the devs","created_at":"2026-05-07T00:00:00Z"},
+            {"name":"ops","members":["lead"],"orchestrator":"lead","created_at":"2026-05-07T01:00:00Z"}
+        ]}"#;
+        fs::write(dir.join("teams.json"), legacy).unwrap();
+        migrate_teams_json_to_yaml(&dir).expect("migrate");
+        // teams.json renamed
+        assert!(
+            !dir.join("teams.json").exists(),
+            "teams.json must be renamed"
+        );
+        assert!(dir.join("teams.json.migrated").exists(), "marker missing");
+        // fleet.yaml has both teams
+        let loaded = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        assert_eq!(loaded.teams.len(), 2);
+        let devs = loaded.teams.get("devs").expect("devs");
+        assert_eq!(devs.members, vec!["alice", "bob"]);
+        assert_eq!(devs.orchestrator.as_deref(), Some("alice"));
+        assert_eq!(devs.description.as_deref(), Some("the devs"));
+        assert_eq!(devs.created_at.as_deref(), Some("2026-05-07T00:00:00Z"));
+        let ops = loaded.teams.get("ops").expect("ops");
+        assert_eq!(ops.orchestrator.as_deref(), Some("lead"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn migrate_teams_json_to_yaml_idempotent_on_rerun() {
+        let dir = tmp_dir("migrate_idempotent");
+        fs::write(
+            dir.join("teams.json"),
+            r#"{"schema_version":1,"teams":[{"name":"devs","members":["a"],"orchestrator":"a","created_at":"x"}]}"#,
+        )
+        .unwrap();
+        migrate_teams_json_to_yaml(&dir).expect("first");
+        // Second run with no teams.json present → no-op, no error.
+        migrate_teams_json_to_yaml(&dir).expect("second");
+        let loaded = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        assert_eq!(loaded.teams.len(), 1, "no duplicate after re-run");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn migrate_teams_json_to_yaml_absent_is_noop() {
+        let dir = tmp_dir("migrate_absent");
+        // No teams.json — must not error, must not create fleet.yaml.
+        migrate_teams_json_to_yaml(&dir).expect("absent");
+        assert!(!dir.join("fleet.yaml").exists());
+        assert!(!dir.join("teams.json.migrated").exists());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn migrate_teams_json_to_yaml_preserves_existing_fleet_team() {
+        // Operator hand-edited fleet.yaml `teams:` entry must win over
+        // the same-name entry in legacy teams.json — operator wins on
+        // conflict, runtime store loses.
+        let dir = tmp_dir("migrate_conflict");
+        fs::write(
+            dir.join("fleet.yaml"),
+            "teams:\n  devs:\n    members: [hand-edited]\n    orchestrator: hand-edited\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("teams.json"),
+            r#"{"schema_version":1,"teams":[{"name":"devs","members":["alice","bob"],"orchestrator":"alice","created_at":"x"}]}"#,
+        )
+        .unwrap();
+        migrate_teams_json_to_yaml(&dir).expect("migrate");
+        let loaded = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        let team = loaded.teams.get("devs").expect("present");
+        assert_eq!(
+            team.members,
+            vec!["hand-edited"],
+            "operator hand-edit must survive migration: got {:?}",
+            team.members
+        );
+        // teams.json still gets renamed even on conflict (we treat the
+        // store as "consumed" once visited; .migrated marker stops
+        // future re-attempts from clobbering).
+        assert!(dir.join("teams.json.migrated").exists());
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1104,18 +1104,15 @@ fn test_delegate_task_resolves_team_to_orchestrator_inbox() {
     // verify the actual inbox recipient is the orchestrator.
     let _g = fleet_test_guard();
     let home = tmp_home("delegate-team");
-    // fleet.yaml for instance validation, teams.json for team resolution
+    // Sprint 54 fleet-yaml unification: instances + teams both live
+    // in fleet.yaml. resolve_team_orchestrator now reads from there.
     std::fs::write(
         home.join("fleet.yaml"),
-        "instances:\n  dev-lead:\n    backend: claude\n  dev-impl:\n    backend: claude\n",
+        "instances:\n  dev-lead:\n    backend: claude\n  dev-impl:\n    backend: claude\n\
+         teams:\n  dev:\n    members: [dev-lead, dev-impl]\n    \
+         orchestrator: dev-lead\n    created_at: \"2026-01-01T00:00:00Z\"\n",
     )
     .ok();
-    // teams.json is the runtime store used by resolve_team_orchestrator
-    std::fs::write(
-            home.join("teams.json"),
-            r#"{"schema_version":1,"teams":[{"name":"dev","members":["dev-lead","dev-impl"],"orchestrator":"dev-lead","description":null,"created_at":"2026-01-01T00:00:00Z"}]}"#,
-        )
-        .ok();
     std::env::set_var("AGEND_HOME", &home);
 
     let result = handle_tool(
@@ -1577,12 +1574,13 @@ fn test_old_inbox_json_with_interrupt_meta_deserializes_into_force_meta() {
 #[test]
 fn resolve_team_layout_auto_attaches_to_orchestrator() {
     let home = tmp_home("team_attach");
-    let team = serde_json::json!({
-        "name": "dev", "members": ["dev-lead", "dev-impl-1"],
-        "orchestrator": "dev-lead", "created_at": "2026-01-01T00:00:00Z"
-    });
-    let store = serde_json::json!({"teams": [team]});
-    std::fs::write(home.join("teams.json"), store.to_string()).expect("write");
+    // Sprint 54 fleet-yaml unification: teams in fleet.yaml.
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "teams:\n  dev:\n    members: [dev-lead, dev-impl-1]\n    \
+         orchestrator: dev-lead\n    created_at: \"2026-01-01T00:00:00Z\"\n",
+    )
+    .expect("write");
     let (layout, target) = resolve_team_layout(&home, "dev-impl-1", None, None);
     assert_eq!(layout, "split-right");
     assert_eq!(target.as_deref(), Some("dev-lead"));
@@ -1600,12 +1598,13 @@ fn resolve_team_layout_no_team_defaults_to_tab() {
 #[test]
 fn resolve_team_layout_caller_override_preserved() {
     let home = tmp_home("override");
-    let team = serde_json::json!({
-        "name": "dev", "members": ["dev-lead", "dev-impl-1"],
-        "orchestrator": "dev-lead", "created_at": "2026-01-01T00:00:00Z"
-    });
-    let store = serde_json::json!({"teams": [team]});
-    std::fs::write(home.join("teams.json"), store.to_string()).expect("write");
+    // Sprint 54 fleet-yaml unification: teams in fleet.yaml.
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "teams:\n  dev:\n    members: [dev-lead, dev-impl-1]\n    \
+         orchestrator: dev-lead\n    created_at: \"2026-01-01T00:00:00Z\"\n",
+    )
+    .expect("write");
     let layout_val = serde_json::json!("tab");
     let (layout, target) = resolve_team_layout(&home, "dev-impl-1", Some(&layout_val), None);
     assert_eq!(
@@ -2171,16 +2170,12 @@ fn broadcast_with_team_filter_targets_team_members() {
     let _g = fleet_test_guard();
     let home = tmp_home("bcast-team");
     std::env::set_var("AGEND_HOME", &home);
+    // Sprint 54 fleet-yaml unification: instances + teams in fleet.yaml.
     std::fs::write(
         home.join("fleet.yaml"),
-        "instances:\n  sender:\n    backend: claude\n  alice:\n    backend: claude\n  bob:\n    backend: claude\n",
-    )
-    .ok();
-    // Create a team
-    let store = json!({"schema_version": 1, "teams": [{"name": "dev2", "members": ["sender", "alice"], "created_at": "2026-01-01T00:00:00Z"}]});
-    std::fs::write(
-        home.join("teams.json"),
-        serde_json::to_string(&store).expect("json"),
+        "instances:\n  sender:\n    backend: claude\n  alice:\n    backend: claude\n  \
+         bob:\n    backend: claude\nteams:\n  dev2:\n    members: [sender, alice]\n    \
+         created_at: \"2026-01-01T00:00:00Z\"\n",
     )
     .ok();
     let sender = crate::identity::Sender::new("sender").expect("valid sender");
@@ -2474,24 +2469,11 @@ fn delegate_task_instance_first_bypasses_team_orchestrator_collision() {
     std::env::set_var("AGEND_HOME", &home);
     std::env::set_var("AGEND_TEST_ISOLATION", "1");
     // Fleet: instance "dev" exists, sender is "lead".
-    let yaml = "defaults:\n  backend: claude\ninstances:\n  dev:\n    role: Test\n  lead:\n    role: Test\n";
+    // Sprint 54 fleet-yaml unification: instances + teams both in fleet.yaml.
+    let yaml = "defaults:\n  backend: claude\ninstances:\n  dev:\n    role: Test\n  \
+                lead:\n    role: Test\nteams:\n  dev:\n    members: [lead, dev]\n    \
+                orchestrator: lead\n    created_at: \"2026-04-30T00:00:00Z\"\n";
     std::fs::write(home.join("fleet.yaml"), yaml).ok();
-    // Team fixture: team named "dev" with orchestrator "lead".
-    let teams = serde_json::json!({
-        "schema_version": 1,
-        "teams": [{
-            "name": "dev",
-            "members": ["lead", "dev"],
-            "orchestrator": "lead",
-            "description": null,
-            "created_at": "2026-04-30T00:00:00Z"
-        }]
-    });
-    std::fs::write(
-        home.join("teams.json"),
-        serde_json::to_string_pretty(&teams).unwrap(),
-    )
-    .ok();
 
     let result = handle_tool(
         "send",
@@ -2526,26 +2508,14 @@ fn m5_regression_via_id_routing() {
     std::env::set_var("AGEND_HOME", &home);
     std::env::set_var("AGEND_TEST_ISOLATION", "1");
     let id = crate::types::InstanceId::new();
+    // Sprint 54 fleet-yaml unification: instances + teams both in fleet.yaml.
     let yaml = format!(
-        "defaults:\n  backend: claude\ninstances:\n  dev:\n    id: \"{}\"\n    role: Test\n  lead:\n    role: Test\n",
+        "defaults:\n  backend: claude\ninstances:\n  dev:\n    id: \"{}\"\n    role: Test\n  \
+         lead:\n    role: Test\nteams:\n  dev:\n    members: [lead, dev]\n    \
+         orchestrator: lead\n    created_at: \"2026-04-30T00:00:00Z\"\n",
         id.full()
     );
     std::fs::write(home.join("fleet.yaml"), &yaml).ok();
-    let teams = serde_json::json!({
-        "schema_version": 1,
-        "teams": [{
-            "name": "dev",
-            "members": ["lead", "dev"],
-            "orchestrator": "lead",
-            "description": null,
-            "created_at": "2026-04-30T00:00:00Z"
-        }]
-    });
-    std::fs::write(
-        home.join("teams.json"),
-        serde_json::to_string_pretty(&teams).unwrap(),
-    )
-    .ok();
 
     let result = handle_tool(
         "send",

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -892,11 +892,17 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Sprint 23 P0 r2 F2 helper — populate `teams.json` store directly
-    /// (bypassing `teams::create` which validates fleet membership). Mirrors
-    /// the in-memory shape `crate::teams::TeamStore` deserialises from disk.
-    fn write_teams_store(home: &std::path::Path, teams_json: &str) {
-        std::fs::write(home.join("teams.json"), teams_json).expect("write teams.json");
+    /// Sprint 54 fleet-yaml unification: teams now live in fleet.yaml's
+    /// `teams:` block (was: separate `teams.json` runtime store).
+    /// Helper writes the dev team directly there, bypassing `teams::create`
+    /// validation paths so tests stay focused on `can_mutate_task` logic.
+    fn write_dev_team_to_fleet(home: &std::path::Path) {
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "teams:\n  dev:\n    members: [dev-lead, dev-impl-2]\n    \
+             orchestrator: dev-lead\n    created_at: \"2026-04-27T00:00:00Z\"\n",
+        )
+        .expect("write fleet.yaml");
     }
 
     #[test]
@@ -904,10 +910,7 @@ mod tests {
         // dev-lead is the orchestrator of the "dev" team; "dev-impl-2"
         // belongs to that team. Cross-team orchestrator path → pass.
         let home = tmp_home("can_mutate_orchestrator");
-        write_teams_store(
-            &home,
-            r#"{"schema_version":1,"teams":[{"name":"dev","members":["dev-lead","dev-impl-2"],"orchestrator":"dev-lead","description":null,"created_at":"2026-04-27T00:00:00Z"}]}"#,
-        );
+        write_dev_team_to_fleet(&home);
         let task = make_test_task(Some("dev-impl-2"));
         assert!(
             can_mutate_task(&home, "dev-lead", &task),
@@ -923,10 +926,7 @@ mod tests {
         // allowed to mutate even though their name doesn't match
         // `task.assignee`.
         let home = tmp_home("can_mutate_team_assignee");
-        write_teams_store(
-            &home,
-            r#"{"schema_version":1,"teams":[{"name":"dev","members":["dev-lead","dev-impl-2"],"orchestrator":"dev-lead","description":null,"created_at":"2026-04-27T00:00:00Z"}]}"#,
-        );
+        write_dev_team_to_fleet(&home);
         let task = make_test_task(Some("dev")); // assignee = team name
         assert!(
             can_mutate_task(&home, "dev-lead", &task),
@@ -1084,6 +1084,11 @@ mod tests {
     #[test]
     fn claim_clears_routed_to() {
         let home = tmp_home("claim_clears_rt");
+        // Sprint 54 fleet-yaml unification: teams::create now writes
+        // to fleet.yaml, so the claim path's instance_exists check fires
+        // (previously fleet.yaml stayed absent → permissive). Pre-seed
+        // instances so the claim by `worker` resolves to a fleet member.
+        write_fleet_yaml(&home, &["lead", "worker"]);
         crate::teams::create(
             &home,
             &serde_json::json!({"name": "devs", "members": ["lead", "worker"], "orchestrator": "lead"}),

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -1,4 +1,13 @@
 //! Team management — named groups of instances for broadcast targeting.
+//!
+//! Sprint 54 fleet-yaml unification: fleet.yaml `teams:` section is now
+//! the canonical store. Runtime CRUD writes there directly via
+//! `crate::fleet` helpers; the legacy `teams.json` runtime store is
+//! migrated one-shot at daemon startup
+//! (`crate::fleet::migrate_teams_json_to_yaml`) and renamed to
+//! `teams.json.migrated`. `reconcile_teams` (the previous
+//! seed-into-runtime bridge) is gone — operator-edited fleet.yaml is
+//! the source of truth, no separate normalization phase.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -21,38 +30,31 @@ impl Team {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct TeamStore {
-    #[serde(default)]
-    schema_version: u32,
-    teams: Vec<Team>,
+fn load_fleet(home: &Path) -> crate::fleet::FleetConfig {
+    crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap_or_default()
 }
 
-impl crate::store::SchemaVersioned for TeamStore {
-    const CURRENT: u32 = 1;
-    fn version_mut(&mut self) -> &mut u32 {
-        &mut self.schema_version
+/// Project a fleet.yaml `(name, TeamConfig)` pair into the public `Team`
+/// JSON shape used by `list` / `find_team_for`. `created_at` defaults
+/// to empty string when absent (operator-edited fleet.yaml entries may
+/// omit it; runtime-created teams always stamp it).
+fn project_team(name: &str, cfg: &crate::fleet::TeamConfig) -> Team {
+    Team {
+        name: name.to_string(),
+        members: cfg.members.clone(),
+        orchestrator: cfg.orchestrator.clone(),
+        description: cfg.description.clone(),
+        created_at: cfg.created_at.clone().unwrap_or_default(),
     }
 }
 
-fn store_path(home: &Path) -> std::path::PathBuf {
-    crate::store::store_path(home, "teams.json")
-}
-
-fn load(home: &Path) -> TeamStore {
-    crate::store::load_versioned(
-        &store_path(home),
-        <TeamStore as crate::store::SchemaVersioned>::CURRENT,
-    )
-}
-
-/// Find which team a member belongs to (one-agent-one-team).
-fn find_team_for_member(store: &TeamStore, name: &str) -> Option<String> {
-    store
+/// Find which team a member belongs to (one-agent-one-team invariant).
+fn find_team_for_member(fleet: &crate::fleet::FleetConfig, name: &str) -> Option<String> {
+    fleet
         .teams
         .iter()
-        .find(|t| t.members.contains(&name.to_string()))
-        .map(|t| t.name.clone())
+        .find(|(_, cfg)| cfg.members.iter().any(|m| m == name))
+        .map(|(team_name, _)| team_name.clone())
 }
 
 /// Return the full [`Team`] record for the team `member` belongs to,
@@ -60,11 +62,12 @@ fn find_team_for_member(store: &TeamStore, name: &str) -> Option<String> {
 /// `api::handlers::prepare_instructions` to split agend.md's peer list
 /// into team members vs other fleet agents.
 pub fn find_team_for(home: &Path, member: &str) -> Option<Team> {
-    let store = load(home);
-    store
+    let fleet = load_fleet(home);
+    fleet
         .teams
-        .into_iter()
-        .find(|t| t.members.iter().any(|m| m == member))
+        .iter()
+        .find(|(_, cfg)| cfg.members.iter().any(|m| m == member))
+        .map(|(name, cfg)| project_team(name, cfg))
 }
 
 pub fn create(home: &Path, args: &Value) -> Value {
@@ -89,28 +92,26 @@ pub fn create(home: &Path, args: &Value) -> Value {
         }
     }
 
+    let fleet = load_fleet(home);
+    if fleet.teams.contains_key(&name) {
+        return serde_json::json!({"error": format!("team '{name}' already exists")});
+    }
     let mut warnings: Vec<String> = Vec::new();
+    // One-agent-one-team check
+    for m in &members {
+        if let Some(existing_team) = find_team_for_member(&fleet, m) {
+            warnings.push(format!("member '{m}' already in team '{existing_team}'"));
+            return serde_json::json!({"error": warnings[0]});
+        }
+    }
 
-    match crate::store::mutate_versioned(&store_path(home), |store: &mut TeamStore| {
-        if store.teams.iter().any(|t| t.name == name) {
-            return Ok(false);
-        }
-        // One-agent-one-team check
-        for m in &members {
-            if let Some(existing_team) = find_team_for_member(store, m) {
-                warnings.push(format!("member '{m}' already in team '{existing_team}'"));
-                return Ok(false);
-            }
-        }
-        store.teams.push(Team {
-            name: name.clone(),
-            members,
-            orchestrator,
-            description,
-            created_at: chrono::Utc::now().to_rfc3339(),
-        });
-        Ok(true)
-    }) {
+    let cfg = crate::fleet::TeamConfig {
+        members,
+        orchestrator,
+        description,
+        created_at: Some(chrono::Utc::now().to_rfc3339()),
+    };
+    match crate::fleet::add_team_to_yaml(home, &name, &cfg) {
         Ok(true) => {
             let mut result = serde_json::json!({"status": "created", "name": name});
             if !warnings.is_empty() {
@@ -118,13 +119,8 @@ pub fn create(home: &Path, args: &Value) -> Value {
             }
             result
         }
-        Ok(false) => {
-            if !warnings.is_empty() {
-                serde_json::json!({"error": warnings[0]})
-            } else {
-                serde_json::json!({"error": format!("team '{name}' already exists")})
-            }
-        }
+        // Race: someone wrote the team between our check and write.
+        Ok(false) => serde_json::json!({"error": format!("team '{name}' already exists")}),
         Err(e) => serde_json::json!({"error": format!("{e}")}),
     }
 }
@@ -134,11 +130,7 @@ pub fn delete(home: &Path, args: &Value) -> Value {
         Some(n) => n.to_string(),
         None => return serde_json::json!({"error": "missing 'name'"}),
     };
-    match crate::store::mutate_versioned(&store_path(home), |store: &mut TeamStore| {
-        let before = store.teams.len();
-        store.teams.retain(|t| t.name != name);
-        Ok(store.teams.len() < before)
-    }) {
+    match crate::fleet::remove_team_from_yaml(home, &name) {
         Ok(true) => serde_json::json!({"status": "deleted", "name": name}),
         Ok(false) => serde_json::json!({"error": format!("team '{name}' not found")}),
         Err(e) => serde_json::json!({"error": format!("{e}")}),
@@ -147,13 +139,16 @@ pub fn delete(home: &Path, args: &Value) -> Value {
 
 /// Return all teams as typed structs.
 pub fn list_all(home: &Path) -> Vec<Team> {
-    load(home).teams
+    let fleet = load_fleet(home);
+    fleet
+        .teams
+        .iter()
+        .map(|(name, cfg)| project_team(name, cfg))
+        .collect()
 }
 
 pub fn list(home: &Path) -> Value {
-    let store = load(home);
-    let teams: Vec<Value> = store
-        .teams
+    let teams: Vec<Value> = list_all(home)
         .iter()
         .map(|t| {
             let mut v = serde_json::to_value(t).unwrap_or_default();
@@ -187,89 +182,94 @@ pub fn update(home: &Path, args: &Value) -> Value {
         .unwrap_or_default();
     let new_orchestrator = args["orchestrator"].as_str().map(String::from);
 
-    // Pre-check: cannot remove orchestrator
-    // (done inside mutate to see current state)
+    let fleet = load_fleet(home);
+    let Some(current) = fleet.teams.get(&name).cloned() else {
+        return serde_json::json!({"error": format!("team '{name}' not found")});
+    };
 
-    match crate::store::mutate_versioned(&store_path(home), |store: &mut TeamStore| {
-        let team_idx = match store.teams.iter().position(|t| t.name == name) {
-            Some(i) => i,
-            None => return Ok(false),
-        };
-        // Block removing the orchestrator
-        if let Some(ref orch) = store.teams[team_idx].orchestrator {
-            if to_remove.contains(orch) {
-                return Ok(false);
+    // Block removing the orchestrator
+    if let Some(ref orch) = current.orchestrator {
+        if to_remove.contains(orch) {
+            return serde_json::json!({
+                "error": format!("cannot remove orchestrator '{orch}'; use update_team --orchestrator to reassign first")
+            });
+        }
+    }
+    // One-agent-one-team check on adds
+    for m in &to_add {
+        if let Some(existing) = find_team_for_member(&fleet, m) {
+            if existing != name {
+                return serde_json::json!({"error": format!("member '{m}' already in team '{existing}'")});
             }
         }
-        // One-agent-one-team check on adds
-        for m in &to_add {
-            if let Some(existing) = find_team_for_member(store, m) {
-                if existing != name {
-                    return Ok(false);
-                }
-            }
+    }
+    // Validate new orchestrator membership against the post-mutation
+    // member set so reassign-then-add transactions don't bounce.
+    let mut new_members = current.members.clone();
+    for m in &to_add {
+        if !new_members.contains(m) {
+            new_members.push(m.clone());
         }
-        let team = &mut store.teams[team_idx];
-        for m in &to_add {
-            if !team.members.contains(m) {
-                team.members.push(m.clone());
-            }
+    }
+    new_members.retain(|m| !to_remove.contains(m));
+    let resolved_orch = if let Some(ref new_orch) = new_orchestrator {
+        if !new_members.contains(new_orch) {
+            return serde_json::json!({"error": format!("new orchestrator '{new_orch}' must be a current member")});
         }
-        team.members.retain(|m| !to_remove.contains(m));
-        // Change orchestrator
-        if let Some(ref new_orch) = new_orchestrator {
-            if !team.members.contains(new_orch) {
-                return Ok(false);
-            }
-            team.orchestrator = Some(new_orch.clone());
-        }
-        Ok(true)
-    }) {
+        Some(new_orch.clone())
+    } else {
+        current.orchestrator.clone()
+    };
+
+    let cfg = crate::fleet::TeamConfig {
+        members: new_members,
+        orchestrator: resolved_orch,
+        description: current.description.clone(),
+        created_at: current.created_at.clone(),
+    };
+    match crate::fleet::update_team_in_yaml(home, &name, &cfg) {
         Ok(true) => serde_json::json!({"status": "updated", "name": name}),
-        Ok(false) => {
-            // Determine specific error
-            let store = load(home);
-            let team = match store.teams.iter().find(|t| t.name == name) {
-                Some(t) => t,
-                None => return serde_json::json!({"error": format!("team '{name}' not found")}),
-            };
-            if let Some(ref orch) = team.orchestrator {
-                if to_remove.contains(orch) {
-                    return serde_json::json!({"error": format!("cannot remove orchestrator '{orch}'; use update_team --orchestrator to reassign first")});
-                }
-            }
-            for m in &to_add {
-                if let Some(existing) = find_team_for_member(&store, m) {
-                    if existing != name {
-                        return serde_json::json!({"error": format!("member '{m}' already in team '{existing}'")});
-                    }
-                }
-            }
-            if let Some(ref new_orch) = new_orchestrator {
-                if !team.members.contains(new_orch) {
-                    return serde_json::json!({"error": format!("new orchestrator '{new_orch}' must be a current member")});
-                }
-            }
-            serde_json::json!({"error": "update failed"})
-        }
+        // Disappeared between load and write.
+        Ok(false) => serde_json::json!({"error": format!("team '{name}' not found")}),
         Err(e) => serde_json::json!({"error": format!("{e}")}),
     }
 }
 
 /// Remove an instance from ALL teams. Auto-delete teams that become empty.
 pub fn remove_member_from_all(home: &Path, instance_name: &str) {
+    let fleet = load_fleet(home);
     let mut degraded_teams: Vec<String> = Vec::new();
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut TeamStore| {
-        for team in &mut store.teams {
-            team.members.retain(|m| m != instance_name);
-            if team.orchestrator.as_deref() == Some(instance_name) {
-                team.orchestrator = None;
-                degraded_teams.push(team.name.clone());
-            }
+    for (team_name, cfg) in &fleet.teams {
+        let in_team = cfg.members.iter().any(|m| m == instance_name);
+        let is_orch = cfg.orchestrator.as_deref() == Some(instance_name);
+        if !in_team && !is_orch {
+            continue;
         }
-        store.teams.retain(|t| !t.members.is_empty());
-        Ok(true)
-    });
+        let new_members: Vec<String> = cfg
+            .members
+            .iter()
+            .filter(|m| *m != instance_name)
+            .cloned()
+            .collect();
+        if new_members.is_empty() {
+            // Last member leaving — drop the team entirely.
+            let _ = crate::fleet::remove_team_from_yaml(home, team_name);
+            continue;
+        }
+        let new_orch = if is_orch {
+            degraded_teams.push(team_name.clone());
+            None
+        } else {
+            cfg.orchestrator.clone()
+        };
+        let new_cfg = crate::fleet::TeamConfig {
+            members: new_members,
+            orchestrator: new_orch,
+            description: cfg.description.clone(),
+            created_at: cfg.created_at.clone(),
+        };
+        let _ = crate::fleet::update_team_in_yaml(home, team_name, &new_cfg);
+    }
     // Create urgent task for each newly degraded team
     for team_name in &degraded_teams {
         crate::tasks::handle(
@@ -284,53 +284,13 @@ pub fn remove_member_from_all(home: &Path, instance_name: &str) {
     }
 }
 
-/// Reconcile teams from fleet.yaml seed config. Additive only — runtime-added
-/// members are preserved; only missing seed members are added.
-pub fn reconcile_teams(home: &Path, fleet: &crate::fleet::FleetConfig) {
-    for (name, seed) in &fleet.teams {
-        let existing = get_members(home, name);
-        if existing.is_empty() {
-            create(
-                home,
-                &serde_json::json!({
-                    "name": name,
-                    "members": seed.members,
-                    "orchestrator": seed.orchestrator,
-                    "description": seed.description,
-                }),
-            );
-        } else {
-            let missing: Vec<&String> = seed
-                .members
-                .iter()
-                .filter(|m| !existing.contains(m))
-                .collect();
-            if !missing.is_empty() {
-                update(home, &serde_json::json!({ "name": name, "add": missing }));
-            }
-            // Reconcile orchestrator if set in fleet.yaml but not in store
-            if let Some(ref orch) = seed.orchestrator {
-                let store = load(home);
-                if let Some(team) = store.teams.iter().find(|t| t.name == *name) {
-                    if team.orchestrator.is_none() {
-                        update(
-                            home,
-                            &serde_json::json!({ "name": name, "orchestrator": orch }),
-                        );
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// Resolve an assignee name: if it's a team, return the orchestrator.
 /// Returns Ok(Some(orchestrator)) if team found, Ok(None) if not a team,
 /// Err if team is degraded.
 pub fn resolve_team_orchestrator(home: &Path, name: &str) -> Result<Option<String>, String> {
-    let store = load(home);
-    match store.teams.iter().find(|t| t.name == name) {
-        Some(team) => match &team.orchestrator {
+    let fleet = load_fleet(home);
+    match fleet.teams.get(name) {
+        Some(cfg) => match &cfg.orchestrator {
             Some(orch) => Ok(Some(orch.clone())),
             None => Err(format!(
                 "team '{name}' is degraded (no orchestrator), cannot route task"
@@ -342,20 +302,18 @@ pub fn resolve_team_orchestrator(home: &Path, name: &str) -> Result<Option<Strin
 
 /// Check if `caller` is the orchestrator of any team that `member` belongs to.
 pub fn is_orchestrator_of(home: &Path, caller: &str, member: &str) -> bool {
-    let store = load(home);
-    store.teams.iter().any(|t| {
-        t.members.contains(&member.to_string()) && t.orchestrator.as_deref() == Some(caller)
+    let fleet = load_fleet(home);
+    fleet.teams.values().any(|cfg| {
+        cfg.members.contains(&member.to_string()) && cfg.orchestrator.as_deref() == Some(caller)
     })
 }
 
 /// Get members of a team.
 pub fn get_members(home: &Path, team_name: &str) -> Vec<String> {
-    let store = load(home);
-    store
+    load_fleet(home)
         .teams
-        .iter()
-        .find(|t| t.name == team_name)
-        .map(|t| t.members.clone())
+        .get(team_name)
+        .map(|cfg| cfg.members.clone())
         .unwrap_or_default()
 }
 
@@ -515,75 +473,6 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    fn make_fleet(teams: &[(&str, &[&str], Option<&str>)]) -> crate::fleet::FleetConfig {
-        let mut map = std::collections::HashMap::new();
-        for (name, members, orch) in teams {
-            map.insert(
-                name.to_string(),
-                crate::fleet::TeamConfig {
-                    members: members.iter().map(|s| s.to_string()).collect(),
-                    orchestrator: orch.map(|s| s.to_string()),
-                    description: None,
-                },
-            );
-        }
-        crate::fleet::FleetConfig {
-            teams: map,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn fleet_yaml_teams_creates_on_startup() {
-        let home = tmp_home("reconcile_create");
-        let fleet = make_fleet(&[("devs", &["alice", "bob"], Some("alice"))]);
-        reconcile_teams(&home, &fleet);
-        let members = get_members(&home, "devs");
-        assert_eq!(members, vec!["alice", "bob"]);
-        let listed = list(&home);
-        assert_eq!(listed["teams"][0]["orchestrator"], "alice");
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    #[test]
-    fn fleet_yaml_teams_additive_reconcile() {
-        let home = tmp_home("reconcile_additive");
-        create(
-            &home,
-            &serde_json::json!({"name": "devs", "members": ["alice", "runtime-extra"], "orchestrator": "alice"}),
-        );
-        let fleet = make_fleet(&[("devs", &["alice", "bob"], Some("alice"))]);
-        reconcile_teams(&home, &fleet);
-        let members = get_members(&home, "devs");
-        assert!(members.contains(&"alice".to_string()));
-        assert!(members.contains(&"bob".to_string()));
-        assert!(members.contains(&"runtime-extra".to_string()));
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    #[test]
-    fn fleet_yaml_teams_idempotent() {
-        let home = tmp_home("reconcile_idempotent");
-        let fleet = make_fleet(&[("devs", &["alice"], Some("alice"))]);
-        reconcile_teams(&home, &fleet);
-        reconcile_teams(&home, &fleet);
-        let listed = list(&home);
-        let teams = listed["teams"].as_array().expect("teams");
-        assert_eq!(teams.len(), 1, "should not duplicate team");
-        assert_eq!(get_members(&home, "devs"), vec!["alice"]);
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    #[test]
-    fn fleet_yaml_reconcile_with_orchestrator() {
-        let home = tmp_home("reconcile_orch");
-        let fleet = make_fleet(&[("ops", &["lead", "worker"], Some("lead"))]);
-        reconcile_teams(&home, &fleet);
-        let listed = list(&home);
-        assert_eq!(listed["teams"][0]["orchestrator"], "lead");
-        std::fs::remove_dir_all(&home).ok();
-    }
-
     #[test]
     fn create_without_orchestrator_still_works() {
         // Backward compat: orchestrator is optional at data level
@@ -654,6 +543,23 @@ mod tests {
         remove_member_from_all(&home, "lead");
         let listed = list(&home);
         assert_eq!(listed["teams"][0]["degraded"], true);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Sprint 54 fleet-yaml unification: operator hand-editing fleet.yaml
+    /// `teams:` block must surface immediately on next read — no separate
+    /// reconcile step required. Locks the contract between fleet.rs
+    /// `add_team_to_yaml` writer and `find_team_for` / `get_members`
+    /// readers (both go through `FleetConfig::load`).
+    #[test]
+    fn fleet_yaml_seed_team_visible_on_first_read() {
+        let home = tmp_home("seed_visible");
+        let yaml = "teams:\n  ops:\n    members: [alice, bob]\n    orchestrator: alice\n";
+        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        let members = get_members(&home, "ops");
+        assert_eq!(members, vec!["alice", "bob"]);
+        let listed = list(&home);
+        assert_eq!(listed["teams"][0]["orchestrator"], "alice");
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/tests/mcp_characterization.rs
+++ b/tests/mcp_characterization.rs
@@ -415,28 +415,48 @@ fn replace_instance_returns_error_when_daemon_down() {
 // ---------------------------------------------------------------------------
 // Priority: team > targets > (all). Self is always excluded.
 
-/// Helper: create a team by writing directly to the teams store file.
+/// Helper: create a team by appending it to fleet.yaml's `teams:` block.
+/// Sprint 54 fleet-yaml unification — teams.json is gone; fleet.yaml is
+/// the canonical store. We round-trip through serde_yaml_ng (rather
+/// than string concatenation) so the helper handles both fresh and
+/// pre-populated fleet.yaml correctly.
 fn setup_team(home: &std::path::Path, name: &str, members: &[&str]) {
-    let store_path = home.join("teams.json");
-    let members_json: Vec<Value> = members.iter().map(|m| json!(m)).collect();
-    let store = if store_path.exists() {
-        let content = std::fs::read_to_string(&store_path).unwrap_or_default();
-        serde_json::from_str::<Value>(&content).unwrap_or(json!({"schema_version": 1, "teams": []}))
+    let fleet_path = home.join("fleet.yaml");
+    let mut doc: serde_yaml_ng::Value = if fleet_path.exists() {
+        let content = std::fs::read_to_string(&fleet_path).expect("read fleet.yaml");
+        serde_yaml_ng::from_str(&content).expect("parse fleet.yaml")
     } else {
-        json!({"schema_version": 1, "teams": []})
+        serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new())
     };
-    let mut teams = store["teams"].as_array().cloned().unwrap_or_default();
-    teams.push(json!({
-        "name": name,
-        "members": members_json,
-        "created_at": "2026-01-01T00:00:00Z"
-    }));
-    let new_store = json!({"schema_version": 1, "teams": teams});
+    if doc.get("teams").is_none() {
+        doc["teams"] = serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new());
+    }
+    let teams = doc
+        .get_mut("teams")
+        .and_then(|v| v.as_mapping_mut())
+        .expect("teams mapping");
+    let mut entry = serde_yaml_ng::Mapping::new();
+    let members_seq: Vec<serde_yaml_ng::Value> = members
+        .iter()
+        .map(|m| serde_yaml_ng::Value::String((*m).to_string()))
+        .collect();
+    entry.insert(
+        serde_yaml_ng::Value::String("members".into()),
+        serde_yaml_ng::Value::Sequence(members_seq),
+    );
+    entry.insert(
+        serde_yaml_ng::Value::String("created_at".into()),
+        serde_yaml_ng::Value::String("2026-01-01T00:00:00Z".into()),
+    );
+    teams.insert(
+        serde_yaml_ng::Value::String(name.to_string()),
+        serde_yaml_ng::Value::Mapping(entry),
+    );
     std::fs::write(
-        &store_path,
-        serde_json::to_string_pretty(&new_store).expect("json"),
+        &fleet_path,
+        serde_yaml_ng::to_string(&doc).expect("serialize fleet.yaml"),
     )
-    .expect("write teams.json");
+    .expect("write fleet.yaml");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- **Operator constraint** per `d-20260507184947833646-2`: teams data lived in two places (fleet.yaml `teams:` seed + `teams.json` runtime store). Operator wants single canonical file. Pattern is precedent-perfect: instances already have runtime mutators in fleet.rs (`add/remove_instance_from_yaml` + `update_instance_field`); teams gets the same shape.
- **Tier-1 single primary** (codex). Decision: `d-20260507184947833646-2`. Task: `t-20260507185023124926-2`.

## What changed
1. **`src/fleet.rs` +405**:
   - `TeamConfig.created_at: Option<String>` (additive, backward-compat)
   - 3 helpers mirroring `add_instance_to_yaml` / `remove_instance_from_yaml` / `update_instance_field` precedent (L497/537/563): `add_team_to_yaml`, `remove_team_from_yaml`, `update_team_in_yaml` (all return `Result<bool>` indicating whether-mutated)
   - `migrate_teams_json_to_yaml(home)` one-shot: idempotent — absent teams.json = no-op; present = parse + merge (operator hand-edits in fleet.yaml win on name conflict per add_team_to_yaml first-writer-wins) + rename `teams.json` → `teams.json.migrated` (one-cycle safety per decision body, **not** deletion)
   - 7 new unit tests covering: add roundtrip, duplicate-no-overwrite, remove returns existed bool, update full-replace, migration full path, idempotent rerun, absent no-op, conflict preserves operator edit
2. **`src/teams.rs` rewrite**: drop `TeamStore` + all `crate::store::mutate_versioned` calls. CRUD writes via fleet.yaml helpers; reads via `FleetConfig::load`. New `fleet_yaml_seed_team_visible_on_first_read` test locks the writer-reader contract.
3. **Startup hook swap** (`daemon/mod.rs:211` + `app/session.rs:149`): `reconcile_teams(home, &fleet)` → `migrate_teams_json_to_yaml(home)` (runs before fleet.yaml load so the merged `teams:` section is visible on first read).
4. **`reconcile_teams` deleted**: post-migration there is no seed→runtime bridge to maintain. Operator-edited fleet.yaml is the canonical source; `find_team_for` / `get_members` etc. read it directly. Dev judgment per decision body — deletion justified, not kept-and-renamed.
5. **8 test setup sites adjusted**: `api/handlers/messaging.rs::setup_team_env`, `api/mod.rs` x3 (dispatch_update_team_*), `mcp/handlers/tests.rs` x4 (delegate_to_team / resolve_team_layout x2 / handle_broadcast / m5 routing x2), `tasks.rs::write_dev_team_to_fleet` (renamed from write_teams_store), `tests/mcp_characterization.rs::setup_team` — all swap teams.json writes for fleet.yaml `teams:` block writes.
6. **`tasks::tests::claim_clears_routed_to` fix**: my new `teams::create` creates fleet.yaml as a side-effect (was: only teams.json). The claim path's `instance_exists` check now fires (previously: no fleet.yaml → permissive). Pre-seed `write_fleet_yaml(&home, &[\"lead\", \"worker\"])` so `worker` resolves.

## Reconcile_teams disposition (rationale per lead's keep-or-delete prompt)
**Deleted** (not keep+rename). Post-migration:
- Read path already goes through `FleetConfig::load` directly — operator hand-edit surfaces immediately, no normalization needed.
- `created_at` backfill is cosmetic only (runtime CRUD stamps it; operator-omitted is fine — `Option<String>`).
- Duplicate team name: `serde_yaml_ng` mapping is last-key-wins on parse — log-warn could be added later but isn't bridge work.
- No remaining seed→runtime distinction; bridge is dead code.

## Scope guardrail
- DO change: persistence backend (teams.json → fleet.yaml `teams:` block).
- DO NOT change: API surface (CRUD signatures unchanged), agent policy (one-agent-one-team / orchestrator-required-in-members invariants preserved), `serde_yaml_ng` only (no new YAML lib).

## Test plan
- [x] 7 new fleet.rs unit tests + 1 new teams.rs seed-visibility test
- [x] All 1621 binary unit tests pass; integration suite passes; cargo fmt + clippy --all-targets -D warnings clean
- [x] LOC budget: net +304 (within ≤400 ceiling)
- [ ] **Phase 5 smoke (operator-restart-deferred per decision body)** — recipe verbatim runnable post-merge:
  1. `mv teams.json.migrated teams.json` (re-arm migration if previously consumed)
  2. Restart daemon (or session)
  3. Observe \`tracing\` log: `teams.json migration complete, renamed to .migrated`
  4. `cat fleet.yaml` — confirm `teams:` section populated
  5. `ls teams.json*` — confirm only `.migrated` remains
  6. MCP `team(action=list)` — round-trip, teams visible
  7. MCP `team(action=create, name=foo, members=[…])` — confirm new entry in fleet.yaml `teams:`

## Tier rationale (Tier-1 single primary)
- Precedent 1:1 fit (`mutate_fleet_yaml` instances → teams parallel)
- No new YAML lib / no new architectural surface
- Migration one-shot idempotent + .migrated rename (no-data-loss path)
- LOC 304 < 400 ceiling
- Cross-module impact = rewrite/swap (fleet.rs / teams.rs / daemon / session / tests) but bounded — single concept "teams persistence canonical swap"

## Reviewer focus checklist (lead's recommendation to codex)
- Migration idempotency + .migrated rename safety (re-run no data loss)
- `reconcile_teams` deletion: full-codebase grep for missed callers
- Production test fix `claim_clears_routed_to` side-effect: any other untested path that relies on absent fleet.yaml side-step?
- Backward-compat: existing fleet.yaml without `teams:` field still loads (HashMap::default empty map)
- 8 test sites swap soundness (each setup helper rewriting fleet.yaml is cohesive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)