### PR TITLE
feat(#910 PR1): list_agents_with_fallback foundation helper

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -51,6 +51,7 @@ pub fn list_live_agents(home: &Path) -> Option<HashSet<String>> {
 
 /// Source of truth for the most-recent agent list resolution: API
 /// or filesystem-glob fallback.
+#[allow(dead_code)] // PR1 of 4 foundation — consumed by PR2 caller migration
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AgentListMode {
     Live,
@@ -61,8 +62,10 @@ enum AgentListMode {
 /// instead of every single call. Important because some callers
 /// (e.g. `src/app/mod.rs:621` periodic sync) fire every 2 seconds —
 /// per-call logging would dump ~1800 lines/hr of redundant info.
+#[allow(dead_code)] // PR1 of 4 foundation
 static LAST_MODE: OnceLock<Mutex<Option<AgentListMode>>> = OnceLock::new();
 
+#[allow(dead_code)] // PR1 of 4 foundation
 fn note_mode_transition(new_mode: AgentListMode) {
     let lock = LAST_MODE.get_or_init(|| Mutex::new(None));
     let Ok(mut guard) = lock.lock() else {
@@ -85,7 +88,10 @@ fn note_mode_transition(new_mode: AgentListMode) {
             // First call in process lifetime. One-time info-level entry
             // so operators grepping daemon.log can confirm the helper
             // initialized + observe the initial mode.
-            tracing::info!(?mode, "#910 list_agents_with_fallback: initial mode resolved");
+            tracing::info!(
+                ?mode,
+                "#910 list_agents_with_fallback: initial mode resolved"
+            );
         }
         // Steady-state (Live → Live or Fallback → Fallback): no log.
         _ => {}
@@ -126,6 +132,7 @@ fn note_mode_transition(new_mode: AgentListMode) {
 ///
 /// #910 PR1: foundation helper, zero caller-site changes. PR2-4
 /// migrate the 5 existing `.port`-glob consume sites.
+#[allow(dead_code)] // PR1 of 4 foundation — consumed by PR2 caller migration
 pub fn list_agents_with_fallback(home: &Path) -> Vec<String> {
     let live = list_live_agents(home);
     list_agents_with_fallback_using(home, live)
@@ -135,6 +142,7 @@ pub fn list_agents_with_fallback(home: &Path) -> Vec<String> {
 /// `live` `Option<HashSet>` directly. Lets tests inject the
 /// daemon-registry result without spinning up an in-process API server.
 /// Production callers use the wrapper [`list_agents_with_fallback`].
+#[allow(dead_code)] // PR1 of 4 foundation
 pub(crate) fn list_agents_with_fallback_using(
     home: &Path,
     live: Option<HashSet<String>>,
@@ -182,8 +190,7 @@ mod tests {
     fn setup_run_dir(home: &Path) -> PathBuf {
         let run = home.join("run").join(pid_string());
         fs::create_dir_all(&run).expect("create run_dir");
-        fs::write(run.join(".daemon"), format!("{}:0", pid_string()))
-            .expect("write .daemon");
+        fs::write(run.join(".daemon"), format!("{}:0", pid_string())).expect("write .daemon");
         run
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -35,3 +35,170 @@ pub fn list_live_agents(home: &Path) -> Option<HashSet<String>> {
         })
     })
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// #910 PR1 of 4: list_agents_with_fallback foundation helper
+//
+// Per `/tmp/dialectic-910-synthesis.md` lead decision. Zero caller-site
+// changes in this PR; PR2-4 migrate the 5 existing .port-glob consume
+// sites (`src/app/session.rs:274`, `src/app/mod.rs:621`, `src/cli.rs:155`,
+// `src/main.rs:683`, `src/agent_ops.rs:339`) over to this helper in turn.
+// ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn tmp_home(suffix: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-runtime-910-{}-{}-{}",
+            std::process::id(),
+            suffix,
+            id
+        ));
+        fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn pid_string() -> String {
+        std::process::id().to_string()
+    }
+
+    fn setup_run_dir(home: &Path) -> PathBuf {
+        let run = home.join("run").join(pid_string());
+        fs::create_dir_all(&run).expect("create run_dir");
+        fs::write(run.join(".daemon"), format!("{}:0", pid_string()))
+            .expect("write .daemon");
+        run
+    }
+
+    fn write_port_file(run: &Path, name: &str) {
+        fs::write(run.join(format!("{name}.port")), "12345").expect("write .port");
+    }
+
+    /// PR1 RED 1: daemon reachable → registry truth; stale `.port` ghosts
+    /// MUST NOT surface in the result.
+    #[test]
+    fn list_agents_with_fallback_prefers_daemon_registry_when_reachable() {
+        let home = tmp_home("prefers-registry");
+        let run = setup_run_dir(&home);
+        write_port_file(&run, "ghost-1"); // stale glob entry — must NOT surface
+
+        let mut live: HashSet<String> = HashSet::new();
+        live.insert("live-1".to_string());
+        live.insert("live-2".to_string());
+
+        let result = list_agents_with_fallback_using(&home, Some(live));
+
+        assert_eq!(
+            result,
+            vec!["live-1".to_string(), "live-2".to_string()],
+            "registry is truth-of-record when API reachable (alphabetical sort)"
+        );
+        assert!(
+            !result.contains(&"ghost-1".to_string()),
+            "stale .port file MUST NOT surface when daemon registry is the truth-of-record"
+        );
+
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// PR1 RED 2: API unreachable → fallback to filesystem `.port` glob.
+    /// Preserves pre-Option-F UX (cli doctor / cli list still work briefly
+    /// during daemon restart windows).
+    #[test]
+    fn list_agents_with_fallback_falls_back_to_glob_when_daemon_offline() {
+        let home = tmp_home("fallback-glob");
+        let run = setup_run_dir(&home);
+        write_port_file(&run, "fallback-1");
+        write_port_file(&run, "fallback-2");
+
+        let result = list_agents_with_fallback_using(&home, None);
+
+        assert_eq!(
+            result.iter().cloned().collect::<HashSet<_>>(),
+            ["fallback-1", "fallback-2"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<HashSet<_>>(),
+            "daemon offline → .port glob is the fallback truth"
+        );
+
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// PR1 RED 3: no daemon AND no run_dir → empty `Vec`, NO panic.
+    /// Cold-boot pre-bootstrap state must degrade gracefully.
+    #[test]
+    fn list_agents_with_fallback_empty_when_no_daemon_no_run_dir() {
+        let home = tmp_home("empty-cold");
+        // No run/ subdir created — pre-bootstrap state.
+
+        let result = list_agents_with_fallback_using(&home, None);
+
+        assert!(
+            result.is_empty(),
+            "no daemon + no run dir → empty Vec (graceful degrade, no panic)"
+        );
+
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// PR1 RED 4: API truth wins even when empty. Registry empty
+    /// (post-daemon-boot, pre-auto-start window) → empty Vec, NOT a
+    /// fallback to stale `.port` ghosts.
+    #[test]
+    fn list_agents_with_fallback_returns_empty_when_daemon_alive_but_registry_empty() {
+        let home = tmp_home("alive-empty");
+        let run = setup_run_dir(&home);
+        write_port_file(&run, "ghost-stale"); // stale glob — must NOT surface
+
+        let result = list_agents_with_fallback_using(&home, Some(HashSet::new()));
+
+        assert!(
+            result.is_empty(),
+            "API truth empty wins over filesystem glob (Some(empty) != None)"
+        );
+        assert!(
+            !result.contains(&"ghost-stale".to_string()),
+            "empty registry must NOT fall through to stale .port ghosts"
+        );
+
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// PR1 RED 5: api.port file present but TCP listener refuses (e.g.
+    /// daemon crashed mid-cycle, stale api.port lingers). Production
+    /// `list_live_agents` returns None on connect-refused → helper falls
+    /// back. This test exercises the FULL production
+    /// `list_agents_with_fallback` (not the factored `_using` variant) to
+    /// lock the connect-refused → None → fallback chain end-to-end.
+    #[test]
+    fn list_agents_with_fallback_falls_back_when_api_port_present_but_listener_refused() {
+        let home = tmp_home("listener-refused");
+        let run = setup_run_dir(&home);
+        // Plant a stale api.port pointing at a port nothing is listening
+        // on. Port 9 (Discard) is one of the legacy unassigned-in-userland
+        // ports — unlikely to have a listener but well-defined behavior
+        // (connect-refused) on Unix.
+        fs::write(run.join("api.port"), "9").expect("write fake api.port");
+
+        let result = list_agents_with_fallback(&home);
+
+        // Behavioral assertion: no panic + empty Vec when there are no
+        // `.port` files for actual agents (only the stale api.port we
+        // planted, which list_agent_ports filters out).
+        assert!(
+            result.is_empty(),
+            "connection-refused → treated as offline → fallback fires → empty agents (only stale api.port present, which is filtered)"
+        );
+
+        fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,9 +4,13 @@
 //! fetch_live_agents` (#827), and `src/tasks.rs::fetch_live_agents`
 //! (#829). The fourth consumer arriving in `task action=health`
 //! (this PR) is the design-call threshold that justifies extraction.
+//!
+//! #910 PR1 (this PR) adds `list_agents_with_fallback`, the foundation
+//! helper that PR2-4 migrate the 5 `.port`-glob consume sites onto.
 
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 
 /// Fetch the daemon's live runtime agent registry via
 /// `api::call(LIST)`. Returns `Some(set)` on success (the set may
@@ -44,6 +48,111 @@ pub fn list_live_agents(home: &Path) -> Option<HashSet<String>> {
 // sites (`src/app/session.rs:274`, `src/app/mod.rs:621`, `src/cli.rs:155`,
 // `src/main.rs:683`, `src/agent_ops.rs:339`) over to this helper in turn.
 // ──────────────────────────────────────────────────────────────────────
+
+/// Source of truth for the most-recent agent list resolution: API
+/// or filesystem-glob fallback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AgentListMode {
+    Live,
+    Fallback,
+}
+
+/// Track the most-recent mode so we can log Live↔Fallback transitions
+/// instead of every single call. Important because some callers
+/// (e.g. `src/app/mod.rs:621` periodic sync) fire every 2 seconds —
+/// per-call logging would dump ~1800 lines/hr of redundant info.
+static LAST_MODE: OnceLock<Mutex<Option<AgentListMode>>> = OnceLock::new();
+
+fn note_mode_transition(new_mode: AgentListMode) {
+    let lock = LAST_MODE.get_or_init(|| Mutex::new(None));
+    let Ok(mut guard) = lock.lock() else {
+        return;
+    };
+    let prev = *guard;
+    *guard = Some(new_mode);
+    match (prev, new_mode) {
+        (Some(AgentListMode::Live), AgentListMode::Fallback) => {
+            tracing::info!(
+                "#910 list_agents_with_fallback: daemon offline → falling back to .port glob"
+            );
+        }
+        (Some(AgentListMode::Fallback), AgentListMode::Live) => {
+            tracing::info!(
+                "#910 list_agents_with_fallback: daemon reachable → registry is authoritative"
+            );
+        }
+        (None, mode) => {
+            // First call in process lifetime. One-time info-level entry
+            // so operators grepping daemon.log can confirm the helper
+            // initialized + observe the initial mode.
+            tracing::info!(?mode, "#910 list_agents_with_fallback: initial mode resolved");
+        }
+        // Steady-state (Live → Live or Fallback → Fallback): no log.
+        _ => {}
+    }
+}
+
+/// Resolve the live agent list with daemon-API-first + filesystem-glob
+/// fallback. **Use this in place of bare `ipc::list_agent_ports(run)`
+/// in operator-facing surfaces.** The daemon's in-memory registry is
+/// truth-of-record when reachable; the `.port` filesystem glob is the
+/// best-effort fallback when the API call fails (daemon offline /
+/// restarting / connect-refused).
+///
+/// Returns an alphabetically-sorted `Vec<String>`. Empty when neither
+/// path yields anything (no daemon AND no run dir, or daemon reachable
+/// but registry is empty).
+///
+/// **Why not just call `list_live_agents` directly?** Production CLI
+/// surfaces (`agend-terminal list`, `agend-terminal doctor`) historically
+/// scan `*.port` when the API is unresponsive — operators rely on that
+/// fallback during daemon restart windows. This helper preserves the
+/// behavior while making the daemon-registry path the default.
+///
+/// **Worst-case latency**: bounded by `api::call`'s connect attempt
+/// (~1s default Unix-socket timeout). When the daemon is offline,
+/// expect a predictable ~1s delay before fallback. Acceptable for the
+/// 2s app-sync cadence at `src/app/mod.rs:621` and one-shot CLI use
+/// cases; do NOT call from per-tick hot paths.
+///
+/// **Log cadence**: only Live↔Fallback transitions log at info level.
+/// Steady-state Live → Live (or Fallback → Fallback) calls are silent.
+///
+/// **State leak across tests**: the in-process `LAST_MODE` tracker is a
+/// `OnceLock<Mutex<Option<_>>>` singleton — tests that assert log
+/// content must run with `cargo test -- --test-threads=1` or accept
+/// log ordering uncertainty. The transition log is observability, not
+/// a tested contract; cf. tests in this module assert RESULT not LOG.
+///
+/// #910 PR1: foundation helper, zero caller-site changes. PR2-4
+/// migrate the 5 existing `.port`-glob consume sites.
+pub fn list_agents_with_fallback(home: &Path) -> Vec<String> {
+    let live = list_live_agents(home);
+    list_agents_with_fallback_using(home, live)
+}
+
+/// Factored variant of [`list_agents_with_fallback`] that accepts the
+/// `live` `Option<HashSet>` directly. Lets tests inject the
+/// daemon-registry result without spinning up an in-process API server.
+/// Production callers use the wrapper [`list_agents_with_fallback`].
+pub(crate) fn list_agents_with_fallback_using(
+    home: &Path,
+    live: Option<HashSet<String>>,
+) -> Vec<String> {
+    if let Some(live_set) = live {
+        note_mode_transition(AgentListMode::Live);
+        let mut v: Vec<String> = live_set.into_iter().collect();
+        v.sort();
+        return v;
+    }
+    note_mode_transition(AgentListMode::Fallback);
+    let Some(run) = crate::daemon::find_active_run_dir(home) else {
+        return Vec::new();
+    };
+    let mut v = crate::ipc::list_agent_ports(&run);
+    v.sort();
+    v
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

**PR1 of 4 per #910 dialectic synthesis.** Foundation helper only — zero caller-site changes in this PR.

- Adds `pub fn list_agents_with_fallback(home: &Path) -> Vec<String>` in `src/runtime.rs`. Daemon-API-first via `list_live_agents`; filesystem `.port`-glob fallback when API unreachable.
- Adds `pub(crate) fn list_agents_with_fallback_using(home, live)` factored variant for test ergonomics (avoids spinning up an in-process API server in unit tests).
- State-transition logging gate per dev cross-audit: only Live↔Fallback transitions log at info level. Steady-state silent — important because PR3 will wire this into the 2s app-sync site (`src/app/mod.rs:621`), where per-call logging would generate ~1800 log lines/hr.
- 5 §3.10 RED→GREEN tests (3 from initial spike + 2 reviewer/dev-2 cross-audit additions).

**This PR does NOT close #910.** PR2 ships first behavioral coverage (CLI sites). Issue stays open until PR4 lands.

## Why

5 caller sites in the codebase treat `run_dir/*.port` filesystem glob as truth-of-record for \"which agents are alive\" — but the daemon has an authoritative in-memory registry. Today's #896 (race) and #908 (sequencing) issues plus the #910 architectural concern are all rooted here. The 4-PR split lets the foundation land risk-free, with each consumer-side migration deferring to its own PR for bisect-friendly revert.

## Scope (changes)

* `src/runtime.rs`:
  - +1 enum `AgentListMode { Live, Fallback }` — internal state tracker for transition logging.
  - +1 `static LAST_MODE: OnceLock<Mutex<Option<AgentListMode>>>` — process-singleton transition state.
  - +1 `fn note_mode_transition(new_mode)` — logs initial mode + Live↔Fallback transitions only.
  - +1 `pub fn list_agents_with_fallback(home)` — production wrapper.
  - +1 `pub(crate) fn list_agents_with_fallback_using(home, live)` — factored test variant.
  - +5 `#[test]` cases at module bottom.

All 5 production-side symbols carry `#[allow(dead_code)] // PR1 of 4 foundation — consumed by PR2 caller migration` until PR2 wires the first caller in. The `#[allow]` documents the intent and is dropped in PR2.

Net diff: +169 / -0 LOC, single file.

## Out of scope (strict)

- No caller-site changes (PR2/PR3/PR4 scope per dispatch).
- No `.port` file removal (would need TUI bridge attach redesign — separate spike).
- No API call coalescing/caching (separate spike if profile-needed).
- No timeout tuning (deferred to operator UX feedback).

## §3.10 RED→GREEN

```bash
# RED at dc093dc (C0 alone):
$ cargo test --bin agend-terminal runtime::tests --no-run
error[E0425]: cannot find function `list_agents_with_fallback_using`
error[E0425]: cannot find function `list_agents_with_fallback`
# (5 compile-fail errors across all 5 tests)

# GREEN at 0e13596 (C1 + lint fixup):
$ cargo test --bin agend-terminal --no-fail-fast runtime::tests
test runtime::tests::list_agents_with_fallback_empty_when_no_daemon_no_run_dir ... ok
test runtime::tests::list_agents_with_fallback_returns_empty_when_daemon_alive_but_registry_empty ... ok
test runtime::tests::list_agents_with_fallback_prefers_daemon_registry_when_reachable ... ok
test runtime::tests::list_agents_with_fallback_falls_back_when_api_port_present_but_listener_refused ... ok
test runtime::tests::list_agents_with_fallback_falls_back_to_glob_when_daemon_offline ... ok
test result: ok. 5 passed; 0 failed
```

## Doc-comment latency note (reviewer condition C)

\"**Worst-case latency**: bounded by `api::call`'s connect attempt (~1s default Unix-socket timeout). When the daemon is offline, expect a predictable ~1s delay before fallback. Acceptable for the 2s app-sync cadence at `src/app/mod.rs:621` and one-shot CLI use cases; do NOT call from per-tick hot paths.\"

## Pre-push checklist

- [x] `cargo fmt --check` clean (caught fmt diff pre-push, applied via `cargo fmt`).
- [x] `cargo clippy --bin agend-terminal --all-targets -- -D warnings` clean (caught 5 dead-code errors pre-push, added `#[allow(dead_code)]` with PR-staging comment).
- [x] All 5 RED → GREEN tests pass.
- [ ] CI 5/5 green on macos / ubuntu / windows + LOC + audit.
- [ ] Reviewer VERIFIED with §3.10 RED→GREEN protocol stated verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)