### PR TITLE
fix(ci_watch): detect short-form owner/name as GitHub without warning

### DIFF
--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -1954,6 +1954,17 @@ fn detect_provider_github_enterprise_custom_domain() {
     assert!(is_custom, "GHE custom domain must flag custom_host");
 }
 
+/// #1188: short-form `owner/name` must be detected as GitHub without custom_host warning.
+#[test]
+fn detect_provider_short_form_owner_name_is_github_not_custom() {
+    let (kind, is_custom) = super::detect_provider_from_remote("suzuke/agend-terminal");
+    assert_eq!(kind, "github");
+    assert!(
+        !is_custom,
+        "short-form owner/name must NOT flag custom_host"
+    );
+}
+
 /// B3: explicit ci_provider in watch JSON overrides auto-detect.
 #[test]
 fn explicit_ci_provider_overrides_auto_detect() {

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -997,8 +997,22 @@ pub fn detect_provider_from_remote(repo: &str) -> (&'static str, bool) {
         ("bitbucket_cloud", true) // custom Bitbucket domain
     } else if repo.contains("github.com") {
         ("github", false) // canonical github.com
+    } else if is_short_form_repo(repo) {
+        // #1188: short-form `owner/name` (no dots, no protocol) — GitHub default, not custom.
+        ("github", false)
     } else {
         // GitHub Enterprise custom domain OR fully unknown → default github + warn
         ("github", true)
     }
+}
+
+/// #1188: Detect `owner/name` short-form repo strings (e.g. "suzuke/agend-terminal").
+/// Pattern: exactly one `/`, no dots, no colons, no protocol prefix.
+fn is_short_form_repo(repo: &str) -> bool {
+    let parts: Vec<&str> = repo.split('/').collect();
+    parts.len() == 2
+        && !parts[0].is_empty()
+        && !parts[1].is_empty()
+        && !repo.contains('.')
+        && !repo.contains(':')
 }


### PR DESCRIPTION
Closes #1188

## Problem
`detect_provider_from_remote` uses `.contains("github.com")` but repos are commonly passed as short-form `owner/name` (no domain). Falls to 'custom CI host' branch → spurious WARN every poll tick.

## Fix
Added `is_short_form_repo()` check: if repo matches `owner/name` pattern (exactly one `/`, no dots, no colons), treat as GitHub without `custom_host=true`.

## Test
- `detect_provider_short_form_owner_name_is_github_not_custom`: verifies `suzuke/agend-terminal` → github, not custom
- All 6 provider detection tests pass

Closes t-20260525050324251602-1