### PR TITLE
feat(#616): team source_repo support

### DIFF
--- a/.agend-managed
+++ b/.agend-managed
@@ -1,0 +1,3 @@
+agent=dev-kiro
+branch=fix/616-team-source-repo
+leased_at=2026-05-10T17:51:37.698484+00:00

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -232,6 +232,8 @@ pub struct TeamConfig {
     /// creation stamps it; operator-edited fleet.yaml entries may omit it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_repo: Option<std::path::PathBuf>,
 }
 
 impl FleetConfig {
@@ -1055,6 +1057,12 @@ fn team_config_to_mapping(config: &TeamConfig) -> serde_yaml_ng::Mapping {
             serde_yaml_ng::Value::String(ts.clone()),
         );
     }
+    if let Some(ref sr) = config.source_repo {
+        team.insert(
+            "source_repo".into(),
+            serde_yaml_ng::Value::String(sr.display().to_string()),
+        );
+    }
     team
 }
 
@@ -1195,6 +1203,7 @@ pub fn migrate_teams_json_to_yaml(home: &Path) -> Result<()> {
             orchestrator: team.orchestrator.clone(),
             description: team.description.clone(),
             created_at: team.created_at.clone(),
+            source_repo: None,
         };
         // add_team_to_yaml is no-op when team already in fleet.yaml —
         // operator hand-edits win, runtime store loses on conflict.
@@ -1586,6 +1595,7 @@ instances:
             orchestrator: Some("alice".into()),
             description: Some("dev squad".into()),
             created_at: Some("2026-05-07T00:00:00Z".into()),
+            source_repo: None,
         };
         let inserted = add_team_to_yaml(&dir, "devs", &cfg).expect("add");
         assert!(inserted);
@@ -1605,6 +1615,7 @@ instances:
             orchestrator: Some("alice".into()),
             description: None,
             created_at: Some("2026-05-07T00:00:00Z".into()),
+            source_repo: None,
         };
         assert!(add_team_to_yaml(&dir, "devs", &cfg1).expect("first"));
         let cfg2 = TeamConfig {
@@ -1612,6 +1623,7 @@ instances:
             orchestrator: Some("bob".into()),
             description: None,
             created_at: Some("2026-05-08T00:00:00Z".into()),
+            source_repo: None,
         };
         let inserted = add_team_to_yaml(&dir, "devs", &cfg2).expect("dup");
         assert!(!inserted, "duplicate must report false (no insert)");
@@ -1633,6 +1645,7 @@ instances:
             orchestrator: Some("alice".into()),
             description: None,
             created_at: None,
+            source_repo: None,
         };
         add_team_to_yaml(&dir, "devs", &cfg).expect("add");
         assert!(remove_team_from_yaml(&dir, "devs").expect("rm"));
@@ -1651,6 +1664,7 @@ instances:
             orchestrator: Some("alice".into()),
             description: None,
             created_at: Some("2026-05-07T00:00:00Z".into()),
+            source_repo: None,
         };
         add_team_to_yaml(&dir, "devs", &cfg).expect("add");
         // Drop bob, reassign orch to alice (no-op), add carol.
@@ -1659,6 +1673,7 @@ instances:
             orchestrator: Some("alice".into()),
             description: Some("post-update".into()),
             created_at: cfg.created_at.clone(),
+            source_repo: None,
         };
         assert!(update_team_in_yaml(&dir, "devs", &new_cfg).expect("upd"));
         let loaded = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
@@ -1671,6 +1686,7 @@ instances:
             orchestrator: None,
             description: None,
             created_at: None,
+            source_repo: None,
         };
         assert!(!update_team_in_yaml(&dir, "nonexistent", &new_cfg2).expect("upd-miss"));
         fs::remove_dir_all(&dir).ok();

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -218,7 +218,7 @@ fn resolve_source_repo(
 /// Resolve source_repo from the agent's team configuration.
 pub(crate) fn resolve_team_source_repo(home: &Path, agent: &str) -> Option<PathBuf> {
     let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok()?;
-    for (_name, cfg) in &fleet.teams {
+    for cfg in fleet.teams.values() {
         if cfg.members.contains(&agent.to_string()) {
             return cfg.source_repo.clone();
         }

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -195,6 +195,12 @@ fn resolve_source_repo(
             "source_repo resolved via fleet.yaml source_repo (tier 2)");
         return p;
     }
+    // Tier 2.5: team source_repo
+    if let Some(p) = resolve_team_source_repo(home, target) {
+        tracing::info!(%target, tier = "team_source_repo", path = %p.display(),
+            "source_repo resolved via team source_repo (tier 2.5)");
+        return p;
+    }
     if let Some(p) = resolved.and_then(|r| r.working_directory.clone()) {
         tracing::info!(%target, tier = "working_directory", path = %p.display(),
             "source_repo resolved via fleet.yaml working_directory (tier 3, deprecation candidate)");
@@ -207,6 +213,17 @@ fn resolve_source_repo(
         tracing::error!(%target, "AGEND_BIND_STRICT_MODE=1: stub fallback rejected");
     }
     stub
+}
+
+/// Resolve source_repo from the agent's team configuration.
+pub(crate) fn resolve_team_source_repo(home: &Path, agent: &str) -> Option<PathBuf> {
+    let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok()?;
+    for (_name, cfg) in &fleet.teams {
+        if cfg.members.contains(&agent.to_string()) {
+            return cfg.source_repo.clone();
+        }
+    }
+    None
 }
 
 /// Parse `owner/repo` from a `git remote get-url origin` output.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -185,6 +185,7 @@ fn team_tools() -> Vec<Value> {
                 "name": {"type": "string"}, "members": {"type": "array", "items": {"type": "string"}},
                 "orchestrator": {"type": "string", "description": "Team orchestrator — must be a member."},
                 "description": {"type": "string"},
+                "source_repo": {"type": "string", "description": "Source repository path for the team."},
                 "add": {"type": "array", "items": {"type": "string"}},
                 "remove": {"type": "array", "items": {"type": "string"}}
             }, "required": ["action"]}}),

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -327,6 +327,7 @@ pub fn get_members(home: &Path, team_name: &str) -> Vec<String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -84,6 +84,7 @@ pub fn create(home: &Path, args: &Value) -> Value {
     };
     let orchestrator = args["orchestrator"].as_str().map(String::from);
     let description = args["description"].as_str().map(String::from);
