### PR TITLE
docs: remove workflow diagram from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,60 +40,6 @@ multi-pane TUI, a Telegram channel, or an optional system tray.
 | Multi-agent comms | Custom IPC | Built-in MCP tools |
 | Git isolation | Manual worktrees | Auto per-agent worktree |
 
-## Development Workflow
-
-How the features fit together across the multi-agent development lifecycle.
-Dashed boxes (- - -) are agent infrastructure — used by agents via MCP tools.
-Solid boxes are operator-facing.
-
-```mermaid
-flowchart TD
-    subgraph S1[" 1 · Setup "]
-        qs["Quick Start"]
-        fl["Fleet Config"]
-        tm["Teams"]
-        cfg["Configuration"]
-        svc["Service"]
-    end
-
-    subgraph S2[" 2 · Dispatch "]
-        tb["Task Board"]
-        send["Communication · send"]:::infra
-        idle["Dispatch Idle"]:::infra
-        sk["Skills"]
-    end
-
-    subgraph S3[" 3 · Development "]
-        wt["Worktree"]:::infra
-        ai["Agent Interaction"]
-        tui["TUI"]
-        ch["Channels"]
-    end
-
-    subgraph S4[" 4 · Integration "]
-        ci["CI Watch"]:::infra
-        rpt["Communication · report"]:::infra
-        dec["Decisions"]:::infra
-        done["Task Board ✓"]
-    end
-
-    subgraph S5[" 5 · Operations "]
-        hm["Health & Monitoring"]:::infra
-        dg["Diagnostics"]
-        sch["Schedules"]:::infra
-    end
-
-    S1 --> S2 --> S3 --> S4 --> S5
-
-    classDef infra fill:#e3f2fd,stroke:#1565c0,stroke-dasharray:5 5
-
-    style S1 fill:#e8f5e9,stroke:#2e7d32
-    style S2 fill:#fff3e0,stroke:#e65100
-    style S3 fill:#f3e5f5,stroke:#6a1b9a
-    style S4 fill:#e0f7fa,stroke:#00838f
-    style S5 fill:#fce4ec,stroke:#c62828
-```
-
 ## Quick Start
 
 ```bash

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -37,60 +37,6 @@ Crash 後自動重啟並移交上下文。透過多 tab / 多 pane 的 TUI、Tel
 | 多 Agent 通訊 | 自訂 IPC | 內建 MCP 工具 |
 | Git 隔離 | 手動 worktree | 自動 per-agent worktree |
 
-## 開發流程
-
-各功能在多 agent 開發生命週期中的定位。
-虛線框（- - -）為 agent 基礎設施——agent 透過 MCP 工具使用。
-實線框為 operator 面向功能。
-
-```mermaid
-flowchart TD
-    subgraph S1[" 1 · 環境設定 "]
-        qs["快速開始"]
-        fl["Fleet 設定"]
-        tm["團隊"]
-        cfg["設定"]
-        svc["服務管理"]
-    end
-
-    subgraph S2[" 2 · 任務分派 "]
-        tb["任務看板"]
-        send["通訊 · send"]:::infra
-        idle["Dispatch Idle"]:::infra
-        sk["Skills 技能"]
-    end
-
-    subgraph S3[" 3 · 開發執行 "]
-        wt["Worktree"]:::infra
-        ai["Agent 互動"]
-        tui["TUI"]
-        ch["頻道"]
-    end
-
-    subgraph S4[" 4 · 整合驗證 "]
-        ci["CI 監控"]:::infra
-        rpt["通訊 · report"]:::infra
-        dec["決策記錄"]:::infra
-        done["任務看板 ✓"]
-    end
-
-    subgraph S5[" 5 · 維運 "]
-        hm["健康與監控"]:::infra
-        dg["診斷工具"]
-        sch["排程"]:::infra
-    end
-
-    S1 --> S2 --> S3 --> S4 --> S5
-
-    classDef infra fill:#e3f2fd,stroke:#1565c0,stroke-dasharray:5 5
-
-    style S1 fill:#e8f5e9,stroke:#2e7d32
-    style S2 fill:#fff3e0,stroke:#e65100
-    style S3 fill:#f3e5f5,stroke:#6a1b9a
-    style S4 fill:#e0f7fa,stroke:#00838f
-    style S5 fill:#fce4ec,stroke:#c62828
-```
-
 ## 快速開始
 
 ```bash


### PR DESCRIPTION
## Summary
- Remove the "Development Workflow" / "開發流程" Mermaid diagram section from both `README.md` and `README.zh-TW.md`
- The Feature Guides section in "Learn More" already provides adequate navigation to all features
- `docs/diagrams/` directory does not exist on main (SVG pre-render PR was closed without merging)

## Test plan
- [ ] Verify both READMEs render correctly without the diagram section
- [ ] Confirm no broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)