### PR TITLE
fix: startup grace period for replace_instance

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -37,6 +37,7 @@ pub struct AgentHandle {
     pub submit_key: String,
     pub inject_prefix: String,
     pub typed_inject: bool,
+    pub spawned_at: std::time::Instant,
 }
 
 pub type AgentRegistry = Arc<Mutex<HashMap<String, AgentHandle>>>;
@@ -529,6 +530,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
                     .as_ref()
                     .map(|b| b.preset().typed_inject)
                     .unwrap_or(false),
+                spawned_at: std::time::Instant::now(),
             },
         );
     }
@@ -908,6 +910,35 @@ fn handle_pty_close(
     sweep_child_tree(name, registry);
 
     if is_user_clean_exit {
+        // Startup grace period: if the process exited within 5s of spawn,
+        // treat as startup failure — do NOT spawn shell fallback.
+        let uptime = {
+            let reg = registry.lock();
+            reg.get(name).map(|h| h.spawned_at.elapsed())
+        };
+        if let Some(uptime) = uptime {
+            if uptime < std::time::Duration::from_secs(5) {
+                tracing::warn!(
+                    agent = name,
+                    uptime_ms = uptime.as_millis() as u64,
+                    "startup failure (exited too quickly), skipping shell fallback"
+                );
+                if let Some(ref home) = home {
+                    crate::event_log::log(
+                        home,
+                        "startup_failure",
+                        name,
+                        &format!("exited in {}ms", uptime.as_millis()),
+                    );
+                }
+                // Mark as crashed so daemon can notify operator.
+                if let Some(ref tx) = crash_tx {
+                    let _ = tx.send(AgentExitEvent::Crash(name.to_string()));
+                }
+                return;
+            }
+        }
+
         // User-initiated clean exit (code 0 or 130): /exit, /quit, Ctrl+C.
         // Do NOT respawn the agent — spawn a shell replacement instead
         // (tmux-style: pane stays alive with a shell prompt).
@@ -1922,6 +1953,7 @@ Allow Trust All Tools mode?
             submit_key: "\r".to_string(),
             inject_prefix: String::new(),
             typed_inject: false,
+            spawned_at: std::time::Instant::now(),
         };
         let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         registry.lock().insert("sweep-test".to_string(), handle);
@@ -2090,6 +2122,26 @@ Allow Trust All Tools mode?
         assert!(
             stripped_from.starts_with("[from:"),
             "stripped should start with [from:, got: {stripped_from}"
+        );
+    }
+
+    /// Startup grace period: agent that exits within 5s should NOT get shell fallback.
+    #[test]
+    fn startup_grace_period_detects_quick_exit() {
+        let spawned_at = std::time::Instant::now();
+        // Simulate immediate exit (0ms uptime)
+        let uptime = spawned_at.elapsed();
+        assert!(
+            uptime < std::time::Duration::from_secs(5),
+            "freshly spawned agent should be within grace period"
+        );
+
+        // Simulate 6s uptime (past grace period)
+        let old_spawn = std::time::Instant::now() - std::time::Duration::from_secs(6);
+        let old_uptime = old_spawn.elapsed();
+        assert!(
+            old_uptime >= std::time::Duration::from_secs(5),
+            "agent running 6s should be past grace period"
         );
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -38,6 +38,7 @@ pub struct AgentHandle {
     pub inject_prefix: String,
     pub typed_inject: bool,
     pub spawned_at: std::time::Instant,
+    pub spawned_at_epoch_ms: u64,
 }
 
 pub type AgentRegistry = Arc<Mutex<HashMap<String, AgentHandle>>>;
@@ -531,6 +532,10 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
                     .map(|b| b.preset().typed_inject)
                     .unwrap_or(false),
                 spawned_at: std::time::Instant::now(),
+                spawned_at_epoch_ms: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64,
             },
         );
     }
