### PR TITLE
docs: feature documentation (task board, teams, worktree) #1195

### DIFF
--- a/docs/FEATURE-task-board.md
+++ b/docs/FEATURE-task-board.md
@@ -1,0 +1,329 @@
+# Task Board
+
+這份文件說明共享任務板的設計目的、資料流、MCP 使用方式、以及
+哪些行為是有保證的，哪些只是 best-effort。
+
+## 1. 設計初衷
+
+- Task board 是整個 fleet 共用的工作清單。
+- lead 用它分派工作。
+- agent 用它認領工作。
+- reviewer 用它做驗收與收尾。
+- operator 可以直接觀察全局狀態。
+- 它的核心價值是「每個人看同一份狀態」。
+- 它不是個人待辦清單。
+- 它也不是單純的訊息信箱。
+- 它是可回放的狀態機。
+- 目前 canonical source 不是 `tasks.json`。
+- canonical source 是 `task_events.jsonl`。
+- `tasks.json` 是舊格式遷移來源。
+- 新的讀路徑透過 replay 折疊事件。
+- 這表示 board 的歷史是 append-only。
+- 也表示狀態可重建。
+- 這是審計與回溯的基礎。
+- 也是 task sweep 與 health 的共同基礎。
+- 任何新功能都應該沿用這個模型。
+- 如果要改 board 狀態，優先考慮事件，而不是直接改檔。
+
+## 2. 檔案與模組
+
+- `src/task_events.rs` 負責事件格式與 replay。
+- `src/tasks.rs` 負責 MCP board surface 與舊資料橋接。
+- `src/mcp/handlers/task.rs` 只是把 MCP call 轉給 `tasks.rs`。
+- `task_events.jsonl` 是 canonical event log。
+- `task_events_archive/` 是歷史封存區。
+- `tasks.json` 是 legacy bridge 檔。
+- 讀者應把 `tasks.json` 視為過渡資料。
+- 寫入者應把 `task_events.jsonl` 視為真相。
+- `TaskBoardState` 是 replay fold 的輸出。
+- `TaskRecord` 是 board 的讀模型。
+- `TaskEvent` 是寫模型。
+- `TaskId` 與 `InstanceName` 都是 newtype。
+- 這是為了避免 ID 混用。
+- replay 對未知 variant 失敗。
+- replay 對高於支援版本的 envelope 失敗。
+- 這是 fail-closed。
+- append 路徑採用單調 seq。
+- seq 是每個 emitter 各自遞增。
+- 這讓同一 emitter 的事件可以排序。
+- 同時也保留跨 emitter 的折疊順序。
+
+## 3. 資料模型
+
+- `Task` 是 MCP/reader 用的公共結構。
+- `TaskRecord` 是 replay 的 canonical view。
+- `Task` 內的 `status` 是字串。
+- `TaskRecord` 內的 `status` 是 enum。
+- `Task` 保留前相容欄位。
+- `TaskRecord` 保留歷史欄位。
+- `TaskEvent::Created` 帶 title、description、priority。
+- `TaskEvent::Created` 可帶 owner。
+- `TaskEvent::Created` 可帶 due_at。
+- `TaskEvent::Created` 可帶 depends_on。
+- `TaskEvent::Created` 可帶 routed_to。
+- `TaskEvent::Created` 可帶 branch。
+- `TaskEvent::Created` 可帶 bind。
+- `TaskEvent::Created` 可帶 eta_secs。
+- `TaskEvent::Claimed` 會設定 owner。
+- `TaskEvent::InProgress` 會設定 owner。
+- `TaskEvent::Done` 會把狀態變 Done。
+- `TaskEvent::Cancelled` 會把狀態變 Cancelled。
+- `TaskEvent::Blocked` 會寫入 block_reason。
+- `TaskEvent::Unblocked` 會清掉 block_reason。
+- `TaskEvent::Released` 會清掉 owner 與 routed_to。
+- `TaskEvent::Reopened` 會保留 owner。
+- `TaskEvent::OwnerAssigned` 只改 owner/routed_to。
+- `TaskEvent::PriorityChanged` 只改 priority。
+- `TaskEvent::Verified` 會更新狀態但不 close。
+- `TaskEvent::Linked` 會追加 PR link。
+- `TaskEvent::TaskCloseProposed` 是審核提案事件。
+
+## 4. 狀態語意
+
+- `open` 是待認領。
+- `claimed` 是有人接手。
+- `in_progress` 是已開始執行。
+- `verified` 是 reviewer 已核准。
+- `done` 是完成。
+- `cancelled` 是取消。
+- `blocked` 是被阻擋。
+- `depends_on` 會影響 view 層的有效狀態。
+- 依賴未完成時，open 會視為 blocked。
+- 依賴完成後，blocked 會自動回 open。
+- claimed / done / cancelled 不會被依賴覆寫。
+- 這個依賴 eval 是 in-memory。
+- 它不會寫成 Blocked/Unblocked 事件。
+- 這樣可避免把 view 狀態誤寫進歷史。
+- circular dependency 會被視為 blocked。
+- 缺失的 dependency 也會視為未完成。
+- claim 會尊重依賴後的 view。
+- 這避免認領一個尚未解除依賴的 task。
+- `started_at` 只在第一次進入 in_progress 時寫入。
+- `updated_at` 會隨事件更新。
+
+## 5. `task action=create`
+
+- `title` 是必要欄位。
+- `description` 可選。
+- `priority` 可選。
+- 預設 priority 是 `normal`。
+- `assignee` 可選。
+- `depends_on` 可選。
+- `due_at` 可直接傳 RFC3339。
+- `duration` 可傳 `30m`、`1h`、`2d`。
+- `branch` 會進入 record。
+- `bind` 可關閉自動 bind。
+- `eta_secs` 可啟用 stall watchdog。
+- create 會先 append `Created` 事件。
+- 成功後回傳 `event=created`。
+- 回傳內的 `task.status` 會是 `open`。
+- 回傳也保留舊欄位 `status=created`。
+- 這是 back-compat alias。
+- create 後可直接被 list 看見。
+- create 不會自動 claim。
+- create 不會自動 start。
+- create 也不會自動 done。
+
+## 6. `task action=list`
+
+- list 預設只列 actionable。
+- actionable 包含 `open`、`claimed`、`in_progress`、`blocked`。
+- 若 `include_history=true`，會列出歷史完成項目。
+- 若指定 `filter_status`，會尊重明確過濾。
+- 若指定 `filter_assignee`，會只看該 owner。
+- `limit` 會按 `updated_at` 由新到舊截斷。
+- 完成超過 14 天的項目在預設視圖會被壓掉。
+- `filtered_default` 會告知 caller 是否套用預設 trim。
+- 這讓 UI 不用自己猜是否少了項目。
+- list 的來源是 replay 之後再做 view 過濾。
+- 所以 list 看到的是 canonical fold 後的結果。
+- list 不會直接讀舊 `tasks.json`。
+- list 也不會修改 board。
+- list 是純讀操作。
+
+## 7. `task action=claim`
+
+- claim 需要 `id`。
+- claim 前會確認 instance 存在於 fleet.yaml。
+- claim 會先看 `list_all` 的 view。
+- 這表示它會尊重 dependency eval。
+- 若 task 不是 open，通常拒絕。
+- 例外是 self reclaim。
+- self reclaim 指的是本人再次 claim 自己已 claimed 的 task。
+- claim 會 append `Claimed` 事件。
+- 成功後回傳 `event=claimed`。
+- 回傳中的 `task.status` 會是 `claimed`。
+- claim 會把 owner 寫成呼叫者。
+- claim 不會保留原本 routed_to。
+- routed_to 會在 claim 時清掉。
+- 這反映 ownership 已移轉到具體 instance。
+
+## 8. `task action=done`
+
+- done 需要 `id`。
+- done 可帶 `result`。
+- done 可帶 `done_source`。
+- done 會先讀 replay record。
+- done 預設採 owner 作為 by。
+- 若沒有 owner，就用 caller。
+- `force=true` 會啟用 ghost-owner cleanup。
+- `force_reason` 在 force 模式下必填。
+- force 會記錄 event_log audit entry。
+- force 也會把 caller 與 reason 寫進事件 result。
+- 這樣 replay trail 也看得到審計原因。
+- done 會 append `Done` 事件。
+- 成功後回傳 `event=done`。
+- 回傳中的 `task.status` 會是 `done`。
+- done 後會嘗試清理 bound worktree 的 init commit。
+- 那是 best-effort。
+- 清理失敗不會阻塞 done 回應。
+
+## 9. `task action=update`
+
+- update 需要 `id`。
+- update 可改 `status`。
+- update 可改 `priority`。
+- update 可改 `assignee`。
+- update 可帶 `force`。
+- update 可帶 `force_reason`。
+- status transition 會對應 canonical event。
+- `open -> claimed` 會發 Claimed。
+- `open -> in_progress` 會發 InProgress。
+- `* -> done` 會發 Done。
+- `* -> cancelled` 會發 Cancelled。
+- `* -> blocked` 會發 Blocked。
+- `blocked -> open` 會發 Unblocked。
+- `claimed/in_progress -> open` 會發 Released。
+- `done -> open` 會發 Reopened。
+- priority change 會發 PriorityChanged。
+- assignee change 會發 OwnerAssigned。
+- 多個變更可合併在同一次 append_batch。
+- 這讓一個 update 呼叫可以原子落盤。
+- update 的 ACL 跟 done 一樣看 owner/orchestrator。
+
+## 10. `task action=sweep`
+
+- sweep 是操作板清理工具。
+- 它不是自動常駐的強制行為。
+- 它支援 dry-run。
+- `apply=false` 是預設。
+- apply 前需要先有 `confirm_ids`。
+- apply 會依 dry-run 提供的候選執行取消。
+- sweep 主要處理陳舊任務分類。
+- 它也會處理 PR close 對應的 task 結案。
+- sweep 的實作會走 `scan_categories`。
+- sweep 的 apply 會批次 emit Cancelled。
+- sweep 會記錄 audit reason。
+- sweep 會把結果寫進 event_log。
+- 這讓 operator 可以先看 plan 再決定。
+
+## 11. `task action=health`
+
+- health 是一張板的快照。
+- 它不是變更。
+- 它回傳 totals。
+- 它回傳 by_status。
+- 它回傳 ghost_owners。
+- 它回傳 stale_claims。
+- 它回傳 age aggregates。
+- 它回傳 recommendations。
+- ghost_owners 分 strict 和 soft。
+- strict 代表 owner 已不在 fleet 和 live。
+- soft 代表 owner 還在 fleet 但不在 live。
+- stale_claims 會找過期 due_at 的 claimed tasks。
+- age 統計只看 non-terminal。
+- recommendations 是 operator 的 next-step hint。
+- health 對 board hygiene 很重要。
+- 它也讓 operator 先看到風險再 sweep。
+
+## 12. 事件記錄與遷移
+
+- canonical log 是 `task_events.jsonl`。
+- append 會先拿 lock 再寫。
+- append_batch 會一次 fsync 多個事件。
+- replay 會先 fold archive，再 fold hot log。
+- replay 是 strict reader。
+- replay 看到未知 event variant 會 abort。
+- replay 看到高版本 schema 會 abort。
+- 這是刻意 fail-closed。
+- `tasks.json` 只在 migration 中出現。
+- migration 會把 legacy tasks 轉成事件。
+- migration 成功後會把舊檔改名成 `.legacy_pre_v2`。
+- 這樣 operator 還能考古。
+- board 的讀面已不依賴舊檔。
+- board 的寫面也不應回去改舊檔。
+
+## 13. ACL 與權限
+
+- 未指派 task 可由任何人 mutating。
+- owner 可以改自己的 task。
+- owner 的 team orchestrator 也可以改。
+- team assignee 的 orchestrator 也可以改。
+- system identities 有 allow-list bypass。
+- `system:auto_orphan`、`system:task_sweep` 等屬於系統身分。
+- force 模式是歷史資料清理用途。
+- force 不是一般使用者的捷徑。
+- force 必須有 reason。
+- ACL 判斷是 replay snapshot 上的 view。
+- 這表示有很小的 TOCTOU 窗口。
+- 但 canonical truth 還是 event log。
+- 衝突最後會由 replay 後序事件決定。
+
+## 14. 與其他子系統的關係
+
+- `team` 模組會影響 assignee 解析。
+- `worktree` / `binding` 會影響 done 後清理。
+- `dispatch` 會建立 task 與 branch 的關聯。
+- `ci_watch` 可能把 PR 成果回寫成 Done。
+- `decision` 不直接管 task board。
+- `inbox` 會承載 task-related 通知。
+- `health` 會把 task board 當作 operator snapshot。
+- `task sweep` 常跟 `ci sweep` 一起看。
+- `release_worktree` 不會直接改 task board。
+- 但 release 後常會清理與 task 相關的檔案狀態。
+
+## 15. 操作範例
+
+- 建立任務時先填 `title`。
+- 如果是追蹤性工作，填 `branch`。
+- 如果要估時，填 `eta_secs`。
+- 如果有依賴，就填 `depends_on`。
+- 如果任務屬於某人，填 `assignee`。
+- 如果要跨 team，先確認 team 已建立。
+- 如果要查全板，先跑 `task action=list`。
+- 如果只看自己，搭配 `filter_assignee`。
+- 如果要看卡住狀態，查 `task action=health`。
+- 如果要清理過期 claim，用 `task action=sweep`。
+- 如果要驗證 sweep 影響，先 dry-run 再 apply。
+- 如果要做歷史清理，才考慮 `force=true`。
+- 如果 reviewer 要接棒，通常看 `branch` 與 `task_id`。
+- 如果要回報結果，done 事件比純文字更可追溯。
+
+## 16. 實作檢查點
+
+- 任何新事件 variant 都要更新 replay fold。
+- 任何新狀態都要更新 list/health 投影。
+- 任何寫入都要考慮 append_batch 原子性。
+- 任何新增 action 都要更新 MCP schema。
+- 任何 ACL 變更都要補測試。
+- 任何 migration 都要保留 idempotency。
+- 任何 board 行為都不要默默吞掉錯誤。
+- 若要做 report-only 功能，優先做 read model。
+- 若要改 board 寫路徑，先看 task_events。
+- 若要修改 task UI，先確認 replay 仍能重建。
+- 若要新增 sweep 類規則，先檢查 health 是否也要反映。
+- 若要改 legacy `tasks.json`，要確認它是否仍是 bridge。
+
+## 17. 總結
+
+- Task board 是 fleet 的共享工作協議。
+- 它的語意靠事件維持，而不是靠單一 mutable 檔案。
+- `task create/list/claim/done/update/sweep/health` 是主要使用面。
+- 預設清單是 actionable。
+- 依賴是 view 層自動計算。
+- ACL 是 owner / orchestrator / system identity。
+- 批次 append 與 strict replay 是最重要的兩個 invariant。
+- 如果看到 board 狀態不對，先查事件，不要先改視圖。
+- 如果要擴充 board，先更新 event model。
+- 如果要 debug，先看 `task_events.jsonl` 與 replay。
+- 這就是這個模組的設計核心。

