### PR TITLE
fix: remove dead requires_daemon_state field + fix stale CLI hint (#672)

### DIFF
--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -1010,7 +1010,7 @@ pub fn format_notification_for_inject(
             attachment_body_placeholder(attachments)
         } else if text.chars().count() > 200 {
             let truncated: String = text.chars().take(200).collect();
-            format!("{truncated}... (run: agend-terminal agent inbox)")
+            format!("{truncated}... (use the inbox MCP tool to read full message)")
         } else {
             text.to_string()
         };

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -2611,6 +2611,24 @@ mod tests {
         );
     }
 
+    // Issue #672: inline-notification truncation hint must point at the
+    // `inbox` MCP tool, not at the (non-existent) `agend-terminal agent
+    // inbox` CLI subcommand. The CLI subcommand was never implemented;
+    // a user following the old hint hits `unrecognized subcommand`.
+    #[test]
+    fn test_inline_long_text_hint_points_at_mcp_tool_not_cli() {
+        let long: String = "x".repeat(250);
+        let out = format_notification_for_inject(false, &NotifySource::Agent("peer"), &long, &[]);
+        assert!(
+            out.contains("inbox MCP tool"),
+            "hint must direct caller to the MCP tool: {out}"
+        );
+        assert!(
+            !out.contains("agend-terminal agent"),
+            "hint must not reference the non-existent `agent` CLI subcommand: {out}"
+        );
+    }
+
     #[test]
     fn test_reply_excerpt_newline_escaped() {
         let msg = InboxMessage {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -20,27 +20,15 @@ pub fn tool_definitions() -> Value {
 }
 
 fn channel_tools() -> Vec<Value> {
-    // Sprint 54 #488 hotfix: these handlers depend on daemon-resident
-    // state (ACTIVE_CHANNEL, telegram bot session) and cannot run
-    // outside the daemon process. Tagged `requires_daemon_state: true`
-    // so the `agend-mcp-bridge` proxy surfaces a structured error to
-    // callers when the daemon is unreachable, rather than degrading
-    // to a local fallback that would silently produce misleading
-    // errors like `no active channel`. Sprint 56 Track I-Phase2c
-    // (#531) hard-removed the local-fallback path that this comment
-    // originally described — flag stays valid as a daemon-side
-    // dispatch hint and as the contract the bridge consumes.
     vec![
         json!({"name": "reply", "description": "Reply to the user via the active channel. Requires daemon API. Sprint 59 Wave 1 PR-4 ((B) decision default with timeout): when both `default_action` and `timeout_secs` are set, the daemon records a pending operator decision sidecar and auto-fires the default after the timeout window. Subsequent reply calls without `default_action` resolve the pending decision (operator override / explicit answer arrived).",
             "inputSchema": {"type": "object", "properties": {
                 "text": {"type": "string"},
                 "default_action": {"type": "string", "description": "Action to auto-execute on timeout when the operator doesn't reply within `timeout_secs`. e.g. 'proceed-with-lean' / 'abort'. Pair with `timeout_secs` (Sprint 59 Wave 1 PR-4)."},
                 "timeout_secs": {"type": "integer", "description": "Seconds to wait for an operator response before firing `default_action`. Required when `default_action` is set; ignored otherwise (Sprint 59 Wave 1 PR-4)."}
-            }, "required": ["text"]},
-            "requires_daemon_state": true}),
+            }, "required": ["text"]}}),
         json!({"name": "download_attachment", "description": "Download a file attachment (telegram multimedia: images, audio, documents). Returns local path. Requires daemon API.",
-            "inputSchema": {"type": "object", "properties": {"file_id": {"type": "string"}}, "required": ["file_id"]},
-            "requires_daemon_state": true}),
+            "inputSchema": {"type": "object", "properties": {"file_id": {"type": "string"}}, "required": ["file_id"]}}),
     ]
 }
 


### PR DESCRIPTION
## Summary

Issue #672 surfaced two user-visible defects:

- **V1** — `requires_daemon_state` field on the `reply` and `download_attachment` MCP tools is dead code. It was added as a Sprint 54 #488 hotfix to coordinate with a local-fallback path that Sprint 56 Track I-Phase2c (#531) has since hard-removed. The flag still leaks into the `tools/list` JSON-RPC response and risks rejection by strict MCP clients. Repo-wide grep confirms zero remaining consumers.
- **V3** — `src/inbox.rs:1013` emits `(run: agend-terminal agent inbox)` when an inline notification's text > 200 chars, but no `agent` subcommand exists in `main.rs` (`Commands` enum: Start / Attach / Inject / List / Connect / App / Stop / Kill / Admin / Capture / Verify / Service / Doctor / Skills / Tray / Demo / Quickstart / Bugreport / Completions / VerifyPush — no `Agent`). Users following the hint hit `unrecognized subcommand`. Replaced with `(use the inbox MCP tool to read full message)` — agents receiving inline notifications already own the `inbox` MCP tool.

## V2 explicitly NOT addressed

**V2 (missing `required: []`) intentionally not addressed — verified as JSON Schema spec compliant per discuss-team Phase 2 consensus.** `required` is an optional JSON Schema keyword whose default value is the empty array, so the 5 tools that omit it (`inbox`, `list_instances`, `task_sweep_config`, `restart_daemon`, `gc_dry_run`) are valid as-is. Pure consistency nit; rejected as a fix target.

## §3.10 test-first

- `ddaaaf5` — test commit, `test_inline_long_text_hint_points_at_mcp_tool_not_cli` fails (hint still says `agent inbox`)
- `b68138d` — fix commit, test passes

Reviewer can verify:
```
git checkout HEAD~1 -- src/inbox.rs
cargo test --bin agend-terminal test_inline_long_text_hint
# expect: 1 failed
git checkout HEAD -- src/inbox.rs
cargo test --bin agend-terminal test_inline_long_text_hint
# expect: 1 passed
```

V1 is pure deletion of a dead field — §3.10 exempts pure deletion.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 2028 lib tests + all integration suites green (0 failed across all binaries)
- [x] §3.10 test-first verified via checkout HEAD~1 → red, checkout HEAD → green
- [x] Repo-wide `grep -rn requires_daemon_state` returns zero remaining matches after fix

## LOC

- `src/mcp/tools.rs`: -13 / +1 (remove 11-line stale comment block + 2 field lines, keep tool JSON intact)
- `src/inbox.rs`: -1 / +1 (string update) + 18 lines test
- Total: +20 / -14 (dispatch budget: ~20-30 ✓)

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)