### PR TITLE
docs: add bug report + feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,62 @@
+---
+name: Bug Report
+about: User-visible problem with witnessed evidence
+title: 'bug: '
+labels: ['bug']
+---
+
+## Symptom
+
+<!-- One sentence: what's user/operator-visible going wrong.
+Write the problem, not the fix. -->
+
+## Reproduction
+
+<!-- Minimal steps to trigger. Copy-pasteable is best.
+Example:
+1. `agend-terminal create_instance name=foo backend=claude`
+2. Wait for telegram topic (~3s)
+3. Check `~/.agend-terminal/fleet.yaml` → expected topic_id=<n>, actual null
+
+If not reliably reproducible, mark "intermittent" and describe the
+trigger conditions you've observed. -->
+
+## Expected vs Actual
+
+<!-- Expected: …
+     Actual:   … -->
+
+## Version / Environment
+
+<!-- - agend-terminal: `cargo pkgid` or commit SHA (`git rev-parse HEAD`)
+     - daemon build: commit on the first line of daemon startup log
+     - OS: macOS 14.5 / Linux Ubuntu 24.04 / Windows 11 / …
+     - Backend (if relevant): claude-code 2.1.81 / codex-cli x.x /
+       kiro-cli x.x / gemini-cli 0.42.0 / opencode x.x
+     - Shell: zsh / bash / fish -->
+
+## Concrete evidence
+
+<!-- Witness timestamp (UTC), log lines, PR/commit refs, screenshots,
+relevant inbox / fleet.yaml / topics.json snippets.
+Keep raw output verbatim; minimize jargon when paraphrasing. -->
+
+## Root cause (if known)
+
+<!-- file:line where the bug lives. Skip this section if you haven't
+traced it yet — operator may dispatch a root-cause investigation. -->
+
+## When introduced (if known)
+
+<!-- git blame or PR ref. Skip for greenfield bugs. -->
+
+## Proposed fix (if any)
+
+<!-- Brief sketch only. Don't pre-bake the implementation — that's
+PR-time discussion. -->
+
+## Priority hint
+
+<!-- P1  operator-blocking / data-loss / silent-failure-class
+     P2  degrades quality but workaround exists
+     P3  cleanup / polish / latent risk -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature / Enhancement
+about: New capability or improvement to existing behavior
+title: 'feat: '
+labels: ['enhancement']
+---
+
+## Problem
+
+<!-- What's the user-visible pain or limitation today?
+Write the problem, not the solution. -->
+
+## Current workaround (if any)
+
+<!-- How are people getting by without this feature? -->
+
+## Proposed behavior
+
+<!-- Brief description of what changes. Not implementation. -->
+
+## Scope boundary
+
+<!-- What's IN scope and explicitly NOT in scope. Important for fleet
+agents to avoid scope creep during implementation. -->
+
+## Acceptance criteria
+
+<!-- How do we know it's done? Bullet list. -->
+
+## Priority hint
+
+<!-- P1  operator-blocking / data-loss / silent-failure-class
+     P2  degrades quality but workaround exists
+     P3  cleanup / polish / latent risk -->


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`.
- Markdown templates (not YAML form) — suggest structure, don't gate it.
- Blank-issue creation stays enabled (no `config.yml`); 1-liner placeholder issues still work.

## Bug template sections

`Symptom → Reproduction → Expected/Actual → Version/Environment → Concrete evidence → Root cause? → When introduced? → Proposed fix? → Priority hint`

First four are mandatory-by-convention so a reviewer can decide "real bug / matches my env / worth chasing" in three seconds. Last four are skippable for shallow issues — deep-dive issues like #964 stay welcome.

## Feature template sections

`Problem → Current workaround → Proposed behavior → Scope boundary → Acceptance criteria → Priority hint`

Mirrors the operator's "why first, then solution" report-format preference. `Scope boundary` explicit to deter scope-creep during fleet-agent implementation.

## Test plan

- [x] Files present at expected `.github/ISSUE_TEMPLATE/` path (GitHub picks them up automatically)
- [ ] After merge: file a test issue, confirm template picker appears at https://github.com/suzuke/agend-terminal/issues/new/choose

🤖 Generated with [Claude Code](https://claude.com/claude-code)