### PR TITLE
feat(mcp): drop agend-terminal mcp fallback + deprecate Commands::Mcp (Sprint 56 Track I-Phase2b) (#531)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -88,11 +88,14 @@ Stop the daemon (also terminates all managed agents).
 agend-terminal stop
 ```
 
-### `mcp`
-Start the MCP stdio server for the current instance. Intended to be invoked by an agent's backend, not by humans directly — the relevant backend config is auto-written to the agent's working directory by `mcp_config.rs`.
+### `mcp` (DEPRECATED — see `agend-mcp-bridge`)
+
+> **Sprint 56 Track I (#531):** `agend-terminal mcp` is deprecated and will be removed in Sprint 57. The daemon now writes the canonical replacement (`agend-mcp-bridge`) into every backend's mcp.json on every start; operators with hand-edited mcp.json get rewritten automatically by the daemon's atomic upsert. The legacy command emits a `DEPRECATED:` warning when invoked but otherwise still runs for one-Sprint backwards compat. See [Phase 1 RCA](RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md).
+
+Start the MCP stdio server for the current instance. Intended to be invoked by an agent's backend, not by humans directly — the relevant backend config is auto-written to the agent's working directory by `mcp_config.rs`. Post-Sprint-56 operators should invoke `agend-mcp-bridge` directly:
 
 ```
-AGEND_INSTANCE_NAME=<name> agend-terminal mcp
+AGEND_INSTANCE_NAME=<name> agend-mcp-bridge
 ```
 
 Running without `AGEND_INSTANCE_NAME` is allowed but enters standalone mode and emits a warning.

--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -269,7 +269,7 @@ Surface Phase 4 GC findings to operators without removing anything. Returns the 
 ## How the Tools Are Wired
 
 1. `agend-terminal` daemon exposes a JSON control API on TCP loopback; the bound port is published to `~/.agend/run/{PID}/api.port` and authenticated by a 32-byte cookie at `~/.agend/run/{PID}/api.cookie` (0600 on Unix).
-2. For each backend, `src/mcp_config.rs` generates the backend's MCP config file pointing at `agend-terminal mcp` (stdio transport).
+2. For each backend, `src/mcp_config.rs` generates the backend's MCP config file pointing at `agend-mcp-bridge` (stdio transport). Sprint 56 Track I (#531) replaced the previous `agend-terminal mcp` invocation; the bridge proxies tool calls to the daemon's TCP API rather than running an inline local-mode server, which fixes the Windows "no active channel" failure mode for daemon-state-required tools (`reply` / `react` / `download_attachment`).
 3. `src/mcp/mod.rs` spawns a stdio server per agent, `src/mcp/tools.rs` serves schemas, `src/mcp/handlers.rs` proxies each call to the daemon API. Shared helpers (messaging, fleet mutation, branch validation) live in `src/agent_ops.rs` and are called from both sides; `tests/no_dual_track_drift.rs` enforces no drift between `agent_ops.rs` and `mcp/handlers.rs`.
 4. All tool calls flow: **agent → MCP stdio server → daemon loopback API → `src/api/handlers/*` → registry / inbox / fleet**. `start_instance` is handled inline by `src/mcp/handlers.rs` (no daemon round-trip) since Task #12.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -66,17 +66,27 @@ to launch the full TUI.
 **When to use:** Background monitoring. Launch-at-login. Quick
 access without keeping a terminal open.
 
-### `agend-terminal mcp` — MCP server (for AI backends)
+### `agend-mcp-bridge` — MCP server (for AI backends)
 
 ```bash
-agend-terminal mcp
+agend-mcp-bridge
 ```
 
 Stdio JSON-RPC 2.0 server providing 35+ tools (task management,
 decisions, messaging, CI watch, etc.). Not meant to be run manually.
 
-Each AI backend (Claude Code, Kiro, Codex, Gemini) auto-launches
-this as a child process based on its MCP config.
+Each AI backend (Claude Code, Kiro, Codex, Gemini, OpenCode) auto-
+launches this as a child process based on its MCP config — the
+daemon writes the bridge path into every backend's mcp.json on
+every start.
+
+> **Sprint 56 deprecation note (#531):** `agend-terminal mcp` was
+> the canonical invocation through v0.6. Phase 2a of the migration
+> ships `agend-mcp-bridge` in release artifacts on all 5 platforms;
+> Phase 2b makes the bridge mandatory (the daemon will no longer
+> fall back to the legacy `agend-terminal mcp` command). The legacy
+> command remains for one Sprint with a deprecation warning;
+> Sprint 57 removes it entirely. See [Phase 1 RCA](RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md).
 
 **When to use:** You don't run this directly. It's started
 automatically when an AI agent needs to talk to the daemon.

--- a/src/main.rs
+++ b/src/main.rs
@@ -591,6 +591,28 @@ fn main() -> anyhow::Result<()> {
             }
         },
         Some(Commands::Mcp) => {
+            // Sprint 56 Track I-Phase2b (#531): `agend-terminal mcp` is
+            // deprecated and will be removed in Sprint 57+. Phase 1 RCA
+            // identified this command as the silent-drop class root for
+            // Windows operators (proxy-fail + daemon-state-required-tool
+            // gate at `mcp/mod.rs:374-388`). Phase 2a shipped the
+            // canonical replacement (`agend-mcp-bridge`) in release
+            // artifacts; Phase 2b emits a deprecation warning here so
+            // operators with hand-edited mcp.json see one clear signal
+            // before Sprint 57's hard removal. The body still runs to
+            // preserve one-Sprint backwards compat — daemon's atomic
+            // mcp.json upsert clobbers their hand-edits with the bridge
+            // path on next start, so this code path becomes unreachable
+            // in normal operation soon after the upgrade.
+            eprintln!(
+                "DEPRECATED: `agend-terminal mcp` is deprecated and will be removed in Sprint 57. \
+                 Update mcp.json to invoke `agend-mcp-bridge` directly. The agend-terminal \
+                 daemon's atomic mcp.json upsert rewrites hand-edited configs to use the bridge \
+                 automatically on next start (Sprint 56 Track I-Phase2a)."
+            );
+            tracing::warn!(
+                "DEPRECATED `agend-terminal mcp` invocation — Sprint 57 will remove. See #531."
+            );
             let instance_name = std::env::var("AGEND_INSTANCE_NAME").unwrap_or_default();
             if instance_name.is_empty() {
                 tracing::warn!("AGEND_INSTANCE_NAME not set, running in standalone mode");

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -14,24 +14,57 @@ use anyhow::Result;
 use serde_json::json;
 use std::path::{Path, PathBuf};
 
-/// Get the agend-terminal binary path for MCP server config.
-fn binary_path() -> String {
-    std::env::current_exe()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| "agend-terminal".to_string())
-}
-
 /// Get the agend-mcp-bridge binary path. Lives alongside the main binary.
-/// Falls back to the main binary with `mcp` arg if bridge not found.
+///
+/// Sprint 56 Track I-Phase2b (#531): the previous "fall back to
+/// `agend-terminal mcp` if bridge missing" behaviour is removed. Phase
+/// 1 RCA (`docs/RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md`)
+/// identified the fallback as the load-bearing failure path: backends
+/// spawned with `agend-terminal mcp` route through `mcp::run`'s
+/// `proxy_or_local`, which for daemon-state-required tools (`reply` /
+/// `react` / `download_attachment`) returns a structured error rather
+/// than falling back to local. Operators on Windows experienced the
+/// "no active channel" failure mode whenever the daemon's atomic
+/// upsert overwrote their hand-edited mcp.json with the fallback
+/// command.
+///
+/// Phase 2a shipped the bridge in release artifacts; Phase 2b drops
+/// the fallback so a missing bridge is loud and explicit. Operators
+/// who somehow ship without the bridge get an immediate FATAL log +
+/// the daemon writes an unrunnable `command:` (intentional — better
+/// than silently writing the broken local-mode command). Reinstall
+/// from v0.7+ release artifacts (which Phase 2a ships) resolves.
 fn bridge_binary_path() -> (String, Vec<&'static str>) {
     if let Ok(exe) = std::env::current_exe() {
-        let bridge = exe.with_file_name("agend-mcp-bridge");
+        let bridge = exe.with_file_name(if cfg!(windows) {
+            "agend-mcp-bridge.exe"
+        } else {
+            "agend-mcp-bridge"
+        });
         if bridge.exists() {
             return (bridge.display().to_string(), vec![]);
         }
+        tracing::error!(
+            expected_path = %bridge.display(),
+            "FATAL: agend-mcp-bridge binary not found alongside agend-terminal. \
+             Reinstall from v0.7+ release artifacts which ship both binaries, \
+             or ensure your build packaging includes agend-mcp-bridge."
+        );
+        eprintln!(
+            "FATAL: agend-mcp-bridge missing at {}. Reinstall from v0.7+ release artifacts.",
+            bridge.display()
+        );
+        // Return a clearly-broken command rather than silently falling
+        // back to `agend-terminal mcp` (the pre-Phase-2b regression
+        // path). Backends will fail loudly on the next mcp.json read.
+        return (bridge.display().to_string(), vec![]);
     }
-    // Fallback: use main binary with --mcp flag (pre-Option-F behaviour)
-    (binary_path(), vec!["mcp"])
+    // current_exe() failure is essentially unreachable in production
+    // but the diagnostic still beats silent fallback.
+    tracing::error!(
+        "FATAL: std::env::current_exe() failed — cannot locate agend-mcp-bridge binary"
+    );
+    ("agend-mcp-bridge".to_string(), vec![])
 }
 
 /// Get the AGEND_HOME value.

--- a/tests/no_local_mcp_mode_invariant.rs
+++ b/tests/no_local_mcp_mode_invariant.rs
@@ -121,3 +121,85 @@ fn cargo_declares_agend_mcp_bridge_bin_target() {
          build itself failed if both are missing."
     );
 }
+
+// ── Sprint 56 Track I-Phase2b (#531): no fallback to local mode ──
+
+const MCP_CONFIG_RS: &str = include_str!("../src/mcp_config.rs");
+const MAIN_RS: &str = include_str!("../src/main.rs");
+
+#[test]
+fn bridge_binary_path_does_not_fall_back_to_local_mode() {
+    // Phase 2b removes the `(binary_path(), vec!["mcp"])` fallback
+    // line that previously fired whenever the bridge binary wasn't
+    // alongside the main binary. Operators on the broken Windows
+    // path always landed there — that's the load-bearing #531 fix.
+    //
+    // We pin the absence of `vec!["mcp"]` (the fallback's tell) in
+    // `mcp_config.rs::bridge_binary_path`. A future regression that
+    // accidentally restores the fallback would re-introduce the
+    // silent-drop class fault on Windows.
+    assert!(
+        !MCP_CONFIG_RS.contains("vec![\"mcp\"]"),
+        "Phase 2b fail-loud invariant: src/mcp_config.rs must not \
+         contain the `vec![\"mcp\"]` fallback that previously made \
+         backends spawn `agend-terminal mcp` instead of the bridge. \
+         See docs/RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md."
+    );
+}
+
+#[test]
+fn commands_mcp_emits_deprecation_warning_in_one_sprint_window() {
+    // Phase 2b keeps `Commands::Mcp` enum + handler for one-Sprint
+    // backwards compat (Sprint 57+ removes outright per dispatch).
+    // The handler must emit a deprecation eprintln so operators with
+    // hand-edited mcp.json see ONE clear signal before the Sprint 57
+    // removal lands.
+    let mcp_arm_idx = MAIN_RS
+        .find("Some(Commands::Mcp)")
+        .expect("main.rs must still carry the Commands::Mcp arm during deprecation window");
+    let arm_end_relative = MAIN_RS[mcp_arm_idx + 1..]
+        .find("Some(Commands::")
+        .expect("at least one more Commands variant must follow Mcp");
+    let arm_section = &MAIN_RS[mcp_arm_idx..mcp_arm_idx + 1 + arm_end_relative];
+    assert!(
+        arm_section.contains("DEPRECATED"),
+        "Phase 2b deprecation invariant: Commands::Mcp arm must emit \
+         a `DEPRECATED:`-prefixed eprintln so operators see one clear \
+         deprecation signal before Sprint 57's removal."
+    );
+    assert!(
+        arm_section.contains("Sprint 57"),
+        "Deprecation message must name the removal Sprint so operators \
+         have a concrete migration deadline."
+    );
+}
+
+#[test]
+fn mcp_config_emits_fatal_when_bridge_missing() {
+    // Pin the FATAL log + eprintln pair in `bridge_binary_path` so a
+    // future edit can't silently swap them back to a fallback path.
+    let bbp_idx = MCP_CONFIG_RS
+        .find("fn bridge_binary_path()")
+        .expect("bridge_binary_path() helper must still exist");
+    let bbp_end = MCP_CONFIG_RS[bbp_idx..]
+        .find("\nfn ")
+        .map(|n| bbp_idx + n)
+        .unwrap_or(MCP_CONFIG_RS.len());
+    let bbp_body = &MCP_CONFIG_RS[bbp_idx..bbp_end];
+    assert!(
+        bbp_body.contains("FATAL"),
+        "bridge_binary_path must emit a FATAL log when the bridge is \
+         missing — Phase 2b's fail-loud contract. Body was:\n{bbp_body}"
+    );
+    // Specific signal: tracing::error! at FATAL level for daemon log,
+    // eprintln! for direct stderr (independent of tracing config —
+    // mirrors Track H2 #525 item 5 pattern).
+    assert!(
+        bbp_body.contains("tracing::error!"),
+        "Must emit tracing::error! for daemon-log audit trail."
+    );
+    assert!(
+        bbp_body.contains("eprintln!"),
+        "Must emit eprintln! for direct-stderr visibility."
+    );
+}


### PR DESCRIPTION
## Summary
Phase 2b of the Track I migration plan from `docs/RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md`. **Architectural removal** of the silent-drop-class root path issue #531 reported, building on Phase 2a (PR #543) which shipped the bridge binary in release artifacts.

Reported by **changhansung** (Windows 11, kiro-cli backend); Phase 1 RCA PR #542 audited 4 dimensions; Phase 2a PR #543 shipped the canonical replacement; this Phase 2b PR removes the legacy fallback that landed Windows operators on the broken path.

- `src/mcp_config.rs::bridge_binary_path` no longer falls back to `agend-terminal mcp`; emits FATAL log + eprintln when bridge missing.
- `Commands::Mcp` enum kept for one-Sprint backwards compat with `DEPRECATED:` eprintln; Sprint 57 will fully remove.
- Docs (USAGE.md / CLI.md / MCP-TOOLS.md) updated to recommend `agend-mcp-bridge`.
- 3 new invariant tests pin the no-fallback + deprecation invariants structurally.

## Surface (6 files, +169/-19 LOC)

| File | LOC | Role |
|---|---|---|
| `src/mcp_config.rs` | +35/-15 | Drop fallback in `bridge_binary_path`; emit FATAL log + eprintln |
| `src/main.rs` | +27/-3 | Commands::Mcp arm gains `DEPRECATED:` eprintln + tracing::warn (kept for one-Sprint compat) |
| `tests/no_local_mcp_mode_invariant.rs` | +83 | 3 new structural pins (no-fallback / deprecation-text / FATAL emit) |
| `docs/USAGE.md` | +13/-3 | Replace `agend-terminal mcp` section with bridge + deprecation note |
| `docs/CLI.md` | +6/-3 | Prefix `mcp` entry with deprecation; show bridge as canonical |
| `docs/MCP-TOOLS.md` | +1/-1 | Update §2 to reflect bridge-path writing |

## Test plan
- [x] `cargo test --test no_local_mcp_mode_invariant` — 7 tests pass (4 from Phase 2a + 3 new)
- [x] `cargo test --bin agend-terminal -- mcp_config` — 35 tests still green (no regression)
- [x] `cargo clippy --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Why one-Sprint deprecation cycle (not hard removal)
Per Phase 1 RCA Section 3 migration impact + Track I-Phase2b dispatch:
- Operators with hand-edited mcp.json pointing at `agend-terminal mcp` would break instantly on hard removal. Daemon's atomic upsert IS rewriting those configs to use the bridge, but that fixes mcp.json on the **next daemon start**, not at upgrade time.
- One-Sprint window with eprintln + tracing::warn gives operators clear migration signal without breaking active sessions.
- Sprint 57 will fully remove `Commands::Mcp` enum + `mcp::run` body per dispatch sequencing.

## Resolution scope
- **#531 closed architecturally** — the silent-drop root path is removed, not just papered over with packaging. Phase 2a fixed the symptom; Phase 2b removes the regression-prone fallback so a future packaging slip can't re-introduce it.
- **Silent-drop class root family terminated** (#488 / #495 / #531 share the same fallback-path pattern).

## Empirical regression-proof anchors
- Restoring `vec!["mcp"]` in `mcp_config.rs::bridge_binary_path` flips `bridge_binary_path_does_not_fall_back_to_local_mode` red.
- Removing the `DEPRECATED` eprintln from the Commands::Mcp arm flips `commands_mcp_emits_deprecation_warning_in_one_sprint_window` red.
- Removing the FATAL emit from `bridge_binary_path` flips `mcp_config_emits_fatal_when_bridge_missing` red.

## STRICT v2 / bypass discipline
- Daemon-managed worktree at `.worktrees/dev` via `bind_self(source_repo, branch=sprint56-track-i-phase2b-issue-531-architectural-removal)`
- Plain `git add/commit/push` (wrapper allowed)
- 0 bypass cycles for this PR ✓ (12th post-policy clean PR)

## Credits
**Reporter**: changhansung (issue #531). The Windows-specific repro + manual verification of the bridge workaround was load-bearing for the Phase 1 RCA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)