### PR TITLE
fix(#1647): persist_or_log the 11 real silent-loss persist drops

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -187,8 +187,13 @@ pub fn save_metadata(home: &Path, instance_name: &str, key: &str, value: Value) 
         .unwrap_or(json!({}));
     meta[key] = value;
     let content = serde_json::to_string_pretty(&meta).unwrap_or_default();
-    // M1: atomic write with fsync
-    let _ = crate::store::atomic_write(&meta_path, content.as_bytes());
+    // M1: atomic write with fsync. #1647: log on failure — this metadata is read
+    // back by `merge_metadata`, and the MCP set_* handlers return OK regardless,
+    // so a dropped write was a silent operator-set-but-lost.
+    persist_or_log!(
+        crate::store::atomic_write(&meta_path, content.as_bytes()),
+        "save_metadata"
+    );
 }
 
 /// Persist multiple metadata key/value pairs in a single atomic write.
@@ -205,8 +210,11 @@ pub fn save_metadata_batch(home: &Path, instance_name: &str, entries: &[(&str, V
         meta[*key] = value.clone();
     }
     let content = serde_json::to_string_pretty(&meta).unwrap_or_default();
-    // M1: atomic write with fsync
-    let _ = crate::store::atomic_write(&meta_path, content.as_bytes());
+    // M1: atomic write with fsync. #1647: log on failure — see save_metadata.
+    persist_or_log!(
+        crate::store::atomic_write(&meta_path, content.as_bytes()),
+        "save_metadata_batch"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -43,10 +43,13 @@ fn store_path(home: &Path) -> std::path::PathBuf {
 
 /// Record a new delegation.
 pub fn track_dispatch(home: &Path, entry: DispatchEntry) {
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
-        store.entries.push(entry);
-        Ok(())
-    });
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+            store.entries.push(entry);
+            Ok(())
+        }),
+        "dispatch_track"
+    );
 }
 
 /// Mark a dispatch as completed (matched by task_id or to-instance).
@@ -55,17 +58,20 @@ pub fn mark_completed(home: &Path, correlation_id: Option<&str>, _to: &str) {
         Some(c) if !c.is_empty() => c,
         _ => return, // No correlation_id → can't match, let sweep continue tracking
     };
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
-        for entry in store.entries.iter_mut() {
-            if entry.status == "completed" {
-                continue;
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+            for entry in store.entries.iter_mut() {
+                if entry.status == "completed" {
+                    continue;
+                }
+                if entry.task_id.as_deref() == Some(cid) {
+                    entry.status = "completed".to_string();
+                }
             }
-            if entry.task_id.as_deref() == Some(cid) {
-                entry.status = "completed".to_string();
-            }
-        }
-        Ok(())
-    });
+            Ok(())
+        }),
+        "dispatch_mark_completed"
+    );
 }
 
 /// Sweep for stuck dispatches. Returns (warn_list, ask_list).
@@ -74,27 +80,30 @@ pub fn sweep_stuck(home: &Path) -> (Vec<DispatchEntry>, Vec<DispatchEntry>) {
     let mut warns = Vec::new();
     let mut asks = Vec::new();
 
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
-        for entry in store.entries.iter_mut() {
-            if entry.status == "completed" {
-                continue;
-            }
-            let delegated = match chrono::DateTime::parse_from_rfc3339(&entry.delegated_at) {
-                Ok(dt) => dt.with_timezone(&chrono::Utc),
-                Err(_) => continue,
-            };
-            let age_min = now.signed_duration_since(delegated).num_minutes();
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+            for entry in store.entries.iter_mut() {
+                if entry.status == "completed" {
+                    continue;
+                }
+                let delegated = match chrono::DateTime::parse_from_rfc3339(&entry.delegated_at) {
+                    Ok(dt) => dt.with_timezone(&chrono::Utc),
+                    Err(_) => continue,
+                };
+                let age_min = now.signed_duration_since(delegated).num_minutes();
 
-            if age_min >= DISPATCH_ASK_MINUTES && entry.status != "asked" {
-                entry.status = "asked".to_string();
-                asks.push(entry.clone());
-            } else if age_min >= DISPATCH_WARN_MINUTES && entry.status == "pending" {
-                entry.status = "warned".to_string();
-                warns.push(entry.clone());
+                if age_min >= DISPATCH_ASK_MINUTES && entry.status != "asked" {
+                    entry.status = "asked".to_string();
+                    asks.push(entry.clone());
+                } else if age_min >= DISPATCH_WARN_MINUTES && entry.status == "pending" {
+                    entry.status = "warned".to_string();
+                    warns.push(entry.clone());
+                }
             }
-        }
-        Ok(())
-    });
+            Ok(())
+        }),
+        "dispatch_sweep_stuck"
+    );
     (warns, asks)
 }
 
