### PR TITLE
feat(bind_self): #P0-1+#P0-4 rebase_mode flag — atomic recover-and-bind (Sprint 60 W1 PR-1)

### DIFF
--- a/src/mcp/handlers/force_release.rs
+++ b/src/mcp/handlers/force_release.rs
@@ -86,6 +86,57 @@ pub(crate) fn handle_force_release_worktree(
         });
     }
 
+    match rebase_clean_self(home, agent, branch) {
+        Ok(o) => json!({
+            "released": true,
+            "dir_existed": o.dir_existed,
+            "dir_removed": o.dir_removed,
+            "binding_outcome": o.binding_outcome,
+        }),
+        Err(e) => json!({"error": e, "code": "path_outside_pool"}),
+    }
+}
+
+/// Outcome of a rebase-clean operation.
+#[derive(Debug)]
+pub(super) struct RebaseCleanOutcome {
+    pub(super) dir_existed: bool,
+    pub(super) dir_removed: bool,
+    pub(super) binding_outcome: Value,
+}
+
+/// Sprint 60 W1 PR-1: shared cleanup helper used by both
+/// `force_release_worktree` (operator/agent-callable) and
+/// `bind_self(rebase_mode=true)` (atomic recover-and-bind).
+///
+/// Validates path safety against the daemon worktree pool, removes
+/// the stale on-disk dir if present, and clears any lingering binding
+/// state via `release_full`. Returns `Err` only on path-safety
+/// violation; all other failures are fail-open with tracing::warn so
+/// partial recovery is preserved.
+///
+/// Caller invariant: `agent` and `branch` must be pre-validated by
+/// `agent::validate_name` + `agent_ops::validate_branch` respectively.
+/// This helper trusts its callers; the path-safety guard below is
+/// defense-in-depth, not the primary validator.
+pub(super) fn rebase_clean_self(
+    home: &Path,
+    agent: &str,
+    branch: &str,
+) -> Result<RebaseCleanOutcome, String> {
+    let worktrees_root = home.join("worktrees");
+    let target = worktrees_root.join(agent).join(branch);
+    let safe = target.starts_with(&worktrees_root)
+        && target != worktrees_root
+        && target != worktrees_root.join(agent);
+    if !safe {
+        return Err(format!(
+            "force_release_worktree refuses to clean path outside the daemon \
+             worktree pool: {}",
+            target.display()
+        ));
+    }
+
     let dir_existed = target.exists();
     let mut dir_removed = false;
     if dir_existed {
@@ -112,11 +163,10 @@ pub(crate) fn handle_force_release_worktree(
     }
 
     let binding_outcome = crate::worktree_pool::release_full(home, agent);
-    json!({
-        "released": true,
-        "dir_existed": dir_existed,
-        "dir_removed": dir_removed,
-        "binding_outcome": serde_json::to_value(&binding_outcome).unwrap_or(Value::Null),
+    Ok(RebaseCleanOutcome {
+        dir_existed,
+        dir_removed,
+        binding_outcome: serde_json::to_value(&binding_outcome).unwrap_or(Value::Null),
     })
 }
 
@@ -377,6 +427,129 @@ mod tests {
             dir_lead.exists(),
             "lead's dir preserved: {}",
             dir_lead.display()
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 60 W1 PR-1: rebase_clean_self helper tests ──────────────
+    //
+    // Direct exercise of the shared cleanup helper. handle_bind_self with
+    // rebase_mode=true forwards to this helper before the lease attempt;
+    // verifying the helper's contract here covers the bind_self call site
+    // by construction (the wiring in handle_bind_self is a single
+    // `if let Err = rebase_clean_self` branch).
+
+    #[test]
+    fn rebase_clean_self_clears_existing_dir_and_invokes_release_full() {
+        let home = tmp_home("rebase-clean-existing");
+        let dir = seed_daemon_worktree(&home, "dev", "feat/rebase-x");
+        assert!(dir.exists());
+        let outcome = rebase_clean_self(&home, "dev", "feat/rebase-x")
+            .expect("clean state in pool must succeed");
+        assert!(outcome.dir_existed);
+        assert!(outcome.dir_removed);
+        assert!(!dir.exists(), "stale dir must be cleaned");
+        assert!(
+            outcome.binding_outcome.is_object(),
+            "binding_outcome must surface release_full result"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn rebase_clean_self_idempotent_on_clean_state() {
+        // No prior bind, no stale dir → helper still runs release_full
+        // (idempotent) and reports dir_existed=false.
+        let home = tmp_home("rebase-clean-idempotent");
+        let outcome = rebase_clean_self(&home, "dev", "feat/never-existed")
+            .expect("helper must not error on clean state");
+        assert!(!outcome.dir_existed);
+        assert!(!outcome.dir_removed);
+        // release_full on missing binding returns released:false + "no binding" error.
+        let bo = &outcome.binding_outcome;
+        assert_eq!(bo["released"].as_bool(), Some(false));
+        assert!(bo["error"].as_str().unwrap_or("").contains("no binding"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn rebase_clean_self_rejects_path_outside_worktree_pool() {
+        // Defense-in-depth: even if a malicious caller bypassed the
+        // outer validators, the helper refuses to clean paths outside
+        // <home>/worktrees/. The path-safety check here mirrors
+        // force_release_worktree's own guard.
+        let home = tmp_home("rebase-outside-pool");
+        // An empty branch resolves to <home>/worktrees/dev (the
+        // agent-level dir) which the safety check rejects.
+        let r = rebase_clean_self(&home, "dev", "");
+        assert!(r.is_err(), "empty branch must reject as path-unsafe");
+        // A branch with `..` would also escape the pool — but
+        // agent_ops::validate_branch already rejects those before this
+        // helper is called. The empty-string case is the only path
+        // that could slip past upstream validators (e.g. caller passes
+        // a JSON null/missing field), so it's the load-bearing guard.
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 60 W1 PR-1: bind_self handler rebase_mode end-to-end ─────
+
+    #[test]
+    fn bind_self_rebase_mode_runs_cleanup_before_lease_attempt() {
+        // Seed the stale state that drove the Wave 1 PR-2 BYPASS
+        // incident: an on-disk worktree dir + binding lingering from a
+        // prior bind cycle. Calling handle_bind_self with
+        // rebase_mode=true must clean the dir + binding even though
+        // the lease itself will fail (no fleet.yaml + no real git
+        // repo in this minimal test fixture).
+        //
+        // Observable: post-call, the stale dir is gone AND the
+        // binding is cleared, regardless of the lease error returned.
+        // This proves the rebase_mode wiring runs the cleanup helper
+        // before the dispatch_auto_bind_lease call.
+        use crate::mcp::handlers::worktree::handle_bind_self;
+        let home = tmp_home("bind-rebase-cleanup");
+        let dir = seed_daemon_worktree(&home, "dev", "feat/rebase-bind");
+        // Seed a binding too so we can verify it's released.
+        let runtime = home.join("runtime").join("dev");
+        std::fs::create_dir_all(&runtime).unwrap();
+        std::fs::write(
+            runtime.join("binding.json"),
+            r#"{"agent":"dev","branch":"feat/rebase-bind","worktree":"/stale"}"#,
+        )
+        .unwrap();
+        assert!(dir.exists());
+
+        let _ignored = handle_bind_self(
+            &home,
+            &json!({"branch": "feat/rebase-bind", "rebase_mode": true}),
+            &crate::identity::Sender::new("dev"),
+        );
+        // Cleanup ran regardless of the downstream lease result.
+        assert!(!dir.exists(), "rebase_mode must clean stale dir pre-lease");
+        assert!(
+            !runtime.join("binding.json").exists(),
+            "rebase_mode must clear stale binding pre-lease"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bind_self_no_rebase_mode_skips_cleanup() {
+        // Inverse: without rebase_mode, the cleanup must NOT run —
+        // existing behavior is preserved. The pre-existing stale dir
+        // remains untouched (dispatch_auto_bind_lease will return
+        // its usual lease_failed for the stuck-state scenario).
+        use crate::mcp::handlers::worktree::handle_bind_self;
+        let home = tmp_home("bind-no-rebase");
+        let dir = seed_daemon_worktree(&home, "dev", "feat/no-rebase");
+        let _ignored = handle_bind_self(
+            &home,
+            &json!({"branch": "feat/no-rebase"}),
+            &crate::identity::Sender::new("dev"),
+        );
+        assert!(
+            dir.exists(),
+            "without rebase_mode, stale dir must be preserved"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -75,6 +75,13 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
     }
     let source_repo_path = source_repo_arg.map(std::path::PathBuf::from);
 
+    if args["rebase_mode"].as_bool().unwrap_or(false) {
+        if let Err(e) = crate::mcp::handlers::force_release::rebase_clean_self(home, agent, branch)
+        {
+            return json!({"error": e, "code": "path_outside_pool"});
+        }
+    }
+
     // task_id="self" — clear distinction from real task IDs in the binding.json
     // audit trail. The tasks store doesn't need a row for a self-bind; the
     // string is purely a marker.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -272,7 +272,8 @@ fn worktree_tools() -> Vec<Value> {
             "inputSchema": {"type": "object", "properties": {
                 "source_repo": {"type": "string", "description": "Local path to source repository. Daemon resolves GitHub owner/repo via `git remote get-url origin`. Sprint 55 P0-B preferred form. Mutually exclusive with `repo` (handler rejects both via `ambiguous_args` code)."},
                 "repo": {"type": "string", "description": "GitHub repo (owner/name). Legacy form retained for one-Sprint deprecation window — emits warn-log; removal Sprint 57. Mutually exclusive with `source_repo`."},
-                "branch": {"type": "string", "description": "Branch to bind (must not be main/master)"}
+                "branch": {"type": "string", "description": "Branch to bind (must not be main/master)"},
+                "rebase_mode": {"type": "boolean", "description": "Sprint 60 W1 PR-1: atomic recover-and-bind. When true, releases self's stale on-disk worktree dir + binding state before lease — closes the lease_failed recovery path without an explicit release_worktree call. Cross-agent isolation preserved (rejects branches leased by another agent)."}
             }, "required": ["branch"]}}),
         // Sprint 53 P0-X: release a daemon-managed worktree + clear binding
         // for `agent`. Idempotent. Only removes worktrees that carry the


### PR DESCRIPTION
## Summary

- **Path A IMPL** — Sprint 60 W1 PR-1 leadoff. Combined P0-1 (bind_self rebase mode) + P0-4 (PR conflict resolution mechanism) per lead dispatch option (a) bundle: rebase_mode flag IS the conflict resolution mechanism.
- Closes the Sprint 59 Wave 1 PR-2 BYPASS root cause: when bind_self returned \`lease_failed\` after a stale on-disk worktree dir lingered, callers needed two MCP calls (\`release_worktree\` → \`bind_self\`). With rebase_mode=true, the same recovery happens atomically.
- New flag: \`bind_self(branch=..., rebase_mode=true)\` → releases self's stale dir + binding via shared helper, then proceeds with normal lease. Cross-agent isolation preserved (dispatch_auto_bind_lease still rejects branches leased by another agent).

## Surface

- \`src/mcp/handlers/force_release.rs\` (+185 LOC, 433→618): refactored handle_force_release_worktree to call new \`rebase_clean_self\` helper; 5 new tests.
- \`src/mcp/handlers/worktree.rs\` (+7 LOC, 692→699): handle_bind_self extracts rebase_mode arg and conditionally invokes the helper before the lease (under 700 ceiling).
- \`src/mcp/tools.rs\` (+3 LOC, 476→477): bind_self schema adds rebase_mode boolean field.

Net +187 LOC / 1 commit (\`5286213\`). Within lead estimate 150-250 LOC budget.

## Tests (5 new in force_release.rs, 17/17 pass)

- \`rebase_clean_self_clears_existing_dir_and_invokes_release_full\`
- \`rebase_clean_self_idempotent_on_clean_state\`
- \`rebase_clean_self_rejects_path_outside_worktree_pool\`
- \`bind_self_rebase_mode_runs_cleanup_before_lease_attempt\` — simulates Wave 1 PR-2 incident scenario
- \`bind_self_no_rebase_mode_skips_cleanup\` — inverse, existing behavior preserved

## STRICT v2 / Q2=(C) compliance

- daemon-managed worktree via \`bind_self\` ✓
- 0 BYPASS, no force-push (single clean commit post-\`reset --soft origin/main\` consolidation BEFORE first push — daemon auto-snapshots collapsed; no published-branch force) ✓
- file_size_invariant: worktree.rs at 699 LOC (under 700 ceiling) ✓
- Tool count invariant: rebase_mode is a param expansion, NOT a new tool — count stays at 31 ✓

## Test plan

- [x] \`cargo build --features tray\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features tray -- -D warnings\` clean (no warnings)
- [x] \`cargo test --features tray --bin agend-terminal force_release\` → 17/17 pass
- [x] \`cargo test --release --features tray --test file_size_invariant\` pass
- [x] Full \`cargo test --features tray --bin agend-terminal\` → 1960 pass; 7 pre-existing local-env claim_verifier flakes unrelated to this PR's surface (CI green for #574/#575/#576 just merged confirms these pass on CI infra)
- [ ] CI green across macos-latest / ubuntu-latest / windows-latest
- [ ] Tier-1 single primary review verdict

## Dogfood note

Once merged, downstream Wave 1 PR-2 (#P0-2 daemon hot-reload) and PR-3 (#P0-3 operator restart MCP tool) inherit the cleaner recover-and-bind primitive — future operators of those flows can use rebase_mode for atomic state recovery instead of orchestrating two-step sequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)