### PR TITLE
fix(#819): WIDE_CHAR_SPACER at Site 1 leaks stale ratatui buf cell (sites 2-5 unchanged per text-path semantics)

### DIFF
--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -1209,4 +1209,106 @@ mod tests {
             buf[(1, 0)].symbol()
         );
     }
+
+    #[test]
+    fn test_wide_char_spacer_preserves_wide_char_at_col_minus_one() {
+        // #819 adjacency lock: clearing the SPACER cell at (x+1, y)
+        // must NOT clobber the WIDE_CHAR cell at (x, y). Test
+        // pre-poisons NEITHER position; renders; asserts the wide
+        // char is intact at col 0 + the spacer position is blank at
+        // col 1. Without this lock a refactor that swapped the order
+        // (clearing spacer BEFORE writing wide char) would silently
+        // overwrite the wide char.
+        let mut vt = VTerm::new(10, 1);
+        vt.process("中".as_bytes());
+        let area = ratatui::layout::Rect::new(0, 0, 10, 1);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        assert_eq!(
+            buf[(0, 0)].symbol(),
+            "中",
+            "wide char must be at col 0, got: {:?}",
+            buf[(0, 0)].symbol()
+        );
+        assert_eq!(
+            buf[(1, 0)].symbol(),
+            " ",
+            "spacer position at col 1 must be blank, got: {:?}",
+            buf[(1, 0)].symbol()
+        );
+    }
+
+    #[test]
+    fn test_text_construction_paths_still_skip_spacers() {
+        // #819 regression-proof for sites 2-5 (lines 331/365/415/492).
+        // These are text/ANSI construction paths — they build fresh
+        // String/Vec<u8> per call and their WIDE_CHAR_SPACER `continue`
+        // is the CORRECT behavior (avoids inserting a placeholder space
+        // into text representations consumers expect to be
+        // WIDE_CHAR-collapsed). Locks the contract that the #819 fix
+        // ONLY touched Site 1 (ratatui rendering); sites 2-5 unchanged.
+        //
+        // If a future refactor "extrapolates" the Site 1 fix to all 5
+        // sites, the asserts below will fail (text output will gain
+        // spurious spaces after wide chars), making the regression
+        // visible. Per general's directive on the #819 dispatch.
+        let mut vt = VTerm::new(20, 2);
+        // Input: wide char + plain char + newline + plain text.
+        // Expected text shape: "中A" (no space between 中 and A —
+        // the wide char's SPACER position must NOT contribute to text).
+        vt.process("中A\r\nB".as_bytes());
+
+        // Site 4 (line 445) — tail_lines() (visible-rows text builder)
+        let tail_text = vt.tail_lines(5);
+        assert!(
+            tail_text.contains("中A"),
+            "tail_lines() must NOT insert space between wide char and next char, got: {tail_text:?}"
+        );
+        assert!(
+            !tail_text.contains("中 A"),
+            "tail_lines() must NOT insert SPACER as space, got: {tail_text:?}"
+        );
+
+        // Site 3 (line 395) — read_scrollback() (scrollback + visible)
+        let scrollback = vt.read_scrollback(10);
+        assert!(
+            scrollback.contains("中A"),
+            "read_scrollback() must NOT insert SPACER as space, got: {scrollback:?}"
+        );
+        assert!(
+            !scrollback.contains("中 A"),
+            "read_scrollback() leaked SPACER as space, got: {scrollback:?}"
+        );
+
+        // Site 2 (line 361) — extract_text() (selection text)
+        let selected = vt.extract_text((0, 0), (0, 5), 0);
+        assert!(
+            selected.contains("中A"),
+            "extract_text() must NOT insert SPACER as space, got: {selected:?}"
+        );
+        assert!(
+            !selected.contains("中 A"),
+            "extract_text() leaked SPACER as space, got: {selected:?}"
+        );
+
+        // Site 5 (line 522) — dump_screen() (ANSI escape sequence builder).
+        // ANSI codes interleave between cells, so we don't assert
+        // verbatim "中A" sequence — instead verify the SPACER never
+        // contributes a literal space between the wide char and the
+        // following char (the actual regression we're proofing).
+        let ansi = vt.dump_screen();
+        let ansi_str = String::from_utf8_lossy(&ansi);
+        assert!(
+            ansi_str.contains("中"),
+            "dump_screen() must emit the wide char, got: {ansi_str:?}"
+        );
+        assert!(
+            ansi_str.contains('A'),
+            "dump_screen() must emit the following char, got: {ansi_str:?}"
+        );
+        assert!(
+            !ansi_str.contains("中 A"),
+            "dump_screen() leaked SPACER as literal space, got: {ansi_str:?}"
+        );
+    }
 }

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -231,6 +231,20 @@ impl VTerm {
                     .get(idx)
                     .unwrap_or_else(|| DEFAULT_CELL.get_or_init(Cell::default));
                 if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                    // Defensive: the WIDE_CHAR branch below skips col+1
+                    // by advancing `col += 2`, so this arm is normally
+                    // unreachable when iterating from a WIDE_CHAR's
+                    // sibling position. Kept as a guard for
+                    // partial-render edge cases (e.g. col 0 starts on
+                    // a SPACER because the WIDE_CHAR fell off the left
+                    // edge during a resize).
+                    let x = area.x + col;
+                    let y = area.y + row;
+                    if x < buf.area().x + buf.area().width && y < buf.area().y + buf.area().height {
+                        let style = cell_to_ratatui_style(cell.fg, cell.bg, cell.flags);
+                        let buf_cell = &mut buf[(x, y)];
+                        buf_cell.set_char(' ').set_style(style);
+                    }
                     col += 1;
                     continue;
                 }
