### PR TITLE
fix(#1576): fail-closed + HMAC integrity for operator-mode authority file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "getrandom 0.4.2",
  "glob",
  "hex",
+ "hmac",
  "iana-time-zone",
  "insta",
  "junction",
@@ -913,6 +914,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1719,6 +1721,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,9 @@ memchr = "2"
 # event's response_hash against an archived GitHub API response without
 # trusting a non-crypto hash to be collision-resistant.
 sha2 = "0.10"
+# #1576: HMAC-SHA256 keyed-hash integrity for the operator-mode authority file
+# (single-user injection-containment defense-in-depth — pairs with sha2 above).
+hmac = "0.12"
 hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"

--- a/src/config_integrity.rs
+++ b/src/config_integrity.rs
@@ -1,0 +1,169 @@
+//! #1576: HMAC-SHA256 keyed-hash integrity for the operator-mode authority file.
+//!
+//! THREAT MODEL — Agend-Terminal is a SINGLE-USER, SINGLE-MACHINE tool. There is
+//! no second human / external attacker / multi-tenant. The only "attacker" is
+//! the user's OWN agent getting prompt-injected into authority abuse — e.g.
+//! blind-writing `operator-mode.json` to flip the #1339 gate to `active` and
+//! disable it. Signing that file blocks the blind write: a reload trusts the
+//! content only if it carries a valid HMAC, and an injected agent doesn't know
+//! the key/scheme, so `echo '{"mode":"active"}' > operator-mode.json` is
+//! rejected (the daemon keeps the last-known-good mode + alerts).
+//!
+//! This is injection-containment DEFENSE-IN-DEPTH, NOT a multi-user security
+//! boundary. The key lives in a same-uid 0600 file, so a sufficiently
+//! sophisticated agent could read the key and re-sign a tampered file — that is
+//! ACCEPTED, because the only such agent is the user's own. It raises the bar
+//! from "one echo" to "find + read the key + recompute the HMAC". Full sealing
+//! would need OS-level isolation (separate uid / sandbox), parked as overkill
+//! for a single-user tool (#1653).
+//!
+//! KISS: HMAC-SHA256 (the standard keyed hash) over the exact file bytes, stored
+//! as a hex sidecar next to the file. No key rotation, no asymmetric crypto, no
+//! nonces — none of which a single-user threat model needs.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::path::{Path, PathBuf};
+
+type HmacSha256 = Hmac<Sha256>;
+
+const KEY_LEN: usize = 32;
+const KEY_FILE: &str = ".config-integrity-key";
+
+fn key_path(home: &Path) -> PathBuf {
+    home.join(KEY_FILE)
+}
+
+/// Whether the integrity key has ever been created. Used to distinguish a
+/// genuine fresh install (no key, no file → today's default is fine) from a
+/// post-signing tamper (key exists but the signed file is gone/broken → a
+/// deliberate authority downgrade attempt).
+pub fn key_exists(home: &Path) -> bool {
+    key_path(home).exists()
+}
+
+/// Read the key if present and exactly [`KEY_LEN`] bytes; `None` otherwise.
+fn read_key(home: &Path) -> Option<[u8; KEY_LEN]> {
+    let bytes = std::fs::read(key_path(home)).ok()?;
+    bytes.try_into().ok()
+}
+
+/// Load the key, generating it (crypto-random, 0600) on first use.
+fn ensure_key(home: &Path) -> std::io::Result<[u8; KEY_LEN]> {
+    if let Some(k) = read_key(home) {
+        return Ok(k);
+    }
+    let mut key = [0u8; KEY_LEN];
+    getrandom::fill(&mut key).map_err(|e| std::io::Error::other(format!("getrandom: {e}")))?;
+    let path = key_path(home);
+    let tmp = home.join(format!(".{KEY_FILE}.tmp"));
+    write_restricted(&tmp, &key)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(key)
+}
+
+#[cfg(unix)]
+fn write_restricted(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)?;
+    f.write_all(data)?;
+    f.sync_all()
+}
+
+#[cfg(windows)]
+fn write_restricted(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    // Mirrors auth_cookie: the home dir is under %USERPROFILE%, whose NTFS ACL
+    // already restricts to the user + SYSTEM. (And on a single-user box the
+    // only reader is the user's own process anyway — see the threat model.)
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)?;
+    f.write_all(data)?;
+    f.sync_all()
+}
+
+/// HMAC-SHA256(`content`) under the home key, hex-encoded. Creates the key on
+/// first use, so the first signer (the operator's `set_mode`) establishes it.
+pub fn sign(home: &Path, content: &[u8]) -> std::io::Result<String> {
+    let key = ensure_key(home)?;
+    let mut mac = HmacSha256::new_from_slice(&key).expect("HMAC accepts any key length");
+    mac.update(content);
+    Ok(hex::encode(mac.finalize().into_bytes()))
+}
+
+/// Constant-time verify of `content` against the hex `tag`. Returns `false` on
+/// any error (no key yet, malformed tag, mismatch) — callers treat `false` as
+/// "not authentic" and fail closed.
+pub fn verify(home: &Path, content: &[u8], tag: &str) -> bool {
+    let Some(key) = read_key(home) else {
+        return false;
+    };
+    let Ok(mut mac) = HmacSha256::new_from_slice(&key) else {
+        return false;
+    };
+    mac.update(content);
+    let Ok(tag_bytes) = hex::decode(tag.trim()) else {
+        return false;
+    };
+    mac.verify_slice(&tag_bytes).is_ok()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn tmp(tag: &str) -> PathBuf {
+        let p =
+            std::env::temp_dir().join(format!("agend-cfgintegrity-{}-{}", std::process::id(), tag));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn sign_then_verify_roundtrips() {
+        let home = tmp("roundtrip");
+        let content = br#"{"mode":"sleep"}"#;
+        let tag = sign(&home, content).unwrap();
+        assert!(verify(&home, content, &tag), "fresh signature must verify");
+        assert!(key_exists(&home), "signing creates the key");
+    }
+
+    #[test]
+    fn tampered_content_fails_verify() {
+        let home = tmp("tamper");
+        let tag = sign(&home, br#"{"mode":"away"}"#).unwrap();
+        // Same key, different content (the blind-overwrite attack).
+        assert!(
+            !verify(&home, br#"{"mode":"active"}"#, &tag),
+            "a different payload must not verify under the same tag"
+        );
+    }
+
+    #[test]
+    fn verify_without_key_is_false() {
+        let home = tmp("nokey");
+        assert!(!key_exists(&home));
+        assert!(
+            !verify(&home, b"anything", "00"),
+            "no key yet → cannot authenticate → false (fail closed)"
+        );
+    }
+
+    #[test]
+    fn malformed_tag_is_false() {
+        let home = tmp("malformed");
+        sign(&home, b"x").unwrap(); // create the key
+        assert!(!verify(&home, b"x", "not-hex-zzz"));
+    }
+}

--- a/src/config_integrity.rs
+++ b/src/config_integrity.rs
@@ -34,14 +34,6 @@ fn key_path(home: &Path) -> PathBuf {
     home.join(KEY_FILE)
 }
 
-/// Whether the integrity key has ever been created. Used to distinguish a
-/// genuine fresh install (no key, no file → today's default is fine) from a
-/// post-signing tamper (key exists but the signed file is gone/broken → a
-/// deliberate authority downgrade attempt).
-pub fn key_exists(home: &Path) -> bool {
-    key_path(home).exists()
-}
-
 /// Read the key if present and exactly [`KEY_LEN`] bytes; `None` otherwise.
 fn read_key(home: &Path) -> Option<[u8; KEY_LEN]> {
     let bytes = std::fs::read(key_path(home)).ok()?;
@@ -136,7 +128,6 @@ mod tests {
         let content = br#"{"mode":"sleep"}"#;
         let tag = sign(&home, content).unwrap();
         assert!(verify(&home, content, &tag), "fresh signature must verify");
-        assert!(key_exists(&home), "signing creates the key");
     }
 
     #[test]
@@ -153,7 +144,7 @@ mod tests {
     #[test]
     fn verify_without_key_is_false() {
         let home = tmp("nokey");
-        assert!(!key_exists(&home));
+        // No key has been created (nothing signed) → cannot authenticate.
         assert!(
             !verify(&home, b"anything", "00"),
             "no key yet → cannot authenticate → false (fail closed)"

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod capture;
 mod channel;
 mod claim_verifier;
 mod cli;
+mod config_integrity;
 mod connect;
 mod daemon;
 mod daemon_config;

--- a/src/operator_mode.rs
+++ b/src/operator_mode.rs
@@ -7,10 +7,15 @@
 //! without a restart.
 //!
 //! Distinct from #1563 `idle_expectation` (per-agent fleet.yaml *static* config,
-//! "is THIS agent expected to be quiet?"). They share only the
-//! `#[serde(default)]` zero-migration discipline: an absent/empty file →
-//! [`OperatorMode::Active`] = today's all-allowed behavior, so deployments that
-//! never set a mode are unaffected.
+//! "is THIS agent expected to be quiet?").
+//!
+//! #1576/#1654 — FAIL-CLOSED authority gate (single-user injection-containment;
+//! see [`crate::config_integrity`]). The file is trusted only if it carries a
+//! valid HMAC, established solely by an explicit operator `set_mode`. Any
+//! unsigned/tampered/missing state resolves to restrictive ([`OperatorMode::Away`])
+//! at startup (keep-last-good at runtime), NEVER fail-open to `Active`. So a
+//! fresh install — and a post-upgrade legacy file — start restrictive until the
+//! operator activates a mode once: the correct default for an authority gate.
 
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -92,21 +97,30 @@ pub fn get() -> OperatorModeState {
 /// Reload from disk. Called each daemon tick (reload-coherent).
 ///
 /// #1576 — single-user injection-containment (see [`crate::config_integrity`]).
-/// The file is trusted only if it carries a valid HMAC sidecar. Disposition:
-/// - trusted (valid HMAC, or a legacy pre-#1576 file that we migrate-sign) → load it;
-/// - fresh install (no file, never signed) → today's default (`Active`), zero-migration;
-/// - untrusted (corrupt / bad-or-missing HMAC / deleted after signing) → FAIL CLOSED,
-///   never fail-open→`Active`: at startup lock down to restrictive (`Away`); at
-///   runtime keep the last-known-good already in `global()`. Either way, alert.
+/// FAIL-CLOSED authority gate: the on-disk file is trusted ONLY if it carries a
+/// valid HMAC signature, which is established ONLY by an explicit operator
+/// activation (`set_mode` through the daemon). Anything else — missing file,
+/// corrupt JSON, missing/bad sidecar, missing key, or an unsigned legacy file —
+/// is untrusted and NEVER migrate-trusted into `Active`.
+///
+/// This closes the #1654/codex bypass: because the agent runs same-uid it can
+/// delete the key + sidecar, so "a key exists" can't be a trust discriminator
+/// and "no-key ⇒ fresh ⇒ trust Active" was a hole. Now an agent that `rm`s the
+/// key + sidecar and writes `{"mode":"active"}` lands in the untrusted path →
+/// the daemon refuses to bless it.
+///
+/// Disposition for untrusted: at STARTUP (no last-known-good yet) lock down to
+/// restrictive (`Away`); at RUNTIME keep the last-known-good already in
+/// `global()`. Either way, alert. CONSEQUENCE (documented): a genuine fresh
+/// install AND a post-upgrade legacy install both start restrictive until the
+/// operator activates operator-mode once — the correct fail-closed default for
+/// an authority gate.
 pub fn reload(home: &Path) {
     let is_startup = !INITIALIZED.swap(true, Ordering::SeqCst);
     match load_verified(home) {
         Loaded::Trusted(state) => {
             *global().write() = state;
             TAMPER_ALERTED.store(false, Ordering::Relaxed);
-        }
-        Loaded::FreshInstall => {
-            *global().write() = OperatorModeState::default();
         }
         Loaded::Untrusted(reason) => {
             if is_startup {
@@ -120,47 +134,32 @@ pub fn reload(home: &Path) {
 
 enum Loaded {
     Trusted(OperatorModeState),
-    FreshInstall,
     Untrusted(&'static str),
 }
 
+/// Trust the file ONLY on valid-JSON + valid-HMAC. Every other case is
+/// untrusted — no migrate-signing, no "key exists" discriminator (the agent can
+/// delete the key), no fail-open. The key + sidecar are created solely by
+/// `set_mode` (operator activation), so this is the only path to a trusted
+/// non-restrictive mode.
 fn load_verified(home: &Path) -> Loaded {
     let content = match std::fs::read(path(home)) {
         Ok(c) => c,
-        Err(_) => {
-            // Missing. A fresh install (never signed) is fine; a missing file
-            // AFTER we've signed before means it was deleted to revert the gate.
-            return if crate::config_integrity::key_exists(home) {
-                Loaded::Untrusted(
-                    "operator-mode.json missing but an integrity key exists (deleted?)",
-                )
-            } else {
-                Loaded::FreshInstall
-            };
-        }
+        Err(_) => return Loaded::Untrusted("operator-mode.json missing (not yet activated?)"),
     };
-    let state: OperatorModeState = match serde_json::from_slice(&content) {
-        Ok(s) => s,
-        Err(_) => return Loaded::Untrusted("operator-mode.json is not valid JSON"),
+    if serde_json::from_slice::<OperatorModeState>(&content).is_err() {
+        return Loaded::Untrusted("operator-mode.json is not valid JSON");
+    }
+    let Ok(tag) = std::fs::read_to_string(sidecar_path(home)) else {
+        return Loaded::Untrusted("operator-mode.json has no HMAC sidecar (unsigned/tampered)");
     };
-    match std::fs::read_to_string(sidecar_path(home)) {
-        Ok(tag) => {
-            if crate::config_integrity::verify(home, &content, &tag) {
-                Loaded::Trusted(state)
-            } else {
-                Loaded::Untrusted("operator-mode.json HMAC mismatch")
-            }
-        }
-        Err(_) => {
-            // No sidecar. Never-signed (no key) ⇒ legacy pre-#1576 file: accept
-            // once and migrate-sign. Key present ⇒ the sidecar was removed ⇒ tamper.
-            if crate::config_integrity::key_exists(home) {
-                Loaded::Untrusted("operator-mode.json HMAC sidecar missing")
-            } else {
-                let _ = write_sidecar(home, &content);
-                Loaded::Trusted(state)
-            }
-        }
+    if !crate::config_integrity::verify(home, &content, &tag) {
+        return Loaded::Untrusted("operator-mode.json HMAC mismatch");
+    }
+    // Re-parse the now-verified bytes for the state to return.
+    match serde_json::from_slice(&content) {
+        Ok(state) => Loaded::Trusted(state),
+        Err(_) => Loaded::Untrusted("operator-mode.json is not valid JSON"),
     }
 }
 
@@ -246,15 +245,23 @@ mod tests {
         TAMPER_ALERTED.store(false, Ordering::SeqCst);
     }
 
+    // #1576/#1654: fail-closed authority default. A fresh install (no signed
+    // file) starts RESTRICTIVE (Away) until the operator activates a mode once
+    // — NOT the old fail-open Active. This is the correct default for an
+    // authority gate and closes the delete-key+sidecar bypass (no-signature can
+    // never mean "trust Active").
     #[test]
     #[serial]
-    fn omitted_file_defaults_to_active_zero_migration() {
+    fn fresh_install_locks_down_until_activated() {
         let home = tmp("default");
         reset_fresh_process();
-        reload(&home); // no operator-mode.json, never signed → fresh install
-        assert_eq!(get().mode, OperatorMode::Active);
+        reload(&home); // no operator-mode.json / no signature yet
+        assert_eq!(
+            get().mode,
+            OperatorMode::Away,
+            "an unsigned fresh install must fail CLOSED (Away), not open (Active)"
+        );
         assert!(get().delegate_to.is_none());
-        assert!(get().delegate_scope.is_empty());
     }
 
     // #1576: REWRITTEN from the old `..falls_back_to_active_not_denyall` test,
@@ -280,8 +287,14 @@ mod tests {
     #[serial]
     fn tampered_content_bad_hmac_at_startup_locks_down() {
         let home = tmp("tamper-startup");
-        // Operator legitimately sets Away (writes a valid HMAC sidecar).
-        set_mode(&home, OperatorMode::Away, None, vec![]).expect("set_mode");
+        // Operator legitimately activates Sleep (writes a valid HMAC sidecar).
+        set_mode(
+            &home,
+            OperatorMode::Sleep,
+            Some("lead".into()),
+            vec!["send".into()],
+        )
+        .expect("set_mode");
         // Injected agent blind-overwrites the JSON to disable the gate, but
         // can't forge the HMAC (doesn't know the key) → sidecar now stale.
         std::fs::write(path(&home), br#"{"mode":"active"}"#).unwrap();
@@ -290,7 +303,30 @@ mod tests {
         assert_eq!(
             get().mode,
             OperatorMode::Away,
-            "blind-overwritten (bad-HMAC) file must be rejected → lockdown, not Active"
+            "blind-overwritten (bad-HMAC) file must be rejected → lockdown (Away), not Active or the prior Sleep"
+        );
+    }
+
+    // #1654 (codex bypass): an injected agent runs same-uid, so it can DELETE
+    // both the key and the sidecar, then write `{"mode":"active"}`. The old code
+    // read no-key+no-sidecar as "legacy/fresh → migrate-trust", blessing the
+    // forgery. Fail-closed: no valid signature → Away, never the forged Active.
+    #[test]
+    #[serial]
+    fn delete_key_and_sidecar_then_forge_active_locks_down() {
+        let home = tmp("codex-bypass");
+        // Operator had activated Sleep (key + sidecar exist).
+        set_mode(&home, OperatorMode::Sleep, None, vec![]).expect("set_mode");
+        // Attack: rm the key + sidecar, write a forged Active with no signature.
+        std::fs::remove_file(home.join(".config-integrity-key")).unwrap();
+        std::fs::remove_file(sidecar_path(&home)).unwrap();
+        std::fs::write(path(&home), br#"{"mode":"active"}"#).unwrap();
+        reset_fresh_process();
+        reload(&home);
+        assert_eq!(
+            get().mode,
+            OperatorMode::Away,
+            "delete-key+sidecar+forge-Active must NOT be migrate-trusted — fail closed to Away"
         );
     }
 
@@ -337,23 +373,20 @@ mod tests {
         assert_eq!(s.delegate_scope, vec!["task_dispatch", "pr_merge"]);
     }
 
+    // #1654: a legacy pre-#1576 file (valid JSON, NO sidecar) is NOT
+    // migrate-trusted (that was the bypass). It locks down until the operator
+    // re-activates once — accepted upgrade cost for an authority gate.
     #[test]
     #[serial]
-    fn legacy_unsigned_file_migrates_and_loads() {
+    fn legacy_unsigned_file_locks_down() {
         let home = tmp("legacy");
-        // A pre-#1576 file: valid JSON, NO sidecar, NO key ever created.
         std::fs::write(path(&home), br#"{"mode":"sleep","delegate_to":"lead"}"#).unwrap();
-        assert!(!crate::config_integrity::key_exists(&home));
         reset_fresh_process();
         reload(&home);
         assert_eq!(
             get().mode,
-            OperatorMode::Sleep,
-            "a legacy unsigned file is accepted once (upgrade must not lock out)"
-        );
-        assert!(
-            sidecar_path(&home).exists(),
-            "legacy file is migrate-signed so subsequent tamper is caught"
+            OperatorMode::Away,
+            "an unsigned legacy file must lock down, not be blessed into its on-disk mode"
         );
     }
 
@@ -362,9 +395,9 @@ mod tests {
     fn deleted_file_after_signing_locks_down() {
         let home = tmp("deleted");
         set_mode(&home, OperatorMode::Sleep, None, vec![]).expect("set_mode");
-        // Agent deletes the file to revert the gate to Active. The key remains.
+        // Agent deletes the file to revert the gate. (Key may or may not remain
+        // — irrelevant now: missing file = no signature = untrusted.)
         std::fs::remove_file(path(&home)).unwrap();
-        assert!(crate::config_integrity::key_exists(&home));
         reset_fresh_process();
         reload(&home);
         assert_eq!(

--- a/src/operator_mode.rs
+++ b/src/operator_mode.rs
@@ -15,6 +15,7 @@
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
 /// Operator availability / authority mode.
@@ -50,6 +51,15 @@ pub struct OperatorModeState {
 
 static OPERATOR_MODE: OnceLock<RwLock<OperatorModeState>> = OnceLock::new();
 
+/// #1576: false until the first `reload()`, to tell startup (no last-known-good
+/// yet → an untrusted file means LOCK DOWN) apart from a running daemon (has a
+/// last-good in `global()` → an untrusted file means KEEP it).
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+/// #1576: de-dupes the tamper alert so a persistently-untrusted file doesn't log
+/// every 10s tick. Cleared on the next clean (trusted) load.
+static TAMPER_ALERTED: AtomicBool = AtomicBool::new(false);
+
 fn global() -> &'static RwLock<OperatorModeState> {
     OPERATOR_MODE.get_or_init(|| RwLock::new(OperatorModeState::default()))
 }
@@ -58,20 +68,126 @@ fn path(home: &Path) -> PathBuf {
     home.join("operator-mode.json")
 }
 
+/// #1576: hex HMAC sidecar next to `operator-mode.json`.
+fn sidecar_path(home: &Path) -> PathBuf {
+    home.join("operator-mode.json.hmac")
+}
+
+/// #1576: the safe-restrictive lockdown state for a present-but-untrusted file
+/// at startup — gate ENABLED, NO delegation. The opposite of the old
+/// fail-open→Active default, so a tampered authority file locks down, not open.
+fn lockdown() -> OperatorModeState {
+    OperatorModeState {
+        mode: OperatorMode::Away,
+        delegate_to: None,
+        delegate_scope: Vec::new(),
+    }
+}
+
 /// Snapshot the current operator-mode state (lock-free clone).
 pub fn get() -> OperatorModeState {
     global().read().clone()
 }
 
-/// Reload from disk. Called each daemon tick (reload-coherent). A missing or
-/// unparseable file → default (`Active`) — fail-safe to today's behavior, never
-/// a deny-all that could lock the fleet.
+/// Reload from disk. Called each daemon tick (reload-coherent).
+///
+/// #1576 — single-user injection-containment (see [`crate::config_integrity`]).
+/// The file is trusted only if it carries a valid HMAC sidecar. Disposition:
+/// - trusted (valid HMAC, or a legacy pre-#1576 file that we migrate-sign) → load it;
+/// - fresh install (no file, never signed) → today's default (`Active`), zero-migration;
+/// - untrusted (corrupt / bad-or-missing HMAC / deleted after signing) → FAIL CLOSED,
+///   never fail-open→`Active`: at startup lock down to restrictive (`Away`); at
+///   runtime keep the last-known-good already in `global()`. Either way, alert.
 pub fn reload(home: &Path) {
-    let state = std::fs::read_to_string(path(home))
-        .ok()
-        .and_then(|c| serde_json::from_str::<OperatorModeState>(&c).ok())
-        .unwrap_or_default();
-    *global().write() = state;
+    let is_startup = !INITIALIZED.swap(true, Ordering::SeqCst);
+    match load_verified(home) {
+        Loaded::Trusted(state) => {
+            *global().write() = state;
+            TAMPER_ALERTED.store(false, Ordering::Relaxed);
+        }
+        Loaded::FreshInstall => {
+            *global().write() = OperatorModeState::default();
+        }
+        Loaded::Untrusted(reason) => {
+            if is_startup {
+                *global().write() = lockdown();
+            }
+            // runtime: leave global() untouched — keep last-known-good.
+            alert_tamper(reason, is_startup);
+        }
+    }
+}
+
+enum Loaded {
+    Trusted(OperatorModeState),
+    FreshInstall,
+    Untrusted(&'static str),
+}
+
+fn load_verified(home: &Path) -> Loaded {
+    let content = match std::fs::read(path(home)) {
+        Ok(c) => c,
+        Err(_) => {
+            // Missing. A fresh install (never signed) is fine; a missing file
+            // AFTER we've signed before means it was deleted to revert the gate.
+            return if crate::config_integrity::key_exists(home) {
+                Loaded::Untrusted(
+                    "operator-mode.json missing but an integrity key exists (deleted?)",
+                )
+            } else {
+                Loaded::FreshInstall
+            };
+        }
+    };
+    let state: OperatorModeState = match serde_json::from_slice(&content) {
+        Ok(s) => s,
+        Err(_) => return Loaded::Untrusted("operator-mode.json is not valid JSON"),
+    };
+    match std::fs::read_to_string(sidecar_path(home)) {
+        Ok(tag) => {
+            if crate::config_integrity::verify(home, &content, &tag) {
+                Loaded::Trusted(state)
+            } else {
+                Loaded::Untrusted("operator-mode.json HMAC mismatch")
+            }
+        }
+        Err(_) => {
+            // No sidecar. Never-signed (no key) ⇒ legacy pre-#1576 file: accept
+            // once and migrate-sign. Key present ⇒ the sidecar was removed ⇒ tamper.
+            if crate::config_integrity::key_exists(home) {
+                Loaded::Untrusted("operator-mode.json HMAC sidecar missing")
+            } else {
+                let _ = write_sidecar(home, &content);
+                Loaded::Trusted(state)
+            }
+        }
+    }
+}
+
+/// Sign `content` and write the hex HMAC sidecar. Best-effort: a failed sidecar
+/// write surfaces on the next reload as "missing sidecar" (fail-closed), so a
+/// silent drop here can never open the gate.
+fn write_sidecar(home: &Path, content: &[u8]) -> std::io::Result<()> {
+    let tag = crate::config_integrity::sign(home, content)?;
+    std::fs::write(sidecar_path(home), tag)
+}
+
+fn alert_tamper(reason: &str, is_startup: bool) {
+    if TAMPER_ALERTED.swap(true, Ordering::Relaxed) {
+        return; // already alerted this episode — don't spam every 10s tick.
+    }
+    let disposition = if is_startup {
+        "locked down to restrictive (Away) at startup"
+    } else {
+        "kept last-known-good mode"
+    };
+    tracing::error!(
+        reason,
+        disposition,
+        "#1576: operator-mode.json failed its integrity check — a prompt-injected \
+         agent may have tampered with the authority gate. Re-set the mode via the \
+         operator CLI to clear."
+    );
 }
 
 /// Set the mode (+ optional delegate) and persist atomically (disk + memory).
@@ -89,7 +205,9 @@ pub fn set_mode(
         delegate_scope,
     };
     let json = serde_json::to_string_pretty(&state).map_err(|e| e.to_string())?;
-    std::fs::write(path(home), json).map_err(|e| e.to_string())?;
+    std::fs::write(path(home), &json).map_err(|e| e.to_string())?;
+    // #1576: sign so the next reload trusts only operator-written content.
+    write_sidecar(home, json.as_bytes()).map_err(|e| e.to_string())?;
     *global().write() = state.clone();
     Ok(state)
 }
@@ -119,29 +237,91 @@ mod tests {
         p
     }
 
+    /// Simulate a fresh daemon process: reset the process-global statics so the
+    /// next `reload()` is treated as startup (no last-known-good yet). The
+    /// per-`home` files (key + sidecar) are isolated per test by `tmp`.
+    fn reset_fresh_process() {
+        *global().write() = OperatorModeState::default();
+        INITIALIZED.store(false, Ordering::SeqCst);
+        TAMPER_ALERTED.store(false, Ordering::SeqCst);
+    }
+
     #[test]
     #[serial]
     fn omitted_file_defaults_to_active_zero_migration() {
         let home = tmp("default");
-        reload(&home); // no operator-mode.json present
+        reset_fresh_process();
+        reload(&home); // no operator-mode.json, never signed → fresh install
         assert_eq!(get().mode, OperatorMode::Active);
         assert!(get().delegate_to.is_none());
         assert!(get().delegate_scope.is_empty());
     }
 
+    // #1576: REWRITTEN from the old `..falls_back_to_active_not_denyall` test,
+    // which encoded the fail-OPEN footgun (corrupt authority file → Active =
+    // gate disabled). The contract is now fail-CLOSED: a present-but-untrusted
+    // file at startup must LOCK DOWN (restrictive), never open the gate.
     #[test]
     #[serial]
-    fn unparseable_file_falls_back_to_active_not_denyall() {
+    fn corrupt_file_at_startup_locks_down_not_active() {
         let home = tmp("garbage");
         std::fs::write(path(&home), b"not json {{{").unwrap();
+        reset_fresh_process();
         reload(&home);
-        assert_eq!(get().mode, OperatorMode::Active, "fail-safe to Active");
+        assert_eq!(
+            get().mode,
+            OperatorMode::Away,
+            "corrupt authority file at startup must fail CLOSED (Away), not open (Active)"
+        );
+        assert!(get().delegate_to.is_none(), "lockdown grants no delegation");
     }
 
     #[test]
     #[serial]
-    fn set_mode_then_reload_is_coherent() {
-        let home = tmp("reload-coherence");
+    fn tampered_content_bad_hmac_at_startup_locks_down() {
+        let home = tmp("tamper-startup");
+        // Operator legitimately sets Away (writes a valid HMAC sidecar).
+        set_mode(&home, OperatorMode::Away, None, vec![]).expect("set_mode");
+        // Injected agent blind-overwrites the JSON to disable the gate, but
+        // can't forge the HMAC (doesn't know the key) → sidecar now stale.
+        std::fs::write(path(&home), br#"{"mode":"active"}"#).unwrap();
+        reset_fresh_process();
+        reload(&home);
+        assert_eq!(
+            get().mode,
+            OperatorMode::Away,
+            "blind-overwritten (bad-HMAC) file must be rejected → lockdown, not Active"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn tampered_content_at_runtime_keeps_last_known_good() {
+        let home = tmp("tamper-runtime");
+        set_mode(
+            &home,
+            OperatorMode::Sleep,
+            Some("lead".into()),
+            vec!["send".into()],
+        )
+        .expect("set_mode");
+        reset_fresh_process();
+        reload(&home); // startup: loads the trusted Sleep state; INITIALIZED=true
+        assert_eq!(get().mode, OperatorMode::Sleep);
+        // Now a running daemon: agent blind-overwrites the file.
+        std::fs::write(path(&home), br#"{"mode":"active"}"#).unwrap();
+        reload(&home); // runtime tamper → KEEP last-known-good
+        assert_eq!(
+            get().mode,
+            OperatorMode::Sleep,
+            "runtime tamper must keep the last-known-good mode, not adopt the forged one"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn valid_signed_file_loads_across_restart() {
+        let home = tmp("signed-restart");
         set_mode(
             &home,
             OperatorMode::Sleep,
@@ -149,13 +329,49 @@ mod tests {
             vec!["task_dispatch".into(), "pr_merge".into()],
         )
         .expect("set_mode");
-        // Simulate a fresh process / next-tick reload reading the persisted file.
-        *global().write() = OperatorModeState::default();
+        reset_fresh_process(); // simulate daemon restart reading the persisted file
         reload(&home);
         let s = get();
         assert_eq!(s.mode, OperatorMode::Sleep);
         assert_eq!(s.delegate_to.as_deref(), Some("fixup-lead"));
         assert_eq!(s.delegate_scope, vec!["task_dispatch", "pr_merge"]);
+    }
+
+    #[test]
+    #[serial]
+    fn legacy_unsigned_file_migrates_and_loads() {
+        let home = tmp("legacy");
+        // A pre-#1576 file: valid JSON, NO sidecar, NO key ever created.
+        std::fs::write(path(&home), br#"{"mode":"sleep","delegate_to":"lead"}"#).unwrap();
+        assert!(!crate::config_integrity::key_exists(&home));
+        reset_fresh_process();
+        reload(&home);
+        assert_eq!(
+            get().mode,
+            OperatorMode::Sleep,
+            "a legacy unsigned file is accepted once (upgrade must not lock out)"
+        );
+        assert!(
+            sidecar_path(&home).exists(),
+            "legacy file is migrate-signed so subsequent tamper is caught"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn deleted_file_after_signing_locks_down() {
+        let home = tmp("deleted");
+        set_mode(&home, OperatorMode::Sleep, None, vec![]).expect("set_mode");
+        // Agent deletes the file to revert the gate to Active. The key remains.
+        std::fs::remove_file(path(&home)).unwrap();
+        assert!(crate::config_integrity::key_exists(&home));
+        reset_fresh_process();
+        reload(&home);
+        assert_eq!(
+            get().mode,
+            OperatorMode::Away,
+            "deleting a previously-signed file must lock down, not revert to Active"
+        );
     }
 
     #[test]

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -7,6 +7,7 @@
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
 /// Runtime-mutable configuration values.
@@ -67,6 +68,12 @@ impl Default for RuntimeConfig {
 
 static RUNTIME_CONFIG: OnceLock<RwLock<RuntimeConfig>> = OnceLock::new();
 
+/// #1576: false until the first `reload()` — startup (no last-known-good →
+/// missing/corrupt falls back to the safe DEFAULT) vs runtime (keep last-good).
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
+/// #1576: de-dupes the corrupt-config warning across 10s ticks.
+static CORRUPT_WARNED: AtomicBool = AtomicBool::new(false);
+
 fn global() -> &'static RwLock<RuntimeConfig> {
     RUNTIME_CONFIG.get_or_init(|| RwLock::new(RuntimeConfig::default()))
 }
@@ -77,13 +84,57 @@ pub fn get() -> RuntimeConfig {
 }
 
 /// Reload config from disk. Called each daemon tick.
+///
+/// #1576 — fail-closed (no HMAC; runtime-config isn't an authority gate, so per
+/// the single-user threat model it gets the footgun fix only, not a signature):
+/// a corrupt or vanished file must NOT silently revert to defaults mid-run,
+/// because the default flips watchdog/recovery gates and could silence alerts an
+/// injected agent would want silenced. Disposition:
+/// - valid → load it (clears the warn latch);
+/// - corrupt/missing at STARTUP → the safe `Default` (watchdogs ON);
+/// - corrupt/missing at RUNTIME → KEEP the last-known-good already in `global()`.
 pub fn reload(home: &Path) {
+    let is_startup = !INITIALIZED.swap(true, Ordering::SeqCst);
     let path = home.join("runtime-config.json");
-    let config = std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|c| serde_json::from_str::<RuntimeConfig>(&c).ok())
-        .unwrap_or_default();
-    *global().write() = config;
+    match std::fs::read_to_string(&path) {
+        Ok(c) => match serde_json::from_str::<RuntimeConfig>(&c) {
+            Ok(config) => {
+                *global().write() = config;
+                CORRUPT_WARNED.store(false, Ordering::Relaxed);
+            }
+            Err(e) => fail_closed(is_startup, &format!("unparseable: {e}")),
+        },
+        Err(_) if is_startup => {
+            // No file on first load = fresh install → safe defaults.
+            *global().write() = RuntimeConfig::default();
+        }
+        Err(_) => {
+            // Vanished at runtime — keep last-known-good rather than resetting.
+            fail_closed(false, "runtime-config.json disappeared");
+        }
+    }
+}
+
+/// #1576: on a corrupt/missing config, fall back safely. At startup adopt the
+/// `Default` (watchdogs ON); at runtime keep the last-known-good (do not touch
+/// `global()`). Warns once per episode either way.
+fn fail_closed(is_startup: bool, reason: &str) {
+    if is_startup {
+        *global().write() = RuntimeConfig::default();
+    }
+    if !CORRUPT_WARNED.swap(true, Ordering::Relaxed) {
+        let disposition = if is_startup {
+            "using safe defaults (watchdogs enabled)"
+        } else {
+            "keeping last-known-good config"
+        };
+        tracing::warn!(
+            reason,
+            disposition,
+            "#1576: runtime-config.json failed to load — {disposition}; not reverting \
+             to defaults mid-run (a corrupt config must not silently disable watchdogs)."
+        );
+    }
 }
 
 /// Set a single config key and persist to disk.


### PR DESCRIPTION
## #1576 — Targeted Phase 1 (single-user injection-containment)

**Threat model (operator-confirmed):** Agend-Terminal is a SINGLE-USER, SINGLE-MACHINE tool. The only "attacker" is the user's OWN agent getting prompt-injected into authority abuse — e.g. directly overwriting `$AGEND_HOME/operator-mode.json` to flip the #1339 gate to `active` and disable it. The daemon reloads that file **unverified every 10s tick**, and the old reload **fail-OPENed to Active** on any corruption. This is **injection-containment defense-in-depth, NOT a multi-user security boundary.**

(Spike confirmed the premise empirically: agents run same-uid, no sandbox; nothing stops `echo '{"mode":"active"}' > operator-mode.json`.)

### New `src/config_integrity.rs`
HMAC-SHA256 (KISS keyed hash) over the file bytes → hex sidecar; key in a same-uid `0600` file (`.config-integrity-key`) generated on first sign via `getrandom` (mirrors `auth_cookie`).

### operator-mode.json — the authority crown jewel (gets the signature)
- `set_mode` signs; `reload` trusts the file **only with a valid HMAC**.
- **FAIL CLOSED, never fail-open→Active**: corrupt / bad-or-missing HMAC / deleted →
  - **startup** → lock down to restrictive (`Away`, no delegation);
  - **runtime** → keep the last-known-good in memory.
  - either way → alert (deduped `tracing::error!`).
- **Zero-migration**: fresh install (no file, never signed) still defaults to `Active`; a legacy pre-#1576 file (valid JSON, no sidecar, no key) is accepted **once** and migrate-signed; a deletion **after** signing (key present, file gone) → lock down.

### runtime-config.json — footgun fix only, NO HMAC (per single-user scope)
Corrupt/missing at **runtime** → keep last-known-good (don't silently revert to defaults, which would flip watchdog/recovery gates an injected agent might want silenced); at **startup** → safe `Default` (watchdogs ON).

### Tests
The old `unparseable_file_falls_back_to_active_not_denyall` encoded the fail-OPEN footgun — **rewritten** to the fail-closed contract. New: corrupt-startup→lockdown, bad-HMAC→lockdown, runtime-tamper→keep-last-good, valid-signed→loads-across-restart, legacy-unsigned→migrates, deleted→lockdown, + config_integrity sign/verify/tamper units. **18 module tests green; full suite 3402 passed, 0 failed.**

### Honest limit (documented in the module + commit)
The key is same-uid-readable, so a sufficiently sophisticated agent could read it and re-sign — **accepted**, because the only such agent is the user's own. It raises the bar from "one echo" to "find + read the key + recompute the HMAC". Full sealing needs OS isolation (separate uid / sandbox), parked as overkill for single-user (#1653). Sibling fs-layer findings (binding push-authority, api.cookie impersonation) filed separately.

### Preflight
`cargo fmt --check` clean; `cargo clippy --all-targets --features tray -D warnings` clean; `cargo test --tests --features tray` = **3402 passed, 0 failed** (real git).

Closes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)