### PR TITLE
fix(#1584): exhaustion notice wording — API rate limit → transient upstream error

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1076,7 +1076,7 @@ pub(crate) fn process_server_rate_limit_retries(
             retry.exhausted = true;
             if let Some(ch) = crate::channel::active_channel() {
                 let msg = format!(
-                    "⚠️ {name} API rate limit auto-retry exhausted ({} retries). Manual intervention required.",
+                    "⚠️ {name} transient upstream error auto-retry exhausted ({} retries). Manual intervention required.",
                     SERVER_RATE_LIMIT_MAX_RETRIES
                 );
                 let _ = crate::channel::gated_notify(


### PR DESCRIPTION
## What
Trivial surgical wording fix. The `ServerRateLimit` auto-retry exhaustion notification (`process_server_rate_limit_retries`, `supervisor.rs`) said:

> ⚠️ {name} **API rate limit** auto-retry exhausted (N retries). Manual intervention required.

But the `ServerRateLimit` pattern (`patterns.rs`) covers the whole **transient-upstream-fault** class — not just rate limits, but also `API Error: 5xx` / `ECONNRESET` / `ETIMEDOUT` / `fetch failed` / `connection reset` / network errors. The "rate limit" wording mis-describes those cases.

## Fix
`API rate limit` → **`transient upstream error`** (accurate for the full class). One `format!` string, no behavior change, no test asserts the text.

## Preflight
`fmt` ✓ · `clippy --all-targets --features tray -D warnings` ✓ (diff is 1 line).

Closes #1584

🤖 Generated with [Claude Code](https://claude.com/claude-code)