### PR TITLE
feat: add metadata KV bag to task system

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -242,6 +242,7 @@ mod tests {
             auto_release_on_verdict: None,
             tags: vec![],
             parent_id: None,
+            metadata: std::collections::BTreeMap::new(),
         }
     }
 

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -347,6 +347,7 @@ mod tests {
             auto_release_on_verdict: None,
             tags: vec![],
             parent_id: None,
+            metadata: std::collections::BTreeMap::new(),
         }
     }
 

--- a/src/daemon/legacy_backfill.rs
+++ b/src/daemon/legacy_backfill.rs
@@ -586,6 +586,7 @@ mod tests {
             auto_release_on_verdict: None,
             tags: vec![],
             parent_id: None,
+            metadata: std::collections::BTreeMap::new(),
         }
     }
 

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -788,6 +788,7 @@ mod tests {
             auto_release_on_verdict: None,
             tags: vec![],
             parent_id: None,
+            metadata: std::collections::BTreeMap::new(),
         }
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -146,9 +146,9 @@ fn decision_tools() -> Vec<Value> {
 
 fn task_tools() -> Vec<Value> {
     vec![
-        json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health, activity. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (4 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
+        json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health, activity, metadata_set, metadata_get. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (4 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
             "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health", "activity"]},
+                "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health", "activity", "metadata_set", "metadata_get"]},
                 "title": {"type": "string"}, "description": {"type": "string"},
                 "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
                 "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}}, "parent_id": {"type": "string", "description": "Parent task ID for subtask composition (A is composed of B,C,D). Complementary to depends_on (execution order)."},
@@ -165,7 +165,9 @@ fn task_tools() -> Vec<Value> {
                 "apply": {"type": "boolean", "description": "#806 sweep: when false (default), returns dry-run plan; when true, emits Cancelled for the confirm_ids subset."},
                 "confirm_ids": {"type": "array", "items": {"type": "string"}, "description": "#806 sweep apply=true: subset of candidate_ids from prior dry-run to actually cancel."},
                 "audit_reason": {"type": "string", "description": "#806 sweep apply=true: required audit text recorded in event-log.jsonl + per-task Cancelled.reason."},
-                "repo": {"type": "string", "description": "#806 sweep: override repo for PR-state queries (defaults to task_sweep.json's repo)."}
+                "repo": {"type": "string", "description": "#806 sweep: override repo for PR-state queries (defaults to task_sweep.json's repo)."},
+                "metadata_key": {"type": "string", "description": "Key for metadata_set action."},
+                "metadata_value": {"description": "Value for metadata_set action (any JSON type)."}
             }, "required": ["action"]}}),
         json!({"name": "task_sweep_config",
         "description": "Configure GitHub-PR auto-close sweep daemon. Sweep polls merged PRs and emits Done events for `Closes t-XXX-N` markers (validated by 5-must-have pipeline).",

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -532,6 +532,7 @@ mod tests {
             auto_release_on_verdict: None,
             tags: vec![],
             parent_id: None,
+            metadata: std::collections::BTreeMap::new(),
         }
     }
 
@@ -667,6 +668,7 @@ mod tests {
             auto_release_on_verdict: None,
             tags: vec![],
             parent_id: None,
+            metadata: std::collections::BTreeMap::new(),
         }];
         terminal
             .draw(|frame| {

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -324,6 +324,7 @@ mod tests {
             auto_release_on_verdict: None,
             tags: vec![],
             parent_id: None,
+            metadata: std::collections::BTreeMap::new(),
         }];
         let all_instances = vec![
             "dev-lead".to_string(),

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -325,6 +325,13 @@ pub enum TaskEvent {
         task_id: TaskId,
         tags: Vec<String>,
     },
+    /// Metadata KV bag update — set one key-value pair on a task.
+    MetadataSet {
+        task_id: TaskId,
+        by: InstanceName,
+        key: String,
+        value: serde_json::Value,
+    },
 }
 
 /// Per-task confidence breakdown produced by the legacy-backfill sweep.
@@ -362,7 +369,8 @@ impl TaskEvent {
             | TaskEvent::OwnerAssigned { task_id, .. }
             | TaskEvent::PriorityChanged { task_id, .. }
             | TaskEvent::DescriptionUpdated { task_id, .. }
-            | TaskEvent::TagsSet { task_id, .. } => task_id,
+            | TaskEvent::TagsSet { task_id, .. }
+            | TaskEvent::MetadataSet { task_id, .. } => task_id,
         }
     }
 
