### PR TITLE
fix(mcp): harden 11 items from #1178 — HIGH+MEDIUM batch

### DIFF
--- a/src/bin/agend-mcp-bridge.rs
+++ b/src/bin/agend-mcp-bridge.rs
@@ -419,7 +419,7 @@ fn connect_daemon(
 
     let stream = TcpStream::connect(SocketAddr::from((Ipv4Addr::LOCALHOST, port)))?;
     let _ = stream.set_nodelay(true);
-    let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(30)));
+    let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(120)));
 
     let writer = stream.try_clone()?;
     let mut rdr = BufReader::new(stream);
@@ -434,7 +434,11 @@ fn connect_daemon(
 
     let mut resp = String::new();
     rdr.read_line(&mut resp)?;
-    if !resp.contains(r#""ok":true"#) && !resp.contains(r#""ok": true"#) {
+    let auth_ok = serde_json::from_str::<serde_json::Value>(resp.trim())
+        .ok()
+        .and_then(|v| v.get("ok")?.as_bool())
+        .unwrap_or(false);
+    if !auth_ok {
         return Err(format!("auth rejected: {}", resp.trim()).into());
     }
 

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -19,6 +19,39 @@ pub(crate) fn git_bypass(cwd: &Path, args: &[&str]) -> std::io::Result<std::proc
         .output()
 }
 
+/// Like `git_bypass` but with a process-level timeout. Spawns the git
+/// subprocess and polls `try_wait` until either the process exits or the
+/// deadline is reached, at which point the child is killed.
+pub(crate) fn git_bypass_timeout(
+    cwd: &Path,
+    args: &[&str],
+    timeout: std::time::Duration,
+) -> std::io::Result<std::process::Output> {
+    let mut child = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("AGEND_GIT_BYPASS", "1")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
+
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait()? {
+            Some(_status) => return child.wait_with_output(),
+            None if start.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("git {:?} timed out after {timeout:?}", &args[..1]),
+                ));
+            }
+            None => std::thread::sleep(std::time::Duration::from_millis(200)),
+        }
+    }
+}
+
 /// Detect the default branch of a repository.
 /// Reads `refs/remotes/origin/HEAD` → extracts branch name.
 /// Falls back to "main" if detection fails.

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -334,6 +334,19 @@ pub(super) fn handle_release_repo(args: &Value) -> Value {
     };
     let path_str = canonical.to_string_lossy();
 
+    // Derive source repo from worktree .git link before any removal —
+    // needed for post-removal prune if git worktree remove fails.
+    let source_repo = canonical
+        .join(".git")
+        .is_file()
+        .then(|| std::fs::read_to_string(canonical.join(".git")).ok())
+        .flatten()
+        .and_then(|content| {
+            let gitdir = content.strip_prefix("gitdir: ")?.trim();
+            let p = std::path::Path::new(gitdir);
+            p.parent()?.parent()?.parent().map(|pp| pp.to_path_buf())
+        });
+
     match std::process::Command::new("git")
         .args(["worktree", "remove", "--force", &path_str])
         .output()
@@ -341,10 +354,16 @@ pub(super) fn handle_release_repo(args: &Value) -> Value {
         Ok(o) if o.status.success() => json!({"path": path}),
         Ok(o) => {
             let _ = std::fs::remove_dir_all(&canonical);
+            if let Some(src) = &source_repo {
+                crate::worktree::prune(src);
+            }
             json!({"path": path, "note": String::from_utf8_lossy(&o.stderr).to_string()})
         }
         Err(_) => {
             let _ = std::fs::remove_dir_all(&canonical);
+            if let Some(src) = &source_repo {
+                crate::worktree::prune(src);
+            }
             json!({"path": path})
         }
     }
@@ -718,12 +737,17 @@ pub(super) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
     watch["subscribers"] = json!(subscribers_json);
     watch["instance"] = json!(subscribers.first().cloned().unwrap_or_default());
 
