### PR TITLE
docs: add usage scenarios to feature docs

### DIFF
--- a/docs/FEATURE-channels.md
+++ b/docs/FEATURE-channels.md
@@ -2,6 +2,16 @@
 
 The Channels system lets operators talk to agents from Telegram or Discord without opening a terminal. Each agent maps to its own Telegram forum topic, and messages are mirrored bidirectionally.
 
+## Usage Scenarios
+
+> **Target audience:** Both operators and agents.
+
+An operator is away from the keyboard and wants to check whether an agent is still alive, send a quick instruction, or read the latest response without opening a terminal. Telegram becomes the control surface, and the daemon keeps the topic state in sync.
+
+An agent posts a reply after finishing a task. The reply is mirrored back into the same topic, so the operator can follow the conversation in place instead of chasing status across different tools.
+
+When the fleet grows, the one-topic-per-agent model keeps conversations isolated. That makes it practical to monitor several agents at once without mixing their context together.
+
 ## Design Goals
 
 When a team is working with multiple agents, the operator needs a communication path that is always available. Channels provides:

--- a/docs/FEATURE-channels.zh-TW.md
+++ b/docs/FEATURE-channels.zh-TW.md
@@ -2,6 +2,16 @@
 
 Channels 系統讓操作者直接在 Telegram 或 Discord 中與 agent 互動，不需要開啟終端。每個 agent 對應一個 Telegram forum topic，訊息自動雙向同步。
 
+## 使用情境
+
+> **Target audience:** Both operators and agents.
+
+操作者出門在外，想快速確認某個 agent 的狀態、送出一則指令，或直接讀到最新回覆時，Telegram 就變成主要操作面。daemon 會把 topic 狀態維持同步，不需要回到 terminal 才能做事。
+
+agent 完成工作後回覆訊息，系統會把回覆同步回同一個 topic，讓操作者可以在原本的對話脈絡裡直接追蹤進度，而不是分散在不同工具裡找訊息。
+
+當 fleet 規模變大時，每個 agent 對應一個 topic 的設計能維持對話隔離。操作者可以同時看多個 agent，但不會把不同上下文混在一起。
+
 ## 設計理念
 
 多 agent 團隊工作時，操作者需要一個隨時隨地都能觸及 agent 的管道。Channels 提供：

--- a/docs/FEATURE-configuration.md
+++ b/docs/FEATURE-configuration.md
@@ -2,6 +2,16 @@
 
 This document explains how AgEnD's configuration is layered, who writes each layer, and where you should make a change depending on the type of setting.
 
+## Usage Scenarios
+
+> **Target audience:** Operators — used through CLI or TUI.
+
+An operator is trying to understand where the current behavior comes from. `AGEND_HOME`, `.env`, `fleet.yaml`, and `runtime-config.json` each control a different layer, and this section helps explain which file should be edited for which kind of change.
+
+When an instance needs a long-term policy change, the right place is usually `fleet.yaml`. When the change is only a live tuning adjustment, `runtime-config.json` is the better fit because it reloads every daemon tick.
+
+If a backend's project-local MCP config looks wrong, the operator should treat it as a derived file rather than the source of truth. Re-running the generator is usually safer than hand-editing the backend-specific artifact.
+
 The main rule is:
 
 - **Keep one source of truth, and make derived files rebuildable.**

--- a/docs/FEATURE-configuration.zh-TW.md
+++ b/docs/FEATURE-configuration.zh-TW.md
@@ -3,6 +3,16 @@
 這份文件說明 AgEnD 的設定是怎麼分層的、誰能寫哪一層、
 以及你應該在哪裡改哪一種設定。
 
+## 使用情境
+
+> **Target audience:** Operators — used through CLI or TUI.
+
+操作者想知道目前的行為到底是從哪裡來的。`AGEND_HOME`、`.env`、`fleet.yaml` 與 `runtime-config.json` 分別控制不同層級，這個 section 的目的就是幫你判斷該改哪個檔案。
+
+當 instance 需要長期策略變更時，通常應該改 `fleet.yaml`。如果只是暫時調整 live 數值，`runtime-config.json` 更適合，因為 daemon 每個 tick 都會重新載入。
+
+如果 backend 的 project-local MCP config 看起來不對，應該把它視為派生檔，而不是主來源。通常重新產生會比手動直接改 backend artifact 更安全。
+
 核心原則只有一句：
 
 - **來源要單一，派生檔要可重建。**
@@ -431,4 +441,3 @@ service 產物不是來源檔，而是由 install 命令根據目前 binary 與 
 3. 任何會被派生的設定，都要保留原始來源。
 4. 看到疑似設定污染，先看 `bugreport`，再看派生檔是不是被重寫。
 5. 記住一句話：**主來源可編輯，派生檔可重建。**
-

--- a/docs/FEATURE-decisions.md
+++ b/docs/FEATURE-decisions.md
@@ -2,6 +2,16 @@
 
 The Decisions system records important architecture and process choices so the team can answer a simple question later: why did we choose this?
 
