### PR TITLE
fix(#807): response shape consistency bundle (event/task fields, ReleaseOutcome serialize, started_at rename)

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -122,7 +122,7 @@ pub(crate) fn check_stalled(
     // sidecar timestamp if present, else dispatched_at. No anchor →
     // skip stall detection (can't compute elapsed without one).
     let last_alive = crate::daemon::task_progress::read_last_progress_at(home, &task.id)
-        .or_else(|| task.dispatched_at.as_deref().and_then(parse_rfc3339))?;
+        .or_else(|| task.started_at.as_deref().and_then(parse_rfc3339))?;
     let elapsed_secs = now.signed_duration_since(last_alive).num_seconds();
     let stall_threshold = (eta_secs as f64 * STALL_MULTIPLIER) as i64;
     if elapsed_secs > stall_threshold {
@@ -162,13 +162,13 @@ fn stall_recipients() -> Vec<String> {
 fn emit_stall(home: &Path, task: &Task, reason: &str) {
     let text = format!(
         "[task_stalled] {tid} '{title}' stalled — {reason}. \
-         dispatched_at={dispatched_at}, eta_secs={eta_secs}, assignee={assignee}. \
+         started_at={started_at}, eta_secs={eta_secs}, assignee={assignee}. \
          Consider: lead re-dispatch / dev unblock-ping / task action=update with \
          status=blocked + reason if dependency.",
         tid = task.id,
         title = task.title,
         reason = reason,
-        dispatched_at = task.dispatched_at.as_deref().unwrap_or("?"),
+        started_at = task.started_at.as_deref().unwrap_or("?"),
         eta_secs = task
             .eta_secs
             .map(|e| e.to_string())
@@ -240,12 +240,7 @@ mod tests {
         dir
     }
 
-    fn make_task(
-        id: &str,
-        status: &str,
-        eta_secs: Option<i64>,
-        dispatched_at: Option<&str>,
-    ) -> Task {
+    fn make_task(id: &str, status: &str, eta_secs: Option<i64>, started_at: Option<&str>) -> Task {
         Task {
             id: id.to_string(),
             title: format!("test task {id}"),
@@ -261,7 +256,7 @@ mod tests {
             updated_at: chrono::Utc::now().to_rfc3339(),
             due_at: None,
             branch: None,
-            dispatched_at: dispatched_at.map(String::from),
+            started_at: started_at.map(String::from),
             eta_secs,
         }
     }

--- a/src/daemon/legacy_backfill.rs
+++ b/src/daemon/legacy_backfill.rs
@@ -581,7 +581,7 @@ mod tests {
             updated_at: "2026-04-26T00:00:00Z".into(),
             due_at: None,
             branch: None,
-            dispatched_at: None,
+            started_at: None,
             eta_secs: None,
         }
     }

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -783,7 +783,7 @@ mod tests {
             updated_at: "2026-05-08T00:00:00Z".into(),
             due_at: None,
             branch: None,
-            dispatched_at: None,
+            started_at: None,
             eta_secs: None,
         }
     }

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -466,7 +466,7 @@ mod tests {
             updated_at: String::new(),
             due_at: None,
             branch: None,
-            dispatched_at: None,
+            started_at: None,
             eta_secs: None,
         }
     }
@@ -522,7 +522,7 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             due_at: None,
             branch: None,
-            dispatched_at: None,
+            started_at: None,
             eta_secs: None,
         }];
         terminal

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -217,7 +217,7 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".to_string(),
             due_at: None,
             branch: None,
-            dispatched_at: None,
+            started_at: None,
             eta_secs: None,
         }];
         let all_instances = vec![

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -429,13 +429,17 @@ pub struct TaskRecord {
     /// `Some(false)` means RCA/audit/design class; auto-bind was skipped.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bind: Option<bool>,
-    /// Sprint 59 Wave 1 PR-1 (#9 task stall watchdog) — RFC3339
-    /// timestamp captured when the task first transitions to
-    /// `in_progress`. Set in the `TaskEvent::InProgress` arm of
+    /// RFC3339 timestamp captured when the task first transitions
+    /// to `in_progress`. Set in the `TaskEvent::InProgress` arm of
     /// [`TaskBoardState::apply`]; idempotent (only first transition
     /// records the timestamp).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub dispatched_at: Option<String>,
+    ///
+    /// #807 Item 3: renamed `dispatched_at` → `started_at`. The
+    /// stamp lands on InProgress (post-claim), not at `send()`
+    /// dispatch. `serde(alias)` preserves replay of legacy
+    /// task_events.jsonl carrying the prior field name.
+    #[serde(alias = "dispatched_at", skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
     /// Sprint 59 Wave 1 PR-1 (#9 task stall watchdog) — operator-
     /// supplied estimate of seconds to completion, sourced from the
     /// `eta_secs` field on `TaskEvent::Created` (or a future
@@ -537,7 +541,7 @@ impl TaskBoardState {
                         result: None,
                         branch: branch.clone(),
                         bind: *bind,
-                        dispatched_at: None,
+                        started_at: None,
                         eta_secs: *eta_secs,
                     });
             }
@@ -555,15 +559,13 @@ impl TaskBoardState {
                     t.status = TaskStatus::InProgress;
                     t.owner = Some(by.clone());
                     t.updated_at = touch_at.clone();
-                    // Sprint 59 Wave 1 PR-1: set dispatched_at on FIRST
-                    // transition to InProgress. Subsequent re-entries
-                    // (e.g. after a Released → Claimed → InProgress
-                    // cycle) leave the original dispatched_at intact —
-                    // the anti-stall scanner cares about "when did the
-                    // task start being worked on", not the latest
-                    // checkpoint.
-                    if t.dispatched_at.is_none() {
-                        t.dispatched_at = Some(touch_at);
+                    // #807 Item 3: stamp started_at on FIRST transition
+                    // to InProgress (renamed from dispatched_at — the
+                    // value lands here post-claim, not at send()).
+                    // Subsequent re-entries (Released → Claimed →
+                    // InProgress cycle) preserve the original stamp.
+                    if t.started_at.is_none() {
+                        t.started_at = Some(touch_at);
                     }
                 }
             }
@@ -1950,7 +1952,7 @@ mod tests {
         // Pre-claim: dispatched_at is None.
         let pre = replay(&home).unwrap();
         let pre_t = pre.tasks.get(&tid).unwrap();
-        assert!(pre_t.dispatched_at.is_none(), "pre-claim: no dispatched_at");
+        assert!(pre_t.started_at.is_none(), "pre-claim: no dispatched_at");
 
         append(
             &home,
@@ -1963,7 +1965,7 @@ mod tests {
         .unwrap();
         // Post-claim, pre-in_progress: still None.
         let mid = replay(&home).unwrap();
-        assert!(mid.tasks.get(&tid).unwrap().dispatched_at.is_none());
+        assert!(mid.tasks.get(&tid).unwrap().started_at.is_none());
 
         append(
             &home,
@@ -1978,7 +1980,7 @@ mod tests {
         let post = replay(&home).unwrap();
         let post_t = post.tasks.get(&tid).unwrap();
         assert!(
-            post_t.dispatched_at.is_some(),
+            post_t.started_at.is_some(),
             "in_progress must set dispatched_at: {post_t:?}"
         );
         std::fs::remove_dir_all(&home).ok();
@@ -2034,7 +2036,7 @@ mod tests {
             .tasks
             .get(&tid)
             .unwrap()
-            .dispatched_at
+            .started_at
             .clone();
         assert!(first_dispatched.is_some());
 
@@ -2075,7 +2077,7 @@ mod tests {
             .tasks
             .get(&tid)
             .unwrap()
-            .dispatched_at
+            .started_at
             .clone();
         assert_eq!(
             first_dispatched, second_dispatched,

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -641,7 +641,22 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 eta_secs: args["eta_secs"].as_i64(),
             };
             match crate::task_events::append(home, &emitter, event) {
-                Ok(_) => serde_json::json!({"id": id, "status": "created"}),
+                Ok(_) => {
+                    // #807 Item 1: response shape consistency. `event`
+                    // names the action verb; `task` carries the full
+                    // Task object so callers can read lifecycle status
+                    // (`task.status == "open"` after create, NOT the
+                    // event name "created"). Legacy `status` field
+                    // kept as back-compat alias.
+                    let task = read_task_record(home, &id).map(|r| record_to_task(&r));
+                    serde_json::json!({
+                        "id": id,
+                        "event": "created",
+                        "task": task,
+                        // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
+                        "status": "created",
+                    })
+                }
                 Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
             }
         }
@@ -730,7 +745,20 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             };
             match crate::task_events::append(home, &emitter, event) {
                 Ok(_) => {
-                    serde_json::json!({"id": id, "status": "claimed", "assignee": instance_name})
+                    // #807 Item 1: see create arm note. claim's
+                    // legacy `status` happens to match lifecycle
+                    // ("claimed"), but the field is still the action
+                    // event name semantically — kept as alias for
+                    // shape consistency.
+                    let task = read_task_record(home, &id).map(|r| record_to_task(&r));
+                    serde_json::json!({
+                        "id": id,
+                        "event": "claimed",
+                        "task": task,
+                        "assignee": instance_name,
+                        // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
+                        "status": "claimed",
+                    })
                 }
                 Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
             }
@@ -833,7 +861,15 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                         let _ =
                             crate::mcp::handlers::dispatch_hook::clean_empty_init_commits(&wt).ok();
                     }
-                    serde_json::json!({"id": id, "status": "done"})
+                    // #807 Item 1: see create arm note.
+                    let task = read_task_record(home, &id).map(|r| record_to_task(&r));
+                    serde_json::json!({
+                        "id": id,
+                        "event": "done",
+                        "task": task,
+                        // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
+                        "status": "done",
+                    })
                 }
                 Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
             }
@@ -1047,7 +1083,15 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                     });
                 }
             }
