### PR TITLE
fix(#1356): freeze scroll position during mouse text selection

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -370,6 +370,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -367,6 +367,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1205,6 +1205,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -428,6 +428,9 @@ fn handle_selection(layout: &mut Layout, mouse: &MouseEvent) {
                 {
                     let col = mouse.column - inner_x;
                     let row = mouse.row - inner_y;
+                    // #1356: snapshot max_scroll so effective_scroll_offset
+                    // compensates for new output during the selection gesture.
+                    pane.selection_scroll_freeze = Some(pane.vterm.max_scroll());
                     pane.selection = Some(crate::layout::Selection {
                         start: (row, col),
                         end: (row, col),
@@ -446,19 +449,19 @@ fn handle_selection(layout: &mut Layout, mouse: &MouseEvent) {
             MouseEventKind::Up(MouseButton::Left) => {
                 if let Some(ref sel) = pane.selection {
                     if sel.start == sel.end {
-                        // Click without drag — clear the zero-width selection
-                        // to avoid a 1-cell white block artifact.
                         pane.selection = None;
                     } else {
-                        let text = pane
-                            .vterm
-                            .extract_text(sel.start, sel.end, pane.scroll_offset);
+                        let text = pane.vterm.extract_text(
+                            sel.start,
+                            sel.end,
+                            pane.effective_scroll_offset(),
+                        );
                         if !text.is_empty() {
                             copy_to_clipboard(&text);
                         }
                     }
                 }
-                // Keep selection visible — cleared on next mouse down or keypress.
+                pane.selection_scroll_freeze = None;
                 true
             }
             _ => false,
@@ -543,6 +546,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -196,6 +196,7 @@ pub(super) fn create_pane(
         last_input_at: None,
         pending_notification_count: 0,
         selection: None,
+        selection_scroll_freeze: None,
         source: crate::layout::PaneSource::Local,
     })
 }
@@ -258,6 +259,7 @@ pub(super) fn attach_pane(
         last_input_at: None,
         pending_notification_count: 0,
         selection: None,
+        selection_scroll_freeze: None,
         source: crate::layout::PaneSource::Local,
     })
 }
@@ -437,6 +439,7 @@ pub(super) fn create_remote_pane(
         last_input_at: None,
         pending_notification_count: 0,
         selection: None,
+        selection_scroll_freeze: None,
         source: crate::layout::PaneSource::Remote(Arc::new(Mutex::new(client))),
     })
 }

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -513,6 +513,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -603,6 +603,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -273,6 +273,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -44,6 +44,10 @@ pub struct Pane {
     pub pending_notification_count: usize,
     /// Active text selection (grid coordinates within this pane's VTerm).
     pub selection: Option<Selection>,
+    /// `max_scroll()` snapshot at selection start. Used to compensate for
+    /// new output during selection so the viewport stays pinned to the
+    /// same content.
+    pub selection_scroll_freeze: Option<usize>,
     /// Whether input/resize go to a local PTY (via registry) or a remote
     /// daemon-hosted agent (via `BridgeClient`).
     pub source: PaneSource,
@@ -59,6 +63,19 @@ pub struct Selection {
 }
 
 impl Pane {
+    /// Effective scroll offset: during active selection, compensates for
+    /// new output since selection started so the viewport stays pinned.
+    pub fn effective_scroll_offset(&self) -> usize {
+        match self.selection_scroll_freeze {
+            Some(frozen_max) => {
+                let current_max = self.vterm.max_scroll();
+                let drift = current_max.saturating_sub(frozen_max);
+                self.scroll_offset.saturating_add(drift)
+            }
+            None => self.scroll_offset,
+        }
+    }
+
     /// Display label: display_name if set, otherwise agent_name.
     pub fn label(&self) -> &str {
         self.display_name.as_deref().unwrap_or(&self.agent_name)
@@ -160,6 +177,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/layout/split.rs
+++ b/src/layout/split.rs
@@ -313,6 +313,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/layout/tab.rs
+++ b/src/layout/tab.rs
@@ -368,6 +368,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -365,6 +365,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
     }

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -416,8 +416,9 @@ fn render_pane(
             priority,
         };
     }
+    let render_offset = pane.effective_scroll_offset();
     pane.vterm
-        .render_to_buffer(frame.buffer_mut(), inner, pane.scroll_offset, !focused);
+        .render_to_buffer(frame.buffer_mut(), inner, render_offset, !focused);
 
     if let Some(ref sel) = pane.selection {
         let (s, e) = if sel.start <= sel.end {
@@ -448,7 +449,7 @@ fn render_pane(
         let (cursor_line, cursor_col) = pane.vterm.cursor_pos();
         let max_x = inner.x + inner.width.saturating_sub(1);
         let max_y = inner.y + inner.height.saturating_sub(1);
-        let (cx, cy) = if pane.scroll_offset == 0 {
+        let (cx, cy) = if render_offset == 0 {
             (
                 (inner.x + cursor_col).min(max_x),
                 (inner.y + cursor_line).min(max_y),
@@ -608,6 +609,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 3,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         };
         let segments = pane_title_segments(&pane, Style::default());
@@ -634,6 +636,7 @@ mod tests {
             last_input_at: None,
             pending_notification_count: 0,
             selection: None,
+            selection_scroll_freeze: None,
             source: PaneSource::Local,
         };
         let segments = pane_title_segments(&pane, Style::default());
@@ -679,6 +682,7 @@ mod tests {
                 last_input_at: None,
                 pending_notification_count: 0,
                 selection: None,
+                selection_scroll_freeze: None,
                 source: PaneSource::Local,
             },
         );


### PR DESCRIPTION
## Summary

- Adds `selection_scroll_freeze: Option<usize>` to `Pane` — snapshots `max_scroll()` at selection start
- `effective_scroll_offset()` compensates for grid growth during selection: `scroll_offset + (current_max_scroll - frozen_max_scroll)`
- Render path and `extract_text` use effective offset so viewport stays pinned during selection gesture
- MouseUp clears freeze to resume live scrolling

## Test plan

- [x] All 26 mouse tests pass
- [x] All 54 vterm tests pass
- [x] All 50 layout tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Manual: select text in a pane receiving active output, verify highlight doesn't drift
- [ ] Manual: verify copied text matches visual selection
- [ ] Manual: verify auto-scroll resumes after releasing selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)