### PR TITLE
chore(#969 RC3): tracing on telegram notify retry path

### DIFF
--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -88,6 +88,19 @@ fn notify_telegram_inner(
             let e: anyhow::Error = e.into();
             if let Some(stale_tid) = topic_id {
                 if is_topic_deleted_error(&e) {
+                    // #969 RC3: pin the topic-deleted detection event for
+                    // future-debugging visibility. Series-close defense-in-
+                    // depth — old topic is gone so no user-visible duplicate
+                    // today, but if a future retry path is added without the
+                    // same idempotency guarantee, this log is the breadcrumb
+                    // operator greps for to confirm the suspected retry-spam
+                    // class.
+                    tracing::info!(
+                        instance = %instance_owned,
+                        topic = stale_tid,
+                        error = %e,
+                        "#969 RC3: notify topic-deleted detected, recreating + retrying"
+                    );
                     if let Some(new_tid) =
                         invalidate_and_recreate_topic(&home_owned, &instance_owned, stale_tid)
                     {


### PR DESCRIPTION
## Summary

Series-close for #969 (3 PRs total). PR 1 (#984 dedup + RC2 mirror_skip) + PR 2 (#988 attach detect) shipped; this is the tiny final piece.

Adds `tracing::info!` at the topic-deleted detection point in `src/channel/telegram/notify.rs` so operators have a grep target for the topic-deleted retry chain.

Closes #969.

## §3.6 docs/observability-only exception

- 13 LOC docs+observability
- `tracing::info!` only, no behavior change
- Existing tests cover the retry path

## What this adds

A `tracing::info!` event right at the point where `is_topic_deleted_error(&e)` returns true, BEFORE `invalidate_and_recreate_topic` fires. Complements the existing "notify: retrying with recreated topic" log (which fires AFTER recreate succeeds) by capturing the detection event itself.

```diff
+ tracing::info!(
+     instance = %instance_owned,
+     topic = stale_tid,
+     error = %e,
+     "#969 RC3: notify topic-deleted detected, recreating + retrying"
+ );
```

## Why RC3 is NOT a current-bug fix (per dev primary)

The only retry site in production is the topic-deleted recovery — the retry sends to a NEW topic so the user does NOT see a duplicate (the old topic is gone). Other transient errors fall through to `tracing::warn!` without retry.

So this PR is defense-in-depth observability — the log is the breadcrumb future debugging needs if:
- A future retry site is added without sufficient idempotency guarantees
- The topic-deleted recovery itself ever races with manual topic restore
- The #984 channel-side dedup catches any actual wire-layer duplicate as a safety net regardless

## Series-close summary

| PR | Closes RC | LOC | Status |
|---|---|---|---|
| #984 | Bundle dedup + RC2 mirror_skip flag-order | ~245 | merged b1d3e7e |
| #988 | RC1 attach detection bounded-backoff | ~237 | merged a601c24 |
| **this** | RC3 topic-deleted retry tracing | 13 | open |

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets --features tray -- -D warnings
- [ ] CI 5/5 green
- [ ] Reviewer §3.6 single-reviewer VERIFIED

## Self-merge command

Per §3.12.1 activation discipline (still pending #986 gh-poll), legacy form: `gh pr merge <N> --squash --delete-branch`.

## Protocol

- §3.6 docs/observability-only ELIGIBLE (13 LOC, no behavior change)
- §10.4 worktree ✓ (`fix/969-rc3-retry-tracing`)
- next_after_ci=fixup-reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)