### PR TITLE
docs(#1547): mark agy a supported fleet backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ graph LR
 | Codex | `codex` | Tested |
 | OpenCode | `opencode` | Tested |
 | Gemini CLI | `gemini` | Tested |
-| Antigravity CLI | `agy` | Unsupported |
+| Antigravity CLI | `agy` | Tested |
 
-> Gemini CLI sunsets 2026-06-18 for free/Pro/Ultra tiers. Antigravity CLI is the official successor.
-> The `agy` backend is currently **unsupported**: beyond the missing Fleet MCP bridge, known issues with it are not being addressed for now. It will not be revisited until project-scoped MCP is supported ([#1262](https://github.com/suzuke/agend-terminal/issues/1262)) or a first-party CLI tool lands. See [docs/KNOWN_ISSUES.md](docs/KNOWN_ISSUES.md) ([#1547](https://github.com/suzuke/agend-terminal/issues/1547)).
+> Gemini CLI sunsets 2026-06-18 for free/Pro/Ultra tiers. Antigravity CLI (`agy`) is the official successor and is now a **supported** Fleet MCP backend ([#1547](https://github.com/suzuke/agend-terminal/issues/1547)).
+> agy refuses any workspace whose path has a dot-prefixed (hidden) ancestor, so daemon agents under `~/.agend-terminal` were invisible to it. The daemon now creates a non-hidden link (`<base>/<instance>` → the hidden real workspace) and spawns agy with `$PWD` pointed at that link, clearing agy's hidden-path guard while the real files stay under `$AGEND_HOME`. `configure_agy` writes the project-scoped `.agents/mcp_config.json` + `.agents/AGENTS.md` (agy's official Customization Roots), so `agy` loads the fleet `send`/`inbox`/`task` tools like every other backend.
 
 ## Documentation
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -19,24 +19,6 @@ Status legend: **Upstream-blocker** (fix lives in another project) ·
 
 ## Upstream / external (not fixed in agend-terminal)
 
-### Antigravity CLI (`agy`) backend — unsupported
-- **Status:** Unsupported
-- **Why:** Beyond the missing Fleet MCP bridge, known problems with this
-  backend are not being addressed for now. Supporting it properly depends on
-  project-scoped MCP being available, or on a first-party CLI tool.
-- **Revisit when:** project-scoped MCP is supported (#1262), or a first-party
-  CLI tool lands.
-- **Refs:** #1547, #1262, #987
-
-### `agy` ignores a hidden parent-directory workspace
-- **Status:** Upstream-blocker
-- **Why:** `agy` treats paths under a hidden directory (e.g.
-  `~/.agend-terminal/*`) as hidden and skips them, so it won't operate in the
-  daemon-managed workspace. The fix belongs in the upstream CLI
-  (`@google/antigravity-cli`).
-- **Revisit when:** upstream supports hidden parent-directory workspaces.
-- **Refs:** #998
-
 ### `opencode --continue` occasionally fails to resume
 - **Status:** Upstream bug (mitigated)
 - **Why:** the OpenCode TUI can send a placeholder ("dummy") session id on

--- a/docs/release-smoke-checklist.md
+++ b/docs/release-smoke-checklist.md
@@ -65,7 +65,7 @@ Gemini CLI's official successor (Gemini CLI sunsets 2026-06-18 for free / Pro / 
 - [ ] **Echo** — inject `echo hello` + Enter; response visible
 - [ ] **Tool use** — inject `list files in /tmp`; tool affordance fires
 - [ ] **Quit** — inject `/exit` + Enter; pane closes; no orphan `agy` process
-- [ ] **Fleet MCP unsupported notice (#995 Bug 3)** — `app.log` MUST contain a `[fleet-mcp-unsupported]` `tracing::warn` line on this spawn; the spawned agy instance has NO `send` / `inbox` / `task` MCP tools (awaiting upstream `google-antigravity/antigravity-cli#60`). For multi-agent fleet work, prefer the `gemini` backend until upstream lands the fix.
+- [ ] **Fleet MCP loads (#1547)** — the daemon creates a non-hidden link for the agy workspace (`<base>/<instance>` → the hidden real workspace) and spawns agy with `$PWD` pointed at it, and `configure_agy` writes `.agents/mcp_config.json` + `.agents/AGENTS.md`. Confirm: no `[fleet-mcp-unsupported]` warning; `app.log` shows the `$PWD` link line; the spawned agy has the `send` / `inbox` / `task` MCP tools (e.g. inject "list your fleet via `list_instances`" and verify it returns the fleet).
 
 ---
 


### PR DESCRIPTION
Reflects #1582 (merged) in user-facing docs: daemon-spawned **agy** now loads the fleet MCP.

## Changes
- **README Backends table** — agy `Unsupported` → `Tested`; the note now describes the mechanism (non-hidden `$PWD` link past agy's hidden-path guard + `.agents/` Customization Roots) rather than the old unsupported framing.
- **docs/KNOWN_ISSUES.md** — remove the two now-resolved agy entries:
  - "Antigravity CLI backend — unsupported" (agy is supported as of #1582).
  - "agy ignores a hidden parent-directory workspace" (worked around daemon-side via the non-hidden link, not awaiting upstream).
- **docs/release-smoke-checklist.md** — flip the "Fleet MCP unsupported notice" step to a "Fleet MCP loads" verification (no `[fleet-mcp-unsupported]` warn; `send`/`inbox`/`task` tools present).

## Scope
Docs-only — no code touched. Mechanism details already in CLAUDE.md (landed with #1582); this PR updates the user-facing surface.

Closes #1547 docs follow-up.