### PR TITLE
fix: pty broadcast must not block under the core lock (daemon freeze)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1237,6 +1237,49 @@ struct PtyReadContext {
 }
 
 /// PTY read loop: feeds VTerm, broadcasts output, auto-dismisses dialogs, handles exit.
+/// Broadcast one PTY output chunk to all subscribers WITHOUT blocking.
+///
+/// The caller holds the agent's `core.lock()` (the broadcast is kept atomic
+/// with `feed_with_fg` so a concurrent `subscribe_with_dump` can't interleave a
+/// dump between process and broadcast). That makes blocking here lethal: a
+/// blocking `send` on a full `bounded(1024)` subscriber channel would hold the
+/// core lock forever and wedge every core-lock waiter — the main TUI
+/// render/input thread, the supervisor, all of it. (Observed: two agents'
+/// pty_read threads parked in a full-channel send while holding their core
+/// locks; the TUI drains those very channels but was itself parked waiting for a
+/// core lock — a deadlock cycle that froze the whole daemon.)
+///
+/// `try_send` never blocks. On `Full` the consumer is too far behind, so the
+/// chunk is dropped (best-effort mirror; the consumer resyncs from the next
+/// screen dump) and `dropped_chunks` is bumped + throttled-logged. On
+/// `Disconnected` the subscriber is removed (the `retain` returns `false`).
+fn broadcast_pty_output(
+    subscribers: &mut Vec<crossbeam_channel::Sender<Vec<u8>>>,
+    data: &[u8],
+    dropped_chunks: &mut u64,
+    agent: &str,
+) {
+    subscribers.retain(|tx| match tx.try_send(data.to_vec()) {
+        Ok(()) => true,
+        Err(crossbeam_channel::TrySendError::Full(_)) => {
+            *dropped_chunks += 1;
+            // Throttle: first drop, then powers-of-two, so a chronically-full
+            // subscriber stays visible in the log without flooding it.
+            if dropped_chunks.is_power_of_two() {
+                tracing::warn!(
+                    agent,
+                    dropped_chunks = *dropped_chunks,
+                    "pty broadcast: subscriber channel full — dropping output chunk (consumer \
+                     stalled). Mirror is best-effort; the daemon is NOT blocked (was a freeze \
+                     before this guard)."
+                );
+            }
+            true
+        }
+        Err(crossbeam_channel::TrySendError::Disconnected(_)) => false,
+    });
+}
+
 fn pty_read_loop(
     pty_reader: &mut dyn Read,
     ctx: &PtyReadContext,
@@ -1259,6 +1302,10 @@ fn pty_read_loop(
     let debug_reads = std::env::var("AGEND_DEBUG_PTY_READ").is_ok();
     let mut read_count: u64 = 0;
     let mut total_bytes: u64 = 0;
+    // #1492-class: count subscriber chunks dropped because a consumer's bounded
+    // channel was full. Throttled-logged so a chronically-stalled subscriber is
+    // observable without flooding (see the broadcast site below).
+    let mut dropped_chunks: u64 = 0;
 
     loop {
         match pty_reader.read(&mut buf) {
@@ -1309,7 +1356,7 @@ fn pty_read_loop(
                     // on Ink redraw fragmentation.
                     let (screen, fg) = c.vterm.tail_lines_with_fg(rows);
                     c.state.feed_with_fg(&screen, &fg);
-                    c.subscribers.retain(|tx| tx.send(data.to_vec()).is_ok());
+                    broadcast_pty_output(&mut c.subscribers, data, &mut dropped_chunks, name);
                     screen
                 };
 

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1664,3 +1664,59 @@ fn provision_opencode_data_dir_no_auth_src_is_ok_1519() {
     );
     std::fs::remove_dir_all(&xdg).ok();
 }
+
+// ── pty broadcast must never block under the core lock ──────────────────────
+//
+// Regression for the daemon freeze where `pty_read_loop` broadcast PTY output
+// to subscribers with a BLOCKING `send` while holding `core.lock()`. A full
+// bounded(1024) subscriber channel (consumer stalled) made that send block
+// forever, holding the core lock and wedging the whole daemon (main TUI thread,
+// supervisor, every api_handler). With the old `send`, `broadcast_full_channel_
+// does_not_block` below would hang forever — it is the load-bearing pin.
+
+#[test]
+fn broadcast_full_channel_does_not_block_and_drops() {
+    // bounded(1), pre-filled, and never drained → the next send has nowhere to
+    // go. The OLD blocking `send` would deadlock here; `try_send` drops instead.
+    let (tx, _rx) = crossbeam_channel::bounded::<Vec<u8>>(1);
+    tx.send(vec![0u8]).expect("prime the single slot");
+    let mut subs = vec![tx];
+    let mut dropped = 0u64;
+    // If this blocks, the test harness hangs — that IS the failure signal.
+    broadcast_pty_output(&mut subs, b"more output", &mut dropped, "agent-x");
+    assert_eq!(
+        dropped, 1,
+        "the chunk must be dropped, not block, on a full channel"
+    );
+    assert_eq!(
+        subs.len(),
+        1,
+        "a merely-full (live) subscriber is kept, not removed"
+    );
+}
+
+#[test]
+fn broadcast_removes_disconnected_subscriber() {
+    let (tx, rx) = crossbeam_channel::bounded::<Vec<u8>>(1024);
+    drop(rx); // consumer gone → Disconnected
+    let mut subs = vec![tx];
+    let mut dropped = 0u64;
+    broadcast_pty_output(&mut subs, b"x", &mut dropped, "agent-x");
+    assert!(subs.is_empty(), "a disconnected subscriber must be removed");
+    assert_eq!(dropped, 0, "disconnect is not a drop");
+}
+
+#[test]
+fn broadcast_delivers_to_healthy_subscriber() {
+    let (tx, rx) = crossbeam_channel::bounded::<Vec<u8>>(1024);
+    let mut subs = vec![tx];
+    let mut dropped = 0u64;
+    broadcast_pty_output(&mut subs, b"hello", &mut dropped, "agent-x");
+    assert_eq!(subs.len(), 1, "a healthy subscriber is kept");
+    assert_eq!(dropped, 0);
+    assert_eq!(
+        rx.try_recv().ok(),
+        Some(b"hello".to_vec()),
+        "output must be delivered"
+    );
+}


### PR DESCRIPTION
## Why

A second, distinct daemon freeze, found right after the api::call self-IPC fix
(#1571) was merged + rebuilt. `app` froze again — but this time it was a **pure
parking_lot mutex deadlock, not a socket-read hang**. `sample(1)` on the wedged
process:

- main TUI thread, supervisor, monitor_tick, and every active api_handler →
  parked acquiring a core lock (parking_lot park, `0xa4afe4`).
- two agents' `*_pty_read` threads (`fixup-dev`, `fixup-dev-2`) → parked in a
  **crossbeam-channel send while holding their core locks** (a different park
  site, which is why their leaves differ from the parking_lot waiters).
- the api::call read-timeout backstop from #1571 fired **0** times, confirming a
  different path entirely.

## Root cause

`pty_read_loop` (in `src/agent/mod.rs`) broadcasts each PTY output chunk to
subscribers **inside the `core.lock()` window** — kept atomic with
`feed_with_fg` so a concurrent `subscribe_with_dump` can't interleave a dump
between `vterm.process` and the broadcast. The broadcast used a **blocking**
`crossbeam_channel::Sender::send` on `bounded(1024)` subscriber channels.

The TUI panes (`subscribe_with_dump`, `app/pane_factory.rs`) and the router
(`daemon::router::register_agent`) drain those channels. When the draining
thread stalls — e.g. the main TUI thread is itself parked waiting for a core
lock — the channel fills to 1024 and `send` **blocks while holding the core
lock**. Every core-lock waiter then parks behind it: the main render/input
thread, the supervisor, the api_handlers. Deadlock cycle → the whole daemon +
TUI freeze (SIGTERM can't even shut it down; the shutdown path wants the same
lock). Two agents hit it at once, so both pty_read threads were parked in send.

## Fix

Extract the broadcast into `broadcast_pty_output` and use non-blocking
`try_send`. The atomic-under-lock semantics are preserved (still inside the
lock, still ordered with feed), but the send can never block:

- `Full` → drop the chunk (best-effort mirror; a stalled consumer resyncs from
  the next screen dump) and bump a `dropped_chunks` counter, throttled-logged at
  powers of two so a chronically-full subscriber stays visible without flooding.
- `Disconnected` → remove the subscriber (the `retain` returns `false`).

This matches the `try_send` drop-on-fail pattern already used for the router
(`router.rs`) and the exit-event channels. The core lock is now held only for
CPU-bound work (`vterm.process` + state detection), never across a blocking
channel op.

## Tests

Exercise the real `broadcast_pty_output` helper:

- `broadcast_full_channel_does_not_block_and_drops` — a pre-filled,
  never-drained `bounded(1)` channel. **The old blocking `send` would hang this
  test forever** — it is the load-bearing pin: asserts the call returns and the
  chunk is dropped.
- `broadcast_removes_disconnected_subscriber` — dropped rx → subscriber removed.
- `broadcast_delivers_to_healthy_subscriber` — normal path delivers, no drop.

`scripts/preflight.sh` clean: fmt, clippy (`--all-targets --features tray
-D warnings`), tests (unit + integration + invariants), and the Windows
`x86_64-pc-windows-msvc` cross-check all pass.

## Relationship to #1571 / #1492

Independent root cause. #1571 (+ the `#1573`/`#1540` self-IPC guard work already
on main) addresses *self-IPC under lock* over the loopback socket. This is *a
blocking channel send under the core lock* — not self-IPC, so those guards don't
catch it. Branched off current `origin/main`, so this binary carries all of
them.

## Operator note

Needs a release rebuild + `app` restart to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)