### PR TITLE
feat(#1440): agent backend env isolation — env_clear + allowlist (flag, default off)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -114,6 +114,134 @@ pub fn is_sensitive_env_key(key: &str) -> bool {
         .any(|denied| denied.eq_ignore_ascii_case(key))
 }
 
+/// #1440: base runtime env allowlist — the minimum any agent CLI needs to
+/// launch and reach its provider. Injected only if present in the daemon env
+/// (so Windows-only keys are harmless on Unix and vice versa). Corp-specific
+/// extras (`NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, …) are intentionally absent
+/// — operators name those in `passthrough_env`, keeping the default minimal
+/// and auditable.
+const BASE_ENV_ALLOWLIST: &[&str] = &[
+    // Identity / shell / paths
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "PATH",
+    // Locale
+    "LANG",
+    "LANGUAGE",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LC_MESSAGES",
+    "TZ",
+    // Temp dirs
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    // Agent IO / auth socket
+    "SSH_AUTH_SOCK",
+    // XDG base dirs
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_RUNTIME_DIR",
+    // Proxies (lower + upper case both seen in the wild)
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    // Windows essentials — inject-if-present; absent on Unix. Without these a
+    // child process fails to start on Windows (CI runs windows-latest).
+    "SYSTEMROOT",
+    "SystemDrive",
+    "windir",
+    "PATHEXT",
+    "COMSPEC",
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "ProgramData",
+    "ProgramFiles",
+    "ProgramFiles(x86)",
+    "NUMBER_OF_PROCESSORS",
+    "PROCESSOR_ARCHITECTURE",
+];
+
+/// #1440: is agent-backend env isolation enabled? Default OFF (phased rollout
+/// — this version does not change default spawn behavior).
+pub fn env_isolation_enabled() -> bool {
+    std::env::var("AGEND_ENV_ISOLATION").as_deref() == Ok("1")
+}
+
+/// #1440: outcome of [`resolve_child_env`].
+pub struct ChildEnvPlan {
+    /// `(key, value)` pairs to inject into the child after `env_clear()`.
+    pub injected: Vec<(String, String)>,
+    /// Names of source-env vars that would NOT survive isolation (warn input).
+    pub dropped: Vec<String>,
+}
+
+/// Case-insensitive membership (matches `is_sensitive_env_key`; also handles
+/// Windows' case-insensitive env-var names, e.g. `Path` vs `PATH`).
+fn env_key_in(key: &str, list: &[&str]) -> bool {
+    list.iter().any(|k| k.eq_ignore_ascii_case(key))
+}
+
+/// #1440: PURE — decide which inherited env vars survive isolation. A var
+/// survives iff it is in the base allowlist, OR a credential key the detected
+/// backend declares (these intentionally override `SENSITIVE_ENV_KEYS` for the
+/// owning backend only → cross-backend credential isolation), OR an operator
+/// `passthrough` key that is NOT itself sensitive (so `LD_PRELOAD` stays
+/// blocked even if listed). `source_env` is a snapshot — the real daemon env
+/// in production, an injected map in tests.
+pub fn resolve_child_env(
+    backend: Option<&Backend>,
+    passthrough: &[String],
+    source_env: &std::collections::BTreeMap<String, String>,
+) -> ChildEnvPlan {
+    let creds: &[&str] = backend.map(|b| b.credential_env_keys()).unwrap_or(&[]);
+    let pass: Vec<&str> = passthrough.iter().map(String::as_str).collect();
+    let mut injected = Vec::new();
+    let mut dropped = Vec::new();
+    for (k, v) in source_env {
+        let allowed = env_key_in(k, BASE_ENV_ALLOWLIST)
+            || env_key_in(k, creds)
+            || (env_key_in(k, &pass) && !is_sensitive_env_key(k));
+        if allowed {
+            injected.push((k.clone(), v.clone()));
+        } else {
+            dropped.push(k.clone());
+        }
+    }
+    injected.sort();
+    dropped.sort();
+    ChildEnvPlan { injected, dropped }
+}
+
+/// #1440: one-time warning listing inherited env var KEY NAMES (never values)
+/// that would be dropped under isolation. Lets operators preview the impact
+/// before flipping `AGEND_ENV_ISOLATION=1`.
+fn warn_env_isolation_disabled_once(dropped: &[String]) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        if dropped.is_empty() {
+            return;
+        }
+        tracing::warn!(
+            dropped_keys = %dropped.join(", "),
+            "AGEND_ENV_ISOLATION off: agent backends inherit the full daemon env. \
+             Under isolation these inherited keys would be dropped (names only). \
+             Opt in with AGEND_ENV_ISOLATION=1 + passthrough_env."
+        );
+    });
+}
+
 /// Validate and sanitize an instance name. Only allows [a-zA-Z0-9_-].
 pub fn validate_name(name: &str) -> Result<&str, String> {
     if name.is_empty() {
@@ -459,6 +587,28 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
         which::which(backend_command).unwrap_or_else(|_| std::path::PathBuf::from(backend_command));
     let mut cmd = CommandBuilder::new(&resolved_command);
     cmd.args(&enriched_args);
+
+    // #1440: agent-backend env isolation. INVARIANT: env_clear() must run here,
+    // before any env injection below, or the explicit keys we set would be wiped.
+    // Default off (phased rollout) — when off, behavior is unchanged except a
+    // one-time warn listing the inherited keys that isolation would drop.
+    {
+        let source_env: std::collections::BTreeMap<String, String> = std::env::vars().collect();
+        let passthrough = (*home)
+            .and_then(|h| crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(h)).ok())
+            .map(|f| f.resolve_passthrough_env(name))
+            .unwrap_or_default();
+        let plan = resolve_child_env(detected_backend.as_ref(), &passthrough, &source_env);
+        if env_isolation_enabled() {
+            cmd.env_clear();
+            for (k, v) in &plan.injected {
+                cmd.env(k, v);
+            }
+        } else {
+            warn_env_isolation_disabled_once(&plan.dropped);
+        }
+    }
+
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
     cmd.env("FORCE_COLOR", "1");

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1327,3 +1327,87 @@ fn matrix6_external_fallback_routes_by_name() {
     let handle = reg.get("ext-agent").expect("external resolves by name");
     assert_eq!(handle.pid, 4321, "external lookup keyed by name");
 }
+
+// ── #1440: agent backend env isolation (clear + allowlist) ──
+
+fn env_map(pairs: &[(&str, &str)]) -> std::collections::BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+/// #1440: an unlisted secret in the daemon env is absent from the child env
+/// under isolation; a base-allowlist key (HOME) survives.
+#[test]
+fn env_isolation_drops_unlisted_secret() {
+    let src = env_map(&[("MY_FAKE_SECRET", "supersecret-value"), ("HOME", "/home/x")]);
+    let plan = resolve_child_env(Some(&Backend::ClaudeCode), &[], &src);
+    assert!(
+        plan.injected.iter().all(|(k, _)| k != "MY_FAKE_SECRET"),
+        "unlisted secret must not reach the child"
+    );
+    assert!(
+        plan.injected.iter().any(|(k, _)| k == "HOME"),
+        "base-allowlist HOME must survive"
+    );
+    assert!(plan.dropped.contains(&"MY_FAKE_SECRET".to_string()));
+}
+
+/// #1440: cross-backend credential isolation — Codex gets OPENAI but never
+/// ANTHROPIC, and Claude gets ANTHROPIC but never OPENAI.
+#[test]
+fn credential_isolation_across_backends() {
+    let src = env_map(&[
+        ("ANTHROPIC_API_KEY", "sk-ant-xxx"),
+        ("OPENAI_API_KEY", "sk-oai-yyy"),
+    ]);
+
+    let codex = resolve_child_env(Some(&Backend::Codex), &[], &src);
+    assert!(codex.injected.iter().any(|(k, _)| k == "OPENAI_API_KEY"));
+    assert!(
+        codex.injected.iter().all(|(k, _)| k != "ANTHROPIC_API_KEY"),
+        "Codex must not inherit ANTHROPIC_API_KEY"
+    );
+
+    let claude = resolve_child_env(Some(&Backend::ClaudeCode), &[], &src);
+    assert!(claude
+        .injected
+        .iter()
+        .any(|(k, _)| k == "ANTHROPIC_API_KEY"));
+    assert!(
+        claude.injected.iter().all(|(k, _)| k != "OPENAI_API_KEY"),
+        "Claude must not inherit OPENAI_API_KEY"
+    );
+}
+
+/// #1440: a non-sensitive passthrough key passes, but a sensitive one
+/// (LD_PRELOAD) stays blocked even when explicitly listed.
+#[test]
+fn passthrough_passes_but_sensitive_still_blocked() {
+    let src = env_map(&[("MY_CORP_CA", "/etc/ca.pem"), ("LD_PRELOAD", "/evil.so")]);
+    let passthrough = vec!["MY_CORP_CA".to_string(), "LD_PRELOAD".to_string()];
+    let plan = resolve_child_env(Some(&Backend::ClaudeCode), &passthrough, &src);
+    assert!(
+        plan.injected.iter().any(|(k, _)| k == "MY_CORP_CA"),
+        "listed non-sensitive passthrough key must pass"
+    );
+    assert!(
+        plan.injected.iter().all(|(k, _)| k != "LD_PRELOAD"),
+        "LD_PRELOAD must stay blocked even when listed in passthrough"
+    );
+    assert!(plan.dropped.contains(&"LD_PRELOAD".to_string()));
+}
+
+/// #1440: the dropped list feeding the one-time warn carries KEY NAMES only,
+/// never values — so the warn can never leak a secret value.
+#[test]
+fn dropped_warn_input_is_key_names_only() {
+    let src = env_map(&[("STRIPE_SECRET", "rk_live_TOPSECRETVALUE")]);
+    let plan = resolve_child_env(Some(&Backend::ClaudeCode), &[], &src);
+    assert!(plan.dropped.contains(&"STRIPE_SECRET".to_string()));
+    assert!(
+        plan.dropped.iter().all(|d| !d.contains("TOPSECRETVALUE")),
+        "warn input must contain key names only, never values"
+    );
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -53,6 +53,44 @@ impl Backend {
         }
     }
 
+    /// #1440: credential env-var names this backend legitimately needs to
+    /// authenticate to its LLM provider. Under `AGEND_ENV_ISOLATION`, only
+    /// these (plus the base runtime allowlist + operator `passthrough_env`)
+    /// survive `env_clear()` — so a Claude agent never inherits `OPENAI_API_KEY`
+    /// and vice versa (cross-backend credential isolation).
+    ///
+    /// These intentionally override the `SENSITIVE_ENV_KEYS` deny-list for the
+    /// owning backend only. `OpenCode` is multi-provider by design, so it
+    /// declares the union of the providers agend drives; long-tail providers
+    /// (Groq, OpenRouter, …) go through `passthrough_env`. `KiroCli`'s AWS
+    /// operation creds (`AWS_*`) are deliberately excluded — pass them via
+    /// `passthrough_env` only when that Kiro agent actually performs AWS work.
+    pub fn credential_env_keys(&self) -> &'static [&'static str] {
+        match self {
+            Backend::ClaudeCode => &[
+                "ANTHROPIC_API_KEY",
+                "ANTHROPIC_AUTH_TOKEN",
+                "CLAUDE_CODE_OAUTH_TOKEN",
+            ],
+            Backend::Codex => &["OPENAI_API_KEY"],
+            Backend::Gemini | Backend::Agy => &[
+                "GEMINI_API_KEY",
+                "GOOGLE_API_KEY",
+                "GOOGLE_APPLICATION_CREDENTIALS",
+            ],
+            Backend::KiroCli => &["KIRO_API_KEY"],
+            Backend::OpenCode => &[
+                "ANTHROPIC_API_KEY",
+                "OPENAI_API_KEY",
+                "GEMINI_API_KEY",
+                "GOOGLE_API_KEY",
+                "OPENCODE_CONFIG",
+                "OPENCODE_API_KEY",
+            ],
+            Backend::Shell | Backend::Raw(_) => &[],
+        }
+    }
+
     /// Parse a bare string form (yaml scalar or MCP tool argument).
     /// Known names → preset variants; shell aliases → [`Backend::Shell`];
     /// anything else becomes [`Backend::Raw`].

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -129,6 +129,7 @@ mod tests {
             },
             instances: Default::default(),
             teams: Default::default(),
