### PR TITLE
fix: fetch --prune before branch cleanup remote-gone detection

### DIFF
--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -120,6 +120,14 @@ fn cleanup_merged_branch(
         return (false, Some(format!("branch '{branch}' is protected")));
     }
 
+    // Prune stale remote refs before remote-gone detection
+    // (GitHub deletes remote branch on merge but local ref may be stale)
+    let _ = std::process::Command::new("git")
+        .args(["fetch", "--prune", "origin"])
+        .current_dir(source_repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output();
+
     // Check if branch is ancestor of main (fast-forward or true merge).
     let is_merged = std::process::Command::new("git")
         .args(["merge-base", "--is-ancestor", branch, "main"])


### PR DESCRIPTION
## Summary

Adds `git fetch --prune origin` at the start of `cleanup_merged_branch` so stale remote refs are pruned before remote-gone detection runs.

## Root cause

After squash-merge on GitHub, the remote branch is deleted but the local `refs/remotes/origin/<branch>` ref persists until a fetch. Without pruning, remote-gone detection returns false and the local branch isn't cleaned up.

## Fix

One `git fetch --prune origin` call before the merge-base and remote-gone checks. Fails gracefully on repos without remotes (test repos).

Closes the branch-cleanup gap for squash-merged PRs.