### PR TITLE
fix(#1064): close TUI residual-text via full-area pre-fill in VTerm render

### DIFF
--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -1311,4 +1311,163 @@ mod tests {
             "dump_screen() leaked SPACER as literal space, got: {ansi_str:?}"
         );
     }
+
+    // ── #1064 area-clamp residual-text class ──
+    //
+    // `render_to_buffer_inner` clamps writes to `rows × cols = min(self.rows,
+    // area.height, grid_rows)` (same for cols). When `area > grid` — e.g.
+    // resize race, initial spawn lag, outer terminal resize mid-frame — the
+    // trailing rows/cols of `area` are never written. Combined with the
+    // ratatui Buffer's cross-frame statefulness (codebase invariant from
+    // #819), unwritten cells retain previous-frame content → operator-
+    // observable residual text.
+    //
+    // These tests pre-poison cells outside the clamped region with sentinel
+    // chars, render, and assert the cells are blanked. The fix is a
+    // full-area pre-fill before the existing clamped-write loop.
+
+    /// T1 (#1064): area taller than grid blanks the trailing rows.
+    #[test]
+    fn area_taller_than_grid_clears_trailing_rows() {
+        let mut vt = VTerm::new(10, 3);
+        vt.process(b"hello");
+        let area = ratatui::layout::Rect::new(0, 0, 10, 5);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        for x in 0..10 {
+            buf[(x, 3)].set_char('A');
+            buf[(x, 4)].set_char('B');
+        }
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        let row3: String = (0..10).map(|x| buf[(x, 3)].symbol()).collect();
+        let row4: String = (0..10).map(|x| buf[(x, 4)].symbol()).collect();
+        assert_eq!(row3, "          ", "row 3 (beyond grid) must be blanked");
+        assert_eq!(row4, "          ", "row 4 (beyond grid) must be blanked");
+    }
+
+    /// T2 (#1064): area wider than grid blanks the trailing cols.
+    #[test]
+    fn area_wider_than_grid_clears_trailing_cols() {
+        let mut vt = VTerm::new(5, 2);
+        vt.process(b"abcde");
+        let area = ratatui::layout::Rect::new(0, 0, 10, 2);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        for x in 5..10 {
+            buf[(x, 0)].set_char('Z');
+        }
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        let tail: String = (5..10).map(|x| buf[(x, 0)].symbol()).collect();
+        assert_eq!(tail, "     ", "cols beyond grid must be blanked");
+    }
+
+    /// T3 (#1064): resize-shrink leaves no orphan in trailing region.
+    ///
+    /// Simulates the resize race: grid was 20×10, render produced full
+    /// content; grid shrinks to 10×5 but the pane area in the layout is
+    /// still 20×10 (one frame behind). Trailing strip must be blanked.
+    #[test]
+    fn resize_shrink_clears_orphan_cells() {
+        let mut vt = VTerm::new(20, 10);
+        vt.process(b"line content that fills the wider grid view");
+        let area = ratatui::layout::Rect::new(0, 0, 20, 10);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        // Capture pre-resize cell content (non-blank somewhere).
+        let pre_resize_filled =
+            (0..20).any(|x| (0..10).any(|y| buf[(x, y)].symbol() != " "));
+        assert!(pre_resize_filled, "sanity: first render must populate cells");
+
+        // Shrink grid; render into same area (simulates layout lag).
+        vt.resize(10, 5);
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        // Bottom-right strip cols 10..20 × rows 5..10 must now be blank.
+        for y in 5..10 {
+            for x in 0..20 {
+                assert_eq!(
+                    buf[(x, y)].symbol(),
+                    " ",
+                    "({x},{y}) beyond new grid must be blanked"
+                );
+            }
+        }
+        for y in 0..5 {
+            for x in 10..20 {
+                assert_eq!(
+                    buf[(x, y)].symbol(),
+                    " ",
+                    "({x},{y}) beyond new grid cols must be blanked"
+                );
+            }
+        }
+    }
+
+    /// T4 (#1064): area == grid renders normally — no regression.
+    #[test]
+    fn area_equals_grid_renders_normally() {
+        let mut vt = VTerm::new(10, 3);
+        vt.process(b"hello");
+        let area = ratatui::layout::Rect::new(0, 0, 10, 3);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        assert_eq!(buf[(0, 0)].symbol(), "h");
+        assert_eq!(buf[(1, 0)].symbol(), "e");
+        assert_eq!(buf[(4, 0)].symbol(), "o");
+    }
+
+    /// T5 (#1064): #819 WIDE_CHAR_SPACER invariant carries over.
+    ///
+    /// The pre-fill must not weaken the #819 fix. Pre-poison the spacer
+    /// cell at col 1; render `中` at col 0; spacer at col 1 must be blank
+    /// (per #819) AND the wide char at col 0 must be intact.
+    #[test]
+    fn wide_char_spacer_invariant_carries_with_prefill() {
+        let mut vt = VTerm::new(10, 1);
+        vt.process("中".as_bytes());
+        let area = ratatui::layout::Rect::new(0, 0, 10, 1);
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        buf[(1, 0)].set_char('X');
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        assert_eq!(buf[(0, 0)].symbol(), "中", "wide char preserved");
+        assert_eq!(buf[(1, 0)].symbol(), " ", "spacer blanked per #819");
+    }
+
+    /// T6 (#1064, optional dev-2 nit): non-zero area origin still works.
+    #[test]
+    fn area_with_non_zero_origin_clears_trailing_region() {
+        let mut vt = VTerm::new(5, 2);
+        vt.process(b"ab");
+        // Buffer covers (0,0,20,10); area is the sub-region (5,3,10,5).
+        let buf_area = ratatui::layout::Rect::new(0, 0, 20, 10);
+        let area = ratatui::layout::Rect::new(5, 3, 10, 5);
+        let mut buf = ratatui::buffer::Buffer::empty(buf_area);
+        // Pre-poison a cell inside `area` but outside the clamped grid region.
+        buf[(12, 3)].set_char('R'); // col 12 = area-col 7, beyond grid cols=5
+        buf[(8, 7)].set_char('S'); // row 7 = area-row 4, beyond grid rows=2
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        assert_eq!(buf[(12, 3)].symbol(), " ", "non-zero origin: col 12 blanked");
+        assert_eq!(buf[(8, 7)].symbol(), " ", "non-zero origin: row 7 blanked");
+        // Buffer cells OUTSIDE area must NOT be touched (sentinel at (0,0)).
+        buf[(0, 0)].set_char('K');
+        vt.render_to_buffer(&mut buf, area, 0, false);
+        assert_eq!(
+            buf[(0, 0)].symbol(),
+            "K",
+            "cells outside area must NOT be affected by pre-fill"
+        );
+    }
+
+    /// T7 (#1064, optional dev-2 nit): zero-size area is a safe no-op.
+    #[test]
+    fn zero_size_area_is_safe_noop() {
+        let mut vt = VTerm::new(10, 3);
+        vt.process(b"hello");
+        let area_zero_h = ratatui::layout::Rect::new(0, 0, 10, 0);
+        let area_zero_w = ratatui::layout::Rect::new(0, 0, 0, 3);
+        let buf_area = ratatui::layout::Rect::new(0, 0, 10, 3);
+        let mut buf = ratatui::buffer::Buffer::empty(buf_area);
+        buf[(0, 0)].set_char('K');
+        // Either should panic-free + not touch any cells.
+        vt.render_to_buffer(&mut buf, area_zero_h, 0, false);
+        vt.render_to_buffer(&mut buf, area_zero_w, 0, false);
+        assert_eq!(buf[(0, 0)].symbol(), "K", "zero-size area must not affect buffer");
+    }
 }

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -181,6 +181,33 @@ impl VTerm {
         scroll_offset: usize,
         show_block_cursor: bool,
     ) {
+        // #1064 area-clamp pre-fill: ratatui Buffer is stateful across
+        // frames (codebase invariant from #819). The clamped-write loop
+        // below only touches `rows × cols = min(self.rows, area.height,
+        // grid_rows)` cells, so trailing rows/cols of `area` (when
+        // `area > grid`, e.g. resize race or initial spawn lag) would
+        // retain previous-frame content → operator-visible residual text.
+        // Blank the full area first with a default cell; the loop then
+        // overwrites with PTY content for the clamped region.
+        let buf_right = buf.area().x.saturating_add(buf.area().width);
+        let buf_bottom = buf.area().y.saturating_add(buf.area().height);
+        let default_style = ratatui::style::Style::default();
+        for dy in 0..area.height {
+            let y = area.y.saturating_add(dy);
+            if y >= buf_bottom {
+                break;
+            }
+            for dx in 0..area.width {
+                let x = area.x.saturating_add(dx);
+                if x >= buf_right {
+                    break;
+                }
+                let cell = &mut buf[(x, y)];
+                cell.set_char(' ');
+                cell.set_style(default_style);
+            }
+        }
+
         let grid = self.term.grid();
         let grid_cols = grid.columns() as u16;
         let grid_rows = grid.screen_lines() as u16;
@@ -1372,9 +1399,11 @@ mod tests {
         let mut buf = ratatui::buffer::Buffer::empty(area);
         vt.render_to_buffer(&mut buf, area, 0, false);
         // Capture pre-resize cell content (non-blank somewhere).
-        let pre_resize_filled =
-            (0..20).any(|x| (0..10).any(|y| buf[(x, y)].symbol() != " "));
-        assert!(pre_resize_filled, "sanity: first render must populate cells");
+        let pre_resize_filled = (0..20).any(|x| (0..10).any(|y| buf[(x, y)].symbol() != " "));
+        assert!(
+            pre_resize_filled,
+            "sanity: first render must populate cells"
+        );
 
         // Shrink grid; render into same area (simulates layout lag).
         vt.resize(10, 5);
@@ -1443,7 +1472,11 @@ mod tests {
         buf[(12, 3)].set_char('R'); // col 12 = area-col 7, beyond grid cols=5
         buf[(8, 7)].set_char('S'); // row 7 = area-row 4, beyond grid rows=2
         vt.render_to_buffer(&mut buf, area, 0, false);
-        assert_eq!(buf[(12, 3)].symbol(), " ", "non-zero origin: col 12 blanked");
+        assert_eq!(
+            buf[(12, 3)].symbol(),
+            " ",
+            "non-zero origin: col 12 blanked"
+        );
         assert_eq!(buf[(8, 7)].symbol(), " ", "non-zero origin: row 7 blanked");
         // Buffer cells OUTSIDE area must NOT be touched (sentinel at (0,0)).
         buf[(0, 0)].set_char('K');
@@ -1468,6 +1501,10 @@ mod tests {
         // Either should panic-free + not touch any cells.
         vt.render_to_buffer(&mut buf, area_zero_h, 0, false);
         vt.render_to_buffer(&mut buf, area_zero_w, 0, false);
-        assert_eq!(buf[(0, 0)].symbol(), "K", "zero-size area must not affect buffer");
+        assert_eq!(
+            buf[(0, 0)].symbol(),
+            "K",
+            "zero-size area must not affect buffer"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Pre-fill the full target `area` with a default-styled space at the top of `VTerm::render_to_buffer_inner` before the existing clamped-write loop runs. Closes the residual-text class operator reported in #1064 — when `area > grid` (resize race, initial spawn lag, outer terminal resize), the trailing strip beyond the clamped `rows × cols` region was never written, and ratatui's cross-frame stateful Buffer (per #819 invariant) retained previous-frame content.

## Lineage

- **#819** — first surfaced the "ratatui Buffer is stateful across frames" invariant; fixed Site 1 (`WIDE_CHAR_SPACER` at x+1 was never written → previous-frame residual).
- **#1064 dialectic** (primary `dev`, cross-audits `dev-2` + `reviewer`) — 3-way VERIFIED. Primary memo `/tmp/dialectic-1064-primary-dev.md` empirically confirmed the area-clamp class via 2 RED unit tests on the spike branch.
- **dev-2** noted initial-spawn is a multi-frame artifact (default 120 × 40 vs allocated pane area) — covered by the same pre-fill.
- **reviewer** confirmed no adjacent class was missed.
- **This PR (Phase 1)** — seals the area-clamp class with a full-area pre-fill + 7 tests.

## What changed

- `src/vterm.rs::render_to_buffer_inner`: full-area pre-fill loop at the top, with buffer-bounds guards matching the existing clamped-loop pattern.
- 7 new tests in `vterm::tests` (RED commit `da938ff`, GREEN commit `2370e19`):
  - T1 `area_taller_than_grid_clears_trailing_rows` — flipped FAIL → PASS
  - T2 `area_wider_than_grid_clears_trailing_cols` — flipped FAIL → PASS
  - T3 `resize_shrink_clears_orphan_cells` — flipped FAIL → PASS
  - T4 `area_equals_grid_renders_normally` — sanity (no regression)
  - T5 `wide_char_spacer_invariant_carries_with_prefill` — #819 carry-over
  - T6 `area_with_non_zero_origin_clears_trailing_region` — flipped FAIL → PASS; non-zero origin handled; cells outside `area` correctly untouched
  - T7 `zero_size_area_is_safe_noop` — degenerate bounds OK

## Cost

`~area.width × area.height` extra cell writes per pane per frame (typical 120 × 40 ≈ 4800 writes/pane). `set_char` / `set_style` are cheap value setters with no heap allocations — negligible at 30 FPS for ~4 panes.

## Test plan

- [x] T1-T7 (4 newly-passing + 3 sanity) — all green
- [x] 48 vterm tests pass (`./target/debug/deps/... vterm::`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `cargo test --test file_size_invariant` clean (vterm.rs 1351 LOC, under 750-cap is N/A for vterm.rs which is on the existing exception list)
- [ ] Operator empirical confirm after merge — does the residual-text symptom go away?

Closes #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)