### PR TITLE
docs(protocol): §3.10 — require empirical reproduction test in fix PRs

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL-v1.md
+++ b/docs/FLEET-DEV-PROTOCOL-v1.md
@@ -86,6 +86,7 @@ Additional: wire-format invariant tests (pin shape); production-path-coupled (no
 
 ### 3.10 Test-first
 Feature/fix PRs must be test-first: failing test commit BEFORE impl commit.
+- Every fix PR MUST include an empirical reproduction test case. Reviewers MUST verify the presence and validity of this test.
 - Reviewer verifies: `git checkout <test-sha>` fails → `HEAD` passes
 - Exemptions: docs-only, pure refactor, test-only, dep bump, EMERGENCY, pure deletion, empirical-revert
 


### PR DESCRIPTION
## Why

§3.10 Test-first currently says \"failing test commit BEFORE impl commit\" — but the rule is silent on **what makes a test count**. A reviewer can technically pass §3.10 by approving a fix PR where the test exercises an adjacent code path but doesn't actually reproduce the reported bug. \"I tested it locally\" then stands in for a regression guard.

This 1-line addition formalizes the implicit expectation: the test must **empirically reproduce** the original failure, and the reviewer's job is to verify that.

## What

Adds one bullet to FLEET-DEV-PROTOCOL §3.10 Test-first:

> Every fix PR MUST include an empirical reproduction test case. Reviewers MUST verify the presence and validity of this test.

No code change. No other doc change.

## Source

This line was drafted on a now-deleted `dev-gemini` worktree (`fix/643-protocol-test-enforcement`) but never got committed before the dev-team teardown. The proposal predates the teardown and is being brought forward under a fresh branch as part of the dev-team worktree cleanup audit (2026-05-13).

## Test plan

- [ ] Verify the wording integrates cleanly with surrounding §3.10 rules
- [ ] Confirm `MUST` capitalization matches the rest of the protocol doc convention