### PR TITLE
fix(#605): deployment spawn passes model and args

### DIFF
--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -301,15 +301,24 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
     for (inst_name, entry) in &yaml_entries {
         let backend_name = entry.backend.as_deref().unwrap_or("claude");
         let work_dir = entry.working_directory.as_deref().unwrap_or(directory);
+        let mut params = serde_json::json!({
+            "name": inst_name,
+            "backend": backend_name,
+            "working_directory": work_dir,
+        });
+        if let Some(ref model) = entry.model {
+            params["model"] = serde_json::json!(model);
+        }
+        if let Some(ref args) = entry.args {
+            if !args.is_empty() {
+                params["args"] = serde_json::json!(args.join(" "));
+            }
+        }
         let _ = crate::api::call(
             home,
             &serde_json::json!({
                 "method": crate::api::method::SPAWN,
-                "params": {
-                    "name": inst_name,
-                    "backend": backend_name,
-                    "working_directory": work_dir,
-                }
+                "params": params,
             }),
         );
     }


### PR DESCRIPTION
## Summary

Phase 3 spawn loop in `src/deployments.rs` now passes `model` and `args` from the template entry to the SPAWN API call.

## Root cause

The spawn params only included `name`, `backend`, and `working_directory`, ignoring `model` and `args` fields from the fleet.yaml template.

## Fix

Read `entry.model` and `entry.args` and include them in the spawn params JSON when present.

Closes #605