### PR TITLE
feat(send): #2 kind=task structurally requires task_id (Sprint 58 Wave 4 PR-1, engineering anti-stall)

### DIFF
--- a/src/mcp/handlers/anti_stall.rs
+++ b/src/mcp/handlers/anti_stall.rs
@@ -1,0 +1,188 @@
+//! Sprint 58 Wave 4 PR-1 (#2 engineering anti-stall): structural
+//! gate ensuring every `send kind=task` dispatch carries an explicit
+//! `task_id`. Closes the Wave 3 PR-1 dispatch protocol gap where
+//! task-board IDs and `send` calls weren't structurally tied — a
+//! lead could create a task entry but forget to dispatch with
+//! `task_id=...`, leaving the recipient with no correlation handle
+//! (incident reference: m-20260509031109840434-59 — dev idle-waited
+//! 100+ min in Wave 3 PR-1 because of this gap).
+//!
+//! Extracted from `comms.rs` to keep that file under the 700 LOC
+//! handler invariant (`tests/file_size_invariant.rs`).
+
+use serde_json::{json, Value};
+
+/// One-shot gate for the unified `send` handler: returns `Some(error
+/// json)` when `request_kind=task` and `task_id` is missing or
+/// malformed, `None` otherwise. Folding the kind check into the gate
+/// keeps the comms.rs call site a single line, which matters for the
+/// 700 LOC handler invariant (`tests/file_size_invariant.rs`).
+pub(super) fn check_kind_task_requires_task_id(args: &Value) -> Option<Value> {
+    if args["request_kind"].as_str() != Some("task") {
+        return None;
+    }
+    match validate_task_id_present(args) {
+        Ok(()) => None,
+        Err(msg) => Some(json!({"error": msg, "code": "task_id_required"})),
+    }
+}
+
+/// Returns the rejection error message on failure (with operator-
+/// actionable hint mentioning `task action=create`) so the send
+/// handler can surface it as a structured `code: "task_id_required"`
+/// response.
+pub(super) fn validate_task_id_present(args: &Value) -> Result<(), String> {
+    let task_id = args["task_id"].as_str().unwrap_or("");
+    if task_id.is_empty() {
+        return Err(
+            "send kind=task requires 'task_id' — first call task action=create to obtain a \
+             't-...' id, then send kind=task task_id=t-... (Sprint 58 Wave 4 anti-stall \
+             contract)"
+                .to_string(),
+        );
+    }
+    if !is_valid_task_id_shape(task_id) {
+        return Err(format!(
+            "send kind=task: 'task_id' value '{task_id}' has invalid shape — task_id must \
+             start with 't-' and contain only ASCII alphanumeric / hyphen / underscore \
+             characters (length 4-128). Did you mean to call task action=create first?"
+        ));
+    }
+    Ok(())
+}
+
+/// Cheap shape check for task_id strings. The auto-generated form
+/// is `t-<14-digit-timestamp>-<seq>`; operator-supplied entries
+/// can use any reasonable identifier as long as it starts with the
+/// `t-` prefix. We accept ASCII alphanumeric + `-_` after the
+/// prefix to allow operator names like `t-sprint58-wave4-pr1`.
+///
+/// Rejects: empty, missing prefix, control characters, length
+/// outside 4-128 (catches obvious typos without rejecting valid
+/// IDs).
+fn is_valid_task_id_shape(s: &str) -> bool {
+    if s.len() < 4 || s.len() > 128 {
+        return false;
+    }
+    let Some(rest) = s.strip_prefix("t-") else {
+        return false;
+    };
+    if rest.is_empty() {
+        return false;
+    }
+    rest.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn empty_task_id_rejected_with_actionable_hint() {
+        let result = validate_task_id_present(&json!({}));
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("task_id"),
+            "rejection must mention task_id: {err}"
+        );
+        assert!(
+            err.contains("task action=create"),
+            "rejection must guide caller to task action=create: {err}"
+        );
+        assert!(
+            err.contains("t-"),
+            "rejection must reference the t-... id prefix shape: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_string_task_id_rejected() {
+        let result = validate_task_id_present(&json!({"task_id": ""}));
+        assert!(result.is_err(), "empty string must be rejected");
+    }
+
+    #[test]
+    fn valid_auto_generated_task_id_accepted() {
+        let result = validate_task_id_present(&json!({"task_id": "t-20260509040842727169-9"}));
+        assert!(
+            result.is_ok(),
+            "auto-generated form must be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn valid_operator_named_task_id_accepted() {
+        let result = validate_task_id_present(&json!({"task_id": "t-sprint58-wave4-pr1"}));
+        assert!(
+            result.is_ok(),
+            "operator-named form must be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn task_id_without_t_prefix_rejected() {
+        let result = validate_task_id_present(&json!({"task_id": "no-prefix"}));
+        let err = result.unwrap_err();
+        assert!(err.contains("invalid shape"), "shape error expected: {err}");
+    }
+
+    #[test]
+    fn task_id_with_only_prefix_rejected() {
+        let result = validate_task_id_present(&json!({"task_id": "t-"}));
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("invalid shape"),
+            "empty body after prefix rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn task_id_with_whitespace_rejected() {
+        let result = validate_task_id_present(&json!({"task_id": "t-with spaces"}));
+        let err = result.unwrap_err();
+        assert!(err.contains("invalid shape"), "whitespace rejected: {err}");
+    }
+
+    #[test]
+    fn task_id_with_slash_rejected() {
+        let result = validate_task_id_present(&json!({"task_id": "t-bad/path"}));
+        let err = result.unwrap_err();
+        assert!(err.contains("invalid shape"), "slash rejected: {err}");
+    }
+
+    #[test]
+    fn task_id_too_short_rejected() {
+        let result = validate_task_id_present(&json!({"task_id": "x"}));
+        let err = result.unwrap_err();
+        // Single-character "x" is empty after prefix-strip OR fails
+        // the length check; either path lands "invalid shape".
+        assert!(err.contains("invalid shape"), "too-short rejected: {err}");
+    }
+
+    #[test]
+    fn task_id_with_underscore_accepted() {
+        // Defensive bonus: underscore allowed (operator-friendly).
+        let result = validate_task_id_present(&json!({"task_id": "t-foo_bar_baz"}));
+        assert!(result.is_ok(), "underscore must be accepted: {result:?}");
+    }
+
+    #[test]
+    fn task_id_at_length_boundary_accepted() {
+        // 128 chars total — at the upper bound.
+        let id = format!("t-{}", "a".repeat(126));
+        assert_eq!(id.len(), 128);
+        let result = validate_task_id_present(&json!({"task_id": id}));
+        assert!(result.is_ok(), "128-char boundary accepted: {result:?}");
+    }
+
+    #[test]
+    fn task_id_over_length_boundary_rejected() {
+        let id = format!("t-{}", "a".repeat(127));
+        assert_eq!(id.len(), 129);
+        let result = validate_task_id_present(&json!({"task_id": id}));
+        assert!(result.is_err(), "129-char rejected");
+    }
+}

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -5,60 +5,7 @@ use crate::identity::Sender;
 use serde_json::{json, Value};
 use std::path::Path;
 
-use super::{err_needs_identity, is_ok_result};
-
-/// Sprint 58 Wave 4 PR-1 (#2 engineering anti-stall): structural
-/// gate ensuring every `send kind=task` dispatch carries an explicit
-/// `task_id`. Closes the Wave 3 PR-1 dispatch protocol gap where
-/// task-board IDs and `send` calls weren't structurally tied — a
-/// lead could create a task entry but forget to dispatch with
-/// `task_id=...`, leaving the recipient with no correlation handle.
-///
-/// Returns the rejection error message on failure (with operator-
-/// actionable hint) so callers can surface it as a structured
-/// `code: "task_id_required"` response.
-fn validate_task_id_present(args: &Value) -> Result<(), String> {
-    let task_id = args["task_id"].as_str().unwrap_or("");
-    if task_id.is_empty() {
-        return Err(
-            "send kind=task requires 'task_id' — first call task action=create to obtain a \
-             't-...' id, then send kind=task task_id=t-... (Sprint 58 Wave 4 anti-stall \
-             contract)"
-                .to_string(),
-        );
-    }
-    if !is_valid_task_id_shape(task_id) {
-        return Err(format!(
-            "send kind=task: 'task_id' value '{task_id}' has invalid shape — task_id must \
-             start with 't-' and contain only ASCII alphanumeric / hyphen / underscore \
-             characters (length 4-128). Did you mean to call task action=create first?"
-        ));
-    }
-    Ok(())
-}
-
-/// Cheap shape check for task_id strings. The auto-generated form
-/// is `t-<14-digit-timestamp>-<seq>`; operator-supplied entries
-/// can use any reasonable identifier as long as it starts with the
-/// `t-` prefix. We accept ASCII alphanumeric + `-_` after the
-/// prefix to allow operator names like `t-sprint58-wave4-pr1`.
-///
-/// Rejects: empty, missing prefix, control characters, length
-/// outside 4-128 (catches obvious typos without rejecting valid
-/// IDs).
-fn is_valid_task_id_shape(s: &str) -> bool {
-    if s.len() < 4 || s.len() > 128 {
-        return false;
-    }
-    let Some(rest) = s.strip_prefix("t-") else {
-        return false;
-    };
-    if rest.is_empty() {
-        return false;
-    }
-    rest.chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-}
+use super::{anti_stall::check_kind_task_requires_task_id, err_needs_identity, is_ok_result};
 
 /// Sprint 30: unified `send` handler. Routes to existing handlers based on
 /// `request_kind` or infers from args (targets/team → broadcast, task field
@@ -77,21 +24,9 @@ pub(super) fn handle_unified_send(home: &Path, args: &Value, sender: &Option<Sen
         }
     }
 
-    // Sprint 58 Wave 4 PR-1 (#2 engineering anti-stall): every
-    // `kind=task` dispatch must carry an explicit `task_id` so the
-    // recipient + observer agents can correlate the dispatch back
-    // to the task board entry. The Wave 3 PR-1 incident (lead
-    // created a task board entry but never dispatched with explicit
-    // task_id reference; dev idle-waited 100+ min) is structurally
-    // eliminated here. Validation runs BEFORE broadcast routing so
-    // both single-target and broadcast `kind=task` paths share the
-    // gate.
-    if args["request_kind"].as_str() == Some("task") {
-        if let Err(msg) = validate_task_id_present(&args) {
-            return json!({"error": msg, "code": "task_id_required"});
-        }
+    if let Some(err) = check_kind_task_requires_task_id(&args) {
+        return err;
     }
-
     // Broadcast mode: targets/team/tags present
     if args.get("targets").is_some() || args.get("team").is_some() || args.get("tags").is_some() {
         return handle_broadcast(home, &args, sender);

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -7,6 +7,59 @@ use std::path::Path;
 
 use super::{err_needs_identity, is_ok_result};
 
+/// Sprint 58 Wave 4 PR-1 (#2 engineering anti-stall): structural
+/// gate ensuring every `send kind=task` dispatch carries an explicit
+/// `task_id`. Closes the Wave 3 PR-1 dispatch protocol gap where
+/// task-board IDs and `send` calls weren't structurally tied — a
+/// lead could create a task entry but forget to dispatch with
+/// `task_id=...`, leaving the recipient with no correlation handle.
+///
+/// Returns the rejection error message on failure (with operator-
+/// actionable hint) so callers can surface it as a structured
+/// `code: "task_id_required"` response.
+fn validate_task_id_present(args: &Value) -> Result<(), String> {
+    let task_id = args["task_id"].as_str().unwrap_or("");
+    if task_id.is_empty() {
+        return Err(
+            "send kind=task requires 'task_id' — first call task action=create to obtain a \
+             't-...' id, then send kind=task task_id=t-... (Sprint 58 Wave 4 anti-stall \
+             contract)"
+                .to_string(),
+        );
+    }
+    if !is_valid_task_id_shape(task_id) {
+        return Err(format!(
+            "send kind=task: 'task_id' value '{task_id}' has invalid shape — task_id must \
+             start with 't-' and contain only ASCII alphanumeric / hyphen / underscore \
+             characters (length 4-128). Did you mean to call task action=create first?"
+        ));
+    }
+    Ok(())
+}
+
+/// Cheap shape check for task_id strings. The auto-generated form
+/// is `t-<14-digit-timestamp>-<seq>`; operator-supplied entries
+/// can use any reasonable identifier as long as it starts with the
+/// `t-` prefix. We accept ASCII alphanumeric + `-_` after the
+/// prefix to allow operator names like `t-sprint58-wave4-pr1`.
+///
+/// Rejects: empty, missing prefix, control characters, length
+/// outside 4-128 (catches obvious typos without rejecting valid
+/// IDs).
+fn is_valid_task_id_shape(s: &str) -> bool {
+    if s.len() < 4 || s.len() > 128 {
+        return false;
+    }
+    let Some(rest) = s.strip_prefix("t-") else {
+        return false;
+    };
+    if rest.is_empty() {
+        return false;
+    }
+    rest.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 /// Sprint 30: unified `send` handler. Routes to existing handlers based on
 /// `request_kind` or infers from args (targets/team → broadcast, task field
 /// → delegate, summary → report, question → query, default → send_to).
@@ -21,6 +74,21 @@ pub(super) fn handle_unified_send(home: &Path, args: &Value, sender: &Option<Sen
     if args.get("instance_name").is_none() {
         if let Some(target) = args.get("target_instance").cloned() {
             args["instance_name"] = target;
+        }
+    }
+
+    // Sprint 58 Wave 4 PR-1 (#2 engineering anti-stall): every
+    // `kind=task` dispatch must carry an explicit `task_id` so the
+    // recipient + observer agents can correlate the dispatch back
+    // to the task board entry. The Wave 3 PR-1 incident (lead
+    // created a task board entry but never dispatched with explicit
+    // task_id reference; dev idle-waited 100+ min) is structurally
+    // eliminated here. Validation runs BEFORE broadcast routing so
+    // both single-target and broadcast `kind=task` paths share the
+    // gate.
+    if args["request_kind"].as_str() == Some("task") {
+        if let Err(msg) = validate_task_id_present(&args) {
+            return json!({"error": msg, "code": "task_id_required"});
         }
     }
 

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -1,5 +1,6 @@
 //! MCP tool dispatch — handle_tool() routes tool calls to implementations.
 
+mod anti_stall;
 mod binding_state;
 mod channel;
 pub(crate) mod ci;

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -239,7 +239,7 @@ fn delegate_task_emits_fleet_event() {
 
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "do the thing", "message": "do the thing", "request_kind": "task", "message": "do the thing", "request_kind": "task"}),
+        &json!({"target_instance": "target", "task": "do the thing", "message": "do the thing", "request_kind": "task", "task_id": "t-test-fixture", "message": "do the thing", "request_kind": "task", "task_id": "t-test-fixture"}),
         "sender",
     );
     // Must have succeeded (API-path or fallback); both populate "target".
@@ -260,9 +260,15 @@ fn delegate_task_emits_fleet_event() {
             assert_eq!(from, "sender");
             assert_eq!(to, "target");
             assert_eq!(summary, "do the thing");
-            // Pin: `delegate_task` has no id slot; correlation surfaces
-            // later via `report_result.correlation_id`. Must be None.
-            assert!(task_id.is_none(), "task_id must be None for delegate");
+            // Sprint 58 Wave 4 PR-1: kind=task dispatches MUST carry an
+            // explicit task_id (anti-stall contract). The fixture
+            // passes "t-test-fixture", so the FleetEvent surfaces it
+            // — closes the Wave 3 PR-1 dispatch correlation gap.
+            assert_eq!(
+                task_id.as_deref(),
+                Some("t-test-fixture"),
+                "task_id must surface from request → FleetEvent post-Wave-4"
+            );
         }
         other => panic!("expected DelegateTask, got {other:?}"),
     }
@@ -645,7 +651,7 @@ fn delegate_task_main_response_clean_when_provenance_fails() {
 
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "do the thing", "message": "do the thing", "request_kind": "task", "message": "do the thing", "request_kind": "task"}),
+        &json!({"target_instance": "target", "task": "do the thing", "message": "do the thing", "request_kind": "task", "task_id": "t-test-fixture", "message": "do the thing", "request_kind": "task", "task_id": "t-test-fixture"}),
         "sender",
     );
 
