### PR TITLE
fix(#814): auto-recover from stale rebase-merge dir + warn on high init count + surface abort failures

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -701,6 +701,17 @@ mod tests;
 ///   `repo action=cleanup_init_commits` consume the Result so operator-
 ///   facing surfaces can report the cleaned count + surface failures.
 pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String> {
+    // #814: auto-recover from prior failed-cleanup state. The
+    // `.git/.../rebase-merge` dir survives when a previous
+    // `git rebase -i` failed AND its companion `git rebase --abort`
+    // also failed (or was skipped). Subsequent `git rebase -i`
+    // refuses to start with "previous rebase in progress", returning
+    // exit code 256 — exactly the failure mode that hit #807 prep
+    // 3 consecutive times. Pre-clear the stale dir so retry can
+    // proceed. Best-effort: a remove failure here doesn't abort the
+    // helper — worst case we get the same status 256 we had before.
+    clear_stale_rebase_state(worktree);
+
     let output = std::process::Command::new("git")
         .args(["log", "origin/main..HEAD", "--format=%H %s"])
         .current_dir(worktree)
@@ -811,4 +822,84 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
             })
         }
     }
+}
+
+/// #814: clear `.git/.../rebase-merge` AND `rebase-apply` dirs that
+/// survived a prior failed cleanup attempt. Called at the top of
+/// `clean_empty_init_commits` so the next `git rebase -i` doesn't
+/// trip over "previous rebase in progress" state inherited from a
+/// previous run's failed `--abort`.
+///
+/// Safety: the daemon-managed worktree this helper operates on is
+/// not shared with operator-driven rebases (operator runs from
+/// canonical checkout or their own clones), so clearing the rebase
+/// state here cannot clobber an operator's in-progress work. The
+/// `tracing::warn!` documents the clear so post-incident audit can
+/// confirm it fired and correlate with the prior failed call.
+///
+/// Fail-soft: any error (missing .git pointer, permission, etc.) is
+/// logged but doesn't abort the helper. Worst case the subsequent
+/// `git rebase -i` returns the same status 256 the operator saw
+/// before — no regression beyond pre-#814 behavior.
+fn clear_stale_rebase_state(worktree: &Path) {
+    let git_dir = match resolve_worktree_gitdir(worktree) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "#814: could not resolve .git dir; skipping stale rebase-state clear"
+            );
+            return;
+        }
+    };
+    for sub in ["rebase-merge", "rebase-apply"] {
+        let path = git_dir.join(sub);
+        if !path.exists() {
+            continue;
+        }
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => {
+                tracing::warn!(
+                    ?path,
+                    "#814: removed stale {} dir from prior failed cleanup attempt",
+                    sub
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    ?path,
+                    error = %e,
+                    "#814: failed to clear stale {} dir — cleanup may still fail",
+                    sub
+                );
+            }
+        }
+    }
+}
+
+/// #814: resolve the worktree's actual `.git` directory.
+///
+/// In a primary checkout `.git` is a directory. In a daemon-managed
+/// `git worktree`-provisioned worktree, `.git` is a FILE containing
+/// a `gitdir: <path>` line pointing at
+/// `<repo>/.git/worktrees/<name>`. This helper handles both forms.
+fn resolve_worktree_gitdir(worktree: &Path) -> Result<std::path::PathBuf, String> {
+    let dotgit = worktree.join(".git");
+    if dotgit.is_dir() {
+        return Ok(dotgit);
+    }
+    if !dotgit.is_file() {
+        return Err(format!(
+            ".git missing at {}; not a directory or file",
+            dotgit.display()
+        ));
+    }
+    let content = std::fs::read_to_string(&dotgit)
+        .map_err(|e| format!("read .git file at {}: {e}", dotgit.display()))?;
+    let gitdir = content
+        .lines()
+        .find_map(|l| l.strip_prefix("gitdir: "))
+        .ok_or_else(|| format!(".git file at {} missing 'gitdir:' prefix", dotgit.display()))?
+        .trim();
+    Ok(std::path::PathBuf::from(gitdir))
 }

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -788,6 +788,21 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
         }
     }
 
