### PR TITLE
fix(#1121): task & decision low findings batch

### DIFF
--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -329,6 +329,21 @@ pub(crate) fn is_fleet_idle_snoozed(home: &Path) -> bool {
     chrono::Utc::now() < until
 }
 
+/// Read and parse the snooze sidecar. Returns `None` if the file is
+/// missing, malformed, or the snooze has expired.
+pub(crate) fn get_snooze_state(home: &Path) -> Option<FleetIdleSnooze> {
+    let content = std::fs::read_to_string(snooze_path(home)).ok()?;
+    let snooze: FleetIdleSnooze = serde_json::from_str(&content).ok()?;
+    let until = chrono::DateTime::parse_from_rfc3339(&snooze.snoozed_until)
+        .ok()?
+        .with_timezone(&chrono::Utc);
+    if chrono::Utc::now() < until {
+        Some(snooze)
+    } else {
+        None
+    }
+}
+
 /// #1084: snooze fleet-idle watchdog until the given timestamp.
 pub(crate) fn snooze_fleet_idle(
     home: &Path,

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -428,19 +428,14 @@ fn dispatch_watchdog_resume(ctx: &HandlerCtx<'_>) -> Value {
 
 fn dispatch_watchdog_status(ctx: &HandlerCtx<'_>) -> Value {
     use crate::daemon::idle_watchdog;
-    if idle_watchdog::is_fleet_idle_snoozed(ctx.home) {
-        let content =
-            std::fs::read_to_string(ctx.home.join("fleet-idle-snooze.json")).unwrap_or_default();
-        let snooze: idle_watchdog::FleetIdleSnooze =
-            serde_json::from_str(&content).unwrap_or_default();
+    if let Some(snooze) = idle_watchdog::get_snooze_state(ctx.home) {
         let remaining = chrono::DateTime::parse_from_rfc3339(&snooze.snoozed_until)
             .ok()
             .map(|dt| {
-                let r = dt
-                    .with_timezone(&chrono::Utc)
+                dt.with_timezone(&chrono::Utc)
                     .signed_duration_since(chrono::Utc::now())
-                    .num_seconds();
-                r.max(0)
+                    .num_seconds()
+                    .max(0)
             })
             .unwrap_or(0);
         json!({
@@ -472,6 +467,9 @@ fn dispatch_watchdog_ack(ctx: &HandlerCtx<'_>) -> Value {
 }
 
 /// Parse human-friendly duration strings like "2h", "30m", "1h30m".
+/// Parse a human duration string into seconds. Supports `h`/`m`/`s`
+/// suffixes (e.g. `"2h30m"`, `"90s"`). A bare number without suffix
+/// is interpreted as **minutes** (e.g. `"30"` → 1800s).
 fn parse_duration_secs(s: &str) -> Option<i64> {
     let s = s.trim();
     if s.is_empty() {

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -40,6 +40,8 @@ use std::path::{Path, PathBuf};
 ///   unlike `Reopened` which preserves it for done→open re-work).
 /// - [`TaskEvent::TaskCloseProposed`] (legacy-backfill dry-run proposal;
 ///   distinct from `Done` per dev-reviewer-2 must-have).
+/// - [`TaskEvent::OwnerAssigned`] (explicit owner assignment without claim).
+/// - [`TaskEvent::PriorityChanged`] (priority mutation tracking).
 /// - [`TaskEvent::Created`] gains `due_at` / `depends_on` / `routed_to`
 ///   fields (`#[serde(default)]` so v1 envelopes round-trip).
 /// - [`TaskRecord`] gains `created_by` / `created_at` / `updated_at` /
@@ -700,9 +702,13 @@ pub fn append_batch(
     let now = chrono::Utc::now().to_rfc3339();
 
     // Sprint 46 P3: resolve emitter's InstanceId for audit trail.
-    let emitter_id = crate::agent::resolve_instance(home, instance.as_str())
-        .ok()
-        .map(|(id, _)| id.full());
+    let emitter_id = match crate::agent::resolve_instance(home, instance.as_str()) {
+        Ok((id, _)) => Some(id.full()),
+        Err(e) => {
+            tracing::debug!(instance = %instance, error = %e, "emitter ID resolution failed");
+            None
+        }
+    };
 
     crate::event_log::append_lines_under_lock(home, LOG_NAME, |log_path| {
         let start_seq = max_seq_for_instance(log_path, &instance)? + 1;


### PR DESCRIPTION
## Summary

- **L1**: Add `tracing::debug!` when `resolve_instance()` returns Err in `task_events.rs` emitter ID resolution (was silently swallowed via `.ok()`)
- **L2**: Add `OwnerAssigned` and `PriorityChanged` to v2 schema docstring (variants existed but were undocumented in the version changelog)
- **L3**: Add `idle_watchdog::get_snooze_state()` returning parsed `FleetIdleSnooze`; replace raw `fs::read_to_string` + manual deser in `dispatch_watchdog_status`
- **L4**: Add doc comment to `parse_duration_secs` explaining "bare number = minutes" convention

Fixes #1121

## Test plan

- [x] 3 watchdog dispatch tests pass (snooze round-trip validates new API path)
- [x] 25 task_events tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)