### PR TITLE
feat: safe daemon restart via exit(42) + wrapper

### DIFF
--- a/scripts/agend-wrapper.sh
+++ b/scripts/agend-wrapper.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# agend-wrapper.sh — restarts daemon on exit code 42
+# Usage: ./scripts/agend-wrapper.sh [daemon args...]
+while true; do
+    agend-terminal daemon "$@"
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 42 ]; then
+        echo "agend daemon exited with code $EXIT_CODE"
+        exit $EXIT_CODE
+    fi
+    echo "agend daemon requested restart (exit 42), restarting..."
+    sleep 1
+done

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1033,56 +1033,14 @@ fn run_core(
     // topic registry, fleet.yaml) — operators re-attach PTY agents
     // post-restart per the MVP scope.
     if RESTART_PENDING.load(Ordering::Acquire) {
-        tracing::info!("operator-initiated restart: re-execing self");
-        exec_self_for_restart();
-        // exec_self_for_restart returns only on failure; fall through
-        // to normal exit so the operator gets a clean stop instead of
-        // a zombie process.
-        tracing::warn!("re-exec failed; falling back to normal exit");
+        let flag = home.join("restart-requested");
+        let _ = std::fs::remove_file(&flag);
+        tracing::info!("operator-initiated restart: exiting with code 42");
+        std::process::exit(42);
     }
 
     tracing::info!("exiting");
     Ok(())
-}
-
-/// Sprint 60 W1 PR-3 (#P0-3): re-exec the daemon with the same args
-/// after `RESTART_PENDING` was set. On Unix uses `execvp` via
-/// `CommandExt::exec` (atomic process-image replacement, preserves
-/// PID); on Windows spawns a fresh process and exits the current one
-/// (no `execvp` equivalent). Returns only on error — the success
-/// case never returns because the process image has been replaced
-/// (Unix) or `exit(0)` was called (Windows).
-fn exec_self_for_restart() {
-    let exe = match std::env::current_exe() {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::error!(error = %e, "current_exe() failed during restart");
-            return;
-        }
-    };
-    let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        let err = std::process::Command::new(&exe).args(&args).exec();
-        // exec only returns on error.
-        tracing::error!(error = %err, exe = %exe.display(), "execvp failed");
-    }
-
-    #[cfg(not(unix))]
-    {
-        match std::process::Command::new(&exe).args(&args).spawn() {
-            Ok(_child) => {
-                // New daemon has been spawned; exit current process so
-                // operators see a single clean transition.
-                std::process::exit(0);
-            }
-            Err(e) => {
-                tracing::error!(error = %e, exe = %exe.display(), "spawn-restart failed");
-            }
-        }
-    }
 }
 
 /// Sprint 57 Wave 3 PR-2 (#548 Q6) shutdown summary record.

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod dispatch_hook;
 mod force_release;
 pub(crate) mod instance;
 pub(crate) mod instance_lifecycle;
+mod restart;
 mod schedule;
 pub(crate) mod sha_gate;
 mod task;
@@ -205,6 +206,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
 
         // --- Phase 4 GC dry-run visibility (Sprint 53 P1-4) ---
         "gc_dry_run" => worktree::handle_gc_dry_run(&home, args, &sender),
+        "restart_daemon" => restart::handle_restart_daemon(&home),
 
         _ => json!({"error": format!("unknown tool: {tool}")}),
     }

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -1,0 +1,9 @@
+use serde_json::{json, Value};
+use std::path::Path;
+
+pub(super) fn handle_restart_daemon(home: &Path) -> Value {
+    crate::daemon::RESTART_PENDING.store(true, std::sync::atomic::Ordering::Release);
+    std::fs::write(home.join("restart-requested"), "").ok();
+    let _ = crate::api::call(home, &json!({"method": crate::api::method::SHUTDOWN}));
+    json!({"ok": true, "restart": "pending", "note": "daemon will exit(42) after graceful shutdown; wrapper script restarts"})
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -169,6 +169,8 @@ fn task_tools() -> Vec<Value> {
             "pause": {"type": "boolean", "description": "Pause/resume the sweep tick"},
             "dry_run": {"type": "boolean", "description": "Log decisions without emitting events"}
         }}}),
+        json!({"name": "restart_daemon", "description": "Request graceful daemon restart. Daemon exits with code 42 after shutdown; wrapper script restarts it. Idempotent.",
+            "inputSchema": {"type": "object", "properties": {}}}),
     ]
 }
 
@@ -455,8 +457,8 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            29,
-            "Sprint 61 tool slim: 32 - react - describe_instance - restart_daemon = 29. \
+            30,
+            "Sprint 61: 29 + restart_daemon(exit-42) = 30. \
              Current tools: {:?}",
             tools
                 .iter()


### PR DESCRIPTION
## Summary

Replaces the fragile re-exec restart with a safe exit-code + wrapper approach.

## Changes
- **restart_daemon MCP tool**: sets RESTART_PENDING flag, triggers graceful shutdown
- **Daemon shutdown**: exits with code 42 instead of re-exec
- **scripts/agend-wrapper.sh**: detects exit 42 and restarts daemon
- Removes `exec_self_for_restart` (old re-exec approach)
- Also includes react/describe_instance removal (from PR #640, not yet in this branch's base)
- Tool count: 30

## Why exit(42) over re-exec
- No fd leaks from inherited file descriptors
- No signal mask inheritance issues  
- Clean process state on restart
- Wrapper script is simple and debuggable