### PR TITLE
fix(#1024): forward reviewed_head in MCP handle_send (closes #1002 ROOT 2)

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -92,17 +92,8 @@ pub(super) fn handle_send_to_instance(
         home,
         &json!({
             "method": crate::api::method::SEND,
-            // #1024 (closes #1002 ROOT 2): include `reviewed_head` in
-            // the forwarded params. Pre-fix this field was silently
-            // dropped at the MCP boundary, causing the API SEND
-            // handler to receive `msg.reviewed_head: None`, which
-            // failed `auto_release::is_verdict_message`'s
-            // `reviewed_head.is_some()` predicate. Net:
-            // `record_verdict` never called for any MCP-send verdict;
-            // `verdict_state` stuck at None; autonomous self-merge
-            // flow broken. Mirrors `handle_report_result`'s existing
-            // forwarding pattern. See
-            // `/tmp/dialectic-1002-root2-spike-dev.md` for the spike.
+            // #1024 (closes #1002 ROOT 2): `reviewed_head` MUST be forwarded; see
+            // sibling `handle_report_result` + `auto_release::is_verdict_message`.
             "params": { "from": sender.as_str(), "target": target, "text": text, "kind": kind, "thread_id": thread_id, "parent_id": parent_id, "correlation_id": args["correlation_id"].as_str(), "reviewed_head": args["reviewed_head"].as_str(), "sequencing": args["sequencing"].as_str(), "eta_minutes": args["eta_minutes"].as_u64(), "reporting_cadence": args["reporting_cadence"].as_str(), "worktree_binding_required": args["worktree_binding_required"].as_bool(), "expect_reply_within_secs": args["expect_reply_within_secs"].as_i64() }
         }),
     ) {

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -92,7 +92,18 @@ pub(super) fn handle_send_to_instance(
         home,
         &json!({
             "method": crate::api::method::SEND,
-            "params": { "from": sender.as_str(), "target": target, "text": text, "kind": kind, "thread_id": thread_id, "parent_id": parent_id, "correlation_id": args["correlation_id"].as_str(), "sequencing": args["sequencing"].as_str(), "eta_minutes": args["eta_minutes"].as_u64(), "reporting_cadence": args["reporting_cadence"].as_str(), "worktree_binding_required": args["worktree_binding_required"].as_bool(), "expect_reply_within_secs": args["expect_reply_within_secs"].as_i64() }
+            // #1024 (closes #1002 ROOT 2): include `reviewed_head` in
+            // the forwarded params. Pre-fix this field was silently
+            // dropped at the MCP boundary, causing the API SEND
+            // handler to receive `msg.reviewed_head: None`, which
+            // failed `auto_release::is_verdict_message`'s
+            // `reviewed_head.is_some()` predicate. Net:
+            // `record_verdict` never called for any MCP-send verdict;
+            // `verdict_state` stuck at None; autonomous self-merge
+            // flow broken. Mirrors `handle_report_result`'s existing
+            // forwarding pattern. See
+            // `/tmp/dialectic-1002-root2-spike-dev.md` for the spike.
+            "params": { "from": sender.as_str(), "target": target, "text": text, "kind": kind, "thread_id": thread_id, "parent_id": parent_id, "correlation_id": args["correlation_id"].as_str(), "reviewed_head": args["reviewed_head"].as_str(), "sequencing": args["sequencing"].as_str(), "eta_minutes": args["eta_minutes"].as_u64(), "reporting_cadence": args["reporting_cadence"].as_str(), "worktree_binding_required": args["worktree_binding_required"].as_bool(), "expect_reply_within_secs": args["expect_reply_within_secs"].as_i64() }
         }),
     ) {
         Ok(resp) if resp["ok"].as_bool() == Some(true) => {

--- a/src/mcp/handlers/comms_p0c_tests.rs
+++ b/src/mcp/handlers/comms_p0c_tests.rs
@@ -27,3 +27,27 @@ fn proceed_auto_bind_when_bind_absent() {
     let args = json!({"branch": "feat/x"});
     assert!(!dispatch_should_skip_auto_bind(&args));
 }
+
+/// #1024 (closes #1002 ROOT 2): source-pin asserting `handle_send`
+/// forwards the `reviewed_head` field to the API SEND params dict.
+/// Pre-fix the field was silently dropped at the MCP boundary,
+/// breaking the `auto_release::is_verdict_message` predicate's
+/// `reviewed_head.is_some()` gate and stranding every MCP-send
+/// verdict (zero `#1002 record_verdict` traces across all logs).
+///
+/// File-level positive pin (cross-platform-safe; same pattern as
+/// `app::tests::flush_idle_notifications_wired_to_submit_aware_inject`
+/// from #982 RC2). If a future refactor moves the params dict,
+/// update this assertion alongside.
+#[test]
+fn handle_send_forwards_reviewed_head_to_api_params() {
+    let source = std::fs::read_to_string("src/mcp/handlers/comms.rs")
+        .or_else(|_| std::fs::read_to_string("agend-terminal/src/mcp/handlers/comms.rs"))
+        .expect("source file must be readable from test cwd");
+    assert!(
+        source.contains("\"reviewed_head\": args[\"reviewed_head\"].as_str()"),
+        "handle_send params dict must forward `reviewed_head` (#1024 / #1002 ROOT 2 fix). \
+         Without this, MCP-send verdicts silently drop the field at the boundary and \
+         record_verdict never fires."
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1002 ROOT 2 — `verdict_state` stuck at None despite #1004 Phase 1 observability deployment. Single-line MCP param-drop in `src/mcp/handlers/comms.rs::handle_send`.

## Root cause (per dev spike `/tmp/dialectic-1002-root2-spike-dev.md`)

Empirical evidence: **ZERO `#1002 record_verdict` traces across ALL daemon logs** (multiple kind=report verdicts sent post-#1004; none reached the bridge). Code-path trace:

1. MCP `send` tool caller passes `reviewed_head=<sha>` as arg
2. `mcp/handlers/comms.rs:handle_send` constructs API SEND params dict — **OMITS `reviewed_head`** at line ~95
3. API SEND handler (`api/handlers/messaging.rs::handle_send`) receives `msg.reviewed_head: None`
4. `auto_release::is_verdict_message(msg)` fails on `reviewed_head.is_some()` predicate
5. `record_verdict` never called → no autonomous self-merge flow

**NOT** the same class as ROOT 1 / #1007 (APP-mode wire-in divergence) — `api::serve` runs in both daemon and APP mode, so the bridge wiring is fine. The bug is purely an MCP-side param-construction omission.

Sibling `handle_report_result` (line ~491) already forwards `reviewed_head` correctly — per-handler omission, not MCP-wide.

## Fix

1 LOC added to `handle_send` params dict at line ~95:

```rust
"reviewed_head": args["reviewed_head"].as_str(),
```

Plus rationale comment block citing #1002 spike + sibling pattern.

## Test

Source-pin regression in `comms_p0c_tests.rs`:

```rust
#[test]
fn handle_send_forwards_reviewed_head_to_api_params() {
    let source = std::fs::read_to_string("src/mcp/handlers/comms.rs")
        .or_else(|_| std::fs::read_to_string("agend-terminal/src/mcp/handlers/comms.rs"))
        .expect("source file must be readable from test cwd");
    assert!(
        source.contains("\"reviewed_head\": args[\"reviewed_head\"].as_str()"),
        "handle_send params dict must forward `reviewed_head` ..."
    );
}
```

Same cross-platform-safe source-pin pattern as #982 RC2 + #1007 wiring pins.

2639 lib tests pass + clippy clean.

## Post-merge verification

```bash
# 1. Restart daemon (operator action)
# 2. Send a test verdict via MCP send
mcp__agend-terminal__send target=lead request_kind=report \
  reviewed_head=abc123 correlation_id=t-test message="VERIFIED test"
# 3. Grep app.log
grep "#1002 record_verdict" ~/.agend-terminal/app.$(date +%F).log
```

Expected: `#1002 record_verdict skipped (gate B) — task not found in task board; correlation_id likely mismatched ...` info trace. Confirms bridge reach + function execution.

## NOT in scope (open questions §7 of spike memo)

- `reply` MCP tool same-class check (separate scan)
- Struct-typed forwarding helper (architectural cleanup candidate)
- §3.12 SOP docs refresh
- `git blame` historical check (was this ever wired?)

## §3.6 / §3.10

- **§3.6 ELIGIBLE**: 1 LOC src + 1 test, no semantic change downstream
- **§3.10 RED→GREEN viable**: regression-pin serves as RED (pre-fix grep fails); fix is GREEN

## Cross-refs

- Issue #1002 — autonomous-flow deviation spike (ROOT 1 closed by #1007; this PR closes ROOT 2)
- PR #1004 — Phase 1 observability deployment (whose traces' absence is the smoking-gun evidence)
- PR #1007 — ROOT 1 fix (similar 2-LOC wire pattern, same class of "code-path drift")
- `/tmp/dialectic-1002-root2-spike-dev.md` — dev spike with full diagnosis

## Test plan
- [x] cargo test --bin agend-terminal (2639 pass)
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [ ] CI green
- [ ] reviewer VERIFIED
- [ ] §3.12.1 self-merge
- [ ] post-restart dogfood verification fires #1002 trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)