### PR TITLE
fix(store): harden data layer — 8-fix medium batch (#1164)

### DIFF
--- a/src/decisions.rs
+++ b/src/decisions.rs
@@ -121,14 +121,15 @@ pub fn post(home: &Path, author: &str, args: &Value) -> Value {
     let ttl_days = args["ttl_days"].as_u64();
     let supersedes = args["supersedes"].as_str().map(String::from);
 
-    let now = chrono::Utc::now().to_rfc3339();
+    let clock = chrono::Utc::now();
+    let now = clock.to_rfc3339();
     // The historical id format was seconds-precision only — two posts in the
     // same UTC second collided and the second silently overwrote the first.
     // Append nanoseconds + a process-local counter so no two posts from the
     // same process can share an id, even when issued back-to-back.
     use std::sync::atomic::{AtomicU64, Ordering};
     static ID_SEQ: AtomicU64 = AtomicU64::new(0);
-    let ts = chrono::Utc::now().format("%Y%m%d%H%M%S%6f");
+    let ts = clock.format("%Y%m%d%H%M%S%6f");
     let seq = ID_SEQ.fetch_add(1, Ordering::Relaxed);
     let id = format!("d-{ts}-{seq}");
 

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -67,30 +67,6 @@ pub fn log(home: &Path, kind: &'static str, instance: &str, detail: &str) {
     }
 }
 
-/// Append a typed event to a sister audit log (e.g. `task_events.jsonl`).
-///
-/// Locked + rotated + fsynced. Returns Err so sister modules with strict
-/// audit semantics can fail-loud rather than swallow IO errors the way
-/// [`log`] does. Future audit logs (decision_events, capability_events)
-/// reuse this primitive.
-#[allow(dead_code)]
-pub fn append<T: Serialize>(home: &Path, log_name: &str, event: &T) -> anyhow::Result<()> {
-    append_lines_under_lock(home, log_name, |_| Ok(vec![serde_json::to_string(event)?]))
-}
-
-/// Append multiple typed events under a single fsync (F7 atomic-batch
-/// pattern). Either all events land or none do — readers never observe a
-/// partial-write window.
-#[allow(dead_code)]
-pub fn append_batch<T: Serialize>(home: &Path, log_name: &str, events: &[T]) -> anyhow::Result<()> {
-    append_lines_under_lock(home, log_name, |_| {
-        events
-            .iter()
-            .map(|e| serde_json::to_string(e).map_err(anyhow::Error::from))
-            .collect()
-    })
-}
-
 /// Lower-level primitive used by sister modules that need read access to
 /// existing log content under the same lock as the write — for example
 /// `task_events::append` computes a monotonic per-instance sequence number

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -415,7 +415,9 @@ impl FleetConfig {
                 return None;
             }
             // Expand ~ to home directory
-            if let Some(rest) = d.strip_prefix("~/") {
+            if d == "~" {
+                dirs_home().unwrap_or_else(|| PathBuf::from(d))
+            } else if let Some(rest) = d.strip_prefix("~/") {
                 if let Some(home) = dirs_home() {
                     home.join(rest)
                 } else {
@@ -548,7 +550,7 @@ impl FleetConfig {
                     }
                 }
             }
-            Ok(())
+            Ok(!assigned_ref.is_empty())
         }) {
             tracing::warn!(error = %e, "backfill_ids: locked write failed");
             return;
@@ -685,10 +687,12 @@ fn acquire_lock(home: &Path) -> Result<std::fs::File> {
 }
 
 /// Lock fleet.yaml, parse it, apply a mutation, and atomically write back.
+/// The closure returns `Ok(true)` when it changed the doc (triggers write)
+/// or `Ok(false)` when the mutation was a no-op (skips write).
 fn mutate_fleet_yaml(
     home: &Path,
     default_content: &str,
-    mutate: impl FnOnce(&mut serde_yaml_ng::Value) -> Result<()>,
+    mutate: impl FnOnce(&mut serde_yaml_ng::Value) -> Result<bool>,
 ) -> Result<()> {
     let fleet_path = fleet_yaml_path(home);
     if default_content.is_empty() && !fleet_path.exists() {
@@ -699,8 +703,12 @@ fn mutate_fleet_yaml(
         std::fs::read_to_string(&fleet_path).unwrap_or_else(|_| default_content.to_string());
     let mut doc: serde_yaml_ng::Value =
         serde_yaml_ng::from_str(&content).context("Failed to parse fleet.yaml")?;
-    mutate(&mut doc)?;
-    atomic_write_yaml(home, &doc)
+    let changed = mutate(&mut doc)?;
+    if changed {
+        atomic_write_yaml(home, &doc)
+    } else {
+        Ok(())
+    }
 }
 
 /// Add a new instance entry to fleet.yaml. Uses file lock + atomic write.
@@ -1014,10 +1022,10 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
             // merge into it per the 3-tier rules. Otherwise, build a
             // fresh mapping.
             if let Some(serde_yaml_ng::Value::Mapping(existing)) = instances.get_mut(&key) {
-                if let Err(conflict) = merge_instance_into_existing(name, existing, config) {
-                    conflicts.push(conflict);
+                match merge_instance_into_existing(name, existing, config) {
+                    Ok(()) => tracing::info!(%name, "merged instance update into fleet.yaml"),
+                    Err(conflict) => conflicts.push(conflict),
                 }
-                tracing::info!(%name, "merged instance update into fleet.yaml");
             } else {
                 let inst = build_instance_mapping(config);
                 instances.insert(key, serde_yaml_ng::Value::Mapping(inst));
@@ -1039,7 +1047,7 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
                 diff_lines.join("\n")
             ));
         }
-        Ok(())
+        Ok(true)
     })
 }
 
