### PR TITLE
feat: /setup-telegram skill + skill add url#subdir support (#1351)

### DIFF
--- a/skills/setup-telegram/SKILL.md
+++ b/skills/setup-telegram/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: setup-telegram
+description: Interactive guide to configure a Telegram channel for AgEnD — creates bot, detects group, writes fleet.yaml
+---
+
+# /setup-telegram — Telegram Channel Setup
+
+Guide the user through setting up a Telegram bot channel for AgEnD. Use `AskUserQuestion` for choices, `Bash` (curl) for API verification, and `Read`/`Edit`/`Write` for config files.
+
+## Prerequisites
+
+Before starting, locate the AgEnD home directory:
+
+```bash
+echo "${AGEND_HOME:-$HOME/.agend-terminal}"
+```
+
+Store this as `AGEND_HOME` for all subsequent steps.
+
+## Step 1: Create a Bot via BotFather
+
+Tell the user:
+
+> 1. Open Telegram and talk to **@BotFather**
+> 2. Send `/newbot` and follow the instructions to name your bot
+> 3. Copy the bot token (looks like `123456789:ABCdef...`)
+
+Ask for the token using `AskUserQuestion`:
+- Question: "Paste your bot token from BotFather"
+- Options: provide a "Skip — configure later" option
+
+If skipped, tell the user they can run `/setup-telegram` again later and stop here.
+
+## Step 2: Validate Token Format
+
+Check the token matches the pattern `<digits>:<35+ alphanumeric chars>`:
+
+```bash
+echo "$TOKEN" | grep -qE '^[0-9]{8,}:[A-Za-z0-9_-]{30,}$'
+```
+
+If invalid, warn the user and ask whether to re-enter, continue anyway, or skip.
+
+## Step 3: Verify Bot with Telegram API
+
+```bash
+curl -s "https://api.telegram.org/bot${TOKEN}/getMe"
+```
+
+Check that `result.is_bot` is `true`. Print the bot username on success. On failure, offer re-enter or skip.
+
+## Step 4: Group Setup
+
+Tell the user:
+
+> 1. Create a Telegram **supergroup** (or use an existing one)
+> 2. Enable **Topics** in group settings (Group → Edit → Topics)
+> 3. Add the bot to the group **as admin**
+> 4. Send any message in the group
+
+Then poll for the group using `getUpdates`:
+
+```bash
+curl -s "https://api.telegram.org/bot${TOKEN}/getUpdates?timeout=30&allowed_updates=[\"message\"]"
+```
+
+Parse the response to find a supergroup chat (type == "supergroup"). Extract `chat.id` and `chat.title`. Retry up to 6 times (total ~3 minutes). If no group detected, ask the user to enter the group_id manually or skip.
+
+## Step 5: Verify Bot is Admin
+
+```bash
+curl -s "https://api.telegram.org/bot${TOKEN}/getChatMember?chat_id=${GROUP_ID}&user_id=${BOT_ID}"
+```
+
+Check that `result.status` is `"administrator"` or `"creator"`. If not, warn the user:
+
+> The bot must be a group admin for topic mode to work. Go to group settings and promote the bot to admin.
+
+This is a warning, not a blocker — continue regardless.
+
+## Step 6: User Allowlist
+
+Ask the user for their Telegram user ID(s):
+
+> Send a message to **@userinfobot** on Telegram to get your user ID (a number like `123456789`).
+
+Collect one or more user IDs. These go into `user_allowlist` in fleet.yaml.
+
+## Step 7: Save Token Securely
+
+Save the token to `$AGEND_HOME/.env`:
+
+```bash
+# Read existing .env, replace or append AGEND_BOT_TOKEN
+```
+
+Rules:
+- If `AGEND_BOT_TOKEN` already exists in `.env`, ask before overwriting (default: keep existing)
+- After writing, set permissions: `chmod 600 "$AGEND_HOME/.env"`
+- Check if `.gitignore` covers `.env` — if not, warn the user
+
+**NEVER write the token value directly into fleet.yaml or any YAML config.** Always use `bot_token_env: AGEND_BOT_TOKEN` which references the environment variable.
+
+## Step 8: Update fleet.yaml
+
+Read the existing `$AGEND_HOME/fleet.yaml`. If a `channel:` section already exists, ask before overwriting (default: keep existing, back up to `fleet.yaml.bak`).
+
+Add or update the channel section:
+
+```yaml
+channel:
+  type: telegram
+  bot_token_env: AGEND_BOT_TOKEN
+  group_id: <detected or entered group_id>
+  mode: topic
+  user_allowlist: [<user_ids>]
+```
+
+Use `Edit` to modify the existing file if possible, or `Write` if creating from scratch.
+
+## Step 9: Final Checklist
+
+Print a summary:
+
+> **Setup complete!**
+> - Bot: @<bot_username>
+> - Group: <group_title> (<group_id>)
+> - Token: stored in `$AGEND_HOME/.env` (env var: `AGEND_BOT_TOKEN`)
+> - Config: `$AGEND_HOME/fleet.yaml` updated
+>
+> **Next steps:**
+> 1. Restart the daemon: `agend restart`
+> 2. Send a message in the Telegram group to verify delivery
+
+## Security Guardrails
+
+These rules are mandatory and must not be bypassed:
+
+1. **Token as env var reference only** — fleet.yaml must use `bot_token_env: AGEND_BOT_TOKEN`, never inline the token string
+2. **chmod 600** — `.env` file must be owner-read/write only
+3. **gitignore check** — warn if `.env` is not covered by `.gitignore`
+4. **Token format validation** — verify format before making API calls
+5. **No token in output** — when displaying the token back to the user, mask it: show first 4 and last 4 characters only (e.g., `1234...wxyz`)

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -181,21 +181,45 @@ pub fn add(home: &Path, source: &str) -> Result<Skill> {
             copy_dir_recursive(&p, &dest)
                 .with_context(|| format!("copy {} → {}", p.display(), dest.display()))?;
         }
