### PR TITLE
fix: agend-git test missing git config in CI (#1225)

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -1933,6 +1933,18 @@ mod tests {
             .unwrap()
             .status
             .success());
+        Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(["config", "user.name", "test"])
+            .output()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(["config", "user.email", "test@test.com"])
+            .output()
+            .unwrap();
         assert!(Command::new("git")
             .arg("-C")
             .arg(&repo)


### PR DESCRIPTION
## Summary
- Add `user.name`/`user.email` config to `has_unmerged_files_false_on_clean_repo` test
- CI on ubuntu/windows lacks global git config, causing `git commit --allow-empty` to fail
- Matches the pattern already used in `has_unmerged_files_true_on_conflict`

## Test plan
- [x] Both unmerged files tests pass locally
- [x] Clippy clean, fmt clean
- [ ] CI green on ubuntu + windows + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)