### PR TITLE
fix(#946): populate correlation_id on system:ci inbox messages — Closes #946

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -4880,4 +4880,92 @@ mod tests {
         );
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    // ── #946 correlation_id population on system:ci inbox messages ──
+    //
+    // Pre-#946 all `system:ci` enqueues carried `correlation_id: None`,
+    // making it impossible for operators to grep inbox.jsonl for
+    // messages from a specific watch. Post-fix every site populates
+    // `Some(format!("{repo}@{branch}"))` so operators can trace a
+    // notification back to its watch in one grep.
+    //
+    // Stable across hash migrations (#943): the correlation_id value
+    // is the (canonical post-#942) `repo@branch` string, NOT the
+    // watch_filename hash. Future hash-scheme changes preserve the
+    // stable grep target.
+
+    #[test]
+    fn ci_pass_inbox_message_carries_repo_branch_correlation_id() {
+        let dir = tmp_dir("946-ci-pass-corr");
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 100,
+            conclusion: Some("success".into()),
+            head_sha: "abc".into(),
+            url: "https://example.com/100".into(),
+        }]);
+        run_ci_check(&dir, &base_watch(), &provider).unwrap();
+        let inbox_path = dir.join("inbox").join("agent1.jsonl");
+        let content = std::fs::read_to_string(&inbox_path).unwrap();
+        // base_watch has repo="o/r", branch="feat"
+        let expected = r#""correlation_id":"o/r@feat""#;
+        assert!(
+            content.contains(expected),
+            "ci-pass message must carry correlation_id={expected}: {content}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn ci_stale_inbox_message_carries_repo_branch_correlation_id() {
+        let dir = tmp_dir("946-ci-stale-corr");
+        // Two-run setup mirrors `mock_stale_sha_emits_ci_stale_inbox_message`
+        // — old-head run completes after new commit pushed; old run's
+        // notification is dropped + emits [ci-stale].
+        let provider = MockCiProvider::with_runs(vec![
+            CiRun {
+                id: 301,
+                conclusion: None,
+                head_sha: "newhead".into(),
+                url: "https://example.com/301".into(),
+            },
+            CiRun {
+                id: 300,
+                conclusion: Some("success".into()),
+                head_sha: "oldhead".into(),
+                url: "https://example.com/300".into(),
+            },
+        ]);
+        run_ci_check(&dir, &base_watch(), &provider).unwrap();
+        let inbox_path = dir.join("inbox").join("agent1.jsonl");
+        let content = std::fs::read_to_string(&inbox_path).unwrap();
+        assert!(
+            content.contains("[ci-stale]"),
+            "expected [ci-stale] inbox message: {content}"
+        );
+        let expected = r#""correlation_id":"o/r@feat""#;
+        assert!(
+            content.contains(expected),
+            "ci-stale message must carry correlation_id={expected}: {content}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn ci_conflict_alert_inbox_message_carries_repo_branch_correlation_id() {
+        let dir = tmp_dir("946-ci-conflict-corr");
+        let subscribers = vec!["agent1".to_string()];
+        emit_ci_conflict_alert(&dir, "o/r", "feat", &subscribers, "watch-start");
+        let inbox_path = dir.join("inbox").join("agent1.jsonl");
+        let content = std::fs::read_to_string(&inbox_path).unwrap();
+        assert!(
+            content.contains("[ci-conflict-detected]"),
+            "expected ci-conflict alert: {content}"
+        );
+        let expected = r#""correlation_id":"o/r@feat""#;
+        assert!(
+            content.contains(expected),
+            "ci-conflict-detected message must carry correlation_id={expected}: {content}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -157,7 +157,12 @@ pub fn emit_ci_conflict_alert(
                 parent_id: None,
                 task_id: None,
                 force_meta: None,
-                correlation_id: None,
+                // #946: stable grep target for operators tracing
+                // notifications back to a specific watch. Uses canonical
+                // (post-#942) `{repo}@{branch}` form — survives future
+                // hash-scheme migrations because it's the logical
+                // identity, not the storage filename hash.
+                correlation_id: Some(format!("{repo}@{branch}")),
                 reviewed_head: None,
                 from: "system:ci".to_string(),
                 text: body.clone(),
@@ -924,7 +929,8 @@ async fn ci_check_repo(
                         parent_id: None,
                         task_id: None,
                         force_meta: None,
-                        correlation_id: None,
+                        // #946: see emit_ci_conflict_alert for rationale.
+                        correlation_id: Some(format!("{repo}@{branch}")),
                         reviewed_head: None,
                         from: "system:ci".to_string(),
                         text: format!(
@@ -1075,7 +1081,9 @@ async fn ci_check_repo(
                         parent_id: None,
                         task_id: None,
                         force_meta: None,
-                        correlation_id: None,
+                        // #946: reuse repo_branch_key (line 977) — same
+                        // canonical `{repo}@{branch}` form.
+                        correlation_id: Some(repo_branch_key.clone()),
                         reviewed_head: None,
                         from: "system:ci".to_string(),
                         text: body.clone(),

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -330,3 +330,70 @@ pub fn startup_sweep(home: &Path) {
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp_dir(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-946-sweep-{}-{}-{}",
+            tag,
+            std::process::id(),
+            id
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// #946 — sweep.rs `[ci-watch-stalled]` enqueue site (fan_out_health_event
+    /// at :161 via bump_consecutive_skips_and_maybe_notify) carries
+    /// `correlation_id = {repo}@{branch}`. Pre-fix: None.
+    #[test]
+    fn ci_stalled_inbox_message_carries_repo_branch_correlation_id() {
+        let dir = tmp_dir("946-stalled-corr");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        // Plant a watch with consecutive_skips == STALL_THRESHOLD-1 so
+        // the next bump tips it over and fires the stall notification.
+        let watch_path = ci_dir.join("test-watch.json");
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "consecutive_skips": STALL_THRESHOLD - 1,
+            "stalled_notified": false,
+            "subscribers": [{"instance": "agent1", "subscribed_at": "2026-05-19T00:00:00Z"}],
+        });
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+
+        let subscribers = vec!["agent1".to_string()];
+        let reset_epoch = chrono::Utc::now().timestamp() as u64 + 3600;
+        bump_consecutive_skips_and_maybe_notify(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &subscribers,
+            reset_epoch,
+            None,
+        );
+
+        let inbox_path = dir.join("inbox").join("agent1.jsonl");
+        let content = std::fs::read_to_string(&inbox_path).unwrap();
+        assert!(
+            content.contains("[ci-watch-stalled]"),
+            "expected [ci-watch-stalled] in inbox: {content}"
+        );
+        let expected = r#""correlation_id":"o/r@feat""#;
+        assert!(
+            content.contains(expected),
+            "ci-watch-stalled message must carry correlation_id={expected}: {content}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -169,7 +169,10 @@ fn fan_out_health_event(
                 parent_id: None,
                 task_id: None,
                 force_meta: None,
-                correlation_id: None,
+                // #946: reuse repo_branch_key (line 157) — same canonical
+                // `{repo}@{branch}` form. Stable grep target across hash
+                // migrations because it's logical identity, not filename.
+                correlation_id: Some(repo_branch_key.clone()),
                 reviewed_head: None,
                 from: "system:ci".to_string(),
                 text: body.clone(),


### PR DESCRIPTION
## Summary

Four enqueue sites in `daemon::ci_watch::{poller, sweep}` previously emitted `system:ci` inbox messages with `correlation_id: None`. Post-fix all four carry `Some(format!(\"{repo}@{branch}\"))` so operators can grep `inbox.jsonl` back to the originating watch in one step.

`correlation_id` value is the **logical identity** of the watch (canonical post-#942 `{repo}@{branch}`), NOT the filename hash — stable across future hash-scheme migrations.

## RED→GREEN per §3.10

- **RED commit** `52a6b53`: 4 tests added. All 4 fail under `correlation_id: None`.
- **GREEN commit** `816d937` (was `d857c0d` pre-rebase): impl swap at 4 sites; all 4 tests pass; full suite 2478/2478.

## Sites touched

| Location | Path | Comment |
|---|---|---|
| `src/daemon/ci_watch/poller.rs:160` | emit_ci_conflict_alert | `[ci-conflict-detected]` |
| `src/daemon/ci_watch/poller.rs:927` | ci-stale supersede | older SHA no longer current head |
| `src/daemon/ci_watch/poller.rs:1078` | ci-pass/fail main fan-out | reuses `repo_branch_key` from line 977 |
| `src/daemon/ci_watch/sweep.rs:172` | fan_out_health_event | `[ci-watch-stalled]`/resumed; reuses `repo_branch_key` from line 157 |

## Operator workflow post-fix

```bash
# Find all system:ci messages from a specific watch:
grep '\"correlation_id\":\"owner/repo@feat/x\"' ~/.agend-terminal/inbox/*.jsonl

# Inspect the watch state file (sha256 filename):
ls ~/.agend-terminal/ci-watches/$(printf 'owner/repo:feat/x' | sha256sum | cut -d' ' -f1).json
```

## Interaction with #942+#943 (d0468d1, already shipped)

The active migration helper from PR #953 ran at boot BEFORE the ci-watch poller, so all `correlation_id` values emitted post-merge use **canonical** (post-#942) repo form. Historical inbox entries pre-#942 contain whatever verbatim repo string the operator originally typed — those values may not match canonical form.

**Operators auditing across the #942 merge boundary** should grep with both forms (e.g., `owner/repo@feat/x` AND `owner/repo.git@feat/x`) if they need to find pre-#942 historical entries. Post-#942 entries are uniform.

This was flagged in `/tmp/dialectic-946-947-dev-2-cross-audit.md` Pushback 1 — the sequencing constraint that #946 ships AFTER #942 satisfied this; remaining concern is historical-entry asymmetry, documented above.

## Out of scope

- Backfilling correlation_id on existing inbox.jsonl entries — not feasible; only new messages get the field
- Adding correlation_id to other producer paths (`system:dispatch_idle`, `system:fixup-watchdog`) — #947 already shipped that for dispatch_idle; other producers already populate
- Operator CLI for `inbox grep --by-watch owner/repo@branch` — separate UX issue if observed

## LOC

| File | Change |
|---|---|
| `src/daemon/ci_watch/poller.rs` | +3 impl + ~110 test |
| `src/daemon/ci_watch/sweep.rs` | +1 impl + ~50 test |

~4 impl + ~160 test = ~164 net. §3.6 single-reviewer eligible (impl < 100 LOC).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test ci_pass_inbox ci_stale_inbox ci_conflict_alert_inbox ci_stalled_inbox → 4/4 pass
- [x] cargo test --bin agend-terminal → 2478/2478 (no regressions)
- [ ] CI 5/5 green
- [ ] Reviewer VERIFIED

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)