### PR TITLE
fix(#1479): team-group on restart fallback + robust session.json save

### DIFF
--- a/src/app/api_server.rs
+++ b/src/app/api_server.rs
@@ -7,7 +7,7 @@
 //! tab during first-time startup (no session.json present).
 
 use crate::agent::AgentRegistry;
-use crate::layout::{Layout, Tab};
+use crate::layout::Layout;
 
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -90,6 +90,11 @@ pub(super) fn noop_guard() -> ApiGuard {
 }
 
 /// Auto-start all fleet instances as tabs. Returns true if any were spawned.
+///
+/// #1479: places agents **grouped by team** (via
+/// `session::place_agents_team_grouped`) rather than one naive tab per agent,
+/// so a hard restart with no `session.json` lands the same team-grouped layout
+/// as a live `create_instance` and the session-restore Rule-3 path.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn auto_start_fleet(
     fleet_path: &Path,
@@ -110,9 +115,11 @@ pub(super) fn auto_start_fleet(
         return false;
     }
     names.sort();
-    let mut spawned = false;
-    for name in &names {
-        if let Some(resolved) = fleet.resolve_instance(name) {
+
+    let mut pane_builder =
+        |sp: &super::session::SessionPane, layout: &mut Layout| -> Option<crate::layout::Pane> {
+            let name = sp.fleet_instance_name.as_deref()?;
+            let resolved = fleet.resolve_instance(name)?;
             match super::pane_factory::create_pane_from_resolved(
                 name,
                 &resolved,
@@ -125,14 +132,13 @@ pub(super) fn auto_start_fleet(
                 name_counter,
                 crate::backend::SpawnMode::Resume,
             ) {
-                Ok(pane) => {
-                    let tab_name = pane.agent_name.clone();
-                    layout.add_tab(Tab::new(tab_name.to_string(), pane));
-                    spawned = true;
+                Ok(pane) => Some(pane),
+                Err(e) => {
+                    tracing::error!(instance = name, error = %e, "fleet auto-start failed");
+                    None
                 }
-                Err(e) => tracing::error!(instance = name, error = %e, "fleet auto-start failed"),
             }
-        }
-    }
-    spawned
+        };
+
+    super::session::place_agents_team_grouped(home, &names, &mut pane_builder, layout)
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -339,6 +339,14 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // enough that the readdir cost is trivial.
     let mut last_remote_sync = std::time::Instant::now();
 
+    // #1479: throttled, change-gated session.json persistence. Graceful exit
+    // already saves (so a hard crash kept the OLD layout); this periodically
+    // persists the current layout (incl. move_pane / split / close) so a
+    // kill -9 / power loss preserves what's on screen. `last_session_json`
+    // caches the last write to skip no-op rewrites.
+    let mut last_session_save = std::time::Instant::now();
+    let mut last_session_json: Option<String> = None;
+
     // fire-and-forget: blocks in crossterm::event::read(); terminated by process exit.
     let (event_tx, event_rx) = crossbeam_channel::unbounded::<Event>();
     std::thread::Builder::new()
@@ -723,6 +731,14 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 }
             }
             default(std::time::Duration::from_millis(50)) => {
+                // #1479: throttled, change-gated session persistence (every
+                // 10s). Cheap when the layout is unchanged (no write); on a
+                // change it preserves the on-screen layout against a hard
+                // crash. Graceful exit still saves unconditionally below.
+                if last_session_save.elapsed() >= std::time::Duration::from_secs(10) {
+                    last_session_save = std::time::Instant::now();
+                    session::save_session_if_changed(&home, &layout, &mut last_session_json);
+                }
                 // Periodic redraw for state updates. In Attached mode, also
                 // poll the daemon's `*.port` directory every 2s and open a
                 // tab for each newly-appeared remote agent (hot-reload

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -621,7 +621,10 @@ mod tests {
     fn save_session_if_changed_writes_only_on_change() {
         let home = tmp_home("save-if-changed");
         let mut layout = Layout::new();
-        layout.add_tab(Tab::new("t1".to_string(), test_pane(1, "dev", Some("dev-1"))));
+        layout.add_tab(Tab::new(
+            "t1".to_string(),
+            test_pane(1, "dev", Some("dev-1")),
+        ));
         let mut cache: Option<String> = None;
 
         assert!(
@@ -633,7 +636,10 @@ mod tests {
             !save_session_if_changed(&home, &layout, &mut cache),
             "unchanged layout must NOT rewrite"
         );
-        layout.add_tab(Tab::new("t2".to_string(), test_pane(2, "rev", Some("rev-1"))));
+        layout.add_tab(Tab::new(
+            "t2".to_string(),
+            test_pane(2, "rev", Some("rev-1")),
+        ));
         assert!(
             save_session_if_changed(&home, &layout, &mut cache),
             "changed layout must write"

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 ///
 /// Single-closure design avoids dual-mutable-borrow on shared state
 /// (`name_counter` and `registry` in Owned mode).
-type PaneBuilder<'a> = dyn FnMut(&SessionPane, &mut Layout) -> Option<Pane> + 'a;
+pub(super) type PaneBuilder<'a> = dyn FnMut(&SessionPane, &mut Layout) -> Option<Pane> + 'a;
 
 /// Saved session layout for persistence across restarts.
 #[derive(Serialize, Deserialize)]
@@ -68,11 +68,11 @@ fn default_ratio() -> f32 {
 
 /// Layout-only pane info. Agent config comes from fleet.yaml on restore.
 #[derive(Serialize, Deserialize)]
-struct SessionPane {
+pub(super) struct SessionPane {
     /// Fleet instance name (key in fleet.yaml). None for shell panes.
-    fleet_instance_name: Option<String>,
+    pub(super) fleet_instance_name: Option<String>,
     /// User-defined display name override.
-    display_name: Option<String>,
+    pub(super) display_name: Option<String>,
 }
 
 /// Sync fleet.yaml to match current pane state on detach.
@@ -115,25 +115,53 @@ pub(super) fn sync_fleet_yaml(home: &Path, layout: &Layout) {
 }
 
 /// Save current session layout to disk. Only stores layout geometry, not agent config.
-pub(super) fn save_session(home: &Path, layout: &Layout) {
-    let tabs: Vec<SessionTab> = layout
-        .tabs
-        .iter()
-        .map(|tab| SessionTab {
-            name: tab.name.clone(),
-            root: save_node(tab.root()),
-        })
-        .collect();
-
+/// Serialize the current layout to the pretty-printed `session.json` form.
+fn serialize_session(layout: &Layout) -> Option<String> {
     let session = Session {
         active_tab: layout.active,
-        tabs,
+        tabs: layout
+            .tabs
+            .iter()
+            .map(|tab| SessionTab {
+                name: tab.name.clone(),
+                root: save_node(tab.root()),
+            })
+            .collect(),
     };
+    serde_json::to_string_pretty(&session).ok()
+}
 
+pub(super) fn save_session(home: &Path, layout: &Layout) {
+    if let Some(json) = serialize_session(layout) {
+        let path = home.join("session.json");
+        let _ = std::fs::write(&path, &json);
+        tracing::info!(path = %path.display(), "session saved");
+    }
+}
+
+/// #1479: write `session.json` only when the serialized layout differs from the
+/// last write (`cache`). Called on a throttled main-loop tick so a hard crash
+/// (kill -9 / power loss) still preserves the actual on-screen layout — graceful
+/// exit's `save_session` only covers clean shutdowns. Change-gated against the
+/// exact serialized form (no signature drift), so it never rewrites the file
+/// when nothing changed. Returns true if a write happened.
+pub(super) fn save_session_if_changed(
+    home: &Path,
+    layout: &Layout,
+    cache: &mut Option<String>,
+) -> bool {
+    let Some(json) = serialize_session(layout) else {
+        return false;
+    };
+    if cache.as_deref() == Some(json.as_str()) {
+        return false;
+    }
     let path = home.join("session.json");
-    if let Ok(json) = serde_json::to_string_pretty(&session) {
-        let _ = std::fs::write(&path, json);
-        tracing::info!(path = %path.display(), tabs = session.tabs.len(), "session saved");
+    if std::fs::write(&path, &json).is_ok() {
+        *cache = Some(json);
+        true
+    } else {
+        false
     }
 }
 
@@ -241,6 +269,7 @@ pub(super) fn restore_with_reconciliation(
     }
 
     // No session.json or empty → rule 1: auto-start fleet (Owned-only).
+    // #1479: auto_start_fleet now team-groups via `place_agents_team_grouped`.
     if !agent_source.is_empty() {
         return super::api_server::auto_start_fleet(
             fleet_path,
@@ -367,11 +396,40 @@ fn apply_session_layout(
     // grouped by team where teams are defined in fleet.yaml.
     let mut unplaced: Vec<String> = agent_source.difference(&placed).cloned().collect();
     unplaced.sort();
+    place_agents_team_grouped(home, &unplaced, pane_builder, layout);
 
+    if session.active_tab < layout.tabs.len() {
+        layout.active = session.active_tab;
+    }
+
+    if !layout.tabs.is_empty() {
+        let _ = std::fs::remove_file(&session_path);
+        tracing::info!(
+            tabs = layout.tabs.len(),
+            "session restored with reconciliation"
+        );
+        return true;
+    }
+
+    false
+}
+
+/// #1479: place a flat list of agents into tabs **grouped by team** (members of
+/// the same fleet.yaml team share one tab, orchestrator-first; teamless agents
+/// each get their own tab). Shared by the session-restore Rule-3 path and the
+/// no-session-json `auto_start_fleet` fallback, so a hard restart (session.json
+/// absent) groups identically to a live `create_instance`. `agents` is expected
+/// pre-sorted. Returns true if any pane was placed.
+pub(super) fn place_agents_team_grouped(
+    home: &Path,
+    agents: &[String],
+    pane_builder: &mut PaneBuilder<'_>,
+    layout: &mut Layout,
+) -> bool {
     let teams = crate::teams::list_all(home);
     let mut team_members: HashMap<String, Vec<String>> = HashMap::new();
     let mut standalone = Vec::new();
-    for name in &unplaced {
+    for name in agents {
         if let Some(team) = teams.iter().find(|t| t.members.contains(name)) {
             team_members
                 .entry(team.name.clone())
@@ -382,6 +440,7 @@ fn apply_session_layout(
         }
     }
 
+    let mut placed_any = false;
     for (team_name, members) in &team_members {
         let team = teams.iter().find(|t| t.name == *team_name);
         let orchestrator = team.and_then(|t| t.orchestrator.as_deref());
@@ -399,6 +458,7 @@ fn apply_session_layout(
                 display_name: None,
             };
             if let Some(pane) = pane_builder(&synthetic_sp, layout) {
+                placed_any = true;
                 if !tab_created {
                     layout.add_tab(Tab::new(team_name.clone(), pane));
                     tab_created = true;
@@ -415,25 +475,12 @@ fn apply_session_layout(
             display_name: None,
         };
         if let Some(pane) = pane_builder(&synthetic_sp, layout) {
+            placed_any = true;
             let tab_name = pane.agent_name.to_string();
             layout.add_tab(Tab::new(tab_name, pane));
         }
     }
-
-    if session.active_tab < layout.tabs.len() {
-        layout.active = session.active_tab;
-    }
-
-    if !layout.tabs.is_empty() {
-        let _ = std::fs::remove_file(&session_path);
-        tracing::info!(
-            tabs = layout.tabs.len(),
-            "session restored with reconciliation"
-        );
-        return true;
-    }
-
-    false
+    placed_any
 }
 
 /// Walk a SessionNode tree, building panes via the caller's closures. Returns
@@ -523,6 +570,75 @@ mod tests {
             std::env::temp_dir().join(format!("agend-session-test-{}-{}", tag, std::process::id()));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    /// #1479: `place_agents_team_grouped` puts team members in one tab and
+    /// teamless agents in their own — the grouping a hard restart (no
+    /// session.json) must reproduce instead of one naive tab per agent.
+    #[test]
+    fn place_agents_team_grouped_groups_team_members() {
+        let home = tmp_home("team-group");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  dev-1: {}\n  dev-2: {}\n  solo: {}\nteams:\n  dev:\n    orchestrator: dev-1\n    members: [dev-1, dev-2]\n",
+        )
+        .expect("write fleet.yaml");
+
+        let mut layout = Layout::new();
+        let mut next_id = 0;
+        let mut pane_builder = |sp: &SessionPane, _l: &mut Layout| -> Option<Pane> {
+            next_id += 1;
+            sp.fleet_instance_name
+                .as_deref()
+                .map(|n| test_pane(next_id, n, Some(n)))
+        };
+        let agents = vec!["dev-1".to_string(), "dev-2".to_string(), "solo".to_string()];
+        let placed = place_agents_team_grouped(&home, &agents, &mut pane_builder, &mut layout);
+
+        assert!(placed, "agents must be placed");
+        assert_eq!(layout.tabs.len(), 2, "team 'dev' (1 tab) + 'solo' (1 tab)");
+        let dev_tab = layout
+            .tabs
+            .iter()
+            .find(|t| t.name == "dev")
+            .expect("a tab named after the team");
+        assert_eq!(
+            dev_tab.root().pane_ids().len(),
+            2,
+            "both dev team members share the 'dev' tab"
+        );
+        let solo_tab = layout
+            .tabs
+            .iter()
+            .find(|t| t.name == "solo")
+            .expect("teamless agent gets its own tab");
+        assert_eq!(solo_tab.root().pane_ids().len(), 1);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1479: throttled save writes only when the layout changed.
+    #[test]
+    fn save_session_if_changed_writes_only_on_change() {
+        let home = tmp_home("save-if-changed");
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("t1".to_string(), test_pane(1, "dev", Some("dev-1"))));
+        let mut cache: Option<String> = None;
+
+        assert!(
+            save_session_if_changed(&home, &layout, &mut cache),
+            "first call must write"
+        );
+        assert!(home.join("session.json").exists());
+        assert!(
+            !save_session_if_changed(&home, &layout, &mut cache),
+            "unchanged layout must NOT rewrite"
+        );
+        layout.add_tab(Tab::new("t2".to_string(), test_pane(2, "rev", Some("rev-1"))));
+        assert!(
+            save_session_if_changed(&home, &layout, &mut cache),
+            "changed layout must write"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1479 — team grouping was lost after a restart. When `session.json` is absent (hard restart / first boot), the no-session fallback `auto_start_fleet` placed **one naive tab per agent** with zero team grouping, even though live `create_instance` and the session-restore Rule-3 path both group by team. (RCA confirmed: `session.json` was empirically absent at the failing restart, so the fallback ran — this is the fallback's gap, not a new-persistence problem.)

**No new persistence file** — reuse what already exists (`session.json` + the Rule-3 team-grouping in `session.rs`), per the dialectic. dev's proposed `layout.json` would duplicate session.json.

## Changes

**(A) Fallback team-grouping.** Extracted the Rule-3 placement into `session::place_agents_team_grouped` (members of a fleet.yaml team → one tab, orchestrator-first; teamless → own tab). `auto_start_fleet` now calls it instead of the per-agent `Tab::new` loop, so the no-session fallback groups **identically to live create_instance** and the restore path. (Single source of truth — the Rule-3 path now calls the same helper.)

**(B) Robust save.** Graceful exit already saved `session.json` (so a hard crash kept the *old* layout). Added `save_session_if_changed` — a throttled (10s), change-gated save on the main-loop tick — so a `kill -9` / power loss preserves the **current** on-screen layout (incl. `move_pane` / split / close). Change-gated against the exact serialized form (no signature drift); never rewrites when nothing changed.

## Tests

- `place_agents_team_grouped_groups_team_members` — team members share one tab, teamless agent gets its own.
- `save_session_if_changed_writes_only_on_change` — writes on first call + on change, skips an unchanged layout.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test` — full suite, 0 failures
- [ ] CI green
- [ ] Operator: confirm team grouping survives a `stop && start` restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)