### PR TITLE
fix(#1504): Windows shim recursive-spawn storm — 3-layer fix (P0)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -544,6 +544,52 @@ pub struct SpawnConfig<'a> {
     pub shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
+/// #1504 L1: split `path` with the platform PATH separator (`;` on Windows,
+/// `:` elsewhere) and drop the shim dir (`$AGEND_HOME/bin`). Pure so the
+/// exclusion is unit-testable without a live env. `split_paths` correctly
+/// handles Windows drive-colons and quoted entries — the bug the old
+/// `.split(':')` introduced.
+fn git_search_without_shim(
+    path: &std::ffi::OsStr,
+    shim_dir: Option<&std::path::Path>,
+) -> Vec<PathBuf> {
+    std::env::split_paths(path)
+        .filter(|p| !p.as_os_str().is_empty())
+        .filter(|p| !same_dir(p, shim_dir))
+        .collect()
+}
+
+/// True when `a` and `b` name the same directory. Prefers `canonicalize`
+/// (resolves slash form + case-folds on Windows NTFS + follows symlinks);
+/// falls back to a lexical compare when either side doesn't exist on disk
+/// (e.g. `$AGEND_HOME/bin` not yet created — a common case). NEVER unwraps
+/// `canonicalize`: it `Err`s on missing paths (#1504).
+fn same_dir(a: &std::path::Path, b: Option<&std::path::Path>) -> bool {
+    let Some(b) = b else { return false };
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(x), Ok(y)) => x == y,
+        _ => lexical_path_eq(a, b),
+    }
+}
+
+/// Lexical directory equality fallback: normalize backslashes to forward
+/// slashes, strip trailing separators, and compare case-insensitively on
+/// Windows. Used only when a path can't be canonicalized (doesn't exist yet).
+fn lexical_path_eq(a: &std::path::Path, b: &std::path::Path) -> bool {
+    let norm = |p: &std::path::Path| {
+        p.to_string_lossy()
+            .replace('\\', "/")
+            .trim_end_matches('/')
+            .to_string()
+    };
+    let (na, nb) = (norm(a), norm(b));
+    if cfg!(windows) {
+        na.eq_ignore_ascii_case(&nb)
+    } else {
+        na == nb
+    }
+}
+
 /// Build a `CommandBuilder` with resolved args, env, and working directory.
 ///
 /// Extracted from `spawn_agent` so the command-construction logic (arg
