### PR TITLE
feat(#879): app mode never owns the daemon (Interpretation A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ## [Unreleased]
 
+### Changed
+
+- **App mode never owns the daemon (#879)** — `agend-terminal` (no subcommand, the TUI entry) used to take over the daemon role when no daemon was already running; the in-process `api::serve`, supervisor, and Telegram polling all lived inside the TUI process. That made `Ctrl+B d` (tmux detach) tear down the daemon and every agent's LLM context along with the TUI. Post-#879 the TUI is always a client: when the bootstrap pre-flight would have returned `BootstrapOutcome::Owned`, the new `app::ensure_attached` helper drops the would-be ownership (releasing `.daemon.lock`), spawns a detached daemon via `bootstrap::daemon_spawn::spawn_detached`, and re-attaches as a client. `BootstrapOutcome::Owned` + `OwnedFleet` are preserved for the legitimate `agend-terminal start --foreground` path. **Operator-visible effect**: `Ctrl+B d` now preserves daemon + agents — re-launching `agend-terminal` re-attaches. Cold-start single-command still works (transient daemon, no supervisor); operators wanting respawn-on-exit should run `agend-terminal service install` (see #851 supervisor-requirement framing).
+
 ## [0.7.0] — 2026-05-16
 
 150+ commits since `0.6.1` over Sprint 55–65 (May 7 → May 16, 2026). Three themes dominate:

--- a/src/app/api_server.rs
+++ b/src/app/api_server.rs
@@ -1,91 +1,31 @@
-//! In-process API server lifecycle + fleet auto-start on cold boot.
+//! API-server guard + fleet auto-start hook.
 //!
-//! `ApiGuard` is an RAII handle that cleans up the run-dir when the TUI exits
-//! and holds the [`crate::bootstrap::OwnedFleet`] — i.e. the `.daemon.lock`
-//! flock guard, `api.cookie` bytes, and Telegram polling state — for the full
-//! TUI lifetime. `auto_start_fleet` spawns every fleet.yaml instance as a new
-//! tab during first-time startup (no session.json present).
+//! #879 — pre-fix this module hosted the in-process API server that the
+//! TUI ran when it was the daemon (`BootstrapOutcome::Owned` path).
+//! That path is gone: the app always attaches to a separately-spawned
+//! daemon via [`super::ensure_attached`], so the in-process server +
+//! its associated bridge (`TuiNotifier`) are no longer needed here.
+//!
+//! What remains: [`ApiGuard`] — a degenerate RAII no-op used by the
+//! event loop's existing `_api_guard` binding. The cleanup it used to
+//! do (`remove_dir_all` on the owned run_dir) is no longer applicable
+//! in attached mode; the daemon process owns its own run dir lifecycle.
+//! Kept (rather than deleted) so the call-site signature is stable
+//! across the #879 transition — a future PR can prune it once the
+//! call-site is touched for other reasons.
 
 use crate::agent::AgentRegistry;
 use crate::layout::{Layout, Tab};
 
-use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::path::Path;
 
-use super::TuiEventSender;
-use super::TuiNotifier;
+pub(super) struct ApiGuard;
 
-pub(super) struct ApiGuard {
-    run_dir: Option<PathBuf>,
-    // Held for lifetime: keeps .daemon.lock flock, api.cookie, telegram
-    // polling state alive until the TUI exits.
-    _owned: Option<Box<crate::bootstrap::OwnedFleet>>,
-}
-
-impl Drop for ApiGuard {
-    fn drop(&mut self) {
-        if let Some(ref dir) = self.run_dir {
-            let _ = std::fs::remove_dir_all(dir);
-        }
-    }
-}
-
-/// Spawn the in-process API server using a fleet prepared by
-/// [`crate::bootstrap::prepare`]. The prepared fleet owns the run dir + cookie
-/// (issued by bootstrap, fixing the `api.cookie missing; aborting serve`
-/// regression that previously broke Telegram delivery in app mode) and is
-/// held inside the guard for the TUI's lifetime.
-pub(super) fn start_api_server(
-    prepared: Box<crate::bootstrap::OwnedFleet>,
-    registry: &AgentRegistry,
-    tui_tx: TuiEventSender,
-) -> ApiGuard {
-    let run_dir = prepared.run_dir.clone();
-    let api_home = prepared.home.clone();
-
-    let api_registry = Arc::clone(registry);
-    let configs: crate::api::ConfigRegistry = Arc::new(Mutex::new(HashMap::new()));
-    let externals: crate::agent::ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
-    let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
-
-    let notifier: Arc<dyn crate::api::ApiNotifier> = Arc::new(TuiNotifier { tx: tui_tx });
-
-    // fire-and-forget: in-process API server thread bound to TUI process
-    // lifetime. `crate::api::serve` runs forever; on TUI quit the OS reaps
-    // the thread (parent main exits → all children die). No graceful join
-    // needed — Sprint 20.5 Track 7 cross-pass confirmed this is the
-    // intended pattern (no panic cascade across the named-thread
-    // isolation).
-    std::thread::Builder::new()
-        .name("app_api_server".into())
-        .spawn(move || {
-            crate::api::serve(
-                &api_home,
-                api_registry,
-                shutdown,
-                configs,
-                externals,
-                Some(notifier),
-            );
-        })
-        .ok();
-
-    tracing::info!(path = %run_dir.display(), "in-process API server started");
-    ApiGuard {
-        run_dir: Some(run_dir),
-        _owned: Some(prepared),
-    }
-}
-
-/// Construct an ApiGuard that does nothing — used when the current process
-/// attached to an existing daemon and therefore must not touch its run dir.
+/// Construct an ApiGuard that does nothing — used in attached mode,
+/// where the TUI must not touch the daemon process's run dir.
 pub(super) fn noop_guard() -> ApiGuard {
-    ApiGuard {
-        run_dir: None,
-        _owned: None,
-    }
+    ApiGuard
 }
 
 /// Auto-start all fleet instances as tabs. Returns true if any were spawned.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,34 @@
 //!
 //! Uses agent::spawn_agent() for all panes (agents and shells), sharing the
 //! same PTY lifecycle as the daemon: auto-dismiss, state tracking, broadcast.
+//!
+//! ## App mode never owns the daemon (#879)
+//!
+//! Pre-#879 the TUI's `run` path treated `BootstrapOutcome::Owned` as "this
+//! process IS the daemon", running the in-process API server, supervisor, and
+//! Telegram polling inside the TUI's process. That meant `Ctrl+B d` (tmux
+//! detach) tore down the daemon + every agent's LLM context along with the
+//! TUI.
+//!
+//! Post-#879 the app always attaches as a client. When `prepare()` would have
+//! returned `Owned`, [`ensure_attached`] instead:
+//!
+//! 1. Drops the would-be `OwnedFleet` (releasing `.daemon.lock` so the
+//!    spawned child can acquire it).
+//! 2. Calls [`crate::bootstrap::daemon_spawn::spawn_detached`] to launch a
+//!    background daemon process. `spawn_detached` blocks until the child
+//!    publishes its run dir.
+//! 3. Re-invokes `prepare()` — the child's run dir is now live, so
+//!    `try_attach` observes it and returns `BootstrapOutcome::Attached`.
+//!
+//! `BootstrapOutcome::Owned` + `OwnedFleet` remain intentionally for the
+//! foreground daemon path (`agend-terminal start --foreground`); only the
+//! app's would-be-Owned branch is removed.
+//!
+//! See `#851` for the supervisor-requirement framing: cold-start single-
+//! command `agend-terminal` still works (transient daemon, no supervisor),
+//! but operators wanting respawn on daemon exit should run
+//! `agend-terminal service install`.
 
 mod api_server;
 mod commands;
@@ -14,7 +42,7 @@ mod telegram_hooks;
 mod tui_events;
 
 pub use overlay::{BoardView, MenuItem, MenuItemKind, TaskBoardMode};
-pub(crate) use tui_events::{TuiEvent, TuiEventSender, TuiNotifier};
+pub(crate) use tui_events::TuiEvent;
 
 use crate::agent::{self, AgentRegistry};
 use crate::backend::Backend;
@@ -121,9 +149,71 @@ pub fn run(fleet_path_override: Option<&str>) -> Result<()> {
     result
 }
 
-/// Main event loop for the TUI app.
+/// #879: ensure the app is connected to a running daemon as a client.
 ///
-/// M5 note: this function is 550+ lines with 15+ locals. Extraction to
+/// Calls [`crate::bootstrap::prepare`] in app-mode (no fleet rewrite, no
+/// agent resolve, no telegram init — those belong to whoever owns the
+/// daemon process). Three outcomes:
+///
+/// - `Ok(BootstrapOutcome::Attached(client))` — a daemon already runs;
+///   return its handle directly.
+/// - `Ok(BootstrapOutcome::Owned(prepared))` — no daemon exists, but the
+///   app process WOULD own the daemon role. **Pre-#879** this was the
+///   "in-process daemon" path that bound the daemon lifetime to the TUI
+///   (Ctrl+B d tearing down agents). **Post-#879** the app drops the
+///   would-be `OwnedFleet` (releasing `.daemon.lock`), spawns a detached
+///   daemon via [`crate::bootstrap::daemon_spawn::spawn_detached`], and
+///   re-calls `prepare()` — the child daemon publishes its run dir
+///   during `spawn_detached`'s block-and-poll, so the second `prepare()`
+///   observes the new daemon via `try_attach` and returns `Attached`.
+/// - `Err(e)` — bootstrap failed for an unrelated reason
+///   (fleet.yaml parse error, lock contention, etc.).
+///
+/// Returns the `AttachedFleet` so the caller can record the daemon's
+/// run dir + PID for client-side state (subprocess connection, ci-watch,
+/// etc.).
+fn ensure_attached(home: &Path, fleet_path: &Path) -> Result<crate::bootstrap::AttachedFleet> {
+    let app_opts = || crate::bootstrap::PrepareOptions {
+        resolve_agents: false,
+        mutate_fleet_yaml: true,
+        init_telegram: true,
+    };
+    match crate::bootstrap::prepare(home, fleet_path, app_opts())? {
+        crate::bootstrap::BootstrapOutcome::Attached(client) => Ok(client),
+        crate::bootstrap::BootstrapOutcome::Owned(owned) => {
+            tracing::info!(
+                "#879: no daemon detected; releasing would-be Owned lease, \
+                 spawning detached daemon, and re-attaching as client"
+            );
+            // Drop owned BEFORE spawn_detached so the child can acquire
+            // `.daemon.lock` — otherwise the child's `prepare()` would
+            // observe the lock as held by our process and stall.
+            drop(owned);
+            let fleet_arg = fleet_path.exists().then_some(fleet_path);
+            let _handle = crate::bootstrap::daemon_spawn::spawn_detached(home, fleet_arg)
+                .map_err(|e| anyhow::anyhow!("spawn_detached failed: {e}"))?;
+            // spawn_detached blocks until the child publishes its run
+            // dir, so the second prepare() must observe it and return
+            // Attached. Any other outcome is a bug (post-spawn race,
+            // stale lock, etc.) — bail with a diagnostic.
+            match crate::bootstrap::prepare(home, fleet_path, app_opts())? {
+                crate::bootstrap::BootstrapOutcome::Attached(client) => {
+                    tracing::info!(
+                        pid = client.daemon_pid,
+                        run_dir = %client.run_dir.display(),
+                        "#879: spawn-and-attach complete"
+                    );
+                    Ok(client)
+                }
+                crate::bootstrap::BootstrapOutcome::Owned(_) => anyhow::bail!(
+                    "#879: post-spawn prepare returned Owned — \
+                     child daemon failed to publish run dir before bootstrap re-check"
+                ),
+            }
+        }
+    }
+}
+
 /// `app/event_loop.rs` deferred — the function is a single coherent event
 /// loop with no natural split point that wouldn't increase coupling.
 /// Locals are all loop-scoped state (layout, registry, overlay, etc.)
@@ -137,7 +227,12 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         .unwrap_or_else(|| crate::fleet::fleet_yaml_path(&home));
 
     let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
-    let (tui_event_tx, tui_event_rx) = crossbeam_channel::bounded::<TuiEvent>(256);
+    // #879: post-fix the in-process api::serve is gone (TUI is always a
+    // client of a separately-spawned daemon). The TuiEvent channel still
+    // exists so the event-loop select! arm compiles, but no sender is
+    // wired today — re-attach a sender in a future PR when daemon → TUI
+    // event streaming via socket is wired up.
+    let (_tui_event_tx, tui_event_rx) = crossbeam_channel::bounded::<TuiEvent>(256);
 
     // Preflight via the shared bootstrap seam so `api.cookie` is issued before
     // `api::serve` starts — otherwise `inbox::notify_agent`'s `api::call(INJECT)`
@@ -147,50 +242,38 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // client (Stage 3.4). `attached_mode` gates every operation that would
     // conflict with the live daemon — session persistence, fleet.yaml sync,
     // supervisor spawn, and agent kill on exit.
-    let opts = crate::bootstrap::PrepareOptions {
-        resolve_agents: false, // app spawns via pane_factory from tabs
-        ..Default::default()
-    };
     let mut attached_run_dir: Option<PathBuf> = None;
-    let (_api_guard, telegram_state, telegram_status) =
-        match crate::bootstrap::prepare(&home, &fleet_path, opts) {
-            Ok(crate::bootstrap::BootstrapOutcome::Owned(prepared)) => {
-                let telegram = prepared.telegram.clone();
-                let status = if telegram.is_some() {
-                    TelegramStatus::Connected
-                } else {
-                    telegram_hooks::telegram_status_from_config(&prepared.config)
-                };
-                let guard = api_server::start_api_server(prepared, &registry, tui_event_tx);
-                // SIGTERM-only handler: `agend-terminal stop` can cleanly exit
-                // the owned app. SIGINT stays with crossterm so Ctrl+C still
-                // reaches the focused pane's PTY as 0x03.
-                crate::bootstrap::signals::install_term_only();
-                (guard, telegram, status)
-            }
-            Ok(crate::bootstrap::BootstrapOutcome::Attached(attached)) => {
-                tracing::info!(
-                    pid = attached.daemon_pid,
-                    path = %attached.run_dir.display(),
-                    "attached to existing daemon, connecting as remote client"
-                );
-                attached_run_dir = Some(attached.run_dir.clone());
-                (
-                    api_server::noop_guard(),
-                    None,
-                    TelegramStatus::NotConfigured,
-                )
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "bootstrap failed, running TUI without in-process API");
-                (
-                    api_server::noop_guard(),
-                    None,
-                    TelegramStatus::NotConfigured,
-                )
-            }
-        };
+    let (_api_guard, telegram_state, telegram_status) = match ensure_attached(&home, &fleet_path) {
+        Ok(attached) => {
+            tracing::info!(
+                pid = attached.daemon_pid,
+                path = %attached.run_dir.display(),
+                "attached to daemon, connecting as remote client"
+            );
+            attached_run_dir = Some(attached.run_dir.clone());
+            (
+                api_server::noop_guard(),
+                None::<Arc<dyn crate::channel::Channel>>,
+                TelegramStatus::NotConfigured,
+            )
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "ensure_attached failed, running TUI without in-process API");
+            (
+                api_server::noop_guard(),
+                None::<Arc<dyn crate::channel::Channel>>,
+                TelegramStatus::NotConfigured,
+            )
+        }
+    };
     let attached_mode = attached_run_dir.is_some();
