### PR TITLE
ci: package agend-mcp-bridge in release artifacts (Sprint 56 Track I-Phase2a) (#531)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,14 +79,23 @@ jobs:
         shell: bash
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../agend-terminal-${{ matrix.target }}.tar.gz agend-terminal
+          # Sprint 56 Track I-Phase2a (#531): bundle agend-mcp-bridge
+          # alongside agend-terminal so backends spawned by the daemon's
+          # mcp_config can find it next to the main binary. Without
+          # this, mcp_config::bridge_binary_path falls back to
+          # `agend-terminal mcp` and reply / react / download_attachment
+          # land on the daemon-state-unreachable error path on Windows.
+          tar czf ../../../agend-terminal-${{ matrix.target }}.tar.gz agend-terminal agend-mcp-bridge
 
       - name: Package (Windows)
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
+          # Sprint 56 Track I-Phase2a (#531): same dual-binary packaging
+          # as the Unix tar arm. PowerShell's Compress-Archive `-Path`
+          # accepts a comma-separated array of file paths.
           Compress-Archive `
-            -Path target/${{ matrix.target }}/release/agend-terminal.exe `
+            -Path "target/${{ matrix.target }}/release/agend-terminal.exe","target/${{ matrix.target }}/release/agend-mcp-bridge.exe" `
             -DestinationPath agend-terminal-${{ matrix.target }}.zip
 
       - name: Upload artifact
@@ -131,6 +140,12 @@ jobs:
           mkdir -p AppDir/usr/share/applications
           mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
           cp target/release/agend-terminal AppDir/usr/bin/agend-terminal
+          # Sprint 56 Track I-Phase2a (#531): ship the bridge binary
+          # alongside the main one inside the AppImage. Same rationale
+          # as the tar/zip arms above — without this, the AppImage
+          # operators hit the same #531 fallback-to-`agend-terminal
+          # mcp` failure mode for daemon-state-required tools.
+          cp target/release/agend-mcp-bridge AppDir/usr/bin/agend-mcp-bridge
           cp assets/appimage/agend-terminal.desktop AppDir/usr/share/applications/agend-terminal.desktop
           # Resize 1024x1024 master → 256x256 for hicolor + AppImage root
           convert assets/appimage/agend-terminal.png -resize 256x256 AppDir/usr/share/icons/hicolor/256x256/apps/agend-terminal.png

--- a/tests/no_local_mcp_mode_invariant.rs
+++ b/tests/no_local_mcp_mode_invariant.rs
@@ -1,0 +1,123 @@
+//! Sprint 56 Track I-Phase2a (#531) — packaging-regression invariant.
+//!
+//! Production builds must ship `agend-mcp-bridge` alongside
+//! `agend-terminal` in every release artifact. The
+//! `mcp_config::bridge_binary_path` fallback at `src/mcp_config.rs:34`
+//! lands operators on the broken `agend-terminal mcp` path whenever
+//! the bridge isn't found next to the main binary, which is the root
+//! cause of issue #531 (Windows daemon overwrites mcp.json with the
+//! local-mode command). The reporter's symptom resolves only when
+//! both binaries land in the same package on every supported
+//! platform.
+//!
+//! This test parses `.github/workflows/release.yml` and asserts the
+//! 3 packaging steps (Unix tar, Windows zip, AppImage stage) all
+//! reference the bridge. It catches release-workflow edits that
+//! drop the bridge — the regression that originally produced #531.
+//!
+//! ## Why text-parse over shell-out
+//!
+//! An alternative would be to `cargo build --release` and verify the
+//! bridge exists in `target/release/`. That's heavier (multi-minute
+//! release build per test invocation) and tests the wrong
+//! abstraction layer — the regression we care about is in the
+//! workflow text, not the local cargo build (which already builds
+//! the bridge by default per `cargo metadata`). Text-parse catches
+//! the regression at the source and runs in milliseconds.
+//!
+//! ## Empirical regression-proof anchor
+//!
+//! Removing `agend-mcp-bridge` from any of the three packaging
+//! steps in release.yml flips this test red. Restoring → green.
+//! See PR #N (Track I-Phase2a) for the captured FAIL signature.
+
+const RELEASE_YML: &str = include_str!("../.github/workflows/release.yml");
+
+#[test]
+fn release_workflow_packages_bridge_in_unix_tar_step() {
+    // The Unix tar packaging step (line 77+ at the time of writing)
+    // gathers the binaries into a tar.gz. The current operator-
+    // visible artifact for Linux + macOS distributions.
+    let tar_idx = RELEASE_YML
+        .find("tar czf")
+        .expect("release.yml must have a `tar czf` packaging step");
+    // Bracket the section: from `tar czf` to the next workflow step
+    // (lines beginning with `      - ` after a newline). Scope the
+    // assertion to ONE packaging step so the workflow-author's
+    // intent is unambiguous.
+    let section_end = RELEASE_YML[tar_idx..]
+        .find("\n      - ")
+        .map(|n| tar_idx + n)
+        .unwrap_or(RELEASE_YML.len());
+    let section = &RELEASE_YML[tar_idx..section_end];
+    assert!(
+        section.contains("agend-mcp-bridge"),
+        "Unix tar packaging step must include `agend-mcp-bridge` so \
+         release tarballs ship both binaries — Phase 2a fix for #531. \
+         Section was:\n{section}"
+    );
+}
+
+#[test]
+fn release_workflow_packages_bridge_in_windows_zip_step() {
+    // The Windows zip packaging step uses PowerShell's
+    // Compress-Archive. Same rationale as the tar arm.
+    let zip_idx = RELEASE_YML
+        .find("Compress-Archive")
+        .expect("release.yml must have a `Compress-Archive` packaging step");
+    let section_end = RELEASE_YML[zip_idx..]
+        .find("\n      - ")
+        .map(|n| zip_idx + n)
+        .unwrap_or(RELEASE_YML.len());
+    let section = &RELEASE_YML[zip_idx..section_end];
+    assert!(
+        section.contains("agend-mcp-bridge"),
+        "Windows zip packaging step must include `agend-mcp-bridge.exe` \
+         so the release zip ships both binaries — Phase 2a fix for #531. \
+         Section was:\n{section}"
+    );
+}
+
+#[test]
+fn release_workflow_includes_bridge_in_appimage_stage() {
+    // The AppImage stage copies binaries into AppDir/usr/bin/. The
+    // bridge must land there too so AppImage users hit the same
+    // post-Phase-2a fix as tar / zip users.
+    let stage_idx = RELEASE_YML
+        .find("AppDir/usr/bin/agend-terminal")
+        .expect("release.yml must have an AppImage stage");
+    // Bracket: from this cp line to the next blank line followed by
+    // a non-indented `- ` step or the end of the script block.
+    let section_end = RELEASE_YML[stage_idx..]
+        .find("# Validate")
+        .map(|n| stage_idx + n)
+        .unwrap_or(RELEASE_YML.len());
+    let section = &RELEASE_YML[stage_idx..section_end];
+    assert!(
+        section.contains("agend-mcp-bridge"),
+        "AppImage stage must copy `agend-mcp-bridge` into \
+         AppDir/usr/bin/ so AppImage installs ship both binaries — \
+         Phase 2a fix for #531. Section was:\n{section}"
+    );
+}
+
+#[test]
+fn cargo_declares_agend_mcp_bridge_bin_target() {
+    // Belt-and-suspenders: even with the workflow correctly
+    // packaging the bridge, the build only produces it if the bin
+    // target is declared. `src/bin/agend-mcp-bridge.rs` is the
+    // automatic discovery path; some packages also declare an
+    // explicit `[[bin]]` block. Either is fine; both missing is
+    // the regression this guards against.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let cargo_toml = std::path::Path::new(manifest_dir).join("Cargo.toml");
+    let src_bin = std::path::Path::new(manifest_dir).join("src/bin/agend-mcp-bridge.rs");
+    let cargo_content = std::fs::read_to_string(&cargo_toml).expect("Cargo.toml must exist");
+    assert!(
+        cargo_content.contains("agend-mcp-bridge") || src_bin.exists(),
+        "agend-mcp-bridge bin target must be declared either in \
+         Cargo.toml [[bin]] block or as src/bin/agend-mcp-bridge.rs — \
+         the workflow assertions above would silently pass while the \
+         build itself failed if both are missing."
+    );
+}


### PR DESCRIPTION
## Summary
Phase 2a of the Track I migration plan from `docs/RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md` (Phase 1 verdict: REMOVE-WITH-MIGRATION). LOW RISK packaging fix that resolves the reported #531 Windows symptom for new installs and post-upgrade operators **without** changing any code path in `src/`.

- `release.yml` tar / zip / AppImage steps now bundle `agend-mcp-bridge` alongside `agend-terminal`.
- New `tests/no_local_mcp_mode_invariant.rs` parses release.yml at test time + asserts all 3 packaging steps reference the bridge.
- `mcp_config.rs::bridge_binary_path` unchanged — its existing fallback automatically prefers the bridge once shipped.
- 4 invariant tests, all green.

## Root cause recap (from Phase 1 RCA)
`mcp_config.rs::bridge_binary_path` falls back to `agend-terminal mcp` whenever the bridge isn't next to the main binary — always for release-installed users. Daemon writes that fallback into every backend's mcp.json on every startup, clobbering operator hand-edits.

## Surface (2 files, +140/-2 LOC)

| File | LOC | Role |
|---|---|---|
| `.github/workflows/release.yml` | +17/-2 | tar / zip / AppImage steps include `agend-mcp-bridge` alongside main binary |
| `tests/no_local_mcp_mode_invariant.rs` | +123 | 4 invariant tests pinning all three packaging steps + bin-target declaration |

## Test plan
- [x] `cargo test --test no_local_mcp_mode_invariant` — 4 tests pass
- [x] `cargo clippy --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual smoke (operator): post-merge, run a dispatched release workflow → confirm artifacts contain both `agend-terminal*` and `agend-mcp-bridge*`

## Empirical regression-proof anchor
Removing `agend-mcp-bridge` from any of the three packaging steps in release.yml flips one of the 3 test assertions red. Restoring → green.

## Why text-parse over shell-out (per dispatch judgment ask)
Picked text-parse over `cargo build --release` + artifact inspection:
- **Lighter**: milliseconds vs multi-minute release build per test invocation
- **Catches regression at the source** (workflow edit) rather than at the artifact end
- **Trade-off**: text-matching vs YAML structural; sufficient for 3 specific lines

## Why no `src/` change
Phase 1 RCA explicit sequencing — Phase 2a is packaging only (LOW RISK, no behavior change), Phase 2b is the deprecation cycle (drop `bridge_binary_path` fallback + docs update + Commands::Mcp deprecation log). Phase 2a alone resolves #531 because the existing fallback already prefers the bridge when present.

## STRICT v2 / bypass discipline
- Daemon-managed worktree at `.worktrees/dev` via `bind_self(source_repo, branch=sprint56-track-i-phase2a-issue-531-release-yml)`
- Plain `git add/commit/push` (wrapper allowed)
- 0 bypass cycles for this PR ✓ (11th post-policy clean PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)