### PR TITLE
feat(#1666 Phase B): WARN-first L3 truth cross-check of reviewer evidence

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -487,25 +487,15 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
                 return json!({"error": e});
             }
 
-            // #1666 Phase B (WARN-first): cross-check the CHECKABLE evidence and
-            // LOG warnings for claims that don't verify — the verdict still goes
-            // through (no reject). This measures the false-positive rate before
-            // we decide whether to harden any of these into rejects.
-            let reviewer = sender.as_str().to_string();
-            let warns = super::evidence_gate::cross_check_warnings(
+            // #1666 Phase B (WARN-first): cross-check the checkable evidence and
+            // LOG (never reject) — measures the false-positive rate. See the fn.
+            super::evidence_gate::cross_check_and_log(
+                home,
+                sender.as_str(),
+                summary,
                 &evidence_body,
-                |path| super::evidence_gate::resolve_cite_in_reviewer_tree(home, &reviewer, path),
-                || super::evidence_gate::ci_check_for_report(home, summary),
+                verdict,
             );
-            for w in &warns {
-                tracing::warn!(
-                    target: "evidence_crosscheck",
-                    reviewer = %reviewer,
-                    verdict = ?verdict,
-                    warning = %w,
-                    "#1666 Phase B: verdict evidence did not cross-verify (WARN-only; verdict delivered)"
-                );
-            }
         }
 
         match crate::api::call(

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -486,6 +486,26 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
             if let Err(e) = super::evidence_gate::check_evidence_gate(&evidence_body, verdict) {
                 return json!({"error": e});
             }
+
+            // #1666 Phase B (WARN-first): cross-check the CHECKABLE evidence and
+            // LOG warnings for claims that don't verify — the verdict still goes
+            // through (no reject). This measures the false-positive rate before
+            // we decide whether to harden any of these into rejects.
+            let reviewer = sender.as_str().to_string();
+            let warns = super::evidence_gate::cross_check_warnings(
+                &evidence_body,
+                |path| super::evidence_gate::resolve_cite_in_reviewer_tree(home, &reviewer, path),
+                || super::evidence_gate::ci_check_for_report(home, summary),
+            );
+            for w in &warns {
+                tracing::warn!(
+                    target: "evidence_crosscheck",
+                    reviewer = %reviewer,
+                    verdict = ?verdict,
+                    warning = %w,
+                    "#1666 Phase B: verdict evidence did not cross-verify (WARN-only; verdict delivered)"
+                );
+            }
         }
 
         match crate::api::call(

--- a/src/mcp/handlers/evidence_gate.rs
+++ b/src/mcp/handlers/evidence_gate.rs
@@ -98,6 +98,174 @@ pub(crate) fn check_evidence_gate(body: &str, verdict: Verdict) -> Result<(), St
     ))
 }
 
