### PR TITLE
fix(pr-state): set dedup flag before terminal-state file removal (#1287)

### DIFF
--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -1636,20 +1636,34 @@ mod tests {
             state: GhPrState::Merged,
             merged_at: Some("2026-05-20T04:17:09Z".to_string()),
         };
-        let poller = MockGhPoller::new(vec![Ok(vec![merged_meta])]);
+        let poller = MockGhPoller::new(vec![Ok(vec![merged_meta.clone()])]);
 
         scan_and_emit_with(&home, &empty_registry(), &poller);
 
-        // File swept (Merged is terminal — gets removed).
-        assert!(
-            load(&home, "owner/repo", "feat/test").is_none(),
-            "Merged terminal → file swept"
+        // #1287: first scan emits but persists with dedup flag — file
+        // survives until next scan confirms already_emitted.
+        let persisted = load(&home, "owner/repo", "feat/test")
+            .expect("#1287: file must survive first scan with dedup flag");
+        assert_eq!(
+            persisted.ready_emitted_for_sha.as_deref(),
+            Some("sha-A"),
+            "#1287: ready_emitted_for_sha must be set after emit"
         );
-        // [pr-merged] in fixup-dev's inbox.
+        // [pr-merged] in dev's inbox.
         let msgs = crate::inbox::drain(&home, "dev");
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].kind.as_deref(), Some("pr-merged"));
         assert!(msgs[0].text.contains("pr-merged"));
+
+        // Second scan: already_emitted → remove without re-emitting.
+        let poller2 = MockGhPoller::new(vec![Ok(vec![merged_meta])]);
+        scan_and_emit_with(&home, &empty_registry(), &poller2);
+        assert!(
+            load(&home, "owner/repo", "feat/test").is_none(),
+            "second scan must sweep terminal file"
+        );
+        let msgs2 = crate::inbox::drain(&home, "dev");
+        assert!(msgs2.is_empty(), "#1287: no duplicate emit on second scan");
         let _ = std::fs::remove_dir_all(&home);
     }
 
@@ -1669,14 +1683,24 @@ mod tests {
             state: GhPrState::Closed,
             merged_at: None,
         };
-        let poller = MockGhPoller::new(vec![Ok(vec![closed_meta])]);
+        let poller = MockGhPoller::new(vec![Ok(vec![closed_meta.clone()])]);
 
         scan_and_emit_with(&home, &empty_registry(), &poller);
 
-        assert!(load(&home, "owner/repo", "feat/test").is_none());
+        // #1287: first scan emits + persists with dedup flag.
+        let persisted = load(&home, "owner/repo", "feat/test")
+            .expect("#1287: file must survive first scan with dedup flag");
+        assert_eq!(persisted.ready_emitted_for_sha.as_deref(), Some("sha-A"));
         let msgs = crate::inbox::drain(&home, "dev");
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].kind.as_deref(), Some("pr-closed-unmerged"));
+
+        // Second scan: already_emitted → remove without re-emitting.
+        let poller2 = MockGhPoller::new(vec![Ok(vec![closed_meta])]);
+        scan_and_emit_with(&home, &empty_registry(), &poller2);
+        assert!(load(&home, "owner/repo", "feat/test").is_none());
+        let msgs2 = crate::inbox::drain(&home, "dev");
+        assert!(msgs2.is_empty(), "#1287: no duplicate emit on second scan");
         let _ = std::fs::remove_dir_all(&home);
     }
 
@@ -1964,16 +1988,25 @@ mod tests {
             "fresh Merged MUST NOT have ready_emitted_for_sha set by suppress hook"
         );
 
-        // First scan emits normally.
+        // #1287: first scan emits + persists dedup flag (no removal).
         let poller = MockGhPoller::new(vec![Ok(vec![])]);
         scan_and_emit_with(&home, &empty_registry(), &poller);
