### PR TITLE
feat(#1084): fleet idle watchdog snooze via JSON sidecar + MCP tool

### DIFF
--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -297,6 +297,57 @@ fn scan_dev_vantage(
     last_alerted.insert(key, *now);
 }
 
+/// #1084: snooze sidecar path.
+fn snooze_path(home: &Path) -> PathBuf {
+    home.join("fleet-idle-snooze.json")
+}
+
+/// #1084: on-disk shape for the fleet-idle snooze sidecar.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub(crate) struct FleetIdleSnooze {
+    #[serde(default)]
+    pub snoozed_until: String,
+    #[serde(default)]
+    pub actor: String,
+}
+
+/// #1084: check whether fleet-idle watchdog is currently snoozed.
+pub(crate) fn is_fleet_idle_snoozed(home: &Path) -> bool {
+    let content = match std::fs::read_to_string(snooze_path(home)) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let snooze: FleetIdleSnooze = match serde_json::from_str(&content) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let until = match chrono::DateTime::parse_from_rfc3339(&snooze.snoozed_until) {
+        Ok(dt) => dt.with_timezone(&chrono::Utc),
+        Err(_) => return false,
+    };
+    chrono::Utc::now() < until
+}
+
+/// #1084: snooze fleet-idle watchdog until the given timestamp.
+pub(crate) fn snooze_fleet_idle(
+    home: &Path,
+    until: chrono::DateTime<chrono::Utc>,
+    actor: &str,
+) -> anyhow::Result<FleetIdleSnooze> {
+    let snooze = FleetIdleSnooze {
+        snoozed_until: until.to_rfc3339(),
+        actor: actor.to_string(),
+    };
+    let body = serde_json::to_string_pretty(&snooze)?;
+    crate::store::atomic_write(&snooze_path(home), body.as_bytes())?;
+    Ok(snooze)
+}
+
+/// #1084: resume fleet-idle watchdog (delete snooze sidecar).
+pub(crate) fn resume_fleet_idle(home: &Path) {
+    let _ = std::fs::remove_file(snooze_path(home));
+}
+
 /// Vantage #12 — fleet-wide idle threshold check. Triggers when
 /// EVERY tracked agent has been silent > FLEET threshold AND at
 /// least one agent is tracked (avoid false-positive on empty fleet).
