### PR TITLE
fix(#852 residual) PR-C: dirty-detached stash recovery (StashAndSwitchToDefault) — Closes #852

### DIFF
--- a/src/bootstrap/canonical_hygiene.rs
+++ b/src/bootstrap/canonical_hygiene.rs
@@ -16,17 +16,22 @@
 //!
 //! Decision matrix (pure helper [`decide_canonical_action`]):
 //!
-//! | head state              | working tree | action               |
-//! | ----------------------- | ------------ | -------------------- |
-//! | already on default      | any          | `NoOp`               |
-//! | detached + clean        | clean        | `SwitchToDefault`    |
-//! | detached + dirty        | dirty        | `WarnDirtyDetached`  |
-//! | normal branch (non-def) | any          | `NoOp`               |
+//! | head state              | working tree | action                       |
+//! | ----------------------- | ------------ | ---------------------------- |
+//! | already on default      | any          | `NoOp`                       |
+//! | detached + clean        | clean        | `SwitchToDefault`            |
+//! | detached + dirty        | dirty        | `StashAndSwitchToDefault`    |
+//! | normal branch (non-def) | any          | `NoOp`                       |
 //!
-//! `WarnDirtyDetached` is intentionally NOT auto-resolved — operator
-//! might be mid-bisect or have legitimate WIP in a detached state,
-//! and silently switching would clobber that work. The boot log
-//! surfaces the warning so the operator can clean up manually.
+//! `StashAndSwitchToDefault` (#852 residual PR-C) auto-stashes the
+//! dirty WIP with a timestamped marker, switches the canonical back
+//! to the default branch, and notifies the operator with the stash
+//! reference so they can recover via `git stash pop`. The stash is
+//! reversible by definition — safer than letting reviewer pollution
+//! land with no recovery path. On stash failure (e.g. `.git/index.lock`
+//! held by another process, in-progress rebase/merge) the dispatch
+//! falls back to the `WarnDirtyDetached` warn log — no half-switch,
+//! no mutation, operator's WIP preserved.
 
 /// The default branch the canonical-hygiene helper switches TO when
 /// it auto-resolves a detached-HEAD state. Mirror of the protected-
@@ -49,9 +54,14 @@ pub enum CanonicalAction {
     /// Operator might be mid-bisect / mid-cherry-pick / have
     /// legitimate WIP. Log a warning and leave alone.
     ///
-    /// Reachable only as a fall-back from [`Self::StashAndSwitchToDefault`]
-    /// after #852 residual PR-C (stash failure path); the pure-
-    /// decision table no longer maps detached+dirty to this variant.
+    /// After #852 residual PR-C the decision table no longer routes
+    /// here — [`Self::StashAndSwitchToDefault`] handles dirty-detached
+    /// reversibly and its stash-failure fall-back calls into the
+    /// `WarnDirtyDetached` warn helper directly (via
+    /// `emit_dirty_detached_warning`) rather than reconstructing this
+    /// variant. The variant is retained for diagnostic / future
+    /// reactivation and tagged `#[allow(dead_code)]` accordingly.
+    #[allow(dead_code)]
     WarnDirtyDetached,
     /// HEAD is detached AND the working tree is dirty: stash the WIP
     /// with a timestamped marker, switch to the default branch, and
@@ -97,7 +107,11 @@ pub(crate) fn run_hygiene(config: &crate::fleet::FleetConfig) {
 /// repo path. Shells out to git twice (rev-parse and status), calls
 /// [`decide_canonical_action`], and dispatches by variant: NoOp is
 /// silent, SwitchToDefault runs `git switch main` plus info log,
-/// WarnDirtyDetached emits a warn log only (no git mutation).
+/// StashAndSwitchToDefault attempts `git stash push -u` + `git switch
+/// main` + operator notify (on stash failure, falls back to
+/// WarnDirtyDetached's warn log), and WarnDirtyDetached is reached
+/// only as the stash-failure fall-back today (the decision table
+/// no longer routes there from clean inputs).
 ///
 /// Best-effort: subprocess failures log a debug line and return; the
 /// daemon boot continues regardless.
@@ -147,25 +161,132 @@ pub(crate) fn apply_to_canonical(canonical: &std::path::Path) {
             }
         }
         CanonicalAction::WarnDirtyDetached => {
-            tracing::warn!(
-                canonical = %canonical.display(),
-                "#852 canonical hygiene: detached HEAD with dirty working tree — \
-                 NOT auto-switching (operator WIP protection). Run `git switch \
-                 {DEFAULT_BRANCH}` manually after committing/stashing changes."
-            );
+            emit_dirty_detached_warning(canonical);
         }
-        // C1 RED stub: route the new variant through the existing
-        // WarnDirtyDetached fall-back so the match stays exhaustive
-        // and apply_to_canonical compiles. C2 GREEN will land the
-        // real stash + switch + notify flow.
         CanonicalAction::StashAndSwitchToDefault => {
-            tracing::warn!(
-                canonical = %canonical.display(),
-                "#852 canonical hygiene (C1 stub): StashAndSwitchToDefault \
-                 not yet implemented; falling through to warn-only"
-            );
+            apply_stash_and_switch(canonical);
         }
     }
+}
+
+/// #852 residual PR-C: handle the detached-HEAD + dirty-tree case
+/// by stashing the WIP with a timestamped marker, switching back to
+/// the default branch, and notifying the operator with recovery
+/// instructions. On stash failure, fall back to
+/// [`emit_dirty_detached_warning`] so the operator's WIP is preserved.
+fn apply_stash_and_switch(canonical: &std::path::Path) {
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    let stash_message = format!("agend canonical hygiene auto-stash {timestamp}");
+    match git_stash_push(canonical, &stash_message) {
+        Err(stderr) => {
+            tracing::warn!(
+                canonical = %canonical.display(),
+                stash_stderr = %stderr,
+                "#852 canonical hygiene: stash push failed; falling back to \
+                 warn-only (operator WIP preserved)"
+            );
+            emit_dirty_detached_warning(canonical);
+        }
+        Ok(()) => {
+            let switch_result = std::process::Command::new("git")
+                .args([
+                    "-C",
+                    &canonical.display().to_string(),
+                    "switch",
+                    DEFAULT_BRANCH,
+                ])
+                .env("AGEND_GIT_BYPASS", "1")
+                .output();
+            match switch_result {
+                Ok(out) if out.status.success() => {
+                    tracing::info!(
+                        canonical = %canonical.display(),
+                        stash_message = %stash_message,
+                        "#852 canonical hygiene: dirty detached HEAD auto-stashed and switched to {DEFAULT_BRANCH}"
+                    );
+                    notify_operator_of_auto_stash(canonical, &stash_message);
+                }
+                Ok(out) => {
+                    // Stash succeeded but switch failed — operator's
+                    // WIP is in the stash, canonical is still detached
+                    // but clean. Warn so the operator restores manually.
+                    tracing::warn!(
+                        canonical = %canonical.display(),
+                        stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                        stash_message = %stash_message,
+                        "#852 canonical hygiene: stash succeeded but git switch {DEFAULT_BRANCH} failed — recover via `git stash pop`"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        canonical = %canonical.display(),
+                        error = %e,
+                        stash_message = %stash_message,
+                        "#852 canonical hygiene: stash succeeded but git switch spawn failed — recover via `git stash pop`"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Emit the dirty-detached warn log. Extracted so the
+/// `StashAndSwitchToDefault` fall-back can reuse the exact text the
+/// `WarnDirtyDetached` arm would emit, keeping operator-visible
+/// messaging consistent across the two reachable paths.
+fn emit_dirty_detached_warning(canonical: &std::path::Path) {
+    tracing::warn!(
+        canonical = %canonical.display(),
+        "#852 canonical hygiene: detached HEAD with dirty working tree — \
+         NOT auto-switching (operator WIP protection). Run `git switch \
+         {DEFAULT_BRANCH}` manually after committing/stashing changes."
+    );
+}
+
+/// Best-effort: shell out to `git stash push -u -m <message>` with
+/// the AGEND bypass set. Returns `Ok(())` on success, `Err(stderr)`
+/// on failure (spawn fail or non-zero exit). The `-u` flag includes
+/// untracked files so any reviewer-left dirt is captured even when
+/// it hasn't been `git add`-ed.
+fn git_stash_push(canonical: &std::path::Path, message: &str) -> Result<(), String> {
+    let out = match std::process::Command::new("git")
+        .args([
+            "-C",
+            &canonical.display().to_string(),
+            "stash",
+            "push",
+            "-u",
+            "-m",
+            message,
+        ])
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => return Err(format!("spawn failed: {e}")),
+    };
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
+}
+
+/// Best-effort: notify the operator-mapped agent (`general` by
+/// convention; see `bootstrap/fleet_normalize.rs`) about the auto-
+/// stash with recovery instructions. Delivery failures are silently
+/// dropped — the tracing::info above already records the canonical
+/// hygiene event for log audits.
+fn notify_operator_of_auto_stash(canonical: &std::path::Path, stash_message: &str) {
+    let home = crate::home_dir();
+    let text = format!(
+        "[system:canonical_auto_stash] Canonical at `{path}` was detached + dirty; \
+         auto-stashed WIP as `{stash_message}` and switched back to {DEFAULT_BRANCH}. \
+         Recover via:\n  git -C {path} stash list\n  git -C {path} stash pop  # or: git stash apply <ref>\n#852.",
+        path = canonical.display(),
+    );
+    let source = crate::inbox::NotifySource::System("canonical_auto_stash");
+    crate::inbox::notify_agent(&home, "general", &source, &text);
 }
 
 /// Pure helper: shell out to git with `AGEND_GIT_BYPASS=1` (so we
@@ -199,20 +320,22 @@ fn git_capture(repo: &std::path::Path, args: &[&str]) -> Option<String> {
 
 /// Classification table:
 ///
-/// | head_state | working_tree_clean | action               |
-/// | ---------- | ------------------ | -------------------- |
-/// | `"HEAD"`   | true               | `SwitchToDefault`    |
-/// | `"HEAD"`   | false              | `WarnDirtyDetached`  |
-/// | `""`       | true               | `SwitchToDefault`    |
-/// | `""`       | false              | `WarnDirtyDetached`  |
-/// | anything   | any                | `NoOp`               |
-///   else                            |                      |
+/// | head_state | working_tree_clean | action                       |
+/// | ---------- | ------------------ | ---------------------------- |
+/// | `"HEAD"`   | true               | `SwitchToDefault`            |
+/// | `"HEAD"`   | false              | `StashAndSwitchToDefault`    |
+/// | `""`       | true               | `SwitchToDefault`            |
+/// | `""`       | false              | `StashAndSwitchToDefault`    |
+/// | anything   | any                | `NoOp`                       |
+///   else                            |                              |
 ///
 /// Empty `head_state` is treated as detached defensively — `git
 /// rev-parse --abbrev-ref HEAD` should never produce empty stdout
 /// but if it does, fail-closed by routing through the detached
-/// branches (with the dirty-tree warn protecting against any
-/// silent state change on weird repo states).
+/// branches. The dirty-tree case auto-stashes + switches (#852
+/// residual PR-C) rather than warn-only, because the stash is fully
+/// reversible (`git stash pop`) and the prior warn-only behaviour
+/// left the canonical permanently polluted from the operator's POV.
 pub fn decide_canonical_action(head_state: &str, working_tree_clean: bool) -> CanonicalAction {
     let detached = head_state == "HEAD" || head_state.is_empty();
     if !detached {
@@ -221,7 +344,7 @@ pub fn decide_canonical_action(head_state: &str, working_tree_clean: bool) -> Ca
     if working_tree_clean {
         CanonicalAction::SwitchToDefault
     } else {
-        CanonicalAction::WarnDirtyDetached
+        CanonicalAction::StashAndSwitchToDefault
     }
 }
 
@@ -260,19 +383,6 @@ mod tests {
         );
     }
 
-    /// HEAD detached BUT working tree dirty → warn and leave alone.
-    /// Operator might be mid-bisect / mid-cherry-pick / have
-    /// legitimate WIP. Silent auto-switch would clobber that work.
-    #[test]
-    fn boot_skips_auto_switch_when_detached_and_dirty() {
-        assert_eq!(
-            decide_canonical_action("HEAD", false),
-            CanonicalAction::WarnDirtyDetached,
-            "detached HEAD + dirty tree → warn only, never auto-switch \
-             (operator WIP protection)"
-        );
-    }
-
     /// HEAD on a non-default normal branch (e.g. operator was on a
     /// feature branch when the daemon started). No-op — daemon
     /// shouldn't reorganize the operator's working state.
@@ -294,7 +404,8 @@ mod tests {
 
     /// Defensive: empty string from `rev-parse` is unexpected but
     /// guard fail-closed — treat as detached. If working tree is
-    /// also dirty, warn rather than auto-switch.
+    /// also dirty, route through the stash-and-switch path so the
+    /// canonical doesn't stay polluted (PR-C behaviour).
     #[test]
     fn boot_treats_empty_rev_parse_as_detached() {
         assert_eq!(
@@ -304,8 +415,10 @@ mod tests {
         );
         assert_eq!(
             decide_canonical_action("", false),
-            CanonicalAction::WarnDirtyDetached,
-            "empty rev-parse + dirty → warn (defensive)"
+            CanonicalAction::StashAndSwitchToDefault,
+            "empty rev-parse + dirty → stash-and-switch (defensive); \
+             mirrors the detached-HEAD + dirty cell of the decision \
+             table"
         );
     }
 
@@ -383,8 +496,10 @@ mod tests {
             .unwrap()
             .trim()
             .to_string();
-        assert!(run(&["checkout", "-q", &initial_sha]).status.success(),
-            "detach HEAD via checkout SHA");
+        assert!(
+            run(&["checkout", "-q", &initial_sha]).status.success(),
+            "detach HEAD via checkout SHA"
+        );
         std::fs::write(canonical.join("file.txt"), "modified-wip\n").unwrap();
         // Plant the index lock so `git stash push` cannot complete.
         std::fs::write(canonical.join(".git").join("index.lock"), "").unwrap();

--- a/src/bootstrap/canonical_hygiene.rs
+++ b/src/bootstrap/canonical_hygiene.rs
@@ -48,7 +48,19 @@ pub enum CanonicalAction {
     /// HEAD is detached BUT the working tree has uncommitted changes.
     /// Operator might be mid-bisect / mid-cherry-pick / have
     /// legitimate WIP. Log a warning and leave alone.
+    ///
+    /// Reachable only as a fall-back from [`Self::StashAndSwitchToDefault`]
+    /// after #852 residual PR-C (stash failure path); the pure-
+    /// decision table no longer maps detached+dirty to this variant.
     WarnDirtyDetached,
+    /// HEAD is detached AND the working tree is dirty: stash the WIP
+    /// with a timestamped marker, switch to the default branch, and
+    /// notify the operator about the stash ref so they can recover
+    /// via `git stash pop`. Reversible by definition — safer than
+    /// letting reviewer pollution land with no recovery path. On
+    /// stash failure, falls back to [`Self::WarnDirtyDetached`]
+    /// behaviour (warn log, no mutation).
+    StashAndSwitchToDefault,
 }
 
 /// Hygiene entry — discover distinct canonical repos from
@@ -142,6 +154,17 @@ pub(crate) fn apply_to_canonical(canonical: &std::path::Path) {
                  {DEFAULT_BRANCH}` manually after committing/stashing changes."
             );
         }
+        // C1 RED stub: route the new variant through the existing
+        // WarnDirtyDetached fall-back so the match stays exhaustive
+        // and apply_to_canonical compiles. C2 GREEN will land the
+        // real stash + switch + notify flow.
+        CanonicalAction::StashAndSwitchToDefault => {
+            tracing::warn!(
+                canonical = %canonical.display(),
+                "#852 canonical hygiene (C1 stub): StashAndSwitchToDefault \
+                 not yet implemented; falling through to warn-only"
+            );
+        }
     }
 }
 
@@ -203,6 +226,7 @@ pub fn decide_canonical_action(head_state: &str, working_tree_clean: bool) -> Ca
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -283,5 +307,108 @@ mod tests {
             CanonicalAction::WarnDirtyDetached,
             "empty rev-parse + dirty → warn (defensive)"
         );
+    }
+
+    // ----------------------------------------------------------------
+    // #852 residual PR-C: dirty-detached stash-recovery tests.
+    // ----------------------------------------------------------------
+
+    /// PR-C contract: detached HEAD with dirty working tree must
+    /// resolve to [`CanonicalAction::StashAndSwitchToDefault`] (reversible
+    /// auto-recovery), not the obsolete `WarnDirtyDetached` (which
+    /// left the canonical permanently polluted for the operator).
+    ///
+    /// In C1 RED, [`decide_canonical_action`] still returns the old
+    /// `WarnDirtyDetached`, so this assertion fails. C2 GREEN updates
+    /// the decision table and this passes.
+    #[test]
+    fn stash_and_switch_on_dirty_detached() {
+        assert_eq!(
+            decide_canonical_action("HEAD", false),
+            CanonicalAction::StashAndSwitchToDefault,
+            "detached HEAD + dirty tree → StashAndSwitchToDefault \
+             (reversible auto-recovery; #852 residual PR-C)"
+        );
+    }
+
+    /// PR-C contract: when `git stash push` fails at the syscall /
+    /// repo-state level (here simulated by planting `.git/index.lock`
+    /// before invoking [`apply_to_canonical`]), the integration fn
+    /// must fall back to the warn-only branch — no panic, no half-
+    /// switch, and HEAD must remain in its detached state so the
+    /// operator can still recover manually.
+    ///
+    /// The fixture builds a real micro-repo so `rev-parse` and
+    /// `status --porcelain` both succeed (otherwise apply exits
+    /// before reaching the stash branch). C1 RED reaches this branch
+    /// via the stub arm; C2 GREEN will actually attempt the stash,
+    /// observe the index-lock failure, and route through the same
+    /// fall-back. The invariants asserted hold in both phases —
+    /// this test is the smoke that proves the new variant's
+    /// dispatch never panics + never loses the operator's WIP.
+    #[test]
+    fn apply_to_canonical_falls_back_to_warn_on_stash_failure() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let canonical = std::env::temp_dir().join(format!(
+            "agend-test-canonical-stash-fallback-{}-{id}",
+            std::process::id(),
+        ));
+        // Best-effort cleanup from any prior run.
+        let _ = std::fs::remove_dir_all(&canonical);
+        std::fs::create_dir_all(&canonical).unwrap();
+
+        // Build a minimal repo: init + initial commit on main, then
+        // detach + dirty the tree so decide_canonical_action observes
+        // the StashAndSwitchToDefault path in C2.
+        let run = |args: &[&str]| {
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(&canonical)
+                .args(args)
+                .env("AGEND_GIT_BYPASS", "1")
+                .env("GIT_AUTHOR_NAME", "test")
+                .env("GIT_AUTHOR_EMAIL", "test@example.com")
+                .env("GIT_COMMITTER_NAME", "test")
+                .env("GIT_COMMITTER_EMAIL", "test@example.com")
+                .output()
+                .expect("git command spawn")
+        };
+        assert!(run(&["init", "-q", "-b", "main"]).status.success());
+        std::fs::write(canonical.join("file.txt"), "initial\n").unwrap();
+        assert!(run(&["add", "file.txt"]).status.success());
+        assert!(run(&["commit", "-q", "-m", "initial"]).status.success());
+        let initial_sha = String::from_utf8(run(&["rev-parse", "HEAD"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+        assert!(run(&["checkout", "-q", &initial_sha]).status.success(),
+            "detach HEAD via checkout SHA");
+        std::fs::write(canonical.join("file.txt"), "modified-wip\n").unwrap();
+        // Plant the index lock so `git stash push` cannot complete.
+        std::fs::write(canonical.join(".git").join("index.lock"), "").unwrap();
+
+        // Drive apply. Must not panic; HEAD must remain detached.
+        apply_to_canonical(&canonical);
+
+        let head_state = String::from_utf8(run(&["rev-parse", "--abbrev-ref", "HEAD"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+        assert_eq!(
+            head_state, "HEAD",
+            "post-fall-back HEAD must remain detached — operator WIP \
+             must not be silently moved when stash recovery fails"
+        );
+
+        // No stash refs should exist on the failure path.
+        let stash_ref = canonical.join(".git").join("refs").join("stash");
+        assert!(
+            !stash_ref.exists(),
+            "stash ref must not exist when git stash push failed"
+        );
+
+        let _ = std::fs::remove_dir_all(&canonical);
     }
 }


### PR DESCRIPTION
## Summary

**Closes #852.** PR-C is the final layer of the 3-PR residual sequence — closes the issue outright after PR-A (broaden detection) and PR-B (runtime drift scan).

Adds the `StashAndSwitchToDefault` action to the canonical-hygiene decision matrix so a detached-HEAD + dirty-working-tree canonical no longer stays polluted under operator WIP protection. The dirty WIP is stashed reversibly with a timestamped marker, the canonical is switched back to `main`, and the operator is notified with `git stash pop` recovery instructions.

**PR-C of 3-PR sequence**: PR-A `a18b524` (L1 broaden detection) + PR-B `c97d8d9` (L2 runtime scan) + this (L3 stash recovery).

## decide_canonical_action table change

| head state | working tree | r0 (pre-PR-C) | r1 (this PR) |
|---|---|---|---|
| already on default | any | `NoOp` | `NoOp` (unchanged) |
| detached + clean | clean | `SwitchToDefault` | `SwitchToDefault` (unchanged) |
| **detached + dirty** | **dirty** | **`WarnDirtyDetached`** | **`StashAndSwitchToDefault`** |
| empty rev-parse + dirty (defensive) | dirty | `WarnDirtyDetached` | `StashAndSwitchToDefault` |
| normal branch (non-default) | any | `NoOp` | `NoOp` (unchanged) |

## Stash recovery rationale

Reversibility is the whole point. Pre-PR-C, `WarnDirtyDetached` was a polite no-op: the daemon noticed the canonical was polluted by reviewer agent activity but refused to touch it (operator WIP protection). The operator's experience was a permanently dirty canonical that surfaced on every interactive `git` call until they manually intervened.

`StashAndSwitchToDefault` resolves this without destroying anything:

1. `git stash push -u -m "agend canonical hygiene auto-stash <ISO-timestamp>"` — `-u` captures untracked files so reviewer pollution that wasn't `git add`-ed is also preserved.
2. `git switch main` — canonical now lands where subsequent operator commands expect.
3. Notify the operator-mapped `general` agent with the exact `git stash pop` recovery sequence.

If the stash fails (e.g. `.git/index.lock` held by another process, in-progress rebase/merge), the dispatch falls back to the old warn-only behaviour: operator WIP is preserved, no half-switch, and the warn log still tells them what to fix. **The operator's working set is never silently lost** — at worst it stays exactly where it was; at best it's stashed and recoverable.

## Notify content

Sent via `crate::inbox::notify_agent(home, "general", NotifySource::System("canonical_auto_stash"), text)`:

```
[system:canonical_auto_stash] Canonical at `<path>` was detached + dirty;
auto-stashed WIP as `agend canonical hygiene auto-stash <ts>` and switched
back to main. Recover via:
  git -C <path> stash list
  git -C <path> stash pop  # or: git stash apply <ref>
#852.
```

## Commits (§3.10 RED → GREEN cadence)

| SHA | Commit | Test status |
|---|---|---|
| `6af8317` | C1 RED — variant + 2 new tests (stub StashAndSwitchToDefault arm; decide unchanged) | `stash_and_switch_on_dirty_detached` FAILS; `apply_to_canonical_falls_back_to_warn_on_stash_failure` smoke passes |
| `99f13cb` | C2 GREEN — `apply_stash_and_switch` + `git_stash_push` helper + `notify_operator_of_auto_stash` + decision table swap + obsolete test cleanup | Both PR-C tests pass; 5 pre-existing canonical_hygiene tests pass (one deleted, one assertion updated) |

## Tests (2 new + 1 updated + 1 deleted)

- **NEW** `stash_and_switch_on_dirty_detached` — pure `decide_canonical_action` test (the C1 RED signal).
- **NEW** `apply_to_canonical_falls_back_to_warn_on_stash_failure` — builds a real micro-repo (init → commit → detach via `checkout <sha>` → write dirty file → plant `.git/index.lock`), invokes `apply_to_canonical`, asserts no panic + HEAD remains detached + no stash ref created. Exercises the real stash → fail → fall-back path in C2.
- **UPDATED** `boot_treats_empty_rev_parse_as_detached` second assertion: `WarnDirtyDetached` → `StashAndSwitchToDefault` (table parallel).
- **DELETED** `boot_skips_auto_switch_when_detached_and_dirty` — obsoleted by PR-C (the new test is its semantic successor with the corrected expectation).

## `WarnDirtyDetached` variant retention

Retained with `#[allow(dead_code)]` + updated rustdoc explaining the variant is no longer constructed by the decision table. The shared warn-log helper `emit_dirty_detached_warning` preserves the operator-facing text verbatim across the (now-unreachable) `WarnDirtyDetached` arm and the active `StashAndSwitchToDefault` stash-failure fall-back. Kept for diagnostic / future reactivation rather than deleted.

## Pre-push baseline — 5/5 green

- `cargo fmt --check`
- `cargo clippy --all-targets --features tray -- -D warnings`
- `cargo clean -p agend-terminal && cargo test --features tray` (2347 binary + integration)
- `cargo test --tests --features tray`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` (CI portability sim)

## Tier-2 daemon-core flag

Yes — both boot path (`bootstrap/mod.rs::canonical_hygiene::run_hygiene`) and per-tick runtime path (`daemon/canonical_drift.rs::run_drift_scan`) invoke the changed dispatch. Existing runtime-validation conventions apply.

## §10.5 spawn rationale

N/A — synchronous `Command::output` blocking calls; no new spawn site added.

## §4.1 push claim

*scope follows dispatch spec t-20260516175706410255-9.*

## Test plan

- [ ] CI 5 platforms green (ubuntu / macos / windows / LOC overrun / audit).
- [ ] Reviewer VERIFIED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)