### PR TITLE
fix(#1559): anchor codex PermissionPrompt on dialog chrome, drop bare wording

### DIFF
--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -349,26 +349,35 @@ impl StatePatterns {
                 ),
                 // [docs] Context overflow error
                 (AgentState::ContextFull, r"ContextOverflow"),
-                // [measured] Codex 0.120.0 renders approval dialogs with a
+                // [measured] Codex 0.120.0 renders its approval dialog with a
                 // distinctive header (`Would you like to run the following
-                // command?`) and a footer (`Press enter to confirm or esc to
-                // cancel`). Observed in tests/fixtures/state-replay/codex-perm.raw.
+                // command?`), a footer (`Press enter to confirm or esc to
+                // cancel`), and the distinctive option `No, and tell Codex what
+                // to do differently`. All three observed in the one captured
+                // surface, tests/fixtures/state-replay/codex-perm.raw.
                 //
-                // #1559 (cross-backend of #1546): anchor on the **chrome**
-                // (header + footer) ONLY. The previous pattern also matched bare
-                // option/verb words (`Yes, proceed`, `No, and tell Codex`,
-                // `Request approval`, `approve`, `deny`) — content-FP-prone: a
-                // codex reviewer agent writing "approve this PR" / "Yes, proceed
-                // with the merge", or a pane quoting an approval discussion,
-                // would falsely read as a live PermissionPrompt. The header +
-                // footer are live-dialog chrome that prose doesn't echo, and
-                // each alone still detects the real codex-perm.raw prompt
-                // (verified: the fixture contains both). Pair with the #1546/
-                // #1552 live-bottom-N position gate at the escalation site so
-                // even the chrome can't FP from a scrollback echo.
+                // #1559 (cross-backend of #1546): anchor on the live-dialog
+                // CHROME + that one distinctive option; DROP the prose-echoable
+                // bare words `approve`, `deny`, `Request approval`, and bare
+                // `Yes, proceed`. Those content-FP'd — a codex reviewer agent
+                // writing "approve this PR" / "Yes, proceed with the merge", or a
+                // pane quoting an approval discussion, would falsely read as a
+                // live PermissionPrompt.
+                //
+                // FN-safety (answering the #1567 review): dropping
+                // `Request approval|approve|deny` is provably FN-free — they were
+                // a [docs] guess that NEVER matched real codex 0.120.0 (fixture
+                // commit e0716ec: "pattern `Request approval|approve|deny`
+                // doesn't match the actual escalation wording … Neither recording
+                // fires PermissionPrompt"). The kept header + footer +
+                // `No, and tell Codex what to do differently` are three
+                // independent, non-prose anchors from the real dialog, so an
+                // approval frame is detected even if one line is off-screen.
+                // Pair with the #1546/#1552 live-bottom-N position gate so even
+                // the chrome can't FP from a scrollback echo.
                 (
                     AgentState::PermissionPrompt,
-                    r"Would you like to run the following command\?|Press enter to confirm or esc to cancel",
+                    r"Would you like to run the following command\?|Press enter to confirm or esc to cancel|No, and tell Codex what to do differently",
                 ),
                 // Phase A Piece-1: git conflict output (backend-independent).
                 (

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -349,22 +349,26 @@ impl StatePatterns {
                 ),
                 // [docs] Context overflow error
                 (AgentState::ContextFull, r"ContextOverflow"),
-                // [measured] Codex 0.120.0 renders approval dialogs with
-                // a distinctive header (`Would you like to run the
-                // following command?`), three numbered options starting
-                // with `Yes, proceed` and ending with `No, and tell
-                // Codex what to do differently`, plus a footer
-                // (`Press enter to confirm or esc to cancel`). Observed
-                // in tests/fixtures/state-replay/codex-perm.raw at byte
-                // ~68K through dismissal at ~90K. The prior pattern
-                // (`Request approval|approve|deny`) never matched any
-                // of the wording. `approve|deny` retained for legacy
-                // and adjacent docs wording; the new alternations cover
-                // the real dialog text. Header + footer are long enough
-                // to avoid false positives on narration lines.
+                // [measured] Codex 0.120.0 renders approval dialogs with a
+                // distinctive header (`Would you like to run the following
+                // command?`) and a footer (`Press enter to confirm or esc to
+                // cancel`). Observed in tests/fixtures/state-replay/codex-perm.raw.
+                //
+                // #1559 (cross-backend of #1546): anchor on the **chrome**
+                // (header + footer) ONLY. The previous pattern also matched bare
+                // option/verb words (`Yes, proceed`, `No, and tell Codex`,
+                // `Request approval`, `approve`, `deny`) — content-FP-prone: a
+                // codex reviewer agent writing "approve this PR" / "Yes, proceed
+                // with the merge", or a pane quoting an approval discussion,
+                // would falsely read as a live PermissionPrompt. The header +
+                // footer are live-dialog chrome that prose doesn't echo, and
+                // each alone still detects the real codex-perm.raw prompt
+                // (verified: the fixture contains both). Pair with the #1546/
+                // #1552 live-bottom-N position gate at the escalation site so
+                // even the chrome can't FP from a scrollback echo.
                 (
                     AgentState::PermissionPrompt,
-                    r"Would you like to run the following command\?|Yes, proceed|No, and tell Codex|Press enter to confirm or esc to cancel|Request approval|approve|deny",
+                    r"Would you like to run the following command\?|Press enter to confirm or esc to cancel",
                 ),
                 // Phase A Piece-1: git conflict output (backend-independent).
                 (

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -752,23 +752,27 @@ fn claude_permission_prompt_dialog_match() {
 
 #[test]
 fn codex_permission_chrome_anchor_1559() {
-    // #1559 (cross-backend of #1546): codex PermissionPrompt now keys on the
-    // live-dialog CHROME (header + footer), observed in codex-perm.raw — each
-    // alone fires. The previous bare alternations (`Request approval`,
-    // `approve`, `deny`, `Yes, proceed`, `No, and tell Codex`) were CUT: they
-    // content-FP'd on a codex reviewer's prose / quoted approval discussion.
+    // #1559 (cross-backend of #1546): codex PermissionPrompt keys on the
+    // live-dialog CHROME (header + footer) + the one distinctive, non-prose
+    // option (`No, and tell Codex what to do differently`) — each fires alone.
+    // The prose-echoable bare words (`Request approval`, `approve`, `deny`, bare
+    // `Yes, proceed`) were CUT: they content-FP'd on a reviewer's prose /
+    // quoted approval discussion (and `approve|deny|Request approval` never
+    // matched real codex anyway — fixture commit e0716ec).
     let patterns = StatePatterns::for_backend(&Backend::Codex);
-    // Chrome anchors — each must fire on its own.
-    assert_eq!(
-        patterns.detect("Would you like to run the following command?"),
-        Some(AgentState::PermissionPrompt),
-        "codex dialog header must fire PermissionPrompt",
-    );
-    assert_eq!(
-        patterns.detect("Press enter to confirm or esc to cancel"),
-        Some(AgentState::PermissionPrompt),
-        "codex dialog footer must fire PermissionPrompt",
-    );
+    // The three real-dialog anchors — each must fire on its own (FN-safety:
+    // an approval frame is caught even if one line is off-screen).
+    for anchor in [
+        "Would you like to run the following command?",
+        "Press enter to confirm or esc to cancel",
+        "› 3. No, and tell Codex what to do differently (esc)",
+    ] {
+        assert_eq!(
+            patterns.detect(anchor),
+            Some(AgentState::PermissionPrompt),
+            "codex dialog anchor {anchor:?} must fire PermissionPrompt",
+        );
+    }
     // FP-block: bare approval words in prose (NOT a live dialog) must NOT fire.
     for prose in [
         "I'll approve this PR once CI is green",
@@ -1308,32 +1312,28 @@ fn codex_tooluse_does_not_false_positive_on_spinner_or_narration() {
 #[test]
 fn codex_permission_prompt_dialog_match() {
     // Codex 0.120.0 approval dialog. #1559: anchor on the live-dialog CHROME
-    // (header + footer) ONLY — both are present in the real box (codex-perm.raw)
-    // and the #1552 position gate keeps the footer at the live bottom. The bare
-    // option rows are NO LONGER anchors (content-FP-prone — they echo in quoted
-    // prose); see codex_permission_chrome_anchor_1559.
+    // (header + footer) + the one distinctive option (`No, and tell Codex what
+    // to do differently`) — all three present in the real box (codex-perm.raw),
+    // each fires alone. The prose-echoable rows are NOT anchors.
     let patterns = StatePatterns::for_backend(&Backend::Codex);
-    for chrome in [
+    for anchor in [
         "  Would you like to run the following command?",
         "  Press enter to confirm or esc to cancel",
-    ] {
-        assert_eq!(
-            patterns.detect(chrome),
-            Some(AgentState::PermissionPrompt),
-            "expected PermissionPrompt for chrome {chrome:?}"
-        );
-    }
-    // Option rows alone (no chrome) must NOT fire — they're echoable prose.
-    for option in [
-        "  1. Yes, proceed (y)",
         "› 3. No, and tell Codex what to do differently (esc)",
     ] {
-        assert_ne!(
-            patterns.detect(option),
+        assert_eq!(
+            patterns.detect(anchor),
             Some(AgentState::PermissionPrompt),
-            "#1559: bare option row {option:?} must NOT fire PermissionPrompt on its own"
+            "expected PermissionPrompt for anchor {anchor:?}"
         );
     }
+    // The prose-echoable option row alone (no chrome / no distinctive option)
+    // must NOT fire — `Yes, proceed` is dropped.
+    assert_ne!(
+        patterns.detect("  1. Yes, proceed (y)"),
+        Some(AgentState::PermissionPrompt),
+        "#1559: bare `Yes, proceed` option row must NOT fire PermissionPrompt on its own"
+    );
 }
 
 #[test]

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -751,22 +751,36 @@ fn claude_permission_prompt_dialog_match() {
 }
 
 #[test]
-fn permission_prompt_legacy_wording_still_matches() {
-    // #1546: Claude's legacy bare wording (`Allow once|Allow always|approve`) was
-    // CUT — it false-positived on prose. Claude now keys on the chrome footer
-    // (see claude_permission_footer_anchor_1546). Codex/other backends are
-    // untouched and still match their own wording.
-    let cases: &[(Backend, &[&str])] =
-        &[(Backend::Codex, &["Request approval", "approve", "deny"])];
-    for (backend, samples) in cases {
-        let patterns = StatePatterns::for_backend(backend);
-        for sample in *samples {
-            assert_eq!(
-                patterns.detect(sample),
-                Some(AgentState::PermissionPrompt),
-                "{backend:?} legacy wording {sample:?} must still fire PermissionPrompt",
-            );
-        }
+fn codex_permission_chrome_anchor_1559() {
+    // #1559 (cross-backend of #1546): codex PermissionPrompt now keys on the
+    // live-dialog CHROME (header + footer), observed in codex-perm.raw — each
+    // alone fires. The previous bare alternations (`Request approval`,
+    // `approve`, `deny`, `Yes, proceed`, `No, and tell Codex`) were CUT: they
+    // content-FP'd on a codex reviewer's prose / quoted approval discussion.
+    let patterns = StatePatterns::for_backend(&Backend::Codex);
+    // Chrome anchors — each must fire on its own.
+    assert_eq!(
+        patterns.detect("Would you like to run the following command?"),
+        Some(AgentState::PermissionPrompt),
+        "codex dialog header must fire PermissionPrompt",
+    );
+    assert_eq!(
+        patterns.detect("Press enter to confirm or esc to cancel"),
+        Some(AgentState::PermissionPrompt),
+        "codex dialog footer must fire PermissionPrompt",
+    );
+    // FP-block: bare approval words in prose (NOT a live dialog) must NOT fire.
+    for prose in [
+        "I'll approve this PR once CI is green",
+        "Yes, proceed with the merge",
+        "the reviewer will deny the request",
+        "Request approval from the lead before merging",
+    ] {
+        assert_ne!(
+            patterns.detect(prose),
+            Some(AgentState::PermissionPrompt),
+            "#1559: bare approval prose {prose:?} must NOT fire PermissionPrompt",
+        );
     }
 }
 
@@ -1293,20 +1307,31 @@ fn codex_tooluse_does_not_false_positive_on_spinner_or_narration() {
 
 #[test]
 fn codex_permission_prompt_dialog_match() {
-    // Codex 0.120.0 approval dialog — header, every option, and
-    // footer must all fire PermissionPrompt. Observed in
-    // codex-perm.raw byte ~68K-90K.
+    // Codex 0.120.0 approval dialog. #1559: anchor on the live-dialog CHROME
+    // (header + footer) ONLY — both are present in the real box (codex-perm.raw)
+    // and the #1552 position gate keeps the footer at the live bottom. The bare
+    // option rows are NO LONGER anchors (content-FP-prone — they echo in quoted
+    // prose); see codex_permission_chrome_anchor_1559.
     let patterns = StatePatterns::for_backend(&Backend::Codex);
-    for sample in [
+    for chrome in [
         "  Would you like to run the following command?",
-        "  1. Yes, proceed (y)",
-        "› 3. No, and tell Codex what to do differently (esc)",
         "  Press enter to confirm or esc to cancel",
     ] {
         assert_eq!(
-            patterns.detect(sample),
+            patterns.detect(chrome),
             Some(AgentState::PermissionPrompt),
-            "expected PermissionPrompt for {sample:?}"
+            "expected PermissionPrompt for chrome {chrome:?}"
+        );
+    }
+    // Option rows alone (no chrome) must NOT fire — they're echoable prose.
+    for option in [
+        "  1. Yes, proceed (y)",
+        "› 3. No, and tell Codex what to do differently (esc)",
+    ] {
+        assert_ne!(
+            patterns.detect(option),
+            Some(AgentState::PermissionPrompt),
+            "#1559: bare option row {option:?} must NOT fire PermissionPrompt on its own"
         );
     }
 }


### PR DESCRIPTION
## What & why
Cross-backend application of **#1546** (Claude chrome-anchor) to **codex** — the *impl-able now* slice (the `codex-perm.raw` fixture already exists; kiro/opencode/gemini stay capture-gated per the #1559 enum).

The codex `PermissionPrompt` pattern matched bare option/verb words (`Yes, proceed`, `No, and tell Codex`, `Request approval`, `approve`, `deny`) alongside the chrome. Those **content-FP**: a codex *reviewer* agent writing "approve this PR" / "Yes, proceed with the merge", or a pane quoting an approval discussion, falsely reads as a live `PermissionPrompt`.

## How
`src/state/patterns.rs` codex arm now anchors **only on the live-dialog chrome** — header `Would you like to run the following command?` + footer `Press enter to confirm or esc to cancel`.

**Verified precondition** (lead-required): the chrome alone still detects the real dialog — `codex-perm.raw` contains *both* the header and footer (and never contained `approve`/`deny`/`Request approval` at all). The `state_pattern_coverage` corpus replay stays green.

## Tests
- `codex_permission_chrome_anchor_1559` (new): header + footer each fire; bare approval prose (`approve` / `Yes, proceed` / `deny` / `Request approval`) does **not**.
- `codex_permission_prompt_dialog_match` (updated): chrome fires; bare option rows alone do **not**.
- `permission_prompt_legacy_wording_still_matches` → replaced (codex no longer matches the bare wording — that's the fix).

Full preflight green (fmt + clippy -D + tests --features tray + windows xwin). 2-file diff.

## Scope
**codex-only.** kiro/opencode/gemini are capture-gated (need an operator capture of their live permission dialog — see the #1559 enum) and untouched. Pair this chrome anchor with the #1546/#1552 live-bottom-N position gate at the escalation site.

## Links
#1559 · #1546 (the Claude template) · #1552 (position gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)