### PR TITLE
fix(agent): bounded subscriber, Builder spawn, id-based metadata cleanup (#1157)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1392,7 +1392,9 @@ pub fn try_dismiss_dialog(
             let agent = name.to_string();
             // fire-and-forget: dialog-dismiss keystroke writer is short-lived
             // (sleep 300ms then write). H2: removes from in-flight set on exit.
-            std::thread::spawn(move || {
+            if std::thread::Builder::new()
+                .name("dismiss-dialog".into())
+                .spawn(move || {
                 std::thread::sleep(std::time::Duration::from_millis(300));
                 // Send keys in chunks split on \r/\n boundaries with delay between,
                 // so TUI frameworks process navigation before confirmation.
@@ -1421,7 +1423,12 @@ pub fn try_dismiss_dialog(
                 tracing::debug!(agent = %agent, "dismiss keystrokes sent");
                 // H2: remove from in-flight set
                 DISMISS_IN_FLIGHT.lock().remove(&agent);
-            });
+            })
+                .is_err()
+            {
+                tracing::warn!(agent = name, "failed to spawn dismiss-dialog thread");
+                DISMISS_IN_FLIGHT.lock().remove(name);
+            }
             return true;
         }
         // Step 4 (Issue #468): operator-visibility log when the literal hint
@@ -1697,7 +1704,7 @@ pub fn broadcast_registry(
 pub fn subscribe_with_dump(agent: &AgentHandle) -> (crossbeam_channel::Receiver<Vec<u8>>, Vec<u8>) {
     let mut core = agent.core.lock();
     let dump = core.vterm.dump_screen();
-    let (tx, rx) = crossbeam_channel::unbounded();
+    let (tx, rx) = crossbeam_channel::bounded(1024);
     core.subscribers.push(tx);
     (rx, dump)
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1395,35 +1395,35 @@ pub fn try_dismiss_dialog(
             if std::thread::Builder::new()
                 .name("dismiss-dialog".into())
                 .spawn(move || {
-                std::thread::sleep(std::time::Duration::from_millis(300));
-                // Send keys in chunks split on \r/\n boundaries with delay between,
-                // so TUI frameworks process navigation before confirmation.
-                let mut w = writer.lock();
-                let mut start = 0;
-                for (i, &b) in keys.iter().enumerate() {
-                    if b == b'\r' || b == b'\n' {
-                        // Send everything up to (not including) this Enter
-                        if start < i {
-                            let _ = w.write_all(&keys[start..i]);
+                    std::thread::sleep(std::time::Duration::from_millis(300));
+                    // Send keys in chunks split on \r/\n boundaries with delay between,
+                    // so TUI frameworks process navigation before confirmation.
+                    let mut w = writer.lock();
+                    let mut start = 0;
+                    for (i, &b) in keys.iter().enumerate() {
+                        if b == b'\r' || b == b'\n' {
+                            // Send everything up to (not including) this Enter
+                            if start < i {
+                                let _ = w.write_all(&keys[start..i]);
+                                let _ = w.flush();
+                                drop(w);
+                                std::thread::sleep(std::time::Duration::from_millis(200));
+                                w = writer.lock();
+                            }
+                            // Send the Enter
+                            let _ = w.write_all(&keys[i..=i]);
                             let _ = w.flush();
-                            drop(w);
-                            std::thread::sleep(std::time::Duration::from_millis(200));
-                            w = writer.lock();
+                            start = i + 1;
                         }
-                        // Send the Enter
-                        let _ = w.write_all(&keys[i..=i]);
-                        let _ = w.flush();
-                        start = i + 1;
                     }
-                }
-                if start < keys.len() {
-                    let _ = w.write_all(&keys[start..]);
-                    let _ = w.flush();
-                }
-                tracing::debug!(agent = %agent, "dismiss keystrokes sent");
-                // H2: remove from in-flight set
-                DISMISS_IN_FLIGHT.lock().remove(&agent);
-            })
+                    if start < keys.len() {
+                        let _ = w.write_all(&keys[start..]);
+                        let _ = w.flush();
+                    }
+                    tracing::debug!(agent = %agent, "dismiss keystrokes sent");
+                    // H2: remove from in-flight set
+                    DISMISS_IN_FLIGHT.lock().remove(&agent);
+                })
                 .is_err()
             {
                 tracing::warn!(agent = name, "failed to spawn dismiss-dialog thread");

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -317,8 +317,21 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
     }
 
     // Always clean up metadata (regardless of workspace vs user dir)
-    let meta = home.join("metadata").join(format!("{name}.json"));
-    let _ = std::fs::remove_file(&meta);
+    let meta_dir = home.join("metadata");
+    // #1157: also clean id-based metadata (Sprint 46 P2 symlink/copy).
+    // Best-effort: fleet.yaml may already be removed by caller.
+    if let Some(id_path) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+        .ok()
+        .and_then(|c| {
+            c.instances
+                .get(name)
+                .and_then(|i| i.id.as_deref())
+                .map(|id| meta_dir.join(format!("{id}.json")))
+        })
+    {
+        let _ = std::fs::remove_file(&id_path);
+    }
+    let _ = std::fs::remove_file(meta_dir.join(format!("{name}.json")));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -61,6 +61,11 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
                 .map(|r| (r.topic_id, r.working_directory))
         })
         .unwrap_or((None, None));
+    // #1157: extract InstanceId before fleet.yaml removal for id-based metadata cleanup.
+    let instance_id = fleet
+        .as_ref()
+        .and_then(|c| c.instances.get(name))
+        .and_then(|i| i.id.clone());
 
     // Sprint 54 P1-B Bug 1: collect per-step errors instead of silently
     // swallowing them. Each cleanup step runs best-effort so even when
@@ -84,6 +89,11 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     }
     if let Some(ref wd) = working_dir {
         cleanup_working_dir(home, name, wd);
+    }
+    // #1157: clean id-based metadata. Fleet.yaml is already removed above,
+    // so cleanup_working_dir's best-effort lookup may miss the id path.
+    if let Some(ref id) = instance_id {
+        let _ = std::fs::remove_file(home.join("metadata").join(format!("{id}.json")));
     }
     crate::teams::remove_member_from_all(home, name);
 


### PR DESCRIPTION
## Summary
- `subscribe_with_dump`: `crossbeam_channel::unbounded()` → `bounded(1024)` — prevents unbounded memory growth when a TUI subscriber stalls (matches router subscriber at `agent.rs:794`)
- `try_dismiss_dialog`: bare `std::thread::spawn` → `Builder::new().name("dismiss-dialog")` — adds thread name for debuggability, returns `Result` instead of panicking on spawn failure, cleans in-flight guard on error
- `cleanup_working_dir` + `full_delete_instance`: also removes `metadata/<InstanceId>.json` (Sprint 46 P2 symlink/copy) on instance deletion — two-site fix: best-effort fleet.yaml lookup in `cleanup_working_dir` for deployment callers, pre-extraction of id in `full_delete_instance` for the main delete path where fleet.yaml is already removed

## Test plan
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo test` — all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)