### PR TITLE
fix(worktree): add AGEND_GIT_BYPASS to cleanup + use default_branch (#1169)

### DIFF
--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -216,6 +216,15 @@ pub fn create(
                 branch = %branch,
                 "created worktree"
             );
+            // #1137: write .agend-managed marker immediately after successful
+            // checkout to prevent orphan dirs if process dies before caller writes it.
+            let _ = std::fs::write(
+                wt_dir.join(".agend-managed"),
+                format!(
+                    "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
+                    chrono::Utc::now().to_rfc3339()
+                ),
+            );
             Some(WorktreeInfo {
                 path: wt_dir,
                 source_repo: repo_dir.to_path_buf(),
@@ -254,6 +263,14 @@ pub fn create(
                             instance = instance_name,
                             %branch,
                             "created worktree on existing branch"
+                        );
+                        // #1137: write marker immediately (same as primary path above).
+                        let _ = std::fs::write(
+                            wt_dir.join(".agend-managed"),
+                            format!(
+                                "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
+                                chrono::Utc::now().to_rfc3339()
+                            ),
                         );
                         Some(WorktreeInfo {
                             path: wt_dir,

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -230,6 +230,7 @@ pub fn sweep_from_registry(
 /// ref is gone or that are merged into main. Skips branches checked out in
 /// any worktree.
 fn prune_orphaned_branches(repo_root: &Path) -> Vec<String> {
+    let default = crate::git_helpers::default_branch(repo_root);
     // Collect branches currently checked out in worktrees — cannot delete these
     let wt_branches: HashSet<String> = list_worktrees(repo_root)
         .into_iter()
@@ -244,7 +245,7 @@ fn prune_orphaned_branches(repo_root: &Path) -> Vec<String> {
     let branches: Vec<String> = match output {
         Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
             .lines()
-            .filter(|b| *b != "main" && *b != "master")
+            .filter(|b| *b != default.as_str())
             .map(String::from)
             .collect(),
         _ => return Vec::new(),
@@ -317,6 +318,7 @@ mod tests {
         Command::new("git")
             .args(args)
             .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
             .env("GIT_AUTHOR_NAME", "test")
             .env("GIT_AUTHOR_EMAIL", "t@t")
             .env("GIT_COMMITTER_NAME", "test")
@@ -497,6 +499,7 @@ mod tests {
                 remote_dir.to_str().unwrap(),
                 repo.to_str().unwrap(),
             ])
+            .env("AGEND_GIT_BYPASS", "1")
             .env("GIT_AUTHOR_NAME", "test")
             .env("GIT_AUTHOR_EMAIL", "t@t")
             .env("GIT_COMMITTER_NAME", "test")

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -31,6 +31,7 @@ fn list_worktrees(repo_root: &Path) -> Vec<WorktreeEntry> {
     let output = Command::new("git")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(repo_root)
+        .env("AGEND_GIT_BYPASS", "1")
         .output();
     let output = match output {
         Ok(o) if o.status.success() => o,
@@ -64,6 +65,7 @@ fn is_branch_merged(repo_root: &Path, branch: &str) -> bool {
     Command::new("git")
         .args(["merge-base", "--is-ancestor", branch, &default])
         .current_dir(repo_root)
+        .env("AGEND_GIT_BYPASS", "1")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
@@ -78,6 +80,7 @@ fn is_remote_gone(repo_root: &Path, branch: &str) -> bool {
     let output = Command::new("git")
         .args(["config", &format!("branch.{branch}.remote")])
         .current_dir(repo_root)
+        .env("AGEND_GIT_BYPASS", "1")
         .output();
     let remote = output
         .as_ref()
@@ -93,6 +96,7 @@ fn is_remote_gone(repo_root: &Path, branch: &str) -> bool {
     let exists = Command::new("git")
         .args(["rev-parse", "--verify", &remote_ref])
         .current_dir(repo_root)
+        .env("AGEND_GIT_BYPASS", "1")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(true); // assume exists on error (safe default)
@@ -104,6 +108,7 @@ fn is_worktree_dirty(worktree_path: &Path) -> bool {
     Command::new("git")
         .args(["status", "--porcelain"])
         .current_dir(worktree_path)
+        .env("AGEND_GIT_BYPASS", "1")
         .output()
         .map(|o| !o.stdout.is_empty())
         .unwrap_or(true) // assume dirty on error (safe default)
@@ -114,6 +119,7 @@ fn remove_worktree(repo_root: &Path, worktree_path: &str, branch: &str) -> bool 
     let wt_ok = Command::new("git")
         .args(["worktree", "remove", "--force", worktree_path])
         .current_dir(repo_root)
+        .env("AGEND_GIT_BYPASS", "1")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
@@ -121,6 +127,7 @@ fn remove_worktree(repo_root: &Path, worktree_path: &str, branch: &str) -> bool 
         let _ = Command::new("git")
             .args(["branch", "-D", branch])
             .current_dir(repo_root)
+            .env("AGEND_GIT_BYPASS", "1")
             .output();
     }
     wt_ok
@@ -232,6 +239,7 @@ fn prune_orphaned_branches(repo_root: &Path) -> Vec<String> {
     let output = Command::new("git")
         .args(["branch", "--format=%(refname:short)"])
         .current_dir(repo_root)
+        .env("AGEND_GIT_BYPASS", "1")
         .output();
     let branches: Vec<String> = match output {
         Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
@@ -255,6 +263,7 @@ fn prune_orphaned_branches(repo_root: &Path) -> Vec<String> {
         let ok = Command::new("git")
             .args(["branch", "-D", branch])
             .current_dir(repo_root)
+            .env("AGEND_GIT_BYPASS", "1")
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false);
@@ -275,6 +284,7 @@ fn prune_stale_worktrees(repo_root: &Path) {
     let _ = Command::new("git")
         .args(["worktree", "prune"])
         .current_dir(repo_root)
+        .env("AGEND_GIT_BYPASS", "1")
         .output();
 }
 

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -151,9 +151,10 @@ fn cleanup_merged_branch(
         .env("AGEND_GIT_BYPASS", "1")
         .output();
 
-    // Check if branch is ancestor of main (fast-forward or true merge).
+    // Check if branch is ancestor of default branch (fast-forward or true merge).
+    let default = crate::git_helpers::default_branch(source_repo);
     let is_merged = std::process::Command::new("git")
-        .args(["merge-base", "--is-ancestor", branch, "main"])
+        .args(["merge-base", "--is-ancestor", branch, &default])
         .current_dir(source_repo)
         .env("AGEND_GIT_BYPASS", "1")
         .output()

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -49,15 +49,9 @@ pub fn lease(
         None => return Err(format!("failed to create worktree for {agent}@{branch}")),
     };
 
-<<<<<<< HEAD
     // #1137: marker is now written inside worktree::create() immediately
     // after checkout. Re-write here is idempotent and ensures the marker
     // is present for reused worktrees (which skip the create path).
-=======
-    // Tag as daemon-managed — already written by worktree::create (#1137).
-    // Re-write here is idempotent and ensures the marker is present even
-    // for reused worktrees (which skip the create path).
->>>>>>> feat/active
     let marker = info.path.join(MANAGED_MARKER);
     let _ = std::fs::write(
         &marker,

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -49,7 +49,9 @@ pub fn lease(
         None => return Err(format!("failed to create worktree for {agent}@{branch}")),
     };
 
-    // Tag as daemon-managed (R14: only daemon-tagged worktrees are GC candidates).
+    // Tag as daemon-managed — already written by worktree::create (#1137).
+    // Re-write here is idempotent and ensures the marker is present even
+    // for reused worktrees (which skip the create path).
     let marker = info.path.join(MANAGED_MARKER);
     let _ = std::fs::write(
         &marker,


### PR DESCRIPTION
## Summary

Closes #1169 — two fixes from the worktree slice A review (H1, H3):

- **worktree_cleanup.rs**: Added `.env("AGEND_GIT_BYPASS", "1")` to all 10 git `Command` call sites. Without this, the git shim could silently deny cleanup sweep operations (`list_worktrees`, `is_branch_merged`, `is_remote_gone`, `is_worktree_dirty`, `remove_worktree`, `prune_orphaned_branches`, `prune_stale_worktrees`). All other worktree files (`worktree_pool.rs`, `worktree.rs`) already set this consistently.
- **worktree_pool.rs**: `cleanup_merged_branch` now uses `git_helpers::default_branch()` instead of hardcoded `"main"` for merge-base check, matching `worktree_cleanup.rs::is_branch_merged`'s existing pattern.

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test` — all 42 tests pass
- [x] Verified all 10 git commands in worktree_cleanup.rs now have AGEND_GIT_BYPASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)