### PR TITLE
fix(bughunt2): propagate swallowed inbox/save errors (3 silent-loss P1s)

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -36,7 +36,16 @@ pub fn fallback_deliver(
     if !in_fleet {
         return json!({"error": format!("target instance '{target}' not found in fleet.yaml (API unavailable: {api_error})")});
     }
-    let _ = crate::inbox::enqueue(home, target, msg);
+    // #bughunt2: this is the last-resort path (the daemon API is already down),
+    // so the inbox is the SOLE channel. A swallowed enqueue here is total,
+    // unrecoverable message loss reported as success — surface it instead.
+    if let Err(e) = crate::inbox::enqueue(home, target, msg) {
+        return json!({
+            "error": format!(
+                "inbox fallback delivery to '{target}' failed — message lost (API unavailable: {api_error}): {e}"
+            )
+        });
+    }
     crate::inbox::notify_agent(home, target, &crate::inbox::NotifySource::Agent(from), text);
     json!({"target": target, "delivery_mode": "inbox_fallback", "note": format!("API unavailable: {api_error}")})
 }
@@ -402,6 +411,35 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    /// #bughunt2: the last-resort delivery path must surface a dropped enqueue
+    /// (the inbox is the SOLE channel when the API is down) instead of reporting
+    /// `inbox_fallback` success for a silently-lost message.
+    #[test]
+    fn fallback_deliver_surfaces_enqueue_failure_not_fake_success() {
+        let home = tmp_home("fallback-enqueue-fail");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  worker:\n    backend: claude\n",
+        )
+        .unwrap();
+        // Force the inbox enqueue to fail: `home/inbox` as a FILE makes
+        // `create_dir_all(home/inbox)` error inside with_inbox_lock.
+        std::fs::write(home.join("inbox"), b"blocker").unwrap();
+        let msg = crate::inbox::InboxMessage::new_system("sender", "update", "body");
+        let api_error = anyhow::anyhow!("daemon API unavailable");
+        let result = fallback_deliver(&home, "sender", "worker", "hi", msg, &api_error);
+        assert!(
+            result.get("error").and_then(|e| e.as_str()).is_some(),
+            "a dropped enqueue must surface as an error, not inbox_fallback success: {result}"
+        );
+        assert_ne!(
+            result.get("delivery_mode").and_then(|d| d.as_str()),
+            Some("inbox_fallback"),
+            "must NOT report success when the message was lost"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     // --- validate_branch (3 from ops.rs + 5 from mcp/handlers.rs) ---

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -296,13 +296,17 @@ fn check_worktree_enforcement(params: &Value, home: &Path, target: &str) -> Resu
 
 // ── Phase 4: Delivery routing ───────────────────────────────────────
 
+/// #bughunt2: returns `Err` when the inbox enqueue fails (disk read-only / I/O)
+/// so `handle_send` can surface a real failure instead of reporting `ok:true`
+/// for a message that was silently dropped — critical for the `inbox_only` /
+/// codex `skip_inject` branches where the inbox is the SOLE delivery channel.
 fn route_and_deliver(
     ctx: &HandlerCtx,
     params: &Value,
     from: &str,
     target: &str,
     msg: crate::inbox::InboxMessage,
-) -> &'static str {
+) -> anyhow::Result<&'static str> {
     let reg = agent::lock_registry(ctx.registry);
     // #1441: registry is UUID-keyed; resolve target name via fleet.yaml.
     let target_id = crate::fleet::resolve_uuid(ctx.home, target);
@@ -338,20 +342,20 @@ fn route_and_deliver(
         && !is_reply_to_drained_blocker;
 
     if !target_in_registry {
-        let _ = crate::inbox::enqueue(ctx.home, target, msg);
-        "inbox_only"
+        crate::inbox::enqueue(ctx.home, target, msg)?;
+        Ok("inbox_only")
     } else if skip_inject {
-        let _ = crate::inbox::enqueue(ctx.home, target, msg);
+        crate::inbox::enqueue(ctx.home, target, msg)?;
         crate::event_log::log(
             ctx.home,
             "ack_absorbed",
             target,
             &format!("from={from} kind={kind}"),
         );
-        "inbox_only"
+        Ok("inbox_only")
     } else {
-        let _ = crate::inbox::enqueue_with_idle_hint(ctx.home, target, msg);
-        "pty"
+        crate::inbox::enqueue_with_idle_hint(ctx.home, target, msg)?;
+        Ok("pty")
     }
 }
 
