### PR TITLE
poc(screenshot): TestBackend buffer → SVG verification (#1257)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -382,6 +382,21 @@ pub(crate) fn handle_clear_blocked_reason(params: &Value, ctx: &HandlerCtx) -> V
     }
 }
 
+/// #1257: TUI screenshot — sends ScreenshotRequest to app event loop,
+/// waits for SVG response. Only works in TUI mode.
+pub(crate) fn handle_tui_screenshot(ctx: &HandlerCtx) -> Value {
+    let Some(notifier) = ctx.notifier else {
+        return json!({"ok": false, "error": "tui_screenshot requires TUI mode (daemon-only mode not supported)"});
+    };
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    notifier.notify(crate::api::ApiEvent::ScreenshotRequest(tx));
+    // Block waiting for the app loop to render and respond.
+    match rx.blocking_recv() {
+        Ok(svg) => json!({"ok": true, "svg": svg}),
+        Err(_) => json!({"ok": false, "error": "screenshot render failed (channel dropped)"}),
+    }
+}
+
 pub(crate) fn handle_pane_snapshot(params: &Value, ctx: &HandlerCtx) -> Value {
     let name = match params["name"].as_str() {
         Some(n) => n,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -25,7 +25,7 @@ pub type ConfigRegistry = Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>
 
 /// Domain events emitted by the API server when agents or teams change.
 /// These are independent of any UI representation.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum ApiEvent {
     InstanceCreated {
         name: String,
@@ -56,6 +56,9 @@ pub enum ApiEvent {
         target_tab: String,
         split_dir: PaneMoveSplitDir,
     },
+    /// #1257: TUI screenshot request. App event loop renders to TestBackend
+    /// and sends back the SVG string via the oneshot channel.
+    ScreenshotRequest(tokio::sync::oneshot::Sender<String>),
 }
 
 /// Direction to split the destination tab's focused pane when the target tab
@@ -179,6 +182,7 @@ pub mod method {
     pub const MCP_TOOL: &str = "mcp_tool";
     pub const MCP_TOOLS_LIST: &str = "mcp_tools_list";
     pub const PANE_SNAPSHOT: &str = "pane_snapshot";
+    pub const TUI_SCREENSHOT: &str = "tui_screenshot";
     pub const VERIFY_PUSH: &str = "verify_push";
 }
 
@@ -478,6 +482,7 @@ fn handle_session(
                 method::UPDATE_TEAM => handlers::team::handle_update_team(params, &ctx),
                 method::MOVE_PANE => handlers::instance::handle_move_pane(params, &ctx),
                 method::PANE_SNAPSHOT => handlers::instance::handle_pane_snapshot(params, &ctx),
+                method::TUI_SCREENSHOT => handlers::instance::handle_tui_screenshot(&ctx),
                 method::VERIFY_PUSH => handlers::verify_push::handle_verify_push(params),
                 method::SET_BLOCKED_REASON => {
                     handlers::instance::handle_set_blocked_reason(params, &ctx)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -614,12 +614,53 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             }
             recv(tui_event_rx) -> ev => {
                 if let Ok(event) = ev {
-                    tui_events::handle_tui_event(
-                        event,
-                        &mut layout,
-                        &registry,
-                        &wakeup_tx,
-                    );
+                    // #1257: handle screenshot request directly (needs terminal access).
+                    if let TuiEvent::ScreenshotRequest(tx) = event {
+                        let svg = {
+                            let size = terminal.size().unwrap_or_default();
+                            let backend = ratatui::backend::TestBackend::new(
+                                if size.width > 0 { size.width } else { 120 },
+                                if size.height > 0 { size.height } else { 40 },
+                            );
+                            let mut snap_term = ratatui::Terminal::new(backend).expect("TestBackend::new cannot fail");
+                            let binary_stale = daemon_binary_stale.load(std::sync::atomic::Ordering::Relaxed);
+                            let _ = snap_term.draw(|frame| {
+                                crate::render::render(
+                                    frame,
+                                    &mut layout,
+                                    key_handler.in_repeat(),
+                                    &registry,
+                                    telegram_status,
+                                    binary_stale,
+                                );
+                                // Render overlay (same as normal draw path).
+                                match &overlay {
+                                    Overlay::Tasks { items, col, row, mode, view } => {
+                                        crate::render::render_tasks(frame, items, *col, *row, mode, *view, &home);
+                                    }
+                                    Overlay::Decisions { items, scroll } => {
+                                        crate::render::render_decisions(frame, items, *scroll);
+                                    }
+                                    Overlay::Help => {
+                                        crate::render::render_help(frame);
+                                    }
+                                    Overlay::Command { input } => {
+                                        crate::render::render_command_palette(frame, input);
+                                    }
+                                    _ => {}
+                                }
+                            });
+                            crate::screenshot::buffer_to_svg(snap_term.backend())
+                        };
+                        let _ = tx.send(svg);
+                    } else {
+                        tui_events::handle_tui_event(
+                            event,
+                            &mut layout,
+                            &registry,
+                            &wakeup_tx,
+                        );
+                    }
                     needs_resize = true;
                 }
             }

--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -10,7 +10,7 @@ use crate::layout::{Layout, MovePlacement, SplitDir, Tab};
 /// Events sent from the API server to the TUI event loop when agents or teams
 /// are created/deleted via MCP tools. The TUI reacts by auto-creating or
 /// removing tabs/panes.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) enum TuiEvent {
     InstanceCreated {
         name: String,
@@ -49,6 +49,8 @@ pub(crate) enum TuiEvent {
         target_tab: String,
         split_dir: SplitDir,
     },
+    /// #1257: TUI screenshot request from MCP tool.
+    ScreenshotRequest(tokio::sync::oneshot::Sender<String>),
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -116,6 +118,7 @@ impl crate::api::ApiNotifier for TuiNotifier {
                     split_dir: dir,
                 }
             }
+            crate::api::ApiEvent::ScreenshotRequest(tx) => TuiEvent::ScreenshotRequest(tx),
         };
         if let Err(e) = self.tx.try_send(tui_event) {
             tracing::warn!(error = %e, "TUI event send failed");
@@ -167,6 +170,9 @@ pub(super) fn handle_tui_event(
             split_dir,
         } => {
             handle_pane_moved(&agent, &target_tab, split_dir, layout);
+        }
+        TuiEvent::ScreenshotRequest(_) => {
+            // Handled directly in app event loop (needs terminal access).
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ mod render;
 mod runtime;
 pub mod runtime_config;
 mod schedules;
+mod screenshot;
 mod service;
 mod skills;
 mod snapshot;

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -727,6 +727,21 @@ fn dispatch_pane_snapshot(ctx: &HandlerCtx<'_>) -> Value {
     instance::handle_pane_snapshot(ctx.home, ctx.args)
 }
 
+fn dispatch_tui_screenshot(ctx: &HandlerCtx<'_>) -> Value {
+    match crate::api::call(
+        ctx.home,
+        &serde_json::json!({"method": crate::api::method::TUI_SCREENSHOT, "params": {}}),
+    ) {
+        Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+            serde_json::json!({"svg": resp["svg"]})
+        }
+        Ok(resp) => {
+            serde_json::json!({"error": resp["error"].as_str().unwrap_or("tui_screenshot failed")})
+        }
+        Err(e) => serde_json::json!({"error": format!("tui_screenshot: {e}")}),
+    }
+}
+
 fn dispatch_task_sweep_config(ctx: &HandlerCtx<'_>) -> Value {
     task::handle_task_sweep_config(ctx.home, ctx.args)
 }
@@ -925,6 +940,11 @@ static REGISTERED: &[HandlerEntry] = &[
         actions: None,
     },
     HandlerEntry {
+        name: "tui_screenshot",
+        handler: dispatch_tui_screenshot,
+        actions: None,
+    },
+    HandlerEntry {
         name: "task_sweep_config",
         handler: dispatch_task_sweep_config,
         actions: None,
@@ -1016,11 +1036,12 @@ mod tests {
                 "reply",
                 "set_display_name",
                 "pane_snapshot",
+                "tui_screenshot",
                 "task_sweep_config",
                 "restart_daemon",
             ]
         );
-        assert_eq!(registered_handlers().len(), 32);
+        assert_eq!(registered_handlers().len(), 33);
     }
 
     /// Coverage test: every tool name advertised by

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -126,6 +126,8 @@ fn instance_tools() -> Vec<Value> {
                 "target": {"type": "string", "description": "Target instance name"},
                 "lines": {"type": "integer", "description": "Number of lines to return (default 100, max 10000)"}
             }, "required": ["target"]}}),
