### PR TITLE
docs: feature documentation (TUI, skills, communication) #1195

### DIFF
--- a/docs/FEATURE-communication.md
+++ b/docs/FEATURE-communication.md
@@ -1,0 +1,397 @@
+# Agent 間通訊系統
+
+AgEnD Terminal 的通訊系統讓 agent 之間能進行結構化的訊息傳遞——委派任務、提出查詢、回報結果、廣播更新。
+
+## 設計理念
+
+多 agent 協作需要一個可靠的通訊管道。直接透過終端輸出傳遞訊息既不結構化也不可追蹤。通訊系統提供：
+
+- **結構化訊息**：每則訊息都有明確的類型（任務/查詢/回報/更新）
+- **持久化收件匣**：即使接收方暫時離線，訊息也不會遺失
+- **任務追蹤**：委派的任務可以追蹤進度和結果
+- **多種投遞方式**：單一目標、多目標廣播、團隊廣播
+
+---
+
+## 三個核心工具
+
+### `send` — 統一發送
+
+所有訊息發送都透過 `send` 工具。根據參數不同，自動分派到對應的處理路徑。
+
+```json
+{
+  "target_instance": "dev",
+  "message": "請修復 #123 的回歸問題",
+  "request_kind": "task",
+  "task_id": "t-20260525..."
+}
+```
+
+### `inbox` — 接收訊息
+
+查看收件匣中的待處理訊息。
+
+```json
+{}
+```
+
+無參數呼叫會取出所有未讀訊息。也可以查詢特定訊息狀態或對話串。
+
+### `reply` — 回覆外部頻道
+
+透過 Telegram、Discord 等外部頻道回覆使用者或操作者。
+
+```json
+{
+  "text": "任務已完成，PR 已建立"
+}
+```
+
+---
+
+## 訊息類型（request_kind）
+
+每則訊息都有一個 `request_kind`，決定接收方的處理義務和系統行為：
+
+| 類型 | 用途 | 回覆義務 |
+|------|------|----------|
+| `task` | 委派工作給其他 agent | 完成後需回報結果 |
+| `query` | 向其他 agent 提問 | 需要回覆答案 |
+| `report` | 回報任務結果或審查結論 | 通常不需回覆 |
+| `update` | 通知狀態更新 | 不需回覆 |
+
+### task — 任務委派
+
+用於指派工作給其他 agent。必須搭配 `task_id`（從任務看板取得）。
+
+```json
+{
+  "target_instance": "dev",
+  "message": "修復 sha_gate.rs 中空字串繞過的問題",
+  "request_kind": "task",
+  "task_id": "t-20260525040842727169-9",
+  "branch": "fix/1177-sha-gate-empty",
+  "success_criteria": "修復完成 + cargo test 通過 + PR 建立"
+}
+```
+
+task 類型支援額外的任務管理參數：
+
+| 參數 | 說明 |
+|------|------|
+| `task_id` | 任務看板 ID（必要，透過 `task action=create` 取得） |
+| `branch` | 指定 git 分支（自動綁定 worktree） |
+| `success_criteria` | 完成標準 |
+| `eta_minutes` | 預期完成時間 |
+| `force` / `force_reason` | 覆蓋忙碌閘門（需要說明原因） |
+| `expect_reply_within_secs` | 逾時監控（秒數） |
+| `next_after_ci` | CI 通過後自動通知的下一個 agent |
+
+### query — 提問
+
+向其他 agent 詢問問題。接收方需要回覆。
+
+```json
+{
+  "target_instance": "reviewer",
+  "message": "這個 race condition 修復方式正確嗎？",
+  "request_kind": "query"
+}
+```
+
+### report — 回報結果
+
+回報任務結果或審查結論。通常搭配 `correlation_id` 指向原始任務。
+
+```json
+{
+  "target_instance": "lead",
+  "message": "審查完成。VERIFIED — 4M/2L/1I。",
+  "request_kind": "report",
+  "correlation_id": "t-20260525040842727169-9",
+  "parent_id": "m-20260525044640824746-72",
+  "reviewed_head": "1c78314"
+}
+```
+
+| 參數 | 說明 |
+|------|------|
+| `correlation_id` | 對應的任務 ID（用於追蹤配對） |
+| `parent_id` | 回覆的訊息 ID（對話串關聯） |
+| `reviewed_head` | 審查時的 git HEAD SHA |
+
+### update — 狀態更新
+
+通知性質的訊息，不要求回覆。
+
+```json
+{
+  "target_instance": "lead",
+  "message": "PR #1187 CI 通過，等待審查",
+  "request_kind": "update"
+}
+```
+
+---
+
+## 投遞模式
+
+### 單一目標
+
+```json
+{
+  "target_instance": "dev",
+  "message": "..."
+}
+```
+
+訊息直接投遞到指定 agent 的收件匣。
+
+### 多目標廣播
+
+```json
+{
+  "targets": ["dev", "reviewer", "tester"],
+  "message": "..."
+}
+```
+
+同一則訊息投遞給多個指定的 agent。
+
+### 團隊廣播
+
+```json
+{
+  "team": "fixup",
+  "message": "..."
+}
+```
+
+投遞給指定團隊的所有成員。
+
+### 標籤廣播
+
+```json
+{
+  "tags": ["backend"],
+  "message": "..."
+}
+```
+
+根據標籤篩選投遞對象。
+
+廣播模式下，發送方自動排除在接收清單之外。每則訊息會附帶 `broadcast_context`，讓接收方知道這是一對多的訊息。
+
+---
+
+## 訊息投遞機制
+
+### PTY 注入（預設）
+
+當目標 agent 正在運行：
+
+1. 訊息寫入收件匣（append-only JSONL）
+2. 同時注入一行提示到 agent 的終端：
+   ```
+   [AGEND-MSG-PENDING] id=m-20260525... kind=task from=lead inbox=1
+   ```
+3. Agent 看到提示後，呼叫 `inbox` 工具讀取完整訊息
+
+### 收件匣備用
+
+當目標 agent 不在線上（未啟動、跨團隊、daemon 離線）：
+
+1. 訊息直接寫入收件匣 JSONL 檔案
+2. Agent 下次上線並呼叫 `inbox` 時收到
+
+### 失敗降級
+
+當 daemon API 呼叫失敗：
+
+1. 自動降級為直接寫入收件匣檔案
+2. 解析對話串（從 `parent_id` 推導 `thread_id`）
+3. 記錄投遞模式為 `inbox_fallback`
+
+無論哪種模式，訊息都不會遺失。收件匣使用 append-only JSONL 格式和檔案鎖，確保並行寫入的安全性。
+
+---
+
+## 收件匣操作
+
+### 取出未讀訊息
+
+```json
+// inbox（無參數）
+{}
+```
+
+回傳所有未讀訊息，並標記為已讀。已讀訊息不會在下次呼叫時重複出現。
+
+### 查詢特定訊息狀態
+
+```json
+// inbox（帶 message_id）
+{
+  "message_id": "m-20260525042040527659-39"
+}
+```
+
+回傳訊息的投遞狀態：已讀（含時間和投遞方式）、未讀過期、或找不到。
+
+### 取得對話串
+
+```json
+// inbox（帶 thread_id）
+{
+  "thread_id": "m-20260525035931943006-17"
+}
+```
+
+回傳指定對話串中的所有訊息，包含已讀和未讀。
+
+---
+
+## 對話串
+
+訊息可以透過 `thread_id` 和 `parent_id` 組成對話串：
+
+```
+訊息 A (id=m-001, thread_id=null)       ← 對話串起始
+  └─ 訊息 B (parent_id=m-001)           ← thread_id 自動繼承為 m-001
+      └─ 訊息 C (parent_id=m-002)       ← thread_id 繼承 m-001
+```
+
+規則：
+- 指定 `parent_id` 但未指定 `thread_id` 時，自動從父訊息繼承 `thread_id`
+- 如果父訊息本身沒有 `thread_id`，父訊息的 `id` 成為 thread root
+
+---
+
+## 任務看板整合
+
+### task_id 要求
+
+Sprint 58 Wave 4 引入了反停滯（anti-stall）契約：
+
+- `kind=task` 的廣播模式（team/targets/tags）**必須**提供 `task_id`
+- `kind=task` 的單一目標模式，如果未提供 `task_id`，系統自動建立
+
+取得 `task_id` 的方式：
+
+```json
+// 先建立任務
+{"action": "create", "title": "修復 #1177", "assignee": "dev"}
+// 回傳 task_id = "t-20260525..."
+
+// 再發送帶 task_id 的訊息
+{"target_instance": "dev", "request_kind": "task", "task_id": "t-20260525..."}
+```
+
+### task_id 格式
+
+- 前綴 `t-`
+- 長度 4-128 字元
+- 只允許英數字、連字號、底線
+
+### 逾時監控
+
+透過 `expect_reply_within_secs` 啟用逾時監控：
+
+```json
+{
+  "target_instance": "dev",
+  "request_kind": "task",
+  "task_id": "t-...",
+  "expect_reply_within_secs": 600
+}
+```
+
+如果在指定時間內沒有收到對應的 `kind=report`（以 `correlation_id` 配對），daemon 會向發送方的收件匣發出 `dispatch_idle_threshold_exceeded` 通知。
+
+fixup 團隊的任務預設自動啟用 10 分鐘逾時。其他團隊需要明確指定。
+
+---
+
+## 忙碌閘門
+
+當目標 agent 已經有認領（claimed）或進行中（in_progress）的任務時，`kind=task` 的投遞會被忙碌閘門擋下。
+
+```json
+// 覆蓋忙碌閘門
+{
+  "target_instance": "dev",
+  "request_kind": "task",
+  "force": true,
+  "force_reason": "緊急修復，需要立即處理"
+}
+```
+
+`force` 需要搭配 `force_reason` 說明原因，記錄在審計日誌中。
+
+---
+
+## Worktree 自動綁定
+
+當 `kind=task` 帶有 `branch` 參數時，系統自動為目標 agent 建立並綁定 git worktree：
+
+```json
+{
+  "target_instance": "dev",
+  "request_kind": "task",
+  "task_id": "t-...",
+  "branch": "fix/1177-sha-gate-empty"
+}
+```
+
+綁定流程：
+1. 從來源 repo checkout 指定分支到 worktree
+2. 將目標 agent 綁定到該 worktree
+3. 如果設定了 `next_after_ci`，自動監控 CI 結果
+
+設定 `"bind": false` 可以跳過自動綁定（例如只是通知，不需要工作目錄）。
+
+---
+
+## CI 通知串接
+
+`next_after_ci` 實現 CI 通過後的自動接力：
+
+```json
+{
+  "target_instance": "dev",
+  "request_kind": "task",
+  "branch": "fix/1177",
+  "next_after_ci": "reviewer"
+}
+```
+
+流程：
+1. Lead 委派任務給 dev，指定 `next_after_ci=reviewer`
+2. Dev 完成工作，推送 PR
+3. CI 通過後，daemon 自動通知 reviewer
+4. Reviewer 收到 `[ci-ready-for-action]` 訊息
+
+不需要手動設定 CI watch——委派時一步到位。
+
+---
+
+## 典型通訊流程
+
+### 完整的任務委派循環
+
+```
+Lead: task(create, title="修復 #1177") → task_id="t-..."
+Lead: send(target=dev, kind=task, task_id="t-...", branch="fix/1177", next_after_ci="reviewer")
+Dev:  inbox() → 取得任務
+Dev:  send(target=lead, kind=report, correlation_id="t-...", message="PR 已建立")
+CI 通過 → Reviewer 自動收到 [ci-ready-for-action]
+Reviewer: send(target=lead, kind=report, correlation_id="t-...", message="VERIFIED")
+```
+
+### 團隊廣播 / 跨 Agent 提問
+
+```
+send(team="fixup", kind=update, message="今日 merge freeze")
+send(target=reviewer, kind=query, message="M3 的 session 刪除時機如何？")
+```

