### PR TITLE
fix(watchdog): skip dev_idle alert for agents with no active task (#1256)

### DIFF
--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -268,6 +268,15 @@ pub(crate) fn scan_and_emit(
     scan_fleet_vantage(home, &now, last_alerted);
 }
 
+/// #1256: check if the task board has any tasks (indicating active use).
+/// When the board has tasks, agents without assigned work should not
+/// trigger idle alerts — their silence is expected.
+fn task_board_is_active(home: &Path) -> bool {
+    crate::task_events::replay(home)
+        .map(|s| !s.tasks.is_empty())
+        .unwrap_or(false)
+}
+
 /// Look up the current in-progress task for an agent (if any).
 fn current_agent_task(home: &Path, agent: &str) -> Option<String> {
     let state = crate::task_events::replay(home).ok()?;
@@ -328,6 +337,11 @@ fn scan_dev_vantage(
         }
         let task_info =
             current_agent_task(home, agent).unwrap_or_else(|| "(no active task)".to_string());
+        // #1256: skip alert when task board is active and agent has no
+        // assigned task — silence is expected when no work is assigned.
+        if task_info == "(no active task)" && task_board_is_active(home) {
+            continue;
+        }
         emit_idle_alert(
             home,
             &dev_idle_recipient(),

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -284,8 +284,11 @@ fn current_agent_task(home: &Path, agent: &str) -> Option<String> {
         .tasks
         .values()
         .find(|t| {
-            t.status == crate::task_events::TaskStatus::InProgress
-                && t.owner.as_ref().map(|n| n.as_str()) == Some(agent)
+            matches!(
+                t.status,
+                crate::task_events::TaskStatus::InProgress
+                    | crate::task_events::TaskStatus::Claimed
+            ) && t.owner.as_ref().map(|n| n.as_str()) == Some(agent)
         })
         .map(|t| format!("{} — {}", t.id, t.title))
 }


### PR DESCRIPTION
Closes #1256

## Problem
dev_idle_watchdog alerts agents that have been silent but have no active task assigned. This causes false-positive noise when agents are legitimately idle (no work dispatched).

## Fix
When the task board is active (has tasks), skip the dev_idle alert for agents that have no claimed/in_progress task. Agents without assigned work are expected to be silent.

When the task board is empty/unused (legacy mode), alerts still fire normally for backward compat.

## Testing
All 33 idle_watchdog tests pass.