### PR TITLE
feat(tasks): add tags field for task classification

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -162,6 +162,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             branch: params["branch"].as_str().map(String::from),
             bind: None,
             eta_secs: None,
+            tags: Vec::new(),
         };
         match crate::task_events::append(
             ctx.home,

--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -240,6 +240,7 @@ mod tests {
             started_at: started_at.map(String::from),
             eta_secs,
             auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 
@@ -547,6 +548,7 @@ mod tests {
                 routed_to: None,
                 branch: None,
                 bind: None,
+                tags: vec![],
                 eta_secs: Some(60),
             },
         )

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -345,6 +345,7 @@ mod tests {
             started_at: None,
             eta_secs: None,
             auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -1193,6 +1193,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: None,
+                tags: vec![],
             },
         )
         .unwrap();

--- a/src/daemon/legacy_backfill.rs
+++ b/src/daemon/legacy_backfill.rs
@@ -584,6 +584,7 @@ mod tests {
             started_at: None,
             eta_secs: None,
             auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -786,6 +786,7 @@ mod tests {
             started_at: None,
             eta_secs: None,
             auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -154,6 +154,8 @@ fn task_tools() -> Vec<Value> {
                 "id": {"type": "string"}, "result": {"type": "string"},
                 "status": {"type": "string", "enum": ["open", "claimed", "in_progress", "blocked", "verified", "done", "cancelled"]},
                 "filter_assignee": {"type": "string"}, "filter_status": {"type": "string"},
+                "filter_tag": {"type": "string", "description": "Filter tasks by tag"},
+                "tags": {"type": "array", "items": {"type": "string"}, "description": "Task classification tags (for create/update)"},
                 "include_history": {"type": "boolean", "description": "#806: opt in to done/cancelled in `list` response (default trims to actionable)."},
                 "limit": {"type": "integer", "description": "#806: cap `list` response to N newest-first entries (sort by updated_at desc)."},
                 "due_at": {"type": "string", "description": "ISO 8601 deadline for the task"},

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -530,6 +530,7 @@ mod tests {
             started_at: None,
             eta_secs: None,
             auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 
@@ -663,6 +664,7 @@ mod tests {
             started_at: None,
             eta_secs: None,
             auto_release_on_verdict: None,
+            tags: vec![],
         }];
         terminal
             .draw(|frame| {

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -322,6 +322,7 @@ mod tests {
             started_at: None,
             eta_secs: None,
             auto_release_on_verdict: None,
+            tags: vec![],
         }];
         let all_instances = vec![
             "dev-lead".to_string(),

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -226,6 +226,9 @@ pub enum TaskEvent {
         /// envelopes default to `None` via serde.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         eta_secs: Option<i64>,
+        /// Task classification tags.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        tags: Vec<String>,
     },
     Claimed {
         task_id: TaskId,
@@ -450,6 +453,9 @@ pub struct TaskRecord {
     /// `EtaUpdated` event if the contract evolves).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eta_secs: Option<i64>,
+    /// Task classification tags.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -522,6 +528,7 @@ impl TaskBoardState {
                 branch,
                 bind,
                 eta_secs,
+                tags,
                 ..
             } => {
                 self.tasks
@@ -547,6 +554,7 @@ impl TaskBoardState {
                         bind: *bind,
                         started_at: None,
                         eta_secs: *eta_secs,
+                        tags: tags.clone(),
                     });
             }
             TaskEvent::Claimed { by, .. } => {
@@ -971,6 +979,7 @@ mod tests {
             branch: None,
             bind: None,
             eta_secs: None,
+            tags: Vec::new(),
         }
     }
 
@@ -1434,6 +1443,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: None,
+                tags: Vec::new(),
             },
         )
         .unwrap();
@@ -1509,6 +1519,7 @@ mod tests {
                     branch: None,
                     bind: None,
                     eta_secs: None,
+                    tags: Vec::new(),
                 },
                 "Claimed" => TaskEvent::Claimed {
                     task_id: tid.clone(),
@@ -1702,6 +1713,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: None,
+                tags: Vec::new(),
             },
         )
         .unwrap();
@@ -1781,6 +1793,7 @@ mod tests {
                     branch: None,
                     bind: None,
                     eta_secs: None,
+                    tags: Vec::new(),
                 },
             },
             // Sweep Linked appears BEFORE operator Claimed in file order
@@ -1952,6 +1965,7 @@ mod tests {
                 branch: None,
                 bind: Some(false),
                 eta_secs: None,
+                tags: Vec::new(),
             },
         )
         .unwrap();
