### PR TITLE
feat(F9): Stage 3 escalate + pause (shadow-mode) (#685 sub-task 7c)

### DIFF
--- a/docs/RECOVERY-STAGES.md
+++ b/docs/RECOVERY-STAGES.md
@@ -68,12 +68,13 @@ Carried inside `HealthTracker` so the dispatcher reads both
               └────────┬────────┘
                        ▼
               ┌─────────────────┐
-              │ Stage3Eligible  │── (7c) Stage 3 fires
-              └────────┬────────┘
-                       ▼
-              ┌─────────────────┐    HealthState transitions to Paused;
-              │ Stage3Pending   │    operator unpause action only.
-              └─────────────────┘
+              │ Stage3Eligible  │── (7c) Stage 3 fires:
+              └────────┬────────┘    enter_paused(now) writes
+                       ▼               HealthState::Paused atomically
+              ┌─────────────────┐    Terminal. `Paused` short-circuits
+              │ Stage3Pending   │    check_hang + maybe_decay; only an
+              │   { entered_at }│    operator unpause (future sub-task)
+              └─────────────────┘    leaves this state.
 ```
 
 Sub-task 7a (Stage 1) implemented:
@@ -93,8 +94,13 @@ Sub-task 7a (Stage 1) implemented:
 - `Stage2Eligible → Stage2Eligible` (channel-full retry — `try_send`
   failed, state stays for next-tick retry without counter increment)
 
-Sub-task 7c (Stage 3) follow-up adds `Stage3Eligible → Stage3Pending +
-HealthState::Paused` transition.
+**Sub-task 7c (Stage 3) implemented** (this PR):
+- `Stage3Eligible → Stage3Pending { entered_at }` (Stage 3 fire — only
+  via `HealthTracker::enter_paused` per §F39.5; atomically writes
+  `state = Paused`, `recovery_stage_state = Stage3Pending`,
+  `last_stage3_fired_at = Some(now)`)
+- `Stage3Pending` is terminal — explicit no-op arm in dispatcher; only
+  a future operator-unpause sub-task transitions out.
 
 ## §RS.3 — Tick order & dispatcher placement
 
@@ -385,3 +391,154 @@ removal candidate.
 - Full PTY-backed integration test for the variant-split spawn —
   unit tests cover the state machine + counter discipline; full
   integration deferred unless shadow telemetry surfaces edge cases.
+
+## §RS.10 — Stage 3 specifics (sub-task 7c)
+
+Stage 3 is the terminal stage of the auto-recovery state machine.
+After Stage 1 ESC failed and Stage 2 auto-restart was attempted up to
+the cumulative cap (`recovery_restart_count >= STAGE2_MAX_RESTARTS`),
+the dispatcher escalates the agent to `HealthState::Paused` and
+notifies the operator that manual intervention is required.
+
+### 10.1 Stage 3 purpose
+
+Auto-recovery is exhausted; further unattended retries would just
+thrash the agent. Stage 3's job is to **stop trying**, lock the
+agent's `HealthState` into a non-acting terminal value, and surface
+the situation to the operator via an Error-level telegram. The
+escalation is **single-shot per Hung cycle** — once `Stage3Pending`,
+the dispatcher's `Stage3Pending` arm is an explicit no-op (see
+§10.5).
+
+### 10.2 `enter_paused` atomic invariants
+
+`src/health.rs::HealthTracker::enter_paused(&mut self, now: Instant)`
+is the **sole writer** of `HealthState::Paused` in the codebase
+(§F39.5 invariant — single grep target). The method writes three
+invariants under the caller's lock:
+
+1. `state = HealthState::Paused`
+2. `recovery_stage_state = RecoveryStageState::Stage3Pending { entered_at: now }`
+3. `last_stage3_fired_at = Some(now)`
+
+The `Stage3Pending` variant carries `entered_at` so the dispatcher's
+no-op debug log can report Paused-since duration without reaching back
+into `HealthTracker`. `last_stage3_fired_at` is reserved for the future
+operator-unpause sub-task (UX "Paused since N minutes") and carries
+`#[allow(dead_code)]` until that sub-task reads it.
+
+DI-friendly signature parallels `maybe_decay_at(now)`: production
+passes `Instant::now()`; tests pass a deterministic base for
+cross-platform-safe arithmetic (PR #775 v2 lesson — `Instant::add`
+saturates on all platforms; `Instant::now() - Duration` can underflow
+on low-uptime Windows CI VMs).
+
+### 10.3 `NotifySeverity::Error` + telegram format
+
+The `NotifySeverity` enum has three levels: `Info`, `Warn`, `Error`.
+Stage 2 uses `Warn`; crash notifications use `Error`. Stage 3 = "auto-
+recovery exhausted, operator must act", so its severity must be ≥ the
+crash level → `Error`. `silent=false` so the operator's channel
+surfaces it alongside crash notifications.
+
+Telegram body (built by `format_stage3_body(name, count)` so unit
+tests pin the operator-facing wording):
+
+```
+[recovery ESCALATION] {name}: PAUSED — manual intervention required.
+  Stage 2 auto-restart fired {count} time(s), all exhausted.
+  Final state: Paused (no further auto-recovery).
+  Action: investigate root cause + manual unpause (CLI command pending sub-task).
+```
+
+Telegram fires in **both** shadow and active modes so operators see
+the escalation pattern before flipping the gate. Pre-emitted before
+the state write so a crash between telegram and `enter_paused` still
+surfaces the decision.
+
+### 10.4 `recovery_restart_count` NOT reset on `enter_paused`
+
+The counter is **preserved** across Stage 3 entry. Rationale: Paused
+means "automated retry is exhausted; root cause must be addressed".
+If a future operator-unpause sub-task brings the agent back to
+`Healthy` and the agent Hungs again without the root cause being
+fixed, the dispatcher's cap check immediately escalates to
+`Stage3Eligible` again rather than burning further auto-restart
+budget. The operator semantics is: pause is sticky; counter reset is
+the unpause sub-task's design space.
+
+### 10.5 `Stage3Pending` idempotent no-op
+
+The dispatcher's `Stage3Pending` arm is an explicit no-op:
+
+```rust
+RecoveryStageState::Stage3Pending { entered_at } => {
+    tracing::debug!(
+        target: "recovery_shadow",
+        agent = %name,
+        paused_for_ms = entered_at.elapsed().as_millis() as u64,
+        "stage3_pending: awaiting operator unpause"
+    );
+}
+```
+
+No state mutation, no telegram re-fire, no timeout escalation. Double
+protection against any subtle re-entry path comes from the top-level
+`HealthState::Paused` early-`continue` in `run()` (§RS.7 7a guard).
+Together: dispatcher cannot escalate out of Paused, cannot re-fire
+Stage 3 telegrams on subsequent ticks, and `maybe_decay_at` honours
+the Paused short-circuit so the counter the operator sees stays
+faithful to the moment Paused entered.
+
+### 10.6 Promotion criteria (`AGEND_AUTO_RECOVERY_STAGE3=1`)
+
+Hybrid template (round 2 convergence):
+
+1. Operator runs daemon with `AGEND_AUTO_RECOVERY_STAGE3` unset
+   (shadow) for ≥2 weeks across the agent fleet.
+2. Operator reviews `recovery_shadow` tracing target output, focusing
+   on **trigger rate per week** rather than FP-per-trigger. FP
+   semantics are undefined for a terminal stage — Stage 3 only fires
+   after Stage 2 retries are demonstrably exhausted, so the risk of
+   inappropriate action is structurally near-zero. The observation
+   target is "how often is the fleet hitting auto-recovery exhaustion
+   at all?".
+3. Once trigger-rate baseline is stable and operator is confident
+   that paused agents are genuinely stuck (rather than e.g. mis-tuned
+   thresholds), flip `AGEND_AUTO_RECOVERY_STAGE3=1`.
+
+Anti-dead-infra clause carries over from Stage 1 / Stage 2: 6 weeks
+without measurement → Stage 3 promotion infrastructure becomes a
+removal candidate.
+
+### 10.7 Paused 解除 limitations (Phase 1)
+
+Once `enter_paused` writes, the agent stays in `Paused` until one of
+the following:
+
+- **Operator manual restart** via the existing CLI agent-restart
+  surface — fully resets the agent (fresh `HealthTracker`), which
+  also resets `recovery_restart_count`. This is the Phase 1 operator
+  workflow.
+- **Future operator-unpause sub-task** will provide a dedicated
+  `unpause` CLI / MCP command that transitions `Paused → Healthy`
+  without a full restart. Its scope includes the design space of
+  whether to reset `recovery_restart_count` on unpause; 7c does
+  **not** make that decision in advance.
+
+No automatic exit from `Paused` exists. `maybe_decay_at` honours the
+short-circuit at line 1 of its body (7a guard) — the counter the
+operator sees is faithful to the Paused-entry moment.
+
+### Out of scope (sub-task 7c)
+
+- Operator unpause command (separate sub-task)
+- Per-backend Stage 3 customization (Phase 3)
+- Multiple-Pause aggregation (single Paused tracking only)
+- `recovery_restart_count` reset on unpause (defer to unpause sub-task)
+- `last_stage3_fired_at` consumer code (reserved for unpause sub-task;
+  `#[allow(dead_code)]` carries the field through 7c)
+- Full PTY-backed integration test for `enter_paused` via a registered
+  agent — unit tests pin the atomic invariants + idempotency at the
+  `HealthTracker` boundary; integration deferred unless shadow
+  telemetry surfaces edge cases.

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -94,6 +94,14 @@ const STAGE2_BACKOFF_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS";
 const STAGE2_TIMEOUT_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE2_TIMEOUT_MS";
 const STAGE2_MAX_RESTARTS_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE2_MAX_RESTARTS";
 
+/// `#685` sub-task 7c: env var controlling Stage 3 escalation activation.
+/// When set to `"1"`, the dispatcher writes `HealthState::Paused` via
+/// `HealthTracker::enter_paused` (active mode). Default unset = shadow
+/// mode: telegram + tracing only, no state write — operator can observe
+/// the decision pattern before flipping. Mirrors STAGE1 / STAGE2 env
+/// gate pattern.
+const STAGE3_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE3";
+
 pub(crate) struct RecoveryDispatcherHandler {
     /// `#685` sub-task 7b: handle to the daemon's `crash_tx` channel.
     /// Stage 1 path (already shipped in 7a) holds but never sends —
@@ -130,6 +138,12 @@ fn stage2_max_restarts() -> u32 {
         },
         Err(_) => crate::health::STAGE2_MAX_RESTARTS_DEFAULT,
     }
+}
+
+fn stage3_gate_active() -> bool {
+    std::env::var(STAGE3_ENV_VAR)
+        .map(|v| v == "1")
+        .unwrap_or(false)
 }
 
 /// Read an env var as milliseconds with a typed default. Logged at