+    // #814: high-count diagnostic. Emit a tracing warn when the
+    // empty-init count exceeds the threshold so post-incident
+    // analysis can identify "slow rebase" cases. KISS hardcoded
+    // constant — the warning is a "slow op may follow" signal,
+    // not a hard cap. Operators seeing this regularly should
+    // investigate upstream (why are session-checkpoint heartbeats
+    // accumulating over 30 inits before the next push?).
+    if empty_inits.len() > INIT_COUNT_WARN_THRESHOLD {
+        tracing::warn!(
+            count = empty_inits.len(),
+            threshold = INIT_COUNT_WARN_THRESHOLD,
+            "#814: high empty-init count — cleanup may be slow"
+        );
+    }
+
     // Mixed: use interactive rebase to drop empty inits.
     // Build a sed script that changes "pick <hash>" to "drop <hash>" for each empty init.
     // Use `sed -i.bak` for cross-platform compat (macOS requires suffix, Linux accepts it).
@@ -810,11 +825,33 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
         }
         Ok(_) | Err(_) => {
             // Abort failed rebase to leave worktree in clean state.
-            let _ = std::process::Command::new("git")
+            // #814: capture the abort status + warn on failure. Pre-fix
+            // the abort was silently swallowed via `let _ = ...`, which
+            // hid the very signal that becomes the next call's stale-
+            // state issue. With this surfaced, post-incident audit can
+            // confirm whether abort itself failed (the upstream cause
+            // of the rebase-merge dir persisting across attempts).
+            let abort = std::process::Command::new("git")
                 .args(["rebase", "--abort"])
                 .current_dir(worktree)
                 .env("AGEND_GIT_BYPASS", "1")
                 .status();
+            match &abort {
+                Ok(s) if !s.success() => {
+                    tracing::warn!(
+                        abort_status = ?s,
+                        "#814: git rebase --abort failed — rebase-merge dir may persist; \
+                         next clean_empty_init_commits call auto-clears via clear_stale_rebase_state"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "#814: git rebase --abort spawn failed — rebase-merge dir may persist"
+                    );
+                }
+                _ => {}
+            }
             tracing::warn!("failed to rebase-drop empty init commits");
             Err(match status {
                 Ok(s) => format!("git rebase -i exited with status {s:?}"),
@@ -823,6 +860,14 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
         }
     }
 }
+
+/// #814: threshold for the high-init-count tracing warn. Empty-init
+/// counts above this signal a slow `git rebase -i` ahead and an
+/// upstream issue worth investigating (why are heartbeats
+/// accumulating?). Hardcoded — not a hard cap, so config-ability
+/// adds no operator value. Matches the observed #807 incident
+/// count (32 inits > 30 threshold → warns).
+const INIT_COUNT_WARN_THRESHOLD: usize = 30;
 
 /// #814: clear `.git/.../rebase-merge` AND `rebase-apply` dirs that
 /// survived a prior failed cleanup attempt. Called at the top of

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1346,3 +1346,156 @@ fn teams_json_migration_preserves_existing_fleet_yaml_source_repo() {
 
     std::fs::remove_dir_all(&parent).ok();
 }
