### PR TITLE
fix: resolve conflict_notify hardcoded base + reuse shared CI runtime

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -31,7 +31,7 @@ use super::watcher::check_ci_watches;
 // runtime per poll cycle. Bounded to 2 worker threads.
 // ---------------------------------------------------------------------------
 
-fn shared_ci_runtime() -> &'static tokio::runtime::Runtime {
+pub(super) fn shared_ci_runtime() -> &'static tokio::runtime::Runtime {
     static RT: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
     RT.get_or_init(|| {
         tokio::runtime::Builder::new_multi_thread()

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -220,22 +220,13 @@ pub trait CiProvider: Send + Sync {
 
     /// #813: synchronous variant for non-async callers (handler-layer
     /// MCP entry points that need a blocking answer on watch-start).
-    /// Always runs the async future on a fresh current-thread runtime
-    /// in a scoped thread — works regardless of whether the caller is
-    /// already inside a tokio runtime (avoids the multi-thread vs
-    /// current-thread runtime-flavor branch). Dead-code allow lifts
-    /// at C3 when handle_watch_ci wires the call site.
+    /// Runs the async future on the shared CI runtime in a scoped
+    /// thread — works regardless of whether the caller is already
+    /// inside a tokio runtime.
     fn check_pr_mergeable_blocking(&self, repo: &str, branch: &str) -> MergeableState {
         std::thread::scope(|s| {
             let handle = s.spawn(|| {
-                let rt = match tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                {
-                    Ok(rt) => rt,
-                    Err(_) => return MergeableState::Unknown,
-                };
-                rt.block_on(self.check_pr_mergeable(repo, branch))
+                super::poller::shared_ci_runtime().block_on(self.check_pr_mergeable(repo, branch))
             });
             handle.join().unwrap_or(MergeableState::Unknown)
         })

--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -175,8 +175,8 @@ fn emit_conflict_notify(home: &Path, agent: &str) {
         .get("branch")
         .and_then(|v| v.as_str())
         .unwrap_or("(unknown)");
-    let base = "main"; // r0: hardcode; future PR can resolve from fleet.yaml
-    let payload = build_notify_payload(operation, &conflicted_files, branch, base);
+    let base = crate::git_helpers::default_branch(&worktree);
+    let payload = build_notify_payload(operation, &conflicted_files, branch, &base);
     let text = payload.to_string();
     let source = crate::inbox::NotifySource::System("conflict_notify");
     crate::inbox::notify_agent(home, agent, &source, &text);


### PR DESCRIPTION
## Summary
- **Task 1**: Replace hardcoded `base = "main"` in `conflict_notify.rs` with `git_helpers::default_branch(&worktree)` to correctly resolve the repo's actual default branch
- **Task 2**: Reuse `shared_ci_runtime()` in `CiProvider::check_pr_mergeable_blocking` instead of creating a fresh thread+runtime per call. Scoped thread retained to avoid block_on-inside-runtime panics.

## Test plan
- [x] 7 conflict_notify tests pass
- [x] 177 ci_watch tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)