### PR TITLE
fix(tui): apply 6 review fixes — spawn rationale, error propagation, session safety (#1184)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -339,7 +339,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // enough that the readdir cost is trivial.
     let mut last_remote_sync = std::time::Instant::now();
 
-    // Crossterm event reader thread
+    // fire-and-forget: blocks in crossterm::event::read(); terminated by process exit.
     let (event_tx, event_rx) = crossbeam_channel::unbounded::<Event>();
     std::thread::Builder::new()
         .name("crossterm_events".into())
@@ -402,7 +402,10 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             needs_resize = false;
         }
         sync_notification_state(&home, &mut layout);
-        // H3: throttle flush to ≥1s intervals (was every 50ms tick → disk I/O storm)
+        // H3: throttle flush to ≥1s intervals (was every 50ms tick → disk I/O storm).
+        // std::sync::Mutex is fine here: only the main thread touches this,
+        // the critical section is sub-microsecond, and the TUI render loop is
+        // not async (crossbeam select!, not tokio).
         {
             static LAST_FLUSH: std::sync::Mutex<Option<std::time::Instant>> =
                 std::sync::Mutex::new(None);

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -108,6 +108,7 @@ pub(super) fn sync_fleet_yaml(home: &Path, layout: &Layout) {
             .filter(|name| !active_fleet_names.contains(name))
             .collect();
         if !to_remove.is_empty() {
+            tracing::info!(removed = ?to_remove, "sync_fleet_yaml: removing fleet entries not in any pane");
             let _ = fleet::remove_instances_from_yaml(home, &to_remove);
         }
     }
@@ -348,7 +349,6 @@ fn apply_session_layout(
     let Some(session) = session else {
         return false;
     };
-    let _ = std::fs::remove_file(&session_path);
     if session.tabs.is_empty() {
         return false;
     }
@@ -425,6 +425,7 @@ fn apply_session_layout(
     }
 
     if !layout.tabs.is_empty() {
+        let _ = std::fs::remove_file(&session_path);
         tracing::info!(
             tabs = layout.tabs.len(),
             "session restored with reconciliation"

--- a/src/app/tui_spawn.rs
+++ b/src/app/tui_spawn.rs
@@ -44,9 +44,11 @@ pub(crate) fn add_instance_with_topic(
 
     if let TopicOutcome::Created(ref tid) = outcome {
         if let Ok(topic_id) = tid.parse::<i32>() {
-            if let Err(e) = crate::channel::telegram::register_topic(home, topic_id, name) {
-                tracing::warn!(instance = name, error = %e, "TUI-spawn: failed to persist topic_id to topics.json");
-            }
+            crate::channel::telegram::register_topic(home, topic_id, name).map_err(|e| {
+                anyhow::anyhow!(
+                    "topic created (id={tid}) but failed to persist to topics.json: {e}"
+                )
+            })?;
         }
         tracing::info!(
             instance = name,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -43,7 +43,8 @@ pub fn attach(home: &Path, name: &str) -> anyhow::Result<()> {
         .take_reader()
         .ok_or_else(|| anyhow::anyhow!("bridge reader already taken"))?;
 
-    // Output thread: agent → terminal stdout
+    // fire-and-forget: lifetime bounded by bridge reader EOF; thread exits
+    // when the connection closes and read_tagged_frame returns Err.
     std::thread::Builder::new()
         .name("tui_output".into())
         .spawn(move || {


### PR DESCRIPTION
## Summary
- **H1**: Add §10.5 `fire-and-forget` rationale comment to `tui_output` thread spawn (`tui.rs`)
- **H2**: Propagate `register_topic` error instead of swallowing and returning `Ok(TopicOutcome::Created)` (`tui_spawn.rs`)
- **M1**: Add §10.5 rationale comment to crossterm event reader thread (`app/mod.rs`)
- **M2**: Log fleet entries removed by `sync_fleet_yaml` via `tracing::info!` (`app/session.rs`)
- **M3**: Defer `session.json` deletion until after reconciliation succeeds — prevents layout data loss on reconciliation failure (`app/session.rs`)
- **M4**: Document `LAST_FLUSH` `std::sync::Mutex` as intentional — TUI render loop is not async (`app/mod.rs`)

Closes #1184

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — all tests pass (including 6 tui_spawn tests)
- [ ] Verify H2: `register_topic` failure now returns `Err` to caller
- [ ] Verify M3: session.json survives if reconciliation panics
- [ ] Verify M5: fleet entry removal logged in tracing output

🤖 Generated with [Claude Code](https://claude.com/claude-code)