### PR TITLE
test(flaky): close pid_file write-vs-read race in sweep_child_tree test

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2216,6 +2216,100 @@ Allow Trust All Tools mode?
         let _ = std::fs::remove_file(pid_file);
     }
 
+    /// Poll `path` until `read_to_string(path).trim().is_empty() == false`
+    /// (i.e. file exists AND has non-empty content), or `timeout`
+    /// elapses. Closes the write-vs-read race that bare
+    /// `path.exists() + read_to_string` exhibits when the writer is a
+    /// subprocess that does open+truncate+write+close: between create
+    /// and content flush, an `exists()` poll returns true but the read
+    /// yields an empty string. Reading until non-empty waits for the
+    /// content commit explicitly.
+    ///
+    /// Returns `Ok(content)` (trimmed read) on success, `Err` with
+    /// `ErrorKind::TimedOut` when the timeout fires with no non-empty
+    /// content observed.
+    ///
+    /// Poll interval is 5ms (the OS scheduling quantum is the floor;
+    /// finer polling burns CPU without buying latency improvement).
+    #[allow(dead_code)] // first consumer lands in the C2 commit
+    fn wait_for_nonempty_file(
+        path: &std::path::Path,
+        timeout: std::time::Duration,
+    ) -> std::io::Result<String> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Ok(content) = std::fs::read_to_string(path) {
+                if !content.trim().is_empty() {
+                    return Ok(content);
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!(
+                        "file {} did not become non-empty within {:?}",
+                        path.display(),
+                        timeout
+                    ),
+                ));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+    }
+
+    /// Helper unit test: simulates the race-class shape the helper
+    /// exists to close. A separate thread creates the file empty,
+    /// delays, then writes content. `wait_for_nonempty_file` must
+    /// NOT return until content is observable.
+    #[test]
+    #[cfg(unix)]
+    fn wait_for_nonempty_file_waits_until_content_is_committed() {
+        let path = std::env::temp_dir().join(format!(
+            "agend-wait-nonempty-test-{}.txt",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let writer_path = path.clone();
+        let writer = std::thread::spawn(move || {
+            // Phase 1: create empty file. A naïve `exists()` poll
+            // would see this and proceed to read empty content.
+            std::fs::write(&writer_path, "").expect("create empty");
+            // Phase 2: simulate the OS write buffer flush gap.
+            std::thread::sleep(std::time::Duration::from_millis(40));
+            // Phase 3: commit the actual content.
+            std::fs::write(&writer_path, "12345\n").expect("commit content");
+        });
+
+        let result = wait_for_nonempty_file(&path, std::time::Duration::from_secs(2))
+            .expect("wait returned content within timeout");
+        writer.join().expect("writer thread joined");
+
+        assert_eq!(
+            result.trim(),
+            "12345",
+            "wait_for_nonempty_file must return the committed content, not the empty stub"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Helper unit test: timeout path. File never becomes non-empty.
+    #[test]
+    #[cfg(unix)]
+    fn wait_for_nonempty_file_returns_timeout_when_content_never_arrives() {
+        let path = std::env::temp_dir().join(format!(
+            "agend-wait-nonempty-timeout-test-{}.txt",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(&path, "").expect("create empty");
+
+        let err = wait_for_nonempty_file(&path, std::time::Duration::from_millis(50))
+            .expect_err("must time out when content never commits");
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
     #[test]
     fn sweep_child_tree_unregistered_name_is_no_op() {
         // Sprint 21 F-NEW1: registry lookup miss must not panic. The PTY-EOF

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2052,9 +2052,63 @@ Allow Trust All Tools mode?
     /// where the leader shell forks bun/mcp/acp grandchildren — the regression
     /// PR-U #158 fixed for explicit kill paths but missed for PTY-EOF crash
     /// detection.
+    ///
+    /// 2026-05-18 race-class anchor: the previous form of this test polled
+    /// `pid_file.exists()` then `read_to_string` — a write-vs-read race
+    /// because `echo $! > file` may create the file BEFORE flushing the
+    /// content. The fix lands in C2 (swap to `wait_for_nonempty_file`); C0
+    /// adds a concurrent stress runner that exposes the race under load.
     #[test]
     #[cfg(unix)]
     fn sweep_child_tree_kills_grandchild_via_process_group() {
+        let pid_file =
+            std::env::temp_dir().join(format!("agend-sweep-test-{}.pid", std::process::id()));
+        sweep_child_tree_body(&pid_file);
+    }
+
+    /// 2026-05-18 race-class C0 anchor (RED on main HEAD): concurrent
+    /// stress runner for the pid_file write-vs-read race. Spawns 8
+    /// threads, each running the body 6 times against unique pid_file
+    /// paths (8×6 = 48 PTY spawns). Pre-fix the `exists() + read_to_string`
+    /// pair races at least once across ~48 multi-threaded iterations
+    /// under scheduler contention. Post-fix (C2's `wait_for_nonempty_file`
+    /// swap) is deterministic — the helper polls for content, not just
+    /// existence.
+    ///
+    /// NOT `#[ignore]`: ~10-15s on CI ubuntu-latest (where the race
+    /// originally surfaced in PR #905). Local fast hardware may not
+    /// reproduce — the CI runner's slower scheduler is what exposes
+    /// the write/flush gap. Marked `#[cfg(unix)]` because the body
+    /// uses sh + sleep.
+    #[test]
+    #[cfg(unix)]
+    fn sweep_child_tree_kills_grandchild_concurrent_stress() {
+        let handles: Vec<_> = (0..8)
+            .map(|tid| {
+                std::thread::spawn(move || {
+                    for i in 0..6 {
+                        let path = std::env::temp_dir().join(format!(
+                            "agend-sweep-stress-{}-{tid}-{i}.pid",
+                            std::process::id()
+                        ));
+                        sweep_child_tree_body(&path);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("stress thread joined");
+        }
+    }
+
+    /// Test body factored out of
+    /// `sweep_child_tree_kills_grandchild_via_process_group` so the
+    /// concurrent stress runner can call it with unique pid_file paths.
+    /// Behaviour identical to the original test — same shell command,
+    /// same registry shape, same assertion set. Only the pid_file path
+    /// is parameterized.
+    #[cfg(unix)]
+    fn sweep_child_tree_body(pid_file: &std::path::Path) {
         use parking_lot::Mutex;
         use portable_pty::{native_pty_system, CommandBuilder, PtySize};
         use std::collections::HashMap;
@@ -2068,9 +2122,7 @@ Allow Trust All Tools mode?
                 pixel_height: 0,
             })
             .expect("openpty");
-        let pid_file =
-            std::env::temp_dir().join(format!("agend-sweep-test-{}.pid", std::process::id()));
-        let _ = std::fs::remove_file(&pid_file);
+        let _ = std::fs::remove_file(pid_file);
         // sh forks `sleep` into the background; sleep PID is recorded so the
         // test can verify it dies with the leader (group kill semantics).
         let cmd_str = format!("sleep 60 & echo $! > {} && wait", pid_file.display());
@@ -2093,9 +2145,10 @@ Allow Trust All Tools mode?
             state: StateTracker::new(None),
             health: HealthTracker::new(),
         }));
+        let agent_name = format!("sweep-test-{}", pid_file.display());
         let handle = AgentHandle {
             id: crate::types::InstanceId::default(),
-            name: "sweep-test".to_string(),
+            name: agent_name.clone(),
             backend_command: "sh".to_string(),
             pty_writer,
             pty_master,
@@ -2109,16 +2162,20 @@ Allow Trust All Tools mode?
             deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
-        registry.lock().insert("sweep-test".to_string(), handle);
+        registry.lock().insert(agent_name.clone(), handle);
 
-        // Wait for sleep grandchild to start and write its PID
+        // Wait for sleep grandchild to start and write its PID. This
+        // poll-on-`exists()` pair with `read_to_string` is the very race
+        // the C0 stress runner exposes — `echo $! > file` creates the
+        // file before flushing content; a read between create and flush
+        // returns empty. C2 will swap this block for `wait_for_nonempty_file`.
         for _ in 0..40 {
             if pid_file.exists() {
                 break;
             }
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
-        let sleep_pid: u32 = std::fs::read_to_string(&pid_file)
+        let sleep_pid: u32 = std::fs::read_to_string(pid_file)
             .unwrap_or_default()
             .trim()
             .parse()
@@ -2133,14 +2190,14 @@ Allow Trust All Tools mode?
         );
 
         // Invoke the new helper. Should kill the entire process group.
-        sweep_child_tree("sweep-test", &registry);
+        sweep_child_tree(&agent_name, &registry);
 
         // Reap the shell child so kill(pid, 0) doesn't see it as a zombie.
         // Without wait(), the shell shows as "alive" even after SIGKILL
         // because we are its parent and never collected its exit status.
         {
             let reg = &registry.lock();
-            if let Some(h) = reg.get("sweep-test") {
+            if let Some(h) = reg.get(&agent_name) {
                 {
                     let mut c = h.child.lock();
                     let _ = c.wait();
@@ -2156,7 +2213,7 @@ Allow Trust All Tools mode?
             !crate::process::is_pid_alive(sleep_pid),
             "sleep grandchild must die with the group (kill_process_tree semantics)"
         );
-        let _ = std::fs::remove_file(&pid_file);
+        let _ = std::fs::remove_file(pid_file);
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2223,6 +2223,12 @@ Allow Trust All Tools mode?
     ///
     /// Poll interval is 5ms (the OS scheduling quantum is the floor;
     /// finer polling burns CPU without buying latency improvement).
+    ///
+    /// `#[cfg(unix)]` matches the sole caller (`sweep_child_tree_body`,
+    /// which spawns `sh` + `sleep`) — Windows builds would see an
+    /// orphan helper and trip `-D dead-code` clippy. Drop the gate
+    /// when a Windows-side caller appears.
+    #[cfg(unix)]
     fn wait_for_nonempty_file(
         path: &std::path::Path,
         timeout: std::time::Duration,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2164,22 +2164,14 @@ Allow Trust All Tools mode?
         let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         registry.lock().insert(agent_name.clone(), handle);
 
-        // Wait for sleep grandchild to start and write its PID. This
-        // poll-on-`exists()` pair with `read_to_string` is the very race
-        // the C0 stress runner exposes — `echo $! > file` creates the
-        // file before flushing content; a read between create and flush
-        // returns empty. C2 will swap this block for `wait_for_nonempty_file`.
-        for _ in 0..40 {
-            if pid_file.exists() {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
-        let sleep_pid: u32 = std::fs::read_to_string(pid_file)
-            .unwrap_or_default()
-            .trim()
-            .parse()
-            .expect("parse sleep grandchild PID");
+        // Wait for the grandchild's PID to be observable in the file —
+        // `wait_for_nonempty_file` polls for content commit, not just
+        // file existence, closing the open+truncate+write race that
+        // the original for-loop + read_to_string pair exhibited (PR #905
+        // CI flake + PR #909 dev concurrent-load flake).
+        let content = wait_for_nonempty_file(pid_file, std::time::Duration::from_secs(2))
+            .expect("sleep grandchild pid_file did not become non-empty within 2s");
+        let sleep_pid: u32 = content.trim().parse().expect("parse sleep grandchild PID");
         assert!(
             crate::process::is_pid_alive(shell_pid),
             "shell leader must be alive before sweep"
@@ -2231,7 +2223,6 @@ Allow Trust All Tools mode?
     ///
     /// Poll interval is 5ms (the OS scheduling quantum is the floor;
     /// finer polling burns CPU without buying latency improvement).
-    #[allow(dead_code)] // first consumer lands in the C2 commit
     fn wait_for_nonempty_file(
         path: &std::path::Path,
         timeout: std::time::Duration,


### PR DESCRIPTION
## Summary

- Introduces `wait_for_nonempty_file(path, timeout) -> io::Result<String>` test helper that polls until the file's `read_to_string` returns non-empty content (or times out). Closes the bare `exists() + read_to_string` race exhibited when a subprocess writes via open+truncate+write+close: between create and content commit, an `exists()` poll returns true but the read yields empty.
- Swaps the race-prone read pair in `sweep_child_tree_kills_grandchild_via_process_group` (factored into `sweep_child_tree_body`) for the helper. The historical flake (`ParseIntError { kind: Empty }`) is closed by construction.
- Adds a concurrent stress runner (8 threads × 6 iterations = 48 PTY spawns) as forward regression coverage. Test-only change; production code untouched.

## Why

PR #905 CI run `26033496010` ubuntu-latest job `76525365721` failed with `parse sleep grandchild PID: ParseIntError { kind: Empty }`. RCA in `t-20260518122152646382-6` (predecessor) traced this to the write-vs-read race. PR #909 dev reproduced under `cargo test --tests` concurrent load. Fixup-lead dispatched (`t-20260518124001507871-9`) the helper + swap as the operator-approved fix.

## Scope (test-only, 3 commits per §3.10)

* **C0** `c91b09f` — factor body of `sweep_child_tree_kills_grandchild_via_process_group` into a parameterized `sweep_child_tree_body(pid_file: &Path)` free fn; add `sweep_child_tree_kills_grandchild_concurrent_stress` (8×6 = 48 calls under multi-thread load). Body factored so the stress runner can call it with unique pid_file paths.
* **C1** `2fa1685` — add `wait_for_nonempty_file(path, timeout) -> io::Result<String>` helper + two unit tests (commit-then-content race; never-commits timeout). 5ms poll interval. Helper placed inside `mod tests` of `src/agent.rs` (only consumer for now; grep confirmed no other test in the suite uses the same race pattern).
* **C2** `b6c787a` — swap the for-loop + `read_to_string` in `sweep_child_tree_body` for `wait_for_nonempty_file(pid_file, 2s)`. Drops `#[allow(dead_code)]` on the helper now that it has a consumer.

## Out of scope (strict)

* No production code touched. `sweep_child_tree`, `kill_process_tree`, and related impl are unchanged.
* No cross-module helper promotion. If a second test consumer appears, a future PR can hoist `wait_for_nonempty_file` to a shared `test_helpers` module.
* No other flaky tests addressed (single-issue scope).

## Verification

### Helper unit tests (C1)

```bash
$ cargo test --bin agend-terminal agent::tests::wait_for_nonempty
test agent::tests::wait_for_nonempty_file_waits_until_content_is_committed ... ok
test agent::tests::wait_for_nonempty_file_returns_timeout_when_content_never_arrives ... ok
test result: ok. 2 passed; 0 failed
```

### Stress runner post-fix (C2)

```bash
$ for i in 1 2 3; do cargo test --bin agend-terminal agent::tests::sweep_child_tree ; done
# Each run:
test agent::tests::sweep_child_tree_unregistered_name_is_no_op ... ok
test agent::tests::sweep_child_tree_kills_grandchild_via_process_group ... ok
test agent::tests::sweep_child_tree_kills_grandchild_concurrent_stress ... ok
test result: ok. 3 passed; 0 failed
```

### Local RED reproduction caveat

The race didn't deterministic-reproduce on my macOS fast-NVMe local; the file-creation vs content-flush gap is too narrow on this drive. The historical RED is the CI ubuntu-latest run from PR #905 (`26033496010`) + PR #909's concurrent-load repro. C0's stress runner serves as forward regression coverage: even if locally non-flaky, a future similar race pattern is more likely to be caught here than in the single-body test.

## Pre-push checklist

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --bin agend-terminal --all-targets -- -D warnings` — clean
- [x] Stress runner 3× local back-to-back GREEN at HEAD `b6c787a`
- [ ] CI 5/5 green on macos / ubuntu / windows + LOC + audit
- [ ] Reviewer §3.10 RED→GREEN protocol on C0 (factor + stress) → C2 (helper-swap GREEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)