### PR TITLE
fix(pr_state): flock-serialized with_pr_state helper (#1342)

### DIFF
--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -435,14 +435,74 @@ pub fn load(home: &Path, repo: &str, branch: &str) -> Option<PrState> {
     serde_json::from_str(&content).ok()
 }
 
-/// Atomic save. Uses [`crate::store::atomic_write`] which is
-/// post-#965 unique-tmp safe (concurrent saves to different PRs do
-/// not contend on a shared tmp inode).
+/// Atomic save — used by tests for setup. Production mutation paths
+/// go through [`with_pr_state`] which serializes under flock.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn save(home: &Path, state: &PrState) -> anyhow::Result<()> {
     let path = pr_state_dir(home).join(pr_state_filename(&state.repo, &state.branch));
     let body = serde_json::to_string_pretty(state)?;
     crate::store::atomic_write(&path, body.as_bytes())?;
     Ok(())
+}
+
+/// #1342: flock-serialized read-modify-write for pr_state files.
+/// All mutation paths MUST go through this helper to prevent lost-update
+/// races (e.g. gh-poll save overwriting scanner's `ready_emitted_for_sha`).
+/// The closure receives a fresh `&mut PrState` loaded under an exclusive
+/// lock; save happens automatically after the closure returns.
+/// Returns `Ok(None)` when the file does not exist (closure not called).
+pub fn with_pr_state<F, R>(
+    home: &std::path::Path,
+    repo: &str,
+    branch: &str,
+    mutate: F,
+) -> anyhow::Result<Option<R>>
+where
+    F: FnOnce(&mut PrState) -> R,
+{
+    let dir = pr_state_dir(home);
+    std::fs::create_dir_all(&dir)?;
+    let data_path = dir.join(pr_state_filename(repo, branch));
+    let lock_path = dir.join(format!("{}.lock", pr_state_filename(repo, branch)));
+    let _lock = crate::store::acquire_file_lock(&lock_path)?;
+    let Some(mut state) = std::fs::read_to_string(&data_path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<PrState>(&c).ok())
+    else {
+        return Ok(None);
+    };
+    let result = mutate(&mut state);
+    let body = serde_json::to_string_pretty(&state)?;
+    crate::store::atomic_write(&data_path, body.as_bytes())?;
+    Ok(Some(result))
+}
+
+/// Variant of [`with_pr_state`] that creates the file if missing,
+/// using `default_fn` to produce the initial state.
+pub fn with_pr_state_or_create<F, D, R>(
+    home: &std::path::Path,
+    repo: &str,
+    branch: &str,
+    default_fn: D,
+    mutate: F,
+) -> anyhow::Result<R>
+where
+    D: FnOnce() -> PrState,
+    F: FnOnce(&mut PrState) -> R,
+{
+    let dir = pr_state_dir(home);
+    std::fs::create_dir_all(&dir)?;
+    let data_path = dir.join(pr_state_filename(repo, branch));
+    let lock_path = dir.join(format!("{}.lock", pr_state_filename(repo, branch)));
+    let _lock = crate::store::acquire_file_lock(&lock_path)?;
+    let mut state = std::fs::read_to_string(&data_path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<PrState>(&c).ok())
+        .unwrap_or_else(default_fn);
+    let result = mutate(&mut state);
+    let body = serde_json::to_string_pretty(&state)?;
+    crate::store::atomic_write(&data_path, body.as_bytes())?;
+    Ok(result)
 }
 
 /// Remove the per-PR file. Used by the per-tick scanner after a
