### PR TITLE
fix(#846): nudge single-shot regression — drop fired_this_cycle reset on leave-idle

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -339,11 +339,9 @@ pub(crate) fn update_track_for_state(
     } else {
         // Agent left Ready/Idle (responding to nudge, operator typed, …).
         // Reset the recovery-window anchor only; the `fired_this_cycle`
-        // latch persists until a new transient error opens the next cycle.
+        // latch persists until a new transient error opens the next cycle
+        // (the `is_transient_error()` branch above is the sole reset point).
         track.recovered_at = None;
-        // C1 RED: keep the regression here so the new test reproduces.
-        // C2 GREEN removes this line.
-        track.fired_this_cycle = false;
     }
 }
 

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -295,6 +295,58 @@ pub(crate) fn decide_nudge(
     NudgeDecision::Fire
 }
 
+/// Pure helper: apply one tick's worth of state observation to a
+/// per-agent `RecoveryNudgeTrack`. Extracted from
+/// `process_rate_limit_recovery_nudges` so the state-machine
+/// transitions are directly unit-testable without spinning up a
+/// supervisor + registry harness (mirror of the `decide_nudge` /
+/// `dedup_decision` patterns elsewhere in this module).
+///
+/// Three branches:
+///
+/// - **Transient error observed** (`is_transient_error()` true): start
+///   a fresh recovery cycle — stamp `last_error_at = now`, clear the
+///   `recovered_at` anchor, clear the `fired_this_cycle` latch.
+/// - **Agent in Ready/Idle**: stamp `recovered_at` on the first
+///   observation after an error (keep the anchor on subsequent ticks
+///   so `recovery_after_secs` can actually elapse).
+/// - **Agent in any other active state** (Thinking / ToolUse /
+///   InteractivePrompt / etc.): the agent left the recovery window.
+///   Clear `recovered_at` so the recovery-window clock restarts on
+///   the NEXT idle re-entry. **`fired_this_cycle` is NOT touched here**
+///   — once a nudge has fired in this cycle, it stays latched until
+///   a NEW transient error opens the next cycle. (This is the #846
+///   regression fix: prior to the fix, leaving Ready/Idle reset the
+///   latch, so any subsequent idle period past the cooldown could
+///   re-fire — operators saw the nudge re-injecting every ~5–6 min on
+///   normal idle-after-work moments.)
+pub(crate) fn update_track_for_state(
+    track: &mut RecoveryNudgeTrack,
+    state: crate::state::AgentState,
+    now: Instant,
+) {
+    if state.is_transient_error() {
+        track.last_error_at = Some(now);
+        track.recovered_at = None;
+        track.fired_this_cycle = false;
+    } else if matches!(
+        state,
+        crate::state::AgentState::Ready | crate::state::AgentState::Idle
+    ) {
+        if track.last_error_at.is_some() && track.recovered_at.is_none() {
+            track.recovered_at = Some(now);
+        }
+    } else {
+        // Agent left Ready/Idle (responding to nudge, operator typed, …).
+        // Reset the recovery-window anchor only; the `fired_this_cycle`
+        // latch persists until a new transient error opens the next cycle.
+        track.recovered_at = None;
+        // C1 RED: keep the regression here so the new test reproduces.
+        // C2 GREEN removes this line.
+        track.fired_this_cycle = false;
+    }
+}
+
 /// #841 per-tick integration for the recovery-nudge path.
 ///
 /// Phase 1 (registry lock held): observe per-agent state and update
