### PR TITLE
refactor: unify MCP tool metadata into single registry (#1379)

### DIFF
--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -35,7 +35,7 @@ use super::{
 /// Shared per-call context — every common parameter `handle_tool`
 /// would otherwise pass into the match arms, bundled together so each
 /// [`HandlerFn`] has a single uniform shape.
-pub(super) struct HandlerCtx<'a> {
+pub(crate) struct HandlerCtx<'a> {
     pub home: &'a Path,
     pub args: &'a Value,
     pub instance_name: &'a str,
@@ -45,23 +45,16 @@ pub(super) struct HandlerCtx<'a> {
 /// One MCP tool's dispatcher. Function pointer (not `Box<dyn …>`) so
 /// the slice in [`registered_handlers`] is `const`-friendly and
 /// allocation-free.
-pub(super) type HandlerFn = fn(&HandlerCtx<'_>) -> Value;
+pub(crate) type HandlerFn = fn(&HandlerCtx<'_>) -> Value;
 
-pub(super) struct HandlerEntry {
-    pub name: &'static str,
-    pub handler: HandlerFn,
-}
-
-/// Look the `tool` name up in the dispatch table. Returns `Some(value)`
+/// Look the `tool` name up in the registry. Returns `Some(value)`
 /// on hit; returns `None` if the tool isn't registered — the caller
 /// falls back to the inline `match` in `mod.rs` for un-migrated arms.
 pub(super) fn try_dispatch(tool: &str, ctx: &HandlerCtx<'_>) -> Option<Value> {
-    for entry in registered_handlers() {
-        if entry.name == tool {
-            return Some((entry.handler)(ctx));
-        }
-    }
-    None
+    crate::mcp::registry::all()
+        .iter()
+        .find(|entry| entry.name == tool)
+        .map(|entry| (entry.handler)(ctx))
 }
 
 // ---------------------------------------------------------------------
@@ -81,32 +74,32 @@ pub(super) fn try_dispatch(tool: &str, ctx: &HandlerCtx<'_>) -> Option<Value> {
 // ---------------------------------------------------------------------
 macro_rules! adapter {
     ($name:ident, hai, $handler:expr) => {
-        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+        pub(crate) fn $name(ctx: &HandlerCtx<'_>) -> Value {
             $handler(ctx.home, ctx.args, ctx.instance_name)
         }
     };
     ($name:ident, ha, $handler:expr) => {
-        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+        pub(crate) fn $name(ctx: &HandlerCtx<'_>) -> Value {
             $handler(ctx.home, ctx.args)
         }
     };
     ($name:ident, hais, $handler:expr) => {
-        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+        pub(crate) fn $name(ctx: &HandlerCtx<'_>) -> Value {
             $handler(ctx.home, ctx.args, ctx.instance_name, ctx.sender)
         }
     };
     ($name:ident, has, $handler:expr) => {
-        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+        pub(crate) fn $name(ctx: &HandlerCtx<'_>) -> Value {
             $handler(ctx.home, ctx.args, ctx.sender)
         }
     };
     ($name:ident, h, $handler:expr) => {
-        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+        pub(crate) fn $name(ctx: &HandlerCtx<'_>) -> Value {
             $handler(ctx.home)
         }
     };
     ($name:ident, a, $handler:expr) => {
-        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+        pub(crate) fn $name(ctx: &HandlerCtx<'_>) -> Value {
             $handler(ctx.args)
         }
     };
@@ -132,7 +125,7 @@ macro_rules! adapter {
 
 macro_rules! action_adapter {
     ($name:ident, $tool_label:literal, [ $( $action:literal => $handler:expr , $shape:ident );+ $(;)? ]) => {
-        fn $name(ctx: &HandlerCtx<'_>) -> Value {
+        pub(crate) fn $name(ctx: &HandlerCtx<'_>) -> Value {
             match ctx.args["action"].as_str().unwrap_or("") {
                 $( $action => { adapter!(@call ctx, $shape, $handler) } )+
                 other => json!({"error": format!(concat!("unknown ", $tool_label, " action: {}"), other)}),
@@ -271,7 +264,7 @@ action_adapter!(dispatch_team, "team", [
 //   - `message_id` present → describe single message
 //   - else `thread_id` present → describe thread
 //   - else → drain pending
-fn dispatch_inbox(ctx: &HandlerCtx<'_>) -> Value {
+pub(crate) fn dispatch_inbox(ctx: &HandlerCtx<'_>) -> Value {
     if ctx
         .args
         .get("message_id")
@@ -286,7 +279,7 @@ fn dispatch_inbox(ctx: &HandlerCtx<'_>) -> Value {
     }
 }
 
-fn dispatch_tui_screenshot(ctx: &HandlerCtx<'_>) -> Value {
+pub(crate) fn dispatch_tui_screenshot(ctx: &HandlerCtx<'_>) -> Value {
     match crate::api::call(
         ctx.home,
         &serde_json::json!({"method": crate::api::method::TUI_SCREENSHOT, "params": {}}),
@@ -302,7 +295,7 @@ fn dispatch_tui_screenshot(ctx: &HandlerCtx<'_>) -> Value {
 }
 
 // `watchdog` — actions with inline business logic (not just forwarding).
-fn dispatch_watchdog(ctx: &HandlerCtx<'_>) -> Value {
+pub(crate) fn dispatch_watchdog(ctx: &HandlerCtx<'_>) -> Value {
     match ctx.args["action"].as_str().unwrap_or("") {
         "snooze" => dispatch_watchdog_snooze(ctx),
         "resume" => dispatch_watchdog_resume(ctx),
@@ -397,7 +390,7 @@ fn dispatch_watchdog_ack(ctx: &HandlerCtx<'_>) -> Value {
     })
 }
 
-fn dispatch_config(ctx: &HandlerCtx<'_>) -> Value {
+pub(crate) fn dispatch_config(ctx: &HandlerCtx<'_>) -> Value {
     match ctx.args["action"].as_str().unwrap_or("") {
         "get" => {
             let key = ctx.args["key"].as_str().unwrap_or("");
@@ -459,149 +452,6 @@ fn parse_duration_secs(s: &str) -> Option<i64> {
     }
 }
 
-// ---------------------------------------------------------------------
-// Registration table
-// ---------------------------------------------------------------------
-
-static REGISTERED: &[HandlerEntry] = &[
-    HandlerEntry {
-        name: "list_instances",
-        handler: dispatch_list_instances,
-    },
-    HandlerEntry {
-        name: "create_instance",
-        handler: dispatch_create_instance,
-    },
-    HandlerEntry {
-        name: "set_description",
-        handler: dispatch_set_description,
-    },
-    HandlerEntry {
-        name: "interrupt",
-        handler: dispatch_interrupt,
-    },
-    HandlerEntry {
-        name: "delete_instance",
-        handler: dispatch_delete_instance,
-    },
-    HandlerEntry {
-        name: "start_instance",
-        handler: dispatch_start_instance,
-    },
-    HandlerEntry {
-        name: "replace_instance",
-        handler: dispatch_replace_instance,
-    },
-    HandlerEntry {
-        name: "move_pane",
-        handler: dispatch_move_pane,
-    },
-    HandlerEntry {
-        name: "set_waiting_on",
-        handler: dispatch_set_waiting_on,
-    },
-    HandlerEntry {
-        name: "send",
-        handler: dispatch_send,
-    },
-    HandlerEntry {
-        name: "bind_self",
-        handler: dispatch_bind_self,
-    },
-    HandlerEntry {
-        name: "binding_state",
-        handler: dispatch_binding_state,
-    },
-    HandlerEntry {
-        name: "release_worktree",
-        handler: dispatch_release_worktree,
-    },
-    HandlerEntry {
-        name: "force_release_worktree",
-        handler: dispatch_force_release_worktree,
-    },
-    HandlerEntry {
-        name: "gc_dry_run",
-        handler: dispatch_gc_dry_run,
-    },
-    HandlerEntry {
-        name: "task",
-        handler: dispatch_task,
-    },
-    HandlerEntry {
-        name: "ci",
-        handler: dispatch_ci,
-    },
-    HandlerEntry {
-        name: "decision",
-        handler: dispatch_decision,
-    },
-    HandlerEntry {
-        name: "deployment",
-        handler: dispatch_deployment,
-    },
-    HandlerEntry {
-        name: "health",
-        handler: dispatch_health,
-    },
-    HandlerEntry {
-        name: "watchdog",
-        handler: dispatch_watchdog,
-    },
-    HandlerEntry {
-        name: "config",
-        handler: dispatch_config,
-    },
-    HandlerEntry {
-        name: "repo",
-        handler: dispatch_repo,
-    },
-    HandlerEntry {
-        name: "schedule",
-        handler: dispatch_schedule,
-    },
-    HandlerEntry {
-        name: "team",
-        handler: dispatch_team,
-    },
-    HandlerEntry {
-        name: "download_attachment",
-        handler: dispatch_download_attachment,
-    },
-    HandlerEntry {
-        name: "inbox",
-        handler: dispatch_inbox,
-    },
-    HandlerEntry {
-        name: "reply",
-        handler: dispatch_reply,
-    },
-    HandlerEntry {
-        name: "set_display_name",
-        handler: dispatch_set_display_name,
-    },
-    HandlerEntry {
-        name: "pane_snapshot",
-        handler: dispatch_pane_snapshot,
-    },
-    HandlerEntry {
-        name: "tui_screenshot",
-        handler: dispatch_tui_screenshot,
-    },
-    HandlerEntry {
-        name: "task_sweep_config",
-        handler: dispatch_task_sweep_config,
-    },
-    HandlerEntry {
-        name: "restart_daemon",
-        handler: dispatch_restart_daemon,
-    },
-];
-
-pub(super) fn registered_handlers() -> &'static [HandlerEntry] {
-    REGISTERED
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -636,46 +486,46 @@ mod tests {
 
     #[test]
     fn registered_handler_names_pin() {
-        let names: Vec<&'static str> = registered_handlers().iter().map(|e| e.name).collect();
+        let names: Vec<&'static str> = crate::mcp::registry::all().iter().map(|e| e.name).collect();
         assert_eq!(
             names,
             vec![
+                "reply",
+                "download_attachment",
+                "send",
+                "inbox",
                 "list_instances",
                 "create_instance",
-                "set_description",
-                "interrupt",
                 "delete_instance",
                 "start_instance",
                 "replace_instance",
-                "move_pane",
+                "interrupt",
+                "set_display_name",
+                "set_description",
                 "set_waiting_on",
-                "send",
-                "bind_self",
-                "binding_state",
-                "release_worktree",
-                "force_release_worktree",
-                "gc_dry_run",
-                "task",
-                "ci",
+                "move_pane",
+                "pane_snapshot",
+                "tui_screenshot",
                 "decision",
+                "task",
+                "task_sweep_config",
+                "restart_daemon",
+                "team",
+                "schedule",
                 "deployment",
+                "ci",
                 "health",
                 "watchdog",
                 "config",
                 "repo",
-                "schedule",
-                "team",
-                "download_attachment",
-                "inbox",
-                "reply",
-                "set_display_name",
-                "pane_snapshot",
-                "tui_screenshot",
-                "task_sweep_config",
-                "restart_daemon",
+                "bind_self",
+                "release_worktree",
+                "force_release_worktree",
+                "binding_state",
+                "gc_dry_run",
             ]
         );
-        assert_eq!(registered_handlers().len(), 33);
+        assert_eq!(crate::mcp::registry::all().len(), 33);
     }
 
     #[test]

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -5,7 +5,7 @@ mod binding_state;
 mod channel;
 pub(crate) mod ci;
 mod comms;
-mod dispatch;
+pub(crate) mod dispatch;
 pub(crate) mod dispatch_hook;
 mod force_release;
 pub(crate) mod instance;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -7,6 +7,7 @@
 //! the bridge proxy and `api/handlers/mcp_proxy.rs`.
 
 pub mod handlers;
+pub(crate) mod registry;
 pub mod tools;
 
 use serde_json::Value;

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -1,0 +1,200 @@
+//! Single source of truth for MCP tool registration.
+//!
+//! Each `ToolEntry` pairs a tool's JSON schema definition with its dispatch
+//! handler. Adding a new tool means adding one entry here + implementing the
+//! handler function. `tools.rs` and `dispatch.rs` both read from this registry.
+
+use super::handlers::dispatch::HandlerFn;
+use serde_json::Value;
+
+pub(crate) struct ToolEntry {
+    pub name: &'static str,
+    pub definition: fn() -> Value,
+    pub handler: HandlerFn,
+}
+
+pub(crate) fn all() -> &'static [ToolEntry] {
+    &ALL_TOOLS
+}
+
+static ALL_TOOLS: [ToolEntry; 33] = [
+    // ── Channel ──
+    ToolEntry {
+        name: "reply",
+        definition: super::tools::def_reply,
+        handler: super::handlers::dispatch::dispatch_reply,
+    },
+    ToolEntry {
+        name: "download_attachment",
+        definition: super::tools::def_download_attachment,
+        handler: super::handlers::dispatch::dispatch_download_attachment,
+    },
+    // ── Communication ──
+    ToolEntry {
+        name: "send",
+        definition: super::tools::def_send,
+        handler: super::handlers::dispatch::dispatch_send,
+    },
+    ToolEntry {
+        name: "inbox",
+        definition: super::tools::def_inbox,
+        handler: super::handlers::dispatch::dispatch_inbox,
+    },
+    // ── Instance ──
+    ToolEntry {
+        name: "list_instances",
+        definition: super::tools::def_list_instances,
+        handler: super::handlers::dispatch::dispatch_list_instances,
+    },
+    ToolEntry {
+        name: "create_instance",
+        definition: super::tools::def_create_instance,
+        handler: super::handlers::dispatch::dispatch_create_instance,
+    },
+    ToolEntry {
+        name: "delete_instance",
+        definition: super::tools::def_delete_instance,
+        handler: super::handlers::dispatch::dispatch_delete_instance,
+    },
+    ToolEntry {
+        name: "start_instance",
+        definition: super::tools::def_start_instance,
+        handler: super::handlers::dispatch::dispatch_start_instance,
+    },
+    ToolEntry {
+        name: "replace_instance",
+        definition: super::tools::def_replace_instance,
+        handler: super::handlers::dispatch::dispatch_replace_instance,
+    },
+    ToolEntry {
+        name: "interrupt",
+        definition: super::tools::def_interrupt,
+        handler: super::handlers::dispatch::dispatch_interrupt,
+    },
+    ToolEntry {
+        name: "set_display_name",
+        definition: super::tools::def_set_display_name,
+        handler: super::handlers::dispatch::dispatch_set_display_name,
+    },
+    ToolEntry {
+        name: "set_description",
+        definition: super::tools::def_set_description,
+        handler: super::handlers::dispatch::dispatch_set_description,
+    },
+    ToolEntry {
+        name: "set_waiting_on",
+        definition: super::tools::def_set_waiting_on,
+        handler: super::handlers::dispatch::dispatch_set_waiting_on,
+    },
+    ToolEntry {
+        name: "move_pane",
+        definition: super::tools::def_move_pane,
+        handler: super::handlers::dispatch::dispatch_move_pane,
+    },
+    ToolEntry {
+        name: "pane_snapshot",
+        definition: super::tools::def_pane_snapshot,
+        handler: super::handlers::dispatch::dispatch_pane_snapshot,
+    },
+    ToolEntry {
+        name: "tui_screenshot",
+        definition: super::tools::def_tui_screenshot,
+        handler: super::handlers::dispatch::dispatch_tui_screenshot,
+    },
+    // ── Decision ──
+    ToolEntry {
+        name: "decision",
+        definition: super::tools::def_decision,
+        handler: super::handlers::dispatch::dispatch_decision,
+    },
+    // ── Task ──
+    ToolEntry {
+        name: "task",
+        definition: super::tools::def_task,
+        handler: super::handlers::dispatch::dispatch_task,
+    },
+    ToolEntry {
+        name: "task_sweep_config",
+        definition: super::tools::def_task_sweep_config,
+        handler: super::handlers::dispatch::dispatch_task_sweep_config,
+    },
+    ToolEntry {
+        name: "restart_daemon",
+        definition: super::tools::def_restart_daemon,
+        handler: super::handlers::dispatch::dispatch_restart_daemon,
+    },
+    // ── Team ──
+    ToolEntry {
+        name: "team",
+        definition: super::tools::def_team,
+        handler: super::handlers::dispatch::dispatch_team,
+    },
+    // ── Schedule ──
+    ToolEntry {
+        name: "schedule",
+        definition: super::tools::def_schedule,
+        handler: super::handlers::dispatch::dispatch_schedule,
+    },
+    // ── Deploy ──
+    ToolEntry {
+        name: "deployment",
+        definition: super::tools::def_deployment,
+        handler: super::handlers::dispatch::dispatch_deployment,
+    },
+    // ── CI ──
+    ToolEntry {
+        name: "ci",
+        definition: super::tools::def_ci,
+        handler: super::handlers::dispatch::dispatch_ci,
+    },
+    // ── Health ──
+    ToolEntry {
+        name: "health",
+        definition: super::tools::def_health,
+        handler: super::handlers::dispatch::dispatch_health,
+    },
+    // ── Watchdog ──
+    ToolEntry {
+        name: "watchdog",
+        definition: super::tools::def_watchdog,
+        handler: super::handlers::dispatch::dispatch_watchdog,
+    },
+    // ── Config ──
+    ToolEntry {
+        name: "config",
+        definition: super::tools::def_config,
+        handler: super::handlers::dispatch::dispatch_config,
+    },
+    // ── Repo ──
+    ToolEntry {
+        name: "repo",
+        definition: super::tools::def_repo,
+        handler: super::handlers::dispatch::dispatch_repo,
+    },
+    // ── Worktree ──
+    ToolEntry {
+        name: "bind_self",
+        definition: super::tools::def_bind_self,
+        handler: super::handlers::dispatch::dispatch_bind_self,
+    },
+    ToolEntry {
+        name: "release_worktree",
+        definition: super::tools::def_release_worktree,
+        handler: super::handlers::dispatch::dispatch_release_worktree,
+    },
+    ToolEntry {
+        name: "force_release_worktree",
+        definition: super::tools::def_force_release_worktree,
+        handler: super::handlers::dispatch::dispatch_force_release_worktree,
+    },
+    ToolEntry {
+        name: "binding_state",
+        definition: super::tools::def_binding_state,
+        handler: super::handlers::dispatch::dispatch_binding_state,
+    },
+    ToolEntry {
+        name: "gc_dry_run",
+        definition: super::tools::def_gc_dry_run,
+        handler: super::handlers::dispatch::dispatch_gc_dry_run,
+    },
+];

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -3,365 +3,340 @@
 use serde_json::{json, Value};
 
 pub fn tool_definitions() -> Value {
-    let mut tools = Vec::new();
-    tools.extend(channel_tools());
-    tools.extend(comm_tools());
-    tools.extend(instance_tools());
-    tools.extend(decision_tools());
-    tools.extend(task_tools());
-    tools.extend(team_tools());
-    tools.extend(schedule_tools());
-    tools.extend(repo_tools());
-    tools.extend(deploy_tools());
-    tools.extend(ci_tools());
-    tools.extend(health_tools());
-    tools.extend(watchdog_tools());
-    tools.extend(config_tools());
-    tools.extend(worktree_tools());
+    let tools: Vec<Value> = crate::mcp::registry::all()
+        .iter()
+        .map(|entry| (entry.definition)())
+        .collect();
     json!({"tools": tools})
 }
 
-fn channel_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "reply", "description": "Reply to the user via the active channel. Requires daemon API. Sprint 59 Wave 1 PR-4 ((B) decision default with timeout): when both `default_action` and `timeout_secs` are set, the daemon records a pending operator decision sidecar and auto-fires the default after the timeout window. Subsequent reply calls without `default_action` resolve the pending decision (operator override / explicit answer arrived).",
-            "inputSchema": {"type": "object", "properties": {
-                "text": {"type": "string"},
-                "default_action": {"type": "string", "description": "Action to auto-execute on timeout when the operator doesn't reply within `timeout_secs`. e.g. 'proceed-with-lean' / 'abort'. Pair with `timeout_secs` (Sprint 59 Wave 1 PR-4)."},
-                "timeout_secs": {"type": "integer", "description": "Seconds to wait for an operator response before firing `default_action`. Required when `default_action` is set; ignored otherwise (Sprint 59 Wave 1 PR-4)."}
-            }, "required": ["text"]}}),
-        json!({"name": "download_attachment", "description": "Download a file attachment (telegram multimedia: images, audio, documents). Returns local path. Requires daemon API.",
-            "inputSchema": {"type": "object", "properties": {"file_id": {"type": "string"}}, "required": ["file_id"]}}),
-    ]
-}
-
-fn comm_tools() -> Vec<Value> {
-    vec![
-        // --- Unified send (Sprint 30: 5→1 consolidation) ---
-        json!({"name": "send", "description": "Send a message to another instance or broadcast to multiple. Replaces send_to_instance/delegate_task/report_result/request_information/broadcast. Sprint 58 Wave 4 PR-1: kind=task dispatches MUST include task_id (call task action=create first to obtain a 't-...' id).",
-            "inputSchema": {"type": "object", "properties": {
-                "target_instance": {"type": "string", "description": "Target instance name (single recipient)"},
-                "targets": {"type": "array", "items": {"type": "string"}, "description": "Multiple targets (broadcast mode)"},
-                "team": {"type": "string", "description": "Team name (broadcast to team)"},
-                "tags": {"type": "array", "items": {"type": "string"}, "description": "Tags filter (broadcast mode)"},
-                "message": {"type": "string", "description": "Message text (or 'task' for delegate, 'summary' for report, 'question' for query)"},
-                "request_kind": {"type": "string", "enum": ["query", "task", "report", "update"], "description": "Message kind (determines behavior). NOTE: kind=task requires task_id (Sprint 58 Wave 4 PR-1 anti-stall contract)."},
-                "requires_reply": {"type": "boolean"},
-                "task_summary": {"type": "string"},
-                "success_criteria": {"type": "string", "description": "For task delegation"},
-                "context": {"type": "string"},
-                "task_id": {"type": "string", "description": "Task board ID for correlation. REQUIRED when request_kind=task — caller must obtain via `task action=create` and reference the resulting `t-...` id, closing the Wave 3 PR-1 dispatch protocol gap."},
-                "correlation_id": {"type": "string"},
-                "parent_id": {"type": "string"},
-                "thread_id": {"type": "string"},
-                "force": {"type": "boolean", "description": "Override busy gate (requires force_reason)"},
-                "force_reason": {"type": "string"},
-                "second_reviewer": {"type": "boolean", "description": "Signal dual review (§3.5)"},
-                "second_reviewer_reason": {"type": "string"},
-                "reviewed_head": {"type": "string", "description": "Git HEAD SHA at time of review"},
-                "artifacts": {"type": "string"},
-                "branch": {"type": "string"},
-                "working_directory": {"type": "string"},
-                "sequencing": {"type": "string", "enum": ["parallel", "sequential", "sequential-merge-only"], "description": "Task execution order constraint"},
-                "eta_minutes": {"type": "integer", "description": "Expected completion time in minutes"},
-                "reporting_cadence": {"type": "string", "enum": ["per-pr", "wave-end", "both"], "description": "When implementer should report back"},
-                "worktree_binding_required": {"type": "boolean", "description": "Whether target must bind to a worktree before starting"},
-                "expect_reply_within_secs": {"type": "integer", "description": "Opt-in dispatch-idle watchdog (PR1). When set on a kind=task/query send, the daemon records a pending-dispatch sidecar and fires `dispatch_idle_threshold_exceeded` to the dispatcher's inbox if the matching kind=report (correlation_id-keyed) hasn't arrived within this many seconds. Default unset = no tracking (cross-team-safe). Fixup-team dispatches inherit a 10-min default automatically; other teams must opt in explicitly."},
-                "next_after_ci": {"type": "string", "description": "#931 Fix 2 (H5a): when dispatching kind=task with a `branch`, set this to the agent that should receive `[ci-ready-for-action]` after CI passes on that branch. The daemon's auto-armed ci-watch carries the chain target so the handoff fires without a manual follow-up `ci action=watch next_after_ci=…`. Example: lead dispatches dev with `next_after_ci=reviewer` — reviewer is auto-notified when dev's PR goes green."},
-                "terminal": {"type": "boolean", "description": "Set true on kind=report to signal task completion. When correlation_id matches a task and reporter is the assignee, the task is auto-closed. Default false — progress reports and review verdicts do not trigger auto-close."}
-            }, "required": ["message"]}}),
-        json!({"name": "inbox", "description": "Check pending messages, OR look up a single message by ID, OR fetch a thread's messages. No params = drain pending. With message_id = describe message status (read/unread/expired/notfound). With thread_id = fetch all messages in thread ordered by timestamp.",
+pub(crate) fn def_reply() -> Value {
+    json!({"name": "reply", "description": "Reply to the user via the active channel. Requires daemon API. Sprint 59 Wave 1 PR-4 ((B) decision default with timeout): when both `default_action` and `timeout_secs` are set, the daemon records a pending operator decision sidecar and auto-fires the default after the timeout window. Subsequent reply calls without `default_action` resolve the pending decision (operator override / explicit answer arrived).",
         "inputSchema": {"type": "object", "properties": {
-            "message_id": {"type": "string", "description": "Look up message status by ID"},
-            "thread_id": {"type": "string", "description": "Fetch all messages in a thread"},
-            "instance": {"type": "string", "description": "For message_id: target instance (defaults to caller). For thread_id: filter to a specific instance's inbox (optional, scans all if omitted)"}
-        }}}),
-    ]
+            "text": {"type": "string"},
+            "default_action": {"type": "string", "description": "Action to auto-execute on timeout when the operator doesn't reply within `timeout_secs`. e.g. 'proceed-with-lean' / 'abort'. Pair with `timeout_secs` (Sprint 59 Wave 1 PR-4)."},
+            "timeout_secs": {"type": "integer", "description": "Seconds to wait for an operator response before firing `default_action`. Required when `default_action` is set; ignored otherwise (Sprint 59 Wave 1 PR-4)."}
+        }, "required": ["text"]}})
 }
 
-fn instance_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "list_instances", "description": "List all active agent instances. Pass optional `name` for detailed info on a single instance.",
-            "inputSchema": {"type": "object", "properties": {"name": {"type": "string", "description": "Optional: instance name for detailed info"}}}}),
-        json!({"name": "create_instance", "description": "Create agent instance(s). Team modes: (a) homogeneous — count:3, backend:\"claude\", team:\"dev\" → dev-1..dev-3 all claude; (b) heterogeneous — backends:[\"codex\",\"kiro-cli\",\"gemini\"], team:\"mixed\" → mixed-1=codex, mixed-2=kiro-cli, mixed-3=gemini, all grouped in one tab.",
-            "inputSchema": {"type": "object", "properties": {
-                "name": {"type": "string", "description": "Instance name (single instance) or base name (ignored when team is set — team name is used as prefix)"},
-                "backend": {"type": "string", "description": "Backend CLI name: claude, gemini, kiro-cli, codex, opencode"},
-                "args": {"type": "string", "description": "Extra CLI arguments"},
-                "model": {"type": "string", "description": "Model override (e.g. --model flag)"},
-                "working_directory": {"type": "string"},
-                "branch": {"type": "string", "description": "Git branch — creates worktree if specified"},
-                "task": {"type": "string", "description": "Initial task to inject after spawn"},
-                "layout": {"type": "string", "enum": ["tab", "split-right", "split-below"], "description": "TUI layout: tab (default), split-right, or split-below. Places the new pane relative to `target_pane` if given, otherwise relative to the caller."},
-                "target_pane": {"type": "string", "description": "Name of an existing instance. When set with layout=split-right/split-below, the new pane is attached next to that instance's pane (wherever it currently lives), instead of the caller's focused pane. Falls back to caller, then new tab, if the target isn't currently displayed."},
-                "count": {"type": "integer", "description": "Number of instances to spawn (requires team; ignored when `backends` is set)"},
-                "team": {"type": "string", "description": "Team name — members become <team>-1, <team>-2, ... grouped in one tab"},
-                "backends": {"type": "array", "items": {"type": "string"}, "description": "Per-member backend list for a mixed-backend team (requires team). Length dictates member count."},
-                "command": {"type": "string", "description": "Deprecated: use 'backend' instead"}
-            }, "required": ["name"]}}),
-        json!({"name": "delete_instance", "description": "Stop and remove an instance.",
-            "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}),
-        json!({"name": "start_instance", "description": "Start a stopped instance.",
-            "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}),
-        json!({"name": "replace_instance", "description": "Replace an instance with a fresh one.",
-            "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}, "reason": {"type": "string"}}, "required": ["name"]}}),
-        json!({"name": "interrupt", "description": "Send ESC byte to target agent's PTY to interrupt current LLM turn. Context preserved, agent accepts next prompt.",
-            "inputSchema": {"type": "object", "properties": {
-                "target": {"type": "string", "description": "Target instance name"},
-                "reason": {"type": "string", "description": "Optional follow-up message to inject after ESC"}
-            }, "required": ["target"]}}),
-        json!({"name": "set_display_name", "description": "Set your display name.",
-            "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}}),
-        json!({"name": "set_description", "description": "Set a description for this instance.",
-            "inputSchema": {"type": "object", "properties": {"description": {"type": "string"}}, "required": ["description"]}}),
-        json!({"name": "set_waiting_on", "description": "Declare what this instance is currently waiting for. Set to empty string to clear. Automatically cleared when stale.",
-            "inputSchema": {"type": "object", "properties": {"condition": {"type": "string", "description": "What you are waiting for, e.g. 'review from at-dev-4'. Empty string to clear."}}, "required": ["condition"]}}),
-        json!({"name": "move_pane", "description": "Move an instance's pane into a different tab in the TUI. If `target_tab` names an existing tab, the pane splits that tab's focused pane; otherwise a new tab with that name is created and the pane becomes its root. Preserves scrollback and PTY state (unlike delete + create).",
-            "inputSchema": {"type": "object", "properties": {
-                "agent": {"type": "string", "description": "Instance name whose pane should be moved."},
-                "target_tab": {"type": "string", "description": "Destination tab name. Created if not present."},
-                "split_dir": {"type": "string", "enum": ["horizontal", "vertical"], "description": "Split direction when the destination tab already exists. Default: horizontal. Ignored when a new tab is created."}
-            }, "required": ["agent", "target_tab"]}}),
-        json!({"name": "pane_snapshot", "description": "Read visible text from a target instance's PTY scrollback. Returns plain text (ANSI stripped). Default 100 lines, max 10000.",
-            "inputSchema": {"type": "object", "properties": {
-                "target": {"type": "string", "description": "Target instance name"},
-                "lines": {"type": "integer", "description": "Number of lines to return (default 100, max 10000)"}
-            }, "required": ["target"]}}),
-        json!({"name": "tui_screenshot", "description": "Capture the current TUI state as an SVG image. Only works in TUI mode (not daemon-only). Returns SVG string.",
-            "inputSchema": {"type": "object", "properties": {}}}),
-    ]
+pub(crate) fn def_download_attachment() -> Value {
+    json!({"name": "download_attachment", "description": "Download a file attachment (telegram multimedia: images, audio, documents). Returns local path. Requires daemon API.",
+        "inputSchema": {"type": "object", "properties": {"file_id": {"type": "string"}}, "required": ["file_id"]}})
 }
 
-fn decision_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "decision", "description": "Manage decisions. Actions: post, list, update.",
-            "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["post", "list", "update"]},
-                "title": {"type": "string"}, "content": {"type": "string"},
-                "scope": {"type": "string", "enum": ["project", "fleet"]},
-                "tags": {"type": "array", "items": {"type": "string"}},
-                "ttl_days": {"type": "number"}, "supersedes": {"type": "string"},
-                "id": {"type": "string"}, "archive": {"type": "boolean"},
-                "include_archived": {"type": "boolean"}
-            }, "required": ["action"]}}),
-    ]
-}
-
-fn task_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health, activity, metadata_set, metadata_get. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (4 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
-            "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health", "activity", "metadata_set", "metadata_get"]},
-                "title": {"type": "string"}, "description": {"type": "string"},
-                "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
-                "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}}, "parent_id": {"type": "string", "description": "Parent task ID for subtask composition (A is composed of B,C,D). Complementary to depends_on (execution order)."},
-                "id": {"type": "string"}, "result": {"type": "string"},
-                "status": {"type": "string", "enum": ["backlog", "open", "claimed", "in_progress", "in_review", "blocked", "verified", "done", "cancelled"]},
-                "filter_assignee": {"type": "string"}, "filter_status": {"type": "string"}, "filter_tag": {"type": "string", "description": "Filter by tag"}, "tags": {"type": "array", "items": {"type": "string"}, "description": "Task tags (for create/update)"},
-                "include_history": {"type": "boolean", "description": "#806: opt in to done/cancelled in `list` response (default trims to actionable)."},
-                "limit": {"type": "integer", "description": "#806: cap `list` response to N newest-first entries (sort by updated_at desc)."},
-                "due_at": {"type": "string", "description": "ISO 8601 deadline for the task"},
-                "branch": {"type": "string", "description": "Git branch the implementer should work on"},
-                "force": {"type": "boolean", "description": "#808: bypass ownership ACL on done/update for historical ghost-owned cleanup. Requires non-empty force_reason."},
-                "force_reason": {"type": "string", "description": "#808: required when force=true. Logged to event-log.jsonl and embedded in the per-task event's reason field for audit."},
-                "apply": {"type": "boolean", "description": "#806 sweep: when false (default), returns dry-run plan; when true, emits Cancelled for the confirm_ids subset."},
-                "confirm_ids": {"type": "array", "items": {"type": "string"}, "description": "#806 sweep apply=true: subset of candidate_ids from prior dry-run to actually cancel."},
-                "audit_reason": {"type": "string", "description": "#806 sweep apply=true: required audit text recorded in event-log.jsonl + per-task Cancelled.reason."},
-                "repo": {"type": "string", "description": "#806 sweep: override repo for PR-state queries (defaults to task_sweep.json's repo)."},
-                "metadata_key": {"type": "string", "description": "Key for metadata_set action."},
-                "metadata_value": {"description": "Value for metadata_set action (any JSON type)."}
-            }, "required": ["action"]}}),
-        json!({"name": "task_sweep_config",
-        "description": "Configure GitHub-PR auto-close sweep daemon. Sweep polls merged PRs and emits Done events for `Closes t-XXX-N` markers (validated by 5-must-have pipeline).",
+pub(crate) fn def_send() -> Value {
+    json!({"name": "send", "description": "Send a message to another instance or broadcast to multiple. Replaces send_to_instance/delegate_task/report_result/request_information/broadcast. Sprint 58 Wave 4 PR-1: kind=task dispatches MUST include task_id (call task action=create first to obtain a 't-...' id).",
         "inputSchema": {"type": "object", "properties": {
-            "repo": {"type": "string", "description": "GitHub `owner/repo` to sweep (empty string disables)"},
-            "pause": {"type": "boolean", "description": "Pause/resume the sweep tick"},
-            "dry_run": {"type": "boolean", "description": "Log decisions without emitting events"}
-        }}}),
-        json!({"name": "restart_daemon", "description": "Request graceful daemon restart. Daemon exits with code 42 after shutdown; a supervisor (launchd/systemd/Task Scheduler from `agend-terminal service install`, or `scripts/agend-wrapper.sh` for manual mode) respawns it. Returns ok:false when no supervisor is detected (bare `agend-terminal start`) — operator must install a supervisor before retry. Idempotent.",
-            "inputSchema": {"type": "object", "properties": {}}}),
-    ]
+            "target_instance": {"type": "string", "description": "Target instance name (single recipient)"},
+            "targets": {"type": "array", "items": {"type": "string"}, "description": "Multiple targets (broadcast mode)"},
+            "team": {"type": "string", "description": "Team name (broadcast to team)"},
+            "tags": {"type": "array", "items": {"type": "string"}, "description": "Tags filter (broadcast mode)"},
+            "message": {"type": "string", "description": "Message text (or 'task' for delegate, 'summary' for report, 'question' for query)"},
+            "request_kind": {"type": "string", "enum": ["query", "task", "report", "update"], "description": "Message kind (determines behavior). NOTE: kind=task requires task_id (Sprint 58 Wave 4 PR-1 anti-stall contract)."},
+            "requires_reply": {"type": "boolean"},
+            "task_summary": {"type": "string"},
+            "success_criteria": {"type": "string", "description": "For task delegation"},
+            "context": {"type": "string"},
+            "task_id": {"type": "string", "description": "Task board ID for correlation. REQUIRED when request_kind=task — caller must obtain via `task action=create` and reference the resulting `t-...` id, closing the Wave 3 PR-1 dispatch protocol gap."},
+            "correlation_id": {"type": "string"},
+            "parent_id": {"type": "string"},
+            "thread_id": {"type": "string"},
+            "force": {"type": "boolean", "description": "Override busy gate (requires force_reason)"},
+            "force_reason": {"type": "string"},
+            "second_reviewer": {"type": "boolean", "description": "Signal dual review (§3.5)"},
+            "second_reviewer_reason": {"type": "string"},
+            "reviewed_head": {"type": "string", "description": "Git HEAD SHA at time of review"},
+            "artifacts": {"type": "string"},
+            "branch": {"type": "string"},
+            "working_directory": {"type": "string"},
+            "sequencing": {"type": "string", "enum": ["parallel", "sequential", "sequential-merge-only"], "description": "Task execution order constraint"},
+            "eta_minutes": {"type": "integer", "description": "Expected completion time in minutes"},
+            "reporting_cadence": {"type": "string", "enum": ["per-pr", "wave-end", "both"], "description": "When implementer should report back"},
+            "worktree_binding_required": {"type": "boolean", "description": "Whether target must bind to a worktree before starting"},
+            "expect_reply_within_secs": {"type": "integer", "description": "Opt-in dispatch-idle watchdog (PR1). When set on a kind=task/query send, the daemon records a pending-dispatch sidecar and fires `dispatch_idle_threshold_exceeded` to the dispatcher's inbox if the matching kind=report (correlation_id-keyed) hasn't arrived within this many seconds. Default unset = no tracking (cross-team-safe). Fixup-team dispatches inherit a 10-min default automatically; other teams must opt in explicitly."},
+            "next_after_ci": {"type": "string", "description": "#931 Fix 2 (H5a): when dispatching kind=task with a `branch`, set this to the agent that should receive `[ci-ready-for-action]` after CI passes on that branch. The daemon's auto-armed ci-watch carries the chain target so the handoff fires without a manual follow-up `ci action=watch next_after_ci=…`. Example: lead dispatches dev with `next_after_ci=reviewer` — reviewer is auto-notified when dev's PR goes green."},
+            "terminal": {"type": "boolean", "description": "Set true on kind=report to signal task completion. When correlation_id matches a task and reporter is the assignee, the task is auto-closed. Default false — progress reports and review verdicts do not trigger auto-close."}
+        }, "required": ["message"]}})
 }
 
-fn team_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "team", "description": "Manage teams. Actions: create, delete, list, update.",
-            "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["create", "delete", "list", "update"]},
-                "name": {"type": "string"}, "members": {"type": "array", "items": {"type": "string"}},
-                "orchestrator": {"type": "string", "description": "Team orchestrator — must be a member."},
-                "description": {"type": "string"},
-                "source_repo": {"type": "string", "description": "Source repository path for the team."},
-                "add": {"type": "array", "items": {"type": "string"}},
-                "remove": {"type": "array", "items": {"type": "string"}}
-            }, "required": ["action"]}}),
-    ]
+pub(crate) fn def_inbox() -> Value {
+    json!({"name": "inbox", "description": "Check pending messages, OR look up a single message by ID, OR fetch a thread's messages. No params = drain pending. With message_id = describe message status (read/unread/expired/notfound). With thread_id = fetch all messages in thread ordered by timestamp.",
+    "inputSchema": {"type": "object", "properties": {
+        "message_id": {"type": "string", "description": "Look up message status by ID"},
+        "thread_id": {"type": "string", "description": "Fetch all messages in a thread"},
+        "instance": {"type": "string", "description": "For message_id: target instance (defaults to caller). For thread_id: filter to a specific instance's inbox (optional, scans all if omitted)"}
+    }}})
 }
 
-fn schedule_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "schedule", "description": "Manage schedules. Actions: create, list, update, delete.",
-            "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["create", "list", "update", "delete"]},
-                "id": {"type": "string"},
-                "cron": {"type": "string", "description": "5- or 6-field cron expression (recurring). 5-field layout: `min hour day-of-month month day-of-week`; 6-field prepends seconds. Day-of-week uses Quartz convention: 1=Sun, 2=Mon, 3=Tue, 4=Wed, 5=Thu, 6=Fri, 7=Sat (NOT Unix 0-6). Example: every Wed+Sat at 15:00 → `0 15 * * 4,7`."},
-                "run_at": {"type": "string", "description": "ISO 8601 one-shot instant."},
-                "message": {"type": "string"}, "target": {"type": "string"},
-                "label": {"type": "string"},
-                "timezone": {"type": "string", "description": "IANA zone name."},
-                "enabled": {"type": "boolean"}
-            }, "required": ["action"]}}),
-    ]
+pub(crate) fn def_list_instances() -> Value {
+    json!({"name": "list_instances", "description": "List all active agent instances. Pass optional `name` for detailed info on a single instance.",
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string", "description": "Optional: instance name for detailed info"}}}})
 }
 
-fn deploy_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "deployment", "description": "Manage deployments. Actions: deploy, teardown, list.",
-            "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["deploy", "teardown", "list"]},
-                "template": {"type": "string", "description": "Template name from fleet.yaml"},
-                "directory": {"type": "string", "description": "Working directory for instances"},
-                "name": {"type": "string", "description": "Deployment name"},
-                "branch": {"type": "string", "description": "Git branch — each instance gets its own worktree"}
-            }, "required": ["action"]}}),
-    ]
-}
-
-fn ci_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "ci", "description": "Manage CI watching. Actions: watch, unwatch, status.",
-            "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["watch", "unwatch", "status"]},
-                "repo": {"type": "string", "description": "GitHub repo (owner/repo). Required for watch/unwatch; optional filter for status."},
-                "branch": {"type": "string", "description": "Branch to watch (default: main); optional filter for status."},
-                "interval_secs": {"type": "number", "description": "Poll interval in seconds (default: 60)"},
-                "next_after_ci": {"type": "string", "description": "Instance to auto-notify when CI passes. Daemon sends [ci-ready-for-action] to this target."},
-                "review_class": {"type": "string", "enum": ["single", "dual"], "description": "#972: review threshold for the daemon's PR-state aggregator. `single` (default) — §3.6 one VERIFIED unlocks the merge gate. `dual` — §3.5 two distinct VERIFIED required before `[pr-ready-for-merge]` fires."}
-            }, "required": ["action"]}}),
-    ]
-}
-
-fn watchdog_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "watchdog", "description": "#1084/#1076: Fleet idle watchdog control. Actions: snooze, resume, status, ack. `ack` suppresses fleet alerts until post-ack agent activity is detected, then auto-clears.",
-            "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["snooze", "resume", "status", "ack"]},
-                "duration": {"type": "string", "description": "Snooze duration (e.g. '2h', '30m', '1h30m'). Clamped to max 4h. Default: 1h."}
-            }, "required": ["action"]}}),
-    ]
-}
-
-fn config_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "config", "description": "#1085: Runtime-mutable daemon configuration. Actions: get, set, list. Keys: dev_idle_threshold_secs, fleet_idle_threshold_secs, hang_auto_recovery_enabled.",
+pub(crate) fn def_create_instance() -> Value {
+    json!({"name": "create_instance", "description": "Create agent instance(s). Team modes: (a) homogeneous — count:3, backend:\"claude\", team:\"dev\" → dev-1..dev-3 all claude; (b) heterogeneous — backends:[\"codex\",\"kiro-cli\",\"gemini\"], team:\"mixed\" → mixed-1=codex, mixed-2=kiro-cli, mixed-3=gemini, all grouped in one tab.",
         "inputSchema": {"type": "object", "properties": {
-            "action": {"type": "string", "enum": ["get", "set", "list"]},
-            "key": {"type": "string", "description": "Config key name (required for get/set)"},
-            "value": {"type": "string", "description": "New value (required for set)"}
-        }, "required": ["action"]}}),
-    ]
+            "name": {"type": "string", "description": "Instance name (single instance) or base name (ignored when team is set — team name is used as prefix)"},
+            "backend": {"type": "string", "description": "Backend CLI name: claude, gemini, kiro-cli, codex, opencode"},
+            "args": {"type": "string", "description": "Extra CLI arguments"},
+            "model": {"type": "string", "description": "Model override (e.g. --model flag)"},
+            "working_directory": {"type": "string"},
+            "branch": {"type": "string", "description": "Git branch — creates worktree if specified"},
+            "task": {"type": "string", "description": "Initial task to inject after spawn"},
+            "layout": {"type": "string", "enum": ["tab", "split-right", "split-below"], "description": "TUI layout: tab (default), split-right, or split-below. Places the new pane relative to `target_pane` if given, otherwise relative to the caller."},
+            "target_pane": {"type": "string", "description": "Name of an existing instance. When set with layout=split-right/split-below, the new pane is attached next to that instance's pane (wherever it currently lives), instead of the caller's focused pane. Falls back to caller, then new tab, if the target isn't currently displayed."},
+            "count": {"type": "integer", "description": "Number of instances to spawn (requires team; ignored when `backends` is set)"},
+            "team": {"type": "string", "description": "Team name — members become <team>-1, <team>-2, ... grouped in one tab"},
+            "backends": {"type": "array", "items": {"type": "string"}, "description": "Per-member backend list for a mixed-backend team (requires team). Length dictates member count."},
+            "command": {"type": "string", "description": "Deprecated: use 'backend' instead"}
+        }, "required": ["name"]}})
 }
 
