### PR TITLE
feat(#1336): event bus Phase 1 — parallel emit spine

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -199,14 +199,14 @@ fn emit_stall(home: &Path, task: &Task, reason: &str) {
             );
         }
     }
-    crate::daemon::event_bus::global().emit(
+    crate::daemon::event_bus::global().emit_lazy(|| {
         crate::daemon::event_bus::EventKind::TaskStateChanged {
             task_id: task.id.clone(),
             title: task.title.clone(),
             assignee: task.assignee.clone(),
             reason: reason.to_string(),
-        },
-    );
+        }
+    });
 }
 
 #[cfg(test)]

--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -199,6 +199,14 @@ fn emit_stall(home: &Path, task: &Task, reason: &str) {
             );
         }
     }
+    crate::daemon::event_bus::global().emit(
+        crate::daemon::event_bus::EventKind::TaskStateChanged {
+            task_id: task.id.clone(),
+            title: task.title.clone(),
+            assignee: task.assignee.clone(),
+            reason: reason.to_string(),
+        },
+    );
 }
 
 #[cfg(test)]

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1154,30 +1154,32 @@ async fn fan_out_notifications(
         }
         new_notified_sha = Some(sha.to_string());
         new_notified_conclusion = conclusion.map(String::from);
-        match conclusion {
-            Some("failure") => {
-                for sub in ctx.subscribers {
-                    crate::daemon::event_bus::global().emit(
-                        crate::daemon::event_bus::EventKind::CiFail {
-                            repo: ctx.repo.to_string(),
-                            branch: ctx.branch.to_string(),
-                            target: sub.clone(),
-                        },
-                    );
+        if crate::daemon::event_bus::global().is_enabled() {
+            match conclusion {
+                Some("failure") => {
+                    for sub in ctx.subscribers {
+                        crate::daemon::event_bus::global().emit(
+                            crate::daemon::event_bus::EventKind::CiFail {
+                                repo: ctx.repo.to_string(),
+                                branch: ctx.branch.to_string(),
+                                target: sub.clone(),
+                            },
+                        );
+                    }
                 }
-            }
-            Some("success") => {
-                for sub in ctx.subscribers {
-                    crate::daemon::event_bus::global().emit(
-                        crate::daemon::event_bus::EventKind::CiReady {
-                            repo: ctx.repo.to_string(),
-                            branch: ctx.branch.to_string(),
-                            target: sub.clone(),
-                        },
-                    );
+                Some("success") => {
+                    for sub in ctx.subscribers {
+                        crate::daemon::event_bus::global().emit(
+                            crate::daemon::event_bus::EventKind::CiReady {
+                                repo: ctx.repo.to_string(),
+                                branch: ctx.branch.to_string(),
+                                target: sub.clone(),
+                            },
+                        );
+                    }
                 }
+                _ => {}
             }
-            _ => {}
         }
     }
 

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1154,6 +1154,31 @@ async fn fan_out_notifications(
         }
         new_notified_sha = Some(sha.to_string());
         new_notified_conclusion = conclusion.map(String::from);
+        match conclusion {
+            Some("failure") => {
+                for sub in ctx.subscribers {
+                    crate::daemon::event_bus::global().emit(
+                        crate::daemon::event_bus::EventKind::CiFail {
+                            repo: ctx.repo.to_string(),
+                            branch: ctx.branch.to_string(),
+                            target: sub.clone(),
+                        },
+                    );
+                }
+            }
+            Some("success") => {
+                for sub in ctx.subscribers {
+                    crate::daemon::event_bus::global().emit(
+                        crate::daemon::event_bus::EventKind::CiReady {
+                            repo: ctx.repo.to_string(),
+                            branch: ctx.branch.to_string(),
+                            target: sub.clone(),
+                        },
+                    );
+                }
+            }
+            _ => {}
+        }
     }
 
     NotifyOutcome {

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -559,6 +559,13 @@ fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
             d.threshold_secs,
         ),
     );
+    crate::daemon::event_bus::global().emit(
+        crate::daemon::event_bus::EventKind::DispatchIdleExceeded {
+            dispatcher: d.dispatcher.clone(),
+            target: d.target.clone(),
+            elapsed_secs,
+        },
+    );
 }
 
 /// Per-loop scheduler state.

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -559,13 +559,13 @@ fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
             d.threshold_secs,
         ),
     );
