### PR TITLE
docs: Tier 3 feature documentation (ci-watch, health, dispatch-idle) #1195

### DIFF
--- a/docs/FEATURE-ci-watch.md
+++ b/docs/FEATURE-ci-watch.md
@@ -1,0 +1,250 @@
+# CI Watch — 自動監控 PR 的 CI 狀態
+
+## 設計初衷
+
+在多 agent 協作的工作流中，dev agent push 完 PR 之後，通常需要等 CI 跑完
+才能通知 reviewer 開始 review。如果沒有自動化機制，operator 必須手動盯著
+GitHub Actions，等綠燈亮了再去戳 reviewer。
+
+CI Watch 解決這個問題：dev 建立 PR 時自動掛上 CI 監控，daemon 定期輪詢
+GitHub（或 GitLab / Bitbucket）的 CI 狀態。CI 通過時自動通知訂閱者，並且
+可以透過 `next_after_ci` 參數自動串接下一個 agent——例如直接通知 reviewer
+開始工作。
+
+整個流程零人工介入：
+
+```
+dev push PR → daemon 自動掛 ci watch →
+CI 跑完 → daemon 通知 reviewer →
+reviewer 自動開始 review
+```
+
+---
+
+## 使用方式
+
+### 訂閱 CI 監控
+
+透過 MCP 工具 `ci action=watch`：
+
+```json
+{
+  "tool": "ci",
+  "action": "watch",
+  "repo": "owner/repo",
+  "branch": "feat/my-feature",
+  "next_after_ci": "reviewer"
+}
+```
+
+參數說明：
+
+| 參數 | 必填 | 說明 |
+|------|------|------|
+| `repo` | 是 | GitHub 倉庫（`owner/repo` 格式） |
+| `branch` | 是 | 要監控的分支 |
+| `next_after_ci` | 否 | CI 通過後自動通知的 agent 名稱 |
+| `interval_secs` | 否 | 輪詢間隔（預設 60 秒） |
+| `task_id` | 否 | 關聯的 task board ID |
+| `required_checks` | 否 | 只追蹤這些 workflow 名稱（其餘忽略） |
+
+### 取消訂閱
+
+```json
+{
+  "tool": "ci",
+  "action": "unwatch",
+  "repo": "owner/repo",
+  "branch": "feat/my-feature"
+}
+```
+
+### 查詢狀態
+
+```json
+{
+  "tool": "ci",
+  "action": "status"
+}
+```
+
+回傳所有活躍的 CI watch 及其最近一次輪詢結果。
+
+### 自動掛載
+
+在 lead 使用 `send` 工具分派任務（`kind=task`）時，如果指定了 `branch` 和
+`next_after_ci`，daemon 會自動為該分支掛上 CI watch。dev 不需要手動呼叫
+`ci action=watch`。
+
+---
+
+## 運作原理
+
+### 檔案結構
+
+每個 CI watch 對應 `$AGEND_HOME/ci-watches/` 目錄下的一個 JSON 檔案。
+檔名是 `{repo}:{branch}` 的 SHA-256 雜湊值（64 hex chars + `.json`），
+避免 repo 名稱中的 `/` 造成路徑問題。
+
+### 輪詢機制
+
+daemon 在背景持續執行 CI watch 輪詢迴圈：
+
+1. **掃描 ci-watches 目錄**：讀取所有 `.json` 檔案
+2. **節流判斷**：根據 `last_polled_at` + `effective_interval_secs` 決定是否該輪詢
+3. **呼叫 CI Provider API**：查詢最新的 workflow run 狀態
+4. **狀態比較**：與上次記錄的 `last_run_id` / `head_sha` 比較
+5. **通知發送**：如果有新的終態結果（success / failure / cancelled），通知所有訂閱者
+6. **狀態持久化**：將最新狀態寫回 watch JSON
+
+### 自適應輪詢間隔
+
+為了避免超過 GitHub API rate limit，daemon 會根據剩餘配額自動調整輪詢間隔：
+
+| 剩餘配額 | 區間 | 乘數 |
+|---------|------|------|
+| > 50% | Healthy | ×1（使用設定的 interval） |
+| 10%–50% | Cautious | ×2 |
+| ≤ 10% | Critical | ×4 |
+
+例如設定 60 秒的 watch，在 Critical 區間會變成 240 秒輪詢一次。
+上限為設定值的 4 倍，不會更長。
+
+如果 API 沒有回傳 rate limit header（GitLab / Bitbucket），保持原始間隔。
+
+### 通知去重
+
+CI Watch 使用兩層去重機制，避免同一個事件重複通知：
+
+**第一層：Run 選取**
+`select_runs_to_notify` 比較最新的 workflow run 與已記錄的 `last_run_id`，
+只選取新的終態 run。
+
+**第二層：SHA 去重**
+`dedupe_notifications_by_head_sha` 確保同一個 `head_sha` 的結論
+（success / failure）只通知一次。處理 `gh run rerun --failed` 的情境：
+run_id 不變但 conclusion 改變。
+
+### 多訂閱者支援
+
+一個 CI watch 可以有多個訂閱者。輪詢只執行一次，通知分別送到每個
+訂閱者的 inbox。每個通知都帶有 supersede token，如果 inbox 中已有
+同一個 repo@branch 的舊通知，新通知會取代舊的（避免通知堆積）。
+
+### Zombie 訂閱者過濾
+
+如果某個訂閱者已經從 fleet 中移除（agent 被刪除），daemon 會在通知時
+跳過該訂閱者，避免向不存在的 inbox 寫入。判斷條件是同時不在 agent
+registry 和 fleet.yaml 的 instances 中。
+
+---
+
+## PR 衝突偵測
+
+CI Watch 同時監控 PR 的 mergeable 狀態。
+
+### Watch 建立時
+
+`ci action=watch` 時會立即查詢 PR 的 mergeable 狀態。如果偵測到
+`CONFLICTING`，會向所有訂閱者送出 `[ci-conflict-detected]` 通知。
+
+### 定期檢查
+
+輪詢過程中也會定期重新檢查 mergeable 狀態。如果狀態從非衝突變成
+衝突（transition detection），同樣送出衝突通知。
+
+---
+
+## 停滯偵測
+
+如果 CI watch 連續被 rate limit 跳過（無法輪詢），daemon 會追蹤
+連續跳過次數。超過 3 次後，向所有訂閱者送出 `[ci-watch-stalled]`
+通知，包含：
+
+- 停滯開始時間
+- 預估下次輪詢時間（rate limit reset 時間）
+- 設定建議（如何取得更高的 API 配額）
+
+當輪詢恢復正常時，送出 `[ci-watch-resumed]` 通知。
+
+---
+
+## TTL 與自動清理
+
+CI Watch 有兩種過期機制：
+
+### 絕對 TTL
+
+每個 watch 建立時設定 `expires_at`（預設 72 小時後）。超過此時間
+無條件移除。
+
+### 不活動 TTL
+
+如果 `last_terminal_seen_at`（最後一次看到終態結果的時間）超過
+設定的小時數，watch 會因不活動而被移除。
+
+### 啟動清掃
+
+daemon 啟動時會執行一次 startup sweep，清理上次 daemon 停止期間
+過期的 watch。
+
+### 保護分支過濾
+
+對 `main` / `master` 等保護分支的 watch 會被自動移除（保護分支
+不應該有 CI watch，因為它們不是 PR 分支）。
+
+---
+
+## CI Provider 支援
+
+CI Watch 支援三種 CI 提供者：
+
+| Provider | 偵測方式 | API |
+|----------|---------|-----|
+| GitHub | 預設，或 remote URL 含 `github` | GitHub Actions API |
+| GitLab | Remote URL 含 `gitlab` | GitLab CI/CD API |
+| Bitbucket | Remote URL 含 `bitbucket` | Bitbucket Pipelines API |
+
+Provider 透過 repo URL 自動偵測，也可以在 watch 時透過 `ci_provider`
+參數手動指定。
+
+### GitHub Token
+
+GitHub API 需要認證才能避免嚴格的 rate limit。daemon 使用環境變數
+`GITHUB_TOKEN` 或 `GH_TOKEN`。如果沒有設定，CI Watch 仍然可以
+運作但會更容易觸發 rate limit 停滯。
+
+---
+
+## 常見問題
+
+### Q: CI Watch 監控的是什麼？
+
+監控 GitHub Actions 的 workflow run（或 GitLab CI / Bitbucket Pipelines
+的等價物）。當所有 check 都完成時，根據聚合結論（success / failure）
+發送通知。
+
+### Q: 可以只監控特定的 workflow 嗎？
+
+可以。使用 `required_checks` 參數指定 workflow 名稱列表。只有這些
+workflow 會被納入通過/失敗判斷，其他的（例如不穩定的 Windows CI）
+會被忽略。
+
+### Q: CI Watch 會自動取消嗎？
+
+會。三種情況下 watch 會自動移除：
+1. 超過絕對 TTL（預設 72 小時）
+2. 超過不活動 TTL
+3. PR 進入終態（merged / closed）且滿足條件
+
+### Q: 多個 agent 可以訂閱同一個 watch 嗎？
+
+可以。多次呼叫 `ci action=watch` 指定同一個 repo + branch 但不同的
+agent 名稱，該 agent 會被加入訂閱者清單。輪詢只執行一次，通知分別
+送到每個訂閱者。
+
+### Q: rate limit 怎麼辦？
+
+daemon 的自適應輪詢間隔會自動降速。如果持續被限速，會送出 stall
+通知。建議設定 `GITHUB_TOKEN` 環境變數，authenticated 請求的 rate
+limit 是每小時 5,000 次（vs 未認證的 60 次）。

