### PR TITLE
fix(#1457): gate notification delivery on input-vs-submit order, not 3s idle

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1053,9 +1053,12 @@ fn pane_input_contains_submit(backend: Option<&crate::backend::Backend>, bytes: 
     let Some(b) = backend else {
         return false;
     };
-    if !matches!(b, crate::backend::Backend::ClaudeCode) {
-        return false;
-    }
+    // #1457: detect the submit key for ALL backends (was claude-only). Without
+    // this, non-claude panes never record a submit timestamp, so `draft_state`
+    // would see `submit=0` and treat every keystroke as a permanent unsent
+    // draft → notifications would NEVER deliver to them (worse than the bug
+    // this fixes). `submit_key` is `\r` for every preset; the empty-key guard
+    // below no-ops backends (Shell/Raw) that declare no submit key.
     let submit = b.preset().submit_key.as_bytes();
     if submit.is_empty() || bytes.len() < submit.len() {
         return false;
@@ -1100,28 +1103,44 @@ fn flush_notifications_for_pane<F>(home: &Path, pane: &mut Pane, mut injector: F
 where
     F: FnMut(&str) -> anyhow::Result<()>,
 {
-    if pane.pending_notification_count == 0
-        || notification_queue::is_composing(home, &pane.agent_name)
-    {
+    if pane.pending_notification_count == 0 {
         return;
     }
-    let queued = notification_queue::drain(home, &pane.agent_name);
-    if queued.is_empty() {
-        pane.pending_notification_count = 0;
-        return;
-    }
-
-    let mut failed_at = None;
-    for (idx, notification) in queued.iter().enumerate() {
-        if injector(&notification.text).is_err() {
-            failed_at = Some(idx);
-            break;
+    // #1457: gate on draft state (input-vs-submit order), not the 3s idle
+    // window. Drafting → defer everything; Abandoned → escape valve releases
+    // just the oldest (trickle, no clobbering batch); None (clean buffer) →
+    // drain the whole backlog.
+    match notification_queue::draft_state(home, &pane.agent_name) {
+        notification_queue::DraftState::Drafting => {}
+        notification_queue::DraftState::Abandoned => {
+            if let Some(notification) = notification_queue::drain_one(home, &pane.agent_name) {
+                if injector(&notification.text).is_err() {
+                    notification_queue::requeue_all(home, &pane.agent_name, &[notification]);
+                }
+            }
+            pane.pending_notification_count =
+                notification_queue::pending_count(home, &pane.agent_name);
+        }
+        notification_queue::DraftState::None => {
+            let queued = notification_queue::drain(home, &pane.agent_name);
+            if queued.is_empty() {
+                pane.pending_notification_count = 0;
+                return;
+            }
+            let mut failed_at = None;
+            for (idx, notification) in queued.iter().enumerate() {
+                if injector(&notification.text).is_err() {
+                    failed_at = Some(idx);
+                    break;
+                }
+            }
+            if let Some(idx) = failed_at {
+                notification_queue::requeue_all(home, &pane.agent_name, &queued[idx..]);
+            }
+            pane.pending_notification_count =
+                notification_queue::pending_count(home, &pane.agent_name);
         }
     }
-    if let Some(idx) = failed_at {
-        notification_queue::requeue_all(home, &pane.agent_name, &queued[idx..]);
-    }
-    pane.pending_notification_count = notification_queue::pending_count(home, &pane.agent_name);
 }
 
 /// Adjust scroll offset of the focused pane by `delta` lines (positive = up, negative = down).
@@ -1181,6 +1200,35 @@ mod tests {
     use super::*;
     use crate::layout::PaneSource;
     use crate::vterm::VTerm;
+
+    /// #1457 regression guard: submit detection must fire for ALL backends, not
+    /// just claude. If this regresses to claude-only, non-claude panes never
+    /// record a submit timestamp → `draft_state` sees `submit=0` → every
+    /// keystroke looks like a permanent unsent draft → notifications NEVER
+    /// deliver to them (strictly worse than the bug #1457 fixes).
+    #[test]
+    fn submit_detection_fires_for_all_backends() {
+        use crate::backend::Backend;
+        for b in [
+            Backend::ClaudeCode,
+            Backend::Codex,
+            Backend::Gemini,
+            Backend::KiroCli,
+            Backend::OpenCode,
+            Backend::Agy,
+        ] {
+            assert!(
+                pane_input_contains_submit(Some(&b), b"hello\r"),
+                "submit key must be detected for {b:?}"
+            );
+            assert!(
+                !pane_input_contains_submit(Some(&b), b"hello"),
+                "no submit key in plain text for {b:?}"
+            );
+        }
+        // No backend → never a submit (anonymous/unknown pane).
+        assert!(!pane_input_contains_submit(None, b"hello\r"));
+    }
 
     fn tmp_home(suffix: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -301,12 +301,12 @@ pub(crate) fn check_pane_input_not_submitted_for_agents(
     }
 }
 
-/// Sprint 54 P2-3: backend allowlist for submit detection. Hard-coded
-/// claude-only first round per dispatch — extending to other backends
-/// requires both wiring `record_submit_activity` in
-/// `app::write_to_focused` AND adding the matching arm here. Resolves
-/// the agent's backend via fleet.yaml so per-instance overrides are
-/// honoured.
+/// Backend support for submit detection. #1457 widened this from the
+/// Sprint 54 P2-3 claude-only first round to ALL backends that declare a
+/// submit key — paired with `app::pane_input_contains_submit` (which now
+/// records the submit timestamp for every backend). Resolves the agent's
+/// backend via fleet.yaml so per-instance overrides are honoured. A backend
+/// with no submit key (Shell/Raw) is unsupported (can't detect submission).
 fn pane_input_backend_supported(home: &std::path::Path, agent: &str) -> bool {
     let Ok(fleet) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) else {
         return false;
@@ -315,7 +315,7 @@ fn pane_input_backend_supported(home: &std::path::Path, agent: &str) -> bool {
         return false;
     };
     crate::backend::Backend::from_command(&resolved.backend_command)
-        .map(|b| matches!(b, crate::backend::Backend::ClaudeCode))
+        .map(|b| !b.preset().submit_key.is_empty())
         .unwrap_or(false)
 }
 
@@ -1566,8 +1566,10 @@ mod tests {
     }
 
     #[test]
-    fn pane_input_not_submitted_skips_non_claude_backend() {
-        // kiro-cli is NOT on the submit-detection allowlist (claude-only first round).
+    fn pane_input_not_submitted_now_fires_for_non_claude_backend() {
+        // #1457: submit detection widened from claude-only to ALL backends with
+        // a submit key. kiro-cli (submit_key=`\r`) is now supported, so a
+        // typed-but-not-submitted kiro pane MUST emit the diagnostic.
         let agent = "kiro-agent-pin-nonclaude";
         let home = fleet_with_backend("pin_nonclaude", agent, "kiro-cli");
         let now_ms = chrono::Utc::now().timestamp_millis();
@@ -1580,19 +1582,18 @@ mod tests {
         let mut tracks: HashMap<String, PaneInputTrack> = HashMap::new();
         check_pane_input_not_submitted_for_agents(&home, &[agent.to_string()], &mut tracks);
         let events = sink.events.lock();
-        for e in events.iter() {
-            if let crate::channel::ux_event::UxEvent::Fleet(
-                crate::channel::ux_event::FleetEvent::PaneInputNotSubmitted {
-                    agent: emitted, ..
-                },
-            ) = e
-            {
-                assert_ne!(
-                    emitted, agent,
-                    "non-claude backend must be skipped per allowlist"
-                );
-            }
-        }
+        let fired = events.iter().any(|e| {
+            matches!(
+                e,
+                crate::channel::ux_event::UxEvent::Fleet(
+                    crate::channel::ux_event::FleetEvent::PaneInputNotSubmitted { agent: emitted, .. },
+                ) if emitted == agent
+            )
+        });
+        assert!(
+            fired,
+            "non-claude backend with a submit key must now emit PaneInputNotSubmitted (#1457)"
+        );
         std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -434,7 +434,12 @@ pub(super) fn route_notification<F>(
 where
     F: FnMut(&str) -> anyhow::Result<()>,
 {
-    if crate::notification_queue::is_composing(home, agent_name) {
+    // #1457: queue (defer) whenever an unsent draft exists — both while the
+    // operator is actively composing and after the escape window (the flush
+    // path trickles the backlog out one-at-a-time once abandoned). Inject
+    // directly only when the buffer is clean (all typed input was submitted).
+    use crate::notification_queue::DraftState;
+    if crate::notification_queue::draft_state(home, agent_name) != DraftState::None {
         crate::notification_queue::enqueue(home, agent_name, notification)?;
         return Ok(());
     }

--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -4,8 +4,13 @@ use serde_json::json;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
 use std::time::Duration;
 
+/// #1457: the old fixed compose-idle window. The notification-delivery guards
+/// no longer use it (replaced by the input-vs-submit `DraftState`); it now only
+/// backs `Pane::is_composing`, a test-only helper — hence `#[cfg(test)]`.
+#[cfg(test)]
 pub const COMPOSE_IDLE_TIMEOUT: Duration = Duration::from_secs(3);
 const COMPOSE_METADATA_KEY: &str = "last_input_epoch_ms";
 /// Sprint 54 P2-3: epoch-ms timestamp of the most recent submit-key
@@ -72,21 +77,67 @@ pub fn read_input_submit_timestamps(home: &Path, agent_name: &str) -> (i64, i64)
     (typed_ms, submit_ms)
 }
 
-pub fn is_composing(home: &Path, agent_name: &str) -> bool {
-    let meta_path = home.join("metadata").join(format!("{agent_name}.json"));
-    let meta = match std::fs::read_to_string(meta_path) {
-        Ok(content) => content,
-        Err(_) => return false,
-    };
-    let value: serde_json::Value = match serde_json::from_str(&meta) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    let Some(last_input_ms) = value[COMPOSE_METADATA_KEY].as_i64() else {
-        return false;
-    };
+/// #1457: how long an unsent draft defers notification delivery before the
+/// escape valve releases it (operator likely walked away mid-draft).
+/// Overridable via `AGEND_DRAFT_ESCAPE_SECS`; default 300s (5 min).
+fn draft_escape_timeout_ms() -> i64 {
+    std::env::var("AGEND_DRAFT_ESCAPE_SECS")
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|s| *s > 0)
+        .map(|s| s.saturating_mul(1000))
+        .unwrap_or(300_000)
+}
+
+/// #1457: draft state used to gate notification delivery. Derived from the
+/// relative ORDER of the last input vs last submit keystroke (not a fixed idle
+/// window) — fixes the `is_composing` false-negative where a >3s pause mid-draft
+/// was misread as "no draft" and a notification clobbered the operator's input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DraftState {
+    /// No unsent draft: everything typed has been submitted (or never typed).
+    None,
+    /// Unsent draft present and operator likely still composing → defer all.
+    Drafting,
+    /// Unsent draft present but idle past the escape window → trickle-release.
+    Abandoned,
+}
+
+/// #1457: classify the focused pane's draft state for delivery gating.
+/// `typed > submit` means keystrokes were entered but not submitted (a live
+/// draft); `typed <= submit` (or never typed) means the buffer is clean.
+pub fn draft_state(home: &Path, agent_name: &str) -> DraftState {
+    let (typed_ms, submit_ms) = read_input_submit_timestamps(home, agent_name);
+    if typed_ms == 0 || typed_ms <= submit_ms {
+        return DraftState::None;
+    }
     let now_ms = chrono::Utc::now().timestamp_millis();
-    now_ms.saturating_sub(last_input_ms) < COMPOSE_IDLE_TIMEOUT.as_millis() as i64
+    if now_ms.saturating_sub(typed_ms) < draft_escape_timeout_ms() {
+        DraftState::Drafting
+    } else {
+        DraftState::Abandoned
+    }
+}
+
+/// #1457: pop and return the single OLDEST queued notification, leaving the
+/// rest queued. The escape valve uses this so an abandoned-draft pane trickles
+/// its backlog one-per-tick instead of clobbering the draft with a full batch.
+pub fn drain_one(home: &Path, agent_name: &str) -> Option<QueuedNotification> {
+    let path = queue_path(home, agent_name);
+    let content = std::fs::read_to_string(&path).ok()?;
+    let mut lines = content.lines();
+    let first = lines.next()?;
+    let oldest = serde_json::from_str::<QueuedNotification>(first).ok();
+    let rest: Vec<&str> = lines.collect();
+    if rest.is_empty() {
+        let _ = std::fs::remove_file(&path);
+    } else {
+        // Best-effort rewrite of the remaining lines (matches enqueue's
+        // non-atomic append model — notifications are best-effort, and the
+        // #911 dedup ledger absorbs a rare re-inject on crash mid-rewrite).
+        let _ = std::fs::write(&path, format!("{}\n", rest.join("\n")));
+    }
+    oldest
 }
 
 pub fn enqueue(home: &Path, agent_name: &str, text: &str) -> anyhow::Result<()> {
@@ -224,6 +275,75 @@ mod tests {
             submit, 0,
             "submit must stay 0 until record_submit_activity is called"
         );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1457: write raw input/submit timestamps so draft-state tests are
+    /// deterministic (no sleeps / no process-global env).
+    fn write_ts(home: &Path, agent: &str, typed_ms: i64, submit_ms: i64) {
+        if typed_ms != 0 {
+            agent_ops::save_metadata(home, agent, COMPOSE_METADATA_KEY, json!(typed_ms));
+        }
+        if submit_ms != 0 {
+            agent_ops::save_metadata(home, agent, SUBMIT_METADATA_KEY, json!(submit_ms));
+        }
+    }
+
+    /// #1457: submitted (or never-typed) buffer → None → notifications deliver.
+    /// This is the submit-then-flush release path.
+    #[test]
+    fn draft_state_none_when_submitted_or_clean() {
+        let home = tmp_home("draft_none");
+        let now = chrono::Utc::now().timestamp_millis();
+        // never typed
+        assert_eq!(draft_state(&home, "fresh"), DraftState::None);
+        // typed then submitted (submit newer) → clean
+        write_ts(&home, "submitted", now - 1000, now - 100);
+        assert_eq!(draft_state(&home, "submitted"), DraftState::None);
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1457: unsent draft, typed recently → Drafting (defer). Crucially this
+    /// holds regardless of how long the pause is (no 3s window) — the old
+    /// `is_composing` would have false-negatived after 3s of thinking.
+    #[test]
+    fn draft_state_drafting_when_typed_after_submit() {
+        let home = tmp_home("draft_drafting");
+        let now = chrono::Utc::now().timestamp_millis();
+        // typed AFTER last submit, well within the escape window — but also
+        // older than the old 3s window, proving we no longer false-negative.
+        write_ts(&home, "a", now - 60_000, now - 120_000);
+        assert_eq!(draft_state(&home, "a"), DraftState::Drafting);
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1457: unsent draft idle past the escape window → Abandoned (release).
+    /// Covers the "typed then deleted the draft / walked away" edge — the
+    /// escape valve is what bounds the otherwise-indefinite defer.
+    #[test]
+    fn draft_state_abandoned_past_escape_window() {
+        let home = tmp_home("draft_abandoned");
+        let now = chrono::Utc::now().timestamp_millis();
+        // typed 400s ago, never submitted since → past the 300s default escape.
+        write_ts(&home, "a", now - 400_000, now - 500_000);
+        assert_eq!(draft_state(&home, "a"), DraftState::Abandoned);
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1457: escape valve releases ONE oldest notification, leaving the rest
+    /// queued (no clobbering batch).
+    #[test]
+    fn drain_one_pops_oldest_leaves_rest() {
+        let home = tmp_home("drain_one");
+        enqueue(&home, "a", "first").expect("enqueue first");
+        enqueue(&home, "a", "second").expect("enqueue second");
+        enqueue(&home, "a", "third").expect("enqueue third");
+        let popped = drain_one(&home, "a").expect("one popped");
+        assert_eq!(popped.text, "first", "oldest must be released first");
+        assert_eq!(pending_count(&home, "a"), 2, "rest stay queued");
+        assert_eq!(drain_one(&home, "a").expect("second pop").text, "second");
+        assert_eq!(drain_one(&home, "a").expect("third pop").text, "third");
+        assert!(drain_one(&home, "a").is_none(), "empty after draining all");
         std::fs::remove_dir_all(home).ok();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1457 — daemon notifications clobbered the operator's in-progress draft. Both delivery guards gated on `is_composing` (last keystroke <3s ago), so any pause >3s mid-draft was misread as "no draft" and a notification flushed/injected over the operator's input.

Replace the fragile time window with a **relative-order** signal (reusing the Sprint 54 P2-3 timestamps the supervisor already proved): `draft_state` = `typed > submit` → unsent draft exists. Single source of truth.

## Changes

**Both delivery guards switched atomically** (only one → inconsistent: enqueue defers but flush drains after 3s anyway):
- `inbox/notify.rs::route_notification`: enqueue unless the buffer is clean (`DraftState::None`).
- `app/mod.rs::flush_notifications_for_pane` — 3-state: `Drafting` → defer all; `Abandoned` → escape valve releases the **oldest one only** (trickle, no clobbering batch); `None` → drain the full backlog.

**Escape valve**: `draft_state` returns `Abandoned` once an unsent draft is idle past `AGEND_DRAFT_ESCAPE_SECS` (default 300s) — so a typed-then-deleted-then-AFK draft can't defer notifications forever. This is what makes the "deleted draft still reads as draft" edge acceptable.

**🔴 CRITICAL prerequisite — all-backend submit detection** (two claude-only gates removed): `pane_input_contains_submit` (recording) and `pane_input_backend_supported` (supervisor) now use `preset().submit_key` for every backend. Without this, non-claude panes would have `submit=0` → every keystroke a permanent draft → notifications **never delivered** (worse than the bug). `submit_key` is `\r` for all presets; Shell/Raw with no key no-op.

**Internal metadata schema unchanged** — same `last_input`/`last_submit` keys, same single-threaded read-modify-write.

## Scope boundary

This fix **only** covers the **notification-delivery path** (the two guards above). The reviewer-identified **direct-inject bypasses** (API `INJECT` / CLI inject / spawn fire-and-forget / Telegram raw inject) are *deliberate* injections and a **separate concern — out of scope** here.

## Tests

- `draft_state_none_when_submitted_or_clean` / `draft_state_drafting_when_typed_after_submit` (proves no 3s false-negative) / `draft_state_abandoned_past_escape_window` (escape valve + deleted-draft edge).
- `drain_one_pops_oldest_leaves_rest` — escape releases oldest only.
- `submit_detection_fires_for_all_backends` — regression guard (claude/codex/gemini/kiro-cli/opencode/agy).
- Updated `pane_input_not_submitted_*` supervisor test: old claude-only-skip → now asserts non-claude fires.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test` — all new tests pass; only failure was an unrelated daemon-boot timing flake (`test_event_log_written`), confirmed passing in isolation
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)