### PR TITLE
fix(tasks): remove unused duration param and flaky tests (#1299)

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -160,7 +160,6 @@ fn task_tools() -> Vec<Value> {
                 "include_history": {"type": "boolean", "description": "#806: opt in to done/cancelled in `list` response (default trims to actionable)."},
                 "limit": {"type": "integer", "description": "#806: cap `list` response to N newest-first entries (sort by updated_at desc)."},
                 "due_at": {"type": "string", "description": "ISO 8601 deadline for the task"},
-                "duration": {"type": "string", "description": "Human duration until deadline (e.g. 30m, 1h, 2d)"},
                 "branch": {"type": "string", "description": "Git branch the implementer should work on"},
                 "force": {"type": "boolean", "description": "#808: bypass ownership ACL on done/update for historical ghost-owned cleanup. Requires non-empty force_reason."},
                 "force_reason": {"type": "string", "description": "#808: required when force=true. Logged to event-log.jsonl and embedded in the per-task event's reason field for audit."},

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -6,29 +6,9 @@ use super::orphan::build_health_response;
 use super::{list_all, record_to_task, status_to_legacy_str, Task};
 
 fn parse_due_at(args: &Value) -> Option<String> {
-    if let Some(due) = args["due_at"].as_str() {
-        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(due) {
-            return Some(dt.with_timezone(&chrono::Utc).to_rfc3339());
-        }
-    }
-    if let Some(dur) = args["duration"].as_str() {
-        if let Some(d) = parse_duration(dur) {
-            return Some((chrono::Utc::now() + d).to_rfc3339());
-        }
-    }
-    None
-}
-
-fn parse_duration(s: &str) -> Option<chrono::Duration> {
-    let s = s.trim();
-    let (num, unit) = s.split_at(s.len().saturating_sub(1));
-    let n: i64 = num.parse().ok()?;
-    match unit {
-        "m" => Some(chrono::Duration::minutes(n)),
-        "h" => Some(chrono::Duration::hours(n)),
-        "d" => Some(chrono::Duration::days(n)),
-        _ => None,
-    }
+    let due = args["due_at"].as_str()?;
+    let dt = chrono::DateTime::parse_from_rfc3339(due).ok()?;
+    Some(dt.with_timezone(&chrono::Utc).to_rfc3339())
 }
 
 /// Read a single task's current replay-derived record. Used by

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1097,64 +1097,6 @@ fn test_done_task_ignored_by_sweep() {
 }
 
 #[test]
-fn test_task_create_accepts_duration_30m() {
-    let home = tmp_home("dur-30m");
-    let before = chrono::Utc::now();
-    let result = handle(
-        &home,
-        "agent1",
-        &serde_json::json!({"action": "create", "title": "timed", "duration": "30m"}),
-    );
-    assert_eq!(result["status"], "created");
-    let listed = handle(&home, "agent1", &serde_json::json!({"action": "list"}));
-    let due_str = listed["tasks"][0]["due_at"].as_str().expect("due_at set");
-    let due = chrono::DateTime::parse_from_rfc3339(due_str)
-        .expect("valid rfc3339")
-        .with_timezone(&chrono::Utc);
-    let expected = before + chrono::Duration::minutes(30);
-    let diff = (due - expected).num_seconds().abs();
-    assert!(diff < 5, "due_at should be ~now+30m, diff={diff}s");
-    std::fs::remove_dir_all(&home).ok();
-}
-
-#[test]
-fn test_task_create_duration_variants() {
-    let home = tmp_home("dur-variants");
-    let now = chrono::Utc::now();
-    handle(
-        &home,
-        "a",
-        &serde_json::json!({"action": "create", "title": "1h", "duration": "1h"}),
-    );
-    let listed = handle(&home, "a", &serde_json::json!({"action": "list"}));
-    let due = chrono::DateTime::parse_from_rfc3339(listed["tasks"][0]["due_at"].as_str().unwrap())
-        .unwrap()
-        .with_timezone(&chrono::Utc);
-    assert!((due - now).num_minutes() >= 59);
-    handle(
-        &home,
-        "a",
-        &serde_json::json!({"action": "create", "title": "2d", "duration": "2d"}),
-    );
-    let listed = handle(&home, "a", &serde_json::json!({"action": "list"}));
-    let due = chrono::DateTime::parse_from_rfc3339(listed["tasks"][1]["due_at"].as_str().unwrap())
-        .unwrap()
-        .with_timezone(&chrono::Utc);
-    assert!((due - now).num_hours() >= 47);
-    handle(
-        &home,
-        "a",
-        &serde_json::json!({"action": "create", "title": "bad", "duration": "xyz"}),
-    );
-    let listed = handle(&home, "a", &serde_json::json!({"action": "list"}));
-    assert!(
-        listed["tasks"][2]["due_at"].is_null(),
-        "invalid duration → no due_at"
-    );
-    std::fs::remove_dir_all(&home).ok();
-}
-
-#[test]
 fn test_daemon_maintenance_unclaims_overdue_and_logs_event() {
     let home = tmp_home("daemon-maint");
     let past = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();


### PR DESCRIPTION
## Summary

- Remove `duration` parameter parsing from `task create` handler (`parse_duration` function + duration branch in `parse_due_at`)
- Remove flaky tests: `test_task_create_accepts_duration_30m` and `test_task_create_duration_variants`
- Remove `duration` from MCP tool schema
- **Keep** `due_at` field and direct ISO 8601 `due_at` param — these ARE consumed by the overdue claim sweep in `mod.rs`

## Why

The `duration` param ("30m" → computed timestamp) had no real consumer — agents don't respect deadlines and no daemon mechanism enforces them. Its tests relied on wall-clock timing (`diff < 5s`) and caused recurring flaky CI failures (observed `diff=5399s` on ubuntu-latest in PRs #1292, #1297).

## Changed files

- `src/tasks/handler.rs` — removed `parse_duration()` and duration branch from `parse_due_at()` (-21 LOC)
- `src/tasks/tests.rs` — removed 2 flaky tests (-57 LOC)
- `src/mcp/tools.rs` — removed `duration` from task tool schema (-1 LOC)

## Test plan

- [x] All remaining task tests pass
- [x] `build_health_response_includes_stale_claims_via_due_at` still passes (due_at is preserved)
- [x] `test_task_create_accepts_due_at_iso` still passes (direct due_at param works)
- [x] clippy clean, fmt clean

Closes #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)