-            serde_json::json!({"id": id, "status": "updated"})
+            // #807 Item 1: see create arm note.
+            let task = read_task_record(home, &id).map(|r| record_to_task(&r));
+            serde_json::json!({
+                "id": id,
+                "event": "updated",
+                "task": task,
+                // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
+                "status": "updated",
+            })
         }
         "sweep" => {
             // #806 manual board-hygiene sweep — distinct from the

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -26,14 +26,23 @@ pub struct Task {
     /// dispatch; reviewer uses this to scope `checkout_repo`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
-    /// Sprint 59 Wave 1 PR-1 (#9 task stall watchdog) — RFC3339
-    /// timestamp captured the first time `status` transitions to
-    /// `in_progress` via `TaskEvent::InProgress`. Used by the
-    /// daemon-side anti-stall scanner to compute elapsed time
-    /// against `eta_secs`. `None` for tasks that never reached
-    /// in_progress OR pre-existed Sprint 59 schema migration.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dispatched_at: Option<String>,
+    /// RFC3339 timestamp captured the first time `status`
+    /// transitions to `in_progress` via `TaskEvent::InProgress`.
+    /// Used by the daemon-side anti-stall scanner to compute
+    /// elapsed time against `eta_secs`. `None` for tasks that
+    /// never reached in_progress OR pre-existed Sprint 59 schema
+    /// migration.
+    ///
+    /// #807 Item 3: renamed `dispatched_at` → `started_at`. The
+    /// value is stamped on first InProgress (post-claim), not at
+    /// `send()` dispatch — old name was misleading. `serde(alias)`
+    /// preserves replay of legacy persisted JSON.
+    #[serde(
+        default,
+        alias = "dispatched_at",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub started_at: Option<String>,
     /// Sprint 59 Wave 1 PR-1 (#9 task stall watchdog) — operator-
     /// supplied estimate of seconds to completion. The anti-stall
     /// scanner emits a `task_stalled` inbox event when elapsed time
@@ -193,7 +202,7 @@ fn record_to_task(r: &crate::task_events::TaskRecord) -> Task {
         updated_at: r.updated_at.clone(),
         due_at: r.due_at.clone(),
         branch: r.branch.clone(),
-        dispatched_at: r.dispatched_at.clone(),
+        started_at: r.started_at.clone(),
         eta_secs: r.eta_secs,
     }
 }
@@ -1500,7 +1509,7 @@ mod tests {
             updated_at: "2026-04-27T00:00:00Z".into(),
             due_at: None,
             branch: None,
-            dispatched_at: None,
+            started_at: None,
             eta_secs: None,
         }
     }