-        SourceKind::Git(url) => {
-            // `git clone` shell-out — same approach as the rest of
-            // the codebase (e.g. dispatch_hook source-repo). Wipe
-            // first so re-add is deterministic.
+        SourceKind::Git(url, subdir) => {
             if dest.exists() {
                 std::fs::remove_dir_all(&dest)
                     .with_context(|| format!("clean dest {}", dest.display()))?;
             }
-            let status = std::process::Command::new("git")
-                .args(["clone", "--depth=1", url.as_str()])
-                .arg(&dest)
-                .status()
-                .context("spawn git clone")?;
-            if !status.success() {
-                return Err(anyhow!("git clone failed for {url}: status={status}"));
+            if let Some(sub) = subdir {
+                let tmp = root.join(".git-clone-tmp");
+                if tmp.exists() {
+                    std::fs::remove_dir_all(&tmp)
+                        .with_context(|| format!("clean clone tmp {}", tmp.display()))?;
+                }
+                let status = std::process::Command::new("git")
+                    .args(["clone", "--depth=1", url.as_str()])
+                    .arg(&tmp)
+                    .status()
+                    .context("spawn git clone")?;
+                if !status.success() {
+                    let _ = std::fs::remove_dir_all(&tmp);
+                    return Err(anyhow!("git clone failed for {url}: status={status}"));
+                }
+                let sub_path = tmp.join(&sub);
+                if !sub_path.exists() || !sub_path.is_dir() {
+                    let _ = std::fs::remove_dir_all(&tmp);
+                    return Err(anyhow!(
+                        "subdirectory '{sub}' not found in cloned repo {url}"
+                    ));
+                }
+                copy_dir_recursive(&sub_path, &dest)
+                    .with_context(|| format!("copy subdir {sub} → {}", dest.display()))?;
+                let _ = std::fs::remove_dir_all(&tmp);
+            } else {
+                let status = std::process::Command::new("git")
+                    .args(["clone", "--depth=1", url.as_str()])
+                    .arg(&dest)
+                    .status()
+                    .context("spawn git clone")?;
+                if !status.success() {
+                    return Err(anyhow!("git clone failed for {url}: status={status}"));
+                }
             }
         }
     }
@@ -573,7 +597,8 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 #[derive(Debug)]
 enum SourceKind {
     Path(PathBuf),
-    Git(String),
+    /// (clone_url, optional subdirectory path within the repo)
+    Git(String, Option<String>),
 }
 
 fn classify_source(source: &str) -> Result<(String, SourceKind)> {
@@ -581,15 +606,30 @@ fn classify_source(source: &str) -> Result<(String, SourceKind)> {
     if trimmed.is_empty() {
         return Err(anyhow!("empty skill source"));
     }
-    let is_git = trimmed.starts_with("git@")
-        || trimmed.starts_with("https://")
-        || trimmed.starts_with("http://")
-        || trimmed.starts_with("ssh://")
-        || trimmed.ends_with(".git");
+    let (url_part, fragment) = match trimmed.split_once('#') {
+        Some((u, f)) if !f.is_empty() => (u, Some(f)),
+        _ => (trimmed, None),
+    };
+    let is_git = url_part.starts_with("git@")
+        || url_part.starts_with("https://")
+        || url_part.starts_with("http://")
+        || url_part.starts_with("ssh://")
+        || url_part.ends_with(".git");
     if is_git {
-        let name = git_repo_name(trimmed)
-            .ok_or_else(|| anyhow!("could not derive skill name from URL: {trimmed}"))?;
-        Ok((name, SourceKind::Git(trimmed.to_string())))
+        let name = if let Some(sub) = fragment {
+            Path::new(sub)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(String::from)
+                .ok_or_else(|| anyhow!("could not derive skill name from subdir: {sub}"))?
+        } else {
+            git_repo_name(url_part)
+                .ok_or_else(|| anyhow!("could not derive skill name from URL: {url_part}"))?
+        };
+        Ok((
+            name,
+            SourceKind::Git(url_part.to_string(), fragment.map(String::from)),
+        ))
     } else {
         let path = PathBuf::from(trimmed);
         let abs = if path.is_absolute() {
@@ -872,13 +912,32 @@ mod tests {
     fn classify_source_distinguishes_git_and_path() {
         let (name, kind) = classify_source("https://github.com/foo/bar.git").unwrap();
         assert_eq!(name, "bar");
-        assert!(matches!(kind, SourceKind::Git(_)));
+        assert!(matches!(kind, SourceKind::Git(..)));
         let (name, kind) = classify_source("git@github.com:foo/bar").unwrap();
         assert_eq!(name, "bar");
-        assert!(matches!(kind, SourceKind::Git(_)));
+        assert!(matches!(kind, SourceKind::Git(..)));
         let (name, kind) = classify_source("/tmp/local-skill").unwrap();
         assert_eq!(name, "local-skill");
         assert!(matches!(kind, SourceKind::Path(_)));
+    }
+
+    #[test]
+    fn classify_source_git_subdir_fragment() {
+        let (name, kind) =
+            classify_source("https://github.com/foo/bar#skills/setup-telegram").unwrap();
+        assert_eq!(name, "setup-telegram");
+        assert!(matches!(kind, SourceKind::Git(_, Some(_))));
+        if let SourceKind::Git(url, Some(sub)) = kind {
+            assert_eq!(url, "https://github.com/foo/bar");
+            assert_eq!(sub, "skills/setup-telegram");
+        }
+    }
+
+    #[test]
+    fn classify_source_git_no_fragment() {
+        let (name, kind) = classify_source("https://github.com/foo/bar").unwrap();
+        assert_eq!(name, "bar");
+        assert!(matches!(kind, SourceKind::Git(_, None)));
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -202,7 +202,15 @@ pub fn add(home: &Path, source: &str) -> Result<Skill> {
                     return Err(anyhow!("git clone failed for {url}: status={status}"));
                 }
                 let sub_path = tmp.join(&sub);
-                if !sub_path.exists() || !sub_path.is_dir() {
+                let resolved = sub_path.canonicalize().unwrap_or_default();
+                let tmp_canon = tmp.canonicalize().unwrap_or_default();
+                if !resolved.starts_with(&tmp_canon) || resolved == tmp_canon {
+                    let _ = std::fs::remove_dir_all(&tmp);
+                    return Err(anyhow!(
+                        "subdir path '{sub}' escapes clone root — path traversal rejected"
+                    ));
+                }
+                if !resolved.is_dir() {
                     let _ = std::fs::remove_dir_all(&tmp);
                     return Err(anyhow!(
                         "subdirectory '{sub}' not found in cloned repo {url}"


### PR DESCRIPTION
## Summary
- Add `url#subdir` fragment support to `skill add` — clones repo to temp dir, copies only the specified subdirectory to unified source. Skill name derived from subdir basename.
- Add `skills/setup-telegram/SKILL.md` — interactive guide for Telegram channel setup (BotFather, token verification, group detection, fleet.yaml config, security guardrails)
- Install via: `agend skill add https://github.com/suzuke/agend-terminal#skills/setup-telegram`

## Test plan
- [x] `classify_source_git_subdir_fragment` — parses `url#subdir`, name from subdir basename
- [x] `classify_source_git_no_fragment` — existing behavior unchanged
- [x] `classify_source_distinguishes_git_and_path` — existing test passes
- [x] `classify_source_rejects_empty` — existing test passes
- [ ] Manual: `agend skill add https://github.com/suzuke/agend-terminal#skills/setup-telegram` installs `setup-telegram` skill
- [ ] Manual: `/setup-telegram` triggers the skill in Claude/Codex backend

Closes #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)