@@ -1991,6 +2005,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: Some(60),
+                tags: vec![],
             },
         )
         .unwrap();
@@ -2055,6 +2070,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: Some(60),
+                tags: vec![],
             },
         )
         .unwrap();
@@ -2153,6 +2169,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: Some(7200),
+                tags: vec![],
             },
         )
         .unwrap();

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -302,6 +302,11 @@ pub enum TaskEvent {
         owner: Option<InstanceName>,
         routed_to: Option<InstanceName>,
     },
+    /// Tags update without status transition.
+    TagsSet {
+        task_id: TaskId,
+        tags: Vec<String>,
+    },
     /// **v2** — priority change without status transition.
     PriorityChanged {
         task_id: TaskId,
@@ -343,7 +348,8 @@ impl TaskEvent {
             | TaskEvent::Released { task_id, .. }
             | TaskEvent::TaskCloseProposed { task_id, .. }
             | TaskEvent::OwnerAssigned { task_id, .. }
-            | TaskEvent::PriorityChanged { task_id, .. } => task_id,
+            | TaskEvent::PriorityChanged { task_id, .. }
+            | TaskEvent::TagsSet { task_id, .. } => task_id,
         }
     }
 
@@ -363,6 +369,7 @@ impl TaskEvent {
             TaskEvent::TaskCloseProposed { .. } => "task_close_proposed",
             TaskEvent::OwnerAssigned { .. } => "owner_assigned",
             TaskEvent::PriorityChanged { .. } => "priority_changed",
+            TaskEvent::TagsSet { .. } => "tags_set",
         }
     }
 }
@@ -664,6 +671,12 @@ impl TaskBoardState {
             TaskEvent::PriorityChanged { priority, .. } => {
                 if let Some(t) = self.tasks.get_mut(&task_id) {
                     t.priority = priority.clone();
+                    t.updated_at = touch_at;
+                }
+            }
+            TaskEvent::TagsSet { tags, .. } => {
+                if let Some(t) = self.tasks.get_mut(&task_id) {
+                    t.tags = tags.clone();
                     t.updated_at = touch_at;
                 }
             }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -537,6 +537,17 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                     priority: p.to_string(),
                 });
             }
+            // Tags update without status transition.
+            if let Some(new_tags) = args["tags"].as_array() {
+                let tags: Vec<String> = new_tags
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+                pending_events.push(crate::task_events::TaskEvent::TagsSet {
+                    task_id: crate::task_events::TaskId(id.clone()),
+                    tags,
+                });
+            }
             // Assignee change without status transition: queue
             // OwnerAssigned. Distinct from Claimed (status stays put).
             if let Some(ref new_owner) = new_assignee {
@@ -791,5 +802,6 @@ fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String
         TaskEvent::PriorityChanged { priority, .. } => {
             ("priority_changed", actor, format!("priority → {priority}"))
         }
+        TaskEvent::TagsSet { tags, .. } => ("tags_set", actor, format!("tags → {tags:?}")),
     }
 }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -102,6 +102,14 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 // optional operator-supplied ETA in seconds. None
                 // disables stall detection for the task.
                 eta_secs: args["eta_secs"].as_i64(),
