### PR TITLE
refactor(#694): BLOCK 2 fourth cut — channel-heavy cohort (inbox/reply/download_attachment)

### DIFF
--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -37,7 +37,7 @@ use crate::identity::Sender;
 use serde_json::{json, Value};
 use std::path::Path;
 
-use super::{binding_state, ci, comms, force_release, instance, schedule, task, worktree};
+use super::{binding_state, channel, ci, comms, force_release, instance, schedule, task, worktree};
 
 /// Shared per-call context — every common parameter `handle_tool`
 /// would otherwise pass into the match arms, bundled together so each
@@ -450,6 +450,45 @@ static TEAM_ACTIONS: &[(&str, HandlerFn)] = &[
     ("update", dispatch_team_update),
 ];
 
+// ---------------------------------------------------------------------
+// Channel-heavy cohort (T-B10) — `download_attachment` / `inbox` /
+// `reply`. Selection is by arg presence (not by `args["action"]`), so
+// every tool here uses `actions: None` and the dispatching branch lives
+// inside the base adapter, exactly mirroring the pre-migration inline
+// match arm. Side effects (telegram channel writes, filesystem media
+// download, inbox storage RMW) are unchanged — adapters are pure
+// forwards.
+
+fn dispatch_download_attachment(ctx: &HandlerCtx<'_>) -> Value {
+    channel::handle_download_attachment(ctx.home, ctx.args, ctx.instance_name)
+}
+
+// `inbox` — three-way branch on arg presence (NOT `args["action"]`):
+//   - `message_id` present → `comms::handle_describe_message`
+//   - else `thread_id` present → `comms::handle_describe_thread`
+//   - else → `comms::handle_inbox` (drain pending)
+// Order matters: the original inline match arm preferred message_id
+// over thread_id, so this `if / else if / else` chain preserves byte-
+// identical routing for callers that (incorrectly) pass both.
+fn dispatch_inbox(ctx: &HandlerCtx<'_>) -> Value {
+    if ctx
+        .args
+        .get("message_id")
+        .and_then(|v| v.as_str())
+        .is_some()
+    {
+        comms::handle_describe_message(ctx.home, ctx.args, ctx.instance_name)
+    } else if ctx.args.get("thread_id").and_then(|v| v.as_str()).is_some() {
+        comms::handle_describe_thread(ctx.home, ctx.args)
+    } else {
+        comms::handle_inbox(ctx.home, ctx.instance_name)
+    }
+}
+
+fn dispatch_reply(ctx: &HandlerCtx<'_>) -> Value {
+    channel::handle_reply(ctx.home, ctx.args, ctx.instance_name)
+}
+
 /// Registered tool dispatchers. **Adding a tool**: write its adapter
 /// above, append a [`HandlerEntry`] here. **Removing**: delete both
 /// halves. Order doesn't affect correctness (linear-scan match by
@@ -591,6 +630,25 @@ static REGISTERED: &[HandlerEntry] = &[
         handler: dispatch_team,
         actions: Some(TEAM_ACTIONS),
     },
+    // Channel-heavy cohort (T-B10): download_attachment / inbox / reply.
+    // Flat dispatch (no `args["action"]` sub-routing) — the conceptual
+    // "actions" for `inbox` (drain / describe / thread) are selected by
+    // arg presence inside `dispatch_inbox`, not by an `action` field.
+    HandlerEntry {
+        name: "download_attachment",
+        handler: dispatch_download_attachment,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "inbox",
+        handler: dispatch_inbox,
+        actions: None,
+    },
+    HandlerEntry {
+        name: "reply",
+        handler: dispatch_reply,
+        actions: None,
+    },
 ];
 
 pub(super) fn registered_handlers() -> &'static [HandlerEntry] {
@@ -666,9 +724,12 @@ mod tests {
                 "repo",
                 "schedule",
                 "team",
+                "download_attachment",
+                "inbox",
+                "reply",
             ]
         );