@@ -1050,7 +1058,7 @@ pub fn remove_instance_from_yaml(home: &Path, name: &str) -> Result<()> {
             instances.remove(serde_yaml_ng::Value::String(name.to_string()));
         }
         tracing::info!(%name, "removed instance from fleet.yaml");
-        Ok(())
+        Ok(true)
     })
 }
 
@@ -1065,7 +1073,7 @@ pub fn remove_instances_from_yaml(home: &Path, names: &[String]) -> Result<()> {
                 instances.remove(serde_yaml_ng::Value::String(name.clone()));
             }
         }
-        Ok(())
+        Ok(true)
     })
 }
 
@@ -1092,9 +1100,10 @@ pub fn update_channel_telegram_group_id(home: &Path, new_group_id: i64) -> Resul
                     serde_yaml_ng::Value::Number(new_group_id.into()),
                 );
                 tracing::info!(new_group_id, "fleet.yaml channel.group_id rewritten");
+                return Ok(true);
             }
         }
-        Ok(())
+        Ok(false)
     })
 }
 
@@ -1139,20 +1148,20 @@ pub fn update_instance_field(
     mutate_fleet_yaml(home, "", |doc| {
         let Some(instances) = doc.get_mut("instances").and_then(|v| v.as_mapping_mut()) else {
             skip_reason = Some("instances_section_missing");
-            return Ok(());
+            return Ok(false);
         };
         let key = serde_yaml_ng::Value::String(name.to_string());
         let Some(inst_val) = instances.get_mut(&key) else {
             skip_reason = Some("instance_entry_missing");
-            return Ok(());
+            return Ok(false);
         };
         let Some(inst) = inst_val.as_mapping_mut() else {
             skip_reason = Some("instance_entry_not_mapping");
-            return Ok(());
+            return Ok(false);
         };
         inst.insert(serde_yaml_ng::Value::String(field.to_string()), value);
         persisted = true;
-        Ok(())
+        Ok(true)
     })?;
     if !persisted {
         tracing::warn!(
@@ -1225,7 +1234,7 @@ pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<
             .context("teams is not a mapping")?;
         let key = serde_yaml_ng::Value::String(name.to_string());
         if teams.contains_key(&key) {
-            return Ok(());
+            return Ok(false);
         }
         teams.insert(
             key,
@@ -1233,7 +1242,7 @@ pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<
         );
         inserted = true;
         tracing::info!(%name, "added team to fleet.yaml");
-        Ok(())
+        Ok(true)
     })?;
     Ok(inserted)
 }