+## Usage Scenarios
+
+> **Target audience:** Agent infrastructure — agents use this via MCP tools; operators typically don't interact directly.
+
+A lead agent makes an architecture choice such as preferring worktrees over direct branch checkout. Recording that choice through `decision action=post` creates a durable explanation that future agents can query instead of rediscovering the same discussion.
+
+When a previous choice becomes obsolete, a new decision can supersede it with a clear replacement path. That keeps review history understandable without forcing anyone to guess which note is current.
+
+An operator or reviewer can search for decisions by tag when they need to understand why a particular gate, policy, or migration rule exists. The record becomes a shared memory layer for the fleet.
+
 ## Design Goals
 
 In a multi-agent workflow, decisions end up scattered across chat logs, PR descriptions, and commit messages. Decisions pulls them into one place and makes them queryable.

--- a/docs/FEATURE-decisions.zh-TW.md
+++ b/docs/FEATURE-decisions.zh-TW.md
@@ -2,6 +2,16 @@
 
 Decisions 系統讓團隊記錄重要的架構和流程決策，提供可查詢的決策歷史，讓任何人都能追溯「為什麼我們做了這個選擇」。
 
+## 使用情境
+
+> **Target audience:** Agent infrastructure — agents use this via MCP tools; operators typically don't interact directly.
+
+lead agent 做出一個架構選擇，例如決定用 worktree 而不是直接 checkout branch。透過 `decision action=post` 把理由記錄下來，未來其他 agent 可以直接查詢，不需要重新翻一次討論串。
+
+當舊決策已經不適用時，可以用新的決策明確 supersede 舊版本，保留歷史但讓目前的規則保持清楚。這樣大家知道哪一條是最新的，不會靠猜測。
+
+操作者或 reviewer 如果想知道某個 gate、政策或 migration 規則為什麼存在，可以依 tag 搜尋決策。這會變成 fleet 共用的記憶層。
+
 ## 設計理念
 
 多 agent 協作中，決策散落在對話、PR 描述、commit message 裡，很難回溯。Decisions 提供：

--- a/docs/FEATURE-diagnostics.md
+++ b/docs/FEATURE-diagnostics.md
@@ -2,6 +2,16 @@
 
 This document groups the operator-facing tools that help you inspect the system before you change it.
 
+## Usage Scenarios
+
+> **Target audience:** Operators — used through CLI or TUI.
+
+When an agent starts behaving oddly, the operator can run `agend-terminal doctor` to check whether the problem is in `fleet.yaml`, the backend binaries, stale helper files, or a dead agent process. The goal is to narrow the blast radius before changing anything.
+
+If Telegram topics have drifted away from the registry, `doctor topics` shows which entries are live and which are orphaned. That gives the operator a safe way to decide whether cleanup is appropriate before touching chat state.
+
+When the problem needs to be handed off, `bugreport` collects the runtime snapshot, logs, and redacted config into one file. That makes it much easier to ask another person for help without reassembling the environment by hand.
+
 The shared rule is simple:
 
 - default to read-only

--- a/docs/FEATURE-diagnostics.zh-TW.md
+++ b/docs/FEATURE-diagnostics.zh-TW.md
@@ -2,6 +2,16 @@
 
 這份文件整理所有「先觀察、再判斷、最後再修」的診斷入口。
 
+## 使用情境
+
+> **Target audience:** Operators — used through CLI or TUI.
+
+當某個 agent 行為異常時，操作者可以先跑 `agend-terminal doctor`，確認問題是在 `fleet.yaml`、backend binary、helper 檔案，還是某個 agent 的連線已經死掉。重點是在改動之前先縮小故障範圍。
+
+如果 Telegram topic 已經跟 registry 漂移，`doctor topics` 會把 live 與 orphan 的條目清楚列出來，讓操作者在動聊天室之前先做安全判斷。
+
+當問題需要交給別人接手時，`bugreport` 會把 runtime snapshot、log 與已 redaction 的設定包成單一檔案，這樣不用再手動拼湊環境資訊。
+
 它們共同的原則很簡單：
 
 - 預設不改狀態。
@@ -370,4 +380,3 @@ agend-terminal capture promote <cap> <name> --scenario-kind silent_stuck
 3. 需要貼給別人看的狀態，優先用 `bugreport`。
 4. 做 capture 時，記得確認 `AGEND_CAPTURE_FIXTURES=1`。
 5. promote 前先看 `scenario_kind`，不要用錯類型造成 manifest 語義錯位。
-

--- a/docs/FEATURE-schedules.md
+++ b/docs/FEATURE-schedules.md
@@ -2,6 +2,16 @@
 
 Schedules let you define cron jobs or one-shot jobs. Deployments let you stamp out a multi-agent team in one step. Both remove repetitive operator work.
 
