### PR TITLE
feat(#1326): add job-level early-fail detection to ci-watch

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -2,7 +2,7 @@ use crate::agent::{self, AgentRegistry};
 use std::path::Path;
 use std::sync::Arc;
 
-use super::provider::{CiPollResult, CiProvider, CiRun, MergeableState, PrState};
+use super::provider::{CiJob, CiPollResult, CiProvider, CiRun, MergeableState, PrState};
 
 type PerKeySlot = Arc<tokio::sync::Mutex<Option<CiPollResult>>>;
 type TickCache = Arc<std::sync::Mutex<std::collections::HashMap<(String, String), PerKeySlot>>>;
@@ -39,6 +39,10 @@ impl CiProvider for CachedCiProvider {
 
     async fn fetch_failure_summary(&self, repo: &str, run_id: u64) -> String {
         self.inner.fetch_failure_summary(repo, run_id).await
+    }
+
+    async fn fetch_run_jobs(&self, repo: &str, run_id: u64) -> Vec<super::provider::CiJob> {
+        self.inner.fetch_run_jobs(repo, run_id).await
     }
 
     fn token_warning(&self) -> Option<&'static str> {
@@ -706,6 +710,93 @@ pub(crate) fn make_ci_ready_for_action_msg(
     msg
 }
 
+// ── #1326 job-level early-fail ──
+
+async fn check_early_job_failures(
+    ctx: &CiCheckCtx<'_>,
+    state: &mut WatchState,
+    pr: &PollResult,
+    provider: &dyn CiProvider,
+) -> bool {
+    if pr.current_sha.is_empty() {
+        return false;
+    }
+    if state.early_fail_notified_sha.as_deref() == Some(pr.current_sha.as_str()) {
+        return false;
+    }
+    let in_progress: Vec<&CiRun> = pr
+        .runs
+        .iter()
+        .filter(|r| r.head_sha == pr.current_sha && r.conclusion.is_none())
+        .collect();
+    if in_progress.is_empty() {
+        return false;
+    }
+
+    let mut all_failed: Vec<String> = Vec::new();
+    let mut all_running: Vec<String> = Vec::new();
+    let mut first_run_id: u64 = 0;
+    let mut first_run_url = String::new();
+
+    for run in &in_progress {
+        let jobs = provider.fetch_run_jobs(ctx.repo, run.id).await;
+        let failed: Vec<&CiJob> = jobs
+            .iter()
+            .filter(|j| j.conclusion.as_deref() == Some("failure"))
+            .collect();
+        if failed.is_empty() {
+            continue;
+        }
+        if first_run_id == 0 {
+            first_run_id = run.id;
+            first_run_url.clone_from(&run.url);
+        }
+        for j in &failed {
+            all_failed.push(j.name.clone());
+        }
+        for j in jobs.iter().filter(|j| j.conclusion.is_none()) {
+            all_running.push(j.name.clone());
+        }
+    }
+
+    if all_failed.is_empty() {
+        return false;
+    }
+
+    let sha_short = &pr.current_sha[..pr.current_sha.len().min(7)];
+    let headline = format!(
+        "[ci-fail] {}@{} ({}): failure",
+        ctx.repo, ctx.branch, sha_short
+    );
+    let detail = all_failed.join(", ");
+    let mut body = format!("{headline}\nDetail: {detail}\nURL: {first_run_url}");
+    if !all_running.is_empty() {
+        body.push_str(&format!("\nStill running: {}", all_running.join(", ")));
+    }
+    body.push_str(&format!(
+        "\n\n⚠ CI failure checklist:\n\
+         1. `gh run view {first_run_id} --log-failed` — read the actual error\n\
+         2. If infra flake → `gh run rerun {first_run_id} --failed`\n\
+         3. If real failure → fix code, push, wait for green\n\
+         4. Do NOT dismiss without evidence"
+    ));
+
+    let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
+    let supersede_token = format!("ci-early-{sha_short}");
+    for sub in ctx.subscribers {
+        crate::inbox::mark_ci_watch_superseded(ctx.home, sub, &repo_branch_key, &supersede_token);
+        let _ = crate::inbox::enqueue_with_idle_hint(
+            ctx.home,
+            sub,
+            crate::inbox::InboxMessage::new_system("system:ci", "ci-watch", body.clone())
+                .with_correlation_id(repo_branch_key.clone()),
+        );
+    }
+
+    state.early_fail_notified_sha = Some(pr.current_sha.clone());
+    true
+}
+
 // ── ci_check_repo decomposition (#1093) ──
 
 struct CiCheckCtx<'a> {
@@ -803,6 +894,10 @@ async fn ci_check_repo(
             return Err(e);
         }
     };
+    // #1326: check in-progress runs for early job-level failures before
+    // the terminal-only notification gates below.
+    check_early_job_failures(&ctx, &mut state, &pr, provider).await;
+
     let to_notify = select_runs_to_notify(
         &pr.runs,
         pr.effective_last_run_id,

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -973,6 +973,8 @@ struct MockCiProvider {
     /// by the new check. Tests targeting #813 set this via
     /// `with_mergeable`.
     mergeable: Mutex<MergeableState>,
+    /// #1326: per-run_id job lists for early-fail testing.
+    jobs: Mutex<std::collections::HashMap<u64, Vec<super::CiJob>>>,
 }
 
 impl MockCiProvider {
@@ -986,6 +988,7 @@ impl MockCiProvider {
             pr_state: Mutex::new(PrState::Open),
             failure_summary: Mutex::new("Build / Test".to_string()),
             mergeable: Mutex::new(MergeableState::Unknown),
+            jobs: Mutex::new(std::collections::HashMap::new()),
         }
     }
 
@@ -1003,6 +1006,7 @@ impl MockCiProvider {
             pr_state: Mutex::new(PrState::Open),
             failure_summary: Mutex::new("Build / Test".to_string()),
             mergeable: Mutex::new(MergeableState::Unknown),
+            jobs: Mutex::new(std::collections::HashMap::new()),
         }
     }
 
@@ -1016,6 +1020,7 @@ impl MockCiProvider {
             pr_state: Mutex::new(PrState::Open),
             failure_summary: Mutex::new("Build / Test".to_string()),
             mergeable: Mutex::new(MergeableState::Unknown),
+            jobs: Mutex::new(std::collections::HashMap::new()),
         }
     }
 
