### PR TITLE
ci: grant audit job checks:write + issues:write to fix main-branch red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,16 @@ jobs:
 
   audit:
     runs-on: ubuntu-latest
+    # rustsec/audit-check@v2 POSTs results to /repos/.../check-runs to surface
+    # advisories on the PR/commit UI. Repo default `default_workflow_permissions:
+    # read` denied that POST with "Resource not accessible by integration" on
+    # every push-to-main since 2026-05-15 (audit was effectively running but its
+    # last reporting step failed, making main CI red). `contents: read` keeps
+    # actions/checkout working after the grant narrows the default scope.
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2


### PR DESCRIPTION
## Symptom

Every push to main since 2026-05-15 has the \`audit\` CI job failing with:

\`\`\`
##[error]Resource not accessible by integration -
https://docs.github.com/rest/checks/runs#create-a-check-run
\`\`\`

The actual \`cargo audit\` step **completed successfully** — 0 vulnerabilities found, 16 informational warnings (gtk-rs unmaintained / paste / proc-macro-error / glib/lru/rand unsound advisories — all just \"no longer maintained\", no real security issues).

The failure is only at the **last reporting step** where \`rustsec/audit-check@v2\` POSTs the advisory list to \`/repos/.../check-runs\` to surface them on the PR/commit UI. That POST is denied by GitHub Actions' permissions API because the repo's \`default_workflow_permissions\` is \`read\`.

Effect: main CI badge red despite no real failure. Operator-perceived flakiness erodes trust in CI signal.

## Root cause

Repo-wide \`default_workflow_permissions: read\` means GITHUB_TOKEN starts read-only. \`rustsec/audit-check@v2\` needs \`checks: write\` to write check-runs. Job-level \`permissions:\` block is empty → falls back to repo default → POST denied.

## Fix

Add job-scoped \`permissions:\` to the audit job:

\`\`\`yaml
permissions:
  contents: read
  checks: write
  issues: write
\`\`\`

- \`checks: write\` — what audit-check actually needs
- \`issues: write\` — audit-check also creates issues for vulnerabilities (none today, but defends against future)
- \`contents: read\` — explicit since job-level permissions override the repo default; needed for \`actions/checkout\`

Surgical: only the audit job gets the elevated scope, all other jobs (linux/macos/windows builds, LOC overrun) stay read-only.

## Why not options I considered + rejected

1. **Bump repo-wide default_workflow_permissions read → write** — gives every workflow write scope; too broad
2. **Switch audit to advisory-only mode** — loses PR-UI surfacing of warnings; defeats the point of running it
3. **\`continue-on-error: true\` on audit** — hides real future security issues silently

## Test plan

- [x] Workflow YAML syntax verified
- [ ] PR's audit job greens (check-run posted to this PR's commit, no permission error)
- [ ] On merge to main, the same audit job greens — verifies the fix carries across event types (\`pull_request\` AND \`push\`)

## Severity

Medium — main CI red on every merge erodes operator confidence in CI signal. Today caught after operator noticed the run failure. Trivial scope (10-line workflow file change, no source code touched).