+## Usage Scenarios
+
+> **Target audience:** Both operators and agents.
+
+An operator wants a daily 9:00 AM standup reminder to go out automatically to the team. A cron-based schedule handles that without requiring anyone to remember the trigger time by hand.
+
+An agent or operator wants to queue a cleanup action after a PR is merged, such as waiting 30 minutes before running a follow-up task. A one-shot schedule is a better fit because the action should happen once, not repeatedly.
+
+For repeatable team setups, a deployment can create the whole arrangement at once while schedules handle the later reminders and follow-up jobs. The two features complement each other rather than overlapping.
+
 ## Design Goals
 
 - **Schedules**: send a morning standup reminder at 9:00 every day, or check CI every hour, without relying on somebody to remember.

--- a/docs/FEATURE-schedules.zh-TW.md
+++ b/docs/FEATURE-schedules.zh-TW.md
@@ -2,6 +2,16 @@
 
 Schedules 讓你設定 cron 定時任務或一次性排程，Deployments 讓你一鍵部署多 agent 團隊。兩者都不需要手動重複操作。
 
+## 使用情境
+
+> **Target audience:** Both operators and agents.
+
+操作者希望每天早上 9 點自動送出 standup 提醒給 team，這種固定節奏的工作最適合用 cron 排程，因為不需要任何人手動記得觸發時間。
+
+agent 或操作者想在 PR merge 後 30 分鐘做一次 cleanup，這類只會發生一次的工作更適合用一次性排程，而不是重複型 cron。
+
+如果是要一次建立整套多 agent 團隊，deployment 會先把環境搭起來；之後的提醒與跟進工作則交給 schedules。兩者分工不同，但可以一起使用。
+
 ## 設計理念
 
 - **Schedules**：每天早上 9 點自動給 team 發 standup 訊息、每小時檢查 CI 狀態——不需要操作者記得做

--- a/docs/FEATURE-service.md
+++ b/docs/FEATURE-service.md
@@ -2,6 +2,16 @@
 
 This document explains how the `service` subcommand hands daemon lifecycle management to the operating system, and where each supported platform writes its service artifact.
 
+## Usage Scenarios
+
+> **Target audience:** Operators — used through CLI or TUI.
+
+An operator wants the daemon to start automatically when the machine logs in, instead of having to run `agend-terminal start` every time. `service install` turns the daemon into a managed OS service so the platform owns startup and restart behavior.
+
+After upgrading the binary, the operator wants the service manager to point at the new executable path. Re-running `service install` regenerates the artifact with the current binary path and `AGEND_HOME`.
+
+When the machine is being decommissioned or the service is no longer needed, `service uninstall` removes the registration cleanly and leaves the platform in a known state.
+
 ## What this feature solves
 
 `agend-terminal` can run in the foreground, background, TUI, or daemon mode, but if you want it to start automatically after login and come back up after a crash, you need more than a manual command.

--- a/docs/FEATURE-service.zh-TW.md
+++ b/docs/FEATURE-service.zh-TW.md
@@ -3,6 +3,16 @@
 這份文件說明 `service` 子命令如何把 daemon 交給作業系統管理，
 以及三個平台各自的落點與限制。
 
+## 使用情境
+
+> **Target audience:** Operators — used through CLI or TUI.
+
+操作者希望機器登入後 daemon 自動啟動，而不是每次都手動跑 `agend-terminal start`。`service install` 會把 daemon 交給作業系統管理，讓平台負責開機登入時的啟動與 crash 後重拉。
+
+在 binary 升級之後，操作者希望 service manager 指向新的可執行檔路徑。重新執行 `service install` 就會重新產生 artifact，帶入最新的 binary path 與 `AGEND_HOME`。
+
+當機器要退役，或不再需要這個 daemon 時，`service uninstall` 可以乾淨地解除註冊，讓平台回到可預期的狀態。
+
 ## 這個功能解決什麼問題
 
 `agend-terminal` 本身可以在前景、背景、TUI 或 daemon 模式運作，
@@ -299,4 +309,3 @@ agend-terminal service status
 3. 若你在 CI 或臨時環境測試，保留 `install` 產生的檔案比強求 service 真正啟動更有用。
 4. 若 `status` 非 `not_installed` 但 daemon 還是沒反應，先看 platform manager log，不要先懷疑 CLI。
 5. 這個功能是「外部 supervisor 入口」，不是 daemon 的自愈機制。
-


### PR DESCRIPTION
Adds a Usage Scenarios / 使用情境 section to the six FEATURE docs and keeps the bilingual pair structure intact.

Files updated:
- docs/FEATURE-channels.md
- docs/FEATURE-channels.zh-TW.md
- docs/FEATURE-decisions.md
- docs/FEATURE-decisions.zh-TW.md
- docs/FEATURE-schedules.md
- docs/FEATURE-schedules.zh-TW.md
- docs/FEATURE-service.md
- docs/FEATURE-service.zh-TW.md
- docs/FEATURE-diagnostics.md
- docs/FEATURE-diagnostics.zh-TW.md
- docs/FEATURE-configuration.md
- docs/FEATURE-configuration.zh-TW.md