### PR TITLE
fix(#779p2): surface bind_full/watch_ci partial failures + harden handle_watch_ci

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -7,16 +7,21 @@ use serde_json::json;
 use std::path::Path;
 
 /// Write a binding for an agent (task assigned).
+///
+/// #779 P2: `bind_full` now returns `Result`; this thin wrapper preserves
+/// the pre-#779-P2 silent semantic via `.ok()` so existing callers (tests
+/// + dispatch path) keep unit-return.
 #[allow(dead_code)] // Used by tests + auto-watch dispatch path
 pub fn bind(home: &Path, agent: &str, task_id: &str, branch: &str) {
-    bind_full(
+    let _ = bind_full(
         home,
         agent,
         task_id,
         branch,
         std::path::Path::new(""),
         std::path::Path::new(""),
-    );
+    )
+    .ok();
 }
 
 /// Write a full binding including worktree + source-repo paths.
@@ -27,6 +32,14 @@ pub fn bind(home: &Path, agent: &str, task_id: &str, branch: &str) {
 /// the git registry leaves a stale prunable entry after a manual `remove_dir_all`
 /// fallback. Pass an empty path when unknown — `release_full` falls back to
 /// deriving the source from the worktree path's `.worktrees/<agent>` ancestor.
+/// #779 P2 (Option B): hard-break signature now returns `Result<(), String>`
+/// so callers can surface partial-failure diagnostics. The two pre-existing
+/// silent failure points (`create_dir_all` + `atomic_write`) become explicit
+/// `Err` cases. Two non-target callers (`worktree_pool::lease`,
+/// `dispatch_auto_bind_lease`) preserve their pre-#779-P2 silent semantic
+/// via `let _ = bind_full(...).ok();` — zero observable behavior change to
+/// the dispatch path. Only `ci::handle_checkout_repo` consumes the Result
+/// to populate its new `warnings` array.
 pub fn bind_full(
     home: &Path,
     agent: &str,
@@ -34,9 +47,9 @@ pub fn bind_full(
     branch: &str,
     worktree: &std::path::Path,
     source_repo: &std::path::Path,
-) {
+) -> Result<(), String> {
     let dir = crate::paths::runtime_dir(home).join(agent);
-    std::fs::create_dir_all(&dir).ok();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create_dir_all {}: {e}", dir.display()))?;
     let path = dir.join("binding.json");
     let lock_path = dir.join(".binding.json.lock");
     let _lock = crate::store::acquire_file_lock(&lock_path);
@@ -56,7 +69,8 @@ pub fn bind_full(
         binding["source_repo"] = json!(src_str);
     }
     let body = serde_json::to_string_pretty(&binding).unwrap_or_default();
-    let _ = crate::store::atomic_write(&path, body.as_bytes());
+    crate::store::atomic_write(&path, body.as_bytes())
+        .map_err(|e| format!("atomic_write {}: {e}", path.display()))
 }
 
 /// Clear a binding for an agent (task completed/released).

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -130,14 +130,19 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
                         chrono::Utc::now().to_rfc3339()
                     ),
                 );
-                crate::binding::bind_full(
+                // #779 P2 C1 mechanical: bind_full now returns Result;
+                // preserve pre-#779-P2 silent semantic here so the call
+                // site compiles. C3 substantive commit replaces with
+                // warning collection.
+                let _ = crate::binding::bind_full(
                     home,
                     instance_name,
                     "self",
                     branch,
                     &worktree_dir,
                     &source_canonical,
-                );
+                )
+                .ok();
                 if let Some(r) = crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(
                     &source_canonical,
                 ) {

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -122,39 +122,58 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
             let mut resp =
                 json!({"path": worktree_path_str, "source": source_path, "branch": branch});
             if bind {
+                // #779 P2 Option B: collect tail-op partial failures
+                // into a `warnings` array. `bound: true` remains
+                // load-bearing (lease succeeded — the main op went
+                // through); `warnings` flags degraded daemon-side
+                // state so callers can diagnose without grepping logs.
+                // Vec ordering preserves tail-op execution order
+                // (marker → bind_full → watch_ci) for positional
+                // semantics. Prefix convention: `<step>: <message>`
+                // — machine-greppable by callers.
+                let mut warnings: Vec<String> = Vec::new();
                 let marker_path = worktree_dir.join(crate::worktree_pool::MANAGED_MARKER);
-                let _ = std::fs::write(
+                if let Err(e) = std::fs::write(
                     &marker_path,
                     format!(
                         "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
                         chrono::Utc::now().to_rfc3339()
                     ),
-                );
-                // #779 P2 C1 mechanical: bind_full now returns Result;
-                // preserve pre-#779-P2 silent semantic here so the call
-                // site compiles. C3 substantive commit replaces with
-                // warning collection.
-                let _ = crate::binding::bind_full(
+                ) {
+                    warnings.push(format!("marker: {e}"));
+                }
+                if let Err(e) = crate::binding::bind_full(
                     home,
                     instance_name,
                     "self",
                     branch,
                     &worktree_dir,
                     &source_canonical,
-                )
-                .ok();
+                ) {
+                    warnings.push(format!("bind_full: {e}"));
+                }
                 if let Some(r) = crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(
                     &source_canonical,
                 ) {
-                    let _ = handle_watch_ci(
+                    let watch_resp = handle_watch_ci(
                         home,
                         &json!({"repo": &r, "branch": branch}),
                         instance_name,
                     );
+                    if let Some(err_msg) = watch_resp.get("error").and_then(|v| v.as_str()) {
+                        let code = watch_resp
+                            .get("code")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown");
+                        warnings.push(format!("watch_ci: {err_msg} (code={code})"));
+                    }
                 }
                 resp["bound"] = json!(true);
                 resp["auto_created_branch"] = json!(auto_created_branch);
                 resp["fetch_attempted"] = json!(fetch_attempted);
+                if !warnings.is_empty() {
+                    resp["warnings"] = json!(warnings);
+                }
             }
             resp
         }
@@ -356,7 +375,18 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     }
 
     let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
-    std::fs::create_dir_all(&ci_dir).ok();
+    // #779 P2 Piece 3 site A: pre-#779-P2 swallowed dir-create errors
+    // silently and continued, returning happy-path Value even when the
+    // subsequent atomic_write was destined to fail. Now surface as
+    // structured error matching the existing `{error, code}` shape so
+    // handle_checkout_repo (and direct callers of `ci action=watch`)
+    // observe the partial-failure class.
+    if let Err(e) = std::fs::create_dir_all(&ci_dir) {
+        return json!({
+            "error": format!("ci-watches dir create failed: {e}"),
+            "code": "ci_watches_dir_create_failed",
+        });
+    }
     let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
     let watch_path = ci_dir.join(&filename);
 
@@ -438,12 +468,26 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
         watch["next_after_ci"] = json!(next);
     }
 
