### PR TITLE
docs: session-35 updates (#1335/#1336/#1340/#1341/#1342/#1344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ### Added
 
+- **`notify_system` helper (#1335)** — `crate::inbox::notify_system()` encapsulates the common daemon notification pattern (`InboxMessage::new_system` + builder chain + `enqueue_with_idle_hint`). Seven daemon modules migrated: `anti_stall`, `decision_timeout`, `dispatch_idle`, `fixup_nudge`, `helper_staleness_watchdog`, `idle_watchdog`, `waiting_on_stale`. Reduces boilerplate from ~8 lines to 1 per notification site.
+- **Event bus (#1336)** — Global event bus behind feature flag `AGEND_EVENT_BUS=1`. `event_bus::emit_lazy(kind, || payload)` defers serialization when disabled; `event_bus::is_enabled()` allows callers to skip payload construction entirely. Zero-cost disabled path (no allocation, no serialization). In-memory broadcast channel with configurable capacity.
+- **`with_pr_state` flock helper (#1342)** — `pr_state::with_pr_state()` and `with_pr_state_or_create()` serialize all read-modify-write operations on `pr-state/*.json` files via `fs4` file locks. Eliminates the lost-update race where gh-poll save overwrites scanner's `ready_emitted_for_sha` flag, causing duplicate `[pr-merged]` notifications. All 6 production `save()` call sites migrated.
+- **Auto-release worktree on pr-merged (#1344)** — Scanner's `MergeState::Merged` branch now calls `auto_release_for_merged_branch()` before emitting `[pr-merged]`. Prevents `gh pr merge --delete-branch` failure when a dev's worktree still holds the local branch. Manual `release_worktree` step removed from the action checklist.
+
+### Changed
+
+- **`request_id` propagation in comms.rs (#1341)** — All three `api::call` sites in `comms.rs` (`handle_send_to_instance`, `handle_delegate_task`, `handle_report_result`) now include a UUIDv4 `request_id` in the JSON envelope, enabling the daemon's `request_dedup::DedupCache` to deduplicate retries on the MCP→daemon path.
+- **`dispatch_idle` flock (#1340)** — `mark_resolved` and `scan_and_emit` in `dispatch_idle` now use flock serialization to prevent race conditions between concurrent resolution and scan operations.
+
 - **`agy` backend (#987)** — Google Antigravity CLI as a sixth first-class backend alongside claude / kiro-cli / codex / opencode / gemini. Mirror-pattern addition: `Backend::Agy` variant + `configure_agy` writes `<workdir>/.antigravitycli/mcp_config.json` with the standard `mcpServers` stdio schema (`agend-mcp-bridge` unchanged). Resume via `agy --continue`. Calibrated against `tests/fixtures/state-replay/agy-thinking.raw` (agy 1.0.0 on macOS 14.5). Motivated by Gemini CLI sunset 2026-06-18; existing `gemini` backend retained for paid Code Assist Standard/Enterprise license holders. Operator note: AGY shares OAuth state with the Antigravity desktop app per OS user; multi-instance agents under the same `$HOME` share auth state (same convention as existing `gemini` backend — no daemon intercept).
 
 ### Changed (#994)

--- a/docs/FEATURE-communication.md
+++ b/docs/FEATURE-communication.md
@@ -225,6 +225,15 @@ When the daemon API call fails:
 
 Regardless of mode, messages are never lost. The inbox uses append-only JSONL format with file locking to ensure safe concurrent writes.
 
+### Idempotent Retry (#1341)
+
+All three MCP→daemon `api::call` sites (`send`, `delegate_task`,
+`report_result`) include a UUIDv4 `request_id` in the JSON envelope. The
+daemon's `request_dedup::DedupCache` uses this to deduplicate retries: if
+the same `request_id` arrives while the first call is still processing (or
+has already completed), the duplicate is suppressed or returns the cached
+result. Without `request_id`, the legacy at-least-once path applies.
+
 ---
 
 ## Inbox Operations

--- a/docs/FEATURE-dispatch-idle.md
+++ b/docs/FEATURE-dispatch-idle.md
@@ -191,6 +191,14 @@ Expired, cleaned-up, or report-dismissed sidecars do not appear.
 - L2 nudge target: target (recipient).
 - Tracking dismissal uses `correlation_id`, not sender or target identity.
 
+### Concurrency (#1340)
+
+`mark_resolved` (called from the MCP report handler) and `scan_and_emit`
+(called from the daemon tick) use flock serialization on the sidecar file
+to prevent lost-update races. Without locking, a concurrent `mark_resolved`
+could overwrite a sidecar that `scan_and_emit` was in the middle of
+processing, causing a missed or duplicate notification.
+
 ---
 
 ## Typical Flow

--- a/docs/FEATURE-worktree.md
+++ b/docs/FEATURE-worktree.md
@@ -15,6 +15,8 @@ collection, as well as the division of responsibility among `bind_self`,
 
 **Controlled cleanup.** After a task is completed and the PR is merged, the daemon soft-releases the worktree (marking it with `released_at`). The worktree remains on disk for a 24-hour grace period. If no one reclaims it, GC (`gc_cutover` with `AGEND_WORKTREE_GC=1`) removes it automatically. For stuck or orphaned worktrees, the operator can use `force_release_worktree` as an emergency measure.
 
+**Auto-release on merge (#1344).** When the pr_state scanner detects a PR has been merged, it automatically calls `auto_release_for_merged_branch` to free the worktree before emitting the `[pr-merged]` notification. This ensures `gh pr merge --delete-branch` succeeds without manual intervention. Dirty worktrees are skipped (with a warning log) and retried on the next scanner tick.
+
 ## 1. Design Rationale
 
 - Each agent works in its own isolated workspace to avoid branch conflicts and shared-checkout contention.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -925,6 +925,99 @@ back to sleep tuning.
 
 ---
 
+## Cross-Cutting: Daemon Notification & State Helpers
+
+### `notify_system` helper (#1335)
+
+Daemon modules that emit inbox notifications (watchdogs, timeouts, idle
+detectors) previously duplicated ~8 lines of `InboxMessage::new_system` +
+builder chain + `enqueue_with_idle_hint`. The `notify_system()` helper
+collapses this to a single call:
+
+```rust
+crate::inbox::notify_system(
+    home,
+    target,          // recipient agent name
+    "system:source", // source identifier
+    "event-kind",    // inbox message kind
+    body,            // message body (impl Into<String>)
+    correlation_id,  // Option<&str>
+    task_id,         // Option<&str>
+);
+```
+
+All `notify_system` messages use `delivery_mode("inbox_fallback")`. Modules
+that need different delivery modes (e.g. `cron_tick`, `daemon/mod.rs`
+schedule/query) should continue using `InboxMessage` directly.
+
+### Event bus (#1336)
+
+Feature-flagged global event bus for decoupled daemon-internal signaling.
+
+**Enable**: `AGEND_EVENT_BUS=1` environment variable.
+
+**Usage**:
+
+```rust
+// Zero-cost when disabled — closure never called.
+event_bus::emit_lazy("pr_state.merged", || {
+    json!({ "repo": repo, "branch": branch })
+});
+
+// Guard for callers that build expensive payloads.
+if event_bus::is_enabled() {
+    let payload = expensive_computation();
+    event_bus::emit("custom.event", payload);
+}
+```
+
+When disabled (default), `emit_lazy` returns immediately without allocating
+or evaluating the closure. `is_enabled()` is a single `AtomicBool` load.
+
+### `with_pr_state` flock helper (#1342)
+
+All mutations to `pr-state/*.json` files must go through `with_pr_state()`
+or `with_pr_state_or_create()`. These helpers:
+
+1. Acquire an `fs4` file lock on `<filename>.lock`
+2. Read + deserialize the current `PrState`
+3. Run the caller's mutation closure
+4. Serialize + `atomic_write` the result
+
+```rust
+// Mutate existing state (returns None if file doesn't exist).
+let result = with_pr_state(home, repo, branch, |state| {
+    state.ready_emitted_for_sha = Some(state.head_sha.clone());
+    ScanAction::Saved
+});
+
+// Create if absent (uses default_fn for initial state).
+with_pr_state_or_create(home, repo, branch, default_fn, |state| {
+    state.ci_results.push(result);
+});
+```
+
+This eliminates the lost-update race where concurrent writers (scanner tick
++ gh-poll) could overwrite each other's changes. The lock file is separate
+from the data file to avoid holding a lock on a file being atomically
+replaced.
+
+### Auto-release worktree on pr-merged (#1344)
+
+When the scanner detects `MergeState::Merged`, it calls
+`auto_release_for_merged_branch(home, &state.branch)` **before** emitting
+the `[pr-merged]` inbox notification. This function:
+
+1. Scans `runtime/<agent>/binding.json` for agents bound to the branch
+2. Acquires the binding lock
+3. Checks `is_worktree_clean` (dirty worktrees are skipped with a warning)
+4. Calls `release_full` to remove the worktree + clear the binding
+
+This ensures `gh pr merge --delete-branch` succeeds because no local
+worktree holds the branch ref.
+
+---
+
 ## Data Flow Summary
 
 ### User sends message via Telegram


### PR DESCRIPTION
## Summary
- **CHANGELOG.md**: 6 new entries under [Unreleased] — notify_system, event bus, pr_state flock, auto-release, dispatch_idle flock, request_id propagation
- **docs/architecture.md**: New "Cross-Cutting: Daemon Notification & State Helpers" section with usage guides for `notify_system`, event bus (`AGEND_EVENT_BUS=1`), `with_pr_state` flock pattern, and auto-release on merge
- **docs/FEATURE-worktree.md**: Auto-release on merge paragraph
- **docs/FEATURE-dispatch-idle.md**: Concurrency/flock section
- **docs/FEATURE-communication.md**: Idempotent retry section

## Test plan
- [x] Docs-only change, no code modifications
- [ ] CI green (markdown lint if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)