### PR TITLE
fix(#781): task claim auto-bind canonical source_repo — Bug A0/A1/A2/B + helper extraction

### DIFF
--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -1215,12 +1215,43 @@ pub fn migrate_teams_json_to_yaml(home: &Path) -> Result<()> {
             orchestrator: team.orchestrator.clone(),
             description: team.description.clone(),
             created_at: team.created_at.clone(),
+            // Legacy `teams.json` schema (pre-Sprint-54) has no
+            // `source_repo` field — migration physically cannot carry
+            // over what doesn't exist. Hard-coded None is the only
+            // option; downstream operator UX (#781 Piece 1a-i / 1a-ii
+            // warn below + Bug A1 Team projection surfacing the field)
+            // makes the resulting `None` state visible so the operator
+            // knows to run `team update source_repo=...` instead of
+            // silently falling to Tier 4 stub at dispatch time.
             source_repo: None,
         };
         // add_team_to_yaml is no-op when team already in fleet.yaml —
         // operator hand-edits win, runtime store loses on conflict.
         match add_team_to_yaml(home, &team.name, &cfg) {
-            Ok(true) => tracing::info!(name = %team.name, "migrated team to fleet.yaml"),
+            Ok(true) => {
+                tracing::info!(name = %team.name, "migrated team to fleet.yaml");
+                // #781 Piece 1a-i — operator-facing warn so the
+                // legacy-migration source_repo=None state surfaces in
+                // daemon logs at startup time, not at first failed
+                // dispatch.
+                tracing::warn!(
+                    name = %team.name,
+                    "migrated team from legacy teams.json without source_repo — \
+                     set via `team(action=update, name={}, source_repo=...)` or \
+                     daemon will fall to working_directory/stub Tier 3/4 in dispatch_auto_bind_lease",
+                    team.name
+                );
+                // #781 Piece 1a-ii — event_log persists the warning
+                // for post-mortem visibility; tracing logs rotate /
+                // tail-only by default and operators may miss them.
+                crate::event_log::log(
+                    home,
+                    "team_migration_missing_source_repo",
+                    &team.name,
+                    "legacy teams.json schema had no source_repo; \
+                     set via team(action=update) to avoid Tier 4 stub fallback",
+                );
+            }
             Ok(false) => tracing::info!(name = %team.name,
                 "team already in fleet.yaml, skipping migration entry"),
             Err(e) => {

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -2,6 +2,23 @@
 
 use std::path::Path;
 
+/// #781 Piece 6 — daemon-internal `git` subprocess wrapper that always
+/// sets `AGEND_GIT_BYPASS=1`. Centralizes the bypass-env contract so
+/// adding a new git call cannot silently trip the fleet-managed
+/// `git worktree` / `git branch` shim deny.
+///
+/// Originated in #780 as a private `fn` inside `mcp::handlers::ci::mod`.
+/// Promoted to `pub(crate)` in `git_helpers` for #781 so both
+/// `handle_checkout_repo` and `dispatch_auto_bind_lease`'s
+/// `ensure_branch_exists` extraction share a single bypass-env helper.
+pub(crate) fn git_bypass(cwd: &Path, args: &[&str]) -> std::io::Result<std::process::Output> {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+}
+
 /// Detect the default branch of a repository.
 /// Reads `refs/remotes/origin/HEAD` → extracts branch name.
 /// Falls back to "main" if detection fails.

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -1,18 +1,7 @@
 use crate::agent_ops::validate_branch;
+use crate::git_helpers::git_bypass;
 use serde_json::{json, Value};
 use std::path::Path;
-
-/// Daemon-internal git subprocess wrapper that always sets
-/// `AGEND_GIT_BYPASS=1`. Centralizes the bypass-env contract so adding
-/// a new git call to this module cannot silently trip the fleet-managed
-/// `git worktree`/`git branch` shim deny.
-fn git_bypass(cwd: &Path, args: &[&str]) -> std::io::Result<std::process::Output> {
-    std::process::Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-}
 
 pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
     let source = match args["source"].as_str() {
@@ -83,156 +72,39 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
         return json!({"error": "source path rejected: system directory"});
     }
     // #780: auto-create branch from `from_ref` when bind:true + branch
-    // missing locally. Closes the single-step bypass-free workflow gap
-    // surfaced post-#779 (`git worktree add <path> <branch>` without
-    // `-b` rejects missing refs). `bind:false` preserves current
-    // back-compat (no auto-create) per decision
+    // missing locally. #781 Piece 6 extracts the decision tree into
+    // `dispatch_hook::ensure_branch_exists` so the same logic services
+    // both this MCP-tool entry and the `send kind=task` dispatch hook
+    // (single source of truth, no #780-vs-#781 logic drift). `bind:false`
+    // preserves current back-compat (no auto-create) per decision
     // `d-20260514102305998399-0` scope.
     let mut auto_created_branch = false;
     let mut fetch_attempted = false;
     if bind {
         let from_ref = args["from_ref"].as_str().unwrap_or("origin/main");
-        // Defense in depth: same charset rules as `branch`. Rejects
-        // option-injection (e.g. `--upload-pack=...`) via the leading-`-`
-        // and ".." guards in `validate_branch`.
-        if !validate_branch(from_ref) {
-            return json!({
-                "error": format!("invalid from_ref '{from_ref}'"),
-                "code": "invalid_from_ref",
-                "stage": "validate_from_ref",
-                "fetch_attempted": false,
-            });
-        }
         let src = Path::new(&source_path);
-        let branch_ref = format!("refs/heads/{branch}");
-        let branch_exists = git_bypass(src, &["rev-parse", "--verify", &branch_ref])
-            .map(|o| o.status.success())
-            .unwrap_or(false);
-        if !branch_exists {
-            // Step 2: try create from `from_ref` (no fetch yet — zero
-            // network on the fast path where origin/main is already
-            // a valid local ref).
-            match git_bypass(src, &["branch", branch, from_ref]) {
-                Ok(o) if o.status.success() => {
-                    auto_created_branch = true;
+        match crate::mcp::handlers::dispatch_hook::ensure_branch_exists(
+            home,
+            src,
+            branch,
+            from_ref,
+            instance_name,
+        ) {
+            Ok((created, fetched)) => {
+                auto_created_branch = created;
+                fetch_attempted = fetched;
+            }
+            Err(err) => {
+                let mut e = json!({
+                    "error": err.message,
+                    "code": serde_json::to_value(err.code).unwrap_or(json!("unknown")),
+                    "stage": serde_json::to_value(err.stage).unwrap_or(json!("unknown")),
+                    "fetch_attempted": err.fetch_attempted,
+                });
+                if let Some(raw) = err.raw {
+                    e["raw"] = json!(raw);
                 }
-                Ok(o) => {
-                    let stderr = String::from_utf8_lossy(&o.stderr).to_string();
-                    if stderr.contains("already exists") {
-                        // Race: concurrent caller authored the branch
-                        // between rev-parse and branch. Idempotent
-                        // fall-through — auto_created_branch stays false
-                        // so callers can distinguish "I created it" vs
-                        // "I observed it pre-existing".
-                    } else if stderr.contains("not a valid object name")
-                        || stderr.contains("not a valid ref")
-                    {
-                        tracing::warn!(
-                            target: "ci_handler",
-                            branch = %branch,
-                            from_ref = %from_ref,
-                            "auto-create fallback: from_ref unresolved locally — fetching origin"
-                        );
-                        let fetch_start = std::time::Instant::now();
-                        let fetch_out = git_bypass(src, &["fetch", "origin", "--quiet"]);
-                        fetch_attempted = true;
-                        let fetch_ms = fetch_start.elapsed().as_millis();
-                        crate::event_log::log(
-                            home,
-                            "checkout_auto_create_fetch",
-                            instance_name,
-                            &format!("branch={branch} from_ref={from_ref} duration_ms={fetch_ms}"),
-                        );
-                        match fetch_out {
-                            Ok(fo) if fo.status.success() => {
-                                match git_bypass(src, &["branch", branch, from_ref]) {
-                                    Ok(ro) if ro.status.success() => {
-                                        auto_created_branch = true;
-                                    }
-                                    Ok(ro) => {
-                                        let rstderr =
-                                            String::from_utf8_lossy(&ro.stderr).to_string();
-                                        if rstderr.contains("already exists") {
-                                            // Race after fetch — leave
-                                            // auto_created_branch=false.
-                                        } else {
-                                            tracing::warn!(
-                                                target: "ci_handler",
-                                                branch = %branch,
-                                                from_ref = %from_ref,
-                                                stderr = %rstderr,
-                                                "auto-create retry failed after fetch"
-                                            );
-                                            return json!({
-                                                "error": format!(
-                                                    "from_ref '{from_ref}' invalid (branch creation failed after fetch)"
-                                                ),
-                                                "code": "invalid_from_ref",
-                                                "stage": "retry_create",
-                                                "fetch_attempted": true,
-                                                "raw": rstderr,
-                                            });
-                                        }
-                                    }
-                                    Err(e) => {
-                                        return json!({
-                                            "error": format!("git branch retry spawn failed: {e}"),
-                                            "code": "branch_create_failed",
-                                            "stage": "retry_create",
-                                            "fetch_attempted": true,
-                                            "raw": e.to_string(),
-                                        });
-                                    }
-                                }
-                            }
-                            Ok(fo) => {
-                                let fstderr = String::from_utf8_lossy(&fo.stderr).to_string();
-                                tracing::warn!(
-                                    target: "ci_handler",
-                                    branch = %branch,
-                                    from_ref = %from_ref,
-                                    stderr = %fstderr,
-                                    "auto-create fetch failed"
-                                );
-                                return json!({
-                                    "error": format!(
-                                        "git fetch origin failed (from_ref '{from_ref}' cannot be resolved)"
-                                    ),
-                                    "code": "fetch_failed",
-                                    "stage": "fetch",
-                                    "fetch_attempted": true,
-                                    "raw": fstderr,
-                                });
-                            }
-                            Err(e) => {
-                                return json!({
-                                    "error": format!("git fetch spawn failed: {e}"),
-                                    "code": "fetch_failed",
-                                    "stage": "fetch",
-                                    "fetch_attempted": true,
-                                    "raw": e.to_string(),
-                                });
-                            }
-                        }
-                    } else {
-                        return json!({
-                            "error": format!("git branch failed: {}", stderr.trim()),
-                            "code": "branch_create_failed",
-                            "stage": "create_branch",
-                            "fetch_attempted": false,
-                            "raw": stderr,
-                        });
-                    }
-                }
-                Err(e) => {
-                    return json!({
-                        "error": format!("git branch spawn failed: {e}"),
-                        "code": "branch_create_failed",
-                        "stage": "create_branch",
-                        "fetch_attempted": false,
-                        "raw": e.to_string(),
-                    });
-                }
+                return e;
             }
         }
     }

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -62,12 +62,6 @@ impl std::error::Error for DispatchError {}
 /// Which tier of [`resolve_source_repo`] fired. Observable via
 /// [`DispatchOutcome::source_repo_tier`] so callers can audit
 /// configuration completeness without parsing logs.
-///
-/// Variants `Override`/`FleetSourceRepo`/`TeamSourceRepo`/`WorkingDirectory`
-/// are wired in C4 once `resolve_source_repo` reports tier. C2 only
-/// constructs `Stub` (placeholder); `allow(dead_code)` on unused variants
-/// until C4 removes the attribute.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceRepoTier {
@@ -88,11 +82,6 @@ pub enum SourceRepoTier {
 
 /// Pipeline stage that produced a [`DispatchError`]. Coarse enough to
 /// remain stable across refactors, fine enough to debug.
-///
-/// Variants `ValidateFromRef`/`CreateBranch`/`Fetch`/`RetryCreate` are
-/// constructed in C4 once `ensure_branch_exists` runs at the dispatch
-/// layer. `allow(dead_code)` on unused variants until C4.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Stage {
@@ -112,11 +101,6 @@ pub enum Stage {
 
 /// Canonical `code` enum — stable across releases. Callers MUST match
 /// on this rather than parsing `message` substrings.
-///
-/// Variants `InvalidFromRef`/`BranchCreateFailed`/`FetchFailed` are
-/// constructed in C4 once `ensure_branch_exists` runs. `allow(dead_code)`
-/// on unused variants until C4.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorCode {
@@ -250,7 +234,8 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
     let resolved = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
         .ok()
         .and_then(|f| f.resolve_instance(target));
-    let source_repo = resolve_source_repo(home, target, source_repo_override, resolved.as_ref());
+    let (source_repo, source_repo_tier) =
+        resolve_source_repo(home, target, source_repo_override, resolved.as_ref());
 
     // P0-1.5: central lease registry check — reject if another agent holds this branch.
     if let Some(other) = crate::binding::scan_existing_branch_binding(home, branch, target) {
@@ -294,6 +279,47 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
         }
     }
 
+    // #781 Piece 6: ensure branch exists in `source_repo` BEFORE the
+    // lease attempt. Centralizing branch provisioning at the dispatch
+    // layer surfaces auto-create observability (DispatchOutcome's
+    // auto_created_branch / fetch_attempted) and shares one decision
+    // tree with `repo action=checkout bind:true` (the #784 entry).
+    //
+    // `from_ref` is hard-coded to `"origin/main"` (mirror #784 default).
+    //
+    // Fail-soft contract: errors from `ensure_branch_exists` fall through
+    // to `worktree_pool::lease` → `worktree::create -b` (which creates
+    // the branch from current HEAD). This preserves pre-#781 behavior
+    // for legacy callers / test fixtures where `source_repo` is a local
+    // repo with no `origin` remote (so the `git branch X origin/main` +
+    // fetch fallback paths both fail). Production canonicals have
+    // `origin/main` populated and hit the fast path. Validate-side
+    // failures (`InvalidFromRef`, e.g. option injection) DO surface as
+    // hard errors so a malicious caller can't slip past the boundary
+    // by triggering soft-fallback.
+    let (auto_created_branch, fetch_attempted) =
+        match ensure_branch_exists(home, &source_repo, branch, "origin/main", target) {
+            Ok(tup) => tup,
+            Err(err)
+                if err.code == ErrorCode::InvalidFromRef && err.stage == Stage::ValidateFromRef =>
+            {
+                return Err(err);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "dispatch_hook",
+                    %target,
+                    %branch,
+                    code = ?err.code,
+                    stage = ?err.stage,
+                    message = %err.message,
+                    "ensure_branch_exists soft-fallback: legacy / origin-less source_repo \
+                     — falling through to worktree::create -b path"
+                );
+                (false, err.fetch_attempted)
+            }
+        };
+
     // Attempt lease (creates worktree + tags as daemon-managed).
     // Lease errors REJECT the dispatch (Q2 + §3.3).
     let lease = crate::worktree_pool::lease(home, &source_repo, target, branch).map_err(|msg| {
@@ -306,7 +332,7 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
             message: msg.clone(),
             code,
             stage: Stage::WorktreeLeaseConflict,
-            fetch_attempted: false,
+            fetch_attempted,
             raw: Some(msg),
         }
     })?;
@@ -344,15 +370,10 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
         tracing::info!(%target, repo = %r, %branch, "dispatch auto-watch_ci");
     }
 
-    // C2 placeholder: `source_repo_tier` / `auto_created_branch` /
-    // `fetch_attempted` are wired to real observability sources in C4 once
-    // `resolve_source_repo` reports tier + `ensure_branch_exists` reports
-    // create/fetch outcomes. Placeholder values are safe defaults — no
-    // existing caller inspects these fields pre-C4.
     Ok(DispatchOutcome {
-        source_repo_tier: SourceRepoTier::Stub,
-        auto_created_branch: false,
-        fetch_attempted: false,
+        source_repo_tier,
+        auto_created_branch,
+        fetch_attempted,
     })
 }
 
@@ -361,32 +382,37 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
 /// `working_directory` → `home/workspace/<agent>` stub. INFO logs which
 /// tier was hit; WARN when the stub fallback (tier 4) fires; optional
 /// `AGEND_BIND_STRICT_MODE=1` env flag rejects tier 4 in production.
+///
+/// #781 Piece 6: returns the resolved path AND the [`SourceRepoTier`]
+/// that fired so callers (`dispatch_auto_bind_lease_with_source`) can
+/// surface tier via [`DispatchOutcome::source_repo_tier`] — operator
+/// audits configuration completeness without parsing logs.
 fn resolve_source_repo(
     home: &Path,
     target: &str,
     override_path: Option<&Path>,
     resolved: Option<&crate::fleet::ResolvedInstance>,
-) -> PathBuf {
+) -> (PathBuf, SourceRepoTier) {
     if let Some(p) = override_path {
         tracing::info!(%target, tier = "override", path = %p.display(),
             "source_repo resolved via explicit caller override (tier 1)");
-        return p.to_path_buf();
+        return (p.to_path_buf(), SourceRepoTier::Override);
     }
     if let Some(p) = resolved.and_then(|r| r.source_repo.clone()) {
         tracing::info!(%target, tier = "fleet_source_repo", path = %p.display(),
             "source_repo resolved via fleet.yaml source_repo (tier 2)");
-        return p;
+        return (p, SourceRepoTier::FleetSourceRepo);
     }
     // Tier 2.5: team source_repo
     if let Some(p) = resolve_team_source_repo(home, target) {
         tracing::info!(%target, tier = "team_source_repo", path = %p.display(),
             "source_repo resolved via team source_repo (tier 2.5)");
-        return p;
+        return (p, SourceRepoTier::TeamSourceRepo);
     }
     if let Some(p) = resolved.and_then(|r| r.working_directory.clone()) {
         tracing::info!(%target, tier = "working_directory", path = %p.display(),
             "source_repo resolved via fleet.yaml working_directory (tier 3, deprecation candidate)");
-        return p;
+        return (p, SourceRepoTier::WorkingDirectory);
     }
     let stub = crate::paths::workspace_dir(home).join(target);
     tracing::warn!(%target, tier = "stub", path = %stub.display(),
@@ -394,17 +420,214 @@ fn resolve_source_repo(
     if std::env::var("AGEND_BIND_STRICT_MODE").as_deref() == Ok("1") {
         tracing::error!(%target, "AGEND_BIND_STRICT_MODE=1: stub fallback rejected");
     }
-    stub
+    (stub, SourceRepoTier::Stub)
+}
+
+/// #781 Piece 6: shared auto-create-branch helper. Encapsulates the
+/// decision tree previously inlined in
+/// `mcp::handlers::ci::handle_checkout_repo` (introduced in #780). Both
+/// the `repo action=checkout bind:true` MCP tool entry and
+/// `dispatch_auto_bind_lease` now route through this single helper so
+/// the fast path (zero network on missing-branch-with-local-origin/main)
+/// and the lazy fetch fallback live in one place.
+///
+/// Behavior (mirror #784 / decision d-20260514102305998399-0):
+/// 1. `rev-parse --verify refs/heads/<branch>` — if exists, return
+///    `(auto_created=false, fetch_attempted=false)`.
+/// 2. Else `git branch <branch> <from_ref>`:
+///    - success → `(true, false)`
+///    - stderr `"already exists"` (concurrent race) → `(false, false)`
+///    - stderr `"not a valid object name"` / `"not a valid ref"` →
+///      `git fetch origin --quiet` then retry; success → `(true, true)`;
+///      retry race "already exists" → `(false, true)`; otherwise
+///      structured error.
+///
+/// `from_ref` runs through `validate_branch` (defense in depth) to
+/// reject option-injection (`--upload-pack=...`) at the daemon API
+/// boundary — same rule applied to the user-supplied `branch` arg.
+///
+/// `actor` is the agent / instance name used as `event_log` identifier
+/// for the fetch-duration breadcrumb (helps post-mortem who triggered
+/// the network I/O).
+pub(crate) fn ensure_branch_exists(
+    home: &Path,
+    source: &Path,
+    branch: &str,
+    from_ref: &str,
+    actor: &str,
+) -> Result<(bool, bool), DispatchError> {
+    if !crate::agent_ops::validate_branch(from_ref) {
+        return Err(DispatchError {
+            message: format!("invalid from_ref '{from_ref}'"),
+            code: ErrorCode::InvalidFromRef,
+            stage: Stage::ValidateFromRef,
+            fetch_attempted: false,
+            raw: None,
+        });
+    }
+    let branch_ref = format!("refs/heads/{branch}");
+    let branch_exists =
+        crate::git_helpers::git_bypass(source, &["rev-parse", "--verify", &branch_ref])
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+    if branch_exists {
+        return Ok((false, false));
+    }
+    // Step 2: try create from `from_ref` (no fetch yet — zero network
+    // on the fast path where origin/main is already a valid local ref).
+    match crate::git_helpers::git_bypass(source, &["branch", branch, from_ref]) {
+        Ok(o) if o.status.success() => Ok((true, false)),
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+            if stderr.contains("already exists") {
+                // Race: concurrent caller authored the branch between
+                // rev-parse and branch. Idempotent fall-through —
+                // auto_created stays false so callers can distinguish
+                // "I created it" vs "I observed it pre-existing".
+                Ok((false, false))
+            } else if stderr.contains("not a valid object name")
+                || stderr.contains("not a valid ref")
+            {
+                tracing::warn!(
+                    target: "dispatch_hook",
+                    %branch,
+                    %from_ref,
+                    "ensure_branch_exists fallback: from_ref unresolved locally — fetching origin"
+                );
+                let fetch_start = std::time::Instant::now();
+                let fetch_out =
+                    crate::git_helpers::git_bypass(source, &["fetch", "origin", "--quiet"]);
+                let fetch_ms = fetch_start.elapsed().as_millis();
+                crate::event_log::log(
+                    home,
+                    "ensure_branch_fetch",
+                    actor,
+                    &format!("branch={branch} from_ref={from_ref} duration_ms={fetch_ms}"),
+                );
+                match fetch_out {
+                    Ok(fo) if fo.status.success() => {
+                        match crate::git_helpers::git_bypass(source, &["branch", branch, from_ref])
+                        {
+                            Ok(ro) if ro.status.success() => Ok((true, true)),
+                            Ok(ro) => {
+                                let rstderr = String::from_utf8_lossy(&ro.stderr).to_string();
+                                if rstderr.contains("already exists") {
+                                    Ok((false, true))
+                                } else {
+                                    tracing::warn!(
+                                        target: "dispatch_hook",
+                                        %branch, %from_ref, stderr = %rstderr,
+                                        "ensure_branch_exists retry failed after fetch"
+                                    );
+                                    Err(DispatchError {
+                                        message: format!(
+                                            "from_ref '{from_ref}' invalid (branch creation failed after fetch)"
+                                        ),
+                                        code: ErrorCode::InvalidFromRef,
+                                        stage: Stage::RetryCreate,
+                                        fetch_attempted: true,
+                                        raw: Some(rstderr),
+                                    })
+                                }
+                            }
+                            Err(e) => Err(DispatchError {
+                                message: format!("git branch retry spawn failed: {e}"),
+                                code: ErrorCode::BranchCreateFailed,
+                                stage: Stage::RetryCreate,
+                                fetch_attempted: true,
+                                raw: Some(e.to_string()),
+                            }),
+                        }
+                    }
+                    Ok(fo) => {
+                        let fstderr = String::from_utf8_lossy(&fo.stderr).to_string();
+                        tracing::warn!(
+                            target: "dispatch_hook",
+                            %branch, %from_ref, stderr = %fstderr,
+                            "ensure_branch_exists fetch failed"
+                        );
+                        Err(DispatchError {
+                            message: format!(
+                                "git fetch origin failed (from_ref '{from_ref}' cannot be resolved)"
+                            ),
+                            code: ErrorCode::FetchFailed,
+                            stage: Stage::Fetch,
+                            fetch_attempted: true,
+                            raw: Some(fstderr),
+                        })
+                    }
+                    Err(e) => Err(DispatchError {
+                        message: format!("git fetch spawn failed: {e}"),
+                        code: ErrorCode::FetchFailed,
+                        stage: Stage::Fetch,
+                        fetch_attempted: true,
+                        raw: Some(e.to_string()),
+                    }),
+                }
+            } else {
+                Err(DispatchError {
+                    message: format!("git branch failed: {}", stderr.trim()),
+                    code: ErrorCode::BranchCreateFailed,
+                    stage: Stage::CreateBranch,
+                    fetch_attempted: false,
+                    raw: Some(stderr),
+                })
+            }
+        }
+        Err(e) => Err(DispatchError {
+            message: format!("git branch spawn failed: {e}"),
+            code: ErrorCode::BranchCreateFailed,
+            stage: Stage::CreateBranch,
+            fetch_attempted: false,
+            raw: Some(e.to_string()),
+        }),
+    }
 }
 
 /// Resolve source_repo from the agent's team configuration.
+///
+/// #781 Piece 5 (defensive logging): the prior `.ok()?` swallowed
+/// FleetConfig::load errors silently — a malformed fleet.yaml or
+/// transient I/O fault dropped Tier 2.5 to None with zero diagnostics,
+/// making post-mortem investigation harder. The defensive branches
+/// below surface the actual error class (load failure vs no team
+/// match vs team match without `source_repo`) so operators can
+/// distinguish "Bug A0 legacy-migration case" (team matched but
+/// source_repo None) from "team membership setup gap".
 pub(crate) fn resolve_team_source_repo(home: &Path, agent: &str) -> Option<PathBuf> {
-    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok()?;
+    let fleet = match crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!(
+                %agent,
+                home = %home.display(),
+                error = %e,
+                "Tier 2.5 resolution skipped: fleet.yaml load failed — \
+                 dispatch will fall through to tier 3 (working_directory) or \
+                 tier 4 (workspace stub)"
+            );
+            return None;
+        }
+    };
     for cfg in fleet.teams.values() {
         if cfg.members.contains(&agent.to_string()) {
+            if cfg.source_repo.is_none() {
+                tracing::warn!(
+                    %agent,
+                    "Tier 2.5 team match but `source_repo` is None — \
+                     likely legacy migration from teams.json (Bug A0, see #781). \
+                     Operator must run `team update name=<team> source_repo=<canonical>` \
+                     to escape the workspace stub fallback at tier 4"
+                );
+            }
             return cfg.source_repo.clone();
         }
     }
+    tracing::debug!(
+        %agent,
+        teams_searched = fleet.teams.len(),
+        "Tier 2.5: no team membership found for agent — falling through to tier 3/4"
+    );
     None
 }
 

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -12,8 +12,7 @@ use std::path::{Path, PathBuf};
 /// auto-bind hook fired from `send kind=task`.
 ///
 /// Introduced in C1 as a types-only commit; first call site materializes
-/// in C2 (signature migration). `allow(dead_code)` until C2 wires it up.
-#[allow(dead_code)]
+/// in C2 (signature migration).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DispatchOutcome {
     /// Which tier of [`resolve_source_repo`] fired — exposes the
@@ -33,7 +32,6 @@ pub struct DispatchOutcome {
 /// #781 Piece 7: structured error. The string-only `Result<_, String>`
 /// it supersedes (pre-#781) lost the `code` / `stage` / `raw` triple
 /// callers need to dispatch error handling programmatically.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DispatchError {
     /// Human-readable summary. Safe to log verbatim.
@@ -64,6 +62,11 @@ impl std::error::Error for DispatchError {}
 /// Which tier of [`resolve_source_repo`] fired. Observable via
 /// [`DispatchOutcome::source_repo_tier`] so callers can audit
 /// configuration completeness without parsing logs.
+///
+/// Variants `Override`/`FleetSourceRepo`/`TeamSourceRepo`/`WorkingDirectory`
+/// are wired in C4 once `resolve_source_repo` reports tier. C2 only
+/// constructs `Stub` (placeholder); `allow(dead_code)` on unused variants
+/// until C4 removes the attribute.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -85,6 +88,10 @@ pub enum SourceRepoTier {
 
 /// Pipeline stage that produced a [`DispatchError`]. Coarse enough to
 /// remain stable across refactors, fine enough to debug.
+///
+/// Variants `ValidateFromRef`/`CreateBranch`/`Fetch`/`RetryCreate` are
+/// constructed in C4 once `ensure_branch_exists` runs at the dispatch
+/// layer. `allow(dead_code)` on unused variants until C4.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -105,6 +112,10 @@ pub enum Stage {
 
 /// Canonical `code` enum — stable across releases. Callers MUST match
 /// on this rather than parsing `message` substrings.
+///
+/// Variants `InvalidFromRef`/`BranchCreateFailed`/`FetchFailed` are
+/// constructed in C4 once `ensure_branch_exists` runs. `allow(dead_code)`
+/// on unused variants until C4.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -207,7 +218,7 @@ pub(crate) fn dispatch_auto_bind_lease(
     task_id: &str,
     branch: &str,
     repo: Option<&str>,
-) -> Result<(), String> {
+) -> Result<DispatchOutcome, DispatchError> {
     dispatch_auto_bind_lease_with_source(home, target, task_id, branch, repo, None)
 }
 
@@ -215,6 +226,11 @@ pub(crate) fn dispatch_auto_bind_lease(
 /// `source_repo_override`. Used by `handle_bind_self(source_repo=...)`;
 /// existing callers go through [`dispatch_auto_bind_lease`] which passes
 /// `None` to preserve pre-Sprint-55 behavior.
+///
+/// #781 Piece 7: returns structured [`DispatchOutcome`] / [`DispatchError`].
+/// C2 commit performs the signature migration mechanically — `source_repo_tier`,
+/// `auto_created_branch`, `fetch_attempted` populated with placeholders here
+/// and wired to real observability sources in C4.
 pub(crate) fn dispatch_auto_bind_lease_with_source(
     home: &Path,
     target: &str,
@@ -222,8 +238,14 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
     branch: &str,
     repo: Option<&str>,
     source_repo_override: Option<&Path>,
-) -> Result<(), String> {
-    let _guard = BindGuard::try_acquire(home, target)?;
+) -> Result<DispatchOutcome, DispatchError> {
+    let _guard = BindGuard::try_acquire(home, target).map_err(|msg| DispatchError {
+        message: msg,
+        code: ErrorCode::BindInFlight,
+        stage: Stage::WorktreeLeaseConflict,
+        fetch_attempted: false,
+        raw: None,
+    })?;
 
     let resolved = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
         .ok()
@@ -232,9 +254,15 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
 
     // P0-1.5: central lease registry check — reject if another agent holds this branch.
     if let Some(other) = crate::binding::scan_existing_branch_binding(home, branch, target) {
-        return Err(format!(
-            "branch '{branch}' already leased by '{other}' — release first or use a different branch"
-        ));
+        return Err(DispatchError {
+            message: format!(
+                "branch '{branch}' already leased by '{other}' — release first or use a different branch"
+            ),
+            code: ErrorCode::LeaseConflict,
+            stage: Stage::WorktreeLeaseConflict,
+            fetch_attempted: false,
+            raw: None,
+        });
     }
 
     // Sprint 57 Wave 4 (#546 Item 4): same-agent different-branch
@@ -251,18 +279,37 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
     if let Some(existing) = crate::binding::read(home, target) {
         if let Some(existing_branch) = existing.get("branch").and_then(|v| v.as_str()) {
             if existing_branch != branch {
-                return Err(format!(
-                    "agent '{target}' already bound to branch '{existing_branch}' — \
-                     release_worktree first before re-binding to '{branch}' \
-                     (lease conflict per P0-1.6 semantic, preserved through Wave 4 #546 Item 4)"
-                ));
+                return Err(DispatchError {
+                    message: format!(
+                        "agent '{target}' already bound to branch '{existing_branch}' — \
+                         release_worktree first before re-binding to '{branch}' \
+                         (lease conflict per P0-1.6 semantic, preserved through Wave 4 #546 Item 4)"
+                    ),
+                    code: ErrorCode::LeaseConflict,
+                    stage: Stage::WorktreeLeaseConflict,
+                    fetch_attempted: false,
+                    raw: None,
+                });
             }
         }
     }
 
     // Attempt lease (creates worktree + tags as daemon-managed).
     // Lease errors REJECT the dispatch (Q2 + §3.3).
-    let lease = crate::worktree_pool::lease(home, &source_repo, target, branch)?;
+    let lease = crate::worktree_pool::lease(home, &source_repo, target, branch).map_err(|msg| {
+        let code = if msg.contains("E4.5") {
+            ErrorCode::ProtectedBranch
+        } else {
+            ErrorCode::LeaseConflict
+        };
+        DispatchError {
+            message: msg.clone(),
+            code,
+            stage: Stage::WorktreeLeaseConflict,
+            fetch_attempted: false,
+            raw: Some(msg),
+        }
+    })?;
 
     // Clean empty "init" commits left by kiro-cli session checkpoints.
     // Best-effort: failure here is non-fatal (worktree is still usable).
@@ -296,7 +343,17 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
         crate::mcp::handlers::ci::handle_watch_ci(home, &watch_args, target);
         tracing::info!(%target, repo = %r, %branch, "dispatch auto-watch_ci");
     }
-    Ok(())
+
+    // C2 placeholder: `source_repo_tier` / `auto_created_branch` /
+    // `fetch_attempted` are wired to real observability sources in C4 once
+    // `resolve_source_repo` reports tier + `ensure_branch_exists` reports
+    // create/fetch outcomes. Placeholder values are safe defaults — no
+    // existing caller inspects these fields pre-C4.
+    Ok(DispatchOutcome {
+        source_repo_tier: SourceRepoTier::Stub,
+        auto_created_branch: false,
+        fetch_attempted: false,
+    })
 }
 
 /// Sprint 55 P0-B EC6 — 3-tier source_repo resolution with observability.

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -287,38 +287,18 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
     //
     // `from_ref` is hard-coded to `"origin/main"` (mirror #784 default).
     //
-    // Fail-soft contract: errors from `ensure_branch_exists` fall through
-    // to `worktree_pool::lease` → `worktree::create -b` (which creates
-    // the branch from current HEAD). This preserves pre-#781 behavior
-    // for legacy callers / test fixtures where `source_repo` is a local
-    // repo with no `origin` remote (so the `git branch X origin/main` +
-    // fetch fallback paths both fail). Production canonicals have
-    // `origin/main` populated and hit the fast path. Validate-side
-    // failures (`InvalidFromRef`, e.g. option injection) DO surface as
-    // hard errors so a malicious caller can't slip past the boundary
-    // by triggering soft-fallback.
+    // Strict error contract (#781 Phase 3 r1, Path A — restored after
+    // initial fail-soft fix was found to weaken Piece 7's structured-
+    // error promise): all `ensure_branch_exists` errors propagate to
+    // the caller as `DispatchError` so they can programmatically
+    // dispatch on `code` / `stage` instead of receiving silent
+    // fallbacks that mask the original failure class. Legacy local-
+    // only test fixtures must register an origin URL + populate
+    // `refs/remotes/origin/main` (see `setup_test_repo` in
+    // `dispatch_hook/tests.rs` and `setup_git_repo_with_remote` in
+    // `p0b_tests.rs` for the canonical fixture pattern).
     let (auto_created_branch, fetch_attempted) =
-        match ensure_branch_exists(home, &source_repo, branch, "origin/main", target) {
-            Ok(tup) => tup,
-            Err(err)
-                if err.code == ErrorCode::InvalidFromRef && err.stage == Stage::ValidateFromRef =>
-            {
-                return Err(err);
-            }
-            Err(err) => {
-                tracing::warn!(
-                    target: "dispatch_hook",
-                    %target,
-                    %branch,
-                    code = ?err.code,
-                    stage = ?err.stage,
-                    message = %err.message,
-                    "ensure_branch_exists soft-fallback: legacy / origin-less source_repo \
-                     — falling through to worktree::create -b path"
-                );
-                (false, err.fetch_attempted)
-            }
-        };
+        ensure_branch_exists(home, &source_repo, branch, "origin/main", target)?;
 
     // Attempt lease (creates worktree + tags as daemon-managed).
     // Lease errors REJECT the dispatch (Q2 + §3.3).

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -5,6 +5,127 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+/// #781 Piece 7: structured dispatch outcome. Mirrors the #784 success
+/// response shape for `repo action=checkout bind:true` so callers across
+/// the fleet observe a single canonical schema regardless of whether the
+/// worktree was provisioned via the `repo` MCP tool or via the
+/// auto-bind hook fired from `send kind=task`.
+///
+/// Introduced in C1 as a types-only commit; first call site materializes
+/// in C2 (signature migration). `allow(dead_code)` until C2 wires it up.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchOutcome {
+    /// Which tier of [`resolve_source_repo`] fired — exposes the
+    /// silent-miss class of Bug A0 (operator sees `Stub` and knows team
+    /// `source_repo` is unset).
+    pub source_repo_tier: SourceRepoTier,
+    /// `true` when this dispatch authored the branch on `source_repo`.
+    /// `false` when the branch pre-existed (back-compat / race
+    /// fall-through). Mirrors `auto_created_branch` from #784.
+    pub auto_created_branch: bool,
+    /// `true` when the lazy `git fetch origin` was invoked because
+    /// `from_ref` did not resolve locally. Surfaces network I/O so
+    /// callers can correlate slow dispatches with fetch fallback.
+    pub fetch_attempted: bool,
+}
+
+/// #781 Piece 7: structured error. The string-only `Result<_, String>`
+/// it supersedes (pre-#781) lost the `code` / `stage` / `raw` triple
+/// callers need to dispatch error handling programmatically.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchError {
+    /// Human-readable summary. Safe to log verbatim.
+    pub message: String,
+    /// Canonical reason class — see [`ErrorCode`]. Stable enum, not
+    /// stderr fragments.
+    pub code: ErrorCode,
+    /// Pipeline locator — which step of `dispatch_auto_bind_lease`
+    /// raised. See [`Stage`].
+    pub stage: Stage,
+    /// `true` when the fetch fallback fired before the failure (lets
+    /// callers distinguish "config / option-injection invalid" from
+    /// "fetch happened but couldn't resolve from_ref").
+    pub fetch_attempted: bool,
+    /// Raw git stderr if any — for debug / post-mortem. `None` when
+    /// the failure didn't involve a git subprocess.
+    pub raw: Option<String>,
+}
+
+impl std::fmt::Display for DispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for DispatchError {}
+
+/// Which tier of [`resolve_source_repo`] fired. Observable via
+/// [`DispatchOutcome::source_repo_tier`] so callers can audit
+/// configuration completeness without parsing logs.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceRepoTier {
+    /// Tier 1 — explicit `source_repo_override` from
+    /// `bind_self(source_repo=...)` etc.
+    Override,
+    /// Tier 2 — per-instance `source_repo:` in fleet.yaml.
+    FleetSourceRepo,
+    /// Tier 2.5 — team `source_repo:` in fleet.yaml.
+    TeamSourceRepo,
+    /// Tier 3 — per-instance `working_directory:` fallback (deprecation
+    /// candidate).
+    WorkingDirectory,
+    /// Tier 4 — `$AGEND_HOME/workspace/<agent>` stub (last resort).
+    /// Surfacing this signals operator config gap.
+    Stub,
+}
+
+/// Pipeline stage that produced a [`DispatchError`]. Coarse enough to
+/// remain stable across refactors, fine enough to debug.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Stage {
+    /// `from_ref` rejected by `validate_branch` charset / option-injection guard.
+    ValidateFromRef,
+    /// First `git branch <name> <from_ref>` attempt failed for a reason
+    /// other than "already exists" / "not a valid ref".
+    CreateBranch,
+    /// `git fetch origin` after the missing-ref fallback failed.
+    Fetch,
+    /// Retry `git branch <name> <from_ref>` after fetch still failed.
+    RetryCreate,
+    /// `worktree_pool::lease` returned error (worktree creation failed,
+    /// cross-agent lease conflict, same-agent different-branch conflict).
+    WorktreeLeaseConflict,
+}
+
+/// Canonical `code` enum — stable across releases. Callers MUST match
+/// on this rather than parsing `message` substrings.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    /// `from_ref` arg rejected by `validate_branch` charset rules.
+    InvalidFromRef,
+    /// `git branch` failed at a stage we can't recover from (not
+    /// already-exists, not invalid-ref).
+    BranchCreateFailed,
+    /// `git fetch origin` exit non-zero / spawn error.
+    FetchFailed,
+    /// `worktree_pool::lease` rejected — cross-agent branch lease,
+    /// same-agent different-branch, worktree::create None, etc.
+    LeaseConflict,
+    /// E4.5 protected ref guard (`main` / `master`).
+    ProtectedBranch,
+    /// `bind_in_flight_set` already contains `(home, agent)` — concurrent
+    /// dispatch blocked.
+    BindInFlight,
+}
+
 /// Sprint 55 P0-B EC11: per-agent in-flight guard scoped to the daemon's
 /// `home` directory. Prevents concurrent `dispatch_auto_bind_lease` calls
 /// for the same agent from interleaving `binding.json` writes / lease

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -69,7 +69,10 @@ fn main_branch_rejects_dispatch() {
     let result = super::dispatch_auto_bind_lease(&home, "test-agent", "T-1", "main", None);
     assert!(result.is_err(), "main branch must REJECT");
     let err = result.expect_err("must be error");
-    assert!(err.contains("E4.5"), "error must mention E4.5: {err}");
+    assert!(
+        err.message.contains("E4.5"),
+        "error must mention E4.5: {err:?}"
+    );
 
     // No binding should exist.
     let binding_path = crate::paths::runtime_dir(&home)
@@ -110,8 +113,8 @@ fn lease_conflict_rejects_dispatch() {
     );
     let err = r2.expect_err("must err");
     assert!(
-        err.contains("already leased by 'agent-a'"),
-        "error must name leasing agent: {err}"
+        err.message.contains("already leased by 'agent-a'"),
+        "error must name leasing agent: {err:?}"
     );
 
     // Agent-b binding must NOT exist (Q2: REJECT = no side effects).
@@ -677,8 +680,8 @@ fn dispatch_auto_bind_lease_rejects_same_agent_different_branch_post_wave_4() {
     // across the architectural shift.
     let err = r2.unwrap_err();
     assert!(
-        err.contains("agent-y") && err.contains("feat/A"),
-        "rejection error must mention the existing binding's agent + branch: {err}"
+        err.message.contains("agent-y") && err.message.contains("feat/A"),
+        "rejection error must mention the existing binding's agent + branch: {err:?}"
     );
 
     // Binding still reflects feat/A — the rejected dispatch must

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -778,3 +778,167 @@ fn release_worktree_then_rebind_different_branch_succeeds_post_wave_4() {
 
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ----------------------------------------------------------------------
+// #781 dispatch_auto_bind_lease structural tests. Pins Piece 2 (Bug B,
+// worktree::create exit-code-128 gate too strict) + Piece 6 (source_repo
+// tier observability) + Piece 7 (structured DispatchOutcome).
+//
+// Source of truth: decision d-20260514124732379010-0 (amended) +
+// d-20260514130311646510-1 (Piece 1 micro-amend).
+//
+// Empirical anchor (§3.10 red→green): comment out the Bug B fix in
+// worktree.rs:228-230 OR revert the SourceRepoTier wiring in C4 →
+// `dispatch_auto_bind_lease_with_pre_existing_branch_in_team_source_repo_succeeds_via_fallback`
+// fails (at C3 HEAD both regressions still active: lease fails with exit
+// 255 unmatched + source_repo_tier placeholder mismatches TeamSourceRepo).
+//
+// Cross-platform: all happy-path tests `#[cfg(unix)]` per §3.7 — Windows
+// runner git-subprocess concurrency observed unstable, see #780/#778
+// fixture history. Backlog D tracks Windows CI smoke test.
+// ----------------------------------------------------------------------
+
+/// Fixture: canonical repo + fleet.yaml team source_repo + simulated
+/// `refs/remotes/origin/main`. Branch parameter pre-created on canonical
+/// so `worktree::create`'s `-b` path hits the duplicate-branch fallback
+/// (this is the Bug B trigger).
+#[cfg(unix)]
+fn p781_canonical_with_team_source_repo(
+    parent: &std::path::Path,
+    branch: &str,
+    pre_create_branch: bool,
+    team: &str,
+    members: &[&str],
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let home = parent.join(format!(
+        "home-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).ok();
+    let canonical = parent.join(format!(
+        "canonical-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&canonical).ok();
+    let bypass = ("AGEND_GIT_BYPASS", "1");
+    std::process::Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(&canonical)
+        .env(bypass.0, bypass.1)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ])
+        .current_dir(&canonical)
+        .env(bypass.0, bypass.1)
+        .output()
+        .unwrap();
+    // Simulate fetched origin/main so #780 auto-create on bind:true
+    // (if invoked) doesn't need network I/O.
+    let main_sha = String::from_utf8(
+        std::process::Command::new("git")
+            .args(["rev-parse", "main"])
+            .current_dir(&canonical)
+            .env(bypass.0, bypass.1)
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string();
+    std::process::Command::new("git")
+        .args(["update-ref", "refs/remotes/origin/main", &main_sha])
+        .current_dir(&canonical)
+        .env(bypass.0, bypass.1)
+        .output()
+        .unwrap();
+    if pre_create_branch {
+        std::process::Command::new("git")
+            .args(["branch", branch, "main"])
+            .current_dir(&canonical)
+            .env(bypass.0, bypass.1)
+            .output()
+            .unwrap();
+    }
+    let members_yaml = members
+        .iter()
+        .map(|m| format!("      - {m}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let yaml = format!(
+        "instances: {{}}\nteams:\n  {team}:\n    members:\n{members_yaml}\n    source_repo: {}\n",
+        canonical.display()
+    );
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+    (home, canonical)
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_auto_bind_lease_with_pre_existing_branch_in_team_source_repo_succeeds_via_fallback() {
+    // ANCHOR (§3.10 red→green). Pre-C4 HEAD this FAILs on:
+    //   (a) `worktree::create` -b path returns exit 255 with stderr
+    //       "already exists"; current exit-code-128 gate misses
+    //       fallback → lease returns Err → dispatch surfaces
+    //       Err(DispatchError { stage: WorktreeLeaseConflict }).
+    //   (b) Even if lease succeeded, C2's placeholder
+    //       `SourceRepoTier::Stub` mismatches the asserted
+    //       `TeamSourceRepo` until C4 wires `resolve_source_repo`.
+    // C4 fixes both: Bug B (stderr-substring fallback) + Piece 6
+    // (tier wiring) → test PASSes.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-p781-anchor-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, canonical) = p781_canonical_with_team_source_repo(
+        &parent,
+        "feat/p781-anchor",
+        true, // pre-create branch on canonical → triggers Bug B fallback path
+        "val",
+        &["val-dev"],
+    );
+
+    let result = super::dispatch_auto_bind_lease(&home, "val-dev", "T-1", "feat/p781-anchor", None);
+
+    let outcome = result.expect("dispatch must succeed via stderr-substring fallback");
+    assert_eq!(
+        outcome.source_repo_tier,
+        super::SourceRepoTier::TeamSourceRepo,
+        "source_repo_tier must observe Tier 2.5 (team source_repo): {outcome:?}"
+    );
+
+    // Binding written with canonical source_repo (Tier 2.5 resolution
+    // actually wins downstream — no Tier 4 stub).
+    let binding = home.join("runtime").join("val-dev").join("binding.json");
+    assert!(binding.exists(), "binding.json must be written");
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&binding).unwrap()).unwrap();
+    let observed = std::path::PathBuf::from(v["source_repo"].as_str().unwrap());
+    assert_eq!(
+        observed.canonicalize().unwrap_or(observed.clone()),
+        canonical.canonicalize().unwrap_or(canonical.clone()),
+        "binding.source_repo must be canonical (Tier 2.5), not workspace stub"
+    );
+
+    std::fs::remove_dir_all(&parent).ok();
+}

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -848,8 +848,23 @@ fn p781_canonical_with_team_source_repo(
         .env(bypass.0, bypass.1)
         .output()
         .unwrap();
-    // Simulate fetched origin/main so #780 auto-create on bind:true
-    // (if invoked) doesn't need network I/O.
+    // Register origin remote with a github-style URL so
+    // `derive_repo_from_remote` resolves to `owner/repo` for the
+    // ci_watches arming downstream — mirrors production canonicals.
+    std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/repo.git",
+        ])
+        .current_dir(&canonical)
+        .env(bypass.0, bypass.1)
+        .output()
+        .unwrap();
+    // Simulate fetched origin/main so #781 ensure_branch_exists fast path
+    // (zero network on `git branch X origin/main` where origin/main is
+    // already a valid local ref) fires without needing real network I/O.
     let main_sha = String::from_utf8(
         std::process::Command::new("git")
             .args(["rev-parse", "main"])
@@ -939,6 +954,319 @@ fn dispatch_auto_bind_lease_with_pre_existing_branch_in_team_source_repo_succeed
         canonical.canonicalize().unwrap_or(canonical.clone()),
         "binding.source_repo must be canonical (Tier 2.5), not workspace stub"
     );
+
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_auto_bind_lease_with_team_source_repo_missing_branch_auto_creates() {
+    // Test 2: branch missing on canonical → ensure_branch_exists's fast
+    // path (zero network on `git branch feat/X origin/main` where
+    // origin/main is already locally populated) creates the branch
+    // pre-lease. Observable via DispatchOutcome.auto_created_branch.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-p781-auto-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) = p781_canonical_with_team_source_repo(
+        &parent,
+        "feat/p781-auto",
+        false, // branch missing → auto-create path
+        "val",
+        &["val-dev"],
+    );
+    let result = super::dispatch_auto_bind_lease(&home, "val-dev", "T-1", "feat/p781-auto", None);
+    let outcome = result.expect("dispatch must succeed");
+    assert_eq!(
+        outcome.source_repo_tier,
+        super::SourceRepoTier::TeamSourceRepo
+    );
+    assert!(
+        outcome.auto_created_branch,
+        "branch missing pre-call must surface auto_created_branch=true: {outcome:?}"
+    );
+    assert!(
+        !outcome.fetch_attempted,
+        "origin/main pre-populated → no fetch fired: {outcome:?}"
+    );
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_auto_bind_lease_existing_branch_ignores_from_ref() {
+    // Test 3: pre-existing branch short-circuits ensure_branch_exists
+    // — from_ref is not consulted, neither create nor fetch fire.
+    // Pins the back-compat path so callers that pre-create branches
+    // (gh PR checkout, manual setup) get auto_created_branch=false.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-p781-exist-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) = p781_canonical_with_team_source_repo(
+        &parent,
+        "feat/p781-exist",
+        true, // pre-create
+        "val",
+        &["val-dev"],
+    );
+    let result = super::dispatch_auto_bind_lease(&home, "val-dev", "T-1", "feat/p781-exist", None);
+    let outcome = result.expect("dispatch must succeed");
+    assert!(
+        !outcome.auto_created_branch,
+        "pre-existing branch must NOT report auto-created: {outcome:?}"
+    );
+    assert!(
+        !outcome.fetch_attempted,
+        "pre-existing branch short-circuits before any fetch: {outcome:?}"
+    );
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_auto_bind_lease_invalid_from_ref_returns_structured_error() {
+    // Test 4: ensure_branch_exists's `validate_branch(from_ref)` gate
+    // rejects option-injection / charset-illegal `from_ref` values at
+    // the daemon API boundary. The hard-coded production `from_ref` is
+    // `origin/main` which always passes, so this test drives the
+    // helper directly with a malicious value to pin the structured-
+    // error surface.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-p781-inv-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, canonical) =
+        p781_canonical_with_team_source_repo(&parent, "feat/p781-inv", false, "val", &["val-dev"]);
+    // Drive ensure_branch_exists directly with an option-injection
+    // attempt — `--upload-pack=...` fails `validate_branch`'s leading-`-`
+    // guard.
+    let err = super::ensure_branch_exists(
+        &home,
+        &canonical,
+        "feat/p781-inv",
+        "--upload-pack=/bin/sh",
+        "val-dev",
+    )
+    .expect_err("validate_from_ref must reject option-injection");
+    assert_eq!(err.code, super::ErrorCode::InvalidFromRef);
+    assert_eq!(err.stage, super::Stage::ValidateFromRef);
+    assert!(!err.fetch_attempted);
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_auto_bind_lease_concurrent_different_targets_race_idempotent() {
+    // Test 5: two concurrent dispatches on the SAME source_repo + SAME
+    // branch + DIFFERENT targets (avoids per-target BindGuard rejection
+    // which fires for same-target collisions). Both probe branch
+    // missing → both attempt `git branch` → one wins, one hits "already
+    // exists" and falls through idempotently. Pins the race semantic:
+    // exactly one caller reports auto_created_branch=true; the loser
+    // either succeeds with auto_created_branch=false (no upstream
+    // worktree conflict for distinct instance_names) or fails at a
+    // later stage. Neither errors with code=BranchCreateFailed.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-p781-race-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) = p781_canonical_with_team_source_repo(
+        &parent,
+        "feat/p781-race",
+        false,
+        "val",
+        &["val-dev-a", "val-dev-b"],
+    );
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let mut handles = Vec::new();
+    for target in ["val-dev-a", "val-dev-b"] {
+        let barrier = std::sync::Arc::clone(&barrier);
+        let home_c = home.clone();
+        let target = target.to_string();
+        // fire-and-forget: test-only race harness; JoinHandle stored in
+        // `handles` and explicitly joined below.
+        handles.push(std::thread::spawn(move || {
+            barrier.wait();
+            super::dispatch_auto_bind_lease(&home_c, &target, "T-1", "feat/p781-race", None)
+        }));
+    }
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    for r in &results {
+        if let Err(e) = r {
+            assert_ne!(
+                e.code,
+                super::ErrorCode::BranchCreateFailed,
+                "race must NOT surface BranchCreateFailed (must absorb via already-exists): {e:?}"
+            );
+        }
+    }
+    let winners = results
+        .iter()
+        .filter(|r| r.as_ref().map(|o| o.auto_created_branch).unwrap_or(false))
+        .count();
+    assert_eq!(
+        winners, 1,
+        "exactly one caller must observe auto_created_branch=true: {results:?}"
+    );
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_auto_bind_lease_stress_50_iter_branch_create_no_flaky_parse() {
+    // Test 6: stress-loop 50 iterations of the missing-branch
+    // auto-create path. Catches flaky stderr-substring matching across
+    // git versions / locales (we rely on "already exists" / "is already
+    // checked out" / "not a valid object name" — if git rewords any
+    // the failure surfaces here, not in production). Each iter is a
+    // fresh home + canonical.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-p781-stress-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    for i in 0..50 {
+        let sub = parent.join(format!("iter-{i}"));
+        std::fs::create_dir_all(&sub).ok();
+        let branch = format!("feat/p781-stress-{i}");
+        let (home, _canonical) =
+            p781_canonical_with_team_source_repo(&sub, &branch, false, "val", &["val-dev"]);
+        let r = super::dispatch_auto_bind_lease(&home, "val-dev", "T-1", &branch, None);
+        let outcome = r.expect("each iter must succeed");
+        assert!(
+            outcome.auto_created_branch,
+            "iter {i}: fresh branch must report auto_created_branch=true"
+        );
+        assert!(
+            !outcome.fetch_attempted,
+            "iter {i}: origin/main pre-populated → no fetch"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_auto_bind_lease_auto_create_path_preserves_p0b_tail_ops() {
+    // Test 7: regression guard. Sprint 53 P0-1+P0-2 tail-ops (binding
+    // write + ci_watches arming via derive_repo_from_remote) must STILL
+    // fire when the auto-create path runs. Easy to regress if
+    // ensure_branch_exists short-circuits the post-lease block.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-p781-tail-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) =
+        p781_canonical_with_team_source_repo(&parent, "feat/p781-tail", false, "val", &["val-dev"]);
+    // Fixture's origin is `https://github.com/owner/repo.git` so
+    // `derive_repo_from_remote_pub` resolves owner/repo for ci_watches.
+    let r = super::dispatch_auto_bind_lease(&home, "val-dev", "T-77", "feat/p781-tail", None);
+    let outcome = r.expect("dispatch must succeed");
+    assert!(outcome.auto_created_branch);
+
+    // binding.json present + branch + task_id
+    let binding = home.join("runtime").join("val-dev").join("binding.json");
+    assert!(binding.exists());
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&binding).unwrap()).unwrap();
+    assert_eq!(v["branch"], "feat/p781-tail");
+    assert_eq!(v["task_id"], "T-77");
+
+    // ci_watches armed via owner/repo derivation
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/p781-tail"),
+    );
+    assert!(
+        watch_path.exists(),
+        "ci_watches must be armed post-auto-create — derive_repo_from_remote produced owner/repo"
+    );
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+fn teams_json_migration_preserves_existing_fleet_yaml_source_repo() {
+    // Test 9 (invariant guard, Piece 1): the migration must NOT
+    // overwrite an existing fleet.yaml team entry — if operator hand-
+    // edited a team into fleet.yaml with source_repo set, and
+    // teams.json contains an entry with the same name (legacy holdover),
+    // the migration short-circuit (`add_team_to_yaml` returns Ok(false)
+    // on duplicate) must preserve the fleet.yaml source_repo.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-p781-mig-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&parent).ok();
+
+    // Pre-existing fleet.yaml with team `val` + source_repo set.
+    let canonical = std::path::PathBuf::from("/tmp/p781-fake-canonical");
+    let yaml = format!(
+        "teams:\n  val:\n    members:\n      - val-dev\n    source_repo: {}\n",
+        canonical.display()
+    );
+    std::fs::write(crate::fleet::fleet_yaml_path(&parent), yaml).unwrap();
+
+    // Legacy teams.json with same team name, no source_repo field.
+    let teams_json = parent.join("teams.json");
+    std::fs::write(
+        &teams_json,
+        serde_json::to_string(&serde_json::json!({
+            "teams": [{
+                "name": "val",
+                "members": ["val-dev"],
+                "orchestrator": "val-dev",
+                "description": null,
+                "created_at": "2026-01-01T00:00:00Z"
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    crate::fleet::migrate_teams_json_to_yaml(&parent).expect("migration");
+
+    // Verify fleet.yaml's source_repo survived.
+    let post: crate::fleet::FleetConfig =
+        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&parent)).unwrap();
+    let team = post.teams.get("val").expect("team val present");
+    assert_eq!(
+        team.source_repo.as_ref().map(|p| p.display().to_string()),
+        Some(canonical.display().to_string()),
+        "fleet.yaml-side source_repo must survive teams.json migration"
+    );
+
+    // teams.json renamed → .migrated
+    assert!(parent.join("teams.json.migrated").exists());
+    assert!(!teams_json.exists());
 
     std::fs::remove_dir_all(&parent).ok();
 }

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -25,6 +25,44 @@ fn setup_test_repo(home: &std::path::Path, agent: &str) -> std::path::PathBuf {
         .env("AGEND_GIT_BYPASS", "1")
         .output()
         .ok();
+    // #781 Phase 3 r1 (Path A — strict mode): pre-#781 fixtures relied
+    // on `worktree::create -b` for missing-branch creation. With #781's
+    // strict `ensure_branch_exists`, dispatch_auto_bind_lease creates
+    // the branch from `origin/main` BEFORE lease. Legacy local-only
+    // fixtures must register an origin URL + populate
+    // `refs/remotes/origin/main` so the fast path resolves without
+    // network I/O. `file:///dev/null/agend-fixture` chosen so
+    // `parse_github_owner_repo` returns None — preserves the pre-#781
+    // assertion in `delegate_task_without_repo_no_ci_watch` that no
+    // ci-watch fires when repo is undeterminable. Tests that need
+    // github-style ci-watch arming (e.g. `…_preserves_p0b_tail_ops`)
+    // use a separate fixture with `https://github.com/...` URL.
+    let _ = std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "file:///dev/null/agend-fixture-no-derive",
+        ])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output();
+    let main_sha = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    if !main_sha.is_empty() {
+        let _ = std::process::Command::new("git")
+            .args(["update-ref", "refs/remotes/origin/main", &main_sha])
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output();
+    }
     // Write fleet.yaml so resolve_instance works.
     std::fs::write(
         crate::fleet::fleet_yaml_path(home),
@@ -1073,13 +1111,33 @@ fn dispatch_auto_bind_lease_invalid_from_ref_returns_structured_error() {
 fn dispatch_auto_bind_lease_concurrent_different_targets_race_idempotent() {
     // Test 5: two concurrent dispatches on the SAME source_repo + SAME
     // branch + DIFFERENT targets (avoids per-target BindGuard rejection
-    // which fires for same-target collisions). Both probe branch
-    // missing → both attempt `git branch` → one wins, one hits "already
-    // exists" and falls through idempotently. Pins the race semantic:
-    // exactly one caller reports auto_created_branch=true; the loser
-    // either succeeds with auto_created_branch=false (no upstream
-    // worktree conflict for distinct instance_names) or fails at a
-    // later stage. Neither errors with code=BranchCreateFailed.
+    // which fires for same-target collisions).
+    //
+    // Race semantics being pinned (#781 Phase 3 r1, reviewer constraint #2
+    // — distinguish `CreateBranch` stage from `WorktreeLeaseConflict`
+    // stage in race-loser error path):
+    //
+    // - At least one caller succeeds (Ok). The other either also succeeds
+    //   (if it observed the branch already existing AND grabbed a distinct
+    //   worktree path) or errors. Worktree path is segmented per agent
+    //   (`<home>/worktrees/<agent>/<branch>/`) so technically both could
+    //   reuse the same branch — but `worktree::create`'s existing-branch
+    //   guard rejects a second `worktree add <branch>` since git's
+    //   per-branch single-checkout invariant holds.
+    // - The loser, if it errored, MUST surface `Stage::WorktreeLeaseConflict`
+    //   (the failure landed at the worktree-add step, after the race-
+    //   absorbed `git branch` already-exists fall-through). It must NOT
+    //   surface `Stage::CreateBranch` (= `git branch` non-`already-exists`
+    //   failure) and must NOT carry `ErrorCode::BranchCreateFailed`.
+    // - At most one Ok observes `auto_created_branch=true`. Branch
+    //   creation race winner is determined by `git branch` ordering; the
+    //   loser's `git branch` hits `already exists` stderr → fall-through
+    //   with `auto_created_branch=false`. We don't require exactly-one-
+    //   true: when the branch-create winner subsequently LOSES the
+    //   worktree-add race, its `DispatchError` does not carry
+    //   `auto_created_branch` (omitted from error shape per Piece 7
+    //   schema), so the signal is observable only from the Ok variant.
+    //   `at_most_one` is the strict invariant; `exactly_one` would flake.
     let parent = std::env::temp_dir().join(format!(
         "agend-p781-race-{}-{}",
         std::process::id(),
@@ -1108,24 +1166,42 @@ fn dispatch_auto_bind_lease_concurrent_different_targets_race_idempotent() {
             super::dispatch_auto_bind_lease(&home_c, &target, "T-1", "feat/p781-race", None)
         }));
     }
-    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
-    for r in &results {
-        if let Err(e) = r {
-            assert_ne!(
-                e.code,
-                super::ErrorCode::BranchCreateFailed,
-                "race must NOT surface BranchCreateFailed (must absorb via already-exists): {e:?}"
-            );
-        }
-    }
-    let winners = results
-        .iter()
-        .filter(|r| r.as_ref().map(|o| o.auto_created_branch).unwrap_or(false))
-        .count();
-    assert_eq!(
-        winners, 1,
-        "exactly one caller must observe auto_created_branch=true: {results:?}"
+    let outcomes: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    let ok_count = outcomes.iter().filter(|o| o.is_ok()).count();
+    assert!(
+        ok_count >= 1,
+        "at least one race winner must succeed (branch-create race must absorb the loser via stderr fall-through): {outcomes:?}"
     );
+
+    // Stage / code differentiation in error path (reviewer constraint #2):
+    // race losers MUST land on WorktreeLeaseConflict, NEVER on CreateBranch.
+    for err in outcomes.iter().filter_map(|o| o.as_ref().err()) {
+        assert_eq!(
+            err.stage,
+            super::Stage::WorktreeLeaseConflict,
+            "race loser must fail at WorktreeLeaseConflict stage (NOT CreateBranch — race must be absorbed at git-branch layer), got stage={:?}: {err:?}",
+            err.stage
+        );
+        assert_ne!(
+            err.code,
+            super::ErrorCode::BranchCreateFailed,
+            "race must NOT surface BranchCreateFailed — already-exists stderr is the fall-through signal: {err:?}"
+        );
+    }
+
+    // At most one Ok caller observes auto_created_branch=true. When the
+    // branch-create winner subsequently loses worktree-add, its
+    // DispatchError omits auto_created_branch (per Piece 7 shape).
+    let true_count = outcomes
+        .iter()
+        .filter(|r| matches!(r, Ok(o) if o.auto_created_branch))
+        .count();
+    assert!(
+        true_count <= 1,
+        "at most one Ok caller may report auto_created_branch=true: {outcomes:?}"
+    );
+
     std::fs::remove_dir_all(&parent).ok();
 }
 

--- a/src/mcp/handlers/p0b_tests.rs
+++ b/src/mcp/handlers/p0b_tests.rs
@@ -120,6 +120,32 @@ fn setup_git_repo(home: &Path, agent: &str) -> std::path::PathBuf {
     setup_git_repo_with_remote(home, agent, "https://github.com/o/r.git")
 }
 
+/// #781 Phase 3 r1: helper used by tests that inline a `git init`
+/// (instead of going through `setup_git_repo*`). Populates
+/// `refs/remotes/origin/main` so the strict
+/// `dispatch_hook::ensure_branch_exists` `git branch X origin/main`
+/// fast path resolves locally without a real fetch. Caller is
+/// responsible for any prior `git remote add origin <url>` — this
+/// helper just writes the ref.
+fn populate_origin_main_for_strict_ensure_branch(repo: &Path) {
+    let head_sha = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    if !head_sha.is_empty() {
+        let _ = std::process::Command::new("git")
+            .args(["update-ref", "refs/remotes/origin/main", &head_sha])
+            .current_dir(repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output();
+    }
+}
+
 fn setup_git_repo_with_remote(home: &Path, agent: &str, origin_url: &str) -> std::path::PathBuf {
     let repo = crate::paths::workspace_dir(home).join(agent);
     std::fs::create_dir_all(&repo).ok();
@@ -150,6 +176,27 @@ fn setup_git_repo_with_remote(home: &Path, agent: &str, origin_url: &str) -> std
         .current_dir(&repo)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
+    // #781 Phase 3 r1 (Path A — strict mode): populate
+    // `refs/remotes/origin/main` so strict `ensure_branch_exists` in
+    // dispatch_auto_bind_lease resolves `origin/main` without network.
+    // Required because #781 moves branch provisioning from
+    // `worktree::create -b` (current-HEAD-based) to the dispatch layer.
+    let main_sha = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    if !main_sha.is_empty() {
+        let _ = std::process::Command::new("git")
+            .args(["update-ref", "refs/remotes/origin/main", &main_sha])
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output();
+    }
     std::fs::write(
         crate::fleet::fleet_yaml_path(home),
         format!(
@@ -386,6 +433,7 @@ fn ec6_dispatch_uses_fleet_source_repo_tier_when_present() {
         .current_dir(&src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
+    populate_origin_main_for_strict_ensure_branch(&src);
     std::fs::write(
         crate::fleet::fleet_yaml_path(&home),
         format!(
@@ -422,7 +470,12 @@ fn ec4_fleet_repo_override_wins_over_derive() {
     let home = tmp_home("ec4-override");
     let src = home.join("src-noremote");
     std::fs::create_dir_all(&src).ok();
-    // git init but NO remote configured → derive returns None.
+    // git init but NO origin remote registered → derive returns None.
+    // #781 Phase 3 r1: populate `refs/remotes/origin/main` so strict
+    // `ensure_branch_exists` resolves locally; we intentionally skip
+    // `git remote add origin <url>` so `derive_repo_from_remote`
+    // returns None (this is the assertion under test — fleet.yaml
+    // `repo:` override wins over remote-URL derivation).
     let _ = std::process::Command::new("git")
         .args(["init", "-b", "main"])
         .current_dir(&src)
@@ -442,6 +495,22 @@ fn ec4_fleet_repo_override_wins_over_derive() {
         .current_dir(&src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
+    let head_sha = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&src)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    if !head_sha.is_empty() {
+        let _ = std::process::Command::new("git")
+            .args(["update-ref", "refs/remotes/origin/main", &head_sha])
+            .current_dir(&src)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output();
+    }
     std::fs::write(
         crate::fleet::fleet_yaml_path(&home),
         format!(
@@ -507,6 +576,7 @@ fn dispatch_with_source_repo_override_wins_over_fleet() {
         .current_dir(&real_src)
         .env("AGEND_GIT_BYPASS", "1")
         .output();
+    populate_origin_main_for_strict_ensure_branch(&real_src);
     // fleet.yaml points to a different (stub) source_repo
     std::fs::write(
         crate::fleet::fleet_yaml_path(&home),

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -105,10 +105,14 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
         repo_arg,
         source_repo_path.as_deref(),
     ) {
-        Ok(()) => {
+        Ok(_outcome) => {
             // Successful bind: read back the worktree path from the binding
             // file we just wrote so the response reflects authoritative
             // state, not a recomputation.
+            //
+            // C2: discards `DispatchOutcome` for back-compat; consumers that
+            // want `auto_created_branch` / `source_repo_tier` should be
+            // migrated as a follow-up.
             let binding_path = crate::paths::runtime_dir(home)
                 .join(agent)
                 .join("binding.json");
@@ -123,10 +127,14 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
                 "branch": branch,
             })
         }
-        Err(msg) => {
-            // Map dispatch_auto_bind_lease error strings to stable codes so
-            // agents can branch on machine-readable signals instead of
-            // grepping the human message.
+        Err(err) => {
+            // Map `DispatchError` to the pre-#781 string-code shape so
+            // existing callers (agent self-bind flow) keep parsing the
+            // same surface. C2 mechanical: preserves prior substring-grep
+            // semantics on `err.message` rather than dispatching on the
+            // new canonical `err.code` enum (that follow-up belongs with
+            // bind_self's MCP-tool consumer migration).
+            let msg = err.message;
             let code = if msg.contains("E4.5") {
                 "e4_5_protected_branch"
             } else if msg.contains("already leased") {

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -11,29 +11,12 @@ use crate::identity::Sender;
 use serde_json::{json, Value};
 use std::path::Path;
 
-/// MCP tool: `bind_self` (Sprint 54 P1-7).
-///
-/// Lets any instance proactively bind itself to a worktree without going
-/// through the dispatch hook — use case is the lead orchestrator wanting
-/// to claim a worktree for a Path A IMPL escalation, or any agent that
-/// wants to pre-claim a branch before the task arrives.
-///
-/// Required args: `repo` (owner/name string), `branch` (string).
-/// Optional args: none.
-///
-/// Returns:
-/// - On success: `{"bound": true, "worktree_path": "...", "branch": "..."}`.
-/// - On failure: `{"error": "...", "code": "..."}` — `code` mirrors the
-///   underlying lease/bind error class (`E4.5`, `cross_agent_conflict`,
-///   `lease_failed`).
-///
-/// Implementation reuses [`crate::mcp::handlers::dispatch_hook::dispatch_auto_bind_lease`]
-/// with `task_id="self"` so every Sprint 53/54 invariant (Phase 1
-/// trailers, P0-1.5 cross-agent registry check, P0-1.6 actual-HEAD
-/// verification, P0-X release_worktree as sole exit point, source_repo
-/// persistence in binding.json, auto watch_ci subscription) applies
-/// uniformly. The handler is intentionally a thin shim — bug fixes in
-/// the dispatch path are inherited automatically.
+/// MCP tool: `bind_self` (Sprint 54 P1-7). Lets any instance proactively
+/// bind itself to a worktree without going through the dispatch hook.
+/// Required args: `repo` / `source_repo` (one of), `branch`. Returns
+/// `{bound, worktree_path, branch}` on success or `{error, code}` on
+/// failure. Thin shim over `dispatch_auto_bind_lease` — bug fixes in
+/// the dispatch path inherit automatically.
 pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender>) -> Value {
     let agent = match sender.as_ref().map(Sender::as_str) {
         Some(a) if !a.is_empty() => a,
@@ -366,6 +349,22 @@ mod tests {
             .env("AGEND_GIT_BYPASS", "1")
             .output()
             .ok();
+        // #781 Phase 3 r1 (Path A): populate `refs/remotes/origin/main`
+        // for strict `ensure_branch_exists`; file:/// URL so
+        // derive_repo returns None.
+        let git = |a: &[&str]| -> Option<std::process::Output> {
+            std::process::Command::new("git")
+                .args(a)
+                .current_dir(&repo)
+                .env("AGEND_GIT_BYPASS", "1")
+                .output()
+                .ok()
+        };
+        git(&["remote", "add", "origin", "file:///dev/null/agend-fix"]);
+        if let Some(o) = git(&["rev-parse", "HEAD"]).filter(|o| o.status.success()) {
+            let sha = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            git(&["update-ref", "refs/remotes/origin/main", &sha]);
+        }
         std::fs::write(
             crate::fleet::fleet_yaml_path(home),
             format!(

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -108,11 +108,8 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
         Ok(_outcome) => {
             // Successful bind: read back the worktree path from the binding
             // file we just wrote so the response reflects authoritative
-            // state, not a recomputation.
-            //
-            // C2: discards `DispatchOutcome` for back-compat; consumers that
-            // want `auto_created_branch` / `source_repo_tier` should be
-            // migrated as a follow-up.
+            // state. #781 `DispatchOutcome` fields are dropped here —
+            // surfacing them is a `bind_self` consumer follow-up.
             let binding_path = crate::paths::runtime_dir(home)
                 .join(agent)
                 .join("binding.json");
@@ -129,11 +126,9 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
         }
         Err(err) => {
             // Map `DispatchError` to the pre-#781 string-code shape so
-            // existing callers (agent self-bind flow) keep parsing the
-            // same surface. C2 mechanical: preserves prior substring-grep
-            // semantics on `err.message` rather than dispatching on the
-            // new canonical `err.code` enum (that follow-up belongs with
-            // bind_self's MCP-tool consumer migration).
+            // existing callers keep parsing the same surface. The follow-up
+            // to dispatch on `err.code` belongs with bind_self's consumer
+            // migration.
             let msg = err.message;
             let code = if msg.contains("E4.5") {
                 "e4_5_protected_branch"

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -199,6 +199,7 @@ mod tests {
             orchestrator: Some("dev-lead".to_string()),
             description: None,
             created_at: "2026-01-01T00:00:00Z".to_string(),
+            source_repo: None,
         }];
         let tasks = vec![crate::tasks::Task {
             id: "t-1".to_string(),

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -116,6 +116,20 @@ pub fn create(home: &Path, args: &Value) -> Value {
         }
     }
 
+    // #781 Piece 4 (Bug A2 UX): operator can silently create a team
+    // without `source_repo`, then watch every `dispatch_auto_bind_lease`
+    // fall through to the Tier 4 workspace stub at run time. Surface
+    // the omission as a warning at create time so the operator can
+    // amend before the gap is observed at dispatch.
+    if source_repo.is_none() {
+        warnings.push(format!(
+            "team '{name}' created without `source_repo` — \
+             dispatch_auto_bind_lease will fall through Tier 2.5 and \
+             land on the workspace stub at Tier 4. Set via \
+             `team(action=update, name={name}, source_repo=...)` to \
+             bind agents on the canonical repo."
+        ));
+    }
     let cfg = crate::fleet::TeamConfig {
         members,
         orchestrator,
@@ -654,6 +668,85 @@ mod tests {
         );
         let none = crate::mcp::handlers::dispatch_hook::resolve_team_source_repo(&home, "other");
         assert!(none.is_none());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn team_list_response_surfaces_source_repo_field() {
+        // #781 Piece 3 (Bug A1): `team list` response must expose
+        // `source_repo` so operators can audit which teams need a
+        // remediation update (Bug A0 legacy-migration cases render
+        // `null`).
+        let home = std::env::temp_dir().join(format!("agend-p781-list-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        super::create(
+            &home,
+            &serde_json::json!({
+                "name": "with-repo",
+                "members": ["agent-w"],
+                "orchestrator": "agent-w",
+                "source_repo": "/tmp/p781-test-canonical",
+            }),
+        );
+        super::create(
+            &home,
+            &serde_json::json!({
+                "name": "without-repo",
+                "members": ["agent-n"],
+                "orchestrator": "agent-n",
+            }),
+        );
+        let list = super::list(&home);
+        let teams = list["teams"].as_array().expect("teams array");
+        let with = teams
+            .iter()
+            .find(|t| t["name"] == "with-repo")
+            .expect("with-repo present");
+        let without = teams
+            .iter()
+            .find(|t| t["name"] == "without-repo")
+            .expect("without-repo present");
+        assert_eq!(
+            with["source_repo"].as_str(),
+            Some("/tmp/p781-test-canonical"),
+            "list response must surface source_repo: {with}"
+        );
+        assert!(
+            without.get("source_repo").is_some(),
+            "list response must include source_repo field even when null: {without}"
+        );
+        assert!(
+            without["source_repo"].is_null(),
+            "missing source_repo must render as null, not absent: {without}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn create_warns_when_source_repo_absent() {
+        // #781 Piece 4 (Bug A2 UX): `team(action=create)` accepts missing
+        // `source_repo` but must surface a warning so the operator can
+        // amend before the gap is observed at dispatch.
+        let home = std::env::temp_dir().join(format!("agend-p781-warn-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let resp = super::create(
+            &home,
+            &serde_json::json!({
+                "name": "no-repo",
+                "members": ["agent-z"],
+                "orchestrator": "agent-z",
+            }),
+        );
+        assert_eq!(resp["status"], "created");
+        let warnings = resp["warnings"]
+            .as_array()
+            .expect("warnings array when source_repo omitted");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.as_str().is_some_and(|s| s.contains("source_repo"))),
+            "warning text must reference source_repo: {warnings:?}"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -22,6 +22,15 @@ pub struct Team {
     pub orchestrator: Option<String>,
     pub description: Option<String>,
     pub created_at: String,
+    /// #781 Piece 3 (Bug A1): operator-visible source_repo. Pre-#781
+    /// the projection silently dropped this field, masking the
+    /// migration-time `source_repo=None` (Bug A0) from `team list`
+    /// callers. Persist as `Option` so legacy-migrated teams render
+    /// `null` rather than disappearing from the projection — operator
+    /// can `jq '.teams[] | select(.source_repo == null)'` to enumerate
+    /// teams needing remediation.
+    #[serde(default)]
+    pub source_repo: Option<std::path::PathBuf>,
 }
 
 impl Team {
@@ -45,6 +54,7 @@ fn project_team(name: &str, cfg: &crate::fleet::TeamConfig) -> Team {
         orchestrator: cfg.orchestrator.clone(),
         description: cfg.description.clone(),
         created_at: cfg.created_at.clone().unwrap_or_default(),
+        source_repo: cfg.source_repo.clone(),
     }
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -224,10 +224,25 @@ pub fn create(
         }
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr);
-            // Branch or worktree already exists — try without -b (exit code 128 = git error)
-            if o.status.code() == Some(128)
-                && (stderr.contains("already exists") || stderr.contains("is already checked out"))
-            {
+            // #781 Piece 2 (Bug B): the prior `o.status.code() == Some(128)`
+            // gate was too strict. `git worktree add -b <existing-branch>`
+            // can exit with code 255 (not 128) when the failure happens
+            // after the "Preparing worktree (new branch …)" progress line
+            // has already been emitted to stderr — observed in macOS git
+            // 2.42+ in the #781 spike (raw capture: exit 255, stderr
+            // "fatal: a branch named '…' already exists"). Exit codes
+            // from `git worktree add` are not contracted in any released
+            // git manpage we could find; the stderr substring is the
+            // load-bearing semantic signal. Rely on it alone.
+            //
+            // Reasoning: across git versions / locales the stderr
+            // wording stays stable (English) for the duplicate-branch
+            // case ("already exists") and the cross-worktree-checkout
+            // case ("is already checked out"); the exit code drift is
+            // version-specific. Adding more codes to the allow-list
+            // would just chase the next git release — the substring
+            // check is what we actually want.
+            if stderr.contains("already exists") || stderr.contains("is already checked out") {
                 let output2 = std::process::Command::new("git")
                     .env("AGEND_GIT_BYPASS", "1")
                     .args(["worktree", "add", &wt_dir.display().to_string(), &branch])


### PR DESCRIPTION
## Summary

Closes #781. Fixes the bypass-free workflow gap where `task action=claim` + `send kind=task` left `binding.source_repo` pointing at the workspace stub (Tier 4) instead of the team's canonical (Tier 2.5), even when fleet.yaml had `teams.<x>.source_repo` set.

scope follows dispatch spec d-20260514124732379010-0 (amended) + d-20260514130311646510-1 (Piece 1 micro-amend)

7-piece scope across A0/A1/A2/B + helper extraction + observability + structured response. Migration trigger CONFIRMED at fleet.rs:1218 (legacy teams.json scenario). This PR addresses migration observability (1a-i warn + 1a-ii event_log) — pure observability, no behavioral change. Residual scenario (post-Sprint-54 fixup team wipe mechanism) UNKNOWN after dev source-code audit → Backlog E. Bug A0 fixup-team-specific symptom may persist until backlog resolves; PR ships defensive measures + observability.

## Bug table

| Piece | Bug | Symptom | Fix |
|---|---|---|---|
| 1a-i + 1a-ii | A0 | Legacy teams.json migrated with `source_repo: None` (legacy schema had no field) — Tier 2.5 silently misses, dispatch lands on Tier 4 stub | Migration emits `tracing::warn!` + `event_log::log` so operator sees the gap at startup (not first failed dispatch). Root cause documented at fleet.rs:1218 |
| 2 | B | `worktree::create` `git worktree add -b <existing-branch>` returns exit 255 (not 128) when failure occurs after the "Preparing worktree" progress line; old gate `o.status.code() == Some(128) && stderr.contains(...)` missed the fallback path → `create` returned None → lease errored | Drop exit-code gate; rely on stderr-substring semantic check alone (load-bearing across git versions / locales) |
| 3 | A1 | `team list` JSON response silently dropped `source_repo` field — operator could not visually verify which teams were missing the canonical | Add `source_repo: Option<PathBuf>` to `Team` projection struct + populate in `project_team` |
| 4 | A2 | `team(action=create)` silently accepted missing `source_repo` arg — no warning, gap surfaces only at dispatch time | Push warning into response when `source_repo` omitted, referencing `team update` remediation path |

## Piece 5 — Tier 2.5 defensive logging
`resolve_team_source_repo` now distinguishes FleetConfig::load failure (warn), no team match for agent (debug), and team match but `source_repo` None (warn — directly identifies Bug A0 cases at dispatch). Pre-#781: `.ok()?` swallowed all three.

## Piece 6 — helper extraction
- `git_bypass` promoted from `mcp::handlers::ci::mod` (private) → `crate::git_helpers` (`pub(crate)`). One bypass-env site for the whole daemon.
- `ensure_branch_exists` extracted from `ci::handle_checkout_repo`'s inline logic → `dispatch_hook::ensure_branch_exists`. Mirror of #784 decision tree (rev-parse → branch → fetch+retry). Two consumers (the `repo action=checkout bind:true` MCP entry AND `dispatch_auto_bind_lease`) share one source of truth.

## Piece 7 — structured DispatchOutcome / DispatchError
- `dispatch_auto_bind_lease` returns `Result<DispatchOutcome, DispatchError>` (was `Result<(), String>`).
- `DispatchOutcome { source_repo_tier, auto_created_branch, fetch_attempted }` — mirror #784 response schema.
- `DispatchError { message, code, stage, fetch_attempted, raw }` — canonical `ErrorCode` enum + `Stage` pipeline locator. `Display` impl preserves pre-#781 `format!` surface for back-compat callers (comms.rs needed zero source change).
- 11 call sites migrated mechanically (comms.rs + worktree.rs + dispatch_hook/tests.rs + p0b_tests.rs — only 3 sites needed actual edits via `err.contains` → `err.message.contains`).

## §3.10 test-first verification

- Test-first commit (red): `86a22d1` — `test(#781): anchor for dispatch_auto_bind_lease pre-existing branch fallback`
- Impl commit (green): `676b94e` — `fix(#781): Bug B fix + helper extraction + Tier 2.5 observability + migration observability`

Reviewer verify:
```
git checkout 86a22d1 && cargo test --features tray --bin agend-terminal \
  dispatch_auto_bind_lease_with_pre_existing_branch_in_team_source_repo_succeeds_via_fallback
# expect: FAILED (DispatchError { code: LeaseConflict, stage: WorktreeLeaseConflict })

git checkout 676b94e && cargo test --features tray --bin agend-terminal \
  dispatch_auto_bind_lease_with_pre_existing_branch_in_team_source_repo_succeeds_via_fallback
# expect: ok. 1 passed
```

Daemon-generated empty heartbeat commits sit between my four substantive commits (same pattern observed in #784). They do not affect §3.10 verifiability — `git diff` between any pair is empty, file state equivalent to the preceding substantive commit. Per lead's hard rule "禁 amend / force push / 跳序 commit", not rebase-dropped.

## 5-commit sequence

| # | SHA | Purpose | Build |
|---|---|---|---|
| C1 | `31d5cbd` | types-only: DispatchOutcome / DispatchError / SourceRepoTier / Stage / ErrorCode | green (`#[allow(dead_code)]` until C2) |
| C2 | `e409528` | signature change + migrate 11 call sites mechanically | green |
| C3 | `86a22d1` | §3.10 anchor test (red) | anchor fails at this SHA |
| C4 | `676b94e` | substantive impl — Pieces 6 + 5 + 2 + 1a-i + 1a-ii + 3 + tests 1-7 + invariant test 9 | green all tests |
| C5 | `08c2afa` | Piece 4 UX warn + test 8 | green |

## Tests (9, all green)

`#[cfg(unix)]` gating per §3.7 cross-backend stance (Backlog D Windows CI):
1. `dispatch_auto_bind_lease_with_pre_existing_branch_in_team_source_repo_succeeds_via_fallback` — anchor §3.10
2. `dispatch_auto_bind_lease_with_team_source_repo_missing_branch_auto_creates` — fast-path auto-create
3. `dispatch_auto_bind_lease_existing_branch_ignores_from_ref` — pre-existing branch short-circuit
4. `dispatch_auto_bind_lease_invalid_from_ref_returns_structured_error` — drives `ensure_branch_exists` directly to pin ValidateFromRef option-injection gate
5. `dispatch_auto_bind_lease_concurrent_different_targets_race_idempotent` — Barrier(2) with DIFFERENT targets (BindGuard per-target reality)
6. `dispatch_auto_bind_lease_stress_50_iter_branch_create_no_flaky_parse` — stress 50 iter inline run
7. `dispatch_auto_bind_lease_auto_create_path_preserves_p0b_tail_ops` — Sprint 53 P0-1+P0-2 binding + ci_watches arm regression guard

Cross-platform (no cfg gate):
8. `teams::tests::team_list_response_surfaces_source_repo_field` — Bug A1 pin
9. `teams_json_migration_preserves_existing_fleet_yaml_source_repo` — Piece 1 invariant guard

Bonus:
- `teams::tests::create_warns_when_source_repo_absent` — Piece 4 UX warn pin

## Cross-platform stance

`unverified cross-backend claim` for Windows (§3.7). Happy-path tests gated `#[cfg(unix)]` matching #778 / #780 fixture convention — Windows CI runner's git-subprocess concurrency observed unstable. **Backlog D** tracks Windows CI smoke test (not blocking #781 ship).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite green (anchor red→green verified)
- [x] §3.10 test-first verify (anchor SHA fails at HEAD, impl SHA passes)
- [x] All 9 new tests pass (1-7 dispatch_hook, 8 teams::list, 9 invariant guard)
- [x] ZERO BYPASS workflow — `repo action=checkout bind:true` single-step provision (no manual `git branch` step thanks to #780 ship); no `AGEND_GIT_BYPASS` env in any commit/push step

🤖 Generated with [Claude Code](https://claude.com/claude-code)