### PR TITLE
feat(F9): per-backend productive markers + cache routing refactor (#685 sub-task 6)

### DIFF
--- a/docs/F685-FIXTURE-CORPUS.md
+++ b/docs/F685-FIXTURE-CORPUS.md
@@ -205,10 +205,13 @@ own unless code/harness changes are bundled).
   oscillation should script-capture the session and contribute a real
   fixture; synthetic-from-real-template (timeline-faithful byte sequence
   derived from an operator's incident report) is acceptable in interim.
-- **Per-backend marker calibration**: deliverable #4 will extend
-  `ProductivityConfig.markers` per backend. The corpus schema does not
-  need changes for this — additional fixtures with backend-specific
-  markers will join the same harness loop.
+- **Per-backend marker calibration**: deliverable #4 (sub-task 6,
+  decision `d-20260514022917793418-0`) shipped per-backend MARKERS for
+  5 managed backends — see `docs/F9-PRODUCTIVE-OUTPUT-GATE.md §F9.2`
+  for current listings. Codex and OpenCode markers remain
+  **synthetic-only** pending real PTY captures via this corpus growth
+  protocol; corpus-side fixtures for those backends will join the same
+  harness loop once captured.
 - **Cargo feature gate revisit**: Phase 1 ships always-on harness (zero
   cost when fixtures lack measurement labels). If corpus grows past
   N ≈ 100 fixtures and aggregate replay time approaches CI budget

--- a/docs/F9-PRODUCTIVE-OUTPUT-GATE.md
+++ b/docs/F9-PRODUCTIVE-OUTPUT-GATE.md
@@ -59,22 +59,64 @@ A signal is **productive** if either:
    bare-keyword approach (`Saved` / `Wrote`) suffers from the same
    scrollback FP surface as the F39 audit's Scenario A/B/C taxonomy.
 
-Phase 1 minimal generic markers (per `GENERIC_PRODUCTIVE_MARKERS` —
-`rg "GENERIC_PRODUCTIVE_MARKERS" src/behavioral.rs`):
-
+Generic structural anchors shared by all backends (file save banners):
 - `^Saved to \S+` — file save banner
 - `^Wrote \d+ bytes` — explicit byte count
 - `^Created file: \S+` — structured creation
-- `^\s*✓\s+(Read|Bash|Edit|Write|Grep)\b` — tool success (mirrors Claude
-  pattern at `rg "Read|Bash|Edit|Write|Grep" src/state.rs`)
 
