### PR TITLE
feat(watchdog PR1): dispatch_idle L1 + fixup_nudge L2 — cross-team-safe + auto-nudge

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -329,6 +329,47 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
         }
     }
 
+    // PR1 watchdog hook — post-enqueue, mirror auto_release ordering
+    // (#870): dispatch tracking is defence-in-depth and must never
+    // block the dispatch primitive. Two-way wiring:
+    //   - Outbound `task` / `query` with a threshold (explicit OR
+    //     L2-defaulted for fixup) records a pending sidecar.
+    //   - Inbound `report` carrying a correlation_id resolves the
+    //     matching sidecar by correlation_id (NOT sender — multi-
+    //     pending-per-target requires correlation-keyed resolution).
+    let kind_str = msg.kind.as_deref().unwrap_or("");
+    if matches!(kind_str, "task" | "query") {
+        // Correlation source: `correlation_id` if the caller set one,
+        // else `task_id` (the kind=task convention — the task-board id
+        // is what the reporter will set as `correlation_id` on the
+        // matching kind=report). For kind=query with neither field
+        // set, sidecar records correlation_id=None and only fires on
+        // timeout (mark_resolved can never match — acceptable for an
+        // un-correlated dispatch).
+        let outbound_corr = msg.correlation_id.as_deref().or(msg.task_id.as_deref());
+        let explicit_threshold = params["expect_reply_within_secs"].as_i64();
+        if let Some(threshold) =
+            crate::daemon::dispatch_idle::fixup_nudge::resolve_threshold_for_dispatch(
+                ctx.home,
+                from,
+                explicit_threshold,
+            )
+        {
+            let _ = crate::daemon::dispatch_idle::record_dispatch(
+                ctx.home,
+                from,
+                target,
+                outbound_corr,
+                kind_str,
+                threshold,
+            );
+        }
+    } else if kind_str == "report" {
+        if let Some(corr) = msg.correlation_id.as_deref() {
+            let _ = crate::daemon::dispatch_idle::mark_resolved(ctx.home, corr);
+        }
+    }
+
     let mut resp = json!({"ok": true, "delivery_mode": delivery_mode});
     if let Some(branch) = branch_checked_out {
         resp["branch_checked_out"] = json!(branch);
@@ -1246,6 +1287,209 @@ mod tests {
         assert!(
             !err.contains("likely daemon refresh"),
             "error must use neutral wording (no causal claim): {err}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── PR1 watchdog hook integration tests (C2 GREEN) ──
+    //
+    // These exercise the handle_send → dispatch_idle hook wiring.
+    // The hook is post-enqueue (auto_release ordering precedent) so
+    // any failure here doesn't surface to the dispatch primitive.
+
+    fn write_fixup_fleet(home: &std::path::Path, members: &[&str]) {
+        let list = members
+            .iter()
+            .map(|m| format!("\"{m}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let orchestrator = members.first().copied().unwrap_or("fixup-lead");
+        let yaml = format!(
+            "schema_version: 1\n\
+             instances:\n\
+             {instances}\
+             teams:\n  fixup:\n    members: [{list}]\n    orchestrator: {orchestrator}\n",
+            instances = members
+                .iter()
+                .map(|m| format!("  {m}:\n    backend: claude\n"))
+                .collect::<String>(),
+        );
+        std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
+    }
+
+    #[test]
+    fn hook_kind_report_resolves_pending_by_correlation_id() {
+        let home = tmp_home("hook-report-resolves");
+        write_fixup_fleet(&home, &["fixup-lead", "fixup-reviewer"]);
+        // Seed a pending sidecar (correlation_id = "t-hook").
+        let id = crate::daemon::dispatch_idle::record_dispatch(
+            &home,
+            "fixup-lead",
+            "fixup-reviewer",
+            Some("t-hook"),
+            "task",
+            600,
+        )
+        .expect("seed sidecar");
+        let ctx = test_ctx(&home);
+        // Reviewer sends report with the matching correlation_id.
+        let result = handle_send(
+            &json!({
+                "from": "fixup-reviewer",
+                "target": "fixup-lead",
+                "text": "VERIFIED",
+                "kind": "report",
+                "correlation_id": "t-hook",
+            }),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true, "report send must succeed: {result}");
+        let pending = crate::daemon::dispatch_idle::list_pending(&home);
+        let entry = pending.iter().find(|p| p.dispatch_id == id).unwrap();
+        assert_eq!(
+            entry.status, "resolved",
+            "kind=report with matching correlation_id must resolve the sidecar"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn hook_kind_update_does_not_resolve_pending() {
+        // Load-bearing contract: BUSY / status updates must NOT
+        // suppress the watchdog. Spike challenge #1.
+        let home = tmp_home("hook-update-no-resolve");
+        write_fixup_fleet(&home, &["fixup-lead", "fixup-reviewer"]);
+        let id = crate::daemon::dispatch_idle::record_dispatch(
+            &home,
+            "fixup-lead",
+            "fixup-reviewer",
+            Some("t-update"),
+            "task",
+            600,
+        )
+        .expect("seed sidecar");
+        let ctx = test_ctx(&home);
+        let result = handle_send(
+            &json!({
+                "from": "fixup-reviewer",
+                "target": "fixup-lead",
+                "text": "BUSY working on the diff",
+                "kind": "update",
+                "correlation_id": "t-update",
+            }),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true);
+        let pending = crate::daemon::dispatch_idle::list_pending(&home);
+        let entry = pending.iter().find(|p| p.dispatch_id == id).unwrap();
+        assert_eq!(
+            entry.status, "pending",
+            "kind=update must NOT flip status (watchdog stays armed)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn hook_fixup_team_dispatch_records_pending_via_default_threshold() {
+        // L2 fixup default-threshold injection: sender in fixup team,
+        // kind=task, no explicit expect_reply_within_secs → sidecar
+        // recorded with the 600s default.
+        let home = tmp_home("hook-fixup-default");
+        write_fixup_fleet(&home, &["fixup-lead", "fixup-reviewer"]);
+        let ctx = test_ctx(&home);
+        let result = handle_send(
+            &json!({
+                "from": "fixup-lead",
+                "target": "fixup-reviewer",
+                "text": "[task] do the thing",
+                "kind": "task",
+                "task_id": "t-fixup-default",
+            }),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true, "dispatch must succeed: {result}");
+        let pending = crate::daemon::dispatch_idle::list_pending(&home);
+        let entry = pending
+            .iter()
+            .find(|p| p.correlation_id.as_deref() == Some("t-fixup-default"))
+            .expect("fixup-team dispatch must seed a sidecar via L2 default");
+        assert_eq!(entry.dispatcher, "fixup-lead");
+        assert_eq!(entry.target, "fixup-reviewer");
+        assert_eq!(
+            entry.threshold_secs, 600,
+            "L2 must inject the 600s fixup default"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn hook_non_fixup_dispatch_no_recording_without_explicit_threshold() {
+        // Cross-team-safe default-disabled invariant: non-fixup
+        // dispatcher with no explicit threshold → NO sidecar.
+        let home = tmp_home("hook-non-fixup-no-record");
+        // Distinct team that ISN'T fixup.
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "schema_version: 1\n\
+             instances:\n  research-lead:\n    backend: claude\n  research-dev:\n    backend: claude\n\
+             teams:\n  research:\n    members: [research-lead, research-dev]\n    orchestrator: research-lead\n",
+        )
+        .unwrap();
+        let ctx = test_ctx(&home);
+        let result = handle_send(
+            &json!({
+                "from": "research-lead",
+                "target": "research-dev",
+                "text": "[task] do the thing",
+                "kind": "task",
+                "task_id": "t-non-fixup",
+            }),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true);
+        let pending = crate::daemon::dispatch_idle::list_pending(&home);
+        assert!(
+            pending
+                .iter()
+                .all(|p| p.correlation_id.as_deref() != Some("t-non-fixup")),
+            "non-fixup dispatch without explicit threshold must NOT record"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn hook_explicit_threshold_overrides_team_default() {
+        // Explicit expect_reply_within_secs wins for any team
+        // (including non-fixup). Other teams opt in this way.
+        let home = tmp_home("hook-explicit-threshold");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "schema_version: 1\n\
+             instances:\n  research-lead:\n    backend: claude\n  research-dev:\n    backend: claude\n\
+             teams:\n  research:\n    members: [research-lead, research-dev]\n    orchestrator: research-lead\n",
+        )
+        .unwrap();
+        let ctx = test_ctx(&home);
+        let result = handle_send(
+            &json!({
+                "from": "research-lead",
+                "target": "research-dev",
+                "text": "[task] research thing",
+                "kind": "task",
+                "task_id": "t-explicit",
+                "expect_reply_within_secs": 1200_i64,
+            }),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true);
+        let pending = crate::daemon::dispatch_idle::list_pending(&home);
+        let entry = pending
+            .iter()
+            .find(|p| p.correlation_id.as_deref() == Some("t-explicit"))
+            .expect("explicit-threshold dispatch records sidecar");
+        assert_eq!(
+            entry.threshold_secs, 1200,
+            "explicit threshold must override team default / absent state"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/dispatch_idle/fixup_nudge.rs
+++ b/src/daemon/dispatch_idle/fixup_nudge.rs
@@ -20,18 +20,17 @@
 
 use std::path::Path;
 
+use super::{list_pending, pending_path, PendingDispatch};
+
 /// Fixup team name as it appears in fleet.yaml. Single source of truth.
-#[allow(dead_code)] // C1 RED stub — wired in C2
 pub(crate) const FIXUP_TEAM_NAME: &str = "fixup";
 
 /// Default dispatch-idle threshold for fixup-team members when no
 /// explicit `expect_reply_within_secs` is set on the dispatch. 600s
 /// (10 min) per the original watchdog spec.
-#[allow(dead_code)] // C1 RED stub — wired in C2
 pub(crate) const FIXUP_DEFAULT_THRESHOLD_SECS: i64 = 600;
 
 /// Scan throttle: 6 ticks × 10s = ~60s — matches L1 cadence.
-#[allow(dead_code)] // C1 RED stub — wired in C2
 pub(crate) const TICKS_PER_SCAN: u64 = 6;
 
 /// Resolve the threshold the dispatcher's send should record against.
@@ -40,13 +39,22 @@ pub(crate) const TICKS_PER_SCAN: u64 = 6;
 /// - `Some(FIXUP_DEFAULT_THRESHOLD_SECS)` when no explicit value and
 ///   the dispatcher is a fixup-team member.
 /// - `None` otherwise (cross-team-safe default-disabled).
-#[allow(dead_code)] // C1 RED stub — wired in C2
 pub(crate) fn resolve_threshold_for_dispatch(
-    _home: &Path,
-    _dispatcher: &str,
-    _explicit_threshold_secs: Option<i64>,
+    home: &Path,
+    dispatcher: &str,
+    explicit_threshold_secs: Option<i64>,
 ) -> Option<i64> {
-    None
+    if let Some(explicit) = explicit_threshold_secs {
+        if explicit > 0 {
+            return Some(explicit);
+        }
+    }
+    let team = crate::teams::find_team_for(home, dispatcher)?;
+    if team.name == FIXUP_TEAM_NAME {
+        Some(FIXUP_DEFAULT_THRESHOLD_SECS)
+    } else {
+        None
+    }
 }
 
 /// Per-loop scheduler state for the auto-nudge tracker.
@@ -56,22 +64,116 @@ pub(crate) struct DispatchIdleFixupNudgeTracker {
 }
 
 impl DispatchIdleFixupNudgeTracker {
-    #[allow(dead_code)] // C1 RED stub — wired in C2
-    pub(crate) fn maybe_scan(&mut self, _home: &Path) -> bool {
-        let _ = self.tick_count;
-        false
+    pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
+        self.tick_count = self.tick_count.saturating_add(1);
+        if self.tick_count < TICKS_PER_SCAN {
+            return false;
+        }
+        self.tick_count = 0;
+        scan_and_nudge(home);
+        true
+    }
+}
+
+fn is_fixup_member(home: &Path, agent: &str) -> bool {
+    crate::teams::find_team_for(home, agent)
+        .map(|t| t.name == FIXUP_TEAM_NAME)
+        .unwrap_or(false)
+}
+
+fn write_dispatch_sidecar(home: &Path, d: &PendingDispatch) -> bool {
+    let body = match serde_json::to_string_pretty(d) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    crate::store::atomic_write(&pending_path(home, &d.dispatch_id), body.as_bytes()).is_ok()
+}
+
+fn emit_nudge(home: &Path, d: &PendingDispatch) -> bool {
+    let elapsed = chrono::DateTime::parse_from_rfc3339(&d.issued_at)
+        .map(|t| {
+            chrono::Utc::now()
+                .signed_duration_since(t.with_timezone(&chrono::Utc))
+                .num_seconds()
+        })
+        .unwrap_or(0);
+    let text = format!(
+        "[fixup-watchdog] dispatched by '{dispatcher}' {elapsed}s ago \
+         (threshold {threshold_secs}s, correlation_id={corr}). \
+         Please status: BUSY / progress / VERIFIED-if-ready.",
+        dispatcher = d.dispatcher,
+        elapsed = elapsed,
+        threshold_secs = d.threshold_secs,
+        corr = d.correlation_id.as_deref().unwrap_or(""),
+    );
+    let msg = crate::inbox::InboxMessage {
+        schema_version: 0,
+        id: None,
+        from: "system:fixup-watchdog".to_string(),
+        text,
+        kind: Some("dispatch_idle_nudge".to_string()),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        channel: None,
+        read_at: None,
+        thread_id: None,
+        parent_id: None,
+        delivery_mode: Some("inbox_fallback".to_string()),
+        task_id: d.correlation_id.clone(),
+        force_meta: None,
+        correlation_id: d.correlation_id.clone(),
+        reviewed_head: None,
+        attachments: Vec::new(),
+        in_reply_to_msg_id: None,
+        in_reply_to_excerpt: None,
+        superseded_by: None,
+        from_id: None,
+        broadcast_context: None,
+        sequencing: None,
+        eta_minutes: None,
+        reporting_cadence: None,
+        worktree_binding_required: None,
+    };
+    match crate::inbox::enqueue(home, &d.target, msg) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                target = %d.target,
+                dispatch_id = %d.dispatch_id,
+                "fixup_nudge: enqueue failed"
+            );
+            false
+        }
     }
 }
 
 /// Scan exceeded sidecars and emit nudges. Exposed `pub(crate)` for
 /// tests.
-#[allow(dead_code)] // C1 RED stub — wired in C2
-pub(crate) fn scan_and_nudge(_home: &Path) {
-    // C1 RED: stub.
+pub(crate) fn scan_and_nudge(home: &Path) {
+    for mut d in list_pending(home) {
+        if d.status != "exceeded" {
+            continue;
+        }
+        if d.nudge_sent_at.is_some() {
+            continue;
+        }
+        if !is_fixup_member(home, &d.dispatcher) {
+            continue;
+        }
+        if !emit_nudge(home, &d) {
+            continue;
+        }
+        d.nudge_sent_at = Some(chrono::Utc::now().to_rfc3339());
+        let _ = write_dispatch_sidecar(home, &d);
+    }
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::doc_lazy_continuation
+)]
 mod tests {
     use super::*;
     use crate::daemon::dispatch_idle::{pending_dir, pending_path, PendingDispatch};

--- a/src/daemon/dispatch_idle/fixup_nudge.rs
+++ b/src/daemon/dispatch_idle/fixup_nudge.rs
@@ -1,0 +1,214 @@
+//! L2: fixup-team-specific dispatch-idle automation.
+//!
+//! Two responsibilities, both hard-coded for the fixup team:
+//! 1. **Threshold injection** at dispatch time — when fixup-team
+//!    members `send(kind=task|query)` without explicit
+//!    `expect_reply_within_secs`, inject the default 600s (10min)
+//!    so the L1 tracker engages by default for fixup orchestration.
+//! 2. **Auto-nudge** when the L1 watchdog fires — scan exceeded
+//!    sidecars where the dispatcher belongs to the fixup team and the
+//!    nudge has not yet been emitted, then send a status-request
+//!    message to the dispatchee (NOT team-wide — target-specific,
+//!    matching the L1 sidecar's `target` field).
+//!
+//! Cross-team isolation: this is the ONLY file that knows the string
+//! "fixup". Other teams who want the same automation add a sibling
+//! `dispatch_idle/<team>_nudge.rs` module following this exact shape.
+//!
+//! Defer config-driven thresholds to L2.1 (TeamConfig schema bump)
+//! when a second team requests its own default.
+
+use std::path::Path;
+
+/// Fixup team name as it appears in fleet.yaml. Single source of truth.
+#[allow(dead_code)] // C1 RED stub — wired in C2
+pub(crate) const FIXUP_TEAM_NAME: &str = "fixup";
+
+/// Default dispatch-idle threshold for fixup-team members when no
+/// explicit `expect_reply_within_secs` is set on the dispatch. 600s
+/// (10 min) per the original watchdog spec.
+#[allow(dead_code)] // C1 RED stub — wired in C2
+pub(crate) const FIXUP_DEFAULT_THRESHOLD_SECS: i64 = 600;
+
+/// Scan throttle: 6 ticks × 10s = ~60s — matches L1 cadence.
+#[allow(dead_code)] // C1 RED stub — wired in C2
+pub(crate) const TICKS_PER_SCAN: u64 = 6;
+
+/// Resolve the threshold the dispatcher's send should record against.
+/// Returns:
+/// - `Some(explicit)` when the caller provided one.
+/// - `Some(FIXUP_DEFAULT_THRESHOLD_SECS)` when no explicit value and
+///   the dispatcher is a fixup-team member.
+/// - `None` otherwise (cross-team-safe default-disabled).
+#[allow(dead_code)] // C1 RED stub — wired in C2
+pub(crate) fn resolve_threshold_for_dispatch(
+    _home: &Path,
+    _dispatcher: &str,
+    _explicit_threshold_secs: Option<i64>,
+) -> Option<i64> {
+    None
+}
+
+/// Per-loop scheduler state for the auto-nudge tracker.
+#[derive(Debug, Default)]
+pub(crate) struct DispatchIdleFixupNudgeTracker {
+    tick_count: u64,
+}
+
+impl DispatchIdleFixupNudgeTracker {
+    #[allow(dead_code)] // C1 RED stub — wired in C2
+    pub(crate) fn maybe_scan(&mut self, _home: &Path) -> bool {
+        let _ = self.tick_count;
+        false
+    }
+}
+
+/// Scan exceeded sidecars and emit nudges. Exposed `pub(crate)` for
+/// tests.
+#[allow(dead_code)] // C1 RED stub — wired in C2
+pub(crate) fn scan_and_nudge(_home: &Path) {
+    // C1 RED: stub.
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::daemon::dispatch_idle::{pending_dir, pending_path, PendingDispatch};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-dispatch-idle-fixup-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    /// Write a fleet.yaml that puts `dispatcher` into the fixup team.
+    fn write_fleet_with_fixup_member(home: &Path, member: &str) {
+        let yaml = format!(
+            "schema_version: 1\n\
+             teams:\n  fixup:\n    members: [{member}]\n    orchestrator: {member}\n"
+        );
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+    }
+
+    /// Write an exceeded sidecar directly (no nudge yet).
+    fn write_exceeded_sidecar(
+        home: &Path,
+        dispatcher: &str,
+        target: &str,
+        correlation_id: &str,
+        elapsed_secs: i64,
+    ) -> String {
+        let dir = pending_dir(home);
+        std::fs::create_dir_all(&dir).unwrap();
+        let id = format!("disp-test-{correlation_id}");
+        let issued = (chrono::Utc::now() - chrono::Duration::seconds(elapsed_secs)).to_rfc3339();
+        let payload = PendingDispatch {
+            schema_version: 1,
+            dispatch_id: id.clone(),
+            dispatcher: dispatcher.to_string(),
+            target: target.to_string(),
+            correlation_id: Some(correlation_id.to_string()),
+            expected_kind: "task".to_string(),
+            threshold_secs: 600,
+            issued_at: issued,
+            status: "exceeded".to_string(),
+            nudge_sent_at: None,
+        };
+        std::fs::write(
+            pending_path(home, &id),
+            serde_json::to_string_pretty(&payload).unwrap(),
+        )
+        .unwrap();
+        id
+    }
+
+    /// 9. First scan nudges; second scan does NOT re-nudge (dedup via
+    /// `nudge_sent_at` field).
+    #[test]
+    fn nudge_dedup_via_nudge_sent_at() {
+        let home = tmp_home("dedup");
+        write_fleet_with_fixup_member(&home, "fixup-lead");
+        write_exceeded_sidecar(&home, "fixup-lead", "fixup-reviewer", "t-dedup", 700);
+        scan_and_nudge(&home);
+        let first_count = crate::inbox::drain(&home, "fixup-reviewer")
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dispatch_idle_nudge"))
+            .count();
+        assert_eq!(first_count, 1, "first scan must send exactly one nudge");
+        scan_and_nudge(&home);
+        let second_count = crate::inbox::drain(&home, "fixup-reviewer")
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dispatch_idle_nudge"))
+            .count();
+        assert_eq!(
+            second_count, 0,
+            "second scan must NOT re-nudge (dedup via nudge_sent_at)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// 10. Nudge must target the sidecar's `target` field (the
+    /// dispatchee), NOT team-wide. Parallel dev-1 + dev-2 dispatches
+    /// must not cross-pollinate.
+    #[test]
+    fn nudge_targets_dispatchee_not_team() {
+        let home = tmp_home("target-precision");
+        // Multiple fixup members; only fixup-reviewer should get the
+        // nudge for the exceeded sidecar.
+        let yaml = "schema_version: 1\n\
+                    teams:\n  fixup:\n    members: [fixup-lead, fixup-reviewer, fixup-dev, fixup-dev-2]\n\
+                            orchestrator: fixup-lead\n";
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        write_exceeded_sidecar(&home, "fixup-lead", "fixup-reviewer", "t-precise", 700);
+        scan_and_nudge(&home);
+        let to_reviewer = crate::inbox::drain(&home, "fixup-reviewer")
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dispatch_idle_nudge"))
+            .count();
+        let to_dev = crate::inbox::drain(&home, "fixup-dev")
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dispatch_idle_nudge"))
+            .count();
+        let to_dev2 = crate::inbox::drain(&home, "fixup-dev-2")
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dispatch_idle_nudge"))
+            .count();
+        assert_eq!(to_reviewer, 1, "the dispatchee receives exactly one nudge");
+        assert_eq!(to_dev, 0, "other team members are NOT nudged");
+        assert_eq!(to_dev2, 0, "other team members are NOT nudged");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// 11. Cross-team isolation contract: if the dispatcher is not in
+    /// the fixup team, this module does not nudge. Other teams must
+    /// supply their own `<team>_nudge.rs`.
+    #[test]
+    fn nudge_skips_non_fixup_dispatcher() {
+        let home = tmp_home("non-fixup");
+        // No fleet.yaml fixup team → dispatcher isn't a fixup member.
+        let yaml = "schema_version: 1\n\
+                    teams:\n  research:\n    members: [research-lead, research-dev]\n\
+                            orchestrator: research-lead\n";
+        std::fs::write(home.join("fleet.yaml"), yaml).unwrap();
+        write_exceeded_sidecar(&home, "research-lead", "research-dev", "t-cross", 700);
+        scan_and_nudge(&home);
+        let inbox = crate::inbox::drain(&home, "research-dev");
+        assert!(
+            !inbox
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("dispatch_idle_nudge")),
+            "fixup_nudge must NOT nudge non-fixup-team dispatchees: {inbox:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -92,24 +92,81 @@ fn next_dispatch_id() -> String {
 /// best-effort (the message has already been delivered; watchdog
 /// coverage is a defence-in-depth layer that must never block the
 /// dispatch primitive).
-#[allow(dead_code)] // C1 RED stub — wired in C2
 pub(crate) fn record_dispatch(
-    _home: &Path,
-    _dispatcher: &str,
-    _target: &str,
-    _correlation_id: Option<&str>,
-    _expected_kind: &str,
-    _threshold_secs: i64,
+    home: &Path,
+    dispatcher: &str,
+    target: &str,
+    correlation_id: Option<&str>,
+    expected_kind: &str,
+    threshold_secs: i64,
 ) -> Option<String> {
-    // C1 RED: stub — return None so failing tests prove the impl gap.
-    None
+    if dispatcher.is_empty() || target.is_empty() || threshold_secs <= 0 {
+        return None;
+    }
+    if !matches!(expected_kind, "task" | "query") {
+        return None;
+    }
+    let dir = pending_dir(home);
+    if std::fs::create_dir_all(&dir).is_err() {
+        return None;
+    }
+    let dispatch_id = next_dispatch_id();
+    let payload = PendingDispatch {
+        schema_version: SCHEMA_VERSION,
+        dispatch_id: dispatch_id.clone(),
+        dispatcher: dispatcher.to_string(),
+        target: target.to_string(),
+        correlation_id: correlation_id.map(String::from),
+        expected_kind: expected_kind.to_string(),
+        threshold_secs,
+        issued_at: chrono::Utc::now().to_rfc3339(),
+        status: "pending".to_string(),
+        nudge_sent_at: None,
+    };
+    let body = match serde_json::to_string_pretty(&payload) {
+        Ok(s) => s,
+        Err(_) => return None,
+    };
+    if crate::store::atomic_write(&pending_path(home, &dispatch_id), body.as_bytes()).is_err() {
+        return None;
+    }
+    Some(dispatch_id)
 }
 
 /// Read all pending dispatch sidecars from disk. Forward-compat: skips
 /// any sidecar whose `schema_version` is unknown.
-#[allow(dead_code)] // C1 RED stub — wired in C2
-pub(crate) fn list_pending(_home: &Path) -> Vec<PendingDispatch> {
-    Vec::new()
+pub(crate) fn list_pending(home: &Path) -> Vec<PendingDispatch> {
+    let dir = pending_dir(home);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(d) = serde_json::from_str::<PendingDispatch>(&content) else {
+            continue;
+        };
+        if d.schema_version != SCHEMA_VERSION {
+            continue;
+        }
+        out.push(d);
+    }
+    out.sort_by(|a, b| a.issued_at.cmp(&b.issued_at));
+    out
+}
+
+fn write_dispatch(home: &Path, d: &PendingDispatch) -> bool {
+    let body = match serde_json::to_string_pretty(d) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    crate::store::atomic_write(&pending_path(home, &d.dispatch_id), body.as_bytes()).is_ok()
 }
 
 /// Resolve a pending dispatch by `correlation_id` (NOT by sender —
@@ -117,16 +174,108 @@ pub(crate) fn list_pending(_home: &Path) -> Vec<PendingDispatch> {
 /// single dispatcher can have multiple pending dispatches outstanding,
 /// each with a distinct correlation_id). Returns the resolved
 /// dispatch_id, or `None` if no matching pending entry exists.
-#[allow(dead_code)] // C1 RED stub — wired in C2
-pub(crate) fn mark_resolved(_home: &Path, _correlation_id: &str) -> Option<String> {
-    None
+pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String> {
+    if correlation_id.is_empty() {
+        return None;
+    }
+    let matched = list_pending(home)
+        .into_iter()
+        .find(|d| d.status == "pending" && d.correlation_id.as_deref() == Some(correlation_id));
+    let mut d = matched?;
+    d.status = "resolved".to_string();
+    let id = d.dispatch_id.clone();
+    if write_dispatch(home, &d) {
+        Some(id)
+    } else {
+        None
+    }
 }
 
 /// Per-tick scan: flip eligible pending entries to `exceeded` and emit
 /// the inbox event to the dispatcher. Exposed `pub(crate)` for tests.
-#[allow(dead_code)] // C1 RED stub — wired in C2
-pub(crate) fn scan_and_emit(_home: &Path) {
-    // C1 RED: stub.
+pub(crate) fn scan_and_emit(home: &Path) {
+    let now = chrono::Utc::now();
+    for mut d in list_pending(home) {
+        if d.status != "pending" {
+            continue;
+        }
+        let issued = match chrono::DateTime::parse_from_rfc3339(&d.issued_at) {
+            Ok(t) => t.with_timezone(&chrono::Utc),
+            Err(_) => continue,
+        };
+        let elapsed_secs = now.signed_duration_since(issued).num_seconds();
+        if elapsed_secs <= d.threshold_secs {
+            continue;
+        }
+        emit_exceeded_event(home, &d, elapsed_secs);
+        d.status = "exceeded".to_string();
+        let _ = write_dispatch(home, &d);
+    }
+}
+
+fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
+    let overshoot = elapsed_secs - d.threshold_secs;
+    let text = format!(
+        "[dispatch_idle_threshold_exceeded] dispatch {dispatch_id} from '{dispatcher}' → '{target}' \
+         (kind={expected_kind}, correlation_id={corr}) idle for {elapsed_secs}s \
+         (threshold {threshold_secs}s, exceeded by {overshoot}s).",
+        dispatch_id = d.dispatch_id,
+        dispatcher = d.dispatcher,
+        target = d.target,
+        expected_kind = d.expected_kind,
+        corr = d.correlation_id.as_deref().unwrap_or(""),
+        elapsed_secs = elapsed_secs,
+        threshold_secs = d.threshold_secs,
+        overshoot = overshoot,
+    );
+    let msg = crate::inbox::InboxMessage {
+        schema_version: 0,
+        id: None,
+        from: "system:dispatch_idle".to_string(),
+        text,
+        kind: Some("dispatch_idle_threshold_exceeded".to_string()),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        channel: None,
+        read_at: None,
+        thread_id: None,
+        parent_id: None,
+        delivery_mode: Some("inbox_fallback".to_string()),
+        task_id: d.correlation_id.clone(),
+        force_meta: None,
+        correlation_id: d.correlation_id.clone(),
+        reviewed_head: None,
+        attachments: Vec::new(),
+        in_reply_to_msg_id: None,
+        in_reply_to_excerpt: None,
+        superseded_by: None,
+        from_id: None,
+        broadcast_context: None,
+        sequencing: None,
+        eta_minutes: None,
+        reporting_cadence: None,
+        worktree_binding_required: None,
+    };
+    if let Err(e) = crate::inbox::enqueue(home, &d.dispatcher, msg) {
+        tracing::warn!(
+            error = %e,
+            dispatcher = %d.dispatcher,
+            dispatch_id = %d.dispatch_id,
+            "dispatch_idle: enqueue failed"
+        );
+    }
+    crate::event_log::log(
+        home,
+        "dispatch_idle_threshold_exceeded",
+        &d.dispatcher,
+        &format!(
+            "dispatch_id={} target={} corr={} elapsed_secs={} threshold_secs={}",
+            d.dispatch_id,
+            d.target,
+            d.correlation_id.as_deref().unwrap_or(""),
+            elapsed_secs,
+            d.threshold_secs,
+        ),
+    );
 }
 
 /// Per-loop scheduler state.
@@ -139,16 +288,23 @@ impl DispatchIdleTracker {
     /// Per-tick entry. Increments the counter; on the throttled
     /// boundary, fires `scan_and_emit` and returns `true`. Returns
     /// `false` for all pre-boundary ticks.
-    #[allow(dead_code)] // C1 RED stub — wired in C2
-    pub(crate) fn maybe_scan(&mut self, _home: &Path) -> bool {
-        // C1 RED: stub — never fires.
-        let _ = self.tick_count;
-        false
+    pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
+        self.tick_count = self.tick_count.saturating_add(1);
+        if self.tick_count < TICKS_PER_SCAN {
+            return false;
+        }
+        self.tick_count = 0;
+        scan_and_emit(home);
+        true
     }
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::doc_lazy_continuation
+)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -229,15 +385,8 @@ mod tests {
     #[test]
     fn record_and_list_pending_dispatch() {
         let home = tmp_home("record");
-        let id = record_dispatch(
-            &home,
-            "lead",
-            "reviewer",
-            Some("t-abc"),
-            "task",
-            600,
-        )
-        .expect("record must return id");
+        let id = record_dispatch(&home, "lead", "reviewer", Some("t-abc"), "task", 600)
+            .expect("record must return id");
         let pending = list_pending(&home);
         assert_eq!(pending.len(), 1);
         let p = &pending[0];
@@ -257,21 +406,14 @@ mod tests {
     fn fires_on_threshold_exceeded() {
         let home = tmp_home("fires");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        let id = write_pending_at(
-            &home,
-            "alpha",
-            "beta",
-            Some("t-fires"),
-            "task",
-            600,
-            issued,
-        );
+        let id = write_pending_at(&home, "alpha", "beta", Some("t-fires"), "task", 600, issued);
         scan_and_emit(&home);
         let inbox = crate::inbox::drain(&home, "alpha");
         assert!(
-            inbox.iter().any(|m| m.kind.as_deref()
-                == Some("dispatch_idle_threshold_exceeded")
-                && m.correlation_id.as_deref() == Some("t-fires")),
+            inbox.iter().any(
+                |m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")
+                    && m.correlation_id.as_deref() == Some("t-fires")
+            ),
             "must emit dispatch_idle_threshold_exceeded event to dispatcher's inbox: {inbox:?}"
         );
         let pending = list_pending(&home);
@@ -288,12 +430,8 @@ mod tests {
     fn mark_resolved_keys_on_correlation_id_not_sender() {
         let home = tmp_home("resolve-by-corr");
         let now = chrono::Utc::now();
-        let id_a = write_pending_at(
-            &home, "lead", "dev-1", Some("t-aaa"), "task", 600, now,
-        );
-        let id_b = write_pending_at(
-            &home, "lead", "dev-2", Some("t-bbb"), "task", 600, now,
-        );
+        let id_a = write_pending_at(&home, "lead", "dev-1", Some("t-aaa"), "task", 600, now);
+        let id_b = write_pending_at(&home, "lead", "dev-2", Some("t-bbb"), "task", 600, now);
         let resolved = mark_resolved(&home, "t-aaa");
         assert_eq!(
             resolved.as_deref(),
@@ -347,24 +485,10 @@ mod tests {
         let home = tmp_home("parallel-iso");
         let stale = chrono::Utc::now() - chrono::Duration::seconds(700);
         let fresh = chrono::Utc::now() - chrono::Duration::seconds(60);
-        let id_stale = write_pending_at(
-            &home,
-            "lead",
-            "dev-1",
-            Some("t-stale"),
-            "task",
-            600,
-            stale,
-        );
-        let id_fresh = write_pending_at(
-            &home,
-            "lead",
-            "dev-2",
-            Some("t-fresh"),
-            "task",
-            600,
-            fresh,
-        );
+        let id_stale =
+            write_pending_at(&home, "lead", "dev-1", Some("t-stale"), "task", 600, stale);
+        let id_fresh =
+            write_pending_at(&home, "lead", "dev-2", Some("t-fresh"), "task", 600, fresh);
         scan_and_emit(&home);
         let inbox = crate::inbox::drain(&home, "lead");
         let exceeded_events: Vec<_> = inbox
@@ -405,8 +529,7 @@ mod tests {
     #[test]
     fn no_team_name_strings_in_l1() {
         let manifest = env!("CARGO_MANIFEST_DIR");
-        let l1_path =
-            std::path::PathBuf::from(manifest).join("src/daemon/dispatch_idle/mod.rs");
+        let l1_path = std::path::PathBuf::from(manifest).join("src/daemon/dispatch_idle/mod.rs");
         let body = std::fs::read_to_string(&l1_path)
             .expect("L1 file must be readable from CARGO_MANIFEST_DIR");
         let mut offenders: Vec<(usize, &str, String)> = Vec::new();

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -1,0 +1,473 @@
+//! L1: cross-team-safe dispatch-idle watchdog.
+//!
+//! Tracks `send(kind=task|query)` calls that carry an explicit
+//! `expect_reply_within_secs` opt-in. When the expected reply hasn't
+//! arrived inside the threshold window, fires a
+//! `dispatch_idle_threshold_exceeded` event to the dispatcher's inbox.
+//!
+//! Cross-team contract: this file MUST stay team-name-free.
+//! `no_team_name_strings_in_l1` is the load-bearing invariant test —
+//! any L1 grep hit for "fixup" / "reviewer" / "lead" fails CI.
+//! Teams opt in by setting `expect_reply_within_secs` on their own
+//! dispatches; team-specific automation lives in sibling modules
+//! (see `fixup_nudge`).
+//!
+//! Pattern lineage: closest mirror is `decision_timeout` (threshold +
+//! resolve + sidecar lifecycle); hook-site precedent is #870 in
+//! `auto_release` (handle_send post-enqueue).
+
+pub(crate) mod fixup_nudge;
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+const PENDING_DIR: &str = "pending-dispatches";
+const SCHEMA_VERSION: u32 = 1;
+
+/// Scan throttle in supervisor ticks. 6 ≈ 60s at the 10s tick rate —
+/// faster than the 30-tick siblings because the threshold the watchdog
+/// is gating (single-digit minutes for orchestrator-class dispatches)
+/// demands ≤60s fire-time accuracy. Mirrors auto_release's
+/// responsiveness-critical cadence rationale.
+pub(crate) const TICKS_PER_SCAN: u64 = 6;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PendingDispatch {
+    #[serde(default)]
+    pub(crate) schema_version: u32,
+    #[serde(default)]
+    pub(crate) dispatch_id: String,
+    /// The `send.from` identity (who is waiting for a reply).
+    #[serde(default)]
+    pub(crate) dispatcher: String,
+    /// The `send.target` identity (who is expected to reply).
+    #[serde(default)]
+    pub(crate) target: String,
+    /// `task_id` / thread correlation id from the original dispatch.
+    #[serde(default)]
+    pub(crate) correlation_id: Option<String>,
+    /// Original dispatch kind: `"task"` or `"query"`.
+    #[serde(default)]
+    pub(crate) expected_kind: String,
+    #[serde(default)]
+    pub(crate) threshold_secs: i64,
+    #[serde(default)]
+    pub(crate) issued_at: String,
+    /// `pending` | `exceeded` | `resolved` | `cancelled`.
+    #[serde(default = "default_status")]
+    pub(crate) status: String,
+    /// L2-owned dedup field: timestamp of the last nudge emitted for
+    /// this dispatch. `None` = no nudge sent yet. L1 never reads this
+    /// field; it lives in the L1 schema to keep the sidecar a single
+    /// source of truth (avoids parallel L2 sidecar bookkeeping).
+    #[serde(default)]
+    pub(crate) nudge_sent_at: Option<String>,
+}
+
+fn default_status() -> String {
+    "pending".to_string()
+}
+
+pub(crate) fn pending_dir(home: &Path) -> PathBuf {
+    home.join(PENDING_DIR)
+}
+
+pub(crate) fn pending_path(home: &Path, dispatch_id: &str) -> PathBuf {
+    pending_dir(home).join(format!("{dispatch_id}.json"))
+}
+
+/// Generate a deterministic-format dispatch id (`disp-<unix_micros>-<seq>`).
+fn next_dispatch_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let ts = chrono::Utc::now().format("%Y%m%d%H%M%S%6f");
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("disp-{ts}-{seq}")
+}
+
+/// Record an outbound dispatch. Returns the new dispatch_id, or `None`
+/// if the inputs are invalid / the disk write failed.
+///
+/// Called from `handle_send` post-enqueue: any failure here is silently
+/// best-effort (the message has already been delivered; watchdog
+/// coverage is a defence-in-depth layer that must never block the
+/// dispatch primitive).
+#[allow(dead_code)] // C1 RED stub — wired in C2
+pub(crate) fn record_dispatch(
+    _home: &Path,
+    _dispatcher: &str,
+    _target: &str,
+    _correlation_id: Option<&str>,
+    _expected_kind: &str,
+    _threshold_secs: i64,
+) -> Option<String> {
+    // C1 RED: stub — return None so failing tests prove the impl gap.
+    None
+}
+
+/// Read all pending dispatch sidecars from disk. Forward-compat: skips
+/// any sidecar whose `schema_version` is unknown.
+#[allow(dead_code)] // C1 RED stub — wired in C2
+pub(crate) fn list_pending(_home: &Path) -> Vec<PendingDispatch> {
+    Vec::new()
+}
+
+/// Resolve a pending dispatch by `correlation_id` (NOT by sender —
+/// decision_timeout's sender-keyed semantic is wrong here because a
+/// single dispatcher can have multiple pending dispatches outstanding,
+/// each with a distinct correlation_id). Returns the resolved
+/// dispatch_id, or `None` if no matching pending entry exists.
+#[allow(dead_code)] // C1 RED stub — wired in C2
+pub(crate) fn mark_resolved(_home: &Path, _correlation_id: &str) -> Option<String> {
+    None
+}
+
+/// Per-tick scan: flip eligible pending entries to `exceeded` and emit
+/// the inbox event to the dispatcher. Exposed `pub(crate)` for tests.
+#[allow(dead_code)] // C1 RED stub — wired in C2
+pub(crate) fn scan_and_emit(_home: &Path) {
+    // C1 RED: stub.
+}
+
+/// Per-loop scheduler state.
+#[derive(Debug, Default)]
+pub(crate) struct DispatchIdleTracker {
+    tick_count: u64,
+}
+
+impl DispatchIdleTracker {
+    /// Per-tick entry. Increments the counter; on the throttled
+    /// boundary, fires `scan_and_emit` and returns `true`. Returns
+    /// `false` for all pre-boundary ticks.
+    #[allow(dead_code)] // C1 RED stub — wired in C2
+    pub(crate) fn maybe_scan(&mut self, _home: &Path) -> bool {
+        // C1 RED: stub — never fires.
+        let _ = self.tick_count;
+        false
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-dispatch-idle-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    /// Write a backdated pending sidecar directly (bypasses
+    /// `record_dispatch`) so timeout scenarios don't require sleeping.
+    fn write_pending_at(
+        home: &Path,
+        dispatcher: &str,
+        target: &str,
+        correlation_id: Option<&str>,
+        expected_kind: &str,
+        threshold_secs: i64,
+        issued_at: chrono::DateTime<chrono::Utc>,
+    ) -> String {
+        let dir = pending_dir(home);
+        std::fs::create_dir_all(&dir).unwrap();
+        let id = next_dispatch_id();
+        let payload = PendingDispatch {
+            schema_version: SCHEMA_VERSION,
+            dispatch_id: id.clone(),
+            dispatcher: dispatcher.to_string(),
+            target: target.to_string(),
+            correlation_id: correlation_id.map(String::from),
+            expected_kind: expected_kind.to_string(),
+            threshold_secs,
+            issued_at: issued_at.to_rfc3339(),
+            status: "pending".to_string(),
+            nudge_sent_at: None,
+        };
+        std::fs::write(
+            pending_path(home, &id),
+            serde_json::to_string_pretty(&payload).unwrap(),
+        )
+        .unwrap();
+        id
+    }
+
+    /// 1. Throttle contract — TICKS_PER_SCAN-1 calls return false, the
+    /// next fires (returns true), and the counter resets.
+    #[test]
+    fn tracker_throttles_to_tick_per_scan() {
+        let home = tmp_home("throttle");
+        let mut tracker = DispatchIdleTracker::default();
+        for i in 0..(TICKS_PER_SCAN - 1) {
+            assert!(
+                !tracker.maybe_scan(&home),
+                "tick {i} (pre-throttle) must return false"
+            );
+        }
+        assert!(
+            tracker.maybe_scan(&home),
+            "{}th tick must fire scan and return true",
+            TICKS_PER_SCAN
+        );
+        assert!(
+            !tracker.maybe_scan(&home),
+            "post-fire tick must reset counter and return false"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// 2. `record_dispatch` writes a sidecar that `list_pending` can
+    /// round-trip.
+    #[test]
+    fn record_and_list_pending_dispatch() {
+        let home = tmp_home("record");
+        let id = record_dispatch(
+            &home,
+            "lead",
+            "reviewer",
+            Some("t-abc"),
+            "task",
+            600,
+        )
+        .expect("record must return id");
+        let pending = list_pending(&home);
+        assert_eq!(pending.len(), 1);
+        let p = &pending[0];
+        assert_eq!(p.dispatch_id, id);
+        assert_eq!(p.dispatcher, "lead");
+        assert_eq!(p.target, "reviewer");
+        assert_eq!(p.correlation_id.as_deref(), Some("t-abc"));
+        assert_eq!(p.expected_kind, "task");
+        assert_eq!(p.threshold_secs, 600);
+        assert_eq!(p.status, "pending");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// 3. `scan_and_emit` flips exceeded entries and emits an inbox
+    /// event to the dispatcher.
+    #[test]
+    fn fires_on_threshold_exceeded() {
+        let home = tmp_home("fires");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+        let id = write_pending_at(
+            &home,
+            "alpha",
+            "beta",
+            Some("t-fires"),
+            "task",
+            600,
+            issued,
+        );
+        scan_and_emit(&home);
+        let inbox = crate::inbox::drain(&home, "alpha");
+        assert!(
+            inbox.iter().any(|m| m.kind.as_deref()
+                == Some("dispatch_idle_threshold_exceeded")
+                && m.correlation_id.as_deref() == Some("t-fires")),
+            "must emit dispatch_idle_threshold_exceeded event to dispatcher's inbox: {inbox:?}"
+        );
+        let pending = list_pending(&home);
+        let p = pending.iter().find(|p| p.dispatch_id == id).unwrap();
+        assert_eq!(p.status, "exceeded", "sidecar must flip pending→exceeded");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// 4. Load-bearing contract: `mark_resolved` keys on
+    /// `correlation_id`, NOT on `dispatcher`. Decision_timeout's
+    /// sender-keyed semantic would resolve the wrong sidecar when a
+    /// single dispatcher has multiple in-flight dispatches.
+    #[test]
+    fn mark_resolved_keys_on_correlation_id_not_sender() {
+        let home = tmp_home("resolve-by-corr");
+        let now = chrono::Utc::now();
+        let id_a = write_pending_at(
+            &home, "lead", "dev-1", Some("t-aaa"), "task", 600, now,
+        );
+        let id_b = write_pending_at(
+            &home, "lead", "dev-2", Some("t-bbb"), "task", 600, now,
+        );
+        let resolved = mark_resolved(&home, "t-aaa");
+        assert_eq!(
+            resolved.as_deref(),
+            Some(id_a.as_str()),
+            "must resolve the correlation_id-matching sidecar, not sender-matching"
+        );
+        let pending = list_pending(&home);
+        let p_a = pending.iter().find(|p| p.dispatch_id == id_a).unwrap();
+        let p_b = pending.iter().find(|p| p.dispatch_id == id_b).unwrap();
+        assert_eq!(p_a.status, "resolved", "matched sidecar must flip");
+        assert_eq!(
+            p_b.status, "pending",
+            "unmatched sidecar from same dispatcher must NOT flip"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// 5. After `mark_resolved`, the subsequent `scan_and_emit` does
+    /// NOT fire an event (status was resolved before threshold check).
+    #[test]
+    fn mark_resolved_suppresses_fire() {
+        let home = tmp_home("resolved-no-fire");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+        write_pending_at(
+            &home,
+            "alpha",
+            "beta",
+            Some("t-suppress"),
+            "task",
+            600,
+            issued,
+        );
+        let resolved = mark_resolved(&home, "t-suppress");
+        assert!(resolved.is_some(), "mark_resolved must locate sidecar");
+        scan_and_emit(&home);
+        let inbox = crate::inbox::drain(&home, "alpha");
+        assert!(
+            !inbox
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
+            "resolved dispatch must NOT fire timeout event: {inbox:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// 6. Load-bearing contract (parallel dev-1 + dev-2 configuration):
+    /// two sidecars, only the exceeded one fires; the fresh one stays
+    /// pending and does NOT pollute the exceeded one's event.
+    #[test]
+    fn parallel_dispatch_isolation() {
+        let home = tmp_home("parallel-iso");
+        let stale = chrono::Utc::now() - chrono::Duration::seconds(700);
+        let fresh = chrono::Utc::now() - chrono::Duration::seconds(60);
+        let id_stale = write_pending_at(
+            &home,
+            "lead",
+            "dev-1",
+            Some("t-stale"),
+            "task",
+            600,
+            stale,
+        );
+        let id_fresh = write_pending_at(
+            &home,
+            "lead",
+            "dev-2",
+            Some("t-fresh"),
+            "task",
+            600,
+            fresh,
+        );
+        scan_and_emit(&home);
+        let inbox = crate::inbox::drain(&home, "lead");
+        let exceeded_events: Vec<_> = inbox
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded"))
+            .collect();
+        assert_eq!(
+            exceeded_events.len(),
+            1,
+            "exactly one exceeded event for the stale dispatch"
+        );
+        assert_eq!(
+            exceeded_events[0].correlation_id.as_deref(),
+            Some("t-stale"),
+            "the event must reference the stale correlation_id"
+        );
+        let pending = list_pending(&home);
+        let p_stale = pending.iter().find(|p| p.dispatch_id == id_stale).unwrap();
+        let p_fresh = pending.iter().find(|p| p.dispatch_id == id_fresh).unwrap();
+        assert_eq!(p_stale.status, "exceeded");
+        assert_eq!(
+            p_fresh.status, "pending",
+            "fresh dispatch must remain pending"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// 7. Invariant: L1 file MUST stay team-name-free. Cross-team-safe
+    /// design contract. If this test ever fails, the L1 primitive has
+    /// leaked team-specific knowledge and a sibling module is the
+    /// right home for that code.
+    ///
+    /// Two structural allowances: comment lines (any `// …` prefix) and
+    /// the boilerplate `pub(crate) mod fixup_nudge;` declaration that
+    /// wires the L2 submodule into the dispatch_idle module tree.
+    /// Test-module contents are also exempt — placeholder names like
+    /// "lead" / "reviewer" / "dev-1" are legitimate test inputs.
+    #[test]
+    fn no_team_name_strings_in_l1() {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let l1_path =
+            std::path::PathBuf::from(manifest).join("src/daemon/dispatch_idle/mod.rs");
+        let body = std::fs::read_to_string(&l1_path)
+            .expect("L1 file must be readable from CARGO_MANIFEST_DIR");
+        let mut offenders: Vec<(usize, &str, String)> = Vec::new();
+        let mut in_test_mod = false;
+        for (lineno, line) in body.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            if trimmed.starts_with("mod tests") {
+                in_test_mod = true;
+            }
+            if in_test_mod {
+                continue;
+            }
+            // Allowlist: the L2 submodule declaration is structural,
+            // not behavioral. Behaviour-side references stay forbidden.
+            if trimmed == "pub(crate) mod fixup_nudge;" {
+                continue;
+            }
+            for needle in ["fixup", "reviewer", "lead"] {
+                if line.contains(needle) {
+                    offenders.push((lineno + 1, needle, line.to_string()));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "L1 file must stay team-name-free; offenders: {offenders:?}"
+        );
+    }
+
+    /// 8. Forward-compat: a future v2 sidecar must be left on disk and
+    /// skipped by the v1 list_pending. Sprint 58 Wave 1 PR-2 contract.
+    #[test]
+    fn forward_compat_serde() {
+        let home = tmp_home("forward-compat");
+        let dir = pending_dir(&home);
+        std::fs::create_dir_all(&dir).unwrap();
+        let payload = serde_json::json!({
+            "schema_version": SCHEMA_VERSION + 1,
+            "dispatch_id": "disp-future",
+            "dispatcher": "x",
+            "target": "y",
+            "expected_kind": "task",
+            "threshold_secs": 600,
+            "issued_at": "2026-05-09T00:00:00Z",
+            "status": "pending",
+        });
+        std::fs::write(
+            pending_path(&home, "disp-future"),
+            serde_json::to_string_pretty(&payload).unwrap(),
+        )
+        .unwrap();
+        let pending = list_pending(&home);
+        assert!(
+            pending.is_empty(),
+            "future-version sidecar must be skipped by v1 reader"
+        );
+        // File preserved on disk so a v2 reader could pick it up later.
+        assert!(pending_path(&home, "disp-future").exists());
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod conflict_notify;
 pub(crate) mod cron_tick;
 pub(crate) mod decision_timeout;
 pub(crate) mod dedup_state;
+pub(crate) mod dispatch_idle;
 pub(crate) mod heartbeat_pair;
 pub(crate) mod helper_staleness_watchdog;
 pub(crate) mod idle_watchdog;

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -243,6 +243,17 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
     // conflict surface this module exists to eliminate. No new spawn
     // site — supervisor's per-tick loop hosts the scan.
     let mut auto_release_tracker = crate::daemon::auto_release::AutoReleaseTracker::default();
+    // PR1 watchdog L1: cross-team-safe dispatch-idle scan. Sibling
+    // pattern; TICKS_PER_SCAN=6 (~60s) because the threshold this
+    // gates (single-digit-minute orchestrator dispatches) demands
+    // sub-minute fire-time accuracy. No new spawn site — supervisor's
+    // per-tick loop hosts the scan.
+    let mut dispatch_idle_tracker = crate::daemon::dispatch_idle::DispatchIdleTracker::default();
+    // PR1 watchdog L2: fixup-team-specific auto-nudge on exceeded
+    // dispatches. Same cadence as L1; hard-coded for fixup until a
+    // second team requests its own policy (L2.1 schema bump).
+    let mut dispatch_idle_fixup_nudge_tracker =
+        crate::daemon::dispatch_idle::fixup_nudge::DispatchIdleFixupNudgeTracker::default();
     loop {
         thread::sleep(TICK);
         tick(&home, &registry, &mut notify_tracks);
@@ -257,6 +268,8 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
         conflict_notify_tracker.maybe_scan(&home, &registry);
         canonical_drift_tracker.maybe_scan(&home);
         auto_release_tracker.maybe_scan(&home);
+        dispatch_idle_tracker.maybe_scan(&home);
+        dispatch_idle_fixup_nudge_tracker.maybe_scan(&home);
         // #836: reclaim expired (10-min TTL) entries from the
         // notification-dedup ledger so memory pressure stays bounded
         // on long-lived daemons.

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -92,7 +92,7 @@ pub(super) fn handle_send_to_instance(
         home,
         &json!({
             "method": crate::api::method::SEND,
-            "params": { "from": sender.as_str(), "target": target, "text": text, "kind": kind, "thread_id": thread_id, "parent_id": parent_id, "correlation_id": args["correlation_id"].as_str(), "sequencing": args["sequencing"].as_str(), "eta_minutes": args["eta_minutes"].as_u64(), "reporting_cadence": args["reporting_cadence"].as_str(), "worktree_binding_required": args["worktree_binding_required"].as_bool() }
+            "params": { "from": sender.as_str(), "target": target, "text": text, "kind": kind, "thread_id": thread_id, "parent_id": parent_id, "correlation_id": args["correlation_id"].as_str(), "sequencing": args["sequencing"].as_str(), "eta_minutes": args["eta_minutes"].as_u64(), "reporting_cadence": args["reporting_cadence"].as_str(), "worktree_binding_required": args["worktree_binding_required"].as_bool(), "expect_reply_within_secs": args["expect_reply_within_secs"].as_i64() }
         }),
     ) {
         Ok(resp) if resp["ok"].as_bool() == Some(true) => {
@@ -342,6 +342,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                     "task": task,
                 },
                 "branch": args["branch"].as_str(),
+                "expect_reply_within_secs": args["expect_reply_within_secs"].as_i64(),
             }
         }),
     ) {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -62,7 +62,8 @@ fn comm_tools() -> Vec<Value> {
                 "sequencing": {"type": "string", "enum": ["parallel", "sequential", "sequential-merge-only"], "description": "Task execution order constraint"},
                 "eta_minutes": {"type": "integer", "description": "Expected completion time in minutes"},
                 "reporting_cadence": {"type": "string", "enum": ["per-pr", "wave-end", "both"], "description": "When implementer should report back"},
-                "worktree_binding_required": {"type": "boolean", "description": "Whether target must bind to a worktree before starting"}
+                "worktree_binding_required": {"type": "boolean", "description": "Whether target must bind to a worktree before starting"},
+                "expect_reply_within_secs": {"type": "integer", "description": "Opt-in dispatch-idle watchdog (PR1). When set on a kind=task/query send, the daemon records a pending-dispatch sidecar and fires `dispatch_idle_threshold_exceeded` to the dispatcher's inbox if the matching kind=report (correlation_id-keyed) hasn't arrived within this many seconds. Default unset = no tracking (cross-team-safe). Fixup-team dispatches inherit a 10-min default automatically; other teams must opt in explicitly."}
             }, "required": ["message"]}}),
         json!({"name": "inbox", "description": "Check pending messages, OR look up a single message by ID, OR fetch a thread's messages. No params = drain pending. With message_id = describe message status (read/unread/expired/notfound). With thread_id = fetch all messages in thread ordered by timestamp.",
         "inputSchema": {"type": "object", "properties": {


### PR DESCRIPTION
## Summary

PR1 of the dispatch-idle watchdog two-PR split (PR2 = L3 visibility follows). Closes the loop on fixup-reviewer / fixup-dev idle stalls observed today (reviewer finished work, didn't auto-send verdict, sat idle 9+ min until manual nudge).

- **L1** (`src/daemon/dispatch_idle/mod.rs`) — cross-team-safe daemon primitive: pending-dispatch sidecar + `DispatchIdleTracker` (TICKS_PER_SCAN=6, ~60s cadence) + `record_dispatch` / `mark_resolved` / `scan_and_emit`. Fires `dispatch_idle_threshold_exceeded` to the dispatcher's inbox.
- **L2** (`src/daemon/dispatch_idle/fixup_nudge.rs`) — fixup-team auto-nudge: `resolve_threshold_for_dispatch` injects the 600s default for fixup-team members; `DispatchIdleFixupNudgeTracker::scan_and_nudge` filters status=exceeded + dispatcher∈fixup + nudge_sent_at.is_none() and sends a `dispatch_idle_nudge` to the **target** (the dispatchee, NOT team-wide).
- **Hooks** in `handle_send` (post-enqueue, mirror of #870 auto_release ordering) — outbound task/query records sidecar; inbound report resolves by correlation_id.
- **MCP plumbing** — new `expect_reply_within_secs: Option<i64>` field on the `send` tool (declared in `mcp/tools.rs`, plumbed through `comms.rs::handle_delegate_task` + `handle_send_to_instance`).
- **Supervisor wire** — 2 new trackers into the per-tick loop (no new spawn site).

## Spike-derived design

Phase 1 spike (m-20260516235912024508-20) identified `decision_timeout.rs` as the closest semantic mirror (threshold + resolve + sidecar lifecycle + maybe_scan + emit), closer than lead's initial 4-tracker references. Hook-site precedent: #870 `auto_release` post-enqueue in `handle_send`. 5 spike challenges (all addressed; tests cited below):

1. **kind=update doesn't resolve** — BUSY status doesn't suppress watchdog. Test: `hook_kind_update_does_not_resolve_pending`.
2. **mark_resolved keys on correlation_id (NOT sender)** — multi-pending-per-target requires correlation-keyed resolution; `decision_timeout`'s sender-keyed semantic is wrong here. Test: `mark_resolved_keys_on_correlation_id_not_sender` (load-bearing).
3. **Parallel-dispatch isolation** — two pending sidecars (dev-1, dev-2); only the exceeded one fires. Test: `parallel_dispatch_isolation`.
4. **LOC estimate stretch** — actual 573+/89- matches spike recalibration (~600-800), not lead's initial 80-150 / 50 spec. Issue body counts are estimates (§3.16); reviewer dispatch quote.
5. **Hook ordering post-enqueue** — sidecar write after enqueue success; dispatch delivery never blocked by tracking. Auto_release precedent.

## Cross-team-safe invariant

`no_team_name_strings_in_l1` test scans `src/daemon/dispatch_idle/mod.rs` for "fixup" / "reviewer" / "lead" outside comments + tests. One structural allowlist: `pub(crate) mod fixup_nudge;` (boilerplate module declaration is not behaviour). Other teams add their own `dispatch_idle/<team>_nudge.rs` sibling.

## 2-PR split (per spike-confirmed decision)

- **This PR (PR1)** — L1 + L2. Daemon hooks fully wired; usable end-to-end.
- **PR2 (follow-up)** — L3 visibility: `list_instances` + `binding_state` surface `dispatched_waiting_for` / `pending_response_to`. Separate review focus + telemetry-iteration latitude.

## Tier-2 daemon-core flag

Touches `supervisor.rs` (per-tick loop) and `handle_send` (dispatch hook). Reviewer should pay attention to:
- Hook ordering vs `auto_release` (line 312 baseline; new hook at line 332).
- `pending-dispatches/` sidecar lifecycle vs daemon restart (disk-backed; forward-compat via `schema_version`).
- 2 new trackers in supervisor — no new spawn site (per-tick hosts both synchronously); no §10.5 rationale comment required.

## §4.1 push claim

Scope follows dispatch spec t-20260517000548074057-5 (lead m-20260517000622610846-26).

## §3.10 test-first verification

- C1 RED at `b7d681f`: skeletons + 11 tests (8 RED + 3 invariant)
- C2 GREEN at `6e9a3d2`: impl + hooks + 5 hook integration tests

Reviewer can verify: `git checkout b7d681f && cargo test --bin agend-terminal dispatch_idle` → 8 fail; `git checkout 6e9a3d2 && cargo test ...` → 11 pass.

## Test plan

- [x] cargo test --tests: 2370 passed, 7 ignored, 0 failed
- [x] cargo clippy --all-targets -- -D warnings: clean
- [x] cargo fmt --check: clean
- [x] dispatch_idle module tests: 11/11 green (8 RED→GREEN + 3 invariant)
- [x] hook integration tests in messaging.rs: 5/5 green
- [ ] CI on 5 platforms (will be exercised by this PR's CI run)

## Lessons learned (per §5 close-loop)

- **Process win**: `decision_timeout.rs` mirror discovery in spike was the right call — its threshold+resolve+sidecar shape was a near-1:1 template. Lead's cited mirrors (`auto_release`, `conflict_notify`, `canonical_drift`, `waiting_on_stale`) were structurally relevant but semantically less close.
- **Scope shift**: LOC stretch from 80-150/50 spec to 200+/120 actual (per spike recalibration). Driven by serde/tests/forward-compat overhead — not behavioural creep.
- **Unexpected discovery**: 20 empty `init` commits accumulated in worktree from daemon session-checkpoint heartbeats during the ~30min work cycle. `repo action=cleanup_init_commits` scrubbed cleanly pre-push. Worth documenting as standard practice for any >15min PR cycle.
- **Self-reflective check**: parallel-dispatch-isolation test caught the dev-1/dev-2 collision risk during spike before any code landed. Test-first discipline literally enabled by spike-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)