### PR TITLE
fix(#1600): expose fire_strategy/linked_task_id in MCP schedule schema

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -252,7 +252,9 @@ pub(crate) fn def_schedule() -> Value {
             "message": {"type": "string"}, "instance": {"type": "string", "description": "Name of the existing instance to deliver the scheduled message to."},
             "label": {"type": "string"},
             "timezone": {"type": "string", "description": "IANA zone name."},
-            "enabled": {"type": "boolean"}
+            "enabled": {"type": "boolean"},
+            "fire_strategy": {"type": "string", "enum": ["always", "until_success"], "description": "Default always (fire every cron match). until_success: skip remaining same-day fires once linked_task_id completes (done); resumes next calendar day. Requires linked_task_id when until_success. See #1521."},
+            "linked_task_id": {"type": "string", "description": "Task ID whose done status (today) suppresses further fires under until_success. Missing task disables the schedule with target_task_missing. See #1521."}
         }, "required": ["action"]}})
 }
 
@@ -476,6 +478,44 @@ mod tests {
             .as_array()
             .expect("required");
         assert!(required.iter().any(|v| v == "instance"));
+    }
+
+    #[test]
+    fn schedule_exposes_fire_strategy_and_linked_task_id() {
+        // #1600: #1521 shipped fire_strategy=until_success end-to-end in the
+        // backend (schedules.rs) but def_schedule()'s MCP inputSchema never
+        // exposed the two fields, so MCP callers could not reach the feature.
+        // #1095 was a prior def_schedule schema-doc gap — this guard keeps the
+        // schema and the backend args in sync so the class doesn't recur.
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().expect("tools array");
+        let schedule = tools
+            .iter()
+            .find(|t| t["name"] == "schedule")
+            .expect("schedule tool not found");
+        let props = &schedule["inputSchema"]["properties"];
+
+        let fire_strategy = &props["fire_strategy"];
+        assert!(
+            fire_strategy.is_object(),
+            "schedule should expose 'fire_strategy'"
+        );
+        let enum_vals: Vec<&str> = fire_strategy["enum"]
+            .as_array()
+            .expect("fire_strategy enum")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(
+            enum_vals,
+            vec!["always", "until_success"],
+            "fire_strategy enum must match the backend's fire_strategy_from_args"
+        );
+
+        assert!(
+            props["linked_task_id"].is_object(),
+            "schedule should expose 'linked_task_id'"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

#1521 (PR #1557) shipped `fire_strategy=until_success` end-to-end in the **backend** (`src/schedules.rs`: `fire_strategy` / `linked_task_id` fields + `validate_fire_strategy` + `fire_strategy_from_args`) but never updated the **MCP inputSchema** in `def_schedule()` (`src/mcp/tools.rs`). MCP callers (LLM agents) had no way to discover or pass the two fields, so the #1521 "remind until done" feature was unreachable from the tool surface despite working internally.

## Change (one file, +41/-1)

`def_schedule()` properties gain two fields:
- `fire_strategy`: `enum ["always", "until_success"]` — enum mirrors the backend's `fire_strategy_from_args`.
- `linked_task_id`: task whose `done` status (today) suppresses further fires under `until_success`.

Plus a guard test `schedule_exposes_fire_strategy_and_linked_task_id` asserting both are present with the correct enum — so this schema/backend drift class (cf. the #1095 `def_schedule` schema-doc gap) doesn't recur.

## Not changed

- Backend validation (`validate_fire_strategy`) already exists — untouched.
- No migration (existing schedules default `fire_strategy: always`).
- No behavior change for callers not passing the fields.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -- -D warnings` ✅
- `cargo test --features tray --bin agend-terminal` → 3042 passed, 0 failed ✅ (incl. new guard test)
- `cargo xwin check --target x86_64-pc-windows-msvc --features tray` ✅

Closes #1600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)