+            passthrough_env: Vec::new(),
             channel: Some(ChannelConfig::Telegram {
                 bot_token_env: "TG_TOKEN".into(),
                 group_id: -1,

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -66,6 +66,13 @@ pub struct FleetConfig {
     pub instances: HashMap<String, InstanceConfig>,
     #[serde(default)]
     pub teams: HashMap<String, TeamConfig>,
+    /// #1440: fleet-wide env keys to pass through to every agent backend when
+    /// `AGEND_ENV_ISOLATION` is on (additive with per-instance
+    /// `passthrough_env`). Still gated by `is_sensitive_env_key`, so listing
+    /// `LD_PRELOAD` etc. has no effect. Use for corp-specific, non-secret env
+    /// like `NODE_EXTRA_CA_CERTS` / `SSL_CERT_FILE`.
+    #[serde(default)]
+    pub passthrough_env: Vec<String>,
     /// Channel configuration (e.g., Telegram). Legacy singular form.
     ///
     /// Prefer [`FleetConfig::channels`] (plural) going forward — per
@@ -240,6 +247,11 @@ pub struct InstanceConfig {
     pub ready_pattern: Option<String>,
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// #1440: per-instance env keys to pass through under `AGEND_ENV_ISOLATION`
+    /// (additive with fleet-level [`FleetConfig::passthrough_env`]). Still
+    /// `is_sensitive_env_key`-gated.
+    #[serde(default)]
+    pub passthrough_env: Vec<String>,
     pub cols: Option<u16>,
     pub rows: Option<u16>,
     pub topic_id: Option<i32>,
@@ -320,6 +332,19 @@ pub struct TeamConfig {
 }
 
 impl FleetConfig {
+    /// #1440: env keys to pass through to instance `name` under
+    /// `AGEND_ENV_ISOLATION` — fleet-level ∪ per-instance, deduplicated.
+    /// Still `is_sensitive_env_key`-gated at injection time.
+    pub fn resolve_passthrough_env(&self, name: &str) -> Vec<String> {
+        let mut keys = self.passthrough_env.clone();
+        if let Some(inst) = self.instances.get(name) {
+            keys.extend(inst.passthrough_env.iter().cloned());
+        }
+        keys.sort();
+        keys.dedup();
+        keys
+    }
+
     pub fn load(path: &Path) -> Result<Self> {
         let meta = std::fs::metadata(path).ok();
         let disk_mtime = meta.as_ref().and_then(|m| m.modified().ok());

--- a/tests/env_isolation_invariant.rs
+++ b/tests/env_isolation_invariant.rs
@@ -1,0 +1,46 @@
+//! #1440 invariant: in `build_command` (src/agent/mod.rs) `cmd.env_clear()`
+//! must precede any `cmd.env(...)`. If a future edit injects a `cmd.env(...)`
+//! before the clear, env isolation would silently wipe the explicitly-set
+//! keys — this test fails loud. Mirrors the §10.5 spawn-rationale source-scan
+//! invariant style.
+
+use std::path::PathBuf;
+
+#[test]
+fn env_clear_precedes_first_env_set_in_build_command() {
+    let src_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/agent/mod.rs");
+    let src = std::fs::read_to_string(&src_path).expect("read src/agent/mod.rs");
+
+    // Isolate the build_command body: from its signature to the next top-level
+    // fn definition after it.
+    let start = src.find("fn build_command").expect("build_command present");
+    let after = &src[start..];
+    let next_fn = after[1..].find("\nfn ").map(|i| i + 1);
+    let next_pub_fn = after[1..].find("\npub fn ").map(|i| i + 1);
+    let end_rel = [next_fn, next_pub_fn]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(after.len());
+    // Strip line comments so prose mentioning the call pattern can't false-match.
+    let body: String = after[..end_rel]
+        .lines()
+        .map(|l| l.split_once("//").map_or(l, |(code, _)| code))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // `cmd.env(` does not match `cmd.env_clear(` or `cmd.env_remove(`.
+    let clear_idx = body
+        .find("cmd.env_clear()")
+        .expect("build_command must call cmd.env_clear() for env isolation");
+    let first_env_idx = body
+        .find("cmd.env(")
+        .expect("build_command must set env via cmd.env(...)");
+
+    assert!(
+        clear_idx < first_env_idx,
+        "#1440 invariant violated: cmd.env_clear() (byte {clear_idx}) must precede \
+         the first cmd.env(...) (byte {first_env_idx}) in build_command, or env \
+         isolation would wipe explicitly-set keys"
+    );
+}


### PR DESCRIPTION
## Summary

Implements #1440 — flips agent-backend spawn env from **inherit-all + denylist** to **clear + allowlist**, behind `AGEND_ENV_ISOLATION` (**default OFF** — no behavior change this version; phased rollout).

A daemon launched from the operator's shell holds unrelated secrets (`STRIPE_SECRET`, other tools' provider keys, `.env` vars). Previously **every** agent backend (a third-party LLM) inherited **all** of them, and `SENSITIVE_ENV_KEYS` could never enumerate them. With isolation on, `build_command` calls `cmd.env_clear()` before any `cmd.env(...)` and re-injects only three classes:

- **Base runtime allowlist** (`BASE_ENV_ALLOWLIST`): `HOME`/`USER`/`SHELL`/`PATH`/locale/proxy/XDG/`SSH_AUTH_SOCK` **+ Windows essentials** (`SystemRoot`/`PATHEXT`/`APPDATA`/…), inject-if-present so one list is cross-platform.
- **Per-backend credentials** (`Backend::credential_env_keys()`): a Claude agent gets `ANTHROPIC_*` but never `OPENAI_API_KEY` and vice versa — **cross-backend credential isolation**. OpenCode (multi-provider) declares the union; KiroCli uses `KIRO_API_KEY` (`AWS_*` via passthrough only).
- **Operator `passthrough_env`** (fleet.yaml fleet-level + per-instance, additive), still gated by `is_sensitive_env_key` so `LD_PRELOAD` etc. stay blocked even when listed.

When isolation is **off**, a one-time `tracing::warn` lists the inherited **key names** (never values) that would be dropped, so operators can preview before opting in.

## Design notes (verified, not assumed)

- Read `portable_pty` source: `env_clear()` empties the `CommandBuilder` env map on **both** Unix and Windows (`environment_block()` builds purely from the map, not the live process env) — so isolation holds cross-platform.
- The issue's base allowlist omitted Windows essentials; without them a child process fails to start on Windows (CI runs windows-latest) — added.
- `resolve_child_env(...)` is a **pure function** (source env injected as a snapshot) so the policy is unit-tested without spawning.

## Tests (acceptance matrix)

- `env_isolation_drops_unlisted_secret` — fake daemon-env secret absent from child; base key survives.
- `credential_isolation_across_backends` — Codex can't see `ANTHROPIC_API_KEY`; Claude can't see `OPENAI_API_KEY`.
- `passthrough_passes_but_sensitive_still_blocked` — listed non-sensitive key passes; `LD_PRELOAD` blocked even when listed.
- `dropped_warn_input_is_key_names_only` — warn input carries names only, never values.
- `tests/env_isolation_invariant.rs` — source-scan: `env_clear()` precedes the first `cmd.env(...)` in `build_command` (§10.5 style regression guard).

## Out of scope (per issue)

Filesystem-level secrets (`.env`, `~/.aws/credentials`), shared-`$HOME` cached creds — separate defenses. This closes the largest/cheapest hole; not an end-to-end sandbox.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test` — full suite, 0 failures; 5 new tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)