### PR TITLE
feat(task): add parent_id tree structure to task board

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -163,6 +163,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             bind: None,
             eta_secs: None,
             tags: Vec::new(),
+            parent_id: None,
         };
         match crate::task_events::append(
             ctx.home,

--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -241,6 +241,7 @@ mod tests {
             eta_secs,
             auto_release_on_verdict: None,
             tags: vec![],
+            parent_id: None,
         }
     }
 
@@ -550,6 +551,7 @@ mod tests {
                 bind: None,
                 eta_secs: Some(60),
                 tags: vec![],
+                parent_id: None,
             },
         )
         .unwrap();

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -346,6 +346,7 @@ mod tests {
             eta_secs: None,
             auto_release_on_verdict: None,
             tags: vec![],
+            parent_id: None,
         }
     }
 

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -1194,6 +1194,7 @@ mod tests {
                 bind: None,
                 eta_secs: None,
                 tags: vec![],
+                parent_id: None,
             },
         )
         .unwrap();

--- a/src/daemon/legacy_backfill.rs
+++ b/src/daemon/legacy_backfill.rs
@@ -585,6 +585,7 @@ mod tests {
             eta_secs: None,
             auto_release_on_verdict: None,
             tags: vec![],
+            parent_id: None,
         }
     }
 

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -787,6 +787,7 @@ mod tests {
             eta_secs: None,
             auto_release_on_verdict: None,
             tags: vec![],
+            parent_id: None,
         }
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -151,7 +151,7 @@ fn task_tools() -> Vec<Value> {
                 "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health", "activity"]},
                 "title": {"type": "string"}, "description": {"type": "string"},
                 "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
-                "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}},
+                "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}}, "parent_id": {"type": "string", "description": "Parent task ID for subtask composition (A is composed of B,C,D). Complementary to depends_on (execution order)."},
                 "id": {"type": "string"}, "result": {"type": "string"},
                 "status": {"type": "string", "enum": ["open", "claimed", "in_progress", "blocked", "verified", "done", "cancelled"]},
                 "filter_assignee": {"type": "string"}, "filter_status": {"type": "string"}, "filter_tag": {"type": "string", "description": "Filter by tag"}, "tags": {"type": "array", "items": {"type": "string"}, "description": "Task tags (for create/update)"},

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -531,6 +531,7 @@ mod tests {
             eta_secs: None,
             auto_release_on_verdict: None,
             tags: vec![],
+            parent_id: None,
         }
     }
 
