### PR TITLE
perf(ci_watch): single-load-per-tick for watch state I/O

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -45,10 +45,8 @@ impl CiProvider for CachedCiProvider {
         self.inner.token_warning()
     }
 }
-use super::registry::{
-    ci_watches_dir, remove_watch, update_watch_state, update_watch_state_with_notify,
-};
-use super::sweep::{bump_consecutive_skips_and_maybe_notify, clear_stall_and_maybe_notify_resumed};
+use super::registry::{ci_watches_dir, flush_watch_state, remove_watch};
+use super::sweep::{bump_consecutive_skips_and_maybe_notify, clear_stall_state};
 use super::watch_state::WatchState;
 use super::WATCH_TTL_HOURS;
 
@@ -64,7 +62,9 @@ use super::provider::{
 #[cfg(test)]
 use super::registry::{parse_subscribers, watch_filename};
 #[cfg(test)]
-use super::sweep::{gc_stale_watches, startup_sweep, STALL_THRESHOLD};
+use super::sweep::{
+    clear_stall_and_maybe_notify_resumed, gc_stale_watches, startup_sweep, STALL_THRESHOLD,
+};
 #[cfg(test)]
 use super::watcher::check_ci_watches;
 
@@ -240,13 +240,7 @@ enum SkipReason {
 
 struct PollContext {
     repo: String,
-    branch: String,
     subscribers: Vec<String>,
-    last_run_id: Option<u64>,
-    head_sha: Option<String>,
-    last_notified_sha: Option<String>,
-    last_notified_conclusion: Option<String>,
-    last_stale_emitted_sha: Option<String>,
     stamped_watch: WatchState,
 }
 
@@ -295,13 +289,7 @@ fn prepare_poll_context(
     stamped.effective_interval_secs = Some(effective_interval);
     Ok(PollContext {
         repo: watch.repo.clone(),
-        branch: watch.branch.clone(),
         subscribers,
-        last_run_id: watch.last_run_id,
-        head_sha: watch.head_sha.clone(),
-        last_notified_sha: watch.last_notified_head_sha.clone(),
-        last_notified_conclusion: watch.last_notified_conclusion.clone(),
-        last_stale_emitted_sha: watch.last_stale_emitted_sha.clone(),
         stamped_watch: stamped,
     })
 }
@@ -353,25 +341,24 @@ pub(super) fn check_ci_watches_with_provider(
                 let home = home.to_path_buf();
                 let watch_path = path.clone();
                 let registry = Arc::clone(registry);
+                let PollContext {
+                    repo,
+                    subscribers,
+                    stamped_watch,
+                } = ctx;
                 // fire-and-forget: ci_check is one-shot per poll cycle
                 shared_ci_runtime().spawn(async move {
                     if let Err(e) = ci_check_repo(
                         &home,
                         &watch_path,
-                        &ctx.repo,
-                        &ctx.branch,
-                        &ctx.subscribers,
-                        ctx.last_run_id,
-                        ctx.head_sha.as_deref(),
-                        ctx.last_notified_sha.as_deref(),
-                        ctx.last_notified_conclusion.as_deref(),
-                        ctx.last_stale_emitted_sha.as_deref(),
+                        stamped_watch,
+                        subscribers,
                         &registry,
                         provider.as_ref(),
                     )
                     .await
                     {
-                        tracing::warn!(repo = %ctx.repo, error = %e, "CI check failed");
+                        tracing::warn!(repo = %repo, error = %e, "CI check failed");
                     }
                 });
             }
@@ -741,42 +728,56 @@ struct NotifyOutcome {
 /// (item 2). The audit string for `remove_watch` joins all subscribers
 /// with commas so event-log readers can see the full membership at the
 /// moment of removal.
-#[allow(clippy::too_many_arguments)]
+/// Single-load-per-tick entry point: receives the pre-loaded `WatchState`
+/// from the caller, passes `&mut` to sub-functions, and flushes once at
+/// the end when state has changed.
 async fn ci_check_repo(
     home: &Path,
     watch_path: &Path,
-    repo: &str,
-    branch: &str,
-    subscribers: &[String],
-    last_run_id: Option<u64>,
-    prev_head_sha: Option<&str>,
-    last_notified_sha: Option<&str>,
-    last_notified_conclusion: Option<&str>,
-    last_stale_emitted_sha: Option<&str>,
+    mut state: WatchState,
+    subscribers: Vec<String>,
     registry: &AgentRegistry,
     provider: &dyn CiProvider,
 ) -> anyhow::Result<()> {
+    let snapshot = state.clone();
+    let repo = state.repo.clone();
+    let branch = state.branch.clone();
     let ctx = CiCheckCtx {
         home,
         watch_path,
-        repo,
-        branch,
-        subscribers,
+        repo: &repo,
+        branch: &branch,
+        subscribers: &subscribers,
     };
-    if check_and_remove_terminal_pr(&ctx, provider).await? {
+    if check_and_remove_terminal_pr(&ctx, &state, provider).await? {
         return Ok(());
     }
-    check_and_alert_mergeable(&ctx, provider).await;
+    check_and_alert_mergeable(&ctx, &mut state, provider).await;
+    let prev_head_sha = state.head_sha.clone();
+    let last_notified_sha = state.last_notified_head_sha.clone();
+    let last_notified_conclusion = state.last_notified_conclusion.clone();
+    let last_stale_emitted_sha = state.last_stale_emitted_sha.clone();
     let tracking = RunTracking {
-        last_run_id,
-        prev_head_sha,
-        last_notified_sha,
-        last_notified_conclusion,
-        last_stale_emitted_sha,
+        last_run_id: state.last_run_id,
+        prev_head_sha: prev_head_sha.as_deref(),
+        last_notified_sha: last_notified_sha.as_deref(),
+        last_notified_conclusion: last_notified_conclusion.as_deref(),
+        last_stale_emitted_sha: last_stale_emitted_sha.as_deref(),
     };
-    let pr = match poll_ci_runs(&ctx, &tracking, provider).await? {
-        Some(pr) => pr,
-        None => return Ok(()),
+    let pr = match poll_ci_runs(&ctx, &tracking, &mut state, provider).await {
+        Ok(Some(pr)) => pr,
+        Ok(None) => {
+            if state != snapshot {
+                flush_watch_state(watch_path, &state);
+            }
+            return Ok(());
+        }
+        Err(e) => {
+            if state != snapshot {
+                flush_watch_state(watch_path, &state);
+            }
+            return Err(e);
+        }
     };
     let to_notify = select_runs_to_notify(
         &pr.runs,
@@ -785,7 +786,14 @@ async fn ci_check_repo(
     );
     if to_notify.is_empty() {
         if let Some(id) = pr.effective_last_run_id {
-            update_watch_state(ctx.watch_path, Some(id), &pr.current_sha);
+            state.last_run_id = Some(id);
+            if !pr.current_sha.is_empty() {
+                state.head_sha = Some(pr.current_sha.clone());
+            }
+            state.last_terminal_seen_at = Some(chrono::Utc::now().to_rfc3339());
+        }
+        if state != snapshot {
+            flush_watch_state(watch_path, &state);
         }
         return Ok(());
     }
@@ -795,26 +803,25 @@ async fn ci_check_repo(
         tracking.last_notified_sha,
         tracking.last_notified_conclusion,
     );
-    let outcome = fan_out_notifications(&ctx, &pr, &deduped, &tracking, registry, provider).await;
-    persist_watch_state(&ctx, &pr, &outcome);
+    let outcome =
+        fan_out_notifications(&ctx, &state, &pr, &deduped, &tracking, registry, provider).await;
+    persist_watch_state(&ctx, &pr, &outcome, &mut state);
+    if state != snapshot {
+        flush_watch_state(watch_path, &state);
+    }
     Ok(())
 }
 
 async fn check_and_remove_terminal_pr(
     ctx: &CiCheckCtx<'_>,
+    state: &WatchState,
     provider: &dyn CiProvider,
 ) -> anyhow::Result<bool> {
     let PrState::Terminal { merged } = provider.check_pr_terminal(ctx.repo, ctx.branch).await
     else {
         return Ok(false);
     };
-    let Ok(content) = std::fs::read_to_string(ctx.watch_path) else {
-        return Ok(false);
-    };
-    let Ok(watch) = serde_json::from_str::<WatchState>(&content) else {
-        return Ok(false);
-    };
-    if let Some(expires_at) = watch.expires_at.as_deref() {
+    if let Some(expires_at) = state.expires_at.as_deref() {
         if let Ok(exp) = chrono::DateTime::parse_from_rfc3339(expires_at) {
             let watch_age =
                 exp.with_timezone(&chrono::Utc) - chrono::Duration::hours(WATCH_TTL_HOURS);
@@ -852,42 +859,28 @@ async fn check_and_remove_terminal_pr(
     Ok(true)
 }
 
-async fn check_and_alert_mergeable(ctx: &CiCheckCtx<'_>, provider: &dyn CiProvider) {
+async fn check_and_alert_mergeable(
+    ctx: &CiCheckCtx<'_>,
+    state: &mut WatchState,
+    provider: &dyn CiProvider,
+) {
     const MERGEABLE_RECHECK_INTERVAL_SECS: i64 = 300;
-    let (should_recheck, prev_mergeable) = match std::fs::read_to_string(ctx.watch_path)
-        .ok()
-        .and_then(|c| serde_json::from_str::<WatchState>(&c).ok())
-    {
-        Some(w) => {
-            let last = w
-                .last_mergeable_check_at
-                .as_deref()
-                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-                .map(|d| d.with_timezone(&chrono::Utc));
-            let now = chrono::Utc::now();
-            let elapsed_ok = last
-                .map(|d| {
-                    now.signed_duration_since(d).num_seconds() >= MERGEABLE_RECHECK_INTERVAL_SECS
-                })
-                .unwrap_or(true);
-            (elapsed_ok, w.last_mergeable_state)
-        }
-        None => (true, None),
-    };
+    let last = state
+        .last_mergeable_check_at
+        .as_deref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.with_timezone(&chrono::Utc));
+    let now = chrono::Utc::now();
+    let should_recheck = last
+        .map(|d| now.signed_duration_since(d).num_seconds() >= MERGEABLE_RECHECK_INTERVAL_SECS)
+        .unwrap_or(true);
     if !should_recheck {
         return;
     }
+    let prev_mergeable = state.last_mergeable_state.clone();
     let new_state = provider.check_pr_mergeable(ctx.repo, ctx.branch).await;
-    let now_rfc3339 = chrono::Utc::now().to_rfc3339();
-    if let Ok(content) = std::fs::read_to_string(ctx.watch_path) {
-        if let Ok(mut w) = serde_json::from_str::<WatchState>(&content) {
-            w.last_mergeable_state = Some(new_state.as_str().to_string());
-            w.last_mergeable_check_at = Some(now_rfc3339);
-            if let Ok(out) = serde_json::to_string_pretty(&w) {
-                let _ = crate::store::atomic_write(ctx.watch_path, out.as_bytes());
-            }
-        }
-    }
+    state.last_mergeable_state = Some(new_state.as_str().to_string());
+    state.last_mergeable_check_at = Some(now.to_rfc3339());
     if matches!(new_state, MergeableState::Conflicting)
         && prev_mergeable.as_deref() != Some("CONFLICTING")
     {
@@ -904,6 +897,7 @@ async fn check_and_alert_mergeable(ctx: &CiCheckCtx<'_>, provider: &dyn CiProvid
 async fn poll_ci_runs(
     ctx: &CiCheckCtx<'_>,
     tracking: &RunTracking<'_>,
+    state: &mut WatchState,
     provider: &dyn CiProvider,
 ) -> anyhow::Result<Option<PollResult>> {
     let poll_result = provider.poll_runs(ctx.repo, ctx.branch).await?;
@@ -914,17 +908,7 @@ async fn poll_ci_runs(
             rate_limit_reset,
         } => {
             if let Some(reset_epoch) = rate_limit_reset {
-                if let Ok(content) = std::fs::read_to_string(ctx.watch_path) {
-                    if let Ok(mut watch) = serde_json::from_str::<WatchState>(&content) {
-                        watch.rate_limit_until = Some(reset_epoch);
-                        let _ = crate::store::atomic_write(
-                            ctx.watch_path,
-                            serde_json::to_string_pretty(&watch)
-                                .unwrap_or_default()
-                                .as_bytes(),
-                        );
-                    }
-                }
+                state.rate_limit_until = Some(reset_epoch);
             }
             let notify_msg = match rate_limit_reset {
                 Some(reset) => format!(
@@ -951,31 +935,13 @@ async fn poll_ci_runs(
             rate_limit_remaining,
             rate_limit_limit,
         } => {
-            if rate_limit_remaining.is_some() || rate_limit_limit.is_some() {
-                if let Ok(content) = std::fs::read_to_string(ctx.watch_path) {
-                    if let Ok(mut watch) = serde_json::from_str::<WatchState>(&content) {
-                        if let Some(r) = rate_limit_remaining {
-                            watch.rate_limit_remaining = Some(r);
-                        }
-                        if let Some(l) = rate_limit_limit {
-                            watch.rate_limit_limit = Some(l);
-                        }
-                        let _ = crate::store::atomic_write(
-                            ctx.watch_path,
-                            serde_json::to_string_pretty(&watch)
-                                .unwrap_or_default()
-                                .as_bytes(),
-                        );
-                    }
-                }
+            if let Some(r) = rate_limit_remaining {
+                state.rate_limit_remaining = Some(r);
             }
-            clear_stall_and_maybe_notify_resumed(
-                ctx.home,
-                ctx.watch_path,
-                ctx.repo,
-                ctx.branch,
-                ctx.subscribers,
-            );
+            if let Some(l) = rate_limit_limit {
+                state.rate_limit_limit = Some(l);
+            }
+            clear_stall_state(state, ctx.home, ctx.repo, ctx.branch, ctx.subscribers);
             if runs.is_empty() {
                 return Ok(None);
             }
@@ -1012,6 +978,7 @@ async fn poll_ci_runs(
 
 async fn fan_out_notifications(
     ctx: &CiCheckCtx<'_>,
+    state: &WatchState,
     pr: &PollResult,
     deduped: &[(usize, u64, &str)],
     tracking: &RunTracking<'_>,
@@ -1077,18 +1044,15 @@ async fn fan_out_notifications(
 
             let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
             let supersede_token = format!("ci-{}-{}", run_id, sha);
-            let action_target_on_success: Option<String> = if conclusion == Some("success") {
-                std::fs::read_to_string(ctx.watch_path)
-                    .ok()
-                    .and_then(|c| serde_json::from_str::<WatchState>(&c).ok())
-                    .and_then(|w| w.next_after_ci.filter(|s| !s.is_empty()))
+            let action_target_on_success: Option<&str> = if conclusion == Some("success") {
+                state.next_after_ci.as_deref().filter(|s| !s.is_empty())
             } else {
                 None
             };
             let fleet_cfg =
                 crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home)).ok();
             for sub in ctx.subscribers {
-                if action_target_on_success.as_deref() == Some(sub.as_str()) {
+                if action_target_on_success == Some(sub.as_str()) {
                     continue;
                 }
                 let in_registry = agent::lock_registry(registry).contains_key(sub);
@@ -1131,73 +1095,77 @@ async fn fan_out_notifications(
     }
 }
 
-fn persist_watch_state(ctx: &CiCheckCtx<'_>, pr: &PollResult, outcome: &NotifyOutcome) {
+fn persist_watch_state(
+    ctx: &CiCheckCtx<'_>,
+    pr: &PollResult,
+    outcome: &NotifyOutcome,
+    state: &mut WatchState,
+) {
     if outcome.new_notified_sha.is_some() {
-        if let Ok(content) = std::fs::read_to_string(ctx.watch_path) {
-            if let Ok(watch) = serde_json::from_str::<WatchState>(&content) {
-                if let Some(next) = watch.next_after_ci.as_deref().filter(|s| !s.is_empty()) {
-                    let last_conclusion = aggregate_conclusion_for_sha_filtered(
-                        &pr.runs,
-                        &pr.current_sha,
-                        watch.required_checks.as_deref(),
-                    );
-                    if last_conclusion == Some("success") {
-                        let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
-                        let pr_number =
-                            crate::daemon::pr_state::load(ctx.home, ctx.repo, ctx.branch)
-                                .map(|s| s.pr_number);
-                        let task_id = watch.task_id.as_deref();
-                        let msg = make_ci_ready_for_action_msg(
-                            ctx.repo,
-                            ctx.branch,
-                            &repo_branch_key,
-                            Some(&pr.current_sha),
-                            pr_number,
-                            task_id,
-                        );
-                        let _ = crate::inbox::enqueue_with_idle_hint(ctx.home, next, msg);
-                    }
-                }
-
-                let last_conclusion = aggregate_conclusion_for_sha(&pr.runs, &pr.current_sha);
-                let conclusion = match last_conclusion {
-                    Some("success") => crate::daemon::pr_state::CiConclusion::Green,
-                    Some(other) => {
-                        crate::daemon::pr_state::CiConclusion::Failed { conclusion: other }
-                    }
-                    None => crate::daemon::pr_state::CiConclusion::Pending,
-                };
-                let subscribers = watch.subscriber_names();
-                let review_class = match watch
-                    .review_class
-                    .as_deref()
-                    .map(|s| s.to_ascii_lowercase())
-                    .as_deref()
-                {
-                    Some("dual") => crate::daemon::pr_state::ReviewClass::Dual,
-                    _ => crate::daemon::pr_state::ReviewClass::Single,
-                };
-                crate::daemon::pr_state::record_ci_result(
-                    ctx.home,
+        if let Some(next) = state.next_after_ci.as_deref().filter(|s| !s.is_empty()) {
+            let last_conclusion = aggregate_conclusion_for_sha_filtered(
+                &pr.runs,
+                &pr.current_sha,
+                state.required_checks.as_deref(),
+            );
+            if last_conclusion == Some("success") {
+                let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
+                let pr_number = crate::daemon::pr_state::load(ctx.home, ctx.repo, ctx.branch)
+                    .map(|s| s.pr_number);
+                let task_id = state.task_id.as_deref();
+                let msg = make_ci_ready_for_action_msg(
                     ctx.repo,
                     ctx.branch,
-                    &pr.current_sha,
-                    conclusion,
-                    subscribers,
-                    review_class,
+                    &repo_branch_key,
+                    Some(&pr.current_sha),
+                    pr_number,
+                    task_id,
                 );
+                let _ = crate::inbox::enqueue_with_idle_hint(ctx.home, next, msg);
             }
         }
+
+        let last_conclusion = aggregate_conclusion_for_sha(&pr.runs, &pr.current_sha);
+        let conclusion = match last_conclusion {
+            Some("success") => crate::daemon::pr_state::CiConclusion::Green,
+            Some(other) => crate::daemon::pr_state::CiConclusion::Failed { conclusion: other },
+            None => crate::daemon::pr_state::CiConclusion::Pending,
+        };
+        let subscriber_names = state.subscriber_names();
+        let review_class = match state
+            .review_class
+            .as_deref()
+            .map(|s| s.to_ascii_lowercase())
+            .as_deref()
+        {
+            Some("dual") => crate::daemon::pr_state::ReviewClass::Dual,
+            _ => crate::daemon::pr_state::ReviewClass::Single,
+        };
+        crate::daemon::pr_state::record_ci_result(
+            ctx.home,
+            ctx.repo,
+            ctx.branch,
+            &pr.current_sha,
+            conclusion,
+            subscriber_names,
+            review_class,
+        );
     }
 
-    update_watch_state_with_notify(
-        ctx.watch_path,
-        Some(outcome.max_notified_id),
-        &pr.current_sha,
-        outcome.new_notified_sha.as_deref(),
-        outcome.new_notified_conclusion.as_deref(),
-        outcome.new_stale_emitted_sha.as_deref(),
-    );
+    state.last_run_id = Some(outcome.max_notified_id);
+    if !pr.current_sha.is_empty() {
+        state.head_sha = Some(pr.current_sha.clone());
+    }
+    if let Some(sha) = &outcome.new_notified_sha {
+        state.last_notified_head_sha = Some(sha.clone());
+    }
+    if let Some(c) = &outcome.new_notified_conclusion {
+        state.last_notified_conclusion = Some(c.clone());
+    }
+    if let Some(s) = &outcome.new_stale_emitted_sha {
+        state.last_stale_emitted_sha = Some(s.clone());
+    }
+    state.last_terminal_seen_at = Some(chrono::Utc::now().to_rfc3339());
 }
 
 #[cfg(test)]

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -1047,6 +1047,7 @@ fn run_ci_check(
         serde_json::to_string_pretty(watch_json).unwrap(),
     )
     .unwrap();
+    let state: WatchState = serde_json::from_value(watch_json.clone()).unwrap();
 
     let registry: AgentRegistry =
         Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
@@ -1057,14 +1058,8 @@ fn run_ci_check(
     rt.block_on(ci_check_repo(
         dir,
         &watch_path,
-        repo,
-        branch,
-        &subscribers,
-        watch_json["last_run_id"].as_u64(),
-        watch_json["head_sha"].as_str(),
-        watch_json["last_notified_head_sha"].as_str(),
-        watch_json["last_notified_conclusion"].as_str(),
-        watch_json["last_stale_emitted_sha"].as_str(),
+        state,
+        subscribers,
         &registry,
         provider,
     ))
@@ -1294,14 +1289,8 @@ fn mock_pr_terminal_clears_watch() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["agent1".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["agent1".to_string()],
         &registry,
         &provider,
     ))
@@ -2090,14 +2079,8 @@ fn auto_clear_skips_young_watch() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat-new",
-        &["agent1".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["agent1".to_string()],
         &registry,
         &provider,
     ))
@@ -2139,14 +2122,8 @@ fn auto_clear_fires_on_old_watch_with_merged_pr() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat-old",
-        &["agent1".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["agent1".to_string()],
         &registry,
         &provider,
     ))
@@ -2186,14 +2163,8 @@ fn fresh_branch_no_pr_classified_as_pending() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["agent1".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["agent1".to_string()],
         &registry,
         &provider,
     ))
@@ -2226,14 +2197,8 @@ fn branch_with_open_pr_classified_as_active() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["agent1".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["agent1".to_string()],
         &registry,
         &provider,
     ))
@@ -2275,14 +2240,8 @@ fn branch_with_merged_pr_classified_as_terminal() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat-merged",
-        &["agent1".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["agent1".to_string()],
         &registry,
         &provider,
     ))
@@ -2368,14 +2327,8 @@ fn subscriber_fan_out_notifies_every_member() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["lead".to_string(), "dev".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string(), "dev".to_string()],
         &registry,
         &provider,
     ))
@@ -2467,14 +2420,8 @@ fn ci_pass_subscriber_inbox_anti_regression() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["lead".to_string(), "dev".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string(), "dev".to_string()],
         &registry,
         &provider,
     ))
@@ -2519,14 +2466,8 @@ fn ci_pass_chain_target_gets_durable_inbox_entry() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["lead".to_string(), "dev".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string(), "dev".to_string()],
         &registry,
         &provider,
     ))
@@ -2571,14 +2512,8 @@ fn ci_pass_chain_target_excluded_from_subscriber_loop() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["lead".to_string(), "dev".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string(), "dev".to_string()],
         &registry,
         &provider,
     ))
@@ -2694,14 +2629,8 @@ fn ci_ready_for_action_carries_full_head_sha() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["lead".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string()],
         &registry,
         &provider,
     ))
@@ -2785,14 +2714,8 @@ fn ci_ready_for_action_carries_pr_number_from_pr_state() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["lead".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string()],
         &registry,
         &provider,
     ))
@@ -2855,14 +2778,8 @@ fn ci_ready_for_action_carries_task_id_from_watch_sidecar() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["lead".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string()],
         &registry,
         &provider,
     ))
@@ -2941,14 +2858,8 @@ fn ci_pass_chain_target_inbox_kind_is_ready_for_action() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["lead".to_string(), "dev".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string(), "dev".to_string()],
         &registry,
         &provider,
     ))
@@ -3000,18 +2911,12 @@ fn ci_pass_chain_target_no_double_fire_on_overlap() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &[
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec![
             "lead".to_string(),
             "dev".to_string(),
             "reviewer".to_string(),
         ],
-        None,
-        None,
-        None,
-        None,
-        None,
         &registry,
         &provider,
     ))
@@ -4069,14 +3974,8 @@ fn pass_dedupe_drops_ci_pass_for_subscriber_who_is_action_target() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["a".to_string(), "b".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["a".to_string(), "b".to_string()],
         &registry,
         &provider,
     ))
@@ -4148,14 +4047,8 @@ fn pass_dedupe_failure_does_not_drop_ci_fail_for_action_target() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["a".to_string(), "b".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["a".to_string(), "b".to_string()],
         &registry,
         &provider,
     ))
@@ -4221,14 +4114,8 @@ fn pass_dedupe_non_action_target_subscribers_receive_ci_pass() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &["a".to_string(), "b".to_string(), "c".to_string()],
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["a".to_string(), "b".to_string(), "c".to_string()],
         &registry,
         &provider,
     ))
