### PR TITLE
fix(#872): remove dead WarnDirtyDetached variant + handler arm

### DIFF
--- a/src/bootstrap/canonical_hygiene.rs
+++ b/src/bootstrap/canonical_hygiene.rs
@@ -30,7 +30,7 @@
 //! reversible by definition — safer than letting reviewer pollution
 //! land with no recovery path. On stash failure (e.g. `.git/index.lock`
 //! held by another process, in-progress rebase/merge) the dispatch
-//! falls back to the `WarnDirtyDetached` warn log — no half-switch,
+//! falls back to `emit_dirty_detached_warning` — no half-switch,
 //! no mutation, operator's WIP preserved.
 
 /// The default branch the canonical-hygiene helper switches TO when
@@ -50,26 +50,13 @@ pub enum CanonicalAction {
     /// `git switch main` so subsequent operator commands land on the
     /// expected branch.
     SwitchToDefault,
-    /// HEAD is detached BUT the working tree has uncommitted changes.
-    /// Operator might be mid-bisect / mid-cherry-pick / have
-    /// legitimate WIP. Log a warning and leave alone.
-    ///
-    /// After #852 residual PR-C the decision table no longer routes
-    /// here — [`Self::StashAndSwitchToDefault`] handles dirty-detached
-    /// reversibly and its stash-failure fall-back calls into the
-    /// `WarnDirtyDetached` warn helper directly (via
-    /// `emit_dirty_detached_warning`) rather than reconstructing this
-    /// variant. The variant is retained for diagnostic / future
-    /// reactivation and tagged `#[allow(dead_code)]` accordingly.
-    #[allow(dead_code)]
-    WarnDirtyDetached,
     /// HEAD is detached AND the working tree is dirty: stash the WIP
     /// with a timestamped marker, switch to the default branch, and
     /// notify the operator about the stash ref so they can recover
     /// via `git stash pop`. Reversible by definition — safer than
     /// letting reviewer pollution land with no recovery path. On
-    /// stash failure, falls back to [`Self::WarnDirtyDetached`]
-    /// behaviour (warn log, no mutation).
+    /// stash failure, `apply_stash_and_switch` calls
+    /// `emit_dirty_detached_warning` directly (warn log, no mutation).
     StashAndSwitchToDefault,
 }
 
@@ -108,10 +95,9 @@ pub(crate) fn run_hygiene(config: &crate::fleet::FleetConfig) {
 /// [`decide_canonical_action`], and dispatches by variant: NoOp is
 /// silent, SwitchToDefault runs `git switch main` plus info log,
 /// StashAndSwitchToDefault attempts `git stash push -u` + `git switch
-/// main` + operator notify (on stash failure, falls back to
-/// WarnDirtyDetached's warn log), and WarnDirtyDetached is reached
-/// only as the stash-failure fall-back today (the decision table
-/// no longer routes there from clean inputs).
+/// main` + operator notify (on stash failure, calls
+/// `emit_dirty_detached_warning` directly — no half-switch, no
+/// mutation, operator's WIP preserved).
 ///
 /// Best-effort: subprocess failures log a debug line and return; the
 /// daemon boot continues regardless.
@@ -159,9 +145,6 @@ pub(crate) fn apply_to_canonical(canonical: &std::path::Path) {
                     );
                 }
             }
-        }
-        CanonicalAction::WarnDirtyDetached => {
-            emit_dirty_detached_warning(canonical);
         }
         CanonicalAction::StashAndSwitchToDefault => {
             apply_stash_and_switch(canonical);
@@ -230,10 +213,9 @@ fn apply_stash_and_switch(canonical: &std::path::Path) {
     }
 }
 
