### PR TITLE
fix: propagate request_id in comms.rs api::call sites (#1341)

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -91,6 +91,7 @@ pub(super) fn handle_send_to_instance(
     let result = match crate::api::call(
         home,
         &json!({
+            "request_id": uuid::Uuid::new_v4().to_string(),
             "method": crate::api::method::SEND,
             // #1024 (closes #1002 ROOT 2): `reviewed_head` MUST be forwarded; see
             // sibling `handle_report_result` + `auto_release::is_verdict_message`.
@@ -358,6 +359,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
     let result = match crate::api::call(
         home,
         &json!({
+            "request_id": uuid::Uuid::new_v4().to_string(),
             "method": crate::api::method::SEND,
             "params": {
                 "from": sender.as_str(),
@@ -480,6 +482,7 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
         match crate::api::call(
             home,
             &json!({
+                "request_id": uuid::Uuid::new_v4().to_string(),
                 "method": crate::api::method::SEND,
                 "params": {
                     "from": sender.as_str(),


### PR DESCRIPTION
## Summary
- Add `request_id: Uuid::new_v4()` to all 3 `api::call` envelopes in `comms.rs`
- Enables daemon's `request_dedup::DedupCache` to deduplicate retries on the MCP→daemon path
- Previously these calls had no `request_id`, falling through to legacy no-dedup path

## Test plan
- [x] `cargo check` passes
- [x] All `api::request_dedup` tests pass (10 tests)
- [x] All `mcp::handlers::comms::p0c_tests` pass (4 tests)
- [ ] CI green

Closes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)