### PR TITLE
fix(#836): notification dedup race — msg_id-based suppression of post-consume retry re-inject

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod idle_watchdog;
 pub(crate) mod legacy_backfill;
 pub(crate) mod lifecycle;
 pub(crate) mod mcp_registry_watcher;
+pub(crate) mod notification_dedup;
 pub(crate) mod per_tick;
 pub(crate) mod poll_reminder;
 pub(crate) mod router;

--- a/src/daemon/notification_dedup.rs
+++ b/src/daemon/notification_dedup.rs
@@ -1,0 +1,284 @@
+//! #836 AGEND-MSG notification dedup ledger.
+//!
+//! Closes the consume → retry race: after `inbox::drain` marks a
+//! message `read_at = Some(now)`, the existing rate-limit retry
+//! mechanism at `src/daemon/supervisor.rs::process_server_rate_limit_retries`
+//! doesn't know the msg was consumed and can still re-inject the
+//! `[AGEND-MSG]` header within the 60s `NOTIFICATION_DEDUP_CAP=1`
+//! window. Recipient sees the header, calls `inbox`, gets empty —
+//! the ghost-notification operator-confusion symptom.
+//!
+//! This module tracks a `(agent, msg_id)` ledger:
+//! - `record_inject` at notify-agent time → entry created (not consumed)
+//! - `mark_consumed` inside `inbox::drain` post-read_at-set → flag flipped
+//! - `should_suppress_reinject` at retry tick → true iff entry exists AND
+//!   consumed
+//!
+//! Entries expire after [`IDEMPOTENCY_WINDOW_SECS`] (10 min); a periodic
+//! sweep called from the supervisor tick reclaims old state. The ledger
+//! is in-memory only for v1 — disk persistence deferred to v1.5 per
+//! spike design call 3; the existing `NOTIFICATION_DEDUP_CAP=1` provides
+//! the safety floor for cross-restart edge cases.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Entry-staleness TTL. Notifications retried beyond this window get
+/// allowed through (assumed to be a genuinely separate retry attempt
+/// or a daemon restart cleared in-memory state). Wider than the
+/// supervisor's `NOTIFICATION_DEDUP_WINDOW_SECS = 60` because the
+/// observed re-emission pattern (Telegram inbound replays, channel
+/// router retries) clusters within ~5 min; 10 min carries a 2× safety
+/// margin without retaining state forever.
+pub const IDEMPOTENCY_WINDOW_SECS: u64 = 600;
+
+#[derive(Debug, Clone, Copy)]
+struct Entry {
+    injected_at: Instant,
+    consumed: bool,
+}
+
+/// Per-(agent, msg_id) delivery state. Lock-grained at the whole
+/// HashMap for simplicity — entries are short-lived (TTL=10min) and
+/// sweep is cheap (O(N)).
+#[derive(Default)]
+pub struct Ledger {
+    state: Mutex<HashMap<(String, String), Entry>>,
+}
+
+impl Ledger {
+    /// Record that an `[AGEND-MSG]` header for `(agent, msg_id)` was
+    /// just injected into the agent's PTY. Idempotent — re-recording
+    /// the same key refreshes the timestamp without flipping
+    /// `consumed` (so a retry that legitimately re-injects WITHIN the
+    /// window before consume still keeps the entry as not-consumed).
+    pub fn record_inject(&self, agent: &str, msg_id: &str) {
+        self.record_inject_at(agent, msg_id, Instant::now());
+    }
+
+    /// Test-time variant that pins the timestamp. Production callers
+    /// use [`record_inject`].
+    pub fn record_inject_at(&self, agent: &str, msg_id: &str, at: Instant) {
+        if let Ok(mut s) = self.state.lock() {
+            s.entry((agent.to_string(), msg_id.to_string()))
+                .and_modify(|e| e.injected_at = at)
+                .or_insert(Entry {
+                    injected_at: at,
+                    consumed: false,
+                });
+        }
+    }
+
+    /// Flag the `(agent, msg_id)` entry as consumed. Called from
+    /// `inbox::drain` post-`read_at`-set per spike design call 5.
+    /// No-op when the entry doesn't exist (drain runs for every
+    /// agent that calls `inbox`, but only some msgs have a
+    /// corresponding recorded inject).
+    pub fn mark_consumed(&self, agent: &str, msg_id: &str) {
+        if let Ok(mut s) = self.state.lock() {
+            if let Some(e) = s.get_mut(&(agent.to_string(), msg_id.to_string())) {
+                e.consumed = true;
+            }
+        }
+    }
+
+    /// Suppression check at retry-tick time. Returns true iff the
+    /// ledger has a non-expired entry for `(agent, msg_id)` AND that
+    /// entry is flagged `consumed`. Other cases (entry absent,
+    /// entry present but not consumed, entry expired) return false
+    /// so the retry can proceed.
+    pub fn should_suppress_reinject(&self, agent: &str, msg_id: &str) -> bool {
+        self.should_suppress_reinject_at(agent, msg_id, Instant::now())
+    }
+
+    /// Test-time variant that pins the clock.
+    pub fn should_suppress_reinject_at(&self, agent: &str, msg_id: &str, now: Instant) -> bool {
+        let Ok(s) = self.state.lock() else {
+            return false;
+        };
+        let Some(entry) = s.get(&(agent.to_string(), msg_id.to_string())) else {
+            return false;
+        };
+        if !entry.consumed {
+            return false;
+        }
+        now.duration_since(entry.injected_at) < Duration::from_secs(IDEMPOTENCY_WINDOW_SECS)
+    }
+
+    /// Drop expired entries. Called periodically from the supervisor
+    /// tick (10s cadence) so memory pressure stays bounded.
+    pub fn sweep_expired(&self) {
+        self.sweep_expired_at(Instant::now());
+    }
+
+    /// Test-time variant. Returns the number of dropped entries for
+    /// caller observability.
+    pub fn sweep_expired_at(&self, now: Instant) -> usize {
+        let Ok(mut s) = self.state.lock() else {
+            return 0;
+        };
+        let before = s.len();
+        let ttl = Duration::from_secs(IDEMPOTENCY_WINDOW_SECS);
+        s.retain(|_, entry| now.duration_since(entry.injected_at) < ttl);
+        before.saturating_sub(s.len())
+    }
+
+    /// Test-only: count entries (for assertions).
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.state.lock().map(|s| s.len()).unwrap_or(0)
+    }
+}
+
+/// Process-wide singleton. Production callers (notify_agent post-
+/// inject, `inbox::drain` post-consume, supervisor retry-tick
+/// suppression check) use this; tests construct local `Ledger::default()`
+/// instances for isolation.
+pub fn global() -> &'static Ledger {
+    static LEDGER: OnceLock<Ledger> = OnceLock::new();
+    LEDGER.get_or_init(Ledger::default)
+}
+
+/// Parse `id=<msg_id>` field from a single-line `[AGEND-MSG]` header.
+/// Returns `None` for headers that don't include an id field (e.g.,
+/// free-form notifications, event-style headers from
+/// `inbox::format_event_header`) so the caller can default to "no
+/// dedup, allow the retry through" per spike risk R3.
+///
+/// The header format is fixed by `inbox::format_header` —
+/// space-separated `key=value` fields, `id=<value>` when set. The
+/// parser splits on whitespace and looks for the first `id=` token;
+/// stops at the next space or end-of-string. Robust to additional
+/// fields and reordering as long as keys are space-delimited.
+pub fn extract_msg_id_from_header(text: &str) -> Option<String> {
+    text.split_ascii_whitespace()
+        .find_map(|tok| tok.strip_prefix("id="))
+        .filter(|v| !v.is_empty())
+        .map(|v| v.to_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// #836 unit: insert + lookup contract. Fresh entry is NOT
+    /// flagged consumed; should_suppress_reinject returns false
+    /// until mark_consumed flips the flag.
+    #[test]
+    fn dedup_set_inserts_on_inject() {
+        let l = Ledger::default();
+        l.record_inject("alice836", "m-1");
+        assert_eq!(l.len(), 1);
+        assert!(
+            !l.should_suppress_reinject("alice836", "m-1"),
+            "fresh entry must not suppress — only consumed entries suppress"
+        );
+    }
+
+    /// #836 unit: mark_consumed + should_suppress contract. Locks
+    /// the load-bearing suppression case — record then consume then
+    /// retry MUST be suppressed.
+    #[test]
+    fn dedup_set_suppresses_already_delivered() {
+        let l = Ledger::default();
+        l.record_inject("alice836", "m-1");
+        l.mark_consumed("alice836", "m-1");
+        assert!(
+            l.should_suppress_reinject("alice836", "m-1"),
+            "consumed entry MUST suppress re-inject (the load-bearing #836 case)"
+        );
+    }
+
+    /// #836 unit: TTL expiry contract. An entry consumed long ago
+    /// (past the 10-min window) is no longer suppressed — the retry
+    /// gets to fire (assumed to be a genuinely-fresh re-attempt).
+    #[test]
+    fn dedup_set_expires_after_window() {
+        let l = Ledger::default();
+        let t0 = Instant::now();
+        l.record_inject_at("alice836", "m-1", t0);
+        l.mark_consumed("alice836", "m-1");
+        let inside_window = t0 + Duration::from_secs(IDEMPOTENCY_WINDOW_SECS - 1);
+        assert!(
+            l.should_suppress_reinject_at("alice836", "m-1", inside_window),
+            "consumed entry inside window must still suppress"
+        );
+        let outside_window = t0 + Duration::from_secs(IDEMPOTENCY_WINDOW_SECS + 1);
+        assert!(
+            !l.should_suppress_reinject_at("alice836", "m-1", outside_window),
+            "consumed entry past 10-min window must NOT suppress"
+        );
+    }
+
+    /// #836 unit: multi-msg drain — agent consumes msg-1 but not
+    /// msg-2. Subsequent retry must suppress for msg-1 (consumed)
+    /// but NOT msg-2 (still pending). Locks the per-msg-id precision
+    /// that Option B was chosen for over the simpler unread-count
+    /// approach in spike Q1.
+    #[test]
+    fn dedup_set_handles_multi_msg_drain() {
+        let l = Ledger::default();
+        l.record_inject("alice836", "m-1");
+        l.record_inject("alice836", "m-2");
+        l.mark_consumed("alice836", "m-1");
+        // Only m-1 is consumed.
+        assert!(l.should_suppress_reinject("alice836", "m-1"));
+        assert!(
+            !l.should_suppress_reinject("alice836", "m-2"),
+            "partial-consume must NOT suppress the still-pending msg"
+        );
+    }
+
+    /// #836 unit: header parser extracts the `id=` field. Locks the
+    /// contract that production's retry-suppression path relies on
+    /// (parse the AGEND-MSG header text, lookup by msg_id).
+    #[test]
+    fn extract_msg_id_finds_id_field_in_canonical_header() {
+        let header = "\u{1b}[2m[AGEND-MSG]\u{1b}[0m from=fixup-lead \
+                      id=m-20260515184625304633-133 kind=task size=1545";
+        let id = extract_msg_id_from_header(header);
+        assert_eq!(id, Some("m-20260515184625304633-133".to_string()));
+    }
+
+    /// #836 unit: header without id= returns None — caller defaults
+    /// to "allow through" per spike risk R3. Locks the conservative
+    /// fallback.
+    #[test]
+    fn extract_msg_id_returns_none_when_field_absent() {
+        let header = "[AGEND-MSG] from=fixup-lead kind=task size=200";
+        assert_eq!(extract_msg_id_from_header(header), None);
+        // Empty value also returns None (defensive against `id=` with
+        // no value).
+        let header_empty = "[AGEND-MSG] from=fixup-lead id= kind=task";
+        assert_eq!(extract_msg_id_from_header(header_empty), None);
+    }
+
+    /// #836 integration race scenario: simulate the consume → retry
+    /// flow. This is the load-bearing test that motivated the whole
+    /// design — locking it GREEN proves the dedup set actually
+    /// suppresses the redundant re-inject.
+    ///
+    /// Steps:
+    /// 1. Sender delivers msg with id="m-race" → record_inject
+    ///    (simulates the post-`notify_agent` hook in C2)
+    /// 2. Agent calls `inbox` → drain marks read_at + invokes
+    ///    `mark_consumed` (simulates the post-drain hook in C2)
+    /// 3. Supervisor's retry-tick fires → `should_suppress_reinject`
+    ///    must return true (the C2 supervisor wires this into its
+    ///    retry phase)
+    #[test]
+    fn e2e_consume_then_retry_suppresses_reinject() {
+        let l = Ledger::default();
+        // Step 1: sender delivers + notify_agent hook records inject.
+        l.record_inject("agent-race", "m-race");
+        // Step 2: drain marks consumed.
+        l.mark_consumed("agent-race", "m-race");
+        // Step 3: retry-tick suppression check.
+        assert!(
+            l.should_suppress_reinject("agent-race", "m-race"),
+            "post-consume retry MUST be suppressed (the #836 ghost-notification fix)"
+        );
+    }
+}

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -235,6 +235,10 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
         helper_staleness_tracker.maybe_scan(&home);
         mcp_registry_tracker.maybe_scan(&home);
         waiting_on_stale_tracker.maybe_scan(&home);
+        // #836: reclaim expired (10-min TTL) entries from the
+        // notification-dedup ledger so memory pressure stays bounded
+        // on long-lived daemons.
+        crate::daemon::notification_dedup::global().sweep_expired();
     }
 }
 
