### PR TITLE
feat(#1031): enrich [ci-ready-for-action] with PR# / full SHA / task_id

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -161,6 +161,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             eta_minutes: params["eta_minutes"].as_u64().map(|v| v as u32),
             reporting_cadence: params["reporting_cadence"].as_str().map(String::from),
             worktree_binding_required: params["worktree_binding_required"].as_bool(),
+            pr_number: None,
         }
     };
 
@@ -1652,6 +1653,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         crate::inbox::enqueue(home, target, msg).expect("seed blocker");
     }
@@ -1746,6 +1748,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         msg.read_at = None;
         crate::inbox::enqueue(&home_path, "codex-agent", msg).expect("seed");

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -207,6 +207,7 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
                 eta_minutes: None,
                 reporting_cadence: None,
                 worktree_binding_required: None,
+                pr_number: None,
             },
         );
         // Also notify agent PTY so it picks up the summary
@@ -508,6 +509,7 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     let _ = inbox::enqueue(&home, &instance_name, msg_obj);
 

--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -202,6 +202,7 @@ fn emit_stall(home: &Path, task: &Task, reason: &str) {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, &recipient, msg) {
             tracing::warn!(

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -543,6 +543,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         }
     }
 }

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -637,6 +637,7 @@ pub(crate) fn make_ci_conflict_alert_msg(
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     }
 }
 
@@ -676,6 +677,7 @@ pub(crate) fn make_ci_stale_drop_msg(
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     }
 }
 
