### PR TITLE
feat: add actionable checklists to PR state and agent state notifications

### DIFF
--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -107,11 +107,17 @@ pub fn scan_and_emit_with(
                 if !already_emitted {
                     let author = resolve_author(&state);
                     let body = format!(
-                        "[pr-merged] {}@{} (merge_commit {}, merged_at {})",
+                        "[pr-merged] {}@{} (merge_commit {}, merged_at {})\n\n\
+                         ⚠ Action checklist:\n\
+                         1. `release_worktree` for branch `{}`\n\
+                         2. `gh issue close` (if linked issue)\n\
+                         3. `task action=done` (if correlation_id present)\n\
+                         4. Report completion to lead",
                         state.repo,
                         state.branch,
                         &merge_commit[..8.min(merge_commit.len())],
                         merged_at,
+                        state.branch,
                     );
                     let _ = crate::inbox::enqueue_with_idle_hint(
                         home,
@@ -138,8 +144,12 @@ pub fn scan_and_emit_with(
                 if !already_emitted {
                     let author = resolve_author(&state);
                     let body = format!(
-                        "[pr-closed-unmerged] {}@{} (closed_at {})",
-                        state.repo, state.branch, closed_at
+                        "[pr-closed-unmerged] {}@{} (closed_at {})\n\n\
+                         ⚠ Action checklist:\n\
+                         1. `release_worktree` for branch `{}`\n\
+                         2. Investigate closure reason (operator decision? superseded?)\n\
+                         3. Report to lead with context",
+                        state.repo, state.branch, closed_at, state.branch,
                     );
                     let _ = crate::inbox::enqueue_with_idle_hint(
                         home,

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -486,14 +486,36 @@ pub(crate) fn maybe_notify_member_state_change(
         payload.to_string(),
     );
     let _ = crate::inbox::enqueue(home, orch, msg);
+    let action_hint = match new_state {
+        crate::state::AgentState::Hang => {
+            "\nAction: check agent pane snapshot, consider restart if no progress >5min"
+        }
+        crate::state::AgentState::UsageLimit => {
+            "\nAction: wait for limit reset or switch backend. Do NOT retry."
+        }
+        crate::state::AgentState::Crashed => {
+            "\nAction: check logs, restart agent, reassign task if needed"
+        }
+        crate::state::AgentState::PermissionPrompt => {
+            "\nAction: approve or deny the pending permission prompt"
+        }
+        crate::state::AgentState::RateLimit => {
+            "\nAction: wait for rate limit cooldown, auto-retry expected"
+        }
+        crate::state::AgentState::AuthError => {
+            "\nAction: check credentials, may need operator re-auth"
+        }
+        _ => "",
+    };
     crate::inbox::notify_agent(
         home,
         orch,
         &crate::inbox::NotifySource::System("supervisor"),
         &format!(
-            "[member_state_change] {name}: {} → {}",
+            "[member_state_change] {name}: {} → {}{}",
             prev_state.display_name(),
-            new_state.display_name()
+            new_state.display_name(),
+            action_hint,
         ),
     );
     tracing::info!(agent = %name, from = prev_state.display_name(), to = new_state.display_name(), orchestrator = %orch, "member-state-change notify sent");

--- a/src/daemon/waiting_on_stale.rs
+++ b/src/daemon/waiting_on_stale.rs
@@ -94,7 +94,13 @@ pub(crate) fn scan_and_emit(
 }
 
 fn emit_stale_alert(home: &Path, agent: &str, condition: &str, elapsed_min: i64) {
-    let text = format!("[waiting_on_stale] {agent}: waiting on \"{condition}\" for {elapsed_min}m");
+    let text = format!(
+        "[waiting_on_stale] {agent}: waiting on \"{condition}\" for {elapsed_min}m\n\n\
+         ⚠ Action checklist:\n\
+         1. Re-evaluate if blocker is resolved\n\
+         2. If resolved → clear waiting_on, resume work\n\
+         3. If still blocked → escalate to lead with status update"
+    );
     // Alert the agent itself
     emit_to(home, agent, "waiting_on_stale", &text, Some(agent));
     // Alert team orchestrator (if any)


### PR DESCRIPTION
## Summary
- Add actionable checklists to 4 notification types, following the existing CI failure checklist pattern
- **`[pr-merged]`**: release worktree, close linked issue, mark task done, report to lead
- **`[pr-closed-unmerged]`**: release worktree, investigate closure reason, report to lead
- **`[member_state_change]`**: state-specific guidance (Hang→check pane, UsageLimit→wait, Crashed→restart, PermissionPrompt→approve/deny, RateLimit→wait, AuthError→re-auth)
- **`[waiting_on_stale]`**: re-evaluate blocker, clear or escalate

## Files changed
- `src/daemon/pr_state/scanner.rs` — pr-merged + pr-closed-unmerged checklists
- `src/daemon/supervisor.rs` — state-specific action hints for member_state_change
- `src/daemon/waiting_on_stale.rs` — waiting_on_stale checklist

## Test plan
- [x] `cargo check` — clean (no test assertions on message content)
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)