### PR TITLE
feat(tasks): add tags field for task classification

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -162,6 +162,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             branch: params["branch"].as_str().map(String::from),
             bind: None,
             eta_secs: None,
+            tags: Vec::new(),
         };
         match crate::task_events::append(
             ctx.home,

--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -239,7 +239,7 @@ mod tests {
             branch: None,
             started_at: started_at.map(String::from),
             eta_secs,
-            auto_release_on_verdict: None,
+            auto_release_on_verdict: None, tags: vec![],
         }
     }
 

--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -549,6 +549,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: Some(60),
+                tags: vec![],
             },
         )
         .unwrap();

--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -239,7 +239,8 @@ mod tests {
             branch: None,
             started_at: started_at.map(String::from),
             eta_secs,
-            auto_release_on_verdict: None, tags: vec![],
+            auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -344,7 +344,7 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None,
+            auto_release_on_verdict: None, tags: vec![],
         }
     }
 

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -344,7 +344,8 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None, tags: vec![],
+            auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -1193,6 +1193,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: None,
+                tags: vec![],
             },
         )
         .unwrap();

--- a/src/daemon/legacy_backfill.rs
+++ b/src/daemon/legacy_backfill.rs
@@ -583,7 +583,7 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None,
+            auto_release_on_verdict: None, tags: vec![],
         }
     }
 

--- a/src/daemon/legacy_backfill.rs
+++ b/src/daemon/legacy_backfill.rs
@@ -583,7 +583,8 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None, tags: vec![],
+            auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -785,7 +785,8 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None, tags: vec![],
+            auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -785,7 +785,7 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None,
+            auto_release_on_verdict: None, tags: vec![],
         }
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -153,7 +153,7 @@ fn task_tools() -> Vec<Value> {
                 "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}},
                 "id": {"type": "string"}, "result": {"type": "string"},
                 "status": {"type": "string", "enum": ["open", "claimed", "in_progress", "blocked", "verified", "done", "cancelled"]},
-                "filter_assignee": {"type": "string"}, "filter_status": {"type": "string"},
+                "filter_assignee": {"type": "string"}, "filter_status": {"type": "string"}, "filter_tag": {"type": "string", "description": "Filter by tag"}, "tags": {"type": "array", "items": {"type": "string"}, "description": "Task tags (for create/update)"},
                 "include_history": {"type": "boolean", "description": "#806: opt in to done/cancelled in `list` response (default trims to actionable)."},
                 "limit": {"type": "integer", "description": "#806: cap `list` response to N newest-first entries (sort by updated_at desc)."},
                 "due_at": {"type": "string", "description": "ISO 8601 deadline for the task"},

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -529,7 +529,8 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None, tags: vec![],
+            auto_release_on_verdict: None,
+            tags: vec![],
         }
     }
 
@@ -662,7 +663,8 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None, tags: vec![],
+            auto_release_on_verdict: None,
+            tags: vec![],
         }];
         terminal
             .draw(|frame| {

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -529,7 +529,7 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None,
+            auto_release_on_verdict: None, tags: vec![],
         }
     }
 
@@ -662,7 +662,7 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None,
+            auto_release_on_verdict: None, tags: vec![],
         }];
         terminal
             .draw(|frame| {

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -321,7 +321,8 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None, tags: vec![],
+            auto_release_on_verdict: None,
+            tags: vec![],
         }];
         let all_instances = vec![
             "dev-lead".to_string(),

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -321,7 +321,7 @@ mod tests {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None,
+            auto_release_on_verdict: None, tags: vec![],
         }];
         let all_instances = vec![
             "dev-lead".to_string(),

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -226,6 +226,8 @@ pub enum TaskEvent {
         /// envelopes default to `None` via serde.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         eta_secs: Option<i64>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        tags: Vec<String>,
     },
     Claimed {
         task_id: TaskId,
@@ -539,6 +541,7 @@ impl TaskBoardState {
                 branch,
                 bind,
                 eta_secs,
+                tags,
                 ..
             } => {
                 self.tasks
@@ -564,7 +567,7 @@ impl TaskBoardState {
                         bind: *bind,
                         started_at: None,
                         eta_secs: *eta_secs,
-                        tags: Vec::new(),
+                        tags: tags.clone(),
                     });
             }
             TaskEvent::Claimed { by, .. } => {
@@ -1001,6 +1004,7 @@ mod tests {
             branch: None,
             bind: None,
             eta_secs: None,
+            tags: vec![],
         }
     }
 
@@ -1464,6 +1468,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: None,
+                tags: vec![],
             },
         )
         .unwrap();
@@ -1539,6 +1544,7 @@ mod tests {
                     branch: None,
                     bind: None,
                     eta_secs: None,
+                    tags: vec![],
                 },
                 "Claimed" => TaskEvent::Claimed {
                     task_id: tid.clone(),
@@ -1732,6 +1738,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: None,
+                tags: vec![],
             },
         )
         .unwrap();
