### PR TITLE
feat(#945 Phase 0): instrument bootstrap + run_core steps with elapsed_ms

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -195,6 +195,10 @@ pub fn serve(
     externals: ExternalRegistry,
     notifier: Option<Arc<dyn ApiNotifier>>,
 ) {
+    // #945 Phase 0: time the bind+port-publish step directly (not the
+    // spawn of api::serve thread — that's sub-ms). Operators care about
+    // "when did api.port appear" for cold-start latency tracking.
+    let _api_port_bind_start = std::time::Instant::now();
     let listener: TcpListener = match crate::ipc::bind_loopback() {
         Ok(l) => l,
         Err(e) => {
@@ -208,6 +212,11 @@ pub fn serve(
         tracing::warn!(error = %e, "failed to publish API port");
         return;
     }
+    tracing::info!(
+        step = "api::serve::bind_and_publish_port",
+        elapsed_ms = _api_port_bind_start.elapsed().as_millis() as u64,
+        "bootstrap-step"
+    );
     // P1-10: Load the per-daemon auth cookie (already issued by
     // `daemon::run` / `verify::run` before any server thread spawned). If
     // it's missing we fail closed — running without auth would be worse

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -27,6 +27,34 @@ use anyhow::{anyhow, Context, Result};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+/// #945 Phase 0 — wrap a bootstrap step with `Instant::now()` + emit a
+/// `tracing::info!` line carrying `step` + `elapsed_ms`. Operator post-boot:
+///
+/// ```bash
+/// grep "bootstrap-step" $AGEND_HOME/daemon.log | \
+///   grep -oE 'step="[^"]+" elapsed_ms=[0-9]+' | \
+///   sort -t= -k2 -n -r | head -10
+/// ```
+///
+/// Surfaces hottest steps for Phase 1+ optimization candidate selection.
+/// Pure instrumentation: zero behavior change, single `tracing::info!` per
+/// step. Generic over the wrapped fn's return type so it composes with both
+/// statement-style sites (`()` return) and expression-style sites (e.g.
+/// `Option<AttachedFleet>` from `try_attach`).
+pub(crate) fn time_step<T>(name: &'static str, f: impl FnOnce() -> T) -> T {
+    let t0 = std::time::Instant::now();
+    let result = f();
+    // Use default target (crate module path) so `tracing_test::traced_test`
+    // captures the event. Operator-side filtering uses the "bootstrap-step"
+    // message string + structured `step=` field — both grep-friendly.
+    tracing::info!(
+        step = name,
+        elapsed_ms = t0.elapsed().as_millis() as u64,
+        "bootstrap-step"
+    );
+    result
+}
+
 /// RAII guard for the daemon-exclusive `.daemon.lock` flock.
 ///
 /// Dropping the struct releases the lock. Keep this alive for the entire
@@ -130,16 +158,22 @@ impl Default for PrepareOptions {
 pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<BootstrapOutcome> {
     std::fs::create_dir_all(home).with_context(|| format!("create home {}", home.display()))?;
 
-    if let Some(attached) = try_attach(home, fleet_path)? {
+    // #945 Phase 0 instrumentation: every reconcile / sweep / migration
+    // step in `prepare` + `run_core` is wrapped with `time_step` so the
+    // operator can post-boot grep `bootstrap-step` log lines for an
+    // empirical timing distribution.
+    if let Some(attached) = time_step("try_attach (pre-lock)", || try_attach(home, fleet_path))? {
         return Ok(BootstrapOutcome::Attached(attached));
     }
 
-    let lock = acquire_daemon_lock(home)?;
+    let lock = time_step("acquire_daemon_lock", || acquire_daemon_lock(home))?;
 
     // Re-check after lock acquired: someone may have raced between the early
     // check and the lock grant. If so, release our lock (by dropping) and
     // return Attached — another daemon owns the truth.
-    if let Some(attached) = try_attach(home, fleet_path)? {
+    if let Some(attached) = time_step("try_attach (post-lock-TOCTOU)", || {
+        try_attach(home, fleet_path)
+    })? {
         drop(lock);
         return Ok(BootstrapOutcome::Attached(attached));
     }
@@ -150,17 +184,23 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     // one `find_active_run_dir` visits on a later app launch can lure that
     // process into attaching to a dead daemon (symptom: input lag from 2s
     // port-poll hitting closed sockets).
-    crate::daemon::sweep_stale_run_dirs(home);
+    time_step("sweep_stale_run_dirs", || {
+        crate::daemon::sweep_stale_run_dirs(home);
+    });
     // #933: alive-but-stale zombie sweep — complements the dead-PID sweep
     // above. Always-on telemetry log per candidate; destructive kill is
     // env-gated via AGEND_DAEMON_BOOT_SWEEP_AGE_DAYS=N. Reuses #927 PR-B
     // primitives (`admin::cleanup_zombies`).
-    let _ = crate::daemon::boot_sweep::boot_sweep_zombies(home);
+    time_step("boot_sweep_zombies", || {
+        crate::daemon::boot_sweep::boot_sweep_zombies(home);
+    });
     // #942/#943: rename legacy-format watch files (DefaultHasher+non-canonical)
     // to canonical+sha256 form. One-shot at boot; idempotent on repeated runs.
     // Active migration (option b from dev-2 cross-audit Pushback 3) prevents
     // the 72h duplicate-notification window across the hash-scheme transition.
-    let _ = crate::daemon::ci_watch::migration::migrate_legacy_watch_filenames(home);
+    time_step("migrate_legacy_watch_filenames", || {
+        crate::daemon::ci_watch::migration::migrate_legacy_watch_filenames(home);
+    });
 
     let run_dir = crate::daemon::run_dir(home);
     std::fs::create_dir_all(&run_dir)
@@ -180,30 +220,44 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
 
     let agents = if opts.resolve_agents {
         let fleet_dir = fleet_path.parent().unwrap_or(home);
-        agent_resolve::resolve(&config, fleet_dir, home)
+        time_step("agent_resolve::resolve", || {
+            agent_resolve::resolve(&config, fleet_dir, home)
+        })
     } else {
         Vec::new()
     };
 
     let telegram = if opts.init_telegram {
-        telegram_init::init(&config, home)
+        time_step("telegram_init::init", || telegram_init::init(&config, home))
     } else {
         None
     };
 
     // agend-git-shim init (shared by daemon + app mode).
-    crate::protocol::extract_default(home);
-    crate::binding::reconcile_hooks(home);
-    crate::binding::symlink_shim(home);
-    crate::binding::reconcile_orphans(home);
-    crate::worktree_pool::reconcile_orphan_leases(home);
+    time_step("protocol::extract_default", || {
+        crate::protocol::extract_default(home);
+    });
+    time_step("binding::reconcile_hooks", || {
+        crate::binding::reconcile_hooks(home);
+    });
+    time_step("binding::symlink_shim", || {
+        crate::binding::symlink_shim(home);
+    });
+    time_step("binding::reconcile_orphans", || {
+        crate::binding::reconcile_orphans(home);
+    });
+    time_step("worktree_pool::reconcile_orphan_leases", || {
+        crate::worktree_pool::reconcile_orphan_leases(home);
+    });
     // #852 PR-C: canonical-repo hygiene. Scan distinct source_repo
     // values from fleet.yaml; for each canonical, auto-switch
     // detached HEAD back to main if the working tree is clean, or
     // warn-log if dirty (operator WIP protection). Pure observation
     // beyond the single `git switch main` mutation when conditions
     // are right. Best-effort — boot continues regardless.
-    canonical_hygiene::run_hygiene(&config);
+    time_step("canonical_hygiene::run_hygiene", || {
+        canonical_hygiene::run_hygiene(&config);
+    });
     // #829 Fix A: boot-time orphan-owner sweep. We pass `live = ∅`
     // explicitly because `api::serve` hasn't bound the Unix socket
     // yet (that happens later in `daemon::run_with_prepared`) and no
@@ -216,7 +270,9 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     // "agent not yet spawned" case isn't over-orphaned. Periodic
     // post-boot callers should keep using `reconcile_orphan_owners`
     // which still fetches `live` from the running daemon.
-    crate::tasks::reconcile_orphan_owners_with_live(home, &std::collections::HashSet::new());
+    time_step("tasks::reconcile_orphan_owners_with_live", || {
+        crate::tasks::reconcile_orphan_owners_with_live(home, &std::collections::HashSet::new());
+    });
 
     Ok(BootstrapOutcome::Owned(Box::new(OwnedFleet {
         home: home.to_path_buf(),
@@ -593,6 +649,88 @@ mod tests {
         assert_eq!(
             surviving, planted_cookie,
             "cookie bytes must be unchanged — try_attach must not have rewritten"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #945 Phase 0 instrumentation tests ──
+
+    /// Unit: `time_step` calls the wrapped fn exactly once and emits a
+    /// `bootstrap-step` log line carrying the expected `step` + `elapsed_ms`
+    /// fields.
+    #[tracing_test::traced_test]
+    #[test]
+    fn time_step_emits_log_with_step_name_and_elapsed_ms() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let counter = AtomicU32::new(0);
+        let result = time_step("test_step_name", || {
+            counter.fetch_add(1, Ordering::Relaxed);
+            42
+        });
+        assert_eq!(result, 42, "wrapped fn return value must pass through");
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            1,
+            "wrapped fn must be called exactly once"
+        );
+        assert!(
+            logs_contain("bootstrap-step"),
+            "log must include the bootstrap-step message"
+        );
+        assert!(
+            logs_contain("test_step_name"),
+            "log must include the step name field"
+        );
+        assert!(
+            logs_contain("elapsed_ms"),
+            "log must include the elapsed_ms field"
+        );
+    }
+
+    /// Integration: `prepare` emits at least 13 `bootstrap-step` log lines
+    /// covering the canonical reconcile / sweep / migration steps. We don't
+    /// pin the exact count (sites may grow over time) but assert every
+    /// step name we instrumented is present.
+    #[tracing_test::traced_test]
+    #[test]
+    fn prepare_emits_bootstrap_step_lines_for_every_instrumented_site() {
+        let home = tmp_home("945-bootstrap-steps");
+        let fleet = write_minimal_fleet(&home);
+        // resolve_agents=false keeps the test fast (no agent worktree
+        // creation) while still exercising every other step.
+        let opts = PrepareOptions {
+            mutate_fleet_yaml: false,
+            init_telegram: false,
+            resolve_agents: false,
+        };
+        let _ = prepare(&home, &fleet, opts).expect("prepare must succeed");
+
+        // Canonical step names instrumented in `prepare`. New sites added
+        // by future PRs should also appear here so the test catches
+        // regressions where someone strips the `time_step` wrapper.
+        let expected_steps = [
+            "try_attach (pre-lock)",
+            "acquire_daemon_lock",
+            "sweep_stale_run_dirs",
+            "boot_sweep_zombies",
+            "migrate_legacy_watch_filenames",
+            "protocol::extract_default",
+            "binding::reconcile_hooks",
+            "binding::symlink_shim",
+            "binding::reconcile_orphans",
+            "worktree_pool::reconcile_orphan_leases",
+            "canonical_hygiene::run_hygiene",
+            "tasks::reconcile_orphan_owners_with_live",
+        ];
+        for step in expected_steps {
+            assert!(
+                logs_contain(step),
+                "prepare must emit bootstrap-step for `{step}`"
+            );
+        }
+        assert!(
+            logs_contain("bootstrap-step"),
+            "logs must include the bootstrap-step message marker"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -399,10 +399,12 @@ fn run_core(
     // GC sites added later would pass currently-resolved digests.
     // Best-effort: failures log + continue, never block boot.
     const SKILLS_STAGE_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
-    match crate::skills::cleanup_stale_stages(home, SKILLS_STAGE_RETENTION_SECS, &[]) {
-        Ok(report) => tracing::info!(?report, "skills-stage GC: daemon-init sweep complete"),
-        Err(e) => tracing::warn!(error = %e, "skills-stage GC: daemon-init sweep failed"),
-    }
+    crate::bootstrap::time_step("skills::cleanup_stale_stages", || {
+        match crate::skills::cleanup_stale_stages(home, SKILLS_STAGE_RETENTION_SECS, &[]) {
+            Ok(report) => tracing::info!(?report, "skills-stage GC: daemon-init sweep complete"),
+            Err(e) => tracing::warn!(error = %e, "skills-stage GC: daemon-init sweep failed"),
+        }
+    });
 
     // Sprint 63 W1 PR-2 (Sprint 58 P2 #5): sweep stale `*.tmp` /
     // `*.json.tmp` orphans under <home>/dedup-state/ left behind by
@@ -412,8 +414,9 @@ fn run_core(
     // Best-effort: failures log + continue (function returns
     // DedupStateGcReport directly, no Err path).
     const DEDUP_TMP_RETENTION_SECS: u64 = 24 * 60 * 60;
-    let dedup_report =
-        crate::daemon::dedup_state::cleanup_tmp_orphans(home, DEDUP_TMP_RETENTION_SECS);
+    let dedup_report = crate::bootstrap::time_step("dedup_state::cleanup_tmp_orphans", || {
+        crate::daemon::dedup_state::cleanup_tmp_orphans(home, DEDUP_TMP_RETENTION_SECS)
+    });
     tracing::info!(?dedup_report, "dedup-state GC: daemon-init sweep complete");
 
     // Sprint 24 P0 PR2 — bridge-phase legacy migration. Walks tasks.json
@@ -423,7 +426,11 @@ fn run_core(
     // tool registration / agent spawn so operators never observe a "list
     // empty" race. Fail-loud: any error aborts daemon startup so the
     // operator sees the failure rather than silently inconsistent state.
-    match crate::tasks::migrate_legacy_tasks_json_to_event_log(home) {
+    let legacy_migration =
+        crate::bootstrap::time_step("tasks::migrate_legacy_tasks_json_to_event_log", || {
+            crate::tasks::migrate_legacy_tasks_json_to_event_log(home)
+        });
+    match legacy_migration {
         Ok(rep) => tracing::info!(
             migrated = rep.migrated,
             skipped = rep.skipped,
@@ -488,27 +495,29 @@ fn run_core(
 
     tracing::info!(count = agents.len(), "starting agents");
 
-    for def in &agents {
-        // #896 Option D: spawn_and_register_agent now rolls back on
-        // synchronous TUI prep failure and returns Err. We log + skip
-        // the affected agent rather than aborting the entire daemon
-        // startup — operator sees `agend-terminal list` shorter than
-        // fleet.yaml expected + daemon log explains which agent failed
-        // and why. Daemon-as-a-whole stays up so the surviving agents
-        // are still usable while the operator investigates.
-        if let Err(e) =
-            spawn_and_register_agent(home, def, &registry, &configs, &crash_tx, &shutdown)
-        {
-            tracing::error!(
-                agent = %def.0,
-                error = %e,
-                "spawn_and_register_agent rolled back; agent NOT in fleet"
-            );
+    crate::bootstrap::time_step("agent_spawn_loop", || {
+        for def in &agents {
+            // #896 Option D: spawn_and_register_agent now rolls back on
+            // synchronous TUI prep failure and returns Err. We log + skip
+            // the affected agent rather than aborting the entire daemon
+            // startup — operator sees `agend-terminal list` shorter than
+            // fleet.yaml expected + daemon log explains which agent failed
+            // and why. Daemon-as-a-whole stays up so the surviving agents
+            // are still usable while the operator investigates.
+            if let Err(e) =
+                spawn_and_register_agent(home, def, &registry, &configs, &crash_tx, &shutdown)
+            {
+                tracing::error!(
+                    agent = %def.0,
+                    error = %e,
+                    "spawn_and_register_agent rolled back; agent NOT in fleet"
+                );
+            }
+            if agents.len() > 1 {
+                std::thread::sleep(spawn_stagger());
+            }
         }
-        if agents.len() > 1 {
-            std::thread::sleep(spawn_stagger());
-        }
-    }
+    });
 
     // #922: write `<run_dir>/.ready` to signal daemon-init-complete —
     // the 4th lifecycle file alongside `.daemon` / `api.cookie` / `api.port`
@@ -522,10 +531,12 @@ fn run_core(
     // sub-stage signals extend `.ready`'s content (JSON payload), not
     // add new files. Cleanup is automatic via `remove_dir_all(run_dir)`
     // at shutdown (no new code path).
-    let ready_path = run_dir(home).join(".ready");
-    if let Err(e) = std::fs::write(&ready_path, chrono::Utc::now().to_rfc3339()) {
-        tracing::warn!(path = %ready_path.display(), error = %e, "failed to write .ready marker");
-    }
+    crate::bootstrap::time_step("ready_marker_write", || {
+        let ready_path = run_dir(home).join(".ready");
+        if let Err(e) = std::fs::write(&ready_path, chrono::Utc::now().to_rfc3339()) {
+            tracing::warn!(path = %ready_path.display(), error = %e, "failed to write .ready marker");
+        }
+    });
 
     // Shutdown wake channel — signal handler sends on this so the main loop's
     // select! wakes immediately instead of waiting up to 10s for the next tick.


### PR DESCRIPTION
## Summary

Closes #945 Phase 0 (\"don't optimize blind\").

Pure instrumentation. Zero behavior change. Wraps every reconcile / sweep / migration / spawn step in `bootstrap::prepare` + `daemon::run_core` + `api::serve` port bind with a `time_step` helper that emits `tracing::info!(step = \"<name>\", elapsed_ms = ..., \"bootstrap-step\")`. After this PR, operator post-boot extracts cold-start timing distribution from `daemon.log` via grep/awk; data drives Phase 1+ optimization decisions.

Per dev-2 spike's (a) recommendation. Single commit (no RED→GREEN split needed — instrumentation is additive; tests assert log-line presence pre-fix would inherently fail since the calls don't exist yet).

## 17 sites instrumented

### `bootstrap::prepare` (12 sites via `time_step` helper)
- `try_attach (pre-lock)` and `try_attach (post-lock-TOCTOU)` (TOCTOU pair)
- `acquire_daemon_lock`
- `sweep_stale_run_dirs`
- `boot_sweep_zombies` (#933)
- `migrate_legacy_watch_filenames` (#942/#943)
- `agent_resolve::resolve` (start mode only)
- `telegram_init::init` (init_telegram=true only)
- `protocol::extract_default`
- `binding::reconcile_hooks` / `symlink_shim` / `reconcile_orphans`
- `worktree_pool::reconcile_orphan_leases`
- `canonical_hygiene::run_hygiene`
- `tasks::reconcile_orphan_owners_with_live`

### `daemon::run_core` (4 sites)
- `skills::cleanup_stale_stages` (Skill GC)
- `dedup_state::cleanup_tmp_orphans`
- `tasks::migrate_legacy_tasks_json_to_event_log`
- `agent_spawn_loop` (wraps the entire N-agent loop)
- `ready_marker_write` (#922)

### `api::serve` (1 site, special-case)
- `api::serve::bind_and_publish_port` — instrumented INSIDE serve() rather than wrapping the `std::thread::spawn` in run_core, because the spawn itself is sub-ms; the value is the bind + port-publish step

## Operator runbook (production)

```bash
# After this PR merges, restart daemon and capture cold-start timing:
agend-terminal stop && agend-terminal start --foreground &
sleep 30  # let bootstrap complete + Skill GC settle
grep \"bootstrap-step\" \$AGEND_HOME/daemon.log

# Extract top-10 hottest steps for Phase 1 optimization:
grep \"bootstrap-step\" \$AGEND_HOME/daemon.log | \\
  grep -oE 'step=\"[^\"]+\" elapsed_ms=[0-9]+' | \\
  sort -t= -k2 -n -r | head -10

# Full distribution (TSV-friendly):
grep \"bootstrap-step\" \$AGEND_HOME/daemon.log | \\
  awk -F'step=\"|\" elapsed_ms=' '{print \$2\"\\t\"\$3}'
```

## Tests

- **Unit** `time_step_emits_log_with_step_name_and_elapsed_ms` — pure helper contract: wrapped fn called exactly once, return-value passes through, log carries `step=` + `elapsed_ms`.
- **Integration** `prepare_emits_bootstrap_step_lines_for_every_instrumented_site` — runs `prepare` end-to-end with `resolve_agents=false` (fast), asserts all 12 canonical `prepare` step names appear in captured logs via `tracing_test::traced_test`.

Both tests use the default tracing target (crate module path); a `target: \"bootstrap-step\"` custom target was tried but bypassed `tracing_test`'s capture filter — removed.

## LOC

| Component | LOC |
|---|---|
| `time_step` helper | +14 |
| 12 prepare sites | +48 |
| 4 run_core sites | +16 |
| 1 api::serve site | +9 |
| 2 tests | +80 |
| **Net** | **~167** |

Higher than the spike's ~38-LOC estimate because each `time_step(\"name\", || { ... })` closure adds ~3 LOC vs the spike's 2-LOC per-step accounting. Still well under §3.6 100-LOC impl threshold (impl-only is ~87 LOC).

§3.6 single-reviewer eligible. §3.5 dual NOT triggered. §3.20 NOT race-class.

## Out of scope (deferred to Phase 0.5 / Phase 1+)

- `BootstrapTiming` struct + final summary line — Phase 0.5 upgrade path. Add when operator wants live summary instead of awk-over-grep
- Phase 1+ optimizations (caching, parallelization, step ordering) — defer until operator has real cold-start numbers to identify hotspots
- Per-agent timing inside the spawn loop — Phase 0 instruments the loop as a whole; per-agent breakdown is a Phase 1 follow-up if the loop is hot
- Conversion to `event_log` JSONL emission — per spike, `tracing::info!` + #914 rolling appender is sufficient; JSONL adds redundant log channels for the same data

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test bootstrap::tests::time_step bootstrap::tests::prepare_emits → 2/2 pass
- [x] cargo test --bin agend-terminal → 2486/2486 (no regressions)
- [ ] CI 5/5 green
- [ ] Reviewer VERIFIED

Closes #945 Phase 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)