--- a/docs/FEATURE-skills.md
+++ b/docs/FEATURE-skills.md
@@ -1,0 +1,302 @@
+# Skills 跨 Backend 技能系統
+
+Skills 系統讓你將可重用的技能（prompt、工具定義、參考文件）安裝一次，所有 backend 的 agent 都能自動使用。不需要為每個 backend 分別設定。
+
+## 設計理念
+
+不同的 AI backend（Claude、Codex、Gemini、OpenCode、Kiro）各有自己的技能目錄慣例（`.claude/skills/`、`.codex/skills/` 等）。手動在每個目錄下維護相同的技能檔案既繁瑣又容易不同步。
+
+Skills 系統提供一個統一的來源目錄 `~/.agend-terminal/skills/`，透過 symlink 自動映射到每個 backend 的慣例路徑。安裝一次，五個 backend 同時生效。
+
+---
+
+## 快速開始
+
+```bash
+# 從 GitHub 安裝技能
+agend-terminal skills add https://github.com/user/my-skill.git
+
+# 從本地目錄安裝
+agend-terminal skills add ~/projects/my-skill
+
+# 列出已安裝的技能
+agend-terminal skills list
+
+# 更新技能
+agend-terminal skills update my-skill
+
+# 移除技能
+agend-terminal skills remove my-skill
+```
+
+安裝後，下次啟動 agent 時技能會自動生效。
+
+---
+
+## 技能目錄結構
+
+### 統一來源
+
+所有技能儲存在單一目錄下：
+
+```
+~/.agend-terminal/
+├── skills/                    ← 統一技能來源
+│   ├── skill-forge/
+│   │   ├── SKILL.md          ← 技能描述文件（必要）
+│   │   └── [其他支援檔案]
+│   ├── code-review-expert/
+│   │   └── SKILL.md
+│   └── ...
+└── skills-lock.json           ← 版本鎖定記錄
+```
+
+### 每個 Agent 的映射
+
+daemon 啟動 agent 時，自動在 agent 的工作目錄下建立 symlink：
+
+```
+<agent-working-dir>/
+├── .claude/skills/   → ~/.agend-terminal/skills/
+├── .codex/skills/    → ~/.agend-terminal/skills/
+├── .gemini/skills/   → ~/.agend-terminal/skills/
+├── .opencode/skills/ → ~/.agend-terminal/skills/
+└── .kiro/skills/     → ~/.agend-terminal/skills/
+```
+
+每個 backend 啟動時讀取自己慣例路徑下的 `SKILL.md`，看到的都是同一份來源。
+
+---
+
+## CLI 命令
+
+### `skills add <source>`
+
+從 git repo 或本地路徑安裝技能。
+
+```bash
+# Git 來源（自動 shallow clone）
+agend-terminal skills add https://github.com/user/skill-forge.git
+agend-terminal skills add git@github.com:user/skill-forge.git
+
+# 本地路徑（完整複製）
+agend-terminal skills add /path/to/my-skill
+agend-terminal skills add ./relative/path
+```
+
+來源類型自動判斷：URL 或 `.git` 結尾視為 git，其餘視為本地路徑。
+
+安裝完成後，`skills-lock.json` 記錄來源和版本（git SHA 或檔案修改時間），供後續 `update` 使用。
+
+重複安裝同名技能會覆蓋更新。
+
+### `skills list`
+
+列出所有已安裝的技能，包含來源和版本資訊。
+
+```bash
+agend-terminal skills list
+```
+
+輸出範例：
+
+```
+skill-forge
+  source: https://github.com/user/skill-forge.git
+  version: abc123d
+  installed_at: 2026-05-16T10:00:00Z
+
+code-review-expert
+  source: /Users/suzuke/projects/code-review
+  version: 1747402800
+  installed_at: 2026-05-20T08:30:00Z
+```
+
+### `skills update [<name>]`
+
+重新從原始來源拉取最新版本。
+
+```bash
+# 更新單一技能
+agend-terminal skills update skill-forge
+
+# 更新所有技能
+agend-terminal skills update
+```
+
+Git 來源會重新 clone 取得最新 commit；本地路徑會重新複製。版本鎖定自動更新。
+
+### `skills remove <name>`
+
+移除技能及其鎖定記錄。
+
+```bash
+agend-terminal skills remove skill-forge
+```
+
+已移除的技能在下次 agent 啟動時不再可見。操作冪等——移除不存在的技能不會報錯。
+
+### `skills install <working_dir>`
+
+手動安裝技能到指定工作目錄。通常由 daemon 自動執行，此命令用於除錯或一次性設定。
+
+```bash
+agend-terminal skills install /tmp/test-agent-wd
+```
+
+---
+
+## 撰寫技能
+
+一個技能就是一個包含 `SKILL.md` 的目錄。`SKILL.md` 是 backend 讀取的進入點，格式為 Markdown。
+
+### 最小結構
+
+```
+my-skill/
+└── SKILL.md
+```
+
+### 帶支援檔案
+
+```
+my-skill/
+├── SKILL.md           ← 主要描述文件
+├── templates/
+│   └── review.md      ← 範本檔案
+└── examples/
+    └── usage.py       ← 範例程式
+```
+
+`SKILL.md` 的內容由 backend 定義如何解析。以 Claude 為例，`SKILL.md` 通常包含技能說明、觸發條件、和提示內容。AgEnD Terminal 本身不解析 `SKILL.md` 內容——只負責將目錄送達正確位置。
+
+---
+
+## 每個 Agent 的技能篩選
+
+透過 `fleet.yaml` 的 `skills` 欄位，可以控制每個 agent 看到哪些技能。
+
+### 預設行為：安裝所有技能
+
+```yaml
+instances:
+  dev:
+    backend: claude
+    # 沒有 skills 欄位 → 安裝所有技能
+```
+
+### 只安裝特定技能
+
+```yaml
+instances:
+  reviewer:
+    backend: claude
+    skills:
+      - code-review-expert
+      - skill-forge
+```
+
+reviewer 只會看到 `code-review-expert` 和 `skill-forge`，其他技能對它不可見。
+
+### 完全不安裝技能
+
+```yaml
+instances:
+  eval-runner:
+    backend: gemini
+    skills: []    # 空陣列 = 不安裝任何技能
+```
+
+### 篩選實作原理
+
+當 `skills` 指定了允許清單：
+
+1. 系統計算允許清單的 SHA-256 摘要
+2. 在 `~/.agend-terminal/.skills-stage/<digest>/` 建立篩選後的副本
+3. Agent 的 symlink 指向篩選後的 stage 目錄，而非統一來源
+
+Stage 目錄在 7 天後自動清理。相同的允許清單會重用同一個 stage 目錄。
+
+---
+
+## 自動安裝時機
+
+Daemon 在以下時機自動為 agent 安裝技能：
+
+| 時機 | 說明 |
+|------|------|
+| 冷啟動 | daemon 啟動時，在 spawn 每個 agent 前同步安裝 |
+| 崩潰重啟 | agent crash 後 respawn 前重新安裝 |
+| Stage 2 重啟 | 乾淨重啟流程中重新安裝 |
+| TUI 新增 agent | 透過 `Ctrl+B c` 或命令面板新增時自動安裝 |
+
+安裝是同步的——agent 啟動時 `SKILL.md` 已經就位。
+
+---
+
+## 安裝模式
+
+### Symlink（預設）
+
+Unix 系統上使用 symlink，零複製、即時反映來源變更。
+
+### Copy + Marker（降級）
+
+Windows 或 symlink 不可用時，完整複製目錄並寫入 `.agend-skills-managed` 標記檔案。
+
+標記檔案的用途：
+- 有標記 → daemon 管理的副本，可以安全覆蓋更新
+- 沒有標記 → 使用者手動建立的技能目錄，daemon 不會覆蓋
+
+---
+
+## 版本鎖定
+
+`skills-lock.json` 記錄每個技能的安裝資訊：
+
+```json
+{
+  "skills": {
+    "skill-forge": {
+      "source": "https://github.com/user/skill-forge.git",
+      "version": "abc123def456...",
+      "installed_at": "2026-05-16T10:00:00Z"
+    }
+  }
+}
+```
+
+- **source**：原始來源（`update` 時從這裡拉取）
+- **version**：git commit SHA 或檔案修改時間戳
+- **installed_at**：安裝時間
+
+寫入使用 atomic write，不會因 crash 而損壞。
+
+---
+
+## 疑難排解
+
+### 技能沒有生效
+
+1. 確認技能目錄包含 `SKILL.md`
+2. 用 `agend-terminal skills list` 確認技能已安裝
+3. 檢查 agent 工作目錄下的 symlink 是否正確：
+   ```bash
+   ls -la <agent-wd>/.claude/skills/
+   ```
+4. 如果 fleet.yaml 有 `skills:` 允許清單，確認技能名稱在清單中
+
+### 手動建立的技能目錄被跳過
+
+這是正常行為。如果你在 agent 工作目錄下手動建立了 `.claude/skills/`，daemon 不會覆蓋它。如果想改由 daemon 管理，先手動刪除該目錄，daemon 下次啟動時會自動重建 symlink。
+
+### Windows 上 symlink 失敗
+
+Windows 預設需要開發者模式或管理員權限才能建立 symlink。系統會自動降級為 copy 模式。如果想使用 symlink：
+
+1. 開啟「設定 → 開發人員選項 → 開發人員模式」
+2. 或以管理員身分執行
+
+### 更新後技能沒有更新
+
+Symlink 模式下修改會即時反映。Copy 模式下需要重新執行 `agend-terminal skills update` 或重啟 daemon。

