### PR TITLE
fix(#869): bind=true syncs stale local ref to origin/<branch> before lease

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -425,8 +425,17 @@ fn resolve_source_repo(
 /// and the lazy fetch fallback live in one place.
 ///
 /// Behavior (mirror #784 / decision d-20260514102305998399-0):
-/// 1. `rev-parse --verify refs/heads/<branch>` — if exists, return
-///    `(auto_created=false, fetch_attempted=false)`.
+/// 1. `rev-parse --verify refs/heads/<branch>` — if exists, **fetch
+///    `origin <branch>` + `update-ref refs/heads/<branch>
+///    refs/remotes/origin/<branch>`** so the (about-to-be-bound)
+///    local ref tracks the remote PR HEAD (#869 fix — stale local
+///    refs from prior cycles were landing the bound worktree at the
+///    wrong SHA). Returns `(auto_created=false, fetch_attempted=N)`
+///    where N reflects whether the fetch actually succeeded.
+///    `update-ref` is no-op when `origin/<branch>` doesn't exist
+///    (newly-pushed branches not yet observed locally) or when the
+///    fetch fails (network outage); in both cases the local ref is
+///    left unchanged and the caller still gets a usable lease.
 /// 2. Else `git branch <branch> <from_ref>`:
 ///    - success → `(true, false)`
 ///    - stderr `"already exists"` (concurrent race) → `(false, false)`
@@ -464,7 +473,43 @@ pub(crate) fn ensure_branch_exists(
             .map(|o| o.status.success())
             .unwrap_or(false);
     if branch_exists {
-        return Ok((false, false));
+        // #869: the local ref may be stale from a prior dispatch cycle
+        // (r0 push → reviewer bind → r1 push observed this 3× across
+        // PR-B/PR-C/etc; local ref pinned at the r0 SHA, downstream
+        // `worktree::create` then lands the bound worktree at that
+        // stale SHA instead of the remote PR HEAD).
+        //
+        // Refresh `origin/<branch>` + fast-forward the local ref via
+        // `update-ref` BEFORE the lease so `worktree::create` reads
+        // the now-current ref. `update-ref` is an atomic ref write
+        // (no working-tree mutation, no checkout side-effects), safe
+        // even when the branch is checked out elsewhere — about to
+        // be replaced by this very lease anyway.
+        //
+        // Best-effort: `fetch` failure (network outage / fake-remote
+        // fixture) leaves `origin/<branch>` at its prior value; the
+        // update-ref still runs against whatever `refs/remotes/origin/
+        // <branch>` is present (defensible because at-least-as-fresh-as-
+        // local is the invariant we want). If `origin/<branch>` doesn't
+        // exist at all (branch never pushed), update-ref is skipped
+        // and the local ref is left untouched — dispatch then falls
+        // through to lease with the existing local SHA, matching the
+        // pre-fix behaviour for that edge case.
+        let fetch_out =
+            crate::git_helpers::git_bypass(source, &["fetch", "origin", branch, "--quiet"]);
+        let fetched_ok = matches!(&fetch_out, Ok(o) if o.status.success());
+        let remote_branch_ref = format!("refs/remotes/origin/{branch}");
+        let remote_exists =
+            crate::git_helpers::git_bypass(source, &["rev-parse", "--verify", &remote_branch_ref])
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+        if remote_exists {
+            let _ = crate::git_helpers::git_bypass(
+                source,
+                &["update-ref", &branch_ref, &remote_branch_ref],
+            );
+        }
+        return Ok((false, fetched_ok));
     }
     // Step 2: try create from `from_ref` (no fetch yet — zero network
     // on the fast path where origin/main is already a valid local ref).

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1814,3 +1814,191 @@ fn clean_empty_init_commits_drops_init_with_only_daemon_trailers() {
 
     std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
 }
+
+// ── #869 ensure_branch_exists branch-exists path sync tests ────────
+
+/// #869 fix: when `refs/heads/<branch>` already exists locally and
+/// `refs/remotes/origin/<branch>` exists at a DIFFERENT SHA, the
+/// branch-exists path must refresh the local ref to track the remote
+/// before returning. Pre-fix this early-returned without syncing, so
+/// the downstream `worktree::create` landed the bound worktree at the
+/// stale local SHA (observed 3× in PR-B/PR-C/etc reviewer cycles).
+#[test]
+fn ensure_branch_exists_syncs_stale_local_to_origin() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-869-sync-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).ok();
+    let repo = setup_test_repo(&home, "dev-869");
+    let branch = "fix/869-sync-fixture";
+
+    let bypass = |args: &[&str]| -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git spawn")
+    };
+    // Create the local branch at the initial commit (the "stale" SHA).
+    let stale_sha = String::from_utf8(bypass(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    assert!(bypass(&["branch", branch]).status.success());
+
+    // Advance HEAD on main, then point refs/remotes/origin/<branch>
+    // at the NEW SHA. This simulates "remote PR head moved forward but
+    // local <branch> ref is pinned at the prior cycle's SHA".
+    std::fs::write(repo.join("file.txt"), "advance").ok();
+    assert!(bypass(&["add", "file.txt"]).status.success());
+    assert!(bypass(&[
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=t@t",
+        "commit",
+        "-m",
+        "advance"
+    ])
+    .status
+    .success());
+    let fresh_sha = String::from_utf8(bypass(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    assert_ne!(stale_sha, fresh_sha, "fixture must produce divergent SHAs");
+    let remote_ref = format!("refs/remotes/origin/{branch}");
+    assert!(bypass(&["update-ref", &remote_ref, &fresh_sha])
+        .status
+        .success());
+
+    // Sanity: pre-call local ref is still at stale_sha.
+    let pre_local =
+        String::from_utf8(bypass(&["rev-parse", &format!("refs/heads/{branch}")]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+    assert_eq!(pre_local, stale_sha);
+
+    // Drive the production function.
+    let result = super::ensure_branch_exists(&home, &repo, branch, "origin/main", "dev-869");
+    assert!(result.is_ok(), "must succeed: {result:?}");
+    let (auto_created, _fetch_attempted) = result.unwrap();
+    assert!(
+        !auto_created,
+        "branch existed pre-call — auto_created must be false"
+    );
+
+    // Post-call assertion: local ref now matches origin/<branch> (the
+    // PR-head SHA). This is the load-bearing invariant the bug fix
+    // restores.
+    let post_local =
+        String::from_utf8(bypass(&["rev-parse", &format!("refs/heads/{branch}")]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+    assert_eq!(
+        post_local, fresh_sha,
+        "#869 contract: local refs/heads/{branch} must be fast-forwarded to refs/remotes/origin/{branch} when both exist"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #869 edge case: branch exists locally but `refs/remotes/origin/
+/// <branch>` does NOT exist (e.g. branch was created locally and never
+/// pushed). The function must leave the local ref unchanged — there's
+/// no remote ref to sync against — and return `(false, fetched_ok)`
+/// without raising an error.
+#[test]
+fn ensure_branch_exists_leaves_local_untouched_when_no_remote_ref() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-869-noremote-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).ok();
+    let repo = setup_test_repo(&home, "dev-869-nr");
+    let branch = "fix/869-noremote-fixture";
+
+    let bypass = |args: &[&str]| -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git spawn")
+    };
+    // Create the local branch; deliberately do NOT populate any
+    // refs/remotes/origin/<branch> ref.
+    assert!(bypass(&["branch", branch]).status.success());
+    let pre_local =
+        String::from_utf8(bypass(&["rev-parse", &format!("refs/heads/{branch}")]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+
+    let result = super::ensure_branch_exists(&home, &repo, branch, "origin/main", "dev-869-nr");
+    assert!(result.is_ok(), "must succeed: {result:?}");
+    let (auto_created, _fetch_attempted) = result.unwrap();
+    assert!(!auto_created);
+
+    // Post-call: local ref unchanged because no remote ref existed to
+    // sync against. (The fetch itself may have spawned and either
+    // succeeded with no work to do or failed against the fake remote;
+    // the load-bearing invariant is "no silent ref mutation").
+    let post_local =
+        String::from_utf8(bypass(&["rev-parse", &format!("refs/heads/{branch}")]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+    assert_eq!(
+        pre_local, post_local,
+        "#869: local ref must be untouched when origin/<branch> is absent"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #869 protection: the new sync path must not interfere with the
+/// existing "branch doesn't exist locally → create from origin/main"
+/// flow. After the fix, dispatching a brand-new branch must still
+/// auto-create from origin/main with the existing (auto_created=true,
+/// fetch_attempted=false) shape on the fast path.
+#[test]
+fn ensure_branch_exists_auto_create_from_main_path_unchanged() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-869-new-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).ok();
+    let repo = setup_test_repo(&home, "dev-869-new");
+    let branch = "fix/869-new-fixture";
+
+    let result = super::ensure_branch_exists(&home, &repo, branch, "origin/main", "dev-869-new");
+    assert!(result.is_ok(), "must succeed: {result:?}");
+    let (auto_created, fetch_attempted) = result.unwrap();
+    assert!(
+        auto_created,
+        "#869: new branch must still auto-create from origin/main"
+    );
+    assert!(
+        !fetch_attempted,
+        "fast path: origin/main is a valid local ref so no fetch needed"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary

**Closes #869.** Eliminates the tree-mismatch bug where `repo action=checkout bind=true` provisioned a worktree at the local `refs/heads/<branch>` ref's stale SHA (077022f / 9b869b1 / 5ce9fcf observed across PR-B / PR-C reviewer cycles in the #852 residual series) instead of the remote PR HEAD. Reviewers had been manually working around this via `gh pr diff` for the past several cycles.

## Root cause

`src/mcp/handlers/dispatch_hook/mod.rs::ensure_branch_exists` early-returned at the branch-exists check (lines 462–468 pre-fix) without fetching or syncing:

```rust
let branch_exists = ...;
if branch_exists {
    return Ok((false, false));  // ← skips fetch + sync
}
```

Downstream `worktree_pool::lease` → `worktree::create` then ran `git worktree add <path> <branch>`, landing the bound worktree at whatever stale SHA the local ref pointed at. The local ref typically came from a prior dispatch in the same cycle (r0 push left local pointing at r0's SHA; remote then advanced to r1; local stayed stale).

## Fix

Inject `git fetch origin <branch> --quiet` + `git update-ref refs/heads/<branch> refs/remotes/origin/<branch>` into the branch-exists path before returning. Both ops run in the source repo **before** the lease creates the worktree, so `worktree::create` reads the now-current ref.

```rust
if branch_exists {
    let fetch_out = git_bypass(source, &["fetch", "origin", branch, "--quiet"]);
    let fetched_ok = matches!(&fetch_out, Ok(o) if o.status.success());
    let remote_branch_ref = format!("refs/remotes/origin/{branch}");
    let remote_exists = git_bypass(source, &["rev-parse", "--verify", &remote_branch_ref])
        .map(|o| o.status.success())
        .unwrap_or(false);
    if remote_exists {
        let _ = git_bypass(source, &["update-ref", &branch_ref, &remote_branch_ref]);
    }
    return Ok((false, fetched_ok));
}
```

### Contract refinement vs spike literal (lead-approved)

The spike's pseudocode gated update-ref on `if fetched_ok`. The shipped version gates on an **independent** `rev-parse refs/remotes/origin/<branch>` check. Rationale:

- **Monotonic improvement** — every case where `fetched_ok` is true also has `remote_exists` true, so all spike scenarios still trigger update-ref.
- **Adds coverage** for "fetch failed (network outage or fake-fixture URL) but `origin/<branch>` cached from a prior successful fetch" — the local ref still gets updated to the cached remote SHA, beating the prior stale-local SHA.
- **Makes the test fixture viable** — the test repo uses a fake `file:///dev/null/...` origin URL where `git fetch` always fails; the independent rev-parse lets the update-ref still fire against a pre-populated `refs/remotes/origin/<branch>` ref.

## Why `update-ref` over `reset --hard`

- **No working-tree mutation.** `update-ref` is a low-level atomic ref write; no checkout side-effects, no risk of clobbering racing operator mutations in any existing worktree.
- **Safe with bound worktrees elsewhere.** The branch may be checked out at the stale SHA in another (about-to-be-released) worktree; `update-ref` atomic semantics avoid the "branch already checked out" failure that `reset --hard` inside the new worktree would hit.
- **Source-repo scoped.** All ops run in the source repo before the lease; the new worktree is provisioned from the now-fresh ref in one go, no second pass inside the bound path.

## Edge cases

| Case | Handling |
|---|---|
| Branch new locally (auto-create) | Existing fast path unchanged — falls through to `git branch <new> origin/main`. ✓ |
| `origin/<branch>` absent (unpushed branch) | `remote_exists=false` → `update-ref` skipped; local ref untouched. Matches pre-fix behaviour. ✓ |
| `git fetch` fails (network outage / fake fixture URL) | `fetched_ok=false`. Independent `rev-parse` gate still runs `update-ref` against any cached origin ref. Worst case: same stale-SHA behaviour as pre-fix. No regression. |
| Re-bind reuse path (`worktree::create` reuses existing worktree) | `worktree::create`'s reuse branch (line 154 of `worktree.rs`) returns the existing worktree at its current HEAD — `update-ref` already ran in this dispatch so the on-disk branch ref is fresh. The reuse path does NOT re-checkout, so a still-bound worktree on a stale SHA won't auto-update from a re-bind alone (caller must `release_worktree` first if a fresh checkout is needed). |
| Local divergence (local has unique commits not on remote) | `update-ref` overwrites local to origin SHA. Local-only commits become unreachable from refs but remain in reflog for 30 days. Same semantic as `git fetch origin <branch>:<branch>` would produce. Acceptable for the dispatch path (a fresh bind expects to work on the PR HEAD). |

## Tests (3 new, all pass)

- `ensure_branch_exists_syncs_stale_local_to_origin` — fixture with local `refs/heads/<branch>` at SHA X + `refs/remotes/origin/<branch>` at SHA Y. Post-call asserts local == Y. **The load-bearing #869 invariant.**
- `ensure_branch_exists_leaves_local_untouched_when_no_remote_ref` — fixture without `refs/remotes/origin/<branch>`. Post-call asserts local unchanged (no silent ref mutation).
- `ensure_branch_exists_auto_create_from_main_path_unchanged` — new-branch path: asserts `(auto_created=true, fetch_attempted=false)` fast-path semantics preserved.

## Risk: LOW

The change modifies a single early-return path that today is a no-op beyond returning `(false, false)`. The fetch is bounded (single branch, `--quiet`); the update-ref is atomic and reversible (reflog preserves the old SHA for 30 days). Worst case on regression: same stale-SHA behaviour as pre-fix (operator falls back to `gh pr diff` workaround). No new failure modes introduced.

## Coordination note

Reviewer cycle for THIS PR exercises the OLD code (the fix only lands at merge). If reviewer hits the tree-mismatch bug during bind for review, established workaround applies: `gh pr diff <N>` + `gh pr view <N> --json files` (per §3.19.1 of `docs/FLEET-DEV-PROTOCOL.md`). After merge, subsequent dispatches benefit from the fix.

## §3.10 cadence

Single C2 GREEN commit. Same precedent as #868 r0 + #870 r0 (lead's clearance both times). Defensive correctness fix to passing-on-happy-path code; comprehensive test coverage (3 new tests covering invariant + edge cases) stands as the contract proof.

## Pre-push baseline — 5/5 green

- `cargo fmt --check`
- `cargo clippy --all-targets --features tray -- -D warnings`
- `cargo clean -p agend-terminal && cargo test --features tray` — 2361 binary tests (+3 net new) + integration. One initial run flaked `worktree_pool::tests::cutover_deletes_with_flag` (pre-existing parallel-execution race, outside this change's scope — `dispatch_hook/` vs `worktree_pool/`); passed on retry + standalone.
- `cargo test --tests --features tray`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray`

## Tier-2 daemon-core flag

Yes — binding lifecycle + remote-sync semantics. Production code change touches only the branch-exists early-return path; downstream behaviour preserved.

## §10.5 spawn rationale

N/A — synchronous `Command::output` calls, no new spawn site.

## §4.1 push claim

*scope follows dispatch spec t-20260516202037401299-9.*

## Test plan

- [ ] CI 5 platforms green (ubuntu / macos / windows / LOC overrun / audit).
- [ ] Reviewer VERIFIED.
- [ ] After merge: next PR review cycle's `repo action=checkout bind=true` should land at PR HEAD first try (no `gh pr diff` fallback needed) — empirical confirmation of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)