### PR TITLE
refactor(#1636): dispatch_idle status String → DispatchStatus enum

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -1585,7 +1585,8 @@ mod tests {
         let pending = crate::daemon::dispatch_idle::list_pending(&home);
         let entry = pending.iter().find(|p| p.dispatch_id == id).unwrap();
         assert_eq!(
-            entry.status, "resolved",
+            entry.status,
+            crate::daemon::dispatch_idle::DispatchStatus::Resolved,
             "kind=report with matching correlation_id must resolve the sidecar"
         );
         std::fs::remove_dir_all(&home).ok();
@@ -1621,7 +1622,8 @@ mod tests {
         let pending = crate::daemon::dispatch_idle::list_pending(&home);
         let entry = pending.iter().find(|p| p.dispatch_id == id).unwrap();
         assert_eq!(
-            entry.status, "pending",
+            entry.status,
+            crate::daemon::dispatch_idle::DispatchStatus::Pending,
             "kind=update must NOT flip status (watchdog stays armed)"
         );
         std::fs::remove_dir_all(&home).ok();
@@ -1696,8 +1698,8 @@ mod tests {
             seeded
                 .iter()
                 .find(|p| p.correlation_id.as_deref() == Some("t-1525-x"))
-                .map(|p| p.status.as_str()),
-            Some("pending"),
+                .map(|p| p.status),
+            Some(crate::daemon::dispatch_idle::DispatchStatus::Pending),
             "sidecar must seed pending, keyed by task_id"
         );
 
@@ -1721,8 +1723,8 @@ mod tests {
             after
                 .iter()
                 .find(|p| p.correlation_id.as_deref() == Some("t-1525-x"))
-                .map(|p| p.status.as_str()),
-            Some("resolved"),
+                .map(|p| p.status),
+            Some(crate::daemon::dispatch_idle::DispatchStatus::Resolved),
             "#1525: a report carrying the id in task_id must clear the sidecar \
              via the correlation_id.or(task_id) symmetry"
         );

--- a/src/daemon/dispatch_idle/fixup_nudge.rs
+++ b/src/daemon/dispatch_idle/fixup_nudge.rs
@@ -20,7 +20,7 @@
 
 use std::path::Path;
 
-use super::{list_pending, pending_path, PendingDispatch};
+use super::{list_pending, pending_path, DispatchStatus, PendingDispatch};
 
 /// Fixup team name as it appears in fleet.yaml. Single source of truth.
 pub(crate) const FIXUP_TEAM_NAME: &str = "fixup";
@@ -139,7 +139,7 @@ fn emit_nudge(home: &Path, d: &PendingDispatch) -> bool {
 /// tests.
 pub(crate) fn scan_and_nudge(home: &Path) {
     for mut d in list_pending(home) {
-        if d.status != "exceeded" {
+        if d.status != DispatchStatus::Exceeded {
             continue;
         }
         if d.nudge_sent_at.is_some() {
@@ -213,7 +213,7 @@ mod tests {
             expected_kind: "task".to_string(),
             threshold_secs: 600,
             issued_at: issued,
-            status: "exceeded".to_string(),
+            status: DispatchStatus::Exceeded,
             nudge_sent_at: None,
         };
         std::fs::write(
@@ -333,7 +333,7 @@ mod tests {
             expected_kind: "task".to_string(),
             threshold_secs: 600,
             issued_at: issued,
-            status: "exceeded".to_string(),
+            status: DispatchStatus::Exceeded,
             nudge_sent_at: None,
         };
         std::fs::write(

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -70,9 +70,9 @@ pub(crate) struct PendingDispatch {
     pub(crate) threshold_secs: i64,
     #[serde(default)]
     pub(crate) issued_at: String,
-    /// `pending` | `exceeded` | `resolved` | `cancelled`.
-    #[serde(default = "default_status")]
-    pub(crate) status: String,
+    /// Sidecar lifecycle state. See [`DispatchStatus`].
+    #[serde(default)]
+    pub(crate) status: DispatchStatus,
     /// L2-owned dedup field: timestamp of the last nudge emitted for
     /// this dispatch. `None` = no nudge sent yet. L1 never reads this
     /// field; it lives in the L1 schema to keep the sidecar a single
@@ -81,8 +81,28 @@ pub(crate) struct PendingDispatch {
     pub(crate) nudge_sent_at: Option<String>,
 }
 
-fn default_status() -> String {
-    "pending".to_string()
+/// #1636: lifecycle of a dispatch-idle sidecar, replacing the stringly-typed
+/// 4-state `status` field so the compiler enforces exhaustiveness at the guard
+/// sites. Serializes to the SAME lowercase wire strings the `String` field used
+/// (`pending` / `resolved` / `exceeded` / `cancelled`) via `rename_all`, so
+/// on-disk sidecars and IPC payloads are byte-identical — pinned by
+/// `dispatch_status_serde_roundtrip`. Strict like the pr_state enums next door:
+/// an unknown status string fails to deserialize, so the sidecar is skipped by
+/// `list_pending`'s existing fail-open loader (the module only ever writes the
+/// four known states).
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum DispatchStatus {
+    /// Dispatch in flight, watchdog armed — the only state that surfaces in
+    /// operator views and matches the resolve/escalate scans.
+    #[default]
+    Pending,
+    /// A matching report arrived → watchdog disarmed.
+    Resolved,
+    /// `threshold_secs` elapsed with no report → idle nudge fired.
+    Exceeded,
+    /// Underlying task reached a terminal state (done/cancelled) → sidecar void.
+    Cancelled,
 }
 
 pub(crate) fn pending_dir(home: &Path) -> PathBuf {
@@ -141,7 +161,7 @@ pub(crate) fn record_dispatch(
         expected_kind: expected_kind.to_string(),
         threshold_secs,
         issued_at: chrono::Utc::now().to_rfc3339(),
-        status: "pending".to_string(),
+        status: DispatchStatus::Pending,
         nudge_sent_at: None,
     };
     let body = match serde_json::to_string_pretty(&payload) {
@@ -253,7 +273,7 @@ pub(crate) fn cleanup_pending_for_task_id(home: &Path, task_id: &str) -> usize {
     }
     let mut count = 0usize;
     for d in list_pending(home) {
-        if d.status != "pending" {
+        if d.status != DispatchStatus::Pending {
             continue;
         }
         if d.correlation_id.as_deref() != Some(task_id) {
@@ -294,7 +314,7 @@ pub(crate) fn cleanup_pending_for_instance(home: &Path, instance_name: &str) -> 
     }
     let mut count = 0usize;
     for d in list_pending(home) {
-        if d.status != "pending" {
+        if d.status != DispatchStatus::Pending {
             continue;
         }
         if d.target != instance_name {
@@ -331,17 +351,17 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
     if correlation_id.is_empty() {
         return None;
     }
-    let matched = list_pending(home)
-        .into_iter()
-        .find(|d| d.status == "pending" && d.correlation_id.as_deref() == Some(correlation_id));
+    let matched = list_pending(home).into_iter().find(|d| {
+        d.status == DispatchStatus::Pending && d.correlation_id.as_deref() == Some(correlation_id)
+    });
     let d = matched?;
     let id = d.dispatch_id.clone();
     let path = pending_path(home, &id);
     crate::store::with_json_state::<PendingDispatch, _, _>(&path, |current| {
-        if current.status != "pending" {
+        if current.status != DispatchStatus::Pending {
             return None;
         }
-        current.status = "resolved".to_string();
+        current.status = DispatchStatus::Resolved;
         Some(id.clone())
     })
     .ok()
@@ -358,14 +378,14 @@ pub(crate) fn refresh_issued_at(home: &Path, correlation_id: &str) -> Option<Str
     if correlation_id.is_empty() {
         return None;
     }
-    let matched = list_pending(home)
-        .into_iter()
-        .find(|d| d.status == "pending" && d.correlation_id.as_deref() == Some(correlation_id));
+    let matched = list_pending(home).into_iter().find(|d| {
+        d.status == DispatchStatus::Pending && d.correlation_id.as_deref() == Some(correlation_id)
+    });
     let d = matched?;
     let id = d.dispatch_id.clone();
     let path = pending_path(home, &id);
     crate::store::with_json_state::<PendingDispatch, _, _>(&path, |current| {
-        if current.status != "pending" {
+        if current.status != DispatchStatus::Pending {
             return None;
         }
         current.issued_at = chrono::Utc::now().to_rfc3339();
@@ -416,7 +436,7 @@ pub(crate) fn pending_for_instance(
         return (as_dispatcher, as_target);
     }
     for d in list_pending(home) {
-        if d.status != "pending" {
+        if d.status != DispatchStatus::Pending {
             continue;
         }
         let elapsed_secs = chrono::DateTime::parse_from_rfc3339(&d.issued_at)
@@ -469,7 +489,7 @@ pub(crate) fn scan_and_emit(home: &Path) {
     // transitions — see #1470-#4 — so it's an unreliable "current state").
     let snapshot = crate::snapshot::load(home);
     for d in list_pending(home) {
-        if d.status != "pending" {
+        if d.status != DispatchStatus::Pending {
             continue;
         }
         let issued = match chrono::DateTime::parse_from_rfc3339(&d.issued_at) {
@@ -538,10 +558,10 @@ pub(crate) fn scan_and_emit(home: &Path) {
                 Ok(d) => d,
                 Err(_) => continue,
             };
-            if current.status != "pending" {
+            if current.status != DispatchStatus::Pending {
                 continue;
             }
-            current.status = "exceeded".to_string();
+            current.status = DispatchStatus::Exceeded;
             if !write_dispatch(home, &current) {
                 tracing::warn!(dispatch_id = %d.dispatch_id, "dispatch-idle exceeded status write failed");
             }
@@ -676,6 +696,41 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
 
+    /// #1636: the `DispatchStatus` enum MUST serialize to / deserialize from the
+    /// exact lowercase wire strings the prior stringly-typed field used, so
+    /// existing on-disk sidecars + IPC payloads stay byte-compatible.
+    #[test]
+    fn dispatch_status_serde_roundtrip() {
+        for (variant, wire) in [
+            (DispatchStatus::Pending, "\"pending\""),
+            (DispatchStatus::Resolved, "\"resolved\""),
+            (DispatchStatus::Exceeded, "\"exceeded\""),
+            (DispatchStatus::Cancelled, "\"cancelled\""),
+        ] {
+            // enum → string matches the legacy wire form
+            assert_eq!(serde_json::to_string(&variant).unwrap(), wire);
+            // string → enum (legacy on-disk values still load)
+            assert_eq!(
+                serde_json::from_str::<DispatchStatus>(wire).unwrap(),
+                variant
+            );
+        }
+        // `#[serde(default)]` on the field → a sidecar JSON with no `status`
+        // key loads as Pending, matching the old `default_status` fn.
+        let no_status = r#"{"dispatch_id":"d1","dispatcher":"a","target":"b"}"#;
+        let d: PendingDispatch = serde_json::from_str(no_status).unwrap();
+        assert_eq!(d.status, DispatchStatus::Pending);
+        // A full sidecar round-trips with the status as a lowercase string.
+        let s = serde_json::to_string(&d).unwrap();
+        assert!(
+            s.contains("\"status\":\"pending\""),
+            "status must serialize as the lowercase wire string, got: {s}"
+        );
+        // An unknown status string fails to deserialize (strict, like the
+        // pr_state enums) — list_pending's fail-open loader then skips it.
+        assert!(serde_json::from_str::<DispatchStatus>("\"bogus\"").is_err());
+    }
+
     fn tmp_home(tag: &str) -> PathBuf {
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -712,7 +767,7 @@ mod tests {
             expected_kind: expected_kind.to_string(),
             threshold_secs,
             issued_at: issued_at.to_rfc3339(),
-            status: "pending".to_string(),
+            status: DispatchStatus::Pending,
             nudge_sent_at: None,
         };
         std::fs::write(
@@ -763,7 +818,7 @@ mod tests {
         assert_eq!(p.correlation_id.as_deref(), Some("t-abc"));
         assert_eq!(p.expected_kind, "task");
         assert_eq!(p.threshold_secs, 600);
-        assert_eq!(p.status, "pending");
+        assert_eq!(p.status, DispatchStatus::Pending);
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -785,7 +840,11 @@ mod tests {
         );
         let pending = list_pending(&home);
         let p = pending.iter().find(|p| p.dispatch_id == id).unwrap();
-        assert_eq!(p.status, "exceeded", "sidecar must flip pending→exceeded");
+        assert_eq!(
+            p.status,
+            DispatchStatus::Exceeded,
+            "sidecar must flip pending→exceeded"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -808,9 +867,14 @@ mod tests {
         let pending = list_pending(&home);
         let p_a = pending.iter().find(|p| p.dispatch_id == id_a).unwrap();
         let p_b = pending.iter().find(|p| p.dispatch_id == id_b).unwrap();
-        assert_eq!(p_a.status, "resolved", "matched sidecar must flip");
         assert_eq!(
-            p_b.status, "pending",
+            p_a.status,
+            DispatchStatus::Resolved,
+            "matched sidecar must flip"
+        );
+        assert_eq!(
+            p_b.status,
+            DispatchStatus::Pending,
             "unmatched sidecar from same dispatcher must NOT flip"
         );
         std::fs::remove_dir_all(&home).ok();
@@ -875,9 +939,10 @@ mod tests {
         let pending = list_pending(&home);
         let p_stale = pending.iter().find(|p| p.dispatch_id == id_stale).unwrap();
         let p_fresh = pending.iter().find(|p| p.dispatch_id == id_fresh).unwrap();
-        assert_eq!(p_stale.status, "exceeded");
+        assert_eq!(p_stale.status, DispatchStatus::Exceeded);
         assert_eq!(
-            p_fresh.status, "pending",
+            p_fresh.status,
+            DispatchStatus::Pending,
             "fresh dispatch must remain pending"
         );
         std::fs::remove_dir_all(&home).ok();
@@ -1601,7 +1666,7 @@ mod tests {
         );
         let pending = list_pending(&home);
         assert!(
-            pending.iter().any(|p| p.status == "pending"),
+            pending.iter().any(|p| p.status == DispatchStatus::Pending),
             "sidecar must remain pending after refresh"
         );
         std::fs::remove_dir_all(&home).ok();
@@ -1638,7 +1703,11 @@ mod tests {
             .iter()
             .find(|p| p.correlation_id.as_deref() == Some("t-1047-c"))
             .unwrap();
-        assert_eq!(d.status, "resolved", "kind=report must set status=resolved");
+        assert_eq!(
+            d.status,
+            DispatchStatus::Resolved,
+            "kind=report must set status=resolved"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -1709,7 +1778,8 @@ mod tests {
             .find(|p| p.dispatch_id == id)
             .unwrap();
         assert_eq!(
-            p.status, "pending",
+            p.status,
+            DispatchStatus::Pending,
             "sidecar stays pending (clock refreshed)"
         );
         std::fs::remove_dir_all(&home).ok();
@@ -1737,7 +1807,7 @@ mod tests {
             .into_iter()
             .find(|p| p.dispatch_id == id)
             .unwrap();
-        assert_eq!(p.status, "exceeded");
+        assert_eq!(p.status, DispatchStatus::Exceeded);
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -683,7 +683,10 @@ fn scan_fleet_vantage(
 fn has_expected_work(home: &Path) -> bool {
     // Check pending dispatch sidecars first (cheap).
     let pending = crate::daemon::dispatch_idle::list_pending(home);
-    if pending.iter().any(|d| d.status == "pending") {
+    if pending
+        .iter()
+        .any(|d| d.status == crate::daemon::dispatch_idle::DispatchStatus::Pending)
+    {
         return true;
     }
     // Only suppress when we can confirm the task board is empty.


### PR DESCRIPTION
## What
Convert the dispatch-idle sidecar `status` from a stringly-typed 4-state `String` (with `status != "pending"` / `== "pending"` guards copy-pasted across ~13 sites) to a `DispatchStatus` enum, so the compiler enforces exhaustiveness at every guard. Mirrors the `pr_state` enums next door.

```rust
#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
#[serde(rename_all = "lowercase")]
pub(crate) enum DispatchStatus {
    #[default] Pending,  // armed; the only state that surfaces / matches scans
    Resolved,            // matching report arrived → disarmed
    Exceeded,            // threshold elapsed → nudge fired
    Cancelled,           // underlying task terminal → sidecar void
}
```

## Pure type refactor — NO behavior change
- **Wire compat preserved:** `#[serde(rename_all = "lowercase")]` → the enum serializes to / deserializes from the **same** on-disk/IPC strings (`pending`/`resolved`/`exceeded`/`cancelled`). `#[serde(default)]` + `#[default] Pending` replaces the old `default_status()` fn (missing `status` key still loads as `pending`).
- **Strict, like pr_state:** an unknown status string fails to deserialize, so `list_pending`'s existing fail-open loader (`from_str(...) else continue`) skips that sidecar — the module only ever writes the four known states.

## Sites converted (~13 guards/assigns + test asserts)
`src/daemon/dispatch_idle/mod.rs` (all `!= "pending"` / `== "pending"` guards, the `= "resolved"` / `= "exceeded"` assigns, struct inits), `fixup_nudge.rs` (the `!= "exceeded"` guard + sidecar inits), `src/daemon/idle_watchdog.rs` (pending-sidecar check), `src/api/handlers/messaging.rs` (test asserts).

## Test
New `dispatch_status_serde_roundtrip`: pins each variant ↔ exact lowercase wire string, the no-`status`-key default → `Pending`, and that an unknown string is rejected. Existing tests (incl. ones that write raw `"status": "..."` JSON to disk) still pass — they validate the wire compat end-to-end.

## Out of scope (separate structs, NOT `dispatch_idle::PendingDispatch`)
`decision_timeout`, `dispatch_tracking`, `comms`/`orphan_sweep` status fields — different state machines, left untouched (clippy-verified no type bleed).

## Preflight
`cargo fmt`, `cargo clippy --all-targets --features tray -- -D warnings` clean, dispatch_idle(38) / serde-roundtrip / idle_watchdog(39) / messaging(45) tests pass.

Closes #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)