@@ -683,10 +685,21 @@ pub(crate) fn make_ci_stale_drop_msg(
 /// `next_after_ci` chain target on CI pass (#1030). Single construction
 /// site so the production emit and the deterministic-hint test (T4)
 /// see identical bytes.
+///
+/// #1031 enrichment: `head_sha` (full 40-char), `pr_number`, and
+/// `task_id` are threaded through so reviewers receive a
+/// directly-actionable payload without needing `gh pr list --head` or
+/// `git rev-parse` lookups. All three fall through to `Option::None`
+/// when the upstream cache (pr_state) doesn't yet have the data —
+/// graceful degradation for fresh watches where the first poll hasn't
+/// populated the aggregator.
 pub(crate) fn make_ci_ready_for_action_msg(
     repo: &str,
     branch: &str,
     repo_branch_key: &str,
+    head_sha: Option<&str>,
+    pr_number: Option<u64>,
+    task_id: Option<&str>,
 ) -> crate::inbox::InboxMessage {
     crate::inbox::InboxMessage {
         schema_version: 0,
@@ -694,12 +707,12 @@ pub(crate) fn make_ci_ready_for_action_msg(
         read_at: None,
         thread_id: None,
         parent_id: None,
-        task_id: None,
+        task_id: task_id.map(String::from),
         force_meta: None,
         // Same canonical `{repo}@{branch}` form used by the [ci-pass]
         // subscriber enqueue so inbox readers can correlate the two.
         correlation_id: Some(repo_branch_key.to_string()),
-        reviewed_head: None,
+        reviewed_head: head_sha.map(String::from),
         from: "system:ci".to_string(),
         text: format!("[ci-ready-for-action] {repo}@{branch}: CI passed, your turn."),
         kind: Some("ci-ready-for-action".to_string()),
@@ -716,6 +729,7 @@ pub(crate) fn make_ci_ready_for_action_msg(
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number,
     }
 }
 
@@ -1214,6 +1228,7 @@ async fn ci_check_repo(
                         eta_minutes: None,
                         reporting_cadence: None,
                         worktree_binding_required: None,
+                        pr_number: None,
                     },
                 );
             }
@@ -1242,7 +1257,16 @@ async fn ci_check_repo(
                     let last_conclusion = aggregate_conclusion_for_sha(&runs, current_sha);
                     if last_conclusion == Some("success") {
                         let repo_branch_key = format!("{repo}@{branch}");
-                        let msg = make_ci_ready_for_action_msg(repo, branch, &repo_branch_key);
+                        // #1031 RED: enrichment params are None at this commit;
+                        // GREEN wires them from pr_state + watch.task_id.
+                        let msg = make_ci_ready_for_action_msg(
+                            repo,
+                            branch,
+                            &repo_branch_key,
+                            None,
+                            None,
+                            None,
+                        );
                         let _ = crate::inbox::enqueue_with_idle_hint(home, next, msg);
                     }
                 }
@@ -3801,6 +3825,230 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    /// #1031 T1: site 3 emit populates `reviewed_head` with the full
+    /// 40-char head SHA from the CI run. RED at this commit (caller
+    /// passes None); GREEN reads `current_sha` at the emit site.
+    #[test]
+    fn ci_ready_for_action_carries_full_head_sha() {
+        let dir = tmp_dir("1031-t1-head-sha");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-21T00:00:00Z"}],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "next_after_ci": "reviewer",
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 1,
+            conclusion: Some("success".to_string()),
+            // Use a realistic full 40-char SHA.
+            head_sha: "abc1234567890abcdef1234567890abcdef12345".to_string(),
+            url: "https://example/run/1".to_string(),
+        }]);
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["lead".to_string()],
+            None,
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+        let messages = crate::inbox::drain(&dir, "reviewer");
+        let action = messages
+            .iter()
+            .find(|m| m.kind.as_deref() == Some("ci-ready-for-action"))
+            .expect("chain target must have a [ci-ready-for-action] entry");
+        assert_eq!(
+            action.reviewed_head.as_deref(),
+            Some("abc1234567890abcdef1234567890abcdef12345"),
+            "#1031 GREEN: reviewed_head must be the full 40-char SHA; got: {action:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1031 T2: site 3 emit populates `pr_number` from the pr_state
+    /// aggregator cache. RED at this commit (caller passes None);
+    /// GREEN reads `pr_state::load(home, repo, branch)`.
+    #[test]
+    fn ci_ready_for_action_carries_pr_number_from_pr_state() {
+        let dir = tmp_dir("1031-t2-pr-number");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        // Pre-populate the pr_state file so the emit-site lookup
+        // finds the cached PR#. record_ci_result writes this naturally
+        // in production; here we seed it manually so the test focuses
+        // on the read-side enrichment.
+        let pr_state_dir = dir.join("pr-state");
+        std::fs::create_dir_all(&pr_state_dir).ok();
+        // The pr_state filename helper hashes repo+branch; emulate by
+        // writing via the public seam.
+        crate::daemon::pr_state::record_ci_result(
+            &dir,
+            "o/r",
+            "feat",
+            "abc1234567890abcdef1234567890abcdef12345",
+            crate::daemon::pr_state::CiConclusion::Pending,
+            vec!["lead".to_string()],
+            crate::daemon::pr_state::ReviewClass::Single,
+        );
+        // Now set pr_number on the seeded state.
+        let pr_state_path = crate::daemon::pr_state::pr_state_dir(&dir)
+            .join(crate::daemon::pr_state::pr_state_filename("o/r", "feat"));
+        if let Ok(content) = std::fs::read_to_string(&pr_state_path) {
+            if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(&content) {
+                v["pr_number"] = serde_json::json!(1031);
+                std::fs::write(&pr_state_path, serde_json::to_string_pretty(&v).unwrap()).unwrap();
+            }
+        }
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-21T00:00:00Z"}],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "next_after_ci": "reviewer",
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 2,
+            conclusion: Some("success".to_string()),
+            head_sha: "abc1234567890abcdef1234567890abcdef12345".to_string(),
+            url: "https://example/run/2".to_string(),
+        }]);
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["lead".to_string()],
+            None,
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+        let messages = crate::inbox::drain(&dir, "reviewer");
+        let action = messages
+            .iter()
+            .find(|m| m.kind.as_deref() == Some("ci-ready-for-action"))
+            .expect("chain target must have a [ci-ready-for-action] entry");
+        assert_eq!(
+            action.pr_number,
+            Some(1031),
+            "#1031 GREEN: pr_number must be populated from pr_state cache; got: {action:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1031 T3: site 3 emit populates `task_id` from the ci-watch
+    /// sidecar's persisted dispatch task_id. RED at this commit
+    /// (caller passes None); GREEN reads `watch["task_id"]`. This
+    /// also implicitly RED-asserts the dispatch-side persist hop —
+    /// the watch sidecar pre-seeded below carries `task_id` directly,
+    /// which the GREEN read path picks up regardless of how it
+    /// arrived (dispatch persist OR manual ci_watch arm).
+    #[test]
+    fn ci_ready_for_action_carries_task_id_from_watch_sidecar() {
+        let dir = tmp_dir("1031-t3-task-id");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).ok();
+        let watch = serde_json::json!({
+            "repo": "o/r",
+            "branch": "feat",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-21T00:00:00Z"}],
+            "instance": "lead",
+            "interval_secs": 60,
+            "last_run_id": null,
+            "head_sha": null,
+            "last_polled_at": null,
+            "last_notified_head_sha": null,
+            "next_after_ci": "reviewer",
+            "task_id": "t-1031-dispatch-id",
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+            "last_terminal_seen_at": null,
+        });
+        let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        let provider = MockCiProvider::with_runs(vec![CiRun {
+            id: 3,
+            conclusion: Some("success".to_string()),
+            head_sha: "abc1234567890abcdef1234567890abcdef12345".to_string(),
+            url: "https://example/run/3".to_string(),
+        }]);
+        let registry: AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(ci_check_repo(
+            &dir,
+            &watch_path,
+            "o/r",
+            "feat",
+            &["lead".to_string()],
+            None,
+            None,
+            None,
+            None,
+            None,
+            &registry,
+            &provider,
+        ))
+        .unwrap();
+        let messages = crate::inbox::drain(&dir, "reviewer");
+        let action = messages
+            .iter()
+            .find(|m| m.kind.as_deref() == Some("ci-ready-for-action"))
+            .expect("chain target must have a [ci-ready-for-action] entry");
+        assert_eq!(
+            action.task_id.as_deref(),
+            Some("t-1031-dispatch-id"),
+            "#1031 GREEN: task_id must propagate from watch sidecar; got: {action:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     /// T4 (deterministic hint delivery via test seam):
     /// `make_ci_ready_for_action_msg` produces an InboxMessage that,
     /// when passed through `enqueue_with_idle_hint_with_emitter`,
@@ -3810,7 +4058,7 @@ mod tests {
     fn ci_ready_for_action_hint_format_deterministic() {
         let dir = tmp_dir("1030-t4-hint-format");
         std::fs::create_dir_all(&dir).unwrap();
-        let msg = super::make_ci_ready_for_action_msg("o/r", "feat", "o/r@feat");
+        let msg = super::make_ci_ready_for_action_msg("o/r", "feat", "o/r@feat", None, None, None);
         let captured: std::sync::Arc<parking_lot::Mutex<Option<String>>> =
             std::sync::Arc::new(parking_lot::Mutex::new(None));
         let cap = captured.clone();

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1257,15 +1257,33 @@ async fn ci_check_repo(
                     let last_conclusion = aggregate_conclusion_for_sha(&runs, current_sha);
                     if last_conclusion == Some("success") {
                         let repo_branch_key = format!("{repo}@{branch}");
-                        // #1031 RED: enrichment params are None at this commit;
-                        // GREEN wires them from pr_state + watch.task_id.
+                        // #1031 GREEN: enrich the chain-target payload so
+                        // the reviewer who wakes can post §3.12 verdict
+                        // mirror without `gh pr list --head` or
+                        // `git rev-parse` lookups.
+                        // - head_sha: current_sha is the full 40-char from
+                        //   the GitHub API (provider.rs:348). The 7-char
+                        //   prefix in the text body stays for human
+                        //   readability; the structured field carries
+                        //   the full SHA.
+                        // - pr_number: read from pr_state aggregator
+                        //   cache (#972). None until the first poll
+                        //   populates the cache via record_ci_result
+                        //   (which fires below on this same tick).
+                        // - task_id: read from the watch sidecar's
+                        //   `task_id` field — persisted by the dispatch
+                        //   path (post-#1031 wiring; pre-persist watches
+                        //   gracefully read None).
+                        let pr_number =
+                            crate::daemon::pr_state::load(home, repo, branch).map(|s| s.pr_number);
+                        let task_id = watch["task_id"].as_str();
                         let msg = make_ci_ready_for_action_msg(
                             repo,
                             branch,
                             &repo_branch_key,
-                            None,
-                            None,
-                            None,
+                            Some(current_sha),
+                            pr_number,
+                            task_id,
                         );
                         let _ = crate::inbox::enqueue_with_idle_hint(home, next, msg);
                     }

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -190,6 +190,7 @@ fn fan_out_health_event(
                 eta_minutes: None,
                 reporting_cadence: None,
                 worktree_binding_required: None,
+                pr_number: None,
             },
         );
     }

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -141,6 +141,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     eta_minutes: None,
                     reporting_cadence: None,
                     worktree_binding_required: None,
+                    pr_number: None,
                 },
             );
             "ok_inbox"

--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -279,6 +279,7 @@ fn emit_timeout_event(home: &Path, d: &PendingDecision, elapsed_secs: i64) {
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, &recipient, msg) {
         tracing::warn!(error = %e, recipient, "decision_timeout: enqueue failed");

--- a/src/daemon/dispatch_idle/fixup_nudge.rs
+++ b/src/daemon/dispatch_idle/fixup_nudge.rs
@@ -139,6 +139,7 @@ fn emit_nudge(home: &Path, d: &PendingDispatch) -> bool {
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     match crate::inbox::enqueue_with_idle_hint(home, &d.target, msg) {
         Ok(()) => true,

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -530,6 +530,7 @@ fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, &d.dispatcher, msg) {
         tracing::warn!(

--- a/src/daemon/helper_staleness_watchdog.rs
+++ b/src/daemon/helper_staleness_watchdog.rs
@@ -145,6 +145,7 @@ fn emit_staleness_alert(home: &Path, helper_name: &str) {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, recipient, msg) {
             tracing::warn!(

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -392,6 +392,7 @@ fn emit_idle_alert(
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, recipient, msg) {
         tracing::warn!(error = %e, recipient, kind, "idle_watchdog: enqueue failed");

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1268,6 +1268,7 @@ pub fn run_task_maintenance(home: &Path) {
                 eta_minutes: None,
                 reporting_cadence: None,
                 worktree_binding_required: None,
+                pr_number: None,
             },
         );
     }
@@ -1341,6 +1342,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                     eta_minutes: None,
                     reporting_cadence: None,
                     worktree_binding_required: None,
+                    pr_number: None,
                 },
             );
         }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -126,6 +126,7 @@ mod tests {
                     eta_minutes: None,
                     reporting_cadence: None,
                     worktree_binding_required: None,
+                    pr_number: None,
                 },
             );
         }

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -1222,6 +1222,7 @@ fn build_event_message(
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     }
 }
 

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -477,6 +477,7 @@ pub(crate) fn maybe_notify_member_state_change(
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     let _ = crate::inbox::enqueue(home, orch, msg);
     crate::inbox::notify_agent(

--- a/src/daemon/waiting_on_stale.rs
+++ b/src/daemon/waiting_on_stale.rs
@@ -134,6 +134,7 @@ fn emit_to(home: &Path, recipient: &str, kind: &str, text: &str, correlation_age
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, recipient, msg) {
         tracing::warn!(error = %e, recipient, kind, "waiting_on_stale: enqueue failed");

--- a/src/hotspot.rs
+++ b/src/hotspot.rs
@@ -149,6 +149,7 @@ pub fn hotspot_warn(home: &Path, agent: &str, file: &Path, last_toucher: &str, s
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     let _ = crate::inbox::enqueue_with_idle_hint(home, "lead", msg);
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -234,6 +234,15 @@ pub struct InboxMessage {
     pub reporting_cadence: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_binding_required: Option<bool>,
+    /// #1031: pull-request number associated with the message. Populated
+    /// by the ci_watch poller on `[ci-pass]` / `[ci-ready-for-action]`
+    /// events from the pr_state aggregator cache, so reviewers can post
+    /// §3.12 verdict mirrors via `gh pr comment <N>` without a
+    /// `gh pr list --head` lookup. Absent on legacy messages and
+    /// non-CI events — `#[serde(default)]` ensures backwards-compat
+    /// with pre-#1031 JSONL inboxes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
 }
 
 /// Metadata attached to a forced delegation (busy gate override).
@@ -950,6 +959,7 @@ pub fn deliver(
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     let _ = enqueue(home, agent_name, msg);
     notify_agent(home, agent_name, source, text);
@@ -1461,6 +1471,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         }
     }
 
@@ -1601,6 +1612,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -1714,6 +1726,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let json = serde_json::to_string(&msg).expect("serialize");
         let parsed: InboxMessage = serde_json::from_str(&json).expect("deserialize");
@@ -1750,6 +1763,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         enqueue(&home, "agent1", msg).ok();
         let msgs = drain(&home, "agent1");
@@ -2337,6 +2351,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let json = serde_json::to_string(&msg).expect("ser");
         assert!(json.contains("thread_id"));
@@ -2394,6 +2409,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("[AGEND-MSG]"));
@@ -2442,6 +2458,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2486,6 +2503,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2522,6 +2540,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         // #761: agent-source prefix stripped.
@@ -2569,6 +2588,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2605,6 +2625,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2655,6 +2676,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2701,6 +2723,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2747,6 +2770,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(header.contains("broadcast=3"), "{header}");
@@ -2787,6 +2811,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -2834,6 +2859,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let json = serde_json::to_string(&with_ctx).expect("ser");
         assert!(json.contains("broadcast_context"));
@@ -2850,6 +2876,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
             ..with_ctx
         };
         let json2 = serde_json::to_string(&without_ctx).expect("ser");
@@ -2887,6 +2914,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let h = format_header(&msg);
         assert!(h.contains("reply_to_excerpt=[bob] original"), "{h}");
@@ -3008,6 +3036,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let h = format_header(&msg);
         assert!(!h.contains('\n'), "must be single line: {h}");
@@ -3042,6 +3071,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -3087,6 +3117,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -3134,6 +3165,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -3184,6 +3216,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let header = format_header(&msg);
         assert!(
@@ -3351,6 +3384,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let back: InboxMessage = serde_json::from_str(&json).unwrap();
@@ -3412,6 +3446,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         enqueue(&home, agent, msg1).unwrap();
         mark_ci_watch_superseded(&home, agent, "owner/repo@main", "new-msg-id");
@@ -3453,6 +3488,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let superseded = InboxMessage {
             schema_version: 0,
@@ -3480,6 +3516,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         enqueue(&home, agent, normal).unwrap();
         enqueue(&home, agent, superseded).unwrap();
@@ -3517,6 +3554,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         };
         let json = serde_json::to_string(&msg).expect("serialize");
         let parsed: InboxMessage = serde_json::from_str(&json).expect("deserialize");

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -161,7 +161,7 @@ impl NotifySource<'_> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InboxMessage {
     #[serde(default)]
     pub schema_version: u32,

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1110,6 +1110,7 @@ mod tests {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
             from_id: None,
         };
         let header = crate::inbox::format_header(&sample_msg);

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -532,6 +532,15 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     if let Some(next) = args["next_after_ci"].as_str().filter(|s| !s.is_empty()) {
         watch["next_after_ci"] = json!(next);
     }
+    // #1031: persist dispatch task_id when supplied (by
+    // dispatch_auto_bind_lease) so the ci_check_repo emit site can
+    // populate `[ci-ready-for-action]` InboxMessage's task_id field,
+    // giving the reviewer a structured back-link to the originating
+    // dispatch. Manual `ci action=watch` callers may also pass
+    // task_id explicitly to bind the watch to a specific task.
+    if let Some(tid) = args["task_id"].as_str().filter(|s| !s.is_empty()) {
+        watch["task_id"] = json!(tid);
+    }
     // #972 reviewer-rejection fix: persist `review_class` so the
     // pr_state aggregator can honor §3.5 dual-review at runtime. Accepted
     // values: `"single"` (default — §3.6) or `"dual"` (§3.5). Other

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -139,6 +139,7 @@ pub(super) fn handle_send_to_instance(
                 eta_minutes: None,
                 reporting_cadence: None,
                 worktree_binding_required: None,
+                pr_number: None,
             };
             crate::agent_ops::fallback_deliver(home, sender.as_str(), target, text, msg, &e)
         }
@@ -389,6 +390,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                 eta_minutes: None,
                 reporting_cadence: None,
                 worktree_binding_required: None,
+                pr_number: None,
             };
             crate::agent_ops::fallback_deliver(home, sender.as_str(), target, &msg, inbox_msg, &e)
         }