-    let _ = crate::store::atomic_write(
+    // #779 P2 Piece 3 site B: atomic_write failure (disk full,
+    // permission, etc.) previously surfaced as `let _ = ...` silent
+    // discard, returning happy-path Value with `watching: true` even
+    // when the watch file was never written. Now surface as structured
+    // error so callers don't act on phantom state. NOTE: site C
+    // (line ~362 `read_to_string(&watch_path).ok()`) is intentionally
+    // NOT hardened — its None case is the load-bearing fresh-watch
+    // init path; hardening there would block legitimate first
+    // subscribes.
+    if let Err(e) = crate::store::atomic_write(
         &watch_path,
         serde_json::to_string_pretty(&watch)
             .unwrap_or_default()
             .as_bytes(),
-    );
+    ) {
+        return json!({
+            "error": format!("watch file write failed: {e}"),
+            "code": "watch_write_failed",
+        });
+    }
     // Sprint 54 P0-5 (sub-scope A): response enrichment — agents see
     // CI health without polling the watch file. Read state freshly
     // from `watch` JSON we just composed; populate diagnostic fields

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -1492,3 +1492,90 @@ fn handle_watch_ci_atomic_write_failure_returns_error_field() {
 
     std::fs::remove_dir_all(&home).ok();
 }
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_watch_ci_failure_surfaces_warning() {
+    // Test 2 (depends on Piece 3 hardening landed in C3): pre-create
+    // ci-watches as a regular file. handle_watch_ci's site-A hardening
+    // returns `{error, code: ci_watches_dir_create_failed}`. handle_
+    // checkout_repo captures it into `warnings: ["watch_ci: ... (code=ci_watches_dir_create_failed)"]`.
+    // `bound: true` MUST still hold (lease succeeded).
+    let home = p778_tmp_home("779p2-watch-warn");
+    let parent = p778_tmp_home("779p2-watch-warn-src");
+    let source = p778_setup_source_repo(&parent, "feat/p779p2-watch");
+    let agent = "p779p2-agent-watch-warn";
+
+    // Block ci-watches dir create by pre-creating the path as a file.
+    let ci_watches = crate::daemon::ci_watch::ci_watches_dir(&home);
+    if let Some(p) = ci_watches.parent() {
+        std::fs::create_dir_all(p).ok();
+    }
+    std::fs::write(&ci_watches, "blocking file (not a dir)").unwrap();
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "source": source.display().to_string(),
+            "branch": "feat/p779p2-watch",
+            "bind": true,
+        }),
+        agent,
+    );
+
+    assert_eq!(
+        resp["bound"].as_bool(),
+        Some(true),
+        "lease success → bound=true must hold despite watch_ci failure: {resp}"
+    );
+    let warnings = resp["warnings"]
+        .as_array()
+        .expect("warnings array must be present when watch_ci failed");
+    let watch_warning = warnings
+        .iter()
+        .find_map(|w| w.as_str().filter(|s| s.starts_with("watch_ci:")))
+        .expect("warnings must contain a `watch_ci:` prefix entry");
+    assert!(
+        watch_warning.contains("code=ci_watches_dir_create_failed"),
+        "watch_ci warning must surface the canonical code: {watch_warning}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_no_failures_no_warnings_field() {
+    // Test 4 (back-compat invariant): clean fixture, no injection.
+    // All tail-ops succeed → `warnings` field MUST be absent (omitted)
+    // from the response. Pre-#779-P2 callers checking only `bound`/
+    // `error` keys see no payload change.
+    let home = p778_tmp_home("779p2-clean");
+    let parent = p778_tmp_home("779p2-clean-src");
+    let source = p778_setup_source_repo(&parent, "feat/p779p2-clean");
+    let agent = "p779p2-agent-clean";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "source": source.display().to_string(),
+            "branch": "feat/p779p2-clean",
+            "bind": true,
+        }),
+        agent,
+    );
+
+    assert!(
+        resp.get("error").is_none(),
+        "clean path must not error: {resp}"
+    );
+    assert_eq!(resp["bound"].as_bool(), Some(true));
+    assert!(
+        resp.get("warnings").is_none(),
+        "no failures → no `warnings` field (back-compat invariant): {resp}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -1382,3 +1382,113 @@ fn checkout_bind_false_does_not_auto_create() {
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&parent).ok();
 }
