### PR TITLE
release: prep v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,63 +5,19 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-28
+
+200+ commits since `0.6.1` over Sprint 55–69 (May 7 → May 28, 2026). Three themes dominate:
+**(1) Task board reliability** — ghost-owner class root-caused and prevented (`teams::delete` cascade, boot orphan sweep, `force` flag) + new sweepers + operator-visible health snapshot; **(2) Bridge ↔ daemon idempotent retry** — eliminates the double-execution class for side-effect MCP calls under transient transport failures (UUID request_id + DedupCache + Condvar block-wait); **(3) MCP handler refactor #694 complete** — all 30+ tool dispatch arms migrated from inline `match` to a dispatch table, paving the way for tool registry hot-reload (#776). Plus Hung detection shadow-mode foundations (F9 Stage 1–3), rate-limit recovery auto-prompt, and ~50 smaller bug fixes / hardening PRs.
+
 ### Added
 
 - **`notify_system` helper (#1335)** — `crate::inbox::notify_system()` encapsulates the common daemon notification pattern (`InboxMessage::new_system` + builder chain + `enqueue_with_idle_hint`). Seven daemon modules migrated: `anti_stall`, `decision_timeout`, `dispatch_idle`, `fixup_nudge`, `helper_staleness_watchdog`, `idle_watchdog`, `waiting_on_stale`. Reduces boilerplate from ~8 lines to 1 per notification site.
 - **Event bus (#1336)** — Global event bus behind feature flag `AGEND_EVENT_BUS=1`. `event_bus::emit_lazy(kind, || payload)` defers serialization when disabled; `event_bus::is_enabled()` allows callers to skip payload construction entirely. Zero-cost disabled path (no allocation, no serialization). In-memory broadcast channel with configurable capacity.
 - **`with_pr_state` flock helper (#1342)** — `pr_state::with_pr_state()` and `with_pr_state_or_create()` serialize all read-modify-write operations on `pr-state/*.json` files via `fs4` file locks. Eliminates the lost-update race where gh-poll save overwrites scanner's `ready_emitted_for_sha` flag, causing duplicate `[pr-merged]` notifications. All 6 production `save()` call sites migrated.
 - **Auto-release worktree on pr-merged (#1344)** — Scanner's `MergeState::Merged` branch now calls `auto_release_for_merged_branch()` before emitting `[pr-merged]`. Prevents `gh pr merge --delete-branch` failure when a dev's worktree still holds the local branch. Manual `release_worktree` step removed from the action checklist.
-
-### Changed
-
-- **`request_id` propagation in comms.rs (#1341)** — All three `api::call` sites in `comms.rs` (`handle_send_to_instance`, `handle_delegate_task`, `handle_report_result`) now include a UUIDv4 `request_id` in the JSON envelope, enabling the daemon's `request_dedup::DedupCache` to deduplicate retries on the MCP→daemon path.
-- **`dispatch_idle` flock (#1340)** — `mark_resolved` and `scan_and_emit` in `dispatch_idle` now use flock serialization to prevent race conditions between concurrent resolution and scan operations.
-
-- **`agy` backend (#987)** — Google Antigravity CLI as a sixth first-class backend alongside claude / kiro-cli / codex / opencode / gemini. Mirror-pattern addition: `Backend::Agy` variant + `configure_agy` writes `<workdir>/.antigravitycli/mcp_config.json` with the standard `mcpServers` stdio schema (`agend-mcp-bridge` unchanged). Resume via `agy --continue`. Calibrated against `tests/fixtures/state-replay/agy-thinking.raw` (agy 1.0.0 on macOS 14.5). Motivated by Gemini CLI sunset 2026-06-18; existing `gemini` backend retained for paid Code Assist Standard/Enterprise license holders. Operator note: AGY shares OAuth state with the Antigravity desktop app per OS user; multi-instance agents under the same `$HOME` share auth state (same convention as existing `gemini` backend — no daemon intercept).
-
-### Changed (#994)
-
-- **`doctor topics` taxonomy reduced from 4 classes to 2** — `drift_fleet` and `stale_registry` classes removed. With topics.json as the single source of truth for topic_id (Phase 1 #1062), there is no second source to drift against. Only `live` (instance in fleet.yaml) and `orphan` (instance retired) remain. The `--prefer-fleet` / `--prefer-registry` CLI flags are removed (no drift to resolve). JSON output `schema_version` bumped to 2. Operator awareness — not regression: the removed classes were unreachable since #1062.
-
-### Changed (#995)
-
-- **`agy` backend display name** — TUI Backend picker (ctrl+b c) and serialized `Backend::Agy.name()` now return `antigravity-cli` instead of the binary name `agy`. The binary command (`preset().command`) remains `agy`; `parse_str` still accepts the `agy` / `antigravity` / `antigravity-cli` aliases for backward-compat with fleet.yaml entries written before #995.
-- **`agy` workspace-trust prompt auto-dismissed** — fresh agy spawns previously sat at the interactive "Do you trust this folder?" gate requiring `↑/↓` + Enter from a human. The `--dangerously-skip-permissions` flag only auto-approves tool-permission requests (per `agy --help`), not the workspace-trust prompt. Mirrors Codex precedent (#468 anchored regex): `dismiss_patterns` matches the "Yes, I trust" line — Enter alone confirms since the prompt pre-selects the trust option.
-- **`agy` backend ships with `fleet_mcp_supported: false` (#995 Bug 3)** — empirical testing proved AGY discovers `<workdir>/.antigravitycli/mcp_config.json` for project-ID storage but ignores its `mcpServers` field; only HOME-level `~/.gemini/antigravity-cli/mcp_config.json` actually loads MCP servers. The fleet scope rule (`src/mcp_config.rs:5-11`) forbids HOME-level writes, so the `agend-mcp-bridge` cannot be configured for agy in the current AGY release. `configure_agy` is now a no-op (previous project-local write was dead code). Daemon spawn path emits a `[fleet-mcp-unsupported]` `tracing::warn` so operators see in `app.log` why fleet `send`/`inbox`/`task` tools are unavailable in agy instances. Use agy for manual / non-fleet work until upstream (filed at google-antigravity/antigravity-cli) adds project-local `mcpServers` loading.
-- **`agend-terminal admin cleanup-zombies` (#927 PR-B)** — kill long-running zombie daemons holding stale `<home>/run/<pid>/` directories. Lists candidates whose `.daemon` mtime is older than `--age` (default `14d`), prompts `[y/N]` unless `--yes` is supplied. Platform-asymmetric termination by design (#936 closed): Unix uses `SIGTERM` → 5 s grace → `SIGKILL`; Windows uses `TerminateProcess` single-stage.
-- **`AGEND_DAEMON_BOOT_SWEEP_AGE_DAYS=<N>` (#933)** — daemon-boot stale-`run/<pid>/` GC. Sweeps run directories older than N days. `0` / unset disables. Destructive — see `AGEND_DAEMON_BOOT_SWEEP_DRY_RUN`.
-- **`AGEND_DAEMON_BOOT_SWEEP_DRY_RUN=1` (#933)** — log-only mode for the boot sweep. Pair with `AGE_DAYS` for safe trials before flipping the destructive switch. `grep "boot-sweep" $AGEND_HOME/daemon.log` shows the candidate set.
-- **`AGEND_DAEMON_THREAD_DUMP_SECS=<N>` (#941)** — periodic in-process thread state dump every N seconds. Output appears in `daemon.log` with `thread-dump` lines. Zero overhead when unset (closes #932 zombie-debugging observability gap).
-- **`.ready` boot-completion sentinel (#922)** — daemon writes `<home>/run/<pid>/.ready` once the agent spawn loop finishes. Companion to the existing `.daemon` / `api.cookie` / `api.port` lifecycle files. Single-signal policy: future sub-stage readiness MUST extend `.ready`'s content rather than introduce a new file. See `CLAUDE.md` for poll caveats (stale-marker safety requires PID-liveness check — use `agend-terminal doctor` or combine `.ready` + `kill -0` on the run dir's `.daemon` PID).
-- **`bootstrap-step` instrumentation (#945 Phase 0)** — every step in `bootstrap::prepare` emits a `bootstrap-step` tracing line with `step=<name>` + `elapsed_ms=<n>`. Operators can extract the cold-boot timing breakdown via `grep "bootstrap-step" $AGEND_HOME/daemon.log | sort -t= -k3 -n -r`.
-- **State detection red SGR anchor for HIGH_FP patterns (#919 Phase A)** — patterns marked `HIGH_FP` (generic strings like `"Error"`, `"failed"`) now require a red SGR escape (`\x1b[31m` family) within 200 bytes / 30 s of the match. Closes the class of false transitions where a backend echoed an error string from a user prompt without color and the daemon misclassified the agent. `Backend::has_red_anchor()` opts in per-backend; the gate fails open when the backend doesn't emit consistent color signaling.
-
-### Added (#686 — maintainer-only)
-
-- **CI code coverage (cargo-llvm-cov + Codecov)** — `.github/workflows/ci.yml` adds a new `coverage` job that runs `cargo llvm-cov --workspace --tests --features tray` on Ubuntu and uploads an lcov report to Codecov. `fail_ci_if_error: false` keeps PRs mergeable when codecov.io is unreachable or unconfigured. `codecov.yml` configures a 2% project threshold + 80% patch target. **Zero end-user impact** — coverage is maintainer-side QA infrastructure; `cargo install agend-terminal` and operating the fleet do not touch codecov. Operator-side setup: link the GitHub repo to Codecov.io to surface the report (no token required for public repos; optional `CODECOV_TOKEN` secret tightens rate limits).
-
-### Changed
-
-- **`agend-terminal list --json` envelope (#938)** — JSON output now wraps the agent array in a discriminated envelope: `{mode: "live" | "fallback_daemon_stuck" | "fallback_daemon_absent", agents: [...]}`. Operator scripts can distinguish authoritative output from offline fallbacks. Plain (non-JSON) output adds a one-line stderr hint when `mode != live`. `--legacy-json` opts back into the pre-#938 shape for one release cycle.
-- **`AGEND_LOG` precedence (#927 PR-A)** — env-set value now reliably wins over the in-code default (`agend_terminal=info`). Default applies only when the var is unset or empty. Previously the implementation occasionally clobbered caller-set values.
-- **`telegram_init` fire-and-forget (#945 Phase 1)** — `bootstrap::telegram_init::init` returns `None` immediately and spawns a background thread to do the actual 5–10 sequential `bot.create_forum_topic` HTTP calls + fleet-binding resolve. Cold-boot wall time drops from ~6.6 s to ~0.5 s. `active_channel()` returns `None` until init completes; callers (all on >10 s cadence) tolerate this. Registry attachment uses a `PENDING_REGISTRY` `OnceLock` bridge — bounded 30 s poll covers the race where the bg thread finishes before the caller publishes.
-- **CI-watch correlation_id format (#946)** — every `system:ci` inbox notification (pass / fail / stalled / conflict) now carries `correlation_id = "{repo}@{branch}"` instead of `None`. Stable identifier per watched branch enables `grep '"correlation_id":"owner/repo@branch"' inbox/*.jsonl` filtering.
-- **`dispatch_idle` watchdog fallback correlation_id (#947)** — when the watchdog fires on a dispatch whose upstream had no `correlation_id`, the synthesized fallback now uses the canonical `disp-<unix_micros>-<seq>` dispatch id format (self-documenting via prefix, stable across dispatch + report). Pre-#947 the fallback was `None` or a churning per-call ULID with no cross-message tie.
-- **`ci_watch` file identity hardening (#942 / #943)** — watch filenames now use sha256 (64 hex chars; pre-#943 used `DefaultHasher` / 16 hex chars, ~2^32 brute force) over a canonicalized repo slug (#942 — 7 divergent forms `git@github.com:owner/repo.git`, `https://github.com/owner/repo[.git]`, raw `owner/repo`, case variants are all collapsed to canonical `owner/repo`). Legacy files are migrated synchronously at boot via `migrate_legacy_watch_filenames` (#942/#943 PR-B): scans `<home>/ci-watches/*.json`, identifies non-canonical filenames by stem length, rewrites `repo` field + filename. Idempotent. Conflicts log a warning with FIRST-wins resolution.
-- **`ci_watch` survives bind/release handoff (#931)** — `release_worktree`'s sole-subscriber cleanup no longer destroys the watch file. `next_after_ci` chain (workflow handoff target), `last_notified_head_sha`, and polling state all persist. The next agent that binds the same branch inherits the chain so `dispatch_auto_bind_lease`'s `[ci-ready-for-action]` handoff fires automatically on the next CI green tick. Unblocks the `dev → ci → reviewer` chain and analogous multi-agent workflows.
-
-### Test infrastructure
-
-- **`admin::cleanup_zombies::poll_until_dead` (#934)** — `pub(crate)` deterministic primitive. Polls `kill -0` (Unix) / `OpenProcess` (Windows) every 10 ms up to a timeout; returns `bool`. Replaces sleep-tuned waits in `agent.rs` shutdown + `process.rs` reaper tests. SOP 1 (§3.20) compliance.
-- **`api::handlers::instance::await_sentinel_nonempty` (#949, rename)** — pre-#949 named for *file existing*, but the instance-boot callers needed *content present* (file is created empty then written to). Renamed to make the contract clear; flake at the four call sites is gone.
-
-## [0.7.0] — 2026-05-16
-
-150+ commits since `0.6.1` over Sprint 55–65 (May 7 → May 16, 2026). Three themes dominate:
-**(1) Task board reliability** — ghost-owner class root-caused and prevented (`teams::delete` cascade, boot orphan sweep, `force` flag) + new sweepers + operator-visible health snapshot; **(2) Bridge ↔ daemon idempotent retry** — eliminates the double-execution class for side-effect MCP calls under transient transport failures (UUID request_id + DedupCache + Condvar block-wait); **(3) MCP handler refactor #694 complete** — all 30+ tool dispatch arms migrated from inline `match` to a dispatch table, paving the way for tool registry hot-reload (#776). Plus Hung detection shadow-mode foundations (F9 Stage 1–3), rate-limit recovery auto-prompt, and ~50 smaller bug fixes / hardening PRs.
-
-### Added
-
+- **`/setup-telegram` skill + `skill add` URL#subdir support (#1351, PR #1354)** — per-channel install skill for guided Telegram setup. `skill add <url>#<subdir>` clones a skill repo and installs a subdirectory as a skill.
+- **CI code coverage (cargo-llvm-cov + Codecov, #686)** — `.github/workflows/ci.yml` adds a `coverage` job that runs `cargo llvm-cov --workspace --tests --features tray` on Ubuntu and uploads an lcov report to Codecov. `fail_ci_if_error: false` keeps PRs mergeable when codecov.io is unreachable. Maintainer-only infrastructure.
 - **Bridge ↔ daemon idempotent retry (#842, PR #843)** — bridge generates UUID v4 `request_id` per JSON envelope; retry on transport failure reuses the same id. New `src/api/request_dedup.rs` `DedupCache` (TTL 10min, 64KB/entry, 64MB ceiling, Condvar block-wait aligned to per-method timeout 5/30/60s, waiter_cap=8, RAII panic guard) caches completed responses + blocks in-flight duplicates. Caller-side retries are now safe by construction for any side-effect MCP call. Backward-compatible: missing `request_id` skips dedup (legacy clients).
 - **`task action=health` (#830, PR #838)** — operator self-serve board hygiene snapshot. Returns totals + by_status + ghost_owners (strict + soft) + stale_claims + age distribution (over_30d / over_90d / median) + recommendations array. Single-call alternative to scanning the full task list when checking "is the board healthy?". Cross-references `scan_orphan_candidates` (#829) for accuracy.
 - **`task action=sweep` (#806, PR #810)** — operator-triggered stale-task cleanup. 4 categories (`shipped` / `superseded` / `team_disbanded` / `validation_leftovers`) with dry-run by default + `confirm_ids` + `audit_reason` required for apply. Dual-channel audit (per-task event + event_log.jsonl `task_sweep_apply`). System identity `system:task_sweep`.
@@ -103,6 +59,26 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ### Changed
 
+- **`request_id` propagation in comms.rs (#1341)** — All three `api::call` sites in `comms.rs` now include a UUIDv4 `request_id` in the JSON envelope, enabling the daemon's `request_dedup::DedupCache` to deduplicate retries on the MCP→daemon path.
+- **`dispatch_idle` flock (#1340, PR #1347)** — `mark_resolved` and `scan_and_emit` in `dispatch_idle` now use flock serialization to prevent race conditions between concurrent resolution and scan operations.
+- **`agy` backend (#987)** — Google Antigravity CLI as a sixth first-class backend alongside claude / kiro-cli / codex / opencode / gemini. Motivated by Gemini CLI sunset 2026-06-18; existing `gemini` backend retained for paid Code Assist Standard/Enterprise license holders.
+- **`doctor topics` taxonomy reduced from 4 classes to 2 (#994)** — `drift_fleet` and `stale_registry` classes removed. Only `live` and `orphan` remain.
+- **`agy` backend display name + workspace-trust auto-dismiss + `fleet_mcp_supported: false` (#995)** — TUI shows `antigravity-cli`; workspace-trust prompt auto-dismissed; MCP config write is a no-op until upstream adds project-local `mcpServers` loading.
+- **`agend-terminal list --json` envelope (#938)** — JSON output now wraps the agent array in a discriminated envelope with `mode` field.
+- **`AGEND_LOG` precedence (#927 PR-A)** — env-set value now reliably wins over the in-code default.
+- **`telegram_init` fire-and-forget (#945 Phase 1)** — Cold-boot wall time drops from ~6.6 s to ~0.5 s by backgrounding Telegram init.
+- **CI-watch correlation_id format (#946)** — every `system:ci` inbox notification now carries `correlation_id = "{repo}@{branch}"`.
+- **`dispatch_idle` watchdog fallback correlation_id (#947)** — synthesized fallback uses canonical `disp-<unix_micros>-<seq>` format.
+- **`ci_watch` file identity hardening (#942 / #943)** — watch filenames now use sha256 over canonicalized repo slug. Legacy files migrated at boot.
+- **`ci_watch` survives bind/release handoff (#931)** — `release_worktree`'s cleanup no longer destroys the watch file.
+- **`agend-terminal admin cleanup-zombies` (#927 PR-B)** — kill long-running zombie daemons holding stale run directories.
+- **Boot sweep env vars (#933)** — `AGEND_DAEMON_BOOT_SWEEP_AGE_DAYS` + `AGEND_DAEMON_BOOT_SWEEP_DRY_RUN` for stale run-dir GC.
+- **Thread dump env var (#941)** — `AGEND_DAEMON_THREAD_DUMP_SECS` for periodic in-process state dumps.
+- **`.ready` boot-completion sentinel (#922)** — single-signal policy for daemon init completion.
+- **`bootstrap-step` instrumentation (#945 Phase 0)** — per-step timing breakdown in daemon log.
+- **State detection red SGR anchor (#919 Phase A)** — HIGH_FP patterns require red color escape within 200 bytes.
+- **Telegram inbound length-based delivery split (#1352, PR #1353)** — short messages (<200 chars) PTY only, long messages inbox+hint. Eliminates dual-delivery duplication.
+- **Replay cache mtime→generation counter (#1355, PR #1357)** — fixes false cache hits from mtime collisions by using a monotonic generation counter + mtime quadruple.
 - **Default fixup batch self-merge (operator-authorized SOP)** — `impl team` / `fixup team` with three-tier composition (lead + dev + reviewer) can squash-merge after CI 5 platforms green + reviewer VERIFIED + verdict mirrored to PR comment (§3.12). No operator merge button required. Established 2026-05-13 for `agend-terminal` repo; scope is per-repo (other repos confirm separately).
 - **`task action=list` default filter (#806)** — pre-#806 returned the full board (all statuses, 500KB+ in production). Now defaults to actionable statuses (`open` / `claimed` / `in_progress` / `blocked`); pass `include_history=true` to surface `done` / `cancelled`. Adds `limit` (newest-first cap) and `filtered_default: bool` response field for transparency.
 - **`task action=create` response shape (#807, PR #811)** — returns full task object instead of just `{id, status: "created"}` so caller sees the same `status` field semantics across create/list/get.
@@ -131,6 +107,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ### Fixed
 
+- **Filter `.lock` files from pr_state scanner (#1349, PR #1350)** — pr_state scanner was attempting to parse `.json.lock` sidecar files as JSON, producing WARN log spam every 10s tick.
+- **TUI mouse selection scroll freeze (#1356, PR #1358)** — selection coordinates drifted when new output arrived during active selection. Fix snapshots `max_scroll()` at MouseDown and compensates for grid growth so the viewport stays pinned to the same content.
 - **WIDE_CHAR_SPACER ratatui buffer cell leak (#819, PR #823)** — Site 1 in `src/vterm.rs::Widget::render` leaked stale chars across frames when the alacritty grid transitioned from `[WIDE_CHAR][SPACER]` to `[NarrowChar][SPACER]`. Fix relocated to the WIDE_CHAR write site (writes blank to (x+1, y) alongside the narrow char). Sites 2-5 (text/ANSI builder paths with fresh allocation) confirmed correct + explicitly regression-proofed. Surfaced as "TUI prompt-line scattered chars that disappear on selection".
 - **Bridge ↔ daemon double-execution under transient transport failure (PR #804 RCA → PR #843)** — `agend-mcp-bridge::is_retriable_io` classified `io::ErrorKind::TimedOut` as retriable. Daemon-side slow handlers (telegram channel inject > 30s) tripped the bridge's `read_timeout` → retry → double execution. Fix is the L1 idempotent retry architecture (see Added). Original PR #804 (cheerc) RCA confirmed correct; closed with credit.
 - **`teams::delete` did not cleanup member tasks (#828)** — single missing wire-up to `full_delete_instance` caused all ghost-owner accumulation. See Added.
@@ -182,6 +160,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 - **`rustls-webpki` upgrade** — security advisory fix paired with audit-job-blocking fix (PR #729).
 - **`twilight-model` 0.16 → 0.17.1** (Discord channel dep).
 - **`libc` 0.2.184 → 0.2.186**, **`uuid` 1.23.0 → 1.23.1**, **`which` 6 → 8** — routine dependabot bumps.
+
+### Test infrastructure
+
+- **`admin::cleanup_zombies::poll_until_dead` (#934)** — `pub(crate)` deterministic primitive. Polls `kill -0` (Unix) / `OpenProcess` (Windows) every 10 ms up to a timeout; returns `bool`. Replaces sleep-tuned waits in `agent.rs` shutdown + `process.rs` reaper tests.
+- **`api::handlers::instance::await_sentinel_nonempty` (#949, rename)** — pre-#949 named for *file existing*, but the instance-boot callers needed *content present*. Renamed to make the contract clear; flake at the four call sites is gone.
 
 ### Workflow validation snapshots
 

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -1,0 +1,92 @@
+# 更新日誌
+
+本文件記錄本專案所有重要變更。
+格式基於 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)；專案遵循 [SemVer](https://semver.org/spec/v2.0.0.html)。
+
+## [0.7.0] — 2026-05-28
+
+自 `0.6.1` 以來超過 200 個 commit，橫跨 Sprint 55–69（2026 年 5 月 7 日至 5 月 28 日）。三大主題：
+**(1) Task board 可靠性** — 根因分析並預防 ghost-owner 問題（`teams::delete` 級聯刪除、啟動時孤兒掃描、`force` 旗標）+ 新的清理工具 + 營運者可見的健康快照；**(2) Bridge ↔ daemon 冪等重試** — 消除暫時性傳輸失敗下有副作用的 MCP 呼叫重複執行問題（UUID request_id + DedupCache + Condvar 阻塞等待）；**(3) MCP handler 重構 #694 完成** — 30+ 個工具分支從行內 `match` 遷移至 dispatch table，為工具註冊表熱重載 (#776) 鋪路。另有 Hung 偵測影子模式基礎設施（F9 Stage 1–3）、速率限制恢復自動提示，以及約 50 個較小的 bug 修復/加固 PR。
+
+### 新增
+
+- **`notify_system` helper (#1335)** — `crate::inbox::notify_system()` 封裝常見的 daemon 通知模式。七個 daemon 模組完成遷移，每個通知點從約 8 行減少到 1 行。
+- **Event bus (#1336)** — 全域事件匯流排，透過 `AGEND_EVENT_BUS=1` 啟用。`event_bus::emit_lazy(kind, || payload)` 在停用時延遲序列化；停用路徑零成本（無配置、無序列化）。
+- **`with_pr_state` flock helper (#1342)** — `pr_state::with_pr_state()` 和 `with_pr_state_or_create()` 透過 `fs4` 檔案鎖序列化所有 `pr-state/*.json` 的讀取-修改-寫入操作。消除 gh-poll 覆寫 scanner 的 `ready_emitted_for_sha` 旗標導致重複 `[pr-merged]` 通知的 lost-update race。全部 6 個生產環境 `save()` 呼叫點已遷移。
+- **pr-merged 時自動釋放 worktree (#1344)** — Scanner 的 `MergeState::Merged` 分支現在在發出 `[pr-merged]` 前呼叫 `auto_release_for_merged_branch()`。防止 dev 的 worktree 仍持有本地分支時 `gh pr merge --delete-branch` 失敗。
+- **`/setup-telegram` skill + `skill add` URL#subdir 支援 (#1351, PR #1354)** — 導引式 Telegram 設定的 per-channel 安裝 skill。`skill add <url>#<subdir>` 可克隆 skill repo 並安裝子目錄。
+- **CI 程式碼覆蓋率（cargo-llvm-cov + Codecov, #686）** — CI 新增 `coverage` job，在 Ubuntu 上執行 `cargo llvm-cov` 並上傳至 Codecov。維護者專用基礎設施。
+- **Bridge ↔ daemon 冪等重試 (#842, PR #843)** — bridge 為每個 JSON 封包產生 UUID v4 `request_id`；傳輸失敗重試時重用同一 id。新的 `DedupCache`（TTL 10 分鐘、64KB/條目、64MB 上限、Condvar 阻塞等待）快取已完成的回應並阻擋進行中的重複請求。
+- **`task action=health` (#830, PR #838)** — 營運者自助式看板健康快照。回傳總數 + 按狀態統計 + ghost_owners + 過期 claims + 年齡分布 + 建議陣列。
+- **`task action=sweep` (#806, PR #810)** — 營運者觸發的過期任務清理。4 個類別搭配預設 dry-run + `confirm_ids` + `audit_reason` 審計。
+- **`repo action=cleanup_merged_branches` (#817, PR #820)** — 營運者觸發的本地分支清理。4 個類別，`min_age_days` 可設定（預設 90）。
+- **`force_release_worktree` GC 模式 (#826, PR #837)** — 對已解散的 agent 額外掃描孤兒 git-level worktree metadata 並強制清理。
+- **Daemon 啟動時孤兒擁有者掃描 (#829, PR #835)** — 啟動時掃描所有 assignee 不在 fleet registry 中的任務，嚴格模式自動設為孤兒。
+- **`teams::delete` 級聯刪除 (#828, PR #834)** — 解散路徑現在遍歷團隊成員並呼叫 `full_delete_instance`，級聯至 `orphan_tasks_for_owner`。修復產生 ghost-owner 的根因。
+- **`task force=true` 旗標 (#808, PR #809)** — 繞過 ACL 清理歷史遺留的 ghost-owned 任務。需要 `force_reason`（記入審計日誌）。
+- **`cleanup_init_commits` trailer 感知 body 檢查 (#833, PR #839)** — `KNOWN_TRAILER_KEYS` 白名單剝離後再判斷 commit body 是否為空。daemon 產生的 heartbeat 現在正確分類為空 commit 並可清理。
+- **Daemon 速率限制恢復自動提示 (#841, PR #844)** — 偵測到 `ServerRateLimit`/`RateLimit`/`ApiError` 狀態閒置後，自動注入單次恢復提示。`fleet.yaml` 可 per-instance 停用。
+- **`ci_watch` 衝突 PR 偵測 (#813, PR #816)** — daemon 現在查詢 PR `mergeable` 狀態；若為 `CONFLICTING`/`DIRTY`，立即發出 `[ci-conflict-detected]` 警報。
+- **Dispatch 測試名稱驗證 (#812, PR #815)** — daemon 驗證 send body 中的 `cargo test ... <test_name>` 是否存在於 PR HEAD tree。
+- **通知去重 race 修復 (#836, PR #840)** — 基於 `msg_id` 的抑制機制，防止接收者命中速率限制時同一通知最多觸發 3 次。
+- **MCP dispatch table 重構 — #694 完成** — 30+ 個工具分支遷移至 dispatch table，啟用未來工具註冊表熱重載。
+- **Hung 偵測 F9 影子模式基礎設施 (#685)** — 生產力輸出閘道、fixture 語料庫、per-backend 標記、Stage 1-3 自動恢復/重啟/升級排程。僅影子模式。
+- **時區顯示設定 (#790, PR #797)** — 透過 `fleet.yaml` 設定顯示時區（預設 Asia/Taipei）。
+
+### 變更
+
+- **comms.rs `request_id` 傳播 (#1341)** — `comms.rs` 中的 3 個 `api::call` 呼叫點現在包含 UUIDv4 `request_id`，啟用 daemon 的 `DedupCache` 去重。
+- **`dispatch_idle` flock (#1340, PR #1347)** — `mark_resolved` 和 `scan_and_emit` 現在使用 flock 序列化，防止並行解析和掃描之間的 race condition。
+- **`agy` backend (#987)** — Google Antigravity CLI 作為第六個一級 backend。因 Gemini CLI 2026-06-18 停止服務而新增。
+- **`doctor topics` 分類從 4 類減少為 2 類 (#994)** — 移除 `drift_fleet` 和 `stale_registry`。僅保留 `live` 和 `orphan`。
+- **`agy` backend 顯示名稱 + workspace-trust 自動關閉 + `fleet_mcp_supported: false` (#995)** — TUI 顯示 `antigravity-cli`；workspace-trust 提示自動關閉；MCP 設定寫入為 no-op。
+- **`agend-terminal list --json` 封包 (#938)** — JSON 輸出現在用帶有 `mode` 欄位的 discriminated envelope 包裝 agent 陣列。
+- **`AGEND_LOG` 優先級 (#927 PR-A)** — 環境變數設定值現在確實優先於程式內預設值。
+- **`telegram_init` 非同步背景化 (#945 Phase 1)** — 冷啟動時間從約 6.6 秒降至約 0.5 秒。
+- **CI-watch `correlation_id` 格式 (#946)** — 每個 `system:ci` inbox 通知現在攜帶 `correlation_id = "{repo}@{branch}"`。
+- **`dispatch_idle` watchdog fallback `correlation_id` (#947)** — 合成的 fallback 使用規範的 `disp-<unix_micros>-<seq>` 格式。
+- **`ci_watch` 檔案身分加固 (#942 / #943)** — watch 檔名現在使用 sha256。舊格式檔案在啟動時遷移。
+- **`ci_watch` 跨 bind/release 移交存活 (#931)** — `release_worktree` 不再銷毀 watch 檔案。
+- **`agend-terminal admin cleanup-zombies` (#927 PR-B)** — 終止持有過期 run 目錄的殭屍 daemon。
+- **啟動掃描環境變數 (#933)** — `AGEND_DAEMON_BOOT_SWEEP_AGE_DAYS` + `AGEND_DAEMON_BOOT_SWEEP_DRY_RUN`。
+- **執行緒狀態傾印環境變數 (#941)** — `AGEND_DAEMON_THREAD_DUMP_SECS`。
+- **`.ready` 啟動完成信號 (#922)** — daemon 初始化完成的單一信號策略。
+- **`bootstrap-step` 儀表化 (#945 Phase 0)** — daemon log 中的每步驟計時分解。
+- **狀態偵測紅色 SGR 錨點 (#919 Phase A)** — `HIGH_FP` 模式現在要求 200 bytes 內出現紅色轉義序列。
+- **Telegram inbound 長度分流 (#1352, PR #1353)** — 短訊息（<200 字元）僅 PTY，長訊息 inbox+hint。消除雙路徑重複投遞。
+- **Replay cache mtime→generation counter (#1355, PR #1357)** — 使用單調遞增的 generation counter + mtime 四元組修復 mtime 碰撞導致的假快取命中。
+- **`task action=list` 預設過濾 (#806)** — 預設只回傳可操作狀態；`include_history=true` 可查看 `done`/`cancelled`。
+- **`task action=create` 回應格式 (#807, PR #811)** — 回傳完整 task 物件而非僅 `{id, status}`。
+
+### 修復
+
+- **過濾 pr_state scanner 的 `.lock` 檔案 (#1349, PR #1350)** — pr_state scanner 嘗試將 `.json.lock` sidecar 檔案解析為 JSON，導致每 10 秒 tick 產生 WARN 日誌。
+- **TUI 滑鼠選取捲動凍結 (#1356, PR #1358)** — 活動選取期間新輸出到達時，選取座標會漂移。修復在 MouseDown 時快照 `max_scroll()`，並補償 grid 成長以將 viewport 固定在相同內容上。
+- **`WIDE_CHAR_SPACER` ratatui buffer cell 洩漏 (#819, PR #823)** — 全形字元過渡到半形字元時，過期字元跨 frame 洩漏。
+- **Bridge ↔ daemon 暫時性傳輸失敗下的重複執行 (PR #804 RCA → PR #843)** — bridge 的 `is_retriable_io` 將 `TimedOut` 分類為可重試，導致慢 handler 觸發重試和重複執行。根本修復是 L1 冪等重試架構。
+- **`teams::delete` 未清理成員任務 (#828)** — 遺漏的 `full_delete_instance` 呼叫是所有 ghost-owner 累積的根因。
+- **`force_release_worktree` 未清理 git-level metadata (#826)** — binding 已移除時未檢查 git-level worktree。新增 GC 模式。
+- **生產環境 `task action=list` 回傳 500KB+ (#806)** — 見「變更」中的預設過濾。
+- **`cleanup_init_commits` 對 daemon 產生的 heartbeat 無效 (#833)** — 見「新增」中的 trailer 感知 body 檢查。
+- **CI 審計 job 自 2026-05-15 起在 main 上持續失敗 (PR #831)** — `permissions: checks: write + issues: write` 修復。
+- **通知在消費+重試時三次觸發 (#836)** — 見「新增」中的通知去重。
+- **WAF-stage / macOS rustup-init 暫時性問題 (#772 v3, PR #800)** — `cache-bin: false` 防止過期 rustup-init 汙染。
+- **PTY 寫入超時防止鏈路死鎖 (#659, PR #679)** — `PTY_WRITE_TIMEOUT = 5s`。
+- **`kill_process_tree` PID 0 防護 (#681, PR #687)** — 拒絕向 PID 0 發送信號。
+- **`flock` 保護 ci-watch RMW race (#692, PR #731)** — 防止兩個 daemon tick 互相覆寫。
+
+### 移除
+
+- **`requires_daemon_state` 欄位 (#672 / #674)** — 已移除無用欄位。
+
+### 建置/依賴
+
+- **`sysinfo` 0.32 → 0.39** — API 遷移。
+- **`rustls-webpki` 升級** — 安全公告修復。
+- **`twilight-model` 0.16 → 0.17.1**（Discord channel 依賴）。
+- **`libc`、`uuid`、`which`** — 例行 dependabot 升級。
+
+### 測試基礎設施
+
+- **`admin::cleanup_zombies::poll_until_dead` (#934)** — 確定性輪詢原語，取代基於 sleep 的等待。
+- **`api::handlers::instance::await_sentinel_nonempty` (#949)** — 重新命名以釐清合約：等待檔案有內容，而非僅存在。

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agend-terminal"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.87"
 description = "Agent Process Manager — orchestrate AI coding agents with PTY isolation, fleet management, and 35 MCP tools"


### PR DESCRIPTION
## Summary

- Cargo.toml version bump: `0.6.1` → `0.7.0`
- CHANGELOG: merge [Unreleased] into [0.7.0] (date: 2026-05-28)
- Add missing PR entries for recent fixes (#1349-#1358)

## Test plan

- [x] `cargo check` passes
- [x] [Unreleased] section is empty
- [x] [0.7.0] contains all changes from Sprint 55–69

🤖 Generated with [Claude Code](https://claude.com/claude-code)