### PR TITLE
feat(#991): create_instance topic_binding param

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -212,21 +212,23 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         env_for_spawn,
     ) {
         Ok(_spawn_mode) => {
-            // #966: Every API-level spawn gets a channel topic via the
-            // hub `ensure_topic_for`. Replaces the prior inline
-            // `active_channel().and_then(create_topic).map(id)` chain —
-            // same semantics, consolidated with team mode + TUI helper.
-            let topic_id = match crate::channel::ensure_topic_for(name) {
-                crate::channel::TopicOutcome::Created(tid) => Some(tid),
-                crate::channel::TopicOutcome::NoChannel => None,
-                crate::channel::TopicOutcome::Failed(err) => {
-                    tracing::warn!(
-                        agent = name,
-                        error = %err,
-                        "SPAWN: channel exists but create_topic failed; \
-                         instance created without topic"
-                    );
-                    None
+            // #991: skip topic creation when caller opts out.
+            let topic_binding = params["topic_binding"].as_str().unwrap_or("auto");
+            let topic_id = if matches!(topic_binding, "skip" | "deferred") {
+                None
+            } else {
+                match crate::channel::ensure_topic_for(name) {
+                    crate::channel::TopicOutcome::Created(tid) => Some(tid),
+                    crate::channel::TopicOutcome::NoChannel => None,
+                    crate::channel::TopicOutcome::Failed(err) => {
+                        tracing::warn!(
+                            agent = name,
+                            error = %err,
+                            "SPAWN: channel exists but create_topic failed; \
+                             instance created without topic"
+                        );
+                        None
+                    }
                 }
             };
             if let Some(n) = ctx.notifier {

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -111,6 +111,7 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
                         ready_pattern: None,
                         command: None,
                         worktree: None,
+                        topic_binding_mode: None,
                     },
                 )
             })

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -65,6 +65,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                     ready_pattern: None,
                     command: None,
                     worktree: None,
+                    topic_binding_mode: None,
                 },
             ) {
                 tracing::warn!(name = %inst_name, error = %e, "failed to write fleet.yaml");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -863,6 +863,7 @@ fn pane_from_menu_item(
                     ready_pattern: None,
                     command: None,
                     worktree: None,
+                    topic_binding_mode: None,
                 },
             ) {
                 tracing::warn!(error = %e, "failed to write fleet.yaml");

--- a/src/app/tui_spawn.rs
+++ b/src/app/tui_spawn.rs
@@ -214,6 +214,7 @@ mod tests {
             ready_pattern: None,
             command: None,
             worktree: None,
+            topic_binding_mode: None,
         }
     }
 
@@ -313,6 +314,7 @@ mod tests {
             ready_pattern: None,
             command: None,
             worktree: None,
+            topic_binding_mode: None,
         };
         let outcome = add_instance_with_topic(&home, "ctrlb-c-agent", &entry).expect("Ok");
 
@@ -359,6 +361,7 @@ mod tests {
             ready_pattern: None,
             command: None,
             worktree: None,
+            topic_binding_mode: None,
         };
         let outcome = add_instance_with_topic(&home, "palette-agent", &entry).expect("Ok");
 

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -68,6 +68,7 @@ fn auto_create_general(config: &mut FleetConfig, home: &Path, persist: bool) {
         ready_pattern: None,
         command: None,
         worktree: None,
+        topic_binding_mode: None,
     };
     if let Err(e) = fleet::add_instance_to_yaml(home, "general", &entry) {
         tracing::warn!(error = %e, "failed to persist general instance");

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -283,6 +283,7 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
                 ready_pattern: template_ready_pattern,
                 command: template_command,
                 worktree: template_worktree,
+                topic_binding_mode: None,
             },
         ));
         created.push(inst_name);

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -231,6 +231,12 @@ pub struct InstanceConfig {
     /// all skills (no per-backend dirs are populated).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skills: Option<Vec<String>>,
+    /// #991: topic binding mode — controls whether a Telegram topic is
+    /// created at spawn time. `None` or `Some("auto")` = current behavior.
+    /// `Some("skip")` = no topic ever. `Some("deferred")` = no topic at
+    /// spawn, operator can retrofit later via `bind_topic`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic_binding_mode: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -643,6 +649,8 @@ pub struct InstanceYamlEntry {
     /// so the worktree pool skips creation. Defaults to auto-create
     /// when `None` or `Some(true)`.
     pub worktree: Option<bool>,
+    /// #991: topic binding mode. See [`InstanceConfig::topic_binding_mode`].
+    pub topic_binding_mode: Option<String>,
 }
 
 /// Atomically write a serde_yaml_ng::Value back to fleet.yaml using temp + fsync + rename.
