### PR TITLE
chore: code-review cleanup — force_release param rename + stale doc fixes

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -232,9 +232,10 @@ fn run_loop(
 /// state. Read-only — emits a `FleetEvent::PaneInputNotSubmitted` when
 /// the threshold is exceeded but does NOT inject prompts, mutate agent
 /// state, or touch the router layer (router = `src/channel/router/*`,
-/// Sprint 49/52 territory). Backend allowlist (claude only, first
-/// round) avoids false-positive flood for backends without
-/// `record_submit_activity` wiring.
+/// Sprint 49/52 territory). Backend support is now all backends that
+/// declare a submit key (via `preset().submit_key`) — #1457 widened it
+/// from the original claude-only first round once `record_submit_activity`
+/// was wired for every backend.
 ///
 /// Threshold defaults to 60s; override via env
 /// `AGEND_PANE_INPUT_THRESHOLD_SECS`.

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -261,9 +261,11 @@ pub fn notify_agent_with_attachments(
     }
 }
 
-/// Compose-aware notification delivery: checks `is_composing` and enqueues
-/// if the target agent is mid-typing, otherwise injects **with** submit_key
-/// so idle agents actually wake up on the incoming notification.
+/// Compose-aware notification delivery: gates on `draft_state` (the
+/// input-vs-submit signal, #1457) and enqueues when the target agent has an
+/// unsent draft, otherwise injects **with** submit_key so idle agents wake up.
+/// Actionable work-delivery (`notification_is_actionable_wake`, #1473) bypasses
+/// the gate and always injects.
 pub fn compose_aware_inject(home: &Path, agent_name: &str, notification: &str) {
     // #911 dedup gate
     if should_suppress_911_reinject_with_ledger(

--- a/src/mcp/handlers/force_release/gc.rs
+++ b/src/mcp/handlers/force_release/gc.rs
@@ -412,7 +412,7 @@ mod tests {
             &json!({
                 "instance": "dev826",
                 "branch": "feat/826",
-                "source_repo": source_repo.display().to_string(),
+                "repository_path": source_repo.display().to_string(),
             }),
             &None,
         );
@@ -478,7 +478,7 @@ mod tests {
             &json!({
                 "instance": "dev826",
                 "branch": "feat/826",
-                "source_repo": source_repo.display().to_string(),
+                "repository_path": source_repo.display().to_string(),
             }),
             &None,
         );
@@ -491,7 +491,7 @@ mod tests {
             &json!({
                 "instance": "dev826",
                 "branch": "feat/826",
-                "source_repo": source_repo.display().to_string(),
+                "repository_path": source_repo.display().to_string(),
             }),
             &None,
         );
@@ -531,7 +531,7 @@ mod tests {
             &json!({
                 "instance": agent,
                 "branch": "feat/aaa",
-                "source_repo": repo_a.display().to_string(),
+                "repository_path": repo_a.display().to_string(),
             }),
             &None,
         );
@@ -547,7 +547,7 @@ mod tests {
             &json!({
                 "instance": agent,
                 "branch": "feat/bbb",
-                "source_repo": repo_b.display().to_string(),
+                "repository_path": repo_b.display().to_string(),
             }),
             &None,
         );
@@ -610,7 +610,7 @@ mod tests {
             &json!({
                 "instance": "agent_x826",
                 "branch": "feat/x",
-                "source_repo": source_repo.display().to_string(),
+                "repository_path": source_repo.display().to_string(),
             }),
             &None,
         );

--- a/src/mcp/handlers/force_release/mod.rs
+++ b/src/mcp/handlers/force_release/mod.rs
@@ -88,10 +88,12 @@ pub(crate) fn handle_force_release_worktree(
         });
     }
 
-    // #826: optional operator-supplied `source_repo` arg. When
+    // #826: optional operator-supplied `repository_path` arg. When
     // present, L2 skips enumeration and goes straight to the named
     // repo. When absent, L2 enumerates daemon-managed candidates.
-    let source_repo_hint = args["source_repo"]
+    // #1461 cleanup: renamed from `source_repo` to the cross-tool
+    // standard `repository_path` (matches checkout / bind_self / team).
+    let source_repo_hint = args["repository_path"]
         .as_str()
         .filter(|s| !s.is_empty())
         .map(PathBuf::from);

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -343,7 +343,8 @@ pub(crate) fn def_force_release_worktree() -> Value {
     json!({"name": "force_release_worktree", "description": "Force-release a stale daemon-managed worktree directory — cleans <home>/worktrees/<agent>/<branch>/ on disk + runs the standard release_full to clear any lingering binding state. Idempotent. Refuses to clean paths outside the daemon worktree pool. Sprint 59 Wave 1 PR-5 emergency cherry-pick supporting Q2=(C) bypass-free permanent protocol.",
         "inputSchema": {"type": "object", "properties": {
             "instance": {"type": "string", "description": "Name of the existing instance (worktree owner)"},
-            "branch": {"type": "string", "description": "Branch name (worktree subdirectory)"}
+            "branch": {"type": "string", "description": "Branch name (worktree subdirectory)"},
+            "repository_path": {"type": "string", "description": "#826: optional local filesystem path to the source repository. When given, candidate enumeration is skipped and cleanup targets this repo directly. Standard cross-tool name (matches checkout / bind_self / team update)."}
         }, "required": ["instance", "branch"]}})
 }
 


### PR DESCRIPTION
## Summary

Three nits from tonight's fresh-eyes review (MCP-layer audit + reviewer-2). Cleanup only — no runtime logic change beyond one MCP param name.

1. **`force_release_worktree` param rename** (MCP audit): the optional `source_repo` arg → **`repository_path`** — the lone MCP repo-path param that #1461's no-alias rename missed; now consistent with checkout / bind_self / team-update. Also **added it to `def_force_release_worktree`'s schema** — it was read by the handler but undeclared, so LLM callers couldn't discover it. Pure rename, **no alias** (the arg was never in the schema → the only callers were the gc tests, migrated to the new key).
2. **`supervisor.rs` doc** (reviewer-2): "claude only, first round" was stale — #1457 widened submit detection to all backends via `preset().submit_key`. Updated.
3. **`notify.rs` doc** (reviewer-2): `compose_aware_inject` said "checks `is_composing`" — #1457 replaced that with the `draft_state` (input-vs-submit) gate; #1473 added the actionable-wake bypass. Updated.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test` — full suite, 0 failures (force_release gc tests migrated to `repository_path`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)