### PR TITLE
fix: exempt orchestrator from ACK absorption PTY skip

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -170,15 +170,21 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             .unwrap_or(false);
         let kind = params["kind"].as_str().unwrap_or("");
         drop(reg);
-        let is_cross_team = {
+        let (is_cross_team, is_orchestrator) = {
             let sender_team = crate::teams::find_team_for(ctx.home, from);
             let target_team = crate::teams::find_team_for(ctx.home, target);
-            match (sender_team, target_team) {
+            let orchestrator = target_team
+                .as_ref()
+                .map(|t| t.orchestrator.as_deref() == Some(target))
+                .unwrap_or(false);
+            let cross = match (sender_team, target_team) {
                 (Some(s), Some(t)) => s.name != t.name,
                 _ => true, // no team = treat as cross-team (safe default)
-            }
+            };
+            (cross, orchestrator)
         };
-        let skip_inject = is_codex && matches!(kind, "update" | "report") && !is_cross_team;
+        let skip_inject =
+            is_codex && matches!(kind, "update" | "report") && !is_cross_team && !is_orchestrator;
         if skip_inject {
             crate::event_log::log(
                 ctx.home,


### PR DESCRIPTION
## 問題現象
Codex backend 的 orchestrator (如 dev-lead) 無法正確收到來自同團隊成員的 report/update 訊息通知 (沒有 AGEND-MSG banner)，導致需要手動 polling inbox。

## 根本原因
Issue #603/#612 引入的 ACK absorption 機制在 src/api/handlers/messaging.rs:178 中，錯誤地將 orchestrator 同樣視為可以跳過 PTY 注入的對象，導致關鍵訊息僅存入 inbox 而未觸發 terminal injection。

## 修復邏輯
在 skip_inject 條件中增加 !is_orchestrator 判斷，確保協調者能收到關鍵訊息通知。

## 驗證
確認程式邏輯已排除 orchestrator，並通過 cargo check。