### PR TITLE
fix(#1675): defer actionable inject while operator has a live (paused) draft

### DIFF
--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -375,8 +375,22 @@ pub(crate) fn should_defer_inject(
         return true;
     }
     if actionable {
-        // Short keystroke-collision window only (NOT the #1457 full draft hold).
+        // #1675: defer a wake while the operator has a LIVE unsubmitted draft.
+        // `operator_typing_recent` is a 1.5s window — pause-blind, so a slow /
+        // multi-line typist pausing >1.5s fell through and the inject's
+        // submit_key force-submitted their half-typed line. The order-based
+        // `Drafting` signal (#1457: typed > submit) is pause-immune (holds up to
+        // the 5-min escape window), so it covers slow composition. Union keeps the
+        // brief post-keystroke settle (window) AND the paused-but-live draft
+        // (order). `None`/`Abandoned` still wake immediately, preserving #1473's
+        // "wake the idle/abandoned agent" (a never-composed pane reads `None`);
+        // the TUI flush drains the queue the instant the operator submits
+        // (draft_state → `None`). `Drafting` is set ONLY by human TUI keystrokes
+        // (record_input_activity), so this fires exactly when a person is
+        // composing in this pane — agent PTY output never sets it.
         operator_typing_recent(home, agent_name)
+            || crate::notification_queue::draft_state(home, agent_name)
+                == crate::notification_queue::DraftState::Drafting
     } else {
         // Ambient: the #1457 full draft gate is applied downstream by
         // route_notification — don't double-gate here.
@@ -880,6 +894,34 @@ mod should_defer_inject_tests_1513 {
         assert!(
             should_defer_inject(&h, "a", Some("idle"), true),
             "recent typing defers actionable"
+        );
+    }
+
+    // #1675: a PAUSED-but-LIVE operator draft (typed >1.5s ago, never submitted →
+    // `Drafting`) must STILL defer an actionable wake. Pre-#1675 the 1.5s
+    // `operator_typing_recent` window let a paused draft fall through, so the
+    // inject's submit_key force-submitted the operator's half-typed line. The
+    // order-based `Drafting` check (pause-immune) is what closes that hole.
+    #[test]
+    fn actionable_defers_on_paused_live_draft_1675() {
+        let h = tmp_home("paused-draft");
+        // typed 3s ago (> TYPING_QUIET_WINDOW_MS=1.5s), no submit recorded:
+        // operator_typing_recent is FALSE but draft_state is Drafting.
+        std::fs::create_dir_all(h.join("metadata")).unwrap();
+        let typed = chrono::Utc::now().timestamp_millis() - 3_000;
+        std::fs::write(
+            h.join("metadata").join("a.json"),
+            format!("{{\"last_input_epoch_ms\":{typed}}}"),
+        )
+        .unwrap();
+        // sanity: the old window-only signal would NOT defer this.
+        assert!(
+            !super::operator_typing_recent(&h, "a"),
+            "3s-old keystroke is outside the 1.5s window"
+        );
+        assert!(
+            should_defer_inject(&h, "a", Some("idle"), true),
+            "#1675: a paused (3s) live operator draft must defer actionable, not force-submit it"
         );
     }
 }

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -2365,10 +2365,14 @@ fn t12_pty_state_kind_matrix() {
         );
 
         // Composing path — hint deferred into notification_queue.
-        // #1513: use a PAUSED draft (>1.5s since last keystroke) so this tests
-        // the #1473 draft-HOLD bypass, not the new fresh-keystroke anti-collision
-        // yield (which would defer actionable too — covered in
-        // should_defer_inject_tests_1513::actionable_defers_on_recent_typing).
+        // #1675: a PAUSED-but-LIVE operator draft (>1.5s since last keystroke,
+        // never submitted → `Drafting`) now defers EVERY kind, including
+        // actionable wakes. Pre-#1675 actionable (#1483) bypassed a paused draft
+        // and force-submitted the operator's half-typed line — the operator
+        // reported that on slow/multi-line typing. The order-based `Drafting`
+        // signal is pause-immune; the TUI flush releases the moment the operator
+        // submits (draft_state → None). (A never-composed pane reads `None` and
+        // still wakes immediately — #1473's wake-the-idle-agent is preserved.)
         let composing_home = tmp_home(&format!("982-t12-{kind}"));
         mark_composing_stale(&composing_home, "agent1");
         let mut msg = make_msg("system:t12", "composing");
@@ -2379,22 +2383,11 @@ fn t12_pty_state_kind_matrix() {
         })
         .expect("composing enqueue");
         let after = crate::notification_queue::pending_count(&composing_home, "agent1");