@@ -753,6 +757,33 @@ pub(crate) fn process_server_rate_limit_retries(
             // that gave up.
             crate::daemon::dedup_state::save(home, name, retry);
             continue;
+        }
+
+        // #836: post-consume suppression gate. If the input_text is
+        // a previously-injected `[AGEND-MSG]` header AND the
+        // corresponding msg has already been drained by the agent,
+        // the notification-dedup ledger says "skip this re-inject".
+        // Headers without an extractable msg_id (event-style, free-form
+        // acks) fall through to the existing retry path unchanged.
+        if let Some(msg_id) =
+            crate::daemon::notification_dedup::extract_msg_id_from_header(&retry.input_text)
+        {
+            if crate::daemon::notification_dedup::global().should_suppress_reinject(name, &msg_id) {
+                tracing::info!(
+                    agent = %name,
+                    msg_id = %msg_id,
+                    "#836: ServerRateLimit retry suppressed — msg already consumed"
+                );
+                crate::event_log::log(
+                    home,
+                    "server_rate_limit_retry_suppressed",
+                    name,
+                    &format!("msg_id={msg_id} consumed_post_inject"),
+                );
+                retry.dedup_count = NOTIFICATION_DEDUP_CAP;
+                crate::daemon::dedup_state::save(home, name, retry);
+                continue;
+            }
         }
 
         // Re-inject last input directly to PTY (no daemon API self-call).

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -483,6 +483,17 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
                     continue;
                 }
                 msg.read_at = Some(now.clone());
