### PR TITLE
fix(#1563): default fleet-idle alert recipient to lead, not general

### DIFF
--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -35,8 +35,10 @@
 //! Scans the entire fleet's last_active timestamps. When EVERY
 //! tracked agent has been idle > `fleet_idle_threshold_secs() = 1800`
 //! (30 min) AND at least one agent has had recent activity (i.e.
-//! a sidecar exists), emits an inbox ping to `general` so the
-//! operator-facing aggregator surfaces the fleet stall. The
+//! a sidecar exists), emits an inbox ping to `lead` (#1563; was
+//! `general`) so the orchestrator surfaces / re-dispatches the
+//! fleet stall. Overridable via `AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT`.
+//! The
 //! "at least one tracked" guard distinguishes "fleet really
 //! stalled" from "fleet not yet started" / "all sidecars stale".
 //!
@@ -61,7 +63,8 @@ pub(crate) fn dev_idle_threshold_secs() -> i64 {
 }
 
 /// Lead-spec threshold for the fleet watchdog (vantage #12): every
-/// tracked agent silent > 30 min → ping general. Overridable via runtime-config.json (#1085).
+/// tracked agent silent > 30 min → ping lead (#1563; recipient was `general`).
+/// Threshold overridable via runtime-config.json (#1085).
 pub(crate) fn fleet_idle_threshold_secs() -> i64 {
     crate::runtime_config::get().fleet_idle_threshold_secs
 }
@@ -262,12 +265,23 @@ fn dev_idle_recipient() -> String {
         .unwrap_or_else(|| "lead".to_string())
 }
 
-/// Recipient for fleet-vantage idle alerts. Defaults to `general`.
+/// Recipient for fleet-vantage idle alerts. Defaults to `lead`.
+///
+/// #1563: the default was `general`, which spammed the general assistant with
+/// fleet-idle alerts overnight (it received them as the hardcoded recipient, not
+/// because it was itself forwarded). Fleet-idle is non-critical *coordination*
+/// signal ("the whole fleet is quiet — does work need dispatching?"), so the
+/// right recipient is the orchestrator `lead` — matching the sibling
+/// [`dev_idle_recipient`] default. Delivery to lead's inbox also *wakes* an idle
+/// lead so it can act. Operator-channel routing was deliberately NOT chosen:
+/// per #1339 the human operator must not be pinged for non-P0 signals.
+/// `AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT` still overrides (e.g. a mode-aware
+/// recipient under a future sleep mode).
 fn fleet_idle_recipient() -> String {
     std::env::var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT")
         .ok()
         .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "general".to_string())
+        .unwrap_or_else(|| "lead".to_string())
 }
 
 /// Pure scan logic: detects + emits idle alerts at both vantages.
