### PR TITLE
feat(#942,#943): canonicalize repo slug + sha256 watch_filename + active migration — Closes #942 + Closes #943

### DIFF
--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -156,6 +156,11 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     // env-gated via AGEND_DAEMON_BOOT_SWEEP_AGE_DAYS=N. Reuses #927 PR-B
     // primitives (`admin::cleanup_zombies`).
     let _ = crate::daemon::boot_sweep::boot_sweep_zombies(home);
+    // #942/#943: rename legacy-format watch files (DefaultHasher+non-canonical)
+    // to canonical+sha256 form. One-shot at boot; idempotent on repeated runs.
+    // Active migration (option b from dev-2 cross-audit Pushback 3) prevents
+    // the 72h duplicate-notification window across the hash-scheme transition.
+    let _ = crate::daemon::ci_watch::migration::migrate_legacy_watch_filenames(home);
 
     let run_dir = crate::daemon::run_dir(home);
     std::fs::create_dir_all(&run_dir)

--- a/src/daemon/ci_watch/migration.rs
+++ b/src/daemon/ci_watch/migration.rs
@@ -1,18 +1,159 @@
-//! #942 + #943 boot-time migration — RED STUB.
+//! #942 + #943 boot-time migration: rename old-format watch files to
+//! the canonical+sha256 form so operators don't see duplicate 72h
+//! notifications across the hash-scheme transition.
 //!
-//! GREEN commit replaces with real implementation: scan ci-watches dir,
-//! rename old-format files (DefaultHasher 16-hex + non-canonical repo)
-//! to new sha256+canonical form. Active migration (option b from
-//! dev-2 cross-audit Pushback 3) prevents 72h duplicate-notification
-//! window operators were seeing.
+//! Pre-#942/#943 filenames used `DefaultHasher` (SipHash-2-4 truncated
+//! to 64 bits) → 16 hex chars + `.json` (21 chars total) + a verbatim
+//! repo string (possibly `.git`-suffixed, cased differently).
+//!
+//! Post-fix filenames use sha256 (256-bit) → 64 hex chars + `.json` (69
+//! chars total) + canonicalized repo string.
+//!
+//! Migration logic:
+//! 1. Scan `<home>/ci-watches/*.json`
+//! 2. For each file: if filename stem length != 64 → old format
+//! 3. Read body, parse `repo` + `branch`
+//! 4. Canonicalize repo, compute new sha256 filename
+//! 5. Rewrite `repo` field in body to canonical form
+//! 6. Rename file; if target already exists, log conflict and skip
+//!
+//! Conflict resolution: when two old files map to the same canonical
+//! target (e.g., `owner/repo.git@feat/x` and `owner/repo@feat/x`),
+//! the FIRST one encountered wins; subsequent conflicts log a warning
+//! and are left in place. Operator can manually clean up via
+//! `rm <home>/ci-watches/<old-name>.json`. The hash-collision case is
+//! cryptographically impossible (sha256 collision-resistant).
+//!
+//! Idempotent: re-running the migration on already-migrated state is
+//! a no-op (all files have 64-hex stems).
 
 use std::path::Path;
 
 use super::registry::{ci_watches_dir, watch_filename};
 
-/// RED STUB — no-op. GREEN commit lands real impl.
-pub fn migrate_legacy_watch_filenames(_home: &Path) -> usize {
-    0
+const SHA256_HEX_LEN: usize = 64;
+
+/// Scan `<home>/ci-watches/` and rename any old-format (non-sha256)
+/// watch files to the canonical+sha256 form. Idempotent. Best-effort:
+/// errors are logged but never abort caller (daemon boot path).
+///
+/// Returns the count of files actually renamed (for logging /
+/// test assertions).
+pub fn migrate_legacy_watch_filenames(home: &Path) -> usize {
+    let ci_dir = ci_watches_dir(home);
+    let Ok(entries) = std::fs::read_dir(&ci_dir) else {
+        return 0;
+    };
+    let mut renamed = 0usize;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let stem = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+        // sha256 hex digests are 64 chars. Anything else is old format.
+        if stem.len() == SHA256_HEX_LEN && stem.chars().all(|c| c.is_ascii_hexdigit()) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            tracing::warn!(
+                path = %path.display(),
+                "#942/#943 migration: failed to read old-format watch file"
+            );
+            continue;
+        };
+        let mut watch: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "#942/#943 migration: failed to parse old-format watch JSON"
+                );
+                continue;
+            }
+        };
+        let raw_repo = watch.get("repo").and_then(|v| v.as_str()).unwrap_or("");
+        let raw_branch = watch.get("branch").and_then(|v| v.as_str()).unwrap_or("");
+        if raw_repo.is_empty() || raw_branch.is_empty() {
+            tracing::warn!(
+                path = %path.display(),
+                "#942/#943 migration: old-format watch missing repo/branch fields"
+            );
+            continue;
+        }
+        let canonical_repo = match crate::mcp::handlers::dispatch_hook::canonicalize_repo_slug(
+            raw_repo,
+        ) {
+            Some(c) => c,
+            None => {
+                tracing::warn!(
+                    path = %path.display(),
+                    repo = %raw_repo,
+                    "#942/#943 migration: repo string cannot be canonicalized; leaving file in place"
+                );
+                continue;
+            }
+        };
+        let new_filename = watch_filename(&canonical_repo, raw_branch);
+        let new_path = ci_dir.join(&new_filename);
+        if new_path == path {
+            // Same filename — only possible if the OLD file already had
+            // canonical repo + sha256 stem somehow. Idempotent no-op.
+            continue;
+        }
+        if new_path.exists() {
+            tracing::warn!(
+                old = %path.display(),
+                new = %new_path.display(),
+                "#942/#943 migration: target already exists (likely two old files mapped to same canonical); skipping rename"
+            );
+            continue;
+        }
+        // Update body's `repo` field to canonical form before write.
+        watch["repo"] = serde_json::json!(canonical_repo);
+        let new_body = match serde_json::to_string_pretty(&watch) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "#942/#943 migration: failed to re-serialize watch JSON"
+                );
+                continue;
+            }
+        };
+        // Atomic-ish: write new file first, then remove old. Both safe to
+        // re-run if interrupted (idempotent on retry).
+        if let Err(e) = std::fs::write(&new_path, new_body) {
+            tracing::warn!(
+                path = %new_path.display(),
+                error = %e,
+                "#942/#943 migration: failed to write new-format file"
+            );
+            continue;
+        }
+        if let Err(e) = std::fs::remove_file(&path) {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "#942/#943 migration: wrote new file but failed to remove old; manual cleanup needed"
+            );
+            // Don't increment counter — partial migration.
+            continue;
+        }
+        tracing::info!(
+            old = %path.display(),
+            new = %new_path.display(),
+            canonical_repo = %canonical_repo,
+            "#942/#943 migration: renamed legacy watch file to canonical+sha256 form"
+        );
+        renamed += 1;
+    }
+    renamed
 }
 
 #[cfg(test)]

