### PR TITLE
feat(phase-a): GIT_EDITOR daemon env defaults (PR-A — Piece-3 of dev-2 enabler)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -357,6 +357,31 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
     cmd.env("FORCE_COLOR", "1");
     cmd.env("AGEND_INSTANCE_NAME", name);
 
+    // Phase A Piece-3: GIT_EDITOR + friends = `true` (Unix no-op
+    // binary that exits 0 without producing output). Prevents git
+    // editor-needing operations from dropping the agent's PTY into
+    // a Vim/editor lockup when the agent runs `git rebase --continue`
+    // / `git commit` (without `-m`) / `git rebase -i` etc. The
+    // empirical experiment (5-backend × 4-scenario) hit this on
+    // opencode + DeepSeek when `rebase --continue` opened the
+    // commit-message editor.
+    //
+    // Cover the full git editor-resolution chain (per `man git-var`:
+    // GIT_EDITOR → core.editor → VISUAL → EDITOR → vi). Setting only
+    // GIT_EDITOR is insufficient if a child script does
+    // `git -c core.editor=` (unsets), so VISUAL/EDITOR are defensive
+    // fallbacks. GIT_SEQUENCE_EDITOR covers `rebase -i`'s todo file
+    // editor specifically.
+    //
+    // Operator override path preserved: these are set BEFORE the
+    // fleet.yaml user-env loop below, so an operator setting
+    // `instances.<name>.env.GIT_EDITOR: vim` (or any other value)
+    // will override the daemon default in the same loop.
+    cmd.env("GIT_EDITOR", "true");
+    cmd.env("GIT_SEQUENCE_EDITOR", "true");
+    cmd.env("EDITOR", "true");
+    cmd.env("VISUAL", "true");
+
     if std::env::var("LANG").is_err() {
         cmd.env("LANG", "en_US.UTF-8");
     }
@@ -2477,5 +2502,49 @@ Allow Trust All Tools mode?
         // The env_remove in build_command is the authoritative guard.
         let _ = cmd;
         std::env::remove_var("AGEND_GIT_BYPASS");