-**Forbidden in this PR**: bare keyword markers. Prose like "I saved your
-time" must not match. Pinned by `infer_productivity_rejects_bare_keyword_scrollback`
-test.
+Per-backend completion markers (shipped by `#685` sub-task 6 —
+deliverable #4, decision `d-20260514022917793418-0`). Each backend's
+`MARKERS` const lists the generic anchors above plus its own
+completion-glyph + tool-vocab regex. Look up each via
+`rg "<BACKEND>_PRODUCTIVE_MARKERS" src/behavioral.rs`:
 
-Per-backend marker extension (e.g. kiro `[fs_read]`, Gemini `✓ ReadFile`)
-is `#685` deliverable #4 — separate sub-task that extends
-`ProductivityConfig.markers` rather than modifying F9 mechanism.
+| Backend | Completion regex (added to generic anchors) | Source | Validation |
+|---|---|---|---|
+| Claude | `^[✓●⏺]\s+(Read\|Bash\|Edit\|Write\|Grep\|Glob\|Listing\|Reading\|Writing\|Searching\|Editing)\b` | `rg "Read\|Bash\|Edit\|Write\|Grep" src/state.rs` (state.rs:212 ToolUse vocab) | F685 fixture `f685-f9-positive-savedfile.raw` (synthetic). Real captures pending corpus growth. |
+| Kiro | `^●\s+(Read\|Write\|Edit\|Bash\|Grep\|Glob\|Task\|List\|Search)\b` PLUS `\[(fs_read\|fs_write\|execute_bash)\]` | `rg "●" src/state.rs` (state.rs:261 ToolUse vocab + bracket-form fs/exec tools) | Synthetic unit tests only — `kiro_markers_*` in `src/behavioral.rs::tests`. **Not validated against real captures** — corpus growth path per F685. |
+| Codex | `^•\s+(Explored\|Edited\|Ran)\b` PLUS `apply_patch` | `rg "Explored\|Edited\|Ran" src/state.rs` (state.rs:308 past-tense title vocab + `apply_patch` literal) | **Synthetic only — not validated against real captures.** Corpus growth path. |
+| Gemini | `^✓\s+(ReadFile\|WriteFile\|ReadManyFiles\|Edit\|Shell\|WebFetch\|Glob\|GoogleSearch\|MemoryTool\|ReadFolder)\b` | `rg "ReadFile\|WriteFile" src/state.rs` (state.rs:405 CamelCase ToolUse vocab) | F685 fixture `f685-silent-stuck-stub.raw` (synthetic_from_real_template). Real captures pending. |
+| OpenCode | `^→\s+(Read\|Write\|Edit\|Glob\|Grep\|Bash\|List\|Task)\b` | `rg "→" src/state.rs` (state.rs:357 completion arrow — distinct from in-flight `✱`) | **Synthetic only — not validated against real captures.** Corpus growth path. |
+
+**Excluded from F9 markers**:
+- All in-progress / spinner glyphs (Braille `[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]`, OpenCode `✱`, Codex `◦ Working`,
+  Gemini `⠦ Thinking`). F9 productivity = completion-only; these fire BEFORE work completes.
+- Gemini `tool.*call` / `MCP.*tool` literals — heartbeat path already covers MCP signals
+  (avoid double counting).
+- Bare keyword markers (e.g. `Saved` / `Wrote` without line-start anchor). Prose like
+  "I saved your time" must not match — pinned by
+  `infer_productivity_rejects_bare_keyword_scrollback` (legacy) and
+  `<backend>_markers_reject_*` per-backend tests.
+
+### Cache routing
+
+Per-backend markers are NOT routed via pointer-eq (would fall through
+to per-call `Regex::new()` compile — the bug that caused PR #766's
+ubuntu/windows CI failure). Sub-task 6 introduced the `MarkerCacheId`
+enum on `ProductivityConfig`:
+
+```rust
+pub enum MarkerCacheId { Generic, Claude, Kiro, Codex, Gemini, OpenCode }
+
+pub struct ProductivityConfig {
+    pub markers: &'static [&'static str],
+    pub use_heartbeat: bool,
+    pub heartbeat_fresh_window_ms: u64,
+    pub cache_id: Option<MarkerCacheId>,
+}
+```
+
+`infer_productivity` matches on `cache_id` to route to the
+corresponding per-backend `LazyLock<Vec<Regex>>` static
+(`CLAUDE_PRODUCTIVE_REGEXES`, etc.). Compile-time exhaustive match
+prevents missing-backend bugs. `None` is reserved for ad-hoc test
+configs and falls back to `Regex::new()` per call (Phase 1 production
+code never hits this path).
+
+Future per-backend `heartbeat_fresh_window_ms` tuning and per-backend
+silence threshold tuning are **out of scope for sub-task 6** — both
+require corpus measurement data (see §F9.5 promotion criteria) before
+calibration.
 
 ## §F9.3 — Dual-path decision table
 

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -278,9 +278,11 @@ impl std::fmt::Display for ProductivitySignal {
     }
 }
 