-        assert!(
-            load(&home, "owner/repo", "feat/test").is_none(),
-            "fresh Merged file swept post-scan"
-        );
+        let persisted = load(&home, "owner/repo", "feat/test")
+            .expect("#1287: file survives first scan with dedup flag");
+        assert_eq!(persisted.ready_emitted_for_sha.as_deref(), Some("sha-B"));
         let msgs = crate::inbox::drain(&home, "dev");
         assert_eq!(msgs.len(), 1, "fresh Merged MUST emit [pr-merged]");
         assert_eq!(msgs[0].kind.as_deref(), Some("pr-merged"));
+
+        // Second scan: already_emitted → swept, no re-emit.
+        let poller2 = MockGhPoller::new(vec![Ok(vec![])]);
+        scan_and_emit_with(&home, &empty_registry(), &poller2);
+        assert!(
+            load(&home, "owner/repo", "feat/test").is_none(),
+            "second scan must sweep terminal file"
+        );
+        let msgs2 = crate::inbox::drain(&home, "dev");
+        assert!(msgs2.is_empty(), "#1287: no duplicate emit on second scan");
         let _ = std::fs::remove_dir_all(&home);
     }
 

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -118,6 +118,11 @@ pub fn scan_and_emit_with(
                         &author,
                         build_event_message("pr-merged", &author, &state, body),
                     );
+                    // #1287: set dedup flag and persist — file removal
+                    // deferred to the next scan so the flag survives
+                    // if gh_poll recreates the watch file.
+                    state.ready_emitted_for_sha = Some(state.head_sha.clone());
+                    dirty = true;
                 } else {
                     tracing::debug!(
                         repo = %state.repo,
@@ -125,9 +130,9 @@ pub fn scan_and_emit_with(
                         head = %state.head_sha,
                         "#1017 pr_state: stale Merged replay suppressed at scan"
                     );
+                    let _ = remove(home, &state.repo, &state.branch);
+                    continue;
                 }
-                let _ = remove(home, &state.repo, &state.branch);
-                continue;
             }
             MergeState::ClosedUnmerged { closed_at } => {
                 if !already_emitted {
@@ -141,6 +146,8 @@ pub fn scan_and_emit_with(
                         &author,
                         build_event_message("pr-closed-unmerged", &author, &state, body),
                     );
+                    state.ready_emitted_for_sha = Some(state.head_sha.clone());
+                    dirty = true;
                 } else {
                     tracing::debug!(
                         repo = %state.repo,
@@ -148,9 +155,9 @@ pub fn scan_and_emit_with(
                         head = %state.head_sha,
                         "#1017 pr_state: stale ClosedUnmerged replay suppressed at scan"
                     );
+                    let _ = remove(home, &state.repo, &state.branch);
+                    continue;
                 }
-                let _ = remove(home, &state.repo, &state.branch);
-                continue;
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

- **Root cause**: `[pr-merged]` and `[pr-closed-unmerged]` terminal-state emit paths in `scanner.rs` never set `ready_emitted_for_sha`, so the dedup gate (`already_emitted`) was always `false`. Combined with gh_poll recreating the watch file each tick, this caused infinite re-emission every ~60s.
- **Fix**: On first emit of a terminal-state event, set the dedup flag (`ready_emitted_for_sha = Some(head_sha)`) and persist via `dirty = true`. File removal is deferred to the **next** scan tick when `already_emitted` is `true`, ensuring the flag survives even if gh_poll recreates the file.
- Same two-scan lifecycle applied to both `Merged` and `ClosedUnmerged` paths.

## Changed files

- `src/daemon/pr_state/scanner.rs` — set dedup flag + persist on first terminal-state emit; remove on second scan
- `src/daemon/pr_state/mod.rs` — updated `t10`, `t11`, `t18` tests to assert two-scan lifecycle (first scan emits + persists with dedup flag, second scan sweeps file)

## Test plan

- [x] All 48 `pr_state` tests pass (`cargo test -p agend-terminal --lib daemon::pr_state`)
- [x] `t10_merged_observation_fires_pr_merged_event` — verifies first scan emits + persists, second scan sweeps
- [x] `t11_closed_unmerged_observation_fires_event` — same pattern for closed-unmerged
- [x] `t18_1017_fresh_merged_still_emits_normally` — verifies fresh terminal files still emit (not suppressed)
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)