### PR TITLE
feat(tui): add fleet dashboard view with live agent status

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -206,6 +206,16 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
                 view: super::overlay::BoardView::Tasks,
             });
         }
+        Action::ShowFleet => {
+            let items = crate::tasks::list_all(ctx.home);
+            out.new_overlay = Some(Overlay::Tasks {
+                items,
+                col: 0,
+                row: 0,
+                mode: super::overlay::TaskBoardMode::Board,
+                view: super::overlay::BoardView::Fleet,
+            });
+        }
         Action::ShowHelp => {
             out.new_overlay = Some(Overlay::Help);
         }

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -44,6 +44,7 @@ pub enum Action {
     ShowTasks,
     ShowStatus,
     ShowMonitor,
+    ShowFleet,
     Detach,
     ShowHelp,
     /// Summon a floating scratch shell overlay (Ctrl+B ~). Esc closes & kills it.
@@ -195,6 +196,7 @@ fn dispatch_prefix(key: KeyEvent) -> Action {
         KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::SHIFT) => Action::ShowDecisions,
         KeyCode::Char('s') => Action::ShowStatus,
         KeyCode::Char('m') | KeyCode::Char('M') => Action::ShowMonitor,
+        KeyCode::Char('f') | KeyCode::Char('F') => Action::ShowFleet,
         KeyCode::Char('T') | KeyCode::Char('t') => Action::ShowTasks,
         KeyCode::Char('d') if !key.modifiers.contains(KeyModifiers::SHIFT) => Action::Detach,
         KeyCode::Char('?') => Action::ShowHelp,

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -226,18 +226,24 @@ fn build_agent_line<'a>(
     agent_tasks: &std::collections::HashMap<&str, &crate::tasks::Task>,
     home: &std::path::Path,
 ) -> Line<'a> {
-    let (state, health_color) = metrics_map
+    let (state, health, health_color) = metrics_map
         .get(name)
         .map(|m| {
             let color = match m.health_state.as_str() {
                 "healthy" | "ok" => Color::Green,
-                "hung" | "crashed" | "failed" => Color::Red,
-                "rate_limit" | "recovering" => Color::Yellow,
+                "hung" | "crashed" | "failed" | "error_loop" => Color::Red,
+                "rate_limit" | "recovering" | "unstable" => Color::Yellow,
+                "idle_long" => Color::DarkGray,
+                "paused" => Color::Magenta,
                 _ => Color::White,
             };
-            (m.agent_state.as_str().to_string(), color)
+            (
+                m.agent_state.as_str().to_string(),
+                m.health_state.clone(),
+                color,
+            )
         })
-        .unwrap_or_else(|| ("stopped".to_string(), Color::DarkGray));
+        .unwrap_or_else(|| ("stopped".to_string(), "—".to_string(), Color::DarkGray));
 
     let task_str = agent_tasks
         .get(name)
@@ -263,7 +269,7 @@ fn build_agent_line<'a>(
             }),
         ),
         Span::styled(format!("{:<12}", state), Style::default().fg(health_color)),
