### PR TITLE
feat(deploy): template params passthrough (Sprint 56 Track E) (#450)

### DIFF
--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -105,6 +105,12 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
                         // Sprint 55 P0-B EC4: see instance.rs (gradient).
                         repo: None,
                         github_login: None,
+                        args: None,
+                        model: None,
+                        env: None,
+                        ready_pattern: None,
+                        command: None,
+                        worktree: None,
                     },
                 )
             })

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -53,6 +53,12 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                     // Sprint 55 P0-B EC4: see instance.rs (gradient).
                     repo: None,
                     github_login: None,
+                    args: None,
+                    model: None,
+                    env: None,
+                    ready_pattern: None,
+                    command: None,
+                    worktree: None,
                 },
             ) {
                 tracing::warn!(name = %inst_name, error = %e, "failed to write fleet.yaml");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -785,6 +785,12 @@ fn pane_from_menu_item(
                     // Sprint 55 P0-B EC4: see instance.rs (gradient).
                     repo: None,
                     github_login: None,
+                    args: None,
+                    model: None,
+                    env: None,
+                    ready_pattern: None,
+                    command: None,
+                    worktree: None,
                 },
             ) {
                 tracing::warn!(error = %e, "failed to write fleet.yaml");

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -62,6 +62,12 @@ fn auto_create_general(config: &mut FleetConfig, home: &Path, persist: bool) {
         // Sprint 55 P0-B EC4: see instance.rs (gradient).
         repo: None,
         github_login: None,
+        args: None,
+        model: None,
+        env: None,
+        ready_pattern: None,
+        command: None,
+        worktree: None,
     };
     if let Err(e) = fleet::add_instance_to_yaml(home, "general", &entry) {
         tracing::warn!(error = %e, "failed to persist general instance");

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -160,6 +160,59 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(String::from);
+        // Sprint 56 Track E (#450): pass-through six template
+        // parameters that the prior schema silently discarded. Scalars
+        // mirror the role/instructions trim → filter-empty → None
+        // pattern so a blank YAML field doesn't write a blank stanza.
+        // `args` / `env` use sequence / mapping shape; empty maps to
+        // None so a missing field is never re-written as `args: []`.
+        let template_args = inst_val
+            .get("args")
+            .and_then(|v| v.as_sequence())
+            .map(|seq| {
+                seq.iter()
+                    .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                    .collect::<Vec<String>>()
+            })
+            .filter(|v| !v.is_empty());
+        let template_model = inst_val
+            .get("model")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from);
+        let template_env = inst_val
+            .get("env")
+            .and_then(|v| v.as_mapping())
+            .map(|m| {
+                let mut out = std::collections::HashMap::new();
+                for (k, v) in m {
+                    if let (Some(k), Some(v)) = (k.as_str(), v.as_str()) {
+                        out.insert(k.to_string(), v.to_string());
+                    }
+                }
+                out
+            })
+            .filter(|m| !m.is_empty());
+        let template_ready_pattern = inst_val
+            .get("ready_pattern")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from);
+        // `command:` template field is preserved verbatim into the
+        // YamlEntry's `command` slot so a custom non-backend invocation
+        // (e.g. `command: my-script.sh`) round-trips. Note that the
+        // existing `command` / `backend` fallback above derives the
+        // SPAWN-time backend label; this passthrough is the durable
+        // YAML record.
+        let template_command = inst_val
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from);
+        let template_worktree = inst_val.get("worktree").and_then(|v| v.as_bool());
 
         // Every member gets its own `<directory>/<inst_name>` subdir —
         // same-backend teammates would otherwise clobber each other's
@@ -213,6 +266,17 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
                 // Sprint 55 P0-B EC4: see instance.rs (gradient).
                 repo: None,
                 github_login: None,
+                // Sprint 56 Track E (#450): six template-parameter
+                // passthroughs. Each is `None` when the template stanza
+                // omits the field, preserving Sprint 21+ "no override"
+                // semantics for backwards compat with existing
+                // templates that don't declare them.
+                args: template_args,
+                model: template_model,
+                env: template_env,
+                ready_pattern: template_ready_pattern,
+                command: template_command,
+                worktree: template_worktree,
             },
         ));
         created.push(inst_name);
