### PR TITLE
fix(dispatch_idle): disable sidecar tracking for kind=query (#1268)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -183,7 +183,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
         None
     };
 
-    let mut msg = {
+    let msg = {
         let mut thread_id = params["thread_id"].as_str().map(String::from);
         let parent_id = params["parent_id"].as_str().map(String::from);
 
@@ -494,17 +494,7 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
                 explicit_threshold,
             )
         {
-            // #1129: kind=query without correlation_id makes the sidecar
-            // unreachable by mark_resolved (keys on correlation_id). Auto-
-            // generate one and stamp it on the outbound message so the
-            // target's reply carries it back.
-            let outbound_corr = if outbound_corr.is_none() && kind_str == "query" {
-                let generated = format!("qcorr-{}", chrono::Utc::now().format("%Y%m%d%H%M%S%6f"));
-                msg.correlation_id = Some(generated.clone());
-                Some(generated)
-            } else {
-                outbound_corr.map(String::from)
-            };
+            let outbound_corr = outbound_corr.map(String::from);
             let _ = crate::daemon::dispatch_idle::record_dispatch(
                 ctx.home,
                 from,
@@ -2262,14 +2252,14 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #1129: kind=query without correlation_id auto-generates one so
-    /// the reply can resolve the dispatch_idle sidecar.
+    /// #1268: kind=query must NOT produce a dispatch_idle sidecar.
+    /// (Replaces #1129 test — query sidecars caused false-positive
+    /// watchdog nudges on broadcast queries.)
     #[test]
-    fn hook_kind_query_without_correlation_id_auto_generates_and_reply_resolves() {
-        let home = tmp_home("1129-query-autogen");
+    fn hook_kind_query_does_not_create_dispatch_sidecar() {
+        let home = tmp_home("1268-query-no-sidecar");
         write_fixup_fleet(&home, &["fixup-lead", "fixup-dev"]);
         let ctx = test_ctx(&home);
-        // Dispatch kind=query with explicit threshold but NO correlation_id.
         let result = handle_send(
             &json!({
                 "from": "fixup-lead",
@@ -2281,40 +2271,10 @@ mod tests {
             &ctx,
         );
         assert_eq!(result["ok"], true, "query must succeed: {result}");
-        // Sidecar must exist with a non-None correlation_id starting with "qcorr-".
         let pending = crate::daemon::dispatch_idle::list_pending(&home);
-        let entry = pending
-            .iter()
-            .find(|p| p.dispatcher == "fixup-lead" && p.target == "fixup-dev")
-            .expect("sidecar must be recorded for query dispatch");
-        let corr = entry
-            .correlation_id
-            .as_ref()
-            .expect("correlation_id must be auto-generated, not None");
         assert!(
-            corr.starts_with("qcorr-"),
-            "auto-generated correlation_id must use qcorr- prefix: {corr}"
-        );
-        // Simulate target replying with the auto-generated correlation_id.
-        let report_result = handle_send(
-            &json!({
-                "from": "fixup-dev",
-                "target": "fixup-lead",
-                "text": "all good",
-                "kind": "report",
-                "correlation_id": corr,
-            }),
-            &ctx,
-        );
-        assert_eq!(report_result["ok"], true);
-        let pending_after = crate::daemon::dispatch_idle::list_pending(&home);
-        let resolved = pending_after
-            .iter()
-            .find(|p| p.correlation_id.as_deref() == Some(corr.as_str()))
-            .expect("sidecar must still exist on disk");
-        assert_eq!(
-            resolved.status, "resolved",
-            "reply with auto-generated correlation_id must resolve the sidecar"
+            pending.iter().all(|p| p.target != "fixup-dev"),
+            "kind=query must not create a dispatch sidecar: {pending:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -1,6 +1,6 @@
 //! L1: cross-team-safe dispatch-idle watchdog.
 //!
-//! Tracks `send(kind=task|query)` calls that carry an explicit
+//! Tracks `send(kind=task)` calls that carry an explicit
 //! `expect_reply_within_secs` opt-in. When the expected reply hasn't
 //! arrived inside the threshold window, fires a
 //! `dispatch_idle_threshold_exceeded` event to the dispatcher's inbox.
@@ -63,7 +63,7 @@ pub(crate) struct PendingDispatch {
     /// `task_id` / thread correlation id from the original dispatch.
     #[serde(default)]
     pub(crate) correlation_id: Option<String>,
-    /// Original dispatch kind: `"task"` or `"query"`.
+    /// Original dispatch kind: `"task"` (#1268: query excluded).
     #[serde(default)]
     pub(crate) expected_kind: String,
     #[serde(default)]
@@ -120,7 +120,7 @@ pub(crate) fn record_dispatch(
     if dispatcher.is_empty() || target.is_empty() || threshold_secs <= 0 {
         return None;
     }
-    if !matches!(expected_kind, "task" | "query") {
+    if !matches!(expected_kind, "task") {
         return None;
     }
     let dir = pending_dir(home);


### PR DESCRIPTION
## Summary
- Remove `kind=query` from `record_dispatch`'s accepted kinds guard — only `kind=task` creates dispatch_idle sidecars now
- Remove `qcorr-*` auto-generation for query sends (was unreachable by `mark_resolved` because recipients reply with their own correlation_ids)
- Replace #1129 test with #1268 test asserting no sidecar is created for queries

Fixes false-positive watchdog nudges on broadcast `kind=query` (18+ spurious notifications per session).

## Test plan
- [x] `hook_kind_query_does_not_create_dispatch_sidecar` — verifies query sends produce no sidecar
- [x] All 43 messaging handler tests pass
- [x] All 32 dispatch_idle tests pass
- [x] No compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)