### PR TITLE
fix(#822): cleanup_init_commits heartbeat synonym whitelist (init + initial) + body-emptiness gate

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -732,14 +732,25 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
         return Ok(0);
     }
 
-    // Identify empty "init" commits.
+    // Identify empty heartbeat commits.
+    //
+    // #822 C1 scaffolding: introduces `HEARTBEAT_NAMES` whitelist +
+    // `is_heartbeat_subject` + `commit_body_is_empty` API surface but
+    // keeps the whitelist at the production-equivalent value
+    // (`["init"]`). The body-emptiness gate stub returns `true` so the
+    // diff-tree gate immediately below remains the load-bearing
+    // emptiness check. C2 fills in the synonym (`"initial"`) and
+    // wires up the real body-gate impl.
     let mut empty_inits: Vec<&str> = Vec::new();
     for line in log.lines() {
         let (hash, msg) = match line.split_once(' ') {
             Some(pair) => pair,
             None => continue,
         };
-        if msg != "init" {
+        if !is_heartbeat_subject(msg) {
+            continue;
+        }
+        if !commit_body_is_empty(worktree, hash) {
             continue;
         }
         // Check if commit has no file changes.
@@ -868,6 +879,60 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
 /// adds no operator value. Matches the observed #807 incident
 /// count (32 inits > 30 threshold → warns).
 const INIT_COUNT_WARN_THRESHOLD: usize = 30;
+
+/// #822: subjects accepted as "heartbeat commit" candidates. The
+/// daemon-side heartbeat producers (worktree.rs / bootstrap/
+/// agent_resolve.rs) hardcode `"init"`, but a separate code path
+/// or external session checkpoint can land an `"initial"` commit
+/// (the #820 stray `9f619c2 initial` was the observed offender).
+///
+/// Empirical census across all 65 heartbeat commits in repo history
+/// at the time of #822: 64 × `init` + 1 × `initial`. Zero `wip`,
+/// `tmp`, `temp`, `checkpoint`, `draft` occurrences — those are
+/// deferred to v1.5 if/when observed.
+///
+/// Hardcoded (KISS); case-sensitive exact match. Body-emptiness
+/// gate (`commit_body_is_empty`) guards against the rare-but-real
+/// case where a user has an empty-diff commit named `init` or
+/// `initial` with real commit-body notes (e.g. an intentional
+/// `--allow-empty` marker commit). That case is theoretical for
+/// today's daemon producers (they never set a body) but the gate
+/// is forward-compatible insurance against expanding the whitelist
+/// in v1.5.
+///
+/// C1 stub value: `["init"]` only — keeps the production-equivalent
+/// behavior so the existing fixture tests stay green while the new
+/// RED test for `"initial"` flips at C2 when this expands to
+/// `["init", "initial"]`.
+const HEARTBEAT_NAMES: &[&str] = &["init"];
+
+/// #822: exact-match check against [`HEARTBEAT_NAMES`].
+///
+/// Lives as a function (not inline `.contains`) so the call site at
+/// the match loop reads at the abstraction level of the contract
+/// (`is_heartbeat_subject`) rather than the implementation
+/// (`HEARTBEAT_NAMES.contains(&msg)`).
+fn is_heartbeat_subject(msg: &str) -> bool {
+    HEARTBEAT_NAMES.contains(&msg)
+}
+
+/// #822: returns true iff the commit's body (the part after the
+/// subject line) is empty or whitespace-only. Guards the whitelist
+/// from dropping commits with legitimate body notes that happen to
+/// share a heartbeat subject.
+///
+/// C1 stub: returns `true` unconditionally so the gate is a no-op
+/// and C1 behavior matches pre-#822 production exactly (the diff-
+/// tree gate immediately below remains the only emptiness check).
+/// C2 fills in the real `git log -1 --format=%b <hash>` impl.
+///
+/// Fail-soft: any git-log error returns `true` (treat as empty body)
+/// rather than `false`. This preserves the existing "drop if diff is
+/// empty" behavior when body-detection fails — neutral fallback that
+/// does not block legitimate cleanups on transient git failures.
+fn commit_body_is_empty(_worktree: &Path, _hash: &str) -> bool {
+    true
+}
 
 /// #814: clear `.git/.../rebase-merge` AND `rebase-apply` dirs that
 /// survived a prior failed cleanup attempt. Called at the top of

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -900,11 +900,10 @@ const INIT_COUNT_WARN_THRESHOLD: usize = 30;
 /// is forward-compatible insurance against expanding the whitelist
 /// in v1.5.
 ///
-/// C1 stub value: `["init"]` only — keeps the production-equivalent
-/// behavior so the existing fixture tests stay green while the new
-/// RED test for `"initial"` flips at C2 when this expands to
-/// `["init", "initial"]`.
-const HEARTBEAT_NAMES: &[&str] = &["init"];
+/// v1 value: `["init", "initial"]` — covers the two empirically
+/// observed offenders. `wip`/`tmp`/`temp`/`checkpoint`/`draft` are
+/// deferred to v1.5 if/when observed in real heartbeat traffic.
+const HEARTBEAT_NAMES: &[&str] = &["init", "initial"];
 
 /// #822: exact-match check against [`HEARTBEAT_NAMES`].
 ///
@@ -921,17 +920,25 @@ fn is_heartbeat_subject(msg: &str) -> bool {
 /// from dropping commits with legitimate body notes that happen to
 /// share a heartbeat subject.
 ///
-/// C1 stub: returns `true` unconditionally so the gate is a no-op
-/// and C1 behavior matches pre-#822 production exactly (the diff-
-/// tree gate immediately below remains the only emptiness check).
-/// C2 fills in the real `git log -1 --format=%b <hash>` impl.
+/// Reads the commit's body via `git log -1 --format=%b <hash>` and
+/// trims. `%b` yields the body only (no subject, no trailing
+/// newline-pad — git always emits a trailing newline that `.trim()`
+/// strips).
 ///
 /// Fail-soft: any git-log error returns `true` (treat as empty body)
 /// rather than `false`. This preserves the existing "drop if diff is
 /// empty" behavior when body-detection fails — neutral fallback that
 /// does not block legitimate cleanups on transient git failures.
-fn commit_body_is_empty(_worktree: &Path, _hash: &str) -> bool {
-    true
+fn commit_body_is_empty(worktree: &Path, hash: &str) -> bool {
+    let out = std::process::Command::new("git")
+        .args(["log", "-1", "--format=%b", hash])
+        .current_dir(worktree)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output();
+    match out {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().is_empty(),
+        _ => true,
+    }
 }
 
 /// #814: clear `.git/.../rebase-merge` AND `rebase-apply` dirs that

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1591,3 +1591,54 @@ fn clean_empty_init_commits_clears_stale_dir_even_when_no_inits_to_drop() {
 
     std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
 }
+
+// ── #822 cleanup_init_commits heartbeat synonym whitelist ──
+
+/// Commit an empty-diff commit on `worktree`'s HEAD with `subject` as
+/// the subject line and optional `body` as the commit body. Pinned
+/// per-#814 r1 pattern (per-process author/committer env so CI runners
+/// without a global gitconfig can still commit).
+fn empty_commit(worktree: &std::path::Path, subject: &str, body: Option<&str>) {
+    let mut args: Vec<&str> = vec!["commit", "--allow-empty", "-m", subject];
+    if let Some(b) = body {
+        args.push("-m");
+        args.push(b);
+    }
+    let status = std::process::Command::new("git")
+        .args(&args)
+        .current_dir(worktree)
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .status()
+        .expect("git commit ran");
+    assert!(status.success(), "empty_commit `{subject}` failed");
+}
+
+/// #822 C1 RED: synthesize an empty-body, empty-diff commit with
+/// subject "initial" — the exact #820 stray case. Pre-fix the helper
+/// only matches `"init"` so the commit is NOT dropped (returns 0).
+/// Post-fix (C2) the whitelist expands to include `"initial"` and
+/// the commit IS dropped (returns 1). Asserts the post-fix behavior;
+/// fails RED at C1, flips GREEN at C2.
+#[test]
+fn clean_empty_init_commits_drops_initial_subject_with_empty_body() {
+    let (_repo, worktree) = setup_repo_and_worktree("initial_red");
+    empty_commit(&worktree, "initial", None);
+
+    let result = super::clean_empty_init_commits(&worktree);
+    assert!(
+        result.is_ok(),
+        "helper must run cleanly on `initial`-named commit, got: {result:?}"
+    );
+    let cleaned = result.unwrap();
+    assert_eq!(
+        cleaned, 1,
+        "empty-body empty-diff `initial` commit must be dropped \
+         (the #820 stray case); cleaned={cleaned}"
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1642,3 +1642,69 @@ fn clean_empty_init_commits_drops_initial_subject_with_empty_body() {
 
     std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
 }
+
+/// #822 C3 regression-proof: the body-emptiness gate must guard
+/// `initial`-subject commits that carry real commit-body notes. This
+/// is the load-bearing FP-class case for v1.5 (the gate also guards
+/// future `wip`/`tmp` synonyms). Body present → KEEP, even with
+/// empty diff and whitelisted subject.
+#[test]
+fn clean_empty_init_commits_keeps_initial_subject_with_body_notes() {
+    let (_repo, worktree) = setup_repo_and_worktree("initial_body");
+    empty_commit(&worktree, "initial", Some("real body notes — do not drop"));
+
+    let result = super::clean_empty_init_commits(&worktree);
+    assert!(result.is_ok(), "helper must succeed, got: {result:?}");
+    assert_eq!(
+        result.unwrap(),
+        0,
+        "`initial` with non-empty body must be kept (body gate guards FP class)",
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}
+
+/// #822 C3 behavior-change documentation: an `init`-subject empty-
+/// diff commit with a non-empty commit body was DROPPED pre-#822
+/// (the body was ignored), and is now KEPT (body gate added). This
+/// is theoretical-only — zero historical occurrences in 64+ daemon-
+/// generated `init` commits, all of which use
+/// `commit --allow-empty -m "init"` with no `-m <body>`. This test
+/// locks the new behavior so future helper edits can't quietly
+/// reintroduce the body-ignore regression.
+#[test]
+fn clean_empty_init_commits_keeps_init_subject_with_body_notes() {
+    let (_repo, worktree) = setup_repo_and_worktree("init_body");
+    empty_commit(&worktree, "init", Some("operator-added body — do not drop"));
+
+    let result = super::clean_empty_init_commits(&worktree);
+    assert!(result.is_ok(), "helper must succeed, got: {result:?}");
+    assert_eq!(
+        result.unwrap(),
+        0,
+        "`init` with non-empty body must be kept post-#822 (behavior change)",
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}
+
+/// #822 C3 regression-proof: the canonical daemon-heartbeat case —
+/// `init` subject with empty body AND empty diff — is still DROPPED
+/// post-#822. Locks the existing behavior so the body-gate addition
+/// can't break the production heartbeat-cleanup path that this
+/// helper exists for in the first place.
+#[test]
+fn clean_empty_init_commits_still_handles_canonical_init_empty() {
+    let (_repo, worktree) = setup_repo_and_worktree("init_canonical");
+    empty_commit(&worktree, "init", None);
+
+    let result = super::clean_empty_init_commits(&worktree);
+    assert!(result.is_ok(), "helper must succeed, got: {result:?}");
+    assert_eq!(
+        result.unwrap(),
+        1,
+        "canonical empty `init` heartbeat must still be dropped (existing behavior)",
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}

--- a/tests/cleanup_init_synonym_e2e.rs
+++ b/tests/cleanup_init_synonym_e2e.rs
@@ -1,0 +1,181 @@
+//! #822 integration smoke — heartbeat-synonym whitelist + body-emptiness
+//! gate end-to-end at the git-query level, dogfooding the #821 helper.
+//!
+//! ## Scope (read this before the test body)
+//!
+//! Production's `clean_empty_init_commits` (in the binary crate at
+//! `src/mcp/handlers/dispatch_hook/mod.rs`) is the canonical entry,
+//! and its unit tests live in
+//! `src/mcp/handlers/dispatch_hook/tests.rs` (the four
+//! `clean_empty_init_commits_*` tests added by #822 C1/C2/C3 cover
+//! the actual function end-to-end inside the binary crate).
+//!
+//! This integration test sits at a deliberately narrower scope: it
+//! reconstructs the exact git-query sequence the production helper
+//! issues (`git log origin/main..HEAD --format=%H %s`, `git diff-tree
+//! --no-commit-id`, `git log -1 --format=%b`) using **only**
+//! `tests/common/git_isolated::git()` for every subprocess
+//! invocation, and asserts the classification contract — which
+//! commits the production helper would mark "drop" vs "keep" — at
+//! the integration scope.
+//!
+//! Why not drive via the full daemon MCP entry? `repo
+//! cleanup_init_commits` requires a bound agent + daemon-managed
+//! worktree state (binding.json, .agend-managed marker, hooks).
+//! Spinning that up in an integration test would add ~80 LOC of
+//! daemon-state orchestration for a 1-LOC assertion — and unit
+//! tests inside the binary crate already cover the function-level
+//! path. The honest integration scope is what's tested here: the
+//! `tests/common/git_isolated` helper, validating it works
+//! correctly for the production query pattern (the helper's first
+//! production-style consumer).
+//!
+//! ## What this dogfoods
+//!
+//! Every git subprocess in this test goes through #821's
+//! `git_isolated::git()` helper. That helper pins
+//! `AGEND_GIT_BYPASS=1` + `GIT_AUTHOR_*`/`GIT_COMMITTER_*` envs +
+//! `current_dir(repo)`. The #821 invariant test enforces this
+//! pattern for all new `tests/*.rs` files (this file has no
+//! `// allow: raw-git-subprocess` markers because it doesn't need
+//! any).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+// `mod common` pulls in tests/common/{env_gate,git_isolated,harness}.rs
+// as one tree per cargo per-binary dead-code rules. This test only
+// consumes git_isolated, leaving the harness helpers unused at this
+// binary's scope — silence the dead-code lint for the inherited items
+// (mirrors the `#[allow(dead_code)]` pattern in env_gate.rs).
+#![allow(dead_code)]
+
+mod common;
+
+use common::git_isolated;
+use std::path::Path;
+
+/// Mirror of production's whitelist (kept literal here so a future
+/// change to the production const surfaces as a test-failure delta
+/// rather than silent drift). The hardcoded list is the contract.
+const HEARTBEAT_NAMES: &[&str] = &["init", "initial"];
+
+fn is_heartbeat_subject(msg: &str) -> bool {
+    HEARTBEAT_NAMES.contains(&msg)
+}
+
+fn commit_body_is_empty(worktree: &Path, hash: &str) -> bool {
+    let out = git_isolated::git(worktree, &["log", "-1", "--format=%b", hash]);
+    out.status.success() && String::from_utf8_lossy(&out.stdout).trim().is_empty()
+}
+
+fn diff_is_empty(worktree: &Path, hash: &str) -> bool {
+    let out = git_isolated::git(
+        worktree,
+        &["diff-tree", "--no-commit-id", "--name-only", "-r", hash],
+    );
+    out.status.success() && out.stdout.trim_ascii().is_empty()
+}
+
+/// Replicates the candidate-selection logic in production's
+/// `clean_empty_init_commits` (mod.rs:735-756 post-#822). Returns
+/// commit hashes that production would mark "drop".
+fn collect_droppable_hashes(worktree: &Path) -> Vec<String> {
+    let out = git_isolated::git(worktree, &["log", "origin/main..HEAD", "--format=%H %s"]);
+    assert!(out.status.success(), "git log failed: {out:?}");
+    let log = String::from_utf8_lossy(&out.stdout);
+    let mut droppable = Vec::new();
+    for line in log.lines() {
+        let Some((hash, msg)) = line.split_once(' ') else {
+            continue;
+        };
+        if !is_heartbeat_subject(msg) {
+            continue;
+        }
+        if !commit_body_is_empty(worktree, hash) {
+            continue;
+        }
+        if !diff_is_empty(worktree, hash) {
+            continue;
+        }
+        droppable.push(hash.to_string());
+    }
+    droppable
+}
+
+/// Mint an empty-diff commit on `worktree`'s current branch with
+/// `subject` + optional `body`. Pure dogfood — every git call here
+/// goes through `git_isolated::git`.
+fn empty_commit(worktree: &Path, subject: &str, body: Option<&str>) {
+    let mut args: Vec<&str> = vec!["commit", "--allow-empty", "-m", subject];
+    if let Some(b) = body {
+        args.push("-m");
+        args.push(b);
+    }
+    let out = git_isolated::git(worktree, &args);
+    assert!(out.status.success(), "empty commit `{subject}` failed");
+}
+
+/// Mint a commit that actually changes a file. Use a unique `filename`
+/// per call so caller can interleave with empty commits without
+/// stomping on existing paths.
+fn diffful_commit(worktree: &Path, subject: &str, filename: &str) {
+    std::fs::write(worktree.join(filename), format!("payload for {subject}\n")).unwrap();
+    let add = git_isolated::git(worktree, &["add", filename]);
+    assert!(add.status.success(), "git add `{filename}` failed");
+    let commit = git_isolated::git(worktree, &["commit", "-m", subject]);
+    assert!(commit.status.success(), "diffful commit `{subject}` failed");
+}
+
+/// Build a temp repo with `origin/main` set up (so `origin/main..HEAD`
+/// resolves) and HEAD on a fresh feature branch. Returns the repo
+/// directory (the same dir is the "worktree" here — for an
+/// integration smoke this collapses the repo/worktree split, which
+/// is fine because the production helper only ever operates on the
+/// worktree path).
+fn setup_repo_with_main_ref(tag: &str) -> std::path::PathBuf {
+    let repo = git_isolated::setup_temp_repo(tag);
+    // Seed main with an initial commit so `origin/main..HEAD` resolves.
+    let seed = git_isolated::git(&repo, &["commit", "--allow-empty", "-m", "main: seed"]);
+    assert!(seed.status.success(), "seed main failed");
+    let head = git_isolated::git(&repo, &["rev-parse", "HEAD"]);
+    let main_sha = String::from_utf8_lossy(&head.stdout).trim().to_string();
+    let update = git_isolated::git(
+        &repo,
+        &["update-ref", "refs/remotes/origin/main", &main_sha],
+    );
+    assert!(update.status.success(), "update-ref origin/main failed");
+    let branch = git_isolated::git(&repo, &["checkout", "-b", "feature"]);
+    assert!(branch.status.success(), "checkout feature failed");
+    repo
+}
+
+/// E2E smoke: `init` empty, `initial` empty, real commit, `init` w/
+/// body, `initial` w/ body all coexist. The classification contract
+/// selects exactly the two empty-body whitelisted subjects.
+#[test]
+fn cleanup_init_synonym_e2e_classifies_via_helper() {
+    let repo = setup_repo_with_main_ref("822_e2e_classify");
+    empty_commit(&repo, "init", None); // → drop
+    empty_commit(&repo, "initial", None); // → drop (the #820 stray case)
+    diffful_commit(&repo, "feat: real work", "real.txt"); // → keep (diff)
+    empty_commit(&repo, "init", Some("operator body notes")); // → keep (body)
+    empty_commit(&repo, "initial", Some("planning notes")); // → keep (body)
+    empty_commit(&repo, "wip", None); // → keep (not in whitelist v1)
+
+    let droppable = collect_droppable_hashes(&repo);
+    assert_eq!(
+        droppable.len(),
+        2,
+        "exactly 2 commits should be flagged for drop \
+         (empty-body `init` + empty-body `initial`); droppable={droppable:?}"
+    );
+
+    // Sanity: total candidate-pool size matches what the helper sees.
+    let log = git_isolated::git(&repo, &["log", "origin/main..HEAD", "--format=%H %s"]);
+    let total = String::from_utf8_lossy(&log.stdout).lines().count();
+    assert_eq!(
+        total, 6,
+        "expected 6 commits on feature branch, got {total}"
+    );
+
+    std::fs::remove_dir_all(&repo).ok();
+}


### PR DESCRIPTION
Closes #822.

scope follows dispatch spec t-20260515103430522938-13

## Summary

Three pieces resolve #822:

1. **Whitelist expansion** — `HEARTBEAT_NAMES = &[\"init\", \"initial\"]` (v1). The pre-#822 helper match-checked subjects exactly equal to \"init\", missing the #820 stray case `9f619c2 initial`. v1 covers the two empirically observed offenders.
2. **Body-emptiness gate** — new `commit_body_is_empty(worktree, hash)` helper using `git log -1 --format=%b <hash>`. A whitelisted-subject empty-diff commit is now only dropped if its commit body is also empty/whitespace. Forward-compatible insurance for v1.5 if `wip`/`tmp` synonyms get added.
3. **Dogfood #821 helper** — new integration smoke test `tests/cleanup_init_synonym_e2e.rs` exclusively uses `tests/common/git_isolated::git()` (shipped in #824) for every git subprocess. First production-pattern consumer of the helper module.

## Empirical history census

`git log --all --format=%s | grep -E '^(init|initial|wip|tmp|temp|checkpoint|draft)$' | sort | uniq -c` across the repo at #822 time:

```
  64 init
   1 initial
```

Zero \`wip\`/\`tmp\`/\`temp\`/\`checkpoint\`/\`draft\` heartbeats in repo history. Daemon-side producers (`worktree.rs:628`, `bootstrap/agent_resolve.rs:160`) hardcode \"init\"; the stray \"initial\" likely originates from an external session-checkpoint flow. v1.5 can add \`wip\`/\`tmp\` if/when observed in real heartbeat traffic.

The issue's \"(or similar)\" wording on the synonym list gave license for this data-driven narrowing.

## Behavior change (documented for reviewers)

An `init`-subject commit with an empty diff AND a non-empty commit body was **DROPPED** pre-#822 (only subject + diff were checked, body was ignored) and is now **KEPT**. This case is theoretical-only — zero historical occurrences across 64 daemon-generated `init` commits, all of which use `commit --allow-empty -m \"init\"` with no `-m <body>`. The behavior change is locked by the test `clean_empty_init_commits_keeps_init_subject_with_body_notes` so future helper edits can't silently revert it.

## Out of scope (deferred)

- `wip`/`tmp`/`temp`/`checkpoint`/`draft` synonyms — v1.5 if observed
- Config-able whitelist — no operator demand
- Sed regex change — sed script is hash-based replacement (no message matching at sed-level); the whitelist enforcement happens in the Rust pre-filter
- Case-insensitive matching — current data shows zero capitalized variants
- Daemon-side standardization of heartbeat naming — separate concern with larger blast radius

## Test plan

5 tests total (1 RED at C1 → flips GREEN at C2, plus 3 GREEN regression-proof at C3, plus 1 integration smoke at C3 dogfooding #821 helper):

- [x] `clean_empty_init_commits_drops_initial_subject_with_empty_body` — C1 RED, C2 GREEN. The #820 stray case (`initial` empty body + empty diff) is now dropped.
- [x] `clean_empty_init_commits_keeps_initial_subject_with_body_notes` — body-gate FP-class guard.
- [x] `clean_empty_init_commits_keeps_init_subject_with_body_notes` — behavior-change documentation.
- [x] `clean_empty_init_commits_still_handles_canonical_init_empty` — regression-proof for the production heartbeat path.
- [x] `cleanup_init_synonym_e2e_classifies_via_helper` (`tests/cleanup_init_synonym_e2e.rs`) — integration smoke, exclusively uses #821 `git_isolated::git()`.

Pre-push verification on this worktree:

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --features tray` full suite — all 2260+ tests passing, 0 regressions
- [x] `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test clean_empty_init` — CI portability sim, 7/7 passing
- [x] `cargo test --test git_subprocess_invariant` — #821 invariant green (no new raw `Command::new(\"git\")` violations)
- [x] `cargo test --test cleanup_init_synonym_e2e` — 1/1 passing

## Commit chain

1. `fe6ea77` — `test(#822): scaffolding for heartbeat synonym whitelist (C1)` — `HEARTBEAT_NAMES = &[\"init\"]` stub + `is_heartbeat_subject` + `commit_body_is_empty` stub + match-site wire-up + RED test
2. `149b60c` — `fix(#822): expand whitelist to [\"init\",\"initial\"] + real body gate (C2)` — fills the stubs; RED → GREEN
3. `c6c724a` — `test(#822): regression-proof + integration-smoke #821 helper dogfood (C3)` — 3 regression-proof unit tests + 1 integration smoke

Last in the 7-issue batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)