@@ -536,7 +540,19 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     if let Err(e) = check_worktree_enforcement(params, ctx.home, vs.target) {
         return e;
     }
-    let delivery_mode = route_and_deliver(ctx, params, vs.from, vs.target, msg.clone());
+    // #bughunt2: a failed enqueue (disk read-only / I/O) must surface as a real
+    // failure — never report ok:true for a silently-dropped message. Return
+    // BEFORE the provenance/dispatch side-effects so they don't fire for an
+    // undelivered message.
+    let delivery_mode = match route_and_deliver(ctx, params, vs.from, vs.target, msg.clone()) {
+        Ok(m) => m,
+        Err(e) => {
+            return json!({
+                "ok": false,
+                "error": format!("send failed: message not delivered to '{}': {e}", vs.target)
+            });
+        }
+    };
     inject_provenance(params, vs.from, vs.target);
     let branch_checked_out = checkout_branch_if_requested(params, ctx.home, vs.target);
     process_verdicts(ctx.home, vs.from, &msg);
@@ -597,6 +613,38 @@ mod tests {
         assert!(
             result["error"].as_str().unwrap_or("").contains("not found"),
             "must return not-found error for nonexistent target: {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #bughunt2: a dropped inbox enqueue (disk-low / I/O) must surface as
+    /// `ok:false`, never the silent `ok:true` for a lost message.
+    #[test]
+    fn send_surfaces_enqueue_failure_not_fake_ok() {
+        let home = tmp_home("send-enqueue-fail");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  offline-agent:\n    backend: claude\n",
+        )
+        .ok();
+        // Force the inbox enqueue to fail: `home/inbox` as a FILE makes
+        // `create_dir_all(home/inbox)` error inside with_inbox_lock.
+        std::fs::write(home.join("inbox"), b"blocker").unwrap();
+        let ctx = test_ctx(&home);
+        let result = handle_send(
+            &json!({"from": "sender", "target": "offline-agent", "text": "hi"}),
+            &ctx,
+        );
+        assert_eq!(
+            result["ok"], false,
+            "a dropped enqueue must NOT report ok:true: {result}"
+        );
+        assert!(
+            result["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("not delivered"),
+            "must surface the delivery failure: {result}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -1578,6 +1578,41 @@ instances: {}
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// #bughunt2 (codex review): teardown's record-cleanup save-failure branch
+    /// must surface a stale-record error, not report `torn_down`. Unix-only: the
+    /// failure is injected by making `home` read-only AFTER deploy (the
+    /// `deployments.lock` already exists so the flock still opens, `load` still
+    /// reads the record, but the `atomic_write` tmp create in the read-only dir
+    /// fails the save).
+    #[cfg(unix)]
+    #[test]
+    fn teardown_surfaces_record_save_failure_not_fake_torn_down() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = deploy_single_instance_for_test("teardown-save-fail", "tpl");
+        assert!(
+            load(&home).deployments.iter().any(|d| d.name == "tpl"),
+            "pre: deployment must exist for the teardown to find"
+        );
+        let ro = std::fs::Permissions::from_mode(0o555);
+        std::fs::set_permissions(&home, ro).unwrap();
+
+        let result = teardown(&home, &serde_json::json!({"name": "tpl"}));
+
+        // Restore write perms so cleanup (and any later test) works.
+        std::fs::set_permissions(&home, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            result.get("error").and_then(|e| e.as_str()).is_some(),
+            "a failed record-cleanup save must surface an error, not torn_down: {result}"
+        );
+        assert_ne!(
+            result.get("status").and_then(|s| s.as_str()),
+            Some("torn_down"),
+            "must NOT report torn_down when the record cleanup was not persisted"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     #[test]
     fn close_last_instance_prunes_deployment_entry() {
         // Production smoke for the Issue #474 fix: deploy → simulate the

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -413,7 +413,21 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
     };
     let mut store = load(home);
     store.deployments.push(deployment);
-    let _ = save(home, &mut store);
+    // #bughunt2: a deploy whose record never persisted is NOT "deployed" — the
+    // instances are live in fleet.yaml but `teardown <name>` can't find them and
+    // a daemon restart resurrects them untracked. Surface the failure (with the
+    // spawned instances) so the operator can reconcile, instead of reporting
+    // success.
+    if let Err(e) = save(home, &mut store) {
+        return serde_json::json!({
+            "error": format!(
+                "deployment '{}' spawned {} instance(s) but failed to persist the deployment record: {e} — teardown-by-name will not work until reconciled",
+                params.deploy_name, created.len()
+            ),
+            "name": params.deploy_name,
+            "instances": created,
+        });
+    }
 
     let _ = instance_name;
     serde_json::json!({"status": "deployed", "name": params.deploy_name, "instances": created})
@@ -464,7 +478,19 @@ pub fn teardown(home: &Path, args: &Value) -> Value {
 
     // Remove from store
     store.deployments.retain(|d| d.name != name);
-    let _ = save(home, &mut store);
+    // #bughunt2: if the record-removal save fails, the instances are already
+    // gone from fleet.yaml but the stale record lingers on disk — `list` and a
+    // re-`teardown` will still show it. Surface it rather than reporting a clean
+    // torn_down.
+    if let Err(e) = save(home, &mut store) {
+        return serde_json::json!({
+            "error": format!(
+                "deployment '{name}' instances were removed but failed to persist the record cleanup: {e} — the stale record remains; retry teardown"
+            ),
+            "name": name,
+            "instances": deployment.instances,
+        });
+    }
 
     serde_json::json!({"status": "torn_down", "name": name, "instances": deployment.instances})
 }
@@ -1512,6 +1538,44 @@ instances: {}
             }),
         );
         home
+    }
+
+    /// #bughunt2: a deploy whose `deployments.json` save fails must surface an
+    /// error (instances are live but untracked), NOT report `status:deployed`.
+    #[test]
+    fn deploy_surfaces_record_save_failure_not_fake_deployed() {
+        let home = tmp_home("deploy-save-fail");
+        let yaml = r#"
+templates:
+  tpl:
+    instances:
+      worker:
+        backend: claude
+instances: {}
+"#;
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+        // Force the record save to fail: a DIRECTORY at the target path makes
+        // atomic_write's final rename unable to replace it.
+        std::fs::create_dir_all(home.join("deployments.json")).unwrap();
+        let result = deploy(
+            &home,
+            "caller",
+            &serde_json::json!({
+                "template": "tpl",
+                "name": "tpl",
+                "directory": home.display().to_string(),
+            }),
+        );
+        assert!(
+            result.get("error").and_then(|e| e.as_str()).is_some(),
+            "a failed record save must surface as an error, not status:deployed: {result}"
+        );
+        assert_ne!(
+            result.get("status").and_then(|s| s.as_str()),
+            Some("deployed"),
+            "must NOT report deployed when the record was not persisted"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]


### PR DESCRIPTION
The 3 silent-loss P1s from the overnight bug-hunt #2 (`/tmp/bughunt-overnight-2.md`). Same theme: the caller is told **success** while a `let _ =` swallowed a **state-bearing** write Result → message/record silently lost.

## Fixes
- **`api/handlers/messaging.rs::handle_send`** — `route_and_deliver` swallowed `inbox::enqueue` and `handle_send` always returned `{ok:true}`. On a disk-low/I/O enqueue failure the message is dropped — total loss for the `inbox_only` / codex `skip_inject` branches where the inbox is the **sole** channel. `route_and_deliver` now returns `Result`; `handle_send` returns `{ok:false, error}` **before** the provenance/dispatch side-effects.
- **`agent_ops.rs::fallback_deliver`** — the last-resort path (daemon API down → inbox is the only channel) swallowed the enqueue and reported `inbox_fallback` success. Now returns an error JSON on enqueue failure.
- **`deployments.rs::deploy` / `teardown`** — `let _ = save(...)` dropped the `deployments.json` persist error and reported `status:deployed` / `torn_down`. A failed deploy-record save leaves instances live in fleet.yaml but **un-tear-down-able** (and resurrected on restart); both now surface the error with the affected instances so the operator can reconcile.

## Scope
**Only** critical delivery/persistence Results. Cosmetic log/notify swallows (tracing, best-effort notify) are left as-is, per the bug-hunt class definition.

## Tests
Each fix pinned: a forced enqueue failure (`home/inbox` as a file → `create_dir_all` errors) / a forced `deployments.json` save failure (target path as a directory → `atomic_write` rename fails) makes the caller surface an error instead of a fake success; existing success-path tests unchanged. Full `cargo test --bin` (3070) + clippy `--all-targets -D warnings` green.