### PR TITLE
fix(#833): cleanup_init_commits body-gate strips daemon-known Agend-* trailers

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -945,10 +945,16 @@ const KNOWN_TRAILER_KEYS: &[&str] = &[
 /// ensures `Agend-Agent` matches only `Agend-Agent:`, NOT
 /// `Agend-Agent-Token:` (partial-prefix regression-proof).
 ///
-/// C1 stub: returns the input unchanged so the RED acceptance test
-/// fails (trailer body still flags non-empty). C2 fills the body.
 fn strip_known_trailers(body: &str) -> String {
-    body.to_string()
+    body.lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            !KNOWN_TRAILER_KEYS
+                .iter()
+                .any(|k| trimmed.starts_with(k) && trimmed[k.len()..].starts_with(':'))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// #822: returns true iff the commit's body (the part after the

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -915,6 +915,42 @@ fn is_heartbeat_subject(msg: &str) -> bool {
     HEARTBEAT_NAMES.contains(&msg)
 }
 
+/// #833: trailer keys the daemon's `prepare-commit-msg` hook injects
+/// into every bound-worktree commit (including the `commit
+/// --allow-empty -m "init"` heartbeats). The body-emptiness gate
+/// (`commit_body_is_empty`) must treat these as "empty for the gate's
+/// purpose" so `cleanup_init_commits` can actually remove the
+/// daemon-injected heartbeats — pre-#833 the gate kept them
+/// indefinitely because the trailer block isn't whitespace.
+///
+/// Sourced verbatim from `assets/hooks/prepare-commit-msg` lines 44-47
+/// (and the matching `.ps1` Windows variant). Exact-key match —
+/// partial-key trailers like `Agend-Agent-Token` are NOT stripped,
+/// preserving operator-extended trailer keys.
+///
+/// New daemon-injected trailers must extend this list. A follow-up
+/// invariant test (lead's post-batch backlog) will grep the hook
+/// script and pin the constants in sync.
+const KNOWN_TRAILER_KEYS: &[&str] = &[
+    "Agend-Agent",
+    "Agend-Task",
+    "Agend-Branch",
+    "Agend-Issued-At",
+];
+
+/// #833: strip lines that look like `<KEY>: <value>` where KEY is in
+/// [`KNOWN_TRAILER_KEYS`]. Leading whitespace tolerated (the hook
+/// emits unindented but `.trim_start()` is defensive). The
+/// `starts_with(k) && trimmed[k.len()..].starts_with(':')` two-step
+/// ensures `Agend-Agent` matches only `Agend-Agent:`, NOT
+/// `Agend-Agent-Token:` (partial-prefix regression-proof).
+///
+/// C1 stub: returns the input unchanged so the RED acceptance test
+/// fails (trailer body still flags non-empty). C2 fills the body.
+fn strip_known_trailers(body: &str) -> String {
+    body.to_string()
+}
+
 /// #822: returns true iff the commit's body (the part after the
 /// subject line) is empty or whitespace-only. Guards the whitelist
 /// from dropping commits with legitimate body notes that happen to
@@ -936,7 +972,15 @@ fn commit_body_is_empty(worktree: &Path, hash: &str) -> bool {
         .env("AGEND_GIT_BYPASS", "1")
         .output();
     match out {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().is_empty(),
+        Ok(o) if o.status.success() => {
+            // #833: strip daemon-injected trailers before the empty
+            // check. The hook injects `Agend-*:` trailers into every
+            // bound-worktree commit, so a heartbeat's "body" is never
+            // literally empty post-hook — but it IS empty in the
+            // operator-content sense.
+            let body = String::from_utf8_lossy(&o.stdout);
+            strip_known_trailers(&body).trim().is_empty()
+        }
         _ => true,
     }
 }

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1711,6 +1711,78 @@ fn clean_empty_init_commits_still_handles_canonical_init_empty() {
 
 // ── #833 cleanup_init_commits trailer-whitelist body gate ──
 
+/// #833 C3 regression-proof: the strip respects the
+/// trailer-key-followed-by-colon contract. `Agend-Agent-Token: x`
+/// must NOT be stripped (it's an operator-extended trailer key,
+/// not the daemon's `Agend-Agent`). Locks the partial-prefix
+/// guard against future scanner refactors.
+#[test]
+fn strip_known_trailers_does_not_match_partial_prefix_keys() {
+    let body = "Agend-Agent-Token: secret\n\
+                Agent-Agent-Plus: other\n\
+                Real operator note line";
+    let stripped = super::strip_known_trailers(body);
+    // None of the lines look like `Agend-Agent:` (with colon directly
+    // after the key) — all must survive.
+    assert_eq!(
+        stripped, body,
+        "partial-prefix trailers must not be stripped, got: {stripped:?}"
+    );
+}
+
+/// #833 C3 regression-proof: a heartbeat-style commit whose body
+/// has DAEMON TRAILERS + REAL OPERATOR NOTES must be KEPT. The
+/// strip removes only the whitelist lines; the surviving operator
+/// content keeps the gate's "is empty" check from returning true.
+/// This is the load-bearing safety case — operator-added content
+/// stays intact even when daemon trailers are mixed in.
+#[test]
+fn clean_empty_init_commits_keeps_init_with_real_body_after_trailers() {
+    let (_repo, worktree) = setup_repo_and_worktree("833_mixed_body");
+    let mixed = "Operator commit notes here.\n\
+                 More context paragraphs.\n\
+                 \n\
+                 Agend-Agent: dev833\n\
+                 Agend-Task: t-...";
+    empty_commit(&worktree, "init", Some(mixed));
+
+    let result = super::clean_empty_init_commits(&worktree);
+    assert!(result.is_ok(), "helper must succeed, got: {result:?}");
+    assert_eq!(
+        result.unwrap(),
+        0,
+        "`init` with real operator body must be KEPT even when daemon \
+         trailers are present — strip removes only the trailer block",
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}
+
+/// #833 C3 regression-proof: unknown daemon-style trailer keys
+/// (e.g., a future `Agend-Sprint:` that hasn't been added to
+/// `KNOWN_TRAILER_KEYS` yet) must NOT be stripped. Conservative
+/// default — extending the whitelist requires an explicit code
+/// change (and ideally the synced-with-hook invariant that
+/// lead's post-batch backlog tracks).
+#[test]
+fn clean_empty_init_commits_keeps_init_with_unknown_trailer_keys() {
+    let (_repo, worktree) = setup_repo_and_worktree("833_unknown_trailer");
+    // `Agend-Custom` is NOT in KNOWN_TRAILER_KEYS — must survive strip.
+    let unknown = "Agend-Custom: something operator added";
+    empty_commit(&worktree, "init", Some(unknown));
+
+    let result = super::clean_empty_init_commits(&worktree);
+    assert!(result.is_ok(), "helper must succeed, got: {result:?}");
+    assert_eq!(
+        result.unwrap(),
+        0,
+        "`init` with non-whitelisted trailer key must be KEPT — conservative default \
+         until KNOWN_TRAILER_KEYS is explicitly extended",
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}
+
 /// #833 C1 RED: a heartbeat-style commit with ONLY daemon-injected
 /// `Agend-*:` trailers in its body (the actual production state every
 /// bound-worktree commit lands in post-hook) must be DROPPED by

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1708,3 +1708,37 @@ fn clean_empty_init_commits_still_handles_canonical_init_empty() {
 
     std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
 }
+
+// ── #833 cleanup_init_commits trailer-whitelist body gate ──
+
+/// #833 C1 RED: a heartbeat-style commit with ONLY daemon-injected
+/// `Agend-*:` trailers in its body (the actual production state every
+/// bound-worktree commit lands in post-hook) must be DROPPED by
+/// `cleanup_init_commits`. Pre-#833 the body-emptiness gate (#822)
+/// saw the trailer block as non-empty and kept the commit —
+/// `repo cleanup_init_commits` was effectively a no-op on real
+/// daemon-managed worktrees. The same FP class I surfaced during
+/// #827 push prep.
+///
+/// Asserts the post-fix contract:
+/// - 1 commit cleaned (the canonical heartbeat shape)
+#[test]
+fn clean_empty_init_commits_drops_init_with_only_daemon_trailers() {
+    let (_repo, worktree) = setup_repo_and_worktree("833_trailer_only");
+    let trailer_block = "Agend-Agent: dev833\n\
+                         Agend-Task: t-20260515150751256952-0\n\
+                         Agend-Branch: fix/833-cleanup-init-trailer-whitelist\n\
+                         Agend-Issued-At: 2026-05-15T18:24:45+00:00";
+    empty_commit(&worktree, "init", Some(trailer_block));
+
+    let result = super::clean_empty_init_commits(&worktree);
+    assert!(result.is_ok(), "helper must succeed, got: {result:?}");
+    assert_eq!(
+        result.unwrap(),
+        1,
+        "`init` with only Agend-* trailers in body must be dropped \
+         (the operational case that motivated #833)",
+    );
+
+    std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
+}

--- a/tests/cleanup_init_synonym_e2e.rs
+++ b/tests/cleanup_init_synonym_e2e.rs
@@ -58,13 +58,43 @@ use std::path::Path;
 /// rather than silent drift). The hardcoded list is the contract.
 const HEARTBEAT_NAMES: &[&str] = &["init", "initial"];
 
+/// #833 mirror of production's trailer-whitelist (
+/// `src/mcp/handlers/dispatch_hook/mod.rs::KNOWN_TRAILER_KEYS`).
+/// Drift between the two surfaces would silently break the dogfood
+/// — explicit replication makes the contract visible.
+const KNOWN_TRAILER_KEYS: &[&str] = &[
+    "Agend-Agent",
+    "Agend-Task",
+    "Agend-Branch",
+    "Agend-Issued-At",
+];
+
 fn is_heartbeat_subject(msg: &str) -> bool {
     HEARTBEAT_NAMES.contains(&msg)
 }
 
+/// #833 mirror of production's `strip_known_trailers`. Pure replication
+/// to keep the integration smoke independent of crate-private fns.
+fn strip_known_trailers(body: &str) -> String {
+    body.lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            !KNOWN_TRAILER_KEYS
+                .iter()
+                .any(|k| trimmed.starts_with(k) && trimmed[k.len()..].starts_with(':'))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 fn commit_body_is_empty(worktree: &Path, hash: &str) -> bool {
     let out = git_isolated::git(worktree, &["log", "-1", "--format=%b", hash]);
-    out.status.success() && String::from_utf8_lossy(&out.stdout).trim().is_empty()
+    if !out.status.success() {
+        return false;
+    }
+    let body = String::from_utf8_lossy(&out.stdout);
+    // #833: strip daemon-known trailers before the empty check.
+    strip_known_trailers(&body).trim().is_empty()
 }
 
 fn diff_is_empty(worktree: &Path, hash: &str) -> bool {
@@ -175,6 +205,36 @@ fn cleanup_init_synonym_e2e_classifies_via_helper() {
     assert_eq!(
         total, 6,
         "expected 6 commits on feature branch, got {total}"
+    );
+
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+/// #833 integration smoke (dogfood #821 `git_isolated::git()`):
+/// reproduce the production heartbeat shape — `init` subject with
+/// ONLY daemon `Agend-*:` trailers in the body — and assert the
+/// classification picks it up post-strip.
+#[test]
+fn cleanup_init_synonym_e2e_drops_init_with_trailer_only_body() {
+    let repo = setup_repo_with_main_ref("833_e2e_trailer");
+    let trailer_block = "Agend-Agent: dev833\n\
+                         Agend-Task: t-20260515150751256952-0\n\
+                         Agend-Branch: fix/833-cleanup-init-trailer-whitelist\n\
+                         Agend-Issued-At: 2026-05-15T18:24:45+00:00";
+    empty_commit(&repo, "init", Some(trailer_block)); // → drop post-strip
+    empty_commit(&repo, "init", Some("operator real notes")); // → keep (real body)
+    empty_commit(
+        &repo,
+        "init",
+        Some("Agend-Custom: future-trailer-not-yet-in-whitelist"),
+    ); // → keep (unknown trailer key)
+
+    let droppable = collect_droppable_hashes(&repo);
+    assert_eq!(
+        droppable.len(),
+        1,
+        "exactly 1 commit should be dropped — the trailer-only `init`. \
+         Real-body and unknown-trailer commits must be kept. droppable={droppable:?}"
     );
 
     std::fs::remove_dir_all(&repo).ok();


### PR DESCRIPTION
Closes #833.

scope follows dispatch spec t-20260515150751256952-0

## Summary

Closes the FP class I surfaced during #827 push prep: every daemon-managed worktree commit carries an `Agend-*:` trailer block injected by `assets/hooks/prepare-commit-msg` (and the `.ps1` Windows variant). #822's body-emptiness gate treats that block as non-empty, so `repo cleanup_init_commits` was effectively a no-op on real production state — the operational symptom I worked around with `reset --hard + cherry-pick` during #827/#828/#834 pushes.

R3 fix per general's routing: hardcoded whitelist of daemon-known trailer keys + line-by-line strip before the empty-check.

## Design notes (per spike-approved hardcoded const)

- **`KNOWN_TRAILER_KEYS: &[&str] = &["Agend-Agent", "Agend-Task", "Agend-Branch", "Agend-Issued-At"]`** — sourced verbatim from `assets/hooks/prepare-commit-msg` lines 44-47. Mirrors the `HEARTBEAT_NAMES` precedent at #822 — daemon-internal config, not operator territory.
- **`strip_known_trailers(body)`** — line filter with `starts_with(k) && trimmed[k.len()..].starts_with(':')` two-step. The colon-after-exact-key check ensures `Agend-Agent:` matches but `Agend-Agent-Token:` does NOT (partial-prefix guard).
- **`commit_body_is_empty` 2-line update** — pipe `%b` stdout through `strip_known_trailers` before the existing `.trim().is_empty()` check. Contract unchanged ("returns true → treat-as-empty"); only the "what counts as empty" widens.
- **Conservative default for unknown trailers** — keys not in the whitelist are NOT stripped. Operator-added trailers + future daemon-trailer additions stay safe until `KNOWN_TRAILER_KEYS` extends.

## Test plan

5 tests total (1 RED@C1 → GREEN@C2 + 3 unit regression-proof + 1 integration smoke dogfooding #821):

Unit (`src/mcp/handlers/dispatch_hook/tests.rs`):

- [x] `clean_empty_init_commits_drops_init_with_only_daemon_trailers` — **RED at C1 (`b958f18`), GREEN at C2 (`f546097`)**. Synthesizes the canonical heartbeat shape (`init` + 4-line `Agend-*:` trailer block); asserts cleaned=1.
- [x] `strip_known_trailers_does_not_match_partial_prefix_keys` — C3 GREEN. `Agend-Agent-Token:` + `Agent-Agent-Plus:` must NOT be stripped.
- [x] `clean_empty_init_commits_keeps_init_with_real_body_after_trailers` — C3 GREEN. **Load-bearing safety case**: mixed body (operator notes + trailers) must be KEPT.
- [x] `clean_empty_init_commits_keeps_init_with_unknown_trailer_keys` — C3 GREEN. `Agend-Custom:` is not in whitelist → must NOT be stripped → commit KEPT.

Integration smoke (`tests/cleanup_init_synonym_e2e.rs`, dogfoods `tests/common/git_isolated::git()` from #821):

- [x] `cleanup_init_synonym_e2e_drops_init_with_trailer_only_body` — extends the existing #825 e2e smoke. Three commits (trailer-only + real-body + unknown-trailer); asserts exactly 1 dropped.

All 7 pre-existing dispatch_hook tests (#814 / #822) verified still GREEN — 10/10 in the module post-#833.

Verified at HEAD `d866ce1` (post-#838 pre-push baseline applied):

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo clean -p agend-terminal && cargo test --features tray` — all binary + integration suites green
- [x] `cargo test --tests --features tray` — file_size_invariant + all `tests/*.rs` green
- [x] CI portability sim: `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` clean
- [x] RED reconfirmed at C1 SHA `b958f18` after `cargo clean -p agend-terminal` — `0 passed; 1 failed`. Flipped GREEN at C2 SHA `f546097`.

## Commit chain

1. `b958f18` — `test(#833): scaffolding for trailer-whitelist body gate (C1)` — `KNOWN_TRAILER_KEYS` const + `strip_known_trailers` stub (returns input unchanged) + `commit_body_is_empty` plumbed through stub + RED test.
2. `f546097` — `fix(#833): strip_known_trailers body — daemon trailer-block removal (C2)` — fills the line-filter body. RED → GREEN.
3. `d866ce1` — `test(#833): 3 unit regression-proof + integration smoke (C3)` — 3 unit edges + 1 e2e dogfooding #821 helper.

## Out of scope (deferred)

- **Hook-script-vs-whitelist sync test** — lead is filing as separate follow-up issue post-batch. Greps `assets/hooks/prepare-commit-msg` for `Agend-*:` keys and asserts each is in `KNOWN_TRAILER_KEYS`; prevents silent drift when a new daemon trailer ships.
- **#836 notification dedup** — independent file scope.
- **macOS flaky test rework** — separate issue post-batch.
- **Other body-gate variants** (subject-prefix matching, etc.) — not needed for the operational case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)