### PR TITLE
docs: add tier 4 user docs

### DIFF
--- a/docs/FEATURE-configuration.md
+++ b/docs/FEATURE-configuration.md
@@ -1,0 +1,434 @@
+# 設定層：`AGEND_HOME`、`fleet.yaml`、runtime config、MCP config
+
+這份文件說明 AgEnD 的設定是怎麼分層的、誰能寫哪一層、
+以及你應該在哪裡改哪一種設定。
+
+核心原則只有一句：
+
+- **來源要單一，派生檔要可重建。**
+
+也就是說：
+
+- `fleet.yaml` 是 fleet 的主要人類可編輯來源。
+- `runtime-config.json` 是可熱更新的執行期數值。
+- 各 backend 的 `mcp.json` / `settings.local.json` 是派生設定，不是主來源。
+- service manager artifact 也是派生設定，不是主來源。
+
+## 設定層次總覽
+
+| 層級 | 典型檔案 / env | 誰寫 | 作用時間 |
+|---|---|---|---|
+| 進程環境 | `AGEND_HOME`, `AGEND_POINTER_ONLY_INJECT`, `AGEND_CAPTURE_FIXTURES` | 操作員 / 啟動器 | 啟動時讀取 |
+| Fleet 主設定 | `$AGEND_HOME/fleet.yaml` | 操作員 + daemon | 啟動 / 重新載入時 |
+| 執行期設定 | `$AGEND_HOME/runtime-config.json` | MCP `config` 工具 | 每個 daemon tick |
+| MCP 派生設定 | `.claude/settings.local.json`, `.kiro/settings/mcp.json`, `mcp-config.json` | daemon / 生成器 | backend 啟動前 |
+| 服務管理器 artifact | plist / unit / task xml | `service install` | OS 登入時 |
+| 診斷輸出 | `bugreport-*.txt`, `captures/*` | operator / capture 工具 | 需要時 |
+
+## `AGEND_HOME`
+
+`AGEND_HOME` 是最重要的根目錄。
+
+### 解析規則
+
+程式優先順序是：
+
+1. 如果環境變數 `AGEND_HOME` 存在，就直接用它。
+2. 否則回到使用者家目錄：
+   - 優先 `~/.agend`
+   - 相容舊路徑 `~/.agend-terminal`
+
+### 為什麼這個根目錄重要
+
+幾乎所有可持久化狀態都掛在這裡：
+
+- `fleet.yaml`
+- `runtime-config.json`
+- `captures/`
+- `service/`
+- `skills/`
+- `bin/`
+- `protocol/`
+- `workspace/`
+- `worktrees/`
+
+換句話說，搬家或備份時，先看 `AGEND_HOME`。
+
+## `.env`
+
+daemon 會從 `AGEND_HOME/.env` 讀取環境變數。
+
+### 支援格式
+
+- `KEY=value`
+- `export KEY=value`
+- single quoted / double quoted value
+
+### 注意事項
+
+- `#` 在 quoted value 中會被保留。
+- unquoted 值的 inline comment 會被剝掉。
+- `.env` 不是唯一來源；它只是啟動期環境補充。
+
+### 適合放什麼
+
+- bot token 的 env 名稱
+- backend API key 的 env 名稱
+- local-only feature flag
+
+### 不適合放什麼
+
+- 大量結構化 fleet 定義
+- runtime 可調 threshold
+- 使用者 global CLI 設定
+
+## `fleet.yaml`
+
+`fleet.yaml` 是 fleet 的主設定檔。
+
+### 預設位置
+
+```text
+$AGEND_HOME/fleet.yaml
+```
+
+### 你會在這裡設定什麼
+
+這個檔案描述每個 instance 的來源、角色與啟動方式。
+常見欄位包含：
+
+- `backend`
+- `working_directory`
+- `role`
+- `instructions`
+- `source_repo`
+- `repo`
+- `github_login`
+- `args`
+- `model`
+- `env`
+- `ready_pattern`
+- `command`
+- `worktree`
+- `skills`
+- `topic_binding_mode`
+- `topic_id`
+- `id`
+
+### 哪些欄位是 daemon-managed
+
+目前明確歸為 daemon-managed 的欄位有：
+
+- `id`
+- `topic_id`
+- `git_branch`
+- `source_repo`
+
+意思是：
+
+- daemon 會覆寫它們。
+- operator 不應把它們當成永久手改欄位。
+- 若手改與 daemon 內容衝突，merge 會以 daemon 為準，或直接報 conflict。
+
+### 哪些欄位是 operator hand-edit
+
+常見 operator 管欄位：
+
+- `backend`
+- `working_directory`
+- `role`
+- `instructions`
+- `repo`
+- `github_login`
+- `args`
+- `model`
+- `env`
+- `ready_pattern`
+- `command`
+- `worktree`
+- `skills`
+- `topic_binding_mode`
+
+### `None` 與 `Some(empty)` 的差別
+
+這個差異很重要，尤其在 `args`、`env`、`skills` 這類欄位。
+
+- `None`：不要覆寫預設。
+- `Some(vec![])` / 空集合：明確 opt-out。
+
+例子：
+
+- `args: null` → 使用 backend 預設參數。
+- `args: []` → 明確要求空參數列。
+- `skills: null` → 安裝全部 skills。
+- `skills: []` → 明確不安裝任何 skills。
+
+### `skills`
+
+`skills` 是 per-instance allowlist。
+
+語意如下：
+
+- `null`：安裝所有共享 skills。
+- `[]`：不安裝任何 skills。
+- `["foo", "bar"]`：只安裝指定的 skills。
+
+這個欄位會影響 backend 工作目錄底下的技能安裝內容。
+
+### `topic_binding_mode`
+
+這個欄位控制 Telegram topic 是否在 spawn 時就建立。
+
+- `auto` / `null`：目前預設行為。
+- `skip`：永遠不建立 topic。
+- `deferred`：spawn 時不建，之後可補綁。
+
+### `repo` / `source_repo`
+
+這兩個欄位都跟來源 repo 有關，但語意不同：
+
+- `source_repo`：daemon 會把它當成綁定來源的一部分。
+- `repo`：GitHub `owner/name` 層級的覆寫。
+
+如果你只是在做 operator hand-edit，避免把 daemon-managed 欄位當成永久真相。
+
+### merge 行為
+
+fleet merge 不是純覆蓋，而是有欄位分類。
+
+- daemon-managed 欄位：daemon 值覆寫 operator 值。
+- operator-hand-edit 欄位：
+  - 既有欄位缺失 → 寫入 daemon 值
+  - 既有欄位相同 → no-op
+  - 既有欄位不同 → 產生 conflict
+- daemon 未提供的欄位：保留 operator 原值
+
+這樣做的目的，是避免 daemon 和 operator 互相把對方的資訊洗掉。
+
+## `runtime-config.json`
+
+這是執行期設定。
+
+### 預設位置
+
+```text
+$AGEND_HOME/runtime-config.json
+```
+
+### 讀取方式
+
+daemon 會在每個 tick 重新載入一次，所以它是 live tunable 的。
+
+### 可調欄位
+
+| key | 預設值 | 意義 |
+|---|---|---|
+| `dev_idle_threshold_secs` | `3600` | 單一 agent 的 idle 閾值 |
+| `fleet_idle_threshold_secs` | `1800` | 整體 fleet 的 idle 閾值 |
+| `hang_auto_recovery_enabled` | `false` | 是否啟用 hang auto-recovery |
+
+### 如何修改
+
+透過 MCP `config` 工具：
+
+- `config get`
+- `config set`
+- `config list`
+
+也就是說，這不是一個通常要手改的檔案。
+
+### 失敗語意
+
+- key 不存在 → error
+- 整數 / 布林 parse 失敗 → error
+- JSON 解析失敗 → 預設值
+
+這意味著：runtime config 壞掉時，daemon 不會停；它會回到預設值。
+
+### 什麼時候適合用它
+
+- 調整 watchdog 閾值。
+- 暫時拉高 fleet idle 閾值。
+- 開關 hang auto-recovery shadow/active。
+
+### 不適合放什麼
+
+- fleet 結構
+- agent 身分
+- backend 路徑
+- 任何需要審核的長期政策
+
+## `DaemonConfig`：進程內旗標
+
+`src/daemon_config.rs` 的設定是 process-wide，但不是持久化檔。
+
+### 現有欄位
+
+- `pointer_only_inject`
+
+### 來源
+
+- `AGEND_POINTER_ONLY_INJECT=1` 會開啟
+- 沒有就預設 `false`
+
+### 用途
+
+這類設定是 daemon startup 時讀一次，
+適合控制特定注入策略或暫時性實驗旗標。
+
+### 注意事項
+
+- 它不會寫回磁碟。
+- 它不會自動跟 fleet.yaml 同步。
+- 如果你要長期保存，應該把需求落到正式設定檔或 MCP config。
+
+## MCP config：各 backend 的派生設定
+
+`src/mcp_config.rs` 負責為 backend 生成對應的 MCP 設定檔。
+
+### 設定範圍
+
+這裡有一條硬規則：
+
+- 寫入只能落在 `$AGEND_HOME` 或專案工作目錄。
+- 不碰使用者全域的 CLI 設定目錄。
+
+也就是說，不要讓程式去改 `~/.claude`、`~/.codex`、`~/.gemini` 之類的個人設定。
+
+### 生成內容
+
+產出的 MCP config 會帶上：
+
+- `AGEND_HOME`
+- 某些情況下的 `AGEND_INSTANCE_NAME`
+- bridge binary 的路徑
+
+### 常見輸出位置
+
+視 backend 而定，常見包括：
+
+- `.claude/settings.local.json`
+- `mcp-config.json`
+- `.kiro/settings/mcp.json`
+
+其他 backend 也會有對應的 project-local 設定檔。
+
+### 備援與錯誤處理
+
+- JSON 破損時，會先備份成 `.corrupt.<timestamp>`。
+- 然後從空物件重新開始。
+- 這跟 `runtime-config.json` 的 silent default 不同；MCP config 會盡量保留一份備份。
+
+### 為什麼是派生檔
+
+MCP config 的真相其實是：
+
+- `fleet.yaml` 裡的 instance 定義
+- `AGEND_HOME`
+- 當前 binary 路徑
+
+MCP config 只是把這些來源轉成 backend 需要的格式。
+
+## `service` artifact 也是派生設定
+
+service 產物不是來源檔，而是由 install 命令根據目前 binary 與 `AGEND_HOME` render 出來的。
+
+| 平台 | 產物 |
+|---|---|
+| macOS | plist |
+| Linux | systemd user unit |
+| Windows | Task Scheduler XML |
+
+如果 binary moved / repathed，重跑 `service install` 才會更新。
+
+## 設定錯誤時的典型反應
+
+### `fleet.yaml` 壞掉
+
+- `doctor` 會報 parse error。
+- daemon 可能無法正常啟動。
+- 先用 `bugreport` 取快照，再修檔。
+
+### `runtime-config.json` 壞掉
+
+- daemon 會回到 default values。
+- 不一定會立刻看到 crash。
+- 這類問題通常要看 log 或 `doctor` 的結果。
+
+### `mcp` 設定檔壞掉
+
+- 會備份舊檔。
+- 重新產生新的派生檔。
+- 如果 backend 行為怪異，先確認是不是 config 被重寫。
+
+### `service` artifact 壞掉
+
+- `service status` 可能顯示 `stopped`。
+- 重新 `service install` 通常比手修 artifact 快。
+
+## 建議的操作順序
+
+### 新機器 / 新安裝
+
+1. 設好 `AGEND_HOME` 或接受預設。
+2. 準備 `.env`。
+3. 編輯 `fleet.yaml`。
+4. 跑 `service install`。
+5. 跑 `doctor`。
+
+### 想調整 idle / watchdog 閾值
+
+1. 用 `config set` 改 `runtime-config.json`。
+2. 等下一個 tick。
+3. 用 `doctor` 或看 event / log 驗證。
+
+### 想改某個 agent 的行為
+
+1. 改 `fleet.yaml` 的 instance 欄位。
+2. 若涉及 backend 設定，讓 MCP config 重新生成。
+3. 必要時重裝 service。
+
+### 想追問題
+
+1. 先跑 `doctor`。
+2. 再跑 `bugreport`。
+3. 若是 backend 互動問題，再考慮 `capture`。
+
+## 常見誤區
+
+### 把 MCP config 當主設定
+
+錯。它是派生檔，會被重寫。
+
+### 把 runtime-config 當 fleet 配置
+
+錯。它只管 live threshold 類的數值。
+
+### 手改 daemon-managed 欄位後期待永久保留
+
+錯。那些欄位會被 daemon 重寫。
+
+### 把空集合和 `null` 當同一件事
+
+錯。很多欄位的語意剛好相反。
+
+## 對應原始碼
+
+- `src/main.rs`：`AGEND_HOME`、CLI default path、`Doctor` / `Service`
+- `src/fleet.rs`：`FleetConfig`、`InstanceYamlEntry`、欄位 merge 規則
+- `src/runtime_config.rs`：runtime-config 讀寫與 tick reload
+- `src/daemon_config.rs`：process-wide runtime flags
+- `src/mcp_config.rs`：backend MCP config 生成
+- `src/store.rs`：lock、atomic write、corrupt backup
+- `src/service/*`：service manager artifact 生成
+- `src/bugreport.rs`：diagnostic report 打包
+- `src/capture.rs`：capture 與 promote 產物
+
+## 實務建議
+
+1. 長期政策放 `fleet.yaml`，不要塞進 runtime config。
+2. 短期 tuning 放 `runtime-config.json`，不要硬改 source code。
+3. 任何會被派生的設定，都要保留原始來源。
+4. 看到疑似設定污染，先看 `bugreport`，再看派生檔是不是被重寫。
+5. 記住一句話：**主來源可編輯，派生檔可重建。**
+

