### PR TITLE
feat(#821): test isolation invariant — helper + grep-based check + grandfather allowlist

### DIFF
--- a/tests/common/git_isolated.rs
+++ b/tests/common/git_isolated.rs
@@ -51,30 +51,63 @@ use std::process::{Command, Output};
 /// Run git in `repo_dir` with cwd isolation + shim bypass + pinned
 /// author/committer. The canonical entry for test fixtures.
 ///
-/// #821 stub — real implementation lands in C2.
+/// allow: raw-git-subprocess  // canonical helper module — exempt
 #[allow(dead_code)]
 pub fn git(repo_dir: &Path, args: &[&str]) -> Output {
-    let _ = (repo_dir, args);
-    Command::new("true").output().expect("stub")
+    Command::new("git")
+        .args(args)
+        .current_dir(repo_dir)
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@example")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@example")
+        .output()
+        .expect("git subprocess spawn")
 }
 
 /// Variant accepting an explicit committer date for back-dating
-/// commits (e.g. stale-detection tests per #817 fixture).
+/// commits (used by stale-detection tests per #817 + #814 r1 lesson —
+/// `chrono::now() - duration` arithmetic is flaky near day boundaries,
+/// so date-sensitive tests pin both author and committer dates).
 ///
-/// #821 stub — real implementation lands in C2.
+/// allow: raw-git-subprocess  // canonical helper module — exempt
 #[allow(dead_code)]
 pub fn git_dated(repo_dir: &Path, args: &[&str], date_rfc3339: &str) -> Output {
-    let _ = (repo_dir, args, date_rfc3339);
-    Command::new("true").output().expect("stub")
+    Command::new("git")
+        .args(args)
+        .current_dir(repo_dir)
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@example")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@example")
+        .env("GIT_AUTHOR_DATE", date_rfc3339)
+        .env("GIT_COMMITTER_DATE", date_rfc3339)
+        .output()
+        .expect("git subprocess spawn")
 }
 
 /// Create a temp git repo with `main` branch + initial commit +
 /// pinned per-repo gitconfig. Returns the repo PathBuf. Standard
