### PR TITLE
docs(#973): adopt gh pr merge --auto + enable branch protection

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL.md
+++ b/docs/FLEET-DEV-PROTOCOL.md
@@ -99,6 +99,33 @@ Feature/fix PRs must be test-first: failing test commit BEFORE impl commit.
 ### 3.12 Verdict Externalization (was §3.5.13)
 Fleet-internal verdict MUST mirror to GH PR comment (`gh pr comment`). Self-merge gate: dual VERIFIED + CI green (independently verified via `gh pr checks`) + verdict mirror posted — all three required before merge.
 
+#### 3.12.1 `gh pr merge --auto` adoption (Sprint 65, #973)
+
+The canonical self-merge invocation is `gh pr merge <N> --auto --squash --delete-branch` (requires `gh` CLI >= 2.31.0). `--auto` moves merge submission to GitHub's server-side queue, eliminating the "Base branch was modified" race observed in #971 close-loop (2026-05-20).
+
+**Prerequisites** (one-time per repo, enabled in #973):
+- `allow_auto_merge: true` at repo level (`gh api repos/<owner>/<repo> -X PATCH -F allow_auto_merge=true`)
+- Branch protection on `main` with `required_status_checks.strict=true` covering the full CI matrix (`Check (ubuntu-latest|macos-latest|windows-latest)`, `LOC overrun`, `audit`). Without `strict=true`, `--auto` invoked after all checks already reported merges IMMEDIATELY — silently skipping the §3.12 conjunction gate. With `strict=true`, GitHub re-checks against current main before merging.
+- Admin-permission note: enabling these settings requires repo admin rights. Delegated maintainers should request via operator.
+
+**Behavior**: `gh pr merge --auto` returns immediately (does NOT block on CI). Merge fires asynchronously when the protection-gate conjunction holds. Author MUST NOT poll manually; the `[pr-merged]` event (delivered by daemon PR-state aggregator, #972) is the close-loop confirmation source.
+
+**Escape-hatch — stalled `--auto`**: if no `[pr-merged]` arrives within 30 min of CI green + verdict mirror posted, possible causes:
+1. Required check never reports (CI infrastructure issue)
+2. Branch protection mis-configuration (status-check context name drift)
+3. Token / permission issue on the `--auto` arming agent
+
+Recovery, in order:
+- (a) Verify protection state: `gh api repos/<owner>/<repo>/branches/main/protection --jq '.required_status_checks'`
+- (b) Verify PR is mergeable: `gh pr view <N> --json mergeable,statusCheckRollup`
+- (c) Re-arm: `gh pr merge <N> --auto --squash --delete-branch` (idempotent — re-arming when already armed is a no-op)
+- (d) Last resort — manual fallback: `gh pr merge <N> --squash --delete-branch` (synchronous; may hit base-modified race; retry 3s later if it does)
+- Notify lead via `send(kind=update)` if escape-hatch invoked, with case (a)/(b)/(c)/(d) identifier.
+
+**Bundle dependency on #972**: `--auto` returns immediately, so the synchronous "PR merged at SHA" terminal feedback is gone. The daemon PR-state aggregator (#972) emits `[pr-merged]` events to the PR author's inbox after observing the GitHub-side merge. Until #972 lands, manual `gh pr view <N> --json state` polling is the only close-loop confirmation; once #972 lands, the polling is replaced by the event.
+
+**Activation order**: #973 lands first (this PR; enables `--auto` infrastructure + docs). Lead dispatch templates and `active_poll_post_dispatch.md` memory continue to reference the legacy synchronous form until #972 lands. After #972 ships, a follow-up commit/PR switches defaults to `--auto`.
+
 ### 3.13 Log-level Changes (was §3.5.14)
 Must have inline rationale, otherwise `LEVEL-CHANGE-RATIONALE-ABSENT — UNVERIFIED`.
 


### PR DESCRIPTION
## Summary

- **Bug**: legacy `gh pr merge <N> --squash --delete-branch` hits transient "Base branch was modified" GraphQL race when main advances between the mergeable-poll and the merge-submit (~1-3s window). Witnessed today during #971 close-loop (1/2 self-merges affected).
- **Fix**: adopt `gh pr merge <N> --auto --squash --delete-branch` as the canonical self-merge invocation. `--auto` moves merge submission to GitHub's server-side queue, eliminating the race.
- **Prerequisites** (executed out-of-band as part of this PR):
  - `allow_auto_merge: true` enabled at repo level
  - Branch protection on `main` with `required_status_checks.strict=true` covering all 5 CI contexts (`Check (ubuntu-latest|macos-latest|windows-latest)`, `LOC overrun`, `audit`). `strict=true` is **NOT optional** per dev's LOAD-BEARING cross-audit pushback — without it, `--auto` invoked after all checks reported merges immediately, silently skipping the §3.12 conjunction gate.
- **Bundle dependency on #972**: `--auto` returns immediately (no synchronous "merged at SHA" confirmation). The daemon PR-state aggregator (#972) delivers `[pr-merged]` events for close-loop. This PR ships the `--auto` infrastructure + docs but does NOT switch dispatch templates / memory to use `--auto` as default until #972 lands.

Closes #973

## Out-of-band repo settings (live)

Both calls executed prior to PR open; verified via subsequent `gh api` query.

**Step 1** — enable auto-merge at repo level:
```bash
gh api repos/suzuke/agend-terminal -X PATCH -F allow_auto_merge=true
# verify
gh api repos/suzuke/agend-terminal --jq '.allow_auto_merge'
# → true
```

**Step 2** — enable branch protection with strict status checks:
```bash
gh api repos/suzuke/agend-terminal/branches/main/protection -X PUT \
    --input branch-protection-973.json
# where branch-protection-973.json contains:
# {
#   "required_status_checks": {
#     "strict": true,
#     "contexts": ["Check (ubuntu-latest)", "Check (macos-latest)",
#                  "Check (windows-latest)", "LOC overrun", "audit"]
#   },
#   "enforce_admins": false,
#   "required_pull_request_reviews": null,
#   "restrictions": null
# }
```
`enforce_admins=false` + `required_pull_request_reviews=null` keep self-merge by author working (no required-review block). `strict=true` forces re-check against current main on every merge.

Verified state:
```json
{
  "strict": true,
  "contexts": ["Check (ubuntu-latest)", "Check (macos-latest)",
               "Check (windows-latest)", "LOC overrun", "audit"],
  "enforce_admins": false,
  "pr_reviews": null
}
```

## §3.12.1 added (FLEET-DEV-PROTOCOL.md, +27 LOC)

The new sub-section documents:
- Canonical self-merge command
- Prerequisites + admin-permission note (delegated maintainers must request via operator)
- Behavior: returns immediately; `[pr-merged]` event is close-loop source (#972)
- Escape-hatch (reviewer NEW requirement): 30-min timeout + 4-step recovery + lead notification
- gh CLI >= 2.31.0 version pin
- Bundle dependency on #972 and activation-order discipline

## Folded pushbacks (per lead's synthesis of all 6 dialectic memos)

| Pushback | Source | Disposition |
|---|---|---|
| LOAD-BEARING (A) `strict=true` required, not optional | dev cross-audit | **Promoted** — my primary said "optional Step 4"; lead-folded to MUST |
| MEDIUM (B) concurrent merge ordering | dev cross-audit | **Folded into A** — `strict=true` handles ordering |
| MEDIUM (C) armed-but-stale sweep | dev cross-audit | **Deferred to #972** — `auto_armed` field + 24h staleness alert lives there |
| minor (D) bundle ordering #972→#973 | dev cross-audit | **Adopted** — docs say "activate after #972 lands" |
| minor (E) gh version pin >=2.31.0 | dev cross-audit | **Adopted** — documented in §3.12.1 |
| minor (F) force-push cancellation | dev cross-audit | **Deferred to #972** — `[pr-state-invalidated]` + auto_armed reset live there |
| minor (G) admin-permission note | dev cross-audit | **Adopted** — documented in §3.12.1 |
| NEW: escape-hatch for stalled --auto | reviewer | **Adopted** — 30-min timeout + 4-step recovery + lead-notify procedure |

## What this PR does NOT change

- Lead dispatch templates: still use legacy `gh pr merge --squash --delete-branch` form until #972 lands
- `active_poll_post_dispatch.md` (private agent memory at `~/.claude/...`): not modified in this PR (outside repo); will be updated session-side after #972 lands
- Daemon-side merge wrapper: NOT added — reviewer constraint that scope stays docs+settings+memory only; this PR honors that

## §3.6 docs-only exception compliance

All four conditions hold:
1. `docs/FLEET-DEV-PROTOCOL.md` edit only ✓
2. Diff ≤ 50 LOC (27 LOC) ✓
3. No `src/` behavior change ✓
4. New rule (§3.12.1) is docs-only; no behavior shift until follow-up activates defaults — current legacy `gh pr merge` flow continues to work alongside

## Test plan

Test strategy per lead's dispatch: `--auto` is GitHub-server-side; hard to unit-test. Verification approaches used here:

- [x] Step 1 API verified: `gh api repos/.../-X PATCH -F allow_auto_merge=true` returned `true`
- [x] Step 2 API verified: `gh api repos/.../branches/main/protection --jq '...'` returns `strict=true` + 5 contexts + null PR-review requirement
- [x] No `src/` changes → no cargo build/test/clippy regression risk
- [ ] CI runs successfully on this PR (canary against the new branch protection)
- [ ] Reviewer §3.6 single-reviewer VERIFIED

## Cadence

- [x] Worktree ready (`feat/973-gh-pr-merge-auto`)
- [x] Branch protection API verify (logged in PR body)
- [x] Docs commit (ce0608a)
- [x] PR open (this PR)
- [ ] CI green
- [ ] Reviewer VERIFIED via auto-chain (next_after_ci=fixup-reviewer)
- [ ] §3.12 self-merge (legacy form, since #972 hasn't landed yet) OR (`--auto` from this PR, recursive)

## Protocol

- §3.6 docs-only single-reviewer eligible
- §10.4 worktree ✓ (`feat/973-gh-pr-merge-auto`)
- §3.10 RED→GREEN: N/A for docs+settings; verification via API query
- next_after_ci=fixup-reviewer (set on ci action=watch arming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)