### PR TITLE
fix(#1619): remove hardcoded GitHub targets (repo-slug fallback + sweep API base)

### DIFF
--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -54,6 +54,12 @@ const SWEEP_EMITTER: &str = "system:task_sweep";
 /// desc so recent merges land first.
 const PR_LIST_LIMIT: u32 = 30;
 
+/// #1619: default GitHub REST API base. Overridable via
+/// `SweepConfig.api_base_url` so self-hosted GitHub Enterprise
+/// (`https://ghe.example.com/api/v3`) works instead of being pinned to
+/// github.com — mirrors `CiProvider::with_base_url`'s configurable base.
+const DEFAULT_GITHUB_API_BASE: &str = "https://api.github.com";
+
 /// Configuration persisted at `<home>/task_sweep.json`. Operator mutates
 /// via the `task_sweep_config` MCP tool; sweep tick reads on each invocation.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
@@ -61,6 +67,10 @@ pub struct SweepConfig {
     /// `owner/repo` GitHub identifier (e.g. `"suzuke/agend-terminal"`).
     /// `None` = sweep disabled (tick is a no-op).
     pub repo: Option<String>,
+    /// #1619: REST API base URL (e.g. `https://ghe.example.com/api/v3`
+    /// for self-hosted GitHub Enterprise). `None` → `https://api.github.com`.
+    #[serde(default)]
+    pub api_base_url: Option<String>,
     /// `true` = tick body short-circuits with no-op.
     #[serde(default)]
     pub paused: bool,
@@ -195,8 +205,12 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
         Some(r) if !r.is_empty() => r.clone(),
         _ => return Ok(()),
     };
+    let api_base = cfg
+        .api_base_url
+        .as_deref()
+        .unwrap_or(DEFAULT_GITHUB_API_BASE);
 
-    let prs = list_recently_merged_prs(&repo)?;
+    let prs = list_recently_merged_prs(&repo, api_base)?;
     if prs.is_empty() {
         return Ok(());
     }
@@ -404,7 +418,18 @@ struct PrMeta {
     api_response_hash: String,
 }
 
-fn list_recently_merged_prs(repo: &str) -> anyhow::Result<Vec<PrMeta>> {
+/// #1619: build the merged-PR list URL from a configurable API base so
+/// self-hosted GitHub Enterprise works. Trailing slashes on the base are
+/// trimmed so `https://ghe/api/v3` and `https://ghe/api/v3/` both yield a
+/// single-slash join. Pure + testable seam (the live call shells out).
+fn build_merged_prs_url(api_base: &str, repo: &str) -> String {
+    let base = api_base.trim_end_matches('/');
+    format!(
+        "{base}/repos/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page={PR_LIST_LIMIT}"
+    )
+}
+
+fn list_recently_merged_prs(repo: &str, api_base: &str) -> anyhow::Result<Vec<PrMeta>> {
     // Build a per-tick current-thread runtime so the sync DaemonTicker
     // body can call async reqwest. Pattern lifted from `ci_watch.rs`.
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -415,9 +440,7 @@ fn list_recently_merged_prs(repo: &str) -> anyhow::Result<Vec<PrMeta>> {
             .timeout(Duration::from_secs(15))
             .user_agent("agend-terminal/task-sweep")
             .build()?;
-        let url = format!(
-            "https://api.github.com/repos/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page={PR_LIST_LIMIT}"
-        );
+        let url = build_merged_prs_url(api_base, repo);
         let mut req = client
             .get(&url)
             .header("Accept", "application/vnd.github+json");
@@ -512,6 +535,15 @@ pub fn handle_task_sweep_config(home: &Path, args: &serde_json::Value) -> serde_
     if let Some(d) = args.get("dry_run").and_then(|v| v.as_bool()) {
         cfg.dry_run = d;
     }
+    // #1619: self-hosted GitHub Enterprise API base (empty string resets
+    // to the github.com default).
+    if let Some(base) = args.get("api_base_url").and_then(|v| v.as_str()) {
+        cfg.api_base_url = if base.is_empty() {
+            None
+        } else {
+            Some(base.to_string())
+        };
+    }
     if let Err(e) = save_config(home, &cfg) {
         return serde_json::json!({"error": format!("save failed: {e}")});
     }
@@ -521,6 +553,7 @@ pub fn handle_task_sweep_config(home: &Path, args: &serde_json::Value) -> serde_
         "dry_run": cfg.dry_run,
         "compliance_mode": cfg.compliance_mode,
         "last_seen_merged_at": cfg.last_seen_merged_at,
+        "api_base_url": cfg.api_base_url,
     })
 }
 
@@ -675,8 +708,12 @@ fn compliance_sweep(home: &Path, repo: &str) -> Vec<ComplianceViolation> {
     if cfg.compliance_mode == "off" {
         return Vec::new();
     }
+    let api_base = cfg
+        .api_base_url
+        .as_deref()
+        .unwrap_or(DEFAULT_GITHUB_API_BASE);
 
-    let prs = match list_recently_merged_prs(repo) {
+    let prs = match list_recently_merged_prs(repo, api_base) {
         Ok(prs) => prs,
         Err(_) => return Vec::new(),
     };
@@ -1037,6 +1074,46 @@ mod tests {
         fs::remove_dir_all(&home).ok();
     }
 
+    /// #1619: the merged-PR list URL is built from a configurable API
+    /// base (self-hosted GitHub Enterprise support) — NOT pinned to
+    /// github.com. Trailing slashes on the base are trimmed.
+    #[test]
+    fn build_merged_prs_url_uses_configurable_base() {
+        // Default github.com base — byte-identical to the pre-#1619 URL.
+        assert_eq!(
+            build_merged_prs_url(DEFAULT_GITHUB_API_BASE, "suzuke/agend-terminal"),
+            "https://api.github.com/repos/suzuke/agend-terminal/pulls?state=closed&sort=updated&direction=desc&per_page=30"
+        );
+        // Self-hosted GHE base.
+        assert_eq!(
+            build_merged_prs_url("https://ghe.corp.example.com/api/v3", "team/proj"),
+            "https://ghe.corp.example.com/api/v3/repos/team/proj/pulls?state=closed&sort=updated&direction=desc&per_page=30"
+        );
+        // Trailing slash on the base is trimmed (no double slash).
+        assert_eq!(
+            build_merged_prs_url("https://ghe.corp.example.com/api/v3/", "team/proj"),
+            "https://ghe.corp.example.com/api/v3/repos/team/proj/pulls?state=closed&sort=updated&direction=desc&per_page=30"
+        );
+    }
+
+    /// #1619: `api_base_url` round-trips through the config tool and an
+    /// empty string resets it to the github.com default (`None`).
+    #[test]
+    fn config_tool_api_base_url_round_trip() {
+        let home = tmp_home("config_api_base");
+        let r1 = handle_task_sweep_config(
+            &home,
+            &serde_json::json!({"api_base_url": "https://ghe.corp.example.com/api/v3"}),
+        );
+        assert_eq!(r1["api_base_url"], "https://ghe.corp.example.com/api/v3");
+        // Reset to default with empty string.
+        let r2 = handle_task_sweep_config(&home, &serde_json::json!({"api_base_url": ""}));
+        assert_eq!(r2["api_base_url"], serde_json::Value::Null);
+        // Default (unset) deserializes to None.
+        assert!(SweepConfig::default().api_base_url.is_none());
+        fs::remove_dir_all(&home).ok();
+    }
+
     /// `sweep_tick` short-circuits when the config is missing or has no
     /// repo set. Operator sees a no-op rather than a noisy GitHub call.
     #[test]
@@ -1197,6 +1274,7 @@ mod tests {
             compliance_mode: "off".to_string(),
             last_seen_merged_at: None,
             alerted_prs: Vec::new(),
+            api_base_url: None,
         };
         save_config(&home, &cfg).unwrap();
         let violations = compliance_sweep(&home, "test/repo");
@@ -1218,6 +1296,7 @@ mod tests {
             compliance_mode: "warn".to_string(),
             last_seen_merged_at: None,
             alerted_prs: Vec::new(),
+            api_base_url: None,
         };
         // Simulate cursor update (done by compliance_sweep at end)
         cfg.last_seen_merged_at = Some("2026-05-12T00:00:00Z".to_string());

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -465,33 +465,34 @@ pub(super) fn handle_release_repo(args: &Value) -> Value {
 /// other agent's subscription) to APPEND idempotent semantics — the
 /// caller is added to a `subscribers` array if not already present, and
 /// existing poll state (`last_run_id`, `head_sha`, etc.) is preserved.
-pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) -> Value {
-    // Sprint 55 P0-B: when caller omits `repo` arg, auto-derive from
-    // sender's binding.json source_repo (set by `bind_self` /
-    // `dispatch_auto_bind_lease`). EC1: surface explicit error if
-    // neither path nor binding present (no silent cwd-derivation). EC15:
-    // validate the binding's source_repo path still exists before reading.
-    let derived_repo: Option<String>;
-    let canonical_repo: Option<String>;
-    let repo: &str = match args["repository"].as_str().filter(|s| !s.is_empty()) {
+/// #1619: resolve the target `owner/repo` for a PR/CI handler.
+///
+/// Resolution order: explicit `repository` arg (canonicalized) → the
+/// caller's `binding.json` `source_repo` origin remote → error. It
+/// NEVER falls back to a hardcoded repo slug: a detection miss on
+/// someone else's deployment must fail loud, not silently operate
+/// (merge/checks/state) on the maintainer's repo.
+///
+/// Originally inline in `handle_watch_ci` (Sprint 55 P0-B); extracted so
+/// `handle_merge_repo` shares the exact same resolution instead of the
+/// old `.unwrap_or("suzuke/agend-terminal")` footgun. EC1: explicit
+/// error when neither arg nor binding present (no silent cwd-derivation).
+/// EC15: validate the binding's source_repo path still exists.
+fn resolve_repo_or_error(home: &Path, instance_name: &str, args: &Value) -> Result<String, Value> {
+    match args["repository"].as_str().filter(|s| !s.is_empty()) {
         Some(r) => {
             // #942: canonicalize on entry so the hash key + stored
             // `repo` field both reflect the single canonical form.
             // Rejects obviously-malformed input (non-GitHub URL, malformed
             // slug) with operator-actionable error.
             match crate::mcp::handlers::dispatch_hook::canonicalize_repo_slug(r) {
-                Some(c) => {
-                    canonical_repo = Some(c);
-                    canonical_repo.as_deref().unwrap_or("")
-                }
-                None => {
-                    return json!({
-                        "error": format!(
-                            "invalid 'repository' format: {r:?} — expected `owner/repo` or full GitHub URL"
-                        ),
-                        "code": "invalid_repo_format",
-                    });
-                }
+                Some(c) => Ok(c),
+                None => Err(json!({
+                    "error": format!(
+                        "invalid 'repository' format: {r:?} — expected `owner/repo` or full GitHub URL"
+                    ),
+                    "code": "invalid_repo_format",
+                })),
             }
         }
         None => {
@@ -500,44 +501,52 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
                 .join(instance_name)
                 .join("binding.json");
             let Ok(content) = std::fs::read_to_string(&binding) else {
-                return json!({
-                    "error": "ci(watch) needs explicit 'repository' arg OR active binding (call bind_self first)",
+                return Err(json!({
+                    "error": "could not determine repo slug; pass explicit 'repository' arg or call bind_self first (no active binding)",
                     "code": "no_binding_no_repo"
-                });
+                }));
             };
             let Ok(v) = serde_json::from_str::<Value>(&content) else {
-                return json!({
+                return Err(json!({
                     "error": "binding.json corrupt — re-bind or pass explicit 'repository'",
                     "code": "binding_corrupt"
-                });
+                }));
             };
             let Some(src) = v["source_repo"].as_str().filter(|s| !s.is_empty()) else {
-                return json!({
+                return Err(json!({
                     "error": "binding has no source_repo — pass explicit 'repository' arg",
                     "code": "no_binding_no_repo"
-                });
+                }));
             };
             let src_path = std::path::Path::new(src);
             if !src_path.exists() {
-                return json!({
+                return Err(json!({
                     "error": format!("binding source_repo '{src}' no longer exists — re-bind or pass explicit 'repository'"),
                     "code": "source_repo_path_deleted"
-                });
+                }));
             }
             match crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(src_path) {
-                Some(r) => {
-                    derived_repo = Some(r);
-                    derived_repo.as_deref().unwrap_or("")
-                }
-                None => {
-                    return json!({
-                        "error": format!("could not derive owner/repo from '{src}' origin remote — pass explicit 'repository' arg or set fleet.yaml `repo:` override"),
-                        "code": "non_github_remote_no_override"
-                    });
-                }
+                Some(r) => Ok(r),
+                None => Err(json!({
+                    "error": format!("could not derive owner/repo from '{src}' origin remote — pass explicit 'repository' arg or set fleet.yaml `repo:` override"),
+                    "code": "non_github_remote_no_override"
+                })),
             }
         }
+    }
+}
+
+pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) -> Value {
+    // Sprint 55 P0-B: when caller omits `repo` arg, auto-derive from
+    // sender's binding.json source_repo (set by `bind_self` /
+    // `dispatch_auto_bind_lease`). #1619: shared `resolve_repo_or_error`
+    // — explicit error when neither arg nor binding present (no silent
+    // cwd-derivation, no hardcoded fallback).
+    let repo_owned = match resolve_repo_or_error(home, instance_name, args) {
+        Ok(r) => r,
+        Err(e) => return e,
     };
+    let repo: &str = &repo_owned;
     let branch = args["branch"].as_str().unwrap_or("main");
     let interval = args["interval_secs"].as_u64().unwrap_or(60);
 
@@ -1155,10 +1164,13 @@ pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
         Some(n) => n,
         None => return json!({"error": "missing 'pr' (PR number)"}),
     };
-    let repo = args["repository"]
-        .as_str()
-        .unwrap_or("suzuke/agend-terminal")
-        .to_string();
+    // #1619: resolve via the shared helper instead of the old
+    // `.unwrap_or("suzuke/agend-terminal")` — a detection miss must NOT
+    // silently merge/check/state-query against the maintainer's repo.
+    let repo = match resolve_repo_or_error(home, instance_name, args) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
     let force = args["force"].as_bool().unwrap_or(false);
     let force_reason = args["force_reason"].as_str().unwrap_or("");
 

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2137,7 +2137,13 @@ fn merge_missing_pr_returns_error() {
 fn merge_force_without_reason_returns_error() {
     let home = std::env::temp_dir().join(format!("agend-merge-force-test-{}", std::process::id()));
     std::fs::create_dir_all(&home).unwrap();
-    let result = super::handle_merge_repo(&home, &json!({"pr": 1234, "force": true}), "dev");
+    // #1619: explicit `repository` so resolution succeeds and the test
+    // reaches the force/force_reason guard it's actually exercising.
+    let result = super::handle_merge_repo(
+        &home,
+        &json!({"pr": 1234, "force": true, "repository": "suzuke/agend-terminal"}),
+        "dev",
+    );
     assert!(result["error"].as_str().unwrap().contains("force_reason"));
     let _ = std::fs::remove_dir_all(&home);
 }
@@ -2151,7 +2157,9 @@ fn merge_force_audit_write_failure_refuses_merge() {
 
     let result = super::handle_merge_repo(
         &home,
-        &json!({"pr": 9999, "force": true, "force_reason": "test emergency"}),
+        // #1619: explicit `repository` so resolution succeeds and the
+        // test reaches the force-path audit write it's exercising.
+        &json!({"pr": 9999, "force": true, "force_reason": "test emergency", "repository": "suzuke/agend-terminal"}),
         "dev",
     );
     let err = result["error"].as_str().unwrap();
@@ -2159,6 +2167,33 @@ fn merge_force_audit_write_failure_refuses_merge() {
         err.contains("audit log write failed"),
         "expected audit failure error, got: {err}"
     );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+/// #1619: a merge with neither an explicit `repository` arg nor an
+/// active binding must FAIL LOUD — never silently fall back to a
+/// hardcoded maintainer repo (the old `.unwrap_or("suzuke/agend-terminal")`
+/// bug, which would have mis-targeted merge/checks/state on someone
+/// else's deployment).
+#[test]
+fn merge_no_repo_no_binding_errors_without_hardcoded_fallback() {
+    let home = std::env::temp_dir().join(format!("agend-merge-norepo-{}", std::process::id()));
+    std::fs::create_dir_all(&home).unwrap();
+    let result = super::handle_merge_repo(&home, &json!({"pr": 4242}), "dev");
+    let err = result["error"]
+        .as_str()
+        .expect("expected an error, not a merge");
+    assert_eq!(
+        result["code"].as_str(),
+        Some("no_binding_no_repo"),
+        "no repo + no binding must surface no_binding_no_repo, got: {result}"
+    );
+    assert!(
+        !err.contains("suzuke/agend-terminal"),
+        "error must NOT leak / fall back to the maintainer repo slug, got: {err}"
+    );
+    // And it must not report a successful merge.
+    assert!(result["merged"].as_bool() != Some(true));
     let _ = std::fs::remove_dir_all(&home);
 }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -219,7 +219,8 @@ pub(crate) fn def_task_sweep_config() -> Value {
     "inputSchema": {"type": "object", "properties": {
         "repository": {"type": "string", "description": "GitHub `owner/repo` slug to sweep (empty string disables)"},
         "pause": {"type": "boolean", "description": "Pause/resume the sweep tick"},
-        "dry_run": {"type": "boolean", "description": "Log decisions without emitting events"}
+        "dry_run": {"type": "boolean", "description": "Log decisions without emitting events"},
+        "api_base_url": {"type": "string", "description": "REST API base URL for self-hosted GitHub Enterprise (e.g. `https://ghe.example.com/api/v3`). Empty string resets to the default `https://api.github.com`."}
     }}})
 }
 


### PR DESCRIPTION
## Problem

Two hardcoded GitHub targets in live code that misfire on third-party deployments — same "hardcoded GitHub target" class, fixed together.

### Problem 1 — repo-slug fallback (security / correctness)

`src/mcp/handlers/ci/mod.rs` `handle_merge_repo` resolved the repo via `.unwrap_or("suzuke/agend-terminal")`. On someone else's deployment, a detection miss meant **merge / checks / state operations silently targeted the maintainer's repo** instead of erroring.

**Fix:** extract `handle_watch_ci`'s existing binding-based resolution into a shared `resolve_repo_or_error` helper and use it in `handle_merge_repo`. Resolution order: explicit `repository` arg (canonicalized) → caller's `binding.json` `source_repo` origin remote → **clear error** (`no_binding_no_repo` / `non_github_remote_no_override` / …). **Never** falls back to any hardcoded slug. `handle_watch_ci` now delegates to the same helper — behavior-identical (pure code move), existing tests pin it.

### Problem 2 — task_sweep API base (self-hosted support)

`src/daemon/task_sweep.rs` `list_recently_merged_prs` hardcoded `https://api.github.com`, so self-hosted GitHub Enterprise connected to the wrong host.

**Fix:** add a configurable `api_base_url` to `SweepConfig` (default `https://api.github.com`), a pure `build_merged_prs_url` builder (trailing-slash safe), and expose `api_base_url` on the `task_sweep_config` MCP tool — mirroring `CiProvider::with_base_url`. GHE base (`https://ghe.example.com/api/v3`) now works; the default path is byte-identical.

> Note: this HTTP call is orthogonal to the larger ScmProvider gh-CLI abstraction (separate task) — fixed directly per dispatch.

## Tests

- `merge_no_repo_no_binding_errors_without_hardcoded_fallback` — no repo + no binding → fails loud, `code=no_binding_no_repo`, asserts the error does **not** contain/fall back to `suzuke/agend-terminal`.
- The two force/audit merge tests now pass an explicit `repository` (they exercise the force path, not resolution).
- `build_merged_prs_url_uses_configurable_base` — default github.com (byte-identical) / GHE / trailing-slash.
- `config_tool_api_base_url_round_trip` — set + empty-string reset to default + `SweepConfig::default()` is `None`.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -- -D warnings` ✅
- `cargo test --features tray --bin agend-terminal` → 3048 passed, 0 failed ✅
- `cargo xwin check --target x86_64-pc-windows-msvc --features tray` ✅
- `cargo test --lib` ✅ (24 passed)

> Pre-existing unrelated local failure: `agend-git.rs::has_unmerged_files_true_on_conflict` fails identically on untouched origin/main in this sandbox (the temp-repo merge needs `git config user.email`, which CI sets) — it lives in the `agend-git` binary, which none of the 4 changed files touch. Passes in CI.

Closes the task. No behavior change on the existing (repo-resolved) path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)