### PR TITLE
fix(#1513): busy-gate direct PTY inject (PR-2: inject_to_agent force-gate)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1203,7 +1203,7 @@ fn spawn_instructions_bootstrap(
 
         let reg = &registry.lock();
         if let Some(handle) = reg.get(&instance_id) {
-            if let Err(e) = inject_to_agent(handle, content.as_bytes()) {
+            if let Err(e) = inject_to_agent(handle, content.as_bytes(), true) {
                 tracing::warn!(agent = %name, error = %e, "instructions bootstrap inject failed");
             } else {
                 tracing::info!(
@@ -1730,11 +1730,38 @@ pub fn write_to_agent_typed(agent: &AgentHandle, data: &[u8]) -> crate::error::R
     Ok(())
 }
 
-/// Inject text + submit to agent PTY. Splits text from submit_key with a delay
-/// so TUI frameworks process them as separate events.
-/// - typed=false: write_all(prefix+text), delay, write_all(submit_key)
-/// - typed=true: per-byte(prefix+text), delay, write_all(submit_key)
-pub fn inject_to_agent(agent: &AgentHandle, text: &[u8]) -> crate::error::Result<()> {
+/// Inject `text` (plus the backend submit key) into an agent's PTY.
+///
+/// `force` exempts the inject from the #1513 busy-gate. Pass `true` for
+/// recovery, operator, and drain injects that MUST reach the PTY: the
+/// ServerRateLimit retry, bootstrap instructions, and the api INJECT handler
+/// (which is both the operator-inject entry AND the notification-queue drain
+/// convergence, so gating it would re-defer an already-flushed item). Pass
+/// `false` for daemon-originated direct injects (cron and schedule replay) that
+/// should yield to a mid-generation or mid-keystroke pane.
+pub fn inject_to_agent(agent: &AgentHandle, text: &[u8], force: bool) -> crate::error::Result<()> {
+    // #1513 PR-2: gate direct PTY injects like the notification path. Self-
+    // contained via AGEND_HOME (this fn has no `home` in scope); the agent-state
+    // read is LOCK-FREE (snapshot) — never the per-agent core lock (#1492). When
+    // AGEND_HOME is absent (non-daemon / unit test) the gate is skipped.
+    if !force {
+        if let Ok(home) = std::env::var("AGEND_HOME") {
+            let home = std::path::Path::new(&home);
+            if crate::inbox::notify::should_defer_direct_inject(home, agent.name.as_str()) {
+                // Gated direct injects (cron / replay) are UTF-8 text wakes;
+                // enqueue ambient-class for the per-tick flush to drain once the
+                // pane settles (the flush re-injects via the api INJECT path,
+                // landing back here with force=true — byte-equivalent delivery).
+                let _ = crate::notification_queue::enqueue_classified(
+                    home,
+                    agent.name.as_str(),
+                    &String::from_utf8_lossy(text),
+                    false,
+                );
+                return Ok(());
+            }
+        }
+    }
     let target = InjectTarget::from_handle(agent);
     inject_with_target(&target, text)
 }

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -23,7 +23,7 @@ pub(crate) fn handle_inject(params: &Value, ctx: &HandlerCtx) -> Value {
                 let result = if raw {
                     agent::write_to_agent(handle, data.as_bytes())
                 } else {
-                    agent::inject_to_agent(handle, data.as_bytes())
+                    agent::inject_to_agent(handle, data.as_bytes(), true)
                 };
                 match result {
                     Ok(()) => json!({"ok": true, "result": {"bytes": data.len()}}),

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -112,7 +112,7 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
             // in run_history, and let the auto-disable below retire it.
             "missed"
         } else if let Some(handle) = target_id.and_then(|id| reg.get(&id)) {
-            match agent::inject_to_agent(handle, message.as_bytes()) {
+            match agent::inject_to_agent(handle, message.as_bytes(), false) {
                 Ok(()) => "ok",
                 Err(e) => {
                     tracing::warn!(error = %e, "schedule inject failed");

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -948,7 +948,7 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
         let reg = agent::lock_registry(registry);
         // #1441: registry is UUID-keyed; resolve target name via fleet.yaml.
         if let Some(handle) = crate::fleet::resolve_uuid(home, target).and_then(|id| reg.get(&id)) {
-            if let Err(e) = agent::inject_to_agent(handle, message.as_bytes()) {
+            if let Err(e) = agent::inject_to_agent(handle, message.as_bytes(), false) {
                 tracing::warn!(error = %e, "replay inject failed");
             }
         } else {

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -826,7 +826,7 @@ pub(crate) fn process_server_rate_limit_retries(
             // #1441: registry is UUID-keyed; resolve the name-keyed track id.
             if let Some(handle) = crate::fleet::resolve_uuid(home, name).and_then(|id| reg.get(&id))
             {
-                agent::inject_to_agent(handle, CONTINUE_RETRY_PAYLOAD).is_ok()
+                agent::inject_to_agent(handle, CONTINUE_RETRY_PAYLOAD, true).is_ok()
             } else {
                 false
             }

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -388,6 +388,16 @@ fn operator_typing_recent(home: &Path, agent_name: &str) -> bool {
             < TYPING_QUIET_WINDOW_MS
 }
 
+/// #1513 PR-2: defer a DIRECT PTY inject (cron / schedule replay via
+/// `inject_to_agent`, force=false) when the agent is mid-generation
+/// (Thinking/ToolUse) or the operator is mid-keystroke — the same collision
+/// avoidance as the notification path, minus the actionable / permission-bypass
+/// nuances (a scheduled wake has no work-delivery urgency). Lock-free snapshot
+/// read (#1492-safe).
+pub(crate) fn should_defer_direct_inject(home: &Path, agent_name: &str) -> bool {
+    crate::snapshot::agent_is_busy(home, agent_name) || operator_typing_recent(home, agent_name)
+}
+
 /// #1473/#1483: does this notification carry an actionable work-delivery
 /// marker that must reach the PTY regardless of draft state? These are the
 /// system/orchestrator wakes the agent is expected to act on (vs. ambient
@@ -905,6 +915,82 @@ mod snapshot_busy_tests_1513 {
         assert!(
             !crate::snapshot::agent_is_busy(&tmp_home("empty"), "a"),
             "no snapshot → not busy"
+        );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod should_defer_direct_inject_tests_1513pr2 {
+    use super::should_defer_direct_inject;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static CTR: AtomicU32 = AtomicU32::new(0);
+    fn tmp_home(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "agend-1513pr2-{}-{}-{}",
+            tag,
+            std::process::id(),
+            CTR.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn snap(name: &str, state: &str) -> crate::snapshot::AgentSnapshot {
+        crate::snapshot::AgentSnapshot {
+            name: name.to_string(),
+            backend_command: String::new(),
+            args: vec![],
+            working_dir: None,
+            submit_key: "\r".to_string(),
+            health_state: "healthy".to_string(),
+            agent_state: state.to_string(),
+        }
+    }
+
+    // cron/replay direct inject while the agent is mid-generation → defer.
+    #[test]
+    fn busy_defers_direct_inject() {
+        let h = tmp_home("busy");
+        crate::snapshot::save(&h, &[snap("a", "thinking")]);
+        assert!(
+            should_defer_direct_inject(&h, "a"),
+            "thinking → defer direct inject"
+        );
+        crate::snapshot::save(&h, &[snap("a", "tool_use")]);
+        assert!(
+            should_defer_direct_inject(&h, "a"),
+            "tool_use → defer direct inject"
+        );
+    }
+
+    // operator mid-keystroke → defer (collision avoidance).
+    #[test]
+    fn typing_defers_direct_inject() {
+        let h = tmp_home("typing");
+        crate::snapshot::save(&h, &[snap("a", "idle")]);
+        crate::notification_queue::record_input_activity(&h, "a");
+        assert!(
+            should_defer_direct_inject(&h, "a"),
+            "recent keystroke → defer direct inject"
+        );
+    }
+
+    // quiet idle pane (and missing snapshot) → inject directly, no false defer.
+    #[test]
+    fn quiet_does_not_defer_direct_inject() {
+        let h = tmp_home("quiet");
+        crate::snapshot::save(&h, &[snap("a", "idle")]);
+        assert!(
+            !should_defer_direct_inject(&h, "a"),
+            "idle + no typing → inject"
+        );
+        // missing snapshot → fail-open (not busy, no typing) → inject
+        assert!(
+            !should_defer_direct_inject(&tmp_home("nosnap"), "a"),
+            "no snapshot → inject"
         );
     }
 }


### PR DESCRIPTION
## Context

PR-1 (#1554, merged) gated the daemon **notification** path
(`compose_aware_inject`). PR-2 extends the same busy-gate to the **direct PTY
inject** path (`inject_to_agent`) so a cron / schedule-replay inject delivered
while the agent is mid-generation (Thinking/ToolUse) or the operator is
mid-keystroke yields instead of corrupting the stream.

## Change

`inject_to_agent` gains `force: bool`. When `!force` and `AGEND_HOME` is set
(daemon context), it consults `should_defer_direct_inject`:
- **agent-busy** — lock-free snapshot read (`snapshot::agent_is_busy`), never the
  per-agent core lock (#1492 deadlock class), OR
- **operator-typing-recent** — the live `record_input_activity` keystroke signal.

If deferred, it enqueues the (UTF-8 text) wake into the **same notification_queue
PR-1 added** (ambient-class). PR-1's per-tick flush drains it once the pane
settles — agent-busy gate + actionable-first + MAX_DEFER caps, all reused.

### `force` across the 5 callers

| caller | force | why |
|---|---|---|
| bootstrap instructions (`agent/mod`) | true | Ready-only spawn-time |
| ServerRateLimit retry (`supervisor`) | true | must wake on rate-limit |
| api INJECT handler | **true** | see below — load-bearing |
| `cron_tick` | false | gated daemon inject |
| schedule replay (`daemon/mod`) | false | gated daemon inject |

### Why the api INJECT handler must be `force=true` (the key mechanism)

The flush drains via
`inject_notification_with_submit → inject_with_submit → api::call(INJECT) →
inject_to_agent` — so the drain **converges back at `inject_to_agent`** through
the api INJECT path. Gating it would re-defer an already-flushed item **and would
break PR-1's existing notification drain**. So `force=true` there is required,
not a choice. Operator api-injects share that path and are correctly exempt too —
an explicit operator action is not the daemon-collision #1513 targets. Delivery
is byte-equivalent (gated text → enqueue → drain → api INJECT → inject_to_agent,
same bytes; the gated callers inject pure UTF-8 schedule/replay text, so the
`from_utf8_lossy` enqueue is identity).

## Tests

`should_defer_direct_inject` — busy→defer (thinking/tool_use), recent
keystroke→defer, quiet / missing-snapshot→inject (no false defer, fail-open).
Full `cargo test --tests` green (59 binaries / 3231); clippy `--all-targets` +
fmt clean. All verification with `AGEND_GIT_BYPASS=1`. Base: fresh `origin/main`
(6e7a6f5, includes PR-1).

> Merge alongside PR-1 (#1554) — both need one rebuild + daemon restart.

Refs #1513, #1514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)