### PR TITLE
feat(ci_watch): lifecycle hygiene Items 1+2+3 (Sprint 57 Wave 2 Track B) (#546 Phase B)

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -230,6 +230,16 @@ pub fn validate_branch(branch: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '/' || c == '_' || c == '-' || c == '.')
 }
 
+/// E4.5 protected-branch invariant. Returns `true` for branches that
+/// agents MUST NOT lease, watch, or otherwise hold a per-agent
+/// concept of interest in. The canonical set is `main` and `master`;
+/// extending the set here propagates to every E4.5 enforcement site
+/// (currently `worktree_pool::lease` for worktree leases and
+/// `mcp::handlers::ci::handle_watch_ci` for CI watch subscriptions).
+pub fn is_protected_ref(branch: &str) -> bool {
+    matches!(branch, "main" | "master")
+}
+
 // ---------------------------------------------------------------------------
 // Working-directory cleanup (CANONICAL 19-entry list)
 // ---------------------------------------------------------------------------
@@ -393,6 +403,41 @@ mod tests {
     #[test]
     fn branch_rejects_empty() {
         assert!(!validate_branch(""));
+    }
+
+    // --- is_protected_ref (E4.5 invariant — Sprint 57 Wave 2 Track B #546) ---
+
+    #[test]
+    fn is_protected_ref_main_and_master() {
+        assert!(is_protected_ref("main"));
+        assert!(is_protected_ref("master"));
+    }
+
+    #[test]
+    fn is_protected_ref_rejects_feature_branches() {
+        assert!(!is_protected_ref("feature/x"));
+        assert!(!is_protected_ref("sprint57-track-b"));
+        assert!(!is_protected_ref("release/v1.0.0"));
+        assert!(!is_protected_ref("hotfix"));
+    }
+
+    #[test]
+    fn is_protected_ref_case_sensitive_by_design() {
+        // Git refs ARE case-sensitive on case-sensitive filesystems;
+        // matching the literal lowercase "main"/"master" is intentional.
+        // Anything else (Main, MAIN, Master) is a different ref and not
+        // protected by this invariant.
+        assert!(!is_protected_ref("Main"));
+        assert!(!is_protected_ref("MAIN"));
+        assert!(!is_protected_ref("Master"));
+    }
+
+    #[test]
+    fn is_protected_ref_rejects_empty_and_substrings() {
+        assert!(!is_protected_ref(""));
+        assert!(!is_protected_ref("mainline"));
+        assert!(!is_protected_ref("upstream-main"));
+        assert!(!is_protected_ref("master/dev"));
     }
 
     #[test]

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -1201,7 +1201,127 @@ pub fn detect_provider_from_remote(repo: &str) -> (&'static str, bool) {
     }
 }
 
+/// Sprint 57 Wave 2 Track B (#546 Item 1 + Item 3 migration) —
+/// scan ci-watches dir, remove any watch that:
+///   1. has `expires_at < now` (absolute TTL elapsed),
+///   2. has `last_terminal_seen_at` older than `WATCH_TTL_HOURS`
+///      (inactivity TTL elapsed), or
+///   3. targets a protected ref per `agent_ops::is_protected_ref`
+///      (E4.5 migration — closes the ci_watch-on-main bypass that
+///      Sprint 56's `handle_watch_ci` left open until Wave 2 Track B
+///      gated it).
+///
+/// The poll loop (`check_ci_watches_with_provider`) already enforces
+/// (1) and (2) lazily on every per-watch tick, but only for watches
+/// it actively polls — a watch can persist on disk indefinitely if
+/// the upstream branch is gone or no agent is currently polling it.
+/// This eager helper closes that gap by walking the entire dir
+/// without entering the poll path.
+///
+/// Returns the number of watches removed. Best-effort: read/parse
+/// failures skip the entry rather than aborting the sweep.
+pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
+    let ci_dir = home.join("ci-watches");
+    let Ok(entries) = std::fs::read_dir(&ci_dir) else {
+        return 0;
+    };
+    let now_utc = chrono::Utc::now();
+    let mut removed = 0usize;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(watch) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        let repo = watch["repo"].as_str().unwrap_or("?");
+        let branch = watch["branch"].as_str().unwrap_or("?");
+        let audit_label = parse_subscribers(&watch).join(",");
+
+        // (3) E4.5 protected-ref migration — applied first because a
+        // protected-ref watch is invalid regardless of TTL state.
+        if crate::agent_ops::is_protected_ref(branch) {
+            remove_watch(
+                home,
+                &path,
+                &audit_label,
+                repo,
+                branch,
+                &format!("{sweep_origin}_protected_branch_migration"),
+            );
+            tracing::info!(repo = %repo, branch = %branch, sweep = %sweep_origin,
+                "ci_watch removed (E4.5 protected-branch migration)");
+            removed += 1;
+            continue;
+        }
+
+        // (1) absolute TTL.
+        if let Some(expires_at) = watch["expires_at"].as_str() {
+            if let Ok(exp) = chrono::DateTime::parse_from_rfc3339(expires_at) {
+                if now_utc > exp.with_timezone(&chrono::Utc) {
+                    remove_watch(
+                        home,
+                        &path,
+                        &audit_label,
+                        repo,
+                        branch,
+                        &format!("{sweep_origin}_expired"),
+                    );
+                    tracing::info!(repo = %repo, branch = %branch, sweep = %sweep_origin,
+                        "ci_watch removed (absolute TTL elapsed)");
+                    removed += 1;
+                    continue;
+                }
+            }
+        }
+
+        // (2) inactivity TTL.
+        if let Some(last_seen) = watch["last_terminal_seen_at"].as_str() {
+            if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(last_seen) {
+                let elapsed = now_utc.signed_duration_since(ts.with_timezone(&chrono::Utc));
+                if elapsed > chrono::Duration::hours(WATCH_TTL_HOURS) {
+                    remove_watch(
+                        home,
+                        &path,
+                        &audit_label,
+                        repo,
+                        branch,
+                        &format!("{sweep_origin}_inactivity_ttl"),
+                    );
+                    tracing::info!(repo = %repo, branch = %branch, hours = WATCH_TTL_HOURS,
+                        sweep = %sweep_origin,
+                        "ci_watch removed (inactivity TTL elapsed)");
+                    removed += 1;
+                    continue;
+                }
+            }
+        }
+    }
+    removed
+}
+
+/// Sprint 57 Wave 2 Track B (#546 Item 1) — daemon-startup eager
+/// sweep. Runs once before the tick loop begins so stale entries
+/// from a prior daemon process don't outlive the restart. Idempotent;
+/// re-runs are no-ops once the dir is clean.
+pub fn startup_sweep(home: &Path) {
+    let removed = gc_stale_watches(home, "startup_sweep");
+    if removed > 0 {
+        tracing::info!(removed, "ci_watch startup sweep complete");
+    }
+}
+
 pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
