### PR TITLE
feat(task): allow description update after creation

### DIFF
--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -305,6 +305,12 @@ pub enum TaskEvent {
         by: InstanceName,
         priority: String,
     },
+    /// Description update after creation.
+    DescriptionUpdated {
+        task_id: TaskId,
+        by: InstanceName,
+        description: String,
+    },
 }
 
 /// Per-task confidence breakdown produced by the legacy-backfill sweep.
@@ -340,7 +346,8 @@ impl TaskEvent {
             | TaskEvent::Released { task_id, .. }
             | TaskEvent::TaskCloseProposed { task_id, .. }
             | TaskEvent::OwnerAssigned { task_id, .. }
-            | TaskEvent::PriorityChanged { task_id, .. } => task_id,
+            | TaskEvent::PriorityChanged { task_id, .. }
+            | TaskEvent::DescriptionUpdated { task_id, .. } => task_id,
         }
     }
 
@@ -360,6 +367,7 @@ impl TaskEvent {
             TaskEvent::TaskCloseProposed { .. } => "task_close_proposed",
             TaskEvent::OwnerAssigned { .. } => "owner_assigned",
             TaskEvent::PriorityChanged { .. } => "priority_changed",
+            TaskEvent::DescriptionUpdated { .. } => "description_updated",
         }
     }
 }
@@ -656,6 +664,12 @@ impl TaskBoardState {
             TaskEvent::PriorityChanged { priority, .. } => {
                 if let Some(t) = self.tasks.get_mut(&task_id) {
                     t.priority = priority.clone();
+                    t.updated_at = touch_at;
+                }
+            }
+            TaskEvent::DescriptionUpdated { description, .. } => {
+                if let Some(t) = self.tasks.get_mut(&task_id) {
+                    t.description = description.clone();
                     t.updated_at = touch_at;
                 }
             }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -527,6 +527,14 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                     priority: p.to_string(),
                 });
             }
+            // Description update.
+            if let Some(desc) = args["description"].as_str() {
+                pending_events.push(crate::task_events::TaskEvent::DescriptionUpdated {
+                    task_id: crate::task_events::TaskId(id.clone()),
+                    by: crate::task_events::InstanceName::from(caller.as_str()),
+                    description: desc.to_string(),
+                });
+            }
             // Assignee change without status transition: queue
             // OwnerAssigned. Distinct from Claimed (status stays put).
             if let Some(ref new_owner) = new_assignee {
@@ -781,5 +789,10 @@ fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String
         TaskEvent::PriorityChanged { priority, .. } => {
             ("priority_changed", actor, format!("priority → {priority}"))
         }
+        TaskEvent::DescriptionUpdated { .. } => (
+            "description_updated",
+            actor,
+            "description updated".to_string(),
+        ),
     }
 }


### PR DESCRIPTION
Closes the task description append requirement.

## Summary
Adds `task action=update id=X description="new text"` to update task description after creation.

## Changes
- `src/task_events.rs`: Added `DescriptionUpdated` event variant + replay apply logic
- `src/tasks/handler.rs`: Handle `description` field in update action + activity timeline summarize

All 76 task tests pass.

Closes t-20260525094706721543-25