### PR TITLE
refactor(#694): extract snapshot + poll-reminder into PerTickHandler trait (BLOCK 1, first cut)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod idle_watchdog;
 pub(crate) mod legacy_backfill;
 pub(crate) mod lifecycle;
 pub(crate) mod mcp_registry_watcher;
+pub(crate) mod per_tick;
 pub(crate) mod poll_reminder;
 pub(crate) mod router;
 pub(crate) mod supervisor;
@@ -522,7 +523,13 @@ fn run_core(
     // tick fires. Idempotent.
     crate::daemon::ci_watch::startup_sweep(home);
 
-    let mut last_snapshot_json = String::new();
+    // Per-tick handlers (#694 BLOCK 1 first cut — see daemon::per_tick).
+    // Owned across the daemon's lifetime so their interior state (snapshot
+    // dedup string, poll-reminder counter) persists across ticks. Called at
+    // their pre-extraction sites in the main loop below.
+    use per_tick::PerTickHandler as _;
+    let snapshot_handler = per_tick::SnapshotRotationHandler::new();
+    let poll_reminder_handler = per_tick::PollReminderHandler::new(30);
 
     // Periodic tick channel (every 10s for health/schedule/session maintenance)
     let tick_rx = {
@@ -566,6 +573,15 @@ fn run_core(
                 continue;
             }
         }
+
+        // Per-tick context shared by handlers extracted under #694 BLOCK 1.
+        // Borrows are valid for the rest of this iteration; coexists with
+        // other immutable uses of `&registry` / `&configs` below.
+        let tick_ctx = per_tick::TickContext {
+            home,
+            registry: &registry,
+            configs: &configs,
+        };
 
         // Periodic maintenance (runs on every wake, whether crash or tick).
         // AwaitingOperator detection lives in the dedicated supervisor thread
@@ -641,43 +657,9 @@ fn run_core(
             });
         }
 
-        // Periodic snapshot: save fleet state (only if changed)
-        {
-            let reg = agent::lock_registry(&registry);
-            let cfgs = configs.lock();
-            let snapshots: Vec<_> = reg
-                .iter()
-                .map(|(name, handle)| {
-                    let (agent_state, health_state) = {
-                        let c = handle.core.lock();
-                        (
-                            c.state.get_state().display_name().to_string(),
-                            c.health.state.display_name().to_string(),
-                        )
-                    };
-                    let cfg = cfgs.get(name);
-                    crate::snapshot::AgentSnapshot {
-                        name: name.clone(),
-                        backend_command: handle.backend_command.clone(),
-                        args: cfg.map(|c| c.args.clone()).unwrap_or_default(),
-                        working_dir: cfg
-                            .and_then(|c| c.working_dir.as_ref())
-                            .map(|p| p.display().to_string()),
-                        submit_key: handle.submit_key.clone(),
-                        health_state,
-                        agent_state,
-                    }
-                })
-                .collect();
-            drop(cfgs);
-            drop(reg);
-            // Only write if snapshot content changed
-            let new_json = serde_json::to_string(&snapshots).unwrap_or_default();
-            if last_snapshot_json != new_json {
-                crate::snapshot::save(home, &snapshots);
-                last_snapshot_json = new_json;
-            }
-        }
+        // Periodic snapshot: save fleet state (only if changed).
+        // #694 BLOCK 1 — extracted into daemon::per_tick::SnapshotRotationHandler.
+        snapshot_handler.run(&tick_ctx);
 
         check_schedules(home, &registry);
         check_ci_watches(home, &registry);
@@ -745,17 +727,9 @@ fn run_core(
             }
         }
 
