### PR TITLE
fix(#1546): add trust-folder permission footer anchor (follow-up)

### DIFF
--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -137,13 +137,18 @@ impl StatePatterns {
                 // zero-FP). Same spirit as the #1541 verb-agnostic structural
                 // anchor; full-screen scan is safe (no bottom-N) because the
                 // footer is self-identifying. Replay-validated against
-                // claude-perm.raw (edit) + claude-mcp-perm.raw (mcp). The
-                // trust-folder prompt is a documented low-risk gap (rare; operator
-                // already globally-trusted, no fixture) — widen the anchor if a
-                // future capture shows a different footer. Claude-only.
+                // claude-perm.raw (edit) + claude-mcp-perm.raw (mcp).
+                //
+                // #1546 trust follow-up: the trust-folder ("Quick safety check: Is
+                // this a project you … trust?") dialog uses a DIFFERENT footer —
+                // `Enter to confirm · Esc to cancel` (not `… Tab to amend`) — so it
+                // needs its own chrome alternation, also zero-FP. Operator capture
+                // (claude-trust-prompt.raw) confirmed the wording. Each permission
+                // TYPE carries a self-identifying footer; the anchor is the union.
+                // Claude-only.
                 (
                     AgentState::PermissionPrompt,
-                    r"Esc to cancel · Tab to amend|allow all edits during this session",
+                    r"Esc to cancel · Tab to amend|allow all edits during this session|Enter to confirm · Esc to cancel",
                 ),
                 // Phase A Piece-1: git rebase/merge/cherry-pick conflict
                 // output is identical regardless of which CLI invoked git,

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3296,6 +3296,19 @@ fn claude_permission_footer_anchor_1546() {
         Some(AgentState::PermissionPrompt),
         "allow-all-edits phrase must fire PermissionPrompt"
     );
+    // #1546 trust follow-up: the trust-folder dialog uses a DIFFERENT footer
+    // (`Enter to confirm · Esc to cancel`) — its own chrome anchor.
+    assert_eq!(
+        p.detect("Enter to confirm · Esc to cancel"),
+        Some(AgentState::PermissionPrompt),
+        "trust-folder footer must fire PermissionPrompt"
+    );
+    // FP-safe: a partial fragment that is NOT the full footer chrome must not fire.
+    assert_ne!(
+        p.detect("Press Enter to confirm your email address"),
+        Some(AgentState::PermissionPrompt),
+        "#1546: bare 'Enter to confirm' prose must NOT false-fire PermissionPrompt"
+    );
     // FP-fixed: the cut bare strings must NOT fire on prose / pasted content
     // (this is the member-state + dispatch-idle bleed #1546 stops).
     for prose in [

--- a/tests/fixtures/state-replay/MANIFEST.yaml
+++ b/tests/fixtures/state-replay/MANIFEST.yaml
@@ -194,6 +194,22 @@ fixtures:
     capture_kind: real_pty
     provenance: "#1546 operator capture"
 
+  - file: claude-trust-prompt.raw
+    backend: claude-code
+    cli_version: "2.1.98"
+    recorded_on: "2026-05-31"
+    scenario: "trust-folder dialog ('Quick safety check: Is this a project you trust?' -> 'Yes, I trust this folder' / 'No, exit', not answered)"
+    # #1546 trust follow-up: the trust dialog's footer is `Enter to confirm · Esc
+    # to cancel` (NOT the tool-perm `… Tab to amend`), so it needs its own chrome
+    # alternation. This short fixture goes straight starting -> permission (the
+    # dialog is the first thing rendered). final_detect stays permission (the
+    # dialog is still on the final frame). Proves the trust footer anchor fires.
+    expected_transitions: [starting, permission]
+    expected_final_state: permission
+    expected_final_detect: permission
+    capture_kind: real_pty
+    provenance: "#1546 trust operator capture"
+
   - file: codex-perm.raw
     backend: codex
     cli_version: "0.120.0"

--- a/tests/fixtures/state-replay/claude-trust-prompt.raw
+++ b/tests/fixtures/state-replay/claude-trust-prompt.raw
@@ -1,0 +1,18 @@
+7[r8[?25h[?25l[?2004h[?1004h[?2031h[<u[>1u[>4;2m[?2026h
+[38;2;255;193;7m──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[39m
+[2G[38;2;255;193;7m[1mAccessing[12Gworkspace:[22m[39m
+
+[2G[1m/Users/suzuke/trusttest-1780232367[22m
+
+[2GQuick[8Gsafety[15Gcheck:[22GIs[25Gthis[30Ga[32Gproject[40Gyou[44Gcreated[52Gor[55Gone[59Gyou[63Gtrust?[70G(Like[76Gyour[81Gown[85Gcode,[91Ga[93Gwell-known[104Gopen[109Gsource[116Gproject,[125Gor[128Gwork[133Gfrom[138Gyour[143Gteam).[150GIf[153Gnot,[158Gtake[163Ga[165Gmoment[172Gto[175Greview[182Gwhat's[189Gin[192Gthis
+[2Gfolder[9Gfirst.
+
+[2GClaude[9GCode'll[17Gbe[20Gable[25Gto[28Gread,[34Gedit,[40Gand[44Gexecute[52Gfiles[58Ghere.
+
+[2G]8;id=zaxmda;https://code.claude.com/docs/en/security[38;2;153;153;153mSecurity guide[39m]8;;
+
+[2G[38;2;177;185;249m❯[4G[38;2;153;153;153m1.[7G[38;2;177;185;249mYes,[12GI[14Gtrust[20Gthis[25Gfolder[39m
+[4G[38;2;153;153;153m2.[7G[39mNo,[11Gexit
+
+[2G[38;2;153;153;153mEnter[8Gto[11Gconfirm[19G·[21GEsc[25Gto[28Gcancel[39m
+[1C[4A[?2026l[>0q[c[?2026$p[c(B[<u[>1u[>4;2m(B[<u[>1u[>4;2m(B[<u[>1u[>4;2m


### PR DESCRIPTION
## Follow-up to #1558

The #1546 main fix keyed PermissionPrompt on the tool-permission chrome footer
`Esc to cancel · Tab to amend`. Operator capture of the **trust-folder** dialog
shows it uses a **different** footer:

```
Quick safety check: Is this a project you created or one you trust?
❯ 1. Yes, I trust this folder
  2. No, exit
Enter to confirm · Esc to cancel
```

So the prior anchor missed the trust prompt (the gap #1558 documented). This adds
`Enter to confirm · Esc to cancel` as its own zero-FP chrome alternation — each
permission type carries a self-identifying footer, and the anchor is now their
union (tool / edit / trust). Claude-only.

## Validation

- Added fixture `claude-trust-prompt.raw` (operator capture, 1783 bytes). Replay:
  `starting → permission` via the trust footer.
- `claude-perm.raw` (edit) + `claude-mcp-perm.raw` (mcp) still detect — **no
  regression**.
- `claude_permission_footer_anchor_1546` extended: trust footer fires; a partial
  fragment ("Press Enter to confirm your email…") does **not** false-fire.
- MANIFEST: `claude-trust-prompt.raw` entry (`[starting, permission]`, final
  `permission`, `#1546 trust operator capture`).

Full `cargo test --tests` green (59 binaries / 3243); clippy `--all-targets` + fmt
clean. Base: fresh `origin/main` (76a388e). Closes the #1546 trust gap.

> Merge with #1521 + #1558 → rebuild.

Refs #1546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)