-fn health_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "health", "description": "Manage health state. Actions: report, clear.",
-            "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["report", "clear"]},
-                "reason": {"type": "string", "enum": ["rate_limit", "quota_exceeded", "awaiting_operator"], "description": "Blocked reason kind (for report)"},
-                "retry_after_secs": {"type": "integer", "description": "Seconds until retry (for rate_limit)"},
-                "note": {"type": "string", "description": "Optional human-readable note"},
-                "instance": {"type": "string", "description": "Target instance name (for clear)"}
-            }, "required": ["action"]}}),
-    ]
+pub(crate) fn def_delete_instance() -> Value {
+    json!({"name": "delete_instance", "description": "Stop and remove an instance.",
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}})
 }
 
-fn repo_tools() -> Vec<Value> {
-    vec![
-        json!({"name": "repo", "description": "Manage repo worktrees. Actions: checkout, release, cleanup_init_commits, cleanup_merged_branches, merge. #817: cleanup_merged_branches is operator-triggered local-branch hygiene (4 categories: clean_merged/squash_merged/stale_idle/active_unknown; dry-run by default + confirm_ids + audit_reason required for apply).",
-            "inputSchema": {"type": "object", "properties": {
-                "action": {"type": "string", "enum": ["checkout", "release", "cleanup_init_commits", "cleanup_merged_branches", "merge"]},
-                "pr": {"type": "integer", "description": "PR number for merge action."},
-                "source": {"type": "string"}, "branch": {"type": "string"},
-                "path": {"type": "string"},
-                "agent": {"type": "string", "description": "#789: target agent for cleanup_init_commits (defaults to caller's instance_name). Cleans empty `init` commits accumulated in the agent's bound worktree by backend session-checkpoint heartbeats. Returns {cleaned_count, [skipped_reason]}. Idempotent — call before push to scrub PR history."},
-                "bind": {"type": "boolean", "description": "#778 Option 1: when true on checkout, atomically bind the caller to the just-provisioned worktree (writes binding.json + .agend-managed marker + arms ci_watches) and lands HEAD on the named branch instead of a detached commit. Default false preserves back-compat for inspection-only callers (review pool, operator triage)."},
-                "base": {"type": "string", "description": "#817 cleanup_merged_branches: branch to compare against for clean/squash merge detection (default 'main')."},
-                "min_age_days": {"type": "integer", "description": "#817 cleanup_merged_branches: stale_idle threshold in days (default 90)."},
-                "apply": {"type": "boolean", "description": "#817 cleanup_merged_branches: when false (default), returns dry-run plan; when true, deletes confirm_ids subset."},
-                "confirm_ids": {"type": "array", "items": {"type": "string"}, "description": "#817 cleanup_merged_branches apply=true: subset of candidate_ids from prior dry-run to actually delete via `git branch -D`."},
-                "audit_reason": {"type": "string", "description": "#817 cleanup_merged_branches apply=true: required audit text recorded in event-log.jsonl per deleted branch with source SHA for restore."}
-            }, "required": ["action"]}}),
-    ]
+pub(crate) fn def_start_instance() -> Value {
+    json!({"name": "start_instance", "description": "Start a stopped instance.",
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}})
 }
 
