### PR TITLE
fix(#1537 follow-up): conditional ci-fail checklist + diagnose empty log-tail

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -671,6 +671,32 @@ pub(crate) fn format_log_tail(
     }
 }
 
+/// CI-fail-notify checklist footer. Step 1 adapts to whether the daemon
+/// pre-fetched the failed-log tail (embedded above the checklist). When absent
+/// — the early-fail path fires mid-run so `--log-failed` is empty, or a fetch
+/// errored/timed out — point the reader at the manual command + the completion
+/// notification instead of a tail that isn't there (#1537 follow-up: the old
+/// unconditional "Read the failed-log tail above" was self-contradictory when
+/// no tail was attached).
+fn failure_checklist(run_id_str: &str, has_tail: bool) -> String {
+    let step1 = if has_tail {
+        format!("1. Read the failed-log tail above (full: `gh run view {run_id_str} --log-failed`)")
+    } else {
+        format!(
+            "1. Daemon did not attach a failed-log tail (the run may still be in progress) — \
+             fetch it with `gh run view {run_id_str} --log-failed` (the run-completion \
+             notification will also carry it)"
+        )
+    };
+    format!(
+        "\n\n⚠ CI failure checklist:\n\
+         {step1}\n\
+         2. If infra flake → `gh run rerun {run_id_str} --failed`\n\
+         3. If real failure → fix code, push, wait for green\n\
+         4. Do NOT dismiss without evidence"
+    )
+}
+
 pub(crate) fn build_inbox_body(
     headline: &str,
     conclusion: &str,
@@ -689,16 +715,14 @@ pub(crate) fn build_inbox_body(
         // agent doesn't need an extra `gh run view` round-trip. None → fall back
         // to the original instruction-only body. The full-log command stays in
         // the checklist footer below.
-        if let Some(tail) = log_tail.filter(|t| !t.is_empty()) {
-            body.push_str(&format!("\n\n── failed log (tail) ──\n{tail}"));
-        }
-        body.push_str(&format!(
-            "\n\n⚠ CI failure checklist:\n\
-             1. Read the failed-log tail above (full: `gh run view {run_id_str} --log-failed`)\n\
-             2. If infra flake → `gh run rerun {run_id_str} --failed`\n\
-             3. If real failure → fix code, push, wait for green\n\
-             4. Do NOT dismiss without evidence"
-        ));
+        let has_tail = match log_tail.filter(|t| !t.is_empty()) {
+            Some(tail) => {
+                body.push_str(&format!("\n\n── failed log (tail) ──\n{tail}"));
+                true
+            }
+            None => false,
+        };
+        body.push_str(&failure_checklist(&run_id_str, has_tail));
         body
     } else {
         format!(
@@ -868,22 +892,14 @@ async fn check_early_job_failures(
     if !all_running.is_empty() {
         body.push_str(&format!("\nStill running: {}", all_running.join(", ")));
     }
-    // CI-fail-notify: daemon pre-fetches the failed-log tail and embeds it inline
-    // (no extra `gh run view` round-trip for the agent). None → instruction only.
-    if let Some(tail) = provider
-        .fetch_failure_log_tail(ctx.repo, first_run_id, 120)
-        .await
-        .filter(|t| !t.is_empty())
-    {
-        body.push_str(&format!("\n\n── failed log (tail) ──\n{tail}"));
-    }
-    body.push_str(&format!(
-        "\n\n⚠ CI failure checklist:\n\
-         1. Read the failed-log tail above (full: `gh run view {first_run_id} --log-failed`)\n\
-         2. If infra flake → `gh run rerun {first_run_id} --failed`\n\
-         3. If real failure → fix code, push, wait for green\n\
-         4. Do NOT dismiss without evidence"
-    ));
+    // #1537 follow-up: the early-fail detector fires while the run is still in
+    // progress (other jobs running, see `all_running`), so `gh run view
+    // --log-failed` has nothing yet — skip the guaranteed-empty (20s-timeout-
+    // prone) pre-fetch here. The run-completion notification re-fires for this
+    // same failure WITH the tail (separate dedup state: this path writes only
+    // `early_fail_notified_sha`, not `last_notified_conclusion`), so the agent
+    // still receives the log. The no-tail checklist points there meanwhile.
+    body.push_str(&failure_checklist(&first_run_id.to_string(), false));
 
     let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
     let supersede_token = format!("ci-early-{sha_short}");

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -5220,6 +5220,22 @@ fn early_job_failure_sends_notification() {
         content.contains("[ci-fail]"),
         "#1326: early job failure must send inbox notification"
     );
+    // #1537-fu: the early-fail path fires mid-run (macos/windows still running),
+    // so it must NOT embed a tail nor claim one is above — `gh run view
+    // --log-failed` is empty until the run completes. It uses the no-tail
+    // checklist (the completion notification carries the tail).
+    assert!(
+        !content.contains("failed log (tail)"),
+        "#1537-fu: mid-run early-fail must not embed a (guaranteed-empty) tail"
+    );
+    assert!(
+        !content.contains("Read the failed-log tail above"),
+        "#1537-fu: mid-run early-fail must not claim a tail is above"
+    );
+    assert!(
+        content.contains("did not attach a failed-log tail"),
+        "#1537-fu: early-fail uses the no-tail checklist wording"
+    );
     std::fs::remove_dir_all(&dir).ok();
 }
 
@@ -5436,8 +5452,14 @@ fn build_inbox_body_embeds_log_tail_when_present() {
         with_tail.contains("gh run view 9 --log-failed"),
         "full-log cmd stays as footer"
     );
+    assert!(
+        with_tail.contains("Read the failed-log tail above"),
+        "#1537-fu: tail present → checklist step 1 says read it"
+    );
 
-    // None → falls back to the instruction-only body (no tail section).
+    // None → no tail section AND the checklist must NOT claim a tail is above
+    // (the #1537-fu bug: unconditional "Read the failed-log tail above" with no
+    // tail attached). Step 1 instead points at the manual command.
     let no_tail = build_inbox_body(
         "[ci-fail] o/r@main: failure",
         "failure",
@@ -5453,5 +5475,13 @@ fn build_inbox_body_embeds_log_tail_when_present() {
     assert!(
         no_tail.contains("CI failure checklist"),
         "checklist still present"
+    );
+    assert!(
+        !no_tail.contains("Read the failed-log tail above"),
+        "#1537-fu: no-tail body must NOT claim a tail is above"
+    );
+    assert!(
+        no_tail.contains("did not attach a failed-log tail"),
+        "#1537-fu: no-tail body points to the manual command instead"
     );
 }

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -580,6 +580,7 @@ impl CiProvider for GitHubCiProvider {
         // runtime stays free — and so we NEVER `block_on` the shared ci runtime
         // (#1476: that would panic "cannot start a runtime from within a
         // runtime"). Bounded by a timeout so a wedged `gh` can't stall the poll.
+        let repo_log = repo.to_string(); // for diagnostic warns (repo is moved into the closure)
         let repo = repo.to_string();
         let run = tokio::task::spawn_blocking(move || {
             std::process::Command::new("gh")
@@ -593,17 +594,39 @@ impl CiProvider for GitHubCiProvider {
                 ])
                 .output()
         });
-        let out = tokio::time::timeout(std::time::Duration::from_secs(20), run)
-            .await
-            .ok()? // timeout
-            .ok()? // JoinError
-            .ok()?; // spawn/exec error
+        // #1537 follow-up: log WHY a fetch yields no tail instead of swallowing
+        // it (every failure mode used to collapse to a silent `None`, so a
+        // tail-less notification was undiagnosable — e.g. the #1542 windows
+        // case). Still always returns None on any failure (notification degrades
+        // to the no-tail checklist); the warn is observability only.
+        let out = match tokio::time::timeout(std::time::Duration::from_secs(20), run).await {
+            Err(_) => {
+                tracing::warn!(repo = %repo_log, run_id, "#1537: failed-log tail fetch timed out (20s) — notification omits tail");
+                return None;
+            }
+            Ok(Err(join_err)) => {
+                tracing::warn!(repo = %repo_log, run_id, error = %join_err, "#1537: failed-log tail fetch task join error");
+                return None;
+            }
+            Ok(Ok(Err(exec_err))) => {
+                tracing::warn!(repo = %repo_log, run_id, error = %exec_err, "#1537: failed-log tail fetch could not exec `gh`");
+                return None;
+            }
+            Ok(Ok(Ok(out))) => out,
+        };
         if !out.status.success() {
+            let stderr: String = String::from_utf8_lossy(&out.stderr)
+                .trim()
+                .chars()
+                .take(300)
+                .collect();
+            tracing::warn!(repo = %repo_log, run_id, code = ?out.status.code(), stderr = %stderr, "#1537: `gh run view --log-failed` non-zero (run may be incomplete) — notification omits tail");
             return None;
         }
         let raw = String::from_utf8_lossy(&out.stdout);
         let trimmed = raw.trim();
         if trimmed.is_empty() {
+            tracing::warn!(repo = %repo_log, run_id, "#1537: `gh run view --log-failed` empty stdout — notification omits tail");
             return None;
         }
         // 8 KiB byte cap alongside the line cap (defends against one huge line).


### PR DESCRIPTION
## What
Deployed-after empirical gap (#1542 windows): a ci-fail subscriber notification said **"1. Read the failed-log tail above"** but carried **no tail**.

## Root cause (refuted the dispatch hypothesis)
The dispatch suspected the subscriber path didn't pre-fetch the tail. Code check (d5fc013) shows **both** ci-fail subscriber paths already pre-fetch:
- completed-run path (`fan_out_notifications` → `build_inbox_body`, poller.rs:1298)
- early-fail path (poller.rs:859)
…and `next_after_ci` is **success-only**, so there's no tail-less handoff path.

The real gap: the tail is embedded only when present, but the checklist's **step 1 was unconditional** → self-contradictory when the fetch returns `None`. The **early-fail path is the common trigger** — it fires **mid-run** (other jobs still running, `all_running`), when `gh run view --log-failed` has nothing yet → `None`. `fetch_failure_log_tail` also collapsed every failure mode (timeout / non-zero exit / empty) to a **silent** `None`, so it was undiagnosable.

## Fix (A + B, per lead's alignment)
- **(A)** `failure_checklist(run_id, has_tail)` — shared footer whose step 1 adapts: tail present → "Read the failed-log tail above"; absent → point at the manual `gh run view <id> --log-failed` + note the completion notification will carry it. Used by both `build_inbox_body` and the early-fail path.
- **early-fail SKIPS the pre-fetch** entirely (guaranteed-empty mid-run + avoids the 20s timeout). The **completion notification re-fires the same failure WITH the tail** — separate dedup state (early-fail writes only `early_fail_notified_sha`; completion gates on `last_notified_conclusion`), verified via `dedupe_notifications_by_head_sha`. So the agent still gets the log.
- **(B)** `fetch_failure_log_tail` now `tracing::warn`s **why** a fetch yields no tail (timeout / non-zero exit + stderr / empty stdout) instead of swallowing it. Still `spawn_blocking` + 20s timeout, never `block_on` the shared runtime (#1476).

## Decision recorded (early-fail gate)
Investigated re-fire behavior as lead asked: the completed-run path **does** re-fire (separate dedup), so gating-out the early-fail fetch is the clean choice (vs keeping a doomed mid-run fetch).

## Tests
- `build_inbox_body_embeds_log_tail_when_present` — asserts the conditional wording both ways (tail → "read above"; none → "did not attach … `gh run view`", and NOT "read above").
- The mid-run early-fail test (`#1326` early-job-failure) now asserts the no-tail wording + no embedded tail.

Full preflight green (fmt + clippy -D + tests --features tray + windows xwin). Scope: #1537 follow-up only — no ci_watch refactor.

## Links
#1537 (original cifail-notify) · #1542 (the empirical case) · #1476 (no block_on shared runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)