+    // Sprint 57 Wave 2 Track B (#546 Item 1) — eager per-tick GC pass
+    // BEFORE the poll loop. The lazy expiry inside the poll body still
+    // runs (Sprint 53/54 era), but it can only see watches actively
+    // being polled. This pass closes the "stale on disk after upstream
+    // branch deletion" gap.
+    let _ = gc_stale_watches(home, "eager_gc");
     check_ci_watches_with_provider(home, registry, |watch| {
         let ci_url = watch
             .get("ci_provider_url")
@@ -2574,7 +2694,15 @@ mod tests {
             "past-expires_at watch must be removed"
         );
         let log = std::fs::read_to_string(dir.join("event-log.jsonl")).unwrap_or_default();
-        assert!(log.contains("reason=expired"), "reason must be expired");
+        // Sprint 57 Wave 2 Track B (#546 Item 1): the eager per-tick GC
+        // pass at the top of `check_ci_watches` removes the watch first
+        // and emits `reason=eager_gc_expired`; the legacy lazy expiry
+        // emits `reason=expired`. Either substring is correct evidence
+        // that the absolute-TTL path fired.
+        assert!(
+            log.contains("expired"),
+            "reason must include 'expired'; got:\n{log}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -3509,7 +3637,7 @@ mod tests {
             &dir,
             &serde_json::json!({
                 "repo": "myws/myrepo",
-                "branch": "main",
+                "branch": "feat-test",
                 "ci_provider": "bitbucket_server",
             }),
             "test-inst",
@@ -4319,5 +4447,180 @@ mod tests {
             matches!(state, super::PrState::Terminal { merged: true }),
             "matching head.ref + recent merged_at must be Terminal(merged); got: {state:?}"
         );
+    }
+
+    // -------------------------------------------------------------
+    // Sprint 57 Wave 2 Track B (#546 Items 1+3) — startup sweep,
+    // per-tick eager GC, and protected-ref migration via
+    // `gc_stale_watches` / `startup_sweep`.
+    // -------------------------------------------------------------
+
+    /// Helper for the new GC tests — write a synthetic watch JSON to
+    /// disk under `home/ci-watches/<filename>`. Returns the file path.
+    fn write_watch(
+        home: &std::path::Path,
+        repo: &str,
+        branch: &str,
+        watch: &serde_json::Value,
+    ) -> std::path::PathBuf {
+        let ci_dir = home.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let filename = super::watch_filename(repo, branch);
+        let path = ci_dir.join(&filename);
+        std::fs::write(&path, serde_json::to_string(watch).unwrap()).ok();
+        path
+    }
+
+    #[test]
+    fn ci_watch_ttl_expires_stale_entries_on_startup_sweep() {
+        // Direct gc_stale_watches call simulates the daemon-startup
+        // path that runs before the tick loop spins up. An expired
+        // (absolute TTL elapsed) entry must be removed AND the event
+        // log must record the removal with the startup_sweep origin.
+        let home = tmp_dir("startup-sweep-ttl");
+        let past = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        let watch = serde_json::json!({
+            "repo": "o/r", "branch": "feat-stale", "interval_secs": 60,
+            "subscribers": [{"instance": "agent-x"}],
+            "last_run_id": null, "head_sha": null,
+            "last_polled_at": null,
+            "expires_at": past,
+            "last_terminal_seen_at": null,
+        });
+        let path = write_watch(&home, "o/r", "feat-stale", &watch);
+
+        super::startup_sweep(&home);
+
+        assert!(
+            !path.exists(),
+            "expired watch must be removed by startup sweep"
+        );
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert!(
+            log.contains("ci_watch_removed"),
+            "removal event must log; got:\n{log}"
+        );
+        assert!(
+            log.contains("startup_sweep_expired"),
+            "reason must include startup_sweep origin; got:\n{log}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn ci_watch_ttl_eager_gc_per_tick() {
+        // Per-tick path: `check_ci_watches` calls `gc_stale_watches`
+        // BEFORE the poll loop. A watch with `expires_at` in the past
+        // but no subscribers list (so the legacy poll body would
+        // continue rather than expire it) must still be removed by
+        // the eager GC.
+        let home = tmp_dir("eager-gc-ttl");
+        let past = (chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339();
+        let watch = serde_json::json!({
+            "repo": "o/r", "branch": "feat-stale-eager", "interval_secs": 60,
+            // empty subscribers — poll loop would `continue` past it
+            // without expiring; eager GC must catch it anyway.
+            "subscribers": [],
+            "last_run_id": null, "head_sha": null,
+            "last_polled_at": null,
+            "expires_at": past,
+            "last_terminal_seen_at": null,
+        });
+        let path = write_watch(&home, "o/r", "feat-stale-eager", &watch);
+
+        let registry: AgentRegistry =
+            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        super::check_ci_watches(&home, &registry);
+
+        assert!(
+            !path.exists(),
+            "eager GC must remove expired watch even when subscribers list is empty"
+        );
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert!(
+            log.contains("eager_gc_expired"),
+            "per-tick eager-GC origin must appear in log; got:\n{log}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn migrate_existing_main_watches_at_startup() {
+        // Item 3 migration: any pre-existing watch with branch=main
+        // (or master) was created before the E4.5 gate landed in
+        // handle_watch_ci. Startup sweep must remove it regardless
+        // of TTL state so the bypass is closed retroactively.
+        let home = tmp_dir("migrate-main-watches");
+        let watch_main = serde_json::json!({
+            "repo": "owner/repo", "branch": "main", "interval_secs": 60,
+            "subscribers": [{"instance": "general"}],
+            "last_run_id": null, "head_sha": null,
+            "last_polled_at": null,
+            // Fresh expires_at — would NOT trip the TTL paths.
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_master = serde_json::json!({
+            "repo": "owner/legacy-repo", "branch": "master", "interval_secs": 60,
+            "subscribers": [{"instance": "lead"}],
+            "last_run_id": null, "head_sha": null,
+            "last_polled_at": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_feat = serde_json::json!({
+            "repo": "owner/repo", "branch": "feat-not-touched", "interval_secs": 60,
+            "subscribers": [{"instance": "dev"}],
+            "last_run_id": null, "head_sha": null,
+            "last_polled_at": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let path_main = write_watch(&home, "owner/repo", "main", &watch_main);
+        let path_master = write_watch(&home, "owner/legacy-repo", "master", &watch_master);
+        let path_feat = write_watch(&home, "owner/repo", "feat-not-touched", &watch_feat);
+
+        super::startup_sweep(&home);
+
+        assert!(
+            !path_main.exists(),
+            "main watch must be migrated/removed by startup sweep"
+        );
+        assert!(
+            !path_master.exists(),
+            "master watch must be migrated/removed by startup sweep"
+        );
+        assert!(path_feat.exists(), "non-protected watch must be preserved");
+
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert!(
+            log.contains("startup_sweep_protected_branch_migration"),
+            "migration reason must surface in audit log; got:\n{log}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn gc_stale_watches_idempotent_on_clean_dir() {
+        // Defensive bonus pin: re-running the sweep on an already-
+        // clean dir must be a no-op (zero removals, zero log entries).
+        let home = tmp_dir("gc-idempotent");
+        let watch = serde_json::json!({
+            "repo": "o/r", "branch": "feat-fresh", "interval_secs": 60,
+            "subscribers": [{"instance": "dev"}],
+            "last_run_id": null, "head_sha": null,
+            "last_polled_at": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": chrono::Utc::now().to_rfc3339(),
+        });
+        let path = write_watch(&home, "o/r", "feat-fresh", &watch);
+
+        let n1 = super::gc_stale_watches(&home, "test_pass1");
+        let n2 = super::gc_stale_watches(&home, "test_pass2");
+
+        assert_eq!(n1, 0, "first sweep on fresh dir must remove nothing");
+        assert_eq!(n2, 0, "second sweep is idempotent");
+        assert!(path.exists(), "fresh watch must survive both sweeps");
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -344,6 +344,12 @@ fn run_core(
     // one-shots and recurring crons.
     replay_missed_at_startup(home, &registry);
 
+    // Sprint 57 Wave 2 Track B (#546 Items 1+3) — eager ci-watch
+    // sweep at daemon startup: removes any expired or protected-ref
+    // watch left behind by a prior daemon process before the first
+    // tick fires. Idempotent.
+    crate::daemon::ci_watch::startup_sweep(home);
+
     let mut last_snapshot_json = String::new();
 
     // Periodic tick channel (every 10s for health/schedule/session maintenance)

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -212,6 +212,21 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     let branch = args["branch"].as_str().unwrap_or("main");
     let interval = args["interval_secs"].as_u64().unwrap_or(60);
 
+    // Sprint 57 Wave 2 Track B (#546 Item 3) — E4.5 protected-ref
+    // gate. Closes the bypass that let any agent subscribe to `main`
+    // (or `master`) CI by calling `ci action=watch` directly. Mirrors
+    // the worktree-lease gate in `worktree_pool::lease`; both go
+    // through `agent_ops::is_protected_ref` so the protected set is
+    // edited in exactly one place. The "main" default at the line
+    // above is the backstop the gate catches when callers omit both
+    // `branch` and explicit-protected branch — both flows land here.
+    if crate::agent_ops::is_protected_ref(branch) {
+        return json!({
+            "error": format!("E4.5 violation: ci action=watch rejects protected branch '{branch}' — use lead/operator dashboards for protected-ref CI surveillance, not per-agent subscriptions"),
+            "code": "e4_5_protected_branch"
+        });
+    }
+
     // Reject unsupported providers early with operator-actionable error.
     if args["ci_provider"].as_str() == Some("bitbucket_server") {
         return json!({"error": "Bitbucket Server not yet supported — track Sprint 41+ candidate. Use bitbucket_cloud for Bitbucket Cloud repos."});

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -123,12 +123,12 @@ fn ci_watch_appends_subscriber_idempotent_distinct_callers() {
     // was the Sprint 53 multi-caller bug.
     let home = std::env::temp_dir().join(format!("agend-watch-append-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "feat-test"});
 
     handle_watch_ci(&home, &args, "lead");
     handle_watch_ci(&home, &args, "dev");
 
-    let watch = read_watch(&watch_path_for(&home, "owner/repo", "main"));
+    let watch = read_watch(&watch_path_for(&home, "owner/repo", "feat-test"));
     let subs: Vec<&str> = watch["subscribers"]
         .as_array()
         .expect("subscribers array")
@@ -149,13 +149,13 @@ fn ci_watch_double_subscribe_same_caller_is_idempotent() {
     // the strict mathematical sense — `f(f(x)) == f(x)`.
     let home = std::env::temp_dir().join(format!("agend-watch-dup-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "feat-test"});
 
     handle_watch_ci(&home, &args, "lead");
     handle_watch_ci(&home, &args, "lead");
     handle_watch_ci(&home, &args, "lead");
 
-    let watch = read_watch(&watch_path_for(&home, "owner/repo", "main"));
+    let watch = read_watch(&watch_path_for(&home, "owner/repo", "feat-test"));
     let subs = watch["subscribers"].as_array().unwrap();
     assert_eq!(subs.len(), 1, "duplicate subscribe must collapse");
     assert_eq!(subs[0]["instance"].as_str(), Some("lead"));
@@ -169,12 +169,12 @@ fn ci_watch_preserves_poll_state_on_resubscribe() {
     // duplicate notification.
     let home = std::env::temp_dir().join(format!("agend-watch-state-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "feat-test"});
 
     handle_watch_ci(&home, &args, "lead");
 
     // Simulate the daemon's poll-loop having stamped state.
-    let path = watch_path_for(&home, "owner/repo", "main");
+    let path = watch_path_for(&home, "owner/repo", "feat-test");
     let mut watch = read_watch(&path);
     watch["last_run_id"] = serde_json::json!(42_u64);
     watch["last_polled_at"] = serde_json::json!(1_700_000_000_000_i64);
@@ -207,12 +207,12 @@ fn ci_watch_legacy_instance_field_migrates_on_resubscribe() {
     let home = std::env::temp_dir().join(format!("agend-watch-migrate-{}", std::process::id()));
     let ci_dir = home.join("ci-watches");
     std::fs::create_dir_all(&ci_dir).ok();
-    let path = watch_path_for(&home, "owner/repo", "main");
+    let path = watch_path_for(&home, "owner/repo", "feat-test");
 
     // Hand-craft a legacy watch file (no subscribers array).
     let legacy = serde_json::json!({
         "repo": "owner/repo",
-        "branch": "main",
+        "branch": "feat-test",
         "interval_secs": 60,
         "instance": "lead",
         "last_run_id": 100,
@@ -227,7 +227,7 @@ fn ci_watch_legacy_instance_field_migrates_on_resubscribe() {
     // Trigger migration via a fresh subscribe.
     handle_watch_ci(
         &home,
-        &serde_json::json!({"repo": "owner/repo", "branch": "main"}),
+        &serde_json::json!({"repo": "owner/repo", "branch": "feat-test"}),
         "dev",
     );
 
@@ -256,16 +256,16 @@ fn ci_unwatch_removes_caller_only_when_others_remain() {
     // and writes the file back. Watch file is NOT deleted.
     let home = std::env::temp_dir().join(format!("agend-unwatch-keep-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "feat-test"});
     handle_watch_ci(&home, &args, "lead");
     handle_watch_ci(&home, &args, "dev");
 
-    let path = watch_path_for(&home, "owner/repo", "main");
+    let path = watch_path_for(&home, "owner/repo", "feat-test");
     assert!(path.exists());
 
     let unwatch_args = serde_json::json!({
         "repo": "owner/repo",
-        "branch": "main",
+        "branch": "feat-test",
         "instance": "lead",
     });
     let resp = handle_unwatch_ci(&home, &unwatch_args);
@@ -297,15 +297,15 @@ fn ci_unwatch_deletes_file_when_subscribers_empty() {
     // branch nobody cares about anymore.
     let home = std::env::temp_dir().join(format!("agend-unwatch-delete-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "feat-test"});
     handle_watch_ci(&home, &args, "lead");
 
-    let path = watch_path_for(&home, "owner/repo", "main");
+    let path = watch_path_for(&home, "owner/repo", "feat-test");
     assert!(path.exists());
 
     let unwatch_args = serde_json::json!({
         "repo": "owner/repo",
-        "branch": "main",
+        "branch": "feat-test",
         "instance": "lead",
     });
     let resp = handle_unwatch_ci(&home, &unwatch_args);
@@ -322,13 +322,13 @@ fn ci_unwatch_unknown_caller_is_noop_keeps_watch() {
     // way to clobber lead's watch via dev's typo).
     let home = std::env::temp_dir().join(format!("agend-unwatch-noop-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "feat-test"});
     handle_watch_ci(&home, &args, "lead");
 
-    let path = watch_path_for(&home, "owner/repo", "main");
+    let path = watch_path_for(&home, "owner/repo", "feat-test");
     let unwatch_args = serde_json::json!({
         "repo": "owner/repo",
-        "branch": "main",
+        "branch": "feat-test",
         "instance": "stranger",
     });
     handle_unwatch_ci(&home, &unwatch_args);
@@ -372,7 +372,7 @@ fn watch_ci_response_includes_health_fields_when_state_populated() {
     // optional-field ladders.
     let home = std::env::temp_dir().join(format!("agend-p05-A1-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "feat-test"});
     let resp = handle_watch_ci(&home, &args, "lead");
 
     assert_eq!(resp["watching"].as_bool(), Some(true));
@@ -394,10 +394,10 @@ fn watch_ci_rate_limit_active_when_until_in_future() {
     // just stamped rate_limit_until.
     let home = std::env::temp_dir().join(format!("agend-p05-A2-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "feat-test"});
     handle_watch_ci(&home, &args, "lead");
 
-    let path = watch_path_for(&home, "owner/repo", "main");
+    let path = watch_path_for(&home, "owner/repo", "feat-test");
     let mut watch = read_watch(&path);
     let future_secs = chrono::Utc::now().timestamp() + 3600;
     watch["rate_limit_until"] = serde_json::json!(future_secs);
@@ -422,7 +422,7 @@ fn watch_ci_next_poll_eta_null_for_fresh_watch() {
     // the next poll" when no poll has happened yet.
     let home = std::env::temp_dir().join(format!("agend-p05-A3-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    let args = serde_json::json!({"repo": "owner/repo", "branch": "main"});
+    let args = serde_json::json!({"repo": "owner/repo", "branch": "feat-test"});
     let resp = handle_watch_ci(&home, &args, "lead");
     assert!(resp["next_poll_eta"].is_null());
     std::fs::remove_dir_all(&home).ok();
@@ -439,12 +439,12 @@ fn ci_status_returns_caller_subscribed_watches() {
     std::fs::create_dir_all(&home).ok();
     handle_watch_ci(
         &home,
-        &serde_json::json!({"repo": "o/r1", "branch": "main"}),
+        &serde_json::json!({"repo": "o/r1", "branch": "feat-test"}),
         "lead",
     );
     handle_watch_ci(
         &home,
-        &serde_json::json!({"repo": "o/r2", "branch": "main"}),
+        &serde_json::json!({"repo": "o/r2", "branch": "feat-test"}),
         "dev",
     );
 
@@ -474,12 +474,12 @@ fn ci_status_filter_by_repo_returns_subset() {
     std::fs::create_dir_all(&home).ok();
     handle_watch_ci(
         &home,
-        &serde_json::json!({"repo": "o/alpha", "branch": "main"}),
+        &serde_json::json!({"repo": "o/alpha", "branch": "feat-test"}),
         "lead",
     );
     handle_watch_ci(
         &home,
-        &serde_json::json!({"repo": "o/beta", "branch": "main"}),
+        &serde_json::json!({"repo": "o/beta", "branch": "feat-test"}),
         "lead",
     );
 
@@ -502,5 +502,102 @@ fn ci_status_no_watches_returns_empty_array_not_error() {
     assert!(resp.get("error").is_none());
     let watches = resp["watches"].as_array().expect("watches array");
     assert!(watches.is_empty());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------
+// Sprint 57 Wave 2 Track B (#546 Item 3) — handle_watch_ci E4.5 gate.
+// ---------------------------------------------------------------------
+
+fn watch_test_home(tag: &str) -> std::path::PathBuf {
+    let home = std::env::temp_dir().join(format!("agend-watch-e45-{}-{}", std::process::id(), tag));
+    std::fs::create_dir_all(&home).ok();
+    home
+}
+
+#[test]
+fn handle_watch_ci_rejects_protected_refs() {
+    // Both `main` and `master` must surface the canonical
+    // `e4_5_protected_branch` error code so callers can branch on
+    // it the same way `bind_self` callers do.
+    for branch in &["main", "master"] {
+        let home = watch_test_home(&format!("reject-{branch}"));
+        let resp = super::handle_watch_ci(
+            &home,
+            &serde_json::json!({"repo": "owner/repo", "branch": branch}),
+            "dev",
+        );
+        assert!(
+            resp["error"].as_str().is_some(),
+            "branch={branch} must error, got {resp}"
+        );
+        assert_eq!(
+            resp["code"].as_str(),
+            Some("e4_5_protected_branch"),
+            "branch={branch} error code must be e4_5_protected_branch, got {resp}"
+        );
+
+        // No side-effect on rejection: ci-watches dir must not gain
+        // a new file for the protected branch.
+        let ci_dir = home.join("ci-watches");
+        if let Ok(rd) = std::fs::read_dir(&ci_dir) {
+            let n: usize = rd.count();
+            assert_eq!(
+                n, 0,
+                "rejected ci_watch must not write a watch file (branch={branch})"
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+}
+
+#[test]
+fn handle_watch_ci_default_branch_does_not_silently_set_main() {
+    // The handler defaults `branch` to "main" when the caller omits
+    // it. After the Item 3 gate, that default-then-create flow must
+    // be rejected with the same E4.5 error rather than silently
+    // creating a watch on main. Pin against re-introduction of the
+    // silent-default behavior.
+    let home = watch_test_home("default-no-silent-main");
+    let resp = super::handle_watch_ci(
+        &home,
+        // NO branch field — exercises the `unwrap_or("main")`.
+        &serde_json::json!({"repo": "owner/repo"}),
+        "dev",
+    );
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("e4_5_protected_branch"),
+        "default-branch path must hit the E4.5 gate, got {resp}"
+    );
+
+    let ci_dir = home.join("ci-watches");
+    if let Ok(rd) = std::fs::read_dir(&ci_dir) {
+        assert_eq!(rd.count(), 0, "no watch file must be created on rejection");
+    }
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn handle_watch_ci_accepts_non_protected_branch() {
+    // Defensive bonus pin: a feature branch must still be accepted
+    // post-gate (the gate must be a CHECK not a refusal-of-all).
+    let home = watch_test_home("accept-feature");
+    let resp = super::handle_watch_ci(
+        &home,
+        &serde_json::json!({
+            "repo": "owner/repo",
+            "branch": "feat/sprint57-wave2-track-b",
+            "interval_secs": 60_u64,
+        }),
+        "dev",
+    );
+    // Either Ok shape OR a different error — but NOT
+    // e4_5_protected_branch.
+    let code = resp["code"].as_str().unwrap_or("");
+    assert_ne!(
+        code, "e4_5_protected_branch",
+        "non-protected branch must NOT trip E4.5 gate, got {resp}"
+    );
     std::fs::remove_dir_all(&home).ok();
 }

--- a/src/mcp/handlers/p0b_tests.rs
+++ b/src/mcp/handlers/p0b_tests.rs
@@ -185,9 +185,14 @@ fn ec7_release_full_unsubscribes_matching_branch() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+// Sprint 57 Wave 2 Track B (#546 Item 2) — release_full unsubscribes
+// the agent from EVERY watch they appear on, including ad-hoc cross-
+// branch watches. Replaces the EC7 r1 reviewer-driven pin that scoped
+// the unsubscribe to the binding-branch only; that scope let agents
+// leak orphan watches across release.
 #[test]
-fn ec7_release_full_leaves_unrelated_watches_untouched() {
-    let home = tmp_home("ec7-unrelated");
+fn release_full_unsubscribes_agent_from_cross_branch_watches_too() {
+    let home = tmp_home("ec7-cross-branch-now-unsubscribed");
     setup_git_repo(&home, "alpha");
     let _ = super::dispatch_hook::dispatch_auto_bind_lease(
         &home,
@@ -196,24 +201,30 @@ fn ec7_release_full_leaves_unrelated_watches_untouched() {
         "feat-ec7u",
         Some("o/r"),
     );
-    // Different branch: must remain after release of feat-ec7u.
-    let other_path = write_ci_watch(&home, "o/r", "main", &["alpha"]);
+    // Seed an ad-hoc cross-branch watch (e.g. agent followed `dev`
+    // for a sibling task). Pre-Sprint-57-Wave-2 this leaked across
+    // release; the new agent-keyed enumerator must clean it up.
+    let other_path = write_ci_watch(&home, "o/r", "dev", &["alpha"]);
 
     crate::worktree_pool::release_full(&home, "alpha");
 
-    let v: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(&other_path).unwrap()).unwrap();
-    let subs = crate::daemon::ci_watch::parse_subscribers(&v);
-    assert_eq!(subs, vec!["alpha".to_string()], "unrelated watch untouched");
+    // alpha was the sole subscriber → file deleted entirely.
+    assert!(
+        !other_path.exists(),
+        "cross-branch watch must be removed when releasing the sole subscriber agent"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 
-// EC7 r1 (reviewer m-99): the unsubscribe predicate must match exact
-// `(repo, branch)` — same branch name on different repos must NOT
-// cross-bleed when one is released.
+// Sprint 57 Wave 2 Track B (#546 Item 2) — replaces the previous EC7 r1
+// pin (`ec7_release_full_does_not_unsubscribe_same_branch_different_repo`).
+// Agent names are unique within the fleet, so the cross-repo concern
+// the EC7 r1 reviewer raised does not apply to agent-keyed
+// unsubscribe: removing `alpha` from any watch where they appear is
+// always correct on release.
 #[test]
-fn ec7_release_full_does_not_unsubscribe_same_branch_different_repo() {
-    let home = tmp_home("ec7-cross-repo");
+fn release_full_unsubscribes_agent_from_cross_repo_watches_too() {
+    let home = tmp_home("ec7-cross-repo-now-unsubscribed");
     setup_git_repo_with_remote(&home, "alpha", "https://github.com/o/repo-a.git");
     let _ = super::dispatch_hook::dispatch_auto_bind_lease(
         &home,
@@ -222,21 +233,24 @@ fn ec7_release_full_does_not_unsubscribe_same_branch_different_repo() {
         "feat-x",
         Some("o/repo-a"),
     );
-    // Same branch name on a DIFFERENT repo. Must remain after release of
-    // alpha (which is bound to o/repo-a).
+    // Same branch name on a DIFFERENT repo (e.g. agent watched
+    // upstream's feat-x for cross-repo coordination). Must shrink to
+    // remaining subscribers on release.
     let cross_repo_path = write_ci_watch(&home, "o/repo-b", "feat-x", &["alpha", "bob"]);
-    // Also seed alpha's own repo-a watch so we can confirm THIS one shrinks.
+    // alpha's own repo-a watch so we can confirm both shrink.
     let own_path = write_ci_watch(&home, "o/repo-a", "feat-x", &["alpha", "bob"]);
 
     crate::worktree_pool::release_full(&home, "alpha");
 
+    // BOTH watches shrink — agent-keyed unsubscribe doesn't care
+    // about repo/branch matching the binding.
     let cross: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&cross_repo_path).unwrap()).unwrap();
     let cross_subs = crate::daemon::ci_watch::parse_subscribers(&cross);
     assert_eq!(
         cross_subs,
-        vec!["alpha".to_string(), "bob".to_string()],
-        "same-branch different-repo watch UNTOUCHED — alpha bleed prevented"
+        vec!["bob".to_string()],
+        "same-branch different-repo watch must also shrink — agent name is unique fleet-wide"
     );
 
     let own: serde_json::Value =
@@ -536,7 +550,12 @@ fn ci_watch_uses_binding_source_repo_when_repo_arg_absent() {
     // ci(watch) with NO repo arg — handler reads binding's source_repo + derives
     // owner/repo via `derive_repo_from_remote_pub`. Origin is configured to
     // `https://github.com/o/r.git` so derive returns `o/r`.
-    let result = super::ci::handle_watch_ci(&home, &json!({}), "alpha");
+    //
+    // Sprint 57 Wave 2 Track B (#546 Item 3): branch field is now
+    // explicit because the default-to-"main" path is rejected by the
+    // new E4.5 gate. Any non-protected branch exercises the auto-derive
+    // logic this test pins.
+    let result = super::ci::handle_watch_ci(&home, &json!({"branch": "feat-auto"}), "alpha");
     assert_eq!(
         result["repo"], "o/r",
         "auto-derive must resolve to 'o/r' from origin URL: {result}"

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1989,7 +1989,11 @@ fn watch_ci_valid_repo_returns_watching() {
     std::env::set_var("AGEND_HOME", &home);
     let result = handle_tool(
         "ci",
-        &json!({"action": "watch", "repo": "owner/repo", "branch": "main"}),
+        // Sprint 57 Wave 2 Track B (#546 Item 3): branch swapped from
+        // "main" to "feat-test" because handle_watch_ci now rejects
+        // protected refs at the E4.5 gate. The happy-path assertion
+        // is unaffected — any non-protected branch suffices.
+        &json!({"action": "watch", "repo": "owner/repo", "branch": "feat-test"}),
         "sender",
     );
     assert_eq!(

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -24,8 +24,11 @@ pub fn lease(
     agent: &str,
     branch: &str,
 ) -> Result<WorktreeLease, String> {
-    // E4.5: reject main branch lease.
-    if branch == "main" || branch == "master" {
+    // E4.5: reject protected-branch lease. Single source of truth for
+    // the protected set is `agent_ops::is_protected_ref` so adding a
+    // new protected ref propagates here and to every other E4.5 site
+    // (Sprint 57 Wave 2 Track B #546 Item 3).
+    if crate::agent_ops::is_protected_ref(branch) {
         return Err(format!(
             "E4.5 violation: cannot lease worktree for protected branch '{branch}'"
         ));
@@ -241,38 +244,22 @@ pub fn release_full(home: &Path, agent: &str) -> ReleaseOutcome {
         }
     }
 
-    // Sprint 55 P0-B EC7: capture branch + derive owner/repo BEFORE
-    // unbind so we can scope the ci-watch unsubscribe by exact
-    // `(repo, branch)` pair. Without the repo predicate, a same-branch-
-    // name on a DIFFERENT repo (e.g. `feat-x` on `org/repo-a` + `feat-x`
-    // on `org/repo-b`) would bleed cross-repo on release.
-    let released_branch = binding["branch"].as_str().map(String::from);
-    let released_repo = binding["source_repo"]
-        .as_str()
-        .filter(|s| !s.is_empty())
-        .and_then(|s| {
-            crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(std::path::Path::new(
-                s,
-            ))
-        });
-
     // Always clear the binding (partial cleanup OK per spec — except when we
     // bailed early on the unmanaged-worktree safety gate above).
     crate::binding::unbind(home, agent);
     out.binding_removed = true;
     out.released = true;
 
-    // Sprint 55 P0-B EC7: best-effort ci-watch unsubscribe scoped to
-    // exact `(released_repo, released_branch)` pair. Removes `agent`
-    // from each matching watch's subscriber array; deletes the watch
-    // file when the array empties. Failure here is logged but does NOT
-    // mutate ReleaseOutcome — release semantics already succeeded.
-    // When released_repo can't be derived (non-GitHub remote / no
-    // origin), the loop is a no-op — leaking a stale subscription
-    // beats cross-repo unsubscribe.
-    if let (Some(branch), Some(repo)) = (released_branch, released_repo) {
-        unsubscribe_ci_watches_for_release(home, agent, &repo, &branch);
-    }
+    // Sprint 57 Wave 2 Track B (#546 Item 2): unsubscribe `agent` from
+    // EVERY ci-watch they appear on, not just the binding-branch entry.
+    // The Sprint 55 P0-B EC7 helper was scoped to the exact
+    // `(released_repo, released_branch)` pair derived from binding.json
+    // — but agents may have added ad-hoc watches outside their
+    // binding-branch (e.g. `ci action=watch repo=… branch=main` to
+    // follow upstream during a closeout cycle). Those leaked across
+    // release until this enumerator landed. Best-effort: failures are
+    // logged but never abort release.
+    unsubscribe_all_ci_watches_for_agent(home, agent);
 
     crate::event_log::log(
         home,
@@ -289,18 +276,21 @@ pub fn release_full(home: &Path, agent: &str) -> ReleaseOutcome {
     out
 }
 
-/// Sprint 55 P0-B EC7 (r1: repo+branch exact match per reviewer m-99) —
-/// scan ci-watches dir, remove `agent` from any watch whose
-/// `(repo, branch)` pair matches the released agent's exactly. If
-/// `agent` was the last subscriber → delete the watch file entirely;
-/// otherwise rewrite it with the shrunk subscriber list. Best-effort:
-/// failures (read/parse/write) are logged but never abort release.
-fn unsubscribe_ci_watches_for_release(
-    home: &Path,
-    agent: &str,
-    released_repo: &str,
-    released_branch: &str,
-) {
+/// Sprint 57 Wave 2 Track B (#546 Item 2) — scan ci-watches dir,
+/// remove `agent` from EVERY watch whose subscriber list contains
+/// them. Replaces the Sprint 55 P0-B EC7 single-(repo, branch)-pair
+/// helper that left ad-hoc watches outside the binding-branch
+/// orphaned on release. Agent names are unique within the fleet so
+/// removing the name from any matching watch is always correct on
+/// release; the cross-repo bleed risk that the EC7 r1 review flagged
+/// only applies when the predicate is "branch matches" — `agent`
+/// matches doesn't have that ambiguity.
+///
+/// Per-watch behaviour: if `agent` was the last subscriber → delete
+/// the watch file entirely; otherwise rewrite it with the shrunk
+/// subscriber list. Best-effort: read/parse/write failures are
+/// logged but never abort release.
+fn unsubscribe_all_ci_watches_for_agent(home: &Path, agent: &str) {
     let ci_dir = home.join("ci-watches");
     let Ok(entries) = std::fs::read_dir(&ci_dir) else {
         return;
@@ -316,11 +306,8 @@ fn unsubscribe_ci_watches_for_release(
         let Ok(mut watch) = serde_json::from_str::<serde_json::Value>(&content) else {
             continue;
         };
-        if watch["repo"].as_str() != Some(released_repo)
-            || watch["branch"].as_str() != Some(released_branch)
-        {
-            continue; // unrelated watch (different repo OR branch) — leave untouched
-        }
+        let watch_branch = watch["branch"].as_str().unwrap_or("?").to_string();
+        let watch_repo = watch["repo"].as_str().unwrap_or("?").to_string();
         let mut subs: Vec<String> = crate::daemon::ci_watch::parse_subscribers(&watch);
         let before = subs.len();
         subs.retain(|s| s != agent);
@@ -329,7 +316,7 @@ fn unsubscribe_ci_watches_for_release(
         }
         if subs.is_empty() {
             let _ = std::fs::remove_file(&path);
-            tracing::info!(%agent, branch = %released_branch, path = %path.display(),
+            tracing::info!(%agent, repo = %watch_repo, branch = %watch_branch, path = %path.display(),
                 "ci-watch unsubscribed last subscriber → removed watch file");
             continue;
         }
@@ -345,7 +332,7 @@ fn unsubscribe_ci_watches_for_release(
                 .unwrap_or_default()
                 .as_bytes(),
         );
-        tracing::info!(%agent, branch = %released_branch, remaining = subs.len(),
+        tracing::info!(%agent, repo = %watch_repo, branch = %watch_branch, remaining = subs.len(),
             "ci-watch unsubscribed agent; subscribers shrunk");
     }
 }
@@ -1022,5 +1009,140 @@ mod tests {
         assert_eq!(removed, 1);
         assert!(!wt.exists(), "worktree must be deleted with flag");
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ------------------------------------------------------------------
+    // Sprint 57 Wave 2 Track B (#546 Item 2) — release_worktree must
+    // unsubscribe the released agent from EVERY ci-watch they appear
+    // on, not just the binding-branch entry.
+    // ------------------------------------------------------------------
+
+    /// Helper: write a synthetic ci-watch JSON listing the given
+    /// subscribers on `(repo, branch)`. Returns the watch path.
+    fn write_ci_watch(
+        home: &std::path::Path,
+        repo: &str,
+        branch: &str,
+        subscribers: &[&str],
+    ) -> PathBuf {
+        let ci_dir = home.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
+        let path = ci_dir.join(&filename);
+        let subs: Vec<serde_json::Value> = subscribers
+            .iter()
+            .map(|s| serde_json::json!({"instance": *s}))
+            .collect();
+        let watch = serde_json::json!({
+            "repo": repo,
+            "branch": branch,
+            "interval_secs": 60,
+            "subscribers": subs,
+            "instance": subscribers.first().copied().unwrap_or(""),
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        std::fs::write(&path, serde_json::to_string_pretty(&watch).unwrap()).ok();
+        path
+    }
+
+    /// Read a ci-watch JSON's subscriber `instance` strings. Returns
+    /// empty Vec if file missing or parse fails — `assert` on the
+    /// caller handles the missing-file case as appropriate.
+    fn read_ci_watch_subscribers(path: &std::path::Path) -> Vec<String> {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return Vec::new();
+        };
+        let Ok(watch) = serde_json::from_str::<serde_json::Value>(&content) else {
+            return Vec::new();
+        };
+        crate::daemon::ci_watch::parse_subscribers(&watch)
+    }
+
+    #[test]
+    fn release_worktree_unsubscribes_all_agent_ci_watches() {
+        // Reproduces the gap shape documented in PR #549 Phase A RCA:
+        // the EC7 helper only unsubscribed the binding-branch watch,
+        // leaving any ad-hoc watches (e.g. an agent watching `main`
+        // during a closeout cycle) orphaned on release.
+        //
+        // Setup: agent `dev` is bound to `feat-track-x`, the auto-
+        // watch for that branch is in place, AND the agent has added
+        // an extra watch on `main` (cross-branch, to follow upstream).
+        // A different agent `lead` shares both watches.
+        let home = tmp_home("p0x-unsubscribe-all");
+        let repo = tmp_repo("p0x-unsubscribe-all-repo");
+        let l = lease(&home, &repo, "dev", "feat-track-x").expect("lease");
+        assert!(l.path.exists(), "pre: worktree must exist");
+
+        // Auto-watch for binding-branch (lease path skipped explicit
+        // ci_watch creation; pre-populate to mirror real fleet state
+        // post-`dispatch_auto_bind_lease` which auto-installs it).
+        let auto_watch = write_ci_watch(&home, "owner/repo", "feat-track-x", &["dev", "lead"]);
+        // Ad-hoc cross-branch watch on `main` (lead also subscribed
+        // so we can verify per-agent shrink without file deletion).
+        let main_watch = write_ci_watch(&home, "owner/repo", "main", &["dev", "lead"]);
+        // Watch the agent isn't subscribed to — must remain untouched.
+        let bystander = write_ci_watch(&home, "owner/repo", "feat-bystander", &["lead"]);
+
+        let outcome = release_full(&home, "dev");
+
+        assert!(outcome.released, "release must succeed");
+        assert!(outcome.binding_removed, "binding must be cleared");
+
+        // Auto-watch: dev was 1 of 2 subscribers → file persists, lead remains.
+        let auto_subs = read_ci_watch_subscribers(&auto_watch);
+        assert_eq!(
+            auto_subs,
+            vec!["lead".to_string()],
+            "binding-branch watch must shrink to remaining subscriber, not be deleted"
+        );
+
+        // Main watch: dev was the orphan vector — must also shrink.
+        // Pre-Sprint-57-Wave-2 this assertion FAILED (dev stayed
+        // subscribed to main); the fix makes it pass.
+        let main_subs = read_ci_watch_subscribers(&main_watch);
+        assert_eq!(
+            main_subs,
+            vec!["lead".to_string()],
+            "ad-hoc cross-branch watch must also shrink — Item 2 regression-proof"
+        );
+
+        // Bystander: dev was never subscribed → file untouched.
+        assert!(bystander.exists(), "bystander watch must survive untouched");
+        let bystander_subs = read_ci_watch_subscribers(&bystander);
+        assert_eq!(
+            bystander_subs,
+            vec!["lead".to_string()],
+            "bystander subscriber list must be unchanged"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn release_worktree_deletes_watch_when_last_subscriber_unsubscribes() {
+        // Defensive bonus pin: agent is the SOLE subscriber to a
+        // cross-branch watch. Release must delete the watch file
+        // entirely (not leave an empty subscribers array).
+        let home = tmp_home("p0x-unsubscribe-last");
+        let repo = tmp_repo("p0x-unsubscribe-last-repo");
+        let _l = lease(&home, &repo, "dev", "feat-x").expect("lease");
+
+        let solo_watch = write_ci_watch(&home, "owner/repo", "main", &["dev"]);
+
+        release_full(&home, "dev");
+
+        assert!(
+            !solo_watch.exists(),
+            "watch with no remaining subscribers must be deleted entirely"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
     }
 }


### PR DESCRIPTION
## Summary

Phase B IMPL bundle for [#546](https://github.com/suzuke/agend-terminal/issues/546) Items 1+2+3 per Phase A RCA (PR #549) recommendations + lead Wave 2 dispatch `m-20260508163709922652-31`. Three structural fixes that close the ci_watch lifecycle hygiene cluster surfaced empirically during Sprint 56 closeout cycles.

| # | Fix | Surface | Tests |
|---|-----|---------|-------|
| 1 | TTL eager GC + startup sweep | `daemon/ci_watch.rs` + `daemon/mod.rs` | 4 (3 spec + 1 idempotency) |
| 2 | Agent-keyed unsubscribe-all | `worktree_pool.rs` | 2 + 2 updated `ec7_*` |
| 3 | E4.5 protected-ref gate | `agent_ops.rs` + `mcp/handlers/ci/mod.rs` + `worktree_pool.rs` | 4 + 4 helper unit |

Total: ~+706 / -95 LOC across 8 files. Tier-1 codex single primary, Path A standard.

## Item 1 — ci_watch TTL eager GC

The poll loop's lazy expiry only sees watches with non-empty subscriber lists; orphaned/expired entries persisted indefinitely. New `gc_stale_watches(home, sweep_origin)` walks the entire `ci-watches/` dir each tick AND once at daemon startup, removing entries that match any of:

1. `agent_ops::is_protected_ref(branch)` (Item 3 migration — main/master watches deleted)
2. `expires_at < now` (absolute TTL)
3. `now - last_terminal_seen_at > WATCH_TTL_HOURS` (inactivity TTL)

Each removal funnels through the existing `remove_watch` audit helper with `reason="<sweep_origin>_<class>"` so operators trace startup vs eager-tick removals. `startup_sweep(home)` invoked once from `daemon::run_core` before the tick loop begins.

## Item 2 — release_worktree agent-keyed unsubscribe

The Sprint 55 P0-B EC7 helper scoped the unsubscribe to `(released_repo, released_branch)` derived from binding.json. Agents that added ad-hoc cross-branch watches (e.g. watching `main` during a closeout cycle) leaked those subscriptions on release. Replaced with `unsubscribe_all_ci_watches_for_agent(home, agent)` that scans every watch and removes the agent unconditionally.

The EC7 r1 reviewer's "cross-repo bleed via shared branch name" concern does NOT apply to agent-keyed matching — agent names are unique within the fleet. The two pre-existing `ec7_*` tests pinning the old scoped behaviour are renamed and re-pinned to the new agent-keyed semantics:

- `ec7_release_full_leaves_unrelated_watches_untouched` → `release_full_unsubscribes_agent_from_cross_branch_watches_too`
- `ec7_release_full_does_not_unsubscribe_same_branch_different_repo` → `release_full_unsubscribes_agent_from_cross_repo_watches_too`

**Empirical proof from Phase A RCA**: this dev agent's Sprint 56 closeout session added a ci_watch on `main` to follow the merge commit; release_worktree did not clean it. The new test `release_worktree_unsubscribes_all_agent_ci_watches` reproduces that exact gap shape and pins the fix.

## Item 3 — E4.5 protected-ref gate on handle_watch_ci

New `pub fn is_protected_ref(branch) -> bool` in `agent_ops.rs` is the single source of truth for the protected set (`main` / `master`). Threaded through:

- `worktree_pool::lease` — replaces the literal check (functional behaviour preserved)
- `handle_watch_ci` — new gate immediately after parsing `branch`, returning `{"error": "...", "code": "e4_5_protected_branch"}`
- `gc_stale_watches` — first predicate, so existing main/master watches on disk are removed by the startup sweep

The default `branch = args["branch"].as_str().unwrap_or("main")` flows into the gate, so callers omitting `branch` no longer silently subscribe to main. Pinned by the regression-proof test `handle_watch_ci_default_branch_does_not_silently_set_main`.

## Test plan

13 new tests + 4 updated pre-existing tests:

- [x] `agent_ops::is_protected_ref_*` (4) — pure helper unit tests
- [x] `daemon::ci_watch::ci_watch_ttl_expires_stale_entries_on_startup_sweep` (lead spec)
- [x] `daemon::ci_watch::ci_watch_ttl_eager_gc_per_tick` (lead spec)
- [x] `daemon::ci_watch::migrate_existing_main_watches_at_startup` (lead spec)
- [x] `daemon::ci_watch::gc_stale_watches_idempotent_on_clean_dir` (defensive bonus)
- [x] `worktree_pool::release_worktree_unsubscribes_all_agent_ci_watches` (lead spec, regression-proof)
- [x] `worktree_pool::release_worktree_deletes_watch_when_last_subscriber_unsubscribes` (defensive bonus)
- [x] `mcp::handlers::ci::tests::handle_watch_ci_rejects_protected_refs` (lead spec)
- [x] `mcp::handlers::ci::tests::handle_watch_ci_default_branch_does_not_silently_set_main` (lead spec, regression-proof)
- [x] `mcp::handlers::ci::tests::handle_watch_ci_accepts_non_protected_branch` (defensive bonus)
- [x] Updated EC7 tests renamed + re-pinned (above)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` — 1748 pass / 7 pre-existing local-only git-state-dependent flakes (claim_verifier::tests x6 + admin::tests::analyze_detects_worktree_branch x1) that pass on canonical CI per Sprint 56 history

## Files changed

| File | Δ | Purpose |
|------|---|---------|
| `src/agent_ops.rs` | +45 | New `is_protected_ref` + 4 unit tests |
| `src/daemon/ci_watch.rs` | +307/-… | `gc_stale_watches` + `startup_sweep` + 4 tests |
| `src/daemon/mod.rs` | +6 | Wire `startup_sweep` before tick loop |
| `src/mcp/handlers/ci/mod.rs` | +15 | E4.5 gate in `handle_watch_ci` |
| `src/mcp/handlers/ci/tests.rs` | +149/-… | 3 new tests + branch-fixture updates |
| `src/mcp/handlers/p0b_tests.rs` | +57/-… | 2 ec7_* tests renamed + re-pinned |
| `src/mcp/handlers/tests.rs` | +6 | branch-fixture update |
| `src/worktree_pool.rs` | +216/-… | Agent-keyed unsubscribe + 2 tests + lease helper-routing |

## Source of truth

Branch base: `main @ 0b58c28` (post-Wave-1-Track-B merge).

Reviewer focus per Path A standard: cross-fix entanglement, E4.5 unexpected ripples, migration migration-data shape correctness.

## Out of scope

- Item 4 (worktree physical placement) — Wave 4 candidate
- Item 5 (dedup ledger persistence) — Wave 2 Track C separately, Tier-2 dual review per dev recommendation
- gh `--delete-branch` ergonomic — Wave 2 Track D parallel-feasible carryover

## Refs

- Phase A RCA: PR #549 / commit `8843a0e`
- Lead dispatch: `m-20260508163709922652-31`
- Phase A reviewer verdict: 6-checklist clean PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)