### PR TITLE
fix(fleet): include topic_binding_mode in merge path (#1162)

### DIFF
--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -848,6 +848,7 @@ pub fn merge_instance_into_existing(
         ("model", &config.model),
         ("ready_pattern", &config.ready_pattern),
         ("command", &config.command),
+        ("topic_binding_mode", &config.topic_binding_mode),
     ] {
         merge_string(existing, field, value)?;
     }
@@ -3541,6 +3542,27 @@ instances:
         assert!(
             err.contains("alpha"),
             "conflict report must name the conflicting instance; got: {err}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn merge_preserves_topic_binding_mode_on_existing_instance() {
+        let home = merge_tmp_home("tbm-merge");
+        std::fs::write(
+            fleet_yaml_path(&home),
+            "instances:\n  helper:\n    backend: claude\n",
+        )
+        .unwrap();
+        let entry = InstanceYamlEntry {
+            topic_binding_mode: Some("skip".into()),
+            ..Default::default()
+        };
+        add_instances_to_yaml(&home, &[("helper", &entry)]).unwrap();
+        let v = read_yaml(&home);
+        assert_eq!(
+            v["instances"]["helper"]["topic_binding_mode"], "skip",
+            "#1162: topic_binding_mode must survive merge into existing instance"
         );
         std::fs::remove_dir_all(&home).ok();
     }


### PR DESCRIPTION
## Summary
- `merge_instance_into_existing` was missing `topic_binding_mode` in its `merge_string` field list, causing the field to be silently dropped during template re-deployments to existing instances
- `build_instance_mapping` (new-instance path) already included it — only the merge path was affected
- Added characterization test that confirms the bug (fails before fix, passes after)

## Test plan
- [x] Characterization test `merge_preserves_topic_binding_mode_on_existing_instance` — asserts topic_binding_mode survives merge into existing instance
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo test` — all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)