### PR TITLE
fix(#1591): reuse retained tab on same-name re-create (no duplicate-tab leak)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -778,14 +778,37 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                                 Ok(pane) => {
                                     let tab_name = pane.agent_name.clone();
                                     known_remote_agents.insert(tab_name.to_string());
-                                    layout.push_tab_preserve_focus(
-                                        crate::layout::Tab::new(tab_name.to_string(), pane),
-                                    );
+                                    // #1591: this sync is add-only — a gone
+                                    // agent's tab is RETAINED (stale output) so
+                                    // scrollback survives. If a same-named agent
+                                    // re-appears (recovery respawn / operator
+                                    // create-after-delete churn), REUSE the
+                                    // retained single-pane tab in place (the
+                                    // fresh pane reconnects to the new instance;
+                                    // the stale dead-connection pane is dropped)
+                                    // instead of appending a DUPLICATE tab.
+                                    // Preserves tab position + focus.
+                                    if let Some(idx) =
+                                        layout.single_pane_tab_index_for_agent(&tab_name)
+                                    {
+                                        layout.tabs[idx] = crate::layout::Tab::new(
+                                            tab_name.to_string(),
+                                            pane,
+                                        );
+                                        tracing::info!(
+                                            agent = %name,
+                                            "reused retained tab for re-appeared remote agent (no duplicate)"
+                                        );
+                                    } else {
+                                        layout.push_tab_preserve_focus(
+                                            crate::layout::Tab::new(tab_name.to_string(), pane),
+                                        );
+                                        tracing::info!(
+                                            agent = %name,
+                                            "opened tab for newly-appeared remote agent"
+                                        );
+                                    }
                                     needs_resize = true;
-                                    tracing::info!(
-                                        agent = %name,
-                                        "opened tab for newly-appeared remote agent"
-                                    );
                                 }
                                 Err(e) => tracing::warn!(
                                     agent = %name,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -91,6 +91,20 @@ impl Layout {
         self.tabs.push(tab);
     }
 
+    /// #1591: index of the single-pane tab whose sole pane belongs to
+    /// `agent_name`, if any. The Attached remote-agent sync is add-only (a gone
+    /// agent's tab is RETAINED with stale output), so when a same-named agent
+    /// re-appears — recovery respawn, or operator create-after-delete churn —
+    /// this lets the sync REUSE the retained tab (reconnect in place) instead of
+    /// appending a duplicate. Scoped to single-pane tabs: a tab the operator has
+    /// split with other agents must not be clobbered, so it falls back to a
+    /// fresh append in that (rare) case.
+    pub fn single_pane_tab_index_for_agent(&self, agent_name: &str) -> Option<usize> {
+        self.tabs.iter().position(|t| {
+            t.root().pane_count() == 1 && t.root().first_pane().agent_name.as_str() == agent_name
+        })
+    }
+
     pub fn active_tab(&self) -> Option<&Tab> {
         self.tabs.get(self.active)
     }
@@ -305,6 +319,58 @@ mod tests {
         assert_eq!(layout.active, 2);
         layout.next_tab();
         assert_eq!(layout.active, 0);
+    }
+
+    /// #1591: locate a retained single-pane tab by agent name; absent → None;
+    /// a multi-pane (operator-split) tab is NOT matched (must not be clobbered).
+    #[test]
+    fn single_pane_tab_index_for_agent_1591() {
+        let mut layout = Layout::new();
+        layout.push_tab_preserve_focus(Tab::new("t-a".to_string(), leaf(1, "a")));
+        layout.push_tab_preserve_focus(Tab::new("t-b".to_string(), leaf(2, "b")));
+        assert_eq!(layout.single_pane_tab_index_for_agent("b"), Some(1));
+        assert_eq!(layout.single_pane_tab_index_for_agent("a"), Some(0));
+        assert_eq!(layout.single_pane_tab_index_for_agent("absent"), None);
+        // A tab the operator split with a second agent is multi-pane → not a
+        // reuse target (whole-tab replace would clobber the other pane).
+        layout.tabs[1].split_focused(SplitDir::Vertical, leaf(3, "c"));
+        assert_eq!(
+            layout.single_pane_tab_index_for_agent("b"),
+            None,
+            "#1591: split (multi-pane) tab must not be a reuse target"
+        );
+    }
+
+    /// #1591: re-appearance of a same-named agent REUSES its retained tab in
+    /// place — no duplicate tab, and the operator's active tab is NOT stolen.
+    #[test]
+    fn reuse_retained_tab_no_duplicate_or_focus_steal_1591() {
+        let mut layout = Layout::new();
+        // Operator working on tab 0; a (now-stale, gone) agy-verify tab retained
+        // at index 1 (add-only sync never removed it).
+        layout.push_tab_preserve_focus(Tab::new("work".to_string(), leaf(1, "operator")));
+        layout.push_tab_preserve_focus(Tab::new("agy-verify".to_string(), leaf(2, "agy-verify")));
+        assert_eq!(layout.active, 0, "operator is on tab 0");
+        let before = layout.tabs.len();
+
+        // agy-verify is re-created → the sync's reuse path replaces the retained
+        // tab in place with a fresh pane (id 99) rather than appending.
+        let idx = layout
+            .single_pane_tab_index_for_agent("agy-verify")
+            .expect("retained agy-verify tab must be found");
+        layout.tabs[idx] = Tab::new("agy-verify".to_string(), leaf(99, "agy-verify"));
+
+        assert_eq!(
+            layout.tabs.len(),
+            before,
+            "#1591: no duplicate tab appended"
+        );
+        assert_eq!(layout.active, 0, "#1591: operator focus not stolen");
+        assert_eq!(
+            layout.tabs[idx].root().first_pane().id,
+            99,
+            "#1591: retained tab now carries the fresh (reconnected) pane"
+        );
     }
     #[test]
     fn move_pane_across_tabs_same_tab_rejected() {


### PR DESCRIPTION
## Re-scope (reality-check)
Filed as "spawn steals TUI focus", but a spike (`/tmp/1591-spike.md`) showed the programmatic-spawn tab-add already uses `push_tab_preserve_focus` (no steal) and operator-foreground spawns correctly switch. The lead confirmed the re-scope to the **real** bug.

## Bug
The Attached remote-agent sync (`src/app/mod.rs`) is **add-only** — a gone agent's tab is **retained** (stale output) on purpose so scrollback survives. But when a **same-named** agent re-appears — **recovery respawn** (crash → respawn `agy-xxx`) or operator **create-after-delete churn** (the spawn-verify cycle that surfaced this) — the sync appended a **second** tab for that name (the stale one was never removed). Repeat → the tab bar fills with stale duplicates.

## Fix (surgical, respects the retention tradeoff)
When the sync re-adds a name, if a retained **single-pane** tab for that agent already exists, **reuse it in place** — replace its stale dead-connection pane with the fresh reconnected pane — instead of appending a duplicate. New `Layout::single_pane_tab_index_for_agent`. Scoped to single-pane tabs so a tab the operator has split with other agents is never clobbered (falls back to append in that rare case). Preserves tab position + focus (`push_tab_preserve_focus` still used for genuinely-new agents).

A re-created agent is a **new instance**, so dropping the stale dead-agent scrollback and showing the fresh connection is correct — no scrollback-continuity concern.

## Tests
- `single_pane_tab_index_for_agent_1591` — finds by name; `None` when absent; **not** matched for a multi-pane (operator-split) tab.
- `reuse_retained_tab_no_duplicate_or_focus_steal_1591` — re-appearance reuses the retained tab in place: tab count unchanged (no duplicate), operator's active tab not stolen, slot carries the fresh pane.

## Preflight
`fmt` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · `test --tests --features tray` (60 binaries, 0 failed) ✓ · `xwin check` ✓. Rebased onto current `main`.

Closes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)