+    }
+
+    /// Phase A Piece-3: GIT_EDITOR + friends must all be set to
+    /// `"true"` (no-op editor binary) in the daemon-spawned agent
+    /// process env so `git rebase --continue` / `git commit`
+    /// (without -m) / `git rebase -i` don't drop the PTY into a
+    /// Vim/editor lockup. Empirical experiment surfaced this on
+    /// opencode + DeepSeek backends; the daemon-side default closes
+    /// the lockup surface across all backends + scenarios.
+    ///
+    /// Operator override is preserved by ordering — these env vars
+    /// are set BEFORE the fleet.yaml user-env loop, so an operator's
+    /// `instances.<name>.env.GIT_EDITOR: vim` would override the
+    /// daemon default. This test pins the default; the override path
+    /// is covered structurally by `build_command`'s existing
+    /// fleet.yaml env-merge logic (no separate test needed for the
+    /// override since the env loop is single-call `cmd.env(k, v)`).
+    #[test]
+    fn build_command_sets_git_editor_defaults() {
+        let config = SpawnConfig {
+            name: "git-editor-test",
+            backend_command: "echo",
+            args: &[],
+            spawn_mode: crate::backend::SpawnMode::Fresh,
+            cols: 80,
+            rows: 24,
+            env: None,
+            working_dir: None,
+            submit_key: "\r",
+            home: None,
+            crash_tx: None,
+            shutdown: None,
+        };
+        let (cmd, _) = build_command(&config).expect("build_command");
+        for key in &["GIT_EDITOR", "GIT_SEQUENCE_EDITOR", "EDITOR", "VISUAL"] {
+            let value = cmd
+                .get_env(key)
+                .unwrap_or_else(|| panic!("{key} must be set in agent env"));
+            assert_eq!(
+                value.to_string_lossy(),
+                "true",
+                "{key} must default to `true` (no-op editor binary), got {value:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Refs Phase A parent dispatch — **Piece-3 of 3** in the dev-2 enabler infrastructure. Closes the Vim/editor lockup surface across all 5 backends + 4 scenarios surfaced by the empirical experiment.
- Inserts 4 env vars into the daemon spawn path (`src/agent.rs::build_command`) so git editor-needing operations exit silently instead of dropping the agent's PTY into a Vim/`$EDITOR` block:

```rust
cmd.env("GIT_EDITOR", "true");
cmd.env("GIT_SEQUENCE_EDITOR", "true");
cmd.env("EDITOR", "true");
cmd.env("VISUAL", "true");
```

`true` is a Unix no-op binary that exits 0 immediately — the established convention for "no-op editor."

## Why this matters

The empirical 5-backend × 4-scenario experiment (operator-authorized 2026-05-16) revealed that agents auto-resolve most git conflicts via Read/Edit/Bash alone — except when git invoked an editor (e.g. `rebase --continue` opening the commit-message editor on opencode + DeepSeek). The agent's PTY went unresponsive until operator manual intervention.

The daemon-side default closes the lockup surface across every backend, since `build_command` is the canonical spawn path for all of them.

## Why all four vars

Per `man git-var`, git's editor-resolution chain is:
```
GIT_EDITOR → core.editor → VISUAL → EDITOR → vi
```

Setting only `GIT_EDITOR` is insufficient if a child script does `git -c core.editor=` (explicit unset), at which point git falls through to VISUAL/EDITOR. So VISUAL and EDITOR are defensive fallbacks. `GIT_SEQUENCE_EDITOR` covers `rebase -i`'s todo-file editor specifically (a separate var per git docs).

## Operator override preserved

The 4 env vars are set BEFORE the fleet.yaml user-env loop in `build_command`. Operator setting `instances.<name>.env.GIT_EDITOR: vim` (or any other value) in fleet.yaml overrides the daemon default via single-call `cmd.env(k, v)` semantics. The defaults are operator-overridable.

## Tier-2 — daemon-core change

Touches the canonical agent spawn path (`src/agent.rs::build_command`). Single primary reviewer per established pattern.

## Files

| Path | Change |
| --- | --- |
| `src/agent.rs` | 4 `cmd.env(K, "true")` calls after `AGEND_INSTANCE_NAME`, before fleet.yaml user-env loop; 1 new unit test `build_command_sets_git_editor_defaults` |

## Test

`build_command_sets_git_editor_defaults` — constructs `CommandBuilder` via `build_command` with minimal `SpawnConfig`, iterates the 4 keys and asserts `cmd.get_env(k)` returns `"true"`. Pure unit test on the spawn path — no subprocess invocation, no PTY, no real git.

The operator-override path is structurally covered by `build_command`'s existing fleet.yaml env-merge logic (single-call `cmd.env(k, v)` semantics — operator value wins on the second call). No separate test needed for the override since the env loop is the same code path that's been working since the fleet.yaml user-env feature shipped.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --features tray -- -D warnings`
- [x] `cargo clean -p agend-terminal && cargo test --features tray` (post-#834 lesson)
- [x] `cargo test --tests --features tray`
- [x] `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` (CI portability sim)
- [x] `cargo test --features tray --bin agend-terminal` → 2337 passed (1 more than #852 PR-C baseline)
- [ ] CI green on ubuntu-latest / macos-latest / windows-latest + LOC overrun + audit

## What's next

PR-B (Pieces 1+2 — conflict notify + escalation timer) follows. PR-B is larger (~150 LOC, new `src/daemon/conflict_notify.rs` module mirroring `waiting_on_stale.rs`, state-classifier additions for `AgentState::GitConflict`).

## Refs

- Phase A parent dispatch: `t-20260516132919819984-0`
- Spike task: `t-20260516133043226938-1`
- PR-A IMPL task: `t-20260516133435746707-2`
- Base: origin/main `977dc3c` (#852 PR-C merge)

scope follows dispatch spec t-20260516133435746707-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)