### PR TITLE
feat(agend-git): exempt gh post-merge cleanup checkout from E4.5 cross-branch fence (Sprint 57 Wave 2 Track D)

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -4,6 +4,7 @@
 //! determine the active worktree, then either:
 //! - passthrough (unbound read-only commands)
 //! - chdir + pass (bound commands routed to worktree)
+//! - silent-exempt (gh post-merge cleanup checkout — Sprint 57 Wave 2 Track D)
 //! - deny (forbidden operations with LLM-friendly error)
 //!
 //! Bypass: AGEND_GIT_BYPASS=1 | AGEND_GIT_BYPASS_AGENT=<name> | AGEND_GIT_BYPASS_UNTIL=<epoch>
@@ -35,12 +36,39 @@ fn main() {
     let binding = read_binding(&home, &agent);
     let subcommand = args.first().map(|s| s.as_str()).unwrap_or("");
 
-    match classify(subcommand, &args, &binding) {
+    // Sprint 57 Wave 2 Track D: resolve parent-process-is-gh signal once.
+    // Used by `classify` to recognize gh-driven post-merge cleanup
+    // checkouts and silently exempt them from the E4.5 cross-branch
+    // fence. See `invocation_is_gh_post_merge` for the rationale.
+    let parent_is_gh = invocation_is_gh_post_merge();
+
+    match classify(subcommand, &args, &binding, parent_is_gh) {
         Action::Passthrough => exec_real_git(&args, None),
         Action::ChdirPass(worktree) => exec_real_git(&args, Some(&worktree)),
+        Action::SilentExempt {
+            target_branch,
+            reason,
+        } => {
+            // Sprint 57 Wave 2 Track D: gh-driven post-merge cleanup
+            // checkout. Already-merged PR + already-deleted remote
+            // branch — the local checkout is purely cosmetic from
+            // gh's perspective. Skip the actual git invocation
+            // (preserves E4.5: no real checkout to main happens),
+            // log the exemption for security review, exit 0 so gh
+            // continues its post-merge cleanup quietly.
+            write_git_event_typed(
+                &home,
+                &agent,
+                subcommand,
+                "post_merge_cleanup_exempt",
+                Some(&target_branch),
+                Some(&reason),
+            );
+            std::process::exit(0);
+        }
         Action::Deny(reason) => {
             emit_deny_error(subcommand, &reason, &agent);
-            write_git_event(&home, &agent, subcommand, &reason);
+            write_git_event_typed(&home, &agent, subcommand, "deny", None, Some(&reason));
             std::process::exit(1);
         }
     }
@@ -120,13 +148,31 @@ fn is_bound(binding: &Binding) -> bool {
 
 // ── Classification ──────────────────────────────────────────────────────
 
+#[derive(Debug, PartialEq, Eq)]
 enum Action {
     Passthrough,
     ChdirPass(String),
+    /// Sprint 57 Wave 2 Track D: gh post-merge cleanup checkout
+    /// recognized — exit 0 without invoking real git. E4.5 protection
+    /// is preserved (no actual checkout to main happens) and the
+    /// `gh pr merge --delete-branch` cleanup proceeds silently.
+    SilentExempt {
+        target_branch: String,
+        reason: String,
+    },
     Deny(String),
 }
 
-fn classify(subcmd: &str, args: &[String], binding: &Binding) -> Action {
+/// Local mirror of `agent_ops::is_protected_ref`. The wrapper binary
+/// is intentionally self-contained (no `crate::*` imports) so it
+/// builds standalone without the full library surface. Sprint 57
+/// Wave 2 Track B introduced the lib-side helper; the literal here
+/// MUST stay in sync.
+fn is_protected_ref(branch: &str) -> bool {
+    matches!(branch, "main" | "master")
+}
+
+fn classify(subcmd: &str, args: &[String], binding: &Binding, parent_is_gh: bool) -> Action {
     let bound = is_bound(binding);
 
     match subcmd {
@@ -166,6 +212,31 @@ fn classify(subcmd: &str, args: &[String], binding: &Binding) -> Action {
                     && target_branch != assigned
                     && !target_branch.starts_with('-')
                 {
+                    // Sprint 57 Wave 2 Track D: gh post-merge cleanup
+                    // exemption. Trigger requires ALL of:
+                    //   - target is a protected ref (main / master)
+                    //   - parent process is `gh` (signal that this
+                    //     invocation is from `gh pr merge --delete-branch`
+                    //     post-merge local-state cleanup)
+                    //   - we're in the agent-invoked path (AGEND_INSTANCE_NAME
+                    //     was set; bound binding is the consequence of that)
+                    // Heuristic robustness: a non-gh parent (interactive
+                    // shell, script, IDE) reaches the cross-branch deny
+                    // unchanged, preserving E4.5 protection for the
+                    // operator-typed case the rule was originally built
+                    // for.
+                    if is_protected_ref(target_branch) && parent_is_gh {
+                        return Action::SilentExempt {
+                            target_branch: target_branch.to_string(),
+                            reason: format!(
+                                "gh post-merge cleanup checkout to '{target_branch}' \
+                                 from binding-branch '{assigned}' \
+                                 (parent process detected as `gh`); \
+                                 PR merge already succeeded — silent exit avoids \
+                                 noisy false-positive deny on the operator's terminal"
+                            ),
+                        };
+                    }
                     return Action::Deny(format!(
                         "cross-branch — assigned to '{assigned}', cannot switch to '{target_branch}'"
                     ));
@@ -189,6 +260,100 @@ fn classify(subcmd: &str, args: &[String], binding: &Binding) -> Action {
             Action::Passthrough
         }
     }
+}
+
+// ── Parent-process detection (gh post-merge cleanup heuristic) ──────────
+
+/// Sprint 57 Wave 2 Track D: detect that this `agend-git` invocation
+/// is a child of `gh`. Returns `true` only when AGEND_INSTANCE_NAME is
+/// set (i.e. we're inside the agent-invoked path the cross-branch
+/// fence guards) AND the parent process name is `gh`. Conservative
+/// by design: any platform-specific lookup failure returns `false`,
+/// letting the fence fire as it would have pre-Track-D rather than
+/// silently weakening E4.5.
+fn invocation_is_gh_post_merge() -> bool {
+    // Operator-shell invocations don't have AGEND_INSTANCE_NAME set;
+    // those already hit the early passthrough at the top of `main()`,
+    // so the cross-branch fence never fires for them. Restricting the
+    // exemption to AGEND_INSTANCE_NAME-set invocations keeps the
+    // surface tight.
+    if env::var("AGEND_INSTANCE_NAME")
+        .ok()
+        .is_none_or(|s| s.is_empty())
+    {
+        return false;
+    }
+    parent_process_name()
+        .map(|n| process_basename_is_gh(&n))
+        .unwrap_or(false)
+}
+
+/// Pure helper for testability — accepts any process-name string and
+/// returns whether it looks like the `gh` binary (basename match).
+/// Handles common platform formats: "gh", "/usr/local/bin/gh",
+/// "C:\\Program Files\\GitHub CLI\\gh.exe".
+fn process_basename_is_gh(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Strip any trailing newline/whitespace and split off the basename.
+    let last = trimmed.rsplit(['/', '\\']).next().unwrap_or(trimmed).trim();
+    // Match either `gh` or `gh.exe` (case-insensitive on Windows
+    // semantics, but case-sensitive paths are universal — the gh CLI
+    // ships its binary lower-case).
+    last == "gh" || last.eq_ignore_ascii_case("gh.exe")
+}
+
+#[cfg(target_os = "linux")]
+fn parent_process_name() -> Option<String> {
+    let ppid = unsafe { libc::getppid() };
+    let path = format!("/proc/{ppid}/comm");
+    std::fs::read_to_string(&path).ok().map(|s| {
+        s.trim_end_matches(['\n', '\r', '\0', ' '])
+            .trim()
+            .to_string()
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn parent_process_name() -> Option<String> {
+    let ppid = unsafe { libc::getppid() };
+    let output = std::process::Command::new("ps")
+        .args(["-p", &ppid.to_string(), "-o", "comm="])
+        .output()
+        .ok()?;
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn parent_process_name() -> Option<String> {
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
+    let pid = sysinfo::Pid::from_u32(std::process::id());
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        true,
+        ProcessRefreshKind::nothing(),
+    );
+    let parent_pid = sys.process(pid)?.parent()?;
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[parent_pid]),
+        true,
+        ProcessRefreshKind::nothing(),
+    );
+    sys.process(parent_pid)
+        .map(|p| p.name().to_string_lossy().to_string())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn parent_process_name() -> Option<String> {
+    None
 }
 
 // ── Exec ────────────────────────────────────────────────────────────────
@@ -270,14 +435,29 @@ fn format_deny_error(subcmd: &str, reason: &str, agent: &str) -> Vec<String> {
     ]
 }
 
-fn write_git_event(home: &str, agent: &str, subcmd: &str, reason: &str) {
+/// Sprint 57 Wave 2 Track D: structured audit-event writer with an
+/// explicit event-type discriminator. Replaces the previous untyped
+/// `write_git_event` that hardcoded `event="deny"`. `event_type` is
+/// the new `kind`-style discriminator (`"deny"` or
+/// `"post_merge_cleanup_exempt"`); `target_branch` carries the
+/// resolved checkout target when relevant for the exemption case;
+/// `detail` mirrors the human-readable reason string.
+fn write_git_event_typed(
+    home: &str,
+    agent: &str,
+    subcmd: &str,
+    event_type: &str,
+    target_branch: Option<&str>,
+    detail: Option<&str>,
+) {
     let events_path = PathBuf::from(home).join("fleet_events.jsonl");
     let event = serde_json::json!({
         "kind": "git_event",
-        "event": "deny",
+        "event": event_type,
         "agent": agent,
         "subcommand": subcmd,
-        "reason": reason,
+        "target_branch": target_branch,
+        "reason": detail,
         "timestamp": chrono::Utc::now().to_rfc3339(),
     });
     // Best-effort append (don't block on failure).
@@ -292,8 +472,17 @@ fn write_git_event(home: &str, agent: &str, subcmd: &str, reason: &str) {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::format_deny_error;
+    use super::*;
+
+    fn bound_binding(branch: &str, worktree: &str) -> Binding {
+        Binding {
+            task_id: Some("T-test".into()),
+            branch: Some(branch.into()),
+            worktree: Some(worktree.into()),
+        }
+    }
 
     #[test]
     fn deny_hint_lists_all_three_bypass_forms() {
@@ -313,5 +502,246 @@ mod tests {
             joined.contains("epoch") && joined.contains("Unix seconds"),
             "AGEND_GIT_BYPASS_UNTIL hint must clarify epoch wording (not ISO), got:\n{joined}"
         );
+    }
+
+    // ----- Sprint 57 Wave 2 Track D — gh post-merge exemption -----
+
+    #[test]
+    fn gh_post_merge_checkout_exempted_from_e45_fence() {
+        // Happy path: agent is bound to a feat branch, gh just merged
+        // it + deleted remote, now runs `git checkout main` to clean
+        // up local state. parent=gh signal fires → SilentExempt.
+        let binding = bound_binding("sprint57-track-x", "/tmp/.worktrees/dev");
+        let action = classify(
+            "checkout",
+            &["checkout".into(), "main".into()],
+            &binding,
+            true, // parent_is_gh = true
+        );
+        match action {
+            Action::SilentExempt {
+                target_branch,
+                reason,
+            } => {
+                assert_eq!(target_branch, "main");
+                assert!(
+                    reason.contains("gh post-merge"),
+                    "reason must label the exemption: {reason}"
+                );
+            }
+            other => panic!("expected SilentExempt for gh post-merge cleanup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gh_post_merge_exemption_also_covers_master() {
+        // master is part of the protected set per `is_protected_ref`;
+        // legacy repos using `master` as default branch must also
+        // trigger the exemption.
+        let binding = bound_binding("sprint57-track-y", "/tmp/.worktrees/dev");
+        let action = classify(
+            "checkout",
+            &["checkout".into(), "master".into()],
+            &binding,
+            true,
+        );
+        assert!(
+            matches!(action, Action::SilentExempt { .. }),
+            "master target must also be exempted, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn interactive_checkout_to_main_still_blocked() {
+        // Regression-proof of E4.5 normal protection: when parent is
+        // NOT gh (interactive shell, script, IDE), the cross-branch
+        // fence must still fire. Without this guarantee Track D
+        // would silently weaken the rule.
+        let binding = bound_binding("sprint57-track-z", "/tmp/.worktrees/dev");
+        let action = classify(
+            "checkout",
+            &["checkout".into(), "main".into()],
+            &binding,
+            false, // parent_is_gh = false (interactive shell)
+        );
+        match action {
+            Action::Deny(reason) => {
+                assert!(
+                    reason.contains("cross-branch"),
+                    "interactive case must still trip the cross-branch fence: {reason}"
+                );
+                assert!(
+                    reason.contains("'main'"),
+                    "deny message must mention target branch: {reason}"
+                );
+            }
+            other => panic!("interactive checkout to main MUST be denied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn switch_subcommand_also_routes_through_gate() {
+        // `git switch main` is the modern equivalent of `git checkout
+        // main`; the gate must apply to both subcommands so the
+        // exemption + the normal block both work via either spelling.
+        let binding = bound_binding("sprint57-track-q", "/tmp/.worktrees/dev");
+        // gh path → exempt
+        let action_gh = classify("switch", &["switch".into(), "main".into()], &binding, true);
+        assert!(matches!(action_gh, Action::SilentExempt { .. }));
+        // interactive path → deny
+        let action_interactive =
+            classify("switch", &["switch".into(), "main".into()], &binding, false);
+        match action_interactive {
+            Action::Deny(_) => {}
+            other => panic!("interactive `switch main` must deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cross_branch_to_non_protected_target_never_exempted() {
+        // Heuristic correctness: even with parent_is_gh=true, a
+        // checkout to a NON-protected branch must still be denied.
+        // The exemption is narrow by design — protected refs only.
+        // gh in normal operation never checks out feature branches
+        // post-merge, so this case represents a heuristic false-
+        // positive boundary we explicitly guard.
+        let binding = bound_binding("sprint57-track-r", "/tmp/.worktrees/dev");
+        let action = classify(
+            "checkout",
+            &["checkout".into(), "feat-other".into()],
+            &binding,
+            true, // parent_is_gh — but target isn't protected.
+        );
+        match action {
+            Action::Deny(reason) => {
+                assert!(
+                    reason.contains("cross-branch"),
+                    "non-protected cross-branch must deny even with parent=gh: {reason}"
+                );
+            }
+            other => panic!(
+                "non-protected cross-branch with parent=gh must deny (NOT exempt), got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn gh_invocation_detection_robust_against_simulated_external_invocation() {
+        // The detection helper must reject `gh`-lookalike basenames
+        // that aren't the canonical CLI binary. This pins the
+        // basename matcher: only the literal `gh` (or `gh.exe`)
+        // qualifies — common false-positives like `github`,
+        // `gh-cli-helper`, or empty strings must NOT.
+        assert!(process_basename_is_gh("gh"));
+        assert!(process_basename_is_gh("/usr/local/bin/gh"));
+        assert!(process_basename_is_gh("/opt/homebrew/bin/gh"));
+        assert!(process_basename_is_gh(
+            "C:\\Program Files\\GitHub CLI\\gh.exe"
+        ));
+        assert!(process_basename_is_gh("gh.exe"));
+
+        // Negative cases — must NOT fire the heuristic.
+        assert!(!process_basename_is_gh(""));
+        assert!(!process_basename_is_gh("github"));
+        assert!(!process_basename_is_gh("/usr/bin/github"));
+        assert!(!process_basename_is_gh("gh-cli-helper"));
+        assert!(!process_basename_is_gh("not-gh"));
+        assert!(!process_basename_is_gh("/path/to/gh.sh")); // shell wrapper
+        assert!(!process_basename_is_gh("agh")); // adjacent letters
+    }
+
+    #[test]
+    fn audit_event_logged_when_exemption_fires() {
+        // Round-trip: classify produces SilentExempt → main() writes a
+        // structured `post_merge_cleanup_exempt` event. We can't run
+        // main() in a unit test (it calls std::process::exit), but
+        // we can call the underlying `write_git_event_typed` writer
+        // directly and assert the on-disk shape, which is what main
+        // would emit.
+        let home = std::env::temp_dir().join(format!(
+            "agend-git-d-audit-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&home).ok();
+
+        write_git_event_typed(
+            home.to_str().unwrap(),
+            "dev",
+            "checkout",
+            "post_merge_cleanup_exempt",
+            Some("main"),
+            Some("gh post-merge cleanup checkout — test fixture"),
+        );
+
+        let events_path = home.join("fleet_events.jsonl");
+        assert!(events_path.exists(), "audit event file must be created");
+
+        let content = std::fs::read_to_string(&events_path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(v["kind"], "git_event");
+        assert_eq!(v["event"], "post_merge_cleanup_exempt");
+        assert_eq!(v["agent"], "dev");
+        assert_eq!(v["subcommand"], "checkout");
+        assert_eq!(v["target_branch"], "main");
+        assert!(
+            v["reason"]
+                .as_str()
+                .map(|s| s.contains("post-merge"))
+                .unwrap_or(false),
+            "reason must record the exemption rationale"
+        );
+        assert!(
+            v["timestamp"].as_str().is_some(),
+            "timestamp must be RFC3339 string"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn deny_event_still_uses_typed_writer() {
+        // Defensive bonus pin: the legacy `event="deny"` shape must
+        // continue to work via the new `write_git_event_typed`
+        // function. Previously the wrapper had a separate
+        // `write_git_event` for deny-only; consolidating to a typed
+        // writer must not change the on-disk shape for the deny
+        // event-type so downstream parsers keep working.
+        let home = std::env::temp_dir().join(format!(
+            "agend-git-d-deny-audit-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&home).ok();
+
+        write_git_event_typed(
+            home.to_str().unwrap(),
+            "dev",
+            "checkout",
+            "deny",
+            None,
+            Some("cross-branch — assigned to 'feat-x', cannot switch to 'main'"),
+        );
+
+        let events_path = home.join("fleet_events.jsonl");
+        let content = std::fs::read_to_string(&events_path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(v["event"], "deny");
+        assert_eq!(v["target_branch"], serde_json::Value::Null);
+        assert!(
+            v["reason"]
+                .as_str()
+                .map(|s| s.contains("cross-branch"))
+                .unwrap_or(false),
+            "deny reason must round-trip"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -339,13 +339,13 @@ fn parent_process_name() -> Option<String> {
     sys.refresh_processes_specifics(
         ProcessesToUpdate::Some(&[pid]),
         true,
-        ProcessRefreshKind::nothing(),
+        ProcessRefreshKind::new(),
     );
     let parent_pid = sys.process(pid)?.parent()?;
     sys.refresh_processes_specifics(
         ProcessesToUpdate::Some(&[parent_pid]),
         true,
-        ProcessRefreshKind::nothing(),
+        ProcessRefreshKind::new(),
     );
     sys.process(parent_pid)
         .map(|p| p.name().to_string_lossy().to_string())


### PR DESCRIPTION
## Summary

Wrapper-side ergonomic fix for the `gh pr merge --delete-branch` post-merge checkout pattern observed 4× across the Sprint 56 → 57 closeout cycle. Closes the noisy false-positive deny on the operator's terminal without weakening E4.5 protection. Per [lead Track D dispatch](#) `m-20260508170401322887-41`. Tier-1 codex single primary, Path A wrapper-side.

## Pattern observed (4× empirical)

| PR | Merge SHA | Symptom |
|----|-----------|---------|
| #544 | `cbdac10` | wrapper deny |
| #547 | `8725118` | wrapper deny (Sprint 56 Track I-Phase2c closeout) |
| #549 | `8843a0e` | wrapper deny (Sprint 57 Track A closeout) |
| #550 | `0b58c28` | wrapper deny (Sprint 57 Track B closeout) |

In each case the merge AND remote branch delete had already succeeded; only the post-merge local-state cleanup (`git checkout main`) failed at the wrapper E4.5 fence. Dev did NOT self-bypass per operator's 2026-05-08 directive — surfaced to lead each time. This commit closes the gap.

## Mechanism

New `Action::SilentExempt { target_branch, reason }` variant in `classify()`. Trigger requires ALL of:

1. Subcommand is `checkout` or `switch`
2. Target branch is a protected ref (`main` / `master`)
3. Parent process is `gh` (basename match)
4. Cross-branch attempt (target ≠ binding.branch)
5. AGEND_INSTANCE_NAME set (constrains to agent-invoked path)

When the trigger fires, the wrapper writes a structured `post_merge_cleanup_exempt` audit event to `fleet_events.jsonl` and exits 0 **without invoking real git**. E4.5 is preserved (no actual checkout to main happens). gh sees success and continues its post-merge cleanup quietly.

## Cross-platform parent-process detection

- **Linux**: `/proc/<ppid>/comm` single file read (no subprocess)
- **macOS**: `ps -p <ppid> -o comm=` subprocess (`/proc` doesn't exist)
- **Windows**: `sysinfo` crate (already a workspace dep)
- **Unknown OS**: returns `None` → exemption never fires (fail-closed)

`process_basename_is_gh()` matcher handles common path formats (`gh`, `/usr/local/bin/gh`, `C:\\Program Files\\GitHub CLI\\gh.exe`) while rejecting false-positives (`github`, `gh-cli-helper`, shell wrappers).

## Audit refactor

`write_git_event` (deny-only) replaced by `write_git_event_typed(home, agent, subcmd, event_type, target_branch, detail)` so both `event="deny"` and `event="post_merge_cleanup_exempt"` shapes funnel through one writer. On-disk JSON shape for the deny event is preserved — pinned by `deny_event_still_uses_typed_writer`.

## Test plan

7 new wrapper-side unit tests + 1 defensive bonus:

- [x] `gh_post_merge_checkout_exempted_from_e45_fence` (lead spec)
- [x] `gh_post_merge_exemption_also_covers_master`
- [x] `interactive_checkout_to_main_still_blocked` (lead spec — regression-proof)
- [x] `switch_subcommand_also_routes_through_gate`
- [x] `cross_branch_to_non_protected_target_never_exempted`
- [x] `gh_invocation_detection_robust_against_simulated_external_invocation` (lead spec)
- [x] `audit_event_logged_when_exemption_fires` (lead spec)
- [x] `deny_event_still_uses_typed_writer` (defensive bonus)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --bin agend-git` — 9/9
- [x] `cargo test --features tray` — 1735 pass / 7 pre-existing local-only git-state flakes

## Files changed

`src/bin/agend-git.rs` (+437/-7 LOC, single file)

## Source of truth

Branch base: `main @ 0b58c28` (post-Wave-1-Track-B merge, parallel-feasible to Wave 2 Track B PR #551 reviewer wait).

Reviewer focus per Path A wrapper-side: exemption mechanism correctness + E4.5 protection preserved + heuristic robustness.

## Out of scope

- Non-wrapper changes (gh CLI behavior unaffected)
- Other E4.5 protected-ref bypass mechanisms
- Changes to STRICT v2 daemon-managed-worktree-only rule itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)