### PR TITLE
refactor(#694): MCP dispatch — 7 sender arms + action sub-routing (task, 5 actions) (BLOCK 2 second cut)

### DIFF
--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -165,30 +165,35 @@ fn dispatch_gc_dry_run(ctx: &HandlerCtx<'_>) -> Value {
     worktree::handle_gc_dry_run(ctx.home, ctx.args, ctx.sender)
 }
 
-// `task` — action sub-routing validation case (T-B8 first action).
+// `task` — action sub-routing validation case (T-B8).
 //
-// Both `dispatch_task` (base) and `dispatch_task_list` (sub-handler for
-// action="list") forward to `task::handle_task`. The forwarding is
-// identical at runtime — the actions table is purely structural here,
-// adding a routing-table layer without changing what gets called.
+// All 5 sub-handlers (`dispatch_task_create` / `..._list` / `..._claim`
+// / `..._update` / `..._done`) AND the base `dispatch_task` all forward
+// to `task::handle_task`. The forwarding is identical at runtime — the
+// actions table is purely structural here, adding a routing-table layer
+// without changing what gets called.
 //
 // `task::handle_task` is itself a 1-line forward to `crate::tasks::handle`,
 // which has its own internal match on `args["action"]`. So:
 //
-// * action="list" → dispatch table actions["list"] hit → dispatch_task_list
-//   → task::handle_task → tasks::handle → "list" arm of internal match
-// * action="create" → dispatch table actions["create"] miss → fall-through
-//   to dispatch_task (base) → task::handle_task → tasks::handle → "create"
+// * recognized action (e.g. "list") → dispatch table actions[…] hit →
+//   matching sub-handler → task::handle_task → tasks::handle → matching
 //   arm of internal match
-// * action="frobnicate" → dispatch table actions miss → fall-through to
-//   dispatch_task (base) → task::handle_task → tasks::handle → "unknown
-//   action" error from internal match
+// * unrecognized action (e.g. "frobnicate") → dispatch table actions miss
+//   → fall-through to base `dispatch_task` → task::handle_task →
+//   tasks::handle → "unknown action" error from internal match
 //
-// T-B8 only migrates `list` to demonstrate the action-routing
-// infrastructure. T-B9+ migrates the other 4 actions (create / claim /
-// update / done) once the lead spot-checks this shape.
+// The "double match" (action-routing in dispatch.rs AND internal match
+// in `tasks::handle`) is redundant work but preserves ZERO behavior
+// change. Refactoring `tasks::handle` to expose per-action `pub fn`s
+// is left as a future optimization once the dispatch table is stable
+// across all action-based tools.
 
 fn dispatch_task(ctx: &HandlerCtx<'_>) -> Value {
+    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
+}
+
+fn dispatch_task_create(ctx: &HandlerCtx<'_>) -> Value {
     task::handle_task(ctx.home, ctx.args, ctx.instance_name)
 }
 
@@ -196,19 +201,46 @@ fn dispatch_task_list(ctx: &HandlerCtx<'_>) -> Value {
     task::handle_task(ctx.home, ctx.args, ctx.instance_name)
 }
 
+fn dispatch_task_claim(ctx: &HandlerCtx<'_>) -> Value {
+    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
+}
+
+fn dispatch_task_update(ctx: &HandlerCtx<'_>) -> Value {
+    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
+}
+
+fn dispatch_task_done(ctx: &HandlerCtx<'_>) -> Value {
+    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
+}
+
 /// Static sub-handler table for `task` action routing. Lifted out of
 /// the entry literal so the table address can be `'static`-borrowed.
-static TASK_ACTIONS: &[(&str, HandlerFn)] = &[("list", dispatch_task_list)];
+/// Action set matches `tasks::handle`'s internal `match` arms.
+static TASK_ACTIONS: &[(&str, HandlerFn)] = &[
+    ("create", dispatch_task_create),
+    ("list", dispatch_task_list),
+    ("claim", dispatch_task_claim),
+    ("update", dispatch_task_update),
+    ("done", dispatch_task_done),
+];
 
 /// Registered tool dispatchers. **Adding a tool**: write its adapter
 /// above, append a [`HandlerEntry`] here. **Removing**: delete both
 /// halves. Order doesn't affect correctness (linear-scan match by
 /// `name`), but keeping similar tools clustered helps grep.
 ///
-/// Declared as a `static` (rather than returned from the fn via an
-/// inline `&[...]`) so the slice address is unambiguously `'static`;
-/// const-promotion of the array literal is fragile once entries carry
-/// `Option<&'static [...]>` fields.
+/// **Why `static` instead of inline `&[...]` return**: Rust's
+/// const-promotion turns an `&[T {...}]` array literal in fn-return
+/// position into a `'static` slice automatically — but only if every
+/// field of `T` is itself const-promotable in that context. Once
+/// `HandlerEntry` gained `actions: Option<&'static [(&str, HandlerFn)]>`
+/// in T-B8, the inner static-slice field defeats promotion of the
+/// outer array and rustc raises E0515 ("returns a reference to data
+/// owned by the current function"). Lifting the array to a top-level
+/// `static` gives the slice an unambiguous `'static` origin and side-
+/// steps the gotcha. Symptom for future readers: if you add a field
+/// to `HandlerEntry` and the array literal stops compiling, this
+/// `static` is why.
 static REGISTERED: &[HandlerEntry] = &[
     // Instance lifecycle — shape 1 (T-B7)
     HandlerEntry {
@@ -408,17 +440,23 @@ mod tests {
         );
     }
 
-    /// Action sub-routing — recognized action in the table fires the
-    /// sub-handler (here: `task` action=`list` → `dispatch_task_list`).
-    /// Currently `dispatch_task_list` is a thin forward to the base
-    /// handler, so the assertion is that the call returns `Some`
-    /// (proves the sub-routing path executed without panic).
+    /// Action sub-routing — each of the 5 recognized `task` actions
+    /// routes through its sub-handler. All 5 sub-handlers currently
+    /// forward to the same base, so the assertion is that the call
+    /// returns `Some` (proves the sub-routing path executed without
+    /// panic for every wired action). Parameterized to avoid 5 near-
+    /// identical test fns.
     #[test]
     fn try_dispatch_routes_known_action_through_sub_handler() {
         let home = std::env::temp_dir();
-        let args = json!({"action": "list"});
-        let ctx = ctx_for(&home, &args, "");
-        assert!(try_dispatch("task", &ctx).is_some());
+        for action in ["create", "list", "claim", "update", "done"] {
+            let args = json!({"action": action});
+            let ctx = ctx_for(&home, &args, "");
+            assert!(
+                try_dispatch("task", &ctx).is_some(),
+                "action='{action}' did not route through dispatch table"
+            );
+        }
     }
 
     /// Action sub-routing — unknown action falls through to the base

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1,4 +1,4 @@
-//! MCP tool dispatch table — first cut of #694 BLOCK 2.
+//! MCP tool dispatch table — #694 BLOCK 2.
 //!
 //! `handle_tool` (in `mod.rs`) historically routed 30+ MCP tools through
 //! a 143-line `match` literal. This module introduces a linear-scan
@@ -9,30 +9,35 @@
 //! **Signature design** — the 30+ arms have at least four distinct
 //! handler shapes (`(home, args, instance)`, `(home, args)`,
 //! `(home, args, sender)`, `(home, args, instance, sender)`). Rather
-//! than commit to one shape now and migrate only the arms that fit,
-//! this module uses a single uniform [`HandlerFn`] keyed on a
-//! [`HandlerCtx`] struct that bundles every common parameter. Each
-//! migrated tool gets a tiny adapter fn that pulls the fields it needs
-//! out of `HandlerCtx`. The same table will accommodate `&sender`-style
-//! arms in T-B8+ without changing the type.
+//! than commit to one shape, this module uses a single uniform
+//! [`HandlerFn`] keyed on a [`HandlerCtx`] struct that bundles every
+//! common parameter. Each migrated tool gets a tiny adapter fn that
+//! pulls the fields it needs out of `HandlerCtx`.
 //!
 //! **Linear scan** — `<10ns` for 30 entries vs `~50ns` allocator hit
 //! for HashMap/phf, and the table size is bounded by the MCP tool
-//! catalogue, so static-search is cheap and avoids the deps. Per
-//! T-B7 dispatch contract: "Linear scan over 30 entries is fine."
+//! catalogue, so static-search is cheap and avoids the deps.
+//!
+//! **Action sub-routing (T-B8)** — tools whose API consolidates several
+//! sub-operations under one name (`task`, `decision`, `team`, …) carry
+//! an optional [`HandlerEntry::actions`] table. [`try_dispatch`] inspects
+//! `ctx.args["action"]`, looks the value up in that table, and routes to
+//! the matching sub-handler if found. Missing-or-unknown action falls
+//! through to the entry's base [`HandlerFn`] — which is the tool's
+//! existing pre-migration handler, so error-handling for unknown
+//! actions remains byte-identical to the pre-extraction code.
 //!
 //! **Fallback in mod.rs** — [`try_dispatch`] returns `Option<Value>`
-//! (`None` = "tool name not in table"). `handle_tool` falls back to
-//! the existing inline match for un-migrated arms; the catch-all
+//! (`None` = "tool name not in table"). `handle_tool` falls back to the
+//! existing inline match for un-migrated arms; the catch-all
 //! `unknown tool` branch in that match still handles fully-unknown
-//! names. This keeps the migration as a pure subtraction from the
-//! inline match in `mod.rs`, no inline-match relocation.
+//! names.
 
 use crate::identity::Sender;
 use serde_json::Value;
 use std::path::Path;
 
-use super::instance;
+use super::{binding_state, comms, force_release, instance, task, worktree};
 
 /// Shared per-call context — every common parameter `handle_tool`
 /// would otherwise pass into the match arms, bundled together so each
@@ -41,7 +46,6 @@ pub(super) struct HandlerCtx<'a> {
     pub home: &'a Path,
     pub args: &'a Value,
     pub instance_name: &'a str,
-    #[allow(dead_code)] // used by T-B8+ migrations (`&sender`-style arms)
     pub sender: &'a Option<Sender>,
 }
 
@@ -53,14 +57,35 @@ pub(super) type HandlerFn = fn(&HandlerCtx<'_>) -> Value;
 pub(super) struct HandlerEntry {
     pub name: &'static str,
     pub handler: HandlerFn,
+    /// Optional action sub-routing table. When `Some`, `try_dispatch`
+    /// reads `ctx.args["action"]` and routes to the matching sub-handler;
+    /// missing-or-unknown action falls through to `handler` (the base).
+    /// `None` means flat dispatch — `ctx.args["action"]` is ignored.
+    pub actions: Option<&'static [(&'static str, HandlerFn)]>,
 }
 
 /// Look the `tool` name up in the dispatch table. Returns `Some(value)`