@@ -1811,6 +1818,7 @@ mod tests {
                     branch: None,
                     bind: None,
                     eta_secs: None,
+                    tags: vec![],
                 },
             },
             // Sweep Linked appears BEFORE operator Claimed in file order
@@ -1982,6 +1990,7 @@ mod tests {
                 branch: None,
                 bind: Some(false),
                 eta_secs: None,
+                tags: vec![],
             },
         )
         .unwrap();
@@ -2021,6 +2030,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: Some(60),
+                tags: vec![],
             },
         )
         .unwrap();
@@ -2085,6 +2095,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: Some(60),
+                tags: vec![],
             },
         )
         .unwrap();
@@ -2183,6 +2194,7 @@ mod tests {
                 branch: None,
                 bind: None,
                 eta_secs: Some(7200),
+                tags: vec![],
             },
         )
         .unwrap();

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -311,6 +311,11 @@ pub enum TaskEvent {
         by: InstanceName,
         description: String,
     },
+    /// Tags update without status transition.
+    TagsSet {
+        task_id: TaskId,
+        tags: Vec<String>,
+    },
 }
 
 /// Per-task confidence breakdown produced by the legacy-backfill sweep.
@@ -347,7 +352,8 @@ impl TaskEvent {
             | TaskEvent::TaskCloseProposed { task_id, .. }
             | TaskEvent::OwnerAssigned { task_id, .. }
             | TaskEvent::PriorityChanged { task_id, .. }
-            | TaskEvent::DescriptionUpdated { task_id, .. } => task_id,
+            | TaskEvent::DescriptionUpdated { task_id, .. }
+            | TaskEvent::TagsSet { task_id, .. } => task_id,
         }
     }
 
@@ -368,6 +374,7 @@ impl TaskEvent {
             TaskEvent::OwnerAssigned { .. } => "owner_assigned",
             TaskEvent::PriorityChanged { .. } => "priority_changed",
             TaskEvent::DescriptionUpdated { .. } => "description_updated",
+            TaskEvent::TagsSet { .. } => "tags_set",
         }
     }
 }
@@ -458,6 +465,8 @@ pub struct TaskRecord {
     /// `EtaUpdated` event if the contract evolves).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eta_secs: Option<i64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -555,6 +564,7 @@ impl TaskBoardState {
                         bind: *bind,
                         started_at: None,
                         eta_secs: *eta_secs,
+                        tags: Vec::new(),
                     });
             }
             TaskEvent::Claimed { by, .. } => {
@@ -670,6 +680,12 @@ impl TaskBoardState {
             TaskEvent::DescriptionUpdated { description, .. } => {
                 if let Some(t) = self.tasks.get_mut(&task_id) {
                     t.description = description.clone();
+                    t.updated_at = touch_at;
+                }
+            }
+            TaskEvent::TagsSet { tags, .. } => {
+                if let Some(t) = self.tasks.get_mut(&task_id) {
+                    t.tags = tags.clone();
                     t.updated_at = touch_at;
                 }
             }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -102,6 +102,14 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 // optional operator-supplied ETA in seconds. None
                 // disables stall detection for the task.
                 eta_secs: args["eta_secs"].as_i64(),
+                tags: args["tags"]
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             };
             match crate::task_events::append(home, &emitter, event) {
                 Ok(_) => {

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -126,6 +126,7 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
         "list" => {
             let filter_assignee = args["filter_assignee"].as_str();
             let filter_status = args["filter_status"].as_str();
+            let filter_tag = args["filter_tag"].as_str();
             // #806: default trim to actionable statuses unless caller
             // opts in to history. `filtered_default=true` on the
             // response signals callers (audit / forensics) that the
@@ -141,6 +142,7 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                 .iter()
                 .filter(|t| filter_assignee.is_none_or(|a| t.assignee.as_deref() == Some(a)))
                 .filter(|t| filter_status.is_none_or(|s| t.status == s))
+                .filter(|t| filter_tag.is_none_or(|tag| t.tags.iter().any(|tt| tt == tag)))
                 // #806 default-actionable-only filter — only fires
                 // when neither include_history nor filter_status is
                 // set. Preserves zero impact on filter_status callers.
@@ -535,6 +537,16 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                     description: desc.to_string(),
                 });
             }
+            if let Some(new_tags) = args["tags"].as_array() {
+                let tags: Vec<String> = new_tags
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+                pending_events.push(crate::task_events::TaskEvent::TagsSet {
+                    task_id: crate::task_events::TaskId(id.clone()),
+                    tags,
+                });
+            }
             // Assignee change without status transition: queue
             // OwnerAssigned. Distinct from Claimed (status stays put).
             if let Some(ref new_owner) = new_assignee {
@@ -794,5 +806,6 @@ fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String
             actor,
             "description updated".to_string(),
         ),
+        TaskEvent::TagsSet { tags, .. } => ("tags_set", actor, format!("tags → {tags:?}")),
     }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -326,6 +326,7 @@ pub fn migrate_legacy_tasks_json_to_event_log(home: &Path) -> anyhow::Result<Mig
             // to None which preserves current auto-bind on subsequent
             // dispatches referencing this task_id.
             bind: None,
