### PR TITLE
fix(tasks): include home path in replay cache key (#1303)

### DIFF
--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -945,7 +945,7 @@ fn max_seq_for_instance(log_path: &Path, instance: &InstanceName) -> anyhow::Res
 // Invalidated explicitly after append_batch and implicitly when file
 // metadata changes (external writes, rotation).
 
-type ReplayCacheKey = (i64, u64, i64);
+type ReplayCacheKey = (std::path::PathBuf, i64, u64, i64);
 
 struct ReplayCacheEntry {
     key: ReplayCacheKey,
@@ -972,7 +972,7 @@ fn replay_cache_key(home: &Path) -> Option<ReplayCacheKey> {
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_nanos() as i64)
         .unwrap_or(0);
-    Some((log_mtime, log_len, archive_mtime))
+    Some((home.to_path_buf(), log_mtime, log_len, archive_mtime))
 }
 
 pub fn invalidate_replay_cache() {


### PR DESCRIPTION
## Summary
- Add `home` path to `ReplayCacheKey` type: `(PathBuf, i64, u64, i64)` instead of `(i64, u64, i64)`
- Prevents parallel test cache collision where tests with different `home` dirs but matching file metadata share a single global cache entry
- Root cause of ALL recurring `left: Null` flakes on ubuntu CI: `test_done_assignee_ok`, `test_concurrent_creates_unique_ids`, `metadata_set_writes_and_reads`, `test_task_auto_unblock_when_all_deps_done`

## Root Cause
`REPLAY_CACHE` is a global singleton keyed by `(log_mtime, log_len, archive_mtime)`. In parallel tests, each test creates an isolated tmp dir, but when file metadata aligns (common on fast CI runners within the same second), Test B's `replay()` returns Test A's cached `TaskBoardState` — causing "task not found" errors that surface as `left: Null` assertion failures.

## Test plan
- [x] `cargo test -- replay_cache` — 2 cache-specific tests pass
- [x] `cargo test -- "tasks::"` — all 99 tasks tests pass
- [x] `cargo fmt --check` — clean

Closes #1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)