### PR TITLE
feat(#841): daemon rate-limit recovery auto-prompt — sibling to fast-retry path

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -209,7 +209,11 @@ pub(crate) enum NudgeDecision {
 /// caller (integration fn) because state transitions need the live
 /// registry read.
 ///
-/// C1 RED stub — C2 GREEN fills in the actual state-machine logic.
+/// Order matters — `Disabled` is checked before any other gate so an
+/// opted-out agent never produces a `Skip(Cooldown)` or similar that
+/// would mislead a future operator inspecting the trace. `DeferToFastRetry`
+/// next, so we don't waste a fire on an agent whose fast-retry path is
+/// already going to handle the same situation.
 pub(crate) fn decide_nudge(
     track: &RecoveryNudgeTrack,
     current_state: crate::state::AgentState,
@@ -217,8 +221,144 @@ pub(crate) fn decide_nudge(
     config: &crate::fleet::RateLimitRecoveryConfig,
     now: Instant,
 ) -> NudgeDecision {
-    let _ = (track, current_state, fast_retry_active, config, now);
-    unimplemented!("decide_nudge — C1 RED stub, C2 GREEN fills in")
+    use crate::state::AgentState;
+
+    if !config.enabled {
+        return NudgeDecision::Skip(NudgeSkipReason::Disabled);
+    }
+    if fast_retry_active {
+        return NudgeDecision::Skip(NudgeSkipReason::DeferToFastRetry);
+    }
+    if track.fired_this_cycle {
+        return NudgeDecision::Skip(NudgeSkipReason::FiredThisCycle);
+    }
+    let Some(last_error_at) = track.last_error_at else {
+        return NudgeDecision::Skip(NudgeSkipReason::NoRecentError);
+    };
+    // Error too stale (>1 hour past the observe window) — treat as no
+    // longer relevant. Operator probably came back to a long-idle agent
+    // that happens to have an old error in its track.
+    let stale_cap = Duration::from_secs(config.observe_after_secs.saturating_add(3600));
+    if now.duration_since(last_error_at) > stale_cap {
+        return NudgeDecision::Skip(NudgeSkipReason::NoRecentError);
+    }
+    if !matches!(current_state, AgentState::Ready | AgentState::Idle) {
+        return NudgeDecision::Skip(NudgeSkipReason::NotIdle);
+    }
+    let Some(recovered_at) = track.recovered_at else {
+        return NudgeDecision::Skip(NudgeSkipReason::NotIdle);
+    };
+    let recovery_window = Duration::from_secs(config.recovery_after_secs);
+    if now.duration_since(recovered_at) < recovery_window {
+        return NudgeDecision::Skip(NudgeSkipReason::StillInRecoveryWindow);
+    }
+    if let Some(last_inject_at) = track.last_inject_at {
+        let cooldown = Duration::from_secs(config.cooldown_secs);
+        if now.duration_since(last_inject_at) < cooldown {
+            return NudgeDecision::Skip(NudgeSkipReason::Cooldown);
+        }
+    }
+    NudgeDecision::Fire
+}
+
+/// #841 per-tick integration for the recovery-nudge path.
+///
+/// Phase 1 (registry lock held): observe per-agent state and update
+/// each `RecoveryNudgeTrack` — stamp `last_error_at` on a transient
+/// error, stamp `recovered_at` when an agent transitions back to
+/// `Ready`/`Idle`, and clear cycle bookkeeping when the agent leaves
+/// the recovered window (e.g. operator typed something, or the nudge
+/// itself was picked up).
+///
+/// Phase 2 (no locks): load fleet.yaml for per-instance config,
+/// evaluate `decide_nudge` for each observed agent, and fire the
+/// configured prompt via `compose_aware_send` when the decision is
+/// `Fire`. The fire branch is the only side-effecting path; all skip
+/// branches are observation-only.
+///
+/// Sibling fn to `process_server_rate_limit_retries`; the two paths
+/// coordinate via the `fast_retry_tracks` argument (when the fast
+/// path is actively retrying for an agent, the nudge defers).
+pub(crate) fn process_rate_limit_recovery_nudges(
+    home: &std::path::Path,
+    registry: &AgentRegistry,
+    fast_retry_tracks: &HashMap<String, RateLimitRetry>,
+    nudge_tracks: &mut HashMap<String, RecoveryNudgeTrack>,
+) {
+    let now = Instant::now();
+
+    // Phase 1: state observation + track update (registry lock held).
+    let mut observed: Vec<(String, crate::state::AgentState)> = Vec::new();
+    {
+        let reg = agent::lock_registry(registry);
+        for (name, handle) in reg.iter() {
+            let state = handle.core.lock().state.current;
+            let track = nudge_tracks.entry(name.clone()).or_default();
+            if state.is_transient_error() {
+                // Restart the cycle — a fresh transient error invalidates any
+                // in-flight recovery wait and any prior `fired_this_cycle` latch.
+                track.last_error_at = Some(now);
+                track.recovered_at = None;
+                track.fired_this_cycle = false;
+            } else if matches!(
+                state,
+                crate::state::AgentState::Ready | crate::state::AgentState::Idle
+            ) {
+                // Only stamp `recovered_at` on the FIRST observation of the
+                // Ready/Idle transition — subsequent ticks keep the same
+                // recovery anchor so the `recovery_after_secs` window can
+                // actually elapse.
+                if track.last_error_at.is_some() && track.recovered_at.is_none() {
+                    track.recovered_at = Some(now);
+                }
+            } else {
+                // Agent transitioned out of Ready/Idle (handler picked up the
+                // nudge, operator typed something, or any other active state).
+                // Reset cycle bookkeeping so the NEXT error→recovery sequence
+                // starts a clean cycle. `last_error_at` is preserved so a
+                // rapid re-error within the stale cap is still recognized.
+                track.recovered_at = None;
+                track.fired_this_cycle = false;
+            }
+            observed.push((name.clone(), state));
+        }
+    }
+    // Registry lock released here.
+
+    // Phase 2: fleet.yaml read + per-agent decision + fire (no locks held).
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
+    let default_cfg = crate::fleet::RateLimitRecoveryConfig::default();
+
+    for (name, state) in &observed {
+        // Clone the track for the pure decide_nudge call so the mutation
+        // path below can take a fresh `&mut` without overlapping borrows.
+        let track_snapshot = nudge_tracks.get(name).cloned().unwrap_or_default();
+        let fast_active = fast_retry_tracks.contains_key(name);
+
+        let cfg = fleet
+            .as_ref()
+            .and_then(|f| f.instances.get(name))
+            .and_then(|i| i.rate_limit_recovery.as_ref())
+            .cloned()
+            .unwrap_or_else(|| default_cfg.clone());
+
+        if matches!(
+            decide_nudge(&track_snapshot, *state, fast_active, &cfg, now),
+            NudgeDecision::Fire
+        ) {
+            tracing::info!(
+                agent = %name,
+                prompt = %cfg.prompt,
+                "#841 rate-limit recovery nudge firing"
+            );
+            crate::inbox::compose_aware_send(home, name, &cfg.prompt);
+            if let Some(t) = nudge_tracks.get_mut(name) {
+                t.last_inject_at = Some(now);
+                t.fired_this_cycle = true;
+                t.recovered_at = None;
+            }
+        }
+    }
 }
 
 /// Parse unlock time from usage_limit pane output (e.g., "resets at 15:14 UTC").
@@ -296,10 +436,20 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
         crate::daemon::mcp_registry_watcher::McpRegistryWatcherTracker::default();
     let mut waiting_on_stale_tracker =
         crate::daemon::waiting_on_stale::WaitingOnStaleTracker::default();
+    // #841 rate-limit recovery nudge tracking — in-memory only for r0
+    // (restart clears state, which is safe; the fast-retry path's
+    // `dedup_state` disk persistence covers the harder restart-window
+    // case for the side it owns).
+    let mut nudge_tracks: HashMap<String, RecoveryNudgeTrack> = HashMap::new();
     loop {
         thread::sleep(TICK);
         tick(&home, &registry, &mut notify_tracks);
         process_server_rate_limit_retries(&home, &registry, &mut retry_tracks);
+        // #841: sibling per-tick. Defers to fast-retry when its
+        // retry_tracks has an entry for the same agent; otherwise applies
+        // the slower observe→recover→nudge cycle for transient errors
+        // that the fast path didn't (or couldn't) handle.
+        process_rate_limit_recovery_nudges(&home, &registry, &retry_tracks, &mut nudge_tracks);
         check_pane_input_not_submitted(&home, &registry, &mut pane_input_tracks);
         anti_stall_tracker.maybe_scan(&home);
         idle_watchdog_tracker.maybe_scan(&home);

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -203,6 +203,32 @@ pub(crate) enum NudgeDecision {
     Fire,
 }
 
+/// Resolve the effective per-agent recovery config from a fleet load
+/// outcome plus an instance name.
+///
+/// **Fail-closed on load error** (`Err(_)`): returns a config with
+/// `enabled = false` (other knobs preserved from `default_cfg`) so a
+/// corrupt or missing fleet.yaml never silently auto-enables the nudge
+/// — the operator sees the warn log at the call site and fixes the
+/// config. Without this gate, a parse error during fleet.yaml edits
+/// would leave the daemon happily injecting `continue your prior work`
+/// into every transient-error recovery, which violates the spike Q3
+/// "Config parse error → enabled=false" contract.
+///
+/// On `Ok`: look up the per-instance override; fall back to
+/// `default_cfg` when the instance isn't in fleet.yaml OR the instance
+/// entry omits the `rate_limit_recovery` field.
+///
+/// C3 RED stub — C4 GREEN fills in.
+pub(crate) fn resolve_recovery_config(
+    fleet: Result<&crate::fleet::FleetConfig, ()>,
+    name: &str,
+    default_cfg: &crate::fleet::RateLimitRecoveryConfig,
+) -> crate::fleet::RateLimitRecoveryConfig {
+    let _ = (fleet, name, default_cfg);
+    unimplemented!("resolve_recovery_config — C3 RED stub, C4 GREEN fills in")
+}
+
 /// Pure helper: classify the recovery-nudge tick against the track,
 /// the current agent state, the fast-retry path's activity, and the
 /// per-agent config. Mutation of `RecoveryNudgeTrack` is left to the
@@ -1531,6 +1557,79 @@ mod tests {
             decide_nudge(&track, AgentState::Idle, false, &cfg, now),
             NudgeDecision::Skip(NudgeSkipReason::NoRecentError)
         );
+    }
+
+    /// r1 fix: when fleet.yaml load FAILS (parse error, missing file,
+    /// corrupted yaml), `resolve_recovery_config` must return a config
+    /// with `enabled = false` so the daemon fails closed — a broken
+    /// config never silently enables auto-inject. Spike Q3 contract.
+    #[test]
+    fn resolve_recovery_config_fails_closed_on_load_error() {
+        let default_cfg = RateLimitRecoveryConfig::default();
+        assert!(
+            default_cfg.enabled,
+            "sanity: per-instance/parsed default IS enabled=true; only the load-error \
+             fallback flips to disabled"
+        );
+
+        let resolved = resolve_recovery_config(Err(()), "agent-x", &default_cfg);
+        assert!(
+            !resolved.enabled,
+            "load error must fail-closed: enabled=false"
+        );
+        // Other knobs preserved so an operator who later restores the
+        // config doesn't get a surprise mismatch in window sizes.
+        assert_eq!(resolved.observe_after_secs, default_cfg.observe_after_secs);
+        assert_eq!(resolved.recovery_after_secs, default_cfg.recovery_after_secs);
+        assert_eq!(resolved.cooldown_secs, default_cfg.cooldown_secs);
+        assert_eq!(resolved.prompt, default_cfg.prompt);
+    }
+
+    /// Per-instance override path: fleet.yaml loaded, instance entry
+    /// present with `rate_limit_recovery: { enabled: false, ... }` →
+    /// the override flows through verbatim (operator opt-out works).
+    #[test]
+    fn resolve_recovery_config_uses_instance_override_when_present() {
+        use std::collections::HashMap;
+        let mut instances = HashMap::new();
+        instances.insert(
+            "opt-out-agent".to_string(),
+            crate::fleet::InstanceConfig {
+                rate_limit_recovery: Some(RateLimitRecoveryConfig {
+                    enabled: false,
+                    observe_after_secs: 999,
+                    recovery_after_secs: 999,
+                    prompt: "should-not-fire".into(),
+                    cooldown_secs: 999,
+                }),
+                ..Default::default()
+            },
+        );
+        let fleet = crate::fleet::FleetConfig {
+            instances,
+            ..Default::default()
+        };
+        let default_cfg = RateLimitRecoveryConfig::default();
+        let resolved = resolve_recovery_config(Ok(&fleet), "opt-out-agent", &default_cfg);
+        assert!(!resolved.enabled, "per-instance opt-out must propagate");
+        assert_eq!(resolved.observe_after_secs, 999);
+        assert_eq!(resolved.prompt, "should-not-fire");
+    }
+
+    /// Fallback path: fleet.yaml loaded successfully but the instance
+    /// is absent (e.g. a runtime-only agent not yet persisted) OR the
+    /// instance entry omits `rate_limit_recovery` → use `default_cfg`
+    /// (the daemon-wide default), which has `enabled=true`.
+    #[test]
+    fn resolve_recovery_config_falls_back_to_default_when_instance_absent() {
+        let fleet = crate::fleet::FleetConfig::default();
+        let default_cfg = RateLimitRecoveryConfig::default();
+        let resolved = resolve_recovery_config(Ok(&fleet), "never-heard-of-this-agent", &default_cfg);
+        assert!(
+            resolved.enabled,
+            "no per-instance override → daemon default kicks in (enabled=true)"
+        );
+        assert_eq!(resolved.observe_after_secs, default_cfg.observe_after_secs);
     }
 
     /// (f) permanent errors excluded: `UsageLimit` and `AuthError` are

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -149,6 +149,78 @@ pub(crate) fn dedup_decision(
     DedupDecision::Allow
 }
 
+// ---------------------------------------------------------------------------
+// #841 rate-limit recovery nudge — sibling fn to fast-retry path
+// ---------------------------------------------------------------------------
+
+/// #841 per-agent tracking for the recovery-nudge path.
+///
+/// Lifecycle (driven by the per-tick state observation in
+/// `process_rate_limit_recovery_nudges`):
+///
+/// - **Error observed** (`is_transient_error()` true) — set
+///   `last_error_at = Some(now)`, clear `recovered_at` and
+///   `fired_this_cycle`.
+/// - **Agent recovers** (state becomes `Ready`/`Idle` while
+///   `last_error_at.is_some()` and `recovered_at.is_none()`) — set
+///   `recovered_at = Some(now)`.
+/// - **Recovery window elapses + cooldown clear + fast-retry inactive** —
+///   `decide_nudge` returns `Fire`; the integration fn injects via
+///   `compose_aware_send`, sets `last_inject_at`, marks
+///   `fired_this_cycle`.
+/// - **Agent leaves `Ready`/`Idle`** (handler picked up the nudge OR
+///   the operator typed something) — clear `recovered_at` and
+///   `fired_this_cycle` so a future error→recovery sequence starts
+///   a fresh cycle.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RecoveryNudgeTrack {
+    pub last_error_at: Option<Instant>,
+    pub recovered_at: Option<Instant>,
+    pub last_inject_at: Option<Instant>,
+    pub fired_this_cycle: bool,
+}
+
+/// Reason the per-tick decision chose to skip the nudge — recorded for
+/// tracing so the operator can audit *why* a recovery nudge that
+/// "should" have fired didn't.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NudgeSkipReason {
+    Disabled,
+    NoRecentError,
+    NotIdle,
+    StillInRecoveryWindow,
+    Cooldown,
+    DeferToFastRetry,
+    FiredThisCycle,
+}
+
+/// Per-tick verdict for one agent, returned by the pure helper
+/// [`decide_nudge`] so the integration fn can act on a value without
+/// holding any registry locks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NudgeDecision {
+    Skip(NudgeSkipReason),
+    Fire,
+}
+
+/// Pure helper: classify the recovery-nudge tick against the track,
+/// the current agent state, the fast-retry path's activity, and the
+/// per-agent config. Mutation of `RecoveryNudgeTrack` is left to the
+/// caller (integration fn) because state transitions need the live
+/// registry read.
+///
+/// C1 RED stub — C2 GREEN fills in the actual state-machine logic.
+pub(crate) fn decide_nudge(
+    track: &RecoveryNudgeTrack,
+    current_state: crate::state::AgentState,
+    fast_retry_active: bool,
+    config: &crate::fleet::RateLimitRecoveryConfig,
+    now: Instant,
+) -> NudgeDecision {
+    let _ = (track, current_state, fast_retry_active, config, now);
+    unimplemented!("decide_nudge — C1 RED stub, C2 GREEN fills in")
+}
+
 /// Parse unlock time from usage_limit pane output (e.g., "resets at 15:14 UTC").
 fn parse_unlock_at(pane_text: &str) -> Option<String> {
     // Common patterns: "resets at HH:MM", "try again after HH:MM", "limit resets HH:MM"
@@ -1208,6 +1280,128 @@ mod tests {
         retry.dedup_audit_emitted = false;
         assert_eq!(retry.dedup_count, 0);
         assert!(!retry.dedup_audit_emitted);
+    }
+
+    // ── #841 rate-limit recovery nudge — pure-helper tests ────────────
+
+    use crate::fleet::RateLimitRecoveryConfig;
+    use crate::state::AgentState;
+
+    /// Build a `RecoveryNudgeTrack` representing "agent saw error at
+    /// `error_offset` ago, recovered at `recovery_offset` ago, and
+    /// has never been nudged before".
+    fn fresh_nudge_track(
+        now: Instant,
+        error_offset: Duration,
+        recovery_offset: Duration,
+    ) -> RecoveryNudgeTrack {
+        RecoveryNudgeTrack {
+            last_error_at: Some(now - error_offset),
+            recovered_at: Some(now - recovery_offset),
+            last_inject_at: None,
+            fired_this_cycle: false,
+        }
+    }
+
+    /// (a) trigger condition fires once. Default config: agent has been
+    /// in Ready for 70s after a ServerRateLimit observed 100s ago — past
+    /// observe_after_secs (30s) and past recovery_after_secs (60s), no
+    /// cooldown, fast-retry inactive → Fire.
+    #[test]
+    fn nudge_fires_when_all_conditions_met() {
+        let cfg = RateLimitRecoveryConfig::default();
+        let now = Instant::now();
+        let track = fresh_nudge_track(now, Duration::from_secs(100), Duration::from_secs(70));
+        assert_eq!(
+            decide_nudge(&track, AgentState::Idle, false, &cfg, now),
+            NudgeDecision::Fire
+        );
+    }
+
+    /// (b) enabled=false → Skip(Disabled). Same path as (e) per-instance
+    /// opt-out — fleet.yaml `rate_limit_recovery.enabled: false` flows
+    /// straight to this gate.
+    #[test]
+    fn nudge_skipped_when_disabled() {
+        let cfg = RateLimitRecoveryConfig {
+            enabled: false,
+            ..RateLimitRecoveryConfig::default()
+        };
+        let now = Instant::now();
+        let track = fresh_nudge_track(now, Duration::from_secs(100), Duration::from_secs(70));
+        assert_eq!(
+            decide_nudge(&track, AgentState::Idle, false, &cfg, now),
+            NudgeDecision::Skip(NudgeSkipReason::Disabled)
+        );
+    }
+
+    /// (c) cooldown: a nudge fired within the last cooldown_secs (300s)
+    /// suppresses the next decision even if a fresh error→recovery
+    /// cycle is otherwise ready to fire.
+    #[test]
+    fn nudge_skipped_within_cooldown() {
+        let cfg = RateLimitRecoveryConfig::default();
+        let now = Instant::now();
+        let mut track = fresh_nudge_track(now, Duration::from_secs(100), Duration::from_secs(70));
+        track.last_inject_at = Some(now - Duration::from_secs(60)); // 60s ago, within 300s cooldown
+        assert_eq!(
+            decide_nudge(&track, AgentState::Idle, false, &cfg, now),
+            NudgeDecision::Skip(NudgeSkipReason::Cooldown)
+        );
+    }
+
+    /// (d) defer-to-fast-retry: when `process_server_rate_limit_retries`
+    /// has an active retry track for this agent, the nudge path skips
+    /// and lets the fast path run. Prevents double-firing.
+    #[test]
+    fn nudge_defers_to_fast_retry() {
+        let cfg = RateLimitRecoveryConfig::default();
+        let now = Instant::now();
+        let track = fresh_nudge_track(now, Duration::from_secs(100), Duration::from_secs(70));
+        assert_eq!(
+            decide_nudge(&track, AgentState::Idle, true, &cfg, now),
+            NudgeDecision::Skip(NudgeSkipReason::DeferToFastRetry)
+        );
+    }
+
+    /// (e) no-recent-error: agent is idle but no error was observed in
+    /// the last `observe_after_secs`. Genuinely idle, not stalled —
+    /// must not inject (false-positive avoidance).
+    #[test]
+    fn nudge_skipped_when_no_recent_error() {
+        let cfg = RateLimitRecoveryConfig::default();
+        let now = Instant::now();
+        let track = RecoveryNudgeTrack {
+            last_error_at: None,
+            recovered_at: Some(now - Duration::from_secs(70)),
+            last_inject_at: None,
+            fired_this_cycle: false,
+        };
+        assert_eq!(
+            decide_nudge(&track, AgentState::Idle, false, &cfg, now),
+            NudgeDecision::Skip(NudgeSkipReason::NoRecentError)
+        );
+    }
+
+    /// (f) permanent errors excluded: `UsageLimit` and `AuthError` are
+    /// hard quota / credential failures — a "continue" nudge cannot
+    /// resolve them. The `is_transient_error` gate must return false
+    /// for these (the integration fn uses it before stamping
+    /// `last_error_at`, so a permanent error never produces a nudge
+    /// even if the agent later transitions to Idle).
+    #[test]
+    fn is_transient_error_excludes_permanent_states() {
+        // Transient — recoverable with a nudge.
+        assert!(AgentState::ServerRateLimit.is_transient_error());
+        assert!(AgentState::RateLimit.is_transient_error());
+        assert!(AgentState::ApiError.is_transient_error());
+        // Permanent — nudge cannot help; would just spam the PTY.
+        assert!(!AgentState::UsageLimit.is_transient_error());
+        assert!(!AgentState::AuthError.is_transient_error());
+        // Non-error states.
+        assert!(!AgentState::Ready.is_transient_error());
+        assert!(!AgentState::Idle.is_transient_error());
+        assert!(!AgentState::Thinking.is_transient_error());
     }
 
     fn tmp_home(tag: &str) -> std::path::PathBuf {

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -218,15 +218,23 @@ pub(crate) enum NudgeDecision {
 /// On `Ok`: look up the per-instance override; fall back to
 /// `default_cfg` when the instance isn't in fleet.yaml OR the instance
 /// entry omits the `rate_limit_recovery` field.
-///
-/// C3 RED stub — C4 GREEN fills in.
 pub(crate) fn resolve_recovery_config(
     fleet: Result<&crate::fleet::FleetConfig, ()>,
     name: &str,
     default_cfg: &crate::fleet::RateLimitRecoveryConfig,
 ) -> crate::fleet::RateLimitRecoveryConfig {
-    let _ = (fleet, name, default_cfg);
-    unimplemented!("resolve_recovery_config — C3 RED stub, C4 GREEN fills in")
+    let Ok(fleet) = fleet else {
+        return crate::fleet::RateLimitRecoveryConfig {
+            enabled: false,
+            ..default_cfg.clone()
+        };
+    };
+    fleet
+        .instances
+        .get(name)
+        .and_then(|i| i.rate_limit_recovery.as_ref())
+        .cloned()
+        .unwrap_or_else(|| default_cfg.clone())
 }
 
 /// Pure helper: classify the recovery-nudge tick against the track,
@@ -352,7 +360,21 @@ pub(crate) fn process_rate_limit_recovery_nudges(
     // Registry lock released here.
 
     // Phase 2: fleet.yaml read + per-agent decision + fire (no locks held).
-    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
+    //
+    // r1 fail-closed fix: load failure (parse error / missing file)
+    // funnels through `resolve_recovery_config` with `Err(())`, which
+    // returns a config carrying `enabled = false` — preventing silent
+    // auto-inject when fleet.yaml is mid-edit or corrupted. The warn
+    // log surfaces *why* the nudge stopped firing so the operator can
+    // diagnose without staring at empty-prompt agents.
+    let fleet_result = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home));
+    if let Err(e) = &fleet_result {
+        tracing::warn!(
+            error = %e,
+            "#841 fleet.yaml load failed — rate-limit recovery nudges disabled until fixed (fail-closed)"
+        );
+    }
+    let fleet_ref: Result<&crate::fleet::FleetConfig, ()> = fleet_result.as_ref().map_err(|_| ());
     let default_cfg = crate::fleet::RateLimitRecoveryConfig::default();
 
     for (name, state) in &observed {
@@ -361,12 +383,7 @@ pub(crate) fn process_rate_limit_recovery_nudges(
         let track_snapshot = nudge_tracks.get(name).cloned().unwrap_or_default();
         let fast_active = fast_retry_tracks.contains_key(name);
 
-        let cfg = fleet
-            .as_ref()
-            .and_then(|f| f.instances.get(name))
-            .and_then(|i| i.rate_limit_recovery.as_ref())
-            .cloned()
-            .unwrap_or_else(|| default_cfg.clone());
+        let cfg = resolve_recovery_config(fleet_ref, name, &default_cfg);
 
         if matches!(
             decide_nudge(&track_snapshot, *state, fast_active, &cfg, now),
@@ -1580,7 +1597,10 @@ mod tests {
         // Other knobs preserved so an operator who later restores the
         // config doesn't get a surprise mismatch in window sizes.
         assert_eq!(resolved.observe_after_secs, default_cfg.observe_after_secs);
-        assert_eq!(resolved.recovery_after_secs, default_cfg.recovery_after_secs);
+        assert_eq!(
+            resolved.recovery_after_secs,
+            default_cfg.recovery_after_secs
+        );
         assert_eq!(resolved.cooldown_secs, default_cfg.cooldown_secs);
         assert_eq!(resolved.prompt, default_cfg.prompt);
     }
@@ -1624,7 +1644,8 @@ mod tests {
     fn resolve_recovery_config_falls_back_to_default_when_instance_absent() {
         let fleet = crate::fleet::FleetConfig::default();
         let default_cfg = RateLimitRecoveryConfig::default();
-        let resolved = resolve_recovery_config(Ok(&fleet), "never-heard-of-this-agent", &default_cfg);
+        let resolved =
+            resolve_recovery_config(Ok(&fleet), "never-heard-of-this-agent", &default_cfg);
         assert!(
             resolved.enabled,
             "no per-instance override → daemon default kicks in (enabled=true)"

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -231,6 +231,68 @@ pub struct InstanceConfig {
     /// all skills (no per-backend dirs are populated).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skills: Option<Vec<String>>,
+    /// #841 per-instance rate-limit recovery config. `None` → use the
+    /// daemon-wide default ([`RateLimitRecoveryConfig::default`]).
+    /// `Some(cfg)` lets operators override knobs (most commonly
+    /// `enabled: false` to opt an agent out of the auto-recovery nudge).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit_recovery: Option<RateLimitRecoveryConfig>,
+}
+
+/// #841 per-instance rate-limit recovery configuration.
+///
+/// When an agent transitions from a transient-error state (e.g.
+/// `ServerRateLimit`, `RateLimit`, `ApiError`) back to `Ready`/`Idle`
+/// but then sits silent for [`recovery_after_secs`] seconds, the
+/// daemon supervisor injects a single `prompt` over the PTY (via
+/// `compose_aware_send`, bypassing the `[AGEND-MSG]` inbox header) to
+/// nudge the agent into continuing. Single-shot per recovery cycle; a
+/// [`cooldown_secs`]-second cooldown prevents repeat firing across
+/// consecutive cycles.
+///
+/// Operator opts an instance out with `enabled: false`; field-level
+/// `#[serde(default)]` lets the operator override one knob without
+/// re-specifying the others.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitRecoveryConfig {
+    #[serde(default = "rate_limit_recovery_default_enabled")]
+    pub enabled: bool,
+    #[serde(default = "rate_limit_recovery_default_observe_after_secs")]
+    pub observe_after_secs: u64,
+    #[serde(default = "rate_limit_recovery_default_recovery_after_secs")]
+    pub recovery_after_secs: u64,
+    #[serde(default = "rate_limit_recovery_default_prompt")]
+    pub prompt: String,
+    #[serde(default = "rate_limit_recovery_default_cooldown_secs")]
+    pub cooldown_secs: u64,
+}
+
+fn rate_limit_recovery_default_enabled() -> bool {
+    true
+}
+fn rate_limit_recovery_default_observe_after_secs() -> u64 {
+    30
+}
+fn rate_limit_recovery_default_recovery_after_secs() -> u64 {
+    60
+}
+fn rate_limit_recovery_default_prompt() -> String {
+    "continue your prior work".to_string()
+}
+fn rate_limit_recovery_default_cooldown_secs() -> u64 {
+    300
+}
+
+impl Default for RateLimitRecoveryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: rate_limit_recovery_default_enabled(),
+            observe_after_secs: rate_limit_recovery_default_observe_after_secs(),
+            recovery_after_secs: rate_limit_recovery_default_recovery_after_secs(),
+            prompt: rate_limit_recovery_default_prompt(),
+            cooldown_secs: rate_limit_recovery_default_cooldown_secs(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -112,6 +112,25 @@ impl AgentState {
         matches!(self, Self::AwaitingOperator | Self::InteractivePrompt)
     }
 
+    /// #841 trigger set for the rate-limit recovery nudge.
+    ///
+    /// Returns `true` for the **transient** error states the daemon
+    /// should try to auto-recover from with a `continue` prompt:
+    /// `ServerRateLimit` (Anthropic-side 5xx / temporary throttle),
+    /// `RateLimit` (generic 429 / throttling — observed on every
+    /// backend), and `ApiError` (provider-validation / transient
+    /// upstream errors observed on OpenCode and others).
+    ///
+    /// Returns `false` for **permanent** errors (`UsageLimit`,
+    /// `AuthError`) — a "continue" nudge cannot resolve a hard quota
+    /// or invalid credentials, and injecting one would just thrash the
+    /// PTY without progress. Fail-closed by exclusion.
+    ///
+    /// C1 RED stub — C2 GREEN fills in the actual classification.
+    pub fn is_transient_error(self) -> bool {
+        unimplemented!("AgentState::is_transient_error — C1 RED stub, C2 GREEN fills in")
+    }
+
     pub fn display_name(self) -> &'static str {
         match self {
             Self::Starting => "starting",

--- a/src/state.rs
+++ b/src/state.rs
@@ -126,9 +126,11 @@ impl AgentState {
     /// or invalid credentials, and injecting one would just thrash the
     /// PTY without progress. Fail-closed by exclusion.
     ///
-    /// C1 RED stub — C2 GREEN fills in the actual classification.
     pub fn is_transient_error(self) -> bool {
-        unimplemented!("AgentState::is_transient_error — C1 RED stub, C2 GREEN fills in")
+        matches!(
+            self,
+            Self::ServerRateLimit | Self::RateLimit | Self::ApiError
+        )
     }
 
     pub fn display_name(self) -> &'static str {


### PR DESCRIPTION
## Summary

- Closes #841 — when an agent hits a transient rate-limit error (e.g. claude-code's `Server is temporarily limiting requests` 5xx, or the generic 429/throttling output every backend emits) and then sits silent at an idle prompt waiting for the next user input, the daemon now detects the post-error stall and injects a single `continue your prior work` nudge over the PTY. Operator no longer has to manually surface "daemon 沒有提醒你繼續，是我主動提醒你" — the supervisor does it automatically after a configurable observe + recovery window.
- **Complementary to existing `process_server_rate_limit_retries`, NOT a replacement.** That fast-retry path (5/15/30s backoff × 3 retries) handles tight transient throttles by re-injecting `last_input_text`. The new sibling fn `process_rate_limit_recovery_nudges` handles the slower failure mode: post-error idle where the fast path either exhausted, transitioned out of `ServerRateLimit` before the first retry fired, or doesn't recognize the error class at all (Kiro / Codex / OpenCode / Gemini all emit different rate-limit strings). The two paths coordinate via the shared `retry_tracks` read — nudge defers when fast-retry is active for the same agent.
- New module surface: `AgentState::is_transient_error()`, `RateLimitRecoveryConfig` (fleet.yaml), `RecoveryNudgeTrack`, `NudgeDecision` + `NudgeSkipReason`, pure `decide_nudge` helper (mirror of `dedup_decision` pattern from Sprint 56 Track G), integration fn `process_rate_limit_recovery_nudges`.

## Architectural decision

Per operator 2026-05-16 「這個要修」authorization (today's `general` was hit by this bug during PR #804 RCA — operator manually surfaced the gap). Phase 1 spike `t-20260516020147858380-6` answered three design questions:

1. **State classifier**: reuse the existing per-backend regex set in `StatePatterns::for_backend` — all 5 backends already classify rate-limit-class errors. Trigger set = `{ServerRateLimit, RateLimit, ApiError}`; permanent errors (`UsageLimit`, `AuthError`) excluded because a `continue` nudge cannot resolve hard quota / invalid credentials.
2. **Inject path**: `compose_aware_send` (raw PTY write with submit_key, bypassing the `[AGEND-MSG]` inbox header). Rationale: avoid polluting the inbox count, avoid the dedup ledger (this is a daemon system nudge, not a from-someone message), and don't clobber `last_input_text` that the fast-retry path depends on. Precedent: `AwaitingOperator` already bypasses inbox via `wants_raw_keystrokes()`.
3. **Fail-closed config**: `fleet.yaml` per-instance `rate_limit_recovery: { enabled, observe_after_secs, recovery_after_secs, prompt, cooldown_secs }` with field-level `#[serde(default)]` so operators override one knob without re-specifying the others. Defaults: `enabled=true, observe_after_secs=30, recovery_after_secs=60, prompt="continue your prior work", cooldown_secs=300`. `None` (field absent) → use the daemon default. Single-shot per recovery cycle (no backoff stairs — one nudge, then if still stalled it's an OTHER problem requiring operator intervention).

## Tier-2 — daemon-core supervisor change

Touches `supervisor::run_loop` (adds one per-tick fn call) + `AgentState` (adds `is_transient_error` query) + `InstanceConfig` (adds optional config field). Single primary reviewer (fixup-reviewer) per established pattern.

## State machine (per-agent track)

```
[no error seen]
      │ state.is_transient_error()
      ▼
[last_error_at=now, recovered_at=None, fired_this_cycle=false]
      │ state ∈ {Ready, Idle}
      ▼
[recovered_at=Some(now)]
      │ now - recovered_at >= recovery_after_secs
      │ AND now - last_inject_at >= cooldown_secs (if any)
      │ AND fast_retry_tracks not contains name
      │ AND config.enabled
      ▼
[Fire — compose_aware_send(cfg.prompt); last_inject_at=Some(now); fired_this_cycle=true]
      │ state leaves {Ready, Idle}
      ▼
[recovered_at=None, fired_this_cycle=false]  ← cycle reset for next sequence
```

`last_error_at` survives state leaving Ready/Idle so a rapid re-error within the stale cap (1 hour past observe window) is still recognized as the same recovery cycle.

## Files

| Path | Change |
| --- | --- |
| `src/state.rs` | `pub fn AgentState::is_transient_error(self) -> bool` returning `matches!(self, ServerRateLimit \| RateLimit \| ApiError)` |
| `src/fleet.rs` | **new** `RateLimitRecoveryConfig` struct + module-level default fns + `InstanceConfig.rate_limit_recovery: Option<RateLimitRecoveryConfig>` field |
| `src/daemon/supervisor.rs` | **new** `RecoveryNudgeTrack`, `NudgeDecision`, `NudgeSkipReason`, `decide_nudge` pure helper, `process_rate_limit_recovery_nudges` integration fn, `run_loop` wire-up |

## Tests (6 new unit tests, all green)

- `nudge_fires_when_all_conditions_met` — happy path (default config, 70s past recovery anchor, no cooldown, no fast-retry)
- `nudge_skipped_when_disabled` — covers both daemon-default and per-instance opt-out
- `nudge_skipped_within_cooldown` — second cycle within 300s suppressed
- `nudge_defers_to_fast_retry` — `fast_retry_active=true` short-circuits before any other gate
- `nudge_skipped_when_no_recent_error` — guards against firing on genuinely idle agents
- `is_transient_error_excludes_permanent_states` — `UsageLimit`/`AuthError` never participate; `ServerRateLimit`/`RateLimit`/`ApiError` do

## Bounds

- `observe_after_secs` (default 30s) — how long after an error the agent must still be in scope for the nudge to consider
- `recovery_after_secs` (default 60s) — additional wait after agent returns to Ready/Idle before the nudge fires
- `cooldown_secs` (default 300s) — minimum gap between consecutive nudges to the same agent
- Stale cap = `observe_after_secs + 3600s` — error observations older than this are treated as no-longer-relevant (covers the "operator came back hours later to a long-idle agent that happens to have an old error in its track" case)
- In-memory only for r0 — daemon restart clears state, which is safe (the fast-retry path's `dedup_state` disk persistence covers the harder restart-window case for the side it owns)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --features tray -- -D warnings`
- [x] `cargo clean -p agend-terminal && cargo test --features tray` (post-#834 lesson — defends against `target/` cache contamination)
- [x] `cargo test --tests --features tray` (catches `tests/*.rs` integration files; covers the `file_size_invariant` binary)
- [x] `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` (CI portability sim)
- [x] 6 new tests in `daemon::supervisor::tests` (5 `decide_nudge` cases + 1 `is_transient_error`)
- [x] `cargo test --features tray --bin agend-terminal` → 2314 passed (6 more than main's 2308 baseline)
- [ ] CI green on ubuntu-latest / macos-latest / windows-latest + LOC overrun + audit

## Backlog follow-ups (from spike report — NOT for r0)

- `process_server_rate_limit_retries` re-injecting `last_input_text` is semantically wrong (forces task restart, not resume). Switch its prompt to the same `cfg.prompt` once #841 ships.
- After the fast-retry path emits `server_rate_limit_exhausted`, chain into the nudge mechanism (one final continue-nudge at +60s) — currently the exhaustion path leaves the agent silent.
- Disk persistence for `recovery_tracks` (mirror #836/#546 patterns) — r0 keeps in-memory only.

## Refs

- Issue: #841
- Phase 1 spike task: `t-20260516020147858380-6`
- Phase 2 IMPL task: `t-20260516020637879277-7`
- Base: origin/main @ `58d3a3d` (#842 idempotent retry merged)

scope follows dispatch spec t-20260516020637879277-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)