### PR TITLE
fix(#854): drop Gemini RateLimit bare-phrase alternation + 2 fixtures

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -518,23 +518,41 @@ impl StatePatterns {
                     AgentState::UsageLimit,
                     r"Usage limit reached|Access resets at",
                 ),
-                // #848 PR-B: narrow Gemini RateLimit to specific
-                // google-gemini/gemini-cli verbatim wordings (issues
-                // #10722/#8437/#22545/#2305/#1502). The pre-#848 pattern
-                // `r"RESOURCE_EXHAUSTED|\b429\b"` matched bare `429`
-                // tokens anywhere — the same false-positive class as
-                // Claude/Codex pre-PR-A (any prose discussing HTTP 429
-                // status codes triggered RateLimit). New pattern keys
-                // on full HTTP-context wording — `429 RESOURCE_EXHAUSTED`,
-                // `rateLimitExceeded` (gRPC error code field),
-                // `got status: 429`, `429 Too Many Requests`, and
-                // `rate limit exceeded` (CLI casual wording). The bare
-                // `\b429\b` token is dropped; the wrapping context in
-                // the new alternations is what distinguishes a real
-                // 429 from discussion prose.
+                // #848 PR-B narrowed bare `\b429\b` to specific
+                // gemini-cli verbatim wordings (issues #10722/#8437/
+                // #22545/#2305/#1502). #854 follow-up further drops
+                // the residual bare `rate limit exceeded` alternation
+                // — it was added as defensive insurance against a
+                // "CLI casual wording" case that turned out to have
+                // no empirical anchor in any of the cited issues, and
+                // it false-positive-matched any prose / commit /
+                // discussion containing the 3-word phrase (same class
+                // as the pre-#848 bare `\b429\b` surface).
+                //
+                // All four remaining alternations are anchored on a
+                // `429` numeric or on the distinctive camelCase gRPC
+                // field `rateLimitExceeded`, so a real Gemini
+                // RateLimit display still matches via 4× coverage:
+                //
+                // - `429 RESOURCE_EXHAUSTED` — numeric + gRPC enum
+                // - `rateLimitExceeded` — single distinctive token
+                // - `got status: 429` — verb-anchored numeric
+                // - `429 Too Many Requests` — HTTP status-text numeric
+                //
+                // Negative regression fixture
+                // `gemini-rate-limit-prose-discussion.raw` exercises
+                // the false-positive class this drop closes; the
+                // existing positive fixture
+                // `gemini-rate-limit-typical.raw` exercises detection
+                // survival on the canonical wording (still matches
+                // 4× over after the drop). New positive fixture
+                // `gemini-rate-limit-canonical-429.raw` exercises
+                // detection on a minimal 429-anchored display that
+                // does NOT include the dropped bare phrase, locking
+                // in the post-#854 contract.
                 (
                     AgentState::RateLimit,
-                    r"429 RESOURCE_EXHAUSTED|rateLimitExceeded|got status: 429|429 Too Many Requests|rate limit exceeded",
+                    r"429 RESOURCE_EXHAUSTED|rateLimitExceeded|got status: 429|429 Too Many Requests",
                 ),
                 // [docs] Token/quota limit
                 (AgentState::ContextFull, r"quota.*exceeded|token.*limit"),

--- a/tests/fixtures/state-replay/MANIFEST.yaml
+++ b/tests/fixtures/state-replay/MANIFEST.yaml
@@ -487,6 +487,44 @@ fixtures:
     capture_kind: synthetic
     provenance: "#848 PR-B regression-proof — prose containing Gemini old-pattern trigger substrings"
 
+  - file: gemini-rate-limit-canonical-429.raw
+    backend: gemini
+    cli_version: "0.37.1"
+    recorded_on: "2026-05-17"
+    scenario: |
+      Gemini pane shows a minimal 429-anchored RateLimit display that
+      does NOT include the bare `rate limit exceeded` phrase. #854
+      dropped that bare alternation from the Gemini RateLimit pattern;
+      this fixture locks in the detection survival contract — the four
+      remaining alternations (`429 RESOURCE_EXHAUSTED`,
+      `rateLimitExceeded`, `got status: 429`, `429 Too Many Requests`)
+      must still classify a real Gemini 429 as RateLimit even when the
+      casual-wording fallback is absent.
+    expected_transitions: [starting, rate_limit]
+    expected_final_state: rate_limit
+    expected_final_detect: rate_limit
+    capture_kind: synthetic_from_docs
+    provenance: "#854 — synthetic from gemini-cli 429-response anchors"
+
+  - file: gemini-rate-limit-prose-discussion.raw
+    backend: gemini
+    cli_version: "0.37.1"
+    recorded_on: "2026-05-17"
+    scenario: |
+      Regression-proof fixture for #854 — the LOAD-BEARING test of the
+      bare-`rate limit exceeded` alternation drop. Pane contains the
+      bare 3-word phrase in dev-prose context (no 429, no
+      `RESOURCE_EXHAUSTED`, no `rateLimitExceeded`). Under the pre-#854
+      pattern this prose triggered a false RateLimit via the
+      defensive-insurance bare alternation. Under the post-#854
+      narrowed pattern the classifier stays Idle — the false-positive
+      class is closed.
+    expected_transitions: [starting, idle]
+    expected_final_state: idle
+    expected_final_detect: idle
+    capture_kind: synthetic
+    provenance: "#854 regression-proof — prose containing dropped Gemini alternation substring"
+
   - file: kiro-rate-limit-typical.raw
     backend: kiro-cli
     cli_version: "2.0.1"

--- a/tests/fixtures/state-replay/gemini-rate-limit-canonical-429.raw
+++ b/tests/fixtures/state-replay/gemini-rate-limit-canonical-429.raw
@@ -1,0 +1,4 @@
+[2J[H[31m[29m] Status: 429 RESOURCE_EXHAUSTED · rateLimitExceeded[0m
+Retrying in 30s · got status: 429 Too Many Requests
+
+Type your message

--- a/tests/fixtures/state-replay/gemini-rate-limit-prose-discussion.raw
+++ b/tests/fixtures/state-replay/gemini-rate-limit-prose-discussion.raw
@@ -1,0 +1,3 @@
+[2J[H[0mWriting docs notes: when Gemini CLI says "rate limit exceeded" in a future hypothetical wording without the 429 status code, our classifier (per #854) deliberately does NOT match — discussion prose containing the bare 3-word phrase must stay non-error. Recording this so the negative fixture intent is self-documenting.
+
+Type your message

--- a/tests/state_pattern_coverage.rs
+++ b/tests/state_pattern_coverage.rs
@@ -38,6 +38,8 @@ const EXPECTED_FIXTURES: &[&str] = &[
     "opencode-discussion-text.raw",
     "gemini-rate-limit-typical.raw",
     "gemini-discussion-text.raw",
+    "gemini-rate-limit-canonical-429.raw",
+    "gemini-rate-limit-prose-discussion.raw",
     "kiro-rate-limit-typical.raw",
     "kiro-usage-limit-typical.raw",
     "kiro-discussion-text.raw",


### PR DESCRIPTION
## Summary

**Closes #854.** Final residual from #848 cross-backend classifier work. Drops the bare `rate limit exceeded` alternation from Gemini's RateLimit regex — that alternation had no empirical anchor in any of the cited gemini-cli issues and false-positive-matched any prose / commit / discussion containing the 3-word phrase (the same class #848 PR-B was meant to close).

## Problem

`src/state.rs:537` (added by #848 PR-B) carried a 5-alternation Gemini RateLimit pattern:

```rust
r"429 RESOURCE_EXHAUSTED|rateLimitExceeded|got status: 429|429 Too Many Requests|rate limit exceeded"
```

The fifth alternation was added as **defensive insurance** against a "CLI casual wording" case. That phrase has no empirical anchor in any of the cited Gemini CLI issues — `#10722` / `#8437` / `#22545` / `#2305` / `#1502` all display 429-anchored wordings. Meanwhile the bare 3-word phrase false-positive-matches any prose containing it — exactly the surface #848 PR-B narrowed `\b429\b` to eliminate.

## Fix — Option A: drop the bare alternation

```rust
// before — 5 alternations, #5 is bare phrase
r"429 RESOURCE_EXHAUSTED|rateLimitExceeded|got status: 429|429 Too Many Requests|rate limit exceeded"

// after — 4 alternations, all anchored on 429 numeric or distinctive camelCase token
r"429 RESOURCE_EXHAUSTED|rateLimitExceeded|got status: 429|429 Too Many Requests"
```

| Alternation | Anchor |
|---|---|
| `429 RESOURCE_EXHAUSTED` | numeric + gRPC enum |
| `rateLimitExceeded` | single distinctive camelCase token |
| `got status: 429` | verb-anchored numeric |
| `429 Too Many Requests` | HTTP status-text numeric |

Per spike (parent task `t-20260516235745105906-2`), **Option B** (anchor the bare phrase with proximity to 429) was considered and rejected — added regex complexity for a never-observed case; the 4 remaining alternations already cover every real error.

## Fixtures (2 new)

### `gemini-rate-limit-canonical-429.raw` (positive)

Minimal 429-anchored Gemini display **without** the dropped bare phrase. Locks in the detection survival contract: the classifier must still observe RateLimit when only the four anchored alternations are present.

```
[29m] Status: 429 RESOURCE_EXHAUSTED · rateLimitExceeded
Retrying in 30s · got status: 429 Too Many Requests
```

### `gemini-rate-limit-prose-discussion.raw` (negative — **LOAD-BEARING**)

Bare 3-word phrase in dev-prose context (no 429, no `RESOURCE_EXHAUSTED`, no `rateLimitExceeded`). Pre-fix this triggered a false RateLimit via the dropped alternation; post-fix the classifier stays Idle. **This is the test that proves the false-positive class is closed.**

### Existing fixtures preserved

- `gemini-rate-limit-typical.raw` (positive) — contains all five wordings together. Still matches via 4 remaining alternations (replay regression verifies).
- `gemini-discussion-text.raw` (negative) — deliberately avoided the bare phrase; continues to stay Idle.

## Migration safety

`grep -rn "rate limit exceeded" src/ tests/`:

- `src/state.rs:1303`, `1969` — test-code **comments only**; the feeds use Claude wordings, not Gemini.
- `src/state.rs:457` — Codex `API rate limit exceeded` alternation. Different backend; anchored by Codex's `API` prefix per #848 PR-A. **Not touched by this PR.**
- `src/daemon/ci_watch/poller.rs` (6 sites) — GitHub API error parsing for HTTP 403 rate-limit responses. **Entirely unrelated module**; no Gemini classifier interaction.

→ **No live test code feeds the bare phrase to the Gemini classifier expecting RateLimit. Migration-safe.**

## Tests (replay regression + coverage, all pass)

- `state::tests::replay_manifest_regression` — replays all fixtures including the 2 new ones; both lock in their `expected_transitions` contract under the post-#854 pattern.
- `state_pattern_coverage::all_fixtures_present_and_nonempty`
- `state_pattern_coverage::fixtures_contain_ansi_escape_sequences`
- `state_pattern_coverage::manifest_references_all_fixtures`

`tests/state_pattern_coverage.rs::EXPECTED_FIXTURES` extended by 2; MANIFEST.yaml carries the expected-state contract for replay.

## Pre-push baseline — 5/5 green

- `cargo fmt --check`
- `cargo clippy --all-targets --features tray -- -D warnings`
- `cargo clean -p agend-terminal && cargo test --features tray` — 2361 binary tests + integration suites
- `cargo test --tests --features tray`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` (CI portability sim)

## Risk: LOW

Removing one regex alternation can only narrow detection (Boolean OR → fewer matches). Existing positive fixture exercises the 4 remaining alternations 4× over. Worst case on regression: the bare-phrase case (which today **falsely** triggers RateLimit) stops triggering — that's the intended behaviour. No new failure modes introduced.

## §3.10 cadence

Single C2 GREEN per #868 / #870 / #869 precedent (defensive classifier narrowing + new fixture-replay coverage; comprehensive tests stand as contract).

## Tier-2 daemon-core flag

Yes — state classifier behaviour change. Production code change touches only the Gemini RateLimit regex string; classifier code path unchanged.

## §10.5 spawn rationale

N/A — regex + fixture-only change.

## §4.1 push claim

*scope follows dispatch spec t-20260517000117924437-4.*

## Test plan

- [ ] CI 5 platforms green (ubuntu / macos / windows / LOC overrun / audit).
- [ ] Reviewer VERIFIED.
- [ ] After merge: no Gemini false-RateLimit false-positives observed against prose containing the 3-word phrase (operationally validated via subsequent classifier replay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)