### PR TITLE
fix(#1518): bound HIGH_FP error re-judging to bottom-N tail (natural recovery)

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -254,6 +254,24 @@ pub(crate) struct TransitionRecord {
 
 const MARKER_SCAN_TAIL_LINES: usize = 5;
 
+/// #1518: bottom-N bound for HIGH_FP error re-judging. Detection is
+/// level-triggered (re-judged every feed), so an error string lingering
+/// anywhere in the viewport keeps re-firing the error state — a retry storm
+/// even after the agent has visually moved on. Bounding HIGH_FP re-matching to
+/// the bottom `ERROR_TAIL_SCAN_LINES` rows lets an error scroll out of the live
+/// tail and recover naturally (non-timer).
+///
+/// Value chosen from fixture evidence: across every canonical error recording
+/// in `tests/fixtures/state-replay/` (claude/gemini/kiro/opencode rate-limit,
+/// throttle, 429, usage-limit), a *fresh* error marker sits at depth 5–6 rows
+/// from the bottom (max 6). 15 clears that by >2× — generous headroom for
+/// multi-line / wrapped error bodies not in the fixtures — while still
+/// suppressing an error that newer content has pushed into the top portion of a
+/// typical 24–50 row viewport. Deliberately conservative: bias is toward NOT
+/// dropping a real error. Distinct from `MARKER_SCAN_TAIL_LINES` (a tighter
+/// structural-marker scan) — do not collapse the two.
+const ERROR_TAIL_SCAN_LINES: usize = 15;
+
 fn recent_screen_tail(screen_text: &str, n: usize) -> String {
     let lines: Vec<&str> = screen_text.lines().collect();
     let start = lines.len().saturating_sub(n);
@@ -335,6 +353,23 @@ fn matched_span_has_red(screen_text: &str, matched: &str, fg: &[CellFg]) -> bool
         search = byte_off + matched.len();
     }
     false
+}
+
+/// #1518: is the matched marker still visible in the live bottom-`n` rows? A
+/// HIGH_FP error phrase that has scrolled up past the tail (pushed there by the
+/// agent's post-recovery output) is stale — it must NOT keep re-firing the error
+/// transition every feed. Returns true iff `matched` occurs within the last `n`
+/// rows of `screen_text` (where the agent's current activity is); a copy that
+/// only survives in the scrolled-up region returns false → caller suppresses.
+fn matched_span_in_recent_tail(screen_text: &str, matched: &str, n: usize) -> bool {
+    if matched.is_empty() {
+        return false;
+    }
+    // Trim trailing blank rows so "bottom-N" tracks the last N lines of actual
+    // CONTENT (where the agent's cursor/activity is), not the blank padding the
+    // emulator leaves below the cursor on a not-yet-full screen — otherwise a
+    // single error line on an near-empty screen would look "scrolled out".
+    recent_screen_tail(screen_text.trim_end(), n).contains(matched)
 }
 
 /// #1450: the `fg` span of the FIRST on-screen occurrence of `matched`, for
@@ -568,12 +603,39 @@ impl StateTracker {
             // was supplied (text-only callers).
             match patterns.detect_with_match(screen_text) {
                 Some((detected, matched)) => {
-                    if self.anchor_on_red
-                        && is_high_fp_state(detected)
+                    let high_fp = is_high_fp_state(detected);
+                    // #1450 red anchor: a HIGH_FP marker needs at least one red
+                    // rendered cell, else it's prose ("Error: ...") not a state.
+                    let anchor_fail = self.anchor_on_red
+                        && high_fp
                         && !fg.is_empty()
-                        && !matched_span_has_red(screen_text, matched, fg)
-                    {
-                        self.log_anchor_suppress(detected, matched, screen_text, fg);
+                        && !matched_span_has_red(screen_text, matched, fg);
+                    // #1518 position gate: a HIGH_FP marker that has scrolled out
+                    // of the live bottom-N rows (e.g. an ApiError / ServerRateLimit
+                    // line pushed up by the post-recovery `continue` output) is
+                    // stale — the agent has moved on, so it must NOT keep re-firing
+                    // the error transition (the level-triggered re-match that drove
+                    // the retry storm). Scoped to HIGH_FP/error states ONLY:
+                    // Ready/Idle and modal/interactive prompts keep full-screen
+                    // scanning, because a modal can legitimately sit above the tail.
+                    let stale_position = high_fp
+                        && !matched_span_in_recent_tail(
+                            screen_text,
+                            matched,
+                            ERROR_TAIL_SCAN_LINES,
+                        );
+                    if anchor_fail || stale_position {
+                        if anchor_fail {
+                            self.log_anchor_suppress(detected, matched, screen_text, fg);
+                        } else {
+                            tracing::debug!(
+                                target: "state_detection",
+                                agent = %self.instance_name,
+                                state = ?detected,
+                                tail_rows = ERROR_TAIL_SCAN_LINES,
+                                "#1518: HIGH_FP marker scrolled out of the live tail — suppressing stale error transition"
+                            );
+                        }
                         // Treat as no detection — fall through to
                         // structural fallback / latch maintenance.
                         if matches!(self.current, AgentState::Starting)

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3127,3 +3127,89 @@ fn pending_transitions_bounded_drops_oldest() {
         "overflow count surfaced for the warn"
     );
 }
+
+// ── #1518: HIGH_FP error detection bounded to the live bottom-N tail ──
+
+#[test]
+fn matched_span_in_recent_tail_unit_1518() {
+    use super::{matched_span_in_recent_tail, ERROR_TAIL_SCAN_LINES};
+    let mut screen = String::from("ERR: boom\n");
+    for i in 0..(ERROR_TAIL_SCAN_LINES + 3) {
+        screen.push_str(&format!("line {i}\n"));
+    }
+    // The error is now above the last ERROR_TAIL_SCAN_LINES rows.
+    assert!(
+        !matched_span_in_recent_tail(&screen, "ERR: boom", ERROR_TAIL_SCAN_LINES),
+        "error scrolled above the tail → not in recent tail"
+    );
+    // A marker within the last N rows IS in the tail.
+    assert!(
+        matched_span_in_recent_tail(&screen, "line 7", ERROR_TAIL_SCAN_LINES),
+        "a marker in the last N rows is in the recent tail"
+    );
+    assert!(
+        !matched_span_in_recent_tail(&screen, "", ERROR_TAIL_SCAN_LINES),
+        "empty match is never in tail"
+    );
+}
+
+#[test]
+fn high_fp_error_only_fires_within_live_tail_1518() {
+    // #1518: a HIGH_FP ServerRateLimit line visible in the live bottom rows fires
+    // the error state; the SAME line scrolled above the live tail (pushed up by
+    // the agent's post-recovery output) must NOT — that level-triggered re-match
+    // was the retry-storm root. Text-path (`feed`) so the #1450 red anchor
+    // fail-opens (no fg mask) and we test the POSITION gate in isolation.
+    // RateLimit is HIGH_FP; the string is the canonical ClaudeCode trigger.
+    let err = "API Error: Request rejected (429) · this may be a temporary capacity issue";
+
+    // A: error in the live tail → RateLimit fires.
+    let mut a = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+    a.feed(err);
+    assert_eq!(
+        a.get_state(),
+        AgentState::RateLimit,
+        "error visible in the live tail must fire the HIGH_FP error state"
+    );
+
+    // B: SAME error scrolled above the bottom-N (ERROR_TAIL_SCAN_LINES rows of
+    // subsequent output below it) → suppressed (must NOT keep firing the error
+    // state). 20 lines clears the N=15 bound with margin.
+    let mut b = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+    let mut screen = format!("{err}\n");
+    for i in 0..20 {
+        screen.push_str(&format!("subsequent output line {i}\n"));
+    }
+    b.feed(&screen);
+    assert_ne!(
+        b.get_state(),
+        AgentState::RateLimit,
+        "#1518: error scrolled above the live tail must NOT keep firing the error state"
+    );
+}
+
+#[test]
+fn modal_prompt_above_live_tail_still_detected_1518() {
+    // reviewer-2 refinement: modal / interactive prompts are NOT HIGH_FP, so they
+    // keep FULL-screen scanning — a permission prompt that sits above the live
+    // streaming tail must still be detected (the bottom-N bound is error-only).
+    // (gate_on_heartbeat may relabel a fresh PermissionPrompt as Thinking; either
+    // way it is DETECTED, not suppressed/missed — the point of this test.)
+    // 20 streaming lines push the prompt above the bottom-N=15 error bound; a
+    // HIGH_FP marker this deep WOULD be suppressed, so detection here proves the
+    // bound is error-only.
+    let mut st = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+    let mut screen = String::from("Do you want to proceed with this edit?\n");
+    for i in 0..20 {
+        screen.push_str(&format!("streaming output {i}\n"));
+    }
+    st.feed(&screen);
+    assert!(
+        matches!(
+            st.get_state(),
+            AgentState::PermissionPrompt | AgentState::Thinking
+        ),
+        "#1518: a modal above the live tail must still be detected (full-screen, not bottom-N bounded), got {:?}",
+        st.get_state()
+    );
+}


### PR DESCRIPTION
## Problem (#1518)

State detection is **level-triggered** — `feed_with_fg` re-judges the whole
viewport every tick. So an error string (ServerRateLimit / RateLimit /
ContextFull) lingering anywhere in the viewport keeps re-firing the error
state: a **retry storm** that persists even after the agent has visually
moved on and new output sits below the stale error.

## Fix

Bound HIGH_FP/error re-matching to the bottom `ERROR_TAIL_SCAN_LINES` rows of
content. An error pushed *above* the live tail by post-recovery output stops
matching → the state recovers **naturally (non-timer)**.

Scoped to **HIGH_FP states only** (`is_high_fp_state`: ServerRateLimit /
RateLimit / ContextFull). **Ready/Idle and modal/interactive prompts keep
FULL-screen scanning** (reviewer-2 refinement) — a permission prompt that sits
above the live streaming tail must never be missed.

~10 LOC of logic (`matched_span_in_recent_tail` helper + one `stale_position`
clause beside the existing `anchor_fail` gate) + a documented constant.

## Why N = 15 (evidence, not a guess)

I first reused `MARKER_SCAN_TAIL_LINES = 5` — `replay_manifest_regression`
caught it: the real `claude-server-throttle.raw` recording renders its
*fresh* throttle marker **6 rows from the bottom** (the `Retrying...` line
wraps, eating a row). I measured the marker depth across **every** canonical
error fixture (claude / gemini / kiro / opencode — rate-limit, throttle, 429,
usage-limit): a fresh error marker consistently sits at **depth 5–6, max 6**.

`ERROR_TAIL_SCAN_LINES = 15` clears that by >2× (headroom for multi-line /
wrapped error bodies not in the fixtures) while still suppressing an error
pushed into the top portion of a typical 24–50 row viewport. Deliberately
conservative — bias toward *not* dropping a real error. Kept distinct from
`MARKER_SCAN_TAIL_LINES` (tighter structural-marker scan); the two are not
collapsed.

## Tests (RED-verified)

Neuter the gate (`stale_position = false && …`) and
`high_fp_error_only_fires_within_live_tail_1518` fails — proving the gate does
the work:

- `matched_span_in_recent_tail_unit_1518` — helper position logic
- `high_fp_error_only_fires_within_live_tail_1518` — in-tail error fires; the
  same error scrolled above the tail is suppressed
- `modal_prompt_above_live_tail_still_detected_1518` — a permission prompt 20
  rows deep (above bottom-15) is still detected → bound is error-only

`replay_manifest_regression` + full `state::` suite (245) green; full
`cargo test --tests`, `clippy --all-targets`, `fmt` clean.

## Out of scope

Color detection untouched (orthogonal PR-A, `src/vterm.rs`). Phase-3
fingerprint-based freshness cooldown deferred — only if the retry storm
persists post-merge.

Refs #1518, #1523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)