### PR TITLE
fix(#1629 PR2): narrow deployments flock to the store load-modify-save (#1617 class)

### DIFF
--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -369,12 +369,6 @@ fn create_deployment_team(
 }
 
 pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
-    let lock_path = store_path(home).with_extension("lock");
-    let _lock = match crate::store::acquire_file_lock(&lock_path) {
-        Ok(l) => l,
-        Err(e) => return serde_json::json!({"error": format!("deployment lock failed: {e}")}),
-    };
-
     let params = match validate_deploy_args(home, args) {
         Ok(p) => p,
         Err(e) => return e,
@@ -411,6 +405,17 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
         directory: params.directory,
         created_at: chrono::Utc::now().to_rfc3339(),
     };
+    // #1629: narrow the deployment-store flock to JUST the load-modify-save (its
+    // C1 lost-update purpose). spawn_instances (api::call SPAWN) and
+    // create_deployment_team (api::call CREATE_TEAM) above now run lock-free — a
+    // self-IPC (loopback api::call) held under this flock is the #1617
+    // lock-while-blocking deadlock class. validate_deploy_args reads only
+    // fleet.yaml, not the store, so it needs no lock either.
+    let lock_path = store_path(home).with_extension("lock");
+    let _lock = match crate::store::acquire_file_lock(&lock_path) {
+        Ok(l) => l,
+        Err(e) => return serde_json::json!({"error": format!("deployment lock failed: {e}")}),
+    };
     let mut store = load(home);
     store.deployments.push(deployment);
     // #bughunt2: a deploy whose record never persisted is NOT "deployed" — the
@@ -434,19 +439,16 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
 }
 
 pub fn teardown(home: &Path, args: &Value) -> Value {
-    // C1 fix: flock around load-modify-save to prevent lost-update race.
-    let lock_path = store_path(home).with_extension("lock");
-    let _lock = match crate::store::acquire_file_lock(&lock_path) {
-        Ok(l) => l,
-        Err(e) => return serde_json::json!({"error": format!("deployment lock failed: {e}")}),
-    };
     let name = match args["name"].as_str() {
         Some(n) => n,
         None => return serde_json::json!({"error": "missing 'name'"}),
     };
 
-    let mut store = load(home);
-    let deployment = match store.deployments.iter().find(|d| d.name == name) {
+    let lock_path = store_path(home).with_extension("lock");
+    // #1629: read the deployment record lock-free (load reads atomically-written
+    // files, so no flock is needed) so the DELETE api::calls below run OUTSIDE any
+    // flock — a self-IPC under the deployment flock is the #1617 deadlock class.
+    let deployment = match load(home).deployments.iter().find(|d| d.name == name) {
         Some(d) => d.clone(),
         None => return serde_json::json!({"error": format!("deployment '{name}' not found")}),
     };
@@ -476,6 +478,13 @@ pub fn teardown(home: &Path, args: &Value) -> Value {
         let _ = crate::teams::delete(home, &serde_json::json!({"name": team}));
     }
 
+    // #1629 (C1 lost-update): flock ONLY the store record-removal load-modify-save.
+    // Re-load under the flock so a concurrent deploy/teardown isn't lost-updated.
+    let _lock = match crate::store::acquire_file_lock(&lock_path) {
+        Ok(l) => l,
+        Err(e) => return serde_json::json!({"error": format!("deployment lock failed: {e}")}),
+    };
+    let mut store = load(home);
     // Remove from store
     store.deployments.retain(|d| d.name != name);
     // #bughunt2: if the record-removal save fails, the instances are already
@@ -2439,5 +2448,67 @@ templates:
             "template source_repo must propagate to team"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // #1629 invariant (#1617 lock-while-blocking class): the deployment-store
+    // flock must be acquired AFTER the loopback `api::call`s (SPAWN/CREATE_TEAM
+    // in deploy, DELETE in teardown), never around them — a self-IPC held under
+    // that flock deadlocks (the loopback handler needs the registry lock). These
+    // structural source-scans slice each fn and assert the api::call site index
+    // precedes the `acquire_file_lock` index. Prod-sliced + `concat` needles so
+    // they can't self-satisfy.
+    fn prod_src() -> &'static str {
+        let src = include_str!("deployments.rs");
+        let cfg_test = ["#[cfg(", "test)]"].concat();
+        match src.find(&cfg_test) {
+            Some(i) => &src[..i],
+            None => src,
+        }
+    }
+
+    fn fn_body<'a>(prod: &'a str, sig: &str) -> &'a str {
+        let start = prod.find(sig).expect("fn present");
+        let rest = &prod[start + sig.len()..];
+        let end = rest.find("\npub fn ").unwrap_or(rest.len());
+        &prod[start..start + sig.len() + end]
+    }
+
+    #[test]
+    fn deploy_api_calls_not_under_flock() {
+        let prod = prod_src();
+        let body = fn_body(prod, "pub fn deploy(home");
+        let lock_at = body
+            .find(&["acquire_file", "_lock"].concat())
+            .expect("deploy locks the store save");
+        let spawn_at = body
+            .find("spawn_instances(")
+            .expect("deploy spawns instances");
+        let team_at = body
+            .find("create_deployment_team(")
+            .expect("deploy creates the team");
+        assert!(
+            spawn_at < lock_at,
+            "spawn_instances (api::call SPAWN) must run BEFORE the deployment flock (#1617 class)"
+        );
+        assert!(
+            team_at < lock_at,
+            "create_deployment_team (api::call CREATE_TEAM) must run BEFORE the deployment flock (#1617 class)"
+        );
+    }
+
+    #[test]
+    fn teardown_api_calls_not_under_flock() {
+        let prod = prod_src();
+        let body = fn_body(prod, "pub fn teardown(home");
+        let lock_at = body
+            .find(&["acquire_file", "_lock"].concat())
+            .expect("teardown locks the record removal");
+        let delete_at = body
+            .find(&["crate::api::", "call"].concat())
+            .expect("teardown DELETEs instances via api::call");
+        assert!(
+            delete_at < lock_at,
+            "the DELETE api::call loop must run BEFORE the record-removal flock (#1617 class)"
+        );
     }
 }


