### PR TITLE
feat(#1547): un-gate agy fleet MCP via official .agents/ Customization Roots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,38 @@ AGEND_DAEMON_BOOT_SWEEP_DRY_RUN=1 AGEND_DAEMON_BOOT_SWEEP_AGE_DAYS=14 \
 grep "boot-sweep" $AGEND_HOME/daemon.log
 ```
 
+## agy fleet MCP via non-hidden workspace link (#1547)
+
+agy (Antigravity CLI) loads project-scoped fleet MCP from
+`<workspace>/.agents/mcp_config.json` (official Customization Roots), written by
+`configure_agy` (`src/mcp_config.rs`). But agy **refuses any workspace folder
+whose path has a dot-prefixed (hidden) ancestor** — `addWorkspaceFolder` logs
+`is hidden: ignore uri` (`root.go:132`) and never reads `.agents/`. Every daemon
+workspace lives under `$AGEND_HOME` (`~/.agend-terminal`, dot-prefixed) → hidden
+→ no fleet `send`/`inbox`/`task` tools.
+
+**Mechanism (operator e2e-verified):** agy decides "hidden" from the **`$PWD`
+env var**, not `getcwd()`/realpath. So the daemon spawns agy with its CWD at the
+real hidden workspace (the validated allowed root) but its `$PWD` pointed at a
+**non-hidden link** to that same dir. The hidden check passes; project discovery
+still resolves the realpath (via `.antigravitycli`) so it is the SAME antigravity
+project — no duplication — and `.agents/` loads.
+
+`src/agy_workspace.rs` owns the link: `ensure_link` (spawn) creates
+`<base>/<instance>` → `$AGEND_HOME/workspace/<instance>` and returns the path
+set as `$PWD` in `agent::build_command`; `remove_link` (teardown) is called from
+`agent_ops::cleanup_working_dir` and only ever removes the managed link, never
+the real workspace. Base defaults to `<user_home>/agend-ws`, overridable via
+fleet.yaml `agy_workspace_link_base`. **Unix:** symlink. **Windows:** a directory
+**junction** (the `junction` crate) — NOT `symlink_dir`, which needs Developer
+Mode / admin privilege; a junction needs neither.
+
+Recovery-safety (M2): agy caches MCP discovery at
+`~/.gemini/antigravity-cli/mcp/<server>/`, so `configure_agy` busts that cache on
+every (re)configure and the Stage-2 respawn path re-runs `configure()` — a
+respawn that skipped it would come back without fleet tools (recovery is exactly
+when they're needed).
+
 ## Release
 
 Tags matching `v*` trigger `.github/workflows/release.yml`, which builds 5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,7 @@ dependencies = [
  "hex",
  "iana-time-zone",
  "insta",
+ "junction",
  "libc",
  "memchr",
  "parking_lot",
@@ -2158,6 +2159,16 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "junction"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,10 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_Threading", "Win32_System_Console", "Win32_Foundation", "Win32_System_Registry", "Win32_System_JobObjects"] }
+# #1547 (A): directory junctions for the non-hidden agy workspace link. A
+# junction needs no privilege, unlike `std::os::windows::fs::symlink_dir`
+# (which requires Developer Mode / admin). Windows-only.
+junction = "1"
 
 [target.'cfg(windows)'.build-dependencies]
 embed-resource = "3"

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -876,6 +876,35 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
         }
     }
 
+    // #1547 (A): agy rejects a workspace whose path has a dot-prefixed (hidden)
+    // ancestor — and every daemon workspace lives under `$AGEND_HOME`
+    // (`~/.agend-terminal`, hidden). agy reads the workspace path from `$PWD`
+    // (not getcwd/realpath; operator e2e-verified), so we keep the CWD at the
+    // real hidden workspace (the validated allowed root set via `cmd.cwd` above)
+    // but point `$PWD` at a NON-hidden link to it. Done LAST — after the
+    // fleet.yaml user-env loop — so the daemon-derived value is authoritative
+    // (mirrors the opencode XDG_DATA_HOME placement rationale above). Link
+    // failure is non-fatal: agy still spawns, just without fleet MCP (the
+    // pre-#1547 behavior), and the boot invariant in `spawn_agent` warns.
+    if matches!(detected_backend, Some(Backend::Agy)) {
+        if let (Some(dir), Some(home_path)) = (working_dir, home) {
+            match crate::agy_workspace::ensure_link(home_path, name, dir) {
+                Ok(link) => {
+                    cmd.env("PWD", &link);
+                    tracing::debug!(
+                        instance = %name, pwd = %link.display(),
+                        "agy: $PWD set to non-hidden workspace link"
+                    );
+                }
+                Err(e) => tracing::warn!(
+                    instance = %name, error = %e,
+                    "agy: could not create non-hidden workspace link — agy will \
+                     reject the hidden workspace and load no fleet MCP"
+                ),
+            }
+        }
+    }
+
     // #708: strip AGEND_GIT_BYPASS from child env — agents must use the
     // git shim (which checks the var), not inherit a blanket bypass.
     cmd.env_remove("AGEND_GIT_BYPASS");

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -925,6 +925,29 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         }
     }
 
+    // #1547 M2(c): agy boot invariant. agy loads fleet MCP from
+    // `<workdir>/.agents/mcp_config.json` (written by `configure_agy` BEFORE
+    // spawn). If it's absent at spawn, agy boots without fleet tools AND caches
+    // "no MCP" in its HOME discovery cache — the recovery-failure class #1547
+    // fixes. Verify + WARN (not fatal: a bare agy is still usable manually, and
+    // configure_agy already errors on its own write failure).
+    if matches!(detected_backend, Some(Backend::Agy)) {
+        if let Some(dir) = working_dir {
+            let cfg = dir.join(".agents").join("mcp_config.json");
+            if !cfg.exists() {
+                tracing::warn!(
+                    target: "fleet_mcp_unsupported",
+                    agent = %name,
+                    path = %cfg.display(),
+                    "⚠️  [agy-mcp-config-missing] spawning agy but \
+                     .agents/mcp_config.json is absent — fleet tools will not load \
+                     and agy will cache 'no MCP'. configure_agy should have written \
+                     it pre-spawn; check earlier warnings."
+                );
+            }
+        }
+    }
+
     let pty_system = native_pty_system();
     let pair = pty_system
         .openpty(PtySize {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -827,6 +827,81 @@ fn build_command_sets_git_editor_defaults() {
     }
 }
 
+/// #1547 (A): `build_command` for an agy backend must set `$PWD` to the
+/// NON-hidden workspace link (so agy's hidden-path guard passes) while the
+/// CWD stays the real hidden workspace. The `agy_workspace::ensure_link` unit
+/// tests cover the link helper in isolation; THIS pins the integration —
+/// that the agy arm in `build_command` actually wires the link path into the
+/// child env. Unix-only: the link is a symlink here (Windows uses a junction,
+/// compile-checked on Windows CI; the PWD-wiring logic is platform-identical).
+#[cfg(unix)]
+#[test]
+fn build_command_agy_sets_pwd_to_non_hidden_link() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let home = std::env::temp_dir().join(format!(
+        "agend-1547-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let workspace = crate::paths::workspace_dir(&home).join("agy-int");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    // Point the link base inside our tmp home so the test never writes into
+    // the real `<user_home>/agend-ws`.
+    let link_base = home.join("ws-links");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        format!(
+            "instances: {{}}\nteams: {{}}\nagy_workspace_link_base: {}\n",
+            link_base.display()
+        ),
+    )
+    .expect("write fleet.yaml");
+
+    let config = SpawnConfig {
+        name: "agy-int",
+        backend_command: "agy",
+        args: &[],
+        spawn_mode: crate::backend::SpawnMode::Fresh,
+        cols: 80,
+        rows: 24,
+        env: None,
+        working_dir: Some(workspace.as_path()),
+        submit_key: "\r",
+        home: Some(home.as_path()),
+        crash_tx: None,
+        shutdown: None,
+    };
+    let (cmd, backend) = build_command(&config).expect("build_command");
+    assert_eq!(backend, Some(Backend::Agy));
+
+    let expected_link = crate::agy_workspace::link_path(&home, "agy-int");
+    let pwd = cmd
+        .get_env("PWD")
+        .expect("agy build_command must set $PWD to the non-hidden link");
+    assert_eq!(
+        std::path::Path::new(pwd),
+        expected_link.as_path(),
+        "agy $PWD must equal the workspace link path"
+    );
+    // The link exists, is a symlink, and resolves to the real workspace.
+    assert!(
+        expected_link
+            .symlink_metadata()
+            .expect("link must exist")
+            .file_type()
+            .is_symlink(),
+        "agy workspace link must be a symlink on Unix"
+    );
+    assert_eq!(
+        std::fs::canonicalize(&expected_link).expect("canonicalize link"),
+        std::fs::canonicalize(&workspace).expect("canonicalize workspace"),
+        "link must resolve to the real hidden workspace"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// #1146: send_to_registry must release the registry lock before
 /// calling inject. Source-grep pin: the lock scope must close
 /// before inject_with_target appears. This is structurally

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -353,6 +353,12 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
         let _ = std::fs::remove_file(&id_path);
     }
     let _ = std::fs::remove_file(meta_dir.join(format!("{name}.json")));
+
+    // #1547 (A): remove the non-hidden agy workspace link (no-op for non-agy
+    // instances / when no link exists). Keyed by instance name, not by
+    // working_dir, so it lives outside both cleanup branches above. Never
+    // touches the real workspace — only the managed symlink/junction.
+    crate::agy_workspace::remove_link(home, name);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agy_workspace.rs
+++ b/src/agy_workspace.rs
@@ -1,0 +1,246 @@
+//! #1547 (A): non-hidden workspace link so daemon-spawned agy loads the
+//! project-local `.agents/` fleet MCP.
+//!
+//! agy (Antigravity CLI) refuses to add a workspace folder whose path has ANY
+//! dot-prefixed (hidden) ancestor — `addWorkspaceFolder` logs
+//! `is hidden: ignore uri` (`root.go:132`) and never reads the
+//! workspace-scoped `.agents/mcp_config.json`. Every daemon agent workspace
+//! lives under `$AGEND_HOME` (`~/.agend-terminal`, dot-prefixed) so it is
+//! "hidden" to agy → no fleet `send`/`inbox`/`task` tools.
+//!
+//! **Mechanism (operator e2e-verified):** agy reads the workspace path from
+//! the `$PWD` env var, NOT from `getcwd()`/realpath. So the daemon spawns agy
+//! with its CWD at the real hidden workspace (the validated allowed root) but
+//! its `$PWD` pointed at a NON-hidden link to that workspace. The hidden check
+//! passes; project discovery still resolves the realpath (via
+//! `.antigravitycli`), so it is the SAME antigravity project — no duplication —
+//! and `.agents/` loads.
+//!
+//! The link lives at `<base>/<instance>` where `<base>` defaults to
+//! `<user_home>/agend-ws` (configurable via fleet.yaml
+//! `agy_workspace_link_base`). Unix: a symlink. Windows: a **directory
+//! junction** (NOT `symlink_dir`, which needs Developer Mode / admin
+//! privilege; a junction needs neither).
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Default non-hidden base when fleet.yaml does not set
+/// `agy_workspace_link_base`: `<user_home>/agend-ws`.
+fn default_link_base(home: &Path) -> PathBuf {
+    // Prefer the real user home (guaranteed non-hidden on a normal install).
+    // Fall back to `$AGEND_HOME`'s parent only if home resolution fails.
+    dirs::home_dir()
+        .or_else(|| home.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("agend-ws")
+}
+
+/// Resolve the non-hidden link base: fleet.yaml `agy_workspace_link_base` (if
+/// set) else `<user_home>/agend-ws`. Best-effort fleet-config load; a missing
+/// or unparsable fleet.yaml falls back to the default.
+pub fn link_base(home: &Path) -> PathBuf {
+    crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+        .ok()
+        .and_then(|f| f.agy_workspace_link_base)
+        .unwrap_or_else(|| default_link_base(home))
+}
+
+/// The link path for an instance: `<base>/<instance>`.
+pub fn link_path(home: &Path, instance: &str) -> PathBuf {
+    link_base(home).join(instance)
+}
+
+/// Create (or refresh) the non-hidden link `<base>/<instance>` →
+/// `real_workspace` and return the link path to set as agy's `$PWD`.
+///
+/// Idempotent: an existing managed link (symlink on Unix, junction on Windows)
+/// is removed and recreated each spawn so a stale target cannot survive. If a
+/// NON-link entry already occupies the path (a real dir/file the operator put
+/// there), this errors rather than clobber it.
+pub fn ensure_link(home: &Path, instance: &str, real_workspace: &Path) -> Result<PathBuf> {
+    let link = link_path(home, instance);
+    let base = link
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    std::fs::create_dir_all(&base)
+        .with_context(|| format!("create agy link base {}", base.display()))?;
+
+    if let Ok(meta) = link.symlink_metadata() {
+        if is_managed_link(&link, &meta) {
+            remove_link_path(&link);
+        } else {
+            anyhow::bail!(
+                "agy workspace link {} already exists and is not a daemon-managed \
+                 link (refusing to clobber); choose a different agy_workspace_link_base \
+                 or remove it manually",
+                link.display()
+            );
+        }
+    }
+
+    create_dir_link(real_workspace, &link).with_context(|| {
+        format!(
+            "create agy workspace link {} -> {}",
+            link.display(),
+            real_workspace.display()
+        )
+    })?;
+    Ok(link)
+}
+
+/// Best-effort teardown: remove an instance's managed link. Never removes a
+/// real directory — only a symlink/junction. Safe to call for any backend
+/// (a no-op when no link exists).
+pub fn remove_link(home: &Path, instance: &str) {
+    let link = link_path(home, instance);
+    if let Ok(meta) = link.symlink_metadata() {
+        if is_managed_link(&link, &meta) {
+            remove_link_path(&link);
+        }
+    }
+}
+
+/// Whether `link` is a daemon-managed link we may remove/recreate. On Unix a
+/// symlink; on Windows a junction (reparse point) — std reports junctions via
+/// the `FILE_ATTRIBUTE_REPARSE_POINT` flag, which `is_symlink()` does not
+/// cover, so the platform check below uses the reparse flag.
+#[cfg(unix)]
+fn is_managed_link(_link: &Path, meta: &std::fs::Metadata) -> bool {
+    meta.file_type().is_symlink()
+}
+
+#[cfg(windows)]
+fn is_managed_link(_link: &Path, meta: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+/// Remove a managed link. Unix symlinks delete via `remove_file`; Windows
+/// junctions are directory reparse points and delete via `remove_dir`. Try
+/// both so the call is robust across platforms. Best-effort + WARN.
+fn remove_link_path(link: &Path) {
+    let res = std::fs::remove_file(link).or_else(|_| std::fs::remove_dir(link));
+    if let Err(e) = res {
+        tracing::warn!(
+            path = %link.display(), error = %e,
+            "agy_workspace: failed to remove managed workspace link"
+        );
+    }
+}
+
+#[cfg(unix)]
+fn create_dir_link(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn create_dir_link(target: &Path, link: &Path) -> std::io::Result<()> {
+    // Directory junction — no privilege required (unlike `symlink_dir`).
+    junction::create(target, link)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home() -> PathBuf {
+        let base =
+            std::env::temp_dir().join(format!("agy_ws_test_{}_{}", std::process::id(), next_id()));
+        std::fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    fn next_id() -> u64 {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        N.fetch_add(1, Ordering::Relaxed)
+    }
+
+    #[test]
+    fn default_base_is_non_hidden() {
+        let home = PathBuf::from("/Users/x/.agend-terminal");
+        let base = default_link_base(&home);
+        // Last component is `agend-ws` and no path component is dot-prefixed
+        // (that is the whole point — a hidden ancestor is what agy rejects).
+        assert_eq!(base.file_name().unwrap(), "agend-ws");
+        assert!(
+            !base
+                .components()
+                .any(|c| c.as_os_str().to_string_lossy().starts_with('.')),
+            "default link base must have no hidden component: {}",
+            base.display()
+        );
+    }
+
+    #[test]
+    fn link_path_joins_instance() {
+        let home = tmp_home();
+        let p = link_path(&home, "agy-1");
+        assert_eq!(p.file_name().unwrap(), "agy-1");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_link_creates_and_resolves_to_real_workspace() {
+        let home = tmp_home();
+        let real = home.join("workspace").join("agy-1");
+        std::fs::create_dir_all(&real).unwrap();
+        // Marker file inside the real workspace, reachable through the link.
+        std::fs::write(real.join("marker"), b"hi").unwrap();
+
+        // Point the base inside our tmp home (no fleet.yaml → default base is
+        // the user home; override via a fleet.yaml under `home`).
+        write_fleet_link_base(&home, &home.join("ws-links"));
+
+        let link = ensure_link(&home, "agy-1", &real).unwrap();
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        // The link resolves to the real workspace (marker reachable).
+        assert_eq!(std::fs::read(link.join("marker")).unwrap(), b"hi");
+        // Idempotent re-create.
+        let link2 = ensure_link(&home, "agy-1", &real).unwrap();
+        assert_eq!(link, link2);
+
+        // Teardown removes the link but NOT the real workspace.
+        remove_link(&home, "agy-1");
+        assert!(link.symlink_metadata().is_err());
+        assert!(real.join("marker").exists());
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_link_refuses_to_clobber_real_dir() {
+        let home = tmp_home();
+        let real = home.join("workspace").join("agy-2");
+        std::fs::create_dir_all(&real).unwrap();
+        write_fleet_link_base(&home, &home.join("ws-links"));
+
+        // Pre-create a REAL dir where the link would go.
+        let link = link_path(&home, "agy-2");
+        std::fs::create_dir_all(&link).unwrap();
+        let err = ensure_link(&home, "agy-2", &real).unwrap_err();
+        assert!(
+            err.to_string().contains("not a daemon-managed link"),
+            "should refuse to clobber a real dir: {err}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Write a minimal fleet.yaml under `home` that sets the link base, so the
+    /// test exercises the configurable-base path deterministically (and does
+    /// not write into the real user home).
+    #[cfg(unix)]
+    fn write_fleet_link_base(home: &Path, base: &Path) {
+        let yaml = format!(
+            "instances: {{}}\nteams: {{}}\nagy_workspace_link_base: {}\n",
+            base.display()
+        );
+        std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
+    }
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -519,7 +519,11 @@ impl Backend {
                 // codex / kiro). Operator-verified in issue body.
                 resume_mode: ResumeMode::ContinueInCwd { flag: "--continue" },
                 quit_command: "/exit",
-                instructions_path: "AGY.md",
+                // #1547: agy reads agent instructions from the official
+                // Customization Roots dir `<workspace>/.agents/AGENTS.md`
+                // (same dir as its MCP config). `create_dir_all` handles the
+                // `.agents/` parent. Shared AGENTS.md format.
+                instructions_path: ".agents/AGENTS.md",
                 instructions_shared: true,
                 inject_instructions_on_ready: false,
                 ready_timeout_secs: 20,
@@ -535,15 +539,15 @@ impl Backend {
                     sequence: b"\r",
                 }],
                 fresh_args: None,
-                // #995 Bug 3: AGY discovers `<workdir>/.antigravitycli/mcp_config.json`
-                // for project-ID storage but its `mcpServers` map is ignored —
-                // only HOME-level `~/.gemini/antigravity-cli/mcp_config.json`
-                // loads (empirically proven; see PR description). The fleet
-                // scope rule (src/mcp_config.rs:5-11) forbids HOME-level
-                // writes, so we ship the agy backend without the bridge until
-                // upstream supports project-local mcpServers. Daemon spawn
-                // path emits a warning so operators are not surprised.
-                fleet_mcp_supported: false,
+                // #1547: agy loads project-scoped MCP via the official
+                // Customization Roots dir `<workspace>/.agents/mcp_config.json`
+                // (operator-verified: plain + yolo both load
+                // `✓ agend-terminal Tools`). `configure_agy`
+                // (src/mcp_config.rs) writes that file + busts agy's HOME
+                // discovery cache so recovery respawns reload the bridge. This
+                // supersedes the dead `.antigravitycli/mcp_config.json` write
+                // (#995 Bug 3 — agy ignored that file's `mcpServers`).
+                fleet_mcp_supported: true,
             },
             // Shell and Raw have no preset behavior. `command` is `""` as a
             // sentinel — callers that need the actual spawn path should use
@@ -1155,7 +1159,9 @@ mod tests {
         assert_eq!(agy.dismiss_patterns.len(), 1, "#995 trust dismiss");
         assert!(agy.dismiss_patterns[0].label.contains("Yes, I trust"));
         assert_eq!(agy.dismiss_patterns[0].sequence, b"\r");
-        assert_eq!(agy.instructions_path, "AGY.md");
+        // #1547: agy instructions live in the official Customization Roots dir
+        // alongside its MCP config (was "AGY.md" pre-un-gate).
+        assert_eq!(agy.instructions_path, ".agents/AGENTS.md");
     }
 
     /// #995 Bug 3: `fleet_mcp_supported` flag pins which backends ship with
@@ -1176,12 +1182,10 @@ mod tests {
         assert!(Backend::Codex.preset().fleet_mcp_supported);
         assert!(Backend::OpenCode.preset().fleet_mcp_supported);
         assert!(Backend::Gemini.preset().fleet_mcp_supported);
-        // Unsupported — see field docstring + Backend::Agy preset comment.
-        assert!(
-            !Backend::Agy.preset().fleet_mcp_supported,
-            "#995 Bug 3: Agy bridge currently doesn't load — flag pins the issue \
-             until upstream supports project-local mcpServers"
-        );
+        // #1547: Agy now loads the bridge via `<workspace>/.agents/mcp_config.json`
+        // (official Customization Roots; configure_agy writes it). Was `false`
+        // under #995 Bug 3 (agy ignored the old `.antigravitycli/` write).
+        assert!(Backend::Agy.preset().fleet_mcp_supported);
         // Shell / Raw — no MCP discovery; sentinel `false`.
         assert!(!Backend::Shell.preset().fleet_mcp_supported);
         assert!(

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -140,6 +140,7 @@ mod tests {
             channels: None,
             templates: None,
             display_timezone: None,
+            agy_workspace_link_base: None,
             home: None,
         };
         c.instances.insert(

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1243,6 +1243,18 @@ fn handle_stage2_restart(
         }
     }
 
+    // #1547 M2(b): re-run MCP config on the recovery/respawn path (idempotent).
+    // Critical for agy: its HOME-level discovery cache means a respawn that does
+    // NOT re-configure comes back WITHOUT fleet tools (recovery is exactly when
+    // they're needed). `configure_agy` rewrites `.agents/mcp_config.json` and
+    // busts the discovery cache; for other backends this is a harmless
+    // idempotent rewrite of the project-local config. Mirrors the skills
+    // re-install above (the spawn path's config-generation is otherwise only
+    // run on the INITIAL spawn, not here).
+    if let Some(ref wd) = config.working_dir {
+        crate::mcp_config::configure(wd, &config.backend_command, Some(name));
+    }
+
     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
     let spawn_result = agent::spawn_agent(
         &agent::SpawnConfig {

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -124,6 +124,15 @@ pub struct FleetConfig {
     /// from Sprint 54 P2-6. Storage timestamps stay UTC unconditionally.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_timezone: Option<String>,
+    /// #1547 (A): base directory under which the daemon creates a NON-hidden
+    /// link to each agy instance's real (hidden) `$AGEND_HOME/workspace/<name>`
+    /// dir. agy rejects any workspace whose path has a dot-prefixed ancestor
+    /// (`is hidden: ignore uri`), so the daemon points agy's `$PWD` at
+    /// `<base>/<name>` (a link) while keeping its CWD at the real allowed-root
+    /// workspace. `None` → default `<user_home>/agend-ws`. Only consulted for
+    /// the agy backend; other backends ignore it. See `crate::agy_workspace`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agy_workspace_link_base: Option<PathBuf>,
     #[serde(skip)]
     pub(crate) home: Option<PathBuf>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod admin;
 mod agent;
 mod agent_ops;
+mod agy_workspace;
 mod api;
 mod app;
 mod auth_cookie;

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -2,13 +2,23 @@
 //!
 //! Reference: https://github.com/suzuke/AgEnD (TypeScript version)
 //!
-//! **Scope rule:** every write here must land inside `$AGEND_HOME` or inside
-//! the agent's `working_directory`. User-global tool configs (`~/.codex/`,
-//! `~/.claude/`, etc.) are off-limits — mutating them risks corrupting the
-//! user's personal CLI setup and can't be cleanly undone. If a backend seems
-//! to need global state (codex trust prompt was the reason for the old
-//! `codex_trust_directory` write), reach for a CLI flag or `dismiss_patterns`
-//! in `src/backend.rs` instead.
+//! **Scope rule:** every CONFIG write here must land inside `$AGEND_HOME` or
+//! inside the agent's `working_directory`. User-global tool configs
+//! (`~/.codex/`, `~/.claude/`, etc.) are off-limits — mutating them risks
+//! corrupting the user's personal CLI setup and can't be cleanly undone. If a
+//! backend seems to need global state (codex trust prompt was the reason for
+//! the old `codex_trust_directory` write), reach for a CLI flag or
+//! `dismiss_patterns` in `src/backend.rs` instead.
+//!
+//! **#1547 narrow exception (`clear_agy_mcp_cache`):** the agy un-gate writes
+//! its config to the in-`working_directory` `.agents/mcp_config.json` (rule
+//! honored), but ALSO deletes agy's HOME-level *discovery cache* subdir
+//! `~/.gemini/antigravity-cli/mcp/agend-terminal/`. This is **not** a config
+//! write and does **not** touch the user's personal agy/gemini *settings* — it
+//! removes only OUR server's transient discovery cache so agy re-discovers from
+//! the project-local config on its next boot (the recovery-safety fix; agy
+//! regenerates the cache itself). Deliberate, reviewed (operator-signed-off),
+//! and idempotent — the only HOME-level mutation in this module.
 
 use anyhow::Result;
 use serde_json::json;
@@ -269,32 +279,92 @@ fn configure_gemini(working_dir: &Path, instance_name: Option<&str>) -> Result<(
     Ok(())
 }
 
-/// AGY (Google Antigravity CLI): **no-op since #995 Bug 3.**
+/// AGY (Google Antigravity CLI): write `<workdir>/.agents/mcp_config.json`.
 ///
-/// #987 originally wrote `<workdir>/.antigravitycli/mcp_config.json` with
-/// the standard `{ "mcpServers": { ... } }` schema. Empirical testing
-/// (PR #1002 — dev-2 spike) proved that AGY discovers this file for
-/// project-ID storage but **ignores its `mcpServers` field**. Only
-/// HOME-level `~/.gemini/antigravity-cli/mcp_config.json` actually loads
-/// MCP servers. The fleet scope rule (top-of-file comment lines 5-11)
-/// forbids HOME-level writes, so we cannot make AGY load the bridge in
-/// the current AGY release.
+/// #1547 un-gate: agy loads project-scoped MCP via the official Customization
+/// Roots dir `<workspace>/.agents/` (operator-verified: plain + yolo
+/// `--dangerously-skip-permissions` both load `✓ agend-terminal Tools`). This
+/// replaces the dead `.antigravitycli/mcp_config.json` write (#995 Bug 3 — agy
+/// ignored that file's `mcpServers`). **Self-contained** — deliberately NOT
+/// coupled to `configure_gemini` (gemini sunsets 2026-06-18 / #1580).
 ///
-/// This function is retained as a discoverable no-op so the dispatch
-/// at `configure()` stays exhaustive for Backend variants. When upstream
-/// AGY (filed at google-antigravity/antigravity-cli) supports
-/// project-local `mcpServers`, this function should be restored.
+/// The file carries ONLY the `mcpServers` block and is written FRESH (not
+/// merged) each spawn, so a stale/garbled prior file cannot poison discovery —
+/// a property the recovery-safety below depends on.
 ///
-/// `Backend::Agy.preset().fleet_mcp_supported` is set to `false`; the
-/// daemon spawn path (`src/agent.rs spawn_agent`) emits a
-/// `[fleet-mcp-unsupported]` warning so operators understand the
-/// instance lacks fleet MCP tools.
-fn configure_agy(_working_dir: &Path, _instance_name: Option<&str>) -> Result<()> {
-    tracing::debug!(
-        "configure_agy: no-op (fleet_mcp_supported=false; awaiting upstream \
-         AGY support for project-local mcpServers loading)"
-    );
+/// #1547 M2 recovery-safety: agy persists a HOME-level MCP discovery cache at
+/// `~/.gemini/antigravity-cli/mcp/<server>/`, shared across instances and
+/// reused across restarts. A boot that ever found `.agents/` absent caches
+/// "no MCP" and never re-discovers — including on the Stage-2/crash respawn
+/// path (`daemon/mod.rs`). So this (1) clears our server's cache subdir on
+/// every (re)configure to force re-discovery from the fresh config on agy's
+/// next boot, and (2) verifies the write landed + warns (never silent) on
+/// write/clear failure. The respawn path also calls `configure()` so recovery
+/// re-runs both steps.
+fn configure_agy(working_dir: &Path, instance_name: Option<&str>) -> Result<()> {
+    let path = working_dir.join(".agents").join("mcp_config.json");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Flock + atomic write so concurrent spawns can't interleave their writes.
+    let _lock = crate::store::acquire_file_lock(&config_lock_path(&path))?;
+
+    let mut server = mcp_server_entry(instance_name);
+    server["trust"] = json!(true);
+    let config = json!({ "mcpServers": { "agend-terminal": server } });
+    let body = serde_json::to_string_pretty(&config)?;
+    crate::store::atomic_write(&path, body.as_bytes())?;
+
+    // #1547 M2(c): verify the write actually landed — never silently leave agy
+    // bare (a missing config = agy boots without fleet tools, the exact
+    // recovery-failure class this PR fixes).
+    if !path.exists() {
+        anyhow::bail!(
+            "configure_agy: {} missing after atomic_write",
+            path.display()
+        );
+    }
+
+    // #1547 M2(a): bust agy's HOME-level discovery cache so its next boot
+    // re-discovers from the config just written.
+    clear_agy_mcp_cache();
+
+    tracing::debug!(path = %path.display(), "configured agy MCP (.agents/)");
     Ok(())
+}
+
+/// #1547 M2(a): remove agy's HOME-level MCP discovery cache subdir for the
+/// `agend-terminal` server so a stale "no MCP" (or outdated) cache cannot
+/// survive a (re)configure. Per the Q2 decision the server name is kept as the
+/// operator-verified `agend-terminal` (shared across instances); clearing it
+/// forces every agy's NEXT boot to re-discover from `.agents/` — a running agy
+/// does not re-read mid-session, so the race is narrow and re-discovery is
+/// idempotent. Best-effort + WARN (never fatal): a missing cache dir is the
+/// normal first-spawn case, only a real removal error is surprising.
+fn clear_agy_mcp_cache() {
+    let Some(home) = dirs::home_dir() else {
+        tracing::warn!("configure_agy: cannot resolve user home — skipping agy MCP cache bust");
+        return;
+    };
+    let cache = home
+        .join(".gemini")
+        .join("antigravity-cli")
+        .join("mcp")
+        .join("agend-terminal");
+    if !cache.exists() {
+        return;
+    }
+    match std::fs::remove_dir_all(&cache) {
+        Ok(()) => tracing::debug!(
+            path = %cache.display(),
+            "configure_agy: cleared agy MCP discovery cache"
+        ),
+        Err(e) => tracing::warn!(
+            path = %cache.display(), error = %e,
+            "configure_agy: failed to clear agy MCP discovery cache — a stale \
+             entry may suppress fleet tools until removed manually"
+        ),
+    }
 }
 
 /// OpenCode: opencode.json — uses { "mcp": { ... } } with command as array.
@@ -855,26 +925,46 @@ mod tests {
 
     /// #987: configure dispatches Backend::Agy to write the standard
     /// #995 Bug 3: configure_agy is a no-op since empirical proof showed
-    /// AGY ignores project-local `.antigravitycli/mcp_config.json` mcpServers
-    /// field. Dispatcher routes to the no-op without crashing; NO file is
-    /// written under the working_dir (operator's `~/.gemini/` is also
-    /// untouched per scope rule). When upstream supports project-local
-    /// mcpServers, this test's assertions should flip (require the file
-    /// to exist with the bridge entry).
+    /// #1547: AGY now loads project-scoped MCP via the official Customization
+    /// Roots file `<workspace>/.agents/mcp_config.json`. The dispatcher routes
+    /// to `configure_agy`, which writes that file (self-contained — NOT coupled
+    /// to configure_gemini) with the bridge entry + `trust:true` + per-instance
+    /// env. The dead `.antigravitycli/` write (#995 Bug 3) is gone.
     #[test]
-    fn configure_dispatches_agy_noop() {
+    fn configure_dispatches_agy_writes_agents_mcp() {
         let dir = tmp_dir("dispatch_agy");
-        configure(&dir, "agy", None);
-        // #995 Bug 3: NO project-local mcp_config.json is written (AGY
-        // ignores it anyway; previous write was dead code).
+        configure(&dir, "agy", Some("agy-1"));
+
+        let cfg = dir.join(".agents").join("mcp_config.json");
         assert!(
-            !dir.join(".antigravitycli/mcp_config.json").exists(),
-            "#995 Bug 3: configure_agy must not write a project-local mcp_config"
+            cfg.exists(),
+            "#1547: configure_agy must write .agents/mcp_config.json"
         );
-        // Sanity: must NOT have touched Gemini's path under .gemini/.
-        assert!(!dir.join(".gemini").exists());
-        // Sanity: nothing else under .antigravitycli/ either.
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&cfg).unwrap()).unwrap();
+        let server = &v["mcpServers"]["agend-terminal"];
+        assert!(
+            server["command"].as_str().is_some_and(|c| !c.is_empty()),
+            "bridge command must be present: {v}"
+        );
+        assert_eq!(
+            server["trust"],
+            json!(true),
+            "agy entry must set trust:true"
+        );
+        assert_eq!(
+            server["env"]["AGEND_INSTANCE_NAME"],
+            json!("agy-1"),
+            "per-instance AGEND_INSTANCE_NAME must be wired"
+        );
+        assert!(
+            server["env"]["AGEND_HOME"].as_str().is_some(),
+            "AGEND_HOME must be present in the bridge env"
+        );
+        // The dead legacy path must NOT be written, and gemini's .gemini/ must
+        // be untouched (configure_agy is self-contained, not configure_gemini).
         assert!(!dir.join(".antigravitycli").exists());
+        assert!(!dir.join(".gemini").exists());
         std::fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
## #1547 — un-gate agy fleet MCP (complete)

Makes daemon-spawned **agy** actually load the fleet `send`/`inbox`/`task` MCP
tools. Two layers:

### M1/M2 (dev's commit 87b4657)
- `configure_agy` writes `<workspace>/.agents/mcp_config.json` (official agy
  Customization Roots) + flips `Backend::Agy.fleet_mcp_supported = true`.
- Recovery-safety: busts agy's HOME-level MCP discovery cache on every
  (re)configure; Stage-2 respawn re-runs `configure()`; spawn boot invariant
  warns if `.agents/mcp_config.json` is missing.
- `instructions_path` → `.agents/AGENTS.md`. Self-contained (NOT coupled to
  `configure_gemini`, which sunsets 2026-06-18 / #1580).

### (A) non-hidden workspace link (commit c64525b — this takeover)
The blocker M1/M2 alone didn't solve: agy **refuses any workspace whose path
has a dot-prefixed (hidden) ancestor** (`addWorkspaceFolder` → `is hidden:
ignore uri`, root.go:132), and every daemon workspace lives under `$AGEND_HOME`
(`~/.agend-terminal`, hidden) → `.agents/` never read.

**Mechanism (operator e2e-verified):** agy decides "hidden" from the `$PWD`
env var, not getcwd/realpath. So spawn agy with CWD at the real hidden
workspace (validated allowed root) but `$PWD` pointed at a non-hidden link to
that same dir. Hidden check passes; project discovery resolves the realpath
(same antigravity project, no duplication); `.agents/` loads.

- `src/agy_workspace.rs`: `ensure_link` (spawn) / `remove_link` (teardown) /
  `link_base` (configurable). **Unix symlink**, **Windows directory junction**
  (`junction` crate — needs no Developer Mode, unlike `symlink_dir`).
- `agent::build_command`: agy → `ensure_link` + `cmd.env("PWD", link)`; CWD
  stays the real hidden dir. Set after the fleet.yaml env loop (daemon value
  authoritative). Link failure non-fatal (warn; falls back to pre-#1547).
- `agent_ops::cleanup_working_dir`: `remove_link` on teardown — only the managed
  link, never the real workspace.
- `FleetConfig::agy_workspace_link_base` (default `<user_home>/agend-ws`).
- CLAUDE.md: documents the hidden-path mechanism + the link fix.

### Tests
- `agy_workspace`: create/idempotent/teardown-preserves-real-dir/refuse-clobber (4).
- backend pin test flips to `fleet_mcp_supported == true`; `configure_agy` no-op
  test flips to assert the `.agents/mcp_config.json` write.
- Full `cargo test --bin` (3026) + invariants (file_size / cargo_include /
  anti_pattern / spawn_rationale / test_isolation) green; clippy
  `--all-targets -D warnings` green.

**Merge gate:** lead does a final daemon-real "auto-create link + spawn" e2e
(authed agy lists fleet MCP tools) before merge. Closes #1547.