### PR TITLE
fix(#996): claude trust dismiss → single Enter (止血 keystroke patch)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1843,6 +1843,11 @@ mod tests {
     /// Production dismiss regex for kiro-cli's "Trust All Tools" prompt
     /// (Issue #468 follow-up — radio-button cursor `)` was unmatched).
     const KIRO_TRUST_REGEX: &str = r"(?m)^[^A-Za-z\n]{0,8}No, exit";
+    /// Production dismiss regex for Claude's workspace-trust prompt (#996
+    /// Phase 1). Modern Claude (v2.1.145+) defaults cursor to "Yes, I trust",
+    /// so the keystroke shipped is single Enter `\r` — see
+    /// `Backend::ClaudeCode.preset().dismiss_patterns[0]`.
+    const CLAUDE_TRUST_REGEX: &str = r"(?m)^[^A-Za-z\n]{0,8}Yes, I trust";
 
     /// `(regex, keystrokes)` pair for `try_dismiss_dialog` — `Down` then
     /// `Enter` to dismiss kiro-cli's "Trust All Tools" prompt.
@@ -1922,6 +1927,56 @@ I see it in the docs but I'm not sure when Gemini shows it.
         assert!(
             try_dismiss_dialog("t", &screen, &test_writer(), &patterns),
             "VTerm-rendered Gemini dialog must match production regex. Screen:\n{screen}"
+        );
+    }
+
+    /// #996 Phase 1: true Claude workspace-trust prompt — vterm-rendered —
+    /// MUST still match the anchored regex so the dismiss fires. The fix
+    /// changes the keystroke (config-pinned in backend.rs tests) but the
+    /// regex is unchanged. Anti-regression for the dismiss path itself.
+    #[test]
+    fn claude_trust_dismiss_matches_real_modal() {
+        let mut vt = crate::vterm::VTerm::new(120, 30);
+        vt.process(b"\x1b[2J\x1b[H");
+        vt.process(" Accessing workspace:\r\n\r\n /private/tmp/claude-test\r\n\r\n".as_bytes());
+        vt.process(" Quick safety check: Is this a project you created or one you trust?\r\n\r\n".as_bytes());
+        vt.process(" ❯ 1. Yes, I trust this folder\r\n".as_bytes()); // marker on row 1 (default)
+        vt.process("   2. No, exit\r\n".as_bytes());
+        vt.process(" Enter to confirm · Esc to cancel\r\n".as_bytes());
+        let screen = vt.tail_lines(30);
+        // Production keystroke after #996 Phase 1: single Enter.
+        let patterns = vec![(CLAUDE_TRUST_REGEX.to_string(), b"\r".to_vec())];
+        assert!(
+            try_dismiss_dialog("t", &screen, &test_writer(), &patterns),
+            "real Claude trust modal (default-Yes cursor) must still match anchored regex. Screen:\n{screen}"
+        );
+    }
+
+    /// #996 Phase 1: operator-quoted content matching the anchored regex —
+    /// reproduces the exact false-positive class observed today on the
+    /// fixup-lead pane (37 events between 19:46:55-19:53:04 +08). The match
+    /// STILL fires (we don't change the regex), but the production keystroke
+    /// is now `\r` (non-destructive single Enter, pinned in backend.rs
+    /// tests) instead of the historical up+up+Enter (history-resubmit blast).
+    #[test]
+    fn claude_trust_false_positive_quoted_content_still_matches_regex() {
+        // Operator pastes (or daemon-routed message includes) the Agy
+        // trust-prompt example verbatim from issue #995. The leading `>` + ` `
+        // satisfies the `[^A-Za-z\n]{0,8}` anchor → regex matches even
+        // though this is normal conversation content, not a real modal.
+        let screen = "\
+[user] Filing #995 — agy bug. The trust prompt shows:
+> Yes, I trust this folder
+  No, exit
+Should we add a dismiss_pattern?
+[claude] checking the existing patterns now
+";
+        let patterns = vec![(CLAUDE_TRUST_REGEX.to_string(), b"\r".to_vec())];
+        assert!(
+            try_dismiss_dialog("t", screen, &test_writer(), &patterns),
+            "regex anchor (?m)^[^A-Za-z\\n]{{0,8}} matches `> Yes, I trust` mid-conversation — \
+             this is the surface that produced today's 37 false-positives on fixup-lead. \
+             The fix is the keystroke (`\\r`, non-destructive), pinned in backend tests."
         );
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1939,7 +1939,10 @@ I see it in the docs but I'm not sure when Gemini shows it.
         let mut vt = crate::vterm::VTerm::new(120, 30);
         vt.process(b"\x1b[2J\x1b[H");
         vt.process(" Accessing workspace:\r\n\r\n /private/tmp/claude-test\r\n\r\n".as_bytes());
-        vt.process(" Quick safety check: Is this a project you created or one you trust?\r\n\r\n".as_bytes());
+        vt.process(
+            " Quick safety check: Is this a project you created or one you trust?\r\n\r\n"
+                .as_bytes(),
+        );
         vt.process(" ❯ 1. Yes, I trust this folder\r\n".as_bytes()); // marker on row 1 (default)
         vt.process("   2. No, exit\r\n".as_bytes());
         vt.process(" Enter to confirm · Esc to cancel\r\n".as_bytes());

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -246,8 +246,26 @@ impl Backend {
                 // drawing chars, `>` `)` `(` cursors, digit-bracket choice
                 // rows, etc.) and is length-capped at 8 chars so a long
                 // indent before alpha text cannot match the phrase.
+                // #996 Phase 1: keystroke changed from up+up+Enter to single
+                // Enter. Modern Claude (v2.1.145+) defaults cursor to "Yes,
+                // I trust this folder" (row 1, `❯` marker). The old
+                // up+up+Enter sequence was correct when the prompt
+                // defaulted to "No, exit" but is now actively harmful:
+                // - TRUE positive: navigates AWAY from default-Yes → may
+                //   confirm "No, exit" → Claude exits.
+                // - FALSE positive on operator-quoted content matching
+                //   the anchored regex: up+up+Enter re-submits prior
+                //   history message → message duplication loop (the #996
+                //   bug observed 37× today on fixup-lead pane).
+                // Single `\r` resolves both: true-positive confirms the
+                // default-Yes; false-positive adds a newline (no
+                // destructive blast). Same shape as Agy #995/#997 dismiss.
+                //
+                // `Yes, proceed` deliberately retained on old keystroke
+                // pending empirical verification at follow-up — modal +
+                // default-cursor for that prompt not yet captured.
                 dismiss_patterns: &[
-                    (r"(?m)^[^A-Za-z\n]{0,8}Yes, I trust", b"\x1b[A\x1b[A\r"),
+                    (r"(?m)^[^A-Za-z\n]{0,8}Yes, I trust", b"\r"),
                     (r"(?m)^[^A-Za-z\n]{0,8}Yes, proceed", b"\x1b[A\x1b[A\r"),
                 ],
                 fresh_args: None, // same as args (no resume in preset)
@@ -980,6 +998,34 @@ mod tests {
         assert!(agy.dismiss_patterns[0].0.contains("Yes, I trust"));
         assert_eq!(agy.dismiss_patterns[0].1, b"\r");
         assert_eq!(agy.instructions_path, "AGY.md");
+    }
+
+    /// #996 Phase 1: ClaudeCode `Yes, I trust` dismiss must send a single
+    /// Enter byte (`\r`), NEVER up-arrow sequences. Modern Claude prompts
+    /// (v2.1.145+) default the cursor to "Yes, I trust" — the historical
+    /// up+up+Enter is now actively harmful (navigates away from default,
+    /// or re-submits history on false-positive). Single Enter confirms the
+    /// default-Yes AND adds a non-destructive newline on false-positive.
+    #[test]
+    fn claude_trust_dismiss_uses_single_enter() {
+        let claude = Backend::ClaudeCode.preset();
+        let trust = claude
+            .dismiss_patterns
+            .iter()
+            .find(|(re, _)| re.contains("Yes, I trust"))
+            .expect("ClaudeCode must have a `Yes, I trust` dismiss pattern");
+
+        assert_eq!(
+            trust.1, b"\r",
+            "#996 Phase 1: trust-prompt keystroke must be single Enter"
+        );
+
+        // Negative pin: no ESC bytes allowed — historical up-arrow (\x1b[A)
+        // and any other CSI sequence in the keystroke is a regression.
+        assert!(
+            !trust.1.contains(&0x1b),
+            "#996: trust dismiss keystroke must not contain ESC (0x1b)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

止血 patch for the auto-dismiss false-positive observed on `fixup-lead` pane today (37 events between 19:46:55–19:53:04 +08). Changes ClaudeCode `Yes, I trust` dismiss keystroke from `\x1b[A\x1b[A\r` (up+up+Enter, destructive) to `\r` (single Enter, non-destructive).

**Two compounding root causes** identified in #996 S1 spike (memo: /tmp/dialectic-996-s1-claude-flag-dev-2.md):

1. **False positive**: anchored regex `(?m)^[^A-Za-z\n]{0,8}Yes, I trust` matches operator-quoted text like `> Yes, I trust this folder` (verbatim from issue #995 body). In conv mode, up+up+Enter = history-back-2 + submit = re-submits a prior message → message duplication loop.
2. **True positive shape drift**: modern Claude (v2.1.145+) workspace-trust prompt pre-selects "Yes, I trust this folder" on row 1 (`❯` marker). The historical up+up+Enter sequence was correct when the prompt defaulted to "No, exit" (#468 era) but now navigates AWAY from default-Yes → may confirm "No, exit" → Claude exits.

Single `\r` resolves both: confirms the default-Yes on a real modal, adds a non-destructive newline on false-positive. Same shape as the Agy dismiss shipped in #997.

`Yes, proceed` (Claude entry #2) keystroke deliberately left on the old sequence — separate modal, default-cursor not empirically verified yet. Filed as Phase 1 follow-up per dispatch.

## Acceptance

- [x] `Backend::ClaudeCode.preset().dismiss_patterns[0].1 == b"\r"`
- [x] No ESC byte (0x1b) anywhere in that keystroke
- [x] Anchored regex unchanged (we don't change the dismiss surface, only the keystroke)
- [x] All existing tests pass (2821 / 0 fail / 33 ignored)
- [x] cargo fmt + clippy --all-targets clean
- [ ] Operator rebuild + restart daemon → fixup-lead pane loop stops (manual verify after merge)

## Test coverage

- **Config pin** (backend.rs `claude_trust_dismiss_uses_single_enter`): trust pattern keystroke == `b"\r"` + negative pin (no 0x1b ESC bytes anywhere). Regression-proof — revert the keystroke change → FAIL.
- **Behavioral true-positive** (agent.rs `claude_trust_dismiss_matches_real_modal`): vterm-rendered real Claude modal (with `❯` row-1 marker) still matches the anchored regex → dismiss fires. Anti-regression for the dismiss path.
- **Behavioral false-positive regression-pin** (agent.rs `claude_trust_false_positive_quoted_content_still_matches_regex`): operator-quoted `> Yes, I trust this folder` mid-conversation still triggers the regex. We deliberately don't change the regex — the fix is the keystroke. This pins that the failure surface is closed at the keystroke level, not at the matcher level.

## §3.6 / §3.10 / §3.12

- §3.6 borderline — 102 LOC total (88 LOC test + 14 LOC src/comment). Behavior change in dispatch keystroke. Opting for normal §3.12 review path.
- §3.10 RED→GREEN ✓ — test was crafted to fail under old keystroke; passes under new keystroke.
- §3.12 mirror after reviewer VERIFIED.
- §3.12.1 ACTIVE — `gh pr merge --auto --squash --delete-branch` (or admin path per operator's new memory).

## Related

- #996 — root issue (operator's destructive blast report)
- #468 — original anchored-regex hotfix (intent comment at backend.rs:241-248)
- #997 — Agy dismiss shipped same shape (`\r`)
- /tmp/dialectic-996-s1-claude-flag-dev-2.md — S1 spike findings
- /tmp/dialectic-996-s4-pattern-audit-dev-2.md — broader pattern audit (Yes, proceed + Kiro No, exit still TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)