### PR TITLE
fix(#1625): restart_instance returns the new pane to its original tab

### DIFF
--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -833,6 +833,39 @@ mod tests {
         assert!(layout.tabs[0].root().has_agent("reviewer"));
     }
 
+    /// #1625: fresh restart of an agent sharing a multi-pane team tab returns
+    /// the respawned pane to that same tab (the repro: fixup-dev was
+    /// fresh-restarted and fell out of the shared "fixup" tab). restart_instance
+    /// now emits LayoutHint::SameTab, which drives the same delete-records-tab →
+    /// SameTab-replacement path as #1431.
+    #[test]
+    fn restart_returns_pane_to_shared_team_tab() {
+        use crate::layout::SplitDir;
+        let mut layout = Layout::new();
+        let mut tab = Tab::new("fixup".into(), leaf(1, "fixup-dev"));
+        tab.split_focused(SplitDir::Horizontal, leaf(2, "fixup-reviewer"));
+        layout.add_tab(tab);
+
+        // restart kills the old pane (DELETE → InstanceDeleted) ...
+        handle_instance_deleted("fixup-dev", &mut layout);
+        assert_eq!(
+            layout.tabs.len(),
+            1,
+            "shared tab survives one pane's delete"
+        );
+        let tab_name = layout
+            .take_removed_tab("fixup-dev")
+            .expect("delete records the agent's tab");
+        assert_eq!(tab_name, "fixup");
+
+        // ... then the SameTab respawn splits back into the shared tab.
+        place_in_remembered_tab(&mut layout, &tab_name, leaf(3, "fixup-dev"));
+        assert_eq!(layout.tabs.len(), 1, "no new tab — pane stays in 'fixup'");
+        assert_eq!(layout.tabs[0].name, "fixup");
+        assert!(layout.tabs[0].root().has_agent("fixup-dev"));
+        assert!(layout.tabs[0].root().has_agent("fixup-reviewer"));
+    }
+
     /// #1431: SameTab never produces a split anchor — placement is resolved via
     /// the remembered-tab map, not resolve_split_anchor (even when a
     /// target_pane / spawner is present).

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -343,6 +343,33 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
     json!({"name": name, "reason": reason, "spawned": spawned})
 }
 
+/// #1625: assemble the SPAWN params for a restart. Mirrors replace_instance by
+/// tagging `layout: same-tab` so the respawned pane returns to the tab the
+/// killed pane occupied (recorded on its DELETE) instead of opening a fresh
+/// tab. `mode` only toggles backend resume args — placement is identical for
+/// resume and fresh restarts — so the hint is applied unconditionally.
+fn restart_spawn_params(
+    name: &str,
+    backend_command: &str,
+    args: &[String],
+    working_directory: Option<&Path>,
+    env: &std::collections::HashMap<String, String>,
+    mode: &str,
+) -> Value {
+    let mut spawn_params = json!({
+        "name": name,
+        "backend": backend_command,
+        "args": args.join(" "),
+        "working_directory": working_directory.map(|p| p.display().to_string()),
+        "env": serde_json::to_value(env).unwrap_or(serde_json::Value::Null),
+        "layout": "same-tab",
+    });
+    if mode == "resume" {
+        spawn_params["mode"] = json!("resume");
+    }
+    spawn_params
+}
+
 pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
     let name = match args["instance"].as_str() {
         Some(n) => n,
@@ -367,16 +394,14 @@ pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
         &json!({"method": crate::api::method::DELETE, "params": {"name": name, "no_wait": true}}),
     );
 
-    let mut spawn_params = json!({
-        "name": name,
-        "backend": resolved.backend_command,
-        "args": resolved.args.join(" "),
-        "working_directory": resolved.working_directory.map(|p| p.display().to_string()),
-        "env": serde_json::to_value(&resolved.env).unwrap_or(serde_json::Value::Null),
-    });
-    if mode == "resume" {
-        spawn_params["mode"] = json!("resume");
-    }
+    let spawn_params = restart_spawn_params(
+        name,
+        &resolved.backend_command,
+        &resolved.args,
+        resolved.working_directory.as_deref(),
+        &resolved.env,
+        mode,
+    );
 
     let spawn_result = crate::api::call(
         home,
@@ -630,3 +655,29 @@ pub(super) fn resolve_team_layout(
 // #964: spawn_single_instance + spawn_single_instance_impl live in
 // sibling file `instance_spawn.rs` to keep this file under the 750-LOC
 // file_size_invariant.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    // #1625: every restart, regardless of mode, must carry the same-tab layout
+    // hint so the respawned pane returns to its original tab (the fresh path
+    // previously omitted it and fell out into a new tab).
+    #[test]
+    fn restart_spawn_params_carries_same_tab_fresh() {
+        let env = HashMap::new();
+        let p = restart_spawn_params("dev", "claude", &[], None, &env, "fresh");
+        assert_eq!(p["layout"], "same-tab");
+        // fresh must NOT request a resume.
+        assert!(p.get("mode").is_none());
+    }
+
+    #[test]
+    fn restart_spawn_params_carries_same_tab_resume() {
+        let env = HashMap::new();
+        let p = restart_spawn_params("dev", "claude", &[], None, &env, "resume");
+        assert_eq!(p["layout"], "same-tab");
+        assert_eq!(p["mode"], "resume");
+    }
+}


### PR DESCRIPTION
## Problem
`restart_instance` respawned the killed pane **without** the `layout: same-tab` hint that `replace_instance` carries (#1431). The SPAWN therefore defaulted to `LayoutHint::Tab` and the new pane opened in a **fresh tab**, dropping the agent out of its team tab.

Repro: `fixup-dev` / `fixup-dev-2` were fresh-restarted and fell out of the shared `fixup` tab.

## Root cause
- `handle_replace_instance` (`instance.rs:328`) sends `"layout": "same-tab"` → TUI consumes the per-agent `removed_tab_memory` (recorded on the pane's DELETE) and returns the pane to its original tab.
- `handle_restart_instance` omitted that param → `LayoutHint::parse(... .unwrap_or("tab"))` → `Tab` → `add_tab` (new tab).

`mode` only toggles backend resume args (`resume_mode.args_for()`), **not** placement — so this affected **both** resume and fresh restarts, not just fresh.

## Fix (surgical)
Extract a pure `restart_spawn_params` helper that unconditionally tags `layout: same-tab`, mirroring the proven #1431 path. No new wiring — the removed-tab memory is already recorded on the preceding DELETE for every removal path.

## Tests
- **Unit** (`mcp/handlers/instance.rs`): `restart_spawn_params` carries `layout=same-tab` for both fresh and resume (and resume still sets `mode=resume`).
- **Integration** (`app/tui_events.rs`): a fresh restart of an agent sharing a multi-pane team tab returns its pane to that tab (mirrors the #1431 SameTab test).

## Preflight
- `cargo fmt --check` clean
- `cargo clippy --all-targets --features tray -D warnings` clean
- `cargo test --tests --features tray` green (61 test-result groups ok; the one `agend-git` conflict test that fails locally is an artifact of the fleet `git` shim — passes with real git).

## Note on the original framing
The dispatch hypothesized "resume preserves placement". Per the code, resume-restart would **also** lose the tab — the apparent preservation is a different path (daemon-restart team auto-grouping rebuilds tabs; layout isn't persisted). The fix treats both modes regardless.

Closes #1625

🤖 Generated with [Claude Code](https://claude.com/claude-code)