### PR TITLE
fix(#1452): self-heal Coverage CI flake — retry + disable test-repo auto-gc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,22 @@ jobs:
         timeout-minutes: 35
         env:
           AGEND_LOCK_AUDIT: "1"
-        run: cargo llvm-cov --workspace --tests --features tray --lcov --output-path coverage.lcov
+        # #1452: Coverage (non-required) recurringly flaked on transient
+        # llvm-profdata profraw corruption and a git-race test under llvm-cov's
+        # slow parallel run — both pass on rerun. Retry once (clean stale
+        # profraw between attempts) so the job self-heals instead of needing a
+        # manual `gh run rerun`. The git-race root is separately hardened by
+        # disabling auto-gc in the affected test's repo setup.
+        run: |
+          for attempt in 1 2; do
+            if cargo llvm-cov --workspace --tests --features tray --lcov --output-path coverage.lcov; then
+              exit 0
+            fi
+            echo "::warning::coverage attempt $attempt failed (likely #1452 profraw/git-race flake); cleaning + retrying"
+            cargo llvm-cov clean --workspace || true
+          done
+          echo "::error::coverage failed after 2 attempts"
+          exit 1
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1665,6 +1665,14 @@ fn setup_repo_and_worktree(tag: &str) -> (std::path::PathBuf, std::path::PathBuf
             .expect("git ran")
     };
     git_run(&repo, &["init", "-b", "main"]);
+    // #1452: disable git auto-gc/maintenance in the fixture repo. The SUT runs
+    // a `git rebase` over 50+ loose-object commits; under llvm-cov's slow,
+    // heavily-parallel CI run an auto-gc repack can fire mid-rebase and race
+    // the revision walk's object reads → "revision walk setup failed: could
+    // not read <sha>" (the recurring Coverage-job flake). Read from the common
+    // config, so it also covers git invocations inside the worktree.
+    git_run(&repo, &["config", "gc.auto", "0"]);
+    git_run(&repo, &["config", "maintenance.auto", "false"]);
     // #814 r1: pin per-repo gitconfig so subprocesses spawned by the
     // SUT (which don't inherit our test env vars) still find an
     // identity. Without this, CI runners with no global gitconfig


### PR DESCRIPTION
## Summary

Fixes #1452. The **non-required** Coverage job recurringly flaked (PRs #1434 / #1445 / #1451), always passing on a manual `gh run rerun`. Two transient classes:

1. **llvm-profdata profraw corruption** (`invalid instrumentation profile data (file header is corrupt)`) — a parallel profraw write/IO race in cargo-llvm-cov.
2. **`clean_empty_init_commits_handles_50_interleaved_inits`** racing under llvm-cov's slow parallel run (`revision walk setup failed: could not read <sha>`).

## Fixes

- **ci.yml Coverage step retries once** (cleaning stale profraw via `cargo llvm-cov clean` between attempts) → the job **self-heals** instead of needing a human rerun. Robustly covers the profraw class and any residual git transient.
- **Root-cause hardening for class 2**: disable git auto-gc/maintenance in the fixture repo (`gc.auto=0`, `maintenance.auto=false`). The SUT rebases 50+ loose-object commits; under heavy parallel load an auto-gc repack can fire mid-rebase and race the revision walk's object reads.

## Why not `#[serial]`

A single `#[serial]` on the test would be **inert** (nothing to serialize against), and group-tagging ~10 git tests over-scopes a non-required job. Removing the auto-gc race is the targeted root fix; the job retry is the safety net.

## Risk

Coverage is non-required and `fail_ci_if_error: false`, so this reduces rerun toil, not a merge gate. **No change to the required Check jobs' test behavior** — the gc.auto config only affects the dispatch_hook fixture repos; the ci.yml change is workflow-only.

## Test plan

- [x] `clean_empty_init_commits_*` tests pass (10/10) with the gc.auto config
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] ci.yml validated as YAML
- [ ] Required Check jobs green
- [ ] Coverage job green (and self-heals on the occasional transient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)