### PR DESCRIPTION
## PR2 of 3 — flock-deadlock-guard series (#1629)

`deploy()` and `teardown()` held the deployment-store flock (`store::acquire_file_lock`) across loopback `api::call` self-IPC — the same lock-while-blocking class as #1617 (the loopback handler needs the registry lock, so a self-IPC under this flock can stall any thread contending it).

### Premise-check (git-verified @ ec0c8ac)
- `deploy:373` flock spans `spawn_instances` (api::call **SPAWN** :312) + `create_deployment_team` (api::call **CREATE_TEAM** :360).
- `teardown:439` flock spans the per-instance `api::call` **DELETE** loop (:456).
- `validate_deploy_args` reads only fleet.yaml, **not** the store → the flock's sole job is the C1 lost-update protection on the load-modify-save.

### Fix (narrow the flock to just the store load-modify-save)
- **deploy:** drop the function-wide lock; acquire only around the final `load → push → save`. validate / SPAWN / CREATE_TEAM now run lock-free.
- **teardown:** read the record lock-free (`load` reads atomically-written files), run DELETE + dir/yaml/team cleanup lock-free, then lock only the final `load → retain → save`. **Order preserved** (delete instances → then remove the store record), so the #bughunt2 crash failure-semantics are unchanged.

### 3rd flock site audited & cleared
`reconcile_orphan_deployments` (:603) holds the flock across `teams::delete` (a **direct** store op, not a loopback) + `cleanup_deployment_dirs` — no `api::call`/enqueue, so it never trips the guard. Left as-is (not a 6th site).

### Tests
Two structural source-scans slice each fn and assert the api::call site **precedes** the `acquire_file_lock` site — prod-sliced + `concat` needles so they can't self-satisfy:
- `deploy_api_calls_not_under_flock`
- `teardown_api_calls_not_under_flock`

### Preflight
- `cargo fmt --check` clean
- `cargo clippy --all-targets --features tray -D warnings` clean
- `cargo test --tests --features tray`: **3380 passed, 0 failed** (real git). 48 deployments behavioral tests green.

PR3 (the `FLOCK_DEPTH` guard) lands once PR1 (#1632) + this are both in main, so the always-on fail-fast guard never red-fails CI on an unfixed site.

Refs #1629

🤖 Generated with [Claude Code](https://claude.com/claude-code)