### PR TITLE
refactor: low findings batch — URL helper, test-only code move, dead_code cleanup

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -362,52 +362,6 @@ pub(super) fn check_ci_watches_with_provider(
     }
 }
 
-/// Outcome of interpreting a `GET /repos/.../actions/runs` response.
-///
-/// Without this, a non-2xx response (e.g. unauthenticated rate-limit
-/// `{"message":"API rate limit exceeded ..."}`) parses cleanly as JSON
-/// but its `workflow_runs` field is absent, and the caller's
-/// `body["workflow_runs"].as_array()` returns `None` — silently behaving
-/// as if the branch had no runs and skipping every subsequent
-/// notification while `last_polled_at` keeps marching forward. Tag the
-/// HTTP status explicitly so API errors surface as `Err` instead of
-/// imitating a quiescent branch.
-///
-/// Production code now uses [`CiPollResult`] via the [`CiProvider`] trait;
-/// this enum is retained for unit-testing the classification logic that
-/// lives inside [`super::provider::GitHubCiProvider::poll_runs`].
-#[cfg(test)]
-enum RunsResponse<'a> {
-    Run(&'a serde_json::Value),
-    NoRuns,
-    ApiError(String),
-}
-
-/// Pure interpreter for a runs-list response. See [`RunsResponse`] for
-/// why the rate-limit / NoRuns distinction matters.
-///
-/// Retained under `#[cfg(test)]` — production classification now happens
-/// inside [`super::provider::GitHubCiProvider::poll_runs`].
-#[cfg(test)]
-fn classify_runs_response(status: u16, body: &serde_json::Value) -> RunsResponse<'_> {
-    if !(200..300).contains(&status) {
-        let message = body["message"].as_str().unwrap_or("(no message)");
-        let hint = if status == 403
-            && std::env::var("GITHUB_TOKEN").is_err()
-            && message.to_lowercase().contains("rate limit")
-        {
-            " — set GITHUB_TOKEN to raise the unauthenticated 60/hr cap"
-        } else {
-            ""
-        };
-        return RunsResponse::ApiError(format!("GH API {status}: {message}{hint}"));
-    }
-    match body["workflow_runs"].as_array().and_then(|a| a.first()) {
-        Some(run) => RunsResponse::Run(run),
-        None => RunsResponse::NoRuns,
-    }
-}
-
 /// Select runs from a CI poll result that should trigger notifications.
 /// Returns indices into `runs` of terminal runs ordered oldest-first
 /// so notifications arrive chronologically. In-progress runs

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -1,6 +1,31 @@
 use super::*;
 use crate::agent::AgentRegistry;
 
+enum RunsResponse<'a> {
+    Run(&'a serde_json::Value),
+    NoRuns,
+    ApiError(String),
+}
+
+fn classify_runs_response(status: u16, body: &serde_json::Value) -> RunsResponse<'_> {
+    if !(200..300).contains(&status) {
+        let message = body["message"].as_str().unwrap_or("(no message)");
+        let hint = if status == 403
+            && std::env::var("GITHUB_TOKEN").is_err()
+            && message.to_lowercase().contains("rate limit")
+        {
+            " — set GITHUB_TOKEN to raise the unauthenticated 60/hr cap"
+        } else {
+            ""
+        };
+        return RunsResponse::ApiError(format!("GH API {status}: {message}{hint}"));
+    }
+    match body["workflow_runs"].as_array().and_then(|a| a.first()) {
+        Some(run) => RunsResponse::Run(run),
+        None => RunsResponse::NoRuns,
+    }
+}
+
 #[test]
 fn ci_watches_dir_returns_expected_path() {
     let home = std::path::Path::new("/tmp/test");

--- a/src/daemon/ci_watch/watcher.rs
+++ b/src/daemon/ci_watch/watcher.rs
@@ -9,6 +9,14 @@ use super::provider::{
 use super::sweep::gc_stale_watches;
 use super::watch_state::WatchState;
 
+fn url_or_default(url: String, default: &str) -> String {
+    if url.is_empty() {
+        default.to_string()
+    } else {
+        url
+    }
+}
+
 /// Check CI watch configs and inject failure logs to agents when CI fails.
 pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
     let _ = gc_stale_watches(home, "eager_gc");
@@ -37,19 +45,11 @@ pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
         let url = ci_url.unwrap_or(default_url);
         match ci_type {
             "gitlab" => {
-                let url = if url.is_empty() {
-                    "https://gitlab.com".to_string()
-                } else {
-                    url
-                };
+                let url = url_or_default(url, "https://gitlab.com");
                 Some(Box::new(GitLabCiProvider::with_base_url(url).ok()?) as Box<dyn CiProvider>)
             }
             "bitbucket_cloud" => {
-                let url = if url.is_empty() {
-                    "https://api.bitbucket.org".to_string()
-                } else {
-                    url
-                };
+                let url = url_or_default(url, "https://api.bitbucket.org");
                 Some(Box::new(BitbucketCiProvider::with_base_url(url).ok()?) as Box<dyn CiProvider>)
             }
             "bitbucket_server" => {
@@ -60,11 +60,7 @@ pub fn check_ci_watches(home: &Path, registry: &AgentRegistry) {
                 None
             }
             _ => {
-                let url = if url.is_empty() {
-                    "https://api.github.com".to_string()
-                } else {
-                    url
-                };
+                let url = url_or_default(url, "https://api.github.com");
                 Some(Box::new(GitHubCiProvider::with_base_url(url).ok()?) as Box<dyn CiProvider>)
             }
         }

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -193,11 +193,7 @@ impl ReviewClass {
 /// Both production ingestion entry points ([`record_ci_result`] and
 /// [`record_verdict`]) translate their inputs into one of these.
 ///
-/// `DraftTransition` / `MergedObserved` / `ClosedUnmergedObserved` are
-/// reserved for v2 (gh-poll integration). Sourced only from tests
-/// today; #972 v1 production code emits `CiObserved` + `VerdictObserved`.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // v2 variants — see docstring
 pub enum Event<'a> {
     /// CI's poll observed a head transition + conclusion.
     CiObserved {


### PR DESCRIPTION
## Summary
- **F6**: Extract `url_or_default` helper in `watcher.rs` — 3× repeated empty-URL-to-default pattern collapsed
- **F7**: Move `RunsResponse` enum + `classify_runs_response` fn from `poller.rs` to `poller_tests.rs` — test-only code belongs in the test module
- Remove stale `#[allow(dead_code)]` + outdated "reserved for v2" docstring on `Event` variants (`DraftTransition`, `MergedObserved`, `ClosedUnmergedObserved`) — all three are now used in production by `scanner.rs`

## Test plan
- [x] `cargo check` passes
- [x] `cargo test -p agend-terminal` — all 143 poller tests pass, 6 `classify_response` tests run from new location
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p agend-terminal -- -D warnings` clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)