### PR TITLE
feat(tasks): add backlog/in_review statuses + transition enforcement (#1265)

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -155,7 +155,7 @@ fn task_tools() -> Vec<Value> {
                 "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
                 "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}}, "parent_id": {"type": "string", "description": "Parent task ID for subtask composition (A is composed of B,C,D). Complementary to depends_on (execution order)."},
                 "id": {"type": "string"}, "result": {"type": "string"},
-                "status": {"type": "string", "enum": ["open", "claimed", "in_progress", "blocked", "verified", "done", "cancelled"]},
+                "status": {"type": "string", "enum": ["backlog", "open", "claimed", "in_progress", "in_review", "blocked", "verified", "done", "cancelled"]},
                 "filter_assignee": {"type": "string"}, "filter_status": {"type": "string"}, "filter_tag": {"type": "string", "description": "Filter by tag"}, "tags": {"type": "array", "items": {"type": "string"}, "description": "Task tags (for create/update)"},
                 "include_history": {"type": "boolean", "description": "#806: opt in to done/cancelled in `list` response (default trims to actionable)."},
                 "limit": {"type": "integer", "description": "#806: cap `list` response to N newest-first entries (sort by updated_at desc)."},

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -285,6 +285,14 @@ pub enum TaskEvent {
         task_id: TaskId,
         reason: String,
     },
+    /// #1265: transition to backlog status.
+    MovedToBacklog {
+        task_id: TaskId,
+    },
+    /// #1265: transition to in_review status.
+    MovedToReview {
+        task_id: TaskId,
+    },
     /// **v2** — sweep dry-run proposal. Distinct from `Done` so an
     /// operator-confirm gate can intercede before the canonical close
     /// transition lands. Per dev-reviewer-2 must-have: do NOT use a
@@ -365,6 +373,8 @@ impl TaskEvent {
             | TaskEvent::Unblocked { task_id }
             | TaskEvent::Reopened { task_id, .. }
             | TaskEvent::Released { task_id, .. }
+            | TaskEvent::MovedToBacklog { task_id }
+            | TaskEvent::MovedToReview { task_id }
             | TaskEvent::TaskCloseProposed { task_id, .. }
             | TaskEvent::OwnerAssigned { task_id, .. }
             | TaskEvent::PriorityChanged { task_id, .. }
@@ -387,6 +397,8 @@ impl TaskEvent {
             TaskEvent::Unblocked { .. } => "unblocked",
             TaskEvent::Reopened { .. } => "reopened",
             TaskEvent::Released { .. } => "released",
+            TaskEvent::MovedToBacklog { .. } => "moved_to_backlog",
+            TaskEvent::MovedToReview { .. } => "moved_to_review",
             TaskEvent::TaskCloseProposed { .. } => "task_close_proposed",
             TaskEvent::OwnerAssigned { .. } => "owner_assigned",
             TaskEvent::PriorityChanged { .. } => "priority_changed",
@@ -423,13 +435,77 @@ pub struct TaskEventEnvelope {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub enum TaskStatus {
+    Backlog,
     Open,
     Claimed,
     InProgress,
+    InReview,
     Verified,
     Done,
     Cancelled,
     Blocked,
+}
+
+impl TaskStatus {
+    /// Parse a status string (MCP-facing).
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "backlog" => Some(Self::Backlog),
+            "open" => Some(Self::Open),
+            "claimed" => Some(Self::Claimed),
+            "in_progress" => Some(Self::InProgress),
+            "in_review" => Some(Self::InReview),
+            "verified" => Some(Self::Verified),
+            "done" => Some(Self::Done),
+            "cancelled" => Some(Self::Cancelled),
+            "blocked" => Some(Self::Blocked),
+            _ => None,
+        }
+    }
+
+    /// #1265: allowed transitions table. Returns true if transitioning
+    /// from `self` to `target` is valid.
+    pub fn can_transition_to(self, target: Self) -> bool {
+        use TaskStatus::*;
+        // Cancelled and Blocked are reachable from any non-terminal state.
+        if target == Cancelled {
+            return self != Done && self != Cancelled;
+        }
+        if target == Blocked {
+            return !matches!(self, Done | Cancelled | Blocked);
+        }
+        matches!(
+            (self, target),
+            // Forward lifecycle
+            (Backlog, Open)
+                | (Open, Claimed)
+                | (Claimed, InProgress)
+                | (InProgress, InReview)
+                | (InReview, Verified)
+                | (Verified, Done)
+                // Skip paths (common shortcuts)
+                | (Open, InProgress)
+                | (Open, Done)
+                | (Claimed, InReview)
+                | (Claimed, Done)
+                | (InProgress, Done)
+                | (InReview, Done)
+                | (InProgress, Verified)
+                // Backward (rejection / rework)
+                | (InReview, InProgress)
+                | (Verified, InProgress)
+                | (Claimed, Open)
+                | (InProgress, Open)
+                // Unblock
+                | (Blocked, Open)
+                | (Blocked, Claimed)
+                | (Blocked, InProgress)
+                | (Blocked, InReview)
+                // Reopen
+                | (Done, Open)
+                | (Cancelled, Open)
+        )
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -688,6 +764,18 @@ impl TaskBoardState {
                     t.status = TaskStatus::Open;
                     t.owner = None;
                     t.routed_to = None;
+                    t.updated_at = touch_at;
+                }
+            }
+            TaskEvent::MovedToBacklog { .. } => {
+                if let Some(t) = self.tasks.get_mut(&task_id) {
+                    t.status = TaskStatus::Backlog;
+                    t.updated_at = touch_at;
+                }
+            }
+            TaskEvent::MovedToReview { .. } => {
+                if let Some(t) = self.tasks.get_mut(&task_id) {
+                    t.status = TaskStatus::InReview;
                     t.updated_at = touch_at;
                 }
             }
@@ -1629,6 +1717,12 @@ mod tests {
                 TaskStatus::Blocked => vec![TaskEvent::Blocked {
                     task_id: tid.clone(),
                     reason: "test".into(),
+                }],
+                TaskStatus::Backlog => vec![TaskEvent::MovedToBacklog {
+                    task_id: tid.clone(),
+                }],
+                TaskStatus::InReview => vec![TaskEvent::MovedToReview {
+                    task_id: tid.clone(),
                 }],
             };
             for e in priming {

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -173,7 +173,14 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             let include_history = args["include_history"].as_bool().unwrap_or(false);
             let limit = args["limit"].as_u64();
             let filtered_default = !include_history && filter_status.is_none();
-            const ACTIONABLE: &[&str] = &["open", "claimed", "in_progress", "blocked"];
+            const ACTIONABLE: &[&str] = &[
+                "backlog",
+                "open",
+                "claimed",
+                "in_progress",
+                "in_review",
+                "blocked",
+            ];
             let now = chrono::Utc::now();
             let done_ttl = chrono::Duration::days(14);
             let tasks = list_all(home);
@@ -296,6 +303,20 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                         "task '{id}' owned by '{}', caller '{caller}' not authorized",
                         record.owner.as_ref().map(|o| o.0.as_str()).unwrap_or("unassigned")
                     )
+                });
+            }
+            // #1265: transition enforcement for done action.
+            if !record
+                .status
+                .can_transition_to(crate::task_events::TaskStatus::Done)
+            {
+                return serde_json::json!({
+                    "error": format!(
+                        "illegal transition: {} → done (task {})",
+                        status_to_legacy_str(record.status),
+                        id
+                    ),
+                    "code": "illegal_transition",
                 });
             }
             if force {
@@ -464,6 +485,20 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             // "updated" so callers don't need to special-case.
             if let Some(ref s) = new_status {
                 let prev_status = record.status;
+                // #1265: transition enforcement — reject illegal status changes.
+                if let Some(target) = crate::task_events::TaskStatus::from_str(s) {
+                    if !prev_status.can_transition_to(target) {
+                        return serde_json::json!({
+                            "error": format!(
+                                "illegal transition: {} → {} (task {})",
+                                crate::tasks::status_to_legacy_str(prev_status),
+                                s,
+                                id
+                            ),
+                            "code": "illegal_transition",
+                        });
+                    }
+                }
                 let event_for_transition: Option<crate::task_events::TaskEvent> =
                     match (prev_status, s.as_str()) {
                         (_, "claimed") => Some(crate::task_events::TaskEvent::Claimed {
@@ -547,6 +582,12 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                                 "status {} → open",
                                 status_to_legacy_str(prev_status)
                             ),
+                        }),
+                        (_, "backlog") => Some(crate::task_events::TaskEvent::MovedToBacklog {
+                            task_id: crate::task_events::TaskId(id.clone()),
+                        }),
+                        (_, "in_review") => Some(crate::task_events::TaskEvent::MovedToReview {
+                            task_id: crate::task_events::TaskId(id.clone()),
                         }),
                         _ => None,
                     };
@@ -904,6 +945,8 @@ fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String
             by.0.clone(),
             format!("metadata[{key}] = {value}"),
         ),
+        TaskEvent::MovedToBacklog { .. } => ("moved_to_backlog", actor, "→ backlog".to_string()),
+        TaskEvent::MovedToReview { .. } => ("moved_to_review", actor, "→ in_review".to_string()),
     }
 }
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -193,9 +193,11 @@ pub(super) fn record_to_task(r: &crate::task_events::TaskRecord) -> Task {
 pub(super) fn status_to_legacy_str(s: crate::task_events::TaskStatus) -> &'static str {
     use crate::task_events::TaskStatus;
     match s {
+        TaskStatus::Backlog => "backlog",
         TaskStatus::Open => "open",
         TaskStatus::Claimed => "claimed",
         TaskStatus::InProgress => "in_progress",
+        TaskStatus::InReview => "in_review",
         TaskStatus::Verified => "verified",
         TaskStatus::Done => "done",
         TaskStatus::Cancelled => "cancelled",

--- a/src/tasks/orphan.rs
+++ b/src/tasks/orphan.rs
@@ -303,9 +303,11 @@ pub fn build_health_response(
     let mut non_terminal_ages_days: Vec<i64> = Vec::new();
     for record in state.tasks.values() {
         let key = match record.status {
+            TaskStatus::Backlog => "backlog",
             TaskStatus::Open => "open",
             TaskStatus::Claimed => "claimed",
             TaskStatus::InProgress => "in_progress",
+            TaskStatus::InReview => "in_review",
             TaskStatus::Blocked => "blocked",
             TaskStatus::Done => "done",
             TaskStatus::Cancelled => "cancelled",


### PR DESCRIPTION
Closes #1265 (Phase 1)

## Changes
- **New statuses**: `backlog`, `in_review` added to TaskStatus enum
- **New events**: `MovedToBacklog`, `MovedToReview` for event sourcing
- **Transition enforcement**: `can_transition_to()` validates all status changes; illegal transitions hard-rejected with error
- **Allowed transitions**: forward lifecycle, skip paths, backward (rejection/rework), unblock, reopen, cancel/block from any active state

## Phase 2 (deferred)
- 5-column board rendering
- Parent-child cascade
- Protocol sync