@@ -665,6 +666,7 @@ mod tests {
             eta_secs: None,
             auto_release_on_verdict: None,
             tags: vec![],
+            parent_id: None,
         }];
         terminal
             .draw(|frame| {

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -323,6 +323,7 @@ mod tests {
             eta_secs: None,
             auto_release_on_verdict: None,
             tags: vec![],
+            parent_id: None,
         }];
         let all_instances = vec![
             "dev-lead".to_string(),

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -233,6 +233,8 @@ pub enum TaskEvent {
         eta_secs: Option<i64>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         tags: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_id: Option<TaskId>,
     },
     Claimed {
         task_id: TaskId,
@@ -474,6 +476,8 @@ pub struct TaskRecord {
     pub eta_secs: Option<i64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<TaskId>,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -547,6 +551,7 @@ impl TaskBoardState {
                 bind,
                 eta_secs,
                 tags,
+                parent_id,
                 ..
             } => {
                 self.tasks
@@ -573,6 +578,7 @@ impl TaskBoardState {
                         started_at: None,
                         eta_secs: *eta_secs,
                         tags: tags.clone(),
+                        parent_id: parent_id.clone(),
                     });
             }
             TaskEvent::Claimed { by, .. } => {
@@ -617,7 +623,20 @@ impl TaskBoardState {
             TaskEvent::Cancelled { .. } => {
                 if let Some(t) = self.tasks.get_mut(&task_id) {
                     t.status = TaskStatus::Cancelled;
-                    t.updated_at = touch_at;
+                    t.updated_at = touch_at.clone();
+                }
+                let children: Vec<TaskId> = self
+                    .tasks
+                    .iter()
+                    .filter(|(_, t)| t.parent_id.as_ref() == Some(&task_id))
+                    .filter(|(_, t)| matches!(t.status, TaskStatus::Open | TaskStatus::Claimed))
+                    .map(|(id, _)| id.clone())
+                    .collect();
+                for child_id in children {
+                    if let Some(child) = self.tasks.get_mut(&child_id) {
+                        child.status = TaskStatus::Cancelled;
+                        child.updated_at = touch_at.clone();
+                    }
                 }
             }
             TaskEvent::Linked { pr_id, .. } => {
@@ -1010,6 +1029,7 @@ mod tests {
             bind: None,
             eta_secs: None,
             tags: vec![],
+            parent_id: None,
         }
     }
 
@@ -1474,6 +1494,7 @@ mod tests {
                 bind: None,
                 eta_secs: None,
                 tags: vec![],
+                parent_id: None,
             },
         )
         .unwrap();
@@ -1550,6 +1571,7 @@ mod tests {
                     bind: None,
                     eta_secs: None,
                     tags: vec![],
+                    parent_id: None,
                 },
                 "Claimed" => TaskEvent::Claimed {
                     task_id: tid.clone(),
@@ -1744,6 +1766,7 @@ mod tests {
                 bind: None,
                 eta_secs: None,
                 tags: vec![],
+                parent_id: None,
             },
         )
         .unwrap();
@@ -1824,6 +1847,7 @@ mod tests {
                     bind: None,
                     eta_secs: None,
                     tags: vec![],
+                    parent_id: None,
                 },
             },
             // Sweep Linked appears BEFORE operator Claimed in file order
@@ -1996,6 +2020,7 @@ mod tests {
                 bind: Some(false),
                 eta_secs: None,
                 tags: vec![],
+                parent_id: None,
             },
         )
         .unwrap();
@@ -2036,6 +2061,7 @@ mod tests {
                 bind: None,
                 eta_secs: Some(60),
                 tags: vec![],
+                parent_id: None,
             },
         )
         .unwrap();
@@ -2101,6 +2127,7 @@ mod tests {
                 bind: None,
                 eta_secs: Some(60),
                 tags: vec![],
+                parent_id: None,
             },
         )
         .unwrap();
@@ -2200,6 +2227,7 @@ mod tests {
                 bind: None,
                 eta_secs: Some(7200),
                 tags: vec![],
+                parent_id: None,
             },
         )
         .unwrap();
