### PR TITLE
Fix #900: propagate env from SPAWN params + fleet.yaml to spawned process

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -676,4 +676,185 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ----- #900: env propagation through SPAWN RPC + fleet.yaml -----
+
+    /// Build a test `HandlerCtx` with an isolated home dir + empty
+    /// registries. Unlike `test_ctx_with_agent`, no pre-existing agent
+    /// is spawned — these env tests spawn the agent under test directly
+    /// so the registry is clean.
+    #[cfg(unix)]
+    fn env_test_ctx(test_name: &str) -> (HandlerCtx<'static>, std::path::PathBuf) {
+        let home =
+            std::env::temp_dir().join(format!("agend-900-{}-{}", test_name, std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).expect("create home");
+
+        let registry: &'static agent::AgentRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let configs: &'static crate::api::ConfigRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let externals: &'static agent::ExternalRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let home_ref: &'static std::path::Path = Box::leak(home.clone().into_boxed_path());
+
+        let ctx = HandlerCtx {
+            registry,
+            configs,
+            externals,
+            notifier: None,
+            home: home_ref,
+        };
+        (ctx, home)
+    }
+
+    /// Write a tiny shell script that captures `$VAR_NAME` to `sentinel_path`
+    /// then sleeps so the agent stays alive long enough for cleanup_agent
+    /// to reap it. Returns the script path to pass as the agent's args.
+    #[cfg(unix)]
+    fn write_env_capture_script(
+        home: &std::path::Path,
+        var_name: &str,
+        sentinel_path: &std::path::Path,
+    ) -> std::path::PathBuf {
+        let script = home.join("env-capture.sh");
+        let body = format!(
+            "#!/bin/sh\nprintf '%s' \"${{{var}:-__UNSET__}}\" > '{sentinel}'\nsleep 30\n",
+            var = var_name,
+            sentinel = sentinel_path.display()
+        );
+        std::fs::write(&script, body).expect("write script");
+        script
+    }
+
+    /// Poll for the sentinel file to appear, then return its contents.
+    /// Returns `None` on timeout. Sentinel always materializes once the
+    /// shell launches (script writes unconditionally), so a `None` here
+    /// means the agent itself never ran.
+    #[cfg(unix)]
+    fn await_sentinel(sentinel_path: &std::path::Path) -> Option<String> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if sentinel_path.exists() {
+                if let Ok(c) = std::fs::read_to_string(sentinel_path) {
+                    return Some(c);
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        None
+    }
+
+    /// #900 ingress 1 — `handle_spawn` MUST extract `env` from `params`
+    /// and propagate it down `spawn_one` → `spawn_agent` → `build_command`
+    /// so the child process inherits the requested env vars. Pre-fix
+    /// `spawn_one` hard-codes `env: None` so any caller-supplied env
+    /// is silently dropped; this is the SPAWN-RPC half of the bug.
+    #[cfg(unix)]
+    #[test]
+    fn handle_spawn_propagates_params_env_to_spawned_process() {
+        let (ctx, home) = env_test_ctx("handle-spawn-params");
+        let sentinel = home.join("sentinel.txt");
+        let script = write_env_capture_script(&home, "MY_SPIKE_900_PARAMS_VAR", &sentinel);
+
+        let result = handle_spawn(
+            &json!({
+                "name": "env-params-test",
+                "backend": "/bin/sh",
+                "args": script.display().to_string(),
+                "env": {"MY_SPIKE_900_PARAMS_VAR": "value-from-params"},
+            }),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true, "spawn must succeed: {result}");
+
+        let actual = await_sentinel(&sentinel);
+        cleanup_agent(&ctx, "env-params-test");
+        let _ = std::fs::remove_dir_all(&home);
+
+        assert_eq!(
+            actual.as_deref(),
+            Some("value-from-params"),
+            "params.env MUST propagate to the child process; the legacy \
+             behavior silently dropped it, leaving the var unset"
+        );
+    }
+
+    /// #900 ingress 2 — when SPAWN params omit `env`, `handle_spawn`
+    /// MUST fall back to `fleet.yaml`'s resolved env for the named
+    /// instance. This is the path that `deploy_template` (Phase 3
+    /// writes fleet entry, then issues SPAWN without env in the wire
+    /// payload) and operator-typed fleet.yaml entries both rely on.
+    #[cfg(unix)]
+    #[test]
+    fn handle_spawn_falls_back_to_fleet_yaml_env_when_params_missing() {
+        let (ctx, home) = env_test_ctx("handle-spawn-fleet-fallback");
+        let sentinel = home.join("sentinel.txt");
+        let script = write_env_capture_script(&home, "MY_SPIKE_900_FLEET_VAR", &sentinel);
+
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  env-fleet-test:\n    backend: shell\n    env:\n      MY_SPIKE_900_FLEET_VAR: value-from-fleet\n",
+        )
+        .expect("write fleet.yaml");
+
+        let result = handle_spawn(
+            &json!({
+                "name": "env-fleet-test",
+                "backend": "/bin/sh",
+                "args": script.display().to_string(),
+                // No "env" field — handler must resolve from fleet.yaml.
+            }),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true, "spawn must succeed: {result}");
+
+        let actual = await_sentinel(&sentinel);
+        cleanup_agent(&ctx, "env-fleet-test");
+        let _ = std::fs::remove_dir_all(&home);
+
+        assert_eq!(
+            actual.as_deref(),
+            Some("value-from-fleet"),
+            "fleet.yaml env MUST propagate when SPAWN params omit env"
+        );
+    }
+
+    /// #900 precedence — params.env wins over fleet.yaml env. Operators
+    /// that pass an explicit `env` in their SPAWN call must always see
+    /// it honoured over whatever's in fleet.yaml for the same key.
+    #[cfg(unix)]
+    #[test]
+    fn handle_spawn_params_env_overrides_fleet_yaml_env() {
+        let (ctx, home) = env_test_ctx("handle-spawn-precedence");
+        let sentinel = home.join("sentinel.txt");
+        let script = write_env_capture_script(&home, "MY_SPIKE_900_PREC_VAR", &sentinel);
+
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  env-precedence-test:\n    backend: shell\n    env:\n      MY_SPIKE_900_PREC_VAR: from-fleet\n",
+        )
+        .expect("write fleet.yaml");
+
+        let result = handle_spawn(
+            &json!({
+                "name": "env-precedence-test",
+                "backend": "/bin/sh",
+                "args": script.display().to_string(),
+                "env": {"MY_SPIKE_900_PREC_VAR": "from-params-wins"},
+            }),
+            &ctx,
+        );
+        assert_eq!(result["ok"], true, "spawn must succeed: {result}");
+
+        let actual = await_sentinel(&sentinel);
+        cleanup_agent(&ctx, "env-precedence-test");
+        let _ = std::fs::remove_dir_all(&home);
+
+        assert_eq!(
+            actual.as_deref(),
+            Some("from-params-wins"),
+            "params.env MUST take precedence over fleet.yaml env for the same key"
+        );
+    }
 }

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -120,6 +120,21 @@ pub(crate) fn handle_delete(params: &Value, ctx: &HandlerCtx) -> Value {
     json!({"ok": true})
 }
 
