### PR TITLE
#1680: align draft-gate metadata read with the write-side UUID resolver

### DIFF
--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -75,7 +75,12 @@ pub fn record_submit_activity(home: &Path, agent_name: &str) {
 /// detection — keeps the read inline-cheap (single file read, single
 /// JSON parse) so per-tick overhead stays bounded.
 pub fn read_input_submit_timestamps(home: &Path, agent_name: &str) -> (i64, i64) {
-    let meta_path = home.join("metadata").join(format!("{agent_name}.json"));
+    // #1680: resolve via the SAME path resolver the write side uses
+    // (`save_metadata` → `metadata_path_resolved`). The previous hand-coded
+    // `metadata/<name>.json` read the never-written name file while the write
+    // landed on `metadata/<uuid>.json`, so `draft_state` was permanently stale
+    // (`None`) and the inject path force-submitted the operator's unsent draft.
+    let meta_path = agent_ops::metadata_path_resolved(home, agent_name);
     let Ok(content) = std::fs::read_to_string(meta_path) else {
         return (0, 0);
     };
@@ -333,6 +338,54 @@ mod tests {
         assert!(
             submit1 >= typed1,
             "submit (called second) must be ≥ typed (called first), got typed={typed1} submit={submit1}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1680 regression: the keystroke WRITE (`record_input_activity` →
+    /// `save_metadata` → `metadata_path_resolved` → `<uuid>.json`) and the
+    /// draft-gate READ (`read_input_submit_timestamps`) MUST land on the SAME
+    /// file when fleet.yaml maps the name → a UUID. Pre-#1680 the read hand-coded
+    /// `<name>.json` (bypassing the resolver) while the write went to
+    /// `<uuid>.json`, so they never intersected → `draft_state` was permanently
+    /// stale (`None`) → the inject path force-submitted the operator's unsent
+    /// draft. Every prior test used a home with NO fleet.yaml (the resolver falls
+    /// back to the name path, so write/read happen to converge) and so could not
+    /// catch the split. This pins the id-mapped path: it FAILS before the read
+    /// resolver alignment and PASSES after.
+    #[test]
+    fn draft_gate_read_resolves_uuid_like_write_1680() {
+        let home = tmp_home("draft_gate_uuid_1680");
+        // Isolate from any prior run sharing the same (suffix,pid) dir.
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::create_dir_all(&home).ok();
+        // fleet.yaml maps the fleet NAME → a UUID, so the resolver routes
+        // metadata to `<uuid>.json` — the production shape that exposed the split.
+        let id = crate::types::InstanceId::new();
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            format!("instances:\n  fixup-x:\n    id: {}\n", id.full()),
+        )
+        .expect("write fleet.yaml");
+
+        // WRITE a compose keystroke (no submit) → `<uuid>.json` via the resolver.
+        record_input_activity(&home, "fixup-x");
+
+        // READ must see it through the SAME resolver. Pre-fix this reads the
+        // never-written `<name>.json` and returns 0 → assert fails (RED).
+        let (typed, submit) = read_input_submit_timestamps(&home, "fixup-x");
+        assert!(
+            typed > 0,
+            "#1680: read must resolve the same UUID file the write used \
+             (got typed=0 → it read the stale name-path)"
+        );
+        assert_eq!(submit, 0, "no submit recorded yet");
+        // End-to-end gate signal: a recent unsent draft must read as Drafting,
+        // NOT None — `None` is precisely what let the inject clobber the draft.
+        assert_eq!(
+            draft_state(&home, "fixup-x"),
+            DraftState::Drafting,
+            "#1680: a live unsent operator draft must gate (Drafting), not read as None"
         );
         std::fs::remove_dir_all(home).ok();
     }


### PR DESCRIPTION
## Bug (#1680)
The keystroke **write** and the draft-gate **read** keyed the metadata file by different identifiers, so they never intersected:

- **WRITE** — `record_input_activity` → `agent_ops::save_metadata` → `metadata_path_resolved` resolves the fleet name to its UUID → writes `metadata/<uuid>.json`.
- **READ** — `notification_queue::read_input_submit_timestamps` **hand-coded** `metadata/<name>.json` → read the never-written name file → bypassed the resolver.

→ read always returned `(0,0)` → `draft_state` was permanently `None` → `route_notification` injected with `submit_key` → **the operator's unsent draft was force-submitted.** (Live-repro'd by the lead.) The same reader also feeds `operator_typing_recent` (notify.rs) and the supervisor typed-but-not-submitted detection (supervisor.rs) — all fixed by this one alignment.

## Fix
`read_input_submit_timestamps` now uses `agent_ops::metadata_path_resolved` — the **same** resolver the write side uses (one line + the existing `agent_ops` import).

### Double-resolve audit (review ask)
All five reader call sites pass fleet **names** (notify recipient name; `pane.agent_name`; `handle.name` ×2 in supervisor). And even if a UUID were passed, `metadata_path_resolved` converges it to the same `<uuid>.json` (fleet lookup misses → `metadata_path(uuid)`). **No hazard.**

## Regression test (the missed gap)
Every prior test used a home with **no fleet.yaml**, so the resolver fell back to the name path and write/read happened to converge — which is exactly why the prod split was invisible. The new test writes an **id-bearing fleet.yaml** (name → UUID), records a compose keystroke, then asserts the read sees it **and** `draft_state == Drafting`.

**Verified RED before, GREEN after:**
- Before fix: `FAILED ... panicked at notification_queue.rs:372` (typed=0 — read the stale name-path).
- After fix: `ok. 1 passed`.

## Evidence
```
cargo test draft_gate_read_resolves_uuid_like_write_1680   # RED→GREEN confirmed
cargo test notification_queue:: → 12 passed
cargo test inbox::notify → 16 ; supervisor → 56 ; agent_ops → 29 ; all pass
cargo fmt --check ✓ ; cargo clippy --all-targets --features tray / tray,discord -D warnings ✓
```

## Scope
Read-path resolver alignment + regression test only. Other hand-coded metadata paths are an explicit follow-up, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)