### PR TITLE
fix(#607): Gemini submit_key \n\r → \r

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1557,7 +1557,7 @@ mod tests {
             ("claude", "\r"),
             ("kiro-cli", "\r"),
             ("codex", "\r"),
-            ("gemini", "\n\r"),
+            ("gemini", "\r"),
         ];
         for (cmd, expected) in cases {
             let key = Backend::from_command(cmd)

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -296,7 +296,7 @@ impl Backend {
                 command: "gemini",
                 args: &["--yolo"],
                 ready_pattern: "Type your message|YOLO",
-                submit_key: "\n\r",
+                submit_key: "\r",
                 inject_prefix: "\r",
                 typed_inject: true,
                 resume_mode: ResumeMode::Fixed {


### PR DESCRIPTION
## Summary

Fixes Gemini backend sometimes failing to submit injected messages.

## Root cause

`submit_key: "\n\r"` — the `\n` was interpreted by Gemini's Ink-based TUI as a literal newline (entering multi-line input mode), so the subsequent `\r` no longer triggered submit.

## Fix

Changed to `submit_key: "\r"` (same as Claude, Kiro, Codex backends).

Closes #607