### PR TITLE
fix(#813): ci_watch CONFLICTING PR detection (alert on mergeable=DIRTY, no silent forever-poll)

### DIFF
--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -23,10 +23,12 @@ pub const WATCH_TTL_HOURS: i64 = 72;
 // The re-exports preserve that path even when the only in-tree use of
 // some items is via the trait object inside `watcher::check_ci_watches`.
 #[allow(unused_imports)]
+pub use poller::{emit_ci_conflict_alert, watch_start_check_mergeable};
+#[allow(unused_imports)]
 pub use provider::{
     detect_provider_from_remote, github_token_warning, github_token_warning_from_env,
     BitbucketCiProvider, CiPollResult, CiProvider, CiRun, GitHubCiProvider, GitLabCiProvider,
-    PrState,
+    MergeableState, PrState,
 };
 #[allow(unused_imports)]
 pub use registry::{ci_watches_dir, remove_watch, watch_filename};

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -2,9 +2,7 @@ use crate::agent::{self, AgentRegistry};
 use std::path::Path;
 use std::sync::Arc;
 
-#[cfg(test)]
-use super::provider::MergeableState;
-use super::provider::{CiPollResult, CiProvider, CiRun, PrState};
+use super::provider::{CiPollResult, CiProvider, CiRun, MergeableState, PrState};
 use super::registry::{
     ci_watches_dir, parse_subscribers, remove_watch, update_watch_state,
     update_watch_state_with_notify,
@@ -120,41 +118,104 @@ fn watch_is_due(last_polled_at: Option<i64>, interval_secs: u64, now_ms: i64) ->
     }
 }
 
-// ── #813 stubs — real impl lands in C2/C3/C4 ─────────────────────────
+// ── #813 ci_watch CONFLICTING PR detection ──
 
-/// #813: emit a `[ci-conflict-detected]` headline to every subscriber.
-/// Mirrors the existing terminal-run fan-out at the ci_check_repo
-/// `for sub in subscribers` loop — in-band inject + inbox enqueue
-/// for persistence. Stub returns a no-op pre-C2; real impl lands in
-/// C2 with the production fan-out code.
+/// #813: emit a `[ci-conflict-detected]` headline to every subscriber's
+/// inbox. Persists to JSONL via `crate::inbox::enqueue` so the
+/// operator sees the alert on the next inbox read. NO in-band PTY
+/// inject here (unlike the terminal-run fan-out) because the
+/// `handle_watch_ci` caller doesn't carry an `&AgentRegistry`; the
+/// inbox enqueue alone provides the durable signal and the next
+/// inbox poll surfaces it within seconds.
+///
+/// `source` is recorded in the alert body so the operator can
+/// distinguish on-watch-start triggers ("watch-start") from periodic
+/// re-check triggers ("poll-transition"). Dead-code allow lifts at
+/// C3 (handle_watch_ci wires the on-start path) + C4 (poller wires
+/// the periodic re-check).
 #[allow(dead_code)]
 pub fn emit_ci_conflict_alert(
-    _home: &Path,
-    _repo: &str,
-    _branch: &str,
-    _subscribers: &[String],
-    _source: &str,
+    home: &Path,
+    repo: &str,
+    branch: &str,
+    subscribers: &[String],
+    source: &str,
 ) {
-    // Stub — see doc comment. Real impl lands in C2.
+    let body = format!(
+        "[ci-conflict-detected] {repo}@{branch}: PR is CONFLICTING with base. \
+         CI workflow trigger blocked until rebase. \
+         URL: https://github.com/{repo}/pulls?q=is%3Apr+head%3A{branch} \
+         (source: {source})"
+    );
+    for sub in subscribers {
+        let _ = crate::inbox::enqueue(
+            home,
+            sub,
+            crate::inbox::InboxMessage {
+                schema_version: 0,
+                id: None,
+                read_at: None,
+                thread_id: None,
+                parent_id: None,
+                task_id: None,
+                force_meta: None,
+                correlation_id: None,
+                reviewed_head: None,
+                from: "system:ci".to_string(),
+                text: body.clone(),
+                kind: Some("ci-watch".to_string()),
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                channel: None,
+                delivery_mode: None,
+                attachments: vec![],
+                in_reply_to_msg_id: None,
+                in_reply_to_excerpt: None,
+                superseded_by: None,
+                from_id: None,
+                broadcast_context: None,
+                sequencing: None,
+                eta_minutes: None,
+                reporting_cadence: None,
+                worktree_binding_required: None,
+            },
+        );
+    }
 }
 