@@ -4423,6 +4310,7 @@ fn run_one_poll_cycle(
     let subscribers = parse_subscribers(watch);
     let watch_path = ci_dir.join(watch_filename(repo, branch));
     std::fs::write(&watch_path, serde_json::to_string_pretty(watch).unwrap()).unwrap();
+    let state: WatchState = serde_json::from_value(watch.clone()).unwrap();
     let registry: AgentRegistry =
         Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -4432,14 +4320,8 @@ fn run_one_poll_cycle(
     let _ = rt.block_on(ci_check_repo(
         dir,
         &watch_path,
-        repo,
-        branch,
-        &subscribers,
-        None,
-        None,
-        None,
-        None,
-        None,
+        state,
+        subscribers,
         &registry,
         provider,
     ));
@@ -4927,14 +4809,8 @@ fn ci_check_repo_success_no_pty_inject_only_inbox() {
     rt.block_on(ci_check_repo(
         &dir,
         &watch_path,
-        "o/r",
-        "feat",
-        &subscribers,
-        None,
-        None,
-        None,
-        None,
-        None,
+        serde_json::from_value(watch.clone()).unwrap(),
+        subscribers,
         &registry,
         &provider,
     ))

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -154,9 +154,9 @@ pub(super) fn update_watch_state_with_notify(
 }
 
 /// Flush an in-memory WatchState to disk under the ci-watch flock.
-/// Merge-safe: reads the current file under lock and preserves
-/// concurrent subscription changes (`subscribers`, `instance`,
-/// `next_after_ci`) while applying poll-owned field updates.
+/// Merge-safe: starts from the on-disk state (preserving all
+/// control-plane fields) and only applies poll-owned deltas from
+/// the in-memory snapshot.
 pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::WatchState) {
     let lock_path = watch_path.with_extension("lock");
     let _lock = match crate::store::acquire_file_lock(&lock_path) {
@@ -166,17 +166,30 @@ pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::W
             return;
         }
     };
-    let current = match std::fs::read_to_string(watch_path)
+    let mut merged = match std::fs::read_to_string(watch_path)
         .ok()
         .and_then(|c| serde_json::from_str::<super::watch_state::WatchState>(&c).ok())
     {
         Some(c) => c,
         None => return, // file deleted by concurrent unwatch — respect deletion
     };
-    let mut merged = state.clone();
-    merged.subscribers = current.subscribers;
-    merged.instance = current.instance;
-    merged.next_after_ci = current.next_after_ci;
+    // Apply only poll-owned fields from in-memory state.
+    merged.last_run_id = state.last_run_id;
+    merged.head_sha = state.head_sha.clone();
+    merged.last_polled_at = state.last_polled_at;
+    merged.effective_interval_secs = state.effective_interval_secs;
+    merged.last_terminal_seen_at = state.last_terminal_seen_at.clone();
+    merged.last_notified_head_sha = state.last_notified_head_sha.clone();
+    merged.last_notified_conclusion = state.last_notified_conclusion.clone();
+    merged.last_stale_emitted_sha = state.last_stale_emitted_sha.clone();
+    merged.last_mergeable_state = state.last_mergeable_state.clone();
+    merged.last_mergeable_check_at = state.last_mergeable_check_at.clone();
+    merged.rate_limit_until = state.rate_limit_until;
+    merged.rate_limit_remaining = state.rate_limit_remaining;
+    merged.rate_limit_limit = state.rate_limit_limit;
+    merged.consecutive_skips = state.consecutive_skips;
+    merged.stalled_notified = state.stalled_notified;
+    merged.stalled_since_ms = state.stalled_since_ms;
     if let Err(e) = crate::store::atomic_write(
         watch_path,
         serde_json::to_string_pretty(&merged)
@@ -325,6 +338,70 @@ mod tests {
         assert!(
             !watch_path.exists(),
             "flush must not resurrect a deleted watch file"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn flush_preserves_concurrent_metadata_update() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-flush-meta-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let watch_path = dir.join("meta.json");
+
+        let initial = super::super::watch_state::WatchState {
+            repo: "o/r".into(),
+            branch: "feat".into(),
+            expires_at: Some("2026-01-01T00:00:00Z".into()),
+            task_id: Some("t-old".into()),
+            required_checks: None,
+            ..Default::default()
+        };
+        std::fs::write(
+            &watch_path,
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        // Poller snapshot taken at tick start (stale metadata).
+        let mut stale = initial.clone();
+        stale.last_run_id = Some(42);
+        stale.head_sha = Some("abc".into());
+
+        // Concurrent `ci watch` updates metadata on disk.
+        let mut updated = initial;
+        updated.expires_at = Some("2026-06-01T00:00:00Z".into());
+        updated.task_id = Some("t-new".into());
+        updated.required_checks = Some(vec!["build".into()]);
+        std::fs::write(
+            &watch_path,
+            serde_json::to_string_pretty(&updated).unwrap(),
+        )
+        .unwrap();
+
+        flush_watch_state(&watch_path, &stale);
+
+        let result: super::super::watch_state::WatchState =
+            serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+        assert_eq!(result.last_run_id, Some(42), "poll field must be applied");
+        assert_eq!(result.head_sha.as_deref(), Some("abc"));
+        assert_eq!(
+            result.expires_at.as_deref(),
+            Some("2026-06-01T00:00:00Z"),
+            "concurrent expires_at update must survive flush"
+        );
+        assert_eq!(
+            result.task_id.as_deref(),
+            Some("t-new"),
+            "concurrent task_id update must survive flush"
+        );
+        assert_eq!(
+            result.required_checks.as_deref(),
+            Some(&["build".to_string()][..]),
+            "concurrent required_checks update must survive flush"
         );
 
         std::fs::remove_dir_all(&dir).ok();

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -166,15 +166,17 @@ pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::W
             return;
         }
     };
-    let mut merged = state.clone();
-    if let Some(current) = std::fs::read_to_string(watch_path)
+    let current = match std::fs::read_to_string(watch_path)
         .ok()
         .and_then(|c| serde_json::from_str::<super::watch_state::WatchState>(&c).ok())
     {
-        merged.subscribers = current.subscribers;
-        merged.instance = current.instance;
-        merged.next_after_ci = current.next_after_ci;
-    }
+        Some(c) => c,
+        None => return, // file deleted by concurrent unwatch — respect deletion
+    };
+    let mut merged = state.clone();
+    merged.subscribers = current.subscribers;
+    merged.instance = current.instance;
+    merged.next_after_ci = current.next_after_ci;
     if let Err(e) = crate::store::atomic_write(
         watch_path,
         serde_json::to_string_pretty(&merged)
@@ -296,6 +298,33 @@ mod tests {
             subs,
             vec!["A"],
             "concurrent unwatch of B must be preserved, not overwritten"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn flush_respects_concurrent_deletion() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-flush-delete-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let watch_path = dir.join("deleted.json");
+
+        let stale = super::super::watch_state::WatchState {
+            repo: "o/r".into(),
+            branch: "feat".into(),
+            last_run_id: Some(99),
+            ..Default::default()
+        };
+
+        // File does not exist (concurrent unwatch deleted it).
+        assert!(!watch_path.exists());
+        flush_watch_state(&watch_path, &stale);
+        assert!(
+            !watch_path.exists(),
+            "flush must not resurrect a deleted watch file"
         );
 
         std::fs::remove_dir_all(&dir).ok();

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -94,15 +94,19 @@ pub fn watch_filename(repo: &str, branch: &str) -> String {
 }
 
 /// Persist updated tracking state (last_run_id + head_sha) to the watch file.
+/// Retained for tests that exercise the legacy per-field write path.
+#[cfg(test)]
+#[allow(dead_code)]
 pub(super) fn update_watch_state(watch_path: &Path, run_id: Option<u64>, head_sha: &str) {
     update_watch_state_with_notify(watch_path, run_id, head_sha, None, None, None);
 }
 
 /// Persist tracking state including last_notified_head_sha,
 /// last_notified_conclusion (#786), and last_stale_emitted_sha
-/// (#1026). All optional fields are written only when caller
-/// supplies them — preserves the "no state churn when no
-/// notification fires" invariant.
+/// (#1026). Retained for tests; production path uses
+/// `flush_watch_state` after in-memory mutation.
+#[cfg(test)]
+#[allow(dead_code)]
 pub(super) fn update_watch_state_with_notify(
     watch_path: &Path,
     run_id: Option<u64>,
@@ -146,6 +150,28 @@ pub(super) fn update_watch_state_with_notify(
                 tracing::warn!(path = %watch_path.display(), error = %e, "ci-watch state write failed");
             }
         }
+    }
+}
+
+/// Flush an in-memory WatchState to disk under the ci-watch flock.
+/// Used by the single-load-per-tick path so the entire tick mutates
+/// the struct in-memory and writes once at the end.
+pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::WatchState) {
+    let lock_path = watch_path.with_extension("lock");
+    let _lock = match crate::store::acquire_file_lock(&lock_path) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!(path = %lock_path.display(), error = %e, "failed to acquire ci-watch lock, skipping flush");
+            return;
+        }
+    };
+    if let Err(e) = crate::store::atomic_write(
+        watch_path,
+        serde_json::to_string_pretty(state)
+            .unwrap_or_default()
+            .as_bytes(),
+    ) {
+        tracing::warn!(path = %watch_path.display(), error = %e, "ci-watch state flush failed");
     }
 }
 

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -154,8 +154,9 @@ pub(super) fn update_watch_state_with_notify(
 }
 
 /// Flush an in-memory WatchState to disk under the ci-watch flock.
