### PR TITLE
feat(skills): #P0-2 skills-stage GC with TOCTOU same-run exclusion (Sprint 62 W1 PR-2)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -348,6 +348,19 @@ fn run_core(
     // G3 H1: replaced set_var with DaemonConfig init (thread-safe).
     crate::daemon_config::init(crate::daemon_config::DaemonConfig::default());
 
+    // Sprint 62 W1 PR-2 (#P0-2 skills-stage GC): sweep stale
+    // <home>/.skills-stage/<digest>/ dirs older than 7 days. Runs
+    // BEFORE any spawn_and_register_agent invocation so concurrent
+    // install_for_agent never races with the GC. Empty exclusion
+    // list at this site (no installs have happened yet); periodic-
+    // GC sites added later would pass currently-resolved digests.
+    // Best-effort: failures log + continue, never block boot.
+    const SKILLS_STAGE_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
+    match crate::skills::cleanup_stale_stages(home, SKILLS_STAGE_RETENTION_SECS, &[]) {
+        Ok(report) => tracing::info!(?report, "skills-stage GC: daemon-init sweep complete"),
+        Err(e) => tracing::warn!(error = %e, "skills-stage GC: daemon-init sweep failed"),
+    }
+
     // Sprint 24 P0 PR2 — bridge-phase legacy migration. Walks tasks.json
     // and emits canonical Created (+ status transition) events into
     // task_events.jsonl. Idempotent: re-run is a no-op via tail-scan

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -341,6 +341,85 @@ fn stage_filtered_source(home: &Path, source: &Path, allowlist: &[String]) -> Re
     Ok(stage)
 }
 
+/// Sprint 62 W1 PR-2 (#P0-2): GC report — what `cleanup_stale_stages`
+/// found and acted on.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StageGcReport {
+    pub candidates: usize,
+    pub deleted: usize,
+    pub preserved_recent: usize,
+    pub preserved_excluded: usize,
+}
+
+/// Sprint 62 W1 PR-2 (#P0-2): GC stale `<home>/.skills-stage/<digest>/`
+/// directories. Closes the Sprint 61 #586 reviewer minor caveat
+/// (stage dirs accumulate without GC) and the Sprint 62 PLAN review
+/// reviewer minor add (TOCTOU safety via same-run exclusion).
+///
+/// - `retention_secs`: stages with mtime older than this threshold are
+///   eligible for deletion. Recommended 7-day window for daemon-init
+///   invocation.
+/// - `exclude_digests`: stage dir names to never delete (currently-
+///   resolved stages from same run, per reviewer minor add). Empty
+///   when invoked at daemon-init (no installs have happened yet);
+///   non-empty for any future periodic-GC site.
+///
+/// Returns counts so callers can log/test the GC outcome. Fail-open:
+/// IO failures during a single dir removal log warn + continue;
+/// missing stage root short-circuits with empty report.
+pub fn cleanup_stale_stages(
+    home: &Path,
+    retention_secs: u64,
+    exclude_digests: &[String],
+) -> Result<StageGcReport> {
+    let stage_root = home.join(".skills-stage");
+    let mut report = StageGcReport::default();
+    let entries = match std::fs::read_dir(&stage_root) {
+        Ok(it) => it,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(report),
+        Err(e) => {
+            return Err(anyhow!("read_dir {}: {}", stage_root.display(), e));
+        }
+    };
+    let now = std::time::SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        report.candidates += 1;
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if exclude_digests.iter().any(|d| d == &name) {
+            report.preserved_excluded += 1;
+            continue;
+        }
+        let mtime = entry.metadata().and_then(|m| m.modified()).ok();
+        let elapsed = mtime
+            .and_then(|t| now.duration_since(t).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        if elapsed < retention_secs {
+            report.preserved_recent += 1;
+            continue;
+        }
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => {
+                report.deleted += 1;
+                tracing::info!(stage = %name, elapsed_secs = elapsed,
+                    "skills-stage GC: removed stale stage dir");
+            }
+            Err(e) => {
+                tracing::warn!(stage = %name, error = %e,
+                    "skills-stage GC: removal failed, skipping");
+            }
+        }
+    }
+    Ok(report)
+}
+
 /// SHA-256 prefix digest used for the filtered-source stage path.
 /// 16 hex chars = first 8 bytes of SHA-256 output → 64 bits of
 /// collision resistance, sufficient at the daemon's scale (collision
