### PR TITLE
fix(tui): wire t/f/s/m keybinds in fleet view overlay

### DIFF
--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -808,6 +808,19 @@ pub(super) fn handle_key(
                         KeyCode::Char('?') => {
                             *mode = TaskBoardMode::Help;
                         }
+                        // #1202: t/f/s/m switch between views within the overlay
+                        KeyCode::Char('t') => {
+                            *view = BoardView::Tasks;
+                        }
+                        KeyCode::Char('f') | KeyCode::Char('F') => {
+                            *view = BoardView::Fleet;
+                        }
+                        KeyCode::Char('s') => {
+                            *view = BoardView::Status;
+                        }
+                        KeyCode::Char('m') | KeyCode::Char('M') => {
+                            *view = BoardView::Monitor;
+                        }
                         KeyCode::Esc | KeyCode::Char('q') => {
                             *overlay = Overlay::None;
                         }


### PR DESCRIPTION
Closes #1202

## Problem
When the Tasks/Fleet overlay is open, pressing t/f/s/m does nothing — keys are caught by the `_ => {}` catch-all in `TaskBoardMode::Board` match.

## Fix
Add handlers for t/f/s/m within the Board mode to switch between views (Tasks/Fleet/Status/Monitor).

Closes t-20260525073449235450-20