### PR TITLE
feat(scm): PR-D — route remaining read sites 1/2/9/10 through ScmProvider

### DIFF
--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -59,18 +59,31 @@ fn local_branches(repo: &Path) -> Vec<String> {
     }
 }
 
-/// Check if a branch has a merged PR via `gh pr list`.
+/// Check if a branch has a merged PR via `gh pr list` (through the
+/// [`crate::scm::ScmProvider`] abstraction — #PR-D).
 fn has_merged_pr(repo: &Path, branch: &str) -> Option<u64> {
-    let output = std::process::Command::new("gh")
-        .args([
-            "pr", "list", "--head", branch, "--state", "merged", "--json", "number", "--limit", "1",
-        ])
-        .current_dir(repo)
-        .output()
+    // #PR-D site 10: the prior call ran `gh pr list --head B --state merged
+    // --json number --limit 1` with `.current_dir(repo)` and NO `--repo`
+    // (gh auto-detects the repo from the cwd) — `repo` here is a filesystem
+    // path, not an owner/repo slug. Routed through pr_list with `cwd =
+    // Some(repo)` so `--repo` is omitted and gh still runs in that dir:
+    // argv set-equal to the original (flag-order canonicalized, gh
+    // order-insensitive; decision d-20260601151209762922-0). Any failure /
+    // no PR → None (unchanged).
+    let prs = crate::scm::make_scm_provider("", None)
+        .pr_list(
+            "",
+            &crate::scm::ListFilter {
+                state: Some("merged"),
+                head: Some(branch.to_string()),
+                limit: Some(1),
+                ..Default::default()
+            },
+            &["number"],
+            Some(repo),
+        )
         .ok()?;
-    let text = String::from_utf8_lossy(&output.stdout);
-    let parsed: serde_json::Value = serde_json::from_str(&text).ok()?;
-    parsed.as_array()?.first()?["number"].as_u64()
+    prs.first().map(|s| s.number).filter(|n| *n != 0)
 }
 
 /// Analyze all local branches and determine cleanup actions.

--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -252,36 +252,28 @@ fn is_squash_merged_diff(repo: &Path, base: &str, branch: &str) -> bool {
     let Some(local_sha) = local_sha else {
         return false;
     };
-    // gh pr list --state merged --head <branch> --json headRefOid
-    let output = std::process::Command::new("gh")
-        .args([
-            "pr",
-            "list",
-            "--state",
-            "merged",
-            "--head",
-            branch,
-            "--base",
-            base,
-            "--repo",
-            &gh_repo,
-            "--json",
-            "headRefOid",
-        ])
-        .output();
-    let Ok(o) = output else { return false };
-    if !o.status.success() {
+    // #PR-D: `gh pr list` via ScmProvider. argv is set-equal to the prior
+    // inline `pr list --state merged --head B --base BASE --repo R --json
+    // headRefOid` — flag ORDER is canonicalized (gh order-insensitive) per
+    // decision d-20260601151209762922-0; same flags+values. Uses --repo
+    // (gh_repo derived above), no cwd. Any failure → false (unchanged from
+    // the prior gh-fail / parse-fail → false).
+    let Ok(prs) = crate::scm::make_scm_provider(&gh_repo, None).pr_list(
+        &gh_repo,
+        &crate::scm::ListFilter {
+            state: Some("merged"),
+            head: Some(branch.to_string()),
+            base: Some(base.to_string()),
+            ..Default::default()
+        },
+        &["headRefOid"],
+        None,
+    ) else {
         return false;
-    }
-    // Parse JSON array and check if any PR's headRefOid matches local SHA.
-    let stdout = String::from_utf8_lossy(&o.stdout);
-    let prs: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap_or_default();
-    prs.iter().any(|pr| {
-        pr["headRefOid"]
-            .as_str()
-            .map(|sha| sha == local_sha)
-            .unwrap_or(false)
-    })
+    };
+    // True iff any merged PR's HEAD SHA matches the local branch tip.
+    prs.iter()
+        .any(|s| s.head_ref_oid.as_deref() == Some(local_sha.as_str()))
 }
 
 /// Extract "owner/repo" from a GitHub remote URL.

