### PR TITLE
fix(#1597): conditional agy workspace link (only when cwd is hidden)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -847,6 +847,9 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
         }
     }
 
+    // #1597: the resolved cwd we actually hand the PTY — captured so the agy
+    // `$PWD` arm below decides on (and points at) the SAME path agy will see.
+    let mut spawn_cwd: Option<PathBuf> = None;
     if let Some(dir) = working_dir {
         // Defense-in-depth: the API spawn handler already calls
         // validate_working_directory at admission, but a symlink could have
@@ -865,6 +868,7 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
             let resolved = crate::api::validate_working_directory(dir, home_path)
                 .map_err(|e| anyhow::anyhow!("working_directory escapes via symlink: {e}"))?;
             cmd.cwd(&resolved);
+            spawn_cwd = Some(resolved);
         } else {
             tracing::warn!(
                 instance = %name,
@@ -873,34 +877,50 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
             );
             std::fs::create_dir_all(dir).ok();
             cmd.cwd(dir);
+            spawn_cwd = Some(dir.to_path_buf());
         }
     }
 
     // #1547 (A): agy rejects a workspace whose path has a dot-prefixed (hidden)
-    // ancestor — and every daemon workspace lives under `$AGEND_HOME`
-    // (`~/.agend-terminal`, hidden). agy reads the workspace path from `$PWD`
-    // (not getcwd/realpath; operator e2e-verified), so we keep the CWD at the
-    // real hidden workspace (the validated allowed root set via `cmd.cwd` above)
-    // but point `$PWD` at a NON-hidden link to it. Done LAST — after the
-    // fleet.yaml user-env loop — so the daemon-derived value is authoritative
-    // (mirrors the opencode XDG_DATA_HOME placement rationale above). Link
-    // failure is non-fatal: agy still spawns, just without fleet MCP (the
-    // pre-#1547 behavior), and the boot invariant in `spawn_agent` warns.
+    // ancestor and reads the workspace path from `$PWD` (not getcwd/realpath;
+    // operator e2e-verified). #1597 makes this CONDITIONAL on the resolved cwd:
+    //
+    // - cwd has NO hidden component (e.g. an explicit non-hidden
+    //   `working_directory`) → agy accepts it directly. Set `$PWD` to the real
+    //   cwd and SKIP the link, so agy reports the user's actual dir and we leave
+    //   no stray symlink shadowing it.
+    // - cwd has a hidden ancestor (the default `$AGEND_HOME/workspace/<name>`
+    //   under `~/.agend-terminal`) → agy would reject it. Point `$PWD` at a
+    //   NON-hidden link to the same dir (the cwd stays the real allowed root).
+    //   This is the case #1547/#1582 exists for.
+    //
+    // Done LAST — after the fleet.yaml user-env loop — so the daemon value is
+    // authoritative. Link failure is non-fatal (agy still spawns, just without
+    // fleet MCP; the boot invariant in `spawn_agent` warns).
     if matches!(detected_backend, Some(Backend::Agy)) {
-        if let (Some(dir), Some(home_path)) = (working_dir, home) {
-            match crate::agy_workspace::ensure_link(home_path, name, dir) {
-                Ok(link) => {
-                    cmd.env("PWD", &link);
-                    tracing::debug!(
-                        instance = %name, pwd = %link.display(),
-                        "agy: $PWD set to non-hidden workspace link"
-                    );
+        if let (Some(cwd), Some(home_path)) = (spawn_cwd.as_deref(), home) {
+            if crate::agy_workspace::path_has_hidden_component(cwd) {
+                match crate::agy_workspace::ensure_link(home_path, name, cwd) {
+                    Ok(link) => {
+                        cmd.env("PWD", &link);
+                        tracing::debug!(
+                            instance = %name, pwd = %link.display(),
+                            "agy: hidden workspace — $PWD set to non-hidden link"
+                        );
+                    }
+                    Err(e) => tracing::warn!(
+                        instance = %name, error = %e,
+                        "agy: could not create non-hidden workspace link — agy will \
+                         reject the hidden workspace and load no fleet MCP"
+                    ),
                 }
-                Err(e) => tracing::warn!(
-                    instance = %name, error = %e,
-                    "agy: could not create non-hidden workspace link — agy will \
-                     reject the hidden workspace and load no fleet MCP"
-                ),
+            } else {
+                // Non-hidden cwd: agy accepts it as-is — no link needed.
+                cmd.env("PWD", cwd);
+                tracing::debug!(
+                    instance = %name, pwd = %cwd.display(),
+                    "agy: non-hidden workspace — $PWD set to the real dir (no link)"
+                );
             }
         }
     }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -827,37 +827,25 @@ fn build_command_sets_git_editor_defaults() {
     }
 }
 
-/// #1547 (A): `build_command` for an agy backend must set `$PWD` to the
-/// NON-hidden workspace link (so agy's hidden-path guard passes) while the
-/// CWD stays the real hidden workspace. The `agy_workspace::ensure_link` unit
-/// tests cover the link helper in isolation; THIS pins the integration —
-/// that the agy arm in `build_command` actually wires the link path into the
-/// child env. Unix-only: the link is a symlink here (Windows uses a junction,
-/// compile-checked on Windows CI; the PWD-wiring logic is platform-identical).
+/// #1597 helper: run `build_command` for an agy backend with the given home +
+/// workspace, returning the resulting cmd and the would-be link path. fleet.yaml
+/// pins `agy_workspace_link_base` inside `home` so tests never touch the real
+/// `<user_home>/agend-ws`.
 #[cfg(unix)]
-#[test]
-fn build_command_agy_sets_pwd_to_non_hidden_link() {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static N: AtomicU64 = AtomicU64::new(0);
-    let home = std::env::temp_dir().join(format!(
-        "agend-1547-{}-{}",
-        std::process::id(),
-        N.fetch_add(1, Ordering::Relaxed)
-    ));
-    let workspace = crate::paths::workspace_dir(&home).join("agy-int");
-    std::fs::create_dir_all(&workspace).expect("create workspace");
-    // Point the link base inside our tmp home so the test never writes into
-    // the real `<user_home>/agend-ws`.
+fn build_agy_cmd(
+    home: &std::path::Path,
+    workspace: &std::path::Path,
+) -> (CommandBuilder, std::path::PathBuf) {
+    std::fs::create_dir_all(workspace).expect("create workspace");
     let link_base = home.join("ws-links");
     std::fs::write(
-        crate::fleet::fleet_yaml_path(&home),
+        crate::fleet::fleet_yaml_path(home),
         format!(
             "instances: {{}}\nteams: {{}}\nagy_workspace_link_base: {}\n",
             link_base.display()
         ),
     )
     .expect("write fleet.yaml");
-
     let config = SpawnConfig {
         name: "agy-int",
         backend_command: "agy",
@@ -866,39 +854,107 @@ fn build_command_agy_sets_pwd_to_non_hidden_link() {
         cols: 80,
         rows: 24,
         env: None,
-        working_dir: Some(workspace.as_path()),
+        working_dir: Some(workspace),
         submit_key: "\r",
-        home: Some(home.as_path()),
+        home: Some(home),
         crash_tx: None,
         shutdown: None,
     };
     let (cmd, backend) = build_command(&config).expect("build_command");
     assert_eq!(backend, Some(Backend::Agy));
+    (cmd, crate::agy_workspace::link_path(home, "agy-int"))
+}
 
-    let expected_link = crate::agy_workspace::link_path(&home, "agy-int");
-    let pwd = cmd
-        .get_env("PWD")
-        .expect("agy build_command must set $PWD to the non-hidden link");
+#[cfg(unix)]
+fn agy_tmp(tag: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    std::env::temp_dir().join(format!(
+        "agend-1597-{tag}-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+/// #1597 case (a): an explicit NON-hidden working_directory → agy accepts it
+/// directly. `$PWD` is the real (resolved) dir and NO link is created (no
+/// shadowing, no stray symlink).
+#[cfg(unix)]
+#[test]
+fn build_command_agy_non_hidden_workspace_uses_real_dir_no_link() {
+    let home = agy_tmp("nonhidden").join("agend-home");
+    let workspace = home.join("proj");
+    let (cmd, link_path) = build_agy_cmd(&home, &workspace);
+
+    let resolved =
+        crate::api::validate_working_directory(&workspace, &home).expect("validate workspace");
+    let pwd = cmd.get_env("PWD").expect("agy must set $PWD");
     assert_eq!(
         std::path::Path::new(pwd),
-        expected_link.as_path(),
-        "agy $PWD must equal the workspace link path"
+        resolved.as_path(),
+        "non-hidden workspace: $PWD must be the real resolved dir, not a link"
     );
-    // The link exists, is a symlink, and resolves to the real workspace.
     assert!(
-        expected_link
+        link_path.symlink_metadata().is_err(),
+        "non-hidden workspace must NOT create a link at {}",
+        link_path.display()
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #1597 case (b): the default hidden workspace (`$AGEND_HOME` is dot-prefixed)
+/// → agy would reject it, so `$PWD` points at a non-hidden link to the real dir.
+/// (This is the #1547/#1582 case.)
+#[cfg(unix)]
+#[test]
+fn build_command_agy_hidden_workspace_uses_link() {
+    // Hidden home segment `.agend-home` makes the resolved cwd hidden.
+    let home = agy_tmp("hidden").join(".agend-home");
+    let workspace = crate::paths::workspace_dir(&home).join("agy-int");
+    let (cmd, link_path) = build_agy_cmd(&home, &workspace);
+
+    let pwd = cmd.get_env("PWD").expect("agy must set $PWD");
+    assert_eq!(
+        std::path::Path::new(pwd),
+        link_path.as_path(),
+        "hidden workspace: $PWD must be the non-hidden link"
+    );
+    assert!(
+        link_path
             .symlink_metadata()
             .expect("link must exist")
             .file_type()
             .is_symlink(),
-        "agy workspace link must be a symlink on Unix"
+        "hidden workspace must create a symlink"
     );
     assert_eq!(
-        std::fs::canonicalize(&expected_link).expect("canonicalize link"),
+        std::fs::canonicalize(&link_path).expect("canonicalize link"),
         std::fs::canonicalize(&workspace).expect("canonicalize workspace"),
         "link must resolve to the real hidden workspace"
     );
+    std::fs::remove_dir_all(&home).ok();
+}
 
+/// #1597 case (c): a non-hidden LEAF under a hidden ANCESTOR is still hidden by
+/// agy's rule → link required.
+#[cfg(unix)]
+#[test]
+fn build_command_agy_hidden_ancestor_uses_link() {
+    // `.cfg` ancestor is hidden even though the `proj` leaf is not.
+    let home = agy_tmp("ancestor").join(".cfg");
+    let workspace = home.join("proj");
+    let (cmd, link_path) = build_agy_cmd(&home, &workspace);
+
+    let pwd = cmd.get_env("PWD").expect("agy must set $PWD");
+    assert_eq!(
+        std::path::Path::new(pwd),
+        link_path.as_path(),
+        "hidden ancestor: $PWD must be the non-hidden link"
+    );
+    assert!(
+        link_path.symlink_metadata().is_ok(),
+        "hidden ancestor must create a link"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 

--- a/src/agy_workspace.rs
+++ b/src/agy_workspace.rs
@@ -51,6 +51,24 @@ pub fn link_path(home: &Path, instance: &str) -> PathBuf {
     link_base(home).join(instance)
 }
 
+/// #1597: whether any component of `p` is dot-prefixed (hidden). This is the
+/// same "ANY dot-prefixed ancestor makes the whole path hidden" rule agy
+/// applies in `addWorkspaceFolder` (`root.go:132`). When this is `false`, agy
+/// accepts the path as a workspace directly — so the non-hidden link is NOT
+/// needed and we can point `$PWD` at the real dir (avoids shadowing an explicit
+/// non-hidden `working_directory` + a stray link). When `true` (e.g. the
+/// default `$AGEND_HOME/workspace/<name>` under `~/.agend-terminal`), the link
+/// is required — that is the whole reason #1547/#1582 exists.
+pub fn path_has_hidden_component(p: &Path) -> bool {
+    use std::path::Component;
+    p.components().any(|c| match c {
+        // Only real path segments can be "hidden"; RootDir, the Windows
+        // `Prefix` (`C:\`), `.` and `..` never count.
+        Component::Normal(seg) => seg.to_string_lossy().starts_with('.'),
+        _ => false,
+    })
+}
+
 /// Create (or refresh) the non-hidden link `<base>/<instance>` →
 /// `real_workspace` and return the link path to set as agy's `$PWD`.
 ///
@@ -174,6 +192,27 @@ mod tests {
             "default link base must have no hidden component: {}",
             base.display()
         );
+    }
+
+    #[test]
+    fn path_has_hidden_component_detects_dot_prefixed_segments() {
+        // Hidden: leaf, ancestor, or the default agend workspace.
+        assert!(path_has_hidden_component(Path::new(
+            "/Users/x/.agend-terminal/workspace/agy"
+        )));
+        assert!(path_has_hidden_component(Path::new("/Users/x/.config/agy"))); // hidden ancestor
+        assert!(path_has_hidden_component(Path::new(
+            "/Users/x/proj/.hidden"
+        ))); // hidden leaf
+             // Not hidden: ordinary absolute path, no dot-prefixed segment.
+        assert!(!path_has_hidden_component(Path::new(
+            "/Users/x/projects/agy-ws"
+        )));
+        assert!(!path_has_hidden_component(Path::new(
+            "/var/folders/ab/cd/T/x"
+        )));
+        // `..` / `.` path operators are not "hidden" segments.
+        assert!(!path_has_hidden_component(Path::new("/Users/x/./proj")));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1597 (cheerc's observation #1). Refines the #1582 agy workspace-link mechanism.

## Problem
`#1582`'s agy arm in `build_command` created a non-hidden link + `PWD=link` for **every** agy instance, unconditionally. For an explicit **non-hidden** `working_directory` — one agy would accept as-is — this:
- **shadowed** it (agy reported `~/agend-ws/<instance>` instead of the user's dir), and
- left a **redundant symlink**.

## Fix — conditional link
Decide on the resolved cwd (the path agy actually sees, captured from the `working_dir` block):
- **No hidden component** → `cmd.env("PWD", <resolved cwd>)` and **skip** `ensure_link`. agy reports the user's real dir; no stray symlink.
- **Dot-prefixed ancestor** (the default `$AGEND_HOME/workspace/<name>` under `~/.agend-terminal`) → `ensure_link` + `PWD=link`, exactly as #1582. This is the case the mechanism exists for.

New helper `agy_workspace::path_has_hidden_component(p)` walks `Component`s for a leading `.`, matching agy's "any dot-prefixed ancestor is hidden" rule (`root.go:132`). `remove_link` teardown is already idempotent (no-op when no link was created).

## Rejected: cheerc's suggestion #2 (fail-fast on hidden dir)
Not implemented — it **contradicts the entire purpose** of #1547/#1582: the default workspace is *deliberately* hidden and the link **is** the fix, so a fail-fast would break the default (and only common) case. At most a debug log; no hard error.

## Tests
- `build_command_agy_non_hidden_workspace_uses_real_dir_no_link` — case (a).
- `build_command_agy_hidden_workspace_uses_link` — case (b), the default.
- `build_command_agy_hidden_ancestor_uses_link` — case (c), non-hidden leaf / hidden ancestor.
- `path_has_hidden_component_detects_dot_prefixed_segments` — helper unit test.
- clippy `--all-targets -D warnings` green; full `cargo test --bin` (3037) green.

**Credit:** @cheerc for the #1597 observation (#1).