### PR TITLE
fix(#1552): runtime AwaitingOperator detection (triad + escalation FP-gate)

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -25,6 +25,18 @@ const TICK: Duration = Duration::from_secs(10);
 const TAIL_LINES: usize = 40;
 /// Debounce cooldown for member-state-change notify (Sprint 43).
 const NOTIFY_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// #1552: minimum continuous time in a runtime prompt state before escalating
+/// to AwaitingOperator (stability gate — a transient streaming flicker of the
+/// permission chrome never holds this long).
+const AWAITING_STABILITY: Duration = Duration::from_secs(8);
+/// #1552: how many live bottom rows the permission chrome must render in for
+/// the escalation position gate. A scrollback footer (the meta-FP: a working
+/// agent whose pane merely echoes the chrome) scrolls above this and fails.
+const AWAITING_TAIL_LINES: usize = 12;
+/// #1552: suppress escalation when the operator typed into the pane within this
+/// window — they're actively dealing with the prompt, no buzz needed.
+const AWAITING_ENGAGEMENT_WINDOW_MS: i64 = 15_000;
 /// Maximum auto-retries for ServerRateLimit before giving up.
 const SERVER_RATE_LIMIT_MAX_RETRIES: u32 = 3;
 /// Backoff schedule for ServerRateLimit retries (seconds).
@@ -500,6 +512,50 @@ fn reaction_kinds(to: crate::state::AgentState, propagation_enabled: bool) -> Ve
     kinds
 }
 
