### PR TITLE
refactor(#1642): dedup block_on_value into channel::shared_async

### DIFF
--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -398,34 +398,18 @@ fn discord_runtime() -> &'static tokio::runtime::Runtime {
 }
 
 /// #1476: run a Discord async call to completion, safe even when already inside
-/// a tokio runtime. `discord_runtime()` is a `current_thread` runtime, so
-/// calling `block_on` on it from within *any* runtime context panics with
-/// "Cannot start a runtime from within a runtime" (the same teloxide-0.17-class
-/// failure telegram hit in #1474). When a runtime is current, run the future on
-/// a dedicated scoped thread with its own fresh runtime — never nested. The
-/// non-nested fast path (shared runtime) is unchanged. Mirrors telegram's
-/// `state::block_on_value`; every shared-runtime `block_on` in this module MUST
-/// go through here (enforced by `tests/block_on_runtime_guard_invariant.rs`).
+/// a tokio runtime.
+///
+/// #1642: delegates to the shared [`crate::channel::shared_async::block_on_value`]
+/// helper (deduped from the byte-identical telegram/discord copies — discord had
+/// inherited telegram's nested-runtime panic AND its fix). See that helper for
+/// the `current_thread` nested-runtime guard rationale.
 fn block_on_value<F>(fut: F) -> F::Output
 where
     F: std::future::Future + Send,
     F::Output: Send,
 {
-    if tokio::runtime::Handle::try_current().is_ok() {
-        std::thread::scope(|s| {
-            s.spawn(|| {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("discord nested runtime")
-                    .block_on(fut)
-            })
-            .join()
-            .expect("discord nested block_on thread panicked")
-        })
-    } else {
-        discord_runtime().block_on(fut)
-    }
+    crate::channel::shared_async::block_on_value(discord_runtime(), "discord", fut)
 }
 
 impl crate::channel::Channel for DiscordChannel {

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -38,6 +38,9 @@ pub mod dedup;
 #[cfg(feature = "discord")]
 pub mod discord;
 pub mod event;
+/// #1642: shared sync→async bridge (`block_on_value`) used by both telegram and
+/// discord — deduped from per-channel copies.
+pub(crate) mod shared_async;
 pub mod sink_registry;
 pub mod telegram;
 pub mod ux_event;

--- a/src/channel/shared_async.rs
+++ b/src/channel/shared_async.rs
@@ -1,0 +1,50 @@
+//! #1642: the shared sync→async bridge for channel runtimes — single source for
+//! the `block_on_value` helper that telegram (#1474) and discord (#1476)
+//! previously shipped as byte-identical copies (the copy-paste-the-bug class:
+//! discord inherited telegram's nested-runtime panic AND later its fix).
+//!
+//! `telegram_runtime()` / `discord_runtime()` are shared `current_thread`
+//! runtimes, so calling `block_on` on one from within *any* tokio runtime
+//! context panics with "Cannot start a runtime from within a runtime" (surfaced
+//! by the teloxide 0.17 / reqwest 0.12 upgrade, #1293). The guard below detects
+//! a current runtime and runs the future on a dedicated scoped thread with its
+//! own *fresh* runtime, which is never nested. The non-nested fast path (the
+//! shared runtime) is unchanged.
+//!
+//! HARD RULE (see CLAUDE.md): every value-returning shared-runtime `block_on`
+//! in a channel module MUST go through here. Enforced by
+//! `tests/block_on_runtime_guard_invariant.rs`, which additionally pins that
+//! THIS helper keeps its `Handle::try_current` + `thread::scope` guard.
+
+use std::future::Future;
+use tokio::runtime::Runtime;
+
+/// Run `fut` to completion on `runtime`, safe even when already inside a tokio
+/// runtime. `runtime` is the shared per-channel `current_thread` runtime;
+/// `label` names the channel for panic messages (e.g. `"telegram"`).
+///
+/// When a runtime is already current, the future runs on a fresh scoped-thread
+/// runtime (never nested); otherwise it uses `runtime` directly. Behaviour is
+/// byte-for-byte the same as the per-channel copies this replaced, modulo the
+/// `label` in the (cold-path) panic strings.
+pub(crate) fn block_on_value<F>(runtime: &Runtime, label: &str, fut: F) -> F::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    if tokio::runtime::Handle::try_current().is_ok() {
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap_or_else(|e| panic!("{label} nested runtime build failed: {e}"))
+                    .block_on(fut)
+            })
+            .join()
+            .unwrap_or_else(|_| panic!("{label} nested block_on thread panicked"))
+        })
+    } else {
+        runtime.block_on(fut)
+    }
+}

