### PR TITLE
feat(#1487): operator-TZ now= field in agent message headers

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -495,7 +495,17 @@ fn init_daemon_services(
     home: &Path,
     telegram: Option<Arc<dyn crate::channel::Channel>>,
 ) -> anyhow::Result<DaemonContext> {
-    crate::daemon_config::init(crate::daemon_config::DaemonConfig::default());
+    // #1487: source the operator timezone from fleet.yaml `display_timezone:`
+    // (reusing the same operator-tz concept as ci_watch / display_time) for the
+    // `now=` header field; `None`/empty → system local time.
+    let display_timezone = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+        .ok()
+        .and_then(|f| f.display_timezone)
+        .filter(|s| !s.is_empty());
+    crate::daemon_config::init(crate::daemon_config::DaemonConfig {
+        display_timezone,
+        ..crate::daemon_config::DaemonConfig::default()
+    });
 
     const SKILLS_STAGE_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
     crate::bootstrap::time_step("skills::cleanup_stale_stages", || {

--- a/src/daemon_config.rs
+++ b/src/daemon_config.rs
@@ -14,6 +14,11 @@ use std::sync::OnceLock;
 pub struct DaemonConfig {
     /// Feature flag: pointer-only inbox injection (replaces AGEND_POINTER_ONLY_INJECT env var).
     pub pointer_only_inject: bool,
+    /// #1487: operator-facing IANA timezone for the `now=` timestamp injected
+    /// into agent message headers. Loaded from fleet.yaml `display_timezone:` at
+    /// boot (see `init_daemon_services`); reuses the same operator-tz concept as
+    /// `display_time::format_local_short`. `None` → system local time.
+    pub display_timezone: Option<String>,
 }
 
 impl Default for DaemonConfig {
@@ -23,6 +28,7 @@ impl Default for DaemonConfig {
                 .ok()
                 .map(|v| v == "1")
                 .unwrap_or(false),
+            display_timezone: None,
         }
     }
 }
@@ -55,7 +61,15 @@ mod tests {
     fn daemon_config_with_overrides() {
         let cfg = DaemonConfig {
             pointer_only_inject: true,
+            display_timezone: Some("Europe/Paris".to_string()),
         };
         assert!(cfg.pointer_only_inject);
+        assert_eq!(cfg.display_timezone.as_deref(), Some("Europe/Paris"));
+    }
+
+    /// #1487: display_timezone defaults to None (→ system local) when unset.
+    #[test]
+    fn daemon_config_display_timezone_defaults_to_none() {
+        assert_eq!(DaemonConfig::default().display_timezone, None);
     }
 }

--- a/src/display_time.rs
+++ b/src/display_time.rs
@@ -47,6 +47,32 @@ pub fn format_local_short(rfc3339: &str, tz: Option<&str>) -> String {
     }
 }
 
+/// #1487: format a UTC instant in the operator display timezone as a
+/// SPACE-FREE RFC 3339 string with year + offset, e.g.
+/// `2026-05-30T16:12:34+08:00`.
+///
+/// Unlike [`format_local_short`] (`MM-DD HH:MM` — spaced, no year, no
+/// offset), this shape is safe to embed as a `now=` field inside the
+/// space-delimited `[AGEND-MSG]` header (agents split fields on spaces),
+/// and it carries the absolute instant plus zone so an agent can reason
+/// about the operator's wall-clock time unambiguously.
+///
+/// `tz` semantics match `format_local_short`: `None` → `chrono::Local`
+/// (system tz); invalid IANA → warn-once + `chrono::Local` fallback.
+pub fn format_iso_offset(now: chrono::DateTime<chrono::Utc>, tz: Option<&str>) -> String {
+    const FMT: &str = "%Y-%m-%dT%H:%M:%S%:z";
+    match tz {
+        Some(iana) => match iana.parse::<chrono_tz::Tz>() {
+            Ok(tz) => now.with_timezone(&tz).format(FMT).to_string(),
+            Err(_) => {
+                warn_invalid_iana_once(iana);
+                now.with_timezone(&chrono::Local).format(FMT).to_string()
+            }
+        },
+        None => now.with_timezone(&chrono::Local).format(FMT).to_string(),
+    }
+}
+
 /// One-shot warn per invalid IANA name to surface fleet.yaml typos
 /// without spamming logs on every render frame.
 fn warn_invalid_iana_once(iana: &str) {
@@ -66,7 +92,7 @@ fn warn_invalid_iana_once(iana: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::format_local_short;
+    use super::{format_iso_offset, format_local_short};
 
     /// `Z` form parses → render-local conversion → `MM-DD HH:MM` shape
     /// (5 chars + space + 5 chars = 11 chars). Shape-only assertion so
@@ -148,5 +174,38 @@ mod tests {
             .format("%m-%d %H:%M")
             .to_string();
         assert_eq!(out_none, expected, "None tz must match chrono::Local");
+    }
+
+    // ─── #1487 format_iso_offset (now= header field) ───────────────────
+
+    /// `Asia/Taipei` converts UTC → UTC+8 and renders the exact
+    /// space-free RFC 3339 + offset string the `now=` header field needs.
+    #[test]
+    fn format_iso_offset_asia_taipei_is_utc_plus_8_space_free() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-30T08:12:34Z")
+            .expect("known-good RFC 3339 fixture")
+            .with_timezone(&chrono::Utc);
+        let out = format_iso_offset(now, Some("Asia/Taipei"));
+        assert_eq!(out, "2026-05-30T16:12:34+08:00");
+        assert!(
+            !out.contains(' '),
+            "now= value must be space-free for header field-splitting, got {out:?}"
+        );
+    }
+
+    /// Invalid IANA name falls back to `chrono::Local` (never panics) and
+    /// stays space-free regardless of the system tz.
+    #[test]
+    fn format_iso_offset_invalid_iana_falls_back_and_stays_space_free() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-30T08:12:34Z")
+            .expect("known-good RFC 3339 fixture")
+            .with_timezone(&chrono::Utc);
+        let out = format_iso_offset(now, Some("Not/A_Real_TZ"));
+        let local = format_iso_offset(now, None);
+        assert_eq!(out, local, "invalid IANA must match chrono::Local (None)");
+        assert!(
+            !out.contains(' '),
+            "fallback must stay space-free, got {out:?}"
+        );
     }
 }

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -89,7 +89,24 @@ pub fn format_header(msg: &InboxMessage) -> String {
             sanitize_header_value(excerpt)
         ));
     }
