### PR TITLE
docs: redesign workflow diagram as real pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,57 +42,43 @@ multi-pane TUI, a Telegram channel, or an optional system tray.
 
 ## Development Workflow
 
-How the features fit together across the multi-agent development lifecycle.
-Dashed boxes (- - -) are agent infrastructure — used by agents via MCP tools.
-Solid boxes are operator-facing.
+How a task flows through the multi-agent pipeline. Each step shows which feature is active.
 
 ```mermaid
 flowchart TD
-    subgraph S1[" 1 · Setup "]
-        qs["Quick Start"]
-        fl["Fleet Config"]
-        tm["Teams"]
-        cfg["Configuration"]
-        svc["Service"]
-    end
+    A["👤 Operator writes fleet.yaml"] --> B["⚙️ Daemon launches agents"]
 
-    subgraph S2[" 2 · Dispatch "]
-        tb["Task Board"]
-        send["Communication · send"]:::infra
-        idle["Dispatch Idle"]:::infra
-        sk["Skills"]
-    end
+    B --> C["👤 Operator assigns task via TUI / Telegram"]
+    C --> D["🤖 Lead creates task on Task Board"]
+    D --> E["🤖 Lead sends task to Dev"]
 
-    subgraph S3[" 3 · Development "]
-        wt["Worktree"]:::infra
-        ai["Agent Interaction"]
-        tui["TUI"]
-        ch["Channels"]
-    end
+    E --> F["🤖 Dev binds git Worktree"]
+    F --> G["🤖 Dev codes — Skills load behavior templates"]
+    G --> H["🤖 Dev pushes PR + reports to Lead"]
 
-    subgraph S4[" 4 · Integration "]
-        ci["CI Watch"]:::infra
-        rpt["Communication · report"]:::infra
-        dec["Decisions"]:::infra
-        done["Task Board ✓"]
-    end
+    H --> I["⚙️ CI Watch monitors GitHub Actions"]
+    I --> J["⚙️ CI passes → auto-notify Reviewer"]
+    J --> K["🤖 Reviewer reviews code"]
+    K --> L["🤖 Lead merges PR → Task done"]
 
-    subgraph S5[" 5 · Operations "]
-        hm["Health & Monitoring"]:::infra
-        dg["Diagnostics"]
-        sch["Schedules"]:::infra
-    end
+    L --> |"next task"| D
 
-    S1 --> S2 --> S3 --> S4 --> S5
+    E -. "⏱️ Dispatch Idle: alert if no response in 10min" .-> C
+    B -. "🏥 Health: auto-restart on crash/hang" .-> B
+    K -. "📝 Decisions: record architectural choices" .-> K
 
-    classDef infra fill:#e3f2fd,stroke:#1565c0,stroke-dasharray:5 5
+    classDef operator fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    classDef agent fill:#e3f2fd,stroke:#1565c0,color:#0d47a1
+    classDef daemon fill:#fff3e0,stroke:#e65100,color:#bf360c
 
-    style S1 fill:#e8f5e9,stroke:#2e7d32
-    style S2 fill:#fff3e0,stroke:#e65100
-    style S3 fill:#f3e5f5,stroke:#6a1b9a
-    style S4 fill:#e0f7fa,stroke:#00838f
-    style S5 fill:#fce4ec,stroke:#c62828
+    class A,C operator
+    class D,E,F,G,H,K,L agent
+    class B,I,J daemon
 ```
+
+Legend: 🟢 Green = Operator action · 🔵 Blue = Agent behavior (via MCP tools) · 🟠 Orange = Daemon automation
+
+> **Always running in background:** Health & Monitoring (auto-restart), Channels (Telegram sync), Schedules (cron jobs), Diagnostics (troubleshooting)
 
 ## Quick Start
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -39,57 +39,43 @@ Crash 後自動重啟並移交上下文。透過多 tab / 多 pane 的 TUI、Tel
 
 ## 開發流程
 
