### PR TITLE
fix(#1044): replace bind_self "self" sentinel with plumbed task_id

### DIFF
--- a/src/daemon/task_progress.rs
+++ b/src/daemon/task_progress.rs
@@ -204,9 +204,8 @@ pub(crate) fn touch_progress_for_branch(home: &Path, branch: &str) -> Option<Str
             continue;
         }
         let task_id = v["task_id"].as_str().unwrap_or("");
-        // task_id="" means "self" — agent bound itself without a
-        // task board entry; no progress to touch.
-        if task_id.is_empty() || task_id == "self" {
+        // #1044: empty task_id = self-bind without task board entry.
+        if task_id.is_empty() {
             continue;
         }
         touch(home, task_id, ProgressSource::CiPush);
@@ -447,16 +446,15 @@ mod tests {
 
     #[test]
     fn touch_progress_for_branch_skips_self_bindings() {
-        // Defensive: bind_self uses task_id="self" as a marker.
-        // touch_progress_for_branch must skip these — they have no
-        // task board entry to track progress against.
+        // #1044: bind_self without task_id uses empty string.
+        // touch_progress_for_branch must skip these — no task board entry.
         let home = tmp_home("hook-self-binding");
         let runtime_dir = crate::paths::runtime_dir(&home).join("dev");
         std::fs::create_dir_all(&runtime_dir).unwrap();
         let binding = serde_json::json!({
             "version": 1,
             "agent": "dev",
-            "task_id": "self",
+            "task_id": "",
             "branch": "feature/y",
             "issued_at": "2026-05-09T00:00:00Z",
         });

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -145,7 +145,7 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
                 if let Err(e) = crate::binding::bind_full(
                     home,
                     instance_name,
-                    "self",
+                    "",
                     branch,
                     &worktree_dir,
                     &source_canonical,

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -723,8 +723,8 @@ fn checkout_bind_true_writes_binding_marker_and_arms_watch() {
     assert_eq!(v["branch"].as_str(), Some("feat/p778"));
     assert_eq!(
         v["task_id"].as_str(),
-        Some("self"),
-        "atomic bind must record task_id=self"
+        Some(""),
+        "atomic bind must record empty task_id (no sentinel)"
     );
 
     // Auto-watch_ci must have been armed via derive_repo_from_remote_pub.
@@ -1318,7 +1318,7 @@ fn checkout_bind_true_auto_create_path_preserves_779_tail_ops() {
     let v: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&binding).unwrap()).unwrap();
     assert_eq!(v["branch"].as_str(), Some("feat/p780-tail"));
-    assert_eq!(v["task_id"].as_str(), Some("self"));
+    assert_eq!(v["task_id"].as_str(), Some(""));
 
     // ci_watch arming uses derive_repo_from_remote_pub on origin URL —
     // the fixture's `https://github.com/owner/repo.git` resolves to

--- a/src/mcp/handlers/p0b_tests.rs
+++ b/src/mcp/handlers/p0b_tests.rs
@@ -564,7 +564,6 @@ fn bind_self_with_source_repo_arg_succeeds() {
 // ── #1044: bind_self task_id plumbing ──────────────────────────────────
 
 #[test]
-#[ignore = "RED: fails without #1044 fix"]
 fn bind_self_with_task_id_arg_persists_real_task_id() {
     let home = tmp_home("bs-tid");
     let src = setup_git_repo(&home, "beta");
@@ -590,7 +589,6 @@ fn bind_self_with_task_id_arg_persists_real_task_id() {
 }
 
 #[test]
-#[ignore = "RED: fails without #1044 fix"]
 fn bind_self_without_task_id_arg_uses_empty_not_self() {
     let home = tmp_home("bs-no-tid");
     let src = setup_git_repo(&home, "gamma");

--- a/src/mcp/handlers/p0b_tests.rs
+++ b/src/mcp/handlers/p0b_tests.rs
@@ -561,6 +561,59 @@ fn bind_self_with_source_repo_arg_succeeds() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+// ── #1044: bind_self task_id plumbing ──────────────────────────────────
+
+#[test]
+#[ignore = "RED: fails without #1044 fix"]
+fn bind_self_with_task_id_arg_persists_real_task_id() {
+    let home = tmp_home("bs-tid");
+    let src = setup_git_repo(&home, "beta");
+    let sender = crate::identity::Sender::new("beta");
+    let args = json!({
+        "branch": "feat-tid",
+        "source_repo": src.display().to_string(),
+        "task_id": "t-20260521-real-task",
+    });
+    let result = super::worktree::handle_bind_self(&home, &args, &sender);
+    assert_eq!(result["bound"], true, "bind must succeed: {result}");
+    let binding_path = crate::paths::runtime_dir(&home)
+        .join("beta")
+        .join("binding.json");
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&binding_path).unwrap()).unwrap();
+    assert_eq!(
+        v["task_id"].as_str(),
+        Some("t-20260521-real-task"),
+        "#1044: bind_self with task_id arg must persist real task_id, not 'self'"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+#[ignore = "RED: fails without #1044 fix"]
+fn bind_self_without_task_id_arg_uses_empty_not_self() {
+    let home = tmp_home("bs-no-tid");
+    let src = setup_git_repo(&home, "gamma");
+    let sender = crate::identity::Sender::new("gamma");
+    let args = json!({
+        "branch": "feat-no-tid",
+        "source_repo": src.display().to_string(),
+    });
+    let result = super::worktree::handle_bind_self(&home, &args, &sender);
+    assert_eq!(result["bound"], true, "bind must succeed: {result}");
+    let binding_path = crate::paths::runtime_dir(&home)
+        .join("gamma")
+        .join("binding.json");
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&binding_path).unwrap()).unwrap();
+    assert_ne!(
+        v["task_id"].as_str(),
+        Some("self"),
+        "#1044: bind_self without task_id must NOT use 'self' sentinel"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 // ── source_repo override via bind_self_with_source param ────────────────
 
 #[test]

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -88,13 +88,14 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
         }
     }
 
-    // task_id="self" — clear distinction from real task IDs in the binding.json
-    // audit trail. The tasks store doesn't need a row for a self-bind; the
-    // string is purely a marker.
+    let task_id = args["task_id"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .unwrap_or("");
     match crate::mcp::handlers::dispatch_hook::dispatch_auto_bind_lease_with_source(
         home,
         agent,
-        "self",
+        task_id,
         branch,
         repo_arg,
         source_repo_path.as_deref(),
@@ -421,8 +422,8 @@ mod tests {
         assert_eq!(v["branch"].as_str(), Some("feat/p17"));
         assert_eq!(
             v["task_id"].as_str(),
-            Some("self"),
-            "self-bind must record task_id=self"
+            Some(""),
+            "self-bind without task_id arg must record empty task_id"
         );
 
         // Worktree dir + .agend-managed marker per P0-X / P1-7.


### PR DESCRIPTION
## Summary
- **Root cause**: `handle_bind_self` and `checkout_repo(bind:true)` hardcoded `task_id="self"` in binding.json, preventing downstream task-board correlation from tracking real task IDs.
- **Fix (Option A)**: `bind_self` reads `args["task_id"]` — real task_id persists to binding.json when provided, empty string when absent. `checkout_repo` bind path uses empty string. `task_progress` already handles empty (skip); removed stale `"self"` check.
- 3 production sites changed, 4 test expectations updated, 2 new regression tests.

## Changed files
- `src/mcp/handlers/worktree.rs` — read `args["task_id"]`, pass through (or `""`)
- `src/mcp/handlers/ci/mod.rs` — `"self"` → `""` in `bind_full` call
- `src/daemon/task_progress.rs` — remove `|| task_id == "self"` guard (empty covers it)
- `src/mcp/handlers/ci/tests.rs` — 2 test expectation updates
- `src/mcp/handlers/p0b_tests.rs` — 2 new regression tests

## Test plan
- [x] `bind_self_with_task_id_arg_persists_real_task_id` — RED without fix, GREEN with fix
- [x] `bind_self_without_task_id_arg_uses_empty_not_self` — RED without fix, GREEN with fix
- [x] 13 existing `bind_self` tests pass
- [x] 14 `checkout_bind` tests pass
- [x] `touch_progress_for_branch_skips_self_bindings` passes with empty string
- [x] `file_size_invariant` passes (worktree.rs = 750 LOC)
- [x] Full test suite, fmt, clippy clean

Closes #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)