### PR TITLE
fix(#1037): auto-derive next_after_ci from team `-reviewer` convention

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -228,6 +228,25 @@ pub(crate) fn dispatch_auto_bind_lease(
 ///
 /// Callers: `comms.rs::handle_delegate_task` (kind=task dispatches that
 /// declare a workflow chain via `args["next_after_ci"]`).
+///
+/// #1037 Option A auto-derive helper: when the dispatcher omits
+/// `next_after_ci`, look up the target's team membership and return the
+/// first member whose instance name ends in `-reviewer` (the de facto
+/// convention used by `fixup-reviewer`, `demo-reviewer`, etc.). Returns
+/// `None` when the target is teamless or no team member matches —
+/// preserves pre-#1037 behavior for teams that don't follow the
+/// convention.
+///
+/// Self-match is excluded so a dispatcher targeting `<team>-reviewer`
+/// itself doesn't chain to itself.
+pub(crate) fn derive_team_reviewer(home: &Path, target: &str) -> Option<String> {
+    crate::teams::find_team_for(home, target).and_then(|team| {
+        team.members
+            .into_iter()
+            .find(|m| m.ends_with("-reviewer") && m != target)
+    })
+}
+
 pub(crate) fn dispatch_auto_bind_lease_with_chain(
     home: &Path,
     target: &str,
@@ -433,12 +452,31 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
         // CI pass. Pre-#931 callers had to issue a follow-up
         // `ci action=watch next_after_ci=…` manually — easily forgotten
         // and one of the root causes of the 4-in-a-row PR stalls.
+        //
+        // #1037 Option A: when the dispatcher omits next_after_ci (the
+        // empirical case for lead's typical send calls — see #1037
+        // issue body for the dogfood evidence on PR #1035), fall back
+        // to auto-deriving from the target's team via the
+        // `<team>-reviewer` naming convention. Closes the loop where
+        // wake-aware routing (#1030) already worked but never fired
+        // because the chain target field was always None.
+        let effective_next = next_after_ci
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .or_else(|| derive_team_reviewer(home, target));
         let mut watch_args = serde_json::json!({"repo": &r, "branch": branch});
-        if let Some(next) = next_after_ci.filter(|s| !s.is_empty()) {
+        if let Some(ref next) = effective_next {
             watch_args["next_after_ci"] = serde_json::json!(next);
         }
         crate::mcp::handlers::ci::handle_watch_ci(home, &watch_args, target);
-        tracing::info!(%target, repo = %r, %branch, next_after_ci = ?next_after_ci, "dispatch auto-watch_ci");
+        tracing::info!(
+            %target,
+            repo = %r,
+            %branch,
+            next_after_ci = ?effective_next,
+            explicit = next_after_ci.is_some(),
+            "dispatch auto-watch_ci"
+        );
     }
 
     Ok(DispatchOutcome {

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1354,6 +1354,178 @@ fn dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931() {
 }
 
 #[test]
+#[cfg(unix)]
+fn dispatch_auto_derives_next_after_ci_from_team_reviewer_convention_1037() {
+    // #1037 RED→GREEN: when the dispatcher does NOT explicitly pass
+    // `next_after_ci`, the daemon auto-derives the chain target from
+    // the target's team using the `<team>-reviewer` naming convention.
+    //
+    // Empirical motivation (lead 2026-05-21): the post-#1030 wake-aware
+    // fix never triggered on real fixup-team PRs because lead's
+    // send(kind=task) MCP calls never set `next_after_ci=fixup-reviewer`
+    // in the args. The wire path propagates the field correctly (per
+    // `dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931`)
+    // — the gap is the caller didn't know to set it. Auto-derive
+    // closes the loop without requiring a per-call burden.
+    //
+    // REGRESSION-PROOF: revert the auto-derive lookup → this test
+    // FAILS because `watch["next_after_ci"]` reads as `null` instead
+    // of `"val-reviewer"` (the team's reviewer-suffixed member).
+    let parent = std::env::temp_dir().join(format!(
+        "agend-1037-auto-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) = p781_canonical_with_team_source_repo(
+        &parent,
+        "feat/1037-auto-derive",
+        true,
+        "val",
+        // val-reviewer present in team → convention match.
+        &["val-dev", "val-reviewer"],
+    );
+
+    // Dispatch WITHOUT explicit next_after_ci. Pre-#1037 this leaves
+    // the sidecar with no next_after_ci field; post-#1037 the daemon
+    // scans val-dev's team members, finds "val-reviewer" by the
+    // `-reviewer` suffix convention, and propagates it.
+    let r = super::dispatch_auto_bind_lease_with_chain(
+        &home,
+        "val-dev",
+        "T-1037-auto",
+        "feat/1037-auto-derive",
+        None,
+        None, // ← no explicit next_after_ci — the field this test pins.
+    );
+    assert!(
+        r.is_ok(),
+        "dispatch_auto_bind_lease_with_chain must succeed: {:?}",
+        r.err()
+    );
+
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/1037-auto-derive"),
+    );
+    assert!(watch_path.exists(), "ci_watches armed by dispatch");
+
+    let watch: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
+            .expect("parse watch");
+    assert_eq!(
+        watch["next_after_ci"].as_str(),
+        Some("val-reviewer"),
+        "#1037 GREEN: dispatch must auto-derive next_after_ci from \
+         `<team>-reviewer` convention when caller omits the arg. \
+         Got: {watch}"
+    );
+
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_auto_derive_no_reviewer_in_team_leaves_next_after_ci_none_1037() {
+    // #1037 negative case: if the target's team has NO member matching
+    // the `<team>-reviewer` convention, auto-derive leaves
+    // next_after_ci as None. This preserves the pre-#1037 behavior for
+    // teams that don't follow the naming convention — no behavior
+    // regression for legacy / atypical team layouts.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-1037-no-reviewer-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) = p781_canonical_with_team_source_repo(
+        &parent,
+        "feat/1037-no-reviewer",
+        true,
+        "val",
+        // No -reviewer member in team. Auto-derive should leave the
+        // field absent rather than picking a non-reviewer member.
+        &["val-dev", "val-lead"],
+    );
+
+    let r = super::dispatch_auto_bind_lease_with_chain(
+        &home,
+        "val-dev",
+        "T-1037-no-reviewer",
+        "feat/1037-no-reviewer",
+        None,
+        None,
+    );
+    assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
+
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/1037-no-reviewer"),
+    );
+    let watch: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
+            .expect("parse watch");
+    assert!(
+        watch["next_after_ci"].as_str().is_none(),
+        "#1037: team without `-reviewer` member must leave \
+         next_after_ci unset; got: {watch}"
+    );
+
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn dispatch_explicit_next_after_ci_overrides_auto_derive_1037() {
+    // #1037 precedence: when caller explicitly passes next_after_ci,
+    // that value wins over the auto-derive fallback. The auto-derive
+    // is a fallback for the "caller didn't bother" case, not a
+    // mandate that overrides explicit intent.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-1037-override-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) = p781_canonical_with_team_source_repo(
+        &parent,
+        "feat/1037-override",
+        true,
+        "val",
+        &["val-dev", "val-reviewer"],
+    );
+
+    // Explicit arg differs from the convention-match. Explicit wins.
+    let r = super::dispatch_auto_bind_lease_with_chain(
+        &home,
+        "val-dev",
+        "T-1037-override",
+        "feat/1037-override",
+        None,
+        Some("val-lead"),
+    );
+    assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
+
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/1037-override"),
+    );
+    let watch: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
+            .expect("parse watch");
+    assert_eq!(
+        watch["next_after_ci"].as_str(),
+        Some("val-lead"),
+        "#1037: explicit next_after_ci arg must override auto-derive; got: {watch}"
+    );
+
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
 fn teams_json_migration_preserves_existing_fleet_yaml_source_repo() {
     // Test 9 (invariant guard, Piece 1): the migration must NOT
     // overwrite an existing fleet.yaml team entry — if operator hand-


### PR DESCRIPTION
## Summary

- Lead's `send(kind=task, ...)` calls don't typically include `next_after_ci=fixup-reviewer` in args, so post-#1030 wake-aware routing never fired on real PRs. The wire path propagates the field correctly when caller supplies it (regression-tested at `dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931`); the gap is operator/dispatcher knowledge.
- Option A confirmed by lead (2026-05-21): auto-derive `next_after_ci` from the target's team via the `<team>-reviewer` naming convention when caller omits the arg. Explicit arg wins.
- New helper `derive_team_reviewer(home, target)` in `dispatch_hook/mod.rs` looks up the target's team via `teams::find_team_for`, returns the first member matching `*-reviewer` (excluding self).
- `dispatch_auto_bind_lease_with_source_and_chain` builds `effective_next = next_after_ci.or_else(derive_team_reviewer)` before assembling `watch_args`.

Zero schema change (no fleet.yaml field added). Matches the de facto naming convention (`fixup-reviewer`, `demo-reviewer`).

Closes #1037.

## Spike correction note

The issue body hypothesised the propagation code was broken. My spike (see lead query thread on the task) found the code is wired correctly — the gap is the caller. Lead confirmed Option A direction after the spike correction.

## Behaviour matrix

| Case | Pre-#1037 sidecar | Post-#1037 sidecar |
|---|---|---|
| Dispatcher passes `next_after_ci=X` | `next_after_ci=X` | `next_after_ci=X` (unchanged) |
| Dispatcher omits, team has `<team>-reviewer` | `next_after_ci=None` | `next_after_ci=<team>-reviewer` |
| Dispatcher omits, team lacks reviewer | `next_after_ci=None` | `next_after_ci=None` (unchanged) |
| Dispatcher omits, target is teamless | `next_after_ci=None` | `next_after_ci=None` (unchanged) |

## Tests (§3.10 RED → GREEN)

RED commit `f26a893` introduced 3 anchors:

| # | Test | RED | GREEN |
|---|---|---|---|
| T1 | `dispatch_auto_derives_next_after_ci_from_team_reviewer_convention_1037` | **FAIL** | PASS — primary signal: team `<team>-reviewer` auto-derived |
| T2 | `dispatch_auto_derive_no_reviewer_in_team_leaves_next_after_ci_none_1037` | PASS | PASS — anti-regression: team without `-reviewer` member preserves None |
| T3 | `dispatch_explicit_next_after_ci_overrides_auto_derive_1037` | PASS | PASS — anti-regression: explicit arg wins over auto-derive |

Existing `dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931` (explicit-arg path) also still passes.

Reviewer verification:

```
git checkout f26a893 && cargo test --bin agend-terminal -- \
  dispatch_auto_derives_next_after_ci_from_team_reviewer_convention_1037
# FAIL (no auto-derive yet)
git checkout HEAD && cargo test ...
# PASS (auto-derive lands)
```

Full suite: **2661 passed, 0 failed** (`cargo test --bin agend-terminal`).
fmt clean. `cargo clippy --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo build` (worktree)
- [x] `cargo test --bin agend-terminal` (2661 passed)
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] CI green on PR (per §3.3.1 reviewer/lead `gh pr checks 1037` independent verification)
- [ ] **Dogfood**: this PR is its own dogfood (same shape as #1033). After merge + operator restart, the NEXT PR opening should produce a sidecar with `next_after_ci=fixup-reviewer` auto-set, closing the recurring manual-kick loop.

## §3.6 / §3.5

- §3.6 borderline (~20 LOC src + 3 tests, two files but contained scope) — lead's call
- §3.5 single reviewer probably sufficient

## Cross-ref

- #1030 (wake-aware routing — routing layer)
- #1033 PR (the merged #1030 fix)
- #1037 issue (orchestration layer gap)
- The trio #1030 + #1033 + #1037 closes the recurring lead-manual-kick class end-to-end. After this PR, the meta-dogfood predicted by lead at #1032 should land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)