### PR TITLE
fix(test): hotfix daemon_run_does_not_duplicate_init_calls UTF-8 boundary panic (Sprint 63)

### DIFF
--- a/tests/agend_git_shim_app_mode_wiring.rs
+++ b/tests/agend_git_shim_app_mode_wiring.rs
@@ -42,13 +42,30 @@ fn bootstrap_prepare_contains_all_shim_init_calls() {
 }
 
 /// Verify daemon::run does NOT duplicate the init calls (they're in bootstrap now).
+///
+/// Sprint 63 hotfix (Sprint 21+ bug, surfaced by Sprint 63 W1 cumulative
+/// run_core additions): the old `&rest[..rest.len().min(5000)]` slice
+/// panics when byte 5000 lands mid-UTF-8-character. The panic was latent
+/// because `run_core`'s leading 5000 bytes were all ASCII pre-Sprint-63;
+/// Sprint 63 W1 PR-1 #595 + PR-2 #596 + PR-3 #597 + PR-4 #598 cumulative
+/// additions (including comments containing Chinese / Unicode chars + new
+/// `#587` automation references) crossed the 5000-byte threshold at a
+/// non-char-boundary position, triggering the panic on every CI run from
+/// 16c30d5 onward.
+///
+/// Fix: use `rest.chars().take(5000).collect::<String>()` for char-aware
+/// truncation. This caps at 5000 *chars* not 5000 *bytes* — slightly
+/// looser than the original intent but the assertions only grep for ASCII
+/// substrings (`binding::reconcile_hooks(home)`, `binding::symlink_shim(home)`),
+/// so any prefix large enough to cover the original 5000 bytes' worth of
+/// content is sufficient.
 #[test]
 fn daemon_run_does_not_duplicate_init_calls() {
     let src = include_str!("../src/daemon/mod.rs");
     let fn_start = src.find("fn run_core(").expect("run_core must exist");
     let rest = &src[fn_start..];
-    // Check the first 200 lines of run_core for the old pattern.
-    let check_area = &rest[..rest.len().min(5000)];
+    // Char-aware truncation: avoids panic when byte 5000 lands mid-utf-8-char.
+    let check_area: String = rest.chars().take(5000).collect();
 
     // These should NOT be in daemon::run anymore (moved to bootstrap::prepare).
     assert!(


### PR DESCRIPTION
<!-- LOC-EST: 5-15 -->

## Summary

- **Path A test-only hotfix** — closes the false-reported-CI-green pattern Sprint 63 W1 PR-2 #596 / PR-3 #597 / PR-4 #598 / W2 PR-1 #599 / W2 PR-2 #600. Main has been broken since 16c30d5 (#596 merge).
- 1 commit `ee088ec` / +19/-2 = net +17 LOC test-only.
- Replaces `&rest[..rest.len().min(5000)]` (panic on non-char-boundary) with `rest.chars().take(5000).collect::<String>()` (char-aware).

## Root cause

`tests/agend_git_shim_app_mode_wiring.rs:51` byte-sliced `src/daemon/mod.rs` content. Bug latent since at least Sprint 21 (when run_core was short + ASCII-only). Sprint 63 W1 cumulative additions (#596 +12 / #597 +50 LOC + UTF-8 chars in comments) crossed the 5000-byte threshold at a non-char-boundary position → panic on macOS + Ubuntu (Windows happened to land at char boundary).

## Fix (Option A per general dispatch m-20260510043402690718-632)

`rest.chars().take(5000).collect::<String>()` — char-aware truncation. Caps at 5000 chars not 5000 bytes; assertions only grep for ASCII substrings so the looser cap is sufficient.

## Process atonement

Engineering mechanism response captured in commit body. New §6 milestone-CI-green ping protocol effective from this PR: must verify via `gh pr checks <num>` showing all 3 platforms `pass`. Pre-push: FULL test suite mandatory.

## STRICT v2 / Q2=(C) compliance

- daemon-managed worktree ✓
- 0 BYPASS, 0 force-push (single clean commit, daemon auto-snapshots consolidated via reset --soft) ✓
- Tool count: 32 unchanged ✓

## Test plan

- [x] `cargo fmt --check` ✓
- [x] `cargo test --features tray --test agend_git_shim_app_mode_wiring daemon_run_does_not_duplicate_init_calls` → PASS (was the failing test on main)
- [x] `cargo test --features tray --bin agend-terminal` → 2001 passed (7 pre-existing local-env claim_verifier flakes unrelated, pass on CI per Sprint 60-63 history)
- [x] `cargo test --features tray --tests` → all integration tests pass
- [ ] CI green across all 3 platforms — verified via `gh pr checks <num>` BEFORE §6 milestone ping per new protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)