### PR TITLE
fix(#1473): actionable wakes bypass draft-gate + scoped Abandoned fix (#1457 regression)

### DIFF
--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -274,9 +274,32 @@ pub fn compose_aware_inject(home: &Path, agent_name: &str, notification: &str) {
     ) {
         return;
     }
+    // #1473: actionable work-delivery (ci-ready / task dispatch / query) MUST
+    // wake the agent's PTY regardless of draft state. The #1457 draft-gate only
+    // exists to stop low-priority notifications from clobbering an operator's
+    // in-progress draft — it must never defer the work the agent is here to do.
+    // (Regression: a never-submitted agent pane read as Abandoned, so ci-ready
+    // for a codex reviewer was deferred to inbox-only and it never woke.)
+    if notification_is_actionable_wake(notification) {
+        let _ = inject_with_submit(home, agent_name, notification);
+        return;
+    }
     let _ = route_notification(home, agent_name, notification, |msg| {
         inject_with_submit(home, agent_name, msg)
     });
+}
+
+/// #1473: does this notification carry an actionable work-delivery marker that
+/// must reach the PTY regardless of draft state? These are the
+/// system/orchestrator wakes the agent is expected to act on (vs. ambient
+/// notifications that may wait behind an operator draft).
+pub(crate) fn notification_is_actionable_wake(notification: &str) -> bool {
+    const ACTIONABLE_MARKERS: &[&str] = &[
+        "[ci-ready-for-action]", // daemon CI-pass handoff
+        "[delegate_task]",       // kind=task dispatch
+        "[request_information]", // kind=query
+    ];
+    ACTIONABLE_MARKERS.iter().any(|m| notification.contains(m))
 }
 
 /// #911 dedup gate predicate. Hybrid (A)+(B) suppression check for
@@ -444,4 +467,32 @@ where
         return Ok(());
     }
     injector(notification)
+}
+
+#[cfg(test)]
+mod actionable_wake_tests {
+    use super::notification_is_actionable_wake as is_actionable;
+
+    /// #1473: ci-ready / task dispatch / query are actionable work-delivery →
+    /// must bypass the draft-gate (recognized regardless of surrounding text).
+    #[test]
+    fn actionable_markers_recognized() {
+        assert!(is_actionable(
+            "[ci-ready-for-action] owner/repo@br: CI passed, your turn."
+        ));
+        assert!(is_actionable(
+            "[from:lead] [delegate_task] do X (task id: t-1)"
+        ));
+        assert!(is_actionable("[from:lead] [request_information] answer Y"));
+    }
+
+    /// Ambient notifications (no actionable marker) stay draft-gated.
+    #[test]
+    fn non_actionable_not_recognized() {
+        assert!(!is_actionable("[from:peer] just a heads-up message"));
+        assert!(!is_actionable(
+            "[system:ci] [ci-fail] owner/repo@br: failure"
+        ));
+        assert!(!is_actionable("[AGEND-MSG] size=42 (use inbox tool)"));
+    }
 }

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -878,6 +878,10 @@ pub(crate) fn handle_status_ci(home: &Path, args: &Value, instance_name: &str) -
             // that haven't run their first mergeable check yet.
             "pr_mergeable_state": watch["last_mergeable_state"].as_str(),
             "pr_mergeable_check_at": watch["last_mergeable_check_at"].as_str(),
+            // #1473 display gap: surface the stored CI-pass handoff target so
+            // `ci action=status` shows it (previously omitted → operators
+            // mis-read it as unset even when armed).
+            "next_after_ci": watch["next_after_ci"].as_str(),
         }));
     }
     let mut resp = json!({"watches": out});

