### PR TITLE
fix(agent): per-chunk deleted check in inject_with_target (#1146 follow-up)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1599,6 +1599,9 @@ fn inject_with_target(target: &InjectTarget, text: &[u8]) -> crate::error::Resul
         }
 
         for chunk in chunk_part.chunks(64) {
+            if target.deleted.load(std::sync::atomic::Ordering::Acquire) {
+                return Ok(());
+            }
             write_with_timeout(&target.pty_writer, chunk)?;
             std::thread::sleep(std::time::Duration::from_millis(2 * chunk.len() as u64));
         }
@@ -1609,6 +1612,9 @@ fn inject_with_target(target: &InjectTarget, text: &[u8]) -> crate::error::Resul
         write_with_timeout(&target.pty_writer, &combined)?;
     }
 
+    if target.deleted.load(std::sync::atomic::Ordering::Acquire) {
+        return Ok(());
+    }
     std::thread::sleep(std::time::Duration::from_millis(50));
     write_with_timeout(&target.pty_writer, submit)?;
     Ok(())


### PR DESCRIPTION
## Summary
- Adds `deleted.load(Acquire)` check before each 64-byte chunk in the typed_inject loop, so in-flight injects stop at the next chunk boundary when the agent is deleted
- Adds the same check before the submit key write, preventing a stale Enter keystroke after deletion
- Follow-up to PR #1150 which introduced `InjectTarget` with an initial deleted check at function entry

## Test plan
- [x] Existing `inject_with_target_skips_deleted_agent_1146` test passes (covers entry-point check)
- [x] `cargo test --bin agend-terminal -- agent::tests` — 50 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)