-/// Per-backend productive-signal calibration. Phase 1 minimal markers ship
-/// the same across backends (heartbeat path universal); backend-specific
-/// extension is `#685` deliverable #4 follow-up.
+/// Per-backend productive-signal calibration. Sub-task 6 (decision
+/// `d-20260514022917793418-0`) shipped per-backend markers across 5
+/// managed backends; the `cache_id` field gates fast routing to a
+/// pre-compiled regex set, mirroring the `LazyLock` idiom at
+/// `src/state.rs:479-483`.
 #[derive(Debug, Clone, Copy)]
 pub struct ProductivityConfig {
     /// Structural marker patterns. Each must be anchored (line-start `^` or
@@ -294,10 +296,57 @@ pub struct ProductivityConfig {
     /// A heartbeat older than this is treated as stale; the markers path
     /// must independently fire.
     pub heartbeat_fresh_window_ms: u64,
+    /// Identifier for the pre-compiled regex cache that matches `markers`.
+    /// `Some(...)` enables the fast path through cached `LazyLock` regexes
+    /// (see `infer_productivity`); `None` falls back to per-call
+    /// `Regex::new()` compile. All Phase 1 callers via
+    /// `config_for_productivity` set `Some(...)`; `None` is an
+    /// intentional future-proofing escape hatch for test / ad-hoc
+    /// configs that want to provide custom markers without registering
+    /// a cache.
+    pub cache_id: Option<MarkerCacheId>,
 }
 
-/// Phase 1 minimal generic markers — structural anchors, NOT bare keywords.
-/// Per-backend tuning extends this in `#685` deliverable #4.
+/// Identifies which pre-compiled regex cache to consult when matching
+/// `ProductivityConfig.markers`. Each variant maps to one of the per-
+/// backend `*_PRODUCTIVE_REGEXES` `LazyLock` statics below.
+///
+/// **CRITICAL**: without this routing, per-backend markers fall through
+/// the ad-hoc `Regex::new()` compile path on every `feed()` call — the
+/// exact bug that caused PR #766's ubuntu/windows CI failure (replay
+/// test cumulative latency exceeding `min_hold` thresholds). The match
+/// on this enum is compile-time exhaustive so adding a backend forces
+/// a cache static + match arm in lockstep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkerCacheId {
+    /// Generic structural anchors only (file save banners + Claude tool
+    /// completion). Used by Shell/Raw backends and as a baseline subset
+    /// inside each per-backend MARKERS list.
+    Generic,
+    Claude,
+    Kiro,
+    Codex,
+    Gemini,
+    OpenCode,
+}
+
+// ---------------------------------------------------------------------------
+// Per-backend markers — explicit composition (generic anchors duplicated
+// into each list; no implicit overlay). Decision §1 lock-broke duplication
+// over overlay: clearer per-backend semantics, single regex cache per
+// backend. Maintenance cost (5-place edit for future common anchor) is
+// the accepted trade-off.
+//
+// Source for completion glyphs + tool vocab: src/state.rs:200-450
+// AgentState ToolUse pattern catalogs (per-backend). F9 productivity is
+// COMPLETION-ONLY — exclude in-progress spinner glyphs from the AgentState
+// regex (those fire before work completes, opposite of productivity
+// signal). Sub-task 6 decision §1.
+// ---------------------------------------------------------------------------
+
+/// Generic structural anchors. File save banners + Claude-shape tool
+/// completion (kept here for Shell/Raw fallback). Each per-backend MARKERS
+/// const includes these three save-banner anchors via explicit duplication.
 const GENERIC_PRODUCTIVE_MARKERS: &[&str] = &[
     r"^Saved to \S+",
     r"^Wrote \d+ bytes",
@@ -305,43 +354,125 @@ const GENERIC_PRODUCTIVE_MARKERS: &[&str] = &[
     r"^\s*✓\s+(Read|Bash|Edit|Write|Grep)\b",
 ];
 
-/// Cached compiled regexes for `GENERIC_PRODUCTIVE_MARKERS` — built once at
-/// first access via `LazyLock`. Mirrors the existing idiom in `src/state.rs`
-/// (`G1: cached regexes via LazyLock`). Without this cache, the replay-
-/// fixture test path (`state::tests::replay_manifest_regression`) compiled
-/// 4 regexes per `feed()` call across hundreds of chunks per fixture,
-/// pushing wall-clock latency past `min_hold` transition thresholds on
-/// slower CI runners (ubuntu/windows). Patterns are static — compile
-/// failure here is a code bug, exercised by every productivity test.
-static GENERIC_PRODUCTIVE_REGEXES: std::sync::LazyLock<Vec<regex::Regex>> =
-    std::sync::LazyLock::new(|| {
-        GENERIC_PRODUCTIVE_MARKERS
-            .iter()
-            .map(|p| {
-                regex::Regex::new(&format!("(?m){p}"))
-                    .unwrap_or_else(|e| panic!("F9 productive marker regex compile: {p}: {e}"))
-            })
-            .collect()
-    });
+/// Claude: generic anchors + completion glyphs (`✓●⏺` — NOT the in-progress
+/// Braille spinner set `⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) with Claude tool-name vocabulary.
+const CLAUDE_PRODUCTIVE_MARKERS: &[&str] = &[
+    r"^Saved to \S+",
+    r"^Wrote \d+ bytes",
+    r"^Created file: \S+",
+    r"^[✓●⏺]\s+(Read|Bash|Edit|Write|Grep|Glob|Listing|Reading|Writing|Searching|Editing)\b",
+];
 
-/// Get productivity config for a backend.
+/// Kiro: generic anchors + `●` completion glyph with Kiro tool-name
+/// vocabulary + bracketed tool-call literals (`[fs_read]`, `[fs_write]`,
+/// `[execute_bash]`). The bracket form fires for Kiro's structured tool
+/// trace output.
+const KIRO_PRODUCTIVE_MARKERS: &[&str] = &[
+    r"^Saved to \S+",
+    r"^Wrote \d+ bytes",
+    r"^Created file: \S+",
+    r"^●\s+(Read|Write|Edit|Bash|Grep|Glob|Task|List|Search)\b",
+    r"\[(fs_read|fs_write|execute_bash)\]",
+];
+
+/// Codex: generic anchors + `•` past-tense title vocabulary (`Explored`,
+/// `Edited`, `Ran`) + `apply_patch` literal completion banner.
+const CODEX_PRODUCTIVE_MARKERS: &[&str] = &[
+    r"^Saved to \S+",
+    r"^Wrote \d+ bytes",
+    r"^Created file: \S+",
+    r"^•\s+(Explored|Edited|Ran)\b",
+    r"apply_patch",
+];
+
+/// Gemini: generic anchors + `✓` completion glyph with Gemini CamelCase
+/// tool-name vocabulary. Excludes `tool.*call` / `MCP.*tool` literals
+/// (heartbeat path already covers MCP — avoid double-counting).
+const GEMINI_PRODUCTIVE_MARKERS: &[&str] = &[
+    r"^Saved to \S+",
+    r"^Wrote \d+ bytes",
+    r"^Created file: \S+",
+    r"^✓\s+(ReadFile|WriteFile|ReadManyFiles|Edit|Shell|WebFetch|Glob|GoogleSearch|MemoryTool|ReadFolder)\b",
+];
+
+/// OpenCode: generic anchors + `→` completion glyph (NOT the in-flight
+/// `✱` glyph) with OpenCode tool-name vocabulary. Synthetic-only —
+/// not validated against real PTY captures; corpus growth path per
+/// `docs/F685-FIXTURE-CORPUS.md §F685-CORPUS.6`.
+const OPENCODE_PRODUCTIVE_MARKERS: &[&str] = &[
+    r"^Saved to \S+",
+    r"^Wrote \d+ bytes",
+    r"^Created file: \S+",
+    r"^→\s+(Read|Write|Edit|Glob|Grep|Bash|List|Task)\b",
+];
+
+/// Build a `LazyLock<Vec<Regex>>` from a static markers slice. Each
+/// marker is compiled with the `(?m)` multiline flag so `^` anchors at
+/// line starts inside the rendered screen.
+fn compile_markers(markers: &'static [&'static str]) -> Vec<regex::Regex> {
+    markers
+        .iter()
+        .map(|p| {
+            regex::Regex::new(&format!("(?m){p}"))
+                .unwrap_or_else(|e| panic!("F9 productive marker regex compile: {p}: {e}"))
+        })
+        .collect()
+}
+
+static GENERIC_PRODUCTIVE_REGEXES: std::sync::LazyLock<Vec<regex::Regex>> =
+    std::sync::LazyLock::new(|| compile_markers(GENERIC_PRODUCTIVE_MARKERS));
+static CLAUDE_PRODUCTIVE_REGEXES: std::sync::LazyLock<Vec<regex::Regex>> =
+    std::sync::LazyLock::new(|| compile_markers(CLAUDE_PRODUCTIVE_MARKERS));
+static KIRO_PRODUCTIVE_REGEXES: std::sync::LazyLock<Vec<regex::Regex>> =
+    std::sync::LazyLock::new(|| compile_markers(KIRO_PRODUCTIVE_MARKERS));
+static CODEX_PRODUCTIVE_REGEXES: std::sync::LazyLock<Vec<regex::Regex>> =
+    std::sync::LazyLock::new(|| compile_markers(CODEX_PRODUCTIVE_MARKERS));
+static GEMINI_PRODUCTIVE_REGEXES: std::sync::LazyLock<Vec<regex::Regex>> =
+    std::sync::LazyLock::new(|| compile_markers(GEMINI_PRODUCTIVE_MARKERS));
+static OPENCODE_PRODUCTIVE_REGEXES: std::sync::LazyLock<Vec<regex::Regex>> =
+    std::sync::LazyLock::new(|| compile_markers(OPENCODE_PRODUCTIVE_MARKERS));
+
+/// Get productivity config for a backend. Each managed backend uses its
+/// own per-backend MARKERS list + cache id; Shell/Raw fall back to the
+/// generic anchor set (no MCP heartbeat).
 pub fn config_for_productivity(backend: &Backend) -> ProductivityConfig {
     match backend {
-        // Managed backends with MCP integration — heartbeat is reliable.
-        Backend::ClaudeCode
-        | Backend::KiroCli
-        | Backend::Codex
-        | Backend::OpenCode
-        | Backend::Gemini => ProductivityConfig {
-            markers: GENERIC_PRODUCTIVE_MARKERS,
+        Backend::ClaudeCode => ProductivityConfig {
+            markers: CLAUDE_PRODUCTIVE_MARKERS,
             use_heartbeat: true,
             heartbeat_fresh_window_ms: 10_000,
+            cache_id: Some(MarkerCacheId::Claude),
         },
-        // Shell / Raw — no MCP, markers only.
+        Backend::KiroCli => ProductivityConfig {
+            markers: KIRO_PRODUCTIVE_MARKERS,
+            use_heartbeat: true,
+            heartbeat_fresh_window_ms: 10_000,
+            cache_id: Some(MarkerCacheId::Kiro),
+        },
+        Backend::Codex => ProductivityConfig {
+            markers: CODEX_PRODUCTIVE_MARKERS,
+            use_heartbeat: true,
+            heartbeat_fresh_window_ms: 10_000,
+            cache_id: Some(MarkerCacheId::Codex),
+        },
+        Backend::Gemini => ProductivityConfig {
+            markers: GEMINI_PRODUCTIVE_MARKERS,
+            use_heartbeat: true,
+            heartbeat_fresh_window_ms: 10_000,
+            cache_id: Some(MarkerCacheId::Gemini),
+        },
+        Backend::OpenCode => ProductivityConfig {
+            markers: OPENCODE_PRODUCTIVE_MARKERS,
+            use_heartbeat: true,
+            heartbeat_fresh_window_ms: 10_000,
+            cache_id: Some(MarkerCacheId::OpenCode),
+        },
+        // Shell / Raw — no MCP, generic markers only.
         Backend::Shell | Backend::Raw(_) => ProductivityConfig {
             markers: GENERIC_PRODUCTIVE_MARKERS,
             use_heartbeat: false,
             heartbeat_fresh_window_ms: 0,
+            cache_id: Some(MarkerCacheId::Generic),
         },
     }
 }
@@ -362,34 +493,43 @@ pub fn infer_productivity(
             source: ProductivitySource::Heartbeat,
         };
     }
