### PR TITLE
refactor: BlockedReason Display + parse_kind eliminates dual mapping (#1416)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -316,16 +316,9 @@ pub(crate) fn handle_set_blocked_reason(params: &Value, ctx: &HandlerCtx) -> Val
         Some(r) => r,
         None => return json!({"ok": false, "error": "missing 'reason'"}),
     };
-    let reason = match reason_str {
-        "rate_limit" => crate::health::BlockedReason::RateLimit {
-            retry_after_secs: params["retry_after_secs"].as_u64(),
-        },
-        "quota_exceeded" => crate::health::BlockedReason::QuotaExceeded,
-        "awaiting_operator" => crate::health::BlockedReason::AwaitingOperator,
-        "permission_prompt" => crate::health::BlockedReason::PermissionPrompt,
-        "hang" => crate::health::BlockedReason::Hang,
-        "crash" => crate::health::BlockedReason::Crash,
-        _ => return json!({"ok": false, "error": format!("unknown reason: {reason_str}")}),
+    let reason = match crate::health::BlockedReason::parse_kind(reason_str, params) {
+        Some(r) => r,
+        None => return json!({"ok": false, "error": format!("unknown reason: {reason_str}")}),
     };
     let reg = agent::lock_registry(ctx.registry);
     match reg.get(name) {
@@ -356,17 +349,11 @@ pub(crate) fn handle_clear_blocked_reason(params: &Value, ctx: &HandlerCtx) -> V
                 .map(|r| serde_json::to_value(r).unwrap_or_default());
             // If a reason filter is specified, only clear if it matches
             if let Some(filter) = filter_reason {
-                let matches = core.health.current_reason.as_ref().is_some_and(|r| {
-                    let kind = match r {
-                        crate::health::BlockedReason::RateLimit { .. } => "rate_limit",
-                        crate::health::BlockedReason::QuotaExceeded => "quota_exceeded",
-                        crate::health::BlockedReason::AwaitingOperator => "awaiting_operator",
-                        crate::health::BlockedReason::PermissionPrompt => "permission_prompt",
-                        crate::health::BlockedReason::Hang => "hang",
-                        crate::health::BlockedReason::Crash => "crash",
-                    };
-                    kind == filter
-                });
+                let matches = core
+                    .health
+                    .current_reason
+                    .as_ref()
+                    .is_some_and(|r| r.kind_str() == filter);
                 if !matches {
                     return json!({"ok": false, "error": "reason mismatch", "current": was});
                 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -197,6 +197,39 @@ pub enum BlockedReason {
     Crash,
 }
 
+impl BlockedReason {
+    pub fn parse_kind(kind: &str, params: &serde_json::Value) -> Option<Self> {
+        match kind {
+            "rate_limit" => Some(Self::RateLimit {
+                retry_after_secs: params["retry_after_secs"].as_u64(),
+            }),
+            "quota_exceeded" => Some(Self::QuotaExceeded),
+            "awaiting_operator" => Some(Self::AwaitingOperator),
+            "permission_prompt" => Some(Self::PermissionPrompt),
+            "hang" => Some(Self::Hang),
+            "crash" => Some(Self::Crash),
+            _ => None,
+        }
+    }
+
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            Self::Hang => "hang",
+            Self::RateLimit { .. } => "rate_limit",
+            Self::QuotaExceeded => "quota_exceeded",
+            Self::AwaitingOperator => "awaiting_operator",
+            Self::PermissionPrompt => "permission_prompt",
+            Self::Crash => "crash",
+        }
+    }
+}
+
+impl std::fmt::Display for BlockedReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.kind_str())
+    }
+}
+
 /// Tracks health for one agent.
 #[derive(Clone)]
 #[allow(dead_code)] // error_events, last_output, record_error, reset: reserved for daemon health monitoring


### PR DESCRIPTION
## Summary
- Add `kind_str()`, `Display`, and `parse_kind()` to `BlockedReason` enum
- Eliminates duplicated 6-variant string↔enum mapping in `handle_set_blocked_reason` and `handle_clear_blocked_reason`
- Net -21 lines of inline mapping code, replaced by 3 reusable methods on the enum

Closes #1416

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)