-        // Poll-reminder: nudge idle agents with unread inbox (every 30 ticks)
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            static POLL_COUNTER: AtomicU64 = AtomicU64::new(0);
-            if POLL_COUNTER
-                .fetch_add(1, Ordering::Relaxed)
-                .is_multiple_of(30)
-            {
-                poll_reminder::poll_reminder_pass(home, &registry);
-            }
-        }
+        // Poll-reminder: nudge idle agents with unread inbox (every 30 ticks).
+        // #694 BLOCK 1 — extracted into daemon::per_tick::PollReminderHandler.
+        poll_reminder_handler.run(&tick_ctx);
 
         // Handle exit event (if any)
         let exit_event = match exit_event {

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -1,0 +1,56 @@
+//! Per-tick handlers — first cut of #694 BLOCK 1.
+//!
+//! The daemon main loop (`run_core` in `src/daemon/mod.rs`) historically
+//! inlined every periodic concern in a single 200-line block. This module
+//! introduces a thin trait, [`PerTickHandler`], so each periodic concern
+//! can be moved into its own file, owned state and all, then invoked from
+//! the main loop in the same position it occupied before. The trait is
+//! deliberately minimal — pattern relocation, not abstraction.
+//!
+//! This first cut extracts two low-risk subsystems:
+//!
+//! - [`SnapshotRotationHandler`] (was `mod.rs:644-680`) — owns the
+//!   `last_snapshot_json` dedup string that used to live as a loop-local
+//!   in `run_core`.
+//! - [`PollReminderHandler`] (was `mod.rs:748-758`) — owns the every-N
+//!   tick counter that used to live as a function-local `static`.
+//!
+//! Follow-up PRs (T-B3+) will move further subsystems behind the same
+//! trait. Until then, the daemon loop holds the handlers as named locals
+//! and calls them at their original sites — a single `Vec<Box<dyn …>>`
+//! iteration would reorder execution and is deferred until enough
+//! handlers exist for the uniform iteration to be the natural shape.
+
+use crate::agent::AgentRegistry;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+pub(crate) mod poll_reminder;
+pub(crate) mod snapshot;
+
+pub(crate) use poll_reminder::PollReminderHandler;
+pub(crate) use snapshot::SnapshotRotationHandler;
+
+/// Shared per-tick context. Field types match what the daemon main loop
+/// holds verbatim — the trait is pure relocation, not abstraction. Future
+/// handlers add fields as their extraction lands.
+pub(crate) struct TickContext<'a> {
+    pub home: &'a Path,
+    pub registry: &'a AgentRegistry,
+    pub configs: &'a Arc<Mutex<HashMap<String, super::AgentConfig>>>,
+}
+
+/// One periodic concern in the daemon main loop. `run` takes `&self`
+/// because handlers are held by reference for the daemon's lifetime;
+/// state that needs to mutate across ticks must use interior mutability
+/// (`AtomicU64`, `Mutex<…>`, etc.).
+pub(crate) trait PerTickHandler: Send + Sync {
+    // Reserved for T-B3+ — once a Vec<Box<dyn PerTickHandler>> aggregator
+    // exists, this will drive tracing spans / diagnostic dumps. The trait
+    // commits to it now so per-handler PRs don't have to re-thread it.
+    #[allow(dead_code)]
+    fn name(&self) -> &'static str;
+    fn run(&self, ctx: &TickContext<'_>);
+}

--- a/src/daemon/per_tick/poll_reminder.rs
+++ b/src/daemon/per_tick/poll_reminder.rs
@@ -1,0 +1,65 @@
+//! Poll-reminder cadence wrapper: fires `crate::daemon::poll_reminder::poll_reminder_pass`
+//! every `every_n_ticks` ticks. Extracted verbatim from `src/daemon/mod.rs:748-758`
+//! (pre-#694 BLOCK 1) — the previous code used a function-local `static AtomicU64`
+//! counter; this handler relocates that counter onto the struct.
+
+use super::{PerTickHandler, TickContext};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub(crate) struct PollReminderHandler {
+    every_n_ticks: u64,
+    counter: AtomicU64,
+}
+
+impl PollReminderHandler {
+    pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self {
+            every_n_ticks,
+            counter: AtomicU64::new(0),
+        }
+    }
+
+    /// `fetch_add` returns the PREVIOUS counter value, then atomically
+    /// increments. So fires at tick indices 0, N, 2N, ... — matching the
+    /// pre-extraction `static AtomicU64` cadence (first call returns 0,
+    /// `0.is_multiple_of(N) == true`, so the very first tick fires).
+    fn should_fire(&self) -> bool {
+        self.counter
+            .fetch_add(1, Ordering::Relaxed)
+            .is_multiple_of(self.every_n_ticks)
+    }
+}
+
+impl PerTickHandler for PollReminderHandler {
+    fn name(&self) -> &'static str {
+        "poll_reminder"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if self.should_fire() {
+            crate::daemon::poll_reminder::poll_reminder_pass(ctx.home, ctx.registry);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin the cadence: with N=3, fires on the 1st, 4th, 7th call
+    /// (counter values 0, 3, 6 — each a multiple of 3).
+    #[test]
+    fn fires_at_expected_cadence() {
+        let h = PollReminderHandler::new(3);
+        let fires: Vec<bool> = (0..7).map(|_| h.should_fire()).collect();
+        assert_eq!(fires, vec![true, false, false, true, false, false, true]);
+    }
+
+    /// Sanity-check the every-tick degenerate case (N=1 fires every call).
+    #[test]
+    fn n_equals_one_fires_every_tick() {
+        let h = PollReminderHandler::new(1);
+        let fires: Vec<bool> = (0..5).map(|_| h.should_fire()).collect();
+        assert_eq!(fires, vec![true; 5]);
+    }
+}

--- a/src/daemon/per_tick/snapshot.rs
+++ b/src/daemon/per_tick/snapshot.rs
@@ -1,0 +1,135 @@
+//! Snapshot rotation: serialize fleet state to `<home>/snapshot.json`,
+//! but skip the disk write when the serialized form is byte-identical to
+//! the previous tick's. Extracted verbatim from `src/daemon/mod.rs:644-680`
+//! (pre-#694 BLOCK 1) — same lock-acquisition order, same skip semantics.
+
+use super::{PerTickHandler, TickContext};
+use crate::agent;
+use parking_lot::Mutex;
+
+/// Owns the `last_snapshot_json` string that used to be a loop-local in
+/// `run_core`. `Mutex` (not `RefCell`) because `PerTickHandler: Send + Sync`.
+pub(crate) struct SnapshotRotationHandler {
+    last_snapshot_json: Mutex<String>,
+}
+
+impl SnapshotRotationHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            last_snapshot_json: Mutex::new(String::new()),
+        }
+    }
+}
+
+impl PerTickHandler for SnapshotRotationHandler {
+    fn name(&self) -> &'static str {
+        "snapshot_rotation"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        // Lock-acquisition order (docs/DAEMON-LOCK-ORDERING.md Rule 1,
+        // top-down): registry (L0) → configs (L0) → per-agent core (L1,
+        // briefly inside the map closure). Identical to the pre-extraction
+        // inline block.
+        let reg = agent::lock_registry(ctx.registry);
+        let cfgs = ctx.configs.lock();
+        let snapshots: Vec<_> = reg
+            .iter()
+            .map(|(name, handle)| {
+                let (agent_state, health_state) = {
+                    let c = handle.core.lock();
+                    (
+                        c.state.get_state().display_name().to_string(),
+                        c.health.state.display_name().to_string(),
+                    )
+                };
+                let cfg = cfgs.get(name);
+                crate::snapshot::AgentSnapshot {
+                    name: name.clone(),
+                    backend_command: handle.backend_command.clone(),
+                    args: cfg.map(|c| c.args.clone()).unwrap_or_default(),
+                    working_dir: cfg
+                        .and_then(|c| c.working_dir.as_ref())
+                        .map(|p| p.display().to_string()),
+                    submit_key: handle.submit_key.clone(),
+                    health_state,
+                    agent_state,
+                }
+            })
+            .collect();
+        drop(cfgs);
+        drop(reg);
+
+        let new_json = serde_json::to_string(&snapshots).unwrap_or_default();
+        let mut last = self.last_snapshot_json.lock();
+        if *last != new_json {
+            crate::snapshot::save(ctx.home, &snapshots);
+            *last = new_json;
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::agent::AgentRegistry;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-snap-handler-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    /// Empty registry round-trip — second `run` with no state change must
+    /// not rewrite the file (the dedup guard is the whole point of the
+    /// pre-extraction `if last_snapshot_json != new_json` check).
+    #[test]
+    fn snapshot_handler_dedupes_unchanged_state() {
+        let home = tmp_home("dedupe");
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            configs: &configs,
+        };
+
+        let h = SnapshotRotationHandler::new();
+        h.run(&ctx);
+        let snapshot_path = home.join("snapshot.json");
+        assert!(
+            snapshot_path.exists(),
+            "first run must create snapshot.json"
+        );
+        let mtime1 = std::fs::metadata(&snapshot_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        // Sleep past filesystem mtime granularity so a real write would
+        // be observable.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        h.run(&ctx);
+        let mtime2 = std::fs::metadata(&snapshot_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        assert_eq!(
+            mtime1, mtime2,
+            "second run with unchanged state must skip the on-disk write"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

#694 BLOCK 1 **first cut**. Establishes a `daemon::per_tick` module with a minimal `PerTickHandler` trait and a `TickContext<'a>` borrow struct. Two of the eight periodic concerns inlined in `daemon::run_core`'s main loop move behind the trait:

- `SnapshotRotationHandler` (was `src/daemon/mod.rs:644-680`) — owns the `last_snapshot_json` dedup string that used to be a loop-local in `run_core`.
- `PollReminderHandler` (was `src/daemon/mod.rs:748-758`) — owns the every-N tick counter that used to be a function-local `static AtomicU64`.

This is **pattern-setting, not stop-the-world**. No LOC threshold for `daemon/mod.rs` reduction yet — the win is establishing the extraction shape so T-B3+ can mechanically follow it for the remaining subsystems.

## Deferred to follow-up PRs (T-B3+)

Per dispatch scope:
- Hang detection / health decay (registry-lock entangled)
- Watchdog PTY classification (HealthTracker shared state)
- External agent liveness
- `check_schedules` (cron — its own beast)
- `check_ci_watches` (just split in #753 — let it stabilize)
- Inbox maintenance batch (6 sub-ops on one 60-tick gate)
- Worktree GC

## Trait shape

```rust
pub(crate) struct TickContext<'a> {
    pub home: &'a Path,
    pub registry: &'a AgentRegistry,
    pub configs: &'a Arc<Mutex<HashMap<String, super::AgentConfig>>>,
}

pub(crate) trait PerTickHandler: Send + Sync {
    fn name(&self) -> &'static str;             // reserved for T-B3+ Vec aggregator
    fn run(&self, ctx: &TickContext<'_>);
}
```

`&self` (not `&mut self`) — handlers are held by reference for the daemon's lifetime, so cross-tick state uses interior mutability (`Mutex<String>` / `AtomicU64`). Avoids forcing the main loop to hold `&mut` references, which would block any future `Vec<Box<dyn PerTickHandler>>` dispatch.

## Design notes

### Why no `Vec<Box<dyn PerTickHandler>>` iteration yet

Snapshot rotation sat at `mod.rs:644`; poll-reminder sat at `mod.rs:748`. Between them: `check_schedules`, `check_ci_watches`, and the every-60-tick inbox-maintenance batch — three subsystems **not** extracted in this PR. Collapsing the two extracted handlers into a single Vec iteration would reorder execution (e.g. snapshot would now run *after* inbox maintenance instead of before it). The dispatch's **zero behavior change** hard constraint rules that out, so handlers are stored as named bindings and called at their pre-extraction sites.

The Vec aggregator is deferred to T-B5+ — once enough subsystems are extracted that the gap between them closes and uniform iteration becomes the natural shape.

### Dedup state: `String` → `Mutex<String>`

The pre-extraction code used a loop-local `let mut last_snapshot_json = String::new()` in `run_core`. With `run(&self, …)` and `Send + Sync`, the handler can't hold a plain `String` field, so the dedup state migrates to `parking_lot::Mutex<String>`. The lock is **uncontested** — only the daemon main loop calls `snapshot_handler.run()` — so the acquisition is effectively free, but it's worth flagging that this introduces one lock acquisition per tick that didn't exist before. No observable behavior change.

### Cadence preservation

`PollReminderHandler::should_fire` uses `counter.fetch_add(1, Relaxed).is_multiple_of(N)`. `fetch_add` returns the **previous** counter value, so the very first tick (counter=0) fires — matching the pre-extraction `static AtomicU64` semantics. Pinned by the `fires_at_expected_cadence` test (N=3 across 7 ticks: `1010010` pattern).

## Lock-ordering analysis (per §3.15 daemon-core cushion)

`SnapshotRotationHandler::run` acquires locks in the same order as the pre-extraction inline block, verbatim:

1. `agent::lock_registry(ctx.registry)` — Level 0 (root)
2. `ctx.configs.lock()` — Level 0 (root)
3. Per agent inside the map closure: `handle.core.lock()` — Level 1 (per-agent)
4. Drop in reverse: core (per iteration), configs, registry.

This is top-down per `docs/DAEMON-LOCK-ORDERING.md` Rule 1. No leaf-level locks involved. **Pure relocation** — no new acquisition order introduced anywhere in this PR.

`PollReminderHandler::run` doesn't acquire any locks itself; it calls `crate::daemon::poll_reminder::poll_reminder_pass(home, registry)` whose locking is unchanged.

## Diff stat

- `src/daemon/mod.rs`: **+23 / -49** (net **-26 lines**, the 200-line `select!` lambda visibly shrinks)
- `src/daemon/per_tick/mod.rs`: new, 56 lines
- `src/daemon/per_tick/snapshot.rs`: new, 130 lines (handler 79 + tests 51)
- `src/daemon/per_tick/poll_reminder.rs`: new, 64 lines (handler 40 + tests 24)

## Test plan

- [x] `cargo build --features tray` — OK
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --bins --features tray` — 2087 passed, 0 failed, 7 ignored (existing tests pass with **identical assertions**, per refactor constraint)
- [x] New unit tests pass:
  - `daemon::per_tick::snapshot::tests::snapshot_handler_dedupes_unchanged_state` — empty registry, second run with no state change must not advance file mtime
  - `daemon::per_tick::poll_reminder::tests::fires_at_expected_cadence` — N=3, 7 ticks, expect `[T,F,F,T,F,F,T]`
  - `daemon::per_tick::poll_reminder::tests::n_equals_one_fires_every_tick` — degenerate-case sanity
- [ ] CI green on this branch

## Refs

- Issue #694 BLOCK 1
- Follows pattern of #701 (ci_watch split, merged a520188)
- `docs/DAEMON-LOCK-ORDERING.md` Rule 1 (top-down acquisition)
- Fleet protocol §3.15 (daemon-core cushion), §10/§12.4 (worktree discipline)