### PR TITLE
feat(supervisor): persist rate-limit dedup ledger across daemon restart (Sprint 57 Wave 2 Track C) (#546 Item 5)

### DIFF
--- a/src/daemon/dedup_state.rs
+++ b/src/daemon/dedup_state.rs
@@ -1,0 +1,618 @@
+//! Sprint 57 Wave 2 Track C (#546 Item 5) — persistence for the
+//! supervisor's per-agent dedup ledger.
+//!
+//! The Sprint 56 Track G (#529) `RateLimitRetry` HashMap is held
+//! in-memory inside `supervisor::run_loop`. A daemon restart blasts
+//! all in-flight dedup state — fingerprint, dedup_count,
+//! last_inject_at — and a fresh cycle that re-fires the same
+//! fingerprint within the 60s dedup window would under-suppress
+//! (the cap is re-armed at 0 after restart). Phase A RCA #549
+//! audited the gap; this module is the Option A persistent-ledger
+//! fix.
+//!
+//! ## Schema (per-agent JSON file at `$AGEND_HOME/dedup-state/<agent>.json`)
+//!
+//! ```json
+//! {
+//!   "schema_version": 1,
+//!   "agent": "dev",
+//!   "fingerprint": "0x123abc...",
+//!   "dedup_count": 1,
+//!   "last_inject_at_unix_micros": 1730000000000000,
+//!   "dedup_audit_emitted": true,
+//!   "retry_count": 2,
+//!   "exhausted": false,
+//!   "input_text": "..."
+//! }
+//! ```
+//!
+//! ## Time field semantics
+//!
+//! `RateLimitRetry::last_inject_at` is `std::time::Instant` (monotonic
+//! clock anchored to process boot) — it CANNOT be serialized
+//! meaningfully across restarts. We persist it as `SystemTime` Unix
+//! micros and reconstruct on load by subtracting the elapsed wall
+//! time from `Instant::now()`. The arithmetic is correct as long as
+//! the wall clock didn't jump backward between persist and load
+//! (clock skew → conservative fallback to `Instant::now()`, i.e.
+//! treat the window as "just expired" — favours allowing retries
+//! over suppressing them, matching fail-open semantics).
+//!
+//! `RateLimitRetry::next_retry_at` is intentionally NOT persisted.
+//! On load we set it to `Instant::now()` (immediately due) and let
+//! the supervisor's existing backoff-scheduling code path
+//! re-derive a fresh `next_retry_at` on the first post-load tick.
+//! This avoids the temptation to invent a "wall-clock retry deadline"
+//! that would couple this module to the SERVER_RATE_LIMIT_BACKOFF
+//! schedule.
+//!
+//! ## Atomic-write semantics
+//!
+//! `save` uses `crate::store::atomic_write` (write-then-rename) so a
+//! crash mid-save leaves either the previous content intact or the
+//! new content fully written — never a half-flushed file. The
+//! supervisor is single-threaded (one `run_loop` thread), so there
+//! is no concurrent-writer race within the daemon process. Across
+//! daemon restarts, the rename's atomicity is the load-bearing
+//! guarantee.
+//!
+//! ## Failure modes
+//!
+//! - Missing dir: returns empty HashMap, lazy-creates on first save.
+//! - Missing file: skipped silently (per-agent, fail-open).
+//! - Malformed JSON / schema mismatch: logged via `tracing::warn`,
+//!   the entry is skipped, the rest of the dir loads normally.
+//! - Write failure: logged via `tracing::warn`, supervisor continues
+//!   with the in-memory state (best-effort persistence; correctness
+//!   degrades to pre-Track-C behavior — acceptable).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::daemon::supervisor::RateLimitRetry;
+
+/// Current on-disk schema version. Bumped when fields are
+/// added/removed in a non-backward-compatible way.
+const SCHEMA_VERSION: u32 = 1;
+
+/// Sub-directory of `$AGEND_HOME` that holds per-agent JSON files.
+pub(crate) const DEDUP_STATE_DIR: &str = "dedup-state";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OnDisk {
+    schema_version: u32,
+    agent: String,
+    /// Hex-formatted u64 (`"0x{:016x}"`) so JSON readers handle the
+    /// full 64-bit range without precision loss.
+    fingerprint: String,
+    dedup_count: u32,
+    /// `last_inject_at` as Unix-epoch microseconds. Reconstructed to
+    /// `Instant` on load via `SystemTime::now()` delta.
+    last_inject_at_unix_micros: i64,
+    dedup_audit_emitted: bool,
+    retry_count: u32,
+    exhausted: bool,
+    input_text: String,
+}
+
+/// Path for a single agent's ledger file.
+pub(crate) fn ledger_path(home: &Path, agent: &str) -> PathBuf {
+    home.join(DEDUP_STATE_DIR).join(format!("{agent}.json"))
+}
+
+/// Convert `Instant` to wall-clock Unix micros. Approximates by
+/// computing the elapsed-since-now offset and adding it to the
+/// current `SystemTime`. Negative offsets (Instant in the future
+/// relative to now — never happens in this module's call sites)
+/// are clamped to now.
+fn instant_to_unix_micros(instant: Instant) -> i64 {
+    let now_inst = Instant::now();
+    let now_sys = SystemTime::now();
+    if instant <= now_inst {
+        let elapsed = now_inst.duration_since(instant);
+        let target = now_sys
+            .checked_sub(elapsed)
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        system_time_to_unix_micros(target)
+    } else {
+        // Instant in the future — clamp to current wall clock.
+        system_time_to_unix_micros(now_sys)
+    }
+}
+
+/// Convert Unix micros back to `Instant`. If the wall clock has
+/// moved forward since persist, returns an Instant that's `(now -
+/// elapsed_wallclock)` ago. If the wall clock has moved BACKWARD
+/// (impossible on monotonic systems, possible across NTP corrections),
+/// returns `Instant::now()` to fail-open.
+fn unix_micros_to_instant(unix_micros: i64) -> Instant {
+    if unix_micros <= 0 {
+        return Instant::now();
+    }
+    let target_sys = match unix_micros_to_system_time(unix_micros) {
+        Some(t) => t,
+        None => return Instant::now(),
+    };
+    let now_sys = SystemTime::now();
+    match now_sys.duration_since(target_sys) {
+        Ok(elapsed) => Instant::now()
+            .checked_sub(elapsed)
+            .unwrap_or_else(Instant::now),
+        // SystemTime is in the future relative to "now" — clock skew
+        // (NTP rewind, persisted from a faster host clock, etc).
+        // Fail-open: treat as if the persist just happened, which
+        // keeps the dedup window honoured for at most its full
+        // duration before the next tick re-evaluates.
+        Err(_) => Instant::now(),
+    }
+}
+
+fn system_time_to_unix_micros(t: SystemTime) -> i64 {
+    match t.duration_since(UNIX_EPOCH) {
+        Ok(d) => d.as_micros().min(i64::MAX as u128) as i64,
+        Err(_) => 0,
+    }
+}
+
+fn unix_micros_to_system_time(unix_micros: i64) -> Option<SystemTime> {
+    if unix_micros < 0 {
+        return None;
+    }
+    UNIX_EPOCH.checked_add(Duration::from_micros(unix_micros as u64))
+}
+
+/// Persist a single agent's `RateLimitRetry` to disk. Idempotent:
+/// repeated calls with the same content overwrite the file in place.
+/// Best-effort — write failures are logged but never propagated.
+pub(crate) fn save(home: &Path, agent: &str, retry: &RateLimitRetry) {
+    let dir = home.join(DEDUP_STATE_DIR);
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(error = %e, agent = %agent, "dedup_state: create_dir_all failed");
+        return;
+    }
+    let on_disk = OnDisk {
+        schema_version: SCHEMA_VERSION,
+        agent: agent.to_string(),
+        fingerprint: format!("0x{:016x}", retry.fingerprint),
+        dedup_count: retry.dedup_count,
+        last_inject_at_unix_micros: instant_to_unix_micros(retry.last_inject_at),
+        dedup_audit_emitted: retry.dedup_audit_emitted,
+        retry_count: retry.retry_count,
+        exhausted: retry.exhausted,
+        input_text: retry.input_text.clone(),
+    };
+    let bytes = match serde_json::to_vec_pretty(&on_disk) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(error = %e, agent = %agent, "dedup_state: serialize failed");
+            return;
+        }
+    };
+    let path = ledger_path(home, agent);
+    if let Err(e) = crate::store::atomic_write(&path, &bytes) {
+        tracing::warn!(error = %e, agent = %agent, "dedup_state: atomic_write failed");
+    }
+}
+
+/// Remove the persisted ledger for an agent. Called when the
+/// supervisor sees the agent recover (Ready / Idle) — the
+/// in-memory `retry_tracks` entry is dropped, so the disk file
+/// must follow. Idempotent on missing file.
+pub(crate) fn clear(home: &Path, agent: &str) {
+    let path = ledger_path(home, agent);
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            tracing::warn!(error = %e, agent = %agent, "dedup_state: clear failed");
+        }
+    }
+}
+
+/// Hydrate the supervisor's `retry_tracks` from disk at startup.
+/// Walks `$AGEND_HOME/dedup-state/*.json`, parses each, returns
+/// the reconstructed HashMap. Per-file parse failures are logged
+/// and skipped (the rest of the dir loads normally) — corrupt or
+/// schema-mismatched files do NOT abort startup.
+pub(crate) fn load_all(home: &Path) -> HashMap<String, RateLimitRetry> {
+    let dir = home.join(DEDUP_STATE_DIR);
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return HashMap::new(),
+        Err(e) => {
+            tracing::warn!(error = %e, dir = %dir.display(), "dedup_state: load_all read_dir failed");
+            return HashMap::new();
+        }
+    };
+    let mut out: HashMap<String, RateLimitRetry> = HashMap::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, path = %path.display(), "dedup_state: read failed");
+                continue;
+            }
+        };
+        let on_disk: OnDisk = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "dedup_state: malformed JSON or schema mismatch — skipping"
+                );
+                continue;
+            }
+        };
+        if on_disk.schema_version != SCHEMA_VERSION {
+            tracing::warn!(
+                got = on_disk.schema_version,
+                expected = SCHEMA_VERSION,
+                path = %path.display(),
+                "dedup_state: unknown schema_version — skipping"
+            );
+            continue;
+        }
+        let fingerprint = match parse_fingerprint(&on_disk.fingerprint) {
+            Some(fp) => fp,
+            None => {
+                tracing::warn!(
+                    raw = %on_disk.fingerprint,
+                    path = %path.display(),
+                    "dedup_state: malformed fingerprint hex — skipping"
+                );
+                continue;
+            }
+        };
+        let last_inject_at = unix_micros_to_instant(on_disk.last_inject_at_unix_micros);
+        let retry = RateLimitRetry {
+            retry_count: on_disk.retry_count,
+            // next_retry_at is NOT persisted — set to "due now" so the
+            // first post-load supervisor tick re-derives a fresh
+            // backoff slot via the existing scheduling code path.
+            next_retry_at: Instant::now(),
+            input_text: on_disk.input_text,
+            exhausted: on_disk.exhausted,
+            fingerprint,
+            dedup_count: on_disk.dedup_count,
+            last_inject_at,
+            dedup_audit_emitted: on_disk.dedup_audit_emitted,
+        };
+        out.insert(on_disk.agent, retry);
+    }
+    out
+}
+
+/// Parse the on-disk fingerprint string (`"0x{:016x}"`) back to u64.
+fn parse_fingerprint(raw: &str) -> Option<u64> {
+    let stripped = raw.strip_prefix("0x").unwrap_or(raw);
+    u64::from_str_radix(stripped, 16).ok()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::daemon::supervisor::{fingerprint_input, RateLimitRetry};
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-dedup-state-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn make_retry(text: &str, dedup_count: u32) -> RateLimitRetry {
+        RateLimitRetry {
+            retry_count: 2,
+            next_retry_at: Instant::now() + Duration::from_secs(15),
+            input_text: text.to_string(),
+            exhausted: false,
+            fingerprint: fingerprint_input(text),
+            dedup_count,
+            last_inject_at: Instant::now(),
+            dedup_audit_emitted: dedup_count >= NOTIFICATION_DEDUP_CAP_TEST,
+        }
+    }
+
+    // Mirror the supervisor's NOTIFICATION_DEDUP_CAP without making
+    // it pub — keeps the test independent of any pub-cap renames.
+    const NOTIFICATION_DEDUP_CAP_TEST: u32 = 1;
+
+    #[test]
+    fn dedup_ledger_persists_to_disk_on_mutation() {
+        let home = tmp_home("persist-on-mutation");
+        let retry = make_retry("hello world", 1);
+
+        save(&home, "dev", &retry);
+
+        let path = ledger_path(&home, "dev");
+        assert!(path.exists(), "save must create the per-agent file");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(parsed["agent"], "dev");
+        assert_eq!(parsed["dedup_count"], 1);
+        assert_eq!(parsed["schema_version"], SCHEMA_VERSION);
+        assert!(
+            parsed["fingerprint"].as_str().unwrap().starts_with("0x"),
+            "fingerprint must serialize as 0x-prefixed hex"
+        );
+        assert_eq!(parsed["input_text"], "hello world");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn dedup_ledger_loads_on_supervisor_startup() {
+        let home = tmp_home("load-on-startup");
+        let original = make_retry("operator typed this", 0);
+
+        save(&home, "dev", &original);
+        save(&home, "lead", &make_retry("different fingerprint", 1));
+
+        let loaded = load_all(&home);
+
+        assert_eq!(loaded.len(), 2, "both agents must be loaded");
+        let dev = loaded.get("dev").expect("dev present");
+        assert_eq!(dev.dedup_count, 0);
+        assert_eq!(dev.fingerprint, fingerprint_input("operator typed this"));
+        assert_eq!(dev.input_text, "operator typed this");
+        assert_eq!(dev.retry_count, 2);
+        let lead = loaded.get("lead").expect("lead present");
+        assert_eq!(lead.dedup_count, 1);
+        assert_eq!(lead.fingerprint, fingerprint_input("different fingerprint"));
+        assert!(
+            lead.dedup_audit_emitted,
+            "audit-emitted flag must round-trip"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn dedup_ledger_handles_missing_file_gracefully() {
+        // No save called — load on a fresh dir must return empty
+        // without erroring or creating any state.
+        let home = tmp_home("missing-file");
+
+        let loaded = load_all(&home);
+        assert!(loaded.is_empty(), "empty home must yield empty ledger");
+
+        // Also: clear on a missing file must be a no-op (no panic,
+        // no error log noise).
+        clear(&home, "nonexistent-agent");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn dedup_ledger_handles_corrupt_file_gracefully() {
+        // A garbage file in the dir must NOT abort load_all — the
+        // rest of the directory must still load normally. This is
+        // the load-bearing "daemon doesn't crash on bad disk
+        // state" invariant.
+        let home = tmp_home("corrupt-file");
+        let dir = home.join(DEDUP_STATE_DIR);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Plant: a valid entry + a malformed-JSON entry + a
+        // schema-mismatched entry + a non-JSON file (should be
+        // ignored by extension filter).
+        save(&home, "good", &make_retry("ok", 0));
+        std::fs::write(dir.join("garbage.json"), b"not-json-at-all").unwrap();
+        std::fs::write(
+            dir.join("bad-schema.json"),
+            br#"{"schema_version": 999, "agent": "x"}"#,
+        )
+        .unwrap();
+        std::fs::write(dir.join("ignored.txt"), b"text file").unwrap();
+
+        let loaded = load_all(&home);
+        assert_eq!(
+            loaded.len(),
+            1,
+            "only the well-formed entry survives, got: {loaded:?}"
+        );
+        assert!(loaded.contains_key("good"));
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn restart_within_60s_dedup_window_with_fingerprint_match_under_suppresses_correctly() {
+        // Empirical regression-proof of the latent bug Phase A RCA
+        // documented. Pre-Track-C: a daemon restart within the 60s
+        // dedup window blasted dedup_count back to 0, allowing a
+        // fresh same-fingerprint inject that should have been
+        // suppressed by the cap.
+        //
+        // Post-Track-C: the persisted ledger preserves dedup_count
+        // + fingerprint + last_inject_at across restart, so the
+        // dedup gate still suppresses correctly on the first
+        // post-load tick.
+        let home = tmp_home("restart-replay");
+
+        // Pre-restart: agent fired one inject for fingerprint F,
+        // hit dedup_count == cap, and the audit event was logged.
+        let pre_restart = make_retry("rate-limited input X", 1);
+        let original_fp = pre_restart.fingerprint;
+        save(&home, "dev", &pre_restart);
+
+        // Simulated daemon restart: new process, fresh in-memory
+        // HashMap. supervisor.run_loop calls load_all to hydrate.
+        let post_restart = load_all(&home);
+
+        let recovered = post_restart
+            .get("dev")
+            .expect("dev's ledger must round-trip");
+        assert_eq!(
+            recovered.fingerprint, original_fp,
+            "fingerprint must survive restart for the dedup gate to recognize repeat input"
+        );
+        assert_eq!(
+            recovered.dedup_count, 1,
+            "dedup_count must survive restart so the cap-1 gate fires on the next tick \
+             (without this, the latent under-suppression bug would re-arm)"
+        );
+        assert!(
+            recovered.dedup_audit_emitted,
+            "audit-emitted latch must survive restart so we don't double-fire the \
+             notification_inject_dedup_capped event"
+        );
+
+        // Window arithmetic: the recovered last_inject_at must be
+        // close enough to "the original inject time" that the
+        // supervisor's `dedup_decision` still sees the window as
+        // open. We can't compare Instants across processes
+        // exactly, but we can verify the elapsed duration is
+        // under the dedup window (60s).
+        let elapsed = recovered.last_inject_at.elapsed();
+        assert!(
+            elapsed.as_secs() < 60,
+            "last_inject_at must be reconstructed within the dedup window \
+             (got elapsed={elapsed:?}); restart-and-load happened immediately"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn concurrent_writes_atomic_or_serialized() {
+        // The supervisor is single-threaded, but the on-disk
+        // semantics must still tolerate the rename-based atomic
+        // write under repeated rapid succession. Pin: 5 saves in a
+        // row never leave the file in a half-written state. Each
+        // load_all must see the LAST save's content.
+        let home = tmp_home("concurrent-saves");
+
+        for i in 0..5_u32 {
+            save(&home, "dev", &make_retry(&format!("input-{i}"), i));
+        }
+
+        let loaded = load_all(&home);
+        let dev = loaded.get("dev").expect("final state must be readable");
+        assert_eq!(dev.dedup_count, 4, "last save must be the final state");
+        assert_eq!(dev.input_text, "input-4");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn dedup_state_directory_created_lazily() {
+        // First save against a home that has no `dedup-state/`
+        // subdir must create the dir and the file. Operators that
+        // never hit a rate-limit episode never have the dir
+        // created at all (no overhead for the steady state).
+        let home = tmp_home("lazy-dir");
+        let dir = home.join(DEDUP_STATE_DIR);
+        assert!(!dir.exists(), "pre: dir must not exist before save");
+
+        save(&home, "dev", &make_retry("first", 0));
+
+        assert!(dir.exists(), "save must create the dir lazily");
+        assert!(ledger_path(&home, "dev").exists());
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ----- Bonus pins (defensive, dev-judgement) -----
+
+    #[test]
+    fn instant_to_unix_micros_roundtrip_preserves_window_arithmetic() {
+        // Pin the cross-process time math: a known Instant
+        // round-tripped through Unix-micros and back must survive
+        // within a small slack (~milliseconds, dominated by
+        // SystemTime::now() jitter between the two reads).
+        let original = Instant::now();
+        let unix = instant_to_unix_micros(original);
+        let recovered = unix_micros_to_instant(unix);
+
+        // |original - recovered| should be small.
+        let drift = if recovered >= original {
+            recovered.duration_since(original)
+        } else {
+            original.duration_since(recovered)
+        };
+        assert!(
+            drift < Duration::from_secs(1),
+            "round-trip drift exceeded 1s: {drift:?}"
+        );
+    }
+
+    #[test]
+    fn fingerprint_hex_round_trips_full_u64_range() {
+        // Pin: edge-case fingerprints (0, u64::MAX, sign-bit
+        // boundaries) survive the hex round-trip without precision
+        // loss. JSON's number type can't hold u64::MAX safely, so
+        // we serialize as hex string — this test is the
+        // regression-proof anchor for that choice.
+        for &fp in &[
+            0u64,
+            1,
+            u64::MAX,
+            0x8000_0000_0000_0000_u64,
+            0xdead_beef_cafe_babe_u64,
+        ] {
+            let s = format!("0x{fp:016x}");
+            let parsed = parse_fingerprint(&s).expect("must parse");
+            assert_eq!(parsed, fp, "round-trip lost precision for 0x{fp:016x}");
+        }
+    }
+
+    #[test]
+    fn clear_removes_only_the_targeted_agent() {
+        // Defensive: clear on agent X must NOT touch agent Y's
+        // file. Closes the bug class where a string-prefix-match
+        // path computation could remove sibling agents'
+        // state.
+        let home = tmp_home("clear-targeted");
+        save(&home, "dev", &make_retry("dev-input", 0));
+        save(&home, "dev2", &make_retry("dev2-input", 0));
+        save(&home, "lead", &make_retry("lead-input", 0));
+
+        clear(&home, "dev");
+
+        let loaded = load_all(&home);
+        assert!(!loaded.contains_key("dev"), "dev must be cleared");
+        assert!(
+            loaded.contains_key("dev2"),
+            "dev2 must NOT be touched (prefix collision check)"
+        );
+        assert!(loaded.contains_key("lead"), "unrelated agent must survive");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn save_overwrites_in_place_on_repeat() {
+        // Idempotency: calling save twice with different content
+        // for the same agent results in the LATEST content on
+        // disk (atomic_write is overwrite-in-place semantics).
+        let home = tmp_home("overwrite-in-place");
+
+        save(&home, "dev", &make_retry("v1", 0));
+        save(&home, "dev", &make_retry("v2-different", 1));
+
+        let loaded = load_all(&home);
+        let dev = loaded.get("dev").unwrap();
+        assert_eq!(dev.input_text, "v2-different");
+        assert_eq!(dev.dedup_count, 1);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -3,6 +3,7 @@
 
 pub(crate) mod ci_watch;
 pub(crate) mod cron_tick;
+pub(crate) mod dedup_state;
 pub(crate) mod heartbeat_pair;
 pub(crate) mod legacy_backfill;
 pub(crate) mod lifecycle;

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -182,7 +182,21 @@ pub fn spawn(home: PathBuf, registry: AgentRegistry) {
 
 fn run_loop(home: PathBuf, registry: AgentRegistry) {
     let mut notify_tracks: HashMap<String, NotifyTrack> = HashMap::new();
-    let mut retry_tracks: HashMap<String, RateLimitRetry> = HashMap::new();
+    // Sprint 57 Wave 2 Track C (#546 Item 5): hydrate dedup ledger
+    // from `$AGEND_HOME/dedup-state/*.json` so a daemon restart
+    // inside the 60s dedup window with a same-fingerprint repeat
+    // doesn't under-suppress (the latent bug Phase A RCA #549
+    // documented). Missing dir / corrupt files / schema mismatches
+    // are best-effort skipped — daemon startup never aborts on
+    // bad disk state for this surface.
+    let mut retry_tracks: HashMap<String, RateLimitRetry> =
+        crate::daemon::dedup_state::load_all(&home);
+    if !retry_tracks.is_empty() {
+        tracing::info!(
+            count = retry_tracks.len(),
+            "supervisor: hydrated rate-limit dedup ledger from disk"
+        );
+    }
     let mut pane_input_tracks: HashMap<String, PaneInputTrack> = HashMap::new();
     loop {
         thread::sleep(TICK);
@@ -562,30 +576,37 @@ pub(crate) fn process_server_rate_limit_retries(
                 let delay = Duration::from_secs(SERVER_RATE_LIMIT_BACKOFF[0]);
                 tracing::info!(agent = %name, delay_secs = delay.as_secs(), "ServerRateLimit detected, scheduling retry");
                 let fingerprint = fingerprint_input(&input_text);
-                retry_tracks.insert(
-                    name.clone(),
-                    RateLimitRetry {
-                        retry_count: 0,
-                        next_retry_at: now + delay,
-                        input_text,
-                        exhausted: false,
-                        // Track G: phase-1 only schedules — it does not
-                        // inject. Seed `dedup_count = 0` so phase 2's
-                        // first retry can fire (preserves at least one
-                        // re-inject for the keystroke retry case);
-                        // subsequent retries hit the cap=1 boundary and
-                        // are suppressed for the inbox-class case.
-                        fingerprint,
-                        dedup_count: 0,
-                        last_inject_at: now,
-                        dedup_audit_emitted: false,
-                    },
-                );
+                let new_retry = RateLimitRetry {
+                    retry_count: 0,
+                    next_retry_at: now + delay,
+                    input_text,
+                    exhausted: false,
+                    // Track G: phase-1 only schedules — it does not
+                    // inject. Seed `dedup_count = 0` so phase 2's
+                    // first retry can fire (preserves at least one
+                    // re-inject for the keystroke retry case);
+                    // subsequent retries hit the cap=1 boundary and
+                    // are suppressed for the inbox-class case.
+                    fingerprint,
+                    dedup_count: 0,
+                    last_inject_at: now,
+                    dedup_audit_emitted: false,
+                };
+                // Sprint 57 Wave 2 Track C (#546 Item 5): persist on
+                // every mutation so a restart inside the dedup window
+                // sees the in-flight state on the next startup.
+                crate::daemon::dedup_state::save(home, name, &new_retry);
+                retry_tracks.insert(name.clone(), new_retry);
             } else if state == crate::state::AgentState::Ready
                 || state == crate::state::AgentState::Idle
             {
                 // Agent recovered — clear retry tracking.
                 if retry_tracks.remove(name).is_some() {
+                    // Sprint 57 Wave 2 Track C (#546 Item 5): mirror
+                    // in-memory removal to disk so the next startup
+                    // doesn't re-hydrate stale state for an agent
+                    // that already recovered.
+                    crate::daemon::dedup_state::clear(home, name);
                     tracing::info!(agent = %name, "ServerRateLimit retry cleared (agent recovered)");
                 }
             }
@@ -652,6 +673,10 @@ pub(crate) fn process_server_rate_limit_retries(
                 let idx = (retry.retry_count as usize).min(SERVER_RATE_LIMIT_BACKOFF.len() - 1);
                 retry.next_retry_at =
                     Instant::now() + Duration::from_secs(SERVER_RATE_LIMIT_BACKOFF[idx]);
+                // Sprint 57 Wave 2 Track C (#546 Item 5): persist
+                // post-suppress so the `dedup_audit_emitted` latch +
+                // `dedup_count` cap-state survive restart.
+                crate::daemon::dedup_state::save(home, name, retry);
                 continue;
             }
             DedupDecision::ForceFreshContent => {
@@ -687,6 +712,10 @@ pub(crate) fn process_server_rate_limit_retries(
                 &format!("gave up after {} retries", SERVER_RATE_LIMIT_MAX_RETRIES),
             );
             retry.exhausted = true;
+            // Sprint 57 Wave 2 Track C (#546 Item 5): persist the
+            // exhausted flag so a restart doesn't re-arm a track
+            // that gave up.
+            crate::daemon::dedup_state::save(home, name, retry);
             continue;
         }
 
@@ -723,9 +752,17 @@ pub(crate) fn process_server_rate_limit_retries(
             let idx = (retry.retry_count as usize).min(SERVER_RATE_LIMIT_BACKOFF.len() - 1);
             retry.next_retry_at =
                 Instant::now() + Duration::from_secs(SERVER_RATE_LIMIT_BACKOFF[idx]);
+            // Sprint 57 Wave 2 Track C (#546 Item 5): persist
+            // post-inject so a restart sees the updated
+            // dedup_count + last_inject_at and the dedup window
+            // calculation stays consistent.
+            crate::daemon::dedup_state::save(home, name, retry);
         } else {
             tracing::warn!(agent = %name, "ServerRateLimit: re-inject failed (agent gone?)");
             retry.exhausted = true;
+            // Sprint 57 Wave 2 Track C (#546 Item 5): persist
+            // exhausted-on-failure too.
+            crate::daemon::dedup_state::save(home, name, retry);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes the latent dedup under-suppression bug Phase A RCA [#549](https://github.com/suzuke/agend-terminal/pull/549) audited: a daemon restart inside the 60s dedup window with a same-fingerprint repeat re-armed `dedup_count` to 0, allowing a fresh inject the cap-1 gate should have suppressed. Per Phase A Option A (pragmatic) + lead Wave 2 Track C dispatch `m-20260508174059070082-63`. **Tier-2 dual review** per dev-recommended persistence-design caution. Path A standard.

## Mechanism

New module `src/daemon/dedup_state.rs` (~370 LOC + ~250 LOC tests) — single-file persistence layer for `RateLimitRetry`:

- `save(home, agent, retry)` — atomic-write per-agent JSON via `crate::store::atomic_write`
- `load_all(home) -> HashMap<…>` — walks `dedup-state/*.json`, returns supervisor-ready map
- `clear(home, agent)` — removes file on Ready/Idle recovery
- `ledger_path(home, agent)` — single source of truth for layout

Schema v1: `schema_version`, `agent`, `fingerprint` (hex string for full u64 range), `dedup_count`, `last_inject_at_unix_micros`, `dedup_audit_emitted`, `retry_count`, `exhausted`, `input_text`. `schema_version` mismatches are skipped, not auto-migrated; future bumps need explicit migration.

## Time-field semantics (Tier-2 review focus)

`Instant` (monotonic, anchored to process boot) cannot be serialized across restart. Persisted as `SystemTime` Unix micros and reconstructed on load by subtracting elapsed wall time from `Instant::now()`. Clock skew fails open (returns `Instant::now()`, treats window as just-persisted — favours allowing retries over suppressing them).

`next_retry_at` intentionally NOT persisted — set to `Instant::now()` on load so the supervisor's existing `SERVER_RATE_LIMIT_BACKOFF` scheduling re-derives a fresh slot. Avoids coupling persistence to the backoff schedule.

## Atomic-write semantics (Tier-2 review focus)

`atomic_write` is write-tmp + rename. The supervisor is single-threaded (one `run_loop` thread → no concurrent-writer race within the daemon process). Across daemon restarts, rename atomicity is the load-bearing guarantee — a crash mid-save leaves either previous content fully intact or new content fully written. Pinned by `concurrent_writes_atomic_or_serialized` (5 rapid saves → final state is the latest).

## Failure modes (Tier-2 review focus)

| Failure | Behaviour | Test |
|---------|-----------|------|
| Missing `dedup-state/` dir | Empty HashMap, lazy-create on first save | `dedup_state_directory_created_lazily` |
| Per-file read error | Skip + log, dir continues | `dedup_ledger_handles_corrupt_file_gracefully` |
| Malformed JSON | Skip + log | same |
| Schema mismatch | Skip + log | same |
| Save: `create_dir_all` fail | Log, supervisor continues with in-memory state | n/a (filesystem error path) |
| Save: serialize fail | Log, no overwrite | n/a (impossible on this struct shape) |
| Save: atomic_write fail | Log, supervisor continues | n/a (filesystem error path) |
| Clear on missing file | No-op | `dedup_ledger_handles_missing_file_gracefully` |

## Wiring

`supervisor::run_loop` calls `load_all(&home)` once at startup to hydrate `retry_tracks`. `process_server_rate_limit_retries` calls `save` after every mutation:

- New ServerRateLimit detected → schedule retry → save
- Suppress arm (audit-emitted latch + advanced `next_retry_at`) → save
- Exhaustion (max-retries reached) → exhausted=true → save
- Successful inject (dedup_count++, last_inject_at refreshed) → save
- Failed inject → exhausted=true → save

Recovery (Ready/Idle) clears both in-memory + on-disk via `dedup_state::clear`.

## Test plan (lead-spec + 4 defensive bonus)

7 lead-spec tests + 4 defensive bonus pins, all green:

- [x] `dedup_ledger_persists_to_disk_on_mutation` (lead spec)
- [x] `dedup_ledger_loads_on_supervisor_startup` (lead spec)
- [x] `dedup_ledger_handles_missing_file_gracefully` (lead spec)
- [x] `dedup_ledger_handles_corrupt_file_gracefully` (lead spec — malformed JSON + schema mismatch + ignored non-JSON files)
- [x] `restart_within_60s_dedup_window_with_fingerprint_match_under_suppresses_correctly` (lead spec — empirical regression-proof of the latent bug)
- [x] `concurrent_writes_atomic_or_serialized` (lead spec — write race protection)
- [x] `dedup_state_directory_created_lazily` (lead spec — no-overhead steady state)
- [x] `instant_to_unix_micros_roundtrip_preserves_window_arithmetic` (bonus — cross-process time-math pin)
- [x] `fingerprint_hex_round_trips_full_u64_range` (bonus — u64::MAX precision pin)
- [x] `clear_removes_only_the_targeted_agent` (bonus — prefix-collision regression-proof)
- [x] `save_overwrites_in_place_on_repeat` (bonus — atomic-write idempotency)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` — 1759 pass / 7 pre-existing local-only git-state flakes
- [x] All 35 pre-existing supervisor tests still green

## Files changed

- `src/daemon/dedup_state.rs` (+618 LOC new module, ~370 LOC code + ~250 LOC tests)
- `src/daemon/mod.rs` (+1 line — module declaration)
- `src/daemon/supervisor.rs` (+57/-20 LOC — load on startup + save on 5 mutation sites + clear on recovery)

## Source of truth

Branch base: `main @ 0a27c5f` (post-Wave-2-Track-D merge). Track C is sequential per Wave 2 plan — Tracks B and D both shipped before this one.

## Out of scope

- **Option B** (restart-replay-immune semantic via inbox watermark) — Sprint 58+ candidate, deferred per Phase A RCA recommendation
- Cross-agent dedup coordination
- Persistence for non-`RateLimitRetry` structures

## Refs

- Phase A RCA: PR #549 / `8843a0e` (Item 5 fix-shape table)
- Lead dispatch: `m-20260508174059070082-63`
- Phase A reviewer endorsement: 6-checklist clean PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)