+/// Parse the SPAWN-RPC `env` field into a `HashMap` of process env vars.
+/// Non-string values are dropped (the SPAWN schema accepts string-string
+/// only — this matches `agent::build_command`'s `cmd.env(k, v)` shape).
+/// `None` here is "no override" (caller will fall back to fleet); the
+/// caller distinguishes "no env field" from "explicit empty map" by
+/// checking the original `Value` shape if that semantic ever matters.
+fn parse_env_object(value: Option<&Value>) -> Option<std::collections::HashMap<String, String>> {
+    let obj = value?.as_object()?;
+    Some(
+        obj.iter()
+            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+            .collect(),
+    )
+}
+
 #[allow(clippy::too_many_lines)]
 pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
     let name = match params["name"].as_str() {
@@ -169,6 +184,22 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         .filter(|s| !s.is_empty());
     super::prepare_instructions(ctx.home, name, command, &work_dir, explicit_role);
 
+    // #900 hybrid (b)+(c): env precedence is params.env > fleet.yaml
+    // resolved env > none. `params.env` lets the SPAWN caller pass an
+    // explicit override (MCP start_instance forwards the already-resolved
+    // env from its own fleet load; future explicit-env spawners do too);
+    // the fleet fallback covers deploy_template Phase 3 + operator
+    // hand-edited fleet.yaml entries where the wire payload omits env.
+    let env_from_params = parse_env_object(params.get("env"));
+    let env_from_fleet = if env_from_params.is_none() {
+        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
+            .ok()
+            .and_then(|f| f.resolve_instance(name).map(|r| r.env))
+    } else {
+        None
+    };
+    let env_for_spawn = env_from_params.as_ref().or(env_from_fleet.as_ref());
+
     match crate::api::spawn_one(
         ctx.home,
         ctx.registry,
@@ -178,6 +209,7 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         spawn_mode,
         &work_dir,
         size,
+        env_for_spawn,
     ) {
         Ok(_spawn_mode) => {
             // Every API-level spawn gets a channel topic (no-op when
@@ -635,6 +667,7 @@ mod tests {
             crate::backend::SpawnMode::Fresh,
             &work_dir,
             size,
+            None,
         );
         assert!(result.is_ok(), "spawn_one must succeed: {result:?}");
 

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -129,6 +129,19 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
     let size = crossterm::terminal::size().unwrap_or((120, 40));
     for (inst_name, backend, work_dir) in &planned {
         super::prepare_instructions(ctx.home, inst_name, backend, work_dir, None);
+        // #900: resolve the just-written fleet.yaml entry so any
+        // operator-supplied `env:` (or `defaults.env`) reaches the
+        // spawned process. The entry is in fleet.yaml at this point
+        // (Phase 1 above wrote it), so resolve_instance returns the
+        // merged defaults+instance map. CREATE_TEAM-time team members
+        // currently have env: None at write-time (line 110), but
+        // operator hand-edits and downstream replace_instance flows
+        // can populate env on the entry between the write and this
+        // re-read — we honour whatever the disk says.
+        let resolved_env =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
+                .ok()
+                .and_then(|f| f.resolve_instance(inst_name).map(|r| r.env));
         match crate::api::spawn_one(
             ctx.home,
             ctx.registry,
@@ -138,6 +151,7 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
             crate::backend::SpawnMode::Fresh,
             work_dir,
             size,
+            resolved_env.as_ref(),
         ) {
             Ok(_) => {
                 tracing::info!(team = team_name, member = %inst_name, backend = %backend, "CREATE_TEAM spawn ok");

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -482,6 +482,14 @@ fn spawn_peer_pid_watcher(pid: u32, stream: std::net::TcpStream) {
 
 /// Spawn a single agent, register it, and start its TUI socket thread.
 /// Shared by the SPAWN and CREATE_TEAM API handlers.
+///
+/// `env` carries the resolved process env to apply on top of inherited
+/// vars (post sensitive-env deny-list filter; see
+/// `agent::is_sensitive_env_key`). Callers are expected to resolve from
+/// `params.env` or `FleetConfig::resolve_instance(name).env` BEFORE
+/// invoking — `spawn_one` is a pure data consumer here, not a re-resolver,
+/// so a single canonical resolve site at the handler boundary stays
+/// authoritative (#900 hybrid (b)+(c) design).
 #[allow(clippy::too_many_arguments)]
 fn spawn_one(
     home: &Path,
@@ -492,6 +500,7 @@ fn spawn_one(
     spawn_mode: crate::backend::SpawnMode,
     work_dir: &Path,
     size: (u16, u16),
+    env: Option<&std::collections::HashMap<String, String>>,
 ) -> anyhow::Result<crate::backend::SpawnMode> {
     std::fs::create_dir_all(work_dir).ok();
     // Sprint 34: clear stale metadata from a previous instance with the
@@ -515,7 +524,7 @@ fn spawn_one(
             spawn_mode,
             cols: size.0,
             rows: size.1,
-            env: None,
+            env,
             working_dir: Some(work_dir),
             submit_key: preset_submit_key,
             home: Some(home),

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -320,6 +320,15 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
                 params["args"] = serde_json::json!(args.join(" "));
             }
         }
+        // #900: forward the template's env directly so handle_spawn
+        // applies it without re-reading fleet.yaml for what we just
+        // wrote there. Skip empty maps so the fleet-fallback path in
+        // handle_spawn still wins for "no override" instances.
+        if let Some(ref env) = entry.env {
+            if !env.is_empty() {
+                params["env"] = serde_json::to_value(env).unwrap_or(serde_json::Value::Null);
+            }
+        }
         let _ = crate::api::call(
             home,
             &serde_json::json!({

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -169,12 +169,19 @@ pub(super) fn handle_start_instance(home: &Path, args: &Value) -> Value {
     match config.resolve_instance(name) {
         Some(resolved) => {
             let cmd_args = resolved.args.join(" ");
+            // #900: forward the resolved env explicitly so the daemon's
+            // SPAWN handler doesn't have to re-read fleet.yaml for what
+            // we already have in hand. params.env wins over the fleet
+            // fallback in handle_spawn, which keeps this RPC the
+            // single-source-of-truth for the instance start.
+            let env_json = serde_json::to_value(&resolved.env).unwrap_or(serde_json::Value::Null);
             match crate::api::call(
                 home,
                 &json!({"method": crate::api::method::SPAWN, "params": {
                     "name": name, "backend": resolved.backend_command, "args": cmd_args,
                     "mode": "resume",
                     "working_directory": resolved.working_directory.map(|p| p.display().to_string()),
+                    "env": env_json,
                 }}),
             ) {
                 Ok(resp) if resp["ok"].as_bool() == Some(true) => json!({"name": name}),
@@ -641,19 +648,38 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
         .get("backend")
         .and_then(|v| v.as_str())
         .map(String::from);
+    // #900: forward operator-supplied `env` through the SPAWN RPC AND
+    // record it on the fleet.yaml entry. The runtime payload lets the
+    // daemon's handle_spawn apply it directly (no second fleet.yaml
+    // read); the persisted entry covers replace_instance / restart
+    // flows that re-resolve from disk later. Non-string values are
+    // filtered out at the daemon side via `parse_env_object`.
+    let env_value: Option<Value> = args.get("env").filter(|v| v.is_object()).cloned();
+    let env_for_entry: Option<std::collections::HashMap<String, String>> =
+        env_value.as_ref().and_then(|v| {
+            v.as_object().map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
+        });
     let (layout, target_pane_owned) =
         resolve_team_layout(home, name, args.get("layout"), args.get("target_pane"));
     let target_pane = target_pane_owned.as_deref();
 
+    let mut spawn_params = json!({
+        "name": name, "backend": command, "args": &cmd_args,
+        "working_directory": work_dir,
+        "layout": layout, "spawner": instance_name,
+        "target_pane": target_pane,
+        "role": role,
+    });
+    if let Some(env) = env_value.as_ref() {
+        spawn_params["env"] = env.clone();
+    }
     match crate::api::call(
         home,
-        &json!({"method": crate::api::method::SPAWN, "params": {
-            "name": name, "backend": command, "args": &cmd_args,
-            "working_directory": work_dir,
-            "layout": layout, "spawner": instance_name,
-            "target_pane": target_pane,
-            "role": role,
-        }}),
+        &json!({"method": crate::api::method::SPAWN, "params": spawn_params}),
     ) {
         Ok(resp) if resp["ok"].as_bool() == Some(true) => {
             let entry = crate::fleet::InstanceYamlEntry {
@@ -678,7 +704,7 @@ fn spawn_single_instance(home: &Path, instance_name: &str, args: &Value) -> Valu
                 github_login: None,
                 args: None,
                 model: None,
-                env: None,
+                env: env_for_entry,
                 ready_pattern: None,
                 command: None,
                 worktree: None,


### PR DESCRIPTION
## Summary

`api::spawn_one` (`src/api/mod.rs:518`) hard-coded `env: None`, silently dropping every operator-provided env source for daemon-API spawns. The TUI direct-spawn path at `src/app/pane_factory.rs:332` already worked because it built `SpawnConfig` from a `ResolvedInstance::env`; this PR brings the API path to parity.

## Hybrid (b)+(c) design per #900 dialectic

- **(b)** `api::spawn_one` gains `env: Option<&HashMap<String, String>>`. spawn_one stays a pure data consumer — it never re-resolves from fleet.yaml. Callers carry that responsibility, keeping the canonical resolve site at the handler boundary (avoids "spawn_one re-read" anti-pattern + mid-spawn drift).
- **(c)** SPAWN-RPC schema gains an optional `env` field (string→string map). Backward compatible — existing callers that omit it fall through to fleet.yaml resolution.

## Precedence (documented in handle_spawn comment)

`params.env > FleetConfig::resolve_instance(name).env > none`

`params.env` lets explicit-env spawners (MCP start_instance / create_instance / deploy_template Phase 3) carry their resolved env across the wire; the fleet fallback covers operator hand-edited fleet.yaml entries that issue SPAWN without env in the wire payload.

## Ingress sites updated

| Caller | Path | Source of env |
|---|---|---|
| `handle_spawn` | api/handlers/instance.rs | params.env ⟶ fleet.resolve_instance(name).env |
| `handle_create_team` loop | api/handlers/team.rs | fleet.resolve_instance(member_name).env (just-written entry) |
| `start_instance` (MCP) | mcp/handlers/instance.rs | resolved.env → SPAWN params.env |
| `spawn_single_instance` (MCP create_instance) | mcp/handlers/instance.rs | args.env → SPAWN params.env AND persisted to fleet.yaml entry |
| `deploy_template` Phase 3 | deployments.rs | entry.env → SPAWN params.env |

## Commits (test-first per §3.10)

1. `44db76e` **test(#900):** 3 RED behavioral tests via `/bin/sh` sentinel-capture script (`${VAR:-__UNSET__}`).
2. `046f227` **fix(#900):** spawn_one sig change + handler-side resolve at the 5 ingress sites + parse_env_object helper.

## RED → GREEN verification

```
git checkout 44db76e
cargo test --bin agend-terminal handle_spawn_
# → 3 FAILED (sentinels read __UNSET__, env never propagated)

git checkout HEAD
cargo test --bin agend-terminal handle_spawn_
# → 3 ok
```

## Test plan
- [x] `cargo test --bin agend-terminal handle_spawn_` — 3/3 (the new contracts) GREEN at HEAD
- [x] `cargo test --bin agend-terminal` — full binary suite 2391/2391 pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [ ] CI 5/5 (macos / ubuntu / windows / audit / LOC overrun) pending
- [ ] Reviewer §3.10 RED→GREEN walk + verify precedence rule honoured

## Out of scope (per dispatch)

- No refactor of `handle_spawn`'s `defaults.backend` derivation — preserves existing `params.backend > fleet.defaults.backend > "claude"` chain.
- No fix for MCP `create_instance` "fleet entry written after SPAWN" ordering — separate issue. This PR still propagates `args.env` through the SPAWN RPC so env reaches the runtime path even before the fleet entry exists.
- No backend-specific behaviour; same path for every preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)