### PR TITLE
fix(task_sweep): github_login mapping + D002 doctor (Sprint 56 Track F) (#496)

### DIFF
--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -104,6 +104,7 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
                         source_repo: None,
                         // Sprint 55 P0-B EC4: see instance.rs (gradient).
                         repo: None,
+                        github_login: None,
                     },
                 )
             })

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -52,6 +52,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                     source_repo: None,
                     // Sprint 55 P0-B EC4: see instance.rs (gradient).
                     repo: None,
+                    github_login: None,
                 },
             ) {
                 tracing::warn!(name = %inst_name, error = %e, "failed to write fleet.yaml");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -784,6 +784,7 @@ fn pane_from_menu_item(
                     source_repo: None,
                     // Sprint 55 P0-B EC4: see instance.rs (gradient).
                     repo: None,
+                    github_login: None,
                 },
             ) {
                 tracing::warn!(error = %e, "failed to write fleet.yaml");

--- a/src/bootstrap/doctor.rs
+++ b/src/bootstrap/doctor.rs
@@ -8,6 +8,7 @@
 //! Sprint 23 P1 — deferred from Sprint 22 P0 PR #230.
 
 use crate::fleet::{ChannelConfig, FleetConfig};
+use std::path::Path;
 
 /// Severity levels for doctor diagnostics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,9 +34,15 @@ pub struct Diagnostic {
 
 /// Validate fleet config for operator pitfalls. Returns diagnostics
 /// ordered by severity (critical first).
-pub fn validate_fleet_config(config: &FleetConfig) -> Vec<Diagnostic> {
+///
+/// `home` is consulted by checks that need to read other daemon-state
+/// files (e.g. D002 reads `task_sweep.json`). Passing the daemon's
+/// `home_dir()` is correct for production callers; tests pass a
+/// dedicated temp dir.
+pub fn validate_fleet_config(config: &FleetConfig, home: &Path) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
     check_channel_user_allowlist(config, &mut diags);
+    check_task_sweep_github_login_mapping(config, home, &mut diags);
     diags
 }
 
@@ -121,10 +128,79 @@ fn check_channel_user_allowlist(config: &FleetConfig, diags: &mut Vec<Diagnostic
     }
 }
 
