### PR TITLE
fix: Phase 2 — #692 #693 #702

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -239,10 +239,24 @@ pub fn reconcile_orphans(home: &Path) {
                                 let age = chrono::Utc::now()
                                     .signed_duration_since(dt.with_timezone(&chrono::Utc));
                                 if age > chrono::Duration::hours(24) {
+                                    // #693: check heartbeat — if agent is still active, don't delete
+                                    let entry_path = entry.path();
+                                    let agent_name = entry_path
+                                        .file_name()
+                                        .and_then(|n| n.to_str())
+                                        .unwrap_or("");
+                                    let hb =
+                                        crate::daemon::heartbeat_pair::snapshot_for(agent_name);
+                                    let hb_age_ms = crate::daemon::heartbeat_pair::now_ms()
+                                        .saturating_sub(hb.heartbeat_at_ms);
+                                    if hb_age_ms < 3_600_000 {
+                                        // Heartbeat within 1h — agent still active, skip
+                                        continue;
+                                    }
                                     let _ = std::fs::remove_file(&binding_path);
                                     tracing::info!(
                                         path = %binding_path.display(),
-                                        "removed orphan binding (>24h old)"
+                                        "removed orphan binding (>24h old, heartbeat stale)"
                                     );
                                 }
                             }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -142,16 +142,15 @@ pub fn run(
     let child_id = child.id();
     let deregister_name = name.to_string();
     let deregister_home = home.to_path_buf();
-    static SIGNAL_RECEIVED: std::sync::atomic::AtomicBool =
-        std::sync::atomic::AtomicBool::new(false);
+    static SIGNAL_RECEIVED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     ctrlc::set_handler(move || {
-        SIGNAL_RECEIVED.store(true, std::sync::atomic::Ordering::Relaxed);
+        let _ = SIGNAL_RECEIVED.set(());
     })
     .ok();
 
     // 11. Wait for child to exit, checking signal flag
     loop {
-        if SIGNAL_RECEIVED.load(std::sync::atomic::Ordering::Relaxed) {
+        if SIGNAL_RECEIVED.get().is_some() {
             crate::process::terminate(child_id);
             let _ = crate::api::call(
                 &deregister_home,


### PR DESCRIPTION
#692: ci-watch atomic writes (already done — verified)
#693: reconcile_orphans heartbeat check before stale binding deletion
#702: connect.rs AtomicBool → OnceLock<()>

Closes #692, Closes #693, Closes #702