### PR TITLE
refactor(#1629 PR3): extend the self-IPC deadlock guard to the fs4 flock tier (capstone)

### DIFF
--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -11,7 +11,7 @@ fn atomic_write_yaml(home: &Path, doc: &serde_yaml_ng::Value) -> Result<()> {
     result
 }
 
-fn acquire_lock(home: &Path) -> Result<std::fs::File> {
+fn acquire_lock(home: &Path) -> Result<crate::store::FileFlockGuard> {
     let lock_path = home.join(".fleet.yaml.lock");
     crate::store::acquire_file_lock(&lock_path).context("failed to acquire fleet lock")
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -130,14 +130,40 @@ pub fn save_atomic<T: Serialize>(path: &Path, data: &T) -> anyhow::Result<()> {
     atomic_write(path, body.as_bytes())
 }
 
+/// #1629: RAII guard returned by [`acquire_file_lock`]. Holds the locked `File`
+/// (the OS advisory lock releases when the `File` drops) and bumps the
+/// `FLOCK_DEPTH` thread-local for its lifetime so the self-IPC deadlock guard
+/// (`assert_no_registry_lock_for_self_ipc`) can see the flock tier — holding a
+/// flock across a loopback `api::call`/`enqueue_with_idle_hint` is the #1617
+/// lock-while-blocking deadlock class. On drop the depth decrement runs before
+/// the inner `File`'s drop releases the OS lock; both happen at the same scope
+/// exit, so no self-IPC can observe an inconsistent (depth, lock-held) pair.
+///
+/// `Deref` to `&File` is intentionally NOT provided: every call site holds the
+/// guard purely for RAII (`let _lock = acquire_file_lock(..)?`), so an opaque
+/// guard keeps the flock-depth invariant un-bypassable.
+pub struct FileFlockGuard {
+    _file: std::fs::File,
+}
+
+impl Drop for FileFlockGuard {
+    fn drop(&mut self) {
+        crate::sync_audit::flock_exited();
+    }
+}
+
 /// Acquire an exclusive advisory lock tied to `lock_path`.
 ///
-/// Released when the returned handle is dropped. Do NOT open the lock file
-/// with `truncate(true)` — truncation is unnecessary (the file contents are
-/// meaningless) and invites confusion in crash paths where a partially
-/// initialised lock file might be observed empty by another opener while
-/// the flock itself is still held on the inode.
-pub fn acquire_file_lock(lock_path: &Path) -> anyhow::Result<std::fs::File> {
+/// Released when the returned [`FileFlockGuard`] is dropped. Do NOT open the
+/// lock file with `truncate(true)` — truncation is unnecessary (the file
+/// contents are meaningless) and invites confusion in crash paths where a
+/// partially initialised lock file might be observed empty by another opener
+/// while the flock itself is still held on the inode.
+///
+/// #1629: this is the SOLE flock chokepoint that bumps `FLOCK_DEPTH`. The 2
+/// daemon-singleton `.daemon.lock` raw `fs4::try_lock` sites deliberately bypass
+/// it (they hold for the daemon's whole life and must not pin the depth).
+pub fn acquire_file_lock(lock_path: &Path) -> anyhow::Result<FileFlockGuard> {
     if let Some(parent) = lock_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -152,7 +178,9 @@ pub fn acquire_file_lock(lock_path: &Path) -> anyhow::Result<std::fs::File> {
     // (current MSRV is 1.87 per `rust-version`).
     fs4::FileExt::lock(&f)
         .map_err(|e| anyhow::anyhow!("flock failed on {}: {e}", lock_path.display()))?;
-    Ok(f)
+    // Bump AFTER the OS lock is held so depth>0 ⟹ lock held.
+    crate::sync_audit::flock_entered();
+    Ok(FileFlockGuard { _file: f })
 }
 
 /// Helper: build a store path from home + filename.
@@ -507,6 +535,36 @@ mod tests {
         drop(guard);
         // After drop, second can acquire.
         assert!(fs4::FileExt::try_lock(&second).is_ok());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn flock_guard_trips_self_ipc_deadlock_guard_1629() {
+        // #1629: holding an acquire_file_lock flock must make the always-on
+        // self-IPC deadlock guard REFUSE (Err); dropping it must clear (Ok). This
+        // is the wiring proof — FileFlockGuard bumps FLOCK_DEPTH, which
+        // assert_no_registry_lock_for_self_ipc now reads alongside the registry +
+        // core tiers.
+        let dir = tmp_dir("flock_guard_selfipc");
+        let lock_path = dir.join("g.lock");
+
+        // No flock held → guard passes.
+        assert!(
+            crate::sync_audit::assert_no_registry_lock_for_self_ipc("test:pre").is_ok(),
+            "no flock held → self-IPC allowed"
+        );
+        {
+            let _guard = acquire_file_lock(&lock_path).expect("acquire flock");
+            assert!(
+                crate::sync_audit::assert_no_registry_lock_for_self_ipc("test:held").is_err(),
+                "#1629: self-IPC must be refused while an acquire_file_lock flock is held"
+            );
+        }
+        // Flock dropped → guard passes again (FileFlockGuard::drop decremented).
+        assert!(
+            crate::sync_audit::assert_no_registry_lock_for_self_ipc("test:post").is_ok(),
+            "#1629: self-IPC must be allowed once the flock is dropped"
+        );
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/sync_audit.rs
+++ b/src/sync_audit.rs
@@ -159,6 +159,40 @@ fn core_lock_exited() {
     CORE_LOCK_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
 }
 
+// ── #1629: fs4 advisory-lock (flock) depth tracking ──────────────────────
+//
+// The #1492/#1535 guard tracks the registry + core locks. A THIRD tier — `fs4`
+// advisory file locks (flocks) acquired via [`crate::store::acquire_file_lock`]
+// — was invisible to it: holding a flock across a self-IPC (loopback `api::call`
+// / `enqueue_with_idle_hint`) is the same lock-while-blocking deadlock class as
+// #1617, yet bumped neither counter — so every flock-while-blocking bug
+// (#1617/#1342/#1340/#1624) had to be caught by manual review. The
+// [`crate::store::FileFlockGuard`] returned by `acquire_file_lock` bumps
+// `FLOCK_DEPTH` for its lifetime so the same self-IPC assert covers the flock
+// tier too.
+//
+// The 2 daemon-singleton `.daemon.lock` raw `fs4::try_lock` sites
+// (`bootstrap::acquire_daemon_lock`, `daemon::run`) deliberately bypass
+// `acquire_file_lock` and MUST NOT bump: they hold for the daemon's whole life,
+// which would pin the depth > 0 and false-trip every self-IPC.
+
+thread_local! {
+    /// How many `acquire_file_lock` flocks this thread currently holds (0 = none).
+    /// A single total-depth counter suffices: the rule is "no self-IPC while
+    /// holding ANY flock", so per-path identity is irrelevant.
+    static FLOCK_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Record that this thread acquired an `acquire_file_lock` flock.
+pub fn flock_entered() {
+    FLOCK_DEPTH.with(|c| c.set(c.get().saturating_add(1)));
+}
+
+/// Record that this thread released an `acquire_file_lock` flock.
+pub fn flock_exited() {
+    FLOCK_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
+}
+
 /// #1535: a `parking_lot::Mutex` wrapper for the per-agent `AgentCore` that
 /// tracks lock depth via [`CORE_LOCK_DEPTH`]. `.lock()` is API-compatible with
 /// `parking_lot::Mutex::lock` (the returned [`CoreGuard`] `Deref`s to `T`), so
@@ -213,10 +247,11 @@ impl<T> Drop for CoreGuard<'_, T> {
 }
 
 /// Return `Err` if a self-IPC vector is entered while this thread holds the
-/// registry lock (#1492) OR any per-agent core lock (#1535) — either ordering
+/// registry lock (#1492), any per-agent core lock (#1535), OR any `fs4` flock
+/// acquired via [`crate::store::acquire_file_lock`] (#1629) — each ordering
 /// deadlocks the daemon (the loopback API handler needs the registry lock and
-/// may lock the target agent's core). `ctx` names the vector (logged + carried
-/// in the error).
+/// may lock the target agent's core; a held flock stalls any thread contending
+/// it). `ctx` names the vector (logged + carried in the error).
 ///
 /// #1492-L2 (decision d-20260531171228817178-0): ALWAYS-ON, fail-fast `Err`
 /// (was debug-only `panic!` + release no-op). On violation it logs at ERROR
@@ -230,19 +265,22 @@ impl<T> Drop for CoreGuard<'_, T> {
 pub fn assert_no_registry_lock_for_self_ipc(ctx: &str) -> anyhow::Result<()> {
     let reg = REGISTRY_LOCK_DEPTH.with(|c| c.get());
     let core = CORE_LOCK_DEPTH.with(|c| c.get());
-    if reg > 0 || core > 0 {
+    let flock = FLOCK_DEPTH.with(|c| c.get());
+    if reg > 0 || core > 0 || flock > 0 {
         tracing::error!(
             ctx,
             registry_depth = reg,
             core_depth = core,
-            "#1492/#1535 lock-across-self-IPC deadlock risk — refusing self-IPC (returning Err)"
+            flock_depth = flock,
+            "#1492/#1535/#1629 lock-across-self-IPC deadlock risk — refusing self-IPC (returning Err)"
         );
         anyhow::bail!(
-            "#1492/#1535 lock-across-self-IPC deadlock risk: `{ctx}` was called while this thread \
-             holds locks (registry depth={reg}, core depth={core}). The loopback API handler needs \
-             the registry lock and may lock the target agent's core, so this self-IPC would \
-             deadlock the daemon. Drop the guard(s) BEFORE the call (collect under lock → drop → \
-             emit; see #1530, docs/DAEMON-LOCK-ORDERING.md)."
+            "#1492/#1535/#1629 lock-across-self-IPC deadlock risk: `{ctx}` was called while this thread \
+             holds locks (registry depth={reg}, core depth={core}, flock depth={flock}). The loopback API \
+             handler needs the registry lock and may lock the target agent's core, and an fs4 flock held \
+             across this self-IPC stalls any thread contending it — so this would deadlock the daemon. \
+             Drop the guard(s) BEFORE the call (collect under lock → drop → emit; see #1530, \
+             docs/DAEMON-LOCK-ORDERING.md)."
         );
     }
     Ok(())

--- a/tests/flock_depth_invariant.rs
+++ b/tests/flock_depth_invariant.rs
@@ -1,0 +1,75 @@
+//! #1629 invariant: `store::acquire_file_lock` (src/store.rs) must be the SOLE
+//! flock chokepoint that bumps `FLOCK_DEPTH` — the thread-local the self-IPC
+//! deadlock guard (`assert_no_registry_lock_for_self_ipc`) reads to see the
+//! fs4-flock tier. Any RAW `fs4::FileExt::lock` / `fs4::FileExt::try_lock`
+//! OUTSIDE the three vetted files bypasses FLOCK_DEPTH and silently reopens the
+//! flock-while-blocking deadlock blind spot (#1617/#1342/#1340/#1624) this guard
+//! closes. This RED fails CI if a new raw flock site appears.
+//!
+//! The three allowed files:
+//! - `store.rs` — `acquire_file_lock` itself (the chokepoint) + its tests.
+//! - `bootstrap/mod.rs` — `acquire_daemon_lock`, the `.daemon.lock` singleton
+//!   held for the daemon's whole life (MUST NOT bump the depth, else it would
+//!   pin FLOCK_DEPTH > 0 and false-trip every self-IPC).
+//! - `daemon/mod.rs` — the escape-hatch `run` `.daemon.lock` singleton.
+
+use std::path::{Path, PathBuf};
+
+fn collect_rs(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read_dir src") {
+        let p = entry.expect("dir entry").path();
+        if p.is_dir() {
+            collect_rs(&p, out);
+        } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(p);
+        }
+    }
+}
+
+#[test]
+fn acquire_file_lock_is_sole_flock_depth_bumper_1629() {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    collect_rs(&src, &mut files);
+    assert!(!files.is_empty(), "no src/*.rs files found");
+
+    // The 3 vetted files allowed to contain a raw fs4 flock call. store.rs is the
+    // chokepoint; the other two are the daemon-singleton `.daemon.lock` sites
+    // that deliberately bypass FLOCK_DEPTH (held for the daemon's whole life).
+    let allowed = ["store.rs", "bootstrap/mod.rs", "daemon/mod.rs"];
+
+    let needles = ["fs4::FileExt::lock", "fs4::FileExt::try_lock"];
+    let mut violations = Vec::new();
+    for file in &files {
+        let rel = file
+            .strip_prefix(&src)
+            .unwrap_or(file)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if allowed.contains(&rel.as_str()) {
+            continue;
+        }
+        let text = std::fs::read_to_string(file).expect("read src file");
+        for (i, line) in text.lines().enumerate() {
+            let t = line.trim_start();
+            if t.starts_with("//") || t.starts_with('*') {
+                continue; // skip comment/doc lines that merely mention the pattern
+            }
+            for needle in &needles {
+                if line.contains(needle) {
+                    violations.push(format!("{}:{}: {}", rel, i + 1, line.trim()));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "#1629: raw `fs4::FileExt::{{lock,try_lock}}` outside the 3 vetted files bypasses \
+         store::acquire_file_lock's FLOCK_DEPTH tracking → reopens the flock-while-blocking \
+         self-IPC deadlock blind spot (#1617 class). Route the lock through \
+         `crate::store::acquire_file_lock` instead; or — if it is a deliberate lifetime-held \
+         singleton like `.daemon.lock` — add its file to the allowlist with rationale:\n{}",
+        violations.join("\n")
+    );
+}

--- a/tests/flock_depth_invariant.rs
+++ b/tests/flock_depth_invariant.rs
@@ -1,10 +1,22 @@
 //! #1629 invariant: `store::acquire_file_lock` (src/store.rs) must be the SOLE
 //! flock chokepoint that bumps `FLOCK_DEPTH` — the thread-local the self-IPC
 //! deadlock guard (`assert_no_registry_lock_for_self_ipc`) reads to see the
-//! fs4-flock tier. Any RAW `fs4::FileExt::lock` / `fs4::FileExt::try_lock`
-//! OUTSIDE the three vetted files bypasses FLOCK_DEPTH and silently reopens the
-//! flock-while-blocking deadlock blind spot (#1617/#1342/#1340/#1624) this guard
-//! closes. This RED fails CI if a new raw flock site appears.
+//! fs4-flock tier. Any RAW fs4 flock OUTSIDE the three vetted files bypasses
+//! FLOCK_DEPTH and silently reopens the flock-while-blocking deadlock blind spot
+//! (#1617/#1342/#1340/#1624) this guard closes. This RED fails CI if a new raw
+//! flock site appears.
+//!
+//! A raw flock has TWO call forms, BOTH caught:
+//!  1. fully-qualified UFCS — `fs4::FileExt::try_lock(&file)` (works with no
+//!     import), matched by the `FileExt::<method>(` needle; and
+//!  2. imported-trait method — `use fs4::FileExt; file.try_lock()` (codex's
+//!     #1635 review probe), matched by the `.<method>(` needle BUT only in files
+//!     that actually import the fs4 `FileExt` trait (a `use … fs4 … FileExt`
+//!     line). That gate is the disambiguation from `Mutex::lock()`/
+//!     `RwLock::lock()`: `.lock(`/`.try_lock(` are ambiguous, so they are only
+//!     flagged where the fs4 trait is in scope — `Mutex::lock()` in a non-fs4
+//!     file never false-FAILs. (`src/inbox/disk.rs` imports `fs4::available_space`
+//!     but NOT `FileExt`, so it is correctly NOT gated on.)
 //!
 //! The three allowed files:
 //! - `store.rs` — `acquire_file_lock` itself (the chokepoint) + its tests.
@@ -14,6 +26,62 @@
 //! - `daemon/mod.rs` — the escape-hatch `run` `.daemon.lock` singleton.
 
 use std::path::{Path, PathBuf};
+
+const ALLOWED: [&str; 3] = ["store.rs", "bootstrap/mod.rs", "daemon/mod.rs"];
+
+/// fs4 `FileExt` method names that take/release an advisory lock. `lock` /
+/// `try_lock` are the exclusive aliases the codebase uses; the `_shared` /
+/// `_exclusive` variants are included for forward-coverage.
+const FLOCK_METHODS: [&str; 6] = [
+    "lock",
+    "try_lock",
+    "lock_shared",
+    "try_lock_shared",
+    "lock_exclusive",
+    "try_lock_exclusive",
+];
+
+/// Does this file import the fs4 `FileExt` trait (so `file.try_lock()` method
+/// syntax resolves to an fs4 flock)? Checked on `use` lines only, so a comment
+/// mentioning the trait does not flip the gate.
+fn imports_fs4_fileext(text: &str) -> bool {
+    text.lines().any(|l| {
+        let t = l.trim_start();
+        t.starts_with("use ") && t.contains("fs4") && t.contains("FileExt")
+    })
+}
+
+/// Return the raw-flock violations in `text` (empty for allowlisted files or
+/// clean files). Pure + path-string-driven so the meta-test can probe both
+/// directions without touching the filesystem.
+fn scan_file(rel: &str, text: &str) -> Vec<String> {
+    if ALLOWED.contains(&rel) {
+        return Vec::new();
+    }
+    let gated = imports_fs4_fileext(text);
+    let mut violations = Vec::new();
+    for (i, line) in text.lines().enumerate() {
+        let t = line.trim_start();
+        if t.starts_with("//") || t.starts_with('*') {
+            continue; // skip comment/doc lines that merely mention the pattern
+        }
+        for m in &FLOCK_METHODS {
+            // Form 1: fully-qualified UFCS, e.g. `fs4::FileExt::try_lock(` or
+            // `fs4::fs_std::FileExt::try_lock(`. `FileExt::` is fs4-specific
+            // (std's unix FileExt has no lock methods), so no import is needed.
+            if line.contains(&format!("FileExt::{m}(")) {
+                violations.push(format!("{}:{}: {}", rel, i + 1, line.trim()));
+            }
+            // Form 2: imported-trait method call, e.g. `file.try_lock(` — only
+            // an fs4 flock when the file imports the FileExt trait (else it is
+            // Mutex/RwLock and must NOT false-FAIL).
+            if gated && line.contains(&format!(".{m}(")) {
+                violations.push(format!("{}:{}: {}", rel, i + 1, line.trim()));
+            }
+        }
+    }
+    violations
+}
 
 fn collect_rs(dir: &Path, out: &mut Vec<PathBuf>) {
     for entry in std::fs::read_dir(dir).expect("read_dir src") {
@@ -33,12 +101,6 @@ fn acquire_file_lock_is_sole_flock_depth_bumper_1629() {
     collect_rs(&src, &mut files);
     assert!(!files.is_empty(), "no src/*.rs files found");
 
-    // The 3 vetted files allowed to contain a raw fs4 flock call. store.rs is the
-    // chokepoint; the other two are the daemon-singleton `.daemon.lock` sites
-    // that deliberately bypass FLOCK_DEPTH (held for the daemon's whole life).
-    let allowed = ["store.rs", "bootstrap/mod.rs", "daemon/mod.rs"];
-
-    let needles = ["fs4::FileExt::lock", "fs4::FileExt::try_lock"];
     let mut violations = Vec::new();
     for file in &files {
         let rel = file
@@ -46,30 +108,59 @@ fn acquire_file_lock_is_sole_flock_depth_bumper_1629() {
             .unwrap_or(file)
             .to_string_lossy()
             .replace('\\', "/");
-        if allowed.contains(&rel.as_str()) {
-            continue;
-        }
         let text = std::fs::read_to_string(file).expect("read src file");
-        for (i, line) in text.lines().enumerate() {
-            let t = line.trim_start();
-            if t.starts_with("//") || t.starts_with('*') {
-                continue; // skip comment/doc lines that merely mention the pattern
-            }
-            for needle in &needles {
-                if line.contains(needle) {
-                    violations.push(format!("{}:{}: {}", rel, i + 1, line.trim()));
-                }
-            }
-        }
+        violations.extend(scan_file(&rel, &text));
     }
 
     assert!(
         violations.is_empty(),
-        "#1629: raw `fs4::FileExt::{{lock,try_lock}}` outside the 3 vetted files bypasses \
+        "#1629: a raw fs4 flock outside the 3 vetted files bypasses \
          store::acquire_file_lock's FLOCK_DEPTH tracking → reopens the flock-while-blocking \
          self-IPC deadlock blind spot (#1617 class). Route the lock through \
          `crate::store::acquire_file_lock` instead; or — if it is a deliberate lifetime-held \
          singleton like `.daemon.lock` — add its file to the allowlist with rationale:\n{}",
         violations.join("\n")
+    );
+}
+
+/// Meta-test: prove the scanner catches BOTH raw-flock forms and does NOT
+/// false-FAIL on `Mutex::lock()`. Guards against the #1635 too-narrow-detection
+/// regression (the original only matched the fully-qualified string and missed
+/// `use fs4::FileExt; file.try_lock()`).
+#[test]
+fn scanner_catches_both_forms_and_spares_mutex() {
+    // codex's exact probe: imported-trait method call, non-allowlisted file.
+    let method_probe = "use fs4::FileExt;\nfn f(file: std::fs::File) { let _ = file.try_lock(); }";
+    assert!(
+        !scan_file("some/new_probe.rs", method_probe).is_empty(),
+        "must catch the imported-trait `file.try_lock()` flock form (#1635 hole)"
+    );
+
+    // Fully-qualified UFCS form, non-allowlisted file (no import needed).
+    let ufcs_probe = "fn f(file: std::fs::File) { let _ = fs4::FileExt::try_lock(&file); }";
+    assert!(
+        !scan_file("some/new_probe.rs", ufcs_probe).is_empty(),
+        "must catch the fully-qualified `fs4::FileExt::try_lock(` flock form"
+    );
+
+    // Legit Mutex::lock() in a non-fs4 file → must NOT false-FAIL.
+    let mutex = "use parking_lot::Mutex;\nfn f(m: &Mutex<u8>) { let _g = m.lock(); }";
+    assert!(
+        scan_file("some/other.rs", mutex).is_empty(),
+        "must NOT flag Mutex::lock() in a non-fs4 file"
+    );
+
+    // fs4 disk-space import without FileExt → not gated; a `.lock()` here is
+    // necessarily non-fs4 and must NOT false-FAIL (mirrors src/inbox/disk.rs).
+    let disk = "use fs4::available_space;\nfn f(m: &std::sync::Mutex<u8>) { let _g = m.lock(); }";
+    assert!(
+        scan_file("inbox/disk.rs", disk).is_empty(),
+        "fs4::available_space (no FileExt) must not gate the method check on"
+    );
+
+    // The 3 vetted files are exempt even with raw fs4 flock usage.
+    assert!(
+        scan_file("store.rs", method_probe).is_empty(),
+        "allowlisted files are exempt"
     );
 }

--- a/tests/flock_depth_invariant.rs
+++ b/tests/flock_depth_invariant.rs
@@ -11,12 +11,26 @@
 //!     import), matched by the `FileExt::<method>(` needle; and
 //!  2. imported-trait method — `use fs4::FileExt; file.try_lock()` (codex's
 //!     #1635 review probe), matched by the `.<method>(` needle BUT only in files
-//!     that actually import the fs4 `FileExt` trait (a `use … fs4 … FileExt`
-//!     line). That gate is the disambiguation from `Mutex::lock()`/
-//!     `RwLock::lock()`: `.lock(`/`.try_lock(` are ambiguous, so they are only
-//!     flagged where the fs4 trait is in scope — `Mutex::lock()` in a non-fs4
-//!     file never false-FAILs. (`src/inbox/disk.rs` imports `fs4::available_space`
-//!     but NOT `FileExt`, so it is correctly NOT gated on.)
+//!     whose `use` statements import the fs4 `FileExt` trait. That gate is the
+//!     disambiguation from `Mutex::lock()`/`RwLock::lock()`: `.lock(`/`.try_lock(`
+//!     are ambiguous, so they are only flagged where the fs4 trait is in scope —
+//!     `Mutex::lock()` in a non-fs4 file never false-FAILs. (`src/inbox/disk.rs`
+//!     imports `fs4::available_space` but NOT `FileExt`, so it is NOT gated on.)
+//!
+//! The FileExt-in-scope detection parses whole `use` STATEMENTS (each may span
+//! several lines until its `;`), so rustfmt's normal multi-line import block —
+//!   `use fs4::{`/`    available_space,`/`    FileExt,`/`};` — is handled the
+//! same as the single-line form.
+//!
+//! DOCUMENTED LIMIT (by design — this is an ACCIDENTAL-reintroduction guard, not
+//! a security boundary; same philosophy as #1631's documented assign-then-drop
+//! limit): the gate keys on the literal token `FileExt` appearing in an `fs4`
+//! `use` statement. Deliberate-evasion forms that HIDE that token are out of
+//! scope and we do NOT chase them: a glob import `use fs4::*;` (no `FileExt`
+//! token), or aliasing the trait to a different name and calling it via that
+//! alias's UFCS (`use fs4::FileExt as Z; Z::try_lock(`). A dev accidentally
+//! re-adding a raw flock writes an explicit `use fs4::…FileExt…` (single- or
+//! multi-line), which IS caught.
 //!
 //! The three allowed files:
 //! - `store.rs` — `acquire_file_lock` itself (the chokepoint) + its tests.
@@ -29,9 +43,9 @@ use std::path::{Path, PathBuf};
 
 const ALLOWED: [&str; 3] = ["store.rs", "bootstrap/mod.rs", "daemon/mod.rs"];
 
-/// fs4 `FileExt` method names that take/release an advisory lock. `lock` /
-/// `try_lock` are the exclusive aliases the codebase uses; the `_shared` /
-/// `_exclusive` variants are included for forward-coverage.
+/// fs4 `FileExt` lock/unlock method names. `lock` / `try_lock` are the exclusive
+/// aliases the codebase uses; the `_shared` / `_exclusive` variants are included
+/// for forward-coverage.
 const FLOCK_METHODS: [&str; 6] = [
     "lock",
     "try_lock",
@@ -42,13 +56,39 @@ const FLOCK_METHODS: [&str; 6] = [
 ];
 
 /// Does this file import the fs4 `FileExt` trait (so `file.try_lock()` method
-/// syntax resolves to an fs4 flock)? Checked on `use` lines only, so a comment
-/// mentioning the trait does not flip the gate.
+/// syntax resolves to an fs4 flock)? Parses whole `use` STATEMENTS — each runs
+/// from a `use`-prefixed line until the line carrying its `;` — so a multi-line
+/// `use fs4::{ … FileExt … };` block is detected as well as the single-line
+/// form. Comment lines are skipped so a commented mention does not flip the gate.
 fn imports_fs4_fileext(text: &str) -> bool {
-    text.lines().any(|l| {
-        let t = l.trim_start();
-        t.starts_with("use ") && t.contains("fs4") && t.contains("FileExt")
-    })
+    let mut stmt = String::new();
+    let mut in_use = false;
+    for line in text.lines() {
+        let t = line.trim_start();
+        if t.starts_with("//") || t.starts_with('*') {
+            continue;
+        }
+        if !in_use {
+            if t.starts_with("use ") {
+                in_use = true;
+                stmt.clear();
+                stmt.push_str(t);
+            } else {
+                continue;
+            }
+        } else {
+            stmt.push(' ');
+            stmt.push_str(t);
+        }
+        if stmt.contains(';') {
+            if stmt.contains("fs4") && stmt.contains("FileExt") {
+                return true;
+            }
+            in_use = false;
+            stmt.clear();
+        }
+    }
+    false
 }
 
 /// Return the raw-flock violations in `text` (empty for allowlisted files or
@@ -123,24 +163,32 @@ fn acquire_file_lock_is_sole_flock_depth_bumper_1629() {
     );
 }
 
-/// Meta-test: prove the scanner catches BOTH raw-flock forms and does NOT
-/// false-FAIL on `Mutex::lock()`. Guards against the #1635 too-narrow-detection
-/// regression (the original only matched the fully-qualified string and missed
-/// `use fs4::FileExt; file.try_lock()`).
+/// Meta-test: prove the scanner catches all the realistic raw-flock forms and
+/// does NOT false-FAIL on `Mutex::lock()`. Guards against the #1635
+/// too-narrow-detection regressions (rounds 1–3): the original matched only the
+/// fully-qualified string; round 2 added the imported-trait method; round 3
+/// (this) handles the multi-line import block.
 #[test]
-fn scanner_catches_both_forms_and_spares_mutex() {
-    // codex's exact probe: imported-trait method call, non-allowlisted file.
-    let method_probe = "use fs4::FileExt;\nfn f(file: std::fs::File) { let _ = file.try_lock(); }";
+fn scanner_catches_all_realistic_forms_and_spares_mutex() {
+    // codex r2 probe: single-line imported-trait method call.
+    let single = "use fs4::FileExt;\nfn f(file: std::fs::File) { let _ = file.try_lock(); }";
     assert!(
-        !scan_file("some/new_probe.rs", method_probe).is_empty(),
-        "must catch the imported-trait `file.try_lock()` flock form (#1635 hole)"
+        !scan_file("some/new_probe.rs", single).is_empty(),
+        "must catch single-line `use fs4::FileExt; file.try_lock()` (#1635 r2)"
     );
 
-    // Fully-qualified UFCS form, non-allowlisted file (no import needed).
-    let ufcs_probe = "fn f(file: std::fs::File) { let _ = fs4::FileExt::try_lock(&file); }";
+    // codex r3 probe: rustfmt's multi-line import block + method call.
+    let multiline = "use fs4::{\n    available_space,\n    FileExt,\n};\nfn f(file: std::fs::File) { let _ = file.try_lock(); }";
     assert!(
-        !scan_file("some/new_probe.rs", ufcs_probe).is_empty(),
-        "must catch the fully-qualified `fs4::FileExt::try_lock(` flock form"
+        !scan_file("some/new_probe.rs", multiline).is_empty(),
+        "must catch the MULTI-LINE `use fs4::{{ …FileExt… }}; file.try_lock()` (#1635 r3)"
+    );
+
+    // Fully-qualified UFCS form (no import needed).
+    let ufcs = "fn f(file: std::fs::File) { let _ = fs4::FileExt::try_lock(&file); }";
+    assert!(
+        !scan_file("some/new_probe.rs", ufcs).is_empty(),
+        "must catch the fully-qualified `fs4::FileExt::try_lock(` form"
     );
 
     // Legit Mutex::lock() in a non-fs4 file → must NOT false-FAIL.
@@ -150,17 +198,18 @@ fn scanner_catches_both_forms_and_spares_mutex() {
         "must NOT flag Mutex::lock() in a non-fs4 file"
     );
 
-    // fs4 disk-space import without FileExt → not gated; a `.lock()` here is
-    // necessarily non-fs4 and must NOT false-FAIL (mirrors src/inbox/disk.rs).
-    let disk = "use fs4::available_space;\nfn f(m: &std::sync::Mutex<u8>) { let _g = m.lock(); }";
+    // fs4 disk-space import WITHOUT FileExt → not gated; a `.lock()` here is
+    // necessarily non-fs4 and must NOT false-FAIL (mirrors src/inbox/disk.rs),
+    // including the multi-line grouped form that omits FileExt.
+    let disk = "use fs4::{\n    available_space,\n    total_space,\n};\nfn f(m: &std::sync::Mutex<u8>) { let _g = m.lock(); }";
     assert!(
         scan_file("inbox/disk.rs", disk).is_empty(),
-        "fs4::available_space (no FileExt) must not gate the method check on"
+        "fs4 import without FileExt must not gate the method check on"
     );
 
     // The 3 vetted files are exempt even with raw fs4 flock usage.
     assert!(
-        scan_file("store.rs", method_probe).is_empty(),
+        scan_file("store.rs", single).is_empty(),
         "allowlisted files are exempt"
     );
 }


### PR DESCRIPTION
## PR3 of 3 — capstone (Closes #1629)

The always-on self-IPC guard (`assert_no_registry_lock_for_self_ipc`) tracked the registry lock (#1492) and per-agent core lock (#1535) but was **blind to the third blocking tier: fs4 advisory flocks.** Holding a flock across a loopback `api::call`/`enqueue_with_idle_hint` is the #1617 lock-while-blocking deadlock class — yet bumped neither counter, so every flock-while-blocking bug (#1617/#1342/#1340/#1624) had to be caught by **manual review**. This makes the class **unit-test-catchable forever**.

### Change (mirrors the CoreMutex/#1535 pattern)
- `FLOCK_DEPTH` thread-local + `flock_entered`/`flock_exited` (sync_audit.rs).
- `store::acquire_file_lock` now returns a **`FileFlockGuard`** newtype (was raw `File`) that bumps `FLOCK_DEPTH` for its lifetime — increment **after** the OS lock is held, decrement on drop. The ~37 RAII `let _lock =` call sites are unchanged; the one explicit `Result<File>` return (`fleet::persist::acquire_lock`) updated.
- `assert_no_registry_lock_for_self_ipc` gains the `flock > 0` clause (same always-on fail-fast `Err`).
- The **2 daemon-singleton `.daemon.lock`** raw `fs4::try_lock` sites (`bootstrap::acquire_daemon_lock`, `daemon::run`) deliberately bypass `acquire_file_lock` and do **NOT** bump — they hold for the daemon's whole life and would otherwise pin the depth > 0 and false-trip every self-IPC (per the phase-1 audit).

### Tests
- **Behavioral** (store.rs): holding an `acquire_file_lock` flock makes the guard return `Err`; dropping it clears to `Ok` — the wiring proof.
- **Structural** (`tests/flock_depth_invariant.rs`, mirrors `tests/core_mutex_invariant.rs`): RED if a raw `fs4::FileExt::{lock,try_lock}` appears outside the 3 vetted files (store.rs + the 2 daemon-singleton sites), so a future untracked flock can't silently reopen the blind spot.

### The proof (guard lands clean)
The lead's key ask: if the guard fires **anywhere**, there's an unfixed 6th flock-while-blocking site. It does not. The full suite — which exercises every flock+emit path through the guard, **including the 5 previously-buggy sites' behavioral tests** (pr_state / dispatch_idle / decision_timeout / deploy / teardown) — passes with the guard always-on:
- `cargo test --tests --features tray`: **3385 passed, 0 failed, 62 groups** (real git)
- `cargo fmt --check` clean; `cargo clippy --all-targets --features tray -D warnings` clean

A **live-daemon smoke was intentionally skipped**: starting a second daemon would collide with the running fleet daemon, and the suite already evaluates the guard on every self-IPC path (a held flock → `Err` → undelivered message → test failure; all such tests pass).

### Series recap
- PR1 #1632 — 3 daemon-loop emit-deferrals ✅ merged
- PR2 #1633 — deployments lock-narrowing ✅ merged
- **PR3 (this)** — the guard. All 5 sites fixed; the class is now structurally enforced.

Closes #1629

🤖 Generated with [Claude Code](https://claude.com/claude-code)