### PR TITLE
feat(daemon): #P0-1 Skills auto-install at agent launch (Sprint 61 W1 PR-1)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1372,6 +1372,29 @@ fn spawn_and_register_agent(
     // `SpawnMode::downgraded_for` for the why.
     let spawn_mode =
         crate::backend::SpawnMode::Resume.downgraded_for(command, working_dir.as_deref());
+
+    // Sprint 61 W1 PR-1 (#P0-1 Skills auto-install at agent launch):
+    // synchronous pre-spawn install per lead recommendation (a) — guarantees
+    // SKILL.md files are in place at the agent's first skill-discovery read.
+    // Best-effort: failures log + continue so a skills problem never blocks
+    // agent boot. Idempotent across restarts (install_for_agent skips
+    // pre-existing non-managed dirs + replaces managed ones per Sprint 60
+    // #581 contract).
+    if let Some(wd) = working_dir.as_deref() {
+        match crate::skills::install_for_agent(home, wd) {
+            Ok(outcomes) => {
+                let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
+                    .iter()
+                    .map(|o| (o.backend.as_str(), o.mode))
+                    .collect();
+                tracing::info!(agent = %name, ?modes, "skills auto-install complete");
+            }
+            Err(e) => {
+                tracing::warn!(agent = %name, error = %e, "skills auto-install failed, proceeding without skills");
+            }
+        }
+    }
+
     if let Err(e) = agent::spawn_agent(
         &agent::SpawnConfig {
             name,

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -759,4 +759,79 @@ mod tests {
         assert!(listed.is_empty());
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ── Sprint 61 W1 PR-1 (#P0-1) — auto-install pre-spawn smoke ──────────
+    //
+    // The daemon's spawn_and_register_agent calls install_for_agent
+    // synchronously BEFORE agent::spawn_agent so SKILL.md files are in
+    // place at the agent's first read. These tests verify the contract
+    // properties that wiring depends on:
+    // - install_for_agent succeeds with an empty (no skills added) source,
+    //   so a fresh daemon launch with no `agend skills add` history
+    //   doesn't fail agent boot.
+    // - The wiring's best-effort Err handling is testable here because
+    //   install_for_agent's only Err return is `ensure_skills_root`
+    //   filesystem failure; on success it always returns `Ok(Vec)`.
+
+    #[test]
+    fn install_for_agent_succeeds_with_empty_source_root() {
+        // Empty source: install_for_agent ensures the source root exists
+        // (via ensure_skills_root) then iterates 5 backends; each install
+        // creates an empty symlink/copy target with the marker. The
+        // outcomes vec has one entry per backend, all in Symlink/Copy
+        // mode (no Skipped from missing source). This is the daemon's
+        // first-launch case: no skills configured → still safe to wire
+        // pre-spawn.
+        let home = tmp_home("install-empty-source");
+        let working = home.join("agent-wd");
+        std::fs::create_dir_all(&working).unwrap();
+        let outcomes = install_for_agent(&home, &working).unwrap();
+        assert_eq!(outcomes.len(), BACKEND_SKILL_DIRS.len());
+        for outcome in &outcomes {
+            assert!(
+                matches!(outcome.mode, InstallMode::Symlink | InstallMode::Copy),
+                "empty-source install must succeed for backend {}: {:?}",
+                outcome.backend,
+                outcome
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn install_for_agent_creates_working_dir_parents_when_needed() {
+        // Daemon's spawn_and_register_agent may pass a working_dir whose
+        // .claude/ etc. parents don't exist yet (fresh agent worktree).
+        // install_for_agent's per-backend create_dir_all(parent) handles
+        // this — verify by passing a working_dir with no .claude/ pre-
+        // existing and checking the backend dirs land cleanly.
+        let home = tmp_home("install-create-parents");
+        let stage = home.join("stage");
+        seed_skill_source(&stage, "anchor");
+        add(&home, stage.join("anchor").to_str().unwrap()).unwrap();
+        let working = home.join("fresh-wd");
+        std::fs::create_dir_all(&working).unwrap();
+        // Sanity: no backend parents yet.
+        assert!(!working.join(".claude").exists());
+        let outcomes = install_for_agent(&home, &working).unwrap();
+        // Every backend's parent dir must now exist + the install
+        // landed at the conventional path.
+        for (backend, rel) in BACKEND_SKILL_DIRS {
+            let target = working.join(rel);
+            let outcome = outcomes
+                .iter()
+                .find(|o| o.backend == *backend)
+                .expect("outcome present for backend");
+            assert!(
+                matches!(outcome.mode, InstallMode::Symlink | InstallMode::Copy),
+                "fresh-parent install must succeed for {backend}"
+            );
+            assert!(target.exists(), "target landed for {backend}");
+            assert!(
+                target.join("anchor").join("SKILL.md").exists(),
+                "skill visible at {target:?}"
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
 }


### PR DESCRIPTION
<!-- LOC-EST: 80-150 -->

## Summary

- **Path A IMPL** — Sprint 61 W1 PR-1 leadoff. Closes the Sprint 60 W2 PR-1 #581 deferral: pure-wiring follow-up auto-invoking `crate::skills::install_for_agent` from the daemon's agent-launch path.
- 1 commit `48f1816` / +98 LOC across 2 files (within lead estimate 80-150 LOC budget).
- Operators no longer need to manually run `agend skills install <working_dir>` per agent.

## Implementation per lead recommendation (a) — synchronous pre-spawn

Hook lands in `src/daemon/mod.rs::spawn_and_register_agent` BEFORE `agent::spawn_agent`:

- Determinism: `install_for_agent` returns synchronously before `pty_system.openpty + spawn_command` → SKILL.md files in place at agent's first skill-discovery read. Closes the reviewer §9 startup-timing-race concern.
- Best-effort: skills install failures log + continue. Agent boot is never blocked by a skills problem.

## Surface

- `src/daemon/mod.rs` (+23): pre-spawn install hook with structured logging
- `src/skills.rs` (+75): 2 new tests covering wiring contract dependencies

Per #582 5-category framework: ~80-130 honest range, brackets actual 98 ✓.

## Tests (15/15 in skills::tests)

- 13 existing skills tests pass (no behavior change to install_for_agent)
- **NEW** `install_for_agent_succeeds_with_empty_source_root` — daemon's first-launch case (no `agend skills add` history) returns Ok with all 5 backends in Symlink/Copy mode. Critical for "never block agent boot" guarantee.
- **NEW** `install_for_agent_creates_working_dir_parents_when_needed` — fresh agent worktree with no `.claude/` etc. parents pre-existing; per-backend `create_dir_all(parent)` handles cleanly.

## Deferred

- End-to-end PTY-based smoke test (multi-process test harness infra not yet in place; deterministic ordering is structural — synchronous Rust call returns BEFORE spawn_command, race closed by control flow).
- Fallback shell respawn path (`agent.rs:959`) does NOT call install_for_agent in this PR. Sprint 61 follow-up candidate.

## STRICT v2 / Q2=(C) compliance

- daemon-managed worktree ✓
- 0 BYPASS, 0 force-push (single clean commit) ✓
- Tool count: 32 unchanged ✓
- file_size_invariant: doc-only N/A; mod.rs in src/daemon/ (700-LOC ceiling targets src/mcp/handlers/) ✓

## Test plan

- [x] `cargo build --features tray` ✓
- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets --features tray -- -D warnings` ✓ (no warnings)
- [x] `cargo test --features tray --bin agend-terminal skills` → 15/15 pass
- [x] `cargo test --release --features tray --test file_size_invariant` ✓
- [x] `cargo test --features tray --bin agend-terminal mcp::tools::tests::tool_definitions_count_invariant_post_sprint_30` ✓
- [ ] CI green across macos-latest / ubuntu-latest / windows-latest
- [ ] Tier-1 single primary review verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)