### PR TITLE
fix: always set cursor position for focused pane in multi-pane layout (#1317)

### DIFF
--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -444,13 +444,19 @@ fn render_pane(
         }
     }
 
-    if focused && pane.scroll_offset == 0 {
+    if focused {
         let (cursor_line, cursor_col) = pane.vterm.cursor_pos();
-        let cx = inner.x + cursor_col;
-        let cy = inner.y + cursor_line;
-        if cx < inner.x + inner.width && cy < inner.y + inner.height {
-            frame.set_cursor_position(ratatui::layout::Position::new(cx, cy));
-        }
+        let max_x = inner.x + inner.width.saturating_sub(1);
+        let max_y = inner.y + inner.height.saturating_sub(1);
+        let (cx, cy) = if pane.scroll_offset == 0 {
+            (
+                (inner.x + cursor_col).min(max_x),
+                (inner.y + cursor_line).min(max_y),
+            )
+        } else {
+            (inner.x, max_y)
+        };
+        frame.set_cursor_position(ratatui::layout::Position::new(cx, cy));
     }
 
     PaneBorderInfo {


### PR DESCRIPTION
## Summary
- **Always** call `Frame::set_cursor_position` for the focused pane, removing the silent skip when `scroll_offset > 0` or cursor is out of bounds
- Clamp cursor coordinates to the pane's visible inner area instead of skipping `set_cursor_position` entirely
- When scrolled back, park cursor at the bottom-left of the focused pane

**Root cause**: ratatui hides the cursor when `set_cursor_position` is never called during a frame render. In multi-pane layouts, the focused pane's cursor could go unset (e.g. cursor exceeds pane area after a resize, or user scrolled back), causing the IME composition window to appear at the terminal's default cursor position — typically top-left or a stale position from a different pane.

## Test plan
- [ ] Open a multi-pane split layout (Ctrl+B | or Ctrl+B -)
- [ ] Switch focus between panes and verify IME composition window follows the focused pane
- [ ] Scroll back in a pane (Ctrl+B [) and verify IME window stays within the focused pane area
- [ ] Resize terminal window and verify cursor stays clamped within focused pane bounds
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)