@@ -915,14 +920,17 @@ fn handle_pty_close(
         // If user sent input (e.g. /exit), it's a legitimate quick exit.
         let uptime = {
             let reg = registry.lock();
-            reg.get(name).map(|h| h.spawned_at.elapsed())
+            reg.get(name)
+                .map(|h| (h.spawned_at.elapsed(), h.spawned_at_epoch_ms))
         };
-        let had_user_input = {
+        let had_user_input_since_spawn = {
             let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
-            pair.last_input_at_ms > 0
+            uptime
+                .map(|(_, epoch_ms)| pair.last_input_at_ms >= epoch_ms)
+                .unwrap_or(false)
         };
-        if let Some(uptime) = uptime {
-            if uptime < std::time::Duration::from_secs(5) && !had_user_input {
+        if let Some((uptime, _)) = uptime {
+            if uptime < std::time::Duration::from_secs(5) && !had_user_input_since_spawn {
                 tracing::warn!(
                     agent = name,
                     uptime_ms = uptime.as_millis() as u64,
@@ -1959,6 +1967,7 @@ Allow Trust All Tools mode?
             inject_prefix: String::new(),
             typed_inject: false,
             spawned_at: std::time::Instant::now(),
+            spawned_at_epoch_ms: 0,
         };
         let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         registry.lock().insert("sweep-test".to_string(), handle);
@@ -2131,29 +2140,29 @@ Allow Trust All Tools mode?
     }
 
     /// Startup grace period: agent that exits within 5s should NOT get shell fallback.
-    /// Startup failure: exit within 5s + no user input → no shell fallback.
+    /// Startup failure: exit within 5s + no user input since spawn → no shell fallback.
     #[test]
     fn startup_failure_no_input_no_shell_fallback() {
-        let spawned_at = std::time::Instant::now();
-        let uptime = spawned_at.elapsed();
-        let had_user_input = false;
+        // spawned_at_epoch_ms = 1000, last_input_at_ms = 500 → input before spawn
+        let spawned_at_epoch_ms: u64 = 1000;
+        let last_input_at_ms: u64 = 500;
+        let had_user_input_since_spawn = last_input_at_ms >= spawned_at_epoch_ms;
         assert!(
-            uptime < std::time::Duration::from_secs(5) && !had_user_input,
-            "should detect startup failure: quick exit + no user input"
+            !had_user_input_since_spawn,
+            "input before spawn should not count as user input"
         );
     }
 
-    /// Quick user exit: exit within 5s but HAD user input → normal clean exit.
+    /// Quick user exit: input AFTER spawn → normal clean exit, not startup failure.
     #[test]
     fn quick_user_exit_still_clean() {
-        let spawned_at = std::time::Instant::now();
-        let uptime = spawned_at.elapsed();
-        let had_user_input = true;
-        // Condition for startup failure is: quick exit AND no input
-        // With input, this should NOT trigger startup failure
+        // spawned_at_epoch_ms = 1000, last_input_at_ms = 1500 → input after spawn
+        let spawned_at_epoch_ms: u64 = 1000;
+        let last_input_at_ms: u64 = 1500;
+        let had_user_input_since_spawn = last_input_at_ms >= spawned_at_epoch_ms;
         assert!(
-            !(uptime < std::time::Duration::from_secs(5) && !had_user_input),
-            "should NOT be startup failure when user input was received"
+            had_user_input_since_spawn,
+            "input after spawn should count as user input → not startup failure"
         );
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -910,25 +910,30 @@ fn handle_pty_close(
     sweep_child_tree(name, registry);
 
     if is_user_clean_exit {
-        // Startup grace period: if the process exited within 5s of spawn,
-        // treat as startup failure — do NOT spawn shell fallback.
+        // Startup grace period: if the process exited within 5s of spawn
+        // AND no user input was received, treat as startup failure.
+        // If user sent input (e.g. /exit), it's a legitimate quick exit.
         let uptime = {
             let reg = registry.lock();
             reg.get(name).map(|h| h.spawned_at.elapsed())
         };
+        let had_user_input = {
+            let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
+            pair.last_input_at_ms > 0
+        };
         if let Some(uptime) = uptime {
-            if uptime < std::time::Duration::from_secs(5) {
+            if uptime < std::time::Duration::from_secs(5) && !had_user_input {
                 tracing::warn!(
                     agent = name,
                     uptime_ms = uptime.as_millis() as u64,
-                    "startup failure (exited too quickly), skipping shell fallback"
+                    "startup failure (exited too quickly, no user input), skipping shell fallback"
                 );
                 if let Some(ref home) = home {
                     crate::event_log::log(
                         home,
                         "startup_failure",
                         name,
-                        &format!("exited in {}ms", uptime.as_millis()),
+                        &format!("exited in {}ms, no user input", uptime.as_millis()),
                     );
                 }
                 // Mark as crashed so daemon can notify operator.
@@ -2126,22 +2131,29 @@ Allow Trust All Tools mode?
     }
 
     /// Startup grace period: agent that exits within 5s should NOT get shell fallback.
+    /// Startup failure: exit within 5s + no user input → no shell fallback.
     #[test]
-    fn startup_grace_period_detects_quick_exit() {
+    fn startup_failure_no_input_no_shell_fallback() {
         let spawned_at = std::time::Instant::now();
-        // Simulate immediate exit (0ms uptime)
         let uptime = spawned_at.elapsed();
+        let had_user_input = false;
         assert!(
-            uptime < std::time::Duration::from_secs(5),
-            "freshly spawned agent should be within grace period"
+            uptime < std::time::Duration::from_secs(5) && !had_user_input,
+            "should detect startup failure: quick exit + no user input"
         );
+    }
 
-        // Simulate 6s uptime (past grace period)
-        let old_spawn = std::time::Instant::now() - std::time::Duration::from_secs(6);
-        let old_uptime = old_spawn.elapsed();
+    /// Quick user exit: exit within 5s but HAD user input → normal clean exit.
+    #[test]
+    fn quick_user_exit_still_clean() {
+        let spawned_at = std::time::Instant::now();
+        let uptime = spawned_at.elapsed();
+        let had_user_input = true;
+        // Condition for startup failure is: quick exit AND no input
+        // With input, this should NOT trigger startup failure
         assert!(
-            old_uptime >= std::time::Duration::from_secs(5),
-            "agent running 6s should be past grace period"
+            !(uptime < std::time::Duration::from_secs(5) && !had_user_input),
+            "should NOT be startup failure when user input was received"
         );
     }
 }

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -322,6 +322,7 @@ mod tests {
             inject_prefix: String::new(),
             typed_inject: false,
             spawned_at: std::time::Instant::now(),
+            spawned_at_epoch_ms: 0,
         }
     }
 

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -321,6 +321,7 @@ mod tests {
             submit_key: "\r".to_string(),
             inject_prefix: String::new(),
             typed_inject: false,
+            spawned_at: std::time::Instant::now(),
         }
     }
 

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -166,6 +166,7 @@ mod tests {
             submit_key: "\r".to_string(),
             inject_prefix: String::new(),
             typed_inject: false,
+            spawned_at: std::time::Instant::now(),
         };
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         reg.lock().insert(name.to_string(), handle);

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -167,6 +167,7 @@ mod tests {
             inject_prefix: String::new(),
             typed_inject: false,
             spawned_at: std::time::Instant::now(),
+            spawned_at_epoch_ms: 0,
         };
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         reg.lock().insert(name.to_string(), handle);

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -278,6 +278,10 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
         &json!({"method": crate::api::method::DELETE, "params": {"name": name}}),
     );
 
+    // Brief pause after kill to let OS reclaim resources (ports, file locks)
+    // before spawning the replacement. Prevents startup race on fast exits.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
     // Enqueue handover context for the new instance.
     let _ = crate::inbox::enqueue(
         home,


### PR DESCRIPTION
## Summary
Prevents shell fallback spawn when backend exits within 5s of spawn (startup failure, not user /exit).

## Problem
gemini spawn → exit 0 in 467ms → reaper treats as user clean exit → spawns shell fallback. Agent becomes /bin/bash instead of gemini.

## Fix
1. **`AgentHandle.spawned_at`**: new `Instant` field tracking spawn time
2. **Reaper grace period**: if `uptime < 5s` and exit code 0, treat as startup failure — emit `startup_failure` event + `Crash` signal, skip shell fallback
3. **replace_instance sleep**: 500ms pause between DELETE and SPAWN to let OS reclaim resources

## Verification
- `cargo build` ✅
- `cargo test` — 0 failures ✅
- `cargo fmt --check` ✅

**NOTE: Do not merge** — awaiting operator rebuild + testing.