@@ -734,6 +798,276 @@ templates:
                 .and_then(|i| i.instructions.as_deref()),
             Some("./instructions/lead.md")
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 56 Track E (#450): template params passthrough ──────────
+
+    #[test]
+    fn deploy_persists_args_into_fleet_yaml() {
+        let home = tmp_home("args_persist");
+        let yaml = r#"
+templates:
+  dev:
+    instances:
+      worker:
+        backend: claude
+        args:
+          - --resume
+          - --model
+          - opus
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
+        );
+        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let inst = reloaded.instances.get("dev-worker").expect("dev-worker");
+        assert_eq!(
+            inst.args,
+            vec![
+                "--resume".to_string(),
+                "--model".to_string(),
+                "opus".to_string()
+            ]
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn deploy_persists_model_into_fleet_yaml() {
+        let home = tmp_home("model_persist");
+        let yaml = r#"
+templates:
+  dev:
+    instances:
+      specialist:
+        backend: claude
+        model: opus
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
+        );
+        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let inst = reloaded
+            .instances
+            .get("dev-specialist")
+            .expect("dev-specialist");
+        assert_eq!(inst.model.as_deref(), Some("opus"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn deploy_persists_env_into_fleet_yaml() {
+        let home = tmp_home("env_persist");
+        let yaml = r#"
+templates:
+  dev:
+    instances:
+      worker:
+        backend: claude
+        env:
+          MCP_SERVER_URL: https://example.com
+          DEBUG: "1"
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
+        );
+        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let inst = reloaded.instances.get("dev-worker").expect("dev-worker");
+        assert_eq!(
+            inst.env.get("MCP_SERVER_URL").map(|s| s.as_str()),
+            Some("https://example.com")
+        );
+        assert_eq!(inst.env.get("DEBUG").map(|s| s.as_str()), Some("1"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn deploy_persists_ready_pattern_into_fleet_yaml() {
+        let home = tmp_home("ready_persist");
+        let yaml = r#"
+templates:
+  dev:
+    instances:
+      worker:
+        backend: claude
+        ready_pattern: "ready for input"
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
+        );
+        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let inst = reloaded.instances.get("dev-worker").expect("dev-worker");
+        assert_eq!(inst.ready_pattern.as_deref(), Some("ready for input"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn deploy_persists_worktree_opt_out_into_fleet_yaml() {
+        // reviewer / orchestrator roles often want `worktree: false` so
+        // the worktree pool skips creation. Template passthrough must
+        // preserve this signal.
+        let home = tmp_home("worktree_persist");
+        let yaml = r#"
+templates:
+  dev:
+    instances:
+      reviewer:
+        backend: claude
+        worktree: false
+      impl:
+        backend: claude
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
+        );
+        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reviewer = reloaded
+            .instances
+            .get("dev-reviewer")
+            .expect("dev-reviewer");
+        assert_eq!(
+            reviewer.worktree,
+            Some(false),
+            "reviewer must round-trip `worktree: false`"
+        );
+        let imp = reloaded.instances.get("dev-impl").expect("dev-impl");
+        assert!(
+            imp.worktree.is_none(),
+            "instance without `worktree:` field must stay None for default auto-create behavior"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn deploy_persists_command_into_fleet_yaml() {
+        // `command:` template field — non-backend custom invocation.
+        let home = tmp_home("command_persist");
+        let yaml = r#"
+templates:
+  dev:
+    instances:
+      script:
+        backend: claude
+        command: ./scripts/my-runner.sh
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
+        );
+        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let inst = reloaded.instances.get("dev-script").expect("dev-script");
+        assert_eq!(
+            inst.command.as_deref(),
+            Some("./scripts/my-runner.sh"),
+            "custom command must round-trip via the template passthrough"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn deploy_omits_template_params_when_not_set_backwards_compat() {
+        // Critical backwards-compat invariant: existing templates that
+        // declare none of args/model/env/ready_pattern/command/worktree
+        // must continue to deploy unchanged. The fleet.yaml stanza for
+        // the deployed instance must have NO sentinel values for those
+        // fields — operator can't tell whether they were "passed
+        // through as None" vs "never declared" otherwise.
+        let home = tmp_home("compat_omit");
+        let yaml = r#"
+templates:
+  dev:
+    instances:
+      lead:
+        backend: claude
+        role: orchestrator
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
+        );
+        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let inst = reloaded.instances.get("dev-lead").expect("dev-lead");
+        assert!(
+            inst.args.is_empty(),
+            "args must default to empty Vec when template doesn't declare it"
+        );
+        assert!(inst.model.is_none(), "model must stay None");
+        assert!(inst.env.is_empty(), "env must default to empty HashMap");
+        assert!(inst.ready_pattern.is_none(), "ready_pattern must stay None");
+        assert!(
+            inst.worktree.is_none(),
+            "worktree must stay None (preserves default auto-create behavior)"
+        );
+        // `command` is a special case — the existing fallback at
+        // deploy()'s line 142-146 reads `command` OR `backend` for the
+        // SPAWN-time backend label; the template-passthrough path only
+        // captures it when the operator explicitly declared `command:`.
+        // A template with only `backend: claude` writes neither field
+        // value into the durable command slot.
+        assert!(
+            inst.command.is_none(),
+            "command must stay None when template only declared `backend:`"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn deploy_passes_all_six_params_simultaneously() {
+        // End-to-end pin: a template that declares all six new fields
+        // round-trips every one through fleet.yaml. Defends against a
+        // future regression where one passthrough is silently dropped
+        // (e.g. someone removes the template_args binding without
+        // updating the constructor).
+        let home = tmp_home("all_six");
+        let yaml = r#"
+templates:
+  full:
+    instances:
+      worker:
+        backend: claude
+        args:
+          - --resume
+        model: sonnet
+        env:
+          API_KEY_VAR: KEY
+        ready_pattern: "now ready"
+        command: my-runner
+        worktree: false
+"#;
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        let _ = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({"template": "full", "directory": home.display().to_string()}),
+        );
+        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let inst = reloaded.instances.get("full-worker").expect("full-worker");
+        assert_eq!(inst.args, vec!["--resume".to_string()]);
+        assert_eq!(inst.model.as_deref(), Some("sonnet"));
+        assert_eq!(inst.env.get("API_KEY_VAR").map(|s| s.as_str()), Some("KEY"));
+        assert_eq!(inst.ready_pattern.as_deref(), Some("now ready"));
+        assert_eq!(inst.command.as_deref(), Some("my-runner"));
+        assert_eq!(inst.worktree, Some(false));
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -529,6 +529,36 @@ pub struct InstanceYamlEntry {
     /// require operator-supplied GitHub identities; operator hand-edits
     /// or fleet.yaml templates opt agents in.
     pub github_login: Option<String>,
+    /// Sprint 56 Track E (#450): process args mirror of
+    /// [`InstanceConfig::args`]. `Some(vec![])` is meaningful (operator
+    /// asks for an empty arglist explicitly); `None` means "don't
+    /// override defaults". Template deployments populate from the
+    /// template stanza's `args:` field; operator hand-edits round-trip
+    /// through the writer.
+    pub args: Option<Vec<String>>,
+    /// Sprint 56 Track E (#450): backend model mirror of
+    /// [`InstanceConfig::model`] (e.g. "opus", "sonnet"). Surfaces as
+    /// the `--model` flag for backends that honour it.
+    pub model: Option<String>,
+    /// Sprint 56 Track E (#450): process env mirror of
+    /// [`InstanceConfig::env`]. Same `Option` semantics as `args`:
+    /// `None` = no override, `Some(empty)` = explicit empty map.
+    pub env: Option<std::collections::HashMap<String, String>>,
+    /// Sprint 56 Track E (#450): ready-state regex mirror of
+    /// [`InstanceConfig::ready_pattern`]. Backends that wait for a
+    /// pattern before considering the agent live read this.
+    pub ready_pattern: Option<String>,
+    /// Sprint 56 Track E (#450): custom command override mirror of
+    /// [`InstanceConfig::command`]. Templates that need a non-backend
+    /// invocation (`command: my-script.sh`) flow through this. Falls
+    /// back to `backend` when unset.
+    pub command: Option<String>,
+    /// Sprint 56 Track E (#450): per-instance worktree opt-out mirror
+    /// of [`InstanceConfig::worktree`]. Templates with reviewer /
+    /// orchestrator roles that never commit set this to `Some(false)`
+    /// so the worktree pool skips creation. Defaults to auto-create
+    /// when `None` or `Some(true)`.
+    pub worktree: Option<bool>,
 }
 
 /// Atomically write a serde_yaml_ng::Value back to fleet.yaml using temp + fsync + rename.
@@ -612,10 +642,42 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
                 // Sprint 56 Track F (#496): same pattern — operator-set
                 // GitHub login round-trips, daemon auto-writers omit.
                 ("github_login", &config.github_login),
+                // Sprint 56 Track E (#450): scalar-string passthroughs
+                // for the new template parameters. `args` / `env` /
+                // `worktree` need typed serialization and are emitted
+                // separately below.
+                ("model", &config.model),
+                ("ready_pattern", &config.ready_pattern),
+                ("command", &config.command),
             ] {
                 if let Some(ref v) = val {
                     inst.insert(key.into(), serde_yaml_ng::Value::String(v.clone()));
                 }
+            }
+            // Sprint 56 Track E (#450): typed-value passthroughs.
+            // Template deployments often populate these from the
+            // template stanza; operator hand-edits round-trip through
+            // these writers symmetrically with `add_instance_to_yaml`'s
+            // scalar-string loop above.
+            if let Some(ref args) = config.args {
+                let seq: Vec<serde_yaml_ng::Value> = args
+                    .iter()
+                    .map(|s| serde_yaml_ng::Value::String(s.clone()))
+                    .collect();
+                inst.insert("args".into(), serde_yaml_ng::Value::Sequence(seq));
+            }
+            if let Some(ref env_map) = config.env {
+                let mut env_yaml = serde_yaml_ng::Mapping::new();
+                for (k, v) in env_map {
+                    env_yaml.insert(
+                        serde_yaml_ng::Value::String(k.clone()),
+                        serde_yaml_ng::Value::String(v.clone()),
+                    );
+                }
+                inst.insert("env".into(), serde_yaml_ng::Value::Mapping(env_yaml));
+            }
+            if let Some(worktree) = config.worktree {
+                inst.insert("worktree".into(), serde_yaml_ng::Value::Bool(worktree));
             }
             instances.insert(
                 serde_yaml_ng::Value::String(name.to_string()),
@@ -1030,6 +1092,12 @@ instances:
             source_repo: None,
             repo: None,
             github_login: None,
+            args: None,
+            model: None,
+            env: None,
+            ready_pattern: None,
+            command: None,
+            worktree: None,
         };
         add_instance_to_yaml(&dir, "new-agent", &entry).expect("add");
         let config = FleetConfig::load(&path).expect("load after add");
@@ -1079,6 +1147,12 @@ instances:
             source_repo: None,
             repo: None,
             github_login: None,
+            args: None,
+            model: None,
+            env: None,
+            ready_pattern: None,
+            command: None,
+            worktree: None,
         };
         add_instance_to_yaml(&dir, "first", &entry).expect("add to new");
         let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
@@ -1680,6 +1754,12 @@ instances:
             source_repo: None,
             repo: None,
             github_login: None,
+            args: None,
+            model: None,
+            env: None,
+            ready_pattern: None,
+            command: None,
+            worktree: None,
         };
         add_instance_to_yaml(&dir, "temp-agent", &entry).expect("add");
 
@@ -2392,6 +2472,12 @@ instances:
             source_repo: Some("/tmp/rt-source".to_string()),
             repo: None,
             github_login: None,
+            args: None,
+            model: None,
+            env: None,
+            ready_pattern: None,
+            command: None,
+            worktree: None,
         };
         add_instance_to_yaml(&dir, "rt-agent", &entry).expect("add");
         let content = std::fs::read_to_string(dir.join("fleet.yaml")).expect("read");

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -610,6 +610,12 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
                 // remote OR fork-vs-upstream disambiguation.
                 repo: None,
                 github_login: None,
+                args: None,
+                model: None,
+                env: None,
+                ready_pattern: None,
+                command: None,
+                worktree: None,
             };
             if let Err(e) = crate::fleet::add_instance_to_yaml(home, name, &entry) {
                 tracing::warn!(error = %e, "failed to persist to fleet.yaml");


### PR DESCRIPTION
## Summary
Closes #450 (cheerc 5/5 trigger). Templates in fleet.yaml previously only supported `backend` and `role`; useful fields like `args` / `model` / `env` / `ready_pattern` were silently discarded during deploy. Operators had to manually edit fleet.yaml after every `deploy` to add them, breaking the automation flow for standardized teams.

- Adds 6 InstanceConfig fields to `InstanceYamlEntry`: `args`, `model`, `env`, `ready_pattern`, `command`, `worktree`. All `Option<…>` with serde defaults — existing fleet.yaml templates unchanged.
- `deploy()` now extracts those 6 fields from the template YAML stanza and threads them into `add_instances_to_yaml`.
- `add_instances_to_yaml`'s write loop extended with typed-value writers for `args` (Sequence), `env` (Mapping), `worktree` (Bool) alongside the existing scalar-string passthroughs.
- 8 new tests covering each field individually + a backwards-compat invariant test + an all-six-simultaneous end-to-end pin.

## Schema audit (RCA-first per dispatch)

| Field | InstanceConfig | InstanceYamlEntry pre-Track-E | Track E |
|---|---|---|---|
| `args` | `Vec<String>` | ❌ missing | ✅ added as `Option<Vec<String>>` |
| `model` | `Option<String>` | ❌ missing | ✅ added |
| `env` | `HashMap<String, String>` | ❌ missing | ✅ added as `Option<HashMap<…>>` |
| `ready_pattern` | `Option<String>` | ❌ missing | ✅ added |
| `command` | `Option<String>` | ❌ missing | ✅ added (custom non-backend invocation) |
| `worktree` | `Option<bool>` | ❌ missing | ✅ added (per-instance opt-out) |

Skipped fields (out of scope, deferred):
- `display_name` — UI cosmetic, not deployment-blocking
- `cols` / `rows` — terminal-size override, rare
- `git_branch` — already handled via `branch:` deploy arg

## Surface (7 files, +450 LOC)

| File | LOC | Role |
|---|---|---|
| `src/fleet.rs` | +86 | 6 new `InstanceYamlEntry` fields + write-loop extensions for typed values (Vec / HashMap / bool) |
| `src/deployments.rs` | +334 | 6 extractors in `deploy()` (~84 prod) + 8 new tests (~250) |
| 5 other files (`api/handlers/team` / `app/commands` / `app/mod` / `bootstrap/fleet_normalize` / `mcp/handlers/instance`) | +6 each | Schema-gradient: existing `InstanceYamlEntry` constructors get `field: None` defaults, matching Sprint 54 P1-B / 55 P0-B / 56 Track F precedent |

## Lead-spec test coverage
- [x] `deploy_persists_args_into_fleet_yaml`
- [x] `deploy_persists_model_into_fleet_yaml`
- [x] `deploy_persists_env_into_fleet_yaml`
- [x] `deploy_persists_ready_pattern_into_fleet_yaml`
- [x] `deploy_persists_worktree_opt_out_into_fleet_yaml`
- [x] `deploy_persists_command_into_fleet_yaml` (audit-add)
- [x] `deploy_omits_template_params_when_not_set_backwards_compat` (load-bearing compat invariant)
- [x] `deploy_passes_all_six_params_simultaneously` (end-to-end pin against future passthrough regression)

## Backwards compatibility
- All 6 fields are `Option<…>` — existing fleet.yaml templates that don't declare them continue to deploy with `None` (no behavior change).
- Empty-collection filter (`Vec`/`HashMap` `is_empty() → None`) on the extractor side prevents `args: []` / `env: {}` from being written for templates that don't declare these fields. Operators can still set explicit empty values via direct `InstanceYamlEntry` construction (the `Option` lets them differentiate "unset" from "empty override").

## Test plan
- [x] `cargo test --bin agend-terminal -- deployments::tests fleet::tests` — 90 tests pass (82 pre-existing + 8 new)
- [x] `cargo clippy --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual smoke: deploy a `research-crew` template with `reviewer` having `worktree: false` and `args: [--resume]` — verify both round-trip into fleet.yaml on first deploy

## STRICT v2 / bypass discipline
- Daemon-managed worktree at `.worktrees/dev` via `bind_self(source_repo, branch=sprint56-track-e-issue-450-template-params)`
- Plain `git add/commit/push` (wrapper allowed)
- 0 bypass cycles for this PR ✓ (6th post-policy clean PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)