### PR TITLE
test(invariant): Cargo.toml [package].include coverage check (closes #505 Phase 2 deferred — silent-drop class 5th instance)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "embed-resource",
  "fs4",
  "getrandom 0.3.4",
+ "glob",
  "hex",
  "iana-time-zone",
  "insta",
@@ -1438,6 +1439,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gobject-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ tokio = { version = "1", features = ["rt", "net", "io-util", "fs", "macros", "ti
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-syn = { version = "2", features = ["parsing", "full"] }
+syn = { version = "2", features = ["parsing", "full", "visit"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 serde_yaml_ng = "0.10"
 
@@ -141,6 +141,10 @@ proptest = "1.4"
 # Used only for asserting that codex_trust_directory writes syntactically
 # valid TOML — the prod code appends raw text, it doesn't depend on this crate.
 toml = "0.8"
+# Sprint 54 P1-A — `tests/cargo_include_invariant.rs` matches resolved
+# `include_str!` paths against `[package].include` glob patterns
+# (e.g. `src/**/*.rs`, `assets/hooks/*`). Test-only.
+glob = "0.3"
 # Log-capture for failure-visibility regression pins (DESIGN-stage-b-ux.md
 # §7 PR-C names `tracing-test` as the sanctioned approach for asserting
 # `tracing::warn!` records are actually emitted).

--- a/tests/cargo_include_invariant.rs
+++ b/tests/cargo_include_invariant.rs
@@ -1,0 +1,341 @@
+//! Cargo.toml `[package].include` invariant — prevents publish-blocker
+//! regression for the silent-drop class 5th instance pattern.
+//!
+//! ## Why this exists
+//! The `cargo publish` verify step builds from the packaged tarball, NOT
+//! the source tree. Any production `include_str!` / `include_bytes!` macro
+//! pointing at a path NOT in `[package].include` fails verbatim with
+//! `couldn't read src/../assets/hooks/...` during publish. Caught the
+//! hard way at:
+//! - **v0.4.0** — `docs/FLEET-DEV-PROTOCOL-v1.md` missing from include
+//! - **v0.6.0** — `assets/hooks/*` missing (publish-blocker hotfix #505)
+//!
+//! Per #505 commit `2c124c0`: "Phase 2 invariant test (grep `include_str!`
+//! against include list) deferred to Sprint 55 / v0.6.1." This test
+//! discharges that deferral. Documented in
+//! `d-20260507062618667443-1` (silent-drop systematic ledger entry #5).
+//!
+//! ## What it checks
+//! For every production `include_str!` / `include_bytes!` macro literal
+//! in `src/**/*.rs`, the resolved absolute-from-repo-root path must be
+//! covered by at least one glob pattern in `[package].include`.
+//!
+//! Test-only macros (inside `#[cfg(test)]` modules, in test-only files
+//! declared via `#[cfg(test)] mod NAME;` from a parent, or in test
+//! fixture-loading sites) are ignored — they never see a `cargo publish`
+//! tarball and are free to point anywhere in the workspace.
+//!
+//! ## How the regression-proof works
+//! `mock_invariant_fires_when_assets_hooks_removed_from_include` calls
+//! the SAME `scan_production_violations` entry point as the prod test
+//! but feeds it a hand-mutated include list with `assets/hooks/*`
+//! removed — expects the resulting violation list to surface the
+//! `prepare-commit-msg` paths verbatim. Same code path, no
+//! mock-only branches.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use syn::{visit::Visit, Macro};
+
+const SRC_DIR: &str = "src";
+
+/// Walk every `.rs` file under `src/` (recursive). Mirrors the helper
+/// used by `tests/anti_pattern_invariant.rs`.
+fn rs_files_under(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(p);
+            }
+        }
+    }
+    walk(root, &mut out);
+    out
+}
+
+/// True iff any `cfg(test)` reference appears in `attrs`. Covers
+/// `#[cfg(test)]`, `#[cfg(any(test, …))]`, `#[cfg(all(test, …))]`,
+/// `#[cfg(not(not(test)))]`, etc. — we string-match the attribute's
+/// token stream rather than chase syn's Meta tree, since any mention
+/// of `test` inside a `cfg(...)` predicate is a strong test-only
+/// signal in practice.
+fn attrs_contain_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        if !a.path().is_ident("cfg") {
+            return false;
+        }
+        let syn::Meta::List(list) = &a.meta else {
+            return false;
+        };
+        list.tokens
+            .to_string()
+            .split(|c: char| !c.is_alphanumeric() && c != '_')
+            .any(|tok| tok == "test")
+    })
+}
+
+/// Collects every `include_str!("…")` / `include_bytes!("…")` literal
+/// reachable from production code in a single source file. Items
+/// inside `#[cfg(test)]` modules are pruned at the visitor level
+/// (the visitor never recurses into them).
+struct ProductionMacroCollector {
+    /// (literal_path_as_written, source_file) pairs. Source file is
+    /// captured by the caller before invoking the visitor.
+    literals: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for ProductionMacroCollector {
+    fn visit_item_mod(&mut self, m: &'ast syn::ItemMod) {
+        if attrs_contain_cfg_test(&m.attrs) {
+            return;
+        }
+        syn::visit::visit_item_mod(self, m);
+    }
+
+    fn visit_item_fn(&mut self, f: &'ast syn::ItemFn) {
+        if attrs_contain_cfg_test(&f.attrs) {
+            return;
+        }
+        syn::visit::visit_item_fn(self, f);
+    }
+
+    fn visit_item_impl(&mut self, i: &'ast syn::ItemImpl) {
+        if attrs_contain_cfg_test(&i.attrs) {
+            return;
+        }
+        syn::visit::visit_item_impl(self, i);
+    }
+
+    fn visit_macro(&mut self, m: &'ast Macro) {
+        let Some(seg) = m.path.segments.last() else {
+            return;
+        };
+        let name = seg.ident.to_string();
+        if name != "include_str" && name != "include_bytes" {
+            return;
+        }
+        if let Ok(lit) = syn::parse2::<syn::LitStr>(m.tokens.clone()) {
+            self.literals.push(lit.value());
+        }
+    }
+}
+
+/// Lightweight test-only-file detector. A `.rs` file under `src/` is
+/// treated as test-only when its parent module declares it via
+/// `#[cfg(test)] mod {stem};` — without this hop, files like
+/// `src/mcp/handlers/tests.rs` (which has no top-level `#[cfg(test)]`
+/// of its own) would leak production-shaped macros through the gate.
+fn is_test_only_file(path: &Path) -> bool {
+    let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    if stem == "lib" || stem == "main" || stem == "mod" {
+        return false;
+    }
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let candidates = [
+        parent.join("mod.rs"),
+        parent
+            .parent()
+            .map(|gp| {
+                let pname = parent.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                gp.join(format!("{pname}.rs"))
+            })
+            .unwrap_or_default(),
+    ];
+    let needle = format!("mod {stem}");
+    for cand in candidates.iter() {
+        if !cand.exists() {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(cand) else {
+            continue;
+        };
+        let lines: Vec<&str> = content.lines().collect();
+        for (idx, line) in lines.iter().enumerate() {
+            if !line.contains(&needle) {
+                continue;
+            }
+            // Look upward at most 3 lines for an attribute group; any
+            // `#[cfg(...test...)]` line counts.
+            let mut cursor = idx;
+            for _ in 0..3 {
+                let Some(prev) = cursor.checked_sub(1).and_then(|i| lines.get(i)) else {
+                    break;
+                };
+                let trimmed = prev.trim();
+                if trimmed.is_empty() || trimmed.starts_with("//") {
+                    cursor -= 1;
+                    continue;
+                }
+                if trimmed.starts_with("#[") && trimmed.contains("cfg") && trimmed.contains("test")
+                {
+                    return true;
+                }
+                if !trimmed.starts_with("#[") {
+                    break;
+                }
+                cursor -= 1;
+            }
+        }
+    }
+    false
+}
+
+/// Resolve a literal as written inside `include_str!` against the
+/// directory of the source file that contains the macro, then strip
+/// the leading components so the result is relative to the repo root
+/// (same shape as patterns in `[package].include`).
+fn resolve_literal(src_file: &Path, literal: &str) -> PathBuf {
+    let base = src_file.parent().unwrap_or_else(|| Path::new("."));
+    let joined = base.join(literal);
+    // Normalize . / ..
+    let mut out = PathBuf::new();
+    for comp in joined.components() {
+        match comp {
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Parse `[package].include` from `Cargo.toml` into raw glob strings.
+fn read_cargo_include() -> Vec<String> {
+    let content = std::fs::read_to_string("Cargo.toml").expect("read Cargo.toml");
+    let parsed: toml::Value = toml::from_str(&content).expect("parse Cargo.toml");
+    parsed
+        .get("package")
+        .and_then(|p| p.get("include"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .expect("[package].include must be a string array")
+}
+
+/// Compile glob patterns. Panics on malformed patterns so a
+/// fat-finger in `Cargo.toml` shows as a loud test failure.
+fn compile_globs(patterns: &[String]) -> Vec<glob::Pattern> {
+    patterns
+        .iter()
+        .map(|p| glob::Pattern::new(p).unwrap_or_else(|e| panic!("bad include glob {p}: {e}")))
+        .collect()
+}
+
+/// Single entry point shared by the prod invariant test and the
+/// regression-proof mock test. Returns one human-readable violation
+/// line per uncovered macro literal.
+fn scan_production_violations(globs: &[glob::Pattern]) -> Vec<String> {
+    let src_root = Path::new(SRC_DIR);
+    let mut violations = Vec::new();
+    let mut seen: HashSet<(PathBuf, String)> = HashSet::new();
+    for src in rs_files_under(src_root) {
+        if is_test_only_file(&src) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&src) else {
+            continue;
+        };
+        let Ok(file) = syn::parse_file(&content) else {
+            continue;
+        };
+        let mut visitor = ProductionMacroCollector { literals: vec![] };
+        visitor.visit_file(&file);
+        for literal in visitor.literals {
+            let resolved = resolve_literal(&src, &literal);
+            let resolved_str = resolved.to_string_lossy().replace('\\', "/");
+            if seen.contains(&(src.clone(), literal.clone())) {
+                continue;
+            }
+            seen.insert((src.clone(), literal.clone()));
+            let covered = globs.iter().any(|g| g.matches(&resolved_str));
+            if !covered {
+                violations.push(format!(
+                    "{}: include_(str|bytes)!({:?}) -> resolved {:?} not in [package].include",
+                    src.display(),
+                    literal,
+                    resolved_str
+                ));
+            }
+        }
+    }
+    violations.sort();
+    violations
+}
+
+#[test]
+fn production_include_macros_are_in_cargo_include_list() {
+    let patterns = read_cargo_include();
+    let globs = compile_globs(&patterns);
+    let violations = scan_production_violations(&globs);
+    assert!(
+        violations.is_empty(),
+        "production include_(str|bytes)! macros reference paths missing from \
+         Cargo.toml [package].include — `cargo publish` will fail with \"couldn't \
+         read ...\". Add the path (or a covering glob) to the include whitelist:\n\
+         {}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn mock_invariant_fires_when_assets_hooks_removed_from_include() {
+    // Empirical regression-proof: same scan_production_violations entry
+    // point as the prod test, but with `assets/hooks/*` deleted from
+    // the include list. Expected to surface the binding.rs hook paths
+    // by their resolved form.
+    let mock_patterns: Vec<String> = read_cargo_include()
+        .into_iter()
+        .filter(|p| p != "assets/hooks/*")
+        .collect();
+    let globs = compile_globs(&mock_patterns);
+    let violations = scan_production_violations(&globs);
+    let bash_present = violations
+        .iter()
+        .any(|v| v.contains("assets/hooks/prepare-commit-msg") && !v.contains(".ps1"));
+    let ps_present = violations
+        .iter()
+        .any(|v| v.contains("assets/hooks/prepare-commit-msg.ps1"));
+    assert!(
+        bash_present && ps_present,
+        "mock-mutate dropping `assets/hooks/*` must surface BOTH hook paths \
+         (bash + ps1) — empirical regression-proof for #505 publish-blocker. \
+         Got violations:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn mock_invariant_fires_when_protocol_doc_removed_from_include() {
+    // v0.4.0 publish-blocker repro: drop the protocol doc include.
+    let mock_patterns: Vec<String> = read_cargo_include()
+        .into_iter()
+        .filter(|p| p != "docs/FLEET-DEV-PROTOCOL-v1.md")
+        .collect();
+    let globs = compile_globs(&mock_patterns);
+    let violations = scan_production_violations(&globs);
+    assert!(
+        violations
+            .iter()
+            .any(|v| v.contains("docs/FLEET-DEV-PROTOCOL-v1.md")),
+        "mock-mutate dropping `docs/FLEET-DEV-PROTOCOL-v1.md` must surface \
+         the protocol.rs include — v0.4.0 publish-blocker repro. \
+         Got violations:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary
- Closes **#505 Phase 2 deferred** per commit `2c124c0` self-defer line.
- Sprint 54 silent-drop class 5th-instance prevention. Documented in `d-20260507062618667443-1` (audit ledger). Decision: `d-20260507192623405441-3`. Task: `t-20260507192655859568-3`.
- **Tier-1 single primary** (codex). Path B (test-only, no runtime wiring, no smoke).

## Why this exists
The `cargo publish` verify step builds from the packaged tarball, NOT the source tree. Any production `include_str!` / `include_bytes!` macro pointing at a path NOT in `[package].include` fails verbatim with `couldn't read src/../...` during publish. Caught the hard way at:
- **v0.4.0** — `docs/FLEET-DEV-PROTOCOL-v1.md` missing from include
- **v0.6.0** — `assets/hooks/*` missing (publish-blocker hotfix #505)

Human-comment-in-Cargo.toml alone didn't prevent the second occurrence; this test does.

## What changed
1. **`tests/cargo_include_invariant.rs` (NEW, 341 LOC)** — syn `Visit` walker prunes `#[cfg(test)]` modules / fns / impls before extracting macro literals; resolves each literal against the source file's directory, normalizes `..`, then asserts coverage by some `[package].include` glob.
   - **Test-only file detection**: parent `mod.rs` lookup for `#[cfg(test)] mod {stem};` declarations — required for `src/mcp/handlers/tests.rs` which has no top-level `#[cfg(test)]` of its own.
   - **Single shared entry point** `scan_production_violations(globs)` — both prod test and mock-mutate tests call it; no mock-only code path.
   - **3 #[test] fns**:
     - `production_include_macros_are_in_cargo_include_list` — current main passes (3 production sites: protocol.rs, binding.rs ×2)
     - `mock_invariant_fires_when_assets_hooks_removed_from_include` — drops `assets/hooks/*`, asserts BOTH bash + ps1 hook violations surface (v0.6.0 repro)
     - `mock_invariant_fires_when_protocol_doc_removed_from_include` — drops protocol doc, asserts protocol.rs violation surfaces (v0.4.0 repro)
2. **`Cargo.toml`** — `syn` features += `visit` (already a prod dep, feature add only); `[dev-dependencies] glob = \"0.3\"` (small + ubiquitous + only-pattern-membership-check needed, no walkdir overkill).
3. **`Cargo.lock`** +7 lines transitive.

## §LOC overage rationale (341 vs 260 buffer)
- syn upgrade is pre-authorized structural overhead — +81 over 260 is NOT surprise creep
- Dual mock-mutate covers BOTH past publish-blocker incidents (v0.4.0 + v0.6.0) — defensive breadth > LOC discipline. Dropping one saves 25 LOC but loses half the regression-proof coverage.
- 35-line top-of-file rationale IS the silent-drop ledger entry materialized in code — anti-pattern to cut per audit ledger \"invariant test as systematic prevention documentation\" mandate.
- 60 LOC `is_test_only_file` parent-mod cfg(test) detection cannot be elided: `src/mcp/handlers/tests.rs` has no top-level cfg(test); without the hop the test falsely flags 1 site.
- Quality gates all green; single file single concern; no production code change → bounded blast radius justifies the overage.

## Why glob 0.3 (vs walkdir / inline matcher)
We only need `Pattern::matches(path_string)` — pattern membership check, not directory traversal. `walkdir` is overkill. Inline matcher would have to reimplement `**/*.rs` semantics — error-prone. `glob` 0.3 is small, ubiquitous, well-tested for these patterns.

## Test plan
- [x] 3 new tests under `tests/cargo_include_invariant.rs` all pass on current main
- [x] Mock-mutate tests fail verbatim with the expected `assets/hooks/...` and `docs/FLEET-DEV-PROTOCOL-v1.md` paths
- [x] cargo fmt --check + clippy --all-targets -D warnings clean
- [x] Full integration suite: 41 test binaries, 0 failures

## Reviewer focus checklist (lead's recommendation)
- LOC overage justified above (5-point rationale)
- Single shared entry point for prod + mock — no mock-only branch drift
- syn `visit` feature add (no new crate)
- glob 0.3 dev-dep choice rationale documented
- Test-only file detection correctness for `src/mcp/handlers/tests.rs` parent-mod hop

🤖 Generated with [Claude Code](https://claude.com/claude-code)