### PR TITLE
Fix #901: pre-focus pane on Down(Left) before forwarding mouse events

### DIFF
--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -892,4 +892,152 @@ mod tests {
             "border_drag must be cleared on mouse-up"
         );
     }
+
+    // ----- #901: Down(Left) on mouse-forwarded pane must focus that pane -----
+
+    use serial_test::serial;
+
+    /// AGEND_HOME isolation for tests that call `handle()` and hit the
+    /// forward path (which writes a metadata file via
+    /// `notification_queue::record_input_activity`). `#[serial]` callers
+    /// guarantee env-var swaps don't race.
+    struct ScopedHome {
+        prev: Option<String>,
+        dir: std::path::PathBuf,
+    }
+    impl ScopedHome {
+        fn new(tag: &str) -> Self {
+            let dir =
+                std::env::temp_dir().join(format!("agend-901-{}-{}", tag, std::process::id()));
+            std::fs::create_dir_all(&dir).ok();
+            let prev = std::env::var("AGEND_HOME").ok();
+            std::env::set_var("AGEND_HOME", &dir);
+            Self { prev, dir }
+        }
+    }
+    impl Drop for ScopedHome {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(p) => std::env::set_var("AGEND_HOME", p),
+                None => std::env::remove_var("AGEND_HOME"),
+            }
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn empty_registry() -> crate::agent::AgentRegistry {
+        std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
+    }
+
+    fn down_left_at(column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::empty(),
+        }
+    }
+
+    /// Build a two-pane vertical split with left at id=1, right at id=2.
+    /// Pane 1 occupies columns 0..10, pane 2 occupies columns 10..20.
+    /// Both panes are 10 rows tall starting at row 1 (row 0 is the tab bar).
+    fn two_pane_layout(right_agent: &str) -> Layout {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("multi".to_string(), leaf(1, "left")));
+        layout.tabs[0].split_focused(SplitDir::Vertical, leaf(2, right_agent));
+        layout.active = 0;
+        layout.tabs[0].pane_rects.insert(1, (0, 1, 10, 10));
+        layout.tabs[0].pane_rects.insert(2, (10, 1, 10, 10));
+        layout
+    }
+
+    /// #901 contract: clicking the body of a mouse-forwarded pane (e.g.
+    /// OpenCode) MUST focus that pane, even though the click is forwarded
+    /// to the backend's PTY. Pre-fix, `mouse::handle` early-returned after
+    /// the SGR forward (lines 62-67) and never ran `handle_down`, leaving
+    /// `tab.focus_id` pointing at the previously-focused pane. The
+    /// operator workaround was to click the pane title bar instead.
+    ///
+    /// RED at parent SHA: focus stays on the left pane.
+    /// GREEN after the top-level pre-focus fix: focus moves to the pane
+    /// under the cursor BEFORE the forward early-return runs.
+    #[test]
+    #[serial]
+    fn pane_body_down_focuses_pane_even_when_mouse_forwarded() {
+        let _home = ScopedHome::new("focus-forwarded");
+
+        let mut layout = two_pane_layout("opencode");
+        layout.tabs[0].focus_id = 1;
+        enable_opencode_mouse(layout.tabs[0].root_mut().find_pane_mut(2).unwrap());
+
+        // Precondition: opencode pane IS the mouse-forward target — without
+        // this the test wouldn't be exercising the bug path.
+        let click = down_left_at(15, 5);
+        assert!(
+            super::pane_for_mouse_forward(&layout, &click).is_some(),
+            "test precondition: opencode pane under cursor must be the forward target"
+        );
+
+        let mut state = MouseState::default();
+        let fleet_path = std::path::Path::new("/nonexistent/fleet.yaml");
+        super::handle(
+            click,
+            &mut layout,
+            &mut state,
+            fleet_path,
+            &empty_registry(),
+        );
+
+        assert_eq!(
+            layout.tabs[0].focus_id, 2,
+            "Down(Left) on mouse-forwarded pane body MUST update focus_id \
+             (started at 1, expected 2 after fix); operator-visible symptom \
+             is clicking OpenCode pane body doesn't focus it"
+        );
+    }
+
+    /// #783/#700 invariant regression-guard: non-mouse panes
+    /// (claude/codex/kiro/gemini) must still route Down(Left) through the
+    /// local `handle_down` path so `handle_selection` updates both
+    /// `focus_id` AND `selecting_pane`. The top-level pre-focus block
+    /// only runs when `pane_for_mouse_forward` matches; for non-mouse
+    /// panes it is a no-op and the legacy local-dispatch path must
+    /// remain intact, including selection-cache state.
+    #[test]
+    #[serial]
+    fn pane_body_down_on_non_mouse_pane_still_updates_focus_via_local_path() {
+        let _home = ScopedHome::new("focus-local");
+
+        let mut layout = two_pane_layout("right");
+        layout.tabs[0].focus_id = 1;
+        // No `enable_opencode_mouse` — neither pane wants mouse.
+
+        let click = down_left_at(15, 5);
+        assert!(
+            super::pane_for_mouse_forward(&layout, &click).is_none(),
+            "test precondition: no pane wants mouse → forward returns None"
+        );
+
+        let mut state = MouseState::default();
+        let fleet_path = std::path::Path::new("/nonexistent/fleet.yaml");
+        super::handle(
+            click,
+            &mut layout,
+            &mut state,
+            fleet_path,
+            &empty_registry(),
+        );
+
+        assert_eq!(
+            layout.tabs[0].focus_id, 2,
+            "non-mouse pane body click must still update focus via \
+             handle_down → handle_selection (legacy path)"
+        );
+        assert_eq!(
+            layout.tabs[0].selecting_pane,
+            Some(2),
+            "handle_selection MUST cache selecting_pane on Down so drag \
+             continues against the same pane"
+        );
+    }
 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -50,6 +50,22 @@ pub(super) fn handle(
 ) -> MouseOutcome {
     let mut out = MouseOutcome::default();
 
+    // #901: pre-focus on Down(Left) BEFORE the forward decision below.
+    // Without this, a click on a mouse-forwarded pane's body (OpenCode
+    // and any future backend that enables SGR mouse) early-returns at
+    // the forward arm and never reaches `handle_down`/`handle_selection`,
+    // so `tab.focus_id` stays put — operator clicks pane body, focus
+    // doesn't move. Pre-focusing at the top is backend-agnostic and
+    // leaves the forward path itself untouched (Down still reaches the
+    // backend so OpenCode's internal buttons still work).
+    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+        if let Some((pane_id, _, _)) = pane_for_mouse_forward(layout, &mouse) {
+            if let Some(tab) = layout.active_tab_mut() {
+                tab.focus_id = pane_id;
+            }
+        }
+    }
+
     // #700 + #783: If a pane's terminal wants mouse events AND shift is not
     // held, forward the event as SGR mouse report to the PTY instead of local
     // handling. The routing decision lives in `pane_for_mouse_forward` so it


