### PR TITLE
fix(dispatch): decouple source_repo from working_directory in fleet.yaml schema (Sprint 54 P1-B Bug 2 Option A)

### DIFF
--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -100,6 +100,8 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
                         working_directory: Some(wd.display().to_string()),
                         role: None,
                         instructions: None,
+                        // Sprint 54 P1-B Bug 2 fix: see instance.rs:593.
+                        source_repo: None,
                     },
                 )
             })

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -48,6 +48,8 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                     working_directory: None,
                     role: None,
                     instructions: None,
+                    // Sprint 54 P1-B Bug 2 fix: see instance.rs:593.
+                    source_repo: None,
                 },
             ) {
                 tracing::warn!(name = %inst_name, error = %e, "failed to write fleet.yaml");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -780,6 +780,8 @@ fn pane_from_menu_item(
                     working_directory: None,
                     role: None,
                     instructions: None,
+                    // Sprint 54 P1-B Bug 2 fix: see instance.rs:593.
+                    source_repo: None,
                 },
             ) {
                 tracing::warn!(error = %e, "failed to write fleet.yaml");

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -57,6 +57,8 @@ fn auto_create_general(config: &mut FleetConfig, home: &Path, persist: bool) {
         working_directory: None,
         role: Some("Fleet coordinator — routes tasks between agents".to_string()),
         instructions: None,
+        // Sprint 54 P1-B Bug 2 fix: see instance.rs:593.
+        source_repo: None,
     };
     if let Err(e) = fleet::add_instance_to_yaml(home, "general", &entry) {
         tracing::warn!(error = %e, "failed to persist general instance");

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -208,6 +208,8 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
                 working_directory: Some(work_dir),
                 role,
                 instructions,
+                // Sprint 54 P1-B Bug 2 fix: see instance.rs:593.
+                source_repo: None,
             },
         ));
         created.push(inst_name);

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -155,6 +155,17 @@ pub struct InstanceConfig {
     #[serde(default)]
     pub args: Vec<String>,
     pub working_directory: Option<String>,
+    /// Sprint 54 P1-B Bug 2 fix Option A: source repository path used by
+    /// `dispatch_auto_bind_lease` when creating per-agent worktrees via
+    /// `git worktree add`. Decouples "where the agent's git history
+    /// lives" (this field) from `working_directory` ("where the agent's
+    /// state/home dir lives"), which the daemon auto-writes to a
+    /// per-agent stub workspace at spawn time. When absent, the
+    /// worktree-leasing path falls back to `working_directory` for
+    /// backward compatibility — operators can hand-edit fleet.yaml to
+    /// point at a real source repo (e.g. operator clone) per agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_repo: Option<String>,
     pub ready_pattern: Option<String>,
     #[serde(default)]
     pub env: HashMap<String, String>,
@@ -365,6 +376,24 @@ impl FleetConfig {
         let rows = inst.rows.or(defaults.rows);
         let model = inst.model.clone().or_else(|| defaults.model.clone());
 
+        // Sprint 54 P1-B Bug 2 fix Option A: resolve source_repo into
+        // a PathBuf with the same `~/` expansion treatment as
+        // working_directory. None when fleet.yaml omits the field —
+        // dispatch_auto_bind_lease falls back to working_directory.
+        let source_repo = inst.source_repo.as_ref().map(|d| {
+            if d == "~" {
+                dirs_home().unwrap_or_else(|| PathBuf::from(d))
+            } else if let Some(rest) = d.strip_prefix("~/") {
+                if let Some(home) = dirs_home() {
+                    home.join(rest)
+                } else {
+                    PathBuf::from(d)
+                }
+            } else {
+                PathBuf::from(d)
+            }
+        });
+
         Some(ResolvedInstance {
             name: name.to_string(),
             backend_command: backend_cmd,
@@ -381,6 +410,7 @@ impl FleetConfig {
             model,
             worktree: inst.worktree,
             instructions: inst.instructions.clone(),
+            source_repo,
         })
     }
 
@@ -442,6 +472,11 @@ pub struct ResolvedInstance {
     pub model: Option<String>,
     pub worktree: Option<bool>,
     pub instructions: Option<String>,
+    /// Sprint 54 P1-B Bug 2 fix: resolved source repository path. See
+    /// `InstanceConfig::source_repo` for semantics; this is the
+    /// `PathBuf` form after fleet.yaml string deserialization, used
+    /// directly by `dispatch_auto_bind_lease` and friends.
+    pub source_repo: Option<PathBuf>,
 }
 
 fn dirs_home() -> Option<PathBuf> {
@@ -454,6 +489,12 @@ pub struct InstanceYamlEntry {
     pub working_directory: Option<String>,
     pub role: Option<String>,
     pub instructions: Option<String>,
+    /// Sprint 54 P1-B Bug 2 fix: optional source-repo path written
+    /// into the fleet.yaml stanza. Daemon auto-write callers leave
+    /// this `None` (gradient deployment per general's constraint —
+    /// only operator hand-edits opt agents in). Callers that DO want
+    /// to seed a default at write time set it explicitly.
+    pub source_repo: Option<String>,
 }
 
 /// Atomically write a serde_yaml_ng::Value back to fleet.yaml using temp + fsync + rename.
@@ -525,6 +566,12 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
                 ("working_directory", &config.working_directory),
                 ("role", &config.role),
                 ("instructions", &config.instructions),
+                // Sprint 54 P1-B Bug 2 fix: persist source_repo when
+                // caller sets it. Daemon auto-write callers leave it
+                // None per gradient-deployment constraint, so this is
+                // a no-op for them; operator-/test-driven callers can
+                // round-trip the field.
+                ("source_repo", &config.source_repo),
             ] {
                 if let Some(ref v) = val {
                     inst.insert(key.into(), serde_yaml_ng::Value::String(v.clone()));
@@ -911,6 +958,7 @@ instances:
             working_directory: Some("/tmp/work".to_string()),
             role: Some("developer".to_string()),
             instructions: Some("./instructions/dev.md".to_string()),
+            source_repo: None,
         };
         add_instance_to_yaml(&dir, "new-agent", &entry).expect("add");
         let config = FleetConfig::load(&path).expect("load after add");
@@ -957,6 +1005,7 @@ instances:
             working_directory: None,
             role: None,
             instructions: None,
+            source_repo: None,
         };
         add_instance_to_yaml(&dir, "first", &entry).expect("add to new");
         let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
@@ -1437,6 +1486,7 @@ instances:
             working_directory: None,
             role: Some("tester".to_string()),
             instructions: None,
+            source_repo: None,
         };
         add_instance_to_yaml(&dir, "temp-agent", &entry).expect("add");
 
@@ -2000,5 +2050,169 @@ defaults:
             "writeback should add id field: {content}"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ─── Sprint 54 P1-B Bug 2 fix: source_repo decouple tests ───────
+
+    /// Backward-compat: fleet.yaml that predates the field deserializes
+    /// cleanly. `source_repo` defaults to None — `dispatch_auto_bind_lease`
+    /// will fall back to `working_directory`. Locks the
+    /// `#[serde(default)]` contract.
+    #[test]
+    fn instance_config_deserializes_without_source_repo_field() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-srf-bc-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        let path = write_fleet(
+            &dir,
+            r#"
+instances:
+  legacy-agent:
+    backend: claude
+    working_directory: /tmp/legacy-agent
+"#,
+        );
+        let config = FleetConfig::load(&path).expect("load");
+        let inst = config.instances.get("legacy-agent").expect("inst present");
+        assert!(
+            inst.source_repo.is_none(),
+            "source_repo defaults to None when omitted: {inst:?}"
+        );
+        let resolved = config.resolve_instance("legacy-agent").expect("resolve");
+        assert!(resolved.source_repo.is_none());
+        assert_eq!(
+            resolved
+                .working_directory
+                .as_deref()
+                .map(|p| p.to_str().unwrap_or("")),
+            Some("/tmp/legacy-agent"),
+            "working_directory still resolves for backward-compat callers"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// New field round-trip: when fleet.yaml carries `source_repo`,
+    /// the resolved struct surfaces it as a `PathBuf` distinct from
+    /// `working_directory`. Locks the schema-decouple contract that
+    /// dispatch_auto_bind_lease relies on.
+    #[test]
+    fn instance_config_resolves_source_repo_when_set() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-srf-set-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        let path = write_fleet(
+            &dir,
+            r#"
+instances:
+  opted-in-agent:
+    backend: claude
+    working_directory: /tmp/opted-in-agent-state
+    source_repo: /tmp/opted-in-agent-source
+"#,
+        );
+        let config = FleetConfig::load(&path).expect("load");
+        let resolved = config.resolve_instance("opted-in-agent").expect("resolve");
+        assert_eq!(
+            resolved
+                .source_repo
+                .as_deref()
+                .map(|p| p.to_str().unwrap_or("")),
+            Some("/tmp/opted-in-agent-source"),
+            "source_repo resolves to the explicit fleet.yaml value"
+        );
+        assert_eq!(
+            resolved
+                .working_directory
+                .as_deref()
+                .map(|p| p.to_str().unwrap_or("")),
+            Some("/tmp/opted-in-agent-state"),
+            "working_directory remains the per-agent state-home dir, decoupled from source_repo"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// `~/` expansion applies to source_repo with the same treatment
+    /// `working_directory` already gets. Locks parity so operator
+    /// muscle-memory transfers cleanly between the two fields.
+    #[test]
+    fn instance_config_source_repo_tilde_expanded() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-srf-tilde-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        let path = write_fleet(
+            &dir,
+            r#"
+instances:
+  tilde-agent:
+    backend: claude
+    source_repo: ~/op-clone
+"#,
+        );
+        let config = FleetConfig::load(&path).expect("load");
+        let resolved = config.resolve_instance("tilde-agent").expect("resolve");
+        let source_repo = resolved.source_repo.expect("source_repo set");
+        let expected_home = dirs::home_dir().expect("home dir");
+        assert_eq!(
+            source_repo,
+            expected_home.join("op-clone"),
+            "~ expansion must match working_directory's behaviour"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Round-trip: writing an `InstanceYamlEntry` with `source_repo`
+    /// set persists the field to disk in a form that re-loads
+    /// identically. Locks the writer-reader symmetry — without this,
+    /// operators editing fleet.yaml could see their `source_repo`
+    /// silently disappear on the next daemon write.
+    #[test]
+    fn add_instance_to_yaml_round_trips_source_repo() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-srf-rt-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        fs::create_dir_all(&dir).ok();
+        let entry = InstanceYamlEntry {
+            backend: Some("claude".to_string()),
+            working_directory: Some("/tmp/rt-state".to_string()),
+            role: Some("opted-in test agent".to_string()),
+            instructions: None,
+            source_repo: Some("/tmp/rt-source".to_string()),
+        };
+        add_instance_to_yaml(&dir, "rt-agent", &entry).expect("add");
+        let content = std::fs::read_to_string(dir.join("fleet.yaml")).expect("read");
+        assert!(
+            content.contains("source_repo: /tmp/rt-source"),
+            "source_repo must round-trip through the writer: {content}"
+        );
+        let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        let resolved = config.resolve_instance("rt-agent").expect("resolve");
+        assert_eq!(
+            resolved
+                .source_repo
+                .as_deref()
+                .map(|p| p.to_str().unwrap_or("")),
+            Some("/tmp/rt-source"),
+        );
+        fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -25,11 +25,21 @@ pub(crate) fn dispatch_auto_bind_lease(
     branch: &str,
     repo: Option<&str>,
 ) -> Result<(), String> {
-    // Resolve source repo from target agent's working directory.
-    let source_repo = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+    // Sprint 54 P1-B Bug 2 fix Option A: resolve source repo from the
+    // target agent's `source_repo` field first (decoupled per-agent
+    // canonical source), falling back to `working_directory` for
+    // backward compatibility with fleet.yaml that predates the field,
+    // and finally to the `home/workspace/<agent>` stub for instances
+    // that haven't been resolved at all. The fallback chain preserves
+    // pre-fix behaviour for agents whose fleet.yaml hasn't been
+    // hand-edited to opt in.
+    let resolved = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
         .ok()
-        .and_then(|f| f.resolve_instance(target))
-        .and_then(|r| r.working_directory)
+        .and_then(|f| f.resolve_instance(target));
+    let source_repo = resolved
+        .as_ref()
+        .and_then(|r| r.source_repo.clone())
+        .or_else(|| resolved.as_ref().and_then(|r| r.working_directory.clone()))
         .unwrap_or_else(|| home.join("workspace").join(target));
 
     // P0-1.5: central lease registry check — reject if another agent holds this branch.

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -599,6 +599,12 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
                 working_directory: Some(work_dir.clone()),
                 role,
                 instructions: None,
+                // Sprint 54 P1-B Bug 2 fix: gradient deployment per
+                // general's constraint — daemon auto-write leaves
+                // source_repo None; operator hand-edits fleet.yaml to
+                // opt agents in. Backward-compat preserved via
+                // dispatch_auto_bind_lease's working_directory fallback.
+                source_repo: None,
             };
             if let Err(e) = crate::fleet::add_instance_to_yaml(home, name, &entry) {
                 tracing::warn!(error = %e, "failed to persist to fleet.yaml");


### PR DESCRIPTION
## Summary
- P1-B Bug 2 fix per operator m-3621 + general's Option A confirmation. The audit (PR #518 squash `eeed1d7`) revealed the visible bug ("daemon worktree empty") was **misdiagnosed** — `git worktree add` ALREADY runs in `worktree_pool::lease()`. RCA #2 + #3 traced the conflation: `dispatch_auto_bind_lease` uses `working_directory` (per-agent state-home stub) as `source_repo` (real code repo). Fix: decouple via additive `source_repo: Option<String>` field.
- Tier-1 single primary (codex). Path A wiring (Phase 5 smoke embargo-deferred). Decision/task: `t-20260508003217937550-14`.

## Embargo (zero violations)
- IMPL/test in parallel worktree `/op-clone-worktrees/sprint54-p1b-bug2-fix-option-c-provisioning` (Phase A migration target, lead-greenlit)
- Operator clone touched only via `git -C` composition for Pre-Phase 0 cleanup (audited)
- Commit cycle uses `AGEND_GIT_BYPASS_AGENT=dev` (lead-greenlit foreseen-fallback per Phase A unbind)
- No \`/usr/bin/git\`, no MCP structural ops, no daemon restart implied

## What changed (8 files, +244 LOC, ≤300 ceiling)

### Schema additive (3 sites in \`src/fleet.rs\`)
- \`InstanceConfig.source_repo: Option<String>\` — fleet.yaml field (serde default = None)
- \`ResolvedInstance.source_repo: Option<PathBuf>\` — runtime form with \`~/\` expansion parity
- \`InstanceYamlEntry.source_repo: Option<String>\` — writer-side field
- \`add_instances_to_yaml\` writer extends field-list to persist when set

### dispatch_auto_bind_lease (1 site, the actual fix)
\`\`\`rust
resolved.source_repo
    .or(resolved.working_directory)
    .unwrap_or_else(|| home.join(\"workspace\").join(target))
\`\`\`
Pre-fix behaviour preserved when \`source_repo\` is None (fallback chain hits working_directory).

### Daemon auto-write sites (5 + 1, gradient deployment per general)
All pass \`source_repo: None\` (operator hand-edits to opt agents in):
- \`mcp/handlers/instance.rs:593\` (spawn_single_instance)
- \`api/handlers/team.rs:98\` (handle_create_team)
- \`app/mod.rs:778\` (TUI new-tab fleet instance)
- \`app/commands.rs:46\` (CLI agent add)
- \`bootstrap/fleet_normalize.rs:51\` (general bootstrap)
- \`deployments.rs:206\` (deployment template)

### Tests (4 new + 3 existing constructor extensions)
- \`instance_config_deserializes_without_source_repo_field\` — backward-compat
- \`instance_config_resolves_source_repo_when_set\` — forward-compat decouple
- \`instance_config_source_repo_tilde_expanded\` — parity with working_directory
- \`add_instance_to_yaml_round_trips_source_repo\` — writer-reader symmetry (regression-proof)

## Verification
- \`cargo build\` + \`cargo fmt --check\` + \`cargo clippy --all-targets -- -D warnings\`: clean
- \`cargo test --bin agend-terminal --lib fleet::\`: 52 passed (4 new + 48 pre-existing)
- Full lib test: 1645 passed / 0 failed (was 1641 + 4 new)

## Migration recipe (operator-side, no daemon restart needed)

Per opted-in agent, hand-edit fleet.yaml:
\`\`\`yaml
instances:
  dev:
    source_repo: /Users/suzuke/Documents/Hack/agend-terminal   # operator clone path
    # ... existing fields untouched
\`\`\`

Subsequent dispatches landing on this agent create worktrees from \`source_repo\` (real code) instead of the workspace-stub \`working_directory\`. Existing leased worktrees may be released+rebound for fresh population, or wait for natural lifecycle release.

For agents NOT opted in: behaviour unchanged. The fallback chain hits \`working_directory\` exactly as it did pre-fix.

## §3.5.13 push form scope-claim
scope follows dispatch — P1-B Bug 2 fix Option A schema-decouple: InstanceConfig + InstanceYamlEntry + ResolvedInstance gain \`source_repo: Option<String>\` additive field; dispatch_auto_bind_lease prefers source_repo over working_directory fallback chain; daemon auto-write 5 sites + 1 fleet_normalize untouched semantically (gradient deployment per general's constraint, all pass \`source_repo: None\`); add_instances_to_yaml writer extends field-list to persist source_repo when set; backward-compat trivial via serde default; 4 new unit tests cover backward-compat + opted-in + tilde-expansion + round-trip; LOC +244 within 300 ceiling; embargo-respecting (parallel worktree only, no MCP structural ops, no daemon restart, AGEND_GIT_BYPASS_AGENT=dev for commit cycle per lead m-20260508010118605812-298 foreseen-fallback); Tier-1; Path A (Phase 5 smoke deferred — operator-side migration recipe in PR body); no other deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)