--- a/src/channel/telegram/state.rs
+++ b/src/channel/telegram/state.rs
@@ -54,34 +54,16 @@ where
 /// Value-returning counterpart of [`spawn_or_block_on`] for Telegram calls
 /// that must return a result (topic create, get_me, send-capturing-id, …).
 ///
-/// Safe to call even when already inside a tokio runtime: the shared
-/// Telegram runtime is a `current_thread` runtime, so calling `block_on`
-/// on it from within *any* runtime context panics with "Cannot start a
-/// runtime from within a runtime" (surfaced after the teloxide 0.17 /
-/// reqwest 0.12 upgrade, #1293). In that case we run the future on a
-/// dedicated scoped thread with its own fresh runtime, which is never
-/// nested. The non-nested fast path is unchanged (shared runtime), so
-/// existing behaviour is preserved byte-for-byte off the hot path.
+/// #1642: delegates to the shared [`crate::channel::shared_async::block_on_value`]
+/// helper (deduped from the byte-identical telegram/discord copies). Safe even
+/// when already inside a tokio runtime — see that helper for the nested-runtime
+/// guard rationale (#1474/#1476).
 pub(super) fn block_on_value<F>(fut: F) -> F::Output
 where
     F: std::future::Future + Send,
     F::Output: Send,
 {
-    if tokio::runtime::Handle::try_current().is_ok() {
-        std::thread::scope(|s| {
-            s.spawn(|| {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("telegram nested runtime")
-                    .block_on(fut)
-            })
-            .join()
-            .expect("telegram nested block_on thread panicked")
-        })
-    } else {
-        telegram_runtime().block_on(fut)
-    }
+    crate::channel::shared_async::block_on_value(telegram_runtime(), "telegram", fut)
 }
 
 pub struct TelegramState {

--- a/tests/block_on_runtime_guard_invariant.rs
+++ b/tests/block_on_runtime_guard_invariant.rs
@@ -16,6 +16,16 @@
 //! `rt.block_on` (a freshly-built, never-shared runtime) does not match the
 //! `_runtime().block_on` marker and is intentionally exempt — a non-shared
 //! runtime is never nested.
+//!
+//! #1642: the canonical `block_on_value` helper was extracted from the
+//! byte-identical telegram/discord copies into `channel::shared_async`, where it
+//! does `runtime.block_on(fut)` on a passed-in `&Runtime` — which does NOT match
+//! the `_runtime().block_on` marker. So the MARKER scan no longer verifies the
+//! central helper is guarded. `shared_helper_is_handle_guarded` closes that gap:
+//! it pins that `channel/shared_async.rs::block_on_value` keeps its
+//! `Handle::try_current` + `thread::scope` guard, so the one place that actually
+//! runs a shared-runtime `block_on` can't be silently de-guarded. The MARKER
+//! scan still catches any NEW raw `*_runtime().block_on` added outside it.
 
 use std::path::{Path, PathBuf};
 
@@ -94,8 +104,33 @@ fn shared_runtime_block_on_must_be_handle_guarded() {
     assert!(
         violations.is_empty(),
         "#1476: unguarded shared-runtime block_on found — every `<name>_runtime().block_on` \
-         must go through a Handle-guarded helper (e.g. `block_on_value`, mirroring telegram \
-         state.rs / discord.rs) so it can't panic from within a tokio runtime:\n{}",
+         must go through the Handle-guarded `channel::shared_async::block_on_value` helper \
+         so it can't panic from within a tokio runtime:\n{}",
         violations.join("\n")
+    );
+}
+
+/// #1642: the extracted central helper runs `runtime.block_on(fut)` on a
+/// passed-in `&Runtime`, which the MARKER scan above does not match. Pin that it
+/// keeps its nested-runtime guard so it can't be de-guarded silently — the
+/// single place that actually performs a shared-runtime `block_on`.
+#[test]
+fn shared_helper_is_handle_guarded() {
+    let helper = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/channel/shared_async.rs");
+    let content = std::fs::read_to_string(&helper)
+        .expect("#1642: channel/shared_async.rs must exist (the deduped block_on_value helper)");
+    assert!(
+        content.contains("fn block_on_value"),
+        "#1642: shared_async.rs must define `block_on_value`"
+    );
+    assert!(
+        content.contains("Handle::try_current"),
+        "#1642: shared_async::block_on_value must keep its `Handle::try_current` guard \
+         (never call `runtime.block_on` unguarded — that reintroduces the #1474/#1476 panic)"
+    );
+    assert!(
+        content.contains("thread::scope"),
+        "#1642: shared_async::block_on_value must run the nested case on a fresh scoped-thread \
+         runtime (`thread::scope`), never nesting on the shared runtime"
     );
 }


### PR DESCRIPTION
## What
`telegram/state.rs` and `discord.rs` shipped **byte-identical** `block_on_value` helpers (differing only in the panic label + the runtime accessor). Extract to `src/channel/shared_async.rs::block_on_value(runtime, label, fut)`; both channels keep thin delegating wrappers (zero call-site churn).

## Why (the bug class)
This is the **#1474→#1476 copy-paste-the-bug** class: discord inherited telegram's nested-runtime panic *and*, later, its fix. A third channel (Slack/Matrix) would have to rediscover or re-copy the `current_thread`-runtime contract — exactly the failure mode that produced #1476. One source of truth closes it.

## Pure dedup, no behavior change
Behaviour is byte-for-byte identical modulo the `label` in the **cold-path** panic strings. (`.expect(&format!(..))` would trip `clippy::expect_fun_call`, so the label panics use `unwrap_or_else(|_| panic!())`.) The telegram-only `spawn_or_block_on` (a different helper) is untouched.

## ⚠ Invariant kept GREEN *and* STILL ENFORCING (the flagged risk)
`tests/block_on_runtime_guard_invariant.rs` scans for `_runtime().block_on` (MARKER) and requires a Handle guard in the enclosing fn.
- After extraction the helper does `runtime.block_on(fut)` on a passed-in `&Runtime` (**no** `_runtime().block_on` match) and call sites become `block_on_value(telegram_runtime(), …)` (no `.block_on` suffix). So the MARKER scan now correctly finds only the still-guarded `spawn_or_block_on` + ci_watch provider sites → **green**, and it **still catches any NEW raw `*_runtime().block_on`** added outside the helper.
- That left one gap: the MARKER no longer verifies the *central helper* is guarded. **Added `shared_helper_is_handle_guarded`** — pins that `shared_async.rs` keeps its `Handle::try_current` + `thread::scope` guard, so the single place that actually runs a shared-runtime `block_on` can't be silently de-guarded. **Net enforcement ≥ before.**

## Preflight
`cargo fmt`; `clippy --all-targets -- -D warnings` clean for **both** `--features tray` and `--features tray,discord` (discord.rs is feature-gated); invariant (both fns) + telegram `block_on_value` nested/outside tests + 198 channel tests pass.

Closes #1642

🤖 Generated with [Claude Code](https://claude.com/claude-code)