### PR TITLE
docs(#852): §3.19 Reviewer Workspace Discipline (PR-A of 3)

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL.md
+++ b/docs/FLEET-DEV-PROTOCOL.md
@@ -139,6 +139,16 @@ When reviewer's claim contradicts dev's claim (e.g. reviewer "stale wording rema
 
 Lead replies to both with the empirical evidence. Reviewer/dev should self-correct rather than escalate to operator.
 
+### 3.19 Reviewer Workspace Discipline
+Reviewers MUST inspect PRs from their own daemon-bound worktree. Specifically:
+
+- **Never `cd` into the canonical source repo** to inspect a PR. The canonical is the operator's working tree; reviewer activity must not leave detached HEAD or stale refs there.
+- **Never create refs in canonical** (`git checkout -b tmp_pr_review`, `git checkout <sha>`, `git fetch origin pr/N/head:pr_head`, etc.). These leave `pr*_head` / `tmp*` / `review/*` branches behind that pollute `git branch --list` and confuse later operator commands.
+- **Use `gh pr diff <N>` or `gh pr view <N> --json files`** to read PR contents without checkout. If a full tree inspection is needed, `repo action=checkout` MCP tool provisions a fresh daemon-managed worktree at the PR's HEAD; releasing it (`release_worktree`) does not touch canonical.
+- **If canonical state is observed dirty post-review** (detached HEAD, stale `tmp*` / `pr*_head` branches), the reviewer's verdict is REJECTED until the canonical is cleaned (operator action OR `repo action=cleanup_merged_branches` with the `reviewer_checkout` category once L3 lands).
+
+Enforcement: L2 `agend-git` shim refuses `checkout -b` and `checkout <sha>` from agent callers when cwd=canonical (PR-B). L3 sweeper cleans the residue and auto-switches detached canonical HEAD back to main at daemon boot (PR-C).
+
 ## §4. Daemon Enforcement Gates
 
 ### 4.1 Push-time Semantic Gate (Sprint 44)


### PR DESCRIPTION
## Summary

- Refs #852 — **PR-A of 3-PR sequence** (L1 docs / L2 shim / L3 sweeper). PR-C closes the issue. This PR ships the protocol-doc layer that codifies the rule reviewers should already be following.
- Single 10-line addition to `docs/FLEET-DEV-PROTOCOL.md`: new §3.19 Reviewer Workspace Discipline, slotted into the §3.x review-protocol cluster between the existing §3.18 (Audit Conflict Resolution) and §4 (Daemon Enforcement Gates).

## Why now

Operator surfaced the violation twice in a single day:
- **PR #805 morning** — reviewer left canonical in detached HEAD after `git checkout <sha>`.
- **PR #850 afternoon** — reviewer left stale `pr*_head` / `tmp*` branches in canonical after PR inspection.

Operator quotes (verbatim):
- "git 又處在一個未知的 branch 了" (canonical is detached AGAIN)
- "task board 又有殘留了" (residue AGAIN)

The recurrence pattern is the immediate motivation — operator manually cleaned canonical twice today; PR-A documents the rule so reviewers stop creating the mess in the first place.

## The new section

> ### 3.19 Reviewer Workspace Discipline
>
> Reviewers MUST inspect PRs from their own daemon-bound worktree. Specifically:
>
> - **Never `cd` into the canonical source repo** to inspect a PR. The canonical is the operator's working tree; reviewer activity must not leave detached HEAD or stale refs there.
> - **Never create refs in canonical** (`git checkout -b tmp_pr_review`, `git checkout <sha>`, `git fetch origin pr/N/head:pr_head`, etc.). These leave `pr*_head` / `tmp*` / `review/*` branches behind that pollute `git branch --list` and confuse later operator commands.
> - **Use `gh pr diff <N>` or `gh pr view <N> --json files`** to read PR contents without checkout. If a full tree inspection is needed, `repo action=checkout` MCP tool provisions a fresh daemon-managed worktree at the PR's HEAD; releasing it (`release_worktree`) does not touch canonical.
> - **If canonical state is observed dirty post-review** (detached HEAD, stale `tmp*` / `pr*_head` branches), the reviewer's verdict is REJECTED until the canonical is cleaned (operator action OR `repo action=cleanup_merged_branches` with the `reviewer_checkout` category once L3 lands).
>
> Enforcement: L2 `agend-git` shim refuses `checkout -b` and `checkout <sha>` from agent callers when cwd=canonical (PR-B). L3 sweeper cleans the residue and auto-switches detached canonical HEAD back to main at daemon boot (PR-C).

## 3-PR sequence

| Layer | PR | Scope |
| --- | --- | --- |
| **L1 docs (this PR)** | PR-A | §3.19 protocol addition — codifies the rule |
| L2 shim deny | PR-B | `src/bin/agend-git.rs` — add `agent caller + canonical cwd` gate to refuse `checkout -b` / `checkout <sha>` |
| L3 sweeper | PR-C | `src/branch_sweep.rs` `reviewer_checkout` category + `bootstrap/mod.rs` boot-time auto-switch on detached canonical + boot sweep |

PR-A is independent of PR-B/PR-C (docs vs Rust). PR-B prevents future occurrences; PR-C cleans existing residue + ongoing.

## Why docs-only (no §3.16 spike)

Per §3.16 trivially-low-risk exception — single-doc surface change, no Rust touch, no test infrastructure, no behavioral change in the daemon. Spike report for the broader 3-PR architecture lives in task `t-20260516115125948696-5`.

## Test plan

- [x] `cargo fmt --check` (vacuous; no Rust)
- [x] `cargo test --features tray --bin agend-terminal` (sanity — 2327 passed, 0 failed; no behavioral change expected)
- [x] Markdown renders cleanly in standard viewers (bold, inline code, nested list all parse)
- [ ] CI green on ubuntu-latest / macos-latest / windows-latest + LOC overrun + audit

## Refs

- Issue: #852 (PR-C closes; this PR refs)
- Phase 1 spike: `t-20260516115125948696-5`
- Phase 2 IMPL PR-A task: `t-20260516115459082987-6`
- Base: origin/main

scope follows dispatch spec t-20260516115459082987-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)