### PR TITLE
refactor: ensure_not_protected helpers eliminate E4.5 guard duplication (#1417)

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -240,6 +240,27 @@ pub fn is_protected_ref(branch: &str) -> bool {
     matches!(branch, "main" | "master")
 }
 
+pub fn ensure_not_protected(branch: &str) -> Result<(), String> {
+    if is_protected_ref(branch) {
+        Err(format!(
+            "E4.5 violation: protected branch '{branch}' cannot be used for agent worktrees"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn ensure_not_protected_json(branch: &str) -> Result<(), serde_json::Value> {
+    if is_protected_ref(branch) {
+        Err(serde_json::json!({
+            "error": format!("E4.5 violation: protected branch '{branch}' rejected"),
+            "code": "e4_5_protected_branch"
+        }))
+    } else {
+        Ok(())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Working-directory cleanup (CANONICAL 19-entry list)
 // ---------------------------------------------------------------------------

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -19,11 +19,10 @@ pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &st
     // (review pool, operator triage) that materialize a detached-HEAD
     // inspection worktree without claiming it.
     let bind = args["bind"].as_bool().unwrap_or(false);
-    if bind && crate::agent_ops::is_protected_ref(branch) {
-        return json!({
-            "error": format!("E4.5 violation: bind=true rejects protected branch '{branch}'"),
-            "code": "e4_5_protected_branch"
-        });
+    if bind {
+        if let Err(e) = crate::agent_ops::ensure_not_protected_json(branch) {
+            return e;
+        }
     }
     if bind && instance_name.is_empty() {
         return json!({
@@ -467,11 +466,8 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     // edited in exactly one place. The "main" default at the line
     // above is the backstop the gate catches when callers omit both
     // `branch` and explicit-protected branch — both flows land here.
-    if crate::agent_ops::is_protected_ref(branch) {
-        return json!({
-            "error": format!("E4.5 violation: ci action=watch rejects protected branch '{branch}' — use lead/operator dashboards for protected-ref CI surveillance, not per-agent subscriptions"),
-            "code": "e4_5_protected_branch"
-        });
+    if let Err(e) = crate::agent_ops::ensure_not_protected_json(branch) {
+        return e;
     }
 
     // Reject unsupported providers early with operator-actionable error.

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -41,15 +41,7 @@ pub fn lease(
     agent: &str,
     branch: &str,
 ) -> Result<WorktreeLease, String> {
-    // E4.5: reject protected-branch lease. Single source of truth for
-    // the protected set is `agent_ops::is_protected_ref` so adding a
-    // new protected ref propagates here and to every other E4.5 site
-    // (Sprint 57 Wave 2 Track B #546 Item 3).
-    if crate::agent_ops::is_protected_ref(branch) {
-        return Err(format!(
-            "E4.5 violation: cannot lease worktree for protected branch '{branch}'"
-        ));
-    }
+    crate::agent_ops::ensure_not_protected(branch)?;
 
     // Create worktree using existing infrastructure. Sprint 57 Wave 4
     // (#546 Item 4): the new external layout requires `home` to


### PR DESCRIPTION
## Summary
- Add `ensure_not_protected()` (returns `Result<(), String>`) and `ensure_not_protected_json()` (returns `Result<(), Value>`) to `agent_ops`
- Migrate 3 call sites from inline 5-line guards to single-line helper calls
- Remaining sites use different flow control (continue/tuple/binary) and retain `is_protected_ref` directly

Closes #1417

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)