### PR TITLE
fix(#1519): per-instance opencode session isolation (XDG_DATA_HOME + auth copy)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -592,6 +592,71 @@ fn lexical_path_eq(a: &std::path::Path, b: &std::path::Path) -> bool {
 
 /// Build a `CommandBuilder` with resolved args, env, and working directory.
 ///
+/// #1519: per-instance opencode data dir (used as `XDG_DATA_HOME`). opencode
+/// writes its session DB + auth under `$XDG_DATA_HOME/opencode/`; keying this
+/// on the instance name gives each opencode agent an isolated session DB.
+/// Pure — testable without a real spawn. Lives under `$AGEND_HOME/backend-data`
+/// so the instance-delete teardown can GC it (see `full_delete_instance`).
+pub(crate) fn opencode_data_dir(home: &std::path::Path, instance: &str) -> PathBuf {
+    home.join("backend-data").join("opencode").join(instance)
+}
+
+/// #1519: the per-instance `XDG_DATA_HOME` to inject for an opencode spawn, or
+/// `None` for any other backend / when `home` is unknown. Pure gate so the
+/// OpenCode-only behavior (and the two-distinct-instances invariant) is
+/// unit-testable without inspecting a `CommandBuilder`.
+fn per_instance_opencode_xdg(
+    backend: Option<&Backend>,
+    home: Option<&std::path::Path>,
+    instance: &str,
+) -> Option<PathBuf> {
+    match (backend, home) {
+        (Some(Backend::OpenCode), Some(h)) => Some(opencode_data_dir(h, instance)),
+        _ => None,
+    }
+}
+
+/// #1519: canonical opencode `auth.json` to seed each per-instance data dir
+/// from. opencode uses XDG semantics on every platform (`~/.local/share`, NOT
+/// macOS's `~/Library/Application Support`), so resolve it the XDG way from the
+/// daemon's CURRENT env — which still holds the operator's (pre-override)
+/// `XDG_DATA_HOME` at spawn time. `None` if neither `XDG_DATA_HOME` nor `HOME`
+/// is set.
+fn canonical_opencode_auth() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local").join("share"))
+        })?;
+    Some(base.join("opencode").join("auth.json"))
+}
+
+/// #1519: prepare a per-instance opencode data dir: create `<xdg>/opencode/`
+/// and copy the canonical credential in (mode 600) so the isolated DB dir is
+/// still authenticated. `auth_src` is passed in (not read from env) so this is
+/// deterministically testable; a missing/absent source is a no-op (the agent
+/// then surfaces opencode's own "not logged in" prompt rather than silently
+/// sharing the global session).
+fn provision_opencode_data_dir(
+    xdg_dir: &std::path::Path,
+    auth_src: Option<&std::path::Path>,
+) -> std::io::Result<()> {
+    let oc_dir = xdg_dir.join("opencode");
+    std::fs::create_dir_all(&oc_dir)?;
+    if let Some(src) = auth_src {
+        if src.exists() {
+            let dst = oc_dir.join("auth.json");
+            std::fs::copy(src, &dst)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o600));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Extracted from `spawn_agent` so the command-construction logic (arg
 /// enrichment, env filtering, PATH prepend, cwd validation) is isolated
 /// from the PTY plumbing that follows.
@@ -713,6 +778,34 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
             }
             cmd.env(k, v);
         }
+    }
+
+    // #1519: per-instance opencode session isolation. opencode stores ALL
+    // sessions in a single global DB under XDG_DATA_HOME (default
+    // ~/.local/share/opencode/opencode.db), and `--continue` resumes the
+    // GLOBAL most-recent session regardless of cwd — so two opencode instances
+    // (fixup-reviewer + fixup-reviewer-2) shared one session byte-for-byte.
+    // Give each instance its OWN XDG_DATA_HOME → its own DB → its own
+    // `--continue` history (ResumeMode unchanged). opencode also reads its
+    // credential from `$XDG_DATA_HOME/opencode/auth.json`, so copy the canonical
+    // auth in (it's a static api key; copy is robust against opencode's
+    // atomic-rename writes that would sever a symlink — and reviewer-2 confirmed
+    // OPENCODE_API_KEY env isn't honored). Gated to OpenCode only.
+    //
+    // Placement is DELIBERATE: this runs AFTER the fleet.yaml user-env loop and
+    // the #1440 allowlist block so the per-instance value overrides BOTH an
+    // on-allowlist XDG_DATA_HOME and an operator-set one — session isolation is
+    // a correctness invariant that must win over operator preference here.
+    if let Some(data_dir) = per_instance_opencode_xdg(detected_backend.as_ref(), *home, name) {
+        if let Err(e) = provision_opencode_data_dir(&data_dir, canonical_opencode_auth().as_deref())
+        {
+            tracing::warn!(
+                instance = %name,
+                error = %e,
+                "#1519: opencode data-dir provision failed; instance may fall back to the shared session"
+            );
+        }
+        cmd.env("XDG_DATA_HOME", &data_dir);
     }
 
     // Add agend-terminal binary + $AGEND_HOME/bin (shim) to PATH.

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1518,3 +1518,128 @@ fn git_search_splits_windows_path_separator_1504() {
         "#1504: shim dir excluded on Windows: {result:?}"
     );
 }
