### PR TITLE
fix(#1474): telegram notify self-heal must not block_on inside runtime

### DIFF
--- a/src/channel/telegram/error.rs
+++ b/src/channel/telegram/error.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use super::state::{lock_state, TelegramState};
-use super::topic_registry::{create_topic_for_instance, unregister_topic};
+use super::topic_registry::{create_topic_for_instance_async, unregister_topic};
 
 /// Classify a send error as "the bound topic was deleted out from under us".
 ///
@@ -194,7 +194,31 @@ pub(crate) fn handle_supergroup_migration(
 /// Returns `Some(new_tid)` on success so callers can retry the send with
 /// the fresh topic. Returns `None` when topic creation fails (no bot
 /// token, network error, etc.) — callers should log and give up.
+///
+/// Synchronous wrapper for callers on a plain (non-runtime) thread — the
+/// reply path, which `block_on`s its own send and only reaches the
+/// topic-deleted branch when NOT inside a runtime (in-runtime sends spawn
+/// fire-and-forget and return early). Async callers — the `notify` send
+/// task, which runs inside the telegram runtime — must use
+/// [`invalidate_and_recreate_topic_async`]; calling this from there would
+/// panic with "Cannot start a runtime from within a runtime" (#1474).
 pub(crate) fn invalidate_and_recreate_topic(
+    home: &Path,
+    instance_name: &str,
+    stale_tid: i32,
+) -> Option<i32> {
+    super::state::telegram_runtime().block_on(invalidate_and_recreate_topic_async(
+        home,
+        instance_name,
+        stale_tid,
+    ))
+}
+
+/// Async core of [`invalidate_and_recreate_topic`]. Awaits topic creation
+/// instead of `block_on`, so the `notify` task (already inside the telegram
+/// runtime) can self-heal a deleted topic without the nested-runtime panic
+/// that wedged the daemon in #1474.
+pub(crate) async fn invalidate_and_recreate_topic_async(
     home: &Path,
     instance_name: &str,
     stale_tid: i32,
@@ -205,7 +229,7 @@ pub(crate) fn invalidate_and_recreate_topic(
         "invalidating stale topic and recreating"
     );
     unregister_topic(home, stale_tid);
-    create_topic_for_instance(home, instance_name)
+    create_topic_for_instance_async(home, instance_name).await
 }
 
 #[cfg(test)]
@@ -388,6 +412,43 @@ instances:
             fleet_yaml.contains("important"),
             "instance role must survive; yaml:\n{fleet_yaml}"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1474 regression: the async self-heal must be drivable from INSIDE a
+    /// tokio runtime context without the "Cannot start a runtime from within
+    /// a runtime" panic. The pre-fix path reached `block_on` transitively
+    /// (`invalidate_and_recreate_topic` → `create_topic_for_instance`); on a
+    /// runtime worker that panicked, and the `notify` send task hit it in a
+    /// tight retry loop — wedging the daemon (API/MCP timed out, TUI froze).
+    /// `block_on` here enters a runtime context (so `Handle::try_current()`
+    /// is `Ok`, the exact precondition for the panic). Note: with no channel
+    /// configured the async creation path returns early before the network
+    /// `create_forum_topic().await`, so this pins the non-network contract
+    /// (no nested `block_on` on the lookup/unregister/resolve path) and the
+    /// unregister side effect; it does not exercise the live bot call.
+    #[test]
+    fn invalidate_async_runs_inside_runtime_without_nested_runtime_panic() {
+        let home = tmp_home("invalidate-async-in-runtime");
+        register_topic(&home, 42, "agent-x").unwrap();
+        register_topic(&home, 99, "agent-y").unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(invalidate_and_recreate_topic_async(&home, "agent-x", 42));
+        assert!(
+            result.is_none(),
+            "no channel → creation fails, must not panic"
+        );
+
+        let reg = load_topic_registry(&home);
+        assert!(
+            !reg.contains_key(&42),
+            "stale topic 42 must be unregistered"
+        );
+        assert_eq!(reg.get(&99), Some(&"agent-y".to_string()));
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -102,7 +102,8 @@ fn notify_telegram_inner(
                         "#969 RC3: notify topic-deleted detected, recreating + retrying"
                     );
                     if let Some(new_tid) =
-                        invalidate_and_recreate_topic(&home_owned, &instance_owned, stale_tid)
+                        invalidate_and_recreate_topic_async(&home_owned, &instance_owned, stale_tid)
+                            .await
                     {
                         tracing::info!(
                             instance = %instance_owned,

--- a/src/channel/telegram/topic_registry.rs
+++ b/src/channel/telegram/topic_registry.rs
@@ -65,20 +65,40 @@ pub fn lookup_topic_for_instance(home: &std::path::Path, instance_name: &str) ->
 }
 
 /// Create a forum topic for a new instance.
+///
+/// Synchronous wrapper around [`create_topic_for_instance_async`]. Safe to
+/// call from plain (non-runtime) threads — boot, `tui_spawn`, MCP/api spawn
+/// handlers. **Must NOT be called from within a tokio runtime** (e.g. the
+/// `notify` send task), because `block_on` inside a runtime worker panics
+/// with "Cannot start a runtime from within a runtime". Async callers must
+/// use [`create_topic_for_instance_async`] directly.
 pub fn create_topic_for_instance(home: &std::path::Path, instance_name: &str) -> Option<i32> {
+    telegram_runtime().block_on(create_topic_for_instance_async(home, instance_name))
+}
+
+/// Async core of [`create_topic_for_instance`]. Awaits the bot call directly
+/// instead of `block_on`, so callers already inside a tokio runtime can reuse
+/// the same idempotent reuse/create/register logic without the nested-runtime
+/// panic.
+pub async fn create_topic_for_instance_async(
+    home: &std::path::Path,
+    instance_name: &str,
+) -> Option<i32> {
     // Idempotent: reuse existing topic from topics.json if present.
     if let Some(tid) = lookup_topic_for_instance(home, instance_name) {
         tracing::info!(instance = %instance_name, topic_id = tid, "reusing existing topic");
         return Some(tid);
     }
     let ch = super::resolve_channel_only_from(home).ok()?;
-    match telegram_runtime().block_on(async {
-        let bot = teloxide::Bot::new(&ch.token);
+    let bot = teloxide::Bot::new(&ch.token);
+    let created: anyhow::Result<i32> = async {
         let topic = bot
             .create_forum_topic(teloxide::types::ChatId(ch.group_id), instance_name)
             .await?;
         Ok::<i32, anyhow::Error>(topic.thread_id.0 .0)
-    }) {
+    }
+    .await;
+    match created {
         Ok(tid) => {
             tracing::info!(instance = %instance_name, topic_id = tid, "created topic");
             if let Err(e) = register_topic(home, tid, instance_name) {


### PR DESCRIPTION
## 症狀

`agend-terminal` TUI 凍結（畫面不更新、按鍵無反應），daemon process 仍存活。`agend-terminal list` / MCP `send` / `list_instances` 全部 timeout。

## 根因

`channel::telegram::notify` 的送信任務跑在 `telegram_runtime().spawn(async move {...})` 內（runtime worker thread）。當通知打到一個**已被刪除的 forum topic**（`Bad Request: message thread not found`），async block 偵測 topic-deleted 後呼叫 sync 的 `invalidate_and_recreate_topic` → `create_topic_for_instance`，後者用 `telegram_runtime().block_on(...)`。

在 runtime worker thread 上呼 `block_on` → panic `Cannot start a runtime from within a runtime`。notify 的重送把這個 panic 打成**緊迫迴圈**（每次 redelivery 一次），把 daemon 的 API handler / async runtime 持續打爆，於是所有 API/MCP 呼叫 timeout，TUI 凍結。

第一手證據：`$AGEND_HOME/app.2026-05-29.log` 自 `01:05:00` 起連續 20+ 次 `ERROR panic location=src/channel/telegram/topic_registry.rs:75:30`，每筆前面都接著 `#969 RC3: notify topic-deleted detected, recreating instance=reviewer topic=3599`。

**不是近期 commit 造成**：`git blame` 指向那行 `block_on` 來自 `b32cd29`（2026-05-04）。它潛伏至今，直到某個綁定 instance 的 topic 被刪才觸發。同類 `block_on`-in-runtime panic 史上已修過兩次（#69、#181），`topic_registry` 這條當年漏網。

## 修法

把 topic 建立拆成 **sync wrapper + async core**（與既有 `telegram_reply_send_inner` 的 runtime-aware 模式一致）：

- `topic_registry` 模組：新增 `create_topic_for_instance_async`（直接 `.await` bot 呼叫）；sync `create_topic_for_instance` 改為 `block_on(async_core)` 的薄 wrapper。
- `error` 模組：新增 `invalidate_and_recreate_topic_async`（給 in-runtime 的 notify 路徑）；sync `invalidate_and_recreate_topic` 保留為 wrapper，給 plain-thread caller（reply 路徑 —— 它在 runtime 內會 spawn 並提早 return，只在 off-runtime 才走到 topic-deleted 分支）。
- `notify` 送信任務改呼 `invalidate_and_recreate_topic_async(...).await`。

sync caller（boot / `tui_spawn` / MCP·api spawn / reply）行為不變。

## 驗證

- `cargo fmt` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- telegram 模組 tests：**97 passed / 0 failed**，含新 regression `error::tests::invalidate_async_runs_inside_runtime_without_nested_runtime_panic`（在 runtime context 內驅動 async core，`Handle::try_current()` = `Ok`，斷言不再 nested-runtime panic）。既有 `invalidate_and_recreate_*`、`create_topic_for_instance_*`、`try_telegram_reply_from_*` 全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)