### PR TITLE
fix(#808): orphan ghost-owned tasks on delete + force flag for historical cleanup

### DIFF
--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -88,6 +88,15 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     }
     crate::teams::remove_member_from_all(home, name);
 
+    // #808: orphan tasks whose owner is the deleted instance so the
+    // ACL gate (`tasks::can_mutate_record`) doesn't lock survivors
+    // out. Best-effort like the other cleanup steps — a failure
+    // feeds the residual audit but doesn't abort the teardown.
+    if let Err(e) = crate::tasks::orphan_tasks_for_owner(home, name) {
+        step_errors.push(format!("task orphan: {e}"));
+        tracing::error!(name, error = %e, "full_delete_instance: task orphan failed");
+    }
+
     // Sprint 54 P1-B Bug 1 audit: enumerate every store that still holds
     // the name. If any do, surface a loud error instead of returning
     // success — `auto_start_fleet` revival of a half-deleted instance is
@@ -338,6 +347,57 @@ mod tests {
         assert!(
             result.is_ok(),
             "clean home + clean post-audit must return Ok, got: {result:?}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn full_delete_instance_orphans_owned_tasks() {
+        // #808 GREEN test 2: deleting an instance must orphan the
+        // tasks it owns so the ACL gate (`tasks::can_mutate_record`)
+        // doesn't lock survivors out. Pre-fix: tasks keep ghost
+        // owner → operator gets "not authorized" on cancel.
+        // Post-fix: orphan_tasks_for_owner clears assignee before
+        // the residual audit so the survivor can mutate.
+        let home = tmp_home("orphan_on_delete");
+        // Create a task owned by the doomed instance via the public
+        // handle entry — this exercises the same event-log flow the
+        // MCP `task` tool uses in production.
+        let r = crate::tasks::handle(
+            &home,
+            "doomed",
+            &serde_json::json!({"action": "create", "title": "owned task", "assignee": "doomed"}),
+        );
+        let task_id = r["id"].as_str().expect("task id").to_string();
+        // Sanity: pre-delete ownership recorded.
+        let pre_tasks = crate::tasks::list_all(&home);
+        let pre = pre_tasks
+            .iter()
+            .find(|t| t.id == task_id)
+            .expect("task exists");
+        assert_eq!(
+            pre.assignee.as_deref(),
+            Some("doomed"),
+            "pre-delete sanity: task owner must be 'doomed'"
+        );
+        // Run the full teardown. `api::call` is unreachable in test
+        // context (harmless) and there's no fleet.yaml / metadata so
+        // the residual audit returns clean.
+        let result = super::full_delete_instance(&home, "doomed");
+        assert!(
+            result.is_ok(),
+            "delete on clean home must return Ok, got: {result:?}"
+        );
+        // Orphan side-effect: assignee cleared.
+        let post_tasks = crate::tasks::list_all(&home);
+        let post = post_tasks
+            .iter()
+            .find(|t| t.id == task_id)
+            .expect("task still exists post-delete");
+        assert!(
+            post.assignee.is_none(),
+            "owned task must be orphaned after full_delete_instance, got assignee={:?}",
+            post.assignee
         );
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -152,7 +152,9 @@ fn task_tools() -> Vec<Value> {
                 "filter_assignee": {"type": "string"}, "filter_status": {"type": "string"},
                 "due_at": {"type": "string", "description": "ISO 8601 deadline for the task"},
                 "duration": {"type": "string", "description": "Human duration until deadline (e.g. 30m, 1h, 2d)"},
-                "branch": {"type": "string", "description": "Git branch the implementer should work on"}
+                "branch": {"type": "string", "description": "Git branch the implementer should work on"},
+                "force": {"type": "boolean", "description": "#808: bypass ownership ACL on done/update for historical ghost-owned cleanup. Requires non-empty force_reason."},
+                "force_reason": {"type": "string", "description": "#808: required when force=true. Logged to event-log.jsonl and embedded in the per-task event's reason field for audit."}
             }, "required": ["action"]}}),
         json!({"name": "task_sweep_config",
         "description": "Configure GitHub-PR auto-close sweep daemon. Sweep polls merged PRs and emits Done events for `Closes t-XXX-N` markers (validated by 5-must-have pipeline).",

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -719,7 +719,19 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 Some(r) => r,
                 None => return serde_json::json!({"error": format!("task '{id}' not found")}),
             };
-            if !can_mutate_record(home, &caller, &record) {
+            // #808: force flag bypasses the ACL gate for historical
+            // ghost-owned cleanup. Validator mirrors comms.rs:200-218.
+            let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
+            let force_reason = args
+                .get("force_reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if force && force_reason.is_empty() {
+                return serde_json::json!({
+                    "error": "force=true requires a non-empty 'force_reason'"
+                });
+            }
+            if !force && !can_mutate_record(home, &caller, &record) {
                 return serde_json::json!({
                     "error": format!(
                         "task '{id}' owned by '{}', caller '{caller}' not authorized",
@@ -727,11 +739,38 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                     )
                 });
             }
+            if force {
+                crate::event_log::log(
+                    home,
+                    "task_force_done",
+                    &caller,
+                    &format!(
+                        "task={id} owner={} reason={force_reason}",
+                        record
+                            .owner
+                            .as_ref()
+                            .map(|o| o.0.as_str())
+                            .unwrap_or("none")
+                    ),
+                );
+            }
             let by = record
                 .owner
                 .as_ref()
                 .map(|o| o.0.clone())
                 .unwrap_or_else(|| caller.clone());
+            // #808: when force is set, prefix the result with an
+            // audit marker so the persisted event itself names the
+            // caller + reason (event_log carries the same record for
+            // cross-board audit).
+            let result_text = if force {
+                Some(format!(
+                    "[forced by '{caller}': {force_reason}] {}",
+                    result_text.unwrap_or_default()
+                ))
+            } else {
+                result_text
+            };
             let event = crate::task_events::TaskEvent::Done {
                 task_id: crate::task_events::TaskId(id.clone()),
                 by: crate::task_events::InstanceName(by),
@@ -794,7 +833,19 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 Some(r) => r,
                 None => return serde_json::json!({"error": format!("task '{id}' not found")}),
             };
-            if !can_mutate_record(home, &caller, &record) {
+            // #808: force flag bypasses the ACL gate for historical
+            // ghost-owned cleanup. Validator mirrors comms.rs:200-218.
+            let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
+            let force_reason = args
+                .get("force_reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if force && force_reason.is_empty() {
+                return serde_json::json!({
+                    "error": "force=true requires a non-empty 'force_reason'"
+                });
+            }
+            if !force && !can_mutate_record(home, &caller, &record) {
                 return serde_json::json!({
                     "error": format!(
                         "task '{id}' owned by '{}', caller '{caller}' not authorized",
@@ -802,6 +853,32 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                     )
                 });
             }
+            if force {
+                crate::event_log::log(
+                    home,
+                    "task_force_update",
+                    &caller,
+                    &format!(
+                        "task={id} owner={} reason={force_reason}",
+                        record
+                            .owner
+                            .as_ref()
+                            .map(|o| o.0.as_str())
+                            .unwrap_or("none")
+                    ),
+                );
+            }
+            // #808: when force is set, embed the caller + reason
+            // directly in the emitted event's `reason` field so the
+            // per-task replay trail also carries the audit (in
+            // addition to the event_log entry above).
+            let reason_text = |base: &str| -> String {
+                if force {
+                    format!("{base} [forced by '{caller}': {force_reason}]")
+                } else {
+                    base.to_string()
+                }
+            };
             // PR4 F1 — collect transitions into a Vec then emit via
             // single `append_batch` so updates are atomic at the F7 batch
             // level (all-or-nothing fsync window).
@@ -867,11 +944,11 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                         (_, "cancelled") => Some(crate::task_events::TaskEvent::Cancelled {
                             task_id: crate::task_events::TaskId(id.clone()),
                             by: crate::task_events::InstanceName::from(caller.as_str()),
-                            reason: "operator update".to_string(),
+                            reason: reason_text("operator update"),
                         }),
                         (_, "blocked") => Some(crate::task_events::TaskEvent::Blocked {
                             task_id: crate::task_events::TaskId(id.clone()),
-                            reason: "operator update".to_string(),
+                            reason: reason_text("operator update"),
                         }),
                         (crate::task_events::TaskStatus::Blocked, "open") => {
                             Some(crate::task_events::TaskEvent::Unblocked {
@@ -887,12 +964,12 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                         | (crate::task_events::TaskStatus::InProgress, "open") => {
                             Some(crate::task_events::TaskEvent::Released {
                                 task_id: crate::task_events::TaskId(id.clone()),
-                                reason: "operator update (status → open)".to_string(),
+                                reason: reason_text("operator update (status → open)"),
                             })
                         }
                         (_, "open") => Some(crate::task_events::TaskEvent::Reopened {
                             task_id: crate::task_events::TaskId(id.clone()),
-                            reason: "operator update".to_string(),
+                            reason: reason_text("operator update"),
                             source_evidence: format!(
                                 "status {} → open",
                                 status_to_legacy_str(prev_status)
@@ -2646,6 +2723,122 @@ mod tests {
                 .map(|e| e.contains("force_reason"))
                 .unwrap_or(false),
             "force=true without force_reason must surface validator error, got: {r}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_force_update_with_reason_cancels_ghost_and_logs_audit() {
+        // GREEN test 1: force=true + non-empty force_reason on
+        // `action=update status=cancelled` bypasses the ACL gate AND
+        // pushes a `task_force_update` entry into event-log.jsonl
+        // (cross-board audit) AND embeds the force_reason into the
+        // per-task event's reason field (per-task replay audit).
+        let home = tmp_home("force_cancel_ghost");
+        write_fleet_yaml(&home, &["operator"]);
+        let r = handle(
+            &home,
+            "operator",
+            &serde_json::json!({
+                "action": "create",
+                "title": "stuck-by-ghost",
+                "assignee": "ghost-instance",
+            }),
+        );
+        let id = r["id"].as_str().expect("id").to_string();
+        let r = handle(
+            &home,
+            "operator",
+            &serde_json::json!({
+                "action": "update",
+                "id": id,
+                "status": "cancelled",
+                "force": true,
+                "force_reason": "post-#808 board hygiene 2026-05-15",
+            }),
+        );
+        assert_eq!(
+            r["status"], "updated",
+            "force=true + force_reason must succeed despite ghost owner, got: {r}"
+        );
+        let tasks = list_all(&home);
+        let t = tasks
+            .iter()
+            .find(|t| t.id == id)
+            .expect("task still present");
+        assert_eq!(t.status, "cancelled", "task must be cancelled");
+        // Cross-board audit: event-log.jsonl records the force action.
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert!(
+            log.contains("task_force_update"),
+            "event-log.jsonl must record task_force_update entry, got: {log}"
+        );
+        assert!(
+            log.contains("post-#808 board hygiene"),
+            "event-log.jsonl must capture the force_reason, got: {log}"
+        );
+        // Per-task replay audit: the Cancelled event's reason field
+        // carries the forced marker.
+        let task_log = std::fs::read_to_string(home.join("task_events.jsonl")).unwrap_or_default();
+        assert!(
+            task_log.contains("forced by 'operator'"),
+            "Cancelled event reason must carry forced marker, got: {task_log}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_force_done_with_reason_succeeds_on_done_arm() {
+        // BONUS test (mandatory per dispatch spec): force flag must
+        // also gate the `action=done` arm — operators sometimes close
+        // ghost-owned tasks as Done rather than Cancelled when the
+        // work was effectively completed before the owner disbanded.
+        let home = tmp_home("force_done_ghost");
+        write_fleet_yaml(&home, &["operator"]);
+        let r = handle(
+            &home,
+            "operator",
+            &serde_json::json!({
+                "action": "create",
+                "title": "ghost-done",
+                "assignee": "ghost-instance",
+            }),
+        );
+        let id = r["id"].as_str().expect("id").to_string();
+        // Without force, the done arm rejects (mirrors RED1 behavior).
+        let r_blocked = handle(
+            &home,
+            "operator",
+            &serde_json::json!({"action": "done", "id": id}),
+        );
+        assert!(
+            r_blocked["error"]
+                .as_str()
+                .map(|e| e.contains("not authorized"))
+                .unwrap_or(false),
+            "done arm without force must reject ghost-owned task, got: {r_blocked}"
+        );
+        // With force + reason, the done arm proceeds and event-log
+        // records the cross-board audit (task_force_done).
+        let r = handle(
+            &home,
+            "operator",
+            &serde_json::json!({
+                "action": "done",
+                "id": id,
+                "result": "completed before owner disband",
+                "force": true,
+                "force_reason": "post-#808 done-arm hygiene",
+            }),
+        );
+        assert_eq!(
+            r["status"], "done",
+            "force=true done must succeed, got: {r}"
+        );
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert!(
+            log.contains("task_force_done"),
+            "event-log.jsonl must record task_force_done entry, got: {log}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -2506,4 +2506,86 @@ mod tests {
 
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ── #808 ghost-owner ACL deadlock: auto-orphan + force flag tests ──
+
+    #[test]
+    fn test_ghost_owner_update_without_force_errors_with_acl() {
+        // Baseline regression: today operator cannot cancel a task
+        // whose owner is no longer in the fleet (ghost-owner ACL
+        // deadlock the issue describes). The #808 force flag must NOT
+        // change this behavior when force=false / absent — the ACL
+        // gate stays load-bearing so accidental cancels still require
+        // an explicit force opt-in.
+        let home = tmp_home("ghost_acl_baseline");
+        write_fleet_yaml(&home, &["operator"]);
+        let r = handle(
+            &home,
+            "operator",
+            &serde_json::json!({
+                "action": "create",
+                "title": "stuck",
+                "assignee": "ghost-instance",
+            }),
+        );
+        let id = r["id"].as_str().expect("id").to_string();
+        let r = handle(
+            &home,
+            "operator",
+            &serde_json::json!({
+                "action": "update",
+                "id": id,
+                "status": "cancelled",
+            }),
+        );
+        assert!(
+            r["error"]
+                .as_str()
+                .map(|e| e.contains("not authorized"))
+                .unwrap_or(false),
+            "ghost-owned task cancel without force must surface ACL error, got: {r}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_force_update_true_without_force_reason_rejected() {
+        // Force-flag contract (mirrors comms.rs:200-218): force=true
+        // without a non-empty force_reason must surface a validator
+        // error, NOT fall through to ACL or succeed silently. The
+        // grammar match is "force_reason" (the validator message names
+        // the missing field) — pre-fix the handler ignores force and
+        // returns the regular ACL error, so this test is RED until C2
+        // ships.
+        let home = tmp_home("force_no_reason");
+        write_fleet_yaml(&home, &["operator"]);
+        let r = handle(
+            &home,
+            "operator",
+            &serde_json::json!({
+                "action": "create",
+                "title": "stuck",
+                "assignee": "ghost-instance",
+            }),
+        );
+        let id = r["id"].as_str().expect("id").to_string();
+        let r = handle(
+            &home,
+            "operator",
+            &serde_json::json!({
+                "action": "update",
+                "id": id,
+                "status": "cancelled",
+                "force": true,
+            }),
+        );
+        assert!(
+            r["error"]
+                .as_str()
+                .map(|e| e.contains("force_reason"))
+                .unwrap_or(false),
+            "force=true without force_reason must surface validator error, got: {r}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -484,6 +484,7 @@ fn read_task_record(home: &Path, id: &str) -> Option<crate::task_events::TaskRec
 /// These are internal daemon modules that emit events on behalf of the system.
 const SYSTEM_IDENTITIES: &[&str] = &[
     "system:auto_close",
+    "system:auto_orphan",
     "system:overdue_sweep",
     "system:task_sweep",
 ];
@@ -491,6 +492,66 @@ const SYSTEM_IDENTITIES: &[&str] = &[
 /// Check if a caller is a recognized system identity.
 pub fn is_system_identity(caller: &str) -> bool {
     SYSTEM_IDENTITIES.contains(&caller)
+}
+
+/// #808: clear ownership on tasks owned by a deleted instance so the
+/// ACL gate (`can_mutate_record`) doesn't lock survivors out. Called
+/// from `full_delete_instance` after fleet-yaml membership cleanup.
+///
+/// Replays the event log, enumerates tasks where `owner == owner_name`
+/// AND status is still "live" (Open/Claimed/InProgress/Blocked), and
+/// emits one `OwnerAssigned { owner: None }` per affected task via
+/// `append_batch` so the entire orphan transition lands under one
+/// fsync. Done/Cancelled tasks are skipped — their terminal state
+/// already disables ACL writes, so re-orphaning them would only churn
+/// the event log.
+///
+/// Concurrency: the caller (`full_delete_instance`) issues
+/// `api::method::DELETE` BEFORE invoking this helper, so the doomed
+/// instance is already dead and cannot claim new tasks mid-flight.
+/// The TOCTOU window between `replay()` and `append_batch()` is
+/// acceptable — a sweeper or operator race that lands later still
+/// wins at replay (later seq overrides).
+///
+/// Returns the count of orphaned tasks on success (0 when nothing
+/// matched), or an `Err` carrying the underlying replay / append
+/// failure detail for the caller to surface into its audit chain.
+pub fn orphan_tasks_for_owner(home: &Path, owner_name: &str) -> Result<usize, String> {
+    use crate::task_events::{InstanceName, TaskEvent, TaskStatus};
+
+    let state = crate::task_events::replay(home).map_err(|e| e.to_string())?;
+    let affected: Vec<crate::task_events::TaskId> = state
+        .tasks
+        .values()
+        .filter(|r| r.owner.as_ref().map(|o| o.0 == owner_name).unwrap_or(false))
+        .filter(|r| {
+            matches!(
+                r.status,
+                TaskStatus::Open
+                    | TaskStatus::Claimed
+                    | TaskStatus::InProgress
+                    | TaskStatus::Blocked
+            )
+        })
+        .map(|r| r.id.clone())
+        .collect();
+    if affected.is_empty() {
+        return Ok(0);
+    }
+    let count = affected.len();
+    let emitter = InstanceName::from("system:auto_orphan");
+    let events: Vec<TaskEvent> = affected
+        .into_iter()
+        .map(|id| TaskEvent::OwnerAssigned {
+            task_id: id,
+            by: emitter.clone(),
+            owner: None,
+            routed_to: None,
+        })
+        .collect();
+    crate::task_events::append_batch(home, &emitter, events)
+        .map(|_| count)
+        .map_err(|e| e.to_string())
 }
 
 fn can_mutate_record(home: &Path, caller: &str, record: &crate::task_events::TaskRecord) -> bool {


### PR DESCRIPTION
Closes #808.

scope follows dispatch spec t-20260515033051588094-2

## Summary

- **C1 (auto-orphan)** — `full_delete_instance` now calls a new `tasks::orphan_tasks_for_owner` after `remove_member_from_all`, batch-emitting `OwnerAssigned{ owner: None }` for each Open/Claimed/InProgress/Blocked task the doomed instance owned. Done/Cancelled tasks are skipped (terminal status already disables ACL writes). New `system:auto_orphan` joins `SYSTEM_IDENTITIES` so the helper's own events satisfy the ACL bypass.
- **C2 (force flag)** — `task action=update` and `task action=done` gain `force` + `force_reason` args (validator borrowed verbatim from `comms.rs:200-218`). force=true bypasses `can_mutate_record`; force=true with empty force_reason → 400-style validator error; success emits a `task_force_done` / `task_force_update` entry into `event-log.jsonl` (cross-board audit) AND embeds the forced-by marker into the per-task event's `reason` field (per-task replay audit, independent of event-log retention).
- **Test-first §3.10** — 5 tests across 3 commits: RED tests first (commit 1), C1 + GREEN test 2 (commit 2), C2 + GREEN test 1 + bonus done-arm test (commit 3).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite: 2212 unit + integration tests + doc-tests + UI smoke — 0 regressions, 0 ignored beyond pre-existing 7
- [x] `tasks::tests::test_ghost_owner_update_without_force_errors_with_acl` (baseline ACL preserved)
- [x] `tasks::tests::test_force_update_true_without_force_reason_rejected` (RED → GREEN: validator now fires)
- [x] `tasks::tests::test_force_update_with_reason_cancels_ghost_and_logs_audit` (GREEN test 1: cancel succeeds + event-log + per-task event reason both carry audit)
- [x] `tasks::tests::test_force_done_with_reason_succeeds_on_done_arm` (bonus mandatory: done arm rejects without force, succeeds with force + reason)
- [x] `mcp::handlers::instance_lifecycle::tests::full_delete_instance_orphans_owned_tasks` (GREEN test 2: orphan side-effect post-delete)

## Post-merge operator validation (acceptance fixture from issue #808)

The 13 ghost-owned tasks the issue enumerated must all become cancellable by `general` once this PR ships. After merge, run:

\`\`\`text
task action=update id=<id> status=cancelled force=true force_reason='post-#808 board hygiene 2026-05-15'
\`\`\`

for each of:

- t-20260506164920713363-2 (owner: dev)
- t-20260506173331744744-3 (owner: lead)
- t-20260507125508842610-0 (owner: dev)
- t-20260507155527342912-0 (owner: dev)
- t-20260509082206650550-10 (owner: lead)
- t-20260510004423005349-33 (owner: dev)
- t-20260510030857101554-41 (owner: dev)
- t-20260510032243945305-42 (owner: dev)
- t-20260510033511490863-43 (owner: dev)
- t-20260510034959589675-44 (owner: dev)
- t-20260510035632287336-45 (owner: dev)
- t-20260514023222557270-2 (owner: reviewer-codex)
- t-20260514043658058701-7 (owner: reviewer-codex)

Each should return `{"status":"updated"}` and append a `task_force_update` entry to `event-log.jsonl`.

## Out of scope (deferred per dispatch t-20260515033051588094-2)

- `teams::delete` orphan hook for team-assigned tasks (operator uses force=true workaround).
- `tasks::orphan_tasks_for_owner` list-filter optimization (no benchmark evidence yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)