### PR TITLE
release: prep v0.6.1 (CHANGELOG restructure + version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-10
+
 ### Removed
 
 - **`agend-terminal mcp` subcommand (Sprint 56 Track I, #531)** — the local-mode stdio JSON-RPC server retired. The `Commands::Mcp` enum variant, `mcp::run` function, ACL machinery, framing helpers, and `proxy_or_local` fallback all deleted from `src/`. Operators with hand-edited mcp.json get the daemon's atomic upsert rewriting their config to use `agend-mcp-bridge` on next start; new installs ship the bridge in release artifacts (Phase 2a, v0.7+). The bridge is the canonical MCP server going forward. Reported by changhansung on Windows 11 + kiro-cli backend; investigated through 4 sequential PRs (Phase 1 RCA / 2a packaging / 2b deprecation / 2c hard removal). See `docs/RCA-issue-531-deprecate-agend-terminal-mcp-2026-05-08.md` for the full architectural reasoning.
+- **`ensure_gitignore` worktree helper (#602, #604)** — `src/worktree.rs::ensure_gitignore` auto-injected `.worktrees` into project `.gitignore` as a back-compat backstop for pre-Sprint-57-Wave-4 layouts. Post-Wave-4 worktrees live outside the repo (under `$AGEND_HOME/worktrees/`), making this inject redundant + polluting user `.gitignore`. Removed callsite + helper + obsolete test assert (-42 LOC). Reported by @cheerc.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agend-terminal"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agend-terminal"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.87"
 description = "Agent Process Manager — orchestrate AI coding agents with PTY isolation, fleet management, and 35 MCP tools"


### PR DESCRIPTION
## Summary

Release prep for v0.6.1 — admin / docs change only, no behavioral code touched.

Operator-confirmed scope per general m-20260510094625056813-24 (Q-A finalization).

## Changes

- **Cargo.toml**: `version = "0.6.0"` → `"0.6.1"`
- **Cargo.lock**: regenerated via `cargo build` (auto-updates `agend-terminal` entry to `0.6.1`)
- **CHANGELOG.md**:
  - Insert new empty `## [Unreleased]` section at top
  - Existing Unreleased content captured under `## [0.6.1] - 2026-05-10`
  - Add new bullet under `[0.6.1] ### Removed` for `ensure_gitignore` worktree helper (Issue #602, PR #604, -42 LOC, reported by @cheerc)

## Final v0.6.1 scope

- **Removed**: `agend-terminal mcp` subcommand (Sprint 56 Track I, #531) — already in [Unreleased]
- **Removed**: `ensure_gitignore` worktree helper (#602, #604) — NEW entry
- **Added**: Bridge runtime invariant test (Sprint 56 Track I-Phase 2c, #531) — already in [Unreleased]

## Risk surface

Zero — Cargo.toml version bump + Cargo.lock regen + CHANGELOG markdown additions. No source code touched.

## Local verification

- `cargo build --features tray --bin agend-terminal` → finished successfully (27.72s) — confirms Cargo.lock regen + no compile breakage from version field change

## Test plan

- [ ] CI: macos-latest / ubuntu-latest / windows-latest all green via `gh pr checks`
- [ ] Tier-1 reviewer VERIFIED
- [ ] Post-merge main CI green
- [ ] Lead tags v0.6.1 + `gh release create` post-merge (out of dev scope)