### PR TITLE
feat(#664): L4b worktree marker check on high-risk ops

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -143,6 +143,32 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             worktree_binding_required: params["worktree_binding_required"].as_bool(),
         }
     };
+
+    // Issue #664 L4b: worktree marker check for high-risk ops.
+    // When kind=task + worktree_binding_required=true, verify target is in
+    // a daemon-managed worktree before dispatching.
+    if params["kind"].as_str() == Some("task")
+        && params["worktree_binding_required"].as_bool() == Some(true)
+    {
+        let mode =
+            std::env::var("AGEND_WORKTREE_ENFORCEMENT").unwrap_or_else(|_| "warn".to_string());
+        if mode != "off" && !crate::binding::is_agent_in_managed_worktree(ctx.home, target) {
+            if mode == "enforce" {
+                return json!({
+                    "ok": false,
+                    "error": "agent not bound in daemon-managed worktree",
+                    "hint": "call bind_self first",
+                    "code": "worktree_not_managed"
+                });
+            }
+            // warn mode: log but allow
+            tracing::warn!(
+                target,
+                "worktree marker check: agent not in managed worktree (warn mode, allowing)"
+            );
+        }
+    }
+
     let _ = crate::inbox::enqueue(ctx.home, target, msg.clone());
 
     let inject_msg = if crate::inbox::pointer_only_inject()

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -102,6 +102,16 @@ pub fn read(home: &Path, agent: &str) -> Option<serde_json::Value> {
         .and_then(|c| serde_json::from_str(&c).ok())
 }
 
+/// Check if an agent is bound in a daemon-managed worktree.
+/// Returns true if the agent has a binding with a worktree path that
+/// contains the `.agend-managed` marker file.
+pub fn is_agent_in_managed_worktree(home: &Path, agent: &str) -> bool {
+    read(home, agent)
+        .and_then(|v| v["worktree"].as_str().map(std::path::PathBuf::from))
+        .map(|wt| wt.join(".agend-managed").exists())
+        .unwrap_or(false)
+}
+
 /// Install the prepare-commit-msg hook into a worktree via core.hooksPath.
 /// Points to `$AGEND_HOME/hooks/` unified directory.
 /// Installs bash hook on Unix, PowerShell hook on Windows.
@@ -222,6 +232,7 @@ pub fn reconcile_orphans(home: &Path) {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -266,6 +277,46 @@ mod tests {
     fn read_missing_returns_none() {
         let home = tmp_home("read-miss");
         assert!(read(&home, "ghost").is_none());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn marker_check_passes_for_managed_worktree() {
+        let home = tmp_home("marker-pass");
+        let wt = home.join("worktrees").join("agent-1").join("feat-branch");
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(wt.join(".agend-managed"), "").unwrap();
+        // Write binding pointing to this worktree
+        let rt = home.join("runtime").join("agent-1");
+        std::fs::create_dir_all(&rt).unwrap();
+        let binding =
+            serde_json::json!({"worktree": wt.to_str().unwrap(), "branch": "feat-branch"});
+        std::fs::write(rt.join("binding.json"), binding.to_string()).unwrap();
+
+        assert!(is_agent_in_managed_worktree(&home, "agent-1"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn marker_check_fails_for_unmanaged() {
+        let home = tmp_home("marker-fail");
+        let wt = home.join("worktrees").join("agent-2").join("feat-branch");
+        std::fs::create_dir_all(&wt).unwrap();
+        // No .agend-managed marker
+        let rt = home.join("runtime").join("agent-2");
+        std::fs::create_dir_all(&rt).unwrap();
+        let binding =
+            serde_json::json!({"worktree": wt.to_str().unwrap(), "branch": "feat-branch"});
+        std::fs::write(rt.join("binding.json"), binding.to_string()).unwrap();
+
+        assert!(!is_agent_in_managed_worktree(&home, "agent-2"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn marker_check_fails_for_no_binding() {
+        let home = tmp_home("marker-no-bind");
+        assert!(!is_agent_in_managed_worktree(&home, "nobody"));
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Summary
Adds enforcement gate for task dispatches with `worktree_binding_required=true`.

## Changes
1. **Helper**: `binding::is_agent_in_managed_worktree()` — checks if agent's binding worktree has `.agend-managed` marker
2. **Guard in send handler**: when `kind=task` + `worktree_binding_required=true`, verify target is in managed worktree
3. **Feature flag**: `AGEND_WORKTREE_ENFORCEMENT` env var (`off`/`warn`/`enforce`), default `warn`

## Tests (3 new)
- `marker_check_passes_for_managed_worktree`
- `marker_check_fails_for_unmanaged`
- `marker_check_fails_for_no_binding`

## Verification
- `cargo clippy -- -D warnings` ✅
- `cargo test` — 0 failures ✅
- `cargo fmt --check` ✅

Relates to #664