### PR TITLE
refactor: validate_name_or_err! macro eliminates 14 duplicated blocks (#1413)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -127,6 +127,18 @@ pub fn validate_name(name: &str) -> Result<&str, String> {
     Ok(name)
 }
 
+/// [`validate_name`] with a JSON error response for MCP handlers.
+/// Use in functions that return `serde_json::Value`:
+/// `validate_name_or_err!(name)` expands to an early return on failure.
+#[macro_export]
+macro_rules! validate_name_or_err {
+    ($name:expr) => {
+        if let Err(e) = $crate::agent::validate_name($name) {
+            return serde_json::json!({"error": e});
+        }
+    };
+}
+
 /// Error from [`resolve_instance`].
 #[derive(Debug)]
 pub enum ResolveError {

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -73,9 +73,7 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
         Some(a) if !a.is_empty() => a,
         _ => return json!({"error": "missing 'agent'"}),
     };
-    if let Err(e) = crate::agent::validate_name(agent) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(agent);
 
     let binding = crate::binding::read(home, agent);
     let bind_in_flight = crate::mcp::handlers::dispatch_hook::is_bind_in_flight(home, agent);

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -72,9 +72,7 @@ pub(super) fn handle_send_to_instance(
         Some(t) => t,
         None => return json!({"error": "missing 'instance_name' or 'target'"}),
     };
-    if let Err(e) = crate::agent::validate_name(target) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(target);
     if *sender == target {
         return json!({"error": "cannot send to self — use a different instance_name"});
     }
@@ -148,9 +146,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
         Some(t) => t,
         None => return json!({"error": "missing 'target_instance'"}),
     };
-    if let Err(e) = crate::agent::validate_name(raw_target) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(raw_target);
     // Sprint 46 P2: resolve target via InstanceId — replaces P1 name-lookup bandaid.
     // If raw_target resolves to a known instance (by id, short-id, or name), route
     // directly. Otherwise fall through to team-orchestrator resolution.
@@ -452,9 +448,7 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
         Some(t) => t,
         None => return json!({"error": "missing 'target_instance'"}),
     };
-    if let Err(e) = crate::agent::validate_name(target) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(target);
     let summary = match args["summary"].as_str() {
         Some(s) => s,
         None => return json!({"error": "missing 'summary'"}),
@@ -576,9 +570,7 @@ pub(super) fn handle_request_information(
         Some(t) => t,
         None => return json!({"error": "missing 'target_instance'"}),
     };
-    if let Err(e) = crate::agent::validate_name(target) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(target);
     let question = match args["question"].as_str() {
         Some(q) => q,
         None => return json!({"error": "missing 'question'"}),

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -122,9 +122,7 @@ pub(super) fn handle_delete_instance(home: &Path, args: &Value) -> Value {
         Some(n) => n,
         None => return json!({"error": "missing 'name'"}),
     };
-    if let Err(e) = crate::agent::validate_name(name) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(name);
     let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
     if let Some(ref config) = fleet {
         if config.channel.is_some()
@@ -153,9 +151,7 @@ pub(super) fn handle_start_instance(home: &Path, args: &Value) -> Value {
         Some(n) => n,
         None => return json!({"error": "missing 'name'"}),
     };
-    if let Err(e) = crate::agent::validate_name(name) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(name);
     let fleet_path = crate::fleet::fleet_yaml_path(home);
     if !fleet_path.exists() {
         return json!({"error": "No fleet.yaml"});
@@ -195,9 +191,7 @@ pub(super) fn handle_start_instance(home: &Path, args: &Value) -> Value {
 
 pub(super) fn handle_describe_instance(home: &Path, args: &Value) -> Value {
     let name = args["name"].as_str().unwrap_or("");
-    if let Err(e) = crate::agent::validate_name(name) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(name);
     match crate::api::call(home, &json!({"method": crate::api::method::LIST})) {
         Ok(resp) => {
             match resp["result"]["agents"]
@@ -238,9 +232,7 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
         Some(n) => n,
         None => return json!({"error": "missing 'name'"}),
     };
-    if let Err(e) = crate::agent::validate_name(name) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(name);
     let reason = args["reason"].as_str().unwrap_or("manual replacement");
 
     // Capture backend + working_directory before kill so we can respawn.
@@ -353,9 +345,7 @@ pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
         Some(n) => n,
         None => return json!({"error": "missing 'name'"}),
     };
-    if let Err(e) = crate::agent::validate_name(name) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(name);
     let reason = args["reason"].as_str().unwrap_or("manual restart");
     let mode = args["mode"].as_str().unwrap_or("resume");
 
@@ -421,9 +411,7 @@ pub(super) fn handle_interrupt(home: &Path, args: &Value) -> Value {
         Some(t) => t,
         None => return json!({"error": "missing 'target'"}),
     };
-    if let Err(e) = crate::agent::validate_name(target) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(target);
     match crate::api::call(home, &super::interrupt_esc_params(target)) {
         Ok(resp) if resp["ok"].as_bool() == Some(true) => {
             if let Some(reason) = args["reason"].as_str() {
@@ -510,9 +498,7 @@ pub(super) fn handle_pane_snapshot(home: &Path, args: &Value) -> Value {
         Some(t) => t,
         None => return json!({"error": "missing 'target'"}),
     };
-    if let Err(e) = crate::agent::validate_name(target) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(target);
     let lines_u64 = args["lines"].as_u64().unwrap_or(100);
     // M1: explicit bounds check before u64→usize cast (32-bit safety)
     if lines_u64 > 10000 {

--- a/src/mcp/handlers/instance_spawn.rs
+++ b/src/mcp/handlers/instance_spawn.rs
@@ -28,9 +28,7 @@ pub(super) fn spawn_single_instance_impl(
         Some(n) => n,
         None => return json!({"error": "missing 'name'"}),
     };
-    if let Err(e) = crate::agent::validate_name(raw_name) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(raw_name);
     let name_owned = {
         // M4: AtomicU64 prevents 65536 wrap-around collision
         use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -151,9 +151,7 @@ pub(crate) fn handle_release_worktree(
         Some(a) if !a.is_empty() => a,
         _ => return json!({"error": "missing 'agent'"}),
     };
-    if let Err(e) = crate::agent::validate_name(agent) {
-        return json!({"error": e});
-    }
+    crate::validate_name_or_err!(agent);
     let dry_run = args["dry_run"].as_bool().unwrap_or(false);
     // #789: clean empty init commits before removal (best-effort).
     if !dry_run {


### PR DESCRIPTION
## Summary
- Add `validate_name_or_err!` macro to replace the 3-line validate+return-json pattern duplicated 14 times across MCP handlers
- Each `if let Err(e) = validate_name(x) { return json!({"error": e}); }` block becomes `validate_name_or_err!(x);`
- 14 sites migrated, -42 lines / +26 lines (net -16)
- 4 remaining sites use different patterns (anyhow, continue, extra JSON fields) — left as-is

Closes #1413

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)