### PR TITLE
refactor(#1380): introduce AgentName newtype for agent/instance names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agend-terminal"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -28,7 +28,7 @@ pub struct AgentCore {
 #[allow(dead_code)]
 pub struct AgentHandle {
     pub(crate) id: crate::types::InstanceId,
-    pub(crate) name: String,
+    pub(crate) name: crate::types::AgentName,
     pub(crate) backend_command: String,
     pub(crate) pty_writer: PtyWriter,
     pub(crate) pty_master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
@@ -666,7 +666,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
             name.to_string(),
             AgentHandle {
                 id: instance_id,
-                name: name.to_string(),
+                name: name.to_string().into(),
                 backend_command: backend_command.to_string(),
                 pty_writer: Arc::clone(&pty_writer),
                 pty_master: Arc::clone(&pty_master),
@@ -2391,7 +2391,7 @@ Allow Trust All Tools mode?
         let agent_name = format!("sweep-test-{}", pid_file.display());
         let handle = AgentHandle {
             id: crate::types::InstanceId::default(),
-            name: agent_name.clone(),
+            name: agent_name.clone().into(),
             backend_command: "sh".to_string(),
             pty_writer,
             pty_master,
@@ -2869,7 +2869,7 @@ Allow Trust All Tools mode?
         }
         let handle = AgentHandle {
             id: crate::types::InstanceId::default(),
-            name: "typed-test".to_string(),
+            name: "typed-test".into(),
             backend_command: "test".to_string(),
             pty_writer: writer,
             pty_master: Arc::new(Mutex::new(pair.master)),
@@ -3100,7 +3100,7 @@ Allow Trust All Tools mode?
             agent_name.to_string(),
             AgentHandle {
                 id: crate::types::InstanceId::default(),
-                name: agent_name.to_string(),
+                name: agent_name.to_string().into(),
                 backend_command: "test".to_string(),
                 pty_writer: Arc::clone(&pty_writer),
                 pty_master: Arc::new(Mutex::new(

--- a/src/app/api_server.rs
+++ b/src/app/api_server.rs
@@ -127,7 +127,7 @@ pub(super) fn auto_start_fleet(
             ) {
                 Ok(pane) => {
                     let tab_name = pane.agent_name.clone();
-                    layout.add_tab(Tab::new(tab_name, pane));
+                    layout.add_tab(Tab::new(tab_name.to_string(), pane));
                     spawned = true;
                 }
                 Err(e) => tracing::error!(instance = name, error = %e, "fleet auto-start failed"),

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -126,7 +126,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                         }
                         _ => {
                             let tab_name = pane.agent_name.clone();
-                            ctx.layout.add_tab(Tab::new(tab_name, pane));
+                            ctx.layout.add_tab(Tab::new(tab_name.to_string(), pane));
                         }
                     }
                     return true;
@@ -156,7 +156,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                 ctx.layout
                     .active_tab()
                     .and_then(|t| t.focused_pane())
-                    .map(|p| p.agent_name.clone())
+                    .map(|p| p.agent_name.to_string())
             });
             if let Some(name) = target_name {
                 // Single pass: find pane info, fleet name, and location
@@ -171,7 +171,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                 'outer: for (ti, tab) in ctx.layout.tabs.iter().enumerate() {
                     for id in tab.root().pane_ids() {
                         if let Some(p) = tab.root().find_pane(id) {
-                            if p.agent_name == name {
+                            if p.agent_name.as_str() == name {
                                 let cmd = match &p.backend {
                                     Some(b) => b.preset().command.to_string(),
                                     None => {
@@ -282,7 +282,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                         }
                         // Fallback: add as new tab
                         let tab_name = new_pane.agent_name.clone();
-                        ctx.layout.add_tab(Tab::new(tab_name, new_pane));
+                        ctx.layout.add_tab(Tab::new(tab_name.to_string(), new_pane));
                         return true;
                     }
                 }
@@ -340,7 +340,7 @@ fn lookup_fleet_name(layout: &Layout, agent_name: &str) -> Option<String> {
     for tab in &layout.tabs {
         for id in tab.root().pane_ids() {
             if let Some(pane) = tab.root().find_pane(id) {
-                if pane.agent_name == agent_name {
+                if pane.agent_name.as_str() == agent_name {
                     return pane.fleet_instance_name.clone();
                 }
             }
@@ -357,7 +357,7 @@ mod tests {
 
     fn test_pane(id: usize, agent: &str, fleet_name: Option<&str>) -> Pane {
         Pane {
-            agent_name: agent.to_string(),
+            agent_name: agent.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -354,7 +354,7 @@ mod tests {
 
     fn test_pane(id: usize, name: &str) -> Pane {
         Pane {
-            agent_name: name.to_string(),
+            agent_name: name.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -761,9 +761,9 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                             ) {
                                 Ok(pane) => {
                                     let tab_name = pane.agent_name.clone();
-                                    known_remote_agents.insert(tab_name.clone());
+                                    known_remote_agents.insert(tab_name.to_string());
                                     layout.push_tab_preserve_focus(
-                                        crate::layout::Tab::new(tab_name, pane),
+                                        crate::layout::Tab::new(tab_name.to_string(), pane),
                                     );
                                     needs_resize = true;
                                     tracing::info!(
@@ -1192,7 +1192,7 @@ mod tests {
 
     fn pane(name: &str) -> Pane {
         Pane {
-            agent_name: name.to_string(),
+            agent_name: name.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id: 1,

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -300,7 +300,13 @@ fn handle_up(
                         .map(|p| p.agent_name.clone())
                         .unwrap_or_else(|| "new".into());
                     if layout
-                        .move_pane_across_tabs(from_tab_idx, src, MovePlacement::NewTab { name: name.to_string() })
+                        .move_pane_across_tabs(
+                            from_tab_idx,
+                            src,
+                            MovePlacement::NewTab {
+                                name: name.to_string(),
+                            },
+                        )
                         .is_some()
                     {
                         out.new_last_tab = Some(from_tab_idx);

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -298,9 +298,9 @@ fn handle_up(
                         .active_tab()
                         .and_then(|t| t.root().find_pane(src))
                         .map(|p| p.agent_name.clone())
-                        .unwrap_or_else(|| "new".to_string());
+                        .unwrap_or_else(|| "new".into());
                     if layout
-                        .move_pane_across_tabs(from_tab_idx, src, MovePlacement::NewTab { name })
+                        .move_pane_across_tabs(from_tab_idx, src, MovePlacement::NewTab { name: name.to_string() })
                         .is_some()
                     {
                         out.new_last_tab = Some(from_tab_idx);
@@ -533,7 +533,7 @@ mod tests {
 
     fn leaf(id: usize, agent: &str) -> Pane {
         Pane {
-            agent_name: agent.to_string(),
+            agent_name: agent.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -217,7 +217,7 @@ pub(super) fn handle_key(
                                 &pane,
                             );
                             let tab_name = pane.agent_name.clone();
-                            ctx.layout.add_tab(Tab::new(tab_name, pane));
+                            ctx.layout.add_tab(Tab::new(tab_name.to_string(), pane));
                             outcome.needs_resize = true;
                         }
                     }
@@ -466,13 +466,13 @@ pub(super) fn handle_key(
                             .get(src_tab)
                             .and_then(|t| t.root().find_pane(src_pane))
                             .map(|p| p.agent_name.clone())
-                            .unwrap_or_else(|| "new".to_string());
+                            .unwrap_or_else(|| "new".into());
                         if ctx
                             .layout
                             .move_pane_across_tabs(
                                 src_tab,
                                 src_pane,
-                                crate::layout::MovePlacement::NewTab { name },
+                                crate::layout::MovePlacement::NewTab { name: name.to_string() },
                             )
                             .is_some()
                         {

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -472,7 +472,9 @@ pub(super) fn handle_key(
                             .move_pane_across_tabs(
                                 src_tab,
                                 src_pane,
-                                crate::layout::MovePlacement::NewTab { name: name.to_string() },
+                                crate::layout::MovePlacement::NewTab {
+                                    name: name.to_string(),
+                                },
                             )
                             .is_some()
                         {

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -57,7 +57,7 @@ pub(super) fn spawn_pane_tab(
         name_counter,
     )?;
     let tab_name = pane.agent_name.clone();
-    layout.add_tab(Tab::new(tab_name, pane));
+    layout.add_tab(Tab::new(tab_name.to_string(), pane));
     Ok(())
 }
 
@@ -183,7 +183,7 @@ pub(super) fn create_pane(
     let backend = Backend::from_command(command);
 
     Ok(Pane {
-        agent_name: name,
+        agent_name: name.into(),
         vterm,
         rx: pane_rx,
         id: pane_id,
@@ -246,7 +246,7 @@ pub(super) fn attach_pane(
     let backend = Backend::from_command(&backend_command);
 
     Ok(Pane {
-        agent_name: name.to_string(),
+        agent_name: name.to_string().into(),
         vterm,
         rx: pane_rx,
         id: pane_id,
@@ -426,7 +426,7 @@ pub(super) fn create_remote_pane(
         .and_then(|r| Backend::from_command(&r.backend_command));
 
     Ok(Pane {
-        agent_name: name.to_string(),
+        agent_name: name.to_string().into(),
         vterm: VTerm::new(cols, rows),
         rx: pane_rx,
         id: pane_id,

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -317,7 +317,7 @@ pub(super) fn restore_with_reconciliation_attached(
                 display_name: None,
             };
             if let Some(pane) = pane_builder(&synthetic_sp, layout) {
-                let tab_name = pane.agent_name.clone();
+                let tab_name = pane.agent_name.to_string();
                 layout.add_tab(Tab::new(tab_name, pane));
             }
         }
@@ -415,7 +415,7 @@ fn apply_session_layout(
             display_name: None,
         };
         if let Some(pane) = pane_builder(&synthetic_sp, layout) {
-            let tab_name = pane.agent_name.clone();
+            let tab_name = pane.agent_name.to_string();
             layout.add_tab(Tab::new(tab_name, pane));
         }
     }
@@ -500,7 +500,7 @@ mod tests {
 
     fn test_pane(id: usize, agent: &str, fleet_name: Option<&str>) -> Pane {
         Pane {
-            agent_name: agent.to_string(),
+            agent_name: agent.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,

--- a/src/app/telegram_hooks.rs
+++ b/src/app/telegram_hooks.rs
@@ -44,7 +44,7 @@ pub(super) fn maybe_create_telegram_topic(
     }
     let submit_key = {
         let reg = agent::lock_registry(registry);
-        reg.get(&pane.agent_name)
+        reg.get(pane.agent_name.as_str())
             .map(|h| h.submit_key.clone())
             .unwrap_or_else(|| "\r".to_string())
     };

--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -590,7 +590,7 @@ mod tests {
 
     fn leaf(id: usize, agent: &str) -> Pane {
         Pane {
-            agent_name: agent.to_string(),
+            agent_name: agent.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -317,7 +317,7 @@ mod tests {
         }));
         crate::agent::AgentHandle {
             id: crate::types::InstanceId::default(),
-            name: name.to_string(),
+            name: name.to_string().into(),
             backend_command: "true".to_string(),
             pty_writer,
             pty_master,

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -138,7 +138,7 @@ mod tests {
         };
         let handle = AgentHandle {
             id: crate::types::InstanceId::default(),
-            name: name.to_string(),
+            name: name.to_string().into(),
             backend_command: "test".to_string(),
             pty_writer: Arc::new(Mutex::new(writer)),
             pty_master: Arc::new(Mutex::new(pair.master)),

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1240,7 +1240,7 @@ mod tests {
         core.lock().state.current = state;
         let handle = crate::agent::AgentHandle {
             id: crate::types::InstanceId::default(),
-            name: name.to_string(),
+            name: name.to_string().into(),
             backend_command: "claude".to_string(),
             pty_writer,
             pty_master: Arc::new(parking_lot::Mutex::new(pair.master)),

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -260,7 +260,7 @@ mod tests {
 
     fn leaf(id: usize, name: &str) -> Pane {
         Pane {
-            agent_name: name.to_string(),
+            agent_name: name.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -23,7 +23,7 @@ pub enum PaneSource {
 /// PTY ownership is in AgentRegistry (Local) or BridgeClient (Remote) —
 /// pane only holds a subscriber channel and a local VTerm.
 pub struct Pane {
-    pub agent_name: String,
+    pub agent_name: crate::types::AgentName,
     pub vterm: VTerm,
     pub rx: crossbeam_channel::Receiver<Vec<u8>>,
     pub id: usize,
@@ -117,7 +117,7 @@ impl Pane {
         match &self.source {
             PaneSource::Local => {
                 let reg = agent::lock_registry(registry);
-                if let Some(handle) = reg.get(&self.agent_name) {
+                if let Some(handle) = reg.get(self.agent_name.as_str()) {
                     let _ = agent::write_to_agent(handle, bytes);
                 }
                 drop(reg);
@@ -139,7 +139,7 @@ impl Pane {
         match &self.source {
             PaneSource::Local => {
                 let reg = agent::lock_registry(registry);
-                if let Some(handle) = reg.get(&self.agent_name) {
+                if let Some(handle) = reg.get(self.agent_name.as_str()) {
                     let master = handle.pty_master.lock();
                     let _ = master.resize(portable_pty::PtySize {
                         rows,
@@ -164,7 +164,7 @@ mod tests {
 
     fn leaf(id: usize, name: &str) -> Pane {
         Pane {
-            agent_name: name.to_string(),
+            agent_name: name.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,

--- a/src/layout/split.rs
+++ b/src/layout/split.rs
@@ -300,7 +300,7 @@ mod tests {
 
     fn mk_pane(id: usize, name: &str) -> Pane {
         Pane {
-            agent_name: name.to_string(),
+            agent_name: name.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,

--- a/src/layout/tab.rs
+++ b/src/layout/tab.rs
@@ -298,7 +298,7 @@ impl Tab {
         if self.focus_id == pane_id {
             self.focus_id = next_id;
         }
-        removed.map(|p| p.agent_name)
+        removed.map(|p| p.agent_name.to_string())
     }
 
     /// Detach a pane from this tab's tree without destroying its VTerm or PTY
@@ -355,7 +355,7 @@ mod tests {
 
     fn leaf(id: usize, name: &str) -> Pane {
         Pane {
-            agent_name: name.to_string(),
+            agent_name: name.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,
@@ -484,7 +484,7 @@ mod tests {
         assert!(tab.split_focused(SplitDir::Vertical, leaf(2, "b")));
         tab.focus_id = 1;
         let d = tab.detach_pane(1).unwrap();
-        assert_eq!(d.agent_name, "a");
+        assert_eq!(d.agent_name.as_str(), "a");
         assert_eq!(tab.focus_id, 2);
     }
     #[test]

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -120,7 +120,7 @@ impl PaneNode {
     /// Collect all agent names in the tree.
     pub fn agent_names(&self) -> Vec<String> {
         match self {
-            PaneNode::Leaf(p) => vec![p.agent_name.clone()],
+            PaneNode::Leaf(p) => vec![p.agent_name.to_string()],
             PaneNode::Split { first, second, .. } => {
                 let mut names = first.agent_names();
                 names.extend(second.agent_names());
@@ -132,7 +132,7 @@ impl PaneNode {
     /// Check if any pane in the tree has the given agent name (no allocation).
     pub fn has_agent(&self, name: &str) -> bool {
         match self {
-            PaneNode::Leaf(p) => p.agent_name == name,
+            PaneNode::Leaf(p) => p.agent_name.as_str() == name,
             PaneNode::Split { first, second, .. } => {
                 first.has_agent(name) || second.has_agent(name)
             }
@@ -142,7 +142,7 @@ impl PaneNode {
     /// Find the pane ID for a given agent name.
     pub fn find_pane_id_by_agent(&self, name: &str) -> Option<usize> {
         match self {
-            PaneNode::Leaf(p) if p.agent_name == name => Some(p.id),
+            PaneNode::Leaf(p) if p.agent_name.as_str() == name => Some(p.id),
             PaneNode::Leaf(_) => None,
             PaneNode::Split { first, second, .. } => first
                 .find_pane_id_by_agent(name)
@@ -352,7 +352,7 @@ mod tests {
 
     fn leaf(id: usize, name: &str) -> Pane {
         Pane {
-            agent_name: name.to_string(),
+            agent_name: name.into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id,

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -62,11 +62,13 @@ fn build_agent_state_snapshot(
         for id in tab.root().pane_ids() {
             if let Some(pane) = tab.root().find_pane(id) {
                 if pane.backend.is_some() {
-                    snapshot.entry(pane.agent_name.to_string()).or_insert_with(|| {
-                        reg.get(pane.agent_name.as_str())
-                            .map(|h| h.core.lock().state.get_state())
-                            .unwrap_or(AgentState::Idle)
-                    });
+                    snapshot
+                        .entry(pane.agent_name.to_string())
+                        .or_insert_with(|| {
+                            reg.get(pane.agent_name.as_str())
+                                .map(|h| h.core.lock().state.get_state())
+                                .unwrap_or(AgentState::Idle)
+                        });
                 }
             }
         }

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -62,8 +62,8 @@ fn build_agent_state_snapshot(
         for id in tab.root().pane_ids() {
             if let Some(pane) = tab.root().find_pane(id) {
                 if pane.backend.is_some() {
-                    snapshot.entry(pane.agent_name.clone()).or_insert_with(|| {
-                        reg.get(&pane.agent_name)
+                    snapshot.entry(pane.agent_name.to_string()).or_insert_with(|| {
+                        reg.get(pane.agent_name.as_str())
                             .map(|h| h.core.lock().state.get_state())
                             .unwrap_or(AgentState::Idle)
                     });
@@ -107,7 +107,7 @@ pub fn highest_priority_state(
         if let Some(pane) = tab.root().find_pane(id) {
             if pane.backend.is_some() {
                 let s = snapshot
-                    .get(&pane.agent_name)
+                    .get(pane.agent_name.as_str())
                     .copied()
                     .unwrap_or(AgentState::Idle);
                 if s.priority() > best.priority() {
@@ -359,7 +359,7 @@ fn render_pane(
 
     let state = if pane.backend.is_some() {
         snapshot
-            .get(&pane.agent_name)
+            .get(pane.agent_name.as_str())
             .copied()
             .unwrap_or(AgentState::Idle)
     } else {
@@ -596,7 +596,7 @@ mod tests {
     #[test]
     fn badge_shows_pending_count() {
         let pane = Pane {
-            agent_name: "agent".to_string(),
+            agent_name: "agent".into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id: 1,
@@ -623,7 +623,7 @@ mod tests {
     #[test]
     fn pane_title_no_state_suffix() {
         let pane = Pane {
-            agent_name: "agent".to_string(),
+            agent_name: "agent".into(),
             vterm: VTerm::new(10, 10),
             rx: crossbeam_channel::bounded(1).1,
             id: 1,
@@ -669,7 +669,7 @@ mod tests {
         let tab = crate::layout::Tab::new(
             "empty".to_string(),
             crate::layout::Pane {
-                agent_name: "test".to_string(),
+                agent_name: "test".into(),
                 vterm: VTerm::new(10, 10),
                 rx: crossbeam_channel::bounded(1).1,
                 id: 1,

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,6 +40,57 @@ impl std::fmt::Display for InstanceId {
     }
 }
 
+/// Strongly-typed agent/instance name. Wraps `String` with `Deref<str>`
+/// + `Borrow<str>` so it works transparently with `HashMap<String, _>::get`
+///   and string comparisons. Newtype prevents accidental confusion with
+///   task IDs, branch names, or other string-shaped identifiers.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AgentName(pub String);
+
+impl AgentName {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AgentName {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::borrow::Borrow<str> for AgentName {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for AgentName {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for AgentName {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl std::fmt::Display for AgentName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for AgentName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Define `AgentName(String)` in `types.rs` with `Deref<str>`, `Borrow<str>`, `From<String/&str>`, `Display`, `AsRef<str>`, serde transparent
- Replace `String` with `AgentName` at two definition points: `AgentHandle.name` and `Pane.agent_name`
- Update 20 consuming files with minimal `.into()` / `.to_string()` / `.as_str()` conversions

Follow-up scope: migrate `AgentRegistry` key type from `String` to `AgentName`, replace `fleet_instance_name: Option<String>` etc.

## Test plan

- [x] 311 agent/pane/layout/render tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Zero behavioral change — all conversions are mechanical

🤖 Generated with [Claude Code](https://claude.com/claude-code)