@@ -305,6 +356,10 @@ fn scan_fleet_vantage(
     now: &chrono::DateTime<chrono::Utc>,
     last_alerted: &mut HashMap<(&'static str, String), chrono::DateTime<chrono::Utc>>,
 ) {
+    // #1084: skip entire fleet vantage when snoozed.
+    if is_fleet_idle_snoozed(home) {
+        return;
+    }
     let raw_pairs = enumerate_agent_activity(home);
     if raw_pairs.is_empty() {
         return;
@@ -803,6 +858,87 @@ mod tests {
             fleet_msg.text.contains("lead"),
             "live agent 'lead' must appear in alert"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #1084 snooze tests ──────────────────────────────────────────
+
+    #[test]
+    fn snooze_suppresses_fleet_idle_alert() {
+        let _g = env_lock();
+        std::env::remove_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT");
+        let home = tmp_home("snooze-suppress");
+        let stale = chrono::Utc::now() - chrono::Duration::seconds(FLEET_IDLE_THRESHOLD_SECS + 60);
+        write_activity_at(&home, "dev", stale);
+        write_activity_at(&home, "lead", stale);
+        // Snooze for 1 hour from now
+        let until = chrono::Utc::now() + chrono::Duration::hours(1);
+        snooze_fleet_idle(&home, until, "test").unwrap();
+        let mut last_alerted = HashMap::new();
+        scan_and_emit(&home, &mut last_alerted);
+        let general = crate::inbox::drain(&home, "general");
+        assert!(
+            !general
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
+            "#1084: snoozed fleet must NOT emit alert: {general:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn expired_snooze_resumes_fleet_alert() {
+        let _g = env_lock();
+        std::env::remove_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT");
+        let home = tmp_home("snooze-expired");
+        let stale = chrono::Utc::now() - chrono::Duration::seconds(FLEET_IDLE_THRESHOLD_SECS + 60);
+        write_activity_at(&home, "dev", stale);
+        write_activity_at(&home, "lead", stale);
+        // Snooze with PAST timestamp (already expired)
+        let past = chrono::Utc::now() - chrono::Duration::seconds(10);
+        snooze_fleet_idle(&home, past, "test").unwrap();
+        let mut last_alerted = HashMap::new();
+        scan_and_emit(&home, &mut last_alerted);
+        let general = crate::inbox::drain(&home, "general");
+        assert!(
+            general
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
+            "#1084: expired snooze must resume alerting: {general:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn snooze_does_not_suppress_dev_idle_alert() {
+        let _g = env_lock();
+        std::env::remove_var("AGEND_IDLE_WATCHDOG_AGENT");
+        std::env::remove_var("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT");
+        let home = tmp_home("snooze-dev-unaffected");
+        let stale = chrono::Utc::now() - chrono::Duration::seconds(DEV_IDLE_THRESHOLD_SECS + 60);
+        write_activity_at(&home, "dev", stale);
+        // Snooze fleet
+        let until = chrono::Utc::now() + chrono::Duration::hours(1);
+        snooze_fleet_idle(&home, until, "test").unwrap();
+        let mut last_alerted = HashMap::new();
+        scan_and_emit(&home, &mut last_alerted);
+        let lead = crate::inbox::drain(&home, "lead");
+        assert!(
+            lead.iter()
+                .any(|m| m.kind.as_deref() == Some("dev_idle_watchdog")),
+            "#1084: fleet snooze must NOT affect dev vantage: {lead:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn resume_clears_snooze() {
+        let home = tmp_home("snooze-resume");
+        let until = chrono::Utc::now() + chrono::Duration::hours(1);
+        snooze_fleet_idle(&home, until, "test").unwrap();
+        assert!(is_fleet_idle_snoozed(&home));
+        resume_fleet_idle(&home);
+        assert!(!is_fleet_idle_snoozed(&home));
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -369,6 +369,129 @@ static HEALTH_ACTIONS: &[(&str, HandlerFn)] = &[
     ("clear", dispatch_health_clear),
 ];
 
+// `watchdog` — actions: snooze / resume / status (#1084).
+
+fn dispatch_watchdog(ctx: &HandlerCtx<'_>) -> Value {
+    match ctx.args["action"].as_str().unwrap_or("") {
+        "snooze" => dispatch_watchdog_snooze(ctx),
+        "resume" => dispatch_watchdog_resume(ctx),
+        "status" => dispatch_watchdog_status(ctx),
+        other => json!({"error": format!("unknown watchdog action: {other}")}),
+    }
+}
+
+fn dispatch_watchdog_snooze(ctx: &HandlerCtx<'_>) -> Value {
+    use crate::daemon::idle_watchdog;
+
+    const MAX_SNOOZE_SECS: i64 = 4 * 3600; // 4h clamp
+
+    let duration_str = ctx.args["duration"].as_str().unwrap_or("1h");
+    let secs = match parse_duration_secs(duration_str) {
+        Some(s) => s.min(MAX_SNOOZE_SECS),
+        None => return json!({"error": format!("invalid duration: {duration_str}")}),
+    };
+    let until = chrono::Utc::now() + chrono::Duration::seconds(secs);
+    let actor = ctx.instance_name;
+    match idle_watchdog::snooze_fleet_idle(ctx.home, until, actor) {
+        Ok(snooze) => {
+            crate::event_log::log(
+                ctx.home,
+                "watchdog_snooze",
+                actor,
+                &format!(
+                    "fleet idle snoozed until {} ({duration_str})",
+                    snooze.snoozed_until
+                ),
+            );
+            json!({
+                "snoozed": true,
+                "snoozed_until": snooze.snoozed_until,
+                "duration_secs": secs,
+            })
+        }
+        Err(e) => json!({"error": format!("snooze failed: {e}")}),
+    }
+}
+
+fn dispatch_watchdog_resume(ctx: &HandlerCtx<'_>) -> Value {
+    use crate::daemon::idle_watchdog;
+    idle_watchdog::resume_fleet_idle(ctx.home);
+    crate::event_log::log(
+        ctx.home,
+        "watchdog_resume",
+        ctx.instance_name,
+        "fleet idle snooze cleared",
+    );
+    json!({"snoozed": false})
+}
+
+fn dispatch_watchdog_status(ctx: &HandlerCtx<'_>) -> Value {
+    use crate::daemon::idle_watchdog;
+    if idle_watchdog::is_fleet_idle_snoozed(ctx.home) {
+        let content =
+            std::fs::read_to_string(ctx.home.join("fleet-idle-snooze.json")).unwrap_or_default();
+        let snooze: idle_watchdog::FleetIdleSnooze =
+            serde_json::from_str(&content).unwrap_or_default();
+        let remaining = chrono::DateTime::parse_from_rfc3339(&snooze.snoozed_until)
+            .ok()
+            .map(|dt| {
+                let r = dt
+                    .with_timezone(&chrono::Utc)
+                    .signed_duration_since(chrono::Utc::now())
+                    .num_seconds();
+                r.max(0)
+            })
+            .unwrap_or(0);
+        json!({
+            "snoozed": true,
+            "snoozed_until": snooze.snoozed_until,
+            "remaining_secs": remaining,
+            "actor": snooze.actor,
+        })
+    } else {
+        json!({"snoozed": false})
+    }
+}
+
+/// Parse human-friendly duration strings like "2h", "30m", "1h30m".
+fn parse_duration_secs(s: &str) -> Option<i64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let mut total: i64 = 0;
+    let mut num_buf = String::new();
+    for ch in s.chars() {
+        if ch.is_ascii_digit() {
+            num_buf.push(ch);
+        } else {
+            let n: i64 = num_buf.parse().ok()?;
+            num_buf.clear();
+            match ch {
+                'h' => total += n * 3600,
+                'm' => total += n * 60,
+                's' => total += n,
+                _ => return None,
+            }
+        }
+    }
+    if !num_buf.is_empty() {
+        let n: i64 = num_buf.parse().ok()?;
+        total += n * 60; // bare number = minutes
+    }
+    if total > 0 {
+        Some(total)
+    } else {
+        None
+    }
+}
+
+static WATCHDOG_ACTIONS: &[(&str, HandlerFn)] = &[
+    ("snooze", dispatch_watchdog_snooze),
+    ("resume", dispatch_watchdog_resume),
+    ("status", dispatch_watchdog_status),
+];
+
 // `repo` — actions: checkout / release.
 
 fn dispatch_repo(ctx: &HandlerCtx<'_>) -> Value {
@@ -673,6 +796,12 @@ static REGISTERED: &[HandlerEntry] = &[
         handler: dispatch_health,
         actions: Some(HEALTH_ACTIONS),
     },
+    // #1084: watchdog snooze/resume/status
+    HandlerEntry {
+        name: "watchdog",
+        handler: dispatch_watchdog,
+        actions: Some(WATCHDOG_ACTIONS),
+    },
     HandlerEntry {
         name: "repo",
         handler: dispatch_repo,
@@ -800,6 +929,7 @@ mod tests {
                 "decision",
                 "deployment",
                 "health",
+                "watchdog",
                 "repo",
                 "schedule",
                 "team",
@@ -812,7 +942,7 @@ mod tests {
                 "restart_daemon",
             ]
         );
-        assert_eq!(registered_handlers().len(), 30);
+        assert_eq!(registered_handlers().len(), 31);
     }
 
     /// Coverage test: every tool name advertised by
@@ -884,6 +1014,7 @@ mod tests {
             ),
             ("schedule", &["create", "list", "update", "delete"]),
             ("team", &["create", "delete", "list", "update"]),
+            ("watchdog", &["snooze", "resume", "status"]),
         ];
         for (tool, actions) in cases {
             for action in actions.iter() {
@@ -959,5 +1090,65 @@ mod tests {
         let args = json!({}); // no "action" key
         let ctx = ctx_for(&home, &args, "");
         assert!(try_dispatch("task", &ctx).is_some());
+    }
+
+    // ── #1084 watchdog snooze MCP tests ──────────────────────────
+
+    fn watchdog_home(tag: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("agend-watchdog-mcp-{}-{}", tag, std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    #[test]
+    fn watchdog_snooze_then_status_round_trip() {
+        let home = watchdog_home("snooze-status");
+        let args = json!({"action": "snooze", "duration": "1h"});
+        let ctx = ctx_for(&home, &args, "test-agent");
+        let result = try_dispatch("watchdog", &ctx).unwrap();
+        assert_eq!(result["snoozed"], true);
+        assert!(result["snoozed_until"].is_string());
+        assert_eq!(result["duration_secs"], 3600);
+
+        let status_args = json!({"action": "status"});
+        let status_ctx = ctx_for(&home, &status_args, "test-agent");
+        let status = try_dispatch("watchdog", &status_ctx).unwrap();
+        assert_eq!(status["snoozed"], true);
+        assert!(status["remaining_secs"].as_i64().unwrap() > 0);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn watchdog_snooze_duration_clamped_to_4h() {
+        let home = watchdog_home("snooze-clamp");
+        let args = json!({"action": "snooze", "duration": "24h"});
+        let ctx = ctx_for(&home, &args, "test-agent");
+        let result = try_dispatch("watchdog", &ctx).unwrap();
+        assert_eq!(
+            result["duration_secs"],
+            4 * 3600,
+            "#1084: 24h must clamp to 4h"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn watchdog_resume_clears_snooze() {
+        let home = watchdog_home("resume");
+        let snooze_args = json!({"action": "snooze", "duration": "2h"});
+        let ctx = ctx_for(&home, &snooze_args, "test-agent");
+        try_dispatch("watchdog", &ctx);
+
+        let resume_args = json!({"action": "resume"});
+        let resume_ctx = ctx_for(&home, &resume_args, "test-agent");
+        let result = try_dispatch("watchdog", &resume_ctx).unwrap();
+        assert_eq!(result["snoozed"], false);
+
+        let status_args = json!({"action": "status"});
+        let status_ctx = ctx_for(&home, &status_args, "test-agent");
+        let status = try_dispatch("watchdog", &status_ctx).unwrap();
+        assert_eq!(status["snoozed"], false);
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -15,6 +15,7 @@ pub fn tool_definitions() -> Value {
     tools.extend(deploy_tools());
     tools.extend(ci_tools());
     tools.extend(health_tools());
+    tools.extend(watchdog_tools());
     tools.extend(worktree_tools());
     json!({"tools": tools})
 }
@@ -230,6 +231,16 @@ fn ci_tools() -> Vec<Value> {
                 "interval_secs": {"type": "number", "description": "Poll interval in seconds (default: 60)"},
                 "next_after_ci": {"type": "string", "description": "Instance to auto-notify when CI passes. Daemon sends [ci-ready-for-action] to this target."},
                 "review_class": {"type": "string", "enum": ["single", "dual"], "description": "#972: review threshold for the daemon's PR-state aggregator. `single` (default) — §3.6 one VERIFIED unlocks the merge gate. `dual` — §3.5 two distinct VERIFIED required before `[pr-ready-for-merge]` fires."}
+            }, "required": ["action"]}}),
+    ]
+}
+
+fn watchdog_tools() -> Vec<Value> {
+    vec![
+        json!({"name": "watchdog", "description": "#1084: Fleet idle watchdog snooze control. Actions: snooze, resume, status.",
+            "inputSchema": {"type": "object", "properties": {
+                "action": {"type": "string", "enum": ["snooze", "resume", "status"]},
+                "duration": {"type": "string", "description": "Snooze duration (e.g. '2h', '30m', '1h30m'). Clamped to max 4h. Default: 1h."}
             }, "required": ["action"]}}),
     ]
 }
@@ -470,8 +481,8 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            30,
-            "Sprint 61: 29 + restart_daemon(exit-42) = 30. \
+            31,
+            "#1084: 30 + watchdog(snooze/resume/status) = 31. \
              Current tools: {:?}",
             tools
                 .iter()


### PR DESCRIPTION
## Summary
- New `watchdog` MCP tool with `snooze` / `resume` / `status` actions for fleet idle watchdog (#1084)
- JSON sidecar `fleet-idle-snooze.json` persists snooze state across daemon restarts
- `is_fleet_idle_snoozed()` check at `scan_fleet_vantage` entry — skips entire scan when snoozed
- Duration clamp: max 4h per snooze call (prevents indefinite suppression)
- Event log audit trail on snooze/resume operations
- KISS-reduced Phase 1: no TUI binding, no ACL infrastructure (deferred per dialectic consensus)

## Test plan
- [x] T1: snooze suppresses fleet alert
- [x] T2: expired snooze resumes alerting
- [x] T3: snooze does not affect dev vantage (#10)
- [x] T4: resume clears snooze
- [x] MCP snooze + status round-trip
- [x] Duration clamp 24h → 4h
- [x] MCP resume clears snooze state
- [x] Dispatch routing invariant tests updated (31 tools, watchdog actions pinned)
- [x] Full test suite: 2729 passed, 0 failed
- [x] `cargo fmt` + `cargo clippy` clean

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)