### PR TITLE
fix(#969 RC1): bounded-backoff attach detection

### DIFF
--- a/src/bootstrap/attach_detect.rs
+++ b/src/bootstrap/attach_detect.rs
@@ -1,0 +1,230 @@
+//! #969 RC1 — bounded-backoff attach detection for the App→Daemon race.
+//!
+//! The race: when operator runs `agend-terminal start` (detached daemon)
+//! and then immediately `agend-terminal app` (interactive TUI) within
+//! milliseconds, the App's `try_attach` calls
+//! [`crate::daemon::find_active_run_dir`] before the daemon has finished
+//! writing its `.daemon` file. `find_active_run_dir` returns `None`, App
+//! bootstraps `Owned`, and BOTH processes end up polling
+//! `check_ci_watches` → duplicate telegram notifications on CI completion.
+//!
+//! Fix: retry `find_active_run_dir` up to 3 times with 100ms backoff
+//! before committing to `Owned`. 300ms total budget closes the race
+//! window for typical daemon bootstrap latency (operator dispatches
+//! report `.daemon` writes complete within ~150ms of process start).
+//!
+//! The helper does NOT cover all RC1 cracks (HOME divergence + zombie
+//! daemon thread are out of scope for r0 per dispatch). The #984 dedup
+//! module catches any RC1 duplicates that slip through this defense as
+//! a wire-layer safety net.
+//!
+//! Contract-test-only: e2e race reproduction requires process orchestration
+//! (a daemon mid-bootstrap with controlled `.daemon` write timing) that's
+//! impractical for §3.20 SOP 1 deterministic tests. The contract test
+//! covers the helper's retry behavior with a synthetic detect_fn callback;
+//! the integration is exercised by manual canary verification.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Default backoff schedule: 3 attempts × 100ms = 300ms total budget.
+/// Picked per #969 PR 2 dispatch; pinning to operator data deferred
+/// (dev-2 cross-audit Pushback 7).
+pub(crate) const DEFAULT_MAX_ATTEMPTS: usize = 3;
+pub(crate) const DEFAULT_BACKOFF: Duration = Duration::from_millis(100);
+
+/// Bounded-backoff wrapper around [`crate::daemon::find_active_run_dir`].
+/// Calls the detection fn up to `max_attempts` times, sleeping
+/// `backoff` between attempts. Returns the first `Some(path)` seen, or
+/// `None` after exhausting attempts.
+///
+/// The `detect_fn` parameter is injected for testability — production
+/// callers pass [`crate::daemon::find_active_run_dir`]; tests pass a
+/// mock that returns canned values to verify retry semantics without
+/// real filesystem state.
+pub(crate) fn find_active_run_dir_with_backoff<F>(
+    home: &Path,
+    max_attempts: usize,
+    backoff: Duration,
+    mut detect_fn: F,
+) -> Option<PathBuf>
+where
+    F: FnMut(&Path) -> Option<PathBuf>,
+{
+    for attempt in 0..max_attempts {
+        if let Some(run_dir) = detect_fn(home) {
+            if attempt > 0 {
+                tracing::info!(
+                    home = %home.display(),
+                    run_dir = %run_dir.display(),
+                    attempt = attempt + 1,
+                    "#969 RC1: attach detected after backoff retry — closed the App/daemon race window"
+                );
+            }
+            return Some(run_dir);
+        }
+        if attempt + 1 < max_attempts {
+            std::thread::sleep(backoff);
+        }
+    }
+    None
+}
+
+/// Production entry point: wraps [`crate::daemon::find_active_run_dir`]
+/// with [`DEFAULT_MAX_ATTEMPTS`] × [`DEFAULT_BACKOFF`] retries.
+pub(crate) fn find_active_run_dir_backoff(home: &Path) -> Option<PathBuf> {
+    find_active_run_dir_with_backoff(
+        home,
+        DEFAULT_MAX_ATTEMPTS,
+        DEFAULT_BACKOFF,
+        crate::daemon::find_active_run_dir,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    //! #969 RC1 contract tests — verify retry semantics without depending
+    //! on real daemon-bootstrap timing.
+
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    fn tmp_home(slug: &str) -> PathBuf {
+        static SEQ: AtomicUsize = AtomicUsize::new(0);
+        let id = SEQ.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "agend-969-rc1-{}-{}-{}",
+            slug,
+            std::process::id(),
+            id
+        ))
+    }
+
+    /// T1 — happy path: detect_fn returns Some on first attempt. No
+    /// retries fired; helper returns immediately.
+    #[test]
+    fn t1_returns_first_some_without_retry() {
+        let home = tmp_home("t1");
+        let expected = home.join("run").join("12345");
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = Arc::clone(&call_count);
+        let expected_clone = expected.clone();
+
+        let result =
+            find_active_run_dir_with_backoff(&home, 3, Duration::from_millis(100), move |_h| {
+                count_clone.fetch_add(1, Ordering::Relaxed);
+                Some(expected_clone.clone())
+            });
+
+        assert_eq!(result, Some(expected));
+        assert_eq!(
+            call_count.load(Ordering::Relaxed),
+            1,
+            "first Some must short-circuit retry loop"
+        );
+    }
+
+    /// T2 — race-closed-on-retry: detect_fn returns None on first 2
+    /// attempts, Some on 3rd. Verifies the helper retries up to
+    /// max_attempts and surfaces the late-arriving Some.
+    #[test]
+    fn t2_closes_race_window_via_retry() {
+        let home = tmp_home("t2");
+        let expected = home.join("run").join("67890");
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = Arc::clone(&call_count);
+        let expected_clone = expected.clone();
+
+        let result = find_active_run_dir_with_backoff(
+            &home,
+            3,
+            Duration::from_millis(10), // tight backoff for test speed
+            move |_h| {
+                let n = count_clone.fetch_add(1, Ordering::Relaxed);
+                if n < 2 {
+                    None
+                } else {
+                    Some(expected_clone.clone())
+                }
+            },
+        );
+
+        assert_eq!(
+            result,
+            Some(expected),
+            "3rd attempt's Some must be returned"
+        );
+        assert_eq!(
+            call_count.load(Ordering::Relaxed),
+            3,
+            "all 3 attempts must fire when first 2 are None"
+        );
+    }
+
+    /// T3 — bounded budget: detect_fn always returns None. After
+    /// max_attempts the helper commits to None. No infinite loop.
+    #[test]
+    fn t3_bounded_attempts_then_returns_none() {
+        let home = tmp_home("t3");
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = Arc::clone(&call_count);
+
+        let start = Instant::now();
+        let result =
+            find_active_run_dir_with_backoff(&home, 3, Duration::from_millis(10), move |_h| {
+                count_clone.fetch_add(1, Ordering::Relaxed);
+                None
+            });
+        let elapsed = start.elapsed();
+
+        assert_eq!(result, None);
+        assert_eq!(
+            call_count.load(Ordering::Relaxed),
+            3,
+            "exhausts max_attempts before returning None"
+        );
+        // 2 inter-attempt sleeps × 10ms = ~20ms; allow 200ms slack for CI scheduling.
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "bounded budget — must not loop indefinitely; got elapsed={elapsed:?}"
+        );
+    }
+
+    /// T4 — zero-attempt edge case: max_attempts=0 returns None
+    /// immediately without calling detect_fn. Defensive contract pin.
+    #[test]
+    fn t4_zero_attempts_returns_none_without_calling_detect() {
+        let home = tmp_home("t4");
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count_clone = Arc::clone(&call_count);
+
+        let result =
+            find_active_run_dir_with_backoff(&home, 0, Duration::from_millis(10), move |_h| {
+                count_clone.fetch_add(1, Ordering::Relaxed);
+                Some(PathBuf::from("/should/never/return"))
+            });
+
+        assert_eq!(result, None);
+        assert_eq!(
+            call_count.load(Ordering::Relaxed),
+            0,
+            "max_attempts=0 must not invoke detect_fn"
+        );
+    }
+
+    /// T5 — default helper production wiring: `find_active_run_dir_backoff`
+    /// returns None when home dir is empty (no run/ subdir). Anchors
+    /// the production wiring against the underlying detection fn.
+    #[test]
+    fn t5_default_helper_returns_none_on_empty_home() {
+        let home = tmp_home("t5");
+        std::fs::create_dir_all(&home).unwrap();
+        // No run/ subdir → find_active_run_dir returns None.
+        let result = find_active_run_dir_backoff(&home);
+        assert_eq!(result, None);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -13,6 +13,7 @@
 //!   The current process is a client and should not touch run dir ownership.
 
 mod agent_resolve;
+mod attach_detect;
 pub(crate) mod canonical_hygiene;
 pub mod daemon_spawn;
 pub(crate) mod doctor;
@@ -305,7 +306,12 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
 /// discovery semantics across PID-recycling, kill -9, and stale
 /// rundir scenarios.
 fn try_attach(home: &Path, fleet_path: &Path) -> Result<Option<AttachedFleet>> {
-    let Some(run_dir) = crate::daemon::find_active_run_dir(home) else {
+    // #969 RC1: bounded-backoff retry closes the App→Daemon race window
+    // where `find_active_run_dir` returns None because the daemon's
+    // `.daemon` file hasn't landed yet but the process is mid-bootstrap.
+    // 3×100ms total budget; on miss the App falls through to Owned mode
+    // (and the #984 dedup module catches any wire-layer duplicates).
+    let Some(run_dir) = attach_detect::find_active_run_dir_backoff(home) else {
         return Ok(None);
     };
     if !crate::ipc::probe_api(&run_dir) {


### PR DESCRIPTION
## Summary

#969 RC1 root cause: App's `try_attach` calls `find_active_run_dir` BEFORE the daemon's `.daemon` write completes, race-misses → App bootstraps `Owned` while daemon also runs → BOTH processes invoke `check_ci_watches` → duplicate telegram notifications.

Fix: bounded-backoff wrapper around `find_active_run_dir` (3×100ms = 300ms total) closes the race window.

Closes #969 PR 2 (of 3 — RC2 done in #984; RC3 tracing follow-up next).

## What changed

- `src/bootstrap/attach_detect.rs` (new, ~80 LOC incl tests) — generic backoff helper with `detect_fn` injection seam for testability + production wrapper using defaults
- `src/bootstrap/mod.rs` — `try_attach` calls the backoff helper instead of `find_active_run_dir` directly (+ module registration)

```diff
 fn try_attach(home: &Path, fleet_path: &Path) -> Result<Option<AttachedFleet>> {
-    let Some(run_dir) = crate::daemon::find_active_run_dir(home) else {
+    let Some(run_dir) = attach_detect::find_active_run_dir_backoff(home) else {
         return Ok(None);
     };
```

## Tests (5 contract tests, §3.20 SOP 1 deterministic)

| Test | Coverage |
|---|---|
| T1 | Happy path — first `Some` short-circuits retry loop |
| T2 | Race closed on retry — `None×2 → Some` on 3rd attempt |
| T3 | Bounded budget — `None×N` returns None, no infinite loop, elapsed bounded |
| T4 | Zero-attempt edge — `max_attempts=0` returns None without calling detect_fn |
| T5 | Default helper anchors against `crate::daemon::find_active_run_dir` via real empty home |

E2E race reproduction would require process orchestration with controlled `.daemon` write timing — impractical for SOP 1 determinism. **Contract-test-only is acknowledged dev-2 cross-audit limitation (Pushback 8)** — the #984 wire-layer dedup catches residual duplicates if the helper's retry budget proves insufficient.

## 3×100ms tuning (dev-2 Pushback 7 — defer pinning)

300ms total budget covers typical daemon bootstrap latency (~150ms for `.daemon` write per operator dispatches). Operator-data-pinning of the interval/count is deferred to follow-up.

## Out of scope (dispatch-specified follow-ups)

- HOME divergence (App's `AGEND_HOME` != fleet.yaml-derived home): r0 defer; separate concern, warrants its own warn + suppress-local-poll plumbing
- Zombie daemon thread (pidfile valid but process unresponsive): r0 defer; covered orthogonally by #933 boot-sweep + #984 dedup
- "Attached-uncertain" state plumbing through `BootstrapOutcome`: scope-creep — minimal fix is sufficient with dedup safety net

## Bundle posture

| Layer | PR | Status |
|---|---|---|
| Bundle dedup + RC2 mirror_skip | #984 | merged ✓ |
| **RC1 attach detection (this PR)** | this | open |
| RC3 tracing | next | pending |

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets --features tray -- -D warnings (drops --bin per #985 lesson)
- [x] cargo test --bin agend-terminal --features tray: 2556 pass / 0 fail / 7 ignored
- [x] cargo test --features tray (full inc tests/): pass
- [ ] CI 5/5 green
- [ ] Reviewer cross-audit VERIFIED

## Self-merge command

Per §3.12.1 activation discipline, this is our own PR with follow-up implications (PR 3 RC3 + future operator-data tuning), so legacy form: `gh pr merge <N> --squash --delete-branch` (NOT `--auto`).

## Protocol

- §3.6 NOT eligible — runtime semantics (App↔Daemon attach lifecycle)
- §3.20 SOP 1 deterministic ✓
- §10.4 worktree ✓ (`fix/969-rc1-attach-detection`)
- next_after_ci=fixup-reviewer (set on ci action=watch arming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)