### PR TITLE
feat(#1339): mode-aware notification routing (PR-2)

### DIFF
--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -383,6 +383,41 @@ pub enum AgentOutboundOp {
     InjectProvenance { from: String, task: String },
 }
 
+/// #1339 PR-2: mode-aware notification policy. The operator mode (#1575)
+/// decides which severities are worth pinging the operator's channel for:
+///
+/// - `Active` — operator at the TUI; today's behavior: **every** severity
+///   passes (hard `true`, no per-severity computation), so a future filter
+///   bug can never silently drop an active-mode notice (reviewer-2 risk).
+/// - `Away` — operator reachable via the channel but not at the TUI: routine
+///   `Info` (e.g. the "ready again" recovery ping) is suppressed; `Warn` and
+///   `Error` still go through.
+/// - `Sleep` — operator unreachable: only `Error` (P0 — a crash, or an agent
+///   stuck awaiting the operator, see #1552 in `daemon::supervisor`) breaks
+///   through; `Info`/`Warn` are held.
+///
+/// CHECKED match on the severity axis for `Away`/`Sleep` (no `_` catch-all) —
+/// adding a `NotifySeverity` variant fails to compile until its per-mode
+/// policy is stated here, the regression-guard the single-chokepoint design
+/// depends on.
+fn should_notify_in_mode(
+    severity: NotifySeverity,
+    mode: crate::operator_mode::OperatorMode,
+) -> bool {
+    use crate::operator_mode::OperatorMode;
+    match mode {
+        OperatorMode::Active => true,
+        OperatorMode::Away => match severity {
+            NotifySeverity::Info => false,
+            NotifySeverity::Warn | NotifySeverity::Error => true,
+        },
+        OperatorMode::Sleep => match severity {
+            NotifySeverity::Info | NotifySeverity::Warn => false,
+            NotifySeverity::Error => true,
+        },
+    }
+}
+
 /// Outbound notify gate — only forwards to [`Channel::notify`] when the
 /// channel reports [`Channel::outbound_authorized`] = `true`. When the
 /// channel is unauthorised (no allowlist configured), the call is
@@ -403,6 +438,22 @@ pub fn gated_notify(
     message: &str,
     silent: bool,
 ) -> std::result::Result<(), ChannelError> {
+    // #1339 PR-2: mode gate at the single Telegram chokepoint. `get()` reads
+    // the process-global operator-mode snapshot the daemon reloads each tick
+    // (reload-coherent); outside the daemon it defaults to `Active`, so this is
+    // a no-op for tests and one-off callers. Placed before the authorization
+    // gate so a mode-suppressed notice is dropped without touching the channel.
+    let mode = crate::operator_mode::get().mode;
+    if !should_notify_in_mode(severity, mode) {
+        tracing::debug!(
+            instance,
+            ?severity,
+            ?mode,
+            "gated_notify: suppressed by operator mode"
+        );
+        return Ok(());
+    }
+
     if !channel.outbound_authorized() {
         // Sprint 22 P1.5 (Candidate 4 from PR #229 P1 dispatch): the
         // previous `tracing::debug!` was invisible at default
@@ -543,6 +594,36 @@ mod tests {
         assert_ne!(NotifySeverity::Info, NotifySeverity::Error);
     }
 
+    /// #1339 PR-2: the full (mode × severity) policy grid. Active passes
+    /// everything (M2 hard-true); Away suppresses only Info; Sleep passes only
+    /// Error (the P0 tier #1552 AwaitingOperator rides on).
+    #[test]
+    fn should_notify_in_mode_policy_grid() {
+        use crate::operator_mode::OperatorMode::{Active, Away, Sleep};
+        use NotifySeverity::{Error, Info, Warn};
+
+        // Active — every severity passes, unconditionally.
+        for sev in [Info, Warn, Error] {
+            assert!(
+                should_notify_in_mode(sev, Active),
+                "Active must pass {sev:?}"
+            );
+        }
+
+        // Away — Info suppressed; Warn + Error pass.
+        assert!(!should_notify_in_mode(Info, Away), "Away suppresses Info");
+        assert!(should_notify_in_mode(Warn, Away), "Away passes Warn");
+        assert!(should_notify_in_mode(Error, Away), "Away passes Error");
+
+        // Sleep — only Error breaks through.
+        assert!(!should_notify_in_mode(Info, Sleep), "Sleep suppresses Info");
+        assert!(!should_notify_in_mode(Warn, Sleep), "Sleep suppresses Warn");
+        assert!(
+            should_notify_in_mode(Error, Sleep),
+            "Sleep passes Error (P0 — AwaitingOperator / crash)"
+        );
+    }
+
     /// Mock channel that records every `notify` call so tests can pin
     /// the gate's pass / drop semantics. Used by the [`gated_notify`]
     /// tests below.
@@ -618,8 +699,12 @@ mod tests {
     fn gated_notify_drops_when_channel_unauthorized() {
         // Fail-closed default: trait method returns false, gate drops
         // the call; underlying `notify` must NOT be invoked.
+        //
+        // #1339 PR-2: `Error` so the drop is provably the *authorization* gate
+        // firing, not the mode gate — `Error` passes every operator mode, so it
+        // always reaches the `outbound_authorized` check this test pins.
         let ch = RecordingChannel::new(false);
-        let result = gated_notify(&ch, "agent1", NotifySeverity::Warn, "leak-bait", false);
+        let result = gated_notify(&ch, "agent1", NotifySeverity::Error, "leak-bait", false);
         assert!(matches!(result, Ok(())), "drop must be Ok, got {result:?}");
         assert_eq!(
             ch.count(),
@@ -632,8 +717,14 @@ mod tests {
     fn gated_notify_forwards_when_channel_authorized() {
         // Operator opted in (allowlist configured) → channel reports
         // outbound_authorized=true → gate forwards to notify.
+        //
+        // #1339 PR-2: use `Error` so this test isolates the *authorization*
+        // gate from the *mode* gate — `Error` passes every operator mode, so a
+        // concurrent operator_mode test leaving the process-global at
+        // `Away`/`Sleep` can't drop this notice and flake the assertion. The
+        // mode dimension is covered by `should_notify_in_mode_policy_grid`.
         let ch = RecordingChannel::new(true);
-        let result = gated_notify(&ch, "agent1", NotifySeverity::Info, "ok", true);
+        let result = gated_notify(&ch, "agent1", NotifySeverity::Error, "ok", true);
         assert!(result.is_ok(), "authorised forward must succeed");
         assert_eq!(
             ch.count(),

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -228,8 +228,20 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         );
         let task_id = result["id"].as_str().unwrap_or("?");
         tracing::info!(title, task_id, "task created via telegram keyword");
+        // #1339 PR-2: route the task-create ACK through the single `gated_notify`
+        // chokepoint too — there must be NO production `Channel::notify` call
+        // that skips the operator-mode gate. An operator messaging the channel
+        // does NOT auto-flip the mode (it is read from `operator-mode.json`,
+        // explicitly set), so a direct `ch.notify` here would bypass the gate.
+        // Routed through, an explicit `Sleep`/`Away` suppresses this `Info` ack
+        // (consistent with the mode's "hold non-Error" semantics); `Active`
+        // (the default) passes it unchanged. The distinct "an operator-initiated
+        // request's ACK should always reach the operator regardless of mode"
+        // semantic is a separate operator-response path, tracked as a follow-up
+        // and out of scope here.
         if let Some(ch) = crate::channel::active_channel() {
-            let _ = ch.notify(
+            let _ = crate::channel::gated_notify(
+                ch.as_ref(),
                 "operator",
                 crate::channel::NotifySeverity::Info,
                 &format!("✅ Task created: {title} [{task_id}]"),

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -960,11 +960,21 @@ fn tick(
                 // `gated_notify` drops the call when the channel is
                 // unauthorised; legacy `None`-allowlist deployments
                 // require explicit opt-in via `user_allowlist: [...]`.
+                //
+                // #1339 PR-2 (M3): `Error`, not `Warn`. Both producers of this
+                // `Stall` notice are "agent blocked, awaiting the operator" —
+                // the #1552 AwaitingOperator escalation and the #1563
+                // InteractivePrompt forward. That is exactly the P0 that must
+                // break through `Sleep`/`Away`: at `Warn` the gate would
+                // silently drop it while the operator is asleep, leaving the
+                // agent stuck on a prompt forever. (Severity is routing-only —
+                // the Telegram adapter ignores it for rendering — so this does
+                // not change the Active-mode message.)
                 if let Some(ch) = crate::channel::active_channel() {
                     let _ = crate::channel::gated_notify(
                         ch.as_ref(),
                         &name,
-                        NotifySeverity::Warn,
+                        NotifySeverity::Error,
                         &msg,
                         false,
                     );

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -717,21 +717,34 @@ fn compliance_sweep(home: &Path, repo: &str) -> Vec<ComplianceViolation> {
                     "compliance violation"
                 );
             }
-            // Telegram alert (dedup: skip if already alerted)
+            // Telegram alert (dedup: skip if already alerted).
+            //
+            // #1339 PR-2: route through `gated_notify` (the single operator-mode
+            // chokepoint) instead of `notify_telegram` directly. This is a
+            // fleet-initiated daemon job, so it MUST honor operator mode —
+            // `Sleep` suppresses this `Warn`-tier ping (the violation is still
+            // recorded by the `tracing::warn!` above, so nothing is lost) and
+            // it also picks up the outbound-allowlist gate. Compliance is
+            // important but not P0-crash class, so `Warn` (not `Error`).
             if !cfg.alerted_prs.contains(&pr.number) {
-                crate::channel::telegram::notify::notify_telegram(
-                    home,
-                    SWEEP_EMITTER,
-                    &format!(
-                        "⚠️ Compliance violation PR #{}: {}",
-                        pr.number,
-                        violations
-                            .iter()
-                            .map(|v| v.check_name)
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ),
+                let msg = format!(
+                    "⚠️ Compliance violation PR #{}: {}",
+                    pr.number,
+                    violations
+                        .iter()
+                        .map(|v| v.check_name)
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 );
+                if let Some(ch) = crate::channel::active_channel() {
+                    let _ = crate::channel::gated_notify(
+                        ch.as_ref(),
+                        SWEEP_EMITTER,
+                        crate::channel::NotifySeverity::Warn,
+                        &msg,
+                        false,
+                    );
+                }
                 cfg.alerted_prs.push(pr.number);
             }
         }


### PR DESCRIPTION
Implements **#1339 PR-2** per the signed 4-lens synthesis (`/tmp/1339-pr2-synthesis.md`) — **not** the original issue spec (no `severity` field on `AgentState`, no `is_p0_class`, no AgentState changes).

Operator mode (#1575) now gates which notification severities reach the operator's channel: an away/sleeping operator stops getting routine pings, while genuine P0s still break through.

## Must-fix points
- **M1 — single chokepoint.** `should_notify_in_mode(severity, mode)` added inside `channel::gated_notify` (the one Telegram funnel). Reuses the existing `NotifySeverity{Info,Warn,Error}`.
- **M2 — Active is a hard `=> true`** for every severity (no computation / fall-through), so a future filter bug can't silently drop an active-mode notice. `Away` suppresses `Info`; `Sleep` passes only `Error`. `Away`/`Sleep` use a **CHECKED match** on severity (no `_`) → a new `NotifySeverity` variant fails to compile until its policy is stated.
- **M3 — #1552 AwaitingOperator / #1563 InteractivePrompt stall notice → `Error`** (`daemon::supervisor`). Both producers mean "agent blocked, awaiting operator" = the P0 that must survive `Sleep`. Severity is routing-only (the Telegram adapter ignores it for rendering), so Active-mode output is unchanged.

## Chokepoint completeness (review revision — codex)
The "single chokepoint" must be **literal**: no production `Channel::notify` / `notify_telegram` may skip `gated_notify`. Two direct callers were routed through it:
- **task_sweep.rs** compliance-violation alert (fleet-initiated daemon job) — was `notify_telegram` direct → now `gated_notify` (Warn).
- **inbound.rs** "✅ Task created" ack — was `ch.notify` direct → now `gated_notify`. An operator messaging the channel does NOT auto-flip the mode, so the direct call genuinely bypassed the gate. Routed through: `Active` passes the Info ack unchanged; explicit `Sleep`/`Away` holds it.

Audited every `notify_telegram(` / `ch.notify(` caller — the only production sinks are now `gated_notify` → the telegram adapter's `Channel::notify` impl; everything else is tests or the unrelated `ApiEvent` notifier.

## Tests
- `should_notify_in_mode_policy_grid` — full (mode × severity) grid.
- The two existing `gated_notify` auth-gate tests use `Error` severity to isolate the authorization gate from the mode gate (prevents a cross-test global-mode flake; the mode dimension is covered by the grid test).
- clippy `--all-targets -D warnings` green; full `cargo test --bin` (3030) green.

## Follow-ups (out of scope, per synthesis / review)
- **Operator-response path** — "an operator-initiated request's ACK should always reach the operator regardless of mode" is a distinct path; the task-create ack rides the fleet-notify gate for now.
- **S1** reachability — `AuthError` / `UsageLimit` can't reach Telegram today.
- **ServerRateLimit-exhausted** (`supervisor.rs`) Warn→Error — tracked in #1595.
- **S2** central `NotificationKind` router.