@@ -711,7 +717,7 @@ fn delegate_task_provenance_failure_logs_tracing_warn() {
     // provenance via SEND params; API layer handles injection.
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "do the thing", "message": "do the thing", "request_kind": "task"}),
+        &json!({"target_instance": "target", "task": "do the thing", "message": "do the thing", "request_kind": "task", "task_id": "t-test-fixture"}),
         "sender",
     );
     // Send may fail (no daemon) — provenance warn only fires on success path.
@@ -1117,7 +1123,7 @@ fn test_delegate_task_resolves_team_to_orchestrator_inbox() {
 
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "dev", "task": "test task", "message": "test task", "request_kind": "task", "message": "test task", "request_kind": "task"}),
+        &json!({"target_instance": "dev", "task": "test task", "message": "test task", "request_kind": "task", "task_id": "t-test-fixture", "message": "test task", "request_kind": "task", "task_id": "t-test-fixture"}),
         "dev-impl",
     );
     // Should not error — team resolved to dev-lead.
@@ -1245,7 +1251,7 @@ fn test_delegate_task_busy_returns_structured_response() {
 
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "new work", "message": "new work", "request_kind": "task", "message": "new work", "request_kind": "task"}),
+        &json!({"target_instance": "target", "task": "new work", "message": "new work", "request_kind": "task", "task_id": "t-test-fixture", "message": "new work", "request_kind": "task", "task_id": "t-test-fixture"}),
         "sender",
     );
     assert_eq!(result["busy"], true, "must return busy: {result}");
