### PR TITLE
fix(#1587): ServerRateLimit FP — dedup net-tail, drop guessed token, pin boundary

### DIFF
--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -2,6 +2,30 @@ use super::AgentState;
 use crate::backend::Backend;
 use regex::Regex;
 
+/// #1587: the ServerRateLimit network-error alternation, deduped from the
+/// byte-identical copy that previously lived in ALL 5 backend pattern blocks
+/// (claude/kiro/codex/opencode/gemini — same copy-paste-the-bug family as
+/// #1639/#1642; one edit now applies uniformly). Sourced from #1136's
+/// operator-observed proxy/network faults (`InvalidHTTPResponse`,
+/// `ECONNRESET`/`ETIMEDOUT`, `fetch failed`, `connection reset`) plus the
+/// realistic Node messages `socket hang up` / `proxy disconnect`.
+///
+/// #1587 deliberately does NOT blind-tighten these tokens. ServerRateLimit is
+/// already `is_high_fp_state`, so the #919 red-SGR anchor + #1518 live-bottom-N
+/// gate apply, and #1586 eliminated the retry-storm — the residual is ≤1
+/// red-gated spurious `continue`. Tightening risks false-NEGATIVES: the English
+/// phrases ARE the Node backends' literal error messages, and the real
+/// rendering carries an `Error:`/`FetchError:` label prefix that a line-start
+/// anchor would reject (cf. the `detect("Error: ECONNRESET")` test). A proper
+/// tighten would need captured per-backend network-error fixtures — a deferred
+/// follow-up only if the single FP ever becomes a real problem.
+///
+/// The bare `network error` token WAS dropped: it was never in #1136's observed
+/// list (an unverified guess), is the most prose-FP-prone of the set, and no
+/// backend was observed emitting it literally — so dropping it is
+/// false-negative-free (the #1136 coverage test never listed it either).
+const SERVER_RATE_LIMIT_NET_ERRORS: &str = r"ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|proxy.*disconnect";
+
 /// Compiled patterns for one backend.
 pub struct StatePatterns {
     /// (state, regex) pairs in priority order (highest priority first).
@@ -73,8 +97,12 @@ impl StatePatterns {
                 // English-word match) is replaced by specific error phrases.
                 (
                     AgentState::ServerRateLimit,
-                    r"Server is temporarily limiting requests|temporarily limiting.*not your usage|API Error: 5\d{2}\b|server-side issue.*temporary|API Error: Repeated 529 Overloaded|overloaded_error|api_error|timeout_error|ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|network error|proxy.*disconnect",
+                    r"Server is temporarily limiting requests|temporarily limiting.*not your usage|API Error: 5\d{2}\b|server-side issue.*temporary|API Error: Repeated 529 Overloaded|overloaded_error|api_error|timeout_error",
                 ),
+                // #1587: shared network-error tail (see SERVER_RATE_LIMIT_NET_ERRORS).
+                // Same ServerRateLimit state → a second entry is equivalent to
+                // appending the alternation, without duplicating the literal.
+                (AgentState::ServerRateLimit, SERVER_RATE_LIMIT_NET_ERRORS),
                 // #848: narrow Claude RateLimit to specific error phrases.
                 // The pre-#848 pattern `r"overloaded|rate.?limit|\b429\b"`
                 // matched the bare substring `rate_limit` / `rate-limit` /
@@ -266,10 +294,7 @@ impl StatePatterns {
                     r"Too Many Requests|ThrottlingError|ThrottlingException|Rate exceeded|\b429\b",
                 ),
                 // #1136: network errors — transient, auto-retry safe.
-                (
-                    AgentState::ServerRateLimit,
-                    r"ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|network error|proxy.*disconnect",
-                ),
+                (AgentState::ServerRateLimit, SERVER_RATE_LIMIT_NET_ERRORS),
                 // [docs] Context overflow triggers compaction
                 // `/compact` was previously included but matches the slash-
                 // command autocomplete menu (kiro lists `/compact` alongside
@@ -358,10 +383,7 @@ impl StatePatterns {
                     r"rate_limit_exceeded|RateLimitError|hit your rate limit",
                 ),
                 // #1136: network errors — transient, auto-retry safe.
-                (
-                    AgentState::ServerRateLimit,
-                    r"ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|network error|proxy.*disconnect",
-                ),
+                (AgentState::ServerRateLimit, SERVER_RATE_LIMIT_NET_ERRORS),
                 // [docs] Context overflow error
                 (AgentState::ContextFull, r"ContextOverflow"),
                 // #1634 [実測 incident]: the configured model was discontinued
@@ -461,10 +483,7 @@ impl StatePatterns {
                     r"API rate limited \(429\)|Rate limited\. Quick retry|API rate limit exceeded",
                 ),
                 // #1136: network errors — transient, auto-retry safe.
-                (
-                    AgentState::ServerRateLimit,
-                    r"ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|network error|proxy.*disconnect",
-                ),
+                (AgentState::ServerRateLimit, SERVER_RATE_LIMIT_NET_ERRORS),
                 // #848 PR-B: NEW OpenCode UsageLimit pattern (pre-#848
                 // OpenCode had no UsageLimit pattern at all, so
                 // subscription-quota strings fell through to whatever
@@ -590,10 +609,7 @@ impl StatePatterns {
                     r"429 RESOURCE_EXHAUSTED|rateLimitExceeded|got status: 429|429 Too Many Requests",
                 ),
                 // #1136: network errors — transient, auto-retry safe.
-                (
-                    AgentState::ServerRateLimit,
-                    r"ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|network error|proxy.*disconnect",
-                ),
+                (AgentState::ServerRateLimit, SERVER_RATE_LIMIT_NET_ERRORS),
                 // [docs] Usage limit messages
                 // #1125 M4: added `RESOURCE_EXHAUSTED` — the gRPC status
                 // code for quota exhaustion. Positioned AFTER RateLimit so

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3154,6 +3154,47 @@ fn network_error_patterns_all_backends() {
     }
 }
 
+/// #1587: lock the bounded-acceptable ServerRateLimit FP behavior at the live
+/// red-anchored gate. A real network error rendered RED still latches
+/// ServerRateLimit (the auto-retry path these tokens exist for); the SAME
+/// FP-prone phrase in plain (non-red) prose does NOT latch. This is the residual
+/// we deliberately do NOT chase with an unsafe blind tighten — see the
+/// `SERVER_RATE_LIMIT_NET_ERRORS` doc for why (FN risk, no per-backend fixtures).
+#[test]
+fn server_rate_limit_red_anchor_fp_boundary_1587() {
+    // Realistic Node rendering carries an `Error:` label prefix.
+    let screen = "Error: socket hang up";
+    let n = screen.chars().count();
+
+    // RED-rendered error → latches ServerRateLimit (auto-retry preserved).
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    t.feed_with_fg(screen, &vec![CellFg::Red; n]);
+    assert_eq!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#1587: a real network error rendered red must still latch ServerRateLimit"
+    );
+
+    // Same wording WITHOUT red (prose / dev-log mention) → must NOT latch.
+    let mut t2 = StateTracker::new(Some(&Backend::Codex));
+    t2.feed_with_fg(screen, &vec![CellFg::Default; n]);
+    assert_ne!(
+        t2.get_state(),
+        AgentState::ServerRateLimit,
+        "#1587: same wording without red must NOT latch (red-anchor FP boundary)"
+    );
+
+    // Dropped token regression: `network error` (the unverified #1136 guess) is
+    // gone — even text-only (fail-open) must NOT classify it as ServerRateLimit.
+    let mut t3 = StateTracker::new(Some(&Backend::Codex));
+    t3.feed("network error");
+    assert_ne!(
+        t3.get_state(),
+        AgentState::ServerRateLimit,
+        "#1587: bare `network error` was dropped — must no longer trigger ServerRateLimit"
+    );
+}
+
 // ── #1527: transition recording at the mutation source ──
 
 #[test]


### PR DESCRIPTION
## Resolution: residual-acceptable + dedup + dropped-guess-token + boundary-test — **NOT a blind tighten**

#1587 asked whether to tighten the FP-prone bare tokens in the ServerRateLimit network-error alternation (`fetch failed | connection reset | socket hang up | network error | …`).

### Spike finding — a blind tighten is UNSAFE (false-negatives)
- The English phrases **are the Node backends' literal error messages** (undici `fetch failed`, Node `socket hang up`) — dropping them = miss real transient errors that legitimately auto-retry.
- The **real rendering carries an `Error:`/`FetchError:` label prefix** (proven by the existing `detect("Error: ECONNRESET")` test) — so a line-start anchor would reject the real shape → FN.
- **No per-backend network-error fixtures exist** to tune a label-anchor against → blind.
- ServerRateLimit is already `is_high_fp_state` (#919 red anchor + #1518 bottom-N) and **#1586 killed the storm** → residual is **≤1 red-gated spurious `continue`**. Chasing it with an unsafe tighten is net-negative. KISS.

(Lead agreed: Path B.)

### Safe minimal action
1. **Dedup** — the net-error alternation was **byte-identical across all 5 backend blocks** (claude/kiro/codex/opencode/gemini — the #1639/#1642 copy-paste family). Extracted to `SERVER_RATE_LIMIT_NET_ERRORS`; claude keeps its specific throttle entry + a second shared-const entry (same state). ×5 → 1; future changes apply uniformly.
2. **Drop `network error`** — #1136's source issue lists only `InvalidHTTPResponse`/`ECONNRESET`/`ETIMEDOUT`/`fetch failed`/`connection reset` as *observed*. `network error` was an **unverified implementer guess**, the most prose-FP-prone token, and no backend was seen emitting it literally. The #1136 coverage test never listed it → dropping is **false-negative-free**.
3. **Boundary regression test** (`server_rate_limit_red_anchor_fp_boundary_1587`) — at the live gate: real error **rendered RED → latches** (auto-retry preserved); same wording **without red → does NOT latch**; bare `network error` **no longer classifies**. Locks the bounded-acceptable behavior.
4. **Documented** (const doc) why we don't blind-tighten + that a proper tighten needs captured per-backend fixtures (deferred follow-up only if the single FP ever becomes a real problem).

## Preflight
`cargo fmt`; `clippy --all-targets -- -D warnings` clean for **both** `--features tray` and `--features tray,discord`; state(264) + #1136 network coverage + `replay_manifest_regression` + pattern-coverage tests pass.

Closes #1587

🤖 Generated with [Claude Code](https://claude.com/claude-code)