@@ -2274,6 +2302,306 @@ mod tests {
         let state = replay(&home).unwrap();
         assert!(state.tasks.contains_key(&TaskId::from("t-pre-compact")));
         assert!(state.tasks.contains_key(&TaskId::from("t-post-compact")));
+        fs::remove_dir_all(&home).ok();
+    }
+
+    // ── parent_id tree structure tests ──────────────────────────────
+
+    #[test]
+    fn parent_id_round_trips_through_replay() {
+        let home = tmp_home("parent-rt");
+        let inst = InstanceName::from("dev");
+        append(
+            &home,
+            &inst,
+            TaskEvent::Created {
+                task_id: TaskId::from("t-parent"),
+                title: "parent".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+        )
+        .unwrap();
+        append(
+            &home,
+            &inst,
+            TaskEvent::Created {
+                task_id: TaskId::from("t-child"),
+                title: "child".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: Some(TaskId::from("t-parent")),
+            },
+        )
+        .unwrap();
+        let state = replay(&home).unwrap();
+        let parent = state.tasks.get(&TaskId::from("t-parent")).unwrap();
+        assert_eq!(parent.parent_id, None);
+        let child = state.tasks.get(&TaskId::from("t-child")).unwrap();
+        assert_eq!(child.parent_id, Some(TaskId::from("t-parent")));
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn parent_id_v1_envelope_defaults_to_none() {
+        let home = tmp_home("parent-v1");
+        let log = home.join("task_events.jsonl");
+        let v1_line = serde_json::json!({
+            "schema_version": 1,
+            "seq": 1,
+            "timestamp": "2026-05-25T00:00:00Z",
+            "instance": "v1-emitter",
+            "event": {
+                "kind": "Created",
+                "task_id": "t-old",
+                "title": "old task",
+                "description": "",
+                "priority": "normal",
+                "owner": null
+            }
+        });
+        fs::write(&log, format!("{v1_line}\n")).unwrap();
+        let state = replay(&home).unwrap();
+        let task = state.tasks.get(&TaskId::from("t-old")).unwrap();
+        assert_eq!(task.parent_id, None, "v1 envelope missing parent_id → None");
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn cascade_cancel_cancels_open_and_claimed_children() {
+        let home = tmp_home("cascade");
+        let inst = InstanceName::from("dev");
+        append(
+            &home,
+            &inst,
+            TaskEvent::Created {
+                task_id: TaskId::from("t-root"),
+                title: "root".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+        )
+        .unwrap();
+        append(
+            &home,
+            &inst,
+            TaskEvent::Created {
+                task_id: TaskId::from("t-child-open"),
+                title: "open child".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: Some(TaskId::from("t-root")),
+            },
+        )
+        .unwrap();
+        append(
+            &home,
+            &inst,
+            TaskEvent::Created {
+                task_id: TaskId::from("t-child-claimed"),
+                title: "claimed child".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: Some(TaskId::from("t-root")),
+            },
+        )
+        .unwrap();
+        append(
+            &home,
+            &inst,
+            TaskEvent::Claimed {
+                task_id: TaskId::from("t-child-claimed"),
+                by: inst.clone(),
+            },
+        )
+        .unwrap();
+        append(
+            &home,
+            &inst,
+            TaskEvent::Created {
+                task_id: TaskId::from("t-child-done"),
+                title: "done child".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: Some(TaskId::from("t-root")),
+            },
+        )
+        .unwrap();
+        append(
+            &home,
+            &inst,
+            TaskEvent::Done {
+                task_id: TaskId::from("t-child-done"),
+                by: inst.clone(),
+                source: DoneSource::OperatorManual {
+                    authored_at: chrono::Utc::now().to_rfc3339(),
+                    result: None,
+                },
+            },
+        )
+        .unwrap();
+        append(
+            &home,
+            &inst,
+            TaskEvent::Created {
+                task_id: TaskId::from("t-child-inprog"),
+                title: "in-progress child".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: Some(TaskId::from("t-root")),
+            },
+        )
+        .unwrap();
+        append(
+            &home,
+            &inst,
+            TaskEvent::InProgress {
+                task_id: TaskId::from("t-child-inprog"),
+                by: inst.clone(),
+            },
+        )
+        .unwrap();
+        append(
+            &home,
+            &inst,
+            TaskEvent::Created {
+                task_id: TaskId::from("t-unrelated"),
+                title: "unrelated".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+        )
+        .unwrap();
+
+        // Cancel the parent
+        append(
+            &home,
+            &inst,
+            TaskEvent::Cancelled {
+                task_id: TaskId::from("t-root"),
+                by: inst.clone(),
+                reason: "test cascade".into(),
+            },
+        )
+        .unwrap();
+
+        let state = replay(&home).unwrap();
+        assert_eq!(
+            state.tasks.get(&TaskId::from("t-root")).unwrap().status,
+            TaskStatus::Cancelled
+        );
+        assert_eq!(
+            state
+                .tasks
+                .get(&TaskId::from("t-child-open"))
+                .unwrap()
+                .status,
+            TaskStatus::Cancelled,
+            "open child must be cascade-cancelled"
+        );
+        assert_eq!(
+            state
+                .tasks
+                .get(&TaskId::from("t-child-claimed"))
+                .unwrap()
+                .status,
+            TaskStatus::Cancelled,
+            "claimed child must be cascade-cancelled"
+        );
+        assert_eq!(
+            state
+                .tasks
+                .get(&TaskId::from("t-child-done"))
+                .unwrap()
+                .status,
+            TaskStatus::Done,
+            "done child must NOT be cascade-cancelled"
+        );
+        assert_eq!(
+            state
+                .tasks
+                .get(&TaskId::from("t-child-inprog"))
+                .unwrap()
+                .status,
+            TaskStatus::InProgress,
+            "in-progress child must NOT be cascade-cancelled"
+        );
+        assert_eq!(
+            state
+                .tasks
+                .get(&TaskId::from("t-unrelated"))
+                .unwrap()
+                .status,
+            TaskStatus::Open,
+            "unrelated task must NOT be affected"
+        );
         fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -97,6 +97,7 @@ mod tests {
                     bind: None,
                     eta_secs: None,
                     tags: vec![],
+                    parent_id: None,
                 },
                 TaskEvent::Claimed {
                     task_id: tid,
@@ -127,6 +128,7 @@ mod tests {
                     bind: None,
                     eta_secs: None,
                     tags: vec![],
+                    parent_id: None,
                 },
                 TaskEvent::Done {
                     task_id: tid,
@@ -161,6 +163,7 @@ mod tests {
                     bind: None,
                     eta_secs: None,
                     tags: vec![],
+                    parent_id: None,
                 },
                 TaskEvent::Cancelled {
                     task_id: tid,

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -110,6 +110,9 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                             .collect()
                     })
                     .unwrap_or_default(),
+                parent_id: args["parent_id"]
+                    .as_str()
+                    .map(|s| crate::task_events::TaskId(s.to_string())),
             };
             match crate::task_events::append(home, &emitter, event) {
                 Ok(_) => {
@@ -588,6 +591,9 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                         let _ =
                             crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, &id);
                     }
+                    if s == "cancelled" {
+                        cascade_cancel_children(home, &id, &emitter);
+                    }
                 }
             }
             // #807 Item 1: see create arm note.
@@ -815,5 +821,53 @@ fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String
             "description updated".to_string(),
         ),
         TaskEvent::TagsSet { tags, .. } => ("tags_set", actor, format!("tags → {tags:?}")),
+    }
+}
+
+fn cascade_cancel_children(
+    home: &Path,
+    parent_id: &str,
+    emitter: &crate::task_events::InstanceName,
+) {
+    let Ok(state) = crate::task_events::replay(home) else {
+        return;
+    };
+    let parent_tid = crate::task_events::TaskId(parent_id.to_string());
+    let mut cancel_events = Vec::new();
+    let mut notify_ids = Vec::new();
+    for (child_id, child) in &state.tasks {
+        if child.parent_id.as_ref() != Some(&parent_tid) {
+            continue;
+        }
+        match child.status {
+            crate::task_events::TaskStatus::Open | crate::task_events::TaskStatus::Claimed => {
+                cancel_events.push(crate::task_events::TaskEvent::Cancelled {
+                    task_id: child_id.clone(),
+                    by: emitter.clone(),
+                    reason: format!("cascade: parent {parent_id} cancelled"),
+                });
+            }
+            crate::task_events::TaskStatus::InProgress => {
+                notify_ids.push((child_id.clone(), child.owner.clone()));
+            }
+            _ => {}
+        }
+    }
+    if !cancel_events.is_empty() {
+        let _ = crate::task_events::append_batch(home, emitter, cancel_events);
+    }
+    for (child_id, owner) in notify_ids {
+        if let Some(ref owner_name) = owner {
+            let msg = crate::inbox::message::InboxMessage {
+                text: format!(
+                    "[parent-cancelled] Parent task {parent_id} was cancelled. \
+                     Your in-progress subtask {} may need attention.",
+                    child_id.0
+                ),
+                kind: Some("parent_cancelled".to_string()),
+                ..Default::default()
+            };
+            let _ = crate::inbox::storage::enqueue(home, &owner_name.0, msg);
+        }
     }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -79,6 +79,8 @@ pub struct Task {
     pub auto_release_on_verdict: Option<bool>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -181,6 +183,7 @@ pub(super) fn record_to_task(r: &crate::task_events::TaskRecord) -> Task {
         // surface lands.
         auto_release_on_verdict: None,
         tags: r.tags.clone(),
+        parent_id: r.parent_id.as_ref().map(|t| t.0.clone()),
     }
 }
 
@@ -328,6 +331,7 @@ pub fn migrate_legacy_tasks_json_to_event_log(home: &Path) -> anyhow::Result<Mig
             // dispatches referencing this task_id.
             bind: None,
             tags: Vec::new(),
+            parent_id: None,
         });
         // Emit the minimum status-transition events to bring the task to
         // its current legacy status. The replay-derived view post-PR3

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -41,6 +41,7 @@ fn make_test_task(assignee: Option<&str>) -> Task {
         started_at: None,
         eta_secs: None,
         tags: vec![],
+        parent_id: None,
         auto_release_on_verdict: None,
     }
 }