-        assert_eq!(registered_handlers().len(), 23);
+        assert_eq!(registered_handlers().len(), 26);
     }
 
     /// Coverage test: every tool name advertised by

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -108,20 +108,15 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
 
     match tool {
         // --- Channel ---
-        "reply" => channel::handle_reply(&home, args, instance_name),
-        "download_attachment" => channel::handle_download_attachment(&home, args, instance_name),
+        // NOTE: `reply` / `download_attachment` migrated to dispatch table
+        // (#694 BLOCK 2 T-B10). See `dispatch::dispatch_reply` /
+        // `dispatch::dispatch_download_attachment`.
 
         // --- Cross-instance communication ---
         // NOTE: `send` migrated to dispatch table (#694 BLOCK 2 T-B8).
-        "inbox" => {
-            if args.get("message_id").and_then(|v| v.as_str()).is_some() {
-                comms::handle_describe_message(&home, args, instance_name)
-            } else if args.get("thread_id").and_then(|v| v.as_str()).is_some() {
-                comms::handle_describe_thread(&home, args)
-            } else {
-                comms::handle_inbox(&home, instance_name)
-            }
-        }
+        // NOTE: `inbox` migrated to dispatch table (#694 BLOCK 2 T-B10).
+        // The three-way branch on `message_id` / `thread_id` / drain
+        // moved verbatim into `dispatch::dispatch_inbox`.
 
         // --- Instance management ---
         // NOTE: 8 instance-lifecycle arms migrated to dispatch table


### PR DESCRIPTION
## Summary

T-B10 — BLOCK 2 fourth cut of #694. Migrate three channel-heavy MCP tools (`inbox`, `reply`, `download_attachment`) to the dispatch table. Pattern matches T-B9 (PR #768) Option-B match-in-base. **Dispatch table count: 23 → 26.** Remaining 4 flat tools (`set_display_name` / `pane_snapshot` / `task_sweep_config` / `restart_daemon`) deferred to T-B11.

## Scope statement

scope follows dispatch spec / no other changes. **ZERO behavior change** — every call path through the new adapters lands at the same `channel::` / `comms::` handler the inline match arm did, with the same parameter shapes. **canary for the bypass-free workflow** (no BYPASS used; rebase + commit + push + gh pr create all clean through the task-bound worktree).

## What changed

`src/mcp/handlers/dispatch.rs` (+65 / -2):

- `use super::{…, channel, …}` — bring `channel` mod into scope (it owns `handle_reply` + `handle_download_attachment`)
- `dispatch_download_attachment` — flat shape-1 forward to `channel::handle_download_attachment`
- `dispatch_inbox` — three-way arg-presence branch moved verbatim from the inline `match` arm:
  - `args["message_id"]` present → `comms::handle_describe_message`
  - else if `args["thread_id"]` present → `comms::handle_describe_thread`
  - else → `comms::handle_inbox` (drain pending)
  - `actions: None` because the conceptual sub-operations are NOT keyed on `args["action"]` — selection by arg presence preserved byte-for-byte
- `dispatch_reply` — flat shape-1 forward to `channel::handle_reply`
- Three new `HandlerEntry { actions: None }` rows appended to `REGISTERED` under a `// Channel-heavy cohort (T-B10)` comment, in alphabetical order (download_attachment, inbox, reply)
- `registered_handler_names_pin` pinned list extended with the three new names; count bumped 23 → 26

`src/mcp/handlers/mod.rs` (+4 / -11):

- Three inline match arms (`reply`, `download_attachment`, `inbox`) **REMOVED**
- Replaced with `NOTE: <tool> migrated to dispatch table (#694 BLOCK 2 T-B10)` comments at the same locations so a future reader greps to the new home

## ZERO behavior change

- `inbox` three-way branch order preserved exactly: `message_id` over `thread_id` over drain — same as the pre-migration `if / else if / else` chain, so callers that (incorrectly) pass both args route identically.
- `reply` / `download_attachment` are 1-line forwards; side effects (telegram channel write, filesystem media download, inbox storage RMW) unchanged.
- `actions: None` for all three — the action sub-routing machinery in `try_dispatch` is bypassed and the base adapter runs directly, just like the inline match arm did.
- `every_advertised_tool_is_routed_somewhere` still passes — the three names now appear in `dispatch.rs` but no longer in `mod.rs`, satisfying the OR condition.

## Workflow note (canary)

This PR is the **first refactor team PR through the bypass-free task-bound workflow** per operator's Q2=(C) protocol. Caught one infra gap on first attempt — the `refactor` team had no `source_repo` metadata so `task action=claim` bound an empty workspace placeholder. After general created the team with `source_repo=/Users/suzuke/Documents/Hack/agend-terminal`, `bind_self branch=refactor/694-block2-fourth-cut source_repo=…` worked cleanly. Subsequent ops (`git fetch`, `git rebase origin/main`, `git commit`, `git push -u`, `gh pr create`) all ran **without any AGEND_GIT_BYPASS variant**.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --all-targets --features tray -- -D warnings`: clean
- `cargo test --features tray`: 2124 lib + 29 integration test crates all green
- `mcp_proxy_parity`: 4/4 passed
- `mcp_proxy_behavioral_parity`: 2/2 passed
- `registered_handler_names_pin`: 26 entries with correct ordering (T-B7 shapes 1+2 → T-B8 shapes 3+4 → `task` → T-B9 action cohort → T-B10 channel cohort)
- `every_advertised_tool_is_routed_somewhere`: passes

## Diff size

`src/mcp/handlers/dispatch.rs`: +65 / -2 = +63 LOC (file_size_invariant skip list per T-B9 broadening; expected per dispatch contract)
`src/mcp/handlers/mod.rs`: +4 / -11 = -7 LOC

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` all green
- [x] `mcp_proxy_parity` + `mcp_proxy_behavioral_parity` green (zero-behavior-change proof)
- [x] `registered_handler_names_pin` updated to 26
- [ ] GitHub Actions CI green across 5 platforms (pending)
- [ ] reviewer-codex VERIFIED (pending dispatch by general)

🤖 Generated with [Claude Code](https://claude.com/claude-code)