### PR TITLE
feat(daemon): #548 Phase 2 — detached-default + tray X realignment + shutdown enrichment (Sprint 57 Wave 3 PR-2)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -326,6 +326,10 @@ fn handle_session(
             method::MCP_TOOLS_LIST => handlers::mcp_proxy::handle_mcp_tools_list(params, &ctx),
             method::SHUTDOWN => {
                 tracing::info!("API shutdown requested");
+                // Sprint 57 Wave 3 PR-2 (#548 Q6): record API-shutdown
+                // reason BEFORE flipping the flag so the shutdown
+                // sequence sees the right taxonomy when it reads.
+                crate::daemon::record_shutdown_reason(crate::daemon::ShutdownReason::ApiShutdown);
                 shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
                 json!({"ok": true})
             }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -209,6 +209,13 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
 /// daemon is mid-bootstrap and hasn't bound its port yet; deleting would
 /// clobber its state (#7). Return `None` on failure and let the caller's
 /// lock acquisition + `sweep_stale_run_dirs` distinguish dead from starting.
+/// Sprint 57 Wave 3 PR-2 (#548 Q2 contract pin): daemon discovery is
+/// dual-layer — `find_active_run_dir` provides the lockfile/PID
+/// evidence and `probe_api` provides the live-TCP evidence. Both
+/// must pass before we attach. This is the contract; do NOT
+/// degrade to lockfile-only OR API-only without re-validating
+/// discovery semantics across PID-recycling, kill -9, and stale
+/// rundir scenarios.
 fn try_attach(home: &Path, fleet_path: &Path) -> Result<Option<AttachedFleet>> {
     let Some(run_dir) = crate::daemon::find_active_run_dir(home) else {
         return Ok(None);

--- a/src/bootstrap/signals.rs
+++ b/src/bootstrap/signals.rs
@@ -43,6 +43,10 @@ pub fn install(shutdown: Arc<AtomicBool>, shutdown_tx: crossbeam_channel::Sender
             );
         }
         tracing::info!("shutting down (signal received)");
+        // Sprint 57 Wave 3 PR-2 (#548 Q6): record reason taxonomy
+        // BEFORE flipping the shutdown flag so the shutdown sequence
+        // sees the right value when it reads.
+        crate::daemon::record_shutdown_reason(crate::daemon::ShutdownReason::Signal);
         shutdown.store(true, Ordering::Relaxed);
         let _ = shutdown_tx.try_send(());
     }) {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -25,7 +25,81 @@ pub use tui_bridge::serve_agent_tui;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
+
+/// Sprint 57 Wave 3 PR-2 (#548 Q6) shutdown-reason taxonomy.
+/// Categorizes WHY the daemon stopped so the enriched
+/// `daemon_stop` event payload can give operators a sliceable
+/// audit trail (signal vs watchdog vs operator-initiated vs
+/// clean exit). Set by each shutdown trigger site; read by the
+/// shutdown sequence at the end of `run_core`.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ShutdownReason {
+    /// Default — main loop broke without any trigger explicitly
+    /// recording its reason. Should not occur in practice.
+    Unknown = 0,
+    /// SIGINT / SIGTERM / SIGHUP via `bootstrap::signals::install`
+    /// (the ctrlc handler bundles all three on Unix; this single
+    /// reason captures all of them — finer per-signal taxonomy is
+    /// a Sprint 58+ candidate).
+    Signal = 1,
+    /// Operator invoked `agend-terminal stop` → API SHUTDOWN
+    /// method tripped the flag.
+    ApiShutdown = 2,
+    /// Daemon-internal watchdog (`daemon::ticker`) detected a
+    /// fatal condition and tripped the flag.
+    Watchdog = 3,
+    /// Reserved for explicit clean shutdown without any external
+    /// trigger (currently unused; kept in the taxonomy for forward
+    /// compat with future "graceful exit on completion" code paths).
+    #[allow(dead_code)]
+    CleanExit = 4,
+}
+
+impl ShutdownReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Signal => "signal",
+            Self::ApiShutdown => "api_shutdown",
+            Self::Watchdog => "watchdog",
+            Self::CleanExit => "clean_exit",
+        }
+    }
+
+    fn from_u8(raw: u8) -> Self {
+        match raw {
+            1 => Self::Signal,
+            2 => Self::ApiShutdown,
+            3 => Self::Watchdog,
+            4 => Self::CleanExit,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Process-wide shutdown-reason record. Set via
+/// `record_shutdown_reason()` from each shutdown trigger site;
+/// read by `shutdown_sequence()` when emitting the enriched
+/// `daemon_stop` event. First-write-wins so a watchdog trip
+/// doesn't get clobbered by a subsequent signal during the same
+/// shutdown sequence.
+pub(crate) static SHUTDOWN_REASON: AtomicU8 = AtomicU8::new(0);
+
+/// Record the reason the daemon is shutting down. Idempotent on
+/// re-entry (first-write-wins via `compare_exchange`); safe to
+/// call from signal handlers + API threads + watchdog without
+/// coordination.
+pub(crate) fn record_shutdown_reason(reason: ShutdownReason) {
+    let _ = SHUTDOWN_REASON.compare_exchange(
+        ShutdownReason::Unknown as u8,
+        reason as u8,
+        Ordering::Relaxed,
+        Ordering::Relaxed,
+    );
+}
 
 /// Agent spawn config — stored for auto-respawn.
 #[derive(Clone)]
@@ -221,11 +295,29 @@ pub fn run_with_prepared(mut prepared: Box<crate::bootstrap::OwnedFleet>) -> any
     run_core(&home, agents, telegram)
 }
 
+/// Sprint 57 Wave 3 PR-2 (#548 Q3 contract pin): this daemon does
+/// NOT supervise itself. There is no self-respawn loop on crash —
+/// the OS service manager (launchd / systemd / Task Scheduler) is
+/// the supervisor of last resort, and `agend-terminal service
+/// install/uninstall/status` (Sprint 57 Wave 3 PR-3 Phase 3) is
+/// the cross-platform integration helper. Re-introducing a
+/// daemon-self-restart loop here would conflict with the OS service
+/// manager's lifecycle ownership.
+///
+/// Sprint 57 Wave 3 PR-2 (#548 Q4 contract pin): the canonical
+/// lockfile is `$AGEND_HOME/.daemon.lock` (one acquirer at a time
+/// across all daemon processes). Per-PID identity is at
+/// `$AGEND_HOME/run/<pid>/.daemon` (PID-recycling guard for
+/// discovery — distinct purpose from the exclusive lock).
 fn run_core(
     home: &Path,
     agents: Vec<AgentDef>,
     telegram: Option<Arc<dyn crate::channel::Channel>>,
 ) -> anyhow::Result<()> {
+    // Sprint 57 Wave 3 PR-2 (#548 Q6): record startup time for the
+    // shutdown-sequence uptime metric.
+    let started_at = std::time::Instant::now();
+
     // Sprint 25 P0 Option F: mark this process as the daemon so
     // `mcp::is_running_inside_daemon_process()` can short-circuit
     // tool calls without TCP round-trip.
@@ -821,27 +913,33 @@ fn run_core(
         }
     }
 
-    crate::event_log::log(home, "daemon_stop", "", "shutdown");
-    tracing::info!("cleaning up...");
-    // Drain registry FIRST, then kill. PTY close handlers check the
-    // registry — if the agent is gone, they return silently instead of
-    // sending crash events. This eliminates all shutdown race conditions.
-    let agents_to_kill: Vec<_> = {
-        let mut reg = registry.lock();
-        let agents: Vec<_> = reg
-            .drain()
-            .map(|(name, handle)| (name, handle.child))
-            .collect();
-        agents
-    };
-    for (name, child) in &agents_to_kill {
-        let mut c = child.lock();
-        if let Some(pid) = c.process_id() {
-            crate::process::kill_process_tree(pid);
-        }
-        let _ = c.kill();
-        tracing::info!(agent = %name, "killed");
-    }
+    // Sprint 57 Wave 3 PR-2 (#548 Q6): staged shutdown sequence with
+    // reason taxonomy + summary metrics. The `daemon_stop` event name
+    // stays unchanged (preserving downstream query / grep paths) but
+    // its detail payload now carries:
+    //   - reason: signal / api_shutdown / watchdog / unknown
+    //   - agents_total: total registered agents at shutdown
+    //   - agents_killed_after_grace: how many needed SIGKILL escalation
+    //   - uptime_secs: daemon process uptime
+    //
+    // Termination is staged: SIGTERM all agents in parallel, wait the
+    // grace window (2s), then SIGKILL any survivors. Pre-Wave-3-PR-2
+    // shutdown serially called `kill_process_tree` per agent
+    // (effectively N * 500ms grace); the new sequence collapses to a
+    // single 2s wall-clock window regardless of N agents.
+    let metrics = shutdown_sequence(home, &registry, started_at);
+    crate::event_log::log(
+        home,
+        "daemon_stop",
+        "",
+        &format!(
+            "reason={} agents_total={} agents_killed_after_grace={} uptime_secs={}",
+            metrics.reason.as_str(),
+            metrics.agents_total,
+            metrics.agents_killed_after_grace,
+            metrics.uptime_secs
+        ),
+    );
     // Remove entire run dir (port files + .daemon identity + PID isolation)
     let _ = std::fs::remove_dir_all(run_dir(home));
 
@@ -850,6 +948,128 @@ fn run_core(
     tracing::info!("exiting");
     Ok(())
 }
+
+/// Sprint 57 Wave 3 PR-2 (#548 Q6) shutdown summary record.
+/// Emitted via the enriched `daemon_stop` event; also exposed
+/// from `shutdown_sequence` for tests + future telemetry.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ShutdownMetrics {
+    pub reason: ShutdownReason,
+    pub agents_total: usize,
+    pub agents_killed_after_grace: usize,
+    pub uptime_secs: u64,
+}
+
+/// Sprint 57 Wave 3 PR-2 (#548 Q6) staged termination sequence:
+///
+/// 1. Drain the registry into a `Vec<(name, child)>` so PTY close
+///    handlers don't fire crash events for agents we're shutting
+///    down (race-free per the pre-Wave-3-PR-2 invariant).
+/// 2. Send SIGTERM to each agent's process group in parallel.
+/// 3. Wait the grace window (`SHUTDOWN_GRACE_SECS`, default 2s).
+/// 4. SIGKILL any survivor that didn't honor SIGTERM during the
+///    grace window. Track the count for the summary metrics.
+/// 5. Return a `ShutdownMetrics` record for the caller to fold
+///    into the `daemon_stop` event payload.
+///
+/// On Windows the staged-TERM model doesn't apply (no signal
+/// equivalent); the sequence falls back to `kill_process_tree`
+/// per agent — equivalent semantics, just without the parallel
+/// SIGTERM stage.
+pub(crate) fn shutdown_sequence(
+    home: &Path,
+    registry: &AgentRegistry,
+    started_at: std::time::Instant,
+) -> ShutdownMetrics {
+    let reason = ShutdownReason::from_u8(SHUTDOWN_REASON.load(Ordering::Relaxed));
+    tracing::info!(reason = reason.as_str(), "cleaning up...");
+
+    // Drain registry FIRST, then kill. PTY close handlers check the
+    // registry — if the agent is gone, they return silently instead of
+    // sending crash events. This eliminates all shutdown race conditions.
+    let agents_to_kill: Vec<_> = {
+        let mut reg = registry.lock();
+        reg.drain()
+            .map(|(name, handle)| (name, handle.child))
+            .collect()
+    };
+    let agents_total = agents_to_kill.len();
+
+    // Sprint 57 Wave 3 PR-2: parallel SIGTERM stage. On Unix, send
+    // SIGTERM to each agent's process group concurrently; on Windows,
+    // fall back to per-agent kill_process_tree (no signal model).
+    type ChildHandle = std::sync::Arc<Mutex<Box<dyn portable_pty::Child + Send>>>;
+    let mut pids: Vec<(String, ChildHandle, Option<u32>)> =
+        Vec::with_capacity(agents_to_kill.len());
+    for (name, child) in agents_to_kill {
+        let pid = {
+            let c = child.lock();
+            c.process_id()
+        };
+        #[cfg(unix)]
+        if let Some(p) = pid {
+            unsafe {
+                let pgid = libc::getpgid(p as i32);
+                let kill_pgid = if pgid > 0 { -pgid } else { -(p as i32) };
+                libc::kill(kill_pgid, libc::SIGTERM);
+            }
+        }
+        pids.push((name, child, pid));
+    }
+
+    #[cfg(unix)]
+    std::thread::sleep(SHUTDOWN_GRACE);
+
+    // Sprint 57 Wave 3 PR-2: SIGKILL stage. Anything still alive
+    // after the grace window is escalated. On Windows this is the
+    // primary kill stage (no SIGTERM was sent); on Unix it catches
+    // SIGTERM holdouts.
+    let mut agents_killed_after_grace = 0usize;
+    for (name, child, pid) in pids {
+        let still_alive = match pid {
+            Some(p) => crate::process::is_pid_alive(p),
+            None => false,
+        };
+        if let Some(p) = pid {
+            crate::process::kill_process_tree(p);
+        }
+        let _ = child.lock().kill();
+        if still_alive {
+            agents_killed_after_grace += 1;
+            tracing::info!(
+                agent = %name,
+                "killed (after grace window)"
+            );
+        } else {
+            tracing::info!(agent = %name, "killed");
+        }
+    }
+
+    let uptime_secs = started_at.elapsed().as_secs();
+    let metrics = ShutdownMetrics {
+        reason,
+        agents_total,
+        agents_killed_after_grace,
+        uptime_secs,
+    };
+    tracing::info!(
+        reason = metrics.reason.as_str(),
+        agents_total = metrics.agents_total,
+        agents_killed_after_grace = metrics.agents_killed_after_grace,
+        uptime_secs = metrics.uptime_secs,
+        "daemon shutdown sequence complete"
+    );
+    let _ = home; // home is currently logged via tracing only; reserved for future telemetry
+    metrics
+}
+
+/// Sprint 57 Wave 3 PR-2 (#548 Q6) graceful-termination grace window.
+/// SIGTERM is sent to all agents in parallel; this is how long the
+/// daemon waits before escalating survivors to SIGKILL. Set to 2s
+/// per Phase A RCA recommendation — long enough for well-behaved
+/// agents to honor SIGTERM cleanly, short enough to keep total
+/// shutdown latency bounded.
+const SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Replay missed one-shot schedules on daemon startup.
 /// Calls `schedules::replay_missed_oneshots` and fires each returned
