### PR TITLE
fix(bughunt3): inbox recover_half_writes drops only the corrupt line, not the whole queue

### DIFF
--- a/src/inbox/disk.rs
+++ b/src/inbox/disk.rs
@@ -70,25 +70,65 @@ pub fn recover_half_writes(home: &Path) {
             continue;
         }
 
-        // Check JSONL files for corrupt trailing lines
+        // A corrupt line in a live JSONL inbox (e.g. a truncated trailing line
+        // from a crash mid-append — `enqueue` appends in place, not via
+        // tmp+rename) must NOT cost the agent its entire queue. Every read path
+        // (drain/sweep/unread_count/…) already skips an unparseable line, so the
+        // fail-open fix is to rewrite the file keeping only the good lines and
+        // preserve the dropped line(s) under inbox.recovery/ for forensics —
+        // never silently destroy a valid message. Done under the per-file flock
+        // (the same lock `enqueue` takes for this physical file) so a concurrent
+        // early-boot send cannot race the rewrite.
         if name_str.ends_with(".jsonl") {
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                let lines: Vec<&str> = content.lines().collect();
-                let bad: Vec<&&str> = lines
-                    .iter()
-                    .filter(|l| {
-                        !l.trim().is_empty()
-                            && serde_json::from_str::<super::InboxMessage>(l).is_err()
-                    })
-                    .collect();
-                if !bad.is_empty() {
-                    // Move entire file to recovery, agent gets a fresh start
-                    ensure_recovery_dir(&recovery_dir);
-                    let dest = recovery_dir.join(&name);
-                    if std::fs::rename(&path, &dest).is_ok() {
-                        recovered += 1;
-                    }
+            use std::io::Write;
+            let lock_path = path.with_extension("jsonl.lock");
+            let Ok(_lock) = crate::store::acquire_file_lock(&lock_path) else {
+                continue;
+            };
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let mut kept: Vec<&str> = Vec::new();
+            let mut bad: Vec<&str> = Vec::new();
+            for l in content.lines() {
+                if l.trim().is_empty() || serde_json::from_str::<super::InboxMessage>(l).is_ok() {
+                    kept.push(l);
+                } else {
+                    bad.push(l);
                 }
+            }
+            if bad.is_empty() {
+                continue;
+            }
+            // Forensics: append only the corrupt line(s) to recovery.
+            ensure_recovery_dir(&recovery_dir);
+            if let Ok(mut rf) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(recovery_dir.join(&name))
+            {
+                for l in &bad {
+                    let _ = writeln!(rf, "{l}");
+                }
+            }
+            // Rewrite the inbox with only the good lines via tmp + atomic rename
+            // (mirrors drain/sweep write-back) so every valid message survives.
+            let tmp = path.with_extension("jsonl.tmp");
+            let rewrite = (|| -> std::io::Result<()> {
+                let mut f = std::fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(&tmp)?;
+                for l in &kept {
+                    writeln!(f, "{l}")?;
+                }
+                f.sync_all()?;
+                std::fs::rename(&tmp, &path)?;
+                Ok(())
+            })();
+            if rewrite.is_ok() {
+                recovered += 1;
             }
         }
     }

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -615,33 +615,85 @@ fn test_atomic_append_tmp_recovery() {
 }
 
 #[test]
