### PR TITLE
fix(#827): "active:" indicator auto-excludes ghost agents (filter against runtime registry)

### DIFF
--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -5,9 +5,49 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
+use std::collections::HashSet;
 
 use super::overlay::render_overlay_frame;
 use super::panels_fleet::{render_fleet_view, render_monitor_view};
+
+/// #827: fetch the daemon's live runtime agent registry via
+/// `api::call(LIST)`. Returns `Some(set)` when the call succeeds (the
+/// set may legitimately be empty when no agents are running) and
+/// `None` when the daemon is offline / unreachable.
+///
+/// The `None`-vs-`Some(empty)` distinction matters at the filter site:
+/// `None` falls back to current (unfiltered) behavior so a degraded
+/// daemon doesn't make the indicator misleadingly report "all idle".
+///
+/// Mirrors the precedent at `src/teams.rs:200-212` (the original
+/// liveness-cross-ref pattern shipped with #785 stale-member
+/// detection). Per-render call cost is one localhost TCP round-trip;
+/// if the board overlay's render frequency makes this a hotspot, a
+/// TTL cache can be slotted in here without changing the call site.
+///
+/// C1 stub: returns `None` so the C2 RED→GREEN flip is the helper-
+/// body fill, not a stub-vs-real wiring change.
+fn fetch_live_agents(_home: &std::path::Path) -> Option<HashSet<String>> {
+    None
+}
+
+/// #827: drop assignees that aren't in the live runtime registry.
+/// When `live` is `Some(set)`, retain only assignees in the set; when
+/// `None` (api::call failed), keep all assignees so the indicator
+/// degrades gracefully rather than reporting incorrect idleness.
+///
+/// Pure function — kept extracted from the render-site call so unit
+/// tests can pin the contract without spinning up a ratatui frame.
+///
+/// C1 stub: identity (no filtering) so the two RED tests fail (cases
+/// where dropping ghosts is the desired outcome) and the two graceful-
+/// fallback / edge-case tests pass naturally at C1.
+fn filter_live_assignees<'a>(
+    assignees: impl Iterator<Item = &'a str>,
+    _live: Option<&HashSet<String>>,
+) -> HashSet<&'a str> {
+    assignees.collect()
+}
 
 pub fn render_decisions(frame: &mut Frame, items: &[crate::decisions::Decision], scroll: usize) {
     let count = items.len();
@@ -241,10 +281,18 @@ pub fn render_tasks(
     }
 
     if inner.height > 2 && inner.width > 10 {
-        let active_agents: std::collections::HashSet<&str> = columns[2]
-            .iter()
-            .filter_map(|t| t.assignee.as_deref())
-            .collect();
+        // #827: cross-ref assignees against the daemon's live runtime
+        // registry so ghost agents from disbanded teams (or any other
+        // path that leaves a task owner string referencing a
+        // no-longer-running instance) don't show up in the "active:"
+        // indicator. `fetch_live_agents` returns `None` when the
+        // daemon is offline; the filter degrades to the pre-#827
+        // identity behavior in that case.
+        let live = fetch_live_agents(home);
+        let active_agents = filter_live_assignees(
+            columns[2].iter().filter_map(|t| t.assignee.as_deref()),
+            live.as_ref(),
+        );
         let status_text = if active_agents.is_empty() {
             "all idle".to_string()
         } else {
@@ -469,6 +517,62 @@ mod tests {
             started_at: None,
             eta_secs: None,
         }
+    }
+
+    // ── #827 active-indicator ghost filter ──
+
+    fn make_live(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// C1 RED: live registry known + one ghost name in assignees →
+    /// ghost dropped, live names retained.
+    #[test]
+    fn filter_drops_ghost_when_live_known() {
+        let live = make_live(&["alpha", "beta"]);
+        let assignees = ["alpha", "beta", "ghost"];
+        let kept = filter_live_assignees(assignees.iter().copied(), Some(&live));
+        assert_eq!(
+            kept,
+            HashSet::from(["alpha", "beta"]),
+            "ghost-agent must be filtered out when live registry is known"
+        );
+    }
+
+    /// C1 RED: every assignee is a ghost → caller renders "all idle".
+    #[test]
+    fn filter_returns_empty_when_all_ghosts() {
+        let live = make_live(&["xenon"]);
+        let assignees = ["alpha", "beta"];
+        let kept = filter_live_assignees(assignees.iter().copied(), Some(&live));
+        assert!(
+            kept.is_empty(),
+            "all-ghost assignees must produce empty set (caller renders 'all idle'); got: {kept:?}"
+        );
+    }
+
+    /// C1 GREEN (also passes at C1 with identity stub): graceful
+    /// fallback when api::call(LIST) fails — keep all assignees
+    /// rather than misleadingly report "all idle".
+    #[test]
+    fn filter_keeps_all_when_live_is_none() {
+        let assignees = ["alpha", "ghost"];
+        let kept = filter_live_assignees(assignees.iter().copied(), None);
+        assert_eq!(
+            kept,
+            HashSet::from(["alpha", "ghost"]),
+            "daemon-offline (live=None) must preserve current behavior — show all assignees"
+        );
+    }
+
+    /// C1 GREEN: empty assignees → empty result regardless of `live`.
+    /// Edge case; locks the contract so a future filter refactor can't
+    /// accidentally inject something into the empty case.
+    #[test]
+    fn filter_handles_empty_assignees() {
+        let live = make_live(&["alpha"]);
+        let kept = filter_live_assignees(std::iter::empty::<&str>(), Some(&live));
+        assert!(kept.is_empty(), "empty input must produce empty output");
     }
 
     #[test]

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -25,10 +25,27 @@ use super::panels_fleet::{render_fleet_view, render_monitor_view};
 /// if the board overlay's render frequency makes this a hotspot, a
 /// TTL cache can be slotted in here without changing the call site.
 ///
-/// C1 stub: returns `None` so the C2 RED→GREEN flip is the helper-
-/// body fill, not a stub-vs-real wiring change.
-fn fetch_live_agents(_home: &std::path::Path) -> Option<HashSet<String>> {
-    None
+/// Failure path emits a `tracing::warn` so the regression is
+/// observable when CI / operators see ghost agents reappearing in
+/// the indicator.
+fn fetch_live_agents(home: &std::path::Path) -> Option<HashSet<String>> {
+    match crate::api::call(
+        home,
+        &serde_json::json!({"method": crate::api::method::LIST}),
+    ) {
+        Ok(resp) => resp["result"]["agents"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|a| a["name"].as_str().map(String::from))
+                .collect()
+        }),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "#827: api::call(LIST) failed — active-indicator ghost filter degrading to identity"
+            );
+            None
+        }
+    }
 }
 
 /// #827: drop assignees that aren't in the live runtime registry.
