### PR TITLE
fix(#896): spawn_and_register_agent publishes .port synchronously (Option D + rollback)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2003,6 +2003,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[allow(clippy::type_complexity)] // test scaffolding tuple; struct would be over-engineering
     fn make_test_registry() -> (
         AgentRegistry,
         Arc<Mutex<HashMap<String, AgentConfig>>>,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -481,7 +481,22 @@ fn run_core(
     tracing::info!(count = agents.len(), "starting agents");
 
     for def in &agents {
-        spawn_and_register_agent(home, def, &registry, &configs, &crash_tx, &shutdown)?;
+        // #896 Option D: spawn_and_register_agent now rolls back on
+        // synchronous TUI prep failure and returns Err. We log + skip
+        // the affected agent rather than aborting the entire daemon
+        // startup — operator sees `agend-terminal list` shorter than
+        // fleet.yaml expected + daemon log explains which agent failed
+        // and why. Daemon-as-a-whole stays up so the surviving agents
+        // are still usable while the operator investigates.
+        if let Err(e) =
+            spawn_and_register_agent(home, def, &registry, &configs, &crash_tx, &shutdown)
+        {
+            tracing::error!(
+                agent = %def.0,
+                error = %e,
+                "spawn_and_register_agent rolled back; agent NOT in fleet"
+            );
+        }
         if agents.len() > 1 {
             std::thread::sleep(spawn_stagger());
         }
@@ -1344,19 +1359,45 @@ fn spawn_and_register_agent(
     }
 
     let rdir = run_dir(home);
+    // #896 Option D: synchronous TUI listener prep BEFORE returning Ok.
+    // Pre-#896 this whole step happened inside the fire-and-forget
+    // accept-loop thread, so `spawn_and_register_agent` could return
+    // Ok while `.port` hadn't landed on disk yet. App-attach during
+    // the spawn loop's stagger window saw "no agents are reachable".
+    // Now we bind + write_port on the caller thread; only after the
+    // port file exists do we hand the listener to the async accept
+    // loop. On prep failure: rollback via `delete_transaction` (kill
+    // child, drop registry entry, clean configs, remove residual
+    // port file) and propagate Err.
+    let meta = match tui_bridge::prepare_tui_listener_and_publish_port(name, &rdir) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::error!(
+                agent = %name,
+                error = %e,
+                "TUI listener prep failed — rolling back agent registration"
+            );
+            lifecycle::delete_transaction(home, name, registry, Some(configs));
+            return Err(anyhow::Error::from(e));
+        }
+    };
+
     let reg = Arc::clone(registry);
     let n = name.clone();
-    // fire-and-forget: serve_agent_tui blocks on UnixListener::accept and
-    // exits when the agent is removed from the registry. JoinHandle is
-    // discarded because shutdown is signalled implicitly by socket-file
-    // removal in delete_transaction.
+    // fire-and-forget: serve_tui_accept_loop blocks on TcpListener::accept
+    // and exits when the agent is removed from the registry. JoinHandle
+    // is discarded because shutdown is signalled implicitly by socket-
+    // file removal in `delete_transaction`.
     if let Err(e) = std::thread::Builder::new()
         .name(format!("{n}_tui_server"))
-        .spawn(move || serve_agent_tui(&n, &rdir, &reg))
+        .spawn(move || tui_bridge::serve_tui_accept_loop(&n, meta, &reg))
     {
-        // Sprint 20 F5 fix: previously a TUI server spawn failure left the
-        // agent registered + child running but with no attachable socket.
-        // Roll back the agent we just spawned so retries start clean.
+        // Sprint 20 F5 fix (preserved): a TUI server spawn failure
+        // would otherwise leave the agent registered + child running
+        // but with no accepting socket. Roll back so retries start
+        // clean. #896 update: prep step already wrote `.port`, so the
+        // rollback now also clears that residual via
+        // `delete_transaction`'s port cleanup.
         tracing::warn!(
             agent = %name,
             error = %e,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1926,4 +1926,169 @@ mod tests {
             "Wave 3 PR-2 contract: grace = 2s exactly"
         );
     }
+
+    // --- #896 Option D anchor (C0 RED) ---
+    //
+    // Locks the boot-time invariant Option D establishes:
+    // `spawn_and_register_agent` MUST publish the agent's `.port`
+    // synchronously before returning Ok. Pre-fix the TUI thread does
+    // the bind+write_port asynchronously after the function returns,
+    // so app probes between agent spawns see an empty / partial
+    // `*.port` set (issue #896, race-class regression widened by
+    // PR #906 daemon api::serve reorder).
+    //
+    // The "no sleep, no retry" wording is the contract — the assertion
+    // is the postcondition at return. Race timing is reviewer-confirmed
+    // via §3.20 SOP 3 (RED→GREEN protocol on three runs).
+
+    #[cfg(unix)]
+    fn make_shell_agent_def(name: &str) -> crate::bootstrap::AgentDef {
+        (
+            name.into(),
+            "/bin/sh".into(),
+            vec!["-c".into(), "sleep 60".into()],
+            None,
+            None,
+            "\r".into(),
+        )
+    }
+
+    #[cfg(unix)]
+    fn setup_run_dir_with_cookie(home: &Path) -> PathBuf {
+        let run = home.join("run").join(std::process::id().to_string());
+        std::fs::create_dir_all(&run).expect("create run_dir");
+        crate::auth_cookie::issue(&run).expect("issue api.cookie");
+        run
+    }
+
+    #[cfg(unix)]
+    fn make_test_registry() -> (
+        AgentRegistry,
+        Arc<Mutex<HashMap<String, AgentConfig>>>,
+        crossbeam_channel::Sender<crate::agent::AgentExitEvent>,
+        crossbeam_channel::Receiver<crate::agent::AgentExitEvent>,
+        Arc<AtomicBool>,
+    ) {
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs: Arc<Mutex<HashMap<String, AgentConfig>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let (crash_tx, crash_rx) = crossbeam_channel::unbounded();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        (registry, configs, crash_tx, crash_rx, shutdown)
+    }
+
+    #[cfg(unix)]
+    fn kill_registered_child(registry: &AgentRegistry, name: &str) {
+        let reg = registry.lock();
+        if let Some(handle) = reg.get(name) {
+            let _ = handle.child.lock().kill();
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawn_and_register_agent_publishes_port_synchronously() {
+        let home = tmp_home("publish_sync");
+        let run_dir = setup_run_dir_with_cookie(&home);
+        let (registry, configs, crash_tx, _crash_rx, shutdown) = make_test_registry();
+        let def = make_shell_agent_def("probe-1");
+
+        spawn_and_register_agent(&home, &def, &registry, &configs, &crash_tx, &shutdown)
+            .expect("spawn ok");
+
+        // CONTRACT: the agent's .port is on disk BEFORE this assertion line.
+        // Pre-fix: TUI thread is async, .port may not be written yet (race).
+        // Post-fix: prepare_tui_listener_and_publish_port ran synchronously
+        // inside spawn_and_register_agent.
+        assert!(
+            crate::ipc::read_port(&run_dir, "probe-1").is_some(),
+            "spawn_and_register_agent must publish .port synchronously before return"
+        );
+
+        kill_registered_child(&registry, "probe-1");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawn_and_register_agent_rollback_on_listener_prep_failure() {
+        // Force prepare-listener failure by NOT issuing api.cookie in
+        // run_dir. `prepare_tui_listener_and_publish_port` reads the
+        // cookie first (so it can hand it to the accept loop); a missing
+        // cookie file is an Err on the synchronous prep path.
+        let home = tmp_home("rollback_prep");
+        let run = home.join("run").join(std::process::id().to_string());
+        std::fs::create_dir_all(&run).expect("create run_dir");
+        // Deliberately skip `auth_cookie::issue` — prep should fail at
+        // cookie read.
+        let (registry, configs, crash_tx, _crash_rx, shutdown) = make_test_registry();
+        let def = make_shell_agent_def("rollback-probe");
+
+        let result =
+            spawn_and_register_agent(&home, &def, &registry, &configs, &crash_tx, &shutdown);
+
+        // CONTRACT (Option D rollback):
+        // 1. spawn_and_register_agent returns Err — caller can decide whether
+        //    to continue or abort.
+        assert!(
+            result.is_err(),
+            "spawn_and_register_agent must return Err when TUI listener prep fails (got Ok)"
+        );
+        // 2. Registry MUST NOT contain the agent — caller sees a clean
+        //    rollback state, no zombie entries.
+        assert!(
+            registry.lock().get("rollback-probe").is_none(),
+            "registry must NOT contain 'rollback-probe' after rollback"
+        );
+        // 3. AgentConfig MUST NOT contain the agent — configs map mirrors
+        //    registry membership.
+        assert!(
+            configs.lock().get("rollback-probe").is_none(),
+            "configs must NOT contain 'rollback-probe' after rollback"
+        );
+        // 4. .port file MUST NOT be on disk — prep failed before write_port
+        //    or the rollback removed it.
+        assert!(
+            crate::ipc::read_port(&run, "rollback-probe").is_none(),
+            "rollback must leave no .port residue"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn app_attach_during_stagger_window_sees_all_agents() {
+        // Behavioral RED: simulates the operator's smoke — multiple agents
+        // spawned sequentially with stagger between them. Pre-fix, an "app
+        // attach" simulated by `ipc::list_agent_ports` mid-loop sees fewer
+        // entries than the loop has produced (TUI threads race). Post-fix,
+        // every iteration's port is on disk by the time the next iteration
+        // begins, so list_agent_ports == iteration_count holds at each step.
+        let home = tmp_home("attach_during_stagger");
+        let run_dir = setup_run_dir_with_cookie(&home);
+        let (registry, configs, crash_tx, _crash_rx, shutdown) = make_test_registry();
+
+        let agent_names = ["a-1", "a-2", "a-3", "a-4"];
+        for (i, name) in agent_names.iter().enumerate() {
+            let def = make_shell_agent_def(name);
+            spawn_and_register_agent(&home, &def, &registry, &configs, &crash_tx, &shutdown)
+                .expect("spawn ok");
+            // CONTRACT: every agent spawned so far has its .port on disk.
+            // Probe is what an `app` reattach would do.
+            let visible = crate::ipc::list_agent_ports(&run_dir);
+            for prior in &agent_names[..=i] {
+                assert!(
+                    visible.contains(&prior.to_string()),
+                    "after spawning {name} (iteration {i}), agent {prior} must have .port on \
+                     disk; got {visible:?}"
+                );
+            }
+        }
+
+        for name in &agent_names {
+            kill_registered_child(&registry, name);
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/tui_bridge.rs
+++ b/src/daemon/tui_bridge.rs
@@ -5,36 +5,86 @@ use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 
-/// Start the TUI socket server for an agent (blocks the calling thread).
+/// Output of the synchronous TUI prep step. Carries the bound TCP
+/// listener and the auth cookie so the async accept loop can resume
+/// without re-reading either from disk.
 ///
-/// Binds a TCP loopback port, publishes it to `{run_dir}/{name}.port`, then
-/// accepts connections. Removes the port file when the listener exits.
-pub fn serve_agent_tui(name: &str, run_dir: &Path, registry: &AgentRegistry) {
-    // P1-10: load the per-daemon cookie once; every incoming TUI client must
-    // present it as the first 32 bytes on the wire. If the cookie file isn't
-    // there yet, the caller (daemon::run / verify::run) skipped its issuance
-    // step — fail closed rather than serve an unauthenticated TUI.
-    let cookie = match crate::auth_cookie::read_cookie(run_dir) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::error!(agent = name, error = %e, "api.cookie missing; TUI server aborted");
-            return;
-        }
-    };
+/// #896 Option D: separating "bind + publish .port" (sync, returnable
+/// failure) from "accept loop" (async, fire-and-forget) is what lets
+/// `spawn_and_register_agent` block on the publish step.
+pub(crate) struct TuiListenerMeta {
+    listener: std::net::TcpListener,
+    cookie: crate::auth_cookie::Cookie,
+}
 
-    let listener = match crate::ipc::bind_loopback() {
-        Ok(l) => l,
+/// Synchronously bind the agent's TUI loopback socket and publish
+/// `{run_dir}/{name}.port`. Returns the listener + cookie so a
+/// subsequent fire-and-forget accept loop (`serve_tui_accept_loop`)
+/// can take over without redoing the io::Result-bearing setup.
+///
+/// #896 Option D contract: callers that need rollback semantics (the
+/// daemon's startup loop via `spawn_and_register_agent`) MUST call
+/// this directly and propagate the Err. Callers that don't need
+/// rollback (CLI capture, agent shell-fallback, verify probe) can use
+/// `serve_agent_tui` which wraps prep + accept-loop into one
+/// best-effort entrypoint.
+pub(crate) fn prepare_tui_listener_and_publish_port(
+    name: &str,
+    run_dir: &Path,
+) -> std::io::Result<TuiListenerMeta> {
+    // P1-10: load the per-daemon cookie once; every incoming TUI
+    // client must present it as the first 32 bytes on the wire.
+    let cookie = crate::auth_cookie::read_cookie(run_dir).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("api.cookie unavailable: {e}"),
+        )
+    })?;
+    let listener = crate::ipc::bind_loopback()?;
+    let port = crate::ipc::local_port(&listener);
+    crate::ipc::write_port(run_dir, name, port)?;
+    tracing::info!(agent = name, port, "TUI socket ready");
+    Ok(TuiListenerMeta { listener, cookie })
+}
+
+/// All-in-one TUI server for callers that don't need rollback on
+/// prep failure (CLI `capture`, agent crash shell-fallback, verify
+/// probe). Internally runs the synchronous prep + the async accept
+/// loop on the calling thread. Prep failure degrades to a warn-log
+/// and early return, preserving the pre-#896 best-effort shape.
+///
+/// Blocks the calling thread on `incoming()` until the listener is
+/// dropped or the agent is removed from the registry. Callers wanting
+/// rollback semantics should call
+/// [`prepare_tui_listener_and_publish_port`] + [`serve_tui_accept_loop`]
+/// separately so they can react to prep failure.
+pub fn serve_agent_tui(name: &str, run_dir: &Path, registry: &AgentRegistry) {
+    let meta = match prepare_tui_listener_and_publish_port(name, run_dir) {
+        Ok(m) => m,
         Err(e) => {
-            tracing::warn!(agent = name, error = %e, "failed to bind TUI socket");
+            tracing::warn!(
+                agent = name,
+                error = %e,
+                "TUI listener prep failed; server aborted"
+            );
             return;
         }
     };
-    let port = crate::ipc::local_port(&listener);
-    if let Err(e) = crate::ipc::write_port(run_dir, name, port) {
-        tracing::warn!(agent = name, error = %e, "failed to publish TUI port");
-        return;
-    }
-    tracing::info!(agent = name, port, "TUI socket ready");
+    serve_tui_accept_loop(name, meta, registry);
+}
+
+/// Run the TUI accept loop with a pre-bound listener + cookie. Blocks
+/// the calling thread; intended to be spawned fire-and-forget after a
+/// successful synchronous `prepare_tui_listener_and_publish_port`
+/// step. Exits when the listener is dropped or accept errors
+/// terminally (e.g. agent removal via `delete_transaction` closes the
+/// underlying socket file).
+pub(crate) fn serve_tui_accept_loop(
+    name: &str,
+    meta: TuiListenerMeta,
+    registry: &AgentRegistry,
+) {
+    let TuiListenerMeta { listener, cookie } = meta;
 
     for stream in listener.incoming() {
         let mut stream = match stream {

--- a/src/daemon/tui_bridge.rs
+++ b/src/daemon/tui_bridge.rs
@@ -79,11 +79,7 @@ pub fn serve_agent_tui(name: &str, run_dir: &Path, registry: &AgentRegistry) {
 /// step. Exits when the listener is dropped or accept errors
 /// terminally (e.g. agent removal via `delete_transaction` closes the
 /// underlying socket file).
-pub(crate) fn serve_tui_accept_loop(
-    name: &str,
-    meta: TuiListenerMeta,
-    registry: &AgentRegistry,
-) {
+pub(crate) fn serve_tui_accept_loop(name: &str, meta: TuiListenerMeta, registry: &AgentRegistry) {
     let TuiListenerMeta { listener, cookie } = meta;
 
     for stream in listener.incoming() {


### PR DESCRIPTION
## Summary

- Lifts the TUI listener bind + `.port` publish onto the caller thread of `spawn_and_register_agent` so the function returns Ok only after `.port` is on disk. App-attach during the agent spawn stagger window (`AGEND_SPAWN_STAGGER_MS` default 500 × N agents) now deterministically sees every configured agent.
- Treats prep failure as a rollback signal: spawned child killed, registry + configs cleaned, `.port` residue removed, `Err` returned. The daemon startup loop logs the failure and continues so a single bad agent doesn't kill the whole daemon.
- Test-first per §3.10: three RED anchors lock the invariant (sync publish, rollback on prep failure, multi-agent visibility at each iteration). Pre-fix all three fail; post-fix all 29 daemon tests pass + the full 2391-test suite stays green.

## Why

RCA `t-20260518140253932017-0` (#896 spike primary): app probing during `daemon::run_with_prepared`'s spawn loop saw `api.port` (written ~ms after `api::serve` thread spawn) but no agent `.port` files (written asynchronously by per-agent TUI threads). Symptom: `WARN attached to daemon but no agents are reachable; check \`agend-terminal list\`` (`src/app/mod.rs:271`).

The race is pre-existing in `spawn_and_register_agent` since Sprint 20, but PR #906 (`#879v4 daemon api-serve reorder`, merged `1583370e`) widened the visibility window — pre-#906 the api.port lived behind the agent spawn loop, so app probing couldn't even attach until agents were already up. Post-#906 api.port shows up first, exposing the latent race.

This PR fixes the underlying race rather than reverting #906. The bridge bounded-retry path that #906 added for MCP tool calls is preserved; app's `.port` glob path now wins the same way.

## Scope

* `src/daemon/tui_bridge.rs` (C1): splits `serve_agent_tui` into
  * `prepare_tui_listener_and_publish_port(name, run_dir) -> io::Result<TuiListenerMeta>` — synchronous; cookie read + bind_loopback + write_port.
  * `serve_tui_accept_loop(name, meta, registry)` — async; the existing accept loop body unchanged.
  * `serve_agent_tui(name, run_dir, registry)` retained as the wrapper for callers that don't need rollback (CLI `capture`, agent crash shell-fallback, `verify::run`).
* `src/daemon/mod.rs` (C2):
  * `spawn_and_register_agent` calls `prepare_tui_listener_and_publish_port` synchronously. On Err: `lifecycle::delete_transaction` rolls back, `Err(anyhow::Error::from(io_err))` propagates.
  * `daemon::run_with_prepared` agent spawn loop changes from `?` to log-and-continue: failed agents get `tracing::error!`, surviving agents still come up.
* `src/daemon/mod.rs` tests (C0):
  * `spawn_and_register_agent_publishes_port_synchronously` — post-condition assertion at return, no sleep.
  * `spawn_and_register_agent_rollback_on_listener_prep_failure` — Err return + clean registry + clean configs + no `.port` residue.
  * `app_attach_during_stagger_window_sees_all_agents` — multi-agent loop, every iteration's port visible to a simulated app attach.

## Out of scope (strict)

* No `.port` glob → API call refactor (Option F filed as separate issue; multi-PR work).
* No change to `find_active_run_dir` semantics.
* No `classify_owner` / `scan_orphan_candidates` / #829 surface touch.
* No reverting of PR #906's api-serve-before-agents reorder (that fix for #879 stays; this PR closes the latent race it exposed).

## Verification

### §3.10 RED→GREEN protocol

```bash
# RED at 07884df (test commit alone):
$ git checkout 07884df
$ cargo test --bin agend-terminal --no-fail-fast daemon::tests
test result: FAILED. 26 passed; 3 failed
  - spawn_and_register_agent_publishes_port_synchronously FAILED
  - spawn_and_register_agent_rollback_on_listener_prep_failure FAILED
  - app_attach_during_stagger_window_sees_all_agents FAILED

# GREEN at 77b9953 (impl complete):
$ git checkout 77b9953
$ cargo test --bin agend-terminal --no-fail-fast daemon::tests
test result: ok. 29 passed; 0 failed; 0 ignored
$ cargo test --bin agend-terminal --no-fail-fast
test result: ok. 2391 passed; 0 failed; 7 ignored
```

### §3.20 race-class compliance

* **SOP 1 (deterministic test)**: all three RED anchors are post-condition / state-shape assertions, not timing assertions. They pass deterministically on three back-to-back runs on the GREEN head.
* **SOP 2 (operator smoke gate)**: REQUIRED pre-merge. See \"REQUIRED post-merge operator smoke confirmation\" below.
* **SOP 3 (reviewer RED→GREEN protocol)**: reviewer's verdict body must state verbatim that they ran RED at 07884df → confirmed 3 failures, and GREEN at 77b9953 → confirmed 3 passes on three back-to-back runs.

## REQUIRED post-merge operator smoke confirmation

Per §3.20 SOP 2 — operator must observe the following on a real fleet before this PR is declared \"done\":

1. Clean `AGEND_HOME`, fleet.yaml with ≥ 4 instances.
2. \`agend-terminal start\` (default detached mode).
3. Within 1s of the daemon's run_dir appearing, \`agend-terminal app\`.
4. Expected: all 4 agents visible as tabs immediately; NO \"attached to daemon but no agents are reachable\" warning.
5. \`agend-terminal list\`: 4 agents shown, all with valid `.port` files in `~/.agend-terminal/run/<pid>/`.

If the smoke uncovers a regression, recovery is operator-driven revert (race regression auto-escalates to P0 per §3.11(a)).

## Test plan

- [x] `cargo test --bin agend-terminal --no-fail-fast daemon::tests` passes (29/29) locally.
- [x] `cargo test --bin agend-terminal --no-fail-fast` passes (2391/0/7 ignored) locally.
- [x] `cargo fmt --check` passes locally.
- [ ] CI all-green on macos / ubuntu / windows + LOC overrun + audit.
- [ ] Reviewer executes §3.10 RED→GREEN protocol per SOP 3.
- [ ] **Operator smoke gate** per §3.20 SOP 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)