### PR TITLE
fix(#1494): idempotent bind on repo checkout — reuse existing worktree

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -145,6 +145,51 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             }
         }
     }
+    // #1494: idempotent bind. When `bind:true` and THIS agent already holds a
+    // binding on the SAME branch whose worktree is live on disk, the branch was
+    // already provisioned — by the dispatch pre-build hook (binding.json +
+    // worktree at `<agent>/<branch>`) or a prior `repo checkout`. The direct
+    // `git worktree add` below would otherwise fail with "is already checked
+    // out" (the same branch is leased at the dispatch path, a DIFFERENT dir
+    // than this handler's `<agent>-<source>` scheme), forcing a manual `cd`.
+    // Return the EXISTING worktree path as success instead — same spirit as
+    // #1465 idempotent-release: operation already at target state = success.
+    //
+    // Cross-agent safety: `binding::read` is keyed per-agent, so a DIFFERENT
+    // agent holding the branch leaves this agent's binding absent/mismatched —
+    // the short-circuit does NOT fire and the genuine `git worktree add`
+    // conflict error below is preserved. Same-agent DIFFERENT-branch bindings
+    // also fall through (branch mismatch), unchanged.
+    if bind {
+        if let Some(existing) = crate::binding::read(home, instance_name) {
+            let same_branch = existing.get("branch").and_then(|v| v.as_str()) == Some(branch);
+            let live_wt = existing
+                .get("worktree")
+                .and_then(|v| v.as_str())
+                .map(std::path::PathBuf::from)
+                .filter(|p| p.exists());
+            if same_branch {
+                if let Some(wt) = live_wt {
+                    let wt_str = wt.display().to_string();
+                    tracing::info!(
+                        instance = instance_name,
+                        %branch,
+                        path = %wt_str,
+                        "repo checkout bind:true idempotent — agent already bound to this branch, returning existing worktree"
+                    );
+                    return json!({
+                        "path": wt_str,
+                        "source": source_path,
+                        "branch": branch,
+                        "bound": true,
+                        "idempotent": true,
+                        "auto_created_branch": auto_created_branch,
+                        "fetch_attempted": fetch_attempted,
+                    });
+                }
+            }
+        }
+    }
     // When `bind:true`, omit `--detach` so HEAD lands on the named
     // branch — subsequent commits write to the right ref without the
     // extra `git switch` that triggered the #778 chicken-and-egg.

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -822,6 +822,71 @@ fn checkout_bind_true_writes_binding_marker_and_arms_watch() {
 
 #[test]
 #[cfg(unix)]
+fn checkout_bind_true_idempotent_when_already_bound_1494() {
+    // #1494 RED→GREEN: the dispatch pre-build hook leases the agent's
+    // worktree at the canonical `<agent>/<branch>` path and writes
+    // binding.json before the agent claims. When the agent THEN runs
+    // `repo action=checkout bind:true` on the same branch, this handler's
+    // DIFFERENT `<agent>-<source>` path scheme means the direct
+    // `git worktree add <agent>-<source> <branch>` fails with "is already
+    // checked out at <agent>/<branch>" — the release-dance pain. The
+    // handler must detect the existing same-branch binding and return that
+    // worktree path idempotently (same spirit as #1465 idempotent-release).
+    //
+    // REGRESSION-PROOF: delete the `if bind { if let Some(existing) = ...`
+    // short-circuit in handle_checkout_repo → the claim re-runs
+    // `git worktree add` on an already-checked-out branch, this returns
+    // `{error, code:"worktree_add_failed"}`, and the assertions below fail.
+    let home = p778_tmp_home("1494-idem");
+    let parent = p778_tmp_home("1494-idem-src");
+    let source = p778_setup_source_repo(&parent, "feat/1494");
+    let agent = "idem-dev";
+
+    // Simulate the dispatch pre-build: lease the worktree at the canonical
+    // `<agent>/<branch>` path + write binding.json — exactly what the
+    // dispatch hook does before the agent claims.
+    let lease = crate::worktree_pool::lease(&home, &source, agent, "feat/1494")
+        .expect("dispatch pre-build lease must succeed");
+    let dispatch_path = lease.path.clone();
+    assert!(dispatch_path.exists(), "pre-built worktree must exist");
+
+    // Agent claims via `repo checkout bind:true` on the SAME branch.
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": "feat/1494",
+            "bind": true,
+        }),
+        agent,
+    );
+
+    assert!(
+        resp.get("error").is_none(),
+        "#1494: re-bind to already-bound branch must be idempotent, not error: {resp}"
+    );
+    assert_eq!(
+        resp["bound"].as_bool(),
+        Some(true),
+        "must still report bound: {resp}"
+    );
+    assert_eq!(
+        resp["idempotent"].as_bool(),
+        Some(true),
+        "#1494: short-circuit must flag the idempotent reuse: {resp}"
+    );
+    assert_eq!(
+        resp["path"].as_str(),
+        Some(dispatch_path.display().to_string().as_str()),
+        "#1494: must return the EXISTING dispatch worktree path, not a fresh one: {resp}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
 fn checkout_writes_event_log_success_and_error_1466() {
     // #1466: every checkout outcome — success AND error — must leave a
     // `worktree_checkout` event-log trace (observability for silent


### PR DESCRIPTION
## What

Closes #1494. Makes `repo action=checkout bind:true` **idempotent** when the target branch is already provisioned for the calling agent — the bind no longer errors with `already checked out`, forcing a manual `cd`.

## Root cause

Two worktree path schemes coexist:

| Path | Used by | Reuse logic |
|---|---|---|
| `home/worktrees/<agent>/<branch>` | dispatch pre-build hook + `bind_self` (via `worktree_pool::lease` → `worktree::create`) | **idempotent** (worktree.rs:140-174 reuses on same-branch) |
| `home/worktrees/<agent>-<source>` | `repo checkout bind:true` (`handle_checkout_repo`) | **none** — direct `git worktree add` |

When the dispatch hook pre-builds the branch at `<agent>/<branch>` and the agent then claims via `repo checkout bind:true`, the direct `git worktree add <agent>-<source> <branch>` fails with `is already checked out at <agent>/<branch>` → `worktree_add_failed`. (`bind_self` was already idempotent; only this path lacked reuse.)

## Fix

Same spirit as #1465 idempotent-release (operation already at target state = success): when `bind:true` and THIS agent already holds a binding on the SAME branch with a live worktree on disk, return that existing worktree path as success instead of erroring.

**Cross-agent conflict preserved**: `binding::read` is keyed per-agent, so a DIFFERENT agent holding the branch leaves this agent's binding absent/mismatched — the short-circuit does NOT fire and the genuine `git worktree add` conflict error is preserved. Same-agent different-branch bindings fall through unchanged.

## Test

`checkout_bind_true_idempotent_when_already_bound_1494` — RED→GREEN reproduction: leases the worktree the way the dispatch hook does, then runs `repo checkout bind:true` on the same branch and asserts idempotent success returning the existing path. Verified RED without the short-circuit (`worktree_add_failed`).

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- 28 checkout + 124 bind/binding tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)