-/// on hit; returns `None` if the tool isn't registered — the caller
-/// falls back to the inline `match` in `mod.rs` for un-migrated arms.
+/// on hit (including the action-routing path); returns `None` if the
+/// tool isn't registered — the caller falls back to the inline `match`
+/// in `mod.rs` for un-migrated arms.
 pub(super) fn try_dispatch(tool: &str, ctx: &HandlerCtx<'_>) -> Option<Value> {
     for entry in registered_handlers() {
         if entry.name == tool {
+            if let Some(action_table) = entry.actions {
+                if let Some(action) = ctx.args["action"].as_str() {
+                    // `HandlerFn` is `Copy`, so destructuring the
+                    // ref-to-tuple as `&(_, sub_handler)` binds the
+                    // fn pointer by value.
+                    if let Some(&(_, sub_handler)) = action_table.iter().find(|(a, _)| *a == action)
+                    {
+                        return Some(sub_handler(ctx));
+                    }
+                }
+                // Action missing or unknown → fall through to base
+                // handler below. Preserves the pre-migration error
+                // path (the base handler is the existing pub fn that
+                // already has its own "unknown action" branch).
+            }
             return Some((entry.handler)(ctx));
         }
     }
@@ -108,47 +133,173 @@ fn dispatch_move_pane(ctx: &HandlerCtx<'_>) -> Value {
     instance::handle_move_pane(ctx.home, ctx.args)
 }
 
+// Shape 3 — takes `instance_name` AND `sender`.
+
+fn dispatch_set_waiting_on(ctx: &HandlerCtx<'_>) -> Value {
+    instance::handle_set_waiting_on(ctx.home, ctx.args, ctx.instance_name, ctx.sender)
+}
+
+fn dispatch_send(ctx: &HandlerCtx<'_>) -> Value {
+    comms::handle_unified_send(ctx.home, ctx.args, ctx.sender)
+}
+
+// Shape 4 — takes `sender` but ignores `instance_name`.
+
+fn dispatch_bind_self(ctx: &HandlerCtx<'_>) -> Value {
+    worktree::handle_bind_self(ctx.home, ctx.args, ctx.sender)
+}
+
+fn dispatch_binding_state(ctx: &HandlerCtx<'_>) -> Value {
+    binding_state::handle_binding_state(ctx.home, ctx.args, ctx.sender)
+}
+
+fn dispatch_release_worktree(ctx: &HandlerCtx<'_>) -> Value {
+    worktree::handle_release_worktree(ctx.home, ctx.args, ctx.sender)
+}
+
+fn dispatch_force_release_worktree(ctx: &HandlerCtx<'_>) -> Value {
+    force_release::handle_force_release_worktree(ctx.home, ctx.args, ctx.sender)
+}
+
+fn dispatch_gc_dry_run(ctx: &HandlerCtx<'_>) -> Value {
+    worktree::handle_gc_dry_run(ctx.home, ctx.args, ctx.sender)
+}
+
+// `task` — action sub-routing validation case (T-B8 first action).
+//
+// Both `dispatch_task` (base) and `dispatch_task_list` (sub-handler for
+// action="list") forward to `task::handle_task`. The forwarding is
+// identical at runtime — the actions table is purely structural here,
+// adding a routing-table layer without changing what gets called.
+//
+// `task::handle_task` is itself a 1-line forward to `crate::tasks::handle`,
+// which has its own internal match on `args["action"]`. So:
+//
+// * action="list" → dispatch table actions["list"] hit → dispatch_task_list
+//   → task::handle_task → tasks::handle → "list" arm of internal match
+// * action="create" → dispatch table actions["create"] miss → fall-through
+//   to dispatch_task (base) → task::handle_task → tasks::handle → "create"
+//   arm of internal match
+// * action="frobnicate" → dispatch table actions miss → fall-through to
+//   dispatch_task (base) → task::handle_task → tasks::handle → "unknown
+//   action" error from internal match
+//
+// T-B8 only migrates `list` to demonstrate the action-routing
+// infrastructure. T-B9+ migrates the other 4 actions (create / claim /
+// update / done) once the lead spot-checks this shape.
+
+fn dispatch_task(ctx: &HandlerCtx<'_>) -> Value {
+    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
+}
+
+fn dispatch_task_list(ctx: &HandlerCtx<'_>) -> Value {
+    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
+}
+
+/// Static sub-handler table for `task` action routing. Lifted out of
+/// the entry literal so the table address can be `'static`-borrowed.
+static TASK_ACTIONS: &[(&str, HandlerFn)] = &[("list", dispatch_task_list)];
+
 /// Registered tool dispatchers. **Adding a tool**: write its adapter
 /// above, append a [`HandlerEntry`] here. **Removing**: delete both
 /// halves. Order doesn't affect correctness (linear-scan match by
 /// `name`), but keeping similar tools clustered helps grep.
+///
+/// Declared as a `static` (rather than returned from the fn via an
+/// inline `&[...]`) so the slice address is unambiguously `'static`;
+/// const-promotion of the array literal is fragile once entries carry
+/// `Option<&'static [...]>` fields.
+static REGISTERED: &[HandlerEntry] = &[
+    // Instance lifecycle — shape 1 (T-B7)
+    HandlerEntry {
+        name: "list_instances",
+        handler: dispatch_list_instances,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "create_instance",
+        handler: dispatch_create_instance,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "set_description",
+        handler: dispatch_set_description,
+        actions: None,
+    },
+    // Instance lifecycle — shape 2 (T-B7)
+    HandlerEntry {
+        name: "interrupt",
+        handler: dispatch_interrupt,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "delete_instance",
+        handler: dispatch_delete_instance,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "start_instance",
+        handler: dispatch_start_instance,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "replace_instance",
+        handler: dispatch_replace_instance,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "move_pane",
+        handler: dispatch_move_pane,
+        actions: None,
+    },
+    // Sender-style — shape 3 (T-B8)
+    HandlerEntry {
+        name: "set_waiting_on",
+        handler: dispatch_set_waiting_on,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "send",
+        handler: dispatch_send,
+        actions: None,
+    },
+    // Sender-style — shape 4 (T-B8)
+    HandlerEntry {
+        name: "bind_self",
+        handler: dispatch_bind_self,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "binding_state",
+        handler: dispatch_binding_state,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "release_worktree",
+        handler: dispatch_release_worktree,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "force_release_worktree",
+        handler: dispatch_force_release_worktree,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "gc_dry_run",
+        handler: dispatch_gc_dry_run,
+        actions: None,
+    },
+    // Action sub-routing validation case (T-B8) — only "list"
+    // wired for early-report spot-check. T-B9 wires the rest.
+    HandlerEntry {
+        name: "task",
+        handler: dispatch_task,
+        actions: Some(TASK_ACTIONS),
+    },
+];
+
 pub(super) fn registered_handlers() -> &'static [HandlerEntry] {
-    &[
-        // Instance lifecycle — shape 1
-        HandlerEntry {
-            name: "list_instances",
-            handler: dispatch_list_instances,
-        },
-        HandlerEntry {
-            name: "create_instance",
-            handler: dispatch_create_instance,
-        },
-        HandlerEntry {
-            name: "set_description",
-            handler: dispatch_set_description,
-        },
-        // Instance lifecycle — shape 2
-        HandlerEntry {
-            name: "interrupt",
-            handler: dispatch_interrupt,
-        },
-        HandlerEntry {
-            name: "delete_instance",
-            handler: dispatch_delete_instance,
-        },
-        HandlerEntry {
-            name: "start_instance",
-            handler: dispatch_start_instance,
-        },
-        HandlerEntry {
-            name: "replace_instance",
-            handler: dispatch_replace_instance,
-        },
-        HandlerEntry {
-            name: "move_pane",
-            handler: dispatch_move_pane,
-        },
-    ]
+    REGISTERED
 }
 
 #[cfg(test)]
