### PR TITLE
fix(#780): auto-create branch from from_ref in repo checkout bind:true

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -2,6 +2,18 @@ use crate::agent_ops::validate_branch;
 use serde_json::{json, Value};
 use std::path::Path;
 
+/// Daemon-internal git subprocess wrapper that always sets
+/// `AGEND_GIT_BYPASS=1`. Centralizes the bypass-env contract so adding
+/// a new git call to this module cannot silently trip the fleet-managed
+/// `git worktree`/`git branch` shim deny.
+fn git_bypass(cwd: &Path, args: &[&str]) -> std::io::Result<std::process::Output> {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+}
+
 pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
     let source = match args["source"].as_str() {
         Some(s) => s,
@@ -70,6 +82,160 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
     {
         return json!({"error": "source path rejected: system directory"});
     }
+    // #780: auto-create branch from `from_ref` when bind:true + branch
+    // missing locally. Closes the single-step bypass-free workflow gap
+    // surfaced post-#779 (`git worktree add <path> <branch>` without
+    // `-b` rejects missing refs). `bind:false` preserves current
+    // back-compat (no auto-create) per decision
+    // `d-20260514102305998399-0` scope.
+    let mut auto_created_branch = false;
+    let mut fetch_attempted = false;
+    if bind {
+        let from_ref = args["from_ref"].as_str().unwrap_or("origin/main");
+        // Defense in depth: same charset rules as `branch`. Rejects
+        // option-injection (e.g. `--upload-pack=...`) via the leading-`-`
+        // and ".." guards in `validate_branch`.
+        if !validate_branch(from_ref) {
+            return json!({
+                "error": format!("invalid from_ref '{from_ref}'"),
+                "code": "invalid_from_ref",
+                "stage": "validate_from_ref",
+                "fetch_attempted": false,
+            });
+        }
+        let src = Path::new(&source_path);
+        let branch_ref = format!("refs/heads/{branch}");
+        let branch_exists = git_bypass(src, &["rev-parse", "--verify", &branch_ref])
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !branch_exists {
+            // Step 2: try create from `from_ref` (no fetch yet — zero
+            // network on the fast path where origin/main is already
+            // a valid local ref).
+            match git_bypass(src, &["branch", branch, from_ref]) {
+                Ok(o) if o.status.success() => {
+                    auto_created_branch = true;
+                }
+                Ok(o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+                    if stderr.contains("already exists") {
+                        // Race: concurrent caller authored the branch
+                        // between rev-parse and branch. Idempotent
+                        // fall-through — auto_created_branch stays false
+                        // so callers can distinguish "I created it" vs
+                        // "I observed it pre-existing".
+                    } else if stderr.contains("not a valid object name")
+                        || stderr.contains("not a valid ref")
+                    {
+                        tracing::warn!(
+                            target: "ci_handler",
+                            branch = %branch,
+                            from_ref = %from_ref,
+                            "auto-create fallback: from_ref unresolved locally — fetching origin"
+                        );
+                        let fetch_start = std::time::Instant::now();
+                        let fetch_out = git_bypass(src, &["fetch", "origin", "--quiet"]);
+                        fetch_attempted = true;
+                        let fetch_ms = fetch_start.elapsed().as_millis();
+                        crate::event_log::log(
+                            home,
+                            "checkout_auto_create_fetch",
+                            instance_name,
+                            &format!("branch={branch} from_ref={from_ref} duration_ms={fetch_ms}"),
+                        );
+                        match fetch_out {
+                            Ok(fo) if fo.status.success() => {
+                                match git_bypass(src, &["branch", branch, from_ref]) {
+                                    Ok(ro) if ro.status.success() => {
+                                        auto_created_branch = true;
+                                    }
+                                    Ok(ro) => {
+                                        let rstderr =
+                                            String::from_utf8_lossy(&ro.stderr).to_string();
+                                        if rstderr.contains("already exists") {
+                                            // Race after fetch — leave
+                                            // auto_created_branch=false.
+                                        } else {
+                                            tracing::warn!(
+                                                target: "ci_handler",
+                                                branch = %branch,
+                                                from_ref = %from_ref,
+                                                stderr = %rstderr,
+                                                "auto-create retry failed after fetch"
+                                            );
+                                            return json!({
+                                                "error": format!(
+                                                    "from_ref '{from_ref}' invalid (branch creation failed after fetch)"
+                                                ),
+                                                "code": "invalid_from_ref",
+                                                "stage": "retry_create",
+                                                "fetch_attempted": true,
+                                                "raw": rstderr,
+                                            });
+                                        }
+                                    }
+                                    Err(e) => {
+                                        return json!({
+                                            "error": format!("git branch retry spawn failed: {e}"),
+                                            "code": "branch_create_failed",
+                                            "stage": "retry_create",
+                                            "fetch_attempted": true,
+                                            "raw": e.to_string(),
+                                        });
+                                    }
+                                }
+                            }
+                            Ok(fo) => {
+                                let fstderr = String::from_utf8_lossy(&fo.stderr).to_string();
+                                tracing::warn!(
+                                    target: "ci_handler",
+                                    branch = %branch,
+                                    from_ref = %from_ref,
+                                    stderr = %fstderr,
+                                    "auto-create fetch failed"
+                                );
+                                return json!({
+                                    "error": format!(
+                                        "git fetch origin failed (from_ref '{from_ref}' cannot be resolved)"
+                                    ),
+                                    "code": "fetch_failed",
+                                    "stage": "fetch",
+                                    "fetch_attempted": true,
+                                    "raw": fstderr,
+                                });
+                            }
+                            Err(e) => {
+                                return json!({
+                                    "error": format!("git fetch spawn failed: {e}"),
+                                    "code": "fetch_failed",
+                                    "stage": "fetch",
+                                    "fetch_attempted": true,
+                                    "raw": e.to_string(),
+                                });
+                            }
+                        }
+                    } else {
+                        return json!({
+                            "error": format!("git branch failed: {}", stderr.trim()),
+                            "code": "branch_create_failed",
+                            "stage": "create_branch",
+                            "fetch_attempted": false,
+                            "raw": stderr,
+                        });
+                    }
+                }
+                Err(e) => {
+                    return json!({
+                        "error": format!("git branch spawn failed: {e}"),
+                        "code": "branch_create_failed",
+                        "stage": "create_branch",
+                        "fetch_attempted": false,
+                        "raw": e.to_string(),
+                    });
+                }
+            }
+        }
+    }
     // When `bind:true`, omit `--detach` so HEAD lands on the named
     // branch — subsequent commits write to the right ref without the
     // extra `git switch` that triggered the #778 chicken-and-egg.
@@ -79,18 +245,7 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
     } else {
         vec!["worktree", "add", "--detach", &worktree_path_str, branch]
     };
-    match std::process::Command::new("git")
-        .args(&git_args)
-        .current_dir(&source_path)
-        // Daemon-internal git spawn — bypass the shim so a test or agent
-        // invocation of `repo action=checkout` from inside an instance
-        // process (where AGEND_INSTANCE_NAME is set) doesn't trip the
-        // `git worktree` fleet-managed deny. Matches the convention used
-        // by `dispatch_hook::derive_repo_from_remote` and other
-        // daemon-side git callers.
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-    {
+    match git_bypass(Path::new(&source_path), &git_args) {
         Ok(o) if o.status.success() => {
             let mut resp =
                 json!({"path": worktree_path_str, "source": source_path, "branch": branch});
@@ -121,11 +276,38 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
                     );
                 }
                 resp["bound"] = json!(true);
+                resp["auto_created_branch"] = json!(auto_created_branch);
+                resp["fetch_attempted"] = json!(fetch_attempted);
             }
             resp
         }