-    let _ = crate::store::atomic_write(
+    if let Err(e) = crate::store::atomic_write(
         &path,
         serde_json::to_string_pretty(&watch)
             .unwrap_or_default()
             .as_bytes(),
-    );
+    ) {
+        return json!({
+            "error": format!("failed to persist unwatch: {e}"),
+            "code": "unwatch_write_failed",
+        });
+    }
     json!({
         "repo": repo,
         "watching": true,

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -184,7 +184,10 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
     let force_reason = args.get("force_reason").and_then(|v| v.as_str());
     let claimed_tasks: Vec<_> = crate::tasks::list_all(home)
         .into_iter()
-        .filter(|t| t.assignee.as_deref() == Some(target) && t.status == "claimed")
+        .filter(|t| {
+            t.assignee.as_deref() == Some(target)
+                && (t.status == "claimed" || t.status == "in_progress")
+        })
         .collect();
     if !claimed_tasks.is_empty() {
         if force {
@@ -654,6 +657,10 @@ pub(super) fn handle_inbox(home: &Path, instance_name: &str) -> Value {
             }
         }
         if !processed_msg_ids.is_empty() {
+            // Known TOCTOU window: a message arriving between this re-read
+            // and the save_metadata call below can lose its pickup_id.
+            // The window is narrow (JSON parse + filter) and self-healing
+            // (next handle_inbox drains surviving IDs).
             let remaining: Vec<Value> = std::fs::read_to_string(&meta_path)
                 .ok()
                 .and_then(|c| serde_json::from_str::<Value>(&c).ok())

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -223,6 +223,10 @@ fn dispatch_task_health(ctx: &HandlerCtx<'_>) -> Value {
     task::handle_task(ctx.home, ctx.args, ctx.instance_name)
 }
 
+fn dispatch_task_activity(ctx: &HandlerCtx<'_>) -> Value {
+    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
+}
+
 /// Static sub-handler table for `task` action routing. Lifted out of
 /// the entry literal so the table address can be `'static`-borrowed.
 /// Action set matches `tasks::handle`'s internal `match` arms.
@@ -234,6 +238,7 @@ static TASK_ACTIONS: &[(&str, HandlerFn)] = &[
     ("done", dispatch_task_done),
     ("sweep", dispatch_task_sweep),
     ("health", dispatch_task_health),
+    ("activity", dispatch_task_activity),
 ];
 
 // ---------------------------------------------------------------------
@@ -383,31 +388,46 @@ fn dispatch_watchdog(ctx: &HandlerCtx<'_>) -> Value {
 
 fn dispatch_config(ctx: &HandlerCtx<'_>) -> Value {
     match ctx.args["action"].as_str().unwrap_or("") {
-        "get" => {
-            let key = ctx.args["key"].as_str().unwrap_or("");
-            if key.is_empty() {
-                return json!({"error": "key is required for get"});
-            }
-            match crate::runtime_config::get_key(key) {
-                Ok(v) => json!({"key": key, "value": v}),
-                Err(e) => json!({"error": e}),
-            }
-        }
-        "set" => {
-            let key = ctx.args["key"].as_str().unwrap_or("");
-            let value = ctx.args["value"].as_str().unwrap_or("");
-            if key.is_empty() || value.is_empty() {
-                return json!({"error": "key and value are required for set"});
-            }
-            match crate::runtime_config::set(ctx.home, key, value) {
-                Ok(_) => json!({"ok": true, "key": key, "value": value}),
-                Err(e) => json!({"error": e}),
-            }
-        }
-        "list" => json!({"config": crate::runtime_config::list()}),
+        "get" => dispatch_config_get(ctx),
+        "set" => dispatch_config_set(ctx),
+        "list" => dispatch_config_list(ctx),
         other => json!({"error": format!("unknown config action: {other}")}),
     }
 }
+
+fn dispatch_config_get(ctx: &HandlerCtx<'_>) -> Value {
+    let key = ctx.args["key"].as_str().unwrap_or("");
+    if key.is_empty() {
+        return json!({"error": "key is required for get"});
+    }
+    match crate::runtime_config::get_key(key) {
+        Ok(v) => json!({"key": key, "value": v}),
+        Err(e) => json!({"error": e}),
+    }
+}
+
+fn dispatch_config_set(ctx: &HandlerCtx<'_>) -> Value {
+    let key = ctx.args["key"].as_str().unwrap_or("");
+    let value = ctx.args["value"].as_str().unwrap_or("");
+    if key.is_empty() || value.is_empty() {
+        return json!({"error": "key and value are required for set"});
+    }
+    match crate::runtime_config::set(ctx.home, key, value) {
+        Ok(_) => json!({"ok": true, "key": key, "value": value}),
+        Err(e) => json!({"error": e}),
+    }
+}
+
+fn dispatch_config_list(ctx: &HandlerCtx<'_>) -> Value {
+    let _ = ctx;
+    json!({"config": crate::runtime_config::list()})
+}
+
+static CONFIG_ACTIONS: &[(&str, HandlerFn)] = &[
+    ("get", dispatch_config_get),
+    ("set", dispatch_config_set),
+    ("list", dispatch_config_list),
+];
 
 fn dispatch_watchdog_snooze(ctx: &HandlerCtx<'_>) -> Value {
     use crate::daemon::idle_watchdog;
@@ -851,7 +871,7 @@ static REGISTERED: &[HandlerEntry] = &[
     HandlerEntry {
         name: "config",
         handler: dispatch_config,
-        actions: None,
+        actions: Some(CONFIG_ACTIONS),
     },
     HandlerEntry {
         name: "repo",
@@ -1051,6 +1071,7 @@ mod tests {
                 "task",
                 &[
                     "create", "list", "claim", "update", "done", "sweep", "health",
+                    "activity",
                 ],
             ),
             ("ci", &["watch", "unwatch", "status"]),
@@ -1069,6 +1090,7 @@ mod tests {
             ("schedule", &["create", "list", "update", "delete"]),
             ("team", &["create", "delete", "list", "update"]),
             ("watchdog", &["snooze", "resume", "status", "ack"]),
+            ("config", &["get", "set", "list"]),
         ];
         for (tool, actions) in cases {
             for action in actions.iter() {
@@ -1090,6 +1112,7 @@ mod tests {
         let action_tools = [
             "task",
             "ci",
+            "config",
             "decision",
             "deployment",
             "health",

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1070,8 +1070,7 @@ mod tests {
             (
                 "task",
                 &[
-                    "create", "list", "claim", "update", "done", "sweep", "health",
-                    "activity",
+                    "create", "list", "claim", "update", "done", "sweep", "health", "activity",
                 ],
             ),
             ("ci", &["watch", "unwatch", "status"]),

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -441,12 +441,17 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     // `git worktree remove` from the owning repo's cwd.
     // #779 P2: bind_full now returns Result; this non-target caller preserves
     // pre-#779-P2 silent semantic via `.ok()` — zero behavior change.
-    let _ =
-        crate::binding::bind_full(home, target, task_id, branch, &lease.path, &source_repo).ok();
-    tracing::info!(
-        %target, %branch, path = %lease.path.display(),
-        "dispatch auto-bind + lease OK"
-    );
+    match crate::binding::bind_full(home, target, task_id, branch, &lease.path, &source_repo) {
+        Ok(()) => tracing::info!(
+            %target, %branch, path = %lease.path.display(),
+            "dispatch auto-bind + lease OK"
+        ),
+        Err(e) => tracing::warn!(
+            %target, %branch, path = %lease.path.display(),
+            error = %e,
+            "dispatch auto-bind lease acquired but bind_full failed — binding.json missing"
+        ),
+    }
 
     // P0-2 + Sprint 55 P0-B EC4: auto-watch_ci. Resolution order:
     //   1. caller-supplied `repo` arg → canonicalize (#942)
@@ -637,8 +642,11 @@ pub(crate) fn ensure_branch_exists(
         // and the local ref is left untouched — dispatch then falls
         // through to lease with the existing local SHA, matching the
         // pre-fix behaviour for that edge case.
-        let fetch_out =
-            crate::git_helpers::git_bypass(source, &["fetch", "origin", branch, "--quiet"]);
+        let fetch_out = crate::git_helpers::git_bypass_timeout(
+            source,
+            &["fetch", "origin", branch, "--quiet"],
+            std::time::Duration::from_secs(60),
+        );
         let fetched_ok = matches!(&fetch_out, Ok(o) if o.status.success());
         let remote_branch_ref = format!("refs/remotes/origin/{branch}");
         let remote_exists =
@@ -675,8 +683,11 @@ pub(crate) fn ensure_branch_exists(
                     "ensure_branch_exists fallback: from_ref unresolved locally — fetching origin"
                 );
                 let fetch_start = std::time::Instant::now();
-                let fetch_out =
-                    crate::git_helpers::git_bypass(source, &["fetch", "origin", "--quiet"]);
+                let fetch_out = crate::git_helpers::git_bypass_timeout(
+                    source,
+                    &["fetch", "origin", "--quiet"],
+                    std::time::Duration::from_secs(60),
+                );
                 let fetch_ms = fetch_start.elapsed().as_millis();
                 crate::event_log::log(
                     home,

--- a/src/mcp/handlers/force_release/mod.rs
+++ b/src/mcp/handlers/force_release/mod.rs
@@ -185,6 +185,11 @@ pub(super) fn rebase_clean_self(
     }
 
     let binding_outcome = crate::worktree_pool::release_full(home, agent, false);
+    // release_full returns early when binding.json is absent (line 244-247
+    // in worktree_pool.rs) — skipping clear_bind_in_flight. In the exact
+    // stale-state recovery case this tool is for (binding gone, dir present),
+    // the in-flight guard would leak and block rebind.
+    crate::mcp::handlers::dispatch_hook::clear_bind_in_flight(home, agent);
     Ok(RebaseCleanOutcome {
         dir_existed,
         dir_removed,


### PR DESCRIPTION
## Summary

Applies all 11 fixes from #1178 (MCP Core architecture review findings across 3 slices):

**HIGH (2):**
- **H1**: `dispatch.rs` `TASK_ACTIONS` missing `"activity"` action — added sub-handler + entry + pinned test update
- **H2**: `dispatch_hook/mod.rs` `bind_full(...).ok()` silently swallowed bind errors — now logs `tracing::warn!` on failure (same pattern as #1171 Fix 1)

**MEDIUM (9):**
- **M-A1**: `config` tool missing `actions: Some(...)` cohort pattern — extracted sub-handlers, added `CONFIG_ACTIONS` static, updated cohort invariant test
- **M-A2**: Bridge 30s TCP read timeout increased to 120s to avoid truncating long daemon ops
- **M-A3**: Bridge auth response validated via JSON parse instead of fragile `string.contains()`
- **M-A4**: `ensure_branch_exists` git fetch calls now use `git_bypass_timeout` (60s process-level cap) — new helper in `git_helpers.rs`
- **M-B1**: `handle_delegate_task` busy gate extended to also check `in_progress` status (previously only `claimed`)
- **M-B2**: `handle_unwatch_ci` `atomic_write` result now propagated (was `let _ = ...`), consistent with `handle_watch_ci`
- **M-B3**: `handle_release_repo` `remove_dir_all` fallback now runs `git worktree prune` to clean dangling registry entries
- **M-B4**: `handle_inbox` metadata double-read TOCTOU window documented as known limitation
- **M-C1**: `force_release` now clears `bind-in-flight` guard after `release_full` even when binding is absent

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test` — 2,850 tests passed, 0 failed
- [x] `try_dispatch_routes_known_action_through_sub_handler` passes with `"activity"` + `"config"` actions
- [x] `action_based_tools_have_actions_populated` passes with `"config"` in cohort list
- [x] All `force_release` tests pass (22 tests)

Closes #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)