### PR TITLE
fix(#1657): auto-approve the agend-terminal MCP server for opencode agents

### DIFF
--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -430,6 +430,20 @@ fn configure_opencode(working_dir: &Path, instance_name: Option<&str>) -> Result
     for key in ["edit", "bash", "webfetch", "external_directory"] {
         perm.insert(key.to_string(), json!("allow"));
     }
+    // #1657: auto-approve the agend-terminal MCP server's tools. Without this,
+    // opencode raises a "Permission required" prompt on every MCP tool-call
+    // (including `send` kind=report) and the call blocks until the 30s MCP
+    // client timeout — so a reviewer's report never lands, its dispatch sidecar
+    // stays Pending, and dispatch_idle false-positives fire (the lead force-
+    // reassigns every review). opencode names MCP tools `<server>_<tool>`, and
+    // its permission keys do simple `*` glob matching, so `agend-terminal_*`
+    // covers all of this server's tools. This mirrors the other backends'
+    // posture (claude `autoApprove:["*"]`, gemini `trust:true`, codex
+    // `--dangerously-bypass`); on a single-user single-machine tool, trusting
+    // the user's own fleet MCP server is consistent and necessary for autonomy.
+    // Empirically verified against opencode 1.15.10: with this key a `send`
+    // tool-call completes immediately; without it the call hangs on the prompt.
+    perm.insert("agend-terminal_*".to_string(), json!("allow"));
 
     let body = serde_json::to_string_pretty(&config)?;
     crate::store::atomic_write(&path, body.as_bytes())?;
@@ -692,6 +706,13 @@ mod tests {
                 "permission.{key} must be \"allow\" so autonomous agents don't block"
             );
         }
+        // #1657: the agend-terminal MCP server's tools must be auto-approved
+        // (`<server>_*` glob), else every MCP tool-call (incl. `send` report)
+        // blocks on opencode's permission prompt until the 30s client timeout.
+        assert_eq!(
+            perm["agend-terminal_*"], "allow",
+            "permission.\"agend-terminal_*\" must be \"allow\" so MCP tool-calls (send/report) don't block on a permission prompt (#1657)"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
## #1657 — opencode MCP tool-calls (incl. `send` report) time out → root fix

### RCA (3-investigation converging, evidence-airtight)
An opencode-backed agent's MCP tool-calls reliably timed out at 30s. opencode's generated `opencode.json` set `permission.{edit,bash,webfetch,external_directory}="allow"` but **nothing covering the `agend-terminal` MCP server**, so opencode raised a "Permission required" prompt on every MCP tool-call and blocked until the client timeout. The report `send` therefore never reached the daemon's `handle_send`, `mark_resolved` never ran, the dispatch sidecar stayed `Pending`, and **dispatch_idle false-positives fired** (the lead force-reassigned every reviewer-2 review).

The daemon's send/resolve path is fully **backend-agnostic and correct** — the bug is purely that opencode prompts. claude/codex/gemini were immune because each already trusts its MCP server (`autoApprove:["*"]` / `--dangerously-bypass` / `trust:true`); opencode was the only backend missing it.

Evidence fit: /tmp write works (edit/bash allowed) · only MCP `send` times out (MCP tools not in the 4 allowed keys) · only opencode · agent healthy (blocked on an unanswered prompt).

### Fix
Add `"agend-terminal_*": "allow"` to `configure_opencode`'s permission block. opencode names MCP tools `<server>_<tool>` and glob-matches permission keys, so this covers all of the server's tools — the same posture every other backend already has.

### ⚠ Empirical verification (mandatory — a wrong key fails silently)
Verified against the **installed opencode 1.15.10** (the `1.4.0` in backend.rs is a stale label):
- **Treatment** (`agend-terminal_*: allow`): `opencode run` calling `agend-terminal_list_instances` → returned `COUNT=11` **immediately**. (Also confirmed the tool name is `agend-terminal_list_instances` = `<server>_<tool>`.)
- **Control** (current prod config, no key): the identical call **hung indefinitely** on the permission prompt — no result.

This confirms the exact schema key causally suppresses the prompt.

### Scope / threat model
Single-user single-machine: auto-approving the user's own fleet MCP server is consistent with all other backends + necessary for autonomy — acceptable. This is the **root** fix for the reviewer-2 report-timeout noise; #1658's dispatch_idle band-aid is unaffected (stays for genuine long work).

### Tests / preflight
- Extended `opencode_sets_permission_allow_for_autonomous_actions` to assert `permission."agend-terminal_*" == "allow"`.
- `cargo fmt --check` clean; `cargo clippy --all-targets --features tray -D warnings` clean; `cargo test --tests --features tray` = **3406 passed, 0 failed** (real git).

Closes #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)