### PR TITLE
refactor(inbox): extract notify_system helper (#1335)

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -176,15 +176,15 @@ fn emit_stall(home: &Path, task: &Task, reason: &str) {
         assignee = task.assignee.as_deref().unwrap_or("?"),
     );
     for recipient in stall_recipients() {
-        let mut msg = crate::inbox::InboxMessage::new_system(
+        if let Err(e) = crate::inbox::notify_system(
+            home,
+            &recipient,
             "system:anti_stall",
             "task_stalled",
             text.clone(),
-        )
-        .with_delivery_mode("inbox_fallback")
-        .with_correlation_id(task.id.clone());
-        msg.task_id = Some(task.id.clone());
-        if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, &recipient, msg) {
+            Some(&task.id),
+            Some(&task.id),
+        ) {
             tracing::warn!(
                 error = %e,
                 recipient = %recipient,

--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -292,11 +292,15 @@ fn emit_timeout_event(home: &Path, d: &PendingDecision, elapsed_secs: i64) {
         default_action = d.default_action,
     );
     let recipient = timeout_recipient();
-    let msg =
-        crate::inbox::InboxMessage::new_system("system:decision_timeout", "decision_timeout", text)
-            .with_delivery_mode("inbox_fallback")
-            .with_correlation_id(d.decision_id.clone());
-    if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, &recipient, msg) {
+    if let Err(e) = crate::inbox::notify_system(
+        home,
+        &recipient,
+        "system:decision_timeout",
+        "decision_timeout",
+        text,
+        Some(&d.decision_id),
+        None,
+    ) {
         tracing::warn!(error = %e, recipient, "decision_timeout: enqueue failed");
     }
 }

--- a/src/daemon/dispatch_idle/fixup_nudge.rs
+++ b/src/daemon/dispatch_idle/fixup_nudge.rs
@@ -113,15 +113,15 @@ fn emit_nudge(home: &Path, d: &PendingDispatch) -> bool {
         .correlation_id
         .clone()
         .unwrap_or_else(|| d.dispatch_id.clone());
-    let mut msg = crate::inbox::InboxMessage::new_system(
+    match crate::inbox::notify_system(
+        home,
+        &d.target,
         "system:fixup-watchdog",
         "dispatch_idle_nudge",
         text,
-    )
-    .with_delivery_mode("inbox_fallback")
-    .with_correlation_id(corr);
-    msg.task_id = d.correlation_id.clone();
-    match crate::inbox::enqueue_with_idle_hint(home, &d.target, msg) {
+        Some(&corr),
+        d.correlation_id.as_deref(),
+    ) {
         Ok(()) => true,
         Err(e) => {
             tracing::warn!(

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -530,15 +530,15 @@ fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
         .correlation_id
         .clone()
         .unwrap_or_else(|| d.dispatch_id.clone());
-    let mut msg = crate::inbox::InboxMessage::new_system(
+    if let Err(e) = crate::inbox::notify_system(
+        home,
+        &d.dispatcher,
         "system:dispatch_idle",
         "dispatch_idle_threshold_exceeded",
         text,
-    )
-    .with_delivery_mode("inbox_fallback")
-    .with_correlation_id(corr);
-    msg.task_id = d.correlation_id.clone();
-    if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, &d.dispatcher, msg) {
+        Some(&corr),
+        d.correlation_id.as_deref(),
+    ) {
         tracing::warn!(
             error = %e,
             dispatcher = %d.dispatcher,

--- a/src/daemon/helper_staleness_watchdog.rs
+++ b/src/daemon/helper_staleness_watchdog.rs
@@ -119,14 +119,15 @@ fn emit_staleness_alert(home: &Path, helper_name: &str) {
          `agend-terminal doctor` reports the same state.)"
     );
     for recipient in RECIPIENTS {
-        let msg = crate::inbox::InboxMessage::new_system(
+        if let Err(e) = crate::inbox::notify_system(
+            home,
+            recipient,
             "system:helper_staleness_watchdog",
             "helper_staleness_watchdog",
             text.clone(),
-        )
-        .with_delivery_mode("inbox_fallback")
-        .with_correlation_id(helper_name);
-        if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, recipient, msg) {
+            Some(helper_name),
+            None,
+        ) {
             tracing::warn!(
                 error = %e,
                 recipient,

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -575,12 +575,16 @@ fn emit_idle_alert(
     text: &str,
     correlation_agent: Option<&str>,
 ) {
-    let mut msg = crate::inbox::InboxMessage::new_system(format!("system:{kind}"), kind, text)
-        .with_delivery_mode("inbox_fallback");
-    if let Some(agent) = correlation_agent {
-        msg = msg.with_correlation_id(agent);
-    }
-    if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, recipient, msg) {
+    let source = format!("system:{kind}");
+    if let Err(e) = crate::inbox::notify_system(
+        home,
+        recipient,
+        &source,
+        kind,
+        text,
+        correlation_agent,
+        None,
+    ) {
         tracing::warn!(error = %e, recipient, kind, "idle_watchdog: enqueue failed");
     } else {
         tracing::info!(recipient, kind, "idle_watchdog: emitted inbox alert");

--- a/src/daemon/waiting_on_stale.rs
+++ b/src/daemon/waiting_on_stale.rs
@@ -114,12 +114,16 @@ fn emit_stale_alert(home: &Path, agent: &str, condition: &str, elapsed_min: i64)
 }
 
 fn emit_to(home: &Path, recipient: &str, kind: &str, text: &str, correlation_agent: Option<&str>) {
-    let mut msg = crate::inbox::InboxMessage::new_system(format!("system:{kind}"), kind, text)
-        .with_delivery_mode("inbox_fallback");
-    if let Some(agent) = correlation_agent {
-        msg = msg.with_correlation_id(agent);
-    }
-    if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, recipient, msg) {
+    let source = format!("system:{kind}");
+    if let Err(e) = crate::inbox::notify_system(
+        home,
+        recipient,
+        &source,
+        kind,
+        text,
+        correlation_agent,
+        None,
+    ) {
         tracing::warn!(error = %e, recipient, kind, "waiting_on_stale: enqueue failed");
     } else {
         tracing::info!(

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -34,8 +34,8 @@ pub(crate) use storage::inbox_path_resolved;
 // Notification & PTY injection (pub)
 pub use notify::{
     compose_aware_inject, deliver, enqueue_with_idle_hint, format_event_header,
-    inject_notification_with_submit, notify_agent, notify_agent_with_attachments, AGENT_MSG_PREFIX,
-    SYSTEM_MSG_PREFIX,
+    inject_notification_with_submit, notify_agent, notify_agent_with_attachments, notify_system,
+    AGENT_MSG_PREFIX, SYSTEM_MSG_PREFIX,
 };
 // Notification & PTY injection (pub(crate))
 pub(crate) use notify::build_excerpt;

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -325,6 +325,28 @@ pub fn enqueue_with_idle_hint(home: &Path, target: &str, msg: InboxMessage) -> a
     })
 }
 
+/// #1335: convenience wrapper for the common daemon notification pattern:
+/// `InboxMessage::new_system` + optional `delivery_mode` / `correlation_id` /
+/// `task_id` + `enqueue_with_idle_hint`. Covers ~15 watchdog-class call sites.
+pub fn notify_system(
+    home: &Path,
+    target: &str,
+    source: &str,
+    kind: &str,
+    body: impl Into<String>,
+    correlation_id: Option<&str>,
+    task_id: Option<&str>,
+) -> anyhow::Result<()> {
+    let mut msg = InboxMessage::new_system(source, kind, body).with_delivery_mode("inbox_fallback");
+    if let Some(cid) = correlation_id {
+        msg = msg.with_correlation_id(cid);
+    }
+    if let Some(tid) = task_id {
+        msg.task_id = Some(tid.to_owned());
+    }
+    enqueue_with_idle_hint(home, target, msg)
+}
+
 /// Test-seam variant of [`enqueue_with_idle_hint`]. Accepts a closure
 /// that receives the formatted hint string so unit tests can verify
 /// the wire format without standing up the API loopback.


### PR DESCRIPTION
## Summary
- Adds `inbox::notify_system()` helper that encapsulates the 4-line boilerplate: `InboxMessage::new_system` + `with_delivery_mode("inbox_fallback")` + optional `correlation_id` / `task_id` + `enqueue_with_idle_hint`
- Migrates 7 daemon modules to the shared helper: anti_stall, decision_timeout, dispatch_idle/mod, dispatch_idle/fixup_nudge, helper_staleness_watchdog, idle_watchdog, waiting_on_stale
- Does NOT touch ci_watch, comms, pr_state, supervisor, telegram (these need richer message construction)

## Test plan
- [x] All 131 tests across affected modules pass (anti_stall 30, dispatch_idle 32, idle_watchdog 33, waiting_on_stale 4, decision_timeout 19, helper_staleness 13)
- [x] `cargo check` clean (no warnings)
- [x] `cargo fmt` clean

Closes #1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)