### PR TITLE
docs(#910 PR4): cleanup audit + canonical-API doc note (Closes #910)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -54,7 +54,9 @@ agend-terminal inject <name> <text...>
 ```
 
 ### `list` / `ls` / `status`
-List running agents. Plain `list` reads run-dir port files directly (works even when the daemon API is briefly unresponsive). Pass `--detailed`/`-d` (or `--json`, which implies detailed) for state / health / backend info via the daemon API.
+List running agents. Plain `list` queries the daemon's in-memory registry via `runtime::list_agents_with_fallback`; when the daemon API is briefly unresponsive (e.g. mid-restart) it falls back to scanning run-dir `.port` files so the command still returns a best-effort answer. Pass `--detailed`/`-d` (or `--json`, which implies detailed) for state / health / backend info via the daemon API (no fallback — `--detailed` requires the daemon to be reachable).
+
+The daemon's in-memory registry is the canonical source of truth for "which agents exist"; the `.port` files are TUI-bridge per-agent socket artifacts and only surface in the offline fallback. Operator scripts wanting authoritative output should pipe `--json` rather than parse plain `list`.
 
 ```
 agend-terminal list [--detailed] [--json]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -693,7 +693,8 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // belongs to the app, NOT the daemon. Saving session.json in Attached
     // mode lets the next attached relaunch restore custom layout via the
     // same reconciliation path Owned mode uses (parameterized over agent
-    // source: fleet.yaml for Owned, `list_agent_ports` for Attached).
+    // source: fleet.yaml for Owned, `runtime::list_agents_with_fallback`
+    // for Attached — see #910 for the registry-truth migration).
     session::save_session(&home, &layout);
     if !attached_mode {
         // Sync fleet.yaml to match current state (Owned-only — daemon owns

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -5,8 +5,10 @@
 //! source depends on bootstrap mode:
 //!
 //! - **Owned**: agent registry = `fleet.yaml` instance names. Panes spawn local PTYs.
-//! - **Attached** (#895): agent registry = daemon's `list_agent_ports(run_dir)`.
-//!   Panes attach to daemon-owned PTYs via `create_remote_pane`.
+//! - **Attached** (#895 / #910): agent registry = daemon's in-memory registry
+//!   via `runtime::list_agents_with_fallback` (falls back to `.port` glob if
+//!   the API is briefly unresponsive). Panes attach to daemon-owned PTYs via
+//!   `create_remote_pane`.
 //!
 //! On restore we reconcile session against the active registry:
 //! - Agents in registry but missing from session → new tabs (Rule 3, team-grouped).
@@ -255,9 +257,10 @@ pub(super) fn restore_with_reconciliation(
     false
 }
 
-/// Restore with reconciliation (Attached mode, #895): daemon's `list_agent_ports`
-/// is source of truth for agents; session.json is a layout hint. Returns true
-/// if any tab was created.
+/// Restore with reconciliation (Attached mode, #895 / #910): daemon's
+/// in-memory registry via `runtime::list_agents_with_fallback` is source of
+/// truth for agents; session.json is a layout hint. Returns true if any tab
+/// was created.
 ///
 /// Mirrors `restore_with_reconciliation` (Owned) but uses `create_remote_pane`
 /// for pane construction. Shell panes from a session.json saved in Owned mode

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2111,6 +2111,15 @@ mod tests {
         // entries than the loop has produced (TUI threads race). Post-fix,
         // every iteration's port is on disk by the time the next iteration
         // begins, so list_agent_ports == iteration_count holds at each step.
+        //
+        // #910 PR4 note: post-#910 the app's canonical discovery path is
+        // `runtime::list_agents_with_fallback`, NOT bare
+        // `ipc::list_agent_ports`. This test still uses the bare fn
+        // intentionally — it locks the FILESYSTEM contract (the .port
+        // file is present synchronously after spawn returns), which is
+        // the worst-case fallback path the helper would expose when the
+        // daemon API is briefly unresponsive. Testing the bare fn here
+        // covers the helper's degraded mode by construction.
         let home = tmp_home("attach_during_stagger");
         let run_dir = setup_run_dir_with_cookie(&home);
         let (registry, configs, crash_tx, _crash_rx, shutdown) = make_test_registry();


### PR DESCRIPTION
## Summary

**PR4 of 4 (final) per #910 dialectic synthesis. Closes #910.**

Pure doc + comment cleanup. No production code behavior change.

- Audit `src/` + `tests/` for stale `list_agent_ports` doc-comment / inline-comment references and update to point at `runtime::list_agents_with_fallback`.
- `docs/CLI.md::list` operator-facing description updated to reflect daemon-registry-first + glob fallback semantics.
- `#896` stress test's intentional bare-fn usage flagged with PR4 rationale comment (testing the filesystem contract IS the helper's degraded fallback path).

Closes #910.

## Audit findings

| Site | Action | Why |
|---|---|---|
| `src/runtime.rs` (helper's own fallback path) | KEEP | Helper internally calls `list_agent_ports` as the worst-case fallback. Correct. |
| `src/ipc.rs::list_agent_ports` (fn def) | KEEP | The fallback primitive. Stays as-is. |
| `src/app/session.rs:8` (module doc) | UPDATED | Was \"`list_agent_ports(run_dir)`\" → now references helper + cites #910. |
| `src/app/session.rs:258` (fn doc) | UPDATED | Same rename. |
| `src/app/mod.rs:696` (inline comment) | UPDATED | Same rename. |
| `src/daemon/mod.rs:2105-2113` (#896 stress test) | EXPANDED COMMENT | Test intentionally uses bare fn to lock filesystem contract = helper's degraded mode. Comment now explains the rationale post-#910. |
| `tests/` directory | NO ACTION | Zero direct `.port` glob refs — clean. |
| `#[allow(dead_code)]` on helper symbols | NO ACTION | PR2 + PR3 already dropped. Verified via grep. |

## Doc updates

`docs/CLI.md::list` operator-facing rewrite:
- Pre-PR4: \"Plain `list` reads run-dir port files directly\".
- Post-PR4: explicit daemon-registry-first + glob-fallback flow; \"the daemon's in-memory registry is the canonical source of truth\" + warning that operator scripts should use `--json` for authoritative output.

## §3.10 disposition

Pure refactor + doc-only changes. Per FLEET-DEV-PROTOCOL §3.10 exemption list. RED→GREEN baseline match: full `cargo test` parity before/after (no behavior change).

## Verification

```bash
$ cargo fmt --check
# clean

$ cargo clippy --bin agend-terminal --all-targets -- -D warnings
# clean

$ cargo test --bin agend-terminal --no-fail-fast runtime::tests
test result: ok. 6 passed; 0 failed  # 5 PR1 + 1 PR3 lock-in

$ cargo test --bin agend-terminal --no-fail-fast app_attach_during_stagger
test result: ok. 1 passed; 0 failed  # #896 stress test still passes
```

## Deferred backlog (separate followups, NOT in this PR)

1. **Remove `.port` files entirely** — would require TUI bridge attach contract redesign (the per-agent socket port is currently the file contents). Separate spike.
2. **CLI \"fallback mode\" hint** — when `list` plain mode is in the fallback path, surface a visual hint (\"daemon offline — showing filesystem snapshot\"). Future UX issue.
3. **API call coalescing** — if the helper becomes hot-path-called from somewhere new, profile-driven optimization. Not needed today.
4. **Per-call timeout tuning** — if list-stall reports appear, drop from 1s default to 250ms with explicit fallback log. Operator UX driven, not premature.

## References

- PR1 foundation: PR #923 (merged 23c1547)
- PR2 CLI sites: PR #924 (merged c8e2809)
- PR3 app sites: PR #925 (merged 5d41b8d)
- Dialectic synthesis: \`/tmp/dialectic-910-synthesis.md\`
- Issue: #910

## Test plan

- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --bin agend-terminal --all-targets -- -D warnings` clean.
- [x] All relevant tests pass locally.
- [ ] CI 5/5 green.
- [ ] Reviewer VERIFIED.
- [ ] **§3.12 self-merge proceeds immediately on VERIFIED + CI green (no idle window — lesson from PR3).**

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)