### PR TITLE
feat(scm): PR-C — route jq sites 8/5/6 through ScmProvider (behavior-identical)

### DIFF
--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -613,27 +613,17 @@ fn is_docs_only_pr(files: &[String]) -> bool {
             .all(|f| f.starts_with("docs/") || f.ends_with(".md"))
 }
 
-/// Get changed files for a PR via GitHub API.
+/// Get changed files for a PR via the [`crate::scm::ScmProvider`]
+/// abstraction (#PR-C; was a direct `gh pr view ... --jq .files[].path`).
 fn get_pr_changed_files(pr_number: u64, repo: &str) -> Vec<String> {
-    let output = std::process::Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &pr_number.to_string(),
-            "--repo",
-            repo,
-            "--json",
-            "files",
-            "--jq",
-            ".files[].path",
-        ])
-        .output();
-    match output {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
-            .lines()
-            .map(String::from)
-            .collect(),
-        _ => Vec::new(),
+    // #PR-C: behavior-identical. The prior call used `--jq .files[].path`
+    // to print one path per line server-side; the typed `pr_view` returns
+    // the parsed `files` paths instead (the `--jq` gh-ism is abstracted
+    // away — same path list). argv delta: `--jq .files[].path` removed.
+    // Failure → empty Vec (unchanged from the prior `_ => Vec::new()`).
+    match crate::scm::make_scm_provider(repo, None).pr_view(repo, pr_number, &["files"]) {
+        Ok(summary) => summary.files.unwrap_or_default(),
+        Err(_) => Vec::new(),
     }
 }
 
@@ -643,27 +633,39 @@ fn has_review_verdict(pr: &PrMeta) -> bool {
     body_upper.contains("VERIFIED")
 }
 
