### PR TITLE
feat: add GitLab CI config and mirror setup guide (#1274)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,44 @@
+# GitLab CI — mirrors core GitHub Actions CI jobs for use as backup
+# when GitHub Actions is degraded. See docs/GITLAB-MIRROR-SETUP.md.
+#
+# Coverage: Linux only (shared runners). macOS/Windows are deferred
+# to GitHub Actions — add tagged runners if cross-platform GitLab CI
+# is needed in the future.
+
+image: rust:latest
+
+stages:
+  - lint
+  - test
+
+variables:
+  CARGO_TERM_COLOR: always
+
+# Cache cargo registry + build artifacts across jobs.
+cache:
+  key: "${CI_COMMIT_REF_SLUG}"
+  paths:
+    - target/
+    - .cargo/registry/
+    - .cargo/git/
+
+before_script:
+  - rustup component add rustfmt clippy
+  - apt-get update -qq && apt-get install -y -qq libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
+
+fmt:
+  stage: lint
+  script:
+    - cargo fmt --check
+
+clippy:
+  stage: lint
+  script:
+    - cargo clippy --all-targets --features tray -- -D warnings
+
+test:
+  stage: test
+  variables:
+    AGEND_LOCK_AUDIT: "1"
+  script:
+    - cargo test --tests --features tray

--- a/docs/GITLAB-MIRROR-SETUP.md
+++ b/docs/GITLAB-MIRROR-SETUP.md
@@ -1,0 +1,63 @@
+# GitLab Mirror Setup Guide
+
+Backup CI channel via GitLab for use when GitHub Actions is degraded. See also [CI-DOWN-SOP.md](CI-DOWN-SOP.md).
+
+## 1. Create GitLab Project
+
+1. Go to [gitlab.com](https://gitlab.com) → **New project** → **Create blank project**
+2. Name: `agend-terminal` (or match your GitHub repo name)
+3. Visibility: **Private** (recommended — source of truth stays on GitHub)
+4. Uncheck "Initialize repository with a README"
+5. Click **Create project**
+
+## 2. Configure Pull Mirror
+
+GitLab will automatically pull from GitHub on a schedule.
+
+1. In your GitLab project: **Settings → Repository → Mirroring repositories**
+2. Git repository URL: `https://github.com/suzuke/agend-terminal.git`
+3. Mirror direction: **Pull**
+4. Authentication method: **Password** — use a GitHub Personal Access Token (PAT)
+   - Create PAT at [github.com/settings/tokens](https://github.com/settings/tokens)
+   - Scopes needed: `repo` (read access to private repos) or `public_repo` (if public)
+   - Paste the PAT as the password
+5. Check **Mirror only protected branches** if you only want `main`, or leave unchecked to mirror all branches
+6. Click **Mirror repository**
+
+GitLab syncs every **5 minutes** by default. You can also click **Update now** to force an immediate sync.
+
+## 3. Verify Mirror Works
+
+1. Push a commit to GitHub
+2. Wait up to 5 minutes (or click **Update now** in GitLab mirror settings)
+3. Confirm the commit appears in GitLab's repository view
+4. Check **CI/CD → Pipelines** — a pipeline should trigger automatically from the `.gitlab-ci.yml` in the repo
+
+## 4. Check GitLab CI During GitHub Actions Downtime
+
+When GitHub Actions is degraded:
+
+1. Go to your GitLab project → **CI/CD → Pipelines**
+2. Find the pipeline for the branch you need to verify
+3. Check that `fmt`, `clippy`, and `test` jobs all pass
+4. Use the result as merge evidence in the [CI-DOWN-SOP](CI-DOWN-SOP.md) PR comment template
+
+## 5. Optional: Report Status Back to GitHub
+
+To show GitLab CI results as commit statuses on GitHub PRs:
+
+1. Create a GitHub PAT with `repo:status` scope
+2. In GitLab: **Settings → CI/CD → Variables** → add `GITHUB_STATUS_TOKEN` (masked)
+3. Add an `after_script` to `.gitlab-ci.yml`:
+
+```yaml
+after_script:
+  - |
+    curl -s -X POST \
+      -H "Authorization: token $GITHUB_STATUS_TOKEN" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/suzuke/agend-terminal/statuses/$CI_COMMIT_SHA" \
+      -d "{\"state\":\"$([ $CI_JOB_STATUS = success ] && echo success || echo failure)\",\"target_url\":\"$CI_PIPELINE_URL\",\"context\":\"gitlab-ci/$CI_JOB_NAME\"}"
+```
+
+This is optional — during normal operations GitHub Actions is the primary CI.


### PR DESCRIPTION
## Summary

- **`.gitlab-ci.yml`** — mirrors core GitHub CI jobs (fmt, clippy, test) on Linux shared runners as backup CI channel during GitHub Actions downtime
- **`docs/GITLAB-MIRROR-SETUP.md`** — step-by-step operator guide for configuring GitHub→GitLab pull mirror, verifying sync, checking CI results, and optional status reporting back to GitHub

## `.gitlab-ci.yml` jobs

| Job | Stage | Command |
|-----|-------|---------|
| fmt | lint | `cargo fmt --check` |
| clippy | lint | `cargo clippy --all-targets --features tray -- -D warnings` |
| test | test | `cargo test --tests --features tray` |

Linux only (shared runners). macOS/Windows deferred to GitHub Actions.

## `docs/GITLAB-MIRROR-SETUP.md` sections

1. Create GitLab project (private visibility)
2. Configure pull mirror (GitHub PAT auth, 5-min sync)
3. Verify mirror works
4. Check GitLab CI during downtime
5. Optional: report status back to GitHub (commit status API)

## Test plan

- [x] `.gitlab-ci.yml` syntax matches GitLab CI spec
- [x] Jobs mirror the core `cargo fmt/clippy/test` commands from `.github/workflows/ci.yml`
- [x] Setup guide covers end-to-end mirror configuration

Closes #1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)