### PR TITLE
docs(#704 sub-task 3 follow-up): add agy backend to release smoke checklist

### DIFF
--- a/docs/release-smoke-checklist.md
+++ b/docs/release-smoke-checklist.md
@@ -57,6 +57,16 @@ Run one block per backend. Skip a block if the binary is not installed; note it 
 - [ ] **Tool use** — inject `list files in /tmp`; tool affordance fires
 - [ ] **Quit** — inject `/exit` + Enter; pane closes; no orphan `gemini` process
 
+### 1f. Antigravity CLI (`agy`, registered as backend `antigravity-cli`) — #987
+
+Gemini CLI's official successor (Gemini CLI sunsets 2026-06-18 for free / Pro / Ultra tiers). The binary command is `agy`; the fleet display name is `antigravity-cli` (#995).
+
+- [ ] **Spawn** — `agend start --agents agy-smoke:agy` — ready prompt (`Antigravity CLI` banner or `Type your message`) appears within **20 s**; workspace-trust dialog auto-dismissed (#995 dismiss_pattern)
+- [ ] **Echo** — inject `echo hello` + Enter; response visible
+- [ ] **Tool use** — inject `list files in /tmp`; tool affordance fires
+- [ ] **Quit** — inject `/exit` + Enter; pane closes; no orphan `agy` process
+- [ ] **Fleet MCP unsupported notice (#995 Bug 3)** — `app.log` MUST contain a `[fleet-mcp-unsupported]` `tracing::warn` line on this spawn; the spawned agy instance has NO `send` / `inbox` / `task` MCP tools (awaiting upstream `google-antigravity/antigravity-cli#60`). For multi-agent fleet work, prefer the `gemini` backend until upstream lands the fix.
+
 ---
 
 ## 2. Cross-cutting (≤ 5 min)
@@ -85,6 +95,7 @@ Backends tested (paste `<backend> --version` output for each):
 - codex:      <version>
 - opencode:   <version>
 - gemini:     <version>
+- agy:        <version>   # registered as backend `antigravity-cli` per #995
 
 Backends skipped (reason):
 -
@@ -93,4 +104,10 @@ Known deviations / new failures observed:
 -
 
 Overall verdict: [ ] PASS  [ ] PASS with caveats  [ ] FAIL
+```
+
+When all backends pass, the release PR body should also include the one-line confirmation:
+
+```
+Real-backend smoke: ✓ all 6 backends
 ```


### PR DESCRIPTION
## Summary

Closes the gap dispatched as #704 sub-task 3 dispatch but discovered already covered: the release smoke checklist was shipped via #756 with **5 backends**. The current target per #704 dispatch (and #987 fleet) is **6 backends including `agy`**. This PR adds the missing §1f section + sign-off line so the checklist matches the post-#987 reality.

## Discovery

When I bound the worktree to start sub-task 3, I found `docs/release-smoke-checklist.md` already exists (96 lines) — PR #756 merged 2026-05-13 covered the foundational checklist. But that PR predates #987 (`agy` backend added 2026-05-20) and #995 (agy polish 2026-05-20). So the existing file lists 5 backends without `agy`.

Reporting to lead via @fixup-lead: PR #756 covered the bulk of the task; this is the follow-up needed to bring it current with #987 / #995. Treat this as the "Sub-task 3 — add agy row" delta, not a full rewrite.

## Changes (1 file, +17 LOC)

- **§1f Antigravity CLI (`agy`, registered as `antigravity-cli`)** — mirrors other backends' Spawn / Echo / Tool use / Quit shape, plus a #995 Bug 3 specific check:
  - `app.log` MUST contain `[fleet-mcp-unsupported]` `tracing::warn` on spawn (because the project-local `mcp_config.json` mcpServers field is ignored by AGY — upstream `google-antigravity/antigravity-cli#60` tracks the fix)
  - Operators should prefer `gemini` for fleet MCP work until upstream lands the fix
- **Sign-off block** — adds `agy: <version>` line + a `Real-backend smoke: ✓ all 6 backends` one-liner suggested for the release PR body (per dispatch acceptance)

## Acceptance (from dispatch)

- [x] `docs/release-smoke-checklist.md` exists with 5+1 backend (含 agy) checklist (file existed; agy added)
- [x] Operator can directly follow + run 10-15 min smoke
- [ ] CHANGELOG entry — skipped per dispatch ("optional, 看你判斷"); 17-LOC docs delta inside an existing v1.0+ document doesn't warrant a CHANGELOG entry
- [x] PR body references #704

## §3.6 / §3.10 / §3.12

- 17 LOC pure docs, no src change, no test change. **§3.6 ELIGIBLE.**
- §3.10 N/A (no code path under test).
- §3.12 mirror after reviewer VERIFIED. fixup-reviewer still in usage_limit (last heartbeat 18:26Z) — dispatch suggested cross-author dev review is appropriate since this is §3.6 docs.
- §3.12.1 ACTIVE — `gh pr merge --auto --squash --delete-branch` post-VERIFIED (or admin per operator memory).

## Related

- Issue #704 — root sub-task tracking
- PR #756 — original checklist (merged 2026-05-13)
- #987 — added agy backend
- #995 — agy backend polish (display name + trust dismiss + fleet_mcp_supported flag)
- `google-antigravity/antigravity-cli#60` — upstream fix tracking for agy MCP project-local support

🤖 Generated with [Claude Code](https://claude.com/claude-code)