### PR TITLE
feat(#1400): restart_instance MCP tool + interrupt snapshot

### DIFF
--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -504,6 +504,7 @@ mod tests {
                 "delete_instance",
                 "start_instance",
                 "replace_instance",
+                "restart_instance",
                 "interrupt",
                 "set_display_name",
                 "set_description",
@@ -530,7 +531,7 @@ mod tests {
                 "gc_dry_run",
             ]
         );
-        assert_eq!(crate::mcp::registry::all().len(), 33);
+        assert_eq!(crate::mcp::registry::all().len(), 34);
     }
 
     #[test]

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -165,6 +165,11 @@ adapter!(
     ha,
     instance::handle_replace_instance
 );
+adapter!(
+    dispatch_restart_instance,
+    ha,
+    instance::handle_restart_instance
+);
 adapter!(dispatch_move_pane, ha, instance::handle_move_pane);
 adapter!(
     dispatch_set_waiting_on,

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -348,6 +348,56 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
     json!({"name": name, "reason": reason, "spawned": spawned})
 }
 
+pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
+    let name = match args["name"].as_str() {
+        Some(n) => n,
+        None => return json!({"error": "missing 'name'"}),
+    };
+    if let Err(e) = crate::agent::validate_name(name) {
+        return json!({"error": e});
+    }
+    let reason = args["reason"].as_str().unwrap_or("manual restart");
+    let mode = args["mode"].as_str().unwrap_or("resume");
+
+    let fleet_path = crate::fleet::fleet_yaml_path(home);
+    let config = match crate::fleet::FleetConfig::load(&fleet_path) {
+        Ok(c) => c,
+        Err(e) => return json!({"error": format!("fleet.yaml: {e}")}),
+    };
+    let resolved = match config.resolve_instance(name) {
+        Some(r) => r,
+        None => return json!({"error": format!("Instance '{name}' not in fleet.yaml")}),
+    };
+
+    let _ = crate::api::call(
+        home,
+        &json!({"method": crate::api::method::DELETE, "params": {"name": name, "no_wait": true}}),
+    );
+
+    let mut spawn_params = json!({
+        "name": name,
+        "backend": resolved.backend_command,
+        "args": resolved.args.join(" "),
+        "working_directory": resolved.working_directory.map(|p| p.display().to_string()),
+        "env": serde_json::to_value(&resolved.env).unwrap_or(serde_json::Value::Null),
+    });
+    if mode == "resume" {
+        spawn_params["mode"] = json!("resume");
+    }
+
+    let spawn_result = crate::api::call(
+        home,
+        &json!({"method": crate::api::method::SPAWN, "params": spawn_params}),
+    );
+    let spawned = spawn_result
+        .as_ref()
+        .map(|r| r["ok"].as_bool() == Some(true))
+        .unwrap_or(false);
+
+    tracing::info!(%name, %reason, %mode, %spawned, "restart_instance");
+    json!({"name": name, "reason": reason, "mode": mode, "spawned": spawned})
+}
+
 pub(super) fn handle_set_display_name(home: &Path, args: &Value, instance_name: &str) -> Value {
     let display_name = args["name"].as_str().unwrap_or("");
     if display_name.len() > 256 {
@@ -380,7 +430,18 @@ pub(super) fn handle_interrupt(home: &Path, args: &Value) -> Value {
                 let header = crate::inbox::format_event_header("interrupt", &[("reason", reason)]);
                 crate::inbox::compose_aware_inject(home, target, &header);
             }
-            json!({"ok": true, "target": target})
+            let mut result = json!({"ok": true, "target": target});
+            if args["snapshot"].as_bool() == Some(true) {
+                if let Ok(snap) = crate::api::call(
+                    home,
+                    &json!({"method": crate::api::method::PANE_SNAPSHOT, "params": {"name": target, "lines": 40}}),
+                ) {
+                    if snap["ok"].as_bool() == Some(true) {
+                        result["snapshot"] = snap["text"].clone();
+                    }
+                }
+            }
+            result
         }
         Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("inject failed")}),
         Err(e) => {

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -17,7 +17,7 @@ pub(crate) fn all() -> &'static [ToolEntry] {
     &ALL_TOOLS
 }
 
-static ALL_TOOLS: [ToolEntry; 33] = [
+static ALL_TOOLS: [ToolEntry; 34] = [
     // ── Channel ──
     ToolEntry {
         name: "reply",
@@ -65,6 +65,11 @@ static ALL_TOOLS: [ToolEntry; 33] = [
         name: "replace_instance",
         definition: super::tools::def_replace_instance,
         handler: super::handlers::dispatch::dispatch_replace_instance,
+    },
+    ToolEntry {
+        name: "restart_instance",
+        definition: super::tools::def_restart_instance,
+        handler: super::handlers::dispatch::dispatch_restart_instance,
     },
     ToolEntry {
         name: "interrupt",

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -484,8 +484,8 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            33,
-            "#1085: 32 + tui_screenshot = 33. \
+            34,
+            "#1400: 33 + restart_instance = 34. \
              Current tools: {:?}",
             tools
                 .iter()

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -107,11 +107,21 @@ pub(crate) fn def_replace_instance() -> Value {
         "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}, "reason": {"type": "string"}}, "required": ["name"]}})
 }
 
+pub(crate) fn def_restart_instance() -> Value {
+    json!({"name": "restart_instance", "description": "Kill and restart an instance. Default mode 'resume' preserves conversation state; 'fresh' starts clean (like replace_instance).",
+        "inputSchema": {"type": "object", "properties": {
+            "name": {"type": "string"},
+            "mode": {"type": "string", "enum": ["resume", "fresh"], "default": "resume", "description": "resume = keep conversation (--continue/--resume); fresh = clean start"},
+            "reason": {"type": "string"}
+        }, "required": ["name"]}})
+}
+
 pub(crate) fn def_interrupt() -> Value {
     json!({"name": "interrupt", "description": "Send ESC byte to target agent's PTY to interrupt current LLM turn. Context preserved, agent accepts next prompt.",
         "inputSchema": {"type": "object", "properties": {
             "target": {"type": "string", "description": "Target instance name"},
-            "reason": {"type": "string", "description": "Optional follow-up message to inject after ESC"}
+            "reason": {"type": "string", "description": "Optional follow-up message to inject after ESC"},
+            "snapshot": {"type": "boolean", "default": false, "description": "When true, return a pane snapshot after ESC for closed-loop verification"}
         }, "required": ["target"]}})
 }
 


### PR DESCRIPTION
## Summary
- Add `restart_instance` MCP tool — kill + respawn with `mode=resume` (preserves conversation via `--continue`/`--resume`, default) or `mode=fresh` (clean start, same as `replace_instance`). Uses #1366's `no_wait` DELETE for fast teardown.
- Enhance `interrupt` tool with optional `snapshot` parameter — when `true`, captures 40-line pane snapshot after ESC injection for closed-loop verification without a separate `pane_snapshot` call.
- 4 files, +84 -3 lines

Closes #1400

## Test plan
- [ ] `restart_instance mode=resume` kills + resumes preserving conversation
- [ ] `restart_instance mode=fresh` kills + fresh spawns (same as replace_instance)
- [ ] `interrupt snapshot=true` returns pane text in response
- [ ] `interrupt snapshot=false` (default) behaves unchanged
- [ ] Existing `replace_instance` / `start_instance` behavior unchanged
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)