### PR TITLE
fix(#1083): install skills in app-mode pane_factory spawn path

### DIFF
--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -98,6 +98,30 @@ pub(super) fn create_pane(
         crate::instructions::generate(&work_dir, command);
     }
 
+    // #1083: install skills for TUI-spawned panes (app mode).
+    // App mode sets resolve_agents=false so the daemon spawn loop is
+    // empty; pane_factory is the sole spawn path. Mirrors the
+    // install_for_agent call in spawn_and_register_agent (cold-boot)
+    // and spawn_one (SPAWN RPC). Best-effort: failures log + continue.
+    {
+        let skills_filter: Option<Vec<String>> =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+                .ok()
+                .and_then(|c| c.instances.get(&name).and_then(|i| i.skills.clone()));
+        match crate::skills::install_for_agent(home, &work_dir, skills_filter.as_deref()) {
+            Ok(outcomes) => {
+                let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
+                    .iter()
+                    .map(|o| (o.backend.as_str(), o.mode))
+                    .collect();
+                tracing::info!(agent = %name, ?modes, "pane skills auto-install complete");
+            }
+            Err(e) => {
+                tracing::warn!(agent = %name, error = %e, "pane skills auto-install failed");
+            }
+        }
+    }
+
     // Backend-specific flags (Claude's --append-system-prompt-file / --mcp-config /
     // --settings) are now injected centrally by agent::spawn_agent, so callers pass
     // raw args and spawn_agent enriches them from files under work_dir.


### PR DESCRIPTION
## Summary
- **Root cause**: App mode sets `resolve_agents=false`, so the daemon cold-boot spawn loop (`spawn_and_register_agent`) is empty. All agents spawn via `pane_factory::create_pane`, which had no `install_for_agent` call — leaving non-Claude instances without skill symlinks after rebuild+restart.
- **Fix**: Add `install_for_agent` with fleet.yaml skills-filter lookup to `create_pane`, mirroring `spawn_and_register_agent` (cold-boot) and `spawn_one` (SPAWN RPC).
- Single-file change: `src/app/pane_factory.rs` (+24 lines)

## Root Cause Analysis

There are 4 agent spawn paths:
1. **Cold-boot** (`spawn_and_register_agent`) — has `install_for_agent` ✅
2. **SPAWN RPC** (`spawn_one`) — has `install_for_agent` (#1080) ✅
3. **Crash respawn** — has `install_for_agent` (#1080) ✅
4. **App-mode pane creation** (`pane_factory::create_pane`) — **MISSING** ❌ ← this PR

App mode (`app/mod.rs:164`) sets `resolve_agents: false`, so `prepare()` returns an empty `agents` vec. The spawn loop in `run_core` iterates nothing. Instead, `session::restore_with_reconciliation` creates panes via `pane_factory`, which never called `install_for_agent`.

Existing Claude instances had skills from a prior daemon-mode boot (symlinks dated May 18). New instances (gemini-4315be, opencode-f068d5, kiro-research) created after that date never got skills.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] Full test suite passes (`cargo test`)
- [ ] Rebuild + restart → verify all instances have 5 skill symlinks
- [ ] Verify fleet.yaml skills allowlist filter works for app-mode spawns

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)