### PR TITLE
fix(#1604): set_display_name/set_description — empty value = explicit clear

### DIFF
--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -422,6 +422,15 @@ pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
 
 pub(super) fn handle_set_display_name(home: &Path, args: &Value, instance_name: &str) -> Value {
     let display_name = args["name"].as_str().unwrap_or("");
+    // #1604: empty/missing `name` = explicit CLEAR (reset to the default = the
+    // agent name; see layout::pane::display_name's `unwrap_or(&agent_name)`),
+    // mirroring set_waiting_on. Pre-#1604 it saved `""` → the pane showed a
+    // blank name instead of falling back. Clear stores `null` so the reader's
+    // Option is None.
+    if display_name.is_empty() {
+        save_metadata(home, instance_name, "display_name", json!(null));
+        return json!({"cleared": true});
+    }
     if display_name.len() > 256 {
         return json!({"error": "display_name exceeds 256 character limit"});
     }
@@ -431,6 +440,12 @@ pub(super) fn handle_set_display_name(home: &Path, args: &Value, instance_name: 
 
 pub(super) fn handle_set_description(home: &Path, args: &Value, instance_name: &str) -> Value {
     let desc = args["description"].as_str().unwrap_or("");
+    // #1604: empty/missing `description` = explicit CLEAR (store `null`),
+    // consistent with set_display_name + set_waiting_on.
+    if desc.is_empty() {
+        save_metadata(home, instance_name, "description", json!(null));
+        return json!({"cleared": true});
+    }
     if desc.len() > 1024 {
         return json!({"error": "description exceeds 1024 character limit"});
     }

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -61,6 +61,64 @@ fn save_and_load_metadata() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+fn read_meta(home: &std::path::Path, agent: &str) -> serde_json::Value {
+    let content =
+        std::fs::read_to_string(home.join(format!("metadata/{agent}.json"))).expect("read meta");
+    serde_json::from_str(&content).expect("parse meta")
+}
+
+// #1604: set_display_name — set, then empty/missing = explicit CLEAR (store
+// null so the pane falls back to the agent name), mirroring set_waiting_on.
+#[test]
+fn set_display_name_empty_clears_to_null_1604() {
+    let home = tmp_home("set_display_name");
+    // set
+    let r =
+        super::instance::handle_set_display_name(&home, &json!({"name": "Dev Agent"}), "agent1");
+    assert_eq!(r["display_name"], "Dev Agent");
+    assert_eq!(read_meta(&home, "agent1")["display_name"], "Dev Agent");
+    // empty string → clear (null, NOT "")
+    let r = super::instance::handle_set_display_name(&home, &json!({"name": ""}), "agent1");
+    assert_eq!(r["cleared"], true);
+    assert!(
+        read_meta(&home, "agent1")["display_name"].is_null(),
+        "#1604: empty must clear to null, not persist an empty string"
+    );
+    // missing `name` → also clear (consistent with empty)
+    super::instance::handle_set_display_name(&home, &json!({"name": "Dev Agent"}), "agent1");
+    let r = super::instance::handle_set_display_name(&home, &json!({}), "agent1");
+    assert_eq!(r["cleared"], true);
+    assert!(read_meta(&home, "agent1")["display_name"].is_null());
+    // over-limit still errors
+    let long = "x".repeat(257);
+    let r = super::instance::handle_set_display_name(&home, &json!({ "name": long }), "agent1");
+    assert!(r["error"].as_str().unwrap_or("").contains("256"));
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// #1604: set_description — same contract (empty/missing = clear to null).
+#[test]
+fn set_description_empty_clears_to_null_1604() {
+    let home = tmp_home("set_description");
+    let r =
+        super::instance::handle_set_description(&home, &json!({"description": "does X"}), "agent1");
+    assert_eq!(r["description"], "does X");
+    assert_eq!(read_meta(&home, "agent1")["description"], "does X");
+    let r = super::instance::handle_set_description(&home, &json!({"description": ""}), "agent1");
+    assert_eq!(r["cleared"], true);
+    assert!(
+        read_meta(&home, "agent1")["description"].is_null(),
+        "#1604: empty must clear to null"
+    );
+    let r = super::instance::handle_set_description(&home, &json!({}), "agent1");
+    assert_eq!(r["cleared"], true);
+    let long = "x".repeat(1025);
+    let r =
+        super::instance::handle_set_description(&home, &json!({ "description": long }), "agent1");
+    assert!(r["error"].as_str().unwrap_or("").contains("1024"));
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn save_metadata_creates_dir() {
     let home = tmp_home("save_meta_dir");

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -139,13 +139,13 @@ pub(crate) fn def_interrupt() -> Value {
 }
 
 pub(crate) fn def_set_display_name() -> Value {
-    json!({"name": "set_display_name", "description": "Set your display name.",
-        "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}}})
+    json!({"name": "set_display_name", "description": "Set your display name. Empty string (or omitting `name`) clears it — the pane falls back to the agent name.",
+        "inputSchema": {"type": "object", "properties": {"name": {"type": "string", "description": "Display name. Empty string to clear (reset to the agent name)."}}}})
 }
 
 pub(crate) fn def_set_description() -> Value {
-    json!({"name": "set_description", "description": "Set a description for this instance.",
-        "inputSchema": {"type": "object", "properties": {"description": {"type": "string"}}}})
+    json!({"name": "set_description", "description": "Set a description for this instance. Empty string (or omitting `description`) clears it.",
+        "inputSchema": {"type": "object", "properties": {"description": {"type": "string", "description": "Description. Empty string to clear."}}}})
 }
 
 pub(crate) fn def_set_waiting_on() -> Value {


### PR DESCRIPTION
## What
`set_display_name` / `set_description` called with an empty (or omitted) value now **explicitly CLEAR** the field (store `null`, return `{"cleared": true}`) instead of silently persisting an empty string. Non-empty values set as before; the 256/1024-char limits still apply.

## Why
Post-#1602 these handlers schema-aligned to their `unwrap_or("")` default, so an empty/missing value **saved `""`** — and the pane reader (`layout::pane::display_name` → `unwrap_or(&agent_name)`) then rendered a **blank** name instead of falling back to the agent name. #1604's audit flagged this as an accidental `unwrap_or("")`, not a designed feature.

## Contract chosen (consistent + least-surprising)
The same one `set_waiting_on` already documents: **empty = explicit clear**. Storing `null` makes the reader's `Option` `None` → display falls back to the agent name / no description. Both handlers are now consistent, and the schema docs say "empty string to clear" (mirroring `set_waiting_on`). (Lead's leaning, confirmed by the reader semantics.)

## Tests
For both tools: set → empty-clears-**to-null** (not `""`) → missing-clears → over-limit-errors.

## Preflight
`cargo fmt`; `clippy --all-targets -- -D warnings` clean for `--features tray` and `--features tray,discord`; mcp handler tests (109) + tools schema tests (14) pass.

Closes #1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)