### PR TITLE
fix(#1446): repo checkout accepts source_repo as alias for source

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -3,10 +3,26 @@ use crate::git_helpers::git_bypass;
 use serde_json::{json, Value};
 use std::path::Path;
 
+/// #1446: resolve the checkout source repo, accepting `source_repo` (the
+/// cross-tool standard name used by bind_self / team update) as an alias for
+/// the legacy `source`. Prefers `source_repo` when both are given; `source` is
+/// retained for backward compatibility. Returns `None` when neither is present
+/// (or both are empty).
+fn checkout_source(args: &Value) -> Option<&str> {
+    args.get("source_repo")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            args.get("source")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+        })
+}
+
 pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
-    let source = match args["source"].as_str() {
+    let source = match checkout_source(args) {
         Some(s) => s,
-        None => return json!({"error": "missing 'source'"}),
+        None => return json!({"error": "missing 'source_repo' (alias: 'source')"}),
     };
     let branch = args["branch"].as_str().unwrap_or("HEAD");
     if !validate_branch(branch) {

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2030,3 +2030,33 @@ fn merge_force_audit_write_failure_refuses_merge() {
     );
     let _ = std::fs::remove_dir_all(&home);
 }
+
+/// #1446: `repo checkout` resolves `source_repo` (the cross-tool standard name)
+/// as an alias for `source`. Before the fix, dispatch books calling checkout
+/// with `source_repo` were rejected as "missing source".
+#[test]
+fn checkout_accepts_source_repo_alias() {
+    use serde_json::json;
+    // Legacy `source` still resolves (backward compat — existing callers).
+    assert_eq!(
+        checkout_source(&json!({"source": "/repo/a"})),
+        Some("/repo/a")
+    );
+    // New `source_repo` resolves (the #1446 bug: previously rejected).
+    assert_eq!(
+        checkout_source(&json!({"source_repo": "/repo/b"})),
+        Some("/repo/b")
+    );
+    // Both given → standard `source_repo` wins.
+    assert_eq!(
+        checkout_source(&json!({"source_repo": "/repo/std", "source": "/repo/legacy"})),
+        Some("/repo/std")
+    );
+    // Empty `source_repo` falls back to `source`.
+    assert_eq!(
+        checkout_source(&json!({"source_repo": "", "source": "/repo/c"})),
+        Some("/repo/c")
+    );
+    // Neither present → None (handler then returns the missing-arg error).
+    assert_eq!(checkout_source(&json!({"branch": "feat-x"})), None);
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -308,7 +308,9 @@ pub(crate) fn def_repo() -> Value {
         "inputSchema": {"type": "object", "properties": {
             "action": {"type": "string", "enum": ["checkout", "release", "cleanup_init_commits", "cleanup_merged_branches", "merge"]},
             "pr": {"type": "integer", "description": "PR number for merge action."},
-            "source": {"type": "string"}, "branch": {"type": "string"},
+            "source_repo": {"type": "string", "description": "checkout: local path to the source repository. Standard cross-tool name (matches bind_self / team update)."},
+            "source": {"type": "string", "description": "checkout: alias for `source_repo`, retained for backward compatibility (#1446). Prefer `source_repo`."},
+            "branch": {"type": "string"},
             "path": {"type": "string"},
             "agent": {"type": "string", "description": "#789: target agent for cleanup_init_commits (defaults to caller's instance_name). Cleans empty `init` commits accumulated in the agent's bound worktree by backend session-checkpoint heartbeats. Returns {cleaned_count, [skipped_reason]}. Idempotent — call before push to scrub PR history."},
             "bind": {"type": "boolean", "description": "#778 Option 1: when true on checkout, atomically bind the caller to the just-provisioned worktree (writes binding.json + .agend-managed marker + arms ci_watches) and lands HEAD on the named branch instead of a detached commit. Default false preserves back-compat for inspection-only callers (review pool, operator triage)."},


### PR DESCRIPTION
## Summary

Fixes #1446. `repo action=checkout` named its repo-path parameter `source`, but `bind_self` and `team(update)` use `source_repo`. Dispatch books that called checkout with `source_repo` were rejected as `missing 'source'` — a **CRITICAL dispatch failure**.

**Additive fix** (no breaking change): checkout now accepts `source_repo` (the cross-tool standard name) as an alias for `source`, preferring `source_repo` when both are given; `source` is retained for backward compatibility (not removed).

## Changes

- `ci/mod.rs`: extracted `checkout_source(args)` — resolves `source_repo` (non-empty) else `source`; `handle_checkout_repo` uses it.
- `tools.rs`: `def_repo` schema documents both `source_repo` (standard) and `source` (alias).
- Confirmed only `checkout` used `source` among repo actions (release/cleanup/merge don't) — no other action needed changing.

## Scope

Only the repo tool's `source`/`source_repo`. **#1447** (fleet-wide instance-param standardization) is explicitly **not** touched — awaits operator sign-off on the standard name.

## Tests

`checkout_accepts_source_repo_alias`: `source` resolves (backward compat), `source_repo` resolves (the bug), `source_repo` wins when both given, empty `source_repo` falls back to `source`, neither → `None` (handler then returns the missing-arg error).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test` — full suite, 0 failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)