### PR TITLE
refactor(#1638): type-encode BlockedReason clear + hang-suppress policy

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -863,12 +863,12 @@ fn tick(
                 // operators aren't vibrated twice per interactive cycle.
                 // #1552: clear the AwaitingOperator health reason on recovery so
                 // `check_hang` is no longer exempt and a future stall can
-                // re-notify (the once-per-episode dedup re-arms). Guarded so we
-                // never clear a different blocked reason (RateLimit / etc.).
-                if matches!(
-                    core.health.current_reason,
-                    Some(crate::health::BlockedReason::AwaitingOperator)
-                ) {
+                // re-notify (the once-per-episode dedup re-arms). #1638: the
+                // operator-resolution clear-policy is now on the type, so this
+                // never clears a different blocked reason (RateLimit / etc.).
+                if core.health.current_reason.as_ref().is_some_and(|r| {
+                    r.auto_clears_on(crate::health::RecoverySignal::OperatorResolved)
+                }) {
                     core.health.clear_blocked_reason();
                 }
                 tracing::info!(

--- a/src/daemon/watchdog.rs
+++ b/src/daemon/watchdog.rs
@@ -1,7 +1,7 @@
 //! Watchdog: classify PTY output into BlockedReason per daemon tick.
 
 use crate::backend::Backend;
-use crate::health::{BlockedReason, HealthTracker};
+use crate::health::HealthTracker;
 use crate::state::AgentState;
 use std::path::Path;
 
@@ -60,10 +60,10 @@ pub fn run_watchdog_pass(
     // blocked-reason guard). The set below re-latches if the agent is in
     // fact still throttled (classify still matches).
     if recovered_from_rate_limit(current_state)
-        && matches!(
-            health.current_reason,
-            Some(BlockedReason::RateLimit { .. } | BlockedReason::QuotaExceeded)
-        )
+        && health
+            .current_reason
+            .as_ref()
+            .is_some_and(|r| r.auto_clears_on(crate::health::RecoverySignal::RateLimitLifted))
     {
         health.clear_blocked_reason();
     }

--- a/src/health.rs
+++ b/src/health.rs
@@ -208,6 +208,20 @@ pub enum BlockedReason {
     Crash,
 }
 
+/// #1638: which recovery signal a [`BlockedReason`] is being tested against.
+/// There are two independent recovery axes, each clearing a different set of
+/// reasons (a single "recovered?" boolean would conflate them and break one):
+/// - [`RateLimitLifted`](Self::RateLimitLifted): the watchdog observed the agent
+///   actively working/ready again after a throttle (#1621/bughunt2 auto-clear).
+/// - [`OperatorResolved`](Self::OperatorResolved): the supervisor consumed a
+///   recovery notice on the transition out of AwaitingOperator/InteractivePrompt
+///   (#1552 "ready again" clear).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoverySignal {
+    RateLimitLifted,
+    OperatorResolved,
+}
+
 impl BlockedReason {
     pub fn parse_kind(kind: &str, params: &serde_json::Value) -> Option<Self> {
         match kind {
@@ -231,6 +245,48 @@ impl BlockedReason {
             Self::AwaitingOperator => "awaiting_operator",
             Self::PermissionPrompt => "permission_prompt",
             Self::Crash => "crash",
+        }
+    }
+
+    /// #1638: does this reason auto-clear when the given [`RecoverySignal`]
+    /// fires? Type-encodes the clear-policy that was previously two hardcoded
+    /// `matches!` (watchdog #1621 + supervisor #1552), so a NEW variant is
+    /// compile-forced to declare its clear behavior for BOTH axes instead of
+    /// silently latching forever (the #1621 set-without-clear class).
+    ///
+    /// Preserves the existing guards exactly:
+    /// - RateLimit/QuotaExceeded auto-clear on `RateLimitLifted` only (#1621),
+    ///   never on operator-resolution.
+    /// - AwaitingOperator auto-clears on `OperatorResolved` only (#1552), never
+    ///   on rate-limit recovery (#1564 — operator-action reasons must persist
+    ///   through an unrelated throttle lift).
+    /// - PermissionPrompt/Hang/Crash never auto-clear (operator/crash action
+    ///   required; today they are MCP-set + MCP/explicit-cleared only). See the
+    ///   PR note on whether InteractivePrompt resolution SHOULD clear
+    ///   PermissionPrompt — left as current behavior here.
+    ///
+    /// The `match self` is intentionally wildcard-free: that is the forcing
+    /// function.
+    pub fn auto_clears_on(&self, signal: RecoverySignal) -> bool {
+        match self {
+            Self::RateLimit { .. } | Self::QuotaExceeded => {
+                matches!(signal, RecoverySignal::RateLimitLifted)
+            }
+            Self::AwaitingOperator => matches!(signal, RecoverySignal::OperatorResolved),
+            Self::PermissionPrompt | Self::Hang | Self::Crash => false,
+        }
+    }
+
+    /// #1638: does this reason legitimately suppress `check_hang` (the agent is
+    /// blocked for a known reason that explains the output silence)? Type-encodes
+    /// what was a hardcoded `matches!` in `check_hang`, so a new variant is
+    /// compile-forced to declare its hang-suppression too. Wildcard-free by
+    /// design. Behavior-preserving: RateLimit/QuotaExceeded/AwaitingOperator
+    /// suppress; PermissionPrompt/Hang/Crash do not.
+    pub fn suppresses_hang_check(&self) -> bool {
+        match self {
+            Self::RateLimit { .. } | Self::QuotaExceeded | Self::AwaitingOperator => true,
+            Self::PermissionPrompt | Self::Hang | Self::Crash => false,
         }
     }
 }
@@ -495,14 +551,9 @@ impl HealthTracker {
         }
 
         // Race mutex: skip hang check when agent is blocked for a known
-        // reason that legitimately suppresses output.
+        // reason that legitimately suppresses output (#1638: policy on the type).
         if let Some(ref reason) = self.current_reason {
-            if matches!(
-                reason,
-                BlockedReason::RateLimit { .. }
-                    | BlockedReason::QuotaExceeded
-                    | BlockedReason::AwaitingOperator
-            ) {
+            if reason.suppresses_hang_check() {
                 return false;
             }
         }
@@ -1556,5 +1607,63 @@ mod tests {
             assert!(result, "silent path must still trigger Hung");
             assert_eq!(h.state, HealthState::Hung);
         });
+    }
+
+    /// #1638: the BlockedReason clear-policy + hang-suppress-policy table. This
+    /// is the behavior-preserving spec — every variant×signal cell must match
+    /// the pre-#1638 hardcoded `matches!` behavior (watchdog #1621 rate-limit
+    /// axis, supervisor #1552 operator-resolution axis, check_hang suppression).
+    /// A new variant added to the enum fails to compile in `auto_clears_on` /
+    /// `suppresses_hang_check` (wildcard-free), forcing a deliberate row here.
+    #[test]
+    fn blocked_reason_policy_table_1638() {
+        use BlockedReason::*;
+        use RecoverySignal::*;
+        let rl = RateLimit {
+            retry_after_secs: Some(30),
+        };
+        let rl_none = RateLimit {
+            retry_after_secs: None,
+        };
+
+        // (reason, clears_on RateLimitLifted, clears_on OperatorResolved, suppresses_hang)
+        let table: &[(BlockedReason, bool, bool, bool)] = &[
+            (rl, true, false, true),
+            (rl_none, true, false, true),
+            (QuotaExceeded, true, false, true),
+            (AwaitingOperator, false, true, true),
+            (PermissionPrompt, false, false, false),
+            (Hang, false, false, false),
+            (Crash, false, false, false),
+        ];
+        for (reason, on_rl, on_op, suppress) in table {
+            assert_eq!(
+                reason.auto_clears_on(RateLimitLifted),
+                *on_rl,
+                "{reason:?} auto_clears_on(RateLimitLifted)"
+            );
+            assert_eq!(
+                reason.auto_clears_on(OperatorResolved),
+                *on_op,
+                "{reason:?} auto_clears_on(OperatorResolved)"
+            );
+            assert_eq!(
+                reason.suppresses_hang_check(),
+                *suppress,
+                "{reason:?} suppresses_hang_check"
+            );
+        }
+
+        // #1564/#1621 guard restated explicitly: an operator-action reason must
+        // NOT clear on a rate-limit lift, and a throttle reason must NOT clear on
+        // operator resolution.
+        assert!(
+            !AwaitingOperator.auto_clears_on(RateLimitLifted),
+            "#1564: AwaitingOperator must survive an unrelated rate-limit lift"
+        );
+        assert!(
+            !QuotaExceeded.auto_clears_on(OperatorResolved),
+            "throttle reason must not be cleared by operator-resolution"
+        );
     }
 }


### PR DESCRIPTION
## #1638 (refactor-scout R4) — kills the #1621 set-without-clear latch class structurally

`BlockedReason`'s per-variant policy was three hardcoded `matches!` (two clear axes + one hang-suppress), so a NEW variant silently inherited "never auto-clears / never suppresses" with no compile nudge — exactly how #1621 latched `RateLimit` forever.

### Now on the type (all **wildcard-free** — the forcing function)
- **`RecoverySignal { RateLimitLifted, OperatorResolved }`** — the two independent recovery axes. A single "recovered?" bool would conflate them: the watchdog axis must NOT clear `AwaitingOperator` (#1564), but the supervisor axis MUST (#1552). (This corrected the original single-axis framing in the spike.)
- **`auto_clears_on(&self, signal) -> bool`** replaces the `matches!` at `watchdog.rs` (rate-limit axis, #1621) and `supervisor.rs` (operator-resolution axis, #1552).
- **`suppresses_hang_check(&self) -> bool`** replaces the `matches!` in `HealthTracker::check_hang`.

A new `BlockedReason` variant now fails to compile in both methods until it declares its clear-policy (both axes) AND its hang-suppress-policy.

### Behavior-preserving — the table IS the spec
`blocked_reason_policy_table_1638` asserts every variant×signal cell matches today's behavior:

| variant | clears on RateLimitLifted | clears on OperatorResolved | suppresses hang |
|---|---|---|---|
| RateLimit / QuotaExceeded | ✅ | ✗ | ✅ |
| AwaitingOperator | ✗ (#1564) | ✅ (#1552) | ✅ |
| PermissionPrompt / Hang / Crash | ✗ | ✗ | ✗ |

The existing #1564/#1621/#1552 watchdog+supervisor behavioral tests stay green (101 in those modules).

### Review-confirm / possible follow-up (NOT changed here)
`PermissionPrompt` does not auto-clear on InteractivePrompt resolution today (supervisor clears only `AwaitingOperator`). Preserved as-is — flag if it should be its own issue.

### Preflight
- `cargo fmt --check` clean; `cargo clippy --all-targets --features tray -D warnings` clean
- `cargo test --tests --features tray`: **3388 passed, 0 failed** (real git)

Daemon behavior — the live clear paths need rebuild+restart to exercise; the exhaustive-match forcing function + table test are the in-PR proof. Base is 4812adc; no overlap with the just-merged #1637 (dispatch_idle enum), so it merges clean.

Closes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)