-/// Emit the dirty-detached warn log. Extracted so the
-/// `StashAndSwitchToDefault` fall-back can reuse the exact text the
-/// `WarnDirtyDetached` arm would emit, keeping operator-visible
-/// messaging consistent across the two reachable paths.
+/// Emit the dirty-detached warn log. Called by
+/// `apply_stash_and_switch` on stash failure when the detached HEAD
+/// + dirty tree state can't be auto-recovered.
 fn emit_dirty_detached_warning(canonical: &std::path::Path) {
     tracing::warn!(
         canonical = %canonical.display(),
@@ -427,13 +409,10 @@ mod tests {
     // ----------------------------------------------------------------
 
     /// PR-C contract: detached HEAD with dirty working tree must
-    /// resolve to [`CanonicalAction::StashAndSwitchToDefault`] (reversible
-    /// auto-recovery), not the obsolete `WarnDirtyDetached` (which
-    /// left the canonical permanently polluted for the operator).
-    ///
-    /// In C1 RED, [`decide_canonical_action`] still returns the old
-    /// `WarnDirtyDetached`, so this assertion fails. C2 GREEN updates
-    /// the decision table and this passes.
+    /// resolve to [`CanonicalAction::StashAndSwitchToDefault`] —
+    /// reversible auto-recovery via stash, with
+    /// `emit_dirty_detached_warning` as the warn-only fallback when
+    /// the stash itself fails.
     #[test]
     fn stash_and_switch_on_dirty_detached() {
         assert_eq!(

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -34,7 +34,7 @@
 //!   uncommitted changes (`git status --porcelain` non-empty), the
 //!   tracker **refuses** to release and emits a warn log — mirror of
 //!   the operator-WIP-protection philosophy from #852 PR-C's
-//!   `StashAndSwitchToDefault → WarnDirtyDetached` fall-back.
+//!   `StashAndSwitchToDefault → emit_dirty_detached_warning` fall-back.
 //!
 //! Manual `release_worktree` MCP still works; the auto-release is
 //! idempotent on an already-released binding.
@@ -79,8 +79,8 @@ pub(crate) enum ReleaseDecision {
     SkipNotBound,
     /// Binding present but worktree has uncommitted changes.
     /// **Operator WIP protection** — mirror of #852 PR-C's
-    /// `WarnDirtyDetached` fall-back; refuses to auto-release until
-    /// the operator commits / stashes / explicitly releases.
+    /// `emit_dirty_detached_warning` fall-back; refuses to auto-release
+    /// until the operator commits / stashes / explicitly releases.
     SkipDirtyWorktree,
 }
 


### PR DESCRIPTION
## Summary

- Pure dead-code deletion of the `CanonicalAction::WarnDirtyDetached` variant + its handler arm. Lead's investigation 2026-05-18 confirmed the variant has never been emitted (zero production daemon.log hits, decision table never routes to it, `apply_stash_and_switch` stash-failure fallback calls `emit_dirty_detached_warning` directly via fn call rather than through the variant).
- Updates 6 doc-comments across `canonical_hygiene.rs` + `auto_release.rs` that referenced the removed variant.
- `emit_dirty_detached_warning` fn retained — still called by the stash-failure fallback in production.

Closes #872

## Why

The variant carried `#[allow(dead_code)]` as a \"future reactivation\" reserve, but lead's investigation showed:
- The only producer `decide_canonical_action` returns `NoOp` / `SwitchToDefault` / `StashAndSwitchToDefault` — never `WarnDirtyDetached`.
- The stash-failure fallback (`apply_stash_and_switch`) calls `emit_dirty_detached_warning(canonical)` directly — NOT via re-classification to the variant.
- 848 MB production daemon.log has 0 hits for `canonical` / `stash` / `detached` / `drift` — operator setup hasn't even triggered the canonical_hygiene module.

The variant is therefore truly dead, not a deferred-reactivation reserve.

## Scope

* `src/bootstrap/canonical_hygiene.rs`:
  - Remove enum variant + its 10-line doc-comment + `#[allow(dead_code)]`.
  - Remove the handler match arm (`CanonicalAction::WarnDirtyDetached => emit_dirty_detached_warning(canonical)`).
  - Update module-level doc + `StashAndSwitchToDefault` variant doc + `apply_to_canonical` dispatch summary + `emit_dirty_detached_warning` fn doc + the `stash_and_switch_on_dirty_detached` test doc-comment to reflect that `emit_dirty_detached_warning` is reached via fn call only.
* `src/daemon/auto_release.rs`:
  - Two doc-comments that referenced `WarnDirtyDetached` as the philosophy mirror now point at `emit_dirty_detached_warning`.

Net diff: +16 / -37 LOC (mostly deletes; tests untouched).

## Out of scope

* No change to `decide_canonical_action` classification table.
* No change to `apply_stash_and_switch` fallback semantics.
* No change to operator-visible warning message text.
* `emit_dirty_detached_warning` fn retained verbatim.

## §3.10 strategy

Pure-deletion exemption per FLEET-DEV-PROTOCOL §3.10 exemption list. The variant + arm + comments deleted are pure code-removal with no behavior delta. Existing `canonical_hygiene::` test suite (6 tests including `stash_and_switch_on_dirty_detached`, `apply_to_canonical_falls_back_to_warn_on_stash_failure`) all pass post-deletion — they were already asserting against `StashAndSwitchToDefault`, never against `WarnDirtyDetached`.

A compile-fail RED for a pure-deletion is awkward (writing `let _ = CanonicalAction::WarnDirtyDetached;` as a test that compile-fails on main and passes on the branch is performative — the deletion itself is what we want; the assert adds noise). Exemption is the right shape.

## §3.6 docs+pure-deletion single-reviewer eligibility

- [x] Pure-deletion (no behaviour change).
- [x] Only `src/` LOC removal + doc-comment edits in same files.
- [x] Diff ≤ 50 LOC (+16 / -37 = 53 LOC, but 37 of those are pure deletes; net change to maintained code ≈ 16 LOC).
- [x] No new rule affecting mid-scope+ PRs.

Borderline on LOC count due to the deleted 10-line doc-comment block — flagging in case reviewer wants dual-review per strict reading. Lead's dispatch said single-reviewer applies.

## Pre-push checklist

- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --bin agend-terminal --all-targets -- -D warnings` clean.
- [x] `cargo test --bin agend-terminal canonical_hygiene::` 6/6 pass.
- [ ] CI 5/5 green on macos / ubuntu / windows + LOC + audit.
- [ ] Reviewer VERIFIED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)