### PR TITLE
fix(mcp): bind_self schema declares source_repo + relaxes required (Sprint 55 P0-B-hotfix)

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -256,11 +256,16 @@ fn worktree_tools() -> Vec<Value> {
         // (Phase 1 trailers, P0-1.5 cross-agent registry check, P0-1.6
         // actual-HEAD verification, P0-X release_worktree as sole exit
         // point, source_repo persistence, auto watch_ci) applies.
+        // Sprint 55 P0-B: dual-arg shape (handler at worktree.rs:24-27) —
+        // schema exposes both `source_repo` (preferred) and legacy `repo`
+        // with `required` relaxed to `branch` only. Handler enforces
+        // mutual exclusivity at runtime via `ambiguous_args` code.
         json!({"name": "bind_self", "description": "Bind the calling agent to a fresh worktree on the named branch. Reuses the dispatch-hook lifecycle so binding.json + worktree + .agend-managed marker + auto watch_ci all land. Rejects 'main'/'master' (E4.5) and cross-agent branch conflicts. Pair with `release_worktree` to unbind.",
             "inputSchema": {"type": "object", "properties": {
-                "repo": {"type": "string", "description": "GitHub repo (owner/name)"},
+                "source_repo": {"type": "string", "description": "Local path to source repository. Daemon resolves GitHub owner/repo via `git remote get-url origin`. Sprint 55 P0-B preferred form. Mutually exclusive with `repo` (handler rejects both via `ambiguous_args` code)."},
+                "repo": {"type": "string", "description": "GitHub repo (owner/name). Legacy form retained for one-Sprint deprecation window — emits warn-log; removal Sprint 57. Mutually exclusive with `source_repo`."},
                 "branch": {"type": "string", "description": "Branch to bind (must not be main/master)"}
-            }, "required": ["repo", "branch"]}}),
+            }, "required": ["branch"]}}),
         // Sprint 53 P0-X: release a daemon-managed worktree + clear binding
         // for `agent`. Idempotent. Only removes worktrees that carry the
         // `.agend-managed` marker (R14 safety — operator-created worktrees


### PR DESCRIPTION
## Summary
Schema-vs-handler gap blocked PR #527 live smoke。Handler at \`worktree.rs:24-27\` (merged via #527 squash \`e515ed6\`) accepts dual-arg shape, but \`tools.rs\` schema only declared legacy \`repo\` arg as required, hiding the new \`source_repo\` form from MCP-bridge schema discovery。

This hotfix exposes the new \`source_repo\` property + relaxes \`required\` to \`[\"branch\"]\` only。No behavior change — declaration parity with already-merged handler。

- Tier-1 single primary (codex)
- Path B declaration-only
- Decision/task: \`t-20260508065126161286-0\`

## Diff (~10 LOC)

```diff
+ "source_repo": {"type": "string", "description": "Local path to source repository. Daemon resolves GitHub owner/repo via \`git remote get-url origin\`. Sprint 55 P0-B preferred form. Mutually exclusive with \`repo\` (handler rejects both via \`ambiguous_args\` code)."},
- "repo": {"type": "string", "description": "GitHub repo (owner/name)"},
+ "repo": {"type": "string", "description": "GitHub repo (owner/name). Legacy form retained for one-Sprint deprecation window — emits warn-log; removal Sprint 57. Mutually exclusive with \`source_repo\`."},
  "branch": {"type": "string", "description": "Branch to bind (must not be main/master)"}
- "required": ["repo", "branch"]
+ "required": ["branch"]
```

## Verification
- ✓ \`cargo build\` clean
- ✓ \`cargo fmt --check\` clean
- ✓ \`cargo clippy --all-targets -- -D warnings\` clean
- Skipped \`cargo test\` — no behavior surface (schema is registered string literal; handler logic at worktree.rs:24-27 already tested in #527's p0b_tests.rs)

## Phase 5 smoke unlocked post-merge
Once merged + operator restarts daemon (m-3658 telegram), agent MCP schema refresh exposes new \`source_repo\` arg → original PR #527 smoke recipe executable per its PR body:
1. \`bind_self(source_repo=\"/path/to/clone\", branch=\"feat-x\")\` — daemon derives owner/repo from origin remote
2. \`ci(action=\"watch\", branch=\"feat-x\")\` — auto-uses binding's source_repo
3. \`release_worktree(target_instance=dev)\` — ci-watch subscribers shrunk by exact (repo+branch) match
4. (Optional) Legacy \`bind_self(repo=\"owner/name\", branch=...)\` warn-log + Sprint 56-57 deprecation cycle

## Embargo + STRICT preserved
- Parallel worktree only (\`~/Documents/Hack/agend-terminal-worktrees/sprint54-p1b-bug2-fix-option-c-provisioning/\`)
- No operator clone touches
- \`bind: false\` set on dispatch m-12 → no auto-bind side effect
- Bypass cycle 18 with explicit set/run/unset audit

## §3.5.13 push form scope-claim
scope follows dispatch — Sprint 55 P0-B-hotfix: \`src/mcp/tools.rs\` \`bind_self\` schema declaration adds \`source_repo: string\` property + relaxes \`required\` to \`[\"branch\"]\` only — exposes dual-arg shape per Sprint 55 P0-B handler (\`worktree.rs:24-27\` already implemented at PR #527 squash \`e515ed6\`); no behavior change (declaration parity with handler); ~10 LOC; embargo-respecting (parallel worktree + bypass cycle 18 audit set/run/unset); Tier-1 single primary; Path B declaration-only; closes schema-vs-handler gap blocking #527 live smoke; no other deviation。

🤖 Generated with [Claude Code](https://claude.com/claude-code)