### PR TITLE
feat(F9): shadow-mode productive-output gate for Hung detection (#685 sub-task 4)

### DIFF
--- a/docs/F9-PRODUCTIVE-OUTPUT-GATE.md
+++ b/docs/F9-PRODUCTIVE-OUTPUT-GATE.md
@@ -1,0 +1,176 @@
+# F9 Productive-Output Gate
+
+Source-of-truth for the F9 sub-finding (`#685` Phase 1 deliverables #2 + #3):
+the dual-path supplement to silence-based Hung detection. Companion to the
+F9 inline structured comments in `src/state.rs`, `src/behavioral.rs`, and
+`src/health.rs`.
+
+Issue: [#685](https://github.com/suzuke/agend-terminal/issues/685) F9 sub-finding.
+Sibling sub-tasks: 1 (Hung audit, PR #750), 2 (F39 audit, PR #752), 3 (F39
+speculative narrow, PR #763).
+
+Decision chain:
+- `d-20260513154400110972-2` (sub-task 1 base — Hung invariants)
+- `d-20260513161542381785-0` (sub-task 2 audit — F39 hypotheses)
+- `d-20260513231713506833-1` (sub-task 3 speculative — F39 Gemini narrow)
+- `d-20260513235514013631-0` (this sub-task — F9 productive-output gate)
+
+Maintenance: section IDs (`§F9.1`-`§F9.5`) are contract anchors. Renaming
+must propagate in the same PR. M1/M2/M3 discipline from sub-task 1 applies
+(inline comments use `§F9.<n>` refs; this doc uses `rg <pattern>` grep
+hints; section headings are stable).
+
+## §F9.1 — Architecture rationale (dual-path supplement)
+
+The naïve framing "replace silence_exceeds_threshold with productive-output
+detection" is **wrong**. It would regress `#659` silent-stuck-in-thinking
+detection — a process that truly stops emitting any PTY bytes would never
+trigger Hung if classification waited for *productive* bytes specifically
+(none come; agent stays in pre-Hung state forever).
+
+F9 ships as **dual-path supplement**:
+
+- **Existing silent path** (any output = alive, threshold-based) preserved
+  in `check_hang`. Catches the `#659` case where the agent goes truly silent.
+- **NEW productive path** supplements: when silence is below threshold
+  (the agent is producing *some* output) but no *productive* output has
+  arrived past a separate threshold, the agent is flagged as a Hung
+  candidate. Catches the F9 grey failure where 1-byte spinner output
+  resets the upstream silence timer indefinitely while no real work
+  happens.
+- `check_hang` returns `true` if EITHER path triggers; the union strictly
+  ADDS coverage and never removes it.
+
+This is the layer at which F9 operates: **HealthState** classification.
+The sibling F39(c) hypothesis (sub-task 2 §F39.4) operates at the
+**AgentState** layer (`Thinking` pattern stickiness) — different concern,
+different bug surface. Cross-reference: `docs/HUNG-STATE-TRANSITIONS.md §F39.4`
+footnote.
+
+## §F9.2 — Productive-signal design
+
+A signal is **productive** if either:
+
+1. **MCP heartbeat** refreshed recently (`use_heartbeat: true` configs).
+   Heartbeat refresh = the agent called an MCP tool, which is concrete
+   evidence of forward progress. Universal across managed backends.
+2. **Structural marker** matched the rendered screen text. Markers use
+   **line-start anchors and specific formats** — NOT bare keywords. The
+   bare-keyword approach (`Saved` / `Wrote`) suffers from the same
+   scrollback FP surface as the F39 audit's Scenario A/B/C taxonomy.
+
+Phase 1 minimal generic markers (per `GENERIC_PRODUCTIVE_MARKERS` —
+`rg "GENERIC_PRODUCTIVE_MARKERS" src/behavioral.rs`):
+
+- `^Saved to \S+` — file save banner
+- `^Wrote \d+ bytes` — explicit byte count
+- `^Created file: \S+` — structured creation
+- `^\s*✓\s+(Read|Bash|Edit|Write|Grep)\b` — tool success (mirrors Claude
+  pattern at `rg "Read|Bash|Edit|Write|Grep" src/state.rs`)
+
+**Forbidden in this PR**: bare keyword markers. Prose like "I saved your
+time" must not match. Pinned by `infer_productivity_rejects_bare_keyword_scrollback`
+test.
+
+Per-backend marker extension (e.g. kiro `[fs_read]`, Gemini `✓ ReadFile`)
+is `#685` deliverable #4 — separate sub-task that extends
+`ProductivityConfig.markers` rather than modifying F9 mechanism.
+
+## §F9.3 — Dual-path decision table
+
+| `silent` | `silent_productive` | `agent_state` | Default mode | `AGEND_PRODUCTIVE_GATE=1` |
+|---|---|---|---|---|
+| ≤ threshold | ≤ threshold | any | not-Hung | not-Hung |
+| > threshold | any | non-Idle | discriminator (existing) | discriminator (existing) |
+| ≤ threshold | > threshold | non-Idle | not-Hung + telemetry | discriminator (NEW path) |
+| any | any | `Idle` | not-Hung (Idle never hangs) | not-Hung (Idle never hangs) |
+
+"discriminator" = the existing input-pending-past-heartbeat /
+heartbeat-fresh / IdleLong branch in `check_hang`. Both paths route into
+the same discriminator once a path triggers — F9 does NOT add a new
+discriminator branch, only a new entry condition.
+
+Find threshold mapping in source: `rg "silence_exceeds_threshold" src/health.rs`
+(silent path) and `rg "productive_silence_exceeds" src/health.rs` (F9 path);
+both use the same per-`AgentState` thresholds in this PR (Phase 1 minimal —
+deliverable #4 may diverge them).
+
+## §F9.4 — Known limitations (to be measured by fixture corpus)
+
+### 4.1 Heartbeat-as-productive gap
+Pure-reasoning long sessions (e.g. Claude internal thinking without MCP
+tool calls) generate no heartbeat refresh **and** no productive markers.
+Once `AGEND_PRODUCTIVE_GATE=1` is set, these sessions are flagged Hung
+after threshold despite legitimate work in progress.
+
+**Mitigation deferred**:
+- Follow-up F9 sub-task integrating spinner-cycling-as-productive (the
+  F39 hypothesis (e) variant — pattern-source-line tracking, but inverted
+  to count spinner-glyph activity as evidence).
+- Operator override mechanism (out of F9 scope).
+
+**Risk-contained**: shadow-mode + env-var opt-in means only opted-in
+users encounter this FN during F9 rollout. Activation is gated on
+fixture corpus measurement (§F9.5).
+
+### 4.2 Generic markers FP residual
+Even with structural anchors, edge cases remain. A user pasting the
+literal string `Saved to /tmp/foo` into a chat message (where the agent
+echoes input back) could match the marker. Pinned by the negative test
+`infer_productivity_rejects_bare_keyword_scrollback` — anchor approach
+substantially narrows the surface, but does not eliminate it.
+
+**Mitigation applied in this PR**: line-start anchors (`^`) +
+specific formats. Tests pin both the positive (real markers match) and
+negative (bare prose does not) contracts.
+
+**Residual risk acknowledged**: documented for fixture-corpus measurement.
+
+### 4.3 Cross-backend pattern uniformity
+Phase 1 ships the same generic markers across all backends. Per-backend
+calibration (kiro `[fs_read]`, Gemini-specific tool banners, etc.) lives
+in deliverable #4. Backends whose progress markers differ from the
+generic set will have lower F9 sensitivity in Phase 1.
+
+## §F9.5 — Activation gate (shadow → opt-in → promotion)
+
+F9 productive-silence telemetry fires unconditionally (`rg "F9 dual-path candidate" src/health.rs`).
+**Classification** is gated on the env var `AGEND_PRODUCTIVE_GATE`:
+
+```
+unset / not "1"   → shadow mode (default): telemetry collected,
+                    no Hung classification from productive path
+"1"               → active mode: productive-silence path can flag Hung
+```
+
+**Anti-dead-infra clause**: the Sprint 27 PR-A behavioral telemetry
+shipped in shadow mode and never promoted. This PR's commit message
+encodes explicit promotion criteria to avoid the same outcome:
+
+1. **Fixture corpus measures FP rate < 1% on 3+ confirmed cases**
+   (`#685` issue acceptance criterion).
+2. **2-week shadow-mode telemetry shows behavioral divergence stable**
+   (Sprint 27 PR-A divergence dashboard pattern reused via
+   `rg "behavioral_shadow" src/behavioral.rs`).
+3. **Operator decision to flip the env var default** (separate PR
+   that changes the default in `check_hang` from unset → `"1"`,
+   or removes the gate entirely once promoted).
+
+Without all three, the gate stays default-off. If the timeline drags
+past 6 weeks without measurement, the F9 path itself becomes a candidate
+for removal — dead shadow infra is worse than no infra.
+
+### 5.1 Cross-references
+
+- `docs/HUNG-STATE-TRANSITIONS.md §F39.4` hypothesis (c) row footnote —
+  layer distinction (F39(c) AgentState vs F9 HealthState).
+- `docs/HUNG-STATE-TRANSITIONS.md §Invariants 5b/5c` — F9 preserves the
+  `check_hang -> bool` return-type contract and the `display_name()`
+  string contract (5c wire-compat). The new `silent_productive: Duration`
+  parameter is an internal-API refactor; the sole production caller is
+  `src/daemon/per_tick/hang_detection.rs` (`rg "check_hang(" src/daemon`).
+- `src/behavioral.rs` — `ProductivitySignal`, `ProductivitySource`,
+  `ProductivityConfig`, `config_for_productivity`, `infer_productivity`,
+  `log_productivity_telemetry`. Parallel to `BehavioralSignal` /
+  `BehavioralConfig` / `infer_from_silence` / `log_shadow_telemetry`
+  (Sprint 27 PR-A — silence-side equivalents).

--- a/docs/HUNG-STATE-TRANSITIONS.md
+++ b/docs/HUNG-STATE-TRANSITIONS.md
@@ -375,6 +375,16 @@ PR #763 (decision `d-20260513231713506833-1`). Reduces FPs from stale
 `esc to cancel` text in scrollback without requiring co-pattern gating.
 Re-evaluate the full (c) hypothesis when fixture corpus data is available.
 
+**F9 layer distinction**: this hypothesis lives at the `AgentState`
+layer (`Thinking` pattern stickiness in `src/state.rs`). The F9
+productive-output gate (sub-task 4, decision `d-20260513235514013631-0`,
+see `docs/F9-PRODUCTIVE-OUTPUT-GATE.md`) operates at the `HealthState`
+layer (`Hung` classification in `src/health.rs::check_hang`). The two
+do NOT overlap: F39 mitigations adjust *which `AgentState::Thinking`
+transitions fire*, while F9 adds a parallel `HealthState::Hung`
+classification path independent of `AgentState`. A fix at one layer
+does not subsume a fix at the other.
+
 **Rejected**: tick force-recheck on screen-hash change — `tick()` already
 calls `maybe_expire_latched_state` periodically (`rg "fn tick" src/state.rs`),
 and the underlying `since.elapsed() >= LATCHED_STATE_EXPIRY` check is

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -586,6 +586,8 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                             core.state.tick();
                             let agent_state = core.state.current;
                             let silent = core.state.last_output.elapsed();
+                            let silent_productive =
+                                core.state.last_productive_output.elapsed();
                             // Sprint 24 P1: pair snapshot for input-aware
                             // hang discrimination (matches daemon/mod.rs
                             // pattern).
@@ -593,6 +595,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                             core.health.check_hang(
                                 agent_state,
                                 silent,
+                                silent_productive,
                                 pair.last_input_at_ms,
                                 pair.heartbeat_at_ms,
                             );

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -232,6 +232,194 @@ pub fn divergence_report() -> Vec<(String, DivergenceStats)> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// F9: productive-output signal (#685 sub-task 4)
+//
+// Parallel to `BehavioralSignal` (silence-based, absence-of-output) — uses
+// presence-of-specific-output evidence. Shares this module + the
+// `behavioral_shadow` tracing target for telemetry infrastructure reuse.
+// See `docs/F9-PRODUCTIVE-OUTPUT-GATE.md` §F9.2 for design rationale.
+// ---------------------------------------------------------------------------
+
+/// Productive-output inference result. Returned by `infer_productivity()`
+/// when MCP heartbeat is fresh OR a structural marker matches the rendered
+/// screen text. Used by `check_hang` as the dual-path supplement signal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProductivitySignal {
+    /// Productive evidence detected — agent is doing actual work.
+    Productive { source: ProductivitySource },
+    /// No productive signal — agent may be silently stuck.
+    NoSignal,
+}
+
+/// Source of a `Productive` signal — heartbeat (MCP tool call) or marker
+/// (text pattern). Carried through telemetry so corpus analysis can
+/// disaggregate which evidence type fires for which scenarios.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProductivitySource {
+    /// MCP heartbeat refreshed recently — agent called a tool.
+    Heartbeat,
+    /// Structural marker pattern matched the screen text. The matched
+    /// pattern literal is carried for telemetry/debug visibility.
+    Marker(&'static str),
+}
+
+impl std::fmt::Display for ProductivitySignal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Delta 1: "productive:" prefix in display ensures grep-equivalence
+        // to enum-namespaced telemetry search (`rg "productive:"`).
+        match self {
+            Self::Productive { source } => match source {
+                ProductivitySource::Heartbeat => write!(f, "productive:heartbeat"),
+                ProductivitySource::Marker(p) => write!(f, "productive:marker({p})"),
+            },
+            Self::NoSignal => write!(f, "productive:none"),
+        }
+    }
+}
+
+/// Per-backend productive-signal calibration. Phase 1 minimal markers ship
+/// the same across backends (heartbeat path universal); backend-specific
+/// extension is `#685` deliverable #4 follow-up.
+#[derive(Debug, Clone, Copy)]
+pub struct ProductivityConfig {
+    /// Structural marker patterns. Each must be anchored (line-start `^` or
+    /// equivalent) to avoid scrollback FP (per F39 Scenario A/B/C taxonomy
+    /// in `docs/HUNG-STATE-TRANSITIONS.md`).
+    pub markers: &'static [&'static str],
+    /// Whether MCP heartbeat refresh counts as productive evidence.
+    /// `false` for backends without MCP integration (Shell/Raw).
+    pub use_heartbeat: bool,
+    /// Heartbeat age window for the `Heartbeat` source classification.
+    /// A heartbeat older than this is treated as stale; the markers path
+    /// must independently fire.
+    pub heartbeat_fresh_window_ms: u64,
+}
+
+/// Phase 1 minimal generic markers — structural anchors, NOT bare keywords.
+/// Per-backend tuning extends this in `#685` deliverable #4.
+const GENERIC_PRODUCTIVE_MARKERS: &[&str] = &[
+    r"^Saved to \S+",
+    r"^Wrote \d+ bytes",
+    r"^Created file: \S+",
+    r"^\s*✓\s+(Read|Bash|Edit|Write|Grep)\b",
+];
+
+/// Cached compiled regexes for `GENERIC_PRODUCTIVE_MARKERS` — built once at
+/// first access via `LazyLock`. Mirrors the existing idiom in `src/state.rs`
+/// (`G1: cached regexes via LazyLock`). Without this cache, the replay-
+/// fixture test path (`state::tests::replay_manifest_regression`) compiled
+/// 4 regexes per `feed()` call across hundreds of chunks per fixture,
+/// pushing wall-clock latency past `min_hold` transition thresholds on
+/// slower CI runners (ubuntu/windows). Patterns are static — compile
+/// failure here is a code bug, exercised by every productivity test.
+static GENERIC_PRODUCTIVE_REGEXES: std::sync::LazyLock<Vec<regex::Regex>> =
+    std::sync::LazyLock::new(|| {
+        GENERIC_PRODUCTIVE_MARKERS
+            .iter()
+            .map(|p| {
+                regex::Regex::new(&format!("(?m){p}"))
+                    .unwrap_or_else(|e| panic!("F9 productive marker regex compile: {p}: {e}"))
+            })
+            .collect()
+    });
+
+/// Get productivity config for a backend.
+pub fn config_for_productivity(backend: &Backend) -> ProductivityConfig {
+    match backend {
+        // Managed backends with MCP integration — heartbeat is reliable.
+        Backend::ClaudeCode
+        | Backend::KiroCli
+        | Backend::Codex
+        | Backend::OpenCode
+        | Backend::Gemini => ProductivityConfig {
+            markers: GENERIC_PRODUCTIVE_MARKERS,
+            use_heartbeat: true,
+            heartbeat_fresh_window_ms: 10_000,
+        },
+        // Shell / Raw — no MCP, markers only.
+        Backend::Shell | Backend::Raw(_) => ProductivityConfig {
+            markers: GENERIC_PRODUCTIVE_MARKERS,
+            use_heartbeat: false,
+            heartbeat_fresh_window_ms: 0,
+        },
+    }
+}
+
+/// Infer productive-output signal from screen text and heartbeat freshness.
+/// Pure function — no side effects, no state mutation. Parallels
+/// `infer_from_silence` shape so future signal types follow the same
+/// `(config, evidence) -> signal` pattern.
+pub fn infer_productivity(
+    config: &ProductivityConfig,
+    screen_text: &str,
+    heartbeat_age: Duration,
+) -> ProductivitySignal {
+    // Heartbeat path first — cheaper than regex scan.
+    if config.use_heartbeat && heartbeat_age.as_millis() <= config.heartbeat_fresh_window_ms as u128
+    {
+        return ProductivitySignal::Productive {
+            source: ProductivitySource::Heartbeat,
+        };
+    }
+    // Markers path — regex scan. Patterns are pre-compiled once via the
+    // `GENERIC_PRODUCTIVE_REGEXES` LazyLock; we look up via pointer-eq on
+    // the `&'static str` since `ProductivityConfig.markers` is also static.
+    // This avoids per-call regex compile (the original cause of CI flake on
+    // slower runners — see `GENERIC_PRODUCTIVE_REGEXES` doc).
+    if std::ptr::eq(
+        config.markers as *const [&'static str],
+        GENERIC_PRODUCTIVE_MARKERS as *const [&'static str],
+    ) {
+        for (i, pattern) in config.markers.iter().enumerate() {
+            if GENERIC_PRODUCTIVE_REGEXES[i].is_match(screen_text) {
+                return ProductivitySignal::Productive {
+                    source: ProductivitySource::Marker(pattern),
+                };
+            }
+        }
+    } else {
+        // Non-generic catalog (future per-backend tuning sub-task may
+        // override). Fall back to ad-hoc compile path. Once deliverable
+        // #4 lands per-backend marker tables, those should ship their
+        // own LazyLock caches too.
+        for pattern in config.markers {
+            let re = regex::Regex::new(&format!("(?m){pattern}")).ok();
+            if let Some(re) = re {
+                if re.is_match(screen_text) {
+                    return ProductivitySignal::Productive {
+                        source: ProductivitySource::Marker(pattern),
+                    };
+                }
+            }
+        }
+    }
+    ProductivitySignal::NoSignal
+}
+
+/// Shadow-mode telemetry for productive-output signals. Parallels
+/// `log_shadow_telemetry` (silence-side) — shares the `behavioral_shadow`
+/// tracing target so dashboards / log queries pick up both signal kinds.
+/// Per Delta 1 (decision `d-20260513235514013631-0`), Sprint 27 call sites
+/// untouched; this is an additive function not a refactor.
+pub fn log_productivity_telemetry(
+    instance: &str,
+    backend: &str,
+    regex_state: &str,
+    productivity: &ProductivitySignal,
+) {
+    if !matches!(productivity, ProductivitySignal::NoSignal) {
+        tracing::debug!(
+            target: "behavioral_shadow",
+            instance,
+            backend,
+            regex_state,
+            productivity = %productivity,
+            "productivity shadow: signal detected"
+        );
+    }
+}
+
 #[allow(dead_code)]
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
@@ -665,5 +853,85 @@ mod tests {
             entry.is_some(),
             "divergence report must contain claude after feed"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // F9 productive-output signal tests (#685 sub-task 4, decision
+    // d-20260513235514013631-0). Tests pin the contract on semantic
+    // outcomes (Productive vs NoSignal + source) — not on regex literals,
+    // so future marker refinement (e.g. deliverable #4 backend tuning)
+    // does not break them.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn infer_productivity_matches_structural_marker() {
+        // Positive: a "Saved to <path>" banner is a structural marker —
+        // line-start anchor + specific format. Must classify Productive.
+        let config = config_for_productivity(&Backend::ClaudeCode);
+        let signal =
+            infer_productivity(&config, "Saved to /tmp/foo.txt\n", Duration::from_secs(99));
+        assert!(matches!(
+            signal,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Marker(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn infer_productivity_rejects_bare_keyword_scrollback() {
+        // Negative: prose containing the bare keyword "Saved" without the
+        // line-start anchor + specific format must NOT classify Productive.
+        // Pins the F9 anti-FP contract from decision §4.
+        let config = config_for_productivity(&Backend::ClaudeCode);
+        let signal = infer_productivity(
+            &config,
+            "I have Saved your work for next time.\n",
+            Duration::from_secs(99),
+        );
+        assert_eq!(signal, ProductivitySignal::NoSignal);
+    }
+
+    #[test]
+    fn infer_productivity_uses_heartbeat_when_fresh() {
+        // Heartbeat path: fresh MCP heartbeat counts as Productive even
+        // when no marker is in screen text. Tool calls are productive
+        // evidence (this is what fired the path; agent is alive).
+        let config = config_for_productivity(&Backend::ClaudeCode);
+        assert!(config.use_heartbeat, "managed backend uses heartbeat");
+        let signal = infer_productivity(&config, "<no markers here>", Duration::from_millis(500));
+        assert!(matches!(
+            signal,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Heartbeat
+            }
+        ));
+    }
+
+    #[test]
+    fn infer_productivity_stale_heartbeat_no_marker_is_no_signal() {
+        // Stale heartbeat (older than config window) + no marker match →
+        // NoSignal. This is the F9 grey-failure case: agent produces
+        // unproductive output (spinner) but no real progress.
+        let config = config_for_productivity(&Backend::ClaudeCode);
+        // 10_000ms is the fresh window per config_for_productivity; use 30s
+        // to be unambiguously past the window.
+        let signal = infer_productivity(
+            &config,
+            "spinning... please wait\n",
+            Duration::from_secs(30),
+        );
+        assert_eq!(signal, ProductivitySignal::NoSignal);
+    }
+
+    #[test]
+    fn shell_backend_disables_heartbeat_path() {
+        // Shell / Raw backends have no MCP integration — heartbeat path
+        // disabled. Markers-only.
+        let config = config_for_productivity(&Backend::Shell);
+        assert!(!config.use_heartbeat);
+        // Fresh "heartbeat" (irrelevant for shell) + no marker → NoSignal.
+        let signal = infer_productivity(&config, "$ ls\n", Duration::from_millis(0));
+        assert_eq!(signal, ProductivitySignal::NoSignal);
     }
 }

--- a/src/daemon/per_tick/hang_detection.rs
+++ b/src/daemon/per_tick/hang_detection.rs
@@ -42,10 +42,17 @@ impl PerTickHandler for HangDetectionHandler {
             core.health.maybe_decay();
             let agent_state = core.state.current;
             let silent = core.state.last_output.elapsed();
+            // F9 (#685 sub-task 4): productive-silence reads the new
+            // `last_productive_output` field which is bumped only when
+            // `infer_productivity` returns a Productive signal. Default
+            // shadow-mode in `check_hang` gates classification on
+            // `AGEND_PRODUCTIVE_GATE=1`.
+            let silent_productive = core.state.last_productive_output.elapsed();
             let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
             if core.health.check_hang(
                 agent_state,
                 silent,
+                silent_productive,
                 pair.last_input_at_ms,
                 pair.heartbeat_at_ms,
             ) {

--- a/src/health.rs
+++ b/src/health.rs
@@ -214,10 +214,21 @@ impl HealthTracker {
     /// [`HealthState::Hung`]; all Hung mutations are inside this function
     /// (entries below, exit at the silence-drops branch). See
     /// `docs/HUNG-STATE-TRANSITIONS.md §Invariants`.
+    ///
+    /// **F9 (#685 sub-task 4)**: `silent_productive` is the dual-path
+    /// supplement signal (silence-since-last-productive-output vs the
+    /// existing `silent` = silence-since-any-output). When the env var
+    /// `AGEND_PRODUCTIVE_GATE=1` is set, the productive-silence path can
+    /// trigger Hung classification independently of the silent path —
+    /// catching the F9 grey failure where 1-byte spinner output keeps
+    /// `silent` below threshold while no productive work happens. Default
+    /// (env var unset) behavior is shadow-mode: telemetry collected, no
+    /// classification change. See `docs/F9-PRODUCTIVE-OUTPUT-GATE.md` §F9.5.
     pub fn check_hang(
         &mut self,
         agent_state: AgentState,
         silent: Duration,
+        silent_productive: Duration,
         last_input_at_ms: u64,
         last_heartbeat_at_ms: u64,
     ) -> bool {
@@ -241,7 +252,40 @@ impl HealthTracker {
             _ => silent > Duration::from_secs(120),
         };
 
-        if !silence_exceeds_threshold {
+        // F9 (#685 sub-task 4): productive-silence threshold mirrors silent
+        // thresholds. Active only when `AGEND_PRODUCTIVE_GATE=1` is set;
+        // telemetry fires regardless for fixture-corpus measurement.
+        let productive_silence_exceeds = match agent_state {
+            AgentState::Idle => false,
+            AgentState::Starting => silent_productive > Duration::from_secs(120),
+            AgentState::Thinking | AgentState::ToolUse => {
+                silent_productive > Duration::from_secs(600)
+            }
+            _ => silent_productive > Duration::from_secs(120),
+        };
+        let f9_gate_active = std::env::var("AGEND_PRODUCTIVE_GATE")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        // Shadow-mode telemetry: fires when the productive path would
+        // independently flag Hung but the silent path does not. Lets the
+        // fixture corpus measure F9 FP rate without affecting prod behavior
+        // until the env var flips to active.
+        if productive_silence_exceeds && !silence_exceeds_threshold {
+            tracing::debug!(
+                target: "behavioral_shadow",
+                silent_secs = silent.as_secs(),
+                silent_productive_secs = silent_productive.as_secs(),
+                agent_state = ?agent_state,
+                active = f9_gate_active,
+                "F9 dual-path candidate: silent_productive exceeded without silent"
+            );
+        }
+        // Dual-path: Hung classification fires if either path exceeded,
+        // gated on env var for productive path until promoted to default.
+        let any_path_exceeds =
+            silence_exceeds_threshold || (f9_gate_active && productive_silence_exceeds);
+
+        if !any_path_exceeds {
             // Hung Exit (X1) / IdleLong Exit (X1): silence dropped below threshold
             // PRE: state in {Hung, IdleLong}, !silence_exceeds_threshold
             // POST: state = Healthy, check_hang returns false
@@ -513,15 +557,33 @@ mod tests {
     #[test]
     fn test_hang_idle_exempt() {
         let mut h = HealthTracker::new();
-        assert!(!h.check_hang(AgentState::Idle, Duration::from_secs(300), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Idle,
+            Duration::from_secs(300),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
         // Idle never hangs
     }
 
     #[test]
     fn test_hang_thinking_long_timeout() {
         let mut h = HealthTracker::new();
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(100), 1_000_000, 0)); // 100s < 600s
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(100),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        )); // 100s < 600s
+        assert!(h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
         // 700s > 600s
     }
 
@@ -617,22 +679,46 @@ mod tests {
             retry_after_secs: Some(60),
         });
         // Thinking + 700s silence would normally trigger hang
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
         assert_ne!(h.state, HealthState::Hung);
 
         // Also test QuotaExceeded and AwaitingOperator
         h.clear_blocked_reason();
         h.set_blocked_reason(BlockedReason::QuotaExceeded);
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
 
         h.clear_blocked_reason();
         h.set_blocked_reason(BlockedReason::AwaitingOperator);
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
 
         // PermissionPrompt does NOT suppress hang check
         h.clear_blocked_reason();
         h.set_blocked_reason(BlockedReason::PermissionPrompt);
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
     }
 
     #[test]
@@ -641,10 +727,22 @@ mod tests {
         h.set_blocked_reason(BlockedReason::RateLimit {
             retry_after_secs: None,
         });
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
 
         h.clear_blocked_reason();
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
         assert_eq!(h.state, HealthState::Hung);
     }
 
@@ -687,7 +785,13 @@ mod tests {
         );
 
         // check_hang should still fire (no reason set)
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
     }
 
     #[test]
@@ -705,7 +809,13 @@ mod tests {
             h.current_reason
         );
         // check_hang should be suppressed
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
     }
 
     #[test]
@@ -718,7 +828,13 @@ mod tests {
         assert!(reason.is_none(), "healthy output should not classify");
         assert!(h.current_reason.is_none());
         // check_hang still works normally
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(700), 1_000_000, 0));
+        assert!(h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
     }
 
     #[test]
@@ -746,6 +862,7 @@ mod tests {
         let result = h.check_hang(
             AgentState::Ready,
             Duration::from_secs(180), // > 120s threshold
+            Duration::from_secs(0),   // F9: productive-silence — recent
             10_000,                   // input delivered at T+10s
             0,                        // no heartbeat (or T-0)
         );
@@ -762,6 +879,7 @@ mod tests {
         let result = h.check_hang(
             AgentState::Ready,
             Duration::from_secs(180), // > 120s threshold
+            Duration::from_secs(0),   // F9: productive-silence — recent
             0,                        // no input ever delivered
             5_000,                    // heartbeat at T+5s (some past activity)
         );
@@ -782,8 +900,9 @@ mod tests {
         let result = h.check_hang(
             AgentState::Ready,
             Duration::from_secs(180),
-            0,     // input at T+0
-            8_000, // heartbeat at T+8s (already responded)
+            Duration::from_secs(0), // F9: productive-silence — recent
+            0,                      // input at T+0
+            8_000,                  // heartbeat at T+8s (already responded)
         );
         assert!(!result, "input already responded → IdleLong");
         assert_eq!(h.state, HealthState::IdleLong);
@@ -797,6 +916,7 @@ mod tests {
         let result = h.check_hang(
             AgentState::Ready,
             Duration::from_secs(60), // < 120s threshold
+            Duration::from_secs(0),  // F9: productive-silence — recent
             10_000,
             0,
         );
@@ -810,10 +930,22 @@ mod tests {
         // (silent drops below threshold). State must transition back to
         // Healthy so future cron consumers don't see stale IdleLong.
         let mut h = HealthTracker::new();
-        h.check_hang(AgentState::Ready, Duration::from_secs(180), 0, 5_000);
+        h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(180),
+            Duration::from_secs(0),
+            0,
+            5_000,
+        );
         assert_eq!(h.state, HealthState::IdleLong);
         // Activity resumes → silence < threshold.
-        let result = h.check_hang(AgentState::Ready, Duration::from_secs(30), 0, 5_000);
+        let result = h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(30),
+            Duration::from_secs(0),
+            0,
+            5_000,
+        );
         assert!(!result);
         assert_eq!(
             h.state,
@@ -830,15 +962,22 @@ mod tests {
         let result = h.check_hang(
             AgentState::Ready,
             Duration::from_secs(180),
-            5_000, // input
-            0,     // heartbeat — delta exactly 5_000ms
+            Duration::from_secs(0), // F9: productive-silence — recent
+            5_000,                  // input
+            0,                      // heartbeat — delta exactly 5_000ms
         );
         assert!(
             !result,
             "delta == grace window → not yet Hung (boundary inclusive)"
         );
         // delta = 5_001 > grace → Hung
-        let result2 = h.check_hang(AgentState::Ready, Duration::from_secs(180), 5_001, 0);
+        let result2 = h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(180),
+            Duration::from_secs(0),
+            5_001,
+            0,
+        );
         assert!(result2, "delta > grace → Hung");
     }
 
@@ -848,10 +987,22 @@ mod tests {
         // call with same state must return false (already escalated;
         // avoid duplicate escalation).
         let mut h = HealthTracker::new();
-        assert!(h.check_hang(AgentState::Ready, Duration::from_secs(180), 10_000, 0));
+        assert!(h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(180),
+            Duration::from_secs(0),
+            10_000,
+            0
+        ));
         assert_eq!(h.state, HealthState::Hung);
         // Same conditions next tick → no re-escalation.
-        assert!(!h.check_hang(AgentState::Ready, Duration::from_secs(180), 10_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Ready,
+            Duration::from_secs(180),
+            Duration::from_secs(0),
+            10_000,
+            0
+        ));
         assert_eq!(h.state, HealthState::Hung);
     }
 
@@ -870,6 +1021,7 @@ mod tests {
         let result = h.check_hang(
             AgentState::Ready,
             Duration::from_secs(180), // > 120s threshold
+            Duration::from_secs(0),   // F9: productive-silence — recent
             0,                        // no input pending
             now - 1_000,              // heartbeat 1s ago (fresh)
         );
@@ -890,13 +1042,126 @@ mod tests {
         let result = h.check_hang(
             AgentState::Ready,
             Duration::from_secs(180),
-            0,             // no input pending
-            now - 300_000, // heartbeat 300s ago (stale)
+            Duration::from_secs(0), // F9: productive-silence — recent
+            0,                      // no input pending
+            now - 300_000,          // heartbeat 300s ago (stale)
         );
         assert!(
             !result,
             "stale heartbeat + no input → IdleLong (no escalation)"
         );
         assert_eq!(h.state, HealthState::IdleLong);
+    }
+
+    // -----------------------------------------------------------------------
+    // F9 productive-output gate tests (#685 sub-task 4, decision
+    // d-20260513235514013631-0). Pins the dual-path contract:
+    //   - Default (env var unset): productive-silence path produces telemetry
+    //     but does NOT change Hung classification.
+    //   - Activated (AGEND_PRODUCTIVE_GATE=1): productive-silence-exceeded +
+    //     silent-NOT-exceeded triggers Hung.
+    //   - Existing silent path unchanged in both modes (no regression on
+    //     #659 silent-stuck detection).
+    // Tests must serialise on the env var because Rust tests share process
+    // env. Use a single Once-style mutex to avoid flake.
+    // -----------------------------------------------------------------------
+
+    fn with_f9_gate<R>(active: bool, f: impl FnOnce() -> R) -> R {
+        // Tests touch a shared process-wide env var — serialise via a
+        // function-scoped mutex so parallel test threads don't race.
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let lock = LOCK.get_or_init(|| Mutex::new(()));
+        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        let prior = std::env::var("AGEND_PRODUCTIVE_GATE").ok();
+        // SAFETY: this is a test-only helper; set_var/remove_var are
+        // process-global mutations and we serialise with the mutex above.
+        // The unsafe block annotation matches Rust 1.84+ semantics where
+        // env mutations are wrapped in unsafe. On older toolchains the
+        // wrapping is a no-op syntactically.
+        unsafe {
+            if active {
+                std::env::set_var("AGEND_PRODUCTIVE_GATE", "1");
+            } else {
+                std::env::remove_var("AGEND_PRODUCTIVE_GATE");
+            }
+        }
+        let result = f();
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("AGEND_PRODUCTIVE_GATE", v),
+                None => std::env::remove_var("AGEND_PRODUCTIVE_GATE"),
+            }
+        }
+        result
+    }
+
+    #[test]
+    fn f9_default_shadow_does_not_classify_hung_on_productive_silence_alone() {
+        // Default mode (env var unset): productive-silence above threshold
+        // but silent below threshold → NO Hung classification (shadow only).
+        // Pins the "additive, no regression" contract.
+        with_f9_gate(false, || {
+            let mut h = HealthTracker::new();
+            let result = h.check_hang(
+                AgentState::Thinking,
+                Duration::from_secs(60),  // silent < 600s threshold
+                Duration::from_secs(700), // silent_productive > 600s
+                0,
+                0,
+            );
+            assert!(
+                !result,
+                "shadow-mode must not flag Hung on productive-only path"
+            );
+            assert_ne!(
+                h.state,
+                HealthState::Hung,
+                "shadow-mode must not mutate state to Hung"
+            );
+        });
+    }
+
+    #[test]
+    fn f9_activated_classifies_hung_on_productive_silence_exceeded() {
+        // Activated mode: productive-silence above threshold + silent
+        // below threshold → Hung. This is the F9 grey-failure capture:
+        // 1-byte spinner output keeps silent low while no real work
+        // happens (silent_productive grows).
+        with_f9_gate(true, || {
+            let mut h = HealthTracker::new();
+            let result = h.check_hang(
+                AgentState::Thinking,
+                Duration::from_secs(60),  // silent < 600s threshold
+                Duration::from_secs(700), // silent_productive > 600s
+                10_000,                   // input pending past heartbeat
+                0,
+            );
+            assert!(
+                result,
+                "activated F9 gate flags Hung when productive-silence exceeds"
+            );
+            assert_eq!(h.state, HealthState::Hung);
+        });
+    }
+
+    #[test]
+    fn f9_does_not_regress_silent_path() {
+        // Regression guard: when silent_productive is recent (any-output
+        // path triggers Hung) the existing silent-side classification
+        // path must still fire identically. F9 is strictly additive.
+        with_f9_gate(true, || {
+            let mut h = HealthTracker::new();
+            // silent path exceeds; productive-silence is fresh.
+            let result = h.check_hang(
+                AgentState::Thinking,
+                Duration::from_secs(700), // silent > 600s threshold
+                Duration::from_secs(0),   // silent_productive recent
+                10_000,
+                0,
+            );
+            assert!(result, "silent path must still trigger Hung");
+            assert_eq!(h.state, HealthState::Hung);
+        });
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -566,6 +566,13 @@ pub struct StateTracker {
     pub current: AgentState,
     pub(crate) since: Instant,
     pub last_output: Instant,
+    /// F9 (#685 sub-task 4): bumped only when `infer_productivity()` returns
+    /// a `Productive` signal (heartbeat refresh or structural marker match).
+    /// Bare screen change does NOT bump this — unlike `last_output`. Read by
+    /// the daemon supervisor and passed to `check_hang` as `silent_productive`
+    /// for the dual-path Hung detection. See `docs/F9-PRODUCTIVE-OUTPUT-GATE.md`
+    /// §F9.1 architecture and §F9.3 dual-path decision table.
+    pub last_productive_output: Instant,
     /// Hash of the last screen text fed to `feed()`. `None` before the first
     /// call. Used to skip re-detection when the screen hasn't changed —
     /// crucial for not resetting `last_output` on cursor-blink noise.
@@ -589,6 +596,11 @@ pub struct StateTracker {
     last_heartbeat: Option<Instant>,
     /// Sprint 27: behavioral probe config for shadow-mode telemetry.
     behavioral_config: Option<crate::behavioral::BehavioralConfig>,
+    /// F9 (#685 sub-task 4): productive-output config for the dual-path
+    /// supplement to silence-based Hung detection. Per-backend markers +
+    /// heartbeat-as-productive toggle. See
+    /// `docs/F9-PRODUCTIVE-OUTPUT-GATE.md` §F9.2 productive-signal design.
+    productivity_config: Option<crate::behavioral::ProductivityConfig>,
     /// Instance name for telemetry logging.
     instance_name: String,
     /// Backend name for telemetry logging.
@@ -647,12 +659,14 @@ impl StateTracker {
             current: initial_state,
             since: Instant::now(),
             last_output: Instant::now(),
+            last_productive_output: Instant::now(),
             last_screen_hash: None,
             patterns: backend.map(StatePatterns::for_backend),
             interactive_prompt_pending_notice: false,
             interactive_recovery_pending_notice: false,
             last_heartbeat: None,
             behavioral_config: backend.map(crate::behavioral::config_for),
+            productivity_config: backend.map(crate::behavioral::config_for_productivity),
             instance_name: String::new(),
             backend_name: backend.map(|b| b.name().to_string()).unwrap_or_default(),
         }
@@ -795,6 +809,34 @@ impl StateTracker {
                 &self.backend_name,
                 signal,
                 self.current.display_name(),
+            );
+        }
+
+        // F9 (#685 sub-task 4): productive-output detection. Bumps
+        // `last_productive_output` only on a Productive signal. The bump
+        // affects nothing about Hung classification directly — the daemon
+        // supervisor reads `last_productive_output.elapsed()` and passes it
+        // to `check_hang` as the dual-path signal. Activation of the new
+        // classification branch is gated on `AGEND_PRODUCTIVE_GATE=1` in
+        // `check_hang` (shadow-mode default). See
+        // `docs/F9-PRODUCTIVE-OUTPUT-GATE.md` §F9.5.
+        if let Some(ref pconfig) = self.productivity_config {
+            let heartbeat_age = self
+                .last_heartbeat
+                .map(|t| t.elapsed())
+                .unwrap_or_else(|| Duration::from_secs(u32::MAX as u64));
+            let signal = crate::behavioral::infer_productivity(pconfig, screen_text, heartbeat_age);
+            if matches!(
+                signal,
+                crate::behavioral::ProductivitySignal::Productive { .. }
+            ) {
+                self.last_productive_output = Instant::now();
+            }
+            crate::behavioral::log_productivity_telemetry(
+                &self.instance_name,
+                &self.backend_name,
+                self.current.display_name(),
+                &signal,
             );
         }
     }
@@ -1385,22 +1427,52 @@ mod tests {
     #[test]
     fn starting_hang_120s() {
         let mut h = HealthTracker::new();
-        assert!(!h.check_hang(AgentState::Starting, Duration::from_secs(119), 1_000_000, 0));
-        assert!(h.check_hang(AgentState::Starting, Duration::from_secs(121), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Starting,
+            Duration::from_secs(119),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
+        assert!(h.check_hang(
+            AgentState::Starting,
+            Duration::from_secs(121),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
     }
 
     #[test]
     fn idle_never_hangs() {
         let mut h = HealthTracker::new();
         // Even with 10000s of silence, Idle should never be considered hung.
-        assert!(!h.check_hang(AgentState::Idle, Duration::from_secs(10_000), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Idle,
+            Duration::from_secs(10_000),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
     }
 
     #[test]
     fn thinking_hang_600s() {
         let mut h = HealthTracker::new();
-        assert!(!h.check_hang(AgentState::Thinking, Duration::from_secs(599), 1_000_000, 0));
-        assert!(h.check_hang(AgentState::Thinking, Duration::from_secs(601), 1_000_000, 0));
+        assert!(!h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(599),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
+        assert!(h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(601),
+            Duration::from_secs(0),
+            1_000_000,
+            0
+        ));
     }
 
     // ── P2: Pattern matching ────────────────────────────────────────────


### PR DESCRIPTION
Decision: `d-20260513235514013631-0` (three-party consensus: lead-claude + dev-claude + reviewer-opencode)
Audit chain (siblings): `d-20260513154400110972-2` (sub-task 1 base, PR #750) + `d-20260513161542381785-0` (sub-task 2 F39 audit, PR #752) + `d-20260513231713506833-1` (sub-task 3 F39 narrow, PR #763)

Issue: [#685](https://github.com/suzuke/agend-terminal/issues/685) — Phase 1 deliverables #2 + #3 (productive-work signals + thinking-vs-stuck differentiation). **Issue stays open** (multi-PR initiative); this PR ticks the F9 sub-task checkbox.

## Summary
Dual-path supplement to `silence_exceeds_threshold` in `check_hang`. Existing silent path preserved (no regression on `#659` silent-stuck-in-thinking detection). NEW productive path supplements: silent below threshold but `silent_productive` above threshold → Hung candidate. Ships in shadow-mode default; classification activation gated on `AGEND_PRODUCTIVE_GATE=1` env var with explicit promotion criteria in commit message.

## Why dual-path (not replacement)
Issue body phrased "replace silence_exceeds_threshold with productive-output detection". Round 1 reviewer caught this as wrong framing — it would regress `#659` (the agent goes truly silent → silent_productive would also stay constant, but the silent path catches it independently). F9 is strictly additive: `check_hang` returns `true` if EITHER path triggers.

## Architecture (3 layers)
1. **Storage** (`src/state.rs`): new `StateTracker.last_productive_output: Instant` bumped only when `infer_productivity()` returns Productive.
2. **Inference** (`src/behavioral.rs`): parallel `ProductivitySignal` / `ProductivitySource` / `ProductivityConfig` types alongside Sprint 27 PR-A's silence-side `BehavioralSignal` (different signal domain — absence vs presence). Shared `behavioral_shadow` tracing target via `"productive:"` prefix in display field (Delta 1 — Sprint 27 call sites untouched).
3. **Consumer** (`src/health.rs::check_hang`): new `silent_productive: Duration` parameter and shadow-gated branch. Sole production caller (`src/daemon/per_tick/hang_detection.rs`) and one app-tick site updated.

## Productive markers (structural anchors only — NOT bare keywords)
```
^Saved to \S+
^Wrote \d+ bytes
^Created file: \S+
^\s*✓\s+(Read|Bash|Edit|Write|Grep)\b
```
Bare keyword `Saved` / `Wrote` is forbidden — prone to scrollback FP per the F39 Scenario A/B/C taxonomy (sub-task 2 audit). Pinned by `infer_productivity_rejects_bare_keyword_scrollback` test. Per-backend marker extension (kiro `[fs_read]`, Gemini-specific banners) is `#685` deliverable #4 — separate sub-task extending `ProductivityConfig.markers`.

## Shadow-mode rollout + promotion criteria
- **Default** (env var unset): productive-silence path emits telemetry via `log_productivity_telemetry` but does NOT change Hung classification. Pinned by `f9_default_shadow_does_not_classify_hung_on_productive_silence_alone`.
- **`AGEND_PRODUCTIVE_GATE=1`**: productive path can classify Hung. Pinned by `f9_activated_classifies_hung_on_productive_silence_exceeded`.
- **Existing silent path**: unchanged in both modes. Pinned by `f9_does_not_regress_silent_path`.

**Promotion criteria** (anti-dead-infra clause — Sprint 27 PR-A still shadow as warning):
1. Fixture corpus measures FP rate < 1% on 3+ confirmed cases (`#685` issue acceptance).
2. 2-week shadow-mode telemetry shows behavioral divergence stable.
3. Operator decision to flip the env var default.

Without all three, the gate stays off. If timeline drags past 6 weeks without measurement, F9 path becomes a candidate for removal — dead shadow infra is worse than no infra.

## Acknowledged limitations
1. **Heartbeat-as-productive gap**: pure-reasoning long sessions (e.g. Claude internal thinking without MCP tool calls) generate no heartbeat refresh and no productive markers. Once activated, these are flagged Hung after threshold. Mitigation deferred to spinner-cycling-as-productive follow-up (F39 hypothesis (e) variant). Risk-contained: shadow + env-var opt-in.
2. **Generic markers FP residual**: structural anchors substantially narrow the surface but edge cases remain (e.g. a user pasting `Saved to /tmp/foo` echoed back). Documented for fixture-corpus measurement.
3. **Cross-backend pattern uniformity**: Phase 1 ships generic markers across all backends; per-backend calibration in `#685` deliverable #4.

## 5c wire-compat preserved
- `check_hang -> bool` return type unchanged
- `display_name()` string contract untouched
- New `silent_productive: Duration` parameter is internal API; sole prod caller updated (`src/daemon/per_tick/hang_detection.rs` + `src/app/mod.rs` app-tick site)

Layer distinction note in `docs/HUNG-STATE-TRANSITIONS.md §F39.4` footnote clarifies F9 (HealthState layer) vs F39(c) (AgentState layer) — different concerns, no overlap.

## Out of scope
- `#685` deliverable #4 (backend-specific marker tuning) — separate sub-task
- `#685` deliverable #5 (fixture corpus design) — separate sub-task; corpus measurement gates promotion
- Other F39 mitigation hypotheses (a)/(b)/(d)/(e)/(f) — fixture-corpus-gated
- Refactor of `log_shadow_telemetry` signature (Delta 1 → prefix-only)
- Filename rename of `docs/HUNG-STATE-TRANSITIONS.md` (M3-equivalent contract break)
- Operator override mechanism for false-Hung — separate concern

scope: follows spec (decision `d-20260513235514013631-0`) — dual-path F9 + shadow-mode + new doc + audit footnote + tests, single-concern (§4.1).

## Test plan
- [x] 8 new F9 tests pass locally:
  - 5 behavioral: `infer_productivity_matches_structural_marker`, `infer_productivity_rejects_bare_keyword_scrollback`, `infer_productivity_uses_heartbeat_when_fresh`, `infer_productivity_stale_heartbeat_no_marker_is_no_signal`, `shell_backend_disables_heartbeat_path`
  - 3 health: `f9_default_shadow_does_not_classify_hung_on_productive_silence_alone`, `f9_activated_classifies_hung_on_productive_silence_exceeded`, `f9_does_not_regress_silent_path`
- [x] All 2108+ existing tests still pass (binary suite green)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Single commit (`1a211bf`)
- [ ] Cross-platform CI green (ubuntu + macOS + Windows + LOC + audit)
- [ ] Phase 3 review by reviewer-opencode

🤖 Generated with [Claude Code](https://claude.com/claude-code)