### PR TITLE
fix(#1553): prompt states never reach the Hung threshold (recovery no longer ESC/restarts real prompts)

### DIFF
--- a/src/health.rs
+++ b/src/health.rs
@@ -175,6 +175,17 @@ pub const STAGE2_MAX_RESTARTS_DEFAULT: u32 = 3;
 pub fn productive_silence_exceeds(agent_state: AgentState, silent_productive: Duration) -> bool {
     match agent_state {
         AgentState::Idle => false,
+        // #1553: an agent parked on a permission/approval/interactive prompt is
+        // CORRECTLY blocked on a human, not hung — silence is expected and
+        // open-ended. It must never reach the Hung threshold, otherwise the
+        // recovery pipeline acts on it: Stage-1 ESC cancels the live prompt and
+        // Stage-2 restart kills the agent mid-approval. Gating here (the single
+        // shared Hung-threshold fn, read by `check_hang`) covers every downstream
+        // recovery path uniformly — Stage 1/2/3 + the cron interrupt/replace
+        // consumers — not just the Stage-1 ESC the issue named.
+        AgentState::PermissionPrompt
+        | AgentState::InteractivePrompt
+        | AgentState::AwaitingOperator => false,
         AgentState::Starting => silent_productive > Duration::from_secs(120),
         AgentState::Thinking | AgentState::ToolUse => silent_productive > Duration::from_secs(600),
         _ => silent_productive > Duration::from_secs(120),
@@ -1013,6 +1024,83 @@ mod tests {
             Duration::from_secs(0),
             1_000_000,
             0
+        ));
+    }
+
+    // ── #1553: prompt states must never reach the Hung threshold ──
+    #[test]
+    fn test_1553_prompt_states_never_hang() {
+        // PermissionPrompt / InteractivePrompt / AwaitingOperator are correctly
+        // blocked on a human — silence is expected, so they must NEVER exceed the
+        // Hung threshold (else Stage-1 ESC cancels the live prompt / Stage-2
+        // restart kills the agent mid-approval).
+        let long = Duration::from_secs(600); // well past every per-state threshold
+        for state in [
+            AgentState::PermissionPrompt,
+            AgentState::InteractivePrompt,
+            AgentState::AwaitingOperator,
+        ] {
+            assert!(
+                !productive_silence_exceeds(state, long),
+                "{state:?} must never exceed the Hung threshold"
+            );
+        }
+    }
+
+    #[test]
+    fn test_1553_check_hang_skips_prompt_state_without_reason() {
+        // The exact gap: a real PermissionPrompt agent whose #1552 AwaitingOperator
+        // escalation has NOT fired (current_reason == None) was classified Hung
+        // after 120s → ESC'd/restarted. The AgentState-layer gate must prevent it
+        // even without any blocked reason.
+        for state in [
+            AgentState::PermissionPrompt,
+            AgentState::InteractivePrompt,
+            AgentState::AwaitingOperator,
+        ] {
+            let mut h = HealthTracker::new();
+            assert_eq!(h.current_reason, None, "no blocked reason (the gap)");
+            assert!(
+                !h.check_hang(
+                    state,
+                    Duration::from_secs(300), // 5 min — past the old 120s threshold
+                    Duration::from_secs(300),
+                    1_000_000,
+                    0
+                ),
+                "{state:?} with no reason must not be classified Hung"
+            );
+            assert_ne!(h.state, HealthState::Hung);
+        }
+    }
+
+    #[test]
+    fn test_1553_regression_other_state_thresholds_unchanged() {
+        // The fix must NOT relax the existing per-state thresholds.
+        assert!(!productive_silence_exceeds(
+            AgentState::Idle,
+            Duration::from_secs(100_000)
+        ));
+        assert!(productive_silence_exceeds(
+            AgentState::Starting,
+            Duration::from_secs(121)
+        ));
+        assert!(!productive_silence_exceeds(
+            AgentState::Starting,
+            Duration::from_secs(119)
+        ));
+        assert!(productive_silence_exceeds(
+            AgentState::Thinking,
+            Duration::from_secs(601)
+        ));
+        assert!(!productive_silence_exceeds(
+            AgentState::Thinking,
+            Duration::from_secs(599)
+        ));
+        // A non-prompt state that genuinely stalls still hangs at the 120s floor.
+        assert!(productive_silence_exceeds(
+            AgentState::Ready,
+            Duration::from_secs(121)
         ));
     }
 


### PR DESCRIPTION
## Bug (#1553)

Hang-recovery cancelled genuine runtime permission/approval prompts: an agent
parked on a `PermissionPrompt` for >120 s was classified `Hung`, so the recovery
dispatcher fired **Stage-1 ESC** (cancels the live prompt → agent stuck) or
**Stage-2 restart** (kills the agent mid-approval).

## Root cause (RCA — /tmp/1553-rca-dev2.md)

`productive_silence_exceeds` (`src/health.rs:175`) — the **single shared
Hung-threshold fn**, read by `check_hang` — routed `PermissionPrompt` /
`InteractivePrompt` / `AwaitingOperator` through its catch-all `_ => silent > 120s`.
The only protection was `check_hang`'s reason-exemption (`health.rs:488`), which
covers `AwaitingOperator` **only** — and that reason is set solely by the #1552
escalation (`supervisor.rs:798`) behind FP-gates, so a real prompt whose escalation
hadn't fired had `current_reason == None` and was classified `Hung`.

(`BlockedReason::PermissionPrompt` exists but is **never set** — left untouched per
scope; this fix is at the `AgentState` layer.)

## Fix (surgical — one match arm)

Gate the three "legitimately waiting on a human" states in
`productive_silence_exceeds` so they never reach `Hung`:

```rust
AgentState::PermissionPrompt
    | AgentState::InteractivePrompt
    | AgentState::AwaitingOperator => false,
```

Because **every** recovery path keys on `Hung`, this one arm uniformly protects
Stage-1 ESC, Stage-2 restart, Stage-3, **and** the cron interrupt/replace consumers
— not just the Stage-1 ESC the issue named (gating only the ESC would leave
Stage-2 restart + cron acting on the still-`Hung` agent). The #1552
`AwaitingOperator` escalation is a separate path, unaffected, and still surfaces
the prompt to the operator.

## Tests
- prompt states never exceed the Hung threshold
- `check_hang` does NOT classify a >120 s-silent prompt-state agent (`reason=None`,
  the exact gap) as `Hung`
- regression: `Starting`/`Thinking`/`Idle`/`Ready` thresholds unchanged

`cargo clippy --all-targets -- -D warnings` clean; full `cargo test --tests` green
(60 binaries). Diff = 1 file, +88.

Closes #1553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)