### PR TITLE
feat(#1339): Operator Mode MVP — authority gate (PR-1: store + gate + tool)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,6 +16,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 mod handlers;
+mod operator_gate;
 pub mod request_dedup;
 
 pub type ConfigRegistry = Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>>;
@@ -476,51 +477,63 @@ fn handle_session(
             home,
         };
 
-        let response = request_dedup::global().dispatch(
-            request_id,
-            request_dedup::method_wait_timeout(method, params),
-            || match method {
-                method::LIST => handlers::query::handle_list(params, &ctx),
-                method::INJECT => handlers::instance::handle_inject(params, &ctx),
-                method::KILL => handlers::instance::handle_kill(params, &ctx),
-                method::DELETE => handlers::instance::handle_delete(params, &ctx),
-                method::SPAWN => handlers::instance::handle_spawn(params, &ctx),
-                method::SEND => handlers::messaging::handle_send(params, &ctx),
-                method::STATUS => handlers::query::handle_status(params, &ctx),
-                method::REGISTER_EXTERNAL => {
-                    handlers::external::handle_register_external(params, &ctx)
-                }
-                method::DEREGISTER_EXTERNAL => {
-                    handlers::external::handle_deregister_external(params, &ctx)
-                }
-                method::CREATE_TEAM => handlers::team::handle_create_team(params, &ctx),
-                method::UPDATE_TEAM => handlers::team::handle_update_team(params, &ctx),
-                method::MOVE_PANE => handlers::instance::handle_move_pane(params, &ctx),
-                method::PANE_SNAPSHOT => handlers::instance::handle_pane_snapshot(params, &ctx),
-                method::TUI_SCREENSHOT => handlers::instance::handle_tui_screenshot(&ctx),
-                method::VERIFY_PUSH => handlers::verify_push::handle_verify_push(params),
-                method::SET_BLOCKED_REASON => {
-                    handlers::instance::handle_set_blocked_reason(params, &ctx)
-                }
-                method::CLEAR_BLOCKED_REASON => {
-                    handlers::instance::handle_clear_blocked_reason(params, &ctx)
-                }
-                method::MCP_TOOL => handlers::mcp_proxy::handle_mcp_tool(params, &ctx),
-                method::MCP_TOOLS_LIST => handlers::mcp_proxy::handle_mcp_tools_list(params, &ctx),
-                method::SHUTDOWN => {
-                    tracing::info!("API shutdown requested");
-                    // Sprint 57 Wave 3 PR-2 (#548 Q6): record API-shutdown
-                    // reason BEFORE flipping the flag so the shutdown
-                    // sequence sees the right taxonomy when it reads.
-                    crate::daemon::record_shutdown_reason(
-                        crate::daemon::ShutdownReason::ApiShutdown,
-                    );
-                    shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
-                    json!({"ok": true})
-                }
-                _ => json!({"ok": false, "error": format!("unknown method: {method}")}),
-            },
-        );
+        // #1339: single operator-mode authority gate. Covers every direct method
+        // AND the `mcp_tool` tunnel (all 36 tools) at the one ingress choke point.
+        // Operator-surface calls (no `instance`) are never denied; Active is a
+        // passthrough. A deny short-circuits before dispatch.
+        let response = if let Err(denied) =
+            operator_gate::check_operation_allowed(method, params, &crate::operator_mode::get())
+        {
+            json!({"ok": false, "error": denied, "denied_by": "operator_mode", "queued": true})
+        } else {
+            request_dedup::global().dispatch(
+                request_id,
+                request_dedup::method_wait_timeout(method, params),
+                || match method {
+                    method::LIST => handlers::query::handle_list(params, &ctx),
+                    method::INJECT => handlers::instance::handle_inject(params, &ctx),
+                    method::KILL => handlers::instance::handle_kill(params, &ctx),
+                    method::DELETE => handlers::instance::handle_delete(params, &ctx),
+                    method::SPAWN => handlers::instance::handle_spawn(params, &ctx),
+                    method::SEND => handlers::messaging::handle_send(params, &ctx),
+                    method::STATUS => handlers::query::handle_status(params, &ctx),
+                    method::REGISTER_EXTERNAL => {
+                        handlers::external::handle_register_external(params, &ctx)
+                    }
+                    method::DEREGISTER_EXTERNAL => {
+                        handlers::external::handle_deregister_external(params, &ctx)
+                    }
+                    method::CREATE_TEAM => handlers::team::handle_create_team(params, &ctx),
+                    method::UPDATE_TEAM => handlers::team::handle_update_team(params, &ctx),
+                    method::MOVE_PANE => handlers::instance::handle_move_pane(params, &ctx),
+                    method::PANE_SNAPSHOT => handlers::instance::handle_pane_snapshot(params, &ctx),
+                    method::TUI_SCREENSHOT => handlers::instance::handle_tui_screenshot(&ctx),
+                    method::VERIFY_PUSH => handlers::verify_push::handle_verify_push(params),
+                    method::SET_BLOCKED_REASON => {
+                        handlers::instance::handle_set_blocked_reason(params, &ctx)
+                    }
+                    method::CLEAR_BLOCKED_REASON => {
+                        handlers::instance::handle_clear_blocked_reason(params, &ctx)
+                    }
+                    method::MCP_TOOL => handlers::mcp_proxy::handle_mcp_tool(params, &ctx),
+                    method::MCP_TOOLS_LIST => {
+                        handlers::mcp_proxy::handle_mcp_tools_list(params, &ctx)
+                    }
+                    method::SHUTDOWN => {
+                        tracing::info!("API shutdown requested");
+                        // Sprint 57 Wave 3 PR-2 (#548 Q6): record API-shutdown
+                        // reason BEFORE flipping the flag so the shutdown
+                        // sequence sees the right taxonomy when it reads.
+                        crate::daemon::record_shutdown_reason(
+                            crate::daemon::ShutdownReason::ApiShutdown,
+                        );
+                        shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
+                        json!({"ok": true})
+                    }
+                    _ => json!({"ok": false, "error": format!("unknown method: {method}")}),
+                },
+            )
+        };
 
         let _ = writeln!(writer, "{}", response);
         let _ = writer.flush();

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -193,6 +193,10 @@ pub mod method {
     pub const UPDATE_TEAM: &str = "update_team";
     pub const MOVE_PANE: &str = "move_pane";
     pub const SHUTDOWN: &str = "shutdown";
+    /// #1339: operator-only mode control. A DIRECT method (not the `mcp_tool`
+    /// tunnel) → the operator_gate treats it as the operator transport, so only
+    /// the operator CLI can reach it; agents (mcp_tool-only) cannot.
+    pub const MODE: &str = "mode";
     pub const SET_BLOCKED_REASON: &str = "set_blocked_reason";
     pub const CLEAR_BLOCKED_REASON: &str = "clear_blocked_reason";
     pub const MCP_TOOL: &str = "mcp_tool";
@@ -519,6 +523,8 @@ fn handle_session(
                     method::MCP_TOOLS_LIST => {
                         handlers::mcp_proxy::handle_mcp_tools_list(params, &ctx)
                     }
+                    // #1339: operator-only mode control (operator transport).
+                    method::MODE => operator_gate::handle_mode_set(params, home),
                     method::SHUTDOWN => {
                         tracing::info!("API shutdown requested");
                         // Sprint 57 Wave 3 PR-2 (#548 Q6): record API-shutdown

--- a/src/api/operator_gate.rs
+++ b/src/api/operator_gate.rs
@@ -3,6 +3,21 @@
 //! so it covers every direct API method AND the `mcp_tool` tunnel (which
 //! carries all 36 MCP tools through one arm).
 //!
+//! ## Scope — this gate governs SOCKET-INGRESS principals only.
+//! It classifies the two principals that arrive over the API socket: the
+//! **operator transport** (direct methods / CLI — full authority) and the
+//! **agent transport** (`mcp_tool` — gated). There is a THIRD principal it does
+//! NOT (and must not) see: **daemon-autonomic self-heal** — crash-respawn
+//! (`daemon::crash_respawn`), hang-recovery restart
+//! (`daemon::per_tick::recovery_dispatcher`), and merged-branch worktree release
+//! (`daemon::auto_release`). Those run in the per-tick daemon loop and call
+//! lifecycle directly; they never traverse this socket, so they are gate-exempt
+//! BY CONSTRUCTION (not by an exception here). They are trusted internal,
+//! triggered only by internal events (process exit / hang detection / merge
+//! detection) and are not agent-invocable — so the fleet keeps self-healing even
+//! while the operator is away/asleep. See the gate-exempt markers on those entry
+//! points.
+//!
 //! Security invariants (pinned by tests below):
 //!  1. **Operator-ness is proven by TRANSPORT, never by the payload.** The agent
 //!     MCP bridge only ever sends `mcp_tool`/`mcp_tools_list`; every other
@@ -35,8 +50,13 @@ pub(crate) enum OpClass {
     /// `delegate_scope` (deny-by-default). Also the **fail-closed default** for
     /// any op not explicitly classified.
     DelegateScoped,
-    /// Structural / authority-changing — blocked for agents in Away/Sleep with
-    /// NO delegate escape (the never-delegate set).
+    /// Structural / authority-changing — blocked for an AGENT/DELEGATE-INITIATED
+    /// request (over the `mcp_tool` socket transport) in Away/Sleep, with NO
+    /// delegate escape (the never-delegate set). NOTE: this label is about
+    /// socket-ingress agent ops ONLY — it does NOT mean the mutation never
+    /// happens in Away/Sleep: daemon-autonomic self-heal (crash-respawn,
+    /// hang-recovery restart, merged-branch release) may still perform the same
+    /// structural change, gate-exempt by construction (see the module scope note).
     AbsolutelyNever,
 }
 
@@ -180,6 +200,46 @@ pub(crate) fn check_operation_allowed(
                 }
             }
         },
+    }
+}
+
+/// #1339: handler for the operator-only `MODE` direct method. Reached only via
+/// the operator transport (a direct API method; the gate lets direct methods
+/// through as the operator surface, and agents can only send `mcp_tool`). This
+/// is the AUTHORITATIVE mode-set path: an agent overwriting `operator-mode.json`
+/// is governed by the same operator-owned-config convention as
+/// `runtime-config.json` / `fleet.yaml` (raw-FS integrity is a fleet-wide
+/// follow-up, out of #1339 scope).
+pub(crate) fn handle_mode_set(params: &Value, home: &std::path::Path) -> Value {
+    use serde_json::json;
+    let Some(mode_str) = params.get("mode").and_then(Value::as_str) else {
+        return json!({"ok": false, "error": "mode requires `mode` (active|away|sleep)"});
+    };
+    let mode = match crate::operator_mode::parse_mode(mode_str) {
+        Ok(m) => m,
+        Err(e) => return json!({"ok": false, "error": e}),
+    };
+    let delegate_to = params
+        .get("delegate")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let delegate_scope: Vec<String> = params
+        .get("scope")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    match crate::operator_mode::set_mode(home, mode, delegate_to, delegate_scope) {
+        Ok(s) => json!({
+            "ok": true,
+            "mode": s.mode,
+            "delegate_to": s.delegate_to,
+            "delegate_scope": s.delegate_scope,
+        }),
+        Err(e) => json!({"ok": false, "error": e}),
     }
 }
 