@@ -245,6 +259,22 @@ impl VTerm {
                 let buf_cell = &mut buf[(x, y)];
                 buf_cell.set_char(ch).set_style(style);
                 if cell.flags.contains(Flags::WIDE_CHAR) {
+                    // #819: when writing a wide char at (x, y), the
+                    // adjacent cell at (x+1, y) is the WIDE_CHAR_SPACER
+                    // position. The outer loop `col += 2` skips it
+                    // entirely, so without an explicit blank-write here
+                    // the staging buffer retains the previous frame's
+                    // char at (x+1, y) — root cause of the "scattered
+                    // chars" operator observation (fixup-lead's CJK
+                    // prompt). Mirror the style from the wide char so
+                    // background continuity is preserved.
+                    let spacer_x = x + 1;
+                    if spacer_x < buf.area().x + buf.area().width
+                        && y < buf.area().y + buf.area().height
+                    {
+                        let spacer_cell = &mut buf[(spacer_x, y)];
+                        spacer_cell.set_char(' ').set_style(style);
+                    }
                     col += 2;
                 } else {
                     col += 1;

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -1147,4 +1147,36 @@ mod tests {
         assert!(!vt.wants_mouse());
         assert!(!vt.mouse_sgr());
     }
+
+    // ── #819 WIDE_CHAR_SPACER stale-char bug ──
+
+    #[test]
+    fn test_wide_char_spacer_clears_stale_buf_cell() {
+        // #819 RED test: at Site 1 (`render_to_buffer_inner`), the
+        // WIDE_CHAR_SPACER `continue` skips writing buf[(x, y)]. The
+        // ratatui Buffer is stateful across frames — previous frame's
+        // content at the spacer position survives. This test
+        // pre-poisons the spacer cell with a sentinel char, then
+        // renders. Pre-fix: sentinel survives (BUG). Post-fix:
+        // sentinel replaced with blank (SUT writes the spacer cell).
+        let mut vt = VTerm::new(10, 1);
+        // A CJK char has display width 2 — alacritty marks col 0 as
+        // WIDE_CHAR and col 1 as WIDE_CHAR_SPACER.
+        vt.process("中".as_bytes());
+        let area = ratatui::layout::Rect::new(0, 0, 10, 1);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        // Pre-poison col=1 (the SPACER position) with a stale sentinel
+        // simulating a previous frame's char at that position.
+        buf[(1, 0)].set_char('X');
+        // Render the current frame.
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        // SPACER position must be blanked, NOT carry the previous
+        // frame's 'X'. This is the #819 fix's invariant.
+        assert_eq!(
+            buf[(1, 0)].symbol(),
+            " ",
+            "WIDE_CHAR_SPACER position must be blanked, got: {:?}",
+            buf[(1, 0)].symbol()
+        );
+    }
 }


### PR DESCRIPTION
Closes #819.

scope follows dispatch spec t-20260515073442639954-11

## Summary

Operator observed scattered/ghost chars in fixup-lead's prompt input line, disappearing on selection. Root cause: in `vterm.rs::render_to_buffer_inner`, the WIDE_CHAR branch advances `col += 2` to skip the spacer position (col+1) after writing a wide char. ratatui's `Buffer` is **stateful** across frames — without an explicit blank-write at (x+1, y), the previous frame's char survives, surfacing as visible "ghost" characters.

**Initial spike analysis pointed at the SPACER `continue` branch** (line 233). After C2 implementation revealed that branch is actually UNREACHABLE in normal flow (the outer loop's `col += 2` skips the spacer cell entirely), the fix relocated to the WIDE_CHAR branch where the spacer's coordinate (x+1) is known. Both arms now defensively clear — the SPACER branch as a guard for partial-render edge cases (e.g. resize cutting off the WIDE_CHAR off the left edge, leaving an orphan spacer at col 0).

## Why sites 2-5 NOT changed (narrowed scope per spike findings)

Trace at HEAD confirmed 5 `WIDE_CHAR_SPACER` `continue` sites:

| Site | Function | Buf type | Bug? |
|---|---|---|---|
| 1 (line 233) | `render_to_buffer_inner` | `ratatui::Buffer` (stateful across frames) | **YES** — root cause, fixed in C2 |
| 2 (line 361) | `extract_text` | `String` (fresh per call) | NO — text path |
| 3 (line 395) | `read_scrollback` | `String` (fresh per call) | NO — text path |
| 4 (line 445) | `tail_lines` | `String` (fresh per call) | NO — text path |
| 5 (line 522) | `dump_screen` | `Vec<u8>` (fresh per call) | NO — ANSI stream path |

Sites 2-5 build fresh String/Vec<u8> per call. Their spacer-skip is the CORRECT behavior — these consumers expect the wide-char's right-half placeholder to be COLLAPSED (the WIDE_CHAR cell at col-1 already carries the visible character; inserting a placeholder space would break copy/paste and scrollback text consumers).

General confirmed via dispatch + comment to issue body that the original "5 sites all leak stale chars" premise was incorrect.

## Pattern B (defensive blank-fill) — skipped

With Site 1 fixed, every cell in `area` is now touched (either via the wide-char + spacer cell pair or via the regular single-cell write). Pattern B (defensive blank-fill for "cells not touched this frame") becomes a no-op. If a future render path adds another skip, address it then.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite: 2260 binary tests + integration + UI smoke + doc-tests, 0 regressions

3 #819 tests (Site 1 + adjacency + sites-2-5 regression-proof):

- [x] `test_wide_char_spacer_clears_stale_buf_cell` — RED at C1, GREEN at C2. Pre-poisons SPACER position with sentinel `X`, asserts blank post-render
- [x] `test_wide_char_spacer_preserves_wide_char_at_col_minus_one` — adjacency lock; without this, a refactor that swapped the order would silently overwrite the wide char
- [x] `test_text_construction_paths_still_skip_spacers` — **explicit regression-proof** for sites 2-5 per general's directive. Tests `extract_text`, `read_scrollback`, `tail_lines`, `dump_screen` for `中A` input. Asserts NO literal space between wide char and following char. Future refactor that extrapolates Site 1 fix to all 5 sites would fail this test.

## Commit chain

1. `7fb020a` — `test(#819): RED test for WIDE_CHAR_SPACER stale buf cell`
2. `99aedac` — `fix(#819): clear wide-char SPACER position in ratatui buf (C2)`
3. `616ecc4` — `test(#819): adjacency lock + explicit regression-proof for sites 2-5 (C3)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)