### PR TITLE
refactor(#1373): dispatch adapter macro — eliminate ~420 lines duplication

### DIFF
--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -18,15 +18,6 @@
 //! for HashMap/phf, and the table size is bounded by the MCP tool
 //! catalogue, so static-search is cheap and avoids the deps.
 //!
-//! **Action sub-routing (T-B8)** — tools whose API consolidates several
-//! sub-operations under one name (`task`, `decision`, `team`, …) carry
-//! an optional [`HandlerEntry::actions`] table. [`try_dispatch`] inspects
-//! `ctx.args["action"]`, looks the value up in that table, and routes to
-//! the matching sub-handler if found. Missing-or-unknown action falls
-//! through to the entry's base [`HandlerFn`] — which is the tool's
-//! existing pre-migration handler, so error-handling for unknown
-//! actions remains byte-identical to the pre-extraction code.
-//!
 //! **Fallback in mod.rs** — [`try_dispatch`] returns `Option<Value>`
 //! (`None` = "tool name not in table"). `handle_tool` falls back to the
 //! existing inline match for un-migrated arms; the catch-all
@@ -59,35 +50,14 @@ pub(super) type HandlerFn = fn(&HandlerCtx<'_>) -> Value;
 pub(super) struct HandlerEntry {
     pub name: &'static str,
     pub handler: HandlerFn,
-    /// Optional action sub-routing table. When `Some`, `try_dispatch`
-    /// reads `ctx.args["action"]` and routes to the matching sub-handler;
-    /// missing-or-unknown action falls through to `handler` (the base).
-    /// `None` means flat dispatch — `ctx.args["action"]` is ignored.
-    pub actions: Option<&'static [(&'static str, HandlerFn)]>,
 }
 
 /// Look the `tool` name up in the dispatch table. Returns `Some(value)`