@@ -205,6 +219,7 @@ impl PerTickHandler for RecoveryDispatcherHandler {
             crate::health::STAGE2_TIMEOUT_DEFAULT_MS,
         );
         let stage2_max = stage2_max_restarts();
+        let stage3_active = stage3_gate_active();
 
         for (name, handle) in reg.iter() {
             // Single per-agent lock acquisition reads all dispatcher
@@ -294,11 +309,23 @@ impl PerTickHandler for RecoveryDispatcherHandler {
                         core.health.recovery_stage_state = RecoveryStageState::Stage3Eligible;
                     }
                 }
-                RecoveryStageState::Stage3Eligible | RecoveryStageState::Stage3Pending => {
-                    // Stage 3 arm ships in sub-task 7c. Dispatcher
-                    // currently no-op for these states; once 7c lands,
-                    // Stage3Eligible → transition HealthState to Paused
-                    // and emit Stage 3 telegram.
+                RecoveryStageState::Stage3Eligible => {
+                    self.handle_stage3_escalate(name, handle, &snapshot, stage3_active);
+                }
+                RecoveryStageState::Stage3Pending { entered_at } => {
+                    // Stage 3 is terminal — no further auto-recovery,
+                    // no timeout escalation, no telegram re-fire. The
+                    // explicit no-op arm exists so the match is
+                    // compile-time exhaustive and so audit traces show
+                    // the dispatcher saw the agent but deliberately
+                    // declined to act. Operator unpause command (future
+                    // sub-task) is the only path out of Paused.
+                    tracing::debug!(
+                        target: TARGET,
+                        agent = %name,
+                        paused_for_ms = entered_at.elapsed().as_millis() as u64,
+                        "stage3_pending: awaiting operator unpause"
+                    );
                 }
             }
         }
