### PR TITLE
refactor(#694): extract hang-detection + watchdog cohort (BLOCK 1 third cut)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -533,6 +533,7 @@ fn run_core(
     let poll_reminder_handler = per_tick::PollReminderHandler::new(30);
     let inbox_maintenance_handler = per_tick::InboxMaintenanceHandler::new(60);
     let external_liveness_handler = per_tick::ExternalLivenessHandler::new();
+    let hang_detection_handler = per_tick::HangDetectionHandler::new();
 
     // Periodic tick channel (every 10s for health/schedule/session maintenance)
     let tick_rx = {
@@ -593,37 +594,8 @@ fn run_core(
         // (spawned earlier) so app mode gets the same behavior as daemon mode.
         // Hang detection and health decay stay here — they're daemon-only
         // concerns (hang notifications tie into crash respawn accounting).
-        {
-            let reg = agent::lock_registry(&registry);
-            for (name, handle) in reg.iter() {
-                {
-                    let mut core = handle.core.lock();
-                    core.health.maybe_decay();
-                    let agent_state = core.state.current;
-                    let silent = core.state.last_output.elapsed();
-                    // Sprint 24 P1: snapshot heartbeat_pair UNDER the
-                    // core lock (Level 1 → Level 3 top-down per Rule 1
-                    // in docs/DAEMON-LOCK-ORDERING.md). Pair lock is
-                    // acquired+released synchronously by `snapshot_for`
-                    // so it's not held during subsequent `check_hang`
-                    // execution (Rule 3 leaf-level).
-                    let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
-                    if core.health.check_hang(
-                        agent_state,
-                        silent,
-                        pair.last_input_at_ms,
-                        pair.heartbeat_at_ms,
-                    ) {
-                        tracing::warn!(
-                            agent = %name,
-                            state = agent_state.display_name(),
-                            silent = ?silent,
-                            "hang detected"
-                        );
-                    }
-                }
-            }
-        }
+        // #694 BLOCK 1 — extracted into daemon::per_tick::HangDetectionHandler.
+        hang_detection_handler.run(&tick_ctx);
 
         // Watchdog: classify PTY output → BlockedReason
         {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -529,11 +529,16 @@ fn run_core(
     // across ticks. Called at their pre-extraction sites in the main
     // loop below.
     use per_tick::PerTickHandler as _;
+    // Watchdog dry-run mode: log classifications without mutating health
+    // state. Read ONCE at daemon startup (matches pre-extraction
+    // semantics; env changes mid-runtime are not observed).
+    let watchdog_dry_run = watchdog::watchdog_dry_run_from_env();
     let snapshot_handler = per_tick::SnapshotRotationHandler::new();
     let poll_reminder_handler = per_tick::PollReminderHandler::new(30);
     let inbox_maintenance_handler = per_tick::InboxMaintenanceHandler::new(60);
     let external_liveness_handler = per_tick::ExternalLivenessHandler::new();
     let hang_detection_handler = per_tick::HangDetectionHandler::new();
+    let watchdog_handler = per_tick::WatchdogHandler::new(watchdog_dry_run);
 
     // Periodic tick channel (every 10s for health/schedule/session maintenance)
     let tick_rx = {
@@ -553,9 +558,6 @@ fn run_core(
             .ok();
         rx
     };
-
-    // Watchdog dry-run mode: log classifications without mutating health state.
-    let watchdog_dry_run = watchdog::watchdog_dry_run_from_env();
 
     // Main loop: event-driven via select on crash channel + periodic tick
     loop {
@@ -594,32 +596,11 @@ fn run_core(
         // (spawned earlier) so app mode gets the same behavior as daemon mode.
         // Hang detection and health decay stay here — they're daemon-only
         // concerns (hang notifications tie into crash respawn accounting).
-        // #694 BLOCK 1 — extracted into daemon::per_tick::HangDetectionHandler.
+        // #694 BLOCK 1 cohort — extracted into daemon::per_tick. Hang and
+        // Watchdog are adjacent so the same-tick `core.health` read-after-
+        // write sequence stays visibly contiguous in the select! lambda.
         hang_detection_handler.run(&tick_ctx);
-
-        // Watchdog: classify PTY output → BlockedReason
-        {
-            let reg = agent::lock_registry(&registry);
-            for (name, handle) in reg.iter() {
-                let backend = match crate::backend::Backend::from_command(&handle.backend_command) {
-                    Some(b) => b,
-                    None => continue,
-                };
-                {
-                    let mut core = handle.core.lock();
-                    let rows = core.vterm.rows() as usize;
-                    let screen = core.vterm.tail_lines(rows);
-                    watchdog::run_watchdog_pass(
-                        home,
-                        name,
-                        &backend,
-                        &screen,
-                        &mut core.health,
-                        watchdog_dry_run,
-                    );
-                }
-            }
-        }
+        watchdog_handler.run(&tick_ctx);
 
         // Liveness check for external agents.
         // #694 BLOCK 1 — extracted into daemon::per_tick::ExternalLivenessHandler.

--- a/src/daemon/per_tick/hang_detection.rs
+++ b/src/daemon/per_tick/hang_detection.rs
@@ -1,0 +1,110 @@
+//! Hang detection + health decay: walks the agent registry every tick,
+//! decays each agent's health, classifies hangs, logs warnings on the
+//! transition. Extracted verbatim from `src/daemon/mod.rs:591-626`
+//! (pre-T-B4) — same iteration order, same lock-acquisition chain,
+//! same `tracing::warn!` field names.
+//!
+//! **Cohort note** (T-B4): this handler MUTATES `core.health` (via
+//! `maybe_decay` + the implicit `check_hang` side-effects on transition
+//! tracking), and is followed in the same tick by [`super::watchdog`]
+//! which also mutates `core.health` (BlockedReason classification). The
+//! two handlers are extracted together so the same-tick mutation
+//! sequence stays contained in a single PR — splitting would route the
+//! sequence across module boundaries with no compile-time signal that
+//! the ordering matters.
+
+use super::{PerTickHandler, TickContext};
+use crate::agent;
+
+pub(crate) struct HangDetectionHandler;
+
+impl HangDetectionHandler {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl PerTickHandler for HangDetectionHandler {
+    fn name(&self) -> &'static str {
+        "hang_detection"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        // Lock-acquisition order per docs/DAEMON-LOCK-ORDERING.md:
+        // registry (L0, root) → per-agent core (L1) → heartbeat_pair
+        // (L3 leaf, acquired+released synchronously by `snapshot_for`).
+        // Rule 3: the leaf lock is never held while acquiring another
+        // lock — `snapshot_for` returns a copy and drops its pair guard
+        // before `check_hang` runs.
+        let reg = agent::lock_registry(ctx.registry);
+        for (name, handle) in reg.iter() {
+            let mut core = handle.core.lock();
+            core.health.maybe_decay();
+            let agent_state = core.state.current;
+            let silent = core.state.last_output.elapsed();
+            let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
+            if core.health.check_hang(
+                agent_state,
+                silent,
+                pair.last_input_at_ms,
+                pair.heartbeat_at_ms,
+            ) {
+                tracing::warn!(
+                    agent = %name,
+                    state = agent_state.display_name(),
+                    silent = ?silent,
+                    "hang detected"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// Smoke test: empty registry → no-op. The interesting integration
+    /// paths (hang threshold tripping, heartbeat_pair freshness, health
+    /// decay) are covered by the existing tests in `crate::health` and
+    /// `daemon::supervisor`; this PR is pure relocation so we only need
+    /// to prove `run()` doesn't panic on the empty case.
+    #[test]
+    fn run_is_noop_on_empty_registry() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-hang-handler-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).ok();
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        HangDetectionHandler::new().run(&ctx);
+
+        assert!(registry.lock().is_empty());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Name pin — used by future Vec<Box<dyn PerTickHandler>> aggregator
+    /// for tracing spans / diagnostic dumps.
+    #[test]
+    fn name_matches_module() {
+        assert_eq!(HangDetectionHandler::new().name(), "hang_detection");
+    }
+}

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -38,12 +38,14 @@ pub(crate) mod hang_detection;
 pub(crate) mod inbox_maintenance;
 pub(crate) mod poll_reminder;
 pub(crate) mod snapshot;
+pub(crate) mod watchdog;
 
 pub(crate) use external_liveness::ExternalLivenessHandler;
 pub(crate) use hang_detection::HangDetectionHandler;
 pub(crate) use inbox_maintenance::InboxMaintenanceHandler;
 pub(crate) use poll_reminder::PollReminderHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;
+pub(crate) use watchdog::WatchdogHandler;
 
 /// Shared per-tick context. Field types match what the daemon main loop
 /// holds verbatim — the trait is pure relocation, not abstraction. New

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -34,11 +34,13 @@ use std::path::Path;
 use std::sync::Arc;
 
 pub(crate) mod external_liveness;
+pub(crate) mod hang_detection;
 pub(crate) mod inbox_maintenance;
 pub(crate) mod poll_reminder;
 pub(crate) mod snapshot;
 
 pub(crate) use external_liveness::ExternalLivenessHandler;
+pub(crate) use hang_detection::HangDetectionHandler;
 pub(crate) use inbox_maintenance::InboxMaintenanceHandler;
 pub(crate) use poll_reminder::PollReminderHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;

--- a/src/daemon/per_tick/watchdog.rs
+++ b/src/daemon/per_tick/watchdog.rs
@@ -1,0 +1,120 @@
+//! Watchdog: classify PTY tail per agent and mutate `core.health` with
+//! the resulting `BlockedReason`. Extracted verbatim from
+//! `src/daemon/mod.rs:628-650` (pre-T-B4) — same iteration order, same
+//! lock-acquisition chain, same vterm tail capture, same call to
+//! `crate::daemon::watchdog::run_watchdog_pass`.
+//!
+//! **Cohort note** (T-B4): paired with [`super::hang_detection`] so the
+//! same-tick `core.health` mutation sequence — hang → watchdog — stays
+//! contained in one PR. Extracting either alone would route the
+//! sequence across module boundaries with no compile-time signal that
+//! the order matters.
+//!
+//! Env-flag note (per lead's T-B4 spot-check): `dry_run` is read ONCE
+//! at construction (in `run_core`'s startup phase). `run()` reads
+//! `self.dry_run` rather than re-querying the env on every tick — the
+//! pre-extraction inline code only read `AGEND_WATCHDOG_DRY_RUN` at
+//! daemon startup, so re-reading would be a subtle behavior change.
+
+use super::{PerTickHandler, TickContext};
+use crate::agent;
+
+pub(crate) struct WatchdogHandler {
+    dry_run: bool,
+}
+
+impl WatchdogHandler {
+    pub(crate) fn new(dry_run: bool) -> Self {
+        Self { dry_run }
+    }
+}
+
+impl PerTickHandler for WatchdogHandler {
+    fn name(&self) -> &'static str {
+        "watchdog"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        // Lock-acquisition order per docs/DAEMON-LOCK-ORDERING.md:
+        // registry (L0) → per-agent core (L1). `&mut core.health` is a
+        // field borrow through the already-held L1 MutexGuard, not a
+        // separate Mutex re-acquisition — same shape as HangDetection.
+        let reg = agent::lock_registry(ctx.registry);
+        for (name, handle) in reg.iter() {
+            let backend = match crate::backend::Backend::from_command(&handle.backend_command) {
+                Some(b) => b,
+                None => continue,
+            };
+            let mut core = handle.core.lock();
+            let rows = core.vterm.rows() as usize;
+            let screen = core.vterm.tail_lines(rows);
+            crate::daemon::watchdog::run_watchdog_pass(
+                ctx.home,
+                name,
+                &backend,
+                &screen,
+                &mut core.health,
+                self.dry_run,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// Empty registry → no iteration, no panic. The interesting paths
+    /// (Backend resolution, vterm tail, BlockedReason classification)
+    /// are covered by existing `daemon::watchdog` tests; this PR is
+    /// pure relocation.
+    #[test]
+    fn run_is_noop_on_empty_registry() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-watchdog-handler-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).ok();
+
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        WatchdogHandler::new(false).run(&ctx);
+        WatchdogHandler::new(true).run(&ctx);
+
+        assert!(registry.lock().is_empty());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Constructor stores `dry_run` for later reads — `run()` reads
+    /// `self.dry_run` rather than re-querying the env on every tick.
+    /// Pin this so a future refactor doesn't sneak a per-tick env read.
+    #[test]
+    fn dry_run_field_is_stored_at_construction() {
+        let h_dry = WatchdogHandler::new(true);
+        let h_live = WatchdogHandler::new(false);
+        assert!(h_dry.dry_run);
+        assert!(!h_live.dry_run);
+    }
+
+    #[test]
+    fn name_matches_module() {
+        assert_eq!(WatchdogHandler::new(false).name(), "watchdog");
+    }
+}


### PR DESCRIPTION
## Summary

#694 BLOCK 1 **third cut**, following the trait pattern landed in #757 / #758. Two more periodic concerns move behind `daemon::per_tick::PerTickHandler`, **as a cohort**:

- `HangDetectionHandler` (was `src/daemon/mod.rs:591-626` pre-T-B4) — walks the registry, runs `core.health.maybe_decay()`, snapshots `heartbeat_pair` (L3 leaf), checks for hang transitions, logs warnings. Stateless.
- `WatchdogHandler` (was `src/daemon/mod.rs:628-650` pre-T-B4) — walks the registry, captures vterm tail, classifies BlockedReason via `crate::daemon::watchdog::run_watchdog_pass`. Owns one `dry_run: bool` field read from env at construction.

After this PR: **6 of 8 BLOCK 1 subsystems extracted**. T-B5 closes out BLOCK 1 (check_schedules + thin check_ci_watches wrapper).

## Why a cohort (not two separate PRs)

Both blocks **mutate `core.health` in the same tick**:

- HangDetection writes via `core.health.maybe_decay()` and transition tracking inside `check_hang`.
- Watchdog writes via `&mut core.health` passed to `run_watchdog_pass` for BlockedReason classification.

Extracting one without the other splits an implicit "same-tick mutation sequence on `core.health`" invariant across a module boundary. Execution order is preserved within the tick (both handlers run at their original positions, hang first then watchdog), but a future reader scanning each module in isolation would see no compile-time signal that the order matters. Bundling the cohort makes the dependency explicit in a single diff and keeps both writers of `core.health` reviewable together.

This is the rationale that surfaced in the T-B3 early report when deferring watchdog from that PR; T-B4's dispatch instructed exactly this cohort grouping.

## Same-tick adjacency proof

In the post-extraction `run_core`:

```rust
// daemon/mod.rs (after this PR)
hang_detection_handler.run(&tick_ctx);
watchdog_handler.run(&tick_ctx);
```

Consecutive lines, no intervening logic. `git grep -n "hang_detection_handler.run\|watchdog_handler.run" src/daemon/mod.rs` returns the two lines back-to-back.

## Lock-ordering analysis (per §3.15 daemon-core cushion)

Both handlers use the **same** acquisition chain, preserved verbatim from the pre-extraction inline blocks (`docs/DAEMON-LOCK-ORDERING.md` Rules 1 + 3):

```
registry (L0, root)
  → per-agent core (L1)
    → heartbeat_pair (L3 leaf)    [HangDetection only]
```

Key correctness points:

1. `&mut core.health` is a field borrow through the already-held L1 `MutexGuard`, **not** a separate `Mutex<HealthTracker>` re-acquisition. No new locks introduced.
2. `heartbeat_pair::snapshot_for(name)` acquires the L3 leaf, copies the 3-field struct, releases. The leaf lock is never held during another acquisition — Rule 3 satisfied.
3. The handler does not hold the L0 registry guard while waiting on any external IO — `tracing::warn!` is sync log emission, no locks involved beyond Level 3 sink_registry (which has its own leaf-release contract).
4. WatchdogHandler's `&mut core.health` arg to `run_watchdog_pass` mutates BlockedReason inside the already-acquired L1 guard scope — same shape as the pre-extraction code.

No new lock-ordering relationships introduced.

## Trait + context

Unchanged from T-B3. `TickContext` still has `home / registry / externals / configs`; neither new handler needed a TickContext field (HangDetection uses only `registry`; Watchdog uses `home` + `registry`).

## Env-flag plumbing

Per dispatch contract: `watchdog_dry_run` is read ONCE at daemon startup (matching pre-extraction code), then passed by value into `WatchdogHandler::new(dry_run)`. The handler stores the bool on the struct; `run()` reads `self.dry_run` rather than re-querying env on every tick. Pinned by the `dry_run_field_is_stored_at_construction` test so a future refactor that sneaks `std::env::var(...)` inside `run()` trips.

The `let watchdog_dry_run = …;` local now lives in the per-tick handler instantiation block alongside the other handlers (was previously interleaved with the tick-channel setup — minor layout cleanup, same one-shot read semantics).

## Diff stat

- `src/daemon/mod.rs`: **+11 / -58** (net **-47 lines**)
- `src/daemon/per_tick/mod.rs`: +4 / 0 (two new module decls + two new re-exports)
- `src/daemon/per_tick/hang_detection.rs`: **new, 110 lines** (handler 55 + tests 55)
- `src/daemon/per_tick/watchdog.rs`: **new, 120 lines** (handler 55 + tests 65)

Cumulative `run_core` body shrinkage across T-B2 + T-B3 + T-B4: **~-106 lines** from the original 200-line `select!` lambda. The remaining inline blocks in `run_core` are `check_schedules` + `check_ci_watches` (T-B5 targets) and the `select!` driver / exit-event handling (loop-driver, not periodic, stays inline).

## Test plan

- [x] `cargo build --features tray` — OK
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --bins --features tray` — **2101 passed, 0 failed**, 7 ignored. Existing tests pass with **identical assertions**.
- [x] Five new unit tests:
  - `daemon::per_tick::hang_detection::tests::run_is_noop_on_empty_registry` — smoke
  - `daemon::per_tick::hang_detection::tests::name_matches_module` — Vec-aggregator-ready name pin
  - `daemon::per_tick::watchdog::tests::run_is_noop_on_empty_registry` — smoke for both `dry_run` variants
  - `daemon::per_tick::watchdog::tests::dry_run_field_is_stored_at_construction` — pins "no per-tick env read" invariant
  - `daemon::per_tick::watchdog::tests::name_matches_module` — name pin
- [ ] CI green on this branch

## Refs

- Issue #694 BLOCK 1 (continuation of #757, #758)
- T-B2 / PR #757 (snapshot + poll_reminder, merged `fd197bd`)
- T-B3 / PR #758 (inbox_maintenance + external_liveness, merged `84e5fa5`) — early report on T-B3 first surfaced the watchdog↔hang-detection coupling that motivated this cohort
- `docs/DAEMON-LOCK-ORDERING.md` Rules 1 + 3
- Fleet protocol §3.15 (daemon-core cushion), §10/§12.4 (worktree discipline)