### PR TITLE
fix(#1030): wake reviewer on CI green via enqueue_with_idle_hint

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1129,7 +1129,14 @@ async fn ci_check_repo(
                     &repo_branch_key,
                     &supersede_token,
                 );
-                let _ = crate::inbox::enqueue(
+                // #1030: enqueue_with_idle_hint replaces raw enqueue
+                // so the durable inbox write is paired with a
+                // [AGEND-MSG-PENDING] PTY hint that wakes idle backends.
+                // Pre-#1030 the line 1040 inject was the only wake
+                // signal for live subscribers; agents that had cycled
+                // their PTY (session restart, compose-mode entry) saw
+                // the inbox entry but never woke until polled manually.
+                let _ = crate::inbox::enqueue_with_idle_hint(
                     home,
                     sub,
                     crate::inbox::InboxMessage {
@@ -1171,7 +1178,15 @@ async fn ci_check_repo(
         new_notified_conclusion = conclusion.map(String::from);
     }
 
-    // Issue #650: auto-route [ci-ready-for-action] to next_after_ci target on pass
+    // Issue #650 + #1030: auto-route [ci-ready-for-action] to
+    // next_after_ci target on pass. Pre-#1030 this was a PTY-only
+    // inject (only wakes attentive agents; codex/claude-code idle
+    // backends received text in their PTY buffer but never submitted).
+    // Now uses enqueue_with_idle_hint so the durable JSONL inbox carries
+    // the event AND a [AGEND-MSG-PENDING] PTY hint fires to wake the
+    // recipient. Drop the registry lookup — enqueue_with_idle_hint
+    // delivers durably regardless of agent presence, which is the
+    // correct semantic for an actionable handoff.
     if new_notified_sha.is_some() {
         if let Ok(content) = std::fs::read_to_string(watch_path) {
             if let Ok(watch) = serde_json::from_str::<serde_json::Value>(&content) {
@@ -1179,13 +1194,9 @@ async fn ci_check_repo(
                     // Only route on success (not failure)
                     let last_conclusion = aggregate_conclusion_for_sha(&runs, current_sha);
                     if last_conclusion == Some("success") {
-                        let msg =
-                            format!("[ci-ready-for-action] {repo}@{branch}: CI passed, your turn.");
-                        let reg = agent::lock_registry(registry);
-                        if let Some(handle) = reg.get(next) {
-                            let _ = agent::inject_to_agent(handle, msg.as_bytes());
-                        }
-                        drop(reg);
+                        let repo_branch_key = format!("{repo}@{branch}");
+                        let msg = make_ci_ready_for_action_msg(repo, branch, &repo_branch_key);
+                        let _ = crate::inbox::enqueue_with_idle_hint(home, next, msg);
                     }
                 }
 
@@ -3801,10 +3812,7 @@ mod tests {
         ))
         .unwrap();
         let messages = crate::inbox::drain(&dir, "reviewer");
-        let from_ci: Vec<_> = messages
-            .iter()
-            .filter(|m| m.from == "system:ci")
-            .collect();
+        let from_ci: Vec<_> = messages.iter().filter(|m| m.from == "system:ci").collect();
         assert_eq!(
             from_ci.len(),
             1,

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -621,6 +621,46 @@ fn ci_notification_message(
     Some(msg)
 }
 
+/// Build the `[ci-ready-for-action]` inbox message handed to the
+/// `next_after_ci` chain target on CI pass (#1030). Single construction
+/// site so the production emit and the deterministic-hint test (T4)
+/// see identical bytes.
+pub(crate) fn make_ci_ready_for_action_msg(
+    repo: &str,
+    branch: &str,
+    repo_branch_key: &str,
+) -> crate::inbox::InboxMessage {
+    crate::inbox::InboxMessage {
+        schema_version: 0,
+        id: None,
+        read_at: None,
+        thread_id: None,
+        parent_id: None,
+        task_id: None,
+        force_meta: None,
+        // Same canonical `{repo}@{branch}` form used by the [ci-pass]
+        // subscriber enqueue so inbox readers can correlate the two.
+        correlation_id: Some(repo_branch_key.to_string()),
+        reviewed_head: None,
+        from: "system:ci".to_string(),
+        text: format!("[ci-ready-for-action] {repo}@{branch}: CI passed, your turn."),
+        kind: Some("ci-ready-for-action".to_string()),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        channel: None,
+        delivery_mode: None,
+        attachments: vec![],
+        in_reply_to_msg_id: None,
+        in_reply_to_excerpt: None,
+        superseded_by: None,
+        from_id: None,
+        broadcast_context: None,
+        sequencing: None,
+        eta_minutes: None,
+        reporting_cadence: None,
+        worktree_binding_required: None,
+    }
+}
+
 /// Fetch latest CI run and notify ALL subscribed agents on any
 /// terminal conclusion (success, failure, cancelled, timed_out, etc.).
 /// Also tracks `head_sha` — if the branch HEAD changes (e.g. force push),
@@ -3437,6 +3477,344 @@ mod tests {
                 "{sub} inbox payload mismatch: {body}"
             );
         }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ----------------------------------------------------------------------
+    // #1030 RED→GREEN — reviewer auto-wake on CI green.
+    //
+    // Two emit sites in `ci_check_repo` bypass the wake-aware
+    // `enqueue_with_idle_hint` path: site 2 (subscriber [ci-pass] enqueue,
+    // line ~1092) and site 3 (next_after_ci chain target, PTY-only inject
+    // ~lines 1142-1149). The empirical symptom (PRs #1028+#1029): reviewer
+    // sits idle 7 min after CI green until lead manually kicks.
+    //
+    // Tests below: T2/T5/T6 fail RED (chain target has no durable inbox
+    // entry today) and pass GREEN (site 3 swap lands a [ci-ready-for-action]
+    // inbox entry with idle-hint wake). T1/T3 anti-regress the subscriber
+    // fan-out + chain-target dedup. T4 stands alone via the
+    // `enqueue_with_idle_hint_with_emitter` test seam.
+    // ----------------------------------------------------------------------
+
+    /// Helper: a base watch JSON pre-populated with two subscribers + an
+    /// optional `next_after_ci` chain target. Matches the production
+    /// `repo action=checkout bind=true` + `send(kind=task, next_after_ci=...)`
+    /// flow that empirically produced the #1030 wake gap.
+    fn watch_with_chain(next_after_ci: Option<&str>) -> serde_json::Value {
+        let mut watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [
+                {"instance": "lead", "subscribed_at": "2026-05-21T00:00:00Z"},
+                {"instance": "dev",  "subscribed_at": "2026-05-21T00:00:01Z"}
+            ],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        if let Some(n) = next_after_ci {
+            watch["next_after_ci"] = serde_json::json!(n);
+        }
+        watch
+    }
+
+    /// T1 (anti-regression for site 2 swap): with the [ci-pass]
+    /// subscriber enqueue moving from raw `enqueue` to `enqueue_with_idle_hint`,
+    /// every subscriber's durable JSONL inbox MUST still receive the
+    /// `[ci-pass]` line (existing wake-blind path is what survives).
+    #[test]
+    fn ci_pass_subscriber_inbox_anti_regression() {
+        let dir = tmp_dir("1030-t1-anti-regression");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = watch_with_chain(None);
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 1,
+            conclusion: Some("success".to_string()),
+            head_sha: "abc1234".to_string(),
+            url: "https://example/run/1".to_string(),
+        }]);
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["lead".to_string(), "dev".to_string()],
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+        for sub in ["lead", "dev"] {
+            let messages = crate::inbox::drain(&dir, sub);
+            assert!(
+                messages.iter().any(|m| m.text.contains("[ci-pass]")),
+                "{sub} must still receive [ci-pass] after site 2 swap; got: {messages:?}"
+            );
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// T2 (RED→GREEN, primary signal for #1030): when `next_after_ci`
+    /// points at an agent, that agent MUST receive a durable
+    /// `[ci-ready-for-action]` inbox entry on CI pass. RED today —
+    /// site 3 is PTY-only with no inbox write, so the chain target's
+    /// JSONL stays empty. GREEN: site 3 swap lands an InboxMessage via
+    /// `enqueue_with_idle_hint`.
+    #[test]
+    fn ci_pass_chain_target_gets_durable_inbox_entry() {
+        let dir = tmp_dir("1030-t2-chain-target-inbox");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = watch_with_chain(Some("reviewer"));
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 2,
+            conclusion: Some("success".to_string()),
+            head_sha: "abc1234".to_string(),
+            url: "https://example/run/2".to_string(),
+        }]);
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["lead".to_string(), "dev".to_string()],
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+        let messages = crate::inbox::drain(&dir, "reviewer");
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.text.contains("[ci-ready-for-action]")),
+            "reviewer must receive a durable [ci-ready-for-action] inbox entry; got: {messages:?}"
+        );
+    }
+
+    /// T3 (anti-regression for site 2's chain-target skip): the
+    /// subscriber [ci-pass] loop must continue to SKIP an agent whose
+    /// name appears in `next_after_ci`. Without this skip, the chain
+    /// target would receive both [ci-pass] (subscriber) AND
+    /// [ci-ready-for-action] (chain), and the dedup line at poller.rs:1034
+    /// is what keeps it to one. Test guards against accidental removal.
+    #[test]
+    fn ci_pass_chain_target_excluded_from_subscriber_loop() {
+        let dir = tmp_dir("1030-t3-chain-skip");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = watch_with_chain(Some("reviewer"));
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 3,
+            conclusion: Some("success".to_string()),
+            head_sha: "abc1234".to_string(),
+            url: "https://example/run/3".to_string(),
+        }]);
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        // Reviewer NOT in subscribers; only in next_after_ci.
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["lead".to_string(), "dev".to_string()],
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+        let messages = crate::inbox::drain(&dir, "reviewer");
+        assert!(
+            !messages.iter().any(|m| m.text.contains("[ci-pass]")),
+            "reviewer must NOT receive a [ci-pass] subscriber entry; got: {messages:?}"
+        );
+    }
+
+    /// T4 (deterministic hint delivery via test seam):
+    /// `make_ci_ready_for_action_msg` produces an InboxMessage that,
+    /// when passed through `enqueue_with_idle_hint_with_emitter`,
+    /// generates the expected `[AGEND-MSG-PENDING]` hint string. Passes
+    /// in both RED and GREEN — invariant on the helper's wire output.
+    #[test]
+    fn ci_ready_for_action_hint_format_deterministic() {
+        let dir = tmp_dir("1030-t4-hint-format");
+        std::fs::create_dir_all(&dir).unwrap();
+        let msg = super::make_ci_ready_for_action_msg("o/r", "feat", "o/r@feat");
+        let captured: std::sync::Arc<parking_lot::Mutex<Option<String>>> =
+            std::sync::Arc::new(parking_lot::Mutex::new(None));
+        let cap = captured.clone();
+        crate::inbox::enqueue_with_idle_hint_with_emitter(&dir, "reviewer", msg, move |hint| {
+            *cap.lock() = Some(hint.to_string());
+        })
+        .unwrap();
+        let hint = captured.lock().clone().expect("emitter must fire once");
+        assert!(
+            hint.contains("kind=ci-ready-for-action"),
+            "hint must carry kind for downstream filtering; got: {hint}"
+        );
+        assert!(
+            hint.contains("from=system:ci"),
+            "hint must carry from for routing; got: {hint}"
+        );
+        assert!(
+            hint.contains("inbox="),
+            "hint must carry pending count for recipient bookkeeping; got: {hint}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// T5 (RED→GREEN): the chain-target inbox entry's `kind` field
+    /// MUST be `"ci-ready-for-action"` so downstream agent filters can
+    /// distinguish it from the regular `ci-watch` fan-out. RED today —
+    /// no entry exists, so no kind to inspect. GREEN: kind matches.
+    #[test]
+    fn ci_pass_chain_target_inbox_kind_is_ready_for_action() {
+        let dir = tmp_dir("1030-t5-chain-target-kind");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = watch_with_chain(Some("reviewer"));
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 4,
+            conclusion: Some("success".to_string()),
+            head_sha: "abc1234".to_string(),
+            url: "https://example/run/4".to_string(),
+        }]);
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["lead".to_string(), "dev".to_string()],
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+        let messages = crate::inbox::drain(&dir, "reviewer");
+        let action = messages
+            .iter()
+            .find(|m| m.text.contains("[ci-ready-for-action]"))
+            .expect("chain target must have a [ci-ready-for-action] entry");
+        assert_eq!(
+            action.kind.as_deref(),
+            Some("ci-ready-for-action"),
+            "kind field must let downstream filter the chain event"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// T6 (RED→GREEN): when the chain target ALSO appears in
+    /// `subscribers` (overlap — e.g. operator opts the reviewer into
+    /// the watch alongside the dispatch chain), the agent must receive
+    /// EXACTLY ONE inbox entry — the `[ci-ready-for-action]` form
+    /// because the line 1034 dedup skip routes them out of the
+    /// subscriber fan-out. Today RED: 0 entries (PTY-only at site 3,
+    /// subscriber path skipped them, so they get nothing durable).
+    /// GREEN: 1 entry (the chain target inbox emit lands; subscriber
+    /// path still skips them; no double-fire).
+    #[test]
+    fn ci_pass_chain_target_no_double_fire_on_overlap() {
+        let dir = tmp_dir("1030-t6-chain-overlap");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = watch_with_chain(Some("reviewer"));
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 5,
+            conclusion: Some("success".to_string()),
+            head_sha: "abc1234".to_string(),
+            url: "https://example/run/5".to_string(),
+        }]);
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        // Reviewer is BOTH in subscribers AND next_after_ci.
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &[
+                "lead".to_string(),
+                "dev".to_string(),
+                "reviewer".to_string(),
+            ],
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+        let messages = crate::inbox::drain(&dir, "reviewer");
+        let from_ci: Vec<_> = messages
+            .iter()
+            .filter(|m| m.from == "system:ci")
+            .collect();
+        assert_eq!(
+            from_ci.len(),
+            1,
+            "chain target overlap must yield exactly 1 inbox entry; got: {from_ci:?}"
+        );
+        assert!(
+            from_ci[0].text.contains("[ci-ready-for-action]"),
+            "the single entry must be the chain form, not subscriber [ci-pass]: {:?}",
+            from_ci[0]
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -1289,8 +1289,18 @@ pub fn compose_aware_send(home: &Path, agent_name: &str, message: &str) {
 ///   [`crate::inbox::notify_agent`] on the same hop.
 /// - `daemon::supervisor` member-state-change emit — paired with
 ///   [`crate::inbox::notify_agent`].
-/// - `daemon::ci_watch::poller` (3 sites: 149/940/1092) — paired with
-///   the terminal-run fan-out's [`crate::agent::inject_to_agent`].
+/// - `daemon::ci_watch::poller`: only the [ci-pass] terminal-run
+///   subscriber loop (was line 1092, pre-#1030) was paired with the
+///   companion [`crate::agent::inject_to_agent`] call at line ~1040.
+///   #1030 migrated that site to [`enqueue_with_idle_hint`] because the
+///   PTY inject is only seen by attentive agents; idle backends
+///   (codex / claude-code at the prompt) needed the
+///   `[AGEND-MSG-PENDING]` wake hint to actually surface the CI
+///   transition. Two sibling poller sites — `emit_ci_conflict_alert`
+///   (#946, ~line 149) and the stale-SHA drop (#745, ~line 940) — still
+///   call bare [`enqueue`]; despite this comment's pre-#1030 wording
+///   they were never paired with a PTY inject in the same hop. Tracked
+///   for migration in #1032.
 /// - `mcp::handlers::instance` replace handover — the recipient is
 ///   being killed and respawned, so any hint to the about-to-be-dead
 ///   handle is a no-op and the fresh agent reads inbox on startup.


### PR DESCRIPTION
## Summary

- Reviewer auto-wake gap: `ci_check_repo` had two emit sites bypassing the wake-aware path. PR #1028 + #1029 empirical class — reviewer idle 7 min after CI green until lead manually kicked.
- Site 2 (`poller.rs:1092` subscriber `[ci-pass]` enqueue): raw `inbox::enqueue` → wake-aware `enqueue_with_idle_hint`.
- Site 3 (`poller.rs:1142-1149` `next_after_ci` chain `[ci-ready-for-action]`): PTY-only inject → durable `InboxMessage` via `enqueue_with_idle_hint`. Codex / claude-code idle backends now wake on the chain handoff.
- New helper `make_ci_ready_for_action_msg` is the single construction site shared by site 3 emit and the T4 deterministic-hint test.
- `inbox.rs:1292` comment rewritten per dev-2 catch from the 3-way dialectic: only site 1092 was actually paired with PTY inject; sibling sites 149 + 940 stay on bare `enqueue` (out of scope, tracked in #1032).

Closes #1030.

## Why

Operator-flagged recurring lead-manual-kick gap on every CI green. 3-way dialectic confirmed root cause + Bundle A scope (`/tmp/dialectic-1030-primary-dev.md`).

## Tests (§3.10 RED → GREEN)

RED commit `fe44d39` introduces 6 anchors as failing-against-current-impl:

| # | Test | RED | GREEN |
|---|---|---|---|
| T1 | `ci_pass_subscriber_inbox_anti_regression` | PASS | PASS — anti-regression of subscriber [ci-pass] entry after site 2 swap |
| T2 | `ci_pass_chain_target_gets_durable_inbox_entry` | **FAIL** | PASS — primary #1030 signal: chain target gets durable inbox entry |
| T3 | `ci_pass_chain_target_excluded_from_subscriber_loop` | PASS | PASS — anti-regression of poller.rs:1034 dedup skip |
| T4 | `ci_ready_for_action_hint_format_deterministic` | PASS | PASS — invariant via `enqueue_with_idle_hint_with_emitter` seam |
| T5 | `ci_pass_chain_target_inbox_kind_is_ready_for_action` | **FAIL** | PASS — chain-target inbox kind="ci-ready-for-action" for filtering |
| T6 | `ci_pass_chain_target_no_double_fire_on_overlap` | **FAIL** | PASS — overlap case: chain target also in subscribers → exactly 1 entry |

Reviewer verification:

```
git checkout fe44d39 && cargo test --bin agend-terminal -- \
    ci_pass_chain_target_gets_durable_inbox_entry \
    ci_pass_chain_target_inbox_kind_is_ready_for_action \
    ci_pass_chain_target_no_double_fire_on_overlap
# 3 FAIL (site 3 PTY-only; chain-target inbox empty)
git checkout HEAD && cargo test ...
# 6 PASS (impl wired)
```

Full suite: **2656 passed, 0 failed** (`cargo test --bin agend-terminal`).
fmt clean. `cargo clippy --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo build` (worktree)
- [x] `cargo test --bin agend-terminal` (2656 passed)
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] CI green on PR (per §3.3.1 reviewer/lead `gh pr checks 1030` independent verification)
- [ ] Post-merge dogfood: the NEXT PR after this lands should self-validate — reviewer should auto-wake on CI green without lead manual kick.

## Follow-ups (out of this PR scope, both filed)

- **#1031**: H2 payload enrichment (PR# / full head_sha / task_id back-link).
- **#1032**: sibling site migration (poller.rs lines 149 + 940 → `enqueue_with_idle_hint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)