-        Ok(o) => json!({"error": String::from_utf8_lossy(&o.stderr).to_string()}),
-        Err(e) => json!({"error": format!("{e}")}),
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+            let mut err = json!({
+                "error": format!("git worktree add failed: {}", stderr.trim()),
+                "code": "worktree_add_failed",
+                "stage": "worktree_add",
+                "raw": stderr,
+            });
+            if bind {
+                err["fetch_attempted"] = json!(fetch_attempted);
+                err["auto_created_branch"] = json!(auto_created_branch);
+            }
+            err
+        }
+        Err(e) => {
+            let mut err = json!({
+                "error": format!("git worktree add spawn failed: {e}"),
+                "code": "worktree_add_failed",
+                "stage": "worktree_add",
+                "raw": e.to_string(),
+            });
+            if bind {
+                err["fetch_attempted"] = json!(fetch_attempted);
+                err["auto_created_branch"] = json!(auto_created_branch);
+            }
+            err
+        }
     }
 }
 

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -1009,3 +1009,376 @@ fn checkout_bind_true_auto_creates_branch_from_origin_main_when_missing() {
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&parent).ok();
 }
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_existing_branch_ignores_from_ref() {
+    // Back-compat pin: when the branch already exists in the source
+    // repo, the auto-create path is skipped entirely. `from_ref` is
+    // irrelevant — the caller's value (here a typo `origin/maine`) MUST
+    // NOT cause a fetch or any error. `auto_created_branch=false`
+    // distinguishes "branch existed" from "we authored it" so callers
+    // can audit which branches the handler newly created.
+    let home = p778_tmp_home("780-existing");
+    let parent = p778_tmp_home("780-existing-src");
+    // Use #778's fixture which DOES pre-create the feature branch.
+    let source = p778_setup_source_repo(&parent, "feat/p780-existing");
+    let agent = "p780-agent-existing";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "source": source.display().to_string(),
+            "branch": "feat/p780-existing",
+            "bind": true,
+            // intentional typo — must not be consulted when branch exists.
+            "from_ref": "origin/maine",
+        }),
+        agent,
+    );
+
+    assert!(
+        resp.get("error").is_none(),
+        "existing branch must succeed regardless of from_ref: {resp}"
+    );
+    assert_eq!(
+        resp["auto_created_branch"].as_bool(),
+        Some(false),
+        "auto_created_branch must be false for pre-existing branch: {resp}"
+    );
+    assert_eq!(
+        resp["fetch_attempted"].as_bool(),
+        Some(false),
+        "fetch must NOT fire when branch exists: {resp}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+/// Fixture: source repo whose origin remote points at a file:// URL that
+/// does not exist on disk so `git fetch origin` fails fast (no network
+/// round-trip, no DNS, no hang). Used by tests that exercise the
+/// fetch-failure error surface.
+#[cfg(unix)]
+fn p780_setup_source_broken_origin(parent: &Path) -> std::path::PathBuf {
+    let repo = parent.join("source-repo-broken");
+    std::fs::create_dir_all(&repo).ok();
+    let bypass = ("AGEND_GIT_BYPASS", "1");
+    let _ = std::process::Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(&repo)
+        .env(bypass.0, bypass.1)
+        .output();
+    let _ = std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ])
+        .current_dir(&repo)
+        .env(bypass.0, bypass.1)
+        .output();
+    // file:// URL pointing at a non-existent path — `git fetch origin`
+    // exits non-zero immediately with `fatal: '/...' does not appear to
+    // be a git repository`.
+    let broken_url = format!("file:///tmp/agend-p780-nonexistent-{}", std::process::id());
+    let _ = std::process::Command::new("git")
+        .args(["remote", "add", "origin", &broken_url])
+        .current_dir(&repo)
+        .env(bypass.0, bypass.1)
+        .output();
+    repo
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_invalid_from_ref_returns_structured_error_with_stage() {
+    // Error surface pin: when `from_ref` is unresolvable BOTH locally
+    // and after a fetch, the response must carry the canonical code
+    // enum + stage + fetch_attempted + raw fields per decision
+    // d-20260514102305998399-0. The fixture's broken origin URL
+    // guarantees `git fetch origin` fails fast so the test doesn't hit
+    // the network.
+    let home = p778_tmp_home("780-bad-ref");
+    let parent = p778_tmp_home("780-bad-ref-src");
+    let source = p780_setup_source_broken_origin(&parent);
+    let agent = "p780-agent-bad-ref";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "source": source.display().to_string(),
+            "branch": "feat/p780-bad",
+            "bind": true,
+            // Unresolvable: this remote ref does not exist locally and
+            // the broken origin URL prevents fetch from populating it.
+            "from_ref": "origin/totally-bogus-ref-name",
+        }),
+        agent,
+    );
+
+    assert!(
+        resp.get("error").is_some(),
+        "unresolvable from_ref must error: {resp}"
+    );
+    // Stage must be one of the auto-create pipeline stages — either
+    // `fetch` (fetch itself failed) or `retry_create` (fetch succeeded
+    // but ref still missing). Both are valid endpoints; the broken
+    // origin URL deterministically lands on `fetch` for this fixture.
+    let stage = resp["stage"].as_str().unwrap_or_default();
+    assert!(
+        stage == "fetch" || stage == "retry_create",
+        "stage must be fetch or retry_create, got: {resp}"
+    );
+    let code = resp["code"].as_str().unwrap_or_default();
+    assert!(
+        code == "fetch_failed" || code == "invalid_from_ref",
+        "code must be fetch_failed or invalid_from_ref, got: {resp}"
+    );
+    assert_eq!(
+        resp["fetch_attempted"].as_bool(),
+        Some(true),
+        "fetch_attempted must be true after fallback path entered: {resp}"
+    );
+    assert!(
+        resp["raw"].as_str().is_some() && !resp["raw"].as_str().unwrap().is_empty(),
+        "raw stderr must be surfaced for debug: {resp}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_concurrent_branch_create_race_idempotent() {
+    // Race semantic pin: two concurrent callers on the SAME source repo
+    // + SAME branch must not both error out at the `git branch` stage.
+    // The winner sees `auto_created_branch=true`. The loser hits the
+    // `already exists` stderr and falls through idempotently to the
+    // worktree-add stage — where it will fail with
+    // `code=worktree_add_failed` (different `instance_name` → different
+    // worktree path, but same branch ref → git refuses second
+    // checkout). The fall-through invariant we pin: NEITHER caller
+    // returns `code=branch_create_failed`. Barrier(2) makes the race
+    // deterministic without timing-dependent sleeps.
+    let home = p778_tmp_home("780-race");
+    let parent = p778_tmp_home("780-race-src");
+    let source = p780_setup_source_no_feature_branch(&parent);
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let mut handles = Vec::new();
+    for i in 0..2 {
+        let barrier = std::sync::Arc::clone(&barrier);
+        let home_c = home.clone();
+        let source_c = source.clone();
+        // fire-and-forget: test-only race harness; JoinHandle stored
+        // in `handles` and explicitly joined below — not a long-lived
+        // spawn site requiring supervisor wiring.
+        handles.push(std::thread::spawn(move || {
+            let agent = format!("p780-agent-race-{i}");
+            barrier.wait();
+            super::handle_checkout_repo(
+                &home_c,
+                &serde_json::json!({
+                    "source": source_c.display().to_string(),
+                    "branch": "feat/p780-race",
+                    "bind": true,
+                }),
+                &agent,
+            )
+        }));
+    }
+    let results: Vec<serde_json::Value> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // Neither caller may surface `branch_create_failed` — the race must
+    // be absorbed by the idempotent `already exists` fall-through.
+    for r in &results {
+        let code = r["code"].as_str().unwrap_or_default();
+        assert_ne!(
+            code, "branch_create_failed",
+            "race must fall through, never error at branch create: {r}"
+        );
+    }
+    // Exactly one winner observed auto_created_branch=true. The other
+    // either fell through to a successful worktree add (rare — same
+    // branch on same repo blocks second worktree) or failed at
+    // worktree_add stage with auto_created_branch absent (error path).
+    let winners = results
+        .iter()
+        .filter(|r| r["auto_created_branch"].as_bool() == Some(true))
+        .count();
+    assert_eq!(
+        winners, 1,
+        "exactly one caller must author the branch: {results:?}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_stress_50_iter_branch_create_no_flaky_parse() {
+    // Stress pin: 50 sequential fresh-repo iterations exercising the
+    // auto-create path. Catches:
+    //   1. Flaky stderr-matching from git version / locale variation
+    //      (we match on substring "not a valid object name" /
+    //      "already exists" — if a future git rewords these the test
+    //      surfaces the parse drift here, not in production).
+    //   2. Resource / fd leaks from repeated subprocess spawns.
+    //   3. Timing-dependent ordering issues in
+    //      rev-parse → branch → worktree-add.
+    // Each iter rebuilds the source repo from scratch, so the auto-
+    // create path is deterministically exercised. Runtime expectation:
+    // ~50ms × 50 ≈ 2.5s on a typical dev machine.
+    let parent = p778_tmp_home("780-stress-src");
+    for i in 0..50 {
+        let home = p778_tmp_home(&format!("780-stress-{i}"));
+        let source = p780_setup_source_no_feature_branch(&parent.join(format!("iter-{i}")));
+        let agent = format!("p780-agent-stress-{i}");
+
+        let resp = super::handle_checkout_repo(
+            &home,
+            &serde_json::json!({
+                "source": source.display().to_string(),
+                "branch": format!("feat/p780-stress-{i}"),
+                "bind": true,
+            }),
+            &agent,
+        );
+
+        assert!(
+            resp.get("error").is_none(),
+            "iter {i}: auto-create must succeed every time, got: {resp}"
+        );
+        assert_eq!(
+            resp["auto_created_branch"].as_bool(),
+            Some(true),
+            "iter {i}: every iter creates a fresh branch: {resp}"
+        );
+        assert_eq!(
+            resp["fetch_attempted"].as_bool(),
+            Some(false),
+            "iter {i}: fixture has origin/main locally — no fetch should fire: {resp}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_auto_create_path_preserves_779_tail_ops() {
+    // Regression guard: when the auto-create path entered, ALL of
+    // #779's tail-ops (marker write, binding.json, ci_watches arming)
+    // must still fire. This is the property
+    // `checkout_bind_true_writes_binding_marker_and_arms_watch` pinned
+    // for the pre-existing-branch case; #780 introduces a new code path
+    // that easily regresses tail-ops if the auto-create logic
+    // accidentally short-circuits the post-worktree-add block.
+    let home = p778_tmp_home("780-tail");
+    let parent = p778_tmp_home("780-tail-src");
+    let source = p780_setup_source_no_feature_branch(&parent);
+    let agent = "p780-agent-tail";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "source": source.display().to_string(),
+            "branch": "feat/p780-tail",
+            "bind": true,
+        }),
+        agent,
+    );
+
+    assert!(resp.get("error").is_none(), "checkout must succeed: {resp}");
+    assert_eq!(resp["auto_created_branch"].as_bool(), Some(true));
+
+    let wt_path = std::path::PathBuf::from(resp["path"].as_str().expect("path"));
+    assert!(
+        wt_path.join(crate::worktree_pool::MANAGED_MARKER).exists(),
+        ".agend-managed marker must be written on auto-create path"
+    );
+
+    let binding = crate::paths::runtime_dir(&home)
+        .join(agent)
+        .join("binding.json");
+    assert!(
+        binding.exists(),
+        "binding.json must be written on auto-create path"
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&binding).unwrap()).unwrap();
+    assert_eq!(v["branch"].as_str(), Some("feat/p780-tail"));
+    assert_eq!(v["task_id"].as_str(), Some("self"));
+
+    // ci_watch arming uses derive_repo_from_remote_pub on origin URL —
+    // the fixture's `https://github.com/owner/repo.git` resolves to
+    // `owner/repo`.
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/p780-tail"),
+    );
+    assert!(
+        watch_path.exists(),
+        "watch_ci must be armed on auto-create path"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_false_does_not_auto_create() {
+    // Scope invariant pin: #780 auto-create is gated on `bind:true`.
+    // The `bind:false` review-pool / operator-triage path must NOT
+    // auto-create a missing branch — preserves the existing
+    // fail-loud-on-missing-ref semantics for inspection-only callers.
+    let home = p778_tmp_home("780-bind-false");
+    let parent = p778_tmp_home("780-bind-false-src");
+    let source = p780_setup_source_no_feature_branch(&parent);
+    let agent = "p780-agent-bind-false";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "source": source.display().to_string(),
+            "branch": "feat/p780-bind-false",
+            // bind defaulting to false — explicit for test clarity.
+            "bind": false,
+        }),
+        agent,
+    );
+
+    assert!(
+        resp.get("error").is_some(),
+        "bind:false missing branch must surface error (no auto-create): {resp}"
+    );
+    // No auto-create response fields on the bind:false path.
+    assert!(
+        resp.get("auto_created_branch").is_none(),
+        "bind:false must NOT expose auto_created_branch: {resp}"
+    );
+    // Confirm the branch was NOT actually created in the source repo.
+    let probe = std::process::Command::new("git")
+        .args(["rev-parse", "--verify", "refs/heads/feat/p780-bind-false"])
+        .current_dir(&source)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git rev-parse");
+    assert!(
+        !probe.status.success(),
+        "bind:false must not write any ref into source repo"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -862,3 +862,150 @@ fn checkout_bind_true_rejects_anonymous_caller() {
 
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ----------------------------------------------------------------------
+// #780 `from_ref` auto-create branch — lazy fetch-on-missing-ref. Closes
+// the single-step bypass-free workflow gap discovered post-#779: when
+// caller wants `bind:true` on a brand-new branch, `git worktree add
+// <path> <branch>` (no `-b`) fails with `fatal: invalid reference`. The
+// new design auto-creates `<branch>` from `from_ref` (default
+// `origin/main`) inside `handle_checkout_repo` so no manual `git fetch
+// && git branch` pre-step is required.
+//
+// Source of truth: decision d-20260514102305998399-0
+//
+// Empirical anchor (per §3.10): comment out the new auto-create block in
+// `handle_checkout_repo` → the first test below
+// (`checkout_bind_true_auto_creates_branch_from_origin_main_when_missing`)
+// fails because the worktree add hits `fatal: invalid reference`.
+//
+// All happy-path tests are `#[cfg(unix)]` (matching #778 fixture
+// convention — Windows subprocess concurrency unstable in CI). Cross-
+// platform stance is `unverified cross-backend claim` per §3.7; Windows
+// CI smoke test tracked separately (Backlog C).
+// ----------------------------------------------------------------------
+
+/// Fixture: like `p778_setup_source_repo` but does NOT pre-create the
+/// feature branch — that is the precondition that exercises the new
+/// auto-create path. `refs/remotes/origin/main` is populated via
+/// `git update-ref` so the default `from_ref="origin/main"` resolves
+/// without a network fetch (fixture simulates a previously-fetched
+/// canonical clone).
+#[cfg(unix)]
+fn p780_setup_source_no_feature_branch(parent: &Path) -> std::path::PathBuf {
+    let repo = parent.join("source-repo");
+    std::fs::create_dir_all(&repo).ok();
+    let bypass = ("AGEND_GIT_BYPASS", "1");
+    let _ = std::process::Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(&repo)
+        .env(bypass.0, bypass.1)
+        .output();
+    let _ = std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ])
+        .current_dir(&repo)
+        .env(bypass.0, bypass.1)
+        .output();
+    let _ = std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ])
+        .current_dir(&repo)
+        .env(bypass.0, bypass.1)
+        .output();
+    // Simulate fetched remote-tracking ref so `origin/main` resolves
+    // locally without a network round-trip.
+    let main_sha = std::process::Command::new("git")
+        .args(["rev-parse", "main"])
+        .current_dir(&repo)
+        .env(bypass.0, bypass.1)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .expect("rev-parse main");
+    let _ = std::process::Command::new("git")
+        .args(["update-ref", "refs/remotes/origin/main", &main_sha])
+        .current_dir(&repo)
+        .env(bypass.0, bypass.1)
+        .output();
+    repo
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_auto_creates_branch_from_origin_main_when_missing() {
+    // ANCHOR (red→green). Pre-impl: `git worktree add <path> feat/p780-new`
+    // fails because the branch does not exist locally. Post-impl: handler
+    // auto-creates the branch from `from_ref` (default `origin/main`)
+    // before the worktree add, observable via `auto_created_branch=true`
+    // and `fetch_attempted=false` (simulated origin/main was already
+    // present locally — no fetch needed).
+    let home = p778_tmp_home("780-auto");
+    let parent = p778_tmp_home("780-auto-src");
+    let source = p780_setup_source_no_feature_branch(&parent);
+    let agent = "p780-agent-auto";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "source": source.display().to_string(),
+            "branch": "feat/p780-new",
+            "bind": true,
+        }),
+        agent,
+    );
+
+    assert!(
+        resp.get("error").is_none(),
+        "auto-create must succeed when branch missing + origin/main present: {resp}"
+    );
+    assert_eq!(
+        resp["bound"].as_bool(),
+        Some(true),
+        "bind=true must surface: {resp}"
+    );
+    assert_eq!(
+        resp["auto_created_branch"].as_bool(),
+        Some(true),
+        "auto_created_branch must signal the new-branch path: {resp}"
+    );
+    assert_eq!(
+        resp["fetch_attempted"].as_bool(),
+        Some(false),
+        "fetch must NOT fire when origin/main is already a valid local ref: {resp}"
+    );
+
+    // HEAD must land on the named branch (not detached) so subsequent
+    // commits write to the right ref. Same invariant as #778's
+    // checkout_bind_true_writes_binding_marker_and_arms_watch.
+    let wt_path = std::path::PathBuf::from(resp["path"].as_str().expect("path"));
+    let head_ref = std::fs::read_to_string(wt_path.join(".git"))
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find_map(|l| l.strip_prefix("gitdir:").map(str::trim))
+                .map(std::path::PathBuf::from)
+        })
+        .and_then(|d| std::fs::read_to_string(d.join("HEAD")).ok())
+        .unwrap_or_default();
+    assert!(
+        head_ref.starts_with("ref: refs/heads/feat/p780-new"),
+        "HEAD must be on refs/heads/feat/p780-new, got: {head_ref:?}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}


### PR DESCRIPTION
## Summary

Closes #780. Closes the bypass-free single-step workflow gap surfaced post-#779: caller had to manually `git fetch origin && git branch <name> origin/main` on canonical before `repo action=checkout bind:true` because `git worktree add <path> <branch>` (no `-b`) rejects missing refs with `fatal: invalid reference`.

scope follows dispatch spec d-20260514102305998399-0

- New arg `from_ref: Option<&str>` (default `"origin/main"`) — minimal API surface, lazy fetch-on-missing-ref fallback (zero network on fast path)
- Helper extraction `git_bypass(cwd, &args)` centralizes the `AGEND_GIT_BYPASS=1` contract
- Structured response: success adds `auto_created_branch` + `fetch_attempted`; error gets canonical `code`/`stage`/`raw` enum
- Scope: `bind:true` only — `bind:false` back-compat preserved (no auto-create, omits new fields)

## §3.10 Test-first verification

- Test-first commit (red): `918864f` — `test(#780): anchor for bind:true auto-create branch from origin/main`
- Impl commit (green): `af91c61` — `fix(#780): auto-create branch from from_ref in repo checkout bind:true`

Reviewer verify:
```
git checkout 918864f && cargo test --features tray --bin agend-terminal checkout_bind_true_auto_creates
# expect: FAILED ("fatal: invalid reference: feat/p780-new")
git checkout af91c61 && cargo test --features tray --bin agend-terminal checkout_bind_true_auto_creates
# expect: ok. 1 passed
```

Note: 12 empty auto-commits between the anchor and impl SHAs are daemon-generated heartbeat markers (`Agend-Agent: fixup-dev`, no file changes) — they do not affect the §3.10 verify flow since `git diff 918864f..9cc7faa` is empty.

## Tests (7, all `#[cfg(unix)]`)

1. `checkout_bind_true_auto_creates_branch_from_origin_main_when_missing` — anchor (red→green)
2. `checkout_bind_true_existing_branch_ignores_from_ref` — back-compat pin
3. `checkout_bind_true_invalid_from_ref_returns_structured_error_with_stage` — code/stage/fetch_attempted assertion
4. `checkout_bind_true_concurrent_branch_create_race_idempotent` — `std::sync::Barrier(2)` deterministic
5. `checkout_bind_true_stress_50_iter_branch_create_no_flaky_parse` — stress 50 iter, inline run (no ignore)
6. `checkout_bind_true_auto_create_path_preserves_779_tail_ops` — marker + binding.json + ci_watch arm regression guard
7. `checkout_bind_false_does_not_auto_create` — bind:false scope invariant

## Cross-platform stance

`unverified cross-backend claim` for Windows (§3.7). Happy-path tests are `#[cfg(unix)]` matching #778 fixture convention — Windows CI runner's git-subprocess concurrency observed unstable. **Backlog C** tracks Windows CI smoke test (not blocking #780 ship).

## Known limitation: fetch subprocess timeout

`git fetch origin --quiet` in the lazy fallback has no timeout — Rust std `Command` lacks native timeout support. On slow networks this path may block until the OS / git default times out. **Backlog B** tracks systemic audit covering this site + `worktree_pool::cleanup_merged_branch` + other daemon-internal fetches.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite green
- [x] §3.10 test-first verify (anchor SHA fails, impl SHA passes)
- [x] All 7 new tests pass + existing 4 checkout_bind tests pass (11 total)
- [x] ZERO BYPASS workflow — branch created via canonical `git fetch + git branch`, worktree provisioned via `repo action=checkout bind:true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)