### PR TITLE
docs: cleanup stale proxy_or_local + Sprint-57-timeline mentions post-Phase2c (Sprint 57 Wave 1 Track B)

### DIFF
--- a/docs/RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md
+++ b/docs/RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md
@@ -213,11 +213,13 @@ This phase alone resolves #531's reported symptom for new installs and post-upgr
 
 ### Phase 2b — Deprecation (HIGHER RISK, ~30 LOC + doc update)
 
+> **Historical note (added Sprint 57 Wave 1 Track B)**: the "remove in Sprint 57+" timeline below was superseded mid-Sprint-56 by an operator escalation directive (m-20260508141217922488-238) collapsing the deprecation cycle into a single hard-removal at Phase 2c. Phase 2b shipped at PR #544 (commit `cbdac10`) with the loud-FATAL change in step 1 and the doc deprecation notes in step 2; Phase 2c at PR #547 (commit `8725118` on main) hard-removed `Commands::Mcp` instead of waiting for Sprint 57. The Phase 2b plan as written below was followed for steps 1 and 2 only; step 3's "one Sprint" buffer was zeroed.
+
 Conditional on Phase 2a landing first and no operator escalation surfacing:
 
 1. **`mcp_config.rs::bridge_binary_path`**: drop the `agend-terminal mcp` fallback and emit `tracing::error!("FATAL: agend-mcp-bridge missing — install agend-terminal v0.6.X+ which ships both binaries")`. This makes the failure loud rather than silent.
 2. **Update `docs/USAGE.md` / `docs/CLI.md` / `docs/MCP-TOOLS.md`** to recommend `agend-mcp-bridge` and mark `agend-terminal mcp` as deprecated (one Sprint deprecation window before removal).
-3. **Keep `Commands::Mcp` for one Sprint** with a deprecation log line at startup; remove in Sprint 57+.
+3. ~~**Keep `Commands::Mcp` for one Sprint** with a deprecation log line at startup; remove in Sprint 57+.~~ *Superseded by Phase 2c hard-removal — see historical note above.*
 
 ### Out of scope for Phase 2
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -21,11 +21,15 @@ pub fn tool_definitions() -> Value {
 
 fn channel_tools() -> Vec<Value> {
     // Sprint 54 #488 hotfix: these handlers depend on daemon-resident
-    // state (ACTIVE_CHANNEL, telegram bot session) and cannot run in
-    // an MCP subprocess context. Tagged `requires_daemon_state: true`
-    // so `proxy_or_local` returns a structured error instead of
-    // falling back to a local handler that would silently produce
-    // misleading errors like `no active channel`.
+    // state (ACTIVE_CHANNEL, telegram bot session) and cannot run
+    // outside the daemon process. Tagged `requires_daemon_state: true`
+    // so the `agend-mcp-bridge` proxy surfaces a structured error to
+    // callers when the daemon is unreachable, rather than degrading
+    // to a local fallback that would silently produce misleading
+    // errors like `no active channel`. Sprint 56 Track I-Phase2c
+    // (#531) hard-removed the local-fallback path that this comment
+    // originally described — flag stays valid as a daemon-side
+    // dispatch hint and as the contract the bridge consumes.
     vec![
         json!({"name": "reply", "description": "Reply to the user via the active channel. Requires daemon API.",
             "inputSchema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},


### PR DESCRIPTION
## Summary

Cosmetic-only cleanup of two residual references that Sprint 56 Track I-Phase2c (#531) superseded. Filler PR during Track A (PR #549) reviewer wait per lead dispatch `m-20260508161753130539-15`. Tier-1 codex single primary, Path B doc-only.

## Changes (~12 LOC, 2 files)

### `src/mcp/tools.rs:23-31` — `channel_tools()` comment

The `requires_daemon_state: true` flag stays valid (bridge consumes it via `mcp_proxy.rs`), but the original comment described `proxy_or_local` returning a structured error. That helper was deleted in Phase 2c. Reworded to reflect the bridge-proxy reality.

### `docs/RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md:214-220` — Phase 2b plan section

Added an editorial historical-note block at the top of the Phase 2b section + struck through the now-moot step 3 ("Keep `Commands::Mcp` for one Sprint... remove in Sprint 57+"). Operator escalation collapsed the deprecation cycle into Phase 2c hard-removal mid-Sprint-56; doc remains useful as Phase 1 RCA archive without misleading future readers about the actual timeline.

## Scope discipline

Other `Sprint 57` mentions in source/docs all relate to the **unrelated** bind_self legacy `repo:` form deprecation (Sprint 55 → 57 cycle, still in flight). Left untouched. No other `proxy_or_local` mentions in src/. Phase 2b commit message (cbdac10) cannot be amended — git history is immutable per STRICT v2.

## Test plan

Path B doc-only — no IMPL test, no smoke test:

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo build --features tray` clean

## Files

- `src/mcp/tools.rs` (-5/+9 LOC, comment-only)
- `docs/RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md` (-1/+3 LOC, historical note)

## Source of truth

Branch base: `main @ 8843a0e` (post-Wave-1-Track-A merge — PR #549).

Reviewer focus per Path B cosmetic-only: grep accuracy + canonical wording correct + no cross-file reference broken.

## Refs

- PR #547 reviewer non-blocking note: `m-20260508153345229062-12`
- Lead Track B dispatch: `m-20260508161753130539-15`
- Operator escalation directive: `m-20260508141217922488-238`

🤖 Generated with [Claude Code](https://claude.com/claude-code)