### PR TITLE
fix(discord): clippy + stale-test cleanup under --features discord (Sprint 54 P2-8b)

### DIFF
--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -737,7 +737,11 @@ mod tests {
         assert!(caps.emits_deletion_events);
         assert!(caps.threads);
         assert!(caps.attachments);
-        assert!(caps.react);
+        // M3: react support is `false` per production `discord_caps()` —
+        // returns NotSupported until implemented. Sprint 54 P2-8b: test
+        // updated to reflect production reality (was: stale aspirational
+        // `assert!(caps.react)`).
+        assert!(!caps.react);
         assert!(caps.edit);
         assert!(caps.typing_indicator);
         assert!(caps.receives_edit_events);
@@ -950,8 +954,8 @@ mod tests {
             "unknown-agent",
             crate::channel::AgentOutboundOp::Reply { text: "hi".into() },
         );
-        assert!(result.is_err(), "unbound instance must error");
-        let err_msg = format!("{}", result.unwrap_err());
+        let err = result.expect_err("unbound instance must error");
+        let err_msg = format!("{err}");
         assert!(
             err_msg.contains("no discord binding"),
             "error must mention binding, got: {err_msg}"
@@ -968,8 +972,8 @@ mod tests {
             "any-agent",
             crate::channel::AgentOutboundOp::Reply { text: "hi".into() },
         );
-        assert!(result.is_err(), "unauthorized channel must reject");
-        let err_msg = format!("{}", result.unwrap_err());
+        let err = result.expect_err("unauthorized channel must reject");
+        let err_msg = format!("{err}");
         assert!(
             err_msg.contains("outbound disabled"),
             "error must mention outbound gate, got: {err_msg}"
@@ -1441,16 +1445,13 @@ mod tests {
     }
 
     /// Keepalive interval constant is reasonable (≤ Discord's shortest
-    /// auto-archive of 3600s).
+    /// auto-archive of 3600s). Compile-time check via `const {}` blocks —
+    /// per `clippy::assertions_on_constants` and Rust 1.79+ const block
+    /// support — so a regression in `KEEPALIVE_INTERVAL_SECS` fails the
+    /// build, not just this test.
     #[test]
     fn discord_keepalive_interval_within_auto_archive_window() {
-        assert!(
-            super::KEEPALIVE_INTERVAL_SECS < 3600,
-            "keepalive must fire before shortest auto-archive (1h)"
-        );
-        assert!(
-            super::KEEPALIVE_INTERVAL_SECS >= 60,
-            "keepalive should not be too aggressive"
-        );
+        const { assert!(super::KEEPALIVE_INTERVAL_SECS < 3600) };
+        const { assert!(super::KEEPALIVE_INTERVAL_SECS >= 60) };
     }
 }


### PR DESCRIPTION
## Summary
- Per dispatch (`t-20260507215304935562-8`), follow-up to PR #512 (P2-8). Cleans up 5 issues that fire only under `--features discord` (default CI doesn't trigger).
- Tier-1 single primary (codex). Path B test/lint only. LOC net +1.

## What changed (1 file, +15/-14)

### Lint cleanups (`clippy::unwrap_used`)
- L954 (`reply_unbound_returns_user_facing_error`): `result.unwrap_err()` → `result.expect_err(\"unbound instance must error\")`. Collapsed redundant `assert!(result.is_err())` (expect_err covers it).
- L972 (`reply_unauthorized_channel_returns_user_facing_error`): same pattern — `result.expect_err(\"unauthorized channel must reject\")`.

### Lint cleanups (`clippy::assertions_on_constants`)
- L1447, L1451 (`discord_keepalive_interval_within_auto_archive_window`): runtime `assert!(super::KEEPALIVE_INTERVAL_SECS …)` rewrapped in `const { assert!(..) }` blocks. Now compile-time check — regression fails the build, not just this test. Doc comment updated to call out the change.

### Stale aspirational test
- `discord_caps_match_s5_analysis` (line 740): `assert!(caps.react)` → `assert!(!caps.react)` with 4-line comment. Production `discord_caps()` (line 180) sets `react: false // M3: not implemented yet`; the test was aspirational from S5 analysis pre-implementation.

### Caps test grep audit (broader scope per lead's nudge)
Cross-checked **every** `caps.*` field in `discord_caps_match_s5_analysis` against production `discord_caps()`:

| field | production | test | status |
|---|---|---|---|
| `emits_deletion_events` | true | true | ✓ |
| `threads` | true | true | ✓ |
| `attachments` | true | true | ✓ |
| `react` | **false** | **was true** | **FIXED in this PR** |
| `edit` | true | true | ✓ |
| `typing_indicator` | true | true | ✓ |
| `receives_edit_events` | true | true | ✓ |

`react` was the only stale aspirational; no second one to fold-in or escalate.

## Verification
- `cargo clippy --all-targets --features discord -- -D warnings`: clean (was: 2 errors + 2 warnings)
- `cargo test --bin agend-terminal --lib --features discord channel::discord`: **25 passed / 0 failed** (was: 1 failed `discord_caps_match_s5_analysis`)
- `cargo clippy --all-targets -- -D warnings` (default features): clean — no regression
- LOC net +1 (well under 30 ceiling)

## §3.5.13 push form scope-claim
scope follows dispatch — discord clippy/test cleanup: 5 sites per spec (L954+L972 unwrap_err→expect_err, L1447+L1451 runtime assert→const block, caps_match_s5_analysis `assert!(caps.react)` flipped to `assert!(!caps.react)`) + 4-line comment explaining M3 not-implemented; net +1 LOC; full caps-test field audit performed (no second stale found, no scope expansion); cargo clippy --features discord clean post-fix; default-feature CI no regression; Path B test/lint only; no production behavior change; no other deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)