### PR TITLE
fix(#1608b): close the tasks/<id>.json filesystem-probe class (until_success runtime gate)

### DIFF
--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -217,37 +217,39 @@ enum TaskGate {
     Done,
     /// Task exists but isn't done → fire the reminder.
     Pending,
-    /// No task file (deleted/never-existed) → disable the schedule.
+    /// Task absent from the event log (link removed / board reset) → disable.
     Missing,
-    /// File present but unreadable / malformed status → fail-open (fire).
+    /// Replay error (transient log hiccup) → fail-open (fire), never disable.
     ReadError,
 }
 
-/// #1521: read a linked task's current status the same lock-free, fail-open way
-/// the dispatch-idle watchdog does (`tasks/{id}.json` direct read; the board
-/// writes per-task files). Current-status gate (not ever-done), so a reopened
-/// task resumes reminders. `NotFound` is `Missing` (a removed/typo'd link);
-/// any other I/O or parse error is `ReadError` → fail-open so a transient
-/// hiccup never silently drops the reminder.
+/// #1521: read a linked task's current status. Current-status gate (not
+/// ever-done), so a reopened task resumes reminders.
+///
+/// #1608b/#1614: read the EVENT-SOURCED board via `task_events::replay`, NOT a
+/// `tasks/{id}.json` file — that per-task file is never written (the board lives
+/// in `task_events.jsonl`), so the old probe always returned `NotFound` →
+/// `Missing` → `set_enabled(false)`, permanently self-disabling every
+/// `UntilSuccess` schedule on its first fire. (#1608 fixed only the create/update
+/// validator; this is the matching runtime fix.)
+///
+/// A replay ERROR is `ReadError` → fail-open (fire) so a transient log hiccup
+/// never silently drops — OR destructively disables — the reminder. A task
+/// genuinely ABSENT from the (append-only) log is `Missing` (a removed/reset
+/// link); since the task was validated at create-time, this is rare.
 fn linked_task_gate(home: &Path, task_id: Option<&str>) -> TaskGate {
     let Some(id) = task_id.filter(|s| !s.is_empty()) else {
         // UntilSuccess is validated to have a task at create/update, so a
         // None here means the link was lost — treat as Missing (disable).
         return TaskGate::Missing;
     };
-    let path = home.join("tasks").join(format!("{id}.json"));
-    let content = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return TaskGate::Missing,
-        Err(_) => return TaskGate::ReadError,
-    };
-    match serde_json::from_str::<serde_json::Value>(&content) {
-        Ok(v) => match v.get("status").and_then(|s| s.as_str()) {
-            Some("done") => TaskGate::Done,
-            Some(_) => TaskGate::Pending,
-            None => TaskGate::ReadError,
-        },
+    match crate::task_events::replay(home) {
         Err(_) => TaskGate::ReadError,
+        Ok(state) => match state.tasks.get(&crate::task_events::TaskId(id.to_string())) {
+            None => TaskGate::Missing,
+            Some(rec) if rec.status == crate::task_events::TaskStatus::Done => TaskGate::Done,
+            Some(_) => TaskGate::Pending,
+        },
     }
 }
 
@@ -569,14 +571,59 @@ mod tests {
 
     // ── #1521: UntilSuccess fire-strategy ──
 
+    /// #1608b: seed a REAL event-sourced task (so `task_events::replay` — the
+    /// path `linked_task_gate` now reads — sees it), NOT a `tasks/<id>.json`
+    /// file the board never writes. The old file-seed is exactly why the runtime
+    /// gate's filesystem-probe bug stayed green in tests (#1614). Mirrors
+    /// `schedules.rs::seed_real_task`.
     fn seed_task(home: &std::path::Path, id: &str, status: &str) {
-        let dir = home.join("tasks");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join(format!("{id}.json")),
-            serde_json::json!({"id": id, "status": status}).to_string(),
+        use crate::task_events::{append, DoneSource, InstanceName, TaskEvent, TaskId};
+        let emitter = InstanceName::from("test:operator");
+        let tid = TaskId(id.into());
+        append(
+            home,
+            &emitter,
+            TaskEvent::Created {
+                task_id: tid.clone(),
+                title: "t".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
         )
-        .unwrap();
+        .expect("seed Created");
+        let by = InstanceName::from("test:worker");
+        match status {
+            "done" => {
+                append(
+                    home,
+                    &emitter,
+                    TaskEvent::Done {
+                        task_id: tid,
+                        by,
+                        source: DoneSource::OperatorManual {
+                            authored_at: chrono::Utc::now().to_rfc3339(),
+                            result: None,
+                        },
+                    },
+                )
+                .expect("seed Done");
+            }
+            "in_progress" => {
+                append(home, &emitter, TaskEvent::InProgress { task_id: tid, by })
+                    .expect("seed InProgress");
+            }
+            // "open" / others → the Created event already leaves it Open.
+            _ => {}
+        }
     }
 
     /// Seed an enabled `* * * * *` (always-due) cron schedule targeting a known
@@ -702,21 +749,36 @@ mod tests {
         let home = cron_tmp_home("gate");
         seed_task(&home, "d", "done");
         seed_task(&home, "p", "open");
-        std::fs::write(home.join("tasks").join("bad.json"), "{not json").unwrap();
         assert!(matches!(linked_task_gate(&home, Some("d")), TaskGate::Done));
         assert!(matches!(
             linked_task_gate(&home, Some("p")),
             TaskGate::Pending
         ));
+        // #1608b: a task ABSENT from the event log → Missing (was "no file").
         assert!(matches!(
             linked_task_gate(&home, Some("nope")),
             TaskGate::Missing
         ));
+        assert!(matches!(linked_task_gate(&home, None), TaskGate::Missing));
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1608b: a replay ERROR (corrupt event log) → ReadError → fail-open
+    /// (fire), never the destructive `Missing` → `set_enabled(false)`.
+    #[test]
+    fn linked_task_gate_replay_error_fails_open() {
+        let home = cron_tmp_home("gate-err");
+        std::fs::create_dir_all(&home).unwrap();
+        // An unknown event variant makes `task_events::replay` fail-closed (Err).
+        std::fs::write(
+            home.join("task_events.jsonl"),
+            "{\"schema_version\":1,\"seq\":1,\"timestamp\":\"2026-04-27T00:00:00Z\",\"instance\":\"test\",\"event\":{\"kind\":\"TotallyMadeUp\",\"task_id\":\"t-x\"}}\n",
+        )
+        .unwrap();
         assert!(matches!(
-            linked_task_gate(&home, Some("bad")),
+            linked_task_gate(&home, Some("t-x")),
             TaskGate::ReadError
         ));
-        assert!(matches!(linked_task_gate(&home, None), TaskGate::Missing));
         std::fs::remove_dir_all(home).ok();
     }
 }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -231,15 +231,14 @@ fn task_still_live(home: &Path, task_id: &str) -> Option<bool> {
     if task_id.is_empty() {
         return None;
     }
-    let path = home.join("tasks").join(format!("{task_id}.json"));
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return None;
-    };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return None;
-    };
-    let status = value.get("status").and_then(|v| v.as_str())?;
-    Some(LIVE_TASK_STATUSES.contains(&status))
+    // #1608b/#1614: event-sourced lookup, NOT a `tasks/{id}.json` probe — that
+    // file is never written, so the old read always failed → this check was dead
+    // (always `None`) and the #1018 "skip the nudge for a closed task" branch was
+    // unreachable. `load_by_id` returns `None` on absent OR a transient replay
+    // error → fail-open (treat as live), the existing safe semantics.
+    let task = crate::tasks::load_by_id(home, task_id)?;
+    let status = task.status.to_string();
+    Some(LIVE_TASK_STATUSES.contains(&status.as_str()))
 }
 
 /// #1018 (B) eager cleanup: when a task transitions to a terminal
@@ -1329,19 +1328,47 @@ mod tests {
         )
         .unwrap();
         let task_id = "t-closed-12345";
-        let tasks_dir = home.join("tasks");
-        std::fs::create_dir_all(&tasks_dir).unwrap();
-        std::fs::write(
-            tasks_dir.join(format!("{task_id}.json")),
-            serde_json::to_string_pretty(&serde_json::json!({
-                "id": task_id,
-                "status": "done",
-                "title": "test",
-                "assignee": "fixup-dev-2"
-            }))
-            .unwrap(),
-        )
-        .unwrap();
+        // #1608b: seed a REAL closed task on the event-sourced board (the path
+        // `task_still_live` now reads), not a `tasks/<id>.json` file the board
+        // never writes.
+        {
+            use crate::task_events::{append, DoneSource, InstanceName, TaskEvent, TaskId};
+            let emitter = InstanceName::from("test:operator");
+            let tid = TaskId(task_id.into());
+            append(
+                &home,
+                &emitter,
+                TaskEvent::Created {
+                    task_id: tid.clone(),
+                    title: "test".into(),
+                    description: String::new(),
+                    priority: "normal".into(),
+                    owner: Some(InstanceName::from("fixup-dev-2")),
+                    due_at: None,
+                    depends_on: Vec::new(),
+                    routed_to: None,
+                    branch: None,
+                    bind: None,
+                    eta_secs: None,
+                    tags: vec![],
+                    parent_id: None,
+                },
+            )
+            .unwrap();
+            append(
+                &home,
+                &emitter,
+                TaskEvent::Done {
+                    task_id: tid,
+                    by: InstanceName::from("fixup-dev-2"),
+                    source: DoneSource::OperatorManual {
+                        authored_at: chrono::Utc::now().to_rfc3339(),
+                        result: None,
+                    },
+                },
+            )
+            .unwrap();
+        }
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
         let id = write_pending_at(
             &home,

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1640,17 +1640,32 @@ fn test_list_done_filter_returns_all() {
         &serde_json::json!({"action": "done", "id": id2, "result": "ok"}),
     );
 
-    let _ = crate::store::mutate_versioned(
-        &crate::store::store_path(&home, "tasks.json"),
-        |store: &mut TaskStore| {
-            if let Some(t) = store.tasks.iter_mut().find(|t| t.id == id1) {
-                t.updated_at = (chrono::Utc::now() - chrono::Duration::days(15)).to_rfc3339();
-            }
-            Ok(())
-        },
-    );
+    // #1608b: backdate id1 on the REAL event-sourced path. The `list` handler
+    // reads `updated_at` from `task_events::replay` (the LATEST envelope's
+    // timestamp), NOT `tasks.json` (which no read path consults) — so the old
+    // `mutate_versioned(tasks.json)` backdate had zero effect and this test
+    // could not fail for the regression it guards (#1614 fiction-test class).
+    // Rewrite id1's envelopes in `task_events.jsonl` with a 15-day-old timestamp.
+    {
+        let path = home.join("task_events.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        let old = (chrono::Utc::now() - chrono::Duration::days(15)).to_rfc3339();
+        let rewritten = content
+            .lines()
+            .map(|line| {
+                let mut v: serde_json::Value = serde_json::from_str(line).unwrap();
+                if v["event"]["task_id"] == serde_json::json!(id1) {
+                    v["timestamp"] = serde_json::json!(old);
+                }
+                serde_json::to_string(&v).unwrap()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&path, format!("{rewritten}\n")).unwrap();
+    }
 
-    // Explicit filter_status=done returns ALL done tasks regardless of age
+    // Explicit filter_status=done returns ALL done tasks regardless of age (id1
+    // is now genuinely aged past the 14-day done-TTL on the replay path).
     let listed = handle(
         &home,
         "a",

--- a/tests/no_per_task_json_probe_invariant.rs
+++ b/tests/no_per_task_json_probe_invariant.rs
@@ -1,0 +1,72 @@
+//! #1608b / #1614 regression guard: NO code may probe a per-task
+//! `home/tasks/<id>.json` file for task state.
+//!
+//! The AgEnD task board is **event-sourced** — state lives in
+//! `<home>/task_events.jsonl` and is read only via `task_events::replay`
+//! (`tasks::load_by_id`). No production code ever WRITES a per-task
+//! `tasks/<id>.json` file, so any code that builds + reads that path is reading
+//! a file that never exists — an always-fail probe. This was the root cause of
+//! #1600/#1608/#1614 (`until_success` schedules self-disabling, the dispatch-idle
+//! live-check dying, and two fiction tests that seeded the phantom file). Once
+//! fixed, the whole class must stay closed: this test fails if the
+//! `("tasks").join(format!(...))` probe shape reappears anywhere under `src/`.
+//!
+//! If a legitimate need ever arises (it shouldn't — the board is event-sourced),
+//! add `// allow-tasks-json-probe: <reason>` on the same line to opt out.
+
+use std::path::{Path, PathBuf};
+
+const SRC_DIR: &str = "src";
+/// The forbidden path-build shape: `…join("tasks").join(format!(…))`.
+const FORBIDDEN: &str = "\"tasks\").join(format!";
+const ALLOW_MARKER: &str = "allow-tasks-json-probe";
+
+fn rs_files(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if !root.exists() {
+        return out;
+    }
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(p);
+            }
+        }
+    }
+    walk(root, &mut out);
+    out
+}
+
+#[test]
+fn no_per_task_json_filesystem_probe() {
+    let mut offenders: Vec<String> = Vec::new();
+    for file in rs_files(Path::new(SRC_DIR)) {
+        // Skip this invariant file itself (it names the forbidden literal).
+        if file.file_name().and_then(|n| n.to_str()) == Some("no_per_task_json_probe_invariant.rs")
+        {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        for (i, line) in content.lines().enumerate() {
+            if line.contains(FORBIDDEN) && !line.contains(ALLOW_MARKER) {
+                offenders.push(format!("{}:{}  {}", file.display(), i + 1, line.trim()));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "#1608b/#1614: the task board is event-sourced — read task state via \
+         `tasks::load_by_id` / `task_events::replay`, NEVER a per-task \
+         `home/tasks/<id>.json` file (it is never written, so the probe always \
+         fails). Offending sites:\n{}",
+        offenders.join("\n")
+    );
+}


### PR DESCRIPTION
Closes #1614. The class-closing follow-up to #1608, found by the overnight bug-hunt.

## The bug (P1)
#1608 fixed only the **create/update validator** (`schedules.rs::task_exists` → `tasks::load_by_id`). But the daemon **runtime paths** still probed a per-task `home/tasks/<id>.json` file — which the **event-sourced** board (`task_events.jsonl` via `replay`) **never writes**. So:
- `cron_tick.rs::linked_task_gate` always read `NotFound` → `TaskGate::Missing` → **`set_enabled(false)`** → every `fire_strategy=until_success` schedule **permanently self-disabled on its first fire**. The whole #1521/#1608 feature was dead in production.
- `dispatch_idle.rs::task_still_live` always returned `None` → the #1018 "skip the nudge for a closed task" branch was unreachable → watchdog nudges leaked for already-closed tasks.

Two *fiction tests* hid it: they seeded the phantom `tasks/<id>.json` file the real path never reads.

## Fix (closes the whole class)
- **`linked_task_gate`** → `task_events::replay` directly (not `load_by_id`), so a **transient replay error stays `ReadError` → fail-open (fire)**, never the destructive `Missing → disable`. Absent-from-log → `Missing` (rare; validated at create).
- **`task_still_live`** → `tasks::load_by_id` (fail-open on absent/error preserved — that path is safe).
- **Fiction tests → real seeds**: `cron_tick::seed_task` and the dispatch-idle closed-task seed emit real `Created`/`Done` events (mirror #1608's `seed_real_task`); `test_list_done_filter_returns_all` backdates `id1` by rewriting its **`task_events.jsonl`** envelope timestamp (the real read path), so it now genuinely fails if the done-TTL bypass is removed.
- **Regression guard**: new `tests/no_per_task_json_probe_invariant.rs` fails if the `("tasks").join(format!(…))` per-task-file probe reappears under `src/`.

## Tests
`linked_task_gate_replay_error_fails_open` (fail-open on corrupt log) + the migrated real-event tests. Full `cargo test --bin` (3064) + clippy `--all-targets -D warnings` green.

**`until_success` schedules now actually work in production.**