+    let source_repo = args["source_repo"].as_str().map(std::path::PathBuf::from);
 
     // Validate orchestrator
     if let Some(ref orch) = orchestrator {
@@ -110,6 +111,7 @@ pub fn create(home: &Path, args: &Value) -> Value {
         orchestrator,
         description,
         created_at: Some(chrono::Utc::now().to_rfc3339()),
+        source_repo,
     };
     match crate::fleet::add_team_to_yaml(home, &name, &cfg) {
         Ok(true) => {
@@ -221,11 +223,17 @@ pub fn update(home: &Path, args: &Value) -> Value {
         current.orchestrator.clone()
     };
 
+    let new_source_repo = args["source_repo"]
+        .as_str()
+        .map(std::path::PathBuf::from)
+        .or_else(|| current.source_repo.clone());
+
     let cfg = crate::fleet::TeamConfig {
         members: new_members,
         orchestrator: resolved_orch,
         description: current.description.clone(),
         created_at: current.created_at.clone(),
+        source_repo: new_source_repo,
     };
     match crate::fleet::update_team_in_yaml(home, &name, &cfg) {
         Ok(true) => serde_json::json!({"status": "updated", "name": name}),
@@ -267,6 +275,7 @@ pub fn remove_member_from_all(home: &Path, instance_name: &str) {
             orchestrator: new_orch,
             description: cfg.description.clone(),
             created_at: cfg.created_at.clone(),
+            source_repo: cfg.source_repo.clone(),
         };
         let _ = crate::fleet::update_team_in_yaml(home, team_name, &new_cfg);
     }
@@ -560,6 +569,80 @@ mod tests {
         assert_eq!(members, vec!["alice", "bob"]);
         let listed = list(&home);
         assert_eq!(listed["teams"][0]["orchestrator"], "alice");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn team_create_with_source_repo() {
+        let home = tmp_home("create_src_repo");
+        let result = create(
+            &home,
+            &serde_json::json!({
+                "name": "dev",
+                "members": ["alice", "bob"],
+                "orchestrator": "alice",
+                "source_repo": "/tmp/my-repo"
+            }),
+        );
+        assert_eq!(result["status"], "created");
+        let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let team = fleet.teams.get("dev").unwrap();
+        assert_eq!(
+            team.source_repo.as_deref(),
+            Some(std::path::Path::new("/tmp/my-repo"))
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn team_update_source_repo() {
+        let home = tmp_home("update_src_repo");
+        create(
+            &home,
+            &serde_json::json!({
+                "name": "dev",
+                "members": ["alice"],
+                "orchestrator": "alice",
+                "source_repo": "/tmp/old-repo"
+            }),
+        );
+        let result = update(
+            &home,
+            &serde_json::json!({
+                "name": "dev",
+                "source_repo": "/tmp/new-repo"
+            }),
+        );
+        assert_eq!(result["status"], "updated");
+        let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let team = fleet.teams.get("dev").unwrap();
+        assert_eq!(
+            team.source_repo.as_deref(),
+            Some(std::path::Path::new("/tmp/new-repo"))
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn resolve_source_repo_uses_team_tier() {
+        let home = tmp_home("team_tier");
+        create(
+            &home,
+            &serde_json::json!({
+                "name": "dev",
+                "members": ["agent-x"],
+                "orchestrator": "agent-x",
+                "source_repo": "/tmp/team-repo"
+            }),
+        );
+        let resolved =
+            crate::mcp::handlers::dispatch_hook::resolve_team_source_repo(&home, "agent-x");
+        assert_eq!(
+            resolved.as_deref(),
+            Some(std::path::Path::new("/tmp/team-repo"))
+        );
+        let none = crate::mcp::handlers::dispatch_hook::resolve_team_source_repo(&home, "other");
+        assert!(none.is_none());
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Summary

Adds `source_repo` field to team configuration, enabling teams to specify a shared source repository that resolves for all members via tier 2.5 in the dispatch hook.

## Changes

- **fleet.rs**: `TeamConfig` gains `source_repo: Option<PathBuf>`; `team_config_to_mapping` serializes it
- **teams.rs**: `create()` and `update()` parse `source_repo` from args
- **dispatch_hook/mod.rs**: new `resolve_team_source_repo()` helper + tier 2.5 (after instance source_repo, before working_directory)
- **tools.rs**: team tool schema includes `source_repo`

## Tier order
1. Explicit override
2. Fleet instance source_repo
3. **Team source_repo (new)**
4. Fleet working_directory
5. Stub fallback

## Testing
- 3 new tests: create with source_repo, update source_repo, resolve tier
- Full suite: 2001 passed, 7 failed (pre-existing)

Closes #616