### PR TITLE
feat(daemon): #5 dedup-state tmp orphan GC (Sprint 63 W1 PR-2)

### DIFF
--- a/src/daemon/dedup_state.rs
+++ b/src/daemon/dedup_state.rs
@@ -431,6 +431,79 @@ fn quarantine_corrupt_file(path: &Path) -> String {
     }
 }
 
+/// Sprint 63 W1 PR-2 (Sprint 58 P2 #5): GC report — what
+/// `cleanup_tmp_orphans` found and acted on.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DedupStateGcReport {
+    pub candidates: usize,
+    pub deleted: usize,
+    pub preserved_recent: usize,
+}
+
+/// Sprint 63 W1 PR-2 (Sprint 58 P2 #5): GC stale `*.tmp` / `*.json.tmp`
+/// orphans under `<home>/dedup-state/`. Closes the Sprint 57 Track C
+/// #553 Pass 2 reviewer note about startup tmp-file cleanup.
+///
+/// Background: `save` (line 260) uses `crate::store::atomic_write`
+/// (write-then-rename). When the daemon crashes between the write and
+/// the rename, a `*.json.tmp` file lingers in `dedup-state/` with no
+/// reader. These accumulate over crash cycles.
+///
+/// Mirrors the Sprint 62 #591 `cleanup_stale_stages` pattern: fail-
+/// open IO, retention threshold, report struct. No same-run exclusion
+/// needed — daemon-init is the only invocation site, and `save` only
+/// produces tmp files transiently between write+rename within a single
+/// syscall pair (any tmp older than the retention threshold is truly
+/// orphaned).
+///
+/// Returns counts so callers can log/test the GC outcome.
+pub fn cleanup_tmp_orphans(home: &std::path::Path, retention_secs: u64) -> DedupStateGcReport {
+    let dedup_root = home.join(DEDUP_STATE_DIR);
+    let mut report = DedupStateGcReport::default();
+    let entries = match std::fs::read_dir(&dedup_root) {
+        Ok(it) => it,
+        Err(_) => return report, // missing root → empty report (fresh home)
+    };
+    let now = std::time::SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        // Match `*.tmp` (catches both `<agent>.json.tmp` from atomic_write
+        // and any other *.tmp leftover that might land here).
+        if !name.ends_with(".tmp") {
+            continue;
+        }
+        report.candidates += 1;
+        let mtime = entry.metadata().and_then(|m| m.modified()).ok();
+        let elapsed = mtime
+            .and_then(|t| now.duration_since(t).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        if elapsed < retention_secs {
+            report.preserved_recent += 1;
+            continue;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                report.deleted += 1;
+                tracing::info!(file = %name, elapsed_secs = elapsed,
+                    "dedup-state GC: removed orphan tmp file");
+            }
+            Err(e) => {
+                tracing::warn!(file = %name, error = %e,
+                    "dedup-state GC: removal failed, skipping");
+            }
+        }
+    }
+    report
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -1278,6 +1351,78 @@ mod tests {
                 .exists(),
             "healthy file remains at original path"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── Sprint 63 W1 PR-2 (Sprint 58 P2 #5) — tmp orphan cleanup ─────
+
+    /// Helper: stage a back-dated tmp file using `touch -t` so retention
+    /// checks see it as old. POSIX-portable. Mirrors `seed_aged_stage`
+    /// from `src/skills.rs::tests::cleanup_stale_stages_*`.
+    fn seed_aged_tmp(home: &std::path::Path, name: &str, age_secs: u64) {
+        let dir = home.join(DEDUP_STATE_DIR);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        std::fs::write(&path, b"orphan tmp content").unwrap();
+        let now = std::time::SystemTime::now();
+        let back = now - std::time::Duration::from_secs(age_secs);
+        let secs = back
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let dt = chrono::DateTime::<chrono::Utc>::from(
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs),
+        );
+        let arg = dt.format("%Y%m%d%H%M.%S").to_string();
+        let _ = std::process::Command::new("touch")
+            .args(["-t", &arg])
+            .arg(&path)
+            .status();
+    }
+
+    #[test]
+    fn cleanup_tmp_orphans_deletes_aged_tmp_files_above_threshold() {
+        let home = tmp_home("tmp-gc-aged");
+        // Two tmp files: one fresh (now), one aged 2 days.
+        std::fs::create_dir_all(home.join(DEDUP_STATE_DIR)).unwrap();
+        std::fs::write(home.join(DEDUP_STATE_DIR).join("fresh.json.tmp"), b"x").unwrap();
+        seed_aged_tmp(&home, "ancient.json.tmp", 2 * 24 * 60 * 60);
+
+        let report = cleanup_tmp_orphans(&home, 24 * 60 * 60);
+        assert_eq!(report.candidates, 2);
+        assert_eq!(report.deleted, 1);
+        assert_eq!(report.preserved_recent, 1);
+        assert!(home.join(DEDUP_STATE_DIR).join("fresh.json.tmp").exists());
+        assert!(!home.join(DEDUP_STATE_DIR).join("ancient.json.tmp").exists());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn cleanup_tmp_orphans_preserves_non_tmp_files() {
+        // *.json (production state files, not tmp) must NOT be touched
+        // even if aged. Only `*.tmp` is a candidate for cleanup.
+        let home = tmp_home("tmp-gc-preserve-json");
+        seed_aged_tmp(&home, "agent.json", 2 * 24 * 60 * 60);
+        seed_aged_tmp(&home, "agent.json.tmp", 2 * 24 * 60 * 60);
+
+        let report = cleanup_tmp_orphans(&home, 24 * 60 * 60);
+        assert_eq!(report.candidates, 1, "only .tmp counted as candidate");
+        assert_eq!(report.deleted, 1);
+        assert!(
+            home.join(DEDUP_STATE_DIR).join("agent.json").exists(),
+            "production .json file untouched"
+        );
+        assert!(!home.join(DEDUP_STATE_DIR).join("agent.json.tmp").exists());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn cleanup_tmp_orphans_returns_empty_report_when_root_missing() {
+        // Daemon-init invocation on a fresh AgEnD home (no dedup-state
+        // dir created yet). Must return empty report, never error.
+        let home = tmp_home("tmp-gc-no-root");
+        let report = cleanup_tmp_orphans(&home, 24 * 60 * 60);
+        assert_eq!(report, DedupStateGcReport::default());
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -361,6 +361,18 @@ fn run_core(
         Err(e) => tracing::warn!(error = %e, "skills-stage GC: daemon-init sweep failed"),
     }
 
+    // Sprint 63 W1 PR-2 (Sprint 58 P2 #5): sweep stale `*.tmp` /
+    // `*.json.tmp` orphans under <home>/dedup-state/ left behind by
+    // crashed atomic_write cycles. 1-day retention threshold (much
+    // shorter than skills-stage 7-day because tmp files should never
+    // legitimately persist longer than a single syscall pair).
+    // Best-effort: failures log + continue (function returns
+    // DedupStateGcReport directly, no Err path).
+    const DEDUP_TMP_RETENTION_SECS: u64 = 24 * 60 * 60;
+    let dedup_report =
+        crate::daemon::dedup_state::cleanup_tmp_orphans(home, DEDUP_TMP_RETENTION_SECS);
+    tracing::info!(?dedup_report, "dedup-state GC: daemon-init sweep complete");
+
     // Sprint 24 P0 PR2 — bridge-phase legacy migration. Walks tasks.json
     // and emits canonical Created (+ status transition) events into
     // task_events.jsonl. Idempotent: re-run is a no-op via tail-scan


### PR DESCRIPTION
<!-- LOC-EST: 40-80 -->

## Summary

- **Path A IMPL** — Sprint 63 W1 PR-2. Closes Sprint 58 P2 #5 deferred carryover.
- 1 commit `36889ef` / +157 LOC across 2 files.
- ★ HARD-FAIL cohesion-accept Option (a) lead-authorized (parallel to #591 precedent) ★

## Implementation (mirrors #591 cleanup_stale_stages pattern)

`cleanup_tmp_orphans(home, retention_secs) -> DedupStateGcReport` — GC stale `*.tmp` orphans under `<home>/dedup-state/`. Caused by atomic_write crashes between write+rename. Daemon-init invocation in run_core with 1-day retention. Mirrors #591 cleanup_stale_stages pattern (struct + fail-open IO + retention + tracing).

## Tests (3 new)

- deletes-aged-tmp-files-above-threshold
- preserves-non-tmp-files (production .json untouched)
- empty-when-root-missing (daemon-init guard)

## Scope-overage transparency (HARD-FAIL cohesion-accept Option (a) — lead-authorized m-20260510031625050703-563)

**+157 LOC vs PLAN P0-#5 40-80 = 96% over upper bound = HARD-FAIL** (>150% threshold = 120). Lead-authorized cohesion-accept per established standard procedure (8+ precedents including parallel #591). `loc-overrun-accepted` label applied.

★ **7th real-world #587 automation validation case** (3rd HARD-FAIL → OVERRIDE path) ★

Honest re-derivation: 130-180 brackets actual 157 ✓. PLAN missed DedupStateGcReport + tracing + 3-test coverage (same as #591).

Cohesion-accept rationale: shared pattern with #591 — splitting damages pattern integrity; trim loses .tmp/non-.tmp coverage.

## Sprint 58 P2 #5 closure

3+ Sprint deferred (Sprint 58 P2 → 59 → 60 → 61 → 62 → 63 W1 PR-2) closed via #591-pattern-reuse.

## STRICT v2 / Q2=(C) compliance

- daemon-managed worktree ✓
- 0 BYPASS, 0 force-push (single clean commit) ✓
- Tool count: 32 unchanged ✓

## Test plan

- [x] `cargo build --features tray` ✓
- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets --features tray -- -D warnings` ✓
- [x] `cargo test --features tray --bin agend-terminal cleanup_tmp_orphans` → 3/3 pass
- [x] `cargo test --release --features tray --test file_size_invariant` ✓
- [ ] CI green across all 3 platforms
- [ ] **#587 automation: HARD-FAIL → OVERRIDE PASS via `loc-overrun-accepted` label**
- [ ] Tier-1 single primary review verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)