### PR TITLE
feat(#829): daemon boot orphan-owner sweep (auto-apply strict, dry-run soft)

### DIFF
--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -186,6 +186,12 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     crate::binding::symlink_shim(home);
     crate::binding::reconcile_orphans(home);
     crate::worktree_pool::reconcile_orphan_leases(home);
+    // #829: boot-time orphan-owner sweep. Auto-applies for owners
+    // verifiably gone (∉ fleet.yaml ∧ ∉ live registry); dry-run +
+    // tracing::warn for the softer "∈ fleet.yaml ∧ ∉ live" case.
+    // Best-effort with tracing audit; skips entirely if
+    // `api::call(LIST)` fails (e.g. socket bind race during boot).
+    crate::tasks::reconcile_orphan_owners(home);
 
     Ok(BootstrapOutcome::Owned(Box::new(OwnedFleet {
         home: home.to_path_buf(),

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -564,6 +564,82 @@ pub fn orphan_tasks_for_owner(home: &Path, owner_name: &str) -> Result<usize, St
         .map_err(|e| e.to_string())
 }
 
+/// #829: classify a single owner string against the live runtime
+/// registry + the fleet.yaml `instances:` set. Two ghost classes are
+/// distinguished:
+///
+/// - **Strict**: owner is in NEITHER the live registry NOR fleet.yaml.
+///   The owning instance is fully gone (never came back, was deleted
+///   without cascading the orphan, or pre-existed before #828
+///   shipped). Safe to auto-orphan at boot — no operator decision
+///   needed because the owner is verifiably absent.
+/// - **Soft**: owner IS in fleet.yaml but not in the live registry.
+///   Could be a misconfigured agent, a transient binding lag during
+///   boot, or an agent that's about to spawn but hasn't yet. NOT safe
+///   to auto-orphan — dry-run + tracing::warn so the operator can
+///   surface the case via `task action=sweep` if they decide.
+#[derive(Debug, PartialEq, Eq)]
+pub enum OwnerClassification {
+    Live,
+    Strict,
+    Soft,
+}
+
+pub fn classify_owner(
+    owner: &str,
+    live: &std::collections::HashSet<String>,
+    fleet_instances: &std::collections::HashSet<String>,
+) -> OwnerClassification {
+    if live.contains(owner) {
+        OwnerClassification::Live
+    } else if fleet_instances.contains(owner) {
+        OwnerClassification::Soft
+    } else {
+        OwnerClassification::Strict
+    }
+}
+
+/// #829: scan results, split into auto-apply (strict) vs dry-run
+/// (soft) buckets. Owners are kept as separate keys so the boot
+/// orchestrator can batch one `orphan_tasks_for_owner` call per
+/// strict owner — each call lands a single event-log fsync (mirrors
+/// #828's per-member cascade pattern).
+///
+/// Ordering: `BTreeMap` for deterministic iteration order — the tests
+/// pattern-match on the result so stable ordering matters more than
+/// the constant-factor `HashMap` win.
+///
+/// Reused by #830 `task action=health` (dispatch sequencing): same
+/// scan, same classification, just `apply=false` to feed the health
+/// metrics surface. The scan fn is therefore `pub`.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct OrphanScanResult {
+    pub strict: std::collections::BTreeMap<String, Vec<crate::task_events::TaskId>>,
+    pub soft: std::collections::BTreeMap<String, Vec<crate::task_events::TaskId>>,
+}
+
+/// #829 pure scan. Walks `state.tasks` and classifies each non-
+/// terminal task's owner via [`classify_owner`]. Terminal-status tasks
+/// (Done / Cancelled) are skipped — their ACL is already disabled at
+/// the event-log layer, so re-orphaning would be noise.
+///
+/// `live` MUST come from `crate::api::call(LIST)` — the canonical
+/// runtime registry. `fleet_instances` MUST come from
+/// `fleet::FleetConfig::load(...).instances.keys()` — the
+/// configuration-time set. Caller responsibility to populate both;
+/// this fn is pure so it's testable without a daemon.
+///
+/// C1 stub: returns `OrphanScanResult::default()` (both buckets
+/// empty) so the RED test fails on assertions about populated
+/// `strict` / `soft`. C2 fills the body.
+pub fn scan_orphan_candidates(
+    _state: &crate::task_events::TaskBoardState,
+    _live: &std::collections::HashSet<String>,
+    _fleet_instances: &std::collections::HashSet<String>,
+) -> OrphanScanResult {
+    OrphanScanResult::default()
+}
+
 fn can_mutate_record(home: &Path, caller: &str, record: &crate::task_events::TaskRecord) -> bool {
     // B1: system identities pass ACL via explicit allow-list
     if is_system_identity(caller) {
@@ -1522,6 +1598,99 @@ mod tests {
     // pub-promotion in Sprint 23 P0 with zero direct unit coverage —
     // closed here. Behavioural mirror of the Phase 2 D1 operator-pitfall
     // gate.
+
+    // ── #829 boot orphan-owner sweep ──
+
+    fn make_record(
+        id: &str,
+        status: crate::task_events::TaskStatus,
+        owner: Option<&str>,
+    ) -> crate::task_events::TaskRecord {
+        crate::task_events::TaskRecord {
+            id: crate::task_events::TaskId(id.to_string()),
+            title: format!("title-{id}"),
+            description: String::new(),
+            priority: "normal".into(),
+            status,
+            owner: owner.map(crate::task_events::InstanceName::from),
+            linked_prs: Vec::new(),
+            block_reason: None,
+            history: Vec::new(),
+            created_by: crate::task_events::InstanceName::from("test"),
+            created_at: "2026-05-15T00:00:00Z".into(),
+            updated_at: "2026-05-15T00:00:00Z".into(),
+            due_at: None,
+            depends_on: Vec::new(),
+            routed_to: None,
+            result: None,
+            branch: None,
+            bind: None,
+            started_at: None,
+            eta_secs: None,
+        }
+    }
+
+    fn make_state(
+        records: Vec<crate::task_events::TaskRecord>,
+    ) -> crate::task_events::TaskBoardState {
+        let mut state = crate::task_events::TaskBoardState::default();
+        for r in records {
+            state.tasks.insert(r.id.clone(), r);
+        }
+        state
+    }
+
+    fn make_set(names: &[&str]) -> std::collections::HashSet<String> {
+        names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// #829 C1 RED: classify three tasks across the strict / soft /
+    /// live spectrum, plus one Done-status task (excluded). The pure
+    /// scan must surface `alice` as strict (not in fleet.yaml, not live),
+    /// `bob` as soft (in fleet.yaml, not live), and drop `charlie`
+    /// (live) + `done-owner` (terminal status).
+    #[test]
+    fn scan_orphan_candidates_splits_strict_and_soft() {
+        use crate::task_events::{TaskId, TaskStatus};
+        let state = make_state(vec![
+            make_record("t-1", TaskStatus::Claimed, Some("alice829")),
+            make_record("t-2", TaskStatus::InProgress, Some("alice829")),
+            make_record("t-3", TaskStatus::Open, Some("bob829")),
+            make_record("t-4", TaskStatus::InProgress, Some("charlie829")),
+            make_record("t-5", TaskStatus::Done, Some("alice829")),
+            make_record("t-6", TaskStatus::Open, None),
+        ]);
+        let live = make_set(&["charlie829"]);
+        let fleet = make_set(&["bob829", "charlie829"]);
+
+        let result = scan_orphan_candidates(&state, &live, &fleet);
+
+        // alice829 → strict (fully gone). 2 tasks (t-1 + t-2), Done t-5 excluded.
+        let alice_tasks: Vec<TaskId> = result.strict.get("alice829").cloned().unwrap_or_default();
+        assert_eq!(
+            alice_tasks,
+            vec![TaskId("t-1".into()), TaskId("t-2".into())],
+            "alice829 (not in fleet.yaml, not live) must be classified strict with 2 non-terminal tasks"
+        );
+
+        // bob829 → soft (in fleet.yaml but not live). 1 task.
+        let bob_tasks: Vec<TaskId> = result.soft.get("bob829").cloned().unwrap_or_default();
+        assert_eq!(
+            bob_tasks,
+            vec![TaskId("t-3".into())],
+            "bob829 (in fleet.yaml, not live) must be classified soft"
+        );
+
+        // charlie829 → live. Should appear in neither bucket.
+        assert!(
+            !result.strict.contains_key("charlie829"),
+            "live owner must not appear in strict"
+        );
+        assert!(
+            !result.soft.contains_key("charlie829"),
+            "live owner must not appear in soft"
+        );
+    }
 
     #[test]
     fn can_mutate_task_assignee_match() {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -629,6 +629,111 @@ pub struct OrphanScanResult {
 /// configuration-time set. Caller responsibility to populate both;
 /// this fn is pure so it's testable without a daemon.
 ///
+/// #829: fetch the daemon's live runtime agent registry via
+/// `api::call(LIST)`. Returns `Some(set)` on success and `None` when
+/// the API call fails — boot-sweep skips entirely on `None` per
+/// design call 3, defending against the boot-time window where the
+/// daemon binds its API socket DURING bootstrap and a call from
+/// inside bootstrap could race the socket bind.
+///
+/// Duplicate of the same shape used in `src/teams.rs:200-212` and
+/// `src/render/panels.rs::fetch_live_agents` (#827). Three consumers
+/// now — a follow-up after #830 ships will promote a single shared
+/// helper to a common module (probably `src/runtime.rs`).
+fn fetch_live_agents(home: &Path) -> Option<std::collections::HashSet<String>> {
+    crate::api::call(
+        home,
+        &serde_json::json!({"method": crate::api::method::LIST}),
+    )
+    .ok()
+    .and_then(|r| {
+        r["result"]["agents"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|a| a["name"].as_str().map(String::from))
+                .collect()
+        })
+    })
+}
+
+/// #829: boot-time orphan-owner sweeper. Sibling to
+/// `crate::binding::reconcile_orphans` + `crate::worktree_pool::
+/// reconcile_orphan_leases` in `src/bootstrap/mod.rs`. Best-effort,
+/// tracing-audited, no return value.
+///
+/// Strict-case auto-apply (owner ∉ fleet.yaml ∧ ∉ live registry):
+/// emits one `system:auto_orphan` batched event per ghost owner via
+/// `orphan_tasks_for_owner`. Idempotent — re-running on an already-
+/// orphaned task is a no-op at the event-log replay layer.
+///
+/// Soft-case dry-run (owner ∈ fleet.yaml ∧ ∉ live registry): emits a
+/// `tracing::warn!` listing the candidates. NO mutation — preserves
+/// operator judgment for the "agent hasn't booted yet" race that
+/// `auto_start_fleet` will resolve seconds after bootstrap returns.
+///
+/// Skip-on-api-fail: if `api::call(LIST)` returns `None`, the
+/// orchestrator early-returns BEFORE touching any state. Better to
+/// leave residue for next boot than to over-orphan during a daemon
+/// startup race.
+pub fn reconcile_orphan_owners(home: &Path) {
+    let Some(live) = fetch_live_agents(home) else {
+        tracing::info!("#829: api::call(LIST) unavailable at boot — skipping orphan-owner sweep");
+        return;
+    };
+    let fleet_instances: std::collections::HashSet<String> =
+        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+            .ok()
+            .map(|c| c.instances.keys().cloned().collect())
+            .unwrap_or_default();
+    let state = match crate::task_events::replay(home) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "#829: task_events replay failed at boot — skipping orphan-owner sweep"
+            );
+            return;
+        }
+    };
+
+    let result = scan_orphan_candidates(&state, &live, &fleet_instances);
+    if result.strict.is_empty() && result.soft.is_empty() {
+        tracing::debug!("#829: boot orphan-owner sweep clean — no ghost owners detected");
+        return;
+    }
+
+    // Strict bucket → auto-apply via orphan_tasks_for_owner.
+    for (owner, task_ids) in &result.strict {
+        match orphan_tasks_for_owner(home, owner) {
+            Ok(n) => tracing::info!(
+                owner = %owner,
+                tasks = task_ids.len(),
+                orphaned = n,
+                "#829: boot orphan-owner sweep applied (strict — owner fully gone)"
+            ),
+            Err(e) => tracing::warn!(
+                owner = %owner,
+                error = %e,
+                "#829: boot orphan-owner sweep failed for strict candidate"
+            ),
+        }
+    }
+
+    // Soft bucket → dry-run + warn (no mutation).
+    if !result.soft.is_empty() {
+        let soft_summary: Vec<(String, usize)> = result
+            .soft
+            .iter()
+            .map(|(owner, ids)| (owner.clone(), ids.len()))
+            .collect();
+        tracing::warn!(
+            ?soft_summary,
+            "#829: boot detected tasks owned by configured-but-not-live agents \
+             (in fleet.yaml ∧ ∉ live registry); operator may run `task action=sweep` \
+             to apply orphan cleanup"
+        );
+    }
+}
+
 pub fn scan_orphan_candidates(
     state: &crate::task_events::TaskBoardState,
     live: &std::collections::HashSet<String>,
@@ -1658,6 +1763,70 @@ mod tests {
 
     fn make_set(names: &[&str]) -> std::collections::HashSet<String> {
         names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// #829 C3 GREEN: pure-fn classifier test. Three sets cover the
+    /// full state space: in-live, in-fleet-only, in-neither.
+    #[test]
+    fn classify_owner_categorizes_three_states() {
+        let live = make_set(&["charlie829"]);
+        let fleet = make_set(&["bob829", "charlie829"]);
+        assert_eq!(
+            classify_owner("charlie829", &live, &fleet),
+            OwnerClassification::Live,
+            "charlie829 ∈ live must classify Live (live wins over fleet membership)"
+        );
+        assert_eq!(
+            classify_owner("bob829", &live, &fleet),
+            OwnerClassification::Soft,
+            "bob829 ∈ fleet but ∉ live must classify Soft"
+        );
+        assert_eq!(
+            classify_owner("alice829", &live, &fleet),
+            OwnerClassification::Strict,
+            "alice829 ∈ neither must classify Strict"
+        );
+    }
+
+    /// #829 C3 GREEN: cold start case — empty event log → empty result.
+    /// Locks the no-op contract for fresh daemons. C1 RED test already
+    /// implicitly covers this through the assertion on alice829's
+    /// presence, but explicit coverage hardens the contract surface.
+    #[test]
+    fn scan_orphan_candidates_handles_empty_state() {
+        let state = make_state(vec![]);
+        let live = make_set(&["alpha"]);
+        let fleet = make_set(&["alpha", "beta"]);
+        let result = scan_orphan_candidates(&state, &live, &fleet);
+        assert!(result.strict.is_empty(), "empty state → empty strict");
+        assert!(result.soft.is_empty(), "empty state → empty soft");
+    }
+
+    /// #829 C3 GREEN: terminal-status tasks (Done / Cancelled) are
+    /// excluded even when their owner is a ghost. The ACL is already
+    /// disabled at the event-log layer for terminal records, so
+    /// re-orphaning is noise. Locks the skip behavior.
+    #[test]
+    fn scan_orphan_candidates_excludes_terminal_status() {
+        use crate::task_events::TaskStatus;
+        // ghost-829 owns four tasks across the four terminal-vs-live
+        // statuses. Only Open + Claimed should land in `strict`.
+        let state = make_state(vec![
+            make_record("t-open", TaskStatus::Open, Some("ghost829")),
+            make_record("t-claimed", TaskStatus::Claimed, Some("ghost829")),
+            make_record("t-done", TaskStatus::Done, Some("ghost829")),
+            make_record("t-cancel", TaskStatus::Cancelled, Some("ghost829")),
+        ]);
+        let live = make_set(&[]);
+        let fleet = make_set(&[]);
+        let result = scan_orphan_candidates(&state, &live, &fleet);
+        let ghost_strict = result.strict.get("ghost829").cloned().unwrap_or_default();
+        let ids: Vec<String> = ghost_strict.iter().map(|t| t.0.clone()).collect();
+        assert_eq!(
+            ids,
+            vec!["t-claimed".to_string(), "t-open".to_string()],
+            "Done + Cancelled must be excluded; non-terminal must surface (BTreeMap order is by TaskId)"
+        );
     }
 
     /// #829 C1 RED: classify three tasks across the strict / soft /

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -629,15 +629,31 @@ pub struct OrphanScanResult {
 /// configuration-time set. Caller responsibility to populate both;
 /// this fn is pure so it's testable without a daemon.
 ///
-/// C1 stub: returns `OrphanScanResult::default()` (both buckets
-/// empty) so the RED test fails on assertions about populated
-/// `strict` / `soft`. C2 fills the body.
 pub fn scan_orphan_candidates(
-    _state: &crate::task_events::TaskBoardState,
-    _live: &std::collections::HashSet<String>,
-    _fleet_instances: &std::collections::HashSet<String>,
+    state: &crate::task_events::TaskBoardState,
+    live: &std::collections::HashSet<String>,
+    fleet_instances: &std::collections::HashSet<String>,
 ) -> OrphanScanResult {
-    OrphanScanResult::default()
+    use crate::task_events::TaskStatus;
+    let mut result = OrphanScanResult::default();
+    for record in state.tasks.values() {
+        if matches!(record.status, TaskStatus::Done | TaskStatus::Cancelled) {
+            continue;
+        }
+        let Some(owner) = record.owner.as_ref() else {
+            continue;
+        };
+        let bucket = match classify_owner(owner.0.as_str(), live, fleet_instances) {
+            OwnerClassification::Strict => &mut result.strict,
+            OwnerClassification::Soft => &mut result.soft,
+            OwnerClassification::Live => continue,
+        };
+        bucket
+            .entry(owner.0.clone())
+            .or_default()
+            .push(record.id.clone());
+    }
+    result
 }
 
 fn can_mutate_record(home: &Path, caller: &str, record: &crate::task_events::TaskRecord) -> bool {


### PR DESCRIPTION
Closes #829.

scope follows dispatch spec t-20260515141352015815-4

## Summary

Defense-in-depth boot-time sweep that catches ghost-owned tasks left behind by pre-#828 history or any future code path that doesn't cascade orphan-cleanup. Sibling to the existing `binding::reconcile_orphans` + `worktree_pool::reconcile_orphan_leases` hooks at `src/bootstrap/mod.rs:185-188`.

Three pieces in `src/tasks.rs`:

1. **`classify_owner(owner, live, fleet)`** — pure 3-state classifier (Live / Strict / Soft).
2. **`scan_orphan_candidates(state, live, fleet) -> OrphanScanResult`** — pure scan, returns `{ strict, soft }` bucketed by owner name. **Pub** so #830's upcoming `task action=health` MCP tool can reuse the exact same classification pass with `apply=false`.
3. **`reconcile_orphan_owners(home)`** — boot orchestrator. Skip-on-api-fail. Strict-case auto-applies via `orphan_tasks_for_owner` (the #828 primitive); soft-case emits `tracing::warn!` only.

Plus a 6-line wire-up at `src/bootstrap/mod.rs:189`.

## Design notes (5 design calls, all accepted as recommended by spike)

- **(1) Strict-case auto-apply** — owner ∉ fleet.yaml ∧ ∉ live registry. Owner verifiably gone; no operator decision needed. Idempotent at the event-log layer (re-orphan is no-op).
- **(2) Soft-case dry-run + warn** — owner ∈ fleet.yaml ∧ ∉ live registry. Preserves operator judgment for the "agent hasn't booted yet" race that `auto_start_fleet` will resolve seconds after bootstrap returns.
- **(3) Skip-on-api-fail** — `api::call(LIST)` may fail when the daemon binds its API socket DURING bootstrap. If `None`, the orchestrator early-returns BEFORE touching any state. Better to leave residue for next boot than to over-orphan during the socket-bind race.
- **(4) `fetch_live_agents` duplicated in tasks.rs** for v1. Three consumers now (`teams::list`, `panels::*`, `tasks`); promotion to a shared helper is a follow-up after #830 ships and becomes the fourth consumer.
- **(5) `pub fn reconcile_orphan_owners(home: &Path)` returning `()`** — mirrors `binding::reconcile_orphans` precedent. Best-effort, tracing-audited, no return shape.

**Important cross-cutting**: `scan_orphan_candidates` is `pub` to enable #830 reuse. After #830 ships, the same scan powers both the boot auto-apply path (#829) and the operator-facing health metrics tool (#830) — no scan-logic duplication across the two PRs.

## Test plan

4 tests in `src/tasks.rs::tests`:

- [x] `scan_orphan_candidates_splits_strict_and_soft` — **RED at C1 (`ff909cf`), GREEN at C2 (`c267fba`)**. Mixed owners across the strict/soft/live spectrum + Done-status task. Asserts alice829 → strict (2 task IDs, Done excluded), bob829 → soft (1 task ID), charlie829 → neither bucket.
- [x] `classify_owner_categorizes_three_states` — C3 GREEN. Pure 3-state classifier unit test.
- [x] `scan_orphan_candidates_handles_empty_state` — C3 GREEN. Cold-start no-op contract.
- [x] `scan_orphan_candidates_excludes_terminal_status` — C3 GREEN. Done + Cancelled rows must be filtered even when the owner is a ghost.

Verified at HEAD `3c595cc`:
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo clean -p agend-terminal && cargo test --bin agend-terminal --features tray` — 2277 passed, 0 failed, 7 ignored. **`cargo clean` per #834 r0 review lesson** (target/ cache contamination caused the §3.10 traceability false positive on that PR's re-replay).
- [x] CI portability sim: `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test ...` clean.
- [x] RED reconfirmed at C1 SHA `ff909cf` after `cargo clean -p agend-terminal` — `0 passed; 1 failed`. Flipped GREEN at C2 SHA `c267fba`.

## Commit chain

1. `ff909cf` — `test(#829): OrphanScanResult API surface + RED test (C1)` — public API surface (`OwnerClassification`, `OrphanScanResult`, `classify_owner`, `scan_orphan_candidates`) + 1 RED test. `scan_orphan_candidates` stubbed to return `OrphanScanResult::default()`.
2. `c267fba` — `fix(#829): scan_orphan_candidates body — strict/soft bucketing (C2)` — fills the scan body. RED → GREEN.
3. `3c595cc` — `feat(#829): reconcile_orphan_owners boot hook + 3 regression-proof tests (C3)` — orchestrator + bootstrap wire-up + 3 GREEN tests.

## Out of scope (deferred)

- **#830 board health metrics** — reuses `scan_orphan_candidates` (apply=false) for the `ghost_owned_count` metric. Separate PR; ships next in batch.
- **#833 cleanup_init_commits trailer-whitelist** — independent.
- **Promote `fetch_live_agents` to shared helper** — defer until #830's fourth-consumer arrival justifies the extraction.
- **TUI surface for orphan reports** — could land in #830's health tool follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)