### PR TITLE
feat: add actionable instructions to CI + dispatch notifications

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -618,7 +618,13 @@ pub(crate) fn build_inbox_body(
              4. Do NOT dismiss without evidence"
         )
     } else {
-        format!("{headline}\nURL: {run_url}")
+        format!(
+            "{headline}\nURL: {run_url}\n\n\
+             Next steps:\n\
+             1. If review pending → reviewer picks up\n\
+             2. If already reviewed → lead merges\n\
+             3. Check task board for next assignment"
+        )
     }
 }
 
@@ -969,10 +975,23 @@ async fn poll_ci_runs(
             }
             let notify_msg = match rate_limit_reset {
                 Some(reset) => format!(
-                    "[ci-warn] {}@{}: {message} — backoff until reset (epoch {reset})",
+                    "[ci-warn] {}@{}: {message} — backoff until reset (epoch {reset})\n\n\
+                     Action checklist:\n\
+                     1. Check GitHub status page (githubstatus.com)\n\
+                     2. If rate-limited → wait, polling will auto-resume\n\
+                     3. If persistent >30min → escalate to operator\n\
+                     4. If token error → report to operator",
                     ctx.repo, ctx.branch
                 ),
-                None => format!("[ci-warn] {}@{}: {message}", ctx.repo, ctx.branch),
+                None => format!(
+                    "[ci-warn] {}@{}: {message}\n\n\
+                     Action checklist:\n\
+                     1. Check GitHub status page (githubstatus.com)\n\
+                     2. If rate-limited → wait, polling will auto-resume\n\
+                     3. If persistent >30min → escalate to operator\n\
+                     4. If token error → report to operator",
+                    ctx.repo, ctx.branch
+                ),
             };
             if let Some(ch) = crate::channel::active_channel() {
                 for sub in ctx.subscribers {

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -169,6 +169,11 @@ fn build_stalled_body(
     if let Some(w) = setup_warning {
         s.push_str(&format!("\nSetup hint: {w}"));
     }
+    s.push_str(
+        "\n\nPolling paused due to rate-limit backoff (\u{2265}3 consecutive skips).\n\
+         Will auto-resume when rate-limit window expires.\n\
+         Action: no immediate action needed. If stalled >30min, check githubstatus.com and escalate to operator.",
+    );
     s
 }
 

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -509,7 +509,12 @@ fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
     let text = format!(
         "[dispatch_idle_threshold_exceeded] dispatch {dispatch_id} from '{dispatcher}' → '{target}' \
          (kind={expected_kind}, correlation_id={corr}) idle for {elapsed_secs}s \
-         (threshold {threshold_secs}s, exceeded by {overshoot}s).",
+         (threshold {threshold_secs}s, exceeded by {overshoot}s).\n\n\
+         Action checklist:\n\
+         1. Check target agent's pane — is it stuck or just slow?\n\
+         2. If stuck → force release worktree + redispatch\n\
+         3. If slow but progressing → extend patience\n\
+         4. If crashed → restart agent, reassign task",
         dispatch_id = d.dispatch_id,
         dispatcher = d.dispatcher,
         target = d.target,


### PR DESCRIPTION
## Summary
- `[ci-pass]`: append next-steps guidance (reviewer picks up → lead merges → check task board)
- `[ci-warn]`: append action checklist (check GitHub status, rate-limit auto-resume, escalation path)
- `[ci-watch-stalled]`: append explanation of backoff behavior + action guidance for prolonged stalls
- `[dispatch_idle_threshold_exceeded]`: append triage checklist (check pane, force release, restart)

All 4 notification types now include actionable instructions instead of pure status. Existing notification structure/kind unchanged.

## Test plan
- [x] Full test suite passes (2849/2849, 0 failures)
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean
- [x] No tests assert exact message content for these notification types

🤖 Generated with [Claude Code](https://claude.com/claude-code)