### PR TITLE
fix(#1513): busy-gate daemon notification inject (PR-1: compose_aware_inject)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1138,24 +1138,125 @@ where
                 notification_queue::pending_count(home, &pane.agent_name);
         }
         notification_queue::DraftState::None => {
-            let queued = notification_queue::drain(home, &pane.agent_name);
+            let mut queued = notification_queue::drain(home, &pane.agent_name);
             if queued.is_empty() {
                 pane.pending_notification_count = 0;
                 return;
             }
-            let mut failed_at = None;
-            for (idx, notification) in queued.iter().enumerate() {
-                if injector(&notification.text).is_err() {
-                    failed_at = Some(idx);
-                    break;
+            // #1513: actionable wakes drain FIRST, then ambient (stable by ts).
+            queued.sort_by(|a, b| {
+                b.actionable
+                    .cmp(&a.actionable)
+                    .then_with(|| a.timestamp.cmp(&b.timestamp))
+            });
+            // #1513: if the agent is mid-generation (Thinking/ToolUse), injecting
+            // now would corrupt the PTY stream — HOLD non-expired items and only
+            // release those past their MAX_DEFER cap (anti-starvation). The state
+            // read is lock-free from the snapshot (inject path must not take the
+            // core lock — #1492). Once any inject fails, preserve the remaining
+            // order by holding the rest.
+            let agent_busy = crate::snapshot::agent_is_busy(home, &pane.agent_name);
+            let now_ms = chrono::Utc::now().timestamp_millis();
+            let mut keep: Vec<notification_queue::QueuedNotification> = Vec::new();
+            let mut inject_failed = false;
+            for notification in queued {
+                if inject_failed || !flush_release(&notification, agent_busy, now_ms) {
+                    keep.push(notification);
+                } else if injector(&notification.text).is_err() {
+                    inject_failed = true;
+                    keep.push(notification);
                 }
             }
-            if let Some(idx) = failed_at {
-                notification_queue::requeue_all(home, &pane.agent_name, &queued[idx..]);
+            if !keep.is_empty() {
+                notification_queue::requeue_all(home, &pane.agent_name, &keep);
             }
             pane.pending_notification_count =
                 notification_queue::pending_count(home, &pane.agent_name);
         }
+    }
+}
+
+/// #1513: MAX_DEFER anti-starvation caps — once an item has been deferred this
+/// long it is released even while the agent is still busy. Actionable wakes get
+/// a tight cap (work delivery must land fast); ambient can wait longer.
+const ACTIONABLE_MAX_DEFER_MS: i64 = 1_000;
+const AMBIENT_MAX_DEFER_MS: i64 = 7_000;
+
+/// #1513: should this queued item be RELEASED (injected) now vs HELD? Released
+/// when the agent is not mid-generation, OR the item is past its MAX_DEFER cap
+/// (anti-starvation backstop so a perpetually-busy agent never traps the queue).
+/// Pure so the busy-hold / cap-release matrix is unit-testable.
+fn flush_release(
+    item: &notification_queue::QueuedNotification,
+    agent_busy: bool,
+    now_ms: i64,
+) -> bool {
+    if !agent_busy {
+        return true;
+    }
+    let cap = if item.actionable {
+        ACTIONABLE_MAX_DEFER_MS
+    } else {
+        AMBIENT_MAX_DEFER_MS
+    };
+    now_ms.saturating_sub(item.deferred_since_ms) >= cap
+}
+
+#[cfg(test)]
+mod flush_release_tests_1513 {
+    use super::{flush_release, ACTIONABLE_MAX_DEFER_MS};
+    use crate::notification_queue::QueuedNotification;
+
+    fn item(actionable: bool, deferred_since_ms: i64) -> QueuedNotification {
+        QueuedNotification {
+            text: "x".into(),
+            timestamp: String::new(),
+            actionable,
+            deferred_since_ms,
+        }
+    }
+
+    #[test]
+    fn not_busy_always_releases() {
+        let now = 10_000;
+        assert!(
+            flush_release(&item(true, now), false, now),
+            "idle agent releases actionable"
+        );
+        assert!(
+            flush_release(&item(false, now), false, now),
+            "idle agent releases ambient"
+        );
+    }
+
+    #[test]
+    fn busy_holds_then_cap_releases() {
+        let base = 100_000;
+        // fresh defer while busy → held
+        assert!(
+            !flush_release(&item(true, base), true, base),
+            "busy holds fresh actionable"
+        );
+        assert!(
+            !flush_release(&item(false, base), true, base),
+            "busy holds fresh ambient"
+        );
+        // past the actionable cap (1s) but within ambient cap (7s) → actionable releases, ambient holds
+        let mid = base + ACTIONABLE_MAX_DEFER_MS + 1;
+        assert!(
+            flush_release(&item(true, base), true, mid),
+            "actionable releases past its 1s cap even while busy"
+        );
+        assert!(
+            !flush_release(&item(false, base), true, mid),
+            "ambient still held at ~1s while busy"
+        );
+        // well past ambient cap → ambient releases too
+        let late = base + 8_000;
+        assert!(
+            flush_release(&item(false, base), true, late),
+            "ambient releases past its cap while busy"
+        );
     }
 }
 

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -298,6 +298,13 @@ pub fn notify_agent_with_attachments(
 /// unsent draft, otherwise injects **with** submit_key so idle agents wake up.
 /// Actionable work-delivery (`notification_is_actionable_wake`, #1473) bypasses
 /// the gate and always injects.
+/// #1513: operator-typing quiet window — an actionable wake injected within this
+/// many ms of the operator's last keystroke would collide with their input, so
+/// it is deferred and drained once the pane settles. Short by design (NOT the
+/// #1457 full draft hold) so a reviewer's ci-ready never waits behind a long
+/// operator draft (preserves #1473).
+const TYPING_QUIET_WINDOW_MS: i64 = 1_500;
+
 pub fn compose_aware_inject(home: &Path, agent_name: &str, notification: &str) {
     // #911 dedup gate
     if should_suppress_911_reinject_with_ledger(
@@ -308,19 +315,77 @@ pub fn compose_aware_inject(home: &Path, agent_name: &str, notification: &str) {
     ) {
         return;
     }
-    // #1473: actionable work-delivery (ci-ready / task dispatch / query) MUST
-    // wake the agent's PTY regardless of draft state. The #1457 draft-gate only
-    // exists to stop low-priority notifications from clobbering an operator's
-    // in-progress draft — it must never defer the work the agent is here to do.
-    // (Regression: a never-submitted agent pane read as Abandoned, so ci-ready
-    // for a codex reviewer was deferred to inbox-only and it never woke.)
-    if notification_is_actionable_wake(notification) {
+    let actionable = notification_is_actionable_wake(notification);
+    // #1513: busy-gate BEFORE the actionable split so every path is covered.
+    // agent_state is read LOCK-FREE from the per-tick snapshot — the inject path
+    // must NEVER take the per-agent core lock (#1492 self-IPC-under-lock deadlock
+    // class). ≤1-tick staleness is acceptable (busy states persist > a tick); the
+    // time-critical "operator typing" signal uses the live keystroke metadata.
+    if should_defer_inject(
+        home,
+        agent_name,
+        crate::snapshot::agent_state_of(home, agent_name).as_deref(),
+        actionable,
+    ) {
+        let _ = crate::notification_queue::enqueue_classified(
+            home,
+            agent_name,
+            notification,
+            actionable,
+        );
+        return;
+    }
+    // #1473: actionable work-delivery (ci-ready / task dispatch / query) wakes
+    // the PTY regardless of an operator DRAFT — only the busy/typing gate above
+    // defers it. Ambient stays behind the #1457 draft gate in route_notification.
+    if actionable {
         let _ = inject_with_submit(home, agent_name, notification);
         return;
     }
     let _ = route_notification(home, agent_name, notification, |msg| {
         inject_with_submit(home, agent_name, msg)
     });
+}
+
+/// #1513: should this notification be DEFERRED (enqueued) rather than injected
+/// now? Pure decision over the lock-free snapshot state + live keystroke recency.
+pub(crate) fn should_defer_inject(
+    home: &Path,
+    agent_name: &str,
+    agent_state: Option<&str>,
+    actionable: bool,
+) -> bool {
+    // An actionable wake must reach an agent STUCK waiting for input — a
+    // permission / awaiting-operator pane is exactly where new work delivery
+    // should land, never be held.
+    if actionable && matches!(agent_state, Some("permission") | Some("awaiting_operator")) {
+        return false;
+    }
+    // Agent actively generating → injecting now corrupts the PTY stream
+    // (mid-token). Applies to BOTH classes.
+    if matches!(agent_state, Some("thinking") | Some("tool_use")) {
+        return true;
+    }
+    if actionable {
+        // Short keystroke-collision window only (NOT the #1457 full draft hold).
+        operator_typing_recent(home, agent_name)
+    } else {
+        // Ambient: the #1457 full draft gate is applied downstream by
+        // route_notification — don't double-gate here.
+        false
+    }
+}
+
+/// #1513: did the operator type into this pane within the quiet window? Uses the
+/// LIVE keyboard-written `last_input_epoch_ms` (notification_queue metadata) —
+/// NOT `heartbeat_pair.last_input_at_ms` (which is the daemon-INJECT timestamp).
+fn operator_typing_recent(home: &Path, agent_name: &str) -> bool {
+    let (typed_ms, _) = crate::notification_queue::read_input_submit_timestamps(home, agent_name);
+    typed_ms != 0
+        && chrono::Utc::now()
+            .timestamp_millis()
+            .saturating_sub(typed_ms)
+            < TYPING_QUIET_WINDOW_MS
 }
 
 /// #1473/#1483: does this notification carry an actionable work-delivery
@@ -697,6 +762,149 @@ mod operator_tz_tests {
         assert!(
             header.contains("now="),
             "#1509: notify_agent pointer header must carry now= (was the gap): {header}"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod should_defer_inject_tests_1513 {
+    use super::should_defer_inject;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static CTR: AtomicU32 = AtomicU32::new(0);
+    fn tmp_home(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "agend-1513-{}-{}-{}",
+            tag,
+            std::process::id(),
+            CTR.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    // Agent mid-generation → defer BOTH classes (injecting corrupts the PTY).
+    #[test]
+    fn busy_defers_both_classes() {
+        let h = tmp_home("busy");
+        for st in ["thinking", "tool_use"] {
+            assert!(
+                should_defer_inject(&h, "a", Some(st), true),
+                "actionable defers when {st}"
+            );
+            assert!(
+                should_defer_inject(&h, "a", Some(st), false),
+                "ambient defers when {st}"
+            );
+        }
+    }
+
+    // Actionable wake must reach an agent STUCK waiting → bypass defer.
+    #[test]
+    fn actionable_bypasses_in_permission_and_awaiting() {
+        let h = tmp_home("perm");
+        for st in ["permission", "awaiting_operator"] {
+            assert!(
+                !should_defer_inject(&h, "a", Some(st), true),
+                "actionable bypasses {st}"
+            );
+        }
+    }
+
+    // No typing + idle (or unknown/stale snapshot) → inject (no false defer).
+    #[test]
+    fn idle_and_stale_snapshot_do_not_defer() {
+        let h = tmp_home("idle");
+        assert!(
+            !should_defer_inject(&h, "a", Some("idle"), true),
+            "idle actionable injects"
+        );
+        assert!(
+            !should_defer_inject(&h, "a", Some("ready"), false),
+            "ready ambient injects"
+        );
+        // stale/missing snapshot → state None → fail-open (no defer)
+        assert!(
+            !should_defer_inject(&h, "a", None, true),
+            "missing snapshot does not defer actionable"
+        );
+        assert!(
+            !should_defer_inject(&h, "a", None, false),
+            "missing snapshot does not defer ambient"
+        );
+    }
+
+    // Ambient is NEVER deferred by this gate when idle — the #1457 full draft
+    // gate downstream (route_notification) owns operator-draft deferral (#1473).
+    #[test]
+    fn ambient_idle_falls_through_to_1457() {
+        let h = tmp_home("amb");
+        crate::notification_queue::record_input_activity(&h, "a"); // operator just typed
+                                                                   // ambient + idle + recent typing → still NOT deferred here (route_notification handles it)
+        assert!(
+            !should_defer_inject(&h, "a", Some("idle"), false),
+            "ambient defers via #1457 downstream, not here"
+        );
+    }
+
+    // Actionable + recent operator keystroke → defer (short anti-collision window).
+    #[test]
+    fn actionable_defers_on_recent_typing() {
+        let h = tmp_home("typing");
+        crate::notification_queue::record_input_activity(&h, "a"); // now
+        assert!(
+            should_defer_inject(&h, "a", Some("idle"), true),
+            "recent typing defers actionable"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod snapshot_busy_tests_1513 {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static CTR: AtomicU32 = AtomicU32::new(0);
+    fn tmp_home(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "agend-1513snap-{}-{}-{}",
+            tag,
+            std::process::id(),
+            CTR.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn snap(name: &str, state: &str) -> crate::snapshot::AgentSnapshot {
+        crate::snapshot::AgentSnapshot {
+            name: name.to_string(),
+            backend_command: String::new(),
+            args: vec![],
+            working_dir: None,
+            submit_key: "\r".to_string(),
+            health_state: "healthy".to_string(),
+            agent_state: state.to_string(),
+        }
+    }
+
+    #[test]
+    fn agent_is_busy_reads_snapshot_state() {
+        let h = tmp_home("busy");
+        crate::snapshot::save(&h, &[snap("a", "thinking"), snap("b", "idle")]);
+        assert!(crate::snapshot::agent_is_busy(&h, "a"), "thinking → busy");
+        assert!(!crate::snapshot::agent_is_busy(&h, "b"), "idle → not busy");
+        // missing agent / missing snapshot → fail-open (not busy)
+        assert!(
+            !crate::snapshot::agent_is_busy(&h, "ghost"),
+            "unknown agent → not busy"
+        );
+        assert!(
+            !crate::snapshot::agent_is_busy(&tmp_home("empty"), "a"),
+            "no snapshot → not busy"
         );
     }
 }

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -110,6 +110,23 @@ fn mark_composing(home: &Path, agent: &str) {
     .ok();
 }
 
+/// #1513: a PAUSED operator draft — keystroke entered but idle past the
+/// fresh-keystroke anti-collision window (here ~3s ago, still well within the
+/// #1457 5-min draft hold). Used to test that an actionable wake bypasses the
+/// DRAFT HOLD (the #1473 contract) without colliding with the new #1513
+/// fresh-keystroke yield (covered separately in `should_defer_inject_tests_1513`).
+fn mark_composing_stale(home: &Path, agent: &str) {
+    std::fs::create_dir_all(home.join("metadata")).ok();
+    std::fs::write(
+        home.join("metadata").join(format!("{agent}.json")),
+        format!(
+            "{{\"last_input_epoch_ms\":{}}}",
+            chrono::Utc::now().timestamp_millis() - 3_000
+        ),
+    )
+    .ok();
+}
+
 #[test]
 fn enqueue_drain_roundtrip() {
     let home = tmp_home("roundtrip");
@@ -2296,8 +2313,12 @@ fn t12_pty_state_kind_matrix() {
         );
 
         // Composing path — hint deferred into notification_queue.
+        // #1513: use a PAUSED draft (>1.5s since last keystroke) so this tests
+        // the #1473 draft-HOLD bypass, not the new fresh-keystroke anti-collision
+        // yield (which would defer actionable too — covered in
+        // should_defer_inject_tests_1513::actionable_defers_on_recent_typing).
         let composing_home = tmp_home(&format!("982-t12-{kind}"));
-        mark_composing(&composing_home, "agent1");
+        mark_composing_stale(&composing_home, "agent1");
         let mut msg = make_msg("system:t12", "composing");
         msg.kind = Some(kind.to_string());
         let before = crate::notification_queue::pending_count(&composing_home, "agent1");

--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -23,6 +23,16 @@ const SUBMIT_METADATA_KEY: &str = "last_submit_epoch_ms";
 pub struct QueuedNotification {
     pub text: String,
     pub timestamp: String,
+    /// #1513: actionable work-delivery wake (ci-ready / task / query) vs ambient.
+    /// Actionable items drain FIRST and carry a tighter MAX_DEFER cap. `serde
+    /// default` keeps pre-#1513 queue lines (no field) deserializing as ambient.
+    #[serde(default)]
+    pub actionable: bool,
+    /// #1513: epoch-ms when this item was FIRST deferred. Drives the MAX_DEFER
+    /// anti-starvation cap (release after the cap even if the agent stays busy).
+    /// Preserved across requeue so the cap counts from the original defer.
+    #[serde(default)]
+    pub deferred_since_ms: i64,
 }
 
 fn queue_path(home: &Path, agent_name: &str) -> PathBuf {
@@ -153,16 +163,37 @@ pub fn drain_one(home: &Path, agent_name: &str) -> Option<QueuedNotification> {
 }
 
 pub fn enqueue(home: &Path, agent_name: &str, text: &str) -> anyhow::Result<()> {
+    enqueue_classified(home, agent_name, text, false)
+}
+
+/// #1513: enqueue a notification tagged actionable/ambient. `deferred_since_ms`
+/// is stamped now (first defer). Actionable items drain first and carry a
+/// tighter MAX_DEFER cap; ambient retains the legacy contract.
+pub fn enqueue_classified(
+    home: &Path,
+    agent_name: &str,
+    text: &str,
+    actionable: bool,
+) -> anyhow::Result<()> {
+    let msg = QueuedNotification {
+        text: text.to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        actionable,
+        deferred_since_ms: chrono::Utc::now().timestamp_millis(),
+    };
+    append_queued(home, agent_name, &msg)
+}
+
+/// #1513: append a fully-formed `QueuedNotification` verbatim, preserving its
+/// `actionable` + `deferred_since_ms` (used by `requeue_all` so the MAX_DEFER
+/// cap counts from the ORIGINAL defer, not the requeue).
+fn append_queued(home: &Path, agent_name: &str, msg: &QueuedNotification) -> anyhow::Result<()> {
     let path = queue_path(home, agent_name);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let msg = QueuedNotification {
-        text: text.to_string(),
-        timestamp: chrono::Utc::now().to_rfc3339(),
-    };
     let mut file = OpenOptions::new().create(true).append(true).open(path)?;
-    writeln!(file, "{}", serde_json::to_string(&msg)?)?;
+    writeln!(file, "{}", serde_json::to_string(msg)?)?;
     Ok(())
 }
 
@@ -197,7 +228,9 @@ pub fn drain(home: &Path, agent_name: &str) -> Vec<QueuedNotification> {
 
 pub fn requeue_all(home: &Path, agent_name: &str, notifications: &[QueuedNotification]) {
     for notification in notifications {
-        let _ = enqueue(home, agent_name, &notification.text);
+        // #1513: preserve actionable + deferred_since_ms verbatim so the
+        // MAX_DEFER cap keeps counting from the original defer.
+        let _ = append_queued(home, agent_name, notification);
     }
 }
 
@@ -226,6 +259,38 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    #[test]
+    fn enqueue_classified_round_trips_actionable_and_deferred_since_1513() {
+        let home = tmp_home("classified");
+        enqueue_classified(&home, "a", "work", true).expect("enqueue actionable");
+        enqueue(&home, "a", "ambient").expect("enqueue ambient"); // actionable=false default
+        let drained = drain(&home, "a");
+        assert_eq!(drained.len(), 2);
+        let actionable = drained
+            .iter()
+            .find(|q| q.text == "work")
+            .expect("find actionable");
+        assert!(
+            actionable.actionable,
+            "actionable flag preserved across serde"
+        );
+        assert!(actionable.deferred_since_ms > 0, "deferred_since stamped");
+        let ambient = drained
+            .iter()
+            .find(|q| q.text == "ambient")
+            .expect("find ambient");
+        assert!(!ambient.actionable, "ambient default false");
+        // requeue preserves the original deferred_since (cap counts from first defer)
+        let since = actionable.deferred_since_ms;
+        requeue_all(&home, "a", std::slice::from_ref(actionable));
+        let again = drain(&home, "a");
+        assert_eq!(
+            again[0].deferred_since_ms, since,
+            "requeue preserves deferred_since"
+        );
+        std::fs::remove_dir_all(home).ok();
     }
 
     #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -38,6 +38,27 @@ pub fn load(home: &Path) -> Option<FleetSnapshot> {
         .and_then(|c| serde_json::from_str(&c).ok())
 }
 
+/// #1513: an agent's current state string from the latest per-tick snapshot.
+/// LOCK-FREE (file read) — safe on the inject path, which must NEVER take the
+/// per-agent core lock (#1492 self-IPC-under-lock deadlock class).
+pub fn agent_state_of(home: &Path, agent_name: &str) -> Option<String> {
+    load(home)?
+        .agents
+        .into_iter()
+        .find(|a| a.name == agent_name)
+        .map(|a| a.agent_state)
+}
+
+/// #1513: is the agent mid-generation (Thinking/ToolUse) per the latest
+/// snapshot? Fail-OPEN (returns false on a missing snapshot/agent) so a stale or
+/// absent snapshot never starves the notification queue — the MAX_DEFER cap is
+/// the backstop. Matches `AgentState::display_name` (`thinking` / `tool_use`).
+pub fn agent_is_busy(home: &Path, agent_name: &str) -> bool {
+    agent_state_of(home, agent_name)
+        .map(|s| matches!(s.as_str(), "thinking" | "tool_use"))
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Problem (#1513 / #1514)

A daemon notification injected while an agent is **mid-generation**
(Thinking/ToolUse) corrupts the PTY stream; one injected within the operator's
**keystroke window** collides with their input. The #1473 actionable-wake
bypass made it worse — ci-ready / task / query wakes called `inject_with_submit`
**directly**, skipping every defer (the #1514 root cause).

## PR-1 — gate the `compose_aware_inject` (daemon notification) path

`should_defer_inject` runs at the entry, **before** the actionable split, so all
paths are covered:

| condition | actionable | ambient |
|---|---|---|
| agent Thinking/ToolUse | defer | defer |
| operator typed < 1.5s ago | defer | (→ #1457) |
| PermissionPrompt / AwaitingOperator | **bypass** (deliver) | (→ #1457) |
| otherwise | inject | → route_notification (#1457) |

**Two signals, both correct (codex's corrections absorbed):**
- agent_state is read **lock-free** from the per-tick snapshot
  (`snapshot::agent_state_of`) — the inject path must **never** take the
  per-agent core lock (#1492 self-IPC-under-lock deadlock class). The telegram
  routing path the spec first cited actually locks registry+core.
- operator-typing recency uses the **live keyboard-written**
  `record_input_activity` metadata — **not** `heartbeat_pair.last_input_at_ms`,
  which is the daemon-*inject* timestamp.

**#1473 preserved, not reopened:** actionable wakes still bypass the #1457 full
draft **hold** — they only yield ~1.5s to a *fresh* keystroke, then drain within
a tight **1s** cap. Ambient stays behind #1457's draft gate in
`route_notification`.

**Drain side:** deferred items enqueue tagged `actionable` + `deferred_since_ms`
(serde-default → back-compat). The per-tick `flush_notifications_for_pane` gains
an agent-busy gate (lock-free `snapshot::agent_is_busy`, fail-open), drains
**actionable-first**, and releases via pure `flush_release` with **MAX_DEFER
anti-starvation caps** (actionable 1s / ambient 7s) so a perpetually-busy agent
never traps the queue.

## Tests

- `should_defer_inject_tests_1513` — busy→defer both classes; permission/
  awaiting bypass; idle + **stale/missing snapshot** → no false defer; ambient
  idle → falls through to #1457; actionable + fresh keystroke → defer.
- `snapshot_busy_tests_1513` — lock-free snapshot busy read (+ fail-open).
- `flush_release_tests_1513` — not-busy releases; busy holds fresh, releases
  past the per-class cap.
- queue round-trip — `actionable` + `deferred_since_ms` survive serde; requeue
  preserves the original defer time (cap counts from first defer).
- `t12_pty_state_kind_matrix` reconciled — uses a **paused** draft (>1.5s) to
  test the #1473 draft-hold bypass; the fresh-keystroke yield is its own test.

Full `cargo test --tests` green (59 binaries / 3228); clippy `--all-targets` +
fmt clean. All verification run with `AGEND_GIT_BYPASS=1`. Base: fresh
`origin/main` (384a946).

## Out of scope → PR-2 (follow-up)

`inject_to_agent` direct-path force-gate (cron/schedule replay; `AGEND_HOME`
self-contained + `force: bool` threaded through the 5 callers, supervisor
ServerRateLimit retry exempt). Independent, smaller, separately reviewable.

> Post-merge needs a rebuild + daemon restart (notification routing path).

Refs #1513, #1514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)