--- a/docs/FEATURE-teams.md
+++ b/docs/FEATURE-teams.md
@@ -1,0 +1,255 @@
+# Teams
+
+這份文件說明 team 的設計、如何建立/更新/刪除 team、以及它和
+`send team=...` 廣播路徑之間的關係。
+
+## 1. 設計初衷
+
+- Team 是把 agents 組織成群組的方法。
+- 一個 team 對應一個名稱。
+- 一個 team 可以有多個 members。
+- 一個 team 必須有一個 orchestrator。
+- orchestrator 是該 team 的主要協調者。
+- team 的用途是結構化協作。
+- 它比單一 instance 更適合分工。
+- 它也讓廣播可以針對群組發送。
+- team 資料現在由 `fleet.yaml` 內的 `teams:` 保存。
+- `teams.json` 已經是舊橋接路徑。
+- runtime CRUD 直接寫 `fleet.yaml`。
+- 讀取也直接從 `fleet.yaml` 投影。
+- 因此 team 不是另一份平行真相。
+- 它只是 fleet 的一部分。
+- 若 team 狀態變怪，先看 `fleet.yaml`。
+- 若要看 runtime 差異，再看 list 的 stale_members。
+
+## 2. 檔案與模組
+
+- `src/teams.rs` 是主要實作檔。
+- `src/fleet.rs` 是實際存放層。
+- `src/mcp/handlers/task.rs` 不碰 team。
+- `src/mcp/handlers/dispatch.rs` 會把 `team` 參數送進 `send`。
+- `src/mcp/handlers/comms.rs` 會檢查 team 與 orchestrator。
+- `src/api/handlers/instance.rs` 會讀 team 資訊做提示。
+- `teams.rs` 內的 `Team` 是投影模型。
+- `TeamConfig` 才是 `fleet.yaml` 寫入型態。
+- `stale_members` 只在 list 投影時補上。
+- `find_team_for` 的 projection 不需要 stale_members。
+- `degraded` 會在 list 回傳裡附加。
+- 這是 operator 可見的警訊欄位。
+- 讀者不要把 `degraded` 當成持久欄位。
+- 它是 view 層訊號。
+
+## 3. team 資料模型
+
+- `name` 是 team 名稱。
+- `members` 是 team 成員清單。
+- `orchestrator` 是可選欄位，但語意上很重要。
+- `orchestrator` 若缺失，team 變 degraded。
+- `description` 是可選說明。
+- `created_at` 是 runtime 或 operator 建立時間。
+- `source_repo` 是 team 的來源 repo 路徑。
+- `stale_members` 是 list 投影用。
+- `stale_members` 的值來自 live registry 比對。
+- `stale_members` 空時不會輸出到 JSON。
+- 這維持 back-compat。
+- `find_team_for` 回傳完整 Team。
+- `list` 回傳 `{"teams": [...]}`。
+- `get_members` 只是抓 member 清單。
+- `resolve_team_orchestrator` 是 routing 用。
+- `is_orchestrator_of` 是 ACL 用。
+
+## 4. `team action=create`
+
+- `name` 是必要欄位。
+- `members` 是必要欄位。
+- `orchestrator` 可省略，但建議填。
+- `orchestrator` 必須是 members 的其中一個。
+- 如果 orchestrator 不在 members 內，create 會錯。
+- `source_repo` 可省略。
+- 省略時會產生 warning。
+- 那個 warning 會提醒你 dispatch binding 可能 fall through。
+- create 會先讀 fleet.yaml。
+- 若同名 team 已存在，create 會拒絕。
+- 若任何 member 已在其他 team，也會拒絕。
+- 這是 one-agent-one-team 約束。
+- create 成功後會把 team 寫進 `fleet.yaml`。
+- 成功回應是 `status=created`。
+- 回應也可能帶 `warnings`。
+- source_repo 缺失時的 warning 不阻擋建立。
+- 但 operator 應盡快補上。
+
+## 5. `team action=list`
+
+- list 會回傳所有 team。
+- list 的資料來源是 `fleet.yaml`。
+- list 會呼叫 `runtime::list_live_agents`。
+- 如果 live registry 讀不到，stale_members 會維持空。
+- list 會比對每個 member 是否在 live。
+- 不在 live 的 member 會進入 stale_members。
+- stale_members 會排序。
+- team 本體也會排序投影。
+- 這讓結果比較穩定。
+- list 也會加上 `degraded`。
+- `degraded=true` 代表 orchestrator 缺失。
+- 這是 operator 要看的重要訊號。
+- list 不是 mutating action。
+- list 也不會自動修復 team。
+
+## 6. `team action=update`
+
+- update 需要 `name`。
+- update 可加 `add`。
+- update 可加 `remove`。
+- update 可加 `orchestrator`。
+- update 可加 `source_repo`。
+- `remove` 不能移除目前 orchestrator。
+- 若要換 orchestrator，要先指定新的 orchestrator。
+- 新 orchestrator 必須在更新後的 members 裡。
+- `add` 不能把 member 加進另一個 team。
+- 這個檢查遵守 one-agent-one-team。
+- `source_repo` 若沒給，會沿用舊值。
+- update 成功後會寫回 `fleet.yaml`。
+- update 回傳 `status=updated`。
+- update 失敗時會回傳 error。
+- update 是 team 結構調整的主要工具。
+
+## 7. `team action=delete`
+
+- delete 需要 `name`。
+- delete 會先 snapshot team 存在與 members。
+- 如果 team 不存在，直接回錯。
+- delete 不只是移除 yaml 節點。
+- delete 會 cascade 刪除每一個 member instance。
+- cascade 會呼叫 `full_delete_instance`。
+- 這會沿用 instance teardown 的標準流程。
+- 若某 member 刪除失敗，delete 會收集警告。
+- delete 會盡可能繼續清理其他 member。
+- 如果最後 team 變成空了，也算成功。
+- `remove_team_from_yaml` 的結果不一定只有一種成功路徑。
+- 只要 team 最後不在 fleet.yaml 就算完成目的。
+- delete 成功回應會包含 `members_cleaned`。
+- 如果有警告，回應會帶 `cascade_warnings`。
+
+## 8. 成員刪除與自動降級
+
+- `remove_member_from_all` 會把 instance 從所有 team 移除。
+- 它也會處理 orchestrator 身分。
+- 如果移除後 team 沒成員了，team 直接刪掉。
+- 如果移除的是 orchestrator，但 team 還有其他成員，team 會 degraded。
+- degraded team 的 orchestrator 會變成 None。
+- degraded team 不會自動找新 orchestrator。
+- 這是 operator 要接手的部分。
+- 函式會對每個 degraded team 建 urgent task。
+- 任務標題會提示哪個 team 失去 orchestrator。
+- 這把問題從隱性降級轉成明顯待辦。
+- `remove_member_from_all` 是 teardown 的一部分。
+- 不是一般協作的常用入口。
+- 但它對刪除 instance 很重要。
+
+## 9. 參考查詢
+
+- `find_team_for(home, member)` 會回傳 member 所屬 team。
+- 找不到就回 `None`。
+- `get_members(home, team_name)` 只回 members 清單。
+- `resolve_team_orchestrator(home, name)` 用於 assignee routing。
+- 若 name 是 team，會回 orchestrator。
+- 若 team degraded，會回 Err。
+- 若 name 不是 team，會回 Ok(None)。
+- `is_orchestrator_of(home, caller, member)` 用於 ACL。
+- 它會檢查 caller 是否是 member 所屬 team 的 orchestrator。
+- 這些 helper 很常被 task board 讀到。
+- 也會被 comms / dispatch 路徑讀到。
+- 它們是讀模型，不是 mutation。
+- 建文件時要區分這兩類。
+
+## 10. 與 `send team=...` 的關係
+
+- `send` tool 支援 `team` 參數。
+- `team=fixup` 代表廣播給整個 team。
+- 這不是發給 team 名稱本身。
+- 實際上會散發到 team 的成員。
+- `send` 也支援 `targets`、`tags`、`target_instance`。
+- team 廣播是其中一種路由方式。
+- 只要 team 成員集合變動，廣播目標也會變。
+- 這表示 `team list` 的 stale_members 很實用。
+- stale_members 幫你看哪些人會收不到廣播。
+- team 廣播與 orchestrator routing 是兩件事。
+- orchestrator 用於 task 路由與 ACL。
+- team 廣播用於訊息分發。
+- 兩者常一起出現，但語意不同。
+
+## 11. 與 task board 的關係
+
+- task assignee 可以是一個 team name。
+- 如果 assignee 是 team，task 會路由到 orchestrator。
+- 這個 route 由 `resolve_team_orchestrator` 決定。
+- 如果 team degraded，task 不能 route。
+- 因此 team 健康會影響 task 生命週期。
+- `team delete` 也會牽動 task orphan cleanup。
+- 某些刪除後會產生 urgent task。
+- 這是團隊治理的訊號。
+- task board 可以幫你追 team 的工作。
+- team list 可以幫你追 task board 的可達性。
+
+## 12. 與 instance lifecycle 的關係
+
+- 刪 instance 時會呼叫 `remove_member_from_all`。
+- 這會把 instance 從所有 team 中拿掉。
+- 如果 instance 是 orchestrator，team 會 degraded。
+- 如果 instance 是唯一成員，team 會消失。
+- 這是 instance teardown 的一環。
+- 因此 team 並不是孤立資料結構。
+- 它會跟 instance 生滅一起變動。
+- 這也是為什麼 list 要顯示 stale_members。
+- 這讓 operator 看到名單落差。
+
+## 13. 行為約束
+
+- team 名稱應該穩定。
+- member 名單應該避免重複。
+- orchestrator 應該總是屬於 members。
+- source_repo 最好不要缺。
+- 如果缺了，dispatch 自動 bind 會掉到較弱的 fallback。
+- update 不應讓 team 掉到無法路由的狀態。
+- delete 不應默默跳過整個 team。
+- delete 的 cascade 失敗要可見。
+- list 的 stale_members 應該維持排序。
+- degraded 狀態要讓 operator 一眼看懂。
+
+## 14. 常見操作流程
+
+- 新團隊：先 create。
+- 建議一開始就指定 orchestrator。
+- 若要調整成員，使用 update。
+- 若要重定向協調者，先確保新 orchestrator 仍在成員中。
+- 若要移除成員，注意不要移除最後的 orchestrator。
+- 若要解散團隊，使用 delete。
+- 若只是確認誰是誰的 orchestrator，用 find_team_for。
+- 若要看整體健康，用 team list。
+- 若要把訊息丟給整團，使用 send team=...。
+- 若要清掉失聯成員，先看 stale_members。
+
+## 15. 實作檢查點
+
+- `fleet.yaml` 是唯一寫入點。
+- `list` 只是投影，不要變成寫路徑。
+- `source_repo` 缺失應該可被 warning 看見。
+- `degraded` 不應被當作持久欄位。
+- `stale_members` 不應直接寫進 fleet.yaml。
+- delete 的 cascade 要保留錯誤彙整。
+- 更新 orchestrator 時要先檢查 post-mutation members。
+- one-agent-one-team 是重要 invariant。
+- broadcast 與 routing 不可混為一談。
+- 任何新欄位都要確認 projection 與存放一致。
+
+## 16. 小結
+
+- Team 是協作分群的基本單位。
+- 它的真相在 `fleet.yaml`。
+- `team create/delete/list/update` 是主要治理工具。
+- `send team=...` 是主要廣播入口。
+- orchestrator 是 team 的核心協調點。
+- degraded team 不是壞掉的資料，而是需要 operator 處理的狀態。
+- stale_members 是可觀測性欄位。
+- 如果 team 行為異常，先看 fleet，再看 live registry。
+- 這個模組的設計目標是讓 team 成為清楚、可查、可恢復的協作結構。