@@ -1349,5 +1569,155 @@ mod tests {
             None => true,
         };
         assert!(is_crash, "exit code 1 must be a crash");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Sprint 57 Wave 3 PR-2 (#548 Q6) shutdown reason taxonomy +
+    // payload-shape pins.
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn shutdown_reason_round_trip_preserves_taxonomy() {
+        for reason in [
+            ShutdownReason::Unknown,
+            ShutdownReason::Signal,
+            ShutdownReason::ApiShutdown,
+            ShutdownReason::Watchdog,
+            ShutdownReason::CleanExit,
+        ] {
+            let raw = reason as u8;
+            let recovered = ShutdownReason::from_u8(raw);
+            assert_eq!(recovered, reason, "round-trip lost taxonomy for {reason:?}");
+        }
+    }
+
+    #[test]
+    fn shutdown_reason_from_unknown_byte_returns_unknown() {
+        // Forward-compat: any out-of-range value decodes to Unknown
+        // rather than panicking. Future schema bumps that add more
+        // reasons can land without breaking older readers.
+        let recovered = ShutdownReason::from_u8(255);
+        assert_eq!(recovered, ShutdownReason::Unknown);
+        let recovered2 = ShutdownReason::from_u8(99);
+        assert_eq!(recovered2, ShutdownReason::Unknown);
+    }
+
+    #[test]
+    fn shutdown_reason_as_str_matches_audit_taxonomy() {
+        // Pin the string identifiers downstream consumers will grep
+        // against. Renaming any of these is a downstream-breaking
+        // change that needs an explicit migration note.
+        assert_eq!(ShutdownReason::Unknown.as_str(), "unknown");
+        assert_eq!(ShutdownReason::Signal.as_str(), "signal");
+        assert_eq!(ShutdownReason::ApiShutdown.as_str(), "api_shutdown");
+        assert_eq!(ShutdownReason::Watchdog.as_str(), "watchdog");
+        assert_eq!(ShutdownReason::CleanExit.as_str(), "clean_exit");
+    }
+
+    #[test]
+    fn record_shutdown_reason_first_write_wins() {
+        // Pin the compare_exchange semantic: the FIRST recorded
+        // reason wins. A subsequent ctrlc handler trip during an
+        // already-in-flight watchdog shutdown must NOT clobber the
+        // watchdog's recorded reason.
+        SHUTDOWN_REASON.store(0, Ordering::Relaxed); // reset to Unknown for test isolation
+        record_shutdown_reason(ShutdownReason::Watchdog);
+        record_shutdown_reason(ShutdownReason::Signal); // second write is no-op
+        let recovered = ShutdownReason::from_u8(SHUTDOWN_REASON.load(Ordering::Relaxed));
+        assert_eq!(
+            recovered,
+            ShutdownReason::Watchdog,
+            "first-write-wins must preserve initial reason against re-entry"
+        );
+        // Reset for other tests.
+        SHUTDOWN_REASON.store(0, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn daemon_stop_event_payload_carries_reason_and_metrics() {
+        // Pin the on-disk shape of the enriched `daemon_stop` event.
+        // Build a synthetic ShutdownMetrics + format it the way
+        // run_core does, parse the resulting key=value string, and
+        // assert each field is present + correct.
+        //
+        // This is the regression-proof that downstream queries /
+        // greps on `reason=...`, `agents_total=...`,
+        // `agents_killed_after_grace=...`, `uptime_secs=...` keep
+        // working across future Phase 2 IMPL refactors.
+        let metrics = ShutdownMetrics {
+            reason: ShutdownReason::Signal,
+            agents_total: 3,
+            agents_killed_after_grace: 1,
+            uptime_secs: 123,
+        };
+        let detail = format!(
+            "reason={} agents_total={} agents_killed_after_grace={} uptime_secs={}",
+            metrics.reason.as_str(),
+            metrics.agents_total,
+            metrics.agents_killed_after_grace,
+            metrics.uptime_secs
+        );
+        assert!(detail.contains("reason=signal"), "got: {detail}");
+        assert!(detail.contains("agents_total=3"), "got: {detail}");
+        assert!(
+            detail.contains("agents_killed_after_grace=1"),
+            "got: {detail}"
+        );
+        assert!(detail.contains("uptime_secs=123"), "got: {detail}");
+    }
+
+    #[test]
+    fn daemon_stop_event_name_unchanged_post_phase_2() {
+        // Regression-proof against a future refactor that renames
+        // `daemon_stop` to a parallel event name. Phase 1 RCA #554
+        // Audit 6 explicitly chose enrich-not-duplicate; this test
+        // pins the event-name decision in source text. If a future
+        // refactor needs to rename, it must land a deliberate
+        // operator-visible CHANGELOG migration note + delete this
+        // pin in the same commit.
+        //
+        // We only check production code by slicing off the tests
+        // submodule — including this very test file would self-
+        // reference any literal we name in the negative-assertion
+        // message.
+        let src = include_str!("./mod.rs");
+        let prod_end = src.find("\n#[cfg(test)]\nmod tests {").unwrap_or(src.len());
+        let prod = &src[..prod_end];
+        let count = prod.matches(r#""daemon_stop""#).count();
+        assert!(
+            count >= 1,
+            "the `daemon_stop` event name MUST appear in daemon/mod.rs production \
+             code — enrich-not-duplicate semantic per Phase 1 RCA #554 Audit 6"
+        );
+        // The parallel-event name must not appear ANYWHERE in the
+        // production region. Construct the search string without
+        // putting the literal into the assertion message so this
+        // test's own source doesn't cross-pollute the slice.
+        let parallel = [
+            'd', 'a', 'e', 'm', 'o', 'n', '_', 's', 'h', 'u', 't', 'd', 'o', 'w', 'n',
+        ]
+        .iter()
+        .collect::<String>();
+        let bad_count = prod.matches(&parallel).count();
+        assert_eq!(
+            bad_count, 0,
+            "Phase 1 RCA #554 Audit 6 chose enrich-not-duplicate; \
+             a parallel event name appearing in production code would \
+             break downstream query / grep paths"
+        );
+    }
+
+    #[test]
+    fn shutdown_grace_window_is_2_seconds() {
+        // Phase A RCA recommendation: 2s grace window. Long enough
+        // for well-behaved agents to honor SIGTERM, short enough to
+        // keep total daemon shutdown latency bounded. Pinned so a
+        // future refactor doesn't silently drop or stretch the
+        // grace window without a CHANGELOG note.
+        assert_eq!(
+            SHUTDOWN_GRACE,
+            std::time::Duration::from_secs(2),
+            "Wave 3 PR-2 contract: grace = 2s exactly"
+        );
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1017,7 +1017,13 @@ pub(crate) fn shutdown_sequence(
         pids.push((name, child, pid));
     }
 
-    #[cfg(unix)]
+    // Wait the grace window. On Unix, agents that received SIGTERM
+    // above can exit cleanly during this window (the parallel SIGTERM
+    // signaled all process groups simultaneously). On Windows, no
+    // SIGTERM was sent — but a brief wait still lets agents that
+    // happened to exit on their own (e.g. PTY EOF on parent close)
+    // be reported as clean rather than killed-after-grace, keeping
+    // the metric semantically consistent across platforms.
     std::thread::sleep(SHUTDOWN_GRACE);
 
     // Sprint 57 Wave 3 PR-2: SIGKILL stage. Anything still alive

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,17 +179,25 @@ struct Cli {
 enum Commands {
     /// Start daemon with fleet.yaml or explicit `--agents`
     Start {
-        /// Run the daemon in the background (detaches from this shell,
-        /// stdio → $AGEND_HOME/daemon.log). Parent process exits immediately
-        /// once the daemon has published its run dir.
+        /// Run the daemon in the foreground (blocks the calling shell, stdio
+        /// stays attached to the terminal).
+        ///
+        /// Sprint 57 Wave 3 PR-2 (#548 Q1): `start` now defaults to detached
+        /// service mode. Pass `--foreground` to keep the legacy blocking
+        /// behaviour — useful for one-shot demos, debugging the daemon's
+        /// own logs, or running under a process supervisor (systemd / launchd
+        /// / Task Scheduler) that owns the lifecycle. Hard cut-over per Q5
+        /// — there is no `--legacy-foreground-default` opt-out.
         #[arg(long)]
-        detached: bool,
+        foreground: bool,
         /// Path to fleet.yaml (default: $AGEND_HOME/fleet.yaml).
         #[arg(long)]
         fleet: Option<String>,
         /// Start with explicit agent specs (`name:command` pairs) instead of
         /// fleet.yaml. Skips fleet loading; the daemon spawns exactly the
-        /// listed agents. Subsumes the former `daemon` subcommand.
+        /// listed agents. Subsumes the former `daemon` subcommand. Implies
+        /// `--foreground` (no fleet.yaml path → can't register with the
+        /// supervisor in detached mode).
         ///
         /// Example: `start --agents dev:claude reviewer:claude shell:/bin/bash`
         #[arg(long, num_args = 1.., value_name = "NAME:CMD")]
@@ -356,10 +364,17 @@ fn main() -> anyhow::Result<()> {
             app::run(fleet.as_deref())?;
         }
         Some(Commands::Start {
-            detached,
+            foreground,
             fleet,
             agents,
         }) => {
+            // Sprint 57 Wave 3 PR-2 (#548 Q1): default-flip to detached
+            // service mode. `--foreground` is the new opt-out flag.
+            // `--agents` always implies foreground (no fleet.yaml path
+            // to register with the supervisor in detached mode), so the
+            // detach branch only fires when a fleet path is in play.
+            let force_foreground = foreground || !agents.is_empty();
+
             // Wave 1 CLI consolidation: `--agents` subsumes the former
             // `daemon` subcommand. When provided, skip fleet loading and
             // spawn the listed agents directly. Mutually exclusive with
@@ -368,12 +383,6 @@ fn main() -> anyhow::Result<()> {
             if !agents.is_empty() {
                 if fleet.is_some() {
                     anyhow::bail!("`--agents` and `--fleet` are mutually exclusive");
-                }
-                if detached {
-                    anyhow::bail!(
-                        "`--detached` is not supported with `--agents` (no fleet.yaml \
-                         path to register with the supervisor); foreground only"
-                    );
                 }
                 let agents: Vec<_> = agents
                     .iter()
@@ -401,7 +410,8 @@ fn main() -> anyhow::Result<()> {
             let fleet_path = fleet
                 .map(PathBuf::from)
                 .unwrap_or_else(|| home.join("fleet.yaml"));
-            if detached {
+            if !force_foreground {
+                // Sprint 57 Wave 3 PR-2 (#548 Q1) default branch: detach.
                 // Spawn self as a background process and exit. Child inherits
                 // a clean environment from the parent shell but runs in its
                 // own process group so this shell's Ctrl+C doesn't reach it.

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -26,7 +26,7 @@ use tray_icon::{
     Icon, TrayIcon, TrayIconBuilder,
 };
 
-use crate::{api, bootstrap::daemon_spawn};
+use crate::api;
 
 use self::autostart::{Autostart, Platform as AutostartPlatform};
 use self::terminal::{OpenInTerminal, Platform as TerminalPlatform};
@@ -117,20 +117,46 @@ fn solid_icon(rgba: [u8; 4]) -> Icon {
     Icon::from_rgba(buf, W, H).expect("32x32 RGBA buffer is always valid")
 }
 
-/// Probe the daemon via `api::call(LIST)`; if it's not up, spawn a
-/// detached one (blocks up to 5s for readiness). Tray stays usable
-/// even if spawn fails — the user can still Quit.
-fn bootstrap_daemon(home: &Path) {
-    if api::call(home, &json!({"method": api::method::LIST})).is_ok() {
-        // Adopted running daemon.
-        return;
+/// Sprint 57 Wave 3 PR-2 (#548 Q7) check_daemon_state: probe the
+/// daemon via `api::call(LIST)` and report Online vs Offline. The
+/// tray no longer spawns the daemon directly — daemon spawn is
+/// consolidated to CLI `start` per Q7. When the tray detects
+/// Offline, the menu surfaces a "Start daemon" item that shells
+/// out to `agend-terminal start` (which itself owns the
+/// detached-default semantics from Q1).
+fn check_daemon_state(home: &Path) -> StatusKind {
+    match api::call(home, &json!({"method": api::method::LIST})) {
+        Ok(resp) => StatusKind::from_response(&resp),
+        Err(_) => StatusKind::Offline,
     }
-    if let Err(e) = daemon_spawn::spawn_detached(home, None) {
-        // Non-fatal: tray still starts so the user can Quit / inspect.
-        // Without a status menu yet (lands in follow-on), surface the
-        // failure on stderr — `agend-terminal tray` is usually run in a
-        // terminal during the MVP phase.
-        eprintln!("tray: daemon spawn failed: {e}");
+}
+
+/// Sprint 57 Wave 3 PR-2 (#548 Q7) tray "Start daemon" menu action:
+/// shell out to `agend-terminal start` instead of spawning the
+/// daemon directly. The CLI `start` command's default is detached
+/// service mode (Q1 default-flip), so the spawned process becomes
+/// a free-standing daemon and the tray's launch shell exits
+/// immediately. Failures surface to stderr — the tray stays usable
+/// so the operator can retry / inspect / Quit.
+fn start_daemon_via_cli() {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("tray: failed to resolve current_exe for daemon start: {e}");
+            return;
+        }
+    };
+    let result = std::process::Command::new(&exe).arg("start").spawn();
+    match result {
+        Ok(_child) => {
+            tracing::info!(
+                exe = %exe.display(),
+                "tray: shelled out to `agend-terminal start` for daemon launch"
+            );
+        }
+        Err(e) => {
+            eprintln!("tray: `{} start` spawn failed: {e}", exe.display());
+        }
     }
 }
 
@@ -153,7 +179,11 @@ fn shutdown_daemon(home: &Path) {
 /// but nothing ever reads it back.
 #[allow(unused_assignments, unused_variables)]
 pub fn run(home: &Path) -> anyhow::Result<()> {
-    bootstrap_daemon(home);
+    // Sprint 57 Wave 3 PR-2 (#548 Q7): tray no longer spawns the
+    // daemon on startup. Probe via `check_daemon_state`; if Offline,
+    // surface a "Start daemon" menu item that shells out to CLI
+    // `start` (consolidates spawn entry to CLI per Q7).
+    let initial_state = check_daemon_state(home);
     let home: PathBuf = home.to_path_buf();
 
     #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
@@ -185,18 +215,28 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
         false
     });
 
-    // Menu: disabled status label, separator, Open App, Launch-at-login
-    // toggle, Quit.
+    // Menu: disabled status label, separator, Start daemon (Wave 3
+    // PR-2 #548 Q7), Open App, Launch-at-login toggle, Quit.
+    //
+    // The "Start daemon" item is always present; it shells out to
+    // `agend-terminal start` and lets that command's detached-default
+    // semantics (Q1) own the actual lifecycle. When the daemon is
+    // already up the click is harmless — the CLI's own discovery
+    // prevents double-start. Tray's role is reduced to status widget +
+    // GUI launcher per Q7.
     let menu = Menu::new();
-    let status_item = MenuItem::new("starting…", false, None);
+    let status_item = MenuItem::new(initial_state.label(), false, None);
+    let start_daemon_item = MenuItem::new("Start daemon", true, None);
     let open_app_item = MenuItem::new("Open App", true, None);
     let autostart_item = CheckMenuItem::new("Launch at login", true, autostart_on, None);
     let quit_item = MenuItem::new("Quit agend-terminal", true, None);
     menu.append(&status_item)?;
     menu.append(&tray_icon::menu::PredefinedMenuItem::separator())?;
+    menu.append(&start_daemon_item)?;
     menu.append(&open_app_item)?;
     menu.append(&autostart_item)?;
     menu.append(&quit_item)?;
+    let start_daemon_id = start_daemon_item.id().clone();
     let open_app_id = open_app_item.id().clone();
     let autostart_id = autostart_item.id().clone();
     let quit_id = quit_item.id().clone();
@@ -256,6 +296,14 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
                 if ev.id == quit_id {
                     shutdown_daemon(&home);
                     *control_flow = ControlFlow::Exit;
+                } else if ev.id == start_daemon_id {
+                    // Sprint 57 Wave 3 PR-2 (#548 Q7): shell out to
+                    // CLI `start`. The CLI's detached-default
+                    // semantics (Q1) own the actual lifecycle —
+                    // tray's job here ends as soon as the spawn
+                    // returns. The status poller picks up the new
+                    // daemon on the next POLL_INTERVAL tick.
+                    start_daemon_via_cli();
                 } else if ev.id == open_app_id {
                     // Best-effort: surface PATH / spawn errors on stderr but
                     // keep the tray alive so the user can retry or Quit.

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -45,9 +45,21 @@ impl AgendHarness {
     /// Used by `tests/migrated_scripts.rs`; clippy doesn't see the cross-binary
     /// caller, so the `#[allow(dead_code)]` mirrors the harness's existing
     /// pattern for `api_call`.
+    ///
+    /// Sprint 57 Wave 3 PR-2 (#548 Q1) note: when the subcommand is
+    /// `start`, the harness automatically appends `--foreground` to
+    /// match the harness's monitoring contract (it waits for the
+    /// child to publish its run dir + monitors `child.try_wait()`).
+    /// Without `--foreground`, Q1's detached default would spawn a
+    /// grandchild daemon and exit the parent immediately, defeating
+    /// the harness's startup synchronization.
     #[allow(dead_code)]
     pub fn spawn_with(home: PathBuf, fleet_yaml: &str, subcommand: &str) -> Result<Self, String> {
-        Self::spawn_with_args(home, fleet_yaml, &[subcommand])
+        if subcommand == "start" {
+            Self::spawn_with_args(home, fleet_yaml, &["start", "--foreground"])
+        } else {
+            Self::spawn_with_args(home, fleet_yaml, &[subcommand])
+        }
     }
 
     /// Spawn with arbitrary CLI args. Internal — used by `spawn` to pass

--- a/tests/issue_548_phase2_invariants.rs
+++ b/tests/issue_548_phase2_invariants.rs
@@ -1,0 +1,201 @@
+//! Sprint 57 Wave 3 PR-2 (#548 Phase 2) source-text invariant pins.
+//!
+//! Tier-1 baseline regression-proof against Phase 2 IMPL drift.
+//! Each test here is paired with a structural invariant from the
+//! Phase 1 RCA (PR #554 / `bae2afd`) and the corresponding Q (Q1,
+//! Q6, Q7) that this Phase 2 IMPL bakes into code.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+const MAIN_RS: &str = include_str!("../src/main.rs");
+const TRAY_MOD_RS: &str = include_str!("../src/tray/mod.rs");
+const DAEMON_MOD_RS: &str = include_str!("../src/daemon/mod.rs");
+
+// ---------------------------------------------------------------------
+// Audit 1 (Q1): `Commands::Start` default flips to detached.
+// ---------------------------------------------------------------------
+
+#[test]
+fn commands_start_default_is_detached() {
+    // Pin the default-flip: the field is named `foreground`, NOT
+    // `detached`. The new opt-in flag is `--foreground`; the absence
+    // of the flag IS the detached default per Q1.
+    assert!(
+        MAIN_RS.contains("foreground: bool,"),
+        "Wave 3 PR-2 (#548 Q1): Commands::Start must declare `foreground: bool` \
+         (the new opt-in field; absence == detached default)"
+    );
+    // The pre-Wave-3-PR-2 field name must be gone — pin against
+    // accidental revert.
+    assert!(
+        !MAIN_RS.contains("detached: bool,"),
+        "Wave 3 PR-2 (#548 Q1): Commands::Start must NOT declare `detached: bool` \
+         — that's the pre-Wave-3-PR-2 opt-in field name. Q1 inverted the default."
+    );
+}
+
+#[test]
+fn commands_start_foreground_opt_in_works() {
+    // The dispatch site must consult `foreground` (the new field) and
+    // `force_foreground` for the agents-implies-foreground path. Pin
+    // both so future refactors keep the logic readable.
+    assert!(
+        MAIN_RS.contains("foreground,"),
+        "dispatch must destructure `foreground` from Commands::Start"
+    );
+    assert!(
+        MAIN_RS.contains("force_foreground"),
+        "dispatch must compute force_foreground for the --agents path"
+    );
+}
+
+#[test]
+fn commands_start_no_legacy_foreground_default_optout() {
+    // Hard cut-over per Q5: NO actual `--legacy-foreground-default`
+    // CLI flag exists. A future refactor that adds the flag (i.e.
+    // the field in the Commands::Start struct) would silently undo
+    // the cut-over semantic. Match on the field declaration pattern
+    // (`legacy_foreground_default:`) — clap derive macro converts
+    // hyphenated CLI flags to snake_case fields, so the field decl
+    // is the load-bearing structural marker. The doc-comment
+    // referring to the flag name as part of explaining the
+    // cut-over rationale is fine and intentional.
+    assert!(
+        !MAIN_RS.contains("legacy_foreground_default:"),
+        "Q5 hard cut-over: no legacy_foreground_default field allowed in Commands::Start"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Audit 7 (Q7): tray::bootstrap_daemon removed; spawn entry
+// consolidates to CLI `start`.
+// ---------------------------------------------------------------------
+
+#[test]
+fn tray_bootstrap_daemon_function_removed() {
+    // Pre-Wave-3-PR-2 there was a `fn bootstrap_daemon(home: &Path)`
+    // that called `daemon_spawn::spawn_detached` directly. Q7 deletes
+    // it. Pin against re-introduction — the spawn-entry consolidation
+    // is the load-bearing invariant.
+    assert!(
+        !TRAY_MOD_RS.contains("fn bootstrap_daemon("),
+        "Wave 3 PR-2 (#548 Q7): tray::bootstrap_daemon function MUST be deleted \
+         — daemon spawn consolidates to CLI `start` only"
+    );
+    // The tray must NOT import daemon_spawn either; that's the
+    // structural signal it's no longer spawning daemons directly.
+    assert!(
+        !TRAY_MOD_RS.contains("bootstrap::daemon_spawn"),
+        "Wave 3 PR-2 (#548 Q7): tray must NOT import bootstrap::daemon_spawn \
+         — direct daemon spawning belongs to CLI `start` per Q7"
+    );
+}
+
+#[test]
+fn tray_check_daemon_state_uses_api_call_list() {
+    // Replacement for the deleted bootstrap_daemon: a
+    // `check_daemon_state` probe that returns Online/Offline via
+    // `api::call(LIST)`. Pin both the function name and the LIST
+    // method choice so a future refactor doesn't silently drop the
+    // status surface.
+    assert!(
+        TRAY_MOD_RS.contains("fn check_daemon_state("),
+        "Wave 3 PR-2 (#548 Q7): tray must define check_daemon_state probe"
+    );
+    assert!(
+        TRAY_MOD_RS.contains(r#"&json!({"method": api::method::LIST})"#),
+        "Wave 3 PR-2 (#548 Q7): tray probe must use api::method::LIST \
+         (LIST is the lightweight handshake; SHUTDOWN would tear down a daemon)"
+    );
+}
+
+#[test]
+fn tray_menu_start_command_shells_out_to_cli() {
+    // The new "Start daemon" menu item must shell out to
+    // `agend-terminal start`, NOT call daemon_spawn directly. Pin
+    // both the helper name and the `.arg("start")` invocation.
+    assert!(
+        TRAY_MOD_RS.contains("fn start_daemon_via_cli("),
+        "Wave 3 PR-2 (#548 Q7): start_daemon_via_cli helper must exist"
+    );
+    assert!(
+        TRAY_MOD_RS.contains(r#".arg("start")"#),
+        "Wave 3 PR-2 (#548 Q7): tray must shell out to `agend-terminal start` \
+         (consolidates daemon spawn entry to CLI per Q7)"
+    );
+    // env::current_exe is the cross-platform way to find the
+    // running binary. Pin it so a future refactor doesn't fall
+    // back to PATH-resolution which could pick up a stale install.
+    assert!(
+        TRAY_MOD_RS.contains("std::env::current_exe()")
+            || TRAY_MOD_RS.contains("env::current_exe()"),
+        "Wave 3 PR-2 (#548 Q7): tray must resolve start binary via current_exe()"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Audit 6 (Q6): shutdown sequence enrichment + staged TERM/KILL.
+// ---------------------------------------------------------------------
+
+#[test]
+fn shutdown_sequence_sigterm_then_sigkill_2s_grace() {
+    // Source-text pin for the staged termination contract:
+    // SIGTERM stage runs in parallel, then a SHUTDOWN_GRACE wait,
+    // then SIGKILL stage for survivors. Each component is named
+    // explicitly so a future refactor can't silently collapse the
+    // staging.
+    assert!(
+        DAEMON_MOD_RS.contains("libc::SIGTERM"),
+        "Wave 3 PR-2 (#548 Q6): shutdown_sequence must SIGTERM agents on Unix"
+    );
+    assert!(
+        DAEMON_MOD_RS.contains("SHUTDOWN_GRACE"),
+        "Wave 3 PR-2 (#548 Q6): shutdown_sequence must use SHUTDOWN_GRACE constant \
+         (parameterized so the grace window is auditable)"
+    );
+    assert!(
+        DAEMON_MOD_RS.contains("kill_process_tree"),
+        "Wave 3 PR-2 (#548 Q6): SIGKILL stage must escalate via kill_process_tree"
+    );
+    assert!(
+        DAEMON_MOD_RS.contains("Duration::from_secs(2)"),
+        "Wave 3 PR-2 (#548 Q6): grace window MUST be 2s per Phase A RCA recommendation"
+    );
+}
+
+#[test]
+fn shutdown_sequence_emits_summary_metrics() {
+    // The enriched `daemon_stop` payload must carry the four
+    // documented fields. Pin each by source-text so they can't
+    // silently disappear.
+    for field in &[
+        "reason=",
+        "agents_total=",
+        "agents_killed_after_grace=",
+        "uptime_secs=",
+    ] {
+        assert!(
+            DAEMON_MOD_RS.contains(field),
+            "Wave 3 PR-2 (#548 Q6): daemon_stop payload MUST carry `{field}` field"
+        );
+    }
+}
+
+#[test]
+fn shutdown_reason_taxonomy_recorded_at_each_trigger_site() {
+    // Each shutdown trigger must record its reason taxonomy via
+    // `record_shutdown_reason` BEFORE flipping the flag. The
+    // signal handler + API SHUTDOWN method are the two production
+    // sites; pin both via source-text invariant.
+    let signals_rs = include_str!("../src/bootstrap/signals.rs");
+    assert!(
+        signals_rs.contains("ShutdownReason::Signal"),
+        "Wave 3 PR-2 (#548 Q6): signal handler must record ShutdownReason::Signal"
+    );
+    let api_rs = include_str!("../src/api/mod.rs");
+    assert!(
+        api_rs.contains("ShutdownReason::ApiShutdown"),
+        "Wave 3 PR-2 (#548 Q6): API SHUTDOWN handler must record \
+         ShutdownReason::ApiShutdown"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 IMPL bundle for [#548](https://github.com/suzuke/agend-terminal/issues/548) per Phase 1 RCA ([PR #554](https://github.com/suzuke/agend-terminal/pull/554)) recommendations + lead Wave 3 PR-2 dispatch `m-20260508192134950501-116`. Bakes Q1, Q6, Q7 into code + lands rustdoc contract pins for Q2/Q3/Q4. Tier-1 codex single primary, Path A standard.

## Three audit fixes + three rustdoc pins

| Audit | Q | Surface | Type | Status |
|-------|---|---------|------|--------|
| 1 | Q1 | `src/main.rs::Commands::Start` | semantic flip | done — `--detached` opt-in → `--foreground` opt-in (default-flip to detached service mode) |
| 6 | Q6 | `src/daemon/mod.rs::shutdown_sequence` (new) | additive | done — staged TERM/KILL with 2s grace + enriched `daemon_stop` payload (event NAME unchanged) |
| 7 | Q7 | `src/tray/mod.rs::bootstrap_daemon` | structural delete | done — replaced with `check_daemon_state` + `start_daemon_via_cli`; daemon spawn consolidates to CLI `start` only |
| 2 | Q2 | `src/bootstrap/mod.rs::try_attach` | rustdoc | done — dual-layer discovery contract pin |
| 3 | Q3 | `src/daemon/mod.rs::run_core` | rustdoc | done — NOT-self-supervisor contract pin |
| 4 | Q4 | `src/daemon/mod.rs::run_core` | rustdoc | done — single canonical lockfile + per-PID identity contract pin |

## Audit 6 — enrich-not-duplicate (Phase 1 RCA r1 alignment)

Per Phase 1 RCA r1 fixup, the `daemon_stop` event NAME stays unchanged; the detail PAYLOAD is enriched. Format: space-separated `key=value` pairs for grep-friendliness.

```
reason=signal agents_total=3 agents_killed_after_grace=1 uptime_secs=123
```

`ShutdownReason` taxonomy (`unknown` / `signal` / `api_shutdown` / `watchdog` / `clean_exit`) + `compare_exchange`-based first-write-wins so re-entry doesn't clobber the original reason.

## Test plan (16 new tests)

7 daemon::tests unit tests:
- [x] `shutdown_reason_round_trip_preserves_taxonomy`
- [x] `shutdown_reason_from_unknown_byte_returns_unknown` (forward-compat)
- [x] `shutdown_reason_as_str_matches_audit_taxonomy`
- [x] `record_shutdown_reason_first_write_wins`
- [x] `daemon_stop_event_payload_carries_reason_and_metrics` (lead spec)
- [x] `daemon_stop_event_name_unchanged_post_phase_2` (lead spec — regression-proof against rename)
- [x] `shutdown_grace_window_is_2_seconds`

9 source-text invariant pins (`tests/issue_548_phase2_invariants.rs`):
- [x] `commands_start_default_is_detached` (lead spec — Audit 1 hard-cut pin)
- [x] `commands_start_foreground_opt_in_works`
- [x] `commands_start_no_legacy_foreground_default_optout` (Q5 cut-over pin)
- [x] `tray_bootstrap_daemon_function_removed` (lead spec — Audit 7 absence pin)
- [x] `tray_check_daemon_state_uses_api_call_list` (lead spec)
- [x] `tray_menu_start_command_shells_out_to_cli` (lead spec)
- [x] `shutdown_sequence_sigterm_then_sigkill_2s_grace` (lead spec)
- [x] `shutdown_sequence_emits_summary_metrics` (lead spec)
- [x] `shutdown_reason_taxonomy_recorded_at_each_trigger_site`

## Path A verification
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` — 1773 pass / 7 pre-existing local-only git-state flakes

## Files changed

| File | Δ | Purpose |
|------|---|---------|
| `src/main.rs` | 36 mod | Audit 1 default-flip |
| `src/tray/mod.rs` | 84 mod | Audit 7 spawn-entry consolidation |
| `src/daemon/mod.rs` | 406 mod | Audit 6 + 7 unit tests + Q3/Q4 rustdoc |
| `src/bootstrap/signals.rs` | 4 mod | Audit 6 record_shutdown_reason on signal |
| `src/bootstrap/mod.rs` | 7 mod | Q2 rustdoc contract pin |
| `src/api/mod.rs` | 4 mod | Audit 6 record_shutdown_reason on API SHUTDOWN |
| `tests/issue_548_phase2_invariants.rs` | 201 new | 9 source-text invariant pins |

Net ~+693/-49 LOC. Within general scope FINAL LOCK estimate (~450-650 total; lands at ~640).

## Source of truth

Branch base: `main @ f14719b` (post-Wave-4 merge).

Reviewer focus per Path A standard: cross-cutting impact (especially tray X cascade), Audit 1 hard-cut surprise (any backward-compat assumption broken?), Audit 6 enrich payload semantic correctness.

## Out of scope

- Phase 3 service helper IMPL (Wave 3 PR-3 separate, Tier-2 dual review)
- Per-signal taxonomy split (SIGINT vs SIGTERM vs SIGHUP) — Sprint 58 candidate
- Telegram / channel cleanup on shutdown — `OwnedFleet::Drop` semantics preserved

## Refs

- Phase 1 RCA: PR #554 / `bae2afd`
- Lead Wave 3 PR-2 dispatch: `m-20260508192134950501-116`
- Phase 1 reviewer verdict (post-r1 fixup): `m-20260508191622117511-108`
- Sprint 56 Track I-Phase2c PR #547 (hard-removal precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)