### PR TITLE
fix(#852): shim deny matrix — agent caller + canonical cwd → Deny (PR-B of 3)

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -246,13 +246,6 @@ fn classify(
     is_agent_caller: bool,
 ) -> Action {
     let bound = is_bound(binding);
-    // C1 RED stub: `is_agent_caller` is threaded through here but the
-    // actual gate inside the checkout-arm `!bound` branch isn't wired
-    // yet — the existing #778 Option-3 leniency still allows agent
-    // checkout in canonical-rooted worktrees. C2 GREEN inserts the
-    // `is_agent_caller && canonical_cwd → Deny` gate before that
-    // leniency, closing #852's reviewer-pollution surface.
-    let _ = is_agent_caller;
 
     match subcmd {
         // Read-only commands: passthrough when unbound, chdir when bound.
@@ -283,6 +276,32 @@ fn classify(
         "checkout" | "switch" => {
             let target_branch = args.get(1).map(|s| s.as_str()).unwrap_or("");
             if !bound {
+                // #852: agent callers must NOT use the #778 Option-3
+                // leniency below. The leniency was designed for the
+                // operator-typed validation-canary flow (operator runs
+                // `repo action=checkout` to provision a worktree in
+                // detached-HEAD, then `git switch <branch>` to land on
+                // the branch; that follow-up needs to pass without a
+                // BYPASS). But the gate wasn't agent-aware, so
+                // reviewer agents whose binding lookup failed for the
+                // canonical-rooted cwd fell through to the same
+                // leniency — and the resulting `git checkout <sha>` /
+                // `git checkout -b tmp_review` calls polluted
+                // canonical's branch list with stale `pr*_head` /
+                // `tmp*` / `review/*` refs. Operator surfaced the
+                // recurrence on PR #805 morning + PR #850 afternoon.
+                // Fix: route agents to either `repo action=checkout
+                // bind=true` (gives them a properly-bound worktree)
+                // or `gh pr diff/view` (read-only). Operator path
+                // unchanged.
+                if is_agent_caller && canonical_cwd {
+                    return Action::Deny(
+                        "agent callers must not checkout in canonical \
+                         (use `repo action=checkout` for PR inspection or \
+                         `gh pr diff/view` for read-only). #852."
+                            .into(),
+                    );
+                }
                 // #778 Option 3: shim leniency for canonical-rooted
                 // unbound worktrees. When cwd is inside a worktree whose
                 // `.git` pointer resolves to a source repo carrying a
@@ -944,7 +963,7 @@ mod tests {
             &["checkout".into(), "-b".into(), "evil".into()],
             &Binding::default(),
             false,
-            true, // canonical_cwd = yes, but arg is a flag
+            true,  // canonical_cwd = yes, but arg is a flag
             false, // is_agent_caller — operator default
         );
         match action {
@@ -987,7 +1006,7 @@ mod tests {
             &["checkout".into(), "feat/p778".into()],
             &binding,
             false,
-            true, // canonical_cwd — should NOT route through leniency
+            true,  // canonical_cwd — should NOT route through leniency
             false, // is_agent_caller — operator default
         );
         match action {
@@ -1021,13 +1040,13 @@ mod tests {
         let action = classify(
             "checkout",
             &["checkout".into(), "abc1234".into()], // SHA — reviewer's
-                                                    // "let me see this
-                                                    // PR's tree" workflow
+            // "let me see this
+            // PR's tree" workflow
             &Binding::default(), // unbound (binding lookup failed for
-                                 // canonical cwd)
-            false,               // parent_is_gh = no
-            true,                // canonical_cwd = yes
-            true,                // is_agent_caller = yes
+            // canonical cwd)
+            false, // parent_is_gh = no
+            true,  // canonical_cwd = yes
+            true,  // is_agent_caller = yes
         );
         match action {
             Action::Deny(reason) => {
@@ -1038,8 +1057,7 @@ mod tests {
                      {reason}"
                 );
                 assert!(
-                    reason.contains("repo action=checkout")
-                        || reason.contains("gh pr diff"),
+                    reason.contains("repo action=checkout") || reason.contains("gh pr diff"),
                     "deny reason must surface the supported alternative \
                      (repo action=checkout MCP or gh pr diff): {reason}"
                 );

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -47,7 +47,21 @@ fn main() {
     // without a real filesystem fixture.
     let canonical_cwd = cwd_is_canonical_worktree();
 
-    match classify(subcommand, &args, &binding, parent_is_gh, canonical_cwd) {
+    // #852: resolve agent-vs-operator caller identity once. Agents are
+    // daemon-spawned subprocesses (AGEND_INSTANCE_NAME set); operators
+    // are interactive shells with no such env. Used by classify's
+    // canonical-checkout gate to prevent reviewer-style PR-inspection
+    // from polluting canonical worktrees with stale refs.
+    let is_agent_caller = env::var_os("AGEND_INSTANCE_NAME").is_some();
+
+    match classify(
+        subcommand,
+        &args,
+        &binding,
+        parent_is_gh,
+        canonical_cwd,
+        is_agent_caller,
+    ) {
         Action::Passthrough => exec_real_git(&args, None),
         Action::ChdirPass(worktree) => exec_real_git(&args, Some(&worktree)),
         Action::SilentExempt {
@@ -229,8 +243,16 @@ fn classify(
     binding: &Binding,
     parent_is_gh: bool,
     canonical_cwd: bool,
+    is_agent_caller: bool,
 ) -> Action {
     let bound = is_bound(binding);
+    // C1 RED stub: `is_agent_caller` is threaded through here but the
+    // actual gate inside the checkout-arm `!bound` branch isn't wired
+    // yet — the existing #778 Option-3 leniency still allows agent
+    // checkout in canonical-rooted worktrees. C2 GREEN inserts the
+    // `is_agent_caller && canonical_cwd → Deny` gate before that
+    // leniency, closing #852's reviewer-pollution surface.
+    let _ = is_agent_caller;
 
     match subcmd {
         // Read-only commands: passthrough when unbound, chdir when bound.
@@ -594,6 +616,8 @@ mod tests {
             &binding,
             true, // parent_is_gh = true
             false,
+            false, // is_agent_caller — operator default; the gh-exemption
+                   // is independent of #852's agent-vs-operator gate
         );
         match action {
             Action::SilentExempt {
@@ -622,6 +646,7 @@ mod tests {
             &binding,
             true,
             false,
+            false, // is_agent_caller — operator default
         );
         assert!(
             matches!(action, Action::SilentExempt { .. }),
@@ -642,6 +667,7 @@ mod tests {
             &binding,
             false, // parent_is_gh = false (interactive shell)
             false,
+            false, // is_agent_caller — operator default
         );
         match action {
             Action::Deny(reason) => {
@@ -671,6 +697,7 @@ mod tests {
             &binding,
             true,
             false,
+            false, // is_agent_caller — operator default
         );
         assert!(matches!(action_gh, Action::SilentExempt { .. }));
         // interactive path → deny
@@ -680,6 +707,7 @@ mod tests {
             &binding,
             false,
             false,
+            false, // is_agent_caller — operator default
         );
         match action_interactive {
             Action::Deny(_) => {}
@@ -702,6 +730,7 @@ mod tests {
             &binding,
             true, // parent_is_gh — but target isn't protected.
             false,
+            false, // is_agent_caller — operator default
         );
         match action {
             Action::Deny(reason) => {
@@ -850,6 +879,9 @@ mod tests {
             &Binding::default(), // unbound
             false,               // parent_is_gh = no
             true,                // canonical_cwd = yes
+            false,               // is_agent_caller — operator default; the
+                                 // #778 leniency must still fire for the
+                                 // operator-driven validation-canary flow
         );
         assert!(
             matches!(action, Action::Passthrough),
@@ -869,6 +901,7 @@ mod tests {
             &Binding::default(),
             false,
             true,
+            false, // is_agent_caller — operator default
         );
         assert!(
             matches!(action, Action::Passthrough),
@@ -888,6 +921,7 @@ mod tests {
             &Binding::default(),
             false,
             false, // canonical_cwd = no
+            false, // is_agent_caller — operator default
         );
         match action {
             Action::Deny(reason) => assert!(
@@ -911,6 +945,7 @@ mod tests {
             &Binding::default(),
             false,
             true, // canonical_cwd = yes, but arg is a flag
+            false, // is_agent_caller — operator default
         );
         match action {
             Action::Deny(reason) => assert!(
@@ -932,6 +967,7 @@ mod tests {
             &Binding::default(),
             false,
             true,
+            false, // is_agent_caller — operator default
         );
         match action {
             Action::Deny(reason) => assert!(reason.contains("unbound"), "got {reason}"),
@@ -952,10 +988,131 @@ mod tests {
             &binding,
             false,
             true, // canonical_cwd — should NOT route through leniency
+            false, // is_agent_caller — operator default
         );
         match action {
             Action::ChdirPass(ref wt) => assert_eq!(wt, "/tmp/.worktrees/dev"),
             other => panic!("bound same-branch must ChdirPass, got {other:?}"),
+        }
+    }
+
+    // ----- #852 PR-B — agent caller + canonical cwd → Deny -----
+    //
+    // The pre-#852 `!bound + canonical_cwd + positional non-flag arg →
+    // Passthrough` leniency was designed for the operator-typed
+    // validation-canary flow (`repo action=checkout` provisions a
+    // worktree in detached-HEAD; operator's natural `git switch
+    // <branch>` follow-up needed to pass). It accidentally also
+    // covered agent callers whose binding lookup failed for the
+    // current cwd — reviewers especially, who inspect PRs via
+    // canonical-rooted worktrees and end up creating `pr*_head` /
+    // `tmp*` / `review/*` refs that pollute the canonical's branch
+    // list. PR-B gates the leniency on agent-vs-operator identity:
+    // operators keep the leniency, agents are routed to the
+    // `repo action=checkout bind=true` MCP tool (which gives them a
+    // properly-bound worktree) or `gh pr diff/view` (read-only).
+
+    /// #852 PR-B core: when caller is an agent (AGEND_INSTANCE_NAME
+    /// set) AND cwd is a canonical-rooted worktree, the leniency must
+    /// NOT fire — checkout is denied with an actionable hint pointing
+    /// to the supported alternatives.
+    #[test]
+    fn shim_denies_agent_checkout_in_canonical() {
+        let action = classify(
+            "checkout",
+            &["checkout".into(), "abc1234".into()], // SHA — reviewer's
+                                                    // "let me see this
+                                                    // PR's tree" workflow
+            &Binding::default(), // unbound (binding lookup failed for
+                                 // canonical cwd)
+            false,               // parent_is_gh = no
+            true,                // canonical_cwd = yes
+            true,                // is_agent_caller = yes
+        );
+        match action {
+            Action::Deny(reason) => {
+                assert!(
+                    reason.contains("agent"),
+                    "deny reason must explicitly call out the agent-caller \
+                     identity so reviewers see WHY their workflow is rejected: \
+                     {reason}"
+                );
+                assert!(
+                    reason.contains("repo action=checkout")
+                        || reason.contains("gh pr diff"),
+                    "deny reason must surface the supported alternative \
+                     (repo action=checkout MCP or gh pr diff): {reason}"
+                );
+                assert!(
+                    reason.contains("#852"),
+                    "deny reason should reference the issue for operator \
+                     traceability: {reason}"
+                );
+            }
+            other => panic!(
+                "agent caller in canonical worktree must Deny, not {other:?} \
+                 — that's the reviewer-pollution bug fix"
+            ),
+        }
+    }
+
+    /// #852 PR-B operator preservation: when caller is NOT an agent
+    /// (operator's interactive shell, no AGEND_INSTANCE_NAME), the
+    /// existing #778 leniency must continue to fire — the validation-
+    /// canary flow must not regress.
+    #[test]
+    fn shim_allows_operator_checkout_in_canonical() {
+        let action = classify(
+            "checkout",
+            &["checkout".into(), "feat/canary".into()],
+            &Binding::default(),
+            false, // parent_is_gh = no
+            true,  // canonical_cwd = yes
+            false, // is_agent_caller = no (operator shell)
+        );
+        assert!(
+            matches!(action, Action::Passthrough),
+            "operator in canonical worktree must keep the #778 leniency, \
+             got {action:?}"
+        );
+    }
+
+    /// #852 PR-B narrowness check: when the agent IS a caller but cwd
+    /// is NOT canonical (e.g. agent invoked git from a non-worktree
+    /// path), the gate must NOT fire — only the canonical-pollution
+    /// surface is targeted. Operator's `unbound + non-canonical →
+    /// Deny` outcome is preserved (different code path).
+    #[test]
+    fn shim_agent_outside_canonical_unchanged() {
+        let action = classify(
+            "checkout",
+            &["checkout".into(), "feat/x".into()],
+            &Binding::default(),
+            false, // parent_is_gh = no
+            false, // canonical_cwd = NO — gate must NOT fire
+            true,  // is_agent_caller = yes
+        );
+        // Falls through to the existing `unbound — no active task
+        // assignment` Deny (different from the new #852 Deny). The
+        // pre-existing safety net stays intact.
+        match action {
+            Action::Deny(reason) => {
+                assert!(
+                    reason.contains("unbound"),
+                    "non-canonical agent path must keep the original \
+                     unbound deny (not the new #852 agent-canonical deny): \
+                     {reason}"
+                );
+                assert!(
+                    !reason.contains("#852"),
+                    "non-canonical agent path must NOT trigger the #852 \
+                     gate (gate is narrow by design): {reason}"
+                );
+            }
+            other => panic!(
+                "non-canonical unbound must keep the pre-existing deny, \
+                 got {other:?}"
+            ),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Refs #852 — **PR-B of 3-PR sequence** (L1 docs / **L2 shim** / L3 sweeper). PR-A merged at `988affe` (§3.19 protocol section). PR-C (L3 sweeper) closes the issue. This PR adds the shim enforcement that backs the §3.19 doctrine: reviewer agents inspecting PRs can no longer pollute canonical with stale refs.
- **Single-condition gate** in `src/bin/agend-git.rs::classify`: when caller is an agent (`AGEND_INSTANCE_NAME` set) AND cwd is a canonical-rooted worktree, `checkout` / `switch` returns `Deny` with an actionable error pointing to `repo action=checkout` MCP (full tree inspection in a fresh bound worktree) or `gh pr diff/view` (read-only).
- Operator path preserved — operator's interactive shell has no `AGEND_INSTANCE_NAME`, so the existing #778 Option-3 leniency continues to fire for the validation-canary workflow.

## Why this closes the bug

Reviewer agents inspecting PRs would `cd` into a canonical-rooted worktree (or one sharing canonical's `.git/refs/`), then run `git checkout <sha>` or `git checkout -b tmp_pr_review`. Their `binding.json` lookup typically failed for the cwd (the binding is keyed on the agent's assigned worktree, not the inspected one), so they fell into the `!bound` branch. The #778 Option-3 leniency below was designed for **operator-typed** checkouts but didn't gate on caller identity, so the agent's `<sha>` arg (positional, non-flag, in a canonical-rooted worktree) passed straight through. Result: stale `pr*_head` / `tmp*` / `review/*` refs polluting canonical's branch list.

Operator surfaced this twice today:
- **PR #805 morning** — reviewer left canonical in detached HEAD after `git checkout <sha>`.
- **PR #850 afternoon** — reviewer left stale `pr*_head` / `tmp*` branches in canonical.

Operator quotes:
- "git 又處在一個未知的 branch 了" (canonical is detached AGAIN)
- "task board 又有殘留了" (residue AGAIN)

PR-A documented the rule reviewers should follow. PR-B enforces it at the shim layer.

## The gate

```rust
"checkout" | "switch" => {
    let target_branch = args.get(1).map(|s| s.as_str()).unwrap_or("");
    if !bound {
        // #852: agent callers must NOT use the #778 Option-3 leniency below.
        if is_agent_caller && canonical_cwd {
            return Action::Deny(
                "agent callers must not checkout in canonical \
                 (use `repo action=checkout` for PR inspection or \
                 `gh pr diff/view` for read-only). #852."
                    .into(),
            );
        }
        // existing #778 Option-3 leniency follows, unchanged
        if !target_branch.is_empty() && !target_branch.starts_with('-') && canonical_cwd {
            return Action::Passthrough;
        }
        return Action::Deny("unbound — no active task assignment".into());
    }
    // ... bound-path cross-branch fence unchanged
}
```

Order matters: the new gate fires **BEFORE** the Option-3 leniency. Explicit deny trumps inherited leniency.

## Narrowness

The gate fires only when BOTH conditions hold:
- `is_agent_caller == true` — `AGEND_INSTANCE_NAME` env is set (daemon-spawned subprocess).
- `canonical_cwd == true` — cwd is a daemon-managed worktree whose `.git` resolves to a repo with `[remote "origin"]`.

Operator interactive shell (no env) → gate skipped → existing leniency fires. Agent in non-canonical cwd → gate skipped → existing `unbound` deny fires (different code path, same outcome — checkout denied). Agent in canonical cwd → **NEW Deny with actionable hint**.

`AGEND_GIT_BYPASS=1` / `AGEND_GIT_BYPASS_AGENT=<name>` / `AGEND_GIT_BYPASS_UNTIL=<epoch>` emergency overrides remain functional (they bypass the entire shim before classify is even called).

## Files

| Path | Change |
| --- | --- |
| `src/bin/agend-git.rs` | `classify` gains 6th param `is_agent_caller: bool`; new gate inside checkout-arm `!bound` branch BEFORE the #778 Option-3 leniency; all 12 pre-existing `classify(...)` test call sites updated to pass `is_agent_caller=false` (operator default); 3 new unit tests |

## Tests (3 new in `src/bin/agend-git.rs::mod tests`)

- `shim_denies_agent_checkout_in_canonical` — the core gate. Agent caller + canonical cwd + `checkout <sha>` → Deny with explicit "agent" + `repo action=checkout` / `gh pr diff` hint + `#852` issue tag.
- `shim_allows_operator_checkout_in_canonical` — operator preservation. No `AGEND_INSTANCE_NAME` + canonical cwd + `checkout <branch>` → keeps the #778 Passthrough leniency.
- `shim_agent_outside_canonical_unchanged` — narrowness contract. Agent caller + non-canonical cwd → keeps the pre-existing `unbound` deny (different code path), must NOT trigger the new #852 deny.

15 pre-existing shim tests continue to pass (12 call-site updates to pass `is_agent_caller=false`).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --features tray -- -D warnings`
- [x] `cargo clean -p agend-terminal && cargo test --features tray` (post-#834 lesson)
- [x] `cargo test --tests --features tray`
- [x] `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` (CI portability sim)
- [x] `cargo test --features tray --bin agend-terminal` → 2327 passed (no regression)
- [x] `cargo test --features tray --bin agend-git` → 18 passed (15 pre-existing + 3 new #852 tests)
- [ ] CI green on ubuntu-latest / macos-latest / windows-latest + LOC overrun + audit

## Refs

- Issue: #852 (PR-C closes; PR-B refs)
- PR-A: `988affe` (§3.19 docs)
- Phase 1 spike: `t-20260516115125948696-5`
- PR-B IMPL task: `t-20260516121156280870-8`
- Base: origin/main `988affe` (PR-A merge)

scope follows dispatch spec t-20260516121156280870-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)