### PR TITLE
fix(#1126,#1127): stage2 restart off main loop + find_subslice memchr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "iana-time-zone",
  "insta",
  "libc",
+ "memchr",
  "parking_lot",
  "portable-pty",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ dirs = "6"
 # to canonicalize cwd before encoding the project-dir lookup name.
 dunce = "1"
 regex = "1"
+memchr = "2"
 # Sprint 24 P0 PR2 — task_sweep forensic api_response_hash on PrSnapshot.
 # SHA-256 crypto-grade hash + hex encoding so reviewers can correlate an
 # event's response_hash against an archived GitHub API response without

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -773,7 +773,23 @@ fn run_core(
                 tracing::info!(agent = %name, "ignoring stage2 restart during shutdown");
                 break;
             }
-            handle_stage2_restart(home, &name, &registry, &configs, &crash_tx, &shutdown);
+            let home_owned = home.to_path_buf();
+            let reg = Arc::clone(&registry);
+            let cfgs = Arc::clone(&configs);
+            let tx = crash_tx.clone();
+            let sd = Arc::clone(&shutdown);
+            // fire-and-forget: stage2 restart worker is short-lived (backoff sleep
+            // then spawn_agent + restore health counters). Observes shutdown flag
+            // after backoff to abort cleanly. JoinHandle dropped because errors are
+            // logged inside handle_stage2_restart + event_log records outcome.
+            if let Err(e) = std::thread::Builder::new()
+                .name(format!("{name}_stage2"))
+                .spawn(move || {
+                    handle_stage2_restart(&home_owned, &name, &reg, &cfgs, &tx, &sd);
+                })
+            {
+                tracing::warn!(error = %e, "failed to spawn stage2 restart thread");
+            }
             continue;
         }
 
@@ -1603,6 +1619,7 @@ fn handle_stage2_restart(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -2182,6 +2199,44 @@ mod tests {
         for name in &agent_names {
             kill_registered_child(&registry, name);
         }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1126 characterization: handle_stage2_restart runs on a spawned
+    /// thread without blocking the caller. Pre-fix, the function ran
+    /// inline on the main loop with `thread::sleep(backoff)`.
+    #[test]
+    fn stage2_restart_does_not_block_caller() {
+        let home = tmp_home("stage2_nonblock");
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs: Arc<Mutex<HashMap<String, AgentConfig>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let (crash_tx, _crash_rx) = crossbeam_channel::unbounded();
+        let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        std::env::set_var("AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS", "2000");
+
+        let start = std::time::Instant::now();
+        let home_owned = home.to_path_buf();
+        let reg = Arc::clone(&registry);
+        let cfgs = Arc::clone(&configs);
+        let tx = crash_tx.clone();
+        let sd = Arc::clone(&shutdown);
+        let handle = std::thread::Builder::new()
+            .name("test_stage2".into())
+            .spawn(move || {
+                handle_stage2_restart(&home_owned, "ghost", &reg, &cfgs, &tx, &sd);
+            })
+            .unwrap();
+
+        assert!(
+            start.elapsed() < std::time::Duration::from_millis(100),
+            "spawn must return immediately — main loop is not blocked"
+        );
+
+        handle.join().unwrap();
+
+        std::env::remove_var("AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS");
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1039,16 +1039,8 @@ pub(crate) fn has_red_ansi_anchor(ring: &VecDeque<RawChunk>, phrase: &str, now: 
     false
 }
 
-/// Simple O(n×m) byte-slice substring search. For our ring sizes
-/// (≤10×4KB) and phrase lengths (~30-80 chars), the naive impl is
-/// fast enough. Avoids pulling in `memchr` for a single-site need.
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() || haystack.len() < needle.len() {
-        return None;
-    }
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
+    memchr::memmem::find(haystack, needle)
 }
 
 fn hash_screen(text: &str) -> u64 {
@@ -4325,6 +4317,16 @@ mod tests {
             "oldest should be chunk-2 after eviction"
         );
         assert_eq!(last_bytes, b"chunk-11", "newest should be chunk-11");
+    }
+
+    #[test]
+    fn find_subslice_characterization() {
+        assert_eq!(find_subslice(b"hello world", b"world"), Some(6));
+        assert_eq!(find_subslice(b"hello world", b"hello"), Some(0));
+        assert_eq!(find_subslice(b"hello world", b"xyz"), None);
+        assert_eq!(find_subslice(b"hello", b"hello world"), None);
+        assert_eq!(find_subslice(b"", b"a"), None);
+        assert_eq!(find_subslice(b"\x1b[31mERR\x1b[0m", b"\x1b[31m"), Some(0));
     }
 
     /// #919 RED 4: chunks older than ANCHOR_WINDOW_MS are ignored by


### PR DESCRIPTION
## Summary
- **#1126**: `handle_stage2_restart` was called inline on the daemon main loop, blocking it during `thread::sleep(backoff)`. Now spawns to a dedicated thread, mirroring the crash-respawn pattern (line ~864).
- **#1127**: Replaced hand-rolled O(n×m) `find_subslice` with `memchr::memmem::find`. Added `memchr = "2"` as direct dependency (was transitive via `regex`).

## Changes
- `src/daemon/mod.rs`: Stage2 restart call site spawns thread instead of blocking inline; characterization test `stage2_restart_does_not_block_caller`
- `src/state.rs`: `find_subslice` delegates to `memchr::memmem::find`; characterization test `find_subslice_characterization`
- `Cargo.toml`/`Cargo.lock`: added `memchr = "2"`

## Test plan
- [x] `find_subslice_characterization` — pins byte-search semantics (match, no-match, empty haystack, SGR sequences)
- [x] `stage2_restart_does_not_block_caller` — verifies spawn returns in <100ms with 2000ms backoff configured
- [x] All existing `has_red_ansi_anchor` tests pass (exercise `find_subslice` via anchor check path)
- [x] `cargo test` — 2760 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)