### PR TITLE
fix(#1112): inbox O(n) scan optimizations

### DIFF
--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -348,10 +348,8 @@ where
     let from = msg.from.clone();
     let kind = msg.kind.clone();
 
-    storage::enqueue(home, target, msg)?;
-
-    // Build the PTY hint AFTER the inbox write succeeds
-    let pending = storage::unread_count(home, target).0;
+    // Single lock scope: enqueue + count in one read, avoiding double I/O.
+    let pending = storage::enqueue_returning_unread_count(home, target, msg)?;
     let from_short = from.strip_prefix("from:").unwrap_or(&from);
     let kind_str = kind.as_deref().unwrap_or("");
     let hint = format!(

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -93,6 +93,43 @@ pub fn enqueue(home: &Path, name: &str, mut msg: InboxMessage) -> anyhow::Result
     })?
 }
 
+/// Enqueue a message and return the post-enqueue unread count in one lock
+/// scope. Avoids the double-read of separate `enqueue` + `unread_count` calls.
+pub fn enqueue_returning_unread_count(
+    home: &Path,
+    name: &str,
+    mut msg: InboxMessage,
+) -> anyhow::Result<usize> {
+    if super::disk::is_readonly() {
+        anyhow::bail!("inbox readonly: disk space critically low");
+    }
+    msg.schema_version = InboxMessage::CURRENT_VERSION;
+    ensure_msg_id(&mut msg);
+    let line = format!("{}\n", serde_json::to_string(&msg)?);
+
+    with_inbox_lock(home, name, |path| {
+        let existing = std::fs::read_to_string(path).unwrap_or_default();
+        let mut count = 0usize;
+        for l in existing.lines() {
+            if l.trim().is_empty() {
+                continue;
+            }
+            if let Ok(m) = serde_json::from_str::<InboxMessage>(l) {
+                if m.read_at.is_none() {
+                    count += 1;
+                }
+            }
+        }
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        f.write_all(line.as_bytes())?;
+        f.sync_all()?;
+        Ok(count + 1) // +1 for the message we just appended
+    })?
+}
+
 /// Assign a stable `msg.id` when absent. Shared between [`enqueue`] and
 /// [`enqueue_with_idle_hint`] so the latter can pre-stamp an id before
 /// the enqueue, then reference it in the PTY hint without consuming the
