### PR TITLE
perf(tui): agent state snapshot per tick + fetch_live_agents TTL cache

### DIFF
--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -1,5 +1,7 @@
 //! Core rendering: main entry point, tab bar, status bar, pane tree.
 
+use std::collections::HashMap;
+
 use super::border::{render_border_grid, render_pane_titles};
 use crate::agent::{self, AgentRegistry};
 use crate::channel::TelegramStatus;
@@ -50,11 +52,26 @@ pub fn state_color(state: AgentState) -> Color {
     }
 }
 
-pub(super) fn get_agent_state(registry: &AgentRegistry, name: &str) -> AgentState {
+fn build_agent_state_snapshot(
+    layout: &Layout,
+    registry: &AgentRegistry,
+) -> HashMap<String, AgentState> {
     let reg = agent::lock_registry(registry);
-    reg.get(name)
-        .map(|h| h.core.lock().state.get_state())
-        .unwrap_or(AgentState::Idle)
+    let mut snapshot = HashMap::new();
+    for tab in &layout.tabs {
+        for id in tab.root().pane_ids() {
+            if let Some(pane) = tab.root().find_pane(id) {
+                if pane.backend.is_some() {
+                    snapshot.entry(pane.agent_name.clone()).or_insert_with(|| {
+                        reg.get(&pane.agent_name)
+                            .map(|h| h.core.lock().state.get_state())
+                            .unwrap_or(AgentState::Idle)
+                    });
+                }
+            }
+        }
+    }
+    snapshot
 }
 
 pub fn render(
@@ -74,18 +91,25 @@ pub fn render(
         ])
         .split(frame.area());
 
-    render_pane_tree(frame, chunks[1], layout, repeat_mode, registry);
-    render_tab_bar(frame, chunks[0], layout, registry);
+    let snapshot = build_agent_state_snapshot(layout, registry);
+    render_pane_tree(frame, chunks[1], layout, repeat_mode, &snapshot);
+    render_tab_bar(frame, chunks[0], layout, &snapshot);
     render_status_bar(frame, chunks[2], layout, telegram, binary_stale);
 }
 
 /// Get the highest-priority state across all panes in a tab.