@@ -107,23 +116,26 @@ pub fn sweep_orphans(home: &Path) -> Vec<DispatchEntry> {
     let now = chrono::Utc::now();
     let mut orphans = Vec::new();
 
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
-        for entry in store.entries.iter_mut() {
-            if entry.status == "completed" || entry.status == "orphaned" {
-                continue;
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+            for entry in store.entries.iter_mut() {
+                if entry.status == "completed" || entry.status == "orphaned" {
+                    continue;
+                }
+                let delegated = match chrono::DateTime::parse_from_rfc3339(&entry.delegated_at) {
+                    Ok(dt) => dt.with_timezone(&chrono::Utc),
+                    Err(_) => continue,
+                };
+                let age_hours = now.signed_duration_since(delegated).num_hours();
+                if age_hours >= DISPATCH_ORPHAN_HOURS {
+                    entry.status = "orphaned".to_string();
+                    orphans.push(entry.clone());
+                }
             }
-            let delegated = match chrono::DateTime::parse_from_rfc3339(&entry.delegated_at) {
-                Ok(dt) => dt.with_timezone(&chrono::Utc),
-                Err(_) => continue,
-            };
-            let age_hours = now.signed_duration_since(delegated).num_hours();
-            if age_hours >= DISPATCH_ORPHAN_HOURS {
-                entry.status = "orphaned".to_string();
-                orphans.push(entry.clone());
-            }
-        }
-        Ok(())
-    });
+            Ok(())
+        }),
+        "dispatch_sweep_orphans"
+    );
     orphans
 }
 