@@ -39,14 +56,14 @@ fn fetch_live_agents(_home: &std::path::Path) -> Option<HashSet<String>> {
 /// Pure function — kept extracted from the render-site call so unit
 /// tests can pin the contract without spinning up a ratatui frame.
 ///
-/// C1 stub: identity (no filtering) so the two RED tests fail (cases
-/// where dropping ghosts is the desired outcome) and the two graceful-
-/// fallback / edge-case tests pass naturally at C1.
 fn filter_live_assignees<'a>(
     assignees: impl Iterator<Item = &'a str>,
-    _live: Option<&HashSet<String>>,
+    live: Option<&HashSet<String>>,
 ) -> HashSet<&'a str> {
-    assignees.collect()
+    match live {
+        Some(set) => assignees.filter(|name| set.contains(*name)).collect(),
+        None => assignees.collect(),
+    }
 }
 
 pub fn render_decisions(frame: &mut Frame, items: &[crate::decisions::Decision], scroll: usize) {


### PR DESCRIPTION
Closes #827.

scope follows dispatch spec t-20260515141346011031-2

## Summary

Two helpers in `src/render/panels.rs` close the operator-visible \"active: gemini-team-1, dev-gemini\" ghost-agent leak:

1. **`fetch_live_agents(home)`** — queries the daemon's runtime registry via `crate::api::call(home, LIST)` and returns `Option<HashSet<String>>`. Mirrors the precedent at `src/teams.rs:200-212` (#785 stale-member detection). `None` = api::call failed (daemon offline / unreachable); `Some(set)` = success (set may legitimately be empty if no agents are running).
2. **`filter_live_assignees(assignees, live)`** — pure function. `Some(set)` retains only assignees in the set; `None` keeps all (graceful degradation per design call 2).

Wired at the existing \"active:\" indicator site (panels.rs:288-296). Single render site enumerated by the spike — no other \"active:\"-class indicators exist in render code.

## Design notes (4 design calls)

- **(1) Race during agent spawn** — hide unconditionally. Sub-second window self-corrects on the next render frame. Operator tolerance for momentary incorrect-idle > tolerance for persistent ghosts (which is why we're shipping this).
- **(2) Daemon offline fallback** — show all assignees (current pre-#827 behavior). Degraded mode informative > misleadingly reporting \"all idle\". `tracing::warn` emitted from `fetch_live_agents` for observability.
- **(3) Helper extraction scope** — local to `panels.rs` (KISS). Promote to `render/mod.rs` only when a second consumer arrives (e.g. the Fleet view follow-up flagged below).
- **(4) Caching** — per-render `api::call` v1, matching the `teams::list` precedent. Defer TTL cache to v1.5 if perf hotspot observed (single localhost TCP call per overlay frame).

## Test plan

4 unit tests in `panels.rs::tests` covering the pure-function filter contract:

- [x] `filter_drops_ghost_when_live_known` — RED at C1, GREEN at C2. Live registry `{alpha, beta}` + assignees `[alpha, beta, ghost]` → kept set is `{alpha, beta}`.
- [x] `filter_returns_empty_when_all_ghosts` — RED at C1, GREEN at C2. Live `{xenon}` + assignees `[alpha, beta]` → empty (caller renders \"all idle\").
- [x] `filter_keeps_all_when_live_is_none` — GREEN throughout. `live=None` + assignees → all retained (graceful daemon-offline fallback).
- [x] `filter_handles_empty_assignees` — GREEN throughout. Empty input → empty output regardless of `live`.

Verified at HEAD `562a86c`:
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --bin agend-terminal --features tray` — 2268 binary tests, 0 failed, 7 ignored
- [x] `cargo test --tests --features tray` — integration suite green (all 30+ test binaries pass)
- [x] RED reconfirmed at C1 SHA `957a6e0`: `filter_drops_ghost_when_live_known` + `filter_returns_empty_when_all_ghosts` both FAILED (10 passed / 2 failed) — flipped GREEN at C2 SHA `562a86c`.

## Commit chain

1. `957a6e0` — `test(#827): scaffolding for active-indicator ghost filter (C1)` — stubs (`fetch_live_agents` returns `None`, `filter_live_assignees` is identity) + render-site wire-up + 4 unit tests (2 RED + 2 GREEN)
2. `562a86c` — `fix(#827): \"active:\" indicator filters against runtime registry (C2)` — real `api::call(LIST)` impl + `Some/None` filter branches; RED tests flip GREEN

## Out of scope (deferred)

- **#827.5 Fleet view liveness annotation** — `src/render/panels_fleet.rs:146-158` reads `all_instances` from `fleet.yaml` (configured set, not runtime set). Different bug class (annotate stale rather than hide), separate follow-up if/when operator surfaces it.
- **TTL cache for `fetch_live_agents`** — defer to v1.5 if per-render `api::call` becomes a hotspot.
- **Detail view assignee `(stale)` suffix** — separate UX call; this PR is purely the active-indicator filter.
- **#828 auto-orphan on disband** — addresses the smoking-gun root cause; next PR in batch.
- **#829 daemon restart sweeper / #830 board health metrics** — separate PRs in batch sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)