### PR TITLE
feat(#830): task action=health MCP tool (operator self-serve board hygiene snapshot)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ mod process;
 mod protocol;
 mod quickstart;
 mod render;
+mod runtime;
 mod schedules;
 mod service;
 mod skills;

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -219,6 +219,10 @@ fn dispatch_task_sweep(ctx: &HandlerCtx<'_>) -> Value {
     task::handle_task(ctx.home, ctx.args, ctx.instance_name)
 }
 
+fn dispatch_task_health(ctx: &HandlerCtx<'_>) -> Value {
+    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
+}
+
 /// Static sub-handler table for `task` action routing. Lifted out of
 /// the entry literal so the table address can be `'static`-borrowed.
 /// Action set matches `tasks::handle`'s internal `match` arms.
@@ -229,6 +233,7 @@ static TASK_ACTIONS: &[(&str, HandlerFn)] = &[
     ("update", dispatch_task_update),
     ("done", dispatch_task_done),
     ("sweep", dispatch_task_sweep),
+    ("health", dispatch_task_health),
 ];
 
 // ---------------------------------------------------------------------

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -141,9 +141,9 @@ fn decision_tools() -> Vec<Value> {
 
 fn task_tools() -> Vec<Value> {
     vec![
-        json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (4 stale-task categories with dry-run + confirm_ids round-trip).",
+        json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (4 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
             "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep"]},
+                "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health"]},
                 "title": {"type": "string"}, "description": {"type": "string"},
                 "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
                 "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}},

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -10,42 +10,28 @@ use std::collections::HashSet;
 use super::overlay::render_overlay_frame;
 use super::panels_fleet::{render_fleet_view, render_monitor_view};
 
-/// #827: fetch the daemon's live runtime agent registry via
-/// `api::call(LIST)`. Returns `Some(set)` when the call succeeds (the
-/// set may legitimately be empty when no agents are running) and
-/// `None` when the daemon is offline / unreachable.
+/// #827: fetch the daemon's live runtime agent registry. Returns
+/// `Some(set)` on success and `None` when `api::call(LIST)` fails.
 ///
 /// The `None`-vs-`Some(empty)` distinction matters at the filter site:
 /// `None` falls back to current (unfiltered) behavior so a degraded
 /// daemon doesn't make the indicator misleadingly report "all idle".
+/// Per-render call cost is one localhost TCP round-trip; if the
+/// overlay's render frequency makes this a hotspot, a TTL cache can
+/// be slotted in here without changing the call site.
 ///
-/// Mirrors the precedent at `src/teams.rs:200-212` (the original
-/// liveness-cross-ref pattern shipped with #785 stale-member
-/// detection). Per-render call cost is one localhost TCP round-trip;
-/// if the board overlay's render frequency makes this a hotspot, a
-/// TTL cache can be slotted in here without changing the call site.
-///
-/// Failure path emits a `tracing::warn` so the regression is
-/// observable when CI / operators see ghost agents reappearing in
-/// the indicator.
+/// #830: thin wrapper over `crate::runtime::list_live_agents` (the
+/// canonical helper consolidated when #830 became the fourth consumer
+/// of this pattern). The wrapper survives so the call site keeps the
+/// `tracing::warn!` observability hook that #827 added.
 fn fetch_live_agents(home: &std::path::Path) -> Option<HashSet<String>> {
-    match crate::api::call(
-        home,
-        &serde_json::json!({"method": crate::api::method::LIST}),
-    ) {
-        Ok(resp) => resp["result"]["agents"].as_array().map(|arr| {
-            arr.iter()
-                .filter_map(|a| a["name"].as_str().map(String::from))
-                .collect()
-        }),
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "#827: api::call(LIST) failed — active-indicator ghost filter degrading to identity"
-            );
-            None
-        }
+    let result = crate::runtime::list_live_agents(home);
+    if result.is_none() {
+        tracing::warn!(
+            "#827: api::call(LIST) failed — active-indicator ghost filter degrading to identity"
+        );
     }
+    result
 }
 
 /// #827: drop assignees that aren't in the live runtime registry.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,37 @@
