### PR TITLE
fix(agend-git): expand emit_deny_error hint to list 3 bypass forms (Sprint 54 P2-4, Option A)

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -247,9 +247,27 @@ fn resolve_real_git() -> String {
 // ── Error + Telemetry ───────────────────────────────────────────────────
 
 fn emit_deny_error(subcmd: &str, reason: &str, agent: &str) {
-    eprintln!("agend-git: ERROR git {subcmd} denied");
-    eprintln!("           agent={agent}, reason: {reason}");
-    eprintln!("           HINT: use the task board to get a worktree assignment, or set AGEND_GIT_BYPASS=1 for emergency override");
+    for line in format_deny_error(subcmd, reason, agent) {
+        eprintln!("{line}");
+    }
+}
+
+/// Sprint 54 P2-4: build the deny-error block as a `Vec<String>` so the
+/// 3-form bypass hint can be unit-tested for env-var-name presence
+/// without capturing stderr. `emit_deny_error` is a thin wrapper that
+/// `eprintln!`s each line. Per `should_bypass` (above), three bypass
+/// forms exist; the hint enumerates all of them so operators don't
+/// have to grep the source to discover the agent-specific or
+/// time-limited variants.
+fn format_deny_error(subcmd: &str, reason: &str, agent: &str) -> Vec<String> {
+    vec![
+        format!("agend-git: ERROR git {subcmd} denied"),
+        format!("           agent={agent}, reason: {reason}"),
+        "           HINT: use the task board for a worktree assignment, or bypass with one of:".to_string(),
+        "             AGEND_GIT_BYPASS=1               one-shot emergency override".to_string(),
+        "             AGEND_GIT_BYPASS_AGENT=<name>    agent-specific exemption (matches AGEND_INSTANCE_NAME)".to_string(),
+        "             AGEND_GIT_BYPASS_UNTIL=<epoch>   time-limited exemption (Unix seconds, not ISO)".to_string(),
+    ]
 }
 
 fn write_git_event(home: &str, agent: &str, subcmd: &str, reason: &str) {
@@ -270,5 +288,30 @@ fn write_git_event(home: &str, agent: &str, subcmd: &str, reason: &str) {
     {
         use std::io::Write;
         let _ = writeln!(f, "{}", event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_deny_error;
+
+    #[test]
+    fn deny_hint_lists_all_three_bypass_forms() {
+        let lines = format_deny_error("commit", "unbound", "dev");
+        let joined = lines.join("\n");
+        for var in [
+            "AGEND_GIT_BYPASS=1",
+            "AGEND_GIT_BYPASS_AGENT=",
+            "AGEND_GIT_BYPASS_UNTIL=",
+        ] {
+            assert!(
+                joined.contains(var),
+                "deny hint must list {var}, got:\n{joined}"
+            );
+        }
+        assert!(
+            joined.contains("epoch") && joined.contains("Unix seconds"),
+            "AGEND_GIT_BYPASS_UNTIL hint must clarify epoch wording (not ISO), got:\n{joined}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Per general's Option A clarification: existing `emit_deny_error` hint only mentioned `AGEND_GIT_BYPASS=1`, hiding the agent-specific and time-limited variants. Discoverability gap — operators had to grep `should_bypass()` to find them.
- Tier-1 single primary (codex). Path B text/error-message change. Decision/task: `t-20260507223027006670-10`.

## What changed (1 file, +46/-3 = net +43 LOC)

1. **Helper extraction** `format_deny_error` returns `Vec<String>` so the hint block is unit-testable without stderr capture machinery. `emit_deny_error` becomes a thin `for line in format_deny_error(...) { eprintln!("{line}"); }` wrapper.
2. **Hint expansion** to 4-line list (fits the ≤5-line ceiling):
```
HINT: use the task board for a worktree assignment, or bypass with one of:
  AGEND_GIT_BYPASS=1               one-shot emergency override
  AGEND_GIT_BYPASS_AGENT=<name>    agent-specific exemption (matches AGEND_INSTANCE_NAME)
  AGEND_GIT_BYPASS_UNTIL=<epoch>   time-limited exemption (Unix seconds, not ISO)
```
3. **Wording correction** for `AGEND_GIT_BYPASS_UNTIL`: general's m-20260507222948614277-190 referenced this as "ISO timestamp", but `should_bypass` at `agend-git.rs:62` calls `until_str.parse::<u64>()` — **Unix epoch seconds**. Hint clarifies "Unix seconds, not ISO" so operators don't set it to `2026-05-08T12:00:00Z`.
4. **1 iteration-form unit test** `deny_hint_lists_all_three_bypass_forms` asserts all 3 env var names + epoch wording. Future 4th variant adds 1 LOC to the test array.

## Scope guardrail (operator embargo respected)
- DO NOT touch ChdirPass silent-fallback path (P1-B Bug 2 fix territory, embargo-blocked) — confirmed unchanged.
- DO NOT modify `should_bypass()` logic — read-only reference.
- DO NOT add new env vars — purely surfaces existing ones.

## LOC overage rationale (+43 vs 30 nominal ceiling, < 50 drift threshold)
1. `format_deny_error` helper extraction required for unit-testability (eprintln direct calls untestable without stderr capture).
2. 6-line doc on the helper aligns with Sprint 54 audit-ledger documentation pattern (#508 invariant test).
3. 22-line iteration-form test maximizes maintainability — adding a 4th bypass variant is 1 LOC to the array.
4. 43 < 50 drift threshold. Sprint 54 precedent (#508 +81 over 260, #511 +1 over 5) shows tolerance for principled value.

## Verification
- `cargo build --bin agend-git`: clean
- `cargo fmt --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean (mod tests at end-of-file per `clippy::items_after_test_module`)
- `cargo test --bin agend-git`: 1 passed

## §3.5.13 push form scope-claim
scope follows dispatch — emit_deny_error hint expansion (Option A): `src/bin/agend-git.rs:249-253` hint listing 3 bypass forms (`=1` / `_AGENT` / `_UNTIL`) with epoch wording correction (per `agend-git.rs:62` u64 parse, not ISO per general's m-190 — note in PR body) + `format_deny_error` helper extraction for testability + 1 iteration-form unit test for regression-proof; 1 file +46/-3 net +43 LOC (over 30 nominal, under 50 drift, justified per audit-ledger doc + helper extract for testability + future env var maintainability); no `should_bypass` logic change; no ChdirPass touch (embargo); Path B; no other deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)