@@ -464,6 +491,64 @@ impl RecoveryDispatcherHandler {
             }
         }
     }
+
+    /// Stage 3 escalate arm. Stage 3 is the terminal stage of the
+    /// recovery state machine — after Stage 1 ESC failed and Stage 2
+    /// auto-restart was attempted up to the cumulative cap, the agent
+    /// is escalated to `HealthState::Paused` and the operator is
+    /// notified that manual intervention is required.
+    ///
+    /// Order of operations (atomicity-relevant):
+    /// 1. Pre-emit telegram via `notify_stage3_escalate` — fires in
+    ///    BOTH shadow and active modes so operators have visibility
+    ///    into the decision pattern before flipping the gate to `=1`.
+    /// 2. If `gate_active`: acquire the per-agent lock once and call
+    ///    `core.health.enter_paused(now)` — atomically writes
+    ///    `state = Paused`, `recovery_stage_state = Stage3Pending`,
+    ///    `last_stage3_fired_at = Some(now)`. Next-tick dispatcher
+    ///    lands on the `Stage3Pending` no-op arm and on the top-level
+    ///    `Paused` `continue` guard, so the telegram never re-fires.
+    /// 3. Else (shadow): emit `tracing::info!` with would-have-paused
+    ///    details; no state mutation.
+    ///
+    /// `recovery_restart_count` is NOT reset on entry — per decision
+    /// `enter_paused` documentation, the count is preserved so a
+    /// future operator-unpause that doesn't address the root cause
+    /// immediately re-escalates rather than burning further auto-
+    /// restart budget.
+    fn handle_stage3_escalate(
+        &self,
+        name: &str,
+        handle: &agent::AgentHandle,
+        snapshot: &DispatchSnapshot,
+        gate_active: bool,
+    ) {
+        // Pre-emit telegram in BOTH modes — operator visibility on
+        // shadow promotions matters as much as on active escalations.
+        notify_stage3_escalate(name, snapshot);
+
+        if gate_active {
+            let now = Instant::now();
+            let mut core = handle.core.lock();
+            core.health.enter_paused(now);
+            tracing::info!(
+                target: TARGET,
+                agent = %name,
+                recovery_restart_count = snapshot.recovery_restart_count,
+                gate_active = true,
+                "stage3 fired: HealthState transitioned to Paused via enter_paused"
+            );
+        } else {
+            tracing::info!(
+                target: TARGET,
+                agent = %name,
+                recovery_restart_count = snapshot.recovery_restart_count,
+                silent_ms = snapshot.silent.as_millis() as u64,
+                gate_active = false,
+                "stage3 would-have-fired (shadow mode): Paused write NOT applied"
+            );
+        }
+    }
 }
 
 /// Read-only snapshot of per-agent state captured under a single lock