-/// on hit (including the action-routing path); returns `None` if the
-/// tool isn't registered — the caller falls back to the inline `match`
-/// in `mod.rs` for un-migrated arms.
+/// on hit; returns `None` if the tool isn't registered — the caller
+/// falls back to the inline `match` in `mod.rs` for un-migrated arms.
 pub(super) fn try_dispatch(tool: &str, ctx: &HandlerCtx<'_>) -> Option<Value> {
     for entry in registered_handlers() {
         if entry.name == tool {
-            if let Some(action_table) = entry.actions {
-                if let Some(action) = ctx.args["action"].as_str() {
-                    // `HandlerFn` is `Copy`, so destructuring the
-                    // ref-to-tuple as `&(_, sub_handler)` binds the
-                    // fn pointer by value.
-                    if let Some(&(_, sub_handler)) = action_table.iter().find(|(a, _)| *a == action)
-                    {
-                        return Some(sub_handler(ctx));
-                    }
-                }
-                // Action missing or unknown → fall through to base
-                // handler below. Preserves the pre-migration error
-                // path (the base handler is the existing pub fn that
-                // already has its own "unknown action" branch).
-            }
             return Some((entry.handler)(ctx));
         }
     }
@@ -95,287 +65,243 @@ pub(super) fn try_dispatch(tool: &str, ctx: &HandlerCtx<'_>) -> Option<Value> {
 }
 
 // ---------------------------------------------------------------------
-// Adapter fns — one per migrated tool. Each pulls the fields its
-// underlying handler needs out of `HandlerCtx` and forwards the call.
+// Adapter generation macro — eliminates per-tool boilerplate.
+//
+// Each invocation generates:
+//   fn dispatch_<ident>(ctx: &HandlerCtx<'_>) -> Value { <body> }
+//
+// Four shapes match the four handler signatures in the codebase:
+//   (home, args, instance)        → shape: hai
+//   (home, args)                  → shape: ha
+//   (home, args, instance, sender)→ shape: hais
+//   (home, args, sender)          → shape: has
+//   (home)                        → shape: h
+//   (args)                        → shape: a
+//   custom body                   → shape: custom
 // ---------------------------------------------------------------------
-
-// Shape 1 — takes `instance_name`.
-
-fn dispatch_list_instances(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_list_instances(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_create_instance(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_create_instance(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_set_description(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_set_description(ctx.home, ctx.args, ctx.instance_name)
-}
-
-// Shape 2 — ignores `instance_name`.
-
-fn dispatch_interrupt(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_interrupt(ctx.home, ctx.args)
-}
-
-fn dispatch_delete_instance(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_delete_instance(ctx.home, ctx.args)
-}
-
-fn dispatch_start_instance(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_start_instance(ctx.home, ctx.args)
-}
-
-fn dispatch_replace_instance(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_replace_instance(ctx.home, ctx.args)
-}
-
-fn dispatch_move_pane(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_move_pane(ctx.home, ctx.args)
-}
-
-// Shape 3 — takes `instance_name` AND `sender`.
-
-fn dispatch_set_waiting_on(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_set_waiting_on(ctx.home, ctx.args, ctx.instance_name, ctx.sender)
-}
-
-fn dispatch_send(ctx: &HandlerCtx<'_>) -> Value {
-    comms::handle_unified_send(ctx.home, ctx.args, ctx.sender)
-}
-
-// Shape 4 — takes `sender` but ignores `instance_name`.
-
-fn dispatch_bind_self(ctx: &HandlerCtx<'_>) -> Value {
-    worktree::handle_bind_self(ctx.home, ctx.args, ctx.sender)
-}
-
-fn dispatch_binding_state(ctx: &HandlerCtx<'_>) -> Value {
-    binding_state::handle_binding_state(ctx.home, ctx.args, ctx.sender)
-}
-
-fn dispatch_release_worktree(ctx: &HandlerCtx<'_>) -> Value {
-    worktree::handle_release_worktree(ctx.home, ctx.args, ctx.sender)
-}
-
-fn dispatch_force_release_worktree(ctx: &HandlerCtx<'_>) -> Value {
-    force_release::handle_force_release_worktree(ctx.home, ctx.args, ctx.sender)
-}
-
-fn dispatch_gc_dry_run(ctx: &HandlerCtx<'_>) -> Value {
-    worktree::handle_gc_dry_run(ctx.home, ctx.args, ctx.sender)
-}
-
-// `task` — action sub-routing validation case (T-B8).
-//
-// All 5 sub-handlers (`dispatch_task_create` / `..._list` / `..._claim`
-// / `..._update` / `..._done`) AND the base `dispatch_task` all forward
-// to `task::handle_task`. The forwarding is identical at runtime — the
-// actions table is purely structural here, adding a routing-table layer
-// without changing what gets called.
-//
-// `task::handle_task` is itself a 1-line forward to `crate::tasks::handle`,
-// which has its own internal match on `args["action"]`. So:
-//
-// * recognized action (e.g. "list") → dispatch table actions[…] hit →
-//   matching sub-handler → task::handle_task → tasks::handle → matching
-//   arm of internal match
-// * unrecognized action (e.g. "frobnicate") → dispatch table actions miss
-//   → fall-through to base `dispatch_task` → task::handle_task →
-//   tasks::handle → "unknown action" error from internal match
-//
-// The "double match" (action-routing in dispatch.rs AND internal match
-// in `tasks::handle`) is redundant work but preserves ZERO behavior
-// change. Refactoring `tasks::handle` to expose per-action `pub fn`s
-// is left as a future optimization once the dispatch table is stable
-// across all action-based tools.
-
-fn dispatch_task(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_task_create(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_task_list(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_task_claim(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_task_update(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_task_done(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_task_sweep(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_task_health(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_task_activity(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task(ctx.home, ctx.args, ctx.instance_name)
-}
-
-/// Static sub-handler table for `task` action routing. Lifted out of
-/// the entry literal so the table address can be `'static`-borrowed.
-/// Action set matches `tasks::handle`'s internal `match` arms.
-static TASK_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("create", dispatch_task_create),
-    ("list", dispatch_task_list),
-    ("claim", dispatch_task_claim),
-    ("update", dispatch_task_update),
-    ("done", dispatch_task_done),
-    ("sweep", dispatch_task_sweep),
-    ("health", dispatch_task_health),
-    ("activity", dispatch_task_activity),
-];
-
-// ---------------------------------------------------------------------
-// Cohort migration (T-B9) — 7 action-based tools with N sub-handlers
-// each. Pattern (per T-B8 spot-check ACK + T-B9 dispatch):
-//
-//   - `dispatch_<tool>` base handler relocates the inline `match` from
-//     `mod.rs`. Recognized arms point to the same per-action fns the
-//     inline match used; the `other` arm produces the same error JSON.
-//   - Per-action sub-handlers (`dispatch_<tool>_<action>`) forward
-//     directly to the per-action fns. The dispatch table catches
-//     recognized actions and routes through these.
-//   - `<TOOL>_ACTIONS` static lists the (action_name, sub_handler)
-//     pairs.
-//
-// Runtime path: recognized action → dispatch table actions[…] hit →
-// sub-handler → per-action fn. Unknown / missing action → fall through
-// to `dispatch_<tool>` base → its `match` → `other` arm → unknown-
-// action error JSON. The base handler's recognized-action arms are
-// unreachable at runtime (dispatch table catches them first); they're
-// retained because they mirror the pre-migration inline match exactly,
-// which is the double-match safety net the dispatch contract requires.
-
-// `ci` — actions: watch / unwatch / status.
-
-fn dispatch_ci(ctx: &HandlerCtx<'_>) -> Value {
-    match ctx.args["action"].as_str().unwrap_or("") {
-        "watch" => ci::handle_watch_ci(ctx.home, ctx.args, ctx.instance_name),
-        "unwatch" => ci::handle_unwatch_ci(ctx.home, ctx.args),
-        "status" => ci::handle_status_ci(ctx.home, ctx.args, ctx.instance_name),
-        other => json!({"error": format!("unknown ci action: {other}")}),
-    }
-}
-
-fn dispatch_ci_watch(ctx: &HandlerCtx<'_>) -> Value {
-    ci::handle_watch_ci(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_ci_unwatch(ctx: &HandlerCtx<'_>) -> Value {
-    ci::handle_unwatch_ci(ctx.home, ctx.args)
-}
-
-fn dispatch_ci_status(ctx: &HandlerCtx<'_>) -> Value {
-    ci::handle_status_ci(ctx.home, ctx.args, ctx.instance_name)
-}
-
-static CI_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("watch", dispatch_ci_watch),
-    ("unwatch", dispatch_ci_unwatch),
-    ("status", dispatch_ci_status),
-];
-
-// `decision` — actions: post / list / update.
-
-fn dispatch_decision(ctx: &HandlerCtx<'_>) -> Value {
-    match ctx.args["action"].as_str().unwrap_or("") {
-        "post" => task::handle_post_decision(ctx.home, ctx.args, ctx.instance_name, ctx.sender),
-        "list" => task::handle_list_decisions(ctx.home, ctx.args),
-        "update" => task::handle_update_decision(ctx.home, ctx.args, ctx.instance_name),
-        other => json!({"error": format!("unknown decision action: {other}")}),
-    }
-}
-
-fn dispatch_decision_post(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_post_decision(ctx.home, ctx.args, ctx.instance_name, ctx.sender)
-}
-
-fn dispatch_decision_list(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_list_decisions(ctx.home, ctx.args)
-}
-
-fn dispatch_decision_update(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_update_decision(ctx.home, ctx.args, ctx.instance_name)
-}
-
-static DECISION_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("post", dispatch_decision_post),
-    ("list", dispatch_decision_list),
-    ("update", dispatch_decision_update),
-];
-
-// `deployment` — actions: deploy / teardown / list.
-
-fn dispatch_deployment(ctx: &HandlerCtx<'_>) -> Value {
-    match ctx.args["action"].as_str().unwrap_or("") {
-        "deploy" => schedule::handle_deploy_template(ctx.home, ctx.args, ctx.instance_name),
-        "teardown" => schedule::handle_teardown_deployment(ctx.home, ctx.args),
-        "list" => schedule::handle_list_deployments(ctx.home),
-        other => json!({"error": format!("unknown deployment action: {other}")}),
-    }
-}
-
-fn dispatch_deployment_deploy(ctx: &HandlerCtx<'_>) -> Value {
-    schedule::handle_deploy_template(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_deployment_teardown(ctx: &HandlerCtx<'_>) -> Value {
-    schedule::handle_teardown_deployment(ctx.home, ctx.args)
-}
-
-fn dispatch_deployment_list(ctx: &HandlerCtx<'_>) -> Value {
-    schedule::handle_list_deployments(ctx.home)
-}
-
-static DEPLOYMENT_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("deploy", dispatch_deployment_deploy),
-    ("teardown", dispatch_deployment_teardown),
-    ("list", dispatch_deployment_list),
-];
-
-// `health` — actions: report / clear.
-
-fn dispatch_health(ctx: &HandlerCtx<'_>) -> Value {
-    match ctx.args["action"].as_str().unwrap_or("") {
-        "report" => {
-            instance::handle_report_health(ctx.home, ctx.args, ctx.instance_name, ctx.sender)
+macro_rules! adapter {
+    ($name:ident, hai, $handler:expr) => {
+        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+            $handler(ctx.home, ctx.args, ctx.instance_name)
         }
-        "clear" => instance::handle_clear_blocked_reason(ctx.home, ctx.args),
-        other => json!({"error": format!("unknown health action: {other}")}),
+    };
+    ($name:ident, ha, $handler:expr) => {
+        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+            $handler(ctx.home, ctx.args)
+        }
+    };
+    ($name:ident, hais, $handler:expr) => {
+        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+            $handler(ctx.home, ctx.args, ctx.instance_name, ctx.sender)
+        }
+    };
+    ($name:ident, has, $handler:expr) => {
+        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+            $handler(ctx.home, ctx.args, ctx.sender)
+        }
+    };
+    ($name:ident, h, $handler:expr) => {
+        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+            $handler(ctx.home)
+        }
+    };
+    ($name:ident, a, $handler:expr) => {
+        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+            $handler(ctx.args)
+        }
+    };
+    (@call $ctx:ident, hai, $handler:expr) => {
+        $handler($ctx.home, $ctx.args, $ctx.instance_name)
+    };
+    (@call $ctx:ident, ha, $handler:expr) => {
+        $handler($ctx.home, $ctx.args)
+    };
+    (@call $ctx:ident, hais, $handler:expr) => {
+        $handler($ctx.home, $ctx.args, $ctx.instance_name, $ctx.sender)
+    };
+    (@call $ctx:ident, has, $handler:expr) => {
+        $handler($ctx.home, $ctx.args, $ctx.sender)
+    };
+    (@call $ctx:ident, h, $handler:expr) => {
+        $handler($ctx.home)
+    };
+    (@call $ctx:ident, a, $handler:expr) => {
+        $handler($ctx.args)
+    };
+}
+
+macro_rules! action_adapter {
+    ($name:ident, $tool_label:literal, [ $( $action:literal => $handler:expr , $shape:ident );+ $(;)? ]) => {
+        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+            match ctx.args["action"].as_str().unwrap_or("") {
+                $( $action => { adapter!(@call ctx, $shape, $handler) } )+
+                other => json!({"error": format!(concat!("unknown ", $tool_label, " action: {}"), other)}),
+            }
+        }
+    };
+}
+
+// ---------------------------------------------------------------------
+// Flat adapters — one per simple (non-action-based) tool.
+// ---------------------------------------------------------------------
+
+adapter!(
+    dispatch_list_instances,
+    hai,
+    instance::handle_list_instances
+);
+adapter!(
+    dispatch_create_instance,
+    hai,
+    instance::handle_create_instance
+);
+adapter!(
+    dispatch_set_description,
+    hai,
+    instance::handle_set_description
+);
+adapter!(dispatch_interrupt, ha, instance::handle_interrupt);
+adapter!(
+    dispatch_delete_instance,
+    ha,
+    instance::handle_delete_instance
+);
+adapter!(dispatch_start_instance, ha, instance::handle_start_instance);
+adapter!(
+    dispatch_replace_instance,
+    ha,
+    instance::handle_replace_instance
+);
+adapter!(dispatch_move_pane, ha, instance::handle_move_pane);
+adapter!(
+    dispatch_set_waiting_on,
+    hais,
+    instance::handle_set_waiting_on
+);
+adapter!(dispatch_send, has, comms::handle_unified_send);
+adapter!(dispatch_bind_self, has, worktree::handle_bind_self);
+adapter!(
+    dispatch_binding_state,
+    has,
+    binding_state::handle_binding_state
+);
+adapter!(
+    dispatch_release_worktree,
+    has,
+    worktree::handle_release_worktree
+);
+adapter!(
+    dispatch_force_release_worktree,
+    has,
+    force_release::handle_force_release_worktree
+);
+adapter!(dispatch_gc_dry_run, has, worktree::handle_gc_dry_run);
+adapter!(
+    dispatch_download_attachment,
+    hai,
+    channel::handle_download_attachment
+);
+adapter!(dispatch_reply, hai, channel::handle_reply);
+adapter!(
+    dispatch_set_display_name,
+    hai,
+    instance::handle_set_display_name
+);
+adapter!(dispatch_pane_snapshot, ha, instance::handle_pane_snapshot);
+adapter!(
+    dispatch_task_sweep_config,
+    ha,
+    task::handle_task_sweep_config
+);
+adapter!(dispatch_restart_daemon, h, restart::handle_restart_daemon);
+
+// ---------------------------------------------------------------------
+// Action-based adapters — match on args["action"], route to per-action
+// handler. Unknown actions produce tool-specific error JSON.
+// ---------------------------------------------------------------------
+
+adapter!(dispatch_task, hai, task::handle_task);
+
+action_adapter!(dispatch_ci, "ci", [
+    "watch"   => ci::handle_watch_ci,   hai;
+    "unwatch" => ci::handle_unwatch_ci, ha;
+    "status"  => ci::handle_status_ci,  hai;
+]);
+
+action_adapter!(dispatch_decision, "decision", [
+    "post"   => task::handle_post_decision,   hais;
+    "list"   => task::handle_list_decisions,   ha;
+    "update" => task::handle_update_decision,  hai;
+]);
+
+action_adapter!(dispatch_deployment, "deployment", [
+    "deploy"   => schedule::handle_deploy_template,      hai;
+    "teardown" => schedule::handle_teardown_deployment,   ha;
+    "list"     => schedule::handle_list_deployments,      h;
+]);
+
+action_adapter!(dispatch_health, "health", [
+    "report" => instance::handle_report_health,         hais;
+    "clear"  => instance::handle_clear_blocked_reason,  ha;
+]);
+
+action_adapter!(dispatch_repo, "repo", [
+    "checkout"                => ci::handle_checkout_repo,              hai;
+    "release"                 => ci::handle_release_repo,               a;
+    "cleanup_init_commits"    => ci::handle_cleanup_init_commits,       hai;
+    "cleanup_merged_branches" => ci::handle_cleanup_merged_branches,    hai;
+    "merge"                   => ci::handle_merge_repo,                 hai;
+]);
+
+action_adapter!(dispatch_schedule, "schedule", [
+    "create" => schedule::handle_create_schedule,  hai;
+    "list"   => schedule::handle_list_schedules,   ha;
+    "update" => schedule::handle_update_schedule,  ha;
+    "delete" => schedule::handle_delete_schedule,  ha;
+]);
+
+action_adapter!(dispatch_team, "team", [
+    "create" => task::handle_create_team,  ha;
+    "delete" => task::handle_delete_team,  ha;
+    "list"   => task::handle_list_teams,   h;
+    "update" => task::handle_update_team,  ha;
+]);
+
+// `inbox` — three-way branch on arg presence (NOT `args["action"]`):
+//   - `message_id` present → describe single message
+//   - else `thread_id` present → describe thread
+//   - else → drain pending
+fn dispatch_inbox(ctx: &HandlerCtx<'_>) -> Value {
+    if ctx
+        .args
+        .get("message_id")
+        .and_then(|v| v.as_str())
+        .is_some()
+    {
+        comms::handle_describe_message(ctx.home, ctx.args, ctx.instance_name)
+    } else if ctx.args.get("thread_id").and_then(|v| v.as_str()).is_some() {
+        comms::handle_describe_thread(ctx.home, ctx.args)
+    } else {
+        comms::handle_inbox(ctx.home, ctx.instance_name)
     }
 }
 
-fn dispatch_health_report(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_report_health(ctx.home, ctx.args, ctx.instance_name, ctx.sender)
+fn dispatch_tui_screenshot(ctx: &HandlerCtx<'_>) -> Value {
+    match crate::api::call(
+        ctx.home,
+        &serde_json::json!({"method": crate::api::method::TUI_SCREENSHOT, "params": {}}),
+    ) {
+        Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+            serde_json::json!({"svg": resp["svg"]})
+        }
+        Ok(resp) => {
+            serde_json::json!({"error": resp["error"].as_str().unwrap_or("tui_screenshot failed")})
+        }
+        Err(e) => serde_json::json!({"error": format!("tui_screenshot: {e}")}),
+    }
 }
 
-fn dispatch_health_clear(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_clear_blocked_reason(ctx.home, ctx.args)
-}
-
-static HEALTH_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("report", dispatch_health_report),
-    ("clear", dispatch_health_clear),
-];
-
-// `watchdog` — actions: snooze / resume / status (#1084).
-
+// `watchdog` — actions with inline business logic (not just forwarding).
 fn dispatch_watchdog(ctx: &HandlerCtx<'_>) -> Value {
     match ctx.args["action"].as_str().unwrap_or("") {
         "snooze" => dispatch_watchdog_snooze(ctx),
@@ -386,53 +312,10 @@ fn dispatch_watchdog(ctx: &HandlerCtx<'_>) -> Value {
     }
 }
 
-fn dispatch_config(ctx: &HandlerCtx<'_>) -> Value {
-    match ctx.args["action"].as_str().unwrap_or("") {
-        "get" => dispatch_config_get(ctx),
-        "set" => dispatch_config_set(ctx),
-        "list" => dispatch_config_list(ctx),
-        other => json!({"error": format!("unknown config action: {other}")}),
-    }
-}
-
-fn dispatch_config_get(ctx: &HandlerCtx<'_>) -> Value {
-    let key = ctx.args["key"].as_str().unwrap_or("");
-    if key.is_empty() {
-        return json!({"error": "key is required for get"});
-    }
-    match crate::runtime_config::get_key(key) {
-        Ok(v) => json!({"key": key, "value": v}),
-        Err(e) => json!({"error": e}),
-    }
-}
-
-fn dispatch_config_set(ctx: &HandlerCtx<'_>) -> Value {
-    let key = ctx.args["key"].as_str().unwrap_or("");
-    let value = ctx.args["value"].as_str().unwrap_or("");
-    if key.is_empty() || value.is_empty() {
-        return json!({"error": "key and value are required for set"});
-    }
-    match crate::runtime_config::set(ctx.home, key, value) {
-        Ok(_) => json!({"ok": true, "key": key, "value": value}),
-        Err(e) => json!({"error": e}),
-    }
-}
-
-fn dispatch_config_list(ctx: &HandlerCtx<'_>) -> Value {
-    let _ = ctx;
-    json!({"config": crate::runtime_config::list()})
-}
-
-static CONFIG_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("get", dispatch_config_get),
-    ("set", dispatch_config_set),
-    ("list", dispatch_config_list),
-];
-
 fn dispatch_watchdog_snooze(ctx: &HandlerCtx<'_>) -> Value {
     use crate::daemon::idle_watchdog;
 
-    const MAX_SNOOZE_SECS: i64 = 4 * 3600; // 4h clamp
+    const MAX_SNOOZE_SECS: i64 = 4 * 3600;
 
     let duration_str = ctx.args["duration"].as_str().unwrap_or("1h");
     let secs = match parse_duration_secs(duration_str) {
@@ -514,10 +397,36 @@ fn dispatch_watchdog_ack(ctx: &HandlerCtx<'_>) -> Value {
     })
 }
 
+fn dispatch_config(ctx: &HandlerCtx<'_>) -> Value {
+    match ctx.args["action"].as_str().unwrap_or("") {
+        "get" => {
+            let key = ctx.args["key"].as_str().unwrap_or("");
+            if key.is_empty() {
+                return json!({"error": "key is required for get"});
+            }
+            match crate::runtime_config::get_key(key) {
+                Ok(v) => json!({"key": key, "value": v}),
+                Err(e) => json!({"error": e}),
+            }
+        }
+        "set" => {
+            let key = ctx.args["key"].as_str().unwrap_or("");
+            let value = ctx.args["value"].as_str().unwrap_or("");
+            if key.is_empty() || value.is_empty() {
+                return json!({"error": "key and value are required for set"});
+            }
+            match crate::runtime_config::set(ctx.home, key, value) {
+                Ok(_) => json!({"ok": true, "key": key, "value": value}),
+                Err(e) => json!({"error": e}),
+            }
+        }
+        "list" => json!({"config": crate::runtime_config::list()}),
+        other => json!({"error": format!("unknown config action: {other}")}),
+    }
+}
+
 /// Parse human-friendly duration strings like "2h", "30m", "1h30m".
-/// Parse a human duration string into seconds. Supports `h`/`m`/`s`
-/// suffixes (e.g. `"2h30m"`, `"90s"`). A bare number without suffix
-/// is interpreted as **minutes** (e.g. `"30"` → 1800s).
+/// A bare number without suffix is interpreted as **minutes**.
 fn parse_duration_secs(s: &str) -> Option<i64> {
     let s = s.trim();
     if s.is_empty() {
@@ -550,409 +459,142 @@ fn parse_duration_secs(s: &str) -> Option<i64> {
     }
 }
 
-static WATCHDOG_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("snooze", dispatch_watchdog_snooze),
-    ("resume", dispatch_watchdog_resume),
-    ("status", dispatch_watchdog_status),
-    ("ack", dispatch_watchdog_ack),
-];
-
-// `repo` — actions: checkout / release.
-
-fn dispatch_repo(ctx: &HandlerCtx<'_>) -> Value {
-    match ctx.args["action"].as_str().unwrap_or("") {
-        "checkout" => ci::handle_checkout_repo(ctx.home, ctx.args, ctx.instance_name),
-        "release" => ci::handle_release_repo(ctx.args),
-        "cleanup_init_commits" => {
-            ci::handle_cleanup_init_commits(ctx.home, ctx.args, ctx.instance_name)
-        }
-        "cleanup_merged_branches" => {
-            ci::handle_cleanup_merged_branches(ctx.home, ctx.args, ctx.instance_name)
-        }
-        "merge" => ci::handle_merge_repo(ctx.home, ctx.args, ctx.instance_name),
-        other => json!({"error": format!("unknown repo action: {other}")}),
-    }
-}
-
-fn dispatch_repo_checkout(ctx: &HandlerCtx<'_>) -> Value {
-    ci::handle_checkout_repo(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_repo_release(ctx: &HandlerCtx<'_>) -> Value {
-    ci::handle_release_repo(ctx.args)
-}
-
-fn dispatch_repo_cleanup_init_commits(ctx: &HandlerCtx<'_>) -> Value {
-    ci::handle_cleanup_init_commits(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_repo_cleanup_merged_branches(ctx: &HandlerCtx<'_>) -> Value {
-    ci::handle_cleanup_merged_branches(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_repo_merge(ctx: &HandlerCtx<'_>) -> Value {
-    ci::handle_merge_repo(ctx.home, ctx.args, ctx.instance_name)
-}
-
-static REPO_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("checkout", dispatch_repo_checkout),
-    ("release", dispatch_repo_release),
-    ("cleanup_init_commits", dispatch_repo_cleanup_init_commits),
-    (
-        "cleanup_merged_branches",
-        dispatch_repo_cleanup_merged_branches,
-    ),
-    ("merge", dispatch_repo_merge),
-];
-
-// `schedule` — actions: create / list / update / delete.
-
-fn dispatch_schedule(ctx: &HandlerCtx<'_>) -> Value {
-    match ctx.args["action"].as_str().unwrap_or("") {
-        "create" => schedule::handle_create_schedule(ctx.home, ctx.args, ctx.instance_name),
-        "list" => schedule::handle_list_schedules(ctx.home, ctx.args),
-        "update" => schedule::handle_update_schedule(ctx.home, ctx.args),
-        "delete" => schedule::handle_delete_schedule(ctx.home, ctx.args),
-        other => json!({"error": format!("unknown schedule action: {other}")}),
-    }
-}
-
-fn dispatch_schedule_create(ctx: &HandlerCtx<'_>) -> Value {
-    schedule::handle_create_schedule(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_schedule_list(ctx: &HandlerCtx<'_>) -> Value {
-    schedule::handle_list_schedules(ctx.home, ctx.args)
-}
-
-fn dispatch_schedule_update(ctx: &HandlerCtx<'_>) -> Value {
-    schedule::handle_update_schedule(ctx.home, ctx.args)
-}
-
-fn dispatch_schedule_delete(ctx: &HandlerCtx<'_>) -> Value {
-    schedule::handle_delete_schedule(ctx.home, ctx.args)
-}
-
-static SCHEDULE_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("create", dispatch_schedule_create),
-    ("list", dispatch_schedule_list),
-    ("update", dispatch_schedule_update),
-    ("delete", dispatch_schedule_delete),
-];
-
-// `team` — actions: create / delete / list / update.
-
-fn dispatch_team(ctx: &HandlerCtx<'_>) -> Value {
-    match ctx.args["action"].as_str().unwrap_or("") {
-        "create" => task::handle_create_team(ctx.home, ctx.args),
-        "delete" => task::handle_delete_team(ctx.home, ctx.args),
-        "list" => task::handle_list_teams(ctx.home),
-        "update" => task::handle_update_team(ctx.home, ctx.args),
-        other => json!({"error": format!("unknown team action: {other}")}),
-    }
-}
-
-fn dispatch_team_create(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_create_team(ctx.home, ctx.args)
-}
-
-fn dispatch_team_delete(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_delete_team(ctx.home, ctx.args)
-}
-
-fn dispatch_team_list(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_list_teams(ctx.home)
-}
-
-fn dispatch_team_update(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_update_team(ctx.home, ctx.args)
-}
-
-static TEAM_ACTIONS: &[(&str, HandlerFn)] = &[
-    ("create", dispatch_team_create),
-    ("delete", dispatch_team_delete),
-    ("list", dispatch_team_list),
-    ("update", dispatch_team_update),
-];
-
 // ---------------------------------------------------------------------
-// Channel-heavy cohort (T-B10) — `download_attachment` / `inbox` /
-// `reply`. Selection is by arg presence (not by `args["action"]`), so
-// every tool here uses `actions: None` and the dispatching branch lives
-// inside the base adapter, exactly mirroring the pre-migration inline
-// match arm. Side effects (telegram channel writes, filesystem media
-// download, inbox storage RMW) are unchanged — adapters are pure
-// forwards.
+// Registration table
+// ---------------------------------------------------------------------
 
-fn dispatch_download_attachment(ctx: &HandlerCtx<'_>) -> Value {
-    channel::handle_download_attachment(ctx.home, ctx.args, ctx.instance_name)
-}
-
-// `inbox` — three-way branch on arg presence (NOT `args["action"]`):
-//   - `message_id` present → `comms::handle_describe_message`
-//   - else `thread_id` present → `comms::handle_describe_thread`
-//   - else → `comms::handle_inbox` (drain pending)
-// Order matters: the original inline match arm preferred message_id
-// over thread_id, so this `if / else if / else` chain preserves byte-
-// identical routing for callers that (incorrectly) pass both.
-fn dispatch_inbox(ctx: &HandlerCtx<'_>) -> Value {
-    if ctx
-        .args
-        .get("message_id")
-        .and_then(|v| v.as_str())
-        .is_some()
-    {
-        comms::handle_describe_message(ctx.home, ctx.args, ctx.instance_name)
-    } else if ctx.args.get("thread_id").and_then(|v| v.as_str()).is_some() {
-        comms::handle_describe_thread(ctx.home, ctx.args)
-    } else {
-        comms::handle_inbox(ctx.home, ctx.instance_name)
-    }
-}
-
-fn dispatch_reply(ctx: &HandlerCtx<'_>) -> Value {
-    channel::handle_reply(ctx.home, ctx.args, ctx.instance_name)
-}
-
-// Final-cut flat tools (T-B11) — closing out #694 BLOCK 2 at 30/30+
-// arms. All four are stateless: no `args["action"]` sub-routing, no
-// per-tool counters, no env flags. Each adapter is a 1-line forward
-// to the existing per-tool fn.
-
-fn dispatch_set_display_name(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_set_display_name(ctx.home, ctx.args, ctx.instance_name)
-}
-
-fn dispatch_pane_snapshot(ctx: &HandlerCtx<'_>) -> Value {
-    instance::handle_pane_snapshot(ctx.home, ctx.args)
-}
-
-fn dispatch_tui_screenshot(ctx: &HandlerCtx<'_>) -> Value {
-    match crate::api::call(
-        ctx.home,
-        &serde_json::json!({"method": crate::api::method::TUI_SCREENSHOT, "params": {}}),
-    ) {
-        Ok(resp) if resp["ok"].as_bool() == Some(true) => {
-            serde_json::json!({"svg": resp["svg"]})
-        }
-        Ok(resp) => {
-            serde_json::json!({"error": resp["error"].as_str().unwrap_or("tui_screenshot failed")})
-        }
-        Err(e) => serde_json::json!({"error": format!("tui_screenshot: {e}")}),
-    }
-}
-
-fn dispatch_task_sweep_config(ctx: &HandlerCtx<'_>) -> Value {
-    task::handle_task_sweep_config(ctx.home, ctx.args)
-}
-
-// `restart_daemon` is high-sensitivity (Sprint 60 W1 PR-3): the
-// daemon re-execs itself when this handler runs. ZERO behavior
-// change requires byte-identical forwarding to the existing
-// `restart::handle_restart_daemon`; the adapter is a verbatim 1-line
-// forward — no added logic, no extra logging, no field reads beyond
-// `ctx.home`.
-fn dispatch_restart_daemon(ctx: &HandlerCtx<'_>) -> Value {
-    restart::handle_restart_daemon(ctx.home)
-}
-
-/// Registered tool dispatchers. **Adding a tool**: write its adapter
-/// above, append a [`HandlerEntry`] here. **Removing**: delete both
-/// halves. Order doesn't affect correctness (linear-scan match by
-/// `name`), but keeping similar tools clustered helps grep.
-///
-/// **Why `static` instead of inline `&[...]` return**: Rust's
-/// const-promotion turns an `&[T {...}]` array literal in fn-return
-/// position into a `'static` slice automatically — but only if every
-/// field of `T` is itself const-promotable in that context. Once
-/// `HandlerEntry` gained `actions: Option<&'static [(&str, HandlerFn)]>`
-/// in T-B8, the inner static-slice field defeats promotion of the
-/// outer array and rustc raises E0515 ("returns a reference to data
-/// owned by the current function"). Lifting the array to a top-level
-/// `static` gives the slice an unambiguous `'static` origin and side-
-/// steps the gotcha. Symptom for future readers: if you add a field
-/// to `HandlerEntry` and the array literal stops compiling, this
-/// `static` is why.
 static REGISTERED: &[HandlerEntry] = &[
-    // Instance lifecycle — shape 1 (T-B7)
     HandlerEntry {
         name: "list_instances",
         handler: dispatch_list_instances,
-        actions: None,
     },
     HandlerEntry {
         name: "create_instance",
         handler: dispatch_create_instance,
-        actions: None,
     },
     HandlerEntry {
         name: "set_description",
         handler: dispatch_set_description,
-        actions: None,
     },
-    // Instance lifecycle — shape 2 (T-B7)
     HandlerEntry {
         name: "interrupt",
         handler: dispatch_interrupt,
-        actions: None,
     },
     HandlerEntry {
         name: "delete_instance",
         handler: dispatch_delete_instance,
-        actions: None,
     },
     HandlerEntry {
         name: "start_instance",
         handler: dispatch_start_instance,
-        actions: None,
     },
     HandlerEntry {
         name: "replace_instance",
         handler: dispatch_replace_instance,
-        actions: None,
     },
     HandlerEntry {
         name: "move_pane",
         handler: dispatch_move_pane,
-        actions: None,
     },
-    // Sender-style — shape 3 (T-B8)
     HandlerEntry {
         name: "set_waiting_on",
         handler: dispatch_set_waiting_on,
-        actions: None,
     },
     HandlerEntry {
         name: "send",
         handler: dispatch_send,
-        actions: None,
     },
-    // Sender-style — shape 4 (T-B8)
     HandlerEntry {
         name: "bind_self",
         handler: dispatch_bind_self,
-        actions: None,
     },
     HandlerEntry {
         name: "binding_state",
         handler: dispatch_binding_state,
-        actions: None,
     },
     HandlerEntry {
         name: "release_worktree",
         handler: dispatch_release_worktree,
-        actions: None,
     },
     HandlerEntry {
         name: "force_release_worktree",
         handler: dispatch_force_release_worktree,
-        actions: None,
     },
     HandlerEntry {
         name: "gc_dry_run",
         handler: dispatch_gc_dry_run,
-        actions: None,
     },
-    // Action sub-routing (T-B8) — all 5 actions wired (`task`).
     HandlerEntry {
         name: "task",
         handler: dispatch_task,
-        actions: Some(TASK_ACTIONS),
     },
-    // Action-based cohort (T-B9): ci / decision / deployment / health
-    // / repo / schedule / team. Alphabetical per dispatch contract's
-    // suggested decomposition.
     HandlerEntry {
         name: "ci",
         handler: dispatch_ci,
-        actions: Some(CI_ACTIONS),
     },
     HandlerEntry {
         name: "decision",
         handler: dispatch_decision,
-        actions: Some(DECISION_ACTIONS),
     },
     HandlerEntry {
         name: "deployment",
         handler: dispatch_deployment,
-        actions: Some(DEPLOYMENT_ACTIONS),
     },
     HandlerEntry {
         name: "health",
         handler: dispatch_health,
-        actions: Some(HEALTH_ACTIONS),
     },
-    // #1084: watchdog snooze/resume/status
     HandlerEntry {
         name: "watchdog",
         handler: dispatch_watchdog,
-        actions: Some(WATCHDOG_ACTIONS),
     },
-    // #1085: runtime-mutable config
     HandlerEntry {
         name: "config",
         handler: dispatch_config,
-        actions: Some(CONFIG_ACTIONS),
     },
     HandlerEntry {
         name: "repo",
         handler: dispatch_repo,
-        actions: Some(REPO_ACTIONS),
     },
     HandlerEntry {
         name: "schedule",
         handler: dispatch_schedule,
-        actions: Some(SCHEDULE_ACTIONS),
     },
     HandlerEntry {
         name: "team",
         handler: dispatch_team,
-        actions: Some(TEAM_ACTIONS),
     },
-    // Channel-heavy cohort (T-B10): download_attachment / inbox / reply.
-    // Flat dispatch (no `args["action"]` sub-routing) — the conceptual
-    // "actions" for `inbox` (drain / describe / thread) are selected by
-    // arg presence inside `dispatch_inbox`, not by an `action` field.
     HandlerEntry {
         name: "download_attachment",
         handler: dispatch_download_attachment,
-        actions: None,
     },
     HandlerEntry {
         name: "inbox",
         handler: dispatch_inbox,
-        actions: None,
     },
     HandlerEntry {
         name: "reply",
         handler: dispatch_reply,
-        actions: None,
     },
-    // Final-cut flat tools (T-B11) — closing out BLOCK 2 at 30/30+.
     HandlerEntry {
         name: "set_display_name",
         handler: dispatch_set_display_name,
-        actions: None,
     },
     HandlerEntry {
         name: "pane_snapshot",
         handler: dispatch_pane_snapshot,
-        actions: None,
     },
     HandlerEntry {
         name: "tui_screenshot",
         handler: dispatch_tui_screenshot,
-        actions: None,
     },
     HandlerEntry {
         name: "task_sweep_config",
         handler: dispatch_task_sweep_config,
-        actions: None,
     },
     HandlerEntry {
         name: "restart_daemon",
         handler: dispatch_restart_daemon,
-        actions: None,
     },
 ];
 
@@ -967,8 +609,6 @@ mod tests {
     use serde_json::json;
 
     fn ctx_for<'a>(home: &'a Path, args: &'a Value, instance: &'a str) -> HandlerCtx<'a> {
-        // Sender field carries `None` for the `&sender`-style adapters
-        // — every one of them handles the no-sender case gracefully.
         static EMPTY_SENDER: Option<Sender> = None;
         HandlerCtx {
             home,
@@ -978,8 +618,6 @@ mod tests {
         }
     }
 
-    /// Unknown tool name → `None`, so `handle_tool` falls back to the
-    /// inline match (which has its own `unknown tool` catch-all).
     #[test]
     fn try_dispatch_returns_none_for_unregistered_tool() {
         let home = std::env::temp_dir();
@@ -988,8 +626,6 @@ mod tests {
         assert!(try_dispatch("definitely_not_a_real_tool", &ctx).is_none());
     }
 
-    /// Registered tool name → `Some(_)` — proves the table actually
-    /// routes through to the adapter.
     #[test]
     fn try_dispatch_returns_some_for_registered_tool() {
         let home = std::env::temp_dir();
@@ -998,8 +634,6 @@ mod tests {
         assert!(try_dispatch("list_instances", &ctx).is_some());
     }
 
-    /// Regression guard: pin the expected registered tool names + count.
-    /// Future PRs that migrate more arms update this list.
     #[test]
     fn registered_handler_names_pin() {
         let names: Vec<&'static str> = registered_handlers().iter().map(|e| e.name).collect();
@@ -1044,11 +678,6 @@ mod tests {
         assert_eq!(registered_handlers().len(), 33);
     }
 
-    /// Coverage test: every tool name advertised by
-    /// [`crate::mcp::tools::tool_definitions`] must be routed somewhere
-    /// — either by the dispatch table (`dispatch.rs`) or by the
-    /// fallback inline `match` (`mod.rs`). Catches the bug class
-    /// "tool added to the catalogue but routing forgotten".
     #[test]
     fn every_advertised_tool_is_routed_somewhere() {
         let defs = crate::mcp::tools::tool_definitions();
@@ -1083,15 +712,8 @@ mod tests {
         );
     }
 
-    /// Action sub-routing — every recognized action across every
-    /// action-based tool routes through its sub-handler. Parameterized
-    /// on (tool, action) pairs to avoid 8+ near-identical test fns.
-    /// The list mirrors the `actions` fields declared in `REGISTERED`
-    /// and the inline-match arms removed from `mod.rs`; if a new
-    /// action gets added to a tool, add it here so the routing is
-    /// pinned.
     #[test]
-    fn try_dispatch_routes_known_action_through_sub_handler() {
+    fn try_dispatch_routes_known_action_through_base_handler() {
         let home = std::env::temp_dir();
         let cases: &[(&str, &[&str])] = &[
             (
@@ -1130,53 +752,13 @@ mod tests {
         }
     }
 
-    /// Cohort invariant — every action-based tool has `actions:
-    /// Some(...)` populated (not `None`). Pins the "we wired the
-    /// sub-routing infrastructure for every cohort member" property.
     #[test]
-    fn action_based_tools_have_actions_populated() {
-        let action_tools = [
-            "task",
-            "ci",
-            "config",
-            "decision",
-            "deployment",
-            "health",
-            "repo",
-            "schedule",
-            "team",
-            "watchdog",
-        ];
-        for tool in action_tools {
-            let entry = registered_handlers()
-                .iter()
-                .find(|e| e.name == tool)
-                .unwrap_or_else(|| panic!("tool '{tool}' should be in dispatch table"));
-            assert!(
-                entry.actions.is_some(),
-                "tool '{tool}' should have action sub-routing populated"
-            );
-        }
-    }
-
-    /// Action sub-routing — unknown action falls through to the base
-    /// handler. The base handler is `dispatch_task` which forwards to
-    /// `task::handle_task`. Internally `tasks::handle` will return its
-    /// own "unknown action" error JSON. We only assert `Some(_)` to
-    /// confirm the fall-through path executed (vs panicking or
-    /// returning `None`).
-    #[test]
-    fn try_dispatch_unknown_action_falls_through_to_base() {
+    fn try_dispatch_unknown_action_falls_through_to_error() {
         let home = std::env::temp_dir();
         let args = json!({"action": "frobnicate-not-a-real-action"});
         let ctx = ctx_for(&home, &args, "");
         let result = try_dispatch("task", &ctx);
-        assert!(result.is_some(), "fall-through must reach base handler");
-        // Sanity-check the base handler ran by looking for the
-        // upstream "unknown" error wording. (`tasks::handle` returns
-        // `{"error": "unknown task action: ..."}` for unrecognized
-        // actions; pinning this proves the fall-through actually
-        // reached `tasks::handle` and not an empty Some(json!(null)).)
+        assert!(result.is_some(), "base handler must still return Some");
         let v = result.unwrap();
         let err = v.get("error").and_then(|e| e.as_str()).unwrap_or("");
         assert!(
@@ -1185,9 +767,6 @@ mod tests {
         );
     }
 
-    /// Action sub-routing — missing `action` arg falls through to the
-    /// base handler (same path as unknown-action). The base handler's
-    /// internal match handles the missing case its own way.
     #[test]
     fn try_dispatch_missing_action_falls_through_to_base() {
         let home = std::env::temp_dir();


### PR DESCRIPTION
## Summary

- Introduce `adapter!` macro (6 shapes: hai/ha/hais/has/h/a) to generate flat dispatch adapters from one-line declarations
- Introduce `action_adapter!` macro to generate action-based dispatch adapters with match dispatch + error handling
- Remove `HandlerEntry.actions` field, all per-action sub-handler functions, and `*_ACTIONS` static tables — redundant since base handler match already routes correctly
- Simplify `try_dispatch` to direct handler call (no action table lookup)

**dispatch.rs: 1258 → 837 lines (-421, -33%)**

Adding a new MCP tool now requires: one `adapter!()` line + one `HandlerEntry` in the table.

## Test plan

- [x] All 185 dispatch tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Tool routing pin test (`registered_handler_names_pin`) passes — all 33 tools still registered
- [x] Action routing test covers all action-based tools (task/ci/decision/deployment/health/repo/schedule/team/watchdog/config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)