--- a/docs/FEATURE-worktree.md
+++ b/docs/FEATURE-worktree.md
@@ -1,0 +1,281 @@
+# Worktree Management
+
+這份文件說明 git worktree 的建立、綁定、釋放、GC，以及
+`bind_self` / `release_worktree` / `force_release_worktree` /
+`repo action=checkout` / `repo action=release` 之間的分工。
+
+## 1. 設計初衷
+
+- 每個 agent 應該在自己的工作空間工作。
+- 這樣可以避免 branch 衝突。
+- 也可以避免多 agent 共享同一個 checkout。
+- worktree 是這個隔離模型的核心。
+- worktree 讓 branch 與 agent 的關係可追蹤。
+- 這也讓 release 與 GC 可以獨立治理。
+- canonical 佈局是 `~/.agend/worktrees/<agent>/<branch>/`。
+- 這是 daemon-managed 的新 layout。
+- 舊 layout 仍可被偵測。
+- 但新 create 不應回到舊 layout。
+- 綁定資訊放在 `binding.json`。
+- daemon-managed 標記放在 `.agend-managed`。
+- pinned 狀態放在 `.agend-pinned`。
+- GC 只看 daemon-managed worktree。
+- operator-created worktree 不應被 daemon 自動刪。
+
+## 2. 目錄與標記
+
+- `worktree_path(home, agent, branch)` 是 canonical path helper。
+- 它會回傳 `<home>/worktrees/<agent>/<branch>/`。
+- `legacy_worktree_path` 只用於偵測舊 layout。
+- 舊 layout 是 `<source_repo>/.worktrees/<agent>/`。
+- `is_daemon_managed()` 檢查 `.agend-managed` 是否存在。
+- `.agend-managed` 內會寫 `agent=...`。
+- `.agend-managed` 內會寫 `branch=...`。
+- `.agend-managed` 內會寫 `leased_at=...`。
+- `release()` 之後還會補 `released_at=...`。
+- `.agend-pinned` 表示 operator override。
+- pinned 的 worktree 不應進 GC。
+- binding.json 才是 runtime lease 的關鍵來源。
+- source_repo 會從 binding.json 讀回。
+- 這讓 release 能從 owning repo 角度執行 git 操作。
+
+## 3. worktree 建立
+
+- `worktree::create()` 先檢查是不是 git repo。
+- 不是 git repo 就直接回 `None`。
+- 若 repo 沒有 HEAD，會嘗試補一個 init commit。
+- 這是為了讓 worktree 建立可在空 repo 上啟動。
+- init commit 失敗會回 `None`。
+- branch 若未指定，預設是 `agend/<instance_name>`。
+- branch 會先經過 `validate_branch`。
+- 不合法的 branch 會被拒絕。
+- worktree path 會根據 agent 與 branch 組合。
+- 若目標目錄已存在，會先驗證實際 HEAD。
+- 如果現有 worktree 的 branch 不一致，視為 lease conflict。
+- 如果現有 worktree 的 branch 一致，會直接 reuse。
+- reuse 時回傳的 `WorktreeInfo` 仍指向既有 path。
+- 若 worktree 不存在，才呼叫 `git worktree add`。
+- `git worktree add` 失敗時會嘗試另一條相容路徑。
+- create 的重點是「可重用、可驗證、可失敗回報」。
+
+## 4. create 的使用者面
+
+- `repo action=checkout` 是外部最常見的入口。
+- `bind=true` 代表 atomic provision + bind。
+- `bind=false` 代表只建立檢視用 worktree。
+- `bind=true` 需要 `AGEND_INSTANCE_NAME`。
+- `bind=true` 不接受 protected branch。
+- `bind=true` 會把 HEAD 放在 named branch。
+- `bind=false` 會以 detached HEAD 建立。
+- `bind=true` 會走後續 tail-ops。
+- tail-ops 包含 marker、binding.json、ci watch。
+- `bind_self` 也是一種綁定入口。
+- 但它適合 mid-lifecycle 重綁。
+- `bind_self` 可使用 fleet.yaml 的 source_repo。
+- `bind_self` 也支援 `rebase_mode=true`。
+- fresh-task dispatch 傾向用 `repo action=checkout bind:true`。
+- mid-lifecycle recovery 傾向用 `bind_self`。
+
+## 5. lease 與 bind
+
+- `worktree_pool::lease()` 會拒絕 protected branch。
+- protected set 由 `agent_ops::is_protected_ref` 定義。
+- lease 會呼叫 `worktree::create()`。
+- lease 成功後會寫 `.agend-managed`。
+- lease 也會寫 binding.json。
+- binding.json 是 release 的關鍵輸入。
+- lease 的 binding 會把 worktree、source_repo 一起記下。
+- lease 是 daemon-managed worktree 的建立語意。
+- `bind_self` 與 `repo action=checkout bind:true` 最終都會走 lease 邏輯。
+- 這讓綁定狀態與檔案系統狀態一致。
+- bind-in-flight guard 也由 release/cleanup 清掉。
+- lease 失敗通常代表 branch conflict 或 validation 問題。
+
+## 6. soft release
+
+- `worktree_pool::release()` 是 soft mark。
+- soft release 不會刪掉 worktree。
+- 它會先解除 binding。
+- 它會把 released_at 寫進 `.agend-managed`。
+- 這讓 GC 有 grace window。
+- soft release 適合切換到可回收狀態。
+- 它是 Phase 3 soft mark，不是 hard delete。
+- `release()` 之後 worktree 仍存在。
+- 但它已經變成 GC 候選種子。
+- 若 binding 已無，之後可進一步做 hard release。
+
+## 7. hard release
+
+- `release_full()` 是 hard release。
+- 這是 `release_worktree` MCP tool 的核心。
+- 它會先讀 binding.json。
+- 如果沒有 binding，回傳 idempotent no-op。
+- 它只會處理 `.agend-managed` worktree。
+- 如果 worktree 沒有 marker，會拒絕刪除。
+- 這是防止 operator-created worktree 被誤刪。
+- 若 worktree path 已不存在，會先 prune 相關 git metadata。
+- 若 `git worktree remove --force` 成功，會標記 worktree_removed。
+- 若 git command 失敗，會 fallback 到 remove_dir_all。
+- remove_dir_all 失敗也不應卡住 binding 清理。
+- release_full 會清 binding。
+- release_full 也會清 bind-in-flight。
+- 這避免 stale lock 卡住 rebind。
+- release_full 之後還會做 branch cleanup 評估。
+- branch cleanup 只有在 managed_verified 時才可進行。
+
+## 8. branch cleanup
+
+- branch cleanup 只針對已釋放的 daemon-managed worktree。
+- 它不是一般釋放的主責。
+- 它會檢查 branch 是否 protected。
+- protected branch 不會被刪 local ref。
+- 它會先 fetch --prune 遠端。
+- 它會檢查 branch 是否已 merge into main。
+- 它也會檢查 remote tracking ref 是否已消失。
+- 只要符合條件，就可以刪本地 branch。
+- 這是 release_full 的附加清理。
+- 若分支未 merged，會跳過。
+- `branch_cleanup_skipped_reason` 會說明原因。
+- 這讓 release 的回應可審計。
+
+## 9. emergency cleanup
+
+- `force_release_worktree` 是 emergency tool。
+- 它是給 stale worktree directory 使用的。
+- 它的 target 是 `<home>/worktrees/<agent>/<branch>/`。
+- 它會先驗證 path 安全。
+- 安全檢查會拒絕 pool 外路徑。
+- 它會嘗試直接 remove_dir_all 目錄。
+- 目錄刪除失敗不阻止 binding 清理。
+- 它會再呼叫 `release_full()`。
+- 它還會做 git metadata prune。
+- 這是為了處理 no-binding 但 dir 殘留的狀況。
+- `rebase_clean_self()` 是共用 helper。
+- `bind_self(rebase_mode=true)` 也會用到它。
+- 這讓 recovery 與 emergency cleanup 共用同一組安全邏輯。
+
+## 10. repo release
+
+- `repo action=release` 是 generic path release。
+- 它接受一個 path。
+- 它會先 validate/canonicalize path。
+- 不安全的系統路徑會被拒絕。
+- `HOME` 自己也不能刪。
+- path 太淺也會拒絕。
+- 成功時會先嘗試 `git worktree remove --force`。
+- 失敗時會 fallback 到 remove_dir_all。
+- 它不依賴 agent binding。
+- 因此它比較像「對某個路徑做釋放」。
+- `release_worktree` 則是 agent-centric。
+- 兩者一個偏 path，一個偏 agent。
+
+## 11. GC 語意
+
+- `gc_dry_run()` 是非破壞性的。
+- 它只列候選。
+- `gc_cutover()` 才真的刪。
+- `gc_cutover()` 需要 `AGEND_WORKTREE_GC=1`。
+- 沒設 env 會直接跳過。
+- GC 只看 daemon-managed worktree。
+- GC 也會跳過 pinned。
+- GC 也會跳過還有 active binding 的 worktree。
+- GC 必須看到 `released_at`。
+- 沒有 `released_at` 就視為仍 active。
+- GC grace window 是 24 小時。
+- 超過 grace 才算候選。
+- `gc_dry_run` 會記錄 event_log。
+- `gc_cutover` 也會記錄 event_log。
+- 這讓 operator 可以先看 plan 再切 cutover。
+
+## 12. GC 候選條件
+
+- candidate 必須是 daemon-managed。
+- candidate 不能被 pin。
+- candidate 要能解析出 agent 名稱。
+- candidate 不能還有 binding。
+- candidate 必須有 `released_at`。
+- `released_at` 必須超過 24 小時。
+- 新 layout 與 legacy layout 都會被掃。
+- 新 layout 是 `<home>/worktrees/<agent>/<branch>/`。
+- legacy layout 是 `<home>/workspace/*/.worktrees/*/`。
+- `evaluate_candidate()` 是真正的條件中心。
+- 這讓 dry-run 與 cutover 共用判斷。
+- 因此候選一致性比較好。
+
+## 13. pin / unpin
+
+- `.agend-pinned` 是人工保留標記。
+- `pin()` 會寫入時間戳。
+- `unpin()` 會移除 pin file。
+- `is_pinned()` 只是檢查檔案是否存在。
+- pin 是 operator override。
+- 它用來阻止 GC。
+- 這對長期保留的 worktree 很重要。
+- pin 不會改 binding。
+- pin 也不會改 released_at。
+- 它只是 GC 的排除條件。
+
+## 14. orphan 與 reconcile
+
+- `reconcile_orphan_leases()` 是 boot-time log-only 掃描。
+- 它會找 runtime binding.json。
+- 若 worktree 不存在，會告警。
+- 它不會直接刪除。
+- 這是診斷用途。
+- 這跟 GC 不一樣。
+- GC 是刪。
+- reconcile 是觀測。
+- 如果 binding 與檔案系統不一致，先看這裡。
+- 這有助於找出 stale registry state。
+
+## 15. 安全與邊界
+
+- 不要直接對 pool 外路徑做 remove_dir_all。
+- 不要把 operator-created worktree 當 daemon-managed。
+- 不要在未驗證 branch 的情況下 lease。
+- 不要讓 protected branch 進 lease。
+- 不要讓 release_full 在 marker 不存在時硬刪。
+- 不要跳過 bind-in-flight 清理。
+- 不要把 GC 當成 release 的替代品。
+- release 是顯式釋放。
+- GC 是延後回收。
+- force_release_worktree 是 emergency recovery。
+
+## 16. 使用流程
+
+- 新任務先用 `repo action=checkout bind:true`。
+- mid-lifecycle 恢復用 `bind_self`。
+- 準備釋放時先用 `release_worktree`。
+- 若還有殘留 dir，再用 `force_release_worktree`。
+- 只想看候選，先跑 `gc_dry_run`。
+- 確認無誤且要切回收，再設 `AGEND_WORKTREE_GC=1`。
+- 若要保留工作樹，先 pin。
+- 若要解除保留，再 unpin。
+- 若要清理整條路徑，先確認 binding 與 marker。
+- 如果看到 stale bind-in-flight，先看 release_full 路徑。
+
+## 17. 實作檢查點
+
+- canonical path 要一致。
+- 新增行為要保留 daemon-managed marker。
+- release 不應把 operator worktree 刪掉。
+- GC 不應掃到還在 bind 的 worktree。
+- GC grace 必須尊重 released_at。
+- 舊 layout 只做相容，不做新創建。
+- emergency cleanup 要維持 path safety。
+- release_full 的 binding 清理不可漏。
+- branch cleanup 必須看 protected set。
+- 任何新入口都要對齊 worktree pool 語意。
+
+## 18. 總結
+
+- worktree 是 agent 與 branch 的隔離層。
+- `repo action=checkout bind:true` 是新建綁定的主入口。
+- `bind_self` 是 mid-lifecycle 重綁入口。
+- `release_worktree` 是正式釋放入口。
+- `force_release_worktree` 是 emergency recovery 入口。
+- `repo action=release` 是 path-centric 釋放入口。
+- `gc_dry_run` / `gc_cutover` 負責延遲回收。
+- `.agend-managed`、`.agend-pinned`、binding.json 共同描述狀態。
+- 如果 worktree 出問題，先判斷是 lease、release、還是 GC。
+- 這個模組的目標是讓工作空間隔離、可回收、可恢復。


### PR DESCRIPTION
## Summary
- Add Traditional Chinese feature docs for task board, teams, and worktree management.
- Describe actual MCP / daemon behavior from source, including event-log replay, team orchestration, and worktree lease / release / GC flows.

## Validation
- Documentation-only change.
- `git diff --cached --check`
