### PR TITLE
fix(instance,worktree): harden 9 medium-priority items #1171

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -387,7 +387,7 @@ pub(crate) fn handle_pane_snapshot(params: &Value, ctx: &HandlerCtx) -> Value {
         Some(n) => n,
         None => return json!({"ok": false, "error": "missing 'name'"}),
     };
-    let lines = params["lines"].as_u64().unwrap_or(100) as usize;
+    let lines = (params["lines"].as_u64().unwrap_or(100) as usize).min(10_000);
     let reg = agent::lock_registry(ctx.registry);
     let handle = match reg.get(name) {
         Some(h) => h,

--- a/src/instance_monitor.rs
+++ b/src/instance_monitor.rs
@@ -139,7 +139,7 @@ fn tree_rss(sys: &sysinfo::System, root: sysinfo::Pid) -> u64 {
 
 /// Read heartbeat lag and pending pickup count from metadata JSON.
 fn read_metadata_metrics(home: &std::path::Path, name: &str) -> (Option<u64>, usize) {
-    let meta_path = home.join("metadata").join(format!("{name}.json"));
+    let meta_path = crate::agent_ops::metadata_path_resolved(home, name);
     let content = match std::fs::read_to_string(meta_path) {
         Ok(c) => c,
         Err(_) => return (None, 0),

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -291,8 +291,8 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
         &json!({"method": crate::api::method::DELETE, "params": {"name": name}}),
     );
 
-    // Brief pause after kill to let OS reclaim resources (ports, file locks)
-    // before spawning the replacement. Prevents startup race on fast exits.
+    // TODO: replace hardcoded 500ms sleep with event-driven readiness check
+    // (e.g. poll until PID is gone or port is free).
     std::thread::sleep(std::time::Duration::from_millis(500));
 
     // Enqueue handover context for the new instance.
@@ -350,12 +350,18 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
 
 pub(super) fn handle_set_display_name(home: &Path, args: &Value, instance_name: &str) -> Value {
     let display_name = args["name"].as_str().unwrap_or("");
+    if display_name.len() > 256 {
+        return json!({"error": "display_name exceeds 256 character limit"});
+    }
     save_metadata(home, instance_name, "display_name", json!(display_name));
     json!({"display_name": display_name})
 }
 
 pub(super) fn handle_set_description(home: &Path, args: &Value, instance_name: &str) -> Value {
     let desc = args["description"].as_str().unwrap_or("");
+    if desc.len() > 1024 {
+        return json!({"error": "description exceeds 1024 character limit"});
+    }
     save_metadata(home, instance_name, "description", json!(desc));
     json!({"description": desc})
 }

--- a/src/mcp/handlers/instance_spawn.rs
+++ b/src/mcp/handlers/instance_spawn.rs
@@ -74,7 +74,10 @@ pub(super) fn spawn_single_instance_impl(
         cmd_args.push_str(&format!("--model {model_val}"));
     }
     if let Some(dir) = args.get("working_directory").and_then(|v| v.as_str()) {
-        if dir.contains("..") {
+        if std::path::Path::new(dir)
+            .components()
+            .any(|c| c == std::path::Component::ParentDir)
+        {
             return json!({"error": "working_directory must not contain '..'"});
         }
         if !dir.starts_with('/') {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -67,7 +67,10 @@ pub fn is_git_repo(dir: &Path) -> bool {
 /// matches the pre-Wave-4 `{source_repo}/.worktrees/{name}` layout
 /// and returns `None` for the new layout.
 pub fn source_repo_of(working_dir: &Path) -> Option<PathBuf> {
-    if !working_dir.display().to_string().contains(".worktrees/") {
+    if !working_dir
+        .components()
+        .any(|c| c.as_os_str() == ".worktrees")
+    {
         return None;
     }
     working_dir.parent()?.parent().map(|p| p.to_path_buf())

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -177,6 +177,14 @@ pub fn sweep_from_registry(
     let mut removed = Vec::new();
 
     for repo in &repos {
+        // Prune stale remote refs before remote-gone detection
+        let remote = crate::git_helpers::primary_remote(repo);
+        let _ = Command::new("git")
+            .args(["fetch", "--prune", &remote])
+            .current_dir(repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output();
+
         // Phase 1: clean worktrees (existing logic + remote-gone)
         let entries = list_worktrees(repo);
         for entry in &entries {

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -65,9 +65,9 @@ pub fn lease(
     // source_repo persistence (P0-X r1): release_full reads this back to run
     // `git worktree remove --force` from the owning repo's cwd, which
     // prevents stale registry entries that would block re-lease.
-    // #779 P2: bind_full now returns Result; this non-target caller preserves
-    // pre-#779-P2 silent semantic via `.ok()` — zero behavior change.
-    let _ = crate::binding::bind_full(home, agent, "", branch, &info.path, source_repo).ok();
+    if let Err(e) = crate::binding::bind_full(home, agent, "", branch, &info.path, source_repo) {
+        tracing::warn!(%agent, %branch, error = %e, "lease: bind_full failed — worktree created but binding missing");
+    }
 
     Ok(WorktreeLease {
         agent: agent.to_string(),
@@ -88,7 +88,7 @@ pub fn release(home: &Path, lease: &WorktreeLease) {
             "released_at={}\n",
             chrono::Utc::now().to_rfc3339()
         ));
-        let _ = std::fs::write(&marker, content);
+        let _ = crate::store::atomic_write(&marker, content.as_bytes());
     }
     crate::event_log::log(
         home,


### PR DESCRIPTION
## Summary
- **9 medium-priority fixes** from issue #1171 across 7 files
- Hardened worktree pool (bind_full error logging, atomic_write for release marker)
- Improved security: component-based path traversal check, pane_snapshot line cap, display_name/description length limits
- Better correctness: fetch --prune before stale branch detection, metadata_path_resolved for id-based lookup, source_repo_of component check

## Changes
| # | File | Fix |
|---|------|-----|
| 1 | `worktree_pool.rs` | Log `bind_full` errors via `tracing::warn` instead of silently swallowing |
| 2 | `worktree.rs` | `source_repo_of` uses path component check (not `.contains()`) |
| 3 | `worktree_cleanup.rs` | `fetch --prune` before Phase 1 remote-gone branch detection |
| 4 | `worktree_pool.rs` | Release marker uses `atomic_write` for crash safety |
| 5 | `api/handlers/instance.rs` | Cap `pane_snapshot` lines at 10,000 |
| 6 | `mcp/handlers/instance_spawn.rs` | Path traversal check uses `Component::ParentDir` |
| 7 | `mcp/handlers/instance.rs` | Add TODO for hardcoded 500ms sleep replacement |
| 8 | `mcp/handlers/instance.rs` | Cap `display_name` at 256, `description` at 1024 chars |
| 9 | `instance_monitor.rs` | Use `metadata_path_resolved` for id-based metadata lookup |

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test` — all tests pass

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)