### PR TITLE
feat(#8 Phase 2 step-0): route prod detection through BackendProfile (single fork, parity-gated)

### DIFF
--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -26,7 +26,10 @@ use crate::state::AgentState;
 use std::sync::OnceLock;
 
 /// All per-backend detection data for one backend, co-located.
-#[allow(dead_code)] // VALIDATION scaffold: consumed by the harness, not yet by prod.
+///
+/// #8 Phase 2 step-0: now consumed by PROD — `StatePatterns::for_backend`,
+/// `behavioral::config_for[_productivity]`, and `StateTracker::new` route
+/// migrated backends through [`profile`] (else legacy). No longer a scaffold.
 pub struct BackendProfile {
     /// Raw `(state, regex)` detection patterns in priority order — compiled by
     /// the state machine exactly as `StatePatterns::compile_for` does today.
@@ -41,7 +44,6 @@ pub struct BackendProfile {
 /// `None` for backends not yet migrated (their data still lives on the legacy
 /// match path). This `match` is the ONE unavoidable flat-enum lookup; the
 /// per-backend DATA lives in the builders below, one block each.
-#[allow(dead_code)] // VALIDATION: exposed via BackendBehavior::profile; prod reroute is the migration PR.
 pub fn profile(backend: &Backend) -> Option<&'static BackendProfile> {
     static AGY: OnceLock<BackendProfile> = OnceLock::new();
     static KIRO: OnceLock<BackendProfile> = OnceLock::new();
@@ -163,7 +165,10 @@ fn empty_profile() -> BackendProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::behavioral::{config_for, config_for_productivity};
+    // #8 Phase 2 step-0: parity tests must reference the TRUE-legacy companions,
+    // NOT the now-profile-routed prod fns (`config_for`/`for_backend`/`new`) — using
+    // the prod fns would make every assertion circular (profile vs profile).
+    use crate::behavioral::{config_for_legacy, config_for_productivity_legacy};
     use crate::state::patterns::StatePatterns;
     use crate::state::StateTracker;
 
@@ -183,8 +188,9 @@ mod tests {
     #[test]
     fn profile_patterns_byte_identical_to_legacy() {
         for b in migrated() {
+            // TRUE legacy = compile_for directly (for_backend is now profile-routed).
             let legacy: Vec<(AgentState, String)> =
-                StatePatterns::for_backend(&b).pattern_sources();
+                StatePatterns::compile_for(&b).pattern_sources();
             let prof: Vec<(AgentState, String)> = profile(&b)
                 .expect("migrated")
                 .patterns
@@ -216,7 +222,7 @@ mod tests {
             "",
         ];
         for b in migrated() {
-            let legacy = StatePatterns::for_backend(&b);
+            let legacy = StatePatterns::compile_for(&b); // TRUE legacy, not the rerouted entry
             let prof = StatePatterns::from_raw_patterns(&profile(&b).expect("migrated").patterns);
             for item in corpus {
                 assert_eq!(
@@ -236,17 +242,17 @@ mod tests {
             let p = profile(&b).expect("migrated");
             assert_eq!(
                 format!("{:?}", p.behavioral),
-                format!("{:?}", config_for(&b)),
+                format!("{:?}", config_for_legacy(&b)),
                 "behavioral parity for {b:?}"
             );
             assert_eq!(
                 format!("{:?}", p.productivity),
-                format!("{:?}", config_for_productivity(&b)),
+                format!("{:?}", config_for_productivity_legacy(&b)),
                 "productivity parity for {b:?}"
             );
             assert_eq!(
                 p.initial_state,
-                StateTracker::new(Some(&b)).current,
+                StateTracker::legacy_initial_state(Some(&b)),
                 "initial_state parity for {b:?}"
             );
         }
@@ -262,6 +268,57 @@ mod tests {
             Backend::Gemini,
         ] {
             assert!(profile(&b).is_none(), "{b:?} must stay on the legacy path");
+        }
+    }
+
+    /// #8 Phase 2 step-0 MERGE GATE — profile-ON-vs-OFF classify parity at the
+    /// PROD entry. `for_backend` (now profile-routed for migrated backends) must
+    /// detect byte-identically to the TRUE-legacy `compile_for` for EVERY backend
+    /// across the corpus: migrated → the profile path equals legacy; un-migrated →
+    /// both are legacy (guards the fork never perturbs Claude/Codex/OpenCode/Gemini).
+    /// Complements the structural `profile_patterns_byte_identical_to_legacy`
+    /// (identical sources ⟹ identical detection on ALL inputs) — together: complete
+    /// parity, not a snapshot. The full-fixture corpus is also covered empirically
+    /// by `replay_manifest_regression` running against this rerouted prod path.
+    #[test]
+    fn for_backend_classify_parity_with_legacy_step0() {
+        let corpus = [
+            "Requesting permission for: write",
+            "Do you trust the contents of this project",
+            "● Bash(ls -la)",
+            "esc to cancel",
+            "ECONNRESET",
+            "Too Many Requests",
+            "ServiceQuotaExceeded",
+            "Trust All Tools active",
+            "ask a question or describe a task",
+            "Antigravity CLI v2",
+            "Type your message",
+            "? for shortcuts",
+            "Automatic merge failed; fix conflicts",
+            "just unrelated prose with no anchors",
+            "● lowercase(x)",
+            "",
+        ];
+        for b in [
+            Backend::ClaudeCode,
+            Backend::KiroCli,
+            Backend::Codex,
+            Backend::OpenCode,
+            Backend::Gemini,
+            Backend::Agy,
+            Backend::Shell,
+            Backend::Raw("x".to_string()),
+        ] {
+            let prod = StatePatterns::for_backend(&b); // profile-routed entry
+            let legacy = StatePatterns::compile_for(&b); // TRUE legacy
+            for item in corpus {
+                assert_eq!(
+                    prod.detect(item),
+                    legacy.detect(item),
+                    "for_backend (prod) vs compile_for (legacy) parity for {b:?} on {item:?}"
+                );
+            }
         }
     }
 }

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -65,7 +65,24 @@ impl Default for BehavioralConfig {
 }
 
 /// Get behavioral config for a backend.
+///
+/// #8 Phase 2 step-0: migrated backends (`profile() == Some`) source from the
+/// co-located [`crate::backend_profile::BackendProfile`]; un-migrated backends
+/// fall back to [`config_for_legacy`]. `profile_configs_byte_identical_to_legacy`
+/// proves `p.behavioral == config_for_legacy(b)` for every migrated backend, so
+/// this is a pure indirection, not a behavior change.
 pub fn config_for(backend: &Backend) -> BehavioralConfig {
+    if let Some(p) = crate::backend_profile::profile(backend) {
+        return p.behavioral;
+    }
+    config_for_legacy(backend)
+}
+
+/// The pre-reroute behavioral match — both the fork's fallback for un-migrated
+/// backends AND the TRUE-legacy reference for the parity test (after the reroute,
+/// `config_for` sources migrated backends from the profile, so it can't stand in
+/// for "legacy" without making the assertion circular).
+pub(crate) fn config_for_legacy(backend: &Backend) -> BehavioralConfig {
     match backend {
         Backend::ClaudeCode => BehavioralConfig {
             silence_thinking_ms: 2000,
@@ -425,7 +442,21 @@ static OPENCODE_PRODUCTIVE_REGEXES: std::sync::LazyLock<Vec<regex::Regex>> =
 /// Get productivity config for a backend. Each managed backend uses its
 /// own per-backend MARKERS list + cache id; Shell/Raw fall back to the
 /// generic anchor set (no MCP heartbeat).
+///
+/// #8 Phase 2 step-0: migrated backends source from the co-located profile;
+/// un-migrated fall back to [`config_for_productivity_legacy`]. The markers +
+/// `cache_id` are byte-identical to legacy (proven by the parity test), so the
+/// per-marker-list regex cache (keyed by `cache_id`) is unchanged.
 pub fn config_for_productivity(backend: &Backend) -> ProductivityConfig {
+    if let Some(p) = crate::backend_profile::profile(backend) {
+        return p.productivity;
+    }
+    config_for_productivity_legacy(backend)
+}
+
+/// The pre-reroute productivity match — the fork's fallback AND the TRUE-legacy
+/// parity reference (see [`config_for_legacy`] for why a separate fn is needed).
+pub(crate) fn config_for_productivity_legacy(backend: &Backend) -> ProductivityConfig {
     match backend {
         Backend::ClaudeCode => ProductivityConfig {
             markers: CLAUDE_PRODUCTIVE_MARKERS,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -606,6 +606,17 @@ impl StateTracker {
     /// considered alive and `PermissionPrompt` detection is suppressed.
     const HEARTBEAT_FRESH_WINDOW: Duration = Duration::from_secs(120);
 
+    /// The pre-reroute initial-state match — the fork's fallback for un-migrated
+    /// backends (and `None`) AND the TRUE-legacy reference for the parity test
+    /// (after the reroute, `new()` sources migrated backends from the profile, so
+    /// `new().current` can't stand in for "legacy" without circularity).
+    pub(crate) fn legacy_initial_state(backend: Option<&Backend>) -> AgentState {
+        match backend {
+            Some(Backend::Shell | Backend::Raw(_)) | None => AgentState::Ready,
+            Some(_) => AgentState::Starting,
+        }
+    }
+
     pub fn new(backend: Option<&Backend>) -> Self {
         // Backends without a state pattern catalog (Shell, Raw) skip the
         // `Starting → Ready` handshake. Without this they sat in
@@ -616,10 +627,15 @@ impl StateTracker {
         // its own prompt. Managed backends still start in `Starting` so
         // their onboarding / auth dialogs can pattern-match before
         // Ready is declared.
-        let initial_state = match backend {
-            Some(Backend::Shell | Backend::Raw(_)) | None => AgentState::Ready,
-            Some(_) => AgentState::Starting,
-        };
+        // #8 Phase 2 step-0: migrated backends source their initial state from the
+        // co-located profile; un-migrated (and `None`) fall back to
+        // `legacy_initial_state`. The profile values are byte-identical to legacy
+        // (empty_profile=Ready for Shell/Raw, agy/kiro=Starting), proven by
+        // `profile_configs_byte_identical_to_legacy`, so behavior is unchanged.
+        let initial_state = backend
+            .and_then(crate::backend_profile::profile)
+            .map(|p| p.initial_state)
+            .unwrap_or_else(|| Self::legacy_initial_state(backend));
         Self {
             current: initial_state,
             since: Instant::now(),

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -61,11 +61,26 @@ impl StatePatterns {
             Backend::Agy => &AGY,
             Backend::Shell | Backend::Raw(_) => &EMPTY,
         };
-        lock.get_or_init(|| Self::compile_for(backend))
+        // #8 Phase 2 step-0: route migrated backends (profile() == Some) through
+        // their co-located BackendProfile; un-migrated backends fall back to the
+        // legacy `compile_for` match. `from_raw_patterns` compiles via the SAME
+        // `Regex::new` pipeline as `compile_for`, and
+        // `profile_patterns_byte_identical_to_legacy` proves the pattern sources
+        // are identical — so this fork is byte-identical detection, not a change.
+        // The per-backend `OnceLock` still owns the compile-once cache (the fork
+        // lives INSIDE `get_or_init`, so each variant compiles exactly once).
+        lock.get_or_init(|| match crate::backend_profile::profile(backend) {
+            Some(p) => Self::from_raw_patterns(&p.patterns),
+            None => Self::compile_for(backend),
+        })
     }
 
+    // #8 Phase 2: `pub(crate)` so the parity tests can reference the TRUE legacy
+    // compilation directly — after the step-0 reroute, `for_backend` sources
+    // migrated backends from the profile, so it can no longer stand in for
+    // "legacy" in a parity assertion (that would be circular).
     #[allow(clippy::unwrap_used)]
-    fn compile_for(backend: &Backend) -> Self {
+    pub(crate) fn compile_for(backend: &Backend) -> Self {
         let patterns = match backend {
             // Claude Code v2.1.89
             Backend::ClaudeCode => vec![
@@ -752,10 +767,11 @@ impl StatePatterns {
         self.detect_with_match(text).map(|(s, _)| s)
     }
 
-    /// #8 Phase 2 VALIDATION seam: compile a raw `(state, regex)` list exactly as
-    /// `compile_for` does — lets the parity harness compile a `BackendProfile`'s
-    /// patterns and run detection against them for a corpus cross-check.
-    #[cfg(test)]
+    /// #8 Phase 2: compile a raw `(state, regex)` list exactly as `compile_for`
+    /// does (same `Regex::new` pipeline). Step-0 makes this a PROD path —
+    /// `for_backend` uses it to compile a migrated backend's `BackendProfile`
+    /// patterns; the parity harness uses it too. (Un-gated from `#[cfg(test)]`
+    /// when prod started consuming it.)
     #[allow(clippy::unwrap_used)]
     pub(crate) fn from_raw_patterns(raw: &[(AgentState, &'static str)]) -> Self {
         let compiled = raw


### PR DESCRIPTION
## What & why (#8 Phase 2, step 0)
`BackendProfile` was a parity-validated **VALIDATION scaffold** — consumed only by its own harness; prod ran 100% on the legacy `compile_for`/`config_for` matches. So the data-bundle was net-added **duplicate data** with the consolidation dividend unrealized. This wires **prod** through `profile()` for the 3 already-migrated backends (`Agy`, `KiroCli`, `Shell|Raw`), making them LIVE — the first dividend-realizing step of the operator-greenlit "commit to finish" plan (DoD = legacy deleted once all migrate).

## The single fork (uniform `profile() Some → bundle, None → legacy`)
- **`StatePatterns::for_backend`** (detection — the high-risk one): migrated → `from_raw_patterns(profile.patterns)`, else legacy `compile_for`. The fork lives **inside the per-backend `OnceLock::get_or_init`**, so compile-once caching is preserved. `from_raw_patterns` un-gated from `#[cfg(test)]` (now a prod path; **same `Regex::new` pipeline** as `compile_for` ⟹ byte-identical compilation).
- **`behavioral::config_for` / `config_for_productivity`**: migrated → `profile.{behavioral,productivity}`, else extracted `*_legacy` companion.
- **`state::StateTracker::new`**: migrated → `profile.initial_state`, else `legacy_initial_state` companion.
- Removed `#[allow(dead_code)]` on `BackendProfile` + `profile()` (now prod-consumed).

Un-migrated backends (Claude/Codex/OpenCode/Gemini) are untouched: `profile() == None` → legacy, verified.

## Parity proof (merge gate — detection is #1523-adjacent: FP/FN hits the never-auto-clears latch)
1. **Caught & fixed a circular-test trap:** the existing 3 parity tests referenced `for_backend` / `config_for` / `StateTracker::new` as the "legacy" baseline — but the reroute makes those **profile-routed**, so the assertions would become `profile == profile` (pass, prove nothing). Fixed to reference the **true-legacy** companions (`compile_for` / `config_for_legacy` / `config_for_productivity_legacy` / `legacy_initial_state`). This is the load-bearing correctness point.
2. **Structural (complete):** `profile_patterns_byte_identical_to_legacy` — profile pattern sources == `compile_for` sources (identical regex strings + order ⟹ identical detection on ALL inputs).
3. **Prod-entry (new): `for_backend_classify_parity_with_legacy_step0`** — the PROD entry `for_backend` classifies byte-identically to true-legacy `compile_for` for ALL 8 backends over a corpus (migrated → profile path == legacy; un-migrated → both legacy, guards no perturbation).
4. **Configs:** `profile_configs_byte_identical_to_legacy` (behavioral/productivity/initial vs `*_legacy`).
5. **Full corpus (empirical):** `replay_manifest_regression` passes against the rerouted prod path.

## Evidence (local)
- `cargo test backend_profile` → 5 passed (4 fixed + new gate); `cargo test replay_manifest` → 1 passed; `state::` / `behavioral` green.
- `cargo clippy --all-targets --features tray` and `--features tray,discord` → clean. `file_size_invariant` → pass.
- Note: `agend-git`'s scratch-repo test `has_unmerged_files_true_on_conflict` fails **only in-worktree** (the agend-git shim intercepts the test's scratch `git`; #1463-class) — it is NOT in this diff (diff = backend_profile/behavioral/state files only) and passes in clean CI.

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)