### PR TITLE
feat: migrate fs4 0.12.0 → 1.1.0 (supersedes #980)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,12 +1110,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.12.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
- "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ teloxide = { version = "0.15", default-features = false, features = ["macros", "
 # Utilities
 async-trait = "0.1"
 anyhow = "1"
-fs4 = "0.12"
+fs4 = "1.1"
 dirs = "6"
 # Issue #893: dunce::canonicalize strips Windows `\\?\` UNC verbatim prefix
 # when safe, so the path encoding matches what claude CLI's Node

--- a/examples/pty_smoke.rs
+++ b/examples/pty_smoke.rs
@@ -71,7 +71,7 @@ fn main() -> anyhow::Result<()> {
     let _lock_guard = if variant_ge(&mode, "v7") {
         let p = std::env::temp_dir().join("pty_smoke_v7.lock");
         let f = std::fs::File::create(&p)?;
-        fs4::fs_std::FileExt::try_lock_exclusive(&f).ok();
+        fs4::FileExt::try_lock(&f).ok();
         Some(f)
     } else {
         None

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -328,10 +328,11 @@ fn try_attach(home: &Path, fleet_path: &Path) -> Result<Option<AttachedFleet>> {
 }
 
 fn acquire_daemon_lock(home: &Path) -> Result<DaemonLock> {
-    use fs4::fs_std::FileExt;
     let path = home.join(".daemon.lock");
     let file = std::fs::File::create(&path).with_context(|| format!("open {}", path.display()))?;
-    file.try_lock_exclusive().map_err(|e| {
+    // Explicit trait method: Rust 1.89 stabilized inherent
+    // `File::try_lock` shadowing the trait method; current MSRV is 1.87.
+    fs4::FileExt::try_lock(&file).map_err(|e| {
         anyhow!("another agend-terminal daemon is already running (lock held): {e}")
     })?;
     Ok(DaemonLock { _file: file })

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -291,9 +291,9 @@ pub fn run(home: &Path, agents: Vec<AgentDef>) -> anyhow::Result<()> {
     std::fs::create_dir_all(home)?;
     let lock_path = home.join(".daemon.lock");
     let lock_file = std::fs::File::create(&lock_path)?;
-    use fs4::fs_std::FileExt;
-    lock_file
-        .try_lock_exclusive()
+    // Explicit trait method: Rust 1.89 stabilized inherent
+    // `File::try_lock`; current MSRV is 1.87.
+    fs4::FileExt::try_lock(&lock_file)
         .map_err(|e| anyhow::anyhow!("Another daemon is already running (lock held): {e}"))?;
 
     // #933: zombie sweep BEFORE find_active_run_dir so an aged-out

--- a/src/store.rs
+++ b/src/store.rs
@@ -146,8 +146,11 @@ pub fn acquire_file_lock(lock_path: &Path) -> anyhow::Result<std::fs::File> {
         .create(true)
         .truncate(false)
         .open(lock_path)?;
-    use fs4::fs_std::FileExt;
-    f.lock_exclusive()
+    // Trait method explicit because Rust 1.89 stabilized inherent
+    // `File::lock` with the same name; without explicit trait syntax,
+    // the inherent method would be selected and clippy MSRV gate fires
+    // (current MSRV is 1.87 per `rust-version`).
+    fs4::FileExt::lock(&f)
         .map_err(|e| anyhow::anyhow!("flock failed on {}: {e}", lock_path.display()))?;
     Ok(f)
 }
@@ -420,9 +423,9 @@ mod tests {
 
     #[test]
     fn test_acquire_file_lock_is_exclusive_same_process() {
-        // On the same process, a second lock_exclusive on a different File
+        // On the same process, a second lock on a different File
         // handle for the same path blocks; try_lock should refuse.
-        use fs4::fs_std::FileExt;
+        // Explicit trait method (see comment in acquire_file_lock).
         let dir = tmp_dir("flock");
         let lock_path = dir.join("my.lock");
         let guard = acquire_file_lock(&lock_path).expect("first lock");
@@ -434,12 +437,12 @@ mod tests {
             .open(&lock_path)
             .expect("open");
         assert!(
-            second.try_lock_exclusive().is_err(),
+            fs4::FileExt::try_lock(&second).is_err(),
             "second exclusive lock must fail while first held"
         );
         drop(guard);
         // After drop, second can acquire.
-        assert!(second.try_lock_exclusive().is_ok());
+        assert!(fs4::FileExt::try_lock(&second).is_ok());
         fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
## Summary

Migrate fs4 0.12.0 → 1.1.0. Supersedes #980 (dependabot's auto-bump, which was CI-red because it didn't include the API migration).

## Breaking changes in fs4 1.1.0

- `fs_std` module flattened to crate root: `fs4::fs_std::FileExt` → `fs4::FileExt`
- `lock_exclusive()` → `lock()`
- `try_lock_exclusive() -> io::Result<bool>` → `try_lock() -> Result<(), TryLockError>`
- `FileExt` + `AsyncFileExt` consolidated to crate root
- `lock_contended_error()` helper removed (unused by us)

## Sites migrated

| Site | Before | After |
|---|---|---|
| `src/store.rs:140-153` `acquire_file_lock` | `fs4::fs_std::FileExt + f.lock_exclusive()` | `fs4::FileExt::lock(&f)` |
| `src/store.rs:421-444` test | `f.try_lock_exclusive()` | `fs4::FileExt::try_lock(&f)` |
| `src/bootstrap/mod.rs:330-337` `acquire_daemon_lock` | `f.try_lock_exclusive()` | `fs4::FileExt::try_lock(&f)` |
| `src/daemon/mod.rs:290-298` daemon lock | `f.try_lock_exclusive()` | `fs4::FileExt::try_lock(&f)` |
| `src/inbox.rs:28-29` `available_space` / `total_space` | unchanged | unchanged ✓ |

## Explicit trait-method syntax for MSRV compatibility

Rust 1.89 stabilized inherent `File::lock` / `File::try_lock` with names matching fs4's trait. With `use fs4::FileExt` in scope, the inherent method (1.89) wins method resolution → clippy MSRV gate fires (current MSRV is 1.87 per `Cargo.toml` `rust-version`).

Fix: explicit trait syntax `fs4::FileExt::lock(&f)` at all 5 sites with inline comments citing MSRV rationale.

This makes the call site forward-compatible: when MSRV bumps to 1.89+ in the future, the `fs4::FileExt::lock(&f)` calls can be drop-in replaced with inherent `f.lock()` (or `fs4` can be removed entirely if `available_space`/`total_space` are unused).

## Why a separate branch (not pushing to #980)

Per lead's dispatch: don't push directly to `dependabot/cargo/fs4-1.1.0` — dependabot will rebase + overwrite. This PR is based on `origin/main` and supersedes #980.

After this PR merges, close #980 with "superseded by feat/fs4-1.1.0-api-migration".

## Test plan

- [x] cargo build --bin agend-terminal — clean
- [x] cargo clippy --bin agend-terminal --all-targets --features tray -- -D warnings — clean
- [x] cargo test --bin agend-terminal --features tray — 2542 pass / 0 fail / 7 ignored
- [x] cargo test --features tray (full inc tests/) — pass
- [ ] CI 5/5 green
- [ ] Reviewer cross-audit VERIFIED

## Test coverage

The existing `test_acquire_file_lock_is_exclusive_same_process` (src/store.rs:421-444) exercises the lock semantics post-migration. It still validates:
- First lock succeeds
- Second lock fails while first held
- Second lock succeeds after first dropped

The new `try_lock` return type (`Result<(), TryLockError>`) — `Err(WouldBlock)` for "held by another" — is semantically equivalent to the old `try_lock_exclusive`'s `Err` variant. The test's `.is_err()` and `.is_ok()` assertions remain correct.

## Protocol

- §3.6 NOT eligible — runtime semantics (File locking is core lifecycle)
- §3.20 NOT race-class — same-process lock test is deterministic via file-handle isolation; no sleeps
- §10.4 worktree ✓ (`feat/fs4-1.1.0-api-migration`)
- next_after_ci=fixup-reviewer (set on ci action=watch arming)

Supersedes #980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)