### PR TITLE
fix(#1042): use aggregate conclusion in ci-fail dedup filter

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1859,6 +1859,71 @@ mod tests {
         assert_eq!(deduped[0].2, "bbb");
     }
 
+    /// #1042 regression anchor: two runs for the same SHA with DIFFERENT
+    /// individual conclusions (coverage=success, CI=failure) but the same
+    /// AGGREGATE conclusion as last_notified. Pre-fix, the highest-id
+    /// run's individual conclusion ("success") differed from the
+    /// persisted aggregate ("failure"), so the dedup filter passed on
+    /// every poll cycle → re-broadcast. Post-fix, the filter compares
+    /// aggregates and correctly blocks.
+    #[test]
+    #[ignore = "RED: fails without #1042 fix — remove ignore in GREEN commit"]
+    fn test_1042_same_sha_same_aggregate_suppresses_rebroadcast() {
+        let runs = vec![
+            CiRun {
+                id: 700,
+                conclusion: Some("failure".into()),
+                head_sha: "abc".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 701,
+                conclusion: Some("success".into()),
+                head_sha: "abc".into(),
+                url: String::new(),
+            },
+        ];
+        let selected = select_runs_to_notify(&runs, Some(699), None);
+        assert_eq!(selected.len(), 2, "both runs should pass site-1 filter");
+        let deduped =
+            dedupe_notifications_by_head_sha(&runs, &selected, Some("abc"), Some("failure"));
+        assert_eq!(
+            deduped.len(),
+            0,
+            "#1042: same SHA + same aggregate conclusion (failure) \
+             must suppress re-broadcast; got {deduped:?}"
+        );
+    }
+
+    /// #1042 complement: when the aggregate conclusion genuinely changes
+    /// (failure → success after a rerun), the notification MUST fire.
+    #[test]
+    fn test_1042_same_sha_different_aggregate_fires() {
+        let runs = vec![
+            CiRun {
+                id: 800,
+                conclusion: Some("success".into()),
+                head_sha: "abc".into(),
+                url: String::new(),
+            },
+            CiRun {
+                id: 801,
+                conclusion: Some("success".into()),
+                head_sha: "abc".into(),
+                url: String::new(),
+            },
+        ];
+        let selected = select_runs_to_notify(&runs, Some(799), None);
+        let deduped =
+            dedupe_notifications_by_head_sha(&runs, &selected, Some("abc"), Some("failure"));
+        assert_eq!(
+            deduped.len(),
+            1,
+            "#1042: same SHA but aggregate changed (failure→success) \
+             must fire notification; got {deduped:?}"
+        );
+    }
+
     #[test]
     fn test_different_head_sha_triggers_new_notification() {
         let runs = vec![

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -492,13 +492,14 @@ pub(crate) fn dedupe_notifications_by_head_sha<'a>(
     }
     let mut result: Vec<_> = best
         .into_iter()
-        .filter(|(sha, (idx, _))| {
+        .filter(|(sha, (_idx, _))| {
             if last_notified_sha != Some(*sha) {
                 return true; // different sha → always pass
             }
-            // Same sha as last notified — #786: allow through only
-            // when conclusion changed (rerun / re-scheduled run).
-            runs[*idx].conclusion.as_deref() != last_notified_conclusion
+            // #1042: compare AGGREGATE conclusion (not individual run's)
+            // against last_notified_conclusion — the fan-out persists
+            // the aggregate, so dedup must match the same value.
+            aggregate_conclusion_for_sha(runs, sha) != last_notified_conclusion
         })
         .map(|(sha, (idx, id))| (idx, id, sha))
         .collect();
@@ -1867,7 +1868,6 @@ mod tests {
     /// every poll cycle → re-broadcast. Post-fix, the filter compares
     /// aggregates and correctly blocks.
     #[test]
-    #[ignore = "RED: fails without #1042 fix — remove ignore in GREEN commit"]
     fn test_1042_same_sha_same_aggregate_suppresses_rebroadcast() {
         let runs = vec![
             CiRun {


### PR DESCRIPTION
## Summary
- **Root cause**: `dedupe_notifications_by_head_sha` compared the highest-id individual run's conclusion against `last_notified_conclusion` (set from the aggregate). When multiple workflow runs have mixed conclusions (e.g. coverage=success, CI=failure → aggregate=failure), the individual conclusion differed from the persisted aggregate on every poll cycle, bypassing the dedup and re-broadcasting `[ci-fail]` every 60s.
- **Fix**: compare `aggregate_conclusion_for_sha()` instead of the individual run's conclusion in the dedup filter.
- **Tests**: 2 new tests — regression anchor (same SHA + same aggregate suppresses re-broadcast) and complement (genuine conclusion change still fires).

## Test plan
- [x] `test_1042_same_sha_same_aggregate_suppresses_rebroadcast` — RED without fix, GREEN with fix
- [x] `test_1042_same_sha_different_aggregate_fires` — genuine conclusion change (failure→success) still notifies
- [x] Full test suite passes (`cargo test --tests`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)