@@ -1047,6 +1052,12 @@ impl MockCiProvider {
     fn set_pr_state(&self, state: PrState) {
         *self.pr_state.lock() = state;
     }
+
+    #[allow(dead_code)]
+    fn with_jobs(self, run_id: u64, jobs: Vec<super::CiJob>) -> Self {
+        self.jobs.lock().insert(run_id, jobs);
+        self
+    }
 }
 
 #[async_trait::async_trait]
@@ -1063,6 +1074,9 @@ impl CiProvider for MockCiProvider {
     }
     async fn fetch_failure_summary(&self, _repo: &str, _run_id: u64) -> String {
         self.failure_summary.lock().clone()
+    }
+    async fn fetch_run_jobs(&self, _repo: &str, run_id: u64) -> Vec<super::CiJob> {
+        self.jobs.lock().get(&run_id).cloned().unwrap_or_default()
     }
     fn token_warning(&self) -> Option<&'static str> {
         None
@@ -1390,6 +1404,7 @@ fn mock_rate_limit_writes_backoff_and_propagates_error() {
         pr_state: Mutex::new(PrState::Open),
         failure_summary: Mutex::new(String::new()),
         mergeable: Mutex::new(MergeableState::Unknown),
+        jobs: Mutex::new(std::collections::HashMap::new()),
     };
     let result = run_ci_check(&dir, &base_watch(), &provider);
     assert!(result.is_err(), "rate-limit must propagate as error");