@@ -328,32 +380,7 @@ pub(crate) fn process_rate_limit_recovery_nudges(
         for (name, handle) in reg.iter() {
             let state = handle.core.lock().state.current;
             let track = nudge_tracks.entry(name.clone()).or_default();
-            if state.is_transient_error() {
-                // Restart the cycle — a fresh transient error invalidates any
-                // in-flight recovery wait and any prior `fired_this_cycle` latch.
-                track.last_error_at = Some(now);
-                track.recovered_at = None;
-                track.fired_this_cycle = false;
-            } else if matches!(
-                state,
-                crate::state::AgentState::Ready | crate::state::AgentState::Idle
-            ) {
-                // Only stamp `recovered_at` on the FIRST observation of the
-                // Ready/Idle transition — subsequent ticks keep the same
-                // recovery anchor so the `recovery_after_secs` window can
-                // actually elapse.
-                if track.last_error_at.is_some() && track.recovered_at.is_none() {
-                    track.recovered_at = Some(now);
-                }
-            } else {
-                // Agent transitioned out of Ready/Idle (handler picked up the
-                // nudge, operator typed something, or any other active state).
-                // Reset cycle bookkeeping so the NEXT error→recovery sequence
-                // starts a clean cycle. `last_error_at` is preserved so a
-                // rapid re-error within the stale cap is still recognized.
-                track.recovered_at = None;
-                track.fired_this_cycle = false;
-            }
+            update_track_for_state(track, state, now);
             observed.push((name.clone(), state));
         }
     }
@@ -1651,6 +1678,43 @@ mod tests {
             "no per-instance override → daemon default kicks in (enabled=true)"
         );
         assert_eq!(resolved.observe_after_secs, default_cfg.observe_after_secs);
+    }
+
+    /// #846 regression repro: once a nudge has fired in this cycle,
+    /// the `fired_this_cycle` latch MUST persist when the agent leaves
+    /// and re-enters Ready/Idle (e.g. responds to the nudge, the
+    /// operator types something, an unrelated tool call runs). Prior
+    /// to the fix, the integration fn reset the latch on any "left
+    /// Ready/Idle" tick — so any subsequent idle period past
+    /// `cooldown_secs` (default 300s) could re-fire indefinitely.
+    /// Operators saw the nudge re-injecting every ~5–6 min on routine
+    /// idle moments after a stale rate-limit error sat in the track.
+    ///
+    /// The latch should only reset when a NEW transient error opens
+    /// the next cycle.
+    #[test]
+    fn fired_this_cycle_persists_across_idle_round_trips() {
+        let now = Instant::now();
+        let mut track = RecoveryNudgeTrack {
+            last_error_at: Some(now - Duration::from_secs(100)),
+            recovered_at: Some(now - Duration::from_secs(70)),
+            last_inject_at: Some(now - Duration::from_secs(5)),
+            fired_this_cycle: true,
+        };
+
+        // Tick 1: agent transitions out of Idle (e.g. ToolUse during
+        // its response to the nudge).
+        update_track_for_state(&mut track, AgentState::ToolUse, now);
+        // Tick 2: agent settles back into Idle a few seconds later.
+        let later = now + Duration::from_secs(5);
+        update_track_for_state(&mut track, AgentState::Idle, later);
+
+        assert!(
+            track.fired_this_cycle,
+            "fired_this_cycle must persist across idle round-trips — \
+             single-shot guarantee is broken if this flips back to false \
+             before a new transient error opens the next cycle"
+        );
     }
 
     /// (f) permanent errors excluded: `UsageLimit` and `AuthError` are


### PR DESCRIPTION
## Summary

- Closes #846 — hotfix for a single-shot regression introduced in #841 / PR #844 squash `3209662`. The `rate-limit recovery nudge` re-injected `continue your prior work` indefinitely every ~5–6 min on every active agent whenever a stale transient error sat in their `RecoveryNudgeTrack`. Operator-visible during normal idle-after-work moments — not just genuine rate-limit stalls.
- **One-line behavior fix** in `process_rate_limit_recovery_nudges`'s leave-idle branch: drop the `track.fired_this_cycle = false;` reset. The latch now correctly persists across Ready/Idle round-trips and resets only when a new transient error opens the next cycle.
- Refactor for testability: extract the state-machine logic into a pure `update_track_for_state(track, state, now)` helper, mirroring the `decide_nudge` / `dedup_decision` patterns already in this module.

## Operator-visible severity

`grep "rate-limit recovery" ~/.agend-terminal/app.log` from the live session that surfaced this bug:

```
05:21:45 fixup-lead
05:26:05 fixup-dev / fixup-reviewer
05:28:05 fixup-lead          (= +2.3min after own prev)
05:32:06 fixup-dev / fixup-reviewer
05:34:06 fixup-lead          (= +6min)
05:35:46 general
05:37:06 fixup-reviewer
05:38:06 fixup-dev           (= +6min)
```

