### PR TITLE
docs(#633): release_worktree scope boundary + invariant test

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -253,6 +253,15 @@ Daemon detects agent entering error state (UsageLimit/RateLimit/Hang/Crashed/Aut
 - **Never** `git worktree add <path> main` — locks main, breaks operator builds. Always use `-b <new-branch>`. Recovery: `cd <worktree> && git switch -c <dedicated-branch>`
 - **Generic `bind_self` (Sprint 54 P1-7)**: any agent (lead, dev, reviewer, …) may proactively claim a worktree via `bind_self {repo, branch}` without going through the dispatch hook. Inherits every dispatch invariant — Phase 1 trailers, P0-1.5 cross-agent registry, P0-1.6 actual-HEAD verification, P0-X release_worktree as sole exit, source_repo persistence, auto watch_ci. Use case: lead orchestrator escalating to Path A IMPL on a hot branch. Pair with `release_worktree` to unbind. `main`/`master` rejected with E4.5; cross-agent branch conflicts return `code: cross_agent_conflict`.
 
+### release_worktree branch-cleanup scope
+
+`release_worktree` auto-cleanup ONLY operates on branches that satisfy ALL of:
+1. The worktree was daemon-managed (`.agend-managed` marker verified)
+2. The branch is confirmed merged into main OR remote tracking ref is gone (squash-merge)
+3. Protected refs (main/master) are NEVER touched
+
+User-checkout branches, operator-created worktrees without `.agend-managed` marker, and any branch where the marker cannot be verified are NEVER deleted.
+
 ## §11. Tool Quick Reference
 
 | Need | Use | NOT this |

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -105,7 +105,13 @@ pub struct ReleaseOutcome {
 }
 
 /// Attempt to delete a local branch if it has been merged into main or its
-/// remote tracking ref is gone (squash-merge detection).
+/// Delete the local branch ref after worktree release, IFF:
+/// - `managed_verified` is true (caller confirmed .agend-managed marker)
+/// - Branch is merged into main OR remote tracking ref is gone
+///
+/// SAFETY: This function ONLY receives the branch from the daemon's own
+/// binding record. User-checkout branches are never passed here because
+/// release_full gates on the .agend-managed marker.
 ///
 /// Returns `(deleted, skip_reason)`:
 /// - `(true, None)` — branch was deleted
@@ -1439,6 +1445,58 @@ mod tests {
             .unwrap_or(false);
         assert!(branch_exists, "branch must survive dry-run");
 
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn release_full_does_not_delete_unrelated_branch() {
+        let home = tmp_home("unrelated-branch");
+        let repo = tmp_repo("unrelated-branch-repo");
+        // Create an unrelated user branch with its own commit
+        std::process::Command::new("git")
+            .args(["checkout", "-b", "user/my-feature"])
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.name=test",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "user work",
+            ])
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["checkout", "main"])
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .unwrap();
+        // Lease a different branch
+        let _l = lease(&home, &repo, "agent-x", "feat/daemon-task").expect("lease");
+        let outcome = release_full(&home, "agent-x", false);
+        assert!(outcome.released);
+        // Unrelated branch must still exist
+        let branch_exists = std::process::Command::new("git")
+            .args(["rev-parse", "--verify", "user/my-feature"])
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        assert!(
+            branch_exists,
+            "unrelated user branch must NOT be deleted by release_worktree"
+        );
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();
     }


### PR DESCRIPTION
## Summary

Documents the scope boundary for release_worktree branch cleanup and adds an invariant test.

## Changes
- **§10 Git Workflow**: new subsection documenting cleanup scope (3 conditions)
- **cleanup_merged_branch**: safety doc comment explaining scope
- **New test**: `release_full_does_not_delete_unrelated_branch` — verifies user branches are never touched

Closes #633