### PR TITLE
fix(#1366): replace_instance async teardown — remove 5s sync wait + 500ms sleep

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -97,7 +97,14 @@ pub(crate) fn handle_delete(params: &Value, ctx: &HandlerCtx) -> Value {
     // the previous implementation removed the registry entry before the OS
     // had reaped the PID, exposing PID re-use + concurrent-spawn collision
     // races.
-    crate::daemon::lifecycle::delete_transaction(ctx.home, name, ctx.registry, Some(ctx.configs));
+    let skip_exit_wait = params["no_wait"].as_bool().unwrap_or(false);
+    crate::daemon::lifecycle::delete_transaction(
+        ctx.home,
+        name,
+        ctx.registry,
+        Some(ctx.configs),
+        skip_exit_wait,
+    );
     // H3: clean up poll_reminder dedup state for deleted agent
     crate::daemon::poll_reminder::remove_agent(name);
     if let Some(n) = ctx.notifier {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1149,7 +1149,7 @@ fn scroll_focused(layout: &mut Layout, delta: i32) {
 /// `kill_process_tree` + synchronous wait-for-exit + `take_binding` + event
 /// log, matching the API delete path.
 fn kill_agent(home: &Path, registry: &AgentRegistry, name: &str) {
-    crate::daemon::lifecycle::delete_transaction(home, name, registry, None);
+    crate::daemon::lifecycle::delete_transaction(home, name, registry, None, false);
 }
 
 /// Whether the agent's child process is still running.

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -70,13 +70,21 @@ fn drop_active_binding(name: &str) {
 /// Called by both API `handle_delete` and app-mode `kill_agent` so the two
 /// paths cannot drift in cleanup completeness (Sprint 20 F3 was that drift).
 ///
+/// When `skip_exit_wait` is `true`, the kill signal is sent but
+/// [`wait_for_child_exit`] is skipped — the OS reaps the child
+/// asynchronously. Used by `replace_instance` (#1366) where the caller
+/// spawns a fresh instance immediately and the 5 s synchronous wait is
+/// unnecessary overhead.
+///
 /// Returns `true` if the cleanup observed the child exiting cleanly; `false`
-/// if [`CHILD_EXIT_TIMEOUT`] fired and we force-removed anyway.
+/// if [`CHILD_EXIT_TIMEOUT`] fired and we force-removed anyway. When
+/// `skip_exit_wait` is `true`, always returns `true` (optimistic).
 pub fn delete_transaction(
     home: &Path,
     name: &str,
     registry: &AgentRegistry,
     configs: Option<&Arc<Mutex<HashMap<String, super::AgentConfig>>>>,
+    skip_exit_wait: bool,
 ) -> bool {
     // Step 1: snapshot the child handle while still holding registry entry,
     // then release the registry lock before issuing the kill so concurrent
@@ -101,10 +109,17 @@ pub fn delete_transaction(
             }
             let _ = child.kill();
         }
-        // Step 3: synchronous wait for actual exit (Sprint 20 F2 fix —
-        // previously delete returned before the OS had reaped the PID,
-        // exposing PID re-use + concurrent-spawn collision races).
-        wait_for_child_exit(&child_arc)
+        if skip_exit_wait {
+            // #1366: caller opted out of the synchronous wait. The kill
+            // signal has been sent; the OS will reap the child in the
+            // background. Proceed to registry removal immediately.
+            true
+        } else {
+            // Step 3: synchronous wait for actual exit (Sprint 20 F2 fix —
+            // previously delete returned before the OS had reaped the PID,
+            // exposing PID re-use + concurrent-spawn collision races).
+            wait_for_child_exit(&child_arc)
+        }
     } else {
         // No registry entry; nothing to wait on.
         true
@@ -280,7 +295,7 @@ mod tests {
         let reg = empty_registry();
         // No insert → delete still cleans configs/ipc/event-log; returns true
         // (no child to wait on, so "exit observed" is vacuously true).
-        let observed_exit = delete_transaction(&home, "ghost", &reg, None);
+        let observed_exit = delete_transaction(&home, "ghost", &reg, None, false);
         assert!(
             observed_exit,
             "missing registry entry → wait is vacuous true"
@@ -340,7 +355,7 @@ mod tests {
         reg.lock().insert("gamma".into(), handle);
         // `true` exits immediately, so wait_for_child_exit should observe
         // the exit on the first try_wait.
-        let observed_exit = delete_transaction(&home, "gamma", &reg, None);
+        let observed_exit = delete_transaction(&home, "gamma", &reg, None, false);
         assert!(
             observed_exit,
             "exited child must be observed within timeout"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1090,7 +1090,7 @@ fn spawn_and_register_agent(
                 error = %e,
                 "TUI listener prep failed — rolling back agent registration"
             );
-            lifecycle::delete_transaction(home, name, registry, Some(configs));
+            lifecycle::delete_transaction(home, name, registry, Some(configs), false);
             return Err(anyhow::Error::from(e));
         }
     };
@@ -1116,7 +1116,7 @@ fn spawn_and_register_agent(
             error = %e,
             "TUI server thread spawn failed — rolling back agent registration"
         );
-        lifecycle::delete_transaction(home, name, registry, Some(configs));
+        lifecycle::delete_transaction(home, name, registry, Some(configs), false);
         return Err(e.into());
     }
     Ok(())

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -285,15 +285,14 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
         .and_then(|r| r.working_directory)
         .map(|p| p.display().to_string());
 
-    // Kill via DELETE (synchronous — waits for child exit + removes from registry).
+    // #1366: kill via DELETE with no_wait — sends kill signal and removes
+    // registry entry without blocking up to 5 s for child exit. The OS
+    // reaps the old process asynchronously; the new spawn gets its own
+    // PID / PTY / port with no resource collision.
     let _ = crate::api::call(
         home,
-        &json!({"method": crate::api::method::DELETE, "params": {"name": name}}),
+        &json!({"method": crate::api::method::DELETE, "params": {"name": name, "no_wait": true}}),
     );
-
-    // TODO: replace hardcoded 500ms sleep with event-driven readiness check
-    // (e.g. poll until PID is gone or port is free).
-    std::thread::sleep(std::time::Duration::from_millis(500));
 
     // Enqueue handover context for the new instance.
     let _ = crate::inbox::enqueue(


### PR DESCRIPTION
## Summary
- Add `skip_exit_wait` parameter to `delete_transaction` — when `true`, the kill signal is sent but `wait_for_child_exit` (up to 5s) is skipped; the OS reaps the child asynchronously
- `replace_instance` MCP handler passes `no_wait: true` to the DELETE API call, removing the 5.5s+ blocking stall
- Remove the hardcoded 500ms `thread::sleep` placeholder (the TODO it replaced)
- All other callers (`kill_agent`, rollback paths) pass `false` to preserve existing synchronous behavior

Closes #1366

## Test plan
- [ ] Verify `replace_instance` completes in <1s instead of 5.5s+
- [ ] Verify normal `delete_instance` (without `no_wait`) still waits for child exit
- [ ] Verify app-mode `kill_agent` still synchronously waits
- [ ] Existing `delete_transaction` unit tests pass (updated to new signature)
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)