### PR TITLE
fix(#1040): hook derive_team_reviewer at handle_checkout_repo bypass site

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -155,11 +155,24 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
                 if let Some(r) = crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(
                     &source_canonical,
                 ) {
-                    let watch_resp = handle_watch_ci(
+                    // #1040 Option F: this checkout-arm path bypasses
+                    // `dispatch_auto_bind_lease_with_source_and_chain`
+                    // (which carries the #1037 auto-derive). Apply the
+                    // same convention scan here so the dev-self-claim
+                    // flow (`repo action=checkout bind=true` at
+                    // task-claim time — the canonical fixup-team
+                    // entry per protocol) propagates the chain target
+                    // into the sidecar. Pre-#1040 every modern fixup
+                    // PR silently armed `next_after_ci=null` and the
+                    // post-#1037 auto-wake quartet never fired.
+                    let mut watch_args = json!({"repo": &r, "branch": branch});
+                    if let Some(next) = crate::mcp::handlers::dispatch_hook::derive_team_reviewer(
                         home,
-                        &json!({"repo": &r, "branch": branch}),
                         instance_name,
-                    );
+                    ) {
+                        watch_args["next_after_ci"] = json!(next);
+                    }
+                    let watch_resp = handle_watch_ci(home, &watch_args, instance_name);
                     if let Some(err_msg) = watch_resp.get("error").and_then(|v| v.as_str()) {
                         let code = watch_resp
                             .get("code")

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -683,6 +683,69 @@ fn p778_setup_source_repo(parent: &Path, branch: &str) -> std::path::PathBuf {
 
 #[test]
 #[cfg(unix)]
+fn checkout_bind_true_auto_derives_next_after_ci_from_team_1040() {
+    // #1040 RED→GREEN: when `repo action=checkout bind=true` arms a
+    // ci-watch sidecar, the team's `<team>-reviewer` member should be
+    // auto-derived into `next_after_ci` — same convention as the
+    // #1037 dispatch-side auto-derive, applied at the checkout path.
+    //
+    // Empirical motivation (per /tmp/dialectic-1040-primary-dev.md):
+    // `handle_checkout_repo:158-162` calls `handle_watch_ci` directly
+    // with only `{repo, branch}` args, bypassing
+    // `dispatch_auto_bind_lease_with_source_and_chain` entirely. The
+    // #1037 auto-derive helper lives inside the bypassed wrapper, so
+    // every modern fixup-team PR (#1027 through #1031, all of which
+    // used `repo action=checkout bind=true` at task-claim time) armed
+    // sidecars with `next_after_ci=None`.
+    //
+    // REGRESSION-PROOF: revert the `derive_team_reviewer` call at
+    // handle_checkout_repo line 158 → this assertion FAILS because
+    // `watch["next_after_ci"]` reads as null instead of `"val-reviewer"`.
+    let home = p778_tmp_home("1040-derive");
+    let parent = p778_tmp_home("1040-derive-src");
+    let source = p778_setup_source_repo(&parent, "feat/1040-derive");
+    let agent = "val-dev";
+
+    // Seed fleet.yaml with team `val` containing `val-dev` + `val-reviewer`.
+    // The auto-derive scans the target's team for a `*-reviewer` member.
+    let yaml = format!(
+        "instances: {{}}\nteams:\n  val:\n    members:\n      - val-dev\n      - val-reviewer\n    source_repo: {}\n",
+        source.display()
+    );
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "source": source.display().to_string(),
+            "branch": "feat/1040-derive",
+            "bind": true,
+        }),
+        agent,
+    );
+    assert!(resp.get("error").is_none(), "checkout must succeed: {resp}");
+
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/1040-derive"),
+    );
+    assert!(watch_path.exists(), "ci-watch sidecar must be armed");
+
+    let watch: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
+            .expect("parse watch");
+    assert_eq!(
+        watch["next_after_ci"].as_str(),
+        Some("val-reviewer"),
+        "#1040 GREEN: checkout-bound watch must auto-derive next_after_ci \
+         from team `<team>-reviewer` convention. Got: {watch}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
 fn checkout_bind_true_writes_binding_marker_and_arms_watch() {
     // Empirical regression-proof anchor for #778 Option 1.
     let home = p778_tmp_home("ok");


### PR DESCRIPTION
## Summary

- `handle_checkout_repo:158` (the `repo action=checkout bind=true` path) bypassed `dispatch_auto_bind_lease_with_source_and_chain` and called `handle_watch_ci` directly with only `{repo, branch}` args. The #1037 auto-derive helper (`derive_team_reviewer`) lives inside the bypassed wrapper, so the convention scan never fired on the canonical fixup-team task-claim flow.
- Reuse `derive_team_reviewer(home, instance_name)` at the bypass site — same convention scan, single source of truth.
- Per lead's F.1 decision: skip `task_id` propagation in the checkout path (dispatch-driven case already covers it via #1031). bind_self `task_id="self"` sentinel filed as Option G follow-up (out of scope).

Closes #1040.

## Spike-confirmed evidence (memo at /tmp/dialectic-1040-primary-dev.md)

Empirical snapshot of `~/.agend-terminal/ci-watches/`:

| Sidecar | Instance | next_after_ci | task_id |
|---|---|---|---|
| `fix/1042-...` (just created, post-#1037+#1031 merge + restart) | fixup-dev-2 | **null** | null |
| `feat/reverse-words` (control, manual `ci action=watch`) | demo-dev | `demo-reviewer` | null |

Every modern fixup-team PR (#1027 → #1031) armed sidecars via this bypass path. The quartet (#1030+#1033+#1037+#1031) shipped but the auto-wake never empirically fired because the auto-derive never reached the real arm site.

## Tests (§3.10 RED → GREEN)

RED commit `a9857cc` introduces 1 anchor:

| # | Test | RED | GREEN |
|---|---|---|---|
| T1 | `checkout_bind_true_auto_derives_next_after_ci_from_team_1040` | **FAIL** | PASS — checkout-bound sidecar has `next_after_ci=val-reviewer` |

Anti-regression coverage on the other 12 `checkout_bind_true*` tests unchanged (all pass GREEN).

Reviewer verification:

```
git checkout a9857cc && cargo test --bin agend-terminal -- checkout_bind_true_auto_derives_next_after_ci_from_team_1040
# FAIL (handle_checkout_repo:158 still pre-#1040 args)
git checkout HEAD && cargo test ...
# PASS (Option F lands)
```

Full suite: **2677 passed, 0 failed** (`cargo test --bin agend-terminal`). fmt clean. `cargo clippy --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo build` (worktree)
- [x] `cargo test --bin agend-terminal` (2677 passed)
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] CI green on PR (per §3.3.1 reviewer/lead `gh pr checks 1043` independent verification)
- [ ] **Dogfood (third try)**: this PR is the fix's source; daemon still holds pre-#1040 code, so manual lead-kick still required on this PR. Post-merge + operator restart → the NEXT PR is the real empirical validation. If THAT sidecar carries `next_after_ci=fixup-reviewer` auto-set + reviewer auto-wakes on CI green → the quintet (#1030+#1033+#1037+#1031+#1040) closes the recurring lead-manual-kick class end-to-end.

## §3.6 / §3.5

- §3.6 borderline (~16 LOC + 1 test single-file). Lead's call.
- §3.5 single reviewer sufficient.

## Cross-ref

- #1030 routing-layer wake-aware (`enqueue_with_idle_hint`)
- #1032 sibling-class routing migration
- #1037 orchestration-layer auto-derive (dispatch path)
- #1031 payload enrichment (full SHA / PR# / task_id)
- **#1040 (this PR) — orchestration-layer auto-derive at the CHECKOUT path**
- #1042 (filed during #1031 recovery, in-flight by dev-2) — ci-fail dedup
- Option G (bind_self task_id="self" sentinel) — separate ticket per lead

The quintet closes the recurring class at routing + sibling-routing + dispatch-orchestration + payload + checkout-orchestration layers. After this lands and operator restarts, the next PR's empirical dogfood is the final validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)