@@ -158,8 +309,8 @@ mod tests {
     use serde_json::json;
 
     fn ctx_for<'a>(home: &'a Path, args: &'a Value, instance: &'a str) -> HandlerCtx<'a> {
-        // Sender field is only read by T-B8+ adapters; static None is
-        // fine for this test scaffold.
+        // Sender field carries `None` for the `&sender`-style adapters
+        // — every one of them handles the no-sender case gracefully.
         static EMPTY_SENDER: Option<Sender> = None;
         HandlerCtx {
             home,
@@ -180,20 +331,17 @@ mod tests {
     }
 
     /// Registered tool name → `Some(_)` — proves the table actually
-    /// routes through to the adapter. Content of the Value depends on
-    /// the underlying handler; we only assert it's not `None`.
+    /// routes through to the adapter.
     #[test]
     fn try_dispatch_returns_some_for_registered_tool() {
         let home = std::env::temp_dir();
         let args = json!({});
         let ctx = ctx_for(&home, &args, "");
-        // `list_instances` is registered as of T-B7 first cut.
         assert!(try_dispatch("list_instances", &ctx).is_some());
     }
 
-    /// Regression guard: pin the expected set of registered tool names
-    /// for T-B7. Future PRs that migrate more arms will update this
-    /// list; an accidental rename / removal trips the test.
+    /// Regression guard: pin the expected registered tool names + count.
+    /// Future PRs that migrate more arms update this list.
     #[test]
     fn registered_handler_names_pin() {
         let names: Vec<&'static str> = registered_handlers().iter().map(|e| e.name).collect();
@@ -208,9 +356,17 @@ mod tests {
                 "start_instance",
                 "replace_instance",
                 "move_pane",
+                "set_waiting_on",
+                "send",
+                "bind_self",
+                "binding_state",
+                "release_worktree",
+                "force_release_worktree",
+                "gc_dry_run",
+                "task",
             ]
         );
-        assert_eq!(registered_handlers().len(), 8);
+        assert_eq!(registered_handlers().len(), 16);
     }
 
     /// Coverage test: every tool name advertised by
