### PR TITLE
docs(sprint-55): P0 design phase — Phase 3 lead synthesis

### DIFF
--- a/docs/DESIGN-sprint55-p0a-channel-discipline-guard.md
+++ b/docs/DESIGN-sprint55-p0a-channel-discipline-guard.md
@@ -1,0 +1,194 @@
+# Sprint 55 P0-A — Channel Discipline Daemon-Level Enforcement (FINAL)
+
+**Status**: Phase 3 lead-synthesized design — pending operator review per m-3637 design-first directive
+**Date**: 2026-05-08
+**Phase 1 input**: dev RCA `docs/internal/DESIGN-sprint55-p0a-channel-discipline-guard-v1-dev-rca.md`
+**Phase 2 input**: reviewer challenge `docs/internal/CHALLENGE-sprint55-p0a-channel-discipline-guard-reviewer.md`
+**Authors**: dev (primary RCA) + reviewer (challenge) + lead (synthesis)
+
+## §1 Executive summary
+
+**Problem**: `handle_reply` MCP tool handler (`src/mcp/handlers/channel.rs:5-28`) uses singleton `crate::channel::active_channel()` instead of consulting per-instance `reply_to_channel` heartbeat_pair field. In multi-channel fleets (telegram + discord), this can silently route replies to the wrong channel — a deterministic correctness gap, latent today (telegram-only production) but locked-in once discord rolls out broadly.
+
+**Premise (verified by dev + lead cross-grep)**: `reply_to_channel` flag DOES exist in current codebase as Sprint 52 redesign (PR #437 + #440) of Sprint 49's reverted `last_input_channel` design. Sprint 52 deadlock-RCA absorbed; production-proven via 60s soak with 2.1B events 0% drift.
+
+**Final design — Variant-extend** (chosen over Variant-refuse per reviewer Phase 2 challenge):
+- Add `lookup_channel_by_name(name) -> Option<Arc<dyn Channel>>` to channel registry
+- `handle_reply` reads sender's `HeartbeatPair.reply_to_channel`
+- Prefers tagged channel when present + currently-registered
+- Falls back to `active_channel()` singleton when `reply_to_channel == None`
+- Returns structured error `code: "reply_channel_unavailable"` when tagged channel unregistered/offline
+- Warn-log only on actionable divergence (mismatch / refusal / unavailable) — NOT happy-path equality
+
+## §2 Chosen variant: Variant-extend (vs Variant-refuse)
+
+| Aspect | Variant-refuse (rejected) | Variant-extend (CHOSEN) |
+|---|---|---|
+| LOC | ~30-40 | ~50-85 |
+| Multi-channel correctness | Refuses on mismatch | Routes to tagged channel |
+| Agent UX in healthy multi-channel state | Forces retry churn | Transparent attribution preserved |
+| Future `target_channel` arg compatibility | Limited | Natural extension |
+| Locks routing invariant before discord broadens | Partial | Full |
+
+**Rejection rationale for Variant-refuse**: discord integration shipped Sprint 54 P2-8/P2-8b (#512/#513); multi-channel fleet timing is no longer purely hypothetical. Refuse-only creates avoidable retry churn when channel exists but isn't singleton. Extend keeps attribution correctness AND preserves delivery in healthy multi-channel states.
+
+**Counterpoint acknowledged**: Variant-refuse is acceptable as INTERIM step under extreme schedule pressure, with explicit follow-up ticket to migrate to Variant-extend. Operator's call. Default recommendation: Variant-extend now (small marginal LOC, cleaner long-term contract).
+
+## §3 Implementation surface
+
+### Code sites (verified at `26e7331`)
+
+1. **`src/channel/mod.rs`** — add registry lookup-by-name:
+   ```rust
+   pub fn lookup_channel_by_name(name: &str) -> Option<Arc<dyn Channel>> { ... }
+   ```
+   Plus a `name(&self) -> &str` accessor on the `Channel` trait OR equivalent struct field.
+
+2. **`src/mcp/handlers/channel.rs:5-28`** — replace singleton lookup with prefer-chain:
+   ```rust
+   pub fn handle_reply(...) -> Value {
+       let pair_snapshot = heartbeat_pair::snapshot_for(instance_name);
+       let target = match pair_snapshot.reply_to_channel.as_deref() {
+           Some(name) => match crate::channel::lookup_channel_by_name(name) {
+               Some(ch) => ch,
+               None => return json!({
+                   "error": format!("reply_to_channel '{name}' not registered or offline"),
+                   "code": "reply_channel_unavailable"
+               }),
+           },
+           None => match crate::channel::active_channel() {
+               Some(ch) => ch,
+               None => return json!({"error": "no active channel", "code": "no_active_channel"}),
+           },
+       };
+       // ... existing send_from_agent logic
+   }
+   ```
+
+3. **Tests** in `src/mcp/handlers/tests.rs`:
+   - Match: `reply_to_channel` set + lookup returns Some → uses tagged channel
+   - Mismatch: `reply_to_channel` set + lookup returns None → returns structured error
+   - Absent: `reply_to_channel = None` → falls back to `active_channel()`
+   - Capability check: tagged channel exists but doesn't support reply → structured error
+
+### Telemetry
+
+Warn-log on **actionable divergence only**:
+- `reply_to_channel` set + tagged channel unregistered → `WARN`
+- `reply_to_channel` set + tagged channel returns send error → `WARN`
+- `reply_to_channel == None` → no log (happy-path fallback to singleton)
+- `reply_to_channel == active_channel().name()` (single-channel fleet steady state) → no log
+
+Rationale: always-log creates noise floor in single-channel fleet; never-log blocks forensic debugging. Actionable-only balances.
+
+## §4 Edge case adjudication (7 + 4 reviewer-added = 11 total)
+
+### EC1 — Mixed-channel (telegram + TUI in same window) [INHERIT Sprint 52]
+- Sprint 52 `src/layout/pane.rs:111` clears `reply_to_channel` on TUI keyboard input
+- Guard reads cleared `None` → falls back to `active_channel()` (which on TUI may be telegram or whichever singleton)
+- No new logic needed; intentional UX (operator typing locally signals "working here now")
+
+### EC2 — Mid-message channel drop (offline mid-stream)
+- Guard returns `code: "reply_channel_unavailable"`
+- **Bounded retry policy** (per reviewer m-25): agent attempts max 2 retries, backoff 200ms then 800ms, then fail loud
+- Prevents infinite retry loops + handles transient reconnects deterministically
+
+### EC3 — Multi-turn (channel changes between turns same task)
+- Sprint 52 `reply_to_input_id` monotonic counter ensures per-turn freshness
+- Guard reads `snapshot_for` at handler-call-time → current turn's `reply_to_channel` correct
+- No new logic needed
+
+### EC4 — Daemon restart (persistence?)
+- Sprint 52 contract: ephemeral (in-memory `OnceLock<Mutex<HashMap>>`)
+- Post-restart `reply_to_channel = None` → fallback to `active_channel()`
+- INHERIT Sprint 52 ephemeral semantics; persistence adds write-amplification + stale-attribution risks
+
+### EC5 — Concurrent (two channels racing same agent inbox)
+- Sprint 52 inbox.rs:482 "last channel-sourced message wins" semantic
+- Mirror infrastructure auto-sends PTY output to whichever `reply_to_channel` won
+- **Largely benign post-Sprint-52** (mirror covers second channel's expected reply receipt)
+- Document explicitly
+
+### EC6 — Channel disconnect at reply time
+- Same as EC2: structured error `code: "reply_channel_unavailable"`
+- Bounded retry policy per reviewer m-25
+
+### EC7 — "Turn" definition
+- INHERIT Sprint 52's Idle→Ready transition + 3s silence fallback
+- Backend-specific quirks (e.g. KiroCli pause-states) covered by per-backend state-tracker work (Sprint 50-52)
+
+### EC8 (reviewer-added) — Agent-peer-only mode (no external channel registered)
+- Daemon running headless (no telegram, no discord registered)
+- Agent calls `reply` after agent-peer `send` input → `reply_to_channel = None` (only telegram/TUI sources set this) → falls back to `active_channel()` → `None` → structured error `code: "no_active_channel"`
+- **Document explicit behavior**: `reply` requires registered external channel; agent-peer message routing is via `send` MCP tool, not `reply`
+
+### EC9 (reviewer-added) — Channel name aliasing/migration
+- If channel identifier changes (e.g. `telegram` → `telegram-main`), `lookup_channel_by_name` fails despite same logical sink
+- **Recommendation**: stable canonical channel IDs; if rename needed, daemon-side alias map handling (not exposed in P0-A scope)
+- Out-of-scope mitigation: future `target_channel` arg with alias support (Sprint 56)
+
+### EC10 (reviewer-added) — Snapshot/send TOCTOU race
+- `reply_to_channel` snapshot valid at read-time; channel unregistered between snapshot and send call
+- **Branch to same `code: "reply_channel_unavailable"` error** — do not silently fall back to singleton
+- Same retry policy as EC2/EC6 applies
+
+### EC11 (reviewer-added) — Mixed capability channels
+- Some channels may support edit/react but not reply-like semantics
+- `lookup_channel_by_name` MUST validate operation capability via `Channel::supports_reply()` accessor (existing trait method per channel/mod.rs caps probe)
+- If incapable → structured error `code: "channel_capability_unsupported"`
+
+## §5 Cross-P0 integration testing (per reviewer m-25)
+
+When P0-A + P0-B both land:
+
+1. **Restart + binding + reply attribution**: Bind agent (`source_repo` set per P0-B), inject channel input, restart daemon, verify post-restart reply behavior is explicit-error not silent
+2. **Concurrent dispatch + channel switch**: while binding state mutates branch/watch, issue channel-originated messages, verify reply guard preserves attribution OR fails with structured code
+3. **Multi-agent shared repo + mixed channels**: 2 agents same source_repo + different branches; telegram input to one, discord input to other; verify zero cross-agent/channel bleed
+
+Implementation order: **P0-A first, then P0-B** (per reviewer + lead consensus). Channel-discipline guard is smaller, de-risks user-facing routing correctness before broader binding lifecycle refactors.
+
+## §6 LOC + Tier estimate
+
+| Component | LOC est | Notes |
+|---|---|---|
+| `lookup_channel_by_name` registry add | ~10-15 | HashMap lookup pattern |
+| `Channel::name()` accessor | ~5-10 | Trait method or struct field |
+| `handle_reply` prefer-chain refactor | ~25-35 | Snapshot read + lookup + branch |
+| Tests | ~30-50 | 11 edge case unit tests |
+| **Total** | **~70-110** | Slightly above general's 30-50 nominal due to Variant-extend choice |
+
+**Tier**: Tier-1 single primary review (codex). No Tier-2 escalation expected.
+
+**LOC ceiling**: 150 nominal, 200 hard escalate. Past 200 → flag scope drift.
+
+## §7 Out of scope (deferred)
+
+- **`target_channel` explicit arg** — Sprint 56 follow-up after P0-A telemetry establishes mismatch/offline rate baseline
+- **Persistent `reply_to_channel` across daemon restart** — Sprint 52 ephemeral contract preserved
+- **Channel name aliasing infra** — separate refactor if needed
+- **Sprint 49's prompt-injection design** — superseded by Sprint 52 router-layer mirror (production-proven)
+
+## §8 Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Variant-extend introduces channel registry race (concurrent register/lookup) | LOW-MED | Use existing lock-tier-3 pattern (heartbeat_pair precedent) |
+| Warn-log volume in single-channel fleet | LOW | Only-on-actionable-divergence policy (no happy-path noise) |
+| Bounded retry creates user-visible delay on transient channel blips | LOW | 200+800ms backoff is sub-second total; agent decides ultimate retry |
+| Future `target_channel` arg widens scope mid-Sprint | LOW | Out-of-scope this PR; Sprint 56 follow-up explicit |
+| Channel capability check breaks edit/react-only channel implementations | LOW | Capability accessor already exists per `Channel` trait caps probe |
+
+## §9 Status / next steps
+
+- **Phase 1 dev RCA**: Complete (`docs/internal/DESIGN-sprint55-p0a-channel-discipline-guard-v1-dev-rca.md`)
+- **Phase 2 reviewer challenge**: Complete (`docs/internal/CHALLENGE-sprint55-p0a-channel-discipline-guard-reviewer.md`)
+- **Phase 3 lead synthesis**: This document
+- **Operator review**: Pending m-3637 directive
+- **Phase 4 IMPL** (post-approval): dev primary, reviewer Tier-1, ~70-110 LOC, ~1.5-2hr cycle
+
+**Disagreement summary** (resolved per Phase 3 synthesis):
+- Variant choice: dev deferred → reviewer Variant-extend → **lead concurs Variant-extend**
+- Observed bug evidence framing: dev neutral → reviewer "latent deterministic gap" → **lead concurs "latent deterministic"**
+- Cross-P0 test surface: dev 0 cross-tests → reviewer 3 scenarios → **lead concurs 3 scenarios**
+
+Sprint 52 prior-art absorbs deadlock + lock-ordering risk. P0-A delta is small + bounded.

--- a/docs/DESIGN-sprint55-p0b-unified-bind.md
+++ b/docs/DESIGN-sprint55-p0b-unified-bind.md
@@ -1,0 +1,225 @@
+# Sprint 55 P0-B — Unified Bind Dynamic Binding (FINAL)
+
+**Status**: Phase 3 lead-synthesized design — pending operator review per m-3637 design-first directive
+**Date**: 2026-05-08
+**Phase 1 input**: dev RCA `docs/internal/DESIGN-sprint55-p0b-unified-bind-v1-dev-rca.md`
+**Phase 2 input**: reviewer challenge `docs/internal/CHALLENGE-sprint55-p0b-unified-bind-reviewer.md`
+**Authors**: dev (primary RCA) + reviewer (challenge) + lead (synthesis)
+
+## §1 Executive summary
+
+**Problem**: Current `bind_self` MCP tool requires explicit `repo: "owner/name"` GitHub-format argument. `ci(action: watch)` likewise requires explicit `repo` arg. Operators must compute and pass GitHub identifier even when the local source_repo path's `git remote get-url origin` would yield the same answer. Plus: post Sprint 54 PR #519 fleet.yaml `source_repo:` field, the binding chain has 3-tier resolution but no caller-facing dynamic API uses it cleanly.
+
+**Final design** (per dev RCA + reviewer Phase 2 challenge):
+- `bind_self(source_repo: PathBuf, branch: &str)` — daemon resolves owner/repo via existing `derive_repo_from_remote` + `parse_github_owner_repo` parsers
+- `ci(action: watch)` accepts no `repo` arg → reads sender's `binding.json::source_repo` → derives owner/repo
+- Backward-compat: dual-arg acceptance (legacy `repo: "owner/name"` still works) for **two-sprint deprecation cycle** (Sprint 55 → 56 warn → Sprint 57 remove)
+- Three-tier source_repo resolution: explicit arg → fleet.yaml `source_repo:` → working_directory fallback (preserved per Sprint 54 PR #519)
+- **EC10 SPLIT**: auto-bind dispatch trigger scope filter → separate **P0-C** doc (see `DESIGN-sprint55-p0c-auto-bind-task-class-filter.md`)
+- **EC4 non-GitHub remote**: add `repo: Option<String>` companion field to `InstanceConfig` for explicit override
+
+**Premise check**: Code surface intact. All hooks for proposed unified binding exist on `26e7331`:
+- `parse_github_owner_repo` handles HTTPS/HTTP/SSH/`ssh://git@` (`dispatch_hook/mod.rs:95-111`)
+- `derive_repo_from_remote` runs `git remote get-url origin` with bypass (`mod.rs:118-130`)
+- `dispatch_auto_bind_lease` consumes `source_repo` via fleet.yaml resolution (PR #519)
+- `bind_full` persists `source_repo` into `binding.json`
+- `handle_watch_ci` idempotent + append-aware (Sprint 54 P0-1)
+
+## §2 Chosen design: dual-arg bind_self with derivation pipeline
+
+```rust
+// New unified shape
+bind_self(source_repo: PathBuf, branch: &str) -> Result<{worktree_path, branch, owner_repo}>
+
+// Backward-compat (Sprint 55 only, warn-log)
+bind_self(repo: "owner/name", branch: ...) -> existing path with deprecation warning
+
+// Both args present
+bind_self(repo: ..., source_repo: ...) -> reject with code: "ambiguous_args"
+
+// ci(watch) auto-derive
+ci(action: "watch")  // no repo arg
+  → reads caller's binding.json source_repo
+  → derives owner/repo via existing parsers
+  → invokes existing watch logic
+```
+
+### Three-tier source_repo resolution chain (PR #519 preserved + observability per reviewer m-25)
+
+1. **Explicit arg** in `bind_self(source_repo=...)` — wins
+2. **Fleet.yaml `source_repo:`** — second-tier fallback (already wired in `dispatch_auto_bind_lease:36-43`)
+3. **`working_directory`** — third-tier fallback (PR #519 chain preserves)
+4. **`home/workspace/<agent>` stub** — fourth-tier (deprecation candidate; emit warning when hit)
+
+**Per reviewer challenge**: emit info log naming which tier was hit; emit WARN when tier 4 is hit (silent stub-source produces wrong provenance). Optional strict-mode env flag to reject tier 4 in production.
+
+## §3 Rejected alternatives
+
+- **Auto-detect upstream remote when origin is fork** — rejected (magical/surprising; honor explicit `repo` arg instead)
+- **Multi-remote priority parser (origin/upstream/etc)** — rejected for P0-B core; `remote: "upstream"` arg is future extension if needed
+- **Hard-cutover deprecation (one-sprint)** — rejected per reviewer; **two-sprint window** chosen for caller migration runway
+- **Auto-clone fork per agent** — rejected (complexity explosion; multi-agent shared source_repo already supported per Sprint 53 P0-1.5)
+- **EC10 task-class filter bundled in P0-B core** — rejected per reviewer; **split as P0-C** (separate doc)
+- **EC10 in minimal `bind: false` opt-out form** within P0-B — acknowledged as alternative if leadership insists on bundling (defer to operator decision)
+
+## §4 Edge case adjudication (10 + 5 reviewer-added = 15 total)
+
+### EC1 — `ci(watch)` invoked without prior `bind_self`
+**Recommendation**: Surface explicit error `{"error": "ci(watch) needs explicit 'repo' arg OR active binding (call bind_self first)", "code": "no_binding_no_repo"}`. No silent cwd-based derivation.
+
+### EC2 — Fork vs upstream
+**Recommendation**: Honor explicit `repo` arg over derivation. Default derivation reflects local origin (fork or upstream, whichever it is). Operator workflow choice via fleet.yaml `repo:` companion field (NEW per EC4 reviewer challenge).
+
+### EC3 — Multi-remote (origin + upstream + others)
+**Recommendation**: Inherit current behavior — parse `origin` only. Future extension: `remote: "upstream"` arg if needed.
+
+### EC4 — SSH vs HTTPS URL normalization
+**Recommendation**: No new code. `parse_github_owner_repo` already handles 4 URL forms (Sprint 53 P0-2). 
+
+**Reviewer-added**: For non-GitHub remotes (parser returns None) → add `repo: Option<String>` companion field to `InstanceConfig`. Derivation order:
+1. Explicit `bind_self(repo=...)` arg
+2. `binding.repo` / fleet.yaml `repo:` override
+3. Derive from source_repo origin (GitHub parser)
+
+If all three fail → structured error `code: "non_github_remote_no_override"`.
+
+### EC5 — Detached HEAD
+**Recommendation**: No impact. `branch` is explicit caller arg; daemon doesn't read local HEAD.
+
+### EC6 — Migration (fleet.yaml `source_repo:` agents from PR #519)
+**Recommendation**: Three-tier resolution chain (per §2 above) + observability:
+- INFO log naming which tier was used per resolution
+- WARN log when tier 3 (working_directory) hit
+- WARN log when tier 4 (workspace stub) hit
+- Optional strict-mode env flag rejects tier 4 in production
+
+### EC7 — Stale ci-watch on `release_worktree`
+**Recommendation**: `release_worktree(agent)` should unsubscribe ci-watches matching released `repo + branch` exactly; leave unrelated watches untouched.
+
+**Reviewer-added challenge**: This audit is **Phase 3 IMPL prerequisite owned by dev**. Reviewer demands explicit proof in PR (test + trace) that release_worktree cleans only matching watch scope.
+
+### EC8 — Multi-agent shared source_repo
+**Recommendation**: Inherit Sprint 53 P0-1.5 cross-agent registry check + Sprint 54 P0-1 idempotent append. Multiple agents on different branches share source_repo cleanly.
+
+### EC9 — Argument deprecation
+**Final**: **Two-sprint deprecation window** (per reviewer m-25):
+- **Sprint 55**: dual-arg support + warning telemetry (`repo` arg → warn-log; `source_repo` arg → preferred)
+- **Sprint 56**: tighten warnings to explicit migration notices (each `repo` use logs ERROR-level + caller name)
+- **Sprint 57**: remove legacy `repo` arg path; hard-fail on `repo`-only callers
+
+If both args present → reject with `code: "ambiguous_args"` (immediate rejection, not deprecation-window-soft).
+
+### EC10 — **SPLIT to P0-C** (auto-bind dispatch trigger scope)
+Reviewer's verdict: distinct semantic from P0-B's HOW-to-bind contract. Split as P0-C separate dispatch.
+
+See `docs/DESIGN-sprint55-p0c-auto-bind-task-class-filter.md` for full P0-C design.
+
+### EC11 (reviewer-added) — Concurrent `bind_self` same agent, different branches
+**Recommendation**: Per-agent in-flight guard (mutex or atomic counter) to prevent interleaved binding state writes. Bind operations serialized per-agent.
+
+### EC12 (reviewer-added) — No remote configured in source_repo
+**Recommendation**: Explicit error `code: "no_remote_configured"` with remediation hint: "configure origin remote OR pass explicit `repo` arg".
+
+### EC13 (reviewer-added) — Branch absent on origin
+**Recommendation**: Reject by default with `code: "branch_not_found"`. Do NOT auto-create remote branch silently.
+
+If operator wants auto-create, add explicit `auto_create: bool` flag (Sprint 56+ extension).
+
+### EC14 (reviewer-added) — Source_repo path exists but is not a git repo
+**Recommendation**: Explicit validation via `git -C <path> rev-parse --git-dir` before deriving anything. Error `code: "not_a_git_repo"`.
+
+### EC15 (reviewer-added) — Stale binding source_repo path deleted after bind
+**Recommendation**: `ci(watch)` fallback validates source_repo path exists before reading. If gone → fail deterministically with `code: "source_repo_path_deleted"`. Do NOT silently fall back to cwd.
+
+## §5 Cross-P0 integration testing (per reviewer m-25)
+
+When P0-A + P0-B both land, integration test matrices:
+
+### Matrix 1: Unified bind + reply guard interoperability
+- Channel-reply attribution behavior remains correct while binding state mutates
+- Bind agent → telegram input → mid-bind branch switch → verify reply lands on correct channel
+
+### Matrix 2: Recovery test
+- Restart daemon during bound session + ci-watch active + reply action
+- Verify both P0-A reply attribution + P0-B binding restoration behave correctly post-restart
+
+### Matrix 3: Negative-path
+- non-git repo, no origin remote, non-GitHub remote, missing branch, stale path
+
+### Matrix 4: Concurrency
+- Simultaneous `bind_self` from same agent on different branches
+- Two agents sharing same source_repo on different branches
+
+## §6 LOC + Tier estimate
+
+| Component | LOC est | Notes |
+|---|---|---|
+| `handle_bind_self` arg shape change (`worktree.rs:37-102`) | ~40-60 | Accept `source_repo: PathBuf`, dual-arg backward-compat with warn-log, invoke `derive_repo_from_remote` |
+| `handle_watch_ci` auto-binding lookup (`ci/mod.rs:159-285`) | ~30-50 | Read sender's `binding.json::source_repo` when `repo` arg absent |
+| Backward-compat shim (legacy `repo` arg + warn-log) | ~10-20 | Conditional handler entry; deprecation path |
+| `release_full` ci-watch unsubscribe (EC7) | ~15-25 | Audit current behavior first; add unsubscribe loop matching `repo + branch` if absent |
+| `repo: Option<String>` companion field (EC4) | ~10-15 | Additive `InstanceConfig` field + serde + resolver chain plumbing |
+| Per-agent bind in-flight guard (EC11) | ~10-20 | Atomic flag or mutex per-agent in heartbeat_pair |
+| 3-tier resolution chain observability (EC6) | ~15-25 | INFO + WARN logs per tier hit |
+| Tests | ~80-120 | 15 edge case unit tests + integration matrices |
+| **Total** | **~210-335** | Slightly above general's 200-300 nominal due to reviewer-added edge cases |
+
+**Tier**: Tier-1 single primary review (codex) baseline. **Escalate Tier-2** if RCA during IMPL surfaces cross-cutting changes beyond enumerated sites OR test infrastructure churn (e.g. mock binding.json shape changes ripple into unrelated tests).
+
+**LOC ceiling**: 350 nominal (above general's 300, justified by reviewer-added edge cases adding 5 cases × ~10-15 LOC each = ~50-75 additional). 400 hard escalate.
+
+## §7 Out of scope (deferred)
+
+- **GitLab/Bitbucket forge support** — future extension via additional parser
+- **`remote: "upstream"` arg** — future extension if multi-remote workflow surfaces
+- **Auto-create remote branch** — explicit `auto_create: bool` flag (Sprint 56+)
+- **EC10 task-class filter** — split as P0-C (separate Sprint 55 design)
+- **`worktree_pool::lease` semantics redesign** — production-proven, untouchable
+
+## §8 Implementation order (per reviewer + lead consensus)
+
+**Sequential preferred**: P0-A first (smaller user-facing correctness guard) → P0-B core (binding refactor) → P0-C (task-class filter) if approved.
+
+**Parallel possible** if PR scopes are strictly disjoint:
+- P0-A touches `src/mcp/handlers/channel.rs` + `src/channel/mod.rs`
+- P0-B core touches `src/mcp/handlers/worktree.rs` + `src/mcp/handlers/dispatch_hook/mod.rs` + `src/mcp/handlers/ci/mod.rs` + `src/fleet.rs`
+- P0-C touches `src/task` + `src/mcp/handlers/dispatch_hook/mod.rs` (overlap with P0-B)
+
+Recommendation: **Sequential** — channel discipline first to lock routing invariants, then binding refactor with confidence in routing layer。Reduces debugging ambiguity if regressions surface during rollout。
+
+## §9 Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| EC9 deprecation period creates dual-arg ambiguity bugs | LOW-MED | Reject when both args present; warn-log when `repo` arg used; two-sprint runway |
+| EC10 split increases Sprint 55 P0 count from 2 to 3 | LOW | Smaller individual PRs, easier review/test |
+| Non-GitHub remote silent fail without `repo:` companion | LOW | EC4 add `repo: Option<String>` field |
+| Multi-remote workflows surprise | LOW | Honor explicit arg; future extension explicit |
+| `release_worktree` auto-unsubscribe breaks intentional multi-watch agents | LOW | Match `repo + branch` exactly per EC7; unrelated watches unaffected |
+| Backward-compat shim weakens migration "stick" | LOW | Two-sprint deprecation cycle; tier-by-tier escalation of warning severity |
+| LOC creeps past 350 ceiling due to reviewer-added EC11-EC15 | LOW-MED | Some edges (EC13/EC14/EC15) may turn out to be ~5 LOC each (validation guards); total may stay ≤300 |
+
+## §10 Status / next steps
+
+- **Phase 1 dev RCA**: Complete
+- **Phase 2 reviewer challenge**: Complete
+- **Phase 3 lead synthesis**: This document
+- **Operator review**: Pending m-3637 directive
+- **Phase 4 IMPL** (post-approval): dev primary, reviewer Tier-1, ~210-335 LOC, ~3-4hr cycle
+
+**Disagreement summary** (resolved per Phase 3 synthesis):
+- EC10 bundling: dev "Phase 2 picks" → reviewer "split as P0-C" → **lead concurs split**
+- EC9 deprecation cycle: dev "1 sprint" → reviewer "2 sprints" → **lead concurs 2 sprints**
+- EC4 non-GitHub remote: dev "explicit error" → reviewer "add `repo: Option<String>` override field" → **lead concurs add field**
+- EC6 fallback chain observability: dev "info log" → reviewer "info+warn+strict-mode" → **lead concurs full observability**
+- EC7 ownership: dev "audit during P0-B IMPL" → reviewer "explicit IMPL prerequisite + test proof" → **lead concurs IMPL prerequisite**
+
+Sprint 53/54 prior-art covers most concurrency + lock-ordering risks. P0-B core is bounded refactor + edge-case hardening.
+
+## §11 P0-C reference
+
+EC10 originally bundled with P0-B; reviewer Phase 2 challenge split it. See:
+
+`docs/DESIGN-sprint55-p0c-auto-bind-task-class-filter.md`
+
+Standalone scope: ~30-50 LOC for minimal opt-out form (`bind: false` task field), ~80-150 LOC for full task-class taxonomy. Operator decides which form post-P0-B.

--- a/docs/DESIGN-sprint55-p0c-auto-bind-task-class-filter.md
+++ b/docs/DESIGN-sprint55-p0c-auto-bind-task-class-filter.md
@@ -1,0 +1,221 @@
+# Sprint 55 P0-C — Auto-Bind Dispatch Trigger Scope Filter (FINAL)
+
+**Status**: Phase 3 lead-synthesized design — pending operator review per m-3637 design-first directive
+**Date**: 2026-05-08
+**Origin**: SPLIT from P0-B EC10 per Phase 2 reviewer challenge
+**Phase 1 evidence**: dev RCA P0-B EC10 + Phase 0 dogfood (this very design phase task)
+**Phase 2 verdict**: reviewer recommended split (distinct semantic from P0-B's HOW-to-bind contract)
+**Authors**: dev (RCA + dogfood evidence) + reviewer (split verdict + scope advice) + lead (synthesis)
+
+## §1 Executive summary
+
+**Problem (dogfood-derived)**: `dispatch_auto_bind_lease` (`src/mcp/handlers/dispatch_hook/mod.rs:21-83`) fires on EVERY task dispatch, creating a daemon-managed worktree at `<source_repo>/.worktrees/<agent>` regardless of task class. Read-only design/audit/RCA tasks (like this Sprint 55 P0 design phase task itself) get unnecessary worktrees auto-created — wasted resource + STRICT compliance friction (worktree nested under operator clone post Sprint 54 PR #519 + parallel-worktree convention requires manual `release_worktree` cleanup).
+
+**Live evidence**: Sprint 55 P0 design RCA dispatch m-11 to dev (THIS task) is read-only + DOC-only writes. Yet `dispatch_auto_bind_lease` fired on receipt, created daemon worktree at `agend-terminal/.worktrees/dev`. Required Phase 0 `release_worktree` cleanup before dev could work in parallel sibling worktree. Wasted ~5 min of worktree-create + cleanup churn for zero IMPL benefit.
+
+**Final design — Two variants for operator choice**:
+
+### Variant A: Minimal opt-out (~30-50 LOC, recommended for Sprint 55)
+- Add `bind: bool = true` field to `task` board entries + `delegate_task` send args
+- `dispatch_auto_bind_lease` checks field; skips bind on `bind: false`
+- Backward-compat: absence of field defaults to `true` (current behavior)
+- Lead/general explicitly mark RCA/audit/design tasks `bind: false`
+
+### Variant B: Task-class taxonomy (~80-150 LOC, deferred Sprint 56+)
+- Add `class: "rca" | "audit" | "design" | "doc-only" | "impl" | "fix" | "feat"` field
+- Dispatch hook gates auto-bind by class (impl/fix/feat → bind; others → skip)
+- Backward-compat: absence defaults to `impl` class (current behavior)
+
+**Lead recommendation**: Variant A for Sprint 55 (smaller blast radius + faster ship + dogfood-evidence already justifies it). Variant B reserved for Sprint 56+ if cross-cutting class taxonomy proves valuable for other features (test-only mode, observability, telemetry).
+
+## §2 Premise + dogfood evidence
+
+This Sprint 55 P0 design phase task is the dogfood evidence. Phase 0 friction:
+
+```
+1. Lead dispatches task to dev (m-11) → general "delegate_task" send → dispatch_auto_bind_lease fires
+2. Daemon creates worktree at /Users/suzuke/Documents/Hack/agend-terminal/.worktrees/dev
+3. Daemon writes binding.json + .agend-managed marker
+4. Dev arrives in dispatched task; sees nested-under-operator-clone worktree
+5. Dev recognizes STRICT physical-separation intent (operator m-3617) requires parallel sibling worktree
+6. Dev calls `release_worktree(target_instance=dev)` — clears auto-bind (5 min round-trip)
+7. Dev creates parallel worktree at ~/Documents/Hack/agend-terminal-worktrees/sprint54-p1b-bug2-fix-option-c-provisioning
+8. Dev resumes Phase 0 worktree provisioning + Phase 1 RCA
+```
+
+**Wasted cycles**: Phase 0 `release_worktree` cleanup + new branch creation = ~5 min friction for ZERO IMPL benefit. Multiplied across N future RCA/design dispatches = N×5min cumulative loss.
+
+**Why this isn't a P0-B core concern**: P0-B refactors arg-shape and derivation pipeline (HOW the binding happens once triggered). P0-C is about WHEN the binding triggers (task-class policy). Distinct architectural layer; reviewer Phase 2 verdict correctly identified the split.
+
+## §3 Chosen design: Variant A (minimal `bind: bool` opt-out)
+
+### Surface change
+
+```rust
+// task::create
+task(action: "create", title: "...", branch: "...", bind: false)
+
+// send (delegate_task)
+send(target_instance: "dev", request_kind: "task", task_id: "...", bind: false)
+
+// Dispatch hook
+fn dispatch_auto_bind_lease(...) -> Option<...> {
+    if !task_should_bind(task_record) {
+        return None;  // skip auto-bind, return early
+    }
+    // existing bind logic
+}
+
+fn task_should_bind(task_record: &TaskRecord) -> bool {
+    // Default true if field absent (backward-compat)
+    task_record.bind.unwrap_or(true)
+}
+```
+
+### Backward-compat
+
+- Existing dispatches without `bind` field → defaults to `true` → current auto-bind behavior preserved
+- New RCA/audit/design dispatches explicitly pass `bind: false` → skip auto-bind
+- No breaking change for any existing call site
+
+### Caller-side discipline
+
+Lead/general explicitly tag these dispatch classes as `bind: false`:
+- Phase 1 RCA tasks (read-only investigation)
+- Phase 2 reviewer challenge tasks
+- Audit-style tasks (e.g. P1-B Bug 2 audit doc PR #518)
+- Documentation-only PRs (e.g. P2-9 Sprint 48 fwdref cleanup #510, P2-7 flaky tests triage #520)
+- Smoke verification tasks (e.g. Phase 5 smoke batch m-0)
+
+Continue passing `bind: true` (or omitting) for:
+- IMPL tasks
+- Fix tasks
+- Feature tasks
+- Any task expected to commit/push to a feature branch
+
+## §4 Rejected alternatives
+
+### Variant B: Task-class taxonomy
+- **Rejected for Sprint 55** scope reasons (~80-150 LOC + cross-cutting changes to task board + send + dispatch_hook + serde + CLI flags)
+- **Reserved for Sprint 56+** if cross-cutting taxonomy proves valuable for other features (test-only filtering, observability tagging, telemetry buckets)
+- Argument FOR (deferred): named classes are more expressive than bool; future extension easier
+- Argument AGAINST (current): blast radius too large for single-bug fix; bool covers 95% of dogfood need
+
+### Make auto-bind opt-IN via explicit `bind: true`
+- **Rejected**: breaks 50+ existing dispatch sites (every IMPL dispatch would need flag added)
+- Migration burden disproportionate to bug surface
+
+### Always auto-bind + provide easy `release_worktree(on_completion=true)` hook
+- **Rejected**: doesn't avoid initial worktree-create cost (5 min × N tasks still wasted)
+- Treats symptom not cause
+
+### Agent-side env var to disable auto-bind for current dispatch
+- **Rejected**: agents shouldn't have to opt-out post-hoc (already received daemon-state by env-var-set time); should be caller-side directive
+
+## §5 Implementation surface
+
+### Code sites (approximate, dev refines during IMPL)
+
+1. **`src/tasks.rs` (TaskRecord struct)** — add `bind: Option<bool>` field with `#[serde(default, skip_serializing_if = "Option::is_none")]`
+2. **`src/mcp/handlers/comms.rs` (send handler)** — accept `bind` arg; propagate to task record OR direct to dispatch_hook
+3. **`src/mcp/handlers/task.rs` (task create handler)** — accept `bind` arg in `task(action: "create", ...)`
+4. **`src/mcp/handlers/dispatch_hook/mod.rs:21-83`** — read `task_record.bind` (or default true); branch on false → skip bind
+5. **Tests** — unit tests for default-true (no field), explicit-false, explicit-true; mock dispatch hook + verify bind skip behavior
+
+### Telemetry
+
+INFO log when bind is skipped:
+```
+INFO dispatch_auto_bind_lease skipping auto-bind for task <task_id> (bind: false)
+```
+
+No log on default-true path (current behavior, no noise).
+
+## §6 Edge case adjudication
+
+### EC1 — Caller passes `bind: false` but later needs binding
+- **Recommendation**: Caller can explicitly call `bind_self(...)` MCP tool from agent side. Dispatch-time skip doesn't preclude on-demand binding.
+- **Rationale**: Auto-bind and explicit bind are independent code paths; skipping the former preserves the latter
+
+### EC2 — Task pre-existing in board with `bind` field absent
+- **Recommendation**: Default true (backward-compat); current behavior preserved
+- Verified by serde `#[serde(default)]` + `Option::unwrap_or(true)` chain
+
+### EC3 — Mixed bind + class semantics in future Variant B
+- **Recommendation**: If Variant B added Sprint 56+, derive `bind` from `class` if both present (class wins as more specific)
+- **Migration path**: Sprint 56 reads `class` field; falls back to `bind` for backward-compat with Variant A callers
+
+### EC4 — Multiple agents sharing source_repo, mixed bind values
+- **Recommendation**: Each agent's task record has independent `bind` field; no cross-agent coupling
+- **Sprint 53 P0-1.5 lease conflict** still applies (only one agent can hold same-branch lease at a time)
+
+### EC5 — Reviewer challenge on dispatch (Phase 2 task) needs read-only access to dev's parallel worktree
+- **Recommendation**: Reviewer dispatches also `bind: false` (RCA/challenge class)
+- Reviewer reads dev's worktree path via filesystem Read tool; no separate worktree binding needed
+
+## §7 LOC + Tier estimate
+
+| Component | LOC est | Notes |
+|---|---|---|
+| `TaskRecord.bind: Option<bool>` field | ~5 | Additive serde field |
+| `task` create handler accept `bind` | ~5-10 | Plumbing arg → record |
+| `send` handler propagate `bind` | ~5-10 | Plumbing arg → task creation |
+| `dispatch_auto_bind_lease` early-return on `bind: false` | ~10-15 | `task_should_bind` helper + conditional |
+| Tests | ~15-25 | Default + explicit-false + explicit-true paths |
+| **Total** | **~40-65** | Within general's "small" expectation for this kind of feature flag |
+
+**Tier**: Tier-1 single primary review (codex). No Tier-2 expected.
+
+**LOC ceiling**: 80 nominal, 100 hard escalate.
+
+## §8 Out of scope (deferred to Sprint 56+ or beyond)
+
+- **Variant B task-class taxonomy** — full class enumeration + per-class dispatch behavior
+- **Auto-`release_worktree` on task completion** — separate concern (binding lifecycle, not dispatch trigger)
+- **CLI flag for `bind: false` in `agend-terminal task create`** — possible Sprint 56 ergonomics improvement
+- **Heuristic auto-detect of doc-only tasks** — too magical; explicit `bind: false` preferred
+
+## §9 Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Caller forgets `bind: false` on RCA dispatch → wasted worktree | LOW | Lead orchestrator habit + dispatch templates (e.g. `delegate_rca_task` helper that defaults `bind: false`) |
+| Variant A locks design before cross-cutting taxonomy needs surface | LOW | Sprint 56+ migration path documented (Variant B compatible with Variant A via class-wins-over-bind) |
+| Existing 50+ dispatch sites accidentally depend on auto-bind triggering | LOW-MED | Default-true preserves current behavior; explicit opt-out only |
+| Reviewer Phase 2 task can't access dev's parallel worktree if reviewer also `bind: false` | LOW | Reviewer reads via filesystem path (Read tool); doesn't need own binding |
+| Telemetry INFO log on every `bind: false` dispatch creates log noise | LOW | INFO-level (not WARN); operator can filter at log-aggregation layer |
+
+## §10 Implementation order
+
+P0-C can land **independently of P0-A and P0-B** since it touches:
+- Different code (task board + dispatch hook)
+- No shared state with channel discipline (P0-A) or binding refactor (P0-B core)
+- No conflict with proposed test matrices
+
+**Recommended order**: 
+1. P0-A first (smaller user-facing correctness, locks routing invariants)
+2. P0-B core (binding refactor)
+3. P0-C (auto-bind trigger scope filter)
+
+OR P0-C parallel with P0-B (independent scopes).
+
+## §11 Status / next steps
+
+- **Phase 1 dev RCA**: Complete (P0-B EC10 section in dev's P0-B doc)
+- **Phase 2 reviewer challenge**: Complete (split-verdict + Variant A vs B option)
+- **Phase 3 lead synthesis**: This document (extracted as separate P0-C dispatch)
+- **Operator review**: Pending m-3637 directive (Variant A vs B + Sprint 55 OR Sprint 56+ timing)
+- **Phase 4 IMPL** (post-approval): dev primary, reviewer Tier-1, ~40-65 LOC, ~1hr cycle (Variant A)
+
+**Decision required from operator**:
+1. **Variant A vs B**: Variant A recommended for Sprint 55 ship cadence; Variant B deferred Sprint 56+
+2. **Sprint 55 inclusion vs Sprint 56+ defer**: dogfood evidence justifies Sprint 55, but Sprint 55 already has P0-A + P0-B; capacity check
+3. **Caller-side discipline policy**: which dispatch classes ALWAYS pass `bind: false`? (Suggested list in §3 above)
+
+Sprint 55 capacity feasibility:
+- P0-A ~70-110 LOC, ~1.5-2hr
+- P0-B core ~210-335 LOC, ~3-4hr
+- P0-C Variant A ~40-65 LOC, ~1hr
+- **Total Sprint 55 P0**: ~320-510 LOC, ~5.5-7hr engineering (excluding review + CI)
+
+Realistic for single-Sprint ship if dispatched sequentially per-PR with reviewer Tier-1 cycle.


### PR DESCRIPTION
## Sprint 55 P0 design phase — Phase 3 lead synthesis

3 final design docs ready for operator review per m-3637 design-first directive。NOT IMPL — design phase deliverable only。

### Documents
- **P0-A Channel discipline daemon-level enforcement** (Variant-extend chosen, ~70-110 LOC IMPL)
- **P0-B Unified bind dynamic binding** (~210-335 LOC IMPL, Tier-1 baseline)
- **P0-C Auto-bind task-class filter** (NEW, split from P0-B EC10 per reviewer Phase 2, ~40-65 LOC IMPL Variant A)

### Phase tracking
- Phase 1 dev primary RCA — internal docs at \`docs/internal/...-v1-dev-rca.md\` (local-only per (b) verdict)
- Phase 2 reviewer challenge — internal docs at \`docs/internal/...-reviewer.md\` (local-only)
- Phase 3 lead synthesis — this PR's \`docs/DESIGN-...\` final docs (3 docs +640 LOC)

### Synthesis decisions Phase 1 → Phase 3
- **P0-A Variant choice**: dev deferred → reviewer Variant-extend → lead concurs Variant-extend
- **P0-B EC10 bundling**: dev \"Phase 2 picks\" → reviewer split → lead concurs split (NEW P0-C doc)
- **P0-B EC9 deprecation**: dev 1-sprint → reviewer 2-sprint → lead concurs 2-sprint
- **P0-B EC4 non-GitHub**: dev \"explicit error\" → reviewer \"add \`repo: Option<String>\` companion field\" → lead concurs
- **9 reviewer-added edge cases incorporated** (4 P0-A + 5 P0-B)

### Operator review needed
1. P0-A Variant-extend confirmation
2. P0-B EC10 split-vs-bundle preference (split recommended; standalone P0-C doc ready)
3. P0-C Variant A vs B + Sprint 55 inclusion timing
4. Implementation sequencing (recommended P0-A → P0-B → P0-C)

### Embargo + STRICT preserved
- Dev in parallel worktree throughout (NOT operator clone)
- Read-only RCA + doc-only writes
- 0 production code change
- 6 explicit bypass cycles audited (set/run/unset per cycle)
- Cumulative session: 14+1=15 PRs Sprint 54 P-tier shipped, this is Sprint 55 design phase PR

### Live dogfood evidence (P0-C bonus)
This very dispatch hit the EC10 issue **twice in 1 hour**:
1. Phase 0 worktree provisioning friction (initial \`release_worktree\` cleanup)
2. Phase 3 dispatch rejection (daemon auto-bind conflict with existing parallel worktree on same branch)

P0-C addresses this directly via \`bind: false\` opt-out flag for design/RCA dispatches。

🤖 Generated with [Claude Code](https://claude.com/claude-code)