-/// entry point for fixtures that need a fresh git repo.
-///
-/// #821 stub — real implementation lands in C2.
+/// entry point for fixtures that need a fresh git repo. The
+/// per-repo `user.name`/`user.email` config means CI runners
+/// without a global `~/.gitconfig` can still commit (per the #814
+/// r1 lesson — that PR's CI failed cross-platform with `unable to
+/// auto-detect email address`).
 #[allow(dead_code)]
 pub fn setup_temp_repo(tag: &str) -> PathBuf {
-    let _ = tag;
-    std::env::temp_dir()
+    let dir = std::env::temp_dir().join(format!(
+        "agend-test-{}-{}-{tag}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir test temp repo");
+    git(&dir, &["init", "-b", "main"]);
+    git(&dir, &["config", "user.name", "test"]);
+    git(&dir, &["config", "user.email", "test@example"]);
+    dir
 }

--- a/tests/common/git_isolated.rs
+++ b/tests/common/git_isolated.rs
@@ -1,0 +1,80 @@
+//! #821 — isolated git subprocess invocation for test fixtures.
+//!
+//! Test fixtures that shell out to `git` MUST use this module instead
+//! of `std::process::Command::new("git")` directly. The helpers pin:
+//!
+//! - `AGEND_GIT_BYPASS=1` — bypasses the `agend-git` shim's binding-
+//!   based routing. Without this, the shim sees the test process's
+//!   `AGEND_INSTANCE_NAME` (if set by `cargo test` env inheritance)
+//!   and routes git operations to the BOUND worktree's branch instead
+//!   of the test's temp dir. The #820 PR's mid-implementation
+//!   "feat-b polluted host worktree" incident traced back to a
+//!   manual bash debug session running without this env (NOT the
+//!   test fixture itself, but the trap class is real).
+//!
+//! - `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` / `GIT_COMMITTER_*` —
+//!   subprocess `git commit` fails with `unable to auto-detect
+//!   email address` on CI runners that lack a global `~/.gitconfig`.
+//!   Per the #814 r1 lesson — local dev machines inherit the
+//!   developer's gitconfig and mask this trap.
+//!
+//! - `current_dir(repo_dir)` — git uses cwd for upward `.git`
+//!   discovery. Without the dir pin, git walks up from the test
+//!   process's cwd (the agend-terminal worktree) and finds the
+//!   host worktree's `.git`, leaking operations into the host.
+//!
+//! ## Pattern to AVOID (bad)
+//!
+//! ```rust,ignore
+//! std::process::Command::new("git")
+//!     .args(["checkout", "-b", "feat-b"])
+//!     .output()  // ← no cwd pin, no shim bypass, no committer env
+//! ```
+//!
+//! ## Pattern to USE (good)
+//!
+//! ```rust,ignore
+//! use crate::common::git_isolated;
+//! let repo = git_isolated::setup_temp_repo("my-tag");
+//! git_isolated::git(&repo, &["checkout", "-b", "feat-b"]);
+//! ```
+//!
+//! ## Allowlist
+//!
+//! Pre-existing test files using raw `Command::new("git")` are
+//! grandfathered via the `tests/test_isolation_invariant.rs` allowlist.
+//! New tests added after #821 ships MUST use this helper.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Run git in `repo_dir` with cwd isolation + shim bypass + pinned
+/// author/committer. The canonical entry for test fixtures.
+///
+/// #821 stub — real implementation lands in C2.
+#[allow(dead_code)]
+pub fn git(repo_dir: &Path, args: &[&str]) -> Output {
+    let _ = (repo_dir, args);
+    Command::new("true").output().expect("stub")
+}
+
+/// Variant accepting an explicit committer date for back-dating
+/// commits (e.g. stale-detection tests per #817 fixture).
+///
+/// #821 stub — real implementation lands in C2.
+#[allow(dead_code)]
+pub fn git_dated(repo_dir: &Path, args: &[&str], date_rfc3339: &str) -> Output {
+    let _ = (repo_dir, args, date_rfc3339);
+    Command::new("true").output().expect("stub")
+}
+
+/// Create a temp git repo with `main` branch + initial commit +
+/// pinned per-repo gitconfig. Returns the repo PathBuf. Standard
+/// entry point for fixtures that need a fresh git repo.
+///
+/// #821 stub — real implementation lands in C2.
+#[allow(dead_code)]
+pub fn setup_temp_repo(tag: &str) -> PathBuf {
+    let _ = tag;
+    std::env::temp_dir()
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod env_gate;
+pub mod git_isolated;
 pub mod harness;

--- a/tests/git_subprocess_invariant.rs
+++ b/tests/git_subprocess_invariant.rs
@@ -128,11 +128,31 @@ pub struct Violation {
 /// (empty when clean). Public-for-tests so the RED/GREEN probes can
 /// call the SAME scanner the production invariant calls — no mock
 /// branches.
-///
-/// #821 stub — real implementation lands in C2.
-#[allow(dead_code)]
-pub fn scan_test_violations(_tests_dir: &Path) -> Vec<Violation> {
-    Vec::new()
+pub fn scan_test_violations(tests_dir: &Path) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    for file in rs_files_under(tests_dir) {
+        if is_exempt_file(&file) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        let lines: Vec<&str> = content.lines().collect();
+        for (idx, line) in lines.iter().enumerate() {
+            if !line.contains(PATTERN) {
+                continue;
+            }
+            if has_allow_marker(&lines, idx) {
+                continue;
+            }
+            violations.push(Violation {
+                file: file.clone(),
+                line: idx + 1,
+                snippet: (*line).to_string(),
+            });
+        }
+    }
+    violations
 }
 
 #[test]

--- a/tests/git_subprocess_invariant.rs
+++ b/tests/git_subprocess_invariant.rs
@@ -1,0 +1,256 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! #821 — git subprocess isolation invariant. Test files under `tests/`
+//! that shell out to `git` via raw `Command::new("git")` MUST route
+//! through `tests/common/git_isolated` to avoid the trap class
+//! exposed during #820 prep: the `agend-git` shim routes
+//! daemon-process git operations to the bound branch when
+//! `AGEND_GIT_BYPASS` is unset, leaking test ops into the host
+//! worktree's `.git`.
+//!
+//! Sister invariant to `tests/test_isolation_invariant.rs` (Sprint 31
+//! P0, which enforces `AGEND_TEST_ISOLATION=1` for binary-spawning
+//! tests). Different bug class — different env var — different scope.
+//!
+//! ## What it checks
+//!
+//! For every `.rs` file under `tests/`, grep for the literal
+//! `Command::new("git")`. Each hit must be either:
+//!
+//! - In the canonical helper module `tests/common/git_isolated.rs`
+//!   (exempt — the helper IS the canonical authority).
+//! - In this invariant file itself (the lint's own probe fixtures
+//!   naturally contain the offending pattern as test data).
+//! - On a line carrying `// allow: raw-git-subprocess <rationale>`
+//!   (or in a contiguous comment block immediately above).
+//!
+//! ## Allowlist mechanism
+//!
+//! Mirrors `tests/anti_pattern_invariant.rs`: line-or-above
+//! `// allow: raw-git-subprocess` comment exempts the violation.
+//! Always include a rationale next to the marker.
+//!
+//! ## Grandfathered files (initial v1 allowlist)
+//!
+//! Pre-#821 test files using raw `Command::new("git")` are
+//! grandfathered via per-site `// allow:` comments added when this
+//! invariant lands. Follow-up PRs can migrate them to
+//! `git_isolated::git()` incrementally.
+
+use std::path::{Path, PathBuf};
+
+const TESTS_DIR: &str = "tests";
+const ALLOW_MARKER: &str = "allow: raw-git-subprocess";
+const PATTERN: &str = "Command::new(\"git\")";
+
+/// Walk every `.rs` file under `tests/`. Mirrors the helpers used by
+/// `tests/anti_pattern_invariant.rs` and `tests/cargo_include_invariant.rs`.
+fn rs_files_under(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if !root.exists() {
+        return out;
+    }
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(p);
+            }
+        }
+    }
+    walk(root, &mut out);
+    out
+}
+
+/// True iff this file is exempt from the lint:
+/// - The lint itself (`git_subprocess_invariant.rs`) — its probe
+///   fixtures naturally contain the offending pattern as test data.
+/// - The helper module `tests/common/git_isolated.rs` — the
+///   canonical authority is allowed to use the raw subprocess.
+fn is_exempt_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if name == "git_subprocess_invariant.rs" {
+        return true;
+    }
+    let parent = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    parent == "common" && name == "git_isolated.rs"
+}
+
+/// True iff the violation line (or any contiguous `//` comment line
+/// immediately preceding it) carries the allow-marker. Mirrors
+/// `anti_pattern_invariant::has_allowlist_marker` semantics.
+fn has_allow_marker(lines: &[&str], line_idx: usize) -> bool {
+    if lines
+        .get(line_idx)
+        .map(|l| l.contains(ALLOW_MARKER))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    let mut cursor = line_idx;
+    while let Some(prev_idx) = cursor.checked_sub(1) {
+        let Some(prev_line) = lines.get(prev_idx) else {
+            break;
+        };
+        let trimmed = prev_line.trim_start();
+        if !trimmed.starts_with("//") {
+            break;
+        }
+        if trimmed.contains(ALLOW_MARKER) {
+            return true;
+        }
+        cursor = prev_idx;
+    }
+    false
+}
+
+/// One violation entry — `(file, line_number, snippet)`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Violation {
+    pub file: PathBuf,
+    pub line: usize,
+    pub snippet: String,
+}
+
+/// Scan a directory of test files for raw `Command::new("git")`
+/// invocations missing the allow-marker. Returns the violation list
+/// (empty when clean). Public-for-tests so the RED/GREEN probes can
+/// call the SAME scanner the production invariant calls — no mock
+/// branches.
+///
+/// #821 stub — real implementation lands in C2.
+#[allow(dead_code)]
+pub fn scan_test_violations(_tests_dir: &Path) -> Vec<Violation> {
+    Vec::new()
+}
+
+#[test]
+fn invariant_passes_on_repo_test_files() {
+    // Load-bearing test: actual `tests/` dir of this repo MUST pass
+    // once the grandfather allowlist is applied in C3. Pre-C2 this
+    // passes trivially (stub returns empty); post-C2+C3 locks the
+    // contract.
+    let violations = scan_test_violations(Path::new(TESTS_DIR));
+    if !violations.is_empty() {
+        let summary: Vec<String> = violations
+            .iter()
+            .map(|v| format!("  {}:{}: {}", v.file.display(), v.line, v.snippet.trim()))
+            .collect();
+        panic!(
+            "#821 invariant FAILED — {} raw `Command::new(\"git\")` site(s) in tests/ \
+             missing the `// {}` allow-marker. Either migrate to \
+             `tests/common/git_isolated` OR add the marker:\n\n{}",
+            violations.len(),
+            ALLOW_MARKER,
+            summary.join("\n"),
+        );
+    }
+}
+
+#[test]
+fn invariant_detects_raw_git_subprocess_in_synthetic_file() {
+    // C1 RED test: synthesize a temp `tests/`-style directory with a
+    // single .rs file containing a raw `Command::new("git")` call.
+    // The scanner must flag it as a violation post-C2.
+    let temp = synth_tests_dir("raw_git_red");
+    let file = temp.join("offender.rs");
+    std::fs::write(
+        &file,
+        "use std::process::Command;\n\
+         fn naughty() {\n    \
+             let _ = Command::new(\"git\").args([\"status\"]).output();\n\
+         }\n",
+    )
+    .unwrap();
+    let violations = scan_test_violations(&temp);
+    assert!(
+        !violations.is_empty(),
+        "scanner must flag raw Command::new(\"git\") without allow-marker"
+    );
+    assert!(
+        violations.iter().any(|v| v.file.ends_with("offender.rs")),
+        "violation list must name offender.rs, got: {violations:?}"
+    );
+    std::fs::remove_dir_all(&temp).ok();
+}
+
+#[test]
+fn invariant_passes_when_allow_marker_present() {
+    // C2 GREEN: synthesize a file with the allow-marker on the
+    // offending line → scanner returns empty violations.
+    let temp = synth_tests_dir("allow_marker_green");
+    let file = temp.join("clean.rs");
+    std::fs::write(
+        &file,
+        "use std::process::Command;\n\
+         fn justified() {\n    \
+             // allow: raw-git-subprocess legacy fixture grandfathered per #821\n    \
+             let _ = Command::new(\"git\").args([\"status\"]).output();\n\
+         }\n",
+    )
+    .unwrap();
+    let violations = scan_test_violations(&temp);
+    assert!(
+        violations.is_empty(),
+        "allow-marker must suppress violation, got: {violations:?}"
+    );
+    std::fs::remove_dir_all(&temp).ok();
+}
+
+#[test]
+fn invariant_passes_when_helper_module_used() {
+    // C2 GREEN: synthesize a file using `git_isolated::git(...)` →
+    // no raw `Command::new("git")` literal → no violation. Pins the
+    // intent so a future scanner refactor that probes other patterns
+    // doesn't accidentally re-flag helper-routed callers.
+    let temp = synth_tests_dir("helper_green");
+    let file = temp.join("clean_helper.rs");
+    std::fs::write(
+        &file,
+        "use crate::common::git_isolated;\n\
+         fn clean() {\n    \
+             let dir = git_isolated::setup_temp_repo(\"t\");\n    \
+             git_isolated::git(&dir, &[\"status\"]);\n\
+         }\n",
+    )
+    .unwrap();
+    let violations = scan_test_violations(&temp);
+    assert!(
+        violations.is_empty(),
+        "helper-routed callers must surface zero violations, got: {violations:?}"
+    );
+    std::fs::remove_dir_all(&temp).ok();
+}
+
+/// Synthesize a temporary tests-like dir scoped by tag. Used by
+/// RED/GREEN tests to avoid touching the real `tests/` dir.
+fn synth_tests_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-821-{}-{}-{tag}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+// Suppress unused-fn warnings for helpers reached only at runtime
+// (stub doesn't call them; real impl in C2 will).
+#[allow(dead_code)]
+fn _unused_lints_silencer() {
+    let _ = (rs_files_under, has_allow_marker, is_exempt_file, PATTERN);
+}

