### PR TITLE
fix(#1634): detect & surface discontinued/unsupported-model errors

### DIFF
--- a/src/daemon/watchdog.rs
+++ b/src/daemon/watchdog.rs
@@ -39,10 +39,20 @@ pub fn run_watchdog_pass(
 ) {
     let reason = crate::state::classify_pty_output(backend, screen);
 
+    // #1634: model-unsupported is HIGH_FP + never-auto-clearing + hang-suppressing.
+    // Drive its latch from the RED-ANCHORED live `AgentState` (the StateTracker
+    // applied the #919 red gate to reach `ModelUnsupported`), NOT the colorless
+    // `classify_pty_output` — a plain-text prose mention of the error wording has
+    // no color, so routing the latch through the state inherits the FP boundary.
+    let model_unsupported = current_state == AgentState::ModelUnsupported;
+
     if dry_run {
         // Observability only — never mutate health (no set, no clear).
         if let Some(reason) = reason {
             crate::event_log::log(home, "watchdog_dry_run", agent_name, &format!("{reason:?}"));
+        }
+        if model_unsupported {
+            crate::event_log::log(home, "watchdog_dry_run", agent_name, "ModelUnsupported");
         }
         return;
     }
@@ -68,9 +78,47 @@ pub fn run_watchdog_pass(
         health.clear_blocked_reason();
     }
 
+    // #1634: surface model-unsupported. Transition-gated so the operator notify
+    // fires ONCE on entry, not every tick (the red-gated state re-matches while
+    // the error is on screen). Handled before the classify latch and returns —
+    // ModelUnsupported is the dominant, manual-clear-only reason for this agent.
+    if model_unsupported {
+        let already = matches!(
+            health.current_reason,
+            Some(crate::health::BlockedReason::ModelUnsupported)
+        );
+        health.set_blocked_reason(crate::health::BlockedReason::ModelUnsupported);
+        if !already {
+            notify_model_unsupported(home, agent_name, backend);
+        }
+        return;
+    }
+
     if let Some(reason) = reason {
         health.set_blocked_reason(reason);
     }
+}
+
+/// #1634: one-line operator notice on the transition into `ModelUnsupported`.
+/// Mirrors `conflict_notify`: a `System` `notify_agent` surfaces to the
+/// operator via the agent's channel binding. The agent itself can't act (it
+/// errors every turn) — the operator must change the configured model.
+fn notify_model_unsupported(home: &Path, agent_name: &str, backend: &Backend) {
+    let text = format!(
+        "[model-unsupported] agent `{agent_name}` (backend {}): the configured model is \
+         rejected by the provider (e.g. `invalid_request_error` / \"model is not supported\"). \
+         The agent will ERROR every turn until you change its model — agent_state stays Idle but \
+         it is NOT healthy. Fix the model, then restart the agent (or `health action=clear` once \
+         resolved).",
+        backend.name()
+    );
+    let source = crate::inbox::NotifySource::System("model_unsupported");
+    crate::inbox::notify_agent(home, agent_name, &source, &text);
+    tracing::error!(
+        agent = agent_name,
+        backend = backend.name(),
+        "#1634: ModelUnsupported detected — configured model rejected by provider; operator must change the model"
+    );
 }
 
 #[cfg(test)]
@@ -350,6 +398,50 @@ mod tests {
         assert!(
             !super::watchdog_dry_run_from_env(),
             "unset AGEND_WATCHDOG_DRY_RUN should return false"
+        );
+    }
+
+    /// #1634: a red-gated `AgentState::ModelUnsupported` latches the
+    /// `ModelUnsupported` BlockedReason, and — unlike a rate-limit latch — it
+    /// must NOT auto-clear when the agent next reads Idle (it never auto-clears;
+    /// only an operator model change + respawn `reset()` clears it).
+    #[test]
+    fn model_unsupported_latches_and_never_auto_clears_1634() {
+        let home = tmp_home("model-unsupported");
+        let mut health = HealthTracker::new();
+        let backend = Backend::Codex;
+
+        // Red-gated state arrives as ModelUnsupported → latch (+ one-time notify).
+        run_watchdog_pass(
+            &home,
+            "dev",
+            &backend,
+            "screen",
+            &mut health,
+            false,
+            AgentState::ModelUnsupported,
+        );
+        assert!(
+            matches!(health.current_reason, Some(BlockedReason::ModelUnsupported)),
+            "ModelUnsupported state must latch the BlockedReason, got {:?}",
+            health.current_reason
+        );
+
+        // Agent next reads Idle (recovered_from_rate_limit == true). A rate-limit
+        // latch would auto-clear here; ModelUnsupported must persist.
+        run_watchdog_pass(
+            &home,
+            "dev",
+            &backend,
+            "screen",
+            &mut health,
+            false,
+            AgentState::Idle,
+        );
+        assert!(
+            matches!(health.current_reason, Some(BlockedReason::ModelUnsupported)),
+            "#1634: ModelUnsupported must persist through Idle (never auto-clears), got {:?}",
+            health.current_reason
         );
     }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -206,6 +206,11 @@ pub enum BlockedReason {
     AwaitingOperator,
     PermissionPrompt,
     Crash,
+    /// #1634: the backend's configured model is rejected by the provider
+    /// (discontinued/unsupported model id). Set from the red-anchored
+    /// `AgentState::ModelUnsupported`. Manual-clear-only and hang-suppressing —
+    /// see `auto_clears_on` / `suppresses_hang_check`.
+    ModelUnsupported,
 }
 
 /// #1638: which recovery signal a [`BlockedReason`] is being tested against.
@@ -233,6 +238,7 @@ impl BlockedReason {
             "permission_prompt" => Some(Self::PermissionPrompt),
             "hang" => Some(Self::Hang),
             "crash" => Some(Self::Crash),
+            "model_unsupported" => Some(Self::ModelUnsupported),
             _ => None,
         }
     }