@@ -816,9 +830,19 @@ mod tests {
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
         let lead = crate::inbox::drain(&home, "lead");
-        assert_eq!(lead.len(), 1, "lead must receive idle alert: {lead:?}");
-        assert_eq!(lead[0].kind.as_deref(), Some("dev_idle_watchdog"));
-        assert!(lead[0].text.contains("dev"));
+        // #1563: the fleet recipient now also defaults to `lead`, so a
+        // single-agent idle fleet co-fires a `fleet_idle_watchdog` alert here
+        // too. Assert the DEV vantage specifically (filter by kind), not total.
+        let dev_alerts: Vec<_> = lead
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dev_idle_watchdog"))
+            .collect();
+        assert_eq!(
+            dev_alerts.len(),
+            1,
+            "lead must receive one dev idle alert: {lead:?}"
+        );
+        assert!(dev_alerts[0].text.contains("dev"));
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -871,9 +895,14 @@ mod tests {
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
         let lead = crate::inbox::drain(&home, "lead");
+        // #1563: assert the DEV vantage specifically — a `fleet_idle_watchdog`
+        // alert may co-land on `lead` (the agent is past the shorter fleet
+        // threshold), which is a separate vantage this test does not exercise.
         assert!(
-            lead.is_empty(),
-            "active dev must NOT trigger alert: {lead:?}"
+            !lead
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("dev_idle_watchdog")),
+            "active dev (within dev window) must NOT trigger a dev idle alert: {lead:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -890,7 +919,15 @@ mod tests {
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
         let after_first = crate::inbox::drain(&home, "lead");
-        assert_eq!(after_first.len(), 1, "first scan alerts");
+        // #1563: filter the DEV vantage (fleet_idle co-fires to lead now).
+        assert_eq!(
+            after_first
+                .iter()
+                .filter(|m| m.kind.as_deref() == Some("dev_idle_watchdog"))
+                .count(),
+            1,
+            "first scan alerts (dev vantage)"
+        );
         // Touch activity (simulate dev resuming work).
         touch_agent_activity(&home, "dev");
         // Second scan: dev fresh → no alert.
@@ -925,12 +962,12 @@ mod tests {
         write_activity_at(&home, "reviewer", stale_reviewer);
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            general
+            recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "general must receive fleet alert: {general:?}"
+            "lead (#1563 default fleet recipient) must receive fleet alert: {recipient:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -954,12 +991,12 @@ mod tests {
         write_activity_at(&home, "general", recent);
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            !general
+            !recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "fleet partial-activity must NOT trigger fleet alert: {general:?}"
+            "fleet partial-activity must NOT trigger fleet alert: {recipient:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -980,8 +1017,8 @@ mod tests {
         write_activity_at(&home, "lead", stale);
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
-        let fleet_msg = general
+        let recipient = crate::inbox::drain(&home, "lead");
+        let fleet_msg = recipient
             .iter()
             .find(|m| m.kind.as_deref() == Some("fleet_idle_watchdog"))
             .expect("fleet alert");
@@ -1049,7 +1086,15 @@ mod tests {
         scan_and_emit(&home, &mut last_alerted);
         scan_and_emit(&home, &mut last_alerted);
         let lead = crate::inbox::drain(&home, "lead");
-        assert_eq!(lead.len(), 1, "second scan must be deduped: {lead:?}");
+        // #1563: filter the DEV vantage (fleet_idle co-fires to lead now); the
+        // dedup contract is per-vantage → exactly one dev alert across 2 scans.
+        assert_eq!(
+            lead.iter()
+                .filter(|m| m.kind.as_deref() == Some("dev_idle_watchdog"))
+                .count(),
+            1,
+            "second scan must be deduped (dev vantage): {lead:?}"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -1064,8 +1109,8 @@ mod tests {
         let home = tmp_home("fleet-empty");
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
-        assert!(general.is_empty(), "empty fleet must not alert");
+        let recipient = crate::inbox::drain(&home, "lead");
+        assert!(recipient.is_empty(), "empty fleet must not alert");
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -1096,6 +1141,23 @@ mod tests {
         let r = dev_idle_recipient();
         std::env::remove_var("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT");
         assert_eq!(r, "alice");
+    }
+
+    /// #1563: unset → `lead` (was `general`, which spammed the general
+    /// assistant with fleet-idle alerts overnight); a set env value is honored.
+    #[test]
+    fn fleet_idle_recipient_defaults_to_lead_and_honors_env_override() {
+        let _g = env_lock();
+        std::env::remove_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT");
+        assert_eq!(
+            fleet_idle_recipient(),
+            "lead",
+            "#1563: fleet-idle default recipient must be lead, not general"
+        );
+        std::env::set_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT", "ops-bot");
+        let overridden = fleet_idle_recipient();
+        std::env::remove_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT");
+        assert_eq!(overridden, "ops-bot", "env override must be honored");
     }
 
     // ── #1022 ghost-agent cleanup tests ───────────────────────────
@@ -1177,8 +1239,8 @@ mod tests {
         write_activity_at(&home, "conflict-test-1", stale);
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
-        let fleet_msg = general
+        let recipient = crate::inbox::drain(&home, "lead");
+        let fleet_msg = recipient
             .iter()
             .find(|m| m.kind.as_deref() == Some("fleet_idle_watchdog"))
             .expect("fleet alert must fire for stale live agents");
@@ -1219,12 +1281,12 @@ mod tests {
         snooze_fleet_idle(&home, until, "test").unwrap();
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            !general
+            !recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "#1084: snoozed fleet must NOT emit alert: {general:?}"
+            "#1084: snoozed fleet must NOT emit alert: {recipient:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1243,12 +1305,12 @@ mod tests {
         snooze_fleet_idle(&home, past, "test").unwrap();
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            general
+            recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "#1084: expired snooze must resume alerting: {general:?}"
+            "#1084: expired snooze must resume alerting: {recipient:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1307,12 +1369,12 @@ mod tests {
         write_activity_at(&home, "ghost-2", stale);
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            !general
+            !recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "active live agent + stale ghosts must NOT trigger fleet alert: {general:?}"
+            "active live agent + stale ghosts must NOT trigger fleet alert: {recipient:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1332,12 +1394,12 @@ mod tests {
         ack_fleet_idle();
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            !general
+            !recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "acked fleet idle must NOT trigger alert: {general:?}"
+            "acked fleet idle must NOT trigger alert: {recipient:?}"
         );
         clear_fleet_ack();
         std::fs::remove_dir_all(&home).ok();
@@ -1367,12 +1429,12 @@ mod tests {
         advance_task(&home, "t-resume", "dev");
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            general
+            recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "post-ack board progress + still-idle agents must trigger alert: {general:?}"
+            "post-ack board progress + still-idle agents must trigger alert: {recipient:?}"
         );
         assert_eq!(
             FLEET_ACKED_AT.load(Ordering::Relaxed),
@@ -1406,12 +1468,12 @@ mod tests {
         write_activity_at(&home, "general", post_ack);
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            !general
+            !recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "on-demand chatter must NOT wash the ack / re-fire alert: {general:?}"
+            "on-demand chatter must NOT wash the ack / re-fire alert: {recipient:?}"
         );
         assert_ne!(
             FLEET_ACKED_AT.load(Ordering::Relaxed),
@@ -1510,12 +1572,12 @@ mod tests {
         .unwrap();
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            !general
+            !recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "all-done board must not fire fleet idle alert: {general:?}"
+            "all-done board must not fire fleet idle alert: {recipient:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1555,12 +1617,12 @@ mod tests {
         std::fs::write(home.join("task_events.jsonl"), "").unwrap();
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            !general
+            !recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "#1141: fleet idle must be suppressed when no work expected: {general:?}"
+            "#1141: fleet idle must be suppressed when no work expected: {recipient:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1598,12 +1660,12 @@ mod tests {
         .unwrap();
         let mut last_alerted = HashMap::new();
         scan_and_emit(&home, &mut last_alerted);
-        let general = crate::inbox::drain(&home, "general");
+        let recipient = crate::inbox::drain(&home, "lead");
         assert!(
-            general
+            recipient
                 .iter()
                 .any(|m| m.kind.as_deref() == Some("fleet_idle_watchdog")),
-            "#1141: fleet idle must fire when open tasks exist: {general:?}"
+            "#1141: fleet idle must fire when open tasks exist: {recipient:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }


### PR DESCRIPTION
## Problem (#1563 deferred follow-up — general-recipient-rewire)

The fleet idle watchdog's recipient defaulted to the hardcoded `"general"` (`fleet_idle_recipient()`, `src/daemon/idle_watchdog.rs`), so the **general assistant received every fleet-idle alert overnight** — noise, *not* because it was being forwarded, but because it was the hardcoded sink.

## Fix (per lead's design decision)

Fleet-idle is **non-critical coordination signal** ("the whole fleet is quiet — does work need dispatching?"), whose right recipient is the orchestrator **`lead`**:

- `fleet_idle_recipient()` default `"general"` → `"lead"`, mirroring the sibling `dev_idle_recipient()` default. The `AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT` env override (already present) is unchanged.
- **Operator-channel routing was deliberately NOT chosen** — per #1339 the human operator must not be pinged for non-P0 signals; inbox delivery to lead also *wakes* an idle lead so it can act on the stall.
- Updated the module/threshold doc comments that described the old "ping general" recipient.

## Investigation finding
The env var **already existed** — only the default was wrong. No fleet.yaml schema change needed (smallest fix aligned with the existing config convention).

## Tests
- **New** `fleet_idle_recipient_defaults_to_lead_and_honors_env_override`: unset → `lead`; env-set → honored.
- The **14 fleet-vantage tests** that drained the default-recipient mailbox: `general` → `lead`.
- The **4 dev-vantage tests** that asserted a *total* alert count on `lead` now **filter by `kind == "dev_idle_watchdog"`**. Rationale: the fleet recipient now also defaults to `lead`, so a single-/all-idle scenario legitimately co-fires a `fleet_idle_watchdog` alert to lead too. Each dev test now asserts its own vantage specifically — the established `dev_watchdog_exempts_team_orchestrator` filter-by-kind pattern. (This co-fire is pre-existing behavior; previously the fleet alert just went to `general` and was invisible to the lead-drain.)

## Scope
Behavior change isolated to one file (`idle_watchdog.rs`). Daemon-behavior fix → effective after **rebuild + restart**.

## Preflight
`fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · `test --tests --features tray` (60 binaries, 0 failed) ✓ · `xwin check --target x86_64-pc-windows-msvc` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)