@@ -522,7 +582,7 @@ pub fn suppress_stale_terminal_replay_with(home: &Path, threshold: std::time::Du
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        let Ok(mut state) = serde_json::from_str::<PrState>(&content) else {
+        let Ok(state) = serde_json::from_str::<PrState>(&content) else {
             continue;
         };
         if !matches!(
@@ -531,28 +591,37 @@ pub fn suppress_stale_terminal_replay_with(home: &Path, threshold: std::time::Du
         ) {
             continue;
         }
-        // Already-suppressed (idempotent re-runs land here).
         if state.ready_emitted_for_sha.as_deref() == Some(state.head_sha.as_str()) {
             continue;
         }
-        state.ready_emitted_for_sha = Some(state.head_sha.clone());
-        if let Err(e) = save(home, &state) {
-            tracing::warn!(
-                repo = %state.repo,
-                branch = %state.branch,
-                error = %e,
-                "#1017 pr_state: suppress_stale save failed"
-            );
-            continue;
+        let repo = state.repo.clone();
+        let branch = state.branch.clone();
+        match with_pr_state(home, &repo, &branch, |s| {
+            if s.ready_emitted_for_sha.as_deref() == Some(s.head_sha.as_str()) {
+                return false;
+            }
+            s.ready_emitted_for_sha = Some(s.head_sha.clone());
+            true
+        }) {
+            Ok(Some(true)) => {
+                suppressed += 1;
+                tracing::debug!(
+                    repo = %repo,
+                    branch = %branch,
+                    age_hours = age.as_secs() / 3600,
+                    "#1017 pr_state: stale terminal replay suppressed"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    repo = %repo,
+                    branch = %branch,
+                    error = %e,
+                    "#1017 pr_state: suppress_stale save failed"
+                );
+            }
+            _ => {}
         }
-        suppressed += 1;
-        tracing::debug!(
-            repo = %state.repo,
-            branch = %state.branch,
-            head = %state.head_sha,
-            age_hours = age.as_secs() / 3600,
-            "#1017 pr_state: stale terminal replay suppressed"
-        );
     }
     if suppressed > 0 {
         tracing::info!(
@@ -627,28 +696,33 @@ pub fn record_ci_result(
     subscribers: Vec<String>,
     review_class: ReviewClass,
 ) {
-    let mut state = load(home, repo, branch)
-        .unwrap_or_else(|| new_for_branch(repo, branch, head_sha, review_class));
-    // #1314: skip CiObserved on terminal states to prevent read-modify-write
-    // race with scanner (which sets ready_emitted_for_sha after emitting).
-    if matches!(
-        state.merge_state,
-        MergeState::Merged { .. } | MergeState::ClosedUnmerged { .. }
-    ) {
-        return;
-    }
-    if !subscribers.is_empty() && state.subscribers.is_empty() {
-        state.subscribers = subscribers;
-    }
-    apply(
-        &mut state,
-        Event::CiObserved {
-            head_sha,
-            conclusion,
-            observed_at: chrono::Utc::now().to_rfc3339(),
+    if let Err(e) = with_pr_state_or_create(
+        home,
+        repo,
+        branch,
+        || new_for_branch(repo, branch, head_sha, review_class),
+        |state| {
+            // #1314: skip CiObserved on terminal states to prevent
+            // stale write over scanner's ready_emitted_for_sha.
+            if matches!(
+                state.merge_state,
+                MergeState::Merged { .. } | MergeState::ClosedUnmerged { .. }
+            ) {
+                return;
+            }
+            if !subscribers.is_empty() && state.subscribers.is_empty() {
+                state.subscribers = subscribers;
+            }
+            apply(
+                state,
+                Event::CiObserved {
+                    head_sha,
+                    conclusion,
+                    observed_at: chrono::Utc::now().to_rfc3339(),
+                },
+            );
         },
-    );
-    if let Err(e) = save(home, &state) {
+    ) {
         tracing::warn!(
             repo = %repo,
             branch = %branch,
@@ -736,25 +810,27 @@ pub fn record_verdict(
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        let Ok(mut state): Result<PrState, _> = serde_json::from_str(&content) else {
+        let Ok(state): Result<PrState, _> = serde_json::from_str(&content) else {
             continue;
         };
         if state.branch != branch {
             continue;
         }
         matched_any = true;
-        apply(
-            &mut state,
-            Event::VerdictObserved {
-                reviewer,
-                reviewed_head,
-                kind,
-            },
-        );
-        if let Err(e) = save(home, &state) {
+        let repo = state.repo.clone();
+        if let Err(e) = with_pr_state(home, &repo, &branch, |s| {
+            apply(
+                s,
+                Event::VerdictObserved {
+                    reviewer,
+                    reviewed_head,
+                    kind,
+                },
+            );
+        }) {
             tracing::warn!(
-                repo = %state.repo,
-                branch = %state.branch,
+                repo = %repo,
+                branch = %branch,
                 error = %e,
                 "#972 pr_state: record_verdict save failed"
             );

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -2,9 +2,15 @@ use std::path::Path;
 
 use super::gh_poll;
 use super::{
-    apply, format_ready_body, pr_state_dir, remove, resolve_author, save, DraftState, Event,
-    MergeState, PrState,
+    apply, format_ready_body, pr_state_dir, remove, resolve_author, with_pr_state, DraftState,
+    Event, MergeState, PrState,
 };
+
+enum ScanAction {
+    None,
+    Saved,
+    Remove,
+}
 
 pub fn scan_and_emit(home: &Path, registry: &crate::agent::AgentRegistry) {
     scan_and_emit_with(home, registry, &gh_poll::CliGhPoller);
@@ -48,7 +54,7 @@ pub fn scan_and_emit_with(
                 continue;
             }
         };
-        let mut state: PrState = match serde_json::from_str(&content) {
+        let snapshot: PrState = match serde_json::from_str(&content) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(
@@ -59,128 +65,131 @@ pub fn scan_and_emit_with(
                 continue;
             }
         };
-        let mut dirty = false;
+        let repo = snapshot.repo.clone();
+        let branch = snapshot.branch.clone();
 
-        // Emit [pr-ready-for-merge] if eligible and not already fired.
-        if matches!(state.merge_state, MergeState::MergeReady)
-            && state.ready_emitted_for_sha.as_deref() != Some(state.head_sha.as_str())
-        {
-            let author = resolve_author(&state);
-            let body = format_ready_body(&state);
-            let msg = build_event_message("pr-ready-for-merge", &author, &state, body);
-            if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, &author, msg) {
-                tracing::warn!(
-                    repo = %state.repo,
-                    branch = %state.branch,
-                    error = %e,
-                    "#972 pr_state: [pr-ready-for-merge] enqueue failed"
-                );
+        // #1342: all emit + flag-set under flock to prevent lost-update race.
+        let result = with_pr_state(home, &repo, &branch, |state| {
+            let mut dirty = false;
+
+            // Emit [pr-ready-for-merge] if eligible and not already fired.
+            if matches!(state.merge_state, MergeState::MergeReady)
+                && state.ready_emitted_for_sha.as_deref() != Some(state.head_sha.as_str())
+            {
+                let author = resolve_author(state);
+                let body = format_ready_body(state);
+                let msg = build_event_message("pr-ready-for-merge", &author, state, body);
+                if let Err(e) = crate::inbox::enqueue_with_idle_hint(home, &author, msg) {
+                    tracing::warn!(
+                        repo = %state.repo,
+                        branch = %state.branch,
+                        error = %e,
+                        "#972 pr_state: [pr-ready-for-merge] enqueue failed"
+                    );
+                } else {
+                    state.ready_emitted_for_sha = Some(state.head_sha.clone());
+                    dirty = true;
+                    tracing::info!(
+                        repo = %state.repo,
+                        branch = %state.branch,
+                        head = %state.head_sha,
+                        author = %author,
+                        "#972 pr_state: [pr-ready-for-merge] emitted"
+                    );
+                }
+            }
+
+            // Terminal-state sweep.
+            let already_emitted =
+                state.ready_emitted_for_sha.as_deref() == Some(state.head_sha.as_str());
+            match &state.merge_state {
+                MergeState::Merged {
+                    merge_commit,
+                    merged_at,
+                } => {
+                    if !already_emitted {
+                        let author = resolve_author(state);
+                        let body = format!(
+                            "[pr-merged] {}@{} (merge_commit {}, merged_at {})\n\n\
+                             ⚠ Action checklist:\n\
+                             1. `release_worktree` for branch `{}`\n\
+                             2. `gh issue close` (if linked issue)\n\
+                             3. `task action=done` (if correlation_id present)\n\
+                             4. Report completion to lead",
+                            state.repo,
+                            state.branch,
+                            &merge_commit[..8.min(merge_commit.len())],
+                            merged_at,
+                            state.branch,
+                        );
+                        let _ = crate::inbox::enqueue_with_idle_hint(
+                            home,
+                            &author,
+                            build_event_message("pr-merged", &author, state, body),
+                        );
+                        state.ready_emitted_for_sha = Some(state.head_sha.clone());
+                        dirty = true;
+                    } else {
+                        tracing::debug!(
+                            repo = %state.repo,
+                            branch = %state.branch,
+                            head = %state.head_sha,
+                            "#1017 pr_state: stale Merged replay suppressed at scan"
+                        );
+                        return ScanAction::Remove;
+                    }
+                }
+                MergeState::ClosedUnmerged { closed_at } => {
+                    if !already_emitted {
+                        let author = resolve_author(state);
+                        let body = format!(
+                            "[pr-closed-unmerged] {}@{} (closed_at {})\n\n\
+                             ⚠ Action checklist:\n\
+                             1. `release_worktree` for branch `{}`\n\
+                             2. Investigate closure reason (operator decision? superseded?)\n\
+                             3. Report to lead with context",
+                            state.repo, state.branch, closed_at, state.branch,
+                        );
+                        let _ = crate::inbox::enqueue_with_idle_hint(
+                            home,
+                            &author,
+                            build_event_message("pr-closed-unmerged", &author, state, body),
+                        );
+                        state.ready_emitted_for_sha = Some(state.head_sha.clone());
+                        dirty = true;
+                    } else {
+                        tracing::debug!(
+                            repo = %state.repo,
+                            branch = %state.branch,
+                            head = %state.head_sha,
+                            "#1017 pr_state: stale ClosedUnmerged replay suppressed at scan"
+                        );
+                        return ScanAction::Remove;
+                    }
+                }
+                _ => {}
+            }
+
+            if dirty {
+                ScanAction::Saved
             } else {
-                state.ready_emitted_for_sha = Some(state.head_sha.clone());
-                dirty = true;
-                tracing::info!(
-                    repo = %state.repo,
-                    branch = %state.branch,
-                    head = %state.head_sha,
-                    author = %author,
-                    "#972 pr_state: [pr-ready-for-merge] emitted"
-                );
+                ScanAction::None
             }
-        }
+        });
 
-        // Terminal-state sweep.
-        //
-        // #1017: each terminal-state branch first checks the
-        // `ready_emitted_for_sha` debounce gate. The startup hook
-        // `suppress_stale_terminal_replay` sets this to `Some(head_sha)`
-        // for files older than the replay-age threshold so they are
-        // swept (file removed) without firing a stale event. Fresh
-        // terminal-state files have `ready_emitted_for_sha == None`
-        // and fire normally.
-        let already_emitted =
-            state.ready_emitted_for_sha.as_deref() == Some(state.head_sha.as_str());
-        match &state.merge_state {
-            MergeState::Merged {
-                merge_commit,
-                merged_at,
-            } => {
-                if !already_emitted {
-                    let author = resolve_author(&state);
-                    let body = format!(
-                        "[pr-merged] {}@{} (merge_commit {}, merged_at {})\n\n\
-                         ⚠ Action checklist:\n\
-                         1. `release_worktree` for branch `{}`\n\
-                         2. `gh issue close` (if linked issue)\n\
-                         3. `task action=done` (if correlation_id present)\n\
-                         4. Report completion to lead",
-                        state.repo,
-                        state.branch,
-                        &merge_commit[..8.min(merge_commit.len())],
-                        merged_at,
-                        state.branch,
-                    );
-                    let _ = crate::inbox::enqueue_with_idle_hint(
-                        home,
-                        &author,
-                        build_event_message("pr-merged", &author, &state, body),
-                    );
-                    // #1287: set dedup flag and persist — file removal
-                    // deferred to the next scan so the flag survives
-                    // if gh_poll recreates the watch file.
-                    state.ready_emitted_for_sha = Some(state.head_sha.clone());
-                    dirty = true;
-                } else {
-                    tracing::debug!(
-                        repo = %state.repo,
-                        branch = %state.branch,
-                        head = %state.head_sha,
-                        "#1017 pr_state: stale Merged replay suppressed at scan"
-                    );
-                    let _ = remove(home, &state.repo, &state.branch);
-                    continue;
-                }
+        match result {
+            Ok(Some(ScanAction::Remove)) => {
+                let _ = remove(home, &repo, &branch);
             }
-            MergeState::ClosedUnmerged { closed_at } => {
-                if !already_emitted {
-                    let author = resolve_author(&state);
-                    let body = format!(
-                        "[pr-closed-unmerged] {}@{} (closed_at {})\n\n\
-                         ⚠ Action checklist:\n\
-                         1. `release_worktree` for branch `{}`\n\
-                         2. Investigate closure reason (operator decision? superseded?)\n\
-                         3. Report to lead with context",
-                        state.repo, state.branch, closed_at, state.branch,
-                    );
-                    let _ = crate::inbox::enqueue_with_idle_hint(
-                        home,
-                        &author,
-                        build_event_message("pr-closed-unmerged", &author, &state, body),
-                    );
-                    state.ready_emitted_for_sha = Some(state.head_sha.clone());
-                    dirty = true;
-                } else {
-                    tracing::debug!(
-                        repo = %state.repo,
-                        branch = %state.branch,
-                        head = %state.head_sha,
-                        "#1017 pr_state: stale ClosedUnmerged replay suppressed at scan"
-                    );
-                    let _ = remove(home, &state.repo, &state.branch);
-                    continue;
-                }
-            }
-            _ => {}
-        }
-
-        if dirty {
-            if let Err(e) = save(home, &state) {
+            Err(e) => {
                 tracing::warn!(
-                    repo = %state.repo,
-                    branch = %state.branch,
+                    repo = %repo,
+                    branch = %branch,
                     error = %e,
                     "#972 pr_state: post-emit save failed"
                 );
             }
+            _ => {}
         }
         let _ = registry; // reserved for future gh-poll author lookup hook
     }
@@ -265,14 +274,16 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
     for (repo, due_states) in by_repo {
         match poller.poll(&repo) {
             Ok(prs) => {
-                for mut state in due_states {
-                    apply_gh_observations(home, &mut state, &prs, &now);
-                    state.gh_poll_failures = 0;
-                    state.last_gh_poll_at = Some(now.clone());
-                    if let Err(e) = save(home, &state) {
+                for state in due_states {
+                    let branch = state.branch.clone();
+                    if let Err(e) = with_pr_state(home, &repo, &branch, |s| {
+                        apply_gh_observations(home, s, &prs, &now);
+                        s.gh_poll_failures = 0;
+                        s.last_gh_poll_at = Some(now.clone());
+                    }) {
                         tracing::warn!(
-                            repo = %state.repo,
-                            branch = %state.branch,
+                            repo = %repo,
+                            branch = %branch,
                             error = %e,
                             "#986 pr_state: post-gh-poll save failed"
                         );
@@ -281,10 +292,12 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
             }
             Err(e) => {
                 tracing::warn!(repo = %repo, error = %e, "#986 gh-poll failed");
-                for mut state in due_states {
-                    state.gh_poll_failures = state.gh_poll_failures.saturating_add(1);
-                    state.last_gh_poll_at = Some(now.clone());
-                    let _ = save(home, &state);
+                for state in due_states {
+                    let branch = state.branch.clone();
+                    let _ = with_pr_state(home, &repo, &branch, |s| {
+                        s.gh_poll_failures = s.gh_poll_failures.saturating_add(1);
+                        s.last_gh_poll_at = Some(now.clone());
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds `with_pr_state()` and `with_pr_state_or_create()` helpers that serialize read-modify-write under `fs4` exclusive flock
- Migrates all 6 pr_state mutation+save paths to use the locked helper:
  1. scanner emit + flag-set (atomic under flock — the root cause fix)
  2. scanner apply_gh_observations (success path)
  3. scanner gh-poll failure counter (failure path)
  4. suppress_stale_terminal_replay
  5. record_ci_result
  6. record_verdict
- Eliminates the lost-update race where gh-poll save overwrites scanner's `ready_emitted_for_sha` dedup flag, causing duplicate `[pr-merged]` notifications

## Test plan
- [x] All 48 pr_state tests pass
- [x] `cargo check` clean (0 warnings)
- [x] `cargo fmt` clean

Closes #1342

🤖 Generated with [Claude Code](https://claude.com/claude-code)