@@ -405,6 +465,71 @@ mod tests {
                 check_operation_allowed("mcp_tool", &mcp_action(tool, action, "dev-2"), &away())
                     .is_ok(),
                 "{tool}/{action} read action must stay allowed in away"
+            );
+        }
+    }
+
+    // ── mode-control: the operator's `MODE` direct method passes the gate (it is
+    // the operator transport — NOT mcp_tool), even in sleep, with NO instance. ──
+    #[test]
+    fn operator_direct_mode_method_passes_gate_in_any_mode() {
+        let params = json!({"mode": "active"});
+        for st in [
+            OperatorModeState::default(),
+            away(),
+            sleep_with("fixup-lead", &[]),
+        ] {
+            assert!(
+                check_operation_allowed(super::super::method::MODE, &params, &st).is_ok(),
+                "direct MODE method is operator transport → allowed in {:?}",
+                st.mode
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn handle_mode_set_persists_and_updates_global() {
+        let dir = std::env::temp_dir().join(format!("agend-modeset-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let resp = handle_mode_set(
+            &json!({"mode": "sleep", "delegate": "fixup-lead", "scope": ["custom_op"]}),
+            &dir,
+        );
+        assert_eq!(resp["ok"], json!(true));
+        // The global (what the gate reads) reflects it immediately.
+        let s = crate::operator_mode::get();
+        assert_eq!(s.mode, OperatorMode::Sleep);
+        assert_eq!(s.delegate_to.as_deref(), Some("fixup-lead"));
+        // Bad mode string → error, no change.
+        assert_eq!(
+            handle_mode_set(&json!({"mode": "dnd"}), &dir)["ok"],
+            json!(false)
+        );
+        // Reset global so we don't leak Sleep into other tests.
+        crate::operator_mode::set_mode(&dir, OperatorMode::Active, None, vec![]).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── ② invariant: the daemon-autonomic self-heal paths are gate-exempt BY
+    // CONSTRUCTION — they must NOT reference the gate, and must carry the marker. ──
+    #[test]
+    fn autonomic_paths_are_gate_exempt_by_construction() {
+        let root = env!("CARGO_MANIFEST_DIR");
+        for rel in [
+            "src/daemon/crash_respawn.rs",
+            "src/daemon/auto_release.rs",
+            "src/daemon/per_tick/recovery_dispatcher.rs",
+        ] {
+            let src = std::fs::read_to_string(format!("{root}/{rel}")).expect(rel);
+            assert!(
+                !src.contains("check_operation_allowed"),
+                "{rel} must NOT call the operator-mode gate (gate-exempt by construction)"
+            );
+            assert!(
+                src.contains("DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN"),
+                "{rel} must carry the #1339 gate-exempt marker"
             );
         }
     }

--- a/src/api/operator_gate.rs
+++ b/src/api/operator_gate.rs
@@ -1,0 +1,329 @@
+//! #1339: Operator-mode authority gate — the SINGLE API-ingress enforcement
+//! point. Called once in the dispatch path (`api::serve`), before any handler,
+//! so it covers every direct API method AND the `mcp_tool` tunnel (which
+//! carries all 36 MCP tools through one arm).
+//!
+//! Security invariants (pinned by tests below):
+//!  1. **Operator is never locked out.** A request with no `instance` identity
+//!     (operator TUI/CLI/Telegram surface) is ALWAYS allowed — a false deny of
+//!     the operator is worse than an over-permissive edge.
+//!  2. **Active = today's behavior** (zero migration): every operation allowed.
+//!  3. The gate decodes the **inner** tool (`params["tool"]`) for the `mcp_tool`
+//!     method, never the outer `"mcp_tool"` string (else all tools look alike).
+//!  4. **Never-delegate** (structural / authority-changing) ops are blocked for
+//!     agents in Away/Sleep — even in Sleep with a full `delegate_scope`.
+//!  5. **Fail-closed**: an unmapped / newly-added op defaults to the
+//!     delegate-scoped (deny-by-default in Away/Sleep) class, so taxonomy drift
+//!     can never silently land a new mutation as "allowed".
+
+use crate::operator_mode::{OperatorMode, OperatorModeState};
+use serde_json::Value;
+
+/// Authority class of an operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OpClass {
+    /// Read-only or fleet-normal (inter-agent coordination) — never gated, so
+    /// the fleet keeps operating in every mode.
+    AlwaysAllow,
+    /// Operator-authority op a delegate MAY proxy in Sleep within
+    /// `delegate_scope` (deny-by-default). Also the **fail-closed default** for
+    /// any op not explicitly classified.
+    DelegateScoped,
+    /// Structural / authority-changing — blocked for agents in Away/Sleep with
+    /// NO delegate escape (the never-delegate set).
+    AbsolutelyNever,
+}
+
+/// Classify an operation by its decoded name (`op`) and optional sub-`action`
+/// (for action-bearing tools like `team` / `repo` / `schedule` / `config`).
+/// `op` is the inner MCP tool name, or — for direct API methods — the method
+/// constant string (`spawn`/`delete`/…). Unmapped → `DelegateScoped` (fail-closed).
+pub(crate) fn classify(op: &str, action: Option<&str>) -> OpClass {
+    use OpClass::*;
+    match op {
+        // ── Read-only + fleet-normal coordination: never gated ──
+        "list_instances" | "binding_state" | "tokens" | "pane_snapshot"
+        | "tui_screenshot" | "gc_dry_run" | "health" | "download_attachment"
+        | "inbox" | "send" | "task" | "reply" | "decision" | "set_waiting_on"
+        | "interrupt" | "bind_self" | "set_description" | "set_display_name"
+        | "watchdog" | "ci"
+        // direct API read / normal methods
+        | "list" | "inject" | "status" | "register_external"
+        | "deregister_external" | "mcp_tools_list" | "set_blocked_reason"
+        | "clear_blocked_reason" | "verify_push" => AlwaysAllow,
+
+        // ── Action-bearing tools: read actions allow, mutating actions never ──
+        "mode" => match action {
+            Some("get") | None => AlwaysAllow,
+            _ => AbsolutelyNever, // an agent must not flip operator authority
+        },
+        "config" => match action {
+            Some("set") => AbsolutelyNever,
+            _ => AlwaysAllow, // list / get
+        },
+        "schedule" => match action {
+            Some("create") | Some("delete") => AbsolutelyNever,
+            _ => AlwaysAllow, // list / update / run
+        },
+        "team" => match action {
+            Some("create") | Some("delete") | Some("update") => AbsolutelyNever,
+            _ => AlwaysAllow, // list
+        },
+        "deployment" => match action {
+            Some("deploy") | Some("teardown") => AbsolutelyNever,
+            _ => AlwaysAllow, // list
+        },
+        // repo mount/release/merge are all structural / merge-to-main.
+        "repo" => AbsolutelyNever,
+
+        // ── Structural lifecycle / daemon control: never-delegate ──
+        "create_instance" | "delete_instance" | "replace_instance"
+        | "restart_instance" | "start_instance" | "restart_daemon"
+        | "force_release_worktree" | "release_worktree" | "move_pane"
+        // direct API peers
+        | "spawn" | "delete" | "kill" | "shutdown" | "create_team"
+        | "update_team" => AbsolutelyNever,
+
+        // ── Unknown / newly-added op → fail-closed (deny-if-structural). ──
+        _ => DelegateScoped,
+    }
+}
+
+/// Decide whether `method` (+ `params`) is allowed under the current
+/// `state`. `Ok(())` = allowed; `Err(reason)` = denied (caller returns the
+/// reason to the requester). Pure — no I/O, fully unit-testable.
+pub(crate) fn check_operation_allowed(
+    method: &str,
+    params: &Value,
+    state: &OperatorModeState,
+) -> Result<(), String> {
+    // Decode op + sub-action + caller identity. For the MCP tunnel the real op
+    // is the INNER tool, not the outer "mcp_tool" method (invariant 3).
+    let (op, action, caller) = if method == super::method::MCP_TOOL {
+        (
+            params.get("tool").and_then(Value::as_str).unwrap_or(""),
+            params
+                .get("arguments")
+                .and_then(|a| a.get("action"))
+                .and_then(Value::as_str),
+            params.get("instance").and_then(Value::as_str).unwrap_or(""),
+        )
+    } else {
+        (
+            method,
+            None,
+            params.get("instance").and_then(Value::as_str).unwrap_or(""),
+        )
+    };
+
+    // Invariant 1 (TOP): operator / operator-surface (no instance) → never deny.
+    if caller.is_empty() {
+        return Ok(());
+    }
+    // Invariant 2: Active = today's behavior.
+    if state.mode == OperatorMode::Active {
+        return Ok(());
+    }
+
+    // An agent caller while the operator is Away or Sleep.
+    match classify(op, action) {
+        OpClass::AlwaysAllow => Ok(()),
+        OpClass::AbsolutelyNever => Err(format!(
+            "operation '{op}' is blocked (never-delegate structural/authority op) \
+             while the operator is {:?}",
+            state.mode
+        )),
+        OpClass::DelegateScoped => match state.mode {
+            // Active handled above; listed for exhaustiveness.
+            OperatorMode::Active => Ok(()),
+            OperatorMode::Away => Err(format!(
+                "operation '{op}' is blocked while the operator is away \
+                 (no delegate); queued for the operator"
+            )),
+            OperatorMode::Sleep => {
+                let is_delegate = state.delegate_to.as_deref() == Some(caller);
+                let in_scope = state.delegate_scope.iter().any(|s| s == op);
+                if is_delegate && in_scope {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "operation '{op}' is outside the delegate scope \
+                         (operator asleep; delegate={:?})",
+                        state.delegate_to
+                    ))
+                }
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sleep_with(delegate: &str, scope: &[&str]) -> OperatorModeState {
+        OperatorModeState {
+            mode: OperatorMode::Sleep,
+            delegate_to: Some(delegate.to_string()),
+            delegate_scope: scope.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+    fn away() -> OperatorModeState {
+        OperatorModeState {
+            mode: OperatorMode::Away,
+            ..Default::default()
+        }
+    }
+    fn mcp(tool: &str, instance: &str) -> Value {
+        json!({"tool": tool, "instance": instance, "arguments": {}})
+    }
+    fn mcp_action(tool: &str, action: &str, instance: &str) -> Value {
+        json!({"tool": tool, "instance": instance, "arguments": {"action": action}})
+    }
+
+    // ── MUST-PIN 1: operator lock-out — no-instance identity is NEVER denied ──
+    #[test]
+    fn operator_no_instance_is_never_denied_even_for_structural_in_sleep() {
+        let st = sleep_with("fixup-lead", &[]);
+        // mcp_tool create_instance with NO instance (operator surface) → allow.
+        assert!(check_operation_allowed("mcp_tool", &mcp("create_instance", ""), &st).is_ok());
+        // direct dangerous method, no instance (operator TUI) → allow.
+        assert!(check_operation_allowed("delete", &json!({}), &st).is_ok());
+        assert!(check_operation_allowed("shutdown", &json!({}), &st).is_ok());
+    }
+
+    // ── MUST-PIN 2: mcp_tool decodes the INNER tool, not the outer method ──
+    #[test]
+    fn mcp_tool_classifies_inner_tool_not_outer_method() {
+        let st = away();
+        // Inner = create_instance (structural) → denied.
+        let denied = check_operation_allowed("mcp_tool", &mcp("create_instance", "dev-2"), &st);
+        assert!(denied.is_err(), "inner structural tool must be denied");
+        assert!(denied.unwrap_err().contains("create_instance"));
+        // Inner = send (fleet-normal) → allowed even in away.
+        assert!(check_operation_allowed("mcp_tool", &mcp("send", "dev-2"), &st).is_ok());
+    }
+
+    // ── MUST-PIN 3: fail-closed — unmapped op denied for agents in away/sleep ──
+    #[test]
+    fn unknown_op_is_fail_closed_for_agents() {
+        assert!(
+            check_operation_allowed("mcp_tool", &mcp("frobnicate_widgets", "dev-2"), &away())
+                .is_err(),
+            "an unmapped tool must default to deny (fail-closed) in away"
+        );
+        // ...but the operator (no instance) is still never denied.
+        assert!(
+            check_operation_allowed("mcp_tool", &mcp("frobnicate_widgets", ""), &away()).is_ok()
+        );
+    }
+
+    // ── MUST-PIN 4: taxonomy-drift invariant — the dangerous set is AbsolutelyNever,
+    // and a new/unknown op defaults deny-if-structural (DelegateScoped). ──
+    #[test]
+    fn taxonomy_never_delegate_set_and_drift_default() {
+        for op in [
+            "create_instance",
+            "delete_instance",
+            "replace_instance",
+            "restart_instance",
+            "restart_daemon",
+            "force_release_worktree",
+            "move_pane",
+            "spawn",
+            "delete",
+            "kill",
+            "shutdown",
+            "create_team",
+            "update_team",
+            "repo",
+        ] {
+            assert_eq!(
+                classify(op, None),
+                OpClass::AbsolutelyNever,
+                "{op} must be never-delegate"
+            );
+        }
+        for (tool, action) in [
+            ("team", "create"),
+            ("team", "delete"),
+            ("schedule", "create"),
+            ("schedule", "delete"),
+            ("config", "set"),
+            ("deployment", "deploy"),
+            ("mode", "set"),
+        ] {
+            assert_eq!(
+                classify(tool, Some(action)),
+                OpClass::AbsolutelyNever,
+                "{tool}/{action} must be never-delegate"
+            );
+        }
+        // New/unknown op → fail-closed default.
+        assert_eq!(
+            classify("some_new_tool_2099", None),
+            OpClass::DelegateScoped
+        );
+        // Fleet-normal stays allowed.
+        for op in ["send", "task", "inbox", "list_instances", "tokens"] {
+            assert_eq!(classify(op, None), OpClass::AlwaysAllow, "{op}");
+        }
+    }
+
+    // ── MUST-PIN 5 (gate half): never-delegate blocked even sleep+full-scope;
+    // delegate-scope deny-by-default; active = passthrough. (Store reload-
+    // coherence is pinned in operator_mode.rs::set_mode_then_reload_is_coherent.) ──
+    #[test]
+    fn never_delegate_blocked_even_sleep_full_scope() {
+        // Sleep, the caller IS the delegate, scope lists the op — still blocked,
+        // because create_instance is AbsolutelyNever.
+        let st = sleep_with("fixup-lead", &["create_instance", "restart_daemon"]);
+        assert!(
+            check_operation_allowed("mcp_tool", &mcp("create_instance", "fixup-lead"), &st)
+                .is_err(),
+            "never-delegate op blocked even for the delegate with it in scope"
+        );
+    }
+
+    #[test]
+    fn delegate_scope_deny_by_default_and_in_scope_allow() {
+        // An unmapped (DelegateScoped) op: allowed ONLY for the delegate with the
+        // op in scope; denied otherwise.
+        let st = sleep_with("fixup-lead", &["custom_op"]);
+        assert!(
+            check_operation_allowed("mcp_tool", &mcp("custom_op", "fixup-lead"), &st).is_ok(),
+            "delegate + in-scope → allow"
+        );
+        assert!(
+            check_operation_allowed("mcp_tool", &mcp("custom_op", "dev-2"), &st).is_err(),
+            "non-delegate caller → deny even if op in scope"
+        );
+        assert!(
+            check_operation_allowed("mcp_tool", &mcp("other_op", "fixup-lead"), &st).is_err(),
+            "delegate but op not in scope → deny-by-default"
+        );
+    }
+
+    #[test]
+    fn active_is_passthrough_for_everything() {
+        let st = OperatorModeState::default(); // Active
+        assert!(
+            check_operation_allowed("mcp_tool", &mcp("create_instance", "dev-2"), &st).is_ok(),
+            "active mode = today's behavior, agent structural op allowed"
+        );
+    }
+
+    #[test]
+    fn action_bearing_read_actions_allowed_in_away() {
+        // team list / schedule list / config get are read-side → allowed.
+        for (tool, action) in [("team", "list"), ("schedule", "list"), ("config", "get")] {
+            assert!(
+                check_operation_allowed("mcp_tool", &mcp_action(tool, action, "dev-2"), &away())
+                    .is_ok(),
+                "{tool}/{action} read action must stay allowed in away"
+            );
+        }
+    }
+}

--- a/src/api/operator_gate.rs
+++ b/src/api/operator_gate.rs
@@ -4,17 +4,23 @@
 //! carries all 36 MCP tools through one arm).
 //!
 //! Security invariants (pinned by tests below):
-//!  1. **Operator is never locked out.** A request with no `instance` identity
-//!     (operator TUI/CLI/Telegram surface) is ALWAYS allowed — a false deny of
-//!     the operator is worse than an over-permissive edge.
-//!  2. **Active = today's behavior** (zero migration): every operation allowed.
+//!  1. **Operator-ness is proven by TRANSPORT, never by the payload.** The agent
+//!     MCP bridge only ever sends `mcp_tool`/`mcp_tools_list`; every other
+//!     (direct) method is the operator's CLI surface, and the operator TUI runs
+//!     in-process (never hits this socket). So a request on a direct method is
+//!     the operator (full authority); a request on `mcp_tool` is an AGENT and is
+//!     gated. An agent can NOT impersonate the operator by sending an empty/forged
+//!     `params["instance"]` (the #1575 identity-trust bypass this closes).
+//!  2. **Active = today's behavior** (zero migration): every agent op allowed.
 //!  3. The gate decodes the **inner** tool (`params["tool"]`) for the `mcp_tool`
 //!     method, never the outer `"mcp_tool"` string (else all tools look alike).
 //!  4. **Never-delegate** (structural / authority-changing) ops are blocked for
 //!     agents in Away/Sleep — even in Sleep with a full `delegate_scope`.
-//!  5. **Fail-closed**: an unmapped / newly-added op defaults to the
-//!     delegate-scoped (deny-by-default in Away/Sleep) class, so taxonomy drift
-//!     can never silently land a new mutation as "allowed".
+//!  5. **Fail-closed**: an empty/unidentified agent is the most-restricted caller
+//!     (never the delegate, never the operator), and an unmapped / newly-added op
+//!     defaults to the delegate-scoped (deny-by-default in Away/Sleep) class — so
+//!     neither an empty `instance` nor taxonomy drift can land a mutation as
+//!     "allowed".
 
 use crate::operator_mode::{OperatorMode, OperatorModeState};
 use serde_json::Value;
@@ -97,35 +103,52 @@ pub(crate) fn check_operation_allowed(
     params: &Value,
     state: &OperatorModeState,
 ) -> Result<(), String> {
-    // Decode op + sub-action + caller identity. For the MCP tunnel the real op
-    // is the INNER tool, not the outer "mcp_tool" method (invariant 3).
-    let (op, action, caller) = if method == super::method::MCP_TOOL {
-        (
-            params.get("tool").and_then(Value::as_str).unwrap_or(""),
-            params
-                .get("arguments")
-                .and_then(|a| a.get("action"))
-                .and_then(Value::as_str),
-            params.get("instance").and_then(Value::as_str).unwrap_or(""),
-        )
-    } else {
-        (
-            method,
-            None,
-            params.get("instance").and_then(Value::as_str).unwrap_or(""),
-        )
-    };
-
-    // Invariant 1 (TOP): operator / operator-surface (no instance) → never deny.
-    if caller.is_empty() {
+    // ── TRUSTED TRANSPORT discriminator (NOT the spoofable payload `instance`). ──
+    // The agent MCP bridge ONLY ever sends `mcp_tool` / `mcp_tools_list`
+    // (verified: `agend-mcp-bridge.rs` emits exactly those two methods). Every
+    // OTHER (direct) method is the operator's CLI surface, and the operator TUI
+    // executes IN-PROCESS — it never reaches this socket gate at all. So
+    // operator-ness is proven by the TRANSPORT/method, and an agent can NEVER
+    // claim operator authority by sending an empty/forged `params["instance"]`
+    // (the #1575 identity-trust bypass this redesign closes).
+    let is_agent_transport =
+        method == super::method::MCP_TOOL || method == super::method::MCP_TOOLS_LIST;
+    if !is_agent_transport {
+        // Operator CLI surface (direct API methods) — trusted, full authority.
         return Ok(());
     }
-    // Invariant 2: Active = today's behavior.
+    // `mcp_tools_list` is read-only tool enumeration — harmless, always allow.
+    if method == super::method::MCP_TOOLS_LIST {
+        return Ok(());
+    }
+
+    // ── Agent transport (`mcp_tool`). Decode the INNER tool + self-declared id. ──
+    let op = params.get("tool").and_then(Value::as_str).unwrap_or("");
+    let action = params
+        .get("arguments")
+        .and_then(|a| a.get("action"))
+        .and_then(Value::as_str);
+    // Self-declared; an agent could claim ANOTHER AGENT's name (a lesser concern —
+    // the never-delegate set is blocked for every agent regardless), but it can no
+    // longer claim to be the operator (that is transport-gated above).
+    let caller = params.get("instance").and_then(Value::as_str).unwrap_or("");
+
+    // An agent must NEVER change operator authority — in ANY mode, incl. Active.
+    // Operator mode control lives on the operator transport (CLI/direct), not here.
+    if op == "mode" && matches!(action, Some("set")) {
+        return Err(
+            "operation 'mode set' is operator-only (operator transport / operator-mode.json); \
+             agents cannot change operator authority"
+                .to_string(),
+        );
+    }
+
+    // Active = today's behavior (zero migration): agents unrestricted.
     if state.mode == OperatorMode::Active {
         return Ok(());
     }
 
-    // An agent caller while the operator is Away or Sleep.
+    // Agent, operator Away or Sleep.
     match classify(op, action) {
         OpClass::AlwaysAllow => Ok(()),
         OpClass::AbsolutelyNever => Err(format!(
@@ -141,7 +164,10 @@ pub(crate) fn check_operation_allowed(
                  (no delegate); queued for the operator"
             )),
             OperatorMode::Sleep => {
-                let is_delegate = state.delegate_to.as_deref() == Some(caller);
+                // The delegate must be a NON-EMPTY, exactly-matching instance — an
+                // empty/unidentified caller is never the delegate (fail-closed).
+                let is_delegate =
+                    !caller.is_empty() && state.delegate_to.as_deref() == Some(caller);
                 let in_scope = state.delegate_scope.iter().any(|s| s == op);
                 if is_delegate && in_scope {
                     Ok(())
@@ -183,15 +209,68 @@ mod tests {
         json!({"tool": tool, "instance": instance, "arguments": {"action": action}})
     }
 
-    // ── MUST-PIN 1: operator lock-out — no-instance identity is NEVER denied ──
+    // ── MUST-PIN 1a: operator-ness from TRANSPORT — direct methods are the
+    // operator CLI surface and stay allowed (operator never locked out). ──
     #[test]
-    fn operator_no_instance_is_never_denied_even_for_structural_in_sleep() {
+    fn operator_direct_method_always_allowed_even_in_sleep() {
         let st = sleep_with("fixup-lead", &[]);
-        // mcp_tool create_instance with NO instance (operator surface) → allow.
-        assert!(check_operation_allowed("mcp_tool", &mcp("create_instance", ""), &st).is_ok());
-        // direct dangerous method, no instance (operator TUI) → allow.
+        // Direct API methods (operator CLI surface) → allowed, even structural.
         assert!(check_operation_allowed("delete", &json!({}), &st).is_ok());
+        assert!(check_operation_allowed("spawn", &json!({}), &st).is_ok());
         assert!(check_operation_allowed("shutdown", &json!({}), &st).is_ok());
+        // mcp_tools_list (read-only enumeration) → allowed.
+        assert!(check_operation_allowed("mcp_tools_list", &json!({}), &st).is_ok());
+    }
+
+    // ── MUST-PIN 1b (THE #1575 must-fix): an agent CANNOT impersonate the
+    // operator by sending an empty/forged `instance` on the mcp_tool transport.
+    // The reviewed exploit: {tool: restart_instance, instance:"", args:{name:victim}}. ──
+    #[test]
+    fn agent_empty_instance_cannot_impersonate_operator() {
+        for st in [away(), sleep_with("fixup-lead", &[])] {
+            let exploit = json!({
+                "tool": "restart_instance",
+                "instance": "",
+                "arguments": {"name": "victim-agent"}
+            });
+            let denied = check_operation_allowed("mcp_tool", &exploit, &st);
+            assert!(
+                denied.is_err(),
+                "empty-instance agent must NOT be treated as operator ({:?})",
+                st.mode
+            );
+        }
+        // ...but in Active (today's behavior) an agent op is still a passthrough.
+        let active = OperatorModeState::default();
+        assert!(check_operation_allowed(
+            "mcp_tool",
+            &json!({"tool": "restart_instance", "instance": "", "arguments": {}}),
+            &active
+        )
+        .is_ok());
+    }
+
+    // ── An agent must never change operator authority (mode set), in ANY mode. ──
+    #[test]
+    fn agent_cannot_set_operator_mode() {
+        for st in [
+            OperatorModeState::default(), // Active
+            away(),
+            sleep_with("dev-2", &["mode"]), // even with mode in its own scope
+        ] {
+            let denied =
+                check_operation_allowed("mcp_tool", &mcp_action("mode", "set", "dev-2"), &st);
+            assert!(
+                denied.is_err(),
+                "agent mode-set must be denied in {:?}",
+                st.mode
+            );
+        }
+        // Reading the mode is fine for agents.
+        assert!(
+            check_operation_allowed("mcp_tool", &mcp_action("mode", "get", "dev-2"), &away())
+                .is_ok()
+        );
     }
 
     // ── MUST-PIN 2: mcp_tool decodes the INNER tool, not the outer method ──
@@ -206,17 +285,20 @@ mod tests {
         assert!(check_operation_allowed("mcp_tool", &mcp("send", "dev-2"), &st).is_ok());
     }
 
-    // ── MUST-PIN 3: fail-closed — unmapped op denied for agents in away/sleep ──
+    // ── MUST-PIN 3: fail-closed — unmapped op AND empty-instance agent denied ──
     #[test]
-    fn unknown_op_is_fail_closed_for_agents() {
+    fn unknown_op_and_empty_instance_are_fail_closed_for_agents() {
+        // Unmapped tool from a named agent → deny (fail-closed) in away.
         assert!(
             check_operation_allowed("mcp_tool", &mcp("frobnicate_widgets", "dev-2"), &away())
                 .is_err(),
             "an unmapped tool must default to deny (fail-closed) in away"
         );
-        // ...but the operator (no instance) is still never denied.
+        // Empty-instance agent (unidentified) → deny on the agent transport — it is
+        // NOT the operator (that is transport-gated) and NOT a delegate.
         assert!(
-            check_operation_allowed("mcp_tool", &mcp("frobnicate_widgets", ""), &away()).is_ok()
+            check_operation_allowed("mcp_tool", &mcp("frobnicate_widgets", ""), &away()).is_err(),
+            "empty-instance agent must be fail-closed, never elevated"
         );
     }
 

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -312,6 +312,14 @@ fn is_worktree_clean(worktree: &Path) -> bool {
 /// One-shot: if `is_worktree_clean` returns false due to transient
 /// I/O error, this call does not retry. The existing worktree GC
 /// (grace-period sweep) serves as the fallback safety net.
+///
+/// #1339 DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN: reached ONLY from the per-tick
+/// daemon loop on an internal trigger — a CI/PR-merge detection
+/// (`ci_watch::poller` / `pr_state::scanner`) — never from the API socket. It is
+/// daemon self-heal (a third trusted principal), so the operator-mode gate
+/// (`api::operator_gate`, which governs socket-ingress operator-vs-agent) does
+/// NOT apply: worktrees of merged branches are reclaimed even in away/sleep. Not
+/// agent-invocable (the trigger is GitHub merge state, not an agent request).
 pub(crate) fn auto_release_for_merged_branch(home: &Path, branch: &str) {
     let Some(agent) =
         crate::binding::scan_existing_branch_binding(home, branch, /* exclude */ "")

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -1,4 +1,13 @@
 //! Crash-respawn logic — extracted from daemon/mod.rs (#1382).
+//!
+//! #1339 DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN: this structural mutation
+//! (respawning a crashed agent) is reached ONLY from the per-tick daemon loop on
+//! an internal trigger — an agent process exit (`AgentExitEvent`) — never from
+//! the API socket. It is a third trusted principal (daemon self-heal), distinct
+//! from the socket-ingress principals (operator-transport vs agent-transport)
+//! that `api::operator_gate` governs, so the operator-mode gate intentionally
+//! does NOT apply here: the fleet keeps self-healing even in away/sleep. An
+//! agent cannot invoke this (it can at most crash ITSELF → its own respawn).
 
 use crate::agent::{self, AgentRegistry};
 use crate::channel::NotifySeverity;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -435,6 +435,9 @@ fn run_core(
             configs: &ctx.configs,
         };
         crate::runtime_config::reload(home);
+        // #1339: operator-mode.json reloaded each tick — a mode change (via the
+        // `mode` MCP tool) propagates fleet-wide without a restart (reload-coherent).
+        crate::operator_mode::reload(home);
         per_tick::run_handlers_with_panic_guard(&handlers, &tick_ctx);
 
         let exit_event = match exit_event {

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -432,6 +432,13 @@ impl RecoveryDispatcherHandler {
     /// does NOT increment counter; state stays `Stage2Eligible` for
     /// next-tick retry). Telegram notify pre-emit per dev refinement A
     /// (Stages 2/3 fire telegram; Stage 1 silent on success).
+    ///
+    /// #1339 DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN: the restart this triggers is
+    /// reached ONLY from the per-tick recovery state machine on an internal
+    /// trigger — a Hung-state detection (gated by `hang_auto_recovery_enabled`) —
+    /// never from the API socket. Daemon self-heal (a third trusted principal),
+    /// so the operator-mode gate does NOT apply: a hung agent is still recovered
+    /// in away/sleep. Not agent-invocable (an agent can at most hang ITSELF).
     fn handle_stage2_fire(
         &self,
         name: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ mod mcp;
 mod mcp_config;
 mod mouse_forward;
 mod notification_queue;
+pub mod operator_mode;
 mod paths;
 mod process;
 mod protocol;

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,6 +277,17 @@ enum Commands {
         /// Agent name
         name: String,
     },
+    /// #1339: Set the operator availability mode (operator-only authority control).
+    Mode {
+        /// active | away | sleep
+        mode: String,
+        /// Delegate instance that may proxy in-scope ops in sleep mode
+        #[arg(long)]
+        delegate: Option<String>,
+        /// Comma-separated operation/tool names the delegate may proxy in sleep
+        #[arg(long)]
+        scope: Option<String>,
+    },
     /// Admin utilities
     Admin {
         #[command(subcommand)]
@@ -857,6 +868,51 @@ fn main() -> anyhow::Result<()> {
                 Ok(resp) if resp["ok"].as_bool() == Some(true) => println!("Killed {name}"),
                 Ok(resp) => eprintln!(
                     "Kill failed: {}",
+                    resp["error"].as_str().unwrap_or("unknown")
+                ),
+                Err(_) => daemon_not_running_hint(),
+            }
+        }
+        Some(Commands::Mode {
+            mode,
+            delegate,
+            scope,
+        }) => {
+            // #1339: operator-only mode control over the DIRECT `MODE` method —
+            // the operator transport (the gate lets direct methods through;
+            // agents can only send `mcp_tool`, which the gate blocks for set).
+            let scope_arr: Vec<String> = scope
+                .as_deref()
+                .map(|s| {
+                    s.split(',')
+                        .map(|x| x.trim().to_string())
+                        .filter(|x| !x.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default();
+            let mut p = serde_json::json!({"mode": mode});
+            if let Some(d) = &delegate {
+                p["delegate"] = serde_json::json!(d);
+            }
+            if !scope_arr.is_empty() {
+                p["scope"] = serde_json::json!(scope_arr);
+            }
+            match api::call(
+                &home,
+                &serde_json::json!({"method": api::method::MODE, "params": p}),
+            ) {
+                Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+                    println!(
+                        "Operator mode → {}{}",
+                        resp["mode"].as_str().unwrap_or(&mode),
+                        resp["delegate_to"]
+                            .as_str()
+                            .map(|d| format!(" (delegate: {d})"))
+                            .unwrap_or_default()
+                    );
+                }
+                Ok(resp) => eprintln!(
+                    "mode failed: {}",
                     resp["error"].as_str().unwrap_or("unknown")
                 ),
                 Err(_) => daemon_not_running_hint(),

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -424,6 +424,58 @@ pub(crate) fn dispatch_config(ctx: &HandlerCtx<'_>) -> Value {
     }
 }
 
+/// #1339: manual operator-mode control. `mode get` → current mode + delegate;
+/// `mode set <active|away|sleep> [delegate=<name>] [scope=[...]]` → persist and
+/// hot-reload (the daemon tick's `operator_mode::reload` also re-reads the file).
+/// Setting the mode is itself authority-sensitive — the API ingress gate routes
+/// the `mode` tool's `set` action to the never-delegate class, so only the
+/// operator (no `instance` on the wire) or `Active` mode reaches here for a set.
+pub(crate) fn dispatch_mode(ctx: &HandlerCtx<'_>) -> Value {
+    match ctx.args["action"].as_str().unwrap_or("get") {
+        "get" => {
+            let s = crate::operator_mode::get();
+            json!({
+                "ok": true,
+                "mode": s.mode,
+                "delegate_to": s.delegate_to,
+                "delegate_scope": s.delegate_scope,
+            })
+        }
+        "set" => {
+            let Some(mode_str) = ctx.args["mode"].as_str() else {
+                return json!({"error": "mode set requires `mode` (active|away|sleep)"});
+            };
+            let mode = match crate::operator_mode::parse_mode(mode_str) {
+                Ok(m) => m,
+                Err(e) => return json!({"error": e}),
+            };
+            let delegate_to = ctx.args["delegate"].as_str().map(str::to_string);
+            let delegate_scope: Vec<String> = match &ctx.args["scope"] {
+                Value::Array(a) => a
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect(),
+                Value::String(s) => s
+                    .split(',')
+                    .map(|x| x.trim().to_string())
+                    .filter(|x| !x.is_empty())
+                    .collect(),
+                _ => Vec::new(),
+            };
+            match crate::operator_mode::set_mode(ctx.home, mode, delegate_to, delegate_scope) {
+                Ok(s) => json!({
+                    "ok": true,
+                    "mode": s.mode,
+                    "delegate_to": s.delegate_to,
+                    "delegate_scope": s.delegate_scope,
+                }),
+                Err(e) => json!({"error": e}),
+            }
+        }
+        other => json!({"error": format!("unknown mode action: {other} (expected get|set)")}),
+    }
+}
+
 /// Parse human-friendly duration strings like "2h", "30m", "1h30m".
 /// A bare number without suffix is interpreted as **minutes**.
 fn parse_duration_secs(s: &str) -> Option<i64> {
@@ -531,9 +583,10 @@ mod tests {
                 "binding_state",
                 "gc_dry_run",
                 "tokens",
+                "mode",
             ]
         );
-        assert_eq!(crate::mcp::registry::all().len(), 35);
+        assert_eq!(crate::mcp::registry::all().len(), 36);
     }
 
     #[test]

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -424,12 +424,12 @@ pub(crate) fn dispatch_config(ctx: &HandlerCtx<'_>) -> Value {
     }
 }
 
-/// #1339: manual operator-mode control. `mode get` → current mode + delegate;
-/// `mode set <active|away|sleep> [delegate=<name>] [scope=[...]]` → persist and
-/// hot-reload (the daemon tick's `operator_mode::reload` also re-reads the file).
-/// Setting the mode is itself authority-sensitive — the API ingress gate routes
-/// the `mode` tool's `set` action to the never-delegate class, so only the
-/// operator (no `instance` on the wire) or `Active` mode reaches here for a set.
+/// #1339: read the operator-mode (GET-ONLY for agents). `mode get` → current
+/// mode + delegate. SETTING the mode is operator-only and lives on the operator
+/// transport (`agend-terminal mode <active|away|sleep>` CLI → the direct `MODE`
+/// API method); the ingress gate blocks any agent `mode set` regardless, so this
+/// tool exposes read access only — agents observe the mode (e.g. to back off when
+/// the operator is away/asleep) but can never change operator authority.
 pub(crate) fn dispatch_mode(ctx: &HandlerCtx<'_>) -> Value {
     match ctx.args["action"].as_str().unwrap_or("get") {
         "get" => {
@@ -441,38 +441,12 @@ pub(crate) fn dispatch_mode(ctx: &HandlerCtx<'_>) -> Value {
                 "delegate_scope": s.delegate_scope,
             })
         }
-        "set" => {
-            let Some(mode_str) = ctx.args["mode"].as_str() else {
-                return json!({"error": "mode set requires `mode` (active|away|sleep)"});
-            };
-            let mode = match crate::operator_mode::parse_mode(mode_str) {
-                Ok(m) => m,
-                Err(e) => return json!({"error": e}),
-            };
-            let delegate_to = ctx.args["delegate"].as_str().map(str::to_string);
-            let delegate_scope: Vec<String> = match &ctx.args["scope"] {
-                Value::Array(a) => a
-                    .iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect(),
-                Value::String(s) => s
-                    .split(',')
-                    .map(|x| x.trim().to_string())
-                    .filter(|x| !x.is_empty())
-                    .collect(),
-                _ => Vec::new(),
-            };
-            match crate::operator_mode::set_mode(ctx.home, mode, delegate_to, delegate_scope) {
-                Ok(s) => json!({
-                    "ok": true,
-                    "mode": s.mode,
-                    "delegate_to": s.delegate_to,
-                    "delegate_scope": s.delegate_scope,
-                }),
-                Err(e) => json!({"error": e}),
-            }
-        }
-        other => json!({"error": format!("unknown mode action: {other} (expected get|set)")}),
+        other => json!({
+            "error": format!(
+                "mode is read-only via MCP (action '{other}'); set the operator mode with the \
+                 `agend-terminal mode <active|away|sleep>` CLI (operator-only)"
+            )
+        }),
     }
 }
 

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -17,7 +17,7 @@ pub(crate) fn all() -> &'static [ToolEntry] {
     &ALL_TOOLS
 }
 
-static ALL_TOOLS: [ToolEntry; 35] = [
+static ALL_TOOLS: [ToolEntry; 36] = [
     // ── Channel ──
     ToolEntry {
         name: "reply",
@@ -207,5 +207,11 @@ static ALL_TOOLS: [ToolEntry; 35] = [
         name: "tokens",
         definition: super::tools::def_tokens,
         handler: super::handlers::dispatch::dispatch_tokens,
+    },
+    // ── #1339: Operator mode ──
+    ToolEntry {
+        name: "mode",
+        definition: super::tools::def_mode,
+        handler: super::handlers::dispatch::dispatch_mode,
     },
 ];

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -298,6 +298,16 @@ pub(crate) fn def_config() -> Value {
     }, "required": ["action"]}})
 }
 
+pub(crate) fn def_mode() -> Value {
+    json!({"name": "mode", "description": "#1339: Operator availability/authority mode. `get` → current mode + delegate. `set` (operator-only) → active|away|sleep; in sleep a `delegate` may proxy the operations listed in `scope` (deny-by-default), but never-delegate structural/authority ops stay blocked. Active = today's behavior (all allowed).",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["get", "set"], "default": "get"},
+            "mode": {"type": "string", "enum": ["active", "away", "sleep"], "description": "Required for set."},
+            "delegate": {"type": "string", "description": "Instance granted proxy authority in sleep (optional)."},
+            "scope": {"type": "array", "items": {"type": "string"}, "description": "Operation/tool names the delegate may proxy in sleep (deny-by-default)."}
+        }, "required": ["action"]}})
+}
+
 pub(crate) fn def_health() -> Value {
     json!({"name": "health", "description": "Manage health state. Actions: report, clear.",
         "inputSchema": {"type": "object", "properties": {
@@ -503,8 +513,8 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            35,
-            "#1400: 34 + tokens (#1077 Phase 1) = 35. \
+            36,
+            "#1400: 34 + tokens (#1077 Phase 1) = 35; + mode (#1339 Operator Mode) = 36. \
              Current tools: {:?}",
             tools
                 .iter()

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -299,12 +299,9 @@ pub(crate) fn def_config() -> Value {
 }
 
 pub(crate) fn def_mode() -> Value {
-    json!({"name": "mode", "description": "#1339: Operator availability/authority mode. `get` → current mode + delegate. `set` (operator-only) → active|away|sleep; in sleep a `delegate` may proxy the operations listed in `scope` (deny-by-default), but never-delegate structural/authority ops stay blocked. Active = today's behavior (all allowed).",
+    json!({"name": "mode", "description": "#1339: Read the operator availability/authority mode (READ-ONLY for agents). `get` → current mode (active|away|sleep) + delegate. Agents observe this to back off when the operator is away/asleep. SETTING the mode is operator-only via the `agend-terminal mode <active|away|sleep>` CLI — never available to agents.",
         "inputSchema": {"type": "object", "properties": {
-            "action": {"type": "string", "enum": ["get", "set"], "default": "get"},
-            "mode": {"type": "string", "enum": ["active", "away", "sleep"], "description": "Required for set."},
-            "delegate": {"type": "string", "description": "Instance granted proxy authority in sleep (optional)."},
-            "scope": {"type": "array", "items": {"type": "string"}, "description": "Operation/tool names the delegate may proxy in sleep (deny-by-default)."}
+            "action": {"type": "string", "enum": ["get"], "default": "get"}
         }, "required": ["action"]}})
 }
 

--- a/src/operator_mode.rs
+++ b/src/operator_mode.rs
@@ -1,0 +1,181 @@
+//! #1339: Operator Mode — fleet-global runtime authority state.
+//!
+//! `~/.agend-terminal/operator-mode.json` answers *"is the human operator
+//! available, and what authority is delegated?"* — consumed by the single API
+//! ingress gate (`api::check_operation_allowed`). Reloaded each daemon tick
+//! (like [`crate::runtime_config`]), so a mode change propagates fleet-wide
+//! without a restart.
+//!
+//! Distinct from #1563 `idle_expectation` (per-agent fleet.yaml *static* config,
+//! "is THIS agent expected to be quiet?"). They share only the
+//! `#[serde(default)]` zero-migration discipline: an absent/empty file →
+//! [`OperatorMode::Active`] = today's all-allowed behavior, so deployments that
+//! never set a mode are unaffected.
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Operator availability / authority mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OperatorMode {
+    /// Operator at the TUI — full authority; today's behavior (the default).
+    #[default]
+    Active,
+    /// Operator reachable via Telegram but not at the TUI — structural ops
+    /// blocked, NO delegation (the operator still decides, via TG).
+    Away,
+    /// Operator unreachable — a named delegate may proxy operations within
+    /// `delegate_scope`; the never-delegate set stays blocked regardless.
+    Sleep,
+}
+
+/// Fleet-global operator-mode state (mode + delegation).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OperatorModeState {
+    #[serde(default)]
+    pub mode: OperatorMode,
+    /// In `Sleep`, the instance granted proxy authority. `None` ⇒ no delegate
+    /// (so every operator-requiring op is denied/queued, i.e. `Away`-like).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegate_to: Option<String>,
+    /// Operation classes the delegate may proxy. **Deny-by-default**: anything
+    /// not listed here is denied even in `Sleep`. The never-delegate set is
+    /// blocked even if listed here (the gate hard-codes that, not this field).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub delegate_scope: Vec<String>,
+}
+
+static OPERATOR_MODE: OnceLock<RwLock<OperatorModeState>> = OnceLock::new();
+
+fn global() -> &'static RwLock<OperatorModeState> {
+    OPERATOR_MODE.get_or_init(|| RwLock::new(OperatorModeState::default()))
+}
+
+fn path(home: &Path) -> PathBuf {
+    home.join("operator-mode.json")
+}
+
+/// Snapshot the current operator-mode state (lock-free clone).
+pub fn get() -> OperatorModeState {
+    global().read().clone()
+}
+
+/// Reload from disk. Called each daemon tick (reload-coherent). A missing or
+/// unparseable file → default (`Active`) — fail-safe to today's behavior, never
+/// a deny-all that could lock the fleet.
+pub fn reload(home: &Path) {
+    let state = std::fs::read_to_string(path(home))
+        .ok()
+        .and_then(|c| serde_json::from_str::<OperatorModeState>(&c).ok())
+        .unwrap_or_default();
+    *global().write() = state;
+}
+
+/// Set the mode (+ optional delegate) and persist atomically (disk + memory).
+/// Typed — unlike the flat `runtime_config` string setter — because
+/// `delegate_scope` is a structured list a `set(key, value)` API can't carry.
+pub fn set_mode(
+    home: &Path,
+    mode: OperatorMode,
+    delegate_to: Option<String>,
+    delegate_scope: Vec<String>,
+) -> Result<OperatorModeState, String> {
+    let state = OperatorModeState {
+        mode,
+        delegate_to,
+        delegate_scope,
+    };
+    let json = serde_json::to_string_pretty(&state).map_err(|e| e.to_string())?;
+    std::fs::write(path(home), json).map_err(|e| e.to_string())?;
+    *global().write() = state.clone();
+    Ok(state)
+}
+
+/// Parse a mode string (for the MCP `mode` tool). Case-insensitive.
+pub fn parse_mode(s: &str) -> Result<OperatorMode, String> {
+    match s.to_ascii_lowercase().as_str() {
+        "active" => Ok(OperatorMode::Active),
+        "away" => Ok(OperatorMode::Away),
+        "sleep" => Ok(OperatorMode::Sleep),
+        other => Err(format!(
+            "unknown mode: {other} (expected active|away|sleep)"
+        )),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn tmp(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!("agend-opmode-{}-{}", std::process::id(), tag));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    #[serial]
+    fn omitted_file_defaults_to_active_zero_migration() {
+        let home = tmp("default");
+        reload(&home); // no operator-mode.json present
+        assert_eq!(get().mode, OperatorMode::Active);
+        assert!(get().delegate_to.is_none());
+        assert!(get().delegate_scope.is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn unparseable_file_falls_back_to_active_not_denyall() {
+        let home = tmp("garbage");
+        std::fs::write(path(&home), b"not json {{{").unwrap();
+        reload(&home);
+        assert_eq!(get().mode, OperatorMode::Active, "fail-safe to Active");
+    }
+
+    #[test]
+    #[serial]
+    fn set_mode_then_reload_is_coherent() {
+        let home = tmp("reload-coherence");
+        set_mode(
+            &home,
+            OperatorMode::Sleep,
+            Some("fixup-lead".into()),
+            vec!["task_dispatch".into(), "pr_merge".into()],
+        )
+        .expect("set_mode");
+        // Simulate a fresh process / next-tick reload reading the persisted file.
+        *global().write() = OperatorModeState::default();
+        reload(&home);
+        let s = get();
+        assert_eq!(s.mode, OperatorMode::Sleep);
+        assert_eq!(s.delegate_to.as_deref(), Some("fixup-lead"));
+        assert_eq!(s.delegate_scope, vec!["task_dispatch", "pr_merge"]);
+    }
+
+    #[test]
+    fn mode_serializes_lowercase() {
+        let s = OperatorModeState {
+            mode: OperatorMode::Sleep,
+            delegate_to: Some("lead".into()),
+            delegate_scope: vec!["send".into()],
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("\"sleep\""), "mode is lowercase: {json}");
+        // Round-trips.
+        let back: OperatorModeState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn parse_mode_case_insensitive_and_rejects_unknown() {
+        assert_eq!(parse_mode("Active").unwrap(), OperatorMode::Active);
+        assert_eq!(parse_mode("SLEEP").unwrap(), OperatorMode::Sleep);
+        assert!(parse_mode("dnd").is_err(), "dnd is excluded from MVP");
+    }
+}


### PR DESCRIPTION
## What (#1339 PR-1 of 2 — **security-sensitive**)

Adds command-authority enforcement gated on the operator's availability. Per
decision **d-20260531171653513722-1** (operator signed off). **PR-2 = component C**
(notification severity field + `is_p0_class` + mode-aware routing) is a separate
PR (orthogonal, cross-cutting notification routing) — split agreed with lead so
this security PR stays focused for dual-review.

## A. OperatorMode store — `src/operator_mode.rs`
`enum { Active, Away, Sleep }` + `operator-mode.json` + delegate
(`delegate_to` + `delegate_scope`). `OnceLock<RwLock>` like `runtime_config`,
**reloaded each daemon tick** (reload-coherent). `#[serde(default)] = Active` →
**zero migration** (omitted/unparseable file → Active = today's all-allowed
behavior; never a deny-all that could lock the fleet).

## B. Single ingress gate — `src/api/operator_gate.rs`
`check_operation_allowed` called **once** before dispatch (`api/mod.rs`),
covering every direct method AND the `mcp_tool` tunnel (all 36 tools through one
arm). Security invariants:
1. **Operator never locked out** — a request with no `instance` identity
   (operator TUI/CLI/TG surface) is ALWAYS allowed.
2. **Active = passthrough** (today's behavior).
3. Decodes the **inner** tool (`params["tool"]`), never the outer `"mcp_tool"`.
4. **never-delegate** (structural/authority) set → blocked for agents in
   Away/Sleep, **even Sleep + full `delegate_scope`**.
5. **Fail-closed** — unmapped/new op → `DelegateScoped` (deny-by-default in
   Away/Sleep), so taxonomy drift can't silently land a new mutation as allowed.

Sleep: a `DelegateScoped` op is allowed iff `caller == delegate_to` AND op ∈
`delegate_scope`. Fleet-normal (send/task/inbox/reply/decision/readonly) is
`AlwaysAllow` so the fleet keeps operating in every mode.

## D. Manual `mode` MCP tool (set/get)
Registry entry + `def_mode` schema + `dispatch_mode` + count invariants (35→36).

## Excluded (per decision, deferred)
auto-switching (all forms), `dnd`, type-token, partial-scope + `blocked_scope`.

## Tests (5 must-pin + supporting)
- **operator-lockout**: no-instance identity never denied (even structural in sleep)
- **mcp_tool decodes inner tool**, not outer method
- **fail-closed**: unmapped op denied for agents in away/sleep
- **taxonomy-drift**: never-delegate set classified; unknown defaults deny-if-structural
- **reload-coherence**: `set_mode` → reload → `get` reflects it
- plus: never-delegate blocked even sleep+full-scope; delegate-scope deny-by-default;
  active passthrough; action-bearing read actions allowed in away.

`cargo clippy --all-targets -- -D warnings` clean; full `cargo test --tests`
green (60 binaries). Diff = 8 files, +645/-49.

## Note for reviewers (design point to confirm)
`delegate_scope` matches against the **op/tool name**. The `DelegateScoped`
class is reached for ops that are neither fleet-normal (always-allow) nor
never-delegate — primarily the **fail-closed default** for unmapped/new tools.
Confirm the never-delegate taxonomy (`operator_gate::classify`) matches the
operator's intended authority boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)