### PR TITLE
fix(#1527): record state transitions at their source (reliable transitions.jsonl)

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -479,16 +479,38 @@ fn tick(
             // can't reach when the agent goes quiet (no PTY output).
             let prev_state = core.state.current;
             core.state.tick();
+            let new_state = core.state.current;
+
+            // #1527: log EVERY transition recorded at its source (read-loop
+            // `feed` AND `tick`), by draining the per-tracker buffer — replaces
+            // the old prev/new-at-tick comparison, which silently missed any
+            // transition that completed async between two supervisor ticks
+            // (prev==new), i.e. nearly all feed-driven ones including the error
+            // states. `log_state_transition_at` is a file append (no self-IPC,
+            // no new lock) so logging under the core lock is #1492-safe.
+            let snippet = core.vterm.tail_lines(3);
+            let (transitions, dropped) = core.state.drain_pending_transitions();
+            if dropped > 0 {
+                tracing::warn!(
+                    agent = %name,
+                    dropped,
+                    "#1527: transition-log buffer overflowed (drainer fell behind) — oldest dropped"
+                );
+            }
+            for t in &transitions {
+                crate::daemon::usage_limit::log_state_transition_at(
+                    home, &name, t.from, t.to, &t.ts, &snippet,
+                );
+            }
 
             // Sprint 43: member-state-change notify to orchestrator.
-            let new_state = core.state.current;
+            // #1527 NOTE: these reactions are STILL gated on the tick prev/new
+            // comparison, so feed-driven UsageLimit / error transitions miss
+            // them — a PRE-EXISTING latent bug (confirmed in the #1527 spike).
+            // De-gating entangles with #1492 lock discipline (these run under
+            // the core lock and may self-IPC), so it is tracked as a separate
+            // follow-up. Transition LOGGING above is now complete regardless.
             if prev_state != new_state {
-                // #1176: log ALL state transitions for observability.
-                let snippet = core.vterm.tail_lines(3);
-                crate::daemon::usage_limit::log_state_transition(
-                    home, &name, prev_state, new_state, &snippet,
-                );
-
                 // #1176: UsageLimit reaction pipeline.
                 if new_state == crate::state::AgentState::UsageLimit {
                     let backend_cmd = {

--- a/src/daemon/usage_limit.rs
+++ b/src/daemon/usage_limit.rs
@@ -7,17 +7,23 @@
 use crate::state::AgentState;
 use std::path::Path;
 
-/// Log a state transition to `state-transitions.jsonl`.
-pub fn log_state_transition(
+/// #1527: log a state transition to `state-transitions.jsonl` with an explicit
+/// `ts` — the instant the transition was RECORDED (`StateTracker::record_set`),
+/// not the later drain time. The supervisor drains buffered transitions and
+/// logs each with its captured timestamp so the on-disk order + times reflect
+/// reality. File append only (no self-IPC, no lock) → #1492-safe under the
+/// core lock.
+pub fn log_state_transition_at(
     home: &Path,
     agent: &str,
     from: AgentState,
     to: AgentState,
+    ts: &str,
     pty_snippet: &str,
 ) {
     let snippet: String = pty_snippet.chars().take(200).collect();
     let entry = serde_json::json!({
-        "ts": chrono::Utc::now().to_rfc3339(),
+        "ts": ts,
         "agent": agent,
         "from": from.display_name(),
         "to": to.display_name(),
@@ -110,11 +116,12 @@ mod tests {
         std::fs::create_dir_all(&dir).ok();
         std::fs::remove_file(dir.join("state-transitions.jsonl")).ok();
 
-        log_state_transition(
+        log_state_transition_at(
             &dir,
             "dev",
             AgentState::Ready,
             AgentState::UsageLimit,
+            "2026-05-31T00:00:00+00:00",
             "You've hit your limit",
         );
 
@@ -122,6 +129,10 @@ mod tests {
         assert!(content.contains("\"agent\":\"dev\""));
         assert!(content.contains("\"to\":\"usage_limit\""));
         assert!(content.contains("hit your limit"));
+        assert!(
+            content.contains("\"ts\":\"2026-05-31T00:00:00+00:00\""),
+            "must use the explicit (push-time) ts: {content}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -229,6 +229,27 @@ pub struct StateTracker {
     /// transition is suppressed and the tracker stays in the lower
     /// state — letting the natural latched-expiry path eventually fire.
     last_priority_up_into: Option<(AgentState, Instant)>,
+    /// #1527: transitions recorded at the moment `current` actually changes
+    /// (via `record_set`), drained + logged by the supervisor. This replaces
+    /// the supervisor's prev/new-at-tick comparison, which silently missed
+    /// every transition that completed async in the read-loop thread (the
+    /// feed → `transition` path) between two supervisor ticks — i.e. nearly
+    /// all of them, including the error states. Bounded (drop-oldest) so a
+    /// stalled drainer can't grow it without limit.
+    pending_transitions: Vec<TransitionRecord>,
+    /// #1527: count of transitions dropped because `pending_transitions` hit
+    /// its cap before the supervisor drained it. Surfaced in a warn at drain
+    /// so a wedged drainer is visible rather than silently lossy.
+    dropped_transition_count: u64,
+}
+
+/// #1527: one recorded `current` transition, captured at the mutation site so
+/// the timestamp is the real transition time (not the later drain time).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TransitionRecord {
+    pub from: AgentState,
+    pub to: AgentState,
+    pub ts: String,
 }
 
 const MARKER_SCAN_TAIL_LINES: usize = 5;
@@ -337,6 +358,11 @@ impl StateTracker {
     /// Scenario C oscillation can keep `since` recent. See
     /// `docs/HUNG-STATE-TRANSITIONS.md §F39.2`. #1005 Phase A2 closes
     /// this gap via the oscillation guard at `transition()`.
+    /// #1527: max buffered transitions before drop-oldest kicks in. The
+    /// supervisor drains every tick (~10s) and a healthy agent produces far
+    /// fewer than this per tick; the cap only bounds memory if the drainer
+    /// stalls.
+    const PENDING_TRANSITIONS_CAP: usize = 256;
     const LATCHED_STATE_EXPIRY: Duration = Duration::from_secs(30);
 
     /// #1005 Phase A2: minimum hold in the lower-priority state before
@@ -405,6 +431,9 @@ impl StateTracker {
             // legitimate priority-up records into it; subsequent
             // priority-ups within the window check against it.
             last_priority_up_into: None,
+            // #1527: transition audit buffer starts empty.
+            pending_transitions: Vec::new(),
+            dropped_transition_count: 0,
         }
     }
 
@@ -778,8 +807,7 @@ impl StateTracker {
 
     /// Force state to Restarting (called by reaper on crash).
     pub fn set_restarting(&mut self) {
-        self.current = AgentState::Restarting;
-        self.since = Instant::now();
+        self.record_set(AgentState::Restarting); // #1527: also logs the transition
     }
 
     /// Force state to AwaitingOperator when startup stalls on an unexpected
@@ -793,9 +821,45 @@ impl StateTracker {
     /// AwaitingOperator prio → higher always wins).
     pub fn set_awaiting_operator(&mut self) {
         if matches!(self.current, AgentState::Starting) {
-            self.current = AgentState::AwaitingOperator;
-            self.since = Instant::now();
+            self.record_set(AgentState::AwaitingOperator); // #1527: also logs
         }
+    }
+
+    /// #1527: the SINGLE funnel for every `current` mutation. Records the
+    /// transition (bounded, drop-oldest) and updates `current` + `since`. All
+    /// five production mutation sites route through this — `transition()`'s
+    /// three assignment branches plus the two that bypass `transition()`
+    /// entirely (`set_restarting` / `set_awaiting_operator`) — so EVERY state
+    /// change is captured at its true source, regardless of which thread
+    /// (read-loop `feed` or supervisor `tick`) drives it. Callers must NOT also
+    /// assign `current`/`since` (record_set owns both — avoids double-update).
+    /// No-op on same-state (won't reset `since` or push a spurious record).
+    fn record_set(&mut self, new_state: AgentState) {
+        if new_state == self.current {
+            return;
+        }
+        if self.pending_transitions.len() >= Self::PENDING_TRANSITIONS_CAP {
+            self.pending_transitions.remove(0); // drop oldest
+            self.dropped_transition_count = self.dropped_transition_count.saturating_add(1);
+        }
+        self.pending_transitions.push(TransitionRecord {
+            from: self.current,
+            to: new_state,
+            ts: chrono::Utc::now().to_rfc3339(),
+        });
+        self.current = new_state;
+        self.since = Instant::now();
+    }
+
+    /// #1527: drain the buffered transitions (FIFO) for the supervisor to log.
+    /// Returns the records in occurrence order plus the count dropped to the
+    /// cap since the last drain (nonzero ⇒ the drainer fell behind). Clears
+    /// both. The supervisor logs each record AFTER dropping the core lock
+    /// (file append, no self-IPC → no #1492).
+    pub(crate) fn drain_pending_transitions(&mut self) -> (Vec<TransitionRecord>, u64) {
+        let dropped = self.dropped_transition_count;
+        self.dropped_transition_count = 0;
+        (std::mem::take(&mut self.pending_transitions), dropped)
     }
 
     fn transition(&mut self, new_state: AgentState) {
@@ -807,8 +871,7 @@ impl StateTracker {
 
         // Error states: instant transition (no hysteresis)
         if new_state.is_error() {
-            self.current = new_state;
-            self.since = Instant::now();
+            self.record_set(new_state); // #1527: records + sets current/since
         } else {
             // Higher priority than current: transition if current held > min duration
             let held = self.since.elapsed();
@@ -862,12 +925,10 @@ impl StateTracker {
                     }
                     self.last_priority_up_into = Some((new_state, now));
                 }
-                self.current = new_state;
-                self.since = now;
+                self.record_set(new_state); // #1527
             } else if held >= min_hold {
                 // Lower priority only after min hold
-                self.current = new_state;
-                self.since = Instant::now();
+                self.record_set(new_state); // #1527
             }
         }
 

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3041,3 +3041,89 @@ fn network_error_patterns_all_backends() {
         }
     }
 }
+
+// ── #1527: transition recording at the mutation source ──
+
+#[test]
+fn record_set_buffers_transitions_fifo_then_drains() {
+    let mut st = StateTracker::new(None); // starts Ready
+    st.record_set(AgentState::Thinking);
+    st.record_set(AgentState::Idle);
+    let (recs, dropped) = st.drain_pending_transitions();
+    assert_eq!(dropped, 0);
+    assert_eq!(recs.len(), 2);
+    assert_eq!(
+        (recs[0].from, recs[0].to),
+        (AgentState::Ready, AgentState::Thinking)
+    );
+    assert_eq!(
+        (recs[1].from, recs[1].to),
+        (AgentState::Thinking, AgentState::Idle)
+    );
+    assert!(!recs[0].ts.is_empty(), "ts must be captured at record time");
+    assert!(
+        st.drain_pending_transitions().0.is_empty(),
+        "second drain is empty"
+    );
+}
+
+/// The #1527 regression: a mutation that bypasses BOTH `transition()` and
+/// `tick()` (here `set_restarting`) is still recorded — pre-fix the
+/// supervisor's prev/new-at-tick comparison could miss it entirely because
+/// the change completed async in the read-loop / reaper thread.
+#[test]
+fn set_restarting_records_transition_without_tick() {
+    let mut st = StateTracker::new(None); // Ready
+    st.set_restarting();
+    let (recs, _) = st.drain_pending_transitions();
+    assert_eq!(
+        recs.len(),
+        1,
+        "set_restarting must record (it bypasses transition())"
+    );
+    assert_eq!(recs[0].to, AgentState::Restarting);
+}
+
+#[test]
+fn set_awaiting_operator_records_transition() {
+    let mut st = StateTracker::new(Some(&Backend::ClaudeCode)); // starts Starting
+    st.set_awaiting_operator();
+    let (recs, _) = st.drain_pending_transitions();
+    assert_eq!(recs.len(), 1);
+    assert_eq!(recs[0].from, AgentState::Starting);
+    assert_eq!(recs[0].to, AgentState::AwaitingOperator);
+}
+
+#[test]
+fn same_state_record_set_is_noop() {
+    let mut st = StateTracker::new(None); // Ready
+    st.record_set(AgentState::Ready); // same → no record
+    assert!(
+        st.drain_pending_transitions().0.is_empty(),
+        "same-state record_set must not buffer a spurious transition"
+    );
+}
+
+#[test]
+fn pending_transitions_bounded_drops_oldest() {
+    let mut st = StateTracker::new(None); // Ready
+    let overflow = 5usize;
+    for i in 0..(StateTracker::PENDING_TRANSITIONS_CAP + overflow) {
+        let s = if i % 2 == 0 {
+            AgentState::Thinking
+        } else {
+            AgentState::Idle
+        };
+        st.record_set(s);
+    }
+    let (recs, dropped) = st.drain_pending_transitions();
+    assert_eq!(
+        recs.len(),
+        StateTracker::PENDING_TRANSITIONS_CAP,
+        "buffer must be capped"
+    );
+    assert_eq!(
+        dropped as usize, overflow,
+        "overflow count surfaced for the warn"
+    );
+}

--- a/tests/state_current_mutation_invariant.rs
+++ b/tests/state_current_mutation_invariant.rs
@@ -1,0 +1,47 @@
+//! #1527 invariant: `StateTracker::current` must be ASSIGNED through exactly
+//! one funnel (`record_set`), so every state change is recorded for
+//! `state-transitions.jsonl`. The root cause #1527 fixes was transitions
+//! mutating `current` on paths the supervisor's prev/new-at-tick comparison
+//! couldn't see (async feed thread + the `set_restarting`/`set_awaiting_operator`
+//! direct setters). Routing all mutation through `record_set` is what makes the
+//! log complete — so a future direct `self.current = …` would silently
+//! reintroduce the missing-transition bug. This RED fails CI if that happens.
+//!
+//! (Comparisons `== self.current` / `self.current ==` are NOT assignments and
+//! are excluded; only `self.current = <rhs>` assignment is counted.)
+
+#[test]
+fn state_current_assigned_only_via_record_set_1527() {
+    let src = std::fs::read_to_string(
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/state/mod.rs"),
+    )
+    .expect("read src/state/mod.rs");
+
+    let mut assignments = Vec::new();
+    for (i, line) in src.lines().enumerate() {
+        let t = line.trim_start();
+        if t.starts_with("//") || t.starts_with('*') {
+            continue; // skip comments/docs that mention the pattern
+        }
+        // Match `self.current =` assignment, but NOT `self.current ==`
+        // (comparison) and NOT `== self.current`.
+        if let Some(rest) = line.split("self.current").nth(1) {
+            let rest = rest.trim_start();
+            if let Some(after_eq) = rest.strip_prefix('=') {
+                if !after_eq.starts_with('=') {
+                    assignments.push(format!("{}: {}", i + 1, line.trim()));
+                }
+            }
+        }
+    }
+
+    assert_eq!(
+        assignments.len(),
+        1,
+        "#1527: `self.current` must be assigned in exactly ONE place (record_set) so every \
+         transition is recorded; a new direct assignment reintroduces the missing-transition \
+         bug. Found {} assignment site(s):\n{}",
+        assignments.len(),
+        assignments.join("\n")
+    );
+}


### PR DESCRIPTION
## What

`state-transitions.jsonl` silently missed **nearly every** transition — the gap behind the operator's missing "detection accuracy" data and why #1516 had to read `snapshot.json` instead. This is the **observability foundation** for epic #1523 (state-detection robustness).

**Root cause:** the supervisor decided what to log by comparing `core.state.current` before/after `tick()`. But PTY-driven transitions complete **async in the read-loop thread** (`feed` → `transition`), so by the next supervisor tick `prev == new` → not logged. **Also** `set_restarting` / `set_awaiting_operator` mutate `current` directly (bypassing `transition()`), equally invisible. The error states most worth measuring were the ones most often dropped.

## Fix — record at the mutation source

A single `StateTracker::record_set` funnel buffers `(from, to, ts)` whenever `current` actually changes; **all five** production mutation sites route through it (`transition()`'s 3 branches + `set_restarting` + `set_awaiting_operator`). The supervisor **drains** the buffer each tick and logs every record via `log_state_transition_at` (push-time ts, FIFO) — replacing the broken prev/new compare (no double-write). Buffer is **bounded** (cap 256, drop-oldest, dropped-count warn).

- **§3.15 / #1492:** buffer push is in-memory (lock-safe); logging is a file append (no self-IPC, no new lock → safe under the core lock).
- **Grep-invariant** (`tests/state_current_mutation_invariant.rs`, #1502 pattern): pins that `self.current` is assigned in exactly one place (`record_set`) — a future direct assignment reintroduces the bug and fails CI.

## Trace finding (lead's question E — reviewer-2 vs dev-2)

**reviewer-2 was right:** the **UsageLimit reaction** + **member-state-change notify** are *also* gated on the same prev/new compare, so feed-driven error transitions miss them too — a **pre-existing latent bug**. De-gating entangles with #1492 (those reactions run under the core lock and may self-IPC), so it's **deliberately scoped OUT** of this logging fix and flagged for a focused follow-up (a `NOTE` marks it in the supervisor). Logging is complete regardless, so `transitions.jsonl` is now trustworthy → #1516/#1518/#1470 can mine it.

## Tests

`record_set` buffer/FIFO/drain; `set_restarting` + `set_awaiting_operator` recorded (**the async-bypass regression**); same-state no-op; bounded drop-oldest; log push-time ts; grep-invariant.

Validated via `scripts/preflight.sh`: fmt + clippy `--all-targets --features tray -D warnings` + test `--tests --features tray` (incl. the #1492 invariant) + Windows `cargo xwin` — all green.

Closes #1527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)