@@ -245,6 +251,7 @@ impl BlockedReason {
             Self::AwaitingOperator => "awaiting_operator",
             Self::PermissionPrompt => "permission_prompt",
             Self::Crash => "crash",
+            Self::ModelUnsupported => "model_unsupported",
         }
     }
 
@@ -273,7 +280,13 @@ impl BlockedReason {
                 matches!(signal, RecoverySignal::RateLimitLifted)
             }
             Self::AwaitingOperator => matches!(signal, RecoverySignal::OperatorResolved),
-            Self::PermissionPrompt | Self::Hang | Self::Crash => false,
+            // #1634: ModelUnsupported never auto-clears on EITHER axis. A rate-
+            // limit lift doesn't fix a bad model id, and there is no "ready
+            // again" operator-resolution transition (the agent keeps erroring) —
+            // the operator must change the configured model, then the agent
+            // restarts and `HealthTracker::reset()` clears it on respawn. So it
+            // joins the manual-clear-only class with PermissionPrompt/Hang/Crash.
+            Self::PermissionPrompt | Self::Hang | Self::Crash | Self::ModelUnsupported => false,
         }
     }
 
@@ -285,7 +298,17 @@ impl BlockedReason {
     /// suppress; PermissionPrompt/Hang/Crash do not.
     pub fn suppresses_hang_check(&self) -> bool {
         match self {
-            Self::RateLimit { .. } | Self::QuotaExceeded | Self::AwaitingOperator => true,
+            // #1634: ModelUnsupported suppresses hang-check (stuck-but-not-hung —
+            // the model rejection explains the output silence; we don't want
+            // hang-detection ALSO firing/escalating on top of the model-unsupported
+            // notify). NOTE the deliberate novel combination: it NEVER auto-clears
+            // (above, like Crash) yet DOES suppress hang (here, like RateLimit) —
+            // no prior variant pairs those, which is exactly why #1638's
+            // wildcard-free axes force this to be declared explicitly.
+            Self::RateLimit { .. }
+            | Self::QuotaExceeded
+            | Self::AwaitingOperator
+            | Self::ModelUnsupported => true,
             Self::PermissionPrompt | Self::Hang | Self::Crash => false,
         }
     }
@@ -1194,6 +1217,7 @@ mod tests {
             BlockedReason::AwaitingOperator,
             BlockedReason::PermissionPrompt,
             BlockedReason::Crash,
+            BlockedReason::ModelUnsupported,
         ];
         for reason in cases {
             let json = serde_json::to_string(&reason).expect("serialize");
@@ -1635,6 +1659,10 @@ mod tests {
             (PermissionPrompt, false, false, false),
             (Hang, false, false, false),
             (Crash, false, false, false),
+            // #1634: the novel never-auto-clears (false/false) + suppresses-hang
+            // (true) combination — manual-clear-only like Crash, but suppresses
+            // hang-check like RateLimit (stuck-but-not-hung).
+            (ModelUnsupported, false, false, true),
         ];
         for (reason, on_rl, on_op, suppress) in table {
             assert_eq!(

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -48,6 +48,9 @@ pub fn state_color(state: AgentState) -> Color {
             Color::Indexed(208)
         }
         AgentState::UsageLimit | AgentState::AuthError | AgentState::ApiError => Color::Red,
+        // #1634: model-unsupported is a permanent config fault — red like the
+        // other error states.
+        AgentState::ModelUnsupported => Color::Red,
         AgentState::Hang | AgentState::Crashed | AgentState::Restarting => Color::Red,
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -62,6 +62,13 @@ pub enum AgentState {
     UsageLimit,
     AuthError,
     ApiError,
+    /// #1634: the backend's configured model is rejected by the provider
+    /// (discontinued / unsupported / typo'd model id). Distinct from `AuthError`
+    /// (credentials are fine) and `ApiError` (transient) because it is a
+    /// PERMANENT config fault: the agent errors every turn until the operator
+    /// changes the model. HIGH_FP (see `is_high_fp_state`) — requires the #919
+    /// red anchor so an agent merely discussing the error wording can't latch it.
+    ModelUnsupported,
     Crashed,
     Restarting,
 }
@@ -105,6 +112,10 @@ impl AgentState {
             Self::UsageLimit => 11,
             Self::AuthError => 12,
             Self::ApiError => 13,
+            // #1634: error class (instant transition, no hysteresis); shares the
+            // ApiError tier — display ordering only, first-match in `detect()`
+            // is the real gate.
+            Self::ModelUnsupported => 13,
             Self::Crashed => 14,
             Self::Restarting => 15,
         }
@@ -144,6 +155,7 @@ impl AgentState {
             Self::RateLimit => "rate_limit",
             Self::ServerRateLimit => "server_rate_limit",
             Self::UsageLimit => "usage_limit",
+            Self::ModelUnsupported => "model_unsupported",
             Self::AuthError => "auth_error",
             Self::ApiError => "api_error",
             Self::Crashed => "crashed",
@@ -314,7 +326,16 @@ fn oscillation_guard_window() -> Duration {
 fn is_high_fp_state(state: AgentState) -> bool {
     matches!(
         state,
-        AgentState::ServerRateLimit | AgentState::RateLimit | AgentState::ContextFull
+        AgentState::ServerRateLimit
+            | AgentState::RateLimit
+            | AgentState::ContextFull
+            // #1634: the model-unsupported wordings (`invalid_request_error`,
+            // `model is not supported`) appear verbatim in dialectic prose / when
+            // an agent works on THIS detection code, so require the red anchor.
+            // Critical here: ModelUnsupported never auto-clears and suppresses
+            // hang-check, so a FP would silently disable a healthy agent — the
+            // anchor is the FP boundary.
+            | AgentState::ModelUnsupported
     )
 }
 

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -364,6 +364,17 @@ impl StatePatterns {
                 ),
                 // [docs] Context overflow error
                 (AgentState::ContextFull, r"ContextOverflow"),
+                // #1634 [実測 incident]: the configured model was discontinued
+                // (`gpt-5.3-codex` went unsupported on the ChatGPT account).
+                // codex prints these OpenAI error wordings then drops back to the
+                // `›` prompt, so this must rank ABOVE Idle/Ready (first-match
+                // wins). HIGH_FP (`is_high_fp_state`) → gated on the #919 red
+                // anchor so a codex agent merely DISCUSSING these strings (incl.
+                // working on this file) does not latch the never-clearing reason.
+                (
+                    AgentState::ModelUnsupported,
+                    r"invalid_request_error|model is not supported|Model metadata for .*? not found",
+                ),
                 // [measured] Codex 0.120.0 renders its approval dialog with a
                 // distinctive header (`Would you like to run the following
                 // command?`), a footer (`Press enter to confirm or esc to

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -1678,6 +1678,7 @@ fn parse_state(name: &str) -> AgentState {
         "usage_limit" => AgentState::UsageLimit,
         "auth_error" => AgentState::AuthError,
         "api_error" => AgentState::ApiError,
+        "model_unsupported" => AgentState::ModelUnsupported,
         "crashed" => AgentState::Crashed,
         "restarting" => AgentState::Restarting,
         other => panic!("unknown state name in manifest: {other}"),
@@ -2705,6 +2706,74 @@ fn matched_span_has_red_detects_any_red_occurrence() {
     assert!(!super::matched_span_has_red(screen, "ab", &fg_plain));
     // Empty phrase → false (guard).
     assert!(!super::matched_span_has_red(screen, "", &fg));
+}
+
+// ── #1634: model-unsupported detection + red-anchor FP boundary ─────
+
+/// #1634: a red-rendered codex model-unsupported error latches
+/// `ModelUnsupported`; the SAME wording WITHOUT red must NOT latch (the FP
+/// boundary — this reason never auto-clears and suppresses hang-check, so a
+/// codex agent merely discussing the error wording must not silently disable
+/// itself). Text-only feed fails open (pre-#919 contract).
+#[test]
+fn codex_model_unsupported_red_anchor_fp_boundary_1634() {
+    let screen = "invalid_request_error: model is not supported";
+    let n = screen.chars().count();
+    let phrase = "invalid_request_error"; // regex's leftmost match
+    let plen = phrase.chars().count();
+
+    // RED over the matched phrase → latches ModelUnsupported.
+    let mut fg_red = vec![CellFg::Default; n];
+    for c in fg_red.iter_mut().take(plen) {
+        *c = CellFg::Red;
+    }
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    t.feed_with_fg(screen, &fg_red);
+    assert_eq!(
+        t.get_state(),
+        AgentState::ModelUnsupported,
+        "red-rendered codex model error must latch ModelUnsupported"
+    );
+
+    // NO RED (plain) → FP boundary: must NOT latch the never-clearing reason.
+    let mut t2 = StateTracker::new(Some(&Backend::Codex));
+    let fg_plain = vec![CellFg::Default; n];
+    t2.feed_with_fg(screen, &fg_plain);
+    assert_ne!(
+        t2.get_state(),
+        AgentState::ModelUnsupported,
+        "#1634: same wording without red must NOT latch (prose / dogfood FP boundary)"
+    );
+
+    // Text-only feed (empty fg mask) fails open per the #919/#1450 contract.
+    let mut t3 = StateTracker::new(Some(&Backend::Codex));
+    t3.feed(screen);
+    assert_eq!(
+        t3.get_state(),
+        AgentState::ModelUnsupported,
+        "text-only feed (no color mask) fails open and fires"
+    );
+}
+
+/// #1634: the captured-incident fixture (codex error rendered RED) driven
+/// through the production vterm → `tail_lines_with_fg` → `feed_with_fg` path
+/// must latch `ModelUnsupported`. End-to-end regression pin for the real
+/// silent-error incident (the red SGR is resolved by the vterm, not hand-fed).
+#[test]
+fn codex_model_unsupported_fixture_replay_1634() {
+    let bytes = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/state-replay/codex-model-unsupported.raw"
+    ))
+    .expect("read codex-model-unsupported.raw fixture");
+    let mut vt = VTerm::new(80, 24);
+    let mut st = StateTracker::new(Some(&Backend::Codex));
+    drive(&mut vt, &mut st, &bytes);
+    assert_eq!(
+        st.get_state(),
+        AgentState::ModelUnsupported,
+        "#1634: the red-rendered codex model-unsupported incident must latch ModelUnsupported"
+    );
 }
 
 // ── #685 PR-2: F9 productive-marker freshness/dedup ─────────────────

--- a/tests/fixtures/state-replay/MANIFEST.yaml
+++ b/tests/fixtures/state-replay/MANIFEST.yaml
@@ -835,3 +835,22 @@ fixtures:
     # asserts None — what we want here.
     capture_kind: synthetic
     provenance: "#848 PR-B regression-proof — prose containing rate-limit substrings, expected Starting (NOT RateLimit)"
+
+  - file: codex-model-unsupported.raw
+    backend: codex
+    cli_version: "0.135.0"
+    recorded_on: "2026-06-02"
+    scenario: |
+      #1634: codex pane shows a discontinued/unsupported configured model
+      (gpt-5.3-codex went unsupported on the ChatGPT account). The error is
+      rendered RED (`invalid_request_error` / "model is not supported" /
+      "Model metadata for gpt-5.3-codex not found") then codex drops back to
+      the `›` prompt. Pre-#1634 this matched NO pattern → agent_state read Idle
+      (the `›`) and no BlockedReason latched → silent. Now the red-anchored
+      ModelUnsupported pattern fires (HIGH_FP: requires the #919 red SGR, so a
+      codex agent merely DISCUSSING the wording does NOT latch).
+    expected_transitions: [starting, model_unsupported]
+    expected_final_state: model_unsupported
+    expected_final_detect: model_unsupported
+    capture_kind: synthetic_from_incident
+    provenance: "#1634 — synthetic reconstruction of the codex model-unsupported incident (exact wording + red SGR)"

--- a/tests/fixtures/state-replay/codex-model-unsupported.raw
+++ b/tests/fixtures/state-replay/codex-model-unsupported.raw
@@ -1,0 +1,7 @@
+[2J[H[1mOpenAI Codex[0m v0.135.0  (model: gpt-5.3-codex)
+
+[2m›[0m run the migration
+
+[31mstream error: invalid_request_error: model is not supported; Model metadata for gpt-5.3-codex not found. Reconfigure the model and restart the session.[0m
+
+[2m›[0m [0m

--- a/tests/state_pattern_coverage.rs
+++ b/tests/state_pattern_coverage.rs
@@ -14,6 +14,7 @@ const EXPECTED_FIXTURES: &[&str] = &[
     "codex-tooluse.raw",
     "codex-update.raw",
     "codex-perm.raw",
+    "codex-model-unsupported.raw",
     "gemini-thinking.raw",
     "gemini-tooluse.raw",
     "kiro-thinking.raw",


### PR DESCRIPTION
## Problem (today's incident)
codex's configured model `gpt-5.3-codex` went unsupported on the ChatGPT account. codex printed `invalid_request_error` / "model is not supported" / "Model metadata for \`<model>\` not found" then dropped back to its `›` prompt. These matched **no** state pattern → live `AgentState` read **Idle**, `classify_pty_output` returned **None** → no `BlockedReason` latched, nothing notified. The agent errored every turn while showing **healthy/idle**; only a manual `pane_snapshot` found it, and the review gate stalled with no surfaced reason.

## Fix — detection + surfacing (rides the existing per-tick watchdog)
- **New `AgentState::ModelUnsupported`** (error class, priority 13) + codex pattern ranked **above** Idle/Ready. Marked **HIGH_FP** (`is_high_fp_state`) so the **#919 red-SGR anchor is required** before it latches — a codex agent merely *discussing* the wording (incl. working on this file) does not trip it.
- **New `BlockedReason::ModelUnsupported`** with the #1638 policy:

  | axis | value | why |
  |---|---|---|
  | `auto_clears_on(RateLimitLifted)` | **false** | not a throttle |
  | `auto_clears_on(OperatorResolved)` | **false** | no "ready again" — operator must change the model; `reset()` on respawn clears it (manual-clear-only, like Crash/Hang) |
  | `suppresses_hang_check()` | **true** | stuck-but-not-hung; the block explains the silence |

  This **never-clears + suppresses-hang** combination is novel — no prior variant pairs them — exactly what #1638's wildcard-free axes force to be declared explicitly (commented in code).
- The **watchdog latches from the RED-ANCHORED live `AgentState`** (not the colorless `classify_pty_output`), inheriting the StateTracker's #919 FP gate. **Transition-gated** one-line operator notify (mirrors `conflict_notify`) fires **once** on entry, not every tick.

## Scope
**codex only** (the confirmed incident). claude (`not_found_error`) / gemini (`NOT_FOUND`) analogues are a **separate fixture-gated follow-up** — unverified regex now = FP risk with no capture to pin (lead is filing it).

## Tests
- **Red-anchor FP boundary** (`codex_model_unsupported_red_anchor_fp_boundary_1634`): red→latches / same wording **no-red→does NOT latch** / text-only→fails-open.
- **Captured-incident fixture** `codex-model-unsupported.raw` (red SGR) replayed **end-to-end through vterm → ModelUnsupported**, pinned by a direct test **and** `replay_manifest_regression` (transition sequence `[starting, model_unsupported]`).
- **#1638 policy-table row** `(ModelUnsupported, false, false, true)`, serde round-trip, and a **watchdog latch + never-auto-clear** test (persists through Idle).

Live post-restart validation is the daemon-behavior proof; the table + detection + fixture-replay tests are the in-PR proof.

## Preflight
`cargo fmt`; `clippy --all-targets -- -D warnings` clean for **both** `--features tray` and `--features tray,discord`; state(263) / health(37) / watchdog(71) / render(42) + fixture-coverage/corpus tests pass.

Closes #1634

🤖 Generated with [Claude Code](https://claude.com/claude-code)