### PR TITLE
docs: remove orphan line in worktree_pool.rs (#641)

### DIFF
--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -104,7 +104,6 @@ pub struct ReleaseOutcome {
     pub error: Option<String>,
 }
 
-/// Attempt to delete a local branch if it has been merged into main or its
 /// Delete the local branch ref after worktree release, IFF:
 /// - `managed_verified` is true (caller confirmed .agend-managed marker)
 /// - Branch is merged into main OR remote tracking ref is gone


### PR DESCRIPTION
Remove orphan line near line 107 in src/worktree_pool.rs. Closes t-20260511085451194497-6.