--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -114,6 +114,18 @@ pub fn draft_state(home: &Path, agent_name: &str) -> DraftState {
     let now_ms = chrono::Utc::now().timestamp_millis();
     if now_ms.saturating_sub(typed_ms) < draft_escape_timeout_ms() {
         DraftState::Drafting
+    } else if submit_ms == 0 {
+        // #1473 (scoped fix): an unsent draft idle past the escape window with
+        // NO submit ever recorded is not evidence of a real operator draft —
+        // e.g. the operator poked an agent pane once but never composed a
+        // message there. Treat as None so notifications deliver normally,
+        // rather than trapping the pane in Abandoned forever. The Drafting
+        // branch above (recent typing = active draft) is untouched, so #1457's
+        // "don't clobber an in-progress draft" protection is preserved.
+        // NOTE: scoped to the Abandoned branch ON PURPOSE — a naive top-level
+        // `submit_ms == 0 → None` would mis-classify the operator's first-ever
+        // draft (recent typing, no prior submit) and re-introduce the #1457 bug.
+        DraftState::None
     } else {
         DraftState::Abandoned
     }
@@ -324,9 +336,45 @@ mod tests {
     fn draft_state_abandoned_past_escape_window() {
         let home = tmp_home("draft_abandoned");
         let now = chrono::Utc::now().timestamp_millis();
-        // typed 400s ago, never submitted since → past the 300s default escape.
+        // typed 400s ago, with a PRIOR submit (submit_ms>0) → past the 300s
+        // escape → genuine "typed then walked away" → Abandoned (trickle kept).
         write_ts(&home, "a", now - 400_000, now - 500_000);
         assert_eq!(draft_state(&home, "a"), DraftState::Abandoned);
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1473: stale typed + NEVER submitted (submit_ms==0) → None, NOT
+    /// Abandoned. This is the regression case: an agent pane the operator
+    /// poked once but never composed in (e.g. codex reviewer) was trapped in
+    /// Abandoned, deferring its wakes forever. Must deliver normally now.
+    #[test]
+    fn draft_state_never_submitted_stale_is_none() {
+        let home = tmp_home("draft_never_submit");
+        let now = chrono::Utc::now().timestamp_millis();
+        // typed 400s ago (past escape), submit_ms == 0 (never submitted).
+        write_ts(&home, "a", now - 400_000, 0);
+        assert_eq!(
+            draft_state(&home, "a"),
+            DraftState::None,
+            "never-submitted stale pane must be None, not Abandoned (#1473)"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1473 guard: the scoped fix must NOT weaken the active-draft protection.
+    /// A RECENT first-ever draft (typed now, submit_ms==0) is still Drafting —
+    /// proving a naive top-level `submit==0→None` (which would regress #1457)
+    /// was avoided.
+    #[test]
+    fn draft_state_first_draft_recent_still_drafting() {
+        let home = tmp_home("draft_first");
+        let now = chrono::Utc::now().timestamp_millis();
+        write_ts(&home, "a", now - 1_000, 0); // typed 1s ago, never submitted
+        assert_eq!(
+            draft_state(&home, "a"),
+            DraftState::Drafting,
+            "recent first draft must stay protected (Drafting), not None (#1457 preserved)"
+        );
         std::fs::remove_dir_all(home).ok();
     }
 


### PR DESCRIPTION
## Summary

Fixes #1473 — a regression from #1457. A never-submitted agent pane (operator poked it once, never composed) reads as `draft_state=Abandoned` **forever**, so its PTY wakes — including `[ci-ready-for-action]` and task dispatch — were deferred to inbox-only. **A codex reviewer never woke when its CI went green.**

Two fixes; #1457's active-draft protection is left **fully intact**.

### 1. Actionable work-delivery bypasses the draft-gate
`compose_aware_inject` now injects directly (skipping `route_notification`'s defer) when the notification is an actionable wake — `[ci-ready-for-action]`, `[delegate_task]`, `[request_information]`. The draft-gate exists only to stop *low-priority notifications* from clobbering an operator's in-progress draft; it must never defer the work the agent is here to do. (#911 dedup still applies.)

### 2. Scoped `draft_state` fix (Abandoned branch only)
In the **Abandoned** branch only, `submit_ms == 0 → None`. A stale unsent "draft" with no submit ever recorded isn't evidence of a real operator draft. The **Drafting** branch (recent typing) is untouched, so #1457's "don't clobber an in-progress draft" protection holds.

🔴 Deliberately **not** a naive top-level `submit==0 → None` — that would mis-classify the operator's *first-ever* draft (recent typing, no prior submit) and re-introduce the original #1457 bug. A test (`draft_state_first_draft_recent_still_drafting`) guards this.

### Also: display gap
`ci action=status` now surfaces `next_after_ci` (was omitted → an armed handoff looked unset).

### #4 (Abandoned trickle "didn't drain")
Verified `flush_notifications_for_pane`'s Abandoned arm **does** reach `drain_one`+inject — the symptom was the actionable ci-ready being enqueued (fix #1), not a flush bug. No flush change needed.

## Tests

- `actionable_markers_recognized` / `non_actionable_not_recognized` — classifier (work-delivery vs ambient).
- `draft_state_never_submitted_stale_is_none` — the regression case.
- `draft_state_first_draft_recent_still_drafting` — guards that the scoped fix did NOT weaken #1457's protection.
- Existing `draft_state_abandoned_past_escape_window` (submit>0) still asserts genuine "typed-then-walked-away" stays Abandoned.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test` — full suite, 0 failures; 4 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)