### PR TITLE
fix(#1109): low findings batch — comms & router review

### DIFF
--- a/src/daemon/router.rs
+++ b/src/daemon/router.rs
@@ -117,12 +117,14 @@ fn run_loop(home: PathBuf, reg_rx: crossbeam_channel::Receiver<AgentSubscription
             }
         }
 
-        // Remove dead channels.
-        buffers.retain(|_, buf| {
-            matches!(
-                buf.rx.try_recv(),
-                Ok(_) | Err(crossbeam_channel::TryRecvError::Empty)
-            )
+        buffers.retain(|_, buf| match buf.rx.try_recv() {
+            Ok(data) => {
+                let text = String::from_utf8_lossy(&data);
+                buf.buffer.push_str(&text);
+                true
+            }
+            Err(crossbeam_channel::TryRecvError::Empty) => true,
+            Err(crossbeam_channel::TryRecvError::Disconnected) => false,
         });
 
         if !had_activity {
@@ -167,7 +169,11 @@ fn try_dispatch_mirror(home: &std::path::Path, name: &str, buf: &mut AgentBuffer
     }
 
     let mirror_text = if text.len() > MAX_MIRROR_LEN {
-        &text[..MAX_MIRROR_LEN]
+        let mut end = MAX_MIRROR_LEN;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        &text[..end]
     } else {
         text
     };
@@ -232,6 +238,7 @@ fn strip_ansi_simple(s: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -381,6 +388,65 @@ mod tests {
 
         crate::channel::reset_active_channel_for_test();
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn mirror_truncation_safe_on_multibyte_utf8() {
+        let _g = registry_guard();
+        crate::channel::reset_active_channel_for_test();
+
+        let tg = RecordingMockChannel::arc("telegram");
+        crate::channel::register_active_channel(tg.clone());
+
+        let agent = "test_mirror_utf8";
+        crate::daemon::heartbeat_pair::update_with(agent, |p| {
+            p.reply_to_channel = Some("telegram".into());
+            p.reply_to_input_id = Some(42);
+            p.mirror_dispatched_for_turn = false;
+            p.mirror_skip_until_next_turn = false;
+            p.last_mirror_event_id = None;
+        });
+
+        let home = std::env::temp_dir().join(format!("agend-router-utf8-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+
+        // Build a string that has multibyte chars near MAX_MIRROR_LEN boundary
+        let prefix = "x".repeat(MAX_MIRROR_LEN - 2);
+        let text = format!("{prefix}日本語"); // 3-byte chars right at the boundary
+        let mut buf = make_buffer(&text);
+        // Must not panic
+        try_dispatch_mirror(&home, agent, &mut buf);
+        assert_eq!(tg.count(), 1);
+
+        crate::channel::reset_active_channel_for_test();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn retain_preserves_received_data() {
+        let (tx, rx) = crossbeam_channel::bounded::<Vec<u8>>(8);
+        let mut buffers = std::collections::HashMap::new();
+        buffers.insert(
+            "agent".to_string(),
+            AgentBuffer {
+                rx,
+                buffer: String::new(),
+                active: false,
+                last_output_at: Instant::now(),
+                input_id: None,
+            },
+        );
+        tx.send(b"hello".to_vec()).unwrap();
+        buffers.retain(|_, buf| match buf.rx.try_recv() {
+            Ok(data) => {
+                let text = String::from_utf8_lossy(&data);
+                buf.buffer.push_str(&text);
+                true
+            }
+            Err(crossbeam_channel::TryRecvError::Empty) => true,
+            Err(crossbeam_channel::TryRecvError::Disconnected) => false,
+        });
+        assert_eq!(buffers["agent"].buffer, "hello");
     }
 
     #[test]

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -78,10 +78,10 @@ pub(super) fn handle_send_to_instance(
     if *sender == target {
         return json!({"error": "cannot send to self — use a different instance_name"});
     }
-    let text = args["message"]
-        .as_str()
-        .or_else(|| args["text"].as_str())
-        .unwrap_or("");
+    let text = match args["message"].as_str().or_else(|| args["text"].as_str()) {
+        Some(t) if !t.is_empty() => t,
+        _ => return json!({"error": "missing or empty 'message'"}),
+    };
     let kind = args["request_kind"]
         .as_str()
         .or_else(|| args["kind"].as_str());
@@ -180,18 +180,8 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
         None => return json!({"error": "missing 'task'"}),
     };
 
-    // Busy gate: check if target has claimed tasks on the task board.
-    // New names: force/force_reason. Old names: interrupt/reason (backwards-compat).
-    let force = args
-        .get("force")
-        .and_then(|v| v.as_bool())
-        .or_else(|| args.get("interrupt").and_then(|v| v.as_bool()))
-        .unwrap_or(false);
-    let force_reason = args
-        .get("force_reason")
-        .and_then(|v| v.as_str())
-        .or_else(|| args.get("reason").and_then(|v| v.as_str()));
-    let used_deprecated = args.get("interrupt").is_some() || args.get("reason").is_some();
+    let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
+    let force_reason = args.get("force_reason").and_then(|v| v.as_str());
     let claimed_tasks: Vec<_> = crate::tasks::list_all(home)
         .into_iter()
         .filter(|t| t.assignee.as_deref() == Some(target) && t.status == "claimed")
@@ -199,7 +189,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
     if !claimed_tasks.is_empty() {
         if force {
             if force_reason.is_none() || force_reason == Some("") {
-                return json!({"error": "force=true requires a non-empty 'force_reason' (or deprecated 'reason')"});
+                return json!({"error": "force=true requires a non-empty 'force_reason'"});
             }
         } else {
             let current = &claimed_tasks[0];
@@ -423,14 +413,6 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
         }));
     }
     let mut result = result;
-    if used_deprecated {
-        if let Some(obj) = result.as_object_mut() {
-            obj.insert(
-                "warning".into(),
-                json!("interrupt/reason fields deprecated, use force/force_reason; will be removed Sprint 11"),
-            );
-        }
-    }
     if let Some(tid) = auto_created_task_id {
         if let Some(obj) = result.as_object_mut() {
             obj.insert("auto_created_task_id".into(), json!(tid));

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1539,10 +1539,9 @@ fn test_interrupt_handler_validates_target() {
 // --- Sprint 10: backwards-compat for old interrupt/reason names ---
 
 #[test]
-fn test_delegate_task_old_interrupt_true_still_works() {
-    // Old callers using interrupt=true + reason should still work
+fn test_delegate_task_old_interrupt_field_no_longer_bypasses_busy_gate() {
     let _g = fleet_test_guard();
-    let home = tmp_home("old-interrupt-compat");
+    let home = tmp_home("old-interrupt-removed");
     std::fs::write(
         crate::fleet::fleet_yaml_path(&home),
         "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
@@ -1558,23 +1557,14 @@ fn test_delegate_task_old_interrupt_true_still_works() {
     let tid = tasks["tasks"][0]["id"].as_str().unwrap();
     crate::tasks::handle(&home, "target", &json!({"action": "claim", "id": tid}));
 
-    // Use OLD names: interrupt + reason
     let result = handle_tool(
         "send",
         &json!({"target_instance": "target", "task": "urgent", "message": "urgent", "request_kind": "task", "task_id": "t-test-fixture", "interrupt": true, "reason": "legacy caller"}),
         "sender",
     );
-    // Should bypass busy gate (backwards-compat) + emit deprecation warning
     assert!(
-        result.get("busy").is_none(),
-        "old interrupt=true must still bypass busy gate: {result}"
-    );
-    assert!(
-        result["warning"]
-            .as_str()
-            .unwrap_or("")
-            .contains("deprecated"),
-        "old names must emit deprecation warning: {result}"
+        result.get("busy").is_some(),
+        "old interrupt field must NOT bypass busy gate after removal: {result}"
     );
     std::env::remove_var("AGEND_HOME");
     std::fs::remove_dir_all(&home).ok();


### PR DESCRIPTION
## Summary
- **L1**: Reject empty messages in `handle_send_to_instance` — consistent with broadcast/delegate/report handlers
- **L2**: Char-boundary-safe mirror truncation — scans backward from `MAX_MIRROR_LEN` to find valid UTF-8 boundary instead of byte-slicing
- **L3**: Fix `try_recv` data drop in `buffers.retain` — received data now pushed into agent buffer instead of being silently consumed
- **L4**: Remove stale `interrupt`/`reason` backwards-compat (44+ sprints overdue) — callers must use `force`/`force_reason`

3 files, +84 -46. All 2749 tests pass. Clippy clean.

Fixes #1109

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — all tests pass
- [x] New tests: `mirror_truncation_safe_on_multibyte_utf8`, `retain_preserves_received_data`
- [x] Updated test: `test_delegate_task_old_interrupt_field_no_longer_bypasses_busy_gate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)