@@ -1283,7 +1289,7 @@ fn test_delegate_task_force_true_bypasses_busy_gate() {
 
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "urgent", "message": "urgent", "request_kind": "task", "force": true, "force_reason": "critical bug"}),
+        &json!({"target_instance": "target", "task": "urgent", "message": "urgent", "request_kind": "task", "task_id": "t-test-fixture", "force": true, "force_reason": "critical bug"}),
         "sender",
     );
     assert!(
@@ -1332,7 +1338,7 @@ fn test_delegate_task_force_true_without_reason_rejected() {
 
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "urgent", "message": "urgent", "request_kind": "task", "force": true}),
+        &json!({"target_instance": "target", "task": "urgent", "message": "urgent", "request_kind": "task", "task_id": "t-test-fixture", "force": true}),
         "sender",
     );
     assert!(
@@ -1356,7 +1362,7 @@ fn test_delegate_task_idle_target_normal_delivery() {
     // No claimed tasks for target
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "normal work", "message": "normal work", "request_kind": "task", "message": "normal work", "request_kind": "task"}),
+        &json!({"target_instance": "target", "task": "normal work", "message": "normal work", "request_kind": "task", "task_id": "t-test-fixture", "message": "normal work", "request_kind": "task", "task_id": "t-test-fixture"}),
         "sender",
     );
     assert!(
@@ -1381,7 +1387,7 @@ fn test_delegate_task_second_reviewer_flag_requires_reason() {
     std::env::set_var("AGEND_HOME", &home);
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "review PR", "message": "review PR", "request_kind": "task", "second_reviewer": true}),
+        &json!({"target_instance": "target", "task": "review PR", "message": "review PR", "request_kind": "task", "task_id": "t-test-fixture", "second_reviewer": true}),
         "sender",
     );
     assert!(
@@ -1439,7 +1445,7 @@ fn test_delegate_task_no_second_reviewer_flag_default_behavior() {
     std::env::set_var("AGEND_HOME", &home);
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "normal work", "message": "normal work", "request_kind": "task", "message": "normal work", "request_kind": "task"}),
+        &json!({"target_instance": "target", "task": "normal work", "message": "normal work", "request_kind": "task", "task_id": "t-test-fixture", "message": "normal work", "request_kind": "task", "task_id": "t-test-fixture"}),
         "sender",
     );
     // No second_reviewer flag → no error related to it
