### PR TITLE
fix(#1541): verb-agnostic structural anchor for Claude thinking spinner

### DIFF
--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -142,14 +142,6 @@ impl StatePatterns {
                     AgentState::GitConflict,
                     r"Automatic merge failed; fix conflicts|CONFLICT \(content\)|Resolve all conflicts manually|Failed to merge submodule|Failed to merge in",
                 ),
-                // [estimated] Ink render during processing
-                // [measured] Claude spinner uses random verbs (Cogitating,
-                // Bloviating, Transmuting, etc.) — not "Thinking". The
-                // `thought for Ns` anchor catches post-thinking summary.
-                (
-                    AgentState::Thinking,
-                    r"(?i)(Bloviating|Transmuting|Cogitating|Cooked|Brewed|Worked|Cogitated|Crunched|Brewing)|thought for [0-9]+s",
-                ),
                 // #1005 Phase A1: ToolUse = active tool execution, NOT
                 // historical completion record. Pre-fix regex matched
                 // BOTH the braille spinner (`⠋ Listing`) AND the
@@ -181,6 +173,48 @@ impl StatePatterns {
                 (
                     AgentState::ToolUse,
                     r"(?m)^(?:[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\s+(?:Read|Bash|Edit|Write|Grep|Glob|Listing|Reading|Writing|Searching|Editing)|[✓●⏺]\s+(?:Listing|Reading|Writing|Searching|Editing))\b",
+                ),
+                // #1541: verb-AGNOSTIC structural anchor for the Claude thinking
+                // spinner. The old fix enumerated verbs (Cogitating, Bloviating,
+                // …) but Claude's spinner rolls a *random* gerund every run
+                // (Undulating, Julienning, Whisking, …). Any unlisted verb went
+                // undetected → the snapshot recorded `idle` for a busy agent →
+                // the dispatch-idle watchdog mis-fired. (claude-thinking.raw,
+                // verb `Undulating`, is exactly that miss: it used to replay
+                // `[starting, idle]` with no thinking at all.)
+                //
+                // ORDER: placed AFTER the ToolUse arm on purpose. Claude keeps
+                // the sparkle spinner animating WHILE a tool runs, so a tool
+                // frame (`⏺ Listing 1 directory…`) and a spinner frame
+                // (`✳ Burrowing…`) coexist on screen. detect_with_match is
+                // first-match-wins, so ToolUse must precede Thinking to stay
+                // detectable — this keeps #1541 orthogonal to #1005 (a spinner
+                // that is NOT a tool frame still falls through to Thinking).
+                //
+                // [measured] the spinner renders `<glyph> <Verb>… (<elapsed> · …)`
+                // where:
+                //   - <glyph> rolls through the SPARKLE family (✻ ✢ ✶ ✳ ✽) and
+                //     also `*` / `·` — it animates, so do NOT hard-enumerate it.
+                //     (NB: this is sparkle, NOT the braille `⠋⠙⠹` spinner — that
+                //     is ToolUse, the arm directly above.)
+                //   - <Verb>… ends in U+2026 (`…`), never the ASCII `...`.
+                //   - the tail is usually ` (16m · thinking)` / ` (21m · ↑ N
+                //     tokens)` (minutes OR seconds), occasionally `(running stop
+                //     hook)`, occasionally absent.
+                //
+                // Anchor = U+2026 AND (leading sparkle/`*` glyph OR a structural
+                // `(elapsed|running` tail). That double requirement is the prose
+                // false-positive guard the verb list used to provide:
+                //   - `Let me think…`         → U+2026 but no glyph/tail   → no
+                //   - `Thinking...(7s)`       → ASCII `...`, not U+2026    → no
+                //   - `Churned for 7m39s`     → past-tense completion, no `…` → no
+                // `thought for Ns` stays a separate alternation (post-thinking
+                // summary line has no spinner glyph). Backend-scoped to Claude —
+                // codex/kiro/gemini keep their own arms (cross-backend negative
+                // test in src/state/tests.rs).
+                (
+                    AgentState::Thinking,
+                    r"(?i)[✻✢✶✳✽*·]\s*\w+\x{2026}|\w+\x{2026}\s*\((?:\d+[smh]|running )|thought for [0-9]+s",
                 ),
                 // [measured] Prompt symbol in idle state
                 (AgentState::Idle, r"❯"),

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -1950,8 +1950,10 @@ fn claude_spinner_verb_triggers_thinking() {
     let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
     drive(&mut vt, &mut st, b"bypass permissions\r\n");
     assert_eq!(st.get_state(), AgentState::Ready);
-    // Claude spinner uses random verbs, not "Thinking"
-    drive(&mut vt, &mut st, b"Cogitating\xe2\x80\xa6\r\n");
+    // #1541: Claude spinner uses random verbs; the verb-agnostic structural
+    // anchor (sparkle glyph + `<verb>…`) must fire regardless of the verb.
+    // `\xe2\x9c\xbb` = ✻ (U+273B sparkle), `\xe2\x80\xa6` = … (U+2026).
+    drive(&mut vt, &mut st, b"\xe2\x9c\xbb Cogitating\xe2\x80\xa6\r\n");
     assert_eq!(
         st.get_state(),
         AgentState::Thinking,
@@ -3212,4 +3214,62 @@ fn modal_prompt_above_live_tail_still_detected_1518() {
         "#1518: a modal above the live tail must still be detected (full-screen, not bottom-N bounded), got {:?}",
         st.get_state()
     );
+}
+
+// ── #1541: verb-agnostic Claude thinking spinner anchor ─────────────────
+
+#[test]
+fn claude_thinking_anchor_is_verb_agnostic_1541() {
+    // The crux of #1541: spinner verbs roll randomly and were NOT in the old
+    // whitelist (Whisking / Julienning / Burrowing / Lollygagging are all new;
+    // `Churned` proves a past-tense verb in an ACTIVE spinner still counts).
+    // Each frame must fire Thinking so a heads-down agent never reads `idle`.
+    for frame in [
+        "✻ Whisking… (5s)",                         // sparkle glyph + elapsed tail
+        "✶ Churned… (12s · ↑ 2.1k tokens)",         // active past-tense verb + token counter
+        "· Julienning… (16m · thinking)",           // `·` glyph + minutes elapsed
+        "✳ Burrowing… (thinking with high effort)", // sparkle + non-elapsed tail
+        "Lollygagging…(running stop hook)",         // no glyph — Branch B `(running` tail
+    ] {
+        let mut st = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+        st.feed(frame);
+        assert_eq!(
+            st.get_state(),
+            AgentState::Thinking,
+            "#1541: unlisted-verb spinner {frame:?} must fire Thinking"
+        );
+    }
+}
+
+#[test]
+fn claude_thinking_anchor_rejects_prose_and_completion_1541() {
+    // False-positive guards the verb whitelist used to provide for free.
+    for frame in [
+        "Thinking...(7s)",          // prose: ASCII `...`, NOT U+2026
+        "Churned for 7m39s",        // completion: past-tense `for Xm Ys`, no `…`
+        "Let me think about this…", // prose: U+2026 but no glyph and no `(tail`
+    ] {
+        let mut st = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+        st.feed(frame);
+        assert_ne!(
+            st.get_state(),
+            AgentState::Thinking,
+            "#1541: {frame:?} must NOT be misread as Thinking"
+        );
+    }
+}
+
+#[test]
+fn claude_thinking_anchor_does_not_cross_backends_1541() {
+    // The sparkle anchor is Claude-scoped; a Claude spinner frame fed to other
+    // backends' pattern sets must not yield Thinking (each owns its own arm).
+    let claude_frame = "✻ Whisking… (5s)";
+    for backend in [Backend::Codex, Backend::Gemini, Backend::KiroCli] {
+        let detected = StatePatterns::for_backend(&backend).detect(claude_frame);
+        assert_ne!(
+            detected,
+            Some(AgentState::Thinking),
+            "#1541: claude sparkle anchor must not fire Thinking on {backend:?}"
+        );
+    }
 }

--- a/tests/fixtures/state-replay/MANIFEST.yaml
+++ b/tests/fixtures/state-replay/MANIFEST.yaml
@@ -23,8 +23,15 @@ fixtures:
     cli_version: "2.1.98"
     recorded_on: "2026-04-20"
     scenario: "startup banner to idle prompt; response completes inline"
-    expected_transitions: [starting, idle]
-    expected_final_state: idle
+    # #1541: the spinner verb here is `Undulating` — NOT in the old verb
+    # whitelist, so it used to replay `[starting, idle]` with the thinking phase
+    # invisible (the dispatch-idle-misfire root). The verb-agnostic structural
+    # anchor now detects it: `thinking` appears. `final_state` is `thinking`
+    # (latched: Thinking outranks Idle and no wall-clock passes in replay to
+    # expire the latch) while `final_detect` on the settled idle-menu screen is
+    # `idle` — in real operation LATCHED_STATE_EXPIRY recovers to idle.
+    expected_transitions: [starting, idle, thinking]
+    expected_final_state: thinking
     expected_final_detect: idle
 
   - file: codex-thinking.raw
@@ -157,7 +164,13 @@ fixtures:
     # The tracker retains PermissionPrompt via hysteresis (byte-level
     # replay never crosses the min_hold) — no behavioral change for
     # consumers.
-    expected_transitions: [starting, idle, permission]
+    #
+    # #1541: a `thinking` phase now appears before `permission`. The spinner
+    # verb here is `Swooping` (`✢ Swooping…`) — unlisted in the old verb
+    # whitelist, so the agent's thinking was previously invisible. The
+    # verb-agnostic structural anchor detects it; PermissionPrompt (priority
+    # 8) then correctly overrides the latched Thinking (6).
+    expected_transitions: [starting, idle, thinking, permission]
     expected_final_state: permission
     expected_final_detect: idle
 
@@ -204,11 +217,38 @@ fixtures:
     # claude 2.1.98 -ing verbs (Listing|Reading|Writing|Searching|
     # Editing). Final detect() returns Idle because the completion
     # frame shows the bare directory listing under `⏺` without a verb
-    # on the banner line, so only the `❯` prompt glyph matches — the
-    # tracker still reports ToolUse via hysteresis (min_hold=2s not
-    # yet elapsed under byte-level replay).
-    expected_transitions: [starting, idle, tool_use]
-    expected_final_state: tool_use
+    # on the banner line, so only the `❯` prompt glyph matches.
+    #
+    # #1541: the agent THINKS before it runs the tool — `✳ Burrowing…
+    # (thinking with high effort)` renders first. That spinner verb
+    # (`Burrowing`) was unlisted before, so the old replay jumped straight
+    # to `tool_use`; the verb-agnostic anchor now detects the thinking
+    # phase. Thinking (priority 6) latches and the later ToolUse (priority
+    # 5) cannot downgrade it within the zero-wall-clock replay, so the
+    # observed sequence collapses to `[starting, idle, thinking]`
+    # (final_state latched=thinking; final_detect on the settled idle
+    # screen = idle).
+    #
+    # Why this is ACCEPTED under #1541's KISS scope (lead ruling
+    # t-20260531075003109468-4):
+    #  1. EQUIVALENT for the watchdog. dispatch-idle's `target_is_working`
+    #     treats `thinking` and `tool_use` identically as "working", so
+    #     labelling this frame `thinking` vs `tool_use` makes no difference
+    #     to gating — the heads-down agent reads working, NOT idle, and the
+    #     watchdog cannot mis-fire (the entire point of #1541).
+    #  2. ZERO-TIME REPLAY ARTIFACT, not a real regression. In a live
+    #     runtime the Thinking latch expires on its short (30 s) timer and a
+    #     genuinely-running tool registers ToolUse normally — the ToolUse
+    #     PATTERN is untouched and still fires when a tool frame is the
+    #     first busy state (covered directly by
+    #     behavioral::tests::claude_markers_match_completion_glyph_and_tool).
+    #     Only this byte-replay (no wall-clock) collapses the ordering.
+    #  3. Preserving the ToolUse LABEL here would require changing the
+    #     latch/priority machinery — out of #1541's KISS scope. Deferred to
+    #     a follow-up IFF a consumer is ever found that depends on the
+    #     think→tool ToolUse label.
+    expected_transitions: [starting, idle, thinking]
+    expected_final_state: thinking
     expected_final_detect: idle
     # #685 PR-3 (corpus expansion): final=tool_use, no claude productive
     # markers (`✓●⏺ Read|Write|...` -ing form vs Phase A1 alternation)


### PR DESCRIPTION
## Problem (#1541)

Claude's thinking spinner rolls a **random gerund** every run — Undulating,
Julienning, Whisking, Swooping, Burrowing, Lollygagging, … The old detector
enumerated a fixed verb whitelist, so any unlisted verb went **undetected**:
the state snapshot recorded `idle` for a busy agent and the dispatch-idle
watchdog mis-fired. (This is the bug I hit in practice.)

`claude-thinking.raw` in the replay corpus *is* this bug captured — its verb is
`Undulating`, unlisted, so it used to replay `[starting, idle]` with the
thinking phase invisible.

## Fix

Replace the whitelist with a **verb-agnostic structural anchor**:

```
U+2026 (…)  AND  ( leading sparkle/`*`/`·` glyph  OR  a `(elapsed|running` tail )
```

matching the measured render `<glyph> <Verb>… (<elapsed> · …)`. Elapsed is
seconds **or minutes** (`(16m`, `(21m`, `(5s`) per live samples
(`✻ Julienning… (16m · thinking)`, `· Julienning… (21m · ↑ 71.4k tokens)`).
`thought for Ns` stays a separate alternation.

The double requirement (U+2026 **and** glyph/tail) is the prose
false-positive guard the verb list used to provide:

| input | result | why |
|---|---|---|
| `Let me think…` | not Thinking | U+2026 but no glyph / no `(tail` |
| `Thinking...(7s)` | not Thinking | ASCII `...`, not U+2026 |
| `Churned for 7m39s` | not Thinking | past-tense completion, `for Xm Ys`, no `…` |

**Orthogonal to #1005 (ToolUse):** the Thinking arm is placed *after* the
ToolUse arm (`detect_with_match` is first-match-wins) so a tool frame
(`⏺ Listing 1 directory…`) coexisting with the spinner still detects ToolUse.
Backend-scoped to Claude — codex/kiro/gemini arms untouched.

## Manifest replay updates (the fix making invisible thinking visible)

- **claude-thinking.raw** (`Undulating`): `[starting, idle]` → `[starting, idle,
  thinking]`. The fixture that was the bug.
- **claude-perm.raw** (`Swooping`): a `thinking` phase now precedes
  `permission` (PermissionPrompt priority 8 correctly overrides it).
- **claude-tooluse.raw** (`Burrowing`): the agent **thinks before running the
  tool**. Thinking (priority 6) latches and the later ToolUse (5) cannot
  downgrade it within the zero-wall-clock replay → `[starting, idle, thinking]`.
  **Accepted under KISS** (lead ruling): dispatch-idle's `target_is_working`
  treats `thinking` and `tool_use` identically, so watchdog gating is unchanged;
  it is a replay artifact (real runtime expires the latch and a running tool
  registers ToolUse normally — the ToolUse **pattern is untouched**,
  `behavioral::claude_markers_match_completion_glyph_and_tool` green); preserving
  the label would require latch/priority surgery, deferred to a follow-up.
  Fully documented inline in `MANIFEST.yaml`.

## Tests

- `claude_thinking_anchor_is_verb_agnostic_1541` — unlisted verbs
  (Whisking/Churned/Julienning/Burrowing/Lollygagging) all → Thinking
- `claude_thinking_anchor_rejects_prose_and_completion_1541` — the FP guards above
- `claude_thinking_anchor_does_not_cross_backends_1541` — Claude anchor doesn't
  fire on codex/gemini/kiro
- `claude_spinner_verb_triggers_thinking` updated to the structural form

Full `cargo test --tests` green (58 binaries / 3209 tests), `replay_manifest_regression`
green, clippy `--all-targets` + fmt clean. Base: fresh `origin/main` (d5fc013).

Refs #1541, #1523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)