### PR TITLE
fix(ui): add q/Backspace to close task detail overlay

### DIFF
--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -580,7 +580,10 @@ pub(super) fn handle_key(
             }
             match mode {
                 TaskBoardMode::Detail => {
-                    if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
+                    if matches!(
+                        key.code,
+                        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Backspace
+                    ) {
                         *mode = TaskBoardMode::Board;
                     }
                 }


### PR DESCRIPTION
## Summary
- Add `KeyCode::Char('q')` and `KeyCode::Backspace` as close keys for task detail overlay, matching other overlay modes
- 1-line change in `src/app/overlay.rs`

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)