+        json!({"name": "tui_screenshot", "description": "Capture the current TUI state as an SVG image. Only works in TUI mode (not daemon-only). Returns SVG string.",
+            "inputSchema": {"type": "object", "properties": {}}}),
     ]
 }
 
@@ -497,8 +499,8 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            32,
-            "#1085: 31 + config(get/set/list) = 32. \
+            33,
+            "#1085: 32 + tui_screenshot = 33. \
              Current tools: {:?}",
             tools
                 .iter()

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -1,0 +1,116 @@
+//! POC #1257: TUI screenshot → SVG.
+//!
+//! Renders the TUI state into a TestBackend buffer, then converts
+//! the cell grid to an SVG document with monospace text + colors.
+
+use ratatui::backend::TestBackend;
+use ratatui::style::Color;
+
+/// Cell dimensions in the SVG (pixels).
+const CELL_W: u16 = 8;
+const CELL_H: u16 = 16;
+const FONT_SIZE: u16 = 14;
+
+/// Render a TestBackend buffer to an SVG string.
+pub fn buffer_to_svg(backend: &TestBackend) -> String {
+    let buf = backend.buffer().clone();
+    let width = buf.area.width;
+    let height = buf.area.height;
+    let svg_w = width as u32 * CELL_W as u32;
+    let svg_h = height as u32 * CELL_H as u32;
+
+    let mut svg = String::with_capacity(svg_w as usize * svg_h as usize / 2);
+    svg.push_str(&format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" width="{svg_w}" height="{svg_h}" style="background:#1e1e2e">"#
+    ));
+    svg.push_str(&format!(
+        r#"<style>text{{font-family:monospace;font-size:{FONT_SIZE}px;dominant-baseline:hanging}}</style>"#
+    ));
+
+    for y in 0..height {
+        for x in 0..width {
+            let cell = &buf[(x, y)];
+            let symbol = cell.symbol();
+            if symbol == " " || symbol.is_empty() {
+                continue;
+            }
+            let fg = color_to_hex(cell.fg);
+            let px = x as u32 * CELL_W as u32;
+            let py = y as u32 * CELL_H as u32 + 2;
+            let escaped = xml_escape(symbol);
+            svg.push_str(&format!(
+                r#"<text x="{px}" y="{py}" fill="{fg}">{escaped}</text>"#
+            ));
+        }
+    }
+
+    svg.push_str("</svg>");
+    svg
+}
+
+/// Convert ratatui Color to hex. Falls back to #cdd6f4 (catppuccin text).
+fn color_to_hex(c: Color) -> &'static str {
+    match c {
+        Color::Black => "#45475a",
+        Color::Red => "#f38ba8",
+        Color::Green => "#a6e3a1",
+        Color::Yellow => "#f9e2af",
+        Color::Blue => "#89b4fa",
+        Color::Magenta => "#cba6f7",
+        Color::Cyan => "#94e2d5",
+        Color::White | Color::Reset => "#cdd6f4",
+        Color::Gray => "#6c7086",
+        Color::DarkGray => "#585b70",
+        Color::LightRed => "#f38ba8",
+        Color::LightGreen => "#a6e3a1",
+        Color::LightYellow => "#f9e2af",
+        Color::LightBlue => "#89b4fa",
+        Color::LightMagenta => "#cba6f7",
+        Color::LightCyan => "#94e2d5",
+        _ => "#cdd6f4",
+    }
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// POC test: render a simple widget to TestBackend, convert to SVG.
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use ratatui::widgets::{Block, Borders, Paragraph};
+    use ratatui::Terminal;
+
+    #[test]
+    fn poc_buffer_to_svg_produces_valid_svg() {
+        let backend = TestBackend::new(40, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let block = Block::default().borders(Borders::ALL).title(" Task Board ");
+                let paragraph = Paragraph::new("Hello from POC!").block(block);
+                frame.render_widget(paragraph, frame.area());
+            })
+            .unwrap();
+        let svg = buffer_to_svg(terminal.backend());
+        assert!(svg.starts_with("<svg"), "must start with <svg");
+        assert!(svg.ends_with("</svg>"), "must end with </svg>");
+        assert!(
+            svg.len() > 200,
+            "SVG must have content, got {} bytes",
+            svg.len()
+        );
+        // Verify text elements are present.
+        assert!(svg.contains("<text"), "SVG must contain text elements");
+        std::fs::write("/tmp/tui_screenshot_poc.svg", &svg).unwrap();
+        eprintln!(
+            "Written to /tmp/tui_screenshot_poc.svg ({} bytes)",
+            svg.len()
+        );
+    }
+}


### PR DESCRIPTION
## POC: TUI Screenshot → SVG

Verifies the approach for #1257.

### How it works
1. Render TUI to `ratatui::TestBackend` (off-screen)
2. Iterate the cell buffer (character + fg color per cell)
3. Emit SVG with `<text>` elements at grid positions

### Results
- ✅ Zero new dependencies
- ✅ ~80 lines for the converter
- ✅ Valid SVG output with colored text
- ✅ Catppuccin palette for color mapping

### Next steps (Phase 1)
- Wire as MCP tool `tui_screenshot`
- Use actual TUI render path (not test widget)
- Add bg color rectangles for highlighted cells