### PR TITLE
feat(daemon): pane-input-not-submitted detection (Option B+C combo, Sprint 54 P2-3)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -844,8 +844,39 @@ fn pane_from_menu_item(
 fn write_to_focused(home: &Path, layout: &mut Layout, registry: &AgentRegistry, bytes: &[u8]) {
     if let Some(pane) = layout.active_tab_mut().and_then(|t| t.focused_pane_mut()) {
         notification_queue::record_input_activity(home, &pane.agent_name);
+        // Sprint 54 P2-3: backend-aware submit detection (claude-first
+        // allowlist). When the keystroke buffer contains the agent's
+        // submit key (`\r` for claude, also matches paste-with-newlines
+        // since the underlying CLI submits on any \r), record a
+        // separate timestamp so the daemon supervisor can detect
+        // "typed but not submitted" against this paired signal. Other
+        // backends gracefully no-op — the supervisor tick reads
+        // `last_submit_at_ms == 0` for them and skips emission per
+        // the explicit backend allowlist there.
+        if pane_input_contains_submit(pane.backend.as_ref(), bytes) {
+            notification_queue::record_submit_activity(home, &pane.agent_name);
+        }
         pane.write_input(registry, bytes);
     }
+}
+
+/// Sprint 54 P2-3: backend-aware submit detection. Returns true iff
+/// the backend is on the submit-detection allowlist AND the keystroke
+/// buffer contains its submit key. Hard-coded claude-only first round
+/// per dispatch — extending to other backends just requires adding
+/// arms to the match.
+fn pane_input_contains_submit(backend: Option<&crate::backend::Backend>, bytes: &[u8]) -> bool {
+    let Some(b) = backend else {
+        return false;
+    };
+    if !matches!(b, crate::backend::Backend::ClaudeCode) {
+        return false;
+    }
+    let submit = b.preset().submit_key.as_bytes();
+    if submit.is_empty() || bytes.len() < submit.len() {
+        return false;
+    }
+    bytes.windows(submit.len()).any(|w| w == submit)
 }
 
 fn sync_notification_state(home: &Path, layout: &mut Layout) {

--- a/src/channel/ux_event.rs
+++ b/src/channel/ux_event.rs
@@ -123,6 +123,15 @@ pub enum FleetEvent {
         recipients: Vec<String>,
         summary: String,
     },
+    /// Sprint 54 P2-3: operator typed input into an agent's pane but
+    /// has not yet submitted it (no submit-key keystroke since the last
+    /// non-submit keystroke) for at least
+    /// `AGEND_PANE_INPUT_THRESHOLD_SECS` (default 60). Read-only
+    /// diagnostic emitted by the daemon supervisor tick — the agent is
+    /// not interrupted, no prompt injected, no state mutated. Backend
+    /// allowlist applies (claude only, first round); other backends
+    /// gracefully no-op so the event never fires there.
+    PaneInputNotSubmitted { agent: String, typed_age_secs: u64 },
 }
 
 /// Platform-agnostic action chosen by [`select_action`] given a
@@ -247,6 +256,15 @@ pub fn format_fleet_oneliner(fe: &FleetEvent, max_bytes: usize) -> String {
             let tag = format_broadcast_tag(from, recipients);
             (tag, "BROADCAST", summary.clone(), String::new())
         }
+        FleetEvent::PaneInputNotSubmitted {
+            agent,
+            typed_age_secs,
+        } => (
+            format!("[{agent} pane]"),
+            "TYPED-NOT-SUBMITTED",
+            format!("idle {typed_age_secs}s with un-submitted input"),
+            String::new(),
+        ),
     };
 
     // `tag  VERB  <summary>`: verb column is separated by two spaces on

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -36,6 +36,16 @@ pub(crate) struct NotifyTrack {
     consecutive: u32,
 }
 