@@ -526,6 +528,7 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
                     eta_minutes: None,
                     reporting_cadence: None,
                     worktree_binding_required: None,
+                    pr_number: None,
                 };
                 crate::agent_ops::fallback_deliver(
                     home,

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -114,32 +114,14 @@ pub(super) fn handle_send_to_instance(
                 }
             }
             let msg = crate::inbox::InboxMessage {
-                schema_version: 0,
-                id: None,
-                read_at: None,
                 thread_id: resolved_thread,
                 parent_id: resolved_parent,
-                task_id: None,
-                force_meta: None,
                 correlation_id: args["correlation_id"].as_str().map(String::from),
-                reviewed_head: None,
                 from: format!("from:{}", sender.as_str()),
                 text: text.to_string(),
-                kind: None,
                 timestamp: chrono::Utc::now().to_rfc3339(),
-                channel: None,
                 delivery_mode: Some("inbox_fallback".to_string()),
-                attachments: vec![],
-                in_reply_to_msg_id: None,
-                in_reply_to_excerpt: None,
-                superseded_by: None,
-                from_id: None,
-                broadcast_context: None,
-                sequencing: None,
-                eta_minutes: None,
-                reporting_cadence: None,
-                worktree_binding_required: None,
-                pr_number: None,
+                ..Default::default()
             };
             crate::agent_ops::fallback_deliver(home, sender.as_str(), target, text, msg, &e)
         }
