### PR TITLE
docs(sprint48): re-route 3 stale "defer to Sprint 49" forward-references (Sprint 54 P2-9)

### DIFF
--- a/docs/PLAN-sprint48-large-file-split-2026-05-04.md
+++ b/docs/PLAN-sprint48-large-file-split-2026-05-04.md
@@ -106,7 +106,7 @@ Tests (75 / ~1770 LOC): hybrid — small inline per sub-module + shared `tests.r
 - PR 2: `telegram-3a` — core transport + inbound — **Tier-2 dual** (high-risk message flow)
 - PR 3: `telegram-3b` — adapter + outbound — Tier-1 single
 
-**Defer to Sprint 49**: full `render` split + remaining `layout` sub-modules (pane / tree / preset / tab).
+**Update (post-merge)**: delivered in Sprint 48 itself per Option B — `layout` sub-modules via PR #414 (Sprint 48 PR 1), `render` split via PR #421 (Sprint 48 PR 4). Original "defer to Sprint 49" plan superseded; Sprint 49 itself was reverted via PR #425.
 
 **Pros**: 80/20 highest-risk file done in Sprint 48; reviewer bandwidth not blown.
 **Cons**: render.rs still 2386 LOC at end of Sprint 48; layout.rs only partially split.
@@ -177,6 +177,8 @@ External callers see `crate::render::X` unchanged. Same for layout, telegram. **
 - `mod.rs` vs `module.rs+module/` style choice — defer to operator §13.
 
 ## §8 §13 candidate questions for operator
+
+> **Update (post-merge)**: Q1+Q2 below referenced Sprint 49 as a deferral target. Resolution: Option B chosen — both `layout` (PR #414) and `render` (PR #421) split delivered in Sprint 48 itself. Sprint 49 was later reverted via PR #425; no work waiting on it.
 
 1. **Phase split option**: A (3 PRs minimal viable, defer render+layout-2 to Sprint 49) vs B (3-4 PRs all 3 files this sprint) vs C (6 PRs all-split this sprint)?
 2. **Sprint 49 plan**: if option A, when ship Sprint 49 (operator m-330 said Sprint 49 = TUI run_app extract — does render/layout-2 split fit?

--- a/docs/SPRINT48-bitbucket-tray-hang-investigation-2026-05-04.md
+++ b/docs/SPRINT48-bitbucket-tray-hang-investigation-2026-05-04.md
@@ -67,7 +67,10 @@ platforms — only the test execution is skipped on Windows.
 
 **Option B**: Isolate the hanging test(s) by running Windows tray tests
 with `--test-threads=1` and a per-test timeout via cargo-nextest. Higher
-effort, deferred to Sprint 49+ if Option A is insufficient.
+effort, deferred indefinitely — Option A proved sufficient: current
+`.github/workflows/ci.yml` runs `cargo test --tests --features tray`
+on all platforms with `timeout-minutes: 30`, no Windows skip needed.
+(Sprint 49 was reverted via PR #425; this Option B never required pickup.)
 
 ## Recommendation
 


### PR DESCRIPTION
## Summary
- Sprint 48 PLAN docs carried 3 forward-references to Sprint 49 deferral. Sprint 49 itself ran but was reverted via PR #425 (supervisor self-IPC deadlock + design issues) — these forward-pointers stranded readers at a phantom successor.
- Lead pre-grep'd the universe (`d-20260507202404629099-5`): Sprint 52 PLAN docs reference Sprint 49 deliberately as **lessons-learned (DO NOT TOUCH)**. Cleanup target is **Sprint 48 docs only**.
- Decision: `d-20260507202404629099-5`. Task: `t-20260507202425584127-5`. Tier-1 single primary (codex). Path B (doc-only).

## What changed (3 forward-refs, 2 files, +7/-2 LOC)

1. **`docs/SPRINT48-bitbucket-tray-hang-investigation-2026-05-04.md:70`** — \"Option B (Windows tray test isolation) deferred to Sprint 49+ if Option A is insufficient\" → \"deferred indefinitely — Option A proved sufficient\". Verified via `.github/workflows/ci.yml`: `cargo test --tests --features tray` runs on all platforms with `timeout-minutes: 30`, no Windows skip needed.
2. **`docs/PLAN-sprint48-large-file-split-2026-05-04.md:109`** — \"Defer to Sprint 49: full `render` split + remaining `layout` sub-modules\" → \"delivered in Sprint 48 itself per Option B\". Verified via `git log`: PR #414 (`Sprint 48 PR 1 — split layout.rs`) + PR #421 (`Sprint 48 PR 4 — split render.rs`); current `src/render/` has 7 sub-files, `src/layout/` has 6 sub-files.
3. **`docs/PLAN-sprint48-large-file-split-2026-05-04.md:181`** — §13 candidate-questions block Q1+Q2 referenced \"defer to Sprint 49\" / \"Sprint 49 plan\". Added a **single resolution note above Q1+Q2** (kept the original questions verbatim for historical-record fidelity): \"Update (post-merge): … Option B chosen … Sprint 49 was later reverted via PR #425; no work waiting on it.\"

## Verification

- `git diff --stat`: only the 2 Sprint 48 docs changed, +7/-2 LOC (within 30-LOC dispatch budget).
- `git diff -- docs/PLAN-sprint52*.md docs/SPRINT5{2,3}*.md`: **zero diff**. Sprint 52+ PLAN docs untouched (lead's \"DO NOT TOUCH\" guardrail).
- `grep \"Sprint 49\" docs/PLAN-sprint52*.md docs/SPRINT53*.md` = **17 matches**, all preserved as intentional lessons-learned context.
- Path B (doc-only); zero source / Cargo.toml / test changes.

## §3.5.13 push form scope-claim
scope follows dispatch — Sprint 48 forward-reference cleanup: 3 stale \"defer to Sprint 49\" pointers across 2 docs (SPRINT48-bitbucket-tray-hang line ~70 + PLAN-sprint48-large-file-split lines ~109 + ~181) re-routed to grep-grounded successors (PR #414 layout split + PR #421 render split) or \"deferred indefinitely\" markers (Option B tray-test isolation never needed); +7/-2 LOC; Sprint 52+ docs untouched (verified zero-diff); no production code change; Path B; no other deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)