### PR TITLE
test(#996 Phase 2a): pin kiro `No, exit` regression — Down+Enter empirically correct

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -309,6 +309,22 @@ impl Backend {
                     // Down moves to "Yes, I accept", Enter confirms
                     // Keys sent with per-byte delay in try_dismiss_dialog
                     // Issue #468: anchored regex (see ClaudeCode comment above).
+                    //
+                    // #996 Phase 2a empirical verification (2026-05-21):
+                    // byte-level analysis of `tests/fixtures/state-replay/
+                    // kiro-tooluse.raw` confirms the modal opens with the
+                    // `❯` cursor marker + magenta SGR (\x1b[38;2;255;0;255m)
+                    // on "No, exit" (destructive default). State 2 in the
+                    // same fixture shows the marker shifted to "Yes, I
+                    // accept" after a Down-arrow press. The current
+                    // `\x1b[B\r` (Down + Enter) keystroke correctly walks
+                    // off the destructive default before confirming —
+                    // unlike ClaudeCode `Yes, I trust` (which Phase 1
+                    // #1001 fixed by changing to bare `\r` because that
+                    // backend's modern modal defaults the cursor on the
+                    // SAFE option). Do NOT collapse this to bare `\r` —
+                    // see `kiro_no_exit_dismiss_uses_down_then_enter` test
+                    // for the regression pin.
                     (r"(?m)^[^A-Za-z\n]{0,8}No, exit", b"\x1b[B\r"),
                 ],
                 fresh_args: None, // same as args
@@ -1094,6 +1110,56 @@ mod tests {
         assert!(
             !trust.1.contains(&0x1b),
             "#996: trust dismiss keystroke must not contain ESC (0x1b)"
+        );
+    }
+
+    /// #996 Phase 2a: KiroCli `No, exit` dismiss must send Down + Enter
+    /// (`\x1b[B\r`), NOT bare Enter. Empirical evidence from
+    /// `tests/fixtures/state-replay/kiro-tooluse.raw` (byte offsets 5900 +
+    /// 6691): the modal opens with the `❯` cursor marker on "No, exit"
+    /// (destructive default). Bare Enter would EXIT kiro. Down-arrow
+    /// walks the cursor to "Yes, I accept" before Enter confirms.
+    ///
+    /// This regression pin guards against a future "simplify to bare \r"
+    /// refactor (mirror of #1001 / ClaudeCode `Yes, I trust`) that would
+    /// be CORRECT for claude but WRONG for kiro — the empirical default
+    /// cursor on this backend is the destructive option, not the safe
+    /// one. See backend.rs comment block at the dismiss_patterns entry.
+    #[test]
+    fn kiro_no_exit_dismiss_uses_down_then_enter() {
+        let kiro = Backend::KiroCli.preset();
+        let entry = kiro
+            .dismiss_patterns
+            .iter()
+            .find(|(re, _)| re.contains("No, exit"))
+            .expect("KiroCli must have a `No, exit` dismiss pattern");
+
+        // Positive pin: exact keystroke shape Down + Enter
+        assert_eq!(
+            entry.1, b"\x1b[B\r",
+            "#996 Phase 2a: kiro trust-all-tools dismiss must walk off the \
+             destructive default (\\x1b[B = Down) before confirming (\\r). \
+             Empirical evidence: kiro-tooluse.raw byte offsets 5900 + 6691 \
+             show the modal opens with cursor on `No, exit`."
+        );
+
+        // Negative pin: must NOT collapse to bare Enter — that would EXIT kiro
+        // on the empirically-verified destructive default.
+        assert_ne!(
+            entry.1, b"\r",
+            "#996 Phase 2a regression guard: bare Enter would select kiro's \
+             destructive default (`No, exit`). Verify `kiro-tooluse.raw` \
+             fixture before changing the keystroke shape."
+        );
+
+        // Negative pin: must START with ESC + `[B` (Down arrow CSI), not
+        // some other CSI sequence. Defends against off-by-one keystroke
+        // typos like `\x1b[A` (Up — wrong direction).
+        assert!(
+            entry.1.starts_with(b"\x1b[B"),
+            "#996 Phase 2a: keystroke must start with Down-arrow CSI \
+             (\\x1b[B), got: {:?}",
+            entry.1
         );
     }
 


### PR DESCRIPTION
## Summary

- Phase 2a kiro half (claude half deferred to **#1054** per operator (γ) decision).
- Pure test + doc-comment addition; NO production code change.
- Byte-level fixture analysis (`kiro-tooluse.raw` offsets 5900 + 6691) confirms kiro modal's default cursor is on `No, exit` (destructive). Current `\x1b[B\r` (Down + Enter) keystroke is empirically correct — bare `\r` would EXIT kiro.

Closes #996 Phase 2a kiro half. Phase 2a claude half tracked in #1054.

## Empirical evidence

```
@ offset 5900 (state 1):
  \x1b[1m\xe2\x9d\xaf\x1b[22m\x1b[39m \x1b[38;2;255;0;255m\x1b[1mNo, exit
  ↑ "❯" cursor marker + magenta SGR + bold ON "No, exit" (destructive default)

@ offset 6691 (state 2, post Down-arrow):
  \x1b[0mNo, exit
  ↑ plain styling (cursor moved away)

@ offset 6860 (state 2):
  \x1b[1m\xe2\x9d\xaf\x1b[22m\x1b[39m \x1b[38;2;255;0;255m\x1b[1mYes, I accept
  ↑ cursor marker moved to "Yes, I accept" after Down-arrow press
```

S4 (dev-2)'s initial hypothesis "FIX likely — kiro may have flipped default like claude did" — empirically **disproved**. The two backends differ in default behaviour; the keystroke shapes correctly reflect that.

## Change

| File | Change |
|---|---|
| `src/backend.rs:307-327` | Extended doc-comment on `KiroCli::dismiss_patterns` citing kiro-tooluse.raw + cross-ref the new test |
| `src/backend.rs::tests::kiro_no_exit_dismiss_uses_down_then_enter` (new) | 3-assertion regression pin: positive (`\x1b[B\r` exact); negative (not bare `\r`); negative (must start with `\x1b[B`, guards against `\x1b[A` Up-arrow typo) |

## Tests

- `kiro_no_exit_dismiss_uses_down_then_enter` (NEW) — 3 assertions pass
- `claude_trust_dismiss_uses_single_enter` (existing, #1001) — unchanged, still passes
- Full suite: **2686 passed, 0 failed** (`cargo test --bin agend-terminal`)
- fmt clean. `cargo clippy --all-targets -- -D warnings` clean.

## Test plan

- [x] `cargo build` (worktree)
- [x] `cargo test --bin agend-terminal` (2686 passed)
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] CI green on PR (per §3.3.1 reviewer/lead `gh pr checks 1055` independent verification)
- [ ] **META-DOGFOOD**: lead committed to NOT manual-kick post-CI-green to observe whether reviewer auto-wakes under the post-#1040 quintet infrastructure. If reviewer auto-wakes + posts §3.12 verdict mirror without lead intervention, the quintet (#1030+#1033+#1037+#1031+#1040) is empirically validated end-to-end.

## §3.6 / §3.5

- §3.6 eligible (single-file, test + doc-comment only, no production behaviour change). Lead's call.
- §3.5 single reviewer sufficient.

## Cross-ref

- #996 (umbrella) — Phase 1 ClaudeCode #1 closed via #1001; Phase 2a kiro closes via this PR; Phase 2a claude tracked in #1054; Phase 2b (A+C framework) separate dispatch
- **#1054** — deferred claude `Yes, proceed` modal default cursor empirical capture (operator-side task)
- #1001 (Phase 1 ClaudeCode `Yes, I trust` `\r` fix) — sibling pattern, opposite default-cursor empirical outcome
- Memo: `/tmp/dialectic-996-framework-primary-dev.md` (lead synthesis context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)