### PR TITLE
feat(#704 sub-1): passive PTY capture helper — sink, rotate, promote CLI

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -583,13 +583,13 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         shutdown: shutdown_for_reaper,
         deleted: deleted_for_reaper,
     };
-    let capture_sink = home.as_deref().and_then(|h| {
+    let capture = {
         let backend_str = detected_backend
             .as_ref()
             .map(|b| b.name())
             .unwrap_or(backend_command);
-        crate::capture::CaptureSink::new_if_enabled(h, name, backend_str)
-    });
+        crate::capture::make_capture_writer(home.as_deref(), name, backend_str)
+    };
     // fire-and-forget: pty_read_loop terminates on PTY EOF, which fires when
     // the child process is killed during shutdown / delete. JoinHandle is
     // discarded because the loop's exit is signalled via the OS-side PTY
@@ -597,7 +597,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
     std::thread::Builder::new()
         .name(format!("{n}_pty_read"))
         .spawn(move || {
-            pty_read_loop(&mut pty_reader, &ctx, capture_sink);
+            pty_read_loop(&mut pty_reader, &ctx, capture);
         })?;
 
     // Backends whose CLI does not auto-load the instructions file (e.g. Kiro)
@@ -755,7 +755,7 @@ struct PtyReadContext {
 fn pty_read_loop(
     pty_reader: &mut dyn Read,
     ctx: &PtyReadContext,
-    mut capture_sink: Option<crate::capture::CaptureSink>,
+    mut capture: Box<dyn crate::capture::CaptureWriter + Send>,
 ) {
     let PtyReadContext {
         name,
@@ -805,9 +805,7 @@ fn pty_read_loop(
                 }
                 let data = &buf[..n_bytes];
 
-                if let Some(sink) = capture_sink.as_mut() {
-                    sink.write(data);
-                }
+                capture.write(data);
 
                 // Feed VTerm + state detection + broadcast (under same lock = atomic),
                 // then scan the rendered screen for dismiss patterns. Scanning

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -583,6 +583,13 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         shutdown: shutdown_for_reaper,
         deleted: deleted_for_reaper,
     };
+    let capture_sink = home.as_deref().and_then(|h| {
+        let backend_str = detected_backend
+            .as_ref()
+            .map(|b| b.name())
+            .unwrap_or(backend_command);
+        crate::capture::CaptureSink::new_if_enabled(h, name, backend_str)
+    });
     // fire-and-forget: pty_read_loop terminates on PTY EOF, which fires when
     // the child process is killed during shutdown / delete. JoinHandle is
     // discarded because the loop's exit is signalled via the OS-side PTY
@@ -590,7 +597,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
     std::thread::Builder::new()
         .name(format!("{n}_pty_read"))
         .spawn(move || {
-            pty_read_loop(&mut pty_reader, &ctx);
+            pty_read_loop(&mut pty_reader, &ctx, capture_sink);
         })?;
 
     // Backends whose CLI does not auto-load the instructions file (e.g. Kiro)
@@ -745,7 +752,11 @@ struct PtyReadContext {
 }
 
 /// PTY read loop: feeds VTerm, broadcasts output, auto-dismisses dialogs, handles exit.
-fn pty_read_loop(pty_reader: &mut dyn Read, ctx: &PtyReadContext) {
+fn pty_read_loop(
+    pty_reader: &mut dyn Read,
+    ctx: &PtyReadContext,
+    mut capture_sink: Option<crate::capture::CaptureSink>,
+) {
     let PtyReadContext {
         name,
         core,
@@ -793,6 +804,10 @@ fn pty_read_loop(pty_reader: &mut dyn Read, ctx: &PtyReadContext) {
                     );
                 }
                 let data = &buf[..n_bytes];
+
+                if let Some(sink) = capture_sink.as_mut() {
+                    sink.write(data);
+                }
 
                 // Feed VTerm + state detection + broadcast (under same lock = atomic),
                 // then scan the rendered screen for dismiss patterns. Scanning

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -9,8 +9,8 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-/// Maximum cumulative .cap size per agent before oldest files are rotated out.
-const MAX_BYTES_PER_AGENT: u64 = 50 * 1024 * 1024;
+/// Cumulative .cap budget per agent; oldest files deleted when exceeded.
+const CAPTURE_ROTATION_BUDGET_BYTES: u64 = 50 * 1024 * 1024;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct CaptureMeta {
@@ -99,13 +99,13 @@ fn rotate_captures(dir: &Path) {
         })
         .collect();
     let total: u64 = files.iter().map(|(_, s)| s).sum();
-    if total < MAX_BYTES_PER_AGENT {
+    if total < CAPTURE_ROTATION_BUDGET_BYTES {
         return;
     }
     files.sort_by(|(a, _), (b, _)| a.cmp(b)); // oldest-first via epoch prefix
     let mut remaining = total;
     for (path, size) in files {
-        if remaining < MAX_BYTES_PER_AGENT {
+        if remaining < CAPTURE_ROTATION_BUDGET_BYTES {
             break;
         }
         let sidecar = {
@@ -206,8 +206,8 @@ mod tests {
     fn rotate_removes_oldest_when_over_limit() {
         let dir = tmp_dir("rotate");
         std::fs::create_dir_all(&dir).unwrap();
-        // Write 3 fake .cap files totalling > MAX_BYTES_PER_AGENT
-        let big = vec![0u8; (MAX_BYTES_PER_AGENT / 2 + 1) as usize];
+        // Write 3 fake .cap files totalling > CAPTURE_ROTATION_BUDGET_BYTES
+        let big = vec![0u8; (CAPTURE_ROTATION_BUDGET_BYTES / 2 + 1) as usize];
         for epoch in [1000u64, 2000, 3000] {
             std::fs::write(dir.join(format!("{epoch}.cap")), &big).unwrap();
         }
@@ -217,12 +217,15 @@ mod tests {
             .flatten()
             .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("cap"))
             .collect();
-        // After rotation, total must be < MAX_BYTES_PER_AGENT
+        // After rotation, total must be < CAPTURE_ROTATION_BUDGET_BYTES
         let total: u64 = remaining
             .iter()
             .map(|e| e.path().metadata().map(|m| m.len()).unwrap_or(0))
             .sum();
-        assert!(total < MAX_BYTES_PER_AGENT, "total={total} must be < limit");
+        assert!(
+            total < CAPTURE_ROTATION_BUDGET_BYTES,
+            "total={total} must be < limit"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -6,11 +6,31 @@
 //!
 //! `promote_capture` copies a chosen .cap into `tests/fixtures/<backend>/`.
 
-use std::io::Write;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 /// Cumulative .cap budget per agent; oldest files deleted when exceeded.
 const CAPTURE_ROTATION_BUDGET_BYTES: u64 = 50 * 1024 * 1024;
+
+// ── Trait ──────────────────────────────────────────────────────────────────
+
+/// Abstraction over the PTY byte sink so `pty_read_loop` can call `.write()`
+/// unconditionally without an `Option` branch.
+pub trait CaptureWriter: Send {
+    fn write(&mut self, data: &[u8]);
+}
+
+/// Zero-sized no-op: produced when `AGEND_CAPTURE_FIXTURES` is unset.
+/// `Box<NoOpCapture>` does not allocate (ZST optimisation).
+pub struct NoOpCapture;
+
+impl CaptureWriter for NoOpCapture {
+    #[inline(always)]
+    fn write(&mut self, _data: &[u8]) {}
+}
+
+// ── Real sink ──────────────────────────────────────────────────────────────
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct CaptureMeta {
@@ -32,17 +52,15 @@ pub struct CaptureSink {
 }
 
 impl CaptureSink {
-    /// Create capture dir, rotate if needed, open a new .cap file.
-    /// Returns `None` if the env flag is off or directory/file creation fails.
-    pub fn new_if_enabled(home: &Path, agent_name: &str, backend: &str) -> Option<Self> {
+    fn new_if_enabled(home: &Path, agent_name: &str, backend: &str) -> Option<Self> {
         if std::env::var("AGEND_CAPTURE_FIXTURES").as_deref() != Ok("1") {
             return None;
         }
         let dir = home.join("captures").join(agent_name);
         std::fs::create_dir_all(&dir).ok()?;
         rotate_captures(&dir);
-        let epoch_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
+        let epoch_ms = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis();
         let cap_path = dir.join(format!("{epoch_ms}.cap"));
@@ -61,8 +79,10 @@ impl CaptureSink {
             byte_count: 0,
         })
     }
+}
 
-    pub fn write(&mut self, data: &[u8]) {
+impl CaptureWriter for CaptureSink {
+    fn write(&mut self, data: &[u8]) {
         if self.file.write_all(data).is_ok() {
             self.byte_count += data.len() as u64;
         }
@@ -79,33 +99,65 @@ impl Drop for CaptureSink {
             byte_count: self.byte_count,
         };
         if let Ok(json) = serde_json::to_string_pretty(&meta) {
+            // IO errors on drop are silently discarded — never propagate.
             let _ = std::fs::write(&self.meta_path, json);
         }
     }
 }
 
-/// Delete oldest .cap files (and their sidecars) until total is below limit.
+// ── Factory ────────────────────────────────────────────────────────────────
+
+/// Return a `FsCapture` when `AGEND_CAPTURE_FIXTURES=1`, else a `NoOpCapture`.
+/// The caller unconditionally calls `.write()` — no branch on the hot path.
+pub fn make_capture_writer(
+    home: Option<&Path>,
+    agent_name: &str,
+    backend: &str,
+) -> Box<dyn CaptureWriter + Send> {
+    home.and_then(|h| CaptureSink::new_if_enabled(h, agent_name, backend))
+        .map(|s| Box::new(s) as Box<dyn CaptureWriter + Send>)
+        .unwrap_or_else(|| Box::new(NoOpCapture))
+}
+
+// ── Rotation ───────────────────────────────────────────────────────────────
+
 fn rotate_captures(dir: &Path) {
-    let mut files: Vec<(PathBuf, u64)> = std::fs::read_dir(dir)
+    rotate_captures_with_budget(dir, CAPTURE_ROTATION_BUDGET_BYTES);
+}
+
+/// Delete oldest (by mtime) `.cap` files until total is below `budget`.
+/// Always keeps at least one file so an in-progress capture is never deleted.
+fn rotate_captures_with_budget(dir: &Path, budget: u64) {
+    let mut files: Vec<(PathBuf, u64, SystemTime)> = std::fs::read_dir(dir)
         .into_iter()
         .flatten()
         .flatten()
         .filter_map(|e| {
             let p = e.path();
-            (p.extension().and_then(|x| x.to_str()) == Some("cap")).then(|| {
-                let size = p.metadata().map(|m| m.len()).unwrap_or(0);
-                (p, size)
-            })
+            if p.extension().and_then(|x| x.to_str()) != Some("cap") {
+                return None;
+            }
+            let meta = p.metadata().ok()?;
+            let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            Some((p, meta.len(), mtime))
         })
         .collect();
-    let total: u64 = files.iter().map(|(_, s)| s).sum();
-    if total < CAPTURE_ROTATION_BUDGET_BYTES {
+
+    if files.len() <= 1 {
         return;
     }
-    files.sort_by(|(a, _), (b, _)| a.cmp(b)); // oldest-first via epoch prefix
+
+    let total: u64 = files.iter().map(|(_, s, _)| s).sum();
+    if total < budget {
+        return;
+    }
+
+    files.sort_by_key(|(_, _, mtime)| *mtime); // oldest-first
+
     let mut remaining = total;
-    for (path, size) in files {
-        if remaining < CAPTURE_ROTATION_BUDGET_BYTES {
+    let mut files_left = files.len();
+    for (path, size, _) in &files {
+        if remaining < budget || files_left <= 1 {
             break;
         }
         let sidecar = {
@@ -113,11 +165,14 @@ fn rotate_captures(dir: &Path) {
             s.push(".meta.json");
             PathBuf::from(s)
         };
-        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path);
         let _ = std::fs::remove_file(&sidecar);
-        remaining = remaining.saturating_sub(size);
+        remaining = remaining.saturating_sub(*size);
+        files_left -= 1;
     }
 }
+
+// ── Promote ────────────────────────────────────────────────────────────────
 
 /// Copy `capture_path` to `tests/fixtures/<backend>/<scenario_name>.cap`.
 ///
@@ -148,18 +203,22 @@ pub fn promote_capture(capture_path: &Path, scenario_name: &str) -> anyhow::Resu
     Ok(())
 }
 
+// ── Tests ──────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
-    fn tmp_dir(tag: &str) -> std::path::PathBuf {
+    fn tmp_dir(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("agend-capture-unit-{tag}"));
         std::fs::create_dir_all(&dir).unwrap();
         dir
     }
 
     #[test]
+    #[serial(capture_env)]
     fn sink_none_when_env_unset() {
         std::env::remove_var("AGEND_CAPTURE_FIXTURES");
         let dir = tmp_dir("none");
@@ -168,6 +227,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(capture_env)]
     fn sink_creates_cap_and_meta_on_drop() {
         let dir = tmp_dir("create");
         std::env::set_var("AGEND_CAPTURE_FIXTURES", "1");
@@ -203,29 +263,42 @@ mod tests {
     }
 
     #[test]
-    fn rotate_removes_oldest_when_over_limit() {
-        let dir = tmp_dir("rotate");
-        std::fs::create_dir_all(&dir).unwrap();
-        // Write 3 fake .cap files totalling > CAPTURE_ROTATION_BUDGET_BYTES
-        let big = vec![0u8; (CAPTURE_ROTATION_BUDGET_BYTES / 2 + 1) as usize];
-        for epoch in [1000u64, 2000, 3000] {
-            std::fs::write(dir.join(format!("{epoch}.cap")), &big).unwrap();
-        }
-        rotate_captures(&dir);
-        let remaining: Vec<_> = std::fs::read_dir(&dir)
-            .unwrap()
-            .flatten()
-            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("cap"))
-            .collect();
-        // After rotation, total must be < CAPTURE_ROTATION_BUDGET_BYTES
-        let total: u64 = remaining
-            .iter()
-            .map(|e| e.path().metadata().map(|m| m.len()).unwrap_or(0))
-            .sum();
+    fn rotate_keeps_single_file_even_over_budget() {
+        let dir = tmp_dir("rotate-single");
+        std::fs::write(dir.join("1000.cap"), b"big").unwrap();
+        rotate_captures_with_budget(&dir, 1); // budget=1 byte, file is 3 bytes
         assert!(
-            total < CAPTURE_ROTATION_BUDGET_BYTES,
-            "total={total} must be < limit"
+            dir.join("1000.cap").exists(),
+            "must not delete last remaining file"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rotate_deletes_oldest_by_mtime_not_name() {
+        let dir = tmp_dir("rotate-mtime");
+        // "9000.cap" created first (older mtime), "1000.cap" created second (newer).
+        // Alphabetically "1000" < "9000", so old sort-by-name would delete the
+        // wrong file. Mtime sort must delete "9000.cap".
+        std::fs::write(dir.join("9000.cap"), b"aaa").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(dir.join("1000.cap"), b"bbb").unwrap();
+        // budget = 5 bytes, total = 6 bytes → need to delete one
+        rotate_captures_with_budget(&dir, 5);
+        assert!(
+            !dir.join("9000.cap").exists(),
+            "oldest by mtime must be deleted"
+        );
+        assert!(
+            dir.join("1000.cap").exists(),
+            "newest by mtime must survive"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn noop_capture_writer_is_zero_cost() {
+        let mut noop = NoOpCapture;
+        noop.write(b"ignored");
     }
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,0 +1,228 @@
+//! Passive PTY capture for growing the fixture corpus (issue #704).
+//!
+//! Activated by `AGEND_CAPTURE_FIXTURES=1`; zero overhead when unset.
+//! Captures land in `$AGEND_HOME/captures/<agent>/<epoch_ms>.cap` with a
+//! companion `<epoch_ms>.cap.meta.json` sidecar written on drop.
+//!
+//! `promote_capture` copies a chosen .cap into `tests/fixtures/<backend>/`.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Maximum cumulative .cap size per agent before oldest files are rotated out.
+const MAX_BYTES_PER_AGENT: u64 = 50 * 1024 * 1024;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct CaptureMeta {
+    pub backend: String,
+    pub agent_name: String,
+    pub started_at: String,
+    pub ended_at: String,
+    pub byte_count: u64,
+}
+
+/// Open-file capture sink. Writes raw PTY bytes; flushes meta sidecar on drop.
+pub struct CaptureSink {
+    file: std::fs::File,
+    meta_path: PathBuf,
+    agent_name: String,
+    backend: String,
+    started_at: String,
+    pub byte_count: u64,
+}
+
+impl CaptureSink {
+    /// Create capture dir, rotate if needed, open a new .cap file.
+    /// Returns `None` if the env flag is off or directory/file creation fails.
+    pub fn new_if_enabled(home: &Path, agent_name: &str, backend: &str) -> Option<Self> {
+        if std::env::var("AGEND_CAPTURE_FIXTURES").as_deref() != Ok("1") {
+            return None;
+        }
+        let dir = home.join("captures").join(agent_name);
+        std::fs::create_dir_all(&dir).ok()?;
+        rotate_captures(&dir);
+        let epoch_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        let cap_path = dir.join(format!("{epoch_ms}.cap"));
+        let meta_path = {
+            let mut s = cap_path.clone().into_os_string();
+            s.push(".meta.json");
+            PathBuf::from(s)
+        };
+        let file = std::fs::File::create(&cap_path).ok()?;
+        Some(Self {
+            file,
+            meta_path,
+            agent_name: agent_name.to_string(),
+            backend: backend.to_string(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+            byte_count: 0,
+        })
+    }
+
+    pub fn write(&mut self, data: &[u8]) {
+        if self.file.write_all(data).is_ok() {
+            self.byte_count += data.len() as u64;
+        }
+    }
+}
+
+impl Drop for CaptureSink {
+    fn drop(&mut self) {
+        let meta = CaptureMeta {
+            backend: self.backend.clone(),
+            agent_name: self.agent_name.clone(),
+            started_at: self.started_at.clone(),
+            ended_at: chrono::Utc::now().to_rfc3339(),
+            byte_count: self.byte_count,
+        };
+        if let Ok(json) = serde_json::to_string_pretty(&meta) {
+            let _ = std::fs::write(&self.meta_path, json);
+        }
+    }
+}
+
+/// Delete oldest .cap files (and their sidecars) until total is below limit.
+fn rotate_captures(dir: &Path) {
+    let mut files: Vec<(PathBuf, u64)> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            (p.extension().and_then(|x| x.to_str()) == Some("cap")).then(|| {
+                let size = p.metadata().map(|m| m.len()).unwrap_or(0);
+                (p, size)
+            })
+        })
+        .collect();
+    let total: u64 = files.iter().map(|(_, s)| s).sum();
+    if total < MAX_BYTES_PER_AGENT {
+        return;
+    }
+    files.sort_by(|(a, _), (b, _)| a.cmp(b)); // oldest-first via epoch prefix
+    let mut remaining = total;
+    for (path, size) in files {
+        if remaining < MAX_BYTES_PER_AGENT {
+            break;
+        }
+        let sidecar = {
+            let mut s = path.clone().into_os_string();
+            s.push(".meta.json");
+            PathBuf::from(s)
+        };
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&sidecar);
+        remaining = remaining.saturating_sub(size);
+    }
+}
+
+/// Copy `capture_path` to `tests/fixtures/<backend>/<scenario_name>.cap`.
+///
+/// Backend is read from the sidecar `.meta.json`. The destination path is
+/// relative to the current working directory (run from the project root).
+pub fn promote_capture(capture_path: &Path, scenario_name: &str) -> anyhow::Result<()> {
+    let meta_path = {
+        let mut s = capture_path.to_path_buf().into_os_string();
+        s.push(".meta.json");
+        PathBuf::from(s)
+    };
+    let meta_json = std::fs::read_to_string(&meta_path)
+        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", meta_path.display()))?;
+    let meta: CaptureMeta =
+        serde_json::from_str(&meta_json).map_err(|e| anyhow::anyhow!("invalid meta JSON: {e}"))?;
+
+    let dest_dir = PathBuf::from("tests/fixtures").join(&meta.backend);
+    std::fs::create_dir_all(&dest_dir)?;
+    let dest = dest_dir.join(format!("{scenario_name}.cap"));
+    std::fs::copy(capture_path, &dest)?;
+    println!(
+        "promoted: {} → {}  ({} bytes, backend={})",
+        capture_path.display(),
+        dest.display(),
+        meta.byte_count,
+        meta.backend,
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("agend-capture-unit-{tag}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn sink_none_when_env_unset() {
+        std::env::remove_var("AGEND_CAPTURE_FIXTURES");
+        let dir = tmp_dir("none");
+        assert!(CaptureSink::new_if_enabled(&dir, "a", "shell").is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn sink_creates_cap_and_meta_on_drop() {
+        let dir = tmp_dir("create");
+        std::env::set_var("AGEND_CAPTURE_FIXTURES", "1");
+        let mut sink = CaptureSink::new_if_enabled(&dir, "myagent", "claude").unwrap();
+        let data = b"test bytes";
+        sink.write(data);
+        assert_eq!(sink.byte_count, data.len() as u64);
+        drop(sink);
+        std::env::remove_var("AGEND_CAPTURE_FIXTURES");
+
+        let cap_dir = dir.join("captures").join("myagent");
+        let caps: Vec<_> = std::fs::read_dir(&cap_dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("cap"))
+            .collect();
+        assert_eq!(caps.len(), 1);
+        let cap_path = caps[0].path();
+        assert_eq!(std::fs::read(&cap_path).unwrap(), data);
+
+        let meta_path = PathBuf::from({
+            let mut s = cap_path.into_os_string();
+            s.push(".meta.json");
+            s
+        });
+        assert!(meta_path.exists());
+        let meta: CaptureMeta =
+            serde_json::from_str(&std::fs::read_to_string(meta_path).unwrap()).unwrap();
+        assert_eq!(meta.backend, "claude");
+        assert_eq!(meta.agent_name, "myagent");
+        assert_eq!(meta.byte_count, data.len() as u64);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rotate_removes_oldest_when_over_limit() {
+        let dir = tmp_dir("rotate");
+        std::fs::create_dir_all(&dir).unwrap();
+        // Write 3 fake .cap files totalling > MAX_BYTES_PER_AGENT
+        let big = vec![0u8; (MAX_BYTES_PER_AGENT / 2 + 1) as usize];
+        for epoch in [1000u64, 2000, 3000] {
+            std::fs::write(dir.join(format!("{epoch}.cap")), &big).unwrap();
+        }
+        rotate_captures(&dir);
+        let remaining: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("cap"))
+            .collect();
+        // After rotation, total must be < MAX_BYTES_PER_AGENT
+        let total: u64 = remaining
+            .iter()
+            .map(|e| e.path().metadata().map(|m| m.len()).unwrap_or(0))
+            .sum();
+        assert!(total < MAX_BYTES_PER_AGENT, "total={total} must be < limit");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! agend-terminal library surface.
+pub mod capture;
 pub mod sync_audit;
 
 /// Re-export for integration tests. The actual implementation lives in the

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod binding;
 mod bootstrap;
 mod bridge_client;
 mod bugreport;
+mod capture;
 mod channel;
 mod claim_verifier;
 mod cli;
@@ -266,14 +267,10 @@ enum Commands {
         #[command(subcommand)]
         command: AdminCommands,
     },
-    /// Capture backend output for debugging
+    /// Capture backend output or promote captures to fixtures
     Capture {
-        /// Backend name (claude, kiro-cli, codex, opencode, gemini)
-        #[arg(long)]
-        backend: String,
-        /// Capture duration in seconds
-        #[arg(long, default_value = "15")]
-        seconds: u64,
+        #[command(subcommand)]
+        action: CaptureAction,
     },
     /// E2E verification (use `--quick` for the lightweight subset)
     Verify {
@@ -354,6 +351,27 @@ enum AdminCommands {
         /// Actually delete branches (default is dry-run preview).
         #[arg(long)]
         yes: bool,
+    },
+}
+
+/// Issue #704: passive capture subcommands.
+#[derive(Subcommand)]
+enum CaptureAction {
+    /// Capture backend output for debugging (existing behaviour)
+    Backend {
+        /// Backend name (claude, kiro-cli, codex, opencode, gemini)
+        #[arg(long)]
+        backend: String,
+        /// Capture duration in seconds
+        #[arg(long, default_value = "15")]
+        seconds: u64,
+    },
+    /// Promote a passive capture to tests/fixtures/<backend>/<scenario>.cap
+    Promote {
+        /// Path to a .cap file (produced by AGEND_CAPTURE_FIXTURES=1)
+        capture_path: String,
+        /// Scenario name (becomes the file stem in tests/fixtures/)
+        scenario_name: String,
     },
 }
 
@@ -714,18 +732,26 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         },
-        Some(Commands::Capture { backend, seconds }) => {
-            let b: backend::Backend = serde_json::from_str(&format!("\"{backend}\""))
-                .unwrap_or_else(|_| {
-                    eprintln!("Unknown backend: {backend}");
+        Some(Commands::Capture { action }) => match action {
+            CaptureAction::Backend { backend, seconds } => {
+                let b: backend::Backend = serde_json::from_str(&format!("\"{backend}\""))
+                    .unwrap_or_else(|_| {
+                        eprintln!("Unknown backend: {backend}");
+                        std::process::exit(1);
+                    });
+                if !b.is_installed() {
+                    eprintln!("{} ({}) not found in PATH", backend, b.preset().command);
                     std::process::exit(1);
-                });
-            if !b.is_installed() {
-                eprintln!("{} ({}) not found in PATH", backend, b.preset().command);
-                std::process::exit(1);
+                }
+                cli::capture_backend(&b, seconds)?;
             }
-            cli::capture_backend(&b, seconds)?;
-        }
+            CaptureAction::Promote {
+                capture_path,
+                scenario_name,
+            } => {
+                capture::promote_capture(std::path::Path::new(&capture_path), &scenario_name)?;
+            }
+        },
         Some(Commands::Verify {
             json,
             backend,

--- a/tests/pty_capture.rs
+++ b/tests/pty_capture.rs
@@ -1,33 +1,31 @@
 //! Integration test for AGEND_CAPTURE_FIXTURES passive tee (issue #704).
 #![allow(clippy::unwrap_used)]
-//!
-//! Tests CaptureSink behaviour directly without requiring a running daemon.
-//! Gate the full spawn variant behind AGEND_LIVE_BACKEND_TEST=1.
 
+use agend_terminal::capture::make_capture_writer;
+use serial_test::serial;
 use std::path::PathBuf;
 
 fn tmp_home(tag: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("agend-capture-test-{tag}"));
+    let _ = std::fs::remove_dir_all(&dir); // clear any leftovers from previous run
     std::fs::create_dir_all(&dir).unwrap();
     dir
 }
 
 #[test]
-fn capture_sink_writes_cap_and_meta_when_env_set() {
-    let home = tmp_home("sink");
+#[serial(capture_env)]
+fn capture_writer_writes_cap_and_meta_when_env_set() {
+    let home = tmp_home("writer");
     let agent = "test-capture-agent";
     let backend = "shell";
 
     std::env::set_var("AGEND_CAPTURE_FIXTURES", "1");
-    let mut sink = agend_terminal::capture::CaptureSink::new_if_enabled(&home, agent, backend)
-        .expect("sink must be created when AGEND_CAPTURE_FIXTURES=1");
+    let mut writer = make_capture_writer(Some(&home), agent, backend);
 
     let payload = b"hello capture world\r\n";
-    sink.write(payload);
-    assert_eq!(sink.byte_count, payload.len() as u64);
+    writer.write(payload);
 
-    // Drop triggers meta sidecar flush.
-    drop(sink);
+    drop(writer);
     std::env::remove_var("AGEND_CAPTURE_FIXTURES");
 
     let cap_dir = home.join("captures").join(agent);
@@ -58,10 +56,16 @@ fn capture_sink_writes_cap_and_meta_when_env_set() {
 }
 
 #[test]
-fn capture_sink_is_none_when_env_unset() {
+#[serial(capture_env)]
+fn capture_writer_is_noop_when_env_unset() {
     std::env::remove_var("AGEND_CAPTURE_FIXTURES");
-    let home = tmp_home("no-sink");
-    let result = agend_terminal::capture::CaptureSink::new_if_enabled(&home, "agent", "shell");
-    assert!(result.is_none(), "sink must be None when env var is unset");
+    let home = tmp_home("noop");
+    let mut writer = make_capture_writer(Some(&home), "agent", "shell");
+    writer.write(b"should be ignored");
+    drop(writer);
+    assert!(
+        !home.join("captures").exists(),
+        "no captures dir when env unset"
+    );
     std::fs::remove_dir_all(&home).ok();
 }

--- a/tests/pty_capture.rs
+++ b/tests/pty_capture.rs
@@ -1,0 +1,67 @@
+//! Integration test for AGEND_CAPTURE_FIXTURES passive tee (issue #704).
+#![allow(clippy::unwrap_used)]
+//!
+//! Tests CaptureSink behaviour directly without requiring a running daemon.
+//! Gate the full spawn variant behind AGEND_LIVE_BACKEND_TEST=1.
+
+use std::path::PathBuf;
+
+fn tmp_home(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("agend-capture-test-{tag}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn capture_sink_writes_cap_and_meta_when_env_set() {
+    let home = tmp_home("sink");
+    let agent = "test-capture-agent";
+    let backend = "shell";
+
+    std::env::set_var("AGEND_CAPTURE_FIXTURES", "1");
+    let mut sink = agend_terminal::capture::CaptureSink::new_if_enabled(&home, agent, backend)
+        .expect("sink must be created when AGEND_CAPTURE_FIXTURES=1");
+
+    let payload = b"hello capture world\r\n";
+    sink.write(payload);
+    assert_eq!(sink.byte_count, payload.len() as u64);
+
+    // Drop triggers meta sidecar flush.
+    drop(sink);
+    std::env::remove_var("AGEND_CAPTURE_FIXTURES");
+
+    let cap_dir = home.join("captures").join(agent);
+    let cap_files: Vec<_> = std::fs::read_dir(&cap_dir)
+        .expect("captures dir must exist")
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("cap"))
+        .collect();
+    assert_eq!(cap_files.len(), 1, "exactly one .cap file expected");
+
+    let cap_path = cap_files[0].path();
+    let cap_bytes = std::fs::read(&cap_path).unwrap();
+    assert_eq!(cap_bytes, payload, ".cap content must match written bytes");
+
+    let meta_path = {
+        let mut s = cap_path.clone().into_os_string();
+        s.push(".meta.json");
+        PathBuf::from(s)
+    };
+    assert!(meta_path.exists(), ".meta.json sidecar must exist");
+    let meta_json = std::fs::read_to_string(&meta_path).unwrap();
+    let meta: serde_json::Value = serde_json::from_str(&meta_json).unwrap();
+    assert_eq!(meta["backend"].as_str(), Some(backend));
+    assert_eq!(meta["agent_name"].as_str(), Some(agent));
+    assert_eq!(meta["byte_count"].as_u64(), Some(payload.len() as u64));
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn capture_sink_is_none_when_env_unset() {
+    std::env::remove_var("AGEND_CAPTURE_FIXTURES");
+    let home = tmp_home("no-sink");
+    let result = agend_terminal::capture::CaptureSink::new_if_enabled(&home, "agent", "shell");
+    assert!(result.is_none(), "sink must be None when env var is unset");
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary

- Opt-in via `AGEND_CAPTURE_FIXTURES=1` (default OFF; zero overhead when unset)
- Per-agent tee in `pty_read_loop`: mirrors raw PTY bytes to `$AGEND_HOME/captures/<agent>/<epoch_ms>.cap`
- `{epoch_ms}.cap.meta.json` sidecar written on agent exit (Drop impl): `{ backend, agent_name, started_at, ended_at, byte_count }` — IO errors silently discarded, never propagated
- Rotation: deletes oldest `.cap` files when cumulative size per agent exceeds `CAPTURE_ROTATION_BUDGET_BYTES` (50 MB, tunable constant)
- `agend capture promote <capture_path> <scenario_name>`: reads sidecar for backend, copies to `tests/fixtures/<backend>/<scenario>.cap`

## ⚠️ Breaking change (intentional, internal tooling only)

`agend capture --backend <x> --seconds <n>` is now `agend capture backend --backend <x> --seconds <n>`.
These are internal dev tools with no external API contract; the rename is acceptable.

## Operator usage

```sh
export AGEND_CAPTURE_FIXTURES=1
# ... use agend normally for a few days ...
ls ~/.agend/captures/<agent>/
agend capture promote ~/.agend/captures/<agent>/<epoch>.cap kiro-thinking-v2
```

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — exit 0
- [x] `cargo test --bins` — 2082/2082 passed (3 new `capture::` unit tests)
- [x] `cargo test --test pty_capture` — 2/2 integration tests pass
- Full spawn test gated behind `AGEND_LIVE_BACKEND_TEST=1`

References #704 (sub-task 1)