### PR TITLE
fix(dispatch): surface bind_full rollback as error (#1324)

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -100,6 +100,8 @@ pub enum Stage {
     /// Source repo resolution fell through to stub (tier 4) while
     /// `AGEND_BIND_STRICT_MODE=1`.
     ResolveSourceRepo,
+    /// `bind_full` write failed after worktree was leased.
+    Bind,
 }
 
 /// Canonical `code` enum — stable across releases. Callers MUST match
@@ -124,6 +126,8 @@ pub enum ErrorCode {
     BindInFlight,
     /// `AGEND_BIND_STRICT_MODE=1` and source_repo resolved to stub (tier 4).
     StubRejected,
+    /// `bind_full` failed — worktree was rolled back.
+    BindFailed,
 }
 
 /// Sprint 55 P0-B EC11: per-agent in-flight guard scoped to the daemon's
@@ -463,6 +467,16 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
                 .env("AGEND_GIT_BYPASS", "1")
                 .current_dir(&source_repo)
                 .output();
+            // #1324: surface rollback as dispatch error instead of silent success
+            return Err(DispatchError {
+                message: format!(
+                    "bind_full failed for {target}@{branch}, worktree rolled back: {e}"
+                ),
+                code: ErrorCode::BindFailed,
+                stage: Stage::Bind,
+                fetch_attempted,
+                raw: Some(e),
+            });
         }
     }
 

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -210,13 +210,11 @@ fn bind_file_error_rolls_back_worktree() {
     let runtime_agent = runtime_parent.join("test-agent");
     std::fs::write(&runtime_agent, "blocking file").ok();
 
-    // Lease succeeds but bind_full fails → worktree rolled back.
+    // Lease succeeds but bind_full fails → error returned + worktree rolled back.
     let result = super::dispatch_auto_bind_lease(&home, "test-agent", "T-1", "feat/graceful", None);
-    assert!(
-        result.is_ok(),
-        "dispatch_auto_bind_lease must not propagate bind error: {:?}",
-        result.err()
-    );
+    let err = result.expect_err("dispatch must return Err when bind_full fails (#1324)");
+    assert_eq!(err.code, super::ErrorCode::BindFailed);
+    assert_eq!(err.stage, super::Stage::Bind);
 
     // #1310: worktree should NOT exist after rollback.
     let wt = home


### PR DESCRIPTION
## Summary
- When `bind_full` fails after worktree lease, dispatch now returns `Err(DispatchError)` with `code: BindFailed`, `stage: Bind` instead of silently returning `Ok(DispatchOutcome)`
- Adds `BindFailed` to `ErrorCode` and `Bind` to `Stage` enums
- Updates existing `bind_file_error_rolls_back_worktree` test to assert the error is surfaced

## Test plan
- [x] `bind_file_error_rolls_back_worktree` updated to verify `Err` with correct code/stage
- [x] All 45 dispatch_hook tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)