### PR TITLE
fix(#1432): freeze pane grid during mouse selection by pausing output drain

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -331,9 +331,11 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
             if let Some(tab) = ctx.layout.active_tab() {
                 if let Some(pane) = tab.root().find_pane(tab.focus_id) {
                     if let Some(ref sel) = pane.selection {
-                        let text = pane
-                            .vterm
-                            .extract_text(sel.start, sel.end, pane.scroll_offset);
+                        let text = pane.vterm.extract_text(
+                            sel.start,
+                            sel.end,
+                            pane.effective_scroll_offset(),
+                        );
                         if !text.is_empty() {
                             super::mouse::copy_to_clipboard(&text);
                         }

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -94,6 +94,18 @@ impl Pane {
 
     /// Drain pending output into the local VTerm.
     pub fn drain_output(&mut self) {
+        // #1432: while a mouse selection gesture is active, freeze the grid by
+        // not draining new output. `selection_scroll_freeze` is set on MouseDown
+        // and cleared on MouseUp, so this pauses only for the gesture's duration.
+        // The scroll-offset drift compensation (#1358) only handles output that
+        // *appends* to scrollback; agent CLIs frequently redraw in place (cursor
+        // movement, spinners) without growing `max_scroll()`, which the offset
+        // approach cannot pin. Freezing the grid covers every case. Output stays
+        // queued in the unbounded `rx` channel and drains on the next call once
+        // the gesture ends.
+        if self.selection_scroll_freeze.is_some() {
+            return;
+        }
         while let Ok(data) = self.rx.try_recv() {
             self.vterm.process(&data);
             if self.backend.is_some() {
@@ -180,6 +192,52 @@ mod tests {
             selection_scroll_freeze: None,
             source: PaneSource::Local,
         }
+    }
+
+    /// #1432: output must not reach the VTerm while a selection gesture is
+    /// active (grid frozen), and must catch up once the gesture ends.
+    #[test]
+    fn drain_output_frozen_during_selection_then_resumes() {
+        let (tx, rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let mut pane = Pane {
+            agent_name: "agent".into(),
+            vterm: VTerm::new(20, 5),
+            rx,
+            id: 1,
+            backend: None,
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
+            selection: None,
+            selection_scroll_freeze: None,
+            source: PaneSource::Local,
+        };
+
+        tx.send(b"hello".to_vec()).expect("send baseline output");
+        pane.drain_output();
+        let before = pane.vterm.read_scrollback(100);
+        assert!(before.contains("hello"), "baseline: {before:?}");
+
+        // Selection gesture active → freeze: new output must not be drained.
+        pane.selection_scroll_freeze = Some(pane.vterm.max_scroll());
+        tx.send(b" world".to_vec())
+            .expect("send frozen-window output");
+        pane.drain_output();
+        let during = pane.vterm.read_scrollback(100);
+        assert_eq!(during, before, "grid must stay frozen during selection");
+
+        // Gesture ends → drain resumes and catches up.
+        pane.selection_scroll_freeze = None;
+        pane.drain_output();
+        let after = pane.vterm.read_scrollback(100);
+        assert!(
+            after.contains("hello world"),
+            "output must catch up after selection: {after:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1432 — the screen still auto-scrolled while selecting text with the mouse, even after PR #1358.

**Root cause:** PR #1358's `effective_scroll_offset` compensates only for output that *appends* to scrollback (drift = `max_scroll()` growth). Agent CLIs (Claude Code, etc.) frequently redraw **in place** — cursor movement, spinners, status lines — without growing `max_scroll()`. The offset approach can't pin those, so the grid kept changing under an active selection. (Verified: a render test shows the offset math *does* pin append-scrolled content, but in-place redraws have zero drift to compensate.)

**Fix:** freeze the grid outright during the selection gesture. While `selection_scroll_freeze` is set (MouseDown → MouseUp), `Pane::drain_output` skips feeding new PTY bytes into the VTerm. Output stays queued in the unbounded `rx` channel and catches up once the gesture ends. This covers append-scroll, in-place redraws, and alt-screen alike, and keeps the viewport-relative selection coordinates valid.

Also fixes the `Action::CopySelection` (keyboard copy) path, which still extracted text with raw `scroll_offset` instead of `effective_scroll_offset` — a bypass PR #1358 missed.

## Changes

- `src/layout/pane.rs` — `drain_output` early-returns while a selection gesture is active; regression test (`drain_output_frozen_during_selection_then_resumes`).
- `src/app/dispatch.rs` — `CopySelection` uses `effective_scroll_offset()`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test` — full suite, 0 failures; new test verifies grid freezes during selection and catches up after
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)