### PR TITLE
perf: ci-watch per-tick poll_runs dedup cache

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -3,6 +3,48 @@ use std::path::Path;
 use std::sync::Arc;
 
 use super::provider::{CiPollResult, CiProvider, CiRun, MergeableState, PrState};
+
+type TickCache = Arc<tokio::sync::Mutex<std::collections::HashMap<(String, String), CiPollResult>>>;
+
+struct CachedCiProvider {
+    inner: Box<dyn CiProvider>,
+    poll_cache: TickCache,
+}
+
+#[async_trait::async_trait]
+impl CiProvider for CachedCiProvider {
+    async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiPollResult> {
+        let key = (repo.to_string(), branch.to_string());
+        {
+            let cache = self.poll_cache.lock().await;
+            if let Some(cached) = cache.get(&key) {
+                return Ok(cached.clone());
+            }
+        }
+        let result = self.inner.poll_runs(repo, branch).await?;
+        {
+            let mut cache = self.poll_cache.lock().await;
+            cache.insert(key, result.clone());
+        }
+        Ok(result)
+    }
+
+    async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState {
+        self.inner.check_pr_terminal(repo, branch).await
+    }
+
+    async fn check_pr_mergeable(&self, repo: &str, branch: &str) -> MergeableState {
+        self.inner.check_pr_mergeable(repo, branch).await
+    }
+
+    async fn fetch_failure_summary(&self, repo: &str, run_id: u64) -> String {
+        self.inner.fetch_failure_summary(repo, run_id).await
+    }
+
+    fn token_warning(&self) -> Option<&'static str> {
+        self.inner.token_warning()
+    }
+}
 use super::registry::{
     ci_watches_dir, remove_watch, update_watch_state, update_watch_state_with_notify,
 };
@@ -274,6 +316,7 @@ pub(super) fn check_ci_watches_with_provider(
         Ok(e) => e,
         Err(_) => return,
     };
+    let tick_cache: TickCache = Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
     let display_timezone: Option<String> =
         crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
             .ok()
@@ -297,8 +340,11 @@ pub(super) fn check_ci_watches_with_provider(
                         .unwrap_or_default()
                         .as_bytes(),
                 );
