### PR TITLE
fix(#7): redraw Kiro pane after resize (SIGWINCH no-repaint workaround)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -282,12 +282,19 @@ pub struct BackendPreset {
     /// Daemon spawn path emits a `[fleet-mcp-unsupported]` warning when
     /// this is `false` so operators are not surprised by missing tools.
     pub fleet_mcp_supported: bool,
+    /// #7: emit a redraw trigger (Ctrl+L) after a PTY resize. True ONLY for
+    /// backends whose TUI does not repaint on SIGWINCH — kiro-cli 2.1.x TUI v2,
+    /// which otherwise leaves the pane blank until the next keystroke. Read by
+    /// [`crate::layout::pane::Pane::resize_pty`]; `false` for every other
+    /// backend, so they are provably untouched by the redraw injection.
+    pub redraw_after_resize: bool,
 }
 
 impl Backend {
     pub fn preset(&self) -> BackendPreset {
         match self {
             Backend::ClaudeCode => BackendPreset {
+                redraw_after_resize: false, // #7: repaints on SIGWINCH — no trigger needed.
                 command: "claude",
                 args: &["--dangerously-skip-permissions"],
                 ready_pattern: "bypass permissions|❯",
@@ -342,6 +349,10 @@ impl Backend {
                 fleet_mcp_supported: true,
             },
             Backend::KiroCli => BackendPreset {
+                // #7: kiro-cli 2.1.x TUI v2 does not repaint on SIGWINCH, so a
+                // pane switch (which resizes the PTY) leaves it blank until the
+                // next keystroke. resize_pty sends Ctrl+L to force a repaint.
+                redraw_after_resize: true,
                 command: "kiro-cli",
                 args: &["chat", "--trust-all-tools"],
                 ready_pattern:
@@ -387,6 +398,7 @@ impl Backend {
                 fleet_mcp_supported: true,
             },
             Backend::Codex => BackendPreset {
+                redraw_after_resize: false, // #7: repaints on SIGWINCH — no trigger needed.
                 command: "codex",
                 // #1626: `-c check_for_update_on_startup=false` disables codex's
                 // blocking startup update modal ("Update available!"). This is a
@@ -452,6 +464,7 @@ impl Backend {
                 fleet_mcp_supported: true,
             },
             Backend::OpenCode => BackendPreset {
+                redraw_after_resize: false, // #7: repaints on SIGWINCH — no trigger needed.
                 command: "opencode",
                 args: &[],
                 ready_pattern: "Ask anything|tab agents",
@@ -489,6 +502,7 @@ impl Backend {
                 fleet_mcp_supported: true,
             },
             Backend::Gemini => BackendPreset {
+                redraw_after_resize: false, // #7: repaints on SIGWINCH — no trigger needed.
                 command: "gemini",
                 args: &["--yolo"],
                 ready_pattern: "Type your message|YOLO",
@@ -525,6 +539,7 @@ impl Backend {
                 fleet_mcp_supported: true,
             },
             Backend::Agy => BackendPreset {
+                redraw_after_resize: false, // #7: repaints on SIGWINCH — no trigger needed.
                 command: "agy",
                 args: &["--dangerously-skip-permissions"],
                 // #987: agy's interactive TUI renders an "Antigravity CLI <ver>"
@@ -576,6 +591,7 @@ impl Backend {
             // [`Backend::command_string`], which resolves Shell to `$SHELL`
             // and Raw to its stored path.
             Backend::Shell | Backend::Raw(_) => BackendPreset {
+                redraw_after_resize: false, // #7: plain shell / raw exec — no TUI redraw quirk.
                 command: "",
                 args: &[],
                 ready_pattern: "",
@@ -1231,6 +1247,30 @@ mod tests {
                 BackendBehavior::preset(&b).command,
                 b.preset().command,
                 "preset parity for {b:?}"
+            );
+        }
+    }
+
+    // #7: redraw_after_resize is set on EXACTLY one backend (Kiro). If a new
+    // backend ever needs it, flip it deliberately + update this pin.
+    #[test]
+    fn redraw_after_resize_is_kiro_only_7() {
+        assert!(
+            Backend::KiroCli.preset().redraw_after_resize,
+            "Kiro must opt into redraw-after-resize"
+        );
+        for b in [
+            Backend::ClaudeCode,
+            Backend::Codex,
+            Backend::OpenCode,
+            Backend::Gemini,
+            Backend::Agy,
+            Backend::Shell,
+            Backend::Raw("x".to_string()),
+        ] {
+            assert!(
+                !b.preset().redraw_after_resize,
+                "{b:?} must NOT opt into redraw-after-resize"
             );
         }
     }

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -163,15 +163,30 @@ impl Pane {
     pub fn resize_pty(&self, registry: &AgentRegistry, cols: u16, rows: u16) {
         match &self.source {
             PaneSource::Local => {
+                // #7: some backends' TUIs don't repaint on the SIGWINCH that
+                // `master.resize` delivers (kiro-cli 2.1.x), so we follow the
+                // resize with an explicit redraw trigger for those backends only.
+                let redraw = redraw_seq_after_resize(self.backend.as_ref());
                 let reg = agent::lock_registry(registry);
                 if let Some(handle) = reg.get(&self.instance_id) {
-                    let master = handle.pty_master.lock();
-                    let _ = master.resize(portable_pty::PtySize {
-                        rows,
-                        cols,
-                        pixel_width: 0,
-                        pixel_height: 0,
-                    });
+                    {
+                        let master = handle.pty_master.lock();
+                        let _ = master.resize(portable_pty::PtySize {
+                            rows,
+                            cols,
+                            pixel_width: 0,
+                            pixel_height: 0,
+                        });
+                    }
+                    // #7: send the redraw trigger AFTER the resize, on the input
+                    // writer (not the master). Clone the writer and release the
+                    // registry lock before the blocking write (#1530/F1: never
+                    // hold the registry lock across a PTY write).
+                    if let Some(seq) = redraw {
+                        let writer = handle.pty_writer.clone();
+                        drop(reg);
+                        let _ = agent::write_to_pty(&writer, seq);
+                    }
                 }
             }
             PaneSource::Remote(client) => {
@@ -182,10 +197,56 @@ impl Pane {
     }
 }
 
+/// #7: the byte sequence to emit after a PTY resize to force a repaint, for
+/// backends whose preset opts in via [`crate::backend::BackendPreset::redraw_after_resize`].
+///
+/// Returns `Some(Ctrl+L)` only for opted-in backends (kiro-cli 2.1.x TUI v2,
+/// which ignores the resize SIGWINCH and shows a blank pane until the next
+/// keystroke); `None` for every other backend — so they emit NOTHING extra on
+/// resize and are provably untouched. `Ctrl+L` (`0x0c`, form-feed) is the
+/// conventional TUI/readline "redraw" key, distinct from the submit key (`\r`).
+fn redraw_seq_after_resize(backend: Option<&Backend>) -> Option<&'static [u8]> {
+    backend
+        .filter(|b| b.preset().redraw_after_resize)
+        .map(|_| b"\x0c".as_slice())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::vterm::VTerm;
+
+    // #7: the redraw trigger must fire for Kiro ONLY and emit Ctrl+L; every
+    // other backend (and a backend-less pane) must emit NOTHING, so resize
+    // behavior for Claude/Codex/OpenCode/Gemini/Agy/Shell/Raw is unchanged.
+    #[test]
+    fn redraw_seq_after_resize_is_kiro_only_ctrl_l_7() {
+        assert_eq!(
+            redraw_seq_after_resize(Some(&Backend::KiroCli)),
+            Some(b"\x0c".as_slice()),
+            "Kiro must get Ctrl+L after resize"
+        );
+        for b in [
+            Backend::ClaudeCode,
+            Backend::Codex,
+            Backend::OpenCode,
+            Backend::Gemini,
+            Backend::Agy,
+            Backend::Shell,
+            Backend::Raw("whatever".into()),
+        ] {
+            assert_eq!(
+                redraw_seq_after_resize(Some(&b)),
+                None,
+                "{b:?} must emit nothing after resize (provably untouched)"
+            );
+        }
+        assert_eq!(
+            redraw_seq_after_resize(None),
+            None,
+            "a backend-less pane must emit nothing"
+        );
+    }
 
     fn leaf(id: usize, name: &str) -> Pane {
         Pane {


### PR DESCRIPTION
## Problem (#7)
Switching to a Kiro pane shows it **blank** until you click/keystroke. Root cause: `resize_pty()` (pane.rs) calls `master.resize()` → SIGWINCH, but **kiro-cli 2.1.x TUI v2 does not repaint on SIGWINCH**. agend's dynamic pane layout resizes on every switch, so the AWS-CAO large-initial-size avoidance workaround doesn't apply — we must actively trigger a redraw after resize.

## Fix
Per #8/#1674 (per-backend data lives on `BackendPreset`; the `BackendBehavior` trait is a dead, unwired scaffold — confirmed with lead, and backend.rs:1144 deferred this flag to #7):
- **`BackendPreset.redraw_after_resize: bool`** — `KiroCli = true`, all 6 others (`ClaudeCode`/`Codex`/`OpenCode`/`Gemini`/`Agy`/`Shell|Raw`) = `false`.
- **`pane::resize_pty()`** sends **Ctrl+L (`\x0c`)** — the conventional TUI/readline redraw key, distinct from submit (`\r`) — to the **input writer** *after* `master.resize()`, **only** when the pane's backend preset opts in. Writer cloned + registry lock released before the blocking write (#1530/F1 lock discipline).
- **`redraw_seq_after_resize()`** pure helper makes the selection unit-testable.

## Bounded-to-Kiro guarantee (the safety design)
The redraw byte is emitted **only** for backends with `redraw_after_resize = true` — i.e. Kiro alone. Every other backend emits **nothing** extra on resize, so Claude/Codex/OpenCode/Gemini/Agy/Shell/Raw are **provably untouched**. Tests pin this both ways.

## ⚠ NOT verified in-sandbox — MERGE GATED ON OPERATOR SMOKE
**`\x0c`-safety on live kiro-cli 2.1.x is NOT verified here** — there is no live Kiro TUI in a real terminal in the build sandbox, and no kiro-cli 2.1.x keybinding doc to cite. Code reasoning: `\x0c` (form-feed) is the standard non-destructive redraw key and is **not** the submit key, but "conventionally safe" ≠ verified on this specific binary.

**Risk is bounded to Kiro** (flag false everywhere else). Worst cases on Kiro: (a) `\x0c` is a no-op → fix ineffective but harmless; (b) `\x0c` redraws → fixed; (c) `\x0c` maps to a Kiro command → the only real hazard.

**Requires a 30-sec operator live-Kiro smoke BEFORE merge:** switch to a Kiro pane → content appears immediately (no click), and input/state are not corrupted (type a char, send a message — behaves normally). If a side effect shows up, flip `KiroCli`'s `redraw_after_resize` back to `false` (one-line revert).

→ **ready-for-review + ready-to-merge PENDING operator smoke.** codex reviews code (flag plumbing, bounded-to-Kiro, tests) + lead-check; HOLD at merge-ready until the operator runs the smoke on wake.

## Tests
- `redraw_after_resize_is_kiro_only_7` (backend.rs): preset flag Kiro=true, all others=false.
- `redraw_seq_after_resize_is_kiro_only_ctrl_l_7` (pane.rs): Kiro→`\x0c`, all others + backend-less→`None`.
- `cargo test --test file_size_invariant` ✓; clippy `--features tray` and `tray,discord` clean; fmt clean.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)