### PR TITLE
fix(ci-watch): aggregate only to_notify runs in rerun dedup gate (#1307)

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -474,16 +474,16 @@ pub(crate) fn dedupe_notifications_by_head_sha<'a>(
             })
             .or_insert((idx, id));
     }
+    let notify_set: std::collections::HashSet<usize> = to_notify.iter().copied().collect();
     let mut result: Vec<_> = best
         .into_iter()
         .filter(|(sha, (_idx, _))| {
             if last_notified_sha != Some(*sha) {
-                return true; // different sha → always pass
+                return true;
             }
-            // #1042: compare AGGREGATE conclusion (not individual run's)
-            // against last_notified_conclusion — the fan-out persists
-            // the aggregate, so dedup must match the same value.
-            aggregate_conclusion_for_sha(runs, sha) != last_notified_conclusion
+            // #1307: aggregate only over to_notify runs so stale failed
+            // runs (filtered by gate 1) don't poison the conclusion.
+            aggregate_conclusion_for_indices(runs, &notify_set, sha) != last_notified_conclusion
         })
         .map(|(sha, (idx, id))| (idx, id, sha))
         .collect();
@@ -548,6 +548,41 @@ pub(crate) fn aggregate_conclusion_for_sha_filtered<'a>(
         return Some("failure");
     }
     // Still in-progress → wait for all to complete before reporting success
+    if matching.iter().any(|r| r.conclusion.is_none()) {
+        return None;
+    }
+    if let Some(r) = matching
+        .iter()
+        .find(|r| r.conclusion.as_deref() != Some("success"))
+    {
+        return r.conclusion.as_deref();
+    }
+    Some("success")
+}
+
+/// #1307: aggregate conclusion only over runs at the given indices.
+/// Prevents stale failed runs (already filtered out by gate 1) from
+/// poisoning the gate 2 dedup check on rerun.
+fn aggregate_conclusion_for_indices<'a>(
+    runs: &'a [CiRun],
+    indices: &std::collections::HashSet<usize>,
+    sha: &str,
+) -> Option<&'a str> {
+    let matching: Vec<&CiRun> = runs
+        .iter()
+        .enumerate()
+        .filter(|(i, r)| indices.contains(i) && r.head_sha == sha)
+        .map(|(_, r)| r)
+        .collect();
+    if matching.is_empty() {
+        return None;
+    }
+    if matching
+        .iter()
+        .any(|r| r.conclusion.as_deref() == Some("failure"))
+    {
+        return Some("failure");
+    }
     if matching.iter().any(|r| r.conclusion.is_none()) {
         return None;
     }

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -624,6 +624,41 @@ fn test_1042_same_sha_different_aggregate_fires() {
     );
 }
 
+/// #1307: rerun of a failed run produces a new run_id with success on the
+/// same SHA. Gate 1 filters out the old failed run, but gate 2 was
+/// aggregating over ALL runs (including the filtered-out failure), causing
+/// the aggregate to stay "failure" and suppressing the notification.
+#[test]
+fn test_1307_rerun_pass_same_sha_fires_notification() {
+    let runs = vec![
+        CiRun {
+            id: 900,
+            conclusion: Some("failure".into()),
+            head_sha: "abc".into(),
+            url: String::new(),
+            name: String::new(),
+        },
+        CiRun {
+            id: 901,
+            conclusion: Some("success".into()),
+            head_sha: "abc".into(),
+            url: String::new(),
+            name: String::new(),
+        },
+    ];
+    // last_run_id=900: gate 1 filters out run 900 (same id, same conclusion)
+    let selected = select_runs_to_notify(&runs, Some(900), Some("failure"));
+    assert_eq!(selected, vec![1], "only rerun (id=901) should pass gate 1");
+    // gate 2: same SHA as last notified, but aggregate should use only
+    // to_notify runs (success), not all runs (which includes old failure)
+    let deduped = dedupe_notifications_by_head_sha(&runs, &selected, Some("abc"), Some("failure"));
+    assert_eq!(
+        deduped.len(),
+        1,
+        "#1307: rerun pass on same SHA must fire notification; got {deduped:?}"
+    );
+}
+
 #[test]
 fn test_different_head_sha_triggers_new_notification() {
     let runs = vec![


### PR DESCRIPTION
## Summary
- Gate 2 (`dedupe_notifications_by_head_sha`) was aggregating conclusion over ALL runs including stale failed runs already filtered out by gate 1, causing rerun pass notifications to be suppressed
- New `aggregate_conclusion_for_indices` helper aggregates only over runs whose indices passed gate 1 (`select_runs_to_notify`)
- Added regression test `test_1307_rerun_pass_same_sha_fires_notification`

## Root Cause
When a CI run fails and is rerun, GitHub creates a new run (new `run_id`, same `head_sha`). Gate 1 correctly filters out the old failed run. But gate 2 called `aggregate_conclusion_for_sha(runs, sha)` on the unfiltered `runs` slice — the old failed run's "failure" conclusion triggered fail-fast, making the aggregate "failure" == `last_notified_conclusion` ("failure"), suppressing the notification.

## Test plan
- [x] `cargo test -- same_sha` — all 3 tests pass (2 existing #1042 + new #1307)
- [x] `cargo test -- ci_watch` — all 197 ci_watch tests pass
- [x] `cargo fmt --check` — clean

Closes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)