### PR TITLE
fix(#947): dispatch_idle correlation_id falls back to dispatch_id — Closes #947

### DIFF
--- a/src/daemon/dispatch_idle/fixup_nudge.rs
+++ b/src/daemon/dispatch_idle/fixup_nudge.rs
@@ -120,7 +120,14 @@ fn emit_nudge(home: &Path, d: &PendingDispatch) -> bool {
         delivery_mode: Some("inbox_fallback".to_string()),
         task_id: d.correlation_id.clone(),
         force_meta: None,
-        correlation_id: d.correlation_id.clone(),
+        // #947: same fallback as emit_exceeded_event — see that site for
+        // design rationale (blend semantic acceptable due to `disp-`
+        // prefix convention).
+        correlation_id: Some(
+            d.correlation_id
+                .clone()
+                .unwrap_or_else(|| d.dispatch_id.clone()),
+        ),
         reviewed_head: None,
         attachments: Vec::new(),
         in_reply_to_msg_id: None,

--- a/src/daemon/dispatch_idle/fixup_nudge.rs
+++ b/src/daemon/dispatch_idle/fixup_nudge.rs
@@ -313,4 +313,100 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ── #947 fallback contract: fixup_nudge correlation_id ──
+    //
+    // Mirror of the `emit_exceeded_event` fallback semantic. When the
+    // upstream `send` omitted correlation_id, the fixup-watchdog nudge
+    // falls back to `d.dispatch_id`. See dispatch_idle/mod.rs #947 test
+    // block for the design rationale.
+
+    /// Helper to plant an exceeded sidecar with optional correlation_id
+    /// (the existing `write_exceeded_sidecar` always sets one — this
+    /// variant tests the absent case).
+    fn write_exceeded_sidecar_no_correlation(
+        home: &Path,
+        dispatcher: &str,
+        target: &str,
+        elapsed_secs: i64,
+    ) -> String {
+        let dir = pending_dir(home);
+        std::fs::create_dir_all(&dir).unwrap();
+        let id = "disp-test-947-no-corr".to_string();
+        let issued = (chrono::Utc::now() - chrono::Duration::seconds(elapsed_secs)).to_rfc3339();
+        let payload = PendingDispatch {
+            schema_version: 1,
+            dispatch_id: id.clone(),
+            dispatcher: dispatcher.to_string(),
+            target: target.to_string(),
+            correlation_id: None,
+            expected_kind: "task".to_string(),
+            threshold_secs: 600,
+            issued_at: issued,
+            status: "exceeded".to_string(),
+            nudge_sent_at: None,
+        };
+        std::fs::write(
+            pending_path(home, &id),
+            serde_json::to_string_pretty(&payload).unwrap(),
+        )
+        .unwrap();
+        id
+    }
+
+    /// #947 test 3 — fixup_nudge with upstream correlation_id preserves it.
+    #[test]
+    fn fixup_nudge_with_upstream_correlation_preserves_it() {
+        let home = tmp_home("947-fixup-upstream");
+        write_fleet_with_fixup_member(&home, "fixup-lead");
+        write_exceeded_sidecar(
+            &home,
+            "fixup-lead",
+            "fixup-reviewer",
+            "upstream-corr-xyz",
+            700,
+        );
+        scan_and_nudge(&home);
+        let inbox = crate::inbox::drain(&home, "fixup-reviewer");
+        let nudge = inbox
+            .iter()
+            .find(|m| m.kind.as_deref() == Some("dispatch_idle_nudge"))
+            .expect("fixup-watchdog must enqueue nudge");
+        assert_eq!(
+            nudge.correlation_id.as_deref(),
+            Some("upstream-corr-xyz"),
+            "fixup_nudge must preserve upstream correlation_id"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #947 test 4 — fixup_nudge without upstream falls back to dispatch_id.
+    #[test]
+    fn fixup_nudge_without_upstream_falls_back_to_dispatch_id() {
+        let home = tmp_home("947-fixup-fallback");
+        write_fleet_with_fixup_member(&home, "fixup-lead");
+        let dispatch_id =
+            write_exceeded_sidecar_no_correlation(&home, "fixup-lead", "fixup-reviewer", 700);
+        scan_and_nudge(&home);
+        let inbox = crate::inbox::drain(&home, "fixup-reviewer");
+        let nudge = inbox
+            .iter()
+            .find(|m| m.kind.as_deref() == Some("dispatch_idle_nudge"))
+            .expect("fixup-watchdog must enqueue nudge");
+        assert_eq!(
+            nudge.correlation_id.as_deref(),
+            Some(dispatch_id.as_str()),
+            "fixup_nudge must fall back to dispatch_id when upstream missing"
+        );
+        // dispatch_id format check: `disp-` prefix self-documents the value class.
+        assert!(
+            nudge
+                .correlation_id
+                .as_deref()
+                .unwrap_or("")
+                .starts_with("disp-"),
+            "dispatch_id fallback must carry `disp-` prefix"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -811,4 +811,129 @@ mod tests {
         assert!(j2.get("elapsed_secs").is_some());
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ── #947 fallback contract: dispatch_idle nudge's correlation_id ──
+    //
+    // Pre-#947 behavior: `emit_exceeded_event` cloned `d.correlation_id`
+    // verbatim. When the original `send` omitted correlation_id, the
+    // outbound nudge inherited `None` — operators couldn't backtrack
+    // from the nudge to the source sidecar.
+    //
+    // Post-#947: when upstream correlation_id is None, fall back to
+    // `d.dispatch_id` (format `disp-{ts}-{seq}`, self-documenting via
+    // the `disp-` prefix). The schema field is reused; no new field.
+    //
+    // The blend (upstream-chain vs producer-record) is acceptable because
+    // the prefix conventions (`disp-`, `t-`, `m-`) make value class
+    // identifiable at grep time. If a future producer breaks the prefix
+    // convention, file a follow-up to add `source_record_id: Option<String>`
+    // for clean separation (option A from /tmp/dialectic-947-dev-primary.md).
+
+    /// #947 test 1 — when upstream correlation_id is present, it is
+    /// preserved (NOT replaced with dispatch_id). The fallback applies
+    /// only when upstream is None.
+    #[test]
+    fn dispatch_idle_emit_with_upstream_correlation_preserves_it() {
+        let home = tmp_home("947-upstream-preserved");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+        write_pending_at(
+            &home,
+            "alpha",
+            "beta",
+            Some("upstream-corr-abc"),
+            "task",
+            600,
+            issued,
+        );
+        scan_and_emit(&home);
+        let inbox = crate::inbox::drain(&home, "alpha");
+        let nudge = inbox
+            .iter()
+            .find(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded"))
+            .expect("exceeded nudge must enqueue");
+        assert_eq!(
+            nudge.correlation_id.as_deref(),
+            Some("upstream-corr-abc"),
+            "upstream correlation_id must be preserved verbatim"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #947 test 2 — when upstream correlation_id is None, fall back to
+    /// `d.dispatch_id`. The nudge becomes traceable to its source sidecar.
+    #[test]
+    fn dispatch_idle_emit_without_upstream_falls_back_to_dispatch_id() {
+        let home = tmp_home("947-fallback-dispid");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+        let dispatch_id = write_pending_at(&home, "alpha", "beta", None, "task", 600, issued);
+        scan_and_emit(&home);
+        let inbox = crate::inbox::drain(&home, "alpha");
+        let nudge = inbox
+            .iter()
+            .find(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded"))
+            .expect("exceeded nudge must enqueue");
+        assert_eq!(
+            nudge.correlation_id.as_deref(),
+            Some(dispatch_id.as_str()),
+            "missing upstream correlation_id must fall back to dispatch_id"
+        );
+        // Format check: dispatch_id starts with `disp-` (self-documenting prefix).
+        assert!(
+            dispatch_id.starts_with("disp-"),
+            "dispatch_id format must use `disp-` prefix: {dispatch_id}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #947 test 5 (e2e) — after the fix, dispatch_idle nudges ALWAYS
+    /// carry a non-empty correlation_id, regardless of upstream presence.
+    /// This is the load-bearing operator contract for reverse-lookup.
+    #[test]
+    fn dispatch_idle_nudge_correlation_id_always_non_empty() {
+        let home = tmp_home("947-always-non-empty");
+        let now = chrono::Utc::now();
+        // Two pending dispatches: one with upstream, one without.
+        write_pending_at(
+            &home,
+            "alpha",
+            "beta",
+            Some("with-chain"),
+            "task",
+            600,
+            now - chrono::Duration::seconds(700),
+        );
+        write_pending_at(
+            &home,
+            "gamma",
+            "delta",
+            None,
+            "task",
+            600,
+            now - chrono::Duration::seconds(800),
+        );
+        scan_and_emit(&home);
+        let alpha_inbox = crate::inbox::drain(&home, "alpha");
+        let gamma_inbox = crate::inbox::drain(&home, "gamma");
+        for m in alpha_inbox
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded"))
+        {
+            let c = m.correlation_id.as_deref().unwrap_or("");
+            assert!(
+                !c.is_empty(),
+                "alpha nudge correlation_id must be non-empty: {m:?}"
+            );
+        }
+        for m in gamma_inbox
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded"))
+        {
+            let c = m.correlation_id.as_deref().unwrap_or("");
+            assert!(
+                !c.is_empty(),
+                "gamma nudge correlation_id must be non-empty (fallback): {m:?}"
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -311,7 +311,16 @@ fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
         delivery_mode: Some("inbox_fallback".to_string()),
         task_id: d.correlation_id.clone(),
         force_meta: None,
-        correlation_id: d.correlation_id.clone(),
+        // #947: fall back to dispatch_id when upstream correlation_id is
+        // None so the nudge is always traceable to its source sidecar.
+        // The `disp-{ts}-{seq}` prefix is self-documenting — operators
+        // can tell at grep time whether the value is an upstream chain
+        // or a producer record.
+        correlation_id: Some(
+            d.correlation_id
+                .clone()
+                .unwrap_or_else(|| d.dispatch_id.clone()),
+        ),
         reviewed_head: None,
         attachments: Vec::new(),
         in_reply_to_msg_id: None,


### PR DESCRIPTION
## Summary

Two `dispatch_idle` nudge enqueue sites previously cloned `d.correlation_id` verbatim. When the upstream `send` omitted correlation_id, the outbound nudge inherited `None` — operators couldn't backtrack from the nudge to the source sidecar.

Fix: at both sites, fall back to `d.dispatch_id` (format `disp-{ts}-{seq}`, self-documenting via the `disp-` prefix) when upstream correlation_id is absent. Reuses existing schema field; no schema bump.

Sites touched:
- `src/daemon/dispatch_idle/mod.rs:314` (`emit_exceeded_event`)
- `src/daemon/dispatch_idle/fixup_nudge.rs:123` (`emit_nudge`)

## RED→GREEN evidence chain

- RED commit `01ec0dd`: 5 mandatory tests added. 3 fail under current impl (the fallback paths); 2 are regression anchors for the upstream-preserved path (pass already, ensure GREEN doesn't break them).
- GREEN commit `b46781a` (was `a72f5c8` pre-rebase): impl swap; all 5 tests pass.

Local verified: cargo fmt ✓ + clippy `-D warnings` ✓ + dispatch_idle 21/21 ✓ + full suite 2454/2454 ✓.

## Tests

| # | Test | Pre-fix | Post-fix |
|---|---|---|---|
| 1 | `dispatch_idle_emit_with_upstream_correlation_preserves_it` | PASS (anchor) | PASS |
| 2 | `dispatch_idle_emit_without_upstream_falls_back_to_dispatch_id` | FAIL | PASS |
| 3 | `dispatch_idle_nudge_correlation_id_always_non_empty` (e2e) | FAIL | PASS |
| 4 | `fixup_nudge_with_upstream_correlation_preserves_it` | PASS (anchor) | PASS |
| 5 | `fixup_nudge_without_upstream_falls_back_to_dispatch_id` | FAIL | PASS |

## Semantic blend acknowledgement + future migration path

Post-fix, `correlation_id` holds EITHER:
- An **upstream chain ID** (operator-provided, free-form), OR
- A **producer record ID** (`disp-{ts}-{seq}` from this fix's fallback)

These are distinguishable via prefix conventions across the daemon:
- `disp-` → dispatch_idle sidecar
- `t-` → task board ID
- `m-` → message ID
- (free-form) → operator-supplied upstream

**If a future producer emits `correlation_id` values that don't follow the documented prefix conventions**, file a follow-up issue to add `source_record_id: Option<String>` field for clean semantic separation (option A from `/tmp/dialectic-947-dev-primary.md` §2). This locks the evolution path now so future maintainers don't repeat the spike.

## Operator workflow post-fix

```bash
# Find all nudges from a specific dispatch sidecar (operator can now always backtrack):
grep '"correlation_id":"disp-..."' ~/.agend-terminal/inbox/*.jsonl

# Inspect the source sidecar state:
cat ~/.agend-terminal/dispatch_idle/pending/disp-<id>.json
```

## Out of scope

- Backfilling `correlation_id` on existing (already-written) inbox messages — not feasible; only new messages get the fix
- Adding `source_record_id` field preemptively — deferred until prefix-convention break observed
- Auditing other `system:*` producers (`waiting_on_stale`, `helper_staleness_watchdog`, `anti_stall`) — already work; no scope change

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test --bin agend-terminal dispatch_idle:: → 21/21 pass
- [x] cargo test --bin agend-terminal → 2454/2454 pass (no regressions)
- [ ] CI 5/5 green (ubuntu / macos / windows / LOC / audit)
- [ ] Reviewer VERIFIED

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)