### PR TITLE
fix(#700): wants_mouse uses intersects, not contains

### DIFF
--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -268,8 +268,12 @@ impl VTerm {
     }
 
     /// Returns true if the terminal application has enabled mouse reporting.
+    /// Uses `intersects` because alacritty_terminal stores the three mouse-mode
+    /// bits (1000/1002/1003) as mutually-exclusive (each `[?1xxxh]` removes the
+    /// whole MOUSE_MODE set first, then inserts one bit). `contains` would
+    /// require all three bits and therefore never fire.
     pub fn wants_mouse(&self) -> bool {
-        self.term.mode().contains(term::TermMode::MOUSE_MODE)
+        self.term.mode().intersects(term::TermMode::MOUSE_MODE)
     }
 
     /// Returns true if SGR mouse encoding is active (CSI < format).
@@ -1101,5 +1105,43 @@ mod tests {
         let vt = VTerm::new(80, 24);
         let text = vt.read_scrollback(100);
         assert!(text.is_empty(), "empty PTY must return empty string");
+    }
+
+    // #700 regression guard: alacritty_terminal stores mouse-mode bits
+    // (1000/1002/1003) as mutually-exclusive. `contains(MOUSE_MODE)` requires
+    // all three bits and therefore never fires for real backends, which is
+    // exactly the bug that let mouse forwarding silently skip every event.
+    #[test]
+    fn wants_mouse_detects_single_mouse_mode_bit() {
+        for seq in [
+            b"\x1b[?1000h".as_slice(), // click reporting
+            b"\x1b[?1002h",            // button-event tracking
+            b"\x1b[?1003h",            // any-motion tracking
+        ] {
+            let mut vt = VTerm::new(80, 24);
+            vt.process(seq);
+            assert!(
+                vt.wants_mouse(),
+                "wants_mouse must be true after {:?}",
+                std::str::from_utf8(seq).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn wants_mouse_matches_opencode_startup_sequence() {
+        // Exact sequence from tests/fixtures/state-replay/opencode-thinking.raw
+        let mut vt = VTerm::new(80, 24);
+        vt.process(b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h");
+        assert!(vt.wants_mouse(), "wants_mouse must be true after opencode startup");
+        assert!(vt.mouse_sgr(), "mouse_sgr must be true after 1006h");
+    }
+
+    #[test]
+    fn wants_mouse_false_without_mouse_mode() {
+        let mut vt = VTerm::new(80, 24);
+        vt.process(b"plain text \x1b[31mred\x1b[0m");
+        assert!(!vt.wants_mouse());
+        assert!(!vt.mouse_sgr());
     }
 }

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -1133,7 +1133,10 @@ mod tests {
         // Exact sequence from tests/fixtures/state-replay/opencode-thinking.raw
         let mut vt = VTerm::new(80, 24);
         vt.process(b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h");
-        assert!(vt.wants_mouse(), "wants_mouse must be true after opencode startup");
+        assert!(
+            vt.wants_mouse(),
+            "wants_mouse must be true after opencode startup"
+        );
         assert!(vt.mouse_sgr(), "mouse_sgr must be true after 1006h");
     }
 

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -1123,7 +1123,7 @@ mod tests {
             assert!(
                 vt.wants_mouse(),
                 "wants_mouse must be true after {:?}",
-                std::str::from_utf8(seq).unwrap()
+                String::from_utf8_lossy(seq)
             );
         }
     }


### PR DESCRIPTION
## Summary

PR #741's `wants_mouse()` check is permanently false against real backends — the SGR mouse-forwarding gate it guards therefore never fires, leaving OpenCode mouse scroll broken identically to the pre-#741 state.

Root cause: `mode.contains(MOUSE_MODE)` requires **all three** bits (`MOUSE_REPORT_CLICK | MOUSE_DRAG | MOUSE_MOTION`). But alacritty_terminal stores those as **mutually exclusive** — each `\x1b[?1000h` / `\x1b[?1002h` / `\x1b[?1003h` calls `mode.remove(MOUSE_MODE)` before inserting exactly one bit (see `alacritty_terminal-0.26.0/src/term/mod.rs:1953-1968`). So at most one of the three is ever set at a time.

Fix: `contains` → `intersects` (one-character change).

## Why #741 tests didn't catch it

`mouse_forward.rs` tests only covered the SGR encoder in isolation. There was no end-to-end check feeding real mouse-mode sequences through the vterm and asserting `wants_mouse()` flips on.

This PR adds three regression tests for that:
- Each individual bit (1000 / 1002 / 1003)
- The exact OpenCode startup sequence (`[?1000h][?1002h][?1003h][?1006h]`)
- The negative case (no mouse mode → false)

## Test plan

- [x] `cargo test --bins vterm::` — 38 tests pass including 3 new regression tests
- [ ] Manual smoke: wheel scroll inside an OpenCode pane → chat history scrolls
- [ ] Manual smoke: wheel scroll inside a non-mouse-mode backend (e.g. claude-code) → local scrollback still works (forwarding gate skipped)

Refs: #700, #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)