-/// #813: on-watch-start mergeable check. Queries the provider for
-/// the PR's mergeable state and emits a `[ci-conflict-detected]`
-/// alert if CONFLICTING (DIRTY). Updates the watch JSON with the
-/// observed state + check timestamp so the periodic re-check in
-/// Part B (`ci_check_repo`) can de-dupe transitions. Fail-open on
-/// any query error (Unknown → no alert, no block). Stub returns
-/// without side-effect pre-C3.
+/// #813: on-watch-start mergeable check. Queries the provider via
+/// the blocking variant (sync caller — `handle_watch_ci` is non-async),
+/// caches the observed state into the watch JSON, and emits a
+/// `[ci-conflict-detected]` alert when CONFLICTING. Fail-open on
+/// Unknown (no alert, no block — preserves behavior under transient
+/// GH outages). Dead-code allow lifts at C3 when handle_watch_ci
+/// wires the call site.
 #[allow(dead_code)]
 pub fn watch_start_check_mergeable(
-    _home: &Path,
-    _watch_path: &Path,
-    _repo: &str,
-    _branch: &str,
-    _subscribers: &[String],
-    _provider: &dyn CiProvider,
+    home: &Path,
+    watch_path: &Path,
+    repo: &str,
+    branch: &str,
+    subscribers: &[String],
+    provider: &dyn CiProvider,
 ) {
-    // Stub — see doc comment. Real impl lands in C3.
+    let state = provider.check_pr_mergeable_blocking(repo, branch);
+    // Cache the observed state regardless of variant so the poll
+    // cycle's transition detector has a baseline. UNKNOWN is cached
+    // too — distinguishes "never checked" (field absent) from
+    // "checked but uncertain" (field present, value UNKNOWN).
+    let now_rfc3339 = chrono::Utc::now().to_rfc3339();
+    if let Ok(content) = std::fs::read_to_string(watch_path) {
+        if let Ok(mut w) = serde_json::from_str::<serde_json::Value>(&content) {
+            w["last_mergeable_state"] = serde_json::json!(state.as_str());
+            w["last_mergeable_check_at"] = serde_json::json!(now_rfc3339);
+            if let Ok(out) = serde_json::to_string_pretty(&w) {
+                let _ = std::fs::write(watch_path, out);
+            }
+        }
+    }
+    if matches!(state, MergeableState::Conflicting) {
+        emit_ci_conflict_alert(home, repo, branch, subscribers, "watch-start");
+    }
 }
 
 /// Inner implementation that accepts a provider factory for testability.

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -130,10 +130,8 @@ fn watch_is_due(last_polled_at: Option<i64>, interval_secs: u64, now_ms: i64) ->
 ///
 /// `source` is recorded in the alert body so the operator can
 /// distinguish on-watch-start triggers ("watch-start") from periodic
-/// re-check triggers ("poll-transition"). Dead-code allow lifts at
-/// C3 (handle_watch_ci wires the on-start path) + C4 (poller wires
-/// the periodic re-check).
-#[allow(dead_code)]
+/// re-check triggers ("poll-transition"). C3 wires watch-start path;
+/// C4 wires the periodic-poll re-check call site.
 pub fn emit_ci_conflict_alert(
     home: &Path,
     repo: &str,
@@ -187,9 +185,7 @@ pub fn emit_ci_conflict_alert(
 /// caches the observed state into the watch JSON, and emits a
 /// `[ci-conflict-detected]` alert when CONFLICTING. Fail-open on
 /// Unknown (no alert, no block — preserves behavior under transient
-/// GH outages). Dead-code allow lifts at C3 when handle_watch_ci
-/// wires the call site.
-#[allow(dead_code)]
+/// GH outages).
 pub fn watch_start_check_mergeable(
     home: &Path,
     watch_path: &Path,
@@ -4574,6 +4570,61 @@ mod tests {
         assert_eq!(
             entry["pr_mergeable_state"], "CONFLICTING",
             "field must reflect the watch JSON's last_mergeable_state value"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_mergeable_check_fail_open_on_provider_error() {
+        // GREEN coverage: when the provider returns Unknown (rate-limit,
+        // network failure, no PR found) the helper must NOT emit an
+        // alert AND must cache UNKNOWN to the watch JSON (so the
+        // periodic re-check loop has a baseline). Fail-open contract
+        // — block legit work only on confirmed CONFLICTING signal.
+        let dir = tmp_dir("watch_start_unknown");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = serde_json::json!({
+            "repo": "test/repo",
+            "branch": "fix/x",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-15T00:00:00Z"}],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_path = ci_dir.join(watch_filename("test/repo", "fix/x"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+        // Default Mock returns Unknown (no `.with_mergeable(...)`).
+        let provider = MockCiProvider::with_runs(Vec::new());
+
+        super::watch_start_check_mergeable(
+            &dir,
+            &watch_path,
+            "test/repo",
+            "fix/x",
+            &["lead".to_string()],
+            &provider,
+        );
+
+        let inbox_path = dir.join("inbox").join("lead.jsonl");
+        let body = std::fs::read_to_string(&inbox_path).unwrap_or_default();
+        assert!(
+            !body.contains("[ci-conflict-detected]"),
+            "fail-open: Unknown provider result must NOT emit alert, got: {body}"
+        );
+        // Watch JSON now carries UNKNOWN for baseline.
+        let after: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+        assert_eq!(
+            after["last_mergeable_state"].as_str(),
+            Some("UNKNOWN"),
+            "Unknown state must still be cached to watch JSON as a baseline"
         );
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -2,6 +2,8 @@ use crate::agent::{self, AgentRegistry};
 use std::path::Path;
 use std::sync::Arc;
 
+#[cfg(test)]
+use super::provider::MergeableState;
 use super::provider::{CiPollResult, CiProvider, CiRun, PrState};
 use super::registry::{
     ci_watches_dir, parse_subscribers, remove_watch, update_watch_state,
@@ -116,6 +118,43 @@ fn watch_is_due(last_polled_at: Option<i64>, interval_secs: u64, now_ms: i64) ->
         None => true,
         Some(ts) => now_ms.saturating_sub(ts) >= (interval_secs as i64) * 1000,
     }
+}
+
+// ── #813 stubs — real impl lands in C2/C3/C4 ─────────────────────────
+
+/// #813: emit a `[ci-conflict-detected]` headline to every subscriber.
+/// Mirrors the existing terminal-run fan-out at the ci_check_repo
+/// `for sub in subscribers` loop — in-band inject + inbox enqueue
+/// for persistence. Stub returns a no-op pre-C2; real impl lands in
+/// C2 with the production fan-out code.
+#[allow(dead_code)]
+pub fn emit_ci_conflict_alert(
+    _home: &Path,
+    _repo: &str,
+    _branch: &str,
+    _subscribers: &[String],
+    _source: &str,
+) {
+    // Stub — see doc comment. Real impl lands in C2.
+}
+
+/// #813: on-watch-start mergeable check. Queries the provider for
+/// the PR's mergeable state and emits a `[ci-conflict-detected]`
+/// alert if CONFLICTING (DIRTY). Updates the watch JSON with the
+/// observed state + check timestamp so the periodic re-check in
+/// Part B (`ci_check_repo`) can de-dupe transitions. Fail-open on
+/// any query error (Unknown → no alert, no block). Stub returns
+/// without side-effect pre-C3.
+#[allow(dead_code)]
+pub fn watch_start_check_mergeable(
+    _home: &Path,
+    _watch_path: &Path,
+    _repo: &str,
+    _branch: &str,
+    _subscribers: &[String],
+    _provider: &dyn CiProvider,
+) {
+    // Stub — see doc comment. Real impl lands in C3.
 }
 
 /// Inner implementation that accepts a provider factory for testability.
@@ -1745,6 +1784,11 @@ mod tests {
         poll_result: Mutex<Option<CiPollResult>>,
         pr_state: Mutex<PrState>,
         failure_summary: Mutex<String>,
+        /// #813: pre-seeded mergeable response. Defaults to
+        /// `Unknown` (fail-open) so existing tests aren't affected
+        /// by the new check. Tests targeting #813 set this via
+        /// `with_mergeable`.
+        mergeable: Mutex<MergeableState>,
     }
 
     impl MockCiProvider {
@@ -1757,6 +1801,7 @@ mod tests {
                 })),
                 pr_state: Mutex::new(PrState::Open),
                 failure_summary: Mutex::new("Build / Test".to_string()),
+                mergeable: Mutex::new(MergeableState::Unknown),
             }
         }
 
@@ -1777,6 +1822,7 @@ mod tests {
                 })),
                 pr_state: Mutex::new(PrState::Open),
                 failure_summary: Mutex::new("Build / Test".to_string()),
+                mergeable: Mutex::new(MergeableState::Unknown),
             }
         }
 
