### PR TITLE
fix(skills): handle broken symlinks and Claude overwrite (#1229)

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -473,7 +473,11 @@ fn install_one(source: &Path, target: &Path, backend: &str) -> InstallOutcome {
     // Pre-existing non-managed directory: don't overwrite operator's
     // hand-crafted skills dir. Symlinks + previously-managed copies
     // are safe to replace.
-    if target.exists() {
+    //
+    // #1229 Bug 2: use symlink_metadata to detect broken symlinks
+    // (target.exists() follows symlinks and returns false for dangling).
+    let entry_exists = target.symlink_metadata().is_ok();
+    if entry_exists {
         let is_symlink = target
             .symlink_metadata()
             .map(|m| m.file_type().is_symlink())


### PR DESCRIPTION
Closes #1229

## Bug 1: Claude binary overwrites symlink
Claude replaces `.claude/skills` symlink with a real directory. On restart, `install_one` skipped re-creation (no marker). Fix: detect replaced symlinks by checking for SKILL.md content in subdirs, then reclaim.

## Bug 2: Broken symlink EEXIST
`target.exists()` returns false for dangling symlinks → removal skipped → `try_symlink` fails EEXIST. Fix: use `symlink_metadata().is_ok()` for entry detection.

## Testing
All 26 skills tests pass. Operator hand-crafted dirs still preserved (test verified).