### PR TITLE
docs: add missing fields to send in MCP-TOOLS.md (#642)

### DIFF
--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -50,7 +50,7 @@ Send a message to another instance or broadcast to multiple. Unified replacement
 - target_instance, targets, team, tags (routing)
 - request_kind: query / task / report / update
 - task_id (required for kind=task), success_criteria, branch, working_directory
-- context, correlation_id, parent_id, thread_id, requires_reply, task_summary
+- context, requires_reply, task_summary, correlation_id, parent_id, thread_id
 - force, force_reason, second_reviewer, second_reviewer_reason
 - reviewed_head, artifacts
 

--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -50,7 +50,7 @@ Send a message to another instance or broadcast to multiple. Unified replacement
 - target_instance, targets, team, tags (routing)
 - request_kind: query / task / report / update
 - task_id (required for kind=task), success_criteria, branch, working_directory
-- correlation_id, parent_id, thread_id
+- context, correlation_id, parent_id, thread_id, requires_reply, task_summary
 - force, force_reason, second_reviewer, second_reviewer_reason
 - reviewed_head, artifacts
 


### PR DESCRIPTION
Add context, requires_reply, and task_summary to the send tool description in docs/MCP-TOOLS.md. Closes t-20260511085451208702-7.