### PR TITLE
fix(#1465,#1466): release_worktree idempotent + checkout event-log

### DIFF
--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -433,19 +433,21 @@ mod tests {
 
     #[test]
     fn release_worktree_idempotent_on_unbound_agent() {
-        // Pin: release_full's idempotence with the new defensive
-        // clear_bind_in_flight call still works — calling release on
-        // an agent with no binding returns released:false (existing
-        // contract) AND doesn't panic on the new cleanup helper.
+        // #1465: release on an agent with no binding is an idempotent
+        // SUCCESS no-op — released:true, already_released:true, no error
+        // (was released:false + "no binding" pre-#1465). Also pins that the
+        // defensive clear_bind_in_flight call doesn't panic on a clean state.
         let home = tmp_home("release-idem");
         let r1 = handle_release_worktree(&home, &json!({"instance": "never-bound"}), &None);
-        assert_eq!(r1["released"].as_bool(), Some(false));
+        assert_eq!(r1["released"].as_bool(), Some(true), "{r1}");
+        assert_eq!(r1["already_released"].as_bool(), Some(true), "{r1}");
         let r2 = handle_release_worktree(&home, &json!({"instance": "never-bound"}), &None);
         assert_eq!(
             r2["released"].as_bool(),
-            Some(false),
-            "second call same shape: {r2}"
+            Some(true),
+            "second call same idempotent shape: {r2}"
         );
+        assert_eq!(r2["already_released"].as_bool(), Some(true), "{r2}");
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -13,6 +13,35 @@ fn checkout_source(args: &Value) -> Option<&str> {
 }
 
 pub(super) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
+    let result = handle_checkout_repo_inner(home, args, instance_name);
+    log_checkout_outcome(home, args, instance_name, &result);
+    result
+}
+
+/// #1466: record every `repo action=checkout` outcome — success AND every
+/// error path — to the daemon-observable event-log, so a silently-failed
+/// checkout (e.g. the partial-worktree bootstrap race that motivated #1466:
+/// `src/` present but no `.git`) leaves a diagnosable trace. Reuses
+/// `event_log::log` (the same freeform-msg helper as `worktree_released_full`
+/// — no new schema). Best-effort: `event_log::log` is fire-and-forget, so a
+/// logging failure can never affect the checkout result (observability must
+/// not become an availability risk). Logging once at the single wrapper exit
+/// guarantees coverage of all current and future return paths.
+fn log_checkout_outcome(home: &Path, args: &Value, instance_name: &str, result: &Value) {
+    let branch = args["branch"].as_str().unwrap_or("HEAD");
+    let source = checkout_source(args).unwrap_or("");
+    let ok = result.get("error").is_none();
+    let mut msg = format!("branch={branch} source={source} ok={ok}");
+    if let Some(err) = result.get("error").and_then(Value::as_str) {
+        msg.push_str(&format!(" err={err}"));
+    }
+    if let Some(path) = result.get("path").and_then(Value::as_str) {
+        msg.push_str(&format!(" path={path}"));
+    }
+    crate::event_log::log(home, "worktree_checkout", instance_name, &msg);
+}
+
+fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) -> Value {
     let source = match checkout_source(args) {
         Some(s) => s,
         None => return json!({"error": "missing 'repository_path'"}),

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -822,6 +822,60 @@ fn checkout_bind_true_writes_binding_marker_and_arms_watch() {
 
 #[test]
 #[cfg(unix)]
+fn checkout_writes_event_log_success_and_error_1466() {
+    // #1466: every checkout outcome — success AND error — must leave a
+    // `worktree_checkout` event-log trace (observability for silent
+    // bootstrap failures: src/ present but no .git). Reuses event_log
+    // (event-log.jsonl), no new schema.
+    let home = p778_tmp_home("evlog");
+    let parent = p778_tmp_home("evlog-src-parent");
+    let source = p778_setup_source_repo(&parent, "feat/evlog");
+    let agent = "evlog-agent";
+
+    // Error path: missing repository_path → must still be logged (ok=false).
+    let err =
+        super::handle_checkout_repo(&home, &serde_json::json!({ "branch": "feat/evlog" }), agent);
+    assert!(err.get("error").is_some(), "missing repo must error: {err}");
+
+    // Success path.
+    let ok = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": "feat/evlog",
+        }),
+        agent,
+    );
+    assert!(ok.get("error").is_none(), "checkout must succeed: {ok}");
+
+    let log = std::fs::read_to_string(home.join("event-log.jsonl")).expect("event-log written");
+    let lines: Vec<&str> = log
+        .lines()
+        .filter(|l| l.contains("worktree_checkout"))
+        .collect();
+    assert!(
+        lines.len() >= 2,
+        "both checkout outcomes must be logged: {lines:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("ok=false") && l.contains("err=")),
+        "error outcome must log ok=false + err: {lines:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("ok=true") && l.contains("branch=feat/evlog")),
+        "success outcome must log ok=true + branch: {lines:?}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
 fn checkout_bind_false_default_preserves_detached_no_binding() {
     // Back-compat: existing callers (review pool, operator triage) pass
     // no `bind` arg → behavior identical to pre-#778 — detached HEAD,

--- a/src/mcp/handlers/force_release/mod.rs
+++ b/src/mcp/handlers/force_release/mod.rs
@@ -291,15 +291,16 @@ mod tests {
             result["binding_outcome"].is_object(),
             "binding_outcome must surface the release_full result: {result}"
         );
-        // No prior binding existed → release_full returns
-        // released:false + error: "no binding..." — that's the
-        // expected idempotent shape.
+        // No prior binding existed → #1465: release_full is an idempotent
+        // SUCCESS no-op (released:true, already_released:true, no error).
         let outcome = &result["binding_outcome"];
-        assert_eq!(outcome["released"].as_bool(), Some(false));
-        assert!(outcome["error"]
-            .as_str()
-            .unwrap_or("")
-            .contains("no binding"));
+        assert_eq!(outcome["released"].as_bool(), Some(true), "{result}");
+        assert_eq!(
+            outcome["already_released"].as_bool(),
+            Some(true),
+            "{result}"
+        );
+        assert!(outcome["error"].is_null(), "no-op must not error: {result}");
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -492,10 +493,12 @@ mod tests {
             .expect("helper must not error on clean state");
         assert!(!outcome.dir_existed);
         assert!(!outcome.dir_removed);
-        // release_full on missing binding returns released:false + "no binding" error.
+        // #1465: release_full on missing binding is an idempotent success
+        // no-op (released:true, already_released:true, no error).
         let bo = &outcome.binding_outcome;
-        assert_eq!(bo["released"].as_bool(), Some(false));
-        assert!(bo["error"].as_str().unwrap_or("").contains("no binding"));
+        assert_eq!(bo["released"].as_bool(), Some(true));
+        assert_eq!(bo["already_released"].as_bool(), Some(true));
+        assert!(bo["error"].is_null(), "no-op must not error: {bo}");
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -140,8 +140,9 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
 /// MCP tool: `release_worktree`. Required arg: `instance`. Returns
 /// `{released, worktree_removed, binding_removed, error}` —
 /// `released:true` clears binding; worktree removal via
-/// `git worktree remove --force` (or fallback). Idempotent — second
-/// call returns `released:false, error:"no binding for agent X"`.
+/// `git worktree remove --force` (or fallback). Idempotent (#1465) — a
+/// second call (no binding) returns `released:true, already_released:true`
+/// (success no-op, no error).
 pub(crate) fn handle_release_worktree(
     home: &Path,
     args: &Value,
@@ -290,23 +291,16 @@ mod tests {
     }
 
     #[test]
-    fn handler_idempotent_no_binding_returns_released_false() {
-        // Production-smoke: handler called via the same path the MCP layer
-        // uses (`handle_release_worktree`). With no binding, must return
-        // released:false and error indicating no binding — not panic.
+    fn handler_idempotent_no_binding_returns_success_noop() {
+        // #1465: no binding → idempotent SUCCESS no-op (released:true,
+        // already_released:true, no error; was released:false pre-#1465).
         let home = tmp_home("idem-no-binding");
         let result = handle_release_worktree(&home, &json!({"instance": "ghost"}), &None);
-        assert_eq!(
-            result["released"].as_bool(),
-            Some(false),
-            "missing binding must report released=false: {result}"
-        );
+        assert_eq!(result["released"].as_bool(), Some(true), "{result}");
+        assert_eq!(result["already_released"].as_bool(), Some(true), "{result}");
         assert!(
-            result["error"]
-                .as_str()
-                .unwrap_or("")
-                .contains("no binding"),
-            "error must indicate no binding: {result}"
+            result.get("error").is_none(),
+            "no-op must not error: {result}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -110,6 +110,11 @@ pub fn is_daemon_managed(worktree_path: &Path) -> bool {
 #[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct ReleaseOutcome {
     pub released: bool,
+    /// #1465: true when `released` is a no-op success because the agent had
+    /// no binding to begin with (release is idempotent — the target state
+    /// was already reached). Distinguishes "nothing to do, success" from an
+    /// actual teardown. Never true alongside an `error`.
+    pub already_released: bool,
     pub worktree_removed: bool,
     pub binding_removed: bool,
     pub branch_deleted: bool,
@@ -212,9 +217,11 @@ fn cleanup_merged_branch(
 /// Operator-created worktrees without the marker are left alone — surfaced
 /// as `released: false, error: "...no .agend-managed marker..."`.
 ///
-/// Idempotent: second call on the same agent sees no binding, returns
-/// `released: false, error: "no binding for agent X"` (per spec — not a
-/// fatal error).
+/// Idempotent (#1465): second call on the same agent sees no binding and
+/// returns `released: true, already_released: true` (no error) — the release
+/// target state is already reached, so it's a success no-op. A genuine
+/// cleanup failure WITH a binding present still returns `released: false` +
+/// `error` (idempotent success applies only to the nothing-to-do path).
 ///
 /// Partial cleanup: if the worktree path is missing or `git worktree remove`
 /// fails, the binding is still cleared so the agent is not stuck in a
@@ -326,7 +333,14 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
     let mut out = ReleaseOutcome::default();
 
     let Some(binding) = crate::binding::read(home, agent) else {
-        out.error = Some(format!("no binding for agent '{agent}'"));
+        // #1465: release is idempotent. "No binding" means the release
+        // target state is already reached → report a success no-op rather
+        // than an error, so automated dispatch/release can treat release as
+        // a safe always-succeeds operation. (A genuine cleanup failure WITH
+        // a binding present still returns `released:false` + `error` below —
+        // idempotent success applies ONLY to this nothing-to-do path.)
+        out.released = true;
+        out.already_released = true;
         return out;
     };
 
@@ -359,7 +373,13 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
 
     clear_binding_state(home, agent);
     out.binding_removed = true;
-    out.released = true;
+    // #1465 guardrail: only report `released` when no cleanup step failed.
+    // A `WorktreeRemoval::Failed` set `out.error` above — idempotent success
+    // must NOT mask a real execution error as success (reviewer contract:
+    // "binding present but cleanup failed → released:false + error").
+    if out.error.is_none() {
+        out.released = true;
+    }
 
     resolve_branch_cleanup(
         &binding,
@@ -966,16 +986,28 @@ mod tests {
 
     #[test]
     fn p0x_release_full_idempotent_second_call_noop() {
+        // #1465: release is idempotent. The first call tears down; the
+        // second (no binding left) is a SUCCESS no-op — `released:true,
+        // already_released:true`, no error — NOT the pre-#1465 `released:
+        // false + "no binding"` error (that encoded the bug this fixes).
         let home = tmp_home("p0x-idem");
         let repo = tmp_repo("p0x-idem-repo");
         lease(&home, &repo, "agent-i", "feat/idem").expect("lease");
         let r1 = release_full(&home, "agent-i", false);
         assert!(r1.released, "first call must release");
-        let r2 = release_full(&home, "agent-i", false);
-        assert!(!r2.released, "second call must report no release");
         assert!(
-            r2.error.as_deref().unwrap_or("").contains("no binding"),
-            "second call error must indicate no binding: {:?}",
+            !r1.already_released,
+            "first call is a real teardown, not a no-op"
+        );
+        let r2 = release_full(&home, "agent-i", false);
+        assert!(r2.released, "second call must be idempotent success");
+        assert!(
+            r2.already_released,
+            "second call must flag already_released"
+        );
+        assert!(
+            r2.error.is_none(),
+            "idempotent no-op must NOT error: {:?}",
             r2.error
         );
         std::fs::remove_dir_all(&home).ok();
@@ -984,21 +1016,23 @@ mod tests {
 
     #[test]
     fn p0x_release_full_missing_binding_graceful() {
+        // #1465: releasing an agent that never had a binding is a success
+        // no-op (release target state already reached), not an error.
         let home = tmp_home("p0x-missing-binding");
-        // No lease, no binding written. Calling release on a fresh agent.
         let outcome = release_full(&home, "ghost-agent", false);
-        assert!(!outcome.released);
-        assert!(!outcome.worktree_removed);
-        assert!(!outcome.binding_removed);
         assert!(
-            outcome
-                .error
-                .as_deref()
-                .unwrap_or("")
-                .contains("no binding"),
-            "missing binding must surface clear error: {:?}",
+            outcome.released,
+            "missing binding must be idempotent success"
+        );
+        assert!(outcome.already_released, "must flag already_released");
+        assert!(
+            outcome.error.is_none(),
+            "no-op must not error: {:?}",
             outcome.error
         );
+        // Nothing was actually torn down — no worktree/binding removal.
+        assert!(!outcome.worktree_removed);
+        assert!(!outcome.binding_removed);
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
Combined worktree/repo-handler hygiene (two small, independent fixes).

## #1465 — `release_worktree` idempotent on missing binding
`release_full()` returned `{released:false, error:"no binding for agent X"}` when the agent had no binding — breaking idempotency. Automated dispatch/release treats release as a safe always-succeeds operation, and the spurious "no binding" error surfaced in normal flow (**hit live**: a release right after a merge-auto-unbind returned "no binding" — the real-world symptom).

- `ReleaseOutcome` gains `already_released: bool`. No binding → `{released:true, already_released:true}` (release target state already reached → success no-op).
- **🔴 Guardrail (reviewer contract):** idempotent success applies **only** to the nothing-to-do path. A real cleanup failure *with* a binding present (e.g. `WorktreeRemoval::Failed`) still returns `{released:false, error}` — `released` is now gated on `out.error.is_none()` so an execution error is never masked as success.
- `comms.rs` has **no** live dependency on the old error (the §526 comment is a historical Sprint-53 narrative; no caller branches on the string).
- Updated **every entry-point test** that encoded the old contract (worktree_pool, binding_state, force_release, worktree handler) to the new shape + refreshed two stale doc comments.

## #1466 — checkout event-log
`handle_checkout_repo` wrote no event-log, so a silently-failed checkout (partial worktree: `src/` present, no `.git`) left zero trace.

- A thin wrapper logs **every** outcome (success + every error path) once at the single exit via `event_log::log` (`kind="worktree_checkout"`, reusing the same freeform-msg helper as `worktree_released_full` — **no new schema**). Body moved to `handle_checkout_repo_inner`; logging at the wrapper exit guarantees coverage of all current *and future* return paths.
- `msg = branch=… source=<repository_path> ok=true|false [err=…] [path=…]`.
- **Non-blocking:** `event_log::log` is fire-and-forget (failure → warn only), so observability can never affect the checkout result.

## Verification
- `cargo fmt --check`, `clippy --all-targets --features tray -D warnings`: clean.
- Full suite green (incl. `file_size_invariant` — `worktree.rs` kept <750 LOC).
- New test `checkout_writes_event_log_success_and_error_1466` asserts both outcomes are logged.

Closes #1465. Closes #1466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)