### PR TITLE
feat(#686): CI code coverage (cargo-llvm-cov + Codecov)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,3 +209,43 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # #686 (F11): maintainer-side QA infrastructure. Runs cargo-llvm-cov on
+  # Ubuntu only (cross-platform consistency comes from `check` job; coverage
+  # of *what code is exercised* is platform-independent), uploads lcov report
+  # to Codecov. `fail_ci_if_error: false` keeps PR mergeable when codecov.io
+  # is unreachable or unconfigured — coverage is observation infra, not a
+  # blocking gate. Linux tray deps installed for parity with `check` job so
+  # the same `--features tray` compilation surface is measured.
+  #
+  # End-user impact: ZERO — coverage is maintainer-side QA. `cargo install
+  # agend-terminal` and running the fleet do not touch codecov.
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      - name: Install Linux tray deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run coverage
+        timeout-minutes: 35
+        env:
+          AGEND_LOCK_AUDIT: "1"
+        run: cargo llvm-cov --workspace --tests --features tray --lcov --output-path coverage.lcov
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.lcov
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 - **`bootstrap-step` instrumentation (#945 Phase 0)** — every step in `bootstrap::prepare` emits a `bootstrap-step` tracing line with `step=<name>` + `elapsed_ms=<n>`. Operators can extract the cold-boot timing breakdown via `grep "bootstrap-step" $AGEND_HOME/daemon.log | sort -t= -k3 -n -r`.
 - **State detection red SGR anchor for HIGH_FP patterns (#919 Phase A)** — patterns marked `HIGH_FP` (generic strings like `"Error"`, `"failed"`) now require a red SGR escape (`\x1b[31m` family) within 200 bytes / 30 s of the match. Closes the class of false transitions where a backend echoed an error string from a user prompt without color and the daemon misclassified the agent. `Backend::has_red_anchor()` opts in per-backend; the gate fails open when the backend doesn't emit consistent color signaling.
 
+### Added (#686 — maintainer-only)
+
+- **CI code coverage (cargo-llvm-cov + Codecov)** — `.github/workflows/ci.yml` adds a new `coverage` job that runs `cargo llvm-cov --workspace --tests --features tray` on Ubuntu and uploads an lcov report to Codecov. `fail_ci_if_error: false` keeps PRs mergeable when codecov.io is unreachable or unconfigured. `codecov.yml` configures a 2% project threshold + 80% patch target. **Zero end-user impact** — coverage is maintainer-side QA infrastructure; `cargo install agend-terminal` and operating the fleet do not touch codecov. Operator-side setup: link the GitHub repo to Codecov.io to surface the report (no token required for public repos; optional `CODECOV_TOKEN` secret tightens rate limits).
+
 ### Changed
 
 - **`agend-terminal list --json` envelope (#938)** — JSON output now wraps the agent array in a discriminated envelope: `{mode: "live" | "fallback_daemon_stuck" | "fallback_daemon_absent", agents: [...]}`. Operator scripts can distinguish authoritative output from offline fallbacks. Plain (non-JSON) output adds a one-line stderr hint when `mode != live`. `--legacy-json` opts back into the pre-#938 shape for one release cycle.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,18 @@ cargo clippy -- -D warnings          # must be warning-free
 
 CI mirrors these steps on Ubuntu + macOS + Windows (`.github/workflows/ci.yml`).
 
+### Coverage (optional, local)
+
+The `coverage` CI job (#686) runs `cargo-llvm-cov` on Ubuntu and uploads an lcov report to Codecov. To measure locally:
+
+```bash
+cargo install cargo-llvm-cov                  # one-time
+cargo llvm-cov --workspace --tests            # text summary
+cargo llvm-cov --workspace --tests --html     # HTML report at target/llvm-cov/html/index.html
+```
+
+Coverage is observation-only — not a merge gate. PRs that drop project coverage by more than 2% surface as a red Codecov status; the merge decision stays with the reviewer. New code in a PR is expected to hit 80% coverage (configurable in `codecov.yml`).
+
 ## Workflow
 
 1. **Branch from `main`** — never modify `main` directly. Worktrees are preferred over in-place branch switching:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,32 @@
+# #686 (F11): Codecov config — maintainer-side QA infrastructure only.
+#
+# Operator note: coverage report visibility requires the GitHub repo to be
+# linked to Codecov.io. Token (optional but stricter rate limits) goes in
+# the `CODECOV_TOKEN` GitHub secret. When unlinked / unconfigured, the CI
+# job still runs `cargo llvm-cov` and produces `coverage.lcov`; only the
+# upload step soft-fails (`fail_ci_if_error: false`).
+
+coverage:
+  # Use Codecov's adaptive thresholds rather than a hand-picked absolute %.
+  # Auto uses the previous build's coverage as the baseline.
+  status:
+    project:
+      default:
+        target: auto
+        # Allow up to a 2% drop without failing the project-level check.
+        # Larger drops surface as a red PR status — operator can decide
+        # whether to accept the regression or block the merge.
+        threshold: 2%
+    patch:
+      default:
+        # New code introduced in a PR should hit 80% coverage. Pure-config
+        # or pure-data PRs (.yml / .md changes) are exempt because llvm-cov
+        # produces no records for them — Codecov treats absence as PASS.
+        target: 80%
+
+# Suppress the auto-comment on PRs that touch only CI / docs — those have
+# no code coverage to report and the comment becomes noise.
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

Closes #686 (F11). Health audit 2026-05 raised the coverage gap (auditor-kiro C-1, AGREE 5/5): 13.3 KLOC concentrated in daemon-core mega-files with zero coverage visibility, demonstrated by F3 (#682) where `gc_candidates()` tests used legacy-layout fixtures while production wrote to new layout — 0% real-path coverage masked a silent worktree leak that passed CI.

Operator decision 2026-05-12 (option a): add `cargo-llvm-cov` measurement + Codecov reporting.

## Changes

- **`.github/workflows/ci.yml`** — new `coverage` job (Ubuntu only):
  - `taiki-e/install-action@cargo-llvm-cov` for the install step
  - `cargo llvm-cov --workspace --tests --features tray --lcov` measures the same compilation surface as the `check` job's test step
  - `codecov/codecov-action@v4` with `fail_ci_if_error: false` — codecov.io outages / missing tokens soft-fail
  - Linux tray deps installed for parity with `check`
  - 45-min job / 35-min llvm-cov step timeouts (cargo-llvm-cov rebuilds from scratch; first run ~10-15 min)
- **`codecov.yml`** (new) — 2% project threshold + 80% patch target + comment suppressed when no code coverage changes
- **`CONTRIBUTING.md`** — "Coverage (optional, local)" subsection explaining `cargo llvm-cov` local usage + observation-only stance
- **`CHANGELOG.md`** — maintainer-facing entry under [Unreleased]

## Acceptance

- [x] New `coverage` job in CI workflow
- [x] YAML syntax clean (validated via `python3 -c 'yaml.safe_load(...)'` on both files)
- [x] codecov upload soft-fails when token missing (`fail_ci_if_error: false`)
- [x] No production src changes — pure CI infra + docs
- [ ] Job actually runs green in CI (this PR is the validation; cargo-llvm-cov on Ubuntu is well-documented, expected to pass)
- [ ] Codecov status surfaces on PR (requires operator to link repo to Codecov.io — out of PR scope)

## Operator action required (post-merge)

To see the Codecov report on subsequent PRs:
1. Link the GitHub repo to Codecov.io ([codecov.io/github/suzuke/agend-terminal](https://codecov.io/github/suzuke/agend-terminal)) — free for public repos, no signup beyond GitHub OAuth
2. Optional: add `CODECOV_TOKEN` GitHub secret (Repository Settings → Secrets and variables → Actions) for stricter rate-limit treatment. Without it, public repos get OIDC trust automatically.

Without the link, the CI job still runs `cargo llvm-cov` and produces lcov locally (visible in the action run); only the upload step soft-fails.

**End-user impact: ZERO** — coverage is maintainer-side QA. `cargo install agend-terminal` and operating the fleet never touch codecov.

## §3.6 / §3.10 / §3.12

- ~88 LOC net (40 CI workflow + 36 codecov.yml + 12 CONTRIBUTING.md + 4 CHANGELOG). Pure infra + docs, no production src change.
- §3.6 ELIGIBLE — maintainer-only QA infrastructure, no src behavior change.
- §3.10 N/A — no behavior under test; this PR adds the measurement infra.
- §3.12 mirror after reviewer VERIFIED.
- §3.12.1 ACTIVE — `gh pr merge --auto --squash --delete-branch` post-VERIFIED (or admin path per operator's new memory).

## Related

- Issue #686 — root + operator decision
- Issue #682 (F3) — concrete coverage-gap-masking-bug example referenced in #686 body

🤖 Generated with [Claude Code](https://claude.com/claude-code)