### PR TITLE
refactor(#694): extract inbox-maintenance + external-liveness (BLOCK 1 second cut)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -532,6 +532,7 @@ fn run_core(
     let snapshot_handler = per_tick::SnapshotRotationHandler::new();
     let poll_reminder_handler = per_tick::PollReminderHandler::new(30);
     let inbox_maintenance_handler = per_tick::InboxMaintenanceHandler::new(60);
+    let external_liveness_handler = per_tick::ExternalLivenessHandler::new();
 
     // Periodic tick channel (every 10s for health/schedule/session maintenance)
     let tick_rx = {
@@ -578,10 +579,12 @@ fn run_core(
 
         // Per-tick context shared by handlers extracted under #694 BLOCK 1.
         // Borrows are valid for the rest of this iteration; coexists with
-        // other immutable uses of `&registry` / `&configs` below.
+        // other immutable uses of `&registry` / `&externals` / `&configs`
+        // below.
         let tick_ctx = per_tick::TickContext {
             home,
             registry: &registry,
+            externals: &externals,
             configs: &configs,
         };
 
@@ -646,18 +649,9 @@ fn run_core(
             }
         }
 
-        // Liveness check for external agents
-        {
-            let mut ext = crate::agent::lock_external(&externals);
-            ext.retain(|name, handle| {
-                let alive = crate::process::is_pid_alive(handle.pid);
-                if !alive {
-                    tracing::info!(agent = %name, pid = handle.pid, "external agent gone, deregistering");
-                    crate::event_log::log(home, "disconnect", name, "external agent PID gone");
-                }
-                alive
-            });
-        }
+        // Liveness check for external agents.
+        // #694 BLOCK 1 — extracted into daemon::per_tick::ExternalLivenessHandler.
+        external_liveness_handler.run(&tick_ctx);
 
         // Periodic snapshot: save fleet state (only if changed).
         // #694 BLOCK 1 — extracted into daemon::per_tick::SnapshotRotationHandler.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -523,13 +523,15 @@ fn run_core(
     // tick fires. Idempotent.
     crate::daemon::ci_watch::startup_sweep(home);
 
-    // Per-tick handlers (#694 BLOCK 1 first cut — see daemon::per_tick).
-    // Owned across the daemon's lifetime so their interior state (snapshot
-    // dedup string, poll-reminder counter) persists across ticks. Called at
-    // their pre-extraction sites in the main loop below.
+    // Per-tick handlers (#694 BLOCK 1 — see daemon::per_tick). Owned
+    // across the daemon's lifetime so their interior state (snapshot
+    // dedup string, poll-reminder + inbox-maintenance counters) persists
+    // across ticks. Called at their pre-extraction sites in the main
+    // loop below.
     use per_tick::PerTickHandler as _;
     let snapshot_handler = per_tick::SnapshotRotationHandler::new();
     let poll_reminder_handler = per_tick::PollReminderHandler::new(30);
+    let inbox_maintenance_handler = per_tick::InboxMaintenanceHandler::new(60);
 
     // Periodic tick channel (every 10s for health/schedule/session maintenance)
     let tick_rx = {
@@ -664,68 +666,9 @@ fn run_core(
         check_schedules(home, &registry);
         check_ci_watches(home, &registry);
 
-        // Periodic inbox maintenance — every 60 ticks (≈10 min at 10s/tick)
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            static SWEEP_COUNTER: AtomicU64 = AtomicU64::new(0);
-            if SWEEP_COUNTER
-                .fetch_add(1, Ordering::Relaxed)
-                .is_multiple_of(60)
-            {
-                crate::inbox::sweep_expired(home);
-                crate::inbox::check_disk_space(home);
-                run_task_maintenance(home);
-                // Worktree auto-cleanup (runtime registry based)
-                {
-                    let cfgs = configs.lock();
-                    let config_data: std::collections::HashMap<
-                        String,
-                        (Option<std::path::PathBuf>, Option<std::path::PathBuf>),
-                    > = cfgs
-                        .iter()
-                        .map(|(name, cfg)| {
-                            (
-                                name.clone(),
-                                (cfg.working_dir.clone(), cfg.worktree_source.clone()),
-                            )
-                        })
-                        .collect();
-                    drop(cfgs);
-                    let fleet_dirs: Vec<std::path::PathBuf> =
-                        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
-                            .ok()
-                            .map(|c| {
-                                c.instance_names()
-                                    .iter()
-                                    .filter_map(|n| {
-                                        c.resolve_instance(n).and_then(|r| r.working_directory)
-                                    })
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-                    let cleaned =
-                        crate::worktree_cleanup::sweep_from_registry(&config_data, &fleet_dirs);
-                    for (branch, path) in &cleaned {
-                        crate::event_log::log(
-                            home,
-                            "worktree_auto_removed",
-                            branch,
-                            &format!("path={path}, branch merged into main"),
-                        );
-                        tracing::info!(branch, path, "worktree auto-removed (branch merged)");
-                    }
-                }
-                // Phase 4 git-shim: worktree GC (hourly with sweep).
-                // Default: dry-run only. Cutover when AGEND_WORKTREE_GC=1.
-                if std::env::var("AGEND_WORKTREE_GC").as_deref() == Ok("1") {
-                    crate::worktree_pool::gc_cutover(home);
-                } else {
-                    crate::worktree_pool::gc_dry_run(home);
-                }
-                // Phase 5: hotspot scan — check recent commits for multi-agent file conflicts.
-                hotspot_scan(home, &configs);
-            }
-        }
+        // Periodic inbox maintenance — every 60 ticks (≈10 min at 10s/tick).
+        // #694 BLOCK 1 — extracted into daemon::per_tick::InboxMaintenanceHandler.
+        inbox_maintenance_handler.run(&tick_ctx);
 
         // Poll-reminder: nudge idle agents with unread inbox (every 30 ticks).
         // #694 BLOCK 1 — extracted into daemon::per_tick::PollReminderHandler.

--- a/src/daemon/per_tick/external_liveness.rs
+++ b/src/daemon/per_tick/external_liveness.rs
@@ -1,0 +1,127 @@
+//! External-agent liveness sweep: drop entries whose PID is no longer
+//! alive. Extracted verbatim from `src/daemon/mod.rs:647-658` (pre-T-B3) —
+//! same `retain` semantics, same logging, same `event_log::log` call.
+//! Stateless handler: nothing to carry across ticks.
+
+use super::{PerTickHandler, TickContext};
+
+pub(crate) struct ExternalLivenessHandler;
+
+impl ExternalLivenessHandler {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl PerTickHandler for ExternalLivenessHandler {
+    fn name(&self) -> &'static str {
+        "external_liveness"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        let mut ext = crate::agent::lock_external(ctx.externals);
+        ext.retain(|name, handle| {
+            let alive = crate::process::is_pid_alive(handle.pid);
+            if !alive {
+                tracing::info!(
+                    agent = %name,
+                    pid = handle.pid,
+                    "external agent gone, deregistering"
+                );
+                crate::event_log::log(ctx.home, "disconnect", name, "external agent PID gone");
+            }
+            alive
+        });
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentRegistry, ExternalAgentHandle, ExternalRegistry};
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-extlive-handler-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn empty_ctx<'a>(
+        home: &'a std::path::Path,
+        registry: &'a AgentRegistry,
+        externals: &'a ExternalRegistry,
+        configs: &'a Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>>,
+    ) -> TickContext<'a> {
+        TickContext {
+            home,
+            registry,
+            externals,
+            configs,
+        }
+    }
+
+    /// Empty registry — run() is a no-op and the registry stays empty.
+    #[test]
+    fn run_is_noop_on_empty_registry() {
+        let home = tmp_home("empty");
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = empty_ctx(&home, &registry, &externals, &configs);
+
+        let h = ExternalLivenessHandler::new();
+        h.run(&ctx);
+
+        assert!(externals.lock().is_empty());
+    }
+
+    /// Entry with a known-dead PID is evicted; entry with the current
+    /// process PID survives. Pins the retain-by-`is_pid_alive` semantics.
+    #[test]
+    fn run_evicts_dead_pid_keeps_live_pid() {
+        let home = tmp_home("evict");
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+
+        // 999_999_999 is well above macOS's default pid_max (99998) and
+        // Linux's default (32768), so `kill(999_999_999, 0)` returns
+        // ESRCH on every platform we run on. (We can't use PID 0 — on
+        // POSIX, `kill(0, 0)` is a process-group permission check that
+        // returns 0/"alive" for any user.) Current process is provably
+        // alive for the contrasting case.
+        externals.lock().insert(
+            "dead-agent".to_string(),
+            ExternalAgentHandle {
+                backend_command: "claude".to_string(),
+                pid: 999_999_999,
+            },
+        );
+        externals.lock().insert(
+            "live-agent".to_string(),
+            ExternalAgentHandle {
+                backend_command: "claude".to_string(),
+                pid: std::process::id(),
+            },
+        );
+
+        let ctx = empty_ctx(&home, &registry, &externals, &configs);
+        ExternalLivenessHandler::new().run(&ctx);
+
+        let ext = externals.lock();
+        assert!(!ext.contains_key("dead-agent"), "dead PID must be evicted");
+        assert!(ext.contains_key("live-agent"), "live PID must be retained");
+    }
+}

--- a/src/daemon/per_tick/inbox_maintenance.rs
+++ b/src/daemon/per_tick/inbox_maintenance.rs
@@ -125,7 +125,7 @@ mod tests {
     /// so this exercises the composite end-to-end.
     #[test]
     fn run_is_no_op_on_empty_fixtures() {
-        use crate::agent::AgentRegistry;
+        use crate::agent::{AgentRegistry, ExternalRegistry};
         use parking_lot::Mutex;
         use std::collections::HashMap;
         use std::sync::Arc;
@@ -135,10 +135,12 @@ mod tests {
         std::fs::create_dir_all(&home).unwrap();
 
         let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
         let configs = Arc::new(Mutex::new(HashMap::new()));
         let ctx = TickContext {
             home: &home,
             registry: &registry,
+            externals: &externals,
             configs: &configs,
         };
 

--- a/src/daemon/per_tick/inbox_maintenance.rs
+++ b/src/daemon/per_tick/inbox_maintenance.rs
@@ -1,0 +1,153 @@
+//! Inbox-maintenance composite: every-60-tick batch of 6 sub-ops gated
+//! on a single cadence counter. Extracted verbatim from
+//! `src/daemon/mod.rs:667-728` (pre-T-B3) — sub-ops preserved in the
+//! same order, same call signatures, same gating. The pre-extraction
+//! `static AtomicU64` counter moves onto the struct.
+
+use super::{PerTickHandler, TickContext};
+use crate::api::ConfigRegistry;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub(crate) struct InboxMaintenanceHandler {
+    every_n_ticks: u64,
+    counter: AtomicU64,
+}
+
+impl InboxMaintenanceHandler {
+    pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self {
+            every_n_ticks,
+            counter: AtomicU64::new(0),
+        }
+    }
+
+    /// Matches the pre-extraction `static AtomicU64` cadence: `fetch_add`
+    /// returns prev value, so first tick (counter=0) fires.
+    fn should_fire(&self) -> bool {
+        self.counter
+            .fetch_add(1, Ordering::Relaxed)
+            .is_multiple_of(self.every_n_ticks)
+    }
+}
+
+impl PerTickHandler for InboxMaintenanceHandler {
+    fn name(&self) -> &'static str {
+        "inbox_maintenance"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if !self.should_fire() {
+            return;
+        }
+        // Sub-op order matches the pre-extraction inline composite verbatim.
+        crate::inbox::sweep_expired(ctx.home);
+        crate::inbox::check_disk_space(ctx.home);
+        crate::daemon::run_task_maintenance(ctx.home);
+        worktree_auto_cleanup(ctx.home, ctx.configs);
+        worktree_gc(ctx.home);
+        crate::daemon::hotspot_scan(ctx.home, ctx.configs);
+    }
+}
+
+/// Worktree auto-cleanup (runtime registry based): drop branches whose
+/// PRs have merged into main. Logged via `event_log` + tracing on every
+/// removal so operators can audit. Verbatim from the pre-extraction
+/// block at mod.rs:678-717.
+fn worktree_auto_cleanup(home: &Path, configs: &ConfigRegistry) {
+    let cfgs = configs.lock();
+    let config_data: std::collections::HashMap<
+        String,
+        (Option<std::path::PathBuf>, Option<std::path::PathBuf>),
+    > = cfgs
+        .iter()
+        .map(|(name, cfg)| {
+            (
+                name.clone(),
+                (cfg.working_dir.clone(), cfg.worktree_source.clone()),
+            )
+        })
+        .collect();
+    drop(cfgs);
+    let fleet_dirs: Vec<std::path::PathBuf> =
+        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+            .ok()
+            .map(|c| {
+                c.instance_names()
+                    .iter()
+                    .filter_map(|n| c.resolve_instance(n).and_then(|r| r.working_directory))
+                    .collect()
+            })
+            .unwrap_or_default();
+    let cleaned = crate::worktree_cleanup::sweep_from_registry(&config_data, &fleet_dirs);
+    for (branch, path) in &cleaned {
+        crate::event_log::log(
+            home,
+            "worktree_auto_removed",
+            branch,
+            &format!("path={path}, branch merged into main"),
+        );
+        tracing::info!(branch, path, "worktree auto-removed (branch merged)");
+    }
+}
+
+/// Phase 4 git-shim: worktree GC (hourly with sweep). Default dry-run;
+/// cutover when AGEND_WORKTREE_GC=1. Verbatim from the pre-extraction
+/// block at mod.rs:718-724.
+fn worktree_gc(home: &Path) {
+    if std::env::var("AGEND_WORKTREE_GC").as_deref() == Ok("1") {
+        crate::worktree_pool::gc_cutover(home);
+    } else {
+        crate::worktree_pool::gc_dry_run(home);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Cadence predicate test (same pattern as PollReminderHandler).
+    /// N=60 is the production value; pin a small N for compact assertion.
+    #[test]
+    fn fires_on_first_tick_then_every_n() {
+        let h = InboxMaintenanceHandler::new(4);
+        let fires: Vec<bool> = (0..9).map(|_| h.should_fire()).collect();
+        assert_eq!(
+            fires,
+            vec![true, false, false, false, true, false, false, false, true]
+        );
+    }
+
+    /// Smoke test: `run()` against an empty registry + temp home must
+    /// complete without panic. Every sub-op tolerates missing state
+    /// (empty inbox dir, no tasks.json, empty configs, no fleet.yaml),
+    /// so this exercises the composite end-to-end.
+    #[test]
+    fn run_is_no_op_on_empty_fixtures() {
+        use crate::agent::AgentRegistry;
+        use parking_lot::Mutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let tag = std::process::id();
+        let home = std::env::temp_dir().join(format!("agend-inbox-maint-handler-{tag}"));
+        std::fs::create_dir_all(&home).unwrap();
+
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            configs: &configs,
+        };
+
+        // N=1 forces every call to fire (every sub-op runs).
+        let h = InboxMaintenanceHandler::new(1);
+        h.run(&ctx);
+        h.run(&ctx);
+
+        // Cleanup
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -27,16 +27,18 @@
 //! iteration would reorder execution and is deferred until enough
 //! handlers exist for the uniform iteration to be the natural shape.
 
-use crate::agent::AgentRegistry;
+use crate::agent::{AgentRegistry, ExternalRegistry};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
+pub(crate) mod external_liveness;
 pub(crate) mod inbox_maintenance;
 pub(crate) mod poll_reminder;
 pub(crate) mod snapshot;
 
+pub(crate) use external_liveness::ExternalLivenessHandler;
 pub(crate) use inbox_maintenance::InboxMaintenanceHandler;
 pub(crate) use poll_reminder::PollReminderHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;
@@ -48,6 +50,7 @@ pub(crate) use snapshot::SnapshotRotationHandler;
 pub(crate) struct TickContext<'a> {
     pub home: &'a Path,
     pub registry: &'a AgentRegistry,
+    pub externals: &'a ExternalRegistry,
     pub configs: &'a Arc<Mutex<HashMap<String, super::AgentConfig>>>,
 }
 

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -7,15 +7,21 @@
 //! the main loop in the same position it occupied before. The trait is
 //! deliberately minimal — pattern relocation, not abstraction.
 //!
-//! This first cut extracts two low-risk subsystems:
+//! Cumulative extraction state (handlers grow per PR):
 //!
-//! - [`SnapshotRotationHandler`] (was `mod.rs:644-680`) — owns the
-//!   `last_snapshot_json` dedup string that used to live as a loop-local
-//!   in `run_core`.
-//! - [`PollReminderHandler`] (was `mod.rs:748-758`) — owns the every-N
-//!   tick counter that used to live as a function-local `static`.
+//! - [`SnapshotRotationHandler`] (T-B2, was `mod.rs:644-680`) — owns the
+//!   `last_snapshot_json` dedup string that used to live as a loop-local.
+//! - [`PollReminderHandler`] (T-B2, was `mod.rs:748-758`) — owns the
+//!   every-N tick counter that used to live as a function-local `static`.
+//! - [`InboxMaintenanceHandler`] (T-B3, was `mod.rs:667-728`) — the
+//!   every-60-tick composite of 6 sub-ops; counter moves from
+//!   function-local `static AtomicU64` onto the struct.
+//! - [`ExternalLivenessHandler`] (T-B3, was `mod.rs:647-658`) — picked
+//!   over the watchdog block for blast-radius reasons documented in the
+//!   T-B3 PR body. Stateless wrapper around the `externals.retain`
+//!   liveness sweep.
 //!
-//! Follow-up PRs (T-B3+) will move further subsystems behind the same
+//! Follow-up PRs (T-B4+) will move further subsystems behind the same
 //! trait. Until then, the daemon loop holds the handlers as named locals
 //! and calls them at their original sites — a single `Vec<Box<dyn …>>`
 //! iteration would reorder execution and is deferred until enough
@@ -27,15 +33,18 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
+pub(crate) mod inbox_maintenance;
 pub(crate) mod poll_reminder;
 pub(crate) mod snapshot;
 
+pub(crate) use inbox_maintenance::InboxMaintenanceHandler;
 pub(crate) use poll_reminder::PollReminderHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;
 
 /// Shared per-tick context. Field types match what the daemon main loop
-/// holds verbatim — the trait is pure relocation, not abstraction. Future
-/// handlers add fields as their extraction lands.
+/// holds verbatim — the trait is pure relocation, not abstraction. New
+/// fields are added as a handler's extraction lands; existing handlers
+/// are unaffected because all fields are borrowed references.
 pub(crate) struct TickContext<'a> {
     pub home: &'a Path,
     pub registry: &'a AgentRegistry,

--- a/src/daemon/per_tick/snapshot.rs
+++ b/src/daemon/per_tick/snapshot.rs
@@ -73,7 +73,7 @@ impl PerTickHandler for SnapshotRotationHandler {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::agent::AgentRegistry;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
     use parking_lot::Mutex;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -99,10 +99,12 @@ mod tests {
     fn snapshot_handler_dedupes_unchanged_state() {
         let home = tmp_home("dedupe");
         let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
         let configs = Arc::new(Mutex::new(HashMap::new()));
         let ctx = TickContext {
             home: &home,
             registry: &registry,
+            externals: &externals,
             configs: &configs,
         };
 


### PR DESCRIPTION
## Summary

#694 BLOCK 1 **second cut**, following the trait pattern landed in #757. Two more periodic concerns move behind `daemon::per_tick::PerTickHandler`:

- `InboxMaintenanceHandler` (was `src/daemon/mod.rs:667-728`) — the every-60-tick composite of 6 sub-ops (`inbox::sweep_expired`, `check_disk_space`, `run_task_maintenance`, worktree auto-cleanup, worktree GC dry-run/cutover, `hotspot_scan`). Counter migrates from function-local `static AtomicU64` onto the struct, matching the T-B2 PollReminder pattern. Sub-ops kept private to the new file per dispatch.
- `ExternalLivenessHandler` (was `src/daemon/mod.rs:647-658`) — `externals.retain` PID-liveness sweep. Stateless wrapper, no handler-field plumbing.

After this PR: **4 of 8 BLOCK 1 subsystems extracted**, halfway through the block. T-B4+ picks up the remaining cohorts.

## Deferred to follow-up PRs (T-B4+)

- Hang detection / health decay
- Watchdog PTY classification — see "Why ExternalLiveness, not Watchdog" below
- `check_schedules` (cron — its own beast)
- `check_ci_watches` (just split in #753 — let it stabilize)

## Why ExternalLiveness, not Watchdog

Dispatch left the second target as "Watchdog OR external liveness — pick whichever has the smaller blast radius. Make the call yourself; document it." The decision matrix:

| | ExternalLiveness | Watchdog |
|---|---|---|
| Extraction-site LOC | ~11 | ~22 |
| Lock pattern | single L0 (`lock_external`) | L0 → L1 (`lock_registry` → per-agent `core.lock`) |
| Handler-field state | none | `watchdog_dry_run: bool` |
| `TickContext` change | +1 additive field (`externals`) | none |
| Mutation surface | own registry (entry eviction) | `&mut core.health` |
| Cross-subsystem coupling | none | **writes `core.health`, which the still-inline hang-detection block reads in the same tick** |
| Test fixture cost | trivial (`ExternalAgentHandle` + fake PID) | requires PTY-backed `AgentHandle` |

The watchdog↔hang-detection coupling is the decisive factor. Extracting watchdog alone splits an implicit "same-tick read-after-write of `core.health`" invariant across a module boundary. Execution order is preserved within the tick (handlers run at their original sites — see "No Vec aggregator" below), but the cognitive load of "this handler mutates state another inline block depends on" is exactly the sort of subtle coupling that bites future maintainers. Watchdog is parked for a PR that extracts watchdog **+** hang-detection together as a cohort.

## Trait + context changes

`TickContext` gains one field — purely additive:

```rust
pub(crate) struct TickContext<'a> {
    pub home: &'a Path,
    pub registry: &'a AgentRegistry,
    pub externals: &'a ExternalRegistry,  // NEW (T-B3)
    pub configs: &'a Arc<Mutex<HashMap<String, super::AgentConfig>>>,
}
```

`SnapshotRotation` / `PollReminder` / `InboxMaintenance` don't read `externals` — they're unaffected. T-B2 handler tests updated to construct the new field; **no test assertion changes**.

`PerTickHandler` trait itself is unchanged from #757.

## No Vec aggregator yet (same as T-B2)

Same reasoning as #757: handlers are called as named bindings at their original positions in `run_core`'s `select!`. Three subsystems (schedules, ci_watch, the inbox-maintenance block that this PR extracts) historically sat between the extracted sites; collapsing handlers into a single Vec iteration would reorder execution. After this PR the remaining un-extracted blocks are hang-detection / watchdog / check_schedules / check_ci_watches — Vec aggregation can land once enough of those are extracted that the gap closes.

## Lock-ordering analysis (per §3.15 daemon-core cushion)

**InboxMaintenance**:
- `inbox::sweep_expired`, `inbox::check_disk_space`, `run_task_maintenance`, `hotspot_scan` — internal locking unchanged (these are existing functions; we only relocate the call sites).
- `worktree_auto_cleanup` (private fn in the new file): `configs.lock()` (L0) → snapshot to `HashMap` → `drop(cfgs)` → build `fleet_dirs` → call `worktree_cleanup::sweep_from_registry` → log per cleanup. **Same acquire-snapshot-release pattern as the pre-extraction inline block, verbatim.**
- `worktree_gc` (private fn): env-var gate, no locks.

No new lock-ordering relationships introduced. No leaf-level locks touched.

**ExternalLiveness**:
- Single Level-0 lock acquisition (`crate::agent::lock_external(ctx.externals)`).
- `retain` closure calls `is_pid_alive` (syscall, no locks) + `tracing::info!` + `event_log::log` (file lock at Level 2 — separate sub-graph, no Level-0 acquired during it).
- Same lock pattern as the pre-extraction inline block.

## Cadence preservation

`InboxMaintenanceHandler::should_fire` uses `counter.fetch_add(1, Relaxed).is_multiple_of(N)`. `fetch_add` returns the **previous** counter value, so the very first tick (counter=0) fires — matching the pre-extraction `static SWEEP_COUNTER` semantics. Pinned by the `fires_on_first_tick_then_every_n` test (N=4, 9 ticks: `100010001` pattern).

## Diff stat

- `src/daemon/mod.rs`: **+31 / -64** (net **-33 lines**)
- `src/daemon/per_tick/mod.rs`: +27 / -7 (re-exports + TickContext field + doc update)
- `src/daemon/per_tick/snapshot.rs`: +3 / -1 (test fixture: add `externals` field)
- `src/daemon/per_tick/inbox_maintenance.rs`: **new, 155 lines** (handler 99 + tests 56)
- `src/daemon/per_tick/external_liveness.rs`: **new, 127 lines** (handler 37 + tests 90)

Cumulative `daemon/mod.rs` shrinkage across T-B2 + T-B3: ~-59 lines from the `run_core` body.

## Test plan

- [x] `cargo build --features tray` — OK
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --bins --features tray` — **2096 passed, 0 failed**, 7 ignored. Existing tests pass with **identical assertions** (only the two T-B2 handler tests touched: each gained one line to construct the new `externals` TickContext field — neither's assertions changed).
- [x] Four new unit tests:
  - `daemon::per_tick::inbox_maintenance::tests::fires_on_first_tick_then_every_n` — cadence pin (N=4, expect `[T,F,F,F,T,F,F,F,T]`)
  - `daemon::per_tick::inbox_maintenance::tests::run_is_no_op_on_empty_fixtures` — smoke; empty registry + temp home; all 6 sub-ops complete without panic
  - `daemon::per_tick::external_liveness::tests::run_is_noop_on_empty_registry` — empty registry sanity
  - `daemon::per_tick::external_liveness::tests::run_evicts_dead_pid_keeps_live_pid` — pins `retain` semantics; PID `999_999_999` for dead case (above macOS pid_max=99998 and Linux=32768; `kill(pid, 0)` returns ESRCH), `std::process::id()` for live case
- [ ] CI green on this branch

## Refs

- Issue #694 BLOCK 1 (continuation of #757)
- Builds on T-B2 / PR #757 (snapshot + poll-reminder, merged as `fd197bd`)
- `docs/DAEMON-LOCK-ORDERING.md` Rule 1 (top-down acquisition)
- Fleet protocol §3.15 (daemon-core cushion), §10/§12.4 (worktree discipline)