### PR TITLE
fix(#1535): extend #1492 self-IPC guard to per-agent core-lock depth

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,6 +6,7 @@
 use crate::backend::Backend;
 use crate::health::HealthTracker;
 use crate::state::StateTracker;
+use crate::sync_audit::CoreMutex;
 use crate::vterm::VTerm;
 use parking_lot::Mutex;
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
@@ -35,7 +36,7 @@ pub struct AgentHandle {
     pub(crate) backend_command: String,
     pub(crate) pty_writer: PtyWriter,
     pub(crate) pty_master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
-    pub(crate) core: Arc<Mutex<AgentCore>>,
+    pub(crate) core: Arc<CoreMutex<AgentCore>>,
     pub(crate) child: Arc<Mutex<Box<dyn portable_pty::Child + Send>>>,
     pub(crate) submit_key: String,
     pub(crate) inject_prefix: String,
@@ -959,7 +960,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         .map_err(|e| anyhow::anyhow!("clone_reader: {e}"))?;
     let pty_master: Arc<Mutex<Box<dyn MasterPty + Send>>> = Arc::new(Mutex::new(pair.master));
 
-    let core = Arc::new(Mutex::new(AgentCore {
+    let core = Arc::new(CoreMutex::new(AgentCore {
         vterm: VTerm::with_pty_writer(*cols, *rows, Arc::clone(&pty_writer)),
         subscribers: Vec::new(),
         state: StateTracker::new(detected_backend.as_ref()),
@@ -1225,7 +1226,7 @@ struct PtyReadContext {
     /// uses it for all registry lookups; `name` is kept for name-keyed side
     /// channels (ipc port, heartbeat, event log, metadata, router, api).
     instance_id: crate::types::InstanceId,
-    core: Arc<Mutex<AgentCore>>,
+    core: Arc<CoreMutex<AgentCore>>,
     pty_writer: PtyWriter,
     registry: AgentRegistry,
     home: Option<std::path::PathBuf>,

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -232,7 +232,7 @@ fn sweep_child_tree_body(pid_file: &std::path::Path) {
         Arc::new(Mutex::new(pair.master.take_writer().expect("take_writer")));
     let pty_master: Arc<Mutex<Box<dyn portable_pty::MasterPty + Send>>> =
         Arc::new(Mutex::new(pair.master));
-    let core = Arc::new(Mutex::new(AgentCore {
+    let core = Arc::new(crate::sync_audit::CoreMutex::new(AgentCore {
         vterm: crate::vterm::VTerm::with_pty_writer(80, 24, Arc::clone(&pty_writer)),
         subscribers: Vec::new(),
         state: StateTracker::new(None),
@@ -727,7 +727,7 @@ fn write_to_agent_typed_uses_timeout() {
         backend_command: "test".to_string(),
         pty_writer: writer,
         pty_master: Arc::new(Mutex::new(pair.master)),
-        core: Arc::new(Mutex::new(AgentCore {
+        core: Arc::new(crate::sync_audit::CoreMutex::new(AgentCore {
             vterm: VTerm::new(80, 24),
             subscribers: Vec::new(),
             state: StateTracker::new(None),
@@ -942,7 +942,7 @@ fn pty_read_error_triggers_cleanup() {
 
     let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
     let pty_writer: PtyWriter = Arc::new(Mutex::new(Box::new(Vec::<u8>::new())));
-    let core = Arc::new(Mutex::new(AgentCore {
+    let core = Arc::new(crate::sync_audit::CoreMutex::new(AgentCore {
         vterm: VTerm::new(80, 24),
         subscribers: Vec::new(),
         state: StateTracker::new(None),
@@ -1117,7 +1117,7 @@ fn mk_handle_1441(name: &str, id: crate::types::InstanceId) -> AgentHandle {
     let pty_writer: PtyWriter = Arc::new(Mutex::new(pair.master.take_writer().expect("writer")));
     let pty_master: Arc<Mutex<Box<dyn portable_pty::MasterPty + Send>>> =
         Arc::new(Mutex::new(pair.master));
-    let core = Arc::new(Mutex::new(AgentCore {
+    let core = Arc::new(crate::sync_audit::CoreMutex::new(AgentCore {
         vterm: crate::vterm::VTerm::with_pty_writer(80, 24, Arc::clone(&pty_writer)),
         subscribers: Vec::new(),
         state: StateTracker::new(None),
@@ -1452,6 +1452,33 @@ fn lock_registry_tracked_guard_trips_self_ipc_assert_1492() {
     let reg = empty_registry_1492();
     let _guard = lock_registry_tracked(&reg, "test-1492");
     crate::sync_audit::assert_no_registry_lock_for_self_ipc("enqueue_with_idle_hint");
+}
+
+// ── #1535: CoreMutex guard wiring for core-held self-IPC detection ──
+
+/// Real wiring: holding a `CoreMutex` guard bumps `CORE_LOCK_DEPTH`, so the
+/// (extended) self-IPC assert panics while the guard is alive — proving the
+/// core-lock blind spot the registry-only guard missed (#1535) is now covered.
+/// Debug-only: the detection compiles out in release.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "lock-across-self-IPC")]
+fn core_mutex_guard_trips_self_ipc_assert_1535() {
+    let m = crate::sync_audit::CoreMutex::new(0u32);
+    let _guard = m.lock();
+    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
+}
+
+/// Dropping the `CoreMutex` guard BEFORE self-IPC (the collect→drop→emit
+/// pattern, e.g. #1530) clears the depth, so the assert does not trip.
+#[cfg(debug_assertions)]
+#[test]
+fn core_mutex_guard_drop_clears_self_ipc_flag_1535() {
+    let m = crate::sync_audit::CoreMutex::new(0u32);
+    {
+        let _guard = m.lock();
+    } // guard dropped → core depth cleared
+    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
 }
 
 // ── #1504: git-shim PATH parsing + self-exclusion (L1) ──

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -335,7 +335,7 @@ mod tests {
             Arc::new(Mutex::new(pair.master.take_writer().expect("take_writer")));
         let pty_master: Arc<Mutex<Box<dyn portable_pty::MasterPty + Send>>> =
             Arc::new(Mutex::new(pair.master));
-        let core = Arc::new(Mutex::new(crate::agent::AgentCore {
+        let core = Arc::new(crate::sync_audit::CoreMutex::new(crate::agent::AgentCore {
             vterm: crate::vterm::VTerm::with_pty_writer(80, 24, Arc::clone(&pty_writer)),
             subscribers: Vec::new(),
             state: crate::state::StateTracker::new(None),

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -143,7 +143,7 @@ mod tests {
             backend_command: "test".to_string(),
             pty_writer: Arc::new(Mutex::new(writer)),
             pty_master: Arc::new(Mutex::new(pair.master)),
-            core: Arc::new(Mutex::new(core)),
+            core: Arc::new(crate::sync_audit::CoreMutex::new(core)),
             child: Arc::new(Mutex::new(child)),
             submit_key: "\r".to_string(),
             inject_prefix: String::new(),

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1474,7 +1474,7 @@ mod tests {
         let reader = pair.master.try_clone_reader().expect("clone reader");
         let writer = pair.master.take_writer().expect("take writer");
         let pty_writer: crate::agent::PtyWriter = Arc::new(parking_lot::Mutex::new(writer));
-        let core = Arc::new(parking_lot::Mutex::new(crate::agent::AgentCore {
+        let core = Arc::new(crate::sync_audit::CoreMutex::new(crate::agent::AgentCore {
             vterm: crate::vterm::VTerm::with_pty_writer(80, 10, Arc::clone(&pty_writer)),
             subscribers: Vec::new(),
             state: crate::state::StateTracker::new(None),

--- a/src/sync_audit.rs
+++ b/src/sync_audit.rs
@@ -134,18 +134,112 @@ pub fn registry_lock_exited() {
 #[inline(always)]
 pub fn registry_lock_exited() {}
 
+// ── #1535: per-agent core-lock depth tracking + CoreMutex ────────────────
+//
+// The #1492 guard above only tracks the REGISTRY lock. But the supervisor
+// per-agent loop holds the `AgentCore` mutex (the registry lock is already
+// released — handles are Arc-cloned out first) while some reactions self-IPC
+// (`api::call(INJECT)` → orchestrator). That core-held self-IPC ALSO deadlocks
+// — the loopback handler locks the registry AND the target agent's core — yet
+// was invisible to the registry-only guard (#1530 surfaced it; #1535 closes
+// it). [`CoreMutex`] makes EVERY core lock bump `CORE_LOCK_DEPTH` so the same
+// self-IPC assert covers the core-held case too.
+
+#[cfg(debug_assertions)]
+thread_local! {
+    /// How many `AgentCore` locks this thread currently holds (0 = none).
+    /// A single total-depth counter is sufficient: the rule is "no self-IPC
+    /// while holding ANY core lock", so per-agent identity is irrelevant.
+    static CORE_LOCK_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Record that this thread acquired a core lock. Debug-only; release no-op.
+#[cfg(debug_assertions)]
+fn core_lock_entered() {
+    CORE_LOCK_DEPTH.with(|c| c.set(c.get().saturating_add(1)));
+}
+#[cfg(not(debug_assertions))]
+#[inline(always)]
+fn core_lock_entered() {}
+
+/// Record that this thread released a core lock. Debug-only; release no-op.
+#[cfg(debug_assertions)]
+fn core_lock_exited() {
+    CORE_LOCK_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
+}
+#[cfg(not(debug_assertions))]
+#[inline(always)]
+fn core_lock_exited() {}
+
+/// #1535: a `parking_lot::Mutex` wrapper for the per-agent `AgentCore` that
+/// tracks lock depth via [`CORE_LOCK_DEPTH`]. `.lock()` is API-compatible with
+/// `parking_lot::Mutex::lock` (the returned [`CoreGuard`] `Deref`s to `T`), so
+/// the ~50 `.core.lock()` call sites are unchanged. The guard decrements the
+/// depth on drop. Release builds: the depth calls compile to no-ops, so this is
+/// a zero-overhead newtype.
+///
+/// This is the SOLE constructor for an `AgentCore` mutex — enforced by
+/// `tests/core_mutex_invariant.rs` so a future bare `Mutex<AgentCore>` cannot
+/// silently reintroduce the #1492 core-lock blind spot.
+pub struct CoreMutex<T> {
+    inner: parking_lot::Mutex<T>,
+}
+
+impl<T> CoreMutex<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: parking_lot::Mutex::new(value),
+        }
+    }
+
+    /// Lock the core, bumping [`CORE_LOCK_DEPTH`] for the guard's lifetime.
+    pub fn lock(&self) -> CoreGuard<'_, T> {
+        let guard = self.inner.lock();
+        core_lock_entered();
+        CoreGuard { guard }
+    }
+}
+
+/// RAII guard from [`CoreMutex::lock`]; decrements [`CORE_LOCK_DEPTH`] on drop.
+pub struct CoreGuard<'a, T> {
+    guard: parking_lot::MutexGuard<'a, T>,
+}
+
+impl<T> std::ops::Deref for CoreGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.guard
+    }
+}
+
+impl<T> std::ops::DerefMut for CoreGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.guard
+    }
+}
+
+impl<T> Drop for CoreGuard<'_, T> {
+    fn drop(&mut self) {
+        core_lock_exited();
+    }
+}
+
 /// Panic (debug builds only) if a self-IPC vector is entered while this thread
-/// holds the registry lock — that ordering deadlocks the daemon (#1492). `ctx`
-/// names the vector for the panic message. Release builds: no-op, zero cost.
+/// holds the registry lock (#1492) OR any per-agent core lock (#1535) — either
+/// ordering deadlocks the daemon (the loopback API handler needs the registry
+/// lock and may lock the target agent's core). `ctx` names the vector. Release
+/// builds: no-op, zero cost.
 #[cfg(debug_assertions)]
 pub fn assert_no_registry_lock_for_self_ipc(ctx: &str) {
-    let depth = REGISTRY_LOCK_DEPTH.with(|c| c.get());
-    if depth > 0 {
+    let reg = REGISTRY_LOCK_DEPTH.with(|c| c.get());
+    let core = CORE_LOCK_DEPTH.with(|c| c.get());
+    if reg > 0 || core > 0 {
         panic!(
-            "#1492 lock-across-self-IPC deadlock risk: `{ctx}` was called while this thread holds \
-             the registry lock (depth={depth}). The loopback API handler needs the same lock, so \
-             this self-IPC would deadlock the daemon. Drop the registry guard BEFORE the call \
-             (see commit 6f1403d and docs/DAEMON-LOCK-ORDERING.md)."
+            "#1492/#1535 lock-across-self-IPC deadlock risk: `{ctx}` was called while this thread \
+             holds locks (registry depth={reg}, core depth={core}). The loopback API handler needs \
+             the registry lock and may lock the target agent's core, so this self-IPC would \
+             deadlock the daemon. Drop the guard(s) BEFORE the call (collect under lock → drop → \
+             emit; see #1530, commit 6f1403d, docs/DAEMON-LOCK-ORDERING.md)."
         );
     }
 }

--- a/tests/core_mutex_invariant.rs
+++ b/tests/core_mutex_invariant.rs
@@ -1,0 +1,66 @@
+//! #1535 invariant: `CoreMutex` (src/sync_audit.rs) must be the SOLE mutex
+//! wrapper for `AgentCore`. A bare `Mutex<AgentCore>` field or a
+//! `Mutex::new(AgentCore { … })` construction bypasses the `CORE_LOCK_DEPTH`
+//! tracking and silently reintroduces the #1492 core-lock-held self-IPC blind
+//! spot that #1535 closed. This RED fails CI if any such bare usage returns.
+//!
+//! `CoreMutex` is scrubbed before matching (it textually contains
+//! `Mutex<AgentCore>`), and comment/doc lines are skipped, so legitimate
+//! `Arc<CoreMutex<AgentCore>>` usage and prose mentions don't false-positive.
+
+use std::path::{Path, PathBuf};
+
+fn collect_rs(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read_dir src") {
+        let p = entry.expect("dir entry").path();
+        if p.is_dir() {
+            collect_rs(&p, out);
+        } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(p);
+        }
+    }
+}
+
+#[test]
+fn coremutex_is_sole_agentcore_mutex_wrapper_1535() {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    collect_rs(&src, &mut files);
+    assert!(!files.is_empty(), "no src/*.rs files found");
+
+    // Bare (non-CoreMutex) AgentCore mutex patterns. CoreMutex wraps a generic
+    // `parking_lot::Mutex<T>`, so its own definition never matches these.
+    let needles = [
+        "Mutex<AgentCore>",
+        "Mutex<crate::agent::AgentCore>",
+        "Mutex::new(AgentCore",
+        "Mutex::new(crate::agent::AgentCore",
+    ];
+
+    let mut violations = Vec::new();
+    for file in &files {
+        let text = std::fs::read_to_string(file).expect("read src file");
+        for (i, line) in text.lines().enumerate() {
+            let t = line.trim_start();
+            if t.starts_with("//") || t.starts_with('*') {
+                continue; // skip comment/doc lines that merely mention the pattern
+            }
+            // Scrub the allowed wrapper so `CoreMutex<AgentCore>` /
+            // `CoreMutex::new(AgentCore` don't match the bare-`Mutex` needles.
+            let scrubbed = line.replace("CoreMutex", "__CM__");
+            for needle in &needles {
+                if scrubbed.contains(needle) {
+                    violations.push(format!("{}:{}: {}", file.display(), i + 1, line.trim()));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "#1535: bare `Mutex<AgentCore>` usage bypasses CoreMutex's CORE_LOCK_DEPTH \
+         tracking → reopens the #1492 core-lock self-IPC blind spot. Use \
+         `crate::sync_audit::CoreMutex` instead:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
## What
The #1492 lock-across-self-IPC deadlock guard (`assert_no_registry_lock_for_self_ipc`) only tracked `REGISTRY_LOCK_DEPTH`. But the supervisor per-agent loop holds the **`AgentCore` mutex** (the registry lock is already released — handles are `Arc`-cloned out first) while some reactions self-IPC (`api::call(INJECT)` → orchestrator). That **core-held** self-IPC also deadlocks — the loopback handler `handle_inject` locks the registry **and** the target agent's core — yet was invisible to the registry-only guard. It's exactly the class #1530 had to fix by hand. This closes the guard blind spot (which I surfaced during #1530).

## How
- **`CoreMutex<T>` newtype** (`src/sync_audit.rs`) wraps `parking_lot::Mutex`. Its `.lock()` bumps a debug-only `CORE_LOCK_DEPTH` thread-local; the returned `CoreGuard` (Deref/DerefMut to `T`) decrements on drop. Because `.lock()` is API-compatible, **all ~53 `.core.lock()` call sites are unchanged** — only the field type (`Arc<CoreMutex<AgentCore>>`) + the construction sites move.
- The self-IPC assert now panics on `REGISTRY_LOCK_DEPTH > 0` **OR** `CORE_LOCK_DEPTH > 0`. **Debug-only**; release builds compile the tracking + assert to no-ops (zero overhead, exactly like the registry guard) — §3.15-safe.
- **`tests/core_mutex_invariant.rs`** asserts no bare `Mutex<AgentCore>` / `Mutex::new(AgentCore` survives outside `CoreMutex`, so the newtype stays the **sole constructor** and a future bare lock can't silently reopen the blind spot (`CoreMutex` is scrubbed before matching to avoid false positives; comment lines skipped).

## Correctness (③ from the spike)
A single total-depth counter is sufficient: the rule is "no self-IPC while holding **any** core lock", so per-agent identity is irrelevant. Nested different-agent cores (e.g. `propagate_usage_limit` locking peers) inc/dec correctly; same-core re-entrancy already deadlocks in `parking_lot` and is out of scope.

## Tests (RED→GREEN, mirror #1492)
- `core_mutex_guard_trips_self_ipc_assert_1535` — `CoreMutex` guard held → assert panics (`#[should_panic("lock-across-self-IPC")]`).
- `core_mutex_guard_drop_clears_self_ipc_flag_1535` — guard dropped first (collect→drop→emit, e.g. #1530) → no panic.
- `coremutex_is_sole_agentcore_mutex_wrapper_1535` — the grep-invariant.
- Existing #1492 registry-guard tests unchanged + green.

Full debug suite green under `AGEND_LOCK_AUDIT=1` — **no tested path trips the new core-lock assert** (consistent with the spike's ④ audit: false-positive surface clean post-#1530).

## ⚠️ Caveat (D)
A green suite does **not** prove prod has no core-held self-IPC — the assert only fires on paths the tests exercise. CI keeps `AGEND_LOCK_AUDIT=1` (ci.yml) so prod-like paths stay covered over time; any future trip is a real latent bug.

## Links
#1535 (this) · #1492 (original registry guard) · #1530 (the core-held self-IPC this would have caught) · epic #1523

🤖 Generated with [Claude Code](https://claude.com/claude-code)