@@ -384,6 +392,7 @@ impl TaskEvent {
             TaskEvent::PriorityChanged { .. } => "priority_changed",
             TaskEvent::DescriptionUpdated { .. } => "description_updated",
             TaskEvent::TagsSet { .. } => "tags_set",
+            TaskEvent::MetadataSet { .. } => "metadata_set",
         }
     }
 }
@@ -478,6 +487,8 @@ pub struct TaskRecord {
     pub tags: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<TaskId>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -579,6 +590,7 @@ impl TaskBoardState {
                         eta_secs: *eta_secs,
                         tags: tags.clone(),
                         parent_id: parent_id.clone(),
+                        metadata: BTreeMap::new(),
                     });
             }
             TaskEvent::Claimed { by, .. } => {
@@ -713,6 +725,12 @@ impl TaskBoardState {
             TaskEvent::TagsSet { tags, .. } => {
                 if let Some(t) = self.tasks.get_mut(&task_id) {
                     t.tags = tags.clone();
+                    t.updated_at = touch_at;
+                }
+            }
+            TaskEvent::MetadataSet { key, value, .. } => {
+                if let Some(t) = self.tasks.get_mut(&task_id) {
+                    t.metadata.insert(key.clone(), value.clone());
                     t.updated_at = touch_at;
                 }
             }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -718,6 +718,56 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             };
             activity_timeline(home, task_id)
         }
+        "metadata_set" => {
+            let id = match args["id"].as_str() {
+                Some(i) => i,
+                None => return serde_json::json!({"error": "missing 'id'"}),
+            };
+            let key = match args["metadata_key"].as_str() {
+                Some(k) => k,
+                None => return serde_json::json!({"error": "missing 'metadata_key'"}),
+            };
+            let value = if let Some(v) = args.get("metadata_value") {
+                if v.is_null() {
+                    return serde_json::json!({"error": "missing 'metadata_value'"});
+                }
+                v.clone()
+            } else {
+                return serde_json::json!({"error": "missing 'metadata_value'"});
+            };
+            let record = match read_task_record(home, id) {
+                Some(r) => r,
+                None => return serde_json::json!({"error": format!("task not found: {id}")}),
+            };
+            if !can_mutate_record(home, instance_name, &record) {
+                return serde_json::json!({"error": "permission denied: caller is not owner/creator"});
+            }
+            let event = crate::task_events::TaskEvent::MetadataSet {
+                task_id: crate::task_events::TaskId(id.to_string()),
+                by: emitter.clone(),
+                key: key.to_string(),
+                value,
+            };
+            match crate::task_events::append(home, &emitter, event) {
+                Ok(_) => {
+                    let task = read_task_record(home, id).map(|r| record_to_task(&r));
+                    serde_json::json!({"id": id, "event": "metadata_set", "task": task})
+                }
+                Err(e) => serde_json::json!({"error": format!("{e}")}),
+            }
+        }
+        "metadata_get" => {
+            let id = match args["id"].as_str() {
+                Some(i) => i,
+                None => return serde_json::json!({"error": "missing 'id'"}),
+            };
+            match read_task_record(home, id) {
+                Some(r) => {
+                    serde_json::json!({"id": id, "metadata": r.metadata})
+                }
+                None => serde_json::json!({"error": format!("task not found: {id}")}),
+            }
+        }
         _ => serde_json::json!({"error": format!("unknown action: {action}")}),
     }
 }