### PR DESCRIPTION
## Summary

Operator-visible bug: clicking the body of an OpenCode pane doesn't focus it; only clicking the pane title bar works. Other backends behave normally because none of them enable SGR mouse mode.

Root cause is in `src/app/mouse.rs::handle()` — the forward arm (lines 62-67) early-returns after writing SGR bytes to the backend PTY, so the downstream `match mouse.kind` block (which calls `handle_down` → `handle_selection`, the only sites that mutate `tab.focus_id`) never runs for clicks on mouse-forwarded panes.

Fix is **Option D** per the #901 analysis spike (operator-approved): a single top-level `if matches!(mouse.kind, Down(Left))` block at the start of `handle` that pre-focuses the pane under the cursor before the forward decision. `pane_for_mouse_forward` signature stays unchanged, `handle_down` is untouched, no backend-specific branch.

## Commits (test-first per §3.10)

1. `f20baa0` **test(#901):** RED for the OpenCode focus contract + regression-guard for the non-mouse legacy `handle_selection` path. Both `#[serial]` + `ScopedHome` to keep the `notification_queue::record_input_activity` metadata write off the real `~/.agend`.
2. `20912ad` **fix(#901):** 16-line top-level pre-focus block.

## RED → GREEN verification

```
git checkout f20baa0
cargo test --bin agend-terminal mouse::tests::pane_body_down
# → 1 RED (forwarded), 1 GREEN (legacy path regression-guard)

git checkout 20912ad
cargo test --bin agend-terminal mouse::tests::pane_body_down
# → 2 GREEN
```

## Test plan
- [x] `cargo test --bin agend-terminal mouse::` — 18/18 (16 existing + 2 new) all pass at HEAD
- [x] Full binary suite: 2390/2390 pass at HEAD (7 ignored, unchanged)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [ ] CI 5/5 (macos / ubuntu / windows / audit / LOC overrun) pending
- [ ] Reviewer §3.10 RED→GREEN walk + verify regression invariants preserved

## Invariants preserved

- Title-bar click still focuses (handle_down's `title_hit` branch untouched)
- Drag selection on non-mouse backends unchanged (handle_selection untouched)
- Down(Left) still reaches OpenCode's PTY for internal buttons / menus (forward arm L62-67 untouched, runs immediately after pre-focus)
- Non-mouse-pane Down still drives focus via `handle_down → handle_selection` (pinned by `pane_body_down_on_non_mouse_pane_still_updates_focus_via_local_path`)

## Out of scope (per dispatch)
- Removing the L62-67 forward early-return
- Changing `pane_for_mouse_forward` signature
- Touching `handle_selection`'s `selecting_pane`
- Any backend-specific special case

🤖 Generated with [Claude Code](https://claude.com/claude-code)