### PR TITLE
test(service): #1 xml/plist parser round-trip tests (Sprint 63 W1 PR-4 closeout)

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -426,4 +426,137 @@ mod tests {
             r#"ExecStart="/Users/Test User/.cargo/bin/agend-terminal" start --foreground"#
         );
     }
+
+    // ── Sprint 63 W1 PR-4 (Sprint 58 P2 #1) — xml/plist parser round-trip ──
+    //
+    // Per Sprint 57 Phase 3 #557 Pass 2 reviewer note: verify that
+    // values escaped via `xml_escape` for insertion into plist /
+    // Task Scheduler XML templates round-trip cleanly through XML
+    // entity decoding. The escape direction is covered by existing
+    // tests (lines 332-411); the unescape side wasn't previously
+    // exercised, leaving a contract gap if a future contributor
+    // changed the escape rules without updating consumer behaviour.
+
+    /// Test-only XML entity unescape — inverse of `xml_escape`. Pins
+    /// the contract: escape → unescape == identity for any input.
+    /// Used only by these tests; production code never unescapes
+    /// (consumers are real plist parsers like `launchctl` and Task
+    /// Scheduler).
+    ///
+    /// Uses an absolute-byte-index walk over `value` (rather than
+    /// `char_indices` reassignment) so jumping past a multi-byte
+    /// entity preserves byte-position semantics correctly across
+    /// multiple entities in one input.
+    fn xml_unescape(value: &str) -> String {
+        let bytes = value.as_bytes();
+        let mut out = String::with_capacity(value.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'&' {
+                let rest = &value[i..];
+                if rest.starts_with("&amp;") {
+                    out.push('&');
+                    i += "&amp;".len();
+                    continue;
+                } else if rest.starts_with("&lt;") {
+                    out.push('<');
+                    i += "&lt;".len();
+                    continue;
+                } else if rest.starts_with("&gt;") {
+                    out.push('>');
+                    i += "&gt;".len();
+                    continue;
+                } else if rest.starts_with("&quot;") {
+                    out.push('"');
+                    i += "&quot;".len();
+                    continue;
+                } else if rest.starts_with("&apos;") {
+                    out.push('\'');
+                    i += "&apos;".len();
+                    continue;
+                }
+                // Unknown entity → preserve `&` as-is, advance one
+                // byte. xml_escape never produces this; appearing
+                // here means the input wasn't produced by xml_escape.
+                out.push('&');
+                i += 1;
+                continue;
+            }
+            // Non-`&` byte: walk the next char (handles multi-byte
+            // utf-8 sequences correctly).
+            let ch = value[i..]
+                .chars()
+                .next()
+                .expect("i < bytes.len() invariant");
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+        out
+    }
+
+    #[test]
+    fn xml_escape_round_trips_alphanumeric_unchanged() {
+        let raw = "agend-terminal-v1.0_alpha-build42";
+        let escaped = xml_escape(raw);
+        assert_eq!(escaped, raw, "alphanumeric must not be escaped");
+        assert_eq!(xml_unescape(&escaped), raw, "round-trip identity");
+    }
+
+    #[test]
+    fn xml_escape_round_trips_all_five_entity_chars() {
+        // Every entity-escape rule in xml_escape exercised + inverse.
+        let raw = r#"name=foo&bar<baz>qux"id"='1'"#;
+        let escaped = xml_escape(raw);
+        // Forward: every special char converted.
+        assert!(escaped.contains("&amp;"));
+        assert!(escaped.contains("&lt;"));
+        assert!(escaped.contains("&gt;"));
+        assert!(escaped.contains("&quot;"));
+        assert!(escaped.contains("&apos;"));
+        // Reverse: clean round-trip back to raw.
+        assert_eq!(xml_unescape(&escaped), raw);
+    }
+
+    #[test]
+    fn xml_escape_round_trips_unicode_and_mixed() {
+        // Unicode passes through untouched on both legs.
+        let raw = "Téstüser/路徑with&special<chars>";
+        let escaped = xml_escape(raw);
+        assert_eq!(xml_unescape(&escaped), raw);
+        // Sanity: at least one char did get escaped.
+        assert!(escaped.contains("&amp;"));
+        assert!(escaped.contains("&lt;"));
+    }
+
+    #[test]
+    fn xml_escape_round_trips_plist_fragment_under_substitution() {
+        // End-to-end: full plist-fragment template + value with all 5
+        // special chars → substitute → unescape just the value back to
+        // raw. Mirrors the launchd consumer path: launchctl parses
+        // the template's XML entities back to text, which must equal
+        // the original raw input.
+        let template = "<string>__EXECUTABLE__</string>";
+        let raw = r#"/usr/local/bin/with & < > " ' all/specials"#;
+        let escaped = xml_escape(raw);
+        let resolved = apply_substitutions(template, &[("__EXECUTABLE__", escaped.as_str())]);
+        // Strip the wrapper to recover just the escaped value, then
+        // unescape and verify identity with raw input.
+        let inner = resolved
+            .strip_prefix("<string>")
+            .and_then(|s| s.strip_suffix("</string>"))
+            .expect("template wrappers preserved");
+        assert_eq!(xml_unescape(inner), raw);
+    }
+
+    #[test]
+    fn xml_unescape_passes_through_unrecognized_entities() {
+        // Defensive: xml_unescape is only an inverse of xml_escape's
+        // exact 5-entity mapping. Any other `&...;` sequence (e.g. a
+        // numeric `&#65;` or future-added `&nbsp;`) preserves as-is.
+        // Pins behaviour so a future contributor adding a new entity
+        // to xml_escape MUST also update xml_unescape (test fails
+        // loudly via the previous round-trip tests).
+        let weird = "this &nbsp; is not in our escape set";
+        assert_eq!(xml_unescape(weird), weird);
+    }
 }


