### PR TITLE
fix(backend): address review findings M1-M3

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -94,7 +94,6 @@ impl Backend {
     /// `$SHELL` (falling back to the platform default — `/bin/bash` on Unix,
     /// `cmd.exe` on Windows). For [`Backend::Raw`] returns the literal stored
     /// path. For presets returns the static preset command.
-    #[allow(dead_code)] // Call sites migrate in follow-up commits.
     pub fn command_string(&self) -> String {
         match self {
             Backend::ClaudeCode
@@ -488,6 +487,8 @@ impl Backend {
     }
 
     /// Try to detect backend from a command string (matches basename, not full path).
+    /// Prefix matching (e.g. `claude-*`) handles versioned binaries like `claude-2.1.89`.
+    /// This is intentionally broader than `parse_str`, which only accepts exact names.
     pub fn from_command(command: &str) -> Option<Backend> {
         let basename = std::path::Path::new(command)
             .file_name()

--- a/src/backend_harness.rs
+++ b/src/backend_harness.rs
@@ -48,7 +48,9 @@ impl CapabilityMatrix {
             ("kiro-cli", ""),
             ("codex", ""),
             ("claude", "LLM context not tied to PTY buffer (known gap)"),
+            ("opencode", ""),
             ("gemini", ""),
+            ("agy", ""),
         ] {
             backends.insert(
                 name.into(),
@@ -355,7 +357,7 @@ mod tests {
     #[test]
     fn test_capability_matrix_serializes_with_split_columns() {
         let matrix = CapabilityMatrix::new();
-        assert_eq!(matrix.backends.len(), 4);
+        assert_eq!(matrix.backends.len(), 6);
         // All start unverified
         for b in matrix.backends.values() {
             assert_eq!(b.esc_semantics_verified, CapabilityLevel::Unverified);


### PR DESCRIPTION
## Summary
- **M1**: Add OpenCode + Agy to `CapabilityMatrix::new()` — previously only 4/6 backends were tracked, silently excluding these two from harness capability probes
- **M2**: Remove stale `#[allow(dead_code)]` from `command_string()` — has a live caller in `fleet.rs:354`
- **M3**: Document `from_command` prefix matching intent — handles versioned binaries like `claude-2.1.89`

Closes #1157

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --bin agend-terminal -- backend` — 84 passed, 0 failed
- [x] Updated `test_capability_matrix_serializes_with_split_columns` assertion from 4 → 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)