### PR TITLE
ci-fail notification: append actionable checklist

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -534,10 +534,21 @@ pub(crate) fn build_inbox_body(
     conclusion: &str,
     failure_detail: Option<&str>,
     run_url: &str,
+    run_id: Option<u64>,
 ) -> String {
     if conclusion == "failure" {
         let detail = failure_detail.unwrap_or("unknown step");
-        format!("{headline}\nDetail: {detail}\nURL: {run_url}")
+        let run_id_str = run_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "<run_id>".to_string());
+        format!(
+            "{headline}\nDetail: {detail}\nURL: {run_url}\n\n\
+             ⚠ CI failure checklist:\n\
+             1. `gh run view {run_id_str} --log-failed` — read the actual error\n\
+             2. If infra flake → `gh run rerun {run_id_str} --failed`\n\
+             3. If real failure → fix code, push, wait for green\n\
+             4. Do NOT dismiss without evidence"
+        )
     } else {
         format!("{headline}\nURL: {run_url}")
     }
@@ -1015,6 +1026,7 @@ async fn fan_out_notifications(
                 conclusion.unwrap_or(""),
                 failure_detail.as_deref(),
                 &run.url,
+                Some(*run_id),
             );
 
             let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -654,6 +654,7 @@ fn test_inbox_body_failure_has_detail_and_url() {
         "failure",
         Some("Check / Clippy"),
         "https://github.com/o/r/actions/runs/123",
+        Some(123),
     );
     assert!(
         body.contains("Detail: Check / Clippy"),
@@ -663,12 +664,40 @@ fn test_inbox_body_failure_has_detail_and_url() {
 }
 
 #[test]
+fn test_inbox_body_failure_has_checklist() {
+    let body = build_inbox_body(
+        "[ci-fail] o/r@main: failure",
+        "failure",
+        Some("Tests"),
+        "https://github.com/o/r/actions/runs/789",
+        Some(789),
+    );
+    assert!(
+        body.contains("CI failure checklist"),
+        "failure body must have checklist: {body}"
+    );
+    assert!(
+        body.contains("gh run view 789 --log-failed"),
+        "checklist must include run_id in view command: {body}"
+    );
+    assert!(
+        body.contains("gh run rerun 789 --failed"),
+        "checklist must include run_id in rerun command: {body}"
+    );
+    assert!(
+        body.contains("Do NOT dismiss without evidence"),
+        "checklist must warn against dismissal: {body}"
+    );
+}
+
+#[test]
 fn test_inbox_body_success_has_url_no_detail() {
     let body = build_inbox_body(
         "[ci-pass] o/r@main: passed ✓",
         "success",
         None,
         "https://github.com/o/r/actions/runs/456",
+        Some(456),
     );
     assert!(
         body.contains("URL: https://"),
@@ -677,6 +706,10 @@ fn test_inbox_body_success_has_url_no_detail() {
     assert!(
         !body.contains("Detail:"),
         "success body must not have Detail: {body}"
+    );
+    assert!(
+        !body.contains("checklist"),
+        "success body must not have checklist: {body}"
     );
 }
 


### PR DESCRIPTION
## Summary
- `build_inbox_body()` now appends a 4-step actionable checklist when `conclusion == "failure"`, with the actual `run_id` pre-filled in `gh run view` and `gh run rerun` commands
- Non-failure notifications (success, cancelled, etc.) are unaffected
- New `run_id: Option<u64>` parameter added to `build_inbox_body()` for template interpolation

## Context
PR #1242 merged with a real CI failure, PR #1252 repeated the pattern. Root cause: agents receive `[ci-fail]` with no structured next-step guidance, leading to premature dismissal as "infra flake" without reading logs or retrying.

## Test plan
- [x] `test_inbox_body_failure_has_detail_and_url` — existing test updated with new param
- [x] `test_inbox_body_failure_has_checklist` — NEW: verifies checklist presence, run_id in commands, dismissal warning
- [x] `test_inbox_body_success_has_url_no_detail` — updated, verifies no checklist on success
- [x] Full test suite passes (no regressions)
- [x] cargo fmt + clippy clean

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)