### PR TITLE
feat(#1666 Phase A): reviewer-evidence enforcement (L1 doc + L2 daemon gate)

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL.md
+++ b/docs/FLEET-DEV-PROTOCOL.md
@@ -49,9 +49,17 @@ Orchestrator posts scope decision + creates task.
 3. **Freshness boundary** — stale if changed after {sha}
 
 ### 3.3 Verdict
-`VERIFIED` / `REJECTED` / `UNVERIFIED`
+`VERIFIED` / `REJECTED` / `UNVERIFIED` — **start the report with the verdict word** (§3.12 convention; the daemon keys on it).
 
-Every review report must include: `scope_source`, `audit_mode`, `reviewed_head`, `commands`, `files`
+Every review report must include: `scope_source`, `audit_mode`, `reviewed_head`, `commands`, `files`.
+
+**Evidence block (#1666 Phase A — daemon-enforced).** A `VERIFIED` or `REJECTED` verdict MUST carry an `### Evidence` block proving the claim:
+- `ran: <cmd> → <result>` — a command actually executed (e.g. `cargo test` / `clippy` / `gh pr checks <PR#>` / `grep`), with its outcome; and/or
+- `cited: path:line — quote` — a source citation backing a finding.
+
+`UNVERIFIED` is redefined as **"claimed but unproven"** — the evidence-exempt verdict. Use it when you assert a concern you could not run-or-cite (so the gate never forces fabricated evidence).
+
+The daemon HARD-gates this at report time: a `VERIFIED`/`REJECTED` with **no recognizable evidence token** (a `cargo`/`gh`/`clippy`/`grep` command line, or a `path:line` cite) is rejected back to the reviewer. The gate is deliberately **lenient** — it accepts any one recognized token and rejects only on total absence; it does NOT enforce a fixed format. (The §3.21 risk-tier review DEPTH remains lead/reviewer judgment — not daemon-enforced.)
 
 ### 3.3.1 CI Verification Gate (Sprint 61)
 Before approving merge, orchestrator/reviewer MUST independently verify CI:

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -285,7 +285,10 @@ pub(crate) fn build_instructions_body(
     content.push_str(
         "- Review dispatch expects: source of truth, scope boundary, freshness boundary\n",
     );
-    content.push_str("- Verdict wording: VERIFIED / REJECTED / UNVERIFIED only\n");
+    content.push_str("- Verdict wording: VERIFIED / REJECTED / UNVERIFIED only (start the report with the verdict word)\n");
+    content.push_str(
+        "- Reviewer evidence (#1666 §3.3): a VERIFIED or REJECTED verdict MUST carry an `### Evidence` block — `ran: <cmd> → <result>` (e.g. cargo test / clippy / `gh pr checks`) and/or `cited: path:line — quote`. The daemon HARD-rejects an evidence-less VERIFIED/REJECTED back to you. UNVERIFIED = 'claimed but unproven' (evidence-exempt) — use it when you cannot run/cite.\n",
+    );
     content.push_str("- **Worktree mandatory** (§10.4): always work in a git worktree, never the main repo working tree. Use `git worktree add -b <dedicated-branch> <path> origin/main` per branch — **never** `git worktree add <path> main` (locking main into a worktree blocks operator/CI build).\n");
     content.push_str("- **Spawn site rationale** (§10.5): every `tokio::spawn` / `thread::spawn` site MUST carry `// fire-and-forget: <reason>` comment OR explicitly store JoinHandle for graceful join. Tests exempt; trait-method spawns inherit caller rationale. Phase 5b invariant test enforces.\n");
 

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -472,6 +472,22 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
             }
         }
 
+        // #1666 Phase A: reviewer-evidence gate. Only fires on actual verdict
+        // reports (summary STARTS WITH VERIFIED/REJECTED/UNVERIFIED — §3.12
+        // convention, so non-verdict reports are never touched). VERIFIED/
+        // REJECTED must carry an evidence token; UNVERIFIED is exempt. Scans
+        // summary + artifacts (evidence may live in either) and reuses the
+        // sha_gate reject path (`json!({"error"})` → back to the reviewer).
+        if let Some(verdict) = super::evidence_gate::detect_verdict(summary) {
+            let evidence_body = match args["artifacts"].as_str() {
+                Some(a) => format!("{summary}\n{a}"),
+                None => summary.to_string(),
+            };
+            if let Err(e) = super::evidence_gate::check_evidence_gate(&evidence_body, verdict) {
+                return json!({"error": e});
+            }
+        }
+
         match crate::api::call(
             home,
             &json!({

--- a/src/mcp/handlers/evidence_gate.rs
+++ b/src/mcp/handlers/evidence_gate.rs
@@ -1,0 +1,159 @@
+//! #1666 Phase A: reviewer-evidence gate. A `VERIFIED`/`REJECTED` verdict must
+//! carry recognizable evidence — a command actually run, or a `path:line`
+//! source citation — else the daemon rejects it back to the reviewer (reusing
+//! sha_gate's reject path). Modeled on `sha_gate` (pure fn + injected-free unit
+//! tests).
+//!
+//! ⚠ LENIENT BY DESIGN. False-reject is the real risk here: this is a forcing
+//! function on the review pipeline, so an over-strict parser would block legit
+//! verdicts. The gate accepts ANY recognized evidence token and rejects ONLY
+//! when none is present — it does NOT enforce a format. `UNVERIFIED` ("claimed
+//! but unproven") is exempt.
+
+use std::sync::LazyLock;
+
+/// A recognized reviewer verdict. Detected via the §3.12 canonical convention —
+/// the report text (trimmed) STARTS WITH the verdict word. Starts-with (not a
+/// substring scan) is what keeps the gate OFF non-verdict reports: a dev
+/// completion note mentioning "dual-VERIFIED" does not *start* with it, so it is
+/// never gated. Mirrors `auto_release::is_verdict_message`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Verdict {
+    Verified,
+    Rejected,
+    Unverified,
+}
+
+/// Detect the verdict a report carries, or `None` when it is not a verdict
+/// report (so the gate never touches ordinary status/completion reports).
+pub(crate) fn detect_verdict(summary: &str) -> Option<Verdict> {
+    let t = summary.trim_start();
+    // UNVERIFIED first — it contains "VERIFIED" as a substring.
+    if t.starts_with("UNVERIFIED") {
+        Some(Verdict::Unverified)
+    } else if t.starts_with("VERIFIED") {
+        Some(Verdict::Verified)
+    } else if t.starts_with("REJECTED") {
+        Some(Verdict::Rejected)
+    } else {
+        None
+    }
+}
+
+/// `filename.ext:line` citation, e.g. `src/comms.rs:464`. The `.<ext>:<digits>`
+/// shape distinguishes a real source cite from `key: value` or a `12:34` time.
+static PATH_LINE_CITE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"[A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*:\d+")
+        .expect("BUG: evidence path:line cite regex must compile")
+});
+
+/// LENIENT evidence detector — any ONE of these counts as evidence:
+/// - a structured prefix the L1 doc asks for (`ran:` / `cited:` / `### Evidence`)
+/// - a command actually run (the doc lists `cargo`|`gh`|`clippy`|`grep`; `rg` is
+///   grep's sibling)
+/// - a `path:line` source citation
+pub(crate) fn has_evidence_token(body: &str) -> bool {
+    if body.contains("ran:") || body.contains("cited:") || body.contains("### Evidence") {
+        return true;
+    }
+    const CMD_TOKENS: &[&str] = &["cargo ", "cargo\n", "clippy", "grep", "rg ", "gh ", "gh\n"];
+    if CMD_TOKENS.iter().any(|t| body.contains(t)) {
+        return true;
+    }
+    PATH_LINE_CITE.is_match(body)
+}
+
+/// #1666: gate a verdict report on evidence. `VERIFIED`/`REJECTED` must carry a
+/// recognizable evidence token; `UNVERIFIED` is exempt. Returns `Err(msg)` to
+/// reject the verdict back to the reviewer.
+pub(crate) fn check_evidence_gate(body: &str, verdict: Verdict) -> Result<(), String> {
+    if matches!(verdict, Verdict::Unverified) {
+        return Ok(()); // "claimed but unproven" — evidence not required.
+    }
+    if has_evidence_token(body) {
+        return Ok(());
+    }
+    Err(format!(
+        "{verdict:?} verdict carries no evidence — add an `### Evidence` block with \
+         `ran: <cmd> → <result>` (e.g. cargo test / clippy / `gh pr checks`) and/or \
+         `cited: path:line — quote`. Re-send with evidence. (UNVERIFIED is exempt — \
+         use it for a claimed-but-unproven finding.)"
+    ))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // ── detect_verdict: starts-with, UNVERIFIED-first, no prose false-fire ──
+    #[test]
+    fn detect_verdict_starts_with_only() {
+        assert_eq!(
+            detect_verdict("VERIFIED — looks good"),
+            Some(Verdict::Verified)
+        );
+        assert_eq!(detect_verdict("  REJECTED: bug"), Some(Verdict::Rejected));
+        // UNVERIFIED must win over its VERIFIED substring.
+        assert_eq!(
+            detect_verdict("UNVERIFIED — claimed but unproven"),
+            Some(Verdict::Unverified)
+        );
+        // A non-verdict report mentioning the word mid-text is NOT gated.
+        assert_eq!(
+            detect_verdict("#1604 COMPLETE — dual-VERIFIED, merged"),
+            None
+        );
+        assert_eq!(detect_verdict("task done"), None);
+    }
+
+    // ── the lead's required matrix ──
+    #[test]
+    fn verified_with_cargo_passes() {
+        let body = "VERIFIED\n### Evidence\nran: cargo test → 263 passed";
+        assert!(check_evidence_gate(body, Verdict::Verified).is_ok());
+    }
+
+    #[test]
+    fn verified_with_path_line_passes() {
+        let body = "VERIFIED — cited: src/comms.rs:464 — gate hooked beside sha_gate";
+        assert!(check_evidence_gate(body, Verdict::Verified).is_ok());
+    }
+
+    #[test]
+    fn verified_with_no_evidence_rejects() {
+        let body = "VERIFIED — looks fine to me, lgtm";
+        let r = check_evidence_gate(body, Verdict::Verified);
+        assert!(r.is_err(), "no-evidence VERIFIED must reject: {r:?}");
+    }
+
+    #[test]
+    fn unverified_with_no_evidence_passes_exempt() {
+        let body = "UNVERIFIED — couldn't reproduce, claimed but unproven";
+        assert!(
+            check_evidence_gate(body, Verdict::Unverified).is_ok(),
+            "UNVERIFIED is exempt"
+        );
+    }
+
+    #[test]
+    fn rejected_with_evidence_passes() {
+        let body = "REJECTED\nran: cargo clippy → error[E0382] at src/foo.rs:12";
+        assert!(check_evidence_gate(body, Verdict::Rejected).is_ok());
+    }
+
+    // ── leniency: each token shape independently counts ──
+    #[test]
+    fn each_evidence_token_shape_counts() {
+        assert!(has_evidence_token("ran: cargo test"));
+        assert!(has_evidence_token("cited: src/x.rs:9"));
+        assert!(has_evidence_token("### Evidence\n..."));
+        assert!(has_evidence_token("checked via gh pr checks 123"));
+        assert!(has_evidence_token("grep -rn foo src/"));
+        assert!(has_evidence_token("ran clippy clean"));
+        assert!(has_evidence_token("see src/state/mod.rs:314"));
+        // path:line shape is specific — these are NOT cites.
+        assert!(!has_evidence_token("lgtm, ship it"));
+        assert!(!has_evidence_token("ratio 12:34 looks ok"));
+    }
+}

