### PR TITLE
fix(#1488): cascade-clean bound services when an instance is deleted

### DIFF
--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -37,7 +37,7 @@ pub use provider::{
     MergeableState, PrState,
 };
 #[allow(unused_imports)]
-pub use registry::{ci_watches_dir, remove_watch, watch_filename};
+pub use registry::{ci_watches_dir, cleanup_watches_for_instance, remove_watch, watch_filename};
 #[allow(unused_imports)]
 pub use sweep::{gc_stale_watches, startup_sweep};
 pub use watcher::check_ci_watches;

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -64,6 +64,83 @@ pub fn remove_watch(
     );
 }
 
+/// #1488: scrub a deleted instance out of every CI watch. For each watch file:
+/// drop `instance` from the `subscribers` list (and the legacy single
+/// `instance` field), and clear `next_after_ci` if it pointed at the deleted
+/// instance (otherwise CI-pass would route `[ci-ready-for-action]` to a ghost).
+/// A watch left with no subscribers AND no `next_after_ci` is removed entirely
+/// — nothing would ever consume it. Returns the count of watches modified or
+/// removed.
+pub fn cleanup_watches_for_instance(home: &Path, instance: &str) -> usize {
+    let dir = ci_watches_dir(home);
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return 0, // no ci-watches dir yet → nothing to clean
+    };
+    let mut affected = 0usize;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        // flock the watch so a concurrent poll/unwatch doesn't race the RMW.
+        let lock_path = path.with_extension("lock");
+        let _lock = match crate::store::acquire_file_lock(&lock_path) {
+            Ok(l) => l,
+            Err(_) => continue, // contended → skip; boot sweep retries next boot
+        };
+        let mut watch: super::watch_state::WatchState = match std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<super::watch_state::WatchState>(&c).ok())
+        {
+            Some(w) => w,
+            None => continue,
+        };
+
+        let mut changed = false;
+        if let Some(subs) = watch.subscribers.as_mut() {
+            let before = subs.len();
+            subs.retain(|s| s.instance != instance);
+            if subs.len() != before {
+                changed = true;
+            }
+        }
+        if watch.instance.as_deref() == Some(instance) {
+            watch.instance = None;
+            changed = true;
+        }
+        if watch.next_after_ci.as_deref() == Some(instance) {
+            watch.next_after_ci = None;
+            changed = true;
+        }
+        if !changed {
+            continue;
+        }
+
+        let (repo, branch) = (watch.repo.clone(), watch.branch.clone());
+        if watch.subscriber_names().is_empty() && watch.next_after_ci.is_none() {
+            remove_watch(home, &path, instance, &repo, &branch, "instance_deleted");
+        } else if let Err(e) = crate::store::atomic_write(
+            &path,
+            serde_json::to_string_pretty(&watch)
+                .unwrap_or_default()
+                .as_bytes(),
+        ) {
+            tracing::warn!(path = %path.display(), error = %e, "#1488: ci-watch scrub write failed");
+            continue;
+        }
+        affected += 1;
+    }
+    if affected > 0 {
+        tracing::info!(
+            %instance,
+            count = affected,
+            "#1488: scrubbed deleted instance from CI watches"
+        );
+    }
+    affected
+}
+
 /// Deterministic, collision-resistant filename for a CI watch entry.
 /// Uses SHA-256 of `"{repo}:{branch}"` to avoid path traversal and
 /// collisions when repo names contain `/` (e.g. `owner/repo` vs