@@ -961,6 +969,12 @@ fn build_instance_mapping(config: &InstanceYamlEntry) -> serde_yaml_ng::Mapping 
     }
     if let Some(worktree) = config.worktree {
         inst.insert("worktree".into(), serde_yaml_ng::Value::Bool(worktree));
+    }
+    if let Some(ref mode) = config.topic_binding_mode {
+        inst.insert(
+            "topic_binding_mode".into(),
+            serde_yaml_ng::Value::String(mode.clone()),
+        );
     }
     inst
 }
@@ -1517,6 +1531,7 @@ instances:
             ready_pattern: None,
             command: None,
             worktree: None,
+            topic_binding_mode: None,
         };
         add_instance_to_yaml(&dir, "new-agent", &entry).expect("add");
         let config = FleetConfig::load(&path).expect("load after add");
@@ -1572,6 +1587,7 @@ instances:
             ready_pattern: None,
             command: None,
             worktree: None,
+            topic_binding_mode: None,
         };
         add_instance_to_yaml(&dir, "first", &entry).expect("add to new");
         let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
@@ -1761,6 +1777,7 @@ instances:
                     ready_pattern: None,
                     command: None,
                     worktree: None,
+                    topic_binding_mode: None,
                 };
                 let _ = add_instance_to_yaml(&d1, "agent-from-mutate", &entry);
             });
@@ -2393,6 +2410,7 @@ instances:
             ready_pattern: None,
             command: None,
             worktree: None,
+            topic_binding_mode: None,
         };
         add_instance_to_yaml(&dir, "temp-agent", &entry).expect("add");
 
@@ -3111,6 +3129,7 @@ instances:
             ready_pattern: None,
             command: None,
             worktree: None,
+            topic_binding_mode: None,
         };
         add_instance_to_yaml(&dir, "rt-agent", &entry).expect("add");
         let content = std::fs::read_to_string(dir.join("fleet.yaml")).expect("read");