@@ -2713,7 +2722,7 @@ mod tests {
                     updated_at: chrono::Utc::now().to_rfc3339(),
                     due_at: None,
                     branch: None,
-                    dispatched_at: None,
+                    started_at: None,
                     eta_secs: None,
                 });
             }
@@ -2777,7 +2786,7 @@ mod tests {
                 updated_at: chrono::Utc::now().to_rfc3339(),
                 due_at: None,
                 branch: None,
-                dispatched_at: None,
+                started_at: None,
                 eta_secs: None,
             });
             Ok(())
@@ -3771,8 +3780,32 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    // NOTE: `test_task_deserialize_dispatched_at_alias_preserves_back_compat`
-    // is added in C4 (Item 3) — depends on the `started_at` struct
-    // field existing post-rename. Pre-C4 it cannot compile, so it
-    // lands with the rename.
+    #[test]
+    fn test_task_deserialize_dispatched_at_alias_preserves_back_compat() {
+        // #807 Item 3: persisted JSON carrying the old `dispatched_at`
+        // field name MUST still deserialize into the renamed
+        // `started_at` field via `#[serde(alias = "dispatched_at")]`.
+        // Locks the contract that pre-rename task_events.jsonl files
+        // and external test fixtures keep working post-migration.
+        let raw_old = serde_json::json!({
+            "id": "t-test-back-compat",
+            "title": "old",
+            "description": "",
+            "status": "open",
+            "priority": "normal",
+            "assignee": null,
+            "created_by": "test",
+            "depends_on": [],
+            "result": null,
+            "created_at": "2026-04-01T00:00:00Z",
+            "updated_at": "2026-04-01T00:00:00Z",
+            "dispatched_at": "2026-04-02T00:00:00Z",
+        });
+        let t: Task = serde_json::from_value(raw_old).expect("deserialize old shape");
+        assert_eq!(
+            t.started_at.as_deref(),
+            Some("2026-04-02T00:00:00Z"),
+            "serde alias must map legacy `dispatched_at` → new `started_at`"
+        );
+    }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -3614,4 +3614,121 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ── #807 response shape consistency bundle — RED tests ──
+
+    #[test]
+    fn test_action_responses_carry_event_and_task_fields_with_lifecycle_status() {
+        // #807 Item 1 RED: create/claim/update/done responses today
+        // overload `status` with action-event names ("created" /
+        // "updated") that don't match the task's lifecycle status
+        // (which is "open" / unchanged). Post-fix: every action
+        // response gains an `event` field (the action verb) AND a
+        // `task` field (full Task object with the correct lifecycle
+        // `status`). The legacy `status` field stays as a back-compat
+        // alias per the dispatch spec (NOT removed).
+        let home = tmp_home("action_response_shape");
+        write_fleet_yaml(&home, &["agent-a"]);
+
+        // create
+        let r = handle(
+            &home,
+            "agent-a",
+            &serde_json::json!({"action": "create", "title": "t1", "assignee": "agent-a"}),
+        );
+        let id = r["id"].as_str().expect("id").to_string();
+        assert_eq!(
+            r["event"], "created",
+            "create must carry event=created: {r}"
+        );
+        assert_eq!(
+            r["task"]["status"], "open",
+            "create task object must carry lifecycle status=open: {r}"
+        );
+        assert_eq!(
+            r["status"], "created",
+            "back-compat status alias preserved (status=event for create): {r}"
+        );
+
+        // claim
+        let r = handle(
+            &home,
+            "agent-a",
+            &serde_json::json!({"action": "claim", "id": id}),
+        );
+        assert_eq!(r["event"], "claimed", "claim must carry event=claimed: {r}");
+        assert_eq!(
+            r["task"]["status"], "claimed",
+            "claim task object must carry lifecycle status=claimed: {r}"
+        );
+
+        // update → in_progress
+        let r = handle(
+            &home,
+            "agent-a",
+            &serde_json::json!({"action": "update", "id": id, "status": "in_progress"}),
+        );
+        assert_eq!(
+            r["event"], "updated",
+            "update must carry event=updated: {r}"
+        );
+        assert_eq!(
+            r["task"]["status"], "in_progress",
+            "update task object must carry lifecycle status=in_progress (NOT 'updated'): {r}"
+        );
+
+        // done
+        let r = handle(
+            &home,
+            "agent-a",
+            &serde_json::json!({"action": "done", "id": id, "result": "shipped"}),
+        );
+        assert_eq!(r["event"], "done", "done must carry event=done: {r}");
+        assert_eq!(
+            r["task"]["status"], "done",
+            "done task object must carry lifecycle status=done: {r}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn test_task_started_at_replaces_dispatched_at_in_serialized_output() {
+        // #807 Item 3 RED: today the Task struct field is named
+        // `dispatched_at` but the value is stamped on first transition
+        // to InProgress — so the operator's "when was this dispatched
+        // from send()?" reading is misleading. Rename to `started_at`
+        // (matches `claimed_at` naming, mental model honest). serde
+        // alias `dispatched_at` preserves replay of old persisted logs.
+        let home = tmp_home("started_at_rename");
+        write_fleet_yaml(&home, &["a"]);
+        let r = handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "create", "title": "t", "assignee": "a"}),
+        );
+        let id = r["id"].as_str().expect("id").to_string();
+        handle(
+            &home,
+            "a",
+            &serde_json::json!({"action": "update", "id": id, "status": "in_progress"}),
+        );
+        let listed = handle(&home, "a", &serde_json::json!({"action": "list"}));
+        let task = listed["tasks"][0].as_object().expect("task object in list");
+        assert!(
+            task.contains_key("started_at"),
+            "task must serialize `started_at` (not `dispatched_at`), got keys: {:?}",
+            task.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            task["started_at"].is_string(),
+            "started_at must be an RFC3339 string, got: {:?}",
+            task["started_at"]
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // NOTE: `test_task_deserialize_dispatched_at_alias_preserves_back_compat`
+    // is added in C4 (Item 3) — depends on the `started_at` struct
+    // field existing post-rename. Pre-C4 it cannot compile, so it
+    // lands with the rename.
 }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -1612,4 +1612,59 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ── #807 Item 2 — ReleaseOutcome serialization shape ──