@@ -821,6 +871,244 @@ fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String
             "description updated".to_string(),
         ),
         TaskEvent::TagsSet { tags, .. } => ("tags_set", actor, format!("tags → {tags:?}")),
+        TaskEvent::MetadataSet { key, value, by, .. } => (
+            "metadata_set",
+            by.0.clone(),
+            format!("metadata[{key}] = {value}"),
+        ),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(name: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-metadata-test-{}-{}-{}",
+            std::process::id(),
+            name,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn create_task(home: &std::path::Path, task_id: &str) {
+        let args = serde_json::json!({
+            "action": "create",
+            "title": "test task",
+        });
+        let emitter = crate::task_events::InstanceName::from("test:operator");
+        let tid = crate::task_events::TaskId(task_id.into());
+        crate::task_events::append(
+            home,
+            &emitter,
+            crate::task_events::TaskEvent::Created {
+                task_id: tid,
+                title: "test task".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: Some(crate::task_events::InstanceName::from("dev-agent")),
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+            },
+        )
+        .expect("create task");
+        let _ = args;
+    }
+
+    #[test]
+    fn metadata_set_writes_and_reads() {
+        let home = tmp_home("set_read");
+        create_task(&home, "t-meta-001");
+
+        let result = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_set",
+                "id": "t-meta-001",
+                "metadata_key": "pr_url",
+                "metadata_value": "https://github.com/test/repo/pull/42"
+            }),
+        );
+        assert_eq!(result["event"], "metadata_set");
+        assert!(result["error"].is_null(), "unexpected error: {result}");
+
+        let get_result = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_get",
+                "id": "t-meta-001",
+            }),
+        );
+        assert_eq!(
+            get_result["metadata"]["pr_url"],
+            "https://github.com/test/repo/pull/42"
+        );
+    }
+
+    #[test]
+    fn metadata_set_overwrites_existing_key() {
+        let home = tmp_home("overwrite");
+        create_task(&home, "t-meta-002");
+
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_set",
+                "id": "t-meta-002",
+                "metadata_key": "commit_sha",
+                "metadata_value": "abc123"
+            }),
+        );
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_set",
+                "id": "t-meta-002",
+                "metadata_key": "commit_sha",
+                "metadata_value": "def456"
+            }),
+        );
+
+        let result = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_get",
+                "id": "t-meta-002",
+            }),
+        );
+        assert_eq!(result["metadata"]["commit_sha"], "def456");
+    }
+
+    #[test]
+    fn metadata_supports_non_string_values() {
+        let home = tmp_home("non_string");
+        create_task(&home, "t-meta-003");
+
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_set",
+                "id": "t-meta-003",
+                "metadata_key": "retry_count",
+                "metadata_value": 3
+            }),
+        );
+
+        let result = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_get",
+                "id": "t-meta-003",
+            }),
+        );
+        assert_eq!(result["metadata"]["retry_count"], 3);
+    }
+
+    #[test]
+    fn metadata_get_empty_on_new_task() {
+        let home = tmp_home("empty_meta");
+        create_task(&home, "t-meta-004");
+
+        let result = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_get",
+                "id": "t-meta-004",
+            }),
+        );
+        assert!(result["error"].is_null());
+        assert_eq!(result["metadata"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn metadata_set_missing_key_returns_error() {
+        let home = tmp_home("missing_key");
+        create_task(&home, "t-meta-005");
+
+        let result = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_set",
+                "id": "t-meta-005",
+                "metadata_value": "some_value"
+            }),
+        );
+        assert!(result["error"].as_str().unwrap().contains("metadata_key"));
+    }
+
+    #[test]
+    fn metadata_set_missing_value_returns_error() {
+        let home = tmp_home("missing_val");
+        create_task(&home, "t-meta-006");
+
+        let result = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_set",
+                "id": "t-meta-006",
+                "metadata_key": "some_key"
+            }),
+        );
+        assert!(result["error"].as_str().unwrap().contains("metadata_value"));
+    }
+
+    #[test]
+    fn metadata_appears_in_list() {
+        let home = tmp_home("list_meta");
+        create_task(&home, "t-meta-007");
+
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_set",
+                "id": "t-meta-007",
+                "metadata_key": "pr_url",
+                "metadata_value": "https://example.com/pr/1"
+            }),
+        );
+
+        let list = handle(&home, "dev-agent", &serde_json::json!({"action": "list"}));
+        let tasks = list["tasks"].as_array().unwrap();
+        let task = tasks.iter().find(|t| t["id"] == "t-meta-007").unwrap();
+        assert_eq!(task["metadata"]["pr_url"], "https://example.com/pr/1");
+    }
+
+    #[test]
+    fn metadata_get_nonexistent_task_returns_error() {
+        let home = tmp_home("nonexistent");
+
+        let result = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "metadata_get",
+                "id": "t-meta-999",
+            }),
+        );
+        assert!(result["error"].as_str().unwrap().contains("not found"));
     }
 }
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -81,6 +81,8 @@ pub struct Task {
     pub tags: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub metadata: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -184,6 +186,7 @@ pub(super) fn record_to_task(r: &crate::task_events::TaskRecord) -> Task {
         auto_release_on_verdict: None,
         tags: r.tags.clone(),
         parent_id: r.parent_id.as_ref().map(|t| t.0.clone()),
+        metadata: r.metadata.clone(),
     }
 }
 

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -43,6 +43,7 @@ fn make_test_task(assignee: Option<&str>) -> Task {
         tags: vec![],
         parent_id: None,
         auto_release_on_verdict: None,
+        metadata: std::collections::BTreeMap::new(),
     }
 }
 
