### PR TITLE
fix(tui): add clear visual indicator for active board view tab

### DIFF
--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -134,10 +134,10 @@ pub fn render_tasks(
     use crate::app::{BoardView, TaskBoardMode};
     let count = items.len();
     let view_tabs = match view {
-        BoardView::Tasks => "[t] tasks  [f] fleet  [s] status  [m] monitor",
-        BoardView::Fleet => " [t] tasks [f] fleet  [s] status  [m] monitor",
-        BoardView::Status => " [t] tasks  [f] fleet [s] status  [m] monitor",
-        BoardView::Monitor => " [t] tasks  [f] fleet  [s] status [m] monitor",
+        BoardView::Tasks => "[T] TASKS | [f] fleet | [s] status | [m] monitor",
+        BoardView::Fleet => "[t] tasks | [F] FLEET | [s] status | [m] monitor",
+        BoardView::Status => "[t] tasks | [f] fleet | [S] STATUS | [m] monitor",
+        BoardView::Monitor => "[t] tasks | [f] fleet | [s] status | [M] MONITOR",
     };
     let title = format!(" Board ({count}) | {view_tabs} | Tab switch | q close ");
     let inner = render_overlay_frame(frame, Color::Blue, &title);


### PR DESCRIPTION
Closes #1203

## Problem
Active tab in the fleet/tasks overlay used a subtle space-shifting trick that was barely visible.

## Fix
Active view tab shows uppercase key + UPPERCASE name for clear visual distinction:
```
[T] TASKS | [f] fleet | [s] status | [m] monitor
```

Closes t-20260525075406027802-22