@@ -304,6 +381,89 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── #1488 cascade: scrub a deleted instance out of CI watches ──
+
+    fn write_watch(home: &Path, name: &str, ws: &super::super::watch_state::WatchState) {
+        let dir = ci_watches_dir(home);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(format!("{name}.json")),
+            serde_json::to_string_pretty(ws).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn sub(name: &str) -> super::super::watch_state::Subscriber {
+        super::super::watch_state::Subscriber {
+            instance: name.into(),
+            subscribed_at: None,
+        }
+    }
+
+    #[test]
+    fn cleanup_drops_subscriber_clears_next_keeps_watch_with_survivors() {
+        let home = std::env::temp_dir().join(format!("agend-1488-ciw-keep-{}", std::process::id()));
+        let ws = super::super::watch_state::WatchState {
+            repo: "o/r".into(),
+            branch: "feat".into(),
+            subscribers: Some(vec![sub("doomed"), sub("alive")]),
+            next_after_ci: Some("doomed".into()),
+            ..Default::default()
+        };
+        write_watch(&home, "w", &ws);
+        let n = cleanup_watches_for_instance(&home, "doomed");
+        assert_eq!(n, 1, "one watch modified");
+        let path = ci_watches_dir(&home).join("w.json");
+        assert!(path.exists(), "watch with surviving subscriber must remain");
+        let after: super::super::watch_state::WatchState =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(after.subscriber_names(), vec!["alive"], "doomed removed");
+        assert!(
+            after.next_after_ci.is_none(),
+            "next_after_ci pointing at doomed must be cleared"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn cleanup_removes_watch_with_no_survivors() {
+        let home = std::env::temp_dir().join(format!("agend-1488-ciw-rm-{}", std::process::id()));
+        let ws = super::super::watch_state::WatchState {
+            repo: "o/r".into(),
+            branch: "feat".into(),
+            subscribers: Some(vec![sub("doomed")]),
+            next_after_ci: Some("doomed".into()),
+            ..Default::default()
+        };
+        write_watch(&home, "w", &ws);
+        let n = cleanup_watches_for_instance(&home, "doomed");
+        assert_eq!(n, 1);
+        assert!(
+            !ci_watches_dir(&home).join("w.json").exists(),
+            "watch with no remaining subscribers AND no next_after_ci must be removed"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn cleanup_noop_when_instance_absent() {
+        let home = std::env::temp_dir().join(format!("agend-1488-ciw-noop-{}", std::process::id()));
+        let ws = super::super::watch_state::WatchState {
+            repo: "o/r".into(),
+            branch: "feat".into(),
+            subscribers: Some(vec![sub("alive")]),
+            ..Default::default()
+        };
+        write_watch(&home, "w", &ws);
+        assert_eq!(
+            cleanup_watches_for_instance(&home, "ghost"),
+            0,
+            "no watch references ghost → nothing modified"
+        );
+        assert!(ci_watches_dir(&home).join("w.json").exists());
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -119,13 +119,26 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     "inject_failed"
                 }
             }
-        } else {
-            // #1441 routing change (`reg.get(target)` → resolve_uuid via
-            // fleet.yaml) means a schedule targeting a non-fleet instance now
-            // lands here. Defer the self-IPC enqueue past the lock — see the
-            // `deferred_inbox` note above.
+        } else if crate::fleet::instance_is_known(home, target) {
+            // Known fleet instance that simply isn't running right now. Defer
+            // the self-IPC enqueue past the lock (see the `deferred_inbox`
+            // note above) so it lands in the inbox for next time it checks.
             deferred_inbox = true;
             "ok_inbox"
+        } else {
+            // #1488 fail-safe: the target is NOT a known fleet instance —
+            // a deleted/renamed/typo'd target (the #1441 routing change made
+            // these fall through to the inbox fallback). Enqueuing would
+            // create an orphan inbox nobody drains and feed the dangerous
+            // self-IPC fallback that triggered the morning deadlock. Skip +
+            // warn instead; the schedule row stays (cascade/boot-sweep
+            // disables it), so this only fires until cleanup catches up.
+            tracing::warn!(
+                schedule = %sched_id,
+                target,
+                "#1488: schedule target is not a known instance — skipping fire (orphaned target)"
+            );
+            "skipped_unknown_target"
         };
         drop(reg);
 
@@ -214,6 +227,7 @@ pub(crate) fn is_due_in_tz(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
@@ -390,5 +404,88 @@ mod tests {
         let last = Utc.with_ymd_and_hms(2026, 4, 20, 14, 0, 0).unwrap();
         let now = Utc.with_ymd_and_hms(2026, 4, 20, 15, 0, 0).unwrap();
         assert!(classify_once("not a date", last, now).is_none());
+    }
+
+    // ── #1488 fail-safe: don't fire a schedule whose target is a ghost ──
+
+    fn cron_tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let id = C.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-1488-cron-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn empty_registry() -> crate::agent::AgentRegistry {
+        std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
+    }
+
+    fn seed_oneshot(home: &std::path::Path, target: &str) {
+        let at = (chrono::Utc::now() - chrono::Duration::seconds(2)).to_rfc3339();
+        let store = serde_json::json!({
+            "schema_version": 2,
+            "schedules": [{
+                "id": "s-1488", "message": "ping", "target": target,
+                "trigger": {"kind": "once", "at": at}, "enabled": true,
+                "timezone": "UTC", "label": "t",
+                "created_at": at, "updated_at": at, "run_history": []
+            }]
+        });
+        std::fs::write(
+            home.join("schedules.json"),
+            serde_json::to_string_pretty(&store).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn last_status(home: &std::path::Path) -> String {
+        crate::schedules::load(home).schedules[0]
+            .run_history
+            .last()
+            .map(|r| r.status.clone())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn schedule_targeting_unknown_instance_is_skipped_not_enqueued() {
+        let home = cron_tmp_home("ghost");
+        // No fleet.yaml → "ghost" is not a known instance.
+        seed_oneshot(&home, "ghost");
+        check_schedules(&home, &empty_registry());
+        assert_eq!(
+            last_status(&home),
+            "skipped_unknown_target",
+            "fire to a ghost target must be skipped"
+        );
+        assert!(
+            !home.join("inbox").join("ghost.jsonl").exists(),
+            "no orphan inbox file may be created for a ghost target"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn schedule_targeting_known_offline_instance_enqueues_to_inbox() {
+        let home = cron_tmp_home("known");
+        // fleet.yaml declares "offline" (present but not in the registry).
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  offline:\n    backend: claude\n",
+        )
+        .unwrap();
+        seed_oneshot(&home, "offline");
+        check_schedules(&home, &empty_registry());
+        assert_eq!(
+            last_status(&home),
+            "ok_inbox",
+            "a known but offline target must still get an inbox enqueue"
+        );
+        std::fs::remove_dir_all(home).ok();
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod idle_watchdog;
 pub(crate) mod lifecycle;
 pub(crate) mod mcp_registry_watcher;
 pub(crate) mod notification_dedup;
+pub(crate) mod orphan_sweep;
 pub(crate) mod per_tick;
 pub(crate) mod poll_reminder;
 pub(crate) mod pr_state;
@@ -647,6 +648,9 @@ fn build_tick_infrastructure(
     crate::inbox::recover_half_writes(home);
     replay_missed_at_startup(home, &ctx.registry);
     crate::daemon::ci_watch::startup_sweep(home);
+    // #1488: GC bindings (schedules/dispatch_tracking/ci_watch) left orphaned
+    // by instances deleted before the cascade-on-delete fix existed.
+    crate::daemon::orphan_sweep::run(home);
 
     let watchdog_dry_run = watchdog::watchdog_dry_run_from_env();
     // Vec order MUST match the pre-extraction call order (zero-behavior-change guarantee).

--- a/src/daemon/orphan_sweep.rs
+++ b/src/daemon/orphan_sweep.rs
@@ -1,0 +1,254 @@
+//! #1488 boot-time orphan sweep.
+//!
+//! The cascade cleanup in `full_delete_instance` only runs for instances
+//! deleted *after* that fix shipped. Instances deleted earlier (or via any
+//! path that bypassed the cascade) left orphaned bindings behind: schedules
+//! that fire into the cron self-IPC fallback (this morning's deadlock
+//! trigger), dispatch_tracking entries that `sweep_stuck` re-warns forever
+//! (the empirical ~81 "dispatch stuck check" messages), and CI watches whose
+//! subscriber / `next_after_ci` point at a deleted agent.
+//!
+//! This boot sweep GCs those pre-existing orphans once at startup. It REUSES
+//! the per-instance cleanup functions from the delete path so the two share
+//! identical logic — no second implementation to drift. Policy matches the
+//! cascade (lead decision, #1488):
+//! - **schedules**: disabled + marked orphaned, never deleted (the operator
+//!   may re-target a still-useful cron — e.g. an AI-Scout report whose backend
+//!   was swapped). Idempotent across reboots.
+//! - **dispatch_tracking / ci_watch**: GC'd (transient, no re-target value).
+
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Run the boot-time orphan sweep. Best-effort: every sub-step swallows its
+/// own errors (matching the rest of the boot path) so a single failure can't
+/// abort daemon startup.
+pub fn run(home: &Path) {
+    let known: HashSet<String> =
+        match crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) {
+            Ok(c) => c.instances.keys().cloned().collect(),
+            // No fleet.yaml / parse error → can't tell ghost from live, so do
+            // nothing rather than risk disabling every schedule.
+            Err(_) => return,
+        };
+
+    let mut schedules_orphaned = 0usize;
+    let mut dispatches_gced = 0usize;
+    let mut watches_scrubbed = 0usize;
+
+    // schedules: distinct enabled targets that no longer exist.
+    let mut sched_targets: Vec<String> = crate::schedules::load(home)
+        .schedules
+        .iter()
+        .filter(|s| s.enabled && !known.contains(&s.target))
+        .map(|s| s.target.clone())
+        .collect();
+    sched_targets.sort();
+    sched_targets.dedup();
+    for target in sched_targets {
+        schedules_orphaned += crate::schedules::orphan_schedules_for_target(home, &target);
+    }
+
+    // dispatch_tracking: active targets that no longer exist.
+    for target in crate::dispatch_tracking::active_target_names(home) {
+        if !known.contains(&target) {
+            dispatches_gced += crate::dispatch_tracking::cleanup_for_instance(home, &target);
+        }
+    }
+
+    // ci_watch: subscribers / next_after_ci pointing at gone instances.
+    for name in unknown_watch_instances(home, &known) {
+        watches_scrubbed += crate::daemon::ci_watch::cleanup_watches_for_instance(home, &name);
+    }
+
+    if schedules_orphaned + dispatches_gced + watches_scrubbed > 0 {
+        tracing::info!(
+            schedules_orphaned,
+            dispatches_gced,
+            watches_scrubbed,
+            "#1488 boot orphan sweep: cleaned stale bindings of deleted instances"
+        );
+    }
+}
+
+/// Distinct instance names referenced by any CI watch (as a subscriber or as
+/// `next_after_ci`) that are NOT in the known-instance set.
+fn unknown_watch_instances(home: &Path, known: &HashSet<String>) -> Vec<String> {
+    let dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    let mut names: Vec<String> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(watch) = std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|c| serde_json::from_str::<crate::daemon::ci_watch::WatchState>(&c).ok())
+            else {
+                continue;
+            };
+            for sub in watch.subscriber_names() {
+                if !known.contains(&sub) {
+                    names.push(sub);
+                }
+            }
+            if let Some(next) = watch.next_after_ci.as_deref() {
+                if !known.contains(next) {
+                    names.push(next.to_string());
+                }
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let id = C.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-1488-sweep-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn boot_sweep_cleans_orphans_and_preserves_known() {
+        let home = tmp_home("boot");
+        // fleet.yaml knows only "alive".
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  alive:\n    backend: claude\n",
+        )
+        .unwrap();
+        // schedules: one targets the gone "ghost", one targets "alive".
+        std::fs::write(
+            home.join("schedules.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "schema_version": 2,
+                "schedules": [
+                    {"id": "s-ghost", "message": "m", "target": "ghost",
+                     "trigger": {"kind": "cron", "expr": "0 9 * * *"}, "enabled": true,
+                     "timezone": "UTC", "created_at": "2026-01-01T00:00:00Z",
+                     "updated_at": "2026-01-01T00:00:00Z", "run_history": []},
+                    {"id": "s-alive", "message": "m", "target": "alive",
+                     "trigger": {"kind": "cron", "expr": "0 9 * * *"}, "enabled": true,
+                     "timezone": "UTC", "created_at": "2026-01-01T00:00:00Z",
+                     "updated_at": "2026-01-01T00:00:00Z", "run_history": []}
+                ]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        // dispatch_tracking: pending entries to ghost and to alive.
+        crate::dispatch_tracking::track_dispatch(
+            &home,
+            crate::dispatch_tracking::DispatchEntry {
+                task_id: Some("t-g".into()),
+                from: "lead".into(),
+                to: "ghost".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: chrono::Utc::now().to_rfc3339(),
+                status: "pending".into(),
+            },
+        );
+        crate::dispatch_tracking::track_dispatch(
+            &home,
+            crate::dispatch_tracking::DispatchEntry {
+                task_id: Some("t-a".into()),
+                from: "lead".into(),
+                to: "alive".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: chrono::Utc::now().to_rfc3339(),
+                status: "pending".into(),
+            },
+        );
+        // ci_watch: a watch with a ghost subscriber, one with alive.
+        let dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+        std::fs::create_dir_all(&dir).unwrap();
+        for who in ["ghost", "alive"] {
+            std::fs::write(
+                dir.join(format!("{who}.json")),
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "repo": "o/r",
+                    "branch": who,
+                    "subscribers": [{"instance": who}],
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        }
+
+        run(&home);
+
+        // schedules: ghost disabled+marked, alive untouched.
+        let scheds = crate::schedules::load(&home);
+        let ghost_s = scheds.schedules.iter().find(|s| s.id == "s-ghost").unwrap();
+        assert!(!ghost_s.enabled, "ghost-targeting schedule disabled");
+        assert!(ghost_s
+            .run_history
+            .last()
+            .is_some_and(|r| r.status.contains("orphaned")));
+        let alive_s = scheds.schedules.iter().find(|s| s.id == "s-alive").unwrap();
+        assert!(alive_s.enabled, "alive-targeting schedule preserved");
+
+        // dispatch_tracking: ghost entry GC'd, alive entry kept.
+        let store: serde_json::Value =
+            crate::store::load(&crate::store::store_path(&home, "dispatch_tracking.json"));
+        let tos: Vec<&str> = store["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|e| e["to"].as_str())
+            .collect();
+        assert_eq!(tos, vec!["alive"], "only alive dispatch survives: {tos:?}");
+
+        // ci_watch: ghost watch removed (no survivors), alive watch intact.
+        assert!(
+            !dir.join("ghost.json").exists(),
+            "ghost-only watch must be removed"
+        );
+        assert!(dir.join("alive.json").exists(), "alive watch must remain");
+
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn boot_sweep_noop_without_fleet_yaml() {
+        // No fleet.yaml → can't distinguish ghost from live → must do nothing
+        // (never disable schedules on an unreadable fleet).
+        let home = tmp_home("nofleet");
+        std::fs::write(
+            home.join("schedules.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "schema_version": 2,
+                "schedules": [{"id": "s", "message": "m", "target": "whoever",
+                    "trigger": {"kind": "cron", "expr": "0 9 * * *"}, "enabled": true,
+                    "timezone": "UTC", "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:00Z", "run_history": []}]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        run(&home);
+        assert!(
+            crate::schedules::load(&home).schedules[0].enabled,
+            "no fleet.yaml → schedule must stay enabled (no destructive sweep)"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+}

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -127,6 +127,54 @@ pub fn sweep_orphans(home: &Path) -> Vec<DispatchEntry> {
     orphans
 }
 
+/// #1488: drop every dispatch entry that involves `instance` as either the
+/// dispatcher (`from`) or the target (`to`). When an instance is deleted, its
+/// in-flight dispatches can never complete, so `sweep_stuck` would re-warn /
+/// re-ask them forever (the empirical ~81 "dispatch stuck check" messages).
+/// Marking them "orphaned" is NOT enough — `sweep_stuck` only skips
+/// `completed`, so an orphaned-but-uncompleted entry still re-fires. Removal
+/// is the only thing that stops the noise; the entries carry no re-target
+/// value once the instance is gone. Returns the number removed.
+pub fn cleanup_for_instance(home: &Path, instance: &str) -> usize {
+    let mut removed = 0usize;
+    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+        let before = store.entries.len();
+        store
+            .entries
+            .retain(|e| e.from != instance && e.to != instance);
+        removed = before - store.entries.len();
+        Ok(())
+    });
+    if removed > 0 {
+        tracing::info!(
+            %instance,
+            count = removed,
+            "#1488: removed dispatch_tracking entries for deleted instance"
+        );
+    }
+    removed
+}
+
+/// #1488: distinct, still-active (`status != "completed"`) dispatch target
+/// names. The boot orphan sweep uses this to find entries whose `to` instance
+/// no longer exists, then reuses [`cleanup_for_instance`] to remove them —
+/// sharing the exact delete-path logic instead of duplicating it.
+pub fn active_target_names(home: &Path) -> Vec<String> {
+    let store: DispatchStore = crate::store::load_versioned(
+        &store_path(home),
+        <DispatchStore as crate::store::SchemaVersioned>::CURRENT,
+    );
+    let mut names: Vec<String> = store
+        .entries
+        .iter()
+        .filter(|e| e.status != "completed" && !e.to.is_empty())
+        .map(|e| e.to.clone())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
 /// M3: Remove terminal entries (completed/orphaned) older than 30 days.
 /// Prevents unbounded growth of dispatch_tracking.json.
 pub fn gc_old_entries(home: &Path) {
@@ -325,6 +373,54 @@ mod tests {
         let entries = store["entries"].as_array().expect("entries");
         assert_eq!(entries.len(), 1, "old entry should be removed: {entries:?}");
         assert_eq!(entries[0]["task_id"], "t-recent");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #1488 cascade: drop dispatch entries for a deleted instance ──
+
+    fn entry(from: &str, to: &str) -> DispatchEntry {
+        DispatchEntry {
+            task_id: Some(format!("t-{from}-{to}")),
+            from: from.into(),
+            to: to.into(),
+            from_id: None,
+            to_id: None,
+            delegated_at: chrono::Utc::now().to_rfc3339(),
+            status: "pending".into(),
+        }
+    }
+
+    #[test]
+    fn cleanup_for_instance_removes_from_and_to_keeps_unrelated() {
+        let home = tmp_home("cleanup-inst");
+        track_dispatch(&home, entry("lead", "doomed")); // to == doomed
+        track_dispatch(&home, entry("doomed", "dev")); // from == doomed
+        track_dispatch(&home, entry("lead", "dev")); // unrelated
+        let removed = cleanup_for_instance(&home, "doomed");
+        assert_eq!(removed, 2, "both from== and to==doomed entries removed");
+        let store: serde_json::Value =
+            crate::store::load(&crate::store::store_path(&home, "dispatch_tracking.json"));
+        let entries = store["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 1, "unrelated entry must survive");
+        assert_eq!(entries[0]["to"], "dev");
+        assert_eq!(entries[0]["from"], "lead");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn active_target_names_returns_distinct_non_completed() {
+        let home = tmp_home("active-targets");
+        track_dispatch(&home, entry("lead", "dev"));
+        track_dispatch(&home, entry("lead", "dev")); // dup target
+        let mut done = entry("lead", "reviewer");
+        done.status = "completed".into();
+        track_dispatch(&home, done);
+        let names = active_target_names(&home);
+        assert_eq!(
+            names,
+            vec!["dev"],
+            "distinct, completed excluded: {names:?}"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -58,6 +58,18 @@ pub fn resolve_uuid(home: &Path, name: &str) -> Option<crate::types::InstanceId>
         })
 }
 
+/// #1488: is `name` a currently-known fleet instance? True iff fleet.yaml has
+/// an `instances:` entry for it (regardless of whether it has a parseable id or
+/// is currently running). Unlike [`resolve_uuid`], this does not require an id
+/// — an offline-but-configured instance counts as known. Used by the cron
+/// schedule fail-safe and the boot orphan sweep to distinguish a deletable
+/// ghost target from a legitimate offline instance.
+pub fn instance_is_known(home: &Path, name: &str) -> bool {
+    FleetConfig::load(&fleet_yaml_path(home))
+        .map(|c| c.instances.contains_key(name))
+        .unwrap_or(false)
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FleetConfig {
     #[serde(default)]
@@ -681,6 +693,23 @@ instances:
         // Submit key should be default \r, not preset's
         assert_eq!(resolved.submit_key, "\r");
 
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn instance_is_known_true_for_fleet_entry_false_for_ghost() {
+        // #1488: instance_is_known gates the cron fail-safe + boot sweep. An
+        // entry without an id still counts as known (offline-but-configured);
+        // a name absent from fleet.yaml is a deletable ghost.
+        let dir = std::env::temp_dir().join(format!("agend-1488-known-{}", std::process::id()));
+        fs::create_dir_all(&dir).ok();
+        fs::write(
+            fleet_yaml_path(&dir),
+            "instances:\n  alive:\n    backend: claude\n",
+        )
+        .unwrap();
+        assert!(instance_is_known(&dir, "alive"), "fleet entry is known");
+        assert!(!instance_is_known(&dir, "ghost"), "absent name is a ghost");
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -119,6 +119,19 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // accumulate in the tracking list and inflate alert text.
     crate::daemon::idle_watchdog::remove_agent_activity(home, name);
 
+    // #1488: cascade-clean the services bound to the deleted instance.
+    // Without these, an orphaned schedule keeps firing into the cron self-IPC
+    // fallback (this morning's deadlock trigger), dispatch_tracking entries
+    // re-warn forever (the ~81 stuck-check messages), and CI watches route
+    // [ci-ready-for-action] to a ghost. All best-effort like the steps above.
+    // - schedules: DISABLED + marked orphaned (never deleted — operator may
+    //   re-target a still-useful cron at a surviving instance).
+    let _ = crate::schedules::orphan_schedules_for_target(home, name);
+    // - dispatch_tracking: GC'd (no re-target value; removal stops stuck noise).
+    let _ = crate::dispatch_tracking::cleanup_for_instance(home, name);
+    // - ci_watch: drop from subscribers + clear next_after_ci (+ remove empty).
+    let _ = crate::daemon::ci_watch::cleanup_watches_for_instance(home, name);
+
     // Sprint 54 P1-B Bug 1 audit: enumerate every store that still holds
     // the name. If any do, surface a loud error instead of returning
     // success — `auto_start_fleet` revival of a half-deleted instance is
@@ -434,6 +447,78 @@ mod tests {
         assert!(
             !activity_file.exists(),
             "activity sidecar must be removed after full_delete_instance"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn full_delete_instance_cascades_bound_services() {
+        // #1488: deleting an instance must cascade-clean its schedules,
+        // dispatch_tracking entries, and CI watches in one teardown.
+        let home = tmp_home("cascade");
+        // schedule targeting the doomed instance
+        std::fs::write(
+            home.join("schedules.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "schema_version": 2,
+                "schedules": [{"id": "s-d", "message": "m", "target": "doomed",
+                    "trigger": {"kind": "cron", "expr": "0 9 * * *"}, "enabled": true,
+                    "timezone": "UTC", "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:00Z", "run_history": []}]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        // dispatch entry to the doomed instance
+        crate::dispatch_tracking::track_dispatch(
+            &home,
+            crate::dispatch_tracking::DispatchEntry {
+                task_id: Some("t-d".into()),
+                from: "lead".into(),
+                to: "doomed".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: chrono::Utc::now().to_rfc3339(),
+                status: "pending".into(),
+            },
+        );
+        // ci_watch with the doomed instance as sole subscriber
+        let ciw = crate::daemon::ci_watch::ci_watches_dir(&home);
+        std::fs::create_dir_all(&ciw).unwrap();
+        std::fs::write(
+            ciw.join("w.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "repo": "o/r", "branch": "feat",
+                "subscribers": [{"instance": "doomed"}],
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let result = super::full_delete_instance(&home, "doomed");
+        assert!(
+            result.is_ok(),
+            "clean cascade must return Ok, got {result:?}"
+        );
+
+        // schedule disabled + marked orphaned (NOT deleted)
+        let sched = &crate::schedules::load(&home).schedules[0];
+        assert!(!sched.enabled, "schedule must be disabled by cascade");
+        assert!(sched
+            .run_history
+            .last()
+            .is_some_and(|r| r.status.contains("orphaned")));
+        // dispatch entry GC'd
+        let store: serde_json::Value =
+            crate::store::load(&crate::store::store_path(&home, "dispatch_tracking.json"));
+        assert!(
+            store["entries"].as_array().unwrap().is_empty(),
+            "dispatch entry to deleted instance must be GC'd"
+        );
+        // ci watch removed (sole subscriber gone)
+        assert!(
+            !ciw.join("w.json").exists(),
+            "ci watch with only the deleted subscriber must be removed"
         );
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -232,6 +232,42 @@ pub fn set_enabled(home: &Path, schedule_id: &str, enabled: bool) {
     });
 }
 
+/// #1488: when an instance is deleted, disable every schedule that targets it
+/// and mark it orphaned in `run_history` — but DON'T delete the row, so the
+/// operator can re-target a still-useful schedule (e.g. an AI-Scout cron) at a
+/// surviving instance. Idempotent: an already-disabled schedule is left
+/// untouched (no duplicate `orphaned` marker), so a boot-time re-sweep doesn't
+/// grow `run_history` unboundedly. Returns the number of schedules newly
+/// orphaned.
+pub fn orphan_schedules_for_target(home: &Path, deleted_target: &str) -> usize {
+    let target = deleted_target.to_string();
+    let mut orphaned = 0usize;
+    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut ScheduleStore| {
+        let now = chrono::Utc::now().to_rfc3339();
+        for sched in store.schedules.iter_mut() {
+            if sched.target != target || !sched.enabled {
+                continue;
+            }
+            sched.enabled = false;
+            sched.updated_at = now.clone();
+            sched.run_history.push(ScheduleRun {
+                triggered_at: now.clone(),
+                status: format!("orphaned: target instance '{target}' deleted"),
+            });
+            orphaned += 1;
+        }
+        Ok(())
+    });
+    if orphaned > 0 {
+        tracing::info!(
+            target = %deleted_target,
+            count = orphaned,
+            "#1488: disabled + marked orphaned schedules targeting deleted instance"
+        );
+    }
+    orphaned
+}
+
 /// Normalise a 5-field cron to the 6-field form the `cron` crate expects
 /// (prepend a "0" seconds column). Idempotent for 6-field input.
 fn normalise_cron(expr: &str) -> String {
@@ -472,6 +508,7 @@ pub fn delete(home: &Path, args: &Value) -> Value {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -927,5 +964,71 @@ mod tests {
         let id2 = r2["id"].as_str().expect("id2");
         assert_ne!(id1, id2, "rapid-fire schedule IDs must be unique");
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #1488 cascade: orphan schedules when their target is deleted ──
+
+    fn seed_two_schedules(home: &Path) {
+        let store = serde_json::json!({
+            "schema_version": 2,
+            "schedules": [
+                {"id": "s-doomed", "message": "m", "target": "doomed",
+                 "trigger": {"kind": "cron", "expr": "0 9 * * *"}, "enabled": true,
+                 "timezone": "UTC", "created_at": "2026-01-01T00:00:00Z",
+                 "updated_at": "2026-01-01T00:00:00Z", "run_history": []},
+                {"id": "s-alive", "message": "m", "target": "alive",
+                 "trigger": {"kind": "cron", "expr": "0 9 * * *"}, "enabled": true,
+                 "timezone": "UTC", "created_at": "2026-01-01T00:00:00Z",
+                 "updated_at": "2026-01-01T00:00:00Z", "run_history": []}
+            ]
+        });
+        std::fs::write(
+            home.join("schedules.json"),
+            serde_json::to_string_pretty(&store).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn orphan_schedules_disables_target_and_marks_history_leaving_others() {
+        let home = tmp_home("orphan-sched");
+        seed_two_schedules(&home);
+        let n = orphan_schedules_for_target(&home, "doomed");
+        assert_eq!(n, 1, "exactly the doomed-targeting schedule is orphaned");
+        let store = load(&home);
+        let doomed = store.schedules.iter().find(|s| s.id == "s-doomed").unwrap();
+        assert!(!doomed.enabled, "doomed schedule must be disabled");
+        assert!(
+            doomed
+                .run_history
+                .last()
+                .is_some_and(|r| r.status.contains("orphaned")),
+            "doomed schedule must carry an orphaned run_history marker"
+        );
+        let alive = store.schedules.iter().find(|s| s.id == "s-alive").unwrap();
+        assert!(alive.enabled, "unrelated schedule must stay enabled");
+        assert!(alive.run_history.is_empty(), "unrelated schedule untouched");
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn orphan_schedules_is_idempotent_no_double_marking() {
+        let home = tmp_home("orphan-sched-idem");
+        seed_two_schedules(&home);
+        assert_eq!(orphan_schedules_for_target(&home, "doomed"), 1);
+        // Second sweep: already disabled → no-op, no extra history entry.
+        assert_eq!(
+            orphan_schedules_for_target(&home, "doomed"),
+            0,
+            "re-sweep of an already-orphaned schedule must be a no-op"
+        );
+        let store = load(&home);
+        let doomed = store.schedules.iter().find(|s| s.id == "s-doomed").unwrap();
+        assert_eq!(
+            doomed.run_history.len(),
+            1,
+            "idempotent: run_history must not grow on repeated sweeps"
+        );
+        std::fs::remove_dir_all(home).ok();
     }
 }


### PR DESCRIPTION
## What

Deleting an instance left its bound services dangling. This was the real trigger of this morning's incidents:
- **orphaned schedules** kept firing into the cron self-IPC fallback → the daemon **deadlock**
- **dispatch_tracking** entries to the gone instance re-warned forever → the **~81 "dispatch stuck check"** messages
- **CI watches** routed `[ci-ready-for-action]` / polled on behalf of a ghost subscriber

`full_delete_instance` now cascade-cleans all three, plus a cron fail-safe and a boot sweep for pre-existing orphans.

## Cascade (`full_delete_instance`)

- **schedules** — DISABLED + marked orphaned in `run_history`, **never deleted**. The operator may re-target a still-useful cron at a surviving instance (the AI-Scout case lead cited: kiro deleted, its morning/evening reports re-targeted to gemini — not lost). Idempotent so a boot re-sweep doesn't grow `run_history`.
- **dispatch_tracking** — GC'd (removed). Marking `"orphaned"` is *not* enough: `sweep_stuck` only skips `"completed"`, so an orphaned-but-uncompleted entry still re-fires. Removal is the only thing that stops the noise.
- **ci_watch** — drop the instance from `subscribers` + clear `next_after_ci`; remove a watch left with no subscribers and no `next_after_ci`.

## Fail-safe (`cron_tick`)

A schedule whose target is **not a known fleet instance** (deleted / renamed / typo) is now **skipped + warned** (`status "skipped_unknown_target"`) instead of falling through to the inbox / self-IPC fallback that caused the deadlock. A known-but-offline instance still gets its inbox enqueue (`ok_inbox`), so legitimate delivery is unchanged.

## Boot sweep (`daemon/orphan_sweep.rs`)

At startup (wired after `ci_watch::startup_sweep`), GC bindings orphaned by instances deleted **before** this fix existed (the source of the lingering 81 entries). It **reuses the per-instance cleanup functions** so the delete-path and boot-path share one implementation — no second copy to drift. No-ops when `fleet.yaml` is unreadable (never disable schedules on an unknown fleet).

## Policy decision (confirmed with lead)

Schedules are **never auto-deleted** — only disabled + marked orphaned, in both cascade and boot sweep. True GC (deletion) applies only to `dispatch_tracking` and `ci_watch` (transient, no re-target value). Recorded as a decision.

## Tests

Per-helper unit tests (`orphan_schedules_for_target` incl. idempotency, `dispatch_tracking::cleanup_for_instance` / `active_target_names`, `ci_watch::cleanup_watches_for_instance` incl. empty-watch removal, `fleet::instance_is_known`), the cron fail-safe (skip-ghost vs enqueue-known-offline), the boot sweep (cleans orphans / preserves known / no-op without fleet.yaml), and the end-to-end cascade through `full_delete_instance`.

Validated via `scripts/preflight.sh` (#1490): `cargo fmt --check` + `clippy --all-targets --features tray -D warnings` + `cargo test --tests --features tray` + the Windows `cargo xwin` cross-check — **all green**.

Closes #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)