@@ -218,20 +374,9 @@ mod tests {
     /// — either by the dispatch table (`dispatch.rs`) or by the
     /// fallback inline `match` (`mod.rs`). Catches the bug class
     /// "tool added to the catalogue but routing forgotten".
-    ///
-    /// Implemented as a **static source-grep** rather than calling
-    /// `handle_tool` per name: a handler call would invoke real
-    /// side-effectful code paths (filesystem, channel, daemon API)
-    /// against the dev's environment. The source-grep is fast,
-    /// deterministic, and has no side effects. False-positive risk
-    /// (a tool name appearing in a doc comment but no real routing)
-    /// is low because match arms and `HandlerEntry { name: "..." }`
-    /// are the only places where a quoted bare tool name typically
-    /// appears in these files.
     #[test]
     fn every_advertised_tool_is_routed_somewhere() {
         let defs = crate::mcp::tools::tool_definitions();
-        // `tool_definitions()` returns `{"tools": [...]}`.
         let arr = defs
             .get("tools")
             .and_then(|v| v.as_array())
@@ -261,5 +406,55 @@ mod tests {
             missing.is_empty(),
             "tools advertised by tool_definitions() but not routed in mod.rs or dispatch.rs: {missing:?}"
         );
+    }
+
+    /// Action sub-routing — recognized action in the table fires the
+    /// sub-handler (here: `task` action=`list` → `dispatch_task_list`).
+    /// Currently `dispatch_task_list` is a thin forward to the base
+    /// handler, so the assertion is that the call returns `Some`
+    /// (proves the sub-routing path executed without panic).
+    #[test]
+    fn try_dispatch_routes_known_action_through_sub_handler() {
+        let home = std::env::temp_dir();
+        let args = json!({"action": "list"});
+        let ctx = ctx_for(&home, &args, "");
+        assert!(try_dispatch("task", &ctx).is_some());
+    }
+
+    /// Action sub-routing — unknown action falls through to the base
+    /// handler. The base handler is `dispatch_task` which forwards to
+    /// `task::handle_task`. Internally `tasks::handle` will return its
+    /// own "unknown action" error JSON. We only assert `Some(_)` to
+    /// confirm the fall-through path executed (vs panicking or
+    /// returning `None`).
+    #[test]
+    fn try_dispatch_unknown_action_falls_through_to_base() {
+        let home = std::env::temp_dir();
+        let args = json!({"action": "frobnicate-not-a-real-action"});
+        let ctx = ctx_for(&home, &args, "");
+        let result = try_dispatch("task", &ctx);
+        assert!(result.is_some(), "fall-through must reach base handler");
+        // Sanity-check the base handler ran by looking for the
+        // upstream "unknown" error wording. (`tasks::handle` returns
+        // `{"error": "unknown task action: ..."}` for unrecognized
+        // actions; pinning this proves the fall-through actually
+        // reached `tasks::handle` and not an empty Some(json!(null)).)
+        let v = result.unwrap();
+        let err = v.get("error").and_then(|e| e.as_str()).unwrap_or("");
+        assert!(
+            err.contains("unknown") || err.contains("action"),
+            "expected unknown-action error from base; got: {v:?}"
+        );
+    }
+
+    /// Action sub-routing — missing `action` arg falls through to the
+    /// base handler (same path as unknown-action). The base handler's
+    /// internal match handles the missing case its own way.
+    #[test]
+    fn try_dispatch_missing_action_falls_through_to_base() {
+        let home = std::env::temp_dir();
+        let args = json!({}); // no "action" key
+        let ctx = ctx_for(&home, &args, "");
+        assert!(try_dispatch("task", &ctx).is_some());
     }
 }

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -112,7 +112,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         "download_attachment" => channel::handle_download_attachment(&home, args, instance_name),
 
         // --- Cross-instance communication ---
