### PR TITLE
test(#743): split test_crash_respawn_health predicate into spawn + health-flip phases

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -325,6 +325,10 @@ fn test_api_rejects_connection_with_wrong_cookie() {
     daemon.stop();
 }
 
+#[cfg_attr(
+    windows,
+    ignore = "tracking #749: daemon respawn loop on cmd.exe + ConPTY"
+)]
 #[test]
 fn test_crash_respawn_health() {
     let mut daemon = TestDaemon::start("crash");
@@ -366,6 +370,10 @@ fn test_crash_respawn_health() {
     // backends go Starting→Ready, so Phase 1 budget may need recalibration if
     // pattern reused there. Single-kill test: no monotonic Recovering↔Healthy
     // flicker possible; multi-kill extension must re-evaluate Phase 2 budget.
+    //
+    // Windows note: cmd.exe + ConPTY EOF triggers a 5-20s respawn cycle.
+    // SPAWN_TIMEOUT must exceed max backoff to produce a stable diagnostic
+    // panic should this test be re-enabled on Windows. Tracked in #749.
     const SPAWN_TIMEOUT: Duration = Duration::from_secs(28);
     const HEALTH_FLIP_TIMEOUT: Duration = Duration::from_secs(2);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -360,33 +360,82 @@ fn test_crash_respawn_health() {
         );
     }
 
-    // Wait for respawn (poll instead of hard 8s sleep)
-    assert!(
-        wait_until(
-            || {
-                let r = daemon.api_call(&serde_json::json!({"method": "list"}));
-                r["result"]["agents"]
-                    .as_array()
-                    .map(|a| a.len() == 1 && a[0]["health_state"] == "healthy")
-                    .unwrap_or(false)
-            },
-            Duration::from_secs(30)
-        ),
-        "agent did not respawn within 30s"
-    );
+    // Lifecycle: kill → restarting → (process up + registry handle insert) → Ready
+    //            → (respawn_ok lock window, sub-ms in-memory flip) → Healthy.
+    // Note: Shell backend initial state = Ready (src/state.rs:625-628) — managed
+    // backends go Starting→Ready, so Phase 1 budget may need recalibration if
+    // pattern reused there. Single-kill test: no monotonic Recovering↔Healthy
+    // flicker possible; multi-kill extension must re-evaluate Phase 2 budget.
+    const SPAWN_TIMEOUT: Duration = Duration::from_secs(28);
+    const HEALTH_FLIP_TIMEOUT: Duration = Duration::from_secs(2);
 
-    // Agent should be back
+    let phase_start = Instant::now();
+
+    // Phase 1: process up + new registry handle inserted → agent_state == "ready"
+    if !wait_until(
+        || {
+            let r = daemon.api_call(&serde_json::json!({"method": "list"}));
+            r["result"]["agents"]
+                .as_array()
+                .and_then(|a| a.first())
+                .and_then(|a| a["agent_state"].as_str())
+                .map(|s| s == "ready")
+                .unwrap_or(false)
+        },
+        SPAWN_TIMEOUT,
+    ) {
+        let r = daemon.api_call(&serde_json::json!({"method": "list"}));
+        let agents = r["result"]["agents"].as_array();
+        let first = agents.and_then(|a| a.first());
+        panic!(
+            "phase 1 (agent_state == 'ready') not satisfied within 28s. \
+             last: count={}, agent_state={:?}, health_state={:?}",
+            agents.map(|a| a.len()).unwrap_or(0),
+            first.and_then(|a| a["agent_state"].as_str()).unwrap_or("?"),
+            first
+                .and_then(|a| a["health_state"].as_str())
+                .unwrap_or("?"),
+        );
+    }
+    let phase1_elapsed = phase_start.elapsed();
+
+    // Phase 2: respawn_ok flips Recovering → Healthy. Guard against transient
+    // ready+recovering window between spawn_agent insert and respawn_ok lock
+    // reacquire (src/daemon/mod.rs:889-902).
+    if !wait_until(
+        || {
+            let r = daemon.api_call(&serde_json::json!({"method": "list"}));
+            r["result"]["agents"]
+                .as_array()
+                .and_then(|a| a.first())
+                .map(|a| {
+                    a["agent_state"].as_str() == Some("ready")
+                        && a["health_state"].as_str() == Some("healthy")
+                })
+                .unwrap_or(false)
+        },
+        HEALTH_FLIP_TIMEOUT,
+    ) {
+        let r = daemon.api_call(&serde_json::json!({"method": "list"}));
+        let agents = r["result"]["agents"].as_array();
+        let first = agents.and_then(|a| a.first());
+        panic!(
+            "phase 2 (ready + healthy) not satisfied within 2s. \
+             phase1_elapsed={:?}, last: count={}, agent_state={:?}, health_state={:?}",
+            phase1_elapsed,
+            agents.map(|a| a.len()).unwrap_or(0),
+            first.and_then(|a| a["agent_state"].as_str()).unwrap_or("?"),
+            first
+                .and_then(|a| a["health_state"].as_str())
+                .unwrap_or("?"),
+        );
+    }
+
+    // Identity check — second api_call is necessary (wait_until returns bool).
     let resp = daemon.api_call(&serde_json::json!({"method": "list"}));
     let agents = resp["result"]["agents"].as_array().expect("a");
-    assert_eq!(agents.len(), 1, "agent should have respawned");
-    assert_eq!(agents[0]["name"], "shell");
-
-    // Health state should be healthy (respawn_ok called)
-    let health = agents[0]["health_state"].as_str().unwrap_or("");
-    assert_eq!(
-        health, "healthy",
-        "health should be healthy after respawn_ok"
-    );
+    let first = agents.first().expect("agent should have respawned");
+    assert_eq!(first["name"], "shell");
 
     daemon.stop();
 }