--- a/docs/FEATURE-dispatch-idle.md
+++ b/docs/FEATURE-dispatch-idle.md
@@ -1,0 +1,220 @@
+# Dispatch Idle Tracking — 任務回應超時追蹤
+
+## 設計初衷
+
+在多 agent 協作中，orchestrator（通常是 lead）會分派任務給 dev 或 reviewer。
+但如果接收方沒有回應——可能是 agent 卡住了、crash 了、或被其他工作佔用——
+orchestrator 不會知道任務被遺漏了。
+
+Dispatch Idle Tracking 解決這個問題。它在分派任務時啟動一個計時器，如果在
+設定的時間窗口內沒有收到回報（`kind=report`），daemon 會自動通知分派者：
+「你 10 分鐘前派出去的任務還沒有回應」。
+
+這是一個兩層（L1 + L2）的系統：
+
+- **L1（跨團隊安全）**：通知分派者本人，不含任何團隊名稱或團隊邏輯
+- **L2（團隊特化）**：針對 fixup 團隊的額外 nudge，通知目標 agent
+
+---
+
+## 使用方式
+
+### 啟用追蹤
+
+在使用 `send` 工具分派任務時，加上 `expect_reply_within_secs` 參數：
+
+```json
+{
+  "tool": "send",
+  "target_instance": "dev",
+  "message": "請實作 #123 的修正",
+  "request_kind": "task",
+  "task_id": "t-20260525-1",
+  "expect_reply_within_secs": 600
+}
+```
+
+這會建立一個 dispatch idle sidecar，daemon 在 600 秒（10 分鐘）後
+檢查是否有對應的 `kind=report`（以 `correlation_id` 匹配）。
+
+### Fixup 團隊預設值
+
+Fixup 團隊的 `kind=task` 和 `kind=query` dispatch 自動繼承 10 分鐘
+的 idle 追蹤，不需要手動指定 `expect_reply_within_secs`。其他團隊
+必須明確設定。
+
+### 參數說明
+
+| 參數 | 型別 | 說明 |
+|------|------|------|
+| `expect_reply_within_secs` | int | 預期回覆的秒數，超過後觸發 alert |
+
+---
+
+## 運作原理
+
+### Sidecar 機制
+
+每次帶有 `expect_reply_within_secs` 的 dispatch 會在
+`$AGEND_HOME/dispatch-pending/` 目錄下建立一個 JSON sidecar 檔案。
+
+Sidecar 內容：
+
+```json
+{
+  "dispatch_id": "disp-1716616000000-1",
+  "dispatcher": "fixup-lead",
+  "target": "fixup-dev",
+  "correlation_id": "t-20260525-1",
+  "threshold_secs": 600,
+  "created_at": "2026-05-25T05:00:00Z",
+  "status": "pending",
+  "nudge_sent_at": null
+}
+```
+
+`dispatch_id` 由微秒時間戳 + 程序內原子計數器生成，確保唯一性。
+
+### L1：超時偵測與通知
+
+daemon 每 60 秒掃描一次 `dispatch-pending/` 目錄：
+
+1. 讀取所有 `pending` 狀態的 sidecar
+2. 計算 `elapsed = now - created_at`
+3. 如果 `elapsed > threshold_secs`：
+   - 向 **分派者**（dispatcher）的 inbox 發送 `dispatch_idle_threshold_exceeded` 通知
+   - 將 sidecar 狀態改為 `exceeded`
+   - 記錄到 event log
+
+通知內容包含分派 ID、目標 agent、經過時間、correlation_id。
+
+### L2：Fixup Nudge
+
+L2 是 L1 的團隊特化補充，僅對 fixup 團隊生效。
+
+當 sidecar 狀態變為 `exceeded` 後，L2 會額外向 **目標 agent**
+（被分派者）發送 `dispatch_idle_nudge` 通知，提醒它有任務待處理。
+
+去重機制：每個 sidecar 只 nudge 一次（記錄在 `nudge_sent_at` 欄位）。
+
+L2 的隔離保證：
+- L1 的程式碼中不含任何團隊名稱字串（有 CI 測試 `no_team_name_strings_in_l1` 強制保證）
+- L2 作為獨立模組 (`fixup_nudge.rs`) 載入，只在分派者屬於 fixup 團隊時生效
+
+### 解除追蹤
+
+當目標 agent 回傳 `kind=report` 且 `correlation_id` 匹配時，
+daemon 會自動刪除對應的 sidecar，解除追蹤。匹配條件是
+`correlation_id` 相等（不是比對 sender）。
+
+這個設計支援多 dispatch 場景：同一個 orchestrator 可以同時
+分派給多個 agent，每個 sidecar 獨立追蹤。
+
+### Sidecar 重新整理
+
+在 sidecar 尚為 `pending` 且未超時的狀態下，如果目標 agent
+發送了非 report 類型的訊息（如 `kind=update`），daemon 會
+刷新 sidecar 的 `created_at` 時間戳（重新計時），避免在
+agent 明顯活躍時觸發 false alarm。
+
+---
+
+## 過期清理
+
+### 三類過期 Sidecar
+
+daemon 會在掃描時自動清理過期的 sidecar：
+
+| 類型 | 說明 |
+|------|------|
+| Placeholder correlation_id | `correlation_id` 是 `t-pending` 等佔位符（lead 端的分派衛生問題） |
+| 已刪除的目標 | target instance 已從 fleet 中移除 |
+| 已完成的任務 | `correlation_id` 對應的 task board 任務已是 done/cancelled 狀態 |
+
+Fail-open 語義：如果清理過程中讀取 fleet.yaml 或 task board 失敗，
+將 sidecar 視為活躍（不清理），維持既有行為。
+
+---
+
+## 可見性查詢
+
+Agent 可以查詢與自己相關的 dispatch idle 狀態：
+
+```json
+{
+  "tool": "dispatch_idle",
+  "action": "list"
+}
+```
+
+回傳分為兩個視角：
+
+- **as_dispatcher**：以分派者身份，看到自己分派出去的所有 pending/exceeded sidecar
+- **as_target**：以被分派者身份，看到針對自己的所有 sidecar
+
+已經過期清理或被 report 解除的 sidecar 不會出現。
+
+---
+
+## 設定
+
+### 環境變數
+
+| 環境變數 | 預設值 | 說明 |
+|---------|--------|------|
+| `AGEND_DISPATCH_IDLE_THRESHOLD_SECS` | 600 | Fixup 團隊的預設超時秒數 |
+
+### 行為細節
+
+- 掃描頻率：每 60 秒一次（與 daemon tick 週期同步）
+- 每個 sidecar 最多觸發一次 L1 exceeded 通知和一次 L2 nudge
+- L1 通知目標：dispatcher（分派者）
+- L2 nudge 目標：target（被分派者）
+- 匹配解除用的是 `correlation_id`，不是 sender 或 target
+
+---
+
+## 典型流程
+
+```
+1. lead 分派任務給 dev（expect_reply_within_secs=600）
+   → daemon 建立 sidecar (status=pending)
+
+2. 600 秒內 dev 回傳 report（correlation_id 匹配）
+   → daemon 刪除 sidecar ✓
+
+---- 或 ----
+
+2. 600 秒內 dev 沒有回應
+   → daemon 掃描：elapsed > threshold
+   → L1：向 lead 發送 exceeded 通知
+   → sidecar 狀態 → exceeded
+
+3. L2 掃描（fixup 團隊）
+   → 向 dev 發送 nudge 通知
+   → nudge_sent_at 記錄時間
+
+4. dev 收到 nudge，回傳 report
+   → daemon 刪除 sidecar ✓
+```
+
+---
+
+## 常見問題
+
+### Q: 非 fixup 團隊可以用嗎？
+
+可以。L1 是跨團隊安全的，任何 agent 都可以使用 `expect_reply_within_secs`。
+只是 L2 的 nudge 功能目前僅對 fixup 團隊生效。
+
+### Q: 如果 agent 正在工作但還沒完成，會被 nudge 嗎？
+
+如果 agent 有發送 `kind=update` 等非 report 訊息，sidecar 會重新計時。
+只有完全沒有任何通訊才會觸發超時。
+
+### Q: sidecar 會一直留在磁碟上嗎？
+
+不會。三種清理機制：
+1. 目標回傳 report → 立即刪除
+2. 過期清理（placeholder / deleted target / closed task）→ 掃描時刪除
+3. daemon 重啟時的 startup sweep

