### PR TITLE
spike(#8 Phase 2): validate BackendProfile data-bundle — byte-identical parity holds

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1162,6 +1162,10 @@ pub trait BackendBehavior {
     /// Whether state detection anchors on a red-rendered line (#1450). Delegates
     /// to [`Backend::should_anchor_on_red`].
     fn should_anchor_on_red(&self) -> bool;
+    /// #8 Phase 2: the co-located [`crate::backend_profile::BackendProfile`] for
+    /// this backend, or `None` while it's still on the legacy match path. The
+    /// Phase-2 seam — the migration train routes migrated backends through this.
+    fn profile(&self) -> Option<&'static crate::backend_profile::BackendProfile>;
 }
 
 impl BackendBehavior for Backend {
@@ -1176,6 +1180,9 @@ impl BackendBehavior for Backend {
     }
     fn should_anchor_on_red(&self) -> bool {
         Backend::should_anchor_on_red(self)
+    }
+    fn profile(&self) -> Option<&'static crate::backend_profile::BackendProfile> {
+        crate::backend_profile::profile(self)
     }
 }
 

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -1,0 +1,200 @@
+//! #8 Phase 2 VALIDATION (branch `spike/backend-profile-validation`).
+//!
+//! The team voted (3-1, ORIGINAL/per-variant-structs unanimously rejected) for
+//! the `BackendProfile` data-bundle: co-locate the per-backend detection data
+//! that today lives scattered across FIVE `match backend` sites in three files —
+//! `state::patterns::{for_backend, compile_for}` (patterns), `behavioral::
+//! {config_for, config_for_productivity}` (behavioral + productivity), and
+//! `state::StateTracker::new` (initial_state). One backend's full detection
+//! profile is gathered into ONE block here; a single trivial dispatch `match`
+//! replaces the five.
+//!
+//! This is a VALIDATION, not a migration: production is NOT rerouted (the legacy
+//! match paths are untouched, zero risk on the high-stakes #1523 detection
+//! surface). The equivalence harness below proves the moved data is
+//! BYTE-IDENTICAL to legacy for the migrated backends; the migration train then
+//! reroutes production one backend per PR, gated by that harness.
+//!
+//! Migrated here: `Shell`/`Raw` (empty — zero-risk shape proof) + `Agy` (the
+//! smallest REAL pattern set — proves the harness catches real-data drift).
+
+use crate::backend::Backend;
+use crate::behavioral::{BehavioralConfig, MarkerCacheId, ProductivityConfig};
+use crate::state::AgentState;
+use std::sync::OnceLock;
+
+/// All per-backend detection data for one backend, co-located.
+#[allow(dead_code)] // VALIDATION scaffold: consumed by the harness, not yet by prod.
+pub struct BackendProfile {
+    /// Raw `(state, regex)` detection patterns in priority order — compiled by
+    /// the state machine exactly as `StatePatterns::compile_for` does today.
+    pub patterns: Vec<(AgentState, &'static str)>,
+    pub behavioral: BehavioralConfig,
+    pub productivity: ProductivityConfig,
+    pub initial_state: AgentState,
+}
+
+/// The single dispatch: `Backend → &'static BackendProfile`, lazy-cached
+/// (compile-once, mirroring `StatePatterns::for_backend`'s `OnceLock`). Returns
+/// `None` for backends not yet migrated (their data still lives on the legacy
+/// match path). This `match` is the ONE unavoidable flat-enum lookup; the
+/// per-backend DATA lives in the builders below, one block each.
+#[allow(dead_code)] // VALIDATION: exposed via BackendBehavior::profile; prod reroute is the migration PR.
+pub fn profile(backend: &Backend) -> Option<&'static BackendProfile> {
+    static AGY: OnceLock<BackendProfile> = OnceLock::new();
+    // Shell + Raw share one profile — every legacy source treats `Shell | Raw(_)`
+    // identically (empty patterns, default behavioral, generic productivity, Ready).
+    static EMPTY: OnceLock<BackendProfile> = OnceLock::new();
+    match backend {
+        Backend::Agy => Some(AGY.get_or_init(agy_profile)),
+        Backend::Shell | Backend::Raw(_) => Some(EMPTY.get_or_init(empty_profile)),
+        _ => None,
+    }
+}
+
+/// Agy — moved VERBATIM from the four legacy sites (patterns.rs:693,
+/// behavioral.rs:98 + :459, state/mod.rs:619). The harness proves byte-identity.
+fn agy_profile() -> BackendProfile {
+    BackendProfile {
+        patterns: vec![
+            (
+                AgentState::PermissionPrompt,
+                r"Requesting permission for:|Do you trust the contents of this project|tab Amend · e edit command",
+            ),
+            (AgentState::ToolUse, r"●\s+[A-Z][a-zA-Z]+\("),
+            (AgentState::Thinking, r"esc to cancel"),
+            (AgentState::Idle, r"\? for shortcuts"),
+            (AgentState::Ready, r"Antigravity CLI|Type your message"),
+        ],
+        behavioral: BehavioralConfig {
+            silence_thinking_ms: 3000,
+            silence_idle_ms: 8000,
+            supports_cursor_query: false,
+        },
+        productivity: ProductivityConfig {
+            markers: crate::behavioral::GEMINI_PRODUCTIVE_MARKERS,
+            use_heartbeat: true,
+            heartbeat_fresh_window_ms: 10_000,
+            cache_id: Some(MarkerCacheId::Gemini),
+        },
+        initial_state: AgentState::Starting,
+    }
+}
+
+/// Shell / Raw — moved VERBATIM (empty patterns, default behavioral, generic
+/// productivity, Ready initial state).
+fn empty_profile() -> BackendProfile {
+    BackendProfile {
+        patterns: vec![],
+        behavioral: BehavioralConfig::default(),
+        productivity: ProductivityConfig {
+            markers: crate::behavioral::GENERIC_PRODUCTIVE_MARKERS,
+            use_heartbeat: false,
+            heartbeat_fresh_window_ms: 0,
+            cache_id: Some(MarkerCacheId::Generic),
+        },
+        initial_state: AgentState::Ready,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::behavioral::{config_for, config_for_productivity};
+    use crate::state::patterns::StatePatterns;
+    use crate::state::StateTracker;
+
+    fn migrated() -> Vec<Backend> {
+        vec![Backend::Agy, Backend::Shell, Backend::Raw("x".to_string())]
+    }
+
+    /// PRIMARY parity proof (structural, COMPLETE): the profile's raw patterns
+    /// equal the legacy compiled patterns' source strings + states + order.
+    /// Identical regex strings + order ⟹ identical detection — stronger than a
+    /// corpus sample (this is the answer to codex's "snapshot ≠ proof").
+    #[test]
+    fn profile_patterns_byte_identical_to_legacy() {
+        for b in migrated() {
+            let legacy: Vec<(AgentState, String)> =
+                StatePatterns::for_backend(&b).pattern_sources();
+            let prof: Vec<(AgentState, String)> = profile(&b)
+                .expect("migrated")
+                .patterns
+                .iter()
+                .map(|(s, p)| (*s, (*p).to_string()))
+                .collect();
+            assert_eq!(prof, legacy, "pattern source/state/order parity for {b:?}");
+        }
+    }
+
+    /// SECONDARY (behavioral): compile the profile's patterns and confirm
+    /// `detect` is identical to the legacy compiled patterns across a corpus.
+    /// Redundant given the structural proof above, but exercises the full
+    /// compile+detect pipeline.
+    #[test]
+    fn profile_detect_matches_legacy_on_corpus() {
+        let corpus = [
+            "Requesting permission for: write",
+            "Do you trust the contents of this project",
+            "tab Amend · e edit command",
+            "● Bash(ls -la)",
+            "● GenerateImage(prompt)",
+            "Analyzing the request… esc to cancel",
+            "? for shortcuts",
+            "Antigravity CLI v2",
+            "Type your message",
+            "just some unrelated prose with no anchors",
+            "● lowercase(x)", // must NOT match ToolUse ([A-Z] anchor)
+            "",
+        ];
+        for b in migrated() {
+            let legacy = StatePatterns::for_backend(&b);
+            let prof = StatePatterns::from_raw_patterns(&profile(&b).expect("migrated").patterns);
+            for item in corpus {
+                assert_eq!(
+                    prof.detect(item),
+                    legacy.detect(item),
+                    "detect parity for {b:?} on {item:?}"
+                );
+            }
+        }
+    }
+
+    /// Behavioral + productivity + initial_state byte-identical to legacy
+    /// (Debug-string equality — the configs are `Copy`, not `PartialEq`).
+    #[test]
+    fn profile_configs_byte_identical_to_legacy() {
+        for b in migrated() {
+            let p = profile(&b).expect("migrated");
+            assert_eq!(
+                format!("{:?}", p.behavioral),
+                format!("{:?}", config_for(&b)),
+                "behavioral parity for {b:?}"
+            );
+            assert_eq!(
+                format!("{:?}", p.productivity),
+                format!("{:?}", config_for_productivity(&b)),
+                "productivity parity for {b:?}"
+            );
+            assert_eq!(
+                p.initial_state,
+                StateTracker::new(Some(&b)).current,
+                "initial_state parity for {b:?}"
+            );
+        }
+    }
+
+    /// Non-migrated backends still return `None` (legacy path owns them).
+    #[test]
+    fn unmigrated_backends_have_no_profile_yet() {
+        for b in [
+            Backend::ClaudeCode,
+            Backend::KiroCli,
+            Backend::Codex,
+            Backend::OpenCode,
+            Backend::Gemini,
+        ] {
+            assert!(profile(&b).is_none(), "{b:?} must stay on the legacy path");
+        }
+    }
+}

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -332,7 +332,10 @@ pub enum MarkerCacheId {
 /// Generic structural anchors. File save banners + Claude-shape tool
 /// completion (kept here for Shell/Raw fallback). Each per-backend MARKERS
 /// const includes these three save-banner anchors via explicit duplication.
-const GENERIC_PRODUCTIVE_MARKERS: &[&str] = &[
+// #8 Phase 2: pub(crate) so the co-located BackendProfile (crate::backend_profile)
+// can reference these markers when bundling a backend's ProductivityConfig. The
+// arrays + their LazyLock compilation stay here (the profile holds &'static refs).
+pub(crate) const GENERIC_PRODUCTIVE_MARKERS: &[&str] = &[
     r"^Saved to \S+",
     r"^Wrote \d+ bytes",
     r"^Created file: \S+",
@@ -373,7 +376,7 @@ const CODEX_PRODUCTIVE_MARKERS: &[&str] = &[
 /// Gemini: generic anchors + `✓` completion glyph with Gemini CamelCase
 /// tool-name vocabulary. Excludes `tool.*call` / `MCP.*tool` literals
 /// (heartbeat path already covers MCP — avoid double-counting).
-const GEMINI_PRODUCTIVE_MARKERS: &[&str] = &[
+pub(crate) const GEMINI_PRODUCTIVE_MARKERS: &[&str] = &[
     r"^Saved to \S+",
     r"^Wrote \d+ bytes",
     r"^Created file: \S+",

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod app;
 mod auth_cookie;
 mod backend;
 mod backend_harness;
+mod backend_profile;
 mod behavioral;
 mod binding;
 mod bootstrap;

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -749,6 +749,37 @@ impl StatePatterns {
         self.detect_with_match(text).map(|(s, _)| s)
     }
 
+    /// #8 Phase 2 VALIDATION seam: compile a raw `(state, regex)` list exactly as
+    /// `compile_for` does — lets the parity harness compile a `BackendProfile`'s
+    /// patterns and run detection against them for a corpus cross-check.
+    #[cfg(test)]
+    #[allow(clippy::unwrap_used)]
+    pub(crate) fn from_raw_patterns(raw: &[(AgentState, &'static str)]) -> Self {
+        let compiled = raw
+            .iter()
+            .map(|(state, pat)| {
+                let re = Regex::new(pat)
+                    .unwrap_or_else(|e| panic!("BUG: invalid state regex {pat:?}: {e}"));
+                (*state, re)
+            })
+            .collect();
+        Self { patterns: compiled }
+    }
+
+    /// #8 Phase 2 VALIDATION seam: the compiled patterns as `(state, regex
+    /// source string)` pairs, in priority order. Equality of this with another
+    /// backend's raw pattern list is COMPLETE proof of detection parity
+    /// (identical regex strings, order, and states ⟹ identical compiled
+    /// detection) — stronger than a corpus sample. Used by
+    /// `crate::backend_profile`'s parity harness.
+    #[cfg(test)]
+    pub(crate) fn pattern_sources(&self) -> Vec<(AgentState, String)> {
+        self.patterns
+            .iter()
+            .map(|(state, re)| (*state, re.as_str().to_string()))
+            .collect()
+    }
+
     /// #919/#1450: detect + return the matched substring so callers can
     /// locate the phrase's rendered grid cells and check their foreground
     /// color (#1450 replaced the raw-byte SGR ring with VTerm cell color).


### PR DESCRIPTION
## #8 Phase 2 VALIDATION (team voted NEW 3-1) — validation report

Deliverable is a **validation report**, not a merge-chase: does the `BackendProfile` data-bundle work end-to-end, and does byte-identical parity hold? Production is **NOT rerouted** (legacy `match` paths untouched — zero risk on the #1523 detection surface); an equivalence harness proves the moved data is byte-identical, and the migration train reroutes later, gated by it.

### 1. Does byte-identical parity HOLD for Shell/Raw + Agy? — **YES**
4 harness tests, all green; 366 existing backend/state/behavioral tests pass **unchanged**:
- **STRUCTURAL (primary, COMPLETE):** `profile(b).patterns` == legacy compiled patterns' regex **source strings + states + order** (new test-only `StatePatterns::pattern_sources`). Identical raw strings + order ⟹ identical compiled detection. **This is complete proof for the pattern dimension — not a corpus sample** (directly answers codex's "snapshot ≠ proof").
- corpus `detect` parity (belt-and-suspenders, compiles the profile's patterns).
- behavioral / productivity (`{:?}` equality — `Copy`, not `PartialEq`) + `initial_state` (vs `StateTracker::new`) byte-identical.
- unmigrated backends return `None` (legacy owns them).

### 2. Shape clean? — **YES, with one inherent residual**
- `profile()` = **one** trivial dispatch `match`, `OnceLock`-cached (compile-once, mirrors `for_backend`). The per-backend DATA lives one-block-each.
- Exposed via the Phase-1 seam `BackendBehavior::profile(&self)` — composes cleanly.
- Lazy-cache preserved: production still uses `for_backend`'s `OnceLock` (untouched); the profile adds its own.
- **Residual (expected, not a defect):** one dispatch `match` remains — the unavoidable flat-enum lookup. The win is data co-location, not match-elimination (as the design vote concluded).

### 3. SURPRISE — the 5 sources don't cleanly merge across module boundaries
The headline finding for the migration train. Productivity's marker arrays (`GEMINI_/GENERIC_PRODUCTIVE_MARKERS`) are **behavioral.rs-private**, rightly bound to their `LazyLock` regex compilation — so bundling the `ProductivityConfig` required widening them to `pub(crate)`. Backends whose **patterns** reference patterns.rs-private shared consts (e.g. Claude's `SERVER_RATE_LIMIT_NET_ERRORS`) will need the same widening when migrated. **So the migration's hidden cost is incrementally widening per-module private visibility, not just relocating match arms.** (Minor: Agy's behavioral config is literally `BehavioralConfig::default()`.)

### 4. Is the harness trustworthy? (codex: "snapshot is a guardrail not proof")
**For a VERBATIM move, yes — and it's stronger than a corpus.** The primary check is STRUCTURAL: the profile's raw `(state, regex-source)` list equals legacy's, byte-for-byte, in order. Identical regex strings compile to identical matchers (`Regex::new` is deterministic) and priority order is preserved ⟹ detection is provably identical with **no corpus-coverage gap**. The corpus test is redundant insurance.
**Where it WOULD leak, and how to harden:** the structural proof holds because the migration is a verbatim move. If a future step *transforms* a pattern (refactors a regex), structural equality breaks and you'd fall back to corpus parity — where coverage is exactly codex's concern. Mitigation to bake into the migration harness: **auto-derive the corpus from the pattern literals themselves** (for each `(state, regex)`, generate a positive sample that matches + a near-miss), so every pattern branch is exercised by construction rather than a hand-picked corpus. For verbatim moves (the actual plan), structural equality already closes the gap.

### Recommendation
The approach validates cleanly. Proceed with the migration train (one backend per PR, each carrying the structural parity harness), **but budget for the per-module `pub(crate)` visibility-widening** surfaced in §3 — it's the real incremental cost, not the match relocation.

### Preflight
- `cargo fmt --check` clean; `cargo clippy --all-targets -D warnings` clean on `tray` and `tray,discord`
- `cargo test --tests --features tray`: **3421 passed, 0 failed**

Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)