### PR TITLE
fix(#1492): L2 — always-on self-IPC guard, fail-fast Err instead of daemon freeze

### DIFF
--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1419,66 +1419,60 @@ fn empty_registry_1492() -> AgentRegistry {
     std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
 }
 
-/// Real wiring: `lock_registry` sets the debug held-flag, so a self-IPC vector
-/// (modeled by the assert) panics while the guard is alive. Proves the guard —
-/// not just the raw counter — participates. Debug-only: the detection compiles
-/// out in release, so the panic only exists there.
-#[cfg(debug_assertions)]
+/// Real wiring: `lock_registry` bumps the held-counter, so a self-IPC vector
+/// (modeled by the guard) refuses with `Err` while the guard is alive. Proves
+/// the guard — not just the raw counter — participates. #1492-L2: the guard is
+/// always-on and returns `Err` (was a debug-only `panic!` pre-L2).
 #[test]
-#[should_panic(expected = "lock-across-self-IPC")]
 fn lock_registry_guard_trips_self_ipc_assert_1492() {
     let reg = empty_registry_1492();
     let _guard = lock_registry(&reg);
-    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
+    assert!(crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call").is_err());
 }
 
 /// Dropping the `lock_registry` guard BEFORE self-IPC (the 6f1403d-correct
-/// pattern) clears the held-flag, so the assert does not trip.
-#[cfg(debug_assertions)]
+/// pattern) clears the held-counter, so the guard returns `Ok` (does not trip).
 #[test]
 fn lock_registry_guard_drop_clears_self_ipc_flag_1492() {
     let reg = empty_registry_1492();
     {
         let _guard = lock_registry(&reg);
-    } // guard dropped → flag cleared
-    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
+    } // guard dropped → counter cleared
+    assert!(crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call").is_ok());
 }
 
 /// `lock_registry_tracked` participates in the same detection.
-#[cfg(debug_assertions)]
 #[test]
-#[should_panic(expected = "lock-across-self-IPC")]
 fn lock_registry_tracked_guard_trips_self_ipc_assert_1492() {
     let reg = empty_registry_1492();
     let _guard = lock_registry_tracked(&reg, "test-1492");
-    crate::sync_audit::assert_no_registry_lock_for_self_ipc("enqueue_with_idle_hint");
+    assert!(
+        crate::sync_audit::assert_no_registry_lock_for_self_ipc("enqueue_with_idle_hint").is_err()
+    );
 }
 
 // ── #1535: CoreMutex guard wiring for core-held self-IPC detection ──
 
 /// Real wiring: holding a `CoreMutex` guard bumps `CORE_LOCK_DEPTH`, so the
-/// (extended) self-IPC assert panics while the guard is alive — proving the
-/// core-lock blind spot the registry-only guard missed (#1535) is now covered.
-/// Debug-only: the detection compiles out in release.
-#[cfg(debug_assertions)]
+/// (extended) self-IPC guard refuses with `Err` while the guard is alive —
+/// proving the core-lock blind spot the registry-only guard missed (#1535) is
+/// now covered. #1492-L2: always-on, returns `Err`.
 #[test]
-#[should_panic(expected = "lock-across-self-IPC")]
 fn core_mutex_guard_trips_self_ipc_assert_1535() {
     let m = crate::sync_audit::CoreMutex::new(0u32);
     let _guard = m.lock();
-    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
+    assert!(crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call").is_err());
 }
 
 /// Dropping the `CoreMutex` guard BEFORE self-IPC (the collect→drop→emit
-/// pattern, e.g. #1530) clears the depth, so the assert does not trip.
-#[cfg(debug_assertions)]
+/// pattern, e.g. #1530) clears the depth, so the guard returns `Ok`.
 #[test]
 fn core_mutex_guard_drop_clears_self_ipc_flag_1535() {
     let m = crate::sync_audit::CoreMutex::new(0u32);
     {
         let _guard = m.lock();
     } // guard dropped → core depth cleared
-    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
+    assert!(crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call").is_ok());
 }
 
 // ── #1504: git-shim PATH parsing + self-exclusion (L1) ──

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -678,18 +678,21 @@ fn spawn_one(
 pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
     // #1492: self-IPC over the loopback socket. If the caller holds the
     // registry lock, the API handler servicing this call needs the same lock →
-    // deadlock. Debug builds panic here so any unit test hitting the bad path
-    // fails loudly; release builds compile this to a no-op.
-    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call");
+    // deadlock. #1492-L2: the guard is always-on and fail-fast — on a violation
+    // it logs + returns `Err` here (in EVERY build, not just debug), so the
+    // deadlocking call is refused and the daemon stays live instead of freezing.
+    crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call")?;
     let stream = crate::ipc::connect_api(home)?;
-    // #1492 backstop: bound every loopback read with a socket-level timeout.
-    // `assert_no_registry_lock_for_self_ipc` only panics in debug builds — in
-    // release it is a no-op, so a self-IPC made while holding the registry/core
-    // lock deadlocks the daemon AND froze the whole TUI permanently, because the
-    // handshake/response `read_line` below had no timeout and blocked forever in
-    // `recvfrom` while still holding the lock. The timeout converts that
-    // permanent freeze into a recoverable error: the read fails, this call
-    // unwinds, the offending lock guard drops, and the waiting threads proceed.
+    // #1492 backstop (L3): bound every loopback read with a socket-level
+    // timeout. #1492-L2 made the guard above always-on + fail-fast (it now
+    // returns `Err` in every build, not just a debug panic), so a self-IPC made
+    // while holding the registry/core lock is refused before we ever reach this
+    // read. This timeout is the complementary containment net (defense-in-depth)
+    // for any future path that bypasses the guard: were such a read to block
+    // forever in `recvfrom` while holding the lock, it would freeze the whole
+    // TUI permanently. The timeout converts that into a recoverable error: the
+    // read fails, this call unwinds, the offending lock guard drops, and the
+    // waiting threads proceed.
     // Generous default (covers the slowest legit method, create_instance ~60s);
     // `AGEND_API_CALL_TIMEOUT_SECS` lets an operator shrink the recovery window.
     let timeout = api_call_read_timeout();

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -466,9 +466,11 @@ pub(crate) fn should_suppress_911_reinject_with_ledger(
 pub fn enqueue_with_idle_hint(home: &Path, target: &str, msg: InboxMessage) -> anyhow::Result<()> {
     // #1492: this is a self-IPC vector — the default emitter's PTY inject
     // reaches `api::call` over the loopback socket. Calling it while holding
-    // the registry lock deadlocks the daemon (the morning cron bug). Debug
-    // builds panic here for an early, clear signal; release is a no-op.
-    crate::sync_audit::assert_no_registry_lock_for_self_ipc("enqueue_with_idle_hint");
+    // the registry lock deadlocks the daemon (the morning cron bug). #1492-L2:
+    // the guard is always-on and fail-fast — on a violation it logs + returns
+    // `Err` here in every build, so the call is refused (the hint is not
+    // emitted) and the daemon stays live instead of freezing.
+    crate::sync_audit::assert_no_registry_lock_for_self_ipc("enqueue_with_idle_hint")?;
     enqueue_with_idle_hint_with_emitter(home, target, msg, |hint| {
         compose_aware_inject(home, target, hint);
     })

--- a/src/sync_audit.rs
+++ b/src/sync_audit.rs
@@ -94,7 +94,7 @@ pub fn lock_released(tier: u8) {
     }
 }
 
-// ── #1492: lock-across-self-IPC deadlock detection (debug-only) ──────────
+// ── #1492: lock-across-self-IPC deadlock detection (always-on) ───────────
 //
 // The morning cron deadlock (#1479/#1483 neighborhood) was: a thread held the
 // registry lock and then made a self-IPC call (`api::call` over the loopback
@@ -105,34 +105,31 @@ pub fn lock_released(tier: u8) {
 //
 // This makes the bug catchable by ANY unit test that exercises the bad path:
 // a thread-local depth counter is bumped while the registry lock is held, and
-// the self-IPC vectors panic (debug builds only) if it's nonzero. Release
-// builds compile every entry/exit/assert to a no-op — zero overhead.
+// the self-IPC vectors refuse (return `Err`) if it's nonzero.
+//
+// #1492-L2 (decision d-20260531171228817178-0): the depth counters + the
+// self-IPC guard are now ALWAYS-ON (previously debug-only, cfg-gated, with
+// release no-ops). The counters are pure thread-local `Cell` bumps (no atomics,
+// no contention) on control-plane locks, so the steady-state cost is
+// negligible; in exchange a lock-across-self-IPC in a RELEASE daemon now
+// fail-fasts to a logged `Err` instead of freezing the whole daemon. Pairs with
+// the structural collect→drop→emit invariant (#1530) and the #1571 timeout
+// backstop as defense-in-depth.
 
-#[cfg(debug_assertions)]
 thread_local! {
     /// How many registry locks this thread currently holds (0 = none).
     static REGISTRY_LOCK_DEPTH: Cell<u32> = const { Cell::new(0) };
 }
 
-/// Record that this thread acquired the registry lock. Debug-only; release no-op.
-#[cfg(debug_assertions)]
+/// Record that this thread acquired the registry lock.
 pub fn registry_lock_entered() {
     REGISTRY_LOCK_DEPTH.with(|c| c.set(c.get().saturating_add(1)));
 }
-/// Release-build no-op (zero overhead).
-#[cfg(not(debug_assertions))]
-#[inline(always)]
-pub fn registry_lock_entered() {}
 
-/// Record that this thread released the registry lock. Debug-only; release no-op.
-#[cfg(debug_assertions)]
+/// Record that this thread released the registry lock.
 pub fn registry_lock_exited() {
     REGISTRY_LOCK_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
 }
-/// Release-build no-op (zero overhead).
-#[cfg(not(debug_assertions))]
-#[inline(always)]
-pub fn registry_lock_exited() {}
 
 // ── #1535: per-agent core-lock depth tracking + CoreMutex ────────────────
 //
@@ -145,7 +142,6 @@ pub fn registry_lock_exited() {}
 // it). [`CoreMutex`] makes EVERY core lock bump `CORE_LOCK_DEPTH` so the same
 // self-IPC assert covers the core-held case too.
 
-#[cfg(debug_assertions)]
 thread_local! {
     /// How many `AgentCore` locks this thread currently holds (0 = none).
     /// A single total-depth counter is sufficient: the rule is "no self-IPC
@@ -153,23 +149,15 @@ thread_local! {
     static CORE_LOCK_DEPTH: Cell<u32> = const { Cell::new(0) };
 }
 
-/// Record that this thread acquired a core lock. Debug-only; release no-op.
-#[cfg(debug_assertions)]
+/// Record that this thread acquired a core lock.
 fn core_lock_entered() {
     CORE_LOCK_DEPTH.with(|c| c.set(c.get().saturating_add(1)));
 }
-#[cfg(not(debug_assertions))]
-#[inline(always)]
-fn core_lock_entered() {}
 
-/// Record that this thread released a core lock. Debug-only; release no-op.
-#[cfg(debug_assertions)]
+/// Record that this thread released a core lock.
 fn core_lock_exited() {
     CORE_LOCK_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
 }
-#[cfg(not(debug_assertions))]
-#[inline(always)]
-fn core_lock_exited() {}
 
 /// #1535: a `parking_lot::Mutex` wrapper for the per-agent `AgentCore` that
 /// tracks lock depth via [`CORE_LOCK_DEPTH`]. `.lock()` is API-compatible with
@@ -224,29 +212,41 @@ impl<T> Drop for CoreGuard<'_, T> {
     }
 }
 
-/// Panic (debug builds only) if a self-IPC vector is entered while this thread
-/// holds the registry lock (#1492) OR any per-agent core lock (#1535) — either
-/// ordering deadlocks the daemon (the loopback API handler needs the registry
-/// lock and may lock the target agent's core). `ctx` names the vector. Release
-/// builds: no-op, zero cost.
-#[cfg(debug_assertions)]
-pub fn assert_no_registry_lock_for_self_ipc(ctx: &str) {
+/// Return `Err` if a self-IPC vector is entered while this thread holds the
+/// registry lock (#1492) OR any per-agent core lock (#1535) — either ordering
+/// deadlocks the daemon (the loopback API handler needs the registry lock and
+/// may lock the target agent's core). `ctx` names the vector (logged + carried
+/// in the error).
+///
+/// #1492-L2 (decision d-20260531171228817178-0): ALWAYS-ON, fail-fast `Err`
+/// (was debug-only `panic!` + release no-op). On violation it logs at ERROR
+/// with the named site + lock depths, then returns `Err` so the self-IPC
+/// entrypoint refuses the deadlocking call and the daemon stays LIVE — instead
+/// of freezing (the old release no-op gave zero release protection). The two
+/// production vectors (`api::call`, `enqueue_with_idle_hint`) already return
+/// `anyhow::Result`, so they propagate via `?` with no signature change. The
+/// `#[must_use]` `Result` makes ignoring the refusal a compile error at any new
+/// call site.
+pub fn assert_no_registry_lock_for_self_ipc(ctx: &str) -> anyhow::Result<()> {
     let reg = REGISTRY_LOCK_DEPTH.with(|c| c.get());
     let core = CORE_LOCK_DEPTH.with(|c| c.get());
     if reg > 0 || core > 0 {
-        panic!(
+        tracing::error!(
+            ctx,
+            registry_depth = reg,
+            core_depth = core,
+            "#1492/#1535 lock-across-self-IPC deadlock risk — refusing self-IPC (returning Err)"
+        );
+        anyhow::bail!(
             "#1492/#1535 lock-across-self-IPC deadlock risk: `{ctx}` was called while this thread \
              holds locks (registry depth={reg}, core depth={core}). The loopback API handler needs \
              the registry lock and may lock the target agent's core, so this self-IPC would \
              deadlock the daemon. Drop the guard(s) BEFORE the call (collect under lock → drop → \
-             emit; see #1530, commit 6f1403d, docs/DAEMON-LOCK-ORDERING.md)."
+             emit; see #1530, docs/DAEMON-LOCK-ORDERING.md)."
         );
     }
+    Ok(())
 }
-/// Release-build no-op (zero overhead).
-#[cfg(not(debug_assertions))]
-#[inline(always)]
-pub fn assert_no_registry_lock_for_self_ipc(_ctx: &str) {}
 
 /// Convenience macro for lock tier assertion + acquisition tracking.
 #[macro_export]
@@ -382,31 +382,36 @@ mod tests {
     // (Mechanism-level here; the real `lock_registry` guard wiring is tested
     // in `agent::mod` tests — `agent` is bin-only, not in this shared lib.)
 
-    /// No registry lock held → the self-IPC assert is a no-op (no panic). Holds
-    /// in both debug and release (release is a no-op unconditionally).
+    /// No registry lock held → the guard returns `Ok` (allows the self-IPC).
+    /// #1492-L2: always-on now (runs in release too, not just debug).
     #[test]
-    fn self_ipc_assert_is_noop_without_lock() {
-        assert_no_registry_lock_for_self_ipc("test-vector");
+    fn self_ipc_guard_ok_without_lock() {
+        assert!(assert_no_registry_lock_for_self_ipc("test-vector").is_ok());
     }
 
-    /// While the depth flag is set (as `lock_registry` does on acquire), a
-    /// self-IPC vector trips the assert. Debug-only — the detection compiles
-    /// out in release, so the panic only exists there.
-    #[cfg(debug_assertions)]
+    /// #1492-L2: while the depth flag is set (as `lock_registry` does on
+    /// acquire), the self-IPC guard refuses with `Err` (was a debug-only
+    /// `panic!` pre-L2; now an always-on fail-fast `Err`). Balance the
+    /// enter/exit so the always-on thread-local counter doesn't leak into the
+    /// next test sharing this worker thread.
     #[test]
-    #[should_panic(expected = "lock-across-self-IPC")]
-    fn self_ipc_assert_panics_while_lock_depth_nonzero() {
+    fn self_ipc_guard_errs_while_lock_depth_nonzero() {
         registry_lock_entered();
-        assert_no_registry_lock_for_self_ipc("api::call");
+        let result = assert_no_registry_lock_for_self_ipc("api::call");
+        registry_lock_exited();
+        assert!(
+            result.is_err(),
+            "guard must refuse self-IPC while a lock is held"
+        );
     }
 
     /// The correct pattern (release the lock BEFORE self-IPC — the 6f1403d fix
-    /// shape, modeled here by a balanced enter/exit) must NOT trip the assert.
-    #[cfg(debug_assertions)]
+    /// shape, modeled here by a balanced enter/exit) must NOT trip the guard.
+    /// #1492-L2: always-on now (runs in release too).
     #[test]
-    fn self_ipc_assert_ok_after_balanced_enter_exit() {
+    fn self_ipc_guard_ok_after_balanced_enter_exit() {
         registry_lock_entered();
         registry_lock_exited();
-        assert_no_registry_lock_for_self_ipc("api::call");
+        assert!(assert_no_registry_lock_for_self_ipc("api::call").is_ok());
     }
 }

--- a/tests/self_ipc_guard_always_on_invariant_1492.rs
+++ b/tests/self_ipc_guard_always_on_invariant_1492.rs
@@ -1,0 +1,51 @@
+//! #1492-L2 invariant (decision d-20260531171228817178-0): the
+//! lock-across-self-IPC guard + its depth counters in `src/sync_audit.rs` MUST
+//! be ALWAYS-ON — never `#[cfg(debug_assertions)]`-gated again.
+//!
+//! Pre-L2 the counters + `assert_no_registry_lock_for_self_ipc` compiled to a
+//! release no-op, so a RELEASE daemon had ZERO protection against the
+//! #1492/#1535 lock-across-self-IPC deadlock class (it would freeze). L2 made
+//! them always-on and fail-fast (`Err`). Re-introducing a
+//! `#[cfg(debug_assertions)]` gate would silently restore that blind spot — so
+//! this RED fails CI if the gate ever comes back, and also pins the fail-fast
+//! contract (the guard returns `anyhow::Result`, not `()`).
+
+use std::path::PathBuf;
+
+#[test]
+fn self_ipc_guard_and_counters_are_always_on_1492() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/sync_audit.rs");
+    let src = std::fs::read_to_string(&path).expect("read src/sync_audit.rs");
+
+    // (1) No debug-gating ATTRIBUTE may compile out the self-IPC mechanism. The
+    // file legitimately uses the `cfg!(debug_assertions)` MACRO for the separate
+    // tier-audit (`cfg!(` form, not `#[cfg(`), so this catches only a
+    // re-introduced compile-out of the counters/guard.
+    let offending: Vec<String> = src
+        .lines()
+        .enumerate()
+        .filter(|(_, l)| {
+            let t = l.trim_start();
+            t.starts_with("#[cfg(debug_assertions)]")
+                || t.starts_with("#[cfg(not(debug_assertions))]")
+        })
+        .map(|(i, l)| format!("  {}: {}", i + 1, l.trim()))
+        .collect();
+    assert!(
+        offending.is_empty(),
+        "#1492-L2: src/sync_audit.rs must NOT `#[cfg(debug_assertions)]`-gate the \
+         self-IPC depth counters / guard — that restores the release no-op blind \
+         spot the daemon froze on. Offending attribute line(s):\n{}",
+        offending.join("\n")
+    );
+
+    // (2) The guard must be fail-fast: return a `Result` (Err on violation), not
+    // panic-or-noop. Pins the L2 contract at the signature level.
+    assert!(
+        src.contains(
+            "pub fn assert_no_registry_lock_for_self_ipc(ctx: &str) -> anyhow::Result<()>"
+        ),
+        "#1492-L2: `assert_no_registry_lock_for_self_ipc` must return \
+         `anyhow::Result<()>` (fail-fast Err on violation), not `()`."
+    );
+}


### PR DESCRIPTION
## Decision

`d-20260531171228817178-0` (deadlock root-fix architecture). This is the **L2 layer** — landed off the impl-feasibility lens (`/tmp/deadlock-arch-dev.md`).

## Problem

The lock-across-self-IPC deadlock class (#1492/#1535) had **only a debug-only guard**: the depth counters + `assert_no_registry_lock_for_self_ipc` compiled to a release **no-op**, so a RELEASE daemon had **zero** protection — a violation froze the whole daemon (the morning-cron class). #1571's L3 timeout is **not yet in main**, so today there is no containment at all. L2 is the first real release-time defense.

## Change

**1. Counters always-on** — drop `#[cfg(debug_assertions)]` from `REGISTRY_LOCK_DEPTH` / `CORE_LOCK_DEPTH` + the `*_lock_entered/exited` fns; delete the 5 release no-op shims. Pure thread-local `Cell` bumps (no atomics, no contention) on control-plane locks → negligible steady-state cost. **Lock call sites unchanged** (already route through `lock_registry*` / `CoreMutex`).

**2. Guard fail-fast** — `assert_no_registry_lock_for_self_ipc` now returns `anyhow::Result<()>`. On a violation it logs at ERROR (named `ctx` site + lock depths) and returns `Err`, in **every build**, so the deadlocking self-IPC is **refused and the daemon stays live** (vs freeze / debug-only panic). The 2 production vectors already return `anyhow::Result` → propagate via `?`, **no signature change**:
- `api::call` (`src/api/mod.rs`)
- `enqueue_with_idle_hint` (`src/inbox/notify.rs`)

The `#[must_use]` `Result` makes ignoring the refusal a **compile error** at any future call site.

**3. Invariant test** (`tests/self_ipc_guard_always_on_invariant_1492.rs`) — pins the counters/guard as always-on (no `#[cfg(debug_assertions)]` attribute) AND the fail-fast `Result` signature, so a future edit can't silently re-open the release blind spot. Mirrors `core_mutex_invariant.rs`.

**4. Test conversions (same commit)** — the 4 should-panic tests that asserted the old debug panic → `assert!(...is_err())` (`sync_audit.rs` ×1 + `agent/tests.rs` ×3). The 2 drop-clears-flag tests → `assert!(...is_ok())` (the `must_use` Result must be consumed; strengthens "no panic" → "returns Ok"). The shared-thread TLS counter is balanced in the nonzero-depth test so it can't leak into a sibling.

## Untouched (separate mechanisms, per dispatch)
The tier-ordering audit (`assert_lock_tier` / router-thread should-panic tests) and the `core_mutex_invariant` grep test.

## Key result (dispatch's question)
Full suite green (**60 test binaries**), and **always-on did NOT trip the guard `Err` in any existing test** → no hidden lock-across-self-IPC violation site remains (the surfaced #1492/#1530/#1535 sites were already fixed via collect→drop→emit).

## Files
- `src/sync_audit.rs` — counters/guard always-on + fail-fast Err
- `src/api/mod.rs`, `src/inbox/notify.rs` — `?` propagation (2 vectors)
- `src/agent/tests.rs`, `src/sync_audit.rs` tests — should-panic→is_err / is_ok
- `tests/self_ipc_guard_always_on_invariant_1492.rs` — new invariant

## Note
Daemon-behavior change → only effective after a **rebuild + daemon restart** (can't dogfood on its own PR; rebuild batch).

## Preflight
`fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · `test --tests --features tray` (60 binaries, 0 failed) ✓ · `xwin check --target x86_64-pc-windows-msvc` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)