### PR TITLE
feat(tasks): boot orphan sweep — release stale in_progress tasks to open

### DIFF
--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -303,6 +303,25 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
         crate::tasks::reconcile_orphan_owners_with_live(home, &std::collections::HashSet::new());
     });
 
+    // Boot orphan sweep (task t-20260526155509233515-8): a daemon restart
+    // replays the board and sees prev-session `in_progress` tasks, but can't
+    // tell an orphan from one being actively worked → they stick forever. Here
+    // we release every in_progress task back to open.
+    //
+    // PREMISE (binds the empty-`live` correctness): `auto_start_fleet` runs in
+    // `run_with_prepared`, AFTER this `prepare` returns — so at this point NO
+    // agent is alive and `live = ∅`. Every in_progress task is therefore
+    // provably a prev-session orphan (AgEnD agents re-spawn fresh; none resumes
+    // a mid-task in_progress), so releasing all of them cannot false-release an
+    // actively-running task. ⚠ If a future `--session-resume` feature lets an
+    // agent re-attach to a live in_progress across restart, THIS PREMISE BREAKS
+    // and the sweep must instead consult an authoritative post-spawn live set
+    // (see the `live` param on `scan_inprogress_orphans` + the per-tick variant
+    // deferred for that case). Lockless + pre-socket like the owner sweep above.
+    time_step("tasks::release_inprogress_orphans", || {
+        crate::tasks::release_inprogress_orphans_with_live(home, &std::collections::HashSet::new());
+    });
+
     Ok(BootstrapOutcome::Owned(Box::new(OwnedFleet {
         home: home.to_path_buf(),
         fleet_path: fleet_path.to_path_buf(),
@@ -756,6 +775,7 @@ mod tests {
             "worktree_pool::reconcile_orphan_leases",
             "canonical_hygiene::run_hygiene",
             "tasks::reconcile_orphan_owners_with_live",
+            "tasks::release_inprogress_orphans",
         ];
         for step in expected_steps {
             assert!(

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 pub use handler::handle;
-pub use orphan::{orphan_tasks_for_owner, reconcile_orphan_owners_with_live};
+pub use orphan::{
+    orphan_tasks_for_owner, reconcile_orphan_owners_with_live, release_inprogress_orphans_with_live,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Task {

--- a/src/tasks/orphan.rs
+++ b/src/tasks/orphan.rs
@@ -61,6 +61,110 @@ pub fn orphan_tasks_for_owner(home: &Path, owner_name: &str) -> Result<usize, St
         .map_err(|e| e.to_string())
 }
 
+/// Boot orphan sweep (task t-20260526155509233515-8): the STATUS-orphan
+/// analogue of [`scan_orphan_candidates`] (which handles OWNER orphans).
+///
+/// An `InProgress` task is a status-orphan when its owner is absent from `live`
+/// — or it has no owner at all (a malformed in_progress). At boot `live` is
+/// empty (see the bootstrap call site), so this returns ALL in_progress tasks —
+/// provably correct because no agent is alive to be actively working one
+/// (AgEnD agents re-spawn fresh on daemon restart; none resumes a mid-task
+/// in_progress).
+///
+/// Crucially, unlike the owner sweep there is **no Soft-defer**: a fleet agent
+/// re-spawning will NOT resume its prior in_progress, so the task must be
+/// released to open for re-dispatch regardless of whether its owner is in
+/// fleet.yaml. The `live` parameter is kept so a future per-tick variant can
+/// pass an authoritative live set (then `owner ∈ live` ⇒ actively running ⇒
+/// keep) — but the boot caller passes `∅`.
+pub fn scan_inprogress_orphans(
+    state: &crate::task_events::TaskBoardState,
+    live: &std::collections::HashSet<String>,
+) -> Vec<crate::task_events::TaskId> {
+    use crate::task_events::TaskStatus;
+    state
+        .tasks
+        .values()
+        .filter(|r| matches!(r.status, TaskStatus::InProgress))
+        .filter(|r| match r.owner.as_ref() {
+            Some(o) => !live.contains(o.0.as_str()),
+            None => true, // malformed: in_progress with no owner → orphan
+        })
+        .map(|r| r.id.clone())
+        .collect()
+}
+
+/// Boot orphan sweep: release stale `InProgress` tasks (see
+/// [`scan_inprogress_orphans`]) back to `Open` by emitting one batched
+/// [`crate::task_events::TaskEvent::Released`] per task (clears owner →
+/// re-dispatchable), under a single fsync. Returns the released ids.
+///
+/// Best-effort operator courtesy: a single coalesced, file-based inbox notice
+/// (the loopback API socket is NOT bound at bootstrap, so an `api::call`-based
+/// delivery would fail — `inbox::enqueue` is a plain file append). The released
+/// tasks are also visible on the board (now `Open`) and in a `warn` log.
+///
+/// Lock-free + pre-socket-safe by construction: runs in `bootstrap::prepare`
+/// before the agent registry and loopback socket exist, so there is no
+/// registry/core lock to hold across the inbox write → no #1492 concern.
+pub fn release_inprogress_orphans_with_live(
+    home: &Path,
+    live: &std::collections::HashSet<String>,
+) -> Vec<crate::task_events::TaskId> {
+    use crate::task_events::{InstanceName, TaskEvent};
+    let state = match crate::task_events::replay(home) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "boot orphan sweep: task_events replay failed — skipping");
+            return Vec::new();
+        }
+    };
+    let orphans = scan_inprogress_orphans(&state, live);
+    if orphans.is_empty() {
+        tracing::debug!("boot orphan sweep: no in_progress orphans to release");
+        return Vec::new();
+    }
+    let emitter = InstanceName::from("system:boot_orphan_sweep");
+    let events: Vec<TaskEvent> = orphans
+        .iter()
+        .cloned()
+        .map(|task_id| TaskEvent::Released {
+            task_id,
+            reason: "boot orphan recovery: in_progress with no live owner after daemon restart"
+                .to_string(),
+        })
+        .collect();
+    if let Err(e) = crate::task_events::append_batch(home, &emitter, events) {
+        tracing::warn!(error = %e, "boot orphan sweep: Released append_batch failed");
+        return Vec::new();
+    }
+    let ids: Vec<String> = orphans.iter().map(|t| t.0.clone()).collect();
+    tracing::warn!(
+        count = ids.len(),
+        released = ?ids,
+        "boot orphan sweep: released stale in_progress tasks to open (daemon restart)"
+    );
+    notify_boot_orphan_release(home, &ids);
+    orphans
+}
+
+/// Coalesced, file-based operator notice for the boot orphan sweep. One inbox
+/// message listing every released task (NOT one-per-task — avoids flooding).
+/// `enqueue` is a plain append, safe before the loopback socket is bound.
+fn notify_boot_orphan_release(home: &Path, ids: &[String]) {
+    if ids.is_empty() {
+        return;
+    }
+    let body = format!(
+        "[boot_orphan_sweep] released {} stale in_progress task(s) to open after a daemon \
+         restart (now re-dispatchable): {}",
+        ids.len(),
+        ids.join(", ")
+    );
+    let msg = crate::inbox::InboxMessage::new_system("system:boot_orphan_sweep", "update", body);
+    let _ = crate::inbox::enqueue(home, "general", msg);
+}
+
 /// #829: classify a single owner string against the live runtime
 /// registry + the fleet.yaml `instances:` set. Two ghost classes are
 /// distinguished:

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1,6 +1,7 @@
 use super::acl::{can_mutate_task, is_system_identity};
 use super::orphan::{
-    build_health_response, classify_owner, scan_orphan_candidates, OwnerClassification,
+    build_health_response, classify_owner, release_inprogress_orphans_with_live,
+    scan_inprogress_orphans, scan_orphan_candidates, OwnerClassification,
 };
 use super::sweep;
 use super::*;
@@ -431,6 +432,143 @@ fn reconcile_orphan_owners_with_live_empty_set_orphans_strict_ghost() {
         owner_after.is_none(),
         "after boot sweep with empty live, Strict ghost's owner must be cleared (got {owner_after:?})"
     );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ── Boot orphan sweep (task t-20260526155509233515-8) ──
+// STATUS-orphan sweep: at boot, `live = ∅` (auto_start runs after
+// bootstrap), so every in_progress task is a prev-session orphan and is
+// released to open. Unlike the owner sweep there is NO Soft-defer — a
+// re-spawning fleet agent does not resume its prior in_progress.
+
+use crate::task_events::TaskStatus;
+
+/// RED→GREEN pure-fn matrix. With `live = ∅` (boot), only `InProgress`
+/// tasks are orphans regardless of owner; non-in_progress statuses are
+/// always skipped; a `None`-owner in_progress (malformed) still counts.
+#[test]
+fn scan_inprogress_orphans_boot_empty_live_matrix() {
+    let state = make_state(vec![
+        make_record("t-ip-owned", TaskStatus::InProgress, Some("dev-impl-1")),
+        make_record("t-ip-fleet", TaskStatus::InProgress, Some("dev-impl-2")),
+        make_record("t-ip-noowner", TaskStatus::InProgress, None),
+        make_record("t-open", TaskStatus::Open, Some("dev-impl-1")),
+        make_record("t-claimed", TaskStatus::Claimed, Some("dev-impl-1")),
+        make_record("t-done", TaskStatus::Done, Some("dev-impl-1")),
+        make_record("t-cancelled", TaskStatus::Cancelled, Some("dev-impl-1")),
+    ]);
+    let live = std::collections::HashSet::new(); // boot: no agent alive yet
+
+    let mut got: Vec<String> = scan_inprogress_orphans(&state, &live)
+        .into_iter()
+        .map(|t| t.0)
+        .collect();
+    got.sort();
+    assert_eq!(
+        got,
+        vec![
+            "t-ip-fleet".to_string(),
+            "t-ip-noowner".to_string(),
+            "t-ip-owned".to_string()
+        ],
+        "boot (live=∅): all in_progress (incl. no-owner) are orphans; \
+         open/claimed/done/cancelled skipped — NO Soft-defer for in_progress"
+    );
+}
+
+/// The `live` param IS honoured for a future per-tick variant: an
+/// in_progress task whose owner is in the live set is actively running →
+/// NOT an orphan. A no-owner in_progress is still an orphan.
+#[test]
+fn scan_inprogress_orphans_live_owner_is_not_orphan() {
+    let state = make_state(vec![
+        make_record("t-ip-live", TaskStatus::InProgress, Some("dev-impl-1")),
+        make_record("t-ip-dead", TaskStatus::InProgress, Some("dev-impl-9")),
+        make_record("t-ip-noowner", TaskStatus::InProgress, None),
+    ]);
+    let live = make_set(&["dev-impl-1"]);
+
+    let mut got: Vec<String> = scan_inprogress_orphans(&state, &live)
+        .into_iter()
+        .map(|t| t.0)
+        .collect();
+    got.sort();
+    assert_eq!(
+        got,
+        vec!["t-ip-dead".to_string(), "t-ip-noowner".to_string()],
+        "owner ∈ live ⇒ actively running ⇒ kept; dead owner + no-owner ⇒ orphan"
+    );
+}
+
+/// Integration: seed an in_progress task in the event log, run the boot
+/// entrypoint (empty live), and confirm replay shows it released back to
+/// Open with the owner cleared (re-dispatchable). Idempotent re-run is a
+/// no-op (the task is no longer in_progress).
+#[test]
+fn release_inprogress_orphans_releases_to_open_and_clears_owner() {
+    use crate::task_events::{InstanceName, TaskEvent, TaskId};
+    let home = tmp_home("release_inprogress_orphans");
+    let emitter = InstanceName::from("test:seed");
+    let tid = TaskId("t-stuck-1".into());
+    let worker = InstanceName::from("dev-impl-1");
+    crate::task_events::append_batch(
+        &home,
+        &emitter,
+        vec![
+            TaskEvent::Created {
+                task_id: tid.clone(),
+                title: "stuck in_progress across restart".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: Some(worker.clone()),
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+            TaskEvent::Claimed {
+                task_id: tid.clone(),
+                by: worker.clone(),
+            },
+            TaskEvent::InProgress {
+                task_id: tid.clone(),
+                by: worker.clone(),
+            },
+        ],
+    )
+    .expect("seed in_progress task");
+
+    // Pre-condition: replay sees it in_progress + owned.
+    let pre = crate::task_events::replay(&home).expect("pre replay");
+    let pre_rec = pre.tasks.get(&tid).expect("seeded task present");
+    assert_eq!(pre_rec.status, TaskStatus::InProgress, "pre: in_progress");
+    assert!(pre_rec.owner.is_some(), "pre: owned");
+
+    // Subject: boot entrypoint with live=∅ (the bootstrap call site).
+    let released = release_inprogress_orphans_with_live(&home, &std::collections::HashSet::new());
+    assert_eq!(released, vec![tid.clone()], "the stuck task is released");
+
+    let post = crate::task_events::replay(&home).expect("post replay");
+    let post_rec = post.tasks.get(&tid).expect("task still present");
+    assert_eq!(
+        post_rec.status,
+        TaskStatus::Open,
+        "after boot sweep: in_progress orphan released back to open"
+    );
+    assert!(
+        post_rec.owner.is_none(),
+        "Released clears owner → re-dispatchable (got {:?})",
+        post_rec.owner
+    );
+
+    // Idempotent: re-running finds no in_progress orphan → no-op.
+    let again = release_inprogress_orphans_with_live(&home, &std::collections::HashSet::new());
+    assert!(again.is_empty(), "re-run is a no-op once released to open");
 
     std::fs::remove_dir_all(&home).ok();
 }


### PR DESCRIPTION
## What
A daemon restart replays the task board and sees prev-session `in_progress` tasks, but cannot distinguish an **orphan** (worker is gone) from one being **actively worked** → they stick in_progress forever. This adds a boot-time sweep that releases stale in_progress tasks back to `open` for re-dispatch.

Task `t-20260526155509233515-8` (Wave-1 reliability). Sibling to the existing owner-orphan sweep in `tasks/orphan.rs`.

## How
- **`scan_inprogress_orphans(state, live)`** (pure): in_progress tasks whose owner ∉ `live`, or that have no owner (malformed). **No Soft-defer** — unlike the owner sweep, a re-spawning fleet agent does NOT resume its prior in_progress, so it must be released regardless of fleet membership.
- **`release_inprogress_orphans_with_live(home, live)`**: replay → scan → one batched `TaskEvent::Released` per task (single fsync) → returns released ids. Best-effort, coalesced, file-based operator notice.
- Wired in `bootstrap::prepare` next to `reconcile_orphan_owners_with_live`, with `live = ∅`.

## Correctness — orphan vs active (resolved by timing)
`auto_start_fleet` runs in `run_with_prepared`, **after** `prepare` returns, so at the sweep point `live = ∅` is provable: no agent is alive. Every in_progress task is therefore a prev-session orphan (AgEnD agents re-spawn fresh; none resumes a mid-task in_progress), so releasing all of them **cannot false-release an actively-running task**. This mirrors the documented rationale of the adjacent owner sweep.

⚠️ A code comment flags that a future `--session-resume` feature would break this premise — then the retained `live` param + a (deferred) per-tick variant with an authoritative post-spawn live set would apply.

## §3.15 / locking
Runs lockless + pre-socket (in `bootstrap::prepare`, before the registry exists and before the loopback socket binds) → no #1492 self-IPC-under-lock concern. The operator notice is a plain inbox file append, not `api::call` (which would fail pre-socket).

## Tests (RED→GREEN)
- `scan_inprogress_orphans_boot_empty_live_matrix` — boot (live=∅): all in_progress incl. no-owner are orphans; open/claimed/done/cancelled skipped.
- `scan_inprogress_orphans_live_owner_is_not_orphan` — `live` honoured: owner ∈ live ⇒ kept (per-tick safety).
- `release_inprogress_orphans_releases_to_open_and_clears_owner` — integration: seeded in_progress → Released → replay shows Open + owner cleared; idempotent re-run is a no-op.
- `prepare_emits_bootstrap_step_lines_for_every_instrumented_site` — extended with the new `tasks::release_inprogress_orphans` step.

Full preflight green (fmt + clippy -D warnings + tests --features tray + windows xwin check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)