### PR TITLE
fix(F39): narrow Gemini Thinking pattern — require timer-prefix paren

### DIFF
--- a/docs/HUNG-STATE-TRANSITIONS.md
+++ b/docs/HUNG-STATE-TRANSITIONS.md
@@ -359,7 +359,7 @@ validation (`#685` sub-task 5). Not recommendations.**
 |---|---|---|
 | (a) Cursor-anchored / viewport-only | Match patterns only against last N rows or visible viewport; exclude scrollback rows entirely | Count Scenario C bounces before/after on corpus; **feasibility check**: portable-pty / vterm cursor-position API surface on macOS / Linux / Windows ConPTY (Open question §F39.5) |
 | (b) Recent-output-bytes gate | Match against bytes received in last K `feed()` calls (slice accumulated buffer) instead of full rendered screen | Measure output rate distribution per backend; choose K such that legitimate Thinking matches stay above threshold |
-| (c) Co-required negative pattern | `Thinking` valid only if `esc to cancel` present AND prompt indicator (e.g. `❯`) absent | Count Thinking→Idle transitions with spinner visible on corpus |
+| (c) Co-required negative pattern¹ | `Thinking` valid only if `esc to cancel` present AND prompt indicator (e.g. `❯`) absent | Count Thinking→Idle transitions with spinner visible on corpus |
 | (d) Oscillation-detection min-hold extension | Counter detects ≥2 transitions touching the same state within N seconds → extend `min_hold` to N × K seconds before allowing further transitions | Measure oscillation frequency on corpus |
 | (e) Pattern-source-line tracking | `detect()` returns match row index; scrollback rows (above viewport top) yield "stale" verdict and skip `transition()` | Measure scrollback-vs-viewport match rate per pattern |
 | (f) Per-pattern / dynamic `LATCHED_STATE_EXPIRY` | Per-pattern expiry value (shorter for `Thinking`), or dynamic shrink when current state held > 2× typical duration | Measure typical Thinking duration per backend; identify outliers |
@@ -368,6 +368,12 @@ validation (`#685` sub-task 5). Not recommendations.**
 transition gate at `rg "min_hold" src/state.rs`) to make oscillation
 harder; (f) shortens `LATCHED_STATE_EXPIRY` so the latched state
 expires sooner. Both are independently composable.
+
+¹ Hypothesis (c) variant — narrowing Gemini Thinking pattern from
+`r"esc to cancel"` to `r"\(esc to cancel,"` — speculatively applied in
+PR #763 (decision `d-20260513231713506833-1`). Reduces FPs from stale
+`esc to cancel` text in scrollback without requiring co-pattern gating.
+Re-evaluate the full (c) hypothesis when fixture corpus data is available.
 
 **Rejected**: tick force-recheck on screen-hash change — `tick()` already
 calls `maybe_expire_latched_state` periodically (`rg "fn tick" src/state.rs`),

--- a/src/state.rs
+++ b/src/state.rs
@@ -423,7 +423,7 @@ impl StatePatterns {
                 // Braille spinner) is a speculative quick-win for a separate
                 // follow-up PR, not committed here.
                 // See docs/HUNG-STATE-TRANSITIONS.md §F39.1
-                (AgentState::Thinking, r"esc to cancel"),
+                (AgentState::Thinking, r"\(esc to cancel,"),
                 // [measured] Input prompt text
                 (AgentState::Idle, r"Type your message"),
                 // [measured] Full ready prompt + YOLO mode
@@ -2114,6 +2114,39 @@ mod tests {
             AgentState::Idle,
             "stale 'Thinking' word in chat history must not latch"
         );
+    }
+
+    #[test]
+    fn gemini_thinking_pattern_matches_spinner_with_timer() {
+        // F39 contract (decision d-20260513231713506833-1): active Gemini
+        // spinner line with timer-paren prefix `(esc to cancel, Ns)` must
+        // trigger Thinking transition.
+        let mut vt = VTerm::new(120, 24);
+        let mut st = StateTracker::new(Some(&Backend::Gemini));
+        drive(
+            &mut vt,
+            &mut st,
+            b"\xe2\xa0\xa6 Thinking... (esc to cancel, 5s)\r\n",
+        );
+        assert_eq!(st.get_state(), AgentState::Thinking);
+    }
+
+    #[test]
+    fn gemini_thinking_pattern_does_not_match_bare_scrollback_text() {
+        // F39 contract (decision d-20260513231713506833-1): prose containing
+        // literal "esc to cancel" without the timer-paren prefix (chat
+        // history, docs, help text) must NOT trigger Thinking. Locks the
+        // narrowing: r"esc to cancel" → r"\(esc to cancel,". Test asserts
+        // semantic outcome, not regex literal — future further-narrowing
+        // that preserves this contract is free to refactor.
+        let mut vt = VTerm::new(120, 24);
+        let mut st = StateTracker::new(Some(&Backend::Gemini));
+        drive(
+            &mut vt,
+            &mut st,
+            b"Press Ctrl-C or esc to cancel the operation.\r\n",
+        );
+        assert_ne!(st.get_state(), AgentState::Thinking);
     }
 
     #[test]