--- a/tests/worktree_opt_out.rs
+++ b/tests/worktree_opt_out.rs
@@ -67,12 +67,14 @@ instances:
 fn git_status_porcelain_detects_dirty() {
     let dir = std::env::temp_dir().join(format!("agend-wt-dirty-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
@@ -81,6 +83,7 @@ fn git_status_porcelain_detects_dirty() {
         .unwrap();
     std::fs::write(dir.join("dirty.txt"), "uncommitted").unwrap();
 
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     let output = std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["status", "--porcelain"])
@@ -99,12 +102,14 @@ fn git_status_porcelain_detects_dirty() {
 fn git_status_porcelain_clean() {
     let dir = std::env::temp_dir().join(format!("agend-wt-clean-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
@@ -112,6 +117,7 @@ fn git_status_porcelain_clean() {
         .output()
         .unwrap();
 
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     let output = std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["status", "--porcelain"])
@@ -133,12 +139,14 @@ fn e2e_clean_worktree_flip_prunes() {
     let dir = std::env::temp_dir().join(format!("agend-wt-e2e-prune-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
     // Init git repo
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
@@ -149,12 +157,14 @@ fn e2e_clean_worktree_flip_prunes() {
     let wt_dir = dir.join(".worktrees").join("test-agent");
     std::fs::create_dir_all(&wt_dir).unwrap();
     // Init the worktree as a git repo too (so git status works)
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["init", "-b", "main"])
         .current_dir(&wt_dir)
         .output()
         .unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
@@ -163,6 +173,7 @@ fn e2e_clean_worktree_flip_prunes() {
         .unwrap();
 
     // Verify clean
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     let output = std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["status", "--porcelain"])
@@ -185,12 +196,14 @@ fn e2e_clean_worktree_flip_prunes() {
 fn e2e_dirty_worktree_flip_rejected() {
     let dir = std::env::temp_dir().join(format!("agend-wt-e2e-reject-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["init", "-b", "main"])
         .current_dir(&dir)
         .output()
         .unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
@@ -199,12 +212,14 @@ fn e2e_dirty_worktree_flip_rejected() {
         .unwrap();
     let wt_dir = dir.join(".worktrees").join("test-agent");
     std::fs::create_dir_all(&wt_dir).unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["init", "-b", "main"])
         .current_dir(&wt_dir)
         .output()
         .unwrap();
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["commit", "--allow-empty", "-m", "init"])
@@ -214,6 +229,7 @@ fn e2e_dirty_worktree_flip_rejected() {
     // Make dirty
     std::fs::write(wt_dir.join("dirty.txt"), "uncommitted work").unwrap();
 
+    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
     let output = std::process::Command::new("git")
         .env("AGEND_GIT_BYPASS", "1")
         .args(["status", "--porcelain"])


### PR DESCRIPTION
Closes #821.

scope follows dispatch spec t-20260515103427962620-12

## Summary

Three pieces close the #821 invariant:

1. **`tests/common/git_isolated.rs`** — canonical helper module with `git(repo_dir, args)`, `git_dated(repo_dir, args, date)`, `setup_temp_repo(tag)`. Each pins `AGEND_GIT_BYPASS=1` (shim bypass), `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env (CI portability per #814 r1), and `.current_dir(repo_dir)` (cwd isolation against `.git` upward walk).
2. **`tests/git_subprocess_invariant.rs`** — new invariant test. Walks `tests/*.rs`, greps for `Command::new("git")`, requires either the helper module OR a `// allow: raw-git-subprocess <rationale>` marker on the line (or contiguous comment above). Mirrors `tests/anti_pattern_invariant.rs` pattern.
3. **Grandfather allowlist** — `tests/worktree_opt_out.rs` (16 sites) gets per-site `// allow:` markers. Those sites already use the safety pattern (`.env("AGEND_GIT_BYPASS", "1") + .current_dir(&dir)`), just don't go through the helper yet. Follow-up PRs can migrate.

## #820 root-cause refinement (important context for reviewers)

The dispatch text framed #821 as a fix for "test fixture pollution observed during #820". On closer inspection, the #820 incident (a `feat-b` branch appearing on the host worktree mid-implementation) was likely caused by **MY MANUAL BASH DEBUG SESSION** running `git` commands without `AGEND_GIT_BYPASS=1`, NOT the test fixture itself. The #817 fixture I wrote during that PR correctly used `AGEND_GIT_BYPASS=1 + .current_dir()`.

The invariant is still valuable as a **defensive guard against future test fixtures** that miss the pattern. The shim's binding-based routing is a trap class for both manual debug sessions AND test fixtures; this PR addresses the second half.

The first half — bash session protection — is **out of #821 scope**. Suggested follow-up: docs page or `agend-terminal doctor` warning when `AGEND_GIT_BYPASS` is unset in an interactive shell. Lead will file separately.

## Why grandfather (Option B) vs bulk migrate (Option A)

- Smaller PR, contained risk profile
- New tests added after #821 ships MUST use the helper (load-bearing test `invariant_passes_on_repo_test_files` catches the regression)
- Existing `tests/worktree_opt_out.rs` already uses the safety pattern correctly — migration to the helper is functionally equivalent, no urgency
- Follow-up PRs can migrate incrementally as developers touch those tests

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite: 2260 binary tests + integration + UI smoke + doc-tests, 0 regressions
- [x] `cargo test --test git_subprocess_invariant`: 4/4 GREEN

#821 tests (4 total):
- [x] `invariant_detects_raw_git_subprocess_in_synthetic_file` — RED at C1, GREEN at C2 (scanner flags synthetic violation)
- [x] `invariant_passes_when_allow_marker_present` — synthetic file with marker → no violation
- [x] `invariant_passes_when_helper_module_used` — synthetic file calling `git_isolated::git(...)` → no violation
- [x] `invariant_passes_on_repo_test_files` — **load-bearing**: scans actual `tests/` dir, MUST pass with grandfather markers applied. Pre-C3 fails with 16 violations in `worktree_opt_out.rs`; post-C3 passes.

## Refined scope (smaller than spike estimated)

Spike estimated "24 grandfathered files" based on `rg -l 'Command::new("git")' src/ tests/`. After applying design call 2 (scope to `tests/*.rs` only), the actual count is **1 file (16 sites) in `tests/`** — all other 23 files are under `src/` (production code, out of scope; routes through shim correctly via daemon's bound binding context).

## Commit chain

1. `0f2ece7` — `test(#821): scaffolding for git subprocess isolation invariant (C1)` — stub helpers + 1 RED test + 3 GREEN-via-stub tests
2. `ad6fccd` — `fix(#821): scan_test_violations + git_isolated helper impl (C2)` — real scanner + helper module impls; C1 RED → GREEN
3. `8fe2cba` — `test(#821): grandfather allowlist for tests/worktree_opt_out.rs 16 sites (C3)` — adds `// allow:` markers; load-bearing test → GREEN

## Out of scope (deferred)

- Bulk migration of `tests/worktree_opt_out.rs` to use the helper (functionally equivalent; follow-up PR if needed)
- Bash session protection (separate docs/UX issue per design call 4)
- Inline `src/**/*.rs` tests with raw `Command::new("git")` (scope is `tests/*.rs` only per design call 2)
- Refactoring the helper for non-git subprocess (different bug class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)