### PR TITLE
fix(#868): sleep→spin-wait coordination in dedup race tests

### DIFF
--- a/src/api/request_dedup.rs
+++ b/src/api/request_dedup.rs
@@ -534,6 +534,22 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
+    /// #868 — spin-wait helper used by the in-progress / over-cap
+    /// coordination tests below. Replaces the old `thread::sleep(50ms)`
+    /// gating which flaked on slow macOS GH-runners (#856 + #866 + #867).
+    /// Observes the production `cache.inner` state directly — no
+    /// production code changes, no test hook injection. Panics with a
+    /// clear deadline message if the predicate never holds.
+    fn wait_until<F: FnMut() -> bool>(deadline: Duration, mut predicate: F) {
+        let started = Instant::now();
+        while !predicate() {
+            if started.elapsed() > deadline {
+                panic!("#868 wait_until: predicate did not hold within {deadline:?}");
+            }
+            thread::yield_now();
+        }
+    }
+
     /// (a) Same request_id submitted twice — handler must execute exactly
     /// once; the second caller must observe the first call's cached response.
     #[test]
@@ -602,8 +618,17 @@ mod tests {
             })
         });
 
-        // Give T1 enough head-start to install the InProgress entry.
-        thread::sleep(Duration::from_millis(50));
+        // #868 hardening — wait for T1 to install the InProgress entry
+        // by observing `cache.inner` directly instead of betting on
+        // 50ms scheduler latency. Mirror the over-cap test's pattern.
+        wait_until(Duration::from_secs(2), || {
+            cache
+                .inner
+                .lock()
+                .expect("inner mutex")
+                .entries
+                .contains_key("req-C")
+        });
 
         let c2 = Arc::clone(&cache);
         let cnt2 = Arc::clone(&count);
@@ -756,7 +781,9 @@ mod tests {
             2,
         ));
 