@@ -1041,6 +1120,80 @@ mod tests {
             "stage dir {:?} must end with SHA-256 prefix {expected}",
             stage_dir
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 62 W1 PR-2 (#P0-2) — skills-stage GC ────────────────────
+
+    fn seed_aged_stage(home: &Path, name: &str, age_secs: u64) {
+        let path = home.join(".skills-stage").join(name);
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(path.join("marker"), b"stage").unwrap();
+        let now = std::time::SystemTime::now();
+        let back = now - std::time::Duration::from_secs(age_secs);
+        let secs = back
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let dt = chrono::DateTime::<chrono::Utc>::from(
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs),
+        );
+        // touch -t format: [[CC]YY]MMDDhhmm[.ss]
+        let arg = dt.format("%Y%m%d%H%M.%S").to_string();
+        let _ = std::process::Command::new("touch")
+            .args(["-t", &arg])
+            .arg(&path)
+            .status();
+    }
+
+    #[test]
+    fn cleanup_stale_stages_deletes_aged_dirs_above_threshold() {
+        let home = tmp_home("gc-aged");
+        std::fs::create_dir_all(home.join(".skills-stage").join("fresh")).unwrap();
+        std::fs::write(
+            home.join(".skills-stage").join("fresh").join("marker"),
+            b"x",
+        )
+        .unwrap();
+        seed_aged_stage(&home, "ancient", 8 * 24 * 60 * 60);
+
+        let report = cleanup_stale_stages(&home, 7 * 24 * 60 * 60, &[]).unwrap();
+        assert_eq!(report.candidates, 2);
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.preserved_recent, 1);
+        assert_eq!(report.preserved_excluded, 0);
+        assert!(home.join(".skills-stage").join("fresh").exists());
+        assert!(!home.join(".skills-stage").join("ancient").exists());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn cleanup_stale_stages_excludes_named_digests_from_deletion() {
+        // Reviewer minor add: same-run exclusion prevents TOCTOU
+        // deletion of just-staged. Excluded dirs preserved even if
+        // older than retention threshold.
+        let home = tmp_home("gc-exclude");
+        seed_aged_stage(&home, "active-stage", 8 * 24 * 60 * 60);
+        seed_aged_stage(&home, "stale-stage", 8 * 24 * 60 * 60);
+
+        let exclude = vec!["active-stage".to_string()];
+        let report = cleanup_stale_stages(&home, 7 * 24 * 60 * 60, &exclude).unwrap();
+        assert_eq!(report.candidates, 2);
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.preserved_recent, 0);
+        assert_eq!(report.preserved_excluded, 1);
+        assert!(home.join(".skills-stage").join("active-stage").exists());
+        assert!(!home.join(".skills-stage").join("stale-stage").exists());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn cleanup_stale_stages_returns_empty_report_when_root_missing() {
+        // Daemon-init invocation on fresh AgEnD home (no .skills-
+        // stage dir created yet). Must return empty report, not error.
+        let home = tmp_home("gc-no-root");
+        let report = cleanup_stale_stages(&home, 7 * 24 * 60 * 60, &[]).unwrap();
+        assert_eq!(report, StageGcReport::default());
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
<!-- LOC-EST: 50-90 -->

## Summary

- **Path A IMPL** — Sprint 62 W1 PR-2. Closes Sprint 61 #586 reviewer minor caveat (skills-stage GC).
- 1 commit `6c7bf7f` / +166 LOC across 2 files.
- ★ HARD-FAIL cohesion-accept Option (a) lead-authorized ★ — first real-world #587 OVERRIDE path validation case.

## Implementation

`cleanup_stale_stages(home, retention_secs, exclude_digests) -> StageGcReport`:
- Scans `<home>/.skills-stage/<digest>/` dirs
- Skips dirs in exclude_digests (TOCTOU same-run protection per reviewer minor add)
- Deletes dirs older than retention_secs (7 days for daemon-init)
- Returns counts (candidates / deleted / preserved_recent / preserved_excluded)
- Fail-open IO

Daemon-init invocation in `src/daemon/mod.rs::run_core` BEFORE spawn loop with empty exclusion + 7-day retention. Sweeps legacy FNV-named stages from pre-#590 era automatically.

## Tests (24/24, +3 new)

- `cleanup_stale_stages_deletes_aged_dirs_above_threshold` — fresh + aged → deletes ancient, preserves fresh
- `cleanup_stale_stages_excludes_named_digests_from_deletion` — TOCTOU exclusion (★ reviewer minor add ★)
- `cleanup_stale_stages_returns_empty_report_when_root_missing` — daemon-init early-return guard

## Scope-overage transparency (HARD-FAIL cohesion-accept Option (a) — lead-authorized m-20260510022431882076-505)

**+166 LOC vs PLAN P0-2 50-90 = 84% over upper bound = HARD-FAIL** (>150% threshold = 135).

Per #582 §5.3 escalation: surfaced to lead pre-push; lead-authorized Option (a) cohesion-accept override per established standard procedure (5+ cohesion-accept precedents since Sprint 59 W2). `loc-overrun-accepted` label applied for #587 automation OVERRIDE path verification.

★ **First real-world #587 automation HARD-FAIL → OVERRIDE path validation case** ★ — parallel to #590's PASS path validation. Together both validate the #587 automation end-to-end.

Honest re-derivation per #582 5-category framework:
- Boilerplate: 5 (StageGcReport struct)
- Test density: 75 (helper + 3 tests including TOCTOU)
- New function: 80 (cleanup_stale_stages with fail-open IO + retention + exclusion + tracing + doc)
- Honest range: 130-180 LOC; actual 166 ✓

PLAN P0-2 missed: StageGcReport struct + tracing structured-logging + 3-test load-bearing coverage.

Cohesion-accept rationale: empty-root-missing test load-bearing for daemon-init invocation safety; helper-only split creates unconsumed artifact; trim damages TOCTOU coverage.

## Sprint 61 #586 deferral closure

- ✓ #586 FNV non-crypto — #590 ✓ MERGED 541562b
- ✓ #586 skills-stage GC — THIS PR

#586 closure complete.

## STRICT v2 / Q2=(C) compliance

- daemon-managed worktree ✓
- 0 BYPASS, 0 force-push (single clean commit) ✓
- Tool count: 32 unchanged ✓

## Test plan

- [x] `cargo build --features tray` ✓
- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets --features tray -- -D warnings` ✓
- [x] `cargo test --features tray --bin agend-terminal skills` → 24/24 pass
- [x] `cargo test --release --features tray --test file_size_invariant` ✓
- [ ] CI green across all 3 platforms
- [ ] **#587 LOC overrun automation: expects HARD-FAIL → OVERRIDE PASS once `loc-overrun-accepted` label applied**
- [ ] Tier-1 single primary review verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)