@@ -1789,12 +1835,32 @@ mod tests {
                 })),
                 pr_state: Mutex::new(PrState::Open),
                 failure_summary: Mutex::new("Build / Test".to_string()),
+                mergeable: Mutex::new(MergeableState::Unknown),
             }
         }
 
         fn with_pr_terminal(self) -> Self {
             *self.pr_state.lock() = PrState::Terminal { merged: true };
             self
+        }
+
+        /// #813: pre-seed the mergeable response so tests can exercise
+        /// CONFLICTING / MERGEABLE / UNSTABLE / UNKNOWN paths without
+        /// hitting GitHub. The seed is sticky (not consumed on read)
+        /// so a multi-poll test sees the same state across cycles
+        /// unless explicitly transitioned via `set_mergeable`.
+        #[allow(dead_code)]
+        fn with_mergeable(self, state: MergeableState) -> Self {
+            *self.mergeable.lock() = state;
+            self
+        }
+
+        /// #813: transition the mock's mergeable response between
+        /// poll cycles (lets a test exercise the "transition INTO
+        /// CONFLICTING" alert path without spinning up two providers).
+        #[allow(dead_code)]
+        fn set_mergeable(&self, state: MergeableState) {
+            *self.mergeable.lock() = state;
         }
     }
 
@@ -1806,6 +1872,9 @@ mod tests {
         async fn check_pr_terminal(&self, _repo: &str, _branch: &str) -> PrState {
             let mut guard = self.pr_state.lock();
             std::mem::replace(&mut *guard, PrState::Open)
+        }
+        async fn check_pr_mergeable(&self, _repo: &str, _branch: &str) -> MergeableState {
+            self.mergeable.lock().clone()
         }
         async fn fetch_failure_summary(&self, _repo: &str, _run_id: u64) -> String {
             self.failure_summary.lock().clone()
@@ -2140,6 +2209,7 @@ mod tests {
             })),
             pr_state: Mutex::new(PrState::Open),
             failure_summary: Mutex::new(String::new()),
+            mergeable: Mutex::new(MergeableState::Unknown),
         };
         let result = run_ci_check(&dir, &base_watch(), &provider);
         assert!(result.is_err(), "rate-limit must propagate as error");
