### PR TITLE
fix: filter .lock files from pr_state scanner read_dir (#1349)

### DIFF
--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -509,7 +509,11 @@ where
 /// terminal state (Merged / ClosedUnmerged) is observed and the
 /// `[pr-merged]` / `[pr-closed-unmerged]` events have been emitted.
 pub fn remove(home: &Path, repo: &str, branch: &str) -> std::io::Result<()> {
-    let path = pr_state_dir(home).join(pr_state_filename(repo, branch));
+    let dir = pr_state_dir(home);
+    let filename = pr_state_filename(repo, branch);
+    let path = dir.join(&filename);
+    let lock_path = dir.join(format!("{filename}.lock"));
+    let _ = std::fs::remove_file(&lock_path);
     match std::fs::remove_file(&path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -43,6 +43,9 @@ pub fn scan_and_emit_with(
     };
     for entry in entries.flatten() {
         let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
         let content = match std::fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {
@@ -229,6 +232,9 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
     let mut skipped_should_poll = 0u32;
     for entry in entries.flatten() {
         let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
         let content = match std::fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {


### PR DESCRIPTION
## Summary
- Scanner and `apply_gh_poll` `read_dir` loops now skip non-`.json` files, preventing WARN spam from empty `.lock` files created by `with_pr_state` (#1342)
- `remove()` also deletes the companion `.lock` file to prevent orphaned lock files accumulating

## Test plan
- [x] `cargo check` passes
- [x] All `daemon::pr_state` tests pass
- [ ] CI green
- [ ] After deploy: verify WARN spam in `app.log` stops

Closes #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)