+/// #1552: escalation FP-gate for runtime AwaitingOperator (dev-2 design,
+/// decision d-20260531141354559067-0). `check_awaiting_operator` is the
+/// *necessary* silence+state condition; this adds the *sufficient* guards so a
+/// permission-chrome false positive — a working agent whose pane merely echoes
+/// the footer chrome (e.g. in scrollback: state-detection is full-screen, so it
+/// fires `PermissionPrompt` on healthy agents working on detection code) — can't
+/// escalate into a false operator buzz + a sticky false blocked-state.
+///
+/// `Starting` keeps its original ungated path (a startup stall has no chrome to
+/// position-gate). The runtime prompt states require all three gates; the real
+/// dialog satisfies all three, the meta-FP fails ≥1. Pure (file/now values are
+/// passed in) so it is unit-testable without a daemon.
+fn awaiting_escalation_allowed(
+    state: crate::state::AgentState,
+    state_held: Duration,
+    backend: Option<crate::backend::Backend>,
+    live_tail: &str,
+    operator_typed_ms: i64,
+    now_ms: i64,
+) -> bool {
+    use crate::state::AgentState;
+    match state {
+        // Original startup-stall fallback — no chrome, no position gate.
+        AgentState::Starting => true,
+        AgentState::PermissionPrompt | AgentState::InteractivePrompt => {
+            // (b) stability: the prompt state held continuously long enough.
+            state_held >= AWAITING_STABILITY
+                // (a) position (mandatory): the prompt chrome must re-detect in
+                // the LIVE bottom rows. A scrollback echo fails this — it's the
+                // only gate that catches a finished agent sitting on a footer.
+                && backend.is_some_and(|b| {
+                    matches!(
+                        crate::state::StatePatterns::for_backend(&b).detect(live_tail),
+                        Some(AgentState::PermissionPrompt | AgentState::InteractivePrompt)
+                    )
+                })
+                // (c) engagement: the operator isn't actively typing into it.
+                && !(operator_typed_ms > 0
+                    && now_ms.saturating_sub(operator_typed_ms) < AWAITING_ENGAGEMENT_WINDOW_MS)
+        }
+        _ => false,
+    }
+}
+
 /// One iteration of the supervisor loop. Public for tests.
 fn tick(
     home: &std::path::Path,
@@ -617,22 +673,61 @@ fn tick(
 
             let agent_state = core.state.current;
             let silent = core.state.last_output.elapsed();
-            if core.health.check_awaiting_operator(agent_state, silent) {
-                core.state.set_awaiting_operator();
-                tracing::info!(
-                    agent = %name,
-                    silent_secs = silent.as_secs(),
-                    prev_state = agent_state.display_name(),
-                    "awaiting operator (stalled on interactive prompt)"
+            if core.health.check_awaiting_operator(agent_state, silent) && {
+                // #1552 escalation FP-gates (only reached when silent>30s +
+                // a prompt state, so this registry lock + re-detect is rare,
+                // not per-tick). Lock-free w.r.t. self-IPC; registry-under-
+                // core mirrors the established ordering in this loop.
+                let backend = {
+                    let reg = crate::agent::lock_registry(registry);
+                    reg.get(&instance_id).map(|h| h.backend_command.clone())
+                }
+                .as_deref()
+                .and_then(crate::backend::Backend::from_command);
+                let (typed_ms, _submit_ms) =
+                    crate::notification_queue::read_input_submit_timestamps(home, &name);
+                awaiting_escalation_allowed(
+                    agent_state,
+                    core.state.since.elapsed(),
+                    backend,
+                    &core.vterm.tail_lines(AWAITING_TAIL_LINES),
+                    typed_ms,
+                    crate::daemon::heartbeat_pair::now_ms() as i64,
+                )
+            } {
+                // #1552 Half-1 #3: set the HEALTH reason — `check_hang` exempts
+                // on `current_reason`, not on the state, so setting the state
+                // alone would NOT stop the Hung→Stage-1-ESC path (which would
+                // dismiss the real prompt). The reason also doubles as the
+                // once-per-episode buzz dedup: if it's already AwaitingOperator
+                // we re-affirm state+reason (stay exempt) but don't re-notify,
+                // so the chrome (prio 8 > AwaitingOperator prio 2) flipping the
+                // state back each tick can't buzz the operator repeatedly.
+                let already_escalated = matches!(
+                    core.health.current_reason,
+                    Some(crate::health::BlockedReason::AwaitingOperator)
                 );
+                core.state.set_awaiting_operator();
+                core.health
+                    .set_blocked_reason(crate::health::BlockedReason::AwaitingOperator);
                 // Consume the recovery flag if somehow armed in the same tick,
                 // so the "ready again" ping doesn't fire right after we just
                 // re-entered a blocked state.
                 let _ = core.state.take_recovery_notice();
-                Some(NoticeAction::Stall {
-                    tail: core.vterm.tail_lines(TAIL_LINES),
-                    silent_secs: Some(silent.as_secs()),
-                })
+                if already_escalated {
+                    None
+                } else {
+                    tracing::info!(
+                        agent = %name,
+                        silent_secs = silent.as_secs(),
+                        prev_state = agent_state.display_name(),
+                        "awaiting operator (stalled on prompt) — escalating"
+                    );
+                    Some(NoticeAction::Stall {
+                        tail: core.vterm.tail_lines(TAIL_LINES),
+                        silent_secs: Some(silent.as_secs()),
+                    })
+                }
             } else if core.state.take_interactive_prompt_notice() {
                 // Pattern-based InteractivePrompt fires immediately on state
                 // entry (no silence window), so the notice also goes out on
@@ -650,6 +745,16 @@ fn tick(
                 // Symmetric "ready again" signal: armed on the transition
                 // out of InteractivePrompt / AwaitingOperator. Silent push so
                 // operators aren't vibrated twice per interactive cycle.
+                // #1552: clear the AwaitingOperator health reason on recovery so
+                // `check_hang` is no longer exempt and a future stall can
+                // re-notify (the once-per-episode dedup re-arms). Guarded so we
+                // never clear a different blocked reason (RateLimit / etc.).
+                if matches!(
+                    core.health.current_reason,
+                    Some(crate::health::BlockedReason::AwaitingOperator)
+                ) {
+                    core.health.clear_blocked_reason();
+                }
                 tracing::info!(
                     agent = %name,
                     "recovered from blocked state — notifying telegram"
@@ -1255,6 +1360,101 @@ mod tests {
             reaction_kinds(AgentState::Ready, true).is_empty(),
             "non-error state: no reaction"
         );
+    }
+
+    // ── #1552: runtime AwaitingOperator escalation FP-gates ──
+
+    /// ClaudeCode permission chrome footer — the self-identifying anchor #1546
+    /// installed; `StatePatterns` detects it as `PermissionPrompt`.
+    const PERM_CHROME: &str = "Do you want to proceed?\nEsc to cancel · Tab to amend";
+
+    #[test]
+    fn awaiting_gate_starting_is_ungated() {
+        // Legacy startup-stall path: fires regardless of chrome/position.
+        assert!(awaiting_escalation_allowed(
+            crate::state::AgentState::Starting,
+            Duration::from_secs(0),
+            None,
+            "no chrome here",
+            0,
+            0,
+        ));
+    }
+
+    #[test]
+    fn awaiting_gate_runtime_permission_all_gates_pass() {
+        assert!(awaiting_escalation_allowed(
+            crate::state::AgentState::PermissionPrompt,
+            AWAITING_STABILITY, // held long enough
+            Some(crate::backend::Backend::ClaudeCode),
+            PERM_CHROME, // chrome IS in the live tail
+            0,           // operator never typed
+            10_000,
+        ));
+    }
+
+    #[test]
+    fn awaiting_gate_blocks_scrollback_footer_fp() {
+        // The meta-FP: state is PermissionPrompt (full-screen detection saw the
+        // chrome), held + no typing — but the chrome is NOT in the live bottom
+        // tail (it scrolled up / is a working agent's echo). Position gate (a)
+        // must block escalation. This is the dev-2 live case.
+        assert!(!awaiting_escalation_allowed(
+            crate::state::AgentState::PermissionPrompt,
+            AWAITING_STABILITY,
+            Some(crate::backend::Backend::ClaudeCode),
+            "just normal working output, no dialog chrome at the bottom",
+            0,
+            10_000,
+        ));
+    }
+
+    #[test]
+    fn awaiting_gate_blocks_when_not_stable() {
+        // (b) stability: prompt state held < AWAITING_STABILITY → no escalate.
+        assert!(!awaiting_escalation_allowed(
+            crate::state::AgentState::PermissionPrompt,
+            Duration::from_secs(1),
+            Some(crate::backend::Backend::ClaudeCode),
+            PERM_CHROME,
+            0,
+            10_000,
+        ));
+    }
+
+    #[test]
+    fn awaiting_gate_blocks_when_operator_typing() {
+        // (c) engagement: operator typed 2s ago (< 15s window) → suppress.
+        let now = 100_000i64;
+        assert!(!awaiting_escalation_allowed(
+            crate::state::AgentState::PermissionPrompt,
+            AWAITING_STABILITY,
+            Some(crate::backend::Backend::ClaudeCode),
+            PERM_CHROME,
+            now - 2_000,
+            now,
+        ));
+    }
+
+    #[test]
+    fn awaiting_gate_non_prompt_state_never_escalates() {
+        for s in [
+            crate::state::AgentState::Ready,
+            crate::state::AgentState::Thinking,
+            crate::state::AgentState::ToolUse,
+        ] {
+            assert!(
+                !awaiting_escalation_allowed(
+                    s,
+                    AWAITING_STABILITY,
+                    Some(crate::backend::Backend::ClaudeCode),
+                    PERM_CHROME,
+                    0,
+                    10_000,
+                ),
+                "{s:?} must never escalate via this path"
+            );
+        }
     }
 
     /// NOTIFY_COOLDOWN constant is 60 seconds.

--- a/src/health.rs
+++ b/src/health.rs
@@ -413,13 +413,22 @@ impl HealthTracker {
     /// Check whether agent is stalled on an interactive startup prompt.
     /// Pure predicate — no state mutation.
     ///
-    /// Fires only when the agent is in `Starting` AND has been silent past
-    /// the threshold. Once the agent reaches `Ready` we trust the backend
-    /// and any further quiet period is handled by `check_hang` with a much
-    /// higher threshold — flagging short Ready silences produced false
-    /// positives for agents in the middle of legitimate tool execution.
+    /// Fires when the agent has been silent past the threshold AND is in a
+    /// state that legitimately awaits operator input: `Starting` (the original
+    /// startup-stall fallback) or, post-#1552, a runtime `PermissionPrompt` /
+    /// `InteractivePrompt` (a mid-task stall on an approval the operator must
+    /// answer). Other states (`Ready` mid-tool-use, etc.) are left to
+    /// `check_hang` — flagging short generic silences here produced FPs.
+    ///
+    /// This is the *necessary* condition only; the supervisor adds escalation
+    /// FP-gates (live-bottom-N position, state-stability, operator-engagement
+    /// cooldown) before it actually notifies — see `daemon::supervisor`.
     pub fn check_awaiting_operator(&self, agent_state: AgentState, silent: Duration) -> bool {
-        silent > AWAITING_OP_SILENCE && matches!(agent_state, AgentState::Starting)
+        silent > AWAITING_OP_SILENCE
+            && matches!(
+                agent_state,
+                AgentState::Starting | AgentState::PermissionPrompt | AgentState::InteractivePrompt
+            )
     }
 
     /// Check for hang based on agent state and output timeout.
@@ -874,18 +883,16 @@ mod tests {
 
     #[test]
     fn test_awaiting_operator_non_starting_exempt() {
-        // Only Starting triggers. Ready and all other states are exempt
-        // regardless of silence — Ready silence is handled by `check_hang`
-        // with much higher thresholds so legitimate pauses between tool
-        // bursts don't produce false positives.
+        // #1552: Starting + runtime prompt states (PermissionPrompt /
+        // InteractivePrompt) trigger; every OTHER state is exempt regardless of
+        // silence — generic Ready/tool silence is handled by `check_hang` with
+        // much higher thresholds so legitimate pauses don't produce FPs.
         let h = HealthTracker::new();
         for s in [
             AgentState::Ready,
             AgentState::Idle,
             AgentState::Thinking,
             AgentState::ToolUse,
-            AgentState::InteractivePrompt,
-            AgentState::PermissionPrompt,
             AgentState::Hang,
             AgentState::AwaitingOperator,
             AgentState::Crashed,
@@ -894,6 +901,18 @@ mod tests {
                 !h.check_awaiting_operator(s, Duration::from_secs(60)),
                 "state {:?} should not trigger awaiting_operator",
                 s
+            );
+        }
+        // #1552: the runtime prompt states DO trigger past the threshold (the
+        // supervisor adds the position/stability/engagement FP-gates on top).
+        for s in [AgentState::PermissionPrompt, AgentState::InteractivePrompt] {
+            assert!(
+                h.check_awaiting_operator(s, Duration::from_secs(60)),
+                "runtime prompt state {s:?} must trigger awaiting_operator past threshold"
+            );
+            assert!(
+                !h.check_awaiting_operator(s, Duration::from_secs(10)),
+                "runtime prompt state {s:?} under threshold must not trigger"
             );
         }
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -872,17 +872,23 @@ impl StateTracker {
         self.record_set(AgentState::Restarting); // #1527: also logs the transition
     }
 
-    /// Force state to AwaitingOperator when startup stalls on an unexpected
-    /// interactive prompt. Only fires from `Starting` — Ready-state stalls
-    /// are caught by pattern-based detection (see `InteractivePrompt` once
-    /// added; until then they're missed, which is acceptable for the
-    /// time-based fallback role).
+    /// Force state to AwaitingOperator when the agent is stalled waiting on
+    /// operator input. Fires from `Starting` (the original startup-stall
+    /// fallback) or, post-#1552, from a runtime `PermissionPrompt` /
+    /// `InteractivePrompt` (a mid-task approval stall). Other states are left
+    /// untouched so a late tick-loop detection can't corrupt a healthy
+    /// mid-task agent — the WHEN-to-escalate gating (silence threshold +
+    /// position / stability / engagement FP-gates) lives in the supervisor;
+    /// this setter just guards the legal source states.
     ///
     /// Once the operator unblocks the stall and the ready pattern matches
     /// fresh screen content, `transition()` lifts the state (Ready prio >
     /// AwaitingOperator prio → higher always wins).
     pub fn set_awaiting_operator(&mut self) {
-        if matches!(self.current, AgentState::Starting) {
+        if matches!(
+            self.current,
+            AgentState::Starting | AgentState::PermissionPrompt | AgentState::InteractivePrompt
+        ) {
             self.record_set(AgentState::AwaitingOperator); // #1527: also logs
         }
     }

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -906,17 +906,30 @@ fn set_awaiting_operator_from_starting() {
 }
 
 #[test]
+fn set_awaiting_operator_fires_from_runtime_prompt_states() {
+    // #1552: a mid-task stall on a permission/interactive prompt must be able
+    // to escalate to AwaitingOperator (was Starting-only before).
+    for s in [AgentState::PermissionPrompt, AgentState::InteractivePrompt] {
+        let mut t = tracker_at(&Backend::ClaudeCode, s, 10);
+        t.set_awaiting_operator();
+        assert_eq!(
+            t.current,
+            AgentState::AwaitingOperator,
+            "runtime prompt state {s:?} must escalate"
+        );
+    }
+}
+
+#[test]
 fn set_awaiting_operator_noop_from_non_starting() {
-    // Only Starting transitions. All other states (including Ready) are
-    // no-ops so late-firing tick-loop detections can't corrupt a healthy
-    // mid-task agent. Known interactive prompts from Ready are caught
-    // by pattern-based detection, not this time-based fallback.
+    // #1552: only Starting + the runtime prompt states (PermissionPrompt /
+    // InteractivePrompt) transition. Every OTHER state is a no-op so a late
+    // tick-loop detection can't corrupt a healthy mid-task agent.
     for s in [
         AgentState::Ready,
         AgentState::Idle,
         AgentState::Thinking,
         AgentState::ToolUse,
-        AgentState::PermissionPrompt,
         AgentState::AwaitingOperator,
         AgentState::Crashed,
     ] {


### PR DESCRIPTION
## What & why
A mid-task agent stalled on a real `PermissionPrompt`/`InteractivePrompt` was never flagged `AwaitingOperator` (the gate was **Starting-only**); `check_hang` then mislabelled it `Hung` and the recovery dispatcher's **Stage-1 ESC dismissed the live prompt**. Per decision **d-20260531141354559067-0** (dev impl-feasibility lens + dev-2 FP-loop lens).

## Half 1 — runtime fire (triad; all three needed, none alone suffices)
- `health.rs` `check_awaiting_operator`: gate `Starting → Starting | PermissionPrompt | InteractivePrompt`.
- `state/mod.rs` `set_awaiting_operator`: was **also** Starting-only (a silent second gate) — widened to the same prompt states.
- `supervisor.rs`: after `set_awaiting_operator()`, set the **health** reason `set_blocked_reason(AwaitingOperator)` — `check_hang` exempts on `current_reason`, **not** on state, so the state alone would not stop the Hung→ESC path. Cleared on the recovery arm (guarded so it never clears a different blocked reason).

## Half 2 — escalation FP-gate (dev-2 design)
So a permission-chrome false positive can't amplify into a false operator buzz + sticky blocked-state. The meta-FP: a working agent whose pane merely **echoes** the footer chrome (e.g. in scrollback — detection is full-screen). `awaiting_escalation_allowed` gates the runtime path on:
- **(a) position (mandatory)**: the chrome must re-detect in the **live bottom-N** rows (a scrollback echo fails this — the only gate that catches a finished agent sitting on a footer).
- **(b) stability**: the prompt state held continuously ≥ 8s.
- **(c) engagement**: operator hasn't typed into the pane in the last 15s (`read_input_submit_timestamps`).

`Starting` keeps its original ungated path. **Re-notify dedup** uses the health reason itself (already-`AwaitingOperator` → re-affirm state/reason but no re-buzz), so the chrome (prio 8 > `AwaitingOperator` prio 2) flipping the state back each tick can't buzz repeatedly. **No promote** of `infer_from_silence` (silence-only = chrome-less = more FP).

Lock-free w.r.t. self-IPC (#1492); the registry re-lock for the position gate's backend only runs when already silent>30s on a prompt state (rare, not per-tick).

## Tests
- `set_awaiting_operator` fires from runtime prompt states (+ no-op list updated); `check_awaiting_operator` fires on PermissionPrompt/InteractivePrompt past threshold (state/health).
- `awaiting_escalation_allowed`: Starting ungated · all-gates-pass · **scrollback-footer-FP blocked** (position) · not-stable blocked · operator-typing blocked · non-prompt never escalates.
- `check_hang` AwaitingOperator-reason exemption is pre-existing-tested (the Half-1 #3 linkage target).

Full preflight green (fmt + clippy -D + tests --features tray + windows xwin). 4-file diff. (The in-worktree `agend-git` `has_unmerged_files_true_on_conflict` is the #1463 shim-intercept flake; passes with bypass / in CI.)

## Links
#1552 · decision d-20260531141354559067-0 · #1546 (chrome detection it builds on) · #1518 (bottom-N precedent) · #1513 (engagement signal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)