--- a/src/daemon/ci_watch/migration.rs
+++ b/src/daemon/ci_watch/migration.rs
@@ -1,0 +1,163 @@
+//! #942 + #943 boot-time migration — RED STUB.
+//!
+//! GREEN commit replaces with real implementation: scan ci-watches dir,
+//! rename old-format files (DefaultHasher 16-hex + non-canonical repo)
+//! to new sha256+canonical form. Active migration (option b from
+//! dev-2 cross-audit Pushback 3) prevents 72h duplicate-notification
+//! window operators were seeing.
+
+use std::path::Path;
+
+use super::registry::{ci_watches_dir, watch_filename};
+
+/// RED STUB — no-op. GREEN commit lands real impl.
+pub fn migrate_legacy_watch_filenames(_home: &Path) -> usize {
+    0
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-942-943-mig-{}-{}-{}",
+            tag,
+            std::process::id(),
+            id
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// #942/#943 mandatory test 4 — boot with old-format files: renamed
+    /// to new format, body `repo` field rewritten to canonical.
+    #[test]
+    fn migration_renames_old_format_to_canonical_sha256() {
+        let home = tmp_home("rename");
+        let ci_dir = ci_watches_dir(&home);
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        // Old DefaultHasher-style filename: 16 hex chars. Body's repo is
+        // non-canonical (`.git` suffix).
+        let old_name = "aabbccdd11223344.json";
+        let body = serde_json::json!({
+            "repo": "owner/repo.git",
+            "branch": "feat/x",
+            "interval_secs": 60,
+            "subscribers": [{"instance": "dev", "subscribed_at": "2026-05-19T00:00:00Z"}],
+        });
+        std::fs::write(
+            ci_dir.join(old_name),
+            serde_json::to_string_pretty(&body).unwrap(),
+        )
+        .unwrap();
+
+        let renamed = migrate_legacy_watch_filenames(&home);
+        assert_eq!(renamed, 1, "exactly one file must be renamed");
+
+        // Old file gone.
+        assert!(
+            !ci_dir.join(old_name).exists(),
+            "old-format file must be removed post-migration"
+        );
+
+        // New file: 64-hex sha256 stem; body has canonical repo.
+        let new_filename = watch_filename("owner/repo", "feat/x");
+        let new_path = ci_dir.join(&new_filename);
+        assert!(
+            new_path.exists(),
+            "new-format file must exist at sha256(canonical:branch).json"
+        );
+        let new_body: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&new_path).unwrap()).unwrap();
+        assert_eq!(
+            new_body["repo"].as_str(),
+            Some("owner/repo"),
+            "body's `repo` field must be rewritten to canonical form"
+        );
+        assert_eq!(
+            new_body["branch"].as_str(),
+            Some("feat/x"),
+            "branch field preserved verbatim"
+        );
+        // Subscribers preserved.
+        let subs = new_body["subscribers"].as_array().unwrap();
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs[0]["instance"].as_str(), Some("dev"));
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #942/#943 mandatory test 5 — new-format file (canonical sha256
+    /// filename + canonical body) is NOT touched by migration. Idempotent.
+    #[test]
+    fn migration_leaves_new_format_files_intact() {
+        let home = tmp_home("idempotent");
+        let ci_dir = ci_watches_dir(&home);
+        std::fs::create_dir_all(&ci_dir).unwrap();
+
+        // Pre-migration target file with canonical name.
+        let new_filename = watch_filename("owner/repo", "feat/y");
+        let original_body = serde_json::json!({
+            "repo": "owner/repo",
+            "branch": "feat/y",
+            "subscribers": [{"instance": "agent", "subscribed_at": "2026-05-19T00:00:00Z"}],
+        });
+        let original_serialized = serde_json::to_string_pretty(&original_body).unwrap();
+        std::fs::write(ci_dir.join(&new_filename), &original_serialized).unwrap();
+
+        let renamed = migrate_legacy_watch_filenames(&home);
+        assert_eq!(renamed, 0, "no renames for already-canonical files");
+        assert!(
+            ci_dir.join(&new_filename).exists(),
+            "new-format file must remain on disk"
+        );
+        // Body byte-identical (no spurious rewrite).
+        let after = std::fs::read_to_string(ci_dir.join(&new_filename)).unwrap();
+        assert_eq!(
+            after, original_serialized,
+            "new-format file body must be byte-identical post-migration"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Conflict scenario: two old-format files map to the same canonical
+    /// target. First-encountered wins; second logged + skipped (NOT a
+    /// panic).
+    #[test]
+    fn migration_handles_conflict_without_panic() {
+        let home = tmp_home("conflict");
+        let ci_dir = ci_watches_dir(&home);
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        // Two old files with same canonical (repo, branch).
+        let a = "1111111111111111.json";
+        let b = "2222222222222222.json";
+        let body_a = serde_json::json!({"repo": "owner/repo.git", "branch": "feat/z"});
+        let body_b = serde_json::json!({"repo": "owner/repo", "branch": "feat/z"});
+        std::fs::write(
+            ci_dir.join(a),
+            serde_json::to_string_pretty(&body_a).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            ci_dir.join(b),
+            serde_json::to_string_pretty(&body_b).unwrap(),
+        )
+        .unwrap();
+
+        // Should not panic.
+        let _ = migrate_legacy_watch_filenames(&home);
+
+        // New canonical file exists.
+        let new_filename = watch_filename("owner/repo", "feat/z");
+        assert!(ci_dir.join(&new_filename).exists());
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -10,6 +10,7 @@
 //! - [`poller`] — poll loop + dedup helpers + `ci_check_repo` + tests
 //! - [`watcher`] — top-level entry point + provider factory
 
+pub(crate) mod migration;
 mod poller;
 mod provider;
 mod registry;

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -63,16 +63,33 @@ pub fn remove_watch(
     );
 }
 
-/// Deterministic, collision-free filename for a CI watch entry.
+/// Deterministic, collision-resistant filename for a CI watch entry.
 /// Uses SHA-256 of `"{repo}:{branch}"` to avoid path traversal and
 /// collisions when repo names contain `/` (e.g. `owner/repo` vs
-/// `owner_repo`).
+/// `owner_repo`). Cryptographic — collision is computationally
+/// infeasible (no known sha256 collision attacks).
+///
+/// Pre-#943 this used `std::collections::hash_map::DefaultHasher`
+/// (SipHash-2-4 truncated to 64 bits) — birthday collision at
+/// ~2^32 entries and within-session adversarial collision findable
+/// at ~2^32 brute-force. The docstring already claimed sha256; this
+/// fix brings implementation into line. Filename grows from 16 hex
+/// (DefaultHasher) to 64 hex (sha256).
+///
+/// Old-format files are migrated at boot via
+/// [`super::migration::migrate_legacy_watch_filenames`] (#942/#943
+/// PR-B). Operators don't see duplicate 72h notifications because the
+/// migration runs synchronously before the poller loop starts.
+///
+/// Performance: ~900ns/call vs DefaultHasher's ~100ns. At typical
+/// per-watch subscription rate (~100/agent/day) the ~90µs/day delta
+/// is negligible (#942 dev-2 cross-audit Pushback 4).
 pub fn watch_filename(repo: &str, branch: &str) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let mut h = DefaultHasher::new();
-    format!("{repo}:{branch}").hash(&mut h);
-    format!("{:016x}.json", h.finish())
+    let composite = format!("{repo}:{branch}");
+    format!(
+        "{}.json",
+        crate::daemon::utils::sha256_hex(composite.as_bytes())
+    )
 }
 
 /// Persist updated tracking state (last_run_id + head_sha) to the watch file.
@@ -157,15 +174,22 @@ mod tests {
 
     #[test]
     fn watch_filename_distinguishes_delimiter_ambiguity() {
+        // `owner/repo` + `feat-x` must NOT collide with
+        // `owner` + `repo:feat-x` despite both producing the same raw
+        // composite under naive concatenation.
         let a = watch_filename("owner/repo", "feat-x");
         let b = watch_filename("owner", "repo:feat-x");
-        assert_ne!(a, b, "filename hash must distinguish (repo, branch) splits");
+        assert_ne!(
+            a, b,
+            "filename hash must distinguish (repo, branch) split — composite was `repo:branch` (concat ambiguous)"
+        );
     }
 
     #[test]
     fn watch_filename_differs_from_pre_943_defaulthasher_length() {
-        // Pre-#943 DefaultHasher: 16 hex + .json (21 chars).
-        // Post-#943 sha256: 64 hex + .json (69 chars).
+        // Pre-#943 DefaultHasher output: 16 hex + .json (21 chars total).
+        // Post-#943 sha256: 64 hex + .json (69 chars total).
+        // This guards against accidentally reverting to DefaultHasher.
         let f = watch_filename("owner/repo", "feat/x");
         assert!(
             f.len() > 21,

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -124,3 +124,52 @@ pub(super) fn update_watch_state_with_notify(
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // ── #943 sha256 contract for watch_filename ──
+
+    #[test]
+    fn watch_filename_uses_sha256_64_hex_chars_plus_json_extension() {
+        let f = watch_filename("owner/repo", "feat/x");
+        assert!(f.ends_with(".json"), "filename must end .json: {f}");
+        let stem = f.strip_suffix(".json").unwrap();
+        assert_eq!(
+            stem.len(),
+            64,
+            "sha256 hex digest is 64 chars (post-#943): {f}"
+        );
+        assert!(
+            stem.chars().all(|c| c.is_ascii_hexdigit()),
+            "filename stem must be pure ascii hex: {f}"
+        );
+    }
+
+    #[test]
+    fn watch_filename_deterministic_across_calls() {
+        let a = watch_filename("owner/repo", "feat/x");
+        let b = watch_filename("owner/repo", "feat/x");
+        assert_eq!(a, b, "watch_filename must be deterministic");
+    }
+
+    #[test]
+    fn watch_filename_distinguishes_delimiter_ambiguity() {
+        let a = watch_filename("owner/repo", "feat-x");
+        let b = watch_filename("owner", "repo:feat-x");
+        assert_ne!(a, b, "filename hash must distinguish (repo, branch) splits");
+    }
+
+    #[test]
+    fn watch_filename_differs_from_pre_943_defaulthasher_length() {
+        // Pre-#943 DefaultHasher: 16 hex + .json (21 chars).
+        // Post-#943 sha256: 64 hex + .json (69 chars).
+        let f = watch_filename("owner/repo", "feat/x");
+        assert!(
+            f.len() > 21,
+            "post-#943 filename length must exceed legacy DefaultHasher length (21): got {f}"
+        );
+    }
+}

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -350,8 +350,28 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     // neither path nor binding present (no silent cwd-derivation). EC15:
     // validate the binding's source_repo path still exists before reading.
     let derived_repo: Option<String>;
+    let canonical_repo: Option<String>;
     let repo: &str = match args["repo"].as_str().filter(|s| !s.is_empty()) {
-        Some(r) => r,
+        Some(r) => {
+            // #942: canonicalize on entry so the hash key + stored
+            // `repo` field both reflect the single canonical form.
+            // Rejects obviously-malformed input (non-GitHub URL, malformed
+            // slug) with operator-actionable error.
+            match crate::mcp::handlers::dispatch_hook::canonicalize_repo_slug(r) {
+                Some(c) => {
+                    canonical_repo = Some(c);
+                    canonical_repo.as_deref().unwrap_or("")
+                }
+                None => {
+                    return json!({
+                        "error": format!(
+                            "invalid 'repo' format: {r:?} — expected `owner/repo` or full GitHub URL"
+                        ),
+                        "code": "invalid_repo_format",
+                    });
+                }
+            }
+        }
         None => {
             let binding = home
                 .join("runtime")

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -1832,3 +1832,101 @@ fn cleanup_on_clean_worktree_is_noop_count_zero() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── #942 explicit watch + auto-bind no-split end-to-end ──
+//
+// Pre-#942 bug: caller could pass `repo: "owner/repo.git"` to
+// `handle_watch_ci` and the auto-derived form (from
+// `derive_repo_from_remote`) would produce `owner/repo` → two
+// distinct watch files (different hashes), fragmented subscribers,
+// duplicate notifications.
+//
+// Post-fix: both paths converge on canonical `owner/repo` so the same
+// ci_watches file holds both subscribers.
+
+#[test]
+fn handle_watch_ci_canonicalizes_caller_supplied_repo_with_git_suffix() {
+    let home = p778_tmp_home("942-git-suffix");
+    let r = handle_watch_ci(
+        &home,
+        &serde_json::json!({"repo": "owner/repo.git", "branch": "feat/x"}),
+        "dev",
+    );
+    assert!(
+        r["watching"].as_bool().unwrap_or(false),
+        "watching must succeed for `.git` form: {r}"
+    );
+
+    // File must be at canonical sha256 path.
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+    let canonical_filename = crate::daemon::ci_watch::watch_filename("owner/repo", "feat/x");
+    let canonical_path = ci_dir.join(&canonical_filename);
+    assert!(
+        canonical_path.exists(),
+        "watch file must land at canonical sha256 path"
+    );
+
+    // Body's `repo` field is canonical (not `.git`-suffixed).
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&canonical_path).unwrap()).unwrap();
+    assert_eq!(v["repo"].as_str(), Some("owner/repo"));
+    assert_eq!(v["branch"].as_str(), Some("feat/x"));
+}
+
+#[test]
+fn handle_watch_ci_two_callers_with_different_forms_share_one_watch_file() {
+    let home = p778_tmp_home("942-converge");
+    let _ = handle_watch_ci(
+        &home,
+        &serde_json::json!({"repo": "owner/repo.git", "branch": "feat/x"}),
+        "agent-a",
+    );
+    let _ = handle_watch_ci(
+        &home,
+        &serde_json::json!({"repo": "Owner/Repo", "branch": "feat/x"}),
+        "agent-b",
+    );
+
+    // Single canonical file post-canonicalization.
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+    let files: Vec<_> = std::fs::read_dir(&ci_dir)
+        .unwrap()
+        .flatten()
+        .filter(|e| {
+            e.path().extension().and_then(|s| s.to_str()) == Some("json")
+                && e.path()
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|stem| stem.len() == 64)
+        })
+        .collect();
+    assert_eq!(
+        files.len(),
+        1,
+        "two callers with different repo forms must converge to ONE canonical file: {:?}",
+        files.iter().map(|f| f.path()).collect::<Vec<_>>()
+    );
+
+    // Both agents in subscribers.
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(files[0].path()).unwrap()).unwrap();
+    let subs = crate::daemon::ci_watch::parse_subscribers(&v);
+    assert!(subs.contains(&"agent-a".to_string()), "agent-a subscribed");
+    assert!(subs.contains(&"agent-b".to_string()), "agent-b subscribed");
+}
+
+#[test]
+fn handle_watch_ci_rejects_invalid_repo_format() {
+    let home = p778_tmp_home("942-invalid");
+    // Non-GitHub URL — canonicalize_repo_slug returns None
+    let r = handle_watch_ci(
+        &home,
+        &serde_json::json!({"repo": "https://gitlab.com/owner/repo", "branch": "feat/x"}),
+        "dev",
+    );
+    assert_eq!(
+        r["code"].as_str(),
+        Some("invalid_repo_format"),
+        "GitLab URL must be rejected as invalid_repo_format: {r}"
+    );
+}

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -410,17 +410,19 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     );
 
     // P0-2 + Sprint 55 P0-B EC4: auto-watch_ci. Resolution order:
-    //   1. caller-supplied `repo` arg
-    //   2. fleet.yaml `repo:` override (Sprint 55 EC4)
-    //   3. `derive_repo_from_remote(source_repo)` (existing Sprint 53 P0-2)
+    //   1. caller-supplied `repo` arg → canonicalize (#942)
+    //   2. fleet.yaml `repo:` override → canonicalize (#942)
+    //   3. `derive_repo_from_remote(source_repo)` (existing Sprint 53 P0-2;
+    //      already canonical via `parse_github_owner_repo` → `canonicalize_repo_slug`)
     let resolved_repo = repo
         .filter(|s| !s.is_empty())
-        .map(str::to_string)
+        .and_then(canonicalize_repo_slug)
         .or_else(|| {
             resolved
                 .as_ref()
                 .and_then(|r| r.repo.clone())
                 .filter(|s| !s.is_empty())
+                .and_then(|s| canonicalize_repo_slug(&s))
         })
         .or_else(|| derive_repo_from_remote(&source_repo));
     if let Some(r) = resolved_repo {
@@ -752,36 +754,64 @@ pub(crate) fn resolve_team_source_repo(home: &Path, agent: &str) -> Option<PathB
 /// - `http://github.com/owner/repo(.git)`
 /// - `git@github.com:owner/repo(.git)`
 ///
-/// #942 RED STUB — returns the trimmed input unchanged so tests compile.
-/// GREEN commit replaces with real canonicalization logic.
+/// #942 canonical form for GitHub `owner/repo` identity. Accepts both
+/// full URL forms AND bare slugs; collapses the 7 known divergence forms
+/// (`.git` suffix, casing, whitespace, full HTTPS URL, SSH URL, trailing
+/// slash, HTTP vs HTTPS) to a single canonical `owner/repo` lowercase
+/// string. GitHub itself treats repo identifiers case-insensitively for
+/// routing, so lowercasing here matches server semantics.
+///
+/// Single source of truth for repo identity used by:
+/// - `handle_watch_ci` (canonicalize on entry before hash)
+/// - `dispatch_auto_bind_lease` (tiers 1+2 caller-supplied + fleet.yaml)
+/// - `parse_github_owner_repo` (re-uses via delegate)
+/// - `migrate_legacy_watch_filenames` (#942/#943 boot migration)
+///
+/// Returns `None` for inputs that cannot be canonicalized:
+/// - Non-GitHub remotes (e.g. `https://gitlab.com/...`)
+/// - Malformed slugs (single component, too many components)
+/// - Empty input after trim
+///
+/// **Behavior shift from pre-#942 `parse_github_owner_repo`**: pre-fix
+/// accepted only URL forms (returned `None` for bare slugs like
+/// `owner/repo`). Post-fix accepts both. The only in-tree caller of
+/// the pre-fix shape is `derive_repo_from_remote` which always passes
+/// the output of `git remote get-url` (URL form); the lenient shift
+/// is theoretical for that path. Documented in #942 PR body.
 pub(crate) fn canonicalize_repo_slug(s: &str) -> Option<String> {
     let s = s.trim();
     if s.is_empty() {
-        None
-    } else {
-        Some(s.to_string())
+        return None;
     }
-}
-
-/// Returns `None` for non-GitHub remotes — `watch_ci` only knows how to poll
-/// GitHub Actions, so silently skipping non-GitHub repos is the right behavior
-/// (the alternative would be writing a stale watch entry the poller can't act on).
-fn parse_github_owner_repo(url: &str) -> Option<String> {
-    let url = url.trim();
-    let stripped = url
+    let stripped = s
         .strip_prefix("https://github.com/")
-        .or_else(|| url.strip_prefix("http://github.com/"))
-        .or_else(|| url.strip_prefix("git@github.com:"))
-        .or_else(|| url.strip_prefix("ssh://git@github.com/"))?;
+        .or_else(|| s.strip_prefix("http://github.com/"))
+        .or_else(|| s.strip_prefix("git@github.com:"))
+        .or_else(|| s.strip_prefix("ssh://git@github.com/"))
+        .unwrap_or(s);
     let slug = stripped.trim_end_matches('/').trim_end_matches(".git");
-    // Sanity: must look like `owner/repo` — exactly one '/' and both parts non-empty.
     let mut parts = slug.split('/');
     let owner = parts.next()?;
     let name = parts.next()?;
     if parts.next().is_some() || owner.is_empty() || name.is_empty() {
         return None;
     }
-    Some(format!("{owner}/{name}"))
+    Some(format!(
+        "{}/{}",
+        owner.to_ascii_lowercase(),
+        name.to_ascii_lowercase()
+    ))
+}
+
+/// Returns `None` for non-GitHub remotes — `watch_ci` only knows how to poll
+/// GitHub Actions, so silently skipping non-GitHub repos is the right behavior
+/// (the alternative would be writing a stale watch entry the poller can't act on).
+///
+/// Pre-#942 this was a separate stricter implementation; post-#942 it
+/// delegates to [`canonicalize_repo_slug`] so derived-from-remote URLs
+/// and operator-supplied slugs converge on identical canonical form.
+fn parse_github_owner_repo(url: &str) -> Option<String> {
+    canonicalize_repo_slug(url)
 }
 
 /// Sprint 55 P0-B: re-export `derive_repo_from_remote` as `pub(crate)` so

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -752,6 +752,17 @@ pub(crate) fn resolve_team_source_repo(home: &Path, agent: &str) -> Option<PathB
 /// - `http://github.com/owner/repo(.git)`
 /// - `git@github.com:owner/repo(.git)`
 ///
+/// #942 RED STUB — returns the trimmed input unchanged so tests compile.
+/// GREEN commit replaces with real canonicalization logic.
+pub(crate) fn canonicalize_repo_slug(s: &str) -> Option<String> {
+    let s = s.trim();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
 /// Returns `None` for non-GitHub remotes — `watch_ci` only knows how to poll
 /// GitHub Actions, so silently skipping non-GitHub repos is the right behavior
 /// (the alternative would be writing a stale watch entry the poller can't act on).

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -2070,3 +2070,67 @@ fn ensure_branch_exists_auto_create_from_main_path_unchanged() {
 
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── #942 canonicalize_repo_slug matrix ──
+//
+// Single source of truth for repo identity. Covers all 7 divergence
+// forms enumerated in `/tmp/dialectic-942-dev-primary.md` §1, plus
+// edge cases (empty, malformed, non-GitHub URL).
+
+#[test]
+fn canonicalize_repo_slug_collapses_all_known_divergence_forms() {
+    let cases: &[(&str, Option<&str>)] = &[
+        // bare slug — already canonical
+        ("owner/repo", Some("owner/repo")),
+        // `.git` suffix
+        ("owner/repo.git", Some("owner/repo")),
+        // casing
+        ("Owner/Repo", Some("owner/repo")),
+        ("OWNER/REPO", Some("owner/repo")),
+        // whitespace (trim)
+        (" owner/repo ", Some("owner/repo")),
+        // trailing slash
+        ("owner/repo/", Some("owner/repo")),
+        // full HTTPS URL
+        ("https://github.com/owner/repo", Some("owner/repo")),
+        ("https://github.com/owner/repo.git", Some("owner/repo")),
+        ("https://github.com/Owner/Repo", Some("owner/repo")),
+        // HTTP vs HTTPS
+        ("http://github.com/owner/repo", Some("owner/repo")),
+        // SSH URL forms
+        ("git@github.com:owner/repo.git", Some("owner/repo")),
+        ("ssh://git@github.com/owner/repo", Some("owner/repo")),
+        // malformed: missing repo part
+        ("owner", None),
+        // malformed: too many components
+        ("owner/repo/extra", None),
+        // empty
+        ("", None),
+        ("   ", None),
+        // non-GitHub URL — must NOT canonicalize (returns None;
+        // ci_watch only knows GitHub Actions polling)
+        ("https://gitlab.com/owner/repo", None),
+        ("https://bitbucket.org/owner/repo", None),
+    ];
+    for (input, expected) in cases {
+        let got = super::canonicalize_repo_slug(input);
+        assert_eq!(
+            got.as_deref(),
+            *expected,
+            "canonicalize_repo_slug({input:?}) yielded {got:?}, expected {expected:?}"
+        );
+    }
+}
+
+#[test]
+fn canonicalize_repo_slug_lowercase_is_load_bearing_for_identity() {
+    // GitHub treats org/repo case-insensitively in routing. Two callers
+    // supplying different cases must produce same canonical identity
+    // for the watch_filename hash to converge.
+    let a = super::canonicalize_repo_slug("Owner/Repo").unwrap();
+    let b = super::canonicalize_repo_slug("owner/repo").unwrap();
+    let c = super::canonicalize_repo_slug("OWNER/REPO").unwrap();
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+    assert_eq!(a, "owner/repo");
+}


### PR DESCRIPTION
## Summary

Bundle fix per dev-2 cross-audit recommendation. Closes #942 (handle_watch_ci verbatim-use of `repo` arg as hash input → silent watch fragmentation) + Closes #943 (DefaultHasher vs docstring-claimed sha256 + adversarial collision surface).

Three coordinated changes:
1. **#942**: extract `canonicalize_repo_slug` from `parse_github_owner_repo`; apply at `handle_watch_ci` entry + `dispatch_auto_bind_lease` tiers 1+2
2. **#943**: swap `watch_filename` from DefaultHasher to `daemon::utils::sha256_hex`
3. **Active migration helper** (option b from dev-2 cross-audit Pushback 3): boot-time scan + rename of old-format watch files to canonical+sha256 form

## RED→GREEN per §3.10

- **RED commit** `73b9031`: 11 tests added; 9 fail under STUB `canonicalize_repo_slug` (returns input unchanged) + DefaultHasher + STUB `migrate_legacy_watch_filenames` (returns 0). 2 anchors (deterministic + distinguishes ambiguity) pass either way.
- **GREEN commit** `4866de7` (was `01d2976` pre-rebase): impl swap; all 11 tests pass; full suite 2469/2469.

## 5 dev-2 cross-audit sharpenings (all adopted)

1. **Branch-side canonicalization absent** — documented as known limitation. Branch strings go through hash verbatim; case-sensitive forks (`feat/X` vs `feat/x`) would still fragment. Defer until empirical pain.
2. **`parse_github_owner_repo` delegation shift** — pre-fix accepted only URLs; post-fix accepts bare slugs too. The only in-tree caller is `derive_repo_from_remote` which always passes URL form from `git remote get-url`; widening is theoretical-only.
3. **Option b active migration helper** adopted (~30 LOC). Replaces dev's default (a) "72h TTL absorbs" because operators already burned by silent fragmentation — another duplicate-notification window is unnecessary cognitive load.
4. **sha256 perf quoted explicitly** — 900ns/call × 100/agent/day = 90µs/day. Negligible.
5. **Bundle preferred** — same hot path, single 72h migration window (now actively zero-window thanks to migration helper).

## Critical interaction: #946 supersede keying

Active migration runs at boot BEFORE the poller loop. Post-migration, all watch files have canonical repo strings; `repo_branch_key = format!("{repo}@{branch}")` value is uniform across the corpus. **No 72h duplicate-supersede window** that the dev-2 cross-audit warned about.

## Code surface

| File | Change |
|---|---|
| `src/mcp/handlers/dispatch_hook/mod.rs` | Add `pub(crate) canonicalize_repo_slug`; `parse_github_owner_repo` delegates; tiers 1+2 of resolved_repo call canonicalize |
| `src/mcp/handlers/ci/mod.rs` | `handle_watch_ci` canonicalize on entry; reject malformed (`invalid_repo_format` code) |
| `src/daemon/ci_watch/registry.rs` | `watch_filename` body swap to `sha256_hex`; docstring updated |
| `src/daemon/ci_watch/migration.rs` | NEW module — `migrate_legacy_watch_filenames` + 3 tests |
| `src/daemon/ci_watch/mod.rs` | `pub(crate) mod migration;` |
| `src/bootstrap/mod.rs` | Wire migration call after `boot_sweep_zombies` |

LOC: ~85 impl + ~250 test = ~335 net (over ~180 estimate; ~30 extra for active migration helper which dispatch authorized).

§3.6 single-reviewer eligible (impl < 100 LOC). §3.5 dual NOT triggered.

## Operator runbook

```bash
# Old-format watch files migrate automatically at next daemon boot.
# Operator can verify post-boot:
ls -la ~/.agend-terminal/ci-watches/*.json | awk '{ print length($9) }' | sort -u
# All filenames now 64-hex stem + .json = 69 chars (post-#943).

# Migration log lines visible:
grep "#942/#943 migration" ~/.agend-terminal/daemon.log
```

## Known limitations (PR body documentation)

- **Branch-side fragmentation**: `feat/X` and `feat/x` still produce distinct hashes (case-sensitive). Bounded; covered separately if observed.
- **Conflict in migration**: when two old files map to the same canonical target (e.g., `owner/repo.git@feat/x` + `owner/repo@feat/x` co-exist pre-fix), first wins; second logged + skipped. Operator can manually `rm` stragglers.
- **`parse_github_owner_repo` lenient shift**: now accepts bare slugs (in-tree caller unaffected; documented for future maintainers).

## Out of scope

- Branch canonicalization (separate spike if observed)
- Removing `parse_github_owner_repo` (kept as named delegate for API clarity)
- Operator CLI for manual migration audit (one-time event; manual `ls` + grep sufficient)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test canonicalize_repo_slug watch_filename migration handle_watch_ci — all pass
- [x] cargo test --bin agend-terminal → 2469/2469 (no regressions)
- [ ] CI 5/5 green
- [ ] Reviewer VERIFIED

Closes #942
Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)