### PR TITLE
fix(#893): strip Windows \?\ verbatim prefix from PTY working dir

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -755,8 +755,8 @@ mod tests {
         let home = tmp_home("validate_verbatim");
         let work = crate::paths::workspace_dir(&home).join("agent");
         std::fs::create_dir_all(&work).expect("create dir");
-        let resolved =
-            validate_working_directory(&work, &home).expect("existing path under home must validate");
+        let resolved = validate_working_directory(&work, &home)
+            .expect("existing path under home must validate");
         let resolved_str = resolved.to_string_lossy();
         assert!(
             !resolved_str.starts_with(r"\\?\"),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -124,9 +124,15 @@ pub fn validate_working_directory(
     if path.components().any(|c| matches!(c, Component::ParentDir)) {
         anyhow::bail!("working_directory must not contain '..'");
     }
-    // Canonicalize to resolve symlinks
+    // Canonicalize to resolve symlinks. `dunce::canonicalize` (not
+    // `std::fs::canonicalize`) so that on Windows the returned path does NOT
+    // carry the `\\?\` UNC verbatim prefix: this value becomes the PTY cwd
+    // (agent::build_command -> cmd.cwd), and a `\\?\`-prefixed cwd makes
+    // cmd.exe-based backends warn "UNC paths are not supported" and silently
+    // fall back to C:\Windows (#893 — same prefix bug already fixed for the
+    // session-name encode path in backend::canonicalize_for_encode).
     let canonical = if path.exists() {
-        std::fs::canonicalize(path)
+        dunce::canonicalize(path)
             .map_err(|e| anyhow::anyhow!("working_directory canonicalize failed: {e}"))?
     } else {
         // Path doesn't exist yet (will be created) — use parent for validation
@@ -159,8 +165,11 @@ fn allowed_roots(home: &std::path::Path) -> Vec<std::path::PathBuf> {
 fn is_under_allowed_root(path: &std::path::Path, home: &std::path::Path) -> bool {
     let roots = allowed_roots(home);
     roots.iter().any(|root| {
-        // Canonicalize root too (home might be a symlink)
-        let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.clone());
+        // Canonicalize root too (home might be a symlink). Use
+        // `dunce::canonicalize` to match the prefix form of `path` above —
+        // a `\\?\`-prefixed root vs a plain-prefixed path (or vice versa)
+        // would make `starts_with` spuriously fail on Windows (#893).
+        let canonical_root = dunce::canonicalize(root).unwrap_or_else(|_| root.clone());
         path.starts_with(&canonical_root)
     })
 }
@@ -727,6 +736,35 @@ mod tests {
         std::fs::create_dir_all(&ok).expect("create dir");
         let resolved = validate_working_directory(&ok, &home).expect("normal path must validate");
         assert!(resolved.ends_with("agent"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Windows-only #893 regression: the path returned by
+    /// `validate_working_directory` becomes the PTY cwd
+    /// (`agent::build_command` -> `cmd.cwd`). It MUST NOT carry the `\\?\`
+    /// UNC verbatim prefix that `std::fs::canonicalize` returns on Windows —
+    /// a `\\?\`-prefixed cwd makes cmd.exe-based backends warn "UNC paths are
+    /// not supported" and fall back to C:\Windows. `dunce::canonicalize`
+    /// strips the prefix when safe; falling back to `std::fs::canonicalize`
+    /// here would re-introduce the bug. The validation must also still SUCCEED
+    /// (exercises `is_under_allowed_root`, which must canonicalize the root the
+    /// same way or the `starts_with` check would spuriously reject).
+    #[cfg(windows)]
+    #[test]
+    fn validate_work_dir_strips_verbatim_prefix_on_windows() {
+        let home = tmp_home("validate_verbatim");
+        let work = crate::paths::workspace_dir(&home).join("agent");
+        std::fs::create_dir_all(&work).expect("create dir");
+        let resolved =
+            validate_working_directory(&work, &home).expect("existing path under home must validate");
+        let resolved_str = resolved.to_string_lossy();
+        assert!(
+            !resolved_str.starts_with(r"\\?\"),
+            "validate_working_directory must strip the Windows `\\\\?\\` verbatim \
+             prefix (got {resolved_str:?}); this path becomes the PTY cwd and a \
+             `\\\\?\\` cwd breaks cmd.exe-based backends — keep dunce::canonicalize, \
+             do not fall back to std::fs::canonicalize"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
## Problem

On Windows, some backends (e.g. gemini) print on startup:

> '\?\C:\Users\...\.agend\workspace\<instance>' 是目前用來啟動 CMD.EXE 的目錄路徑。不支援 UNC 路徑。預設目錄是 Windows 目錄。

`validate_working_directory` (`src/api/mod.rs`) returns the path that becomes the backend PTY cwd (`agent::build_command` → `cmd.cwd`). It used `std::fs::canonicalize`, which on Windows returns the `\?\` UNC **verbatim** form. cmd.exe-based backends treat the leading `\` as a UNC path, reject it ("UNC paths are not supported"), and silently fall back to `C:\Windows`. Backends that don't spawn cmd.exe (e.g. claude) accept verbatim paths, which is why only *some* backends warned.

This is the same prefix bug already fixed for the session-name encode path in `backend::canonicalize_for_encode` (#893) — `validate_working_directory` was the remaining gap. Its own comment even claimed "canonicalize no longer called," but it had crept back in.

## Fix

Switch both canonicalize calls in `src/api/mod.rs` to `dunce::canonicalize` (already a dependency):

- **`validate_working_directory`** — strips the `\?\` prefix from the returned cwd when safe.
- **`is_under_allowed_root`** — must canonicalize the root the same way; otherwise a `\?\`-prefixed root vs a plain `path` makes `path.starts_with(root)` spuriously fail and reject a legitimate working directory.

## Test

Added `#[cfg(windows)]` regression test `validate_work_dir_strips_verbatim_prefix_on_windows`, mirroring the existing `backend.rs` verbatim-prefix test. It guards both the prefix strip and that validation still succeeds (would fail if either call reverts to `std::fs::canonicalize`).

```
running 5 tests
test api::tests::validate_work_dir_strips_verbatim_prefix_on_windows ... ok
... (4 existing validate_work_dir tests) ... ok
test result: ok. 5 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)