### PR TITLE
ci_watch: raise poll_runs page size 5 → 20

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -4067,6 +4067,32 @@ mod tests {
         );
     }
 
+    // Larger page size (POLL_RUNS_PAGE_SIZE=20) increases the chance that a
+    // single response contains runs for both the current head and prior
+    // shas (force-push, multiple pushes within poll interval). Verify that
+    // stale-sha runs never bleed into the current head's conclusion.
+    #[test]
+    fn aggregate_ignores_stale_sha_runs_in_response() {
+        let runs = vec![
+            // Current sha — all succeeded.
+            make_run(10, "current", Some("success")),
+            make_run(11, "current", Some("success")),
+            // Prior sha — failure must not leak into "current" conclusion.
+            make_run(8, "prior", Some("failure")),
+            make_run(9, "prior", Some("success")),
+        ];
+        assert_eq!(
+            aggregate_conclusion_for_sha(&runs, "current"),
+            Some("success"),
+            "stale-sha failure must not contaminate current head's aggregate"
+        );
+        assert_eq!(
+            aggregate_conclusion_for_sha(&runs, "prior"),
+            Some("failure"),
+            "prior-sha aggregate still computes independently"
+        );
+    }
+
     #[test]
     fn startup_sweep_preserves_valid_watches() {
         let home = tmp_dir("restart-persist");

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -2,6 +2,23 @@
 // Shared HTTP client for CI providers (Sprint 39 follow-up extraction)
 // ---------------------------------------------------------------------------
 
+/// Page size used by every provider's `poll_runs` query (GitHub
+/// `per_page`, GitLab `per_page`, Bitbucket `pagelen`). Caps how many of
+/// the most-recent runs on a branch we examine per poll.
+///
+/// The aggregator (`poller::aggregate_conclusion_for_sha`) groups runs
+/// by `head_sha` — only runs matching the current head contribute, the
+/// rest are filtered out, so a larger page costs ~one extra parse per
+/// stale entry and a few KB of bytes; rate-limit cost is unchanged (one
+/// call per poll regardless of page size).
+///
+/// Pre-bump value was 5. A push that fans out to ≥5 workflows would
+/// drop the oldest run from the response window, and the aggregator
+/// would silently report `success` from the surviving subset even if
+/// the dropped run failed. 20 gives 4× headroom over the present
+/// agend-terminal push fan-out and stays well under GitHub's 100-cap.
+pub(crate) const POLL_RUNS_PAGE_SIZE: u32 = 20;
+
 /// Auth scheme for CI provider HTTP requests.
 pub(crate) enum CiAuth {
     /// `Authorization: Bearer <token>` (GitHub)
@@ -268,7 +285,7 @@ impl CiProvider for GitHubCiProvider {
         let resp = self
             .http
             .get(&format!(
-                "repos/{repo}/actions/runs?branch={branch}&per_page=5"
+                "repos/{repo}/actions/runs?branch={branch}&per_page={POLL_RUNS_PAGE_SIZE}"
             ))
             .send()
             .await?;
@@ -570,7 +587,7 @@ impl CiProvider for GitLabCiProvider {
         let resp = self
             .http
             .get(&format!(
-                "projects/{project}/pipelines?ref={branch}&per_page=5"
+                "projects/{project}/pipelines?ref={branch}&per_page={POLL_RUNS_PAGE_SIZE}"
             ))
             .send()
             .await?;
@@ -786,7 +803,7 @@ impl CiProvider for BitbucketCiProvider {
         let resp = self
             .http
             .get(&format!(
-                "repositories/{repo}/pipelines/?target.branch={branch}&pagelen=5&sort=-created_on"
+                "repositories/{repo}/pipelines/?target.branch={branch}&pagelen={POLL_RUNS_PAGE_SIZE}&sort=-created_on"
             ))
             .send()
             .await?;


### PR DESCRIPTION
## Summary

- Raise `poll_runs` page size from 5 to 20 across all three CI providers (GitHub `per_page`, GitLab `per_page`, Bitbucket `pagelen`).
- Extracted as `POLL_RUNS_PAGE_SIZE` constant in `daemon/ci_watch/provider.rs` so the three providers share a single tunable.
- Added `aggregate_ignores_stale_sha_runs_in_response` test documenting the stale-sha-isolation invariant the larger page relies on.

## Motivation

Pre-bump, `per_page=5` capped each poll at the 5 most-recent runs for the branch. A push that fans out to ≥5 workflows silently drops the oldest run from the response window, and `aggregate_conclusion_for_sha` emits `[ci-pass]` from the surviving subset even when the dropped run failed.

agend-terminal already sits near that edge — push-triggered workflows include `ci.yml` and `loc-overrun-check.yml`; adding any new workflow would tip into the missed-failure window.

## Cost

- One extra parse per stale-sha run + a few KB of bytes per poll.
- Rate-limit cost is **unchanged** — GitHub charges 1 call per page request regardless of size.
- 20 stays well under GitHub's 100 cap, gives 4× headroom over current fan-out, and remains comfortably below the response-bytes regime where pagination would actually matter.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test daemon::ci_watch::poller::tests::aggregate` (6 tests pass, incl. new `aggregate_ignores_stale_sha_runs_in_response`)
- [ ] CI 5-platform green

🤖 Generated with [Claude Code](https://claude.com/claude-code)