### PR TITLE
docs: add KNOWN_ISSUES.md and mark the agy backend unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ graph LR
 | Codex | `codex` | Tested |
 | OpenCode | `opencode` | Tested |
 | Gemini CLI | `gemini` | Tested |
-| Antigravity CLI | `agy` | Tested |
+| Antigravity CLI | `agy` | Unsupported |
 
 > Gemini CLI sunsets 2026-06-18 for free/Pro/Ultra tiers. Antigravity CLI is the official successor.
-> Agy does not yet support the Fleet MCP bridge — see [#987](https://github.com/suzuke/agend-terminal/issues/987) for status.
+> The `agy` backend is currently **unsupported**: beyond the missing Fleet MCP bridge, known issues with it are not being addressed for now. It will not be revisited until project-scoped MCP is supported ([#1262](https://github.com/suzuke/agend-terminal/issues/1262)) or a first-party CLI tool lands. See [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md) ([#1547](https://github.com/suzuke/agend-terminal/issues/1547)).
 
 ## Documentation
 
@@ -76,6 +76,7 @@ graph LR
 - [Fleet Configuration](docs/FEATURE-fleet.md) — `fleet.yaml` reference
 - [CLI Reference](docs/CLI.md) — All subcommands
 - [MCP Tools](docs/MCP-TOOLS.md) — 35 agent coordination tools
+- [Known Issues](docs/KNOWN_ISSUES.md) — Intentionally-deferred items; check before filing an issue
 
 <details>
 <summary><strong>Feature guides</strong></summary>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -69,7 +69,9 @@ Telegram 綁定（遠端控制 + 外發通知）請參閱 [`docs/USAGE.md` § Ch
 | Codex | `codex` | 已測試 |
 | OpenCode | `opencode` | 已測試 |
 | Gemini CLI | `gemini` | 已測試（2026-06-18 起免費/Pro/Ultra 停止服務；付費 Code Assist Standard/Enterprise 保留存取） |
-| Antigravity CLI | `antigravity-cli`（二進位 `agy`） | 已測試（#987——Gemini CLI 的官方繼任者；#995 polish）。**目前 AGY 版本不支援 Fleet MCP bridge**——agy instance 啟動時不具備 `send`/`inbox`/`task` 工具（operator 會在 `app.log` 中看到 `[fleet-mcp-unsupported]` 警告）。適合手動作業；等待上游 `google-antigravity/antigravity-cli` 修復。 |
+| Antigravity CLI | `antigravity-cli`（二進位 `agy`） | 不支援 |
+
+> `agy` backend 目前**不支援**：除了缺少 Fleet MCP bridge，此 backend 的已知問題暫不進入修正階段。在 project-scoped MCP 被支援（[#1262](https://github.com/suzuke/agend-terminal/issues/1262)）或自家 CLI 工具完成前不會重啟支援。詳見 [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md)（[#1547](https://github.com/suzuke/agend-terminal/issues/1547)）。
 
 ## 深入了解
 
@@ -105,6 +107,7 @@ Telegram 綁定（遠端控制 + 外發通知）請參閱 [`docs/USAGE.md` § Ch
 
 - **命令**——[`docs/CLI.md`](docs/CLI.md) 完整子命令參考。
 - **MCP 工具**——[`docs/MCP-TOOLS.md`](docs/MCP-TOOLS.md) 35 個 agent 間協作工具。
+- **已知問題**——[`docs/KNOWN_ISSUES.md`](docs/KNOWN_ISSUES.md) 暫不處理的已知項；開 issue 前請先確認。
 - **架構**——[`docs/architecture.md`](docs/architecture.md) 涵蓋 git worktree 隔離、健康監控 + 自動重啟、Telegram topic 生命週期，以及 daemon-resident 設計。
 - **秘訣**——[`docs/RECIPE-clean-claude-instance.md`](docs/RECIPE-clean-claude-instance.md) 啟動不含全域指令或 auto-memory 的乾淨 Claude Code instance。
 - **貢獻**——[`CONTRIBUTING.md`](CONTRIBUTING.md)。

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,76 @@
+# Known Issues
+
+A living list of issues that are **known and intentionally not being worked on
+right now**, with the reason and the condition under which they'd be
+reconsidered.
+
+**Please check this list before opening an issue or PR.** Reports that
+re-raise an item here without new evidence — or that propose work already
+deferred for a stated reason — may be closed with a pointer back to this page.
+If you have new evidence or a change that affects the "Revisit when" condition,
+say so explicitly in your report.
+
+Status legend: **Upstream-blocker** (fix lives in another project) ·
+**Unsupported** (intentionally not maintained for now) · **Needs-operator-input**
+(blocked on a capture or decision only the maintainer can provide) ·
+**Stale** (no current owner).
+
+---
+
+## Upstream / external (not fixed in agend-terminal)
+
+### Antigravity CLI (`agy`) backend — unsupported
+- **Status:** Unsupported
+- **Why:** Beyond the missing Fleet MCP bridge, known problems with this
+  backend are not being addressed for now. Supporting it properly depends on
+  project-scoped MCP being available, or on a first-party CLI tool.
+- **Revisit when:** project-scoped MCP is supported (#1262), or a first-party
+  CLI tool lands.
+- **Refs:** #1547, #1262, #987
+
+### `agy` ignores a hidden parent-directory workspace
+- **Status:** Upstream-blocker
+- **Why:** `agy` treats paths under a hidden directory (e.g.
+  `~/.agend-terminal/*`) as hidden and skips them, so it won't operate in the
+  daemon-managed workspace. The fix belongs in the upstream CLI
+  (`@google/antigravity-cli`).
+- **Revisit when:** upstream supports hidden parent-directory workspaces.
+- **Refs:** #998
+
+### `opencode --continue` occasionally fails to resume
+- **Status:** Upstream bug (mitigated)
+- **Why:** the OpenCode TUI can send a placeholder ("dummy") session id on
+  resume, producing an "Unexpected server error". agend-terminal mitigates this
+  by falling back to a fresh session (#1519) — functional, but the prior
+  session is not resumed. This is an OpenCode-side bug, not an agend root fix.
+- **Revisit when:** OpenCode fixes the dummy-session id upstream.
+- **Refs:** #1526 (agend mitigation: #1519)
+
+## Deferred — awaiting operator capture or decision
+
+### Real PTY corpus (5 backends × 2 scenarios) incomplete
+- **Status:** Needs-operator-input
+- **Why:** robust state-detection work needs real terminal captures across the
+  supported backends as a validation gate; the corpus isn't complete yet.
+- **Revisit when:** the operator captures the remaining corpus.
+- **Refs:** #1014
+
+### Claude Code "Yes, proceed" modal — default cursor position unverified
+- **Status:** Needs-operator-input
+- **Why:** confirming the modal's default cursor position needs a real capture.
+- **Revisit when:** the operator captures the modal.
+- **Refs:** #1054
+
+### Operator Mode (active / away / sleep / dnd + delegation)
+- **Status:** Needs-operator-input
+- **Why:** needs an operator-policy freeze and a phased breakdown before
+  implementation can start.
+- **Revisit when:** the operator freezes the policy and the work is phased.
+- **Refs:** #1339
+
+## Stale — no current owner
+
+### Schedule fire-strategy
+- **Status:** Stale
+- **Why:** no current owner; the strategy is undecided.
+- **Refs:** #1521


### PR DESCRIPTION
## What & why
External reports keep re-raising already-known or already-decided topics. This adds one page listing issues that are **knowingly deferred** — with the reason and the condition to revisit — and points contributors at it (operator policy + decision d-20260531094016998074-1).

## Changes (docs only — no code)
- **`docs/KNOWN_ISSUES.md`** (new): a living list, each entry = status / why / revisit-when / refs, grouped into:
  - **Upstream / external** — `agy` backend unsupported (#1547/#1262/#987); `agy` ignores hidden parent-dir workspace (#998); `opencode --continue` dummy-session (#1526, mitigated by #1519).
  - **Deferred / needs-operator-input** — PTY corpus (#1014); Claude "Yes, proceed" cursor (#1054); Operator Mode (#1339).
  - **Stale** — Schedule fire-strategy (#1521).
- **`README.md` + `README.zh-TW.md`**: Antigravity CLI (`agy`) status **`Tested` → `Unsupported`**; the note now states the broader stance (known issues with `agy` aren't addressed for now; not revisited until project-scoped MCP #1262 or a first-party CLI tool lands). Both link `docs/KNOWN_ISSUES.md` from the docs index.

## Deferred (to avoid conflict)
The `.github/ISSUE_TEMPLATE` "Prior art check" pointer to `KNOWN_ISSUES.md` is **not** in this PR — it would conflict with the in-flight **#1548** (which introduces that section). It'll be added as a follow-up (or rebase) after #1548 merges.

## Notes for reviewers
- Neutral, contributor-facing wording; no internal jargon.
- Excluded from the list (active backlog, intentionally): #1077 / #1513 / #1533 / #1463 / #1523 / #1546.
- Pure docs; zero overlap with the in-flight `agend-git.rs` (#1463) / `patterns.rs` (#1546) work.

## Links
#1547 · #1262 · #987 · #998 · #1526 · #1014 · #1054 · #1339 · #1521 · (coordinates with #1548)

🤖 Generated with [Claude Code](https://claude.com/claude-code)