-各功能在多 agent 開發生命週期中的定位。
-虛線框（- - -）為 agent 基礎設施——agent 透過 MCP 工具使用。
-實線框為 operator 面向功能。
+一個任務如何流經多 agent pipeline。每一步標示當下運作的功能。
 
 ```mermaid
 flowchart TD
-    subgraph S1[" 1 · 環境設定 "]
-        qs["快速開始"]
-        fl["Fleet 設定"]
-        tm["團隊"]
-        cfg["設定"]
-        svc["服務管理"]
-    end
+    A["👤 操作者撰寫 fleet.yaml"] --> B["⚙️ Daemon 啟動 agents"]
 
-    subgraph S2[" 2 · 任務分派 "]
-        tb["任務看板"]
-        send["通訊 · send"]:::infra
-        idle["Dispatch Idle"]:::infra
-        sk["Skills 技能"]
-    end
+    B --> C["👤 操作者透過 TUI / Telegram 指派任務"]
+    C --> D["🤖 Lead 在任務看板建立任務"]
+    D --> E["🤖 Lead 分派任務給 Dev"]
 
-    subgraph S3[" 3 · 開發執行 "]
-        wt["Worktree"]:::infra
-        ai["Agent 互動"]
-        tui["TUI"]
-        ch["頻道"]
-    end
+    E --> F["🤖 Dev 綁定 git Worktree"]
+    F --> G["🤖 Dev 開發 — Skills 載入行為模板"]
+    G --> H["🤖 Dev 推送 PR + 回報 Lead"]
 
-    subgraph S4[" 4 · 整合驗證 "]
-        ci["CI 監控"]:::infra
-        rpt["通訊 · report"]:::infra
-        dec["決策記錄"]:::infra
-        done["任務看板 ✓"]
-    end
+    H --> I["⚙️ CI Watch 監控 GitHub Actions"]
+    I --> J["⚙️ CI 通過 → 自動通知 Reviewer"]
+    J --> K["🤖 Reviewer 審查程式碼"]
+    K --> L["🤖 Lead 合併 PR → 任務完成"]
 
-    subgraph S5[" 5 · 維運 "]
-        hm["健康與監控"]:::infra
-        dg["診斷工具"]
-        sch["排程"]:::infra
-    end
+    L --> |"下一個任務"| D
 
-    S1 --> S2 --> S3 --> S4 --> S5
+    E -. "⏱️ Dispatch Idle：10 分鐘未回應則警報" .-> C
+    B -. "🏥 Health：crash/hang 時自動重啟" .-> B
+    K -. "📝 Decisions：記錄架構決策" .-> K
 
-    classDef infra fill:#e3f2fd,stroke:#1565c0,stroke-dasharray:5 5
+    classDef operator fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    classDef agent fill:#e3f2fd,stroke:#1565c0,color:#0d47a1
+    classDef daemon fill:#fff3e0,stroke:#e65100,color:#bf360c
 
-    style S1 fill:#e8f5e9,stroke:#2e7d32
-    style S2 fill:#fff3e0,stroke:#e65100
-    style S3 fill:#f3e5f5,stroke:#6a1b9a
-    style S4 fill:#e0f7fa,stroke:#00838f
-    style S5 fill:#fce4ec,stroke:#c62828
+    class A,C operator
+    class D,E,F,G,H,K,L agent
+    class B,I,J daemon
 ```
+
+圖例：🟢 綠色 = 操作者操作 · 🔵 藍色 = Agent 行為 · 🟠 橙色 = Daemon 自動化
+
+> **背景常駐服務：** Health & Monitoring（自動重啟）、Channels（Telegram 同步）、Schedules（定時任務）、Diagnostics（故障排除）
 
 ## 快速開始
 


### PR DESCRIPTION
## Summary
- Replace the categorized-box diagram with a **real development pipeline** showing actual task flow
- Steps: fleet.yaml → daemon launch → task assign → dev codes → CI → review → merge → loop
- Three color-coded node types: 🟢 Operator (green), 🔵 Agent (blue), 🟠 Daemon (orange)
- Dotted edges for background processes: Dispatch Idle alerts, Health auto-restart, Decision recording
- Legend and "always running" footnote below the diagram
- Both README.md (English) and README.zh-TW.md (Chinese) updated

## Supersedes
- Replaces the category-box diagram from PR #1215 / #1219

## Test plan
- [ ] Verify Mermaid renders correctly on GitHub (both files)
- [ ] Verify the "next task" loop arrow connects back to task creation
- [ ] Verify dotted edges for background processes render as dashed lines
- [ ] Verify three color classes are visually distinguishable

🤖 Generated with [Claude Code](https://claude.com/claude-code)