### PR TITLE
fix(bughunt3): never hold the registry lock across blocking IO in tui_bridge + poll_reminder (#1617 siblings)

### DIFF
--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -33,14 +33,22 @@ pub fn remove_agent(name: &str) {
 /// Pure collector: returns (agent_name, reminder_string) for each agent
 /// that should be nudged. No side effects — does not inject into PTY.
 pub fn collect_poll_reminders(home: &Path, registry: &AgentRegistry) -> Vec<(String, String)> {
+    // #1617-class (mirror conflict_notify's phase-1-collect / phase-2-IO): snapshot
+    // the idle-agent names UNDER the registry lock, then DROP the guard before any
+    // inbox file IO. `inbox::unread_count` does `fs::read_to_string` + full-file
+    // parse; holding the GLOBAL registry lock across that (per agent, in a loop)
+    // stalls every other registry user when the inbox is large or the FS is slow.
+    let idle_names: Vec<String> = {
+        let reg = agent::lock_registry(registry);
+        reg.values()
+            .filter(|handle| handle.core.lock().state.current == AgentState::Idle)
+            .map(|handle| handle.name.to_string())
+            .collect()
+    };
+
+    // Phase 2: the inbox reads + dedup + formatting run lock-free.
     let mut result = Vec::new();
-    let reg = agent::lock_registry(registry);
-    for handle in reg.values() {
-        let name = handle.name.as_str();
-        let agent_state = handle.core.lock().state.current;
-        if agent_state != AgentState::Idle {
-            continue;
-        }
+    for name in &idle_names {
         let (count, oldest) = crate::inbox::unread_count(home, name);
         if count == 0 {
             continue;
@@ -85,6 +93,63 @@ mod tests {
     use parking_lot::Mutex;
     use portable_pty::native_pty_system;
     use std::sync::Arc;
+
+    /// #1617-class invariant: `collect_poll_reminders` must NEVER hold the
+    /// global registry lock across the blocking `inbox::unread_count` file read.
+    /// Holding the registry across per-agent inbox reads stalls every other
+    /// registry user (same class #1593/#1617 closed elsewhere; conflict_notify
+    /// already does the phase-1-collect / phase-2-IO split this mirrors).
+    ///
+    /// Structural source-scan (mirrors #1593 F2): brace-match the idle-name
+    /// snapshot block and assert (a) `unread_count` is NOT inside it (not under
+    /// the lock) and (b) `unread_count` IS called after the block closes (the
+    /// IO runs lock-free). Needles are `concat`-built and the scan is sliced to
+    /// the production region so this test can't self-satisfy.
+    #[test]
+    fn poll_reminder_unread_read_not_held_across_registry_lock() {
+        let src = include_str!("poll_reminder.rs");
+        let cfg_test = ["#[cfg(", "test)]"].concat();
+        let prod = match src.find(&cfg_test) {
+            Some(i) => &src[..i],
+            None => src,
+        };
+
+        // Fix marker: idle agent names are snapshotted into a Vec under the lock.
+        let bind_needle = ["let idle_names: Vec<String>", " = {"].concat();
+        let bstart = prod
+            .find(&bind_needle)
+            .expect("idle-name snapshot binding present (fix marker)");
+
+        let open_rel = prod[bstart..].find('{').expect("binding block opens");
+        let block_start = bstart + open_rel;
+        let mut depth = 0usize;
+        let mut block_end = block_start;
+        for (i, c) in prod[block_start..].char_indices() {
+            match c {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        block_end = block_start + i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(block_end > block_start, "binding block must close");
+
+        let io_needle = ["unread", "_count"].concat();
+        let locked_region = &prod[block_start..=block_end];
+        assert!(
+            !locked_region.contains(&io_needle),
+            "collect_poll_reminders must NOT call inbox::unread_count under the registry lock (#1617 class)"
+        );
+        assert!(
+            prod[block_end..].contains(&io_needle),
+            "inbox::unread_count must run AFTER the registry lock is dropped"
+        );
+    }
 
     fn tmp_home(tag: &str) -> std::path::PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};

--- a/src/daemon/tui_bridge.rs
+++ b/src/daemon/tui_bridge.rs
@@ -107,7 +107,15 @@ pub(crate) fn serve_tui_accept_loop(name: &str, meta: TuiListenerMeta, registry:
             continue;
         }
 
-        let (rx, pty_writer, pty_master, core) = {
+        // #1617-class (mirror #1593 F1 snapshot→drop→IO): capture the rx +
+        // initial dump + the Arcs UNDER the registry lock, then DROP the guard
+        // before writing the dump to the client. `write_frame` is a blocking
+        // socket write — a slow/non-draining TUI client would otherwise pin the
+        // GLOBAL registry lock indefinitely (exactly the hung-peer stall #1617
+        // closed for the PTY path), wedging the whole daemon. `dump` is an owned
+        // Vec, so it survives the drop; intervening PTY output buffers in `rx`
+        // and is sent by the tui_out thread after this initial frame.
+        let (rx, dump, pty_writer, pty_master, core) = {
             let reg = agent::lock_registry(registry);
             // #1441: registry is UUID-keyed; this TUI-bridge server only knows
             // the display name, so locate the live handle by name.
@@ -116,16 +124,18 @@ pub(crate) fn serve_tui_accept_loop(name: &str, meta: TuiListenerMeta, registry:
                 None => continue,
             };
             let (rx, dump) = agent::subscribe_with_dump(agent);
-            if framing::write_frame(&mut stream, &dump).is_err() {
-                continue;
-            }
             (
                 rx,
+                dump,
                 Arc::clone(&agent.pty_writer),
                 Arc::clone(&agent.pty_master),
                 Arc::clone(&agent.core),
             )
         };
+        // Registry lock released — the blocking initial-dump write runs lock-free.
+        if framing::write_frame(&mut stream, &dump).is_err() {
+            continue;
+        }
 
         let mut write_stream = match stream.try_clone() {
             Ok(s) => s,
@@ -190,5 +200,70 @@ pub(crate) fn serve_tui_accept_loop(name: &str, meta: TuiListenerMeta, registry:
         {
             tracing::warn!(agent = %n_err, error = %e, "failed to spawn TUI input thread");
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    /// #1617-class invariant: `serve_tui_accept_loop` must NEVER hold the
+    /// global registry lock across the blocking initial-dump `write_frame`.
+    /// A non-draining TUI client would otherwise pin the registry forever and
+    /// wedge the whole daemon (same hung-peer stall #1617 closed for the PTY).
+    ///
+    /// Structural source-scan (mirrors #1593 F2 /
+    /// `recovery_loop_never_holds_registry_across_blocking_io`): brace-match the
+    /// dump-capture binding block and assert (a) `write_frame` is NOT inside it
+    /// (i.e. not under the lock) and (b) a `write_frame` call DOES exist after
+    /// the block closes (the dump is written lock-free). Needles are `concat`-
+    /// built and the scan is sliced to the production region (before the
+    /// `#[cfg(test)]` mod) so this test's own source can't self-satisfy it.
+    #[test]
+    fn tui_dump_write_not_held_across_registry_lock() {
+        let src = include_str!("tui_bridge.rs");
+        let cfg_test = ["#[cfg(", "test)]"].concat();
+        let prod = match src.find(&cfg_test) {
+            Some(i) => &src[..i],
+            None => src,
+        };
+
+        // The fix marker: the lock block now captures `dump` into the outer
+        // binding (was a 4-tuple without `dump` pre-fix), proving the dump is
+        // moved out of the lock scope before it is written.
+        let bind_needle = ["let (rx, dump, pty_writer", ", pty_master, core) = {"].concat();
+        let bstart = prod
+            .find(&bind_needle)
+            .expect("dump-capture binding present (fix marker)");
+
+        // Brace-match from the binding's opening `{` to find the locked region.
+        let open_rel = prod[bstart..].find('{').expect("binding block opens");
+        let block_start = bstart + open_rel;
+        let mut depth = 0usize;
+        let mut block_end = block_start;
+        for (i, c) in prod[block_start..].char_indices() {
+            match c {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        block_end = block_start + i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(block_end > block_start, "binding block must close");
+
+        let write_needle = ["write", "_frame"].concat();
+        let locked_region = &prod[block_start..=block_end];
+        assert!(
+            !locked_region.contains(&write_needle),
+            "tui_bridge must NOT write_frame while the registry lock is held (#1617 deadlock class)"
+        );
+        assert!(
+            prod[block_end..].contains(&write_needle),
+            "the initial dump must be written via write_frame AFTER the registry lock is dropped"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two **P1 lock-while-blocking siblings of #1617 / #1593-F1**, found in the bug-hunt#3 concurrency sweep. Both held the **global agent registry lock** across a **blocking operation**, so a slow peer / slow FS would pin the registry and stall the whole daemon — the exact contract #1617 closed for the recovery path. Both fixes mirror the proven **snapshot → drop → IO-outside-lock** pattern.

### F1 — `tui_bridge.rs:110` (whole-daemon stall on a non-draining TUI client)
`serve_tui_accept_loop` captured the initial PTY dump **and** wrote it to the client socket (`write_frame`) while the registry guard was still held. `write_frame` is a *blocking* socket write — a non-draining/slow TUI client blocks it indefinitely (the hung-peer stall #1617 fixed for the PTY) → the global registry is pinned → supervisor / hang_detection / watchdog / monitor / dispatch all block.

**Fix:** capture `rx` + the owned `dump` Vec + the Arcs under the lock, **drop** the guard, then `write_frame` the dump lock-free. Intervening PTY output buffers in `rx` and is sent by the `tui_out` thread after the initial frame, so ordering is preserved.

### F2 — `poll_reminder.rs:35` (registry pinned across per-agent inbox file reads)
`collect_poll_reminders` held the registry lock across the entire `reg.values()` loop, calling `inbox::unread_count` (→ `fs::read_to_string` + full-file parse) per idle agent inside it. Inbox JSONL grows over daemon uptime; serializing N full-file reads under the global lock every pass stalls every other registry user (and the whole daemon on a slow FS).

**Fix:** phase-1 collect the idle-agent names under the lock and drop it; phase-2 run the inbox reads + dedup + formatting lock-free — exactly the discipline `conflict_notify.rs:88` already uses.

## Tests
Per-site structural source-scan invariants mirroring #1617's `recovery_loop_never_holds_registry_across_blocking_io`: brace-match the under-lock snapshot block and assert the blocking call (`write_frame` / `unread_count`) is **not** inside it and **is** present after the lock drops. Needles are concat-built and the scan is prod-sliced so the tests can't self-satisfy.

## Preflight
- `cargo fmt`
- `cargo clippy --all-targets --features tray -- -D warnings` ✅
- `cargo test --bin agend-terminal --features tray` → **3086 passed, 0 failed** ✅

No `Closes` (neutral bughunt3). F3 (P2, pr_state flock reorder) ships separately as PR-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)