@@ -5153,6 +5168,169 @@ fn empty_run_poll_refreshes_expires_at() {
     assert!(
         (71..=72).contains(&hours_from_now),
         "expires_at must be refreshed to ~72h even on empty runs, got {hours_from_now}h"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// --- #1326 job-level early-fail tests ---
+
+#[test]
+fn early_job_failure_sends_notification() {
+    use super::CiJob;
+    let dir = tmp_dir("early-fail");
+    let provider = MockCiProvider::with_runs(vec![CiRun {
+        id: 500,
+        conclusion: None,
+        head_sha: "abc1234".into(),
+        url: "https://example.com/500".into(),
+        name: "CI".into(),
+    }])
+    .with_jobs(
+        500,
+        vec![
+            CiJob {
+                name: "Check (ubuntu)".into(),
+                conclusion: Some("failure".into()),
+            },
+            CiJob {
+                name: "Check (macos)".into(),
+                conclusion: None,
+            },
+            CiJob {
+                name: "Check (windows)".into(),
+                conclusion: None,
+            },
+        ],
+    );
+    run_ci_check(&dir, &base_watch(), &provider).unwrap();
+
+    let watch_path = dir.join("ci-watches").join(watch_filename("o/r", "feat"));
+    let updated: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    assert_eq!(
+        updated["early_fail_notified_sha"].as_str(),
+        Some("abc1234"),
+        "#1326: early_fail_notified_sha must be set"
+    );
+
+    let inbox_path = dir.join("inbox").join("agent1.jsonl");
+    let content = std::fs::read_to_string(&inbox_path).unwrap_or_default();
+    assert!(
+        content.contains("[ci-fail]"),
+        "#1326: early job failure must send inbox notification"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn early_job_failure_includes_running_jobs_in_message() {
+    use super::CiJob;
+    let dir = tmp_dir("early-fail-msg");
+    let provider = MockCiProvider::with_runs(vec![CiRun {
+        id: 600,
+        conclusion: None,
+        head_sha: "def5678".into(),
+        url: "https://example.com/600".into(),
+        name: "CI".into(),
+    }])
+    .with_jobs(
+        600,
+        vec![
+            CiJob {
+                name: "Format check".into(),
+                conclusion: Some("failure".into()),
+            },
+            CiJob {
+                name: "Build".into(),
+                conclusion: None,
+            },
+        ],
+    );
+    run_ci_check(&dir, &base_watch(), &provider).unwrap();
+
+    let inbox_path = dir.join("inbox").join("agent1.jsonl");
+    let msg = std::fs::read_to_string(&inbox_path).expect("must have inbox file");
+    assert!(
+        msg.contains("Format check"),
+        "#1326: message must name the failed job"
+    );
+    assert!(
+        msg.contains("Still running: Build"),
+        "#1326: message must list still-running jobs"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn early_job_failure_dedup_prevents_repeat_notification() {
+    use super::CiJob;
+    let dir = tmp_dir("early-fail-dedup");
+    let ci_dir = dir.join("ci-watches");
+    std::fs::create_dir_all(&ci_dir).ok();
+    let watch = serde_json::json!({
+        "repo": "o/r", "branch": "feat", "interval_secs": 60,
+        "instance": "agent1", "last_run_id": null, "head_sha": null,
+        "last_polled_at": null, "last_notified_head_sha": null,
+        "early_fail_notified_sha": "abc1234",
+    });
+    let provider = MockCiProvider::with_runs(vec![CiRun {
+        id: 700,
+        conclusion: None,
+        head_sha: "abc1234".into(),
+        url: "https://example.com/700".into(),
+        name: "CI".into(),
+    }])
+    .with_jobs(
+        700,
+        vec![CiJob {
+            name: "Check".into(),
+            conclusion: Some("failure".into()),
+        }],
+    );
+    run_ci_check(&dir, &watch, &provider).unwrap();
+
+    let inbox_path = dir.join("inbox").join("agent1.jsonl");
+    let content = std::fs::read_to_string(&inbox_path).unwrap_or_default();
+    assert!(
+        !content.contains("[ci-fail]"),
+        "#1326: must not re-notify when early_fail_notified_sha matches"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn no_early_fail_when_all_jobs_passing() {
+    use super::CiJob;
+    let dir = tmp_dir("early-fail-noop");
+    let provider = MockCiProvider::with_runs(vec![CiRun {
+        id: 800,
+        conclusion: None,
+        head_sha: "ghi9999".into(),
+        url: "https://example.com/800".into(),
+        name: "CI".into(),
+    }])
+    .with_jobs(
+        800,
+        vec![
+            CiJob {
+                name: "Check (ubuntu)".into(),
+                conclusion: Some("success".into()),
+            },
+            CiJob {
+                name: "Check (macos)".into(),
+                conclusion: None,
+            },
+        ],
+    );
+    run_ci_check(&dir, &base_watch(), &provider).unwrap();
+
+    let watch_path = dir.join("ci-watches").join(watch_filename("o/r", "feat"));
+    let updated: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    assert!(
+        updated["early_fail_notified_sha"].is_null()
+            || updated.get("early_fail_notified_sha").is_none(),
+        "#1326: no early-fail dedup flag when no jobs failed"
     );
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -123,6 +123,13 @@ pub struct CiRun {
     pub name: String,
 }
 
+/// A single job within a CI run (#1326 job-level early-fail).
+#[derive(Debug, Clone)]
+pub struct CiJob {
+    pub name: String,
+    pub conclusion: Option<String>,
+}
+
 /// Result of polling CI runs for a branch.
 ///
 /// Sprint 54 P0-2: the success variant carries the
@@ -237,6 +244,12 @@ pub trait CiProvider: Send + Sync {
 
     /// Fetch a human-readable summary of the first failed job/step.
     async fn fetch_failure_summary(&self, repo: &str, run_id: u64) -> String;
+
+    /// #1326: fetch jobs for a run to detect early job-level failures.
+    /// Default returns empty — only GitHub implements this currently.
+    async fn fetch_run_jobs(&self, _repo: &str, _run_id: u64) -> Vec<CiJob> {
+        Vec::new()
+    }
 
     /// Optional token/auth warning shown in the `watch_ci` MCP response.
     /// Currently called via `github_token_warning_from_env()` in the handler;
@@ -511,6 +524,35 @@ impl CiProvider for GitHubCiProvider {
                 })
             })
             .unwrap_or_else(|| "unknown step".to_string())
+    }
+
+    async fn fetch_run_jobs(&self, repo: &str, run_id: u64) -> Vec<CiJob> {
+        let resp = match self
+            .http
+            .get(&format!("repos/{repo}/actions/runs/{run_id}/jobs"))
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(_) => return Vec::new(),
+        };
+        let body: serde_json::Value = match resp.json().await {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        body["jobs"]
+            .as_array()
+            .map(|jobs| {
+                jobs.iter()
+                    .filter_map(|j| {
+                        Some(CiJob {
+                            name: j["name"].as_str()?.to_string(),
+                            conclusion: j["conclusion"].as_str().map(String::from),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     fn token_warning(&self) -> Option<&'static str> {

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -191,6 +191,7 @@ pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::W
     merged.stalled_notified = state.stalled_notified;
     merged.stalled_since_ms = state.stalled_since_ms;
     merged.terminal_since = state.terminal_since.clone();
+    merged.early_fail_notified_sha = state.early_fail_notified_sha.clone();
     if let Err(e) = crate::store::atomic_write(
         watch_path,
         serde_json::to_string_pretty(&merged)

--- a/src/daemon/ci_watch/watch_state.rs
+++ b/src/daemon/ci_watch/watch_state.rs
@@ -46,6 +46,10 @@ pub struct WatchState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_stale_emitted_sha: Option<String>,
 
+    // #1326: job-level early-fail dedup
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub early_fail_notified_sha: Option<String>,
+
     // TTL
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,


### PR DESCRIPTION
## Summary
- ci-watch now detects individual job failures within in-progress GitHub Actions runs, notifying agents immediately instead of waiting for the entire run to complete
- Added `CiJob` struct + `fetch_run_jobs()` trait method to `CiProvider` (GitHub-only; GitLab/Bitbucket return empty default)
- New `check_early_job_failures()` in poller.rs runs before the existing terminal-run gates, checking in-progress runs on the current HEAD SHA for job-level `conclusion="failure"`
- Notifications include failed job name(s), still-running jobs list, and standard CI failure checklist
- Dedup via `early_fail_notified_sha` in WatchState prevents repeat alerts for the same commit

## Files changed
- `provider.rs` — `CiJob` struct, `fetch_run_jobs()` trait method + GitHub impl (+42)
- `poller.rs` — `check_early_job_failures()` + integration into `ci_check_repo()` (+97/-1)
- `watch_state.rs` — `early_fail_notified_sha` field (+4)
- `registry.rs` — persist new field in `flush_watch_state` (+1)
- `poller_tests.rs` — 4 tests: notification sent, message content, dedup, no false positive (+178)

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] All 163 ci_watch poller tests pass (4 new + 159 existing)
- [ ] CI green

Closes #1326

🤖 Generated with [Claude Code](https://claude.com/claude-code)