### PR TITLE
fix(#1002 Phase 2): wire pr_state scan into supervisor loop (APP-mode fix)

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -270,6 +270,15 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
         auto_release_tracker.maybe_scan(&home);
         dispatch_idle_tracker.maybe_scan(&home);
         dispatch_idle_fixup_nudge_tracker.maybe_scan(&home);
+        // #1002 Phase 2: pr_state per-tick scan must run here so APP
+        // mode (`agend-terminal app`) drives the #972 aggregator + #986
+        // gh-poll integration the same way as daemon mode. Before this
+        // line, `PrStateScanHandler` was wired ONLY into `run_core`'s
+        // `PerTickHandler` vec (dual-entry-point divergence); APP-mode
+        // operators (the agent fleet) saw `last_gh_poll_at: null`
+        // indefinitely + no `[pr-ready-for-merge]` events.
+        // Source-pin: `pr_state_scan_wired_into_supervisor_loop`.
+        crate::daemon::pr_state::scan_and_emit(&home, &registry);
         // #836: reclaim expired (10-min TTL) entries from the
         // notification-dedup ledger so memory pressure stays bounded
         // on long-lived daemons.
@@ -2007,5 +2016,31 @@ mod tests {
         );
         std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
         std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1002 Phase 2 source-pin: supervisor's per-tick loop MUST call
+    /// `crate::daemon::pr_state::scan_and_emit`. The #972 / #986
+    /// aggregator + gh-poll integration was previously wired only via
+    /// `run_core`'s `PerTickHandler` vec (daemon-only entry). In APP
+    /// mode (`agend-terminal app`), `run_core` is never called — the
+    /// supervisor loop is the canonical per-tick driver instead.
+    /// Without this wiring, `last_gh_poll_at: null` persists
+    /// indefinitely and `[pr-ready-for-merge]` events never emit.
+    ///
+    /// File-level positive pin (cross-platform-safe; same pattern as
+    /// `app::tests::flush_idle_notifications_wired_to_submit_aware_inject`
+    /// from #982 RC2). If a future refactor moves the call out of
+    /// the loop, update this assertion alongside.
+    #[test]
+    fn pr_state_scan_wired_into_supervisor_loop() {
+        let source = std::fs::read_to_string("src/daemon/supervisor.rs")
+            .or_else(|_| std::fs::read_to_string("agend-terminal/src/daemon/supervisor.rs"))
+            .expect("source file must be readable from test cwd");
+        assert!(
+            source.contains("pr_state::scan_and_emit"),
+            "supervisor per-tick loop must invoke pr_state::scan_and_emit \
+             (#1002 Phase 2 dual-entry-point fix). Without this, APP-mode \
+             daemons silently skip the #972 aggregator + #986 gh-poll path."
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes the dual-entry-point wiring divergence that left #972 (PR-state aggregator) + #986 (gh-poll integration) silently dead in APP mode (\`agend-terminal app\`). Empirically confirmed via dogfood PR #1006 + spike memo \`/tmp/dialectic-1002-phase2-evidence-dev.md\`.

## Root cause

\`PrStateScanHandler\` was wired ONLY into \`run_core\`'s \`PerTickHandler\` vec (daemon-only entry). The agent fleet runs \`agend-terminal app\` (APP mode), which:
- Spawns \`api::serve\` (API listener)
- Spawns \`supervisor::spawn\` (per-tick loop)
- Does **NOT** call \`run_core\`

Most per_tick concerns (anti_stall, idle_watchdog, waiting_on_stale, mcp_registry_watcher, etc.) are wired DIRECTLY into the supervisor loop and fire correctly. \`PrStateScanHandler\` was placed behind the partial \`PerTickHandler\` abstraction and never wired into supervisor.

## Evidence

- daemon PID 30543 running post-#1004 binary (lsof + strings confirm all \`#1002\` markers present)
- \`fix/1002-observability-panic-guard.json\` pr-state file: \`last_gh_poll_at: null\` for 28+ min — gh-poll body never entered
- Dogfood PR #1006 + 5-min Monitor: no pr-state file created, zero \`#1002\` traces in app.log
- Other per_tick handlers visible (ci_watch, idle_watchdog, waiting_on_stale) — supervisor IS running; pr_state specifically is missing from its loop

## Change

Insert \`crate::daemon::pr_state::scan_and_emit(&home, &registry);\` in supervisor's per-tick loop next to \`dispatch_idle_fixup_nudge_tracker.maybe_scan(&home);\`. ~2 LOC plus a comment block linking back to spike memo.

## Test

- \`pr_state_scan_wired_into_supervisor_loop\`: source-level positive pin (cross-platform-safe pattern from #982 RC2). Asserts \`supervisor.rs\` body contains literal \`pr_state::scan_and_emit\`.

2601 lib tests pass + clippy clean.

## ROOT 2 cross-reference

The spike + Phase 1 memo flagged ROOT 2 as \`record_verdict\` predicate gates A-E silently mismatching. \`record_verdict\` is called from \`messaging.rs:handle_send\` (API thread), NOT from per_tick — so this Phase 2 wiring fix does **NOT** directly address ROOT 2.

**However**: after this fix lands + operator restart, Phase 1's \`info!\`-level gate traces will surface for the next verdict-bearing PR. If \`verdict_state\` stays None despite gates being instrumented, ROOT 2 is its own bug — file separately.

## Architectural follow-up deferred (Option B)

~30 LOC: extract handlers vec into \`per_tick::default_handlers(...)\` constructor; both \`run_core\` and supervisor call \`run_handlers_with_panic_guard\`. Unified wiring. Per lead synthesis, not in scope for this PR — revisit after Phase 2 efficacy verified.

## Acceptance criteria

- ✅ Supervisor invokes \`pr_state::scan_and_emit\` every tick in both modes
- ✅ Source pin test passes
- ✅ All existing tests pass (2601)
- ⏳ Post-merge + operator restart + dogfood/real PR → \`last_gh_poll_at\` non-null + \`#1002\` traces emerge

## Test plan
- [x] cargo test --bin agend-terminal (2601 pass)
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [ ] CI green on push
- [ ] reviewer VERIFIED
- [ ] §3.12.1 self-merge
- [ ] post-merge dogfood verifies autonomous flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)