@@ -363,34 +345,16 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
         Err(e) => {
             // Centralised fallback (Sprint 40 T-7 B4)
             let inbox_msg = crate::inbox::InboxMessage {
-                schema_version: 0,
-                id: None,
-                read_at: None,
-                thread_id: None,
-                parent_id: None,
                 task_id: task_id_str.map(String::from),
                 force_meta: force_meta_json.as_ref().and_then(|v| {
                     serde_json::from_value::<crate::inbox::ForceMeta>(v.clone()).ok()
                 }),
-                correlation_id: None,
-                reviewed_head: None,
                 delivery_mode: Some("inbox_fallback".to_string()),
                 from: format!("from:{}", sender.as_str()),
                 text: msg.clone(),
                 kind: Some("task".to_string()),
                 timestamp: chrono::Utc::now().to_rfc3339(),
-                channel: None,
-                attachments: vec![],
-                in_reply_to_msg_id: None,
-                in_reply_to_excerpt: None,
-                superseded_by: None,
-                from_id: None,
-                broadcast_context: None,
-                sequencing: None,
-                eta_minutes: None,
-                reporting_cadence: None,
-                worktree_binding_required: None,
-                pr_number: None,
+                ..Default::default()
             };
             crate::agent_ops::fallback_deliver(home, sender.as_str(), target, &msg, inbox_msg, &e)
         }