@@ -82,6 +83,7 @@ fn make_record(
         started_at: None,
         eta_secs: None,
         tags: vec![],
+        parent_id: None,
     }
 }
 
@@ -396,6 +398,7 @@ fn reconcile_orphan_owners_with_live_empty_set_orphans_strict_ghost() {
             bind: None,
             eta_secs: None,
             tags: vec![],
+            parent_id: None,
         }],
     )
     .expect("seed Created event");
@@ -966,6 +969,7 @@ fn test_circular_dep_no_infinite_loop() {
             bind: None,
             eta_secs: None,
             tags: vec![],
+            parent_id: None,
         },
     )
     .unwrap();
@@ -985,6 +989,7 @@ fn test_circular_dep_no_infinite_loop() {
             bind: None,
             eta_secs: None,
             tags: vec![],
+            parent_id: None,
         },
     )
     .unwrap();
@@ -1632,6 +1637,7 @@ fn migration_imports_legacy_tasks_to_event_log() {
                 started_at: None,
                 eta_secs: None,
                 tags: vec![],
+                parent_id: None,
                 auto_release_on_verdict: None,
             });
         }
@@ -1698,6 +1704,7 @@ fn migration_idempotent_on_second_run() {
             started_at: None,
             eta_secs: None,
             tags: vec![],
+            parent_id: None,
             auto_release_on_verdict: None,
         });
         Ok(())


