### PR TITLE
test(#1492): cheap debug-only lock-across-self-IPC deadlock detection

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -343,11 +343,13 @@ pub fn resolve_instance(
 }
 
 /// Lock the agent registry, recovering from poison.
-pub fn lock_registry(
-    reg: &AgentRegistry,
-) -> parking_lot::MutexGuard<'_, std::collections::HashMap<crate::types::InstanceId, AgentHandle>> {
+pub fn lock_registry(reg: &AgentRegistry) -> RegistryGuard<'_> {
     crate::sync_audit::assert_lock_tier(1, "registry");
-    reg.lock()
+    let inner = reg.lock();
+    // #1492: mark the registry lock held so self-IPC vectors can detect a
+    // lock-across-IPC deadlock. Debug-only; release no-op.
+    crate::sync_audit::registry_lock_entered();
+    RegistryGuard { inner }
 }
 
 // ── #945 Phase 1: pending-registry slot for deferred attach ────────────
@@ -403,6 +405,8 @@ pub fn lock_registry_tracked<'a>(reg: &'a AgentRegistry, site: &'static str) -> 
     crate::sync_audit::assert_lock_tier(1, "registry");
     let inner = reg.lock();
     crate::sync_audit::set_registry_holder(site);
+    // #1492: see lock_registry. Debug-only; release no-op.
+    crate::sync_audit::registry_lock_entered();
     RegistryGuard { inner }
 }
 
@@ -434,6 +438,10 @@ impl<'a> std::ops::DerefMut for RegistryGuard<'a> {
 
 impl<'a> Drop for RegistryGuard<'a> {
     fn drop(&mut self) {
+        // #1492: clear the held-flag as the registry scope ends (debug-only;
+        // release no-op). The inner MutexGuard releases via field-drop right
+        // after this body.
+        crate::sync_audit::registry_lock_exited();
         crate::sync_audit::clear_registry_holder();
     }
 }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1411,3 +1411,45 @@ fn dropped_warn_input_is_key_names_only() {
         "warn input must contain key names only, never values"
     );
 }
