### PR TITLE
feat(task): add action=activity for task timeline

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -144,9 +144,9 @@ fn decision_tools() -> Vec<Value> {
 
 fn task_tools() -> Vec<Value> {
     vec![
-        json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (4 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
+        json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health, activity. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (4 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
             "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health"]},
+                "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health", "activity"]},
                 "title": {"type": "string"}, "description": {"type": "string"},
                 "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
                 "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}},

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -818,6 +818,38 @@ pub fn replay(home: &Path) -> anyhow::Result<TaskBoardState> {
     Ok(state)
 }
 
+/// Return all task event envelopes for a given `task_id`, sorted chronologically.
+/// Used by `task action=activity` to build a timeline.
+pub fn envelopes_for_task(home: &Path, task_id: &str) -> anyhow::Result<Vec<TaskEventEnvelope>> {
+    let tid = TaskId(task_id.to_string());
+    let mut all = Vec::new();
+
+    let archive = archive_dir(home);
+    if archive.is_dir() {
+        let mut archives: Vec<std::path::PathBuf> = std::fs::read_dir(&archive)?
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("jsonl"))
+            .collect();
+        archives.sort();
+        for path in archives {
+            let mut envs = Vec::new();
+            read_envelopes_strict(&path, &mut envs)?;
+            all.extend(envs.into_iter().filter(|e| *e.event.task_id() == tid));
+        }
+    }
+
+    let lp = log_path(home);
+    if lp.exists() {
+        let mut envs = Vec::new();
+        read_envelopes_strict(&lp, &mut envs)?;
+        all.extend(envs.into_iter().filter(|e| *e.event.task_id() == tid));
+    }
+
+    sort_envelopes(&mut all);
+    Ok(all)
+}
+
 /// Sort envelopes by timestamp (absolute nanos) → instance → seq.
 fn sort_envelopes(envelopes: &mut [TaskEventEnvelope]) {
     envelopes.sort_by(|a, b| {

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -677,6 +677,109 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             };
             build_health_response(&state, live.as_ref(), &fleet_instances)
         }
+        "activity" => {
+            let task_id = match args["id"].as_str().filter(|s| !s.is_empty()) {
+                Some(id) => id,
+                None => return serde_json::json!({"error": "missing 'id'"}),
+            };
+            activity_timeline(home, task_id)
+        }
         _ => serde_json::json!({"error": format!("unknown action: {action}")}),
+    }
+}
+
+/// #1147: Build a chronological activity timeline for a task.
+fn activity_timeline(home: &Path, task_id: &str) -> Value {
+    let envelopes = match crate::task_events::envelopes_for_task(home, task_id) {
+        Ok(e) => e,
+        Err(e) => return serde_json::json!({"error": format!("failed to read task events: {e}")}),
+    };
+
+    let events: Vec<Value> = envelopes
+        .iter()
+        .map(|env| {
+            let (event_type, actor, summary) = summarize_event(env);
+            serde_json::json!({
+                "timestamp": env.timestamp,
+                "actor": actor,
+                "event_type": event_type,
+                "summary": summary,
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "task_id": task_id,
+        "events": events,
+        "count": events.len(),
+    })
+}
+
+fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String, String) {
+    use crate::task_events::TaskEvent;
+    let actor = env.instance.0.clone();
+    match &env.event {
+        TaskEvent::Created {
+            title,
+            branch,
+            owner,
+            ..
+        } => {
+            let assignee = owner.as_ref().map(|o| o.0.as_str()).unwrap_or("unassigned");
+            let br = branch.as_deref().unwrap_or("");
+            let summary = if br.is_empty() {
+                format!("created task: {title} (assignee: {assignee})")
+            } else {
+                format!("created task: {title} (assignee: {assignee}, branch: {br})")
+            };
+            ("created", actor, summary)
+        }
+        TaskEvent::Claimed { by, .. } => ("claimed", by.0.clone(), "claimed task".to_string()),
+        TaskEvent::InProgress { by, .. } => {
+            ("in_progress", by.0.clone(), "started work".to_string())
+        }
+        TaskEvent::Verified { by_reviewer, .. } => {
+            ("verified", by_reviewer.0.clone(), "verified".to_string())
+        }
+        TaskEvent::Done { source, .. } => {
+            let detail = match source {
+                crate::task_events::DoneSource::PrMerged { pr_id, .. } => {
+                    format!("done (PR {} merged)", pr_id)
+                }
+                crate::task_events::DoneSource::OperatorManual { result, .. } => {
+                    format!(
+                        "done{}",
+                        result
+                            .as_ref()
+                            .map(|r| format!(": {r}"))
+                            .unwrap_or_default()
+                    )
+                }
+                _ => "done".to_string(),
+            };
+            ("done", actor, detail)
+        }
+        TaskEvent::Cancelled { by, reason, .. } => {
+            ("cancelled", by.0.clone(), format!("cancelled: {reason}"))
+        }
+        TaskEvent::Blocked { reason, .. } => ("blocked", actor, format!("blocked: {reason}")),
+        TaskEvent::Unblocked { .. } => ("unblocked", actor, "unblocked".to_string()),
+        TaskEvent::Reopened { reason, .. } => ("reopened", actor, format!("reopened: {reason}")),
+        TaskEvent::Released { reason, .. } => {
+            ("released", actor, format!("released claim: {reason}"))
+        }
+        TaskEvent::Linked { pr_id, .. } => ("linked", actor, format!("linked PR {pr_id}")),
+        TaskEvent::TaskCloseProposed { .. } => (
+            "close_proposed",
+            actor,
+            "close proposed by sweep".to_string(),
+        ),
+        TaskEvent::OwnerAssigned { owner, .. } => {
+            let o = owner.as_ref().map(|n| n.0.as_str()).unwrap_or("none");
+            ("owner_assigned", actor, format!("assigned to {o}"))
+        }
+        TaskEvent::PriorityChanged { priority, .. } => {
+            ("priority_changed", actor, format!("priority → {priority}"))
+        }
     }
 }

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -2701,3 +2701,51 @@ fn test_task_deserialize_dispatched_at_alias_preserves_back_compat() {
         "serde alias must map legacy `dispatched_at` → new `started_at`"
     );
 }
