### PR TITLE
feat(daemon): #6 per-signal shutdown reason taxonomy split (Sprint 63 W1 PR-3)

### DIFF
--- a/src/bootstrap/signals.rs
+++ b/src/bootstrap/signals.rs
@@ -91,6 +91,14 @@ pub fn install_term_only() {
 unsafe fn install_unix_sigterm() {
     extern "C" fn handler(_signum: libc::c_int) {
         // Signal-handler-safe: only atomic ops, no allocation, no tracing.
+        // Sprint 63 W1 PR-3 (Sprint 58 P2 #6): record SignalSigterm
+        // specifically rather than relying on the bundled `Signal`
+        // reason — `record_shutdown_reason` is signal-handler-safe
+        // (pure compare_exchange on AtomicU8). First-write-wins via
+        // compare_exchange in record_shutdown_reason: if a different
+        // shutdown reason has already been recorded (api / watchdog),
+        // this no-ops correctly.
+        crate::daemon::record_shutdown_reason(crate::daemon::ShutdownReason::SignalSigterm);
         TERM_REQUESTED.store(true, Ordering::Relaxed);
     }
     let mut action: libc::sigaction = std::mem::zeroed();

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -48,8 +48,11 @@ pub(crate) enum ShutdownReason {
     Unknown = 0,
     /// SIGINT / SIGTERM / SIGHUP via `bootstrap::signals::install`
     /// (the ctrlc handler bundles all three on Unix; this single
-    /// reason captures all of them — finer per-signal taxonomy is
-    /// a Sprint 58+ candidate).
+    /// reason captures all of them when the per-signal-aware
+    /// handlers below haven't fired). The daemon's ctrlc path still
+    /// records `Signal` because the ctrlc crate's callback signature
+    /// doesn't expose the originating signal — daemon-side
+    /// per-signal migration via sigaction is a Sprint 64+ candidate.
     Signal = 1,
     /// Operator invoked `agend-terminal stop` → API SHUTDOWN
     /// method tripped the flag.
@@ -67,6 +70,26 @@ pub(crate) enum ShutdownReason {
     /// `run_core` re-execs self after the shutdown sequence rather
     /// than returning to the bootstrap layer.
     OperatorRestart = 5,
+    /// Sprint 63 W1 PR-3 (Sprint 58 P2 #6): SIGINT specifically (vs
+    /// the bundled `Signal` when the handler can't distinguish).
+    /// Set by per-signal sigaction handlers; future Sprint 64+
+    /// daemon-side migration would record this from the daemon's
+    /// install path. Currently set by no production handler — the
+    /// app's `install_term_only` is SIGTERM-only, and daemon's
+    /// ctrlc-based `install` records `Signal`.
+    #[allow(dead_code)]
+    SignalSigint = 6,
+    /// Sprint 63 W1 PR-3 (Sprint 58 P2 #6): SIGTERM specifically.
+    /// Set by `bootstrap::signals::install_term_only` (the app's
+    /// SIGTERM-only sigaction handler); also set by future per-signal
+    /// daemon migration.
+    SignalSigterm = 7,
+    /// Sprint 63 W1 PR-3 (Sprint 58 P2 #6): SIGHUP specifically.
+    /// Set by future per-signal daemon migration. No current
+    /// production handler distinguishes SIGHUP from the bundled
+    /// `Signal` reason.
+    #[allow(dead_code)]
+    SignalSighup = 8,
 }
 
 impl ShutdownReason {
@@ -78,6 +101,9 @@ impl ShutdownReason {
             Self::Watchdog => "watchdog",
             Self::CleanExit => "clean_exit",
             Self::OperatorRestart => "operator_restart",
+            Self::SignalSigint => "signal_sigint",
+            Self::SignalSigterm => "signal_sigterm",
+            Self::SignalSighup => "signal_sighup",
         }
     }
 
@@ -88,6 +114,9 @@ impl ShutdownReason {
             3 => Self::Watchdog,
             4 => Self::CleanExit,
             5 => Self::OperatorRestart,
+            6 => Self::SignalSigint,
+            7 => Self::SignalSigterm,
+            8 => Self::SignalSighup,
             _ => Self::Unknown,
         }
     }
@@ -1733,11 +1762,28 @@ mod tests {
             ShutdownReason::ApiShutdown,
             ShutdownReason::Watchdog,
             ShutdownReason::CleanExit,
+            // Sprint 60 W1 PR-3 + Sprint 63 W1 PR-3 additions.
+            ShutdownReason::OperatorRestart,
+            ShutdownReason::SignalSigint,
+            ShutdownReason::SignalSigterm,
+            ShutdownReason::SignalSighup,
         ] {
             let raw = reason as u8;
             let recovered = ShutdownReason::from_u8(raw);
             assert_eq!(recovered, reason, "round-trip lost taxonomy for {reason:?}");
         }
+    }
+
+    #[test]
+    fn shutdown_reason_per_signal_taxonomy_strings_pinned() {
+        // Sprint 63 W1 PR-3 (Sprint 58 P2 #6): per-signal taxonomy
+        // string identifiers are pinned for downstream `daemon_stop`
+        // event consumers (greppers / parsers).
+        assert_eq!(ShutdownReason::SignalSigint.as_str(), "signal_sigint");
+        assert_eq!(ShutdownReason::SignalSigterm.as_str(), "signal_sigterm");
+        assert_eq!(ShutdownReason::SignalSighup.as_str(), "signal_sighup");
+        // Bundled `Signal` reason still pins to "signal" for backward compat.
+        assert_eq!(ShutdownReason::Signal.as_str(), "signal");
     }
 
     #[test]


### PR DESCRIPTION
<!-- LOC-EST: 30-80 -->

## Summary

- **Path A IMPL** — Sprint 63 W1 PR-3. Closes Sprint 58 P2 #6 deferred carryover.
- 1 commit `df626ae` / +56 LOC net (within PLAN 30-80 budget).
- Adds 3 per-signal `ShutdownReason` variants; wires SignalSigterm via `install_term_only`'s sigaction handler; documents Sprint 64+ candidate for daemon-side ctrlc → sigaction migration.

## Implementation

### Wired now (production)
- `ShutdownReason::SignalSigterm` (=7) — `bootstrap::signals::install_term_only`'s SIGTERM sigaction handler records this. Production app shutdowns now show `signal_sigterm` in `daemon_stop` event.

### Infrastructure (Sprint 64+ candidate target)
- `ShutdownReason::SignalSigint` (=6) — for future daemon ctrlc → sigaction migration
- `ShutdownReason::SignalSighup` (=8) — same
- `as_str` + `from_u8` arms updated for round-trip preservation

### Why daemon's ctrlc path NOT migrated in this PR
The ctrlc crate's callback signature does not expose the originating signal — distinguishing requires `sigaction` per-signal handlers (Unix only) + cross-platform fallback. Sprint 64+ candidate; documented in enum variant comments.

## Tests (5 pass, 1 new)

- **NEW** `shutdown_reason_per_signal_taxonomy_strings_pinned` — pins "signal_sigint" / "signal_sigterm" / "signal_sighup"
- `shutdown_reason_round_trip_preserves_taxonomy` — extended with OperatorRestart + 3 new variants
- 3 existing tests still pass

## Backwards-compat

- Existing `Signal` reason value (=1) unchanged; daemon ctrlc path still records it
- New variants 6/7/8 don't collide; from_u8 falls back to Unknown for unrecognized
- `daemon_stop` event: daemon-side shutdowns keep `signal`; app's SIGTERM shutdowns now record `signal_sigterm` (audit-trail improvement, no breaking change)

## STRICT v2 / Q2=(C) compliance

- daemon-managed worktree ✓
- 0 BYPASS, 0 force-push (single clean commit) ✓
- Tool count: 32 unchanged ✓

## Test plan

- [x] `cargo build --features tray` ✓
- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets --features tray -- -D warnings` ✓
- [x] `cargo test --features tray --bin agend-terminal shutdown_reason` → 5/5 pass
- [x] `cargo test --release --features tray --test file_size_invariant` ✓
- [ ] CI green across all 3 platforms
- [ ] #587 LOC overrun automation reports PASS (56 ≤ 80 = within budget)
- [ ] Tier-1 single primary review verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)