--- a/src/mcp/handlers/evidence_gate.rs
+++ b/src/mcp/handlers/evidence_gate.rs
@@ -12,11 +12,12 @@
 
 use std::sync::LazyLock;
 
-/// A recognized reviewer verdict. Detected via the §3.12 canonical convention —
-/// the report text (trimmed) STARTS WITH the verdict word. Starts-with (not a
-/// substring scan) is what keeps the gate OFF non-verdict reports: a dev
-/// completion note mentioning "dual-VERIFIED" does not *start* with it, so it is
-/// never gated. Mirrors `auto_release::is_verdict_message`.
+/// A recognized reviewer verdict. Detected (see [`detect_verdict`]) when the
+/// verdict word is the LEADING token of the report — after stripping leading
+/// whitespace + markdown line-prefixes. Leading-token (not a substring scan) is
+/// what keeps the gate OFF non-verdict reports: a dev completion note mentioning
+/// "dual-VERIFIED" mid-text is never gated. Mirrors the §3.12 verdict convention
+/// (`auto_release::is_verdict_message`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Verdict {
     Verified,
@@ -26,18 +27,34 @@ pub(crate) enum Verdict {
 
 /// Detect the verdict a report carries, or `None` when it is not a verdict
 /// report (so the gate never touches ordinary status/completion reports).
+///
+/// #1668 (codex catch): strip leading whitespace AND markdown line-prefixes
+/// (`>`, `-`, `*`, `#`, in any combination) BEFORE the match — otherwise a
+/// reviewer could evade the gate by markdown-prefixing the verdict
+/// (`> VERIFIED` / `## VERIFIED`). After stripping, the verdict word must be the
+/// leading TOKEN: it matches only when followed by end-of-string or a
+/// non-alphanumeric boundary, so `VERIFIED`/`VERIFIED:`/`VERIFIED —` match while
+/// `dual-VERIFIED` (no prefix to strip; doesn't start with the word) and
+/// `#1604 … dual-VERIFIED` (strips `#` → leads with `1604`) stay `None`. This
+/// preserves the original mid-text-false-positive protection.
 pub(crate) fn detect_verdict(summary: &str) -> Option<Verdict> {
-    let t = summary.trim_start();
-    // UNVERIFIED first — it contains "VERIFIED" as a substring.
-    if t.starts_with("UNVERIFIED") {
-        Some(Verdict::Unverified)
-    } else if t.starts_with("VERIFIED") {
-        Some(Verdict::Verified)
-    } else if t.starts_with("REJECTED") {
-        Some(Verdict::Rejected)
-    } else {
-        None
+    let t = summary
+        .trim_start_matches(|c: char| c.is_whitespace() || matches!(c, '>' | '-' | '*' | '#'));
+    // UNVERIFIED first — it shares the "VERIFIED" tail (strip_prefix already
+    // disambiguates, but keep the order explicit).
+    for (word, verdict) in [
+        ("UNVERIFIED", Verdict::Unverified),
+        ("VERIFIED", Verdict::Verified),
+        ("REJECTED", Verdict::Rejected),
+    ] {
+        if let Some(rest) = t.strip_prefix(word) {
+            // Bounded token: EOL or a non-alphanumeric char (rejects `VERIFIEDx`).
+            if rest.chars().next().is_none_or(|c| !c.is_alphanumeric()) {
+                return Some(verdict);
+            }
+        }
     }
+    None
 }
 
 /// `filename.ext:line` citation, e.g. `src/comms.rs:464`. The `.<ext>:<digits>`
@@ -86,9 +103,9 @@ pub(crate) fn check_evidence_gate(body: &str, verdict: Verdict) -> Result<(), St
 mod tests {
     use super::*;
 
-    // ── detect_verdict: starts-with, UNVERIFIED-first, no prose false-fire ──
+    // ── detect_verdict: leading-token match, UNVERIFIED-first, no prose FP ──
     #[test]
-    fn detect_verdict_starts_with_only() {
+    fn detect_verdict_leading_token() {
         assert_eq!(
             detect_verdict("VERIFIED — looks good"),
             Some(Verdict::Verified)
@@ -104,7 +121,43 @@ mod tests {
             detect_verdict("#1604 COMPLETE — dual-VERIFIED, merged"),
             None
         );
+        assert_eq!(detect_verdict("dual-VERIFIED"), None);
         assert_eq!(detect_verdict("task done"), None);
+        assert_eq!(detect_verdict("ratio 12:34 ok"), None);
+        // `VERIFIEDx` is not the verdict word (alphanumeric boundary).
+        assert_eq!(detect_verdict("VERIFIEDish maybe"), None);
+    }
+
+    /// #1668 (codex catch): markdown-prefixed verdicts must NOT evade the gate.
+    /// Stripping leading `>`/`-`/`*`/`#`/whitespace (any combination) before the
+    /// token match — WITHOUT reintroducing the mid-text false-positive.
+    #[test]
+    fn detect_verdict_strips_markdown_prefixes_1668() {
+        // GATED now (were evading via trim_start()-only):
+        for s in [
+            "> VERIFIED",
+            "- VERIFIED",
+            "* VERIFIED",
+            "## VERIFIED",
+            ">VERIFIED",        // no space
+            "  > VERIFIED",     // whitespace + prefix
+            "> - * # VERIFIED", // any combination
+            "- REJECTED: nope",
+            "> UNVERIFIED",
+        ] {
+            assert!(
+                detect_verdict(s).is_some(),
+                "#1668: markdown-prefixed verdict must be detected: {s:?}"
+            );
+        }
+        assert_eq!(detect_verdict("> VERIFIED"), Some(Verdict::Verified));
+        assert_eq!(detect_verdict("## REJECTED — x"), Some(Verdict::Rejected));
+        assert_eq!(detect_verdict("> UNVERIFIED"), Some(Verdict::Unverified));
+
+        // Protection must SURVIVE: stripping leading `#` then leading with a
+        // non-verdict token stays None (no new mid-text false-positive).
+        assert_eq!(detect_verdict("#1604 COMPLETE — dual-VERIFIED"), None);
+        assert_eq!(detect_verdict("- some bullet, later VERIFIED"), None);
     }
 
     // ── the lead's required matrix ──

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod ci;
 mod comms;
 pub(crate) mod dispatch;
 pub(crate) mod dispatch_hook;
+pub(crate) mod evidence_gate;
 mod force_release;
 pub(crate) mod instance;
 pub(crate) mod instance_lifecycle;


### PR DESCRIPTION
## What — meta-leverage: every future review must carry evidence
A `VERIFIED`/`REJECTED` verdict must carry **evidence** (a command actually run, or a `path:line` citation), enforced at report time. Self-applies to this fleet once shipped.

### L1 (protocol / doc)
- `docs/FLEET-DEV-PROTOCOL.md` §3.3 + `src/instructions.rs` verdict contract gain an **`### Evidence`** block requirement: `ran: <cmd> → <result>` and/or `cited: path:line — quote`.
- **`UNVERIFIED` redefined = "claimed but unproven"** — the evidence-EXEMPT verdict, so the gate never forces fabricated evidence.
- §3.21 risk-tier review DEPTH stays lead/reviewer judgment — **not** daemon-enforced.

### L2 (daemon HARD gate)
- New `src/mcp/handlers/evidence_gate.rs`, modeled exactly on `sha_gate.rs` (pure fns + injected-free unit tests). `check_evidence_gate(body, verdict)` rejects an evidence-less VERIFIED/REJECTED; UNVERIFIED exempt.
- **Hook (spike finding):** beside the SHA-gate in `comms.rs::handle_report_result` (~464). Reuses the identical `return json!({"error": e})` path → the reject propagates back to the reviewer as the tool result. Scans `summary` + `artifacts`.

## ⚠ Load-bearing constraint: false-reject is the real risk — two protections
1. **`detect_verdict` keys on the §3.12 convention** — the report `trim_start().starts_with` the verdict word (mirrors `auto_release::is_verdict_message`). Starts-with (not a substring scan) keeps the gate **off non-verdict reports**: a dev note saying "dual-VERIFIED" doesn't *start* with it → never gated.
2. **Lenient parser** — accepts ANY one recognized token and rejects ONLY on total absence; does NOT enforce a format.

### Evidence-token grammar (spike finding)
Any ONE counts: `ran:` / `cited:` / `### Evidence`; a `cargo`/`gh `/`clippy`/`grep`/`rg ` command mention; or a `filename.ext:line` cite (regex `[A-Za-z0-9_./-]+\.[A-Za-z][A-Za-z0-9]*:\d+` — the `.<ext>:<digits>` shape excludes `key: value` / `12:34`).

## Tests (evidence_gate)
The lead's matrix — VERIFIED+cargo→pass, VERIFIED+path:line→pass, VERIFIED+no-evidence→**reject**, UNVERIFIED+no-evidence→pass(exempt), REJECTED+evidence→pass — plus `detect_verdict` starts-with/UNVERIFIED-first/no-prose-false-fire and a per-token leniency sweep (incl. `12:34`/`lgtm` negatives).

Not Phase B (L3 truth cross-check) — separate task.

## Preflight
`cargo fmt`; `clippy --all-targets -- -D warnings` clean for `tray` + `tray,discord`; evidence_gate(7) + comms(4) + handlers::tests(109) + instructions(47) + file_size_invariant pass.

Closes #1666 (Phase A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)