### PR TITLE
refactor: SSOT magic strings P1

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -154,7 +154,7 @@ pub fn resolve_instance(
     home: &std::path::Path,
     name_or_id: &str,
 ) -> Result<(crate::types::InstanceId, String), ResolveError> {
-    let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
         .ok()
         .unwrap_or_default();
 
@@ -1394,7 +1394,7 @@ pub fn inject_to_agent(agent: &AgentHandle, text: &[u8]) -> crate::error::Result
         // then chunk only the body. Use `stripped` (ANSI-free) for detection
         // since raw text may have color escapes before the bracket.
         let is_system_header =
-            stripped.starts_with("[AGEND-MSG]") || stripped.starts_with("[from:");
+            stripped.starts_with(crate::inbox::SYSTEM_MSG_PREFIX) || stripped.starts_with("[from:");
         let (atomic_part, chunk_part) = if is_system_header {
             match all_bytes.iter().position(|&b| b == b'\n') {
                 Some(pos) => all_bytes.split_at(pos + 1),
@@ -2182,7 +2182,7 @@ Allow Trust All Tools mode?
             "defaults:\n  backend: claude\ninstances:\n  dev:\n    id: \"{}\"\n    role: Test\n",
             id.full()
         );
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let (resolved_id, resolved_name) = resolve_instance(&home, "dev").unwrap();
         assert_eq!(resolved_id, id);
         assert_eq!(resolved_name, "dev");
@@ -2196,7 +2196,7 @@ Allow Trust All Tools mode?
         // Verify that a non-existent name returns NotFound.
         let home = resolve_test_home("notfound");
         let yaml = "defaults:\n  backend: claude\ninstances:\n  dev:\n    role: Test\n";
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let result = resolve_instance(&home, "nonexistent");
         assert!(
             matches!(result, Err(ResolveError::NotFound(_))),

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -29,7 +29,7 @@ pub fn fallback_deliver(
     msg: crate::inbox::InboxMessage,
     api_error: &anyhow::Error,
 ) -> Value {
-    let in_fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+    let in_fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
         .ok()
         .map(|c| c.instances.contains_key(target))
         .unwrap_or(false);
@@ -84,7 +84,7 @@ pub fn send_to(
         Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("send failed")}),
         Err(e) => {
             // Validate target exists in fleet.yaml before writing to inbox.
-            let in_fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+            let in_fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                 .ok()
                 .map(|c| c.instances.contains_key(target))
                 .unwrap_or(false);
@@ -118,7 +118,7 @@ pub fn metadata_path(home: &Path, name: &str) -> PathBuf {
 /// Sprint 46 P2: resolve metadata path by InstanceId when available.
 /// Migrates legacy name-based files to id-based on first access.
 pub fn metadata_path_resolved(home: &Path, name: &str) -> PathBuf {
-    let id = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+    let id = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
         .ok()
         .and_then(|c| {
             c.instances
@@ -206,7 +206,7 @@ pub fn save_metadata_batch(home: &Path, instance_name: &str, entries: &[(&str, V
 
 /// Look up submit_key for a target instance from fleet config.
 pub fn get_submit_key(home: &Path, target: &str) -> String {
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     if let Ok(config) = crate::fleet::FleetConfig::load(&fleet_path) {
         if let Some(resolved) = config.resolve_instance(target) {
             return resolved.submit_key;

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -136,7 +136,7 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         .as_str()
         .map(String::from)
         .unwrap_or_else(|| {
-            crate::fleet::FleetConfig::load(&ctx.home.join("fleet.yaml"))
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
                 .ok()
                 .and_then(|f| f.defaults.backend.map(|b| b.preset().command.to_string()))
                 .unwrap_or_else(|| "claude".to_string())
@@ -657,7 +657,7 @@ mod tests {
         let home = std::env::temp_dir().join(format!("agend-topic-persist-{}", std::process::id()));
         std::fs::create_dir_all(&home).ok();
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "instances:\n  agent1:\n    backend: claude\n",
         )
         .unwrap();
@@ -668,7 +668,7 @@ mod tests {
             serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(42)),
         )
         .unwrap();
-        let cfg = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         assert_eq!(
             cfg.instances.get("agent1").and_then(|i| i.topic_id),
             Some(42),

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -263,7 +263,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     // branch in the target's working directory (Sprint 31 task #52).
     let mut branch_checked_out: Option<&str> = None;
     if let Some(branch) = params["branch"].as_str().filter(|b| !b.is_empty()) {
-        let fleet_path = ctx.home.join("fleet.yaml");
+        let fleet_path = crate::fleet::fleet_yaml_path(ctx.home);
         if let Ok(config) = crate::fleet::FleetConfig::load(&fleet_path) {
             if let Some(resolved) = config.resolve_instance(target) {
                 if let Some(ref wd) = resolved.working_directory {
@@ -344,7 +344,7 @@ mod tests {
         let home = tmp_home("fleet-defined");
         // Define instance in fleet.yaml but don't start it
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "instances:\n  offline-agent:\n    backend: claude\n",
         )
         .ok();
@@ -370,7 +370,7 @@ mod tests {
     fn test_send_to_active_registry_target_returns_pty() {
         let home = tmp_home("active-pty");
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "instances:\n  active-agent:\n    backend: claude\n  sender:\n    backend: claude\n",
         )
         .ok();
@@ -465,7 +465,7 @@ mod tests {
                 yaml.push_str("    created_at: \"2026-01-01T00:00:00Z\"\n");
             }
         }
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).ok();
     }
 
     fn audit_log_contains(home: &std::path::Path, kind: &str) -> bool {
@@ -736,7 +736,7 @@ mod tests {
         let home = tmp_home("branch-nongit");
         // Create fleet.yaml with working_directory pointing to a non-git dir
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             format!(
                 "instances:\n  sender:\n    backend: claude\n  target:\n    backend: claude\n    working_directory: {}\n",
                 home.join("workspace/target").display()
@@ -775,7 +775,7 @@ mod tests {
             .current_dir(&wd)
             .output();
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             format!(
                 "instances:\n  sender:\n    backend: claude\n  target:\n    backend: claude\n    working_directory: {}\n",
                 wd.display()
@@ -815,12 +815,12 @@ mod tests {
             &[("dev", &["codex-agent", "sender"])],
         );
         // Override codex-agent backend to codex in fleet.yaml
-        let yaml = std::fs::read_to_string(home.join("fleet.yaml")).unwrap();
+        let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).unwrap();
         let yaml = yaml.replace(
             "  codex-agent:\n    backend: claude",
             "  codex-agent:\n    backend: codex",
         );
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
 
         let registry: &'static agent::AgentRegistry =
             Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
@@ -891,12 +891,12 @@ mod tests {
             &["codex-agent", "general"],
             &[("team-a", &["general"]), ("team-b", &["codex-agent"])],
         );
-        let yaml = std::fs::read_to_string(home.join("fleet.yaml")).unwrap();
+        let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).unwrap();
         let yaml = yaml.replace(
             "  codex-agent:\n    backend: claude",
             "  codex-agent:\n    backend: codex",
         );
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
 
         let registry: &'static agent::AgentRegistry =
             Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
@@ -965,7 +965,7 @@ mod tests {
         let yaml = "instances:\n  sender:\n    backend: claude\n  codex-agent:\n    backend: codex\n\
                     teams:\n  team-a:\n    members:\n      - sender\n      - codex-agent\n    orchestrator: codex-agent\n    created_at: \"2026-01-01T00:00:00Z\"\n";
         std::fs::create_dir_all(&home).unwrap();
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
 
         let registry: &'static agent::AgentRegistry =
             Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
@@ -1029,7 +1029,7 @@ mod tests {
         let yaml = "instances:\n  sender:\n    backend: claude\n  codex-agent:\n    backend: codex\n  lead:\n    backend: claude\n\
                     teams:\n  team-a:\n    members:\n      - sender\n      - codex-agent\n      - lead\n    orchestrator: lead\n    created_at: \"2026-01-01T00:00:00Z\"\n";
         std::fs::create_dir_all(&home).unwrap();
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
 
         let registry: &'static agent::AgentRegistry =
             Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
@@ -1094,7 +1094,7 @@ mod tests {
                     teams:\n  team-a:\n    members:\n      - general\n    created_at: \"2026-01-01T00:00:00Z\"\n\
                     \n  team-b:\n    members:\n      - codex-agent\n    orchestrator: codex-agent\n    created_at: \"2026-01-01T00:00:00Z\"\n";
         std::fs::create_dir_all(&home).unwrap();
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
 
         let registry: &'static agent::AgentRegistry =
             Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn prepare_instructions(
     explicit_role: Option<&str>,
 ) {
     std::fs::create_dir_all(work_dir).ok();
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     // Look up team membership so agend.md can split collaborators (team
     // members) from the rest of the fleet. Owned here so we can hand out
     // borrowed TeamContexts into each match arm without moves.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -940,7 +940,7 @@ mod tests {
         // First create a team via the teams store
         // Sprint 54 fleet-yaml unification: teams live in fleet.yaml.
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "teams:\n  t1:\n    members: [m1]\n    created_at: \"2026-01-01T00:00:00Z\"\n",
         )
         .unwrap();
@@ -1022,7 +1022,7 @@ mod tests {
         let (port, home, _notifier, shutdown) = start_test_server("send-char");
         // Target must exist in fleet.yaml for validation to pass.
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "instances:\n  receiver:\n    backend: claude\n",
         )
         .ok();
@@ -1329,7 +1329,7 @@ mod tests {
         // Pre-create team with members
         // Sprint 54 fleet-yaml unification: teams live in fleet.yaml.
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "teams:\n  t1:\n    members: [m1, m2]\n    created_at: \"2026-01-01T00:00:00Z\"\n",
         )
         .unwrap();
@@ -1362,7 +1362,7 @@ mod tests {
         // Pre-create team
         // Sprint 54 fleet-yaml unification: teams live in fleet.yaml.
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "teams:\n  t1:\n    members: [m1]\n    created_at: \"2026-01-01T00:00:00Z\"\n",
         )
         .unwrap();

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -33,7 +33,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
         "spawn" | "vsplit" | "hsplit" => {
             let base_name = parts.get(1).unwrap_or(&"agent");
             let backend_name = parts.get(2).unwrap_or(&"claude");
-            let fleet_path = ctx.home.join("fleet.yaml");
+            let fleet_path = crate::fleet::fleet_yaml_path(ctx.home);
             let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
             let pc = cols.saturating_sub(2);
             let pr = rows.saturating_sub(4);
@@ -195,7 +195,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
 
                     let pane_result = if let Some(ref fname) = fleet_name {
                         // Fleet agent — resolve from fleet.yaml (full config)
-                        let fleet_path = ctx.home.join("fleet.yaml");
+                        let fleet_path = crate::fleet::fleet_yaml_path(ctx.home);
                         let fleet = crate::fleet::FleetConfig::load(&fleet_path).ok();
                         if let Some(resolved) =
                             fleet.as_ref().and_then(|f| f.resolve_instance(fname))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -134,7 +134,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     let home = crate::home_dir();
     let fleet_path = fleet_override
         .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| home.join("fleet.yaml"));
+        .unwrap_or_else(|| crate::fleet::fleet_yaml_path(&home));
 
     let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
     let (tui_event_tx, tui_event_rx) = crossbeam_channel::bounded::<TuiEvent>(256);
@@ -796,7 +796,7 @@ fn pane_from_menu_item(
                 tracing::warn!(error = %e, "failed to write fleet.yaml");
             }
             // Resolve from fleet to get defaults merged
-            let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
+            let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
             if let Some(resolved) = fleet.as_ref().and_then(|f| f.resolve_instance(&inst_name)) {
                 pane_factory::create_pane_from_resolved(
                     &inst_name,

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -260,7 +260,7 @@ pub(super) fn create_pane_from_resolved(
     spawn_mode: crate::backend::SpawnMode,
 ) -> Result<Pane> {
     // Build fleet peer list for agent instructions
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     let peers: Vec<(String, Option<String>)> = crate::fleet::FleetConfig::load(&fleet_path)
         .map(|f| {
             f.instances
@@ -417,7 +417,7 @@ pub(super) fn unique_fleet_name(home: &Path, base: &str) -> String {
 /// collision-skip path (a random `short_id()` lands in a pre-seeded collision
 /// bucket with probability ~10⁻⁷, so the tests would otherwise be vacuous).
 fn unique_fleet_name_with(home: &Path, base: &str, mut ids: impl Iterator<Item = u32>) -> String {
-    let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
     let taken = |name: &str| -> bool {
         if fleet
             .as_ref()

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -54,7 +54,7 @@ struct SessionPane {
 /// Sync fleet.yaml to match current pane state on detach.
 /// Removes fleet entries not present in any pane; adds panes with backend but missing from fleet.
 pub(super) fn sync_fleet_yaml(home: &Path, layout: &Layout) {
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     let fleet = fleet::FleetConfig::load(&fleet_path).ok();
 
     // Collect all fleet_instance_names currently in panes

--- a/src/bootstrap/doctor_topics.rs
+++ b/src/bootstrap/doctor_topics.rs
@@ -103,7 +103,7 @@ impl TopicReport {
 /// `can_manage_topics` permission probe done elsewhere.
 pub fn classify(home: &Path) -> TopicReport {
     let registry = load_topic_registry(home);
-    let fleet = FleetConfig::load(&home.join("fleet.yaml")).ok();
+    let fleet = FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
     let fleet_topic_ids: HashMap<String, i32> = fleet
         .as_ref()
         .map(|c| {
@@ -485,7 +485,7 @@ mod tests {
                 yaml.push_str(&format!("    topic_id: {t}\n"));
             }
         }
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
     }
 
     #[test]

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -269,7 +269,7 @@ mod tests {
     }
 
     fn write_minimal_fleet(home: &Path) -> PathBuf {
-        let path = home.join("fleet.yaml");
+        let path = crate::fleet::fleet_yaml_path(home);
         std::fs::write(
             &path,
             "defaults:\n  backend: claude\ninstances:\n  worker:\n    backend: claude\n",
@@ -279,7 +279,7 @@ mod tests {
     }
 
     fn write_fleet_with_extra_instructions(home: &Path) -> PathBuf {
-        let path = home.join("fleet.yaml");
+        let path = crate::fleet::fleet_yaml_path(home);
         let instructions_dir = home.join("instructions");
         std::fs::create_dir_all(&instructions_dir).expect("mkdir instructions");
         std::fs::write(

--- a/src/bugreport.rs
+++ b/src/bugreport.rs
@@ -45,7 +45,7 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
     for (title, path, redact, fallback) in [
         (
             "Fleet Config (tokens redacted)",
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(home),
             true,
             "(not found)",
         ),

--- a/src/channel/telegram/bootstrap.rs
+++ b/src/channel/telegram/bootstrap.rs
@@ -135,7 +135,7 @@ pub fn init_from_config(
     }
 
     // Write back topic_ids + update registry
-    if home.join("fleet.yaml").exists() && !topic_map.is_empty() {
+    if crate::fleet::fleet_yaml_path(home).exists() && !topic_map.is_empty() {
         for (name, tid) in &topic_map {
             let _ = crate::fleet::update_instance_field(
                 home,

--- a/src/channel/telegram/creds.rs
+++ b/src/channel/telegram/creds.rs
@@ -13,7 +13,7 @@ pub(super) fn resolve_channel() -> anyhow::Result<(TelegramCreds, crate::fleet::
 pub(super) fn resolve_channel_from(
     home: &std::path::Path,
 ) -> anyhow::Result<(TelegramCreds, crate::fleet::FleetConfig)> {
-    let config = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))?;
+    let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))?;
     match &config.channel {
         Some(crate::fleet::ChannelConfig::Telegram {
             bot_token_env,

--- a/src/channel/telegram/error.rs
+++ b/src/channel/telegram/error.rs
@@ -366,13 +366,13 @@ instances:
     command: /bin/true
     topic_id: 99
 ";
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
         register_topic(&home, 42, "agent-x");
 
         let _ = invalidate_and_recreate_topic(&home, "agent-x", 42);
 
-        let config =
-            crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).expect("load fleet.yaml");
+        let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("load fleet.yaml");
         let agent_x = config.instances.get("agent-x").expect("agent-x exists");
         assert_eq!(
             agent_x.topic_id, None,
@@ -393,12 +393,13 @@ instances:
     topic_id: 42
     role: important
 ";
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
         register_topic(&home, 42, "agent-x");
 
         let _ = invalidate_and_recreate_topic(&home, "agent-x", 42);
 
-        let fleet_yaml = std::fs::read_to_string(home.join("fleet.yaml")).expect("read fleet.yaml");
+        let fleet_yaml =
+            std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("read fleet.yaml");
         assert!(
             fleet_yaml.contains("agent-x"),
             "instance must survive invalidation; yaml:\n{fleet_yaml}"
@@ -451,11 +452,11 @@ instances:
         let yaml = format!(
             "channel:\n  type: telegram\n  bot_token_env: AGEND_BOT_TOKEN\n  group_id: {group_id}\n  mode: {mode}\n  user_allowlist:\n  - 42\n"
         );
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).expect("write fleet.yaml");
     }
 
     fn channel_group_id_from_yaml(home: &std::path::Path) -> Option<i64> {
-        let text = std::fs::read_to_string(home.join("fleet.yaml")).ok()?;
+        let text = std::fs::read_to_string(crate::fleet::fleet_yaml_path(home)).ok()?;
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&text).ok()?;
         doc.get("channel")
             .and_then(|c| c.get("group_id"))

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -57,7 +57,9 @@ pub(super) fn resolve_topic(state: &mut TelegramState, topic_id: Option<i32>) ->
             return name;
         }
         // Unknown topic_id — reload from fleet.yaml
-        if let Ok(config) = crate::fleet::FleetConfig::load(&state.home.join("fleet.yaml")) {
+        if let Ok(config) =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&state.home))
+        {
             for (inst_name, inst) in &config.instances {
                 if inst.topic_id == Some(tid) {
                     state.topic_to_instance.insert(tid, inst_name.clone());

--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -21,7 +21,7 @@ fn notify_telegram_inner(
     text: &str,
     disable_notification: bool,
 ) {
-    let config = match crate::fleet::FleetConfig::load(&home.join("fleet.yaml")) {
+    let config = match crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) {
         Ok(c) => c,
         Err(_) => return,
     };

--- a/src/channel/telegram/reply.rs
+++ b/src/channel/telegram/reply.rs
@@ -306,7 +306,7 @@ instances:
     command: /bin/true
     topic_id: 42
 ";
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
         std::fs::create_dir_all(home.join("channel")).ok();
         std::fs::write(home.join("channel").join("topics.json"), "{\"B\":42}")
             .expect("write topics.json");
@@ -320,7 +320,8 @@ instances:
             "inject_provenance should bubble the forced error"
         );
 
-        let fleet_yaml = std::fs::read_to_string(home.join("fleet.yaml")).expect("read fleet.yaml");
+        let fleet_yaml =
+            std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("read fleet.yaml");
         assert!(
             fleet_yaml.contains("B:"),
             "provenance failure mutated fleet.yaml (removed B): {fleet_yaml}"
@@ -353,7 +354,7 @@ instances:
     command: /bin/true
     topic_id: 42
 ";
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
         std::fs::create_dir_all(home.join("channel")).ok();
         std::fs::write(home.join("channel").join("topics.json"), "{\"B\":42}")
             .expect("write topics.json");
@@ -364,13 +365,14 @@ instances:
         let res = try_telegram_reply_from(&home, "B", "main-path send");
         assert!(res.is_err());
 
-        let fleet_yaml = std::fs::read_to_string(home.join("fleet.yaml")).expect("read fleet.yaml");
+        let fleet_yaml =
+            std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("read fleet.yaml");
         assert!(
             fleet_yaml.contains("B:"),
             "Sprint 23 P1: instance must survive topic invalidation; yaml was:\n{fleet_yaml}"
         );
-        let config =
-            crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).expect("load fleet.yaml");
+        let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("load fleet.yaml");
         let inst_b = config.instances.get("B").expect("B exists");
         assert_eq!(
             inst_b.topic_id, None,
@@ -402,7 +404,7 @@ instances:
     command: /bin/true
     topic_id: 42
 ";
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
         register_topic(&home, 42, "agent-x");
         std::env::set_var("SPRINT23_P1_FAKE_TOKEN", "fake");
 
@@ -417,7 +419,8 @@ instances:
             "stale topic 42 must be unregistered after retry; reg={reg:?}"
         );
 
-        let fleet_yaml = std::fs::read_to_string(home.join("fleet.yaml")).expect("read fleet.yaml");
+        let fleet_yaml =
+            std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("read fleet.yaml");
         assert!(
             fleet_yaml.contains("agent-x"),
             "instance must survive topic invalidation; yaml:\n{fleet_yaml}"
@@ -442,7 +445,7 @@ instances:
     command: /bin/true
     topic_id: 42
 ";
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
         register_topic(&home, 42, "agent-x");
         std::env::set_var("SPRINT23_P1_FAKE_TOKEN2", "fake");
 
@@ -465,7 +468,7 @@ instances:
     // ── Sprint 56 Track A — supergroup migration self-heal ───────────
 
     fn read_channel_group_id(home: &std::path::Path) -> Option<i64> {
-        let text = std::fs::read_to_string(home.join("fleet.yaml")).ok()?;
+        let text = std::fs::read_to_string(crate::fleet::fleet_yaml_path(home)).ok()?;
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&text).ok()?;
         doc.get("channel")
             .and_then(|c| c.get("group_id"))
@@ -489,7 +492,7 @@ instances:
     command: /bin/true
     topic_id: 42
 ";
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
         register_topic(&home, 42, "agent-x");
         std::env::set_var("SPRINT56_FAKE_TOKEN", "fake");
 
@@ -538,7 +541,7 @@ instances:
     command: /bin/true
     topic_id: 42
 ";
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
         register_topic(&home, 42, "agent-x");
         std::env::set_var("SPRINT56_FAKE_TOKEN_2", "fake");
 

--- a/src/channel/telegram/topic_registry.rs
+++ b/src/channel/telegram/topic_registry.rs
@@ -291,7 +291,7 @@ instances:
     role: "General"
     topic_id: 1
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
         let mut state = TelegramState::new(
             "tok",
             -1,
@@ -316,7 +316,7 @@ instances:
   bob:
     topic_id: 500
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
         let mut state = TelegramState::new(
             "tok",
             -1,
@@ -326,7 +326,7 @@ instances:
             None,
         );
         assert_eq!(resolve_topic(&mut state, Some(500)), "bob");
-        std::fs::remove_file(home.join("fleet.yaml")).ok();
+        std::fs::remove_file(crate::fleet::fleet_yaml_path(&home)).ok();
         assert_eq!(resolve_topic(&mut state, Some(500)), "bob");
         std::fs::remove_dir_all(&home).ok();
     }
@@ -357,10 +357,10 @@ instances:
     fn register_topic_writes_fleet_yaml() {
         let home = tmp_home("register_writes_yaml");
         let yaml = "defaults:\n  backend: claude\ninstances:\n  alice:\n    backend: claude\n";
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
         register_topic(&home, 42, "alice");
-        let content =
-            std::fs::read_to_string(home.join("fleet.yaml")).expect("fleet.yaml must exist");
+        let content = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home))
+            .expect("fleet.yaml must exist");
         assert!(
             content.contains("topic_id"),
             "fleet.yaml must contain topic_id after register_topic: {content}"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,7 +104,7 @@ pub fn run_doctor(home: &Path) -> anyhow::Result<()> {
     check("Home directory", home, " ✗ (not found)");
     check(".env file", &home.join(".env"), " - (optional)");
 
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     print!("  fleet.yaml: {}", fleet_path.display());
     if fleet_path.exists() {
         match fleet::FleetConfig::load(&fleet_path) {

--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -1,6 +1,11 @@
 use crate::agent::{self, AgentRegistry};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+/// Canonical path to the ci-watches directory.
+pub fn ci_watches_dir(home: &Path) -> PathBuf {
+    home.join("ci-watches")
+}
 
 // ---------------------------------------------------------------------------
 // H2: Shared tokio runtime for CI watch — avoids spawning a new thread +
@@ -1225,7 +1230,7 @@ pub fn detect_provider_from_remote(repo: &str) -> (&'static str, bool) {
 /// Returns the number of watches removed. Best-effort: read/parse
 /// failures skip the entry rather than aborting the sweep.
 pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = ci_watches_dir(home);
     let Ok(entries) = std::fs::read_dir(&ci_dir) else {
         return 0;
     };
@@ -1318,7 +1323,7 @@ pub fn startup_sweep(home: &Path) {
         tracing::info!(removed, "ci_watch startup sweep complete");
     }
     // Log surviving watches so operators can confirm persistence across restart.
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = ci_watches_dir(home);
     if let Ok(entries) = std::fs::read_dir(&ci_dir) {
         let active: Vec<String> = entries
             .flatten()
@@ -1420,7 +1425,7 @@ fn check_ci_watches_with_provider(
     registry: &AgentRegistry,
     make_provider: impl Fn(&serde_json::Value) -> Option<Box<dyn CiProvider>> + Send + Sync + 'static,
 ) {
-    let entries = match std::fs::read_dir(home.join("ci-watches")) {
+    let entries = match std::fs::read_dir(ci_watches_dir(home)) {
         Ok(e) => e,
         Err(_) => return,
     };
@@ -2114,6 +2119,15 @@ fn update_watch_state_with_notify(
 mod tests {
     use super::*;
     use crate::agent::AgentRegistry;
+
+    #[test]
+    fn ci_watches_dir_returns_expected_path() {
+        let home = std::path::Path::new("/tmp/test");
+        assert_eq!(
+            ci_watches_dir(home),
+            std::path::PathBuf::from("/tmp/test/ci-watches")
+        );
+    }
 
     fn tmp_dir(tag: &str) -> std::path::PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};
@@ -4226,7 +4240,7 @@ mod tests {
         branch: &str,
         watch: serde_json::Value,
     ) -> std::path::PathBuf {
-        let path = home.join("ci-watches").join(watch_filename(repo, branch));
+        let path = ci_watches_dir(home).join(watch_filename(repo, branch));
         std::fs::write(&path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
         path
     }
@@ -4560,7 +4574,7 @@ mod tests {
         branch: &str,
         watch: &serde_json::Value,
     ) -> std::path::PathBuf {
-        let ci_dir = home.join("ci-watches");
+        let ci_dir = ci_watches_dir(home);
         std::fs::create_dir_all(&ci_dir).ok();
         let filename = super::watch_filename(repo, branch);
         let path = ci_dir.join(&filename);
@@ -4786,7 +4800,7 @@ mod tests {
     #[test]
     fn startup_sweep_preserves_valid_watches() {
         let home = tmp_dir("restart-persist");
-        let ci_dir = home.join("ci-watches");
+        let ci_dir = ci_watches_dir(&home);
         std::fs::create_dir_all(&ci_dir).unwrap();
 
         // Create a valid (non-expired) watch

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -310,7 +310,7 @@ pub fn run(home: &Path, agents: Vec<AgentDef>) -> anyhow::Result<()> {
     // agend-git-shim init now in bootstrap::prepare (shared with app mode).
 
     // Check for previous snapshot if fleet.yaml doesn't exist
-    if !home.join("fleet.yaml").exists() {
+    if !crate::fleet::fleet_yaml_path(home).exists() {
         if let Some(snapshot) = crate::snapshot::load(home) {
             tracing::info!(
                 count = snapshot.agents.len(),
@@ -710,7 +710,7 @@ fn run_core(
                         .collect();
                     drop(cfgs);
                     let fleet_dirs: Vec<std::path::PathBuf> =
-                        crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+                        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                             .ok()
                             .map(|c| {
                                 c.instance_names()
@@ -1407,7 +1407,7 @@ fn spawn_and_register_agent(
         // → install only the named skills (Some(empty) opts the agent
         // out of skills entirely).
         let skills_filter: Option<Vec<String>> =
-            crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                 .ok()
                 .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
         match crate::skills::install_for_agent(home, wd, skills_filter.as_deref()) {

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -318,7 +318,7 @@ pub(crate) fn check_pane_input_not_submitted_for_agents(
 /// the agent's backend via fleet.yaml so per-instance overrides are
 /// honoured.
 fn pane_input_backend_supported(home: &std::path::Path, agent: &str) -> bool {
-    let Ok(fleet) = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")) else {
+    let Ok(fleet) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) else {
         return false;
     };
     let Some(resolved) = fleet.resolve_instance(agent) else {
@@ -1748,7 +1748,7 @@ mod tests {
     fn fleet_with_backend(tag: &str, agent_name: &str, backend_cmd: &str) -> std::path::PathBuf {
         let home = tmp_home(tag);
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             format!(
                 "instances:\n  {agent_name}:\n    backend: {backend_cmd}\n    \
                  working_directory: \"/tmp\"\n"

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -209,7 +209,7 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
     // mismatch — see `docs/RCA-issue-496-task-sweep-no-auto-close-2026-05-08.md`.
     // `Option<FleetConfig>` because a missing/malformed fleet.yaml must
     // not abort the sweep — fall back to direct compare for compat.
-    let fleet_cfg = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
+    let fleet_cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
 
     // Snapshot of currently-open tasks. Read from tasks::list_all (the
     // PR2 bridge-phase legacy reader); PR3 cutover switches this to

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -77,7 +77,7 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
     }
 
     // Load fleet.yaml to find template definition
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     if !fleet_path.exists() {
         return serde_json::json!({"error": "No fleet.yaml"});
     }
@@ -562,7 +562,7 @@ pub(crate) fn reconcile_orphan_deployments(home: &Path) -> Vec<String> {
     // Snapshot current fleet.yaml instance set. If fleet.yaml fails to load,
     // bail out with an empty result so a transient parse error doesn't wipe
     // the deployment store.
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     let live_instances: std::collections::HashSet<String> = match crate::fleet::FleetConfig::load(
         &fleet_path,
     ) {
@@ -724,7 +724,7 @@ templates:
         backend: kiro-cli
         role: implementer
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
 
         let args = serde_json::json!({
             "template": "dev",
@@ -732,8 +732,8 @@ templates:
         });
         let _ = deploy(&home, "caller", &args);
 
-        let reloaded =
-            crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).expect("reload fleet.yaml");
+        let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("reload fleet.yaml");
         let lead = reloaded
             .instances
             .get("dev-lead")
@@ -766,12 +766,13 @@ templates:
         backend: claude
         description: orchestrator via alias
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
 
         let args = serde_json::json!({"template": "dev", "directory": home.display().to_string()});
         let _ = deploy(&home, "caller", &args);
 
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         assert_eq!(
             reloaded
                 .instances
@@ -794,12 +795,13 @@ templates:
         backend: claude
         instructions: ./instructions/lead.md
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
 
         let args = serde_json::json!({"template": "dev", "directory": home.display().to_string()});
         let _ = deploy(&home, "caller", &args);
 
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         assert_eq!(
             reloaded
                 .instances
@@ -826,13 +828,14 @@ templates:
           - --model
           - opus
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let inst = reloaded.instances.get("dev-worker").expect("dev-worker");
         assert_eq!(
             inst.args,
@@ -856,13 +859,14 @@ templates:
         backend: claude
         model: opus
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let inst = reloaded
             .instances
             .get("dev-specialist")
@@ -884,13 +888,14 @@ templates:
           MCP_SERVER_URL: https://example.com
           DEBUG: "1"
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let inst = reloaded.instances.get("dev-worker").expect("dev-worker");
         assert_eq!(
             inst.env.get("MCP_SERVER_URL").map(|s| s.as_str()),
@@ -911,13 +916,14 @@ templates:
         backend: claude
         ready_pattern: "ready for input"
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let inst = reloaded.instances.get("dev-worker").expect("dev-worker");
         assert_eq!(inst.ready_pattern.as_deref(), Some("ready for input"));
         std::fs::remove_dir_all(&home).ok();
@@ -939,13 +945,14 @@ templates:
       impl:
         backend: claude
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let reviewer = reloaded
             .instances
             .get("dev-reviewer")
@@ -975,13 +982,14 @@ templates:
         backend: claude
         command: ./scripts/my-runner.sh
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let inst = reloaded.instances.get("dev-script").expect("dev-script");
         assert_eq!(
             inst.command.as_deref(),
@@ -1008,13 +1016,14 @@ templates:
         backend: claude
         role: orchestrator
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let inst = reloaded.instances.get("dev-lead").expect("dev-lead");
         assert!(
             inst.args.is_empty(),
@@ -1063,13 +1072,14 @@ templates:
         command: my-runner
         worktree: false
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
             &serde_json::json!({"template": "full", "directory": home.display().to_string()}),
         );
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let inst = reloaded.instances.get("full-worker").expect("full-worker");
         assert_eq!(inst.args, vec!["--resume".to_string()]);
         assert_eq!(inst.model.as_deref(), Some("sonnet"));
@@ -1093,12 +1103,13 @@ templates:
       lead:
         backend: claude
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
 
         let args = serde_json::json!({"template": "dev", "directory": home.display().to_string()});
         let _ = deploy(&home, "caller", &args);
 
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let lead = reloaded.instances.get("dev-lead").expect("dev-lead");
         assert!(
             lead.role.is_none(),
@@ -1128,7 +1139,7 @@ instances:
     backend: claude
     role: survivor
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
 
         let _ = deploy(
             &home,
@@ -1136,15 +1147,15 @@ instances:
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
         // Sanity: deployed entries are there.
-        let after_deploy =
-            crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).expect("post-deploy");
+        let after_deploy = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("post-deploy");
         assert!(after_deploy.instances.contains_key("dev-lead"));
         assert!(after_deploy.instances.contains_key("dev-impl"));
 
         let _ = teardown(&home, &serde_json::json!({"name": "dev"}));
 
-        let after_teardown =
-            crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).expect("post-teardown");
+        let after_teardown = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("post-teardown");
         assert!(
             !after_teardown.instances.contains_key("dev-lead"),
             "deployed entry must be removed"
@@ -1179,7 +1190,7 @@ templates:
         backend: claude
         role: implementer
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
 
         let _ = deploy(
             &home,
@@ -1213,7 +1224,7 @@ templates:
       impl:
         backend: claude
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
 
         let _ = deploy(
             &home,
@@ -1257,7 +1268,7 @@ templates:
       impl-2:
         backend: kiro-cli
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
 
         let _ = deploy(
             &home,
@@ -1265,7 +1276,8 @@ templates:
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
 
-        let reloaded = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let reloaded =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let workdirs: std::collections::HashSet<String> = ["dev-lead", "dev-impl-1", "dev-impl-2"]
             .iter()
             .filter_map(|name| {
@@ -1312,7 +1324,7 @@ templates:
       good:
         backend: claude
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
 
         // Point the daemon-less API call at a non-running daemon: `api::call`
         // just returns an error, but `deploy` itself only tracks the names it
@@ -1354,7 +1366,7 @@ templates:
         backend: claude
 instances: {}
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
@@ -1386,7 +1398,7 @@ templates:
         backend: claude
 instances: {}
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
@@ -1418,7 +1430,7 @@ templates:
         backend: claude
 instances: {}
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
@@ -1426,7 +1438,8 @@ instances: {}
         );
         let _ = teardown(&home, &serde_json::json!({"name": "dev"}));
 
-        let config = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).expect("load fleet");
+        let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("load fleet");
         assert!(
             !config.instances.contains_key("dev-impl"),
             "teardown must remove fleet entry to prevent respawn"
@@ -1460,7 +1473,7 @@ templates:
         backend: claude
 instances: {}
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
@@ -1520,7 +1533,7 @@ templates:
         backend: claude
 instances: {}
 "#;
-        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
         let _ = deploy(
             &home,
             "caller",
@@ -1565,7 +1578,7 @@ instances: {}
         // — gets pruned on next `reconcile_orphans` call.
         let home = tmp_home("reconcile_orphans");
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "templates:\n  tpl:\n    instances:\n      worker:\n        backend: claude\ninstances: {}\n",
         )
         .unwrap();
@@ -1671,7 +1684,7 @@ instances: {}
         save(&home, &mut store).unwrap();
         // Empty fleet.yaml — simulates the "all instances closed" state
         // that triggers the prune branch in reconcile.
-        std::fs::write(home.join("fleet.yaml"), "instances: {}\n").unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), "instances: {}\n").unwrap();
         (home, custom_root)
     }
 
@@ -1918,7 +1931,7 @@ instances: {}
         // Re-add one member back into fleet.yaml so reconcile sees it
         // as live and refuses to prune.
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "instances:\n  alive-team-a:\n    backend: claude\n",
         )
         .unwrap();

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -4,6 +4,14 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+/// Single source of truth for the fleet configuration filename.
+pub const FLEET_YAML_FILENAME: &str = "fleet.yaml";
+
+/// Canonical path to fleet.yaml given a home directory.
+pub fn fleet_yaml_path(home: &Path) -> PathBuf {
+    home.join(FLEET_YAML_FILENAME)
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FleetConfig {
     #[serde(default)]
@@ -577,7 +585,7 @@ pub struct InstanceYamlEntry {
 /// Caller must hold the file lock.
 fn atomic_write_yaml(home: &Path, doc: &serde_yaml_ng::Value) -> Result<()> {
     let yaml = serde_yaml_ng::to_string(doc).context("Failed to serialize fleet.yaml")?;
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = fleet_yaml_path(home);
     // Use the shared helper so fsync-before-rename is uniform across the
     // codebase. The previous write→rename (no fsync) left a crash window
     // where the renamed-over fleet.yaml could be truncated on power loss.
@@ -603,7 +611,7 @@ fn mutate_fleet_yaml(
     default_content: &str,
     mutate: impl FnOnce(&mut serde_yaml_ng::Value) -> Result<()>,
 ) -> Result<()> {
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = fleet_yaml_path(home);
     if default_content.is_empty() && !fleet_path.exists() {
         return Ok(());
     }
@@ -1472,7 +1480,7 @@ instances:
     }
 
     fn read_channel_group_id(home: &Path) -> Option<i64> {
-        let text = std::fs::read_to_string(home.join("fleet.yaml")).ok()?;
+        let text = std::fs::read_to_string(fleet_yaml_path(home)).ok()?;
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&text).ok()?;
         doc.get("channel")
             .and_then(|c| c.get("group_id"))
@@ -2792,7 +2800,7 @@ instances:
     }
 
     fn read_yaml(home: &std::path::Path) -> serde_yaml_ng::Value {
-        let content = std::fs::read_to_string(home.join("fleet.yaml")).expect("read");
+        let content = std::fs::read_to_string(fleet_yaml_path(home)).expect("read");
         serde_yaml_ng::from_str(&content).expect("parse")
     }
 
@@ -2845,7 +2853,7 @@ instances:
         // OVERWRITE existing.
         let home = merge_tmp_home("rule-1-overwrite");
         std::fs::write(
-            home.join("fleet.yaml"),
+            fleet_yaml_path(&home),
             "instances:\n  dev:\n    backend: claude\n    source_repo: /old/path\n    role: \
              developer\n",
         )
@@ -2880,7 +2888,7 @@ instances:
         // know about must survive the merge unchanged.
         let home = merge_tmp_home("rule-2-deep-merge");
         std::fs::write(
-            home.join("fleet.yaml"),
+            fleet_yaml_path(&home),
             "instances:\n  dev:\n    backend: claude\n    role: developer\n    custom_operator_field: \
              my-special-value\n    display_name: Friendly Dev\n",
         )
@@ -2908,7 +2916,7 @@ instances:
         // both sides changed incompatibly → error with diff.
         let home = merge_tmp_home("rule-3-conflict");
         std::fs::write(
-            home.join("fleet.yaml"),
+            fleet_yaml_path(&home),
             "instances:\n  dev:\n    backend: claude\n    role: senior-dev\n",
         )
         .unwrap();
@@ -2946,7 +2954,7 @@ instances:
         // no error, no spurious churn.
         let home = merge_tmp_home("idempotent");
         std::fs::write(
-            home.join("fleet.yaml"),
+            fleet_yaml_path(&home),
             "instances:\n  dev:\n    backend: claude\n    role: developer\n    source_repo: /x\n",
         )
         .unwrap();
@@ -2973,7 +2981,7 @@ instances:
         // explicitly supplies.
         let home = merge_tmp_home("first-time-migration");
         std::fs::write(
-            home.join("fleet.yaml"),
+            fleet_yaml_path(&home),
             "instances:\n  reviewer:\n    backend: claude\n    role: code-reviewer\n    \
              instructions: ./reviewer-instructions.md\n",
         )
@@ -3003,7 +3011,7 @@ instances:
         // mapping created from the entry.
         let home = merge_tmp_home("new-instance");
         std::fs::write(
-            home.join("fleet.yaml"),
+            fleet_yaml_path(&home),
             "instances:\n  existing:\n    backend: claude\n",
         )
         .unwrap();
@@ -3031,7 +3039,7 @@ instances:
         // and the merge contract says daemon wins.
         let home = merge_tmp_home("daemon-managed-no-error");
         std::fs::write(
-            home.join("fleet.yaml"),
+            fleet_yaml_path(&home),
             "instances:\n  dev:\n    backend: claude\n    source_repo: /operator-edit\n",
         )
         .unwrap();
@@ -3062,7 +3070,7 @@ instances:
         // randomize order on every write.
         let home = merge_tmp_home("ordering");
         std::fs::write(
-            home.join("fleet.yaml"),
+            fleet_yaml_path(&home),
             "instances:\n  dev:\n    role: developer\n    backend: claude\n    \
              working_directory: /workspace/dev\n",
         )
@@ -3076,7 +3084,7 @@ instances:
         };
         add_instances_to_yaml(&home, &[("dev", &entry)]).unwrap();
 
-        let content = std::fs::read_to_string(home.join("fleet.yaml")).unwrap();
+        let content = std::fs::read_to_string(fleet_yaml_path(&home)).unwrap();
         // role should come before backend in the rewritten file.
         let role_pos = content.find("role:").expect("role present");
         let backend_pos = content.find("backend:").expect("backend present");
@@ -3095,7 +3103,7 @@ instances:
         // succeed). Pin the all-or-nothing semantic.
         let home = merge_tmp_home("multi-atomic");
         std::fs::write(
-            home.join("fleet.yaml"),
+            fleet_yaml_path(&home),
             "instances:\n  alpha:\n    role: senior-dev\n  beta:\n    role: junior-dev\n",
         )
         .unwrap();

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -288,7 +288,7 @@ pub(crate) fn inbox_path(home: &Path, name: &str) -> PathBuf {
 pub(crate) fn inbox_path_resolved(home: &Path, name: &str) -> PathBuf {
     // Only use id-based path when the instance has a real ID in fleet.yaml
     // (backfilled by P1). Instances without an ID use name-based paths.
-    let id = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+    let id = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
         .ok()
         .and_then(|c| {
             c.instances
@@ -613,6 +613,10 @@ pub fn pointer_only_inject() -> bool {
 
 /// ANSI-colored header prefix for visual distinction in terminal.
 pub const HEADER_PREFIX: &str = "\x1b[44;97m[AGEND-MSG]\x1b[0m";
+
+/// Plain-text system message prefix (without ANSI colors).
+/// Used for detection/matching in agent PTY output parsing.
+pub const SYSTEM_MSG_PREFIX: &str = "[AGEND-MSG]";
 
 /// Sanitize a value for header inclusion: replace control chars with space.
 fn sanitize_header_value(s: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,7 +522,7 @@ fn main() -> anyhow::Result<()> {
 
             let fleet_path = fleet
                 .map(PathBuf::from)
-                .unwrap_or_else(|| home.join("fleet.yaml"));
+                .unwrap_or_else(|| crate::fleet::fleet_yaml_path(&home));
             if !force_foreground {
                 // Sprint 57 Wave 3 PR-2 (#548 Q1) default branch: detach.
                 // Spawn self as a background process and exit. Child inherits

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -126,7 +126,7 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
 /// formatted as `"<repo>:<branch>"` for terse human reading. Empty
 /// list when the watches dir doesn't exist or the agent isn't on any.
 fn enumerate_ci_watches_for_agent(home: &Path, agent: &str) -> Vec<String> {
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
     let Ok(entries) = std::fs::read_dir(&ci_dir) else {
         return Vec::new();
     };
@@ -489,7 +489,7 @@ mod tests {
         // existing cleanup) — operators can verify pre/post-release
         // that watches were removed.
         let home = tmp_home("watches");
-        let ci_dir = home.join("ci-watches");
+        let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
         std::fs::create_dir_all(&ci_dir).unwrap();
         let watch = json!({
             "repo": "owner/repo",

--- a/src/mcp/handlers/channel.rs
+++ b/src/mcp/handlers/channel.rs
@@ -40,7 +40,7 @@ pub(super) fn handle_reply(home: &Path, args: &Value, instance_name: &str) -> Va
             crate::daemon::decision_timeout::mark_resolved_for_sender(home, instance_name);
     }
 
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     if !fleet_path.exists() {
         return json!({"error": "No fleet.yaml — cannot send reply"});
     }

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -232,7 +232,7 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
         return json!({"error": "Bitbucket Server not yet supported — track Sprint 41+ candidate. Use bitbucket_cloud for Bitbucket Cloud repos."});
     }
 
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
     std::fs::create_dir_all(&ci_dir).ok();
     let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
     let watch_path = ci_dir.join(&filename);
@@ -386,7 +386,7 @@ pub(super) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
         .or_else(|| std::env::var("AGEND_INSTANCE_NAME").ok())
         .unwrap_or_default();
     let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
-    let path = home.join("ci-watches").join(&filename);
+    let path = crate::daemon::ci_watch::ci_watches_dir(home).join(&filename);
 
     let mut watch = match std::fs::read_to_string(&path)
         .ok()
@@ -460,7 +460,7 @@ pub(super) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
 pub(super) fn handle_status_ci(home: &Path, args: &Value, instance_name: &str) -> Value {
     let filter_repo = args["repo"].as_str();
     let filter_branch = args["branch"].as_str();
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
     let entries = match std::fs::read_dir(&ci_dir) {
         Ok(e) => e,
         Err(_) => return json!({"watches": Vec::<Value>::new()}),

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -66,7 +66,7 @@ fn dispatch_with_branch_and_repo_auto_invokes_watch_ci() {
     let args = serde_json::json!({"repo": "owner/repo", "branch": "feat/test"});
     handle_watch_ci(&home, &args, "test-agent");
     let filename = crate::daemon::ci_watch::watch_filename("owner/repo", "feat/test");
-    let watch_path = home.join("ci-watches").join(&filename);
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(&filename);
     assert!(watch_path.exists(), "watch file must be created");
     std::fs::remove_dir_all(&home).ok();
 }
@@ -79,7 +79,7 @@ fn dispatch_idempotent_double_watch_safe() {
     handle_watch_ci(&home, &args, "agent-1");
     handle_watch_ci(&home, &args, "agent-1"); // second call — idempotent
     let filename = crate::daemon::ci_watch::watch_filename("owner/repo", "feat/idem");
-    let watch_path = home.join("ci-watches").join(&filename);
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(&filename);
     assert!(watch_path.exists());
     std::fs::remove_dir_all(&home).ok();
 }
@@ -89,10 +89,10 @@ fn dispatch_without_repo_no_auto_watch() {
     // If no repo field, auto-watch should not fire.
     // This tests the comms.rs logic: args["repo"].as_str() returns None.
     let home = std::env::temp_dir().join(format!("agend-no-watch-{}", std::process::id()));
-    std::fs::create_dir_all(home.join("ci-watches")).ok();
+    std::fs::create_dir_all(crate::daemon::ci_watch::ci_watches_dir(&home)).ok();
     // No watch file should exist for a branch without repo.
     let filename = crate::daemon::ci_watch::watch_filename("", "feat/no-repo");
-    let watch_path = home.join("ci-watches").join(&filename);
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(&filename);
     assert!(!watch_path.exists(), "no watch without repo");
     std::fs::remove_dir_all(&home).ok();
 }
@@ -108,7 +108,7 @@ fn dispatch_without_repo_no_auto_watch() {
 
 fn watch_path_for(home: &Path, repo: &str, branch: &str) -> std::path::PathBuf {
     let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
-    home.join("ci-watches").join(filename)
+    crate::daemon::ci_watch::ci_watches_dir(home).join(filename)
 }
 
 fn read_watch(path: &Path) -> serde_json::Value {
@@ -205,7 +205,7 @@ fn ci_watch_legacy_instance_field_migrates_on_resubscribe() {
     // legacy field is preserved as a deprecated alias so a rollback
     // to a pre-r0 daemon binary can still read SOMEONE.
     let home = std::env::temp_dir().join(format!("agend-watch-migrate-{}", std::process::id()));
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
     std::fs::create_dir_all(&ci_dir).ok();
     let path = watch_path_for(&home, "owner/repo", "feat-test");
 
@@ -539,7 +539,7 @@ fn handle_watch_ci_rejects_protected_refs() {
 
         // No side-effect on rejection: ci-watches dir must not gain
         // a new file for the protected branch.
-        let ci_dir = home.join("ci-watches");
+        let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
         if let Ok(rd) = std::fs::read_dir(&ci_dir) {
             let n: usize = rd.count();
             assert_eq!(
@@ -571,7 +571,7 @@ fn handle_watch_ci_default_branch_does_not_silently_set_main() {
         "default-branch path must hit the E4.5 gate, got {resp}"
     );
 
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
     if let Ok(rd) = std::fs::read_dir(&ci_dir) {
         assert_eq!(rd.count(), 0, "no watch file must be created on rejection");
     }

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -104,7 +104,7 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
 ) -> Result<(), String> {
     let _guard = BindGuard::try_acquire(home, target)?;
 
-    let resolved = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+    let resolved = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
         .ok()
         .and_then(|f| f.resolve_instance(target));
     let source_repo = resolve_source_repo(home, target, source_repo_override, resolved.as_ref());
@@ -221,7 +221,7 @@ fn resolve_source_repo(
 
 /// Resolve source_repo from the agent's team configuration.
 pub(crate) fn resolve_team_source_repo(home: &Path, agent: &str) -> Option<PathBuf> {
-    let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok()?;
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok()?;
     for cfg in fleet.teams.values() {
         if cfg.members.contains(&agent.to_string()) {
             return cfg.source_repo.clone();

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -27,7 +27,7 @@ fn setup_test_repo(home: &std::path::Path, agent: &str) -> std::path::PathBuf {
         .ok();
     // Write fleet.yaml so resolve_instance works.
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(home),
         format!(
             "instances:\n  {agent}:\n    backend: claude\n    working_directory: {}\n",
             repo.display()
@@ -87,7 +87,7 @@ fn lease_conflict_rejects_dispatch() {
     setup_test_repo(&home, "agent-a");
     setup_test_repo(&home, "agent-b");
     std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             format!("instances:\n  agent-a:\n    backend: claude\n    working_directory: {}\n  agent-b:\n    backend: claude\n    working_directory: {}\n",
                 home.join("workspace").join("agent-a").display(),
                 home.join("workspace").join("agent-b").display()),
@@ -259,7 +259,7 @@ fn delegate_task_lease_conflict_rejects_without_delivering() {
 
     let repo = home.join("workspace").join("agent-a");
     std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             // allow: shared-source_repo — this test exercises the central
             // lease registry's cross-agent collision rejection, which fires
             // precisely when two agents are bound to the same source repo
@@ -449,7 +449,7 @@ fn delegate_task_with_repo_creates_ci_watch() {
     assert!(result.is_ok(), "dispatch must succeed: {:?}", result.err());
 
     let filename = crate::daemon::ci_watch::watch_filename("owner/repo", "feat/p02-with-repo");
-    let watch_path = home.join("ci-watches").join(&filename);
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(&filename);
     assert!(
         watch_path.exists(),
         "watch file must exist at {}",
@@ -487,7 +487,7 @@ fn delegate_task_without_repo_no_ci_watch() {
     );
 
     // But ci-watches dir must be empty / non-existent (no auto-watch fired).
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
     let entries: Vec<_> = std::fs::read_dir(&ci_dir)
         .ok()
         .map(|rd| rd.flatten().collect())
@@ -520,7 +520,7 @@ fn delegate_task_idempotent_existing_watch() {
     assert!(r1.is_ok(), "first dispatch must succeed: {:?}", r1.err());
 
     let filename = crate::daemon::ci_watch::watch_filename("owner/repo", "feat/p02-idem");
-    let watch_path = home.join("ci-watches").join(&filename);
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(&filename);
     assert!(watch_path.exists(), "first dispatch must create watch");
 
     // Mutate watch state to simulate an in-flight poll, then re-dispatch.
@@ -540,7 +540,7 @@ fn delegate_task_idempotent_existing_watch() {
     assert!(r2.is_ok(), "re-dispatch must succeed: {:?}", r2.err());
 
     // ci-watches dir must still contain exactly one entry.
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
     let entry_count = std::fs::read_dir(&ci_dir)
         .expect("read ci-watches")
         .flatten()
@@ -599,7 +599,7 @@ fn delegate_task_with_repo_creates_ci_watch_via_handle_delegate_task() {
 
     // Production-smoke assertion: ci-watches entry must exist post-dispatch.
     let filename = crate::daemon::ci_watch::watch_filename("owner/repo", "feat/p02-integration");
-    let watch_path = home.join("ci-watches").join(&filename);
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(&filename);
     assert!(
         watch_path.exists(),
         "handle_delegate_task end-to-end must create ci-watches entry. \

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -127,7 +127,7 @@ pub(super) fn handle_delete_instance(home: &Path, args: &Value) -> Value {
     if let Err(e) = crate::agent::validate_name(name) {
         return json!({"error": e});
     }
-    let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
     if let Some(ref config) = fleet {
         if config.channel.is_some()
             && config.instances.contains_key(name)
@@ -158,7 +158,7 @@ pub(super) fn handle_start_instance(home: &Path, args: &Value) -> Value {
     if let Err(e) = crate::agent::validate_name(name) {
         return json!({"error": e});
     }
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     if !fleet_path.exists() {
         return json!({"error": "No fleet.yaml"});
     }
@@ -204,9 +204,10 @@ pub(super) fn handle_describe_instance(home: &Path, args: &Value) -> Value {
                     merge_metadata(home, name, &mut info);
                     // Surface topic_id from fleet.yaml for debugging (#415).
                     if info.get("topic_id").is_none() {
-                        if let Some(tid) = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
-                            .ok()
-                            .and_then(|c| c.instances.get(name)?.topic_id)
+                        if let Some(tid) =
+                            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+                                .ok()
+                                .and_then(|c| c.instances.get(name)?.topic_id)
                         {
                             info["topic_id"] = json!(tid);
                         }
@@ -233,7 +234,7 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
     // Capture backend + working_directory before kill so we can respawn.
     // Prefer fleet.yaml (short name like "claude") over LIST API (which may
     // store a resolved path). SPAWN expects the short preset name.
-    let fleet_resolved = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+    let fleet_resolved = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
         .ok()
         .and_then(|f| f.resolve_instance(name));
 
@@ -564,7 +565,7 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
         static DEDUP_SEQ: AtomicU64 = AtomicU64::new(0);
 
         let existing: std::collections::HashSet<String> =
-            crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                 .map(|c| c.instance_names().into_iter().collect())
                 .unwrap_or_default();
         if existing.contains(raw_name) {

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -53,7 +53,7 @@ use std::path::Path;
 /// is a human-readable string listing the residual stores plus any
 /// per-step error captured during cleanup.
 pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String> {
-    let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).ok();
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
     let (topic_id, working_dir) = fleet
         .as_ref()
         .and_then(|c| {
@@ -130,7 +130,7 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
 /// (disk-backed) where the silent-drop revival risk lives.
 pub(crate) fn name_residual_anywhere(home: &Path, name: &str) -> Vec<&'static str> {
     let mut sources: Vec<&'static str> = Vec::new();
-    if let Ok(cfg) = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")) {
+    if let Ok(cfg) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) {
         if cfg.instances.contains_key(name) {
             sources.push("fleet.yaml");
         }
@@ -206,7 +206,7 @@ mod tests {
     fn name_residual_anywhere_detects_fleet_yaml_instance_residual() {
         let home = tmp_home("fleet_yaml_inst");
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "instances:\n  zombie:\n    backend: claude\n",
         )
         .unwrap();
@@ -226,7 +226,7 @@ mod tests {
         // separately from the instances: stanza.
         let home = tmp_home("fleet_yaml_team");
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "teams:\n  ops:\n    members: [zombie, alice]\n    orchestrator: alice\n",
         )
         .unwrap();
@@ -288,7 +288,7 @@ mod tests {
         // as a missing entry in this list, not as a silent skip.
         let home = tmp_home("multi");
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(&home),
             "instances:\n  zombie:\n    backend: claude\n",
         )
         .unwrap();

--- a/src/mcp/handlers/p0b_tests.rs
+++ b/src/mcp/handlers/p0b_tests.rs
@@ -46,7 +46,7 @@ fn write_binding(home: &Path, agent: &str, source_repo: &str, branch: &str) {
 }
 
 fn write_ci_watch(home: &Path, repo: &str, branch: &str, subs: &[&str]) -> std::path::PathBuf {
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
     std::fs::create_dir_all(&ci_dir).ok();
     let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
     let path = ci_dir.join(&filename);
@@ -151,7 +151,7 @@ fn setup_git_repo_with_remote(home: &Path, agent: &str, origin_url: &str) -> std
         .env("AGEND_GIT_BYPASS", "1")
         .output();
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(home),
         format!(
             "instances:\n  {agent}:\n    backend: claude\n    working_directory: {}\n",
             repo.display()
@@ -387,7 +387,7 @@ fn ec6_dispatch_uses_fleet_source_repo_tier_when_present() {
         .env("AGEND_GIT_BYPASS", "1")
         .output();
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         format!(
             "instances:\n  alpha:\n    backend: claude\n    source_repo: {}\n",
             src.display()
@@ -441,7 +441,7 @@ fn ec4_fleet_repo_override_wins_over_derive() {
         .env("AGEND_GIT_BYPASS", "1")
         .output();
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         format!(
             "instances:\n  alpha:\n    backend: claude\n    source_repo: {}\n    repo: explicit/override\n",
             src.display()
@@ -453,7 +453,7 @@ fn ec4_fleet_repo_override_wins_over_derive() {
     let _ =
         super::dispatch_hook::dispatch_auto_bind_lease(&home, "alpha", "T-1", "feat-ec4o", None);
     let watch_filename = crate::daemon::ci_watch::watch_filename("explicit/override", "feat-ec4o");
-    let watch_path = home.join("ci-watches").join(&watch_filename);
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(&watch_filename);
     assert!(
         watch_path.exists(),
         "ci-watch landed under fleet.yaml `repo:` override path: {}",
@@ -507,7 +507,7 @@ fn dispatch_with_source_repo_override_wins_over_fleet() {
         .output();
     // fleet.yaml points to a different (stub) source_repo
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         format!(
             "instances:\n  alpha:\n    backend: claude\n    source_repo: {}\n",
             stub_src.display()

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -90,7 +90,7 @@ instances:
   dev:
     role: "Developer"
 "#;
-    std::fs::write(home.join("fleet.yaml"), yaml).ok();
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
     let key = get_submit_key(&home, "dev");
     // Claude Code preset submit_key is "\r" or similar
     assert!(!key.is_empty());
@@ -225,7 +225,7 @@ fn setup_recorder(tag: &str) -> (Arc<Recorder>, std::path::PathBuf) {
     // Minimal fleet so send_to's `get_submit_key` lookup resolves
     // (fallback path on unreachable daemon still needs submit_key).
     let yaml = "defaults:\n  backend: claude\ninstances:\n  target:\n    role: Test\n  sender:\n    role: Test\n";
-    std::fs::write(home.join("fleet.yaml"), yaml).ok();
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
     let rec = Recorder::new();
     ux_sink_registry().clear_for_test();
     ux_sink_registry().register(rec.clone() as Arc<dyn UxEventSink>);
@@ -1121,7 +1121,7 @@ fn test_delegate_task_resolves_team_to_orchestrator_inbox() {
     // Sprint 54 fleet-yaml unification: instances + teams both live
     // in fleet.yaml. resolve_team_orchestrator now reads from there.
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  dev-lead:\n    backend: claude\n  dev-impl:\n    backend: claude\n\
          teams:\n  dev:\n    members: [dev-lead, dev-impl]\n    \
          orchestrator: dev-lead\n    created_at: \"2026-01-01T00:00:00Z\"\n",
@@ -1164,7 +1164,7 @@ fn test_send_to_inbox_fallback_mode() {
     let _g = fleet_test_guard();
     let home = tmp_home("delivery-fallback");
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  receiver:\n    backend: claude\n",
     )
     .ok();
@@ -1246,7 +1246,7 @@ fn test_delegate_task_busy_returns_structured_response() {
     let _g = fleet_test_guard();
     let home = tmp_home("busy-gate");
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
     )
     .ok();
@@ -1285,7 +1285,7 @@ fn test_delegate_task_force_true_bypasses_busy_gate() {
     let _g = fleet_test_guard();
     let home = tmp_home("interrupt-bypass");
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
     )
     .ok();
@@ -1334,7 +1334,7 @@ fn test_delegate_task_force_true_without_reason_rejected() {
     let _g = fleet_test_guard();
     let home = tmp_home("interrupt-no-reason");
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
     )
     .ok();
@@ -1366,7 +1366,7 @@ fn test_delegate_task_idle_target_normal_delivery() {
     let _g = fleet_test_guard();
     let home = tmp_home("idle-target");
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
     )
     .ok();
@@ -1392,7 +1392,7 @@ fn test_delegate_task_second_reviewer_flag_requires_reason() {
     let _g = fleet_test_guard();
     let home = tmp_home("sr-no-reason");
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
     )
     .ok();
@@ -1418,7 +1418,7 @@ fn test_delegate_task_second_reviewer_with_reason_ok() {
     let _g = fleet_test_guard();
     let home = tmp_home("sr-with-reason");
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
     )
     .ok();
@@ -1450,7 +1450,7 @@ fn test_delegate_task_no_second_reviewer_flag_default_behavior() {
     let _g = fleet_test_guard();
     let home = tmp_home("sr-default");
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
     )
     .ok();
@@ -1534,7 +1534,7 @@ fn test_delegate_task_old_interrupt_true_still_works() {
     let _g = fleet_test_guard();
     let home = tmp_home("old-interrupt-compat");
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
     )
     .ok();
@@ -1594,7 +1594,7 @@ fn resolve_team_layout_auto_attaches_to_orchestrator() {
     let home = tmp_home("team_attach");
     // Sprint 54 fleet-yaml unification: teams in fleet.yaml.
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "teams:\n  dev:\n    members: [dev-lead, dev-impl-1]\n    \
          orchestrator: dev-lead\n    created_at: \"2026-01-01T00:00:00Z\"\n",
     )
@@ -1618,7 +1618,7 @@ fn resolve_team_layout_caller_override_preserved() {
     let home = tmp_home("override");
     // Sprint 54 fleet-yaml unification: teams in fleet.yaml.
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "teams:\n  dev:\n    members: [dev-lead, dev-impl-1]\n    \
          orchestrator: dev-lead\n    created_at: \"2026-01-01T00:00:00Z\"\n",
     )
@@ -1881,7 +1881,7 @@ fn reply_no_active_channel_returns_error() {
     let home = tmp_home("reply-no-ch");
     std::env::set_var("AGEND_HOME", &home);
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  sender:\n    backend: claude\n",
     )
     .ok();
@@ -2173,7 +2173,7 @@ fn broadcast_without_targets_sends_to_all() {
     let home = tmp_home("bcast-all");
     std::env::set_var("AGEND_HOME", &home);
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  sender:\n    backend: claude\n  target1:\n    backend: claude\n",
     )
     .ok();
@@ -2196,7 +2196,7 @@ fn broadcast_with_team_filter_targets_team_members() {
     std::env::set_var("AGEND_HOME", &home);
     // Sprint 54 fleet-yaml unification: instances + teams in fleet.yaml.
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  sender:\n    backend: claude\n  alice:\n    backend: claude\n  \
          bob:\n    backend: claude\nteams:\n  dev2:\n    members: [sender, alice]\n    \
          created_at: \"2026-01-01T00:00:00Z\"\n",
@@ -2431,7 +2431,7 @@ fn start_instance_response_shape_includes_structured_result() {
     std::env::set_var("AGEND_HOME", &home);
     // Set up fleet.yaml so start_instance can resolve the instance
     std::fs::write(
-        home.join("fleet.yaml"),
+        crate::fleet::fleet_yaml_path(&home),
         "instances:\n  shape-agent:\n    backend: claude\n",
     )
     .ok();
@@ -2497,7 +2497,7 @@ fn delegate_task_instance_first_bypasses_team_orchestrator_collision() {
     let yaml = "defaults:\n  backend: claude\ninstances:\n  dev:\n    role: Test\n  \
                 lead:\n    role: Test\nteams:\n  dev:\n    members: [lead, dev]\n    \
                 orchestrator: lead\n    created_at: \"2026-04-30T00:00:00Z\"\n";
-    std::fs::write(home.join("fleet.yaml"), yaml).ok();
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
 
     let result = handle_tool(
         "send",
@@ -2539,7 +2539,7 @@ fn m5_regression_via_id_routing() {
          orchestrator: lead\n    created_at: \"2026-04-30T00:00:00Z\"\n",
         id.full()
     );
-    std::fs::write(home.join("fleet.yaml"), &yaml).ok();
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), &yaml).ok();
 
     let result = handle_tool(
         "send",
@@ -2568,7 +2568,7 @@ fn new_instance_writes_to_id_jsonl() {
         "defaults:\n  backend: claude\ninstances:\n  fresh:\n    id: \"{}\"\n    role: Test\n",
         id.full()
     );
-    std::fs::write(home.join("fleet.yaml"), &yaml).unwrap();
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), &yaml).unwrap();
     let resolved = crate::inbox::inbox_path_resolved(&home, "fresh");
     assert!(
         resolved.to_string_lossy().contains(&id.full()),
@@ -2587,7 +2587,7 @@ fn legacy_instance_migration() {
         "defaults:\n  backend: claude\ninstances:\n  old:\n    id: \"{}\"\n    role: Test\n",
         id.full()
     );
-    std::fs::write(home.join("fleet.yaml"), &yaml).unwrap();
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), &yaml).unwrap();
     // Create legacy name-based inbox file
     std::fs::create_dir_all(home.join("inbox")).unwrap();
     std::fs::write(home.join("inbox/old.jsonl"), "legacy data\n").unwrap();

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -350,7 +350,7 @@ mod tests {
             .output()
             .ok();
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(home),
             format!(
                 "instances:\n  {agent}:\n    backend: claude\n    working_directory: {}\n",
                 repo.display()

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -54,7 +54,7 @@ pub fn run(home: &Path) -> anyhow::Result<()> {
         .filter(|t| !t.is_empty());
 
     // Step 3: Check existing fleet.yaml for group_id
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     let existing_group_id = std::fs::read_to_string(&fleet_path)
         .ok()
         .and_then(|content| serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&content).ok())
@@ -483,7 +483,7 @@ fn generate_fleet_yaml(
     group_id: Option<i64>,
     _token: Option<&str>,
 ) -> anyhow::Result<()> {
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
 
     if fleet_path.exists() {
         // Check compatibility with existing config
@@ -774,7 +774,7 @@ fn print_next_steps(home: &Path) {
     println!("       new id; quickstart now refuses regular groups upfront.\n");
     println!("  ── Next Steps ──\n");
     println!("  1. Edit fleet.yaml to add more instances:");
-    println!("     {}\n", home.join("fleet.yaml").display());
+    println!("     {}\n", crate::fleet::fleet_yaml_path(home).display());
     println!("  2. Start the fleet:");
     println!("     agend-terminal start\n");
     println!("  3. Check agent status:");
@@ -1331,7 +1331,7 @@ mod tests {
         std::fs::create_dir_all(&home).ok();
         let backend = Backend::all()[0].clone();
         generate_fleet_yaml(&home, &backend, Some(-1001234567890), None).expect("test");
-        let yaml = std::fs::read_to_string(home.join("fleet.yaml")).expect("test");
+        let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("test");
         assert!(
             yaml.contains("user_allowlist"),
             "emitted fleet.yaml must include user_allowlist for Sprint 21 fail-closed; got:\n{yaml}"
@@ -1400,7 +1400,7 @@ mod tests {
         std::fs::create_dir_all(&home).ok();
         let backend = Backend::all()[0].clone();
         generate_fleet_yaml(&home, &backend, None, None).expect("test");
-        let yaml = std::fs::read_to_string(home.join("fleet.yaml")).expect("test");
+        let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("test");
         assert!(
             yaml.contains("user_allowlist"),
             "commented-out channel section must mention user_allowlist; got:\n{yaml}"

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -150,10 +150,11 @@ pub(super) fn render_fleet_view(
     home: &std::path::Path,
 ) {
     let teams = crate::teams::list_all(home);
-    let all_instances: Vec<String> = crate::fleet::FleetConfig::load(&home.join("fleet.yaml"))
-        .ok()
-        .map(|c| c.instance_names())
-        .unwrap_or_default();
+    let all_instances: Vec<String> =
+        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+            .ok()
+            .map(|c| c.instance_names())
+            .unwrap_or_default();
     let text_lines = build_fleet_view_lines(tasks, &teams, &all_instances);
 
     let lines: Vec<Line> = if text_lines.is_empty() {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -64,7 +64,7 @@ fn store_path(home: &Path) -> std::path::PathBuf {
 /// Check if an instance name is known (in fleet.yaml).
 /// Returns true if fleet.yaml doesn't exist (no fleet = no restriction).
 fn instance_exists(home: &Path, name: &str) -> bool {
-    let fleet_path = home.join("fleet.yaml");
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
     if !fleet_path.exists() {
         return true; // no fleet config = no restriction
     }
@@ -932,7 +932,7 @@ mod tests {
     /// validation paths so tests stay focused on `can_mutate_task` logic.
     fn write_dev_team_to_fleet(home: &std::path::Path) {
         std::fs::write(
-            home.join("fleet.yaml"),
+            crate::fleet::fleet_yaml_path(home),
             "teams:\n  dev:\n    members: [dev-lead, dev-impl-2]\n    \
              orchestrator: dev-lead\n    created_at: \"2026-04-27T00:00:00Z\"\n",
         )
@@ -1675,7 +1675,7 @@ mod tests {
             .map(|n| format!("  {n}:\n    backend: claude"))
             .collect();
         let yaml = format!("instances:\n{}", entries.join("\n"));
-        std::fs::write(home.join("fleet.yaml"), yaml).ok();
+        std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).ok();
     }
 
     #[test]

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -31,7 +31,7 @@ impl Team {
 }
 
 fn load_fleet(home: &Path) -> crate::fleet::FleetConfig {
-    crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap_or_default()
+    crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).unwrap_or_default()
 }
 
 /// Project a fleet.yaml `(name, TeamConfig)` pair into the public `Team`
@@ -565,7 +565,7 @@ mod tests {
     fn fleet_yaml_seed_team_visible_on_first_read() {
         let home = tmp_home("seed_visible");
         let yaml = "teams:\n  ops:\n    members: [alice, bob]\n    orchestrator: alice\n";
-        std::fs::write(home.join("fleet.yaml"), yaml).expect("write fleet.yaml");
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
         let members = get_members(&home, "ops");
         assert_eq!(members, vec!["alice", "bob"]);
         let listed = list(&home);
@@ -586,7 +586,7 @@ mod tests {
             }),
         );
         assert_eq!(result["status"], "created");
-        let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let team = fleet.teams.get("dev").unwrap();
         assert_eq!(
             team.source_repo.as_deref(),
@@ -615,7 +615,7 @@ mod tests {
             }),
         );
         assert_eq!(result["status"], "updated");
-        let fleet = crate::fleet::FleetConfig::load(&home.join("fleet.yaml")).unwrap();
+        let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         let team = fleet.teams.get("dev").unwrap();
         assert_eq!(
             team.source_repo.as_deref(),

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -423,7 +423,7 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
 /// subscriber list. Best-effort: read/parse/write failures are
 /// logged but never abort release.
 fn unsubscribe_all_ci_watches_for_agent(home: &Path, agent: &str) {
-    let ci_dir = home.join("ci-watches");
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
     let Ok(entries) = std::fs::read_dir(&ci_dir) else {
         return;
     };
@@ -1201,7 +1201,7 @@ mod tests {
         branch: &str,
         subscribers: &[&str],
     ) -> PathBuf {
-        let ci_dir = home.join("ci-watches");
+        let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
         std::fs::create_dir_all(&ci_dir).ok();
         let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
         let path = ci_dir.join(&filename);


### PR DESCRIPTION
Pure refactor — no behavior change.

1. `fleet.yaml` → `fleet::FLEET_YAML_FILENAME` + `fleet_yaml_path(home)`
2. `ci-watches` → `ci_watch::ci_watches_dir(home)`
3. `[AGEND-MSG]` → `inbox::SYSTEM_MSG_PREFIX`