### PR DESCRIPTION
## Summary
- Adds `parent_id: Option<TaskId>` to `TaskEvent::Created` and `TaskRecord` for subtask composition (A decomposes into B,C,D)
- Cascade cancel: when parent is cancelled, open/claimed children auto-cancel; in-progress children get inbox notification
- MCP `task` tool schema updated with `parent_id` parameter
- Complementary to `depends_on` (execution ordering vs composition)

## Changes
- `src/task_events.rs` — parent_id field on Created event + TaskRecord, cascade cancel in fold
- `src/tasks/handler.rs` — parse parent_id from args, cascade_cancel_children function (emits Cancelled events + inbox notifications for in-progress children)
- `src/tasks/mod.rs` — parent_id on Task struct, record_to_task mapping
- `src/mcp/tools.rs` — parent_id in task tool schema
- `src/api/handlers/messaging.rs` — parent_id: None for auto-created tasks
- All test construction sites updated with parent_id: None

## Test plan
- [x] `parent_id_round_trips_through_replay` — create parent + child, verify parent_id survives replay
- [x] `parent_id_v1_envelope_defaults_to_none` — v1 envelope without parent_id field defaults to None
- [x] `cascade_cancel_cancels_open_and_claimed_children` — parent cancel cascades to open/claimed children, skips done/in-progress/unrelated
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — all 2821+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)