### PR TITLE
fix(#1476): guard discord shared-runtime block_on + invariant + hard rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,35 @@ Hooks are per-clone. After a fresh `git clone`, install with:
 scripts/install-hooks.sh
 ```
 
+## sync→async bridge: no raw shared-runtime `block_on` (#1476)
+
+**HARD RULE.** A sync→async bridge MUST NOT call `block_on` directly on a
+long-lived shared runtime accessor (`telegram_runtime()`, `discord_runtime()`,
+`shared_ci_runtime()`, …). Those are `current_thread` runtimes, so
+`<name>_runtime().block_on(...)` panics with *"Cannot start a runtime from
+within a runtime"* the moment a caller reaches it from inside a tokio runtime.
+
+This is exactly the bug telegram hit (#1474, teloxide 0.17 made the path
+reachable → panic on the next daemon restart) and that discord had copy-pasted
+(#1476). It stays latent for weeks because it only fires when the *caller's*
+context changes, not the bridge's.
+
+**Required pattern**: route every value-returning shared-runtime call through a
+`block_on_value`-style helper that guards with
+`tokio::runtime::Handle::try_current().is_ok()` and, when already inside a
+runtime, runs the future on a `std::thread::scope` thread with a *fresh* runtime
+(never nested). See `src/channel/telegram/state.rs::block_on_value` and
+`src/channel/discord.rs::block_on_value`.
+
+Local, freshly-built runtimes (`let rt = Builder::…build()?; rt.block_on(…)`)
+are exempt — a non-shared runtime is never nested. Only the shared-accessor
+form is dangerous.
+
+Enforced by `tests/block_on_runtime_guard_invariant.rs`: any
+`<name>_runtime().block_on` not inside a Handle-guarded / scoped-thread helper
+fails CI. Adding a new channel/bridge? Add a guarded helper, never a raw
+`block_on`.
+
 ## Worktree branch policy
 
 When creating a worktree, **always use `-b <dedicated-branch>`** to create a

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -378,7 +378,7 @@ pub(crate) fn send_keepalive_patch(
     channel_id: u64,
 ) -> anyhow::Result<()> {
     let id = twilight_model::id::Id::new(channel_id);
-    discord_runtime().block_on(async { http.update_thread(id).archived(false).await })?;
+    block_on_value(async { http.update_thread(id).archived(false).await })?;
     Ok(())
 }
 
@@ -395,6 +395,37 @@ fn discord_runtime() -> &'static tokio::runtime::Runtime {
             .build()
             .expect("discord tokio runtime")
     })
+}
+
+/// #1476: run a Discord async call to completion, safe even when already inside
+/// a tokio runtime. `discord_runtime()` is a `current_thread` runtime, so
+/// calling `block_on` on it from within *any* runtime context panics with
+/// "Cannot start a runtime from within a runtime" (the same teloxide-0.17-class
+/// failure telegram hit in #1474). When a runtime is current, run the future on
+/// a dedicated scoped thread with its own fresh runtime — never nested. The
+/// non-nested fast path (shared runtime) is unchanged. Mirrors telegram's
+/// `state::block_on_value`; every shared-runtime `block_on` in this module MUST
+/// go through here (enforced by `tests/block_on_runtime_guard_invariant.rs`).
+fn block_on_value<F>(fut: F) -> F::Output
+where
+    F: std::future::Future + Send,
+    F::Output: Send,
+{
+    if tokio::runtime::Handle::try_current().is_ok() {
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("discord nested runtime")
+                    .block_on(fut)
+            })
+            .join()
+            .expect("discord nested block_on thread panicked")
+        })
+    } else {
+        discord_runtime().block_on(fut)
+    }
 }
 
 impl crate::channel::Channel for DiscordChannel {
@@ -426,7 +457,7 @@ impl crate::channel::Channel for DiscordChannel {
         let channel_id = twilight_model::id::Id::new(payload.channel_id);
         let text = msg.text;
         let cp = *payload;
-        discord_runtime().block_on(async {
+        block_on_value(async {
             let response = http.create_message(channel_id).content(&text).await?;
             let sent = response.model().await?;
             Ok(MsgRef {
@@ -456,7 +487,7 @@ impl crate::channel::Channel for DiscordChannel {
             .parse()
             .map_err(|_| anyhow::anyhow!("invalid discord message_id: {}", msg.id))?;
         let text = payload.text;
-        discord_runtime().block_on(async {
+        block_on_value(async {
             http.update_message(
                 twilight_model::id::Id::new(channel_id),
                 twilight_model::id::Id::new(mid),
@@ -483,7 +514,7 @@ impl crate::channel::Channel for DiscordChannel {
             .id
             .parse()
             .map_err(|_| anyhow::anyhow!("invalid discord message_id: {}", msg.id))?;
-        discord_runtime().block_on(async {
+        block_on_value(async {
             http.delete_message(
                 twilight_model::id::Id::new(channel_id),
                 twilight_model::id::Id::new(mid),
@@ -512,7 +543,7 @@ impl crate::channel::Channel for DiscordChannel {
             .get("category_id")
             .and_then(|v| v.parse::<u64>().ok());
         let gid = twilight_model::id::Id::new(guild_id);
-        discord_runtime().block_on(async {
+        block_on_value(async {
             let mut req = http.create_guild_channel(gid, display_name);
             if let Some(pid) = parent_id {
                 req = req.parent_id(twilight_model::id::Id::new(pid));
@@ -539,7 +570,7 @@ impl crate::channel::Channel for DiscordChannel {
             .clone()
             .ok_or_else(|| anyhow::anyhow!("discord http client not initialized"))?;
         let cid = twilight_model::id::Id::new(payload.channel_id);
-        discord_runtime().block_on(async {
+        block_on_value(async {
             http.delete_channel(cid).await?;
             Ok(())
         })

--- a/tests/block_on_runtime_guard_invariant.rs
+++ b/tests/block_on_runtime_guard_invariant.rs
@@ -1,0 +1,101 @@
+//! #1476 invariant: every shared-runtime `<name>_runtime().block_on(...)` call
+//! MUST sit inside a Handle-guarded helper, so it never panics "Cannot start a
+//! runtime from within a runtime" when reached from a tokio context.
+//!
+//! Background: telegram (#1474) and discord (#1476) shipped the SAME
+//! copy-pasted bug — a sync→async bridge calling `block_on` on a shared
+//! `current_thread` runtime, which is safe only until a caller invokes it from
+//! within a runtime (teloxide 0.17 / reqwest 0.12 made that path reachable and
+//! it panicked on the next daemon restart). The fix is a `block_on_value`-style
+//! helper guarding with `Handle::try_current` → run on a scoped thread with a
+//! fresh runtime. This test fails loud if a future bridge adds another raw
+//! shared-runtime `block_on`, closing the copy-paste hole.
+//!
+//! "Guarded" = the enclosing fn (scanning backward to its `fn` opener, capped)
+//! contains a `Handle::try_current` or `std::thread::scope`. Local-runtime
+//! `rt.block_on` (a freshly-built, never-shared runtime) does not match the
+//! `_runtime().block_on` marker and is intentionally exempt — a non-shared
+//! runtime is never nested.
+
+use std::path::{Path, PathBuf};
+
+/// Marker for the dangerous pattern: `block_on` on a shared `*_runtime()`
+/// accessor. Excludes local `rt.block_on` (own fresh runtime, never nested).
+const MARKER: &str = "_runtime().block_on";
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            collect_rs_files(&p, out);
+        } else if p.extension().and_then(|x| x.to_str()) == Some("rs") {
+            out.push(p);
+        }
+    }
+}
+
+/// A match line is guarded if a `Handle::try_current` / `thread::scope` appears
+/// between it and the start of its enclosing fn (capped at 40 lines back).
+fn enclosing_fn_is_guarded(lines: &[&str], match_idx: usize) -> bool {
+    let mut i = match_idx;
+    let mut scanned = 0;
+    while i > 0 && scanned < 40 {
+        i -= 1;
+        scanned += 1;
+        let line = lines[i];
+        if line.contains("Handle::try_current") || line.contains("thread::scope") {
+            return true;
+        }
+        let t = line.trim_start();
+        // Reached the enclosing fn opener without finding a guard.
+        if t.starts_with("fn ")
+            || t.starts_with("pub fn ")
+            || t.starts_with("pub(crate) fn ")
+            || t.starts_with("pub(super) fn ")
+            || t.starts_with("async fn ")
+        {
+            return false;
+        }
+    }
+    false
+}
+
+#[test]
+fn shared_runtime_block_on_must_be_handle_guarded() {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src, &mut files);
+    assert!(!files.is_empty(), "no .rs files found under src/");
+
+    let mut violations = Vec::new();
+    for f in &files {
+        let Ok(content) = std::fs::read_to_string(f) else {
+            continue;
+        };
+        let lines: Vec<&str> = content.lines().collect();
+        for (idx, line) in lines.iter().enumerate() {
+            if !line.contains(MARKER) {
+                continue;
+            }
+            // Skip comment/doc lines that merely mention the pattern.
+            let t = line.trim_start();
+            if t.starts_with("//") || t.starts_with("*") {
+                continue;
+            }
+            if !enclosing_fn_is_guarded(&lines, idx) {
+                violations.push(format!("{}:{}: {}", f.display(), idx + 1, line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "#1476: unguarded shared-runtime block_on found — every `<name>_runtime().block_on` \
+         must go through a Handle-guarded helper (e.g. `block_on_value`, mirroring telegram \
+         state.rs / discord.rs) so it can't panic from within a tokio runtime:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary

RCA of the morning restart (#1474 telegram panic + cron deadlock) flagged that `discord.rs` had the **same copy-pasted bug** telegram hit: 6 raw `discord_runtime().block_on(...)` calls. `discord_runtime()` is a `current_thread` runtime, so `block_on` on it from within any tokio runtime panics *"Cannot start a runtime from within a runtime"*. Latent only because discord isn't active in this fleet — it would panic on the next restart once enabled. (Independent cross-verification of dev's finding: confirmed, 6 sites, same Channel-dispatch path.)

## Changes

1. **`discord::block_on_value`** — mirrors telegram's `state::block_on_value`: guards with `Handle::try_current().is_ok()` and, when already in a runtime, runs the future on a `std::thread::scope` thread with a *fresh* runtime (never nested); shared-runtime fast path unchanged. All **6 sites** routed through it (`send_keepalive_patch`, `send`, `edit`, `delete`, `create_channel`, `delete_channel`). `discord.rs:360` (keepalive *spawned thread*, not a runtime context) left as-is.
2. **`tests/block_on_runtime_guard_invariant.rs`** — file-scan invariant: any `<name>_runtime().block_on` not inside a `Handle::try_current` / `thread::scope` helper **fails CI**. Scans *files* (not compilation), so it covers the feature-gated discord module too. Verified it flags a raw site and goes green once guarded. Closes the copy-paste hole for the next bridge.
3. **CLAUDE.md hard rule** — sync→async bridges must route shared-runtime `block_on` through a `block_on_value`-style helper; no raw `*_runtime().block_on`.

Telegram side (#1474 / e849a27) is already fixed — untouched.

## Note (out of scope)

`--features discord` has a **pre-existing** `twilight_model` version conflict (9 errors on origin/main, unrelated to this change; hits the un-touched keepalive line). The default CI build excludes discord and is clean. This PR fixes the `block_on` pattern + locks it in via the invariant; the twilight build break is a separate issue worth a follow-up.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` (default build, clean)
- [x] `cargo test` — full suite, 0 failures; invariant green
- [x] Invariant proven: flags a raw `discord_runtime().block_on` site, green once guarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)