### PR TITLE
refactor(#994): make topics.json single source of truth for topic_id (Phase 1/3)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -263,40 +263,6 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
             let mut result = json!({"name": name});
             if let Some(tid) = topic_id {
                 result["topic_id"] = json!(tid);
-                // Persist topic_id to fleet.yaml so daemon can route messages
-                // to this instance's topic on restart (#415).
-                //
-                // #962: consume the Result<bool> from update_instance_field so
-                // the MCP response carries `topic_persisted: false` (and
-                // optionally `topic_persist_error`) when the persist silently
-                // no-op'd or hit an IO error. Pre-#962 the `let _ = ...` swallow
-                // surfaced as demo-blocking "topic_id: null" fleet.yaml rows.
-                if let Ok(tid_num) = tid.parse::<i32>() {
-                    match crate::fleet::update_instance_field(
-                        ctx.home,
-                        name,
-                        "topic_id",
-                        serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(tid_num)),
-                    ) {
-                        Ok(true) => { /* persisted — happy path stays minimal */ }
-                        Ok(false) => {
-                            // Silent no-op already warn-logged inside
-                            // update_instance_field. Surface to MCP caller so
-                            // automation (replace_instance, operator scripts)
-                            // can detect partial-success without daemon.log grep.
-                            result["topic_persisted"] = json!(false);
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                agent = name,
-                                error = %e,
-                                "update_instance_field failed — topic_id NOT persisted to fleet.yaml"
-                            );
-                            result["topic_persisted"] = json!(false);
-                            result["topic_persist_error"] = json!(format!("{e}"));
-                        }
-                    }
-                }
             }
             json!({"ok": true, "result": result})
         }

