### PR TITLE
Fix #922: write .ready sentinel after spawn loop + swap smoke poll target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,13 @@ jobs:
           "$BIN" start --agents "shell:$SHELL_CMD" > daemon.log 2>&1 &
           DAEMON_PID=$!
 
-          # Wait up to 30s for api.port to appear
+          # #922: poll for `.ready` instead of `api.port`. `api.port` is
+          # published BEFORE the agent spawn loop (#906 reorder), so
+          # external probers seeing it cannot assume the registry is
+          # populated. `.ready` is the daemon-init-complete signal —
+          # spawn loop done, agent count final. Wait up to 30s.
           for i in $(seq 1 60); do
-            if find "$AGEND_HOME/run" -name api.port 2>/dev/null | grep -q .; then
+            if find "$AGEND_HOME/run" -name .ready 2>/dev/null | grep -q .; then
               echo "daemon ready (iter $i)"
               break
             fi
@@ -131,9 +135,25 @@ jobs:
             sleep 0.5
           done
 
-          # List — must include the shell agent
-          "$BIN" list --json | tee list.out
-          grep -q '"shell"' list.out || { echo "shell agent missing from list"; exit 1; }
+          # List — must include the shell agent. Defense-in-depth retry
+          # budget (3× 100ms) in case `.ready` is observed slightly
+          # before the list IPC sees the final registry on a slow runner.
+          # The actual contract is `.ready ⟹ count is final`, so the
+          # retries should never fire in healthy CI — they are a safety
+          # net against future regressions of the daemon-side contract.
+          shell_visible=0
+          for attempt in 1 2 3; do
+            "$BIN" list --json | tee list.out
+            if grep -q '"shell"' list.out; then
+              shell_visible=1
+              break
+            fi
+            sleep 0.1
+          done
+          if [ "$shell_visible" -ne 1 ]; then
+            echo "shell agent missing from list after 3 retries"
+            exit 1
+          fi
 
           # Inject
           "$BIN" inject shell 'echo hi'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,75 @@ file (legacy unbounded) is renamed to `daemon.log.migration.<unix-epoch>`
 and the rolling appender takes over a fresh path. Migration is
 idempotent — re-running the old binary after the fix doesn't double-rotate.
 
