### PR TITLE
fix: resolve backend label in handle_spawn + log deploy spawn errors (#1261)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -149,7 +149,7 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
     }
     let command = params["backend"]
         .as_str()
-        .map(String::from)
+        .map(|s| crate::backend::Backend::parse_str(s).command_string())
         .unwrap_or_else(|| {
             crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
                 .ok()

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -353,13 +353,25 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
                 params["env"] = serde_json::to_value(env).unwrap_or(serde_json::Value::Null);
             }
         }
-        let _ = crate::api::call(
+        let spawn_result = crate::api::call(
             home,
             &serde_json::json!({
                 "method": crate::api::method::SPAWN,
                 "params": params,
             }),
         );
+        match spawn_result {
+            Ok(ref v) if v.get("ok").and_then(|b| b.as_bool()) == Some(false) => {
+                let err = v.get("error").and_then(|e| e.as_str()).unwrap_or("unknown");
+                tracing::error!(instance = %inst_name, error = %err,
+                    "deploy_template: Phase 3 spawn failed");
+            }
+            Err(e) => {
+                tracing::error!(instance = %inst_name, error = %e,
+                    "deploy_template: Phase 3 spawn call failed");
+            }
+            _ => {}
+        }
     }
 
     // Phase 4 — create the team. Route through the CREATE_TEAM API (not a


### PR DESCRIPTION
Closes #1261

## Bug 1: Backend label not resolved
`handle_spawn` used `params["backend"]` as raw command string. Labels like "claude-code" or "kiro" weren't resolved to actual binary names. Fix: route through `Backend::parse_str() → command_string()`.

## Bug 2: Deployment swallows spawn errors  
`deploy_template` Phase 3 used `let _ =` on spawn API call, silently discarding failures. Fix: check result and `tracing::error` on failure.