+    parts.push(operator_now_field()); // #1487
     parts.join(" ")
+}
+
+/// #1487: build the `now=<operator-TZ timestamp>` header field so an agent
+/// sees the current operator-local time on EVERY message — fixing both the
+/// daemon's UTC offset (operator is e.g. UTC+8) and the spawn-time date
+/// freeze. The value is space-free RFC3339 + offset (`2026-05-30T16:12:34+08:00`):
+/// the header is a space-delimited `key=value` list (agents tokenize on
+/// spaces per agend.md), so a spaced value would shatter field parsing.
+///
+/// Reuses the operator display timezone (`display_timezone`) and the shared
+/// [`crate::display_time::format_iso_offset`] formatter so there is a single
+/// source of truth for operator-tz conversion; `None` → system local time.
+pub(crate) fn operator_now_field() -> String {
+    let tz = crate::daemon_config::get().display_timezone;
+    let stamp = crate::display_time::format_iso_offset(chrono::Utc::now(), tz.as_deref());
+    format!("now={stamp}")
 }
 
 /// Build the `in_reply_to_excerpt` value for inbound replies.
@@ -120,6 +137,7 @@ pub fn format_event_header(kind: &str, fields: &[(&str, &str)]) -> String {
     for (k, v) in fields {
         parts.push(format!("{}={}", k, sanitize_header_value(v)));
     }
+    parts.push(operator_now_field()); // #1487
     parts.join(" ")
 }
 
@@ -415,17 +433,21 @@ where
         && (msg_text.starts_with("[ci-pass]")
             || msg_text.starts_with("[ci-fail]")
             || msg_text.starts_with("[ci-ended]"));
+    // #1487: `now=<operator-TZ timestamp>` so the agent sees fresh, correctly-
+    // zoned time on the wake hint too (space-free value — see operator_now_field).
+    let now_field = operator_now_field();
     let hint = if is_ci_conclusion {
         let first_line = msg_text.lines().next().unwrap_or(&msg_text);
-        format!("{} (inbox={})", first_line, pending,)
+        format!("{} (inbox={}) {}", first_line, pending, now_field)
     } else {
         format!(
-            "{} id={} kind={} from={} inbox={} (use inbox tool)",
+            "{} id={} kind={} from={} inbox={} {} (use inbox tool)",
             PENDING_HEADER_PREFIX,
             sanitize_header_value(&id),
             sanitize_header_value(kind_str),
             sanitize_header_value(from_short),
             pending,
+            now_field,
         )
     };
     emit_hint(&hint);
