### PR TITLE
feat(skills): #P0-2 fleet.yaml per-instance skills override (Sprint 61 W1 PR-2)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -732,7 +732,10 @@ pub fn run_skills_install(home: &Path, working_dir: &str) -> anyhow::Result<()> 
             wd.display()
         ));
     }
-    let outcomes = crate::skills::install_for_agent(home, &wd)?;
+    // CLI subcommand uses install-all default; per-instance filtering
+    // is the daemon's automatic launch-flow responsibility (Sprint 61
+    // W1 PR-2 #P0-2 fleet.yaml `instance.<name>.skills:` override).
+    let outcomes = crate::skills::install_for_agent(home, &wd, None)?;
     println!("installed skills into {}:", wd.display());
     for o in outcomes {
         match o.mode {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1381,13 +1381,26 @@ fn spawn_and_register_agent(
     // pre-existing non-managed dirs + replaces managed ones per Sprint 60
     // #581 contract).
     if let Some(wd) = working_dir.as_deref() {
-        match crate::skills::install_for_agent(home, wd) {
+        // Sprint 61 W1 PR-2 (#P0-2): consult fleet.yaml for per-instance
+        // skills override. None → install all (W1 PR-1 default); Some(vec)
+        // → install only the named skills (Some(empty) opts the agent
+        // out of skills entirely).
+        let skills_filter: Option<Vec<String>> =
+            crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+                .ok()
+                .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
+        match crate::skills::install_for_agent(home, wd, skills_filter.as_deref()) {
             Ok(outcomes) => {
                 let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
                     .iter()
                     .map(|o| (o.backend.as_str(), o.mode))
                     .collect();
-                tracing::info!(agent = %name, ?modes, "skills auto-install complete");
+                tracing::info!(
+                    agent = %name,
+                    ?modes,
+                    filter = ?skills_filter,
+                    "skills auto-install complete"
+                );
             }
             Err(e) => {
                 tracing::warn!(agent = %name, error = %e, "skills auto-install failed, proceeding without skills");

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -207,6 +207,15 @@ pub struct InstanceConfig {
     /// operator's GitHub login.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_login: Option<String>,
+    /// Sprint 61 W1 PR-2 (#P0-2): per-instance skills allowlist. When
+    /// `Some(vec)`, the daemon's auto-install hook installs only the
+    /// listed skill names from `<home>/skills/` into this agent's
+    /// per-backend skill paths. When `None`, every skill in the unified
+    /// source is installed (preserves the W1 PR-1 #585 default behavior).
+    /// `Some(vec![])` is meaningful — explicitly opts the agent OUT of
+    /// all skills (no per-backend dirs are populated).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skills: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -273,15 +273,77 @@ pub fn update_all(home: &Path) -> Vec<(String, Result<Skill>)> {
 /// resolves to the unified source. Idempotent: pre-existing daemon-
 /// managed symlinks/copies are replaced; pre-existing non-managed
 /// directories are left alone with a tracing::warn.
-pub fn install_for_agent(home: &Path, working_dir: &Path) -> Result<Vec<InstallOutcome>> {
+///
+/// Sprint 61 W1 PR-2 (#P0-2): when `filter` is `Some(allowlist)`, only
+/// the named skills land in each backend's path — built by staging a
+/// scratch source dir under `<home>/.skills-stage/<digest>/` containing
+/// only the allowlisted entries from the unified source, then installing
+/// from the stage. `Some(vec![])` is meaningful and explicit — agent
+/// gets per-backend dirs that contain only the daemon-managed marker
+/// (no skills). `None` preserves the W1 PR-1 #585 install-all default.
+pub fn install_for_agent(
+    home: &Path,
+    working_dir: &Path,
+    filter: Option<&[String]>,
+) -> Result<Vec<InstallOutcome>> {
     let source = ensure_skills_root(home)?;
+    let staged_source = match filter {
+        None => source,
+        Some(allowlist) => stage_filtered_source(home, &source, allowlist)?,
+    };
     let mut outcomes = Vec::with_capacity(BACKEND_SKILL_DIRS.len());
     for (backend, rel) in BACKEND_SKILL_DIRS {
         let target = working_dir.join(rel);
-        let outcome = install_one(&source, &target, backend);
+        let outcome = install_one(&staged_source, &target, backend);
         outcomes.push(outcome);
     }
     Ok(outcomes)
+}
+
+/// Stage a filtered copy of the unified source containing only the
+/// allowlisted skills. Stage path is `<home>/.skills-stage/<digest>/`
+/// where `digest` is a stable per-allowlist FNV-1a hash so multiple
+/// distinct filters coexist without overwrite. Rebuilt every call
+/// (idempotent + cheap — copies only of allowlisted names, not the
+/// full unified source).
+fn stage_filtered_source(home: &Path, source: &Path, allowlist: &[String]) -> Result<PathBuf> {
+    let mut digest_input = String::new();
+    let mut sorted: Vec<&String> = allowlist.iter().collect();
+    sorted.sort();
+    for name in &sorted {
+        digest_input.push_str(name);
+        digest_input.push('\n');
+    }
+    let digest = format!("{:016x}", fnv1a_64(digest_input.as_bytes()));
+    let stage = home.join(".skills-stage").join(&digest);
+    if stage.exists() {
+        std::fs::remove_dir_all(&stage)
+            .with_context(|| format!("clean stage {}", stage.display()))?;
+    }
+    std::fs::create_dir_all(&stage).with_context(|| format!("create stage {}", stage.display()))?;
+    for name in allowlist {
+        let from = source.join(name);
+        if !from.exists() {
+            tracing::warn!(skill = %name, source = %source.display(),
+                "stage_filtered_source: allowlisted skill not present, skipping");
+            continue;
+        }
+        let to = stage.join(name);
+        copy_dir_recursive(&from, &to)?;
+    }
+    Ok(stage)
+}
+
+/// FNV-1a 64-bit hash — small, dependency-free, stable across runs.
+/// Used for the filtered-source stage path so identical allowlists
+/// always resolve to the same stage dir.
+fn fnv1a_64(data: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in data {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100_0000_01b3);
+    }
+    h
 }
 
 /// Per-backend install result.
@@ -635,7 +697,7 @@ mod tests {
         let working = home.join("agent-wd");
         std::fs::create_dir_all(&working).unwrap();
 
-        let outcomes = install_for_agent(&home, &working).unwrap();
+        let outcomes = install_for_agent(&home, &working, None).unwrap();
         assert_eq!(outcomes.len(), BACKEND_SKILL_DIRS.len());
         for outcome in &outcomes {
             assert!(
@@ -673,7 +735,7 @@ mod tests {
         std::fs::create_dir_all(&claude).unwrap();
         std::fs::write(claude.join("operator-skill.md"), "hand-crafted\n").unwrap();
 
-        let outcomes = install_for_agent(&home, &working).unwrap();
+        let outcomes = install_for_agent(&home, &working, None).unwrap();
         let claude_outcome = outcomes.iter().find(|o| o.backend == "claude").unwrap();
         assert_eq!(
             claude_outcome.mode,
@@ -703,9 +765,9 @@ mod tests {
         std::fs::create_dir_all(&working).unwrap();
 
         // First install.
-        install_for_agent(&home, &working).unwrap();
+        install_for_agent(&home, &working, None).unwrap();
         // Second install must succeed (idempotent).
-        let outcomes = install_for_agent(&home, &working).unwrap();
+        let outcomes = install_for_agent(&home, &working, None).unwrap();
         for outcome in &outcomes {
             assert!(matches!(
                 outcome.mode,
@@ -785,7 +847,7 @@ mod tests {
         let home = tmp_home("install-empty-source");
         let working = home.join("agent-wd");
         std::fs::create_dir_all(&working).unwrap();
-        let outcomes = install_for_agent(&home, &working).unwrap();
+        let outcomes = install_for_agent(&home, &working, None).unwrap();
         assert_eq!(outcomes.len(), BACKEND_SKILL_DIRS.len());
         for outcome in &outcomes {
             assert!(
@@ -813,7 +875,7 @@ mod tests {
         std::fs::create_dir_all(&working).unwrap();
         // Sanity: no backend parents yet.
         assert!(!working.join(".claude").exists());
-        let outcomes = install_for_agent(&home, &working).unwrap();
+        let outcomes = install_for_agent(&home, &working, None).unwrap();
         // Every backend's parent dir must now exist + the install
         // landed at the conventional path.
         for (backend, rel) in BACKEND_SKILL_DIRS {
@@ -831,6 +893,93 @@ mod tests {
                 target.join("anchor").join("SKILL.md").exists(),
                 "skill visible at {target:?}"
             );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 61 W1 PR-2 (#P0-2) — fleet.yaml per-instance override ─────
+
+    #[test]
+    fn install_for_agent_with_filter_includes_only_allowlisted_skills() {
+        // Stage 3 skills in unified source; install only `alpha` + `gamma`
+        // for the agent. `beta` must NOT appear at any backend path.
+        let home = tmp_home("filter-allowlist");
+        let stage = home.join("stage");
+        seed_skill_source(&stage, "alpha");
+        seed_skill_source(&stage, "beta");
+        seed_skill_source(&stage, "gamma");
+        add(&home, stage.join("alpha").to_str().unwrap()).unwrap();
+        add(&home, stage.join("beta").to_str().unwrap()).unwrap();
+        add(&home, stage.join("gamma").to_str().unwrap()).unwrap();
+        let working = home.join("agent-wd");
+        std::fs::create_dir_all(&working).unwrap();
+        let allowlist = vec!["alpha".to_string(), "gamma".to_string()];
+
+        let outcomes = install_for_agent(&home, &working, Some(&allowlist)).unwrap();
+        for outcome in &outcomes {
+            assert!(matches!(
+                outcome.mode,
+                InstallMode::Symlink | InstallMode::Copy
+            ));
+            assert!(outcome.target.join("alpha").join("SKILL.md").exists());
+            assert!(outcome.target.join("gamma").join("SKILL.md").exists());
+            assert!(
+                !outcome.target.join("beta").exists(),
+                "beta must NOT appear under {} (filter excluded)",
+                outcome.target.display()
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn install_for_agent_with_empty_filter_opts_out_of_all_skills() {
+        // Some(empty) is meaningful — agent gets per-backend dirs but
+        // none of the skills from the unified source.
+        let home = tmp_home("filter-empty");
+        let stage = home.join("stage");
+        seed_skill_source(&stage, "anchor");
+        add(&home, stage.join("anchor").to_str().unwrap()).unwrap();
+        let working = home.join("agent-wd");
+        std::fs::create_dir_all(&working).unwrap();
+        let empty: Vec<String> = Vec::new();
+
+        let outcomes = install_for_agent(&home, &working, Some(&empty)).unwrap();
+        for outcome in &outcomes {
+            assert!(matches!(
+                outcome.mode,
+                InstallMode::Symlink | InstallMode::Copy
+            ));
+            assert!(
+                !outcome.target.join("anchor").exists(),
+                "anchor must NOT appear under {} (empty filter)",
+                outcome.target.display()
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn install_for_agent_with_filter_skips_unknown_skill_names() {
+        // Allowlist references a skill not in the unified source — the
+        // helper logs warn + skips silently rather than failing the
+        // whole install. Other allowlisted skills land normally.
+        let home = tmp_home("filter-unknown");
+        let stage = home.join("stage");
+        seed_skill_source(&stage, "real");
+        add(&home, stage.join("real").to_str().unwrap()).unwrap();
+        let working = home.join("agent-wd");
+        std::fs::create_dir_all(&working).unwrap();
+        let allowlist = vec!["real".to_string(), "ghost".to_string()];
+
+        let outcomes = install_for_agent(&home, &working, Some(&allowlist)).unwrap();
+        for outcome in &outcomes {
+            assert!(matches!(
+                outcome.mode,
+                InstallMode::Symlink | InstallMode::Copy
+            ));
+            assert!(outcome.target.join("real").join("SKILL.md").exists());
+            assert!(!outcome.target.join("ghost").exists());
         }
         std::fs::remove_dir_all(&home).ok();
     }


### PR DESCRIPTION
<!-- LOC-EST: 50-130 -->

## Summary

- **Path A IMPL** — Sprint 61 W1 PR-2. Closes Sprint 60 #581 deferral 2: pure-wiring follow-up adding optional `instance.<name>.skills:` allowlist to fleet.yaml.
- 1 commit `16c69db` / +185 LOC across 4 files.
- Operators can now scope skill installs per agent (vs uniform install-all from W1 PR-1 #585).

## Implementation per lead recommendation Option (a)

Additive signature extension on `install_for_agent`: new `filter: Option<&[String]>` parameter. When `Some(allowlist)`, helper stages a filtered copy of unified source under `<home>/.skills-stage/<digest>/` then installs from stage. `Some(vec![])` is meaningful — explicit opt-out of all skills.

## Surface

- `src/fleet.rs` (+9): `InstanceConfig.skills: Option<Vec<String>>` with serde-default
- `src/skills.rs` (+165): signature extension + `stage_filtered_source` helper + FNV-1a digest + 3 new filter tests
- `src/daemon/mod.rs` (+17): spawn_and_register_agent reads fleet skills field + passes filter
- `src/cli.rs` (+5): CLI subcommand passes None (install-all preserved at manual level)

## Tests (18/18 in skills::tests)

- 15 existing (mechanical sed-update for new None param)
- **NEW** filter-allowlist (Some(["alpha", "gamma"]) → only alpha + gamma, NOT beta)
- **NEW** filter-empty (Some(vec![]) → per-backend dirs with no skills)
- **NEW** filter-unknown (allowlist references unknown name → log warn + skip silently)

## Scope-overage transparency (per #582)

**+185 LOC vs PLAN P0-2 50-130 = 42% over upper bound** (above 130% soft-warn). Per 5-category framework: honest range 130-180 LOC; actual 185 just over by 5.

Cohesion-accept rationale: signature extension + staging helper + filter tests + fleet integration form a cohesive change; splitting fleet.yaml field separate from staging would create unconsumed schema field until follow-up.

## Backwards-compat

- `skills` field is `Option<Vec<String>>` with serde-default — fleet.yaml without field parses unchanged
- `install_for_agent(_, _, None)` byte-identical to W1 PR-1 #585 behavior
- CLI subcommand passes None (install-all preserved at manual level)
- Tool count: 32 unchanged

## Sprint 60 #581 deferrals

- ✓ Deferral 1 (auto-install at agent launch) — W1 PR-1 #585
- ✓ Deferral 2 (fleet.yaml per-instance override) — THIS PR

## STRICT v2 / Q2=(C) compliance

- daemon-managed worktree ✓
- 0 BYPASS, 0 force-push (single clean commit) ✓
- Tool count: 32 unchanged ✓

## Test plan

- [x] `cargo build --features tray` ✓
- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets --features tray -- -D warnings` ✓
- [x] `cargo test --features tray --bin agend-terminal skills` → 18/18 pass
- [x] `cargo test --release --features tray --test file_size_invariant` ✓
- [x] `cargo test --features tray --bin agend-terminal mcp::tools::tests::tool_definitions_count_invariant_post_sprint_30` ✓
- [ ] CI green across all 3 platforms
- [ ] Tier-1 single primary review verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope-overage transparency (cohesion-accept option (a))

**+185 net LOC delivered vs PLAN P0-2 estimate ~50-130 LOC** = 42% over upper bound (above 130% soft-warn threshold = 169).

### Cohesion-accept (reviewer option (a))
Per Tier-1 single primary adjudication: signature extension + staging helper + filter tests + fleet integration form cohesive change; splitting fleet.yaml field separate from staging would create unconsumed schema field until follow-up.

### Honest re-derivation via 5-category framework
- New API extension + staging helper baseline 130-180 LOC
- Brackets actual 185 LOC (just over by 5)

### Sprint 62+ candidate (per reviewer minor caveat)
- FNV non-crypto digest + optional stage GC for `<home>/.skills-stage/<digest>/` cleanup

### Q2=(C) compliance preserved
0 BYPASS, single clean commit, daemon-managed worktree throughout.

### Reviewer adjudication reference
m-20260510002852292717-454 (cohesion-accept option (a) + Sprint 60 #581 deferral 2 closure).