-        Span::styled(format!("{:<10}", ""), Style::default()),
+        Span::styled(format!("{:<10}", health), Style::default().fg(health_color)),
         Span::styled(
             format!("{:<30}", task_str),
             Style::default().fg(Color::White),

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -7,6 +7,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
 /// Pure function: build fleet view text lines for testing.
+#[cfg(test)]
 pub fn build_fleet_view_lines(
     tasks: &[crate::tasks::Task],
     teams: &[crate::teams::Team],

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -155,35 +155,123 @@ pub(super) fn render_fleet_view(
             .ok()
             .map(|c| c.instance_names())
             .unwrap_or_default();
-    let text_lines = build_fleet_view_lines(tasks, &teams, &all_instances);
+    let metrics = crate::instance_monitor::latest_metrics();
 
-    let lines: Vec<Line> = if text_lines.is_empty() {
-        vec![Line::from(Span::styled(
-            "No agents configured. Add instances to fleet.yaml.",
-            Style::default().fg(Color::DarkGray),
-        ))]
-    } else {
-        text_lines
-            .iter()
-            .map(|l| {
-                let style = if l.starts_with('═') {
-                    if l.contains("unassigned") {
-                        Style::default()
-                            .fg(Color::DarkGray)
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default()
-                            .fg(Color::Cyan)
-                            .add_modifier(Modifier::BOLD)
-                    }
-                } else {
-                    Style::default().fg(Color::White)
-                };
-                Line::from(Span::styled(l.as_str(), style))
-            })
-            .collect()
-    };
+    // Build a lookup of live metrics by instance name.
+    let metrics_map: std::collections::HashMap<&str, &crate::instance_monitor::InstanceMetrics> =
+        metrics.iter().map(|m| (m.name.as_str(), m)).collect();
+
+    // Header
+    let header = Line::from(Span::styled(
+        format!(
+            " {:<16} {:<12} {:<10} {:<30} {:<20}",
+            "AGENT", "STATE", "HEALTH", "TASK", "BRANCH"
+        ),
+        Style::default()
+            .add_modifier(Modifier::BOLD)
+            .fg(Color::Cyan),
+    ));
+
+    let mut lines = vec![header];
+
+    // Build agent→task mapping
+    let mut agent_tasks: std::collections::HashMap<&str, &crate::tasks::Task> =
+        std::collections::HashMap::new();
+    for t in tasks {
+        if matches!(t.status.as_str(), "claimed" | "in_progress") {
+            if let Some(ref a) = t.assignee {
+                agent_tasks.entry(a.as_str()).or_insert(t);
+            }
+        }
+    }
+
+    // Build agent→branch from bindings
+    let mut assigned: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for team in &teams {
+        lines.push(Line::from(Span::styled(
+            format!("═══ {} ═══", team.name),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for member in &team.members {
+            assigned.insert(member.as_str());
+            lines.push(build_agent_line(member, &metrics_map, &agent_tasks, home));
+        }
+    }
+    let mut unassigned: Vec<&str> = all_instances
+        .iter()
+        .filter(|n| !assigned.contains(n.as_str()))
+        .map(String::as_str)
+        .collect();
+    unassigned.sort_unstable();
+    if !unassigned.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "═══ unassigned ═══",
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for name in &unassigned {
+            lines.push(build_agent_line(name, &metrics_map, &agent_tasks, home));
+        }
+    }
     frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn build_agent_line<'a>(
+    name: &str,
+    metrics_map: &std::collections::HashMap<&str, &crate::instance_monitor::InstanceMetrics>,
+    agent_tasks: &std::collections::HashMap<&str, &crate::tasks::Task>,
+    home: &std::path::Path,
+) -> Line<'a> {
+    let (state, health_color) = metrics_map
+        .get(name)
+        .map(|m| {
+            let color = match m.health_state.as_str() {
+                "healthy" | "ok" => Color::Green,
+                "hung" | "crashed" | "failed" => Color::Red,
+                "rate_limit" | "recovering" => Color::Yellow,
+                _ => Color::White,
+            };
+            (m.agent_state.as_str().to_string(), color)
+        })
+        .unwrap_or_else(|| ("stopped".to_string(), Color::DarkGray));
+
+    let task_str = agent_tasks
+        .get(name)
+        .map(|t| {
+            let title: String = t.title.chars().take(28).collect();
+            title
+        })
+        .unwrap_or_else(|| "—".to_string());
+
+    let branch = crate::binding::read(home, name)
+        .and_then(|v| v["branch"].as_str().map(String::from))
+        .unwrap_or_else(|| "—".to_string());
+    let branch_short: String = branch.chars().take(18).collect();
+
+    let symbol = if state == "stopped" { "○" } else { "●" };
+    Line::from(vec![
+        Span::styled(
+            format!(" {symbol} {:<15}", name),
+            Style::default().fg(if state == "stopped" {
+                Color::DarkGray
+            } else {
+                Color::White
+            }),
+        ),
+        Span::styled(format!("{:<12}", state), Style::default().fg(health_color)),
+        Span::styled(format!("{:<10}", ""), Style::default()),
+        Span::styled(
+            format!("{:<30}", task_str),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled(
+            format!("{:<20}", branch_short),
+            Style::default().fg(Color::Blue),
+        ),
+    ])
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #1143 (Phase 1)

## What
Fleet status dashboard accessible via `Ctrl+B → f`:
```
═══ sprint ═══
 ● dev            working      Fix CI dedup                  fix/1134
 ● dev2           idle                                       —
 ● reviewer       reviewing    Fix CI dedup                  fix/1134
═══ unassigned ═══
 ○ general        stopped      —                             —
```

## Changes
- `keybinds.rs`: Add `ShowFleet` action + `f/F` keybind
- `app/dispatch.rs`: Handle ShowFleet → opens Tasks overlay in Fleet view
- `render/panels_fleet.rs`: Enhanced fleet view with live metrics (agent_state, task, branch)

## Navigation
- `j/k` scroll, `t/f/s/m` switch views, `Esc/q` close
- Reuses existing overlay infrastructure (no new widget system)