### PR TITLE
fix(#603): skip PTY inject for Codex on update/report

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -161,9 +161,21 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
 
     let reg = agent::lock_registry(ctx.registry);
     let delivery_mode = if reg.contains_key(target) {
+        // Issue #603: Codex is one-shot — skip PTY inject for messages that
+        // don't require a reply (update/report), avoiding wasted turns.
+        let is_codex = reg
+            .get(target)
+            .map(|h| h.backend_command == "codex")
+            .unwrap_or(false);
+        let kind = params["kind"].as_str().unwrap_or("");
+        let skip_inject = is_codex && matches!(kind, "update" | "report");
         drop(reg);
-        crate::inbox::compose_aware_send(ctx.home, target, &inject_msg);
-        "pty"
+        if skip_inject {
+            "inbox_only"
+        } else {
+            crate::inbox::compose_aware_send(ctx.home, target, &inject_msg);
+            "pty"
+        }
     } else {
         drop(reg);
         "inbox_only"


### PR DESCRIPTION
## Summary

Optimizes Codex backend by skipping PTY injection for messages that don't require a reply (`kind=update` and `kind=report`).

## Root cause

Codex is one-shot — every PTY inject triggers a full turn. `update` and `report` messages don't need replies, but were still being injected, wasting Codex turns.

## Fix

In `handle_send`, check if target is Codex backend AND message kind is `update` or `report`. If so, deliver to inbox only (skip `compose_aware_send`).

`query` and `task` messages still inject normally (they require replies).

Closes #603