### PR TITLE
fix(#911): compose_aware_inject dedup gate (A)+(B) hybrid

### DIFF
--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -3455,4 +3455,144 @@ mod tests {
             "[1 photo attached]"
         );
     }
+
+    // ── #911 dedup-gate anchor (C0 RED) ─────────────────────────────────
+    //
+    // Locks the (A)+(B) hybrid gate contract that C1 lands at
+    // `compose_aware_inject`. Pre-C1 the predicate fn doesn't exist:
+    // these tests compile-fail at C0 = §3.10 RED anchor. C1 introduces
+    // `should_suppress_911_reinject_with_ledger` + gate-wires and the
+    // tests flip GREEN.
+    //
+    // Test names track the synthesis spec verbatim (lead-locked):
+    //   1. ledger-hit suppression
+    //   2. event-header pass-through
+    //   3. JSONL fallback on ledger MISS (closes H6 TTL eviction)
+    //   4. integration: enqueue → notify → drain → direct-inject → no PTY
+    //   5. predicate tightness: non-[AGEND-MSG] content with stray id=
+
+    #[test]
+    fn compose_aware_inject_suppressed_after_drain_for_same_msg_id_911() {
+        let home = tmp_home("911-ledger-hit");
+        let agent = "lead-911-ledger-hit";
+        let msg_id = "m-911-ledger-hit-UNIQ";
+
+        let ledger = crate::daemon::notification_dedup::Ledger::default();
+        ledger.record_inject(agent, msg_id);
+        ledger.mark_consumed(agent, msg_id);
+
+        let header = format!("[AGEND-MSG] from=test kind=task size=42 id={msg_id}");
+        let suppressed = should_suppress_911_reinject_with_ledger(&home, agent, &header, &ledger);
+
+        assert!(
+            suppressed,
+            "consumed ledger entry MUST suppress reinject (fast path B)"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn compose_aware_inject_event_header_not_gated_by_dedup_911() {
+        let home = tmp_home("911-event-pass");
+        let agent = "lead-911-event-pass";
+
+        let ledger = crate::daemon::notification_dedup::Ledger::default();
+        let event_header = format_event_header("interrupt", &[("reason", "operator stop")]);
+
+        let suppressed =
+            should_suppress_911_reinject_with_ledger(&home, agent, &event_header, &ledger);
+
+        assert!(
+            !suppressed,
+            "event headers (no id=) MUST NEVER be suppressed — not message-bound"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn compose_aware_inject_suppressed_via_jsonl_fallback_when_ledger_evicted_911() {
+        let home = tmp_home("911-jsonl-fallback");
+        let agent = "lead-911-jsonl-fallback";
+        let msg_id = "m-911-jsonl-fallback-UNIQ";
+
+        // Empty ledger — simulates H6 TTL eviction (entry was recorded
+        // + consumed 10+ min ago, sweep removed it).
+        let ledger = crate::daemon::notification_dedup::Ledger::default();
+
+        // Manually seed the inbox JSONL with a drained msg.
+        let mut msg = make_msg("dev-2", "fallback body");
+        msg.id = Some(msg_id.to_string());
+        msg.read_at = Some("2026-05-18T00:00:00Z".to_string());
+        enqueue(&home, agent, msg).unwrap();
+
+        let header = format!("[AGEND-MSG] from=dev-2 kind=task size=10 id={msg_id}");
+        let suppressed = should_suppress_911_reinject_with_ledger(&home, agent, &header, &ledger);
+
+        assert!(
+            suppressed,
+            "JSONL fallback MUST catch drained msg when ledger has no entry (closes H6 TTL race)"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn enqueue_notify_drain_then_direct_inject_no_pty_911() {
+        // Integration: real flow through enqueue + drain. The global
+        // ledger gets the `mark_consumed` callback as a side effect of
+        // `drain`. Unique agent + msg_id to avoid pollution from
+        // other tests running on the same process-singleton ledger.
+        let home = tmp_home("911-integration");
+        let agent = "lead-911-integration-UNIQ";
+        let msg_id = "m-911-integration-UNIQ";
+
+        let mut msg = make_msg("dev-2", "integration body");
+        msg.id = Some(msg_id.to_string());
+
+        enqueue(&home, agent, msg).unwrap();
+        crate::daemon::notification_dedup::global().record_inject(agent, msg_id);
+
+        let drained = drain(&home, agent);
+        assert_eq!(drained.len(), 1, "exactly one msg should drain");
+
+        let header = format_header(&drained[0]);
+
+        let suppressed = should_suppress_911_reinject_with_ledger(
+            &home,
+            agent,
+            &header,
+            crate::daemon::notification_dedup::global(),
+        );
+
+        assert!(
+            suppressed,
+            "after enqueue → record_inject → drain (which marks consumed in global ledger), \
+             a direct re-inject of the same msg's header MUST be suppressed"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn compose_aware_inject_non_agend_msg_header_pass_through_911() {
+        let home = tmp_home("911-predicate-tight");
+        let agent = "lead-911-predicate-tight";
+
+        let ledger = crate::daemon::notification_dedup::Ledger::default();
+
+        // Non-canonical prefix but contains literal `id=` substring.
+        // Could be free-form chat text quoting a msg_id. MUST NOT be gated.
+        let non_agend = "Some chat message that happens to contain id=m-fake-12345 inline.";
+
+        let suppressed = should_suppress_911_reinject_with_ledger(&home, agent, non_agend, &ledger);
+
+        assert!(
+            !suppressed,
+            "non-[AGEND-MSG] content MUST pass through gate even with stray id= substring"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -1102,9 +1102,106 @@ pub fn notify_agent_with_attachments(
 /// the pre-#81 behavior of actually delivering Telegram / notify_agent
 /// traffic to backends that don't poll inbox on their own.
 pub fn compose_aware_inject(home: &Path, agent_name: &str, notification: &str) {
+    // #911 dedup gate: (A)+(B) hybrid against the canonical
+    // `[AGEND-MSG]` header. Returns early when the msg was already
+    // consumed by the recipient — closes the operator-observable
+    // "header arrives after inbox drain" symptom.
+    //
+    // Mitigation-first: this is symptom containment + observability,
+    // not root-cause attribution. The producer paths that fire stale
+    // notify_agent calls are not (yet) identified; daemon-side log
+    // instrumentation is filed as a separate follow-up.
+    if should_suppress_911_reinject_with_ledger(
+        home,
+        agent_name,
+        notification,
+        crate::daemon::notification_dedup::global(),
+    ) {
+        return;
+    }
     let _ = route_notification(home, agent_name, notification, |msg| {
         inject_with_submit(home, agent_name, msg)
     });
+}
+
+/// #911 dedup gate predicate. Hybrid (A)+(B) suppression check for
+/// a candidate PTY notification:
+///
+/// - **Fast path (B)** — `notification_dedup` ledger. If the
+///   `(agent, msg_id)` entry exists AND is flagged consumed AND
+///   within the 10-min TTL, suppress.
+/// - **Fallback path (A)** — when the ledger has no entry (TTL
+///   evicted at 10 min OR never recorded), read the agent's inbox
+///   JSONL for `msg_id` and check `read_at`. If `Some(_)`, the msg
+///   was drained — suppress.
+///
+/// Returns `true` to suppress, `false` to allow inject through.
+///
+/// Scope predicate: only canonical `[AGEND-MSG]` headers with an
+/// `id=` token. Free-form text and event-style headers (no `id=`)
+/// always return `false` — they aren't message-bound.
+///
+/// The two-path design closes H6 (cross-audit `m-20260518162253458320-159`):
+/// stale re-injects > 10 min post-drain miss the ledger but still get
+/// caught by the JSONL source-of-truth.
+///
+/// Production callers (compose_aware_inject) pass
+/// `notification_dedup::global()`. Tests construct local
+/// `Ledger::default()` instances for isolation.
+pub(crate) fn should_suppress_911_reinject_with_ledger(
+    home: &Path,
+    agent_name: &str,
+    notification: &str,
+    ledger: &crate::daemon::notification_dedup::Ledger,
+) -> bool {
+    // Reviewer condition C: only canonical `HEADER_PREFIX` headers
+    // gate (the ANSI-wrapped `[AGEND-MSG]` produced by `format_header`
+    // and `format_event_header`). Stray `id=` in free-form chat
+    // content with no ANSI prefix must NOT trigger.
+    if !notification.starts_with(HEADER_PREFIX) {
+        return false;
+    }
+    let Some(msg_id) = crate::daemon::notification_dedup::extract_msg_id_from_header(notification)
+    else {
+        return false;
+    };
+    // Fast path (B): in-memory ledger.
+    if ledger.should_suppress_reinject(agent_name, &msg_id) {
+        tracing::info!(
+            agent = %agent_name,
+            msg_id = %msg_id,
+            "#911 compose_aware_inject suppressed: dedup ledger hit"
+        );
+        return true;
+    }
+    // Fallback (A): JSONL read_at source-of-truth.
+    if msg_already_drained_in_jsonl(home, agent_name, &msg_id) {
+        tracing::info!(
+            agent = %agent_name,
+            msg_id = %msg_id,
+            "#911 compose_aware_inject suppressed: JSONL fallback (ledger MISS, read_at set)"
+        );
+        return true;
+    }
+    false
+}
+
+/// Read the agent's inbox JSONL and return `true` iff a message with
+/// the given `msg_id` exists AND has `read_at` set. Best-effort: any
+/// IO/parse error returns `false` so the caller defaults to allowing
+/// the inject through (better operator-visible spurious header than
+/// silently dropped legit retry).
+fn msg_already_drained_in_jsonl(home: &Path, agent_name: &str, msg_id: &str) -> bool {
+    let path = inbox_path(home, agent_name);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    content.lines().any(|line| {
+        let Ok(msg) = serde_json::from_str::<InboxMessage>(line) else {
+            return false;
+        };
+        msg.id.as_deref() == Some(msg_id) && msg.read_at.is_some()
+    })
 }
 
 /// Compose-aware message delivery with auto-submit: checks `is_composing`
@@ -3481,7 +3578,9 @@ mod tests {
         ledger.record_inject(agent, msg_id);
         ledger.mark_consumed(agent, msg_id);
 
-        let header = format!("[AGEND-MSG] from=test kind=task size=42 id={msg_id}");
+        // Canonical [AGEND-MSG] header includes the HEADER_PREFIX
+        // ANSI wrapping — match production's `format_header` output.
+        let header = format!("{HEADER_PREFIX} from=test id={msg_id} kind=task size=42");
         let suppressed = should_suppress_911_reinject_with_ledger(&home, agent, &header, &ledger);
 
         assert!(
@@ -3527,7 +3626,7 @@ mod tests {
         msg.read_at = Some("2026-05-18T00:00:00Z".to_string());
         enqueue(&home, agent, msg).unwrap();
 
-        let header = format!("[AGEND-MSG] from=dev-2 kind=task size=10 id={msg_id}");
+        let header = format!("{HEADER_PREFIX} from=dev-2 id={msg_id} kind=task size=10");
         let suppressed = should_suppress_911_reinject_with_ledger(&home, agent, &header, &ledger);
 
         assert!(


### PR DESCRIPTION
## Summary

- Adds an (A)+(B) hybrid suppression gate to `compose_aware_inject` (`src/inbox.rs:1104`) that closes the operator-observable \"`[AGEND-MSG]` header arrives after inbox drain\" symptom.
- Fast path (B) consults the `notification_dedup` ledger (existing #836 surface).
- Fallback (A) reads the inbox JSONL `read_at` field when the ledger has no entry — closes H6 (the 10-min TTL eviction race that lets stale re-injects slip past the ledger).
- 5 §3.10 tests: 4 unit + 1 integration. Test-first per C0 (RED via compile-fail on missing predicate fn) → C1 GREEN.

## Why

Operator and lead independently observed the desync at ~1-minute gap between header arrival and inbox drain — a logical mis-sequencing, not a sub-ms timing race. The existing #836 `notification_dedup` ledger only gates `supervisor::process_server_rate_limit_retries`; other PTY-inject paths (any caller flowing through `compose_aware_inject`) had no gate. This PR makes the gate site canonical at `compose_aware_inject`.

## Mitigation-first framing (REQUIRED per dispatch)

> **This PR is symptom containment + observability upgrade, not RCA closure.**

The producer paths that fire stale `notify_agent` / direct `compose_aware_inject` calls for already-drained messages are not identified by this PR. Root cause attribution remains open pending daemon-log instrumentation (separate follow-up if operator requests). Operator should observe ≥1 dialectic session post-merge with zero spurious headers for confidence.

## Investigated inject sites (pre-impl deep-dive per dispatch)

| Site | Header style | `id=`? | Gate covers? |
|---|---|---|---|
| `mcp/handlers/instance.rs:369` (`handle_interrupt`) | `format_event_header(\"interrupt\", ...)` | No | N/A — naturally out-of-scope (gate only fires on `id=` headers). Rules out dev's #911 spike H5 candidate. |
| `inbox.rs::notify_agent` initial inject | `format_header(msg)` | Yes | YES — gate fast-path (B). |
| `daemon::supervisor.rs::process_server_rate_limit_retries` | raw body, no header | N/A | Pre-existing ledger gate at the supervisor site retained. |
| `daemon::poll_reminder::poll_reminder_pass` | `format_event_header(\"poll-reminder\", ...)` | No | N/A — event-style. |
| `daemon::conflict_notify::*` | via `notify_agent`, has `id=` | Yes | YES — gate fast-path (B). |
| `daemon::supervisor.rs::member_state_change_notify` | via `notify_agent` | Yes | YES — gate fast-path (B). |
| `app/mod.rs::flush_idle_notifications` | re-injects from deferred queue | Mixed | YES — gate at `compose_aware_inject`. |

Net result: regardless of which specific producer is the root cause, the symptom is contained at the canonical `compose_aware_inject` site.

## Scope (changes)

* `src/inbox.rs`:
  - New `pub(crate) fn should_suppress_911_reinject_with_ledger(home, agent_name, notification, ledger) -> bool` — pure-fn predicate, takes a ledger reference so tests can pass `Ledger::default()` for isolation. Production callers pass `notification_dedup::global()`.
  - New `fn msg_already_drained_in_jsonl(home, agent_name, msg_id) -> bool` — best-effort JSONL scan; IO/parse errors return false (default to allow inject through).
  - `compose_aware_inject` adds gate check at entry — returns early when predicate fires; otherwise unchanged.
* Scope predicate (reviewer condition C): only `HEADER_PREFIX` (ANSI-wrapped `[AGEND-MSG]`) matches. Stray `id=` in free-form chat passes through. Event headers (no `id=`) pass through.

## Out of scope

- Event-header dedup (deferred — flag if operator-visible event spam surfaces).
- Producer-specific root-cause fix (separate investigation).
- Daemon log instrumentation patch (separate follow-up if operator wants empirical confirmation).

## Verification

### §3.10 RED→GREEN
```bash
# RED at 5dd0f99 (C0 alone):
$ cargo test --bin agend-terminal --no-run \
    inbox::tests::compose_aware_inject_suppressed_after_drain_for_same_msg_id_911
error[E0425]: cannot find function `should_suppress_911_reinject_with_ledger`
# (5 compile-fail errors across all 5 _911 tests)

# GREEN at b55ed1c:
$ cargo test --bin agend-terminal --no-fail-fast _911
test inbox::tests::compose_aware_inject_non_agend_msg_header_pass_through_911 ... ok
test inbox::tests::compose_aware_inject_event_header_not_gated_by_dedup_911 ... ok
test inbox::tests::compose_aware_inject_suppressed_after_drain_for_same_msg_id_911 ... ok
test inbox::tests::compose_aware_inject_suppressed_via_jsonl_fallback_when_ledger_evicted_911 ... ok
test inbox::tests::enqueue_notify_drain_then_direct_inject_no_pty_911 ... ok
test result: ok. 5 passed; 0 failed
```

Inbox suite regression check: 88/88 pass at HEAD.

### Pre-push gates
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin agend-terminal --all-targets -- -D warnings` clean
- [x] `cargo test --bin agend-terminal inbox::` 88/88 pass

### Post-merge observation criterion

Operator should run ≥1 dialectic session post-merge and observe zero spurious `[AGEND-MSG]` headers for already-drained messages. If any spurious header still appears, file a follow-up with the daemon log + msg_id so the producer site can be identified (the gate would catch ledger-tracked + JSONL-tracked drains; an escaping spurious header means the producer is hitting a path that bypasses both — separate fix).

## Test plan

- [x] All 5 §3.10 tests pass (4 unit + 1 integration).
- [x] Pre-push gates clean.
- [ ] CI 5/5 green on macos / ubuntu / windows + LOC + audit.
- [ ] Reviewer VERIFIED with §3.10 RED→GREEN protocol stated verbatim.
- [ ] Post-merge operator observation (see criterion above).

Closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)