### PR TITLE
refactor(#994): Phase 2 — test fixture + comment cleanup for topics.json SOT

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -689,7 +689,8 @@ mod tests {
     #[test]
     #[allow(clippy::unwrap_used)]
     fn topic_id_persists_to_fleet_yaml_via_update_instance_field() {
-        // Regression test for #415: topic_id must round-trip through fleet.yaml.
+        // Helper-level test for update_instance_field (#415). Post-#994
+        // production uses topics.json, but this function still works.
         let home = std::env::temp_dir().join(format!("agend-topic-persist-{}", std::process::id()));
         std::fs::create_dir_all(&home).ok();
         std::fs::write(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -843,7 +843,7 @@ fn pane_from_menu_item(
             // `add_instance_to_yaml` directly, bypassing the topic-creation
             // side effect that `handle_spawn` does. Now routes through
             // `tui_spawn::add_instance_with_topic` so the channel topic is
-            // created + topic_id persisted to fleet.yaml at TUI-spawn time.
+            // created + topic_id persisted to topics.json at TUI-spawn time.
             if let Err(e) = tui_spawn::add_instance_with_topic(
                 home,
                 &inst_name,

--- a/src/app/tui_spawn.rs
+++ b/src/app/tui_spawn.rs
@@ -12,8 +12,8 @@
 //!      `Option<Arc<dyn Channel>>` — post-#945 Phase 1 the channel
 //!      registers ~6s after app startup; cached snapshots are commonly
 //!      `None` and silently no-op forever)
-//!   3. Persist topic_id back to fleet.yaml via `update_instance_field`
-//!      when a topic was created — closes the #964-class caller-path
+//!   3. Persist topic_id to topics.json via `register_topic` when a
+//!      topic was created — closes the #964-class caller-path
 //!      replication for the TUI surface
 //!
 //! Returns `TopicOutcome` so callers handle Created / NoChannel /
@@ -185,7 +185,7 @@ mod tests {
     }
 
     /// T1 — happy path: mock channel registered, helper invoked,
-    /// fleet.yaml ends with topic_id persisted + helper returns
+    /// topics.json ends with topic_id persisted + helper returns
     /// `Created(topic_id)`.
     #[test]
     #[serial]
@@ -247,9 +247,9 @@ mod tests {
     /// post-state matches what ctrl+b c → Backend menu should produce.
     ///
     /// Pre-fix (Backend menu calling `add_instance_to_yaml` directly +
-    /// no topic creation): fleet.yaml had the entry but `topic_id: null`.
-    /// Post-fix (Backend menu calling this helper): fleet.yaml has the
-    /// entry AND topic_id is Some(_).
+    /// no topic creation): no topic_id persisted anywhere.
+    /// Post-fix (Backend menu calling this helper): topics.json has the
+    /// topic_id mapping.
     ///
     /// THIS is the caller-path regression anchor for the #966 bug
     /// (matches #964 T1 pattern — the test PR #966 should ship to

--- a/src/bootstrap/doctor_topics.rs
+++ b/src/bootstrap/doctor_topics.rs
@@ -3,9 +3,14 @@
 //!
 //! Backs the `agend-terminal doctor topics [--cleanup] [--format
 //! human|json]` CLI subcommand. Reads `topics.json` (registry) +
-//! `fleet.yaml` (instance topic_id) + classifies every observable
+//! `fleet.yaml` (instance list) and classifies every observable
 //! (topic_id, instance_name) pair into one of 4 mutually-exclusive
 //! classes via precedence-ordered first-match-wins assignment.
+//!
+//! Post-#994 Phase 1: topics.json is the single source of truth for
+//! topic_id. The `fleet_topic_ids` comparison also reads topics.json,
+//! making DriftFleet and StaleRegistry unreachable from `classify()`.
+//! These classes remain in the enum for manual report construction.
 //!
 //! ## Why 4 classes (not 5)
 //!
@@ -28,17 +33,12 @@
 //! ## Classification algorithm (4 classes, precedence-ordered)
 //!
 //! For each `(topic_id, instance_name)` candidate observed across
-//! 2 sources (`topics.json` / `fleet.yaml.<inst>.topic_id`), apply
-//! rules in order; assign first-match:
+//! topics.json + fleet.yaml instance list, apply rules in order;
+//! assign first-match:
 //!
-//! 1. `live` — present in topics.json AND fleet.yaml.topic_id
-//!    matches. Both sources agree.
-//! 2. `drift_fleet` — present in topics.json AND fleet.yaml.topic_id
-//!    exists BUT differs. Drift between sources.
-//! 3. `stale_registry` — present in topics.json AND
-//!    fleet.yaml.topic_id matches OR is absent. Treat as
-//!    registry-resident; chat-side unverifiable. Operator's
-//!    manual verification via Telegram UI is the recovery path.
+//! 1. `live` — present in topics.json AND instance in fleet.yaml.
+//! 2. `drift_fleet` — (unreachable post-#994: same-source comparison)
+//! 3. `stale_registry` — (unreachable post-#994: same-source comparison)
 //! 4. `orphan` — present in topics.json mapping to instance name
 //!    NOT in fleet.yaml. Instance retired without registry cleanup.
 
@@ -49,9 +49,9 @@ use std::path::Path;
 /// 4-class taxonomy (per F2 reduced from RCA's original 5).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TopicClass {
-    /// topics.json AND fleet.yaml.topic_id agree.
+    /// topics.json entry matches (post-#994: always the case).
     Live,
-    /// topics.json AND fleet.yaml.topic_id exist but differ.
+    /// topics.json entries differ (unreachable post-#994).
     DriftFleet,
     /// topics.json says it should exist; chat-side unverifiable.
     StaleRegistry,
@@ -76,9 +76,8 @@ pub struct ClassifiedTopic {
     pub topic_id: i32,
     pub instance_name: String,
     pub class: TopicClass,
-    /// `Some(fleet_id)` when fleet.yaml has a topic_id for the
-    /// instance (regardless of whether it matches). `None` when
-    /// fleet.yaml has no entry OR no topic_id field.
+    /// `Some(fleet_id)` from topics.json lookup for the instance.
+    /// `None` when not in topics.json.
     pub fleet_topic_id: Option<i32>,
 }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -117,8 +117,8 @@ pub struct AttachedFleet {
 
 /// Knobs for [`prepare`]. See field docs for semantics.
 pub struct PrepareOptions {
-    /// If true, fleet.yaml may be rewritten (general auto-create, topic_id
-    /// backfill). Set false for read-only contexts like verifier/CI.
+    /// If true, fleet.yaml may be rewritten (general auto-create) and
+    /// topics.json updated. Set false for read-only contexts like verifier/CI.
     pub mutate_fleet_yaml: bool,
     /// If true, initialize Telegram polling when `channel:` is configured.
     /// Set false for tests that don't need real bot traffic.

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -76,7 +76,7 @@ pub(super) fn resolve_topic(state: &mut TelegramState, topic_id: Option<i32>) ->
         // Fix C: warn before fallback so operator sees misroute.
         tracing::warn!(
             thread_id = tid,
-            "resolve_topic: topic_id not found in memory, fleet.yaml, or topics.json — falling back to \"general\""
+            "resolve_topic: topic_id not found in memory or topics.json — falling back to \"general\""
         );
     }
     "general".to_string()

--- a/src/mcp/handlers/instance_964_tests.rs
+++ b/src/mcp/handlers/instance_964_tests.rs
@@ -4,11 +4,10 @@
 //!
 //! T1 + T2 inject a mock `spawn_fn` into `spawn_single_instance_impl`
 //! that mimics `handle_spawn`'s side effects (`register_topic` writes
-//! `topic_id` back via `update_instance_field`) WITHOUT standing up a
-//! real daemon. This isolates the ordering invariant: the fleet.yaml
-//! entry MUST exist when SPAWN runs, otherwise the mock's
-//! `update_instance_field` call hits #962 Path 2 (silent no-op) and
-//! the assertion fails — which is exactly what HEAD-pre-fix did.
+//! `topic_id` to `topics.json`) WITHOUT standing up a real daemon.
+//! This isolates the ordering invariant: the fleet.yaml entry MUST
+//! exist when SPAWN runs, otherwise the mock's `register_topic` call
+//! fails and the assertion fails.
 //!
 //! Class lesson (per dev-2 cross-audit): the existing test
 //! `topic_id_persists_to_fleet_yaml_via_update_instance_field`
@@ -38,19 +37,18 @@ fn tmp_home(slug: &str) -> std::path::PathBuf {
 }
 
 /// T1 (load-bearing): MCP create_instance must persist `topic_id` to
-/// fleet.yaml on the happy path. The mock `spawn_fn` mimics
+/// topics.json on the happy path. The mock `spawn_fn` mimics
 /// `handle_spawn`'s `register_topic` chain: it calls
-/// `update_instance_field("topic_id", ...)` then returns the topic_id
+/// `register_topic(home, topic_id, name)` then returns the topic_id
 /// in the SPAWN response. After the swap fix, the fleet.yaml entry
-/// exists by the time the mock fires, so the helper write succeeds and
-/// the post-state has `topic_id = Some(5198)`.
+/// exists by the time the mock fires, so the register succeeds.
 ///
 /// Pre-#964 (SPAWN-then-add ordering): mock would fire BEFORE the
-/// caller added the entry → helper hits #962 Path 2 silent no-op →
-/// `topic_id` stays `None` → assertion fails. This test is the
-/// regression anchor.
+/// caller added the entry. Post-#994 Phase 1, topic_id is persisted
+/// to topics.json (not fleet.yaml), so the ordering constraint is
+/// relaxed — but the test anchors the caller-path contract.
 #[test]
-fn t1_create_instance_persists_topic_id_to_fleet_yaml() {
+fn t1_create_instance_persists_topic_id() {
     let home = tmp_home("t1");
     let target_topic_id = 5198_i32;
 
@@ -58,16 +56,7 @@ fn t1_create_instance_persists_topic_id_to_fleet_yaml() {
         let name = req["params"]["name"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("missing name"))?;
-        // Mimic handle_spawn → register_topic → update_instance_field.
-        // With the swap fix, fleet.yaml entry exists here, so the
-        // helper persists topic_id. Pre-fix, the entry didn't exist,
-        // so the helper silently no-op'd.
-        crate::fleet::update_instance_field(
-            h,
-            name,
-            "topic_id",
-            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(target_topic_id)),
-        )?;
+        crate::channel::telegram::register_topic(h, target_topic_id, name)?;
         Ok(json!({
             "ok": true,
             "result": {"topic_id": target_topic_id}
@@ -87,16 +76,12 @@ fn t1_create_instance_persists_topic_id_to_fleet_yaml() {
         "MCP response must carry topic_id; got {result}"
     );
 
-    let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
-        .expect("reload fleet.yaml");
-    let persisted = cfg.instances.get("t1-instance").and_then(|i| i.topic_id);
+    let persisted = crate::channel::telegram::lookup_topic_for_instance(&home, "t1-instance");
     assert_eq!(
         persisted,
         Some(target_topic_id),
-        "#964 regression: topic_id must be persisted to fleet.yaml \
-         after MCP create_instance returns. Got {persisted:?} for \
-         entry={:?}",
-        cfg.instances.get("t1-instance")
+        "#964 regression: topic_id must be persisted to topics.json \
+         after MCP create_instance returns. Got {persisted:?}"
     );
 
     let _ = std::fs::remove_dir_all(&home);

--- a/src/mcp/handlers/instance_spawn.rs
+++ b/src/mcp/handlers/instance_spawn.rs
@@ -136,9 +136,9 @@ pub(super) fn spawn_single_instance_impl(
     );
     let target_pane = target_pane_owned.as_deref();
 
-    // #964: ADD fleet.yaml entry BEFORE the SPAWN RPC so the SPAWN-time
-    // `register_topic` → `update_instance_field("topic_id")` chain finds the
-    // entry. Pre-fix SPAWN-then-add ordering hit #962 Path 2 silent no-op.
+    // #964: ADD fleet.yaml entry BEFORE the SPAWN RPC so the instance
+    // exists when SPAWN runs. Pre-fix SPAWN-then-add ordering caused
+    // silent failures.
     let entry = crate::fleet::InstanceYamlEntry {
         backend: backend_str
             .or_else(|| {

--- a/tests/test-fleet-telegram.yaml
+++ b/tests/test-fleet-telegram.yaml
@@ -16,9 +16,7 @@ instances:
   general:
     role: "Fleet coordinator"
     working_directory: ~/Documents/Hack/agend
-    topic_id: 1
 
   blog-writer:
     role: "Blog content writer"
     working_directory: ~/Documents/Hack/blog
-    topic_id: 42


### PR DESCRIPTION
## Summary

- Migrate #964 T1 test mock from `update_instance_field("topic_id", ...)` to `register_topic()`, assertion from fleet.yaml to topics.json
- Update stale comments across 8 files referencing old fleet.yaml topic_id persistence path
- Remove `topic_id` fields from `tests/test-fleet-telegram.yaml` example fixture
- Update `doctor_topics.rs` module docs to reflect post-Phase 1 state (DriftFleet/StaleRegistry unreachable)
- instance_lifecycle.rs:61 already clean (Phase 1 handled it)

9 files, -17 LOC net. Phase 1 lineage: #1062

## Test plan

- [x] All 2703 tests pass (0 failures)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] No behavioral changes — comments + test assertions only

Closes #994 (Phase 2 of 3; Phase 3: DriftFleet code path removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)