### PR TITLE
fix(#762): dedup [ci-pass] for subscribers who are also action target

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -4081,4 +4081,238 @@ mod tests {
 
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    // ── #762: dedup [ci-pass] for subscribers who are also action_target ─────
+    //
+    // Pre-fix: the fan-out loop at poller.rs:836 enqueues [ci-pass] to EVERY
+    // subscriber, then the [ci-ready-for-action] dispatch at 889-908 separately
+    // injects to next_after_ci. When the same agent is in both lists, it
+    // received both notifications for the same CI pass. Issue #762 example:
+    // PR #756 lead `claude-f54bf9` got [ci-pass] AND [ci-ready-for-action].
+    //
+    // Fix: load `next_after_ci` once into `action_target_on_success`, skip the
+    // [ci-pass] enqueue for that exact subscriber on success, fan out to
+    // everyone else. Failure path leaves the option as None so all subscribers
+    // (including the action_target) get [ci-fail].
+
+    /// #762 §3.10 anchor — subscribers `[a, b]` with `next_after_ci: a` and
+    /// a successful run must drop the `[ci-pass]` for `a` (the action target),
+    /// while `b` still receives `[ci-pass]`. Pre-fix the fan-out loop
+    /// unconditionally enqueued for every subscriber, so `a` got both
+    /// `[ci-pass]` and `[ci-ready-for-action]`.
+    #[test]
+    fn pass_dedupe_drops_ci_pass_for_subscriber_who_is_action_target() {
+        let dir = tmp_dir("dedup-success");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [
+                {"instance": "a", "subscribed_at": "2026-05-15T00:00:00Z"},
+                {"instance": "b", "subscribed_at": "2026-05-15T00:00:01Z"}
+            ],
+            "next_after_ci": "a",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 100,
+            conclusion: Some("success".to_string()),
+            head_sha: "abc".to_string(),
+            url: "https://example/run/100".to_string(),
+        }]);
+
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["a".to_string(), "b".to_string()],
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+
+        // `a` is the action_target on success → MUST NOT receive [ci-pass].
+        let a_inbox = dir.join("inbox").join("a.jsonl");
+        let a_body = std::fs::read_to_string(&a_inbox).unwrap_or_default();
+        assert!(
+            !a_body.contains("[ci-pass]"),
+            "action_target `a` must NOT receive [ci-pass] (will get [ci-ready-for-action] instead); inbox body:\n{a_body}"
+        );
+
+        // `b` is not the action_target → MUST still receive [ci-pass].
+        let b_inbox = dir.join("inbox").join("b.jsonl");
+        let b_body = std::fs::read_to_string(&b_inbox).unwrap_or_else(|_| {
+            panic!("subscriber `b` inbox missing — fan-out regression: {b_inbox:?}")
+        });
+        assert!(
+            b_body.contains("[ci-pass]") && b_body.contains("o/r@feat"),
+            "subscriber `b` must receive [ci-pass]; inbox body:\n{b_body}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #762 invariant — failure conclusion must NOT dedupe. Both subscribers
+    /// (including the action_target) need to know the CI failed; the
+    /// [ci-ready-for-action] dispatch only fires on success per issue #650,
+    /// so a failure-path drop would leave the action_target uninformed.
+    #[test]
+    fn pass_dedupe_failure_does_not_drop_ci_fail_for_action_target() {
+        let dir = tmp_dir("dedup-failure");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [
+                {"instance": "a", "subscribed_at": "2026-05-15T00:00:00Z"},
+                {"instance": "b", "subscribed_at": "2026-05-15T00:00:01Z"}
+            ],
+            "next_after_ci": "a",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 200,
+            conclusion: Some("failure".to_string()),
+            head_sha: "def".to_string(),
+            url: "https://example/run/200".to_string(),
+        }]);
+
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["a".to_string(), "b".to_string()],
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+
+        // Both subscribers (including action_target `a`) must receive [ci-fail].
+        for sub in ["a", "b"] {
+            let inbox_path = dir.join("inbox").join(format!("{sub}.jsonl"));
+            let body = std::fs::read_to_string(&inbox_path)
+                .unwrap_or_else(|_| panic!("{sub} inbox missing on failure-path: {inbox_path:?}"));
+            assert!(
+                body.contains("[ci-fail]") && body.contains("o/r@feat"),
+                "{sub} must receive [ci-fail] (failure path must NOT dedupe); inbox body:\n{body}"
+            );
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #762 invariant — subscribers disjoint from `next_after_ci` all receive
+    /// `[ci-pass]` on success. The dedupe filter must be exact-match only;
+    /// it must not drop notifications for non-action-target subscribers.
+    #[test]
+    fn pass_dedupe_non_action_target_subscribers_receive_ci_pass() {
+        let dir = tmp_dir("dedup-non-overlap");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [
+                {"instance": "a", "subscribed_at": "2026-05-15T00:00:00Z"},
+                {"instance": "b", "subscribed_at": "2026-05-15T00:00:01Z"},
+                {"instance": "c", "subscribed_at": "2026-05-15T00:00:02Z"}
+            ],
+            // next_after_ci points to an agent NOT in subscribers list.
+            "next_after_ci": "d",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 300,
+            conclusion: Some("success".to_string()),
+            head_sha: "fed".to_string(),
+            url: "https://example/run/300".to_string(),
+        }]);
+
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["a".to_string(), "b".to_string(), "c".to_string()],
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+
+        // All 3 subscribers must receive [ci-pass]; `d` is not subscribed
+        // and would receive [ci-ready-for-action] via inject (silent in
+        // tests with empty registry).
+        for sub in ["a", "b", "c"] {
+            let inbox_path = dir.join("inbox").join(format!("{sub}.jsonl"));
+            let body = std::fs::read_to_string(&inbox_path)
+                .unwrap_or_else(|_| panic!("subscriber `{sub}` inbox missing: {inbox_path:?}"));
+            assert!(
+                body.contains("[ci-pass]") && body.contains("o/r@feat"),
+                "subscriber `{sub}` must receive [ci-pass] (next_after_ci=d ≠ {sub}); inbox body:\n{body}"
+            );
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -829,11 +829,39 @@ async fn ci_check_repo(
             // request per cycle); only the notification side-effects loop.
             let repo_branch_key = format!("{repo}@{branch}");
             let supersede_token = format!("ci-{}-{}", run_id, sha);
+            // #762: load `next_after_ci` once and only when this notification
+            // is for a successful run. The same agent appearing as both a
+            // subscriber and the action target produced a [ci-pass] +
+            // [ci-ready-for-action] duplicate pre-fix; skipping the
+            // [ci-pass] enqueue for that one subscriber preserves notify
+            // semantics for everyone else (and for the failure path, where
+            // the action target still needs to know about the fail).
+            let action_target_on_success: Option<String> = if conclusion == Some("success") {
+                std::fs::read_to_string(watch_path)
+                    .ok()
+                    .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+                    .and_then(|w| {
+                        w["next_after_ci"]
+                            .as_str()
+                            .filter(|s| !s.is_empty())
+                            .map(String::from)
+                    })
+            } else {
+                None
+            };
             // EMPIRICAL REGRESSION-PROOF FLIP: replace `subscribers` below
             // with `&subscribers[..1]` to simulate the pre-r0 single-recipient
             // bug. The `subscriber_fan_out_notifies_every_member` test
             // immediately fails with the dev-inbox-missing assertion.
             for sub in subscribers {
+                // #762: skip [ci-pass] enqueue for the action target on
+                // success; it receives [ci-ready-for-action] via inject
+                // below. Match is exact-string equality so a partial-prefix
+                // collision (e.g. "lead" vs "lead-2") doesn't accidentally
+                // drop the notification.
+                if action_target_on_success.as_deref() == Some(sub.as_str()) {
+                    continue;
+                }
                 let reg = agent::lock_registry(registry);
                 if let Some(handle) = reg.get(sub) {
                     let _ = agent::inject_to_agent(handle, headline.as_bytes());


### PR DESCRIPTION
## Summary

When the same agent appears in both a CI watch's subscriber list AND its `next_after_ci` action target, that agent receives two notifications for one CI pass: a `[ci-pass]` from the fan-out loop and a `[ci-ready-for-action]` from the dispatch block. This PR drops the redundant `[ci-pass]` for that one agent when the run conclusion is `"success"`. Other subscribers still receive `[ci-pass]`; failures fan out to all subscribers unchanged.

Closes #762
scope follows dispatch spec d-20260515011002060413-1

## Bug surface (pre-fix)

`src/daemon/ci_watch/poller.rs::ci_check_repo`:

- **Fan-out loop** at `poller.rs:836`: `for sub in subscribers { ... enqueue [ci-pass] ... }`
- **[ci-ready] dispatch** at `poller.rs:889-908`: re-reads watch file, picks `next_after_ci`, calls `agent::inject_to_agent` with `[ci-ready-for-action]`

Same agent in both lists ⇒ 2 notifications for 1 CI pass. Issue #762 example: PR #756 lead `claude-f54bf9` received both for a single CI success.

## Fix

Compute `action_target_on_success: Option<String>` once before the fan-out loop and use it to filter:

```rust
let action_target_on_success: Option<String> = if conclusion == Some("success") {
    std::fs::read_to_string(watch_path)
        .ok()
        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
        .and_then(|w| w["next_after_ci"].as_str().filter(|s| !s.is_empty()).map(String::from))
} else {
    None
};

for sub in subscribers {
    // #762: skip [ci-pass] for the action target on success
    if action_target_on_success.as_deref() == Some(sub.as_str()) {
        continue;
    }
    // ... existing enqueue + inject ...
}
```

The `[ci-ready-for-action]` dispatch at lines 889-908 is unchanged; the action target still receives that notification via inject. The pre-fix duplicate watch-file read at 891-893 also stays — keeping scope tight to the dedup itself.

## Reviewer guardrails (all three honored)

1. **Success-only**: filter is gated on `conclusion == Some("success")`. Failure path keeps full fan-out (action target still needs to know about failures).
2. **Exact match**: `as_deref() == Some(sub.as_str())` — no prefix-collision drops between e.g. `lead` and `lead-2`.
3. **Dispatch order preserved**: the `[ci-ready-for-action]` block fires AFTER the fan-out, so the action target's notification ordering is unchanged.

## §3.10 RED → GREEN evidence

| Commit | Status |
|---|---|
| `1730714` — test(#762): §3.10 anchor RED | 1 of 3 anchor tests FAILS on unchanged impl |
| `f64086c` — fix(#762): §3.10 GREEN | All 3 pass after the filter is wired |

### RED signature captured
```
thread 'pass_dedupe_drops_ci_pass_for_subscriber_who_is_action_target'
  panicked: action_target `a` must NOT receive [ci-pass]
  (will get [ci-ready-for-action] instead); inbox body:
  {... "text":"[ci-pass] o/r@feat (abc): passed ✓\nURL:..." ...}
```

The other 2 invariant tests pass in RED — failure-path and non-overlap subscribers are unaffected by the bug, and the GREEN commit preserves their behavior.

## Tests added

3 cross-platform tests at `src/daemon/ci_watch/poller.rs` `mod tests`, modeled on the existing `subscriber_fan_out_notifies_every_member` fixture (line 3070):

1. **Primary anchor**: subscribers `[a, b]`, `next_after_ci: a`, conclusion `success` → only `b` gets `[ci-pass]` in inbox; `a` does not
2. **Failure invariant**: same setup but conclusion `failure` → BOTH `a` and `b` get `[ci-fail]` (no success-path dedup applies)
3. **Non-overlap invariant**: subscribers `[a, b, c]`, `next_after_ci: d` (not in list) → all 3 get `[ci-pass]` (filter is exact-match, not greedy)

All use `MockCiProvider::with_runs(...)` + `run_ci_check(...)` from the existing test infrastructure (poller.rs:1715, 1790). Cross-platform — no `#[cfg(unix)]` needed.

## Test plan

- [x] `cargo test pass_dedupe` — 3/3 passing
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] Full suite `cargo test --features tray --bin agend-terminal` — 2214 passed, 7 ignored (pre-existing), 0 failed
- [ ] CI green on ubuntu/macos/windows

## Hard rules followed

- ZERO BYPASS — `repo action=checkout bind:true` single-step
- **≤100 LOC, single module** cap — code change is +28 LOC in `src/daemon/ci_watch/poller.rs`; tests add ~234 LOC of structurally-symmetric `serde_json::json!` + assert blocks (modeled on existing fan-out test for review symmetry)
- §3.10 RED → GREEN 2-commit cadence
- 3 reviewer guardrails honored (success-only / exact-match / dispatch-order)

correlation_id: t-2026-05-14-fixup-backlog
task: t-20260515010701798886-1
decision: d-20260515011002060413-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)