+
+// ── #814 clean_empty_init_commits stale-rebase-merge recovery ──
+
+/// Spawn a temp git repo + worktree pair scoped to `tag`. The repo
+/// has an initial commit + `refs/remotes/origin/main` so the
+/// helper's `git log origin/main..HEAD` query has a baseline. The
+/// worktree branches off `main` so subsequent commits land in
+/// `origin/main..HEAD`. Returns `(repo_dir, worktree_dir)`.
+fn setup_repo_and_worktree(tag: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+    let base = std::env::temp_dir().join(format!("agend-814-{}-{tag}", std::process::id()));
+    std::fs::create_dir_all(&base).ok();
+    let repo = base.join("repo");
+    std::fs::create_dir_all(&repo).ok();
+    let git_run = |dir: &std::path::Path, args: &[&str]| {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("git ran")
+    };
+    git_run(&repo, &["init", "-b", "main"]);
+    git_run(&repo, &["commit", "--allow-empty", "-m", "main: initial"]);
+    let main_sha = String::from_utf8_lossy(&git_run(&repo, &["rev-parse", "HEAD"]).stdout)
+        .trim()
+        .to_string();
+    git_run(
+        &repo,
+        &["update-ref", "refs/remotes/origin/main", &main_sha],
+    );
+    let worktree = base.join("wt");
+    git_run(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            &worktree.display().to_string(),
+        ],
+    );
+    (repo, worktree)
+}
+
+/// Interleave `n_inits` empty `init` commits with `n_real` commits
+/// that actually modify a file, advancing the branch HEAD inside
+/// `worktree`. Pattern alternates real / init / real / init ... so
+/// the helper exercises the mixed-cleanup rebase path (not the
+/// all-empty soft-reset shortcut).
+fn create_interleaved_commit_chain(worktree: &std::path::Path, n_inits: usize, n_real: usize) {
+    let git_run = |args: &[&str]| {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(worktree)
+            .env("AGEND_GIT_BYPASS", "1")
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("git ran")
+    };
+    let total = n_inits + n_real;
+    let mut inits_remaining = n_inits;
+    let mut reals_remaining = n_real;
+    for i in 0..total {
+        // Alternate: even index → init, odd → real (when both still available).
+        let pick_init = if reals_remaining == 0 {
+            true
+        } else if inits_remaining == 0 {
+            false
+        } else {
+            i % 2 == 0
+        };
+        if pick_init {
+            git_run(&["commit", "--allow-empty", "-m", "init"]);
+            inits_remaining -= 1;
+        } else {
+            let path = worktree.join(format!("real-{i}.txt"));
+            std::fs::write(&path, format!("real commit {i}\n")).expect("write");
+            git_run(&["add", &format!("real-{i}.txt")]);
+            git_run(&["commit", "-m", &format!("real commit {i}")]);
+            reals_remaining -= 1;
+        }
+    }
+}
+
+/// Read the worktree's actual `.git` dir (a worktree's `.git` is a
+/// file pointing to `<repo>/.git/worktrees/<name>`).
+fn worktree_gitdir(worktree: &std::path::Path) -> std::path::PathBuf {
+    let dotgit = worktree.join(".git");
+    if dotgit.is_dir() {
+        return dotgit;
+    }
+    let content = std::fs::read_to_string(&dotgit).expect("read .git");
+    let gitdir = content
+        .lines()
+        .find_map(|l| l.strip_prefix("gitdir: "))
+        .expect("gitdir prefix");
+    std::path::PathBuf::from(gitdir.trim())
+}
+
+/// Synthesize a malformed `.git/.../rebase-merge/` dir as if a
+/// prior `git rebase -i` failed and `--abort` failed to recover
+/// it. This is the exact stale-state that triggered #807's 3
+/// consecutive `cleanup_init_commits` failures.
+fn pre_poison_stale_rebase_merge(worktree: &std::path::Path) {
+    let gitdir = worktree_gitdir(worktree);
+    let rebase_merge = gitdir.join("rebase-merge");
+    std::fs::create_dir_all(&rebase_merge).expect("create rebase-merge");
+    // Minimal content git looks for to refuse a new rebase.
+    std::fs::write(rebase_merge.join("head-name"), "refs/heads/feature").expect("write head-name");
+    std::fs::write(rebase_merge.join("onto"), "deadbeef").expect("write onto");
+    std::fs::write(rebase_merge.join("interactive"), "").expect("write interactive");
+}
+
+#[test]
+fn clean_empty_init_commits_recovers_from_stale_rebase_merge_dir() {
+    // #814 RED test: synthesize the exact failure state #807 hit —
+    // 32 interleaved empty inits + 3 real commits + a leftover
+    // `.git/.../rebase-merge/` dir from a prior failed cleanup.
+    // Pre-fix: `git rebase -i` immediately errors with "rebase in
+    // progress" → helper returns Err("...status 256"). Post-fix:
+    // `clear_stale_rebase_state` removes the stale dir at entry,
+    // letting the rebase proceed normally.
+    let (_repo, worktree) = setup_repo_and_worktree("recover");
+    create_interleaved_commit_chain(&worktree, 32, 3);
+    pre_poison_stale_rebase_merge(&worktree);
+
+    let result = super::clean_empty_init_commits(&worktree);
+    assert!(
+        result.is_ok(),
+        "helper must auto-recover from stale rebase-merge dir, got: {result:?}"
+    );
+    let cleaned = result.unwrap();
+    assert_eq!(
+        cleaned, 32,
+        "all 32 empty inits should be dropped, cleaned: {cleaned}"
+    );
+    // Post-condition: stale dir is gone (cleared by the helper +
+    // by the successful rebase that followed).
+    let gitdir = worktree_gitdir(&worktree);
+    assert!(
+        !gitdir.join("rebase-merge").exists(),
+        "rebase-merge dir should be gone post-cleanup"
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1499,3 +1499,68 @@ fn clean_empty_init_commits_recovers_from_stale_rebase_merge_dir() {
 
     std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
 }
+
+#[test]
+fn clean_empty_init_commits_handles_50_interleaved_inits() {
+    // #814 perf coverage: 50 inits + 4 real commits + threshold
+    // warn fires (50 > 30). Must complete within a generous bound
+    // (30s on slow CI machines) so the helper isn't accidentally
+    // unbounded. Validates Cause 2 (30+ ceiling) is NOT a hard
+    // ceiling — just a tracing warn signal.
+    let (_repo, worktree) = setup_repo_and_worktree("high_count");
+    create_interleaved_commit_chain(&worktree, 50, 4);
+
+    let start = std::time::Instant::now();
+    let result = super::clean_empty_init_commits(&worktree);
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_ok(),
+        "50-init case must succeed (Cause 2 not a hard ceiling), got: {result:?}"
+    );
+    assert_eq!(result.unwrap(), 50, "all 50 inits should be dropped",);
+    assert!(
+        elapsed < std::time::Duration::from_secs(30),
+        "high-count must complete in < 30s, took {elapsed:?}"
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}
+
+#[test]
+fn clean_empty_init_commits_clears_stale_dir_even_when_no_inits_to_drop() {
+    // #814 edge case: stale rebase-merge dir survives a prior
+    // failed attempt, but the branch has since been fully cleaned
+    // (or the operator pushed and there are no inits to drop).
+    // The helper should still clear the stale dir defensively so
+    // subsequent calls aren't blocked, even when there's no work
+    // to do this cycle.
+    let (_repo, worktree) = setup_repo_and_worktree("no_inits_stale");
+    // No commits added beyond the worktree-creation point — but
+    // worktree branched off main so origin/main..HEAD is empty.
+    pre_poison_stale_rebase_merge(&worktree);
+    let gitdir_before = worktree_gitdir(&worktree);
+    assert!(
+        gitdir_before.join("rebase-merge").exists(),
+        "pre-condition: stale dir exists"
+    );
+
+    let result = super::clean_empty_init_commits(&worktree);
+    assert!(
+        result.is_ok(),
+        "no-inits-with-stale-dir case must succeed, got: {result:?}"
+    );
+    assert_eq!(
+        result.unwrap(),
+        0,
+        "zero inits to drop, but call must not error",
+    );
+    // Stale dir was cleared at entry even though nothing else ran.
+    let gitdir = worktree_gitdir(&worktree);
+    assert!(
+        !gitdir.join("rebase-merge").exists(),
+        "stale rebase-merge dir must be cleared even in no-op case"
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1372,6 +1372,13 @@ fn setup_repo_and_worktree(tag: &str) -> (std::path::PathBuf, std::path::PathBuf
             .expect("git ran")
     };
     git_run(&repo, &["init", "-b", "main"]);
+    // #814 r1: pin per-repo gitconfig so subprocesses spawned by the
+    // SUT (which don't inherit our test env vars) still find an
+    // identity. Without this, CI runners with no global gitconfig
+    // abort `git rebase` at exit 128 "unable to auto-detect email
+    // address" — the actual cause of the first CI fail post-#814.
+    git_run(&repo, &["config", "user.name", "test"]);
+    git_run(&repo, &["config", "user.email", "t@t"]);
     git_run(&repo, &["commit", "--allow-empty", "-m", "main: initial"]);
     let main_sha = String::from_utf8_lossy(&git_run(&repo, &["rev-parse", "HEAD"]).stdout)
         .trim()
@@ -1391,6 +1398,14 @@ fn setup_repo_and_worktree(tag: &str) -> (std::path::PathBuf, std::path::PathBuf
             &worktree.display().to_string(),
         ],
     );
+    // #814 r1: pin worktree-level gitconfig too. The SUT's
+    // `git rebase -i` runs inside the worktree and reads worktree
+    // config FIRST — without this we get exit 128 even when the
+    // repo dir has user.name set, because the worktree inherits
+    // the bare repo `.git/worktrees/wt/config` which is empty by
+    // default.
+    git_run(&worktree, &["config", "user.name", "test"]);
+    git_run(&worktree, &["config", "user.email", "t@t"]);
     (repo, worktree)
 }
 
@@ -1466,6 +1481,18 @@ fn pre_poison_stale_rebase_merge(worktree: &std::path::Path) {
     std::fs::write(rebase_merge.join("interactive"), "").expect("write interactive");
 }
 
+/// #814 r1 — CI root-cause analysis:
+/// `clean_empty_init_commits` shells out to git without setting
+/// `GIT_COMMITTER_NAME` / `GIT_COMMITTER_EMAIL`. The local dev
+/// machine inherits the developer's global `~/.gitconfig` so
+/// rebase succeeds. CI runners have no global gitconfig → rebase
+/// aborts with exit 128 ("unable to auto-detect email address").
+/// Same root cause across linux/macos/windows in the first CI run.
+///
+/// Fix: fixture pins per-repo AND per-worktree `user.name` +
+/// `user.email` via `git config` so the SUT's subprocess reads
+/// them from the worktree's `.git/config` regardless of env vars
+/// or global config.
 #[test]
 fn clean_empty_init_commits_recovers_from_stale_rebase_merge_dir() {
     // #814 RED test: synthesize the exact failure state #807 hit —


### PR DESCRIPTION
Closes #814.

scope follows dispatch spec t-20260515055040217515-9

## Summary

`daemon::dispatch_hook::clean_empty_init_commits` failed 3 consecutive times during #807 prep with `git rebase -i exited with status 256`. Spike root-cause analysis confirmed **Cause 1 (stale `.git/.../rebase-merge` dir blocking retry) is dominant**:

1. The rebase fails for any reason (`sed` script edge case, conflict on real commits, etc.).
2. The helper's `git rebase --abort` runs with `let _ = ...` — exit status silently discarded.
3. If abort itself fails (rare but possible — malformed rebase state, permission issue, race), the `.git/.../rebase-merge` dir survives.
4. Next call to `git rebase -i` immediately errors with "previous rebase in progress" → `status 256`.
5. Operator sees `cleanup_failed` 3 times in a row; manual `rm -rf .git/.../rebase-merge` is the only recovery.

**Cause 2 (30+ ceiling)** is plausible but secondary — ~5-8s for ~36 commits, no hard timeout. Cause 3 (interleaved pattern) was **debunked** in spike — sed processes lines independently; ordering doesn't affect matching.

## Three pieces (one PR, 3 commits)

- **C1 — RED test**: `clean_empty_init_commits_recovers_from_stale_rebase_merge_dir`. Synthesizes the exact #807 failure state: 32 interleaved empty inits + 3 real commits + pre-poisoned `.git/.../rebase-merge/` dir with the minimal content git looks for (`head-name`, `onto`, `interactive`). Pre-fix: helper returns `Err("git rebase -i exited with status 32768")`. Post-C2: helper auto-recovers, returns Ok(32), and the stale dir is gone post-cleanup.
- **C2 — main fix**: `clear_stale_rebase_state(worktree)` + `resolve_worktree_gitdir(worktree)` helpers + hook at the top of `clean_empty_init_commits`. Resolves the actual `.git` dir (handles BOTH the directory form of primary checkouts AND the `gitdir: <path>` file form of `git worktree`-provisioned worktrees), best-effort `remove_dir_all` on `rebase-merge` + `rebase-apply`. `tracing::warn!` documents each clear so post-incident audit can correlate with the prior failed call. Fail-soft: missing .git, permission errors, etc. are logged but don't abort the helper.
- **C3 — additional diagnostics + tests**: `INIT_COUNT_WARN_THRESHOLD = 30` hardcoded constant + tracing warn when count exceeds it. `git rebase --abort` exit status now captured + logged on failure (was silently swallowed via `let _ = ...` — the root cause of stale state persisting across calls). 2 more tests: 50-init high-count case (validates Cause 2 is NOT a hard ceiling) and stale-dir-no-inits edge case (helper must defensively clear even in no-op).

## Design notes (5 lead-pinned design calls)

| Call | Decision | Rationale |
|---|---|---|
| Single PR commits | 3 commits (RED → C2 → C3) | Clean test-first cadence; each commit independently testable |
| Threshold config-ability | Hardcoded `INIT_COUNT_WARN_THRESHOLD = 30` | KISS; warning is a "slow op" signal not a hard cap. Operators seeing this regularly should investigate upstream (heartbeat accumulation), not tune the knob |
| Surface warning in MCP response | `tracing::warn!` only | Operator-facing response shape stays clean (`{cleaned_count: N}`); daemon log carries the diagnostic for post-incident audit. No clear MCP consumer for `warnings: Vec<String>` |
| Bundle warn-on-abort-failure | YES bundle into C3 | 3 LOC fixes the silent-failure source that creates stale state. Low risk, high diagnostic value |
| git2-rs rewrite | DEFER (out of scope) | 70→40 LOC rewrite + 6-caller blast radius too large for this PR. Future investigation if subprocess overhead becomes pain point |

## Safety analysis

`clear_stale_rebase_state` is best-effort `remove_dir_all` on `.git/.../rebase-merge` and `rebase-apply`. Concern: could this clobber an operator's in-progress rebase?

**No** — the daemon-managed worktree this helper operates on is NOT shared with operator-driven rebases. Operators run from canonical checkouts or their own clones. The helper's invariant: only called on worktrees provisioned by `dispatch_auto_bind_lease` / `repo action=checkout bind:true`, which are daemon-exclusive. Clearing rebase state here is safe.

`tracing::warn!` documents every clear (`#814: removed stale rebase-merge dir from prior failed cleanup attempt`) so post-incident audit can confirm it fired.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite: 2250 binary tests + integration + UI smoke + doc-tests, 0 regressions.

#814 tests (3 total, all in `dispatch_hook::tests`, all use actual `git` subprocess):
- [x] `clean_empty_init_commits_recovers_from_stale_rebase_merge_dir` — RED at C1 (status 32768), GREEN at C2
- [x] `clean_empty_init_commits_handles_50_interleaved_inits` — 50 inits + 4 reals + threshold warn fires + completes < 30s
- [x] `clean_empty_init_commits_clears_stale_dir_even_when_no_inits_to_drop` — defensive clear even in no-op case

All 3 tests run in ~1.5s total (50-init case ~1s — well within the 30s budget).

## Commit chain

1. `2de6dab` — `test(#814): RED test for clean_empty_init_commits stale rebase-merge recovery`
2. `f058ac1` — `fix(#814): clear_stale_rebase_state + resolve_worktree_gitdir hook (C2)`
3. `808b86f` — `fix(#814): high-init-count warn + capture rebase --abort failure + 2 more tests (C3)`

## Self-validation (real-world dogfood)

Ran `repo action=cleanup_init_commits` on this branch before push — cleared 4 init heartbeats cleanly with no stale rebase-merge dirs encountered. Helper now self-protects against the failure mode it ships.

## Out of scope (deferred per dispatch spec)

- git2-rs rewrite (subprocess → typed API)
- `warnings: Vec<String>` field on MCP response shape
- Config-able threshold
- Investigation of why some PRs accumulate more inits than others (separate concern; #807 had longer wall-clock window between branch creation and first push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)