### PR TITLE
fix(#1002): Phase 1 — observability + per-handler panic guard

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -714,16 +714,17 @@ fn run_core(
         // `let handlers = …` above). The pre-collapse call order is
         // preserved verbatim by the Vec literal's element order; this
         // loop is the only call site.
-        for handler in &handlers {
-            // #941: wrap each handler.run() in an Instant measurement so
-            // `HANDLER_TIMING` (per_tick/mod.rs) accumulates per-handler
-            // stats for the periodic ThreadDumpHandler. When thread-dump
-            // is disabled, `record_handler_timing` is a sub-µs no-op
-            // (one cached atomic load + early return).
-            let start = std::time::Instant::now();
-            handler.run(&tick_ctx);
-            per_tick::record_handler_timing(handler.name(), start.elapsed());
-        }
+        //
+        // #1002 Phase 1: dispatch now goes through
+        // `per_tick::run_handlers_with_panic_guard`, which wraps each
+        // `handler.run()` in `catch_unwind`. A panic in handler N no
+        // longer aborts handlers N+1..end on the same tick — they all
+        // run, and the panic is logged with handler identity instead
+        // of vanishing. The wrapper folds in #941 per-handler timing
+        // (previously inline here). See
+        // `per_tick::tests::panicking_handler_does_not_skip_siblings`
+        // for the regression-pin.
+        per_tick::run_handlers_with_panic_guard(&handlers, &tick_ctx);
 
         // Handle exit event (if any)
         let exit_event = match exit_event {

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -138,3 +138,151 @@ pub(crate) fn snapshot_handler_timings() -> HashMap<String, HandlerStats> {
         .map(|(k, v)| ((*k).to_string(), v.clone()))
         .collect()
 }
+
+/// #1002 Phase 1 — per-handler panic isolation for the main-loop
+/// dispatch.
+///
+/// Drives the per-tick handler iteration in two steps:
+/// 1. `std::panic::catch_unwind` wraps each `handler.run(...)` call so
+///    a panic in handler N does not abort the iteration before
+///    handlers N+1..end run on this tick.
+/// 2. On a caught panic, log handler identity + panic payload (best-
+///    effort `Debug`-formatting of `Box<dyn Any>`) so future
+///    `grep "panic"` over `app.log` surfaces the silent failure that
+///    #1002 was filed against.
+///
+/// The handler trait object itself is `Send + Sync`, but `tick_ctx`
+/// holds borrowed references — `AssertUnwindSafe` is required.
+/// Borrows are not invalidated by unwinding because the catch boundary
+/// is per-handler (no shared mutable state crosses the boundary).
+///
+/// Test seam: `handlers` accepts any `&[Box<dyn PerTickHandler>]`, so
+/// the unit test (`per_tick::tests::panicking_handler_does_not_skip_siblings`)
+/// constructs a fixture vec with a panicking handler in the middle and
+/// asserts the trailing handler runs.
+pub(crate) fn run_handlers_with_panic_guard(
+    handlers: &[Box<dyn PerTickHandler>],
+    ctx: &TickContext<'_>,
+) {
+    for handler in handlers {
+        let start = std::time::Instant::now();
+        let name = handler.name();
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            handler.run(ctx);
+        }));
+        record_handler_timing(name, start.elapsed());
+        if let Err(payload) = outcome {
+            // Best-effort payload Debug; tracing crate stringifies via Debug.
+            let payload_str = panic_payload_str(&payload);
+            tracing::error!(
+                handler = name,
+                payload = %payload_str,
+                "#1002 per_tick handler panicked — subsequent handlers \
+                 in this tick continue; next tick re-invokes this handler"
+            );
+        }
+    }
+}
+
+/// Reduce a panic payload (`Box<dyn Any + Send>`) to a printable
+/// string. Mirrors `std::panic::panic_any` conventions: `String` and
+/// `&'static str` are the only payloads `panic!()` produces by
+/// default; other payloads fall through to a placeholder.
+fn panic_payload_str(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex as PLMutex;
+    use std::sync::Arc;
+
+    /// Mock handler with arbitrary `run` behaviour: either records a
+    /// hit on a shared counter or panics with a fixed message.
+    struct MockHandler {
+        name_: &'static str,
+        on_run: Box<dyn Fn(&TickContext<'_>) + Send + Sync>,
+    }
+
+    impl PerTickHandler for MockHandler {
+        fn name(&self) -> &'static str {
+            self.name_
+        }
+        fn run(&self, ctx: &TickContext<'_>) {
+            (self.on_run)(ctx);
+        }
+    }
+
+    #[test]
+    fn panicking_handler_does_not_skip_siblings() {
+        // #1002 Phase 1 RED→GREEN pin: a panic in handler N MUST NOT
+        // abort handler N+1's invocation on this tick. Pre-fix, the
+        // panic propagated up the for-loop and silently killed the
+        // entire tick (the daemon's `run_core` had no `catch_unwind`
+        // around `handler.run(&tick_ctx)`).
+        let home = std::env::temp_dir().join(format!("agend-pertick-test-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let registry: AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let before_count = Arc::new(PLMutex::new(0u32));
+        let after_count = Arc::new(PLMutex::new(0u32));
+        let before_clone = before_count.clone();
+        let after_clone = after_count.clone();
+
+        let handlers: Vec<Box<dyn PerTickHandler>> = vec![
+            Box::new(MockHandler {
+                name_: "before",
+                on_run: Box::new(move |_| *before_clone.lock() += 1),
+            }),
+            Box::new(MockHandler {
+                name_: "panicker",
+                on_run: Box::new(|_| panic!("#1002 test panic")),
+            }),
+            Box::new(MockHandler {
+                name_: "after",
+                on_run: Box::new(move |_| *after_clone.lock() += 1),
+            }),
+        ];
+
+        run_handlers_with_panic_guard(&handlers, &ctx);
+
+        assert_eq!(*before_count.lock(), 1, "pre-panic handler ran");
+        assert_eq!(
+            *after_count.lock(),
+            1,
+            "post-panic handler MUST still run — catch_unwind isolates the panic"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn panic_payload_str_handles_common_panic_types() {
+        let string_payload: Box<dyn std::any::Any + Send> = Box::new(String::from("string panic"));
+        let static_payload: Box<dyn std::any::Any + Send> = Box::new("static str panic");
+        let other_payload: Box<dyn std::any::Any + Send> = Box::new(42u32);
+
+        assert_eq!(panic_payload_str(&string_payload), "string panic");
+        assert_eq!(panic_payload_str(&static_payload), "static str panic");
+        assert_eq!(
+            panic_payload_str(&other_payload),
+            "<non-string panic payload>"
+        );
+    }
+}

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -565,9 +565,13 @@ pub fn record_verdict(
 ) {
     // #1002 Phase 1: tracing on every silent gate (A-E) so the next
     // #982-style "verdict_state stuck at None" bisect can identify
-    // which gate fired without code spelunking.
+    // which gate fired without code spelunking. Levels are chosen so
+    // default daemon filter (`agend_terminal=info`) surfaces every
+    // operator-actionable miss — debug-level would be invisible at
+    // default and re-create the silent-failure class #1002 was filed
+    // against.
     let Some(reviewed_head) = reviewed_head else {
-        tracing::debug!(
+        tracing::info!(
             task_id,
             reviewer,
             "#1002 record_verdict skipped (gate A) — reviewed_head is None; \
@@ -581,7 +585,7 @@ pub fn record_verdict(
         .into_iter()
         .find(|t| t.id == task_id);
     let Some(task) = task else {
-        tracing::debug!(
+        tracing::info!(
             task_id,
             reviewer,
             "#1002 record_verdict skipped (gate B) — task not found in task board; \
@@ -592,7 +596,7 @@ pub fn record_verdict(
     let branch = match task.branch {
         Some(b) if !b.is_empty() => b,
         _ => {
-            tracing::debug!(
+            tracing::info!(
                 task_id,
                 reviewer,
                 "#1002 record_verdict skipped (gate C) — task.branch field empty; \
@@ -608,7 +612,7 @@ pub fn record_verdict(
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
         Err(e) => {
-            tracing::debug!(
+            tracing::warn!(
                 task_id,
                 dir = %dir.display(),
                 error = %e,
@@ -648,7 +652,7 @@ pub fn record_verdict(
         }
     }
     if !matched_any {
-        tracing::debug!(
+        tracing::info!(
             task_id,
             branch = %branch,
             reviewer,
@@ -734,7 +738,7 @@ pub fn scan_and_emit_with(
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
         Err(e) => {
-            tracing::debug!(
+            tracing::warn!(
                 dir = %dir.display(),
                 error = %e,
                 "#1002 pr_state: scan_and_emit_with read_dir failed — skipping tick"
@@ -747,7 +751,7 @@ pub fn scan_and_emit_with(
         let content = match std::fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {
-                tracing::debug!(
+                tracing::warn!(
                     path = %path.display(),
                     error = %e,
                     "#1002 pr_state: scan_and_emit_with read_to_string failed — skipping file"
@@ -758,7 +762,7 @@ pub fn scan_and_emit_with(
         let mut state: PrState = match serde_json::from_str(&content) {
             Ok(s) => s,
             Err(e) => {
-                tracing::debug!(
+                tracing::warn!(
                     path = %path.display(),
                     error = %e,
                     "#1002 pr_state: scan_and_emit_with json parse failed — skipping file"
@@ -864,7 +868,7 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(e) => {
-            tracing::debug!(
+            tracing::warn!(
                 dir = %dir.display(),
                 error = %e,
                 "#1002 apply_gh_poll read_dir failed — gh-poll skipped this tick"
@@ -882,7 +886,7 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
         let content = match std::fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {
-                tracing::debug!(
+                tracing::warn!(
                     path = %path.display(),
                     error = %e,
                     "#1002 apply_gh_poll read_to_string failed — skipping file"
@@ -893,7 +897,7 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
         let state: PrState = match serde_json::from_str(&content) {
             Ok(s) => s,
             Err(e) => {
-                tracing::debug!(
+                tracing::warn!(
                     path = %path.display(),
                     error = %e,
                     "#1002 apply_gh_poll json parse failed — skipping file"

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -563,26 +563,61 @@ pub fn record_verdict(
     reviewed_head: Option<&str>,
     kind: VerdictKind<'_>,
 ) {
+    // #1002 Phase 1: tracing on every silent gate (A-E) so the next
+    // #982-style "verdict_state stuck at None" bisect can identify
+    // which gate fired without code spelunking.
     let Some(reviewed_head) = reviewed_head else {
+        tracing::debug!(
+            task_id,
+            reviewer,
+            "#1002 record_verdict skipped (gate A) — reviewed_head is None; \
+             reviewer kind=report did not carry reviewed_head field"
+        );
         return;
     };
     // Look up task → branch via list_all (no per-id getter in v1).
     // Pre-filter by task id so we only iterate enough to find the match.
-    let branch = match crate::tasks::list_all(home)
+    let task = crate::tasks::list_all(home)
         .into_iter()
-        .find(|t| t.id == task_id)
-        .and_then(|t| t.branch)
-    {
+        .find(|t| t.id == task_id);
+    let Some(task) = task else {
+        tracing::debug!(
+            task_id,
+            reviewer,
+            "#1002 record_verdict skipped (gate B) — task not found in task board; \
+             correlation_id likely mismatched (e.g. used review-task id instead of impl-task id)"
+        );
+        return;
+    };
+    let branch = match task.branch {
         Some(b) if !b.is_empty() => b,
-        _ => return,
+        _ => {
+            tracing::debug!(
+                task_id,
+                reviewer,
+                "#1002 record_verdict skipped (gate C) — task.branch field empty; \
+                 task was created without a branch hint"
+            );
+            return;
+        }
     };
     // We don't always know the repo from the task. Walk the pr-state
     // directory and find the file whose branch matches. (Typically 1
     // pr per branch; ambiguity unlikely.)
     let dir = pr_state_dir(home);
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return;
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!(
+                task_id,
+                dir = %dir.display(),
+                error = %e,
+                "#1002 record_verdict skipped (gate D) — pr-state dir read failed"
+            );
+            return;
+        }
     };
+    let mut matched_any = false;
     for entry in entries.flatten() {
         let path = entry.path();
         let Ok(content) = std::fs::read_to_string(&path) else {
@@ -594,6 +629,7 @@ pub fn record_verdict(
         if state.branch != branch {
             continue;
         }
+        matched_any = true;
         apply(
             &mut state,
             Event::VerdictObserved {
@@ -610,6 +646,15 @@ pub fn record_verdict(
                 "#972 pr_state: record_verdict save failed"
             );
         }
+    }
+    if !matched_any {
+        tracing::debug!(
+            task_id,
+            branch = %branch,
+            reviewer,
+            "#1002 record_verdict noop (gate E) — no pr-state file matched task branch; \
+             CI watch may not have created the file yet for this branch"
+        );
     }
 }
 
@@ -686,16 +731,40 @@ pub fn scan_and_emit_with(
     let dir = pr_state_dir(home);
     // #986: Phase 1 — batched gh-poll per repo for files due.
     apply_gh_poll(home, &dir, poller);
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return;
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!(
+                dir = %dir.display(),
+                error = %e,
+                "#1002 pr_state: scan_and_emit_with read_dir failed — skipping tick"
+            );
+            return;
+        }
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %e,
+                    "#1002 pr_state: scan_and_emit_with read_to_string failed — skipping file"
+                );
+                continue;
+            }
         };
-        let Ok(mut state): Result<PrState, _> = serde_json::from_str(&content) else {
-            continue;
+        let mut state: PrState = match serde_json::from_str(&content) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %e,
+                    "#1002 pr_state: scan_and_emit_with json parse failed — skipping file"
+                );
+                continue;
+            }
         };
         let mut dirty = false;
 
@@ -792,19 +861,45 @@ pub fn scan_and_emit_with(
 fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
     use std::collections::HashMap;
 
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!(
+                dir = %dir.display(),
+                error = %e,
+                "#1002 apply_gh_poll read_dir failed — gh-poll skipped this tick"
+            );
+            return;
+        }
     };
     let now = chrono::Utc::now().to_rfc3339();
     // Group files by repo + collect those due for refresh.
     let mut by_repo: HashMap<String, Vec<PrState>> = HashMap::new();
+    let mut skipped_terminal = 0u32;
+    let mut skipped_should_poll = 0u32;
     for entry in entries.flatten() {
         let path = entry.path();
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %e,
+                    "#1002 apply_gh_poll read_to_string failed — skipping file"
+                );
+                continue;
+            }
         };
-        let Ok(state): Result<PrState, _> = serde_json::from_str(&content) else {
-            continue;
+        let state: PrState = match serde_json::from_str(&content) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %e,
+                    "#1002 apply_gh_poll json parse failed — skipping file"
+                );
+                continue;
+            }
         };
         // Skip already-terminal states — they'll be swept by the
         // main scanner loop on this pass.
@@ -812,11 +907,22 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
             state.merge_state,
             MergeState::Merged { .. } | MergeState::ClosedUnmerged { .. }
         ) {
+            skipped_terminal = skipped_terminal.saturating_add(1);
             continue;
         }
         if gh_poll::should_poll(&state, &now) {
             by_repo.entry(state.repo.clone()).or_default().push(state);
+        } else {
+            skipped_should_poll = skipped_should_poll.saturating_add(1);
         }
+    }
+    if !by_repo.is_empty() || skipped_terminal > 0 || skipped_should_poll > 0 {
+        tracing::debug!(
+            repos_to_poll = by_repo.len(),
+            skipped_terminal,
+            skipped_should_poll_cadence = skipped_should_poll,
+            "#1002 apply_gh_poll grouping done"
+        );
     }
     for (repo, due_states) in by_repo {
         match poller.poll(&repo) {
@@ -1973,6 +2079,85 @@ mod tests {
         scan_and_emit_with(&home, &empty_registry(), &poller);
         let msgs2 = crate::inbox::drain(&home, "dev");
         assert_eq!(msgs2.len(), 0, "second scan: file swept, no re-emit");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    fn tmp_home_for_1002(tag: &str) -> std::path::PathBuf {
+        let home = std::env::temp_dir().join(format!("agend-1002-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), "instances: {}\n").unwrap();
+        std::fs::create_dir_all(home.join("inbox")).ok();
+        home
+    }
+
+    /// #1002 Phase 1 observability pin: a malformed pr-state JSON
+    /// file MUST emit a tracing::debug! message identifying the path
+    /// and parse error, rather than silently continuing.
+    ///
+    /// Pre-fix code at `scan_and_emit_with` had:
+    ///   let Ok(state): Result<PrState, _> = serde_json::from_str(&content)
+    ///       else { continue; };
+    /// — the silent `continue` meant a corrupt file or a schema-skew
+    /// PrState was indistinguishable from "no files at all". This pin
+    /// catches the next regression where a silent skip masks a real
+    /// issue.
+    #[test]
+    #[tracing_test::traced_test]
+    fn t15_malformed_pr_state_file_emits_observability_trace() {
+        let home = tmp_home_for_1002("t15-malformed");
+        let dir = pr_state_dir(&home);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Write a deliberately malformed pr-state JSON file.
+        let bad_path = dir.join("malformed.json");
+        std::fs::write(&bad_path, "{this is not json").unwrap();
+
+        // MockGhPoller with no responses — apply_gh_poll's
+        // read_dir/parse layer is exercised first and emits its own
+        // trace; the scanner-loop layer also reads the same dir.
+        let poller = MockGhPoller::new(vec![]);
+        scan_and_emit_with(&home, &empty_registry(), &poller);
+
+        // The malformed file path appears in tracing output via the
+        // #1002 debug line. We don't pin the exact format (impl-detail)
+        // but require:
+        //   1. The new "#1002" tracing marker is present
+        //   2. The malformed file's name is referenced
+        assert!(
+            logs_contain("#1002"),
+            "scanner must emit a #1002-tagged observability trace on malformed file"
+        );
+        assert!(
+            logs_contain("malformed.json"),
+            "trace must identify the malformed file by name"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// #1002 Phase 1 observability pin: record_verdict's gate A
+    /// (reviewed_head is None) MUST emit a tracing::debug! identifying
+    /// the silent skip with the gate marker. Pre-fix, the early-return
+    /// at `let Some(reviewed_head) = reviewed_head else { return };`
+    /// silently swallowed the call; #982's verdict_state stuck at
+    /// None could not be bisected without code spelunking.
+    #[test]
+    #[tracing_test::traced_test]
+    fn t16_record_verdict_gate_a_emits_observability_trace() {
+        let home = tmp_home_for_1002("t16-gate-a");
+        // record_verdict with reviewed_head=None hits gate A
+        // immediately — no fleet or pr-state setup required.
+        record_verdict(
+            &home,
+            "t-fake-task-id",
+            "fixup-reviewer",
+            None,
+            VerdictKind::Verified,
+        );
+        assert!(
+            logs_contain("#1002"),
+            "record_verdict must emit a #1002 observability trace on gate A"
+        );
+        assert!(logs_contain("gate A"), "trace must identify gate A by name");
         let _ = std::fs::remove_dir_all(&home);
     }
 }


### PR DESCRIPTION
## Summary

Closes the immediate #982-style \"silent autonomous-flow failure\" diagnostic gap. Phase 1 is **observability + isolation only** — no behavioural change to the gh-poll / verdict-record paths. Once deployed, the next deviation incident produces a \`grep \"#1002\"\` trail identifying which gate fired.

Spike: \`/tmp/dialectic-1002-autonomous-flow-spike-dev.md\` (4 deviations on #982 traced to ROOT 1 gh-poll never executed + ROOT 2 record_verdict 5 unmonitored gates).

## Changes

### 1. Per-handler panic isolation

\`src/daemon/per_tick/mod.rs\` adds \`run_handlers_with_panic_guard(handlers, ctx)\` — wraps each \`handler.run(...)\` in \`std::panic::catch_unwind\` with \`AssertUnwindSafe\`. On caught panic:
- handler identity + payload logged via \`tracing::error!\` (\`#1002\` tag)
- iteration continues — handlers N+1..end on same tick still run
- next tick re-invokes the failed handler (no permanent skip)

Folds in #941 per-handler timing (was inline in main loop). \`src/daemon/mod.rs:717\` replaces the manual \`for handler\` loop with the new helper.

### 2. PR-state observability

\`src/daemon/pr_state/mod.rs\` instruments every silent early-return with \`tracing::debug!\` carrying the \`#1002\` marker:

- **\`scan_and_emit_with\`**: read_dir / read_to_string / json parse failures
- **\`apply_gh_poll\`**: same trio plus per-tick \"grouping done\" summary (\`repos_to_poll\`, \`skipped_terminal\`, \`skipped_should_poll_cadence\`)
- **\`record_verdict\`**: 5 gates (A reviewed_head None / B task not found / C task.branch empty / D pr-state dir read fail / E no branch match)

Pre-fix code paths like \`let Ok(state) = serde_json::from_str(...) else { continue; };\` are rewritten as explicit \`match\` arms with debug emission. Idiomatic same-shape replacement; no logic change.

## Tests (4 new pins)

| Test | Location | Pin |
|---|---|---|
| \`panicking_handler_does_not_skip_siblings\` | per_tick::tests | 3-handler vec, middle panics → both siblings still run |
| \`panic_payload_str_handles_common_panic_types\` | per_tick::tests | Debug helper across String / &'static str / other |
| \`t15_malformed_pr_state_file_emits_observability_trace\` | pr_state::tests | malformed JSON → \`tracing_test::traced_test\` + \`logs_contain(\"#1002\")\` + filename |
| \`t16_record_verdict_gate_a_emits_observability_trace\` | pr_state::tests | \`reviewed_head=None\` → \`logs_contain(\"gate A\")\` |

2599 lib tests pass + clippy clean.

## §3.6 NOT eligible

Cross-subsystem touch (per_tick + pr_state), new public helper, behaviour change at panic boundary. Normal review.

## Phase 2 follow-up

Decided based on real \`#1002\` trace evidence collected post-deploy. Spike memo §4 lists candidate structural fixes (loosen gate B correlation_id match, dedicated verdict_telemetry log, webhook-as-primary). Phase 1 ships standalone so the diagnostic surface lands before any structural follow-up.

## Test plan
- [x] cargo test --bin agend-terminal (2599 pass)
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [ ] CI green on push
- [ ] reviewer VERIFIED
- [ ] §3.12.1 self-merge via gh pr merge --auto

🤖 Generated with [Claude Code](https://claude.com/claude-code)