+/// D002: task_sweep is configured but no agent has a `github_login`
+/// mapping declared in fleet.yaml. Sprint 56 Track F (#496): the sweep's
+/// authorship gate compares `pr.author_login` against
+/// `task.created_by` / `task.assignee` after resolving through the
+/// `github_login` mapping; with zero mappings configured the gate
+/// silently rejects every cross-namespace mismatch (the cheerc-class
+/// repro that landed Track C-RCA's verdict).
+///
+/// Mirrors D001's `tracing::error!("FATAL: …")` + copy-paste fix
+/// stanza pattern so operators see an actionable signal at startup
+/// rather than discovering the problem via "my sweep doesn't work".
+///
+/// Silent when:
+///   - `task_sweep_config.repo` is unset (sweep disabled, no auto-close
+///     to mis-author, so the mapping isn't relevant).
+///   - At least one instance has `github_login` set (operator has begun
+///     mapping; D002 doesn't nag, the per-PR `tracing::warn!` at
+///     `task_sweep.rs:218` covers any remaining unmapped instances).
+///
+/// Reads `<home>/task_sweep.json` directly via the same loader the
+/// sweep tick uses, so a missing config file is treated as
+/// sweep-disabled (no false-positive D002 on fresh deployments).
+fn check_task_sweep_github_login_mapping(
+    config: &FleetConfig,
+    home: &Path,
+    diags: &mut Vec<Diagnostic>,
+) {
+    let sweep_cfg = crate::daemon::task_sweep::load_sweep_config_for_doctor(home);
+    let sweep_enabled = sweep_cfg
+        .repo
+        .as_deref()
+        .map(|r| !r.is_empty())
+        .unwrap_or(false)
+        && !sweep_cfg.paused;
+    if !sweep_enabled {
+        return;
+    }
+    let any_mapped = config
+        .instances
+        .values()
+        .any(|inst| inst.github_login.is_some());
+    if any_mapped {
+        return;
+    }
+    let repo = sweep_cfg.repo.as_deref().unwrap_or("<unset>");
+    diags.push(Diagnostic {
+        severity: Severity::Critical,
+        code: "D002",
+        message: format!(
+            "task_sweep is enabled (repo='{repo}') but no instance in fleet.yaml has a \
+             `github_login` mapping. The sweep's authorship gate compares the GitHub PR \
+             author against the agend instance name, so every merged PR with a `Closes \
+             t-...` marker will be silently rejected (see \
+             docs/RCA-issue-496-task-sweep-no-auto-close-2026-05-08.md)."
+        ),
+        fix_stanza: Some(
+            "Add a `github_login` field to each instance in fleet.yaml that \
+             opens PRs:\n  \
+             instances:\n    <instance-name>:\n      github_login: <YOUR_GITHUB_USERNAME>\n\
+             Instances that don't open PRs can omit the field — D002 only fires \
+             when ZERO instances are mapped."
+                .to_string(),
+        ),
+    });
+}
+
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::fleet::FleetConfig;
+    use crate::fleet::{FleetConfig, InstanceConfig};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     fn telegram_config(user_allowlist: Option<Vec<i64>>) -> ChannelConfig {
         ChannelConfig::Telegram {
@@ -136,13 +212,53 @@ mod tests {
         }
     }
 
+    /// Per-test scratch home directory for D002 fixtures (writes
+    /// `task_sweep.json`). Without a sweep config file the loader returns
+    /// the default (`repo: None`) and D002 stays silent — so D001 tests
+    /// don't need to fabricate a sweep state.
+    fn tmp_home(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-doctor-test-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Write a `task_sweep.json` enabling the sweep with the given repo
+    /// so D002 evaluation has a config to read.
+    fn enable_sweep(home: &std::path::Path, repo: &str) {
+        let body = serde_json::json!({
+            "repo": repo,
+            "paused": false,
+            "dry_run": false,
+        });
+        std::fs::write(
+            home.join("task_sweep.json"),
+            serde_json::to_string(&body).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// Build an `InstanceConfig` with the requested `github_login`.
+    fn instance_with_login(github_login: Option<&str>) -> InstanceConfig {
+        InstanceConfig {
+            github_login: github_login.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn missing_user_allowlist_emits_critical() {
         let config = FleetConfig {
             channel: Some(telegram_config(None)),
             ..Default::default()
         };
-        let diags = validate_fleet_config(&config);
+        let diags = validate_fleet_config(&config, &tmp_home("doctor"));
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Critical);
         assert_eq!(diags[0].code, "D001");
@@ -156,7 +272,7 @@ mod tests {
             channel: Some(telegram_config(Some(vec![12345]))),
             ..Default::default()
         };
-        let diags = validate_fleet_config(&config);
+        let diags = validate_fleet_config(&config, &tmp_home("doctor"));
         assert!(diags.is_empty());
     }
 
@@ -173,7 +289,7 @@ mod tests {
             channel: Some(telegram_config(Some(vec![]))),
             ..Default::default()
         };
-        let diags = validate_fleet_config(&config);
+        let diags = validate_fleet_config(&config, &tmp_home("doctor"));
         assert_eq!(diags.len(), 1, "empty allowlist must trigger one D001");
         assert_eq!(diags[0].severity, Severity::Critical);
         assert_eq!(diags[0].code, "D001");
@@ -198,8 +314,8 @@ mod tests {
             channel: Some(telegram_config(Some(vec![]))),
             ..Default::default()
         };
-        let none_msg = &validate_fleet_config(&cfg_none)[0].message;
-        let empty_msg = &validate_fleet_config(&cfg_empty)[0].message;
+        let none_msg = &validate_fleet_config(&cfg_none, &tmp_home("doctor"))[0].message;
+        let empty_msg = &validate_fleet_config(&cfg_empty, &tmp_home("doctor"))[0].message;
         assert_ne!(
             none_msg, empty_msg,
             "missing-field vs empty-list diagnostics must read differently"
@@ -223,7 +339,7 @@ mod tests {
             channel: Some(telegram_config(Some(vec![]))),
             ..Default::default()
         };
-        let diags = validate_fleet_config(&config);
+        let diags = validate_fleet_config(&config, &tmp_home("doctor"));
         let stanza = diags[0]
             .fix_stanza
             .as_deref()
@@ -237,7 +353,7 @@ mod tests {
     #[test]
     fn no_channel_configured_silent() {
         let config = FleetConfig::default();
-        let diags = validate_fleet_config(&config);
+        let diags = validate_fleet_config(&config, &tmp_home("doctor"));
         assert!(diags.is_empty());
     }
 
@@ -250,7 +366,7 @@ mod tests {
             channels: Some(channels),
             ..Default::default()
         };
-        let diags = validate_fleet_config(&config);
+        let diags = validate_fleet_config(&config, &tmp_home("doctor"));
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("tg-main"));
     }
@@ -264,7 +380,127 @@ mod tests {
             }),
             ..Default::default()
         };
-        let diags = validate_fleet_config(&config);
+        let diags = validate_fleet_config(&config, &tmp_home("doctor"));
         assert!(diags.is_empty());
+    }
+
+    // ── Sprint 56 Track F (#496): D002 task_sweep github_login mapping ──
+
+    /// Lead-spec D002 #1: sweep configured AND no instance has
+    /// `github_login` mapped → emit Critical D002 with copy-paste fix.
+    #[test]
+    fn d002_fires_when_sweep_configured_and_no_mappings() {
+        let home = tmp_home("d002-fires");
+        enable_sweep(&home, "cheerc/talented-payroll");
+        let mut config = FleetConfig::default();
+        config
+            .instances
+            .insert("dev".into(), instance_with_login(None));
+        config
+            .instances
+            .insert("lead".into(), instance_with_login(None));
+
+        let diags = validate_fleet_config(&config, &home);
+        let d002: Vec<_> = diags.iter().filter(|d| d.code == "D002").collect();
+        assert_eq!(
+            d002.len(),
+            1,
+            "D002 must fire exactly once when sweep configured + zero mappings; got: {diags:?}"
+        );
+        assert_eq!(d002[0].severity, Severity::Critical);
+        assert!(
+            d002[0].message.contains("cheerc/talented-payroll"),
+            "D002 message must echo the configured repo for context: {}",
+            d002[0].message
+        );
+        assert!(
+            d002[0].message.contains("github_login"),
+            "D002 message must name the field operators need to add"
+        );
+        let stanza = d002[0]
+            .fix_stanza
+            .as_deref()
+            .expect("D002 must include a copy-paste fix stanza");
+        assert!(
+            stanza.contains("github_login") && stanza.contains("instances:"),
+            "D002 fix stanza must show the actual fleet.yaml shape: {stanza}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Lead-spec D002 #2: at least one instance is mapped → D002 stays
+    /// silent. The per-PR `tracing::warn!` at `task_sweep.rs:218` carries
+    /// the burden for any remaining unmapped instances; D002 doesn't
+    /// nag once the operator has begun mapping.
+    #[test]
+    fn d002_silent_when_at_least_one_mapping() {
+        let home = tmp_home("d002-silent-some");
+        enable_sweep(&home, "cheerc/talented-payroll");
+        let mut config = FleetConfig::default();
+        config
+            .instances
+            .insert("dev".into(), instance_with_login(Some("alice")));
+        config
+            .instances
+            .insert("lead".into(), instance_with_login(None));
+
+        let diags = validate_fleet_config(&config, &home);
+        assert!(
+            !diags.iter().any(|d| d.code == "D002"),
+            "D002 must stay silent when ≥1 instance is mapped; got: {diags:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Lead-spec D002 #3: sweep is unconfigured (no `task_sweep.json`
+    /// or `repo: null`) → D002 stays silent regardless of mapping
+    /// state. D002 only screens deployments where the sweep would
+    /// actually fire and silently mis-author tasks; we don't pester
+    /// fleets that don't run the sweep at all.
+    #[test]
+    fn d002_silent_when_sweep_unconfigured() {
+        let home = tmp_home("d002-silent-disabled");
+        // Note: no `enable_sweep(...)` call — task_sweep.json absent.
+        let mut config = FleetConfig::default();
+        config
+            .instances
+            .insert("dev".into(), instance_with_login(None));
+
+        let diags = validate_fleet_config(&config, &home);
+        assert!(
+            !diags.iter().any(|d| d.code == "D002"),
+            "D002 must stay silent when task_sweep is unconfigured; got: {diags:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Defensive: sweep `paused: true` is treated like sweep-disabled —
+    /// the silent-mis-author symptom can't manifest while the tick body
+    /// short-circuits, so D002 must not fire and waste operator
+    /// attention.
+    #[test]
+    fn d002_silent_when_sweep_paused() {
+        let home = tmp_home("d002-silent-paused");
+        let body = serde_json::json!({
+            "repo": "cheerc/talented-payroll",
+            "paused": true,
+            "dry_run": false,
+        });
+        std::fs::write(
+            home.join("task_sweep.json"),
+            serde_json::to_string(&body).unwrap(),
+        )
+        .unwrap();
+        let mut config = FleetConfig::default();
+        config
+            .instances
+            .insert("dev".into(), instance_with_login(None));
+
+        let diags = validate_fleet_config(&config, &home);
+        assert!(
+            !diags.iter().any(|d| d.code == "D002"),
+            "D002 must stay silent when sweep is paused; got: {diags:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -61,6 +61,7 @@ fn auto_create_general(config: &mut FleetConfig, home: &Path, persist: bool) {
         source_repo: None,
         // Sprint 55 P0-B EC4: see instance.rs (gradient).
         repo: None,
+        github_login: None,
     };
     if let Err(e) = fleet::add_instance_to_yaml(home, "general", &entry) {
         tracing::warn!(error = %e, "failed to persist general instance");

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -163,7 +163,7 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     // Doctor pre-flight: detect operator pitfalls in fleet.yaml and emit
     // actionable diagnostics before any agents spawn. Sprint 23 P1 —
     // deferred from Sprint 22 P0 PR #230.
-    let diags = doctor::validate_fleet_config(&config);
+    let diags = doctor::validate_fleet_config(&config, home);
     doctor::emit_diagnostics(&diags);
 
     let agents = if opts.resolve_agents {

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -77,6 +77,16 @@ fn load_config(home: &Path) -> SweepConfig {
     crate::store::load(&config_path(home))
 }
 
+/// Sprint 56 Track F (#496): public loader for the doctor's D002 check.
+/// Same implementation as the private `load_config` — exposed so
+/// `bootstrap::doctor::check_task_sweep_github_login_mapping` can read
+/// the sweep state without re-implementing the deserialization. Returns
+/// the default (`repo: None`) when the file is missing, mirroring the
+/// tick body's "no-op when unconfigured" semantics.
+pub fn load_sweep_config_for_doctor(home: &Path) -> SweepConfig {
+    load_config(home)
+}
+
 fn save_config(home: &Path, cfg: &SweepConfig) -> anyhow::Result<()> {
     crate::store::save_atomic(&config_path(home), cfg)
 }
@@ -112,6 +122,51 @@ impl TaskSweep {
 
 // ── Tick body ───────────────────────────────────────────────────────
 
+/// Sprint 56 Track F (#496): resolve an agend-local instance name to its
+/// configured GitHub login via `fleet.yaml`'s per-instance
+/// `github_login` field. Returns `None` when fleet config is absent /
+/// malformed, the instance is not declared, or the field is omitted —
+/// the sweep then falls back to direct string compare for backwards
+/// compatibility with deployments where instance name happens to equal
+/// the GitHub login.
+fn resolve_github_login<'a>(
+    fleet: Option<&'a crate::fleet::FleetConfig>,
+    instance_name: &str,
+) -> Option<&'a str> {
+    fleet?.instances.get(instance_name)?.github_login.as_deref()
+}
+
+/// Sprint 56 Track F (#496): pure helper for the sweep's authorship
+/// gate. Returns `true` iff `pr_login` matches either the task creator
+/// or the task assignee, after each is resolved through the fleet's
+/// `github_login` mapping (with a direct-compare fall-back for
+/// instances that have no mapping configured).
+///
+/// Compat invariant: when no fleet config is loaded, or no instance has
+/// `github_login` set, the helper degrades to the pre-Track-F behavior
+/// — direct string compare against the agend instance name. This
+/// preserves existing deployments where the instance name happens to
+/// equal the operator's GitHub login. Operators can opt into the
+/// stricter mapping per-instance.
+fn compute_author_ok(
+    pr_login: &str,
+    task: &crate::tasks::Task,
+    fleet: Option<&crate::fleet::FleetConfig>,
+) -> bool {
+    let creator = task.created_by.as_str();
+    let creator_login = resolve_github_login(fleet, creator).unwrap_or(creator);
+    if pr_login.eq_ignore_ascii_case(creator_login) {
+        return true;
+    }
+    if let Some(assignee) = task.assignee.as_deref() {
+        let assignee_login = resolve_github_login(fleet, assignee).unwrap_or(assignee);
+        if pr_login.eq_ignore_ascii_case(assignee_login) {
+            return true;
+        }
+    }
+    false
+}
+
 fn sweep_tick(home: &Path) -> anyhow::Result<()> {
     let cfg = load_config(home);
     if cfg.paused {
@@ -126,6 +181,16 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
     if prs.is_empty() {
         return Ok(());
     }
+
+    // Sprint 56 Track F (#496): load fleet config so the authorship gate
+    // below can resolve `task.created_by` / `task.assignee` (agend-local
+    // instance names) into `github_login` GitHub usernames before
+    // comparing against `pr.author_login`. Pre-Track-F the gate compared
+    // disjoint namespaces and silently rejected every cross-namespace
+    // mismatch — see `docs/RCA-issue-496-task-sweep-no-auto-close-2026-05-08.md`.
+    // `Option<FleetConfig>` because a missing/malformed fleet.yaml must
+    // not abort the sweep — fall back to direct compare for compat.
+    let fleet_cfg = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
 
     // Snapshot of currently-open tasks. Read from tasks::list_all (the
     // PR2 bridge-phase legacy reader); PR3 cutover switches this to
@@ -197,19 +262,20 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
             // task creator OR assignee must match. Defends pre-PR-220
             // `update_decision` bug class where a malicious PR body could
             // close another agent's task.
-            let creator = task.created_by.as_str();
-            let assignee = task.assignee.as_deref();
-            let author_ok = pr.author_login.eq_ignore_ascii_case(creator)
-                || assignee
-                    .map(|a| pr.author_login.eq_ignore_ascii_case(a))
-                    .unwrap_or(false);
+            //
+            // Sprint 56 Track F (#496): the comparison is against the
+            // GitHub username, not the agend-local instance name. The
+            // pure helper `compute_author_ok` resolves creator/assignee
+            // via the fleet's `github_login` mapping with a fall-back to
+            // a direct string compare for compat — see helper docs.
+            let author_ok = compute_author_ok(&pr.author_login, task, fleet_cfg.as_ref());
             if !author_ok {
                 tracing::warn!(
                     pr = pr.number,
                     marker = %marker,
                     pr_author = %pr.author_login,
-                    task_creator = creator,
-                    task_assignee = ?assignee,
+                    task_creator = task.created_by.as_str(),
+                    task_assignee = ?task.assignee.as_deref(),
                     "sweep: PR.user.login not authorised to close — rejected"
                 );
                 continue;
@@ -435,6 +501,133 @@ mod tests {
         ));
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    // ── Sprint 56 Track F (#496): authorship gate via github_login ──
+
+    fn task_with(created_by: &str, assignee: Option<&str>) -> crate::tasks::Task {
+        crate::tasks::Task {
+            id: "t-1-1".into(),
+            title: "x".into(),
+            description: String::new(),
+            status: "open".into(),
+            priority: "normal".into(),
+            assignee: assignee.map(str::to_string),
+            routed_to: None,
+            created_by: created_by.into(),
+            depends_on: Vec::new(),
+            result: None,
+            created_at: "2026-05-08T00:00:00Z".into(),
+            updated_at: "2026-05-08T00:00:00Z".into(),
+            due_at: None,
+            branch: None,
+        }
+    }
+
+    fn fleet_with_login(instance: &str, github_login: &str) -> crate::fleet::FleetConfig {
+        let mut instances = std::collections::HashMap::new();
+        instances.insert(
+            instance.into(),
+            crate::fleet::InstanceConfig {
+                github_login: Some(github_login.into()),
+                ..Default::default()
+            },
+        );
+        crate::fleet::FleetConfig {
+            instances,
+            ..Default::default()
+        }
+    }
+
+    /// Lead-spec #1: with `github_login: alice` mapped on instance `dev`,
+    /// a PR by `alice` against a task created by `dev` must close.
+    #[test]
+    fn mapping_present_compares_against_github_login() {
+        let task = task_with("dev", None);
+        let fleet = fleet_with_login("dev", "alice");
+        assert!(compute_author_ok("alice", &task, Some(&fleet)));
+        // Case-insensitive — GitHub usernames are.
+        assert!(compute_author_ok("Alice", &task, Some(&fleet)));
+    }
+
+    /// Lead-spec #2: no `github_login` mapping AND no fleet config — the
+    /// helper falls back to direct string compare against the agend
+    /// instance name. Compat path for deployments where instance name
+    /// happens to equal the operator's GitHub login (the implicit
+    /// assumption pre-Track-F).
+    #[test]
+    fn mapping_absent_falls_back_to_direct_compare() {
+        let task = task_with("dev", None);
+        // No fleet at all.
+        assert!(compute_author_ok("dev", &task, None));
+        assert!(!compute_author_ok("alice", &task, None));
+        // Fleet present but no mapping for this instance.
+        let mut fleet = crate::fleet::FleetConfig::default();
+        fleet.instances.insert(
+            "other".into(),
+            crate::fleet::InstanceConfig {
+                github_login: Some("bob".into()),
+                ..Default::default()
+            },
+        );
+        assert!(compute_author_ok("dev", &task, Some(&fleet)));
+        assert!(!compute_author_ok("alice", &task, Some(&fleet)));
+    }
+
+    /// Lead-spec #3: when `github_login: alice` is mapped, a PR by `bob`
+    /// must NOT close — the security gate (PR-220 defense) is preserved
+    /// even after Track F's namespace fix.
+    #[test]
+    fn mapping_present_mismatch_does_not_close() {
+        let task = task_with("dev", None);
+        let fleet = fleet_with_login("dev", "alice");
+        assert!(!compute_author_ok("bob", &task, Some(&fleet)));
+        // The PR author equals the agend instance name string but the
+        // mapping says the real login is `alice` — direct-name match
+        // must NOT bypass the mapping when one is configured.
+        assert!(!compute_author_ok("dev", &task, Some(&fleet)));
+    }
+
+    /// Mapping resolves through the assignee branch too — a task claimed
+    /// by `dev-impl` with `github_login: bob` must accept a PR by `bob`
+    /// even when the creator's mapping doesn't match.
+    #[test]
+    fn mapping_resolves_assignee_branch() {
+        let task = task_with("lead", Some("dev-impl"));
+        let mut fleet = crate::fleet::FleetConfig::default();
+        fleet.instances.insert(
+            "lead".into(),
+            crate::fleet::InstanceConfig {
+                github_login: Some("alice".into()),
+                ..Default::default()
+            },
+        );
+        fleet.instances.insert(
+            "dev-impl".into(),
+            crate::fleet::InstanceConfig {
+                github_login: Some("bob".into()),
+                ..Default::default()
+            },
+        );
+        assert!(compute_author_ok("alice", &task, Some(&fleet))); // creator branch
+        assert!(compute_author_ok("bob", &task, Some(&fleet))); // assignee branch
+        assert!(!compute_author_ok("eve", &task, Some(&fleet))); // neither
+    }
+
+    /// Resolver: returns mapped login when fleet has it.
+    #[test]
+    fn resolve_github_login_returns_mapped() {
+        let fleet = fleet_with_login("dev", "alice");
+        assert_eq!(resolve_github_login(Some(&fleet), "dev"), Some("alice"));
+    }
+
+    /// Resolver: returns None when instance is not in the fleet (so the
+    /// caller's fall-back path engages rather than a false-negative).
+    #[test]
+    fn resolve_github_login_returns_none_for_unknown_instance() {
+        let fleet = fleet_with_login("dev", "alice");
+        assert_eq!(resolve_github_login(Some(&fleet), "ghost"), None);
+        assert_eq!(resolve_github_login(None, "dev"), None);
     }
 
     /// Must-have #1 — HTML-comment injection: a directive hidden inside

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -212,6 +212,7 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
                 source_repo: None,
                 // Sprint 55 P0-B EC4: see instance.rs (gradient).
                 repo: None,
+                github_login: None,
             },
         ));
         created.push(inst_name);

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -196,6 +196,17 @@ pub struct InstanceConfig {
     /// Content is appended to the generated agent instructions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    /// Sprint 56 Track F (#496): operator-controlled GitHub username for
+    /// this instance. Lets `task_sweep`'s authorship gate compare
+    /// `pr.author_login` against the right namespace — without this
+    /// mapping, the gate compared GitHub user names against agend
+    /// instance names (e.g. `cheerc` vs `dev-lead`) and silently
+    /// rejected every cross-namespace mismatch. When `None`, the sweep
+    /// falls back to direct string compare for backwards compatibility
+    /// with deployments where instance name happens to equal the
+    /// operator's GitHub login.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_login: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -512,6 +523,12 @@ pub struct InstanceYamlEntry {
     /// `InstanceConfig::repo`. Daemon auto-write callers leave this
     /// `None` (gradient deployment); operator hand-edits opt agents in.
     pub repo: Option<String>,
+    /// Sprint 56 Track F (#496): GitHub login mapping per
+    /// `InstanceConfig::github_login`. Daemon auto-write callers leave
+    /// this `None` so existing instance creation paths don't suddenly
+    /// require operator-supplied GitHub identities; operator hand-edits
+    /// or fleet.yaml templates opt agents in.
+    pub github_login: Option<String>,
 }
 
 /// Atomically write a serde_yaml_ng::Value back to fleet.yaml using temp + fsync + rename.
@@ -592,6 +609,9 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
                 // Sprint 55 P0-B EC4: same pattern — operator-set repo
                 // override round-trips, daemon auto-writers omit.
                 ("repo", &config.repo),
+                // Sprint 56 Track F (#496): same pattern — operator-set
+                // GitHub login round-trips, daemon auto-writers omit.
+                ("github_login", &config.github_login),
             ] {
                 if let Some(ref v) = val {
                     inst.insert(key.into(), serde_yaml_ng::Value::String(v.clone()));
@@ -1009,6 +1029,7 @@ instances:
             instructions: Some("./instructions/dev.md".to_string()),
             source_repo: None,
             repo: None,
+            github_login: None,
         };
         add_instance_to_yaml(&dir, "new-agent", &entry).expect("add");
         let config = FleetConfig::load(&path).expect("load after add");
@@ -1057,6 +1078,7 @@ instances:
             instructions: None,
             source_repo: None,
             repo: None,
+            github_login: None,
         };
         add_instance_to_yaml(&dir, "first", &entry).expect("add to new");
         let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
@@ -1657,6 +1679,7 @@ instances:
             instructions: None,
             source_repo: None,
             repo: None,
+            github_login: None,
         };
         add_instance_to_yaml(&dir, "temp-agent", &entry).expect("add");
 
@@ -2368,6 +2391,7 @@ instances:
             instructions: None,
             source_repo: Some("/tmp/rt-source".to_string()),
             repo: None,
+            github_login: None,
         };
         add_instance_to_yaml(&dir, "rt-agent", &entry).expect("add");
         let content = std::fs::read_to_string(dir.join("fleet.yaml")).expect("read");

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -609,6 +609,7 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
                 // `repo` override None; operator opts in for non-GitHub
                 // remote OR fork-vs-upstream disambiguation.
                 repo: None,
+                github_login: None,
             };
             if let Err(e) = crate::fleet::add_instance_to_yaml(home, name, &entry) {
                 tracing::warn!(error = %e, "failed to persist to fleet.yaml");


### PR DESCRIPTION
## Summary
Implements Track C-RCA's recommended two-piece fix for issue #496 (task_sweep authorship gate silent-drop). Track F arbitrated by lead in [m-20260508093728910247-74](https://github.com/suzuke/agend-terminal/issues/496) post-RCA verdict landing in `cdc5259`.

- **Piece 1** — `github_login: Option<String>` on `InstanceConfig` + `InstanceYamlEntry` (with serde defaults for backwards compat). Sweep tick loads fleet config once and resolves task creator/assignee via the new mapping before the `eq_ignore_ascii_case` compare. Direct-compare fall-back preserves pre-Track-F behavior for deployments where instance name happens to equal the GitHub login.
- **Piece 2** — D002 doctor diagnostic mirroring Sprint 56 Track B's D001 precedent. Critical-level emit when sweep is configured AND zero instances are mapped. Routes through existing `emit_diagnostics` -> `tracing::error!("FATAL: …")` -> stderr.
- 10 new tests (6 sweep / 4 D002), all green. 0 production regressions.

## RCA pointer
Track C-RCA doc on main covers the silent-drop chain in detail: [`docs/RCA-issue-496-task-sweep-no-auto-close-2026-05-08.md`](https://github.com/suzuke/agend-terminal/blob/main/docs/RCA-issue-496-task-sweep-no-auto-close-2026-05-08.md).

## Surface (10 files, +479/-20)

| File | LOC | Role |
|---|---|---|
| `src/fleet.rs` | +24 | `github_login` field on `InstanceConfig` + `InstanceYamlEntry` + write loop entry |
| `src/daemon/task_sweep.rs` | +209 (~30 prod / ~179 tests) | `resolve_github_login` resolver + `compute_author_ok` pure helper + `load_sweep_config_for_doctor` exposure + sweep_tick wiring + 6 unit tests |
| `src/bootstrap/doctor.rs` | +258 (~70 prod / ~188 tests) | D002 check + signature extension (`home: &Path`) + 4 D002 tests + helpers |
| `src/bootstrap/mod.rs` | +2/-1 | Pass `home` into `validate_fleet_config` |
| 6 other files | +1 each | `github_login: None` gradient on existing `InstanceYamlEntry` constructors (matches Sprint 54 P1-B / Sprint 55 P0-B precedent for opt-in fields) |

## Test plan
- [x] `cargo test --bin agend-terminal -- daemon::task_sweep::tests bootstrap::doctor::tests` — 18 tests pass (6 + 4 new + 8 pre-existing)
- [x] `cargo clippy --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Full bin test: 1695 passed; 7 failed (pre-existing env-dependent failures: `admin::tests::analyze_detects_worktree_branch` + 6 `claim_verifier::tests` `git diff HEAD..HEAD` ambiguity, none in Track F surfaces)

### Lead-spec test coverage
- [x] `mapping_present_compares_against_github_login` — `github_login: alice` mapped on `dev`, PR by `alice` against task by `dev` → close
- [x] `mapping_absent_falls_back_to_direct_compare` — no mapping, PR by `dev` against task by `dev` → close (compat)
- [x] `mapping_present_mismatch_does_not_close` — `github_login: alice`, PR by `bob` → reject (security gate preserved)
- [x] `d002_fires_when_sweep_configured_and_no_mappings` — emit Critical with copy-paste fix
- [x] `d002_silent_when_at_least_one_mapping` — operator opt-in respected
- [x] `d002_silent_when_sweep_unconfigured` — no nag for fleets without sweep
- [x] Bonus: `mapping_resolves_assignee_branch` (assignee branch coverage), `d002_silent_when_sweep_paused` (defensive)

## Backwards compatibility
- Existing fleet.yaml without `github_login`: deserializes via `#[serde(default)]`; `compute_author_ok` falls back to direct compare against the agend instance name → preserves Sprint 23 P1's implicit `instance_name == github_login` assumption.
- Existing `validate_fleet_config(&config)` test calls updated to pass `&tmp_home("doctor")` (8 sites in doctor.rs::tests + 1 production caller in `bootstrap/mod.rs::prepare`). No external API surface; signature change is internal.

## STRICT v2 / bypass discipline
- Daemon-managed worktree at `.worktrees/dev` via `bind_self(source_repo, branch=sprint56-track-f-issue-496-fix)`
- Plain `git add/commit/push` (wrapper allowed; one stash + rebase + soft-reset cycle to absorb daemon hook auto-commits, all via plain git)
- 0 bypass cycles for this PR ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)