+
+/// #1147: task action=activity returns chronological timeline.
+#[test]
+fn activity_timeline_returns_events_for_task() {
+    let home = tmp_home("activity-timeline");
+    // Create a task.
+    let create_result = super::handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "create",
+            "title": "implement widget",
+            "assignee": "dev",
+            "branch": "feat/widget",
+        }),
+    );
+    let task_id = create_result["id"].as_str().unwrap();
+    // Claim it.
+    super::handle(
+        &home,
+        "dev",
+        &serde_json::json!({"action": "claim", "id": task_id}),
+    );
+    // Mark done.
+    super::handle(
+        &home,
+        "dev",
+        &serde_json::json!({"action": "done", "id": task_id, "result": "PR merged"}),
+    );
+    // Query activity timeline.
+    let result = super::handle(
+        &home,
+        "lead",
+        &serde_json::json!({"action": "activity", "id": task_id}),
+    );
+    assert_eq!(result["task_id"].as_str(), Some(task_id));
+    let events = result["events"].as_array().expect("events array");
+    assert_eq!(
+        events.len(),
+        3,
+        "expected 3 events (created+claimed+done): {events:?}"
+    );
+    assert_eq!(events[0]["event_type"].as_str(), Some("created"));
+    assert_eq!(events[1]["event_type"].as_str(), Some("claimed"));
+    assert_eq!(events[2]["event_type"].as_str(), Some("done"));
+    assert_eq!(events[1]["actor"].as_str(), Some("dev"));
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
Closes #1147

## Summary
Adds `task action=activity id=<task_id>` which returns a chronological timeline of all events for a task.

## Response format
```json
{
  "task_id": "t-xxx",
  "count": 3,
  "events": [
    {"timestamp": "...", "actor": "lead", "event_type": "created", "summary": "created task: ..."},
    {"timestamp": "...", "actor": "dev", "event_type": "claimed", "summary": "claimed task"},
    {"timestamp": "...", "actor": "dev", "event_type": "done", "summary": "done: PR merged"}
  ]
}
```

## Changes
- `src/task_events.rs`: Added `pub fn envelopes_for_task()` — reads all envelopes for a task_id from archives + live log
- `src/tasks/handler.rs`: Added `activity` action + `activity_timeline()` + `summarize_event()` 
- `src/mcp/tools.rs`: Added `activity` to task action enum in MCP schema
- `src/tasks/tests.rs`: Test verifying create→claim→done produces 3 timeline events

## Data sources
Pure read aggregation from existing `task_events.jsonl` (append-only audit log). No new storage.

Closes t-20260525012712862133-6