### PR TITLE
fix(#829): boot orphan-sweep takes explicit empty live set (Fix A)

### DIFF
--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -194,12 +194,19 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     // beyond the single `git switch main` mutation when conditions
     // are right. Best-effort — boot continues regardless.
     canonical_hygiene::run_hygiene(&config);
-    // #829: boot-time orphan-owner sweep. Auto-applies for owners
-    // verifiably gone (∉ fleet.yaml ∧ ∉ live registry); dry-run +
-    // tracing::warn for the softer "∈ fleet.yaml ∧ ∉ live" case.
-    // Best-effort with tracing audit; skips entirely if
-    // `api::call(LIST)` fails (e.g. socket bind race during boot).
-    crate::tasks::reconcile_orphan_owners(home);
+    // #829 Fix A: boot-time orphan-owner sweep. We pass `live = ∅`
+    // explicitly because `api::serve` hasn't bound the Unix socket
+    // yet (that happens later in `daemon::run_with_prepared`) and no
+    // fleet agents have spawned (auto-start runs even later). The
+    // pre-Fix A call resolved `live` via `api::call(LIST)` here, which
+    // always returned None at this point in bootstrap → guaranteed
+    // no-op every boot → ghost owners accumulated until manual
+    // cleanup. Strict ghosts (∉ fleet.yaml ∧ ∉ live) are auto-cleared;
+    // Soft candidates (∈ fleet.yaml ∧ ∉ live) stay dry-run so the
+    // "agent not yet spawned" case isn't over-orphaned. Periodic
+    // post-boot callers should keep using `reconcile_orphan_owners`
+    // which still fetches `live` from the running daemon.
+    crate::tasks::reconcile_orphan_owners_with_live(home, &std::collections::HashSet::new());
 
     Ok(BootstrapOutcome::Owned(Box::new(OwnedFleet {
         home: home.to_path_buf(),

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -2286,6 +2286,75 @@ mod tests {
         );
     }
 
+    /// #829 Fix A — C1 RED anchor.
+    ///
+    /// Locks the boot-path contract: with an explicit empty live set
+    /// (the verifiable state at `bootstrap::prepare` time — `api::serve`
+    /// has not yet bound the socket, no agents have been spawned), a
+    /// ghost-owned task (owner ∉ fleet.yaml ∧ ∉ live) MUST land as
+    /// Strict and have its owner cleared via `orphan_tasks_for_owner`.
+    ///
+    /// Pre-Fix A this symbol doesn't exist: compile-fail = RED. Post-Fix
+    /// A the wrapper factors out the body and the boot caller can pass
+    /// `HashSet::new()` directly, severing the broken `api::call` chain.
+    #[test]
+    fn reconcile_orphan_owners_with_live_empty_set_orphans_strict_ghost() {
+        use crate::task_events::{InstanceName, TaskEvent, TaskId};
+        let home = tmp_home("reconcile_with_live_empty_orphans_strict");
+        // No fleet.yaml written → FleetConfig::load Err → empty fleet
+        // instances → "dev-impl-1" classifies Strict.
+
+        let emitter = InstanceName::from("test:legacy_migration");
+        let tid = TaskId("t-ghost-1".into());
+        crate::task_events::append_batch(
+            &home,
+            &emitter,
+            vec![TaskEvent::Created {
+                task_id: tid.clone(),
+                title: "ghost-owned legacy task".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: Some(InstanceName::from("dev-impl-1")),
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+            }],
+        )
+        .expect("seed Created event");
+
+        // Pre-condition: replay sees the ghost owner.
+        let pre = crate::task_events::replay(&home).expect("pre replay");
+        assert_eq!(
+            pre.tasks
+                .get(&tid)
+                .and_then(|r| r.owner.as_ref().map(|o| o.0.clone())),
+            Some("dev-impl-1".into()),
+            "pre-condition: ghost owner persisted to event log"
+        );
+
+        // Subject under test: boot-path entrypoint that the bootstrap
+        // call site uses. `live = ∅` is the verifiable state at boot
+        // (pre-auto-start, pre-api::serve bind). Does NOT touch the
+        // periodic `reconcile_orphan_owners(home)` path that fetches
+        // live via `api::call`.
+        reconcile_orphan_owners_with_live(&home, &std::collections::HashSet::new());
+
+        let post = crate::task_events::replay(&home).expect("post replay");
+        let owner_after = post
+            .tasks
+            .get(&tid)
+            .and_then(|r| r.owner.as_ref().map(|o| o.0.clone()));
+        assert!(
+            owner_after.is_none(),
+            "after boot sweep with empty live, Strict ghost's owner must be cleared (got {owner_after:?})"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     #[test]
     fn can_mutate_task_assignee_match() {
         let home = tmp_home("can_mutate_assignee");

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -706,10 +706,7 @@ pub fn reconcile_orphan_owners(home: &Path) {
 /// Body factored out of `reconcile_orphan_owners`; this fn is the
 /// shared core used by both the boot path (empty live) and the
 /// periodic path (api-derived live). Strict/soft semantics unchanged.
-pub fn reconcile_orphan_owners_with_live(
-    home: &Path,
-    live: &std::collections::HashSet<String>,
-) {
+pub fn reconcile_orphan_owners_with_live(home: &Path, live: &std::collections::HashSet<String>) {
     let fleet_instances: std::collections::HashSet<String> =
         crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
             .ok()

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -647,7 +647,7 @@ pub struct OrphanScanResult {
 /// configuration-time set. Caller responsibility to populate both;
 /// this fn is pure so it's testable without a daemon.
 ///
-/// #829: boot-time orphan-owner sweeper. Sibling to
+/// #829: orphan-owner sweeper. Sibling to
 /// `crate::binding::reconcile_orphans` + `crate::worktree_pool::
 /// reconcile_orphan_leases` in `src/bootstrap/mod.rs`. Best-effort,
 /// tracing-audited, no return value.
@@ -662,15 +662,54 @@ pub struct OrphanScanResult {
 /// operator judgment for the "agent hasn't booted yet" race that
 /// `auto_start_fleet` will resolve seconds after bootstrap returns.
 ///
-/// Skip-on-api-fail: if `api::call(LIST)` returns `None`, the
-/// orchestrator early-returns BEFORE touching any state. Better to
-/// leave residue for next boot than to over-orphan during a daemon
-/// startup race.
+/// Fix A note (#829 follow-up): this wrapper is the post-boot /
+/// periodic entrypoint that still resolves `live` via
+/// `api::call(LIST)`. The boot caller now uses
+/// [`reconcile_orphan_owners_with_live`] directly with an empty live
+/// set — see that fn for the bootstrap-time rationale. Keeping the
+/// `api::call` path here means a future periodic-sweep tick can reuse
+/// the same orchestrator without re-implementing live-set fetching.
+///
+/// Skip-on-api-fail: if `api::call(LIST)` returns `None`, the wrapper
+/// early-returns BEFORE touching any state. Better to leave residue
+/// for the next periodic tick than to over-orphan against a stale
+/// (empty) live picture in a post-boot context where agents are
+/// genuinely meant to be running.
+#[allow(dead_code)] // Fix A: reserved for periodic-sweep callers (no wired site today)
 pub fn reconcile_orphan_owners(home: &Path) {
     let Some(live) = crate::runtime::list_live_agents(home) else {
-        tracing::info!("#829: api::call(LIST) unavailable at boot — skipping orphan-owner sweep");
+        tracing::info!("#829: api::call(LIST) unavailable — skipping orphan-owner sweep");
         return;
     };
+    reconcile_orphan_owners_with_live(home, &live);
+}
+
+/// #829 Fix A: boot-path entrypoint that takes `live` explicitly.
+///
+/// Pre-Fix A, `reconcile_orphan_owners` ran from `bootstrap::prepare`
+/// BEFORE `api::serve` bound the Unix socket (the socket is opened
+/// later in `daemon::run_with_prepared`), so `api::call(LIST)` always
+/// returned `None` and the sweep early-exited every boot. Operator
+/// surfaced the symptom on 2026-05-18 (45 accumulated ghost owners).
+///
+/// At bootstrap time `live = ∅` is provably correct: no agents have
+/// spawned yet (auto-start runs later in `run_with_prepared`). The
+/// bootstrap caller now passes `HashSet::new()` directly, severing
+/// the broken `api::call` chain. The classifier still does the right
+/// thing in this context:
+///
+/// - Owner ∈ fleet.yaml → Soft (warn, don't kill — correctly defers
+///   the "agent not yet spawned" case).
+/// - Owner ∉ fleet.yaml → Strict (auto-apply — catches the ghost
+///   buildup on next daemon boot).
+///
+/// Body factored out of `reconcile_orphan_owners`; this fn is the
+/// shared core used by both the boot path (empty live) and the
+/// periodic path (api-derived live). Strict/soft semantics unchanged.
+pub fn reconcile_orphan_owners_with_live(
+    home: &Path,
+    live: &std::collections::HashSet<String>,
+) {
     let fleet_instances: std::collections::HashSet<String> =
         crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
             .ok()
@@ -681,15 +720,15 @@ pub fn reconcile_orphan_owners(home: &Path) {
         Err(e) => {
             tracing::warn!(
                 error = %e,
-                "#829: task_events replay failed at boot — skipping orphan-owner sweep"
+                "#829: task_events replay failed — skipping orphan-owner sweep"
             );
             return;
         }
     };
 
-    let result = scan_orphan_candidates(&state, &live, &fleet_instances);
+    let result = scan_orphan_candidates(&state, live, &fleet_instances);
     if result.strict.is_empty() && result.soft.is_empty() {
-        tracing::debug!("#829: boot orphan-owner sweep clean — no ghost owners detected");
+        tracing::debug!("#829: orphan-owner sweep clean — no ghost owners detected");
         return;
     }
 
@@ -700,12 +739,12 @@ pub fn reconcile_orphan_owners(home: &Path) {
                 owner = %owner,
                 tasks = task_ids.len(),
                 orphaned = n,
-                "#829: boot orphan-owner sweep applied (strict — owner fully gone)"
+                "#829: orphan-owner sweep applied (strict — owner fully gone)"
             ),
             Err(e) => tracing::warn!(
                 owner = %owner,
                 error = %e,
-                "#829: boot orphan-owner sweep failed for strict candidate"
+                "#829: orphan-owner sweep failed for strict candidate"
             ),
         }
     }
@@ -719,7 +758,7 @@ pub fn reconcile_orphan_owners(home: &Path) {
             .collect();
         tracing::warn!(
             ?soft_summary,
-            "#829: boot detected tasks owned by configured-but-not-live agents \
+            "#829: detected tasks owned by configured-but-not-live agents \
              (in fleet.yaml ∧ ∉ live registry); operator may run `task action=sweep` \
              to apply orphan cleanup"
         );


### PR DESCRIPTION
## Summary

- Factors `reconcile_orphan_owners` into a wrapper + body so the bootstrap call site can pass `live = ∅` directly, severing the broken `api::call(LIST)` chain that made the boot sweep a guaranteed no-op every restart.
- Strict ghosts (∉ fleet.yaml ∧ ∉ live) are auto-cleared on next boot; soft candidates (∈ fleet.yaml ∧ ∉ live) stay dry-run so newly-spawning agents aren't over-orphaned.
- Test-first per §3.10: C1 RED test compile-fails on the missing `_with_live` symbol; C2 introduces the factor-out and the test flips GREEN.

## Why

RCA `t-20260518122152646382-6` traced the symptom (45 ghost owners that survived multiple daemon restarts, manually batch-cancelled by operator on 2026-05-18) to ordering: `reconcile_orphan_owners` runs inside `bootstrap::prepare` (`src/bootstrap/mod.rs:202`) BEFORE `api::serve` binds the Unix socket later in `daemon::run_with_prepared` (`src/daemon/mod.rs:467-487`). The in-process `api::call(LIST)` therefore connects to a non-existent socket → `list_live_agents` returns `None` → `reconcile_orphan_owners` logs ``"#829: api::call(LIST) unavailable…"`` and returns. Every boot. No periodic recovery — `reconcile_orphan_owners` had only one call site.

At bootstrap time `live = ∅` is provably correct: agents are spawned later in `run_with_prepared` after auto-start. Passing an empty set explicitly makes the classifier do the right thing without depending on a socket that doesn't exist yet.

## Scope

* `src/tasks.rs` — new `pub fn reconcile_orphan_owners_with_live(home, &HashSet<String>)` carrying the body; existing `pub fn reconcile_orphan_owners(home)` reduced to a thin wrapper that fetches `live` via `runtime::list_live_agents` and delegates. `#[allow(dead_code)]` on the wrapper because there's no periodic site wired today — dispatch spec reserves it for a future supervisor tick rather than deleting and re-deriving the same fetch-and-delegate pattern.
* `src/bootstrap/mod.rs` — `crate::tasks::reconcile_orphan_owners(home)` → `crate::tasks::reconcile_orphan_owners_with_live(home, &std::collections::HashSet::new())`. Inline comment names the `live = ∅` rationale.
* `src/tasks.rs` tests — C1 RED test `reconcile_orphan_owners_with_live_empty_set_orphans_strict_ghost` seeds a ghost-owned `Created` event via `append_batch`, calls the new entrypoint with empty live, asserts replay shows owner = None.

## Out of scope (strict)

* No change to `classify_owner` / `scan_orphan_candidates` / `orphan_tasks_for_owner` — reused as-is.
* No change to `runtime::list_live_agents` — still used by the post-boot wrapper.
* No Fix B (move sweep call to `daemon::run_with_prepared` after `api::serve` binds).
* No Fix C (wire reconcile into the periodic supervisor tick).
* No unrelated cleanup.

## Verification

### §3.10 RED→GREEN protocol

```bash
# RED at 53a0b83 (test commit alone):
$ git checkout 53a0b83
$ cargo test --bin agend-terminal tasks::tests::reconcile_orphan_owners_with_live_empty_set_orphans_strict_ghost --no-run
error[E0425]: cannot find function `reconcile_orphan_owners_with_live` in this scope
    --> src/tasks.rs:2343:9
669 | pub fn reconcile_orphan_owners(home: &Path) {
    | ------------------------------------------- similarly named function defined here
2343|     reconcile_orphan_owners_with_live(&home, &std::collections::HashSet::new());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

# GREEN at 4dba708 (factor-out + boot call site swap):
$ git checkout 4dba708
$ cargo test --bin agend-terminal tasks::tests::reconcile_orphan_owners_with_live_empty_set_orphans_strict_ghost
test tasks::tests::reconcile_orphan_owners_with_live_empty_set_orphans_strict_ghost ... ok
test result: ok. 1 passed; 0 failed
```

### Tasks suite regression

```bash
$ cargo test --bin agend-terminal tasks::
test result: ok. 75 passed; 0 failed; 0 ignored
```

## Test plan

- [x] `cargo test --bin agend-terminal tasks::` passes locally (75/75).
- [ ] CI all-green on macos-latest / ubuntu-latest / windows-latest + LOC overrun + audit.
- [ ] Reviewer verifies §3.10 RED→GREEN via `git checkout 53a0b83` (compile fails) → `git checkout 4dba708` (test passes).
- [ ] On next daemon boot post-merge, look for `#829: orphan-owner sweep clean — no ghost owners detected` (clean) or `#829: orphan-owner sweep applied (strict — owner fully gone)` (auto-clear) in the daemon log — replacing the prior `#829: api::call(LIST) unavailable at boot — skipping orphan-owner sweep` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)