-pub fn highest_priority_state(tab: &crate::layout::Tab, registry: &AgentRegistry) -> AgentState {
+pub fn highest_priority_state(
+    tab: &crate::layout::Tab,
+    snapshot: &HashMap<String, AgentState>,
+) -> AgentState {
     let mut best = AgentState::Idle;
     for id in tab.root().pane_ids() {
         if let Some(pane) = tab.root().find_pane(id) {
             if pane.backend.is_some() {
-                let s = get_agent_state(registry, &pane.agent_name);
+                let s = snapshot
+                    .get(&pane.agent_name)
+                    .copied()
+                    .unwrap_or(AgentState::Idle);
                 if s.priority() > best.priority() {
                     best = s;
                 }
@@ -96,7 +120,12 @@ pub fn highest_priority_state(tab: &crate::layout::Tab, registry: &AgentRegistry
 }
 
 /// SYNC: layout math (label width, spacing) must match tab_bar_hit_test() in app.rs.
-fn render_tab_bar(frame: &mut Frame, area: Rect, layout: &Layout, registry: &AgentRegistry) {
+fn render_tab_bar(
+    frame: &mut Frame,
+    area: Rect,
+    layout: &Layout,
+    snapshot: &HashMap<String, AgentState>,
+) {
     let mut spans = Vec::new();
 
     let drag_tab_target = layout
@@ -110,7 +139,7 @@ fn render_tab_bar(frame: &mut Frame, area: Rect, layout: &Layout, registry: &Age
         let is_reorder_target = layout
             .tab_reorder_target
             .is_some_and(|t| t == i && layout.tab_reorder_source.is_some_and(|s| s != i));
-        let state = highest_priority_state(tab, registry);
+        let state = highest_priority_state(tab, snapshot);
         let sc = state_color(state);
 
         let style = if is_drag_drop || is_reorder_target {
@@ -185,7 +214,7 @@ fn render_pane_tree(
     area: Rect,
     layout: &mut Layout,
     repeat_mode: bool,
-    registry: &AgentRegistry,
+    snapshot: &HashMap<String, AgentState>,
 ) {
     let tab = match layout.tabs.get_mut(layout.active) {
         Some(t) => t,
@@ -205,7 +234,7 @@ fn render_pane_tree(
 
     if tab.zoomed {
         if let Some(pane) = tab.root_mut().find_pane_mut(focus_id) {
-            let info = render_pane(frame, area, pane, true, false, registry, false, false);
+            let info = render_pane(frame, area, pane, true, false, snapshot, false, false);
             let infos = vec![info];
             render_border_grid(frame, &infos);
             render_pane_titles(frame, &infos);
@@ -228,7 +257,7 @@ fn render_pane_tree(
         &mut rects,
         &mut border_infos,
         repeat_mode,
-        registry,
+        snapshot,
         drag_source,
         drag_target,
     );
@@ -246,7 +275,7 @@ fn render_node(
     rects: &mut std::collections::HashMap<usize, (u16, u16, u16, u16)>,
     border_infos: &mut Vec<PaneBorderInfo>,
     repeat_mode: bool,
-    registry: &AgentRegistry,
+    snapshot: &HashMap<String, AgentState>,
     drag_source: Option<usize>,
     drag_target: Option<usize>,
 ) {
@@ -262,7 +291,7 @@ fn render_node(
                 pane,
                 focused,
                 repeat_mode,
-                registry,
+                snapshot,
                 is_drag_source,
                 is_drag_target,
             );
@@ -283,7 +312,7 @@ fn render_node(
                 rects,
                 border_infos,
                 repeat_mode,
-                registry,
+                snapshot,
                 drag_source,
                 drag_target,
             );
@@ -295,7 +324,7 @@ fn render_node(
                 rects,
                 border_infos,
                 repeat_mode,
-                registry,
+                snapshot,
                 drag_source,
                 drag_target,
             );
@@ -318,7 +347,7 @@ fn render_pane(
     pane: &mut crate::layout::Pane,
     focused: bool,
     repeat_mode: bool,
-    registry: &AgentRegistry,
+    snapshot: &HashMap<String, AgentState>,
     is_drag_source: bool,
     is_drag_target: bool,
 ) -> PaneBorderInfo {
@@ -329,7 +358,10 @@ fn render_pane(
     }
 
     let state = if pane.backend.is_some() {
-        get_agent_state(registry, &pane.agent_name)
+        snapshot
+            .get(&pane.agent_name)
+            .copied()
+            .unwrap_or(AgentState::Idle)
     } else {
         AgentState::Idle
     };
@@ -644,9 +676,8 @@ mod tests {
                 source: PaneSource::Local,
             },
         );
-        let registry: crate::agent::AgentRegistry =
-            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
-        let result = highest_priority_state(&tab, &registry);
+        let snapshot = HashMap::new();
+        let result = highest_priority_state(&tab, &snapshot);
         assert_eq!(result, AgentState::Idle);
     }
 

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -16,21 +16,36 @@ use super::panels_fleet::{render_fleet_view, render_monitor_view};
 /// The `None`-vs-`Some(empty)` distinction matters at the filter site:
 /// `None` falls back to current (unfiltered) behavior so a degraded
 /// daemon doesn't make the indicator misleadingly report "all idle".
-/// Per-render call cost is one localhost TCP round-trip; if the
-/// overlay's render frequency makes this a hotspot, a TTL cache can
-/// be slotted in here without changing the call site.
+/// Per-render call cost is one localhost TCP round-trip, amortised
+/// behind a 2-second TTL cache so consecutive frames reuse the
+/// previous result without a network call.
 ///
 /// #830: thin wrapper over `crate::runtime::list_live_agents` (the
 /// canonical helper consolidated when #830 became the fourth consumer
 /// of this pattern). The wrapper survives so the call site keeps the
 /// `tracing::warn!` observability hook that #827 added.
 fn fetch_live_agents(home: &std::path::Path) -> Option<HashSet<String>> {
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{Duration, Instant};
+
+    type Cache = (Option<Instant>, Option<HashSet<String>>);
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    const TTL: Duration = Duration::from_secs(2);
+
+    let cache = CACHE.get_or_init(|| Mutex::new((None, None)));
+    let Ok(mut guard) = cache.lock() else {
+        return crate::runtime::list_live_agents(home);
+    };
+    if guard.0.is_some_and(|ts| ts.elapsed() < TTL) {
+        return guard.1.clone();
+    }
     let result = crate::runtime::list_live_agents(home);
     if result.is_none() {
         tracing::warn!(
             "#827: api::call(LIST) failed — active-indicator ghost filter degrading to identity"
         );
     }
+    *guard = (Some(Instant::now()), result.clone());
     result
 }
 


### PR DESCRIPTION
## Summary
- **3A**: `fetch_live_agents` now uses a 2-second `OnceLock<Mutex<Cache>>` TTL cache, so consecutive TUI frames reuse the previous result instead of making a TCP round-trip to `api::call(LIST)` every frame
- **3C**: `build_agent_state_snapshot` locks the agent registry once per frame and builds a `HashMap<String, AgentState>` snapshot. The snapshot is passed through `render_tab_bar` → `render_pane_tree` → `render_node` → `render_pane` instead of the raw `AgentRegistry`, eliminating per-pane mutex locks

## Test plan
- [x] `cargo check` — compiles cleanly
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt -- --check` — formatted
- [x] All 39 render tests pass (`render::core_render`, `render::panels`, `render::border`, `render::overlay`, `render::panels_fleet`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)