### PR TITLE
feat(telegram): topic cleanup (α)+(γ) F2 — track-on-create + 4-class doctor (Sprint 59 Wave 2 PR-IMPL)

### DIFF
--- a/src/bootstrap/doctor_topics.rs
+++ b/src/bootstrap/doctor_topics.rs
@@ -695,7 +695,7 @@ mod tests {
         // Registry should now reflect fleet.yaml's topic_id (99).
         let reg = load_topic_registry(&home);
         assert_eq!(reg.get(&99), Some(&"alpha".to_string()));
-        assert!(reg.get(&42).is_none());
+        assert!(!reg.contains_key(&42));
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/bootstrap/doctor_topics.rs
+++ b/src/bootstrap/doctor_topics.rs
@@ -1,0 +1,727 @@
+//! Sprint 59 Wave 2 PR-IMPL (F2 — γ-reduced 4-class) — operator-
+//! callable diagnostic + cleanup surface for telegram topic state.
+//!
+//! Backs the `agend-terminal doctor topics [--cleanup] [--format
+//! human|json]` CLI subcommand. Reads `topics.json` (registry) +
+//! `fleet.yaml` (instance topic_id) + classifies every observable
+//! (topic_id, instance_name) pair into one of 4 mutually-exclusive
+//! classes via precedence-ordered first-match-wins assignment.
+//!
+//! ## Why 4 classes (not 5)
+//!
+//! The Sprint 59 Wave 2 PR-1 RCA originally proposed a 5-class
+//! taxonomy that included `stale_chat` (topic exists in chat but
+//! not in topics.json). Detecting `stale_chat` requires
+//! enumerating live forum topics in the chat — the Telegram Bot
+//! API + teloxide-core 0.11.2 do NOT expose any "list forum
+//! topics" method. Per surface-block #1 + (F2) decision (lead
+//! m-20260509165526589860-288 + general
+//! m-20260509165440054018-286), `stale_chat` is dropped from the
+//! taxonomy.
+//!
+//! Operators encountering chat-side topics that are NOT tracked
+//! by `topics.json` must verify via the Telegram UI directly —
+//! the `--cleanup` flag cannot detect or act on that class.
+//! Sprint 60+ candidate: teloxide upgrade evaluation if a future
+//! Bot API version exposes forum-topic enumeration.
+//!
+//! ## Classification algorithm (4 classes, precedence-ordered)
+//!
+//! For each `(topic_id, instance_name)` candidate observed across
+//! 2 sources (`topics.json` / `fleet.yaml.<inst>.topic_id`), apply
+//! rules in order; assign first-match:
+//!
+//! 1. `live` — present in topics.json AND fleet.yaml.topic_id
+//!    matches. Both sources agree.
+//! 2. `drift_fleet` — present in topics.json AND fleet.yaml.topic_id
+//!    exists BUT differs. Drift between sources.
+//! 3. `stale_registry` — present in topics.json AND
+//!    fleet.yaml.topic_id matches OR is absent. Treat as
+//!    registry-resident; chat-side unverifiable. Operator's
+//!    manual verification via Telegram UI is the recovery path.
+//! 4. `orphan` — present in topics.json mapping to instance name
+//!    NOT in fleet.yaml. Instance retired without registry cleanup.
+
+use crate::fleet::FleetConfig;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// 4-class taxonomy (per F2 reduced from RCA's original 5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopicClass {
+    /// topics.json AND fleet.yaml.topic_id agree.
+    Live,
+    /// topics.json AND fleet.yaml.topic_id exist but differ.
+    DriftFleet,
+    /// topics.json says it should exist; chat-side unverifiable.
+    StaleRegistry,
+    /// topics.json maps to instance NOT in fleet.yaml.
+    Orphan,
+}
+
+impl TopicClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TopicClass::Live => "live",
+            TopicClass::DriftFleet => "drift_fleet",
+            TopicClass::StaleRegistry => "stale_registry",
+            TopicClass::Orphan => "orphan",
+        }
+    }
+}
+
+/// One classified topic entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClassifiedTopic {
+    pub topic_id: i32,
+    pub instance_name: String,
+    pub class: TopicClass,
+    /// `Some(fleet_id)` when fleet.yaml has a topic_id for the
+    /// instance (regardless of whether it matches). `None` when
+    /// fleet.yaml has no entry OR no topic_id field.
+    pub fleet_topic_id: Option<i32>,
+}
+
+/// Classification report — sorted by topic_id for stable output.
+#[derive(Debug, Clone, Default)]
+pub struct TopicReport {
+    pub entries: Vec<ClassifiedTopic>,
+    /// `can_manage_topics` permission status; `None` when the
+    /// telegram channel is unconfigured/unavailable. `--cleanup`
+    /// chat-mutating operations gated on `Some(true)`.
+    pub can_manage_topics: Option<bool>,
+}
+
+impl TopicReport {
+    pub fn count_by_class(&self, class: TopicClass) -> usize {
+        self.entries.iter().filter(|e| e.class == class).count()
+    }
+}
+
+/// Build the classification report by reading the on-disk sources.
+/// Pure function — no chat-side network calls beyond the optional
+/// `can_manage_topics` permission probe done elsewhere.
+pub fn classify(home: &Path) -> TopicReport {
+    let registry = load_topic_registry(home);
+    let fleet = FleetConfig::load(&home.join("fleet.yaml")).ok();
+    let fleet_topic_ids: HashMap<String, i32> = fleet
+        .as_ref()
+        .map(|c| {
+            c.instances
+                .iter()
+                .filter_map(|(n, i)| i.topic_id.map(|t| (n.clone(), t)))
+                .collect()
+        })
+        .unwrap_or_default();
+    let fleet_instance_names: std::collections::HashSet<String> = fleet
+        .as_ref()
+        .map(|c| c.instances.keys().cloned().collect())
+        .unwrap_or_default();
+
+    let mut entries: Vec<ClassifiedTopic> = registry
+        .into_iter()
+        // Skip the fleet_binding sentinel + `general` topic_id=1
+        // pseudo-instance — these are reserved markers, not user-
+        // facing topics that operators classify.
+        .filter(|(tid, name)| *tid != 1 && name != crate::channel::telegram::FLEET_BINDING_SENTINEL)
+        .map(|(topic_id, instance_name)| {
+            let fleet_topic_id = fleet_topic_ids.get(&instance_name).copied();
+            let in_fleet = fleet_instance_names.contains(&instance_name);
+            // Precedence-ordered first-match-wins assignment per RCA §4.1
+            // (4-class reduction per F2):
+            // 1. orphan — instance not in fleet.yaml (regardless of
+            //    fleet topic_id state, which would be None for
+            //    missing instances anyway).
+            let class = if !in_fleet {
+                TopicClass::Orphan
+            } else if let Some(fleet_id) = fleet_topic_id {
+                if fleet_id == topic_id {
+                    // 2. live — registry + fleet agree.
+                    // Note: chat-side unverifiable per F2 API gap;
+                    // class is "registry says live, chat unverified".
+                    TopicClass::Live
+                } else {
+                    // 3. drift_fleet — registry + fleet differ.
+                    TopicClass::DriftFleet
+                }
+            } else {
+                // 4. stale_registry — instance in fleet but no
+                //    fleet topic_id (or it's been cleared);
+                //    registry is the only anchor.
+                TopicClass::StaleRegistry
+            };
+            ClassifiedTopic {
+                topic_id,
+                instance_name,
+                class,
+                fleet_topic_id,
+            }
+        })
+        .collect();
+    entries.sort_by_key(|e| e.topic_id);
+
+    TopicReport {
+        entries,
+        // can_manage_topics is set externally by callers that
+        // probe the permission via a network call — cli.rs
+        // populates it before display.
+        can_manage_topics: None,
+    }
+}
+
+/// Load topic registry from `topics.json`. Returns empty map on
+/// missing/corrupt file — operators get an empty report rather
+/// than a crash.
+fn load_topic_registry(home: &Path) -> HashMap<i32, String> {
+    let path = home.join("topics.json");
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<HashMap<String, String>>(&s).ok())
+        .map(|m| {
+            m.into_iter()
+                .filter_map(|(k, v)| k.parse::<i32>().ok().map(|id| (id, v)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Render the report as a human-readable multi-line string.
+pub fn render_human(report: &TopicReport) -> String {
+    let mut out = String::new();
+    out.push_str("Telegram topic state:\n");
+    let total = report.entries.len();
+    if total == 0 {
+        out.push_str("  (no tracked topics in topics.json)\n");
+    } else {
+        for class in [
+            TopicClass::Live,
+            TopicClass::DriftFleet,
+            TopicClass::StaleRegistry,
+            TopicClass::Orphan,
+        ] {
+            let count = report.count_by_class(class);
+            if count == 0 {
+                continue;
+            }
+            out.push_str(&format!("  {count} {} ", class.as_str()));
+            let names: Vec<String> = report
+                .entries
+                .iter()
+                .filter(|e| e.class == class)
+                .map(|e| {
+                    let drift_note =
+                        if let (TopicClass::DriftFleet, Some(fid)) = (e.class, e.fleet_topic_id) {
+                            format!(" (registry={}, fleet={})", e.topic_id, fid)
+                        } else {
+                            format!(":{}", e.topic_id)
+                        };
+                    format!("{}{}", e.instance_name, drift_note)
+                })
+                .collect();
+            out.push_str(&format!("({})\n", names.join(", ")));
+        }
+    }
+    out.push('\n');
+    match report.can_manage_topics {
+        Some(true) => {
+            out.push_str("Bot can_manage_topics: ✓ enabled (cleanup operations available)\n")
+        }
+        Some(false) => out.push_str(
+            "Bot can_manage_topics: ✗ DISABLED — chat-mutating cleanup will be skipped. \
+             Grant via Telegram → Chat → Manage admins → bot name → enable 'Manage topics'.\n",
+        ),
+        None => {
+            out.push_str("Bot can_manage_topics: ? (telegram channel unconfigured/unavailable)\n")
+        }
+    }
+    out.push('\n');
+    out.push_str(
+        "F2 limitation note: `stale_chat` class detection is unavailable — Telegram Bot API \
+         does not expose forum-topic enumeration. Operators must verify chat-side state via \
+         the Telegram UI directly. Sprint 60+ candidate tracks teloxide upgrade evaluation.\n",
+    );
+    if total > 0 {
+        out.push_str(
+            "\nRun with --cleanup to act on stale_registry / drift_fleet / orphan entries.\n",
+        );
+    }
+    out
+}
+
+/// Render the report as JSON.
+pub fn render_json(report: &TopicReport) -> String {
+    let entries: Vec<serde_json::Value> = report
+        .entries
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "topic_id": e.topic_id,
+                "instance_name": e.instance_name,
+                "class": e.class.as_str(),
+                "fleet_topic_id": e.fleet_topic_id,
+            })
+        })
+        .collect();
+    let counts = serde_json::json!({
+        "live": report.count_by_class(TopicClass::Live),
+        "drift_fleet": report.count_by_class(TopicClass::DriftFleet),
+        "stale_registry": report.count_by_class(TopicClass::StaleRegistry),
+        "orphan": report.count_by_class(TopicClass::Orphan),
+        "total": report.entries.len(),
+    });
+    let payload = serde_json::json!({
+        "schema_version": 1,
+        "entries": entries,
+        "counts": counts,
+        "can_manage_topics": report.can_manage_topics,
+        "limitation_note": "stale_chat class unavailable per Telegram Bot API forum-topic enumeration gap (Sprint 59 Wave 2 PR-IMPL F2)",
+    });
+    serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".into())
+}
+
+/// Action taken by `--cleanup` per classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CleanupAction {
+    /// Removed from `topics.json`; no chat operation.
+    UnregisteredOnly {
+        topic_id: i32,
+        instance_name: String,
+    },
+    /// Called `delete_topic` on chat side + unregistered.
+    DeletedFromChatAndRegistry {
+        topic_id: i32,
+        instance_name: String,
+    },
+    /// Skipped because the bot lacks `can_manage_topics`.
+    SkippedNoPermission {
+        topic_id: i32,
+        instance_name: String,
+    },
+    /// Skipped per operator's `--prefer-fleet` / `--prefer-registry`
+    /// resolution choice not matching this entry's class needs.
+    SkippedNeedsResolution {
+        topic_id: i32,
+        instance_name: String,
+        reason: &'static str,
+    },
+    /// API error during cleanup; entry left as-is.
+    SkippedApiError {
+        topic_id: i32,
+        instance_name: String,
+        error: String,
+    },
+}
+
+/// Cleanup preference for `drift_fleet` resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriftResolution {
+    /// Take fleet.yaml as authoritative; update topics.json to
+    /// match. (Default if operator doesn't pick.)
+    PreferFleet,
+    /// Take topics.json as authoritative; update fleet.yaml to
+    /// match.
+    PreferRegistry,
+    /// Don't resolve; operator wants to see the drift surfaced
+    /// without acting.
+    LeaveDrift,
+}
+
+/// Plan + execute the cleanup pass. The planning + execution split
+/// makes it testable without mocking the telegram API: pure
+/// classification + plan in this function; chat-side mutation
+/// happens via the existing `delete_topic` / `unregister_topic`
+/// surfaces.
+///
+/// `can_manage_topics` short-circuits chat-mutating ops. When
+/// `false` or `None`, only `UnregisteredOnly` actions fire (registry-
+/// only cleanup of `stale_registry` entries).
+pub fn execute_cleanup(
+    home: &Path,
+    report: &TopicReport,
+    drift_resolution: DriftResolution,
+) -> Vec<CleanupAction> {
+    let mut actions = Vec::new();
+    let can_manage = report.can_manage_topics.unwrap_or(false);
+    for entry in &report.entries {
+        match entry.class {
+            TopicClass::Live => {
+                // No action — agreement state.
+            }
+            TopicClass::StaleRegistry => {
+                // Registry says it should exist; chat-side
+                // unverifiable. Operator's recovery path is manual
+                // verify; we surface the entry but don't auto-clean
+                // (would risk losing a real-but-unverified topic).
+                actions.push(CleanupAction::SkippedNeedsResolution {
+                    topic_id: entry.topic_id,
+                    instance_name: entry.instance_name.clone(),
+                    reason: "stale_registry: chat-side unverifiable per teloxide API gap; \
+                             operator must manually verify via Telegram UI",
+                });
+            }
+            TopicClass::DriftFleet => match drift_resolution {
+                DriftResolution::PreferFleet => {
+                    // Update topics.json to match fleet.yaml.
+                    if let Some(fid) = entry.fleet_topic_id {
+                        let mut reg = registry_load(home);
+                        reg.remove(&entry.topic_id);
+                        reg.insert(fid, entry.instance_name.clone());
+                        registry_save(home, &reg);
+                        actions.push(CleanupAction::UnregisteredOnly {
+                            topic_id: entry.topic_id,
+                            instance_name: entry.instance_name.clone(),
+                        });
+                    }
+                }
+                DriftResolution::PreferRegistry => {
+                    // Update fleet.yaml to match topics.json.
+                    let _ = crate::fleet::update_instance_field(
+                        home,
+                        &entry.instance_name,
+                        "topic_id",
+                        serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(entry.topic_id)),
+                    );
+                    actions.push(CleanupAction::UnregisteredOnly {
+                        topic_id: entry.topic_id,
+                        instance_name: entry.instance_name.clone(),
+                    });
+                }
+                DriftResolution::LeaveDrift => {
+                    actions.push(CleanupAction::SkippedNeedsResolution {
+                        topic_id: entry.topic_id,
+                        instance_name: entry.instance_name.clone(),
+                        reason: "drift_fleet: operator chose to leave drift unresolved",
+                    });
+                }
+            },
+            TopicClass::Orphan => {
+                if !can_manage {
+                    actions.push(CleanupAction::SkippedNoPermission {
+                        topic_id: entry.topic_id,
+                        instance_name: entry.instance_name.clone(),
+                    });
+                    continue;
+                }
+                use crate::channel::telegram::topic_registry::{delete_topic, DeleteTopicOutcome};
+                match delete_topic(home, entry.topic_id) {
+                    DeleteTopicOutcome::Deleted => {
+                        actions.push(CleanupAction::DeletedFromChatAndRegistry {
+                            topic_id: entry.topic_id,
+                            instance_name: entry.instance_name.clone(),
+                        });
+                    }
+                    DeleteTopicOutcome::PermissionDenied => {
+                        actions.push(CleanupAction::SkippedNoPermission {
+                            topic_id: entry.topic_id,
+                            instance_name: entry.instance_name.clone(),
+                        });
+                    }
+                    DeleteTopicOutcome::ApiError(e) => {
+                        actions.push(CleanupAction::SkippedApiError {
+                            topic_id: entry.topic_id,
+                            instance_name: entry.instance_name.clone(),
+                            error: e,
+                        });
+                    }
+                    DeleteTopicOutcome::ChannelUnavailable => {
+                        actions.push(CleanupAction::SkippedApiError {
+                            topic_id: entry.topic_id,
+                            instance_name: entry.instance_name.clone(),
+                            error: "channel unavailable".to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    actions
+}
+
+fn registry_load(home: &Path) -> HashMap<i32, String> {
+    load_topic_registry(home)
+}
+
+fn registry_save(home: &Path, reg: &HashMap<i32, String>) {
+    let map: HashMap<String, &String> = reg.iter().map(|(k, v)| (k.to_string(), v)).collect();
+    if let Ok(json) = serde_json::to_string_pretty(&map) {
+        let _ = crate::store::atomic_write(&home.join("topics.json"), json.as_bytes());
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-doctor-topics-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn write_registry(home: &Path, entries: &[(i32, &str)]) {
+        let map: HashMap<String, String> = entries
+            .iter()
+            .map(|(tid, name)| (tid.to_string(), name.to_string()))
+            .collect();
+        let json = serde_json::to_string_pretty(&map).unwrap();
+        std::fs::write(home.join("topics.json"), json).unwrap();
+    }
+
+    fn write_fleet(home: &Path, instances: &[(&str, Option<i32>)]) {
+        let mut yaml = String::from("instances:\n");
+        for (name, tid) in instances {
+            yaml.push_str(&format!("  {name}:\n"));
+            yaml.push_str("    backend: claude\n");
+            if let Some(t) = tid {
+                yaml.push_str(&format!("    topic_id: {t}\n"));
+            }
+        }
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+    }
+
+    #[test]
+    fn classify_live_when_registry_and_fleet_agree() {
+        let home = tmp_home("live");
+        write_registry(&home, &[(42, "alpha")]);
+        write_fleet(&home, &[("alpha", Some(42))]);
+        let report = classify(&home);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].class, TopicClass::Live);
+        assert_eq!(report.entries[0].topic_id, 42);
+        assert_eq!(report.entries[0].instance_name, "alpha");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn classify_drift_fleet_when_registry_and_fleet_differ() {
+        let home = tmp_home("drift");
+        write_registry(&home, &[(42, "alpha")]);
+        write_fleet(&home, &[("alpha", Some(99))]);
+        let report = classify(&home);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].class, TopicClass::DriftFleet);
+        assert_eq!(report.entries[0].topic_id, 42);
+        assert_eq!(report.entries[0].fleet_topic_id, Some(99));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn classify_stale_registry_when_fleet_lacks_topic_id() {
+        let home = tmp_home("stale-registry");
+        write_registry(&home, &[(42, "alpha")]);
+        write_fleet(&home, &[("alpha", None)]);
+        let report = classify(&home);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].class, TopicClass::StaleRegistry);
+        assert_eq!(report.entries[0].fleet_topic_id, None);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn classify_orphan_when_instance_missing_from_fleet() {
+        let home = tmp_home("orphan");
+        write_registry(&home, &[(42, "retired-agent")]);
+        write_fleet(&home, &[("alpha", Some(1))]); // alpha exists, retired-agent doesn't
+        let report = classify(&home);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].class, TopicClass::Orphan);
+        assert_eq!(report.entries[0].instance_name, "retired-agent");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn precedence_orphan_beats_other_classes_when_instance_absent() {
+        // Even when topic_id matches fleet.yaml entry value (which
+        // wouldn't happen in practice for an orphan, but pin the
+        // precedence semantic): orphan wins because instance is
+        // not in fleet.yaml.
+        let home = tmp_home("precedence-orphan");
+        write_registry(&home, &[(42, "ghost")]);
+        write_fleet(&home, &[("alpha", Some(42))]); // ghost not in fleet
+        let report = classify(&home);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].class, TopicClass::Orphan);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn fleet_binding_sentinel_excluded_from_classification() {
+        let home = tmp_home("sentinel-exclude");
+        write_registry(
+            &home,
+            &[
+                (42, "alpha"),
+                (1, "general"),
+                (99, crate::channel::telegram::FLEET_BINDING_SENTINEL),
+            ],
+        );
+        write_fleet(&home, &[("alpha", Some(42))]);
+        let report = classify(&home);
+        // Only alpha should appear; general (tid=1) + fleet_binding sentinel filtered out.
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].instance_name, "alpha");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn classify_handles_missing_registry_file() {
+        let home = tmp_home("missing-registry");
+        write_fleet(&home, &[("alpha", Some(42))]);
+        let report = classify(&home);
+        assert!(report.entries.is_empty());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn classify_handles_missing_fleet_yaml() {
+        let home = tmp_home("missing-fleet");
+        write_registry(&home, &[(42, "alpha")]);
+        // No fleet.yaml — instance absent everywhere.
+        let report = classify(&home);
+        assert_eq!(report.entries.len(), 1);
+        // No fleet.yaml means instance not in fleet → orphan
+        assert_eq!(report.entries[0].class, TopicClass::Orphan);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn render_human_includes_class_counts_and_permission_status() {
+        let home = tmp_home("render-human");
+        write_registry(&home, &[(42, "alpha"), (43, "beta")]);
+        write_fleet(&home, &[("alpha", Some(42)), ("beta", Some(99))]);
+        let mut report = classify(&home);
+        report.can_manage_topics = Some(true);
+        let out = render_human(&report);
+        assert!(
+            out.contains("1 live"),
+            "human output must show live count: {out}"
+        );
+        assert!(
+            out.contains("1 drift_fleet"),
+            "human output must show drift count: {out}"
+        );
+        assert!(
+            out.contains("can_manage_topics: ✓"),
+            "permission status must be visible: {out}"
+        );
+        assert!(
+            out.contains("F2 limitation note"),
+            "limitation note must be present: {out}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn render_human_warns_when_permission_disabled() {
+        let home = tmp_home("render-no-perm");
+        write_registry(&home, &[(42, "alpha")]);
+        write_fleet(&home, &[("alpha", Some(42))]);
+        let mut report = classify(&home);
+        report.can_manage_topics = Some(false);
+        let out = render_human(&report);
+        assert!(out.contains("can_manage_topics: ✗"), "must warn: {out}");
+        assert!(out.contains("Manage topics"), "actionable hint: {out}");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn render_json_structured_payload() {
+        let home = tmp_home("render-json");
+        write_registry(&home, &[(42, "alpha"), (43, "ghost")]);
+        write_fleet(&home, &[("alpha", Some(42))]);
+        let mut report = classify(&home);
+        report.can_manage_topics = Some(true);
+        let json_str = render_json(&report);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed["counts"]["live"], 1);
+        assert_eq!(parsed["counts"]["orphan"], 1);
+        assert_eq!(parsed["counts"]["total"], 2);
+        assert!(parsed["limitation_note"].is_string());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn execute_cleanup_orphan_skipped_without_permission() {
+        let home = tmp_home("cleanup-no-perm");
+        write_registry(&home, &[(42, "ghost")]);
+        write_fleet(&home, &[("alpha", Some(1))]);
+        let mut report = classify(&home);
+        report.can_manage_topics = Some(false);
+        let actions = execute_cleanup(&home, &report, DriftResolution::PreferFleet);
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(
+            actions[0],
+            CleanupAction::SkippedNoPermission { .. }
+        ));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn execute_cleanup_stale_registry_surfaces_resolution_needed() {
+        let home = tmp_home("cleanup-stale");
+        write_registry(&home, &[(42, "alpha")]);
+        write_fleet(&home, &[("alpha", None)]);
+        let mut report = classify(&home);
+        report.can_manage_topics = Some(true);
+        let actions = execute_cleanup(&home, &report, DriftResolution::PreferFleet);
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            CleanupAction::SkippedNeedsResolution { reason, .. } => {
+                assert!(reason.contains("stale_registry"));
+                assert!(reason.contains("manually verify"));
+            }
+            other => panic!("expected SkippedNeedsResolution, got {other:?}"),
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn execute_cleanup_drift_prefer_fleet_updates_registry() {
+        let home = tmp_home("cleanup-drift-fleet");
+        write_registry(&home, &[(42, "alpha")]);
+        write_fleet(&home, &[("alpha", Some(99))]);
+        let mut report = classify(&home);
+        report.can_manage_topics = Some(true);
+        let _ = execute_cleanup(&home, &report, DriftResolution::PreferFleet);
+        // Registry should now reflect fleet.yaml's topic_id (99).
+        let reg = load_topic_registry(&home);
+        assert_eq!(reg.get(&99), Some(&"alpha".to_string()));
+        assert!(reg.get(&42).is_none());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn execute_cleanup_drift_leave_surfaces_unresolved() {
+        let home = tmp_home("cleanup-drift-leave");
+        write_registry(&home, &[(42, "alpha")]);
+        write_fleet(&home, &[("alpha", Some(99))]);
+        let mut report = classify(&home);
+        report.can_manage_topics = Some(true);
+        let actions = execute_cleanup(&home, &report, DriftResolution::LeaveDrift);
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            CleanupAction::SkippedNeedsResolution { reason, .. } => {
+                assert!(reason.contains("drift_fleet"));
+            }
+            other => panic!("expected SkippedNeedsResolution, got {other:?}"),
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn class_as_str_round_trips_to_taxonomy_names() {
+        assert_eq!(TopicClass::Live.as_str(), "live");
+        assert_eq!(TopicClass::DriftFleet.as_str(), "drift_fleet");
+        assert_eq!(TopicClass::StaleRegistry.as_str(), "stale_registry");
+        assert_eq!(TopicClass::Orphan.as_str(), "orphan");
+    }
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -15,6 +15,7 @@
 mod agent_resolve;
 pub mod daemon_spawn;
 pub(crate) mod doctor;
+pub(crate) mod doctor_topics;
 mod fleet_normalize;
 pub mod signals;
 mod telegram_init;

--- a/src/channel/telegram/bootstrap.rs
+++ b/src/channel/telegram/bootstrap.rs
@@ -101,22 +101,35 @@ pub fn init_from_config(
         }
     }
 
-    // Auto-create topics for instances without topic_id
+    // Auto-create topics for instances without topic_id.
+    //
+    // Sprint 59 Wave 2 PR-IMPL (F2 — α-a' track-on-create refactor):
+    // route through `create_topic_for_instance` instead of inline
+    // `bot.create_forum_topic`. This closes S1 (duplicate accumulation
+    // on registry-state loss): `create_topic_for_instance` at
+    // topic_registry.rs:74-79 already implements idempotent same-
+    // name reuse — if a topic with the same instance name is in
+    // `topics.json`, it returns the existing topic_id rather than
+    // calling the create API again. Bootstrap now benefits from
+    // the same dedup. Combined with the existing orphan-cleanup at
+    // bootstrap.rs:71-78 (which scans topics.json for retired
+    // instances), the (α-a)+(α-b) pair from RCA design collapses
+    // into a single track-on-create flow + existing orphan scan.
+    //
+    // Note: chat-side enumeration to detect "duplicate-named topic
+    // already exists in chat but not in topics.json" remains
+    // technically impossible per teloxide 0.11.2 + Telegram Bot API
+    // gap (no list_forum_topics method). That edge case requires
+    // operator intervention via the (γ) `agend-terminal doctor
+    // topics` surface (Sprint 60+ candidate: teloxide upgrade
+    // evaluation if a future Bot API version exposes enumeration).
     for (name, inst) in &config.instances {
         if name == "general" && inst.topic_id.is_none() {
             topic_map.insert("general".to_string(), 1);
         } else if inst.topic_id.is_none() {
-            tracing::info!(instance = %name, "creating topic");
-            match telegram_runtime().block_on(async {
-                bot.create_forum_topic(chat_id, name, teloxide::types::Rgb::from_u32(0x6FB9F0), "")
-                    .await
-            }) {
-                Ok(topic) => {
-                    let tid = topic.thread_id.0 .0;
-                    tracing::info!(instance = %name, topic_id = tid, "created topic");
-                    topic_map.insert(name.clone(), tid);
-                }
-                Err(e) => tracing::error!(instance = %name, error = %e, "failed to create topic"),
+            tracing::info!(instance = %name, "auto-creating topic via track-on-create");
+            if let Some(tid) = create_topic_for_instance(home, name) {
+                topic_map.insert(name.clone(), tid);
             }
         }
     }

--- a/src/channel/telegram/creds.rs
+++ b/src/channel/telegram/creds.rs
@@ -1,9 +1,9 @@
 //! Telegram credential resolution — loads bot token + group id from fleet.yaml.
 
 /// Resolved Telegram channel credentials — avoids repeated fleet.yaml loads.
-pub(super) struct TelegramCreds {
-    pub(super) token: String,
-    pub(super) group_id: i64,
+pub(crate) struct TelegramCreds {
+    pub(crate) token: String,
+    pub(crate) group_id: i64,
 }
 
 pub(super) fn resolve_channel() -> anyhow::Result<(TelegramCreds, crate::fleet::FleetConfig)> {
@@ -59,6 +59,6 @@ pub(super) fn resolve_channel_only() -> anyhow::Result<TelegramCreds> {
 /// topics the user observed were exactly this: the positive-pin dispatch
 /// test creating a team via the API, reaching the topic helper, and the
 /// unscoped resolver loading the real fleet.yaml instead of the test's.
-pub(super) fn resolve_channel_only_from(home: &std::path::Path) -> anyhow::Result<TelegramCreds> {
+pub(crate) fn resolve_channel_only_from(home: &std::path::Path) -> anyhow::Result<TelegramCreds> {
     resolve_channel_from(home).map(|(ch, _)| ch)
 }

--- a/src/channel/telegram/topic_registry.rs
+++ b/src/channel/telegram/topic_registry.rs
@@ -10,7 +10,7 @@ use super::state::telegram_runtime;
 /// (`fleet.yaml` keys are slugs; underscores-bracketing is reserved).
 /// See [`init_from_config`] orphan-cleanup filter and fleet-binding
 /// resolution.
-pub(super) const FLEET_BINDING_SENTINEL: &str = "__fleet__";
+pub(crate) const FLEET_BINDING_SENTINEL: &str = "__fleet__";
 
 pub(super) fn topic_registry_path(home: &Path) -> PathBuf {
     home.join("topics.json")
@@ -102,21 +102,115 @@ pub fn create_topic_for_instance(home: &std::path::Path, instance_name: &str) ->
     }
 }
 
+/// Sprint 59 Wave 2 PR-IMPL (F2 — α-shared helper): query whether
+/// the bot has `can_manage_topics` permission in the chat. Returns
+/// `false` on any error path (network failure / not-an-admin /
+/// permission-introspection failure) so callers default to safe-
+/// skip rather than risking a permission-denied API call mid-flight.
+///
+/// Used by [`delete_topic`] (α-c surfacing) and the (γ) `--cleanup`
+/// flag pre-call check.
+pub fn can_manage_topics_for(bot: &teloxide::Bot, chat_id: teloxide::types::ChatId) -> bool {
+    let me = match telegram_runtime().block_on(async { bot.get_me().await }) {
+        Ok(me) => me,
+        Err(_) => return false,
+    };
+    let member =
+        match telegram_runtime().block_on(async { bot.get_chat_member(chat_id, me.id).await }) {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
+    match member.kind {
+        teloxide::types::ChatMemberKind::Administrator(admin) => admin.can_manage_topics,
+        teloxide::types::ChatMemberKind::Owner(_) => true, // chat owners have all rights
+        _ => false,
+    }
+}
+
+/// Sprint 59 Wave 2 PR-IMPL (F2 — α-c): outcome of a `delete_topic`
+/// call, surfaced to callers so the (γ) `--cleanup` flag and
+/// future operator-driven cleanup paths can distinguish silent-
+/// success from permission-denied-skip from genuine error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeleteTopicOutcome {
+    /// Topic was deleted successfully on chat side + unregistered
+    /// from `topics.json`.
+    Deleted,
+    /// Bot lacks `can_manage_topics` permission. Topic remains in
+    /// chat AND in `topics.json` (operator must manually delete via
+    /// Telegram UI OR fix bot permissions then retry).
+    PermissionDenied,
+    /// Telegram API returned a non-permission error (network,
+    /// rate limit, transient). Topic state on chat side is
+    /// indeterminate; registry left untouched so a retry can
+    /// re-attempt cleanup.
+    ApiError(String),
+    /// Channel resolution failed (no telegram channel configured
+    /// or bot token missing). Topic remains in registry; no chat-
+    /// side attempt was made.
+    ChannelUnavailable,
+}
+
 /// Delete a forum topic.
-pub fn delete_topic(home: &std::path::Path, topic_id: i32) {
+///
+/// Sprint 59 Wave 2 PR-IMPL (F2 — α-c): replaces the prior
+/// `let _ = ...` swallowing with explicit match arms that
+/// distinguish permission errors (warn-log with actionable hint)
+/// from generic errors (error-log with full chain). Returns
+/// [`DeleteTopicOutcome`] so callers can branch on outcome.
+///
+/// Pre-flight permission check via [`can_manage_topics_for`]
+/// short-circuits the API call when the bot lacks the
+/// `can_manage_topics` admin right — avoids a guaranteed-fail
+/// API roundtrip + surfaces the actionable hint immediately.
+pub fn delete_topic(home: &std::path::Path, topic_id: i32) -> DeleteTopicOutcome {
     let ch = match super::resolve_channel_only_from(home) {
         Ok(c) => c,
-        Err(_) => return,
+        Err(_) => {
+            tracing::warn!(
+                topic_id,
+                "delete_topic: telegram channel unavailable — skipping"
+            );
+            return DeleteTopicOutcome::ChannelUnavailable;
+        }
     };
+    let bot = teloxide::Bot::new(&ch.token);
+    let chat_id = teloxide::types::ChatId(ch.group_id);
+
+    if !can_manage_topics_for(&bot, chat_id) {
+        tracing::warn!(
+            topic_id,
+            "delete_topic skipped: bot lacks can_manage_topics permission. \
+             Grant via Telegram → Chat → Manage admins → bot name → enable \
+             'Manage topics'. Topic remains in chat AND topics.json registry."
+        );
+        return DeleteTopicOutcome::PermissionDenied;
+    }
+
     let tid = teloxide::types::ThreadId(teloxide::types::MessageId(topic_id));
-    let _ = telegram_runtime().block_on(async {
-        let bot = teloxide::Bot::new(&ch.token);
-        let chat_id = teloxide::types::ChatId(ch.group_id);
+    let result = telegram_runtime().block_on(async {
+        // close_forum_topic is best-effort — close errors are
+        // non-fatal because the subsequent delete_forum_topic
+        // will close the topic anyway.
         let _ = bot.close_forum_topic(chat_id, tid).await;
         bot.delete_forum_topic(chat_id, tid).await
     });
-    unregister_topic(home, topic_id);
-    tracing::info!(topic_id, "deleted topic");
+    match result {
+        Ok(_) => {
+            unregister_topic(home, topic_id);
+            tracing::info!(topic_id, "delete_topic: deleted topic + unregistered");
+            DeleteTopicOutcome::Deleted
+        }
+        Err(e) => {
+            let err_str = e.to_string();
+            tracing::error!(
+                topic_id,
+                error = %err_str,
+                "delete_topic: API error — topic NOT deleted, registry unchanged for retry"
+            );
+            DeleteTopicOutcome::ApiError(err_str)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -547,6 +547,120 @@ fn get_screen_lines(
 // only needs strict ordering, not absolute mtime values.
 // ─────────────────────────────────────────────────────────────────
 
+// ─────────────────────────────────────────────────────────────────
+// Sprint 59 Wave 2 PR-IMPL (F2 — γ): `agend-terminal doctor topics`
+// — operator-callable diagnostic for telegram topic state.
+// Backed by `crate::bootstrap::doctor_topics`.
+// ─────────────────────────────────────────────────────────────────
+
+/// Options surface for `cli::run_doctor_topics`. Mirrors the clap
+/// args at `Commands::Doctor { action: Some(DoctorAction::Topics { ... }) }`
+/// so the cli entry-point is a thin shim.
+pub struct DoctorTopicsOptions<'a> {
+    pub cleanup: bool,
+    pub format: &'a str,
+    pub yes: bool,
+    pub prefer_fleet: bool,
+    pub prefer_registry: bool,
+}
+
+/// Run the topics-diagnostic doctor flow. Pure read in the default
+/// case; calls `execute_cleanup` when `--cleanup` is set.
+pub fn run_doctor_topics(home: &Path, opts: DoctorTopicsOptions) -> anyhow::Result<()> {
+    use crate::bootstrap::doctor_topics::{
+        classify, execute_cleanup, render_human, render_json, CleanupAction, DriftResolution,
+    };
+
+    if opts.prefer_fleet && opts.prefer_registry {
+        anyhow::bail!("--prefer-fleet and --prefer-registry are mutually exclusive; pick one");
+    }
+
+    let mut report = classify(home);
+
+    // Probe `can_manage_topics` permission so the human/json output
+    // can surface it. Best-effort: failures fall back to `None`.
+    report.can_manage_topics = probe_can_manage_topics(home);
+
+    // Always print the inspection output — operator sees state
+    // before any cleanup acts.
+    let output = match opts.format {
+        "json" => render_json(&report),
+        "human" | _ => render_human(&report),
+    };
+    println!("{output}");
+
+    if !opts.cleanup {
+        return Ok(());
+    }
+
+    // Cleanup gate: confirmation prompt unless --yes.
+    if !opts.yes {
+        eprintln!(
+            "About to act on stale_registry / drift_fleet / orphan entries above. \
+             Continue? (y/N): "
+        );
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        let trimmed = input.trim().to_lowercase();
+        if trimmed != "y" && trimmed != "yes" {
+            eprintln!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    let drift_resolution = if opts.prefer_fleet {
+        DriftResolution::PreferFleet
+    } else if opts.prefer_registry {
+        DriftResolution::PreferRegistry
+    } else {
+        DriftResolution::LeaveDrift
+    };
+
+    let actions = execute_cleanup(home, &report, drift_resolution);
+    println!("\nCleanup actions ({}):", actions.len());
+    for action in &actions {
+        match action {
+            CleanupAction::DeletedFromChatAndRegistry {
+                topic_id,
+                instance_name,
+            } => println!("  ✓ deleted topic {topic_id} ({instance_name}) — chat + registry"),
+            CleanupAction::UnregisteredOnly {
+                topic_id,
+                instance_name,
+            } => println!("  ✓ updated registry for {topic_id} ({instance_name}) — chat unchanged"),
+            CleanupAction::SkippedNoPermission {
+                topic_id,
+                instance_name,
+            } => println!("  ⚠ skipped {topic_id} ({instance_name}) — bot lacks can_manage_topics"),
+            CleanupAction::SkippedNeedsResolution {
+                topic_id,
+                instance_name,
+                reason,
+            } => println!("  ⚠ skipped {topic_id} ({instance_name}) — {reason}"),
+            CleanupAction::SkippedApiError {
+                topic_id,
+                instance_name,
+                error,
+            } => println!("  ✗ skipped {topic_id} ({instance_name}) — API error: {error}"),
+        }
+    }
+    Ok(())
+}
+
+/// Probe `can_manage_topics` for the configured telegram channel.
+/// Returns `None` when the channel is unconfigured (no telegram
+/// section in fleet.yaml OR bot token unavailable). The probe is
+/// network-bound; expensive failures (rate limit, network blip)
+/// fall back to `Some(false)` to err on the safe side (cleanup
+/// will skip rather than try-and-fail).
+fn probe_can_manage_topics(home: &Path) -> Option<bool> {
+    use crate::channel::telegram::{can_manage_topics_for, resolve_channel_only_from};
+    let ch = resolve_channel_only_from(home).ok()?;
+    let bot = teloxide::Bot::new(&ch.token);
+    let chat_id = teloxide::types::ChatId(ch.group_id);
+    Some(can_manage_topics_for(&bot, chat_id))
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod helper_staleness_tests {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -585,7 +585,7 @@ pub fn run_doctor_topics(home: &Path, opts: DoctorTopicsOptions) -> anyhow::Resu
     // before any cleanup acts.
     let output = match opts.format {
         "json" => render_json(&report),
-        "human" | _ => render_human(&report),
+        _ => render_human(&report),
     };
     println!("{output}");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,8 +295,11 @@ enum Commands {
         #[command(subcommand)]
         action: ServiceAction,
     },
-    /// Health check
-    Doctor,
+    /// Health check (or `doctor topics` for telegram topic state diagnostic)
+    Doctor {
+        #[command(subcommand)]
+        action: Option<DoctorAction>,
+    },
     /// Menu-bar / system-tray resident app (requires `--features tray`).
     #[cfg(feature = "tray")]
     Tray,
@@ -344,6 +347,41 @@ enum AdminCommands {
 
 /// Sprint 57 Wave 3 PR-3 (#548 Phase 3) — `agend-terminal service`
 /// subcommand actions. Maps to `service::install / uninstall / status`.
+/// Sprint 59 Wave 2 PR-IMPL (F2 — γ): subcommands for `agend-terminal
+/// doctor`. Default (no subcommand) runs the existing fleet-wide
+/// health check; `topics` adds telegram topic state diagnostic +
+/// optional cleanup.
+#[derive(Subcommand)]
+enum DoctorAction {
+    /// Diagnose telegram topic state (live / drift_fleet / stale_registry / orphan).
+    /// Pair with `--cleanup` to act on stale/drift/orphan entries (chat-mutating
+    /// operations gated by bot's `can_manage_topics` permission).
+    Topics {
+        /// Act on stale/drift/orphan entries (registry update + chat-side delete).
+        /// Requires the bot to have `can_manage_topics` permission for chat-mutating
+        /// operations on `orphan` entries; without permission, those skip with warn.
+        #[arg(long)]
+        cleanup: bool,
+        /// Output format: `human` (default, multi-line table) or `json` (structured
+        /// for piping into other tools).
+        #[arg(long, default_value = "human")]
+        format: String,
+        /// Skip interactive confirmation prompt for `--cleanup`.
+        #[arg(long)]
+        yes: bool,
+        /// For `drift_fleet` entries during `--cleanup`: take fleet.yaml as
+        /// authoritative (update topics.json to match). Mutually exclusive with
+        /// `--prefer-registry`.
+        #[arg(long)]
+        prefer_fleet: bool,
+        /// For `drift_fleet` entries during `--cleanup`: take topics.json as
+        /// authoritative (update fleet.yaml to match). Mutually exclusive with
+        /// `--prefer-fleet`.
+        #[arg(long)]
+        prefer_registry: bool,
+    },
+}
+
 #[derive(Subcommand)]
 enum ServiceAction {
     /// Register the daemon with the OS service manager so it auto-
@@ -678,7 +716,28 @@ fn main() -> anyhow::Result<()> {
                 }
             },
         },
-        Some(Commands::Doctor) => cli::run_doctor(&home)?,
+        Some(Commands::Doctor { action: None }) => cli::run_doctor(&home)?,
+        Some(Commands::Doctor {
+            action:
+                Some(DoctorAction::Topics {
+                    cleanup,
+                    format,
+                    yes,
+                    prefer_fleet,
+                    prefer_registry,
+                }),
+        }) => {
+            cli::run_doctor_topics(
+                &home,
+                cli::DoctorTopicsOptions {
+                    cleanup,
+                    format: &format,
+                    yes,
+                    prefer_fleet,
+                    prefer_registry,
+                },
+            )?;
+        }
         #[cfg(feature = "tray")]
         Some(Commands::Tray) => tray::run(&home)?,
         Some(Commands::Demo) => cli::run_demo()?,


### PR DESCRIPTION
## Summary
Wave 2 IMPL of operator-actionable telegram topic cleanup per Wave 2 PR-1 RCA (merged #573 16d8def). Lead + general authorized **(F2) scope-reduction path** post surface-block #1: teloxide 0.11.2 + Telegram Bot API expose no forum-topic enumeration, so chat-side state introspection is unavailable — `(F2)` refactors bootstrap to existing track-on-create infrastructure + ships a 4-class doctor surface (vs original 5-class with stale_chat).

★ **(F1)/(F3)/(F4) considered + rejected**:
- (F1) drop (α) entirely → S1/S2 unaddressed
- (F3) teloxide upgrade → Sprint 60+ candidate
- (F4) direct Bot API via reqwest → significant scope expansion

## Architecture (4 layers)

| Layer | Surface | Purpose |
|---|---|---|
| (α-a') | bootstrap.rs:104-122 refactor | Route through `create_topic_for_instance` (existing topics.json idempotent reuse) — closes S1 duplicate accumulation |
| (α-b) | unchanged | bootstrap.rs:71-78 orphan-cleanup already covers S2 |
| (α-c) | topic_registry.rs:106 | `delete_topic` returns `DeleteTopicOutcome` enum, surfaces permission/API errors with actionable hints — closes S4 silent failure |
| (α-shared) | topic_registry.rs::can_manage_topics_for | Permission-check helper using `get_chat_member` + `ChatMemberKind::Administrator` |
| (γ) | NEW src/bootstrap/doctor_topics.rs | 4-class taxonomy + render_human/render_json + execute_cleanup |
| (γ-cli) | cli.rs::run_doctor_topics + main.rs DoctorAction::Topics | `agend-terminal doctor topics [--cleanup] [--format human|json] [--yes] [--prefer-fleet|--prefer-registry]` |

## 4-class taxonomy (precedence-ordered, first-match-wins)

| # | Class | Definition |
|---|---|---|
| 1 | `live` | topics.json AND fleet.yaml.topic_id agree |
| 2 | `drift_fleet` | topics.json + fleet.yaml.topic_id differ |
| 3 | `stale_registry` | topics.json says it should exist; chat-side unverifiable |
| 4 | `orphan` | topics.json maps to instance NOT in fleet.yaml |

`stale_chat` (in chat but not in topics.json) **dropped** per (F2) API gap — Telegram Bot API has no forum-topic enumeration. Operators must verify chat-side state via Telegram UI for that class. Sprint 60+ candidate: teloxide upgrade evaluation.

## DeleteTopicOutcome enum

```rust
pub enum DeleteTopicOutcome {
    Deleted,                 // chat + registry both updated
    PermissionDenied,        // bot lacks can_manage_topics; registry preserved for retry
    ApiError(String),        // non-permission failure; registry preserved
    ChannelUnavailable,      // telegram channel unconfigured
}
```

## CleanupAction surface (per classification)

```rust
pub enum CleanupAction {
    UnregisteredOnly { topic_id, instance_name },                       // drift_fleet resolution
    DeletedFromChatAndRegistry { topic_id, instance_name },             // orphan with permission
    SkippedNoPermission { topic_id, instance_name },                    // orphan without permission
    SkippedNeedsResolution { topic_id, instance_name, reason },         // stale_registry / drift LeaveDrift
    SkippedApiError { topic_id, instance_name, error },                 // chat API failure
}
```

## Documented limitation

Both `render_human` and `render_json` outputs include the F2 limitation note:
> `stale_chat` class detection is unavailable — Telegram Bot API does not expose forum-topic enumeration. Operators must verify chat-side state via the Telegram UI directly. Sprint 60+ candidate tracks teloxide upgrade evaluation.

## Tests (16 new in doctor_topics.rs)

Lead-spec verbatim (per RCA §4.1 precedence rules):
- `classify_live_when_registry_and_fleet_agree`
- `classify_drift_fleet_when_registry_and_fleet_differ`
- `classify_stale_registry_when_fleet_lacks_topic_id`
- `classify_orphan_when_instance_missing_from_fleet`
- `precedence_orphan_beats_other_classes_when_instance_absent`

Defensive bonuses (11):
- fleet_binding_sentinel_excluded_from_classification
- classify_handles_missing_registry_file / classify_handles_missing_fleet_yaml
- render_human_includes_class_counts_and_permission_status
- render_human_warns_when_permission_disabled
- render_json_structured_payload
- execute_cleanup_orphan_skipped_without_permission
- execute_cleanup_stale_registry_surfaces_resolution_needed
- execute_cleanup_drift_prefer_fleet_updates_registry
- execute_cleanup_drift_leave_surfaces_unresolved
- class_as_str_round_trips_to_taxonomy_names

## Path A verify
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] file_size_invariant pass
- [x] 33 tests pass (16 new + 17 topic_registry pre-existing)
- [x] tool count invariant 31 unchanged (no new MCP tool — pure CLI subcommand)

## Backwards compatibility
- Existing `agend-terminal doctor` (no subcommand) runs identical pre-PR behavior
- Existing `delete_topic` callers (3 sites: instance_lifecycle.rs:82 / adapter.rs:264 / bootstrap.rs:75) silently ignore the new `DeleteTopicOutcome` return value via Rust convention — no caller changes required
- No schema migration (`topics.json` + `fleet.yaml.topic_id` field unchanged)
- Existing daemon restarts continue to work; first restart post-merge runs the refactored auto-create flow (observable via tracing logs "auto-creating topic via track-on-create")

## Visibility plumbing (audit trail)
- `FLEET_BINDING_SENTINEL` bumped `pub(super)` → `pub(crate)` so doctor_topics.rs can filter it out of classification
- `TelegramCreds` + fields bumped `pub(super)` → `pub(crate)` so cli.rs can probe permissions via public surface
- `resolve_channel_only_from` bumped `pub(super)` → `pub(crate)` for the same reason

## Test plan
- [ ] CI green on x86_64 Linux + macOS + Windows
- [ ] Reviewer confirm (α-a') refactor preserves bootstrap behavior + adds S1 dedup automatically
- [ ] Reviewer confirm DeleteTopicOutcome shape covers all 4 outcome paths
- [ ] Reviewer confirm 4-class precedence-ordered classification matches RCA §4.1
- [ ] Reviewer confirm F2 limitation note surfaced in both human + json outputs
- [ ] Reviewer confirm `--cleanup` interactive prompt + --yes skip + --prefer-fleet/registry mutex

## Sprint 59 Wave 2 PR-IMPL self-claim ledger
Task `t-20260509090003452174-17` claimed under formal lead dispatch `m-20260509165526589860-288` post operator-(F2)-authorization via general `m-20260509165440054018-286`. STRICT v2 daemon-managed worktree via bind_self preserved. 0 bypass cycles. Target 40th post-policy ledger-clean PR.

Refs: #573 (Wave 2 PR-1 RCA, merged 16d8def), Sprint 59 Wave 2 PR-IMPL, operator F2 decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Scope-overrun transparency

**+1008 net LOC delivered vs F2 estimate ~200-330 LOC** (3-5x estimate miss, exceeds RCA §8.2 #4 split-trigger > 850).

### Why single PR was retained (reviewer-adjudicated option (a))
Per reviewer Tier-1 single primary adjudication (VERDICT: VERIFIED with cohesion-accept): split at (α)/(γ) seam would not reduce review risk materially. Dominant surface is integrated doctor-topics module (727 LOC including 277 test LOC at 38% appropriate density) + CLI wiring + cleanup semantics — forced split would add coordination overhead while preserving most complexity in one side.

### F2 estimate miss methodology gaps
F2 estimate (~200-330) under-estimated:
- New CLI subcommand boilerplate in cli.rs + main.rs (~175 LOC)
- 4-class taxonomy + per-class cleanup actions (~150 LOC)
- Two render formats (human + json) with F2 limitation note (~80 LOC)
- DriftResolution enum + interactive prompt + --yes/--prefer flags (~80 LOC)
- 16 tests at appropriate defensive density

Honest re-estimate: ~600-900 LOC, closer to original RCA estimate 490-770 than F2 200-330.

### Sprint 60 candidate added
"LOC estimation methodology improvement + ceiling enforcement protocol" — Sprint 60 P2 per general m-20260509171322275216-294.

### Q2=(C) compliance preserved
0 BYPASS, incremental r0→r1 (no force-push, no amend), daemon-managed worktree throughout.

### Reviewer adjudication reference
m-20260509172909173277-301 (option (a) ACCEPT, cohesion justifies single PR).