-/// Used by the single-load-per-tick path so the entire tick mutates
-/// the struct in-memory and writes once at the end.
+/// Merge-safe: reads the current file under lock and preserves
+/// concurrent subscription changes (`subscribers`, `instance`,
+/// `next_after_ci`) while applying poll-owned field updates.
 pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::WatchState) {
     let lock_path = watch_path.with_extension("lock");
     let _lock = match crate::store::acquire_file_lock(&lock_path) {
@@ -165,9 +166,18 @@ pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::W
             return;
         }
     };
+    let mut merged = state.clone();
+    if let Some(current) = std::fs::read_to_string(watch_path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<super::watch_state::WatchState>(&c).ok())
+    {
+        merged.subscribers = current.subscribers;
+        merged.instance = current.instance;
+        merged.next_after_ci = current.next_after_ci;
+    }
     if let Err(e) = crate::store::atomic_write(
         watch_path,
-        serde_json::to_string_pretty(state)
+        serde_json::to_string_pretty(&merged)
             .unwrap_or_default()
             .as_bytes(),
     ) {
@@ -228,5 +238,66 @@ mod tests {
             f.len() > 21,
             "post-#943 filename length must exceed legacy DefaultHasher length (21): got {f}"
         );
+    }
+
+    #[test]
+    fn flush_preserves_concurrent_unwatch() {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-flush-merge-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let watch_path = dir.join("test.json");
+
+        let initial = super::super::watch_state::WatchState {
+            repo: "o/r".into(),
+            branch: "feat".into(),
+            subscribers: Some(vec![
+                super::super::watch_state::Subscriber {
+                    instance: "A".into(),
+                    subscribed_at: None,
+                },
+                super::super::watch_state::Subscriber {
+                    instance: "B".into(),
+                    subscribed_at: None,
+                },
+            ]),
+            ..Default::default()
+        };
+        std::fs::write(
+            &watch_path,
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        let mut stale = initial.clone();
+        stale.last_run_id = Some(42);
+        stale.head_sha = Some("abc123".into());
+
+        let mut on_disk = initial;
+        on_disk.subscribers = Some(vec![super::super::watch_state::Subscriber {
+            instance: "A".into(),
+            subscribed_at: None,
+        }]);
+        std::fs::write(
+            &watch_path,
+            serde_json::to_string_pretty(&on_disk).unwrap(),
+        )
+        .unwrap();
+
+        flush_watch_state(&watch_path, &stale);
+
+        let result: super::super::watch_state::WatchState =
+            serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+        assert_eq!(result.last_run_id, Some(42), "poll fields must be applied");
+        assert_eq!(result.head_sha.as_deref(), Some("abc123"));
+        let subs: Vec<String> = result.subscriber_names();
+        assert_eq!(
+            subs,
+            vec!["A"],
+            "concurrent unwatch of B must be preserved, not overwritten"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -75,8 +75,9 @@ pub(super) fn bump_consecutive_skips_and_maybe_notify(
 }
 
 /// Sprint 54 P0-5 helper: clear the stall state on the first successful
-/// poll after a stall window. Fans out `[ci-watch-resumed]` exactly
-/// once per resume — symmetry with the stalled path.
+/// poll after a stall window. Retained for tests; production path uses
+/// `clear_stall_state` with in-memory mutation.
+#[cfg(test)]
 pub(super) fn clear_stall_and_maybe_notify_resumed(
     home: &Path,
     watch_path: &Path,
@@ -107,6 +108,32 @@ pub(super) fn clear_stall_and_maybe_notify_resumed(
     ) {
         tracing::warn!(path = %watch_path.display(), error = %e, "ci-watch stall-clear write failed");
     }
+    if was_stalled {
+        let body =
+            format!("[ci-watch-resumed] {repo}@{branch}: poll resumed after rate-limit backoff");
+        fan_out_health_event(home, repo, branch, subscribers, "ci-watch-resumed", body);
+    }
+}
+
+/// In-memory variant of [`clear_stall_and_maybe_notify_resumed`] — clears
+/// stall fields on the provided `WatchState` and emits the resume
+/// notification if the watch was stalled.  The caller is responsible for
+/// flushing the state to disk.
+pub(super) fn clear_stall_state(
+    state: &mut super::watch_state::WatchState,
+    home: &Path,
+    repo: &str,
+    branch: &str,
+    subscribers: &[String],
+) {
+    let was_stalled = state.stalled_notified.unwrap_or(false);
+    let had_skips = state.consecutive_skips.unwrap_or(0) > 0;
+    if !was_stalled && !had_skips {
+        return;
+    }
+    state.consecutive_skips = Some(0);
+    state.stalled_notified = Some(false);
+    state.stalled_since_ms = None;
     if was_stalled {
         let body =
             format!("[ci-watch-resumed] {repo}@{branch}: poll resumed after rate-limit backoff");

--- a/src/daemon/ci_watch/watch_state.rs
+++ b/src/daemon/ci_watch/watch_state.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Subscriber {
     pub instance: String,
     #[serde(default)]
     pub subscribed_at: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct WatchState {
     #[serde(default)]
     pub repo: String,


### PR DESCRIPTION
## Summary
- Refactored `ci_check_repo` to accept an owned `WatchState` and pass `&mut` to all sub-functions, replacing 5–11 independent file read/write cycles per tick with a single load (by caller) + single conditional flush at exit
- Added `flush_watch_state` (locked atomic write) and `clear_stall_state` (in-memory stall clearing) helpers
- Derived `PartialEq` on `WatchState`/`Subscriber` for dirty-tracking — state is only written back when it actually changed

## Test plan
- [x] All 186 ci_watch tests pass (0 regressions)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt` clean
- [x] Rate-limit error path correctly flushes state before propagating error
- [ ] CI green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)