+## Daemon lifecycle files (#922)
+
+A booted daemon publishes four files under `$AGEND_HOME/run/<pid>/`:
+
+| File | Written by | Purpose | Tier (#879v4 spike vocabulary) |
+|---|---|---|---|
+| `.daemon` | `bootstrap::prepare` early | PID identity for `find_active_run_dir` liveness checks | daemon-pid-published |
+| `api.cookie` | `auth_cookie::issue` after `.daemon` | 32-byte shared secret for cookie handshake on the daemon API socket | daemon-pid-published (auth-ready) |
+| `api.port` | `api::serve` thread after `bind_loopback` | TCP loopback port for the JSON control API | daemon-api-ready |
+| `.ready` | daemon main thread after agent spawn loop completes | Boot-completion signal: spawn loop done, agent count final for this boot | daemon-init-complete |
+
+`.ready` exists ⟹ the daemon's agent spawn loop has finished and
+`agend-terminal list` (or `/api/list`) will return the FINAL agent
+set for this boot. NOT a guarantee that `count == fleet.size` — the
+daemon's log-and-continue policy lets individual agents fail without
+aborting the loop, so final count may be less.
+
+**Lifecycle file single-signal policy** (per dev-2 catch in #922 dialectic):
+`.ready` is the SINGLE boot-completion signal. Future sub-stage signals
+MUST extend `.ready`'s content (JSON payload with per-subsystem ready
+flags) rather than introduce new files. The four-file table above is
+the entire surface — no fifth file.
+
+### Race-condition distinction
+
+Two timing races have been closed across recent PRs — they live on
+DIFFERENT surfaces:
+
+- **#908** closed the per-agent `.port`-file race: `spawn_and_register_agent`
+  now blocks until the per-agent TUI thread completes `bind_loopback` +
+  `write_port`. After the function returns, that agent's `.port` file
+  is on disk.
+- **#922** closes the API-level partial-results race: external probers
+  seeing `api.port` cannot assume the registry is populated, because
+  `api.port` is written by `api::serve` BEFORE the agent spawn loop
+  runs (per #906 reorder). `.ready` is the daemon-init-complete signal
+  external probers wait for.
+
+### Stale-marker safety
+
+A residual `.ready` from a crashed daemon's old `run/<pid>/` directory
+will still exist on disk until cleanup. Bare `until [ -f .ready ]`
+polling is INSUFFICIENT in crash-residue scenarios — it can return
+true for a stale marker. Operator-correct idioms that combine
+`.ready` with PID-liveness:
+
+```bash
+# Idiom A (recommended): use `agend-terminal doctor`
+until agend-terminal doctor 2>&1 | grep -q "Active agents:"; do sleep 0.1; done
+
+# Idiom B: glob `.ready` + verify the run_dir's `.daemon` PID is alive
+until for d in "$AGEND_HOME"/run/*/; do
+  [ -f "$d/.ready" ] && pid=$(cat "$d/.daemon" 2>/dev/null) && kill -0 "$pid" 2>/dev/null && exit 0
+done; do sleep 0.1; done
+```
+
+The CI smoke harness in `.github/workflows/ci.yml` polls `.ready`
+directly; it also checks `kill -0 $DAEMON_PID` each loop iteration
+(daemon-died gate), which gives equivalent liveness coverage to Idiom B
+because the smoke daemon's PID is captured at spawn time.
+
+### Interaction with `runtime::list_agents_with_fallback` (#910)
+
+`runtime::list_agents_with_fallback` (the canonical "enumerate live
+agents" helper that #910 PR1 introduced) does NOT wait for `.ready`.
+Callers that want a guarantee of complete enumeration should wait for
+`.ready` first; bare callers during the boot window may legitimately
+return a partial set as the spawn loop is in flight.
+
 ## Release
 
 Tags matching `v*` trigger `.github/workflows/release.yml`, which builds 5

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -502,6 +502,23 @@ fn run_core(
         }
     }
 
+    // #922: write `<run_dir>/.ready` to signal daemon-init-complete —
+    // the 4th lifecycle file alongside `.daemon` / `api.cookie` / `api.port`
+    // (see CLAUDE.md "Daemon lifecycle files"). Distinct from `api.port`
+    // existence: `api.port` appears at #906 reorder time (before the
+    // spawn loop), so external probers seeing it cannot assume the
+    // registry is populated. `.ready` is the load-bearing "spawn loop
+    // completed, agent count is final" signal — log-and-continue means
+    // count may be < fleet.size, but no further changes from THIS boot
+    // sequence. Single boot-completion signal per lead synth — future
+    // sub-stage signals extend `.ready`'s content (JSON payload), not
+    // add new files. Cleanup is automatic via `remove_dir_all(run_dir)`
+    // at shutdown (no new code path).
+    let ready_path = run_dir(home).join(".ready");
+    if let Err(e) = std::fs::write(&ready_path, chrono::Utc::now().to_rfc3339()) {
+        tracing::warn!(path = %ready_path.display(), error = %e, "failed to write .ready marker");
+    }
+
     // Shutdown wake channel — signal handler sends on this so the main loop's
     // select! wakes immediately instead of waiting up to 10s for the next tick.
     let (shutdown_tx, shutdown_rx) = crossbeam_channel::bounded::<()>(1);

--- a/tests/ready_marker_invariants.rs
+++ b/tests/ready_marker_invariants.rs
@@ -1,0 +1,297 @@
+//! #922 RED tests — `.ready` marker post-condition contract.
+//!
+//! Pins the load-bearing invariant:
+//!
+//!   `<run_dir>/.ready` exists ⟹ daemon's agent spawn loop has completed,
+//!   so the API registry's agent count is FINAL (no further changes from
+//!   this boot sequence; subsequent changes are operator-initiated via
+//!   spawn/kill/etc. RPC).
+//!
+//! Per the lead-synthed weakening: `.ready` does NOT promise `count == N`,
+//! because daemon's log-and-continue policy lets individual agent spawn
+//! errors NOT abort the loop (see src/daemon/mod.rs ~line 491). Test 2
+//! pins "count stable over 100 ms" rather than "count == N".
+//!
+//! Test 4 (N=10 stress) is non-gating — it documents the high-N case
+//! without enforcing it (slow CI runners may legitimately need more
+//! time per agent). It runs `#[cfg(unix)]` only and asserts only that
+//! `.ready` eventually exists, not the final count.
+//!
+//! RED on parent (no `.ready` write): tests 1-3 fail because polling
+//! `.ready` times out. GREEN after the daemon writes `.ready` post
+//! spawn-loop.
+
+#![allow(clippy::unwrap_used)]
+
+// All tests + helpers are `#[cfg(unix)]` because the harness drives
+// `/bin/sh` agents. Windows path is covered by the smoke harness
+// (`.github/workflows/ci.yml`) which exercises `cmd.exe` end-to-end.
+// Gating imports + helpers behind cfg(unix) so Windows clippy
+// doesn't flag them as dead.
+#[cfg(unix)]
+use serde_json::Value;
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::{Command, Stdio};
+#[cfg(unix)]
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+fn agend_binary() -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_BIN_EXE_agend-terminal"));
+    assert!(
+        path.exists(),
+        "agend-terminal binary missing — run `cargo build --bin agend-terminal` first"
+    );
+    path
+}
+
+#[cfg(unix)]
+fn tmp_home(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-922-{}-{}-{}",
+        tag,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Scan `<home>/run/*` for the first run-dir containing `.ready`.
+/// Returns `None` until the daemon writes the marker.
+#[cfg(unix)]
+fn find_ready(home: &Path) -> Option<PathBuf> {
+    let run_base = home.join("run");
+    let entries = std::fs::read_dir(&run_base).ok()?;
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() && p.join(".ready").exists() {
+            return Some(p.join(".ready"));
+        }
+    }
+    None
+}
+
+/// Poll for `.ready` until present or `deadline` elapses. Returns
+/// `true` iff observed before the deadline.
+#[cfg(unix)]
+fn wait_for_ready(home: &Path, deadline: Instant) -> bool {
+    while Instant::now() < deadline {
+        if find_ready(home).is_some() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    false
+}
+
+/// Subprocess `agend-terminal list --json` against `home`. Returns the
+/// parsed agent count, or `None` if the call failed or returned bad JSON.
+#[cfg(unix)]
+fn agent_count_via_list(bin: &Path, home: &Path) -> Option<usize> {
+    let out = Command::new(bin)
+        .arg("list")
+        .arg("--json")
+        .env("AGEND_HOME", home)
+        .env("AGEND_TEST_ISOLATION", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v: Value = serde_json::from_slice(&out.stdout).ok()?;
+    v["agents"].as_array().map(Vec::len)
+}
+
+/// Spawn an `agend-terminal start --foreground --agents …` daemon child
+/// with `stagger_ms` tight race window. Returns the spawned `Child`
+/// handle for the caller to teardown.
+#[cfg(unix)]
+fn spawn_daemon_with_agents(
+    bin: &Path,
+    home: &Path,
+    agents: &[&str],
+    stagger_ms: &str,
+) -> std::process::Child {
+    let mut cmd = Command::new(bin);
+    cmd.arg("start").arg("--foreground");
+    for a in agents {
+        cmd.args(["--agents", a]);
+    }
+    cmd.env("AGEND_HOME", home)
+        .env("AGEND_SPAWN_STAGGER_MS", stagger_ms)
+        .env("AGEND_TEST_ISOLATION", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn daemon")
+}
+
+/// #922 contract test (baseline N=3 with stagger=0 for tight race):
+/// after `.ready` is observed, `agend-terminal list` returns all 3
+/// agents. On parent (no `.ready` write), polling times out → assertion
+/// fails with the "didn't observe .ready" branch.
+#[cfg(unix)]
+#[test]
+fn ready_marker_implies_all_agents_registered_n3() {
+    let bin = agend_binary();
+    let home = tmp_home("ready-n3");
+
+    let mut child = spawn_daemon_with_agents(
+        &bin,
+        &home,
+        &["t1:/bin/sh", "t2:/bin/sh", "t3:/bin/sh"],
+        "0",
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(8);
+    let ready = wait_for_ready(&home, deadline);
+
+    let count_after_ready = if ready {
+        agent_count_via_list(&bin, &home)
+    } else {
+        None
+    };
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&home);
+
+    assert!(
+        ready,
+        "daemon must write <run_dir>/.ready after the agent spawn loop \
+         completes (#922). Polling timed out — no `.ready` file appeared \
+         within 8s of daemon start."
+    );
+    assert_eq!(
+        count_after_ready,
+        Some(3),
+        "after `.ready` is observed, registry must contain all 3 spawned \
+         shell agents — got {count_after_ready:?}"
+    );
+}
+
+/// #922 weakened-invariant test (lead synth refinement): `.ready` does
+/// NOT promise `count == N` (log-and-continue), but it DOES promise the
+/// count is FINAL for this boot sequence. Pin "count stable over 100 ms"
+/// rather than count-equality.
+#[cfg(unix)]
+#[test]
+fn ready_marker_implies_agent_count_is_final() {
+    let bin = agend_binary();
+    let home = tmp_home("ready-stable");
+
+    let mut child = spawn_daemon_with_agents(&bin, &home, &["a:/bin/sh", "b:/bin/sh"], "0");
+
+    let deadline = Instant::now() + Duration::from_secs(8);
+    let ready = wait_for_ready(&home, deadline);
+
+    let (first, second) = if ready {
+        let c1 = agent_count_via_list(&bin, &home);
+        std::thread::sleep(Duration::from_millis(100));
+        let c2 = agent_count_via_list(&bin, &home);
+        (c1, c2)
+    } else {
+        (None, None)
+    };
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&home);
+
+    assert!(ready, "daemon must write `.ready` within 8s of start");
+    assert_eq!(
+        first, second,
+        "after `.ready` is observed, agent count must be FINAL: sample at \
+         T+0 = {first:?}, sample at T+100ms = {second:?}. Differing samples \
+         mean spawn-loop work was still happening after `.ready` was \
+         written (contract violation)."
+    );
+    assert!(
+        first.is_some() && first.unwrap_or(0) > 0,
+        "stable count must be a real number (>0 since we spawned agents), \
+         got {first:?}"
+    );
+}
+
+/// #922 degenerate N=1 case (reviewer condition C): single-agent
+/// daemon must still write `.ready` and report 1 agent.
+#[cfg(unix)]
+#[test]
+fn ready_marker_n1_degenerate_case() {
+    let bin = agend_binary();
+    let home = tmp_home("ready-n1");
+
+    let mut child = spawn_daemon_with_agents(&bin, &home, &["solo:/bin/sh"], "0");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let ready = wait_for_ready(&home, deadline);
+    let count = if ready {
+        agent_count_via_list(&bin, &home)
+    } else {
+        None
+    };
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&home);
+
+    assert!(
+        ready,
+        "N=1 daemon must still write `.ready` after the single agent's \
+         spawn loop iteration"
+    );
+    assert_eq!(
+        count,
+        Some(1),
+        "after `.ready`, the single shell agent must be in registry, \
+         got {count:?}"
+    );
+}
+
+/// #922 N=10 stress (non-gating per lead synth): does NOT assert
+/// count == 10 (slow CI may legitimately miss agents under log-and-continue),
+/// only that `.ready` is eventually written. Provides empirical coverage
+/// for high-N boot behavior without fragile timing assertions.
+#[cfg(unix)]
+#[test]
+fn ready_marker_n10_stress_non_gating() {
+    let bin = agend_binary();
+    let home = tmp_home("ready-n10");
+
+    let agents: Vec<String> = (1..=10).map(|i| format!("s{i}:/bin/sh")).collect();
+    let agents_ref: Vec<&str> = agents.iter().map(String::as_str).collect();
+
+    let mut child = spawn_daemon_with_agents(&bin, &home, &agents_ref, "0");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let ready = wait_for_ready(&home, deadline);
+
+    let count = if ready {
+        agent_count_via_list(&bin, &home)
+    } else {
+        None
+    };
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&home);
+
+    assert!(
+        ready,
+        "high-N daemon (N=10) must still write `.ready` within the budget \
+         — `.ready` write is a single fs::write at end of spawn loop, \
+         independent of per-agent latency"
+    );
+    // Non-gating: just log observed count for empirical visibility.
+    // Log-and-continue means count could be < 10 if some agents failed.
+    eprintln!("ready_marker_n10_stress: observed agent count = {count:?}");
+}


### PR DESCRIPTION
## Summary

Closes the API-level partial-results race that bit #920 (Windows CLI smoke) and origin/main fd2ea188. `api.port` is published BEFORE the agent spawn loop (#906 reorder), so external probers seeing it cannot assume the registry is populated. `.ready` is the new load-bearing "spawn loop completed, agent count final" signal.

## Design (3-way dialectic synthesis, lead-decided)

- **Daemon side** (`src/daemon/mod.rs`): single `std::fs::write` of `<run_dir>/.ready` (RFC 3339 timestamp payload) immediately after the agent spawn loop completes. Failures log via `tracing::warn!` and continue startup.
- **Smoke harness** (`.github/workflows/ci.yml`): polls `.ready` instead of `api.port` + 3× 100ms retry budget on the `list` call (defense-in-depth, not workaround).
- **Cleanup**: reuses existing `remove_dir_all(run_dir)` at shutdown — no new code.

## Lifecycle file table (4 files per `run/<pid>/`)

| File | Purpose | Tier |
|---|---|---|
| `.daemon` | PID identity | daemon-pid-published |
| `api.cookie` | API auth handshake secret | daemon-pid-published |
| `api.port` | TCP loopback port | daemon-api-ready |
| **`.ready`** | spawn loop done, count final | **daemon-init-complete (NEW)** |

## Invariant (lead-synth weakening)

`.ready ⟹ spawn loop completed; agent count is FINAL`. NOT `count == fleet.size` — log-and-continue means individual agent failures don't abort. Test 2 (`ready_marker_implies_agent_count_is_final`) pins stability over 100ms rather than count-equality.

## Race-condition distinction (per dev-2 catch)

- **#908** closed the per-agent `.port`-file race: `spawn_and_register_agent` now blocks until per-agent TUI bind+write_port completes.
- **#922** (this PR) closes the API-level partial-results race: external probers waiting for `.ready` instead of `api.port`.

DIFFERENT races on DIFFERENT surfaces.

## Stale-marker safety (per reviewer condition B)

Crash-residue `.ready` files in old `run/<pid>/` directories remain on disk until cleanup. **Bare `until [ -f .ready ]` polling is INSUFFICIENT** in crash-residue scenarios. Operator-correct idioms (documented in CLAUDE.md):

```bash
# Recommended: use doctor
until agend-terminal doctor 2>&1 | grep -q "Active agents:"; do sleep 0.1; done

# Or: .ready + PID-alive check via .daemon
```

The CI smoke harness uses the second pattern implicitly (`kill -0 $DAEMON_PID` each loop iteration).

## Single-signal policy (per dev-2 catch)

`.ready` is the SINGLE boot-completion signal. Future sub-stage signals MUST extend `.ready`'s content (JSON payload with per-subsystem ready flags) rather than introduce new files. The 4-file table above is the entire surface.

## #910 interaction

`runtime::list_agents_with_fallback` callers wanting complete enumeration should wait for `.ready` first. Bare list during boot window may legitimately return partial. Documented in CLAUDE.md.

## Behavior preservation note (per reviewer condition C2)

Smoke polling target changed `api.port → .ready` — intentionally slower-but-correct readiness. Operator scripts polling `api.port` should switch to `.ready` (or use the `doctor` idiom). `api.port` is still written and remains the bridge's load-bearing contract.

## Commits (test-first §3.10)

1. `bd9d62a` **test(#922):** 4 RED tests covering the weakened invariant
2. `f0fc5fb` **fix(#922):** daemon `.ready` write + smoke poll swap + CLAUDE.md docs

## RED → GREEN verification

```
git checkout bd9d62a
cargo test --test ready_marker_invariants  # → 4 FAILED (all timeout)

git checkout f0fc5fb
cargo test --test ready_marker_invariants  # → 4 ok
```

## Tests (4)

- **N=3 baseline** — count == 3 after `.ready`
- **count stable over 100ms** — finality test per lead synth weakening
- **N=1 degenerate** — single-agent fleet still gets `.ready`
- **N=10 stress non-gating** — `.ready` independent of per-agent latency

## Out of scope

- Sub-stage readiness signals (deferred per single-signal policy)
- RCA on `.ready` write failures (would need new spike if observed in practice)
- Bridge / app discovery (#910 covers fleet discovery refactor)
- MCP event-log integration (filesystem signal, not event)

## Test plan
- [x] `cargo test --test ready_marker_invariants` — 4/4 GREEN
- [x] `cargo test --bin agend-terminal` — 2423/2423 (no regressions)
- [x] `cargo test --test integration` — 13/13
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin agend-terminal --tests -- -D warnings` clean
- [ ] CI 5/5 pending
- [ ] Reviewer §3.10 RED→GREEN walk + 4-test post-condition verification

Closes #922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)