--- a/src/app/tui_spawn.rs
+++ b/src/app/tui_spawn.rs
@@ -43,50 +43,16 @@ pub(crate) fn add_instance_with_topic(
     let outcome = ensure_topic_for(name);
 
     if let TopicOutcome::Created(ref tid) = outcome {
-        if let Ok(tid_num) = tid.parse::<i32>() {
-            // Mirrors handle_spawn's #962-discipline match. Surface
-            // failures via tracing::warn rather than swallowing; the
-            // helper still returns Created because the topic WAS made
-            // (the channel-side registry recorded it). Operator-visible
-            // signal: warn-log entry with the fleet-yaml mismatch.
-            match crate::fleet::update_instance_field(
-                home,
-                name,
-                "topic_id",
-                serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(tid_num)),
-            ) {
-                Ok(true) => {
-                    tracing::info!(
-                        instance = name,
-                        topic_id = %tid,
-                        "TUI-spawn: created channel topic + persisted topic_id"
-                    );
-                }
-                Ok(false) => {
-                    tracing::warn!(
-                        instance = name,
-                        topic_id = %tid,
-                        "TUI-spawn: topic created but fleet.yaml entry unexpectedly \
-                         missing — topic_id NOT persisted"
-                    );
-                }
-                Err(e) => {
-                    tracing::error!(
-                        instance = name,
-                        topic_id = %tid,
-                        error = %e,
-                        "TUI-spawn: topic_id persist failed"
-                    );
-                }
+        if let Ok(topic_id) = tid.parse::<i32>() {
+            if let Err(e) = crate::channel::telegram::register_topic(home, topic_id, name) {
+                tracing::warn!(instance = name, error = %e, "TUI-spawn: failed to persist topic_id to topics.json");
             }
-        } else {
-            tracing::warn!(
-                instance = name,
-                topic_id = %tid,
-                "TUI-spawn: non-numeric topic_id; skipping fleet.yaml persist \
-                 (expected telegram i32 format)"
-            );
         }
+        tracing::info!(
+            instance = name,
+            topic_id = %tid,
+            "TUI-spawn: created channel topic (persisted to topics.json)"
+        );
     } else if let TopicOutcome::Failed(ref err) = outcome {
         tracing::warn!(
             instance = name,
@@ -236,11 +202,10 @@ mod tests {
             TopicOutcome::Created(ref tid) => assert_eq!(tid, "7001"),
             other => panic!("expected Created, got {other:?}"),
         }
-        let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         assert_eq!(
-            cfg.instances.get("t1-agent").and_then(|i| i.topic_id),
+            crate::channel::telegram::lookup_topic_for_instance(&home, "t1-agent"),
             Some(7001),
-            "topic_id must be persisted to fleet.yaml"
+            "topic_id must be persisted to topics.json"
         );
         reset_active_channel_for_test();
         let _ = std::fs::remove_dir_all(&home);
@@ -322,11 +287,10 @@ mod tests {
             TopicOutcome::Created(ref tid) => assert_eq!(tid, "9100"),
             other => panic!("expected Created, got {other:?}"),
         }
-        let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         assert_eq!(
-            cfg.instances.get("ctrlb-c-agent").and_then(|i| i.topic_id),
+            crate::channel::telegram::lookup_topic_for_instance(&home, "ctrlb-c-agent"),
             Some(9100),
-            "#966 Backend menu caller-path: topic_id must be persisted"
+            "#966 Backend menu caller-path: topic_id must be persisted to topics.json"
         );
         reset_active_channel_for_test();
         let _ = std::fs::remove_dir_all(&home);
@@ -369,11 +333,10 @@ mod tests {
             TopicOutcome::Created(ref tid) => assert_eq!(tid, "9200"),
             other => panic!("expected Created, got {other:?}"),
         }
-        let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         assert_eq!(
-            cfg.instances.get("palette-agent").and_then(|i| i.topic_id),
+            crate::channel::telegram::lookup_topic_for_instance(&home, "palette-agent"),
             Some(9200),
-            "#966 palette caller-path: topic_id must be persisted"
+            "#966 palette caller-path: topic_id must be persisted to topics.json"
         );
         reset_active_channel_for_test();
         let _ = std::fs::remove_dir_all(&home);
@@ -446,11 +409,10 @@ mod tests {
             TopicOutcome::Created(ref tid) => assert_eq!(tid, "8500"),
             other => panic!("expected Created via runtime lookup, got {other:?}"),
         }
-        let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
         assert_eq!(
-            cfg.instances.get("late-agent").and_then(|i| i.topic_id),
+            crate::channel::telegram::lookup_topic_for_instance(&home, "late-agent"),
             Some(8500),
-            "late-arriving channel must persist topic_id for new instances"
+            "late-arriving channel must persist topic_id to topics.json"
         );
         reset_active_channel_for_test();
         let _ = std::fs::remove_dir_all(&home);

--- a/src/bootstrap/doctor_topics.rs
+++ b/src/bootstrap/doctor_topics.rs
@@ -104,15 +104,10 @@ impl TopicReport {
 pub fn classify(home: &Path) -> TopicReport {
     let registry = load_topic_registry(home);
     let fleet = FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
-    let fleet_topic_ids: HashMap<String, i32> = fleet
-        .as_ref()
-        .map(|c| {
-            c.instances
-                .iter()
-                .filter_map(|(n, i)| i.topic_id.map(|t| (n.clone(), t)))
-                .collect()
-        })
-        .unwrap_or_default();
+    let fleet_topic_ids: HashMap<String, i32> = {
+        let reg = load_topic_registry(home);
+        reg.into_iter().map(|(tid, name)| (name, tid)).collect()
+    };
     let fleet_instance_names: std::collections::HashSet<String> = fleet
         .as_ref()
         .map(|c| c.instances.keys().cloned().collect())
@@ -374,16 +369,15 @@ pub fn execute_cleanup(
                     }
                 }
                 DriftResolution::PreferRegistry => {
-                    // Update fleet.yaml to match topics.json.
-                    let _ = crate::fleet::update_instance_field(
-                        home,
-                        &entry.instance_name,
-                        "topic_id",
-                        serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(entry.topic_id)),
+                    tracing::info!(
+                        instance = %entry.instance_name,
+                        topic_id = entry.topic_id,
+                        "doctor: PreferRegistry is no-op post-refactor (topics.json is canonical)"
                     );
-                    actions.push(CleanupAction::UnregisteredOnly {
+                    actions.push(CleanupAction::SkippedNeedsResolution {
                         topic_id: entry.topic_id,
                         instance_name: entry.instance_name.clone(),
+                        reason: "prefer_registry: no-op (topics.json is already canonical source)",
                     });
                 }
                 DriftResolution::LeaveDrift => {
@@ -502,27 +496,32 @@ mod tests {
     }
 
     #[test]
-    fn classify_drift_fleet_when_registry_and_fleet_differ() {
-        let home = tmp_home("drift");
+    fn classify_live_even_when_fleet_yaml_differs() {
+        let home = tmp_home("drift-now-live");
         write_registry(&home, &[(42, "alpha")]);
         write_fleet(&home, &[("alpha", Some(99))]);
         let report = classify(&home);
         assert_eq!(report.entries.len(), 1);
-        assert_eq!(report.entries[0].class, TopicClass::DriftFleet);
-        assert_eq!(report.entries[0].topic_id, 42);
-        assert_eq!(report.entries[0].fleet_topic_id, Some(99));
+        assert_eq!(
+            report.entries[0].class,
+            TopicClass::Live,
+            "post-refactor: fleet_topic_ids reads topics.json, not fleet.yaml — always agrees with registry"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn classify_stale_registry_when_fleet_lacks_topic_id() {
-        let home = tmp_home("stale-registry");
+    fn classify_live_when_fleet_yaml_lacks_topic_id() {
+        let home = tmp_home("stale-now-live");
         write_registry(&home, &[(42, "alpha")]);
         write_fleet(&home, &[("alpha", None)]);
         let report = classify(&home);
         assert_eq!(report.entries.len(), 1);
-        assert_eq!(report.entries[0].class, TopicClass::StaleRegistry);
-        assert_eq!(report.entries[0].fleet_topic_id, None);
+        assert_eq!(
+            report.entries[0].class,
+            TopicClass::Live,
+            "post-refactor: topics.json is canonical — fleet.yaml topic_id irrelevant"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -601,13 +600,11 @@ mod tests {
         let mut report = classify(&home);
         report.can_manage_topics = Some(true);
         let out = render_human(&report);
+        // Post-refactor: fleet_topic_ids comes from topics.json (same source as registry),
+        // so both entries are Live — DriftFleet is unreachable from classify().
         assert!(
-            out.contains("1 live"),
+            out.contains("2 live"),
             "human output must show live count: {out}"
-        );
-        assert!(
-            out.contains("1 drift_fleet"),
-            "human output must show drift count: {out}"
         );
         assert!(
             out.contains("can_manage_topics: ✓"),
@@ -666,54 +663,59 @@ mod tests {
     }
 
     #[test]
-    fn execute_cleanup_stale_registry_surfaces_resolution_needed() {
+    fn execute_cleanup_former_stale_registry_now_live() {
+        // Post-refactor: fleet_topic_ids comes from topics.json, so a registry
+        // entry always matches itself → Live (StaleRegistry unreachable).
         let home = tmp_home("cleanup-stale");
         write_registry(&home, &[(42, "alpha")]);
         write_fleet(&home, &[("alpha", None)]);
         let mut report = classify(&home);
         report.can_manage_topics = Some(true);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].class, TopicClass::Live);
         let actions = execute_cleanup(&home, &report, DriftResolution::PreferFleet);
-        assert_eq!(actions.len(), 1);
-        match &actions[0] {
-            CleanupAction::SkippedNeedsResolution { reason, .. } => {
-                assert!(reason.contains("stale_registry"));
-                assert!(reason.contains("manually verify"));
-            }
-            other => panic!("expected SkippedNeedsResolution, got {other:?}"),
-        }
+        assert!(
+            actions.is_empty(),
+            "Live entries produce no cleanup actions"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn execute_cleanup_drift_prefer_fleet_updates_registry() {
+    fn execute_cleanup_former_drift_now_live_prefer_fleet() {
+        // Post-refactor: fleet_topic_ids comes from topics.json, so registry
+        // entry always agrees with itself → Live (DriftFleet unreachable).
         let home = tmp_home("cleanup-drift-fleet");
         write_registry(&home, &[(42, "alpha")]);
         write_fleet(&home, &[("alpha", Some(99))]);
         let mut report = classify(&home);
         report.can_manage_topics = Some(true);
-        let _ = execute_cleanup(&home, &report, DriftResolution::PreferFleet);
-        // Registry should now reflect fleet.yaml's topic_id (99).
-        let reg = load_topic_registry(&home);
-        assert_eq!(reg.get(&99), Some(&"alpha".to_string()));
-        assert!(!reg.contains_key(&42));
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].class, TopicClass::Live);
+        let actions = execute_cleanup(&home, &report, DriftResolution::PreferFleet);
+        assert!(
+            actions.is_empty(),
+            "Live entries produce no cleanup actions"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn execute_cleanup_drift_leave_surfaces_unresolved() {
+    fn execute_cleanup_former_drift_now_live_leave() {
+        // Post-refactor: fleet_topic_ids comes from topics.json, so registry
+        // entry always agrees with itself → Live (DriftFleet unreachable).
         let home = tmp_home("cleanup-drift-leave");
         write_registry(&home, &[(42, "alpha")]);
         write_fleet(&home, &[("alpha", Some(99))]);
         let mut report = classify(&home);
         report.can_manage_topics = Some(true);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].class, TopicClass::Live);
         let actions = execute_cleanup(&home, &report, DriftResolution::LeaveDrift);
-        assert_eq!(actions.len(), 1);
-        match &actions[0] {
-            CleanupAction::SkippedNeedsResolution { reason, .. } => {
-                assert!(reason.contains("drift_fleet"));
-            }
-            other => panic!("expected SkippedNeedsResolution, got {other:?}"),
-        }
+        assert!(
+            actions.is_empty(),
+            "Live entries produce no cleanup actions"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -73,12 +73,9 @@ fn auto_create_general(config: &mut FleetConfig, home: &Path, persist: bool) {
     if let Err(e) = fleet::add_instance_to_yaml(home, "general", &entry) {
         tracing::warn!(error = %e, "failed to persist general instance");
     }
-    let _ = fleet::update_instance_field(
-        home,
-        "general",
-        "topic_id",
-        serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(1)),
-    );
+    if let Err(e) = crate::channel::telegram::register_topic(home, 1, "general") {
+        tracing::warn!(error = %e, "failed to register general topic_id=1");
+    }
     tracing::info!("auto-created 'general' instance for channel");
 }
 
@@ -142,6 +139,7 @@ mod tests {
             channels: None,
             templates: None,
             display_timezone: None,
+            home: None,
         };
         c.instances.insert(
             "worker".to_string(),

--- a/src/channel/telegram/bootstrap.rs
+++ b/src/channel/telegram/bootstrap.rs
@@ -84,22 +84,11 @@ pub fn init_from_config(
     let bot = teloxide::Bot::new(&token);
     let chat_id = teloxide::types::ChatId(*group_id);
 
-    let mut topic_map: HashMap<String, i32> = config
-        .instances
+    let mut topic_map: HashMap<String, i32> = reg
         .iter()
-        .filter_map(|(name, inst)| inst.topic_id.map(|tid| (name.clone(), tid)))
+        .filter(|(tid, name)| **tid != 1 && name.as_str() != FLEET_BINDING_SENTINEL)
+        .map(|(tid, name)| (name.clone(), *tid))
         .collect();
-
-    // Merge topics.json entries not already in fleet.yaml.
-    for (tid, inst_name) in &reg {
-        if *tid != 1 && inst_name != FLEET_BINDING_SENTINEL && !topic_map.contains_key(inst_name) {
-            tracing::info!(
-                instance = %inst_name, topic_id = tid,
-                "merging topic from topics.json (not in fleet.yaml)"
-            );
-            topic_map.insert(inst_name.clone(), *tid);
-        }
-    }
 
     // Auto-create topics for instances without topic_id.
     //
@@ -123,10 +112,16 @@ pub fn init_from_config(
     // operator intervention via the (γ) `agend-terminal doctor
     // topics` surface (Sprint 60+ candidate: teloxide upgrade
     // evaluation if a future Bot API version exposes enumeration).
-    for (name, inst) in &config.instances {
-        if name == "general" && inst.topic_id.is_none() {
+    for name in config.instances.keys() {
+        if topic_map.contains_key(name.as_str()) {
+            continue;
+        }
+        if name == "general" {
             topic_map.insert("general".to_string(), 1);
-        } else if inst.topic_id.is_none() {
+            if let Err(e) = register_topic(home, 1, "general") {
+                tracing::warn!(error = %e, "failed to register general topic");
+            }
+        } else {
             tracing::info!(instance = %name, "auto-creating topic via track-on-create");
             if let Some(tid) = create_topic_for_instance(home, name) {
                 topic_map.insert(name.clone(), tid);
@@ -134,19 +129,12 @@ pub fn init_from_config(
         }
     }
 
-    // Write back topic_ids + update registry
-    if crate::fleet::fleet_yaml_path(home).exists() && !topic_map.is_empty() {
-        for (name, tid) in &topic_map {
-            let _ = crate::fleet::update_instance_field(
-                home,
-                name,
-                "topic_id",
-                serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(*tid)),
-            );
-            reg.insert(*tid, name.clone());
-        }
-        save_topic_registry(home, &reg);
-        tracing::info!("updated fleet.yaml with topic_ids");
+    // Ensure topic registry reflects any auto-created entries
+    for (name, tid) in &topic_map {
+        reg.insert(*tid, name.clone());
+    }
+    if let Err(e) = save_topic_registry(home, &reg) {
+        tracing::warn!(error = %e, "failed to save topic registry");
     }
 
     let fleet_binding_topic_id =
@@ -207,7 +195,7 @@ pub(super) fn resolve_fleet_binding(
             let tid = topic.thread_id.0 .0;
             tracing::info!(topic_id = tid, %name, "created fleet_binding topic");
             reg.insert(tid, FLEET_BINDING_SENTINEL.to_string());
-            save_topic_registry(home, reg);
+            let _ = save_topic_registry(home, reg);
             Some(tid)
         }
         Err(e) => {

--- a/src/channel/telegram/error.rs
+++ b/src/channel/telegram/error.rs
@@ -205,14 +205,6 @@ pub(crate) fn invalidate_and_recreate_topic(
         "invalidating stale topic and recreating"
     );
     unregister_topic(home, stale_tid);
-    // Clear the stale topic_id from fleet.yaml so create_topic_for_instance
-    // doesn't short-circuit on the old value.
-    let _ = crate::fleet::update_instance_field(
-        home,
-        instance_name,
-        "topic_id",
-        serde_yaml_ng::Value::Null,
-    );
     create_topic_for_instance(home, instance_name)
 }
 
@@ -311,7 +303,7 @@ mod tests {
         let mut reg = HashMap::new();
         reg.insert(99, "ghost".to_string());
         reg.insert(100, "alive".to_string());
-        save_topic_registry(&home, &reg);
+        save_topic_registry(&home, &reg).unwrap();
 
         cleanup_deleted_topic(&home, "ghost", 99, None);
 
@@ -339,8 +331,8 @@ mod tests {
     #[test]
     fn invalidate_and_recreate_strips_stale_topic_from_registry() {
         let home = tmp_home("invalidate-recreate-strip");
-        register_topic(&home, 42, "agent-x");
-        register_topic(&home, 99, "agent-y");
+        register_topic(&home, 42, "agent-x").unwrap();
+        register_topic(&home, 99, "agent-y").unwrap();
 
         let result = invalidate_and_recreate_topic(&home, "agent-x", 42);
         assert!(result.is_none(), "no bot → creation fails");
@@ -355,31 +347,19 @@ mod tests {
     }
 
     #[test]
-    fn invalidate_and_recreate_clears_fleet_yaml_topic_id() {
-        let home = tmp_home("invalidate-recreate-yaml");
-        let yaml = "\
-instances:
-  agent-x:
-    command: /bin/true
-    topic_id: 42
-  agent-y:
-    command: /bin/true
-    topic_id: 99
-";
-        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
-        register_topic(&home, 42, "agent-x");
+    fn invalidate_and_recreate_clears_topics_json() {
+        let home = tmp_home("invalidate-recreate-json");
+        register_topic(&home, 42, "agent-x").unwrap();
+        register_topic(&home, 99, "agent-y").unwrap();
 
         let _ = invalidate_and_recreate_topic(&home, "agent-x", 42);
 
-        let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
-            .expect("load fleet.yaml");
-        let agent_x = config.instances.get("agent-x").expect("agent-x exists");
-        assert_eq!(
-            agent_x.topic_id, None,
-            "topic_id must be cleared after invalidation"
+        let reg = load_topic_registry(&home);
+        assert!(
+            !reg.contains_key(&42),
+            "stale topic_id must be removed from topics.json"
         );
-        let agent_y = config.instances.get("agent-y").expect("agent-y exists");
-        assert_eq!(agent_y.topic_id, Some(99));
+        assert_eq!(reg.get(&99), Some(&"agent-y".to_string()));
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -394,7 +374,7 @@ instances:
     role: important
 ";
         std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
-        register_topic(&home, 42, "agent-x");
+        register_topic(&home, 42, "agent-x").unwrap();
 
         let _ = invalidate_and_recreate_topic(&home, "agent-x", 42);
 
@@ -417,7 +397,7 @@ instances:
         let mut reg = HashMap::new();
         reg.insert(42, FLEET_BINDING_SENTINEL.to_string());
         reg.insert(100, "at-dev-1".to_string());
-        save_topic_registry(&home, &reg);
+        save_topic_registry(&home, &reg).unwrap();
         let state = Arc::new(Mutex::new(TelegramState::new(
             "tok",
             -12345,
@@ -569,7 +549,7 @@ instances:
         let home = tmp_home("fleet-self-heal-neg");
         let mut reg = HashMap::new();
         reg.insert(42, FLEET_BINDING_SENTINEL.to_string());
-        save_topic_registry(&home, &reg);
+        save_topic_registry(&home, &reg).unwrap();
         let state = Arc::new(Mutex::new(TelegramState::new(
             "tok",
             -1,

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -66,20 +66,7 @@ pub(super) fn resolve_topic(state: &mut TelegramState, topic_id: Option<i32>) ->
         if let Some(name) = state.topic_to_instance.get(&tid).cloned() {
             return name;
         }
-        // Unknown topic_id — reload from fleet.yaml
-        if let Ok(config) =
-            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&state.home))
-        {
-            for (inst_name, inst) in &config.instances {
-                if inst.topic_id == Some(tid) {
-                    state.topic_to_instance.insert(tid, inst_name.clone());
-                    state.instance_to_topic.insert(inst_name.clone(), tid);
-                    return inst_name.clone();
-                }
-            }
-        }
-        // Fix B: check topics.json as third source (runtime-created topics
-        // may exist there but not in fleet.yaml or in-memory state).
+        // topics.json is the canonical source for topic_id → instance mapping.
         let reg = load_topic_registry(&state.home);
         if let Some(inst_name) = reg.get(&tid) {
             state.topic_to_instance.insert(tid, inst_name.clone());

--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -34,7 +34,7 @@ fn notify_telegram_inner(
             Ok(t) => (
                 t,
                 *group_id,
-                config.instances.get(instance_name).and_then(|i| i.topic_id),
+                crate::channel::telegram::lookup_topic_for_instance(home, instance_name),
             ),
             Err(_) => return,
         },

--- a/src/channel/telegram/reply.rs
+++ b/src/channel/telegram/reply.rs
@@ -119,11 +119,8 @@ pub(super) fn try_telegram_reply_from(
     instance_name: &str,
     text: &str,
 ) -> anyhow::Result<(i32, i64)> {
-    let (ch, config) = resolve_channel_from(home)?;
-    let topic_id = config
-        .instances
-        .get(instance_name)
-        .and_then(|inst| inst.topic_id);
+    let (ch, _config) = resolve_channel_from(home)?;
+    let topic_id = crate::channel::telegram::lookup_topic_for_instance(home, instance_name);
     // #969: catches the PTY-mirror + reply-tool race (RC2). The RC2
     // root-cause fix (move mirror_skip set BEFORE send in
     // handle_reply) closes the dominant window; this dedup catches
@@ -197,11 +194,8 @@ pub(super) fn try_telegram_reply_no_cleanup_from(
     instance_name: &str,
     text: &str,
 ) -> anyhow::Result<(i32, i64)> {
-    let (ch, config) = resolve_channel_from(home)?;
-    let topic_id = config
-        .instances
-        .get(instance_name)
-        .and_then(|inst| inst.topic_id);
+    let (ch, _config) = resolve_channel_from(home)?;
+    let topic_id = crate::channel::telegram::lookup_topic_for_instance(home, instance_name);
     telegram_reply_send_inner(&ch, instance_name, topic_id, text)
         .map(|msg_id| (msg_id, ch.group_id))
 }
@@ -355,7 +349,7 @@ instances:
     }
 
     #[test]
-    fn try_telegram_reply_cleanup_variant_mutates_fleet_on_topic_deleted() {
+    fn try_telegram_reply_cleanup_variant_clears_topics_json_on_topic_deleted() {
         let _g = channel_env_test_guard();
         let home = tmp_home("cleanup_variant_baseline");
 
@@ -368,12 +362,9 @@ channel:
 instances:
   B:
     command: /bin/true
-    topic_id: 42
 ";
         std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
-        std::fs::create_dir_all(home.join("channel")).ok();
-        std::fs::write(home.join("channel").join("topics.json"), "{\"B\":42}")
-            .expect("write topics.json");
+        register_topic(&home, 42, "B").unwrap();
 
         std::env::set_var("PR57_ROUND2_FAKE_TOKEN", "fake");
         set_forced_send_error(anyhow::anyhow!("Bad Request: message thread not found"));
@@ -381,24 +372,10 @@ instances:
         let res = try_telegram_reply_from(&home, "B", "main-path send");
         assert!(res.is_err());
 
-        let fleet_yaml =
-            std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("read fleet.yaml");
-        assert!(
-            fleet_yaml.contains("B:"),
-            "Sprint 23 P1: instance must survive topic invalidation; yaml was:\n{fleet_yaml}"
-        );
-        let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
-            .expect("load fleet.yaml");
-        let inst_b = config.instances.get("B").expect("B exists");
-        assert_eq!(
-            inst_b.topic_id, None,
-            "topic_id must be cleared after invalidation"
-        );
-
         let reg = load_topic_registry(&home);
         assert!(
             !reg.contains_key(&42),
-            "stale topic 42 must be unregistered"
+            "stale topic 42 must be unregistered from topics.json"
         );
 
         std::env::remove_var("PR57_ROUND2_FAKE_TOKEN");
@@ -421,7 +398,7 @@ instances:
     topic_id: 42
 ";
         std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
-        register_topic(&home, 42, "agent-x");
+        register_topic(&home, 42, "agent-x").unwrap();
         std::env::set_var("SPRINT23_P1_FAKE_TOKEN", "fake");
 
         set_forced_send_error(anyhow::anyhow!("Bad Request: message thread not found"));
@@ -462,7 +439,7 @@ instances:
     topic_id: 42
 ";
         std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
-        register_topic(&home, 42, "agent-x");
+        register_topic(&home, 42, "agent-x").unwrap();
         std::env::set_var("SPRINT23_P1_FAKE_TOKEN2", "fake");
 
         set_forced_send_error(anyhow::anyhow!("Too Many Requests: retry after 5"));
@@ -509,7 +486,7 @@ instances:
     topic_id: 42
 ";
         std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
-        register_topic(&home, 42, "agent-x");
+        register_topic(&home, 42, "agent-x").unwrap();
         std::env::set_var("SPRINT56_FAKE_TOKEN", "fake");
 
         let new_id = -1009999999999_i64;
@@ -558,7 +535,7 @@ instances:
     topic_id: 42
 ";
         std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
-        register_topic(&home, 42, "agent-x");
+        register_topic(&home, 42, "agent-x").unwrap();
         std::env::set_var("SPRINT56_FAKE_TOKEN_2", "fake");
 
         set_forced_send_error(anyhow::anyhow!("Too Many Requests: retry after 5"));

--- a/src/channel/telegram/topic_registry.rs
+++ b/src/channel/telegram/topic_registry.rs
@@ -12,11 +12,11 @@ use super::state::telegram_runtime;
 /// resolution.
 pub(crate) const FLEET_BINDING_SENTINEL: &str = "__fleet__";
 
-pub(super) fn topic_registry_path(home: &Path) -> PathBuf {
+pub(crate) fn topic_registry_path(home: &Path) -> PathBuf {
     home.join("topics.json")
 }
 
-pub(super) fn load_topic_registry(home: &Path) -> HashMap<i32, String> {
+pub(crate) fn load_topic_registry(home: &Path) -> HashMap<i32, String> {
     let path = topic_registry_path(home);
     std::fs::read_to_string(&path)
         .ok()
@@ -29,36 +29,30 @@ pub(super) fn load_topic_registry(home: &Path) -> HashMap<i32, String> {
         .unwrap_or_default()
 }
 
-pub(super) fn save_topic_registry(home: &Path, registry: &HashMap<i32, String>) {
+pub(crate) fn save_topic_registry(
+    home: &Path,
+    registry: &HashMap<i32, String>,
+) -> anyhow::Result<()> {
     let map: HashMap<String, &String> = registry.iter().map(|(k, v)| (k.to_string(), v)).collect();
-    if let Ok(json) = serde_json::to_string_pretty(&map) {
-        // H2: atomic write to prevent partial-file on crash
-        let _ = crate::store::atomic_write(&topic_registry_path(home), json.as_bytes());
-    }
+    let json = serde_json::to_string_pretty(&map)?;
+    crate::store::atomic_write(&topic_registry_path(home), json.as_bytes())?;
+    Ok(())
 }
 
-pub(super) fn register_topic(home: &Path, topic_id: i32, instance_name: &str) {
-    // Write-side unification (Fix B): all three sources updated atomically.
-    // 1. topics.json (disk registry)
+pub(crate) fn register_topic(
+    home: &Path,
+    topic_id: i32,
+    instance_name: &str,
+) -> anyhow::Result<()> {
     let mut reg = load_topic_registry(home);
     reg.insert(topic_id, instance_name.to_string());
-    save_topic_registry(home, &reg);
-    // 2. fleet.yaml topic_id field
-    let _ = crate::fleet::update_instance_field(
-        home,
-        instance_name,
-        "topic_id",
-        serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(topic_id)),
-    );
-    // 3. in-memory state is updated by the caller (Channel trait methods
-    //    that hold &self.state). Free-function callers without state access
-    //    rely on resolve_topic's topics.json fallback as defense-in-depth.
+    save_topic_registry(home, &reg)
 }
 
-pub(super) fn unregister_topic(home: &Path, topic_id: i32) {
+pub(crate) fn unregister_topic(home: &Path, topic_id: i32) {
     let mut reg = load_topic_registry(home);
     reg.remove(&topic_id);
-    save_topic_registry(home, &reg);
+    let _ = save_topic_registry(home, &reg);
 }
 
 /// Reverse-lookup a topic_id for an instance from `topics.json`.
@@ -92,7 +86,10 @@ pub fn create_topic_for_instance(home: &std::path::Path, instance_name: &str) ->
     }) {
         Ok(tid) => {
             tracing::info!(instance = %instance_name, topic_id = tid, "created topic");
-            register_topic(home, tid, instance_name);
+            if let Err(e) = register_topic(home, tid, instance_name) {
+                tracing::warn!(instance = %instance_name, topic_id = tid, error = %e, "failed to register topic");
+                return None;
+            }
             Some(tid)
         }
         Err(e) => {
@@ -279,19 +276,10 @@ mod tests {
     }
 
     #[test]
-    fn resolve_topic_reloads_from_fleet_yaml() {
+    fn resolve_topic_reloads_from_topics_json() {
         let home = tmp_home("resolve_reload");
-        let yaml = r#"defaults:
-  backend: claude
-instances:
-  alice:
-    role: "Test"
-    topic_id: 229
-  general:
-    role: "General"
-    topic_id: 1
-"#;
-        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
+        register_topic(&home, 229, "alice").unwrap();
+        register_topic(&home, 1, "general").unwrap();
         let mut state = TelegramState::new(
             "tok",
             -1,
@@ -312,11 +300,7 @@ instances:
     #[test]
     fn resolve_topic_reload_caches_for_next_call() {
         let home = tmp_home("resolve_cache");
-        let yaml = r#"instances:
-  bob:
-    topic_id: 500
-"#;
-        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
+        register_topic(&home, 500, "bob").unwrap();
         let mut state = TelegramState::new(
             "tok",
             -1,
@@ -326,7 +310,7 @@ instances:
             None,
         );
         assert_eq!(resolve_topic(&mut state, Some(500)), "bob");
-        std::fs::remove_file(crate::fleet::fleet_yaml_path(&home)).ok();
+        std::fs::remove_file(topic_registry_path(&home)).ok();
         assert_eq!(resolve_topic(&mut state, Some(500)), "bob");
         std::fs::remove_dir_all(&home).ok();
     }
@@ -336,7 +320,7 @@ instances:
         let home = tmp_home("resolve_topics_json");
         let mut reg = HashMap::new();
         reg.insert(2474, "test-gemini".to_string());
-        save_topic_registry(&home, &reg);
+        save_topic_registry(&home, &reg).unwrap();
         let mut state = TelegramState::new_for_contract_test(
             -1,
             HashMap::new(),
@@ -354,16 +338,16 @@ instances:
     }
 
     #[test]
-    fn register_topic_writes_fleet_yaml() {
-        let home = tmp_home("register_writes_yaml");
+    fn register_topic_writes_only_topics_json() {
+        let home = tmp_home("register_writes_json");
         let yaml = "defaults:\n  backend: claude\ninstances:\n  alice:\n    backend: claude\n";
         std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).ok();
-        register_topic(&home, 42, "alice");
+        register_topic(&home, 42, "alice").unwrap();
         let content = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home))
             .expect("fleet.yaml must exist");
         assert!(
-            content.contains("topic_id"),
-            "fleet.yaml must contain topic_id after register_topic: {content}"
+            !content.contains("topic_id"),
+            "fleet.yaml must NOT contain topic_id after register_topic: {content}"
         );
         let reg = load_topic_registry(&home);
         assert_eq!(reg.get(&42), Some(&"alice".to_string()));
@@ -374,8 +358,8 @@ instances:
     fn topic_registry_roundtrip() {
         let home = tmp_home("registry_roundtrip");
         assert!(load_topic_registry(&home).is_empty());
-        register_topic(&home, 100, "alice");
-        register_topic(&home, 200, "bob");
+        register_topic(&home, 100, "alice").unwrap();
+        register_topic(&home, 200, "bob").unwrap();
         let reg = load_topic_registry(&home);
         assert_eq!(reg.get(&100), Some(&"alice".to_string()));
         assert_eq!(reg.get(&200), Some(&"bob".to_string()));
@@ -389,8 +373,8 @@ instances:
     #[test]
     fn topic_registry_overwrite() {
         let home = tmp_home("registry_overwrite");
-        register_topic(&home, 100, "alice");
-        register_topic(&home, 100, "bob");
+        register_topic(&home, 100, "alice").unwrap();
+        register_topic(&home, 100, "bob").unwrap();
         let reg = load_topic_registry(&home);
         assert_eq!(reg.get(&100), Some(&"bob".to_string()));
         assert_eq!(reg.len(), 1);
@@ -425,8 +409,8 @@ instances:
     #[test]
     fn lookup_topic_for_instance_finds_existing() {
         let home = tmp_home("lookup_existing");
-        register_topic(&home, 42, "alice");
-        register_topic(&home, 99, "bob");
+        register_topic(&home, 42, "alice").unwrap();
+        register_topic(&home, 99, "bob").unwrap();
         assert_eq!(lookup_topic_for_instance(&home, "alice"), Some(42));
         assert_eq!(lookup_topic_for_instance(&home, "bob"), Some(99));
         std::fs::remove_dir_all(&home).ok();
@@ -435,7 +419,7 @@ instances:
     #[test]
     fn lookup_topic_for_instance_returns_none_when_missing() {
         let home = tmp_home("lookup_missing");
-        register_topic(&home, 42, "alice");
+        register_topic(&home, 42, "alice").unwrap();
         assert_eq!(lookup_topic_for_instance(&home, "nonexistent"), None);
         std::fs::remove_dir_all(&home).ok();
     }
@@ -449,7 +433,7 @@ instances:
     #[test]
     fn create_topic_for_instance_reuses_existing_topic() {
         let home = tmp_home("create_reuse");
-        register_topic(&home, 77, "reuse-agent");
+        register_topic(&home, 77, "reuse-agent").unwrap();
         let result = create_topic_for_instance(&home, "reuse-agent");
         assert_eq!(
             result,

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -45,6 +45,8 @@ pub struct FleetConfig {
     /// from Sprint 54 P2-6. Storage timestamps stay UTC unconditionally.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_timezone: Option<String>,
+    #[serde(skip)]
+    pub(crate) home: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -264,6 +266,7 @@ impl FleetConfig {
         let mut config: FleetConfig = serde_yaml_ng::from_str(&content)
             .with_context(|| format!("Failed to parse fleet config: {}", path.display()))?;
         config.normalize();
+        config.home = path.parent().map(|p| p.to_path_buf());
         // Sprint 46 P1: backfill instance IDs + reserved-name warnings
         config.backfill_ids(path);
         Ok(config)
@@ -459,7 +462,11 @@ impl FleetConfig {
             role: inst.role.clone(),
             cols,
             rows,
-            topic_id: inst.topic_id,
+            topic_id: self
+                .home
+                .as_ref()
+                .and_then(|h| crate::channel::telegram::lookup_topic_for_instance(h, name))
+                .or(inst.topic_id),
             git_branch: inst.git_branch.clone(),
             model,
             worktree: inst.worktree,
@@ -1110,6 +1117,7 @@ pub fn update_channel_telegram_group_id(home: &Path, new_group_id: i64) -> Resul
 /// Post-fix `Result<bool>` lets callers detect partial-success. Internal
 /// `tracing::warn!` fires on every no-op path so even callers using
 /// `let _ = update_instance_field(...)` get an audit trail.
+#[allow(dead_code)]
 pub fn update_instance_field(
     home: &Path,
     name: &str,

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -207,17 +207,19 @@ pub(super) fn handle_describe_instance(home: &Path, args: &Value) -> Value {
                 Some(agent) => {
                     let mut info = agent.clone();
                     merge_metadata(home, name, &mut info);
-                    // Surface topic_id + topic_binding_mode from fleet.yaml.
+                    // Surface topic_id from topics.json + topic_binding_mode from fleet.yaml.
+                    if info.get("topic_id").is_none() {
+                        if let Some(tid) =
+                            crate::channel::telegram::lookup_topic_for_instance(home, name)
+                        {
+                            info["topic_id"] = json!(tid);
+                        }
+                    }
                     if let Some(inst) =
                         crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                             .ok()
                             .and_then(|c| c.instances.get(name).cloned())
                     {
-                        if info.get("topic_id").is_none() {
-                            if let Some(tid) = inst.topic_id {
-                                info["topic_id"] = json!(tid);
-                            }
-                        }
                         if let Some(ref mode) = inst.topic_binding_mode {
                             info["topic_binding_mode"] = json!(mode);
                         }

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -61,7 +61,6 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
                 .map(|r| (r.topic_id, r.working_directory))
         })
         .unwrap_or((None, None));
-    let topic_id = topic_id.or_else(|| telegram::lookup_topic_for_instance(home, name));
 
     // Sprint 54 P1-B Bug 1: collect per-step errors instead of silently
     // swallowing them. Each cleanup step runs best-effort so even when


### PR DESCRIPTION
## Summary

- Migrate all 10 topic_id read sites (R1-R10) from `fleet.yaml` to `topics.json` via `lookup_topic_for_instance()`
- Remove all 7 fleet.yaml topic_id write sites (W1-W7) — `register_topic` / `save_topic_registry` now return `Result<()>` and write only to `topics.json`
- Add `FleetConfig.home: Option<PathBuf>` (`#[serde(skip)]`) so `resolve_instance` can look up `topics.json` without changing 30+ callers
- Update `doctor_topics::classify()` to read `fleet_topic_ids` from `topics.json` — `DriftFleet` / `StaleRegistry` classes now unreachable (same-source comparison)
- Remove redundant `instance_lifecycle.rs:64` fallback
- 13 files changed, -147 LOC net, all 2689 tests pass

## Files changed

| File | Sites |
|------|-------|
| `src/channel/telegram/topic_registry.rs` | W1 (register_topic), sig changes |
| `src/channel/telegram/inbound.rs` | R1 |
| `src/channel/telegram/reply.rs` | R3, R4 |
| `src/channel/telegram/notify.rs` | R6 |
| `src/channel/telegram/bootstrap.rs` | R5, R7, R8, W5 |
| `src/channel/telegram/error.rs` | W4 |
| `src/fleet.rs` | R10 (resolve_instance), home field |
| `src/mcp/handlers/instance.rs` | R2, W6 |
| `src/mcp/handlers/instance_lifecycle.rs` | redundant fallback removal |
| `src/app/tui_spawn.rs` | W3 |
| `src/api/handlers/instance.rs` | legacy topic_id write removal |
| `src/bootstrap/fleet_normalize.rs` | W7 |
| `src/bootstrap/doctor_topics.rs` | R9, W2 (classify + PreferRegistry) |

## Test plan

- [x] All 2689 existing tests pass (0 failures, 7 ignored)
- [x] 14 existing tests updated for new topics.json-canonical behavior
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Pre-push integration tests pass

Release-note: topic_id storage consolidated to topics.json; fleet.yaml topic_id field is now read-only fallback (Phase 2 will remove it)

Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)