### PR TITLE
refactor: SSOT magic strings P2

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1393,8 +1393,8 @@ pub fn inject_to_agent(agent: &AgentHandle, text: &[u8]) -> crate::error::Result
         // failures in the receiving agent. Write header line as single unit,
         // then chunk only the body. Use `stripped` (ANSI-free) for detection
         // since raw text may have color escapes before the bracket.
-        let is_system_header =
-            stripped.starts_with(crate::inbox::SYSTEM_MSG_PREFIX) || stripped.starts_with("[from:");
+        let is_system_header = stripped.starts_with(crate::inbox::SYSTEM_MSG_PREFIX)
+            || stripped.starts_with(crate::inbox::AGENT_MSG_PREFIX);
         let (atomic_part, chunk_part) = if is_system_header {
             match all_bytes.iter().position(|&b| b == b'\n') {
                 Some(pos) => all_bytes.split_at(pos + 1),

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -256,7 +256,7 @@ pub fn is_protected_ref(branch: &str) -> bool {
 /// is missing the 5 Kiro paths: `.kiro/agents/{agend.json,agend-prompt.md,
 /// default.json}`, `.kiro/prompts/agend.md`, `.kiro/settings.json`.
 pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
-    let workspaces = home.join("workspace");
+    let workspaces = crate::paths::workspace_dir(home);
 
     // If under $AGEND_HOME/workspace/, remove the whole directory
     if working_dir.starts_with(&workspaces) {

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -149,7 +149,7 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
     let requested_work_dir = params["working_directory"]
         .as_str()
         .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| ctx.home.join("workspace").join(name));
+        .unwrap_or_else(|| crate::paths::workspace_dir(ctx.home).join(name));
     let work_dir = match crate::api::validate_working_directory(&requested_work_dir, ctx.home) {
         Ok(p) => p,
         Err(e) => return json!({"ok": false, "error": format!("{e}")}),
@@ -624,7 +624,7 @@ mod tests {
 
         // Call spawn_one directly (team-spawn path bypasses handle_spawn)
         let size = (80u16, 24u16);
-        let work_dir = home.join("workspace").join("team-meta");
+        let work_dir = crate::paths::workspace_dir(&home).join("team-meta");
         std::fs::create_dir_all(&work_dir).ok();
         let result = crate::api::spawn_one(
             ctx.home,

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -85,7 +85,7 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
             failed.push(format!("{inst_name}: agent already exists"));
             continue;
         }
-        let work_dir = ctx.home.join("workspace").join(&inst_name);
+        let work_dir = crate::paths::workspace_dir(ctx.home).join(&inst_name);
         planned.push((inst_name, backend.clone(), work_dir));
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -512,7 +512,7 @@ mod tests {
     #[test]
     fn validate_work_dir_allows_normal_path() {
         let home = tmp_home("validate_normal");
-        let ok = home.join("workspace").join("agent");
+        let ok = crate::paths::workspace_dir(&home).join("agent");
         let resolved = validate_working_directory(&ok, &home).expect("normal path must validate");
         assert_eq!(resolved, ok);
         std::fs::remove_dir_all(&home).ok();

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -91,7 +91,7 @@ pub(super) fn create_pane(
     // Resolve working directory
     let work_dir = working_dir
         .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| home.join("workspace").join(&name));
+        .unwrap_or_else(|| crate::paths::workspace_dir(home).join(&name));
 
     // Generate MCP config for agent backends
     if Backend::from_command(command).is_some() {
@@ -425,7 +425,7 @@ fn unique_fleet_name_with(home: &Path, base: &str, mut ids: impl Iterator<Item =
         {
             return true;
         }
-        if home.join("workspace").join(name).exists() {
+        if crate::paths::workspace_dir(home).join(name).exists() {
             return true;
         }
         if crate::inbox::inbox_path_resolved(home, name).exists() {
@@ -490,7 +490,7 @@ mod tests {
         let home = tmp_home("diff");
         let a = unique_fleet_name(&home, "codex");
         // Realize `a` as a workspace so the next call must not collide with it.
-        std::fs::create_dir_all(home.join("workspace").join(&a)).expect("create a");
+        std::fs::create_dir_all(crate::paths::workspace_dir(&home).join(&a)).expect("create a");
         let b = unique_fleet_name(&home, "codex");
         assert_ne!(a, b);
         std::fs::remove_dir_all(&home).ok();
@@ -523,8 +523,10 @@ mod tests {
         let home = tmp_home("fallback");
         // Seed the exact 100 suffixes the iterator will produce
         for n in 1..=100u32 {
-            std::fs::create_dir_all(home.join("workspace").join(format!("codex-{n:06x}")))
-                .expect("seed");
+            std::fs::create_dir_all(
+                crate::paths::workspace_dir(&home).join(format!("codex-{n:06x}")),
+            )
+            .expect("seed");
         }
         let name =
             unique_fleet_name_with(&home, "codex", (1u32..=100).collect::<Vec<_>>().into_iter());

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -35,7 +35,7 @@ pub fn bind_full(
     worktree: &std::path::Path,
     source_repo: &std::path::Path,
 ) {
-    let dir = home.join("runtime").join(agent);
+    let dir = crate::paths::runtime_dir(home).join(agent);
     std::fs::create_dir_all(&dir).ok();
     let path = dir.join("binding.json");
     let lock_path = dir.join(".binding.json.lock");
@@ -61,7 +61,9 @@ pub fn bind_full(
 
 /// Clear a binding for an agent (task completed/released).
 pub fn unbind(home: &Path, agent: &str) {
-    let path = home.join("runtime").join(agent).join("binding.json");
+    let path = crate::paths::runtime_dir(home)
+        .join(agent)
+        .join("binding.json");
     let _ = std::fs::remove_file(path);
 }
 
@@ -72,7 +74,7 @@ pub fn scan_existing_branch_binding(
     branch: &str,
     exclude_agent: &str,
 ) -> Option<String> {
-    let runtime_dir = home.join("runtime");
+    let runtime_dir = crate::paths::runtime_dir(home);
     let entries = std::fs::read_dir(&runtime_dir).ok()?;
     for entry in entries.flatten() {
         let agent = entry.file_name().to_string_lossy().to_string();
@@ -96,7 +98,9 @@ pub fn scan_existing_branch_binding(
 /// Read the current binding for an agent (for internal use/tests).
 #[allow(dead_code)] // Used by tests + Phase 2
 pub fn read(home: &Path, agent: &str) -> Option<serde_json::Value> {
-    let path = home.join("runtime").join(agent).join("binding.json");
+    let path = crate::paths::runtime_dir(home)
+        .join(agent)
+        .join("binding.json");
     std::fs::read_to_string(path)
         .ok()
         .and_then(|c| serde_json::from_str(&c).ok())
@@ -163,7 +167,7 @@ pub fn reconcile_hooks(home: &Path) {
     }
 
     // Legacy layout: <home>/workspace/*/.worktrees/*/
-    let worktrees_base = home.join("workspace");
+    let worktrees_base = crate::paths::workspace_dir(home);
     if !worktrees_base.exists() {
         return;
     }
@@ -219,7 +223,7 @@ pub fn symlink_shim(home: &Path) {
 /// Clear orphan bindings (agents no longer in registry).
 /// Called at daemon startup.
 pub fn reconcile_orphans(home: &Path) {
-    let runtime_dir = home.join("runtime");
+    let runtime_dir = crate::paths::runtime_dir(home);
     if !runtime_dir.exists() {
         return;
     }
@@ -306,7 +310,7 @@ mod tests {
         std::fs::create_dir_all(&wt).unwrap();
         std::fs::write(wt.join(".agend-managed"), "").unwrap();
         // Write binding pointing to this worktree
-        let rt = home.join("runtime").join("agent-1");
+        let rt = crate::paths::runtime_dir(&home).join("agent-1");
         std::fs::create_dir_all(&rt).unwrap();
         let binding =
             serde_json::json!({"worktree": wt.to_str().unwrap(), "branch": "feat-branch"});
@@ -322,7 +326,7 @@ mod tests {
         let wt = home.join("worktrees").join("agent-2").join("feat-branch");
         std::fs::create_dir_all(&wt).unwrap();
         // No .agend-managed marker
-        let rt = home.join("runtime").join("agent-2");
+        let rt = crate::paths::runtime_dir(&home).join("agent-2");
         std::fs::create_dir_all(&rt).unwrap();
         let binding =
             serde_json::json!({"worktree": wt.to_str().unwrap(), "branch": "feat-branch"});

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -287,7 +287,7 @@ mod tests {
             "# Extra Instructions\nAlways include rollout checklist.",
         )
         .expect("write instructions file");
-        let work_dir = home.join("workspace").join("worker");
+        let work_dir = crate::paths::workspace_dir(home).join("worker");
         let yaml = format!(
             "defaults:\n  backend: claude\ninstances:\n  worker:\n    backend: claude\n    working_directory: {}\n    instructions: ./instructions/dev.md\n",
             work_dir.display()

--- a/src/daemon/task_progress.rs
+++ b/src/daemon/task_progress.rs
@@ -190,7 +190,7 @@ pub(crate) fn touch_progress_for_branch(home: &Path, branch: &str) -> Option<Str
     if branch.is_empty() {
         return None;
     }
-    let runtime_dir = home.join("runtime");
+    let runtime_dir = crate::paths::runtime_dir(home);
     let entries = std::fs::read_dir(&runtime_dir).ok()?;
     for entry in entries.flatten() {
         let binding_path = entry.path().join("binding.json");
@@ -389,7 +389,7 @@ mod tests {
         // sidecar with source=ci_push.
         let home = tmp_home("hook-pr-push");
         // Seed a binding with task_id + branch.
-        let runtime_dir = home.join("runtime").join("dev");
+        let runtime_dir = crate::paths::runtime_dir(&home).join("dev");
         std::fs::create_dir_all(&runtime_dir).unwrap();
         let binding = serde_json::json!({
             "version": 1,
@@ -451,7 +451,7 @@ mod tests {
         // touch_progress_for_branch must skip these — they have no
         // task board entry to track progress against.
         let home = tmp_home("hook-self-binding");
-        let runtime_dir = home.join("runtime").join("dev");
+        let runtime_dir = crate::paths::runtime_dir(&home).join("dev");
         std::fs::create_dir_all(&runtime_dir).unwrap();
         let binding = serde_json::json!({
             "version": 1,

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -492,7 +492,7 @@ fn cleanup_deployment_dirs(home: &Path, deployment: &Deployment) {
         // to `home/workspace/<deploy_name>` (subdir lands at
         // `home/workspace/<deploy_name>/<inst>`) AND covers historical
         // teardown semantics that cleaned `home/workspace/<inst>` directly.
-        let default_subdir = home.join("workspace").join(inst);
+        let default_subdir = crate::paths::workspace_dir(home).join(inst);
         if default_subdir.exists() {
             crate::agent_ops::cleanup_working_dir(home, inst, &default_subdir);
         }
@@ -1373,7 +1373,7 @@ instances: {}
             &serde_json::json!({"template": "dev", "directory": home.display().to_string()}),
         );
         // Create workspace dir (simulates what daemon would create).
-        let workspace = home.join("workspace").join("dev-worker");
+        let workspace = crate::paths::workspace_dir(&home).join("dev-worker");
         std::fs::create_dir_all(&workspace).ok();
         std::fs::write(workspace.join("test.txt"), "data").ok();
         assert!(workspace.exists());
@@ -1412,7 +1412,7 @@ instances: {}
 
         // Binding should be cleared by cleanup_working_dir or DELETE.
         // Workspace dir should not exist.
-        let workspace = home.join("workspace").join("dev-agent");
+        let workspace = crate::paths::workspace_dir(&home).join("dev-agent");
         assert!(!workspace.exists(), "workspace must be cleaned");
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1743,7 +1743,7 @@ instances: {}
         // Hand-create the workspace subdir (production's spawn path
         // would have created it; deploy_single_instance_for_test stops
         // short of spawning).
-        let wd = home.join("workspace").join("tpl-worker");
+        let wd = crate::paths::workspace_dir(&home).join("tpl-worker");
         std::fs::create_dir_all(&wd).unwrap();
         std::fs::write(wd.join("agent_data.txt"), "data").unwrap();
         assert!(wd.exists(), "test setup: workspace dir must exist");

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -618,6 +618,9 @@ pub const HEADER_PREFIX: &str = "\x1b[44;97m[AGEND-MSG]\x1b[0m";
 /// Used for detection/matching in agent PTY output parsing.
 pub const SYSTEM_MSG_PREFIX: &str = "[AGEND-MSG]";
 
+/// Agent-to-agent message prefix.
+pub const AGENT_MSG_PREFIX: &str = "[from:";
+
 /// Sanitize a value for header inclusion: replace control chars with space.
 fn sanitize_header_value(s: &str) -> String {
     s.chars()

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod layout;
 mod mcp;
 mod mcp_config;
 mod notification_queue;
+mod paths;
 mod process;
 mod protocol;
 mod quickstart;

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -161,7 +161,7 @@ fn cross_branch_holders_for(home: &Path, branch: &str, exclude_agent: &str) -> V
     if branch.is_empty() {
         return Vec::new();
     }
-    let runtime_dir = home.join("runtime");
+    let runtime_dir = crate::paths::runtime_dir(home);
     let Ok(entries) = std::fs::read_dir(&runtime_dir) else {
         return Vec::new();
     };
@@ -203,7 +203,7 @@ mod tests {
     }
 
     fn write_binding(home: &std::path::Path, agent: &str, branch: &str, worktree: &str) {
-        let dir = home.join("runtime").join(agent);
+        let dir = crate::paths::runtime_dir(home).join(agent);
         std::fs::create_dir_all(&dir).unwrap();
         let payload = json!({
             "version": 1,

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -210,7 +210,7 @@ fn resolve_source_repo(
             "source_repo resolved via fleet.yaml working_directory (tier 3, deprecation candidate)");
         return p;
     }
-    let stub = home.join("workspace").join(target);
+    let stub = crate::paths::workspace_dir(home).join(target);
     tracing::warn!(%target, tier = "stub", path = %stub.display(),
         "source_repo using home/workspace stub (tier 4) — fleet.yaml has no source_repo OR working_directory; binding may target wrong git history");
     if std::env::var("AGEND_BIND_STRICT_MODE").as_deref() == Ok("1") {

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -2,7 +2,7 @@
 // These call the PRODUCTION function directly (§1.4 compliance).
 
 fn setup_test_repo(home: &std::path::Path, agent: &str) -> std::path::PathBuf {
-    let repo = home.join("workspace").join(agent);
+    let repo = crate::paths::workspace_dir(home).join(agent);
     std::fs::create_dir_all(&repo).ok();
     std::process::Command::new("git")
         .args(["init", "-b", "main"])
@@ -47,7 +47,9 @@ fn dispatch_with_branch_creates_binding_and_worktree() {
     let result = super::dispatch_auto_bind_lease(&home, "test-agent", "T-100", "feat/test", None);
     assert!(result.is_ok(), "dispatch must succeed: {:?}", result.err());
 
-    let binding_path = home.join("runtime").join("test-agent").join("binding.json");
+    let binding_path = crate::paths::runtime_dir(&home)
+        .join("test-agent")
+        .join("binding.json");
     assert!(binding_path.exists(), "binding.json must exist");
     let content = std::fs::read_to_string(&binding_path).expect("read");
     let v: serde_json::Value = serde_json::from_str(&content).expect("parse");
@@ -70,7 +72,9 @@ fn main_branch_rejects_dispatch() {
     assert!(err.contains("E4.5"), "error must mention E4.5: {err}");
 
     // No binding should exist.
-    let binding_path = home.join("runtime").join("test-agent").join("binding.json");
+    let binding_path = crate::paths::runtime_dir(&home)
+        .join("test-agent")
+        .join("binding.json");
     assert!(
         !binding_path.exists(),
         "rejected dispatch must not create binding"
@@ -89,8 +93,8 @@ fn lease_conflict_rejects_dispatch() {
     std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
             format!("instances:\n  agent-a:\n    backend: claude\n    working_directory: {}\n  agent-b:\n    backend: claude\n    working_directory: {}\n",
-                home.join("workspace").join("agent-a").display(),
-                home.join("workspace").join("agent-b").display()),
+                crate::paths::workspace_dir(&home).join("agent-a").display(),
+                crate::paths::workspace_dir(&home).join("agent-b").display()),
         ).ok();
 
     // First dispatch succeeds in agent-a's clone.
@@ -111,7 +115,9 @@ fn lease_conflict_rejects_dispatch() {
     );
 
     // Agent-b binding must NOT exist (Q2: REJECT = no side effects).
-    let binding_b = home.join("runtime").join("agent-b").join("binding.json");
+    let binding_b = crate::paths::runtime_dir(&home)
+        .join("agent-b")
+        .join("binding.json");
     assert!(
         !binding_b.exists(),
         "rejected dispatch must not create binding"
@@ -139,7 +145,9 @@ fn same_agent_re_dispatch_idempotent() {
     );
 
     // Binding should exist with new task_id.
-    let binding = home.join("runtime").join("agent-x").join("binding.json");
+    let binding = crate::paths::runtime_dir(&home)
+        .join("agent-x")
+        .join("binding.json");
     let content = std::fs::read_to_string(&binding).expect("read");
     let v: serde_json::Value = serde_json::from_str(&content).expect("parse");
     assert_eq!(v["task_id"], "T-2", "task_id must update on re-dispatch");
@@ -156,7 +164,7 @@ fn bind_file_error_stays_graceful() {
     setup_test_repo(&home, "test-agent");
 
     // Block bind_full by creating runtime/test-agent as a file (not dir).
-    let runtime_parent = home.join("runtime");
+    let runtime_parent = crate::paths::runtime_dir(&home);
     std::fs::create_dir_all(&runtime_parent).ok();
     let runtime_agent = runtime_parent.join("test-agent");
     std::fs::write(&runtime_agent, "blocking file").ok();
@@ -257,7 +265,7 @@ fn delegate_task_lease_conflict_rejects_without_delivering() {
     std::fs::create_dir_all(&home).ok();
     setup_test_repo(&home, "agent-a");
 
-    let repo = home.join("workspace").join("agent-a");
+    let repo = crate::paths::workspace_dir(&home).join("agent-a");
     std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
             // allow: shared-source_repo — this test exercises the central
@@ -359,7 +367,9 @@ fn same_agent_different_branch_rejects() {
 
     // Binding still reflects feat/A (T-1) — the rejected dispatch must
     // not have overwritten it.
-    let binding = home.join("runtime").join("agent-x").join("binding.json");
+    let binding = crate::paths::runtime_dir(&home)
+        .join("agent-x")
+        .join("binding.json");
     let content = std::fs::read_to_string(&binding).expect("read binding");
     let v: serde_json::Value = serde_json::from_str(&content).expect("parse binding");
     assert_eq!(
@@ -480,7 +490,9 @@ fn delegate_task_without_repo_no_ci_watch() {
     assert!(result.is_ok(), "dispatch must succeed: {:?}", result.err());
 
     // Bind/lease still happened (load-bearing).
-    let binding_path = home.join("runtime").join("test-agent").join("binding.json");
+    let binding_path = crate::paths::runtime_dir(&home)
+        .join("test-agent")
+        .join("binding.json");
     assert!(
         binding_path.exists(),
         "binding.json must exist (lease succeeded)"
@@ -671,7 +683,9 @@ fn dispatch_auto_bind_lease_rejects_same_agent_different_branch_post_wave_4() {
 
     // Binding still reflects feat/A — the rejected dispatch must
     // NOT have overwritten it.
-    let binding = home.join("runtime").join("agent-y").join("binding.json");
+    let binding = crate::paths::runtime_dir(&home)
+        .join("agent-y")
+        .join("binding.json");
     let content = std::fs::read_to_string(&binding).expect("read binding");
     let v: serde_json::Value = serde_json::from_str(&content).expect("parse binding");
     assert_eq!(

--- a/src/mcp/handlers/force_release.rs
+++ b/src/mcp/handlers/force_release.rs
@@ -510,7 +510,7 @@ mod tests {
         let home = tmp_home("bind-rebase-cleanup");
         let dir = seed_daemon_worktree(&home, "dev", "feat/rebase-bind");
         // Seed a binding too so we can verify it's released.
-        let runtime = home.join("runtime").join("dev");
+        let runtime = crate::paths::runtime_dir(&home).join("dev");
         std::fs::create_dir_all(&runtime).unwrap();
         std::fs::write(
             runtime.join("binding.json"),

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -613,7 +613,12 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
         .get("working_directory")
         .and_then(|v| v.as_str())
         .map(String::from)
-        .unwrap_or_else(|| home.join("workspace").join(name).display().to_string());
+        .unwrap_or_else(|| {
+            crate::paths::workspace_dir(home)
+                .join(name)
+                .display()
+                .to_string()
+        });
 
     if let Some(branch) = args.get("branch").and_then(|v| v.as_str()) {
         if !validate_branch(branch) {

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -263,7 +263,7 @@ mod tests {
     #[test]
     fn name_residual_anywhere_detects_runtime_binding_residual() {
         let home = tmp_home("binding");
-        let dir = home.join("runtime").join("zombie");
+        let dir = crate::paths::runtime_dir(&home).join("zombie");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("binding.json"), "{}").unwrap();
         let sources = name_residual_anywhere(&home, "zombie");

--- a/src/mcp/handlers/p0b_tests.rs
+++ b/src/mcp/handlers/p0b_tests.rs
@@ -34,7 +34,7 @@ fn tmp_home(tag: &str) -> std::path::PathBuf {
 }
 
 fn write_binding(home: &Path, agent: &str, source_repo: &str, branch: &str) {
-    let dir = home.join("runtime").join(agent);
+    let dir = crate::paths::runtime_dir(home).join(agent);
     std::fs::create_dir_all(&dir).ok();
     let v = json!({
         "version": 1,
@@ -92,7 +92,7 @@ fn ec15_ci_watch_source_repo_path_deleted_returns_error() {
 #[test]
 fn ci_watch_binding_corrupt_returns_error() {
     let home = tmp_home("corrupt");
-    let dir = home.join("runtime").join("alpha");
+    let dir = crate::paths::runtime_dir(&home).join("alpha");
     std::fs::create_dir_all(&dir).ok();
     std::fs::write(dir.join("binding.json"), "this is not json").ok();
     let result = super::ci::handle_watch_ci(&home, &json!({}), "alpha");
@@ -121,7 +121,7 @@ fn setup_git_repo(home: &Path, agent: &str) -> std::path::PathBuf {
 }
 
 fn setup_git_repo_with_remote(home: &Path, agent: &str, origin_url: &str) -> std::path::PathBuf {
-    let repo = home.join("workspace").join(agent);
+    let repo = crate::paths::workspace_dir(home).join(agent);
     std::fs::create_dir_all(&repo).ok();
     let _ = std::process::Command::new("git")
         .args(["init", "-b", "main"])
@@ -402,7 +402,9 @@ fn ec6_dispatch_uses_fleet_source_repo_tier_when_present() {
         Some("o/r"),
     );
     assert!(r.is_ok(), "dispatch via fleet source_repo tier ok: {r:?}");
-    let binding_path = home.join("runtime").join("alpha").join("binding.json");
+    let binding_path = crate::paths::runtime_dir(&home)
+        .join("alpha")
+        .join("binding.json");
     let v: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&binding_path).unwrap()).unwrap();
     assert_eq!(
@@ -483,7 +485,7 @@ fn bind_self_with_source_repo_arg_succeeds() {
 #[test]
 fn dispatch_with_source_repo_override_wins_over_fleet() {
     let home = tmp_home("override-wins");
-    let stub_src = home.join("workspace").join("alpha");
+    let stub_src = crate::paths::workspace_dir(&home).join("alpha");
     let real_src = home.join("override-src");
     std::fs::create_dir_all(&real_src).ok();
     let _ = std::process::Command::new("git")
@@ -523,7 +525,9 @@ fn dispatch_with_source_repo_override_wins_over_fleet() {
         Some(&real_src), // override wins over fleet stub
     );
     assert!(r.is_ok(), "override dispatch ok: {r:?}");
-    let binding_path = home.join("runtime").join("alpha").join("binding.json");
+    let binding_path = crate::paths::runtime_dir(&home)
+        .join("alpha")
+        .join("binding.json");
     let v: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&binding_path).unwrap()).unwrap();
     assert_eq!(
@@ -571,7 +575,7 @@ fn ci_watch_no_origin_remote_returns_non_github_error() {
     // Distinct from EC1 (no binding at all): here a binding exists but
     // its source_repo has no origin remote → derive returns None.
     let home = tmp_home("ci-no-origin");
-    let src = home.join("workspace").join("alpha");
+    let src = crate::paths::workspace_dir(&home).join("alpha");
     std::fs::create_dir_all(&src).ok();
     let _ = std::process::Command::new("git")
         .args(["init", "-b", "main"])

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -102,7 +102,7 @@ instances:
 #[test]
 fn cleanup_agend_workspace_removes_entire_dir() {
     let home = tmp_home("cleanup_ws");
-    let ws = home.join("workspace").join("test-agent");
+    let ws = crate::paths::workspace_dir(&home).join("test-agent");
     std::fs::create_dir_all(&ws).ok();
     std::fs::write(ws.join("somefile.txt"), "data").ok();
     std::fs::write(ws.join("opencode.json"), "{}").ok();
@@ -140,7 +140,7 @@ fn cleanup_user_dir_only_removes_agend_files() {
 #[test]
 fn cleanup_removes_metadata() {
     let home = tmp_home("cleanup_meta");
-    let ws = home.join("workspace").join("agent1");
+    let ws = crate::paths::workspace_dir(&home).join("agent1");
     std::fs::create_dir_all(&ws).ok();
 
     std::fs::create_dir_all(home.join("metadata")).ok();
@@ -1748,11 +1748,11 @@ fn consolidated_deployment_unknown_action_errors() {
 fn create_instance_default_working_directory_path() {
     let home = tmp_home("create-default-wd");
     let name = "test-agent";
-    let expected = home.join("workspace").join(name);
+    let expected = crate::paths::workspace_dir(&home).join(name);
     // Verify PathBuf construction matches (cross-platform safe)
     assert_eq!(
         expected,
-        home.join("workspace").join(name),
+        crate::paths::workspace_dir(&home).join(name),
         "default working_directory must be $AGEND_HOME/workspace/<name>"
     );
     // Verify the path ends with the expected components

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -97,7 +97,9 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
             // Successful bind: read back the worktree path from the binding
             // file we just wrote so the response reflects authoritative
             // state, not a recomputation.
-            let binding_path = home.join("runtime").join(agent).join("binding.json");
+            let binding_path = crate::paths::runtime_dir(home)
+                .join(agent)
+                .join("binding.json");
             let worktree_path = std::fs::read_to_string(&binding_path)
                 .ok()
                 .and_then(|s| serde_json::from_str::<Value>(&s).ok())
@@ -326,7 +328,7 @@ mod tests {
     // signature.
 
     fn p17_setup_repo(home: &std::path::Path, agent: &str) -> std::path::PathBuf {
-        let repo = home.join("workspace").join(agent);
+        let repo = crate::paths::workspace_dir(home).join(agent);
         std::fs::create_dir_all(&repo).ok();
         std::process::Command::new("git")
             .args(["init", "-b", "main"])
@@ -392,7 +394,9 @@ mod tests {
             .expect("worktree_path in success response");
         assert!(!worktree_path.is_empty(), "worktree_path must be populated");
 
-        let binding_path = home.join("runtime").join("agent-self").join("binding.json");
+        let binding_path = crate::paths::runtime_dir(&home)
+            .join("agent-self")
+            .join("binding.json");
         assert!(
             binding_path.exists(),
             "binding.json must exist after bind_self"
@@ -471,7 +475,9 @@ mod tests {
         );
 
         // No side-effects on rejection.
-        let binding = home.join("runtime").join("agent-e45").join("binding.json");
+        let binding = crate::paths::runtime_dir(&home)
+            .join("agent-e45")
+            .join("binding.json");
         assert!(
             !binding.exists(),
             "rejected bind_self must not write binding.json"

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,23 @@
+//! Centralized path helpers — single source of truth for daemon directory layout.
+
+use std::path::{Path, PathBuf};
+
+/// `<home>/workspace/` — per-agent working directories.
+pub fn workspace_dir(home: &Path) -> PathBuf {
+    home.join("workspace")
+}
+
+/// `<home>/runtime/` — per-agent runtime state (binding.json, metadata).
+pub fn runtime_dir(home: &Path) -> PathBuf {
+    home.join("runtime")
+}
+
+/// `<home>/runtime/<agent>/binding.json`
+#[allow(dead_code)]
+pub fn binding_path(home: &Path, agent: &str) -> PathBuf {
+    runtime_dir(home).join(agent).join(BINDING_FILENAME)
+}
+
+/// Binding state filename.
+#[allow(dead_code)]
+pub const BINDING_FILENAME: &str = "binding.json";

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -520,7 +520,7 @@ channel:
         "\n# channel:\n#   type: telegram\n#   bot_token_env: AGEND_BOT_TOKEN\n#   group_id: YOUR_GROUP_ID\n#   user_allowlist: [YOUR_USER_ID]\n".to_string()
     };
 
-    let workspace_dir = home.join("workspace").join("general");
+    let workspace_dir = crate::paths::workspace_dir(home).join("general");
     std::fs::create_dir_all(&workspace_dir)?;
     let working_dir = format!("    working_directory: {}", workspace_dir.display());
 

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -6,7 +6,7 @@
 use std::path::{Path, PathBuf};
 
 /// Marker file placed in daemon-managed worktrees (R14 mitigation).
-const MANAGED_MARKER: &str = ".agend-managed";
+pub(crate) const MANAGED_MARKER: &str = ".agend-managed";
 
 /// Root directory for daemon-managed worktrees in the new layout.
 /// `<home>/worktrees/` — contains `<agent>/<branch>/` subdirectories.
@@ -489,7 +489,7 @@ pub fn is_pinned(worktree_path: &Path) -> bool {
 
 /// Reconcile orphan leases at daemon startup (log only, no delete in Phase 3).
 pub fn reconcile_orphan_leases(home: &Path) {
-    let runtime_dir = home.join("runtime");
+    let runtime_dir = crate::paths::runtime_dir(home);
     if !runtime_dir.exists() {
         return;
     }
@@ -557,7 +557,7 @@ pub fn gc_candidates(home: &Path) -> Vec<GcCandidate> {
     }
 
     // Legacy layout: <home>/workspace/*/.worktrees/*/
-    let workspace = home.join("workspace");
+    let workspace = crate::paths::workspace_dir(home);
     if workspace.exists() {
         if let Ok(entries) = std::fs::read_dir(&workspace) {
             for entry in entries.flatten() {
@@ -890,7 +890,7 @@ mod tests {
         let home = tmp_home("p0x-unmanaged");
         let unmanaged_wt = tmp_home("p0x-unmanaged-wt-target");
         // Hand-craft a binding pointing at an unmanaged path.
-        std::fs::create_dir_all(home.join("runtime").join("agent-u")).ok();
+        std::fs::create_dir_all(crate::paths::runtime_dir(&home).join("agent-u")).ok();
         let binding = serde_json::json!({
             "version": 1,
             "agent": "agent-u",
@@ -900,7 +900,9 @@ mod tests {
             "worktree": unmanaged_wt.display().to_string(),
         });
         std::fs::write(
-            home.join("runtime").join("agent-u").join("binding.json"),
+            crate::paths::runtime_dir(&home)
+                .join("agent-u")
+                .join("binding.json"),
             serde_json::to_string_pretty(&binding).unwrap(),
         )
         .unwrap();
@@ -1564,7 +1566,7 @@ mod tests {
         )
         .unwrap();
         // Create active binding for dev-1
-        let rt = home.join("runtime").join("dev-1");
+        let rt = crate::paths::runtime_dir(&home).join("dev-1");
         std::fs::create_dir_all(&rt).unwrap();
         std::fs::write(
             rt.join("binding.json"),


### PR DESCRIPTION
4. `workspace` → `paths::workspace_dir(home)`
5. `runtime` → `paths::runtime_dir(home)`
6. `[from:` → `inbox::AGENT_MSG_PREFIX`
7. `.agend-managed` → `pub(crate) MANAGED_MARKER`
8. New `src/paths.rs` module

Pure refactor — no behavior change.