### PR TITLE
docs: hoist Git Behavior detail out of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,56 +13,11 @@ agend-terminal demo    # Try it in 30 seconds
 
 ## ⚠️ Git Behavior Modification (Important)
 
-agend-terminal does **not** run AI agents against vanilla `git`. To coordinate multiple agents safely on the same repo, the daemon installs a thin shim layer between agents and your real `git` binary. **Read this section before installing** — once you start the daemon, the modifications below take effect.
+agend-terminal modifies git behavior for spawned agents (PATH shim, commit
+trailers, deny matrix, daemon-managed worktrees). Your own terminal is
+**not** affected.
 
-### What gets modified
-
-- **PATH shim for agent processes.** A symlink at `$AGEND_HOME/bin/git` points to a small Rust binary (`agend-git`). When the daemon spawns an agent's PTY, that path is prepended to the agent's `PATH`. Agents that invoke `git` end up running the shim; the shim forwards almost every command to your real `git` (resolved via `AGEND_REAL_GIT` or `which`).
-- **Per-worktree commit hooks.** For agent-managed worktrees, the daemon points `core.hooksPath` to `$AGEND_HOME/hooks` and installs a `prepare-commit-msg` hook that appends `Agend-Agent`, `Agend-Branch`, `Agend-Issued-At`, and (when present) `Agend-Task` trailers to the commit message. Trailers are skipped if already present (idempotent).
-- **Deny matrix on agent git ops.** The shim refuses certain commands from unbound or cross-branch contexts: `git worktree add/remove/move`, `git checkout` of a different branch, etc. The daemon owns the worktree pool — see Phase 3 lease in `docs/proposals/agend-git-shim.md`.
-- **Auto bind/lease on dispatch (or via `bind_self`).** When you delegate a task to an agent with a `branch` field, the daemon auto-creates a managed worktree, marks it with a `.agend-managed` file, and writes a `binding.json` recording the agent → branch link.
-- **Worktree lifecycle is daemon-managed.** Cleanup is via the `release_worktree` MCP tool, not direct `git worktree remove`. A daemon-side hourly GC sweep flags stale entries (currently dry-run only; not auto-deleted).
-
-### Why
-
-- **Multi-agent safety.** Multiple AI agents working in the same repo without isolation will race on the same branch. Per-agent worktrees make that impossible at the git layer rather than relying on agent-side discipline.
-- **Audit trail.** `Agend-Agent: <name>` trailer answers "which agent made this commit?" without parsing chat logs. Useful when reviewing autonomous work, much more useful when something went wrong.
-- **Lifecycle hygiene.** Crashed agents, stale dispatches, and abandoned branches accumulate fast in a multi-agent setup. The daemon's bind/lease/release gives the cleanup work a single owner.
-- **Safety guard rails.** The deny matrix catches the obvious foot-guns (agents accidentally checking out `main`, deleting other agents' worktrees) at the shim layer instead of after the fact.
-
-### Risk
-
-- **Agents see a different `git` than you do.** The PATH injection only happens inside agent PTYs spawned by the daemon. Your own terminal's `git` is unchanged. But if you compare what an agent did against `git log` from your shell, the agent's command went through the shim and the shim may have intercepted it. Set `AGEND_GIT_BYPASS=1` if you need to reproduce an agent's exact bare-`git` behavior.
-- **Commits gain extra trailers.** Tools that parse commit messages strictly (some changelog generators, some CLA bots) may need their parsers updated. Standard `git log --format` output is unaffected; the trailers are appended after the commit body.
-- **Some commands deny unexpectedly.** A new agent or operator unfamiliar with the bind/lease lifecycle will see `agend-git: ERROR ... HINT: ...` errors when running `git worktree add` or `git checkout main`. The error message names the reason and the override path. This is intentional, but it surprises people the first time.
-- **Restart needed to pick up changes.** After upgrading, `cargo build --release` and restart the daemon. The shim binary path is fixed at startup; in-flight agents do not pick up new shim logic until they respawn.
-
-### How to opt out / bypass
-
-Routine operations inside your bound worktree (`status`, `diff`, `log`, `add`, `commit`, `push origin <your-branch>`, `fetch`, `checkout <existing-branch>` within the same repo) **pass through the shim cleanly** — no bypass needed. Try bare `git` first; if the shim denies, the deny message will name the reason.
-
-For the operations that legitimately need bypass:
-
-```bash
-# One-off command
-AGEND_GIT_BYPASS=1 AGEND_GIT_BYPASS_AGENT=<name> git worktree add ...
-
-# Per-agent persistent override
-export AGEND_GIT_BYPASS_AGENT=<name>
-
-# Time-bounded bypass (Unix epoch)
-export AGEND_GIT_BYPASS_UNTIL=$(date -v +1H +%s)
-```
-
-Skipping the shim skips the safety net (trailer, deny matrix, registry). Use it for explicitly intended overrides (operator manual cleanup, daemon's own internal git ops, etc.) and not as the default.
-
-**Operator's own terminal is not affected.** The PATH injection only happens inside agent PTYs spawned by the daemon. `which git` from your shell still resolves to your normal `git` binary.
-
-### Where to read more
-
-- [`docs/FLEET-DEV-PROTOCOL.md`](docs/FLEET-DEV-PROTOCOL.md) §13 — full bypass guideline
-- [`docs/proposals/agend-git-shim.md`](docs/proposals/agend-git-shim.md) — design doc covering Phases 1-5
-- PRs [#446](https://github.com/suzuke/agend-terminal/pull/446) (Phase 1 trailer) · [#447](https://github.com/suzuke/agend-terminal/pull/447) (Phase 2 deny matrix) · [#449](https://github.com/suzuke/agend-terminal/pull/449) (Phase 3 lease) · [#454](https://github.com/suzuke/agend-terminal/pull/454) (Phase 4 GC dry-run) · [#455](https://github.com/suzuke/agend-terminal/pull/455) (Phase 5 hotspot)
+**Read [`docs/GIT-BEHAVIOR.md`](docs/GIT-BEHAVIOR.md) before starting the daemon** — what gets modified, why, the risk surface, and the opt-out paths are all documented there.
 
 ## What It Does
 
@@ -89,10 +44,10 @@ multi-pane TUI, a Telegram channel, or an optional system tray.
 # Demo (no config)
 agend-terminal demo
 
-# Interactive setup — detects backends, wires Telegram, writes fleet.yaml
+# Interactive setup — detects backends, optionally wires Telegram, writes fleet.yaml
 agend-terminal quickstart
 
-# Or hand-write:
+# Or hand-write a minimum fleet.yaml and start the daemon:
 cat > ~/.agend/fleet.yaml << 'YAML'
 defaults:
   backend: claude
@@ -103,19 +58,11 @@ instances:
   reviewer:
     role: "Code reviewer"
     working_directory: ~/my-project
-
-# Optional: bind the fleet to a Telegram group for remote control + alerts.
-# `user_allowlist` is REQUIRED to receive outbound notifications (stall /
-# crash / CI alerts). Without it, the fleet runs but the bound group is
-# muted (fail-closed default — see docs/USAGE.md "Channel: Telegram").
-# channel:
-#   type: telegram
-#   bot_token_env: AGEND_BOT_TOKEN
-#   group_id: YOUR_GROUP_ID
-#   user_allowlist: [YOUR_TELEGRAM_USER_ID]   # message @userinfobot to get yours
 YAML
 agend-terminal start
 ```
+
+For optional Telegram binding (remote control + outbound alerts), see [`docs/USAGE.md` § Channel: Telegram](docs/USAGE.md#channel-telegram).
 
 ## Backends
 

--- a/docs/GIT-BEHAVIOR.md
+++ b/docs/GIT-BEHAVIOR.md
@@ -1,0 +1,52 @@
+# Git Behavior Modification
+
+agend-terminal does **not** run AI agents against vanilla `git`. To coordinate multiple agents safely on the same repo, the daemon installs a thin shim layer between agents and your real `git` binary. **Read this page before starting the daemon** — once you start it, the modifications below take effect for every spawned agent.
+
+Your own terminal is **not affected**. The PATH injection only happens inside agent PTYs spawned by the daemon. `which git` from your shell still resolves to your normal `git` binary.
+
+## What gets modified
+
+- **PATH shim for agent processes.** A symlink at `$AGEND_HOME/bin/git` points to a small Rust binary (`agend-git`). When the daemon spawns an agent's PTY, that path is prepended to the agent's `PATH`. Agents that invoke `git` end up running the shim; the shim forwards almost every command to your real `git` (resolved via `AGEND_REAL_GIT` or `which`).
+- **Per-worktree commit hooks.** For agent-managed worktrees, the daemon points `core.hooksPath` to `$AGEND_HOME/hooks` and installs a `prepare-commit-msg` hook that appends `Agend-Agent`, `Agend-Branch`, `Agend-Issued-At`, and (when present) `Agend-Task` trailers to the commit message. Trailers are skipped if already present (idempotent).
+- **Deny matrix on agent git ops.** The shim refuses certain commands from unbound or cross-branch contexts: `git worktree add/remove/move`, `git checkout` of a different branch, etc. The daemon owns the worktree pool — see Phase 3 lease in [`docs/proposals/agend-git-shim.md`](proposals/agend-git-shim.md).
+- **Auto bind/lease on dispatch (or via `bind_self`).** When you delegate a task to an agent with a `branch` field, the daemon auto-creates a managed worktree, marks it with a `.agend-managed` file, and writes a `binding.json` recording the agent → branch link.
+- **Worktree lifecycle is daemon-managed.** Cleanup is via the `release_worktree` MCP tool, not direct `git worktree remove`. A daemon-side hourly GC sweep flags stale entries (currently dry-run only; not auto-deleted).
+
+## Why
+
+- **Multi-agent safety.** Multiple AI agents working in the same repo without isolation will race on the same branch. Per-agent worktrees make that impossible at the git layer rather than relying on agent-side discipline.
+- **Audit trail.** `Agend-Agent: <name>` trailer answers "which agent made this commit?" without parsing chat logs. Useful when reviewing autonomous work, much more useful when something went wrong.
+- **Lifecycle hygiene.** Crashed agents, stale dispatches, and abandoned branches accumulate fast in a multi-agent setup. The daemon's bind/lease/release gives the cleanup work a single owner.
+- **Safety guard rails.** The deny matrix catches the obvious foot-guns (agents accidentally checking out `main`, deleting other agents' worktrees) at the shim layer instead of after the fact.
+
+## Risk
+
+- **Agents see a different `git` than you do.** The PATH injection only happens inside agent PTYs spawned by the daemon. Your own terminal's `git` is unchanged. But if you compare what an agent did against `git log` from your shell, the agent's command went through the shim and the shim may have intercepted it. Set `AGEND_GIT_BYPASS=1` if you need to reproduce an agent's exact bare-`git` behavior.
+- **Commits gain extra trailers.** Tools that parse commit messages strictly (some changelog generators, some CLA bots) may need their parsers updated. Standard `git log --format` output is unaffected; the trailers are appended after the commit body.
+- **Some commands deny unexpectedly.** A new agent or operator unfamiliar with the bind/lease lifecycle will see `agend-git: ERROR ... HINT: ...` errors when running `git worktree add` or `git checkout main`. The error message names the reason and the override path. This is intentional, but it surprises people the first time.
+- **Restart needed to pick up changes.** After upgrading, `cargo build --release` and restart the daemon. The shim binary path is fixed at startup; in-flight agents do not pick up new shim logic until they respawn.
+
+## How to opt out / bypass
+
+Routine operations inside your bound worktree (`status`, `diff`, `log`, `add`, `commit`, `push origin <your-branch>`, `fetch`, `checkout <existing-branch>` within the same repo) **pass through the shim cleanly** — no bypass needed. Try bare `git` first; if the shim denies, the deny message will name the reason.
+
+For the operations that legitimately need bypass:
+
+```bash
+# One-off command
+AGEND_GIT_BYPASS=1 AGEND_GIT_BYPASS_AGENT=<name> git worktree add ...
+
+# Per-agent persistent override
+export AGEND_GIT_BYPASS_AGENT=<name>
+
+# Time-bounded bypass (Unix epoch)
+export AGEND_GIT_BYPASS_UNTIL=$(date -v +1H +%s)
+```
+
+Skipping the shim skips the safety net (trailer, deny matrix, registry). Use it for explicitly intended overrides (operator manual cleanup, daemon's own internal git ops, etc.) and not as the default.
+
+## Where to read more
+
+- [`docs/FLEET-DEV-PROTOCOL.md`](FLEET-DEV-PROTOCOL.md) §13 — full bypass guideline
+- [`docs/proposals/agend-git-shim.md`](proposals/agend-git-shim.md) — design doc covering Phases 1–5
+- PRs [#446](https://github.com/suzuke/agend-terminal/pull/446) (Phase 1 trailer) · [#447](https://github.com/suzuke/agend-terminal/pull/447) (Phase 2 deny matrix) · [#449](https://github.com/suzuke/agend-terminal/pull/449) (Phase 3 lease) · [#454](https://github.com/suzuke/agend-terminal/pull/454) (Phase 4 GC dry-run) · [#455](https://github.com/suzuke/agend-terminal/pull/455) (Phase 5 hotspot)


### PR DESCRIPTION
## Summary

Operator request: \"README的部分只要放重點，不要長篇大論，需要額外解釋的可以用link的方式\".

| Section | Before | After | Change |
|---|---|---|---|
| Git Behavior Modification (L14-65) | 51 lines | 7 lines + link | -44 |
| Quick Start (L86-118) | 33 lines | 25 lines | -8 |
| **README total** | **140 lines** | **87 lines** | **-53** |

## What moved

- README L14-65 (5 subsections: What gets modified / Why / Risk / How to opt out / Where to read more) → new \`docs/GIT-BEHAVIOR.md\` (content preserved verbatim; H1 heading + one-line \"your own terminal is not affected\" lede reformatted at top of the new doc).
- Quick Start's commented-out Telegram YAML block → one-line link to \`docs/USAGE.md § Channel: Telegram\` (already documents the same field set + user_allowlist semantics in detail).

## What stayed

- ⚠️ Warning + bolded \"Read [...] before starting the daemon\" callout preserved in README — operator still sees the heads-up at a glance.
- Pre-alpha warning, install snippet, What It Does, Why Not tmux?, Backends, Learn More, License — all unchanged per lead's section-by-section audit.
- Quick Start retains the minimum \`fleet.yaml\` hand-write example so the \"copy-paste to first start\" path still works without leaving the README.

## Test plan
- [x] README still has the ⚠️ Git Behavior callout near the top
- [x] Link \`docs/GIT-BEHAVIOR.md\` resolves on GitHub
- [x] All 5 subsection contents preserved (diff is move-only, no information loss)
- [x] \`docs/USAGE.md#channel-telegram\` anchor exists (existing § \"Channel: Telegram\")
- [x] No production code edits (\`git diff --stat\` shows README.md + new docs/GIT-BEHAVIOR.md only)
- [ ] CI 5/5 green (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)