### PR TITLE
docs: feature documentation — channels, decisions, schedules (#1195)

### DIFF
--- a/docs/FEATURE-channels.md
+++ b/docs/FEATURE-channels.md
@@ -1,0 +1,279 @@
+# Channels — Telegram / Discord 整合
+
+Channels 系統讓操作者直接在 Telegram 或 Discord 中與 agent 互動，不需要開啟終端。每個 agent 對應一個 Telegram forum topic，訊息自動雙向同步。
+
+## 設計理念
+
+多 agent 團隊工作時，操作者需要一個隨時隨地都能觸及 agent 的管道。Channels 提供：
+
+- **雙向通訊**：在 Telegram topic 中發訊息，agent 收到；agent 回覆，Telegram 中看到
+- **一對一映射**：每個 agent 有自己的 topic，對話不會混在一起
+- **平台無關抽象**：核心程式碼不依賴特定平台，透過 Channel trait 適配不同服務
+- **自動設定**：daemon 啟動時自動建立缺少的 topic，不需手動設定
+
+---
+
+## 快速開始
+
+### 1. 設定 Telegram Bot
+
+在 `fleet.yaml` 中加入 channel 設定：
+
+```yaml
+channel:
+  telegram:
+    bot_token: "123456:ABC-DEF..."
+    group_id: -1001234567890
+    user_allowlist:
+      - 12345678    # 你的 Telegram user ID
+```
+
+- `bot_token`：從 @BotFather 取得
+- `group_id`：Telegram 群組 ID（必須是已啟用 Topics 的超級群組）
+- `user_allowlist`：允許與 agent 互動的 Telegram user ID 列表
+
+### 2. 啟動 daemon
+
+```bash
+agend-terminal start
+```
+
+Daemon 啟動時會自動：
+1. 讀取 `fleet.yaml` 的 channel 設定
+2. 載入 `topics.json`（topic ID ↔ agent 名稱的映射）
+3. 為缺少 topic 的 agent 自動建立 Telegram forum topic
+4. 建立 fleet binding topic（跨 agent 的團隊事件通知）
+5. 開始輪詢收取訊息
+
+### 3. 開始對話
+
+在 Telegram 群組中找到對應 agent 名稱的 topic，直接打字即可。Agent 會在該 topic 中回覆。
+
+---
+
+## 核心概念
+
+### Channel Trait
+
+所有 channel 實作共用同一個 trait 介面：
+
+| 方法 | 說明 |
+|------|------|
+| `send` | 發送訊息到指定 binding |
+| `edit` | 編輯已發送的訊息 |
+| `delete` | 刪除訊息 |
+| `create_binding` | 為 agent 建立頻道綁定 |
+| `remove_binding` | 移除綁定 |
+| `create_topic` | 建立新的 forum topic |
+| `poll_event` | 輪詢收取新訊息 |
+
+核心程式碼只透過 trait 操作，不直接呼叫 Telegram API。新增 Discord 或 Slack 支援只需實作這個 trait。
+
+### Binding（綁定）
+
+Binding 是 agent 與 channel 之間的連結。每個 binding 包含平台特定的定址資訊（例如 Telegram topic ID），但核心程式碼不需要知道這些細節——binding 是不透明的（opaque）。
+
+```
+agent "dev" ← binding → Telegram topic #42
+agent "reviewer" ← binding → Telegram topic #43
+```
+
+### Capabilities（能力矩陣）
+
+每個 channel 宣告自己支援的功能，核心程式碼據此決定降級行為：
+
+| 能力 | Telegram | Discord |
+|------|----------|---------|
+| 原生討論串 | 是（forum topics） | 是（threads） |
+| Markdown | MarkdownV2 | Discord Markdown |
+| 附件上傳 | 是 | 是 |
+| 訊息編輯 | 是 | 是 |
+| Emoji 反應 | 是 | 是 |
+| 打字指示器 | 是 | 是 |
+| 訊息長度上限 | 4096 bytes | 2000 chars |
+| 刪除事件 | 否 | 是 |
+
+不支援的功能會靜默降級，不會報錯。
+
+---
+
+## Topics 映射
+
+### topics.json
+
+Agent 與 Telegram topic 的映射關係持久化在 `topics.json`：
+
+```json
+{
+  "42": "dev",
+  "43": "reviewer",
+  "100": "general",
+  "500": "__fleet__"
+}
+```
+
+- Key 是 Telegram forum topic ID（字串化的數字）
+- Value 是 agent 的 instance name
+- `__fleet__` 是保留的 sentinel，用於跨 agent 的團隊事件通知
+
+### 自動建立 Topic
+
+Daemon 啟動時，對每個在 `fleet.yaml` 中定義但在 `topics.json` 中沒有對應 topic 的 agent，自動建立 forum topic。
+
+TUI 中透過 `Ctrl+B c` 新增 agent 時，也會自動建立 topic 並註冊。
+
+### 孤兒 Topic 清理
+
+使用 `doctor topics` 命令檢查和清理孤兒 topic：
+
+```bash
+# 檢查 topic 狀態
+agend-terminal doctor topics
+
+# 清理孤兒 topic
+agend-terminal doctor topics --cleanup
+```
+
+Topic 分為兩類：
+- **Live**：在 `topics.json` 和 `fleet.yaml` 中都存在
+- **Orphan**：在 `topics.json` 中存在但 `fleet.yaml` 中沒有（agent 已刪除但 topic 未清理）
+
+---
+
+## 訊息流程
+
+### 收訊（Telegram → Agent）
+
+```
+1. 使用者在 Telegram forum topic 中發送訊息
+2. 輪詢執行緒偵測到新訊息，取得 topic_id
+3. 透過 topic_to_instance 映射解析目標 agent
+4. 訊息寫入 agent 的收件匣
+5. Agent 呼叫 inbox 工具讀取完整訊息
+```
+
+### 發訊（Agent → Telegram）
+
+```
+1. Agent 呼叫 reply MCP 工具
+2. 去重檢查：相同內容在 5 秒內不重複發送
+3. 查詢 instance_to_topic 取得目標 topic_id
+4. 透過 Telegram Bot API 發送訊息
+5. 記錄 message_id 供後續編輯/刪除使用
+```
+
+### Mirror Skip（防重複）
+
+Agent 的回覆會同時出現在 Telegram topic 和 PTY 終端輸出中。為避免 PTY mirror 把 agent 自己的回覆又轉發一次，系統在發送前設定 `mirror_skip_until_next_turn` 旗標。這個旗標會在下一輪使用者輸入時自動重置。
+
+---
+
+## 去重機制
+
+防止以下 race condition 造成重複訊息：
+
+- App 和 daemon 同時輪詢 CI watch，各發一次通知
+- PTY mirror 和 reply 工具同時發送相同內容
+- 重試邏輯未充分保護的發送路徑
+
+去重使用內容雜湊 + TTL 視窗（預設 5 秒）：
+
+```yaml
+# fleet.yaml 可調整 TTL
+channel:
+  dedup_ttl_secs: 5
+```
+
+相同的 (instance, topic, content hash) 在 TTL 內只會發送一次。記憶體上限 1024 筆，使用插入順序的 LRU 策略。
+
+---
+
+## 通知閘門
+
+Agent 的對外通知（CI 狀態、任務完成等）預設關閉（fail-closed）。必須在 `fleet.yaml` 中設定 `user_allowlist` 才會啟用：
+
+```yaml
+channel:
+  telegram:
+    user_allowlist:
+      - 12345678
+```
+
+未設定時，所有對外通知靜默丟棄，不會報錯。這防止未設定的 bot 意外將資訊洩漏到未授權的群組。
+
+---
+
+## Fleet Binding Topic
+
+fleet binding 是一個特殊的 topic，用於顯示跨 agent 的團隊事件：
+
+| 事件類型 | 格式 |
+|----------|------|
+| 任務委派 | `[lead → dev] DELEGATE 修復 #1177 (#t-...)` |
+| 結果回報 | `[dev → lead] REPORT PR 已建立 (#t-...)` |
+| 決策發布 | `[lead] DECISION 使用 prefix match (#d-...)` |
+| 廣播 | `[lead → 3 agents] BROADCAST merge freeze` |
+
+操作者可以在一個 topic 中看到整個團隊的活動概覽，不需要逐一檢查每個 agent 的 topic。
+
+---
+
+## 自我修復
+
+### Topic 被刪除
+
+如果 Telegram topic 被意外刪除（管理員操作或 API 錯誤），系統會自動：
+
+1. 偵測到 topic-deleted 錯誤
+2. 清除無效的 topic 映射
+3. 重新建立 topic
+4. 重試發送
+
+### 超級群組遷移
+
+Telegram 群組升級為超級群組時，`group_id` 會改變。系統偵測到 `MigrateToChatId` 錯誤後：
+
+1. 讀取新的 chat ID
+2. 更新 `fleet.yaml` 中的 `group_id`
+3. 重試發送
+
+這兩種情況都不需要操作者介入。
+
+---
+
+## 多 Channel 支援
+
+目前支援 Telegram，Discord 為預留介面（feature gate）。架構設計支援同時使用多個 channel：
+
+- 每個 channel 獨立註冊在全域 registry 中
+- 每個 agent 可以綁定到不同的 channel
+- 收訊事件由 dispatcher 統一合併
+- 發訊根據 binding 的 channel kind 路由到正確的 adapter
+
+---
+
+## 疑難排解
+
+### Bot 收不到訊息
+
+1. 確認 bot 已加入群組且有讀取權限
+2. 確認群組已啟用 Topics（設定 → Topics → 開啟）
+3. 確認 `user_allowlist` 包含你的 Telegram user ID
+4. 檢查 daemon 日誌中的 channel 初始化訊息
+
+### Topic 沒有自動建立
+
+1. 確認 bot 有 `can_manage_topics` 權限（群組管理員設定）
+2. 執行 `agend-terminal doctor topics` 檢查狀態
+3. 檢查 `topics.json` 中的現有映射
+
+### 訊息重複
+
+調整去重 TTL：
+
+```yaml
+channel:
+  dedup_ttl_secs: 10    # 加大視窗
+```
+
+如果問題持續，檢查是否有多個 daemon 實例同時運行。

--- a/docs/FEATURE-decisions.md
+++ b/docs/FEATURE-decisions.md
@@ -1,0 +1,292 @@
+# Decisions — 決策追溯系統
+
+Decisions 系統讓團隊記錄重要的架構和流程決策，提供可查詢的決策歷史，讓任何人都能追溯「為什麼我們做了這個選擇」。
+
+## 設計理念
+
+多 agent 協作中，決策散落在對話、PR 描述、commit message 裡，很難回溯。Decisions 提供：
+
+- **集中記錄**：所有重要決策存在同一個地方
+- **結構化資料**：標題、內容、範圍、標籤、作者
+- **修正追蹤**：新決策可以明確取代舊決策（supersedes）
+- **自動過期**：TTL 機制避免過時決策造成混淆
+
+---
+
+## 快速開始
+
+```json
+// 記錄一個決策
+{
+  "action": "post",
+  "title": "使用 prefix match 比對 SHA",
+  "content": "reviewed_head 使用 7 字元以上的 prefix match，而非完整 SHA 比對。原因：git log --oneline 預設顯示 7 字元。",
+  "scope": "project",
+  "tags": ["sha-gate", "sprint-58"]
+}
+
+// 列出所有有效決策
+{
+  "action": "list"
+}
+
+// 修正先前的決策
+{
+  "action": "post",
+  "title": "SHA prefix match 改為最少 7 字元",
+  "content": "原先沒有最短長度限制，空字串會繞過。現在要求至少 7 字元。",
+  "scope": "project",
+  "tags": ["sha-gate", "sprint-58"],
+  "supersedes": "d-20260525040000000000-1"
+}
+```
+
+---
+
+## 操作
+
+### post — 記錄決策
+
+建立一筆新決策。
+
+| 參數 | 類型 | 必要 | 說明 |
+|------|------|------|------|
+| `title` | string | 是 | 決策標題 |
+| `content` | string | 是 | 決策內容和理由 |
+| `scope` | string | 是 | `"project"`（專案級）或 `"fleet"`（團隊級） |
+| `tags` | string[] | 否 | 分類標籤 |
+| `ttl_days` | number | 否 | 自動過期天數（預設 90 天） |
+| `supersedes` | string | 否 | 被取代的決策 ID |
+
+回應包含自動產生的決策 ID：
+
+```json
+{
+  "id": "d-20260525040000000000-1",
+  "status": "created"
+}
+```
+
+### list — 查詢決策
+
+列出所有有效決策。
+
+| 參數 | 類型 | 必要 | 說明 |
+|------|------|------|------|
+| `tags` | string[] | 否 | 按標籤篩選（任一符合即納入） |
+| `include_archived` | bool | 否 | 是否包含已封存的決策（預設 false） |
+
+結果按建立時間倒序排列（最新的在前）。
+
+### update — 修改決策
+
+修改現有決策的內容、標籤、或狀態。
+
+| 參數 | 類型 | 必要 | 說明 |
+|------|------|------|------|
+| `id` | string | 是 | 決策 ID |
+| `content` | string | 否 | 新內容 |
+| `tags` | string[] | 否 | 新標籤 |
+| `ttl_days` | number | 否 | 新的過期天數 |
+| `archive` | bool | 否 | 設為 true 手動封存 |
+
+修改權限：只有原作者或其所屬團隊的 orchestrator 可以修改。
+
+---
+
+## 決策結構
+
+每筆決策包含以下欄位：
+
+```json
+{
+  "id": "d-20260525040000000000-1",
+  "title": "使用 prefix match 比對 SHA",
+  "content": "reviewed_head 使用 7 字元以上的 prefix match...",
+  "scope": "project",
+  "author": "fixup-dev-2",
+  "tags": ["sha-gate", "sprint-58"],
+  "ttl_days": 90,
+  "created_at": "2026-05-25T04:00:00Z",
+  "updated_at": "2026-05-25T04:00:00Z",
+  "archived": false,
+  "supersedes": null
+}
+```
+
+### 決策 ID 格式
+
+`d-<時間戳微秒>-<序號>`，例如 `d-20260525040000000000-1`。微秒精度加上原子計數器保證唯一性。
+
+### Scope（範圍）
+
+- `project`：專案級決策，與當前工作目錄相關
+- `fleet`：團隊級決策，跨專案的共通規則
+
+Scope 目前作為元資料使用，不影響存取權限。
+
+---
+
+## Supersedes（取代機制）
+
+當需要修正先前的決策時，使用 `supersedes` 建立新舊關聯：
+
+```json
+{
+  "action": "post",
+  "title": "SHA 最短長度改為 7 字元",
+  "content": "修正 d-20260525040000000000-1，加入最短長度檢查",
+  "supersedes": "d-20260525040000000000-1"
+}
+```
+
+執行流程：
+
+1. 取得舊決策的鎖定
+2. 將舊決策標記為 `archived: true`
+3. 更新舊決策的 `updated_at`
+4. 建立新決策，記錄 `supersedes` 指向舊 ID
+
+這整個流程在檔案鎖下原子執行，不會有兩個 agent 同時取代同一筆決策的 race condition。
+
+`list` 預設不顯示已封存的決策。要查看完整歷史（包含被取代的舊決策），使用 `include_archived: true`。
+
+---
+
+## 標籤系統
+
+標籤是任意字串陣列，用於分類和篩選：
+
+```json
+{
+  "tags": ["sha-gate", "sprint-58", "security"]
+}
+```
+
+查詢時，`tags` 篩選使用「任一符合」邏輯——只要決策包含篩選標籤中的任何一個就會被納入。
+
+### 受保護標籤
+
+在 `fleet.yaml` 中可以定義受保護的標籤：
+
+```yaml
+retention:
+  protected_decision_tags:
+    - SPRINT_99
+    - ARCHITECTURE
+```
+
+帶有受保護標籤的決策不會被自動過期，無論 TTL 設定為何。適合用於長期有效的架構決策。
+
+---
+
+## 自動過期
+
+決策有 TTL（Time To Live）機制，過期的決策會自動封存：
+
+| 參數 | 預設值 | 說明 |
+|------|--------|------|
+| 預設 TTL | 90 天 | 未指定 `ttl_days` 時的過期時間 |
+| 最低保護期 | 14 天 | 不論 TTL 多短，至少保留 14 天 |
+| 受保護標籤 | — | 有受保護標籤的決策永不過期 |
+
+過期流程：
+
+1. Daemon 定期掃描所有決策
+2. 跳過：已封存、建立不足 14 天、帶受保護標籤
+3. 符合過期條件的決策移至 `decisions/.archive/`
+
+需要設定環境變數 `AGEND_RETENTION_CUTOVER=1` 才會啟用自動過期掃描。
+
+---
+
+## 儲存方式
+
+- 位置：`$AGEND_HOME/decisions/`
+- 格式：每筆決策一個 JSON 檔案（`{id}.json`）
+- 鎖定：每筆決策有獨立的 flock（`{id}.lock`），不影響其他決策的併發操作
+- 寫入：使用 `atomic_write()`（暫存檔 → fsync → rename），crash-safe
+- 封存：過期的決策移至 `decisions/.archive/` 子目錄
+
+---
+
+## TUI 檢視
+
+在 TUI 中按 `Ctrl+B D`（大寫 D）開啟決策面板：
+
+- `j` / `k` 或 `↑` / `↓`：上下捲動
+- `PgUp` / `PgDn`：快速捲動
+- `q` / `Esc`：關閉面板
+
+面板顯示每筆決策的標題、作者、時間戳、內容和標籤。選中的決策會展開完整內容。
+
+---
+
+## 決策逾時（Decision Timeout）
+
+Agent 可以在 `reply` 中設定自動決策：
+
+```json
+{
+  "text": "是否要繼續使用精簡方案？",
+  "default_action": "proceed-with-lean",
+  "timeout_secs": 1800
+}
+```
+
+如果操作者在 30 分鐘內沒有回覆，daemon 自動執行 `default_action`。
+
+流程：
+1. Agent 呼叫 `reply` 帶 `default_action` 和 `timeout_secs`
+2. 建立 pending decision sidecar（`pending-decisions/{id}.json`）
+3. 操作者回覆 → 標記為 `resolved`，取消自動執行
+4. 逾時 → 標記為 `timeout`，發送帶有 default action 的通知到 agent 收件匣
+
+同一個 agent 同時只能有一個 pending decision。新的 pending 會自動取消前一個。
+
+---
+
+## 修改權限
+
+| 角色 | 權限 |
+|------|------|
+| 原作者 | 可修改自己建立的決策 |
+| 團隊 orchestrator | 可修改所屬團隊成員建立的決策 |
+| 其他 agent | 不可修改，回傳授權錯誤 |
+
+---
+
+## 典型用法
+
+### 記錄架構決策
+
+```json
+{
+  "action": "post",
+  "title": "Agent 間通訊使用 inbox JSONL 而非 RPC",
+  "content": "選擇 append-only JSONL 因為：1) crash-safe 2) 離線 agent 可延遲讀取 3) 除錯時 cat 就能看。RPC 需要兩端都在線，且 crash 時訊息遺失。",
+  "scope": "fleet",
+  "tags": ["architecture", "communication"]
+}
+```
+
+### 追溯決策原因
+
+```json
+{
+  "action": "list",
+  "tags": ["sha-gate"]
+}
+```
+
+### 修正錯誤的決策
+
+```json
+{
+  "action": "post",
+  "title": "SHA gate 需要最少 7 字元（修正）",
+  "content": "原決策未考慮空字串情境。空字串是任何字串的 prefix，會繞過所有驗證。",
+  "supersedes": "d-20260525040000000000-1",
+  "tags": ["sha-gate", "security"]
+}
+```

--- a/docs/FEATURE-schedules.md
+++ b/docs/FEATURE-schedules.md
@@ -1,0 +1,305 @@
+# Schedules & Deployments — 定時任務與批次部署
+
+Schedules 讓你設定 cron 定時任務或一次性排程，Deployments 讓你一鍵部署多 agent 團隊。兩者都不需要手動重複操作。
+
+## 設計理念
+
+- **Schedules**：每天早上 9 點自動給 team 發 standup 訊息、每小時檢查 CI 狀態——不需要操作者記得做
+- **Deployments**：一個指令部署整個團隊（lead + dev + reviewer），包含 worktree 建立、fleet.yaml 寫入、team 建立
+
+---
+
+## Schedules — 定時任務
+
+### 快速開始
+
+```json
+// 每天早上 9 點發送 standup 提醒
+{
+  "action": "create",
+  "cron": "0 9 * * *",
+  "message": "早安！請回報昨天的進度和今天的計畫。",
+  "target": "lead"
+}
+
+// 30 分鐘後執行一次
+{
+  "action": "create",
+  "run_at": "2026-05-25T10:00:00",
+  "message": "提醒：PR review deadline 到了",
+  "target": "reviewer"
+}
+```
+
+### 操作
+
+#### create — 建立排程
+
+| 參數 | 類型 | 必要 | 說明 |
+|------|------|------|------|
+| `cron` | string | 二選一 | Cron 表達式（重複執行） |
+| `run_at` | string | 二選一 | 一次性時間（RFC 3339 或本地時間） |
+| `message` | string | 是 | 觸發時發送的訊息內容 |
+| `target` | string | 否 | 目標 agent（預設為建立者自己） |
+| `label` | string | 否 | 人類可讀的標籤 |
+
+`cron` 和 `run_at` 必須且只能指定一個。
+
+#### list — 列出排程
+
+```json
+{"action": "list"}
+```
+
+回傳所有排程，包含執行歷史（最近 50 次）。
+
+#### update — 修改排程
+
+| 參數 | 類型 | 說明 |
+|------|------|------|
+| `id` | string | 排程 ID（必要） |
+| `cron` | string | 新的 cron 表達式 |
+| `run_at` | string | 改為一次性排程 |
+| `message` | string | 新訊息內容 |
+| `target` | string | 新目標 agent |
+| `label` | string | 新標籤 |
+| `enabled` | bool | 啟用/停用 |
+
+可以在 cron 和一次性之間切換。
+
+#### delete — 刪除排程
+
+```json
+{"action": "delete", "id": "s-20260525..."}
+```
+
+### Cron 格式
+
+支援標準的 5 欄位和 6 欄位 cron 格式：
+
+```
+# 5 欄位（系統自動補秒數 0）
+分 時 日 月 星期幾
+0 9 * * *           → 每天 09:00
+30 14 * * 1-5       → 週一到五 14:30
+0 */2 * * *         → 每 2 小時
+
+# 6 欄位（秒 分 時 日 月 星期幾）
+30 0 9 * * *        → 每天 09:00:30
+```
+
+星期幾使用 Quartz 慣例：1=週日, 2=週一, ..., 7=週六。
+
+### 時區處理
+
+每個排程記錄建立時的時區（IANA 格式），cron 表達式在該時區下求值。
+
+偵測順序：
+1. `TZ` 環境變數
+2. 系統時區（macOS: CoreFoundation, Linux: `/etc/localtime`）
+3. 降級為 `UTC`
+
+時區在建立時鎖定，不會因為系統時區變更而改變。
+
+### 觸發機制
+
+Daemon 的主迴圈每 10 秒執行一次 tick：
+
+1. 載入所有已啟用的排程
+2. 計算檢查區間：`(上次檢查時間, 現在]`
+3. 對每個排程判斷是否應該觸發
+4. 觸發時投遞訊息給目標 agent
+
+區間追蹤防止 daemon 重啟時重複觸發。
+
+### 訊息投遞
+
+根據目標 agent 的狀態使用不同投遞方式：
+
+| 狀態 | 投遞方式 | 記錄狀態 |
+|------|----------|----------|
+| 在線 | 直接注入 PTY stdin | `ok` |
+| 離線 | 寫入收件匣 | `ok_inbox` |
+| 錯過（daemon 當時沒在跑） | 不投遞 | `missed` |
+
+### 一次性排程
+
+一次性排程（`run_at`）在觸發後自動停用，不會再次觸發。
+
+如果 daemon 在排程時間沒有運行：
+- 24 小時內：daemon 啟動時補發（replay）
+- 超過 24 小時：標記為 `stale_dropped` 並停用，不補發過時的訊息
+
+### 執行歷史
+
+每個排程保留最近 50 次執行記錄：
+
+```json
+{
+  "run_history": [
+    {"triggered_at": "2026-05-25T09:00:00Z", "status": "ok"},
+    {"triggered_at": "2026-05-24T09:00:00Z", "status": "ok_inbox"},
+    {"triggered_at": "2026-05-23T09:00:00Z", "status": "missed"}
+  ]
+}
+```
+
+### 儲存
+
+- 位置：`$AGEND_HOME/schedules.json`
+- 格式：版本化 JSON（v1 → v2 自動升級）
+- 鎖定：flock + atomic write（temp → fsync → rename）
+
+---
+
+## Deployments — 批次部署
+
+### 快速開始
+
+```json
+// 部署一個三人團隊
+{
+  "action": "deploy",
+  "template": "fixup-team",
+  "directory": "/tmp/fixup-workspace",
+  "branch": "main"
+}
+```
+
+### 部署範本
+
+在 `fleet.yaml` 中定義部署範本：
+
+```yaml
+templates:
+  fixup-team:
+    orchestrator: lead
+    instances:
+      lead:
+        backend: claude
+        role: "團隊 orchestrator，負責任務分派和審查結果彙整"
+      dev:
+        backend: claude
+        role: "實作者，負責寫程式碼和修 bug"
+      reviewer:
+        backend: claude
+        role: "審查者，負責 code review"
+```
+
+### 操作
+
+#### deploy — 部署
+
+| 參數 | 類型 | 必要 | 說明 |
+|------|------|------|------|
+| `template` | string | 是 | 範本名稱（`fleet.yaml` 中定義） |
+| `directory` | string | 是 | 工作目錄父路徑 |
+| `name` | string | 否 | 部署名稱（預設使用範本名） |
+| `branch` | string | 否 | Git 分支（自動建立 worktree） |
+
+部署流程分四個階段：
+
+1. **驗證與 Worktree**：驗證範本，為每個 agent 建立 `<directory>/<name>-<suffix>` 子目錄。如果指定了 `branch`，使用 `git worktree add`
+2. **Fleet.yaml 寫入**：將所有 instance 定義寫入 `fleet.yaml`
+3. **Agent 啟動**：逐一 spawn 每個 agent
+4. **Team 建立**：如果是多 agent 範本，自動建立 team 並指定 orchestrator
+
+#### teardown — 拆除
+
+```json
+{
+  "action": "teardown",
+  "name": "fixup-team"
+}
+```
+
+拆除流程：
+1. 刪除所有 agent instance
+2. 清理檔案系統（刪除工作目錄）
+3. 從 `fleet.yaml` 移除 instance 定義
+4. 刪除 team（如果有）
+5. 從部署記錄中移除
+
+如果父目錄在拆除後為空，也會一併清理。
+
+#### list — 列出部署
+
+```json
+{"action": "list"}
+```
+
+回傳所有部署記錄，包含 instance 清單和建立時間。
+
+### 孤兒部署清理
+
+Daemon 啟動時自動檢查孤兒部署——部署記錄中的 instance 在 `fleet.yaml` 中已不存在的情況。孤兒部署會自動清理相關的 team 和檔案系統。
+
+### 儲存
+
+- 位置：`$AGEND_HOME/deployments.json`
+- 格式：版本化 JSON
+- 鎖定：flock + atomic write
+
+---
+
+## 典型用法
+
+### 每日 Standup 提醒
+
+```json
+{
+  "action": "create",
+  "cron": "0 9 * * 1-5",
+  "message": "早安！請回報：1) 昨天完成了什麼 2) 今天計畫做什麼 3) 有沒有阻塞",
+  "target": "lead",
+  "label": "daily-standup"
+}
+```
+
+### 定期檢查 PR 狀態
+
+```json
+{
+  "action": "create",
+  "cron": "0 */3 * * *",
+  "message": "請檢查所有 open PR 的 CI 狀態，回報任何失敗的 check。",
+  "target": "reviewer",
+  "label": "pr-health-check"
+}
+```
+
+### 延遲提醒
+
+```json
+{
+  "action": "create",
+  "run_at": "2026-05-25T15:00:00",
+  "message": "提醒：今天 3 點有 release cut，確認所有 PR 已合併",
+  "target": "lead"
+}
+```
+
+### 一鍵部署團隊
+
+```json
+{
+  "action": "deploy",
+  "template": "fixup-team",
+  "directory": "/tmp/sprint-59",
+  "branch": "main",
+  "name": "sprint-59"
+}
+```
+
+部署完成後，三個 agent 各自在 `/tmp/sprint-59/sprint-59-lead`、`/tmp/sprint-59/sprint-59-dev`、`/tmp/sprint-59/sprint-59-reviewer` 目錄工作，team 已建立，lead 為 orchestrator。
+
+### 工作結束後拆除
+
+```json
+{
+  "action": "teardown",
+  "name": "sprint-59"
+}
+```
+
+一個指令清理所有 agent、team、工作目錄和 fleet.yaml 記錄。


### PR DESCRIPTION
## Summary
- **FEATURE-channels.md** (279 lines): Telegram/Discord 整合——Channel trait、binding 機制、topics.json、去重、自我修復、fleet binding、通知閘門
- **FEATURE-decisions.md** (292 lines): 決策追溯系統——post/list/update、supersedes 修正追蹤、TTL 自動過期、受保護標籤、TUI overlay、decision timeout
- **FEATURE-schedules.md** (305 lines): 定時任務與批次部署——cron/one-shot 排程、時區處理、觸發機制、deployment templates、teardown

All docs in 繁體中文, sourced from actual codebase (channel/, decisions.rs, schedules.rs, cron_tick.rs, deployments.rs).

## Test plan
- [x] All 3 files created in docs/
- [x] Line counts within 200-400 range
- [ ] Content accuracy verified against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)