### PR TITLE
fix(tui): sort active-indicator names to stop frame-to-frame flicker

### DIFF
--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -58,10 +58,11 @@ fn filter_live_assignees<'a>(
 /// visibly flickers between frames when the iteration order
 /// reshuffles. The helper sorts before joining to lock a stable
 /// left-to-right order independent of hash-bucket layout.
-fn format_active_status(names: Vec<&str>) -> String {
+fn format_active_status(mut names: Vec<&str>) -> String {
     if names.is_empty() {
         "all idle".to_string()
     } else {
+        names.sort_unstable();
         format!("active: {}", names.join(", "))
     }
 }

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -52,6 +52,20 @@ fn filter_live_assignees<'a>(
     }
 }
 
+/// Format the "active:" footer. Pure function extracted so we can
+/// pin deterministic ordering in a unit test — `HashSet` iteration
+/// is non-deterministic, so a render path that joins it directly
+/// visibly flickers between frames when the iteration order
+/// reshuffles. The helper sorts before joining to lock a stable
+/// left-to-right order independent of hash-bucket layout.
+fn format_active_status(names: Vec<&str>) -> String {
+    if names.is_empty() {
+        "all idle".to_string()
+    } else {
+        format!("active: {}", names.join(", "))
+    }
+}
+
 pub fn render_decisions(frame: &mut Frame, items: &[crate::decisions::Decision], scroll: usize) {
     let count = items.len();
     let title = format!(" Decisions ({count}) | j/k scroll | q close ");
@@ -296,12 +310,7 @@ pub fn render_tasks(
             columns[2].iter().filter_map(|t| t.assignee.as_deref()),
             live.as_ref(),
         );
-        let status_text = if active_agents.is_empty() {
-            "all idle".to_string()
-        } else {
-            let names: Vec<&str> = active_agents.into_iter().collect();
-            format!("active: {}", names.join(", "))
-        };
+        let status_text = format_active_status(active_agents.into_iter().collect());
         let status_y = inner.y + inner.height.saturating_sub(1);
         let status_area = Rect::new(
             inner.x + 1,
@@ -577,6 +586,26 @@ mod tests {
         let live = make_live(&["alpha"]);
         let kept = filter_live_assignees(std::iter::empty::<&str>(), Some(&live));
         assert!(kept.is_empty(), "empty input must produce empty output");
+    }
+
+    /// RED: HashSet iteration order is non-deterministic, so a render
+    /// path that joins names straight from the set visibly flickers
+    /// between frames. Pin the contract: same input set → same output
+    /// string, regardless of caller's iteration order.
+    #[test]
+    fn format_active_status_sorts_names_alphabetically() {
+        let result = format_active_status(vec!["zebra", "alpha", "mike"]);
+        assert_eq!(
+            result, "active: alpha, mike, zebra",
+            "names must render in stable alphabetical order — otherwise the active-indicator flickers across frames"
+        );
+    }
+
+    /// Edge case: zero live names → "all idle" sentinel.
+    #[test]
+    fn format_active_status_returns_all_idle_for_empty() {
+        let result = format_active_status(vec![]);
+        assert_eq!(result, "all idle");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The bottom-left `active: <names>` indicator in the task-board overlay visibly flickers because `HashSet::iter` is non-deterministic — `filter_live_assignees` returns a `HashSet<&str>` and the old render code joined those names directly. Same set, different frame, different order, visible bouncing.
- #827 (PR #832) earlier landed the ghost-agent filter in the same block but did not stabilise iteration order, so the flicker survived.
- Fix is two lines: collect into a `Vec`, `sort_unstable()`, then `join`. Helper extracted to a pure function so the contract can be pinned by unit test (RED → GREEN split, §3.10).

## Commits

1. `test: pin active-indicator deterministic ordering (RED)` — extract `format_active_status` helper without sort + add two unit tests. The ordering test is RED at this commit (`active: zebra, alpha, mike` ≠ `active: alpha, mike, zebra`).
2. `fix: sort active-indicator names to prevent frame-to-frame flicker` — add `names.sort_unstable()`. RED test goes GREEN.

Total diff: 1 file, ~37 net LOC.

## Test plan

- [x] `cargo test --bin agend-terminal panels::` — 10/10 pass at HEAD, 9/10 pass after reverting just the sort line (the ordering test fails as expected, confirming the test pins the right invariant).
- [ ] CI green across mac/ubuntu/windows + audit + LOC overrun.
- [ ] Eyeball check: open the task-board overlay with 2+ active assignees, confirm the indicator no longer bounces between frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)