### PR TITLE
fix(#1626): disable codex startup update modal at spawn layer

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -388,7 +388,16 @@ impl Backend {
             },
             Backend::Codex => BackendPreset {
                 command: "codex",
+                // #1626: `-c check_for_update_on_startup=false` disables codex's
+                // blocking startup update modal ("Update available!"). This is a
+                // per-invocation config override on the child argv — it does NOT
+                // write `~/.codex/config.toml`, so it stays fleet-scoped and never
+                // touches the operator's global codex config. Must precede the
+                // `resume` subcommand (`-c` is a global option). Primary fix; the
+                // #1069 dismiss below stays as a fallback (see its comment).
                 args: &[
+                    "-c",
+                    "check_for_update_on_startup=false",
                     "resume",
                     "--last",
                     "--dangerously-bypass-approvals-and-sandbox",
@@ -420,13 +429,26 @@ impl Backend {
                     },
                     // #1069: version-update modal blocks agent until operator
                     // selects an option. "2\r" = "Skip" (least invasive).
+                    // #1626 FALLBACK: the `-c check_for_update_on_startup=false`
+                    // flag above normally suppresses this modal entirely, so this
+                    // dismiss never fires in the happy path. Kept as belt-and-
+                    // suspenders: codex silently no-ops unknown `-c` keys, so if
+                    // upstream ever renames the key the flag dormant-fails and this
+                    // dismiss degrades the failure from "blocking hang" to a racy
+                    // (but non-blocking) auto-skip.
                     DismissPattern {
                         label: r"(?m)^[^A-Za-z\n]*Update available!",
                         sequence: b"2\r",
                     },
                 ],
-                // Codex: "resume --last" → fresh start drops the resume subcommand
-                fresh_args: Some(&["--dangerously-bypass-approvals-and-sandbox"]),
+                // Codex: "resume --last" → fresh start drops the resume subcommand.
+                // #1626: keep the `-c check_for_update_on_startup=false` override
+                // in fresh mode too (no subcommand here, so order is unconstrained).
+                fresh_args: Some(&[
+                    "-c",
+                    "check_for_update_on_startup=false",
+                    "--dangerously-bypass-approvals-and-sandbox",
+                ]),
                 fleet_mcp_supported: true,
             },
             Backend::OpenCode => BackendPreset {
@@ -1621,6 +1643,34 @@ mod tests {
             re.is_match(&centered),
             "#1087: centered modal with 45-space prefix must match"
         );
+    }
+
+    /// #1626: the `-c check_for_update_on_startup=false` override must be present
+    /// in BOTH spawn modes and, in Resume mode, must come BEFORE the `resume`
+    /// subcommand — `-c` is a global option, so codex's clap rejects it if it
+    /// trails the subcommand. Pins both the presence and the ordering so a future
+    /// preset edit can't silently drop the flag or move it past `resume`.
+    #[test]
+    fn codex_disables_startup_update_check_before_resume() {
+        for mode in [SpawnMode::Resume, SpawnMode::Fresh] {
+            let argv = Backend::Codex.preset_spawn_args(mode);
+            let c_idx = argv
+                .iter()
+                .position(|a| a == "-c")
+                .unwrap_or_else(|| panic!("#1626: codex {mode:?} argv must contain `-c`"));
+            assert_eq!(
+                argv[c_idx + 1],
+                "check_for_update_on_startup=false",
+                "#1626: `-c` must be followed by the update-check override in {mode:?} mode"
+            );
+            if let Some(resume_idx) = argv.iter().position(|a| a == "resume") {
+                assert!(
+                    c_idx < resume_idx,
+                    "#1626: `-c check_for_update_on_startup=false` must precede the \
+                     `resume` subcommand (global option), got argv={argv:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem
When the daemon spawns a codex backend and a codex update is available, codex renders a **blocking** startup modal:

```
✨ Update available! 0.135.0 → 0.136.0
  1. Update   2. Skip   3. Skip until next version
```

It disrupts codex startup. Worse, our own #1069 auto-dismiss (`DismissPattern "Update available!" → b"2\r"`) **races the live TUI** — when the modal isn't actually focused (timing skew on restart, or the 0.135 3-option layout), the stray `2` leaks into the running codex agent's composer (the "stray '2' got misread" symptom).

## RCA
The modal fires when `check_for_update_on_startup` (top-level codex config bool, default `true`) is set **and** `latest_version > dismissed_version` (`~/.codex/version.json`: latest `0.136.0`, dismissed `0.131.0`). The stray `2` is **our own dismiss**, not a codex bug — the dismiss approach is inherently race-prone and TUI-layout-coupled.

## Fix (spawn layer, zero global writes)
Prepend **`-c check_for_update_on_startup=false`** to the Codex preset `args` (before the `resume` subcommand — `-c` is a global clap option) and `fresh_args` (`src/backend.rs`). `-c key=value` is codex's per-invocation config override: it applies on the child argv and **does NOT write `~/.codex/config.toml`**, so the suppression stays fleet-scoped and never touches the operator's global codex config (operator directive: no global writes). With the modal suppressed entirely, the dismiss never fires → the stray-`2` race cannot occur.

### Evidence codex honors the flag (read-back via `doctor`, no writes — throwaway `CODEX_HOME`)
| invocation | `doctor` → "startup update check" |
|---|---|
| `codex -c check_for_update_on_startup=false doctor` | **false** |
| `codex doctor` (control) | **true** |

argv-order also confirmed (clap accepts `-c` before the subcommand): `codex -c … resume --help` and fresh-mode both parse (exit 0).

## ⚠ Caveat (why we KEEP the #1069 dismiss as a fallback)
codex **silently no-ops unknown `-c` keys** (a bogus key is ignored by `doctor`; `--strict-config` only validates the config *file*, not `-c` overrides). So if codex upstream ever **renames** `check_for_update_on_startup`, the flag **dormant-fails** and the modal returns. The #1069 `b"2\r"` dismiss is therefore retained as belt-and-suspenders: it never fires while the flag works (no stray-`2` in the happy path), and degrades the upstream-rename failure from a *blocking hang* to a *racy-but-non-blocking* auto-skip.

## Tests
- New `codex_disables_startup_update_check_before_resume`: pins the override is present in **both** spawn modes and **precedes** the `resume` subcommand.
- Existing #1069 codex dismiss tests retained (fallback kept).
- Preflight: `cargo fmt`, `cargo clippy --all-targets --features tray -- -D warnings` clean, 34 backend tests pass.

Closes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)