@@ -84,6 +85,7 @@ fn make_record(
         eta_secs: None,
         tags: vec![],
         parent_id: None,
+        metadata: std::collections::BTreeMap::new(),
     }
 }
 
@@ -1639,6 +1641,7 @@ fn migration_imports_legacy_tasks_to_event_log() {
                 tags: vec![],
                 parent_id: None,
                 auto_release_on_verdict: None,
+                metadata: std::collections::BTreeMap::new(),
             });
         }
         Ok(())
@@ -1706,6 +1709,7 @@ fn migration_idempotent_on_second_run() {
             tags: vec![],
             parent_id: None,
             auto_release_on_verdict: None,
+            metadata: std::collections::BTreeMap::new(),
         });
         Ok(())
     })


### PR DESCRIPTION
## Summary
- Add `MetadataSet` event variant to `TaskEvent` enum + `metadata: BTreeMap<String, serde_json::Value>` field on `TaskRecord` and `Task`
- New MCP actions: `metadata_set` (write single key-value pair) and `metadata_get` (read all metadata for a task)
- Metadata appears in `task action=list` responses; backward compatible (empty metadata omitted via `serde(skip_serializing_if)`)

## Files changed (11)
- `src/task_events.rs` — `MetadataSet` variant, `metadata` field on `TaskRecord`, `apply()` match arm
- `src/tasks/mod.rs` — `metadata` field on `Task`, `record_to_task()` mapping
- `src/tasks/handler.rs` — `metadata_set`/`metadata_get` action handlers + 8 tests + `summarize_event` arm
- `src/mcp/tools.rs` — schema: `metadata_set`/`metadata_get` in action enum, `metadata_key`/`metadata_value` params
- 7 test fixture files — add `metadata: BTreeMap::new()` to `Task`/`TaskRecord` struct literals

## Test plan
- [x] 8 new handler tests: set/get, overwrite, non-string values, empty default, missing params, list inclusion, nonexistent task
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] Full test suite passes (all existing tests + 8 new)

Closes t-20260525124805867028-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)