### PR TITLE
fix(#692): flock protects ci-watch RMW race

### DIFF
--- a/src/daemon/ci_watch.rs
+++ b/src/daemon/ci_watch.rs
@@ -2093,6 +2093,15 @@ fn update_watch_state_with_notify(
     head_sha: &str,
     notified_sha: Option<&str>,
 ) {
+    // #692: flock protects RMW against concurrent unsubscribe
+    let lock_path = watch_path.with_extension("lock");
+    let _lock = match crate::store::acquire_file_lock(&lock_path) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!(path = %lock_path.display(), error = %e, "failed to acquire ci-watch lock, skipping update");
+            return;
+        }
+    };
     if let Ok(content) = std::fs::read_to_string(watch_path) {
         if let Ok(mut watch) = serde_json::from_str::<serde_json::Value>(&content) {
             watch["last_run_id"] = serde_json::json!(run_id);

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -433,6 +433,12 @@ fn unsubscribe_all_ci_watches_for_agent(home: &Path, agent: &str) {
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
+        // #692: flock protects read-modify-write against concurrent ci_watch tick
+        let lock_path = path.with_extension("lock");
+        let _lock = match crate::store::acquire_file_lock(&lock_path) {
+            Ok(l) => l,
+            Err(_) => continue, // skip if can't lock
+        };
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };


### PR DESCRIPTION
flock serialises unsubscribe + tick write on same watch file.

Closes #692