### PR TITLE
fix(#962): 3-layer hybrid for silent fleet.yaml persist failures — Closes #962

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -252,13 +252,37 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
                 result["topic_id"] = json!(tid);
                 // Persist topic_id to fleet.yaml so daemon can route messages
                 // to this instance's topic on restart (#415).
+                //
+                // #962: consume the Result<bool> from update_instance_field so
+                // the MCP response carries `topic_persisted: false` (and
+                // optionally `topic_persist_error`) when the persist silently
+                // no-op'd or hit an IO error. Pre-#962 the `let _ = ...` swallow
+                // surfaced as demo-blocking "topic_id: null" fleet.yaml rows.
                 if let Ok(tid_num) = tid.parse::<i32>() {
-                    let _ = crate::fleet::update_instance_field(
+                    match crate::fleet::update_instance_field(
                         ctx.home,
                         name,
                         "topic_id",
                         serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(tid_num)),
-                    );
+                    ) {
+                        Ok(true) => { /* persisted — happy path stays minimal */ }
+                        Ok(false) => {
+                            // Silent no-op already warn-logged inside
+                            // update_instance_field. Surface to MCP caller so
+                            // automation (replace_instance, operator scripts)
+                            // can detect partial-success without daemon.log grep.
+                            result["topic_persisted"] = json!(false);
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                agent = name,
+                                error = %e,
+                                "update_instance_field failed — topic_id NOT persisted to fleet.yaml"
+                            );
+                            result["topic_persisted"] = json!(false);
+                            result["topic_persist_error"] = json!(format!("{e}"));
+                        }
+                    }
                 }
             }
             json!({"ok": true, "result": result})

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -292,11 +292,34 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
     // handle_spawn can read this instance's role and the full peer list
     // when building the AgentContext for its agend.md. Single lock take
     // for the whole batch.
+    //
+    // #962 Layer 3: hard-fail if persist fails. Pre-#962 this was
+    // warn-and-continue, which let Phase 3 spawn instances NOT in
+    // fleet.yaml — `update_instance_field` then silently no-op'd
+    // topic_id persistence (the root cause of operator's demo bug:
+    // 3 demo agents with topic_id=null). Fail-fast here surfaces the
+    // upstream failure immediately and prevents the partial-success
+    // state where agents spawn but fleet.yaml is missing entries.
     if !yaml_entries.is_empty() {
         let refs: Vec<(&str, &crate::fleet::InstanceYamlEntry)> =
             yaml_entries.iter().map(|(n, e)| (n.as_str(), e)).collect();
         if let Err(e) = crate::fleet::add_instances_to_yaml(home, &refs) {
-            tracing::warn!(error = %e, "failed to persist deployment to fleet.yaml");
+            tracing::error!(
+                error = %e,
+                template = template,
+                deploy_name = deploy_name,
+                count = yaml_entries.len(),
+                "deploy_template: Phase 2 add_instances_to_yaml failed — aborting before Phase 3 spawn"
+            );
+            return serde_json::json!({
+                "error": format!(
+                    "deploy_template: failed to persist {} instance(s) to fleet.yaml: {e} \
+                     — Phase 3 spawn aborted to prevent partial-success state \
+                     (no agents spawned)",
+                    yaml_entries.len()
+                ),
+                "code": "deploy_yaml_persist_failed",
+            });
         }
     }
 

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -1025,21 +1025,69 @@ pub fn update_channel_telegram_group_id(home: &Path, new_group_id: i64) -> Resul
 }
 
 /// Update a specific field of an instance in fleet.yaml. Uses file lock + atomic write.
