### PR TITLE
fix(#631): test isolation — add AGEND_GIT_BYPASS to admin + worktree_opt_out

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -24,6 +24,7 @@ pub enum BranchAction {
 /// List local branches that are NOT checked out in any worktree.
 fn worktree_branches(repo: &Path) -> std::collections::HashSet<String> {
     let output = std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(repo)
         .output();
@@ -42,6 +43,7 @@ fn worktree_branches(repo: &Path) -> std::collections::HashSet<String> {
 /// List all local branch names.
 fn local_branches(repo: &Path) -> Vec<String> {
     let output = std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["branch", "--format=%(refname:short)"])
         .current_dir(repo)
         .output();
@@ -113,6 +115,7 @@ pub fn execute_cleanup(repo: &Path, checks: &[BranchCheck], dry_run: bool) -> (u
                     log_lines.push(msg);
                 } else {
                     let result = std::process::Command::new("git")
+                        .env("AGEND_GIT_BYPASS", "1")
                         .args(["branch", "-d", &check.branch])
                         .current_dir(repo)
                         .output();
@@ -172,11 +175,13 @@ mod tests {
 
     fn init_repo(dir: &Path) {
         std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
             .args(["init", "-b", "main"])
             .current_dir(dir)
             .output()
             .unwrap();
         std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
             .args([
                 "-c",
                 "user.name=test",
@@ -208,12 +213,14 @@ mod tests {
         let dir = tmp_dir("wt-detect");
         init_repo(&dir);
         std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
             .args(["branch", "feat-wt"])
             .current_dir(&dir)
             .output()
             .unwrap();
         let wt_path = dir.join("wt");
         std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
             .args(["worktree", "add", wt_path.to_str().unwrap(), "feat-wt"])
             .current_dir(&dir)
             .output()
@@ -224,6 +231,7 @@ mod tests {
         assert_eq!(wt_check.action, BranchAction::SkipWorktree);
 
         std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
             .args(["worktree", "remove", wt_path.to_str().unwrap()])
             .current_dir(&dir)
             .output()
@@ -236,6 +244,7 @@ mod tests {
         let dir = tmp_dir("unmerged");
         init_repo(&dir);
         std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
             .args(["branch", "feat-unmerged"])
             .current_dir(&dir)
             .output()

--- a/tests/worktree_opt_out.rs
+++ b/tests/worktree_opt_out.rs
@@ -68,11 +68,13 @@ fn git_status_porcelain_detects_dirty() {
     let dir = std::env::temp_dir().join(format!("agend-wt-dirty-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
     std::process::Command::new("git")
-        .args(["init"])
+        .env("AGEND_GIT_BYPASS", "1")
+        .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();
     std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
         .current_dir(&dir)
         .output()
@@ -80,6 +82,7 @@ fn git_status_porcelain_detects_dirty() {
     std::fs::write(dir.join("dirty.txt"), "uncommitted").unwrap();
 
     let output = std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["status", "--porcelain"])
         .current_dir(&dir)
         .output()
@@ -97,17 +100,20 @@ fn git_status_porcelain_clean() {
     let dir = std::env::temp_dir().join(format!("agend-wt-clean-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
     std::process::Command::new("git")
-        .args(["init"])
+        .env("AGEND_GIT_BYPASS", "1")
+        .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();
     std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
         .current_dir(&dir)
         .output()
         .unwrap();
 
     let output = std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["status", "--porcelain"])
         .current_dir(&dir)
         .output()
@@ -128,11 +134,13 @@ fn e2e_clean_worktree_flip_prunes() {
     std::fs::create_dir_all(&dir).unwrap();
     // Init git repo
     std::process::Command::new("git")
-        .args(["init"])
+        .env("AGEND_GIT_BYPASS", "1")
+        .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();
     std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
         .current_dir(&dir)
         .output()
@@ -142,11 +150,13 @@ fn e2e_clean_worktree_flip_prunes() {
     std::fs::create_dir_all(&wt_dir).unwrap();
     // Init the worktree as a git repo too (so git status works)
     std::process::Command::new("git")
-        .args(["init"])
+        .env("AGEND_GIT_BYPASS", "1")
+        .args(["init", "-b", "main"])
         .current_dir(&wt_dir)
         .output()
         .unwrap();
     std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
         .current_dir(&wt_dir)
         .output()
@@ -154,6 +164,7 @@ fn e2e_clean_worktree_flip_prunes() {
 
     // Verify clean
     let output = std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["status", "--porcelain"])
         .current_dir(&wt_dir)
         .output()
@@ -175,11 +186,13 @@ fn e2e_dirty_worktree_flip_rejected() {
     let dir = std::env::temp_dir().join(format!("agend-wt-e2e-reject-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
     std::process::Command::new("git")
-        .args(["init"])
+        .env("AGEND_GIT_BYPASS", "1")
+        .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();
     std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
         .current_dir(&dir)
         .output()
@@ -187,11 +200,13 @@ fn e2e_dirty_worktree_flip_rejected() {
     let wt_dir = dir.join(".worktrees").join("test-agent");
     std::fs::create_dir_all(&wt_dir).unwrap();
     std::process::Command::new("git")
-        .args(["init"])
+        .env("AGEND_GIT_BYPASS", "1")
+        .args(["init", "-b", "main"])
         .current_dir(&wt_dir)
         .output()
         .unwrap();
     std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
         .current_dir(&wt_dir)
         .output()
@@ -200,6 +215,7 @@ fn e2e_dirty_worktree_flip_rejected() {
     std::fs::write(wt_dir.join("dirty.txt"), "uncommitted work").unwrap();
 
     let output = std::process::Command::new("git")
+        .env("AGEND_GIT_BYPASS", "1")
         .args(["status", "--porcelain"])
         .current_dir(&wt_dir)
         .output()


### PR DESCRIPTION
## Summary

Fixes test isolation issues where the agend-git shim intercepted git commands in tests, causing spurious commits in the worktree HEAD.

## Files fixed
- `src/admin.rs`: all git Command calls get AGEND_GIT_BYPASS=1
- `tests/worktree_opt_out.rs`: AGEND_GIT_BYPASS=1 + git init -b main

## Result
- All tests pass (0 failures, previously 7+ failures)
- No spurious commits left in worktree HEAD after test run

Closes #631