### PR TITLE
fix(discord): map_or → is_some_and for HEARTBEAT_ACK opcode check (clippy::unnecessary_map_or, Sprint 54 P2-8)

### DIFF
--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -239,7 +239,7 @@ pub(crate) fn build_identify_payload(
 
 /// Returns `true` if the frame is a HEARTBEAT_ACK (opcode 11).
 pub(crate) fn is_heartbeat_ack(raw: &str) -> bool {
-    parse_gateway_opcode(raw).map_or(false, |f| f.op == 11)
+    parse_gateway_opcode(raw).is_some_and(|f| f.op == 11)
 }
 
 /// Map a twilight `Ready` payload to `ChannelEvent::Connected`.


### PR DESCRIPTION
## Summary
- Per dispatch (`t-20260507210030782250-7`): single-line fix at `src/channel/discord.rs:242` for `clippy::unnecessary_map_or`. Lurked since #316/#317 (Sprint 32) because default CI build doesn't include the discord feature.
- Tier-1 single primary (codex). Path B trivial.

## What changed (1 file, +1/-1 LOC)
```diff
 pub(crate) fn is_heartbeat_ack(raw: &str) -> bool {
-    parse_gateway_opcode(raw).map_or(false, |f| f.op == 11)
+    parse_gateway_opcode(raw).is_some_and(|f| f.op == 11)
 }
```
Behavior-identical: both forms return `true` iff `parse_gateway_opcode(raw).is_some()` AND the closure returns `true`.

## Verification
- `cargo clippy --all-targets -- -D warnings` (default features): clean
- `cargo test --bin agend-terminal --lib` (default): 1621 passed / 0 failed
- `cargo clippy --all-targets --features discord` no longer surfaces `unnecessary_map_or` at line 242

## Pre-existing under `--features discord` (flagged to lead, NOT in scope)
Per dispatch escalation trigger ("More clippy errors surface under `--features discord` (separate scope, separate PR)"), these are pre-existing and **not folded in**:
- 2 errors `clippy::unwrap_used` on `Result::unwrap_err()`
- 2 warnings `clippy::assertions_on_constants`
- 1 test failure `channel::discord::tests::discord_caps_match_s5_analysis` (`assertion failed: caps.react`)

These are observable only with `--features discord` (default CI doesn't trigger them). Lead may dispatch a follow-up PR to clean them up if desired — they are explicitly out of this PR's scope.

## §3.5.13 push form scope-claim
scope follows dispatch — discord clippy fix: src/channel/discord.rs:242 single-line `map_or(false, |f| f.op == 11)` → `is_some_and(|f| f.op == 11)`; +1/-1 LOC; no other discord.rs code touched; no test logic change; default-feature CI verified clean; pre-existing `--features discord` clippy errors / test failure flagged to lead as separate scope, not folded in; no other deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)