-        // T1 holds the entry InProgress for a while.
+        // T1 holds the entry InProgress for a while. The handler's
+        // 300ms sleep is intentional substantive work — it represents
+        // T1 holding InProgress while T4 dispatches, NOT coordination.
         let c = Arc::clone(&cache);
         let t1 = thread::spawn(move || {
             c.dispatch(Some("req-cap"), Duration::from_secs(5), || {
@@ -764,7 +791,17 @@ mod tests {
                 json!({"first": true})
             })
         });
-        thread::sleep(Duration::from_millis(50));
+        // #868 hardening — wait for T1 to install the InProgress entry
+        // by observing `cache.inner` directly. Old `thread::sleep(50ms)`
+        // flaked on slow macOS GH-runners (#856, #866, #867).
+        wait_until(Duration::from_secs(2), || {
+            cache
+                .inner
+                .lock()
+                .expect("inner mutex")
+                .entries
+                .contains_key("req-cap")
+        });
 
         // T2 + T3 fill the waiter slots.
         let c2 = Arc::clone(&cache);
@@ -775,7 +812,21 @@ mod tests {
         let t3 = thread::spawn(move || {
             c3.dispatch(Some("req-cap"), Duration::from_secs(5), || json!({}))
         });
-        thread::sleep(Duration::from_millis(50));
+        // #868 hardening — wait for T2 + T3 to attach as waiters
+        // (increment `waiter_count` to the cap) before dispatching T4.
+        // Old `thread::sleep(50ms)` flaked on slow macOS GH-runners;
+        // T4 would otherwise become a 3rd waiter and block 5s on the
+        // Condvar instead of fast-failing with `OverCap`.
+        wait_until(Duration::from_secs(2), || {
+            cache
+                .inner
+                .lock()
+                .expect("inner mutex")
+                .entries
+                .get("req-cap")
+                .map(|e| e.waiter_count >= 2)
+                .unwrap_or(false)
+        });
 
         // T4 — over cap — should fail fast.
         let started = Instant::now();


### PR DESCRIPTION
## Summary

**Closes #868.** Replaces `thread::sleep(50ms)` coordination kludges in two `request_dedup` race tests with deadline-bounded observable-state spin-waits, eliminating the macOS CI flake that has hit 3 recent PRs (#856 + #866 + #867).

## Race observed

`over_cap_waiters_get_in_progress_error_fast` spawns 4 threads against a shared `DedupCache` with `waiter_cap = 2`:

- **T1** holds the entry InProgress for 300ms (real handler work).
- **T2 + T3** must increment `waiter_count` to exactly 2.
- **T4** dispatches and must observe `waiter_count >= waiter_cap` → return `OverCap` → `in_progress` error without blocking.

Two `thread::sleep(50ms)` calls between thread spawns bet against scheduler latency. On saturated macOS GH-runners that bet lost: T4 became a 3rd waiter and blocked the full 5s timeout instead of fast-failing, breaking the `elapsed < 100ms` assertion.

## Fix: observable-state spin-wait

Introduce a private `wait_until(deadline, predicate)` helper in the test module that spins with `thread::yield_now()` while polling the production `cache.inner` field directly. The `inner` field is already test-exposed (used at line 827 in `total_cap_overflow_evicts_oldest_terminal_entry`), so this approach changes zero production code.

```rust
fn wait_until<F: FnMut() -> bool>(deadline: Duration, mut predicate: F) {
    let started = Instant::now();
    while !predicate() {
        if started.elapsed() > deadline {
            panic!("#868 wait_until: predicate did not hold within {deadline:?}");
        }
        thread::yield_now();
    }
}
```

Each former `sleep(50ms)` becomes a predicate spin on the actual state transition we needed to gate on:

- `over_cap_waiters_get_in_progress_error_fast` — **2 replacements**: wait for entry presence (T1 registered Fresh), then wait for `waiter_count >= 2` (T2 + T3 attached as waiters).
- `c_in_progress_race_second_waits_for_first` — **1 replacement (sibling fold)**: wait for entry presence. Same race pattern; hadn't flaked yet in observed history but same kludge. Folding per spike recommendation since the helper costs nothing extra to reuse.

## Why observable-state spin over `std::sync::Barrier`

The Phase 1 spike (parent task t-20260516191225109887-2) considered Barrier and rejected it: a Barrier needs each party (T2, T3, main) to call `barrier.wait()`. The waiters run `cache.dispatch(...)` — production code under test. Injecting `barrier.wait()` between `check_or_register` and `wait_for` would require either:

- **Production code changes** — test/production entanglement, reduces fidelity, the test no longer exercises the real dispatch path.
- **Invasive test hooks** — same problem in a different shape.

`tokio::sync::Notify` was also considered and rejected (overkill — adds tokio dep just for one test; production code is sync `Mutex` + `Condvar`).

The observable-state approach is bounded by a 2s deadline. On regression, it surfaces a clean panic `#868 wait_until: predicate did not hold within 2s` (immediate, actionable diagnostic) vs the prior cryptic `over-cap caller should not block (took 5s)` failure mode.

## Preserved sleeps (intentional substantive work)

The handler-internal `thread::sleep(300ms)` in `over_cap_waiters_*` and `sleep(200ms)` in `c_in_progress_race_*` are NOT coordination — they represent "T1 holds InProgress while T2-T4 dispatch" work-windows. Replacing them would defeat the test's whole point. Inline comments now document the distinction.

## Flake-history citation

Inline `// #868 hardening` comments at each replacement site cite the three previous occurrences: #856 + #866 + #867 macOS GH-runner reruns.

## Determinism check

Per dispatch instruction (5+ reruns to confirm), I ran 10 sequential local runs of each hardened test:

- `over_cap_waiters_get_in_progress_error_fast`: **10/10 pass**, timings stable at 0.31s.
- `c_in_progress_race_second_waits_for_first`: **10/10 pass**, timings stable at 0.20–0.21s.

Total: 20/20 passes, no timing variance.

## Pre-push baseline — 5/5 green

- `cargo fmt --check`
- `cargo clippy --all-targets --features tray -- -D warnings`
- `cargo clean -p agend-terminal && cargo test --features tray` (2347 binary + integration)
- `cargo test --tests --features tray`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` (CI portability sim)

## Tier-2 daemon-core flag

Yes — tests exercise the daemon-core `DedupCache::dispatch` path. Production code unchanged, so the existing dispatch invariants remain whatever they were before this PR. The change is purely in the test harness's coordination layer.

## §3.10 cadence

Single C2 GREEN commit. No RED→GREEN split needed: the test was passing on the happy-path before this PR; the change is determinism hardening, not a behavioural addition. Spike (parent task) provided the design analysis.

## §10.5 spawn rationale

N/A — the only `thread::spawn` sites are existing in the test bodies (unchanged) and are joined explicitly via `t.join()` later in each test. No new spawn sites added.

## §4.1 push claim

*scope follows dispatch spec t-20260516191536548480-3.*

## Test plan

- [ ] CI 5 platforms green (ubuntu / macos / windows / LOC overrun / audit). Bonus signal: macOS in particular should now pass cleanly (3-PR flake history was macOS-only).
- [ ] Reviewer VERIFIED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)