### PR TITLE
feat: per-instance idle watchdog disable (#1402)

### DIFF
--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -258,8 +258,9 @@ pub(crate) fn scan_and_emit(
     home: &Path,
     last_alerted: &mut HashMap<(&'static str, String), chrono::DateTime<chrono::Utc>>,
 ) {
-    // #1240: discard all alerts during snooze — check once at entry
-    // rather than per-vantage so both dev + fleet are suppressed.
+    if !crate::runtime_config::get().idle_watchdog_enabled {
+        return;
+    }
     if is_fleet_idle_snoozed(home) {
         return;
     }
@@ -311,6 +312,7 @@ fn scan_dev_vantage(
     } else if let Ok(cfg) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) {
         cfg.instances
             .iter()
+            .filter(|(_, ic)| ic.idle_watchdog_enabled)
             .map(|(name, ic)| {
                 let threshold = ic
                     .timeout_secs
@@ -478,7 +480,12 @@ fn scan_fleet_vantage(
         if let Ok(cfg) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) {
             raw_pairs
                 .into_iter()
-                .filter(|(name, _)| cfg.instances.contains_key(name))
+                .filter(|(name, _)| {
+                    cfg.instances
+                        .get(name)
+                        .map(|ic| ic.idle_watchdog_enabled)
+                        .unwrap_or(false)
+                })
                 .collect()
         } else {
             raw_pairs

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -274,6 +274,12 @@ pub struct InstanceConfig {
     /// reviewers to have tighter timeouts than dev agents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_secs: Option<u64>,
+    #[serde(default = "default_true")]
+    pub idle_watchdog_enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -27,6 +27,14 @@ pub struct RuntimeConfig {
     /// to all same-backend agents + gates new dispatches. Default false.
     #[serde(default)]
     pub usage_limit_propagation_enabled: bool,
+    /// #1402: Master gate for idle watchdog. When false, scan_and_emit
+    /// is a no-op — no dev-idle or fleet-idle alerts fire. Default true.
+    #[serde(default = "default_true")]
+    pub idle_watchdog_enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_dev_idle() -> i64 {
@@ -43,6 +51,7 @@ impl Default for RuntimeConfig {
             fleet_idle_threshold_secs: default_fleet_idle(),
             hang_auto_recovery_enabled: false,
             usage_limit_propagation_enabled: false,
+            idle_watchdog_enabled: true,
         }
     }
 }
@@ -96,6 +105,13 @@ pub fn set(home: &Path, key: &str, value: &str) -> Result<String, String> {
                 _ => return Err(format!("invalid boolean: {value} (use true/false)")),
             };
         }
+        "idle_watchdog_enabled" => {
+            config.idle_watchdog_enabled = match value {
+                "true" | "1" => true,
+                "false" | "0" => false,
+                _ => return Err(format!("invalid boolean: {value} (use true/false)")),
+            };
+        }
         _ => return Err(format!("unknown config key: {key}")),
     }
     let path = home.join("runtime-config.json");
@@ -113,6 +129,7 @@ pub fn get_key(key: &str) -> Result<String, String> {
         "fleet_idle_threshold_secs" => Ok(config.fleet_idle_threshold_secs.to_string()),
         "hang_auto_recovery_enabled" => Ok(config.hang_auto_recovery_enabled.to_string()),
         "usage_limit_propagation_enabled" => Ok(config.usage_limit_propagation_enabled.to_string()),
+        "idle_watchdog_enabled" => Ok(config.idle_watchdog_enabled.to_string()),
         _ => Err(format!("unknown config key: {key}")),
     }
 }


### PR DESCRIPTION
## Summary
- **Per-instance**: `idle_watchdog_enabled: bool` on InstanceConfig (default true). Disabled instances are excluded from both dev-idle and fleet-idle scans.
- **Daemon-level**: `idle_watchdog_enabled: bool` on RuntimeConfig (default true). When false, `scan_and_emit` is a no-op. Controllable via `config(action=set, key=idle_watchdog_enabled, value=false)`.
- Backward compatible: existing fleet.yaml files without the field get `true` (no behavior change)

### fleet.yaml example
```yaml
instances:
  general:
    idle_watchdog_enabled: false  # never triggers idle alerts
  dev:
    role: "Developer"  # default true, monitored normally
```

Closes #1402

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)