### PR TITLE
fix(render): force full redraw on tab switch to clear wide-char ghost artifacts

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -395,6 +395,10 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             let (c, r) = crossterm::terminal::size().unwrap_or((120, 40));
             let pane_area = ratatui::layout::Rect::new(0, 1, c, r.saturating_sub(2));
             crate::layout::resize_panes(pane_area, &mut layout, &registry);
+            // #1140: force full redraw to clear wide-char ghost artifacts.
+            // ratatui's Buffer::diff() can leave stale spacer cells when
+            // wide chars are replaced by narrow chars across frames.
+            let _ = terminal.clear();
             needs_resize = false;
         }
         sync_notification_state(&home, &mut layout);


### PR DESCRIPTION
Closes #1140

## Problem
Scattered single-character residuals appear in panes with mixed CJK/ASCII output. Characters are spaced every 1-2 cells, persist across tab switches, disappear on mouse selection.

## Root Cause
ratatui 0.29's `Buffer::diff()` can leave stale spacer cells when CJK wide characters (2-cell) are replaced by narrow ASCII characters in subsequent frames. The terminal doesn't properly clear the wide char's right cell.

## Fix
Call `terminal.clear()` on tab switch / resize events (the `needs_resize` path). This forces ratatui to do a complete redraw on the next `draw()` call, eliminating any stale diff state.

The `needs_resize` flag is already set on: tab switches, pane splits/closes, zoom toggles, and actual terminal resizes — all the scenarios where the render layout changes and ghost artifacts could accumulate.

## Trade-off
Slightly more terminal I/O on tab switch (full screen write vs diff). Negligible — tab switches are user-initiated, infrequent events.