-    crate::daemon::event_bus::global().emit(
+    crate::daemon::event_bus::global().emit_lazy(|| {
         crate::daemon::event_bus::EventKind::DispatchIdleExceeded {
             dispatcher: d.dispatcher.clone(),
             target: d.target.clone(),
             elapsed_secs,
-        },
-    );
+        }
+    });
 }
 
 /// Per-loop scheduler state.

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -1,0 +1,219 @@
+//! Structured event bus for daemon-internal notifications.
+//!
+//! Phase 1: parallel emit spine. Existing `enqueue_with_idle_hint` calls
+//! remain untouched; this module emits a structured `Event` alongside them
+//! so future subscribers can react without per-module plumbing.
+//!
+//! Gated by `AGEND_EVENT_BUS=1`. When disabled, `emit()` is a no-op.
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub enum EventKind {
+    TaskStateChanged {
+        task_id: String,
+        title: String,
+        assignee: Option<String>,
+        reason: String,
+    },
+    CiReady {
+        repo: String,
+        branch: String,
+        target: String,
+    },
+    CiFail {
+        repo: String,
+        branch: String,
+        target: String,
+    },
+    DispatchIdleExceeded {
+        dispatcher: String,
+        target: String,
+        elapsed_secs: i64,
+    },
+    MemberStateChanged {
+        agent: String,
+        team: String,
+        from_state: String,
+        to_state: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct Event {
+    pub kind: EventKind,
+    pub timestamp: std::time::Instant,
+}
+
+impl Event {
+    pub fn new(kind: EventKind) -> Self {
+        Self {
+            kind,
+            timestamp: std::time::Instant::now(),
+        }
+    }
+}
+
+pub fn global() -> &'static EventBus {
+    static BUS: std::sync::OnceLock<EventBus> = std::sync::OnceLock::new();
+    BUS.get_or_init(EventBus::new)
+}
+
+type Subscriber = Arc<dyn Fn(&Event) + Send + Sync>;
+
+pub struct EventBus {
+    subscribers: parking_lot::Mutex<Vec<Subscriber>>,
+    enabled: bool,
+}
+
+impl EventBus {
+    pub fn new() -> Self {
+        let enabled = std::env::var("AGEND_EVENT_BUS")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        Self {
+            subscribers: parking_lot::Mutex::new(Vec::new()),
+            enabled,
+        }
+    }
+
+    pub fn subscribe(&self, f: impl Fn(&Event) + Send + Sync + 'static) {
+        self.subscribers.lock().push(Arc::new(f));
+    }
+
+    pub fn emit(&self, kind: EventKind) {
+        if !self.enabled {
+            return;
+        }
+        let event = Event::new(kind);
+        let subs = self.subscribers.lock();
+        for sub in subs.iter() {
+            sub(&event);
+        }
+        tracing::debug!(kind = ?event.kind, "event_bus: emitted");
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for EventBus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventBus")
+            .field("enabled", &self.enabled)
+            .field("subscriber_count", &self.subscribers.lock().len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[test]
+    fn emit_disabled_by_default() {
+        let bus = EventBus::new();
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let r = Arc::clone(&received);
+        bus.subscribe(move |e| r.lock().unwrap().push(e.kind.clone()));
+        bus.emit(EventKind::CiReady {
+            repo: "owner/repo".into(),
+            branch: "main".into(),
+            target: "dev".into(),
+        });
+        assert!(
+            received.lock().unwrap().is_empty(),
+            "emit must be no-op when AGEND_EVENT_BUS != 1"
+        );
+    }
+
+    #[test]
+    fn emit_delivers_to_subscribers_when_enabled() {
+        let bus = EventBus {
+            subscribers: parking_lot::Mutex::new(Vec::new()),
+            enabled: true,
+        };
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let r = Arc::clone(&received);
+        bus.subscribe(move |e| r.lock().unwrap().push(e.kind.clone()));
+        bus.emit(EventKind::TaskStateChanged {
+            task_id: "t-1".into(),
+            title: "test".into(),
+            assignee: Some("dev".into()),
+            reason: "stalled".into(),
+        });
+        let events = received.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], EventKind::TaskStateChanged { task_id, .. } if task_id == "t-1")
+        );
+    }
+
+    #[test]
+    fn multiple_subscribers_all_receive() {
+        let bus = EventBus {
+            subscribers: parking_lot::Mutex::new(Vec::new()),
+            enabled: true,
+        };
+        let count_a = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let count_b = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let ca = Arc::clone(&count_a);
+        let cb = Arc::clone(&count_b);
+        bus.subscribe(move |_| {
+            ca.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        });
+        bus.subscribe(move |_| {
+            cb.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        });
+        bus.emit(EventKind::CiFail {
+            repo: "o/r".into(),
+            branch: "feat".into(),
+            target: "dev".into(),
+        });
+        assert_eq!(count_a.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert_eq!(count_b.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn all_event_kinds_constructible() {
+        let kinds = vec![
+            EventKind::TaskStateChanged {
+                task_id: "t-1".into(),
+                title: "t".into(),
+                assignee: None,
+                reason: "r".into(),
+            },
+            EventKind::CiReady {
+                repo: "o/r".into(),
+                branch: "b".into(),
+                target: "t".into(),
+            },
+            EventKind::CiFail {
+                repo: "o/r".into(),
+                branch: "b".into(),
+                target: "t".into(),
+            },
+            EventKind::DispatchIdleExceeded {
+                dispatcher: "lead".into(),
+                target: "dev".into(),
+                elapsed_secs: 600,
+            },
+            EventKind::MemberStateChanged {
+                agent: "dev".into(),
+                team: "fixup".into(),
+                from_state: "Ready".into(),
+                to_state: "ServerRateLimit".into(),
+            },
+        ];
+        for k in kinds {
+            let _ = format!("{k:?}");
+        }
+    }
+}

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -79,6 +79,10 @@ impl EventBus {
         }
     }
 
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
     pub fn subscribe(&self, f: impl Fn(&Event) + Send + Sync + 'static) {
         self.subscribers.lock().push(Arc::new(f));
     }
@@ -93,6 +97,13 @@ impl EventBus {
             sub(&event);
         }
         tracing::debug!(kind = ?event.kind, "event_bus: emitted");
+    }
+
+    pub fn emit_lazy(&self, f: impl FnOnce() -> EventKind) {
+        if !self.enabled {
+            return;
+        }
+        self.emit(f());
     }
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod cron_tick;
 pub(crate) mod decision_timeout;
 pub(crate) mod dedup_state;
 pub(crate) mod dispatch_idle;
+pub(crate) mod event_bus;
 pub(crate) mod heartbeat_pair;
 pub(crate) mod helper_staleness_watchdog;
 pub(crate) mod idle_watchdog;

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -403,6 +403,14 @@ pub(crate) fn maybe_notify_member_state_change(
         ),
     );
     tracing::info!(agent = %name, from = prev_state.display_name(), to = new_state.display_name(), orchestrator = %orch, "member-state-change notify sent");