@@ -503,13 +467,8 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
             Err(e) => {
                 // Centralised fallback (Sprint 40 T-7 B4)
                 let inbox_msg = crate::inbox::InboxMessage {
-                    schema_version: 0,
-                    id: None,
-                    read_at: None,
                     thread_id: args["thread_id"].as_str().map(String::from),
                     parent_id: args["parent_id"].as_str().map(String::from),
-                    task_id: None,
-                    force_meta: None,
                     correlation_id: correlation_id.map(String::from),
                     reviewed_head: reviewed_head.map(String::from),
                     delivery_mode: Some("inbox_fallback".to_string()),
@@ -517,18 +476,7 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
                     text: msg.clone(),
                     kind: Some("report".to_string()),
                     timestamp: chrono::Utc::now().to_rfc3339(),
-                    channel: None,
-                    attachments: vec![],
-                    in_reply_to_msg_id: None,
-                    in_reply_to_excerpt: None,
-                    superseded_by: None,
-                    from_id: None,
-                    broadcast_context: None,
-                    sequencing: None,
-                    eta_minutes: None,
-                    reporting_cadence: None,
-                    worktree_binding_required: None,
-                    pr_number: None,
+                    ..Default::default()
                 };
                 crate::agent_ops::fallback_deliver(
                     home,

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -468,6 +468,15 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
         if let Some(ref next) = effective_next {
             watch_args["next_after_ci"] = serde_json::json!(next);
         }
+        // #1031: persist the dispatch task_id alongside the watch so
+        // the ci_check_repo emit site can back-link the
+        // `[ci-ready-for-action]` event to the originating dispatch.
+        // Reviewer's verdict report can then echo this task_id in
+        // its correlation_id, closing the [[feedback-dispatch-task-id-mirror]]
+        // false-positive class on the verdict-reply side.
+        if !task_id.is_empty() {
+            watch_args["task_id"] = serde_json::json!(task_id);
+        }
         crate::mcp::handlers::ci::handle_watch_ci(home, &watch_args, target);
         tracing::info!(
             %target,

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1355,6 +1355,60 @@ fn dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931() {
 
 #[test]
 #[cfg(unix)]
+fn dispatch_persists_task_id_into_ci_watch_sidecar_1031() {
+    // #1031: when `send(kind=task, task_id=T)` triggers the dispatch
+    // auto-arm, the task_id is persisted into the ci-watch sidecar's
+    // `task_id` field. The ci_check_repo emit site reads it back to
+    // enrich `[ci-ready-for-action]` payloads — closing the
+    // dispatcher→reviewer back-link that pre-#1031 required manual
+    // inbox-archaeology.
+    //
+    // REGRESSION-PROOF: revert the `watch_args["task_id"]` write in
+    // dispatch_hook/mod.rs → this assertion FAILS because
+    // `watch["task_id"]` reads as null instead of `"T-1031-persist"`.
+    let parent = std::env::temp_dir().join(format!(
+        "agend-1031-persist-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) = p781_canonical_with_team_source_repo(
+        &parent,
+        "feat/1031-persist",
+        true,
+        "val",
+        &["val-dev", "val-reviewer"],
+    );
+
+    let r = super::dispatch_auto_bind_lease_with_chain(
+        &home,
+        "val-dev",
+        "T-1031-persist",
+        "feat/1031-persist",
+        None,
+        Some("val-reviewer"),
+    );
+    assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
+
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/1031-persist"),
+    );
+    let watch: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
+            .expect("parse watch");
+    assert_eq!(
+        watch["task_id"].as_str(),
+        Some("T-1031-persist"),
+        "#1031: dispatch must persist task_id into ci-watch sidecar; got: {watch}"
+    );
+
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
 fn dispatch_auto_derives_next_after_ci_from_team_reviewer_convention_1037() {
     // #1037 RED→GREEN: when the dispatcher does NOT explicitly pass
     // `next_after_ci`, the daemon auto-derives the chain target from

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -318,6 +318,7 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         },
     );
 

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -975,6 +975,7 @@ fn agent_picked_up_emitted_on_inbox_drain() {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         },
     );
 
@@ -1044,6 +1045,7 @@ fn agent_picked_up_fires_for_all_pending_messages() {
             eta_minutes: None,
             reporting_cadence: None,
             worktree_binding_required: None,
+            pr_number: None,
         },
     );
 
@@ -1223,6 +1225,7 @@ fn test_describe_message_shows_delivery_mode() {
         eta_minutes: None,
         reporting_cadence: None,
         worktree_binding_required: None,
+        pr_number: None,
     };
     let inbox_dir = home.join("inbox");
     std::fs::create_dir_all(&inbox_dir).ok();

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -912,6 +912,7 @@ mod tests {
                     eta_minutes: None,
                     reporting_cadence: None,
                     worktree_binding_required: None,
+                    pr_number: None,
                 },
             );
         }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -335,6 +335,7 @@ fn test_inbox(home: &Path) -> TestResult {
                 eta_minutes: None,
                 reporting_cadence: None,
                 worktree_binding_required: None,
+                pr_number: None,
             },
         );
     }


