### PR TITLE
docs(#1455): Protocol Structure & Maintenance + consolidation meta-rule

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL.md
+++ b/docs/FLEET-DEV-PROTOCOL.md
@@ -2,6 +2,20 @@
 
 **Status:** ACTIVE — all fleet agents must follow this protocol.
 
+## Protocol Structure & Maintenance
+
+This document has two layers:
+
+- **Normative layer (§0–§13)** — the rules. Everything you need to *act correctly right now*. No sprint numbers, PR/issue references, dates, or incident retellings belong here.
+- **Appendix A — Rationale & Incident Log** — the *why* and the *when*. The empirical incidents, activation histories, and motivations behind the rules, keyed by section ID. A rule distilled from an incident carries a `↳ 緣由 A-§X` pointer; follow it only when questioning or revising the rule.
+- **Appendix B — Section Number Map** — archaeology of past renumberings.
+
+**Consolidation ritual (maintenance meta-rule).** New rules accrete; old ones rarely get retired. To keep the normative layer legible:
+
+- A new rule MUST land in the normative layer as an *imperative* (what to do), with any incident narrative going to Appendix A — never inline.
+- Every ~10 new rules OR every protocol-touching sprint, do a consolidation pass: merge overlapping rules, retire superseded ones (move the trail to Appendix A), and confirm the normative layer still reads in one sitting.
+- If a normative section can no longer be understood without its appendix entry, the rule wording is incomplete — fix the wording, don't lean on the appendix.
+
 ## §0. KISS Principle
 
 Every PR must answer: **"What real problem does this solve?"** and **"Would deletion break anyone?"** Changes lacking a concrete failure mode = `KISS-VIOLATION — UNVERIFIED`.


### PR DESCRIPTION
## What

**#1455 rebase-and-reduce.** #1455's other half (relocate incident narrative → Appendix A) was already done by the merged #1453 (main has Appendix A @714 + B @755), so merging #1455 wholesale would collide two independent Appendix-A bodies. This rescues **only #1455's unique content**: the **Protocol Structure & Maintenance** section.

Added after the `Status:` line:
- The two-layer explanation — **Normative layer (§0–§13)** / **Appendix A — Rationale & Incident Log** / **Appendix B — Section Number Map**.
- The **consolidation ritual** maintenance meta-rule: new rules land as imperatives (narrative → Appendix A, never inline); a consolidation pass every ~10 rules / protocol-touching sprint; fix rule wording rather than lean on the appendix.

## Scope discipline

- Based on **current origin/main** (already has #1453's Appendix A/B) — the new block's references resolve against the existing appendices.
- **Pure additive**: one section, **+14 / -0**. Did NOT redo #1453's per-section `↳ 緣由` pointers or Appendix A creation.
- Heeded the #1508 lesson: verified `git diff --stat` against a freshly-fetched `origin/main` is this file only — no stale-base reverse-revert.

Docs-only (no Rust touched).

Refs #1455 (old #1455 to be closed as superseded by #1453 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)