### PR TITLE
fix: skip record_ci_result on terminal merge state (#1314)

### DIFF
--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -629,6 +629,14 @@ pub fn record_ci_result(
 ) {
     let mut state = load(home, repo, branch)
         .unwrap_or_else(|| new_for_branch(repo, branch, head_sha, review_class));
+    // #1314: skip CiObserved on terminal states to prevent read-modify-write
+    // race with scanner (which sets ready_emitted_for_sha after emitting).
+    if matches!(
+        state.merge_state,
+        MergeState::Merged { .. } | MergeState::ClosedUnmerged { .. }
+    ) {
+        return;
+    }
     if !subscribers.is_empty() && state.subscribers.is_empty() {
         state.subscribers = subscribers;
     }


### PR DESCRIPTION
## Summary
- `record_ci_result` now early-returns when `merge_state` is `Merged` or `ClosedUnmerged`
- Prevents read-modify-write race where ci_watch overwrites scanner's `ready_emitted_for_sha` dedup flag

## Root Cause
Two concurrent writers operate on the same pr_state JSON file without coordination:
1. **Scanner** (`scan_and_emit`): reads file → emits `[pr-merged]` → sets `ready_emitted_for_sha` → saves
2. **ci_watch** (`record_ci_result`): reads file (stale, pre-emission) → applies `CiObserved` → saves → **overwrites** `ready_emitted_for_sha` back to `None`

Next scanner tick reads the overwritten file, sees `ready_emitted_for_sha == None`, and re-emits. This repeats ~4 times (once per minute) until one side wins the last write.

## Fix
`record_ci_result` has no business applying `CiObserved` after a PR is already merged/closed — the CI result is moot. Early return prevents the stale-read overwrite entirely.

## Test plan
- [x] `cargo test -- record_ci` — 2 existing tests pass
- [x] `cargo check` — clean
- [x] `cargo fmt --check` — clean

Closes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)