--- a/docs/FEATURE-tui.md
+++ b/docs/FEATURE-tui.md
@@ -1,0 +1,244 @@
+# TUI 多 Agent 管理介面
+
+AgEnD Terminal 提供一個類似 tmux 的終端多工介面，讓你在單一畫面中同時管理、監控整個 agent fleet 的狀態與輸出。
+
+## 啟動方式
+
+```bash
+# 啟動 TUI（owned 模式，自動啟動 daemon 和所有 fleet agent）
+agend-terminal app
+
+# 附加到已運行的 daemon（attached 模式，不啟動新 agent）
+agend-terminal app --attach
+```
+
+### Owned vs Attached 模式
+
+- **Owned 模式**：TUI 擁有 daemon 生命週期。啟動時自動讀取 `fleet.yaml`，spawn 所有定義的 agent，關閉時同步停止。適合本地開發。
+- **Attached 模式**：連接到已運行的 daemon。TUI 只負責顯示，不管理 agent 生命週期。適合遠端連線或多人共用 daemon。
+
+---
+
+## 核心概念
+
+### Tab 與 Pane
+
+每個 tab 包含一個或多個 pane，每個 pane 對應一個 agent 的終端輸出。Pane 可以水平或垂直分割，形成樹狀佈局。
+
+### Prefix 鍵
+
+所有操作都透過 `Ctrl+B` 前綴觸發（與 tmux 相同）。按下 `Ctrl+B` 後進入命令模式，再按對應的鍵執行操作。
+
+部分操作支援連續重複：按住方向鍵調整 pane 大小時，1.5 秒內不需要重新按 `Ctrl+B`。
+
+要向 agent 發送 `Ctrl+B` 本身，按 `Ctrl+B Ctrl+B`。
+
+---
+
+## 快捷鍵一覽
+
+### Tab 管理
+
+| 快捷鍵 | 說明 |
+|--------|------|
+| `Ctrl+B c` | 新增 tab（開啟選單選擇 agent/backend/shell） |
+| `Ctrl+B n` | 下一個 tab |
+| `Ctrl+B p` | 上一個 tab |
+| `Ctrl+B l` | 切換至上次使用的 tab |
+| `Ctrl+B 0-9` | 直接跳到第 N 個 tab |
+| `Ctrl+B &` | 關閉 tab（含確認提示） |
+| `Ctrl+B ,` | 重新命名 tab |
+| `Ctrl+B w` | 列出所有 tab（可搜尋跳轉） |
+
+### Pane 管理
+
+| 快捷鍵 | 說明 |
+|--------|------|
+| `Ctrl+B "` | 水平分割（上下） |
+| `Ctrl+B %` | 垂直分割（左右） |
+| `Ctrl+B o` | 循環切換 pane 焦點（可連續按） |
+| `Ctrl+B ↑↓←→` | 方向鍵切換 pane 焦點 |
+| `Ctrl+B Alt+↑↓←→` | 調整 pane 大小 |
+| `Ctrl+B H/J/K/L` | 調整 pane 大小（vim 風格，Shift 按住） |
+| `Ctrl+B x` | 關閉 pane（多 pane 時有確認提示） |
+| `Ctrl+B z` | 縮放切換（單一 pane 填滿 tab，再按恢復） |
+| `Ctrl+B Space` | 切換佈局預設模式 |
+| `Ctrl+B .` | 重新命名 pane |
+| `Ctrl+B !` | 移動 pane 至其他 tab |
+| `Ctrl+B @` | 翻轉分割方向（水平 ↔ 垂直） |
+
+### 捲動模式
+
+| 快捷鍵 | 說明 |
+|--------|------|
+| `Ctrl+B [` | 進入鍵盤捲動模式 |
+| `j` / `k` | 向下 / 向上捲動 |
+| `↑` / `↓` | 向上 / 向下捲動 |
+| `PgUp` / `PgDn` | 捲動 10 行 |
+| `q` / `Esc` | 離開捲動模式 |
+
+### 面板與 Overlay
+
+| 快捷鍵 | 說明 |
+|--------|------|
+| `Ctrl+B D` | 開啟決策面板（唯讀，可捲動） |
+| `Ctrl+B T` | 開啟任務看板（四欄看板視圖） |
+| `Ctrl+B ?` | 開啟快捷鍵說明 |
+| `Ctrl+B ~` | 開啟浮動 shell（Esc 關閉並終止） |
+| `Ctrl+B :` | 開啟命令面板 |
+| `Ctrl+B d` | 分離（退出 TUI，相當於關閉） |
+
+### 滑鼠操作
+
+| 操作 | 說明 |
+|------|------|
+| 點擊 pane 區域 | 切換焦點 |
+| 點擊 tab 標籤 | 切換 tab |
+| 點擊 `[+]` 按鈕 | 新增 tab 選單 |
+| 拖曳 tab 標籤 | 重新排列 tab 順序 |
+| 拖曳分割邊框 | 即時調整 pane 大小 |
+| 拖曳 pane 標題列 | 交換 pane 位置 |
+| 拖曳 pane 標題 → tab 列 | 跨 tab 移動 pane |
+| 滾輪 | 捲動焦點 pane（每格 3 行） |
+| `Shift+拖曳` | 文字選取 |
+
+---
+
+## 命令面板
+
+按 `Ctrl+B :` 開啟命令面板，輸入命令後按 Enter 執行。
+
+| 命令 | 參數 | 說明 |
+|------|------|------|
+| `:spawn` | `<name> [backend]` | 新增 tab 並啟動 agent |
+| `:vsplit` | `<name> [backend]` | 垂直分割並啟動 agent |
+| `:hsplit` | `<name> [backend]` | 水平分割並啟動 agent |
+| `:layout` | `[name]` | 設定佈局（無參數則循環切換） |
+| `:kill` | `<name>` | 終止 agent 並從 fleet 移除 |
+| `:restart` | `[name]` | 重新啟動 agent（預設為焦點 pane） |
+| `:send` | `<to> <msg>` | 發送訊息給指定 agent |
+| `:broadcast` | `<msg>` | 廣播訊息給所有 agent |
+| `:status` | — | 記錄 agent 狀態（除錯用） |
+
+`backend` 預設為 `claude`。支援的 backend 包括 claude、codex、gemini、opencode、kiro。
+
+---
+
+## 任務看板
+
+按 `Ctrl+B T` 開啟任務看板。看板提供四種視圖，按 `Tab` 切換：
+
+- **Tasks**：四欄看板（Backlog / Open / InProgress / Done）
+- **Fleet**：agent 列表與狀態
+- **Status**：agent 健康狀態儀表板
+- **Monitor**：即時監控
+
+### 任務看板操作
+
+| 快捷鍵 | 說明 |
+|--------|------|
+| `←` / `→`（或 `h` / `l`） | 切換欄位 |
+| `↑` / `↓`（或 `j` / `k`） | 在欄位內移動 |
+| `Enter` | 檢視任務詳情 |
+| `n` | 新增任務 |
+| `d` | 取消任務 |
+| `D`（Shift+d） | 標記任務完成 |
+| `a` | 指派任務給 agent |
+| `H`（Shift+h） | 左移狀態（降級） |
+| `L`（Shift+l） | 右移狀態（升級） |
+| `?` | 顯示看板說明 |
+| `q` / `Esc` | 關閉看板 |
+
+---
+
+## Session 持久化
+
+TUI 會自動儲存當前的佈局狀態到 `~/.agend-terminal/session.json`，包含：
+
+- Tab 名稱與順序
+- Pane 分割樹結構與比例
+- 當前 active tab
+
+### 恢復機制
+
+下次啟動時，TUI 會根據 session 和 agent 來源（fleet.yaml 或 daemon registry）進行對帳：
+
+1. **Rule 1**：從 fleet.yaml 自動啟動所有定義的 agent
+2. **Rule 2**：session 中存在但 fleet 中不存在的 agent 靜默移除，兄弟 pane 接管空間
+3. **Rule 3**：fleet 中存在但 session 中沒有的 agent 追加為新 tab，按 team 分組
+4. **Rule 4**：如果沒有任何 agent，建立一個 fallback shell
+
+這確保 fleet.yaml 永遠是 agent 集合的權威來源，而 session.json 只負責記住佈局偏好。
+
+---
+
+## 終端相容性
+
+### 鍵盤協定
+
+TUI 支援 Kitty 鍵盤協定（disambiguated escape codes）。在不支援的終端上自動降級到標準 ANSI 模式。Shift+字母鍵在兩種模式下都能正常運作。
+
+### 換行輸入
+
+- `Shift+Enter`：不送出的換行（需要現代終端支援）
+- `Ctrl+J`：不送出的換行（所有終端通用）
+
+### Panic 恢復
+
+如果 TUI 意外 crash，panic hook 會自動恢復終端狀態：
+
+1. 關閉 Kitty 鍵盤增強
+2. 恢復 ratatui 終端設定
+3. 關閉滑鼠擷取
+4. 顯示游標
+
+確保 crash 後終端仍然可用。
+
+---
+
+## 常見用法
+
+### 快速啟動一個三 agent 團隊
+
+```bash
+# 在 fleet.yaml 中定義
+instances:
+  lead:
+    backend: claude
+    role: orchestrator
+  dev:
+    backend: claude
+  reviewer:
+    backend: claude
+
+# 啟動 TUI
+agend-terminal app
+```
+
+TUI 會自動為每個 agent 建立一個 tab，依照 team 分組。
+
+### 臨時新增 agent
+
+在 TUI 中按 `Ctrl+B c`，從選單選擇 backend，或按 `Ctrl+B :` 輸入：
+
+```
+:spawn helper claude
+```
+
+### 分割畫面同時觀察兩個 agent
+
+```
+Ctrl+B %    # 垂直分割，選擇第二個 agent
+```
+
+或在命令面板：
+
+```
+:vsplit reviewer
+```
+
+### 跨 tab 移動 pane
+
+```
+Ctrl+B !    # 開啟移動選單，選擇目標 tab 或建立新 tab
+```


### PR DESCRIPTION
## Summary
- **FEATURE-tui.md** (244 lines): TUI 多 agent 管理介面完整文件——快捷鍵一覽、overlay 操作、任務看板、session 持久化、滑鼠操作、命令面板
- **FEATURE-skills.md** (302 lines): Skills 跨 backend 技能系統——安裝/更新/移除流程、目錄結構、per-agent 篩選、版本鎖定、疑難排解
- **FEATURE-communication.md** (397 lines): Agent 間通訊系統——send/inbox/reply 工具、訊息類型、投遞機制、任務看板整合、CI 串接、忙碌閘門

All docs in 繁體中文, sourced from actual codebase (app/, skills.rs, comms.rs).

## Test plan
- [x] All 3 files created in docs/
- [x] Line counts within 200-400 range
- [ ] Content accuracy verified against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)