### PR TITLE
feat(#650): CI pass auto-route to next_after_ci

### DIFF
--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -2018,6 +2018,28 @@ async fn ci_check_repo(
         new_notified_sha = Some(sha.to_string());
     }
 
+    // Issue #650: auto-route [ci-ready-for-action] to next_after_ci target on pass
+    if new_notified_sha.is_some() {
+        if let Ok(content) = std::fs::read_to_string(watch_path) {
+            if let Ok(watch) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(next) = watch["next_after_ci"].as_str().filter(|s| !s.is_empty()) {
+                    // Only route on success (not failure)
+                    let last_conclusion = aggregate_conclusion_for_sha(&runs, current_sha);
+                    if last_conclusion == Some("success") {
+                        let msg = format!(
+                            "[ci-ready-for-action] {repo}@{branch}: CI passed, your turn.\r"
+                        );
+                        let reg = agent::lock_registry(registry);
+                        if let Some(handle) = reg.get(next) {
+                            let _ = agent::inject_to_agent(handle, msg.as_bytes());
+                        }
+                        drop(reg);
+                    }
+                }
+            }
+        }
+    }
+
     update_watch_state_with_notify(
         watch_path,
         Some(max_notified_id),

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -310,6 +310,10 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     watch["expires_at"] = json!((chrono::Utc::now()
         + chrono::Duration::hours(crate::daemon::ci_watch::WATCH_TTL_HOURS))
     .to_rfc3339());
+    // Issue #650: store next_after_ci for auto-routing on CI pass
+    if let Some(next) = args["next_after_ci"].as_str().filter(|s| !s.is_empty()) {
+        watch["next_after_ci"] = json!(next);
+    }
 
     let _ = crate::store::atomic_write(
         &watch_path,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -229,7 +229,8 @@ fn ci_tools() -> Vec<Value> {
                 "action": {"type": "string", "enum": ["watch", "unwatch", "status"]},
                 "repo": {"type": "string", "description": "GitHub repo (owner/repo). Required for watch/unwatch; optional filter for status."},
                 "branch": {"type": "string", "description": "Branch to watch (default: main); optional filter for status."},
-                "interval_secs": {"type": "number", "description": "Poll interval in seconds (default: 60)"}
+                "interval_secs": {"type": "number", "description": "Poll interval in seconds (default: 60)"},
+                "next_after_ci": {"type": "string", "description": "Instance to auto-notify when CI passes. Daemon sends [ci-ready-for-action] to this target."}
             }, "required": ["action"]}}),
     ]
 }


### PR DESCRIPTION
## Summary

When CI passes, daemon auto-notifies a designated next agent with [ci-ready-for-action].

## Changes
- src/mcp/tools.rs: ci tool gains `next_after_ci` param
- src/mcp/handlers/ci/mod.rs: stores field in watch JSON
- src/daemon/ci_watch.rs: on CI pass, injects [ci-ready-for-action] to target

Closes #650