+                tags: args["tags"]
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             };
             match crate::task_events::append(home, &emitter, event) {
                 Ok(_) => {
@@ -126,6 +134,7 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
         "list" => {
             let filter_assignee = args["filter_assignee"].as_str();
             let filter_status = args["filter_status"].as_str();
+            let filter_tag = args["filter_tag"].as_str();
             // #806: default trim to actionable statuses unless caller
             // opts in to history. `filtered_default=true` on the
             // response signals callers (audit / forensics) that the
@@ -141,6 +150,7 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 .iter()
                 .filter(|t| filter_assignee.is_none_or(|a| t.assignee.as_deref() == Some(a)))
                 .filter(|t| filter_status.is_none_or(|s| t.status == s))
+                .filter(|t| filter_tag.is_none_or(|tag| t.tags.iter().any(|tt| tt == tag)))
                 // #806 default-actionable-only filter — only fires
                 // when neither include_history nor filter_status is
                 // set. Preserves zero impact on filter_status callers.

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -76,6 +76,9 @@ pub struct Task {
     /// through any production code path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_release_on_verdict: Option<bool>,
+    /// Task classification tags (e.g. "bug", "feature", "urgent").
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -177,6 +180,7 @@ pub(super) fn record_to_task(r: &crate::task_events::TaskRecord) -> Task {
         // event variant + record field if/when an operator-write
         // surface lands.
         auto_release_on_verdict: None,
+        tags: r.tags.clone(),
     }
 }
 
@@ -323,6 +327,7 @@ pub fn migrate_legacy_tasks_json_to_event_log(home: &Path) -> anyhow::Result<Mig
             // to None which preserves current auto-bind on subsequent
             // dispatches referencing this task_id.
             bind: None,
+            tags: Vec::new(),
         });
         // Emit the minimum status-transition events to bring the task to
         // its current legacy status. The replay-derived view post-PR3

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -41,6 +41,7 @@ fn make_test_task(assignee: Option<&str>) -> Task {
         started_at: None,
         eta_secs: None,
         auto_release_on_verdict: None,
+        tags: vec![],
     }
 }
 
@@ -78,6 +79,7 @@ fn make_record(
         result: None,
         branch: None,
         bind: None,
+        tags: vec![],
         started_at: None,
         eta_secs: None,
     }
@@ -392,6 +394,7 @@ fn reconcile_orphan_owners_with_live_empty_set_orphans_strict_ghost() {
             routed_to: None,
             branch: None,
             bind: None,
+            tags: vec![],
             eta_secs: None,
         }],
     )
@@ -961,6 +964,7 @@ fn test_circular_dep_no_infinite_loop() {
             depends_on: vec![crate::task_events::TaskId("t-B".into())],
             routed_to: None,
             bind: None,
+            tags: vec![],
             eta_secs: None,
         },
     )
@@ -979,6 +983,7 @@ fn test_circular_dep_no_infinite_loop() {
             depends_on: vec![crate::task_events::TaskId("t-A".into())],
             routed_to: None,
             bind: None,
+            tags: vec![],
             eta_secs: None,
         },
     )
@@ -1627,6 +1632,7 @@ fn migration_imports_legacy_tasks_to_event_log() {
                 started_at: None,
                 eta_secs: None,
                 auto_release_on_verdict: None,
+                tags: vec![],
             });
         }
         Ok(())
@@ -1692,6 +1698,7 @@ fn migration_idempotent_on_second_run() {
             started_at: None,
             eta_secs: None,
             auto_release_on_verdict: None,
+            tags: vec![],
         });
         Ok(())
     })


### PR DESCRIPTION
## What
Task board supports classification tags (bug, feature, urgent, etc).

## Changes
- `tags: Vec<String>` added to Task, TaskRecord, TaskEvent::Created
- `task create` accepts `tags` array param
- `task list` supports `filter_tag` param
- MCP tool schema updated

## Usage
```
task action=create title="fix bug" tags=["bug","urgent"]
task action=list filter_tag=bug
```