### PR TITLE
fix(#614): use git init -b main in all test helpers

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -710,7 +710,7 @@ mod tests {
         std::fs::create_dir_all(&wd).ok();
         // Init a git repo so is_git_repo returns true
         let _ = std::process::Command::new("git")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&wd)
             .output();
         std::fs::write(

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -5,7 +5,7 @@ fn setup_test_repo(home: &std::path::Path, agent: &str) -> std::path::PathBuf {
     let repo = home.join("workspace").join(agent);
     std::fs::create_dir_all(&repo).ok();
     std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&repo)
         .env("AGEND_GIT_BYPASS", "1")
         .output()

--- a/src/mcp/handlers/p0b_tests.rs
+++ b/src/mcp/handlers/p0b_tests.rs
@@ -124,7 +124,7 @@ fn setup_git_repo_with_remote(home: &Path, agent: &str, origin_url: &str) -> std
     let repo = home.join("workspace").join(agent);
     std::fs::create_dir_all(&repo).ok();
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&repo)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
@@ -368,7 +368,7 @@ fn ec6_dispatch_uses_fleet_source_repo_tier_when_present() {
     let src = home.join("src-tier2");
     std::fs::create_dir_all(&src).ok();
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
@@ -422,7 +422,7 @@ fn ec4_fleet_repo_override_wins_over_derive() {
     std::fs::create_dir_all(&src).ok();
     // git init but NO remote configured → derive returns None.
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
@@ -487,7 +487,7 @@ fn dispatch_with_source_repo_override_wins_over_fleet() {
     let real_src = home.join("override-src");
     std::fs::create_dir_all(&real_src).ok();
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&real_src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
@@ -574,7 +574,7 @@ fn ci_watch_no_origin_remote_returns_non_github_error() {
     let src = home.join("workspace").join("alpha");
     std::fs::create_dir_all(&src).ok();
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -329,7 +329,7 @@ mod tests {
         let repo = home.join("workspace").join(agent);
         std::fs::create_dir_all(&repo).ok();
         std::process::Command::new("git")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&repo)
             .env("AGEND_GIT_BYPASS", "1")
             .output()

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -449,7 +449,7 @@ mod tests {
         // git init
         std::process::Command::new("git")
             .env("AGEND_GIT_BYPASS", "1")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&dir)
             .output()
             .ok();
@@ -578,7 +578,7 @@ mod tests {
         std::fs::create_dir_all(&dir).ok();
         std::process::Command::new("git")
             .env("AGEND_GIT_BYPASS", "1")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&dir)
             .output()
             .ok();
@@ -604,7 +604,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::process::Command::new("git")
             .env("AGEND_GIT_BYPASS", "1")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&dir)
             .output()
             .unwrap();


### PR DESCRIPTION
## Summary

Fixes spurious 'init' commits by ensuring all test repo helpers use `git init -b main`.

## Root cause

Test helpers used `git init` without `-b main`. On systems where the default branch is not 'main', the production auto-init logic in `worktree::create()` would trigger, creating spurious commits.

## Files fixed (5)
- src/worktree.rs
- src/mcp/handlers/dispatch_hook/tests.rs
- src/mcp/handlers/p0b_tests.rs
- src/mcp/handlers/worktree.rs
- src/api/handlers/messaging.rs

Closes #614