### PR TITLE
fix(#614): use git init -b main in all test helpers

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -710,7 +710,7 @@ mod tests {
         std::fs::create_dir_all(&wd).ok();
         // Init a git repo so is_git_repo returns true
         let _ = std::process::Command::new("git")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&wd)
             .output();
         std::fs::write(

--- a/src/bootstrap/agent_resolve.rs
+++ b/src/bootstrap/agent_resolve.rs
@@ -152,7 +152,7 @@ mod tests {
 
     fn init_git_repo(dir: &std::path::Path) {
         std::process::Command::new("git")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(dir)
             .output()
             .unwrap();

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -5,7 +5,7 @@ fn setup_test_repo(home: &std::path::Path, agent: &str) -> std::path::PathBuf {
     let repo = home.join("workspace").join(agent);
     std::fs::create_dir_all(&repo).ok();
     std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&repo)
         .env("AGEND_GIT_BYPASS", "1")
         .output()

--- a/src/mcp/handlers/p0b_tests.rs
+++ b/src/mcp/handlers/p0b_tests.rs
@@ -124,7 +124,7 @@ fn setup_git_repo_with_remote(home: &Path, agent: &str, origin_url: &str) -> std
     let repo = home.join("workspace").join(agent);
     std::fs::create_dir_all(&repo).ok();
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&repo)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
@@ -368,7 +368,7 @@ fn ec6_dispatch_uses_fleet_source_repo_tier_when_present() {
     let src = home.join("src-tier2");
     std::fs::create_dir_all(&src).ok();
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
@@ -422,7 +422,7 @@ fn ec4_fleet_repo_override_wins_over_derive() {
     std::fs::create_dir_all(&src).ok();
     // git init but NO remote configured → derive returns None.
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
@@ -487,7 +487,7 @@ fn dispatch_with_source_repo_override_wins_over_fleet() {
     let real_src = home.join("override-src");
     std::fs::create_dir_all(&real_src).ok();
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&real_src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
@@ -574,7 +574,7 @@ fn ci_watch_no_origin_remote_returns_non_github_error() {
     let src = home.join("workspace").join("alpha");
     std::fs::create_dir_all(&src).ok();
     let _ = std::process::Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -329,7 +329,7 @@ mod tests {
         let repo = home.join("workspace").join(agent);
         std::fs::create_dir_all(&repo).ok();
         std::process::Command::new("git")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&repo)
             .env("AGEND_GIT_BYPASS", "1")
             .output()

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -781,7 +781,7 @@ mod tests {
     fn claude_creates_mcp_config() {
         let dir = tmp_dir("claude");
         std::process::Command::new("git")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&dir)
             .output()
             .ok();

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -449,7 +449,7 @@ mod tests {
         // git init
         std::process::Command::new("git")
             .env("AGEND_GIT_BYPASS", "1")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&dir)
             .output()
             .ok();
@@ -578,7 +578,7 @@ mod tests {
         std::fs::create_dir_all(&dir).ok();
         std::process::Command::new("git")
             .env("AGEND_GIT_BYPASS", "1")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&dir)
             .output()
             .ok();
@@ -604,7 +604,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::process::Command::new("git")
             .env("AGEND_GIT_BYPASS", "1")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(&dir)
             .output()
             .unwrap();


### PR DESCRIPTION
## Summary

Pure test-scope fix: all `git init` calls in test helpers now use `-b main` to prevent spurious init commits when the system default branch is not 'main'.

## Files changed (7, all test code)
- src/worktree.rs (3 test inits)
- src/mcp/handlers/dispatch_hook/tests.rs
- src/mcp/handlers/p0b_tests.rs (5 inits)
- src/mcp/handlers/worktree.rs
- src/api/handlers/messaging.rs
- src/bootstrap/agent_resolve.rs
- src/mcp_config.rs (test only, production init at L140 unchanged)

Closes #614