### PR TITLE
fix(lockaudit F1+F2): never hold registry across blocking PTY write; kill supervisor core→registry inversion

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1253,9 +1253,15 @@ fn spawn_instructions_bootstrap(
         // longer widens an external-mutation window.
         std::thread::sleep(std::time::Duration::from_millis(500));
 
-        let reg = &registry.lock();
-        if let Some(handle) = reg.get(&instance_id) {
-            if let Err(e) = inject_to_agent(handle, content.as_bytes(), true) {
+        // #1530/F1: snapshot the inject target under the registry lock, release
+        // it, THEN inject — don't hold the registry across the blocking write.
+        // force=true bootstrap → use the (non-gated) target inject directly.
+        let inject_snap = {
+            let reg = registry.lock();
+            reg.get(&instance_id).map(InjectTarget::from_handle)
+        };
+        if let Some(tgt) = inject_snap {
+            if let Err(e) = inject_with_target(&tgt, content.as_bytes()) {
                 tracing::warn!(agent = %name, error = %e, "instructions bootstrap inject failed");
             } else {
                 tracing::info!(
@@ -1815,7 +1821,15 @@ fn write_with_timeout(writer: &PtyWriter, data: &[u8]) -> std::io::Result<()> {
 }
 
 pub fn write_to_agent(agent: &AgentHandle, data: &[u8]) -> crate::error::Result<()> {
-    write_with_timeout(&agent.pty_writer, data).map_err(crate::error::AgendError::PtyWrite)?;
+    write_to_pty(&agent.pty_writer, data)
+}
+
+/// #1530/F1: write to a pre-captured [`PtyWriter`] (`Arc::clone(&h.pty_writer)`),
+/// so the caller can release the registry lock BEFORE this blocking write
+/// (`write_with_timeout` waits up to `PTY_WRITE_TIMEOUT`). Same delivery as
+/// [`write_to_agent`].
+pub(crate) fn write_to_pty(writer: &PtyWriter, data: &[u8]) -> crate::error::Result<()> {
+    write_with_timeout(writer, data).map_err(crate::error::AgendError::PtyWrite)?;
     Ok(())
 }
 
@@ -1829,7 +1843,9 @@ pub fn write_to_agent_typed(agent: &AgentHandle, data: &[u8]) -> crate::error::R
     Ok(())
 }
 
-/// Inject `text` (plus the backend submit key) into an agent's PTY.
+/// Inject `text` (plus the backend submit key) into an agent's PTY, via a
+/// pre-captured [`InjectTarget`] snapshot + agent `name`, so the caller can
+/// release the registry lock BEFORE this (potentially multi-second) write runs.
 ///
 /// `force` exempts the inject from the #1513 busy-gate. Pass `true` for
 /// recovery, operator, and drain injects that MUST reach the PTY: the
@@ -1838,22 +1854,33 @@ pub fn write_to_agent_typed(agent: &AgentHandle, data: &[u8]) -> crate::error::R
 /// convergence, so gating it would re-defer an already-flushed item). Pass
 /// `false` for daemon-originated direct injects (cron and schedule replay) that
 /// should yield to a mid-generation or mid-keystroke pane.
-pub fn inject_to_agent(agent: &AgentHandle, text: &[u8], force: bool) -> crate::error::Result<()> {
+///
+/// #1530/F1: this snapshot form replaced the old `inject_to_agent(&AgentHandle)`
+/// — callers must `InjectTarget::from_handle(h)` UNDER the registry lock, `drop`
+/// the guard, THEN call this — so the registry is never held across the (up to
+/// 5s `recv_timeout` + payload-scaled sleep) blocking write. The busy-gate's
+/// agent-state read is the lock-free on-disk snapshot (never the per-agent core
+/// lock, #1492).
+pub(crate) fn inject_with_target_gated(
+    target: &InjectTarget,
+    name: &str,
+    text: &[u8],
+    force: bool,
+) -> crate::error::Result<()> {
     // #1513 PR-2: gate direct PTY injects like the notification path. Self-
-    // contained via AGEND_HOME (this fn has no `home` in scope); the agent-state
-    // read is LOCK-FREE (snapshot) — never the per-agent core lock (#1492). When
-    // AGEND_HOME is absent (non-daemon / unit test) the gate is skipped.
+    // contained via AGEND_HOME; AGEND_HOME absent (non-daemon / unit test) →
+    // gate skipped.
     if !force {
         if let Ok(home) = std::env::var("AGEND_HOME") {
             let home = std::path::Path::new(&home);
-            if crate::inbox::notify::should_defer_direct_inject(home, agent.name.as_str()) {
+            if crate::inbox::notify::should_defer_direct_inject(home, name) {
                 // Gated direct injects (cron / replay) are UTF-8 text wakes;
                 // enqueue ambient-class for the per-tick flush to drain once the
                 // pane settles (the flush re-injects via the api INJECT path,
                 // landing back here with force=true — byte-equivalent delivery).
                 let _ = crate::notification_queue::enqueue_classified(
                     home,
-                    agent.name.as_str(),
+                    name,
                     &String::from_utf8_lossy(text),
                     false,
                 );
@@ -1861,8 +1888,7 @@ pub fn inject_to_agent(agent: &AgentHandle, text: &[u8], force: bool) -> crate::
             }
         }
     }
-    let target = InjectTarget::from_handle(agent);
-    inject_with_target(&target, text)
+    inject_with_target(target, text)
 }
 
 /// #1146: inner inject that works on a snapshot of fields rather than a

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -961,6 +961,33 @@ fn broadcast_registry_releases_lock_before_inject_1146() {
     );
 }
 
+/// #1530/F1 (lockaudit): the registry-borrow inject footgun
+/// `inject_to_agent(&AgentHandle)` is REMOVED. Every inject/write now goes
+/// through a snapshot — `inject_with_target_gated` / `inject_with_target`
+/// (an `InjectTarget`) or `write_to_pty` (a `PtyWriter`) — so a caller
+/// physically cannot hold the registry across the (up to 5s recv_timeout +
+/// payload-scaled sleep) blocking PTY write: capturing the snapshot drops the
+/// registry borrow. Re-introducing `fn inject_to_agent(&AgentHandle, …)` would
+/// re-open the freeze class (registry held across inject), so this pins it gone.
+#[test]
+fn inject_handle_footgun_removed_uses_snapshots_f1() {
+    let src = include_str!("mod.rs");
+    assert!(
+        !src.contains("pub fn inject_to_agent("),
+        "#1530/F1: inject_to_agent(&AgentHandle) must stay removed — it lets a caller \
+         hold the registry across a blocking inject; use inject_with_target_gated \
+         (snapshot under lock → drop → inject)"
+    );
+    assert!(
+        src.contains("pub(crate) fn inject_with_target_gated("),
+        "#1530/F1: the snapshot inject API inject_with_target_gated must exist"
+    );
+    assert!(
+        src.contains("pub(crate) fn write_to_pty("),
+        "#1530/F1: the snapshot write API write_to_pty must exist"
+    );
+}
+
 /// #1146 reviewer fix: inject_with_target must skip if the agent
 /// was deleted between snapshot and inject (delete/reuse race).
 /// The deleted flag is an Arc<AtomicBool> shared with AgentHandle,

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -12,18 +12,28 @@ pub(crate) fn handle_inject(params: &Value, ctx: &HandlerCtx) -> Value {
     }
     let data = params["data"].as_str().unwrap_or("");
     let raw = params["raw"].as_bool().unwrap_or(false);
-    let reg = agent::lock_registry(ctx.registry);
+    // #1530/F1: snapshot the inject target (+ the restarting check) under the
+    // registry lock, then RELEASE it before the (up to 5s + payload-scaled)
+    // blocking PTY write — never hold the registry across write/inject.
     // #1441: registry is UUID-keyed; resolve name via fleet.yaml.
-    match crate::fleet::resolve_uuid(ctx.home, name).and_then(|id| reg.get(&id)) {
-        Some(handle) => {
-            let is_restarting = handle.core.lock().state.current.is_unavailable();
+    let snap = {
+        let reg = agent::lock_registry(ctx.registry);
+        crate::fleet::resolve_uuid(ctx.home, name)
+            .and_then(|id| reg.get(&id))
+            .map(|handle| {
+                let is_restarting = handle.core.lock().state.current.is_unavailable();
+                (agent::InjectTarget::from_handle(handle), is_restarting)
+            })
+    };
+    match snap {
+        Some((tgt, is_restarting)) => {
             if is_restarting {
                 json!({"ok": false, "error": format!("agent '{name}' is restarting, retry later")})
             } else {
                 let result = if raw {
-                    agent::write_to_agent(handle, data.as_bytes())
+                    agent::write_to_pty(&tgt.pty_writer, data.as_bytes())
                 } else {
-                    agent::inject_to_agent(handle, data.as_bytes(), true)
+                    agent::inject_with_target_gated(&tgt, name, data.as_bytes(), true)
                 };
                 match result {
                     Ok(()) => json!({"ok": true, "result": {"bytes": data.len()}}),

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -178,13 +178,20 @@ fn respawn_agent_worker(
             }
             std::thread::sleep(std::time::Duration::from_secs(2));
             {
-                let r = reg.lock();
-                if let Some(handle) = respawned_id.and_then(|id| r.get(&id)) {
-                    let reason = handle.core.lock().health.crash_reason().to_string();
+                // #1530/F1: snapshot the writer + crash reason under the
+                // registry lock, then RELEASE it before the blocking PTY write.
+                let snap = {
+                    let r = reg.lock();
+                    respawned_id.and_then(|id| r.get(&id)).map(|handle| {
+                        let reason = handle.core.lock().health.crash_reason().to_string();
+                        (agent::InjectTarget::from_handle(handle), reason)
+                    })
+                };
+                if let Some((tgt, reason)) = snap {
                     let msg = format!(
                         "[system] Agent restarted due to {reason}. Previous context was lost.\r"
                     );
-                    let _ = agent::write_to_agent(handle, msg.as_bytes());
+                    let _ = agent::write_to_pty(&tgt.pty_writer, msg.as_bytes());
                 }
             }
             let rdir = run_dir(home);

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -129,14 +129,20 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
             &format!("{label}: {message}"),
         );
 
-        let reg = agent::lock_registry(registry);
         // #1441: registry is UUID-keyed; resolve target name via fleet.yaml.
         let target_id = crate::fleet::resolve_uuid(home, target);
-        // The inbox fallback below does self-IPC (`enqueue_with_idle_hint` →
-        // `api::call` over the loopback socket). It MUST run outside the
-        // registry-lock window: the API handler servicing the self-call needs
-        // the same lock, so calling it here deadlocks the daemon tick. Record
-        // the intent under the lock; execute the enqueue after `drop(reg)`.
+        // #1530/F1: snapshot the inject target under the registry lock, then
+        // RELEASE the lock before the (up to 5s + payload-scaled) blocking PTY
+        // write — the registry must not be held across inject. The inbox
+        // fallback below also does self-IPC (`enqueue_with_idle_hint` →
+        // `api::call` loopback), which the API handler can't service while we
+        // hold the registry — so it too runs only after the lock is released.
+        let inject_snap = {
+            let reg = agent::lock_registry(registry);
+            target_id
+                .and_then(|id| reg.get(&id))
+                .map(|h| (agent::InjectTarget::from_handle(h), h.name.to_string()))
+        };
         let mut deferred_inbox = false;
         let status = if fire.missed {
             // Daemon was down through the one-shot instant — don't silently
@@ -144,8 +150,8 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
             // three days ago). Just mark it missed so the user can see it
             // in run_history, and let the auto-disable below retire it.
             "missed"
-        } else if let Some(handle) = target_id.and_then(|id| reg.get(&id)) {
-            match agent::inject_to_agent(handle, message.as_bytes(), false) {
+        } else if let Some((tgt, name)) = inject_snap.as_ref() {
+            match agent::inject_with_target_gated(tgt, name, message.as_bytes(), false) {
                 Ok(()) => "ok",
                 Err(e) => {
                     tracing::warn!(error = %e, "schedule inject failed");
@@ -173,7 +179,6 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
             );
             "skipped_unknown_target"
         };
-        drop(reg);
 
         if deferred_inbox {
             let _ = crate::inbox::enqueue_with_idle_hint(

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -948,14 +948,21 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
             &format!("{label}: {message}"),
         );
 
-        let reg = agent::lock_registry(registry);
-        // #1441: registry is UUID-keyed; resolve target name via fleet.yaml.
-        if let Some(handle) = crate::fleet::resolve_uuid(home, target).and_then(|id| reg.get(&id)) {
-            if let Err(e) = agent::inject_to_agent(handle, message.as_bytes(), false) {
+        // #1530/F1: snapshot the inject target under the registry lock, then
+        // RELEASE it before the (up to 5s + payload-scaled) blocking PTY write —
+        // never hold the registry across inject. #1441: registry is UUID-keyed.
+        let inject_snap = {
+            let reg = agent::lock_registry(registry);
+            crate::fleet::resolve_uuid(home, target)
+                .and_then(|id| reg.get(&id))
+                .map(|h| (agent::InjectTarget::from_handle(h), h.name.to_string()))
+        };
+        if let Some((tgt, name)) = inject_snap {
+            if let Err(e) = agent::inject_with_target_gated(&tgt, &name, message.as_bytes(), false)
+            {
                 tracing::warn!(error = %e, "replay inject failed");
             }
         } else {
-            drop(reg);
             let _ = crate::inbox::enqueue_with_idle_hint(
                 home,
                 target,

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -636,14 +636,25 @@ fn tick(
     // deadlocks against code paths that take core then registry.
     // #1441: registry is UUID-keyed; carry the id for the re-lock lookup and
     // the display name for the many name-keyed side channels in this loop.
-    let handles: Vec<(crate::types::InstanceId, String, _)> = {
+    // #1530/F2: also capture each agent's backend_command here (under the
+    // registry lock, registry→core order) so the per-agent loop never needs to
+    // RE-acquire the registry while holding that agent's core — the core→registry
+    // inversion that risked an AB-BA deadlock with the registry→core render/
+    // monitor loops. `Backend::from_command` on the captured string is lock-free.
+    let handles: Vec<(String, String, _)> = {
         let reg = agent::lock_registry(registry);
-        reg.iter()
-            .map(|(id, h)| (*id, h.name.to_string(), Arc::clone(&h.core)))
+        reg.values()
+            .map(|h| {
+                (
+                    h.name.to_string(),
+                    h.backend_command.clone(),
+                    Arc::clone(&h.core),
+                )
+            })
             .collect()
     };
 
-    for (instance_id, name, core) in handles {
+    for (name, backend_command, core) in handles {
         // Mutate state + pull the tail under the core lock, then drop it
         // before running `format!` and the Telegram spawn. `tail_lines`
         // allocates a fresh String, so the lock window is bounded by the
@@ -728,12 +739,9 @@ fn tick(
             // spot is tracked in #1535; until then this site's regression
             // protection is the pure-fn tests + this comment.
             for decision in reactions_from_transitions(&transitions) {
-                let backend = {
-                    let reg = crate::agent::lock_registry(registry);
-                    reg.get(&instance_id).map(|h| h.backend_command.clone())
-                }
-                .as_deref()
-                .and_then(crate::backend::Backend::from_command);
+                // #1530/F2: backend resolved from the pre-captured command
+                // (no registry re-acquire while holding core).
+                let backend = crate::backend::Backend::from_command(&backend_command);
                 reaction_intents.push(ReactionIntent {
                     from: decision.from,
                     to: decision.to,
@@ -760,15 +768,10 @@ fn tick(
             let idle_expectation = idle_expectation_for(home, &name);
             if core.health.check_awaiting_operator(agent_state, silent) && {
                 // #1552 escalation FP-gates (only reached when silent>30s +
-                // a prompt state, so this registry lock + re-detect is rare,
-                // not per-tick). Lock-free w.r.t. self-IPC; registry-under-
-                // core mirrors the established ordering in this loop.
-                let backend = {
-                    let reg = crate::agent::lock_registry(registry);
-                    reg.get(&instance_id).map(|h| h.backend_command.clone())
-                }
-                .as_deref()
-                .and_then(crate::backend::Backend::from_command);
+                // a prompt state). #1530/F2: backend resolved from the
+                // pre-captured command — NO registry re-acquire while holding
+                // core (removes the core→registry inversion).
+                let backend = crate::backend::Backend::from_command(&backend_command);
                 let (typed_ms, _submit_ms) =
                     crate::notification_queue::read_input_submit_timestamps(home, &name);
                 awaiting_escalation_allowed(
@@ -1091,13 +1094,21 @@ pub(crate) fn process_server_rate_limit_retries(
         }
 
         let injected = {
-            let reg = agent::lock_registry(registry);
-            // #1441: registry is UUID-keyed; resolve the name-keyed track id.
-            if let Some(handle) = crate::fleet::resolve_uuid(home, name).and_then(|id| reg.get(&id))
-            {
-                agent::inject_to_agent(handle, CONTINUE_RETRY_PAYLOAD, true).is_ok()
-            } else {
-                false
+            // #1530/F1: snapshot the inject target under the registry lock, then
+            // release it BEFORE the (up to 5s) blocking PTY write — never hold
+            // the registry across inject. #1441: registry is UUID-keyed.
+            let snap = {
+                let reg = agent::lock_registry(registry);
+                crate::fleet::resolve_uuid(home, name)
+                    .and_then(|id| reg.get(&id))
+                    .map(agent::InjectTarget::from_handle)
+            };
+            match snap {
+                Some(tgt) => {
+                    agent::inject_with_target_gated(&tgt, name, CONTINUE_RETRY_PAYLOAD, true)
+                        .is_ok()
+                }
+                None => false,
             }
         };
 
@@ -1700,6 +1711,37 @@ instances:
     #[test]
     fn notify_cooldown_is_60_seconds() {
         assert_eq!(super::NOTIFY_COOLDOWN, std::time::Duration::from_secs(60));
+    }
+
+    /// #1530/F2 (lockaudit): the per-agent tick must NOT re-acquire the registry
+    /// while holding an agent core (the core→registry inversion that risked an
+    /// AB-BA deadlock with the registry→core render/monitor loops). The backend
+    /// is pre-captured in the handles snapshot (registry→core order) and resolved
+    /// lock-free; the old nested per-agent registry lookups under the core lock
+    /// are gone. Source-grep pin (mirrors #1146); scoped to the `tick` fn body so
+    /// it never matches its own assertion text.
+    #[test]
+    fn tick_does_not_reacquire_registry_under_core_f2() {
+        let src = include_str!("supervisor.rs");
+        let start = src
+            .find("\nfn tick(")
+            .expect("supervisor tick fn must exist");
+        // The per-agent loop lives well within the first 18 KB of the fn; the
+        // test module is far past that, so this window excludes this test.
+        let body = &src[start..(start + 18_000).min(src.len())];
+        // The removed nested lookup keyed the registry by the per-agent id.
+        let needle = ["reg.get(&", "instance_id)"].concat();
+        assert!(
+            !body.contains(&needle),
+            "#1530/F2: the tick per-agent loop must not re-look-up the registry by \
+             agent id while holding the core — the backend is pre-captured in the \
+             handles snapshot (registry→core)"
+        );
+        assert!(
+            body.contains("backend_command"),
+            "#1530/F2: tick must pre-capture each agent's backend_command in the \
+             handles snapshot and resolve Backend lock-free"
+        );
     }
 
     // ── #1523: AuthError content-FP stability gate ──────────────────────

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -135,11 +135,17 @@ impl Pane {
         self.mark_input_activity();
         match &self.source {
             PaneSource::Local => {
-                let reg = agent::lock_registry(registry);
-                if let Some(handle) = reg.get(&self.instance_id) {
-                    let _ = agent::write_to_agent(handle, bytes);
+                // #1530/F1: snapshot the writer under the registry lock, release
+                // it, THEN write — never hold the registry across the (up to 5s)
+                // blocking PTY write.
+                let writer_snap = {
+                    let reg = agent::lock_registry(registry);
+                    reg.get(&self.instance_id)
+                        .map(|h| agent::InjectTarget::from_handle(h).pty_writer)
+                };
+                if let Some(writer) = writer_snap {
+                    let _ = agent::write_to_pty(&writer, bytes);
                 }
-                drop(reg);
                 // Clear reply_to on TUI keyboard input (Sprint 52).
                 crate::daemon::heartbeat_pair::update_with(&self.agent_name, |p| {
                     p.reply_to_channel = None;


### PR DESCRIPTION
From the lock-while-blocking RCA (`/tmp/lockaudit-dev-rca.md`) — the #1492/#1535/#1571/#1583 freeze class. Two unpatched siblings the three prior fixes never covered. Proven #1530 collect→drop→emit pattern.

## F1 ⭐ (highest-likelihood next freeze)
The **registry lock was held across a blocking `inject_to_agent`/`write_to_agent`** — `write_with_timeout` waits up to `PTY_WRITE_TIMEOUT` (5s) on a channel `recv_timeout`, and `inject_to_agent` sleeps proportionally to payload size. A stuck/slow PTY writer (or a large inject) stalled **every** registry consumer (supervisor tick, all injects, API handlers, TUI render) for seconds. Same class as #1583, opposite direction (write/inject) + the registry lock.

**Fix** — snapshot-emit helpers + convert the 7 lock-held sites to *snapshot-under-lock → `drop` → emit*:
- `inject_with_target_gated(&InjectTarget, name, text, force)` — gate + inject on a pre-captured snapshot. The old `inject_to_agent(&AgentHandle)` **footgun is removed** so no caller can inject while still borrowing the registry.
- `write_to_pty(&PtyWriter, data)` — write on a captured writer.
- Sites: `supervisor.rs` (ServerRateLimit continue-inject), `daemon/mod.rs` (schedule replay), `cron_tick.rs` (schedule fire), `api/handlers/instance.rs` (inject/write handler), `crash_respawn.rs` (restart notice), `agent/mod.rs` (instructions bootstrap), `layout/pane.rs` (TUI keystroke write).

## F2 (lock-ordering inversion)
The supervisor per-agent tick **re-acquired the registry while holding an agent core** (core→registry) at the #1530 reaction-backend + #1552 escalation gates — inverting the registry→core order used by the render/monitor/API loops (AB-BA deadlock risk). **Fix:** pre-capture each agent's `backend_command` in the tick-top handles snapshot (registry→core) and resolve `Backend::from_command` lock-free — no nested registry re-acquire under a core.

## Tests (source-grep pins, mirroring #1146)
- `inject_handle_footgun_removed_uses_snapshots_f1` — the `&AgentHandle` inject footgun stays removed; the snapshot APIs exist.
- `tick_does_not_reacquire_registry_under_core_f2` — the tick loop never re-looks-up the registry by agent id while holding a core; backend is pre-captured.

## Out of scope (separate follow-up)
Finding 3 — the lock-ordering tier audit is dormant (`lock_acquired` is never called → `CURRENT_TIER` always 0 → the descending-order check is dead). Reviving it is a separate PR.

## Preflight
`fmt` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · `test --tests --features tray` (60 binaries, 0 failed) ✓ · `xwin check` ✓. Rebased onto current `main` (no reverse-revert; diff is 8 source files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)