4 distinct nudge fires for `fixup-lead` in a single session, plus repeated fires for every other active fixup-team agent. Recursive dogfood: I (fixup-dev) received "continue your prior work" 3× from the daemon while drafting this hotfix.

## Root cause

The integration fn `process_rate_limit_recovery_nudges` resets `fired_this_cycle = false` on every "left Ready/Idle" tick:

```rust
} else {
    // Agent transitioned out of Ready/Idle ...
    track.recovered_at = None;
    track.fired_this_cycle = false;  // ← THE BUG
}
```

Net effect: every time an agent responds to anything (Idle → Thinking → ToolUse → back to Idle), the single-shot latch is cleared. Once Idle ≥ `recovery_after_secs=60s` AND `now - last_inject_at >= cooldown_secs=300s` AND `last_error_at` still within the 1-hour stale cap, `decide_nudge` returns `Fire` again. The cooldown timer alone (5 min) does not stop the re-fire — it just gates the cadence.

The design intent ("single-shot per recovery cycle") was correct, but the implementation treated every idle re-entry as a new cycle. A cycle should be bounded by **error events**, not idle transitions.

## The fix

`fired_this_cycle` now resets in exactly one place: the `is_transient_error()` branch (a fresh transient error opens the next cycle):

```rust
if state.is_transient_error() {
    track.last_error_at = Some(now);
    track.recovered_at = None;
    track.fired_this_cycle = false;  // ← sole reset point
} else if matches!(state, Ready | Idle) {
    if track.last_error_at.is_some() && track.recovered_at.is_none() {
        track.recovered_at = Some(now);
    }
} else {
    track.recovered_at = None;
    // (no fired_this_cycle reset — that's the bug fix)
}
```

Once a nudge fires, the latch stays `true` until a NEW transient error opens the next cycle, regardless of how many idle round-trips the agent goes through.

## Why r0/r1 tests missed this

The 9 r0/r1 tests cover the `decide_nudge` decision gate (which is correct in isolation — given `fired_this_cycle=true` it returns `Skip(FiredThisCycle)`) and the load-error fail-closed gate. None exercised the state-update logic across a Ready/Idle round-trip. C1 pinned that gap with the new `fired_this_cycle_persists_across_idle_round_trips` test and extracted `update_track_for_state` to make the state machine directly unit-testable.

## Tier-2 — daemon-core supervisor change

Surgical fix to supervisor `process_rate_limit_recovery_nudges` (extraction) + behavior fix in `update_track_for_state` else-arm. Single primary reviewer (fixup-reviewer) per established pattern.

## Files

| Path | Change |
| --- | --- |
| `src/daemon/supervisor.rs` | extract `update_track_for_state` pure helper, drop the offending `fired_this_cycle = false` reset, +1 unit test |

## Tests

- All 45 supervisor unit tests pass (44 pre-existing + 1 new regression test).
- New test `fired_this_cycle_persists_across_idle_round_trips`: install track with `fired_this_cycle=true`, call `update_track_for_state(_, ToolUse, _)` then `update_track_for_state(_, Idle, _)`, assert latch stays `true`.
- `cargo test --features tray --bin agend-terminal` → 2318 passed (1 more than r1's 2317).
- `cargo fmt --check` clean; `cargo clippy --all-targets --features tray -- -D warnings` clean.
- Verified RED at C1 (test fails because the offending line is still in the else-arm) → GREEN at C2 (line removed).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --features tray -- -D warnings`
- [x] `cargo clean -p agend-terminal && cargo test --features tray` (post-#834 lesson)
- [x] `cargo test --tests --features tray`
- [x] `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` (CI portability sim)
- [x] 1 new test pinning the regression
- [ ] CI green on ubuntu-latest / macos-latest / windows-latest + LOC overrun + audit

## Refs

- Hotfix issue: #846
- Regression introduced in: #841 / PR #844 squash `3209662`
- Spike report originally proposing the single-shot guarantee (now correctly enforced): task `t-20260516020147858380-6`
- RCA report that motivated this hotfix: `m-20260516053935369821-9`

scope follows dispatch spec t-20260516054025766091-0

🤖 Generated with [Claude Code](https://claude.com/claude-code)