### PR TITLE
fix(bughunt2): reap handoff_timeout last_escalated entries (unbounded leak)

### DIFF
--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -40,6 +40,13 @@ pub(crate) fn scan_and_emit(
     let Ok(fleet) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) else {
         return;
     };
+    // #1598-mirror: collect every (target, correlation) key still backed by a
+    // pending unread handoff this tick, so the trailing `retain` can reap
+    // `last_escalated` entries whose repo@branch handoff is no longer active
+    // (read/resolved). Without it the map grows one entry per timed-out
+    // (reviewer, branch) forever — a slow leak, since `.get`/`.insert` were the
+    // only ops and REALERT_AFTER_MINS suppresses but never evicts.
+    let mut active: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
     for target in fleet.instances.keys() {
         for (correlation, sent_at) in crate::inbox::unread_of_kind(home, target, HANDOFF_KIND) {
             let age_min = now.signed_duration_since(sent_at).num_minutes();
@@ -48,6 +55,7 @@ pub(crate) fn scan_and_emit(
             }
             let corr = correlation.unwrap_or_else(|| "<unknown>".to_string());
             let key = (target.clone(), corr.clone());
+            active.insert(key.clone());
             if let Some(prev) = last_escalated.get(&key) {
                 if now.signed_duration_since(*prev).num_minutes() < REALERT_AFTER_MINS {
                     continue;
@@ -86,6 +94,10 @@ pub(crate) fn scan_and_emit(
             last_escalated.insert(key, *now);
         }
     }
+    // Reap dedup entries for handoffs that are no longer pending (read/resolved
+    // → absent from this tick's unread scan), bounding the map to the set of
+    // currently-active handoffs.
+    last_escalated.retain(|k, _| active.contains(k));
 }
 
 #[cfg(test)]
@@ -195,6 +207,32 @@ mod tests {
         assert!(
             crate::inbox::drain(&home, "lead").is_empty(),
             "re-escalation within the dedup window must be suppressed"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn stale_entry_reaped_when_handoff_no_longer_pending() {
+        let home = tmp_home("reap");
+        write_fleet(&home);
+        // Old unread handoff → first scan escalates and records a dedup entry.
+        seed_handoff(&home, "reviewer", "o/r@gone", 15, false);
+        let now = chrono::Utc::now();
+        let mut last = HashMap::new();
+        scan_and_emit(&home, &now, &mut last);
+        assert!(
+            last.contains_key(&("reviewer".to_string(), "o/r@gone".to_string())),
+            "first scan must record a dedup entry for the escalated handoff"
+        );
+        // Reviewer reads/resolves it → the handoff leaves the unread scan. The
+        // next scan must reap the now-stale (reviewer, o/r@gone) entry rather
+        // than accumulating one per dead branch forever (the leak).
+        crate::inbox::drain(&home, "reviewer");
+        scan_and_emit(&home, &(now + chrono::Duration::minutes(1)), &mut last);
+        assert!(
+            last.is_empty(),
+            "a dedup entry whose handoff is no longer pending must be reaped, not leaked: {:?}",
+            last.keys().collect::<Vec<_>>()
         );
         std::fs::remove_dir_all(home).ok();
     }


### PR DESCRIPTION
## What

`src/daemon/handoff_timeout_watchdog.rs` — `scan_and_emit`'s `last_escalated`
map (`HashMap<(String,String), DateTime>`, keyed by `(target, "repo@branch")`)
was **unbounded**: only `.get` (@51) and `.insert` (@86), no remove/retain/TTL.
`REALERT_AFTER_MINS=30` suppresses re-notify but never evicts → one entry per
timed-out `(reviewer, branch)` accumulates forever → slow memory leak on the
lifetime-long handler (`per_tick/handoff_timeout.rs:14`).

Found in autonomous bug-hunt #2 (P1).

## Fix (KISS, mirrors #1598)

Mirror #1598's `retry_tracks.retain`: collect the `(target, correlation)` keys
still backed by a **pending unread handoff this tick** into an `active` set,
then at the end of `scan_and_emit`:

```rust
last_escalated.retain(|k, _| active.contains(k));
```

This bounds the map to currently-active handoffs and reaps entries whose
handoff has been read/resolved (absent from the unread scan) — immediate,
exact eviction rather than a TTL lag.

## Test

`stale_entry_reaped_when_handoff_no_longer_pending`: old unread handoff →
first scan records a dedup entry; reviewer reads/resolves it → next scan reaps
the now-stale `(reviewer, repo@branch)` entry. Existing
`dedup_suppresses_reescalation_within_window` covers the inverse (active entry
retained to keep suppressing).

## Verification
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --bin agend-terminal` — 3073 passed, 0 failed
- diff-stat vs fresh origin/main: 1 file, +38

🤖 Generated with [Claude Code](https://claude.com/claude-code)