### PR TITLE
fix(#1496): unify dispatch — task(create) is a pure record, send(kind=task) is sole dispatch

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -173,9 +173,18 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                     || t.status == crate::task_events::TaskStatus::InProgress)
         })
         .collect();
+    // #1496 Option 1: a send(kind=task) whose `task_id` is already one of the
+    // target's active tasks is ENRICHING that in-flight dispatch (finally
+    // delivering its context), not opening a competing one — let it through the
+    // busy-gate. Pairs with dropping task(create)'s premature auto-notify so the
+    // create→send dispatch sequence no longer needs force=true (#1496 spike).
+    let enriching_active = args["task_id"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .is_some_and(|tid| claimed_tasks.iter().any(|t| t.id.as_str() == tid));
     // #1286: branch-specific dispatch dedup — reject if target already has
     // an active task on the same branch (more specific than generic busy).
-    if !force {
+    if !force && !enriching_active {
         if let Some(branch) = args["branch"].as_str() {
             if let Some(dup) = claimed_tasks
                 .iter()
@@ -190,7 +199,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
             }
         }
     }
-    if !claimed_tasks.is_empty() {
+    if !claimed_tasks.is_empty() && !enriching_active {
         if force {
             if force_reason.is_none() || force_reason == Some("") {
                 return json!({"error": "force=true requires a non-empty 'force_reason'"});

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1284,6 +1284,60 @@ fn test_delegate_task_busy_returns_structured_response() {
 }
 
 #[test]
+fn test_delegate_task_enriching_same_task_id_bypasses_busy_gate_1496() {
+    // #1496 Option 1: a send(kind=task) whose `task_id` IS the target's current
+    // active task is ENRICHING that in-flight dispatch (finally delivering its
+    // context), not opening a competing one — it must pass the busy-gate WITHOUT
+    // force. This is what lets the create→send dispatch sequence work without the
+    // force-resend tax. Contrast test_delegate_task_busy_returns_structured_response
+    // (a DIFFERENT task_id, correctly gated).
+    //
+    // Exercises BOTH gates: the #1286 same-branch dedup reject and the generic
+    // busy reject — the `!enriching_active` guard short-circuits both.
+    //
+    // REGRESSION-PROOF: drop the `&& !enriching_active` guards in comms.rs → this
+    // send is rejected ("already has active task on branch" / busy:true) and the
+    // assertions below fail.
+    let _g = fleet_test_guard();
+    let home = tmp_home("busy-enrich-1496");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
+    )
+    .ok();
+    std::env::set_var("AGEND_HOME", &home);
+    crate::tasks::handle(
+        &home,
+        "target",
+        &json!({"action": "create", "title": "in-flight work", "branch": "feat/x"}),
+    );
+    let tasks = crate::tasks::handle(&home, "target", &json!({"action": "list"}));
+    let tid = tasks["tasks"][0]["id"].as_str().unwrap().to_string();
+    crate::tasks::handle(&home, "target", &json!({"action": "claim", "id": &tid}));
+
+    // Enriching dispatch: same task_id AND same branch as the target's active task.
+    let result = handle_tool(
+        "send",
+        &json!({"instance": "target", "task": "full context", "message": "full context", "request_kind": "task", "branch": "feat/x", "task_id": tid}),
+        "sender",
+    );
+    assert!(
+        result.get("busy").is_none(),
+        "#1496: send with task_id == target's active task must bypass the busy-gate (enriching, not competing): {result}"
+    );
+    assert!(
+        result.get("error").is_none()
+            || !result["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("already has active task"),
+        "#1496: enriching same-task send must not hit the #1286 same-branch dedup reject: {result}"
+    );
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
 fn test_delegate_task_force_true_bypasses_busy_gate() {
     let _g = fleet_test_guard();
     let home = tmp_home("interrupt-bypass");

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -97,41 +97,21 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             match crate::task_events::append(home, &emitter, event) {
                 Ok(_) => {
                     let task = read_task_record(home, &id).map(|r| record_to_task(&r));
-                    let dispatch_target = routed_to.as_ref().or(assignee.as_ref());
-                    if let Some(target) = dispatch_target {
-                        if target != instance_name {
-                            let branch_str = args["branch"]
-                                .as_str()
-                                .map(|b| format!("\nBranch: {b}"))
-                                .unwrap_or_default();
-                            let msg_text =
-                                format!("[delegate_task] {title}{branch_str} (task id: {id})");
-                            let inbox_msg = crate::inbox::InboxMessage {
-                                from: format!("from:{instance_name}"),
-                                text: msg_text.clone(),
-                                kind: Some("task".to_string()),
-                                task_id: Some(id.clone()),
-                                correlation_id: Some(id.clone()),
-                                timestamp: chrono::Utc::now().to_rfc3339(),
-                                ..Default::default()
-                            };
-                            let _ = crate::inbox::storage::enqueue(home, target, inbox_msg);
-                            crate::dispatch_tracking::track_dispatch(
-                                home,
-                                crate::dispatch_tracking::DispatchEntry {
-                                    task_id: Some(id.clone()),
-                                    from: instance_name.to_string(),
-                                    to: target.to_string(),
-                                    from_id: None,
-                                    to_id: None,
-                                    delegated_at: chrono::Utc::now().to_rfc3339(),
-                                    status: "pending".to_string(),
-                                },
-                            );
-                            let source = crate::inbox::NotifySource::Agent(instance_name);
-                            crate::inbox::notify::notify_agent(home, target, &source, &msg_text);
-                        }
-                    }
+                    // #1496 Option 1: `task(action:create)` is a PURE board record
+                    // with ZERO dispatch side-effects — no inbox enqueue, no
+                    // dispatch_tracking, no PTY notify. Dispatch (notify + worktree
+                    // auto-bind) is solely `send(kind=task)`'s job; it auto-creates
+                    // the board row when `task_id` is empty (comms.rs), so the
+                    // single-step "create + dispatch" use case is fully preserved
+                    // via one `send(kind=task)` call.
+                    //
+                    // The prior auto-notify (#1238) was a second, inferior dispatch
+                    // path: a title-only, non-actionable wake carrying no task
+                    // description. It fired prematurely — pushing the assignee into
+                    // the busy state before the real, context-rich `send(kind=task)`
+                    // arrived — so that send hit the busy-gate and forced operators
+                    // to re-send with `force=true`. Removing it unifies dispatch on
+                    // one path and kills the race (see #1496 spike).
                     serde_json::json!({
                         "id": id,
                         "event": "created",
@@ -1215,30 +1195,12 @@ mod tests {
         crate::inbox::storage::drain(home, agent)
     }
 
-    #[test]
-    fn create_with_assignee_sends_task_to_inbox() {
-        let home = tmp_home("assign_inbox");
-        let result = handle(
-            &home,
-            "lead-agent",
-            &serde_json::json!({
-                "action": "create",
-                "title": "implement feature X",
-                "assignee": "dev-agent",
-                "branch": "fix/feature-x",
-            }),
-        );
-        assert_eq!(result["event"], "created");
-        let task_id = result["id"].as_str().unwrap();
-
-        let msgs = drain_inbox(&home, "dev-agent");
-        assert!(!msgs.is_empty(), "assignee should receive inbox message");
-        let msg = &msgs[0];
-        assert_eq!(msg.kind.as_deref(), Some("task"));
-        assert_eq!(msg.task_id.as_deref(), Some(task_id));
-        assert!(msg.text.contains("implement feature X"));
-        assert!(msg.text.contains("fix/feature-x"));
-    }
+    // #1496 Option 1: create no longer auto-notifies, so the prior
+    // `create_with_assignee_sends_task_to_inbox` /
+    // `create_with_assignee_correlation_id_matches_task_id` tests (which asserted
+    // an inbox message on create) are removed — their inverse is now
+    // `create_with_assignee_has_no_dispatch_side_effects_1496`. Dispatch-message
+    // shape (kind/task_id/correlation_id) is covered on the send(kind=task) path.
 
     #[test]
     fn create_without_assignee_sends_no_message() {
@@ -1292,29 +1254,6 @@ mod tests {
         assert_eq!(task["assignee"], "dev-agent");
     }
 
-    #[test]
-    fn create_with_assignee_correlation_id_matches_task_id() {
-        let home = tmp_home("corr_id");
-        let result = handle(
-            &home,
-            "lead-agent",
-            &serde_json::json!({
-                "action": "create",
-                "title": "correlated task",
-                "assignee": "dev-agent",
-            }),
-        );
-        let task_id = result["id"].as_str().unwrap();
-
-        let msgs = drain_inbox(&home, "dev-agent");
-        let msg = &msgs[0];
-        assert_eq!(
-            msg.correlation_id.as_deref(),
-            Some(task_id),
-            "correlation_id should match task_id for auto-close"
-        );
-    }
-
     fn write_fleet_yaml_with_team(home: &std::path::Path, team: &str, orchestrator: &str) {
         let yaml = format!(
             "teams:\n  {team}:\n    orchestrator: {orchestrator}\n    members:\n      - dev-a\n      - dev-b\n"
@@ -1323,7 +1262,12 @@ mod tests {
     }
 
     #[test]
-    fn create_with_team_assignee_routes_to_orchestrator() {
+    fn create_with_team_assignee_records_orchestrator_routing() {
+        // #1496 Option 1: create no longer notifies, but it still RESOLVES a team
+        // assignee to its orchestrator and RECORDS that on the task (`routed_to`).
+        // The dispatch-time team→orchestrator inbox routing is covered separately
+        // on the send(kind=task) path
+        // (mcp::handlers::tests::test_delegate_task_resolves_team_to_orchestrator_inbox).
         let home = tmp_home("team_route");
         write_fleet_yaml_with_team(&home, "my-team", "team-lead");
 
@@ -1337,64 +1281,61 @@ mod tests {
             }),
         );
         assert_eq!(result["event"], "created");
-
-        let orch_msgs = drain_inbox(&home, "team-lead");
-        assert!(
-            !orch_msgs.is_empty(),
-            "orchestrator should receive inbox message when team is assignee"
+        assert_eq!(
+            result["task"]["routed_to"].as_str(),
+            Some("team-lead"),
+            "team assignee must resolve to its orchestrator in the record: {result}"
         );
-        assert_eq!(orch_msgs[0].kind.as_deref(), Some("task"));
-        assert!(orch_msgs[0].text.contains("team task"));
 
-        let team_msgs = drain_inbox(&home, "my-team");
+        // Pure record: no inbox side-effect for the orchestrator OR the raw team.
         assert!(
-            team_msgs.is_empty(),
-            "raw team name should NOT receive inbox message"
+            !home.join("inbox").join("team-lead.jsonl").exists()
+                && !home.join("inbox").join("my-team.jsonl").exists(),
+            "create must not enqueue any inbox message"
         );
     }
 
     #[test]
-    fn create_with_assignee_tracks_dispatch() {
-        let home = tmp_home("dispatch_track");
+    fn create_with_assignee_has_no_dispatch_side_effects_1496() {
+        // #1496 Option 1: `task(action:create)` is a PURE board record. Creating
+        // a task assigned to ANOTHER agent must NOT enqueue an inbox message or
+        // write a dispatch-tracking entry — dispatch (notify + worktree auto-bind)
+        // is solely `send(kind=task)`'s job. Pre-#1496 (#1238) this auto-notified
+        // with a title-only, non-actionable wake that raced the real send into the
+        // busy-gate, taxing every dispatch with a force-resend.
+        //
+        // REGRESSION-PROOF: restore the auto-notify block in the create handler →
+        // both assertions below fail (the assignee's inbox jsonl and
+        // dispatch_tracking.json reappear). Subsumes the old self-assign case:
+        // create never dispatches now, for self OR other.
+        let home = tmp_home("create_no_dispatch_1496");
         let result = handle(
             &home,
             "lead-agent",
             &serde_json::json!({
                 "action": "create",
-                "title": "tracked dispatch task",
+                "title": "pure record task",
                 "assignee": "dev-agent",
+                "branch": "feat/x",
             }),
         );
-        assert_eq!(result["event"], "created");
-        let task_id = result["id"].as_str().unwrap();
-
-        let store: serde_json::Value =
-            crate::store::load(&crate::store::store_path(&home, "dispatch_tracking.json"));
-        let entries = store["entries"].as_array().expect("entries array");
-        assert_eq!(entries.len(), 1, "one dispatch entry expected");
-        assert_eq!(entries[0]["task_id"], task_id);
-        assert_eq!(entries[0]["from"], "lead-agent");
-        assert_eq!(entries[0]["to"], "dev-agent");
-        assert_eq!(entries[0]["status"], "pending");
-    }
-
-    #[test]
-    fn create_self_assign_no_dispatch_tracking() {
-        let home = tmp_home("dispatch_self");
-        handle(
-            &home,
-            "dev-agent",
-            &serde_json::json!({
-                "action": "create",
-                "title": "self task",
-                "assignee": "dev-agent",
-            }),
-        );
-
-        let path = crate::store::store_path(&home, "dispatch_tracking.json");
+        assert_eq!(result["event"], "created", "task still created: {result}");
         assert!(
-            !path.exists(),
-            "self-assign should not create dispatch tracking entry"
+            result["id"].as_str().is_some(),
+            "task id returned: {result}"
+        );
+
+        // No inbox message enqueued for the assignee.
+        let assignee_inbox = home.join("inbox").join("dev-agent.jsonl");
+        assert!(
+            !assignee_inbox.exists(),
+            "#1496: create must not enqueue an inbox message for the assignee"
+        );
+        // No dispatch-tracking entry written.
+        let track = crate::store::store_path(&home, "dispatch_tracking.json");
+        assert!(
+            !track.exists(),
+            "#1496: create must not write a dispatch-tracking entry"
         );
     }
 


### PR DESCRIPTION
Implements **Option 1** from the #1496 spike (operator-approved; 4-person dialectic unanimous). Closes #1496.

## Root cause

Since #1238, `task(action:create, assignee)` carried a **second, inferior dispatch mechanism**: a title-only, non-actionable PTY notify that delivered no task description (plain `enqueue` + `notify_agent`, vs `send(kind=task)`'s full-body `enqueue_with_idle_hint` actionable pointer). It caused **two** pains:
- **cheerc's:** the `[delegate_task] <title>` line doesn't match the `[AGEND-MSG]` pattern agents are trained on → agent acts on the bare title, never reads the inbox/description.
- **ours:** the premature wake pushed the assignee into the busy state *before* the real `send(kind=task)` arrived, so that send hit the busy-gate → forced `force=true` re-send on every dispatch.

## ① Main fix — `task(create)` is a pure board record

`tasks/handler.rs`: removed the auto-notify block. Create no longer enqueues an inbox message, tracks a dispatch, or notifies — **zero dispatch side-effects**. Dispatch (notify + worktree auto-bind + dispatch tracking) is solely `send(kind=task)`'s job; it **auto-creates the board row** when `task_id` is empty (comms.rs:310-344), so single-step "create + dispatch" is fully preserved via one `send(kind=task)`.

- **Verified (lead's mandatory grep):** `tasks/handler.rs` never calls `dispatch_auto_bind_lease`/`lease`/`create`/`bind_full` — worktree provisioning happens only on the `send(kind=task)` path (comms.rs:288), so removing the notify does **not** strip worktrees from `task create --assignee --branch` users.
- **Incidental fix:** `send(kind=task)` with empty `task_id` auto-creates with `assignee=target`, so pre-#1496 the internal create *also* auto-notified the target on top of send's own notify — a latent **double-notification**. Now single.

## ② Busy-gate enrich exemption

`comms.rs`: a `send(kind=task)` whose `task_id` IS one of the target's active tasks is **enriching** that in-flight dispatch (finally delivering its context), not opening a competing one — it bypasses both the #1286 same-branch reject and the generic busy reject **without** `force=true`. ~10 lines, gated on `!enriching_active`.

## Tests (RED→GREEN, both proven)

- **Added** `create_with_assignee_has_no_dispatch_side_effects_1496` — asserts no inbox message + no dispatch-tracking entry on create (RED if the notify block returns).
- **Added** `test_delegate_task_enriching_same_task_id_bypasses_busy_gate_1496` — same-`task_id` send bypasses both gates (RED if the `!enriching_active` guards are dropped).
- **Removed** 3 tests that asserted the removed auto-notify (`create_with_assignee_sends_task_to_inbox`, `..._correlation_id_matches_task_id`, `create_self_assign_no_dispatch_tracking`) and inverted `create_with_assignee_tracks_dispatch`.
- **Repurposed** `create_with_team_assignee_routes_to_orchestrator` → `..._records_orchestrator_routing` (asserts record-level `routed_to`; send-path team→orchestrator inbox routing stays covered by `test_delegate_task_resolves_team_to_orchestrator_inbox`).

## Scope note

Lead's dispatch flagged 2 tests; there were actually **5** tied to create's auto-notify — all handled above (delete/invert/repurpose).

## Verification

- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.
- tasks + comms + handlers + dispatch_tracking + inbox suites green (565+).
- Rebased onto fresh origin/main (`bbfc493`, #1508) before push — diff is only the 3 intended files (#1508 stale-worktree lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)