### PR TITLE
fix(health,ci_watch): harden 8 items from #1183 — HIGH+MEDIUM batch

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -179,7 +179,7 @@ pub fn watch_start_check_mergeable(
             w["last_mergeable_state"] = serde_json::json!(state.as_str());
             w["last_mergeable_check_at"] = serde_json::json!(now_rfc3339);
             if let Ok(out) = serde_json::to_string_pretty(&w) {
-                let _ = std::fs::write(watch_path, out);
+                let _ = crate::store::atomic_write(watch_path, out.as_bytes());
             }
         }
     }
@@ -826,7 +826,7 @@ async fn check_and_alert_mergeable(ctx: &CiCheckCtx<'_>, provider: &dyn CiProvid
             w.last_mergeable_state = Some(new_state.as_str().to_string());
             w.last_mergeable_check_at = Some(now_rfc3339);
             if let Ok(out) = serde_json::to_string_pretty(&w) {
-                let _ = std::fs::write(ctx.watch_path, out);
+                let _ = crate::store::atomic_write(ctx.watch_path, out.as_bytes());
             }
         }
     }
@@ -1026,16 +1026,17 @@ async fn fan_out_notifications(
             } else {
                 None
             };
+            let fleet_cfg =
+                crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home)).ok();
             for sub in ctx.subscribers {
                 if action_target_on_success.as_deref() == Some(sub.as_str()) {
                     continue;
                 }
                 let in_registry = agent::lock_registry(registry).contains_key(sub);
-                let fleet_known =
-                    crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
-                        .ok()
-                        .map(|f| f.instances.contains_key(sub))
-                        .unwrap_or(true);
+                let fleet_known = fleet_cfg
+                    .as_ref()
+                    .map(|f| f.instances.contains_key(sub))
+                    .unwrap_or(true);
                 if !in_registry && !fleet_known {
                     tracing::debug!(
                         sub = %sub,

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -25,6 +25,7 @@ pub(crate) fn parse_subscribers(watch: &serde_json::Value) -> Vec<String> {
             .filter(|s| !s.is_empty())
             .map(String::from)
             .collect();
+        out.sort();
         out.dedup();
         if !out.is_empty() {
             return out;
@@ -136,12 +137,14 @@ pub(super) fn update_watch_state_with_notify(
             }
             watch.last_terminal_seen_at = Some(chrono::Utc::now().to_rfc3339());
             // M1: atomic write to prevent partial-file on crash
-            let _ = crate::store::atomic_write(
+            if let Err(e) = crate::store::atomic_write(
                 watch_path,
                 serde_json::to_string_pretty(&watch)
                     .unwrap_or_default()
                     .as_bytes(),
-            );
+            ) {
+                tracing::warn!(path = %watch_path.display(), error = %e, "ci-watch state write failed");
+            }
         }
     }
 }

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -46,12 +46,14 @@ pub(super) fn bump_consecutive_skips_and_maybe_notify(
             watch.stalled_since_ms = Some(chrono::Utc::now().timestamp_millis());
         }
     }
-    let _ = crate::store::atomic_write(
+    if let Err(e) = crate::store::atomic_write(
         watch_path,
         serde_json::to_string_pretty(&watch)
             .unwrap_or_default()
             .as_bytes(),
-    );
+    ) {
+        tracing::warn!(path = %watch_path.display(), error = %e, "ci-watch stall-counter write failed");
+    }
 
     if should_notify {
         let stalled_since_ms = watch.stalled_since_ms;
@@ -97,12 +99,14 @@ pub(super) fn clear_stall_and_maybe_notify_resumed(
     watch.consecutive_skips = Some(0);
     watch.stalled_notified = Some(false);
     watch.stalled_since_ms = None;
-    let _ = crate::store::atomic_write(
+    if let Err(e) = crate::store::atomic_write(
         watch_path,
         serde_json::to_string_pretty(&watch)
             .unwrap_or_default()
             .as_bytes(),
-    );
+    ) {
+        tracing::warn!(path = %watch_path.display(), error = %e, "ci-watch stall-clear write failed");
+    }
     if was_stalled {
         let body =
             format!("[ci-watch-resumed] {repo}@{branch}: poll resumed after rate-limit backoff");

--- a/src/daemon/ci_watch/watch_state.rs
+++ b/src/daemon/ci_watch/watch_state.rs
@@ -104,6 +104,7 @@ impl WatchState {
                 .filter(|s| !s.instance.is_empty())
                 .map(|s| s.instance.clone())
                 .collect();
+            out.sort();
             out.dedup();
             if !out.is_empty() {
                 return out;

--- a/src/daemon/dispatch_idle/fixup_nudge.rs
+++ b/src/daemon/dispatch_idle/fixup_nudge.rs
@@ -152,7 +152,9 @@ pub(crate) fn scan_and_nudge(home: &Path) {
             continue;
         }
         d.nudge_sent_at = Some(chrono::Utc::now().to_rfc3339());
-        let _ = write_dispatch_sidecar(home, &d);
+        if !write_dispatch_sidecar(home, &d) {
+            tracing::warn!(dispatch_id = %d.dispatch_id, "fixup-nudge sidecar write failed");
+        }
     }
 }
 

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -470,7 +470,9 @@ pub(crate) fn scan_and_emit(home: &Path) {
 
         emit_exceeded_event(home, &d, elapsed_secs);
         d.status = "exceeded".to_string();
-        let _ = write_dispatch(home, &d);
+        if !write_dispatch(home, &d) {
+            tracing::warn!(dispatch_id = %d.dispatch_id, "dispatch-idle exceeded status write failed");
+        }
     }
 }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -454,24 +454,12 @@ impl HealthTracker {
             }
         }
 
-        let silence_exceeds_threshold = match agent_state {
-            AgentState::Idle => false, // Waiting for input — never hangs
-            AgentState::Starting => silent > Duration::from_secs(120),
-            AgentState::Thinking | AgentState::ToolUse => silent > Duration::from_secs(600),
-            _ => silent > Duration::from_secs(120),
-        };
+        let silence_exceeds_threshold = productive_silence_exceeds(agent_state, silent);
 
         // F9 (#685 sub-task 4): productive-silence threshold mirrors silent
         // thresholds. Active only when `AGEND_PRODUCTIVE_GATE=1` is set;
         // telemetry fires regardless for fixture-corpus measurement.
-        let productive_silence_exceeds = match agent_state {
-            AgentState::Idle => false,
-            AgentState::Starting => silent_productive > Duration::from_secs(120),
-            AgentState::Thinking | AgentState::ToolUse => {
-                silent_productive > Duration::from_secs(600)
-            }
-            _ => silent_productive > Duration::from_secs(120),
-        };
+        let productive_exceeds = productive_silence_exceeds(agent_state, silent_productive);
         let f9_gate_active = std::env::var("AGEND_PRODUCTIVE_GATE")
             .map(|v| v == "1")
             .unwrap_or(false);
@@ -479,7 +467,7 @@ impl HealthTracker {
         // independently flag Hung but the silent path does not. Lets the
         // fixture corpus measure F9 FP rate without affecting prod behavior
         // until the env var flips to active.
-        if productive_silence_exceeds && !silence_exceeds_threshold {
+        if productive_exceeds && !silence_exceeds_threshold {
             tracing::debug!(
                 target: "behavioral_shadow",
                 silent_secs = silent.as_secs(),
@@ -491,8 +479,7 @@ impl HealthTracker {
         }
         // Dual-path: Hung classification fires if either path exceeded,
         // gated on env var for productive path until promoted to default.
-        let any_path_exceeds =
-            silence_exceeds_threshold || (f9_gate_active && productive_silence_exceeds);
+        let any_path_exceeds = silence_exceeds_threshold || (f9_gate_active && productive_exceeds);
 
         if !any_path_exceeds {
             // Hung Exit (X1) / IdleLong Exit (X1): silence dropped below threshold
@@ -721,11 +708,17 @@ impl HealthTracker {
             if self.total_crashes == 0 {
                 self.crash_times.clear();
             }
-            // Recover from Failed/Unstable if crashes decayed enough
+            // Recover from Failed/Unstable if crashes decayed enough.
+            // Known limitation: Failed → Recovering with a dead process
+            // leaves the agent in Recovering until operator manual restart
+            // or #685 Stage 2 auto-restart fires. record_crash returned
+            // (false, _, _) when entering Failed, so the process is gone.
             if self.total_crashes < DEFAULT_MAX_RETRIES && self.state == HealthState::Failed {
                 self.state = HealthState::Recovering;
             }
-            if self.total_crashes < 3 && self.state == HealthState::Unstable {
+            if self.total_crashes < 3
+                && matches!(self.state, HealthState::Unstable | HealthState::Recovering)
+            {
                 self.state = HealthState::Healthy;
             }
         }


### PR DESCRIPTION
## Summary
- **H1**: `ci_watch/poller.rs` — replace `std::fs::write` with `atomic_write` at 2 mergeable-state persistence sites (crash-safety)
- **M-A1**: `ci_watch/poller.rs` — hoist `FleetConfig::load()` above per-subscriber loop (N×M → 1 file read per poll cycle)
- **M-A2**: `ci_watch/registry.rs`, `ci_watch/sweep.rs` — add `tracing::warn!` on `atomic_write` failure at 3 sites
- **M-A3**: `ci_watch/watch_state.rs`, `ci_watch/registry.rs` — `sort()` before `dedup()` to handle non-consecutive duplicate subscribers
- **M-B1**: `health.rs` — DRY: replace inline threshold match blocks with `productive_silence_exceeds()` function calls
- **M-B2**: `health.rs` — document `Failed→Recovering` decay limitation; fix `Recovering` not decaying further to `Healthy`
- **M-B3**: `dispatch_idle/mod.rs` — log warning on `write_dispatch` failure (prevents silent dedup breakage)
- **M-B4**: `dispatch_idle/fixup_nudge.rs` — log warning on `write_dispatch_sidecar` failure (prevents silent nudge dedup breakage)

Closes #1183

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo test` — 2799+ tests pass, 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)