@@ -3126,6 +3145,45 @@ instances:
                 .as_deref()
                 .map(|p| p.to_str().unwrap_or("")),
             Some("/tmp/rt-source"),
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn topic_binding_mode_round_trips_through_fleet_yaml() {
+        let dir = std::env::temp_dir().join(format!("agend-fleet-tb-rt-{}", std::process::id()));
+        write_fleet(&dir, "instances: {}\n");
+        let entry = InstanceYamlEntry {
+            backend: Some("claude".to_string()),
+            topic_binding_mode: Some("skip".to_string()),
+            ..Default::default()
+        };
+        add_instance_to_yaml(&dir, "internal-helper", &entry).expect("add");
+        let content = std::fs::read_to_string(dir.join("fleet.yaml")).expect("read");
+        assert!(
+            content.contains("topic_binding_mode: skip"),
+            "topic_binding_mode must appear in fleet.yaml: {content}"
+        );
+        let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        let inst = config.instances.get("internal-helper").expect("exists");
+        assert_eq!(
+            inst.topic_binding_mode.as_deref(),
+            Some("skip"),
+            "topic_binding_mode must round-trip through serde"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn topic_binding_mode_absent_parses_as_none() {
+        let dir =
+            std::env::temp_dir().join(format!("agend-fleet-tb-absent-{}", std::process::id()));
+        write_fleet(&dir, "instances:\n  agent1:\n    backend: claude\n");
+        let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+        let inst = config.instances.get("agent1").expect("exists");
+        assert!(
+            inst.topic_binding_mode.is_none(),
+            "absent field must parse as None for back-compat"
         );
         fs::remove_dir_all(&dir).ok();
     }

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -207,14 +207,19 @@ pub(super) fn handle_describe_instance(home: &Path, args: &Value) -> Value {
                 Some(agent) => {
                     let mut info = agent.clone();
                     merge_metadata(home, name, &mut info);
-                    // Surface topic_id from fleet.yaml for debugging (#415).
-                    if info.get("topic_id").is_none() {
-                        if let Some(tid) =
-                            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
-                                .ok()
-                                .and_then(|c| c.instances.get(name)?.topic_id)
-                        {
-                            info["topic_id"] = json!(tid);
+                    // Surface topic_id + topic_binding_mode from fleet.yaml.
+                    if let Some(inst) =
+                        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+                            .ok()
+                            .and_then(|c| c.instances.get(name).cloned())
+                    {
+                        if info.get("topic_id").is_none() {
+                            if let Some(tid) = inst.topic_id {
+                                info["topic_id"] = json!(tid);
+                            }
+                        }
+                        if let Some(ref mode) = inst.topic_binding_mode {
+                            info["topic_binding_mode"] = json!(mode);
                         }
                     }
                     json!({"instance": info})

--- a/src/mcp/handlers/instance_964_tests.rs
+++ b/src/mcp/handlers/instance_964_tests.rs
@@ -181,3 +181,125 @@ fn t2b_api_unavailable_rolls_back_fleet_yaml_entry() {
 
     let _ = std::fs::remove_dir_all(&home);
 }
+
+// ── #991 topic_binding tests ──────────────────────────────────────
+
+#[test]
+fn t3_topic_binding_skip_persists_to_fleet_yaml_and_spawn_params() {
+    let home = tmp_home("t3-tb");
+
+    let spawn_fn = |_h: &Path, req: &Value| -> anyhow::Result<Value> {
+        assert_eq!(
+            req["params"]["topic_binding"].as_str(),
+            Some("skip"),
+            "SPAWN RPC must carry topic_binding param"
+        );
+        Ok(json!({"ok": true, "result": {}}))
+    };
+
+    let result = spawn_single_instance_impl(
+        &home,
+        "test-spawner",
+        &json!({"name": "t3-skip", "backend": "claude", "topic_binding": "skip"}),
+        &spawn_fn,
+    );
+    assert!(result.get("error").is_none(), "must succeed: {result}");
+
+    let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+        .expect("reload fleet.yaml");
+    let inst = cfg.instances.get("t3-skip").expect("instance exists");
+    assert_eq!(
+        inst.topic_binding_mode.as_deref(),
+        Some("skip"),
+        "fleet.yaml must persist topic_binding_mode=skip"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn t4_topic_binding_omitted_defaults_to_auto() {
+    let home = tmp_home("t4-tb");
+
+    let spawn_fn = |_h: &Path, req: &Value| -> anyhow::Result<Value> {
+        assert!(
+            req["params"]["topic_binding"].is_null(),
+            "SPAWN params must NOT carry topic_binding when omitted"
+        );
+        Ok(json!({"ok": true, "result": {}}))
+    };
+
+    let result = spawn_single_instance_impl(
+        &home,
+        "test-spawner",
+        &json!({"name": "t4-auto", "backend": "claude"}),
+        &spawn_fn,
+    );
+    assert!(result.get("error").is_none(), "must succeed: {result}");
+
+    let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+        .expect("reload fleet.yaml");
+    let inst = cfg.instances.get("t4-auto").expect("instance exists");
+    assert!(
+        inst.topic_binding_mode.is_none(),
+        "fleet.yaml must NOT have topic_binding_mode when omitted (auto default)"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn t5_topic_binding_deferred_persists_and_forwards() {
+    let home = tmp_home("t5-tb");
+
+    let spawn_fn = |_h: &Path, req: &Value| -> anyhow::Result<Value> {
+        assert_eq!(
+            req["params"]["topic_binding"].as_str(),
+            Some("deferred"),
+            "SPAWN RPC must carry topic_binding=deferred"
+        );
+        Ok(json!({"ok": true, "result": {}}))
+    };
+
+    let result = spawn_single_instance_impl(
+        &home,
+        "test-spawner",
+        &json!({"name": "t5-deferred", "backend": "claude", "topic_binding": "deferred"}),
+        &spawn_fn,
+    );
+    assert!(result.get("error").is_none(), "must succeed: {result}");
+
+    let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+        .expect("reload fleet.yaml");
+    let inst = cfg.instances.get("t5-deferred").expect("instance exists");
+    assert_eq!(
+        inst.topic_binding_mode.as_deref(),
+        Some("deferred"),
+        "fleet.yaml must persist topic_binding_mode=deferred"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn t6_topic_binding_invalid_value_treated_as_auto() {
+    let home = tmp_home("t6-tb");
+
+    let spawn_fn = |_h: &Path, _req: &Value| -> anyhow::Result<Value> {
+        Ok(json!({"ok": true, "result": {}}))
+    };
+
+    let result = spawn_single_instance_impl(
+        &home,
+        "test-spawner",
+        &json!({"name": "t6-invalid", "backend": "claude", "topic_binding": "bogus"}),
+        &spawn_fn,
+    );
+    assert!(result.get("error").is_none(), "must succeed: {result}");
+
+    let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+        .expect("reload fleet.yaml");
+    let inst = cfg.instances.get("t6-invalid").expect("instance exists");
+    assert!(
+        inst.topic_binding_mode.is_none(),
+        "invalid topic_binding value must be treated as auto (not persisted)"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}

--- a/src/mcp/handlers/instance_spawn.rs
+++ b/src/mcp/handlers/instance_spawn.rs
@@ -165,6 +165,11 @@ pub(super) fn spawn_single_instance_impl(
         ready_pattern: None,
         command: None,
         worktree: None,
+        topic_binding_mode: args
+            .get("topic_binding")
+            .and_then(|v| v.as_str())
+            .filter(|s| matches!(*s, "skip" | "deferred"))
+            .map(String::from),
     };
     if let Err(e) = crate::fleet::add_instance_to_yaml(home, name, &entry) {
         return json!({"error": format!("failed to register instance in fleet.yaml: {e}")});
@@ -179,6 +184,9 @@ pub(super) fn spawn_single_instance_impl(
     });
     if let Some(env) = env_value.as_ref() {
         spawn_params["env"] = env.clone();
+    }
+    if let Some(tb) = args.get("topic_binding").and_then(|v| v.as_str()) {
+        spawn_params["topic_binding"] = json!(tb);
     }
     match spawn_fn(
         home,


### PR DESCRIPTION
## Summary
- **Problem**: Every `create_instance` auto-creates a Telegram topic, even for internal-only roles (dev-2, reviewer-2) that only receive inter-agent `send` — wastes API calls + clutters the channel.
- **Fix**: Add `topic_binding` parameter to `create_instance` with three modes: `auto` (default, current behavior), `skip` (no topic ever), `deferred` (no topic at spawn, retrofit later).
- **Persistence**: `topic_binding_mode` field in fleet.yaml per instance, distinguishable from silent failure per #962 discipline.

## Changes
- `fleet.rs`: Added `topic_binding_mode` to `InstanceConfig` + `InstanceYamlEntry` + `build_instance_mapping`
- `instance_spawn.rs`: Read `topic_binding` from args, persist to fleet.yaml entry, forward to SPAWN RPC
- `api/handlers/instance.rs`: Gate `ensure_topic_for` on `topic_binding` param in `handle_spawn`; expose `topic_binding_mode` in `describe_instance` response
- 11 files total (5 production + 6 constructor-site `topic_binding_mode: None` additions)

## Not in this PR (follow-up)
- `bind_topic` MCP action for retrofit (`deferred` mode round-trip)
- `team` / `deployment` template per-member `topic_binding` propagation
- `list_instances` bulk exposure (currently only `describe_instance`)

## Test plan
- [x] `t3_topic_binding_skip_persists_to_fleet_yaml_and_spawn_params` — skip mode persists + forwards
- [x] `t4_topic_binding_omitted_defaults_to_auto` — omitted = no field in fleet.yaml
- [x] `t5_topic_binding_deferred_persists_and_forwards` — deferred mode persists + forwards
- [x] `t6_topic_binding_invalid_value_treated_as_auto` — bogus value = auto
- [x] `topic_binding_mode_round_trips_through_fleet_yaml` — fleet.yaml serde round-trip
- [x] `topic_binding_mode_absent_parses_as_none` — back-compat for existing fleet.yaml
- [x] All existing tests pass, `cargo clippy --all-targets -- -D warnings` clean

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)