### PR TITLE
fix(worktree): write .agend-managed marker immediately after checkout

### DIFF
--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -216,6 +216,15 @@ pub fn create(
                 branch = %branch,
                 "created worktree"
             );
+            // #1137: write .agend-managed marker immediately after successful
+            // checkout to prevent orphan dirs if process dies before caller writes it.
+            let _ = std::fs::write(
+                wt_dir.join(".agend-managed"),
+                format!(
+                    "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
+                    chrono::Utc::now().to_rfc3339()
+                ),
+            );
             Some(WorktreeInfo {
                 path: wt_dir,
                 source_repo: repo_dir.to_path_buf(),
@@ -254,6 +263,14 @@ pub fn create(
                             instance = instance_name,
                             %branch,
                             "created worktree on existing branch"
+                        );
+                        // #1137: write marker immediately (same as primary path above).
+                        let _ = std::fs::write(
+                            wt_dir.join(".agend-managed"),
+                            format!(
+                                "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
+                                chrono::Utc::now().to_rfc3339()
+                            ),
                         );
                         Some(WorktreeInfo {
                             path: wt_dir,

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -49,7 +49,9 @@ pub fn lease(
         None => return Err(format!("failed to create worktree for {agent}@{branch}")),
     };
 
-    // Tag as daemon-managed (R14: only daemon-tagged worktrees are GC candidates).
+    // #1137: marker is now written inside worktree::create() immediately
+    // after checkout. Re-write here is idempotent and ensures the marker
+    // is present for reused worktrees (which skip the create path).
     let marker = info.path.join(MANAGED_MARKER);
     let _ = std::fs::write(
         &marker,


### PR DESCRIPTION
Closes #1137

## Problem
The `.agend-managed` marker was written in `worktree_pool::lease()` AFTER `worktree::create()` returned. If the process crashed between these two calls, the worktree dir would exist without a marker — making it invisible to GC.

## Fix
Move the marker write into `worktree::create()`, immediately after successful `git worktree add`. Both success paths (new branch + existing branch fallback) now write the marker before returning.

The `lease()` call site retains an idempotent re-write for reused worktrees.

## Changes
- `src/worktree.rs`: +18 lines (marker write in both success paths)
- `src/worktree_pool.rs`: comment update only