+/// Sprint 54 P2-3: dedup key for `PaneInputNotSubmitted` emission.
+/// Records the `last_input_epoch_ms` of the most recent emit so the
+/// supervisor doesn't re-fire on every 10-s tick while the operator
+/// stares at typed-but-not-submitted text. Re-arms when a fresh
+/// keystroke updates `last_input_epoch_ms` past the recorded value.
+#[derive(Debug, Default)]
+pub(crate) struct PaneInputTrack {
+    last_emitted_for_typed_ms: i64,
+}
+
 /// Per-agent ServerRateLimit retry state.
 #[derive(Debug, Clone)]
 pub(crate) struct RateLimitRetry {
@@ -81,11 +91,104 @@ pub fn spawn(home: PathBuf, registry: AgentRegistry) {
 fn run_loop(home: PathBuf, registry: AgentRegistry) {
     let mut notify_tracks: HashMap<String, NotifyTrack> = HashMap::new();
     let mut retry_tracks: HashMap<String, RateLimitRetry> = HashMap::new();
+    let mut pane_input_tracks: HashMap<String, PaneInputTrack> = HashMap::new();
     loop {
         thread::sleep(TICK);
         tick(&home, &registry, &mut notify_tracks);
         process_server_rate_limit_retries(&home, &registry, &mut retry_tracks);
+        check_pane_input_not_submitted(&home, &registry, &mut pane_input_tracks);
     }
+}
+
+/// Sprint 54 P2-3: per-tick check for "typed but not submitted" pane
+/// state. Read-only — emits a `FleetEvent::PaneInputNotSubmitted` when
+/// the threshold is exceeded but does NOT inject prompts, mutate agent
+/// state, or touch the router layer (router = `src/channel/router/*`,
+/// Sprint 49/52 territory). Backend allowlist (claude only, first
+/// round) avoids false-positive flood for backends without
+/// `record_submit_activity` wiring.
+///
+/// Threshold defaults to 60s; override via env
+/// `AGEND_PANE_INPUT_THRESHOLD_SECS`.
+pub(crate) fn check_pane_input_not_submitted(
+    home: &std::path::Path,
+    registry: &AgentRegistry,
+    tracks: &mut HashMap<String, PaneInputTrack>,
+) {
+    let agent_names: Vec<String> = {
+        let reg = agent::lock_registry(registry);
+        reg.keys().cloned().collect()
+    };
+    check_pane_input_not_submitted_for_agents(home, &agent_names, tracks);
+}
+
+/// Sprint 54 P2-3: pure-function variant of
+/// [`check_pane_input_not_submitted`] that takes the agent name list
+/// directly. Lets tests exercise the detection / emission / dedup logic
+/// without standing up a real `AgentRegistry` (which would need a
+/// spawned PTY + child process).
+pub(crate) fn check_pane_input_not_submitted_for_agents(
+    home: &std::path::Path,
+    agent_names: &[String],
+    tracks: &mut HashMap<String, PaneInputTrack>,
+) {
+    let threshold_secs: u64 = std::env::var("AGEND_PANE_INPUT_THRESHOLD_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(60);
+    let threshold_ms = (threshold_secs as i64).saturating_mul(1000);
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    for name in agent_names {
+        if !pane_input_backend_supported(home, name) {
+            continue;
+        }
+        let (typed_ms, submit_ms) =
+            crate::notification_queue::read_input_submit_timestamps(home, name);
+        if typed_ms == 0 || typed_ms <= submit_ms {
+            continue;
+        }
+        let typed_age_ms = now_ms.saturating_sub(typed_ms);
+        if typed_age_ms < threshold_ms {
+            continue;
+        }
+        let track = tracks.entry(name.clone()).or_default();
+        if track.last_emitted_for_typed_ms == typed_ms {
+            // Already notified for this exact typing event — wait for a
+            // new keystroke to re-arm.
+            continue;
+        }
+        track.last_emitted_for_typed_ms = typed_ms;
+        let typed_age_secs = (typed_age_ms / 1000).max(0) as u64;
+        crate::channel::sink_registry::registry().emit(&crate::channel::ux_event::UxEvent::Fleet(
+            crate::channel::ux_event::FleetEvent::PaneInputNotSubmitted {
+                agent: name.clone(),
+                typed_age_secs,
+            },
+        ));
+        tracing::info!(
+            agent = %name,
+            typed_age_secs,
+            "pane-input-not-submitted detected (read-only diagnostic)"
+        );
+    }
+}
+
+/// Sprint 54 P2-3: backend allowlist for submit detection. Hard-coded
+/// claude-only first round per dispatch — extending to other backends
+/// requires both wiring `record_submit_activity` in
+/// `app::write_to_focused` AND adding the matching arm here. Resolves
+/// the agent's backend via fleet.yaml so per-instance overrides are
+/// honoured.
+fn pane_input_backend_supported(home: &std::path::Path, agent: &str) -> bool {
+    let Ok(fleet) = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")) else {
+        return false;
+    };
+    let Some(resolved) = fleet.resolve_instance(agent) else {
+        return false;
+    };
+    crate::backend::Backend::from_command(&resolved.backend_command)
+        .map(|b| matches!(b, crate::backend::Backend::ClaudeCode))
+        .unwrap_or(false)
 }
 
 /// Decide and dispatch member-state-change notify. Returns true if notify sent.
@@ -1055,5 +1158,218 @@ mod tests {
             !body.contains("format_notification"),
             "retry must NOT re-format notification (would add header)"
         );
+    }
+
+    // ─── Sprint 54 P2-3: pane-input-not-submitted detection tests ───
+
+    /// Helper: minimal `UxEventSink` that records every emitted event
+    /// in-memory so the supervisor's emission can be asserted without
+    /// standing up a real channel adapter.
+    struct TestSink {
+        events: parking_lot::Mutex<Vec<crate::channel::ux_event::UxEvent>>,
+    }
+    impl crate::channel::ux_event::UxEventSink for TestSink {
+        fn emit(&self, event: &crate::channel::ux_event::UxEvent) {
+            self.events.lock().push(event.clone());
+        }
+    }
+
+    /// Helper: stand up `home/fleet.yaml` declaring `agent_name` with the
+    /// chosen backend command, then return `home`. Used by the
+    /// pane-input-not-submitted suite so `pane_input_backend_supported`
+    /// resolves the agent against a real fleet config.
+    fn fleet_with_backend(tag: &str, agent_name: &str, backend_cmd: &str) -> std::path::PathBuf {
+        let home = tmp_home(tag);
+        std::fs::write(
+            home.join("fleet.yaml"),
+            format!(
+                "instances:\n  {agent_name}:\n    backend: {backend_cmd}\n    \
+                 working_directory: \"/tmp\"\n"
+            ),
+        )
+        .expect("write fleet.yaml");
+        home
+    }
+
+    /// Helper: pre-populate the agent's metadata with a typed timestamp
+    /// older than `now - threshold_secs` and a (possibly absent) submit
+    /// timestamp. Bypasses `record_input_activity` / `record_submit_activity`
+    /// so tests can set arbitrary epoch-ms values.
+    fn seed_input_submit(home: &std::path::Path, agent: &str, typed_ms: i64, submit_ms: i64) {
+        let meta_dir = home.join("metadata");
+        std::fs::create_dir_all(&meta_dir).ok();
+        let mut meta = serde_json::Map::new();
+        if typed_ms > 0 {
+            meta.insert("last_input_epoch_ms".into(), serde_json::json!(typed_ms));
+        }
+        if submit_ms > 0 {
+            meta.insert("last_submit_epoch_ms".into(), serde_json::json!(submit_ms));
+        }
+        std::fs::write(
+            meta_dir.join(format!("{agent}.json")),
+            serde_json::to_string_pretty(&serde_json::Value::Object(meta)).expect("serialize"),
+        )
+        .expect("write metadata");
+    }
+
+    #[test]
+    fn pane_input_not_submitted_emits_event_when_threshold_exceeded() {
+        // Per-test unique agent name avoids cross-test sink_registry
+        // contamination (cargo test runs in parallel; the global sink
+        // registry sees emissions from every test concurrently).
+        let agent = "claude-agent-pin-emit";
+        let home = fleet_with_backend("pin_emit", agent, "claude");
+        // Typed 5 minutes ago, never submitted → must emit.
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        seed_input_submit(&home, agent, now_ms - 300_000, 0);
+        std::env::set_var("AGEND_PANE_INPUT_THRESHOLD_SECS", "60");
+        let sink = std::sync::Arc::new(TestSink {
+            events: parking_lot::Mutex::new(Vec::new()),
+        });
+        crate::channel::sink_registry::registry().register(sink.clone());
+        let mut tracks: HashMap<String, PaneInputTrack> = HashMap::new();
+        check_pane_input_not_submitted_for_agents(&home, &[agent.to_string()], &mut tracks);
+        let events = sink.events.lock();
+        let matched = events.iter().filter_map(|e| match e {
+            crate::channel::ux_event::UxEvent::Fleet(
+                crate::channel::ux_event::FleetEvent::PaneInputNotSubmitted {
+                    agent: emitted, ..
+                },
+            ) if emitted == agent => Some(()),
+            _ => None,
+        });
+        assert!(
+            matched.count() >= 1,
+            "expected ≥1 PaneInputNotSubmitted event for {agent}, got: {events:?}"
+        );
+        std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn pane_input_not_submitted_skips_when_within_threshold() {
+        let agent = "claude-agent-pin-within";
+        let home = fleet_with_backend("pin_within", agent, "claude");
+        // Typed 5s ago — well within default 60s threshold → no emit.
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        seed_input_submit(&home, agent, now_ms - 5_000, 0);
+        let sink = std::sync::Arc::new(TestSink {
+            events: parking_lot::Mutex::new(Vec::new()),
+        });
+        crate::channel::sink_registry::registry().register(sink.clone());
+        let mut tracks: HashMap<String, PaneInputTrack> = HashMap::new();
+        check_pane_input_not_submitted_for_agents(&home, &[agent.to_string()], &mut tracks);
+        let events = sink.events.lock();
+        for e in events.iter() {
+            if let crate::channel::ux_event::UxEvent::Fleet(
+                crate::channel::ux_event::FleetEvent::PaneInputNotSubmitted {
+                    agent: emitted, ..
+                },
+            ) = e
+            {
+                assert_ne!(emitted, agent, "must not emit within threshold");
+            }
+        }
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn pane_input_not_submitted_skips_when_submit_caught_up() {
+        let agent = "claude-agent-pin-submit";
+        let home = fleet_with_backend("pin_submit", agent, "claude");
+        // Typed 5min ago AND submitted 4min ago (submit > 0 and >= typed).
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        seed_input_submit(&home, agent, now_ms - 300_000, now_ms - 240_000);
+        std::env::set_var("AGEND_PANE_INPUT_THRESHOLD_SECS", "60");
+        let sink = std::sync::Arc::new(TestSink {
+            events: parking_lot::Mutex::new(Vec::new()),
+        });
+        crate::channel::sink_registry::registry().register(sink.clone());
+        let mut tracks: HashMap<String, PaneInputTrack> = HashMap::new();
+        check_pane_input_not_submitted_for_agents(&home, &[agent.to_string()], &mut tracks);
+        let events = sink.events.lock();
+        for e in events.iter() {
+            if let crate::channel::ux_event::UxEvent::Fleet(
+                crate::channel::ux_event::FleetEvent::PaneInputNotSubmitted {
+                    agent: emitted, ..
+                },
+            ) = e
+            {
+                assert_ne!(
+                    emitted, agent,
+                    "must not emit when submit timestamp >= typed"
+                );
+            }
+        }
+        std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn pane_input_not_submitted_skips_non_claude_backend() {
+        // kiro-cli is NOT on the submit-detection allowlist (claude-only first round).
+        let agent = "kiro-agent-pin-nonclaude";
+        let home = fleet_with_backend("pin_nonclaude", agent, "kiro-cli");
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        seed_input_submit(&home, agent, now_ms - 300_000, 0);
+        std::env::set_var("AGEND_PANE_INPUT_THRESHOLD_SECS", "60");
+        let sink = std::sync::Arc::new(TestSink {
+            events: parking_lot::Mutex::new(Vec::new()),
+        });
+        crate::channel::sink_registry::registry().register(sink.clone());
+        let mut tracks: HashMap<String, PaneInputTrack> = HashMap::new();
+        check_pane_input_not_submitted_for_agents(&home, &[agent.to_string()], &mut tracks);
+        let events = sink.events.lock();
+        for e in events.iter() {
+            if let crate::channel::ux_event::UxEvent::Fleet(
+                crate::channel::ux_event::FleetEvent::PaneInputNotSubmitted {
+                    agent: emitted, ..
+                },
+            ) = e
+            {
+                assert_ne!(
+                    emitted, agent,
+                    "non-claude backend must be skipped per allowlist"
+                );
+            }
+        }
+        std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn pane_input_not_submitted_dedups_per_typed_timestamp() {
+        let agent = "claude-agent-pin-dedup";
+        let home = fleet_with_backend("pin_dedup", agent, "claude");
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let typed_ms = now_ms - 300_000;
+        seed_input_submit(&home, agent, typed_ms, 0);
+        std::env::set_var("AGEND_PANE_INPUT_THRESHOLD_SECS", "60");
+        let sink = std::sync::Arc::new(TestSink {
+            events: parking_lot::Mutex::new(Vec::new()),
+        });
+        crate::channel::sink_registry::registry().register(sink.clone());
+        let mut tracks: HashMap<String, PaneInputTrack> = HashMap::new();
+        // Tick once → one emit. Tick again with same metadata → still one.
+        check_pane_input_not_submitted_for_agents(&home, &[agent.to_string()], &mut tracks);
+        check_pane_input_not_submitted_for_agents(&home, &[agent.to_string()], &mut tracks);
+        let events = sink.events.lock();
+        let count = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    crate::channel::ux_event::UxEvent::Fleet(
+                        crate::channel::ux_event::FleetEvent::PaneInputNotSubmitted { agent: emitted, .. },
+                    ) if emitted == agent
+                )
+            })
+            .count();
+        assert_eq!(
+            count, 1,
+            "must dedup repeated ticks for same typed_ms; got {count}"
+        );
+        std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
+        std::fs::remove_dir_all(home).ok();
     }
 }

--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -8,6 +8,11 @@ use std::time::Duration;
 
 pub const COMPOSE_IDLE_TIMEOUT: Duration = Duration::from_secs(3);
 const COMPOSE_METADATA_KEY: &str = "last_input_epoch_ms";
+/// Sprint 54 P2-3: epoch-ms timestamp of the most recent submit-key
+/// keystroke (e.g. `\r` for claude). Distinct from
+/// `COMPOSE_METADATA_KEY` which records ANY input keystroke. Used by
+/// the daemon supervisor to detect "typed but not submitted" state.
+const SUBMIT_METADATA_KEY: &str = "last_submit_epoch_ms";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueuedNotification {
@@ -31,6 +36,40 @@ pub fn record_input_activity(home: &Path, agent_name: &str) {
         COMPOSE_METADATA_KEY,
         json!(chrono::Utc::now().timestamp_millis()),
     );
+}
+
+/// Sprint 54 P2-3: record a submit-key keystroke (e.g. claude `\r`).
+/// Caller (`app::write_to_focused`) is responsible for the backend
+/// allowlist + submit-key match — this helper only persists the
+/// timestamp. The daemon supervisor tick reads it via
+/// `last_submit_at_ms` and compares against `last_input_at_ms` for
+/// the typed-but-not-submitted detection.
+pub fn record_submit_activity(home: &Path, agent_name: &str) {
+    agent_ops::save_metadata(
+        home,
+        agent_name,
+        SUBMIT_METADATA_KEY,
+        json!(chrono::Utc::now().timestamp_millis()),
+    );
+}
+
+/// Sprint 54 P2-3: read the last input/submit timestamps. Returns
+/// `(typed_ms, submit_ms)` tuple; either component is `0` when missing
+/// (legacy data, agent never typed, or non-submit-detected backend).
+/// Used by the daemon supervisor tick for typed-but-not-submitted
+/// detection — keeps the read inline-cheap (single file read, single
+/// JSON parse) so per-tick overhead stays bounded.
+pub fn read_input_submit_timestamps(home: &Path, agent_name: &str) -> (i64, i64) {
+    let meta_path = home.join("metadata").join(format!("{agent_name}.json"));
+    let Ok(content) = std::fs::read_to_string(meta_path) else {
+        return (0, 0);
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return (0, 0);
+    };
+    let typed_ms = value[COMPOSE_METADATA_KEY].as_i64().unwrap_or(0);
+    let submit_ms = value[SUBMIT_METADATA_KEY].as_i64().unwrap_or(0);
+    (typed_ms, submit_ms)
 }
 
 pub fn is_composing(home: &Path, agent_name: &str) -> bool {
@@ -144,6 +183,47 @@ mod tests {
         assert_eq!(drained.len(), 2);
         assert_eq!(drained[0].text, "a");
         assert_eq!(pending_count(&home, "agent1"), 0);
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// Sprint 54 P2-3: round-trip both timestamps; ensure
+    /// `read_input_submit_timestamps` returns paired values and
+    /// `record_submit_activity` writes a value strictly newer than the
+    /// preceding `record_input_activity` call.
+    #[test]
+    fn record_and_read_input_submit_timestamps_round_trip() {
+        let home = tmp_home("ts_round_trip");
+        // Fresh agent → both 0.
+        let (typed0, submit0) = read_input_submit_timestamps(&home, "agent1");
+        assert_eq!((typed0, submit0), (0, 0));
+        record_input_activity(&home, "agent1");
+        std::thread::sleep(Duration::from_millis(2));
+        record_submit_activity(&home, "agent1");
+        let (typed1, submit1) = read_input_submit_timestamps(&home, "agent1");
+        assert!(typed1 > 0, "typed timestamp must be set after record");
+        assert!(submit1 > 0, "submit timestamp must be set after record");
+        assert!(
+            submit1 >= typed1,
+            "submit (called second) must be ≥ typed (called first), got typed={typed1} submit={submit1}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// Sprint 54 P2-3: typed-only (no submit) must read as
+    /// `submit_ms == 0`. This is the daemon-supervisor's signal for
+    /// "user typed but never pressed Enter" — it MUST distinguish
+    /// from "user typed AND submitted" otherwise the dedup logic
+    /// degrades to never firing.
+    #[test]
+    fn typed_only_leaves_submit_zero() {
+        let home = tmp_home("typed_only");
+        record_input_activity(&home, "agent1");
+        let (typed, submit) = read_input_submit_timestamps(&home, "agent1");
+        assert!(typed > 0);
+        assert_eq!(
+            submit, 0,
+            "submit must stay 0 until record_submit_activity is called"
+        );
         std::fs::remove_dir_all(home).ok();
     }
 }


### PR DESCRIPTION
## Summary
- Per general's clarification + lead's design sign-off (m-20260507225647812201-213): emit a read-only diagnostic when an operator typed input into an agent's pane but hasn't submitted it for ≥ `AGEND_PANE_INPUT_THRESHOLD_SECS` (default 60s).
- Tier-1 single primary (codex). Path A wiring (Phase 5 smoke embargo-deferred, recipe in PR body). Decision: `d-20260507225155538248-6`. Task: `t-20260507225221953009-11`.

## Phase 1 RCA finding worth highlighting
**There is no existing "submitted" signal in the codebase**: `is_composing` (3s window) and `heartbeat_pair.last_input_at_ms` both record ANY input; neither distinguishes typed-vs-submitted. Option B (new tracker) is therefore necessary not optional. Documented in commit body for future detectors that may benefit from the `last_submit_at_ms` signal this PR introduces.

## Embargo (zero violations)
Phase 1 RCA architecture map verified detection stays in TUI / metadata / daemon-supervisor / heartbeat_pair layers — **zero router-layer touch** (router = `src/channel/router/*`, Sprint 49/52 territory). Read-only metric + event emission only. No agent state mutation, no prompt injection.

## What changed (4 files, +444 LOC — lead-approved overage per Sprint 54 #508/#511/#515 precedent)

1. **`src/notification_queue.rs` +80**: `last_submit_epoch_ms` metadata key + `record_submit_activity` helper + `read_input_submit_timestamps(home, agent) -> (i64, i64)` getter. 2 unit tests.
2. **`src/app/mod.rs` +31**: `write_to_focused` calls `record_submit_activity` when `pane_input_contains_submit(backend, bytes)` is true. Backend allowlist (claude only, first round) + submit-key match.
3. **`src/daemon/supervisor.rs` +315**: New `PaneInputTrack` dedup struct + `check_pane_input_not_submitted(home, registry, tracks)` wired into `run_loop` + pure-function `check_pane_input_not_submitted_for_agents` for testability without spawning real PTY+child. `pane_input_backend_supported` resolves backend via `FleetConfig::load`. Emission via `sink_registry::registry().emit(UxEvent::Fleet(FleetEvent::PaneInputNotSubmitted { agent, typed_age_secs }))`. **5 unit tests**: positive emit / under-threshold skip / submit-caught-up skip / non-claude skip / dedup. Per-test unique agent names avoid global-sink-registry cross-contamination under parallel cargo test.
4. **`src/channel/ux_event.rs` +18**: `PaneInputNotSubmitted` enum variant + 9-line semantic doc + `format_fleet_oneliner` arm rendering as `[<agent> pane]  TYPED-NOT-SUBMITTED  idle <secs>s with un-submitted input`.

## Backend allowlist (defense in depth)
BOTH `pane_input_contains_submit` (TUI write side) AND `pane_input_backend_supported` (supervisor emit side) gate to `Backend::ClaudeCode`. For other backends `record_submit_activity` is never called → `last_submit_epoch_ms` stays absent (read as 0) → supervisor's `typed_ms <= submit_ms` check trivially true → skip. The allowlist additionally short-circuits before metadata read.

## Phase 5 smoke (operator-restart-deferred)
Live daemon needs the new code to wire the supervisor tick + the new metadata writer.

1. Start a claude-backed agent and focus its pane.
2. Type a few characters WITHOUT pressing Enter. Walk away.
3. Wait `AGEND_PANE_INPUT_THRESHOLD_SECS` (default 60s).
4. Within 10s of crossing the threshold, observe a `PaneInputNotSubmitted` `UxEvent` in the configured `fleet_binding` (Telegram if wired) or daemon log line `pane-input-not-submitted detected (read-only diagnostic)`.
5. Press Enter (bytes contain `\r`) → next supervisor tick sees `submit_ms >= typed_ms` → no further events.
6. Type another character WITHOUT submit → re-arms; another event after the threshold.

## §3.5.13 push form scope-claim
scope follows dispatch — pane-input-not-submitted detection (Option B+C combo per Phase 1 RCA): 4 files +444 LOC (+144 over 300 nominal, lead-approved per Sprint 54 #508/#511/#515 precedent — production code ~155, test breadth 5 conditions + DRY helpers ~220, audit-ledger doc ~70; under 600 implicit hard cap); new `last_submit_at_ms` metadata + `record_submit_activity` helper + `pane.write_input` submit detection via backend `submit_key` + daemon supervisor tick check + `FleetEvent::PaneInputNotSubmitted` emission + claude-first backend allowlist + `AGEND_PANE_INPUT_THRESHOLD_SECS` env override default 60s; embargo-respecting (zero router-layer touch verified per Phase 1 architecture map); Tier-1; Path A (Phase 5 smoke deferred — live daemon needs operator restart); no other deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)