### PR TITLE
Fix #879 (v4): daemon api-serve reorder + bridge bounded-retry on tools/list

### DIFF
--- a/src/bin/agend-mcp-bridge.rs
+++ b/src/bin/agend-mcp-bridge.rs
@@ -70,10 +70,21 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
             "notifications/initialized" | "notifications/cancelled" => continue,
 
-            "tools/list" => match proxy_tools_list(&home, &mut conn) {
+            "tools/list" => match proxy_tools_list_with_retry(&home, &mut conn) {
                 Ok(r) => serde_json::json!({"jsonrpc": "2.0", "id": id, "result": r}).to_string(),
-                Err(_) => serde_json::json!({"jsonrpc": "2.0", "id": id, "result": {"tools": []}})
-                    .to_string(),
+                Err(e) => {
+                    // #879v4 C2 — Bug 2 fix: a `tools/list` failure surfaces
+                    // as a visible JSON-RPC error so operators see daemon
+                    // unavailability instead of an unexplained empty tool
+                    // list (the previous `{tools: []}` silent-degrade was
+                    // the same antipattern shape as #881 noop_guard).
+                    eprintln!("agend-mcp-bridge: tools/list failed after retry: {e}");
+                    serde_json::json!({
+                        "jsonrpc": "2.0", "id": id,
+                        "error": {"code": -32603, "message": format!("daemon not ready: {e}")}
+                    })
+                    .to_string()
+                }
             },
 
             "tools/call" => {
@@ -136,16 +147,51 @@ fn proxy_tool_call(
     }
 }
 
-fn proxy_tools_list(
+/// Poll `mcp_tools_list` at a fixed cadence until it succeeds or the
+/// deadline expires. Covers the residual sub-millisecond race between
+/// `api::serve` thread start and the TCP `bind` + `api.port` write that
+/// remains even after the #879v4 C1 daemon reorder.
+///
+/// Retry is gated to TRANSPORT failures only (no run dir, connection
+/// refused, broken pipe, etc.). Application-level errors — the daemon
+/// answered with `ok:false` — propagate immediately so the caller sees
+/// the real diagnostic instead of looping on a deterministic failure.
+///
+/// Default budget 30 s — well above any observed startup time on a 9-agent
+/// fleet — overridable via `AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS` for tests.
+/// On exhaustion the last transport error propagates; callers convert to a
+/// visible JSON-RPC error, never a silent empty tool list (Bug 2 contract).
+fn proxy_tools_list_with_retry(
     home: &Path,
     conn: &mut Option<(BufReader<TcpStream>, TcpStream)>,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let timeout_ms: u64 = std::env::var("AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30_000);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+    let interval = std::time::Duration::from_millis(100);
     let envelope = serde_json::json!({"method": "mcp_tools_list", "params": {}});
-    let resp = proxy_request(home, conn, &envelope)?;
-    if resp["ok"].as_bool() == Some(true) {
-        Ok(resp["result"].clone())
-    } else {
-        Err("daemon error on tools_list".into())
+    loop {
+        match proxy_request(home, conn, &envelope) {
+            Ok(resp) => {
+                if resp["ok"].as_bool() == Some(true) {
+                    return Ok(resp["result"].clone());
+                }
+                let msg = resp["error"]
+                    .as_str()
+                    .unwrap_or("daemon error on tools_list");
+                return Err(msg.into());
+            }
+            Err(e) => {
+                let now = std::time::Instant::now();
+                if now >= deadline {
+                    return Err(e);
+                }
+                let remaining = deadline - now;
+                std::thread::sleep(interval.min(remaining));
+            }
+        }
     }
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -449,16 +449,12 @@ fn run_core(
     // Shutdown flag — shared with agent reapers to distinguish crash from shutdown
     let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-    tracing::info!(count = agents.len(), "starting agents");
-
-    for def in &agents {
-        spawn_and_register_agent(home, def, &registry, &configs, &crash_tx, &shutdown)?;
-        if agents.len() > 1 {
-            std::thread::sleep(spawn_stagger());
-        }
-    }
-
-    // API socket server
+    // #879v4 C1 ordering: start the API socket server BEFORE spawning agents.
+    // The agents' `agend-mcp-bridge` processes attempt to connect to
+    // `api.port` as soon as their MCP backend invokes `tools/list`; a
+    // legacy ordering that spawned agents first delayed `api.port`
+    // publication by ~N×spawn_stagger and surfaced as silent empty tool
+    // lists (see #879 RCA spike + tests/attached_path_mcp_invariants.rs).
     let api_reg = Arc::clone(&registry);
     let api_home = home.to_path_buf();
     let api_shutdown = Arc::clone(&shutdown);
@@ -481,6 +477,15 @@ fn run_core(
                 None,
             )
         })?;
+
+    tracing::info!(count = agents.len(), "starting agents");
+
+    for def in &agents {
+        spawn_and_register_agent(home, def, &registry, &configs, &crash_tx, &shutdown)?;
+        if agents.len() > 1 {
+            std::thread::sleep(spawn_stagger());
+        }
+    }
 
     // Shutdown wake channel — signal handler sends on this so the main loop's
     // select! wakes immediately instead of waiting up to 10s for the next tick.

--- a/tests/attached_path_mcp_invariants.rs
+++ b/tests/attached_path_mcp_invariants.rs
@@ -1,0 +1,243 @@
+//! #879v4 RED tests — pin the two pre-existing bugs unmasked by PR #903
+//! (then reverted via fe528c1) when always-Attached mode removed the in-process
+//! `api::serve` shim that previously masked the daemon-side startup race.
+//!
+//! ## Bug 1 — daemon-side startup ordering race
+//!
+//! Before #879v4, `daemon::run_core` spawned all queued agents BEFORE starting
+//! the `api::serve` thread (src/daemon/mod.rs:452-483). With N agents and the
+//! default 500 ms spawn stagger, `api.port` could be missing for ~N×500 ms +
+//! tens of ms while the agents' MCP bridges were already trying to connect.
+//!
+//! The RED test asserts `api.port` is published within a budget that's strictly
+//! smaller than the agent-spawn loop's wall time. On main (HEAD = fe528c1, the
+//! revert of #903) the test fails because the loop completes before
+//! `api::serve` binds; after the C1 reorder it passes because the API server
+//! starts before any agent is spawned.
+//!
+//! ## Bug 2 — bridge silent-degrade on tools/list error
+//!
+//! `src/bin/agend-mcp-bridge.rs:75` previously returned `{tools: []}` on ANY
+//! `proxy_tools_list` error, including "no run dir" and "connection refused".
+//! Operators saw an empty tool list with no clue why — same antipattern shape
+//! as the #881 noop_guard regression but a different module.
+//!
+//! The RED test boots the bridge with an empty `AGEND_HOME` (no daemon
+//! anywhere), sends an `initialize` + `tools/list`, and asserts the response
+//! carries a visible JSON-RPC `error` field instead of a silent empty list. On
+//! main the bridge replies `{result: {tools: []}}` immediately; after C2 it
+//! retries for the bounded window (test override via
+//! `AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS`) and then surfaces a -32603 error.
+
+#![allow(clippy::unwrap_used)]
+
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+// `Instant` is only used by the unix-gated daemon-ordering test below;
+// importing it unconditionally trips Windows clippy's `unused_imports`.
+#[cfg(unix)]
+use std::time::Instant;
+
+const CLAUDE_CODE_INIT: &str = r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}"#;
+const TOOLS_LIST: &str = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#;
+
+fn bridge_binary() -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_BIN_EXE_agend-mcp-bridge"));
+    assert!(
+        path.exists(),
+        "bridge binary missing at {} — run `cargo build --bin agend-mcp-bridge` first",
+        path.display()
+    );
+    path
+}
+
+#[cfg(unix)]
+fn agend_binary() -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_BIN_EXE_agend-terminal"));
+    assert!(
+        path.exists(),
+        "agend-terminal binary missing at {} — run `cargo build --bin agend-terminal` first",
+        path.display()
+    );
+    path
+}
+
+/// Scan `$AGEND_HOME/run/*` for the first run-dir containing `api.port`.
+/// Mirrors `agend-mcp-bridge::find_run_dir` so the assertion uses the same
+/// discovery contract as a real bridge would.
+#[cfg(unix)]
+fn find_api_port(home: &std::path::Path) -> Option<PathBuf> {
+    let run_base = home.join("run");
+    let entries = std::fs::read_dir(&run_base).ok()?;
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() && p.join("api.port").exists() {
+            return Some(p.join("api.port"));
+        }
+    }
+    None
+}
+
+/// Bug 1 contract: `api.port` MUST be published before the agent spawn loop
+/// completes. With N=3 agents and a 1000 ms stagger, the legacy ordering
+/// (agents-first) takes ~2 s before `api::serve` even starts; the budget here
+/// is 1500 ms so the test fails on main and passes after C1.
+#[cfg(unix)]
+#[test]
+fn api_port_published_before_agent_spawn_loop_completes() {
+    let bin = agend_binary();
+    let tmp = std::env::temp_dir().join(format!(
+        "agend-879v4-daemon-order-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    let start = Instant::now();
+    let mut child = Command::new(&bin)
+        .arg("start")
+        .arg("--foreground")
+        .args(["--agents", "t1:/bin/sh"])
+        .args(["--agents", "t2:/bin/sh"])
+        .args(["--agents", "t3:/bin/sh"])
+        .env("AGEND_HOME", &tmp)
+        // Pin the stagger so the legacy agents-first ordering takes a
+        // deterministic ~2 s; the C1 reorder makes `api.port` appear
+        // independently of this.
+        .env("AGEND_SPAWN_STAGGER_MS", "1000")
+        // Disable any background work that could compete for startup time
+        // and inflate the legacy budget (false positives), and silence
+        // logs going to a real $HOME log dir.
+        .env("AGEND_TEST_ISOLATION", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn agend-terminal daemon");
+
+    // Budget: well below 2 s (legacy wall time with N=3 + 1000 ms stagger)
+    // and well above the C1-reordered actual wall time (~50-200 ms even on
+    // slow CI). Poll cheaply so we don't add measurement noise.
+    let deadline = start + Duration::from_millis(1500);
+    let mut api_port_path: Option<PathBuf> = None;
+    while Instant::now() < deadline {
+        if let Some(p) = find_api_port(&tmp) {
+            api_port_path = Some(p);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    let elapsed = start.elapsed();
+
+    // Best-effort teardown. SIGKILL is fine — the test owns the tempdir
+    // and OS releases the .daemon.lock file lock on process death.
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(
+        api_port_path.is_some(),
+        "Bug 1: api.port MUST be published before the agent spawn loop completes. \
+         With N=3 agents at 1000ms stagger, the legacy agents-first ordering \
+         delays api.port by ~2s; this test budget is 1500ms. Elapsed: {elapsed:?}. \
+         Without C1 (api::serve spawn BEFORE agent loop in src/daemon/mod.rs), \
+         the agents' mcp-bridges race against an unwritten api.port file."
+    );
+}
+
+/// Bug 2 contract: when the daemon is unreachable, the bridge's `tools/list`
+/// arm MUST surface a visible JSON-RPC error, NOT silently return
+/// `{result: {tools: []}}`. Forcing the timeout small via
+/// `AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS` keeps the test fast on CI.
+#[test]
+fn bridge_tools_list_no_silent_empty_when_daemon_unreachable() {
+    let bridge = bridge_binary();
+    let tmp = std::env::temp_dir().join(format!(
+        "agend-879v4-bridge-silent-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    let mut child = Command::new(&bridge)
+        .env("AGEND_HOME", &tmp)
+        .env("AGEND_INSTANCE_NAME", "test-silent-degrade")
+        .env("AGEND_TEST_ISOLATION", "1")
+        // C2 introduces this knob; on main (no C2) the bridge ignores it
+        // and returns `{tools: []}` immediately. The contract this test
+        // pins is the visible-error response, not the timeout duration.
+        .env("AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS", "300")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bridge");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+
+    writeln!(stdin, "{CLAUDE_CODE_INIT}").expect("write init");
+    writeln!(stdin, "{TOOLS_LIST}").expect("write tools/list");
+    stdin.flush().expect("flush");
+    drop(stdin);
+
+    let (tx, rx) = mpsc::channel::<Vec<String>>();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        let lines: Vec<String> = reader
+            .lines()
+            .take(2)
+            .map_while(Result::ok)
+            .filter(|l| !l.trim().is_empty())
+            .collect();
+        let _ = tx.send(lines);
+    });
+
+    let lines = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("bridge must respond within 5s");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(
+        lines.len() >= 2,
+        "expected init + tools/list responses, got {lines:?}"
+    );
+    let tools_resp: Value = serde_json::from_str(lines[1].trim()).unwrap_or_else(|e| {
+        panic!(
+            "tools/list response must be NDJSON, got {:?}: {e}",
+            lines[1]
+        )
+    });
+
+    let has_error = tools_resp.get("error").is_some();
+    let has_empty_tools_result = tools_resp["result"]["tools"]
+        .as_array()
+        .map(|a| a.is_empty())
+        .unwrap_or(false);
+
+    assert!(
+        !has_empty_tools_result,
+        "Bug 2: tools/list MUST NOT silently return `{{result: {{tools: []}}}}` \
+         when daemon is unreachable. This silent-degrade pattern hides \
+         bootstrap races from operators (see #881 for the same antipattern \
+         in noop_guard). Got: {tools_resp}"
+    );
+    assert!(
+        has_error,
+        "Bug 2: tools/list MUST surface a visible JSON-RPC error when \
+         daemon is unreachable, NOT a silent empty list. Got: {tools_resp}"
+    );
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -56,6 +56,7 @@ impl TestDaemon {
         // Wave 1 CLI consolidation: the historical `daemon` subcommand was
         // removed; `start --agents <name:cmd ...>` is the canonical
         // replacement.
+        let expected_agents = agents.len();
         let mut args: Vec<&str> = vec!["start", "--agents"];
         args.extend(agents);
 
@@ -79,7 +80,26 @@ impl TestDaemon {
         }
         assert!(found, "daemon API port not published after 6s");
 
-        TestDaemon { child, home }
+        // #879v4 C1 — after the daemon-reorder fix, `api.port` is published
+        // BEFORE the agent spawn loop runs. Wait for the registry to settle
+        // so tests can call `list`/`kill`/`inject` against the expected
+        // agents without racing the staggered spawn loop.
+        let daemon = TestDaemon { child, home };
+        let registered = wait_until(
+            || {
+                let resp = daemon.api_call(&serde_json::json!({"method": "list"}));
+                resp["result"]["agents"]
+                    .as_array()
+                    .map(|a| a.len() == expected_agents)
+                    .unwrap_or(false)
+            },
+            Duration::from_secs(15),
+        );
+        assert!(
+            registered,
+            "agents not registered within 15s of api.port publish (expected {expected_agents})"
+        );
+        daemon
     }
 
     fn find_api_port(home: &Path) -> Option<u16> {


### PR DESCRIPTION
## Summary

Two-bug fix that addresses the regressions surfaced by PR #903 (reverted via fe528c1).
The #879 RCA spike identified both bugs as **pre-existing**, unmasked by #903 when always-Attached
mode removed the in-process `api::serve` shim that previously masked the daemon-side startup race.

- **C1 (`src/daemon/mod.rs`):** spawn `api::serve` thread **before** the agent spawn loop, closing a
  deterministic ~N×stagger race window between agents' `mcp-bridge` connecting and `api.port`
  becoming readable (reviewer observed ~4.6 s window across 3 fresh-sandbox cycles with N=9 agents).
- **C2 (`src/bin/agend-mcp-bridge.rs`):** replace `Err(_) => {tools: []}` silent-degrade in the
  `tools/list` arm with bounded retry (30 s @ 100 ms cadence, env-overridable) and a visible
  JSON-RPC `-32603` error on exhaustion. Retry is gated to transport errors only — application
  errors (`ok:false` from daemon) propagate immediately, preserving the existing
  `bridge_does_not_retry_application_errors` contract.

## Commits (test-first, no fix before its RED test)

1. `5ddd073` **test(#879v4):** pin two RED tests in `tests/attached_path_mcp_invariants.rs` —
   `api_port_published_before_agent_spawn_loop_completes` and
   `bridge_tools_list_no_silent_empty_when_daemon_unreachable`. Both fail at parent SHA fe528c1.
2. `525c448` **fix(C1):** daemon reorder. Includes a benign `tests/integration.rs` harness
   adjustment (`TestDaemon::start_with_agents` now waits for the registry to settle after
   `api.port` appears) so the lifecycle / inject / list tests remain green under the new
   ordering — the harness change is a no-op on the pre-C1 code path.
3. `6a50e15` **fix(C2):** bridge bounded retry + visible error.

## Test plan
- [x] `cargo test --test attached_path_mcp_invariants` GREEN at HEAD, RED at parent SHA (`fe528c1`)
- [x] `cargo test --test integration` 13/13 pass (was 3 failures pre-harness-fix; harness change scoped to C1)
- [x] `cargo test --test mcp_bridge_idle_reconnect --test mcp_bridge_client_handshake` all pass (incl. the application-error-no-retry contract)
- [x] `cargo test --test mcp_proxy_lifecycle --test mcp_proxy_behavioral_parity --test mcp_subprocess_is_zero_state` all pass
- [x] `cargo test --test spawn_rationale_audit` pass (no new spawn site; existing rationale comment moved with the api::serve block)
- [x] `cargo clippy --bin agend-mcp-bridge --tests` clean
- [ ] CI 5/5 (macos / ubuntu / windows / audit / LOC overrun) — green confirmation pending
- [ ] Independent reviewer verifies RED → GREEN by `git checkout 5ddd073 && cargo test --test attached_path_mcp_invariants`

## Out of scope (separate PRs per RCA spike conclusion)
- Dynamic `STARTUP_TIMEOUT` (`5s + 2×N`)
- 3-tier probe split (`daemon-pid-published` / `daemon-api-ready` / `daemon-init-complete`)
- `§3.X` silent-degrade-Err-arm discipline codification

## Source of truth
`/tmp/879v4-rca-handoff.md` (RCA spike handoff) + reviewer Part 2 audit + operator approval (2026-05-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)