@@ -137,14 +149,17 @@ pub fn sweep_orphans(home: &Path) -> Vec<DispatchEntry> {
 /// value once the instance is gone. Returns the number removed.
 pub fn cleanup_for_instance(home: &Path, instance: &str) -> usize {
     let mut removed = 0usize;
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
-        let before = store.entries.len();
-        store
-            .entries
-            .retain(|e| e.from != instance && e.to != instance);
-        removed = before - store.entries.len();
-        Ok(())
-    });
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+            let before = store.entries.len();
+            store
+                .entries
+                .retain(|e| e.from != instance && e.to != instance);
+            removed = before - store.entries.len();
+            Ok(())
+        }),
+        "dispatch_cleanup_for_instance"
+    );
     if removed > 0 {
         tracing::info!(
             %instance,
@@ -180,6 +195,9 @@ pub fn active_target_names(home: &Path) -> Vec<String> {
 pub fn gc_old_entries(home: &Path) {
     const RETENTION_DAYS: i64 = 30;
     let now = chrono::Utc::now();
+    // best-effort (#1647): unlike the sibling track/sweep/cleanup writes above,
+    // a dropped GC pass is harmless — it only delays pruning already-terminal
+    // rows, and the next maintenance tick retries. Intentionally not logged.
     let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
         store.entries.retain(|entry| {
             if entry.status != "completed" && entry.status != "orphaned" {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,15 +3,18 @@
 
 /// Log-and-continue for a persistence/enqueue call that is genuinely
 /// fire-and-forget — it runs inside a per-tick loop / event handler whose
-/// caller has no meaningful way to handle the `Err` (the #1630 silent-message-
-/// loss class: a dropped inbox `enqueue` `Result` means the message never lands
-/// on disk and the recipient never sees it).
+/// caller has no meaningful way to handle the `Err` (the #1630 silent-loss
+/// class: a dropped inbox `enqueue` `Result` means the message never lands on
+/// disk; #1647 extends it to dropped state persists — `atomic_write` /
+/// `mutate_versioned` whose loss the daemon/operator actually cares about, e.g.
+/// dispatch-tracking, schedule, and instance-metadata writes).
 ///
 /// On `Err`, emit a `tracing::error!` (not `warn!`) tagged with the `op` label
-/// — and the `target` recipient where one is in scope — so a dropped message is
-/// POST-HOC DIAGNOSABLE in the daemon log. This is a diagnosis breadcrumb, not
-/// loss-prevention; **where the enclosing fn returns `Result`, propagate the
-/// `Err` with `?`/`return` instead of using this macro.**
+/// — and the `target` where one is in scope — so the drop is POST-HOC
+/// DIAGNOSABLE in the daemon log. The message is op-agnostic (the `op` field
+/// says which call dropped); this is a diagnosis breadcrumb, not loss-
+/// prevention; **where the enclosing fn returns `Result`, propagate the `Err`
+/// with `?`/`return` instead of using this macro.**
 ///
 /// The happy path is unchanged — `Ok(_)` is discarded exactly as the prior
 /// `let _ = …` did; this only upgrades the silent drop to a logged drop.
@@ -22,17 +25,17 @@
 ///
 /// ```ignore
 /// persist_or_log!(crate::inbox::enqueue_with_idle_hint(home, target, msg), "schedule_replay", target);
-/// persist_or_log!(crate::inbox::enqueue(home, "general", msg), "boot_orphan_sweep");
+/// persist_or_log!(crate::store::atomic_write(&meta_path, content.as_bytes()), "save_metadata");
 /// ```
 macro_rules! persist_or_log {
     ($call:expr, $op:expr $(,)?) => {
         if let Err(e) = $call {
-            tracing::error!(error = %e, op = $op, "enqueue failed — message dropped (silent-loss #1630)");
+            tracing::error!(error = %e, op = $op, "op failed — result dropped (silent-loss #1630/#1647)");
         }
     };
     ($call:expr, $op:expr, $target:expr $(,)?) => {
         if let Err(e) = $call {
-            tracing::error!(error = %e, op = $op, target = %$target, "enqueue failed — message dropped (silent-loss #1630)");
+            tracing::error!(error = %e, op = $op, target = %$target, "op failed — result dropped (silent-loss #1630/#1647)");
         }
     };
 }

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -258,44 +258,47 @@ pub fn replay_missed_oneshots(home: &Path) -> Vec<Schedule> {
     let cutoff = now - chrono::Duration::hours(24);
     let mut to_replay = Vec::new();
 
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut ScheduleStore| {
-        for sched in store.schedules.iter_mut() {
-            if !sched.enabled {
-                continue;
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut ScheduleStore| {
+            for sched in store.schedules.iter_mut() {
+                if !sched.enabled {
+                    continue;
+                }
+                let at = match &sched.trigger {
+                    Trigger::Once { at } => at.clone(),
+                    Trigger::Cron { .. } => continue,
+                };
+                let at_utc = match chrono::DateTime::parse_from_rfc3339(&at) {
+                    Ok(dt) => dt.with_timezone(&chrono::Utc),
+                    Err(_) => continue,
+                };
+                if at_utc >= now {
+                    continue; // not missed yet
+                }
+                sched.enabled = false;
+                sched.updated_at = now.to_rfc3339();
+                if at_utc < cutoff {
+                    tracing::warn!(
+                        id = %sched.id,
+                        run_at = %at,
+                        "dropping stale one-shot schedule (>24h past)"
+                    );
+                    sched.run_history.push(ScheduleRun {
+                        triggered_at: now.to_rfc3339(),
+                        status: "stale_dropped".to_string(),
+                    });
+                } else {
+                    sched.run_history.push(ScheduleRun {
+                        triggered_at: now.to_rfc3339(),
+                        status: "replayed".to_string(),
+                    });
+                    to_replay.push(sched.clone());
+                }
             }
-            let at = match &sched.trigger {
-                Trigger::Once { at } => at.clone(),
-                Trigger::Cron { .. } => continue,
-            };
-            let at_utc = match chrono::DateTime::parse_from_rfc3339(&at) {
-                Ok(dt) => dt.with_timezone(&chrono::Utc),
-                Err(_) => continue,
-            };
-            if at_utc >= now {
-                continue; // not missed yet
-            }
-            sched.enabled = false;
-            sched.updated_at = now.to_rfc3339();
-            if at_utc < cutoff {
-                tracing::warn!(
-                    id = %sched.id,
-                    run_at = %at,
-                    "dropping stale one-shot schedule (>24h past)"
-                );
-                sched.run_history.push(ScheduleRun {
-                    triggered_at: now.to_rfc3339(),
-                    status: "stale_dropped".to_string(),
-                });
-            } else {
-                sched.run_history.push(ScheduleRun {
-                    triggered_at: now.to_rfc3339(),
-                    status: "replayed".to_string(),
-                });
-                to_replay.push(sched.clone());
-            }
-        }
-        Ok(())
-    });
+            Ok(())
+        }),
+        "schedule_replay_missed"
+    );
     to_replay
 }
 
@@ -304,13 +307,16 @@ pub fn replay_missed_oneshots(home: &Path) -> Vec<Schedule> {
 /// retrigger.
 pub fn set_enabled(home: &Path, schedule_id: &str, enabled: bool) {
     let sid = schedule_id.to_string();
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut ScheduleStore| {
-        if let Some(sched) = store.schedules.iter_mut().find(|s| s.id == sid) {
-            sched.enabled = enabled;
-            sched.updated_at = chrono::Utc::now().to_rfc3339();
-        }
-        Ok(())
-    });
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut ScheduleStore| {
+            if let Some(sched) = store.schedules.iter_mut().find(|s| s.id == sid) {
+                sched.enabled = enabled;
+                sched.updated_at = chrono::Utc::now().to_rfc3339();
+            }
+            Ok(())
+        }),
+        "schedule_set_enabled"
+    );
 }
 
 /// #1521: record that an `UntilSuccess` schedule's linked task was observed
@@ -319,12 +325,15 @@ pub fn set_enabled(home: &Path, schedule_id: &str, enabled: bool) {
 pub fn mark_success_today(home: &Path, schedule_id: &str, date: &str) {
     let sid = schedule_id.to_string();
     let d = date.to_string();
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut ScheduleStore| {
-        if let Some(sched) = store.schedules.iter_mut().find(|s| s.id == sid) {
-            sched.last_success_date = Some(d.clone());
-        }
-        Ok(())
-    });
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut ScheduleStore| {
+            if let Some(sched) = store.schedules.iter_mut().find(|s| s.id == sid) {
+                sched.last_success_date = Some(d.clone());
+            }
+            Ok(())
+        }),
+        "schedule_mark_success_today"
+    );
 }
 
 /// #1488: when an instance is deleted, disable every schedule that targets it
@@ -337,22 +346,25 @@ pub fn mark_success_today(home: &Path, schedule_id: &str, date: &str) {
 pub fn orphan_schedules_for_target(home: &Path, deleted_target: &str) -> usize {
     let target = deleted_target.to_string();
     let mut orphaned = 0usize;
-    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut ScheduleStore| {
-        let now = chrono::Utc::now().to_rfc3339();
-        for sched in store.schedules.iter_mut() {
-            if sched.target != target || !sched.enabled {
-                continue;
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut ScheduleStore| {
+            let now = chrono::Utc::now().to_rfc3339();
+            for sched in store.schedules.iter_mut() {
+                if sched.target != target || !sched.enabled {
+                    continue;
+                }
+                sched.enabled = false;
+                sched.updated_at = now.clone();
+                sched.run_history.push(ScheduleRun {
+                    triggered_at: now.clone(),
+                    status: format!("orphaned: target instance '{target}' deleted"),
+                });
+                orphaned += 1;
             }
-            sched.enabled = false;
-            sched.updated_at = now.clone();
-            sched.run_history.push(ScheduleRun {
-                triggered_at: now.clone(),
-                status: format!("orphaned: target instance '{target}' deleted"),
-            });
-            orphaned += 1;
-        }
-        Ok(())
-    });
+            Ok(())
+        }),
+        "schedule_orphan_for_target"
+    );
     if orphaned > 0 {
         tracing::info!(
             target = %deleted_target,


### PR DESCRIPTION
## #1647 — triage + fix the persist-drop tail that #1630 deferred

Triaged all ~36 remaining `let _ = <persist>` Result-drops (the non-enqueue class #1630 left). **11 are REAL silent-loss; the rest are legitimately best-effort and stay as-is** (markers, PID/heartbeat, per-tick rewritten sidecars, dedup-ledger-backed queues).

### First: generalize the `persist_or_log!` message
It was enqueue-specific (`"enqueue failed — message dropped"`) — misleading at a metadata/dispatch/schedule site. Now op-agnostic (`"op failed — result dropped"`); the `op` field already says which call dropped, so the existing enqueue call sites still read correctly. `tests/enqueue_drop_invariant.rs` is token-based (not message-based) → stays green.

### The 11 fixed (all `persist_or_log!` — every enclosing fn returns `()`, so propagation isn't available)
| sites | store | why REAL |
|---|---|---|
| `dispatch_tracking.rs` track / mark_completed / sweep_stuck / sweep_orphans / cleanup_for_instance | DispatchStore (watchdog reads it) | dropped write → dispatch invisible to watchdog, or loses the status flip that is the SOLE de-dup → #1488 "dispatch stuck" re-nag every tick |
| `schedules.rs` replay_missed_oneshots / set_enabled / mark_success_today / orphan_schedules_for_target | ScheduleStore | dropped write → one-shot double-fires, or #1521 until-success / #1488 orphan re-nags a done/dead schedule |
| `agent_ops.rs` save_metadata / save_metadata_batch | instance metadata (read back by merge_metadata) | MCP set_display_name/description/waiting_on return OK regardless → dropped write was a silent operator-set-but-lost |

### Left INTENTIONAL (not touched)
~21 best-effort sites stay lossy. Only `dispatch_tracking::gc_old_entries` got a `// best-effort:` note — it's the lone unwrapped `mutate_versioned` beside 5 wrapped siblings, so it would otherwise read as an oversight. The 4 borderline log-only candidates (ci_watch poller:333, worktree_pool:468, instructions:432, schedules record_run) are **skipped** (low value, per triage).

### Preflight
- `cargo fmt --check` clean; `cargo clippy --all-targets --features tray -D warnings` clean
- `cargo test --tests --features tray`: **3391 passed, 0 failed** (real git); enqueue_drop_invariant green; 65 dispatch/schedule/agent_ops behavioral tests green.

Additive log-on-error only — happy path unchanged (`Ok` still discarded). The large line counts are fmt re-indenting the closure bodies one level deeper under the macro wrap.

Closes #1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)