+
+// ── #1519: per-instance opencode session isolation ──
+
+#[test]
+fn opencode_data_dir_is_per_instance_1519() {
+    let home = std::path::Path::new("/tmp/agend-home");
+    let a = opencode_data_dir(home, "fixup-reviewer");
+    let b = opencode_data_dir(home, "fixup-reviewer-2");
+    assert_ne!(a, b, "distinct instances must get distinct data dirs");
+    assert!(
+        a.ends_with("backend-data/opencode/fixup-reviewer"),
+        "got {a:?}"
+    );
+    assert!(
+        b.ends_with("backend-data/opencode/fixup-reviewer-2"),
+        "got {b:?}"
+    );
+}
+
+/// The core #1519 regression: two opencode instances resolve to DISTINCT
+/// XDG_DATA_HOME values — the property that prevents the shared-session
+/// collision. Pre-fix there was no per-instance XDG at all (both inherited the
+/// daemon's, defaulting to the one global DB).
+#[test]
+fn per_instance_opencode_xdg_distinct_for_two_opencode_instances_1519() {
+    let home = std::path::Path::new("/tmp/agend-home");
+    let a = per_instance_opencode_xdg(Some(&Backend::OpenCode), Some(home), "fixup-reviewer");
+    let b = per_instance_opencode_xdg(Some(&Backend::OpenCode), Some(home), "fixup-reviewer-2");
+    assert!(
+        a.is_some() && b.is_some(),
+        "OpenCode + home must yield an XDG dir"
+    );
+    assert_ne!(
+        a, b,
+        "two opencode instances MUST get distinct XDG_DATA_HOME"
+    );
+}
+
+#[test]
+fn per_instance_opencode_xdg_gated_to_opencode_1519() {
+    let home = std::path::Path::new("/tmp/agend-home");
+    // Non-opencode backends must NOT get a per-instance XDG override.
+    assert_eq!(
+        per_instance_opencode_xdg(Some(&Backend::ClaudeCode), Some(home), "dev"),
+        None,
+        "claude must be unaffected"
+    );
+    assert_eq!(
+        per_instance_opencode_xdg(Some(&Backend::Codex), Some(home), "dev"),
+        None,
+        "codex must be unaffected"
+    );
+    // OpenCode but no home → can't isolate → None (falls back to global; logged).
+    assert_eq!(
+        per_instance_opencode_xdg(Some(&Backend::OpenCode), None, "rev"),
+        None,
+        "no home → no per-instance dir"
+    );
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn provision_opencode_data_dir_copies_auth_1519() {
+    let base = std::env::temp_dir().join(format!(
+        "agend-1519-prov-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    // Fake canonical auth source.
+    let src_dir = base.join("canonical");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    let src = src_dir.join("auth.json");
+    std::fs::write(&src, r#"{"opencode-go":{"type":"api","key":"secret"}}"#).unwrap();
+
+    let xdg = base.join("xdg");
+    provision_opencode_data_dir(&xdg, Some(&src)).unwrap();
+
+    let dst = xdg.join("opencode").join("auth.json");
+    assert!(
+        dst.exists(),
+        "auth.json must be copied into <xdg>/opencode/"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&dst).unwrap(),
+        std::fs::read_to_string(&src).unwrap(),
+        "copied auth content must match the canonical source"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "copied auth.json must be mode 600, got {mode:o}"
+        );
+    }
+    std::fs::remove_dir_all(&base).ok();
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn provision_opencode_data_dir_no_auth_src_is_ok_1519() {
+    let xdg = std::env::temp_dir().join(format!(
+        "agend-1519-noauth-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    // No auth source → still creates the dir, no auth.json, no error.
+    provision_opencode_data_dir(&xdg, None).unwrap();
+    assert!(
+        xdg.join("opencode").is_dir(),
+        "data dir must still be created"
+    );
+    assert!(
+        !xdg.join("opencode").join("auth.json").exists(),
+        "no auth.json when no source provided"
+    );
+    std::fs::remove_dir_all(&xdg).ok();
+}

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -131,6 +131,11 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     let _ = crate::dispatch_tracking::cleanup_for_instance(home, name);
     // - ci_watch: drop from subscribers + clear next_after_ci (+ remove empty).
     let _ = crate::daemon::ci_watch::cleanup_watches_for_instance(home, name);
+    // #1519: GC the per-instance opencode data dir ($AGEND_HOME/backend-data/
+    // opencode/<name> — the per-instance XDG_DATA_HOME holding its isolated
+    // session DB + copied auth). No-op for non-opencode instances (the dir was
+    // never created). Best-effort like the steps above.
+    let _ = std::fs::remove_dir_all(crate::agent::opencode_data_dir(home, name));
 
     // Sprint 54 P1-B Bug 1 audit: enumerate every store that still holds
     // the name. If any do, surface a loud error instead of returning


### PR DESCRIPTION
## What

Two opencode instances (`fixup-reviewer` + `fixup-reviewer-2`) ran **byte-for-byte identical** — same session, token count, cost. **Root cause**: opencode stores ALL sessions in one global DB under `XDG_DATA_HOME` (`~/.local/share/opencode/opencode.db`), and `--continue` resumes the **global** most-recent session regardless of cwd — so any two opencode instances collide. (claude doesn't: its sessions are project/cwd-scoped.)

## Fix (XDG_DATA_HOME isolation — operator-approved, cross-audited)

Give each opencode instance its **own** `XDG_DATA_HOME` → its own session DB → `--continue` naturally isolates. **ResumeMode is unchanged.**

- `XDG_DATA_HOME = $AGEND_HOME/backend-data/opencode/<instance>`, **gated to `Backend::OpenCode`** (claude/codex/kiro/gemini untouched).
- opencode reads its credential from `$XDG_DATA_HOME/opencode/auth.json`, so spawn **copies the canonical `auth.json` in (mode 600)**. Copy, not symlink — opencode's atomic-rename writes would sever a symlink; the credential is a static api key, so a copy snapshot is safe. (reviewer-2 confirmed `OPENCODE_API_KEY` env is **not** honored → copy is required.)
- `cmd.env("XDG_DATA_HOME", …)` is injected **after** the fleet.yaml user-env loop so it deliberately overrides both an on-#1440-allowlist value and an operator-set `XDG_DATA_HOME` (session isolation is a correctness invariant; env-isolation defaults OFF so the allowlist loop can't be assumed to run).
- The per-instance dir is **GC'd on instance delete** via the #1488 cascade (`full_delete_instance`).

## Why not `--session <id>`

reviewer-2 verified `opencode -s <fresh-id>` **errors** (never auto-creates) and session IDs are opaque random `ses_<32hex>` — a session-id scheme would need run→capture→persist→resume (racy) plus hits opencode issue **#28581** (resume-from-launch-dir). XDG is simpler and avoids undocumented session plumbing. (Empirically verified opencode respects `XDG_DATA_HOME` via `opencode db path`; the only wrinkle — auth.json relocating with it — is handled by the copy.)

## Tests

`opencode_data_dir` (per-instance) / `per_instance_opencode_xdg` (OpenCode-only; **two instances → two distinct dirs** = the #1519 regression) / auth provision (copy + 600 + content). e2e (two live opencode) left to operator validation (token cost).

Validated via `scripts/preflight.sh`: fmt + clippy `--all-targets --features tray -D warnings` + test `--tests --features tray` + Windows `cargo xwin` — all green.

**Operator note**: after re-authenticating opencode, **restart the opencode instances** so the next spawn re-copies the refreshed `auth.json`. This is also the PR whose merge+restart finally separates the two collided reviewers (chicken-and-egg: it's the fix for the collision).

Closes #1519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)