### PR TITLE
Fix #893: canonicalize cwd before encode_project_dir lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "dirs",
+ "dunce",
  "embed-resource",
  "fs4",
  "getrandom 0.3.4",
@@ -906,6 +907,12 @@ checksum = "d81175dab5ec79c30e0576df2ed2c244e1721720c302000bb321b107e82e265c"
 dependencies = [
  "futures",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,11 @@ async-trait = "0.1"
 anyhow = "1"
 fs4 = "0.12"
 dirs = "6"
+# Issue #893: dunce::canonicalize strips Windows `\\?\` UNC verbatim prefix
+# when safe, so the path encoding matches what claude CLI's Node
+# `fs.realpathSync.native` produces. Used in claude_session::has_resumable
+# to canonicalize cwd before encoding the project-dir lookup name.
+dunce = "1"
 regex = "1"
 # Sprint 24 P0 PR2 — task_sweep forensic api_response_hash on PrSnapshot.
 # SHA-256 crypto-grade hash + hex encoding so reviewers can correlate an

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -548,7 +548,8 @@ mod claude_session {
     /// (`custom-title`, `agent-name`, `pr-link`) before the first user
     /// message, and `claude --continue` cannot resume from those.
     pub fn has_resumable(working_dir: &Path, projects_root: &Path) -> bool {
-        let project_dir = projects_root.join(encode_project_dir(working_dir));
+        let canonical = canonicalize_for_encode(working_dir);
+        let project_dir = projects_root.join(encode_project_dir(&canonical));
         let Ok(entries) = std::fs::read_dir(&project_dir) else {
             return false;
         };
@@ -558,7 +559,25 @@ mod claude_session {
             .any(|e| jsonl_has_user_entry(&e.path()))
     }
 
+    /// Canonicalize `working_dir` so the encoded project-dir name matches what
+    /// claude CLI's Node `fs.realpathSync.native` produces before writing the
+    /// session jsonl. Falls back to the raw input on canonicalize Err so cold
+    /// spawns (working_dir not yet on disk) preserve the conservative-false
+    /// branch in [`has_resumable`].
+    ///
+    /// Uses `dunce::canonicalize` rather than `std::fs::canonicalize`: on
+    /// Windows the former strips `\\?\` UNC verbatim prefixes when safe,
+    /// matching node's behavior; on Unix the two are identical.
+    fn canonicalize_for_encode(working_dir: &Path) -> PathBuf {
+        dunce::canonicalize(working_dir).unwrap_or_else(|_| working_dir.to_path_buf())
+    }
+
     /// Encode an absolute path the way Claude names project dirs.
+    ///
+    // TODO: option B (--session-id) follow-up — see #893 spike artifacts for
+    // storage design (fixup-dev-2's metadata/<agent>.json proposal). Trigger:
+    // if a new encode-mismatch class appears that `--continue` newest-wins
+    // doesn't cover.
     fn encode_project_dir(path: &Path) -> String {
         path.to_string_lossy()
             .chars()
@@ -703,6 +722,120 @@ mod claude_session {
             // A `.txt` file with `"type":"user"` text must not count.
             std::fs::write(proj.join("note.txt"), "{\"type\":\"user\"}\n").unwrap();
             assert!(!has_resumable(work, &root));
+        }
+
+        /// Issue #893 regression fixture. On macOS, `/tmp` is a symlink to
+        /// `/private/tmp`, and claude CLI's Node `fs.realpathSync.native`
+        /// canonicalizes before encoding the project-dir name. Without
+        /// caller-side canonicalize, agend encodes the raw `/tmp/...` and
+        /// looks at `<root>/-tmp-...` while claude wrote to
+        /// `<root>/-private-tmp-...` → `read_dir` ENOENT → `has_resumable`
+        /// returns false → `--continue` never fires → context lost on
+        /// relaunch. Verified empirically by the #893 spike (filesystem
+        /// inspection of `~/.claude/projects/` after `claude -p` on a
+        /// `/tmp/...` cwd showed only `-private-tmp-...` entries).
+        ///
+        /// Pre-fix this test asserts the bug; post-fix `canonicalize_for_encode`
+        /// rewrites `/tmp/X` → `/private/tmp/X` so the lookup matches.
+        #[test]
+        #[cfg(target_os = "macos")]
+        fn has_resumable_handles_tmp_to_private_tmp_alias() {
+            let root = unique_tmp("tmp-alias");
+            let token = format!(
+                "tmp-alias-{}-{}",
+                std::process::id(),
+                root.file_name().and_then(|n| n.to_str()).unwrap_or("x")
+            );
+            let raw_work = PathBuf::from(format!("/tmp/{}/sub", token));
+            std::fs::create_dir_all(&raw_work).unwrap();
+            let canonical_work = std::fs::canonicalize(&raw_work).unwrap();
+            assert_ne!(
+                raw_work, canonical_work,
+                "macOS should canonicalize /tmp → /private/tmp; if this asserts the \
+                 host /tmp symlink is missing — investigate before treating the rest \
+                 of this test as a real failure"
+            );
+            // Pre-populate projects_root with a user-bearing jsonl under the
+            // CANONICAL encoding (what claude CLI would actually write).
+            let canonical_dir = root.join(encode_project_dir(&canonical_work));
+            std::fs::create_dir_all(&canonical_dir).unwrap();
+            std::fs::write(
+                canonical_dir.join("a.jsonl"),
+                "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+            )
+            .unwrap();
+            // Sanity: the raw-encoded dir does NOT exist on disk. If this
+            // asserts, the fix has accidentally normalized the encoded form
+            // too — adjust the fixture rather than relaxing this check.
+            let raw_encoded_dir = root.join(encode_project_dir(&raw_work));
+            assert!(
+                !raw_encoded_dir.exists(),
+                "raw-encoded dir should not exist; encoding scheme must preserve \
+                 the /tmp vs /private/tmp distinction"
+            );
+            assert!(
+                has_resumable(&raw_work, &root),
+                "has_resumable should canonicalize the raw /tmp path before encoding \
+                 and find the jsonl at the canonical encoding"
+            );
+            let _ = std::fs::remove_dir_all(format!("/tmp/{}", token));
+        }
+
+        /// Windows-only invariant: `canonicalize_for_encode` must NOT return
+        /// a path with the `\\?\` UNC verbatim-prefix that `std::fs::canonicalize`
+        /// produces, because Node's `fs.realpathSync.native` (which claude CLI
+        /// uses to derive the project-dir name) strips it. If we kept the
+        /// verbatim prefix, the encoded project-dir name would diverge from
+        /// claude's by the prefix characters → same class of bug as #893's
+        /// macOS `/tmp` → `/private/tmp` alias.
+        ///
+        /// Also exercises Windows path normalization: case-fold round-trip
+        /// via `has_resumable` (the real-world cwd casing claude inherits
+        /// matches what canonicalize returns).
+        #[test]
+        #[cfg(target_os = "windows")]
+        fn canonicalize_for_encode_strips_verbatim_prefix_on_windows() {
+            let root = unique_tmp("win-verbatim");
+            let work_root = unique_tmp("win-work");
+            let raw_work = work_root.join("sub");
+            std::fs::create_dir_all(&raw_work).unwrap();
+            let canonical = super::canonicalize_for_encode(&raw_work);
+            let canonical_str = canonical.to_string_lossy();
+            assert!(
+                !canonical_str.starts_with(r"\\?\"),
+                "canonicalize_for_encode must strip Windows `\\\\?\\` verbatim prefix \
+                 (got {canonical_str:?}); dunce::canonicalize handles this — fall through \
+                 to std::fs::canonicalize would re-introduce the prefix"
+            );
+            // End-to-end: pre-populate projects_root with a user-bearing jsonl
+            // under the canonical encoding; has_resumable should find it
+            // when called with the raw (pre-canonicalize) cwd.
+            let canonical_dir = root.join(encode_project_dir(&canonical));
+            std::fs::create_dir_all(&canonical_dir).unwrap();
+            std::fs::write(
+                canonical_dir.join("a.jsonl"),
+                "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+            )
+            .unwrap();
+            assert!(
+                has_resumable(&raw_work, &root),
+                "has_resumable should canonicalize the cwd and find the jsonl under \
+                 the same encoding claude CLI's fs.realpathSync.native produces"
+            );
+        }
+
+        /// Cold-spawn invariant: `working_dir` may not exist on disk yet
+        /// (first call before claude has created the project). Canonicalize
+        /// returns Err in that branch; the fallback to the raw path keeps
+        /// `has_resumable`'s conservative-false return intact.
+        #[test]
+        fn canonicalize_for_encode_falls_back_to_raw_on_err() {
+            let nonexistent = Path::new("/this/path/does/not/exist/anywhere");
+            let canonical = super::canonicalize_for_encode(nonexistent);
+            assert_eq!(canonical, nonexistent.to_path_buf());
+            // And has_resumable on a non-existent cwd stays false.
+            let root = unique_tmp("nonexistent-cwd");
+            assert!(!has_resumable(nonexistent, &root));
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #893. `claude_session::has_resumable` (`src/backend.rs`) encoded the
working_dir as-passed before joining `projects_root`. Claude CLI's Node
`fs.realpathSync.native` canonicalizes the cwd before writing the session
jsonl, so on macOS `/tmp/<X>` → agend looks at `-tmp-<X>` while claude
wrote to `-private-tmp-<X>`. `read_dir` ENOENT → `has_resumable` false →
`SpawnMode::Resume` downgraded to `Fresh` → `--continue` never issued →
context lost on relaunch.

3-way spike unanimous on option A (canonicalize before encode). Spike
trace (`divergence=true; project_dir_raw_exists=false;
project_dir_canonical_exists=true`) is the RCA-fitting evidence.

Same encoding-mismatch class would surface on Windows for `\\?\` UNC
verbatim prefixes that std `Path::canonicalize` produces but
`fs.realpathSync.native` strips — hence `dunce::canonicalize` instead of
std.

## Quality bars (per dispatch + reviewer audit)

- [x] **1. `dunce::canonicalize`** used (not std `Path::canonicalize`) —
  Windows UNC verbatim-prefix safety; identical to std on Unix.
  `dunce = "1"` added to Cargo.toml.
- [x] **2. Windows CI test mandatory** —
  `canonicalize_for_encode_strips_verbatim_prefix_on_windows`
  (`#[cfg(target_os = \"windows\")]`) asserts no `\\?\` prefix leak +
  end-to-end has_resumable round-trip.
- [x] **3. RED test retained as permanent regression fixture** —
  spike test renamed to `has_resumable_handles_tmp_to_private_tmp_alias`
  (`#[cfg(target_os = \"macos\")]`). Pre-populates `projects_root` under
  the canonical encoding; asserts has_resumable finds it via the raw
  `/tmp/...` input. Self-verified RED protocol: temporarily reverting
  the production fix causes the test to FAIL at
  `src/backend.rs:774` — \"has_resumable should canonicalize the raw
  /tmp path...\".
- [x] **4. Fallback to raw path on canonicalize Err** —
  `canonicalize_for_encode` returns the raw input on Err; preserves
  has_resumable's conservative-false branch for cold spawns where
  working_dir doesn't yet exist on disk. Covered by
  `canonicalize_for_encode_falls_back_to_raw_on_err` (Unix+Windows).
- [x] **5. TODO comment for option B follow-up** placed on
  `encode_project_dir` referencing fixup-dev-2's
  `metadata/<agent>.json` storage proposal + the trigger criterion
  (new encode-mismatch class that `--continue` newest-wins doesn't
  cover).
- [x] **6. NOT race-class** per §3.20 SOP 1 — synchronous path
  resolution; deterministic test. No race-class smoke needed.
- [x] **7. §3.20 SOP 2 operator smoke gate** — see steps below.

## Operator smoke gate (§3.20 SOP 2)

\`\`\`
# Sandbox
export AGEND_HOME=/tmp/agend-smoke-893
rm -rf \$AGEND_HOME
./target/release/agend-terminal app
# spawn claude orchestrator, exchange 1 turn (\"remember word XYZ\"), ctrl+B d
./target/release/agend-terminal app
# verify: claude resumes with XYZ context (NOT fresh slate)

# Production (operator may smoke on real fleet)
# same flow on ~/.agend-terminal/ baseline
\`\`\`

Expected: context preserved across detach/relaunch. Pre-fix the same
flow returned fresh slate (the operator-reported #893 symptom).

## Spike artifacts

- 3-way unanimous A converging via independent reasoning: dev (initial
  A MEDIUM-HIGH), dev-2 (revised C→A MEDIUM-HIGH after `--continue`
  newest-wins empirical), lead (A firming). Reviewer audit folded in
  the dunce + Windows CI bar.
- Q1(a) instrumentation trace + Q1(b) S1/S2 filesystem evidence is
  recorded on issue #893's thread.

## Test plan

- [x] `cargo test --bin agend-terminal --features tray backend::claude_session` 9/9 GREEN
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin agend-terminal --features tray --tests -- -D warnings` clean
- [x] RED protocol self-verified on macOS (test FAILS on reverted fix)
- [ ] CI 5/5 incl. windows-latest job (waiting for run)
- [ ] Reviewer §3.20 SOP 3 RED protocol on retained test
- [ ] Operator smoke gate sandbox + production AGEND_HOME

🤖 Generated with [Claude Code](https://claude.com/claude-code)