### PR TITLE
hotfix: remove ensure_gitignore (Issue #602)

### DIFF
--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -188,15 +188,6 @@ pub fn create(
         });
     }
 
-    // Sprint 57 Wave 4 (#546 Item 4): worktrees live external to
-    // source_repo, so the source repo's .gitignore no longer needs
-    // a `.worktrees` entry — but `ensure_gitignore` is kept as a
-    // best-effort idempotent backstop for repos that DID accumulate
-    // legacy worktrees pre-Wave-4. New creates land at
-    // `$AGEND_HOME/worktrees/...` which is outside the source tree
-    // entirely, so .gitignore there is moot for new path.
-    ensure_gitignore(repo_dir);
-
     // Worktree's parent dir must exist before `git worktree add`
     // runs against it. Branches with `/` (e.g. `feat/foo`) become
     // nested dirs naturally via create_dir_all.
@@ -438,33 +429,6 @@ pub fn list_legacy_residual(source_repo: &Path) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Ensure .worktrees is listed in .gitignore.
-fn ensure_gitignore(repo_dir: &Path) {
-    let gitignore = repo_dir.join(".gitignore");
-    let content = std::fs::read_to_string(&gitignore).unwrap_or_default();
-    if !content
-        .lines()
-        .any(|line| line.trim() == ".worktrees" || line.trim() == ".worktrees/")
-    {
-        use std::io::Write;
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&gitignore)
-        {
-            let prefix = if content.is_empty() || content.ends_with('\n') {
-                ""
-            } else {
-                "\n"
-            };
-            if let Err(e) = writeln!(f, "{prefix}.worktrees") {
-                tracing::warn!(error = %e, "failed to update .gitignore");
-            }
-            tracing::info!("added .worktrees to .gitignore");
-        }
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -547,12 +511,6 @@ mod tests {
             info.path, expected,
             "worktree path must follow new external layout"
         );
-
-        // .gitignore is still touched as a back-compat backstop for
-        // legacy worktrees pre-Wave-4 — the entry exists even though
-        // new creates land outside the source repo.
-        let gitignore = std::fs::read_to_string(repo.join(".gitignore")).unwrap_or_default();
-        assert!(gitignore.contains(".worktrees"));
 
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();


### PR DESCRIPTION
## Summary

Closes #602.

Remove the `ensure_gitignore` function that auto-injects `.worktrees` into the source repo's `.gitignore` on every worktree creation. Since Sprint 57 Wave 4 (#546 Item 4) moved worktrees external to source_repo (`$AGEND_HOME/worktrees/<agent>/<branch>/`), this side-effect is redundant for all new repos and adds an unwelcome modification of the user's `.gitignore`.

## Scope

3 surgical edits, 42 LOC net deletion:

1. `src/worktree.rs:198` — remove the lone callsite + the explanatory comment block (lines 191-198) that no longer applies
2. `src/worktree.rs:441-466` — delete `fn ensure_gitignore` entirely
3. `src/worktree.rs` `test_create_worktree` — remove the `.gitignore contains \".worktrees\"` assertion + comment block

`grep -rn ensure_gitignore --include='*.rs'` returns 0 matches after the change.

## Risk surface

- New worktrees land at `$AGEND_HOME/worktrees/...` outside the source tree → `.gitignore` modification was already a no-op for behavior, only a courtesy injection.
- Pre-Wave-4 legacy `.worktrees/` directories inside source repos are a non-issue on current main (Wave 4 shipped Sprint 57).
- No behavior change for any new code path; removes a side-effect that surprises users.

## Local verification

- `cargo build --features tray --bin agend-terminal` → finished successfully (27.58s)
- `cargo test --features tray --bin agend-terminal worktree::tests` → 30 passed (incl. `test_create_worktree`)

> Note: a separate full-suite run surfaced 6 pre-existing `claim_verifier::tests::*_red` failures unrelated to this change (out-of-scope for this hotfix). They reproduce on baseline (verified via stash flow). Filed as a separate concern.

## Test plan

- [ ] CI: macos-latest / ubuntu-latest / windows-latest all green via `gh pr checks`
- [ ] Tier-1 reviewer VERIFIED
- [ ] Post-merge main CI green