### PR TITLE
fix: auto-release worktree on pr-merged in scanner (#1344)

### DIFF
--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -108,19 +108,22 @@ pub fn scan_and_emit_with(
                     merged_at,
                 } => {
                     if !already_emitted {
+                        // #1344: auto-release worktree before emitting [pr-merged]
+                        crate::daemon::auto_release::auto_release_for_merged_branch(
+                            home,
+                            &state.branch,
+                        );
                         let author = resolve_author(state);
                         let body = format!(
                             "[pr-merged] {}@{} (merge_commit {}, merged_at {})\n\n\
                              ⚠ Action checklist:\n\
-                             1. `release_worktree` for branch `{}`\n\
-                             2. `gh issue close` (if linked issue)\n\
-                             3. `task action=done` (if correlation_id present)\n\
-                             4. Report completion to lead",
+                             1. `gh issue close` (if linked issue)\n\
+                             2. `task action=done` (if correlation_id present)\n\
+                             3. Report completion to lead",
                             state.repo,
                             state.branch,
                             &merge_commit[..8.min(merge_commit.len())],
                             merged_at,
-                            state.branch,
                         );
                         let _ = crate::inbox::enqueue_with_idle_hint(
                             home,


### PR DESCRIPTION
## Summary
- Call `auto_release_for_merged_branch()` in scanner's `MergeState::Merged` branch before emitting `[pr-merged]` inbox event
- Removes manual `release_worktree` step from the action checklist since it's now automatic
- Prevents `gh pr merge --delete-branch` failure when worktree still holds the local branch

## Test plan
- [x] `cargo check` passes
- [x] All `daemon::pr_state` tests pass (22 tests)
- [x] All `daemon::auto_release` tests pass (14 tests)
- [ ] CI green

Closes #1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)