+//! #830: shared runtime-registry helpers. Consolidates the
+//! `api::call(LIST)` liveness-cross-ref pattern that was duplicated
+//! across `src/teams.rs:200-212` (#785), `src/render/panels.rs::
+//! fetch_live_agents` (#827), and `src/tasks.rs::fetch_live_agents`
+//! (#829). The fourth consumer arriving in `task action=health`
+//! (this PR) is the design-call threshold that justifies extraction.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Fetch the daemon's live runtime agent registry via
+/// `api::call(LIST)`. Returns `Some(set)` on success (the set may
+/// legitimately be empty when no agents are running) and `None`
+/// when the daemon is offline / unreachable.
+///
+/// The `None`-vs-`Some(empty)` distinction lets callers degrade
+/// differently: render-time filters (#827) keep all assignees on
+/// `None` to avoid misleading "all idle" reports; the #829 boot
+/// sweeper skips the orphan-clear entirely on `None` to avoid
+/// over-orphaning during the daemon's own socket-bind race; #830's
+/// health response surfaces a degraded `live_agents_available: false`
+/// hint to the operator. Each caller chooses its own fallback by
+/// matching on the `Option`.
+pub fn list_live_agents(home: &Path) -> Option<HashSet<String>> {
+    crate::api::call(
+        home,
+        &serde_json::json!({"method": crate::api::method::LIST}),
+    )
+    .ok()
+    .and_then(|r| {
+        r["result"]["agents"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|a| a["name"].as_str().map(String::from))
+                .collect()
+        })
+    })
+}

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -629,32 +629,6 @@ pub struct OrphanScanResult {
 /// configuration-time set. Caller responsibility to populate both;
 /// this fn is pure so it's testable without a daemon.
 ///
-/// #829: fetch the daemon's live runtime agent registry via
-/// `api::call(LIST)`. Returns `Some(set)` on success and `None` when
-/// the API call fails — boot-sweep skips entirely on `None` per
-/// design call 3, defending against the boot-time window where the
-/// daemon binds its API socket DURING bootstrap and a call from
-/// inside bootstrap could race the socket bind.
-///
-/// Duplicate of the same shape used in `src/teams.rs:200-212` and
-/// `src/render/panels.rs::fetch_live_agents` (#827). Three consumers
-/// now — a follow-up after #830 ships will promote a single shared
-/// helper to a common module (probably `src/runtime.rs`).
-fn fetch_live_agents(home: &Path) -> Option<std::collections::HashSet<String>> {
-    crate::api::call(
-        home,
-        &serde_json::json!({"method": crate::api::method::LIST}),
-    )
-    .ok()
-    .and_then(|r| {
-        r["result"]["agents"].as_array().map(|arr| {
-            arr.iter()
-                .filter_map(|a| a["name"].as_str().map(String::from))
-                .collect()
-        })
-    })
-}
-
 /// #829: boot-time orphan-owner sweeper. Sibling to
 /// `crate::binding::reconcile_orphans` + `crate::worktree_pool::
 /// reconcile_orphan_leases` in `src/bootstrap/mod.rs`. Best-effort,
@@ -675,7 +649,7 @@ fn fetch_live_agents(home: &Path) -> Option<std::collections::HashSet<String>> {
 /// leave residue for next boot than to over-orphan during a daemon
 /// startup race.
 pub fn reconcile_orphan_owners(home: &Path) {
-    let Some(live) = fetch_live_agents(home) else {
+    let Some(live) = crate::runtime::list_live_agents(home) else {
         tracing::info!("#829: api::call(LIST) unavailable at boot — skipping orphan-owner sweep");
         return;
     };
@@ -759,6 +733,250 @@ pub fn scan_orphan_candidates(
             .push(record.id.clone());
     }
     result
+}
+
+/// #830 hardcoded severity thresholds. Defaults are tuned for the
+/// current operator's fleet shape (10s of agents, low-100s of
+/// tasks); revisit if v1.5 brings demand for config-ability.
+const OVER_30D_WARN_THRESHOLD: usize = 5;
+const STALE_BLOCKED_WARN_THRESHOLD: usize = 10;
+
+/// #830: structured-recommendations health response. Pure pub fn so
+/// tests can drive it with synthesized inputs (no daemon spawn).
+///
+/// `state` — `crate::task_events::replay(home)` output
+/// `live` — `crate::runtime::list_live_agents(home)` — `None` when
+///   the daemon is unreachable (surfaced as a degraded-mode hint in
+///   the response).
+/// `fleet_instances` — keys from `crate::fleet::FleetConfig::load
+///   (...).instances` — the configured set (vs `live` runtime set).
+///
+/// Reuses `scan_orphan_candidates` (#829) for the ghost_owners
+/// section so the boot sweeper and the health surface share one
+/// classification pass. Sorted output where feasible
+/// (`BTreeMap`/`sort_unstable`) for stable test pinning.
+pub fn build_health_response(
+    state: &crate::task_events::TaskBoardState,
+    live: Option<&std::collections::HashSet<String>>,
+    fleet_instances: &std::collections::HashSet<String>,
+) -> Value {
+    use crate::task_events::TaskStatus;
+    use chrono::DateTime;
+    let now = chrono::Utc::now();
+
+    // ── Status counts + non-terminal collector ──
+    let mut by_status: std::collections::BTreeMap<&'static str, usize> =
+        std::collections::BTreeMap::new();
+    let mut non_terminal_ages_days: Vec<i64> = Vec::new();
+    for record in state.tasks.values() {
+        let key = match record.status {
+            TaskStatus::Open => "open",
+            TaskStatus::Claimed => "claimed",
+            TaskStatus::InProgress => "in_progress",
+            TaskStatus::Blocked => "blocked",
+            TaskStatus::Done => "done",
+            TaskStatus::Cancelled => "cancelled",
+            TaskStatus::Verified => "verified",
+        };
+        *by_status.entry(key).or_insert(0) += 1;
+        if !matches!(record.status, TaskStatus::Done | TaskStatus::Cancelled) {
+            if let Ok(dt) = DateTime::parse_from_rfc3339(&record.created_at) {
+                let age = now.signed_duration_since(dt.with_timezone(&chrono::Utc));
+                non_terminal_ages_days.push(age.num_days());
+            }
+        }
+    }
+    let total_all: usize = by_status.values().copied().sum();
+    let total_terminal = by_status.get("done").copied().unwrap_or(0)
+        + by_status.get("cancelled").copied().unwrap_or(0);
+    let total_non_terminal = total_all.saturating_sub(total_terminal);
+
+    // ── Ghost owners (reuse #829 scan_orphan_candidates) ──
+    let empty_live = std::collections::HashSet::new();
+    let live_set = live.unwrap_or(&empty_live);
+    let scan = scan_orphan_candidates(state, live_set, fleet_instances);
+    let strict_count: usize = scan.strict.values().map(|v| v.len()).sum();
+    let soft_count: usize = scan.soft.values().map(|v| v.len()).sum();
+    let strict_owners: Vec<&String> = scan.strict.keys().collect();
+    let soft_owners: Vec<&String> = scan.soft.keys().collect();
+
+    // ── Stale claims (replicates sweep_overdue_claimed's predicate,
+    //    read-only — no mutation) ──
+    let mut stale_claim_ids: Vec<String> = Vec::new();
+    for record in state.tasks.values() {
+        if record.status != TaskStatus::Claimed {
+            continue;
+        }
+        let Some(due) = &record.due_at else {
+            continue;
+        };
+        let Ok(due_utc) = DateTime::parse_from_rfc3339(due) else {
+            continue;
+        };
+        if now > due_utc.with_timezone(&chrono::Utc) {
+            stale_claim_ids.push(record.id.0.clone());
+        }
+    }
+    stale_claim_ids.sort_unstable();
+
+    // ── Age aggregates ──
+    non_terminal_ages_days.sort_unstable();
+    let oldest_days = non_terminal_ages_days.last().copied().unwrap_or(0);
+    let median_days = if non_terminal_ages_days.is_empty() {
+        0
+    } else {
+        non_terminal_ages_days[non_terminal_ages_days.len() / 2]
+    };
+    let over_30d_count = non_terminal_ages_days.iter().filter(|d| **d > 30).count();
+    let over_90d_count = non_terminal_ages_days.iter().filter(|d| **d > 90).count();
+
+    // ── Recommendations ──
+    let blocked_count = by_status.get("blocked").copied().unwrap_or(0);
+    let mut recommendations: Vec<Value> = Vec::new();
+    if let Some(rec) = rec_ghost_owners_strict(&scan, strict_count) {
+        recommendations.push(rec);
+    }
+    if let Some(rec) = rec_ghost_owners_soft(&scan, soft_count) {
+        recommendations.push(rec);
+    }
+    if let Some(rec) = rec_stale_claims(&stale_claim_ids) {
+        recommendations.push(rec);
+    }
+    if let Some(rec) = rec_over_30d(over_30d_count) {
+        recommendations.push(rec);
+    }
+    if let Some(rec) = rec_blocked_overflow(blocked_count) {
+        recommendations.push(rec);
+    }
+
+    serde_json::json!({
+        "as_of": now.to_rfc3339(),
+        "live_agents_available": live.is_some(),
+        "totals": {
+            "all": total_all,
+            "non_terminal": total_non_terminal,
+            "terminal": total_terminal,
+        },
+        "by_status": by_status,
+        "ghost_owners": {
+            "strict_count": strict_count,
+            "strict_owners": strict_owners,
+            "soft_count": soft_count,
+            "soft_owners": soft_owners,
+        },
+        "stale_claims": {
+            "overdue_count": stale_claim_ids.len(),
+            "overdue_ids": stale_claim_ids,
+        },
+        "age": {
+            "oldest_non_terminal_days": oldest_days,
+            "median_non_terminal_days": median_days,
+            "over_30d_count": over_30d_count,
+            "over_90d_count": over_90d_count,
+        },
+        "recommendations": recommendations,
+    })
+}
+
+/// Trigger: any `scan.strict` entries — owners verifiably gone
+/// (∉ fleet.yaml ∧ ∉ live). Next-action hint mentions #829 auto-orphan
+/// on next daemon boot (the same scan that produced these candidates
+/// will fire automatically) so operator can either wait or run
+/// `task action=sweep` to apply now.
+fn rec_ghost_owners_strict(scan: &OrphanScanResult, count: usize) -> Option<Value> {
+    if scan.strict.is_empty() {
+        return None;
+    }
+    let candidate_ids: Vec<String> = scan
+        .strict
+        .values()
+        .flat_map(|ids| ids.iter().map(|t| t.0.clone()))
+        .collect();
+    Some(serde_json::json!({
+        "code": "ghost_owners_strict",
+        "severity": "warn",
+        "hint": format!(
+            "{count} task(s) owned by fully-gone agents (∉ fleet.yaml ∧ ∉ live); \
+             next daemon boot will auto-orphan via #829 — or run `task action=sweep` now"
+        ),
+        "candidate_ids": candidate_ids,
+    }))
+}
+
+/// Trigger: any `scan.soft` entries — owners in fleet.yaml but not
+/// in the live runtime registry. Could be transient (agent
+/// restarting) or a real misconfig; operator decides.
+fn rec_ghost_owners_soft(scan: &OrphanScanResult, count: usize) -> Option<Value> {
+    if scan.soft.is_empty() {
+        return None;
+    }
+    let candidate_ids: Vec<String> = scan
+        .soft
+        .values()
+        .flat_map(|ids| ids.iter().map(|t| t.0.clone()))
+        .collect();
+    Some(serde_json::json!({
+        "code": "ghost_owners_soft",
+        "severity": "info",
+        "hint": format!(
+            "{count} task(s) owned by configured-but-not-live agents \
+             (∈ fleet.yaml ∧ ∉ live); could be transient — check `binding_state` \
+             or run `task action=sweep` if persistent"
+        ),
+        "candidate_ids": candidate_ids,
+    }))
+}
+
+/// Trigger: any tasks past their `due_at`. Daemon's
+/// `sweep_overdue_claimed` already auto-releases these on its tick,
+/// so this is info-level (operator just sees the in-flight state).
+fn rec_stale_claims(ids: &[String]) -> Option<Value> {
+    if ids.is_empty() {
+        return None;
+    }
+    Some(serde_json::json!({
+        "code": "stale_claims",
+        "severity": "info",
+        "hint": format!(
+            "{} claim(s) past due_at; daemon's overdue sweep will release on next tick",
+            ids.len()
+        ),
+        "candidate_ids": ids.to_vec(),
+    }))
+}
+
+/// Trigger: more than `OVER_30D_WARN_THRESHOLD` non-terminal tasks
+/// older than 30 days. Suggests `task action=sweep` for board
+/// hygiene.
+fn rec_over_30d(count: usize) -> Option<Value> {
+    if count <= OVER_30D_WARN_THRESHOLD {
+        return None;
+    }
+    Some(serde_json::json!({
+        "code": "over_30d",
+        "severity": "warn",
+        "hint": format!(
+            "{count} non-terminal task(s) older than 30 days; \
+             consider `task action=sweep` for stale-task review"
+        ),
+    }))
+}
+
+/// Trigger: more than `STALE_BLOCKED_WARN_THRESHOLD` tasks in the
+/// blocked state. Indicates accumulating dependency backlog or
+/// unattended `block_reason` causes.
+fn rec_blocked_overflow(count: usize) -> Option<Value> {
+    if count <= STALE_BLOCKED_WARN_THRESHOLD {
+        return None;
+    }
+    Some(serde_json::json!({
+        "code": "blocked_overflow",
+        "severity": "warn",
+        "hint": format!(
+            "{count} task(s) currently in `blocked` state; \
+             check `block_reason` per task and unblock or cancel"
+        ),
+    }))
 }
 
 fn can_mutate_record(home: &Path, caller: &str, record: &crate::task_events::TaskRecord) -> bool {
@@ -1384,6 +1602,27 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 Err(e) => serde_json::json!({"error": format!("sweep apply failed: {e}")}),
             }
         }
+        "health" => {
+            // #830 one-shot board hygiene snapshot. Operator self-serve
+            // diagnosis: "is the board clean?" + recommended next
+            // actions surfaced as a structured `recommendations` array.
+            let live = crate::runtime::list_live_agents(home);
+            let fleet_instances: std::collections::HashSet<String> =
+                crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+                    .ok()
+                    .map(|c| c.instances.keys().cloned().collect())
+                    .unwrap_or_default();
+            let state = match crate::task_events::replay(home) {
+                Ok(s) => s,
+                Err(e) => {
+                    return serde_json::json!({
+                        "error": format!("task_events replay failed: {e}"),
+                        "code": "replay_failed",
+                    });
+                }
+            };
+            build_health_response(&state, live.as_ref(), &fleet_instances)
+        }
         _ => serde_json::json!({"error": format!("unknown action: {action}")}),
     }
 }
