### PR TITLE
fix(#1467): verify PR actually merged before returning merged:true

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -1003,6 +1003,75 @@ pub(crate) fn handle_cleanup_merged_branches(
     }
 }
 
+/// #1467: outcome of post-merge verification via `gh pr view`.
+enum MergeVerdict {
+    /// PR confirmed merged: `state == "MERGED"` AND a non-empty merge commit
+    /// oid. Carries the merge commit SHA.
+    Confirmed(String),
+    /// Not (yet) confirmed merged. May be transient (merge queue / eventual
+    /// consistency) — caller should re-query, not treat as a hard failure.
+    Unconfirmed {
+        state: String,
+        merge_state_status: String,
+    },
+}
+
+/// #1467: classify a `gh pr view --json state,mergeCommit,mergeStateStatus`
+/// payload into a [`MergeVerdict`]. PURE — tests drive it directly without
+/// shelling `gh`. A PR is confirmed merged only when GitHub reports
+/// `state == "MERGED"` AND a non-empty `mergeCommit.oid`.
+fn classify_merge_view(view: &Value) -> MergeVerdict {
+    let state = view["state"].as_str().unwrap_or("UNKNOWN").to_string();
+    let oid = view["mergeCommit"]["oid"].as_str().unwrap_or("");
+    if state == "MERGED" && !oid.is_empty() {
+        MergeVerdict::Confirmed(oid.to_string())
+    } else {
+        MergeVerdict::Unconfirmed {
+            state,
+            merge_state_status: view["mergeStateStatus"].as_str().unwrap_or("").to_string(),
+        }
+    }
+}
+
+/// #1467: after `gh pr merge` reports success, confirm the PR actually landed.
+/// Bounded poll (≤3 attempts, 2s apart) to tolerate merge-queue / eventual-
+/// consistency lag — NOT an infinite wait. Returns the last verdict seen; the
+/// first `Confirmed` short-circuits.
+fn verify_merge_landed(repo: &str, pr: u64) -> MergeVerdict {
+    let mut last = MergeVerdict::Unconfirmed {
+        state: "UNKNOWN".to_string(),
+        merge_state_status: String::new(),
+    };
+    for attempt in 0..3 {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_secs(2));
+        }
+        let out = std::process::Command::new("gh")
+            .args([
+                "pr",
+                "view",
+                &pr.to_string(),
+                "--repo",
+                repo,
+                "--json",
+                "state,mergeCommit,mergedAt,mergeStateStatus",
+            ])
+            .output();
+        match out {
+            Ok(o) if o.status.success() => {
+                if let Ok(v) = serde_json::from_slice::<Value>(&o.stdout) {
+                    match classify_merge_view(&v) {
+                        MergeVerdict::Confirmed(c) => return MergeVerdict::Confirmed(c),
+                        unconfirmed => last = unconfirmed,
+                    }
+                }
+            }
+            _ => {} // transient gh failure — keep polling, fall back to `last`
+        }
+    }
+    last
+}
+
 pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
     let pr = match args["pr"].as_u64() {
         Some(n) => n,
@@ -1116,13 +1185,37 @@ pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
         ])
         .output();
     match merge_output {
-        Ok(o) if o.status.success() => {
-            json!({
+        // #1467: `gh pr merge` exit 0 is NECESSARY but not SUFFICIENT — a
+        // merge-queue / branch-protection / eventual-consistency situation can
+        // exit 0 without the PR actually landing (observed: cross-team PRs
+        // reported merged:true while still OPEN, commits unpushed). Verify the
+        // post-condition with `gh pr view` before claiming success.
+        Ok(o) if o.status.success() => match verify_merge_landed(&repo, pr) {
+            MergeVerdict::Confirmed(merge_commit) => json!({
                 "merged": true,
                 "pr": pr,
                 "forced": force,
-            })
-        }
+                "mergeCommit": merge_commit,
+            }),
+            MergeVerdict::Unconfirmed {
+                state,
+                merge_state_status,
+            } => json!({
+                // NOT merged, but NOT a hard error either: `gh pr merge`
+                // succeeded and the PR may still land (merge queue / eventual
+                // consistency). Report the true state so the caller can re-query
+                // rather than trust a false merged:true.
+                "merged": false,
+                "pending": true,
+                "code": "merge_unconfirmed",
+                "pr": pr,
+                "state": state,
+                "mergeStateStatus": merge_state_status,
+                "hint": "gh pr merge reported success but the PR is not yet confirmed MERGED \
+                         (possible merge-queue / eventual consistency). Re-query `gh pr view` \
+                         before acting; do NOT blindly re-merge.",
+            }),
+        },
         Ok(o) => {
             json!({
                 "error": "gh pr merge failed",

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2062,3 +2062,57 @@ fn checkout_resolves_repository_path() {
     // Neither present → None (handler then returns the missing-arg error).
     assert_eq!(checkout_source(&json!({"branch": "feat-x"})), None);
 }
+
+// #1467: post-merge verification — `gh pr merge` exit 0 is not proof the PR
+// landed; only state==MERGED + a non-empty merge commit oid confirms it.
+
+#[test]
+fn merge_view_confirmed_when_merged_with_commit() {
+    let view = json!({
+        "state": "MERGED",
+        "mergeCommit": {"oid": "abc123def"},
+        "mergedAt": "2026-05-29T16:00:00Z",
+        "mergeStateStatus": "CLEAN"
+    });
+    match super::classify_merge_view(&view) {
+        super::MergeVerdict::Confirmed(oid) => assert_eq!(oid, "abc123def"),
+        super::MergeVerdict::Unconfirmed { state, .. } => {
+            panic!("expected Confirmed, got Unconfirmed(state={state})")
+        }
+    }
+}
+
+#[test]
+fn merge_view_unconfirmed_when_open_after_merge() {
+    // The #1467 bug shape: `gh pr merge` exited 0 but the PR is still OPEN
+    // (merge-queue / eventual consistency / branch-protection) — must NOT be
+    // reported as merged.
+    let view = json!({
+        "state": "OPEN",
+        "mergeCommit": null,
+        "mergeStateStatus": "BLOCKED"
+    });
+    match super::classify_merge_view(&view) {
+        super::MergeVerdict::Unconfirmed {
+            state,
+            merge_state_status,
+        } => {
+            assert_eq!(state, "OPEN");
+            assert_eq!(merge_state_status, "BLOCKED");
+        }
+        super::MergeVerdict::Confirmed(oid) => {
+            panic!("OPEN PR must not be Confirmed, got commit {oid}")
+        }
+    }
+}
+
+#[test]
+fn merge_view_unconfirmed_when_merged_state_but_no_commit() {
+    // Defensive: state says MERGED but no merge commit oid yet (race window) →
+    // still unconfirmed; don't claim merged without the commit.
+    let view = json!({"state": "MERGED", "mergeCommit": null, "mergeStateStatus": "UNKNOWN"});
+    assert!(matches!(
+        super::classify_merge_view(&view),
+        super::MergeVerdict::Unconfirmed { .. }
+    ));
+}


### PR DESCRIPTION
## Summary

Fixes #1467 (🔴 correctness). `handle_merge_repo` returned `merged:true` on `gh pr merge` exit 0 **alone** — but exit 0 is necessary, not sufficient. A merge-queue / branch-protection / eventual-consistency situation can exit 0 without the PR landing (observed: cross-team PRs reported `merged:true` while still **OPEN**, commits unpushed). A false `merged:true` silently corrupts cross-team coordination.

## Fix

After `gh pr merge` succeeds, verify the post-condition via `gh pr view --json state,mergeCommit,mergedAt,mergeStateStatus`. **Three-state** result (reconciles "don't misreport eventual-consistency as failure" with KISS):

- `state==MERGED` && non-empty `mergeCommit.oid` → `{merged:true, pr, mergeCommit, forced}`
- not yet confirmed → `{merged:false, pending:true, code:"merge_unconfirmed", state, mergeStateStatus, hint}` — **not a hard error**: `gh pr merge` succeeded and the PR may still land (merge queue); the caller should re-query, not trust a false success nor blindly re-merge.
- `gh pr merge` itself exit≠0 → `{merged:false, error, stderr}` (unchanged).

**Bounded poll** (≤3 attempts, 2s apart) tolerates merge-queue / eventual-consistency lag without an infinite wait. **No in-handler retry** of the merge (re-issuing risks double-action / races) — retry is the caller's decision.

## Design / testability

The verdict logic is a pure `classify_merge_view(&Value)` seam (no `gh` shell), unit-tested for:
- confirmed merge (MERGED + commit),
- open-after-merge / pending (the #1467 bug shape),
- merged-state-without-commit race guard.

## Contract change

This adds a `pending` / `merge_unconfirmed` state to the merge tool's return — **strictly safer**: cross-team callers receive the true state instead of a false `merged:true`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test` — full suite, 0 failures; 3 new `merge_view_*` tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)