### PR TITLE
fix(#772 v3): cache-bin:false to prevent stale rustup-init pollution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,49 +28,30 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      # #772 v3 (root-cause prevention): Swatinem/rust-cache@v2 by
+      # default caches `~/.cargo/bin/` along with the rest of cargo
+      # state. The cache write occasionally captures a stale
+      # `rustup-init` shim at proxy paths (cargo, rustc, rustfmt,
+      # clippy-driver); subsequent restores then overwrite the freshly-
+      # installed dtolnay rustup proxies with that stale shim. Symptom
+      # is `cargo fmt → unexpected argument 'fmt' found / Usage:
+      # rustup-init` (signature documented across PRs #796, #799, #800).
+      #
+      # v1 (PR #796): post-cache bootstrap step relying on exit codes —
+      # bypassed because `rustup-init --version` returns exit 0.
+      # v2 (PR #800 r0): content-validating detect+recover — detection
+      # confirmed staleness on all 3 platforms (universal cache pollution,
+      # not macos-specific!), but recovery failed (`rustup default` does
+      # not regenerate deleted proxies in ~/.cargo/bin/).
+      # v3 (this commit): don't enter the bad state in the first place.
+      # `cache-bin: false` tells Swatinem/rust-cache@v2 to exclude
+      # `~/.cargo/bin/` from the cache. dtolnay/rust-toolchain@stable
+      # then installs fresh proxies every run. Cost: ~1MB cache miss
+      # and ~5-10s install per run, negligible vs the detect+recover
+      # logic v2 attempted to maintain.
       - uses: Swatinem/rust-cache@v2
-      # #772 v2 (replaces v1 from PR #796): content-validating proxy check
-      # with auto-invalidation. v1 bootstrap step (`rustup show && rustc
-      # --version && cargo --version`) relied on EXIT CODES — but the
-      # stale `rustup-init` binary in `~/.cargo/bin/cargo` responds to
-      # `--version` with `rustup-init 1.29.0` exit-0, defeating the
-      # check. PR #799's macos saga (3 reruns over ~3hr) confirmed the
-      # detection gap.
-      #
-      # v2 validates output CONTENT (must start with the tool's own name)
-      # for ALL 4 proxies the workflow invokes (cargo + rustc + rustfmt +
-      # clippy-driver) and auto-invalidates stale cache binaries when
-      # mismatch detected. `LC_ALL=C` reduces locale-format risk.
-      # `shell: bash` required — for-loop syntax is bash-only and
-      # windows-latest defaults to PowerShell.
-      #
-      # On recovery: surgical 6-binary `rm` preserves `rustup` itself
-      # (so we can re-install). After `rustup default stable` + component
-      # add, `rustup show` forces proxy refresh. Final invariant loop
-      # hard-fails if any proxy is still broken.
-      #
-      # DO NOT remove or move before rust-cache without addressing #772
-      # root cause (cache-overwrite of toolchain binaries).
-      - name: Force toolchain bootstrap (mitigates macOS rustup-init transient #772 v2)
-        shell: bash
-        run: |
-          needs_recovery=0
-          for tool in cargo rustc rustfmt clippy-driver; do
-            if ! LC_ALL=C "$tool" --version 2>&1 | grep -qE "^${tool} [0-9]"; then
-              echo "::warning::Stale binary at ~/.cargo/bin/$tool ($(LC_ALL=C "$tool" --version 2>&1 | head -1)); will invalidate"
-              needs_recovery=1
-            fi
-          done
-          if [ "$needs_recovery" = "1" ]; then
-            rm -rf ~/.cargo/bin/cargo ~/.cargo/bin/rustc ~/.cargo/bin/rustfmt ~/.cargo/bin/clippy-driver ~/.cargo/bin/cargo-fmt ~/.cargo/bin/cargo-clippy
-            rustup default stable
-            rustup component add rustfmt clippy
-            rustup show
-          fi
-          for tool in cargo rustc rustfmt clippy-driver; do
-            LC_ALL=C "$tool" --version 2>&1 | grep -qE "^${tool} [0-9]" \
-              || { echo "::error::$tool proxy still broken after recovery: $(LC_ALL=C "$tool" --version 2>&1 | head -1)"; exit 1; }
-          done
+        with:
+          cache-bin: false
 
       # tray-icon / tao on Linux link against GTK3 + the ayatana app-
       # indicator — these come from `libgtk-3-dev` (provides glib-2.0.pc,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,30 +29,48 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      # #772: force toolchain bootstrap AFTER rust-cache restore.
-      # Symptom: `cargo fmt` on macos-latest resolves to `rustup-init`
-      # (signature: `error: unexpected argument 'fmt' found / Usage:
-      # rustup-init[EXE] [OPTIONS]`).
-      # Root cause: `Swatinem/rust-cache@v2` caches `~/.cargo/bin/`. A
-      # prior failed bootstrap can leave a stale rustup-init binary
-      # there; cache restore on a subsequent run **overwrites** the
-      # freshly-installed rustup proxy with that stale binary. r0 of
-      # this fix placed the bootstrap step BEFORE rust-cache and got
-      # immediately undone by the cache restore (#796 r1).
-      # Mitigation: run bootstrap AFTER cache restore so any stale
-      # binaries get overwritten by the freshly-bootstrapped ones.
-      # `rustup show` triggers install; `rustc --version` +
-      # `cargo --version` hard-assert the proxy is verifiably-backed
-      # end-to-end before any cargo invocation runs. Cheap on
-      # ubuntu/windows; pays ~30-60s on cold macOS bootstrap where
-      # the bug fires. Single insertion covers all 3 matrix platforms.
-      # DO NOT remove or move before rust-cache without addressing
-      # #772 root cause (cache-overwrite of toolchain binaries).
-      - name: Force toolchain bootstrap (mitigates macOS rustup-init transient #772)
+      # #772 v2 (replaces v1 from PR #796): content-validating proxy check
+      # with auto-invalidation. v1 bootstrap step (`rustup show && rustc
+      # --version && cargo --version`) relied on EXIT CODES — but the
+      # stale `rustup-init` binary in `~/.cargo/bin/cargo` responds to
+      # `--version` with `rustup-init 1.29.0` exit-0, defeating the
+      # check. PR #799's macos saga (3 reruns over ~3hr) confirmed the
+      # detection gap.
+      #
+      # v2 validates output CONTENT (must start with the tool's own name)
+      # for ALL 4 proxies the workflow invokes (cargo + rustc + rustfmt +
+      # clippy-driver) and auto-invalidates stale cache binaries when
+      # mismatch detected. `LC_ALL=C` reduces locale-format risk.
+      # `shell: bash` required — for-loop syntax is bash-only and
+      # windows-latest defaults to PowerShell.
+      #
+      # On recovery: surgical 6-binary `rm` preserves `rustup` itself
+      # (so we can re-install). After `rustup default stable` + component
+      # add, `rustup show` forces proxy refresh. Final invariant loop
+      # hard-fails if any proxy is still broken.
+      #
+      # DO NOT remove or move before rust-cache without addressing #772
+      # root cause (cache-overwrite of toolchain binaries).
+      - name: Force toolchain bootstrap (mitigates macOS rustup-init transient #772 v2)
+        shell: bash
         run: |
-          rustup show
-          rustc --version
-          cargo --version
+          needs_recovery=0
+          for tool in cargo rustc rustfmt clippy-driver; do
+            if ! LC_ALL=C "$tool" --version 2>&1 | grep -qE "^${tool} [0-9]"; then
+              echo "::warning::Stale binary at ~/.cargo/bin/$tool ($(LC_ALL=C "$tool" --version 2>&1 | head -1)); will invalidate"
+              needs_recovery=1
+            fi
+          done
+          if [ "$needs_recovery" = "1" ]; then
+            rm -rf ~/.cargo/bin/cargo ~/.cargo/bin/rustc ~/.cargo/bin/rustfmt ~/.cargo/bin/clippy-driver ~/.cargo/bin/cargo-fmt ~/.cargo/bin/cargo-clippy
+            rustup default stable
+            rustup component add rustfmt clippy
+            rustup show
+          fi
+          for tool in cargo rustc rustfmt clippy-driver; do
+            LC_ALL=C "$tool" --version 2>&1 | grep -qE "^${tool} [0-9]" \
+              || { echo "::error::$tool proxy still broken after recovery: $(LC_ALL=C "$tool" --version 2>&1 | head -1)"; exit 1; }
+          done
 
       # tray-icon / tao on Linux link against GTK3 + the ayatana app-
       # indicator — these come from `libgtk-3-dev` (provides glib-2.0.pc,


### PR DESCRIPTION
## Summary

**v3 architectural pivot** — root-cause prevention via `cache-bin: false` on `Swatinem/rust-cache@v2`, replacing v1's exit-code check (PR #796) and v2's detect+recover attempt (this PR's r0 commit `51a5f34`).

Amends #772. The fix simply excludes `~/.cargo/bin/` from cache restoration so `dtolnay/rust-toolchain@stable` installs fresh proxies every run. No detect+recover shell logic to maintain.

## Three-version history

| Version | Approach | Outcome |
|---|---|---|
| v1 (#796) | Post-cache bootstrap `rustup show && cargo --version` | **Bypassed** — `rustup-init --version` returns exit 0 (caught by PR #799 macos saga, 3 reruns) |
| v2 (#800 r0) | Content-validating detect+recover (`grep -q "^${tool} [0-9]"` + rm + rustup default) | **Detection worked, recovery failed** — `rustup default` doesn't regenerate deleted proxies. Also false-positived on `clippy-driver` (outputs `clippy 0.1.95`, not `clippy-driver ...`) |
| **v3 (this PR)** | **`cache-bin: false`** — exclude `~/.cargo/bin/` from cache | **Don't enter the bad state in the first place** |

## v2 architectural lesson

PR #800 r0 CI evidence (commit `51a5f34`):

```
##[warning]Stale binary at ~/.cargo/bin/cargo (rustup-init 1.29.0 ...)
##[warning]Stale binary at ~/.cargo/bin/rustc (rustup-init 1.29.0 ...)
##[warning]Stale binary at ~/.cargo/bin/rustfmt (rustup-init 1.29.0 ...)
##[warning]Stale binary at ~/.cargo/bin/clippy-driver (rustup-init 1.29.0 ...)
info: default toolchain set to stable-aarch64-apple-darwin
##[error]cargo proxy still broken after recovery: cargo: command not found
```

Important findings from v2:
1. **Cache pollution is UNIVERSAL across platforms**, not just macos — v1 hid this for ubuntu/windows because their proxies happened to be exit-0 on `--version` despite being wrong binaries.
2. **`rustup default` does NOT regenerate deleted proxies** — rustup considers the toolchain "already installed" and skips proxy creation.
3. **Detect+recover is the wrong abstraction layer** — defending against a known bad cache state is fragile; preventing entry to that state is robust.

## v3 simplicity rationale

Single 1-line change vs ~50 LOC of shell:

```yaml
- uses: Swatinem/rust-cache@v2
  with:
    cache-bin: false
```

- No shell logic to maintain
- No false-positive risk on tool naming quirks (e.g. clippy-driver/clippy mismatch)
- No platform-specific recovery paths (rm + cp + reinstall edge cases)
- Cost: ~1MB cache miss + ~5-10s fresh-install per run = negligible vs 3-platform breakage observed in r0

## Validation — this PR's own CI run

If `cache-bin: false` correctly excludes `~/.cargo/bin/`:
- `dtolnay/rust-toolchain@stable` installs fresh proxies every run
- No stale `rustup-init` shim can pollute the cache
- All 3 platforms CLEAN GREEN

## Soak criterion (mirror #772 v1)

- **Primary**: 0 occurrences of `cargo fmt → unexpected argument 'fmt'` / `Usage: rustup-init` in macOS jobs across **next 5 fixup PRs OR 7 days, whichever first**
- v2's "bonus" criterion removed (no detect+recover loop to fire warnings)
- If recurrence → reconsider full toolchain-cache exclusion or pin rustup-init version

## Hard rules followed

- ZERO BYPASS — daemon-mediated git only
- No amend, no force push (history is r0 broken commit + r1 fix; squash-merge collapses to clean main)
- CI infra only — no source / test / docs changes
- Single-line semantic change (with 20 lines of inline rationale comment documenting v1→v2→v3 evolution)

## Test plan

- [x] r0 detection mechanism validated (universal cache pollution proven, see r0 commit log)
- [ ] CI green on ubuntu/macos/windows under v3 (`cache-bin: false`)

## Commits on branch
- `51a5f34` — fix(#772 v2): content-validating proxy check + auto-invalidation (r0, ARCHIVED — recovery failed)
- `70c4644` — fix(#772 v3): cache-bin:false to prevent ~/.cargo/bin stale-shim pollution

Squash-merge will produce a single clean commit on main with the v3 framing.

correlation_id: t-2026-05-14-fixup-backlog
task: t-20260514231257578720-0
decision: d-20260514231644927338-0 (supersedes recovery section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)