### PR TITLE
fix(#1602): reply text→message + enforce MCP inputSchema at dispatch

### DIFF
--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -60,7 +60,7 @@ Check pending messages, look up by ID, or fetch thread messages.
 
 ### `reply`
 Reply to the user via the active channel (NOT for inter-agent use).
-- **text**: reply content
+- **message**: reply content
 - default_action, timeout_secs
 
 ### `download_attachment`

--- a/src/mcp/handlers/channel.rs
+++ b/src/mcp/handlers/channel.rs
@@ -4,7 +4,11 @@ use std::path::Path;
 use std::sync::Arc;
 
 pub(super) fn handle_reply(home: &Path, args: &Value, instance_name: &str) -> Value {
-    let text = args["text"].as_str().unwrap_or("").to_string();
+    // #1602: the reply content param is `message` (was `text`) — now consistent
+    // with `send`/`schedule`. The MCP dispatch validator rejects a missing
+    // `message` with a clear named error, so a mis-named param no longer
+    // silently becomes an empty reply.
+    let text = args["message"].as_str().unwrap_or("").to_string();
     tracing::info!(from = %instance_name, %text, "reply");
 
     // Sprint 59 Wave 1 PR-4 ((B) decision default with timeout):

--- a/src/mcp/handlers/channel_p0a_tests.rs
+++ b/src/mcp/handlers/channel_p0a_tests.rs
@@ -140,7 +140,7 @@ fn ec1_3_4_5_7_snapshot_at_handler_time_falls_back_to_active_when_reply_to_none(
     set_reply_to("alpha", None);
     crate::channel::register_active_channel(MockChannel::arc("telegram", ReplyOutcome::Ok));
 
-    let result = super::handle_reply(&home, &serde_json::json!({"text": "hi"}), "alpha");
+    let result = super::handle_reply(&home, &serde_json::json!({"message": "hi"}), "alpha");
     assert_eq!(
         result["message_id"], "mock-msg-1",
         "fallback to singleton must succeed: {result}"
@@ -158,7 +158,7 @@ fn ec2_6_10_unavailable_returns_structured_error_when_lookup_misses() {
     set_reply_to("alpha", Some("discord"));
     crate::channel::register_active_channel(MockChannel::arc("telegram", ReplyOutcome::Ok));
 
-    let result = super::handle_reply(&home, &serde_json::json!({"text": "hi"}), "alpha");
+    let result = super::handle_reply(&home, &serde_json::json!({"message": "hi"}), "alpha");
     assert_eq!(result["code"], "reply_channel_unavailable");
     assert!(
         result["error"]
@@ -179,7 +179,7 @@ fn ec8_no_active_channel_when_no_external_channel_registered() {
     let home = tmp_home("ec8");
     set_reply_to("alpha", None);
 
-    let result = super::handle_reply(&home, &serde_json::json!({"text": "hi"}), "alpha");
+    let result = super::handle_reply(&home, &serde_json::json!({"message": "hi"}), "alpha");
     assert_eq!(
         result["code"], "no_active_channel",
         "no channels registered must surface no_active_channel: {result}"
@@ -207,7 +207,7 @@ fn ec12_multi_channel_lookup_routes_to_tagged_not_singleton() {
     let home = tmp_home("ec12");
     set_reply_to("alpha", Some("discord"));
 
-    let result = super::handle_reply(&home, &serde_json::json!({"text": "hi"}), "alpha");
+    let result = super::handle_reply(&home, &serde_json::json!({"message": "hi"}), "alpha");
     // discord mock returns Ok → message_id present. If routing collapsed
     // to telegram (singleton-style fallback), it would have surfaced
     // channel_capability_unsupported instead.
@@ -233,7 +233,7 @@ fn ec9_channel_kind_mismatch_is_unavailable_not_silent_fallback() {
     set_reply_to("alpha", Some("telegram-main"));
     crate::channel::register_active_channel(MockChannel::arc("telegram", ReplyOutcome::Ok));
 
-    let result = super::handle_reply(&home, &serde_json::json!({"text": "hi"}), "alpha");
+    let result = super::handle_reply(&home, &serde_json::json!({"message": "hi"}), "alpha");
     assert_eq!(
         result["code"], "reply_channel_unavailable",
         "kind mismatch must NOT silently fall back: {result}"
@@ -254,7 +254,7 @@ fn ec11_capability_unsupported_returns_structured_error() {
         ReplyOutcome::NotSupported,
     ));
 
-    let result = super::handle_reply(&home, &serde_json::json!({"text": "hi"}), "alpha");
+    let result = super::handle_reply(&home, &serde_json::json!({"message": "hi"}), "alpha");
     assert_eq!(result["code"], "channel_capability_unsupported");
     std::fs::remove_dir_all(&home).ok();
 }
@@ -269,7 +269,7 @@ fn happy_path_tagged_channel_matches_singleton_returns_message_id() {
     set_reply_to("alpha", Some("telegram"));
     crate::channel::register_active_channel(MockChannel::arc("telegram", ReplyOutcome::Ok));
 
-    let result = super::handle_reply(&home, &serde_json::json!({"text": "hi"}), "alpha");
+    let result = super::handle_reply(&home, &serde_json::json!({"message": "hi"}), "alpha");
     assert_eq!(result["message_id"], "mock-msg-1");
     let snap = crate::daemon::heartbeat_pair::snapshot_for("alpha");
     assert!(

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -61,7 +61,11 @@ pub(super) fn handle_send_to_instance(
     if *sender == target {
         return json!({"error": "cannot send to self — use a different instance"});
     }
-    let text = match args["message"].as_str().or_else(|| args["text"].as_str()) {
+    // #1602: `message` only — the legacy `text` alias is dropped (reply's
+    // text→message rename removed the last schema that declared `text`, and the
+    // dispatch validator now rejects a message-less `send` before this handler
+    // runs anyway). `send`/`reply`/`schedule` are all `message` now.
+    let text = match args["message"].as_str() {
         Some(t) if !t.is_empty() => t,
         _ => return json!({"error": "missing or empty 'message'"}),
     };

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -47,6 +47,57 @@ pub(crate) struct HandlerCtx<'a> {
 /// allocation-free.
 pub(crate) type HandlerFn = fn(&HandlerCtx<'_>) -> Value;
 
+/// #1602: validate `args` against the tool's declared `inputSchema` before
+/// dispatch. The schemas declare `required[]` but nothing enforced it, so a
+/// mis-named / omitted param failed LATE and misleadingly (the operator's
+/// `reply` bug: a wrong key silently became an empty `text`). Now:
+///
+/// - a missing REQUIRED key → hard-reject with `<tool>: missing required
+///   parameter '<name>'`;
+/// - an UNKNOWN key → warn only (forward-compat; never reject).
+///
+/// Returns `Some(error_value)` to short-circuit dispatch, or `None` to proceed.
+///
+/// **Enforceability invariant (#1602/#1603):** every field a tool declares in
+/// `required[]` MUST be one the handler genuinely needs — i.e. the handler
+/// ERRORS (not defaults) when it's absent. The systematic audit found 5 tools
+/// whose handler instead DEFAULTS a "required" field, so their schemas were
+/// LYING. They were schema-aligned (field removed from `required[]`) rather than
+/// allowlisted, keeping this validator a plain hard-reject. The 5:
+/// `mode` (`action` → `"get"`), `create_instance` (`name` auto-derived in team
+/// mode; single path still errors "missing 'name'"), `set_waiting_on`
+/// (`condition` absent = clear), and `set_display_name` / `set_description`
+/// (handler tolerates absent, sets `""` — a separate follow-up decides whether
+/// set-X-without-X should hard-error).
+///
+/// Tools whose handler DOES error on a missing field (`reply.message`,
+/// `send.message`, `delete_instance.instance`, action-based `task`/`decision`)
+/// keep their `required[]` and are hard-rejected here. A new tool that declares
+/// a field its handler defaults will trip the pinning test below.
+fn validate_args(tool: &str, def: &Value, args: &Value) -> Option<Value> {
+    let schema = &def["inputSchema"];
+    if let Some(required) = schema["required"].as_array() {
+        for req in required.iter().filter_map(Value::as_str) {
+            if args.get(req).is_none() {
+                return Some(json!({
+                    "error": format!("{tool}: missing required parameter '{req}'")
+                }));
+            }
+        }
+    }
+    if let (Some(props), Some(obj)) = (schema["properties"].as_object(), args.as_object()) {
+        for key in obj.keys() {
+            if !props.contains_key(key) {
+                tracing::warn!(
+                    tool, param = %key,
+                    "#1602: unknown parameter (ignored) — not in the tool's inputSchema"
+                );
+            }
+        }
+    }
+    None
+}
+
 /// Look the `tool` name up in the registry. Returns `Some(value)`
 /// on hit; returns `None` if the tool isn't registered — the caller
 /// falls back to the inline `match` in `mod.rs` for un-migrated arms.
@@ -54,7 +105,15 @@ pub(super) fn try_dispatch(tool: &str, ctx: &HandlerCtx<'_>) -> Option<Value> {
     crate::mcp::registry::all()
         .iter()
         .find(|entry| entry.name == tool)
-        .map(|entry| (entry.handler)(ctx))
+        .map(|entry| {
+            // #1602: enforce the declared inputSchema at the single dispatch
+            // chokepoint — a missing required param is rejected with a clear
+            // named error instead of failing late inside the handler.
+            if let Some(err) = validate_args(entry.name, &(entry.definition)(), ctx.args) {
+                return err;
+            }
+            (entry.handler)(ctx)
+        })
 }
 
 // ---------------------------------------------------------------------
@@ -718,5 +777,122 @@ mod tests {
         let status = try_dispatch("watchdog", &status_ctx).unwrap();
         assert_eq!(status["snoozed"], false);
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #1602: inputSchema enforcement at dispatch ──────────────────────
+
+    #[test]
+    fn validate_rejects_missing_required_with_named_error() {
+        // reply requires `message` (post-#1602 rename); omitting it is the
+        // exact bug the operator hit (a mis-named param became an empty reply).
+        let def = crate::mcp::tools::def_reply();
+        let err = validate_args("reply", &def, &json!({})).expect("must reject");
+        assert_eq!(
+            err["error"], "reply: missing required parameter 'message'",
+            "must name the tool + the missing param: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_passes_when_required_present_and_unknown_only_warns() {
+        // `message` present → no reject; an unknown key only warns (no reject).
+        let def = crate::mcp::tools::def_reply();
+        assert!(
+            validate_args("reply", &def, &json!({"message": "hi"})).is_none(),
+            "valid call must pass"
+        );
+        assert!(
+            validate_args("reply", &def, &json!({"message": "hi", "bogus": 1})).is_none(),
+            "unknown param must warn, not reject"
+        );
+    }
+
+    /// #1602/#1603 audit pin. The systematic re-audit found 5 tools whose
+    /// HANDLER defaults a field instead of erroring on its absence, so that
+    /// field must NOT be in `required[]` (else the validator would hard-reject a
+    /// legitimate call). Pins BOTH that the schema omits it from `required[]`
+    /// AND that the validator lets the field-less call through. If a future
+    /// tool/edit declares a handler-defaulted field required, this fails — re-run
+    /// the audit (`grep unwrap_or` the handler).
+    #[test]
+    fn handler_defaulted_fields_are_not_declared_required() {
+        use crate::mcp::tools::*;
+        // (tool, def, handler-defaulted field, a legit call that omits it)
+        let cases = [
+            ("mode", def_mode(), "action", json!({})), // → "get" (read-only)
+            (
+                "create_instance",
+                def_create_instance(),
+                "name",
+                json!({"team": "dev", "count": 2, "backend": "claude"}),
+            ), // team mode auto-names; single path still errors "missing 'name'"
+            (
+                "set_waiting_on",
+                def_set_waiting_on(),
+                "condition",
+                json!({}),
+            ), // → clear
+            (
+                "set_display_name",
+                def_set_display_name(),
+                "name",
+                json!({}),
+            ), // → ""
+            (
+                "set_description",
+                def_set_description(),
+                "description",
+                json!({}),
+            ), // → ""
+        ];
+        for case in &cases {
+            let (tool, def, field, args) = (case.0, &case.1, case.2, &case.3);
+            let declares_required = def["inputSchema"]["required"]
+                .as_array()
+                .is_some_and(|r| r.iter().any(|v| v.as_str() == Some(field)));
+            assert!(
+                !declares_required,
+                "{tool}: '{field}' is handler-defaulted — it must NOT be declared required[]"
+            );
+            assert!(
+                validate_args(tool, def, args).is_none(),
+                "{tool}: omitting handler-defaulted '{field}' must pass validation"
+            );
+        }
+    }
+
+    /// #1602: genuinely-required fields (the handler ERRORS on absence) stay
+    /// enforced — the validator hard-rejects them with a named error.
+    #[test]
+    fn genuinely_required_fields_are_hard_rejected() {
+        use crate::mcp::tools::*;
+        let cases = [
+            ("reply", def_reply(), "message"),
+            ("send", def_send(), "message"),
+            ("delete_instance", def_delete_instance(), "instance"),
+            ("task", def_task(), "action"),
+        ];
+        for case in &cases {
+            let (tool, def, field) = (case.0, &case.1, case.2);
+            let err = validate_args(tool, def, &json!({})).expect("must reject");
+            assert_eq!(
+                err["error"],
+                format!("{tool}: missing required parameter '{field}'"),
+                "{tool} must hard-reject its missing required field"
+            );
+        }
+    }
+
+    #[test]
+    fn try_dispatch_rejects_reply_without_message() {
+        // End-to-end through the dispatch chokepoint.
+        let home = std::env::temp_dir();
+        let args = json!({}); // no message
+        let ctx = ctx_for(&home, &args, "alpha");
+        let result = try_dispatch("reply", &ctx).expect("registered tool returns Some");
+        assert_eq!(
+            result["error"], "reply: missing required parameter 'message'",
+            "dispatch must reject reply with no message: {result}"
+        );
     }
 }

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2062,7 +2062,7 @@ fn reply_no_active_channel_returns_error() {
         "instances:\n  sender:\n    backend: claude\n",
     )
     .ok();
-    let result = handle_tool("reply", &json!({"text": "hello"}), "sender");
+    let result = handle_tool("reply", &json!({"message": "hello"}), "sender");
     assert!(
         result.get("error").is_some(),
         "reply with no active channel must error: {result}"

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -13,10 +13,10 @@ pub fn tool_definitions() -> Value {
 pub(crate) fn def_reply() -> Value {
     json!({"name": "reply", "description": "Reply to the user via the active channel. Requires daemon API. Sprint 59 Wave 1 PR-4 ((B) decision default with timeout): when both `default_action` and `timeout_secs` are set, the daemon records a pending operator decision sidecar and auto-fires the default after the timeout window. Subsequent reply calls without `default_action` resolve the pending decision (operator override / explicit answer arrived).",
         "inputSchema": {"type": "object", "properties": {
-            "text": {"type": "string"},
+            "message": {"type": "string", "description": "The reply text to send to the user."},
             "default_action": {"type": "string", "description": "Action to auto-execute on timeout when the operator doesn't reply within `timeout_secs`. e.g. 'proceed-with-lean' / 'abort'. Pair with `timeout_secs` (Sprint 59 Wave 1 PR-4)."},
             "timeout_secs": {"type": "integer", "description": "Seconds to wait for an operator response before firing `default_action`. Required when `default_action` is set; ignored otherwise (Sprint 59 Wave 1 PR-4)."}
-        }, "required": ["text"]}})
+        }, "required": ["message"]}})
 }
 
 pub(crate) fn def_download_attachment() -> Value {
@@ -75,24 +75,24 @@ pub(crate) fn def_list_instances() -> Value {
 
 pub(crate) fn def_create_instance() -> Value {
     json!({"name": "create_instance", "description": "Create agent instance(s). Team modes: (a) homogeneous — count:3, backend:\"claude\", team:\"dev\" → dev-1..dev-3 all claude; (b) heterogeneous — backends:[\"codex\",\"kiro-cli\",\"gemini\"], team:\"mixed\" → mixed-1=codex, mixed-2=kiro-cli, mixed-3=gemini, all grouped in one tab.",
-        "inputSchema": {"type": "object", "properties": {
-            "name": {"type": "string", "description": "Instance name (single instance) or base name (ignored when team is set — team name is used as prefix)"},
-            "backend": {"type": "string", "description": "Backend CLI name: claude, gemini, kiro-cli, codex, opencode"},
-            "args": {"type": "string", "description": "Extra CLI arguments"},
-            "model": {"type": "string", "description": "Model override (e.g. --model flag)"},
-            "working_directory": {"type": "string"},
-            "branch": {"type": "string", "description": "Git branch — creates worktree if specified"},
-            "task": {"type": "string", "description": "Initial task to inject after spawn"},
-            "layout": {"type": "string", "enum": ["tab", "split-right", "split-below"], "description": "TUI layout: tab (default), split-right, or split-below. Places the new pane relative to `target_pane` if given, otherwise relative to the caller."},
-            "target_pane": {"type": "string", "description": "Name of an existing instance. When set with layout=split-right/split-below, the new pane is attached next to that instance's pane (wherever it currently lives), instead of the caller's focused pane. Falls back to caller, then new tab, if the target isn't currently displayed."},
-            "count": {"type": "integer", "description": "Number of instances to spawn (requires team; ignored when `backends` is set)"},
-            "team": {"type": "string", "description": "Team name — members become <team>-1, <team>-2, ... grouped in one tab"},
-            "backends": {"type": "array", "items": {"type": "string"}, "description": "Per-member backend list for a mixed-backend team (requires team). Length dictates member count."},
-            "command": {"type": "string", "description": "Deprecated: use 'backend' instead"},
-            "role": {"type": "string", "description": "Agent role label (e.g. `reviewer`) recorded on the spawned instance's fleet.yaml entry."},
-            "env": {"type": "object", "description": "#900: environment variables (object of string→string) injected into the spawned backend process and persisted to the fleet.yaml entry so replace/restart flows re-apply them."},
-            "topic_binding": {"type": "string", "description": "Telegram topic binding for the spawned agent, forwarded to the spawn RPC."}
-        }, "required": ["name"]}})
+    "inputSchema": {"type": "object", "properties": {
+        "name": {"type": "string", "description": "Instance name (single instance) or base name (ignored when team is set — team name is used as prefix)"},
+        "backend": {"type": "string", "description": "Backend CLI name: claude, gemini, kiro-cli, codex, opencode"},
+        "args": {"type": "string", "description": "Extra CLI arguments"},
+        "model": {"type": "string", "description": "Model override (e.g. --model flag)"},
+        "working_directory": {"type": "string"},
+        "branch": {"type": "string", "description": "Git branch — creates worktree if specified"},
+        "task": {"type": "string", "description": "Initial task to inject after spawn"},
+        "layout": {"type": "string", "enum": ["tab", "split-right", "split-below"], "description": "TUI layout: tab (default), split-right, or split-below. Places the new pane relative to `target_pane` if given, otherwise relative to the caller."},
+        "target_pane": {"type": "string", "description": "Name of an existing instance. When set with layout=split-right/split-below, the new pane is attached next to that instance's pane (wherever it currently lives), instead of the caller's focused pane. Falls back to caller, then new tab, if the target isn't currently displayed."},
+        "count": {"type": "integer", "description": "Number of instances to spawn (requires team; ignored when `backends` is set)"},
+        "team": {"type": "string", "description": "Team name — members become <team>-1, <team>-2, ... grouped in one tab"},
+        "backends": {"type": "array", "items": {"type": "string"}, "description": "Per-member backend list for a mixed-backend team (requires team). Length dictates member count."},
+        "command": {"type": "string", "description": "Deprecated: use 'backend' instead"},
+        "role": {"type": "string", "description": "Agent role label (e.g. `reviewer`) recorded on the spawned instance's fleet.yaml entry."},
+        "env": {"type": "object", "description": "#900: environment variables (object of string→string) injected into the spawned backend process and persisted to the fleet.yaml entry so replace/restart flows re-apply them."},
+        "topic_binding": {"type": "string", "description": "Telegram topic binding for the spawned agent, forwarded to the spawn RPC."}
+    }}})
 }
 
 pub(crate) fn def_delete_instance() -> Value {
@@ -140,17 +140,17 @@ pub(crate) fn def_interrupt() -> Value {
 
 pub(crate) fn def_set_display_name() -> Value {
     json!({"name": "set_display_name", "description": "Set your display name.",
-        "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}})
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}}})
 }
 
 pub(crate) fn def_set_description() -> Value {
     json!({"name": "set_description", "description": "Set a description for this instance.",
-        "inputSchema": {"type": "object", "properties": {"description": {"type": "string"}}, "required": ["description"]}})
+        "inputSchema": {"type": "object", "properties": {"description": {"type": "string"}}}})
 }
 
 pub(crate) fn def_set_waiting_on() -> Value {
     json!({"name": "set_waiting_on", "description": "Declare what this instance is currently waiting for. Set to empty string to clear. Automatically cleared when stale.",
-        "inputSchema": {"type": "object", "properties": {"condition": {"type": "string", "description": "What you are waiting for, e.g. 'review from at-dev-4'. Empty string to clear."}}, "required": ["condition"]}})
+        "inputSchema": {"type": "object", "properties": {"condition": {"type": "string", "description": "What you are waiting for, e.g. 'review from at-dev-4'. Empty string to clear."}}}})
 }
 
 pub(crate) fn def_move_pane() -> Value {
@@ -302,9 +302,9 @@ pub(crate) fn def_config() -> Value {
 
 pub(crate) fn def_mode() -> Value {
     json!({"name": "mode", "description": "#1339: Read the operator availability/authority mode (READ-ONLY for agents). `get` → current mode (active|away|sleep) + delegate. Agents observe this to back off when the operator is away/asleep. SETTING the mode is operator-only via the `agend-terminal mode <active|away|sleep>` CLI — never available to agents.",
-        "inputSchema": {"type": "object", "properties": {
-            "action": {"type": "string", "enum": ["get"], "default": "get"}
-        }, "required": ["action"]}})
+    "inputSchema": {"type": "object", "properties": {
+        "action": {"type": "string", "enum": ["get"], "default": "get"}
+    }}})
 }
 
 pub(crate) fn def_health() -> Value {
@@ -412,11 +412,18 @@ mod tests {
             .iter()
             .find(|t| t["name"] == "create_instance")
             .expect("create_instance tool not found");
-        let required = create["inputSchema"]["required"]
+        // #1602/#1603 schema-align: `name` is NOT required — the handler
+        // defaults it (team mode auto-names; the single-instance path still
+        // errors "missing 'name'"). Declaring it required would make the schema
+        // lie and the dispatch validator hard-reject a legitimate team create.
+        let required_strs: Vec<&str> = create["inputSchema"]["required"]
             .as_array()
-            .expect("required");
-        let required_strs: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
-        assert!(required_strs.contains(&"name"), "name should be required");
+            .map(|r| r.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+        assert!(
+            !required_strs.contains(&"name"),
+            "name must NOT be required (handler-defaulted — see #1603 audit)"
+        );
         assert!(
             !required_strs.contains(&"command"),
             "command should NOT be required (backend is preferred, default is claude)"
@@ -439,10 +446,10 @@ mod tests {
             props["target_pane"].is_object(),
             "create_instance should expose 'target_pane'"
         );
-        let required = create["inputSchema"]["required"]
+        let required_strs: Vec<&str> = create["inputSchema"]["required"]
             .as_array()
-            .expect("required");
-        let required_strs: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+            .map(|r| r.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
         assert!(
             !required_strs.contains(&"target_pane"),
             "target_pane must stay optional"


### PR DESCRIPTION
Root-causes the operator's "Telegram text is empty" confusion. Two parts.

## Part A — rename `reply.text` → `reply.message` (full rename, no alias)
`reply` was the only content tool using `text`; `send`/`schedule` already use `message`.
- `def_reply` inputSchema property + `required` → `message`; `handle_reply` reads `args["message"]`.
- All hardcoded callers/tests updated (`channel_p0a_tests` ×7, `handlers/tests`, `docs/MCP-TOOLS.md`).
- Dropped `send`'s vestigial `text` fallback (`comms.rs`). `send`/`reply`/`schedule` are now uniformly `message`.

## Part B — enforce declared `inputSchema` at the single dispatch chokepoint
Every tool declares `required[]` but nothing enforced it → a mis-named/omitted param failed **late and misleadingly** inside the handler. Now, in `try_dispatch`:
- missing **required** key → hard-reject `<tool>: missing required parameter '<name>'`;
- **unknown** key → warn only (forward-compat, never reject).

### Enforceability — schema-align, not an allowlist (per codex review + lead decision)
A systematic **grep-based** re-audit (the first eyeballed pass missed `mode`) found **5 tools** whose HANDLER **defaults** a declared-"required" field instead of erroring — so their schemas were **lying**. Rather than allowlist them (band-aid; schema stays dishonest), the field is removed from each `required[]` so the schema tells the truth and the validator stays a plain hard-reject:

| tool | field | handler behavior on absence |
|---|---|---|
| `mode` | `action` | defaults to `"get"` (read-only) |
| `create_instance` | `name` | team mode auto-names; single path still errors `missing 'name'` |
| `set_waiting_on` | `condition` | absent = "clear" |
| `set_display_name` | `name` | tolerates absent (sets `""`) |
| `set_description` | `description` | tolerates absent (sets `""`) |

Tools whose handler **errors** on a missing field (`reply.message`, `send.message`, `delete_instance.instance`, action-based `task`/`decision`/…) keep `required[]` and are hard-rejected.

**Zero behavior change**: handlers are untouched; only the schemas stop lying. (Whether `set_display_name`/`set_description` *should* hard-error on a missing value is a separate behavior question → follow-up, not bundled here.)

## Tests
- `validate_rejects_missing_required_with_named_error`, `try_dispatch_rejects_reply_without_message` (e2e).
- `validate_passes_when_required_present_and_unknown_only_warns`.
- `genuinely_required_fields_are_hard_rejected` (reply/send/delete_instance/task).
- `handler_defaulted_fields_are_not_declared_required` — **pins the audit**: asserts each of the 5 omits its defaulted field from `required[]` AND passes validation when omitted; re-trips if a future tool declares a handler-defaulted field required.
- Two existing `create_instance` schema tests updated (they asserted the old lying `required:["name"]`).
- Full `cargo test --bin` (3043) + mcp invariants + clippy `--all-targets -D warnings` green.

Closes #1602.