--- a/docs/FEATURE-diagnostics.md
+++ b/docs/FEATURE-diagnostics.md
@@ -1,0 +1,373 @@
+# 診斷與取證：`agend-terminal doctor / bugreport / capture`
+
+這份文件整理所有「先觀察、再判斷、最後再修」的診斷入口。
+
+它們共同的原則很簡單：
+
+- 預設不改狀態。
+- 需要改狀態時，會先把可見輸出印給操作員。
+- 能紅就紅，能警告就警告，不會悄悄幫你修掉。
+
+## 功能總覽
+
+| 命令 | 目的 | 預設是否改狀態 |
+|---|---|---|
+| `doctor` | 全域健康檢查 | 否 |
+| `doctor topics` | Telegram topic 狀態診斷 | 否；`--cleanup` 才會改 |
+| `bugreport` | 匯出可附帶回報的診斷檔 | 否 |
+| `capture backend` | 擷取 backend PTY 內容 | 是，寫 capture 檔 |
+| `capture promote` | 把 capture 提升成 fixture | 是，寫 fixture / manifest |
+
+這幾個入口對應到不同場景：
+
+- `doctor`：我現在這台機器是不是健康？
+- `doctor topics`：Telegram topic 有沒有孤兒或缺失？
+- `bugreport`：我要把現在的狀態打包給別人看。
+- `capture`：我要留下可重播的原始輸出。
+
+## `doctor`：全域健康檢查
+
+```bash
+agend-terminal doctor
+```
+
+### 它檢查什麼
+
+`doctor` 會依序印出以下項目：
+
+1. `AGEND_HOME` 是否存在。
+2. `.env` 是否存在。
+3. `fleet.yaml` 是否存在、是否能 parse、目前有幾個 instance。
+4. 每個 instance 是否能透過 daemon 的 runtime helper 找到活著的 agent。
+5. thread census。
+6. 所有 backend binary 是否在 PATH。
+7. `$AGEND_HOME/bin` 的 helper staleness。
+
+### 判讀方式
+
+`doctor` 的輸出不是「有沒有一切完美」，而是「哪些層壞了」。
+
+常見訊號：
+
+- `✗ (not found)`：檔案或目錄缺失。
+- `✗ (parse error: ...)`：設定檔已經壞掉。
+- `✗ (port stale)`：agent 名稱還在，但實際 PTY / IPC 可能已死。
+- `✓ (port responsive)`：daemon 看到該 agent 且 probe 成功。
+- `patterns may need update`：backend 版本與我們 calibrate 的版本不一致。
+
+### `doctor` 不做的事
+
+它不會：
+
+- 自動修 fleet.yaml。
+- 自動更新 backend。
+- 自動重啟 daemon。
+- 自動修 helper staleness。
+
+這是故意的。`doctor` 是觀察，不是治療。
+
+## `doctor topics`：Telegram topic 診斷
+
+```bash
+agend-terminal doctor topics
+agend-terminal doctor topics --cleanup
+agend-terminal doctor topics --cleanup --yes
+agend-terminal doctor topics --format json
+```
+
+### 主要用途
+
+這個入口用來看 Telegram topic registry 與實際群組聊天室的狀態是否一致。
+
+它會把每個 topic 分成兩類：
+
+- `live`：資料庫 / registry 與聊天室都還對得上。
+- `orphan`：registry 裡還有，但聊天室狀態已經不一致，或反過來需要清理。
+
+### `--cleanup`
+
+`--cleanup` 不是單純的格式開關，而是會真的執行修復：
+
+1. 先印出診斷結果。
+2. 再要求確認，除非加了 `--yes`。
+3. 依結果對 registry 與聊天室做同步清理。
+
+這裡的清理包含兩個面向：
+
+- registry 更新
+- chat-side delete
+
+### 權限檢查
+
+`doctor topics` 會先 probe bot 是否有 `can_manage_topics`。
+
+這件事的影響是：
+
+- 有權限 → 可以刪聊天室 topic。
+- 沒權限 → 只會跳過，並印出 warn。
+
+如果 probe 失敗，輸出會傾向保守，避免誤刪。
+
+### JSON 與 human
+
+`--format human`
+
+- 多行表格。
+- 適合人在 terminal 直接看。
+
+`--format json`
+
+- 給腳本或其他工具 pipe。
+- 適合在外層做自動化 triage。
+
+### cleanup 動作的回報格式
+
+cleanup 後，CLI 會列出每個動作：
+
+- `deleted topic ... — chat + registry`
+- `skipped ... — bot lacks can_manage_topics`
+- `skipped ... — API error: ...`
+
+這讓你知道是「真的修掉了」還是「因為權限或 API 失敗跳過」。
+
+## `bugreport`：一鍵匯出診斷包
+
+```bash
+agend-terminal bugreport
+```
+
+### 輸出位置
+
+`bugreport` 會把檔案寫到：
+
+- 目前工作目錄
+- 如果目前工作目錄不可用，則退回 `AGEND_HOME`
+
+檔名格式：
+
+```text
+bugreport-YYYYMMDD-HHMMSS.txt
+```
+
+### 包含哪些內容
+
+`bugreport` 的內容很適合拿來附在 issue 或回報裡，因為它收了這些章節：
+
+1. 版本資訊
+2. `AGEND_HOME`
+3. fleet config（已 redacted token / secret）
+4. schedules.json
+5. daemon status
+6. 最新 snapshot
+7. event log 最後 50 行
+8. 已安裝 backend
+9. 目前 active sockets
+10. `.env`（已 redacted）
+
+### 為什麼有些內容會 redacted
+
+`bugreport` 會把敏感值遮掉，尤其是：
+
+- token
+- key
+- secret
+- password
+- bearer
+- authorization
+- credential
+- group_id
+
+這樣可以在不外洩敏感資訊的前提下，把狀態完整附上。
+
+### `bugreport` 與 `doctor` 的差別
+
+- `doctor`：現場即時健康摘要。
+- `bugreport`：可分享的靜態快照。
+
+如果你要把問題交給別人看，通常先跑 `bugreport`，再附上 `doctor` 的輸出會更完整。
+
+## `capture backend`：抓 backend 原始輸出
+
+```bash
+agend-terminal capture backend --backend claude --seconds 15
+```
+
+### 目的
+
+這個命令是為了把 backend PTY 的原始輸出留下來，讓你可以：
+
+- 做 fixture。
+- 做 replay。
+- 重現某個 shell / backend 的行為。
+
+### 行為
+
+`capture backend` 會：
+
+1. 起一個對應 backend 的 agent。
+2. 在指定秒數內持續讀取 PTY。
+3. 把 bytes 寫到 capture 檔。
+4. 結束時寫出 `.meta.json` sidecar。
+
+### 捕獲檔位置
+
+預設落在：
+
+```text
+$AGEND_HOME/captures/<agent>/<epoch_ms>.cap
+```
+
+對應 sidecar：
+
+```text
+$AGEND_HOME/captures/<agent>/<epoch_ms>.cap.meta.json
+```
+
+### 何時使用
+
+適合以下情境：
+
+- 你想重播某個 backend 的 prompt / response 序列。
+- 你要建立 fixture corpus。
+- 你要比較不同 backend 的實際輸出差異。
+
+### 重要限制
+
+- `AGEND_CAPTURE_FIXTURES` 沒開時，capture writer 是 no-op。
+- 這個功能是觀測工具，不是 replay 引擎本身。
+- capture 內容是 raw PTY bytes，不是美化過的摘要。
+
+## `capture promote`：把 capture 變成可重播 fixture
+
+```bash
+agend-terminal capture promote \
+  $AGEND_HOME/captures/myagent/1234567890.cap \
+  sample-scenario \
+  --scenario-kind silent_stuck
+```
+
+### 它會做什麼
+
+`promote` 會把一個 `.cap` 檔提升成 canonical fixture，流程是：
+
+1. 讀 `.cap.meta.json`。
+2. 複製 `.cap` 到 `tests/fixtures/state-replay/<scenario>.raw`。
+3. 在 `tests/fixtures/state-replay/MANIFEST.yaml` 追加一筆條目。
+4. 可選擇做 `auto_replay` 的警告比對。
+
+### `scenario_kind`
+
+目前合法值是：
+
+- `productive_marker_fire`
+- `productive_silence`
+- `silent_stuck`
+- `hung`
+- `real_capture`
+
+這個值是 manifest schema 的一部分，不是任意文字。
+
+### `auto_replay`
+
+如果你加 `--auto-replay`，CLI 會把 `scenario_kind` 對應的 hung/not_hung 預期拿來比對。
+
+注意：
+
+- mismatch 只會 warning，不會回滾 promote。
+- 這是刻意的，因為 operator review 仍是 v1 safety net。
+
+### `expected_hung`
+
+這個選項用來做交叉檢查：
+
+- `silent_stuck` / `hung` 通常期待 `hung`
+- `productive_*` 通常期待 `not_hung`
+- `real_capture` 不做這個比較
+
+## 檔案與資料來源對照
+
+| 命令 | 主要讀取 | 主要寫入 |
+|---|---|---|
+| `doctor` | `fleet.yaml`、`$AGEND_HOME/bin`、runtime probe | 無 |
+| `doctor topics` | Telegram channel / registry | 可選：registry + 聊天室刪除 |
+| `bugreport` | `fleet.yaml`、`schedules.json`、snapshot、event log、`.env` | `bugreport-*.txt` |
+| `capture backend` | backend PTY | `$AGEND_HOME/captures/.../*.cap` + `.meta.json` |
+| `capture promote` | `.cap` + `.meta.json` | `tests/fixtures/state-replay/*.raw` + `MANIFEST.yaml` |
+
+## 典型工作流程
+
+### 1. 先做健康檢查
+
+```bash
+agend-terminal doctor
+```
+
+看出來是：
+
+- file 層壞了
+- backend 不在 PATH
+- helper staleness
+- agent port stale
+
+### 2. 若是 Telegram topic 問題
+
+```bash
+agend-terminal doctor topics --format json
+```
+
+先看哪些是 orphan，再決定要不要 cleanup。
+
+### 3. 若要回報 issue
+
+```bash
+agend-terminal bugreport
+```
+
+把產出的檔案貼到 issue 或附檔。
+
+### 4. 若要新增 replay fixture
+
+```bash
+export AGEND_CAPTURE_FIXTURES=1
+agend-terminal capture backend --backend claude --seconds 20
+agend-terminal capture promote <cap> <name> --scenario-kind silent_stuck
+```
+
+## 常見誤區
+
+### 把 `doctor` 當修復工具
+
+不對。`doctor` 是觀察與列舉問題，不是自動修復。
+
+### 忽略 `doctor topics` 的 permission probe
+
+如果 bot 沒有 `can_manage_topics`，cleanup 會保守跳過。
+不要把這當成程式沒壞；多半是權限不足。
+
+### 把 bugreport 當完整安全備份
+
+它是診斷包，不是 restore 檔。
+你可以靠它看出狀態，但不要拿它當正式的資料備份。
+
+### 把 capture 當 fixture 的最終版本
+
+`capture backend` 只負責抓原始資料。
+要讓 replay harness 看得到，還要 `capture promote`。
+
+## 對應原始碼
+
+- `src/cli.rs`：`run_doctor`、`run_doctor_topics`、`capture_backend`
+- `src/main.rs`：CLI subcommand routing
+- `src/bugreport.rs`：bugreport 內容與 redaction
+- `src/capture.rs`：capture sink、rotation、promote
+- `src/bootstrap/doctor_topics.rs`：topic classification 與 cleanup
+- `src/bootstrap/doctor.rs`：fleet health validation
+
+## 實務建議
+
+1. 遇到 agent staleness，先跑 `doctor`，不要直接刪檔。
+2. Telegram topic 問題先看 `doctor topics`，再做 cleanup。
+3. 需要貼給別人看的狀態，優先用 `bugreport`。
+4. 做 capture 時，記得確認 `AGEND_CAPTURE_FIXTURES=1`。
+5. promote 前先看 `scenario_kind`，不要用錯類型造成 manifest 語義錯位。
+