@@ -507,6 +592,45 @@ fn notify_stage2_fire(name: &str, _handle: &agent::AgentHandle, snapshot: &Dispa
             target: TARGET,
             agent = %name,
             "stage2 telegram skipped: no active channel"
+        );
+    }
+}
+
+/// Build the Stage 3 escalation telegram body. Extracted so unit
+/// tests can pin the operator-facing wording (decision §3 "dev's
+/// revised 4-line content") independent of the `gated_notify` plumbing.
+fn format_stage3_body(name: &str, recovery_restart_count: u32) -> String {
+    format!(
+        "[recovery ESCALATION] {name}: PAUSED — manual intervention required.\n  \
+         Stage 2 auto-restart fired {count} time(s), all exhausted.\n  \
+         Final state: Paused (no further auto-recovery).\n  \
+         Action: investigate root cause + manual unpause (CLI command pending sub-task).",
+        count = recovery_restart_count,
+    )
+}
+
+/// Stage 3 escalation telegram. Operator-action-required severity =
+/// `NotifySeverity::Error` (per decision §3 dev-grep evidence: enum has
+/// only Info/Warn/Error; Stage 2 = Warn, crash = Error; Stage 3 ≥ crash
+/// since auto-recovery is exhausted and only operator action can
+/// resume). `silent=false` so the operator's channel surfaces it
+/// alongside crash notifications. Uses `gated_notify` so the
+/// info-leak gate prevents leakage when channel is unauthorised.
+fn notify_stage3_escalate(name: &str, snapshot: &DispatchSnapshot) {
+    let body = format_stage3_body(name, snapshot.recovery_restart_count);
+    if let Some(channel) = crate::channel::active_channel() {
+        let _ = crate::channel::gated_notify(
+            channel.as_ref(),
+            name,
+            crate::channel::NotifySeverity::Error,
+            &body,
+            false,
+        );
+    } else {
+        tracing::debug!(
+            target: TARGET,
+            agent = %name,
+            "stage3 telegram skipped: no active channel"
         );
     }
 }