@@ -1533,7 +1539,7 @@ fn test_delegate_task_old_interrupt_true_still_works() {
     // Use OLD names: interrupt + reason
     let result = handle_tool(
         "send",
-        &json!({"target_instance": "target", "task": "urgent", "message": "urgent", "request_kind": "task", "interrupt": true, "reason": "legacy caller"}),
+        &json!({"target_instance": "target", "task": "urgent", "message": "urgent", "request_kind": "task", "task_id": "t-test-fixture", "interrupt": true, "reason": "legacy caller"}),
         "sender",
     );
     // Should bypass busy gate (backwards-compat) + emit deprecation warning
@@ -1811,7 +1817,7 @@ fn test_isolation_active_after_setup_recorder() {
 #[test]
 fn send_kind_task_maps_message_field_to_task() {
     let sender = crate::identity::Sender::new("lead2-test").expect("valid sender name");
-    let args = json!({"target_instance": "dev", "message": "do X", "request_kind": "task"});
+    let args = json!({"target_instance": "dev", "message": "do X", "request_kind": "task", "task_id": "t-test-fixture"});
     let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
     // Whatever error/success we observe, it must NOT be the field-name bug:
     let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
@@ -2485,7 +2491,7 @@ fn delegate_task_instance_first_bypasses_team_orchestrator_collision() {
         "send",
         &json!({
             "target_instance": "dev",
-            "request_kind": "task",
+            "request_kind": "task", "task_id": "t-test-fixture",
             "message": "do something"
         }),
         "lead",
@@ -2527,7 +2533,7 @@ fn m5_regression_via_id_routing() {
         "send",
         &json!({
             "target_instance": "dev",
-            "request_kind": "task",
+            "request_kind": "task", "task_id": "t-test-fixture",
             "message": "do something"
         }),
         "lead",
@@ -2600,4 +2606,303 @@ fn bandaid_removed_invariant() {
         !comms_src.contains("instances.contains_key"),
         "P1 bandaid pattern `instances.contains_key` must be removed from comms.rs"
     );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Sprint 58 Wave 4 PR-1 (#2 engineering anti-stall) — kind=task
+// must carry an explicit task_id. Closes the Wave 3 PR-1 dispatch
+// protocol gap (lead created a task entry but didn't dispatch with
+// explicit task_id reference; dev idle-waited 100+ min). Tests pin
+// the structural gate so future refactors can't re-introduce the
+// gap.
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn send_kind_task_without_task_id_rejects_with_clear_error() {
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-no-id");
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "target",
+            "task": "do the thing",
+            "message": "do the thing",
+            "request_kind": "task",
+            // task_id intentionally omitted
+        }),
+        "sender",
+    );
+    let err = result["error"].as_str().unwrap_or("");
+    let code = result["code"].as_str().unwrap_or("");
+    assert!(
+        err.contains("task_id"),
+        "rejection must mention task_id: {result}"
+    );
+    assert_eq!(
+        code, "task_id_required",
+        "rejection must surface structured code: {result}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn send_kind_task_with_task_id_succeeds() {
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-with-id");
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "target",
+            "task": "do the thing",
+            "message": "do the thing",
+            "request_kind": "task",
+            "task_id": "t-test-fixture",
+        }),
+        "sender",
+    );
+    assert!(
+        is_ok_result(&result),
+        "kind=task with task_id must succeed: {result}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn send_kind_query_without_task_id_still_works() {
+    // The anti-stall gate scopes to kind=task only — kind=query
+    // should remain unaffected.
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-query-ok");
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "target",
+            "message": "what's the status?",
+            "request_kind": "query",
+        }),
+        "sender",
+    );
+    let err = result["error"].as_str().unwrap_or("");
+    assert!(
+        !err.contains("task_id"),
+        "kind=query must NOT trigger task_id gate: {result}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn send_kind_update_without_task_id_still_works() {
+    // The anti-stall gate scopes to kind=task only — kind=update
+    // should remain unaffected.
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-update-ok");
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "target",
+            "message": "checkpoint reached",
+            "request_kind": "update",
+        }),
+        "sender",
+    );
+    let err = result["error"].as_str().unwrap_or("");
+    assert!(
+        !err.contains("task_id"),
+        "kind=update must NOT trigger task_id gate: {result}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn send_kind_report_without_task_id_still_works() {
+    // The anti-stall gate scopes to kind=task only — kind=report
+    // (which uses correlation_id, not task_id) must remain unaffected.
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-report-ok");
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "target",
+            "message": "review verdict: VERIFIED",
+            "request_kind": "report",
+        }),
+        "sender",
+    );
+    let err = result["error"].as_str().unwrap_or("");
+    assert!(
+        !err.contains("task_id"),
+        "kind=report must NOT trigger task_id gate: {result}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn send_with_invalid_task_id_format_rejects() {
+    // Format validation: task_id must start with `t-` and contain
+    // only ASCII alphanumeric / hyphen / underscore (length 4-128).
+    // A bare empty string is caught earlier (handled by the
+    // "task_id_required" branch). This test pins the *shape* check
+    // for malformed-but-non-empty inputs.
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-bad-format");
+
+    let bad_ids = [
+        "no-prefix",     // missing t- prefix
+        "t-",            // empty after prefix
+        "t-with spaces", // ASCII whitespace not allowed
+        "t-bad/path",    // forward slash not allowed
+        "x",             // too short
+    ];
+    for bad in &bad_ids {
+        let result = handle_tool(
+            "send",
+            &json!({
+                "target_instance": "target",
+                "task": "do",
+                "message": "do",
+                "request_kind": "task",
+                "task_id": bad,
+            }),
+            "sender",
+        );
+        let err = result["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("task_id") && err.contains("invalid shape"),
+            "malformed task_id `{bad}` must be rejected with shape error: {result}"
+        );
+    }
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn error_message_includes_actionable_hint_text() {
+    // UX pin: the rejection message must explicitly tell the operator
+    // *how to recover* — i.e. mention `task action=create`. Without
+    // this hint, the error is just blame; with it, it's a recipe.
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-hint");
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "target",
+            "task": "do",
+            "message": "do",
+            "request_kind": "task",
+        }),
+        "sender",
+    );
+    let err = result["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("task action=create"),
+        "rejection must guide caller to task action=create: {result}"
+    );
+    assert!(
+        err.contains("t-"),
+        "rejection must reference the t-... id prefix shape: {result}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn send_kind_task_broadcast_path_also_requires_task_id() {
+    // Defensive bonus: the gate runs BEFORE broadcast routing in
+    // handle_unified_send, so kind=task on a broadcast (targets
+    // array OR team) is also gated. Without this, an operator could
+    // bypass the contract by adding a `targets` field.
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-broadcast");
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "targets": ["alpha", "beta"],
+            "message": "do",
+            "request_kind": "task",
+            // task_id intentionally omitted
+        }),
+        "sender",
+    );
+    assert_eq!(
+        result["code"].as_str(),
+        Some("task_id_required"),
+        "broadcast kind=task must also require task_id: {result}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn send_default_kind_without_task_id_still_works() {
+    // Defensive: when request_kind is omitted entirely, the
+    // anti-stall gate must NOT fire. This is the most common
+    // legacy call shape (plain instance-to-instance message).
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-default-kind");
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "target",
+            "message": "plain message",
+            // request_kind intentionally omitted → defaults
+        }),
+        "sender",
+    );
+    let err = result["error"].as_str().unwrap_or("");
+    assert!(
+        !err.contains("task_id"),
+        "missing request_kind must NOT trigger task_id gate: {result}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn task_id_required_error_uses_stable_code_for_machine_consumption() {
+    // Defensive: agents may branch on `code: "task_id_required"`
+    // programmatically (e.g. retry with task action=create then
+    // re-dispatch). Pin the code string against accidental rename.
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("anti-stall-stable-code");
+
+    let result = handle_tool(
+        "send",
+        &json!({
+            "target_instance": "target",
+            "task": "do",
+            "message": "do",
+            "request_kind": "task",
+        }),
+        "sender",
+    );
+    assert_eq!(
+        result["code"].as_str(),
+        Some("task_id_required"),
+        "stable code surface for machine-readable retry logic: {result}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -46,19 +46,19 @@ fn channel_tools() -> Vec<Value> {
 fn comm_tools() -> Vec<Value> {
     vec![
         // --- Unified send (Sprint 30: 5→1 consolidation) ---
-        json!({"name": "send", "description": "Send a message to another instance or broadcast to multiple. Replaces send_to_instance/delegate_task/report_result/request_information/broadcast.",
+        json!({"name": "send", "description": "Send a message to another instance or broadcast to multiple. Replaces send_to_instance/delegate_task/report_result/request_information/broadcast. Sprint 58 Wave 4 PR-1: kind=task dispatches MUST include task_id (call task action=create first to obtain a 't-...' id).",
             "inputSchema": {"type": "object", "properties": {
                 "target_instance": {"type": "string", "description": "Target instance name (single recipient)"},
                 "targets": {"type": "array", "items": {"type": "string"}, "description": "Multiple targets (broadcast mode)"},
                 "team": {"type": "string", "description": "Team name (broadcast to team)"},
                 "tags": {"type": "array", "items": {"type": "string"}, "description": "Tags filter (broadcast mode)"},
                 "message": {"type": "string", "description": "Message text (or 'task' for delegate, 'summary' for report, 'question' for query)"},
-                "request_kind": {"type": "string", "enum": ["query", "task", "report", "update"], "description": "Message kind (determines behavior)"},
+                "request_kind": {"type": "string", "enum": ["query", "task", "report", "update"], "description": "Message kind (determines behavior). NOTE: kind=task requires task_id (Sprint 58 Wave 4 PR-1 anti-stall contract)."},
                 "requires_reply": {"type": "boolean"},
                 "task_summary": {"type": "string"},
                 "success_criteria": {"type": "string", "description": "For task delegation"},
                 "context": {"type": "string"},
-                "task_id": {"type": "string", "description": "Task board ID for correlation"},
+                "task_id": {"type": "string", "description": "Task board ID for correlation. REQUIRED when request_kind=task — caller must obtain via `task action=create` and reference the resulting `t-...` id, closing the Wave 3 PR-1 dispatch protocol gap."},
                 "correlation_id": {"type": "string"},
                 "parent_id": {"type": "string"},
                 "thread_id": {"type": "string"},


### PR DESCRIPTION
## Summary
Closes the Wave 3 PR-1 dispatch protocol gap **structurally**: `send` MCP tool now rejects `kind=task` without an explicit `task_id`. Lead can no longer create a task board entry without dispatching with task_id correlation — the failure mode that left dev idle-waiting 100+ min in Wave 3 PR-1 becomes physically impossible.

★ **Dogfood**: this PR's own dispatch (`m-20260509040924963198-96`) used the new explicit task_id semantic, meta-compliant with the protocol fix being shipped.

## Backwards-compat audit (per general's directive)

| Surface | Count | Action |
|---|---|---|
| Production Rust call sites setting `request_kind=task` | **0** | None — flows through MCP JSON args |
| Test fixtures (`tests.rs`) | 14 | Updated to add `task_id="t-test-fixture"` |
| Comments (`dispatch_hook/tests.rs`) | 2 | No change |
| Schema enum + descriptions | 3 | Updated docs |
| String literals in inbox/api rendering | 2 | No change (not requests) |

**Total < 50 → hard-enforce immediate** per directive threshold. No deprecation rollout needed.

## Surface

| File | Δ | Purpose |
|---|---|---|
| `src/mcp/handlers/comms.rs` | +57 | `validate_task_id_present` + `is_valid_task_id_shape` helpers, gate in `handle_unified_send` BEFORE broadcast routing |
| `src/mcp/tools.rs` | +2/-2 | Tool description + enum description + `task_id` property docs |
| `src/mcp/handlers/tests.rs` | +261/-2 | 10 new lead-spec tests, 14 fixture updates, 1 contract-shift assertion update |

## Validation rules

```rust
fn is_valid_task_id_shape(s: &str) -> bool {
    if s.len() < 4 || s.len() > 128 { return false; }
    let Some(rest) = s.strip_prefix("t-") else { return false; };
    if rest.is_empty() { return false; }
    rest.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
}
```

Allows operator-named IDs (`t-sprint58-wave4-pr1`) while catching obvious typos (missing prefix, whitespace, slashes, empty, too-short).

Error response shape (operator-actionable):
```json
{
  "error": "send kind=task requires 'task_id' — first call task action=create to obtain a 't-...' id, then send kind=task task_id=t-... (Sprint 58 Wave 4 anti-stall contract)",
  "code": "task_id_required"
}
```

## Tests (10 new lead-spec + defensive)

Lead-spec (7):
- `send_kind_task_without_task_id_rejects_with_clear_error`
- `send_kind_task_with_task_id_succeeds`
- `send_kind_query_without_task_id_still_works`
- `send_kind_update_without_task_id_still_works`
- `send_kind_report_without_task_id_still_works`
- `send_with_invalid_task_id_format_rejects` (5 malformed inputs)
- `error_message_includes_actionable_hint_text`

Defensive bonus (3):
- `send_kind_task_broadcast_path_also_requires_task_id` (no `targets` field bypass)
- `send_default_kind_without_task_id_still_works` (request_kind absent doesn't trigger)
- `task_id_required_error_uses_stable_code_for_machine_consumption` (pin `code: "task_id_required"`)

## Path A + smoke verify
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test mcp::handlers::tests --test-threads=1` — 114 passed (10 new + 104 pre-existing serialized; agent_picked_up parallel-flake unrelated to PR surface)
- [x] `cargo test mcp::handlers::dispatch_hook mcp::tools` — 25 passed
- [x] **Smoke**: `send_kind_task_without_task_id_rejects_with_clear_error` invokes via `handle_tool("send", ...)` — the same production dispatch path the MCP server uses. Confirms structured `code: "task_id_required"` + actionable error mentioning `task action=create` returned on production path.
- [x] Full `--bin agend-terminal` test run: 1847 pass / 7 pre-existing local-only flakes (claim_verifier x6 git-state-dependent + admin x1 worktree-branch, same set documented in Wave 2 PR-1 / Wave 3 PR-1 r0 pushes, none on this PR's surface)

## Test plan
- [ ] CI green on x86_64 Linux + macOS + Windows
- [ ] Reviewer confirm gate placement (BEFORE broadcast routing in `handle_unified_send`) covers both single-target and broadcast `kind=task` paths
- [ ] Reviewer confirm shape validator allows operator-named IDs while rejecting typos
- [ ] Reviewer confirm error message UX includes actionable `task action=create` hint
- [ ] Reviewer confirm dogfood compliance (this dispatch itself used the new contract)

## Sprint 58 Wave 4 closeout
Wave 4 = 1 PR (this) → Sprint 58 final closeout post-merge. Sprint 58 cumulative target: 9 PRs (Wave 1+2+3 = 8 + Wave 4 PR-1 = 9), 33rd post-policy clean PR closing. STRICT v2 daemon-managed worktree via bind_self preserved. 0 bypass cycles.

Refs: #2 (engineering anti-stall), Sprint 58 Wave 4 PR-1, Wave 3 PR-1 incident reference `m-20260509031109840434-59`

🤖 Generated with [Claude Code](https://claude.com/claude-code)