+/// Update a single field on an instance entry in fleet.yaml. Returns
+/// `Ok(true)` when the mutation actually fired (entry found + writable),
+/// `Ok(false)` when the call silently no-ops (one of three documented
+/// paths: fleet.yaml missing / instance entry missing / entry not a
+/// mapping). Err only fires for lock contention, YAML parse failure,
+/// or atomic-write IO error.
+///
+/// #962: pre-fix every silent no-op returned `Ok(())` and callers
+/// could not distinguish "persisted" from "silently dropped on the
+/// floor". The empirical demo-blocking bug rooted in this exact gap:
+/// `deployments.rs:298-300` warn-and-continued past a Phase 2 fleet.yaml
+/// write failure, then `handle_spawn:256` called this function on an
+/// instance entry that didn't exist — silently no-op'd `topic_id`
+/// persistence for all 3 demo agents.
+///
+/// Post-fix `Result<bool>` lets callers detect partial-success. Internal
+/// `tracing::warn!` fires on every no-op path so even callers using
+/// `let _ = update_instance_field(...)` get an audit trail.
 pub fn update_instance_field(
     home: &Path,
     name: &str,
     field: &str,
     value: serde_yaml_ng::Value,
-) -> Result<()> {
+) -> Result<bool> {
+    let fleet_path = fleet_yaml_path(home);
+    if !fleet_path.exists() {
+        tracing::warn!(
+            instance = name,
+            field = field,
+            reason = "fleet_yaml_missing",
+            "update_instance_field skipped — silent no-op detected"
+        );
+        return Ok(false);
+    }
+    let mut persisted = false;
+    let mut skip_reason: Option<&'static str> = None;
     mutate_fleet_yaml(home, "", |doc| {
-        if let Some(instances) = doc.get_mut("instances").and_then(|v| v.as_mapping_mut()) {
-            let key = serde_yaml_ng::Value::String(name.to_string());
-            if let Some(inst) = instances.get_mut(&key).and_then(|v| v.as_mapping_mut()) {
-                inst.insert(serde_yaml_ng::Value::String(field.to_string()), value);
-            }
-        }
+        let Some(instances) = doc.get_mut("instances").and_then(|v| v.as_mapping_mut()) else {
+            skip_reason = Some("instances_section_missing");
+            return Ok(());
+        };
+        let key = serde_yaml_ng::Value::String(name.to_string());
+        let Some(inst_val) = instances.get_mut(&key) else {
+            skip_reason = Some("instance_entry_missing");
+            return Ok(());
+        };
+        let Some(inst) = inst_val.as_mapping_mut() else {
+            skip_reason = Some("instance_entry_not_mapping");
+            return Ok(());
+        };
+        inst.insert(serde_yaml_ng::Value::String(field.to_string()), value);
+        persisted = true;
         Ok(())
-    })
+    })?;
+    if !persisted {
+        tracing::warn!(
+            instance = name,
+            field = field,
+            reason = skip_reason.unwrap_or("unknown"),
+            "update_instance_field skipped — silent no-op detected"
+        );
+    }
+    Ok(persisted)
 }
 
 /// Sprint 54 fleet-yaml teams unification: serialize a `TeamConfig` to a