@@ -966,5 +1090,134 @@ mod tests {
         let recent = base;
         let now_recent = base + Duration::from_secs(5);
         assert!(now_recent.saturating_duration_since(recent) < timeout);
+    }
+
+    // -------------------------------------------------------------------
+    // `#685` sub-task 7c Stage 3 tests. Cover the new dispatcher arm
+    // surface: env gate round-trip, enter_paused atomic invariants,
+    // recovery_restart_count NOT reset on Paused entry (operator-must-
+    // fix-root-cause signal), Stage3Pending idempotent no-op semantics,
+    // and operator-facing telegram content. Decision §7.
+    // -------------------------------------------------------------------
+
+    fn with_stage3_gate<R>(active: bool, f: impl FnOnce() -> R) -> R {
+        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+        let lock = LOCK.get_or_init(|| std::sync::Mutex::new(()));
+        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        let prior = std::env::var(STAGE3_ENV_VAR).ok();
+        unsafe {
+            if active {
+                std::env::set_var(STAGE3_ENV_VAR, "1");
+            } else {
+                std::env::remove_var(STAGE3_ENV_VAR);
+            }
+        }
+        let result = f();
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var(STAGE3_ENV_VAR, v),
+                None => std::env::remove_var(STAGE3_ENV_VAR),
+            }
+        }
+        result
+    }
+
+    #[test]
+    fn stage3_gate_env_var_round_trip() {
+        // Operator can flip `AGEND_AUTO_RECOVERY_STAGE3=1` without
+        // restarting the daemon — same shape as Stage 1 / Stage 2 gate
+        // env tests. Decision §4 shadow-mode default + env var promotion
+        // workflow.
+        with_stage3_gate(true, || {
+            assert!(stage3_gate_active());
+        });
+        with_stage3_gate(false, || {
+            assert!(!stage3_gate_active());
+        });
+    }
+
+    #[test]
+    fn enter_paused_sets_state_recovery_stage_and_timestamp_atomically() {
+        // Decision §1: `enter_paused(now)` writes 3 invariants in one
+        // logical step:
+        //   1. state = Paused
+        //   2. recovery_stage_state = Stage3Pending { entered_at: now }
+        //   3. last_stage3_fired_at = Some(now)
+        // Single grep target enforces 7a §F39.5 "Paused entered ONLY
+        // via Stage 3 dispatcher".
+        let mut tracker = crate::health::HealthTracker::new();
+        let now = Instant::now();
+        tracker.enter_paused(now);
+        assert_eq!(tracker.state, HealthState::Paused);
+        match tracker.recovery_stage_state {
+            RecoveryStageState::Stage3Pending { entered_at } => {
+                assert_eq!(entered_at, now);
+            }
+            other => panic!("expected Stage3Pending, got {other:?}"),
+        }
+        assert_eq!(tracker.last_stage3_fired_at, Some(now));
+    }
+
+    #[test]
+    fn enter_paused_does_not_reset_recovery_restart_count() {
+        // Decision §1 critical invariant: `recovery_restart_count` is
+        // preserved across `enter_paused` to keep the operator-must-fix
+        // signal. If a future operator unpauses the agent without
+        // addressing the root cause and it Hungs again, the dispatcher
+        // cap check immediately escalates to Stage3Eligible rather than
+        // burning further auto-restart budget.
+        let mut tracker = crate::health::HealthTracker::new();
+        tracker.recovery_restart_count = 3;
+        let now = Instant::now();
+        tracker.enter_paused(now);
+        assert_eq!(tracker.recovery_restart_count, 3);
+        assert_eq!(tracker.state, HealthState::Paused);
+    }
+
+    #[test]
+    fn stage3_pending_state_no_op_under_maybe_decay() {
+        // Stage 3 is terminal: dispatcher's `Stage3Pending` arm is
+        // explicit no-op, and `maybe_decay_at` honours the
+        // `HealthState::Paused` short-circuit. Together these ensure
+        // that ticking the dispatcher / decay loop while an agent is
+        // Paused does NOT silently mutate state away from Paused or
+        // re-fire Stage 3. Pinned at the decay boundary because that's
+        // the only health-side mutation that runs on every tick;
+        // dispatcher-tick Stage3Pending no-op is verified by reading
+        // the source (no AgentHandle harness exists for the run() arm).
+        let mut tracker = crate::health::HealthTracker::new();
+        let entered = Instant::now();
+        tracker.enter_paused(entered);
+        // Simulate a very long stable window — decay must still not
+        // exit Paused or touch the preserved counter.
+        tracker.recovery_restart_count = 2;
+        tracker.last_stage2_fired_at = Some(entered);
+        tracker.maybe_decay_at(entered + Duration::from_secs(31 * 60));
+        assert_eq!(tracker.state, HealthState::Paused);
+        assert_eq!(tracker.recovery_restart_count, 2);
+        match tracker.recovery_stage_state {
+            RecoveryStageState::Stage3Pending { entered_at } => {
+                assert_eq!(entered_at, entered);
+            }
+            other => panic!("expected Stage3Pending preserved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn format_stage3_body_includes_recovery_restart_count_and_action() {
+        // Decision §3 telegram content (dev-revised after grep evidence
+        // cut Backend + N1): operator-facing wording must surface the
+        // exhausted Stage 2 count + manual-unpause action hint. Cuts
+        // Backend (DispatchSnapshot lacks the field) and Stage 1 N1
+        // (HealthTracker doesn't track the count).
+        let body = format_stage3_body("orchestrator", 3);
+        assert!(body.contains("ESCALATION"));
+        assert!(body.contains("orchestrator"));
+        assert!(body.contains("PAUSED"));
+        assert!(body.contains("Stage 2 auto-restart fired 3 time(s)"));
+        assert!(body.contains("manual unpause"));
+        // Negative: must NOT include the cut fields per decision §3.
+        assert!(!body.contains("Backend:"));
+        assert!(!body.contains("Stage 1 ESC"));
     }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -117,11 +117,15 @@ pub enum RecoveryStageState {
     /// stub — emitted by 7b when Stage 2 ships.)
     Stage2Pending { entered_at: Instant },
     /// Stage 2 timed out. Dispatcher will fire Stage 3 on next tick.
-    /// (Phase 1 stub.)
     Stage3Eligible,
     /// Stage 3 dispatched (HealthState transitioned to Paused).
-    /// Awaiting operator unpause action. (Phase 1 stub.)
-    Stage3Pending,
+    /// Awaiting operator unpause action. `entered_at` is the
+    /// `Instant` passed to [`HealthTracker::enter_paused`] and is the
+    /// same value stamped into [`HealthTracker::last_stage3_fired_at`]
+    /// — kept on the variant so dispatcher tick-time debug logs can
+    /// report Paused-since duration without reaching back into
+    /// `HealthTracker` (parallel `Stage1Pending` / `Stage2Pending`).
+    Stage3Pending { entered_at: Instant },
 }
 
 /// Stage 1 default timeout — ESC dispatched, dispatcher waits this long
@@ -243,6 +247,15 @@ pub struct HealthTracker {
     /// decrement the recovery counter. `None` means Stage 2 has never
     /// fired for this agent in the current daemon run.
     pub last_stage2_fired_at: Option<Instant>,
+    /// `#685` sub-task 7c: timestamp of last Stage 3 escalation (the
+    /// transition into `HealthState::Paused`). Reserved for the future
+    /// operator-unpause sub-task — it will read this to display "Paused
+    /// since {duration}" in the unpause UI and may extend
+    /// [`Self::maybe_decay_at`] to honour a Paused decay window. Stage 3
+    /// is terminal in Phase 2, so nothing in 7c reads the field; carry
+    /// `#[allow(dead_code)]` until the unpause sub-task lands.
+    #[allow(dead_code)]
+    pub(crate) last_stage3_fired_at: Option<Instant>,
 }
 
 impl HealthTracker {
@@ -260,7 +273,43 @@ impl HealthTracker {
             last_stage1_fired_at: None,
             recovery_restart_count: 0,
             last_stage2_fired_at: None,
+            last_stage3_fired_at: None,
         }
+    }
+
+    /// `#685` sub-task 7c: atomic transition into `HealthState::Paused`
+    /// for Stage 3 escalation. Encapsulates the three invariants that
+    /// the dispatcher's Stage 3 arm must apply together so the §F39.5
+    /// rule "Paused entered ONLY via Stage 3 dispatcher" has a single
+    /// grep target — `enter_paused` is the sole writer of
+    /// `HealthState::Paused` in the codebase.
+    ///
+    /// Invariants written in one logical step (caller holds the per-
+    /// agent lock for the duration):
+    /// 1. `state` → `HealthState::Paused` (terminal — no further
+    ///    auto-recovery; check_hang short-circuits and maybe_decay
+    ///    no-touches Paused per 7a guards).
+    /// 2. `recovery_stage_state` → `Stage3Pending { entered_at: now }`
+    ///    so the dispatcher's next tick lands on the idempotent no-op
+    ///    arm rather than re-firing Stage 3.
+    /// 3. `last_stage3_fired_at` → `Some(now)` for the future operator-
+    ///    unpause sub-task's UX (Paused-since-{duration}).
+    ///
+    /// **`recovery_restart_count` is NOT reset** — preserves the
+    /// operator-must-fix-root-cause signal across a future manual
+    /// unpause. If the post-unpause agent Hungs again without the root
+    /// cause being addressed, the cap check in
+    /// [`crate::daemon::per_tick::recovery_dispatcher`] immediately
+    /// re-escalates to Stage3Eligible rather than burning further
+    /// auto-restart budget.
+    ///
+    /// DI-friendly signature (parallels [`Self::maybe_decay_at`]) so
+    /// tests can supply a deterministic `now`. Production callers
+    /// always pass `Instant::now()`.
+    pub fn enter_paused(&mut self, now: Instant) {
+        self.state = HealthState::Paused;
+        self.recovery_stage_state = RecoveryStageState::Stage3Pending { entered_at: now };
+        self.last_stage3_fired_at = Some(now);
     }
 
     /// Record a crash event. Returns (should_respawn, respawn_delay, should_notify).


### PR DESCRIPTION
## Summary

Phase 2 **terminal stage** of the auto-recovery state machine —
escalation to `HealthState::Paused` + Error-severity telegram when
Stage 1 ESC and Stage 2 auto-restart (cap reached) have both failed
to bring an agent back to `Healthy`.

Built on:
- Sub-task 7a (PR #774) — `HealthState::Paused` variant + guards;
  Stage 1 dispatcher
- Sub-task 7b (PR #775) — Stage 2 auto-restart dispatcher;
  `Stage2Pending → Stage3Eligible` transition

Per decision `d-20260514044213135801-3` (15-point acceptance). Phase 1
discussion: 2 rounds of three-party convergence (lead-claude /
dev-claude / reviewer-opencode); deltas locked on enter_paused setter
(parallel `maybe_decay_at` DI), `NotifySeverity::Error` (enum-grep
evidence — no `Critical`), dev-revised telegram content (cut Backend
+ Stage 1 N1; both unavailable in data flow), hybrid promotion
criteria (trigger-rate-per-week + operator confidence flip),
recovery_restart_count NOT reset on enter_paused.

**Scope statement** (push-time): Stage 3 dispatcher arm + Paused
state writer (`enter_paused` sole grep target) + Error-severity
telegram + env var gate + §RS.10 doc. **Out**: operator unpause
command (separate sub-task per Phase 1 limitation in §RS.10.7).

NOT `Closes #685` — multi-PR initiative; issue stays OPEN until all
sub-tasks land + final closure decision.

## Changes

- `src/health.rs`: `enter_paused(&mut self, now: Instant)` method
  (atomic 3-invariant setter); `last_stage3_fired_at: Option<Instant>`
  field (pub(crate), `#[allow(dead_code)]` until unpause sub-task);
  `RecoveryStageState::Stage3Pending` carries `entered_at: Instant`.
- `src/daemon/per_tick/recovery_dispatcher.rs`: split
  `Stage3Eligible | Stage3Pending` placeholder into two arms;
  `handle_stage3_escalate` + `notify_stage3_escalate` +
  `format_stage3_body` (testable formatter); `STAGE3_ENV_VAR`
  + `stage3_gate_active()` helper; `with_stage3_gate` test helper.
- `docs/RECOVERY-STAGES.md`: new §RS.10 (7 sub-sections); §RS.2
  lifecycle ASCII updated.

### Cross-platform discipline

All new test timestamps use `Instant::add` rather than `Instant::now()
- Duration` per PR #775 v2 lesson — Windows anchors `Instant::now()`
to system uptime via `QueryPerformanceCounter`, low-uptime CI VMs
panic on subtraction. `enter_paused_at` style + `saturating_duration_since`
keeps the tests safe on all platforms.

### Single grep target invariant (§F39.5)

`HealthState::Paused` is now written via a single call site:
`HealthTracker::enter_paused`. The dispatcher's Stage 3 arm is the
only caller. No existing path (record_crash, check_hang,
respawn_ok) writes Paused. Grep `HealthState::Paused.*=` returns this
method body only — operator unpause sub-task will add the second
writer.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test recovery_dispatcher` — 23/23 pass (5 new Stage 3 +
      18 existing 7a/7b)
- [x] `cargo test --bin agend-terminal` — 2151/2151 pass + 7 ignored
      (unchanged from main; replay_manifest_regression preserved)
- [x] `cargo test replay_manifest` — 1/1 pass
- [ ] cross-platform CI green (Windows / Ubuntu / macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)