--- a/docs/FEATURE-health.md
+++ b/docs/FEATURE-health.md
@@ -1,0 +1,271 @@
+# Health & Monitoring — Agent 健康狀態與自動恢復
+
+## 設計初衷
+
+AI coding agent 會遇到各種異常：程序 crash、API rate limit、回應超時
+（hang）、進入錯誤迴圈。如果每一種都需要 operator 手動介入，那多 agent
+的系統就無法長時間無人值守。
+
+Health & Monitoring 是 AgEnD daemon 的核心子系統，它持續監控每個 agent
+的健康狀態，自動執行恢復動作（重啟、發送 ESC 鍵、通知 operator），
+並提供結構化的狀態報告讓 operator 和其他 agent 了解系統狀況。
+
+---
+
+## 兩層狀態模型
+
+AgEnD 將 agent 的狀態分為兩個獨立的層次：
+
+### AgentState — 即時偵測
+
+AgentState 是從 PTY 輸出即時解析出的瞬間狀態。每一行輸出都可能
+改變 AgentState。
+
+| 狀態 | 說明 |
+|------|------|
+| `Starting` | Agent 程序剛啟動，尚未就緒 |
+| `Ready` | 就緒，等待輸入 |
+| `Idle` | 閒置，無 pending 工作 |
+| `Thinking` | 正在思考（產生中間輸出） |
+| `ToolUse` | 正在執行工具呼叫 |
+| `RateLimit` | 遇到 API rate limit |
+| `InteractivePrompt` | 顯示互動式提示（如權限確認） |
+| `PermissionPrompt` | 等待權限確認 |
+| `AwaitingOperator` | 等待 operator 操作 |
+| `Hang` | 疑似卡住 |
+| `Crashed` | 程序已結束 |
+
+### HealthState — 累積生命週期
+
+HealthState 是從多次事件累積推導出的生命週期狀態。它反映的是
+agent 的整體健康趨勢，不會因為一行輸出就改變。
+
+| 狀態 | 說明 | 是否觸發自動恢復 |
+|------|------|----------------|
+| `Healthy` | 正常運行 | 否 |
+| `Recovering` | Crash 後正在恢復 | 否 |
+| `Unstable` | 10 分鐘內 3+ 次 crash | 否 |
+| `Failed` | 超過最大重試次數（5 次），停止自動重啟 | 否（終態） |
+| `Hung` | 有 pending input 但超時未回應 | 是 |
+| `IdleLong` | 長時間無活動，但沒有 pending input（非異常） | 否 |
+| `ErrorLoop` | 10 分鐘內同一狀態錯誤 3+ 次 | 否 |
+| `Paused` | 自動恢復三階段全部失敗，等待 operator 手動介入 | 否（終態） |
+
+---
+
+## Crash 處理
+
+### 自動重啟
+
+當 agent 程序 crash 時，daemon 會自動重啟：
+
+1. **記錄 crash**：將 crash 時間加入滑動窗口（10 分鐘）
+2. **計算退避延遲**：指數退避，從 5 秒開始，每次加倍，上限 5 分鐘
+3. **判斷是否重啟**：
+   - 總 crash 次數 < 5 次：重啟
+   - 總 crash 次數 ≥ 5 次：進入 `Failed` 狀態，停止重啟
+4. **通知判斷**：
+   - 第 1 次 crash：靜默重啟
+   - 第 2 次起：發送通知（受 5 分鐘冷卻時間限制）
+
+### 狀態轉換
+
+```
+Healthy → (1 crash) → Recovering → (respawn OK) → Healthy
+Healthy → (3 crashes in 10min) → Unstable
+任何狀態 → (5+ crashes) → Failed（終態，需 operator 介入或等待衰減）
+```
+
+### Crash 衰減
+
+如果 agent 穩定運行 30 分鐘（無新 crash），crash 計數會自動衰減：
+
+- `total_crashes` 每 30 分鐘減 1
+- `Failed` → `Recovering`（當 crash 計數降到 5 以下）
+- `Recovering` → `Healthy`（當 crash 計數降到 3 以下）
+- `Unstable` → `Healthy`（當 crash 計數降到 3 以下）
+
+---
+
+## Hang 偵測
+
+### 判斷邏輯
+
+daemon 每 tick 檢查每個 agent 的沉默時間。超過門檻值時進入分類流程：
+
+| AgentState | 沉默門檻 |
+|------------|---------|
+| `Idle` | 永不視為 hang |
+| `Starting` | 120 秒 |
+| `Thinking` / `ToolUse` | 600 秒 |
+| 其他 | 120 秒 |
+
+### Hung vs IdleLong 分辨
+
+沉默超過門檻後，daemon 進一步判斷是真 hang 還是正常閒置：
+
+**Hung（真卡住）**：有 pending input 但 agent 沒回應
+- 條件：`last_input_at_ms > last_heartbeat_at_ms + 5s`
+- 意思是：operator 送了輸入，但 agent 超過 5 秒沒有任何 MCP 呼叫（heartbeat）
+- 觸發自動恢復階梯
+
+**Hung（F1 交叉檢查）**：heartbeat 新鮮但 PTY 無輸出
+- 條件：heartbeat 最近有更新，但 PTY 已沉默超過門檻
+- 意思是：agent 在呼叫 MCP 工具（heartbeat 刷新），但沒有產生 PTY 輸出
+- 可能是 agent 陷入緊密的 MCP 迴圈
+
+**IdleLong（正常閒置）**：沒有 pending input，agent 只是在等下一個任務
+- 不觸發任何恢復動作
+- operator 04:00 UTC 離開後的正常狀態
+
+### 5 秒寬限窗口
+
+input 送達和 heartbeat 刷新之間有 5 秒的寬限窗口，避免在 MCP roundtrip
+完成前誤判為 Hung。
+
+---
+
+## 自動恢復階梯
+
+當 agent 被分類為 `Hung` 時，daemon 啟動三階段恢復：
+
+### Stage 1：ESC 鍵
+
+- 向 agent 的 PTY 發送 ESC 鍵（中斷當前操作）
+- 等待 10 秒看是否恢復
+- 冷卻時間 60 秒（避免頻繁發送 ESC）
+
+### Stage 2：自動重啟
+
+- Stage 1 失敗後，自動重啟 agent 程序
+- 等待 30 秒看是否恢復
+- 最多重啟 3 次（跨 Hung 週期累計）
+- 退避延遲 1 秒
+
+### Stage 3：暫停
+
+- Stage 2 的 3 次重啟都失敗後
+- 將 HealthState 設為 `Paused`（終態）
+- 通知 operator 需要手動介入
+- `check_hang` 不再觸發（短路返回 false）
+- crash 衰減不會改變 `Paused` 狀態
+
+整個階梯可以透過 runtime config 的 `hang_auto_recovery_enabled` 開關控制。
+
+---
+
+## Watchdog — PTY 輸出分類
+
+daemon 的 watchdog 每 tick 掃描每個 agent 的最新 PTY 輸出，比對
+已知的異常模式：
+
+| 偵測到的模式 | 設定的 BlockedReason |
+|-------------|---------------------|
+| "rate limit" / "Too Many Requests" | `RateLimit` |
+| "quota exceeded" | `QuotaExceeded` |
+| "awaiting operator" / 互動式提示 | `AwaitingOperator` |
+| "permission" 提示 | `PermissionPrompt` |
+
+設定 BlockedReason 後：
+- `RateLimit` / `QuotaExceeded` / `AwaitingOperator`：抑制 hang 偵測（避免 false alarm）
+- `PermissionPrompt`：**不**抑制 hang 偵測
+
+### 試運行模式
+
+設定 `AGEND_WATCHDOG_DRY_RUN=1` 環境變數可以啟用試運行模式：
+watchdog 只記錄偵測結果到 event log，不實際修改 health 狀態。
+適合在上線前測試 pattern matching 的準確性。
+
+---
+
+## Idle Watchdog — 閒置偵測
+
+獨立於 health monitoring 的另一個 watchdog，追蹤 agent 和整個 fleet
+的活動狀態。
+
+### 兩個觀測角度
+
+**Dev 角度**：單一 agent 閒置超過 60 分鐘
+- 通知 lead：「dev 已經閒置 60 分鐘了」
+
+**Fleet 角度**：所有 agent 都閒置超過 30 分鐘
+- 通知 general：「整個 fleet 已經閒置 30 分鐘了」
+- 在 task board 為空且沒有 pending dispatch 時，抑制 alert（沒有預期工作）
+
+### 活動追蹤
+
+每個 agent 的活動狀態記錄在 `$AGEND_HOME/agent-activity/<agent>.json`
+sidecar 中。agent 每次透過 `send` 工具發送訊息時自動更新時間戳。
+
+### Snooze 與 Ack
+
+| 操作 | 說明 |
+|------|------|
+| Snooze | 暫停 fleet idle alert 到指定時間 |
+| Ack | 確認收到 alert，下次有新活動前不再通知 |
+| Resume | 清除 snooze / ack，恢復正常偵測 |
+
+---
+
+## MCP 工具
+
+### health report
+
+向 daemon 回報目前的 blocked reason：
+
+```json
+{
+  "tool": "health",
+  "action": "report",
+  "reason": "rate_limit",
+  "retry_after_secs": 60
+}
+```
+
+Agent 可以主動回報自己遇到的問題，讓 watchdog 知道不需要觸發
+hang 偵測。
+
+### health clear_blocked_reason
+
+清除先前設定的 blocked reason，恢復正常 hang 偵測：
+
+```json
+{
+  "tool": "health",
+  "action": "clear_blocked_reason"
+}
+```
+
+---
+
+## 常見問題
+
+### Q: agent 被判定為 Hung 但其實在正常工作？
+
+可能的原因：
+1. Agent 的 PTY 輸出被 backend 的 TUI 框架吃掉（沒有到達 daemon 的 vterm）
+2. Agent 在執行長時間的工具呼叫（超過 600 秒）
+
+解決方式：
+- 調整 `AGEND_PRODUCTIVE_GATE=1` 啟用 F9 productive-output gate
+- 使用 `health action=report` 主動回報 agent 的狀態
+
+### Q: Failed 狀態可以自動恢復嗎？
+
+可以，但需要時間。crash 計數每 30 分鐘衰減 1 次。如果 agent 的
+total_crashes 降到 5 以下，會自動轉為 Recovering，再降到 3 以下
+轉為 Healthy。但在 Failed 期間程序已停止，需要 operator 手動重啟
+或等待 Stage 2 auto-recovery 觸發。
+
+### Q: Paused 狀態怎麼解除？
+
+目前 Paused 是終態，需要 operator 手動介入。未來會加入 operator
+unpause 命令界面。
+
+### Q: 如何查看 agent 的當前健康狀態？
+
+```bash
+agend-terminal list --detailed
+```
+
+或透過 MCP 工具查詢 agent registry。


### PR DESCRIPTION
## Summary
- **FEATURE-ci-watch.md** (250 lines): CI 狀態自動監控——自適應輪詢、通知去重、停滯偵測、PR 衝突偵測、多 provider 支援
- **FEATURE-health.md** (271 lines): 兩層狀態模型（AgentState vs HealthState）、crash 自動重啟、hang 偵測（Hung vs IdleLong）、三階段自動恢復、watchdog PTY 分類、idle watchdog
- **FEATURE-dispatch-idle.md** (220 lines): L1/L2 超時追蹤、sidecar 機制、nudge、過期清理、可見性查詢

所有內容以繁體中文撰寫，基於源碼確認實際行為。

Closes #1195

## Test plan
- [x] All 3 files created in docs/
- [x] Line counts within 200-400 range per file
- [x] Content verified against source code (ci_watch/, health.rs, watchdog.rs, idle_watchdog.rs, dispatch_idle/)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)