### PR TITLE
feat(silent-failure): bot admin check + Critical-stderr mirror + cli doctor (Sprint 56 Track H2) (#525 items 3+5+8)

### DIFF
--- a/src/bootstrap/doctor.rs
+++ b/src/bootstrap/doctor.rs
@@ -47,6 +47,16 @@ pub fn validate_fleet_config(config: &FleetConfig, home: &Path) -> Vec<Diagnosti
 }
 
 /// Emit diagnostics to tracing at appropriate severity levels.
+///
+/// Sprint 56 Track H2 (#525 item 5): Critical-severity diagnostics are
+/// ALSO mirrored to `eprintln!` so the operator sees them regardless of
+/// the daemon's tracing destination. The pre-Track-H2 path emitted only
+/// via `tracing::error!`; in `agend-terminal start --detached` mode the
+/// daemon detaches stderr from the operator's terminal and tracing
+/// lands in a log file most operators never check, leaving D-class
+/// diagnostics silent for the failure modes they were built to defend.
+/// Mirroring to stderr is independent of tracing setup and survives
+/// the detach.
 pub fn emit_diagnostics(diags: &[Diagnostic]) {
     for d in diags {
         let fix = d
@@ -57,6 +67,7 @@ pub fn emit_diagnostics(diags: &[Diagnostic]) {
         match d.severity {
             Severity::Critical => {
                 tracing::error!(code = d.code, "FATAL: {}{fix}", d.message);
+                eprintln!("FATAL [{}]: {}{fix}", d.code, d.message);
             }
             Severity::Warning => {
                 tracing::warn!(code = d.code, "{}{fix}", d.message);
@@ -502,5 +513,59 @@ mod tests {
             "D002 must stay silent when sweep is paused; got: {diags:?}"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 56 Track H2 (#525 item 5): mirror Critical to stderr ──
+
+    /// Lead-spec item 5: Critical-severity diagnostics must be
+    /// emitted to BOTH `tracing::error!` AND direct `eprintln!`.
+    /// Pre-Track-H2 only the tracing path fired, which detached-mode
+    /// daemons couldn't surface. We can't easily capture `tracing`
+    /// output in unit tests without a subscriber harness, so we pin
+    /// the structural invariant: the function executes without panic
+    /// and the `Diagnostic` shape we'd expect to mirror is reachable
+    /// from the public API.
+    ///
+    /// The actual mirroring is verified by:
+    /// - Reading the source: line `eprintln!("FATAL [{}]: {}{fix}",
+    ///   d.code, d.message);` immediately follows the
+    ///   `tracing::error!` for `Severity::Critical`
+    /// - Manual smoke (operator) — `agend-terminal start` with a
+    ///   broken fleet.yaml prints `FATAL [D001]: …` to stderr
+    ///   regardless of `RUST_LOG` setting
+    #[test]
+    fn emit_diagnostics_critical_does_not_panic_and_mirrors() {
+        let diags = vec![Diagnostic {
+            severity: Severity::Critical,
+            code: "TEST",
+            message: "test critical".into(),
+            fix_stanza: Some("apply fix".into()),
+        }];
+        // Must not panic. Stderr capture would require child-process
+        // shell; this assertion ensures the function executes the
+        // Critical arm without aborting.
+        emit_diagnostics(&diags);
+    }
+
+    /// Defensive: Warning and Info severity must NOT be mirrored to
+    /// stderr — they stay tracing-only. The mirror exists specifically
+    /// to surface FATAL-class signals that operators must act on.
+    #[test]
+    fn emit_diagnostics_warning_and_info_do_not_panic() {
+        let diags = vec![
+            Diagnostic {
+                severity: Severity::Warning,
+                code: "WARN_TEST",
+                message: "warning sample".into(),
+                fix_stanza: None,
+            },
+            Diagnostic {
+                severity: Severity::Info,
+                code: "INFO_TEST",
+                message: "info sample".into(),
+                fix_stanza: None,
+            },
+        ];
+        emit_diagnostics(&diags);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,6 +115,31 @@ pub fn run_doctor(home: &Path) -> anyhow::Result<()> {
                         println!("    {name}: {} {}", r.backend_command, r.args.join(" "));
                     }
                 }
+                // Sprint 56 Track H2 (#525 item 8): run the same
+                // `validate_fleet_config` pre-flight that
+                // `bootstrap::prepare` does. Pre-Track-H2 the CLI
+                // doctor only checked file existence + parse + backend
+                // binaries, so an operator running `agend-terminal
+                // doctor` saw all green even when D001 / D002 should
+                // have flagged a fail-closed misconfiguration. Wiring
+                // both functions through their existing public API
+                // surfaces the FATAL diagnostics that Track B's D001
+                // and Track F's D002 produce.
+                let diags = crate::bootstrap::doctor::validate_fleet_config(&config, home);
+                crate::bootstrap::doctor::emit_diagnostics(&diags);
+                if !diags.is_empty() {
+                    let critical = diags
+                        .iter()
+                        .filter(|d| {
+                            matches!(d.severity, crate::bootstrap::doctor::Severity::Critical)
+                        })
+                        .count();
+                    if critical > 0 {
+                        println!(
+                            "\n  ⚠ {critical} critical fleet diagnostic(s) emitted above (D001/D002 etc.) — fix before next daemon start"
+                        );
+                    }
+                }
             }
             Err(e) => println!(" ✗ (parse error: {e})"),
         }

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -150,6 +150,26 @@ fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>)> {
     match detect_group(&token) {
         Ok((group_id, group_title)) => {
             println!("✓ {group_title} ({group_id})\n");
+            // Sprint 56 Track H2 (#525 item 3): verify the bot is
+            // admin in the captured group. Topic mode (the only mode
+            // we write — see `generate_fleet_yaml`) calls
+            // `bot.create_forum_topic`, which requires admin. Without
+            // this pre-check, a non-admin bot proceeds through
+            // quickstart silently; bootstrap then fails with
+            // `tracing::error!` on first topic-create attempt and
+            // silently continues. Operator only finds out when
+            // notifications never arrive. Warn-loud non-fatal — the
+            // operator may add the bot as admin later and re-run.
+            match verify_bot_is_admin(&token, group_id) {
+                Ok(true) => println!("  ✓ Bot has admin in group\n"),
+                Ok(false) => println!(
+                    "  ⚠ Bot is NOT admin in group — topic mode requires admin. \
+                     Add the bot as admin in Telegram group settings, then \
+                     re-run quickstart or restart the daemon. Continuing for \
+                     now…\n"
+                ),
+                Err(e) => println!("  ⚠ Could not verify admin status: {e} — continuing anyway\n"),
+            }
             Ok((token, Some(group_id)))
         }
         Err(e) => {
@@ -158,6 +178,48 @@ fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>)> {
             Ok((token, None))
         }
     }
+}
+
+/// Sprint 56 Track H2 (#525 item 3): verify the bot has admin status
+/// in the given chat by calling `getMe` to learn the bot's user_id,
+/// then `getChatMember` to read the bot's status. Returns `Ok(true)`
+/// for `"administrator"` / `"creator"` (admin equivalents per Bot
+/// API), `Ok(false)` for other statuses, `Err` only when the API
+/// calls themselves fail (network, malformed response). The Err arm
+/// distinguishes "we don't know" from "we know it's not admin"; the
+/// caller surfaces both with different operator hints.
+fn verify_bot_is_admin(token: &str, chat_id: i64) -> anyhow::Result<bool> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        let me_url = format!("https://api.telegram.org/bot{token}/getMe");
+        let me: serde_json::Value = reqwest::get(&me_url).await?.json().await?;
+        let bot_id = me["result"]["id"].as_i64().ok_or_else(|| {
+            anyhow::anyhow!("getMe response missing result.id — cannot resolve bot user_id")
+        })?;
+        let url = format!(
+            "https://api.telegram.org/bot{token}/getChatMember?chat_id={chat_id}&user_id={bot_id}"
+        );
+        let resp: serde_json::Value = reqwest::get(&url).await?.json().await?;
+        if resp["ok"].as_bool() != Some(true) {
+            anyhow::bail!(
+                "getChatMember failed: {}",
+                resp["description"].as_str().unwrap_or("unknown error")
+            );
+        }
+        let status = resp["result"]["status"].as_str().unwrap_or("");
+        Ok(is_bot_admin_status(status))
+    })
+}
+
+/// Pure helper: classify a Telegram chat-member `status` string into
+/// admin-vs-non-admin. Extracted from [`verify_bot_is_admin`] so the
+/// policy can be unit-tested without HTTP. Per Bot API docs, only
+/// `"administrator"` and `"creator"` carry admin permissions; every
+/// other status (member / restricted / left / kicked) is non-admin.
+fn is_bot_admin_status(status: &str) -> bool {
+    matches!(status, "administrator" | "creator")
 }
 
 fn mask_token(tok: &str) -> String {
@@ -786,6 +848,42 @@ mod tests {
              a covering rule exists further up"
         );
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    // ── Sprint 56 Track H2 (#525 item 3): admin status classifier ────
+
+    /// Lead-spec item 3: classifier accepts the two Telegram statuses
+    /// that carry admin permissions (`administrator` and `creator`).
+    #[test]
+    fn is_bot_admin_status_classifies_administrator_as_admin() {
+        assert!(is_bot_admin_status("administrator"));
+        assert!(is_bot_admin_status("creator"));
+    }
+
+    /// Lead-spec: any non-admin status (member / restricted / left /
+    /// kicked) must classify as not-admin so the warn-loud path fires
+    /// for operators whose bot was added without admin privileges.
+    #[test]
+    fn is_bot_admin_status_classifies_non_admin_correctly() {
+        for status in ["member", "restricted", "left", "kicked"] {
+            assert!(
+                !is_bot_admin_status(status),
+                "status `{status}` must not classify as admin"
+            );
+        }
+    }
+
+    /// Defensive: empty / unknown statuses must NOT default to admin.
+    /// A future Bot API addition we don't recognize should fall back
+    /// to "warn the operator" rather than silently treat as admin.
+    #[test]
+    fn is_bot_admin_status_unknown_status_treated_as_non_admin() {
+        for status in ["", "owner", "supreme-leader", "ADMIN"] {
+            assert!(
+                !is_bot_admin_status(status),
+                "unknown / case-mismatched status `{status}` must not pass"
+            );
+        }
     }
 
     /// Defensive: pure-pattern matcher pin. Anything outside the


### PR DESCRIPTION
## Summary
Closes #525 sub-items 3, 5, and 8 — three independent silent-failure prevention surfaces general's triage grouped together.

- **Item 3**: `verify_bot_is_admin` helper + `is_bot_admin_status` pure classifier; quickstart now warn-loud-non-fatal if the bot isn't admin in the captured group (topic mode requires admin for `create_forum_topic`).
- **Item 5**: `emit_diagnostics` Critical arm now ALSO `eprintln!`s alongside `tracing::error!`; defends `start --detached` mode where tracing detaches.
- **Item 8**: `cli::run_doctor` now invokes `validate_fleet_config + emit_diagnostics`, surfacing D001/D002 to operators running `agend-terminal doctor`.
- 5 new tests, all green.

## Surface (3 files, +188 LOC)
| File | LOC | Role |
|---|---|---|
| `src/quickstart.rs` | +98 | `verify_bot_is_admin` + `is_bot_admin_status` + 3 admin-check branches in telegram_setup post detect_group + 3 unit tests |
| `src/bootstrap/doctor.rs` | +65 | `eprintln!` mirror in Critical arm + 2 unit tests + doc comment update |
| `src/cli.rs` | +25 | post-FleetConfig::load: invoke `validate_fleet_config + emit_diagnostics` + critical-count summary line |

## Test plan
- [x] `cargo test --bin agend-terminal -- is_bot_admin_status emit_diagnostics_critical emit_diagnostics_warning` — 5 new pass
- [x] `cargo clippy --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual smoke (operator): create `~/.agend/fleet.yaml` with telegram channel + `user_allowlist` field omitted → `agend-terminal doctor` → confirm `FATAL [D001]: …` line on stderr

## STRICT v2 / bypass discipline
- Daemon-managed worktree at `.worktrees/dev` via `bind_self(source_repo, branch=sprint56-track-h2-525-silent-failure-prevention)`
- Plain `git add/commit/push` (wrapper allowed)
- 0 bypass cycles for this PR ✓ (8th post-policy clean PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)