### PR TITLE
fix(#783): opencode mouse scroll works in multi-pane via cursor-position routing

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -874,6 +874,31 @@ fn write_to_focused(home: &Path, layout: &mut Layout, registry: &AgentRegistry, 
     }
 }
 
+/// #783: write bytes to a SPECIFIC pane by id, bypassing focus. Used by
+/// the mouse-forward path so the SGR report reaches the pane under the
+/// cursor (e.g. opencode in a non-focused split) instead of the focused
+/// pane. Shares the same submit-detection bookkeeping as
+/// `write_to_focused` since the byte stream eventually lands at the
+/// same `Pane::write_input` sink.
+fn write_to_pane(
+    home: &Path,
+    layout: &mut Layout,
+    registry: &AgentRegistry,
+    pane_id: usize,
+    bytes: &[u8],
+) {
+    if let Some(pane) = layout
+        .active_tab_mut()
+        .and_then(|t| t.root_mut().find_pane_mut(pane_id))
+    {
+        notification_queue::record_input_activity(home, &pane.agent_name);
+        if pane_input_contains_submit(pane.backend.as_ref(), bytes) {
+            notification_queue::record_submit_activity(home, &pane.agent_name);
+        }
+        pane.write_input(registry, bytes);
+    }
+}
+
 /// Sprint 54 P2-3: backend-aware submit detection. Returns true iff
 /// the backend is on the submit-detection allowlist AND the keystroke
 /// buffer contains its submit key. Hard-coded claude-only first round

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -54,12 +54,14 @@ pub(super) fn handle(
     // held, forward the event as SGR mouse report to the PTY instead of local
     // handling. The routing decision lives in `pane_for_mouse_forward` so it
     // can be unit-tested without the PTY write side-effect.
-    // §3.10 RED: `pane_id` is destructured for the C2 GREEN refactor where
-    // it routes writes to the cursor-target pane. Until then, the write
-    // still goes through `write_to_focused`.
-    if let Some((_pane_id, inner_x, inner_y)) = pane_for_mouse_forward(layout, &mouse) {
+    // #783: route the SGR write to the cursor-target pane (which is not
+    // necessarily the focused pane). `pane_for_mouse_forward` returns the
+    // pane id under the cursor that wants mouse + SGR; we then call
+    // `write_to_pane` (sibling of `write_to_focused`) to deliver bytes to
+    // that specific pane's PTY.
+    if let Some((pane_id, inner_x, inner_y)) = pane_for_mouse_forward(layout, &mouse) {
         if let Some(encoded) = crate::mouse_forward::encode_sgr(&mouse, inner_x, inner_y) {
-            super::write_to_focused(&crate::home_dir(), layout, registry, &encoded);
+            super::write_to_pane(&crate::home_dir(), layout, registry, pane_id, &encoded);
             return out;
         }
     }
@@ -478,9 +480,10 @@ fn pane_for_mouse_forward(layout: &Layout, mouse: &MouseEvent) -> Option<(usize,
         return None;
     }
     let tab = layout.active_tab()?;
-    // §3.10 RED: still focus-only. §3.10 GREEN replaces with
-    // `tab.pane_at(mouse.column, mouse.row)`.
-    let pane_id = tab.focus_id;
+    // #783: look up the pane UNDER THE CURSOR, not the focused one.
+    // Pre-fix used `tab.focus_id`, which broke multi-pane scenarios where
+    // the wants_mouse pane (opencode) was not focused.
+    let pane_id = tab.pane_at(mouse.column, mouse.row)?;
     let pane = tab.root().find_pane(pane_id)?;
     if !pane.vterm.wants_mouse() || !pane.vterm.mouse_sgr() {
         return None;

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -50,42 +50,17 @@ pub(super) fn handle(
 ) -> MouseOutcome {
     let mut out = MouseOutcome::default();
 
-    // #700: If focused pane's terminal wants mouse events AND shift is not held,
-    // forward the event as SGR mouse report to the PTY instead of local handling.
-    if !mouse
-        .modifiers
-        .contains(crossterm::event::KeyModifiers::SHIFT)
-    {
-        if let Some(tab) = layout.active_tab() {
-            if let Some(pane) = tab.focused_pane() {
-                if pane.vterm.wants_mouse() && pane.vterm.mouse_sgr() {
-                    let pane_id = tab.focus_id;
-                    if let Some(&(px, py, pw, ph)) = tab.pane_rects.get(&pane_id) {
-                        let inner_x = px + 1;
-                        let inner_y = py + 1;
-                        let inner_w = pw.saturating_sub(2);
-                        let inner_h = ph.saturating_sub(2);
-                        // Only forward if cursor is inside pane content area
-                        if mouse.column >= inner_x
-                            && mouse.column < inner_x + inner_w
-                            && mouse.row >= inner_y
-                            && mouse.row < inner_y + inner_h
-                        {
-                            if let Some(encoded) =
-                                crate::mouse_forward::encode_sgr(&mouse, inner_x, inner_y)
-                            {
-                                super::write_to_focused(
-                                    &crate::home_dir(),
-                                    layout,
-                                    registry,
-                                    &encoded,
-                                );
-                                return out;
-                            }
-                        }
-                    }
-                }
-            }
+    // #700 + #783: If a pane's terminal wants mouse events AND shift is not
+    // held, forward the event as SGR mouse report to the PTY instead of local
+    // handling. The routing decision lives in `pane_for_mouse_forward` so it
+    // can be unit-tested without the PTY write side-effect.
+    // §3.10 RED: `pane_id` is destructured for the C2 GREEN refactor where
+    // it routes writes to the cursor-target pane. Until then, the write
+    // still goes through `write_to_focused`.
+    if let Some((_pane_id, inner_x, inner_y)) = pane_for_mouse_forward(layout, &mouse) {
+        if let Some(encoded) = crate::mouse_forward::encode_sgr(&mouse, inner_x, inner_y) {
+            super::write_to_focused(&crate::home_dir(), layout, registry, &encoded);
+            return out;
         }
     }
 
@@ -485,6 +460,47 @@ pub(super) fn copy_to_clipboard(text: &str) {
     }
 }
 
+/// #783: pick the pane that should receive an SGR mouse-forward for this
+/// event, returning the pane id plus the inner top-left of that pane in
+/// terminal coordinates. Returns `None` when the event should fall
+/// through to local TUI handling (shift held, no pane under cursor, the
+/// pane's terminal does not want mouse, or cursor sits on the border).
+///
+/// Pre-fix (#700) consulted only the focused pane, which broke #783's
+/// multi-pane case (opencode in a non-focused split). The §3.10 GREEN
+/// commit switches the lookup to `tab.pane_at(col, row)` so the pane
+/// UNDER the cursor handles its own mouse events regardless of focus.
+fn pane_for_mouse_forward(layout: &Layout, mouse: &MouseEvent) -> Option<(usize, u16, u16)> {
+    if mouse
+        .modifiers
+        .contains(crossterm::event::KeyModifiers::SHIFT)
+    {
+        return None;
+    }
+    let tab = layout.active_tab()?;
+    // §3.10 RED: still focus-only. §3.10 GREEN replaces with
+    // `tab.pane_at(mouse.column, mouse.row)`.
+    let pane_id = tab.focus_id;
+    let pane = tab.root().find_pane(pane_id)?;
+    if !pane.vterm.wants_mouse() || !pane.vterm.mouse_sgr() {
+        return None;
+    }
+    let &(px, py, pw, ph) = tab.pane_rects.get(&pane_id)?;
+    let inner_x = px + 1;
+    let inner_y = py + 1;
+    let inner_w = pw.saturating_sub(2);
+    let inner_h = ph.saturating_sub(2);
+    if mouse.column >= inner_x
+        && mouse.column < inner_x + inner_w
+        && mouse.row >= inner_y
+        && mouse.row < inner_y + inner_h
+    {
+        Some((pane_id, inner_x, inner_y))
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -510,6 +526,107 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
         }
+    }
+
+    fn scroll_up_at(column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind: MouseEventKind::ScrollUp,
+            column,
+            row,
+            modifiers: KeyModifiers::empty(),
+        }
+    }
+
+    /// Opencode mouse-on startup: 1000h + 1002h + 1003h enable a tracking
+    /// mode (`wants_mouse`); 1006h selects SGR encoding (`mouse_sgr`).
+    /// Matches the sequence pinned in `vterm::tests::wants_mouse_matches_opencode_startup_sequence`.
+    fn enable_opencode_mouse(pane: &mut Pane) {
+        pane.vterm
+            .process(b"\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h");
+    }
+
+    /// #783 §3.10 anchor — in a multi-pane tab, mouse-forwarding must
+    /// target the pane UNDER the cursor, not the focused pane. The
+    /// pre-fix `tab.focused_pane()` lookup skipped SGR forwarding when
+    /// the wants_mouse pane (opencode in right split) was not focused;
+    /// the operator's scroll then fell through to the local TUI scroll
+    /// handler. This test pins the contract by asserting the routing
+    /// decision itself.
+    ///
+    /// RED on the §3.10 RED commit: `pane_for_mouse_forward` still uses
+    /// `tab.focus_id`, so the focused (no-mouse) pane gets the lookup
+    /// and returns `None`. Asserting `Some(2, _, _)` fails.
+    /// GREEN after the cursor-lookup refactor.
+    #[test]
+    fn pane_for_mouse_forward_targets_pane_under_cursor_not_focused() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("multi".to_string(), leaf(1, "left")));
+        layout.tabs[0].split_focused(SplitDir::Vertical, leaf(2, "opencode"));
+        layout.active = 0;
+        // Focus the LEFT pane (id=1); opencode lives in RIGHT pane (id=2).
+        layout.tabs[0].focus_id = 1;
+
+        // Layout rects: Pane 1 at (0,1)-(10,11), Pane 2 at (10,1)-(20,11).
+        layout.tabs[0].pane_rects.insert(1, (0, 1, 10, 10));
+        layout.tabs[0].pane_rects.insert(2, (10, 1, 10, 10));
+
+        // Pane 2 (right, NOT focused) is the opencode pane wanting mouse.
+        enable_opencode_mouse(layout.tabs[0].root_mut().find_pane_mut(2).unwrap());
+
+        // Mouse scroll over the RIGHT pane interior (column 15, row 5).
+        let mouse = scroll_up_at(15, 5);
+
+        let routed = super::pane_for_mouse_forward(&layout, &mouse);
+        assert_eq!(
+            routed.map(|(id, _, _)| id),
+            Some(2),
+            "mouse over right opencode pane must route there regardless of focus; got {routed:?}"
+        );
+    }
+
+    /// #783 invariant — when no pane under the cursor wants mouse,
+    /// `pane_for_mouse_forward` returns `None` so the event falls through
+    /// to local TUI handling. Pins that the cursor-lookup refactor does
+    /// not change behavior for non-opencode panes.
+    #[test]
+    fn pane_for_mouse_forward_returns_none_when_target_pane_lacks_mouse() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("multi".to_string(), leaf(1, "left")));
+        layout.tabs[0].split_focused(SplitDir::Vertical, leaf(2, "right"));
+        layout.active = 0;
+        layout.tabs[0].focus_id = 1;
+        layout.tabs[0].pane_rects.insert(1, (0, 1, 10, 10));
+        layout.tabs[0].pane_rects.insert(2, (10, 1, 10, 10));
+        // No `enable_opencode_mouse` — neither pane wants mouse.
+
+        let mouse = scroll_up_at(15, 5);
+        assert!(
+            super::pane_for_mouse_forward(&layout, &mouse).is_none(),
+            "no pane wants mouse → fall through to local scroll handling"
+        );
+    }
+
+    /// #783 regression-guard — single-pane case must keep working
+    /// (post-#700/#739/#741/#744 wants_mouse path). The cursor-lookup
+    /// refactor must not regress the single-pane scenario where focused
+    /// == under-cursor.
+    #[test]
+    fn pane_for_mouse_forward_single_pane_with_mouse_still_routes() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("single".to_string(), leaf(1, "opencode")));
+        layout.active = 0;
+        layout.tabs[0].focus_id = 1;
+        layout.tabs[0].pane_rects.insert(1, (0, 1, 20, 10));
+
+        enable_opencode_mouse(layout.tabs[0].root_mut().find_pane_mut(1).unwrap());
+
+        let mouse = scroll_up_at(10, 5);
+        let routed = super::pane_for_mouse_forward(&layout, &mouse);
+        assert_eq!(
+            routed.map(|(id, _, _)| id),
+            Some(1),
+            "single-pane opencode tab must still route mouse to that pane"
+        );
     }
 
     fn up_event() -> MouseEvent {


### PR DESCRIPTION
## Summary

Multi-pane mouse scroll over opencode pane was falling through to local TUI scroll handling instead of forwarding SGR to opencode's PTY. The mouse-forward path at `src/app/mouse.rs:60` consulted `tab.focused_pane()`, so when the operator focused a non-opencode pane and scrolled over the opencode split, the focused pane's `wants_mouse()` returned false and the entire forward block was skipped.

Switching the lookup to `tab.pane_at(mouse.column, mouse.row)` makes the pane UNDER the cursor handle its own mouse events regardless of focus. The SGR write now goes through a new `write_to_pane(pane_id, ...)` helper that bypasses focus.

Closes #783
scope follows dispatch spec d-20260515000221472380-1

## Operator validation checklist

Reviewers / operator: please verify by running the app and manually:

- [ ] **Single-pane opencode tab**: scroll still works (regression guard for #700/#739/#741/#744 path — must not regress single-pane behavior)
- [ ] **Multi-pane opencode tab**: scroll works in opencode pane regardless of focus (this is the bug — needs operator-attended UX validation since auto-tests cover routing decisions but not the real PTY+visual loop)
- [ ] **Multi-pane non-opencode panes**: scroll behavior unchanged (no spillover — sibling pane scrolling does not affect opencode's content)

## Bug at source

Pre-fix `src/app/mouse.rs:53-90`:

```rust
if let Some(tab) = layout.active_tab() {
    if let Some(pane) = tab.focused_pane() {       // ← BUG: focused only
        if pane.vterm.wants_mouse() && pane.vterm.mouse_sgr() {
            let pane_id = tab.focus_id;            // ← uses focused id
            // ... cursor-rect check + SGR encode + write_to_focused ...
        }
    }
}
```

Single-pane works because focused == under-cursor. Multi-pane breaks when:
1. wants_mouse pane (opencode) is NOT focused (e.g. operator focused the left split, opencode is right)
2. operator mouse-scrolls over the opencode pane
3. `tab.focused_pane()` returns the LEFT pane (no wants_mouse) → forward block skipped
4. Falls through to local `ScrollUp/ScrollDown` handler at `mouse.rs:93-94` → scrolls local TUI buffer, not opencode

## Fix

`pane_for_mouse_forward(layout, mouse) -> Option<(pane_id, inner_x, inner_y)>` extracted as a pure routing function. Body switches to `tab.pane_at(col, row)`:

```rust
let pane_id = tab.pane_at(mouse.column, mouse.row)?;
let pane = tab.root().find_pane(pane_id)?;
if !pane.vterm.wants_mouse() || !pane.vterm.mouse_sgr() {
    return None;
}
// ... rest of rect check unchanged ...
```

Plus a new sibling helper in `src/app/mod.rs`:

```rust
fn write_to_pane(home, layout, registry, pane_id, bytes) {
    // root_mut().find_pane_mut(pane_id) instead of focused_pane_mut()
}
```

## §3.10 RED→GREEN evidence

| Commit | Status |
|---|---|
| `46b16e2` — test(#783): §3.10 anchor RED | 1 of 3 routing tests FAILS — focus-only impl returns `None` when cursor is over a non-focused wants_mouse pane |
| `69f0e28` — fix(#783): §3.10 GREEN | All 3 routing tests pass after `tab.pane_at(col, row)` switch |

### RED signature captured
```
thread 'pane_for_mouse_forward_targets_pane_under_cursor_not_focused'
  panicked at src/app/mouse.rs:582:9:
  assertion `left == right` failed: mouse over right opencode pane
  must route there regardless of focus; got None
    left: None
   right: Some(2)
```

## Test coverage

3 routing tests added (`pane_for_mouse_forward_*` in `src/app/mouse.rs`):
1. **Bug-pin**: 2-pane tab, opencode in non-focused right pane, mouse-scroll over right → must route to right pane
2. **Invariant**: 2-pane tab without any wants_mouse → routing returns None (falls through to local scroll)
3. **Regression-guard**: single-pane opencode tab — single-pane #700/#739/#741/#744 path must still work post-refactor

The routing decision is tested directly via the extracted `pane_for_mouse_forward` function — no PTY side-effects needed. Operator-attended manual validation (checklist above) covers the real-world opencode behavior.

## Scope verification

- **LOC**: 36 net added (= 19 in `mouse.rs` + 25 in `mod.rs` − 8 deletions in mouse.rs)
- **Modules touched**: 2 (`src/app/mouse.rs`, `src/app/mod.rs`)
- **Caps from dispatch**: ≤150 LOC ≤3 modules — **PASSED with comfortable margin**

## Soak criterion (mixed)

- **Primary** (operator-attended): operator confirms 3-item checklist above within 24h of merge
- **Secondary** (auto-test): 3 routing tests added in this PR are the regression guard for future TUI refactors. If anyone changes `pane_for_mouse_forward` and accidentally restores focus-only logic, the bug-pin test catches it.

## Hard rules followed

- ZERO BYPASS — `repo action=checkout bind:true` single-step
- §3.10 RED/GREEN separated into 2 commits (squash collapses)
- No new modules added (extracted within existing files)
- Cross-platform — pure routing logic, no `#[cfg(unix)]` gating
- Operator validation checklist in PR body per dispatch hard rule

## Test plan

- [x] `cargo test pane_for_mouse_forward` — 3/3 passing
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] Full suite `cargo test --features tray --bin agend-terminal` — 2208 passed, 7 ignored (pre-existing), 0 failed
- [ ] CI green on ubuntu/macos/windows
- [ ] Operator-attended UX validation (3-item checklist above) within 24h of merge

correlation_id: t-2026-05-14-fixup-backlog
task: t-20260514235857065766-1
decision: d-20260515000221472380-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)