### PR TITLE
feat(watchdog PR2): L3 visibility — list_instances + binding_state surface dispatch metadata

### DIFF
--- a/src/api/handlers/query.rs
+++ b/src/api/handlers/query.rs
@@ -19,6 +19,8 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                     c.health.state.display_name().to_string(),
                 )
             };
+            let (dispatched_waiting_for, pending_response_to) =
+                crate::daemon::dispatch_idle::pending_for_instance(ctx.home, name);
             json!({
                 "name": name,
                 "backend": handle.backend_command,
@@ -26,20 +28,26 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                 "inject_prefix": handle.inject_prefix,
                 "agent_state": agent_state,
                 "health_state": health_state,
-                "kind": "managed"
+                "kind": "managed",
+                "dispatched_waiting_for": dispatched_waiting_for,
+                "pending_response_to": pending_response_to,
             })
         })
         .collect();
     drop(reg);
     let ext = agent::lock_external(ctx.externals);
     for (name, handle) in ext.iter() {
+        let (dispatched_waiting_for, pending_response_to) =
+            crate::daemon::dispatch_idle::pending_for_instance(ctx.home, name);
         agents.push(json!({
             "name": name,
             "backend": handle.backend_command,
             "agent_state": "external",
             "health_state": "connected",
             "kind": "external",
-            "pid": handle.pid
+            "pid": handle.pid,
+            "dispatched_waiting_for": dispatched_waiting_for,
+            "pending_response_to": pending_response_to,
         }));
     }
     json!({"ok": true, "result": {"protocol_version": crate::framing::PROTOCOL_VERSION, "agents": agents}})

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -191,6 +191,75 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
     }
 }
 
