### PR TITLE
fix: write .agend-managed marker unconditionally on checkout (#1275)

### DIFF
--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -257,10 +257,7 @@ mod tests {
 
     #[test]
     fn flush_preserves_concurrent_unwatch() {
-        let dir = std::env::temp_dir().join(format!(
-            "agend-flush-merge-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("agend-flush-merge-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let watch_path = dir.join("test.json");
 
@@ -279,11 +276,7 @@ mod tests {
             ]),
             ..Default::default()
         };
-        std::fs::write(
-            &watch_path,
-            serde_json::to_string_pretty(&initial).unwrap(),
-        )
-        .unwrap();
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&initial).unwrap()).unwrap();
 
         let mut stale = initial.clone();
         stale.last_run_id = Some(42);
@@ -294,11 +287,7 @@ mod tests {
             instance: "A".into(),
             subscribed_at: None,
         }]);
-        std::fs::write(
-            &watch_path,
-            serde_json::to_string_pretty(&on_disk).unwrap(),
-        )
-        .unwrap();
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&on_disk).unwrap()).unwrap();
 
         flush_watch_state(&watch_path, &stale);
 
@@ -318,10 +307,7 @@ mod tests {
 
     #[test]
     fn flush_respects_concurrent_deletion() {
-        let dir = std::env::temp_dir().join(format!(
-            "agend-flush-delete-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("agend-flush-delete-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let watch_path = dir.join("deleted.json");
 
@@ -345,10 +331,7 @@ mod tests {
 
     #[test]
     fn flush_preserves_concurrent_metadata_update() {
-        let dir = std::env::temp_dir().join(format!(
-            "agend-flush-meta-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("agend-flush-meta-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let watch_path = dir.join("meta.json");
 
@@ -360,11 +343,7 @@ mod tests {
             required_checks: None,
             ..Default::default()
         };
-        std::fs::write(
-            &watch_path,
-            serde_json::to_string_pretty(&initial).unwrap(),
-        )
-        .unwrap();
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&initial).unwrap()).unwrap();
 
         // Poller snapshot taken at tick start (stale metadata).
         let mut stale = initial.clone();
@@ -376,11 +355,7 @@ mod tests {
         updated.expires_at = Some("2026-06-01T00:00:00Z".into());
         updated.task_id = Some("t-new".into());
         updated.required_checks = Some(vec!["build".into()]);
-        std::fs::write(
-            &watch_path,
-            serde_json::to_string_pretty(&updated).unwrap(),
-        )
-        .unwrap();
+        std::fs::write(&watch_path, serde_json::to_string_pretty(&updated).unwrap()).unwrap();
 
         flush_watch_state(&watch_path, &stale);
 

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -121,27 +121,20 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
         Ok(o) if o.status.success() => {
             let mut resp =
                 json!({"path": worktree_path_str, "source": source_path, "branch": branch});
+            // #1275: write .agend-managed unconditionally so
+            // release_worktree and GC can always clean up.
+            let mut warnings: Vec<String> = Vec::new();
+            let marker_path = worktree_dir.join(crate::worktree_pool::MANAGED_MARKER);
+            if let Err(e) = std::fs::write(
+                &marker_path,
+                format!(
+                    "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
+                    chrono::Utc::now().to_rfc3339()
+                ),
+            ) {
+                warnings.push(format!("marker: {e}"));
+            }
             if bind {
-                // #779 P2 Option B: collect tail-op partial failures
-                // into a `warnings` array. `bound: true` remains
-                // load-bearing (lease succeeded — the main op went
-                // through); `warnings` flags degraded daemon-side
-                // state so callers can diagnose without grepping logs.
-                // Vec ordering preserves tail-op execution order
-                // (marker → bind_full → watch_ci) for positional
-                // semantics. Prefix convention: `<step>: <message>`
-                // — machine-greppable by callers.
-                let mut warnings: Vec<String> = Vec::new();
-                let marker_path = worktree_dir.join(crate::worktree_pool::MANAGED_MARKER);
-                if let Err(e) = std::fs::write(
-                    &marker_path,
-                    format!(
-                        "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
-                        chrono::Utc::now().to_rfc3339()
-                    ),
-                ) {
-                    warnings.push(format!("marker: {e}"));
-                }
                 if let Err(e) = crate::binding::bind_full(
                     home,
                     instance_name,
@@ -184,9 +177,9 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
                 resp["bound"] = json!(true);
                 resp["auto_created_branch"] = json!(auto_created_branch);
                 resp["fetch_attempted"] = json!(fetch_attempted);
-                if !warnings.is_empty() {
-                    resp["warnings"] = json!(warnings);
-                }
+            }
+            if !warnings.is_empty() {
+                resp["warnings"] = json!(warnings);
             }
             resp
         }

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -848,8 +848,8 @@ fn checkout_bind_false_default_preserves_detached_no_binding() {
 
     let wt_path = std::path::PathBuf::from(resp["path"].as_str().expect("path"));
     assert!(
-        !wt_path.join(crate::worktree_pool::MANAGED_MARKER).exists(),
-        ".agend-managed marker must NOT be written without bind:true"
+        wt_path.join(crate::worktree_pool::MANAGED_MARKER).exists(),
+        ".agend-managed marker must be written even without bind:true (#1275)"
     );
 
     let binding = crate::paths::runtime_dir(&home)


### PR DESCRIPTION
## Summary
- Move `.agend-managed` marker write out of the `if bind` block so all daemon-provisioned worktrees get the marker
- `bind=false` still skips `binding.json` and `ci_watch` arming — only the marker is unconditional
- Update test assertion: `checkout_bind_false_default_preserves_detached_no_binding` now expects marker to exist
- Includes `cargo fmt` fix for registry.rs (from merged PR #1264)

Fixes #1275 — `release_worktree` and GC can now clean up `bind=false` worktrees.

## Test plan
- [x] 15 `checkout_bind` tests pass (including updated `bind_false` test)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)