### PR TITLE
fix(#700): SGR mouse forwarding

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -209,26 +209,6 @@ pub fn strip_ansi_pub(s: &str) -> String {
     strip_ansi(s)
 }
 
-/// Strip mouse mode enable/disable sequences from PTY output.
-/// Prevents backends (opencode, etc.) from stealing mouse events from the TUI.
-/// Strips: \x1b[?{1000,1002,1003,1006,1015}{h,l}
-///
-/// NOTE: chunk-boundary splits of mouse sequences are not handled;
-/// probability is negligible (8-byte sequence vs 4KB+ read chunks).
-fn strip_mouse_mode_sequences(data: &[u8]) -> std::borrow::Cow<'_, [u8]> {
-    // Fast path: no ESC byte → no mouse sequence possible
-    if !data.contains(&0x1b) {
-        return std::borrow::Cow::Borrowed(data);
-    }
-    use regex::bytes::Regex;
-    use std::sync::OnceLock;
-    static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        Regex::new(r"\x1b\[\?(1000|1002|1003|1006|1015)[hl]").expect("mouse mode regex")
-    });
-    re.replace_all(data, &b""[..])
-}
-
 fn strip_ansi(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
@@ -821,10 +801,6 @@ fn pty_read_loop(pty_reader: &mut dyn Read, ctx: &PtyReadContext) {
                 // won't defeat us (VTerm resolves the geometry). Cooldown: 10s.
                 let screen = {
                     let mut c = core.lock();
-                    // #700: strip mouse mode enable sequences from PTY output
-                    // so backends can't steal mouse events from the TUI.
-                    let filtered = strip_mouse_mode_sequences(data);
-                    let data = &*filtered;
                     c.vterm.process(data);
                     let rows = c.vterm.rows() as usize;
                     let screen = c.vterm.tail_lines(rows);
@@ -2478,33 +2454,5 @@ Allow Trust All Tools mode?
         // The env_remove in build_command is the authoritative guard.
         let _ = cmd;
         std::env::remove_var("AGEND_GIT_BYPASS");
-    }
-
-    #[test]
-    fn strip_mouse_mode_all_modes_enable_disable() {
-        for mode in &["1000", "1002", "1003", "1006", "1015"] {
-            let enable = format!("\x1b[?{mode}h");
-            let disable = format!("\x1b[?{mode}l");
-            let input_h = format!("A{enable}B");
-            let input_l = format!("X{disable}Y");
-            let r1 = strip_mouse_mode_sequences(input_h.as_bytes());
-            assert_eq!(&*r1, b"AB", "failed for {mode}h");
-            let r2 = strip_mouse_mode_sequences(input_l.as_bytes());
-            assert_eq!(&*r2, b"XY", "failed for {mode}l");
-        }
-    }
-
-    #[test]
-    fn strip_mouse_mode_preserves_normal_ansi() {
-        let input = b"\x1b[31mRed\x1b[0m Normal \x1b[?25h";
-        let result = strip_mouse_mode_sequences(input);
-        assert_eq!(&*result, &input[..]);
-    }
-
-    #[test]
-    fn strip_mouse_mode_fast_path_no_esc() {
-        let input = b"plain text without escape";
-        let result = strip_mouse_mode_sequences(input);
-        assert_eq!(&*result, &input[..]);
     }
 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -49,6 +49,46 @@ pub(super) fn handle(
     registry: &AgentRegistry,
 ) -> MouseOutcome {
     let mut out = MouseOutcome::default();
+
+    // #700: If focused pane's terminal wants mouse events AND shift is not held,
+    // forward the event as SGR mouse report to the PTY instead of local handling.
+    if !mouse
+        .modifiers
+        .contains(crossterm::event::KeyModifiers::SHIFT)
+    {
+        if let Some(tab) = layout.active_tab() {
+            if let Some(pane) = tab.focused_pane() {
+                if pane.vterm.wants_mouse() && pane.vterm.mouse_sgr() {
+                    let pane_id = tab.focus_id;
+                    if let Some(&(px, py, pw, ph)) = tab.pane_rects.get(&pane_id) {
+                        let inner_x = px + 1;
+                        let inner_y = py + 1;
+                        let inner_w = pw.saturating_sub(2);
+                        let inner_h = ph.saturating_sub(2);
+                        // Only forward if cursor is inside pane content area
+                        if mouse.column >= inner_x
+                            && mouse.column < inner_x + inner_w
+                            && mouse.row >= inner_y
+                            && mouse.row < inner_y + inner_h
+                        {
+                            if let Some(encoded) =
+                                crate::mouse_forward::encode_sgr(&mouse, inner_x, inner_y)
+                            {
+                                super::write_to_focused(
+                                    &crate::home_dir(),
+                                    layout,
+                                    registry,
+                                    &encoded,
+                                );
+                                return out;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     match mouse.kind {
         MouseEventKind::ScrollUp => super::scroll_focused(layout, 3),
         MouseEventKind::ScrollDown => super::scroll_focused(layout, -3),

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod keybinds;
 mod layout;
 mod mcp;
 mod mcp_config;
+mod mouse_forward;
 mod notification_queue;
 mod paths;
 mod process;

--- a/src/mouse_forward.rs
+++ b/src/mouse_forward.rs
@@ -1,0 +1,88 @@
+//! SGR mouse event encoder — converts crossterm MouseEvent to xterm SGR format.
+//! Used to forward mouse events to backends that enable mouse tracking.
+
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+/// Encode a crossterm MouseEvent as SGR mouse report bytes.
+/// `pane_col`/`pane_row` are the pane's top-left offset (subtracted from event coords).
+/// Returns None if the event kind is not forwardable.
+pub fn encode_sgr(event: &MouseEvent, pane_col: u16, pane_row: u16) -> Option<Vec<u8>> {
+    let x = event.column.saturating_sub(pane_col) + 1; // 1-based
+    let y = event.row.saturating_sub(pane_row) + 1;
+
+    let (button, suffix) = match event.kind {
+        MouseEventKind::Down(btn) => (button_code(btn), 'M'),
+        MouseEventKind::Up(btn) => (button_code(btn), 'm'),
+        MouseEventKind::Drag(btn) => (button_code(btn) + 32, 'M'),
+        MouseEventKind::ScrollUp => (64, 'M'),
+        MouseEventKind::ScrollDown => (65, 'M'),
+        MouseEventKind::ScrollLeft => (66, 'M'),
+        MouseEventKind::ScrollRight => (67, 'M'),
+        MouseEventKind::Moved => (35, 'M'), // motion with no button
+    };
+
+    Some(format!("\x1b[<{button};{x};{y}{suffix}").into_bytes())
+}
+
+fn button_code(btn: MouseButton) -> u8 {
+    match btn {
+        MouseButton::Left => 0,
+        MouseButton::Middle => 1,
+        MouseButton::Right => 2,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_sgr_left_click() {
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        };
+        let result = encode_sgr(&event, 0, 0).unwrap();
+        assert_eq!(result, b"\x1b[<0;11;6M");
+    }
+
+    #[test]
+    fn encode_sgr_scroll_up() {
+        let event = MouseEvent {
+            kind: MouseEventKind::ScrollUp,
+            column: 3,
+            row: 2,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        };
+        let result = encode_sgr(&event, 0, 0).unwrap();
+        assert_eq!(result, b"\x1b[<64;4;3M");
+    }
+
+    #[test]
+    fn encode_sgr_with_pane_offset() {
+        let event = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Right),
+            column: 15,
+            row: 10,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        };
+        let result = encode_sgr(&event, 5, 3).unwrap();
+        // x = 15-5+1 = 11, y = 10-3+1 = 8
+        assert_eq!(result, b"\x1b[<2;11;8M");
+    }
+
+    #[test]
+    fn encode_sgr_button_release() {
+        let event = MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: 1,
+            row: 1,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        };
+        let result = encode_sgr(&event, 0, 0).unwrap();
+        assert_eq!(result, b"\x1b[<0;2;2m"); // lowercase m for release
+    }
+}

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -267,6 +267,16 @@ impl VTerm {
         }
     }
 
+    /// Returns true if the terminal application has enabled mouse reporting.
+    pub fn wants_mouse(&self) -> bool {
+        self.term.mode().contains(term::TermMode::MOUSE_MODE)
+    }
+
+    /// Returns true if SGR mouse encoding is active (CSI < format).
+    pub fn mouse_sgr(&self) -> bool {
+        self.term.mode().contains(term::TermMode::SGR_MOUSE)
+    }
+
     /// Maximum scroll offset (history size).
     pub fn max_scroll(&self) -> usize {
         use alacritty_terminal::grid::Dimensions;


### PR DESCRIPTION
Reverts strip approach. Implements SGR mouse forwarding to PTY when backend enables mouse tracking. Shift = local override.

Closes #700