### PR TITLE
docs(.github): require a prior-art check on new issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,6 +5,17 @@ title: 'bug: '
 labels: ['bug']
 ---
 
+## Prior art check (required)
+
+<!-- Reports that duplicate an existing (open OR closed) issue, or re-raise an
+already-resolved topic without new evidence, may be closed without further
+review. A quick search saves everyone time. -->
+
+- [ ] I searched **open and closed** issues for prior reports or prior
+      conclusions on this, and linked any I found below.
+- [ ] This is not a re-report of an already-resolved issue — or, if it
+      revisits one, I explain what new evidence or change warrants reopening it.
+
 ## Symptom
 
 <!-- One sentence: what's user/operator-visible going wrong.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Require contributors to go through a template (which carries the prior-art
+# check) rather than opening a blank issue that skips it.
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,6 +5,17 @@ title: 'feat: '
 labels: ['enhancement']
 ---
 
+## Prior art check (required)
+
+<!-- Requests that duplicate an existing (open OR closed) issue, or re-raise an
+already-decided approach without new evidence, may be closed without further
+review. A quick search saves everyone time. -->
+
+- [ ] I searched **open and closed** issues for prior requests or prior
+      decisions on this, and linked any I found below.
+- [ ] This is not a re-request of an already-decided topic — or, if it
+      revisits one, I explain what new evidence or change warrants advancing it.
+
 ## Problem
 
 <!-- What's the user-visible pain or limitation today?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- Thanks for contributing! Please complete the checklist below. PRs that
+duplicate an already-merged change, or re-implement an already-decided approach
+without advancing it, may be closed without further review. -->
+
+## What & why
+
+<!-- One or two sentences: what this changes and the problem it solves.
+Link the issue it closes, e.g. `Closes #123`. -->
+
+## Prior art check (required)
+
+- [ ] I compared this change against the **current `main`** branch and
+      confirmed it isn't already implemented.
+- [ ] I searched **closed** issues and PRs for prior attempts or decisions in
+      this area, and linked any I found below.
+- [ ] If this revisits an existing decision, I explain below what new evidence
+      or change warrants advancing it (rather than re-proposing the same thing).
+
+## How it was verified
+
+<!-- Tests added/updated, manual steps, or commands run
+(e.g. `cargo test`, `cargo fmt --check`, `cargo clippy`). -->
+
+## Notes for reviewers
+
+<!-- Anything reviewers should know: trade-offs, follow-ups, out-of-scope. -->


### PR DESCRIPTION
## What & why
External reports have duplicated existing (open or closed) issues or re-raised already-resolved topics without new evidence. This makes the "check current project state first" expectation visible at the point of contribution (decision d-20260531094016998074-1).

## Changes (docs / `.github` only — no code)
- **`ISSUE_TEMPLATE/bug_report.md` + `feature_request.md`**: add a required **Prior art check** section near the top — search **open AND closed** issues, cite prior art, and confirm it isn't a re-report of a resolved topic (or explain what new evidence warrants reopening).
- **`PULL_REQUEST_TEMPLATE.md`** (new): checklist to compare against current `main`, search closed issues/PRs, confirm the change isn't already implemented, and explain how it advances any decision it revisits.
- **`ISSUE_TEMPLATE/config.yml`** (new): `blank_issues_enabled: false` so new issues go through a template carrying the check (rather than bypassing it with a blank issue).

Each template notes that duplicates of existing work, or re-raises of a resolved topic without advancing it, may be closed without further review.

## Notes for reviewers
- Wording is intentionally neutral/contributor-facing (no internal jargon).
- Zero overlap with the in-flight `agend-git.rs` (#1463) / `patterns.rs` (#1546) work.
- Existing issue-template sections/front-matter are unchanged apart from the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)