### PR TITLE
feat(recovery): add hang_auto_recovery_enabled runtime config gate

### DIFF
--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -125,9 +125,10 @@ impl RecoveryDispatcherHandler {
 }
 
 fn stage2_gate_active() -> bool {
-    std::env::var(STAGE2_ENV_VAR)
-        .map(|v| v == "1")
-        .unwrap_or(false)
+    crate::runtime_config::get().hang_auto_recovery_enabled
+        || std::env::var(STAGE2_ENV_VAR)
+            .map(|v| v == "1")
+            .unwrap_or(false)
 }
 
 fn stage2_max_restarts() -> u32 {
@@ -141,9 +142,10 @@ fn stage2_max_restarts() -> u32 {
 }
 
 fn stage3_gate_active() -> bool {
-    std::env::var(STAGE3_ENV_VAR)
-        .map(|v| v == "1")
-        .unwrap_or(false)
+    crate::runtime_config::get().hang_auto_recovery_enabled
+        || std::env::var(STAGE3_ENV_VAR)
+            .map(|v| v == "1")
+            .unwrap_or(false)
 }
 
 /// Read an env var as milliseconds with a typed default. Logged at
@@ -160,9 +162,11 @@ fn env_ms(var: &str, default_ms: u64) -> Duration {
 }
 
 fn stage1_gate_active() -> bool {
-    std::env::var(STAGE1_ENV_VAR)
-        .map(|v| v == "1")
-        .unwrap_or(false)
+    // #685 Phase 2: runtime config master gate OR per-stage env var.
+    crate::runtime_config::get().hang_auto_recovery_enabled
+        || std::env::var(STAGE1_ENV_VAR)
+            .map(|v| v == "1")
+            .unwrap_or(false)
 }
 
 /// Decision branch for the combined-gate inspection. Centralises the

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -248,7 +248,7 @@ fn watchdog_tools() -> Vec<Value> {
 
 fn config_tools() -> Vec<Value> {
     vec![
-        json!({"name": "config", "description": "#1085: Runtime-mutable daemon configuration. Actions: get, set, list. Keys: dev_idle_threshold_secs, fleet_idle_threshold_secs.",
+        json!({"name": "config", "description": "#1085: Runtime-mutable daemon configuration. Actions: get, set, list. Keys: dev_idle_threshold_secs, fleet_idle_threshold_secs, hang_auto_recovery_enabled.",
         "inputSchema": {"type": "object", "properties": {
             "action": {"type": "string", "enum": ["get", "set", "list"]},
             "key": {"type": "string", "description": "Config key name (required for get/set)"},

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -18,6 +18,11 @@ pub struct RuntimeConfig {
     /// Fleet-wide idle threshold before watchdog alerts (seconds).
     #[serde(default = "default_fleet_idle")]
     pub fleet_idle_threshold_secs: i64,
+    /// #685 Phase 2: Master gate for hang auto-recovery stages 1-3.
+    /// When true, Hung agents trigger ESC → restart → escalate.
+    /// Default false (shadow mode only).
+    #[serde(default)]
+    pub hang_auto_recovery_enabled: bool,
 }
 
 fn default_dev_idle() -> i64 {
@@ -32,6 +37,7 @@ impl Default for RuntimeConfig {
         Self {
             dev_idle_threshold_secs: default_dev_idle(),
             fleet_idle_threshold_secs: default_fleet_idle(),
+            hang_auto_recovery_enabled: false,
         }
     }
 }
@@ -71,6 +77,13 @@ pub fn set(home: &Path, key: &str, value: &str) -> Result<String, String> {
                 .parse()
                 .map_err(|_| format!("invalid integer: {value}"))?;
         }
+        "hang_auto_recovery_enabled" => {
+            config.hang_auto_recovery_enabled = match value {
+                "true" | "1" => true,
+                "false" | "0" => false,
+                _ => return Err(format!("invalid boolean: {value} (use true/false)")),
+            };
+        }
         _ => return Err(format!("unknown config key: {key}")),
     }
     let path = home.join("runtime-config.json");
@@ -86,6 +99,7 @@ pub fn get_key(key: &str) -> Result<String, String> {
     match key {
         "dev_idle_threshold_secs" => Ok(config.dev_idle_threshold_secs.to_string()),
         "fleet_idle_threshold_secs" => Ok(config.fleet_idle_threshold_secs.to_string()),
+        "hang_auto_recovery_enabled" => Ok(config.hang_auto_recovery_enabled.to_string()),
         _ => Err(format!("unknown config key: {key}")),
     }
 }
@@ -122,6 +136,25 @@ mod tests {
         let dir = std::env::temp_dir().join("agend-test-runtime-config-bad");
         std::fs::create_dir_all(&dir).ok();
         assert!(set(&dir, "nonexistent", "123").is_err());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn hang_auto_recovery_enabled_default_false() {
+        let c = RuntimeConfig::default();
+        assert!(!c.hang_auto_recovery_enabled);
+    }
+
+    #[test]
+    fn set_hang_auto_recovery_enabled() {
+        let dir = std::env::temp_dir().join("agend-test-runtime-config-hang");
+        std::fs::create_dir_all(&dir).ok();
+        set(&dir, "hang_auto_recovery_enabled", "true").unwrap();
+        reload(&dir);
+        assert_eq!(get_key("hang_auto_recovery_enabled").unwrap(), "true");
+        set(&dir, "hang_auto_recovery_enabled", "false").unwrap();
+        reload(&dir);
+        assert_eq!(get_key("hang_auto_recovery_enabled").unwrap(), "false");
         std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
Closes #685

## Summary
Phase 2: Enable hang auto-recovery via runtime config gate.

Adds `hang_auto_recovery_enabled` key to `runtime-config.json` (default: **false**). When true, activates all three recovery stages:
- **Stage 1**: ESC inject to hung agent
- **Stage 2**: Auto-restart if still hung after 30s timeout
- **Stage 3**: Pause + operator escalation if restarts exhausted (cap N=3)

## Operator usage
```
config set key=hang_auto_recovery_enabled value=true
```

## Design
- Runtime config master gate OR existing per-stage env vars (either activates)
- Default OFF — operator explicitly opts in
- Existing Stage 1-2-3 infrastructure unchanged (already shipped in prior sub-tasks)
- Recovery state machine: Hung → ESC → wait 30s → restart → wait 30s → pause+escalate

## Changes
- `src/runtime_config.rs`: Added `hang_auto_recovery_enabled` field + set/get/list support
- `src/daemon/per_tick/recovery_dispatcher.rs`: Stage gate functions check runtime config
- `src/mcp/tools.rs`: Updated config tool description

## Tests
- `hang_auto_recovery_enabled_default_false`: verifies default
- `set_hang_auto_recovery_enabled`: verifies set/get round-trip
- All 23 recovery_dispatcher tests pass, all 5 runtime_config tests pass

Closes t-20260525041945314309-3