@@ -3203,5 +3251,142 @@ instances:
         );
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── #962 silent-persist failure tests (Layer 1 internal tracing) ──
+    //
+    // Each test pins one of the 3 documented silent no-op paths inside
+    // `update_instance_field`. Pre-#962 all three returned `Ok(())` and
+    // callers had no way to distinguish persisted from silently-dropped.
+    // Post-#962 they return `Ok(false)` and emit `tracing::warn!` with
+    // a stable `reason` field.
+
+    fn tmp_home_962(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("agend-962-{}-{}-{}", tag, std::process::id(), id));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn update_instance_field_returns_false_when_fleet_yaml_absent() {
+        let home = tmp_home_962("absent");
+        // No fleet.yaml planted.
+        let result = update_instance_field(
+            &home,
+            "any-agent",
+            "topic_id",
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(42)),
+        );
+        assert!(
+            matches!(result, Ok(false)),
+            "missing fleet.yaml must return Ok(false), got {result:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn update_instance_field_returns_false_when_instance_entry_missing() {
+        let home = tmp_home_962("entry-missing");
+        // fleet.yaml exists but has no entry for "ghost".
+        std::fs::write(
+            fleet_yaml_path(&home),
+            "instances:\n  alpha:\n    backend: claude\n",
+        )
+        .unwrap();
+        let result = update_instance_field(
+            &home,
+            "ghost",
+            "topic_id",
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(42)),
+        );
+        assert!(
+            matches!(result, Ok(false)),
+            "missing instance entry must return Ok(false), got {result:?}"
+        );
+        // Confirm fleet.yaml unchanged.
+        let body = std::fs::read_to_string(fleet_yaml_path(&home)).unwrap();
+        assert!(!body.contains("ghost"), "ghost entry must NOT be inserted");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn update_instance_field_returns_false_when_not_mapping() {
+        let home = tmp_home_962("not-mapping");
+        // Instance entry exists but is a SCALAR (string), not a mapping.
+        std::fs::write(
+            fleet_yaml_path(&home),
+            "instances:\n  alpha: just-a-string\n",
+        )
+        .unwrap();
+        let result = update_instance_field(
+            &home,
+            "alpha",
+            "topic_id",
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(42)),
+        );
+        assert!(
+            matches!(result, Ok(false)),
+            "non-mapping entry must return Ok(false), got {result:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn update_instance_field_returns_true_on_successful_persist() {
+        let home = tmp_home_962("happy");
+        std::fs::write(
+            fleet_yaml_path(&home),
+            "instances:\n  alpha:\n    backend: claude\n",
+        )
+        .unwrap();
+        let result = update_instance_field(
+            &home,
+            "alpha",
+            "topic_id",
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(123)),
+        );
+        assert!(
+            matches!(result, Ok(true)),
+            "happy path must return Ok(true), got {result:?}"
+        );
+        let body = std::fs::read_to_string(fleet_yaml_path(&home)).unwrap();
+        assert!(
+            body.contains("topic_id: 123"),
+            "topic_id must be persisted; got:\n{body}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn update_instance_field_emits_warn_with_reason_on_each_no_op_path() {
+        // Path 2: instance entry missing.
+        let home = tmp_home_962("warn-entry-missing");
+        std::fs::write(
+            fleet_yaml_path(&home),
+            "instances:\n  alpha:\n    backend: claude\n",
+        )
+        .unwrap();
+        let _ = update_instance_field(
+            &home,
+            "ghost",
+            "topic_id",
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(42)),
+        );
+        assert!(
+            logs_contain("update_instance_field skipped"),
+            "tracing::warn! must fire on silent no-op path"
+        );
+        assert!(
+            logs_contain("instance_entry_missing"),
+            "tracing reason must identify the specific no-op path"
+        );
+        assert!(logs_contain("ghost"), "tracing must carry instance name");
+        assert!(logs_contain("topic_id"), "tracing must carry field name");
+        std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Summary

Closes #962 (demo-blocking: 3 demo agents spawned with `topic_id: null` in fleet.yaml despite `topics.json` carrying valid IDs).

**RCA shift from operator's framing**: the bug is NOT `update_instance_field` returning Err and being swallowed by `let _ = ...`. It's `update_instance_field` returning **`Ok(())` while silently no-op'ing in 3 paths**:

1. `fleet.yaml` doesn't exist (returns Ok early at line 627)
2. Instance entry missing from `instances` map (closure's `if let Some` skips silently)
3. Instance entry exists but is NOT a mapping (e.g., YAML null placeholder)

Operator's 3 fix levels (warn/surface/retry) targeted Err swallowing — but the actual demo bug almost certainly hit Path 2 (`deployments.rs:298-300` Phase 2 warn-and-continue let Phase 3 spawn proceed without instances in fleet.yaml).

## 3-Layer hybrid (~70 net LOC)

| Layer | Site | Change |
|---|---|---|
| 1 | `src/fleet.rs` `update_instance_field` | `Result<()>` → `Result<bool>` + internal `tracing::warn!` on each silent no-op path |
| 2 | `src/api/handlers/instance.rs:256` | Match on bool; populate `topic_persisted: false` + `topic_persist_error` in MCP response |
| 3 | `src/deployments.rs:298` | warn-and-continue → hard Err with `deploy_yaml_persist_failed` code |

**Side effect**: 6 existing `let _ = update_instance_field(...)` callers automatically get audit-trail observability via Layer 1's internal tracing, without caller-side code changes:
- `api/handlers/instance.rs:256` (Layer 2 also updates this site)
- `bootstrap/doctor_topics.rs:378`
- `bootstrap/fleet_normalize.rs:75`
- `channel/telegram/bootstrap.rs:140`
- `channel/telegram/error.rs:210`
- `channel/telegram/topic_registry.rs:47`

## Tests (5 mandatory passing, full suite 2500/2500)

| # | Test | Pins |
|---|---|---|
| 1 | `update_instance_field_returns_false_when_fleet_yaml_absent` | Path 1 |
| 2 | `update_instance_field_returns_false_when_instance_entry_missing` | Path 2 (demo root) |
| 3 | `update_instance_field_returns_false_when_not_mapping` | Path 3 |
| 4 | `update_instance_field_returns_true_on_successful_persist` | Happy path anchor |
| 5 | `update_instance_field_emits_warn_with_reason_on_each_no_op_path` | `tracing::warn!` capture via `tracing_test::traced_test` |

§3.10 RED→GREEN inherent: each test would fail pre-fix because `update_instance_field` returned `Result<()>` (compile error on `Ok(true)` matching). Post-fix all 5 pass.

Layer 2 + Layer 3 contracts verified by build + clippy `-D warnings` (mechanical match arms / hard-return) + 2500/2500 full suite no-regression check. Heavier Layer 2/3 specific tests deferred to follow-up if reviewer wants them — happy to add.

## Class-fix discipline (#881 / #919 alignment)

Silent no-op antipattern shared across:
- #881: notify() silently no-ops when channel is None
- #919: state detection silently misclassifies prose vs backend errors
- **#962**: update_instance_field silently no-ops on missing fleet.yaml entry

Shared discipline: any fn that COULD silently no-op MUST return a signal richer than `Result<()>`. Generalization across `fleet::update_*` callers deferred to lead-tracked follow-up issue ('Silent-degrade MEDIUM cluster cleanup') per dispatch synth.

## Operator workflow post-fix

```bash
# Hot path — daemon.log now carries audit trail for ANY silent no-op:
grep \"update_instance_field skipped\" \$AGEND_HOME/daemon.log

# MCP / replace_instance callers can detect partial-success:
agend-terminal admin spawn ... | jq '.result.topic_persisted'

# deploy_template now fails LOUD when Phase 2 fleet.yaml write fails:
agend-terminal admin deploy --template demo --directory /tmp/demo
# → \"error\": \"deploy_template: failed to persist 3 instance(s) to fleet.yaml: ... — Phase 3 spawn aborted\"
```

## Out of scope (per dispatch)

- `mutate_fleet_yaml` internal behavior (root cause is fleet.yaml content, not the helper)
- `topic_registry::create_topic_for_instance` (already emits `tracing::error!` per sister-path good pattern)
- MEDIUM cluster (dispatch_tracking / ci_watch / agent metadata persistence) — separate follow-up issue
- `agend-terminal admin migrate-instances` for existing-null `topic_id` rows — separate follow-up

## LOC

| Component | LOC |
|---|---|
| `src/fleet.rs` update_instance_field refactor + tests | +201 |
| `src/api/handlers/instance.rs:256` consume bool (Layer 2) | +28 |
| `src/deployments.rs:298` hard-fail (Layer 3) | +25 |
| **Net** | **~70 impl + ~175 test = ~245** |

§3.6 single-reviewer eligible (impl ≈ 70 LOC). §3.5 dual NOT triggered. NOT race-class per §3.20.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test update_instance_field → 7/7 pass (5 new + 2 pre-existing)
- [x] cargo test --bin agend-terminal → 2500/2500 (no regressions)
- [ ] CI 5/5 green
- [ ] Reviewer VERIFIED

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)