### PR TITLE
fix(#1492): bound api::call loopback read with timeout + dedup #1450 anchor-suppress flood

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@
 //! registry and loopback-binding rules.
 
 use crate::agent::{self, AgentRegistry, ExternalRegistry};
+use anyhow::Context;
 use parking_lot::Mutex;
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -681,6 +682,20 @@ pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
     // fails loudly; release builds compile this to a no-op.
     crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
     let stream = crate::ipc::connect_api(home)?;
+    // #1492 backstop: bound every loopback read with a socket-level timeout.
+    // `assert_no_registry_lock_for_self_ipc` only panics in debug builds — in
+    // release it is a no-op, so a self-IPC made while holding the registry/core
+    // lock deadlocks the daemon AND froze the whole TUI permanently, because the
+    // handshake/response `read_line` below had no timeout and blocked forever in
+    // `recvfrom` while still holding the lock. The timeout converts that
+    // permanent freeze into a recoverable error: the read fails, this call
+    // unwinds, the offending lock guard drops, and the waiting threads proceed.
+    // Generous default (covers the slowest legit method, create_instance ~60s);
+    // `AGEND_API_CALL_TIMEOUT_SECS` lets an operator shrink the recovery window.
+    let timeout = api_call_read_timeout();
+    stream
+        .set_read_timeout(Some(timeout))
+        .context("set api::call read timeout")?;
     let run = crate::daemon::find_active_run_dir(home)
         .ok_or_else(|| anyhow::anyhow!("no active daemon (run dir not found)"))?;
     let cookie = crate::auth_cookie::read_cookie(&run)?;
@@ -693,9 +708,41 @@ pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
     writer.flush()?;
 
     let mut line = String::new();
-    reader.read_line(&mut line)?;
+    if let Err(e) = reader.read_line(&mut line) {
+        if matches!(
+            e.kind(),
+            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+        ) {
+            let method = request["method"].as_str().unwrap_or("<unknown>");
+            tracing::warn!(
+                method,
+                ?timeout,
+                "#1492: api::call read timed out — the loopback handler did not respond \
+                 in time. This is the self-IPC-deadlock backstop firing; the most likely \
+                 cause is a caller that invoked api::call while holding the registry/core \
+                 lock (drop the guard BEFORE the call — see docs/DAEMON-LOCK-ORDERING.md)."
+            );
+            anyhow::bail!("api::call ({method}) timed out after {timeout:?}");
+        }
+        return Err(e).context("api::call read response");
+    }
     let resp: Value = serde_json::from_str(line.trim())?;
     Ok(resp)
+}
+
+/// Read-response timeout for [`call`]. Defaults to 90s — comfortably above the
+/// slowest legitimate daemon method (`create_instance`, whose own budget is
+/// ~60s) so a genuine slow call never trips the backstop, while still bounding a
+/// wedged self-IPC instead of blocking forever. Overridable via
+/// `AGEND_API_CALL_TIMEOUT_SECS` to shrink the deadlock-recovery window (values
+/// <1 are clamped to 1s).
+fn api_call_read_timeout() -> std::time::Duration {
+    let secs = std::env::var("AGEND_API_CALL_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(|v| v.max(1))
+        .unwrap_or(90);
+    std::time::Duration::from_secs(secs)
 }
 
 #[cfg(test)]
@@ -813,6 +860,27 @@ mod tests {
             "unexpected error: {msg}"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn api_call_read_timeout_default_override_and_clamp() {
+        // #1492 backstop: the loopback read timeout that converts a wedged
+        // self-IPC from a permanent daemon freeze into a recoverable error.
+        std::env::remove_var("AGEND_API_CALL_TIMEOUT_SECS");
+        assert_eq!(
+            api_call_read_timeout(),
+            std::time::Duration::from_secs(90),
+            "default must exceed the slowest legit method (create_instance ~60s)"
+        );
+        std::env::set_var("AGEND_API_CALL_TIMEOUT_SECS", "5");
+        assert_eq!(api_call_read_timeout(), std::time::Duration::from_secs(5));
+        std::env::set_var("AGEND_API_CALL_TIMEOUT_SECS", "0");
+        assert_eq!(
+            api_call_read_timeout(),
+            std::time::Duration::from_secs(1),
+            "sub-1s values clamp to 1s — never a zero/instant timeout"
+        );
+        std::env::remove_var("AGEND_API_CALL_TIMEOUT_SECS");
     }
 
     // -----------------------------------------------------------------------

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -177,6 +177,15 @@ pub struct StateTracker {
     /// depth class as #1005 ToolUse oscillation guard. Cleared on
     /// non-matching feed so a genuine future Productive signal re-fires.
     last_productive_marker_hash: Option<u64>,
+    /// #1450: hash of the last emitted anchor-suppress WARN's
+    /// (state, matched, line_context). The HIGH_FP red-anchor gate is
+    /// level-triggered — it re-evaluates on every `feed()`, so a backend that
+    /// statically displays a phrase matching a HIGH_FP pattern but never renders
+    /// red (e.g. an opencode pane showing the source identifier
+    /// `"ContextOverflow")`) re-logged the suppression on every tick, flooding
+    /// the daemon log (14k+ identical lines/incident). Dedup on this hash so the
+    /// WARN fires once per distinct suppression, not once per render.
+    last_anchor_suppress_hash: Option<u64>,
     /// Hash of the last screen text fed to `feed()`. `None` before the first
     /// call. Used to skip re-detection when the screen hasn't changed —
     /// crucial for not resetting `last_output` on cursor-blink noise.
@@ -448,6 +457,7 @@ impl StateTracker {
             last_output: Instant::now(),
             last_productive_output: Instant::now(),
             last_productive_marker_hash: None,
+            last_anchor_suppress_hash: None,
             last_screen_hash: None,
             patterns: backend.map(StatePatterns::for_backend),
             interactive_prompt_pending_notice: false,
@@ -777,17 +787,28 @@ impl StateTracker {
     /// the predicate) from "genuinely not red" (correct suppression)
     /// straight from the logs — no DEBUG rebuild.
     fn log_anchor_suppress(
-        &self,
+        &mut self,
         detected: AgentState,
         matched: &str,
         screen_text: &str,
         fg: &[CellFg],
     ) {
-        let span_fg: Vec<CellFg> = first_occurrence_span(screen_text, matched, fg);
         let line_context = screen_text
             .lines()
             .find(|l| l.contains(matched))
             .unwrap_or(matched);
+        // #1450: dedup. The gate is level-triggered (re-runs every feed), so a
+        // static on-screen phrase that never renders red would otherwise re-log
+        // this WARN on every tick. Emit only when the suppressed
+        // (state, matched, line) tuple differs from the last one logged.
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        format!("{detected:?}\u{1}{matched}\u{1}{line_context}").hash(&mut hasher);
+        let suppress_hash = hasher.finish();
+        if self.last_anchor_suppress_hash == Some(suppress_hash) {
+            return;
+        }
+        self.last_anchor_suppress_hash = Some(suppress_hash);
+        let span_fg: Vec<CellFg> = first_occurrence_span(screen_text, matched, fg);
         tracing::warn!(
             agent = %self.instance_name,
             backend = %self.backend_name,

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3370,3 +3370,40 @@ fn claude_permission_footer_anchor_1546() {
         );
     }
 }
+
+/// #1450 regression: a HIGH_FP pattern that matches but never renders red —
+/// e.g. an opencode pane statically displaying the source identifier
+/// `ContextOverflow` — must log the red-anchor suppression ONCE, not on every
+/// render tick. The gate is level-triggered (`feed_with_fg` re-runs detection
+/// each tick), so before the dedup this flooded the daemon log with 14k+
+/// identical WARN lines per incident — the symptom that buried the real signal
+/// during a freeze investigation. A changing line elsewhere on screen (which
+/// defeats `feed()`'s screen-hash dedup) must NOT re-open the floodgate, since
+/// the suppressed (state, matched, line) tuple is unchanged.
+#[test]
+#[tracing_test::traced_test]
+fn anchor_suppress_warn_deduped_across_ticks() {
+    let mut vt = VTerm::new(80, 24);
+    let mut st = StateTracker::new(Some(&Backend::OpenCode));
+    // Five renders: each scrolls a fresh counter line (new screen hash → passes
+    // feed()'s screen-hash dedup) while the non-red `ContextOverflow` line stays
+    // in the live tail, so the HIGH_FP match + red-anchor-fail fires every tick.
+    for i in 0..5 {
+        drive(
+            &mut vt,
+            &mut st,
+            format!("working tick {i}\r\nContextOverflow\r\n").as_bytes(),
+        );
+    }
+    logs_assert(|lines: &[&str]| {
+        let hits = lines.iter().filter(|l| l.contains("#1450")).count();
+        if hits == 1 {
+            Ok(())
+        } else {
+            Err(format!(
+                "#1450 red-anchor suppress WARN must be deduped to exactly one \
+                 across 5 identical-suppression ticks, got {hits}"
+            ))
+        }
+    });
+}


### PR DESCRIPTION
## Why

A running release `app` froze hard — the process sat at ~0.5% CPU and the TUI was
unresponsive to all input. `sample(1)` on the wedged PID showed the **main TUI
thread parked in `_pthread_cond_wait`** on the registry lock for the entire
sample window, while **three `mcp_tool_send` threads sat in `__recvfrom` with no
timeout**. `SIGTERM` could not shut it down (the shutdown path wants the same
lock) — only `SIGKILL` worked.

## Root cause (the freeze)

This is the `#1492/#1535` **self-IPC-under-lock deadlock** class, manifesting in
a release build:

- `api::call` (in the `call` fn of `src/api/mod.rs`) does loopback self-IPC and
  reads the auth handshake + the response line with **no socket read timeout**.
- `assert_no_registry_lock_for_self_ipc` is the guard against a caller holding
  the registry/core lock across that self-IPC — but it **only panics in debug;
  in release it compiles to a no-op** (see the two cfg-gated defs in
  `src/sync_audit.rs`). The lock-depth counters it reads are themselves
  `#[cfg(debug_assertions)]`.
- So in release the violating path deadlocks: the loopback handler servicing the
  call needs the registry lock the caller still holds, the caller's `read_line`
  blocks **forever** in `recvfrom` while holding that lock, and every other
  thread that wants the lock (main TUI render/input, supervisor, monitor_tick,
  the other api_handlers) parks behind it. Permanent freeze.

## Fix

**Backstop (recovers the freeze regardless of which path violates lock
discipline):** set a socket read timeout on the `api::call` stream right after
connect. A wedged self-IPC now fails with a clear error → the call unwinds → the
offending lock guard drops → the waiting threads proceed. The timeout-path log
names the request `method` so the next occurrence is identifiable from
`daemon.log` without a debug rebuild. Default 90s (comfortably above the slowest
legit method's ~60s budget, so a genuine slow call never trips it); operators can
shrink the recovery window via `AGEND_API_CALL_TIMEOUT_SECS`. This also makes
`mcp_proxy`'s "a timed-out tool thread runs to completion in the background (no
leak)" claim true — the inner `api::call` now terminates instead of leaking a
lock-holding zombie thread.

I could **not** pinpoint the exact lock-holding caller by inspection: the
release binary is stripped (`atos` can't symbolicate), and the obvious delivery
path (`route_and_deliver` in `src/api/handlers/messaging.rs`) already
`drop(reg)`s before its self-IPC. The read-timeout backstop neutralizes the
whole class; pinning the specific offender needs a debug-build repro where the
guard panics with the call site.

**Noise (`#1450`):** the HIGH_FP red-anchor gate is level-triggered, so an
opencode pane statically displaying the source identifier `ContextOverflow` (a
phrase that matches the ContextFull pattern but never renders red) re-logged the
suppression WARN on **every render tick** — 14,955 identical lines in the
incident log, burying the real signal. `log_anchor_suppress` (in
`src/state/mod.rs`) now dedups on the `(state, matched, line_context)` hash so
the WARN fires once per distinct suppression, not once per render.

## Tests

Both route through the real producer (per the CLAUDE.md test-fidelity rule):

- `anchor_suppress_warn_deduped_across_ticks` — drives 5 renders through the
  real `VTerm` `drive()` harness with a changing line (defeats `feed()`'s
  screen-hash dedup) and a static non-red `ContextOverflow`; asserts exactly one
  `#1450` WARN via `tracing_test`.
- `api_call_read_timeout_default_override_and_clamp` — default 90s, env override,
  sub-1s clamp to 1s.

`scripts/preflight.sh` clean: fmt, clippy (`--all-targets --features tray
-D warnings`), tests (unit + integration + invariants), and the Windows
`x86_64-pc-windows-msvc` cross-check all pass.

## Operator note

The fix needs a release rebuild + `app` restart to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)