### PR DESCRIPTION
Decision: `d-20260513231713506833-1` (three-party consensus: lead-claude + dev-claude + reviewer-opencode)
Sibling decisions: `d-20260513161542381785-0` (sub-task 2 audit, PR #752) + `d-20260513154400110972-2` (sub-task 1 base, PR #750)

Issue: [#685](https://github.com/suzuke/agend-terminal/issues/685) — F39 sub-finding follow-up. **Issue stays open** (multi-PR initiative); this PR ticks the F39 speculative-fix checkbox.

## Summary
Speculative 1-commit follow-up to the F39 audit (PR #752). Narrows Gemini's Thinking-state regex from `r"esc to cancel"` to `r"\(esc to cancel,"` to reduce false-positive matches against scrollback text. Two unit tests added; audit doc updated with footnote.

## Why this narrow
Active Gemini spinner format is `⠦ Thinking... (esc to cancel, Ns)` — byte-validated via:
- `src/state.rs` `[measured]` comment above the Gemini pattern block
- `src/state.rs` test fixtures (`pipeline_gemini_thinking_via_vterm` / `pipeline_gemini_chat_history_does_not_latch_thinking`) drive `\xe2\xa0\xa6 Thinking... (esc to cancel, 2s)\r\n`

The `(esc to cancel,` literal — open-paren + comma + dynamic timer prefix — is uniquely bound to the active spinner line. Chat history, documentation, and help text containing the bare phrase "esc to cancel" do not include the timer-paren surrounding.

## Why NOT narrow Kiro (asymmetry rationale)
`src/state.rs` Kiro pattern is `r"Kiro is working|esc to cancel"`. The first alternation (`Kiro is working`) is product-name-unique — already tight. The second is a fallback; narrowing it without measured FP gain creates FN risk. Both team members (round 1) agreed Kiro narrowing has no measured benefit. **If Gemini PR shows zero FNs after 2 weeks, revisit Kiro narrowing with the same pattern** (deferred sibling decision).

## Revert criteria (also in commit message)
- Any reproducible Gemini Thinking-state miss within **2 weeks of merge** (single human-verified incident triggers revert)
- Gemini spinner format change (verify against test fixture in `state.rs`)
- Revert procedure: `git revert <SHA> && cargo test`

## #659 acknowledgment
Silent stuck-in-thinking (#659) is handled by the silence-based `check_hang` path (§Entry.E1 / §IdleLong.E1 in `docs/HUNG-STATE-TRANSITIONS.md`), independent of this pattern narrow. The narrow assumes the spinner line is still rendering (which means the CLI thinks a request is in flight). True silent-stuck scenarios degrade through the heartbeat/silence detector, not via Thinking pattern matching.

## Changes
1. **`src/state.rs`** regex literal change at the Gemini Thinking pattern row + 2 unit tests:
   - `gemini_thinking_pattern_matches_spinner_with_timer` — positive: spinner line with timer → Thinking
   - `gemini_thinking_pattern_does_not_match_bare_scrollback_text` — negative: bare "esc to cancel" prose → NOT Thinking
   - Tests contract on semantic outcome (not regex literal) so future further-narrowing that preserves the contract does not break tests.
2. **`docs/HUNG-STATE-TRANSITIONS.md` §F39.4** footnote on hypothesis (c) row noting this speculative variant was applied in this PR.

## Out of scope
- Other 5 mitigation hypotheses (a/b/d/e/f) — full state-machine work, fixture-corpus-gated.
- Fixture corpus design (#685 deliverable #5).
- Kiro pattern narrow — sibling decision, deferred 2 weeks.

scope: follows spec (decision `d-20260513231713506833-1`) — speculative regex narrow + 2 tests + audit-doc footnote, single-concern (§4.1 push-time semantic gate).

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Both new tests pass locally:
  ```
  test state::tests::gemini_thinking_pattern_matches_spinner_with_timer ... ok
  test state::tests::gemini_thinking_pattern_does_not_match_bare_scrollback_text ... ok
  ```
- [x] Existing Gemini tests still pass (`cargo test --bin agend-terminal gemini` 17 passed)
- [ ] Cross-platform CI green required pre-merge (ubuntu + macOS + Windows + LOC + audit)
- [ ] Phase 3 review by reviewer-opencode

🤖 Generated with [Claude Code](https://claude.com/claude-code)