### PR TITLE
docs: add Usage Scenarios to batch B feature docs (#1195)

### DIFF
--- a/docs/FEATURE-ci-watch.md
+++ b/docs/FEATURE-ci-watch.md
@@ -1,5 +1,15 @@
 # CI Watch — Automated PR CI Monitoring
 
+## Usage Scenarios
+
+> **Target audience:** Agent infrastructure — agents use this via MCP tools; operators typically don't interact directly.
+
+**Automatic CI-to-reviewer handoff.** A dev agent finishes implementation and creates a PR. The daemon automatically attaches a CI watch to the PR's branch. When all GitHub Actions checks pass, the daemon sends a `[ci-pass]` notification to the reviewer agent, who begins the code review immediately — no human intervention required.
+
+**Selective workflow monitoring.** A repository has multiple CI workflows, but only "build" and "test" are required for merge. The dev specifies `required_checks: ["build", "test"]` when the watch is created, so a flaky "windows-compat" workflow does not block the reviewer handoff.
+
+**Conflict early warning.** While monitoring CI, the daemon also checks the PR's mergeable status. If upstream changes cause a merge conflict, a `[ci-conflict-detected]` notification is sent to the dev agent immediately, allowing it to rebase before the reviewer wastes time on a conflicted branch.
+
 ## Design Rationale
 
 In a multi-agent workflow, after a dev agent pushes a PR it typically needs to

--- a/docs/FEATURE-ci-watch.zh-TW.md
+++ b/docs/FEATURE-ci-watch.zh-TW.md
@@ -1,5 +1,15 @@
 # CI Watch — 自動監控 PR 的 CI 狀態
 
+## 使用情境
+
+> **適用對象：** Agent 基礎設施——agent 透過 MCP tools 使用，operator 通常不直接操作。
+
+**自動 CI 到 reviewer 的交接。** Dev agent 完成實作並建立 PR。Daemon 自動在該 PR 的分支上掛載 CI watch。當所有 GitHub Actions check 通過後，daemon 向 reviewer agent 發送 `[ci-pass]` 通知，reviewer 立即開始 code review——完全不需要人工介入。
+
+**選擇性 workflow 監控。** 一個 repo 有多個 CI workflow，但只有 "build" 和 "test" 是合併的必要條件。Dev 在建立 watch 時指定 `required_checks: ["build", "test"]`，這樣不穩定的 "windows-compat" workflow 不會阻擋 reviewer 的交接。
+
+**衝突早期預警。** 在監控 CI 的同時，daemon 也會檢查 PR 的 mergeable 狀態。如果上游變更導致合併衝突，daemon 會立即向 dev agent 發送 `[ci-conflict-detected]` 通知，讓 dev 可以在 reviewer 浪費時間審查衝突分支之前先完成 rebase。
+
 ## 設計初衷
 
 在多 agent 協作的工作流中，dev agent push 完 PR 之後，通常需要等 CI 跑完

--- a/docs/FEATURE-dispatch-idle.md
+++ b/docs/FEATURE-dispatch-idle.md
@@ -1,5 +1,15 @@
 # Dispatch Idle Tracking — Task Response Timeout Monitoring
 
+## Usage Scenarios
+
+> **Target audience:** Agent infrastructure — agents use this via MCP tools; operators typically don't interact directly.
+
+**Dropped task detection.** A lead agent dispatches a task to a dev agent with `expect_reply_within_secs=600`. The dev agent crashes before processing the message. After 10 minutes of silence, the daemon sends a `dispatch_idle_threshold_exceeded` notification to the lead, alerting it that the task may have been missed. The lead can then re-dispatch to another agent or investigate.
+
+**Active work acknowledgment.** A dev agent receives a complex task and starts working on it. Partway through, it sends a `kind=update` message to report progress. The daemon sees this activity and resets the idle timer, preventing a false alarm while the dev is clearly engaged.
+
+**Fixup team nudge.** In the fixup team, after the L1 notification goes to the lead, the L2 layer sends an additional `dispatch_idle_nudge` directly to the target dev agent. This two-pronged approach ensures both the dispatcher and the recipient are aware of the stalled task.
+
 ## Design Rationale
 
 In multi-agent collaboration, an orchestrator (typically the lead) dispatches

--- a/docs/FEATURE-dispatch-idle.zh-TW.md
+++ b/docs/FEATURE-dispatch-idle.zh-TW.md
@@ -1,5 +1,15 @@
 # Dispatch Idle Tracking — 任務回應超時追蹤
 
+## 使用情境
+
+> **適用對象：** Agent 基礎設施——agent 透過 MCP tools 使用，operator 通常不直接操作。
+
+**遺漏任務偵測。** Lead agent 以 `expect_reply_within_secs=600` 向 dev agent 分派一項任務。Dev agent 在處理訊息前 crash 了。沉默 10 分鐘後，daemon 向 lead 發送 `dispatch_idle_threshold_exceeded` 通知，提醒任務可能被遺漏。Lead 可以重新分派給其他 agent 或進行調查。
+
+**活躍工作確認。** Dev agent 收到一項複雜任務並開始處理。工作過程中，它發送一條 `kind=update` 訊息回報進度。Daemon 看到這個活動後重設閒置計時器，避免在 dev 明顯在工作時觸發誤報。
+
+**Fixup 團隊提醒。** 在 fixup 團隊中，L1 通知送到 lead 之後，L2 層會額外向目標 dev agent 直接發送 `dispatch_idle_nudge`。這種雙管齊下的方式確保分派者和接收者都知道任務停滯了。
+
 ## 設計初衷
 
 在多 agent 協作中，orchestrator（通常是 lead）會分派任務給 dev 或 reviewer。

--- a/docs/FEATURE-health.md
+++ b/docs/FEATURE-health.md
@@ -1,5 +1,15 @@
 # Health & Monitoring — Agent Health State and Auto-Recovery
 
+## Usage Scenarios
+
+> **Target audience:** Daemon infrastructure — fully automated, operators observe via TUI.
+
+**Automatic crash recovery.** A dev agent's process crashes due to an unexpected API error. The daemon detects the exit, records it in the crash sliding window, waits for an exponential backoff delay (starting at 5 seconds), and restarts the agent automatically. If the agent stabilizes, it resumes work as if nothing happened. If it crashes repeatedly (5+ times), the daemon stops restarting and notifies the operator.
+
+**Hang detection and recovery.** An agent receives a task but produces no PTY output for over 600 seconds while in `Thinking` state. The daemon classifies it as `Hung` and initiates the three-stage recovery ladder: first sending an ESC key to interrupt, then restarting the process if ESC fails, and finally pausing the agent and alerting the operator if restarts are also ineffective.
+
+**Operator health dashboard.** The operator checks the TUI and sees that one agent is in `Unstable` state (3 crashes in 10 minutes) while another shows `IdleLong` (no pending work, just waiting). The structured health state lets the operator quickly distinguish between agents that need attention and those that are simply idle.
+
 ## Design Rationale
 
 AI coding agents encounter various anomalies: process crashes, API rate limits,

--- a/docs/FEATURE-health.zh-TW.md
+++ b/docs/FEATURE-health.zh-TW.md
@@ -1,5 +1,15 @@
 # Health & Monitoring — Agent 健康狀態與自動恢復
 
+## 使用情境
+
+> **適用對象：** Daemon 基礎設施——全自動運作，operator 透過 TUI 觀察。
+
+**自動 crash 恢復。** Dev agent 的程序因為意外的 API 錯誤而 crash。Daemon 偵測到程序結束，將 crash 記錄在滑動窗口中，等待指數退避延遲（從 5 秒開始），然後自動重啟 agent。如果 agent 穩定下來，它會像什麼都沒發生一樣繼續工作。如果連續 crash（5 次以上），daemon 停止重啟並通知 operator。
+
+**Hang 偵測與恢復。** Agent 收到任務但在 `Thinking` 狀態下超過 600 秒沒有 PTY 輸出。Daemon 將其分類為 `Hung`，啟動三階段恢復階梯：先發送 ESC 鍵嘗試中斷，若 ESC 無效則重啟程序，若重啟也無效則暫停 agent 並通知 operator 手動介入。
+
+**Operator 健康儀表板。** Operator 查看 TUI，發現一個 agent 處於 `Unstable` 狀態（10 分鐘內 3 次 crash），另一個顯示 `IdleLong`（沒有待處理工作，只是在等待）。結構化的健康狀態讓 operator 能快速區分需要關注的 agent 和只是閒置的 agent。
+
 ## 設計初衷
 
 AI coding agent 會遇到各種異常：程序 crash、API rate limit、回應超時

--- a/docs/FEATURE-task-board.md
+++ b/docs/FEATURE-task-board.md
@@ -6,6 +6,16 @@ current state is reconstructed by replaying (folding) those events. This gives
 the board a complete audit trail, makes state reproducible, and provides the
 foundation for sweep, health, and dependency evaluation.
 
+## Usage Scenarios
+
+> **Target audience:** Agent infrastructure — agents use this via MCP tools; operators typically don't interact directly.
+
+**Task dispatch and tracking.** A lead agent creates a task on the board with a title, priority, and assignee, then dispatches it to a dev agent. The dev receives the task in its inbox, claims it via `task action=claim`, and begins work. As the dev progresses, it updates the task status to `in_progress`. When the work is complete, the dev marks it `done` with a result summary. The entire lifecycle is recorded as append-only events in `task_events.jsonl`.
+
+**Cross-agent visibility.** A reviewer agent checks the task board to see which tasks are marked `done` and ready for verification. After reviewing the associated PR, the reviewer marks the task as `verified`. Meanwhile, the operator can observe the full board state at any time through the TUI without needing to query individual agents.
+
+**Board hygiene.** Over time, tasks accumulate — some with owners who no longer exist in the fleet (ghost owners), others with expired deadlines. The operator runs `task action=health` to get a snapshot of board health, then uses `task action=sweep` in dry-run mode to identify candidates for cleanup before applying changes.
+
 ## 1. Design Rationale
 
 - The task board is a single source of truth shared by every agent.

--- a/docs/FEATURE-task-board.zh-TW.md
+++ b/docs/FEATURE-task-board.zh-TW.md
@@ -3,6 +3,16 @@
 這份文件說明共享任務板的設計目的、資料流、MCP 使用方式、以及
 哪些行為是有保證的，哪些只是 best-effort。
 
+## 使用情境
+
+> **適用對象：** Agent 基礎設施——agent 透過 MCP tools 使用，operator 通常不直接操作。
+
+**任務分派與追蹤。** Lead agent 在任務板上建立一個任務，填入標題、優先級和指派對象，然後分派給 dev agent。Dev 在 inbox 中收到任務後，透過 `task action=claim` 認領並開始工作。工作過程中，dev 將任務狀態更新為 `in_progress`。完成後，dev 以 `done` 標記任務並附上結果摘要。整個生命週期以 append-only 事件記錄在 `task_events.jsonl` 中。
+
+**跨 agent 可見性。** Reviewer agent 查看任務板，找出已標記 `done` 且待驗證的任務。完成 PR 審查後，reviewer 將任務標記為 `verified`。同時，operator 可以隨時透過 TUI 觀察完整的任務板狀態，無需逐一查詢各個 agent。
+
+**任務板衛生。** 隨著時間推移，任務會堆積——有些 owner 已不在 fleet 中（ghost owners），有些截止日期已過。Operator 執行 `task action=health` 取得任務板健康快照，再使用 `task action=sweep` 的 dry-run 模式找出清理候選項，確認後才實際執行。
+
 ## 1. 設計初衷
 
 - Task board 是整個 fleet 共用的工作清單。

--- a/docs/FEATURE-teams.md
+++ b/docs/FEATURE-teams.md
@@ -4,6 +4,16 @@ Teams group agents into named units for structured collaboration. Each team has
 members, an optional (but strongly recommended) orchestrator, and is stored as
 part of `fleet.yaml` — not as a separate data source.
 
+## Usage Scenarios
+
+> **Target audience:** Both operators and agents.
+
+**Team setup by operator.** An operator defines a new team in `fleet.yaml` or via the `team action=create` MCP tool — for example, creating a "fixup" team with a lead, dev, and reviewer, designating the lead as orchestrator. This structures how tasks are routed and who coordinates the group's work.
+
+**Agent-to-team broadcast.** A lead agent needs to inform every member of its team about a status change. Instead of sending individual messages, it uses `send team=fixup` to broadcast to all members at once. The daemon resolves the team membership and delivers the message to each member's inbox.
+
+**Orchestrator-based task routing.** When a task is assigned to a team name rather than a specific agent, the task board routes it to the team's orchestrator via `resolve_team_orchestrator`. If the orchestrator has been removed and the team is degraded, routing fails — prompting the operator to designate a new orchestrator.
+
 ## 1. Design Rationale
 
 - A team is a named group of agents with a designated orchestrator.

--- a/docs/FEATURE-teams.zh-TW.md
+++ b/docs/FEATURE-teams.zh-TW.md
@@ -3,6 +3,16 @@
 這份文件說明 team 的設計、如何建立/更新/刪除 team、以及它和
 `send team=...` 廣播路徑之間的關係。
 
+## 使用情境
+
+> **適用對象：** Operator 與 agent 皆適用。
+
+**Operator 建立團隊。** Operator 在 `fleet.yaml` 中或透過 `team action=create` MCP 工具定義新團隊——例如建立一個包含 lead、dev、reviewer 的 "fixup" 團隊，並指定 lead 為 orchestrator。這決定了任務的路由方式以及由誰協調團隊工作。
+
+**Agent 團隊廣播。** Lead agent 需要通知團隊中的每個成員某項狀態變更。它不需要逐一發送訊息，而是使用 `send team=fixup` 一次廣播給所有成員。Daemon 會解析團隊成員名單，將訊息送到每個成員的 inbox。
+
+**基於 orchestrator 的任務路由。** 當任務指派給團隊名稱而非特定 agent 時，任務板會透過 `resolve_team_orchestrator` 將任務路由到該團隊的 orchestrator。如果 orchestrator 已被移除且團隊處於 degraded 狀態，路由會失敗——提醒 operator 需要指定新的 orchestrator。
+
 ## 1. 設計初衷
 
 - Team 是把 agents 組織成群組的方法。

--- a/docs/FEATURE-worktree.md
+++ b/docs/FEATURE-worktree.md
@@ -5,6 +5,16 @@ collection, as well as the division of responsibility among `bind_self`,
 `release_worktree`, `force_release_worktree`, `repo action=checkout`, and
 `repo action=release`.
 
+## Usage Scenarios
+
+> **Target audience:** Agent infrastructure — fully managed by the daemon; agents work in worktrees transparently without needing to manage them directly.
+
+**Automatic workspace isolation.** When a lead dispatches a task with a branch name to a dev agent, the daemon provisions a dedicated git worktree for that agent at `~/.agend/worktrees/<agent>/<branch>/`. The dev works in this isolated directory, making commits and pushing without risk of conflicting with other agents working on different branches in the same repository.
+
+**Mid-lifecycle recovery.** An agent's worktree binding becomes stale after a crash or daemon restart. The agent uses `bind_self` to re-establish its binding to the existing worktree, optionally with `rebase_mode=true` to rebase onto the latest upstream changes before resuming work.
+
+**Controlled cleanup.** After a task is completed and the PR is merged, the daemon soft-releases the worktree (marking it with `released_at`). The worktree remains on disk for a 24-hour grace period. If no one reclaims it, GC (`gc_cutover` with `AGEND_WORKTREE_GC=1`) removes it automatically. For stuck or orphaned worktrees, the operator can use `force_release_worktree` as an emergency measure.
+
 ## 1. Design Rationale
 
 - Each agent works in its own isolated workspace to avoid branch conflicts and shared-checkout contention.

--- a/docs/FEATURE-worktree.zh-TW.md
+++ b/docs/FEATURE-worktree.zh-TW.md
@@ -4,6 +4,16 @@
 `bind_self` / `release_worktree` / `force_release_worktree` /
 `repo action=checkout` / `repo action=release` 之間的分工。
 
+## 使用情境
+
+> **適用對象：** Agent 基礎設施——由 daemon 全自動管理，agent 透明地在 worktree 中工作，不需要直接管理。
+
+**自動工作空間隔離。** 當 lead 將帶有分支名稱的任務分派給 dev agent 時，daemon 會在 `~/.agend/worktrees/<agent>/<branch>/` 為該 agent 建立專用的 git worktree。Dev 在這個隔離目錄中工作、提交和推送，不會與同一 repo 中工作於不同分支的其他 agent 產生衝突。
+
+**中途恢復。** Agent 的 worktree binding 在 crash 或 daemon 重啟後可能變得過時。Agent 使用 `bind_self` 重新建立與現有 worktree 的綁定，可選擇以 `rebase_mode=true` 先 rebase 到最新的上游變更再繼續工作。
+
+**可控的清理。** 任務完成且 PR 合併後，daemon 對 worktree 執行 soft release（標記 `released_at`）。Worktree 會在磁碟上保留 24 小時寬限期。如果沒有人重新認領，GC（設定 `AGEND_WORKTREE_GC=1` 後執行 `gc_cutover`）會自動移除。對於卡住或孤立的 worktree，operator 可以使用 `force_release_worktree` 作為緊急手段。
+
 ## 1. 設計初衷
 
 - 每個 agent 應該在自己的工作空間工作。


### PR DESCRIPTION
## Summary
- Add a **Usage Scenarios** / **使用情境** section to 6 feature docs (12 files total: .md + .zh-TW.md)
- Each section includes a target audience blockquote and 2-3 concrete scenario descriptions
- Part of #1195 documentation improvement effort

## Files Changed
| Feature | English | Chinese |
|---------|---------|---------|
| Task Board | `FEATURE-task-board.md` | `FEATURE-task-board.zh-TW.md` |
| Teams | `FEATURE-teams.md` | `FEATURE-teams.zh-TW.md` |
| Worktree | `FEATURE-worktree.md` | `FEATURE-worktree.zh-TW.md` |
| CI Watch | `FEATURE-ci-watch.md` | `FEATURE-ci-watch.zh-TW.md` |
| Health | `FEATURE-health.md` | `FEATURE-health.zh-TW.md` |
| Dispatch Idle | `FEATURE-dispatch-idle.md` | `FEATURE-dispatch-idle.zh-TW.md` |

## Target Audience Tags
- **Agent infrastructure**: task-board, ci-watch, dispatch-idle
- **Daemon infrastructure**: health
- **Both operators and agents**: teams
- **Agent infrastructure (daemon-managed)**: worktree

## Test plan
- [x] 12 files modified with usage scenario sections
- [x] Each section placed between title and Design Rationale
- [x] English and Chinese versions consistent in structure
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)