### PR TITLE
fix(#761): strip from: prefix in PTY header field

### DIFF
--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -2143,13 +2143,101 @@ mod tests {
         };
         let header = format_header(&msg);
         assert!(header.contains("[AGEND-MSG]"));
-        assert!(header.contains("from=from:dev-lead"));
+        // #761: `from=` field strips the redundant `from:` prefix that
+        // the agent producer adds at Source::Agent display impl.
+        assert!(header.contains("from=dev-lead"));
+        assert!(!header.contains("from=from:"));
         assert!(header.contains("id=m-42"));
         assert!(header.contains("kind=task"));
         assert!(header.contains("thread=t-100"));
         assert!(header.contains("parent=m-41"));
         assert!(header.contains("size=500"));
         assert!(!header.contains('\n'), "header must be single line");
+    }
+
+    /// #761: agent-source `from:NAME` (sole producer at the
+    /// `Source::Agent` Display impl in inbox.rs:144) gets its redundant
+    /// `from:` prefix stripped at PTY-header rendering. Pre-fix the
+    /// header read `from=from:dev-fast-1`; the double prefix confused
+    /// agents that parsed the field as identity.
+    #[test]
+    fn test_header_format_strips_from_prefix_for_agent_sources() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "from:dev-fast-1".into(),
+            text: "ping".into(),
+            kind: Some("task".into()),
+            timestamp: "2026-05-14T19:00:00Z".into(),
+            channel: None,
+            delivery_mode: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            attachments: vec![],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+            superseded_by: None,
+            from_id: None,
+            broadcast_context: None,
+            sequencing: None,
+            eta_minutes: None,
+            reporting_cadence: None,
+            worktree_binding_required: None,
+        };
+        let header = format_header(&msg);
+        assert!(
+            header.contains("from=dev-fast-1"),
+            "agent from= should drop the `from:` producer prefix: {header}"
+        );
+        assert!(
+            !header.contains("from=from:"),
+            "header must NOT carry the doubled `from=from:` form: {header}"
+        );
+    }
+
+    /// #761: non-agent sources (system events, telegram users) carry
+    /// their own namespace prefix (`system:`, `user:`) and must
+    /// survive the strip pass untouched. Only the literal `from:`
+    /// prefix from `Source::Agent` is dropped.
+    #[test]
+    fn test_header_format_preserves_system_namespace() {
+        let msg = InboxMessage {
+            schema_version: 1,
+            id: Some("m-1".into()),
+            from: "system:fleet_idle_watchdog".into(),
+            text: "ping".into(),
+            kind: Some("watchdog".into()),
+            timestamp: "2026-05-14T19:00:00Z".into(),
+            channel: None,
+            delivery_mode: None,
+            force_meta: None,
+            correlation_id: None,
+            reviewed_head: None,
+            read_at: None,
+            thread_id: None,
+            parent_id: None,
+            task_id: None,
+            attachments: vec![],
+            in_reply_to_msg_id: None,
+            in_reply_to_excerpt: None,
+            superseded_by: None,
+            from_id: None,
+            broadcast_context: None,
+            sequencing: None,
+            eta_minutes: None,
+            reporting_cadence: None,
+            worktree_binding_required: None,
+        };
+        let header = format_header(&msg);
+        assert!(
+            header.contains("from=system:fleet_idle_watchdog"),
+            "system namespace must survive untouched: {header}"
+        );
     }
 
     #[test]
@@ -2182,7 +2270,9 @@ mod tests {
             worktree_binding_required: None,
         };
         let header = format_header(&msg);
-        assert!(header.contains("from=from:agent"));
+        // #761: agent-source prefix stripped.
+        assert!(header.contains("from=agent"));
+        assert!(!header.contains("from=from:"));
         assert!(header.contains("id=m-1"));
         assert!(!header.contains("kind="));
         assert!(!header.contains("thread="));
@@ -2708,7 +2798,10 @@ mod tests {
             !header.contains('\r'),
             "header must not contain CR: {header:?}"
         );