-/// Check 2: All CI checks passed (queries gh pr checks).
+/// #PR-C: client-side reproduction of site-6's prior `gh` `--jq`:
+///   `[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | length`
+/// Counts checks whose `state` is NEITHER "SUCCESS" NOR "SKIPPED"
+/// (case-sensitive; null/empty/unknown states all count as not-passed,
+/// matching jq's `!=` on a null `.state`). This is the byte-for-byte
+/// behavioral equivalent of the dropped server-side jq.
+fn count_checks_not_passed(checks: &[crate::scm::CheckState]) -> usize {
+    checks
+        .iter()
+        .filter(|c| c.state != "SUCCESS" && c.state != "SKIPPED")
+        .count()
+}
+
+/// Check 2: All CI checks passed (queries `gh pr checks` via the
+/// [`crate::scm::ScmProvider`] abstraction — #PR-C).
 fn check_ci_green(pr: &PrMeta, repo: &str) -> Option<ComplianceViolation> {
-    let output = std::process::Command::new("gh")
-        .args([
-            "pr",
-            "checks",
-            &pr.number.to_string(),
-            "--repo",
-            repo,
-            "--json",
-            "state",
-            "--jq",
-            "[.[] | select(.state != \"SUCCESS\" and .state != \"SKIPPED\")] | length",
-        ])
-        .output();
-    match output {
-        Ok(o) if o.status.success() => {
-            let count: u32 = String::from_utf8_lossy(&o.stdout)
-                .trim()
-                .parse()
-                .unwrap_or(1);
+    // #PR-C: behavior-identical, FAIL-CLOSED preserved. The prior call
+    // pushed the count server-side via
+    //   --jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | length'
+    // then `unwrap_or(1)` (unparseable → treat as 1 = not green). The
+    // typed `pr_checks` returns every check (a null/absent state is kept
+    // as "" — see scm::parse_checks) and we reproduce the jq filter
+    // client-side: any state that is NEITHER "SUCCESS" NOR "SKIPPED"
+    // counts as not-passed (case-sensitive, null/unknown → not-passed).
+    // Fail-closed direction unchanged: a gh failure / unparseable
+    // response → Err → counted as a violation (was the prior `_ =>` arm +
+    // `unwrap_or(1)`); the ONLY None (passed) path is "all checks
+    // SUCCESS/SKIPPED", identical to before. argv delta: `--jq <expr>`
+    // removed + `--json state` → `name,state` (pr_checks' fixed field
+    // set; the count reads only `state`, so the result is identical).
+    match crate::scm::make_scm_provider(repo, None).pr_checks(repo, pr.number) {
+        Ok(checks) => {
+            let count = count_checks_not_passed(&checks);
             if count > 0 {
                 Some(ComplianceViolation {
                     pr_number: pr.number,
@@ -674,8 +676,9 @@ fn check_ci_green(pr: &PrMeta, repo: &str) -> Option<ComplianceViolation> {
                 None
             }
         }
-        _ => {
-            // Can't verify CI — treat as violation in enforce mode
+        Err(_) => {
+            // Can't verify CI — treat as violation (fail-closed), same as
+            // the prior gh-failure / unparseable path.
             Some(ComplianceViolation {
                 pr_number: pr.number,
                 check_name: "ci_green",
@@ -1076,6 +1079,42 @@ mod tests {
 
     /// #1619: the merged-PR list URL is built from a configurable API
     /// base (self-hosted GitHub Enterprise support) — NOT pinned to
+    /// #PR-C site-6: the client-side `count_checks_not_passed` must
+    /// reproduce the prior `--jq`
+    /// `[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | length`
+    /// EXACTLY — incl. the fail-closed treatment of null / empty / unknown
+    /// states as not-passed. (gh-failure / unparseable → pr_checks Err →
+    /// the `Err(_)` violation arm in check_ci_green, also fail-closed.)
+    #[test]
+    fn count_checks_not_passed_reproduces_jq() {
+        use crate::scm::CheckState;
+        let mk = |state: &str| CheckState {
+            name: "c".to_string(),
+            state: state.to_string(),
+        };
+        // empty → 0 (all-passed → None violation).
+        assert_eq!(count_checks_not_passed(&[]), 0);
+        // all SUCCESS / SKIPPED → 0.
+        assert_eq!(
+            count_checks_not_passed(&[mk("SUCCESS"), mk("SKIPPED"), mk("SUCCESS")]),
+            0
+        );
+        // mixed: one FAILURE among greens → 1.
+        assert_eq!(
+            count_checks_not_passed(&[mk("SUCCESS"), mk("FAILURE"), mk("SKIPPED")]),
+            1
+        );
+        // unknown states count as not-passed.
+        assert_eq!(
+            count_checks_not_passed(&[mk("PENDING"), mk("NEUTRAL"), mk("CANCELLED")]),
+            3
+        );
+        // null/empty state (parse_checks keeps it as "") → not-passed.
+        assert_eq!(count_checks_not_passed(&[mk(""), mk("SUCCESS")]), 1);
+        // case-sensitive: lowercase "success" is NOT the green sentinel.
+        assert_eq!(count_checks_not_passed(&[mk("success")]), 1);
+    }
+
     /// github.com. Trailing slashes on the base are trimmed.
     #[test]
     fn build_merged_prs_url_uses_configurable_base() {

--- a/src/mcp/handlers/sha_gate.rs
+++ b/src/mcp/handlers/sha_gate.rs
@@ -56,35 +56,27 @@ pub(crate) fn extract_pr_number(text: &str) -> Option<String> {
     Some(format!("{repo_path}#{pr_num}"))
 }
 
-/// Fetch the current HEAD SHA of a PR via `gh pr view`.
+/// Fetch the current HEAD SHA of a PR via the [`crate::scm::ScmProvider`]
+/// abstraction (#PR-C; was a direct `gh pr view ... -q .headRefOid`).
 pub(crate) fn fetch_pr_head_sha(pr_ref: &str) -> Result<String, String> {
     let parts: Vec<&str> = pr_ref.splitn(2, '#').collect();
     if parts.len() != 2 {
         return Err(format!("invalid PR ref: {pr_ref}"));
     }
     let (repo, number) = (parts[0], parts[1]);
-    let output = std::process::Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            number,
-            "--repo",
-            repo,
-            "--json",
-            "headRefOid",
-            "-q",
-            ".headRefOid",
-        ])
-        .output()
-        .map_err(|e| format!("gh pr view failed: {e}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "gh pr view exited {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // #PR-C: behavior-identical conversion. The prior call used gh's
+    // `-q .headRefOid` to print the SHA string server-side; the typed
+    // `pr_view` returns the parsed `head_ref_oid` field instead — the
+    // `-q` gh-ism is intentionally abstracted away (same SHA). argv
+    // delta: `-q .headRefOid` removed (only difference). Return contract
+    // unchanged: Err on gh failure, Err on empty SHA, Ok(sha) otherwise.
+    let num: u64 = number
+        .parse()
+        .map_err(|_| format!("invalid PR number in ref: {pr_ref}"))?;
+    let summary = crate::scm::make_scm_provider(repo, None)
+        .pr_view(repo, num, &["headRefOid"])
+        .map_err(|e| e.to_string())?;
+    let sha = summary.head_ref_oid.unwrap_or_default();
     if sha.is_empty() {
         return Err("gh pr view returned empty SHA".to_string());
     }

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -13,12 +13,11 @@
 //! moved in verbatim (byte-identical argv), which is what makes the
 //! eventual call-site conversion behavior-preserving.
 //!
-//! Wiring is incremental: PR-A added the scaffold; **PR-B wires the first
-//! two call sites** (site 7 `pr_state/gh_poll.rs` via `pr_list`, site 4
-//! `tasks/sweep.rs` via `pr_view`). The remaining verbs (`pr_checks`,
-//! `pr_merge`) and the non-GitHub stubs are still unwired in non-test
-//! builds, so the module-wide `dead_code` allow stays until the later
-//! site conversions (PR-B+ / PR-Z) reach them.
+//! Wiring is incremental: PR-A added the scaffold; PR-B wired sites 7
+//! (`pr_list`) + 4 (`pr_view`); **PR-C wires sites 8 + 5 (`pr_view`) and 6
+//! (`pr_checks`)**. The remaining write verb (`pr_merge`, site 3) and the
+//! non-GitHub stubs are still unwired in non-test builds, so the
+//! module-wide `dead_code` allow stays until PR-Z reaches them.
 #![allow(dead_code)]
 
 use serde_json::Value;
@@ -244,15 +243,20 @@ fn parse_pr_summary(v: &Value) -> PrSummary {
 }
 
 /// Parse a `gh pr checks --json name,state` array.
+///
+/// #PR-C: every array element is kept (NO drop on a missing/null `name`
+/// or `state`) — a null/absent `state` becomes `""`. This is required so
+/// the site-6 (`check_ci_green`) count reproduces the prior `--jq`
+/// `select(.state != "SUCCESS" and .state != "SKIPPED")` exactly, where a
+/// null state is `!= "SUCCESS"` ⟹ counted as not-passed (fail-closed). It
+/// also matches site 2's `as_str().unwrap_or("")` treatment of null state.
 fn parse_checks(v: &Value) -> Vec<CheckState> {
     v.as_array()
         .map(|arr| {
             arr.iter()
-                .filter_map(|c| {
-                    Some(CheckState {
-                        name: c["name"].as_str()?.to_string(),
-                        state: c["state"].as_str()?.to_string(),
-                    })
+                .map(|c| CheckState {
+                    name: c["name"].as_str().unwrap_or("").to_string(),
+                    state: c["state"].as_str().unwrap_or("").to_string(),
                 })
                 .collect()
         })
@@ -430,6 +434,24 @@ mod tests {
     }
 
     #[test]
+    fn pr_view_args_prc_sites_drop_q_and_jq() {
+        // #PR-C: sites 8 + 5 previously used gh's `-q`/`--jq` to extract a
+        // field server-side. pr_view intentionally does NOT emit those —
+        // it returns the parsed PrSummary field instead. These pins make
+        // the (intentional, behavior-identical) argv delta explicit.
+        // site 8 (sha_gate): was `... --json headRefOid -q .headRefOid`.
+        assert_eq!(
+            pr_view_args("o/r", 1, &["headRefOid"]),
+            vec!["pr", "view", "1", "--repo", "o/r", "--json", "headRefOid"]
+        );
+        // site 5 (task_sweep): was `... --json files --jq .files[].path`.
+        assert_eq!(
+            pr_view_args("o/r", 1, &["files"]),
+            vec!["pr", "view", "1", "--repo", "o/r", "--json", "files"]
+        );
+    }
+
+    #[test]
     fn pr_checks_args_match_existing_gh_call() {
         assert_eq!(
             pr_checks_args("o/r", 42),
@@ -593,16 +615,25 @@ mod tests {
     }
 
     #[test]
-    fn parse_checks_filters_malformed_entries() {
+    fn parse_checks_keeps_all_entries_null_state_empty() {
+        // #PR-C: NO drop — a missing/null `state` is kept as "" so the
+        // site-6 fail-closed count treats it as not-passed (matches the
+        // prior `--jq` select on null state).
         let v = serde_json::json!([
             {"name": "build", "state": "SUCCESS"},
-            {"name": "no_state"},                      // dropped (missing state)
+            {"name": "no_state"},          // kept, state → ""
             {"name": "lint", "state": "FAILURE"},
+            {"state": "PENDING"},          // kept, name → ""
         ]);
         let checks = parse_checks(&v);
-        assert_eq!(checks.len(), 2);
+        assert_eq!(checks.len(), 4, "every array element is kept");
         assert_eq!(checks[0].name, "build");
-        assert_eq!(checks[1].state, "FAILURE");
+        assert_eq!(
+            checks[1].state, "",
+            "missing state → empty string (not dropped)"
+        );
+        assert_eq!(checks[2].state, "FAILURE");
+        assert_eq!(checks[3].name, "", "missing name → empty string");
     }
 
     // ---- selection + NotSupported ----


### PR DESCRIPTION
## What

Third step of the ScmProvider migration (after PR-A #1606 scaffold, PR-B #1607 sites 7+4). Converts the three `gh` sites that used `-q`/`--jq` for **server-side extraction/aggregation**.

## Why behavior-identical, not literal byte-identical (lead-ruled)

`-q`/`--jq` is a gh-ism (no GitLab/Bitbucket analogue). The typed trait returns parsed data and does the extraction **client-side in Rust** — so converting these sites necessarily drops the `-q`/`--jq` tokens. Literal byte-identical argv is therefore impossible here; the invariant is **behavior-identical**: same return value, fail-closed direction preserved. Each argv delta is intentional and documented below (so reviewers don't false-REJECT it as a regression).

## Sites

**site 8 — `sha_gate.rs` `fetch_pr_head_sha`**
`pr_view(repo, num, [headRefOid])` → `summary.head_ref_oid`. **argv delta:** `-q .headRefOid` removed. Same SHA; `Err` on gh-fail, `Err` on empty SHA (unchanged).

**site 5 — `task_sweep.rs` `get_pr_changed_files`**
`pr_view(repo, num, [files])` → `summary.files`. **argv delta:** `--jq .files[].path` removed. Same path list; failure → empty `Vec` (unchanged).

**site 6 — `task_sweep.rs` `check_ci_green` (FAIL-CLOSED — handled most carefully)**
`pr_checks(repo, num)` → client-side `count_checks_not_passed()` reproducing the prior `--jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED")] | length'` **exactly** (case-sensitive; null/empty/unknown states all count as not-passed). **argv delta:** `--jq <expr>` removed + `--json state` → `name,state` (the count reads only `state`, so identical).
- **Fail-closed preserved:** gh-failure / unparseable → `pr_checks` `Err` → violation (was the `_ =>` arm + `unwrap_or(1)`). The ONLY `None` (passed) path is "all checks SUCCESS/SKIPPED" — identical to before.

## scm/mod.rs — `parse_checks` made lenient (important)

Every array element is now kept; a null/absent `state` becomes `""` (was: dropped via `?`). **Required** so a null-state check counts as not-passed (matches the jq + site-2's `as_str().unwrap_or("")`); a silent drop would have been a fail-closed regression. The PR-A `parse_checks` test was updated to assert the lenient contract.

## Tests

- `count_checks_not_passed_reproduces_jq` — empty / all-green / mixed / unknown-state / null-state / case-sensitivity fixtures.
- `parse_checks_keeps_all_entries_null_state_empty` — lenient parse.
- `pr_view_args_prc_sites_drop_q_and_jq` — argv-delta pins (no `-q`/`--jq`).
- Existing `sha_gate` + `task_sweep` compliance tests stay green.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -- -D warnings` ✅
- `cargo test --features tray --bin agend-terminal` → 3066 passed, 0 failed ✅
- `cargo xwin check --target x86_64-pc-windows-msvc --features tray` ✅

Reviewer focus: **codex** — verify behavior-equivalence + the client-side extraction faithfully reproduces the dropped jq (esp. site-6 fail-closed incl. null/unknown state); the argv deltas are **intentional (jq is the abstracted gh-ism)**, not regressions. **reviewer-2** — no behavior regression in sweep / sha-gate; site-6 fail-closed unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)