--- a/docs/FEATURE-service.md
+++ b/docs/FEATURE-service.md
@@ -1,0 +1,302 @@
+# 服務管理：`agend-terminal service`
+
+這份文件說明 `service` 子命令如何把 daemon 交給作業系統管理，
+以及三個平台各自的落點與限制。
+
+## 這個功能解決什麼問題
+
+`agend-terminal` 本身可以在前景、背景、TUI 或 daemon 模式運作，
+但若希望它在登入後自動啟動、在 crash 後重新拉起，
+就不能只靠手動執行。
+`service` 提供的是「交給 OS 管理生命周期」這個入口。
+
+你可以把它理解成兩件事：
+
+1. 把目前這個 `agend-terminal` binary 的絕對路徑寫進平台的 service manager。
+2. 讓平台在使用者登入時自動啟動，並在 daemon 掛掉後嘗試重新拉起。
+
+重要前提：
+
+- 這是 **user-level** 設定，不需要 root / admin。
+- 它不會讓 daemon 自我監督；真正的 supervisor 是 OS 自己。
+- install / uninstall 都是 idempotent，重跑不會破壞既有狀態。
+
+## 支援平台
+
+| 平台 | 服務管理器 | 輸出位置 | 註冊方式 |
+|---|---|---|---|
+| macOS | `launchd` | `~/Library/LaunchAgents/com.agend-terminal.daemon.plist` | `launchctl load -w` |
+| Linux | `systemd --user` | `~/.config/systemd/user/agend-terminal-daemon.service` | `systemctl --user enable --now` |
+| Windows | Task Scheduler | `\AgendTerminalDaemon` | `schtasks /Create /XML` |
+
+這三個平台都屬於使用者層級。
+如果你在沒有對應平台工具的環境中執行，`install` 會回報平台不支援。
+
+## 三個子命令
+
+```bash
+agend-terminal service install
+agend-terminal service uninstall
+agend-terminal service status
+```
+
+### `install`
+
+`install` 會做以下事情：
+
+1. 解析目前執行中的 `agend-terminal` binary 絕對路徑。
+2. 依平台套用對應 template，並把路徑與 `AGEND_HOME` 填入。
+3. 寫入平台要求的 artifact。
+4. 呼叫平台 service manager 完成註冊。
+
+如果你重跑 `install`，它會重新產生 template，這對 binary 更新或 `AGEND_HOME` 變動很有用。
+
+### `uninstall`
+
+`uninstall` 會嘗試：
+
+1. 解除註冊。
+2. 刪除對應的 service artifact。
+
+如果原本就沒有安裝，這會是 no-op 成功。
+
+### `status`
+
+`status` 只回答三種結果：
+
+- `running`
+- `stopped`
+- `not_installed`
+
+注意：`status` 是在查平台 service manager，而不是直接看 daemon 內部狀態。
+
+## macOS 行為
+
+macOS 使用 `launchd` 的 user agent。
+
+### 位置
+
+- plist：`~/Library/LaunchAgents/com.agend-terminal.daemon.plist`
+- label：`com.agend-terminal.daemon`
+
+### install
+
+macOS 的流程是：
+
+1. 先把 template render 成 plist。
+2. 寫入 LaunchAgents 目錄。
+3. 先 `launchctl unload -w`，再 `launchctl load -w`。
+
+這個順序讓重新安裝保持 idempotent。
+
+### status
+
+判斷邏輯是：
+
+- plist 不存在 → `NotInstalled`
+- `launchctl list <label>` 成功，且輸出包含 PID → `Running`
+- plist 存在但未載入或未執行 → `Stopped`
+
+### 注意事項
+
+- `launchctl` 失敗時，status 不會誤判成 `running`。
+- 如果 plist 已存在，但 daemon 沒有被 launchd 管理，仍會顯示 `stopped`。
+- `StandardOutPath` / `StandardErrorPath` 已固定為 `/dev/null`；真正的日誌輸出走 daemon tracing。
+
+## Linux 行為
+
+Linux 使用 `systemd --user`。
+
+### 位置
+
+- unit：`~/.config/systemd/user/agend-terminal-daemon.service`
+- 若有設定 `XDG_CONFIG_HOME`，會先使用它。
+
+### install
+
+Linux 的流程是：
+
+1. render unit template。
+2. 寫入 `~/.config/systemd/user/`。
+3. 執行 `systemctl --user daemon-reload`。
+4. 執行 `systemctl --user enable --now agend-terminal-daemon.service`。
+
+這樣可以同時做到開機後登入自啟，以及立即啟動。
+
+### status
+
+判斷邏輯是：
+
+- unit 檔不存在 → `NotInstalled`
+- `systemctl --user is-active` 成功 → `Running`
+- unit 存在但未 active → `Stopped`
+
+### 注意事項
+
+- 在某些 CI 或無 systemd session bus 的環境中，`enable --now` 可能失敗，但 unit 檔案仍然已經寫入。
+- 這種情況下，install 會保留檔案並把 activation 問題當成 warning。
+- 因為是 user-level unit，不需要 sudo。
+
+## Windows 行為
+
+Windows 使用 Task Scheduler。
+
+### 位置
+
+- task 名稱：`\AgendTerminalDaemon`
+- XML cache：`$AGEND_HOME/service/scheduler.task.xml`
+
+### install
+
+Windows 的流程比較特別：
+
+1. render XML template。
+2. 以 UTF-16 LE + BOM 寫入 XML。
+3. 執行 `schtasks /Create /XML <path> /F`。
+
+XML 會先套用 `xml_escape`，避免 `&`、`<`、`>`、`"`、`'` 破壞結構。
+
+### status
+
+判斷邏輯是：
+
+- XML cache 不存在 → `NotInstalled`
+- `schtasks /Query /TN \AgendTerminalDaemon /FO LIST` 成功且內容含 `Running` → `Running`
+- XML 存在但查詢不是 active → `Stopped`
+
+### 注意事項
+
+- `schtasks` 失敗時，install 仍可能保留 XML，方便你檢查 render 後的內容。
+- task scheduler 的命名是固定的，不會依 instance 改名。
+- Windows 也不需要 admin，只要使用者自身可建立排程即可。
+
+## idempotency 規則
+
+| 操作 | 已存在時 | 不存在時 |
+|---|---|---|
+| `install` | 重新產生 artifact 並重註冊 | 正常安裝 |
+| `uninstall` | 刪除 artifact 並解除註冊 | no-op 成功 |
+| `status` | 回報 `running` / `stopped` | 回報 `not_installed` |
+
+這裡的 idempotency 是針對「操作結果可重跑」，不是說 platform command 一定完全安靜。
+例如 `launchctl unload`、`systemctl daemon-reload`、`schtasks /Create` 可能會輸出 warning，但功能上仍保持可重跑。
+
+## 與 daemon lifecycle 的關係
+
+`service` 只負責把 daemon 放到 OS supervisor 底下。
+真正的 daemon 邏輯仍然在 `start` / `app` / `daemon` 路徑中。
+
+換句話說：
+
+- `service install`：告訴 OS「請幫我啟動這個 binary」
+- `agend-terminal start`：真正跑 daemon
+- `service status`：看 OS 這邊是不是還握著 service 註冊
+
+這也代表如果你更新 binary，通常要重新 install 一次，
+讓 service manager 持有最新的絕對路徑與 `AGEND_HOME`。
+
+## 常見操作流程
+
+### 第一次安裝
+
+```bash
+agend-terminal service install
+agend-terminal service status
+```
+
+你通常會先確認：
+
+- artifact 已寫入
+- service manager 已接受註冊
+- status 顯示 `running` 或 `stopped`，但不是 `not_installed`
+
+### 更新 binary 後重裝
+
+```bash
+cargo build --release
+agend-terminal service install
+```
+
+這會重新 render template，帶入新的 `current_exe()` 路徑。
+
+### 解除安裝
+
+```bash
+agend-terminal service uninstall
+agend-terminal service status
+```
+
+如果你想確認真的清掉了，`status` 應該回 `not_installed`。
+
+## 失敗排查
+
+### `this platform is not supported`
+
+表示目前編譯目標沒有對應的 service manager 實作。
+確認你是在 macOS / Linux / Windows 其中之一。
+
+### `status` 回 `stopped`
+
+表示平台認得這個 service artifact，但它現在沒在跑。
+建議檢查：
+
+- binary 是否還存在
+- `AGEND_HOME` 是否正確
+- service manager log 是否有啟動失敗
+- daemon 啟動後是否立刻 panic
+
+### Windows XML 可以寫，但 task 沒出現
+
+常見原因：
+
+- `schtasks` 不可用
+- 目前使用者沒有建立排程的權限
+- XML 中有未 escape 的字元
+
+### Linux unit 寫入成功但沒有啟動
+
+常見原因：
+
+- 沒有 systemd user session bus
+- `systemctl --user` 無法在該環境運作
+- unit 內容指向了不存在的 binary
+
+### macOS plist 存在但沒有載入
+
+常見原因：
+
+- `launchctl load -w` 失敗
+- plist 路徑被移動
+- binary 已更新，但 plist 還保留舊路徑（重跑 install 即可）
+
+## 跟其他設定的關係
+
+`service` 只管 OS supervisor。
+它不負責：
+
+- fleet.yaml 的 agent 配置
+- runtime-config.json 的 runtime threshold
+- MCP JSON 的 backend 端設定
+- bugreport / capture 的診斷輸出
+
+這些是不同層次的配置。
+如果你在改完 fleet 或 runtime config 後遇到 daemon 行為異常，
+先看 `doctor`，再看 `service status`，最後再重裝 service。
+
+## 對應原始碼
+
+- `src/main.rs`：`Commands::Service` 與 CLI 文案
+- `src/service/mod.rs`：跨平台共用 helper
+- `src/service/macos.rs`：launchd 實作
+- `src/service/linux.rs`：systemd user 實作
+- `src/service/windows.rs`：Task Scheduler 實作
+- `src/daemon/restart.rs`：supervisor 偵測與重啟語意
+
+## 實務建議
+
+1. 安裝後立刻跑一次 `status`。
+2. 更新 binary 後重新 `install`，不要假設舊 artifact 會自動更新。
+3. 若你在 CI 或臨時環境測試，保留 `install` 產生的檔案比強求 service 真正啟動更有用。
+4. 若 `status` 非 `not_installed` 但 daemon 還是沒反應，先看 platform manager log，不要先懷疑 CLI。
+5. 這個功能是「外部 supervisor 入口」，不是 daemon 的自愈機制。
+


### PR DESCRIPTION
Adds three Traditional Chinese user docs for service management, diagnostics, and configuration.

Files:
- docs/FEATURE-service.md
- docs/FEATURE-diagnostics.md
- docs/FEATURE-configuration.md

Covers the actual command flows and file locations in src/service/, src/cli.rs, src/bugreport.rs, src/capture.rs, src/fleet.rs, src/runtime_config.rs, src/daemon_config.rs, and src/mcp_config.rs.