@@ -1253,7 +1262,7 @@ pub fn remove_team_from_yaml(home: &Path, name: &str) -> Result<bool> {
                 tracing::info!(%name, "removed team from fleet.yaml");
             }
         }
-        Ok(())
+        Ok(removed)
     })?;
     Ok(removed)
 }
@@ -1277,7 +1286,7 @@ pub fn update_team_in_yaml(home: &Path, name: &str, config: &TeamConfig) -> Resu
                 existed = true;
             }
         }
-        Ok(())
+        Ok(existed)
     })?;
     Ok(existed)
 }

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -115,7 +115,22 @@ fn upsert_mcp_servers(path: &Path, instance_name: Option<&str>) -> Result<()> {
 
     let mut config: serde_json::Value = if path.exists() {
         let content = std::fs::read_to_string(path)?;
-        serde_json::from_str(&content).unwrap_or(json!({}))
+        match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "malformed MCP config JSON, backing up and starting fresh"
+                );
+                let backup = path.with_extension(format!(
+                    "corrupt.{}",
+                    chrono::Utc::now().format("%Y%m%d%H%M%S")
+                ));
+                let _ = std::fs::copy(path, &backup);
+                json!({})
+            }
+        }
     } else {
         json!({})
     };

--- a/src/store.rs
+++ b/src/store.rs
@@ -191,7 +191,19 @@ pub fn load_versioned<T: DeserializeOwned + Default>(path: &Path, current_versio
     // / corrupt fallbacks.
     let peek: serde_json::Value = match serde_json::from_str(&content) {
         Ok(v) => v,
-        Err(_) => return T::default(),
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "load_versioned: corrupt JSON, returning default — backing up corrupt file"
+            );
+            let backup = path.with_extension(format!(
+                "corrupt.{}",
+                chrono::Utc::now().format("%Y%m%d%H%M%S")
+            ));
+            let _ = std::fs::copy(path, &backup);
+            return T::default();
+        }
     };
     let version = peek
         .get("schema_version")

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -25,7 +25,7 @@
 // consumers land — see the anti-bypass invariant in
 // `tests/task_events_invariant.rs` for the contract that no other
 // caller may reference the log directly.
-#![allow(dead_code)]
+// #1164: module-level #![allow(dead_code)] removed; targeted allows below.
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -53,6 +53,7 @@ use std::path::{Path, PathBuf};
 pub const SCHEMA_VERSION: u32 = 2;
 
 /// Hot-file event count above which [`compact`] archives the older slice.
+#[allow(dead_code)]
 pub const COMPACTION_KEEP: usize = 10_000;
 
 /// Sister-module log basename used with [`crate::event_log::append`] +
@@ -66,6 +67,7 @@ const LOG_NAME: &str = "task_events";
 pub struct TaskId(pub String);
 
 impl TaskId {
+    #[allow(dead_code)]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -899,6 +901,7 @@ fn read_envelopes_strict(path: &Path, out: &mut Vec<TaskEventEnvelope>) -> anyho
 /// short-circuits when the hot log already fits the threshold. Holds the
 /// same lock as [`append`] so concurrent appenders see a consistent
 /// hot-file at all times.
+#[allow(dead_code)]
 pub fn compact(home: &Path) -> anyhow::Result<()> {
     let log_path = log_path(home);
     if !log_path.exists() {


### PR DESCRIPTION
## Summary

Closes #1164 — 8 fixes across 6 files in the store & data layer:

- **fleet.rs**: bare `~` tilde expansion, merge log moved to success branch, `mutate_fleet_yaml` returns `Result<bool>` to skip no-op disk writes (all 9 callers updated)
- **task_events.rs**: module-level `#![allow(dead_code)]` replaced with 3 targeted allows
- **event_log.rs**: removed dead `append`/`append_batch` functions (only `append_lines_under_lock` is used)
- **decisions.rs**: merged double `Utc::now()` into single clock capture
- **store.rs**: `load_versioned` now backs up corrupt files before returning default (matching `load()` pattern)
- **mcp_config.rs**: `upsert_mcp_servers` warns + backs up malformed JSON instead of silent `unwrap_or(json!({}))`

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test` — all 42 tests pass
- [x] Verified all 9 `mutate_fleet_yaml` callers return correct `bool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)