@@ -541,5 +563,43 @@ mod actionable_wake_tests {
         assert!(!is_actionable(
             "[AGEND-MSG-PENDING] id=m-6 kind=task_summary from=x inbox=1 (use inbox tool)"
         ));
+    }
+}
+
+#[cfg(test)]
+mod operator_tz_tests {
+    use super::{format_header, operator_now_field};
+    use crate::inbox::message::InboxMessage;
+
+    /// #1487: the `now=` field is space-free so it survives the header's
+    /// space-delimited tokenization (the exact tz-conversion math is covered
+    /// in `display_time::format_iso_offset` tests). Uses whatever
+    /// `display_timezone` is configured in this process (None → system local).
+    #[test]
+    fn operator_now_field_is_space_free() {
+        let field = operator_now_field();
+        assert!(field.starts_with("now="), "must be a now= field: {field}");
+        assert!(
+            !field["now=".len()..].contains(' '),
+            "now= value must not contain spaces (would break header tokenization): {field}"
+        );
+    }
+
+    /// #1487: the [AGEND-MSG] header carries `now=` AND still carries the
+    /// existing fields agents parse (id / kind / size) — additive, no break.
+    #[test]
+    fn message_header_includes_now_without_breaking_existing_fields() {
+        let mut msg = InboxMessage {
+            from: "from:lead".to_string(),
+            text: "hello".to_string(),
+            ..Default::default()
+        };
+        msg.id = Some("m-1".to_string());
+        msg.kind = Some("task".to_string());
+        let header = format_header(&msg);
+        assert!(header.contains("now="), "header must carry now=: {header}");
+        assert!(header.contains("id=m-1"), "id= preserved: {header}");
+        assert!(header.contains("kind=task"), "kind= preserved: {header}");
+        assert!(header.contains("size=5"), "size= preserved: {header}");
     }
 }


### PR DESCRIPTION
## What

Agents saw the daemon's **UTC** wall-clock (8h off an Asia/Taipei operator) and a **date frozen at spawn time**. This adds a fresh `now=<operator-local time>` field to the `[AGEND-MSG]` / `[AGEND-MSG-PENDING]` headers so every message carries the correct, current operator-zone time — fixing both the offset and the date freeze at once (each message stamps fresh time).

## Approach (RCA-driven pivot)

The original spec proposed a new `timezone:` fleet field. RCA found `FleetConfig.display_timezone` + `display_time.rs` **already** implement operator-tz conversion (used by `ci_watch`). Adding a parallel field would guarantee config drift, so this reuses the existing one (confirmed with lead).

- `DaemonConfig` gains `display_timezone: Option<String>`, loaded at boot from fleet.yaml `display_timezone:`. `None` → system local time.
- `display_time::format_iso_offset` converts a UTC instant to a **space-free** RFC3339 + offset string (`2026-05-30T16:12:34+08:00`). `format_local_short` is unsuitable for headers (spaced, no year, no offset); the new formatter shares its IANA-parse + warn-once + `chrono::Local` fallback.
- `notify.rs` appends `now=` in `format_header` / `format_event_header` / the pending-pointer hint.

## Header compatibility

The header is a space-delimited `key=value` list (agents tokenize on spaces: `id=`/`kind=`/`size=`). The `now=` value is **space-free** (ISO `T` + offset), so the addition is purely additive — existing parse is unaffected. Covered by `message_header_includes_now_without_breaking_existing_fields`.

## Tests

- `display_time::format_iso_offset_asia_taipei_is_utc_plus_8_space_free` — exact UTC+8 render, space-free
- `display_time::format_iso_offset_invalid_iana_falls_back_and_stays_space_free`
- `notify::operator_now_field_is_space_free`
- `notify::message_header_includes_now_without_breaking_existing_fields`
- `daemon_config::daemon_config_display_timezone_defaults_to_none`

CI parity green locally: `cargo fmt --check` + `clippy --all-targets --features tray -D warnings` + `test --bin agend-terminal --features tray`.

Closes #1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)