@@ -693,16 +739,15 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
     // real git binary without recursion (R12 mitigation).
     // Excludes $AGEND_HOME/bin/ from PATH to avoid resolving to the shim itself.
     if std::env::var("AGEND_REAL_GIT").is_err() {
-        let agend_bin = home
-            .map(|h| h.join("bin").display().to_string())
+        // #1504: build the git search PATH using the platform-aware separator.
+        // The prior `.split(':')` was hardcoded Unix; on Windows PATH is
+        // `;`-separated AND entries carry drive-colons (`C:\…`), so `:`-splitting
+        // shredded PATH → `which_in` failed → AGEND_REAL_GIT never got injected →
+        // the shim later resolved git to itself (recursive-spawn storm, #1504 L1).
+        let agend_bin: Option<PathBuf> = home.map(|h| h.join("bin"));
+        let path_os = std::env::var_os("PATH").unwrap_or_default();
+        let search = std::env::join_paths(git_search_without_shim(&path_os, agend_bin.as_deref()))
             .unwrap_or_default();
-        let search_paths: Vec<PathBuf> = std::env::var("PATH")
-            .unwrap_or_default()
-            .split(':')
-            .filter(|p| !p.is_empty() && *p != agend_bin)
-            .map(PathBuf::from)
-            .collect();
-        let search = std::env::join_paths(&search_paths).unwrap_or_default();
         if let Ok(git_path) = which::which_in("git", Some(search), ".") {
             cmd.env("AGEND_REAL_GIT", git_path);
         }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1453,3 +1453,68 @@ fn lock_registry_tracked_guard_trips_self_ipc_assert_1492() {
     let _guard = lock_registry_tracked(&reg, "test-1492");
     crate::sync_audit::assert_no_registry_lock_for_self_ipc("enqueue_with_idle_hint");
 }
+
+// ── #1504: git-shim PATH parsing + self-exclusion (L1) ──
+
+#[test]
+fn git_search_excludes_shim_dir_1504() {
+    // Cross-platform: the shim dir ($AGEND_HOME/bin) must be filtered out of the
+    // git search PATH, and real dirs preserved. Uses the platform separator via
+    // join_paths/split_paths so it exercises the #1504 L1 fix on every OS.
+    let shim = std::path::PathBuf::from("/tmp/agend-home-1504/bin");
+    let real = std::path::PathBuf::from("/usr/bin");
+    let path = std::env::join_paths([real.clone(), shim.clone(), std::path::PathBuf::from("/bin")])
+        .expect("join PATH");
+    let result = super::git_search_without_shim(&path, Some(&shim));
+    assert!(
+        !result.iter().any(|p| super::same_dir(p, Some(&shim))),
+        "#1504: shim dir must be excluded from git search PATH: {result:?}"
+    );
+    assert!(
+        result.contains(&real),
+        "#1504: real PATH dirs must survive: {result:?}"
+    );
+}
+
+#[test]
+fn same_dir_lexical_slash_and_none_1504() {
+    // Nonexistent paths → lexical fallback → backslash normalized to forward,
+    // so a forward-slash AGEND_HOME/bin still matches a backslash PATH entry.
+    assert!(
+        super::same_dir(
+            std::path::Path::new("C:/agend/bin"),
+            Some(std::path::Path::new("C:\\agend\\bin")),
+        ),
+        "#1504: slash-variant dirs must compare equal via lexical fallback"
+    );
+    assert!(!super::same_dir(
+        std::path::Path::new("/usr/bin"),
+        Some(std::path::Path::new("/usr/local/bin")),
+    ));
+    assert!(
+        !super::same_dir(std::path::Path::new("/usr/bin"), None),
+        "no shim dir → never excludes"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn git_search_splits_windows_path_separator_1504() {
+    // RED against the old `.split(':')`: a `;`-separated Windows PATH whose
+    // entries carry drive-colons must split into WHOLE entries (not be shredded
+    // on the `C:` colon), and the shim dir must be excluded. Runs on the
+    // windows-latest CI job.
+    let shim = std::path::PathBuf::from("C:\\agend\\bin");
+    let path = std::ffi::OsString::from(
+        "C:\\Program Files\\Git\\cmd;C:\\agend\\bin;C:\\Windows\\System32",
+    );
+    let result = super::git_search_without_shim(&path, Some(&shim));
+    assert!(
+        result.contains(&std::path::PathBuf::from("C:\\Program Files\\Git\\cmd")),
+        "#1504: drive-colon entry must survive splitting: {result:?}"
+    );
+    assert!(
+        !result.iter().any(|p| super::same_dir(p, Some(&shim))),
+        "#1504: shim dir excluded on Windows: {result:?}"
+    );
+}

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -17,8 +17,38 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// #1504 L3: max times the shim may re-enter before hard-failing. Healthy
+/// operation never exceeds 1 (real git ≠ shim → no re-entry), so a small cap
+/// has zero false-trip risk while containing a self-resolution spawn storm.
+const MAX_SHIM_DEPTH: u32 = 3;
+
+/// Current shim recursion depth, read from the propagated sentinel env.
+fn shim_depth() -> u32 {
+    env::var("AGEND_GIT_SHIM_DEPTH")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0)
+}
+
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
+
+    // #1504 L3: recursion guard. If git ever resolves back to THIS shim (e.g.
+    // AGEND_REAL_GIT unset + self-exclusion miss), each real-git spawn re-enters
+    // here; on Windows `exec_real_git` uses `status()` (spawn), so it's an
+    // unbounded process storm, not a single exec-replace. Cap the depth and
+    // hard-fail with an actionable message. Checked BEFORE `should_bypass`
+    // because the bypass path also execs real git.
+    let depth = shim_depth();
+    if depth >= MAX_SHIM_DEPTH {
+        eprintln!(
+            "agend-git: FATAL recursion guard tripped (AGEND_GIT_SHIM_DEPTH={depth}) — the \
+             shim resolved git to itself. AGEND_REAL_GIT is unset/unresolvable and \
+             $AGEND_HOME/bin was not excluded from PATH. Set AGEND_REAL_GIT to the real \
+             git binary. (#1504)"
+        );
+        std::process::exit(70); // EX_SOFTWARE
+    }
 
     // Bypass checks (3-layer per §7).
     if should_bypass() {
@@ -918,7 +948,10 @@ fn commit_is_empty_heartbeat(worktree: &str, hash: &str) -> bool {
 
 fn exec_with_conflict_guidance(args: &[String], worktree: &str) -> ! {
     let git = resolve_real_git();
+    // #1504 L3: propagate incremented depth (rebase/merge/pull/cherry-pick reach
+    // here and also spawn real git — same recursion vector as exec_real_git).
     let status = Command::new(&git)
+        .env("AGEND_GIT_SHIM_DEPTH", (shim_depth() + 1).to_string())
         .arg("-C")
         .arg(worktree)
         .args(args)
@@ -947,6 +980,9 @@ fn exec_with_conflict_guidance(args: &[String], worktree: &str) -> ! {
 fn exec_real_git(args: &[String], chdir: Option<&str>) -> ! {
     let git = resolve_real_git();
     let mut cmd = Command::new(&git);
+    // #1504 L3: propagate the incremented depth so a self-resolution loop trips
+    // the recursion guard at the next entry instead of spawning unbounded.
+    cmd.env("AGEND_GIT_SHIM_DEPTH", (shim_depth() + 1).to_string());
     if let Some(dir) = chdir {
         cmd.arg("-C").arg(dir);
     }
@@ -979,20 +1015,54 @@ fn resolve_real_git() -> String {
             return path;
         }
     }
-    // Priority 2: which excluding $AGEND_HOME/bin/.
-    let agend_bin = env::var("AGEND_HOME")
-        .map(|h| format!("{h}/bin"))
-        .unwrap_or_default();
-    let path_sep = if cfg!(windows) { ';' } else { ':' };
-    let search: String = env::var("PATH")
-        .unwrap_or_default()
-        .split(path_sep)
-        .filter(|p| !p.is_empty() && *p != agend_bin)
-        .collect::<Vec<_>>()
-        .join(&path_sep.to_string());
+    // Priority 2: which excluding $AGEND_HOME/bin/ (the shim dir).
+    // #1504 L2: exclude via canonicalized Path comparison, not a string compare.
+    // `format!("{h}/bin")` (forward slash) never matched a Windows PATH entry
+    // (backslash / case / trailing-slash), so the shim failed to exclude itself
+    // and `which_in` resolved git back to THIS binary → recursive-spawn storm.
+    // With L1 fixed the daemon injects AGEND_REAL_GIT and Priority 1 above
+    // short-circuits, so this fallback rarely runs — but it must be correct when
+    // it does. `split_paths` also gives the right separator + drive-colon handling.
+    let agend_bin: Option<PathBuf> =
+        env::var_os("AGEND_HOME").map(|h| PathBuf::from(h).join("bin"));
+    let path_os = env::var_os("PATH").unwrap_or_default();
+    let search_paths: Vec<PathBuf> = std::env::split_paths(&path_os)
+        .filter(|p| !p.as_os_str().is_empty())
+        .filter(|p| !same_dir(p, agend_bin.as_deref()))
+        .collect();
+    let search = std::env::join_paths(&search_paths).unwrap_or_default();
     which::which_in("git", Some(&search), ".")
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "/usr/bin/git".to_string())
+}
+
+/// #1504: directory equality via `canonicalize` (resolves slash form, case-folds
+/// on Windows NTFS, follows symlinks), with a lexical fallback when a path can't
+/// be canonicalized (e.g. `$AGEND_HOME/bin` not yet created). NEVER unwraps
+/// `canonicalize` — it `Err`s on missing paths.
+fn same_dir(a: &std::path::Path, b: Option<&std::path::Path>) -> bool {
+    let Some(b) = b else { return false };
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(x), Ok(y)) => x == y,
+        _ => lexical_path_eq(a, b),
+    }
+}
+
+/// Lexical directory equality: normalize backslashes to `/`, strip trailing
+/// separators, compare case-insensitively on Windows. Fallback only.
+fn lexical_path_eq(a: &std::path::Path, b: &std::path::Path) -> bool {
+    let norm = |p: &std::path::Path| {
+        p.to_string_lossy()
+            .replace('\\', "/")
+            .trim_end_matches('/')
+            .to_string()
+    };
+    let (na, nb) = (norm(a), norm(b));
+    if cfg!(windows) {
+        na.eq_ignore_ascii_case(&nb)
+    } else {
+        na == nb
+    }
 }
 
 // ── Error + Telemetry ───────────────────────────────────────────────────
@@ -1087,6 +1157,23 @@ mod tests {
     // ── #1463: init-heartbeat argv detection (forensic hook gate) ──
     fn s(v: &[&str]) -> Vec<String> {
         v.iter().map(|x| x.to_string()).collect()
+    }
+
+    // ── #1504 L2: shim self-exclusion via canonicalize + lexical fallback ──
+    #[test]
+    fn same_dir_lexical_slash_fallback_1504() {
+        // Nonexistent dirs → lexical fallback → backslash normalized to `/`, so a
+        // forward-slash `$AGEND_HOME/bin` still matches a backslash PATH entry
+        // (the Windows self-exclusion miss that caused the recursion).
+        assert!(same_dir(
+            std::path::Path::new("C:/h/bin"),
+            Some(std::path::Path::new("C:\\h\\bin")),
+        ));
+        assert!(!same_dir(
+            std::path::Path::new("/usr/bin"),
+            Some(std::path::Path::new("/h/bin")),
+        ));
+        assert!(!same_dir(std::path::Path::new("/usr/bin"), None));
     }
 
     #[test]

--- a/tests/agent_path_colon_split_invariant_1504.rs
+++ b/tests/agent_path_colon_split_invariant_1504.rs
@@ -1,0 +1,36 @@
+//! #1504 L1 invariant: `agent/mod.rs` must not parse PATH with a hardcoded `:`
+//! separator. Windows PATH is `;`-separated and entries carry drive-colons
+//! (`C:\…`), so `.split(':')` shreds it → `which_in("git")` fails → the daemon
+//! never injects `AGEND_REAL_GIT` → the shim resolves git to itself → recursive
+//! spawn storm (the #1504 root cause). Use `std::env::split_paths`.
+//!
+//! Pairs with the runtime fix; this is the deterministic, cross-platform RED
+//! that fails CI if the hardcoded split ever returns (comment mentions of the
+//! pattern are skipped).
+
+#[test]
+fn agent_mod_no_hardcoded_path_colon_split_1504() {
+    let src = std::fs::read_to_string(
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/agent/mod.rs"),
+    )
+    .expect("read src/agent/mod.rs");
+
+    let mut violations = Vec::new();
+    for (i, line) in src.lines().enumerate() {
+        let t = line.trim_start();
+        // Skip comment/doc lines that merely mention the pattern.
+        if t.starts_with("//") || t.starts_with('*') {
+            continue;
+        }
+        if line.contains(".split(':')") {
+            violations.push(format!("{}: {}", i + 1, line.trim()));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "#1504: agent/mod.rs parses PATH with hardcoded `.split(':')` — use \
+         std::env::split_paths (Windows PATH is `;`-separated with drive-colons):\n{}",
+        violations.join("\n")
+    );
+}

--- a/tests/shim_recursion_guard_1504.rs
+++ b/tests/shim_recursion_guard_1504.rs
@@ -10,6 +10,7 @@
 #[test]
 fn recursion_guard_hard_fails_at_max_depth_1504() {
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_agend-git"))
+        .env("AGEND_TEST_ISOLATION", "1")
         .env("AGEND_GIT_SHIM_DEPTH", "3")
         .arg("--version")
         .output()
@@ -33,6 +34,7 @@ fn recursion_guard_hard_fails_at_max_depth_1504() {
 #[test]
 fn recursion_guard_does_not_fire_below_cap_1504() {
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_agend-git"))
+        .env("AGEND_TEST_ISOLATION", "1")
         .env("AGEND_GIT_SHIM_DEPTH", "2")
         .arg("--version")
         .output()

--- a/tests/shim_recursion_guard_1504.rs
+++ b/tests/shim_recursion_guard_1504.rs
@@ -1,0 +1,46 @@
+//! #1504 L3: the agend-git shim's recursion guard hard-fails (exit 70) when the
+//! propagated `AGEND_GIT_SHIM_DEPTH` sentinel reaches the cap, instead of
+//! spawning git unbounded (the Windows fork-bomb: `exec_real_git` uses
+//! `status()` = spawn, not exec-replace). Process-isolated, so it runs on every
+//! OS and never mutates the test process env.
+
+/// RED before the guard exists: depth=3 would pass through to real `git
+/// --version` (exit 0) or, in the bug state, re-spawn the shim. GREEN: hard-fail
+/// exit 70 with an actionable message.
+#[test]
+fn recursion_guard_hard_fails_at_max_depth_1504() {
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_agend-git"))
+        .env("AGEND_GIT_SHIM_DEPTH", "3")
+        .arg("--version")
+        .output()
+        .expect("run agend-git shim");
+    assert_eq!(
+        out.status.code(),
+        Some(70),
+        "#1504: depth>=MAX must hard-fail with exit 70; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("recursion guard"),
+        "#1504: guard must emit an actionable message, got: {stderr}"
+    );
+}
+
+/// Control: below the cap the guard must NOT fire — proves it is depth-gated,
+/// not an unconditional fail. (Exact non-70 code depends on git availability;
+/// only the guard exit 70 is asserted against.)
+#[test]
+fn recursion_guard_does_not_fire_below_cap_1504() {
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_agend-git"))
+        .env("AGEND_GIT_SHIM_DEPTH", "2")
+        .arg("--version")
+        .output()
+        .expect("run agend-git shim");
+    assert_ne!(
+        out.status.code(),
+        Some(70),
+        "#1504: depth below MAX must not trip the recursion guard; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
🔴 **P0.** Closes #1504. On Windows the `agend-git` shim could resolve `git` to **itself**, and because `exec_real_git` uses `status()` (spawn) rather than an exec-replace on non-unix, that **fork-bombs** the machine. Operator RCA + 4-person dialectic (my spike + 2 reviewers + dev) → this 3-layer fix.

## The recursion chain & the fix

**L1 — daemon never injected `AGEND_REAL_GIT`** (`src/agent/mod.rs`). It built the git search PATH with hardcoded `.split(':')`. Windows PATH is `;`-separated **and** entries carry drive-colons (`C:\Program Files\Git\cmd`), so `:`-splitting shredded PATH → `which_in("git")` failed → env never set.
→ `std::env::split_paths` + `var_os`; `$AGEND_HOME/bin` exclusion now compares **normalized Paths**. Extracted `git_search_without_shim` + `same_dir` (pure, unit-tested).

**L2 — the shim re-selected itself** (`resolve_real_git`). Priority-2 fallback excluded the shim dir via string compare `*p != format!("{h}/bin")` (forward slash) — never matched a Windows PATH entry (backslash/case/trailing-slash) → `which_in` found the shim in `$AGEND_HOME/bin`.
→ same `same_dir()`: `canonicalize` (resolves slash form + case-folds on NTFS) with a **lexical fallback**, and **never unwraps** `canonicalize` (it `Err`s on a not-yet-created bin dir — dev's catch).

> Note (dev's observation, confirmed): with **L1 fixed the daemon always injects `AGEND_REAL_GIT`**, so `resolve_real_git` Priority 1 short-circuits and the L2 fallback rarely runs. L1 is the primary fix; L2 is correctness for the fallback.

**L3 — no recursion brake** (defense-in-depth). `AGEND_GIT_SHIM_DEPTH` is incremented on **every** real-git spawn (`exec_real_git` **and** `exec_with_conflict_guidance` — rebase/merge/pull/cherry-pick reach the latter) and checked at the **very top of `main()`** (before `should_bypass`, which also execs real git). At depth ≥ 3 → hard-fail `exit 70` + actionable message instead of spawning unbounded. Healthy operation never exceeds depth 1, so the cap has zero false-trip risk.

## Tests (RED→GREEN)

| Test | Coverage | Platform |
|---|---|---|
| `git_search_excludes_shim_dir_1504`, `same_dir_lexical_slash_and_none_1504` | L1/L2 exclusion logic | all |
| `git_search_splits_windows_path_separator_1504` | `#[cfg(windows)]` — drive-colon PATH survives splitting | **windows-latest CI** |
| `same_dir_lexical_slash_fallback_1504` (agend-git) | L2 self-exclusion | all |
| `recursion_guard_hard_fails_at_max_depth_1504` + below-cap control | L3, process-isolated | all |
| `agent_mod_no_hardcoded_path_colon_split_1504` | grep-invariant forbidding `.split(':')` | all |

Verified the guard RED (cap raised → depth 3 passes through). **#1511's 5 agend-git tests stay green** (36 total in `--bin agend-git`).

## Conflicts / verification

- **No conflict with #1511** — it edits `classify()`; this edits `resolve_real_git`/`main`/`exec_*` (disjoint fns). Rebased onto fresh `origin/main` (includes #1511 `39fc005`); diff-stat is only the 5 intended files (#1508 stale-worktree lesson).
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, shim integration suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)