### PR TITLE
fix(#1080): install skills on all spawn paths, not just cold boot

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -570,6 +570,24 @@ fn spawn_one(
     env: Option<&std::collections::HashMap<String, String>>,
 ) -> anyhow::Result<crate::backend::SpawnMode> {
     std::fs::create_dir_all(work_dir).ok();
+    // #1080: skills auto-install for dynamically spawned instances.
+    // spawn_one is the SPAWN-RPC choke point — without this, instances
+    // created via create_instance / start_instance / replace_instance
+    // never get skill symlinks (only cold-boot spawn_and_register_agent
+    // called install_for_agent). Best-effort: install-all default (no
+    // fleet.yaml skills filter — cold-boot handles that on next restart).
+    match crate::skills::install_for_agent(home, work_dir, None) {
+        Ok(outcomes) => {
+            let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
+                .iter()
+                .map(|o| (o.backend.as_str(), o.mode))
+                .collect();
+            tracing::info!(agent = %name, ?modes, "spawn_one skills auto-install complete");
+        }
+        Err(e) => {
+            tracing::warn!(agent = %name, error = %e, "spawn_one skills auto-install failed, proceeding");
+        }
+    }
     // Sprint 34: clear stale metadata from a previous instance with the
     // same name. spawn_one is the true choke point — both handle_spawn
     // (direct) and team.rs (team-spawn) flow through here.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -574,9 +574,13 @@ fn spawn_one(
     // spawn_one is the SPAWN-RPC choke point — without this, instances
     // created via create_instance / start_instance / replace_instance
     // never get skill symlinks (only cold-boot spawn_and_register_agent
-    // called install_for_agent). Best-effort: install-all default (no
-    // fleet.yaml skills filter — cold-boot handles that on next restart).
-    match crate::skills::install_for_agent(home, work_dir, None) {
+    // called install_for_agent). Respects fleet.yaml `instance.<name>.skills:`
+    // allowlist, same as cold-boot path.
+    let skills_filter: Option<Vec<String>> =
+        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+            .ok()
+            .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
+    match crate::skills::install_for_agent(home, work_dir, skills_filter.as_deref()) {
         Ok(outcomes) => {
             let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
                 .iter()

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -873,7 +873,11 @@ fn run_core(
                             let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
                             // #1080: re-install skills on crash respawn (idempotent).
                             if let Some(ref wd) = config.working_dir {
-                                if let Err(e) = crate::skills::install_for_agent(&home, wd, None) {
+                                let skills_filter: Option<Vec<String>> =
+                                    crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+                                        .ok()
+                                        .and_then(|c| c.instances.get(&config.name).and_then(|i| i.skills.clone()));
+                                if let Err(e) = crate::skills::install_for_agent(&home, wd, skills_filter.as_deref()) {
                                     tracing::warn!(agent = %config.name, error = %e, "crash-respawn skills install failed");
                                 }
                             }
@@ -1575,7 +1579,11 @@ fn handle_stage2_restart(
 
     // #1080: re-install skills on stage2 restart (idempotent).
     if let Some(ref wd) = config.working_dir {
-        if let Err(e) = crate::skills::install_for_agent(home, wd, None) {
+        let skills_filter: Option<Vec<String>> =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+                .ok()
+                .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
+        if let Err(e) = crate::skills::install_for_agent(home, wd, skills_filter.as_deref()) {
             tracing::warn!(
                 target: "recovery_shadow",
                 agent = %name, error = %e, "stage2 skills install failed"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -871,6 +871,12 @@ fn run_core(
                                 return;
                             }
                             let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
+                            // #1080: re-install skills on crash respawn (idempotent).
+                            if let Some(ref wd) = config.working_dir {
+                                if let Err(e) = crate::skills::install_for_agent(&home, wd, None) {
+                                    tracing::warn!(agent = %config.name, error = %e, "crash-respawn skills install failed");
+                                }
+                            }
                             // Respawn fresh: stale --resume after a crash tends
                             // to loop on "conversation not found".
                             match agent::spawn_agent(
@@ -1565,6 +1571,16 @@ fn handle_stage2_restart(
             "shutdown during stage2 backoff, aborting"
         );
         return;
+    }
+
+    // #1080: re-install skills on stage2 restart (idempotent).
+    if let Some(ref wd) = config.working_dir {
+        if let Err(e) = crate::skills::install_for_agent(home, wd, None) {
+            tracing::warn!(
+                target: "recovery_shadow",
+                agent = %name, error = %e, "stage2 skills install failed"
+            );
+        }
     }
 
     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1243,4 +1243,40 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    #[test]
+    fn install_with_filter_only_installs_allowlisted_skills() {
+        let home = tmp_home("1080-filter");
+        let stage = home.join("stage");
+        seed_skill_source(&stage, "allowed-skill");
+        seed_skill_source(&stage, "blocked-skill");
+        add(&home, stage.join("allowed-skill").to_str().unwrap()).unwrap();
+        add(&home, stage.join("blocked-skill").to_str().unwrap()).unwrap();
+        let working = home.join("agent-wd");
+        std::fs::create_dir_all(&working).unwrap();
+
+        let filter = vec!["allowed-skill".to_string()];
+        let outcomes = install_for_agent(&home, &working, Some(&filter)).unwrap();
+        for outcome in &outcomes {
+            assert!(
+                matches!(outcome.mode, InstallMode::Symlink | InstallMode::Copy),
+                "backend {} must install: {:?}",
+                outcome.backend,
+                outcome
+            );
+            let skill_dir = outcome.target.join("allowed-skill");
+            assert!(
+                skill_dir.join("SKILL.md").exists(),
+                "allowed-skill must be visible at {:?}",
+                skill_dir
+            );
+            let blocked = outcome.target.join("blocked-skill");
+            assert!(
+                !blocked.exists(),
+                "blocked-skill must NOT be visible at {:?}",
+                blocked
+            );
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1196,4 +1196,51 @@ mod tests {
         assert_eq!(report, StageGcReport::default());
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ── #1080 regression: pre-existing backend config dirs must not
+    //    block skills symlink creation ────────────────────────────
+
+    #[test]
+    fn install_succeeds_when_backend_config_dir_preexists_without_skills() {
+        let home = tmp_home("1080-preexist");
+        let stage = home.join("stage");
+        seed_skill_source(&stage, "anchor");
+        add(&home, stage.join("anchor").to_str().unwrap()).unwrap();
+        let working = home.join("agent-wd");
+        std::fs::create_dir_all(&working).unwrap();
+
+        // Simulate a codex backend that created .codex/ with config
+        // but no skills/ subdir (the #1080 scenario).
+        let codex_dir = working.join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::write(codex_dir.join("config.toml"), "# codex config").unwrap();
+
+        // Simulate kiro backend with .kiro/settings/ but no skills/.
+        let kiro_dir = working.join(".kiro");
+        std::fs::create_dir_all(kiro_dir.join("settings")).unwrap();
+
+        let outcomes = install_for_agent(&home, &working, None).unwrap();
+        for outcome in &outcomes {
+            assert!(
+                matches!(outcome.mode, InstallMode::Symlink | InstallMode::Copy),
+                "#1080: backend {} must install even when parent config dir preexists: {:?}",
+                outcome.backend,
+                outcome
+            );
+        }
+        // Codex config file must be preserved alongside the new skills symlink.
+        assert!(
+            codex_dir.join("config.toml").exists(),
+            "codex config.toml must not be clobbered"
+        );
+        assert!(
+            working.join(".codex/skills").exists(),
+            ".codex/skills must exist"
+        );
+        assert!(
+            working.join(".kiro/skills").exists(),
+            ".kiro/skills must exist"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }


### PR DESCRIPTION
## Summary
- Root cause: `spawn_one` (SPAWN RPC choke point) never called `install_for_agent` — only cold-boot `spawn_and_register_agent` did. Instances created via `create_instance` / `start_instance` / `replace_instance` after daemon startup never got skill symlinks.
- Fix: add `install_for_agent` to 3 spawn paths: `spawn_one` (api/mod.rs), crash respawn (daemon/mod.rs), stage2 restart (daemon/mod.rs). All best-effort + idempotent.
- Regression test: verifies skills install succeeds when backend config dirs (`.codex/`, `.kiro/`) already exist without a `skills/` subdir.

## Test plan
- [x] `cargo fmt --check` — pass
- [x] `cargo clippy --all-targets -- -D warnings` — pass
- [x] `cargo test --tests` — all pass (including new #1080 regression test)
- [ ] CI green

Closes #1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)