### PR TITLE
fix(#773): poll-until-parseable for sleep PID file (test flake)

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -113,18 +113,32 @@ mod tests {
                 .expect("spawn sh + sleep")
         };
         let shell_pid = child.id();
-        // Wait for sleep to start and write its PID
-        for _ in 0..20 {
-            if pid_file.exists() {
-                break;
+        // #773: poll until the PID file BOTH exists AND parses as a u32.
+        // `pid_file.exists()` flips true the moment the shell opens the
+        // file for writing — before `echo $! > file` flushes its content
+        // — so the previous `for _ in 0..20 { if pid_file.exists() }`
+        // loop could exit early and the subsequent `parse()` panic with
+        // `ParseIntError { kind: Empty }` on an empty / partial read.
+        // The combined budget (5s = 100 × 50ms) covers both spawn
+        // latency AND write-flush race on a contended CI runner.
+        let sleep_pid: u32 = {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            loop {
+                if let Ok(content) = std::fs::read_to_string(&pid_file) {
+                    if let Ok(pid) = content.trim().parse::<u32>() {
+                        break pid;
+                    }
+                }
+                if std::time::Instant::now() >= deadline {
+                    let last = std::fs::read_to_string(&pid_file).unwrap_or_default();
+                    panic!(
+                        "PID file never materialized with parseable content after 5s; \
+                         last read: {last:?}"
+                    );
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
             }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
-        let sleep_pid: u32 = std::fs::read_to_string(&pid_file)
-            .unwrap_or_default()
-            .trim()
-            .parse()
-            .expect("parse sleep PID");
+        };
         assert!(is_pid_alive(shell_pid), "shell must be alive before kill");
         assert!(
             is_pid_alive(sleep_pid),


### PR DESCRIPTION
## Summary

Replace the existing exists()-then-parse pattern in `test_kill_process_tree_kills_child_subprocess` with a poll-until-parseable loop. Catches both spawn-latency AND write-flush race in a uniform 5s budget.

Closes #773
scope follows dispatch spec d-20260514201420821098-9

## Test-only fix — no production code change

Modification is confined to `src/process.rs:117-141` inside the `#[cfg(test)] #[cfg(unix)] mod tests` block. `kill_process_tree` and all production paths are untouched.

## Root cause + (a)+(e) rationale

The previous loop exited on `pid_file.exists()`, which flips true the moment the shell opens the file via `echo $! > file`. The actual `write()` + flush of the PID happens **after** open. On a contended ubuntu-latest runner, the test could read empty / partial content and `parse().expect("parse sleep PID")` panicked with:

```
thread '...test_kill_process_tree_kills_child_subprocess...' panicked at
  src/process.rs:127:14:
  parse sleep PID: ParseIntError { kind: Empty }
```

**Option (a) alone (extend poll budget)** wouldn't fix this — increasing the loop count still exits on `exists()` before content lands. **Option (e) (poll-until-parseable)** is required to handle the write-flush race. The combined fix uses both: 5s deadline (100 × 50ms iterations) covers spawn latency AND post-open write-flush race.

## `harness::wait_until` cross-crate concern

Two candidates exist:
- `tests/integration.rs:10` — free fn `wait_until`
- `tests/common/harness.rs` — `AgendHarness::wait_for` method

Both live in the **integration test crate**, separate compilation unit from `src/`. `src/process.rs`'s inline `mod tests` cannot import them without:
1. Promoting `wait_until` to a `src/test_harness.rs` (or similar), adding `#[cfg(test)]`-gated public surface area
2. Or duplicating the helper inline (what this PR does)

For a 15-LOC test-only fix at a single site, inline polling keeps surface area minimal. If a 2nd site emerges, refactor to a shared helper would be warranted.

## Diagnostic enrichment

On deadline expiry, the panic message now includes the last observed file content:

```rust
panic!(
    "PID file never materialized with parseable content after 5s; \
     last read: {last:?}"
);
```

If a future flake survives the 5s budget (extremely unlikely but possible under pathological CI load), the panic carries actionable diagnostics — operator sees the exact byte content present at deadline, not just a generic timeout message.

## Cross-platform stance

`#[cfg(unix)]` gate preserved. The test uses:
- `std::os::unix::process::CommandExt::pre_exec` 
- `libc::setsid()`
- shell idiom `sleep 60 & echo $! > {} && wait` (bash/sh)
- `kill_process_tree` itself uses `libc::kill` on negative pgid (unix process group semantics)

Windows path exists at `process.rs:86-89` via `terminate(pid)` but no analogous test — by design, not a gap.

## Soak criterion (mirror #772)

**0 occurrences** of `panicked at .*process.rs.* parse sleep PID` OR `ParseIntError { kind: Empty }` signature in process.rs tests in **next 5 fixup PRs OR 7 days**. If recurrence → reopen, escalate to layer (b) named pipe synchronization or layer (d) atomic mktemp+rename via shell.

## Test plan

- [x] `cargo test test_kill_process_tree_kills_child_subprocess` — 1/1 passing
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] Full suite `cargo test --features tray --bin agend-terminal` — 2205 passed, 7 ignored (pre-existing), 0 failed
- [ ] CI green on ubuntu/macos/windows

correlation_id: t-2026-05-14-fixup-backlog
task: t-20260514201205234657-11
decision: d-20260514201420821098-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)