### PR TITLE
fix(fleet): emit name collision error once at load, not per-tick WARN

### DIFF
--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -498,13 +498,18 @@ impl FleetConfig {
             .map(|t| t.keys().cloned().collect())
             .unwrap_or_default();
 
-        // Reserved-name warnings (no write).
+        // #1186: Name collision detection — emit error once, not per-tick WARN.
+        static COLLISION_REPORTED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
         for name in self.instances.keys() {
             if template_names.contains(name) {
-                tracing::warn!(
-                    name,
-                    "instance name collides with template name — may cause routing ambiguity"
-                );
+                if !COLLISION_REPORTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                    tracing::error!(
+                        name,
+                        "fleet.yaml: instance name collides with template name — \
+                         rename one to avoid routing ambiguity"
+                    );
+                }
             }
         }
 

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -502,14 +502,14 @@ impl FleetConfig {
         static COLLISION_REPORTED: std::sync::atomic::AtomicBool =
             std::sync::atomic::AtomicBool::new(false);
         for name in self.instances.keys() {
-            if template_names.contains(name) {
-                if !COLLISION_REPORTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
-                    tracing::error!(
-                        name,
-                        "fleet.yaml: instance name collides with template name — \
-                         rename one to avoid routing ambiguity"
-                    );
-                }
+            if template_names.contains(name)
+                && !COLLISION_REPORTED.swap(true, std::sync::atomic::Ordering::Relaxed)
+            {
+                tracing::error!(
+                    name,
+                    "fleet.yaml: instance name collides with template name — \
+                     rename one to avoid routing ambiguity"
+                );
             }
         }
 


### PR DESCRIPTION
Closes #1186

## Problem
When fleet.yaml has an instance and template sharing the same name, a `tracing::warn!` fires on EVERY `FleetConfig::load()` call (multiple times per daemon tick = per-tick spam).

## Fix
Replace with `static AtomicBool`-gated `tracing::error!` that fires only once per process lifetime. Operator sees a clear error on first load, then silence.

## Changes
- `src/fleet.rs`: +10/-5 lines in `backfill_ids()`