### PR TITLE
refactor(#694): BLOCK 1 final cut — schedules + ci_watch wrapper (8/8 done)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -26,7 +26,6 @@ pub(crate) mod watchdog;
 
 use crate::agent::{self, AgentRegistry};
 use crate::channel::NotifySeverity;
-use ci_watch::check_ci_watches;
 pub use tui_bridge::serve_agent_tui;
 
 use parking_lot::Mutex;
@@ -539,6 +538,7 @@ fn run_core(
     let hang_detection_handler = per_tick::HangDetectionHandler::new();
     let watchdog_handler = per_tick::WatchdogHandler::new(watchdog_dry_run);
     let check_schedules_handler = per_tick::CheckSchedulesHandler::new();
+    let ci_watch_poll_handler = per_tick::CiWatchPollHandler::new();
 
     // Periodic tick channel (every 10s for health/schedule/session maintenance)
     let tick_rx = {
@@ -612,7 +612,8 @@ fn run_core(
 
         // #694 BLOCK 1 — extracted into daemon::per_tick::CheckSchedulesHandler.
         check_schedules_handler.run(&tick_ctx);
-        check_ci_watches(home, &registry);
+        // #694 BLOCK 1 — extracted into daemon::per_tick::CiWatchPollHandler.
+        ci_watch_poll_handler.run(&tick_ctx);
 
         // Periodic inbox maintenance — every 60 ticks (≈10 min at 10s/tick).
         // #694 BLOCK 1 — extracted into daemon::per_tick::InboxMaintenanceHandler.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -27,7 +27,6 @@ pub(crate) mod watchdog;
 use crate::agent::{self, AgentRegistry};
 use crate::channel::NotifySeverity;
 use ci_watch::check_ci_watches;
-use cron_tick::check_schedules;
 pub use tui_bridge::serve_agent_tui;
 
 use parking_lot::Mutex;
@@ -539,6 +538,7 @@ fn run_core(
     let external_liveness_handler = per_tick::ExternalLivenessHandler::new();
     let hang_detection_handler = per_tick::HangDetectionHandler::new();
     let watchdog_handler = per_tick::WatchdogHandler::new(watchdog_dry_run);
+    let check_schedules_handler = per_tick::CheckSchedulesHandler::new();
 
     // Periodic tick channel (every 10s for health/schedule/session maintenance)
     let tick_rx = {
@@ -610,7 +610,8 @@ fn run_core(
         // #694 BLOCK 1 — extracted into daemon::per_tick::SnapshotRotationHandler.
         snapshot_handler.run(&tick_ctx);
 
-        check_schedules(home, &registry);
+        // #694 BLOCK 1 — extracted into daemon::per_tick::CheckSchedulesHandler.
+        check_schedules_handler.run(&tick_ctx);
         check_ci_watches(home, &registry);
 
         // Periodic inbox maintenance — every 60 ticks (≈10 min at 10s/tick).

--- a/src/daemon/per_tick/check_schedules.rs
+++ b/src/daemon/per_tick/check_schedules.rs
@@ -1,0 +1,78 @@
+//! Cron + one-shot schedule firing per tick — thin wrapper around
+//! [`crate::daemon::cron_tick::check_schedules`]. Extracted from
+//! `src/daemon/mod.rs:613` (pre-T-B5), which was already a single
+//! function call: all schedule state (the `.schedule_last_check`
+//! file, the schedule store, fired-once tracking) lives inside
+//! `cron_tick::check_schedules` and is persisted to disk under
+//! `home`. Nothing to migrate to a handler field.
+//!
+//! Kept as a distinct handler (vs inlining `cron_tick::check_schedules`
+//! directly at the call site) so the per-tick dispatch shape stays
+//! uniform: every periodic concern flows through a `PerTickHandler`,
+//! reachable by name from the future Vec aggregator.
+
+use super::{PerTickHandler, TickContext};
+
+pub(crate) struct CheckSchedulesHandler;
+
+impl CheckSchedulesHandler {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl PerTickHandler for CheckSchedulesHandler {
+    fn name(&self) -> &'static str {
+        "check_schedules"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        crate::daemon::cron_tick::check_schedules(ctx.home, ctx.registry);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// Smoke test: empty registry + temp home with no `schedules.json`
+    /// → `check_schedules` returns at the empty-store guard, no panic.
+    /// The interesting integration paths (cron parsing, schedule firing,
+    /// one-shot consumption) are covered by existing `cron_tick` and
+    /// `schedules` tests; this PR is pure relocation.
+    #[test]
+    fn run_is_noop_with_no_schedules() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-check-schedules-handler-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).ok();
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        CheckSchedulesHandler::new().run(&ctx);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn name_matches_module() {
+        assert_eq!(CheckSchedulesHandler::new().name(), "check_schedules");
+    }
+}

--- a/src/daemon/per_tick/ci_watch_poll.rs
+++ b/src/daemon/per_tick/ci_watch_poll.rs
@@ -1,0 +1,75 @@
+//! CI-watch poll per tick — thin wrapper around
+//! [`crate::daemon::ci_watch::check_ci_watches`]. Extracted from
+//! `src/daemon/mod.rs:614` (pre-T-B5), which was already a single
+//! function call: the ci_watch module (split into its own
+//! submodule tree by #701) owns all polling state, eager-GC pass,
+//! and lazy expiry. Nothing to migrate to a handler field.
+//!
+//! Kept as a distinct handler (vs inlining the call) so the per-tick
+//! dispatch shape stays uniform — every periodic concern flows through
+//! a `PerTickHandler`, reachable by name from the future Vec aggregator.
+
+use super::{PerTickHandler, TickContext};
+
+pub(crate) struct CiWatchPollHandler;
+
+impl CiWatchPollHandler {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl PerTickHandler for CiWatchPollHandler {
+    fn name(&self) -> &'static str {
+        "ci_watch_poll"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        crate::daemon::ci_watch::check_ci_watches(ctx.home, ctx.registry);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// Smoke test: empty registry + temp home with no watches → handler
+    /// completes without panic. Integration paths (provider invocation,
+    /// branch SHA polling, expiry sweep) are covered by existing
+    /// `daemon::ci_watch::poller` tests.
+    #[test]
+    fn run_is_noop_with_no_watches() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-ci-watch-handler-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).ok();
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        CiWatchPollHandler::new().run(&ctx);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn name_matches_module() {
+        assert_eq!(CiWatchPollHandler::new().name(), "ci_watch_poll");
+    }
+}

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -33,6 +33,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
+pub(crate) mod check_schedules;
 pub(crate) mod external_liveness;
 pub(crate) mod hang_detection;
 pub(crate) mod inbox_maintenance;
@@ -40,6 +41,7 @@ pub(crate) mod poll_reminder;
 pub(crate) mod snapshot;
 pub(crate) mod watchdog;
 
+pub(crate) use check_schedules::CheckSchedulesHandler;
 pub(crate) use external_liveness::ExternalLivenessHandler;
 pub(crate) use hang_detection::HangDetectionHandler;
 pub(crate) use inbox_maintenance::InboxMaintenanceHandler;

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -34,6 +34,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 pub(crate) mod check_schedules;
+pub(crate) mod ci_watch_poll;
 pub(crate) mod external_liveness;
 pub(crate) mod hang_detection;
 pub(crate) mod inbox_maintenance;
@@ -42,6 +43,7 @@ pub(crate) mod snapshot;
 pub(crate) mod watchdog;
 
 pub(crate) use check_schedules::CheckSchedulesHandler;
+pub(crate) use ci_watch_poll::CiWatchPollHandler;
 pub(crate) use external_liveness::ExternalLivenessHandler;
 pub(crate) use hang_detection::HangDetectionHandler;
 pub(crate) use inbox_maintenance::InboxMaintenanceHandler;


### PR DESCRIPTION
## Summary

#694 BLOCK 1 **final cut**. Two thin-wrapper handlers extracted, closing out BLOCK 1 at **8 of 8 subsystems**.

- `CheckSchedulesHandler` — wraps `crate::daemon::cron_tick::check_schedules`. Was `src/daemon/mod.rs:613` (one-line inline call).
- `CiWatchPollHandler` — wraps `crate::daemon::ci_watch::check_ci_watches`. Was `src/daemon/mod.rs:614` (one-line inline call). The underlying function lives in the ci_watch submodule tree split out by #701.

Both handlers are stateless: same shape as `ExternalLivenessHandler` from T-B3. No handler-field state needed.

## BLOCK 1 closure

After this PR merges, the daemon's `run_core` select! lambda contains 8 consecutive `<handler>_handler.run(&tick_ctx);` calls and **nothing else** in its periodic-concern section (just blank lines + comments between them). The original 200-line lambda from #694's diagnosis is now ~10 handler-invocation lines plus per-handler comments.

Final per-tick handler list (in execution order):

```rust
hang_detection_handler.run(&tick_ctx);
watchdog_handler.run(&tick_ctx);
external_liveness_handler.run(&tick_ctx);
snapshot_handler.run(&tick_ctx);
check_schedules_handler.run(&tick_ctx);
ci_watch_poll_handler.run(&tick_ctx);
inbox_maintenance_handler.run(&tick_ctx);
poll_reminder_handler.run(&tick_ctx);
```

Verified via `git grep -n '_handler.run\b' src/daemon/mod.rs`: 8 matches, contiguous block (lines 602/603/607/611/614/616/620/624). No intervening non-handler logic.

## Why both handlers are thin wrappers

Dispatch speculated that CheckSchedules might need to migrate "cron-tick counters / last-fired timestamps currently held in the inline block." Reading the code:

- **The inline blocks are one-liners** (`check_schedules(home, &registry); check_ci_watches(home, &registry);`). No state in the inline blocks themselves.
- All cron state lives inside `cron_tick::check_schedules` and is **persisted to disk** via `<home>/.schedule_last_check`. Migrating that to in-memory would lose the daemon-restart survivability (the timestamp tracks "last tick we observed" so missed schedules don't re-fire), which is real behavior visible to operators after a daemon crash + restart — a clear ZERO behavior change violation.
- All ci_watch state is in the submodule and on disk too (watch registry, eager-GC tracking).

So both handlers wrap their pub-fn target without any state migration, and `cron_tick::check_schedules` / `ci_watch::check_ci_watches` remain untouched.

## State-migration restraint (per §3.15 daemon-core cushion)

Refusing to refactor the underlying function bodies in pursuit of "cleaner" handler-field state is deliberate. The schedules file-backed timestamp is a real persistence contract. Same logic for ci_watch's on-disk watch registry. Hand-waving these into memory would silently change daemon-restart semantics — exactly the class of subtle regression §3.15 exists to prevent.

## Diff stat

- `src/daemon/mod.rs`: +6 / -4 (net **+2 lines**, but two stale imports removed, two new handler instantiations + two `.run()` call replacements — the net positive is comment doubling on the new dispatch sites)
- `src/daemon/per_tick/mod.rs`: +4 / 0 (two new mod decls + two new re-exports)
- `src/daemon/per_tick/check_schedules.rs`: **new, 78 lines** (handler 30 + tests 48)
- `src/daemon/per_tick/ci_watch_poll.rs`: **new, 75 lines** (handler 30 + tests 45)

Cumulative `run_core` body shrinkage across T-B2 + T-B3 + T-B4 + T-B5: original ~200-line `select!` lambda body is now ~30 lines of handler dispatch + comments. That's the headline win of #694 BLOCK 1.

## Test plan

- [x] `cargo build --features tray` — OK
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean (removed now-unused `use ci_watch::check_ci_watches;` and `use cron_tick::check_schedules;` imports)
- [x] `cargo fmt --check` — clean
- [x] `cargo test --bins --features tray` — **2105 passed, 0 failed**, 7 ignored. Existing tests pass with **identical assertions** (no pre-existing test file touched).
- [x] Four new unit tests:
  - `daemon::per_tick::check_schedules::tests::run_is_noop_with_no_schedules`
  - `daemon::per_tick::check_schedules::tests::name_matches_module`
  - `daemon::per_tick::ci_watch_poll::tests::run_is_noop_with_no_watches`
  - `daemon::per_tick::ci_watch_poll::tests::name_matches_module`
- [ ] CI green on this branch

## Follow-ups

### T-B6 candidate — Vec consolidation (not implemented here)

With BLOCK 1 closed, the T-B2-era constraint that blocked Vec aggregation (handlers separated by inline `check_schedules` / `check_ci_watches` / inbox-maintenance blocks) is fully resolved. The 8 handler `.run()` calls now sit contiguously in the select! lambda with no intervening non-handler logic, so collapsing to `Vec<Box<dyn PerTickHandler>>` becomes provably zero-behavior-change.

Sketch for T-B6:

```rust
let handlers: Vec<Box<dyn per_tick::PerTickHandler>> = vec![
    Box::new(per_tick::HangDetectionHandler::new()),
    Box::new(per_tick::WatchdogHandler::new(watchdog_dry_run)),
    Box::new(per_tick::ExternalLivenessHandler::new()),
    Box::new(per_tick::SnapshotRotationHandler::new()),
    Box::new(per_tick::CheckSchedulesHandler::new()),
    Box::new(per_tick::CiWatchPollHandler::new()),
    Box::new(per_tick::InboxMaintenanceHandler::new(60)),
    Box::new(per_tick::PollReminderHandler::new(30)),
];

// In the tick body:
for h in &handlers { h.run(&tick_ctx); }
```

**What T-B6 changes**: call-site consolidation only. The 8 lines in the tick body become 1 `for` loop; the 8 separate `let <name>_handler = ...;` lines become a `vec![Box::new(...), ...]` literal.

**What T-B6 does NOT change**:
- Error handling — no handler returns `Result`; T-B6 doesn't introduce one.
- Panic propagation — same `&self`-call semantics; a panicking handler still terminates the tick the same way.
- Per-handler instrumentation — no tracing spans added; the existing per-handler `tracing::warn!` / `tracing::info!` sites inside handler bodies are unchanged.
- Trait shape — `PerTickHandler` itself unchanged.
- Execution order — Vec order preserves the current named-binding order verbatim.

A T-B6 reviewer should be able to verify the diff by `diff -u`: the 8 `<handler>.run(&tick_ctx);` lines collapse into a `for h in &handlers { h.run(&tick_ctx); }` (3 lines), and the 8 `let <handler> = ...;` lines collapse into a `vec![Box::new(...), ...]` literal. Full stop, no other code paths touched.

### Future-extension hooks

The `PerTickHandler::name()` method, dead-coded since T-B2, becomes useful once the Vec exists — a `for` loop over `&handlers` can wrap each `.run()` in a `tracing::info_span!("tick", handler = h.name()).entered()` or similar without touching individual handlers. That's a separate diagnostic-quality PR (NOT T-B6 itself, which stays pure call-site consolidation).

## Refs

- Issue #694 BLOCK 1 (continuation of #757, #758, #759 — closing the block)
- T-B2 / PR #757 (snapshot + poll_reminder, merged `fd197bd`)
- T-B3 / PR #758 (inbox_maintenance + external_liveness, merged `84e5fa5`)
- T-B4 / PR #759 (hang_detection + watchdog cohort, merged `59650b6`)
- `docs/DAEMON-LOCK-ORDERING.md` (unchanged — no new lock-acquisition relationships)
- Fleet protocol §3.15 (daemon-core cushion), §10/§12.4 (worktree discipline)