--- a/src/daemon/pr_state/gh_poll.rs
+++ b/src/daemon/pr_state/gh_poll.rs
@@ -94,6 +94,7 @@ impl GhPoller for CliGhPoller {
                 "state",
                 "mergedAt",
             ],
+            None, // #PR-D: uses --repo (no cwd), byte-identical to before
         );
         let elapsed = start.elapsed();
         // dev-2 BLOCKING #1: slip observability. >1s flags potential

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -1103,19 +1103,22 @@ enum MergeVerdict {
     },
 }
 
-/// #1467: classify a `gh pr view --json state,mergeCommit,mergeStateStatus`
-/// payload into a [`MergeVerdict`]. PURE — tests drive it directly without
-/// shelling `gh`. A PR is confirmed merged only when GitHub reports
-/// `state == "MERGED"` AND a non-empty `mergeCommit.oid`.
-fn classify_merge_view(view: &Value) -> MergeVerdict {
-    let state = view["state"].as_str().unwrap_or("UNKNOWN").to_string();
-    let oid = view["mergeCommit"]["oid"].as_str().unwrap_or("");
+/// #1467: classify a `gh pr view` result into a [`MergeVerdict`]. PURE —
+/// tests drive it directly without shelling `gh`. A PR is confirmed merged
+/// only when GitHub reports `state == "MERGED"` AND a non-empty merge-commit
+/// oid. #PR-D: takes the typed [`crate::scm::PrSummary`] (was a raw `Value`);
+/// the three reads map 1:1 (`state` → `state`; `mergeCommit.oid` →
+/// `merge_commit_oid`, empty→None; `mergeStateStatus` → `merge_state_status`),
+/// so the verdict is byte-for-byte the same.
+fn classify_merge_summary(s: &crate::scm::PrSummary) -> MergeVerdict {
+    let state = s.state.clone().unwrap_or_else(|| "UNKNOWN".to_string());
+    let oid = s.merge_commit_oid.clone().unwrap_or_default();
     if state == "MERGED" && !oid.is_empty() {
-        MergeVerdict::Confirmed(oid.to_string())
+        MergeVerdict::Confirmed(oid)
     } else {
         MergeVerdict::Unconfirmed {
             state,
-            merge_state_status: view["mergeStateStatus"].as_str().unwrap_or("").to_string(),
+            merge_state_status: s.merge_state_status.clone().unwrap_or_default(),
         }
     }
 }
@@ -1125,6 +1128,13 @@ fn classify_merge_view(view: &Value) -> MergeVerdict {
 /// consistency lag — NOT an infinite wait. Returns the last verdict seen; the
 /// first `Confirmed` short-circuits.
 fn verify_merge_landed(repo: &str, pr: u64) -> MergeVerdict {
+    // #PR-D site 1: the single `gh pr view` goes through ScmProvider. argv
+    // byte-identical (`pr view <pr> --repo R --json state,mergeCommit,
+    // mergedAt,mergeStateStatus`). The retry loop stays here (deliberately
+    // NOT folded into the trait — spike §4). On any gh failure pr_view
+    // returns Err → keep polling / fall back to `last` (was the prior
+    // non-success / parse-fail skip).
+    let provider = crate::scm::make_scm_provider(repo, None);
     let mut last = MergeVerdict::Unconfirmed {
         state: "UNKNOWN".to_string(),
         merge_state_status: String::new(),
@@ -1133,27 +1143,15 @@ fn verify_merge_landed(repo: &str, pr: u64) -> MergeVerdict {
         if attempt > 0 {
             std::thread::sleep(std::time::Duration::from_secs(2));
         }
-        let out = std::process::Command::new("gh")
-            .args([
-                "pr",
-                "view",
-                &pr.to_string(),
-                "--repo",
-                repo,
-                "--json",
-                "state,mergeCommit,mergedAt,mergeStateStatus",
-            ])
-            .output();
-        match out {
-            Ok(o) if o.status.success() => {
-                if let Ok(v) = serde_json::from_slice::<Value>(&o.stdout) {
-                    match classify_merge_view(&v) {
-                        MergeVerdict::Confirmed(c) => return MergeVerdict::Confirmed(c),
-                        unconfirmed => last = unconfirmed,
-                    }
-                }
+        if let Ok(summary) = provider.pr_view(
+            repo,
+            pr,
+            &["state", "mergeCommit", "mergedAt", "mergeStateStatus"],
+        ) {
+            match classify_merge_summary(&summary) {
+                MergeVerdict::Confirmed(c) => return MergeVerdict::Confirmed(c),
+                unconfirmed => last = unconfirmed,
             }
-            _ => {} // transient gh failure — keep polling, fall back to `last`
         }
     }
     last
@@ -1179,59 +1177,52 @@ pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
     }
 
     if !force {
-        let checks_output = std::process::Command::new("gh")
-            .args([
-                "pr",
-                "checks",
-                &pr.to_string(),
-                "--repo",
-                &repo,
-                "--json",
-                "name,state",
-            ])
-            .output();
-        match checks_output {
-            Ok(o) if o.status.success() => {
-                let checks: Vec<serde_json::Value> = match serde_json::from_slice(&o.stdout) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return json!({
-                            "error": format!("failed to parse CI checks response: {e}"),
-                            "hint": "merge refused (fail-closed)"
-                        });
-                    }
-                };
-                let failing: Vec<_> = checks
-                    .iter()
-                    .filter(|c| {
-                        let st = c["state"].as_str().unwrap_or("");
-                        st != "SUCCESS" && st != "SKIPPED"
-                    })
-                    .collect();
-                if !failing.is_empty() {
-                    let summary: Vec<String> = failing
-                        .iter()
-                        .map(|c| {
-                            format!(
-                                "{}: {}",
-                                c["name"].as_str().unwrap_or("?"),
-                                c["state"].as_str().unwrap_or("?")
-                            )
-                        })
-                        .collect();
-                    return json!({
-                        "error": "CI checks not all passed — merge refused",
-                        "failing_checks": summary,
-                        "hint": "Wait for CI to pass, or use force=true with force_reason for emergency bypass"
-                    });
-                }
-            }
-            _ => {
+        // #PR-D site 2: `gh pr checks` via ScmProvider. argv byte-identical
+        // (`pr checks <pr> --repo R --json name,state`). The client-side
+        // filter (state ≠ SUCCESS/SKIPPED) reproduces the prior inline one;
+        // a null/empty state counts as failing (lenient parse_checks) — same
+        // as the prior `as_str().unwrap_or("")`, preserving the fail-closed
+        // gate. Intentional observable delta: the prior code surfaced two
+        // distinct errors (parse-fail vs query-fail) which pr_checks can't
+        // tell apart — both now collapse to ONE fail-closed message. The
+        // merge DECISION (any checks problem → refuse) is unchanged.
+        let checks = match crate::scm::make_scm_provider(&repo, None).pr_checks(&repo, pr) {
+            Ok(c) => c,
+            Err(_) => {
                 return json!({
-                    "error": "failed to query CI checks — merge refused",
-                    "hint": "Verify PR number and repo, or use force=true with force_reason"
+                    "error": "CI checks could not be determined — merge refused",
+                    "hint": "Verify PR number and repo, or use force=true with force_reason (fail-closed)"
                 });
             }
+        };
+        let failing: Vec<&crate::scm::CheckState> = checks
+            .iter()
+            .filter(|c| c.state != "SUCCESS" && c.state != "SKIPPED")
+            .collect();
+        if !failing.is_empty() {
+            let summary: Vec<String> = failing
+                .iter()
+                .map(|c| {
+                    // Preserve the prior `unwrap_or("?")` placeholder for an
+                    // empty/null name or state.
+                    let name = if c.name.is_empty() {
+                        "?"
+                    } else {
+                        c.name.as_str()
+                    };
+                    let state = if c.state.is_empty() {
+                        "?"
+                    } else {
+                        c.state.as_str()
+                    };
+                    format!("{name}: {state}")
+                })
+                .collect();
+            return json!({
+                "error": "CI checks not all passed — merge refused",
+                "failing_checks": summary,
+                "hint": "Wait for CI to pass, or use force=true with force_reason for emergency bypass"
+            });
         }
     }
 

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2222,13 +2222,15 @@ fn checkout_resolves_repository_path() {
 
 #[test]
 fn merge_view_confirmed_when_merged_with_commit() {
-    let view = json!({
-        "state": "MERGED",
-        "mergeCommit": {"oid": "abc123def"},
-        "mergedAt": "2026-05-29T16:00:00Z",
-        "mergeStateStatus": "CLEAN"
-    });
-    match super::classify_merge_view(&view) {
+    // #PR-D: classify now takes the typed PrSummary (was a raw Value).
+    let summary = crate::scm::PrSummary {
+        state: Some("MERGED".into()),
+        merge_commit_oid: Some("abc123def".into()),
+        merge_state_status: Some("CLEAN".into()),
+        merged_at: Some("2026-05-29T16:00:00Z".into()),
+        ..Default::default()
+    };
+    match super::classify_merge_summary(&summary) {
         super::MergeVerdict::Confirmed(oid) => assert_eq!(oid, "abc123def"),
         super::MergeVerdict::Unconfirmed { state, .. } => {
             panic!("expected Confirmed, got Unconfirmed(state={state})")
@@ -2240,13 +2242,14 @@ fn merge_view_confirmed_when_merged_with_commit() {
 fn merge_view_unconfirmed_when_open_after_merge() {
     // The #1467 bug shape: `gh pr merge` exited 0 but the PR is still OPEN
     // (merge-queue / eventual consistency / branch-protection) — must NOT be
-    // reported as merged.
-    let view = json!({
-        "state": "OPEN",
-        "mergeCommit": null,
-        "mergeStateStatus": "BLOCKED"
-    });
-    match super::classify_merge_view(&view) {
+    // reported as merged. (mergeCommit null → merge_commit_oid None.)
+    let summary = crate::scm::PrSummary {
+        state: Some("OPEN".into()),
+        merge_commit_oid: None,
+        merge_state_status: Some("BLOCKED".into()),
+        ..Default::default()
+    };
+    match super::classify_merge_summary(&summary) {
         super::MergeVerdict::Unconfirmed {
             state,
             merge_state_status,
@@ -2264,9 +2267,14 @@ fn merge_view_unconfirmed_when_open_after_merge() {
 fn merge_view_unconfirmed_when_merged_state_but_no_commit() {
     // Defensive: state says MERGED but no merge commit oid yet (race window) →
     // still unconfirmed; don't claim merged without the commit.
-    let view = json!({"state": "MERGED", "mergeCommit": null, "mergeStateStatus": "UNKNOWN"});
+    let summary = crate::scm::PrSummary {
+        state: Some("MERGED".into()),
+        merge_commit_oid: None,
+        merge_state_status: Some("UNKNOWN".into()),
+        ..Default::default()
+    };
     assert!(matches!(
-        super::classify_merge_view(&view),
+        super::classify_merge_summary(&summary),
         super::MergeVerdict::Unconfirmed { .. }
     ));
 }

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -13,14 +13,16 @@
 //! moved in verbatim (byte-identical argv), which is what makes the
 //! eventual call-site conversion behavior-preserving.
 //!
-//! Wiring is incremental: PR-A added the scaffold; PR-B wired sites 7
-//! (`pr_list`) + 4 (`pr_view`); **PR-C wires sites 8 + 5 (`pr_view`) and 6
-//! (`pr_checks`)**. The remaining write verb (`pr_merge`, site 3) and the
-//! non-GitHub stubs are still unwired in non-test builds, so the
+//! Wiring is incremental: PR-A scaffold; PR-B sites 7 (`pr_list`) + 4
+//! (`pr_view`); PR-C sites 8 + 5 (`pr_view`) + 6 (`pr_checks`); **PR-D
+//! sites 1 (`pr_view`) + 2 (`pr_checks`) + 9 + 10 (`pr_list`, the latter
+//! via the new `cwd` param)**. Only the write verb (`pr_merge`, site 3)
+//! and the non-GitHub stubs remain unwired in non-test builds, so the
 //! module-wide `dead_code` allow stays until PR-Z reaches them.
 #![allow(dead_code)]
 
 use serde_json::Value;
+use std::path::Path;
 use std::process::Command;
 
 // ---------------------------------------------------------------------------
@@ -118,13 +120,18 @@ pub(crate) trait ScmProvider: Send + Sync {
     fn pr_checks(&self, repo: &str, pr: u64) -> anyhow::Result<Vec<CheckState>>;
     /// `gh pr list …` → PRs matching `filter` (sites 7/9/10). `fields`
     /// is the explicit `--json` set (each list site reads a different
-    /// subset), passed verbatim so the emitted argv is byte-identical to
-    /// the site it replaces.
+    /// subset), passed verbatim.
+    ///
+    /// `cwd`: when `Some(dir)`, gh runs in `dir` and `--repo` is OMITTED
+    /// (gh auto-detects the repo from the cwd's remote) — site 10
+    /// (`admin::has_merged_pr`) has only a filesystem path, no slug, and
+    /// relied on this. When `None`, `--repo <repo>` is emitted as usual.
     fn pr_list(
         &self,
         repo: &str,
         filter: &ListFilter,
         fields: &[&str],
+        cwd: Option<&Path>,
     ) -> anyhow::Result<Vec<PrSummary>>;
     /// `gh pr merge …` — the only WRITE (site 3).
     fn pr_merge(&self, repo: &str, pr: u64, opts: &MergeOpts) -> anyhow::Result<MergeOutcome>;
@@ -159,13 +166,24 @@ fn pr_checks_args(repo: &str, pr: u64) -> Vec<String> {
     ]
 }
 
-fn pr_list_args(repo: &str, filter: &ListFilter, fields: &[&str]) -> Vec<String> {
-    // Order: `pr list --repo R --json <fields> [--state] [--head] [--base]
-    // [--limit]`. This reproduces site 7's exact argv (the first list-site
-    // conversion). gh treats flag order as insensitive, so the other list
-    // sites (9/10) stay behavior-identical; their literal-argv match is
-    // pinned when they convert.
-    let mut a = vec!["pr".into(), "list".into(), "--repo".into(), repo.into()];
+fn pr_list_args(
+    repo: &str,
+    filter: &ListFilter,
+    fields: &[&str],
+    cwd: Option<&Path>,
+) -> Vec<String> {
+    // Canonical order: `pr list [--repo R] --json <fields> [--state]
+    // [--head] [--base] [--limit]`. Per decision d-20260601151209762922-0,
+    // byte-identical means the same flags + values (a SET); gh treats flag
+    // ORDER as insensitive, so the list sites whose original order differs
+    // (site 9) stay behavior-identical — their pins assert set-equality.
+    // When `cwd` is Some, `--repo` is omitted (gh auto-detects from the
+    // cwd's remote — site 10's exact pre-conversion argv had no `--repo`).
+    let mut a = vec!["pr".into(), "list".into()];
+    if cwd.is_none() {
+        a.push("--repo".into());
+        a.push(repo.into());
+    }
     a.push("--json".into());
     a.push(fields.join(","));
     if let Some(s) = filter.state {
@@ -273,17 +291,23 @@ fn parse_checks(v: &Value) -> Vec<CheckState> {
 pub(crate) struct GitHubScmProvider;
 
 impl GitHubScmProvider {
-    fn run(args: &[String]) -> anyhow::Result<std::process::Output> {
-        Command::new("gh")
-            .args(args)
-            .output()
+    /// Run `gh` with the given args. `cwd`: when `Some`, set the process
+    /// working directory (site 10 runs gh inside the repo dir so gh
+    /// auto-detects the repo, no `--repo`).
+    fn run(args: &[String], cwd: Option<&Path>) -> anyhow::Result<std::process::Output> {
+        let mut cmd = Command::new("gh");
+        cmd.args(args);
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
+        }
+        cmd.output()
             .map_err(|e| anyhow::anyhow!("failed to run gh: {e}"))
     }
 }
 
 impl ScmProvider for GitHubScmProvider {
     fn pr_view(&self, repo: &str, pr: u64, fields: &[&str]) -> anyhow::Result<PrSummary> {
-        let out = Self::run(&pr_view_args(repo, pr, fields))?;
+        let out = Self::run(&pr_view_args(repo, pr, fields), None)?;
         if !out.status.success() {
             anyhow::bail!(
                 "gh pr view #{pr} ({repo}) exited {}: {}",
@@ -296,7 +320,7 @@ impl ScmProvider for GitHubScmProvider {
     }
 
     fn pr_checks(&self, repo: &str, pr: u64) -> anyhow::Result<Vec<CheckState>> {
-        let out = Self::run(&pr_checks_args(repo, pr))?;
+        let out = Self::run(&pr_checks_args(repo, pr), None)?;
         if !out.status.success() {
             anyhow::bail!(
                 "gh pr checks #{pr} ({repo}) exited {}: {}",
@@ -313,8 +337,9 @@ impl ScmProvider for GitHubScmProvider {
         repo: &str,
         filter: &ListFilter,
         fields: &[&str],
+        cwd: Option<&Path>,
     ) -> anyhow::Result<Vec<PrSummary>> {
-        let out = Self::run(&pr_list_args(repo, filter, fields))?;
+        let out = Self::run(&pr_list_args(repo, filter, fields, cwd), cwd)?;
         if !out.status.success() {
             anyhow::bail!(
                 "gh pr list ({repo}) exited {}: {}",
@@ -329,7 +354,7 @@ impl ScmProvider for GitHubScmProvider {
     }
 
     fn pr_merge(&self, repo: &str, pr: u64, opts: &MergeOpts) -> anyhow::Result<MergeOutcome> {
-        let out = Self::run(&pr_merge_args(repo, pr, opts))?;
+        let out = Self::run(&pr_merge_args(repo, pr, opts), None)?;
         if out.status.success() {
             Ok(MergeOutcome::Submitted)
         } else {
@@ -367,6 +392,7 @@ macro_rules! not_supported_provider {
                 _repo: &str,
                 _filter: &ListFilter,
                 _fields: &[&str],
+                _cwd: Option<&Path>,
             ) -> anyhow::Result<Vec<PrSummary>> {
                 Err(NotSupported($kind).into())
             }
@@ -489,7 +515,8 @@ mod tests {
                     "isDraft",
                     "state",
                     "mergedAt"
-                ]
+                ],
+                None,
             ),
             vec![
                 "pr",
@@ -516,7 +543,7 @@ mod tests {
             base: Some("main".into()),
             limit: None,
         };
-        let a = pr_list_args("o/r", &f, &["headRefOid"]);
+        let a = pr_list_args("o/r", &f, &["headRefOid"], None);
         assert_eq!(
             a,
             vec![
@@ -535,6 +562,84 @@ mod tests {
             ]
         );
         assert!(!a.contains(&"--limit".to_string()));
+    }
+
+    #[test]
+    fn pr_list_args_site9_set_equality_with_original() {
+        // #PR-D site 9 (branch_sweep): the prior inline argv was
+        //   pr list --state merged --head B --base BASE --repo R --json headRefOid
+        // Our canonical builder emits the SAME flags+values in a different
+        // ORDER (gh order-insensitive). Per decision d-20260601151209762922-0
+        // byte-identical = set-equality (flags+values), not exact sequence —
+        // so assert the multiset of tokens matches.
+        let f = ListFilter {
+            state: Some("merged"),
+            head: Some("feat/dedup".into()),
+            base: Some("main".into()),
+            limit: None,
+        };
+        let mut produced = pr_list_args("suzuke/agend-terminal", &f, &["headRefOid"], None);
+        let mut original: Vec<String> = [
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--head",
+            "feat/dedup",
+            "--base",
+            "main",
+            "--repo",
+            "suzuke/agend-terminal",
+            "--json",
+            "headRefOid",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        produced.sort();
+        original.sort();
+        assert_eq!(
+            produced, original,
+            "site-9 argv must be set-equal to the original (flags+values), order aside"
+        );
+    }
+
+    #[test]
+    fn pr_list_args_cwd_some_omits_repo() {
+        // #PR-D site 10 (admin::has_merged_pr): ran gh in the repo dir with
+        // NO --repo (gh auto-detects). cwd=Some ⟹ `--repo` is omitted; the
+        // argv is byte-identical (set) to the prior `pr list --head B
+        // --state merged --json number --limit 1`.
+        let f = ListFilter {
+            state: Some("merged"),
+            head: Some("feat/x".into()),
+            base: None,
+            limit: Some(1),
+        };
+        let a = pr_list_args(
+            "ignored-when-cwd",
+            &f,
+            &["number"],
+            Some(Path::new("/repo")),
+        );
+        assert!(
+            !a.contains(&"--repo".to_string()),
+            "cwd=Some must omit --repo (gh auto-detects from the cwd)"
+        );
+        let mut produced = a;
+        let mut original: Vec<String> = [
+            "pr", "list", "--head", "feat/x", "--state", "merged", "--json", "number", "--limit",
+            "1",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        produced.sort();
+        original.sort();
+        assert_eq!(
+            produced, original,
+            "site-10 argv set-equal to original (no --repo)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Fourth step of the ScmProvider migration (after PR-A #1606, PR-B #1607, PR-C #1610). Converts the **last 4 read sites**; the write `gh pr merge` (site 3) stays for **PR-Z**. Per-site verdict + delta below; per decision d-20260601151209762922-0, *byte-identical = same flags+values*; flag-ORDER canonicalization is OK (gh order-insensitive).

## site 1 — `ci/mod.rs` `verify_merge_landed` (BYTE-IDENTICAL)
`pr_view(repo, pr, [state,mergeCommit,mergedAt,mergeStateStatus])` — argv literal-identical. `classify_merge_view(&Value)` → `classify_merge_summary(&PrSummary)` (the 3 reads map 1:1 → verdict unchanged); its 3 pure tests migrated to `PrSummary`. Retry loop stays in the caller (not folded into the trait).

## site 2 — `ci/mod.rs` merge checks gate (BYTE-IDENTICAL argv; 1 intentional observable delta)
`pr_checks(repo, pr)` — argv literal-identical. Client-side filter (`state ≠ SUCCESS/SKIPPED`) reproduces the prior inline filter; a null/empty state counts as failing (lenient `parse_checks` from PR-C), **preserving the fail-closed gate**. The `"?"` placeholder for empty name/state is preserved.
- **DELTA (intentional, observable):** the prior code surfaced two distinct errors — `"failed to parse CI checks response"` vs `"failed to query CI checks — merge refused"` — which `pr_checks` can't tell apart → **collapsed to one** fail-closed message (`"CI checks could not be determined — merge refused"`). The merge **decision** (any checks problem → refuse) is unchanged. (Lead-ruled acceptable.)

## site 9 — `branch_sweep.rs` `is_squash_merged_diff` (flag-order carve-out)
`pr_list(gh_repo, {merged,head,base}, [headRefOid], None)` — argv **set-equal** to the prior (flag ORDER canonicalized; gh order-insensitive — one shared builder can't be literal-identical to both site-7's and site-9's original orders). Any failure → `false` (unchanged). Pin asserts set-equality. (NB: site 9's gh call uses `--repo`, not `current_dir` — the surrounding `git` commands use cwd.)

## site 10 — `admin/mod.rs` `has_merged_pr` (cwd param; BYTE-IDENTICAL)
This site has only a `&Path` (no owner/repo slug) and ran gh **in-cwd with NO `--repo`** (gh auto-detects). Added **`cwd: Option<&Path>`** to `ScmProvider::pr_list` — when `Some`, `--repo` is omitted and gh runs in that dir. `pr_list("", {merged,head,limit:1}, [number], Some(repo))` — argv set-equal to the prior (no `--repo`).

## scm/mod.rs
`pr_list` gains `cwd: Option<&Path>` (`run()` sets `current_dir`, omits `--repo` when cwd set). The site-7 caller (`gh_poll`) updated to pass `None` (byte-identical). Pins updated: site-7 exact (cwd=None), site-9 set-equality, site-10 cwd-omits-repo. The `dead_code` allow stays — only `pr_merge` (site 3) + the non-GitHub stubs remain unwired → PR-Z.

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -- -D warnings` ✅
- `cargo test --features tray --bin agend-terminal` → 3072 passed, 0 failed ✅
- `cargo xwin check --target x86_64-pc-windows-msvc --features tray` ✅

Reviewer focus: **codex** — byte-identical argv for sites 1/2 (literal) + 9/10 (set-equality, flag-order/`--repo`-omission intentional); site-2 error-message collapse is the one intentional observable delta. **reviewer-2** — no behavior regression in merge gate / pr_state / branch_sweep / admin; site-2 fail-closed unchanged (null-state still blocks).

After this: **PR-Z** (site 3, the only write `gh pr merge`) closes the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)