### PR DESCRIPTION
Closes #743

Decision: `d-20260513151150561341-1` (supersedes `d-20260513144554112398-0`); three-party consensus: lead-claude + dev-claude + reviewer-opencode.

## Summary
- Follow-up to #742 (12s → 30s CI flake band-aid). Refactor `test_crash_respawn_health` for diagnostic quality — 30s total budget unchanged.
- Split the conflated `len() == 1 && healthy` predicate into two phases with separate timeouts and structured failure dumps.
- Drop redundant duplicate-health assertion and `len() == 1` check.
- **Windows: test excluded** pending fix of separately tracked daemon respawn loop (#749).

## Why the original split (from issue #743) didn't work as written
The issue proposed splitting Phase 1 on `agents.len() == 1` and Phase 2 on `health_state == "healthy"`. Code evidence: `handle_kill` (src/api/handlers/instance.rs:55-90) does NOT remove from registry — only sets `Restarting` state + kills process. `handle_list` (src/api/handlers/query.rs:10-46) iterates registry with no `agent_state` filter. So `len() == 1` is invariantly true during the entire kill→respawn window — the proposed Phase 1 would have been a no-op.

This PR uses `agent_state == "ready"` for Phase 1 instead, which is what actually flips when `spawn_agent` writes the new handle into the registry.

## Changes
- **Phase 1 (28s, SPAWN_TIMEOUT)**: `agent_state == "ready"` — process up + new registry handle inserted.
- **Phase 2 (2s, HEALTH_FLIP_TIMEOUT)**: `agent_state == "ready" && health_state == "healthy"` — `respawn_ok` (src/daemon/mod.rs:901) is a sub-ms in-memory `Recovering → Healthy` flip. AND-guard catches the transient `ready + recovering` window in the lock release/reacquire gap (src/daemon/mod.rs:889-902).
- **Structured panics**: Both `wait_until` timeouts now panic with `count + agent_state + health_state`. Phase 2 panic additionally dumps `phase1_elapsed` to reveal whether spawn was slow or health-flip stalled.
- **Const-at-top with lifecycle comment** encoding the Shell-backend caveat (initial state = Ready per src/state.rs:625-628) + single-kill assumption + Windows note (SPAWN_TIMEOUT must exceed max backoff).
- **Drop line 381** `assert_eq!(agents.len(), 1, ...)` — Phase 1 `.first()` access implies `len() >= 1`; single-agent daemon, so `== 1` and `>= 1` coincide.
- **Drop lines 385-389** duplicate `assert_eq!(health, "healthy")` — Phase 2 `wait_until` already verified this.

## Windows excluded
`test_crash_respawn_health` is `#[cfg_attr(windows, ignore = "...")]` on Windows pending #749. Root cause is daemon-side, not test-side: `cmd.exe` + ConPTY EOF causes an infinite respawn cycle (the new PTY reader hits EOF immediately after `spawn_agent` insert, triggering `set_restarting` on the fresh handle and emitting another Crash event). Real Windows backends (claude, kiro-cli, codex, opencode, gemini) maintain stdin/stdout under PTY and are unaffected — this is an unsupported test combo (Windows + bare `cmd.exe` + crash respawn), not a production bug.

The structured-panic diagnostics this PR added are what surfaced the issue — the previous `len()==1 && healthy` predicate masked it because the daemon eventually re-runs `respawn_ok` mid-cycle, hitting a sub-100ms `healthy` flicker window.

`#[cfg_attr(windows, ignore = ...)]` (not `#[cfg(not(windows))]`) keeps the test discoverable on Windows builds via `cargo test --list --ignored` so a maintainer fixing the daemon side can re-enable it.

## Out of scope
- `wait_until` signature change (Option<Value>) — scope creep across many tests.
- Tracing per-poll inside `wait_until` — issue's "Optional polish", deferred to a separate PR. (Structured panics already delivered the diagnostic value: this very CI cycle surfaced #749.)
- `test_fleet_multi_agent_lifecycle` — does not check health, no split need; #742's 30s bump is sufficient.
- Fixing the daemon-side respawn loop — separate concern, tracked in #749.

scope: follows revised spec (decision `d-20260513151150561341-1`), Windows exclusion only (§4.1 push-time semantic gate).

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --test integration test_crash_respawn_health` passes locally on macOS (~10.9s)
- [x] PR @ 3478e0c CI: ubuntu ✓, macOS ✓, audit ✓, LOC overrun ✓ (windows fail exposed #749)
- [ ] PR @ efe8c61 CI: expect all platforms green (windows now ignored)
- [ ] 2 consecutive greens on main post-merge (acceptance via pragmatic compromise per decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)