+                // #836: signal post-consume so the notification-dedup
+                // ledger can suppress redundant re-inject attempts
+                // from the rate-limit retry path. The ledger only has
+                // a record when notify_agent earlier called
+                // `record_inject(agent, msg_id)`; for messages whose
+                // delivery never went through the PTY-inject path
+                // (inbox-only or pre-#836 flight), `mark_consumed` is
+                // a no-op.
+                if let Some(ref id) = msg.id {
+                    crate::daemon::notification_dedup::global().mark_consumed(name, id);
+                }
                 unread.push(msg.clone());
             }
             all_messages.push(msg);
@@ -1064,6 +1075,18 @@ pub fn notify_agent_with_attachments(
     let notification =
         format_notification_for_inject(pointer_only_inject(), source, text, attachments);
     compose_aware_inject(home, agent_name, &notification);
+    // #836: record the (agent, msg_id) tuple in the dedup ledger so a
+    // subsequent post-consume retry tick can suppress redundant
+    // re-inject attempts. We parse the msg_id back out of the
+    // formatted header (single source of truth — `format_header`
+    // already includes `id=<msg_id>` when set). Headers without an
+    // id field (event-style notifications, free-form acks) skip the
+    // record cleanly per the parser's `Option<String>` contract.
+    if let Some(msg_id) =
+        crate::daemon::notification_dedup::extract_msg_id_from_header(&notification)
+    {
+        crate::daemon::notification_dedup::global().record_inject(agent_name, &msg_id);
+    }
     // Store raw body AFTER inject — overwrites any formatted text the inject
     // handler may have stored. Ensures retry re-injects raw body, not header.
     crate::daemon::heartbeat_pair::update_with(agent_name, |p| {


### PR DESCRIPTION
Closes #836.

scope follows dispatch spec t-20260515163112707682-1

## Summary

Closes the consume → retry race that surfaced repeatedly during the 5th batch's own dispatch flow (the recurring `[AGEND-MSG] from=fixup-lead kind=task size=…` notifications when the inbox was already drained). After `inbox::drain` marks a message `read_at = Some(now)`, the existing rate-limit retry mechanism at `src/daemon/supervisor.rs::process_server_rate_limit_retries` previously didn't know the msg was consumed and could still re-inject the `[AGEND-MSG]` header within the 60s `NOTIFICATION_DEDUP_CAP=1` window. Recipient sees the header, calls `inbox`, gets empty — the ghost-notification operator-confusion symptom.

## Option B per spike (msg_id-based dedup set + drain hook)

1. **New `src/daemon/notification_dedup.rs`** module — in-memory `Ledger` keyed by `(agent, msg_id)`. Entries flip to `consumed: true` post-drain; `should_suppress_reinject` returns true iff entry exists AND consumed AND within 10-min TTL.
2. **`inbox::notify_agent_with_attachments` post-inject hook** — parses `id=<msg_id>` back out of the formatted header (no signature churn per spike design call 4) and records the inject.
3. **`inbox::drain` post-read_at-set hook** — single chokepoint per spike design call 5; calls `mark_consumed` for each msg whose `read_at` newly transitions from None to Some.
4. **Supervisor retry suppression** — Phase 2 of `process_server_rate_limit_retries` extracts `msg_id` from `retry.input_text` and checks the ledger BEFORE the PTY-write. If suppressed, emits `server_rate_limit_retry_suppressed` event-log entry + bumps `dedup_count = NOTIFICATION_DEDUP_CAP` so future ticks in the same window stay suppressed.
5. **Periodic sweep** — `global().sweep_expired()` per supervisor tick (10s cadence) reclaims entries older than `IDEMPOTENCY_WINDOW_SECS = 600` (10 min).

## Design notes (5 design calls, all approved as recommended by spike)

1. **Option B** chosen over Option A (`unread_count`-based) for per-msg precision — partial-consume cases (1 of 3 msgs drained) correctly suppress only the consumed msg's retry, not the still-pending ones.
2. **IDEMPOTENCY_WINDOW_SECS = 600** — covers Telegram inbound retries + 2× safety margin.
3. **In-memory only for v1** — disk persistence deferred to v1.5; the existing `NOTIFICATION_DEDUP_CAP=1` provides the safety floor for daemon-restart edge cases.
4. **Header-parse for msg_id** — no `notify_agent` signature churn; the canonical `format_header` line carries `id=<msg_id>` already (used by recipient agents and by the supervisor's retry path).
5. **mark_consumed inside drain** — single chokepoint; can't be missed by any drain caller.

## Test plan

7 unit tests in `src/daemon/notification_dedup.rs::tests`:

- [x] `dedup_set_inserts_on_inject` — fresh entry not consumed; should_suppress returns false.
- [x] `dedup_set_suppresses_already_delivered` — **load-bearing**: record + mark_consumed → suppress returns true.
- [x] `dedup_set_expires_after_window` — 10-min TTL contract; consumed entry past window does NOT suppress.
- [x] `dedup_set_handles_multi_msg_drain` — partial-consume precision; m-1 consumed → suppress(m-1)=true, m-2 still pending → suppress(m-2)=false.
- [x] `extract_msg_id_finds_id_field_in_canonical_header` — header parser locks the production-path contract.
- [x] `extract_msg_id_returns_none_when_field_absent` — conservative fallback (caller defaults to allow).
- [x] `e2e_consume_then_retry_suppresses_reinject` — race-scenario integration: record + mark_consumed + suppress = true. The flow the dispatch describes.

Verified at HEAD `e820166`:
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo clean -p agend-terminal && cargo test --features tray` — all binary + integration suites green (~2300 tests post-#833)
- [x] `cargo test --tests --features tray` — file_size_invariant + all `tests/*.rs` green
- [x] CI portability sim: `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` clean

## Operational impact

5th batch final ship. The `[AGEND-MSG]` notification storm that operator and I both observed during this batch's own dispatch flow is now closed at the source. Combined with #833's body-gate fix (`cleanup_init_commits` no longer no-op'd by `Agend-*` trailers), the operational hygiene loop is whole again.

## Out of scope (deferred)

- **Disk persistence** of the dedup ledger across daemon restarts — defer to v1.5; in-memory + `NOTIFICATION_DEDUP_CAP=1` safety floor is sufficient for v1.
- **Cross-process IPC dedup** — different concern, separate issue if needed.
- **Replacing inbox transport** — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)