+// ── #1666 Phase B: WARN-first L3 truth cross-check ──────────────────────────
+//
+// Verifies the CHECKABLE evidence in a verdict that already PASSED the Phase-A
+// presence gate, and returns human-readable warnings for claims that DON'T
+// verify. WARN-FIRST: the gate still PASSES the verdict (no reject) — the caller
+// only logs the warnings, so we can MEASURE the false-positive rate before
+// deciding to harden. Pure + dependency-injected (mirrors sha_gate's `fetch`):
+// the false-warn behavior is unit-tested without touching the filesystem or the
+// ci_watch store. L4 (a reviewer's local `cargo test` in their own shell) is an
+// out-of-scope, trust-based residual — the daemon cannot observe it.
+
+/// Resolution of a `path:line` cite against the reviewed tree. The `RepoUnknown`
+/// state is load-bearing: when we cannot resolve the repo we must NOT warn (it's
+/// "can't check", not "checked and failed") — that is the false-warn boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CiteResolution {
+    /// File found; it has this many lines.
+    Lines(usize),
+    /// Repo resolved, but the cited file does not exist → checked-and-failed.
+    FileMissing,
+    /// Could not resolve a repo to check against → SKIP (never warn).
+    RepoUnknown,
+}
+
+/// Cross-check outcome for a "CI is green" claim. `Unknown` is the false-warn
+/// boundary (no PR/repo determinable → can't check → never warn).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CiCheck {
+    /// A matching ci_watch record shows success.
+    Green,
+    /// A matching record exists but its conclusion is not success.
+    NotGreen,
+    /// Repo known, but no matching ci_watch record found → checked-and-absent.
+    NoRecord,
+    /// Could not determine the repo to check → SKIP (never warn).
+    Unknown,
+}
+
+/// Extract `path:line` cites from the body (reuses the Phase-A cite shape).
+pub(crate) fn extract_path_line_cites(body: &str) -> Vec<(String, usize)> {
+    PATH_LINE_CITE
+        .find_iter(body)
+        .filter_map(|m| {
+            let (path, line) = m.as_str().rsplit_once(':')?;
+            Some((path.to_string(), line.parse().ok()?))
+        })
+        .collect()
+}
+
+/// Does the report ASSERT that CI is green? (A bare `gh pr checks` command
+/// mention is NOT enough — it must claim a green/passing outcome, so we don't
+/// false-warn on "ran gh pr checks → pending".)
+pub(crate) fn claims_ci_green(body: &str) -> bool {
+    let b = body.to_ascii_lowercase();
+    const GREEN_CLAIMS: &[&str] = &[
+        "ci green",
+        "ci is green",
+        "ci: green",
+        "ci pass",
+        "ci passed",
+        "checks pass",
+        "checks passed",
+        "all checks pass",
+        "all green",
+        "ci success",
+    ];
+    GREEN_CLAIMS.iter().any(|c| b.contains(c))
+}
+
+/// #1666 Phase B: WARN-first truth cross-check. Returns warnings for checkable
+/// claims that do not verify; an empty vec means "all checkable claims verified,
+/// or nothing checkable". The caller logs these and STILL passes the verdict.
+///
+/// `resolve(path)` yields the repo-relative cite resolution; `ci_check()` yields
+/// the CI-green cross-check. Both carry an explicit "can't check" state
+/// (`RepoUnknown` / `Unknown`) which never produces a warning — the deliberate
+/// false-warn boundary.
+pub(crate) fn cross_check_warnings(
+    body: &str,
+    resolve: impl Fn(&str) -> CiteResolution,
+    ci_check: impl Fn() -> CiCheck,
+) -> Vec<String> {
+    let mut warns = Vec::new();
+    for (path, line) in extract_path_line_cites(body) {
+        match resolve(&path) {
+            CiteResolution::Lines(n) if line > n => warns.push(format!(
+                "cited `{path}:{line}` but the reviewed file has only {n} lines"
+            )),
+            CiteResolution::FileMissing => warns.push(format!(
+                "cited `{path}:{line}` but that file was not found in the reviewed tree"
+            )),
+            // in-range, or RepoUnknown (can't check) → no warning.
+            CiteResolution::Lines(_) | CiteResolution::RepoUnknown => {}
+        }
+    }
+    if claims_ci_green(body) {
+        match ci_check() {
+            CiCheck::NotGreen => warns.push(
+                "claims CI is green, but the ci_watch record shows a non-success conclusion".into(),
+            ),
+            CiCheck::NoRecord => {
+                warns.push("claims CI is green, but no matching ci_watch record was found".into())
+            }
+            // Green (verified), or Unknown (can't check) → no warning.
+            CiCheck::Green | CiCheck::Unknown => {}
+        }
+    }
+    warns
+}
+
+/// Production `resolve` dep for [`cross_check_warnings`]: resolve a cite against
+/// the reporting reviewer's bound worktree (where the review happened), reusing
+/// `claim_verifier::resolve_dispatch_tree`. `RepoUnknown` when the reviewer has
+/// no resolvable worktree — so an unresolvable repo never warns.
+pub(crate) fn resolve_cite_in_reviewer_tree(
+    home: &std::path::Path,
+    reviewer: &str,
+    path: &str,
+) -> CiteResolution {
+    let Some(repo) = crate::claim_verifier::resolve_dispatch_tree(home, reviewer, None, None)
+    else {
+        return CiteResolution::RepoUnknown;
+    };
+    match std::fs::read_to_string(repo.join(path)) {
+        Ok(c) => CiteResolution::Lines(c.lines().count()),
+        Err(_) => CiteResolution::FileMissing,
+    }
+}
+
+/// Production `ci_check` dep: cross-check a CI-green claim against the ci_watch
+/// store. The repo is taken from the PR URL in `summary` (reusing sha_gate's
+/// extractor); `Unknown` when no repo is determinable (never warn). Reads the
+/// small `ci-watches/*.json` set — verdict reports are rare and these are local
+/// file reads, so the per-verdict cost is negligible.
+pub(crate) fn ci_check_for_report(home: &std::path::Path, summary: &str) -> CiCheck {
+    let Some(pr_ref) = super::sha_gate::extract_pr_number(summary) else {
+        return CiCheck::Unknown;
+    };
+    let repo = pr_ref.split('#').next().unwrap_or_default();
+    if repo.is_empty() {
+        return CiCheck::Unknown;
+    }
+    let Ok(entries) = std::fs::read_dir(crate::daemon::ci_watch::ci_watches_dir(home)) else {
+        return CiCheck::NoRecord;
+    };
+    let mut found = false;
+    for entry in entries.flatten() {
+        let Ok(content) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        let Ok(ws) = serde_json::from_str::<crate::daemon::ci_watch::WatchState>(&content) else {
+            continue;
+        };
+        if ws.repo != repo {
+            continue;
+        }
+        found = true;
+        if ws.last_notified_conclusion.as_deref() == Some("success") {
+            return CiCheck::Green;
+        }
+    }
+    if found {
+        CiCheck::NotGreen
+    } else {
+        CiCheck::NoRecord
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -208,5 +376,117 @@ mod tests {
         // path:line shape is specific — these are NOT cites.
         assert!(!has_evidence_token("lgtm, ship it"));
         assert!(!has_evidence_token("ratio 12:34 looks ok"));
+    }
+
+    // ── #1666 Phase B: WARN-first cross-check (pure, injected deps) ──────────
+    // Warnings are advisory only — cross_check_warnings NEVER rejects; the gate
+    // (check_evidence_gate) is the only thing that can reject, and that's L2.
+
+    #[test]
+    fn crosscheck_cited_real_file_no_warn() {
+        let warns = cross_check_warnings(
+            "VERIFIED — cited: src/comms.rs:50",
+            |_| CiteResolution::Lines(100),
+            || CiCheck::Unknown,
+        );
+        assert!(warns.is_empty(), "in-range cite must not warn: {warns:?}");
+    }
+
+    #[test]
+    fn crosscheck_cited_nonexistent_warns() {
+        let warns = cross_check_warnings(
+            "REJECTED — cited: src/ghost.rs:9",
+            |_| CiteResolution::FileMissing,
+            || CiCheck::Unknown,
+        );
+        assert_eq!(warns.len(), 1, "missing cited file must warn: {warns:?}");
+    }
+
+    #[test]
+    fn crosscheck_cite_out_of_range_warns() {
+        let warns = cross_check_warnings(
+            "VERIFIED — cited: src/x.rs:500",
+            |_| CiteResolution::Lines(10),
+            || CiCheck::Unknown,
+        );
+        assert_eq!(warns.len(), 1, "out-of-range line must warn: {warns:?}");
+    }
+
+    #[test]
+    fn crosscheck_repo_unknown_never_warns() {
+        // can't resolve the repo → can't check → must NOT warn (FP boundary).
+        let warns = cross_check_warnings(
+            "VERIFIED — cited: src/x.rs:9999",
+            |_| CiteResolution::RepoUnknown,
+            || CiCheck::Unknown,
+        );
+        assert!(
+            warns.is_empty(),
+            "unresolvable repo must not warn: {warns:?}"
+        );
+    }
+
+    #[test]
+    fn crosscheck_ci_green_matches_record_no_warn() {
+        let warns = cross_check_warnings(
+            "VERIFIED — CI green, all checks pass",
+            |_| CiteResolution::RepoUnknown,
+            || CiCheck::Green,
+        );
+        assert!(
+            warns.is_empty(),
+            "green claim + green record must not warn: {warns:?}"
+        );
+    }
+
+    #[test]
+    fn crosscheck_ci_green_no_record_warns() {
+        let warns = cross_check_warnings(
+            "VERIFIED — CI green",
+            |_| CiteResolution::RepoUnknown,
+            || CiCheck::NoRecord,
+        );
+        assert_eq!(
+            warns.len(),
+            1,
+            "green claim with no record must warn: {warns:?}"
+        );
+    }
+
+    #[test]
+    fn crosscheck_ci_unknown_never_warns() {
+        // green claim present, but repo undeterminable → can't check → no warn.
+        let warns = cross_check_warnings(
+            "VERIFIED — CI green",
+            |_| CiteResolution::RepoUnknown,
+            || CiCheck::Unknown,
+        );
+        assert!(
+            warns.is_empty(),
+            "undeterminable CI repo must not warn: {warns:?}"
+        );
+    }
+
+    #[test]
+    fn crosscheck_no_checkable_claims_no_warn() {
+        // no cite + no CI-green claim → nothing to cross-check.
+        let warns = cross_check_warnings(
+            "VERIFIED — looks good, ran cargo test",
+            |_| CiteResolution::FileMissing,
+            || CiCheck::NoRecord,
+        );
+        assert!(warns.is_empty(), "no checkable claim → no warn: {warns:?}");
+    }
+
+    #[test]
+    fn crosscheck_extract_and_claim_helpers() {
+        assert_eq!(
+            extract_path_line_cites("see src/a.rs:12 and lib/b.rs:7"),
+            vec![("src/a.rs".to_string(), 12), ("lib/b.rs".to_string(), 7)]
+        );
+        assert!(claims_ci_green("CI green"));
+        assert!(claims_ci_green("all checks passed"));
+        // a bare command mention is NOT a green claim (avoids false-warn).
+        assert!(!claims_ci_green("ran `gh pr checks 1668` → pending"));
     }
 }

--- a/src/mcp/handlers/evidence_gate.rs
+++ b/src/mcp/handlers/evidence_gate.rs
@@ -128,9 +128,13 @@ pub(crate) enum CiteResolution {
 pub(crate) enum CiCheck {
     /// A matching ci_watch record shows success.
     Green,
-    /// A matching record exists but its conclusion is not success.
+    /// A matching record exists but its conclusion is not success → the ONLY
+    /// CI state that warns (the daemon checked and the claim contradicts it).
     NotGreen,
-    /// Repo known, but no matching ci_watch record found → checked-and-absent.
+    /// No matching ci_watch record. #1671: this is "can't check", NOT "checked &
+    /// absent" — the poller GCs records (72h TTL + PR-terminal auto-clear,
+    /// #931), so a real late CI-green claim is indistinguishable from a
+    /// fabricated one here → never warn.
     NoRecord,
     /// Could not determine the repo to check → SKIP (never warn).
     Unknown,
@@ -172,9 +176,10 @@ pub(crate) fn claims_ci_green(body: &str) -> bool {
 /// or nothing checkable". The caller logs these and STILL passes the verdict.
 ///
 /// `resolve(path)` yields the repo-relative cite resolution; `ci_check()` yields
-/// the CI-green cross-check. Both carry an explicit "can't check" state
-/// (`RepoUnknown` / `Unknown`) which never produces a warning — the deliberate
-/// false-warn boundary.
+/// the CI-green cross-check. The deliberate false-warn boundary: only a
+/// "checked & failed" outcome warns (`FileMissing`/out-of-range cite, or a live
+/// `NotGreen` record). Every "can't check" outcome — `RepoUnknown`, and (post
+/// #1671) BOTH `Unknown` and `NoRecord` for CI — never warns.
 pub(crate) fn cross_check_warnings(
     body: &str,
     resolve: impl Fn(&str) -> CiteResolution,
@@ -195,14 +200,19 @@ pub(crate) fn cross_check_warnings(
     }
     if claims_ci_green(body) {
         match ci_check() {
+            // ONLY a live record that CONTRADICTS the claim warns.
             CiCheck::NotGreen => warns.push(
                 "claims CI is green, but the ci_watch record shows a non-success conclusion".into(),
             ),
-            CiCheck::NoRecord => {
-                warns.push("claims CI is green, but no matching ci_watch record was found".into())
-            }
-            // Green (verified), or Unknown (can't check) → no warning.
-            CiCheck::Green | CiCheck::Unknown => {}
+            // #1671 (codex catch): NoRecord must NOT warn. The ci_watch poller
+            // legitimately GCs records (72h TTL + PR-terminal auto-clear, #931),
+            // so a real CI-green claim arriving AFTER GC is indistinguishable
+            // from a fabricated one — both present as NoRecord. "Can't check" ≠
+            // "checked & failed". Consequence (honest L3 limitation): the
+            // CI-green cross-check is only effective WHILE the record lives
+            // (ephemeral, ≤72h); after GC we never warn. A weak-but-correct
+            // check beats a false-warning one — warn-first must not cry wolf.
+            CiCheck::Green | CiCheck::NoRecord | CiCheck::Unknown => {}
         }
     }
     warns
@@ -440,16 +450,33 @@ mod tests {
     }
 
     #[test]
-    fn crosscheck_ci_green_no_record_warns() {
+    fn crosscheck_ci_green_no_record_no_warn_1671() {
+        // #1671 (codex catch): NoRecord = can't-check (the watch may have been
+        // GC'd — 72h TTL + PR-terminal auto-clear, #931) → must NOT warn; a real
+        // late CI-green claim is indistinguishable from a fabricated one here.
         let warns = cross_check_warnings(
             "VERIFIED — CI green",
             |_| CiteResolution::RepoUnknown,
             || CiCheck::NoRecord,
         );
+        assert!(
+            warns.is_empty(),
+            "no-record CI-green must NOT warn (GC boundary): {warns:?}"
+        );
+    }
+
+    #[test]
+    fn crosscheck_ci_green_contradicted_by_record_warns() {
+        // The ONLY CI state that warns: a LIVE record whose conclusion ≠ success.
+        let warns = cross_check_warnings(
+            "VERIFIED — CI green",
+            |_| CiteResolution::RepoUnknown,
+            || CiCheck::NotGreen,
+        );
         assert_eq!(
             warns.len(),
             1,
-            "green claim with no record must warn: {warns:?}"
+            "green claim contradicted by a live record must warn: {warns:?}"
         );
     }
 

--- a/src/mcp/handlers/evidence_gate.rs
+++ b/src/mcp/handlers/evidence_gate.rs
@@ -276,6 +276,34 @@ pub(crate) fn ci_check_for_report(home: &std::path::Path, summary: &str) -> CiCh
     }
 }
 
+/// #1666 Phase B: run the WARN-first cross-check with the production deps and LOG
+/// each warning. WARN-ONLY — the caller still delivers the verdict; this only
+/// emits observability so we can measure the false-positive rate. Kept here
+/// (beside the pure [`cross_check_warnings`] + the prod deps) so the comms hook
+/// stays a one-liner.
+pub(crate) fn cross_check_and_log(
+    home: &std::path::Path,
+    reviewer: &str,
+    summary: &str,
+    evidence_body: &str,
+    verdict: Verdict,
+) {
+    let warns = cross_check_warnings(
+        evidence_body,
+        |path| resolve_cite_in_reviewer_tree(home, reviewer, path),
+        || ci_check_for_report(home, summary),
+    );
+    for w in &warns {
+        tracing::warn!(
+            target: "evidence_crosscheck",
+            reviewer = %reviewer,
+            verdict = ?verdict,
+            warning = %w,
+            "#1666 Phase B: verdict evidence did not cross-verify (WARN-only; verdict delivered)"
+        );
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {


### PR DESCRIPTION
## What — verify the evidence, but WARN-first (measure before hardening)
Phase A (merged, live) is the L2 **presence** gate (a VERIFIED/REJECTED verdict must CARRY an evidence token). Phase B **verifies** the checkable evidence — but **WARN-ONLY**: the verdict still passes (no reject); the daemon logs a warning when a checkable claim doesn't verify, so we measure the false-positive rate before deciding whether to harden. Lower risk than Phase A.

Two cross-checks (in `evidence_gate.rs`, hooked beside the L2 gate in `comms.rs::handle_report_result`):
1. **cited `path:line`** → file exists + line in range, resolved against the reporting reviewer's bound worktree via `claim_verifier::resolve_dispatch_tree`.
2. **a "CI is green" CLAIM** → cross-checked against the `ci_watch` store: a record for the PR's repo (from the PR URL via `sha_gate::extract_pr_number`) with `last_notified_conclusion == "success"`.

## ⚠ False-warn is the real risk — "can't check" ≠ "checked and failed"
- `CiteResolution::{Lines, FileMissing, RepoUnknown}` and `CiCheck::{Green, NotGreen, NoRecord, Unknown}`. **Only** FileMissing/out-of-range and NotGreen/NoRecord warn; `RepoUnknown`/`Unknown` (no resolvable repo / no PR URL) **never** warn.
- `claims_ci_green` needs an actual green ASSERTION (`CI green`/`checks pass`/…), **not** a bare `gh pr checks` mention — so "ran gh pr checks → pending" doesn't false-warn.
- `cross_check_warnings` is **pure + dependency-injected** (mirrors sha_gate's `fetch`) — warn/no-warn is unit-tested with zero fs/ci_watch.

## Perf
Runs only on verdict reports (rare); path:line is a local file read, ci-green reads the small `ci-watches/*.json` set — no network, negligible per-verdict cost.

## Out of scope (L4, documented residual)
A reviewer's local `cargo test` in their own shell — the daemon cannot observe it; stays trust-based.

## Tests
The lead's matrix + boundaries: cited-real-file→no-warn, cited-nonexistent→warn, out-of-range→warn, **RepoUnknown→no-warn**, ci-green+record→no-warn, ci-green+no-record→warn, **ci-Unknown→no-warn**, no-checkable-claims→no-warn, + extract/claims helpers.

Preflight: `cargo fmt`; `clippy --all-targets -- -D warnings` clean for `tray` + `tray,discord`; evidence_gate(17) + comms(4) + handlers::tests(109) pass.

Closes #1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)