### PR DESCRIPTION
<!-- LOC-EST: 50-100 -->

## Summary

- **Path A test-only IMPL** — Sprint 63 W1 closeout PR. Closes Sprint 58 P2 #1 deferred carryover.
- 1 commit `62fdd0d` / +133 LOC test-only.
- Verifies `xml_escape` (production helper) round-trips through XML entity decoding via test-only `xml_unescape` inverse.

## Tests (5 new + 4 existing = 9 total in service::tests::xml*)

- `xml_escape_round_trips_alphanumeric_unchanged`
- `xml_escape_round_trips_all_five_entity_chars` — every escape rule + inverse
- `xml_escape_round_trips_unicode_and_mixed`
- `xml_escape_round_trips_plist_fragment_under_substitution` — end-to-end plist consumer path
- `xml_unescape_passes_through_unrecognized_entities` — defensive forward-compat

`xml_unescape` uses absolute-byte-index walk (avoids char_indices reassignment skew bug across multi-entity inputs).

## Scope-overage transparency (per #582 §5.2 soft-warn)

133 LOC vs PLAN P0-#1 50-100 = 33% over upper bound. Per #587: 130%×100=130 soft-warn; 150%×100=150 hard-fail. 133 > 130 → **SOFT-WARN exit 0**. No escalation needed.

Honest re-derivation: 110-140 brackets actual 133 ✓. PLAN missed 5-test breadth + byte-index-walk implementation required for multi-entity correctness.

## Sprint 63 W1 closeout (4 PRs / 4 Sprint 58 P2 items closed)

- W1 PR-1 #595 ✓ MERGED 99239d3 (Sprint 58 P2 #4)
- W1 PR-2 #596 ✓ MERGED 16c30d5 (Sprint 58 P2 #5)
- W1 PR-3 #597 ✓ MERGED 7ff86c6 (Sprint 58 P2 #6)
- W1 PR-4 (this) — Sprint 58 P2 #1

## STRICT v2 / Q2=(C) compliance

- daemon-managed worktree ✓
- 0 BYPASS, 0 force-push (single clean commit) ✓
- Tool count: 32 unchanged ✓

## Test plan

- [x] `cargo build --features tray` ✓
- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --all-targets --features tray -- -D warnings` ✓ (post-fix: redundant_pattern_matching lint)
- [x] `cargo test --features tray --bin agend-terminal service::tests::xml` → 9/9 pass
- [x] `cargo test --release --features tray --test file_size_invariant` ✓
- [ ] CI green across all 3 platforms
- [ ] #587 LOC overrun automation reports SOFT-WARN PASS (133 within 130-150 band)
- [ ] Tier-1 single primary review verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)