### PR TITLE
fix(#1403): scaffold only creates matching backend config dir

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -594,7 +594,14 @@ fn spawn_one(
         crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
             .ok()
             .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
-    match crate::skills::install_for_agent(home, work_dir, skills_filter.as_deref()) {
+    let backend_skill =
+        crate::backend::Backend::from_command(backend).and_then(|b| b.skill_dir_name());
+    match crate::skills::install_for_agent_backend(
+        home,
+        work_dir,
+        skills_filter.as_deref(),
+        backend_skill,
+    ) {
         Ok(outcomes) => {
             let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
                 .iter()

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -108,7 +108,13 @@ pub(super) fn create_pane(
             crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                 .ok()
                 .and_then(|c| c.instances.get(&name).and_then(|i| i.skills.clone()));
-        match crate::skills::install_for_agent(home, &work_dir, skills_filter.as_deref()) {
+        let backend_skill = Backend::from_command(command).and_then(|b| b.skill_dir_name());
+        match crate::skills::install_for_agent_backend(
+            home,
+            &work_dir,
+            skills_filter.as_deref(),
+            backend_skill,
+        ) {
             Ok(outcomes) => {
                 let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
                     .iter()

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -572,6 +572,19 @@ impl Backend {
         self.as_str()
     }
 
+    /// Skill directory key matching `BACKEND_SKILL_DIRS`. Returns `None`
+    /// for backends without a skill directory (Shell, Raw, Agy).
+    pub fn skill_dir_name(&self) -> Option<&'static str> {
+        match self {
+            Backend::ClaudeCode => Some("claude"),
+            Backend::Codex => Some("codex"),
+            Backend::Gemini => Some("gemini"),
+            Backend::OpenCode => Some("opencode"),
+            Backend::KiroCli => Some("kiro"),
+            Backend::Agy | Backend::Shell | Backend::Raw(_) => None,
+        }
+    }
+
     /// Extra CLI flags to pass on spawn, derived from files that
     /// `instructions::generate` has written to `working_dir`. Only emits a flag
     /// when the corresponding file is present, so this is safe to call

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -114,7 +114,14 @@ fn respawn_agent_worker(
             crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                 .ok()
                 .and_then(|c| c.instances.get(&config.name).and_then(|i| i.skills.clone()));
-        if let Err(e) = crate::skills::install_for_agent(home, wd, skills_filter.as_deref()) {
+        let backend_skill = crate::backend::Backend::from_command(&config.backend_command)
+            .and_then(|b| b.skill_dir_name());
+        if let Err(e) = crate::skills::install_for_agent_backend(
+            home,
+            wd,
+            skills_filter.as_deref(),
+            backend_skill,
+        ) {
             tracing::warn!(agent = %config.name, error = %e, "crash-respawn skills install failed");
         }
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1024,7 +1024,14 @@ fn spawn_and_register_agent(
             crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                 .ok()
                 .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
-        match crate::skills::install_for_agent(home, wd, skills_filter.as_deref()) {
+        let backend_skill =
+            crate::backend::Backend::from_command(command).and_then(|b| b.skill_dir_name());
+        match crate::skills::install_for_agent_backend(
+            home,
+            wd,
+            skills_filter.as_deref(),
+            backend_skill,
+        ) {
             Ok(outcomes) => {
                 let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
                     .iter()
@@ -1210,7 +1217,14 @@ fn handle_stage2_restart(
             crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                 .ok()
                 .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
-        if let Err(e) = crate::skills::install_for_agent(home, wd, skills_filter.as_deref()) {
+        let backend_skill = crate::backend::Backend::from_command(&config.backend_command)
+            .and_then(|b| b.skill_dir_name());
+        if let Err(e) = crate::skills::install_for_agent_backend(
+            home,
+            wd,
+            skills_filter.as_deref(),
+            backend_skill,
+        ) {
             tracing::warn!(
                 target: "recovery_shadow",
                 agent = %name, error = %e, "stage2 skills install failed"

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -318,15 +318,30 @@ pub fn install_for_agent(
     working_dir: &Path,
     filter: Option<&[String]>,
 ) -> Result<Vec<InstallOutcome>> {
+    install_for_agent_backend(home, working_dir, filter, None)
+}
+
+/// Backend-scoped variant: when `backend` is `Some`, only install
+/// skills for the matching backend directory. When `None`, install all.
+pub fn install_for_agent_backend(
+    home: &Path,
+    working_dir: &Path,
+    filter: Option<&[String]>,
+    backend: Option<&str>,
+) -> Result<Vec<InstallOutcome>> {
     let source = ensure_skills_root(home)?;
     let staged_source = match filter {
         None => source,
         Some(allowlist) => stage_filtered_source(home, &source, allowlist)?,
     };
-    let mut outcomes = Vec::with_capacity(BACKEND_SKILL_DIRS.len());
-    for (backend, rel) in BACKEND_SKILL_DIRS {
+    let dirs: Vec<_> = BACKEND_SKILL_DIRS
+        .iter()
+        .filter(|(name, _)| backend.is_none_or(|b| *name == b))
+        .collect();
+    let mut outcomes = Vec::with_capacity(dirs.len());
+    for (name, rel) in dirs {
         let target = working_dir.join(rel);
-        let outcome = install_one(&staged_source, &target, backend);
+        let outcome = install_one(&staged_source, &target, name);
         outcomes.push(outcome);
     }
     Ok(outcomes)


### PR DESCRIPTION
## Summary

- Add `Backend::skill_dir_name()` — maps backend to `BACKEND_SKILL_DIRS` key (e.g. `ClaudeCode` → `"claude"`, `KiroCli` → `"kiro"`)
- Add `install_for_agent_backend()` with optional backend filter — when `Some("claude")`, only creates `.claude/skills/`
- Update 4 production call sites to pass backend filter
- CLI `skills install` retains install-all behavior (operator's explicit intent)

Before: backend=claude instance gets `.codex/`, `.gemini/`, `.kiro/`, `.opencode/` dirs
After: backend=claude instance gets only `.claude/skills/`

## Test plan

- [x] 28 skills tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `install_for_agent()` backward compat preserved (delegates to `install_for_agent_backend(None)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)