### PR TITLE
docs(rca): #4 ci_watch Item 1 narrative tightening (Sprint 63 W1 PR-1)

### DIFF
--- a/docs/RCA-issue-546-ci-watch-lifecycle-hygiene-2026-05-09.md
+++ b/docs/RCA-issue-546-ci-watch-lifecycle-hygiene-2026-05-09.md
@@ -63,9 +63,16 @@ Concrete failure modes:
 2. **Agent released without unsubscribe (see Item 2)**: subscriber array is
    non-empty but the agent is gone. Watch keeps polling → fine for TTL, but
    wastes API budget.
-3. **Daemon restart immediately followed by branch-delete**: watch file on
-   disk has expired `expires_at`, but no poll tick has run yet because the
-   branch is now 404. The file persists indefinitely.
+3. **Daemon restart with the upstream branch already 404**: the per-tick
+   poll fires, but the GitHub API call returns 404 for the deleted branch.
+   The 404 response handler returns before reaching the per-watch
+   expiry-check branch (which only fires on successful CI verdict
+   responses), so a watch with `expires_at < now` persists indefinitely
+   on disk until either (a) the agent re-creates a same-name branch and
+   the next poll sees a non-404 response that flows into the expiry
+   check, or (b) an out-of-band sweep removes it. Sprint 63 W1 PR-1
+   tightening note: pre-Sprint-57-W2-Track-B, no out-of-band sweep
+   existed; the file persisted forever.
 4. **No audit-log event** is emitted when a watch expires (the lazy `remove`
    at ci_watch.rs:1310 has no `event_log::log` call alongside it). Operator
    has no signal of cleanup activity.
@@ -84,6 +91,16 @@ Two-step:
 
 Add `event_log::log(home, "ci_watch_expired", &watch.repo, &reason)` next to
 each removal so operators can trace lifecycle events.
+
+### Status as of Sprint 57 W2 Track B (post-RCA mitigation)
+
+`daemon::ci_watch::gc_stale_watches` (`src/daemon/ci_watch.rs:1223`) implements
+both steps above. The eager sweep walks `$AGEND_HOME/ci-watches/*.json`
+without entering the poll path, applies (1) absolute TTL / (2) inactivity
+TTL / (3) protected-ref migration in precedence order, and emits
+`tracing::info!` per removal. Failure modes 1-3 above are mitigated; the
+"persists indefinitely" tail of failure mode 3 only applies to pre-Sprint-
+57-W2-Track-B daemon versions.
 
 ### Tests gap
 


### PR DESCRIPTION
<!-- LOC-EST: 10-30 -->

## Summary

- **Path B doc tightening** — Sprint 63 W1 leadoff. Closes Sprint 58 P2 #4 (deferred carryover) per Sprint 57 Wave 1 Track A reviewer non-blocking note.
- 1 commit `0624586` / +17 LOC net (within PLAN 10-30 budget).

## Changes

### Failure mode 3 wording tightened
Pre-fix imprecision: "no poll tick has run yet because the branch is now 404" — the poll tick DOES run; the 404 is the API response. Post-fix tightens cause-and-effect: per-tick poll fires → API 404 → 404 handler returns before expiry check → watch persists. Adds recovery paths for completeness.

### NEW section: "Status as of Sprint 57 W2 Track B (post-RCA mitigation)"
Without a status annotation, future readers wouldn't know whether the §73-86 "Recommended fix shape (Phase B IMPL)" has shipped. New section names `daemon::ci_watch::gc_stale_watches` (`src/daemon/ci_watch.rs:1223`) + confirms failure modes 1-3 mitigated post-Track-B.

## Surface

- `docs/RCA-issue-546-ci-watch-lifecycle-hygiene-2026-05-09.md` (+20/-3 = net +17 LOC)

Per #587 automation: 17 ≤ 30 = PASS exit 0.

## Sprint 58 P2 #4 closure

3-Sprint deferred (Sprint 58 P2 → 59 → 60 → 61 → 62 → 63 W1 PR-1) closed via cheapest-filler narrative tightening leadoff.

## STRICT v2 / Q2=(C) compliance

- daemon-managed worktree ✓
- 0 BYPASS, 0 force-push (single clean commit) ✓
- Tool count: 32 unchanged ✓
- file_size_invariant: doc-only N/A ✓

## Test plan

- [x] `cargo fmt --check` ✓ (doc-only)
- [x] No `.rs` changes — clippy/tests N/A
- [ ] CI green across all 3 platforms (doc-only, expects fast pass)
- [ ] #587 LOC overrun automation reports PASS (17 ≤ 30 = within budget)
- [ ] Tier-1 single primary review verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)