### PR TITLE
fix(#1116,#1117): decision_timeout race + dispatch medium batch

### DIFF
--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -92,6 +92,10 @@ fn pending_path(home: &Path, decision_id: &str) -> PathBuf {
     pending_dir(home).join(format!("{decision_id}.json"))
 }
 
+fn decision_lock_path(home: &Path, decision_id: &str) -> PathBuf {
+    pending_dir(home).join(format!("{decision_id}.lock"))
+}
+
 /// Generate a deterministic-format decision ID (`d-<unix_micros>-<seq>`).
 fn next_decision_id() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -200,10 +204,18 @@ pub(crate) fn mark_resolved_for_sender(home: &Path, sender: &str) -> Option<Stri
         return None;
     }
     pending.sort_by(|a, b| a.issued_at.cmp(&b.issued_at));
-    let mut latest = pending.pop()?;
-    latest.status = "resolved".to_string();
-    let id = latest.decision_id.clone();
-    if write_decision(home, &latest) {
+    let candidate = pending.pop()?;
+    let id = candidate.decision_id.clone();
+    // #1116: flock + re-read to serialize against concurrent scan_and_emit
+    let _lock = crate::store::acquire_file_lock(&decision_lock_path(home, &id)).ok()?;
+    let path = pending_path(home, &id);
+    let content = std::fs::read_to_string(&path).ok()?;
+    let mut current: PendingDecision = serde_json::from_str(&content).ok()?;
+    if current.status != "pending" {
+        return None;
+    }
+    current.status = "resolved".to_string();
+    if write_decision(home, &current) {
         Some(id)
     } else {
         None
@@ -232,7 +244,7 @@ impl DecisionTimeoutTracker {
 /// and emit the auto-default inbox event. Exposed for tests.
 pub(crate) fn scan_and_emit(home: &Path) {
     let now = chrono::Utc::now();
-    for mut d in list_pending(home) {
+    for d in list_pending(home) {
         if d.status != "pending" {
             continue;
         }
@@ -244,9 +256,27 @@ pub(crate) fn scan_and_emit(home: &Path) {
         if elapsed_secs <= d.timeout_secs {
             continue;
         }
-        emit_timeout_event(home, &d, elapsed_secs);
-        d.status = "timeout".to_string();
-        let _ = write_decision(home, &d);
+        // #1116: flock + re-read to serialize against concurrent mark_resolved
+        let _lock = match crate::store::acquire_file_lock(&decision_lock_path(home, &d.decision_id))
+        {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let path = pending_path(home, &d.decision_id);
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let mut current: PendingDecision = match serde_json::from_str(&content) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+        if current.status != "pending" {
+            continue;
+        }
+        emit_timeout_event(home, &current, elapsed_secs);
+        current.status = "timeout".to_string();
+        let _ = write_decision(home, &current);
     }
 }
 
@@ -710,6 +740,54 @@ mod tests {
             "#1092 fix: new pending must be live"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #1116: resolve-vs-scan race characterization ──────────────
+
+    /// #1116 characterization: concurrent mark_resolved + scan_and_emit
+    /// on the same timed-out decision must not BOTH succeed. Invariant:
+    /// if resolve wins, no timeout event fires; if scan wins, resolve
+    /// returns None.
+    #[test]
+    fn t1116_race_resolve_vs_scan_must_not_both_succeed() {
+        let _g = env_lock();
+        std::env::remove_var("AGEND_DECISION_TIMEOUT_RECIPIENT");
+        for i in 0..100 {
+            let h = tmp_home(&format!("1116-race-{i}"));
+            let issued = chrono::Utc::now() - chrono::Duration::seconds(2000);
+            write_pending_at(&h, "general", "proceed", 1800, issued);
+
+            let h1 = h.clone();
+            let h2 = h.clone();
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+            let b1 = barrier.clone();
+            let b2 = barrier.clone();
+
+            let t1 = std::thread::spawn(move || {
+                b1.wait();
+                mark_resolved_for_sender(&h1, "general")
+            });
+            let t2 = std::thread::spawn(move || {
+                b2.wait();
+                scan_and_emit(&h2);
+            });
+
+            let resolved = t1.join().unwrap();
+            t2.join().unwrap();
+
+            let inbox = crate::inbox::drain(&h, "general");
+            let timeout_fired = inbox
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("decision_timeout"));
+
+            assert!(
+                !(resolved.is_some() && timeout_fired),
+                "#1116 race iteration {i}: resolve succeeded AND timeout fired — \
+                 read-modify-write not serialized"
+            );
+
+            std::fs::remove_dir_all(&h).ok();
+        }
     }
 
     /// #1092 fix: after the fix, resolve + scan does NOT fire stale

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -508,6 +508,7 @@ static WATCHDOG_ACTIONS: &[(&str, HandlerFn)] = &[
     ("snooze", dispatch_watchdog_snooze),
     ("resume", dispatch_watchdog_resume),
     ("status", dispatch_watchdog_status),
+    ("ack", dispatch_watchdog_ack),
 ];
 
 // `repo` — actions: checkout / release.
@@ -1015,7 +1016,9 @@ mod tests {
         let cases: &[(&str, &[&str])] = &[
             (
                 "task",
-                &["create", "list", "claim", "update", "done", "sweep"],
+                &[
+                    "create", "list", "claim", "update", "done", "sweep", "health",
+                ],
             ),
             ("ci", &["watch", "unwatch", "status"]),
             ("decision", &["post", "list", "update"]),
@@ -1032,7 +1035,7 @@ mod tests {
             ),
             ("schedule", &["create", "list", "update", "delete"]),
             ("team", &["create", "delete", "list", "update"]),
-            ("watchdog", &["snooze", "resume", "status"]),
+            ("watchdog", &["snooze", "resume", "status", "ack"]),
         ];
         for (tool, actions) in cases {
             for action in actions.iter() {
@@ -1060,6 +1063,7 @@ mod tests {
             "repo",
             "schedule",
             "team",
+            "watchdog",
         ];
         for tool in action_tools {
             let entry = registered_handlers()

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -97,6 +97,9 @@ pub enum Stage {
     /// `worktree_pool::lease` returned error (worktree creation failed,
     /// cross-agent lease conflict, same-agent different-branch conflict).
     WorktreeLeaseConflict,
+    /// Source repo resolution fell through to stub (tier 4) while
+    /// `AGEND_BIND_STRICT_MODE=1`.
+    ResolveSourceRepo,
 }
 
 /// Canonical `code` enum — stable across releases. Callers MUST match
@@ -119,6 +122,8 @@ pub enum ErrorCode {
     /// `bind_in_flight_set` already contains `(home, agent)` — concurrent
     /// dispatch blocked.
     BindInFlight,
+    /// `AGEND_BIND_STRICT_MODE=1` and source_repo resolved to stub (tier 4).
+    StubRejected,
 }
 
 /// Sprint 55 P0-B EC11: per-agent in-flight guard scoped to the daemon's
@@ -328,6 +333,21 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     let (source_repo, source_repo_tier) =
         resolve_source_repo(home, target, source_repo_override, resolved.as_ref());
 
+    if source_repo_tier == SourceRepoTier::Stub
+        && std::env::var("AGEND_BIND_STRICT_MODE").as_deref() == Ok("1")
+    {
+        return Err(DispatchError {
+            message: format!(
+                "AGEND_BIND_STRICT_MODE=1: stub fallback rejected for '{target}' — \
+                 set source_repo in fleet.yaml"
+            ),
+            code: ErrorCode::StubRejected,
+            stage: Stage::ResolveSourceRepo,
+            fetch_attempted: false,
+            raw: None,
+        });
+    }
+
     // P0-1.5: central lease registry check — reject if another agent holds this branch.
     if let Some(other) = crate::binding::scan_existing_branch_binding(home, branch, target) {
         return Err(DispatchError {
@@ -535,9 +555,6 @@ fn resolve_source_repo(
     let stub = crate::paths::workspace_dir(home).join(target);
     tracing::warn!(%target, tier = "stub", path = %stub.display(),
         "source_repo using home/workspace stub (tier 4) — fleet.yaml has no source_repo OR working_directory; binding may target wrong git history");
-    if std::env::var("AGEND_BIND_STRICT_MODE").as_deref() == Ok("1") {
-        tracing::error!(%target, "AGEND_BIND_STRICT_MODE=1: stub fallback rejected");
-    }
     (stub, SourceRepoTier::Stub)
 }
 
@@ -875,12 +892,8 @@ pub(crate) fn derive_repo_from_remote_pub(source_repo: &std::path::Path) -> Opti
 /// explicitly. Returns `None` if the repo has no `origin` remote, the remote
 /// isn't GitHub, or the git command fails.
 fn derive_repo_from_remote(source_repo: &std::path::Path) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
-        .current_dir(source_repo)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-        .ok()?;
+    let output =
+        crate::git_helpers::git_bypass(source_repo, &["remote", "get-url", "origin"]).ok()?;
     if !output.status.success() {
         return None;
     }


### PR DESCRIPTION
## Summary

- **#1116**: Add per-decision flock around read-modify-write in `mark_resolved_for_sender` and `scan_and_emit` to prevent concurrent resolve+timeout from both succeeding. Double-check pattern: scan without lock, re-read under lock, skip if status changed.
- **#1117 M1**: Add `"ack"` to `WATCHDOG_ACTIONS` table (was only reachable via base handler fallthrough)
- **#1117 M2**: `AGEND_BIND_STRICT_MODE=1` now returns `DispatchError` with `ErrorCode::StubRejected` instead of logging and proceeding with stub
- **#1117 L1**: Add `"health"` to task action pin test (7th action was missing)
- **#1117 L2**: Add `"watchdog"` to `action_based_tools_have_actions_populated` test
- **#1117 L3**: `derive_repo_from_remote` uses `git_helpers::git_bypass` instead of raw `Command::new("git")`

Fixes #1116
Fixes #1117

## Test plan

- [x] `t1116_race_resolve_vs_scan_must_not_both_succeed` — 100-iteration concurrent stress test with barrier sync
- [x] All 19 decision_timeout tests pass
- [x] All 14 dispatch tests pass (pin tests updated)
- [x] All 45 dispatch_hook tests pass
- [x] All 7 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)