@@ -126,6 +163,16 @@ pub fn mark_ci_watch_superseded(
         let mut lines: Vec<String> = Vec::new();
         for line in content.lines() {
             if line.trim().is_empty() {
+                lines.push(line.to_string());
+                continue;
+            }
+            // Pre-filter: skip JSON parse for lines that can't match criteria.
+            // Matching lines must contain "ci-watch", "system:ci", and the
+            // repo_branch_key, and must NOT already have a non-null read_at.
+            if !line.contains("ci-watch")
+                || !line.contains("system:ci")
+                || !line.contains(repo_branch_key)
+            {
                 lines.push(line.to_string());
                 continue;
             }
@@ -189,8 +236,8 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
         };
 
         let now = chrono::Utc::now().to_rfc3339();
-        let mut unread = Vec::new();
         let mut all_messages: Vec<InboxMessage> = Vec::new();
+        let mut newly_read: Vec<bool> = Vec::new();
 
         for line in content.lines() {
             if line.trim().is_empty() {
@@ -212,28 +259,31 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
                 // M6: skip superseded messages — they are stale
                 if msg.superseded_by.is_some() {
                     msg.read_at = Some(now.clone());
+                    newly_read.push(false);
                     all_messages.push(msg);
                     continue;
                 }
                 msg.read_at = Some(now.clone());
-                // #836: signal post-consume so the notification-dedup
-                // ledger can suppress redundant re-inject attempts
-                // from the rate-limit retry path. The ledger only has
-                // a record when notify_agent earlier called
-                // `record_inject(agent, msg_id)`; for messages whose
-                // delivery never went through the PTY-inject path
-                // (inbox-only or pre-#836 flight), `mark_consumed` is
-                // a no-op.
                 if let Some(ref id) = msg.id {
                     crate::daemon::notification_dedup::global().mark_consumed(name, id);
                 }
-                unread.push(msg.clone());
+                newly_read.push(true);
+            } else {
+                newly_read.push(false);
             }
             all_messages.push(msg);
         }
 
+        let has_unread = newly_read.iter().any(|&b| b);
+
         // Sprint 52: set reply_to on dequeue — last channel-sourced message wins.
-        if let Some(channel_msg) = unread.iter().rev().find(|m| m.channel.is_some()) {
+        if let Some(channel_msg) = all_messages
+            .iter()
+            .zip(newly_read.iter())
+            .rev()
+            .find(|(m, &nr)| nr && m.channel.is_some())
+            .map(|(m, _)| m)
+        {
             let channel_name = match channel_msg.channel.as_ref().expect("checked") {
                 crate::channel::ChannelKind::Telegram => "telegram",
                 crate::channel::ChannelKind::Discord => "discord",
@@ -247,7 +297,7 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
             });
         }
 
-        if !unread.is_empty() {
+        if has_unread {
             let write_tmp = path.with_extension("jsonl.tmp");
             let result = (|| -> anyhow::Result<()> {
                 let mut f = std::fs::OpenOptions::new()
@@ -267,7 +317,13 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
             }
         }
 
-        unread
+        // Extract newly-read messages without cloning — consume all_messages
+        // after write-back (which only borrows).
+        all_messages
+            .into_iter()
+            .zip(newly_read)
+            .filter_map(|(msg, nr)| nr.then_some(msg))
+            .collect()
     }) {
         Ok(msgs) => msgs,
         Err(e) => {
@@ -454,37 +510,46 @@ pub fn describe_message(home: &Path, msg_id: &str, instance: &str) -> MessageSta
 /// Get all messages in a thread, ordered by timestamp.
 /// If `instance` is Some, only scan that agent's inbox; otherwise scan all.
 pub fn get_thread(home: &Path, thread_id: &str, instance: Option<&str>) -> Vec<InboxMessage> {
-    let inbox_dir = home.join("inbox");
-    let entries = match std::fs::read_dir(&inbox_dir) {
-        Ok(e) => e,
-        Err(_) => return Vec::new(),
-    };
     let mut msgs = Vec::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        if let Some(inst) = instance {
-            let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-            if stem != inst {
+
+    if let Some(inst) = instance {
+        // Direct path lookup — skip directory scan entirely.
+        let path = inbox_path_resolved(home, inst);
+        collect_thread_messages(&path, thread_id, &mut msgs);
+    } else {
+        let inbox_dir = home.join("inbox");
+        let entries = match std::fs::read_dir(&inbox_dir) {
+            Ok(e) => e,
+            Err(_) => return Vec::new(),
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
                 continue;
             }
+            collect_thread_messages(&path, thread_id, &mut msgs);
         }
-        let content = match std::fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        for line in content.lines() {
-            if let Ok(msg) = serde_json::from_str::<InboxMessage>(line) {
-                if msg.thread_id.as_deref() == Some(thread_id) {
-                    msgs.push(msg);
-                }
+    }
+
+    msgs.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    msgs
+}
+
+fn collect_thread_messages(path: &Path, thread_id: &str, out: &mut Vec<InboxMessage>) {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    for line in content.lines() {
+        if !line.contains(thread_id) {
+            continue;
+        }
+        if let Ok(msg) = serde_json::from_str::<InboxMessage>(line) {
+            if msg.thread_id.as_deref() == Some(thread_id) {
+                out.push(msg);
             }
         }
     }
-    msgs.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-    msgs
 }
 
 /// Look up a message by ID across all inbox files. Returns the message if found.

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -2923,3 +2923,165 @@ fn t14_pr_ready_for_merge_load_bearing_emits_hint() {
     assert_eq!(drained[0].kind.as_deref(), Some("pr-ready-for-merge"));
     fs::remove_dir_all(&home).ok();
 }
+
+// --- #1112 characterization tests for scan optimizations ---
+
+#[test]
+fn m4_drain_returns_correct_unread_no_duplicates() {
+    let home = tmp_home("1112-m4-drain");
+    enqueue(&home, "a", make_msg("alice", "msg1")).unwrap();
+    enqueue(&home, "a", make_msg("bob", "msg2")).unwrap();
+    enqueue(&home, "a", make_msg("carol", "msg3")).unwrap();
+
+    let drained = drain(&home, "a");
+    assert_eq!(drained.len(), 3);
+    assert_eq!(drained[0].text, "msg1");
+    assert_eq!(drained[1].text, "msg2");
+    assert_eq!(drained[2].text, "msg3");
+    assert!(drained.iter().all(|m| m.read_at.is_some()));
+
+    // All messages remain in the JSONL file after drain
+    let path = super::storage::inbox_path(&home, "a");
+    let content = fs::read_to_string(&path).unwrap();
+    let persisted: Vec<InboxMessage> = content
+        .lines()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+    assert_eq!(persisted.len(), 3, "all messages persisted");
+    assert!(
+        persisted.iter().all(|m| m.read_at.is_some()),
+        "all have read_at on disk"
+    );
+
+    // Second drain returns empty
+    assert!(drain(&home, "a").is_empty());
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn m4_drain_mixed_read_unread() {
+    let home = tmp_home("1112-m4-mixed");
+    enqueue(&home, "a", make_msg("alice", "first")).unwrap();
+    drain(&home, "a"); // mark first as read
+
+    enqueue(&home, "a", make_msg("bob", "second")).unwrap();
+    let drained = drain(&home, "a");
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].text, "second");
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn m1_supersede_preserves_non_matching_messages() {
+    let home = tmp_home("1112-m1-preserve");
+    let agent = "dev";
+
+    // Enqueue a normal message and a ci-watch message
+    enqueue(&home, agent, make_msg("from:lead", "task dispatch")).unwrap();
+    let mut ci = make_msg("system:ci", "[ci-pass] owner/repo@main: passed");
+    ci.kind = Some("ci-watch".to_string());
+    enqueue(&home, agent, ci).unwrap();
+
+    super::storage::mark_ci_watch_superseded(&home, agent, "owner/repo@main", "new-id");
+
+    // The normal message should drain normally
+    let drained = drain(&home, agent);
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].text, "task dispatch");
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn m1_supersede_skips_already_read() {
+    let home = tmp_home("1112-m1-read");
+    let agent = "dev";
+
+    let mut ci = make_msg("system:ci", "[ci-pass] owner/repo@main: ok");
+    ci.kind = Some("ci-watch".to_string());
+    enqueue(&home, agent, ci).unwrap();
+
+    // Drain to mark as read
+    drain(&home, agent);
+
+    // Supersede should not affect already-read messages
+    super::storage::mark_ci_watch_superseded(&home, agent, "owner/repo@main", "new-id");
+
+    let path = super::storage::inbox_path(&home, agent);
+    let content = fs::read_to_string(&path).unwrap();
+    let msg: InboxMessage = serde_json::from_str(content.lines().next().unwrap()).unwrap();
+    assert!(
+        msg.superseded_by.is_none(),
+        "already-read should not be superseded"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn m3_get_thread_with_instance_direct_path() {
+    let home = tmp_home("1112-m3-thread");
+    let mut msg1 = make_msg("from:lead", "thread msg 1");
+    msg1.thread_id = Some("t-abc".to_string());
+    enqueue(&home, "agent1", msg1).unwrap();
+
+    let mut msg2 = make_msg("from:dev", "thread msg 2");
+    msg2.thread_id = Some("t-abc".to_string());
+    enqueue(&home, "agent1", msg2).unwrap();
+
+    // Unrelated message in different agent's inbox
+    let mut other = make_msg("from:lead", "other thread");
+    other.thread_id = Some("t-xyz".to_string());
+    enqueue(&home, "agent2", other).unwrap();
+
+    // With instance filter — direct path
+    let thread = super::storage::get_thread(&home, "t-abc", Some("agent1"));
+    assert_eq!(thread.len(), 2);
+
+    // Without instance filter — scans all
+    let thread_all = super::storage::get_thread(&home, "t-abc", None);
+    assert_eq!(thread_all.len(), 2);
+
+    // Cross-agent thread
+    let mut msg3 = make_msg("from:lead", "thread msg 3");
+    msg3.thread_id = Some("t-abc".to_string());
+    enqueue(&home, "agent2", msg3).unwrap();
+    let thread_cross = super::storage::get_thread(&home, "t-abc", None);
+    assert_eq!(thread_cross.len(), 3);
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn m2_enqueue_returning_unread_count_accuracy() {
+    let home = tmp_home("1112-m2-count");
+    let count1 =
+        super::storage::enqueue_returning_unread_count(&home, "a", make_msg("x", "1")).unwrap();
+    assert_eq!(count1, 1);
+
+    let count2 =
+        super::storage::enqueue_returning_unread_count(&home, "a", make_msg("x", "2")).unwrap();
+    assert_eq!(count2, 2);
+
+    // Drain marks everything as read
+    drain(&home, "a");
+
+    let count3 =
+        super::storage::enqueue_returning_unread_count(&home, "a", make_msg("x", "3")).unwrap();
+    assert_eq!(count3, 1, "only the new message is unread after drain");
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn m2_hint_uses_merged_enqueue_count() {
+    let home = tmp_home("1112-m2-hint");
+    enqueue(&home, "a", make_msg("seed", "pre")).unwrap();
+
+    let captured = capture_hint();
+    let captured_clone = captured.clone();
+    enqueue_with_idle_hint_with_emitter(&home, "a", make_msg("system:ci", "new"), move |hint| {
+        *captured_clone.lock() = Some(hint.to_string());
+    })
+    .unwrap();
+
+    let got = captured.lock().clone().expect("hint emitted");
+    assert!(got.contains("inbox=2"), "should show 2 unread: {got:?}");
+    fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary
- **M1**: `mark_ci_watch_superseded` — string pre-filter (`contains("ci-watch")`) before JSON parse, skipping deserialization for non-matching lines
- **M2**: `enqueue_with_idle_hint` — merged enqueue + unread_count into single lock scope via new `enqueue_returning_unread_count()`, eliminating double file read
- **M3**: `get_thread` — direct path lookup via `inbox_path_resolved()` when instance is provided, plus string pre-filter on thread_id
- **M4**: `drain` — eliminated per-message `.clone()` by replacing dual-vec pattern with single vec + bool mask, consuming via `into_iter().zip().filter_map()` after write-back

## Test plan
- [x] 7 new characterization tests covering all 4 optimizations
- [x] All 111 inbox tests pass (`cargo test --bin agend-terminal inbox::tests`)
- [x] `cargo clippy --all-targets` clean (zero warnings)
- [x] `cargo fmt --check` clean
- [x] `spawn_rationale_audit` passes (2/2)

Fixes #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)