### PR TITLE
feat(scm): PR-Z — route the merge write (site 3) through ScmProvider; close migration

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -1253,25 +1253,28 @@ pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
         }
     }
 
-    let merge_output = std::process::Command::new("gh")
-        .args([
-            "pr",
-            "merge",
-            &pr.to_string(),
-            "--repo",
-            &repo,
-            "--admin",
-            "--squash",
-            "--delete-branch",
-        ])
-        .output();
-    match merge_output {
+    // #PR-Z site 3: the ONLY write — `gh pr merge` via ScmProvider. argv
+    // byte-identical (`pr merge <pr> --repo R --admin --squash
+    // --delete-branch`, pinned by scm::tests::pr_merge_args_match_existing_gh_call).
+    // MergeOutcome maps the original exit-status branches 1:1: Submitted =
+    // exit-0 (→ verify_merge_landed post-condition, unchanged; retry loop
+    // stays in that caller), Failed = non-zero (→ "gh pr merge failed" +
+    // raw stderr), Err = spawn failure (→ "failed to run gh: {e}").
+    match crate::scm::make_scm_provider(&repo, None).pr_merge(
+        &repo,
+        pr,
+        &crate::scm::MergeOpts {
+            admin: true,
+            squash: true,
+            delete_branch: true,
+        },
+    ) {
         // #1467: `gh pr merge` exit 0 is NECESSARY but not SUFFICIENT — a
         // merge-queue / branch-protection / eventual-consistency situation can
         // exit 0 without the PR actually landing (observed: cross-team PRs
         // reported merged:true while still OPEN, commits unpushed). Verify the
         // post-condition with `gh pr view` before claiming success.
-        Ok(o) if o.status.success() => match verify_merge_landed(&repo, pr) {
+        Ok(crate::scm::MergeOutcome::Submitted) => match verify_merge_landed(&repo, pr) {
             MergeVerdict::Confirmed(merge_commit) => json!({
                 "merged": true,
                 "pr": pr,
@@ -1297,13 +1300,17 @@ pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
                          before acting; do NOT blindly re-merge.",
             }),
         },
-        Ok(o) => {
+        Ok(crate::scm::MergeOutcome::Failed { stderr }) => {
             json!({
                 "error": "gh pr merge failed",
-                "stderr": String::from_utf8_lossy(&o.stderr).to_string(),
+                "stderr": stderr,
             })
         }
-        Err(e) => json!({"error": format!("failed to run gh: {e}")}),
+        // pr_merge's spawn-failure Err already carries "failed to run gh: …"
+        // (set in GitHubScmProvider::run), so surface it as-is — using
+        // `e.to_string()` reproduces the original `format!("failed to run
+        // gh: {e}")` exactly (no double prefix).
+        Err(e) => json!({"error": e.to_string()}),
     }
 }
 

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -13,13 +13,13 @@
 //! moved in verbatim (byte-identical argv), which is what makes the
 //! eventual call-site conversion behavior-preserving.
 //!
-//! Wiring is incremental: PR-A scaffold; PR-B sites 7 (`pr_list`) + 4
-//! (`pr_view`); PR-C sites 8 + 5 (`pr_view`) + 6 (`pr_checks`); **PR-D
-//! sites 1 (`pr_view`) + 2 (`pr_checks`) + 9 + 10 (`pr_list`, the latter
-//! via the new `cwd` param)**. Only the write verb (`pr_merge`, site 3)
-//! and the non-GitHub stubs remain unwired in non-test builds, so the
-//! module-wide `dead_code` allow stays until PR-Z reaches them.
-#![allow(dead_code)]
+//! Migration complete: PR-A scaffold; PR-B sites 7 (`pr_list`) + 4
+//! (`pr_view`); PR-C sites 8 + 5 (`pr_view`) + 6 (`pr_checks`); PR-D
+//! sites 1 (`pr_view`) + 2 (`pr_checks`) + 9 + 10 (`pr_list` + `cwd`);
+//! **PR-Z site 3 (`pr_merge`, the only write)**. All four verbs and the
+//! non-GitHub stubs (constructed by `make_scm_provider` for non-GitHub
+//! remotes) are now reachable, so the module-wide `dead_code` allow is
+//! gone.
 
 use serde_json::Value;
 use std::path::Path;
@@ -84,7 +84,7 @@ pub(crate) struct MergeOpts {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum MergeOutcome {
     Submitted,
-    Failed { code: Option<i32>, stderr: String },
+    Failed { stderr: String },
 }
 
 /// Returned by non-GitHub providers so callers fail LOUD instead of an
@@ -359,8 +359,10 @@ impl ScmProvider for GitHubScmProvider {
             Ok(MergeOutcome::Submitted)
         } else {
             Ok(MergeOutcome::Failed {
-                code: out.status.code(),
-                stderr: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+                // #PR-Z: NOT trimmed — site 3 (the sole caller) put the raw
+                // stderr in its error JSON (`.to_string()`); preserve that
+                // byte-for-byte.
+                stderr: String::from_utf8_lossy(&out.stderr).to_string(),
             })
         }
     }
@@ -644,10 +646,13 @@ mod tests {
 
     #[test]
     fn pr_merge_args_match_existing_gh_call() {
-        // site 3: --admin --squash --delete-branch.
+        // #PR-Z site-3 BYTE-IDENTICAL anchor: handle_merge_repo's only write
+        // emitted EXACTLY `gh pr merge <pr> --repo R --admin --squash
+        // --delete-branch` (verified via git show — flag ORDER is
+        // admin→squash→delete-branch, NOT reordered).
         assert_eq!(
             pr_merge_args(
-                "o/r",
+                "suzuke/agend-terminal",
                 7,
                 &MergeOpts {
                     admin: true,
@@ -660,7 +665,7 @@ mod tests {
                 "merge",
                 "7",
                 "--repo",
-                "o/r",
+                "suzuke/agend-terminal",
                 "--admin",
                 "--squash",
                 "--delete-branch",
@@ -670,6 +675,40 @@ mod tests {
         assert_eq!(
             pr_merge_args("o/r", 7, &MergeOpts::default()),
             vec!["pr", "merge", "7", "--repo", "o/r"]
+        );
+        // Per-flag MergeOpts → argv mapping (each flag independent).
+        assert_eq!(
+            pr_merge_args(
+                "o/r",
+                1,
+                &MergeOpts {
+                    admin: true,
+                    ..Default::default()
+                }
+            ),
+            vec!["pr", "merge", "1", "--repo", "o/r", "--admin"]
+        );
+        assert_eq!(
+            pr_merge_args(
+                "o/r",
+                1,
+                &MergeOpts {
+                    squash: true,
+                    ..Default::default()
+                }
+            ),
+            vec!["pr", "merge", "1", "--repo", "o/r", "--squash"]
+        );
+        assert_eq!(
+            pr_merge_args(
+                "o/r",
+                1,
+                &MergeOpts {
+                    delete_branch: true,
+                    ..Default::default()
+                }
+            ),
+            vec!["pr", "merge", "1", "--repo", "o/r", "--delete-branch"]
         );
     }
 


### PR DESCRIPTION
## What

**Final step** of the ScmProvider migration (PR-A #1606 → PR-B #1607 → PR-C #1610 → PR-D #1613). Converts the **ONLY write** — site 3, `handle_merge_repo`'s `gh pr merge` (`ci/mod.rs`) — to `ScmProvider::pr_merge`, and removes the now-unnecessary module-wide `dead_code` allow. After this, all 10 `gh` PR-op sites go through the trait. 🎉

## site 3 — `ci/mod.rs` `handle_merge_repo` (HIGHEST RISK: the fleet's own auto-merge)

- `pr_merge(repo, pr, MergeOpts{admin, squash, delete_branch: all true})`.
- **argv BYTE-IDENTICAL**: `gh pr merge <pr> --repo R --admin --squash --delete-branch` — flag order **verified against `git show`** (admin→squash→delete-branch, *not* reordered), pinned by `scm::tests::pr_merge_args_match_existing_gh_call`.
- `MergeOutcome` maps the original exit-status branches **1:1**:
  - `Submitted` (exit 0) → `verify_merge_landed` post-condition (unchanged; the #1467 retry loop stays in that caller, **not** folded into the trait),
  - `Failed` (non-zero) → `{"error":"gh pr merge failed","stderr": <raw stderr>}`,
  - `Err` (spawn failure) → `{"error":"failed to run gh: {e}"}`.
- stderr preserved **raw** (untrimmed) to match the prior `.to_string()`; the `Err` arm uses `e.to_string()` (pr_merge's Err already carries the `"failed to run gh:"` prefix — avoids a double prefix). **Merge decision + error contract byte-for-byte unchanged.**

> Why byte-identical matters here (lead's note): the daemon's auto-merge will route through `pr_merge` post-deploy; manual `gh pr merge` (bash) bypasses it, so `pr_merge`'s first real execution is a post-deploy auto-merge and must match the old `gh pr merge` exactly.

## scm/mod.rs

- `pr_merge`'s `MergeOutcome::Failed.stderr` no longer trimmed (site 3 is the sole caller; matches its raw stderr).
- Dropped the unused `MergeOutcome::Failed.code` field (site 3 never read it).
- **Removed `#![allow(dead_code)]`**: all four verbs (`pr_view`/`pr_checks`/`pr_list`/`pr_merge`) are now wired and the non-GitHub stubs are reachable via `make_scm_provider` — `clippy -D warnings` is clean with the allow gone.
- `pr_merge_args` test extended with per-flag `MergeOpts`→argv coverage.

## Migration complete

All 10 `gh` PR-op sites now go through `ScmProvider`. The only remaining direct `gh` calls are the out-of-scope **auth** (`github_token.rs` — `gh auth status/token`) and **CI-log** (`ci_watch/provider.rs` — `gh run view --log-failed`) ones, both flagged out-of-scope in the spike.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -- -D warnings` ✅ (with the `dead_code` allow **removed**)
- `cargo test --features tray --bin agend-terminal` → 3073 passed, 0 failed ✅
- `cargo xwin check --target x86_64-pc-windows-msvc --features tray` ✅

Reviewer focus: **codex** — verify the `gh pr merge` argv is byte-identical (flag order `--admin --squash --delete-branch`, pinned + git-verified). **reviewer-2** — merge decision / error contract unchanged (Submitted→verify, non-zero→`gh pr merge failed`+raw stderr, spawn-fail→`failed to run gh`); the retry/`verify_merge_landed` post-condition is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)