### PR TITLE
feat(#1490): one-shot CI-parity preflight (scripts/preflight.sh)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,31 @@ cargo clippy --all-targets -- -D warnings
 CI runs these in the first two steps of `ci.yml`. Skipping them locally means
 the next push fails and needs an extra "fix fmt / fix clippy" round trip.
 
+### Before `git push`: run the full CI-parity preflight
+
+```bash
+scripts/preflight.sh          # full matrix; --quick skips the Windows check
+```
+
+This is the one-shot mirror of CI's `check` job and the best way to avoid a
+local-green → CI-red round trip. It runs `cargo fmt --check`,
+`cargo clippy --all-targets --features tray -- -D warnings`,
+`cargo test --tests --features tray` (unit + integration + invariants), and a
+**Windows cross-check** (`x86_64-pc-windows-msvc`) — the keystone, since
+Windows-only code (`libc::getppid`, `/bin/sh` spawns, `UnixStream`) compiles
+fine on a unix dev box but breaks CI's `windows-latest` runner.
+
+The Windows step needs the MSVC C toolchain because a transitive C dependency
+(`ring`) won't otherwise cross-compile on macOS/Linux. Install it once:
+
+```bash
+cargo install cargo-xwin && rustup target add x86_64-pc-windows-msvc
+```
+
+Without `cargo-xwin` the Windows step SKIPs with a hint (never false-fails);
+CI's `windows-latest` runner stays the backstop. The preflight is intentionally
+*not* a git hook — the full matrix takes a few minutes; run it manually.
+
 A pre-commit hook at `.git/hooks/pre-commit` auto-formats staged `.rs` files
 and re-stages them. It does NOT run clippy — clippy is too slow for a
 pre-commit path. Run clippy yourself before `git push`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,16 @@ cargo clippy -- -D warnings          # must be warning-free
 
 CI mirrors these steps on Ubuntu + macOS + Windows (`.github/workflows/ci.yml`).
 
+### Before pushing: `scripts/preflight.sh`
+
+Run the one-shot CI-parity preflight to catch failures locally instead of after a push:
+
+```bash
+scripts/preflight.sh          # full matrix; --quick skips the Windows cross-check
+```
+
+It runs exactly CI's `check` job — `cargo fmt --check`, `cargo clippy --all-targets --features tray -- -D warnings`, `cargo test --tests --features tray`, and a **Windows cross-check** (`x86_64-pc-windows-msvc`) that catches windows-only compile errors a unix dev box would otherwise miss. The Windows step prefers [`cargo-xwin`](https://github.com/rust-cross/cargo-xwin) (`cargo install cargo-xwin && rustup target add x86_64-pc-windows-msvc`) since a transitive C dependency (`ring`) won't cross-compile on macOS/Linux without the MSVC toolchain; if it's not installed the step SKIPs with a hint rather than false-failing.
+
 ### Coverage (optional, local)
 
 The `coverage` CI job (#686) runs `cargo-llvm-cov` on Ubuntu and uploads an lcov report to Codecov. To measure locally:

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# #1490 — one-shot CI-parity preflight.
+#
+# Mirrors the GitHub Actions `check` job (.github/workflows/ci.yml) locally so
+# the local-green -> CI-red round-trip stops costing a push + a ~10min wait.
+# Born from the retro HIGH point: a single session burned 5 CI-red cycles on
+# problems a local check would have caught — Windows-only compile errors,
+# fmt drift, tray-gated failures, and the 750-LOC file_size_invariant.
+#
+# Runs, in order (each is exactly what CI's `check` job runs):
+#   1. cargo fmt --check
+#   2. cargo clippy --all-targets --features tray -- -D warnings
+#   3. cargo test --tests --features tray   (unit + integration + invariants)
+#   4. Windows cross-check (x86_64-pc-windows-msvc)   <- the keystone
+#
+# Step 4 catches the class that hurts most: Windows-only code
+# (libc::getppid, /bin/sh spawns, UnixStream) compiles fine on a unix dev
+# box but breaks CI's windows-latest runner. There is a wrinkle — a plain
+# `cargo check --target x86_64-pc-windows-msvc` cannot complete on a stock
+# macOS/Linux box because a transitive C dependency (`ring`, via TLS) needs
+# the Windows C toolchain (`assert.h` et al.) and its build script aborts
+# before our crate is ever type-checked. So this step prefers `cargo xwin`
+# (bundles the MSVC CRT/SDK) and degrades gracefully:
+#   - `cargo-xwin` installed  -> `cargo xwin check` (real, complete check)
+#   - else plain `cargo check` -> works only if the host has a Windows
+#     toolchain; on a C-dep build-script failure it SKIPS with a hint
+#     rather than reporting a false failure.
+#   - target not installed     -> SKIP + `rustup target add` hint.
+#
+# Usage:
+#   scripts/preflight.sh            # full matrix (default)
+#   scripts/preflight.sh --quick    # skip the Windows cross-check (host only)
+#   scripts/preflight.sh -h|--help
+#
+# Exit codes:
+#   0  — every step that ran passed (a skipped Windows step is still 0)
+#   1  — at least one step failed
+#   2  — invocation / environment error (cargo missing, bad arg)
+#
+# NOT a git hook: the full matrix takes minutes; wiring it into pre-push
+# would tax every push. Run it manually before pushing (see CLAUDE.md).
+# CI stays the source of truth — this just front-runs it.
+
+set -uo pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly WINDOWS_TARGET="x86_64-pc-windows-msvc"
+
+run_quick="false"
+while (( $# > 0 )); do
+    case "$1" in
+        --quick) run_quick="true"; shift ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "[$SCRIPT_NAME] unknown arg: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "[$SCRIPT_NAME] cargo not found in PATH" >&2
+    echo "  install: https://rustup.rs/" >&2
+    exit 2
+fi
+
+# Run from repo root so cargo finds the manifest regardless of CWD.
+cd "$(dirname "$0")/.." || exit 2
+
+passed=()
+failed=()
+skipped=()
+
+banner() {
+    echo
+    echo "──────────────────────────────────────────────────────────────"
+    echo "[$SCRIPT_NAME] $1"
+    echo "──────────────────────────────────────────────────────────────"
+}
+
+# step "<label>" cmd args...   — runs cmd, records pass/fail, never aborts the
+# script (run-all so the dev sees every problem in one pass, not one at a time).
+step() {
+    local label="$1"; shift
+    banner "$label"
+    echo "  \$ $*"
+    if "$@"; then
+        passed+=("$label")
+    else
+        failed+=("$label")
+    fi
+}
+
+step "fmt --check" \
+    cargo fmt --check
+step "clippy (--all-targets --features tray -D warnings)" \
+    cargo clippy --all-targets --features tray -- -D warnings
+step "test (--tests --features tray: unit + integration + invariants)" \
+    cargo test --tests --features tray
+
+# ── Step 4: Windows cross-check ──────────────────────────────────────────
+windows_check() {
+    if [[ "$run_quick" == "true" ]]; then
+        skipped+=("windows check ($WINDOWS_TARGET) — --quick")
+        return
+    fi
+
+    if command -v rustup >/dev/null 2>&1 \
+        && ! rustup target list --installed 2>/dev/null | grep -qx "$WINDOWS_TARGET"; then
+        banner "windows check ($WINDOWS_TARGET) — target not installed, SKIP"
+        echo "  enable (catches windows-only compile errors locally):"
+        echo "      rustup target add $WINDOWS_TARGET"
+        skipped+=("windows check ($WINDOWS_TARGET) — target not installed")
+        return
+    fi
+
+    # Preferred path: cargo-xwin bundles the MSVC CRT/SDK so the `ring` C
+    # build script (and every other Windows compile) succeeds on a unix host.
+    if command -v cargo-xwin >/dev/null 2>&1; then
+        step "windows check (cargo xwin check --target $WINDOWS_TARGET --all-targets --features tray)" \
+            cargo xwin check --target "$WINDOWS_TARGET" --all-targets --features tray
+        return
+    fi
+
+    # Fallback: plain cargo check. Works only when the host already has a
+    # Windows C toolchain. On a C-dep build-script failure (the `ring`
+    # assert.h wall) we SKIP with a hint instead of false-failing.
+    banner "windows check (cargo check --target $WINDOWS_TARGET --all-targets --features tray)"
+    local log
+    log="$(mktemp -t "preflight-win.XXXXXX")"
+    if cargo check --target "$WINDOWS_TARGET" --all-targets --features tray 2>&1 | tee "$log"; then
+        passed+=("windows check ($WINDOWS_TARGET)")
+        rm -f "$log"
+        return
+    fi
+
+    if grep -qE "(error occurred in cc-rs|failed to run custom build command|fatal error: '.*\.h' file not found|linker .* not found)" "$log"; then
+        echo
+        echo "[$SCRIPT_NAME] windows check blocked by a C-dependency build script"
+        echo "  (e.g. 'ring' needs the Windows C toolchain) — this is NOT your code."
+        echo "  for a real local Windows check on unix, install cargo-xwin:"
+        echo "      cargo install cargo-xwin && rustup target add $WINDOWS_TARGET"
+        echo "  (otherwise CI's windows-latest runner is the backstop.)"
+        skipped+=("windows check ($WINDOWS_TARGET) — C-dep toolchain missing; install cargo-xwin")
+        rm -f "$log"
+        return
+    fi
+
+    failed+=("windows check ($WINDOWS_TARGET)")
+    rm -f "$log"
+}
+windows_check
+
+# ── Summary ──────────────────────────────────────────────────────────────
+echo
+echo "══════════════════════════════════════════════════════════════"
+echo "[$SCRIPT_NAME] Summary"
+echo "══════════════════════════════════════════════════════════════"
+echo "  passed  (${#passed[@]}): ${passed[*]:-<none>}"
+echo "  failed  (${#failed[@]}): ${failed[*]:-<none>}"
+if (( ${#skipped[@]} > 0 )); then
+    echo "  skipped (${#skipped[@]}):"
+    for s in "${skipped[@]}"; do
+        echo "    - $s"
+    done
+fi
+echo
+
+if (( ${#failed[@]} > 0 )); then
+    echo "[$SCRIPT_NAME] PREFLIGHT FAILED — fix the above before pushing." >&2
+    exit 1
+fi
+
+echo "[$SCRIPT_NAME] OK — local CI matrix clean. Safe to push."
+exit 0


### PR DESCRIPTION
## What

`scripts/preflight.sh` — a one-shot mirror of CI's `check` job, run manually before `git push` to kill the local-green → CI-red round-trip (the retro HIGH point: this fleet burned 5 CI-red cycles in one session on things a local check catches).

```bash
scripts/preflight.sh          # full matrix
scripts/preflight.sh --quick  # skip the Windows cross-check (host only)
scripts/preflight.sh --help
```

Runs, in order, exactly what `.github/workflows/ci.yml`'s `check` job runs:
1. `cargo fmt --check`
2. `cargo clippy --all-targets --features tray -- -D warnings`
3. `cargo test --tests --features tray` (unit + integration + invariants)
4. **Windows cross-check** (`x86_64-pc-windows-msvc`) — the keystone

## The Windows-check wrinkle (design pivot)

The task assumed a plain `cargo check --target x86_64-pc-windows-msvc` would surface windows-only compile errors. **It can't on a stock macOS/Linux box**: the transitive C dependency `ring` (TLS) needs the Windows C toolchain (`assert.h`) and its build script aborts *before* our crate is type-checked. Verified empirically.

The genuinely-working path is [`cargo-xwin`](https://github.com/rust-cross/cargo-xwin), which bundles the MSVC CRT/SDK — validated locally: it compiles `ring` and checks the full crate (teloxide, tray-icon, …) for `windows-msvc` in ~56s. So step 4:
- **prefers** `cargo xwin check --all-targets --features tray` when `cargo-xwin` is installed;
- **falls back** to plain `cargo check`, which **SKIPs** (not fails) on a C-dep build-script error with an install hint;
- **SKIPs** with a `rustup target add` hint when the target is absent.

It never false-fails. Install for full local Windows coverage:
```bash
cargo install cargo-xwin && rustup target add x86_64-pc-windows-msvc
```

## Scope decisions
- **Form**: `scripts/` shell helper — matches the existing convention (`clippy-all-platforms.sh`, `install-hooks.sh`); no `xtask` crate / Makefile exists.
- **Not a git hook**: full matrix is ~3 min; the `pre-commit` hook's own comment already says "run clippy yourself before push" — manual is the established philosophy.
- **`cargo test --tests --features tray`**: true CI mirror; the `--tests` integration targets include the invariant tests (`file_size_invariant`, …).
- **`cargo build --release` omitted**: not in the task's matrix; `clippy --all-targets` already compiles every target in dev mode, so release-only compile failures are rare and CI backstops them. Kept the preflight lean.

## Validation
- `bash -n` clean; `--help` renders; bad-arg → exit 2.
- Full run end-to-end on this branch: all 4 steps **passed** in ~3 min (including the xwin Windows check with `--all-targets`).

Closes #1490

🤖 Generated with [Claude Code](https://claude.com/claude-code)