+/// PR2 L3 visibility — per-instance dispatch metadata view.
+/// Pending sidecars where this instance is the **dispatcher**: outbound
+/// dispatches it's still waiting for replies on.
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub(crate) struct DispatchedWaitingFor {
+    pub correlation_id: Option<String>,
+    pub target: String,
+    pub threshold_secs: i64,
+    pub elapsed_secs: i64,
+}
+
+/// PR2 L3 visibility — per-instance dispatch metadata view.
+/// Pending sidecars where this instance is the **target**: inbound
+/// dispatches it owes a reply on.
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub(crate) struct PendingResponseTo {
+    pub correlation_id: Option<String>,
+    pub dispatcher: String,
+    pub threshold_secs: i64,
+    pub elapsed_secs: i64,
+}
+
+/// PR2 L3 helper: return the per-instance dispatch-idle metadata for
+/// `agent`, split into outbound (as dispatcher) and inbound (as target)
+/// views.
+///
+/// Only `status == "pending"` sidecars surface — `resolved`,
+/// `exceeded`, and `cancelled` entries are filtered out so the
+/// operator-facing view stays focused on live work.
+pub(crate) fn pending_for_instance(
+    home: &Path,
+    agent: &str,
+) -> (Vec<DispatchedWaitingFor>, Vec<PendingResponseTo>) {
+    let now = chrono::Utc::now();
+    let mut as_dispatcher = Vec::new();
+    let mut as_target = Vec::new();
+    if agent.is_empty() {
+        return (as_dispatcher, as_target);
+    }
+    for d in list_pending(home) {
+        if d.status != "pending" {
+            continue;
+        }
+        let elapsed_secs = chrono::DateTime::parse_from_rfc3339(&d.issued_at)
+            .map(|t| {
+                now.signed_duration_since(t.with_timezone(&chrono::Utc))
+                    .num_seconds()
+            })
+            .unwrap_or(0);
+        if d.dispatcher == agent {
+            as_dispatcher.push(DispatchedWaitingFor {
+                correlation_id: d.correlation_id.clone(),
+                target: d.target.clone(),
+                threshold_secs: d.threshold_secs,
+                elapsed_secs,
+            });
+        }
+        if d.target == agent {
+            as_target.push(PendingResponseTo {
+                correlation_id: d.correlation_id.clone(),
+                dispatcher: d.dispatcher.clone(),
+                threshold_secs: d.threshold_secs,
+                elapsed_secs,
+            });
+        }
+    }
+    (as_dispatcher, as_target)
+}
+
 /// Per-tick scan: flip eligible pending entries to `exceeded` and emit
 /// the inbox event to the dispatcher. Exposed `pub(crate)` for tests.
 pub(crate) fn scan_and_emit(home: &Path) {
@@ -591,6 +660,155 @@ mod tests {
         );
         // File preserved on disk so a v2 reader could pick it up later.
         assert!(pending_path(&home, "disp-future").exists());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── PR2 L3 visibility tests for pending_for_instance ──
+
+    /// Dispatcher view: pending sidecars where this agent is the
+    /// outbound dispatcher surface in `dispatched_waiting_for`.
+    #[test]
+    fn pending_for_instance_surfaces_dispatcher_view() {
+        let home = tmp_home("pfi-dispatcher");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(120);
+        write_pending_at(
+            &home,
+            "fixup-lead",
+            "fixup-reviewer",
+            Some("t-l3-disp"),
+            "task",
+            600,
+            issued,
+        );
+        let (as_dispatcher, as_target) = pending_for_instance(&home, "fixup-lead");
+        assert_eq!(as_dispatcher.len(), 1);
+        assert_eq!(as_dispatcher[0].target, "fixup-reviewer");
+        assert_eq!(
+            as_dispatcher[0].correlation_id.as_deref(),
+            Some("t-l3-disp")
+        );
+        assert_eq!(as_dispatcher[0].threshold_secs, 600);
+        assert!(
+            (110..=130).contains(&as_dispatcher[0].elapsed_secs),
+            "elapsed_secs within 10s window of expected 120: {}",
+            as_dispatcher[0].elapsed_secs
+        );
+        assert!(
+            as_target.is_empty(),
+            "dispatcher agent must NOT appear in its own target view"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Target view: pending sidecars where this agent owes a reply
+    /// surface in `pending_response_to`.
+    #[test]
+    fn pending_for_instance_surfaces_target_view() {
+        let home = tmp_home("pfi-target");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(120);
+        write_pending_at(
+            &home,
+            "fixup-lead",
+            "fixup-reviewer",
+            Some("t-l3-target"),
+            "task",
+            600,
+            issued,
+        );
+        let (_, as_target) = pending_for_instance(&home, "fixup-reviewer");
+        assert_eq!(as_target.len(), 1);
+        assert_eq!(as_target[0].dispatcher, "fixup-lead");
+        assert_eq!(as_target[0].correlation_id.as_deref(), Some("t-l3-target"));
+        assert_eq!(as_target[0].threshold_secs, 600);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Cross-team-safe: a non-fixup agent (and any agent not on a
+    /// sidecar) sees empty arrays. Non-fixup teams that haven't opted
+    /// in to the watchdog never record sidecars (see L2 default
+    /// threshold logic), so L3 is a no-op for them.
+    #[test]
+    fn pending_for_instance_empty_for_unaffected_agent() {
+        let home = tmp_home("pfi-unaffected");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(60);
+        write_pending_at(
+            &home,
+            "fixup-lead",
+            "fixup-reviewer",
+            Some("t-fixup"),
+            "task",
+            600,
+            issued,
+        );
+        let (as_dispatcher, as_target) = pending_for_instance(&home, "research-dev");
+        assert!(
+            as_dispatcher.is_empty() && as_target.is_empty(),
+            "unaffected agent surfaces empty arrays"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Stale filter: resolved / exceeded / cancelled sidecars do NOT
+    /// surface. Only `status == "pending"` reaches L3.
+    #[test]
+    fn pending_for_instance_filters_stale_sidecars() {
+        let home = tmp_home("pfi-stale-filter");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(60);
+        // One pending (must surface)
+        write_pending_at(&home, "lead", "dev", Some("t-pending"), "task", 600, issued);
+        // Three non-pending (must be filtered).
+        for (corr, status) in [
+            ("t-resolved", "resolved"),
+            ("t-exceeded", "exceeded"),
+            ("t-cancelled", "cancelled"),
+        ] {
+            let id = write_pending_at(&home, "lead", "dev", Some(corr), "task", 600, issued);
+            // Flip status on disk.
+            let path = pending_path(&home, &id);
+            let body = std::fs::read_to_string(&path).unwrap();
+            let mut v: serde_json::Value = serde_json::from_str(&body).unwrap();
+            v["status"] = serde_json::Value::String(status.to_string());
+            std::fs::write(&path, serde_json::to_string_pretty(&v).unwrap()).unwrap();
+        }
+        let (as_dispatcher, _) = pending_for_instance(&home, "lead");
+        assert_eq!(
+            as_dispatcher.len(),
+            1,
+            "only status=pending sidecars surface"
+        );
+        assert_eq!(
+            as_dispatcher[0].correlation_id.as_deref(),
+            Some("t-pending"),
+            "non-pending entries must be filtered"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Wire shape: the serde-derived JSON for the L3 metadata uses
+    /// stable snake_case field names. Pins the operator-visible
+    /// schema so future renames are an intentional break, not a
+    /// silent regression.
+    #[test]
+    fn pending_for_instance_serializes_with_stable_field_names() {
+        let home = tmp_home("pfi-shape");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(60);
+        write_pending_at(&home, "lead", "dev", Some("t-shape"), "task", 600, issued);
+        let (as_dispatcher, as_target) = pending_for_instance(&home, "lead");
+        let j = serde_json::to_value(&as_dispatcher[0]).unwrap();
+        assert!(j.get("correlation_id").is_some());
+        assert!(j.get("target").is_some());
+        assert!(j.get("threshold_secs").is_some());
+        assert!(j.get("elapsed_secs").is_some());
+        assert!(
+            as_target.is_empty(),
+            "lead is dispatcher only — target view stays empty"
+        );
+        let (_, as_target_dev) = pending_for_instance(&home, "dev");
+        let j2 = serde_json::to_value(&as_target_dev[0]).unwrap();
+        assert!(j2.get("correlation_id").is_some());
+        assert!(j2.get("dispatcher").is_some());
+        assert!(j2.get("threshold_secs").is_some());
+        assert!(j2.get("elapsed_secs").is_some());
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -80,6 +80,14 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
     let binding = crate::binding::read(home, agent);
     let bind_in_flight = crate::mcp::handlers::dispatch_hook::is_bind_in_flight(home, agent);
     let ci_watches = enumerate_ci_watches_for_agent(home, agent);
+    // PR2 L3 visibility: surface pending dispatch metadata alongside
+    // binding state so operators investigating a stuck binding can see
+    // in one tool call whether the agent owes a reply or is waiting
+    // for one. Empty arrays for agents with no pending sidecars
+    // (cross-team-safe: non-fixup teams without explicit thresholds
+    // never record sidecars, so this is a no-op for them).
+    let (dispatched_waiting_for, pending_response_to) =
+        crate::daemon::dispatch_idle::pending_for_instance(home, agent);
 
     if let Some(b) = binding {
         // Bound: enrich with on-disk reality checks so the operator
@@ -110,6 +118,8 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
             "ci_watches": ci_watches,
             "bind_in_flight": bind_in_flight,
             "cross_branch_holders": cross_branch_holders,
+            "dispatched_waiting_for": dispatched_waiting_for,
+            "pending_response_to": pending_response_to,
         })
     } else {
         json!({
@@ -118,6 +128,8 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
             "bind_in_flight": bind_in_flight,
             "ci_watches": ci_watches,
             "cross_branch_holders": Vec::<String>::new(),
+            "dispatched_waiting_for": dispatched_waiting_for,
+            "pending_response_to": pending_response_to,
         })
     }
 }
@@ -513,6 +525,73 @@ mod tests {
         assert!(
             entries.contains(&"owner/repo:feature/x"),
             "alpha's watch must surface as owner/repo:feature/x: {entries:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── PR2 L3 visibility: binding_state surfaces dispatch metadata ──
+
+    /// Both bound and unbound binding_state responses must surface the
+    /// new `dispatched_waiting_for` + `pending_response_to` fields read
+    /// from `<home>/pending-dispatches/*.json`. Operator investigating
+    /// a stuck binding can see in one call whether the agent owes a
+    /// reply or is waiting for one.
+    #[test]
+    fn binding_state_surfaces_pending_dispatch_metadata() {
+        let home = tmp_home("l3-binding");
+        // Seed a sidecar where "alpha" is the dispatcher waiting on
+        // "beta", and "alpha" is also the target of an inbound
+        // dispatch from "gamma" (covers both arrays in one shot).
+        crate::daemon::dispatch_idle::record_dispatch(
+            &home,
+            "alpha",
+            "beta",
+            Some("t-out"),
+            "task",
+            600,
+        )
+        .unwrap();
+        crate::daemon::dispatch_idle::record_dispatch(
+            &home,
+            "gamma",
+            "alpha",
+            Some("t-in"),
+            "task",
+            600,
+        )
+        .unwrap();
+        // Unbound alpha — exercises the unbound JSON shape.
+        let unbound = handle_binding_state(&home, &json!({"agent": "alpha"}), &None);
+        assert_eq!(unbound["bound"].as_bool(), Some(false));
+        let dw = unbound["dispatched_waiting_for"]
+            .as_array()
+            .expect("dispatched_waiting_for must be an array (unbound case)");
+        assert_eq!(dw.len(), 1);
+        assert_eq!(dw[0]["target"].as_str(), Some("beta"));
+        assert_eq!(dw[0]["correlation_id"].as_str(), Some("t-out"));
+        let pr = unbound["pending_response_to"]
+            .as_array()
+            .expect("pending_response_to must be an array (unbound case)");
+        assert_eq!(pr.len(), 1);
+        assert_eq!(pr[0]["dispatcher"].as_str(), Some("gamma"));
+        assert_eq!(pr[0]["correlation_id"].as_str(), Some("t-in"));
+        // Bound alpha — exercises the bound JSON shape carries the
+        // same L3 fields.
+        let wt = home.join("worktree-l3");
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(wt.join(".agend-managed"), "agent=alpha\n").unwrap();
+        write_binding(&home, "alpha", "feature/l3", wt.to_str().unwrap());
+        let bound = handle_binding_state(&home, &json!({"agent": "alpha"}), &None);
+        assert_eq!(bound["bound"].as_bool(), Some(true));
+        assert_eq!(
+            bound["dispatched_waiting_for"].as_array().map(|a| a.len()),
+            Some(1),
+            "bound shape must include dispatched_waiting_for"
+        );
+        assert_eq!(
+            bound["pending_response_to"].as_array().map(|a| a.len()),
+            Some(1),
+            "bound shape must include pending_response_to"
         );
         std::fs::remove_dir_all(&home).ok();
     }


### PR DESCRIPTION
## Summary

Closes the parent watchdog task (`t-20260516235634005027-1`). PR2 of the two-PR split — **PR1 #878 (squash 8cdd3d9)** shipped L1 cross-team-safe primitive + L2 fixup auto-nudge; this PR adds the operator-facing read surface that exposes pending dispatch metadata from `<home>/pending-dispatches/*.json` sidecars (already on disk per PR1).

- **`dispatch_idle::pending_for_instance(home, agent)`** — new pure helper returning `(Vec<DispatchedWaitingFor>, Vec<PendingResponseTo>)`. Only `status=="pending"` surfaces; resolved/exceeded/cancelled filtered out.
- **`handle_list`** (`src/api/handlers/query.rs`) — each agent entry (managed + external) gains `dispatched_waiting_for` + `pending_response_to`.
- **`handle_binding_state`** (`src/mcp/handlers/binding_state.rs`) — both bound and unbound response shapes carry the same fields. Operator investigating a stuck binding sees in one call whether the agent owes a reply or is waiting for one.

## Cross-team-safe

Non-fixup teams without explicit thresholds never recorded sidecars (per PR1's L2 default-disabled contract). For them, the new fields surface as empty arrays — no leakage of fixup-specific state. Tested via `pending_for_instance_empty_for_unaffected_agent`.

## Tests (6 new)

- `pending_for_instance_surfaces_dispatcher_view` — outbound view
- `pending_for_instance_surfaces_target_view` — inbound view
- `pending_for_instance_empty_for_unaffected_agent` — cross-team-safe invariant
- `pending_for_instance_filters_stale_sidecars` — resolved/exceeded/cancelled filtered
- `pending_for_instance_serializes_with_stable_field_names` — wire-shape pin (operator-visible schema is intentional, not silent)
- `binding_state_surfaces_pending_dispatch_metadata` — integration covering both bound + unbound shapes

## Tier-2 daemon-core

MCP surface schema add (`list_instances` + `binding_state` JSON shape gains 2 fields). Existing operator tooling is forward-compatible: older clients ignoring unknown JSON fields see no behaviour change.

## §4.1 push claim

Scope follows dispatch spec `t-20260517005431205907-8`.

## §3.10 cadence note

Single C2 GREEN commit (lead-allowed per PR2 spec — small read-only surface; comprehensive tests stand as contract instead of staged RED→GREEN). Tests added alongside impl in same commit; no behavioural change is testable without the helper present.

## Test plan

- [x] cargo test --tests: passes, 0 failed (dispatch_idle module: 16/16, binding_state module: 12/12, full bin suite green)
- [x] cargo clippy --all-targets -- -D warnings: clean
- [x] cargo fmt --check: clean
- [ ] CI on 5 platforms (this PR's CI run)
- [ ] Reviewer verifies new fields surface in handle_list + binding_state from live daemon

## Lessons learned

- **Process win**: built on PR1 in <40min total wall time (well under lead's 1.5-2hr ETA) because PR1's pending sidecar schema was the only data dependency — pure read helper + thin wire deltas. The 2-PR split paid off: PR1 reviewer focus on cross-team-safety primitive; PR2 reviewer focus on operator-visible schema.
- **Scope shift**: LOC overshoot to 307+ vs lead's 150-200 spec was driven by 5 thorough unit tests on `pending_for_instance` (one per contract: dispatcher view / target view / cross-team-safe / stale filter / wire shape). Wire-shape pin in particular is load-bearing for a surface other tools depend on.
- **Unexpected discovery**: none — clean PR cycle. PR1's mirror discovery (`decision_timeout` as semantic template) and post-enqueue hook ordering precedent carried directly into PR2's helper design.

Closes #t-20260516235634005027-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)