-fn test_half_written_jsonl_goes_to_recovery() {
-    // A JSONL file with a corrupt line must be moved to recovery.
-    let home = tmp_home("half-write");
+fn test_half_written_jsonl_preserves_good_messages() {
+    // bughunt#3 (fail-open): a trailing corrupt line must NOT cost the agent
+    // its whole queue. The good messages survive (still drainable) and only
+    // the corrupt line is moved to recovery for forensics.
+    let home = tmp_home("half-write-failopen");
     let inbox_dir = home.join("inbox");
     fs::create_dir_all(&inbox_dir).ok();
 
     let jsonl = inbox_dir.join("agent1.jsonl");
-    let good = serde_json::to_string(&make_msg("ok", "fine")).unwrap();
-    // Write a good line followed by a truncated/corrupt line
+    let good1 = serde_json::to_string(&make_msg("a", "first")).unwrap();
+    let good2 = serde_json::to_string(&make_msg("b", "second")).unwrap();
+    // Two good lines followed by a truncated/corrupt line (crash mid-append).
     fs::write(
         &jsonl,
-        format!("{good}\n{{\"from\":\"broken\",\"text\":\"trun"),
+        format!("{good1}\n{good2}\n{{\"from\":\"broken\",\"text\":\"trun"),
     )
     .ok();
 
     recover_half_writes(&home);
 
-    assert!(!jsonl.exists(), "corrupt JSONL must be moved to recovery");
+    // The inbox survives and BOTH good messages are still drainable (zero loss).
+    assert!(jsonl.exists(), "inbox must survive a corrupt trailing line");
+    let msgs = drain(&home, "agent1");
+    assert_eq!(msgs.len(), 2, "both good messages must survive (zero loss)");
+    assert_eq!(msgs[0].from, "a");
+    assert_eq!(msgs[1].from, "b");
+
+    // The corrupt line — and only it — is preserved under inbox.recovery/.
     let recovery = home.join("inbox.recovery");
-    assert!(recovery.exists());
-    // The recovery subdir should contain the moved file
+    assert!(recovery.exists(), "recovery dir must hold the dropped line");
     let subdirs: Vec<_> = fs::read_dir(&recovery).unwrap().flatten().collect();
     assert_eq!(subdirs.len(), 1);
     let files: Vec<_> = fs::read_dir(subdirs[0].path()).unwrap().flatten().collect();
     assert_eq!(files.len(), 1);
     assert!(files[0].file_name().to_string_lossy().contains("agent1"));
+    let salvaged = fs::read_to_string(files[0].path()).unwrap();
+    assert!(
+        salvaged.contains("broken") && !salvaged.contains("first"),
+        "only the corrupt line is salvaged, never a good message"
+    );
 
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_recover_noop_when_all_lines_good() {
+    // No corrupt line → no rewrite, no recovery dir, every message intact.
+    let home = tmp_home("recover-noop-good");
+    let inbox_dir = home.join("inbox");
+    fs::create_dir_all(&inbox_dir).ok();
+    let jsonl = inbox_dir.join("agent1.jsonl");
+    let good = serde_json::to_string(&make_msg("ok", "fine")).unwrap();
+    fs::write(&jsonl, format!("{good}\n")).ok();
+
+    recover_half_writes(&home);
+
+    assert!(jsonl.exists());
+    assert!(
+        !home.join("inbox.recovery").exists(),
+        "no recovery dir for a clean inbox"
+    );
+    let msgs = drain(&home, "agent1");
+    assert_eq!(msgs.len(), 1);
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_recover_noop_on_empty_file() {
+    // Empty inbox file → no corrupt lines → no-op, no recovery dir.
+    let home = tmp_home("recover-noop-empty");
+    let inbox_dir = home.join("inbox");
+    fs::create_dir_all(&inbox_dir).ok();
+    let jsonl = inbox_dir.join("agent1.jsonl");
+    fs::write(&jsonl, "").ok();
+
+    recover_half_writes(&home);
+
+    assert!(jsonl.exists(), "empty inbox must be left untouched");
+    assert!(!home.join("inbox.recovery").exists());
     fs::remove_dir_all(&home).ok();
 }
 


### PR DESCRIPTION
## Bug (bughunt#3, P1 — fail-closed + silent-loss class)

`recover_half_writes` (`src/inbox/disk.rs`) moved an **entire** `<agent>.jsonl` to `inbox.recovery/` whenever **any** line failed to parse.

- `enqueue` (`storage.rs:77-85`) is a **plain in-place append** (`sync_all`, **not** tmp+rename), so a crash / `SIGKILL` (daemon restart) / OOM / power-loss mid-append leaves a **truncated trailing line** in a live inbox.
- `recover_half_writes` runs **unconditionally on every boot** (`daemon/mod.rs:653`). On the next boot it sees that one bad line and **nukes the whole inbox**.
- `inbox.recovery/` has **no reader anywhere** (grep-confirmed — forensic only) → **zero auto-restore** → silent loss of every queued task/query/report for that agent until an operator manually restores. For codex `skip_inject` agents the inbox is the **sole** delivery channel.

It was **strictly more destructive than a no-op**: every runtime read path (`drain:242`, `sweep_expired`, `unread_count`, `describe_message`, `get_thread`, `find_message`) already skips an unparseable line fail-open. Doing nothing → the next `drain` delivers all good messages and skips the corrupt line.

## Fix (fail-open, mirrors `drain`/`sweep` write-back)

Under the **per-file flock** (the same lock `enqueue` takes for this physical file, so a concurrent early-boot send can't race), rewrite the inbox keeping only parseable + empty lines via **tmp + atomic rename**, and append **only the dropped corrupt line(s)** to `inbox.recovery/` for forensics. Never drop a valid message.

- The `.tmp` branch is unchanged — a stale `.tmp` from an interrupted atomic rewrite is genuinely partial and the real `.jsonl` survived the (atomic) rename, so moving it aside stays correct.
- Forward-schema lines **parse** as `InboxMessage` (version > CURRENT) so they are **not** in `bad`; `drain` already drops them per-message. `recover` only touches truly-unparseable lines.

## Tests

- `test_half_written_jsonl_preserves_good_messages` — 2 good lines + trailing corrupt line → **both messages still drainable (zero loss)**, only the corrupt line salvaged to recovery.
- `test_recover_noop_when_all_lines_good` / `test_recover_noop_on_empty_file` — clean inbox and empty file are no-ops (no recovery dir).

Preflight green: `cargo fmt`, `cargo clippy --all-targets --features tray -D warnings`, `cargo test --bin agend-terminal inbox::tests::` (114 passed).

No `Closes` — neutral bughunt3 finding (like #1620/#1621).

🤖 Generated with [Claude Code](https://claude.com/claude-code)