-                let provider = match make_provider(&watch) {
-                    Some(p) => p,
+                let provider: Box<dyn CiProvider> = match make_provider(&watch) {
+                    Some(p) => Box::new(CachedCiProvider {
+                        inner: p,
+                        poll_cache: Arc::clone(&tick_cache),
+                    }),
                     None => {
                         tracing::warn!(repo = %ctx.repo, "ci_check: failed to build CI provider");
                         continue;

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use super::provider::{CiPollResult, CiProvider, CiRun, MergeableState, PrState};
 
-type TickCache = Arc<tokio::sync::Mutex<std::collections::HashMap<(String, String), CiPollResult>>>;
+type PerKeySlot = Arc<tokio::sync::Mutex<Option<CiPollResult>>>;
+type TickCache = Arc<std::sync::Mutex<std::collections::HashMap<(String, String), PerKeySlot>>>;
 
 struct CachedCiProvider {
     inner: Box<dyn CiProvider>,
@@ -15,17 +16,16 @@ struct CachedCiProvider {
 impl CiProvider for CachedCiProvider {
     async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiPollResult> {
         let key = (repo.to_string(), branch.to_string());
-        {
-            let cache = self.poll_cache.lock().await;
-            if let Some(cached) = cache.get(&key) {
-                return Ok(cached.clone());
-            }
+        let slot = {
+            let mut map = self.poll_cache.lock().unwrap_or_else(|e| e.into_inner());
+            map.entry(key).or_default().clone()
+        };
+        let mut guard = slot.lock().await;
+        if let Some(cached) = guard.as_ref() {
+            return Ok(cached.clone());
         }
         let result = self.inner.poll_runs(repo, branch).await?;
-        {
-            let mut cache = self.poll_cache.lock().await;
-            cache.insert(key, result.clone());
-        }
+        *guard = Some(result.clone());
         Ok(result)
     }
 
@@ -316,7 +316,7 @@ pub(super) fn check_ci_watches_with_provider(
         Ok(e) => e,
         Err(_) => return,
     };
-    let tick_cache: TickCache = Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+    let tick_cache: TickCache = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
     let display_timezone: Option<String> =
         crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
             .ok()

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -5019,11 +5019,14 @@ impl CiProvider for CountingProvider {
     }
 }
 
+fn new_tick_cache() -> super::TickCache {
+    std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
 #[test]
 fn tick_cache_dedup_same_repo_branch_single_api_call() {
     let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
-    let cache: super::TickCache =
-        std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+    let cache = new_tick_cache();
     let provider = super::CachedCiProvider {
         inner: Box::new(CountingProvider {
             call_count: std::sync::Arc::clone(&call_count),
@@ -5054,8 +5057,7 @@ fn tick_cache_dedup_same_repo_branch_single_api_call() {
 #[test]
 fn tick_cache_different_repo_branch_independent_calls() {
     let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
-    let cache: super::TickCache =
-        std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+    let cache = new_tick_cache();
     let provider = super::CachedCiProvider {
         inner: Box::new(CountingProvider {
             call_count: std::sync::Arc::clone(&call_count),
@@ -5081,14 +5083,12 @@ fn tick_cache_does_not_persist_across_ticks() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     // Tick 1
     {
-        let cache: super::TickCache =
-            std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
         let provider = super::CachedCiProvider {
             inner: Box::new(CountingProvider {
                 call_count: std::sync::Arc::clone(&call_count),
                 runs: vec![],
             }),
-            poll_cache: cache,
+            poll_cache: new_tick_cache(),
         };
         rt.block_on(async {
             let _ = provider.poll_runs("owner/repo", "main").await;
@@ -5096,14 +5096,12 @@ fn tick_cache_does_not_persist_across_ticks() {
     }
     // Tick 2 — fresh cache
     {
-        let cache: super::TickCache =
-            std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
         let provider = super::CachedCiProvider {
             inner: Box::new(CountingProvider {
                 call_count: std::sync::Arc::clone(&call_count),
                 runs: vec![],
             }),
-            poll_cache: cache,
+            poll_cache: new_tick_cache(),
         };
         rt.block_on(async {
             let _ = provider.poll_runs("owner/repo", "main").await;
@@ -5113,5 +5111,41 @@ fn tick_cache_does_not_persist_across_ticks() {
         call_count.load(std::sync::atomic::Ordering::Relaxed),
         2,
         "each tick must create a fresh cache — no cross-tick sharing"
+    );
+}
+
+#[tokio::test]
+async fn tick_cache_concurrent_same_key_single_api_call() {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    let call_count = Arc::new(AtomicU32::new(0));
+    let cache = new_tick_cache();
+    let barrier = Arc::new(tokio::sync::Barrier::new(4));
+
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let cc = Arc::clone(&call_count);
+        let c = Arc::clone(&cache);
+        let b = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            let provider = super::CachedCiProvider {
+                inner: Box::new(CountingProvider {
+                    call_count: cc,
+                    runs: vec![],
+                }),
+                poll_cache: c,
+            };
+            b.wait().await;
+            provider.poll_runs("owner/repo", "feat/x").await.unwrap();
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+    assert_eq!(
+        call_count.load(Ordering::Relaxed),
+        1,
+        "4 concurrent tasks with same key must coalesce to 1 API call"
     );
 }

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -4989,3 +4989,129 @@ fn aggregate_required_checks_ignores_non_required_failure() {
         Some("success"),
     );
 }
+
+// ── per-tick CachedCiProvider dedup tests ──
+
+struct CountingProvider {
+    call_count: std::sync::Arc<std::sync::atomic::AtomicU32>,
+    runs: Vec<CiRun>,
+}
+
+#[async_trait::async_trait]
+impl CiProvider for CountingProvider {
+    async fn poll_runs(&self, _repo: &str, _branch: &str) -> anyhow::Result<CiPollResult> {
+        self.call_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(CiPollResult::Runs {
+            runs: self.runs.clone(),
+            rate_limit_remaining: None,
+            rate_limit_limit: None,
+        })
+    }
+    async fn check_pr_terminal(&self, _repo: &str, _branch: &str) -> PrState {
+        PrState::Open
+    }
+    async fn fetch_failure_summary(&self, _repo: &str, _run_id: u64) -> String {
+        String::new()
+    }
+    fn token_warning(&self) -> Option<&'static str> {
+        None
+    }
+}
+
+#[test]
+fn tick_cache_dedup_same_repo_branch_single_api_call() {
+    let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let cache: super::TickCache =
+        std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+    let provider = super::CachedCiProvider {
+        inner: Box::new(CountingProvider {
+            call_count: std::sync::Arc::clone(&call_count),
+            runs: vec![CiRun {
+                id: 1,
+                conclusion: Some("success".into()),
+                head_sha: "aaa".into(),
+                url: String::new(),
+                name: "CI".into(),
+            }],
+        }),
+        poll_cache: std::sync::Arc::clone(&cache),
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let r1 = provider.poll_runs("owner/repo", "feat/x").await.unwrap();
+        let r2 = provider.poll_runs("owner/repo", "feat/x").await.unwrap();
+        assert!(matches!(r1, CiPollResult::Runs { .. }));
+        assert!(matches!(r2, CiPollResult::Runs { .. }));
+    });
+    assert_eq!(
+        call_count.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "same repo@branch must hit cache on second call"
+    );
+}
+
+#[test]
+fn tick_cache_different_repo_branch_independent_calls() {
+    let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let cache: super::TickCache =
+        std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+    let provider = super::CachedCiProvider {
+        inner: Box::new(CountingProvider {
+            call_count: std::sync::Arc::clone(&call_count),
+            runs: vec![],
+        }),
+        poll_cache: std::sync::Arc::clone(&cache),
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let _ = provider.poll_runs("owner/repo", "feat/a").await;
+        let _ = provider.poll_runs("owner/repo", "feat/b").await;
+    });
+    assert_eq!(
+        call_count.load(std::sync::atomic::Ordering::Relaxed),
+        2,
+        "different branches must each call the API independently"
+    );
+}
+
+#[test]
+fn tick_cache_does_not_persist_across_ticks() {
+    let call_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    // Tick 1
+    {
+        let cache: super::TickCache =
+            std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+        let provider = super::CachedCiProvider {
+            inner: Box::new(CountingProvider {
+                call_count: std::sync::Arc::clone(&call_count),
+                runs: vec![],
+            }),
+            poll_cache: cache,
+        };
+        rt.block_on(async {
+            let _ = provider.poll_runs("owner/repo", "main").await;
+        });
+    }
+    // Tick 2 — fresh cache
+    {
+        let cache: super::TickCache =
+            std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+        let provider = super::CachedCiProvider {
+            inner: Box::new(CountingProvider {
+                call_count: std::sync::Arc::clone(&call_count),
+                runs: vec![],
+            }),
+            poll_cache: cache,
+        };
+        rt.block_on(async {
+            let _ = provider.poll_runs("owner/repo", "main").await;
+        });
+    }
+    assert_eq!(
+        call_count.load(std::sync::atomic::Ordering::Relaxed),
+        2,
+        "each tick must create a fresh cache — no cross-tick sharing"
+    );
+}

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -130,7 +130,7 @@ pub struct CiRun {
 /// the provider exposes them. The tick-loop feeds these into
 /// [`crate::daemon::ci_watch::adaptive_interval`] to widen the next poll's effective interval
 /// before the limit is exhausted (preempt vs. recover).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CiPollResult {
     /// Runs retrieved successfully (may be empty). Rate-limit fields
     /// are `None` for providers that don't expose the quota headers


### PR DESCRIPTION
## Summary
- Add `CachedCiProvider` wrapper that caches `poll_runs` results by `(repo, branch)` key within a single poll tick
- Cache lifetime = one `check_ci_watches_with_provider` call — no cross-tick sharing
- Prevents duplicate GitHub API calls when multiple watch files resolve to the same `repo@branch`
- `CiPollResult` now derives `Clone` to support cache storage

## Changes
- `provider.rs`: Add `Clone` derive to `CiPollResult`
- `poller.rs`: Add `CachedCiProvider` struct + `CiProvider` impl + `TickCache` type alias; wrap provider in `check_ci_watches_with_provider` loop
- `poller_tests.rs`: 3 tests — same repo@branch dedup, different branch independence, cross-tick isolation

## Test plan
- [x] `tick_cache_dedup_same_repo_branch_single_api_call` — same (repo, branch) → 1 API call
- [x] `tick_cache_different_repo_branch_independent_calls` — different branches → separate API calls
- [x] `tick_cache_does_not_persist_across_ticks` — fresh cache per tick
- [x] All 168 existing ci_watch tests pass
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)