### PR TITLE
fix(channel): self-heal Telegram supergroup migration (Sprint 56 Track A) (#523)

### DIFF
--- a/src/channel/telegram/error.rs
+++ b/src/channel/telegram/error.rs
@@ -120,6 +120,72 @@ pub(crate) fn handle_send_failure(
     true
 }
 
+/// Classify a Telegram send error as "the bound chat was migrated to a
+/// supergroup". The Bot API returns `migrate_to_chat_id` in the response
+/// parameters when the configured `group_id` points at a regular group
+/// that has been upgraded — typically because the operator enabled
+/// Topics, which forces a supergroup. teloxide-core decodes that
+/// parameter into [`teloxide::RequestError::MigrateToChatId`]; we match
+/// on the typed variant rather than the description string so the
+/// classifier is independent of locale / Bot API copy changes.
+pub(crate) fn is_supergroup_migration_error(err: &anyhow::Error) -> bool {
+    extract_migrated_chat_id(err).is_some()
+}
+
+/// Pull the new supergroup chat_id out of a migration error.
+///
+/// Returns `Some(new_id)` for [`RequestError::MigrateToChatId`], `None`
+/// otherwise. Callers use this to (a) classify and (b) read the new
+/// `-100…` prefixed id in a single pass.
+pub(crate) fn extract_migrated_chat_id(err: &anyhow::Error) -> Option<i64> {
+    err.downcast_ref::<teloxide::RequestError>().and_then(|e| {
+        if let teloxide::RequestError::MigrateToChatId(teloxide::types::ChatId(id)) = e {
+            Some(*id)
+        } else {
+            None
+        }
+    })
+}
+
+/// Self-heal path for supergroup migration: extract the new chat_id,
+/// atomically rewrite `channel.group_id` in `fleet.yaml`, and update
+/// `state.group_id` in-memory so cached-state callers (`Channel::send`,
+/// `apply_fleet_action`) pick up the new id without a daemon restart.
+///
+/// Returns `Some(new_id)` when applied (caller may retry the failed
+/// send with the new id). Returns `None` when (a) the error is not a
+/// migration error, or (b) yaml persistence failed — in case (b) we log
+/// and give up; the next migration error will retry persistence so the
+/// daemon doesn't loop forever on a disk-IO failure.
+///
+/// `state` is `Option` because callers reached from non-state-aware
+/// paths (`try_telegram_reply_from`) only have `home` to work with;
+/// `fleet.yaml` is the source of truth, so a `None` call still heals
+/// disk state and the next state-aware send picks up the fresh value.
+pub(crate) fn handle_supergroup_migration(
+    home: &Path,
+    state: Option<&Arc<Mutex<TelegramState>>>,
+    err: &anyhow::Error,
+) -> Option<i64> {
+    let new_id = extract_migrated_chat_id(err)?;
+    tracing::warn!(
+        new_chat_id = new_id,
+        "telegram chat migrated to supergroup — rewriting fleet.yaml channel.group_id"
+    );
+    if let Err(e) = crate::fleet::update_channel_telegram_group_id(home, new_id) {
+        tracing::error!(
+            %e, new_chat_id = new_id,
+            "failed to persist migrated group_id to fleet.yaml — next migration error will retry"
+        );
+        return None;
+    }
+    if let Some(state) = state {
+        let mut s = lock_state(state);
+        s.group_id = teloxide::types::ChatId(new_id);
+    }
+    Some(new_id)
+}
+
 /// Lightweight self-heal for a stale topic: strip the dead topic_id from
 /// the on-disk registry and fleet.yaml, create a fresh forum topic, and
 /// persist the new mapping. Does NOT delete the instance (unlike
@@ -370,6 +436,130 @@ instances:
         let reg_after = load_topic_registry(&home);
         assert!(!reg_after.values().any(|v| v == FLEET_BINDING_SENTINEL));
         assert_eq!(reg_after.get(&100), Some(&"at-dev-1".to_string()));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 56 Track A — supergroup migration self-heal ────────────
+
+    fn migration_err(new_id: i64) -> anyhow::Error {
+        anyhow::Error::from(teloxide::RequestError::MigrateToChatId(
+            teloxide::types::ChatId(new_id),
+        ))
+    }
+
+    fn write_telegram_fleet_yaml(home: &std::path::Path, group_id: i64, mode: &str) {
+        let yaml = format!(
+            "channel:\n  type: telegram\n  bot_token_env: AGEND_BOT_TOKEN\n  group_id: {group_id}\n  mode: {mode}\n  user_allowlist:\n  - 42\n"
+        );
+        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+    }
+
+    fn channel_group_id_from_yaml(home: &std::path::Path) -> Option<i64> {
+        let text = std::fs::read_to_string(home.join("fleet.yaml")).ok()?;
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&text).ok()?;
+        doc.get("channel")
+            .and_then(|c| c.get("group_id"))
+            .and_then(|v| v.as_i64())
+    }
+
+    #[test]
+    fn classifier_matches_typed_migrate_to_chat_id() {
+        let err = migration_err(-1001234567890);
+        assert!(is_supergroup_migration_error(&err));
+        assert_eq!(extract_migrated_chat_id(&err), Some(-1001234567890));
+    }
+
+    #[test]
+    fn classifier_rejects_unrelated_request_errors() {
+        // RetryAfter is also a RequestError but not a migration.
+        let err = anyhow::Error::from(teloxide::RequestError::RetryAfter(
+            teloxide::types::Seconds::from_seconds(5),
+        ));
+        assert!(!is_supergroup_migration_error(&err));
+        assert_eq!(extract_migrated_chat_id(&err), None);
+    }
+
+    #[test]
+    fn classifier_rejects_anyhow_string_errors() {
+        // Stringly-typed errors (anyhow::anyhow!) carry no typed
+        // RequestError payload — match must miss, not false-positive.
+        for msg in [
+            "network timeout",
+            "Bad Request: message thread not found",
+            "Too Many Requests: retry after 5",
+            "Bad Request: chat upgraded to supergroup", // legacy description text alone
+        ] {
+            let err = anyhow::anyhow!(msg.to_string());
+            assert!(
+                !is_supergroup_migration_error(&err),
+                "must not match string-only: {msg}"
+            );
+            assert_eq!(extract_migrated_chat_id(&err), None);
+        }
+    }
+
+    #[test]
+    fn handle_migration_persists_to_fleet_yaml_and_returns_new_id() {
+        let home = tmp_home("migration-persist");
+        write_telegram_fleet_yaml(&home, -100111111, "topic");
+        let new_id = -1009999999999_i64;
+
+        let applied = handle_supergroup_migration(&home, None, &migration_err(new_id));
+
+        assert_eq!(applied, Some(new_id));
+        assert_eq!(channel_group_id_from_yaml(&home), Some(new_id));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn handle_migration_with_state_mutates_in_memory_group_id() {
+        let home = tmp_home("migration-state");
+        write_telegram_fleet_yaml(&home, -100111111, "topic");
+        let new_id = -1008888888888_i64;
+        let state = Arc::new(Mutex::new(TelegramState::new(
+            "tok",
+            -100111111,
+            HashMap::new(),
+            home.clone(),
+            HashMap::new(),
+            None,
+        )));
+
+        let applied = handle_supergroup_migration(&home, Some(&state), &migration_err(new_id));
+
+        assert_eq!(applied, Some(new_id));
+        assert_eq!(lock_state(&state).group_id.0, new_id);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn handle_migration_returns_none_for_unrelated_error() {
+        let home = tmp_home("migration-unrelated");
+        write_telegram_fleet_yaml(&home, -100222222, "topic");
+        let unrelated = anyhow::anyhow!("network timeout");
+
+        let applied = handle_supergroup_migration(&home, None, &unrelated);
+
+        assert!(applied.is_none());
+        // fleet.yaml must not be mutated when the error is unrelated.
+        assert_eq!(channel_group_id_from_yaml(&home), Some(-100222222));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn handle_migration_is_idempotent_when_yaml_already_has_new_id() {
+        // If a parallel send already healed fleet.yaml, the second call's
+        // mutate_fleet_yaml is a no-op-style overwrite (same value); the
+        // function must still return Some(new_id) so the caller retries
+        // the original send rather than treating it as fatal.
+        let home = tmp_home("migration-idempotent");
+        let new_id = -1007777777777_i64;
+        write_telegram_fleet_yaml(&home, new_id, "topic");
+
+        let applied = handle_supergroup_migration(&home, None, &migration_err(new_id));
+
+        assert_eq!(applied, Some(new_id));
+        assert_eq!(channel_group_id_from_yaml(&home), Some(new_id));
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/channel/telegram/reply.rs
+++ b/src/channel/telegram/reply.rs
@@ -127,6 +127,23 @@ pub(super) fn try_telegram_reply_from(
     match telegram_reply_send_inner(&ch, instance_name, topic_id, text) {
         Ok(msg_id) => Ok((msg_id, ch.group_id)),
         Err(e) => {
+            // Supergroup migration must be checked before topic-deleted:
+            // a migrated chat returns `MigrateToChatId` regardless of
+            // whether the topic still exists, and we want to heal the
+            // chat-level error before classifying topic state on the
+            // (now-orphaned) old chat_id.
+            if handle_supergroup_migration(home, None, &e).is_some() {
+                if let Ok((new_ch, _)) = resolve_channel_from(home) {
+                    tracing::info!(
+                        instance = %instance_name,
+                        old_chat_id = ch.group_id,
+                        new_chat_id = new_ch.group_id,
+                        "retrying send after supergroup migration"
+                    );
+                    return telegram_reply_send_inner(&new_ch, instance_name, topic_id, text)
+                        .map(|msg_id| (msg_id, new_ch.group_id));
+                }
+            }
             if let Some(stale_tid) = topic_id {
                 if is_topic_deleted_error(&e) {
                     if let Some(new_tid) =
@@ -442,6 +459,99 @@ instances:
         );
 
         std::env::remove_var("SPRINT23_P1_FAKE_TOKEN2");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 56 Track A — supergroup migration self-heal ───────────
+
+    fn read_channel_group_id(home: &std::path::Path) -> Option<i64> {
+        let text = std::fs::read_to_string(home.join("fleet.yaml")).ok()?;
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&text).ok()?;
+        doc.get("channel")
+            .and_then(|c| c.get("group_id"))
+            .and_then(|v| v.as_i64())
+    }
+
+    #[test]
+    fn try_telegram_reply_from_persists_migrated_chat_id_to_fleet_yaml() {
+        let _g = channel_env_test_guard();
+        let home = tmp_home("reply-migration-persist");
+        let yaml = "\
+channel:
+  type: telegram
+  bot_token_env: SPRINT56_FAKE_TOKEN
+  group_id: -100111111
+  mode: topic
+  user_allowlist:
+    - 42
+instances:
+  agent-x:
+    command: /bin/true
+    topic_id: 42
+";
+        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        register_topic(&home, 42, "agent-x");
+        std::env::set_var("SPRINT56_FAKE_TOKEN", "fake");
+
+        let new_id = -1009999999999_i64;
+        set_forced_send_error(anyhow::Error::from(teloxide::RequestError::MigrateToChatId(
+            teloxide::types::ChatId(new_id),
+        )));
+
+        // The forced-error injector is single-use: the first send call
+        // consumes the migration error, the migration handler heals
+        // fleet.yaml, then the retry's real send hits "Invalid bot
+        // token" (fake token). We assert on the load-bearing side-effect
+        // (fleet.yaml rewritten) rather than `is_ok()`, mirroring the
+        // existing `try_telegram_reply_from_invalidates_on_topic_deleted`
+        // pattern at this site.
+        let _ = try_telegram_reply_from(&home, "agent-x", "hello");
+
+        // fleet.yaml channel.group_id rewritten to the migrated id.
+        assert_eq!(read_channel_group_id(&home), Some(new_id));
+        // Topic registry untouched — migration is chat-level, not topic-level.
+        let reg = load_topic_registry(&home);
+        assert_eq!(
+            reg.get(&42),
+            Some(&"agent-x".to_string()),
+            "migration must not invalidate topic; reg={reg:?}"
+        );
+
+        std::env::remove_var("SPRINT56_FAKE_TOKEN");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn try_telegram_reply_from_unrelated_error_does_not_rewrite_channel_group_id() {
+        let _g = channel_env_test_guard();
+        let home = tmp_home("reply-migration-no-mutate");
+        let yaml = "\
+channel:
+  type: telegram
+  bot_token_env: SPRINT56_FAKE_TOKEN_2
+  group_id: -100222222
+  mode: topic
+  user_allowlist:
+    - 42
+instances:
+  agent-x:
+    command: /bin/true
+    topic_id: 42
+";
+        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        register_topic(&home, 42, "agent-x");
+        std::env::set_var("SPRINT56_FAKE_TOKEN_2", "fake");
+
+        set_forced_send_error(anyhow::anyhow!("Too Many Requests: retry after 5"));
+
+        let res = try_telegram_reply_from(&home, "agent-x", "hello");
+        assert!(res.is_err(), "unrelated error must propagate");
+
+        // Original group_id preserved — RetryAfter must not trigger
+        // migration self-heal.
+        assert_eq!(read_channel_group_id(&home), Some(-100222222));
+
+        std::env::remove_var("SPRINT56_FAKE_TOKEN_2");
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/channel/telegram/reply.rs
+++ b/src/channel/telegram/reply.rs
@@ -494,9 +494,9 @@ instances:
         std::env::set_var("SPRINT56_FAKE_TOKEN", "fake");
 
         let new_id = -1009999999999_i64;
-        set_forced_send_error(anyhow::Error::from(teloxide::RequestError::MigrateToChatId(
-            teloxide::types::ChatId(new_id),
-        )));
+        set_forced_send_error(anyhow::Error::from(
+            teloxide::RequestError::MigrateToChatId(teloxide::types::ChatId(new_id)),
+        ));
 
         // The forced-error injector is single-use: the first send call
         // consumes the migration error, the migration handler heals

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -633,6 +633,35 @@ pub fn remove_instances_from_yaml(home: &Path, names: &[String]) -> Result<()> {
     })
 }
 
+/// Atomically rewrite `channel.group_id` after a Telegram supergroup
+/// migration. Mirrors [`update_instance_field`] for the top-level
+/// `channel:` block; uses the same file lock + atomic write path so a
+/// concurrent fleet read never observes a torn write.
+///
+/// The mutator is a no-op (Ok(())) when `channel:` is absent or its
+/// `type` is not `telegram` — the migration error handler is the only
+/// caller and it only fires on the telegram send path, so the no-op
+/// branches are defensive belt-and-suspenders rather than intended
+/// flow.
+pub fn update_channel_telegram_group_id(home: &Path, new_group_id: i64) -> Result<()> {
+    mutate_fleet_yaml(home, "", |doc| {
+        if let Some(channel) = doc.get_mut("channel").and_then(|v| v.as_mapping_mut()) {
+            let is_telegram = channel
+                .get(serde_yaml_ng::Value::String("type".into()))
+                .and_then(|v| v.as_str())
+                == Some("telegram");
+            if is_telegram {
+                channel.insert(
+                    serde_yaml_ng::Value::String("group_id".into()),
+                    serde_yaml_ng::Value::Number(new_group_id.into()),
+                );
+                tracing::info!(new_group_id, "fleet.yaml channel.group_id rewritten");
+            }
+        }
+        Ok(())
+    })
+}
+
 /// Update a specific field of an instance in fleet.yaml. Uses file lock + atomic write.
 pub fn update_instance_field(
     home: &Path,
@@ -1057,6 +1086,124 @@ instances:
         let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
         assert_eq!(config.instances["agent1"].topic_id, Some(42));
 
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    // ─── Sprint 56 Track A — supergroup migration self-heal ────────────
+
+    fn channel_yaml(group_id: i64) -> String {
+        format!(
+            r#"channel:
+  type: telegram
+  bot_token_env: AGEND_BOT_TOKEN
+  group_id: {group_id}
+  mode: topic
+  user_allowlist:
+    - 42
+instances:
+  agent1:
+    command: /bin/bash
+"#
+        )
+    }
+
+    fn read_channel_group_id(home: &Path) -> Option<i64> {
+        let text = std::fs::read_to_string(home.join("fleet.yaml")).ok()?;
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&text).ok()?;
+        doc.get("channel")
+            .and_then(|c| c.get("group_id"))
+            .and_then(|v| v.as_i64())
+    }
+
+    #[test]
+    fn update_channel_telegram_group_id_round_trip() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-migrate-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        write_fleet(&dir, &channel_yaml(-100111));
+        let new_id = -1009999999999_i64;
+
+        update_channel_telegram_group_id(&dir, new_id).expect("update channel.group_id");
+
+        assert_eq!(read_channel_group_id(&dir), Some(new_id));
+        // Sibling fields and instances must survive the rewrite.
+        let text = std::fs::read_to_string(dir.join("fleet.yaml")).unwrap();
+        assert!(text.contains("bot_token_env: AGEND_BOT_TOKEN"));
+        assert!(text.contains("mode: topic"));
+        assert!(text.contains("user_allowlist"));
+        assert!(text.contains("agent1"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn update_channel_telegram_group_id_idempotent_same_value() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-migrate-idem-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        let new_id = -1008888888888_i64;
+        write_fleet(&dir, &channel_yaml(new_id));
+
+        update_channel_telegram_group_id(&dir, new_id).expect("idempotent rewrite");
+        update_channel_telegram_group_id(&dir, new_id).expect("idempotent twice");
+
+        assert_eq!(read_channel_group_id(&dir), Some(new_id));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn update_channel_telegram_group_id_noop_on_non_telegram_channel() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-migrate-discord-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        write_fleet(
+            &dir,
+            r#"channel:
+  type: discord
+  bot_token_env: AGEND_DISCORD_BOT_TOKEN
+  guild_id: 12345
+"#,
+        );
+
+        update_channel_telegram_group_id(&dir, -100777).expect("noop on discord");
+
+        // No `group_id` on a discord channel — must not have been
+        // injected by the telegram-only helper.
+        let text = std::fs::read_to_string(dir.join("fleet.yaml")).unwrap();
+        assert!(
+            !text.contains("group_id"),
+            "telegram helper must not mutate discord channel: {text}"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn update_channel_telegram_group_id_noop_when_no_channel_block() {
+        // Self-heal helper is no-op-friendly: callers don't have to
+        // pre-check, the disk write simply does nothing if there's no
+        // channel block to mutate.
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-migrate-no-channel-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        write_fleet(
+            &dir,
+            r#"instances:
+  agent1:
+    command: /bin/bash
+"#,
+        );
+
+        update_channel_telegram_group_id(&dir, -100777).expect("noop when no channel");
+        // fleet.yaml must still parse and not have a synthesized channel.
+        let text = std::fs::read_to_string(dir.join("fleet.yaml")).unwrap();
+        assert!(!text.contains("channel:"), "must not synthesize channel");
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -203,6 +203,33 @@ fn verify_bot(token: &str) -> anyhow::Result<String> {
     })
 }
 
+/// Classify a single `chat` payload from `getUpdates` against the
+/// quickstart's "topic mode" requirement. Pure function — pulled out
+/// of `detect_group` so the chat-type policy can be unit-tested
+/// without HTTP. Returns:
+///   - `Ok(Some((id, title)))` for an accepted supergroup
+///   - `Err(...)` for an explicit reject (regular group; Topics required
+///     but the chat hasn't been upgraded yet — issue #523 first half)
+///   - `Ok(None)` for irrelevant chat types (private, channel, etc.)
+///     — keep scanning the update stream for a matching chat.
+fn classify_quickstart_chat(chat: &serde_json::Value) -> anyhow::Result<Option<(i64, String)>> {
+    let chat_type = chat["type"].as_str().unwrap_or("");
+    let title = chat["title"].as_str().unwrap_or("Unknown Group");
+    match chat_type {
+        "supergroup" => {
+            let id = chat["id"].as_i64().unwrap_or(0);
+            Ok(Some((id, title.to_string())))
+        }
+        "group" => anyhow::bail!(
+            "Group '{title}' is a regular group, but topic mode requires a \
+             supergroup. Open the group settings in Telegram and enable Topics \
+             (this upgrades the group to a supergroup), then send another message \
+             and re-run quickstart."
+        ),
+        _ => Ok(None),
+    }
+}
+
 fn detect_group(token: &str) -> anyhow::Result<(i64, String)> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -213,11 +240,8 @@ fn detect_group(token: &str) -> anyhow::Result<(i64, String)> {
         if let Some(updates) = resp["result"].as_array() {
             for update in updates {
                 if let Some(chat) = update.get("message").and_then(|m| m.get("chat")) {
-                    let chat_type = chat["type"].as_str().unwrap_or("");
-                    if chat_type == "supergroup" || chat_type == "group" {
-                        let id = chat["id"].as_i64().unwrap_or(0);
-                        let title = chat["title"].as_str().unwrap_or("Unknown Group").to_string();
-                        return Ok((id, title));
+                    if let Some(hit) = classify_quickstart_chat(chat)? {
+                        return Ok(hit);
                     }
                 }
             }
@@ -424,6 +448,48 @@ mod tests {
             "general instance must be present"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 56 Track A — chat-type guard for issue #523 ────────────
+
+    fn fake_chat(chat_type: &str, id: i64, title: &str) -> serde_json::Value {
+        serde_json::json!({"type": chat_type, "id": id, "title": title})
+    }
+
+    #[test]
+    fn classify_supergroup_returns_id_and_title() {
+        let chat = fake_chat("supergroup", -1001234567890, "AgEnD Ops");
+        let result = classify_quickstart_chat(&chat).expect("supergroup must accept");
+        assert_eq!(result, Some((-1001234567890, "AgEnD Ops".to_string())));
+    }
+
+    #[test]
+    fn classify_regular_group_rejects_with_topics_hint() {
+        let chat = fake_chat("group", -123, "Old Group");
+        let err = classify_quickstart_chat(&chat).expect_err("regular group must error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("supergroup") && msg.contains("Topics"),
+            "rejection must explain the upgrade requirement: {msg}"
+        );
+        assert!(
+            msg.contains("Old Group"),
+            "rejection should name the group so the operator knows which to upgrade: {msg}"
+        );
+    }
+
+    #[test]
+    fn classify_private_chat_returns_none_keeps_scanning() {
+        // Private/channel hits are not errors — quickstart's update loop
+        // should keep scanning for a supergroup match.
+        for ct in ["private", "channel", ""] {
+            let chat = fake_chat(ct, 42, "irrelevant");
+            assert_eq!(
+                classify_quickstart_chat(&chat).expect("non-group types must not error"),
+                None,
+                "type={ct}"
+            );
+        }
     }
 
     /// Snapshot test: commented-out channel section also mentions


### PR DESCRIPTION
## Summary
- Detects `migrate_to_chat_id` from Telegram API (typed via `RequestError::MigrateToChatId`), atomically rewrites `channel.group_id` in fleet.yaml, and updates in-memory `state.group_id`. The MCP reply path retries via yaml-fresh re-resolution after self-heal.
- `quickstart.rs` preventive guard: refuses a regular `group` chat type when topic mode is required (which is always — `generate_fleet_yaml` writes `mode: topic` unconditionally), with an operator-actionable error pointing at "enable Topics → upgrades to supergroup".
- 16 new tests across `error.rs` ×7, `fleet.rs` ×4, `reply.rs` ×2, `quickstart.rs` ×3 covering happy / migration / idempotency / pre-existing-error-class non-regression.

## RCA (closes #523)

Two compounding gaps:

1. **`quickstart.rs:detect_group`** accepts both `supergroup` and `group` chat types, then `generate_fleet_yaml` writes `mode: topic` regardless. Telegram topics require a supergroup, so the moment the operator enables Topics in the captured regular group, Telegram migrates the chat to a new id and the captured `group_id` becomes stale.
2. **`channel/telegram/`** has zero `migrate_to_chat_id` consumer — once the chat migrates, every reply fails with "The group has been migrated to a supergroup with ID #-100…" until manual fleet.yaml edit.

## Surface (4 files, +518/-5 lines, ~104 production LOC + ~414 test LOC)

| File | Net LOC | Role |
|---|---|---|
| `src/channel/telegram/error.rs` | +190 | classifier + extractor + orchestrator (`is_supergroup_migration_error`, `extract_migrated_chat_id`, `handle_supergroup_migration`) |
| `src/fleet.rs` | +147 | `update_channel_telegram_group_id` (atomic file-lock rewrite) |
| `src/channel/telegram/reply.rs` | +110 | migration branch in `try_telegram_reply_from` (checked BEFORE topic-deleted) |
| `src/quickstart.rs` | +71 | `classify_quickstart_chat` extraction + chat-type guard |

### Why typed `RequestError::MigrateToChatId` over description-string match

teloxide-core 0.11.2 decodes the API's `migrate_to_chat_id` parameter directly into the typed variant in `net/telegram_response.rs`. Matching the typed error survives Bot API description copy changes / locale variations and avoids the false-positive risk of substring matching the literal "chat upgraded to supergroup" text — both behaviors covered by `classifier_rejects_anyhow_string_errors`.

### Migration-check ordering rationale

In `try_telegram_reply_from` the migration branch runs BEFORE the existing topic-deleted branch: a migrated chat returns `MigrateToChatId` regardless of whether the topic survived, and we want to heal the chat-level error before classifying topic state on the (now-orphaned) old chat_id.

## Out of scope (Sprint 57 candidate)

`apply_fleet_action` (fleet binding mirror) and `notify_telegram` (stall notifications) read cached `state.group_id` directly without going through `try_telegram_reply_from`. After a migration heal via the reply path:
- fleet.yaml is correct
- `state.group_id` is mutated only when caller passes state (reply path doesn't have it; the MCP reply path heals fleet.yaml only)
- These two send sites continue to fail until next daemon restart

Issue #523 only describes the reply-path failure (which is what users hit via `agend-terminal mcp` reply). A `send_with_migration_retry` helper covering all three send sites with state-aware retry is a clean Sprint 57 follow-up but expanding it now would push the PR past the LOC budget without addressing the reported symptom.

## Test plan
- [x] `cargo test --bin agend-terminal` — 16 new tests pass (1677 total pass / 10 pre-existing failures unrelated: `admin::tests::analyze_detects_worktree_branch` + 9 `claim_verifier::tests` with `git diff HEAD..HEAD` ambiguity, none in surfaces this PR touches)
- [x] `cargo clippy --bin agend-terminal --tests -- -D warnings` — clean
- [x] Unit: classifier matches typed MigrateToChatId, rejects RetryAfter, rejects string-only descriptions
- [x] Unit: `update_channel_telegram_group_id` round-trip preserves siblings, idempotent on same value, no-op on discord channel + missing channel block
- [x] Integration: forced migration error → fleet.yaml `channel.group_id` rewritten; unrelated `RetryAfter` error preserves original
- [x] Unit: quickstart's `classify_quickstart_chat` accepts supergroup with id+title, rejects regular group with Topics hint + group title, returns None for private/channel/empty types
- [ ] Manual smoke (operator): create regular group → run quickstart → confirm rejection with Topics hint
- [ ] Manual smoke (operator): existing fleet.yaml with stale group_id → enable Topics in old group → trigger MCP reply → verify fleet.yaml rewritten with new -100… id and reply succeeds on next attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)