@@ -1827,6 +2066,157 @@ mod tests {
             vec!["t-claimed".to_string(), "t-open".to_string()],
             "Done + Cancelled must be excluded; non-terminal must surface (BTreeMap order is by TaskId)"
         );
+    }
+
+    // ── #830 task action=health build_health_response ──
+
+    fn make_record_with_age_days(
+        id: &str,
+        status: crate::task_events::TaskStatus,
+        owner: Option<&str>,
+        age_days: i64,
+    ) -> crate::task_events::TaskRecord {
+        let created_at = (chrono::Utc::now() - chrono::Duration::days(age_days)).to_rfc3339();
+        let mut r = make_record(id, status, owner);
+        r.created_at = created_at;
+        r
+    }
+
+    /// #830: status counts roll up across all 4 active states +
+    /// Done/Cancelled terminals. Totals stay consistent
+    /// (`all = non_terminal + terminal`).
+    #[test]
+    fn build_health_response_reports_status_counts_correctly() {
+        use crate::task_events::TaskStatus;
+        let state = make_state(vec![
+            make_record("t-1", TaskStatus::Open, None),
+            make_record("t-2", TaskStatus::Open, None),
+            make_record("t-3", TaskStatus::Claimed, Some("alpha")),
+            make_record("t-4", TaskStatus::InProgress, Some("alpha")),
+            make_record("t-5", TaskStatus::Blocked, None),
+            make_record("t-6", TaskStatus::Done, Some("alpha")),
+            make_record("t-7", TaskStatus::Cancelled, None),
+        ]);
+        let live = make_set(&["alpha"]);
+        let fleet = make_set(&["alpha"]);
+
+        let resp = build_health_response(&state, Some(&live), &fleet);
+
+        assert_eq!(resp["totals"]["all"], 7);
+        assert_eq!(resp["totals"]["non_terminal"], 5);
+        assert_eq!(resp["totals"]["terminal"], 2);
+        assert_eq!(resp["by_status"]["open"], 2);
+        assert_eq!(resp["by_status"]["claimed"], 1);
+        assert_eq!(resp["by_status"]["in_progress"], 1);
+        assert_eq!(resp["by_status"]["blocked"], 1);
+        assert_eq!(resp["by_status"]["done"], 1);
+        assert_eq!(resp["by_status"]["cancelled"], 1);
+    }
+
+    /// #830: a clean board (no ghosts, no stale claims, low age,
+    /// blocked count under threshold) must produce an EMPTY
+    /// `recommendations` array. Positive signal for operators —
+    /// "everything's fine, nothing to do".
+    #[test]
+    fn build_health_response_clean_board_emits_empty_recommendations() {
+        use crate::task_events::TaskStatus;
+        let state = make_state(vec![
+            make_record_with_age_days("t-1", TaskStatus::Open, None, 1),
+            make_record_with_age_days("t-2", TaskStatus::InProgress, Some("alpha"), 1),
+        ]);
+        let live = make_set(&["alpha"]);
+        let fleet = make_set(&["alpha"]);
+
+        let resp = build_health_response(&state, Some(&live), &fleet);
+        let recs = resp["recommendations"]
+            .as_array()
+            .expect("recommendations must be array");
+        assert!(
+            recs.is_empty(),
+            "clean board → empty recommendations, got: {recs:?}"
+        );
+    }
+
+    /// #830: ghost-owner candidates from `scan_orphan_candidates` (#829)
+    /// must surface in BOTH the `ghost_owners` section AND a
+    /// `ghost_owners_strict` / `ghost_owners_soft` recommendation entry
+    /// with structured `{code, severity, hint, candidate_ids}`.
+    #[test]
+    fn build_health_response_includes_ghost_owners_from_scan() {
+        use crate::task_events::TaskStatus;
+        let state = make_state(vec![
+            // alice is ∉ live ∧ ∉ fleet → strict
+            make_record("t-1", TaskStatus::Claimed, Some("alice830")),
+            // bob is ∈ fleet ∧ ∉ live → soft
+            make_record("t-2", TaskStatus::Open, Some("bob830")),
+        ]);
+        let live = make_set(&[]);
+        let fleet = make_set(&["bob830"]);
+
+        let resp = build_health_response(&state, Some(&live), &fleet);
+
+        assert_eq!(resp["ghost_owners"]["strict_count"], 1);
+        assert_eq!(resp["ghost_owners"]["soft_count"], 1);
+        let recs = resp["recommendations"]
+            .as_array()
+            .expect("recommendations array");
+        let codes: Vec<&str> = recs.iter().filter_map(|r| r["code"].as_str()).collect();
+        assert!(
+            codes.contains(&"ghost_owners_strict"),
+            "ghost_owners_strict recommendation must fire, got codes: {codes:?}"
+        );
+        assert!(
+            codes.contains(&"ghost_owners_soft"),
+            "ghost_owners_soft recommendation must fire, got codes: {codes:?}"
+        );
+    }
+
+    /// #830: claims past `due_at` surface as `stale_claims` entry +
+    /// `stale_claims` recommendation. Locks the read-only replication
+    /// of `sweep_overdue_claimed`'s predicate.
+    #[test]
+    fn build_health_response_includes_stale_claims_via_due_at() {
+        use crate::task_events::TaskStatus;
+        let past = (chrono::Utc::now() - chrono::Duration::days(2)).to_rfc3339();
+        let mut overdue = make_record("t-overdue", TaskStatus::Claimed, Some("alpha"));
+        overdue.due_at = Some(past);
+        let state = make_state(vec![overdue]);
+        let live = make_set(&["alpha"]);
+        let fleet = make_set(&["alpha"]);
+
+        let resp = build_health_response(&state, Some(&live), &fleet);
+
+        assert_eq!(resp["stale_claims"]["overdue_count"], 1);
+        let ids = resp["stale_claims"]["overdue_ids"]
+            .as_array()
+            .expect("overdue_ids must be array");
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], "t-overdue");
+        let recs = resp["recommendations"]
+            .as_array()
+            .expect("recommendations array");
+        let codes: Vec<&str> = recs.iter().filter_map(|r| r["code"].as_str()).collect();
+        assert!(
+            codes.contains(&"stale_claims"),
+            "stale_claims recommendation must fire, got codes: {codes:?}"
+        );
+    }
+
+    /// #830: daemon-offline degrades gracefully. `live = None` flows
+    /// through (`live_agents_available: false` in the response) — the
+    /// ghost_owners scan effectively treats all owners as ghosts (live
+    /// set is empty), which is the worst case but at least operator
+    /// can see the snapshot.
+    #[test]
+    fn build_health_response_handles_daemon_offline_gracefully() {
+        use crate::task_events::TaskStatus;
+        let state = make_state(vec![make_record("t-1", TaskStatus::Open, None)]);
+        let fleet = make_set(&[]);
+
+        let resp = build_health_response(&state, None, &fleet);
+
+        assert_eq!(resp["live_agents_available"], false);
+        assert_eq!(resp["totals"]["all"], 1);
     }
 
     /// #829 C1 RED: classify three tasks across the strict / soft /

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -278,19 +278,11 @@ pub fn list(home: &Path) -> Value {
     // M members) HashSet lookups, no repeated locking. If the API call
     // fails (daemon offline / unreachable), stale_members stays empty
     // — best-effort staleness reporting, never blocks `list` itself.
-    let live_agents: std::collections::HashSet<String> = crate::api::call(
-        home,
-        &serde_json::json!({"method": crate::api::method::LIST}),
-    )
-    .ok()
-    .and_then(|r| {
-        r["result"]["agents"].as_array().map(|arr| {
-            arr.iter()
-                .filter_map(|a| a["name"].as_str().map(String::from))
-                .collect()
-        })
-    })
-    .unwrap_or_default();
+    //
+    // #830: routed through the canonical `runtime::list_live_agents`
+    // helper that #827/#829/#830 share (the original copy lived here).
+    let live_agents: std::collections::HashSet<String> =
+        crate::runtime::list_live_agents(home).unwrap_or_default();
 
     let teams: Vec<Value> = list_all(home)
         .iter_mut()


### PR DESCRIPTION
Closes #830.

scope follows dispatch spec t-20260515141354518126-5

## Summary

Adds `task action=health` — operator-callable one-shot snapshot of board hygiene state. Returns `totals` + `by_status` counts + `ghost_owners` (#829 scan reuse) + `stale_claims` (read-only replication of `sweep_overdue_claimed`'s predicate) + age aggregates + structured `recommendations` array with `{code, severity, hint, candidate_ids?}` per entry.

Includes the long-anticipated `fetch_live_agents` consolidation: the pattern duplicated across `teams::list` / `panels.rs` / `tasks.rs` (#785/#827/#829) extracts into a new `src/runtime.rs::list_live_agents` now that #830 is the fourth consumer (per spike design call 3).

## Response shape (sample)

```json
{
  "as_of": "2026-05-15T18:00:00Z",
  "live_agents_available": true,
  "totals": {"all": 47, "non_terminal": 38, "terminal": 9},
  "by_status": {"open": 12, "claimed": 5, "in_progress": 18, "blocked": 3, "done": 7, "cancelled": 2},
  "ghost_owners": {
    "strict_count": 0, "strict_owners": [],
    "soft_count": 2, "soft_owners": ["dev-impl-2"]
  },
  "stale_claims": {"overdue_count": 2, "overdue_ids": ["t-..."]},
  "age": {
    "oldest_non_terminal_days": 18,
    "median_non_terminal_days": 3,
    "over_30d_count": 4,
    "over_90d_count": 0
  },
  "recommendations": [
    {
      "code": "ghost_owners_soft",
      "severity": "info",
      "hint": "2 task(s) owned by configured-but-not-live agents …",
      "candidate_ids": ["t-..."]
    },
    {"code": "stale_claims", "severity": "info", "hint": "…", "candidate_ids": ["t-..."]},
    {"code": "over_30d", "severity": "warn", "hint": "4 non-terminal task(s) older than 30 days; consider `task action=sweep`"}
  ]
}
```

Clean-board case: empty `recommendations: []` — positive signal that everything's fine.

## Design notes (5 design calls, all approved as recommended)

1. **Structured recommendations** `{code, severity, hint, candidate_ids?}` — machine-parseable codes for cron/monitoring; severity for TUI color mapping; hint for human readability; `candidate_ids` lets operators copy-paste into `task action=sweep`.
2. **Inline tasks.rs v1** — `build_health_response` + 5 recommendation generators live next to `scan_orphan_candidates` to share the pure-fn testability pattern. Submodule split (`tasks/health.rs`) deferred.
3. **`fetch_live_agents` extraction** — new `src/runtime.rs::list_live_agents`. `panels.rs::fetch_live_agents` becomes a thin wrapper preserving the #827 `tracing::warn` observability hook; `tasks.rs` removes its private duplicate (used by #829's `reconcile_orphan_owners`); `teams::list` switches to the helper.
4. **`build_health_response` is pub fn** — pure fn `(state, live, fleet_instances) -> Value`. Testable directly without daemon spawn.
5. **Hardcoded severity thresholds** — `OVER_30D_WARN_THRESHOLD = 5`, `STALE_BLOCKED_WARN_THRESHOLD = 10`. Tuned for current operator's fleet shape; config-ability deferred.

## Five recommendation generators

- `rec_ghost_owners_strict` — `scan.strict` non-empty (warn)
- `rec_ghost_owners_soft` — `scan.soft` non-empty (info)
- `rec_stale_claims` — claims past `due_at` (info; daemon's overdue sweep auto-releases)
- `rec_over_30d` — `over_30d_count > 5` (warn)
- `rec_blocked_overflow` — `blocked` count > 10 (warn)

Each returns `Option<Value>` — `None` when threshold not exceeded so caller can simply `if let Some(rec) = …` push.

## Test plan

5 tests in `src/tasks.rs::tests`:

- [x] `build_health_response_reports_status_counts_correctly` — locks `by_status` + `totals` shape across all 6 task statuses.
- [x] `build_health_response_clean_board_emits_empty_recommendations` — positive signal contract: clean board → `recommendations: []`.
- [x] `build_health_response_includes_ghost_owners_from_scan` — verifies #829 `scan_orphan_candidates` reuse populates both the `ghost_owners` section AND the strict/soft recommendation entries.
- [x] `build_health_response_includes_stale_claims_via_due_at` — locks read-only replication of `sweep_overdue_claimed`'s predicate.
- [x] `build_health_response_handles_daemon_offline_gracefully` — `live = None` flows through with `live_agents_available: false` hint; operator still gets the snapshot.

Verified at HEAD `96f4b4d`:

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo clean -p agend-terminal && cargo test --features tray` — all binary + integration suites green
- [x] `cargo test --tests --features tray` — file_size_invariant + all `tests/*.rs` green (the post-#837 r0 lesson baked in)
- [x] CI portability sim: `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` clean

## Out of scope (deferred)

- **TUI dashboard for health** — separate UX feature; once #830 ships, a follow-up could add a "press 'h' from Ctrl+B t" hotkey overlay rendering the JSON.
- **Per-team / per-orchestrator slicing** — future enhancement if operators ask.
- **Historical trend graphs** — requires persisted snapshots, much larger scope.
- **Config-able thresholds** — defer to v1.5 if operator demand surfaces.
- **`tasks/health.rs` submodule split** — defer until tasks.rs LOC trends critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)