+
+// ── #1492: lock_registry guard wiring for lock-across-self-IPC detection ──
+
+#[cfg(test)]
+fn empty_registry_1492() -> AgentRegistry {
+    std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Real wiring: `lock_registry` sets the debug held-flag, so a self-IPC vector
+/// (modeled by the assert) panics while the guard is alive. Proves the guard —
+/// not just the raw counter — participates. Debug-only: the detection compiles
+/// out in release, so the panic only exists there.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "lock-across-self-IPC")]
+fn lock_registry_guard_trips_self_ipc_assert_1492() {
+    let reg = empty_registry_1492();
+    let _guard = lock_registry(&reg);
+    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
+}
+
+/// Dropping the `lock_registry` guard BEFORE self-IPC (the 6f1403d-correct
+/// pattern) clears the held-flag, so the assert does not trip.
+#[cfg(debug_assertions)]
+#[test]
+fn lock_registry_guard_drop_clears_self_ipc_flag_1492() {
+    let reg = empty_registry_1492();
+    {
+        let _guard = lock_registry(&reg);
+    } // guard dropped → flag cleared
+    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
+}
+
+/// `lock_registry_tracked` participates in the same detection.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "lock-across-self-IPC")]
+fn lock_registry_tracked_guard_trips_self_ipc_assert_1492() {
+    let reg = empty_registry_1492();
+    let _guard = lock_registry_tracked(&reg, "test-1492");
+    crate::sync_audit::assert_no_registry_lock_for_self_ipc("enqueue_with_idle_hint");
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -666,6 +666,11 @@ fn spawn_one(
 /// 0600 so only the daemon's user can read it — this is the peer-UID
 /// substitute for TCP loopback (see `auth_cookie.rs`).
 pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
+    // #1492: self-IPC over the loopback socket. If the caller holds the
+    // registry lock, the API handler servicing this call needs the same lock →
+    // deadlock. Debug builds panic here so any unit test hitting the bad path
+    // fails loudly; release builds compile this to a no-op.
+    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
     let stream = crate::ipc::connect_api(home)?;
     let run = crate::daemon::find_active_run_dir(home)
         .ok_or_else(|| anyhow::anyhow!("no active daemon (run dir not found)"))?;

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -375,6 +375,11 @@ pub(crate) fn should_suppress_911_reinject_with_ledger(
 /// best-effort `[AGEND-MSG-PENDING]` PTY hint so daemon-side events do not
 /// strand silently when the recipient is at an idle prompt.
 pub fn enqueue_with_idle_hint(home: &Path, target: &str, msg: InboxMessage) -> anyhow::Result<()> {
+    // #1492: this is a self-IPC vector — the default emitter's PTY inject
+    // reaches `api::call` over the loopback socket. Calling it while holding
+    // the registry lock deadlocks the daemon (the morning cron bug). Debug
+    // builds panic here for an early, clear signal; release is a no-op.
+    crate::sync_audit::assert_no_registry_lock_for_self_ipc("enqueue_with_idle_hint");
     enqueue_with_idle_hint_with_emitter(home, target, msg, |hint| {
         compose_aware_inject(home, target, hint);
     })

--- a/src/sync_audit.rs
+++ b/src/sync_audit.rs
@@ -94,6 +94,66 @@ pub fn lock_released(tier: u8) {
     }
 }
 
+// ── #1492: lock-across-self-IPC deadlock detection (debug-only) ──────────
+//
+// The morning cron deadlock (#1479/#1483 neighborhood) was: a thread held the
+// registry lock and then made a self-IPC call (`api::call` over the loopback
+// socket, reachable via `enqueue_with_idle_hint`). The loopback API handler
+// needs the SAME registry lock → both sides wait forever. The integration
+// "restart smoke test" (#1481) only catches it after a real restart, which is
+// flaky and slow.
+//
+// This makes the bug catchable by ANY unit test that exercises the bad path:
+// a thread-local depth counter is bumped while the registry lock is held, and
+// the self-IPC vectors panic (debug builds only) if it's nonzero. Release
+// builds compile every entry/exit/assert to a no-op — zero overhead.
+
+#[cfg(debug_assertions)]
+thread_local! {
+    /// How many registry locks this thread currently holds (0 = none).
+    static REGISTRY_LOCK_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Record that this thread acquired the registry lock. Debug-only; release no-op.
+#[cfg(debug_assertions)]
+pub fn registry_lock_entered() {
+    REGISTRY_LOCK_DEPTH.with(|c| c.set(c.get().saturating_add(1)));
+}
+/// Release-build no-op (zero overhead).
+#[cfg(not(debug_assertions))]
+#[inline(always)]
+pub fn registry_lock_entered() {}
+
+/// Record that this thread released the registry lock. Debug-only; release no-op.
+#[cfg(debug_assertions)]
+pub fn registry_lock_exited() {
+    REGISTRY_LOCK_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
+}
+/// Release-build no-op (zero overhead).
+#[cfg(not(debug_assertions))]
+#[inline(always)]
+pub fn registry_lock_exited() {}
+
+/// Panic (debug builds only) if a self-IPC vector is entered while this thread
+/// holds the registry lock — that ordering deadlocks the daemon (#1492). `ctx`
+/// names the vector for the panic message. Release builds: no-op, zero cost.
+#[cfg(debug_assertions)]
+pub fn assert_no_registry_lock_for_self_ipc(ctx: &str) {
+    let depth = REGISTRY_LOCK_DEPTH.with(|c| c.get());
+    if depth > 0 {
+        panic!(
+            "#1492 lock-across-self-IPC deadlock risk: `{ctx}` was called while this thread holds \
+             the registry lock (depth={depth}). The loopback API handler needs the same lock, so \
+             this self-IPC would deadlock the daemon. Drop the registry guard BEFORE the call \
+             (see commit 6f1403d and docs/DAEMON-LOCK-ORDERING.md)."
+        );
+    }
+}
+/// Release-build no-op (zero overhead).
+#[cfg(not(debug_assertions))]
+#[inline(always)]
+pub fn assert_no_registry_lock_for_self_ipc(_ctx: &str) {}
+
 /// Convenience macro for lock tier assertion + acquisition tracking.
 #[macro_export]
 macro_rules! lock_tier_assert {
@@ -222,5 +282,37 @@ mod tests {
         IS_ROUTER_THREAD.set(true);
         // L3 is allowed for router thread
         assert_lock_tier(3, "heartbeat_pair");
+    }
+
+    // ── #1492: lock-across-self-IPC deadlock detection ──
+    // (Mechanism-level here; the real `lock_registry` guard wiring is tested
+    // in `agent::mod` tests — `agent` is bin-only, not in this shared lib.)
+
+    /// No registry lock held → the self-IPC assert is a no-op (no panic). Holds
+    /// in both debug and release (release is a no-op unconditionally).
+    #[test]
+    fn self_ipc_assert_is_noop_without_lock() {
+        assert_no_registry_lock_for_self_ipc("test-vector");
+    }
+
+    /// While the depth flag is set (as `lock_registry` does on acquire), a
+    /// self-IPC vector trips the assert. Debug-only — the detection compiles
+    /// out in release, so the panic only exists there.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "lock-across-self-IPC")]
+    fn self_ipc_assert_panics_while_lock_depth_nonzero() {
+        registry_lock_entered();
+        assert_no_registry_lock_for_self_ipc("api::call");
+    }
+
+    /// The correct pattern (release the lock BEFORE self-IPC — the 6f1403d fix
+    /// shape, modeled here by a balanced enter/exit) must NOT trip the assert.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn self_ipc_assert_ok_after_balanced_enter_exit() {
+        registry_lock_entered();
+        registry_lock_exited();
+        assert_no_registry_lock_for_self_ipc("api::call");
     }
 }


### PR DESCRIPTION
## What

The morning cron deadlock — a thread holding the **registry lock** then making a **self-IPC** call (`api::call` over the loopback socket, reachable via `enqueue_with_idle_hint`), whose handler needs the *same* lock → both wait forever — was only catchable by the flaky/slow restart smoke test (#1481). This makes it catchable by **any unit test** that hits the bad path.

## Mechanism (debug builds only — release compiles to no-ops, zero overhead)

- A thread-local **registry-lock depth** counter in `sync_audit`. `lock_registry` / `lock_registry_tracked` bump it on acquire; the `RegistryGuard`'s `Drop` decrements it on release.
  - `lock_registry` now returns the same `RegistryGuard` wrapper as the tracked variant — **source-compatible across all 68 call sites** via its existing `Deref`/`DerefMut` to the registry map (build confirms no ripple).
- The self-IPC vectors `api::call` and `inbox::enqueue_with_idle_hint` assert the depth is zero on entry and **panic** with a clear `lock-across-self-IPC deadlock risk` message (naming the vector) if not.

Net effect: holding the registry lock across self-IPC now **fails loudly in any debug test** instead of wedging the daemon at runtime.

## Validation

The **entire existing suite (2902 unit + all integration targets) passes with the assert live** — confirming no current path holds the lock across self-IPC (6f1403d fixed the known one; the assert finds no others).

Regression tests:
- `sync_audit` — the depth mechanism (no-op at depth 0 / panics when nonzero / clears on balanced exit).
- `agent::tests` — the **real** `lock_registry` & `lock_registry_tracked` guard wiring: guard held → assert panics; guard dropped first (the 6f1403d-correct pattern) → no panic.

Validated via `scripts/preflight.sh`: `cargo fmt --check` + `clippy --all-targets --features tray -D warnings` + `cargo test --tests --features tray` + Windows `cargo xwin` cross-check — **all green**.

Release overhead: the detection fns are `#[cfg(not(debug_assertions))]` empty `#[inline(always)]` no-ops; the only residual is the `RegistryGuard` wrapper's `Drop` (one cached-bool check, already present for the tracked variant) — effectively zero.

Closes #1492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)