+    crate::daemon::event_bus::global().emit(
+        crate::daemon::event_bus::EventKind::MemberStateChanged {
+            agent: name.to_string(),
+            team: team.name.clone(),
+            from_state: prev_state.display_name().to_string(),
+            to_state: new_state.display_name().to_string(),
+        },
+    );
     true
 }
 

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -403,14 +403,14 @@ pub(crate) fn maybe_notify_member_state_change(
         ),
     );
     tracing::info!(agent = %name, from = prev_state.display_name(), to = new_state.display_name(), orchestrator = %orch, "member-state-change notify sent");
-    crate::daemon::event_bus::global().emit(
+    crate::daemon::event_bus::global().emit_lazy(|| {
         crate::daemon::event_bus::EventKind::MemberStateChanged {
             agent: name.to_string(),
             team: team.name.clone(),
             from_state: prev_state.display_name().to_string(),
             to_state: new_state.display_name().to_string(),
-        },
-    );
+        }
+    });
     true
 }
 


### PR DESCRIPTION
## Summary
- New `src/daemon/event_bus.rs`: `EventKind` enum (5 kinds), `Event` struct, `EventBus` with `subscribe()`/`emit()`, global singleton via `OnceLock`
- Parallel emit calls in 4 daemon modules alongside existing `enqueue_with_idle_hint` (pure additive, no behavior change)
- Feature-flagged via `AGEND_EVENT_BUS=1` — disabled by default, `emit()` is a no-op
- 4 unit tests: disabled-by-default, subscriber delivery, multi-subscriber fan-out, all kinds constructible

### Emit sites
| Module | EventKind | Location |
|--------|-----------|----------|
| `anti_stall.rs` | `TaskStateChanged` | `emit_stall()` |
| `ci_watch/poller.rs` | `CiReady` / `CiFail` | `fan_out_notifications()` |
| `dispatch_idle/mod.rs` | `DispatchIdleExceeded` | `emit_exceeded_event()` |
| `supervisor.rs` | `MemberStateChanged` | `maybe_notify_member_state_change()` |

## Test plan
- [x] `emit_disabled_by_default` — no events delivered when env var unset
- [x] `emit_delivers_to_subscribers_when_enabled` — events reach subscribers
- [x] `multiple_subscribers_all_receive` — fan-out works
- [x] `all_event_kinds_constructible` — smoke test all 5 variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)