-fn worktree_tools() -> Vec<Value> {
-    vec![
-        // Sprint 54 P1-7: generic self-bind. Same `dispatch_auto_bind_lease`
-        // lifecycle as `repo action=checkout bind:true` (#779 Option 1);
-        // difference is caller context (fleet.yaml-resolved source_repo vs
-        // explicit `source` arg), not the underlying mechanism. Every
-        // Sprint 53/54 invariant (Phase 1 trailers, P0-1.5 cross-agent
-        // registry check, P0-1.6 actual-HEAD verification, P0-X
-        // release_worktree as sole exit point, source_repo persistence,
-        // auto watch_ci) applies uniformly.
-        // Sprint 55 P0-B: dual-arg shape (handler at worktree.rs:24-27) —
-        // schema exposes both `source_repo` (preferred) and legacy `repo`
-        // with `required` relaxed to `branch` only. Handler enforces
-        // mutual exclusivity at runtime via `ambiguous_args` code.
-        json!({"name": "bind_self", "description": "Bind the calling agent to a worktree on the named branch. For fresh-task workflows that know the source repo, prefer `repo action=checkout bind:true` (#779 Option 1) — single-step atomic provision + bind. Use `bind_self` when the caller is mid-lifecycle: (a) re-binding a recovered worktree via `rebase_mode=true`, (b) binding via fleet.yaml-resolved source_repo (no explicit source arg), or (c) post-`release_worktree` re-claim of the same branch. Both paths share `dispatch_auto_bind_lease` so binding.json + .agend-managed marker + auto watch_ci all land. Rejects 'main'/'master' (E4.5) and cross-agent branch conflicts. Pair with `release_worktree` to unbind.",
-            "inputSchema": {"type": "object", "properties": {
-                "source_repo": {"type": "string", "description": "Local path to source repository. Daemon resolves GitHub owner/repo via `git remote get-url origin`. Sprint 55 P0-B preferred form. Mutually exclusive with `repo` (handler rejects both via `ambiguous_args` code)."},
-                "repo": {"type": "string", "description": "GitHub repo (owner/name). Legacy form retained for one-Sprint deprecation window — emits warn-log; removal Sprint 57. Mutually exclusive with `source_repo`."},
-                "branch": {"type": "string", "description": "Branch to bind (must not be main/master)"},
-                "rebase_mode": {"type": "boolean", "description": "Sprint 60 W1 PR-1: atomic recover-and-bind. When true, releases self's stale on-disk worktree dir + binding state before lease — closes the lease_failed recovery path without an explicit release_worktree call. Cross-agent isolation preserved (rejects branches leased by another agent)."}
-            }, "required": ["branch"]}}),
-        // Sprint 53 P0-X: release a daemon-managed worktree + clear binding
-        // for `agent`. Idempotent. Only removes worktrees that carry the
-        // `.agend-managed` marker (R14 safety — operator-created worktrees
-        // are left alone). Operator- and agent-callable.
-        json!({"name": "release_worktree", "description": "Release the daemon-managed worktree and clear the binding for the given agent. Idempotent. Only removes worktrees carrying the `.agend-managed` marker — operator-created worktrees are left alone.",
-            "inputSchema": {"type": "object", "properties": {
-                "agent": {"type": "string", "description": "Agent name whose worktree + binding to release"}
-            }, "required": ["agent"]}}),
-        // Sprint 59 Wave 1 PR-5 emergency cherry-pick: closes the
-        // bind_self lease_failed recovery path so callers never
-        // resort to AGEND_GIT_BYPASS=1 to clean stale on-disk
-        // worktree dirs (operator Q2=(C) bypass-free permanent
-        // protocol). Required when the binding state was already
-        // released but the on-disk dir lingers (e.g. prior PR cycle
-        // crashed mid-cleanup).
-        json!({"name": "force_release_worktree", "description": "Force-release a stale daemon-managed worktree directory — cleans <home>/worktrees/<agent>/<branch>/ on disk + runs the standard release_full to clear any lingering binding state. Idempotent. Refuses to clean paths outside the daemon worktree pool. Sprint 59 Wave 1 PR-5 emergency cherry-pick supporting Q2=(C) bypass-free permanent protocol.",
-            "inputSchema": {"type": "object", "properties": {
-                "agent": {"type": "string", "description": "Agent name (worktree owner)"},
-                "branch": {"type": "string", "description": "Branch name (worktree subdirectory)"}
-            }, "required": ["agent", "branch"]}}),
-        // Sprint 60 W1 PR-3 (#P0-3): operator-initiated restart MCP tool.
-        // Closes the operator-restart-required SPOF that drove the
-        // Sprint 59 PR-4 (P3) abandon path. Sets RESTART_PENDING +
-        // records OperatorRestart shutdown reason; the daemon's main
-        // loop notices, runs shutdown_sequence, and re-execs self
-        // (Unix) or spawns + exits (Windows). On-disk state (binding
-        // metadata, topic registry, fleet.yaml) is preserved across
-        // restart automatically since it's already on disk; PTY
-        // agents are killed and operator re-attaches post-restart
-        // (MVP scope).
-        // Sprint 58 Wave 3 PR-2 (#8): daemon-side binding diagnostic.
-        // Operator + agent introspection surface for lease-block recovery
-        // debugging. Reports binding.json + on-disk worktree state +
-        // ci-watch subscriptions + bind-in-flight guard + cross-branch
-        // holders in one call. Pairs with `release_worktree`'s
-        // comprehensive cleanup (#9).
-        json!({"name": "binding_state", "description": "Report the structured daemon-side bind state for an agent: binding.json content, worktree existence + .agend-managed marker, ci-watch subscriptions, bind-in-flight guard, and cross-branch holders. Operator + agent introspection surface; non-destructive. Pairs with release_worktree.",
-            "inputSchema": {"type": "object", "properties": {
-                "agent": {"type": "string", "description": "Agent name to inspect"}
-            }, "required": ["agent"]}}),
-        // Sprint 53 P1-4: operator-callable Phase 4 GC visibility. Wraps
-        // worktree_pool::gc_dry_run; non-destructive (Phase 4 cutover stays
-        // gated behind AGEND_WORKTREE_GC=1).
-        json!({"name": "gc_dry_run", "description": "List Phase 4 GC candidates (released, past-grace, daemon-managed worktrees) without deleting them. Non-destructive. Default human format; pass `format=json` for tooling.",
+pub(crate) fn def_replace_instance() -> Value {
+    json!({"name": "replace_instance", "description": "Replace an instance with a fresh one.",
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}, "reason": {"type": "string"}}, "required": ["name"]}})
+}
+
+pub(crate) fn def_interrupt() -> Value {
+    json!({"name": "interrupt", "description": "Send ESC byte to target agent's PTY to interrupt current LLM turn. Context preserved, agent accepts next prompt.",
         "inputSchema": {"type": "object", "properties": {
-            "format": {"type": "string", "enum": ["human", "json"], "description": "Output format (default: human)"}
-        }}}),
-    ]
+            "target": {"type": "string", "description": "Target instance name"},
+            "reason": {"type": "string", "description": "Optional follow-up message to inject after ESC"}
+        }, "required": ["target"]}})
+}
+
+pub(crate) fn def_set_display_name() -> Value {
+    json!({"name": "set_display_name", "description": "Set your display name.",
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}})
+}
+
+pub(crate) fn def_set_description() -> Value {
+    json!({"name": "set_description", "description": "Set a description for this instance.",
+        "inputSchema": {"type": "object", "properties": {"description": {"type": "string"}}, "required": ["description"]}})
+}
+
+pub(crate) fn def_set_waiting_on() -> Value {
+    json!({"name": "set_waiting_on", "description": "Declare what this instance is currently waiting for. Set to empty string to clear. Automatically cleared when stale.",
+        "inputSchema": {"type": "object", "properties": {"condition": {"type": "string", "description": "What you are waiting for, e.g. 'review from at-dev-4'. Empty string to clear."}}, "required": ["condition"]}})
+}
+
+pub(crate) fn def_move_pane() -> Value {
+    json!({"name": "move_pane", "description": "Move an instance's pane into a different tab in the TUI. If `target_tab` names an existing tab, the pane splits that tab's focused pane; otherwise a new tab with that name is created and the pane becomes its root. Preserves scrollback and PTY state (unlike delete + create).",
+        "inputSchema": {"type": "object", "properties": {
+            "agent": {"type": "string", "description": "Instance name whose pane should be moved."},
+            "target_tab": {"type": "string", "description": "Destination tab name. Created if not present."},
+            "split_dir": {"type": "string", "enum": ["horizontal", "vertical"], "description": "Split direction when the destination tab already exists. Default: horizontal. Ignored when a new tab is created."}
+        }, "required": ["agent", "target_tab"]}})
+}
+
+pub(crate) fn def_pane_snapshot() -> Value {
+    json!({"name": "pane_snapshot", "description": "Read visible text from a target instance's PTY scrollback. Returns plain text (ANSI stripped). Default 100 lines, max 10000.",
+        "inputSchema": {"type": "object", "properties": {
+            "target": {"type": "string", "description": "Target instance name"},
+            "lines": {"type": "integer", "description": "Number of lines to return (default 100, max 10000)"}
+        }, "required": ["target"]}})
+}
+
+pub(crate) fn def_tui_screenshot() -> Value {
+    json!({"name": "tui_screenshot", "description": "Capture the current TUI state as an SVG image. Only works in TUI mode (not daemon-only). Returns SVG string.",
+        "inputSchema": {"type": "object", "properties": {}}})
+}
+
+pub(crate) fn def_decision() -> Value {
+    json!({"name": "decision", "description": "Manage decisions. Actions: post, list, update.",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["post", "list", "update"]},
+            "title": {"type": "string"}, "content": {"type": "string"},
+            "scope": {"type": "string", "enum": ["project", "fleet"]},
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "ttl_days": {"type": "number"}, "supersedes": {"type": "string"},
+            "id": {"type": "string"}, "archive": {"type": "boolean"},
+            "include_archived": {"type": "boolean"}
+        }, "required": ["action"]}})
+}
+
+pub(crate) fn def_task() -> Value {
+    json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health, activity, metadata_set, metadata_get. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (4 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health", "activity", "metadata_set", "metadata_get"]},
+            "title": {"type": "string"}, "description": {"type": "string"},
+            "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
+            "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}}, "parent_id": {"type": "string", "description": "Parent task ID for subtask composition (A is composed of B,C,D). Complementary to depends_on (execution order)."},
+            "id": {"type": "string"}, "result": {"type": "string"},
+            "status": {"type": "string", "enum": ["backlog", "open", "claimed", "in_progress", "in_review", "blocked", "verified", "done", "cancelled"]},
+            "filter_assignee": {"type": "string"}, "filter_status": {"type": "string"}, "filter_tag": {"type": "string", "description": "Filter by tag"}, "tags": {"type": "array", "items": {"type": "string"}, "description": "Task tags (for create/update)"},
+            "include_history": {"type": "boolean", "description": "#806: opt in to done/cancelled in `list` response (default trims to actionable)."},
+            "limit": {"type": "integer", "description": "#806: cap `list` response to N newest-first entries (sort by updated_at desc)."},
+            "due_at": {"type": "string", "description": "ISO 8601 deadline for the task"},
+            "branch": {"type": "string", "description": "Git branch the implementer should work on"},
+            "force": {"type": "boolean", "description": "#808: bypass ownership ACL on done/update for historical ghost-owned cleanup. Requires non-empty force_reason."},
+            "force_reason": {"type": "string", "description": "#808: required when force=true. Logged to event-log.jsonl and embedded in the per-task event's reason field for audit."},
+            "apply": {"type": "boolean", "description": "#806 sweep: when false (default), returns dry-run plan; when true, emits Cancelled for the confirm_ids subset."},
+            "confirm_ids": {"type": "array", "items": {"type": "string"}, "description": "#806 sweep apply=true: subset of candidate_ids from prior dry-run to actually cancel."},
+            "audit_reason": {"type": "string", "description": "#806 sweep apply=true: required audit text recorded in event-log.jsonl + per-task Cancelled.reason."},
+            "repo": {"type": "string", "description": "#806 sweep: override repo for PR-state queries (defaults to task_sweep.json's repo)."},
+            "metadata_key": {"type": "string", "description": "Key for metadata_set action."},
+            "metadata_value": {"description": "Value for metadata_set action (any JSON type)."}
+        }, "required": ["action"]}})
+}
+
+pub(crate) fn def_task_sweep_config() -> Value {
+    json!({"name": "task_sweep_config",
+    "description": "Configure GitHub-PR auto-close sweep daemon. Sweep polls merged PRs and emits Done events for `Closes t-XXX-N` markers (validated by 5-must-have pipeline).",
+    "inputSchema": {"type": "object", "properties": {
+        "repo": {"type": "string", "description": "GitHub `owner/repo` to sweep (empty string disables)"},
+        "pause": {"type": "boolean", "description": "Pause/resume the sweep tick"},
+        "dry_run": {"type": "boolean", "description": "Log decisions without emitting events"}
+    }}})
+}
+
+pub(crate) fn def_restart_daemon() -> Value {
+    json!({"name": "restart_daemon", "description": "Request graceful daemon restart. Daemon exits with code 42 after shutdown; a supervisor (launchd/systemd/Task Scheduler from `agend-terminal service install`, or `scripts/agend-wrapper.sh` for manual mode) respawns it. Returns ok:false when no supervisor is detected (bare `agend-terminal start`) — operator must install a supervisor before retry. Idempotent.",
+        "inputSchema": {"type": "object", "properties": {}}})
+}
+
+pub(crate) fn def_team() -> Value {
+    json!({"name": "team", "description": "Manage teams. Actions: create, delete, list, update.",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["create", "delete", "list", "update"]},
+            "name": {"type": "string"}, "members": {"type": "array", "items": {"type": "string"}},
+            "orchestrator": {"type": "string", "description": "Team orchestrator — must be a member."},
+            "description": {"type": "string"},
+            "source_repo": {"type": "string", "description": "Source repository path for the team."},
+            "add": {"type": "array", "items": {"type": "string"}},
+            "remove": {"type": "array", "items": {"type": "string"}}
+        }, "required": ["action"]}})
+}
+
+pub(crate) fn def_schedule() -> Value {
+    json!({"name": "schedule", "description": "Manage schedules. Actions: create, list, update, delete.",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["create", "list", "update", "delete"]},
+            "id": {"type": "string"},
+            "cron": {"type": "string", "description": "5- or 6-field cron expression (recurring). 5-field layout: `min hour day-of-month month day-of-week`; 6-field prepends seconds. Day-of-week uses Quartz convention: 1=Sun, 2=Mon, 3=Tue, 4=Wed, 5=Thu, 6=Fri, 7=Sat (NOT Unix 0-6). Example: every Wed+Sat at 15:00 → `0 15 * * 4,7`."},
+            "run_at": {"type": "string", "description": "ISO 8601 one-shot instant."},
+            "message": {"type": "string"}, "target": {"type": "string"},
+            "label": {"type": "string"},
+            "timezone": {"type": "string", "description": "IANA zone name."},
+            "enabled": {"type": "boolean"}
+        }, "required": ["action"]}})
+}
+
+pub(crate) fn def_deployment() -> Value {
+    json!({"name": "deployment", "description": "Manage deployments. Actions: deploy, teardown, list.",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["deploy", "teardown", "list"]},
+            "template": {"type": "string", "description": "Template name from fleet.yaml"},
+            "directory": {"type": "string", "description": "Working directory for instances"},
+            "name": {"type": "string", "description": "Deployment name"},
+            "branch": {"type": "string", "description": "Git branch — each instance gets its own worktree"}
+        }, "required": ["action"]}})
+}
+
+pub(crate) fn def_ci() -> Value {
+    json!({"name": "ci", "description": "Manage CI watching. Actions: watch, unwatch, status.",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["watch", "unwatch", "status"]},
+            "repo": {"type": "string", "description": "GitHub repo (owner/repo). Required for watch/unwatch; optional filter for status."},
+            "branch": {"type": "string", "description": "Branch to watch (default: main); optional filter for status."},
+            "interval_secs": {"type": "number", "description": "Poll interval in seconds (default: 60)"},
+            "next_after_ci": {"type": "string", "description": "Instance to auto-notify when CI passes. Daemon sends [ci-ready-for-action] to this target."},
+            "review_class": {"type": "string", "enum": ["single", "dual"], "description": "#972: review threshold for the daemon's PR-state aggregator. `single` (default) — §3.6 one VERIFIED unlocks the merge gate. `dual` — §3.5 two distinct VERIFIED required before `[pr-ready-for-merge]` fires."}
+        }, "required": ["action"]}})
+}
+
+pub(crate) fn def_watchdog() -> Value {
+    json!({"name": "watchdog", "description": "#1084/#1076: Fleet idle watchdog control. Actions: snooze, resume, status, ack. `ack` suppresses fleet alerts until post-ack agent activity is detected, then auto-clears.",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["snooze", "resume", "status", "ack"]},
+            "duration": {"type": "string", "description": "Snooze duration (e.g. '2h', '30m', '1h30m'). Clamped to max 4h. Default: 1h."}
+        }, "required": ["action"]}})
+}
+
+pub(crate) fn def_config() -> Value {
+    json!({"name": "config", "description": "#1085: Runtime-mutable daemon configuration. Actions: get, set, list. Keys: dev_idle_threshold_secs, fleet_idle_threshold_secs, hang_auto_recovery_enabled.",
+    "inputSchema": {"type": "object", "properties": {
+        "action": {"type": "string", "enum": ["get", "set", "list"]},
+        "key": {"type": "string", "description": "Config key name (required for get/set)"},
+        "value": {"type": "string", "description": "New value (required for set)"}
+    }, "required": ["action"]}})
+}
+
+pub(crate) fn def_health() -> Value {
+    json!({"name": "health", "description": "Manage health state. Actions: report, clear.",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["report", "clear"]},
+            "reason": {"type": "string", "enum": ["rate_limit", "quota_exceeded", "awaiting_operator"], "description": "Blocked reason kind (for report)"},
+            "retry_after_secs": {"type": "integer", "description": "Seconds until retry (for rate_limit)"},
+            "note": {"type": "string", "description": "Optional human-readable note"},
+            "instance": {"type": "string", "description": "Target instance name (for clear)"}
+        }, "required": ["action"]}})
+}
+
+pub(crate) fn def_repo() -> Value {
+    json!({"name": "repo", "description": "Manage repo worktrees. Actions: checkout, release, cleanup_init_commits, cleanup_merged_branches, merge. #817: cleanup_merged_branches is operator-triggered local-branch hygiene (4 categories: clean_merged/squash_merged/stale_idle/active_unknown; dry-run by default + confirm_ids + audit_reason required for apply).",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["checkout", "release", "cleanup_init_commits", "cleanup_merged_branches", "merge"]},
+            "pr": {"type": "integer", "description": "PR number for merge action."},
+            "source": {"type": "string"}, "branch": {"type": "string"},
+            "path": {"type": "string"},
+            "agent": {"type": "string", "description": "#789: target agent for cleanup_init_commits (defaults to caller's instance_name). Cleans empty `init` commits accumulated in the agent's bound worktree by backend session-checkpoint heartbeats. Returns {cleaned_count, [skipped_reason]}. Idempotent — call before push to scrub PR history."},
+            "bind": {"type": "boolean", "description": "#778 Option 1: when true on checkout, atomically bind the caller to the just-provisioned worktree (writes binding.json + .agend-managed marker + arms ci_watches) and lands HEAD on the named branch instead of a detached commit. Default false preserves back-compat for inspection-only callers (review pool, operator triage)."},
+            "base": {"type": "string", "description": "#817 cleanup_merged_branches: branch to compare against for clean/squash merge detection (default 'main')."},
+            "min_age_days": {"type": "integer", "description": "#817 cleanup_merged_branches: stale_idle threshold in days (default 90)."},
+            "apply": {"type": "boolean", "description": "#817 cleanup_merged_branches: when false (default), returns dry-run plan; when true, deletes confirm_ids subset."},
+            "confirm_ids": {"type": "array", "items": {"type": "string"}, "description": "#817 cleanup_merged_branches apply=true: subset of candidate_ids from prior dry-run to actually delete via `git branch -D`."},
+            "audit_reason": {"type": "string", "description": "#817 cleanup_merged_branches apply=true: required audit text recorded in event-log.jsonl per deleted branch with source SHA for restore."}
+        }, "required": ["action"]}})
+}
+
+pub(crate) fn def_bind_self() -> Value {
+    json!({"name": "bind_self", "description": "Bind the calling agent to a worktree on the named branch. For fresh-task workflows that know the source repo, prefer `repo action=checkout bind:true` (#779 Option 1) — single-step atomic provision + bind. Use `bind_self` when the caller is mid-lifecycle: (a) re-binding a recovered worktree via `rebase_mode=true`, (b) binding via fleet.yaml-resolved source_repo (no explicit source arg), or (c) post-`release_worktree` re-claim of the same branch. Both paths share `dispatch_auto_bind_lease` so binding.json + .agend-managed marker + auto watch_ci all land. Rejects 'main'/'master' (E4.5) and cross-agent branch conflicts. Pair with `release_worktree` to unbind.",
+        "inputSchema": {"type": "object", "properties": {
+            "source_repo": {"type": "string", "description": "Local path to source repository. Daemon resolves GitHub owner/repo via `git remote get-url origin`. Sprint 55 P0-B preferred form. Mutually exclusive with `repo` (handler rejects both via `ambiguous_args` code)."},
+            "repo": {"type": "string", "description": "GitHub repo (owner/name). Legacy form retained for one-Sprint deprecation window — emits warn-log; removal Sprint 57. Mutually exclusive with `source_repo`."},
+            "branch": {"type": "string", "description": "Branch to bind (must not be main/master)"},
+            "rebase_mode": {"type": "boolean", "description": "Sprint 60 W1 PR-1: atomic recover-and-bind. When true, releases self's stale on-disk worktree dir + binding state before lease — closes the lease_failed recovery path without an explicit release_worktree call. Cross-agent isolation preserved (rejects branches leased by another agent)."}
+        }, "required": ["branch"]}})
+}
+
+pub(crate) fn def_release_worktree() -> Value {
+    json!({"name": "release_worktree", "description": "Release the daemon-managed worktree and clear the binding for the given agent. Idempotent. Only removes worktrees carrying the `.agend-managed` marker — operator-created worktrees are left alone.",
+        "inputSchema": {"type": "object", "properties": {
+            "agent": {"type": "string", "description": "Agent name whose worktree + binding to release"}
+        }, "required": ["agent"]}})
+}
+
+pub(crate) fn def_force_release_worktree() -> Value {
+    json!({"name": "force_release_worktree", "description": "Force-release a stale daemon-managed worktree directory — cleans <home>/worktrees/<agent>/<branch>/ on disk + runs the standard release_full to clear any lingering binding state. Idempotent. Refuses to clean paths outside the daemon worktree pool. Sprint 59 Wave 1 PR-5 emergency cherry-pick supporting Q2=(C) bypass-free permanent protocol.",
+        "inputSchema": {"type": "object", "properties": {
+            "agent": {"type": "string", "description": "Agent name (worktree owner)"},
+            "branch": {"type": "string", "description": "Branch name (worktree subdirectory)"}
+        }, "required": ["agent", "branch"]}})
+}
+
+pub(crate) fn def_binding_state() -> Value {
+    json!({"name": "binding_state", "description": "Report the structured daemon-side bind state for an agent: binding.json content, worktree existence + .agend-managed marker, ci-watch subscriptions, bind-in-flight guard, and cross-branch holders. Operator + agent introspection surface; non-destructive. Pairs with release_worktree.",
+        "inputSchema": {"type": "object", "properties": {
+            "agent": {"type": "string", "description": "Agent name to inspect"}
+        }, "required": ["agent"]}})
+}
+
+pub(crate) fn def_gc_dry_run() -> Value {
+    json!({"name": "gc_dry_run", "description": "List Phase 4 GC candidates (released, past-grace, daemon-managed worktrees) without deleting them. Non-destructive. Default human format; pass `format=json` for tooling.",
+    "inputSchema": {"type": "object", "properties": {
+        "format": {"type": "string", "enum": ["human", "json"], "description": "Output format (default: human)"}
+    }}})
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Introduce `src/mcp/registry.rs` as single source of truth for all 33 MCP tools
- Each `ToolEntry` pairs the tool's JSON definition function with its dispatch handler
- **Before**: adding a tool required editing 4 places (tools.rs + dispatch.rs + 2 test counts)
- **After**: adding a tool requires editing **2 files** (registry.rs entry + handler impl)
- All 33 tool behaviors unchanged; linear-scan dispatch preserved

### Architecture
```
registry.rs (single source of truth)
    ├── ToolEntry { name, definition: fn(), handler: fn() }
    └── ALL_TOOLS: [ToolEntry; 33]

tools.rs (thin consumer)
    └── tool_definitions() → iterates registry → collects definitions

dispatch.rs (thin consumer)  
    └── try_dispatch() → iterates registry → finds handler
```

Closes #1379

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all 2808 tests pass
- [x] `cargo fmt` — clean
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)