### PR TITLE
fix: double injection caused by synchronous PTY/Provenance blocking API timeout

### DIFF
--- a/.agend-managed
+++ b/.agend-managed
@@ -1,0 +1,3 @@
+agent=gemini-7d0621
+branch=fix/double-injection
+leased_at=2026-05-15T01:55:43.911015+00:00

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -26,6 +26,7 @@ pub struct AgentCore {
 
 /// Handle to interact with an agent.
 #[allow(dead_code)]
+#[derive(Clone)]
 pub struct AgentHandle {
     pub id: crate::types::InstanceId,
     pub name: String,

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -19,26 +19,32 @@ pub(crate) fn handle_inject(params: &Value, ctx: &HandlerCtx) -> Value {
             if is_restarting {
                 json!({"ok": false, "error": format!("agent '{name}' is restarting, retry later")})
             } else {
-                let result = if raw {
-                    agent::write_to_agent(handle, data.as_bytes())
-                } else {
-                    agent::inject_to_agent(handle, data.as_bytes())
-                };
-                // Record for ServerRateLimit auto-retry.
-                if result.is_ok() && !data.is_empty() {
-                    drop(reg);
-                    crate::daemon::heartbeat_pair::update_with(name, |p| {
-                        p.last_input_text = Some(data.to_string());
+                let handle_clone = handle.clone();
+                let data_clone = data.to_string();
+                let name_clone = name.to_string();
+
+                // Record for ServerRateLimit auto-retry (best-effort, before spawn).
+                if !data_clone.is_empty() {
+                    crate::daemon::heartbeat_pair::update_with(&name_clone, |p| {
+                        p.last_input_text = Some(data_clone.clone());
                     });
-                    return match result {
-                        Ok(()) => json!({"ok": true, "result": {"bytes": data.len()}}),
-                        Err(e) => json!({"ok": false, "error": format!("{e}")}),
-                    };
                 }
-                match result {
-                    Ok(()) => json!({"ok": true, "result": {"bytes": data.len()}}),
-                    Err(e) => json!({"ok": false, "error": format!("{e}")}),
-                }
+
+                // H1 fix: background the actual PTY write. Large messages with
+                // typed_inject pacing (2ms/byte) can exceed the 5s API timeout,
+                // triggering double-injection fallbacks in the client.
+                std::thread::Builder::new()
+                    .name(format!("inject_{}", name_clone))
+                    .spawn(move || {
+                        if raw {
+                            let _ = agent::write_to_agent(&handle_clone, data_clone.as_bytes());
+                        } else {
+                            let _ = agent::inject_to_agent(&handle_clone, data_clone.as_bytes());
+                        }
+                    })
+                    .ok();
+
+                json!({"ok": true, "result": {"queued": true}})
             }
         }
         None => {
@@ -372,7 +378,6 @@ mod tests {
     use parking_lot::Mutex;
     use serde_json::json;
     use std::collections::HashMap;
-    use std::sync::Arc;
 
     fn test_ctx_with_agent(name: &str) -> (HandlerCtx<'static>, Box<std::path::PathBuf>) {
         let home = Box::new(std::env::temp_dir().join(format!(

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -177,26 +177,37 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        if let Some(ch) = crate::channel::active_channel() {
-            if let Err(e) = ch.send_from_agent(
-                target,
-                crate::channel::AgentOutboundOp::InjectProvenance {
-                    from: prov_from,
-                    task: prov_task,
-                },
-            ) {
-                tracing::warn!(
-                    %e, target, from,
-                    "provenance injection failed — routing may be broken"
-                );
-            }
-        } else {
-            tracing::warn!(
-                target,
-                from,
-                "provenance injection failed — no active channel"
-            );
-        }
+        let target_clone = target.to_string();
+        let from_clone = from.to_string();
+
+        // H1 fix: background the provenance injection. Slow network IO to
+        // Telegram/Discord can exceed the 5s API timeout, triggering
+        // double-injection fallbacks in the client.
+        std::thread::Builder::new()
+            .name(format!("provenance_{}", target_clone))
+            .spawn(move || {
+                if let Some(ch) = crate::channel::active_channel() {
+                    if let Err(e) = ch.send_from_agent(
+                        &target_clone,
+                        crate::channel::AgentOutboundOp::InjectProvenance {
+                            from: prov_from,
+                            task: prov_task,
+                        },
+                    ) {
+                        tracing::warn!(
+                            %e, target = %target_clone, from = %from_clone,
+                            "provenance injection failed — routing may be broken"
+                        );
+                    }
+                } else {
+                    tracing::warn!(
+                        target = %target_clone,
+                        from = %from_clone,
+                        "provenance injection failed — no active channel"
+                    );
+                }
+            })
+            .ok();
     }
 
     // B2 boundary: worktree-checkout side-effect pushed from MCP comms to


### PR DESCRIPTION
## Root Cause
Synchronous PTY injection in `handle_inject` (especially with `typed_inject` pacing of 2ms/byte) and synchronous Telegram Provenance delivery in `handle_send` could exceed the 5-second API timeout in `ipc.rs`.
When this happens, the client (MCP tool) triggers a `fallback_deliver`, which injects the message a second time via the `inbox` path, leading to duplicate messages in the agent CLI.

## Fix
- Added `#[derive(Clone)]` to `AgentHandle`.
- Backgrounded PTY injection in `handle_inject` using a spawned thread.
- Backgrounded Telegram Provenance delivery in `handle_send` using a spawned thread.
- This allows the API to respond immediately (`ok: true`), preventing client-side timeouts and duplicate injections.