### PR TITLE
docs: fix workflow diagram LR→TD for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Dashed boxes (- - -) are agent infrastructure — used by agents via MCP tools.
 Solid boxes are operator-facing.
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph S1[" 1 · Setup "]
         qs["Quick Start"]
         fl["Fleet Config"]

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -44,7 +44,7 @@ Crash 後自動重啟並移交上下文。透過多 tab / 多 pane 的 TUI、Tel
 實線框為 operator 面向功能。
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph S1[" 1 · 環境設定 "]
         qs["快速開始"]
         fl["Fleet 設定"]


### PR DESCRIPTION
## Summary
- Change Mermaid `flowchart LR` to `flowchart TD` in both README.md and README.zh-TW.md
- The horizontal layout compressed all 5 stages into one row, making labels unreadable on GitHub
- Vertical (top-down) layout gives each stage more horizontal space

## Test plan
- [ ] Verify Mermaid renders readable on GitHub (both files)
- [ ] Verify stages flow top-to-bottom with arrows S1→S2→S3→S4→S5

🤖 Generated with [Claude Code](https://claude.com/claude-code)