-        // #1483: actionable work-delivery kinds (ci-ready-for-action / task /
-        // query) bypass the draft-gate and inject straight to the PTY — they
-        // are NOT deferred into the queue even while composing. Only ambient
-        // kinds (report / update / waiting_on_stale) defer.
-        if matches!(kind, "task" | "query") {
-            assert_eq!(
-                after, before,
-                "actionable kind={kind} must bypass draft-gate (not deferred) while composing"
-            );
-        } else {
-            assert_eq!(
-                after,
-                before + 1,
-                "ambient kind={kind} must defer 1 hint while composing"
-            );
-        }
+        assert_eq!(
+            after,
+            before + 1,
+            "#1675: kind={kind} must defer 1 hint while the operator has a live draft"
+        );
         fs::remove_dir_all(&composing_home).ok();
     }
     fs::remove_dir_all(&home).ok();


### PR DESCRIPTION
## Problem (#1675, operator-authored P1)
When the operator types slowly / multi-line in the TUI and an inbox notification arrives, the inject path appended the notification text **+ submit-key (`\r`)** to the operator's input pane → **force-submitted their half-typed message**.

## RCA (premise corrected during spike)
This is **not** "no operator-typing gate exists." A #1513 gate already defers actionable injects via `operator_typing_recent` — but that uses a **1.5s fixed window** (`TYPING_QUIET_WINDOW_MS = 1_500`), which is **pause-blind**. A slow / multi-line typist pausing >1.5s falls outside the window, so an actionable wake (`[delegate_task]` / `[ci-ready-for-action]` / `[request_information]`) injects immediately and its appended `submit_key` force-submits the half-typed line.

The **drain side already** uses the pause-immune **order-based `Drafting`** signal (#1457: `typed > submit`, 5-min escape) and holds correctly during a live draft — so only the **inject-time** gate was the hole.

## Fix (minimal)
`should_defer_inject`'s actionable branch now defers on `operator_typing_recent` **OR** `draft_state == Drafting`. The order-based check is pause-immune, so slow/multi-line composition is held instead of clobbered.

- `None` / `Abandoned` still **wake immediately** → preserves #1473's "wake the idle/abandoned agent" (a never-composed pane reads `None`).
- `Drafting` is set **only by human TUI keystrokes** (`record_input_activity`); agent PTY output never sets it → fires exactly when a person is composing in that pane.
- The TUI flush drains the queue the instant the operator submits (`Drafting → None`); held at most while actively composing (≤5-min escape), never lost.

## Contract change (needs MED review)
Reverses #1483/#1473's explicit *"actionable work-delivery bypasses the draft-gate regardless of draft state"* — **for live drafts only**. Pre-#1675 a >1.5s-paused operator draft was bypassable; the operator reported that force-submitting their typing.
- Flipped `t12`/#982 test: actionable-while-(paused)-composing now **defers** (+1) instead of bypassing.
- Added `actionable_defers_on_paused_live_draft_1675` regression pin (fails pre-fix, passes post-fix).
- Decision recorded: `d-20260602161804065856-1`.

## Acceptance
- ✅ Slow/multi-line TUI typing never force-submitted (held while `Drafting`, pause-immune).
- ✅ Notifications still reach the operator (drained the moment they submit; ≤5-min escape backstop).

## Test
`cargo test should_defer_inject_tests_1513` (incl. new pin) ✓; `t12` ✓; `cargo test --test file_size_invariant` ✓; clippy `--features tray` and `tray,discord` clean.

Closes #1675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)