-    // Markers path — regex scan. Patterns are pre-compiled once via the
-    // `GENERIC_PRODUCTIVE_REGEXES` LazyLock; we look up via pointer-eq on
-    // the `&'static str` since `ProductivityConfig.markers` is also static.
-    // This avoids per-call regex compile (the original cause of CI flake on
-    // slower runners — see `GENERIC_PRODUCTIVE_REGEXES` doc).
-    if std::ptr::eq(
-        config.markers as *const [&'static str],
-        GENERIC_PRODUCTIVE_MARKERS as *const [&'static str],
-    ) {
-        for (i, pattern) in config.markers.iter().enumerate() {
-            if GENERIC_PRODUCTIVE_REGEXES[i].is_match(screen_text) {
-                return ProductivitySignal::Productive {
-                    source: ProductivitySource::Marker(pattern),
-                };
-            }
-        }
-    } else {
-        // Non-generic catalog (future per-backend tuning sub-task may
-        // override). Fall back to ad-hoc compile path. Once deliverable
-        // #4 lands per-backend marker tables, those should ship their
-        // own LazyLock caches too.
-        for pattern in config.markers {
-            let re = regex::Regex::new(&format!("(?m){pattern}")).ok();
-            if let Some(re) = re {
-                if re.is_match(screen_text) {
+    // Markers path — route to pre-compiled `LazyLock` cache via cache_id.
+    // Compile-time exhaustive match catches missing-backend bugs. The
+    // `None` arm exists for future custom configs (test code, ad-hoc
+    // markers) that opt out of the cache; Phase 1 production code never
+    // hits it.
+    let cached_regexes: Option<&[regex::Regex]> = match config.cache_id {
+        Some(MarkerCacheId::Generic) => Some(&GENERIC_PRODUCTIVE_REGEXES),
+        Some(MarkerCacheId::Claude) => Some(&CLAUDE_PRODUCTIVE_REGEXES),
+        Some(MarkerCacheId::Kiro) => Some(&KIRO_PRODUCTIVE_REGEXES),
+        Some(MarkerCacheId::Codex) => Some(&CODEX_PRODUCTIVE_REGEXES),
+        Some(MarkerCacheId::Gemini) => Some(&GEMINI_PRODUCTIVE_REGEXES),
+        Some(MarkerCacheId::OpenCode) => Some(&OPENCODE_PRODUCTIVE_REGEXES),
+        None => None,
+    };
+    match cached_regexes {
+        Some(regexes) => {
+            for (i, pattern) in config.markers.iter().enumerate() {
+                if regexes[i].is_match(screen_text) {
                     return ProductivitySignal::Productive {
                         source: ProductivitySource::Marker(pattern),
                     };
+                }
+            }
+        }
+        None => {
+            // Ad-hoc compile fallback — Phase 1 dead code path; reserved
+            // for future ProductivityConfig callers that supply custom
+            // markers without registering a cache id. Compile latency
+            // limited to non-production paths (test code or one-off
+            // tooling).
+            for pattern in config.markers {
+                if let Ok(re) = regex::Regex::new(&format!("(?m){pattern}")) {
+                    if re.is_match(screen_text) {
+                        return ProductivitySignal::Productive {
+                            source: ProductivitySource::Marker(pattern),
+                        };
+                    }
                 }
             }
         }
@@ -933,5 +1073,208 @@ mod tests {
         // Fresh "heartbeat" (irrelevant for shell) + no marker → NoSignal.
         let signal = infer_productivity(&config, "$ ls\n", Duration::from_millis(0));
         assert_eq!(signal, ProductivitySignal::NoSignal);
+    }
+
+    // -------------------------------------------------------------------
+    // Sub-task 6 (#685 deliverable #4): per-backend productive markers
+    // (decision d-20260514022917793418-0). 10 tests pin the per-backend
+    // marker contract: completion-glyph + tool-vocab fires positive on
+    // each backend's expected output shape; bare prose missing the
+    // line-start anchor fires NoSignal (anti-FP). Stale heartbeat used
+    // throughout to force the markers path.
+    // -------------------------------------------------------------------
+
+    /// Duration that exceeds `heartbeat_fresh_window_ms` for any backend
+    /// — forces inference through the markers path so positive/negative
+    /// tests verify the per-backend regex, not the heartbeat shortcut.
+    fn stale_heartbeat() -> Duration {
+        Duration::from_secs(u32::MAX as u64)
+    }
+
+    #[test]
+    fn claude_markers_match_completion_glyph_and_tool() {
+        let config = config_for_productivity(&Backend::ClaudeCode);
+        assert_eq!(config.cache_id, Some(MarkerCacheId::Claude));
+        // `✓ Read foo.toml` — completion glyph + Claude tool vocab.
+        let signal = infer_productivity(&config, "✓ Read foo.toml\n", stale_heartbeat());
+        assert!(matches!(
+            signal,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Marker(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn claude_markers_reject_in_progress_spinner_and_prose() {
+        let config = config_for_productivity(&Backend::ClaudeCode);
+        // `⠦ Read foo.toml` — in-progress spinner glyph (NOT completion);
+        // bare prose without anchor. Neither should fire productive.
+        let in_progress = infer_productivity(&config, "⠦ Read foo.toml\n", stale_heartbeat());
+        assert_eq!(in_progress, ProductivitySignal::NoSignal);
+        let prose = infer_productivity(
+            &config,
+            "I have saved your time previously\n",
+            stale_heartbeat(),
+        );
+        assert_eq!(prose, ProductivitySignal::NoSignal);
+    }
+
+    #[test]
+    fn kiro_markers_match_glyph_or_bracketed_tool() {
+        let config = config_for_productivity(&Backend::KiroCli);
+        assert_eq!(config.cache_id, Some(MarkerCacheId::Kiro));
+        // `● Read foo.toml` — Kiro completion glyph.
+        let glyph = infer_productivity(&config, "● Read foo.toml\n", stale_heartbeat());
+        assert!(matches!(
+            glyph,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Marker(_)
+            }
+        ));
+        // `[fs_read]` bracketed tool literal (not line-anchored).
+        let bracketed = infer_productivity(
+            &config,
+            "Running tool [fs_read] on file\n",
+            stale_heartbeat(),
+        );
+        assert!(matches!(
+            bracketed,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Marker(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn kiro_markers_reject_bare_tool_name_prose() {
+        let config = config_for_productivity(&Backend::KiroCli);
+        // `Read foo.toml` without `●` prefix — chat prose mentioning tool name.
+        let prose = infer_productivity(
+            &config,
+            "Will Read foo.toml when ready\n",
+            stale_heartbeat(),
+        );
+        assert_eq!(prose, ProductivitySignal::NoSignal);
+    }
+
+    #[test]
+    fn codex_markers_match_dot_title_or_apply_patch() {
+        let config = config_for_productivity(&Backend::Codex);
+        assert_eq!(config.cache_id, Some(MarkerCacheId::Codex));
+        // `• Edited` — Codex past-tense title glyph.
+        let title = infer_productivity(&config, "• Edited\n", stale_heartbeat());
+        assert!(matches!(
+            title,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Marker(_)
+            }
+        ));
+        // `apply_patch` literal in Codex tool log line.
+        let patch =
+            infer_productivity(&config, "└ Ran apply_patch (15 hunks)\n", stale_heartbeat());
+        assert!(matches!(
+            patch,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Marker(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn codex_markers_reject_in_flight_spinner_prose() {
+        let config = config_for_productivity(&Backend::Codex);
+        // `◦ Working` — Codex in-progress spinner; must NOT fire.
+        let spinner = infer_productivity(
+            &config,
+            "◦ Working (5s • esc to interrupt)\n",
+            stale_heartbeat(),
+        );
+        assert_eq!(spinner, ProductivitySignal::NoSignal);
+    }
+
+    #[test]
+    fn gemini_markers_match_check_glyph_and_camelcase_tool() {
+        let config = config_for_productivity(&Backend::Gemini);
+        assert_eq!(config.cache_id, Some(MarkerCacheId::Gemini));
+        // `✓ ReadFile` — Gemini completion glyph + CamelCase tool name.
+        let signal = infer_productivity(&config, "✓ ReadFile foo.toml\n", stale_heartbeat());
+        assert!(matches!(
+            signal,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Marker(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn gemini_markers_reject_braille_spinner_and_mcp_prose() {
+        let config = config_for_productivity(&Backend::Gemini);
+        // `⠦ Thinking... (esc to cancel, 2s)` — Gemini in-progress spinner.
+        let spinner = infer_productivity(
+            &config,
+            "⠦ Thinking... (esc to cancel, 2s)\n",
+            stale_heartbeat(),
+        );
+        assert_eq!(spinner, ProductivitySignal::NoSignal);
+        // Bare prose with `MCP tool` mention — heartbeat path is the
+        // canonical MCP signal; marker path explicitly excludes the
+        // literal to avoid double-counting. Per decision §1 exclusion.
+        let mcp_prose = infer_productivity(
+            &config,
+            "About to call MCP tool method\n",
+            stale_heartbeat(),
+        );
+        assert_eq!(mcp_prose, ProductivitySignal::NoSignal);
+    }
+
+    #[test]
+    fn opencode_markers_match_arrow_glyph_completion() {
+        let config = config_for_productivity(&Backend::OpenCode);
+        assert_eq!(config.cache_id, Some(MarkerCacheId::OpenCode));
+        // `→ Read foo.toml` — OpenCode completion glyph.
+        let signal = infer_productivity(&config, "→ Read foo.toml\n", stale_heartbeat());
+        assert!(matches!(
+            signal,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Marker(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn opencode_markers_reject_in_flight_asterisk_glyph() {
+        let config = config_for_productivity(&Backend::OpenCode);
+        // `✱ Glob "*.toml"` — OpenCode in-flight glyph (NOT completion).
+        let in_flight = infer_productivity(
+            &config,
+            "✱ Glob \"*.toml\" (2 matches)\n",
+            stale_heartbeat(),
+        );
+        assert_eq!(in_flight, ProductivitySignal::NoSignal);
+    }
+
+    #[test]
+    fn ad_hoc_fallback_path_compiles_and_matches() {
+        // Pin the `cache_id: None` fallback path — for callers (test
+        // code, future ad-hoc configs) that supply custom markers
+        // without registering a cache. Phase 1 production never hits
+        // this path; the test ensures it stays correct.
+        let custom = ProductivityConfig {
+            markers: &["^CUSTOM PRODUCTIVE SIGNAL \\d+"],
+            use_heartbeat: false,
+            heartbeat_fresh_window_ms: 0,
+            cache_id: None,
+        };
+        let signal =
+            infer_productivity(&custom, "CUSTOM PRODUCTIVE SIGNAL 42\n", stale_heartbeat());
+        assert!(matches!(
+            signal,
+            ProductivitySignal::Productive {
+                source: ProductivitySource::Marker(_)
+            }
+        ));
+        let negative = infer_productivity(&custom, "nothing matches\n", stale_heartbeat());
+        assert_eq!(negative, ProductivitySignal::NoSignal);
     }
 }


### PR DESCRIPTION
Decision: `d-20260514022917793418-0` (three-party consensus: lead-claude + dev-claude + reviewer-opencode)
Audit chain (siblings): `d-20260513154400110972-2` (sub-task 1) + `d-20260513161542381785-0` (sub-task 2) + `d-20260513231713506833-1` (sub-task 3) + `d-20260513235514013631-0` (sub-task 4) + `d-20260514015214320625-1` (sub-task 5)

Issue: [#685](https://github.com/suzuke/agend-terminal/issues/685) Phase 1 deliverable #4. **Issue stays open** (multi-PR initiative); this PR ticks the backend-tuning sub-task checkbox.

## Summary
Per-backend productive-output markers for 5 managed backends + cache routing refactor. Refactor is **MUST-include**: without it, per-backend markers bypass pointer-eq routing and fall through to per-call `Regex::new()` compile — reproducing the PR #766 ubuntu/windows CI failure.

## Critical: cache routing refactor
Sub-task 4 (PR #766) shipped pointer-eq routing against `GENERIC_PRODUCTIVE_MARKERS` to find the cached `GENERIC_PRODUCTIVE_REGEXES` `LazyLock`. Per-backend markers (e.g. `CLAUDE_PRODUCTIVE_MARKERS`) have different pointers → fail the check → ad-hoc compile path. This is the same mechanism that caused PR #766 to fail `replay_manifest_regression` on ubuntu+windows due to cumulative wall-clock latency exceeding `min_hold` thresholds.

**Solution** (decision §1):
```rust
pub enum MarkerCacheId { Generic, Claude, Kiro, Codex, Gemini, OpenCode }

pub struct ProductivityConfig {
    pub markers: &'static [&'static str],
    pub use_heartbeat: bool,
    pub heartbeat_fresh_window_ms: u64,
    pub cache_id: Option<MarkerCacheId>,  // NEW
}
```

`infer_productivity` matches on `cache_id` to route to per-backend `LazyLock<Vec<Regex>>` static (`CLAUDE_PRODUCTIVE_REGEXES`, etc.). Compile-time exhaustive match prevents missing-backend bugs. `None` reserved for ad-hoc/test configs (Phase 1 production never hits this path).

## Per-backend MARKERS (explicit composition, no overlay)

Each backend's `MARKERS` const literally lists generic anchors + per-backend completion patterns. Source: `src/state.rs:200-450` ToolUse vocabulary (completion-only — in-progress spinner glyphs excluded; F9 productivity = cumulative-completion).

| Backend | Completion regex (added to generic anchors) | Validation |
|---|---|---|
| Claude | `^[✓●⏺]\s+(Read\|Bash\|Edit\|Write\|Grep\|Glob\|Listing\|Reading\|Writing\|Searching\|Editing)\b` | F685 fixture `f685-f9-positive-savedfile.raw` (synthetic) |
| Kiro | `^●\s+(Read\|Write\|Edit\|Bash\|Grep\|Glob\|Task\|List\|Search)\b` PLUS `\[(fs_read\|fs_write\|execute_bash)\]` | **Synthetic only** — real captures pending corpus growth |
| Codex | `^•\s+(Explored\|Edited\|Ran)\b` PLUS `apply_patch` | **Synthetic only** — real captures pending |
| Gemini | `^✓\s+(ReadFile\|WriteFile\|ReadManyFiles\|Edit\|Shell\|WebFetch\|Glob\|GoogleSearch\|MemoryTool\|ReadFolder)\b` | F685 fixture `f685-silent-stuck-stub.raw` (synthetic_from_real_template) |
| OpenCode | `^→\s+(Read\|Write\|Edit\|Glob\|Grep\|Bash\|List\|Task)\b` | **Synthetic only** — real captures pending |

## Excluded from F9 markers
- **In-progress / spinner glyphs** (Braille `[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]`, OpenCode `✱`, Codex `◦ Working`, Gemini `⠦ Thinking`). F9 productivity = completion-only — these fire BEFORE work completes.
- **Gemini `tool.*call` / `MCP.*tool`** — heartbeat path already covers MCP signals (avoid double-counting).
- **Bare keyword markers** (`Saved`/`Wrote` without line-start anchor). Pinned by per-backend `_reject_*` tests.

**Codex `apply_patch` INCLUDED** per decision (low-FP-risk tool name literal, improves Codex sensitivity).

## Files
| File | LOC | What |
|---|---|---|
| `src/behavioral.rs` | +385 -28 | `MarkerCacheId` enum + 5 per-backend `MARKERS` statics + 5 `LazyLock<Vec<Regex>>` caches + `compile_markers` helper + `infer_productivity` match-arm refactor + `config_for_productivity` per-backend match + 11 new unit tests |
| `docs/F9-PRODUCTIVE-OUTPUT-GATE.md` | +52 -10 | §F9.2 per-backend tables + cache routing note + codex/opencode synthetic-only labels |
| `docs/F685-FIXTURE-CORPUS.md` | +5 -3 | §F685-CORPUS.6 status note: sub-task 6 shipped per-backend markers; per-backend captures remain corpus growth path |

## Tests (11 new, 2127 total pass)
- 5 backends × positive (completion-glyph fires Productive): `claude_markers_match_completion_glyph_and_tool`, `kiro_markers_match_glyph_or_bracketed_tool`, `codex_markers_match_dot_title_or_apply_patch`, `gemini_markers_match_check_glyph_and_camelcase_tool`, `opencode_markers_match_arrow_glyph_completion`
- 5 backends × negative (bare prose / in-progress spinner fires NoSignal): `claude_markers_reject_in_progress_spinner_and_prose`, `kiro_markers_reject_bare_tool_name_prose`, `codex_markers_reject_in_flight_spinner_prose`, `gemini_markers_reject_braille_spinner_and_mcp_prose`, `opencode_markers_reject_in_flight_asterisk_glyph`
- 1 fallback: `ad_hoc_fallback_path_compiles_and_matches` (pins `cache_id: None` path)
- **CRITICAL**: `state::tests::replay_manifest_regression` still passes post-refactor (would fail if cache routing has latency bug)

## Out of scope (per decision §3)
- Per-backend silence threshold tuning — needs corpus measurement
- Per-backend `heartbeat_fresh_window_ms` tuning — needs corpus measurement
- F39 mitigation selection / F9 promotion — fixture-corpus-N-gated
- Real PTY captures for codex/opencode — corpus growth path
- Phase 2 staged auto-recovery

scope: follows spec (decision `d-20260514022917793418-0`) — per-backend markers + cache routing refactor + tests + doc updates; no behavior change to F9 architecture / shadow-mode default / env var gate / heartbeat semantics.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bin agend-terminal`: 2127 passed (11 new + 2116 existing)
- [x] `state::tests::replay_manifest_regression`: passes (CRITICAL — would fail if cache routing has latency regression)
- [ ] Cross-platform CI green (ubuntu + macOS + Windows + LOC + audit)
- [ ] Phase 3 review by reviewer-opencode

🤖 Generated with [Claude Code](https://claude.com/claude-code)