### PR TITLE
fix(app): write .ready lifecycle marker in TUI mode

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -230,6 +230,15 @@ pub fn serve(
     };
     tracing::info!(port, "API listening");
 
+    // #1189: write `.ready` after confirmed bind + port publish + cookie load.
+    // Only if not already written (daemon mode writes it later after spawn loop).
+    let ready_path = run_dir.join(".ready");
+    if !ready_path.exists() {
+        if let Err(e) = std::fs::write(&ready_path, chrono::Utc::now().to_rfc3339()) {
+            tracing::warn!(path = %ready_path.display(), error = %e, "failed to write .ready marker");
+        }
+    }
+
     // #680: connection counter — limits concurrent API sessions.
     let max_conns: usize = std::env::var("AGEND_API_MAX_CONNS")
         .ok()

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -230,10 +230,10 @@ pub fn serve(
     };
     tracing::info!(port, "API listening");
 
-    // #1189: write `.ready` after confirmed bind + port publish + cookie load.
-    // Only if not already written (daemon mode writes it later after spawn loop).
-    let ready_path = run_dir.join(".ready");
-    if !ready_path.exists() {
+    // #1189: write `.ready` in app (TUI) mode after confirmed bind success.
+    // Daemon mode writes `.ready` later (after spawn loop) with richer semantics.
+    if notifier.is_some() {
+        let ready_path = run_dir.join(".ready");
         if let Err(e) = std::fs::write(&ready_path, chrono::Utc::now().to_rfc3339()) {
             tracing::warn!(path = %ready_path.display(), error = %e, "failed to write .ready marker");
         }

--- a/src/app/api_server.rs
+++ b/src/app/api_server.rs
@@ -73,6 +73,15 @@ pub(super) fn start_api_server(
         .ok();
 
     tracing::info!(path = %run_dir.display(), "in-process API server started");
+
+    // #1189: write `.ready` lifecycle marker in app (TUI) mode.
+    // Daemon mode writes it in `daemon/mod.rs` after the spawn loop;
+    // app mode has no spawn loop, so write it here after API is up.
+    let ready_path = run_dir.join(".ready");
+    if let Err(e) = std::fs::write(&ready_path, chrono::Utc::now().to_rfc3339()) {
+        tracing::warn!(path = %ready_path.display(), error = %e, "failed to write .ready marker");
+    }
+
     ApiGuard {
         run_dir: Some(run_dir),
         _owned: Some(prepared),

--- a/src/app/api_server.rs
+++ b/src/app/api_server.rs
@@ -74,14 +74,6 @@ pub(super) fn start_api_server(
 
     tracing::info!(path = %run_dir.display(), "in-process API server started");
 
-    // #1189: write `.ready` lifecycle marker in app (TUI) mode.
-    // Daemon mode writes it in `daemon/mod.rs` after the spawn loop;
-    // app mode has no spawn loop, so write it here after API is up.
-    let ready_path = run_dir.join(".ready");
-    if let Err(e) = std::fs::write(&ready_path, chrono::Utc::now().to_rfc3339()) {
-        tracing::warn!(path = %ready_path.display(), error = %e, "failed to write .ready marker");
-    }
-
     ApiGuard {
         run_dir: Some(run_dir),
         _owned: Some(prepared),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -334,6 +334,16 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // Start true so restored split panes get correct sizes before first draw.
     let mut needs_resize = true;
 
+    // #1189: write `.ready` lifecycle marker after TUI fully initialized
+    // (API bound + session restore complete). Daemon mode writes it in
+    // daemon/mod.rs after spawn loop; app mode writes here.
+    if !attached_mode {
+        let ready_path = crate::daemon::run_dir(&home).join(".ready");
+        if let Err(e) = std::fs::write(&ready_path, chrono::Utc::now().to_rfc3339()) {
+            tracing::warn!(path = %ready_path.display(), error = %e, "failed to write .ready marker");
+        }
+    }
+
     // Throttle for Attached-mode remote agent discovery. 2s is short enough
     // that a fleet.yaml reload (daemon tick is 10s) feels timely but long
     // enough that the readdir cost is trivial.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -334,16 +334,6 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // Start true so restored split panes get correct sizes before first draw.
     let mut needs_resize = true;
 
-    // #1189: write `.ready` lifecycle marker after TUI fully initialized
-    // (API bound + session restore complete). Daemon mode writes it in
-    // daemon/mod.rs after spawn loop; app mode writes here.
-    if !attached_mode {
-        let ready_path = crate::daemon::run_dir(&home).join(".ready");
-        if let Err(e) = std::fs::write(&ready_path, chrono::Utc::now().to_rfc3339()) {
-            tracing::warn!(path = %ready_path.display(), error = %e, "failed to write .ready marker");
-        }
-    }
-
     // Throttle for Attached-mode remote agent discovery. 2s is short enough
     // that a fleet.yaml reload (daemon tick is 10s) feels timely but long
     // enough that the readdir cost is trivial.


### PR DESCRIPTION
Closes #1189

## Problem
`.ready` lifecycle marker is written in daemon mode after the agent spawn loop (`daemon/mod.rs:550`). App (TUI) mode has no spawn loop, so `.ready` was never written.

## Fix
Write `.ready` in `app/api_server.rs::start_api_server()` after the API thread spawns — the app-mode equivalent of 'daemon init complete'.

Closes t-20260525052159786265-2