### PR DESCRIPTION
## Summary

Three new structured fields on `[ci-ready-for-action]` InboxMessage so reviewers (post-#1030/#1037 auto-wake) can post §3.12 verdict mirrors without `gh pr list --head` or `git rev-parse` lookups:

- `reviewed_head: Option<String>` — full 40-char SHA from CI run.
- `pr_number: Option<u64>` — NEW field on InboxMessage; from pr_state aggregator (#972) cache via `pr_state::load(home, repo, branch)` at emit.
- `task_id: Option<String>` — existing field, now populated. Dispatch path persists `task_id` into ci-watch sidecar JSON; emit reads it.

All three degrade gracefully to `None` when upstream sources aren't yet populated (fresh watches, legacy inboxes). No behaviour regression.

Closes #1031.

## Why

`[ci-ready-for-action]` payload pre-#1031 carried only a 7-char SHA prefix in the text body. Reviewer-wake worked but the reviewer immediately ran `gh pr list --head` to discover the PR# — friction the auto-wake was supposed to eliminate. Per #1030 H2 spike memo's deferred follow-up.

## Wiring matrix

| Layer | File | Change |
|---|---|---|
| Schema | `src/inbox.rs::InboxMessage` | new `pr_number: Option<u64>`, `#[serde(default, skip_serializing_if)]` |
| Helper | `src/daemon/ci_watch/poller.rs::make_ci_ready_for_action_msg` | new `head_sha` / `pr_number` / `task_id` params |
| Site 3 emit | `src/daemon/ci_watch/poller.rs::ci_check_repo` | reads `current_sha` + `pr_state::load` + `watch["task_id"]` |
| Dispatch persist | `src/mcp/handlers/dispatch_hook/mod.rs` | writes `task_id` to `watch_args` |
| Sidecar persist | `src/mcp/handlers/ci/mod.rs::handle_watch_ci` | accepts `args["task_id"]` and writes to watch JSON |

All 25+ pre-existing `InboxMessage` constructor sites mechanically updated to pass `pr_number: None` (RED commit).

## Tests (§3.10 RED → GREEN)

RED commit `7a4907e` introduces 3 site-level RED anchors:

| # | Test | RED | GREEN |
|---|---|---|---|
| T1 | `ci_ready_for_action_carries_full_head_sha` | **FAIL** | PASS — `reviewed_head=current_sha` |
| T2 | `ci_ready_for_action_carries_pr_number_from_pr_state` | **FAIL** | PASS — `pr_number` from pr_state cache |
| T3 | `ci_ready_for_action_carries_task_id_from_watch_sidecar` | **FAIL** | PASS — `task_id` from watch sidecar |
| T4 | `dispatch_persists_task_id_into_ci_watch_sidecar_1031` | n/a (added in GREEN) | PASS — dispatch persist hop |

Reviewer verification:

```
git checkout 7a4907e && cargo test --bin agend-terminal -- ci_ready_for_action_carries
# 3 FAIL (all 3 site-level emits pass None to helper)
git checkout HEAD && cargo test ...
# 3 PASS (impl wires upstream sources)
```

Full suite: **2668 passed, 0 failed** (`cargo test --bin agend-terminal`).
fmt clean. `cargo clippy --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo build` (worktree)
- [x] `cargo test --bin agend-terminal` (2668 passed)
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] CI green on PR (per §3.3.1 reviewer/lead `gh pr checks 1039` independent verification)
- [ ] **Dogfood**: this PR is dispatched WITHOUT explicit `next_after_ci` per lead's instruction. After CI green, fixup-reviewer should: (a) wake via #1037 auto-derive, AND (b) receive a payload with PR# / full SHA / task_id populated (#1031). End-to-end empirical close-loop.

## §3.6 / §3.5

- §3.6 NOT eligible (cross-layer: inbox schema + dispatch persist + emit enrichment). Normal review.
- §3.5 single reviewer sufficient.

## Cross-ref

- #1030 (routing layer — wake-aware enqueue)
- #1032 (sibling-class routing migration)
- #1037 (orchestration layer — auto-derive `next_after_ci`)
- #1031 (this PR — payload layer)

The quartet closes the recurring lead-manual-kick class end-to-end at all four affected layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)