### PR TITLE
docs(.github): point the prior-art check at docs/KNOWN_ISSUES.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,7 @@ labels: ['bug']
 already-resolved topic without new evidence, may be closed without further
 review. A quick search saves everyone time. -->
 
+- [ ] I checked [docs/KNOWN_ISSUES.md](https://github.com/suzuke/agend-terminal/blob/main/docs/KNOWN_ISSUES.md) — this isn't an item already listed there as intentionally deferred.
 - [ ] I searched **open and closed** issues for prior reports or prior
       conclusions on this, and linked any I found below.
 - [ ] This is not a re-report of an already-resolved issue — or, if it

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,6 +11,7 @@ labels: ['enhancement']
 already-decided approach without new evidence, may be closed without further
 review. A quick search saves everyone time. -->
 
+- [ ] I checked [docs/KNOWN_ISSUES.md](https://github.com/suzuke/agend-terminal/blob/main/docs/KNOWN_ISSUES.md) — this isn't an item already listed there as intentionally deferred.
 - [ ] I searched **open and closed** issues for prior requests or prior
       decisions on this, and linked any I found below.
 - [ ] This is not a re-request of an already-decided topic — or, if it

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ Link the issue it closes, e.g. `Closes #123`. -->
 
 ## Prior art check (required)
 
+- [ ] I checked [docs/KNOWN_ISSUES.md](https://github.com/suzuke/agend-terminal/blob/main/docs/KNOWN_ISSUES.md) — this isn't an item listed there as intentionally deferred.
 - [ ] I compared this change against the **current `main`** branch and
       confirmed it isn't already implemented.
 - [ ] I searched **closed** issues and PRs for prior attempts or decisions in


### PR DESCRIPTION
## What & why
Follow-up to **#1548** (issue/PR prior-art-check templates) + **#1549** (`docs/KNOWN_ISSUES.md`), now both on `main`. Closes part 4 of the KNOWN_ISSUES task — wires the two together so contributors confirm their report isn't already listed as intentionally deferred.

## Changes (docs only, purely additive — one line each)
- `ISSUE_TEMPLATE/bug_report.md` + `feature_request.md`: add a Prior-art-check item linking `docs/KNOWN_ISSUES.md`.
- `PULL_REQUEST_TEMPLATE.md`: same, for re-implementations of deferred items.

Absolute GitHub link so it resolves in the new-issue / new-PR form. No dead link (the target is on `main` as of #1549).

## Links
#1548 · #1549 · #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)