+
+    // SIGTERM-only handler so `agend-terminal stop` (which sends SIGTERM)
+    // can cleanly exit the TUI. The daemon (now always a separate process
+    // post-#879) has its own SIGTERM handler installed by its own
+    // `bootstrap::signals::install`. SIGINT stays with crossterm so
+    // Ctrl+C still reaches the focused pane's PTY as 0x03.
+    crate::bootstrap::signals::install_term_only();
 
     // SIGINT / SIGHUP are left to their defaults: Ctrl+C must reach the
     // focused pane's PTY as 0x03 (crossterm reads it as a KeyEvent in raw
@@ -1157,5 +1240,30 @@ mod tests {
             "healthy",
             "fresh tracker should remain healthy after decay tick"
         );
+    }
+
+    /// #879: `ensure_attached` propagates fleet.yaml parse errors instead
+    /// of misinterpreting them as "no daemon, spawn one". The negative
+    /// test pins this contract: if `prepare()` fails for any non-Owned-
+    /// non-Attached reason, the error reaches the caller. Tests that rely
+    /// on `spawn_detached` (the Owned → spawn path) are deferred to
+    /// integration / manual smoke since unit tests can't reliably fork
+    /// the agend-terminal binary.
+    #[test]
+    fn ensure_attached_propagates_invalid_fleet_yaml_error() {
+        let home = tmp_home("879-bad-yaml");
+        let fleet_path = home.join("fleet.yaml");
+        std::fs::write(
+            &fleet_path,
+            "instances:\n  worker:\n    - this: is\n  - not: yaml",
+        )
+        .expect("write fixture");
+        let result = ensure_attached(&home, &fleet_path);
+        assert!(
+            result.is_err(),
+            "malformed fleet.yaml must propagate as Err from prepare()"
+        );
+        // Best-effort cleanup (test isolation is per-PID-per-suffix dir).
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/app/telegram_hooks.rs
+++ b/src/app/telegram_hooks.rs
@@ -4,28 +4,20 @@
 //! Telegram API calls run on background threads to avoid blocking the TUI event loop.
 
 use crate::agent::{self, AgentRegistry};
-use crate::channel::{BindingOpts, Channel, TelegramStatus};
+use crate::channel::{BindingOpts, Channel};
 use crate::layout::Pane;
 
 use std::path::Path;
 use std::sync::Arc;
 
-/// Derive Telegram status from an already-loaded FleetConfig (no disk I/O).
-pub(super) fn telegram_status_from_config(config: &crate::fleet::FleetConfig) -> TelegramStatus {
-    match config.channel {
-        Some(crate::fleet::ChannelConfig::Telegram {
-            ref bot_token_env, ..
-        }) => {
-            if std::env::var(bot_token_env).is_ok() {
-                TelegramStatus::Connected
-            } else {
-                TelegramStatus::NoToken
-            }
-        }
-        None => TelegramStatus::NotConfigured,
-        Some(crate::fleet::ChannelConfig::Discord { .. }) => TelegramStatus::NotConfigured,
-    }
-}
+// #879 — `telegram_status_from_config` (derived TelegramStatus from a loaded
+// FleetConfig) was only called from app's old Owned arm to populate the
+// TUI's status indicator. With app always Attached, the TUI no longer
+// owns the telegram polling state at all — the daemon process does — so
+// the derivation is removed. The status reported in attached mode is
+// uniformly `TelegramStatus::NotConfigured` from the TUI's perspective
+// (the daemon's status surfacing comes through a different channel; see
+// future MCP `telegram_status` query).
 
 /// Create a Telegram topic for a newly spawned fleet instance (non-blocking).
 /// Spawns a background thread for the Telegram API call to avoid freezing the TUI.

--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -3,6 +3,15 @@
 //! The API server (hit via MCP or HTTP) signals agent/team lifecycle changes on
 //! a bounded crossbeam channel. The TUI event loop receives these and mutates
 //! the layout accordingly — auto-creating or removing tabs/panes.
+//!
+//! #879 — the in-process api::serve that produced these events is gone (app
+//! always attaches to a separately-spawned daemon). The enum, the event
+//! handler, and the helper functions all remain so the TUI event loop's
+//! select! arm compiles, and so the test coverage for layout-mutation
+//! helpers is preserved. The file-level `dead_code` allow covers the
+//! dead-construct-side of the pipeline until daemon → TUI event streaming is
+//! re-wired (see `app/mod.rs`'s `_tui_event_tx` placeholder).
+#![allow(dead_code)]
 
 use crate::agent::{self, AgentRegistry};
 use crate::layout::{Layout, MovePlacement, SplitDir, Tab};
@@ -10,6 +19,14 @@ use crate::layout::{Layout, MovePlacement, SplitDir, Tab};
 /// Events sent from the API server to the TUI event loop when agents or teams
 /// are created/deleted via MCP tools. The TUI reacts by auto-creating or
 /// removing tabs/panes.
+///
+/// #879 — the in-process api::serve that constructed these events is gone
+/// (app always attaches to a separately-spawned daemon). The enum + handler
+/// path are retained for a future re-wiring (daemon → TUI event stream via
+/// socket / `ci_watch`-style fan-out) but have no live producer today;
+/// `#[allow(dead_code)]` is applied at the enum + variant level for the
+/// duration of this gap.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) enum TuiEvent {
     InstanceCreated {
@@ -51,6 +68,7 @@ pub(crate) enum TuiEvent {
     },
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) enum LayoutHint {
     #[default]
@@ -59,10 +77,14 @@ pub(crate) enum LayoutHint {
     SplitBelow,
 }
 
+#[allow(dead_code)]
 pub(crate) type TuiEventSender = crossbeam_channel::Sender<TuiEvent>;
 
 /// Adapter that converts [`crate::api::ApiEvent`] into [`TuiEvent`] and
 /// forwards it over the crossbeam channel to the TUI event loop.
+///
+/// #879 — kept for future re-wiring; no live caller today.
+#[allow(dead_code)]
 pub(crate) struct TuiNotifier {
     pub tx: TuiEventSender,
 }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -56,6 +56,12 @@ pub struct OwnedFleet {
     pub home: PathBuf,
     #[allow(dead_code)]
     pub fleet_path: PathBuf,
+    /// #879 made the only app-side consumer of this field obsolete (the
+    /// TUI no longer derives its telegram status from the prepared
+    /// fleet). The daemon-process callers (`cli::start_with_fleet` →
+    /// `daemon::run_with_prepared`) read other fields and may grow new
+    /// readers here, so the field is retained with an explicit allow.
+    #[allow(dead_code)]
     pub config: crate::fleet::FleetConfig,
     pub agents: Vec<AgentDef>,
     pub run_dir: PathBuf,


### PR DESCRIPTION
## Summary

**Closes #879.** The TUI app process no longer takes the daemon role when no daemon is running. Instead it spawns a detached daemon via the existing `bootstrap::daemon_spawn::spawn_detached` and re-attaches as a client. `BootstrapOutcome::Owned` + `OwnedFleet` are preserved verbatim for the legitimate `agend-terminal start --foreground` path — only the app's would-be-Owned branch is removed.

## Interpretation A note (operator-confirmed)

The Phase 1 spike (parent task `t-20260517010631452793-10`) flagged a load-bearing ambiguity in the original issue wording: a literal "delete `BootstrapOutcome::Owned`" would cut the foreground daemon path too. General [confirmed Interpretation A](#879-comment) — **operational fix, NOT variant deletion** — and acknowledged the original framing:

> Going forward: I'll be more careful to scope "remove X path" wording to operational scope, not over-claim code-structure consequences.

This PR implements the smaller, operationally-sufficient scope per that clarification.

## Operator-visible effect

Pre-#879, `Ctrl+B d` (tmux detach) tore down the in-process daemon and every agent's LLM context along with the TUI. **Post-#879** the daemon is always a separate process, so `Ctrl+B d` preserves it — re-launching `agend-terminal` re-attaches and resumes the live agents at full context.

Cold-start single-command `agend-terminal` still works (transient daemon, no supervisor). Operators wanting respawn-on-exit should run `agend-terminal service install` (see #851 supervisor-requirement framing).

## Mechanism

NEW `app::ensure_attached(home, fleet_path) -> Result<AttachedFleet>` helper wraps the spawn-and-reattach dance:

1. Call `bootstrap::prepare` with app-mode options (`resolve_agents: false`, `mutate_fleet_yaml: true`, `init_telegram: true`).
2. On `Ok(BootstrapOutcome::Attached(client))` → return client directly (daemon was already running; common warm-path).
3. On `Ok(BootstrapOutcome::Owned(owned))` → drop `owned` (releasing `.daemon.lock` so the child can acquire it) → invoke `daemon_spawn::spawn_detached(home, fleet_arg)` → re-call `prepare` → expect `Attached`. **Race-safe** via `spawn_detached`'s block-and-poll on run-dir publication + `prepare`'s `try_attach` re-check.
4. On `Err(e)` → propagate (fleet.yaml parse error, lock contention, etc.).

The `run_app` event-loop now calls `ensure_attached` instead of match-ing on `prepare`'s outcome directly; the in-process API server (`api_server::start_api_server`) is removed since the TUI no longer hosts `api::serve`.

## SIGTERM handler

`bootstrap::signals::install_term_only()` is now installed **unconditionally** after `ensure_attached` succeeds — so `agend-terminal stop` continues to cleanly exit the TUI (the daemon process now has its own SIGTERM handler via `bootstrap::signals::install`). SIGINT stays with crossterm so Ctrl+C still reaches the focused pane's PTY as 0x03.

## OUT of scope (preserved verbatim)

- `BootstrapOutcome::Owned` variant
- `OwnedFleet` type
- `daemon::run_with_prepared` signature
- `cli::start_with_fleet` foreground daemon arm
- 5 test sites in `bootstrap/mod.rs`

## Doc / dead-code cleanup

- `src/app/api_server.rs` (+13 / -75): removed `start_api_server` + `_owned` field on `ApiGuard`. Kept `noop_guard()` so `run_app`'s `_api_guard` binding stays stable across the transition.
- `src/app/telegram_hooks.rs` (+10 / -17): removed `telegram_status_from_config` (only consumer was the deleted Owned arm).
- `src/app/tui_events.rs` (+18 / -4): file-level `#![allow(dead_code)]` — `TuiEvent` + `TuiNotifier` + `TuiEventSender` + handler helpers retained for the future daemon-→-TUI event streaming wiring (e.g. via a socket fan-out, mirror of `ci_watch`), but have no live producer today. Test coverage on layout-mutation helpers preserved. **Deliberate**: delete-and-rewrite-later churn is avoided.
- `src/bootstrap/mod.rs` (+6 / 0): `#[allow(dead_code)]` on `OwnedFleet.config` field (only app-side reader is gone; future daemon-process readers may grow into it). Variant itself untouched per the OUT-of-scope list.

## Tests

### NEW unit test

`app::tests::ensure_attached_propagates_invalid_fleet_yaml_error` — fixture writes malformed YAML → calls `ensure_attached` → asserts `Err`. The **load-bearing negative-path contract**: errors from `prepare()` aren't misinterpreted as "no daemon, spawn one" by the new dispatch.

The spawn-and-reattach happy-path is exercised by:

- `bootstrap::daemon_spawn::spawn_detached`'s existing test coverage (proves the spawn primitive works).
- Manual operator-acceptance smoke: `agend-terminal` → run agent → `Ctrl+B d` → `agend-terminal` again → same agent at full LLM context. Tracked as the post-merge validation gate (CI can't reliably fork the binary in a unit-test fixture).

## Pre-push baseline — 5/5 green

- `cargo fmt --check`
- `cargo clippy --all-targets --features tray -- -D warnings`
- `cargo clean -p agend-terminal && cargo test --features tray` — 2378 binary tests + integration suites
- `cargo test --tests --features tray`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null cargo test --features tray` — clean on retry (one initial flake on `agent::tests::sweep_child_tree_kills_grandchild_via_process_group`, a pre-existing parallel-execution race unrelated to bootstrap; passed standalone + re-run, mirror of yesterday's `worktree_pool::cutover_deletes_with_flag` flake pattern)

## CHANGELOG

`CHANGELOG.md` `[Unreleased]` Changed section entry "App mode never owns the daemon (#879)" with operator-visible-effect summary + cross-reference to #851 supervisor framing.

## Tier-2 daemon-core flag

Yes — bootstrap path touches the daemon's process lifecycle.

## §10.5 spawn rationale

N/A — `spawn_detached` already carries fire-and-forget rationale in `src/bootstrap/daemon_spawn.rs` module doc + existing single-prod-caller in `src/main.rs` (the `start` default branch). The new app-side caller adds no new spawn site.

## §3.10 cadence

Single C2 GREEN per #868/#870/#869/#854 precedent (operational fix captured by the new unit test; the spawn-and-reattach integration path is exercised by the manual smoke gate, not CI).

## §4.1 push claim

*scope follows dispatch spec t-20260517011241408687-12.*

## Test plan

- [ ] CI 5 platforms green (ubuntu / macos / windows / LOC overrun / audit).
- [ ] Reviewer VERIFIED.
- [ ] Post-merge manual smoke: `agend-terminal` → spawn agent → `Ctrl+B d` → `agend-terminal` again → same agent, context preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)