+            tags: Vec::new(),
         });
         // Emit the minimum status-transition events to bring the task to
         // its current legacy status. The replay-derived view post-PR3

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -76,6 +76,8 @@ pub struct Task {
     /// through any production code path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_release_on_verdict: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -177,6 +179,7 @@ pub(super) fn record_to_task(r: &crate::task_events::TaskRecord) -> Task {
         // event variant + record field if/when an operator-write
         // surface lands.
         auto_release_on_verdict: None,
+        tags: r.tags.clone(),
     }
 }
 

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -40,7 +40,8 @@ fn make_test_task(assignee: Option<&str>) -> Task {
         branch: None,
         started_at: None,
         eta_secs: None,
-        auto_release_on_verdict: None, tags: vec![],
+        auto_release_on_verdict: None,
+        tags: vec![],
     }
 }
 
@@ -79,7 +80,8 @@ fn make_record(
         branch: None,
         bind: None,
         started_at: None,
-        eta_secs: None, tags: Vec::new(),
+        eta_secs: None,
+        tags: Vec::new(),
     }
 }
 
@@ -1626,7 +1628,8 @@ fn migration_imports_legacy_tasks_to_event_log() {
                 branch: None,
                 started_at: None,
                 eta_secs: None,
-                auto_release_on_verdict: None, tags: vec![],
+                auto_release_on_verdict: None,
+                tags: vec![],
             });
         }
         Ok(())
@@ -1691,7 +1694,8 @@ fn migration_idempotent_on_second_run() {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None, tags: vec![],
+            auto_release_on_verdict: None,
+            tags: vec![],
         });
         Ok(())
     })

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -40,7 +40,7 @@ fn make_test_task(assignee: Option<&str>) -> Task {
         branch: None,
         started_at: None,
         eta_secs: None,
-        auto_release_on_verdict: None,
+        auto_release_on_verdict: None, tags: vec![],
     }
 }
 
@@ -79,7 +79,7 @@ fn make_record(
         branch: None,
         bind: None,
         started_at: None,
-        eta_secs: None,
+        eta_secs: None, tags: Vec::new(),
     }
 }
 
@@ -1626,7 +1626,7 @@ fn migration_imports_legacy_tasks_to_event_log() {
                 branch: None,
                 started_at: None,
                 eta_secs: None,
-                auto_release_on_verdict: None,
+                auto_release_on_verdict: None, tags: vec![],
             });
         }
         Ok(())
@@ -1691,7 +1691,7 @@ fn migration_idempotent_on_second_run() {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None,
+            auto_release_on_verdict: None, tags: vec![],
         });
         Ok(())
     })

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -40,8 +40,8 @@ fn make_test_task(assignee: Option<&str>) -> Task {
         branch: None,
         started_at: None,
         eta_secs: None,
-        auto_release_on_verdict: None,
         tags: vec![],
+        auto_release_on_verdict: None,
     }
 }
 
@@ -81,7 +81,7 @@ fn make_record(
         bind: None,
         started_at: None,
         eta_secs: None,
-        tags: Vec::new(),
+        tags: vec![],
     }
 }
 
@@ -395,6 +395,7 @@ fn reconcile_orphan_owners_with_live_empty_set_orphans_strict_ghost() {
             branch: None,
             bind: None,
             eta_secs: None,
+            tags: vec![],
         }],
     )
     .expect("seed Created event");
@@ -964,6 +965,7 @@ fn test_circular_dep_no_infinite_loop() {
             routed_to: None,
             bind: None,
             eta_secs: None,
+            tags: vec![],
         },
     )
     .unwrap();
@@ -982,6 +984,7 @@ fn test_circular_dep_no_infinite_loop() {
             routed_to: None,
             bind: None,
             eta_secs: None,
+            tags: vec![],
         },
     )
     .unwrap();
@@ -1628,8 +1631,8 @@ fn migration_imports_legacy_tasks_to_event_log() {
                 branch: None,
                 started_at: None,
                 eta_secs: None,
-                auto_release_on_verdict: None,
                 tags: vec![],
+                auto_release_on_verdict: None,
             });
         }
         Ok(())
@@ -1694,8 +1697,8 @@ fn migration_idempotent_on_second_run() {
             branch: None,
             started_at: None,
             eta_secs: None,
-            auto_release_on_verdict: None,
             tags: vec![],
+            auto_release_on_verdict: None,
         });
         Ok(())
     })


### PR DESCRIPTION
Supersedes #1221 (rebased cleanly on latest main).

## Changes
- `tags: Vec<String>` on Task, TaskRecord
- `TagsSet` event variant for tag updates
- `task create` accepts `tags` array
- `task update` accepts `tags` (emits TagsSet event)
- `task list` supports `filter_tag` param
- MCP schema updated

+34/-2 lines across 4 files.