### PR TITLE
perf(inbox): shrink drain lock scope + binding fail-closed

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -8,20 +8,21 @@ use std::path::Path;
 
 /// Write a binding for an agent (task assigned).
 ///
-/// #779 P2: `bind_full` now returns `Result`; this thin wrapper preserves
-/// the pre-#779-P2 silent semantic via `.ok()` so existing callers (tests
-/// + dispatch path) keep unit-return.
+/// Fail-closed: if lock acquisition or I/O fails, binding.json is NOT
+/// written and the error is logged. Pre-#1163 this silently proceeded
+/// via `.ok()`, breaking the serialization guarantee.
 #[allow(dead_code)] // Used by tests + auto-watch dispatch path
 pub fn bind(home: &Path, agent: &str, task_id: &str, branch: &str) {
-    let _ = bind_full(
+    if let Err(e) = bind_full(
         home,
         agent,
         task_id,
         branch,
         std::path::Path::new(""),
         std::path::Path::new(""),
-    )
-    .ok();
+    ) {
+        tracing::warn!(%agent, task_id, branch, error = %e, "bind failed (fail-closed)");
+    }
 }
 
 /// Write a full binding including worktree + source-repo paths.
@@ -407,6 +408,24 @@ mod tests {
         assert!(
             read(&home, agent).is_none(),
             "#1163: binding.json must not be written when lock fails"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bind_wrapper_fail_closed_on_lock_error() {
+        let home = tmp_home("bind-failclose");
+        let agent = "fc-agent";
+        let rt = crate::paths::runtime_dir(&home).join(agent);
+        std::fs::create_dir_all(&rt).unwrap();
+        let lock_path = rt.join(".binding.json.lock");
+        std::fs::create_dir_all(&lock_path).unwrap();
+
+        bind(&home, agent, "T-999", "branch");
+
+        assert!(
+            read(&home, agent).is_none(),
+            "bind() must not write binding.json when lock acquisition fails (fail-closed)"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -222,17 +222,19 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
         return Vec::new();
     }
 
-    match with_inbox_lock(home, name, |path| {
-        // Leftover from a crashed predecessor — consume it first, under lock
-        // to prevent duplicate delivery when two drain callers race.
+    // Phase 1 (locked): read file, mark read_at, write back.
+    // Side effects (dedup, heartbeat) are deferred to phase 2.
+    let (all_messages, newly_read) = match with_inbox_lock(home, name, |path| {
         let tmp = path.with_extension("draining");
         if tmp.exists() {
-            return read_drain_file(&tmp);
+            let msgs = read_drain_file(&tmp);
+            let flags = vec![true; msgs.len()];
+            return (msgs, flags);
         }
 
         let content = match std::fs::read_to_string(path) {
             Ok(c) => c,
-            Err(_) => return Vec::new(),
+            Err(_) => return (Vec::new(), Vec::new()),
         };
 
         let now = chrono::Utc::now().to_rfc3339();
@@ -256,7 +258,6 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
                 continue;
             }
             if msg.read_at.is_none() {
-                // M6: skip superseded messages — they are stale
                 if msg.superseded_by.is_some() {
                     msg.read_at = Some(now.clone());
                     newly_read.push(false);
@@ -264,9 +265,6 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
                     continue;
                 }
                 msg.read_at = Some(now.clone());
-                if let Some(ref id) = msg.id {
-                    crate::daemon::notification_dedup::global().mark_consumed(name, id);
-                }
                 newly_read.push(true);
             } else {
                 newly_read.push(false);
@@ -275,28 +273,6 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
         }
 
         let has_unread = newly_read.iter().any(|&b| b);
-
-        // Sprint 52: set reply_to on dequeue — last channel-sourced message wins.
-        if let Some(channel_msg) = all_messages
-            .iter()
-            .zip(newly_read.iter())
-            .rev()
-            .find(|(m, &nr)| nr && m.channel.is_some())
-            .map(|(m, _)| m)
-        {
-            let channel_name = match channel_msg.channel.as_ref().expect("checked") {
-                crate::channel::ChannelKind::Telegram => "telegram",
-                crate::channel::ChannelKind::Discord => "discord",
-            };
-            crate::daemon::heartbeat_pair::update_with(name, |p| {
-                p.reply_to_channel = Some(channel_name.to_string());
-                p.reply_to_input_id = Some(p.reply_to_input_id.unwrap_or(0) + 1);
-                p.reply_to_set_at_ms = crate::daemon::heartbeat_pair::now_ms() as i64;
-                p.mirror_dispatched_for_turn = false;
-                p.mirror_skip_until_next_turn = false;
-            });
-        }
-
         if has_unread {
             let write_tmp = path.with_extension("jsonl.tmp");
             let result = (|| -> anyhow::Result<()> {
@@ -317,20 +293,49 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
             }
         }
 
-        // Extract newly-read messages without cloning — consume all_messages
-        // after write-back (which only borrows).
-        all_messages
-            .into_iter()
-            .zip(newly_read)
-            .filter_map(|(msg, nr)| nr.then_some(msg))
-            .collect()
+        (all_messages, newly_read)
     }) {
-        Ok(msgs) => msgs,
+        Ok(pair) => pair,
         Err(e) => {
             tracing::warn!(error = %e, "inbox drain lock failed");
-            Vec::new()
+            return Vec::new();
+        }
+    };
+
+    // Phase 2 (unlocked): side effects that don't need file exclusion.
+    for (msg, &is_new) in all_messages.iter().zip(&newly_read) {
+        if is_new {
+            if let Some(ref id) = msg.id {
+                crate::daemon::notification_dedup::global().mark_consumed(name, id);
+            }
         }
     }
+
+    if let Some(channel_msg) = all_messages
+        .iter()
+        .zip(newly_read.iter())
+        .rev()
+        .find(|(m, &nr)| nr && m.channel.is_some())
+        .map(|(m, _)| m)
+    {
+        let channel_name = match channel_msg.channel.as_ref().expect("checked") {
+            crate::channel::ChannelKind::Telegram => "telegram",
+            crate::channel::ChannelKind::Discord => "discord",
+        };
+        crate::daemon::heartbeat_pair::update_with(name, |p| {
+            p.reply_to_channel = Some(channel_name.to_string());
+            p.reply_to_input_id = Some(p.reply_to_input_id.unwrap_or(0) + 1);
+            p.reply_to_set_at_ms = crate::daemon::heartbeat_pair::now_ms() as i64;
+            p.mirror_dispatched_for_turn = false;
+            p.mirror_skip_until_next_turn = false;
+        });
+    }
+
+    all_messages
+        .into_iter()
+        .zip(newly_read)
+        .filter_map(|(msg, nr)| nr.then_some(msg))
+        .collect()
 }
 
 fn read_drain_file(tmp: &Path) -> Vec<InboxMessage> {

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -2605,3 +2605,35 @@ fn m2_hint_uses_merged_enqueue_count() {
     assert!(got.contains("inbox=2"), "should show 2 unread: {got:?}");
     fs::remove_dir_all(&home).ok();
 }
+
+#[test]
+fn drain_marks_read_and_preserves_order_after_lock_shrink() {
+    let home = tmp_home("drain-lock-shrink");
+    enqueue(&home, "agent-ls", make_msg("a", "first")).unwrap();
+    enqueue(&home, "agent-ls", make_msg("b", "second")).unwrap();
+    enqueue(&home, "agent-ls", make_msg("c", "third")).unwrap();
+
+    let msgs = drain(&home, "agent-ls");
+    assert_eq!(msgs.len(), 3, "all three messages must be drained");
+    assert_eq!(msgs[0].from, "a");
+    assert_eq!(msgs[1].from, "b");
+    assert_eq!(msgs[2].from, "c");
+
+    // Verify read_at was set (persisted to file under lock)
+    let content = fs::read_to_string(storage::inbox_path_resolved(&home, "agent-ls")).unwrap();
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let m: InboxMessage = serde_json::from_str(line).unwrap();
+        assert!(
+            m.read_at.is_some(),
+            "all messages must have read_at set after drain: {:?}",
+            m.from
+        );
+    }
+
+    let second = drain(&home, "agent-ls");
+    assert!(second.is_empty(), "second drain must return empty");
+    fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary
- **Inbox drain lock scope**: Moved `notification_dedup::mark_consumed` and `heartbeat_pair::update_with` outside the flock critical section. These side effects don't need file exclusion — only the read→mark→write-back cycle requires the lock. Reduces contention window on busy agents.
- **binding.json.lock fail-closed**: `bind()` wrapper previously swallowed all errors from `bind_full()` via `.ok()`, silently proceeding when lock acquisition failed. Now uses `if let Err` with `tracing::warn` — binding.json is NOT written and the failure is visible.

## Test plan
- [x] `drain_marks_read_and_preserves_order_after_lock_shrink` — verifies drain correctness after restructuring
- [x] `bind_wrapper_fail_closed_on_lock_error` — verifies bind() fails closed when lock can't be acquired
- [x] All 125 existing inbox tests pass
- [x] All 12 existing binding tests pass
- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)