### PR TITLE
fix(#852): sweeper enhancement — reviewer_checkout bucket + canonical hygiene boot hook (PR-C of 3)

### DIFF
--- a/src/bootstrap/canonical_hygiene.rs
+++ b/src/bootstrap/canonical_hygiene.rs
@@ -45,27 +45,152 @@ pub enum CanonicalAction {
     WarnDirtyDetached,
 }
 
-/// Pure helper: classify the canonical's HEAD state from
-/// `git rev-parse --abbrev-ref HEAD` output + a working-tree-clean
-/// boolean. Caller is responsible for shelling out to git and
-/// passing the trimmed outputs.
+/// Boot-time hygiene entry — discover distinct canonical repos from
+/// `config.instances[*].source_repo` and apply [`apply_to_canonical`]
+/// to each. Best-effort: any per-canonical failure is logged and
+/// skipped (boot must never fail because hygiene couldn't shell out
+/// to git).
+pub(crate) fn run_at_boot(config: &crate::fleet::FleetConfig) {
+    let mut seen = std::collections::HashSet::<std::path::PathBuf>::new();
+    for (name, instance) in &config.instances {
+        let Some(source_repo) = instance.source_repo.as_ref() else {
+            continue;
+        };
+        let path = std::path::PathBuf::from(source_repo);
+        if !seen.insert(path.clone()) {
+            continue;
+        }
+        if !path.is_dir() {
+            tracing::debug!(
+                instance = %name,
+                source_repo = %path.display(),
+                "#852 canonical hygiene: source_repo not a directory, skipping"
+            );
+            continue;
+        }
+        apply_to_canonical(&path);
+    }
+}
+
+/// Run the canonical-hygiene decision against a single canonical
+/// repo path. Shells out to git twice (rev-parse and status), calls
+/// [`decide_canonical_action`], and dispatches by variant: NoOp is
+/// silent, SwitchToDefault runs `git switch main` plus info log,
+/// WarnDirtyDetached emits a warn log only (no git mutation).
 ///
-/// `head_state`:
-/// - `"HEAD"` (literal) → detached
-/// - `"main"` / `"master"` → on default branch
-/// - any other non-empty string → on some other normal branch
-/// - empty string → treat as detached (defensive — `rev-parse`
-///   should never emit empty stdout but guard fail-closed)
+/// Best-effort: subprocess failures log a debug line and return; the
+/// daemon boot continues regardless.
+pub(crate) fn apply_to_canonical(canonical: &std::path::Path) {
+    let head_state = match git_capture(canonical, &["rev-parse", "--abbrev-ref", "HEAD"]) {
+        Some(s) => s,
+        None => return,
+    };
+    let status = match git_capture(canonical, &["status", "--porcelain"]) {
+        Some(s) => s,
+        None => return,
+    };
+    let working_tree_clean = status.is_empty();
+    match decide_canonical_action(&head_state, working_tree_clean) {
+        CanonicalAction::NoOp => {}
+        CanonicalAction::SwitchToDefault => {
+            let switch_result = std::process::Command::new("git")
+                .args([
+                    "-C",
+                    &canonical.display().to_string(),
+                    "switch",
+                    DEFAULT_BRANCH,
+                ])
+                .env("AGEND_GIT_BYPASS", "1")
+                .output();
+            match switch_result {
+                Ok(out) if out.status.success() => {
+                    tracing::info!(
+                        canonical = %canonical.display(),
+                        "#852 canonical hygiene: detached HEAD on clean tree, auto-switched to {DEFAULT_BRANCH}"
+                    );
+                }
+                Ok(out) => {
+                    tracing::warn!(
+                        canonical = %canonical.display(),
+                        stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                        "#852 canonical hygiene: git switch {DEFAULT_BRANCH} failed"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        canonical = %canonical.display(),
+                        error = %e,
+                        "#852 canonical hygiene: git switch spawn failed"
+                    );
+                }
+            }
+        }
+        CanonicalAction::WarnDirtyDetached => {
+            tracing::warn!(
+                canonical = %canonical.display(),
+                "#852 canonical hygiene: detached HEAD with dirty working tree — \
+                 NOT auto-switching (operator WIP protection). Run `git switch \
+                 {DEFAULT_BRANCH}` manually after committing/stashing changes."
+            );
+        }
+    }
+}
+
+/// Pure helper: shell out to git with `AGEND_GIT_BYPASS=1` (so we
+/// bypass the shim's restrictions on boot), capture trimmed stdout
+/// on success. Returns `None` on spawn failure or non-zero exit.
+fn git_capture(repo: &std::path::Path, args: &[&str]) -> Option<String> {
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C").arg(repo).args(args);
+    cmd.env("AGEND_GIT_BYPASS", "1");
+    let out = match cmd.output() {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::debug!(
+                repo = %repo.display(),
+                error = %e,
+                "#852 canonical hygiene: git spawn failed"
+            );
+            return None;
+        }
+    };
+    if !out.status.success() {
+        tracing::debug!(
+            repo = %repo.display(),
+            stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+            "#852 canonical hygiene: git command failed"
+        );
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Classification table:
 ///
-/// `working_tree_clean`: true iff `git status --porcelain` produced
-/// no output. The caller is expected to compute this once at boot.
+/// | head_state | working_tree_clean | action               |
+/// | ---------- | ------------------ | -------------------- |
+/// | `"HEAD"`   | true               | `SwitchToDefault`    |
+/// | `"HEAD"`   | false              | `WarnDirtyDetached`  |
+/// | `""`       | true               | `SwitchToDefault`    |
+/// | `""`       | false              | `WarnDirtyDetached`  |
+/// | anything   | any                | `NoOp`               |
+///   else                            |                      |
 ///
-/// C1 RED stub — returns `NoOp` unconditionally so the new tests
-/// asserting `SwitchToDefault` / `WarnDirtyDetached` fail. C2 GREEN
-/// fills in the actual classification table.
+/// Empty `head_state` is treated as detached defensively — `git
+/// rev-parse --abbrev-ref HEAD` should never produce empty stdout
+/// but if it does, fail-closed by routing through the detached
+/// branches (with the dirty-tree warn protecting against any
+/// silent state change on weird repo states).
 pub fn decide_canonical_action(head_state: &str, working_tree_clean: bool) -> CanonicalAction {
-    let _ = (head_state, working_tree_clean);
-    CanonicalAction::NoOp
+    let detached = head_state == "HEAD" || head_state.is_empty();
+    if !detached {
+        return CanonicalAction::NoOp;
+    }
+    if working_tree_clean {
+        CanonicalAction::SwitchToDefault
+    } else {
+        CanonicalAction::WarnDirtyDetached
+    }
 }
 
 #[cfg(test)]

--- a/src/bootstrap/canonical_hygiene.rs
+++ b/src/bootstrap/canonical_hygiene.rs
@@ -1,0 +1,153 @@
+//! #852 PR-C: boot-time canonical-repo hygiene.
+//!
+//! When the daemon comes up, the canonical source repo might have
+//! been left in an unhealthy state by a previous fleet session
+//! (e.g. reviewer agent's `git checkout <sha>` left HEAD detached;
+//! see PR-A §3.19 protocol + PR-B shim enforcement). This module
+//! decides whether to auto-switch the canonical's HEAD back to the
+//! default branch ("main") so subsequent operator commands aren't
+//! surprised.
+//!
+//! Decision matrix (pure helper [`decide_canonical_action`]):
+//!
+//! | head state              | working tree | action               |
+//! | ----------------------- | ------------ | -------------------- |
+//! | already on default      | any          | `NoOp`               |
+//! | detached + clean        | clean        | `SwitchToDefault`    |
+//! | detached + dirty        | dirty        | `WarnDirtyDetached`  |
+//! | normal branch (non-def) | any          | `NoOp`               |
+//!
+//! `WarnDirtyDetached` is intentionally NOT auto-resolved — operator
+//! might be mid-bisect or have legitimate WIP in a detached state,
+//! and silently switching would clobber that work. The boot log
+//! surfaces the warning so the operator can clean up manually.
+
+/// The default branch the canonical-hygiene helper switches TO when
+/// it auto-resolves a detached-HEAD state. Mirror of the protected-
+/// refs convention used by `agend-git` shim's `is_protected_ref`.
+pub const DEFAULT_BRANCH: &str = "main";
+
+/// Possible actions for the canonical's HEAD state at boot.
+/// Returned by [`decide_canonical_action`] as a pure value; the
+/// integration fn dispatches based on the variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CanonicalAction {
+    /// HEAD is on a normal branch (default or otherwise) — nothing
+    /// to do. Most-common path on boot.
+    NoOp,
+    /// HEAD is detached AND the working tree is clean. Safe to
+    /// `git switch main` so subsequent operator commands land on the
+    /// expected branch.
+    SwitchToDefault,
+    /// HEAD is detached BUT the working tree has uncommitted changes.
+    /// Operator might be mid-bisect / mid-cherry-pick / have
+    /// legitimate WIP. Log a warning and leave alone.
+    WarnDirtyDetached,
+}
+
+/// Pure helper: classify the canonical's HEAD state from
+/// `git rev-parse --abbrev-ref HEAD` output + a working-tree-clean
+/// boolean. Caller is responsible for shelling out to git and
+/// passing the trimmed outputs.
+///
+/// `head_state`:
+/// - `"HEAD"` (literal) → detached
+/// - `"main"` / `"master"` → on default branch
+/// - any other non-empty string → on some other normal branch
+/// - empty string → treat as detached (defensive — `rev-parse`
+///   should never emit empty stdout but guard fail-closed)
+///
+/// `working_tree_clean`: true iff `git status --porcelain` produced
+/// no output. The caller is expected to compute this once at boot.
+///
+/// C1 RED stub — returns `NoOp` unconditionally so the new tests
+/// asserting `SwitchToDefault` / `WarnDirtyDetached` fail. C2 GREEN
+/// fills in the actual classification table.
+pub fn decide_canonical_action(head_state: &str, working_tree_clean: bool) -> CanonicalAction {
+    let _ = (head_state, working_tree_clean);
+    CanonicalAction::NoOp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Most-common boot path: HEAD is on `main`. No-op regardless of
+    /// working-tree state (operator might have WIP that's expected).
+    #[test]
+    fn boot_no_op_when_canonical_on_main() {
+        assert_eq!(
+            decide_canonical_action("main", true),
+            CanonicalAction::NoOp,
+            "HEAD on main + clean → no-op"
+        );
+        assert_eq!(
+            decide_canonical_action("main", false),
+            CanonicalAction::NoOp,
+            "HEAD on main + dirty → no-op (operator WIP is not our concern)"
+        );
+    }
+
+    /// HEAD detached AND working tree clean → safe to auto-switch.
+    /// This is the symptom that reviewer agents historically caused
+    /// (PR-A §3.19 / PR-B shim enforcement context).
+    #[test]
+    fn boot_auto_switch_when_detached_and_clean() {
+        assert_eq!(
+            decide_canonical_action("HEAD", true),
+            CanonicalAction::SwitchToDefault,
+            "detached HEAD + clean tree → SwitchToDefault is safe and \
+             closes the operator-visible 'git 又處在一個未知的 branch 了' \
+             surface"
+        );
+    }
+
+    /// HEAD detached BUT working tree dirty → warn and leave alone.
+    /// Operator might be mid-bisect / mid-cherry-pick / have
+    /// legitimate WIP. Silent auto-switch would clobber that work.
+    #[test]
+    fn boot_skips_auto_switch_when_detached_and_dirty() {
+        assert_eq!(
+            decide_canonical_action("HEAD", false),
+            CanonicalAction::WarnDirtyDetached,
+            "detached HEAD + dirty tree → warn only, never auto-switch \
+             (operator WIP protection)"
+        );
+    }
+
+    /// HEAD on a non-default normal branch (e.g. operator was on a
+    /// feature branch when the daemon started). No-op — daemon
+    /// shouldn't reorganize the operator's working state.
+    #[test]
+    fn boot_no_op_on_feature_branch() {
+        assert_eq!(
+            decide_canonical_action("feat/some-work", true),
+            CanonicalAction::NoOp,
+            "HEAD on feature branch → no-op (operator's choice of branch \
+             must not be overridden by daemon hygiene)"
+        );
+        assert_eq!(
+            decide_canonical_action("feat/some-work", false),
+            CanonicalAction::NoOp,
+            "HEAD on feature branch + dirty → no-op (daemon never \
+             touches non-detached HEADs)"
+        );
+    }
+
+    /// Defensive: empty string from `rev-parse` is unexpected but
+    /// guard fail-closed — treat as detached. If working tree is
+    /// also dirty, warn rather than auto-switch.
+    #[test]
+    fn boot_treats_empty_rev_parse_as_detached() {
+        assert_eq!(
+            decide_canonical_action("", true),
+            CanonicalAction::SwitchToDefault,
+            "empty rev-parse + clean → treat as detached (defensive)"
+        );
+        assert_eq!(
+            decide_canonical_action("", false),
+            CanonicalAction::WarnDirtyDetached,
+            "empty rev-parse + dirty → warn (defensive)"
+        );
+    }
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -13,6 +13,7 @@
 //!   The current process is a client and should not touch run dir ownership.
 
 mod agent_resolve;
+pub(crate) mod canonical_hygiene;
 pub mod daemon_spawn;
 pub(crate) mod doctor;
 pub(crate) mod doctor_topics;

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -187,6 +187,13 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     crate::binding::symlink_shim(home);
     crate::binding::reconcile_orphans(home);
     crate::worktree_pool::reconcile_orphan_leases(home);
+    // #852 PR-C: canonical-repo hygiene. Scan distinct source_repo
+    // values from fleet.yaml; for each canonical, auto-switch
+    // detached HEAD back to main if the working tree is clean, or
+    // warn-log if dirty (operator WIP protection). Pure observation
+    // beyond the single `git switch main` mutation when conditions
+    // are right. Best-effort — boot continues regardless.
+    canonical_hygiene::run_at_boot(&config);
     // #829: boot-time orphan-owner sweep. Auto-applies for owners
     // verifiably gone (∉ fleet.yaml ∧ ∉ live registry); dry-run +
     // tracing::warn for the softer "∈ fleet.yaml ∧ ∉ live" case.

--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -63,20 +63,32 @@ pub(crate) struct Categories {
     pub squash_merged: Vec<Candidate>,
     pub stale_idle: Vec<Candidate>,
     pub active_unknown: Vec<Candidate>,
+    /// #852 PR-C: reviewer-checkout residue. Naming patterns
+    /// `tmp.*` / `pr\d+_head` / `review/.*` that historically
+    /// accumulated when reviewer agents `cd canonical && git
+    /// checkout <sha>` (the bug PR-A documented and PR-B
+    /// enforced at the shim). These branches have no legitimate
+    /// purpose and land in the default delete list — but the
+    /// daemon boot sweep is dry-run-only for r0 so operator can
+    /// validate the regex against their real residue before any
+    /// destructive action.
+    pub reviewer_checkout: Vec<Candidate>,
 }
 
 #[allow(dead_code)]
 impl Categories {
     /// Concatenated sorted list of all candidate branch names across
-    /// the 3 deletable buckets (clean_merged + squash_merged +
-    /// stale_idle). `active_unknown` is NOT in this default list —
-    /// the operator must explicitly pick those IDs by their bucket.
+    /// the deletable buckets (clean_merged + squash_merged +
+    /// stale_idle + #852 PR-C reviewer_checkout). `active_unknown` is
+    /// NOT in this default list — the operator must explicitly pick
+    /// those IDs by their bucket.
     pub fn deletable_ids(&self) -> Vec<String> {
         let mut v: Vec<String> = self
             .clean_merged
             .iter()
             .chain(self.squash_merged.iter())
             .chain(self.stale_idle.iter())
+            .chain(self.reviewer_checkout.iter())
             .map(|c| c.name.clone())
             .collect();
         v.sort();
@@ -94,6 +106,7 @@ impl Categories {
             .iter()
             .chain(self.squash_merged.iter())
             .chain(self.stale_idle.iter())
+            .chain(self.reviewer_checkout.iter())
             .chain(self.active_unknown.iter())
             .map(|c| c.name.clone())
             .collect();
@@ -205,6 +218,20 @@ fn is_squash_merged(repo: &Path, base: &str, branch: &str) -> bool {
 /// flaky around day boundaries. Dead-code allow lifts at C3 when
 /// the MCP handler wires the call site.
 #[allow(dead_code)]
+/// #852 PR-C: classify reviewer-checkout residue by name. Pattern
+/// covers the three observed pollution shapes:
+/// - `tmp.*` — operator's `tmp_pr_review` / `tmp/abc1234` style
+/// - `pr\d+_head` — `gh pr fetch`-style `pr123_head` refs
+/// - `review/.*` — explicit `review/<n>` namespace
+///
+/// First-match wins. Conservative — empty / `main` / `master` /
+/// genuine branch prefixes never match. C1 RED stub returns false
+/// unconditionally; C2 GREEN wires the regex.
+pub(crate) fn is_reviewer_checkout(name: &str) -> bool {
+    let _ = name;
+    false
+}
+
 pub(crate) fn scan(
     repo: &Path,
     base: &str,
@@ -215,6 +242,19 @@ pub(crate) fn scan(
     let mut cats = Categories::default();
     for b in &branches {
         if b.name == base {
+            continue;
+        }
+        // 0. reviewer_checkout (#852 PR-C) — naming-pattern residue.
+        // Checked FIRST so reviewer-pollution branches that happen to
+        // also satisfy clean_merged / squash_merged conditions still
+        // surface in the dedicated bucket (operator can audit them
+        // separately from the regular merge-based categories).
+        if is_reviewer_checkout(&b.name) {
+            cats.reviewer_checkout.push(Candidate {
+                name: b.name.clone(),
+                tip_sha: b.tip_sha.clone(),
+                reason: "reviewer-checkout residue (tmp.* / pr*_head / review/*)".to_string(),
+            });
             continue;
         }
         // 1. clean_merged — reachable from base via merge commit.
@@ -351,6 +391,94 @@ pub(crate) fn emit_delete_batch(
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    // ── #852 PR-C — reviewer_checkout pattern unit tests ──────────────
+
+    /// `tmp_pr_review` / `tmp/abc1234` / `tmp-merge` — the operator-
+    /// created scratch branches that show up after `cd canonical &&
+    /// git checkout -b tmp_<...>`. Must classify as reviewer_checkout.
+    #[test]
+    fn reviewer_checkout_pattern_matches_tmp_prefix() {
+        assert!(
+            is_reviewer_checkout("tmp_pr_review"),
+            "`tmp_pr_review` must match"
+        );
+        assert!(
+            is_reviewer_checkout("tmp/abc1234"),
+            "`tmp/abc1234` must match (slash-separated tmp branch)"
+        );
+        assert!(
+            is_reviewer_checkout("tmp-merge"),
+            "`tmp-merge` must match (hyphen variant)"
+        );
+        assert!(is_reviewer_checkout("tmp"), "bare `tmp` must match");
+    }
+
+    /// `pr<N>_head` — the `gh pr fetch` / manual `git fetch origin
+    /// refs/pull/<N>/head:pr<N>_head` style. Common operator-typed
+    /// pattern when inspecting a PR locally. Must classify as
+    /// reviewer_checkout.
+    #[test]
+    fn reviewer_checkout_pattern_matches_pr_head_suffix() {
+        assert!(
+            is_reviewer_checkout("pr123_head"),
+            "`pr123_head` must match"
+        );
+        assert!(
+            is_reviewer_checkout("pr850_head"),
+            "`pr850_head` must match (real example from operator's report)"
+        );
+        assert!(
+            is_reviewer_checkout("pr1_head"),
+            "single-digit pr1_head must match"
+        );
+    }
+
+    /// `review/.*` — explicit `review/<n>` namespace. Some workflows
+    /// adopt this prefix for inspection refs.
+    #[test]
+    fn reviewer_checkout_pattern_matches_review_prefix() {
+        assert!(
+            is_reviewer_checkout("review/123"),
+            "`review/123` must match"
+        );
+        assert!(
+            is_reviewer_checkout("review/feat-x"),
+            "`review/feat-x` must match"
+        );
+    }
+
+    /// **CRITICAL** negative: legitimate working branch names must NOT
+    /// match. The pattern is narrow by design — only the three
+    /// observed pollution shapes. A false-positive here would have
+    /// the boot sweeper auto-deleting legitimate work.
+    #[test]
+    fn reviewer_checkout_pattern_does_not_match_main_or_fix_branches() {
+        assert!(!is_reviewer_checkout("main"), "main must NOT match");
+        assert!(!is_reviewer_checkout("master"), "master must NOT match");
+        assert!(
+            !is_reviewer_checkout("fix/123-real-work"),
+            "fix/.* (legitimate fix branch) must NOT match"
+        );
+        assert!(
+            !is_reviewer_checkout("feat/some-feature"),
+            "feat/.* must NOT match"
+        );
+        assert!(
+            !is_reviewer_checkout("temporary-work"),
+            "`temporary-work` must NOT match — only `tmp.*` (3-letter \
+             prefix) qualifies, not arbitrary 'temp' variants"
+        );
+        assert!(
+            !is_reviewer_checkout("pr-merge-queue"),
+            "`pr-merge-queue` must NOT match — pattern requires \
+             `pr\\d+_head` shape specifically"
+        );
+        assert!(
+            !is_reviewer_checkout(""),
+            "empty string must NOT match (defensive)"
+        );
+    }
 
     /// Spawn a temp git repo scoped to `tag`. The repo has an initial
     /// commit on `main` + pinned per-repo gitconfig (`user.name`/

--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -225,11 +225,20 @@ fn is_squash_merged(repo: &Path, base: &str, branch: &str) -> bool {
 /// - `review/.*` — explicit `review/<n>` namespace
 ///
 /// First-match wins. Conservative — empty / `main` / `master` /
-/// genuine branch prefixes never match. C1 RED stub returns false
-/// unconditionally; C2 GREEN wires the regex.
+/// genuine branch prefixes never match. Uses an inline anchored
+/// regex (`^` anchor explicit, full-string `is_match` semantics on
+/// the regex crate) so prefix-match-only is the contract.
 pub(crate) fn is_reviewer_checkout(name: &str) -> bool {
-    let _ = name;
-    false
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    // SAFETY: regex literal is compile-time-validated by the test
+    // suite (the pattern's anchor + alternations are exercised by
+    // the four `reviewer_checkout_pattern_*` unit tests). `.unwrap`
+    // here is the established crate convention for build-time
+    // patterns (see `state.rs::StatePatterns::for_backend`).
+    #[allow(clippy::unwrap_used)]
+    let re = RE.get_or_init(|| regex::Regex::new(r"^(tmp.*|pr\d+_head|review/.*)$").unwrap());
+    re.is_match(name)
 }
 
 pub(crate) fn scan(


### PR DESCRIPTION
## Summary

- **Closes #852** — PR-C of 3-PR sequence. PR-A `988affe` (§3.19 docs) + PR-B `37d8a81` (shim enforcement) prevent FUTURE pollution; PR-C cleans EXISTING residue and adds boot-time canonical hygiene.
- Two surgically scoped additions:
  - **`reviewer_checkout` category** in `src/branch_sweep.rs::Categories` — naming-pattern bucket for `tmp.*` / `pr\d+_head` / `review/.*` residue, classified before the merge-based buckets so operator can audit them separately. Added to default `deletable_ids` per spike Q3.
  - **Boot-time canonical hygiene** in `src/bootstrap/canonical_hygiene.rs` (NEW module) — discovers distinct `source_repo` paths from fleet.yaml, auto-switches detached HEAD back to `main` when the working tree is clean, warn-logs when dirty (operator WIP protection).

## Why this closes the bug

PR-A documented the rule; PR-B enforced it at the shim. But existing canonical residue (`pr*_head` / `tmp*` / `review/*` branches + detached HEAD) was left from sessions BEFORE PR-A/PR-B landed — operator surfaced both symptoms on PR #805 morning + PR #850 afternoon:
- "git 又處在一個未知的 branch 了" — canonical detached
- "task board 又有殘留了" — stale branches

PR-C provides the cleanup tooling and the boot-time auto-recovery for the detached-HEAD case.

## Layer 1: `reviewer_checkout` bucket

`Categories` gains a 5th field `reviewer_checkout: Vec<Candidate>`. The classifier `is_reviewer_checkout(name: &str)` matches `^(tmp.*|pr\d+_head|review/.*)$` (OnceLock-cached regex; same pattern as `state.rs::StatePatterns::for_backend`).

`scan()` checks `is_reviewer_checkout` FIRST (priority 0, before `clean_merged`). Rationale: reviewer-pollution branches that happen to also satisfy clean_merged / squash_merged conditions surface in the dedicated bucket so the operator can audit them separately from the regular merge-based categories.

Added to both `deletable_ids` (default delete list — these branches have no legitimate purpose) AND `all_ids` (confirm_subset validation).

Operator entry point: `repo action=cleanup_merged_branches` (existing #817 MCP tool) — when the operator runs it on a canonical that has reviewer-pollution residue, the new bucket surfaces those branches in the dry-run plan; operator confirms via `confirm_ids` subset to delete.

## Layer 2: boot-time canonical hygiene

New `src/bootstrap/canonical_hygiene.rs` module:

- **`decide_canonical_action(head_state, working_tree_clean) -> CanonicalAction`** — pure helper. Decision table:

| `head_state` | `working_tree_clean` | action |
| --- | --- | --- |
| `"HEAD"` (detached) | true | `SwitchToDefault` |
| `"HEAD"` (detached) | false | `WarnDirtyDetached` |
| `""` (empty — defensive) | true | `SwitchToDefault` |
| `""` (empty — defensive) | false | `WarnDirtyDetached` |
| any normal branch | any | `NoOp` |

`WarnDirtyDetached` is intentionally NOT auto-resolved — operator might be mid-bisect / mid-cherry-pick / have legitimate WIP, and silently switching would clobber that work. The warn log surfaces the recovery hint.

- **`run_at_boot(config)`** — discovers distinct canonical paths from `config.instances[*].source_repo` (HashSet dedup), dispatches `apply_to_canonical` per canonical. Skips silently when the path isn't a directory.
- **`apply_to_canonical(canonical)`** — shells out to git twice (rev-parse + status) via `git_capture` helper with `AGEND_GIT_BYPASS=1`, calls `decide_canonical_action`, dispatches actions. `SwitchToDefault` invokes `git switch main` + info log; `WarnDirtyDetached` warn-logs only.

Wired into `bootstrap::run` as sibling to `tasks::reconcile_orphan_owners` (per spike Q3 placement).

## Scope decision: boot-time reviewer_checkout sweep DEFERRED

The dispatch said "decide at impl time: auto-delete obvious matches OR keep all matches in dry-run-only mode (operator confirms). Recommendation: dry-run-only is safer for r0; auto-delete in follow-up if observed useful." PR-C goes narrower — the boot path stays at detached-HEAD auto-switch ONLY. The `reviewer_checkout` bucket is reachable via the existing manual `repo action=cleanup_merged_branches` entry point.

Rationale: the boot path is high-risk (every daemon start runs it; mis-detection deletes legitimate branches). Manual sweep gates on operator confirm via `confirm_ids`, which is the safer default for r0. Auto-sweep at boot is a follow-up issue once the regex has been validated against real residue.

## Tier-2 — daemon-core change

Touches `src/bootstrap/mod.rs` (boot path) + `src/branch_sweep.rs` (sweep logic). Single primary reviewer per established pattern.

## Files

| Path | Change |
| --- | --- |
| `src/bootstrap/canonical_hygiene.rs` | **NEW** — `CanonicalAction` enum + `decide_canonical_action` pure helper + `run_at_boot` discovery + `apply_to_canonical` dispatcher + `git_capture` helper |
| `src/bootstrap/mod.rs` | `pub(crate) mod canonical_hygiene;` declaration + `canonical_hygiene::run_at_boot(&config)` call site |
| `src/branch_sweep.rs` | `Categories.reviewer_checkout` field; `is_reviewer_checkout(name)` regex; `scan()` priority-0 classification; `deletable_ids` + `all_ids` chain extension; 4 new tests |
| `src/bootstrap/canonical_hygiene.rs::mod tests` | 5 decision-table tests |

## Tests (9 new, all green)

- `reviewer_checkout_pattern_matches_tmp_prefix` — `tmp_pr_review` / `tmp/abc1234` / `tmp-merge` / bare `tmp`
- `reviewer_checkout_pattern_matches_pr_head_suffix` — `pr123_head` / `pr850_head` / `pr1_head`
- `reviewer_checkout_pattern_matches_review_prefix` — `review/123` / `review/feat-x`
- `reviewer_checkout_pattern_does_not_match_main_or_fix_branches` — **CRITICAL negative**; `main`/`master`/`fix/.*`/`feat/.*`/`temporary-work`/`pr-merge-queue`/empty all must NOT match
- `boot_no_op_when_canonical_on_main` — HEAD on `main`, any tree state → NoOp
- `boot_no_op_on_feature_branch` — HEAD on `feat/...` → NoOp
- `boot_auto_switch_when_detached_and_clean` — HEAD=`HEAD` + clean tree → SwitchToDefault
- `boot_skips_auto_switch_when_detached_and_dirty` — HEAD=`HEAD` + dirty tree → WarnDirtyDetached
- `boot_treats_empty_rev_parse_as_detached` — defensive (empty rev-parse output)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --features tray -- -D warnings`
- [x] `cargo clean -p agend-terminal && cargo test --features tray` (post-#834 lesson)
- [x] `cargo test --tests --features tray`
- [x] `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` (CI portability sim)
- [x] `cargo test --features tray --bin agend-terminal` → 2336 passed (9 more than #851 baseline)
- [ ] CI green on ubuntu-latest / macos-latest / windows-latest + LOC overrun + audit

## Backlog follow-ups (NOT for r0)

- **Boot-time `reviewer_checkout` dry-run sweep** — wire the bucket scan into `run_at_boot` (event-log matches; no auto-delete). Cheap follow-up once the regex is validated.
- **Boot-time `reviewer_checkout` auto-delete** — narrower follow-up: auto-delete only `pr<N>_head` matches where #N is squash-merged. Higher confidence than `tmp*` / `review/*`.
- **Tray-app autostart** — `src/tray/autostart/macos.rs` registers a separate launchd plist; verify it also runs hygiene at startup (likely yes — same `bootstrap::run` path).

## §10.5 spawn rationale

No new spawn sites. `run_at_boot` is synchronous (inline during `bootstrap::run`). Subprocess invocations via `Command::output()` (blocking, not threads).

## Refs

- Issue: #852 (this PR closes)
- PR-A: `988affe` (§3.19 protocol docs)
- PR-B: `37d8a81` (shim enforcement)
- Phase 1 spike: `t-20260516115125948696-5`
- PR-C IMPL task: `t-20260516124312092008-10`
- Base: origin/main `37d8a81` (PR-B merge)

scope follows dispatch spec t-20260516124312092008-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)