-        "send" => comms::handle_unified_send(&home, args, &sender),
+        // NOTE: `send` migrated to dispatch table (#694 BLOCK 2 T-B8).
         "inbox" => {
             if args.get("message_id").and_then(|v| v.as_str()).is_some() {
                 comms::handle_describe_message(&home, args, instance_name)
@@ -127,10 +127,10 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         // NOTE: 8 instance-lifecycle arms migrated to dispatch table
         // (#694 BLOCK 2 T-B7): list_instances, create_instance,
         // delete_instance, start_instance, replace_instance,
-        // set_description, interrupt, move_pane. See dispatch.rs.
-        // Action-based + `&sender`-style arms stay inline for T-B8+.
+        // set_description, interrupt, move_pane. T-B8 adds
+        // `set_waiting_on`. See dispatch.rs. Remaining action-based +
+        // channel-heavy arms stay inline for T-B9+.
         "set_display_name" => instance::handle_set_display_name(&home, args, instance_name),
-        "set_waiting_on" => instance::handle_set_waiting_on(&home, args, instance_name, &sender),
         "pane_snapshot" => instance::handle_pane_snapshot(&home, args),
         // Consolidated: health action=report/clear
         "health" => match args["action"].as_str().unwrap_or("") {
@@ -148,7 +148,12 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         },
 
         // --- Task board ---
-        "task" => task::handle_task(&home, args, instance_name),
+        // NOTE: `task` migrated to dispatch table (#694 BLOCK 2 T-B8),
+        // including a sub-routing table for the `action` parameter.
+        // T-B8 wires `action=list` to a sub-handler; the other four
+        // actions (create/claim/update/done) fall through to the base
+        // handler `dispatch_task` which forwards to `task::handle_task`,
+        // preserving pre-migration behavior. T-B9+ wires the rest.
 
         // --- Task sweep config ---
         "task_sweep_config" => task::handle_task_sweep_config(&home, args),
@@ -195,29 +200,11 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
             other => json!({"error": format!("unknown ci action: {other}")}),
         },
 
-        // --- Generic self-bind (Sprint 54 P1-7) — agents can claim a
-        // worktree without going through the dispatch hook. Reuses the
-        // same lifecycle helper so every Sprint 53/54 invariant applies.
-        "bind_self" => worktree::handle_bind_self(&home, args, &sender),
-
-        // --- Daemon-managed worktree release (Sprint 53 P0-X) ---
-        "release_worktree" => worktree::handle_release_worktree(&home, args, &sender),
-
-        // --- Force-release stale worktree dir (Sprint 59 Wave 1 PR-5
-        //     emergency cherry-pick — closes BYPASS escape hatch by
-        //     making the bind_self lease_failed recovery path daemon-
-        //     managed).
-        "force_release_worktree" => {
-            force_release::handle_force_release_worktree(&home, args, &sender)
-        }
+        // NOTE: bind_self / release_worktree / force_release_worktree /
+        // binding_state / gc_dry_run migrated to dispatch table (#694
+        // BLOCK 2 T-B8). See dispatch.rs `dispatch_<name>` adapters.
 
         // --- Sprint 60 W1 PR-3 (#P0-3): operator restart MCP tool ---
-
-        // --- Daemon binding-state diagnostic (Sprint 58 Wave 3 PR-2 #8) ---
-        "binding_state" => binding_state::handle_binding_state(&home, args, &sender),
-
-        // --- Phase 4 GC dry-run visibility (Sprint 53 P1-4) ---
-        "gc_dry_run" => worktree::handle_gc_dry_run(&home, args, &sender),
         "restart_daemon" => restart::handle_restart_daemon(&home),
 
         _ => json!({"error": format!("unknown tool: {tool}")}),


### PR DESCRIPTION
## Summary

#694 **BLOCK 2 second cut**. Two-part scope in a single PR:

**Part 1 — 7 sender-style arms migrated** to the dispatch table (`HandlerCtx.sender` finally gets users; the `#[allow(dead_code)]` from T-B7 is dropped):

| Shape | Migrated |
|---|---|
| 3: `(home, args, instance_name, &Option<Sender>)` | `set_waiting_on`, `send` |
| 4: `(home, args, &Option<Sender>)` | `bind_self`, `binding_state`, `release_worktree`, `force_release_worktree`, `gc_dry_run` |

**Part 2 — action sub-routing infrastructure + `task` validation case**:

`HandlerEntry` gains an optional sub-routing table:

```rust
pub(super) struct HandlerEntry {
    pub name: &'static str,
    pub handler: HandlerFn,
    pub actions: Option<&'static [(&'static str, HandlerFn)]>,  // NEW
}
```

`try_dispatch` semantics extended:
- Tool name miss → return `None` (caller falls back to inline match in `mod.rs`).
- Tool name hit + `actions == None` → call base handler (unchanged from T-B7).
- Tool name hit + `actions == Some(table)` + `args["action"]` matches an entry in `table` → call the matching sub-handler.
- Tool name hit + `actions == Some(table)` + `args["action"]` missing or unrecognized → fall through to base handler. This preserves the pre-migration "unknown action" error path verbatim because the base handler IS the existing `task::handle_task`, whose internal `tasks::handle` match already produces `{"error": "unknown task action: …"}` for unrecognized keys.

`task` migrated as validation case with **all 5 actions wired** (`create`/`list`/`claim`/`update`/`done`).

After this PR: **16 of 30+ arms in dispatch table** (8 from T-B7 + 7 sender + 1 task with 5-action sub-routing). T-B9 picks up the next action-based cohort (`decision`/`team`/`schedule`/`deployment`/`repo`/`ci`/`health`) reusing this established pattern.

## Sub-handler design — preserve double-match (T-B8 deliberate)

All 5 task sub-handlers (`dispatch_task_create` / `..._list` / etc.) AND the base `dispatch_task` forward to **the same target**: `task::handle_task`, which forwards to `crate::tasks::handle`, which has its own internal `match args["action"]`. So routing has two action-match layers — dispatch.rs's `actions` table and `tasks::handle`'s internal match.

This redundancy is **deliberate for ZERO behavior change**:
- The dispatch table's `actions` mapping is purely structural metadata. Behavior comes from `tasks::handle` as before.
- Refactoring `tasks::handle` to expose per-action `pub fn`s is a separate concern (touches that module's internals; requires verifying no callers depend on the internal match being the sole entry point; different module ownership).
- T-B9+ may flatten the double match once the dispatch table is stable across all action-based tools.

Per dispatch contract spot-check on T-B8 first cut: lead explicitly endorsed this default ("yes, keep it… Don't conflate").

## Fall-through validation (ZERO behavior change for unknown actions)

The new `try_dispatch_unknown_action_falls_through_to_base` test sends `action=frobnicate-not-a-real-action`, asserts `Some(_)` returned, then asserts the returned `Value`'s `error` field contains either `"unknown"` or `"action"` wording. This pins the invariant that `tasks::handle`'s pre-migration "unknown task action" error reaches the caller unchanged via the fall-through path.

## Const-promotion gotcha (`static REGISTERED`)

T-B7 returned the dispatch table via an inline `&[HandlerEntry { … }]` literal in fn-return position — Rust const-promotion auto-promoted it to `'static`. T-B8 adding `actions: Option<&'static [(&str, HandlerFn)]>` defeats promotion: the inner static-slice field breaks the outer array's const-evaluability, raising E0515 ("returns a reference to data owned by the current function").

Fix: lift the array to a top-level `static REGISTERED: &[HandlerEntry] = &[…]` declaration. Documented inline in dispatch.rs so a future contributor adding a `HandlerEntry` field doesn't lose 10 minutes to the same trap.

## Test plan

- [x] `cargo build --features tray` — OK
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] `cargo fmt --check` — clean (per dispatch contract's "don't skip fmt" note; ran `cargo fmt` before commit)
- [x] `cargo test --features tray` (**full set**, not just `--bins` — per T-B7 lesson) — 2114 unit + all integration tests pass
- [x] 7 dispatch tests pass:
  - `try_dispatch_returns_none_for_unregistered_tool` (T-B7)
  - `try_dispatch_returns_some_for_registered_tool` (T-B7)
  - `registered_handler_names_pin` (T-B7; now 16 names, count==16)
  - `every_advertised_tool_is_routed_somewhere` (T-B7 coverage test)
  - `try_dispatch_routes_known_action_through_sub_handler` (T-B8 — **parameterized**, iterates all 5 actions: create/list/claim/update/done; one test fn instead of five per lead's nit on test ergonomics)
  - `try_dispatch_unknown_action_falls_through_to_base` (T-B8 — pins the unknown-action error path)
  - `try_dispatch_missing_action_falls_through_to_base` (T-B8 — pins the missing-key error path)
- [ ] CI green on this branch

## Diff stat

- `src/mcp/handlers/dispatch.rs`: +319 / -67 (T-B7 was 265 lines; now 519 lines = 7 new sender adapters + 5 task sub-adapters + 1 task base + `TASK_ACTIONS` static + extended `try_dispatch` + extended `HandlerEntry` + `REGISTERED` static refactor + 3 new tests + parameterized existing test + expanded doc-comments)
- `src/mcp/handlers/mod.rs`: +12 / -28 (8 arms removed: 7 sender + task base; navigation comments updated)

## Hard constraints (Group B refactor rules)

- [x] **ZERO behavior change** for ALL migrated arms. Each migrated arm's adapter forwards the same underlying call with the same args. Task action sub-handlers all forward to `task::handle_task` (same target as the base handler), so the actions-table layer is structural only.
- [x] **Existing test assertions UNCHANGED**. The T-B7 source-grep coverage test `every_advertised_tool_is_routed_somewhere` extends naturally because newly migrated arm names appear as `"<name>"` literals in `dispatch.rs`. `tests/mcp_proxy_parity.rs` (the integration test T-B7 patched for source-grep broadening) continues to pass with its T-B7 assertions intact.
- [x] **Fallback inline match** keeps un-migrated arms (`reply`, `inbox`, `set_display_name`, `pane_snapshot`, `health`, `decision`, `team`, `schedule`, `deployment`, `repo`, `ci`, `task_sweep_config`, `restart_daemon`, `download_attachment`) working exactly as today.
- [x] **`daemon/mod.rs` not touched** — this is `mcp/handlers/` only.

## Refs

- Issue #694 BLOCK 2 (continuation of #765 / T-B7)
- T-B7 / PR #765 (dispatch table + 8 instance arms, merged `452a57f`)
- Fleet protocol §3.15 (daemon-core cushion), §12.4 (worktree discipline)
- Action-based dispatch lead's spot-check ACK on shape + preserve-double-match default