### PR TITLE
feat(scm): PR-B — route sites 7 + 4 through ScmProvider (byte-identical)

### DIFF
--- a/src/daemon/pr_state/gh_poll.rs
+++ b/src/daemon/pr_state/gh_poll.rs
@@ -71,26 +71,36 @@ pub struct CliGhPoller;
 
 impl GhPoller for CliGhPoller {
     fn poll(&self, repo: &str) -> anyhow::Result<Vec<GhPrMetadata>> {
+        // #PR-B: route the `gh pr list` shell-out through `ScmProvider`
+        // instead of calling `Command::new("gh")` directly. The emitted
+        // argv is byte-identical to the prior inline call (pinned by
+        // `scm::tests::pr_list_args_match_site7_byte_identical`); the
+        // `--json` field set is passed verbatim. Behavior is unchanged:
+        // on any failure pr_list returns Err (same as the prior all-Err
+        // contract), Ok(vec) on success.
         let start = std::time::Instant::now();
-        let out = std::process::Command::new("gh")
-            .args([
-                "pr",
-                "list",
-                "--repo",
-                repo,
-                "--json",
-                "author,number,headRefName,isDraft,state,mergedAt",
-                "--state",
-                "all",
-                "--limit",
-                "100",
-            ])
-            .output()
-            .map_err(|e| anyhow::anyhow!("gh CLI invocation failed: {e}"))?;
+        let result = crate::scm::make_scm_provider(repo, None).pr_list(
+            repo,
+            &crate::scm::ListFilter {
+                state: Some("all"),
+                limit: Some(100),
+                ..Default::default()
+            },
+            &[
+                "author",
+                "number",
+                "headRefName",
+                "isDraft",
+                "state",
+                "mergedAt",
+            ],
+        );
         let elapsed = start.elapsed();
         // dev-2 BLOCKING #1: slip observability. >1s flags potential
         // scanner-thread blocking; >10% of tick budget triggers the
-        // fire-and-forget refactor commitment in the PR body.
+        // fire-and-forget refactor commitment in the PR body. Timing the
+        // whole trait call preserves the original semantics (the prior
+        // code warned after the gh process ran, regardless of exit).
         if elapsed > Duration::from_secs(1) {
             tracing::warn!(
                 repo = %repo,
@@ -99,39 +109,38 @@ impl GhPoller for CliGhPoller {
                  if recurrent, refactor to fire-and-forget worker"
             );
         }
-        if !out.status.success() {
-            anyhow::bail!(
-                "gh pr list exit={}: {}",
-                out.status,
-                String::from_utf8_lossy(&out.stderr)
-            );
-        }
-        let raw: Vec<serde_json::Value> = serde_json::from_slice(&out.stdout)
-            .map_err(|e| anyhow::anyhow!("gh pr list JSON parse: {e}"))?;
-        Ok(raw.into_iter().filter_map(parse_one).collect())
+        Ok(result?
+            .into_iter()
+            .filter_map(summary_to_gh_metadata)
+            .collect())
     }
 }
 
-/// Parse a single `gh pr list` JSON entry into [`GhPrMetadata`].
-/// Returns None on malformed entries (defensive — skip rather than
-/// abort the whole batch).
-pub(super) fn parse_one(v: serde_json::Value) -> Option<GhPrMetadata> {
+/// Map a provider-neutral [`crate::scm::PrSummary`] to [`GhPrMetadata`].
+/// Reproduces the prior `parse_one` contract verbatim: `number`,
+/// `author_login`, `head_ref` and a recognized `state` are required (a
+/// missing/unknown one drops the entry — defensive skip rather than
+/// aborting the batch), `is_draft` defaults to false, and `merged_at` is
+/// the already-nonempty-filtered optional. (`PrSummary.number` is 0 only
+/// when the JSON had no usable `number`, which a real PR never is, so it
+/// stands in for `parse_one`'s `number?` presence check.)
+fn summary_to_gh_metadata(s: crate::scm::PrSummary) -> Option<GhPrMetadata> {
+    let state = match s.state.as_deref()? {
+        "OPEN" => GhPrState::Open,
+        "MERGED" => GhPrState::Merged,
+        "CLOSED" => GhPrState::Closed,
+        _ => return None,
+    };
+    if s.number == 0 {
+        return None;
+    }
     Some(GhPrMetadata {
-        number: v.get("number")?.as_u64()?,
-        author_login: v.get("author")?.get("login")?.as_str()?.to_string(),
-        head_ref: v.get("headRefName")?.as_str()?.to_string(),
-        is_draft: v.get("isDraft").and_then(|x| x.as_bool()).unwrap_or(false),
-        state: match v.get("state")?.as_str()? {
-            "OPEN" => GhPrState::Open,
-            "MERGED" => GhPrState::Merged,
-            "CLOSED" => GhPrState::Closed,
-            _ => return None,
-        },
-        merged_at: v
-            .get("mergedAt")
-            .and_then(|x| x.as_str())
-            .filter(|s| !s.is_empty())
-            .map(String::from),
+        number: s.number,
+        author_login: s.author_login?,
+        head_ref: s.head_ref?,
+        is_draft: s.is_draft.unwrap_or(false),
+        state,
+        merged_at: s.merged_at,
     })
 }
 
@@ -285,18 +294,22 @@ pub(crate) mod tests {
         }
     }
 
-    /// T1: parse_one handles the canonical `gh pr list` JSON shape.
+    /// T1: summary_to_gh_metadata maps a canonical PrSummary to full
+    /// GhPrMetadata. (gh-JSON → PrSummary parsing is covered by
+    /// `scm::tests`; this pins the gh_poll-side mapping that replaced the
+    /// old `parse_one`.)
     #[test]
-    fn t1_parse_canonical_gh_response() {
-        let raw = serde_json::json!({
-            "number": 984,
-            "author": {"login": "suzuke", "id": "...", "is_bot": false, "name": "suzuke"},
-            "headRefName": "fix/969-channel-dedup-mirror-skip",
-            "isDraft": false,
-            "state": "MERGED",
-            "mergedAt": "2026-05-20T04:17:09Z"
-        });
-        let meta = parse_one(raw).expect("parse OK");
+    fn t1_map_canonical_summary() {
+        let s = crate::scm::PrSummary {
+            number: 984,
+            state: Some("MERGED".into()),
+            author_login: Some("suzuke".into()),
+            head_ref: Some("fix/969-channel-dedup-mirror-skip".into()),
+            is_draft: Some(false),
+            merged_at: Some("2026-05-20T04:17:09Z".into()),
+            ..Default::default()
+        };
+        let meta = summary_to_gh_metadata(s).expect("map OK");
         assert_eq!(meta.number, 984);
         assert_eq!(meta.author_login, "suzuke");
         assert_eq!(meta.head_ref, "fix/969-channel-dedup-mirror-skip");
@@ -305,31 +318,59 @@ pub(crate) mod tests {
         assert_eq!(meta.merged_at.as_deref(), Some("2026-05-20T04:17:09Z"));
     }
 
-    /// T1b: parse_one tolerates missing optional fields.
+    /// T1b: missing optional fields default (is_draft → false, merged_at
+    /// → None), matching the prior parse_one tolerance.
     #[test]
-    fn t1b_parse_missing_optional_fields() {
-        let raw = serde_json::json!({
-            "number": 970,
-            "author": {"login": "suzuke"},
-            "headRefName": "fix/x",
-            "state": "OPEN",
-            // isDraft + mergedAt absent
-        });
-        let meta = parse_one(raw).expect("parse OK");
+    fn t1b_map_missing_optional_fields() {
+        let s = crate::scm::PrSummary {
+            number: 970,
+            state: Some("OPEN".into()),
+            author_login: Some("suzuke".into()),
+            head_ref: Some("fix/x".into()),
+            is_draft: None,
+            merged_at: None,
+            ..Default::default()
+        };
+        let meta = summary_to_gh_metadata(s).expect("map OK");
         assert!(!meta.is_draft, "missing isDraft → false");
         assert_eq!(meta.merged_at, None, "missing mergedAt → None");
     }
 
-    /// T1c: parse_one returns None for unknown state strings.
+    /// T1c: unknown state string → None (drop), matching parse_one.
     #[test]
-    fn t1c_parse_unknown_state_returns_none() {
-        let raw = serde_json::json!({
-            "number": 1,
-            "author": {"login": "x"},
-            "headRefName": "br",
-            "state": "DRAFT", // not a valid PR state
-        });
-        assert!(parse_one(raw).is_none());
+    fn t1c_map_unknown_state_returns_none() {
+        let s = crate::scm::PrSummary {
+            number: 1,
+            state: Some("DRAFT".into()), // not a valid PR state
+            author_login: Some("x".into()),
+            head_ref: Some("br".into()),
+            ..Default::default()
+        };
+        assert!(summary_to_gh_metadata(s).is_none());
+    }
+
+    /// T1d: a missing required field (number absent → 0, or author/head
+    /// None) drops the entry — the parse_one `?` semantics.
+    #[test]
+    fn t1d_map_missing_required_fields_drop() {
+        // number 0 (no usable number in JSON) → drop.
+        let no_num = crate::scm::PrSummary {
+            number: 0,
+            state: Some("OPEN".into()),
+            author_login: Some("x".into()),
+            head_ref: Some("br".into()),
+            ..Default::default()
+        };
+        assert!(summary_to_gh_metadata(no_num).is_none());
+        // missing author_login → drop.
+        let no_author = crate::scm::PrSummary {
+            number: 5,
+            state: Some("OPEN".into()),
+            author_login: None,
+            head_ref: Some("br".into()),
+            ..Default::default()
+        };
+        assert!(summary_to_gh_metadata(no_author).is_none());
     }
 
     fn fresh_state(branch: &str) -> super::super::PrState {

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -13,11 +13,12 @@
 //! moved in verbatim (byte-identical argv), which is what makes the
 //! eventual call-site conversion behavior-preserving.
 //!
-//! **PR-A is scaffold only: it defines the trait + GitHub impl + neutral
-//! types and adds no callers.** The 10 `gh` sites stay as-is; conversion
-//! is the subsequent PR-B… series. Everything here is therefore unused
-//! in non-test builds until then — hence the module-wide `dead_code`
-//! allow, which PR-B removes as it wires the first call sites.
+//! Wiring is incremental: PR-A added the scaffold; **PR-B wires the first
+//! two call sites** (site 7 `pr_state/gh_poll.rs` via `pr_list`, site 4
+//! `tasks/sweep.rs` via `pr_view`). The remaining verbs (`pr_checks`,
+//! `pr_merge`) and the non-GitHub stubs are still unwired in non-test
+//! builds, so the module-wide `dead_code` allow stays until the later
+//! site conversions (PR-B+ / PR-Z) reach them.
 #![allow(dead_code)]
 
 use serde_json::Value;
@@ -116,8 +117,16 @@ pub(crate) trait ScmProvider: Send + Sync {
     fn pr_view(&self, repo: &str, pr: u64, fields: &[&str]) -> anyhow::Result<PrSummary>;
     /// `gh pr checks <pr> --json name,state` (sites 2/6).
     fn pr_checks(&self, repo: &str, pr: u64) -> anyhow::Result<Vec<CheckState>>;
-    /// `gh pr list …` → PRs matching `filter` (sites 7/9/10).
-    fn pr_list(&self, repo: &str, filter: &ListFilter) -> anyhow::Result<Vec<PrSummary>>;
+    /// `gh pr list …` → PRs matching `filter` (sites 7/9/10). `fields`
+    /// is the explicit `--json` set (each list site reads a different
+    /// subset), passed verbatim so the emitted argv is byte-identical to
+    /// the site it replaces.
+    fn pr_list(
+        &self,
+        repo: &str,
+        filter: &ListFilter,
+        fields: &[&str],
+    ) -> anyhow::Result<Vec<PrSummary>>;
     /// `gh pr merge …` — the only WRITE (site 3).
     fn pr_merge(&self, repo: &str, pr: u64, opts: &MergeOpts) -> anyhow::Result<MergeOutcome>;
 }
@@ -151,8 +160,15 @@ fn pr_checks_args(repo: &str, pr: u64) -> Vec<String> {
     ]
 }
 
-fn pr_list_args(repo: &str, filter: &ListFilter) -> Vec<String> {
+fn pr_list_args(repo: &str, filter: &ListFilter, fields: &[&str]) -> Vec<String> {
+    // Order: `pr list --repo R --json <fields> [--state] [--head] [--base]
+    // [--limit]`. This reproduces site 7's exact argv (the first list-site
+    // conversion). gh treats flag order as insensitive, so the other list
+    // sites (9/10) stay behavior-identical; their literal-argv match is
+    // pinned when they convert.
     let mut a = vec!["pr".into(), "list".into(), "--repo".into(), repo.into()];
+    a.push("--json".into());
+    a.push(fields.join(","));
     if let Some(s) = filter.state {
         a.push("--state".into());
         a.push(s.into());
@@ -165,10 +181,6 @@ fn pr_list_args(repo: &str, filter: &ListFilter) -> Vec<String> {
         a.push("--base".into());
         a.push(b.clone());
     }
-    a.push("--json".into());
-    // Neutral superset of fields the three list sites read; callers pick
-    // the subset they need off `PrSummary`.
-    a.push("number,state,author,headRefName,headRefOid,isDraft,mergedAt".into());
     if let Some(l) = filter.limit {
         a.push("--limit".into());
         a.push(l.to_string());
@@ -292,8 +304,13 @@ impl ScmProvider for GitHubScmProvider {
         Ok(parse_checks(&v))
     }
 
-    fn pr_list(&self, repo: &str, filter: &ListFilter) -> anyhow::Result<Vec<PrSummary>> {
-        let out = Self::run(&pr_list_args(repo, filter))?;
+    fn pr_list(
+        &self,
+        repo: &str,
+        filter: &ListFilter,
+        fields: &[&str],
+    ) -> anyhow::Result<Vec<PrSummary>> {
+        let out = Self::run(&pr_list_args(repo, filter, fields))?;
         if !out.status.success() {
             anyhow::bail!(
                 "gh pr list ({repo}) exited {}: {}",
@@ -341,7 +358,12 @@ macro_rules! not_supported_provider {
             fn pr_checks(&self, _repo: &str, _pr: u64) -> anyhow::Result<Vec<CheckState>> {
                 Err(NotSupported($kind).into())
             }
-            fn pr_list(&self, _repo: &str, _filter: &ListFilter) -> anyhow::Result<Vec<PrSummary>> {
+            fn pr_list(
+                &self,
+                _repo: &str,
+                _filter: &ListFilter,
+                _fields: &[&str],
+            ) -> anyhow::Result<Vec<PrSummary>> {
                 Err(NotSupported($kind).into())
             }
             fn pr_merge(
@@ -424,42 +446,73 @@ mod tests {
     }
 
     #[test]
-    fn pr_list_args_build_from_filter() {
-        // site 9 (branch_sweep) shape: merged + head + base.
+    fn pr_list_args_match_site7_byte_identical() {
+        // #PR-B byte-identical anchor: site 7 (pr_state/gh_poll.rs
+        // CliGhPoller::poll) emits EXACTLY this argv pre-conversion —
+        // `gh pr list --repo R --json <6 fields> --state all --limit 100`.
+        let f = ListFilter {
+            state: Some("all"),
+            head: None,
+            base: None,
+            limit: Some(100),
+        };
+        assert_eq!(
+            pr_list_args(
+                "suzuke/agend-terminal",
+                &f,
+                &[
+                    "author",
+                    "number",
+                    "headRefName",
+                    "isDraft",
+                    "state",
+                    "mergedAt"
+                ]
+            ),
+            vec![
+                "pr",
+                "list",
+                "--repo",
+                "suzuke/agend-terminal",
+                "--json",
+                "author,number,headRefName,isDraft,state,mergedAt",
+                "--state",
+                "all",
+                "--limit",
+                "100",
+            ]
+        );
+    }
+
+    #[test]
+    fn pr_list_args_optional_flags_omitted_when_unset() {
+        // head/base/state/limit each appear only when set; fields are
+        // passed verbatim (each list site supplies its own subset).
         let f = ListFilter {
             state: Some("merged"),
             head: Some("feat/x".into()),
             base: Some("main".into()),
             limit: None,
         };
+        let a = pr_list_args("o/r", &f, &["headRefOid"]);
         assert_eq!(
-            pr_list_args("o/r", &f),
+            a,
             vec![
                 "pr",
                 "list",
                 "--repo",
                 "o/r",
+                "--json",
+                "headRefOid",
                 "--state",
                 "merged",
                 "--head",
                 "feat/x",
                 "--base",
                 "main",
-                "--json",
-                "number,state,author,headRefName,headRefOid,isDraft,mergedAt",
             ]
         );
-        // site 10 (admin) shape: head + merged + limit 1.
-        let f2 = ListFilter {
-            state: Some("merged"),
-            head: Some("feat/y".into()),
-            base: None,
-            limit: Some(1),
-        };
-        let a = pr_list_args("o/r", &f2);
-        assert_eq!(a.last().map(String::as_str), Some("1"));
-        assert!(a.contains(&"--limit".to_string()));
-        assert!(!a.contains(&"--base".to_string()));
+        assert!(!a.contains(&"--limit".to_string()));
     }
 
     #[test]

--- a/src/tasks/sweep.rs
+++ b/src/tasks/sweep.rs
@@ -21,39 +21,28 @@ pub(super) enum PrState {
 /// `gh_pr_lookup` below.
 pub(super) type PrLookup<'a> = &'a dyn Fn(&str, u32) -> Result<PrState, String>;
 
-/// Production PR-state lookup — shells out to `gh pr view`.
-/// Mirrors the existing precedent at
-/// `src/mcp/handlers/sha_gate.rs::fetch_pr_head_sha`.
+/// Production PR-state lookup — resolves `gh pr view` through the
+/// [`crate::scm::ScmProvider`] abstraction (#PR-B; was a direct
+/// `Command::new("gh")` shell-out).
 pub(super) fn gh_pr_lookup(repo: &str, num: u32) -> Result<PrState, String> {
-    let output = std::process::Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &num.to_string(),
-            "--repo",
-            repo,
-            "--json",
-            "state,mergedAt",
-        ])
-        .output()
-        .map_err(|e| format!("gh pr view failed: {e}"))?;
-    if !output.status.success() {
-        // PR may not exist on this repo — treat as Unknown so
-        // categorization skips rather than erroring out the whole
-        // sweep over a stale PR reference.
-        return Ok(PrState::Unknown);
-    }
-    let body = String::from_utf8_lossy(&output.stdout);
-    let json: serde_json::Value =
-        serde_json::from_str(&body).map_err(|e| format!("gh json parse: {e}"))?;
-    match json["state"].as_str() {
-        Some("MERGED") => Ok(PrState::Merged {
-            merged_at: json["mergedAt"].as_str().unwrap_or("unknown").to_string(),
-        }),
-        Some("CLOSED") => Ok(PrState::Closed),
-        Some("OPEN") => Ok(PrState::Open),
-        _ => Ok(PrState::Unknown),
-    }
+    // #PR-B: argv is byte-identical to the prior inline call
+    // (`gh pr view <num> --repo R --json state,mergedAt`, pinned by
+    // `scm::tests::pr_view_args_match_existing_gh_call`). The prior code
+    // returned Ok(Unknown) on a non-zero exit (PR may not exist → skip,
+    // don't abort the sweep); pr_view surfaces failures as Err, and the
+    // sole caller already does `.unwrap_or(PrState::Unknown)`
+    // (categorize), so the observable behavior is unchanged.
+    let summary = crate::scm::make_scm_provider(repo, None)
+        .pr_view(repo, num as u64, &["state", "mergedAt"])
+        .map_err(|e| e.to_string())?;
+    Ok(match summary.state.as_deref() {
+        Some("MERGED") => PrState::Merged {
+            merged_at: summary.merged_at.unwrap_or_else(|| "unknown".to_string()),
+        },
+        Some("CLOSED") => PrState::Closed,
+        Some("OPEN") => PrState::Open,
+        _ => PrState::Unknown,
+    })
 }
 
 #[derive(Debug, Clone, serde::Serialize)]


### PR DESCRIPTION
## What

Second step of the ScmProvider migration (after PR-A scaffold #1606). Converts the two **lowest-risk** `gh` call sites — both already had a mock/fn-ptr test seam — to go through the trait instead of `Command::new("gh")`. **Byte-identical argv, zero behavior change**; only the IO indirection changes.

## site 7 — `pr_state/gh_poll.rs` `CliGhPoller::poll`

- Now calls `scm::make_scm_provider(repo, None).pr_list(repo, {state: all, limit: 100}, [author, number, headRefName, isDraft, state, mergedAt])`.
- **Byte-identical argv**: `gh pr list --repo R --json author,number,headRefName,isDraft,state,mergedAt --state all --limit 100` — pinned by `scm::tests::pr_list_args_match_site7_byte_identical`.
- Slip-observability warn (>1s) **preserved** (now times the whole trait call; same threshold / message / fields).
- `parse_one` (Value→GhPrMetadata) was orphaned by the conversion → replaced with `summary_to_gh_metadata` (PrSummary→GhPrMetadata), reproducing the exact required / optional / drop contract. Its 3 tests migrated to the new mapping + a 4th pinning the required-field drops.
- Error contract unchanged: all failures → `Err` (matches the prior all-Err), `Ok(vec)` on success.

## site 4 — `tasks/sweep.rs` `gh_pr_lookup`

- Now calls `pr_view(repo, num, [state, mergedAt])`; **byte-identical argv** (`gh pr view <num> --repo R --json state,mergedAt`) — pinned by `scm::tests::pr_view_args_match_existing_gh_call`.
- The prior non-zero-exit → `Ok(Unknown)` is now surfaced as `Err`; the sole caller (`sweep.rs` categorize) already does `.unwrap_or(PrState::Unknown)`, so the observable result is unchanged.

## scm/mod.rs

`pr_list` gains an explicit `fields` param (each list site reads a different `--json` subset) and the builder is ordered `--json`-first to reproduce site 7's exact argv. Sites 9/10 (later PRs) get the same canonical order — gh is flag-order-insensitive so behavior is identical; their literal-argv match is pinned when they convert. Module `dead_code` allow stays (`pr_checks` / `pr_merge` / non-GitHub stubs are wired in later PRs).

## Only observable delta

Error-**log** wording on a gh failure (the trait's bail message vs the prior inline strings) — fed only to `tracing::warn`. The scanner's failure-counter / categorize-skip behavior is identical.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -- -D warnings` ✅
- `cargo test --features tray --bin agend-terminal` → 3064 passed, 0 failed ✅ (incl. migrated gh_poll mapping tests + scm argv pins; existing scanner/sweep/MockGhPoller tests green)
- `cargo xwin check --target x86_64-pc-windows-msvc --features tray` ✅

Reviewer focus: **codex** — verify the emitted gh argv is byte-identical (argv-builder pins + the two call sites); **reviewer-2** — verify no behavior regression in the pr_state scanner + task sweep paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)