### PR TITLE
fix(#852 residual) PR-B: runtime canonical-drift scan (5-min throttled, mirrors conflict_notify)

### DIFF
--- a/src/bootstrap/canonical_hygiene.rs
+++ b/src/bootstrap/canonical_hygiene.rs
@@ -1,12 +1,18 @@
-//! #852 PR-C: boot-time canonical-repo hygiene.
+//! #852 canonical-repo hygiene (boot-time + #852-residual runtime).
 //!
-//! When the daemon comes up, the canonical source repo might have
-//! been left in an unhealthy state by a previous fleet session
-//! (e.g. reviewer agent's `git checkout <sha>` left HEAD detached;
-//! see PR-A §3.19 protocol + PR-B shim enforcement). This module
-//! decides whether to auto-switch the canonical's HEAD back to the
-//! default branch ("main") so subsequent operator commands aren't
-//! surprised.
+//! When the canonical source repo is left in an unhealthy state
+//! — e.g. a reviewer agent's `git checkout <sha>` left HEAD detached
+//! (see §3.19 + the L2 shim deny matrix) — this module decides
+//! whether to auto-switch the canonical's HEAD back to the default
+//! branch ("main") so subsequent operator commands aren't surprised.
+//!
+//! Two call sites share the same helper:
+//!
+//! - **Boot path** (`bootstrap/mod.rs`): one-shot scan at daemon
+//!   startup — catches state inherited from the prior session.
+//! - **Runtime path** (`daemon/canonical_drift.rs`): per-tick
+//!   throttled scan (5-min cadence) — catches drift accrued AFTER
+//!   boot for long-lived daemons. #852 residual PR-B.
 //!
 //! Decision matrix (pure helper [`decide_canonical_action`]):
 //!
@@ -45,12 +51,15 @@ pub enum CanonicalAction {
     WarnDirtyDetached,
 }
 
-/// Boot-time hygiene entry — discover distinct canonical repos from
+/// Hygiene entry — discover distinct canonical repos from
 /// `config.instances[*].source_repo` and apply [`apply_to_canonical`]
 /// to each. Best-effort: any per-canonical failure is logged and
-/// skipped (boot must never fail because hygiene couldn't shell out
-/// to git).
-pub(crate) fn run_at_boot(config: &crate::fleet::FleetConfig) {
+/// skipped (the caller — boot or per-tick runtime — must never fail
+/// because hygiene couldn't shell out to git).
+///
+/// Called from two sites: `bootstrap/mod.rs` at daemon startup and
+/// `daemon/canonical_drift.rs` per-tick (5-min throttled cadence).
+pub(crate) fn run_hygiene(config: &crate::fleet::FleetConfig) {
     let mut seen = std::collections::HashSet::<std::path::PathBuf>::new();
     for (name, instance) in &config.instances {
         let Some(source_repo) = instance.source_repo.as_ref() else {

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -193,7 +193,7 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     // warn-log if dirty (operator WIP protection). Pure observation
     // beyond the single `git switch main` mutation when conditions
     // are right. Best-effort — boot continues regardless.
-    canonical_hygiene::run_at_boot(&config);
+    canonical_hygiene::run_hygiene(&config);
     // #829: boot-time orphan-owner sweep. Auto-applies for owners
     // verifiably gone (∉ fleet.yaml ∧ ∉ live registry); dry-run +
     // tracing::warn for the softer "∈ fleet.yaml ∧ ∉ live" case.

--- a/src/daemon/canonical_drift.rs
+++ b/src/daemon/canonical_drift.rs
@@ -1,0 +1,101 @@
+//! #852 residual PR-B: runtime canonical-drift detection.
+//!
+//! Boot-time hygiene (`canonical_hygiene::run_hygiene`, originally added in
+//! the #852 PR-C boot-only path) catches the canonical HEAD state at daemon
+//! startup but cannot detect drift that happens AFTER boot. A long-lived
+//! daemon may run for hours/days while the canonical accrues detached-HEAD
+//! residue from agent activity that slips past the shim (or activity
+//! pre-dating #858's tightened deny matrix). This per-tick tracker mirrors
+//! `conflict_notify.rs` and `waiting_on_stale.rs`: 5-minute throttled
+//! cadence + reuse of the boot-time hygiene helper.
+//!
+//! Spike Q2 sticky-point resolution: supervisor today doesn't carry
+//! `FleetConfig` in scope. Reloading `FleetConfig::load` inside the tracker
+//! on every fire (5-min cadence) is cheap I/O and avoids threading a new
+//! arg through the supervisor loop signature. The boot-time path stays
+//! authoritative for the helper API; this module is a thin adapter.
+
+use std::path::Path;
+
+/// Scan throttle: 30 ticks × 10s = 5 min cadence (matches
+/// `waiting_on_stale` + `conflict_notify`).
+const TICKS_PER_SCAN: u64 = 30;
+
+#[derive(Debug, Default)]
+pub(crate) struct CanonicalDriftTracker {
+    tick_count: u64,
+}
+
+impl CanonicalDriftTracker {
+    /// Per-tick entry. Increments the tick counter; on the throttled
+    /// boundary, fires a drift scan and returns `true`. Returns `false`
+    /// otherwise (pre-throttle tick OR post-fire reset).
+    pub(crate) fn maybe_scan(&mut self, _home: &Path) -> bool {
+        self.tick_count = self.tick_count.saturating_add(1);
+        // C1 RED stub: counter is incremented but throttle gate is not
+        // yet implemented; throttle test will fail at the 30th tick
+        // until C2 GREEN lands the real logic.
+        false
+    }
+}
+
+/// Reload `FleetConfig` + dispatch to the canonical-hygiene helper.
+/// Best-effort: a missing or unparseable fleet.yaml is logged at debug
+/// and skipped (per boot-time semantics — daemon must never crash
+/// because hygiene couldn't read config).
+fn run_drift_scan(_home: &Path) {
+    // C1 RED stub: no-op. C2 GREEN will load FleetConfig + dispatch to
+    // canonical_hygiene::run_hygiene.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("agend-test-canonical-drift-{tag}-{id}"))
+    }
+
+    /// Pure tick-gate contract: 29 calls return false, the 30th fires
+    /// (returns true), the 31st returns false again. Matches the
+    /// `WaitingOnStale` / `ConflictNotify` cadence contract so the
+    /// supervisor loop's per-tick call sequence behaves uniformly.
+    #[test]
+    fn tracker_throttles_to_tick_per_scan() {
+        let home = tmp_home("throttle");
+        std::fs::create_dir_all(&home).unwrap();
+        let mut tracker = CanonicalDriftTracker::default();
+        for i in 0..29 {
+            assert!(
+                !tracker.maybe_scan(&home),
+                "tick {i} (pre-throttle) must return false"
+            );
+        }
+        assert!(
+            tracker.maybe_scan(&home),
+            "30th tick must fire scan and return true"
+        );
+        assert!(
+            !tracker.maybe_scan(&home),
+            "31st tick must reset counter and return false"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// Smoke: the runtime scan must not panic when fleet.yaml is absent
+    /// (the most-common fresh-daemon / test-harness state). Boot-time
+    /// helper logs + skips on FleetConfig::load error; the runtime path
+    /// inherits the same best-effort discipline.
+    #[test]
+    fn runtime_scan_calls_canonical_hygiene_no_panic_on_empty_fleet() {
+        let home = tmp_home("empty");
+        std::fs::create_dir_all(&home).unwrap();
+        // No fleet.yaml written — FleetConfig::load returns Err and the
+        // tracker logs + returns without touching the canonical.
+        run_drift_scan(&home);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+}

--- a/src/daemon/canonical_drift.rs
+++ b/src/daemon/canonical_drift.rs
@@ -15,7 +15,8 @@
 //! arg through the supervisor loop signature. The boot-time path stays
 //! authoritative for the helper API; this module is a thin adapter.
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 /// Scan throttle: 30 ticks × 10s = 5 min cadence (matches
 /// `waiting_on_stale` + `conflict_notify`).
@@ -24,6 +25,15 @@ const TICKS_PER_SCAN: u64 = 30;
 #[derive(Debug, Default)]
 pub(crate) struct CanonicalDriftTracker {
     tick_count: u64,
+    /// Per-canonical-path last-action timestamp. Reserved for future
+    /// per-path dedup / re-alert suppression (mirror of
+    /// `waiting_on_stale::WaitingOnStaleTracker::last_alerted_at`).
+    /// Not read in this PR — the boot-time helper handles all log
+    /// suppression today; the field is wired through so a future PR
+    /// can add per-path throttling without re-flexing the struct
+    /// shape.
+    #[allow(dead_code)]
+    last_action_at: HashMap<PathBuf, chrono::DateTime<chrono::Utc>>,
 }
 
 impl CanonicalDriftTracker {
@@ -42,14 +52,16 @@ impl CanonicalDriftTracker {
 }
 
 /// Reload `FleetConfig` + dispatch to the canonical-hygiene helper.
-/// Best-effort: a missing or unparseable fleet.yaml is logged at debug
+/// Best-effort: a missing or unparseable fleet.yaml is logged at warn
 /// and skipped (per boot-time semantics — daemon must never crash
-/// because hygiene couldn't read config).
+/// because hygiene couldn't read config). Warn (not debug) because
+/// a runtime fleet.yaml load failure indicates an actual operator-
+/// visible config regression and should not be silenced.
 fn run_drift_scan(home: &Path) {
     let path = crate::fleet::fleet_yaml_path(home);
     match crate::fleet::FleetConfig::load(&path) {
         Ok(config) => crate::bootstrap::canonical_hygiene::run_hygiene(&config),
-        Err(e) => tracing::debug!(
+        Err(e) => tracing::warn!(
             error = %e,
             path = %path.display(),
             "#852 canonical_drift: fleet.yaml load failed; skipping scan"

--- a/src/daemon/canonical_drift.rs
+++ b/src/daemon/canonical_drift.rs
@@ -58,6 +58,7 @@ fn run_drift_scan(home: &Path) {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};

--- a/src/daemon/canonical_drift.rs
+++ b/src/daemon/canonical_drift.rs
@@ -30,12 +30,14 @@ impl CanonicalDriftTracker {
     /// Per-tick entry. Increments the tick counter; on the throttled
     /// boundary, fires a drift scan and returns `true`. Returns `false`
     /// otherwise (pre-throttle tick OR post-fire reset).
-    pub(crate) fn maybe_scan(&mut self, _home: &Path) -> bool {
+    pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
         self.tick_count = self.tick_count.saturating_add(1);
-        // C1 RED stub: counter is incremented but throttle gate is not
-        // yet implemented; throttle test will fail at the 30th tick
-        // until C2 GREEN lands the real logic.
-        false
+        if self.tick_count < TICKS_PER_SCAN {
+            return false;
+        }
+        self.tick_count = 0;
+        run_drift_scan(home);
+        true
     }
 }
 
@@ -43,9 +45,16 @@ impl CanonicalDriftTracker {
 /// Best-effort: a missing or unparseable fleet.yaml is logged at debug
 /// and skipped (per boot-time semantics — daemon must never crash
 /// because hygiene couldn't read config).
-fn run_drift_scan(_home: &Path) {
-    // C1 RED stub: no-op. C2 GREEN will load FleetConfig + dispatch to
-    // canonical_hygiene::run_hygiene.
+fn run_drift_scan(home: &Path) {
+    let path = crate::fleet::fleet_yaml_path(home);
+    match crate::fleet::FleetConfig::load(&path) {
+        Ok(config) => crate::bootstrap::canonical_hygiene::run_hygiene(&config),
+        Err(e) => tracing::debug!(
+            error = %e,
+            path = %path.display(),
+            "#852 canonical_drift: fleet.yaml load failed; skipping scan"
+        ),
+    }
 }
 
 #[cfg(test)]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2,6 +2,7 @@
 //! schedule checking, health monitoring, Telegram notifications.
 
 pub(crate) mod anti_stall;
+pub(crate) mod canonical_drift;
 pub(crate) mod ci_watch;
 pub(crate) mod conflict_notify;
 pub(crate) mod cron_tick;

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -230,6 +230,13 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
     // spawn site — supervisor's per-tick loop hosts the scan.
     let mut conflict_notify_tracker =
         crate::daemon::conflict_notify::ConflictNotifyTracker::default();
+    // #852 residual PR-B: per-tick canonical-drift scan. Sibling to
+    // waiting_on_stale + conflict_notify (same TICKS_PER_SCAN cadence,
+    // same supervisor-hosted no-new-spawn-site pattern). Catches
+    // detached-HEAD residue accrued AFTER daemon boot for long-lived
+    // daemons; reuses the boot-time canonical_hygiene helper.
+    let mut canonical_drift_tracker =
+        crate::daemon::canonical_drift::CanonicalDriftTracker::default();
     loop {
         thread::sleep(TICK);
         tick(&home, &registry, &mut notify_tracks);
@@ -242,6 +249,7 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
         mcp_registry_tracker.maybe_scan(&home);
         waiting_on_stale_tracker.maybe_scan(&home);
         conflict_notify_tracker.maybe_scan(&home, &registry);
+        canonical_drift_tracker.maybe_scan(&home);
         // #836: reclaim expired (10-min TTL) entries from the
         // notification-dedup ledger so memory pressure stays bounded
         // on long-lived daemons.


### PR DESCRIPTION
## Summary

PR-B of the #852 residual sequence (PR-A #863 + this + PR-C stash recovery to follow). Closes the boot-only gap from the original #852 by adding a per-tick canonical-drift scan that catches detached-HEAD residue accrued AFTER daemon boot for long-lived sessions.

**Refs #852 residual — PR-B of 3 in residual sequence (PR-A #863 + this + PR-C stash recovery).**

## What this PR does

Adds `src/daemon/canonical_drift.rs` — a sibling tracker to `conflict_notify.rs` and `waiting_on_stale.rs`, hosted by the supervisor's existing per-tick loop. Every 30 ticks (5-minute cadence at the current TICK rate), the tracker reloads `FleetConfig` and dispatches to the boot-time hygiene helper, which is renamed from `run_at_boot` to `run_hygiene` to reflect that both call sites now share it.

```rust
// src/daemon/supervisor.rs (per-tick loop, after conflict_notify)
canonical_drift_tracker.maybe_scan(&home);
```

## Mirror-existing-pattern rationale

`canonical_drift` deliberately mirrors `conflict_notify.rs` (Phase A PR-B #862) and `waiting_on_stale.rs` (#651) for three reasons:

1. **Operational uniformity** — same `TICKS_PER_SCAN = 30` cadence across all three trackers means the supervisor's per-tick cost stays predictable.
2. **No new spawn site** (per §10.5) — the supervisor loop already exists; we add a method call, not a thread.
3. **Already-validated invariants** — the throttle/reset/`maybe_scan(&home)` shape is exercised by prior reviews; reuse is the smallest-blast-radius extension.

## Sticky point + chosen resolution (spike Q2)

The supervisor loop does not have `FleetConfig` in scope (it carries `home: &Path` and `registry: &AgentRegistry` only). Two options surfaced in the spike:

- **(i)** Thread a new `FleetConfig` arg through the supervisor signature.
- **(ii)** Reload `FleetConfig::load(crate::fleet::fleet_yaml_path(home))` inside the tracker.

**Chosen: (ii).** At 5-minute cadence the YAML reload is negligible I/O, and we avoid mutating an already-busy supervisor signature that 30+ trackers/callers depend on. The boot-time path stays authoritative for the helper API; this module is a thin runtime adapter.

## Naming choice rationale

Renamed `canonical_hygiene::run_at_boot → run_hygiene` (spike option (b), lead concur).

- Grep impact: 2 sites total (decl + boot caller). New runtime caller lands as `run_hygiene` directly.
- `run_at_boot` no longer accurately names the helper — both boot and per-tick runtime now invoke it.
- Module-level doc updated to enumerate both call sites for the next reader.

## Commits (§3.10 RED → GREEN cadence)

| SHA | Commit | Tests |
|---|---|---|
| `4dcc980` | C1 RED — module skeleton + 2 tests (throttle test fails on stub) | `tracker_throttles_to_tick_per_scan` FAILED, smoke passed |
| `31a25db` | C2 GREEN — real throttle + `run_drift_scan` + rename + supervisor wire | Both tests pass; `canonical_hygiene` boot tests (5) still pass |
| `4b926d0` | C3 polish — `#[allow(clippy::unwrap_used, clippy::expect_used)]` on test module (mirror `waiting_on_stale.rs:150`) | clippy `-D warnings` clean |

## Pre-push baseline — 5/5 green

- `cargo fmt --check`
- `cargo clippy --all-targets --features tray -- -D warnings`
- `cargo clean -p agend-terminal && cargo test --features tray` (2346 binary + integration)
- `cargo test --tests --features tray`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` (CI portability sim)

## Tier-2 daemon-core flag

Yes — touches `src/daemon/supervisor.rs` per-tick loop + adds new daemon module. Existing runtime-validation conventions apply.

## §4.1 push claim

*scope follows dispatch spec t-20260516161626940472-7.*

## Test plan

- [ ] CI 5 platforms green (ubuntu / macos / windows / LOC overrun / audit).
- [ ] Reviewer VERIFIED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)