+
+    #[test]
+    fn test_release_outcome_success_omits_error_key() {
+        // #807 Item 2 RED: pre-fix `ReleaseOutcome` always serializes
+        // `error: None` → `"error": null`, which client renderers
+        // (Claude Code, etc.) interpret as an `<error>` envelope on
+        // what is actually a successful release. Fix: add
+        // `#[serde(skip_serializing_if = "Option::is_none")]` so the
+        // `error` key is absent on success.
+        let outcome = ReleaseOutcome {
+            released: true,
+            worktree_removed: true,
+            binding_removed: true,
+            branch_deleted: true,
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&outcome).expect("serialize");
+        let obj = json.as_object().expect("object shape");
+        assert!(
+            !obj.contains_key("error"),
+            "success response must NOT carry `error` key (#807 cosmetic fix), got keys: {:?}",
+            obj.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !obj.contains_key("branch_cleanup_skipped_reason"),
+            "success response must NOT carry `branch_cleanup_skipped_reason` when None, got keys: {:?}",
+            obj.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_release_outcome_real_failure_emits_error_key() {
+        // #807 Item 2 contract guarantee: actual failures STILL emit
+        // the `error` field. Only the `None`-on-success case is
+        // omitted — `skip_serializing_if` only drops `None`, never
+        // `Some`.
+        let outcome = ReleaseOutcome {
+            released: false,
+            error: Some("test failure".to_string()),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&outcome).expect("serialize");
+        let obj = json.as_object().expect("object shape");
+        assert!(
+            obj.contains_key("error"),
+            "real failure must surface `error` key, got keys: {:?}",
+            obj.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            obj["error"], "test failure",
+            "error message must round-trip unchanged"
+        );
+    }
 }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -109,7 +109,13 @@ pub struct ReleaseOutcome {
     pub worktree_removed: bool,
     pub binding_removed: bool,
     pub branch_deleted: bool,
+    // #807 Item 2: drop optional keys on success so clients
+    // don't render `"error": null` as an `<error>` envelope.
+    // Real failures still emit `error` (skip_serializing_if
+    // drops `None` only, never `Some`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub branch_cleanup_skipped_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 


### PR DESCRIPTION
Closes #807.

scope follows dispatch spec t-20260515033100472248-4

## Summary

Three cosmetic response-shape inconsistencies bundled per the issue's framing. Each item is surgical (~5-30 LOC), they touch disjoint surfaces, and they share the "honest naming" thesis.

- **Item 1 — task action responses overload `status`**: `task action=create` returned `status: "created"` (an event name) while the board recorded `status: "open"` (the lifecycle status). Same shape for `update` ("updated" vs unchanged). Post-fix every action response gains an `event` field (the verb) AND a `task` field (full Task object with the real lifecycle status). Legacy `status` field kept as deprecated alias for back-compat.
- **Item 2 — `release_worktree` success rendered as `<error>` envelope**: `ReleaseOutcome.error: Option<String>` always serialized — `None` came out as `"error": null`, which client renderers (Claude Code, MCP UIs) interpret as an error envelope on a successful release. Post-fix: `#[serde(skip_serializing_if = "Option::is_none")]` drops the key on success; real failures still emit `error` (`skip_serializing_if` only drops `None`).
- **Item 3 — `Task.dispatched_at` misleads operators**: field is stamped on first `InProgress` transition (post-claim), NOT at `send()` dispatch — producing the counter-intuitive `dispatched_at > claimed_at` ordering. Renamed to `started_at` (matches `claimed_at` mental model). `#[serde(alias = "dispatched_at")]` preserves replay of legacy persisted task_events.jsonl files.

## Design notes (3 design calls per dispatch spec)

| Question | Decision | Rationale |
|---|---|---|
| Keep deprecated `status` alias on action responses? | **YES, keep** | Zero-break. Future sweeper batch-clean only. Comment in code marks deprecation. |
| Item 1 — scope to `create` only or all 4 actions? | **All 4** (create/claim/update/done) | Same surface, KISS. +10 LOC over single-action fix. Consistency beats narrow scope. |
| Item 3 — rename to `started_at` or `first_in_progress_at`? | **`started_at`** | Short, pairs with `claimed_at`, matches operator mental model. |

## Back-compat

- **Item 1**: Zero break. Adds `event` + `task` fields; `status` field unchanged.
- **Item 2**: Wire-format only. `None` → key absent (was: key present with `null` value). Rust-side deserialization tolerates both (Option<String> defaults to None on missing). JS/Python clients reading `r.error` get `undefined`/`KeyError` vs `null` — defensive callers already handle both.
- **Item 3**: Field rename + `serde(alias = "dispatched_at")` on both `Task.started_at` and `TaskRecord.started_at`. Persisted task_events.jsonl carrying the legacy field name keeps deserializing without migration.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite: 2224 binary tests + integration + UI smoke + doc-tests, 0 regressions (was 2215 pre-PR + 7 new tests + 2 newly-arrived = 2224).

C1 RED tests (3 failing pre-fix, structural):
- [x] `test_action_responses_carry_event_and_task_fields_with_lifecycle_status` — RED at C1, GREEN at C2 (Item 1)
- [x] `test_release_outcome_success_omits_error_key` — RED at C1, GREEN at C3 (Item 2)
- [x] `test_task_started_at_replaces_dispatched_at_in_serialized_output` — RED at C1, GREEN at C4 (Item 3)
- [x] `test_release_outcome_real_failure_emits_error_key` — baseline regression (passes at C1; locks Item 2 fix to drop only `None`, never `Some`).

C4 back-compat test (lands with the rename — requires `started_at` field to compile):
- [x] `test_task_deserialize_dispatched_at_alias_preserves_back_compat` — legacy JSON shape still deserializes to renamed field via serde alias.

## Commit chain

1. `fec51a2` — `test(#807): RED tests for response shape consistency bundle`
2. `da304cd` — `fix(#807): event + task fields on all 4 action responses (Item 1 / C2)`
3. `646bd24` — `fix(#807): omit ReleaseOutcome optional keys on success (Item 2 / C3)`
4. `f00126f` — `fix(#807): rename Task.dispatched_at → started_at + serde alias (Item 3 / C4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)