+
+// ----------------------------------------------------------------------
+// #779 P2 (Option B) — partial-failure surfacing for handle_checkout_repo
+// bind:true tail-ops + handle_watch_ci self-error surface.
+//
+// Source of truth: decision d-20260514142300613621-0.
+//
+// Empirical anchor (§3.10): comment out the warnings-collection block
+// in handle_checkout_repo OR revert the handle_watch_ci hardening at
+// site A / B → both anchor tests below fail. C2 commits these tests
+// red; C3 makes them green.
+//
+// Cross-platform: all happy-path tests `#[cfg(unix)]` per §3.7.
+// ----------------------------------------------------------------------
+
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_bind_full_failure_surfaces_warning() {
+    // ANCHOR (§3.10 red→green) — C2 red, C3 green.
+    //
+    // Injection: pre-create `<home>/runtime/<agent>` as a regular FILE
+    // (not directory). `bind_full`'s `std::fs::create_dir_all(&dir)`
+    // fails with "not a directory" → `Err("create_dir_all ...")`.
+    // handle_checkout_repo's warning-collection logic (added in C3)
+    // captures the Err and pushes "bind_full: ..." onto the warnings
+    // vec. `bound: true` must still hold because lease succeeded —
+    // tail-op degradation does not poison main success.
+    let home = p778_tmp_home("779p2-bind-fail");
+    let parent = p778_tmp_home("779p2-bind-fail-src");
+    let source = p778_setup_source_repo(&parent, "feat/p779p2-bind");
+    let agent = "p779p2-agent-bind";
+
+    // Block bind_full by pre-creating runtime/<agent> as a regular file.
+    let runtime = crate::paths::runtime_dir(&home);
+    std::fs::create_dir_all(&runtime).ok();
+    std::fs::write(runtime.join(agent), "blocking file (not a dir)").unwrap();
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "source": source.display().to_string(),
+            "branch": "feat/p779p2-bind",
+            "bind": true,
+        }),
+        agent,
+    );
+
+    assert_eq!(
+        resp["bound"].as_bool(),
+        Some(true),
+        "lease success → bound=true must hold even with tail-op partial failure: {resp}"
+    );
+    let warnings = resp["warnings"]
+        .as_array()
+        .expect("warnings array must be present when bind_full failed");
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().is_some_and(|s| s.starts_with("bind_full:"))),
+        "warnings must contain a `bind_full:` prefix entry: {resp}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn handle_watch_ci_atomic_write_failure_returns_error_field() {
+    // ANCHOR (§3.10 red→green) — C2 red, C3 green.
+    //
+    // Direct test of handle_watch_ci's NEW error surface (Piece 3
+    // hardening sites A + B). Independent of handle_checkout_repo
+    // wrapper — pins the contract that ci_watches dir-create / atomic-
+    // write failures become observable in the Value response as
+    // `error` + `code`, not silently swallowed.
+    //
+    // Injection: pre-create `<home>/ci-watches` as a regular FILE.
+    // handle_watch_ci's `std::fs::create_dir_all(&ci_dir)` (site A)
+    // fails because the path is already a file. Post-C3 returns
+    // `{error, code: "ci_watches_dir_create_failed"}`. Pre-C3 swallows
+    // the error and returns success-shape — test FAILS.
+    let home = p778_tmp_home("779p2-watch-fail");
+    std::fs::create_dir_all(&home).ok();
+
+    // Block ci-watches dir create by pre-creating the path as a file.
+    let ci_watches = crate::daemon::ci_watch::ci_watches_dir(&home);
+    if let Some(parent) = ci_watches.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::write(&ci_watches, "blocking file (not a dir)").unwrap();
+
+    let resp = super::handle_watch_ci(
+        &home,
+        &serde_json::json!({"repo": "owner/repo", "branch": "feat/p779p2-watch"}),
+        "p779p2-agent-watch",
+    );
+
+    assert!(
+        resp.get("error").is_some(),
+        "handle_watch_ci must surface error when ci-watches dir create fails: {resp}"
+    );
+    let code = resp["code"].as_str().unwrap_or_default();
+    assert!(
+        code == "ci_watches_dir_create_failed" || code == "watch_write_failed",
+        "code must be one of the canonical Piece-3 hardening codes, got '{code}': {resp}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -324,7 +324,10 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
     // Bind with worktree + source-repo paths. Bind file write error stays graceful (Q1).
     // source_repo persistence (P0-X r1): release_full uses it to run
     // `git worktree remove` from the owning repo's cwd.
-    crate::binding::bind_full(home, target, task_id, branch, &lease.path, &source_repo);
+    // #779 P2: bind_full now returns Result; this non-target caller preserves
+    // pre-#779-P2 silent semantic via `.ok()` — zero behavior change.
+    let _ =
+        crate::binding::bind_full(home, target, task_id, branch, &lease.path, &source_repo).ok();
     tracing::info!(
         %target, %branch, path = %lease.path.display(),
         "dispatch auto-bind + lease OK"

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -63,7 +63,9 @@ pub fn lease(
     // source_repo persistence (P0-X r1): release_full reads this back to run
     // `git worktree remove --force` from the owning repo's cwd, which
     // prevents stale registry entries that would block re-lease.
-    crate::binding::bind_full(home, agent, "", branch, &info.path, source_repo);
+    // #779 P2: bind_full now returns Result; this non-target caller preserves
+    // pre-#779-P2 silent semantic via `.ok()` — zero behavior change.
+    let _ = crate::binding::bind_full(home, agent, "", branch, &info.path, source_repo).ok();
 
     Ok(WorktreeLease {
         agent: agent.to_string(),


### PR DESCRIPTION
## Summary

Closes the PR #779 P2 polish flag (reviewer-opencode non-blocking review note: "`bind_full` / `handle_watch_ci` errors silently swallowed").

scope follows dispatch spec d-20260514142300613621-0

3-piece scope:
- **Piece 1 (C1)**: hard-break `bind_full -> Result<(), String>`. 3 callers migrated; 2 non-target callers (`worktree_pool::lease`, `dispatch_auto_bind_lease`) preserve pre-#779-P2 silent semantic via `let _ = bind_full(...).ok();` — zero observable behavior change to dispatch path.
- **Piece 2 (C3)**: `handle_checkout_repo` bind:true block collects tail-op partial failures into a `warnings: Vec<String>`. Attached to response only when non-empty (back-compat). `bound: true` remains load-bearing — lease success is the main op; warnings flag degraded daemon-side state.
- **Piece 3 (C3)**: `handle_watch_ci` self-harden — sites A (`create_dir_all`) + B (`atomic_write`) return `{error, code}` Value instead of silently swallowing. Site C (`read_to_string`) intentionally NOT hardened — None case is load-bearing fresh-watch init path.

## Tests (4, all `#[cfg(unix)]`)

| # | Test | Anchor | Mechanism |
|---|---|---|---|
| 1 | `checkout_bind_true_bind_full_failure_surfaces_warning` | C2 red → C3 green | pre-create `runtime/<agent>` as file → bind_full create_dir_all fails → warnings contains `bind_full:` prefix, `bound=true` preserved |
| 2 | `checkout_bind_true_watch_ci_failure_surfaces_warning` | added C3 green | pre-create `ci-watches` as file → handle_watch_ci site A errors → warnings contains `watch_ci: ... (code=ci_watches_dir_create_failed)`, `bound=true` preserved |
| 3 | `handle_watch_ci_atomic_write_failure_returns_error_field` | C2 red → C3 green | direct call with pre-created ci-watches as file → Value has `error` + `code in {ci_watches_dir_create_failed, watch_write_failed}` |
| 4 | `checkout_bind_true_no_failures_no_warnings_field` | added C3 green | clean fixture → `resp.get("warnings").is_none()` (back-compat invariant) |

## §3.10 test-first verification

- Test-first commit (red): `782ae6b` — tests 1 + 3 fail at this SHA
- Impl commit (green): `283b84f` — both pass

Reviewer verify:
```
git checkout 782ae6b && cargo test --features tray --bin agend-terminal \
  "checkout_bind_true_bind_full_failure_surfaces_warning|handle_watch_ci_atomic_write_failure"
# expect: 2 FAILED (warnings field absent; handle_watch_ci returns happy-path with watching:true)
git checkout 283b84f && (same cmd)
# expect: 2 PASSED
```

## 3-commit sequence

| # | SHA | Purpose |
|---|---|---|
| C1 | `014f208` | hard break `bind_full -> Result<()>` + migrate 3 callers (mechanical, preserve silent) |
| C2 | `782ae6b` | §3.10 anchor tests (red) — tests 1 + 3 |
| C3 | `283b84f` | substantive impl — handle_watch_ci hardening sites A+B + handle_checkout_repo warnings collection + tests 2 + 4 |

## Response shape contract (per reviewer constraint 14:18+14:21)

- `bound: true` = main success (lease succeeded). Load-bearing for callers.
- `warnings: [...]` = tail-op-degraded. Absent when no failures. Prefix convention machine-greppable: `<step>: <message>`.
- `bound=true` + `warnings=[...]` = "I have a worktree, but daemon state is partial-degraded — diagnose via warnings".

## Hardening rationale: handle_watch_ci sites A+B yes, site C no

- Site A (line 354 `create_dir_all`): hardened. Failure = parent path conflict.
- Site B (line 452 `atomic_write`): hardened. Failure = disk full / permissions / etc.
- Site C (line 362 `read_to_string(&watch_path).ok()`): **NOT hardened**. `.ok()` swallow is load-bearing — None case is fresh-watch initialization path (file legitimately doesn't exist on first subscribe). Hardening would block legitimate first subscribes.

## 3-callers migration safety (Piece 1)

- `src/worktree_pool.rs::lease` → `let _ = bind_full(...).ok();` — silent semantic preserved
- `src/mcp/handlers/dispatch_hook/mod.rs::dispatch_auto_bind_lease_with_source` → `let _ = bind_full(...).ok();` — silent semantic preserved
- `src/binding.rs::bind` (thin wrapper) → `let _ = bind_full(...).ok();` — unit-return preserved
- `src/mcp/handlers/ci/mod.rs::handle_checkout_repo` bind:true → `if let Err(e) = bind_full(...) { warnings.push(format!("bind_full: {e}")); }` — only target caller consumes the Result

**Zero observable behavior change to dispatch path.**

## Cross-platform stance

`unverified cross-backend claim` for Windows (§3.7). Happy-path tests `#[cfg(unix)]` matching #778/#780/#781 fixture convention — Windows runner git-subprocess concurrency unstable. **Backlog D** tracks Windows CI smoke test.

## Backlog impact

- ~~Backlog I~~ (handle_watch_ci silence) — **subsumed into this PR's Piece 3** per lead 14:21 Option B decision.
- Backlog H (unify `dispatch_auto_bind_lease` bind tail-ops into `DispatchOutcome.partial_failures` structured field) — unchanged from earlier dispatch.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite green (zero failures locally)
- [x] §3.10 test-first verify (C2 SHA fails, C3 SHA passes)
- [x] All 4 new tests pass + existing checkout_bind* and dispatch_auto_bind* tests pass
- [x] ZERO BYPASS workflow — `repo action=checkout bind:true` single-step provision (no manual `git branch` thanks to #780 ship); no `AGEND_GIT_BYPASS` env in any commit/push step

🤖 Generated with [Claude Code](https://claude.com/claude-code)