### PR TITLE
feat: cross-team messaging allowlist via accept_from (#1368)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -80,25 +80,42 @@ fn check_team_isolation(home: &Path, from: &str, target: &str) -> Result<(), Val
         _ => false,
     };
     if !is_general_bus && !same_team {
-        crate::event_log::log(
-            home,
-            "send_cross_team_blocked",
-            from,
-            &format!(
-                "target={target}, sender_team={:?}, target_team={:?}",
-                from_team.as_ref().map(|t| &t.name),
-                target_team.as_ref().map(|t| &t.name),
-            ),
-        );
-        return Err(json!({
-            "ok": false,
-            "error": format!(
-                "cross-team send blocked: '{from}' (team={:?}) → '{target}' (team={:?}). \
-                 Route via general, or use create_instance(team=...) to grow your team.",
-                from_team.as_ref().map(|t| &t.name),
-                target_team.as_ref().map(|t| &t.name),
-            )
-        }));
+        // Rule 4: accept_from allowlist — sender in target team's accept_from
+        // AND target is the team's orchestrator.
+        let allowed_by_allowlist = target_team.as_ref().is_some_and(|t| {
+            t.accept_from.contains(&from.to_string()) && t.orchestrator.as_deref() == Some(target)
+        });
+        if allowed_by_allowlist {
+            crate::event_log::log(
+                home,
+                "send_cross_team_allowed_allowlist",
+                from,
+                &format!(
+                    "target={target}, target_team={:?}",
+                    target_team.as_ref().map(|t| &t.name),
+                ),
+            );
+        } else {
+            crate::event_log::log(
+                home,
+                "send_cross_team_blocked",
+                from,
+                &format!(
+                    "target={target}, sender_team={:?}, target_team={:?}",
+                    from_team.as_ref().map(|t| &t.name),
+                    target_team.as_ref().map(|t| &t.name),
+                ),
+            );
+            return Err(json!({
+                "ok": false,
+                "error": format!(
+                    "cross-team send blocked: '{from}' (team={:?}) → '{target}' (team={:?}). \
+                     Route via general, add sender to team's accept_from, or use create_instance(team=...) to grow your team.",
+                    from_team.as_ref().map(|t| &t.name),
+                    target_team.as_ref().map(|t| &t.name),
+                )
+            }));
+        }
     }
     if is_general_bus && !same_team {
         crate::event_log::log(

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -292,6 +292,8 @@ pub struct TeamConfig {
     pub created_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_repo: Option<std::path::PathBuf>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accept_from: Vec<String>,
 }
 
 impl FleetConfig {

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -213,6 +213,14 @@ fn team_config_to_mapping(config: &TeamConfig) -> serde_yaml_ng::Mapping {
             serde_yaml_ng::Value::String(sr.display().to_string()),
         );
     }
+    if !config.accept_from.is_empty() {
+        let seq: Vec<serde_yaml_ng::Value> = config
+            .accept_from
+            .iter()
+            .map(|s| serde_yaml_ng::Value::String(s.clone()))
+            .collect();
+        team.insert("accept_from".into(), serde_yaml_ng::Value::Sequence(seq));
+    }
     team
 }
 
@@ -326,6 +334,7 @@ pub fn migrate_teams_json_to_yaml(home: &Path) -> Result<()> {
             description: team.description.clone(),
             created_at: team.created_at.clone(),
             source_repo: None,
+            accept_from: Vec::new(),
         };
         match add_team_to_yaml(home, &team.name, &cfg) {
             Ok(true) => {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -213,6 +213,7 @@ pub(crate) fn def_team() -> Value {
             "orchestrator": {"type": "string", "description": "Team orchestrator — must be a member."},
             "description": {"type": "string"},
             "source_repo": {"type": "string", "description": "Source repository path for the team."},
+            "accept_from": {"type": "array", "items": {"type": "string"}, "description": "External agent names allowed to send directly to this team's orchestrator (cross-team allowlist). Empty = deny all cross-team sends (default)."},
             "add": {"type": "array", "items": {"type": "string"}},
             "remove": {"type": "array", "items": {"type": "string"}}
         }, "required": ["action"]}})

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -303,6 +303,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             source_repo: None,
             stale_members: Vec::new(),
