### PR TITLE
feat(repo): merge action with CI preflight gate (#1244)

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -1020,8 +1020,15 @@ pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
             .output();
         match checks_output {
             Ok(o) if o.status.success() => {
-                let checks: Vec<serde_json::Value> =
-                    serde_json::from_slice(&o.stdout).unwrap_or_default();
+                let checks: Vec<serde_json::Value> = match serde_json::from_slice(&o.stdout) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return json!({
+                            "error": format!("failed to parse CI checks response: {e}"),
+                            "hint": "merge refused (fail-closed)"
+                        });
+                    }
+                };
                 let failing: Vec<_> = checks
                     .iter()
                     .filter(|c| {
@@ -1066,13 +1073,20 @@ pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
             "timestamp": chrono::Utc::now().to_rfc3339(),
         });
         let events_path = home.join("fleet_events.jsonl");
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(events_path)
-        {
+        let audit_written = (|| -> std::io::Result<()> {
             use std::io::Write;
-            let _ = writeln!(f, "{event}");
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(events_path)?;
+            writeln!(f, "{event}")?;
+            Ok(())
+        })();
+        if let Err(e) = audit_written {
+            return json!({
+                "error": format!("force-merge refused: audit log write failed: {e}"),
+                "hint": "fix fleet_events.jsonl permissions or disk space, then retry"
+            });
         }
     }
 

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -990,6 +990,122 @@ pub(crate) fn handle_cleanup_merged_branches(
     }
 }
 
+pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
+    let pr = match args["pr"].as_u64() {
+        Some(n) => n,
+        None => return json!({"error": "missing 'pr' (PR number)"}),
+    };
+    let repo = args["repo"]
+        .as_str()
+        .unwrap_or("suzuke/agend-terminal")
+        .to_string();
+    let force = args["force"].as_bool().unwrap_or(false);
+    let force_reason = args["force_reason"].as_str().unwrap_or("");
+
+    if force && force_reason.is_empty() {
+        return json!({"error": "force=true requires non-empty force_reason"});
+    }
+
+    if !force {
+        let checks_output = std::process::Command::new("gh")
+            .args([
+                "pr",
+                "checks",
+                &pr.to_string(),
+                "--repo",
+                &repo,
+                "--json",
+                "name,state",
+            ])
+            .output();
+        match checks_output {
+            Ok(o) if o.status.success() => {
+                let checks: Vec<serde_json::Value> =
+                    serde_json::from_slice(&o.stdout).unwrap_or_default();
+                let failing: Vec<_> = checks
+                    .iter()
+                    .filter(|c| {
+                        let st = c["state"].as_str().unwrap_or("");
+                        st != "SUCCESS" && st != "SKIPPED"
+                    })
+                    .collect();
+                if !failing.is_empty() {
+                    let summary: Vec<String> = failing
+                        .iter()
+                        .map(|c| {
+                            format!(
+                                "{}: {}",
+                                c["name"].as_str().unwrap_or("?"),
+                                c["state"].as_str().unwrap_or("?")
+                            )
+                        })
+                        .collect();
+                    return json!({
+                        "error": "CI checks not all passed — merge refused",
+                        "failing_checks": summary,
+                        "hint": "Wait for CI to pass, or use force=true with force_reason for emergency bypass"
+                    });
+                }
+            }
+            _ => {
+                return json!({
+                    "error": "failed to query CI checks — merge refused",
+                    "hint": "Verify PR number and repo, or use force=true with force_reason"
+                });
+            }
+        }
+    }
+
+    if force {
+        let event = serde_json::json!({
+            "kind": "merge_force_bypass",
+            "agent": instance_name,
+            "pr": pr,
+            "repo": repo,
+            "force_reason": force_reason,
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+        });
+        let events_path = home.join("fleet_events.jsonl");
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(events_path)
+        {
+            use std::io::Write;
+            let _ = writeln!(f, "{event}");
+        }
+    }
+
+    let merge_output = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "merge",
+            &pr.to_string(),
+            "--repo",
+            &repo,
+            "--admin",
+            "--squash",
+            "--delete-branch",
+        ])
+        .output();
+    match merge_output {
+        Ok(o) if o.status.success() => {
+            json!({
+                "merged": true,
+                "pr": pr,
+                "forced": force,
+            })
+        }
+        Ok(o) => {
+            json!({
+                "error": "gh pr merge failed",
+                "stderr": String::from_utf8_lossy(&o.stderr).to_string(),
+            })
+        }
+        Err(e) => json!({"error": format!("failed to run gh: {e}")}),
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests;

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2013,3 +2013,23 @@ fn merge_force_without_reason_returns_error() {
     assert!(result["error"].as_str().unwrap().contains("force_reason"));
     let _ = std::fs::remove_dir_all(&home);
 }
+
+#[test]
+fn merge_force_audit_write_failure_refuses_merge() {
+    let home = std::env::temp_dir().join(format!("agend-merge-audit-fail-{}", std::process::id()));
+    std::fs::create_dir_all(&home).unwrap();
+    let events_path = home.join("fleet_events.jsonl");
+    std::fs::create_dir_all(&events_path).unwrap();
+
+    let result = super::handle_merge_repo(
+        &home,
+        &json!({"pr": 9999, "force": true, "force_reason": "test emergency"}),
+        "dev",
+    );
+    let err = result["error"].as_str().unwrap();
+    assert!(
+        err.contains("audit log write failed"),
+        "expected audit failure error, got: {err}"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -1993,3 +1993,23 @@ fn handle_watch_ci_rejects_invalid_repo_format() {
         "GitLab URL must be rejected as invalid_repo_format: {r}"
     );
 }
+
+// ----- #1244 PR-B: merge preflight CI gate -----
+
+#[test]
+fn merge_missing_pr_returns_error() {
+    let home = std::env::temp_dir().join(format!("agend-merge-test-{}", std::process::id()));
+    std::fs::create_dir_all(&home).unwrap();
+    let result = super::handle_merge_repo(&home, &json!({}), "dev");
+    assert!(result["error"].as_str().unwrap().contains("pr"));
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn merge_force_without_reason_returns_error() {
+    let home = std::env::temp_dir().join(format!("agend-merge-force-test-{}", std::process::id()));
+    std::fs::create_dir_all(&home).unwrap();
+    let result = super::handle_merge_repo(&home, &json!({"pr": 1234, "force": true}), "dev");
+    assert!(result["error"].as_str().unwrap().contains("force_reason"));
+    let _ = std::fs::remove_dir_all(&home);
+}

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -569,6 +569,7 @@ fn dispatch_repo(ctx: &HandlerCtx<'_>) -> Value {
         "cleanup_merged_branches" => {
             ci::handle_cleanup_merged_branches(ctx.home, ctx.args, ctx.instance_name)
         }
+        "merge" => ci::handle_merge_repo(ctx.home, ctx.args, ctx.instance_name),
         other => json!({"error": format!("unknown repo action: {other}")}),
     }
 }
@@ -589,6 +590,10 @@ fn dispatch_repo_cleanup_merged_branches(ctx: &HandlerCtx<'_>) -> Value {
     ci::handle_cleanup_merged_branches(ctx.home, ctx.args, ctx.instance_name)
 }
 
+fn dispatch_repo_merge(ctx: &HandlerCtx<'_>) -> Value {
+    ci::handle_merge_repo(ctx.home, ctx.args, ctx.instance_name)
+}
+
 static REPO_ACTIONS: &[(&str, HandlerFn)] = &[
     ("checkout", dispatch_repo_checkout),
     ("release", dispatch_repo_release),
@@ -597,6 +602,7 @@ static REPO_ACTIONS: &[(&str, HandlerFn)] = &[
         "cleanup_merged_branches",
         dispatch_repo_cleanup_merged_branches,
     ),
+    ("merge", dispatch_repo_merge),
 ];
 
 // `schedule` — actions: create / list / update / delete.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -275,9 +275,10 @@ fn health_tools() -> Vec<Value> {
 
 fn repo_tools() -> Vec<Value> {
     vec![
-        json!({"name": "repo", "description": "Manage repo worktrees. Actions: checkout, release, cleanup_init_commits, cleanup_merged_branches. #817: cleanup_merged_branches is operator-triggered local-branch hygiene (4 categories: clean_merged/squash_merged/stale_idle/active_unknown; dry-run by default + confirm_ids + audit_reason required for apply).",
+        json!({"name": "repo", "description": "Manage repo worktrees. Actions: checkout, release, cleanup_init_commits, cleanup_merged_branches, merge. #817: cleanup_merged_branches is operator-triggered local-branch hygiene (4 categories: clean_merged/squash_merged/stale_idle/active_unknown; dry-run by default + confirm_ids + audit_reason required for apply).",
             "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["checkout", "release", "cleanup_init_commits", "cleanup_merged_branches"]},
+                "action": {"type": "string", "enum": ["checkout", "release", "cleanup_init_commits", "cleanup_merged_branches", "merge"]},
+                "pr": {"type": "integer", "description": "PR number for merge action."},
                 "source": {"type": "string"}, "branch": {"type": "string"},
                 "path": {"type": "string"},
                 "agent": {"type": "string", "description": "#789: target agent for cleanup_init_commits (defaults to caller's instance_name). Cleans empty `init` commits accumulated in the agent's bound worktree by backend session-checkpoint heartbeats. Returns {cleaned_count, [skipped_reason]}. Idempotent — call before push to scrub PR history."},


### PR DESCRIPTION
## Summary
- Add `repo action=merge` MCP tool that enforces CI checks before merging PRs
- Queries `gh pr checks --json name,state` and refuses merge unless all checks pass (SUCCESS/SKIPPED)
- Supports `force=true` with mandatory `force_reason` for emergency bypass, audit-logged to `fleet_events.jsonl`
- Executes `gh pr merge --admin --squash --delete-branch` on success

## Changed files
- `src/mcp/handlers/ci/mod.rs` — `handle_merge_repo()` implementation
- `src/mcp/handlers/dispatch.rs` — wire `"merge"` action into `dispatch_repo()` + `REPO_ACTIONS`
- `src/mcp/tools.rs` — add `"merge"` to action enum, `"pr"` parameter
- `src/mcp/handlers/ci/tests.rs` — 2 unit tests (missing PR, force without reason)

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Unit tests pass: `merge_missing_pr_returns_error`, `merge_force_without_reason_returns_error`
- [ ] CI green on push

Closes #1244 (PR-B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)