@@ -4341,6 +4411,109 @@ mod tests {
             );
         }
 
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── #813 ci_watch CONFLICTING PR detection — RED tests ──
+
+    #[test]
+    fn test_watch_start_on_conflicting_emits_alert() {
+        // RED: pre-C3, `watch_start_check_mergeable` is a no-op stub
+        // so the subscriber inbox stays empty even when the provider
+        // reports CONFLICTING. Post-C3 the hook emits a
+        // `[ci-conflict-detected]` headline + inbox entry so the
+        // operator gets the signal before GH webhook silence kicks in.
+        let dir = tmp_dir("watch_start_conflict");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = serde_json::json!({
+            "repo": "test/repo",
+            "branch": "fix/x",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-15T00:00:00Z"}],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_path = ci_dir.join(watch_filename("test/repo", "fix/x"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+        let provider =
+            MockCiProvider::with_runs(Vec::new()).with_mergeable(MergeableState::Conflicting);
+
+        super::watch_start_check_mergeable(
+            &dir,
+            &watch_path,
+            "test/repo",
+            "fix/x",
+            &["lead".to_string()],
+            &provider,
+        );
+
+        let inbox_path = dir.join("inbox").join("lead.jsonl");
+        let body = std::fs::read_to_string(&inbox_path).unwrap_or_default();
+        assert!(
+            body.contains("[ci-conflict-detected]"),
+            "subscriber inbox must carry the conflict alert, got: {body}"
+        );
+        assert!(
+            body.contains("test/repo@fix/x"),
+            "alert must identify the repo + branch, got: {body}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_ci_status_response_includes_pr_mergeable_state() {
+        // RED: pre-C4 the `ci action=status` response shape doesn't
+        // carry a `pr_mergeable_state` field; status callers can't
+        // distinguish "CI running" silence from "CONFLICTING blocked
+        // forever" silence. Post-C4 the field surfaces the cached
+        // mergeable state from the watch JSON (null when no check has
+        // run yet).
+        let dir = tmp_dir("status_mergeable_field");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = serde_json::json!({
+            "repo": "test/repo",
+            "branch": "fix/x",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-15T00:00:00Z"}],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+            // Pre-seed the new field as if a prior poll cycle stamped it.
+            "last_mergeable_state": "CONFLICTING",
+            "last_mergeable_check_at": "2026-05-15T00:00:00Z",
+        });
+        let watch_path = ci_dir.join(watch_filename("test/repo", "fix/x"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+        let r = crate::mcp::handlers::ci::handle_status_ci(
+            &dir,
+            &serde_json::json!({"repo": "test/repo"}),
+            "lead",
+        );
+        let entry = r["watches"][0]
+            .as_object()
+            .expect("watches[0] is an object");
+        assert!(
+            entry.contains_key("pr_mergeable_state"),
+            "status response must carry pr_mergeable_state field (#813), got keys: {:?}",
+            entry.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            entry["pr_mergeable_state"], "CONFLICTING",
+            "field must reflect the watch JSON's last_mergeable_state value"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -693,6 +693,57 @@ async fn ci_check_repo(
         }
     }
 
+    // #813: periodic mergeable re-check. Cached `last_mergeable_check_at`
+    // in watch JSON gates the frequency to once every
+    // MERGEABLE_RECHECK_INTERVAL_SECS (5 min). Alert emits ONLY on a
+    // transition INTO CONFLICTING — avoids alert spam while still
+    // conflicting and silently handles transitions OUT of CONFLICTING
+    // (back to Mergeable post-rebase). Fail-open on Unknown.
+    const MERGEABLE_RECHECK_INTERVAL_SECS: i64 = 300;
+    let (should_recheck, prev_mergeable) = match std::fs::read_to_string(watch_path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+    {
+        Some(w) => {
+            let last = w["last_mergeable_check_at"]
+                .as_str()
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|d| d.with_timezone(&chrono::Utc));
+            let now = chrono::Utc::now();
+            let elapsed_ok = last
+                .map(|d| {
+                    now.signed_duration_since(d).num_seconds() >= MERGEABLE_RECHECK_INTERVAL_SECS
+                })
+                .unwrap_or(true);
+            (
+                elapsed_ok,
+                w["last_mergeable_state"].as_str().map(String::from),
+            )
+        }
+        None => (true, None),
+    };
+    if should_recheck {
+        let new_state = provider.check_pr_mergeable(repo, branch).await;
+        let now_rfc3339 = chrono::Utc::now().to_rfc3339();
+        // Persist the new state regardless of variant.
+        if let Ok(content) = std::fs::read_to_string(watch_path) {
+            if let Ok(mut w) = serde_json::from_str::<serde_json::Value>(&content) {
+                w["last_mergeable_state"] = serde_json::json!(new_state.as_str());
+                w["last_mergeable_check_at"] = serde_json::json!(now_rfc3339);
+                if let Ok(out) = serde_json::to_string_pretty(&w) {
+                    let _ = std::fs::write(watch_path, out);
+                }
+            }
+        }
+        // Emit alert ONLY on transition INTO Conflicting (avoid spam
+        // when state stays Conflicting across cycles).
+        if matches!(new_state, MergeableState::Conflicting)
+            && prev_mergeable.as_deref() != Some("CONFLICTING")
+        {
+            emit_ci_conflict_alert(home, repo, branch, subscribers, "poll-transition");
+        }
+    }
+
     let poll_result = provider.poll_runs(repo, branch).await?;
     let runs = match poll_result {
         CiPollResult::ApiError {
@@ -4625,6 +4676,164 @@ mod tests {
             after["last_mergeable_state"].as_str(),
             Some("UNKNOWN"),
             "Unknown state must still be cached to watch JSON as a baseline"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Helper for C4 tests: run ci_check_repo with a provider, return after
+    /// one cycle. Builds the watch JSON at provided path + invokes
+    /// ci_check_repo via a current-thread runtime block_on.
+    fn run_one_poll_cycle(
+        dir: &Path,
+        watch: &serde_json::Value,
+        provider: &dyn CiProvider,
+    ) -> std::path::PathBuf {
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let repo = watch["repo"].as_str().unwrap();
+        let branch = watch["branch"].as_str().unwrap();
+        let subscribers = parse_subscribers(watch);
+        let watch_path = ci_dir.join(watch_filename(repo, branch));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(watch).unwrap()).unwrap();
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let _ = rt.block_on(ci_check_repo(
+            dir,
+            &watch_path,
+            repo,
+            branch,
+            &subscribers,
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            provider,
+        ));
+        watch_path
+    }
+
+    #[test]
+    fn test_periodic_recheck_emits_alert_on_transition_into_conflicting() {
+        // GREEN: ci_check_repo periodic re-check fires when
+        // `last_mergeable_check_at` is older than 5min (or absent).
+        // Provider returns CONFLICTING; previous cached state was
+        // MERGEABLE → transition INTO Conflicting → alert emits.
+        let dir = tmp_dir("recheck_transition_into");
+        let watch = serde_json::json!({
+            "repo": "test/repo",
+            "branch": "fix/x",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-15T00:00:00Z"}],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+            // Cached state from a prior poll cycle, expired (>5min stale).
+            "last_mergeable_state": "MERGEABLE",
+            "last_mergeable_check_at":
+                (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339(),
+        });
+        let provider =
+            MockCiProvider::with_runs(Vec::new()).with_mergeable(MergeableState::Conflicting);
+        run_one_poll_cycle(&dir, &watch, &provider);
+
+        let inbox =
+            std::fs::read_to_string(dir.join("inbox").join("lead.jsonl")).unwrap_or_default();
+        assert!(
+            inbox.contains("[ci-conflict-detected]"),
+            "transition INTO CONFLICTING must emit alert, got inbox: {inbox}"
+        );
+        assert!(
+            inbox.contains("poll-transition"),
+            "alert source must be `poll-transition` (not `watch-start`), got: {inbox}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_periodic_recheck_does_not_re_alert_while_still_conflicting() {
+        // GREEN: prevent alert spam. Cached state already CONFLICTING +
+        // provider returns CONFLICTING again → NO new alert fired.
+        let dir = tmp_dir("recheck_no_spam");
+        let watch = serde_json::json!({
+            "repo": "test/repo",
+            "branch": "fix/x",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-15T00:00:00Z"}],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+            "last_mergeable_state": "CONFLICTING",
+            "last_mergeable_check_at":
+                (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339(),
+        });
+        let provider =
+            MockCiProvider::with_runs(Vec::new()).with_mergeable(MergeableState::Conflicting);
+        run_one_poll_cycle(&dir, &watch, &provider);
+
+        let inbox =
+            std::fs::read_to_string(dir.join("inbox").join("lead.jsonl")).unwrap_or_default();
+        assert!(
+            !inbox.contains("[ci-conflict-detected]"),
+            "still-CONFLICTING (no transition) must NOT spam alerts, got: {inbox}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_status_response_has_null_pr_mergeable_state_pre_first_check() {
+        // GREEN: a fresh watch without `last_mergeable_state` in its
+        // JSON surfaces `pr_mergeable_state: null` in the status
+        // response. Callers tolerating null are unaffected.
+        let dir = tmp_dir("status_null_pre_check");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = serde_json::json!({
+            "repo": "test/repo",
+            "branch": "fix/x",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-15T00:00:00Z"}],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+            // No `last_mergeable_state` / `last_mergeable_check_at` —
+            // simulates a pre-#813 watch OR a fresh watch that hasn't
+            // run its first re-check yet.
+        });
+        let watch_path = ci_dir.join(watch_filename("test/repo", "fix/x"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+        let r = crate::mcp::handlers::ci::handle_status_ci(
+            &dir,
+            &serde_json::json!({"repo": "test/repo"}),
+            "lead",
+        );
+        let entry = r["watches"][0].as_object().expect("watches[0]");
+        assert!(
+            entry["pr_mergeable_state"].is_null(),
+            "pre-first-check watch must surface pr_mergeable_state=null, got {:?}",
+            entry["pr_mergeable_state"]
+        );
+        assert!(
+            entry["pr_mergeable_check_at"].is_null(),
+            "pre-first-check watch must surface pr_mergeable_check_at=null, got {:?}",
+            entry["pr_mergeable_check_at"]
         );
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -144,6 +144,49 @@ pub enum PrState {
     Unknown,
 }
 
+/// #813: PR mergeable-state result. GitHub returns `mergeable_state`
+/// as one of: clean / dirty / unstable / blocked / behind / unknown.
+/// We collapse to the operator-actionable subset:
+/// - `Mergeable` — clean / unstable (CI failures are a separate signal)
+/// - `Conflicting` — dirty (merge conflict with base)
+/// - `Unstable` — blocked / behind (review-policy / branch-behind, not
+///   a conflict per se but worth surfacing)
+/// - `Unknown` — query failed, fail-open path (no alert, no block)
+///
+/// Dead-code allow lifts at C2/C3/C4 when watcher + poller wire the
+/// enum into production paths.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MergeableState {
+    Mergeable,
+    Conflicting,
+    Unstable,
+    Unknown,
+}
+
+#[allow(dead_code)]
+impl MergeableState {
+    /// Stable string representation written to watch JSON + status
+    /// response. Pair with `from_str` for round-trip.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Mergeable => "MERGEABLE",
+            Self::Conflicting => "CONFLICTING",
+            Self::Unstable => "UNSTABLE",
+            Self::Unknown => "UNKNOWN",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "MERGEABLE" => Self::Mergeable,
+            "CONFLICTING" => Self::Conflicting,
+            "UNSTABLE" => Self::Unstable,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 /// Abstraction over a CI server's REST API.
 /// Each method corresponds to one provider-specific HTTP call.
 /// Return types are provider-neutral — all schema parsing happens
@@ -155,6 +198,42 @@ pub trait CiProvider: Send + Sync {
 
     /// Check whether the PR/MR for `branch` has reached a terminal state.
     async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState;
+
+    /// #813: Check the PR/MR's mergeable state. Returns `Unknown` on
+    /// any query failure (rate-limit, auth, network, no PR found) so
+    /// callers fail-open without alerting.
+    ///
+    /// Cross-backend stance §3.7: GitHub provider does the real query;
+    /// GitLab / Bitbucket return `Unknown` (unverified — no operator
+    /// has exercised the path) and the caller's fail-open guard
+    /// suppresses the alert. Promotion blocked behind a fleet
+    /// running on that backend.
+    ///
+    /// Dead-code allow lifts at C3/C4 when watcher + poller wire it.
+    #[allow(dead_code)]
+    async fn check_pr_mergeable(&self, repo: &str, branch: &str) -> MergeableState {
+        let _ = (repo, branch);
+        MergeableState::Unknown
+    }
+
+    /// #813: synchronous variant for non-async callers (handler-layer
+    /// MCP entry points that need a blocking answer on watch-start).
+    /// Wraps the async via the current tokio runtime — both daemon
+    /// and MCP handler tasks live inside a runtime, so the `block_on`
+    /// always finds a context. Returns `Unknown` if no runtime is
+    /// available (test harness without `#[tokio::test]`).
+    #[allow(dead_code)]
+    fn check_pr_mergeable_blocking(&self, repo: &str, branch: &str) -> MergeableState {
+        let handle = match tokio::runtime::Handle::try_current() {
+            Ok(h) => h,
+            Err(_) => return MergeableState::Unknown,
+        };
+        // Bridge to async via `block_in_place` so we don't deadlock on
+        // single-threaded runtimes. `tokio::task::block_in_place`
+        // requires multi-thread runtime; fall back to `Handle::block_on`
+        // when not available.
+        tokio::task::block_in_place(|| handle.block_on(self.check_pr_mergeable(repo, branch)))
+    }
 
     /// Fetch a human-readable summary of the first failed job/step.
     async fn fetch_failure_summary(&self, repo: &str, run_id: u64) -> String;

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -152,10 +152,6 @@ pub enum PrState {
 /// - `Unstable` — blocked / behind (review-policy / branch-behind, not
 ///   a conflict per se but worth surfacing)
 /// - `Unknown` — query failed, fail-open path (no alert, no block)
-///
-/// Dead-code allow lifts at C2/C3/C4 when watcher + poller wire the
-/// enum into production paths.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MergeableState {
     Mergeable,
@@ -164,25 +160,17 @@ pub enum MergeableState {
     Unknown,
 }
 
-#[allow(dead_code)]
 impl MergeableState {
     /// Stable string representation written to watch JSON + status
-    /// response. Pair with `from_str` for round-trip.
+    /// response. Watch JSON is read back as `&str`; no `from_str`
+    /// helper is needed because the only consumer compares against
+    /// the literal `"CONFLICTING"`.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Mergeable => "MERGEABLE",
             Self::Conflicting => "CONFLICTING",
             Self::Unstable => "UNSTABLE",
             Self::Unknown => "UNKNOWN",
-        }
-    }
-
-    pub fn from_str(s: &str) -> Self {
-        match s {
-            "MERGEABLE" => Self::Mergeable,
-            "CONFLICTING" => Self::Conflicting,
-            "UNSTABLE" => Self::Unstable,
-            _ => Self::Unknown,
         }
     }
 }
@@ -207,9 +195,7 @@ pub trait CiProvider: Send + Sync {
     /// GitLab / Bitbucket return `Unknown` (unverified — no operator
     /// has exercised the path) and the caller's fail-open guard
     /// suppresses the alert. Promotion blocked behind a fleet
-    /// running on that backend. Dead-code allow lifts at C4 when the
-    /// periodic re-check call site lands in `ci_check_repo`.
-    #[allow(dead_code)]
+    /// running on that backend.
     async fn check_pr_mergeable(&self, repo: &str, branch: &str) -> MergeableState {
         let _ = (repo, branch);
         MergeableState::Unknown

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -207,9 +207,8 @@ pub trait CiProvider: Send + Sync {
     /// GitLab / Bitbucket return `Unknown` (unverified — no operator
     /// has exercised the path) and the caller's fail-open guard
     /// suppresses the alert. Promotion blocked behind a fleet
-    /// running on that backend.
-    ///
-    /// Dead-code allow lifts at C3/C4 when watcher + poller wire it.
+    /// running on that backend. Dead-code allow lifts at C4 when the
+    /// periodic re-check call site lands in `ci_check_repo`.
     #[allow(dead_code)]
     async fn check_pr_mergeable(&self, repo: &str, branch: &str) -> MergeableState {
         let _ = (repo, branch);
@@ -218,21 +217,26 @@ pub trait CiProvider: Send + Sync {
 
     /// #813: synchronous variant for non-async callers (handler-layer
     /// MCP entry points that need a blocking answer on watch-start).
-    /// Wraps the async via the current tokio runtime — both daemon
-    /// and MCP handler tasks live inside a runtime, so the `block_on`
-    /// always finds a context. Returns `Unknown` if no runtime is
-    /// available (test harness without `#[tokio::test]`).
+    /// Always runs the async future on a fresh current-thread runtime
+    /// in a scoped thread — works regardless of whether the caller is
+    /// already inside a tokio runtime (avoids the multi-thread vs
+    /// current-thread runtime-flavor branch). Dead-code allow lifts
+    /// at C3 when handle_watch_ci wires the call site.
     #[allow(dead_code)]
     fn check_pr_mergeable_blocking(&self, repo: &str, branch: &str) -> MergeableState {
-        let handle = match tokio::runtime::Handle::try_current() {
-            Ok(h) => h,
-            Err(_) => return MergeableState::Unknown,
-        };
-        // Bridge to async via `block_in_place` so we don't deadlock on
-        // single-threaded runtimes. `tokio::task::block_in_place`
-        // requires multi-thread runtime; fall back to `Handle::block_on`
-        // when not available.
-        tokio::task::block_in_place(|| handle.block_on(self.check_pr_mergeable(repo, branch)))
+        std::thread::scope(|s| {
+            let handle = s.spawn(|| {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(_) => return MergeableState::Unknown,
+                };
+                rt.block_on(self.check_pr_mergeable(repo, branch))
+            });
+            handle.join().unwrap_or(MergeableState::Unknown)
+        })
     }
 
     /// Fetch a human-readable summary of the first failed job/step.
@@ -420,6 +424,62 @@ impl CiProvider for GitHubCiProvider {
                 }
             }
             None => PrState::Unknown,
+        }
+    }
+
+    /// #813: Query the PR's `mergeable_state` field. Requires two
+    /// GETs because the list endpoint doesn't compute `mergeable` —
+    /// only the per-PR detail endpoint does. Per GitHub docs:
+    /// https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+    ///
+    /// Fail-open on any error (network, auth, parse, missing) so the
+    /// caller's guard suppresses the alert under transient issues.
+    async fn check_pr_mergeable(&self, repo: &str, branch: &str) -> MergeableState {
+        let owner = repo.split('/').next().unwrap_or("");
+        // (1) List endpoint to resolve PR number from branch.
+        let list: serde_json::Value = match self
+            .http
+            .get(&format!(
+                "repos/{repo}/pulls?head={owner}:{branch}&state=open&per_page=1"
+            ))
+            .send()
+            .await
+        {
+            Ok(r) => match r.json().await {
+                Ok(v) => v,
+                Err(_) => return MergeableState::Unknown,
+            },
+            Err(_) => return MergeableState::Unknown,
+        };
+        let pr_number = match list
+            .as_array()
+            .and_then(|a| a.first())
+            .and_then(|pr| pr["number"].as_u64())
+        {
+            Some(n) => n,
+            None => return MergeableState::Unknown,
+        };
+        // (2) Detail endpoint reads `mergeable_state` (computed
+        // asynchronously by GitHub post-push — value may be "unknown"
+        // for ~seconds after a push, which we surface as Unknown).
+        let detail: serde_json::Value = match self
+            .http
+            .get(&format!("repos/{repo}/pulls/{pr_number}"))
+            .send()
+            .await
+        {
+            Ok(r) => match r.json().await {
+                Ok(v) => v,
+                Err(_) => return MergeableState::Unknown,
+            },
+            Err(_) => return MergeableState::Unknown,
+        };
+        match detail["mergeable_state"].as_str() {
+            Some("dirty") => MergeableState::Conflicting,
+            Some("clean") => MergeableState::Mergeable,
+            Some("blocked") | Some("behind") => MergeableState::Unstable,
+            Some("unstable") => MergeableState::Mergeable,
+            _ => MergeableState::Unknown,
         }
     }
 

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -222,7 +222,6 @@ pub trait CiProvider: Send + Sync {
     /// already inside a tokio runtime (avoids the multi-thread vs
     /// current-thread runtime-flavor branch). Dead-code allow lifts
     /// at C3 when handle_watch_ci wires the call site.
-    #[allow(dead_code)]
     fn check_pr_mergeable_blocking(&self, repo: &str, branch: &str) -> MergeableState {
         std::thread::scope(|s| {
             let handle = s.spawn(|| {

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -752,6 +752,12 @@ pub(crate) fn handle_status_ci(home: &Path, args: &Value, instance_name: &str) -
             "last_terminal_seen_at": watch["last_terminal_seen_at"].as_str(),
             "head_sha": watch["head_sha"].as_str(),
             "expires_at": watch["expires_at"].as_str(),
+            // #813: surface cached mergeable state so callers can
+            // distinguish "CI running" silence from "CONFLICTING
+            // blocked forever" silence. Field is `null` for watches
+            // that haven't run their first mergeable check yet.
+            "pr_mergeable_state": watch["last_mergeable_state"].as_str(),
+            "pr_mergeable_check_at": watch["last_mergeable_check_at"].as_str(),
         }));
     }
     let mut resp = json!({"watches": out});

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -669,7 +669,7 @@ pub(super) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
 /// Caller filtering: agents only see watches they're subscribed to —
 /// avoids leaking lead's polling targets to every dev. The empty
 /// instance name (anonymous CLI) sees all watches.
-pub(super) fn handle_status_ci(home: &Path, args: &Value, instance_name: &str) -> Value {
+pub(crate) fn handle_status_ci(home: &Path, args: &Value, instance_name: &str) -> Value {
     let filter_repo = args["repo"].as_str();
     let filter_branch = args["branch"].as_str();
     let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -533,6 +533,22 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
             "code": "watch_write_failed",
         });
     }
+    // #813: on-watch-start mergeable check. Builds a default provider
+    // for the repo (GitHub-only impl; GitLab/Bitbucket inherit the
+    // Unknown stub per §3.7), queries mergeable_state synchronously,
+    // and emits `[ci-conflict-detected]` to every subscriber if the
+    // PR is in DIRTY state. Fail-open on any provider error.
+    let subscribers_for_alert: Vec<String> = crate::daemon::ci_watch::parse_subscribers(&watch);
+    if let Some(provider) = build_default_provider(repo) {
+        crate::daemon::ci_watch::watch_start_check_mergeable(
+            home,
+            &watch_path,
+            repo,
+            branch,
+            &subscribers_for_alert,
+            provider.as_ref(),
+        );
+    }
     // Sprint 54 P0-5 (sub-scope A): response enrichment — agents see
     // CI health without polling the watch file. Read state freshly
     // from `watch` JSON we just composed; populate diagnostic fields
@@ -743,6 +759,35 @@ pub(crate) fn handle_status_ci(home: &Path, args: &Value, instance_name: &str) -
         resp["setup_warning"] = json!(w);
     }
     resp
+}
+
+/// #813: build the default `CiProvider` for a repo URL. Mirrors
+/// `watcher.rs::check_ci_watches`'s factory but with the canonical
+/// host URLs (no per-watch URL override) — sufficient for the
+/// on-watch-start mergeable check at dispatch time. GitHub fully
+/// implemented; GitLab/Bitbucket return Unknown via the trait
+/// default (§3.7 cross-backend stance — promotion blocked behind
+/// real operator usage).
+fn build_default_provider(repo: &str) -> Option<Box<dyn crate::daemon::ci_watch::CiProvider>> {
+    use crate::daemon::ci_watch::{
+        detect_provider_from_remote, BitbucketCiProvider, CiProvider, GitHubCiProvider,
+        GitLabCiProvider,
+    };
+    let (kind, _is_custom) = detect_provider_from_remote(repo);
+    let provider: Option<Box<dyn CiProvider>> = match kind {
+        "gitlab" => GitLabCiProvider::with_base_url("https://gitlab.com".to_string())
+            .ok()
+            .map(|p| Box::new(p) as Box<dyn CiProvider>),
+        "bitbucket_cloud" => {
+            BitbucketCiProvider::with_base_url("https://api.bitbucket.org".to_string())
+                .ok()
+                .map(|p| Box::new(p) as Box<dyn CiProvider>)
+        }
+        _ => GitHubCiProvider::with_base_url("https://api.github.com".to_string())
+            .ok()
+            .map(|p| Box::new(p) as Box<dyn CiProvider>),
+    };
+    provider
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #813.

scope follows dispatch spec t-20260515055035195814-8

## Summary

CONFLICTING PRs silently block CI workflow triggers — GitHub Actions doesn't fire `synchronize` events on a PR with merge conflicts, so daemon's `ci_watch` polls forever returning zero runs while the operator wonders what's wrong. Today's #807/#811 dragged ~30min before root-cause surfaced.

Three-part fix:

- **Part A — on watch start (`handle_watch_ci`)**: after the existing subscriber insert + atomic_write, build a default `CiProvider` for the repo, query `mergeable_state` synchronously, and emit `[ci-conflict-detected]` to every subscriber if the PR is DIRTY. Caches the observed state into the watch JSON so Part B has a baseline.
- **Part B — periodic re-check (`ci_check_repo`)**: every 5 minutes (gated via `last_mergeable_check_at` in watch JSON), re-query mergeable_state. Alert emits **only on transition INTO Conflicting** so re-polls during a still-conflicting state don't spam inbox.
- **Part C — `ci action=status` enrichment**: response gains `pr_mergeable_state` + `pr_mergeable_check_at` fields per watch entry, surfaced from the cached watch JSON. Null for pre-first-check watches; back-compat preserved (pure additions).

## Design notes (5 lead-pinned design calls)

| Call | Decision | Rationale |
|---|---|---|
| Notification format | Single-line, mirror `[ci-pass]`/`[ci-fail]` shape | Operator clicks the PR URL for detail; inbox just carries the actionable signal |
| Cache TTL | 300s (5 min, hardcoded) | GH `mergeable` recomputes async post-push (seconds); 5min catches rebase resolution; 2 GET requests/watch lifecycle is negligible |
| Stop polling vs continue on CONFLICTING | Continue at normal cadence | `poll_runs` is cheap; mergeable re-check loop IS the resolution detector; deferring `paused_until_mergeable` flag until rate-limit pressure surfaces |
| Async/sync boundary | `check_pr_mergeable_blocking()` sync variant on trait | Encapsulates the runtime bridge inside the trait so MCP-layer handlers don't repeat the pattern; uses `std::thread::scope` + fresh current-thread runtime to avoid the multi-thread vs current-thread flavor branch |
| Cross-backend (GitLab/Bitbucket) | Stubs return `MergeableState::Unknown` (§3.7) | Only GitHub fully implemented; non-GitHub backends fail-open silently. Promotion blocked behind a fleet running on that backend |

## GitHub API surface

`GitHubCiProvider::check_pr_mergeable` issues 2 GETs:
- `GET /repos/{repo}/pulls?head={owner}:{branch}&state=open` — list endpoint resolves PR number from branch.
- `GET /repos/{repo}/pulls/{pr_number}` — detail endpoint reads `mergeable_state`. GH only computes `mergeable` on detail-endpoint fetches, not on list responses.

Collapse:
- `dirty` → `Conflicting`
- `clean` / `unstable` → `Mergeable` (CI failure is a separate signal — `unstable` ≈ CI is failing but no merge conflict)
- `blocked` / `behind` → `Unstable` (review-policy / branch-behind, not a true conflict but worth surfacing)
- everything else → `Unknown` (fail-open path)

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite: 2247 binary tests + integration + UI smoke + doc-tests, 0 regressions.

#813 tests (6 total, all in `daemon::ci_watch::poller::tests`):

C1 RED → flipped GREEN at C2/C4:
- [x] `test_watch_start_on_conflicting_emits_alert` (RED → GREEN at C2)
- [x] `test_ci_status_response_includes_pr_mergeable_state` (RED → GREEN at C4)

C3 coverage:
- [x] `test_mergeable_check_fail_open_on_provider_error` — Unknown provider result must NOT emit alert AND must cache UNKNOWN to watch JSON

C4 coverage:
- [x] `test_periodic_recheck_emits_alert_on_transition_into_conflicting` — transition prev=MERGEABLE → CONFLICTING triggers alert with source=`poll-transition`
- [x] `test_periodic_recheck_does_not_re_alert_while_still_conflicting` — prev=CONFLICTING → CONFLICTING does NOT re-emit (anti-spam)
- [x] `test_status_response_has_null_pr_mergeable_state_pre_first_check` — pre-#813 watches surface `pr_mergeable_state: null` in status response

## Commit chain

1. `7bba7de` — `test(#813): RED tests for ci_watch CONFLICTING PR detection`
2. `a56f7f9` — `fix(#813): GitHubCiProvider mergeable query + emit_ci_conflict_alert + watch_start_check_mergeable (C2)`
3. `bca1e4d` — `fix(#813): wire watch_start_check_mergeable into handle_watch_ci (C3)`
4. `afcd68a` — `fix(#813): periodic mergeable re-check (Part B) + ci status enrichment (Part C) (C4)`

## Cross-backend stance (§3.7)

GitHub fully implemented + tested. GitLab + Bitbucket inherit the `CiProvider` trait default that returns `MergeableState::Unknown` — claim explicitly unverified pending a fleet running on those backends. Operator-actionable error message + fail-open behavior prevents false-positive blocks on non-GitHub repos.

## Out of scope (deferred per dispatch spec)

- `paused_until_mergeable` flag (follow-up if rate-limit pressure surfaces).
- Per-file conflict detail in notification (operator clicks the PR URL for that).
- Config-able TTL (currently hardcoded 300s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)