+            accept_from: Vec::new(),
         }];
         let tasks = vec![crate::tasks::Task {
             id: "t-1".to_string(),

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -44,6 +44,8 @@ pub struct Team {
     /// staleness, matching #779 P2's `warnings` pattern.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub stale_members: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accept_from: Vec<String>,
 }
 
 impl Team {
@@ -68,9 +70,8 @@ fn project_team(name: &str, cfg: &crate::fleet::TeamConfig) -> Team {
         description: cfg.description.clone(),
         created_at: cfg.created_at.clone().unwrap_or_default(),
         source_repo: cfg.source_repo.clone(),
-        // #785: populated by `list()` only — `find_team_for` consumers
-        // don't need the diagnostic, default empty here.
         stale_members: Vec::new(),
+        accept_from: cfg.accept_from.clone(),
     }
 }
 
@@ -146,12 +147,21 @@ pub fn create(home: &Path, args: &Value) -> Value {
              bind agents on the canonical repo."
         ));
     }
+    let accept_from: Vec<String> = args["accept_from"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
     let cfg = crate::fleet::TeamConfig {
         members,
         orchestrator,
         description,
         created_at: Some(chrono::Utc::now().to_rfc3339()),
         source_repo,
+        accept_from,
     };
     match crate::fleet::add_team_to_yaml(home, &name, &cfg) {
         Ok(true) => {
@@ -371,12 +381,21 @@ pub fn update(home: &Path, args: &Value) -> Value {
         .map(std::path::PathBuf::from)
         .or_else(|| current.source_repo.clone());
 
+    let new_accept_from: Vec<String> = args["accept_from"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_else(|| current.accept_from.clone());
     let cfg = crate::fleet::TeamConfig {
         members: new_members,
         orchestrator: resolved_orch,
         description: current.description.clone(),
         created_at: current.created_at.clone(),
         source_repo: new_source_repo,
+        accept_from: new_accept_from,
     };
     match crate::fleet::update_team_in_yaml(home, &name, &cfg) {
         Ok(true) => serde_json::json!({"status": "updated", "name": name}),
@@ -419,6 +438,7 @@ pub fn remove_member_from_all(home: &Path, instance_name: &str) {
             description: cfg.description.clone(),
             created_at: cfg.created_at.clone(),
             source_repo: cfg.source_repo.clone(),
+            accept_from: cfg.accept_from.clone(),
         };
         let _ = crate::fleet::update_team_in_yaml(home, team_name, &new_cfg);
     }
@@ -1198,6 +1218,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             source_repo: None,
             stale_members: Vec::new(),
+            accept_from: Vec::new(),
         };
         let v = serde_json::to_value(&clean).expect("serialize Team");
         assert!(
@@ -1231,6 +1252,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             source_repo: None,
             stale_members: vec!["stale-2".to_string()],
+            accept_from: Vec::new(),
         };
         let v = serde_json::to_value(&team).expect("serialize");
         let stale: Vec<&str> = v["stale_members"]


### PR DESCRIPTION
## Summary
- Add `accept_from` field to `TeamConfig` — explicit agent name allowlist for cross-team messaging to orchestrator
- New isolation Rule 4: if sender is in target team's `accept_from` AND target is the team's orchestrator → allow with audit log
- Existing 3 isolation rules (same-team, general-bus, unaffiliated) unchanged
- `#[serde(default)]` ensures zero behavior change for existing fleet.yaml files

### fleet.yaml example
```yaml
teams:
  fixup:
    members: [fixup-lead, fixup-dev, fixup-reviewer]
    orchestrator: fixup-lead
    accept_from: [opencode-1035d9, general]
```

### Files changed (6)
- `fleet/mod.rs`: TeamConfig + accept_from field
- `api/handlers/messaging.rs`: Rule 4 in check_team_isolation
- `fleet/persist.rs`: serialize accept_from to YAML
- `teams.rs`: parse accept_from in create/update, project to Team
- `mcp/tools.rs`: expose in team tool schema
- `render/panels_fleet.rs`: test fix

Closes #1368

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all tests pass
- [ ] CI green on all platforms
- [ ] Manual test: set accept_from in fleet.yaml, verify cross-team send to orchestrator works

🤖 Generated with [Claude Code](https://claude.com/claude-code)