-        assert!(header.contains("from=from:evil agent"));
+        // #761: `from:` agent prefix is stripped BEFORE sanitize, so the
+        // newline-escaped tail `evil agent` is what surfaces in the field.
+        assert!(header.contains("from=evil agent"));
+        assert!(!header.contains("from=from:"));
         assert!(header.contains("kind=task  injection"));
     }
 

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -632,9 +632,14 @@ fn sanitize_header_value(s: &str) -> String {
 /// Fields: from / id / kind / thread / parent / size.
 /// Optional fields (thread/parent) omitted when None.
 pub fn format_header(msg: &InboxMessage) -> String {
+    // #761: strip the redundant `from:` prefix that `Source::Agent`'s
+    // Display impl (inbox.rs:144) adds. `strip_prefix` returns `Some`
+    // for agent sources and `None` otherwise, so `system:` / `user:`
+    // namespaces survive untouched via the `unwrap_or` fallback.
+    let from_value = msg.from.strip_prefix("from:").unwrap_or(&msg.from);
     let mut parts = vec![
         HEADER_PREFIX.to_string(),
-        format!("from={}", sanitize_header_value(&msg.from)),
+        format!("from={}", sanitize_header_value(from_value)),
     ];
     if let Some(ref id) = msg.id {
         parts.push(format!("id={}", sanitize_header_value(id)));


### PR DESCRIPTION
## Summary

Removes the redundant `from:` prefix from the `[AGEND-MSG]` PTY header's `from=` field for agent-source messages. Pre-fix:

```
[AGEND-MSG] from=from:dev-fast-1 id=m-1 kind=task size=4
                  ^^^^ doubled
```

Post-fix:

```
[AGEND-MSG] from=dev-fast-1 id=m-1 kind=task size=4
```

System / user namespaces (e.g. `system:fleet_idle_watchdog`, `user:telegram_user`) are untouched.

Closes #761
scope follows dispatch spec d-20260514195045953221-8

## Source enum confirmation

The `from:` prefix has a single producer at `src/inbox.rs:144`:

```rust
Self::Agent(name) => write!(f, "from:{name}"),
```

`Source::System(_)` writes `system:<subsystem>`, `Source::User(_)` writes `user:<name>`. So `strip_prefix("from:")` removes exactly the agent producer's namespace and falls back to the raw value for any other producer.

## Cross-prefix safety — bracket form untouched

There are TWO independent prefix surfaces in the codebase. This fix only touches one:

| Surface | Constant | Producer | Touched by this PR? |
|---|---|---|---|
| AGEND-MSG header field | n/a | `format_header` `from=` | **YES** — fix here |
| Bracketed line prefix | `AGENT_MSG_PREFIX = "[from:"` (inbox.rs:622) | TUI render path | **NO** — unchanged |

The bracket form `[from:NAME]` is used by `src/agent.rs:1423-1424` for detecting agent-sourced lines in the PTY output stream. Agent training docs at `src/instructions.rs:299` refer to the bracket form, not the `from=` field. These surfaces are independent. Verified by `rg "parse.*from=" src/` → 0 hits (no code parses the `from=` field back).

## Cross-platform tests rationale

Pure string manipulation — no filesystem, no subprocess, no platform-specific behavior. All 5 tests run unconditionally (no `#[cfg(unix)]` gating), per #785 / #786 / #790 precedent.

## §3.10 RED / GREEN pair

| Phase | Commit | Status |
|---|---|---|
| RED | `9394aac` | 4 of 5 tests fail; 1 passes coincidentally (system-namespace path unaffected by bug) |
| GREEN | `61956ba` | All 5 tests pass after 1-line `strip_prefix` fix |

### RED signature captured
```
thread 'test_header_format_strips_from_prefix_for_agent_sources' panicked:
  agent from= should drop the `from:` producer prefix:
  [44;97m[AGEND-MSG][0m from=from:dev-fast-1 id=m-1 kind=task size=4
```

## Pieces shipped

- `src/inbox.rs:637` (now :641 after comment): `strip_prefix("from:").unwrap_or(&msg.from)` — 1 substantive line + 4-line `// #761:` comment
- 3 existing assertion updates (inbox.rs:2148, 2188, 2802) — pinned to new contract + negative assertions
- 2 new tests (`test_header_format_strips_from_prefix_for_agent_sources`, `test_header_format_preserves_system_namespace`)
- ~96 LOC total in RED commit + 6 LOC in GREEN commit (most LOC is full `InboxMessage` struct literals for symmetry with surrounding tests)

## Hard rules followed

- ZERO BYPASS — `repo action=checkout bind:true` single-step
- Strip exactly `"from:"` (sole agent producer per Source enum confirmation)
- `system:` / `user:` namespaces preserved untouched
- Bracketed `[from:NAME]` form (TUI render) not modified
- Agent training docs (`instructions.rs:305-308`) not modified
- All 5 tests cross-platform — no `#[cfg(unix)]` gating

## Test plan

- [x] `cargo test test_header_format` — 10/10 passing
- [x] `cargo test test_format_header` — 2/2 passing
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] Full suite `cargo test --features tray --bin agend-terminal` — 2205 passed, 7 ignored (pre-existing), 0 failed
- [ ] CI green on ubuntu/macos/windows

correlation_id: t-2026-05-14-fixup-backlog
task: t-20260514194737056510-10
decision: d-20260514195045953221-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)