### PR TITLE
#1682: route all metadata file-path construction through the agent_ops resolver

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1619,7 +1619,7 @@ fn on_clean_exit_shell_fallback(
     };
 
     let work_dir: Option<std::path::PathBuf> = home.as_ref().and_then(|h| {
-        let meta_path = h.join("metadata").join(format!("{name}.json"));
+        let meta_path = crate::agent_ops::metadata_path_resolved(h, name);
         std::fs::read_to_string(meta_path)
             .ok()
             .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -160,6 +160,47 @@ pub fn metadata_path_resolved(home: &Path, name: &str) -> PathBuf {
     id_path
 }
 
+/// #1682: id-based metadata path (pure — no migration side effects, unlike
+/// `metadata_path_resolved`). For cleanup paths where the `InstanceId` is known
+/// directly, e.g. `full_delete_instance` after fleet.yaml has already been
+/// removed (so a name→id lookup would fail).
+pub fn metadata_path_for_id(home: &Path, id: &crate::types::InstanceId) -> PathBuf {
+    home.join("metadata").join(format!("{}.json", id.full()))
+}
+
+/// #1682: resolve an instance's id-based metadata path from fleet.yaml WITHOUT
+/// the symlink/dir migration side effects of `metadata_path_resolved`. `None`
+/// when the name has no id mapping (returns to the caller, which falls back to
+/// the name path). Mirrors the lookup in `metadata_path_resolved`.
+fn id_metadata_path(home: &Path, name: &str) -> Option<PathBuf> {
+    let id = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+        .ok()?
+        .instances
+        .get(name)
+        .and_then(|i| i.id.as_deref())
+        .and_then(crate::types::InstanceId::parse)?;
+    Some(metadata_path_for_id(home, &id))
+}
+
+/// #1682: remove an instance's metadata, covering BOTH the legacy name path and
+/// the id-resolved path, so a delete / spawn-clear leaves no split copy behind.
+/// Pure (no symlink creation). Replaces the hand-coded `remove_file` of just the
+/// name file that, post-#1680, missed the `<uuid>.json` readers actually read.
+pub fn remove_metadata(home: &Path, name: &str) {
+    let _ = std::fs::remove_file(metadata_path(home, name));
+    if let Some(id_path) = id_metadata_path(home, name) {
+        let _ = std::fs::remove_file(id_path);
+    }
+}
+
+/// #1682: does ANY metadata file exist for this instance — legacy name path OR
+/// id-resolved path — WITHOUT the symlink/dir side effects of
+/// `metadata_path_resolved`. For residual / cleanup-verification checks that
+/// must not themselves create metadata.
+pub fn metadata_exists(home: &Path, name: &str) -> bool {
+    metadata_path(home, name).exists() || id_metadata_path(home, name).is_some_and(|p| p.exists())
+}
+
 /// Load metadata for an instance and merge it into the given JSON value.
 pub fn merge_metadata(home: &Path, name: &str, info: &mut Value) {
     let meta_path = metadata_path_resolved(home, name);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -650,7 +650,9 @@ fn spawn_one(
     // Sprint 34: clear stale metadata from a previous instance with the
     // same name. spawn_one is the true choke point — both handle_spawn
     // (direct) and team.rs (team-spawn) flow through here.
-    let _ = std::fs::remove_file(home.join("metadata").join(format!("{name}.json")));
+    // #1682: clear BOTH the legacy name file and the id-resolved file — post-#1680
+    // readers use `<uuid>.json`, which the old name-only remove left stale.
+    crate::agent_ops::remove_metadata(home, name);
     let preset_submit_key = crate::backend::Backend::from_command(backend)
         .map(|b| b.preset().submit_key)
         .unwrap_or("\r");

--- a/src/channel/telegram/bot_api.rs
+++ b/src/channel/telegram/bot_api.rs
@@ -34,7 +34,7 @@ pub(crate) fn try_telegram_react(
 ) -> anyhow::Result<()> {
     let ch = resolve_channel_only_from(home)?;
     let mid: i32 = message_id.and_then(|m| m.parse().ok()).unwrap_or_else(|| {
-        let meta_path = home.join("metadata").join(format!("{instance_name}.json"));
+        let meta_path = crate::agent_ops::metadata_path_resolved(home, instance_name);
         std::fs::read_to_string(&meta_path)
             .ok()
             .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -393,36 +393,36 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
     // Append to pending_pickup_ids array so multi-message bursts each
     // get a ✅ confirmation on inbox drain (F2 fix).
     {
-        let meta_path = home.join("metadata").join(format!("{instance_name}.json"));
-        let mut meta: serde_json::Value = std::fs::read_to_string(&meta_path)
-            .ok()
-            .and_then(|c| serde_json::from_str(&c).ok())
-            .unwrap_or(serde_json::json!({}));
+        // #1682: read-modify-write pending_pickup_ids through the resolver. The
+        // previous hand-coded `<name>.json` read + bare `rename` wrote the legacy
+        // name file (and clobbered the resolver's `<uuid>.json` symlink), so the
+        // pickup IDs split from the id file every other reader/writer uses —
+        // multi-message bursts then lost their ✅ confirmations.
         let entry = serde_json::json!({
             "kind": "telegram",
             "msg_id": msg.id.0.to_string(),
         });
-        match meta.get_mut("pending_pickup_ids") {
-            Some(arr) if arr.is_array() => {
-                let vec = arr.as_array_mut().expect("checked");
-                vec.push(entry);
-                // M2: cap to prevent unbounded growth (keep newest 100)
-                if vec.len() > 100 {
-                    *vec = vec.split_off(vec.len() - 100);
-                }
-            }
-            _ => {
-                meta["pending_pickup_ids"] = serde_json::json!([entry]);
-            }
+        let meta_path = crate::agent_ops::metadata_path_resolved(&home, &instance_name);
+        let existing: serde_json::Value = std::fs::read_to_string(&meta_path)
+            .ok()
+            .and_then(|c| serde_json::from_str(&c).ok())
+            .unwrap_or(serde_json::json!({}));
+        let mut ids: Vec<serde_json::Value> = existing
+            .get("pending_pickup_ids")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        ids.push(entry);
+        // M2: cap to prevent unbounded growth (keep newest 100)
+        if ids.len() > 100 {
+            ids = ids.split_off(ids.len() - 100);
         }
-        let meta_dir = home.join("metadata");
-        std::fs::create_dir_all(&meta_dir).ok();
-        let tmp_path = meta_path.with_extension("json.tmp");
-        if let Ok(content) = serde_json::to_string_pretty(&meta) {
-            if std::fs::write(&tmp_path, &content).is_ok() {
-                let _ = std::fs::rename(&tmp_path, &meta_path);
-            }
-        }
+        crate::agent_ops::save_metadata(
+            &home,
+            &instance_name,
+            "pending_pickup_ids",
+            serde_json::json!(ids),
+        );
     }
     // Also store as last_message_id for the `react` MCP tool's fallback.
     crate::agent_ops::save_metadata(

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1267,7 +1267,7 @@ fn format_recovery_notice(name: &str) -> String {
 /// as a `Duration`. Returns `None` if the file is missing, unparseable, or
 /// the timestamp is in the future.
 fn read_heartbeat_age(home: &std::path::Path, name: &str) -> Option<Duration> {
-    let meta_path = home.join("metadata").join(format!("{name}.json"));
+    let meta_path = crate::agent_ops::metadata_path_resolved(home, name);
     let content = std::fs::read_to_string(meta_path).ok()?;
     let meta: serde_json::Value = serde_json::from_str(&content).ok()?;
     let ts = meta["last_heartbeat"].as_str()?;
@@ -1282,7 +1282,7 @@ fn clear_waiting_on_if_stale(home: &std::path::Path, name: &str, is_stale: bool)
     if !is_stale {
         return;
     }
-    let meta_path = home.join("metadata").join(format!("{name}.json"));
+    let meta_path = crate::agent_ops::metadata_path_resolved(home, name);
     let meta: serde_json::Value = match std::fs::read_to_string(&meta_path)
         .and_then(|c| serde_json::from_str(&c).map_err(std::io::Error::other))
     {

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -145,7 +145,7 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // the name. If any do, surface a loud error instead of returning
     // success — `auto_start_fleet` revival of a half-deleted instance is
     // exactly the silent-drop class pattern this fix prevents.
-    let residual = name_residual_anywhere(home, name);
+    let residual = name_residual_anywhere(home, name, instance_id.as_deref());
     if residual.is_empty() && step_errors.is_empty() {
         return Ok(());
     }
@@ -181,7 +181,19 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
 /// `full_delete_instance` clears them as part of its cleanup. The audit
 /// fn is positioned for stores whose state survives daemon restart
 /// (disk-backed) where the silent-drop revival risk lives.
-pub(crate) fn name_residual_anywhere(home: &Path, name: &str) -> Vec<&'static str> {
+///
+/// #1682 (defect-1): `id` is the instance's captured `InstanceId` (taken BEFORE
+/// fleet.yaml removal). It is required because the metadata residual lives at the
+/// id-resolved `<uuid>.json`, and once fleet.yaml is gone the name→id resolver
+/// can no longer find it — so the audit must check the id path DIRECTLY (no fleet
+/// reload) or it goes blind to exactly the stale file a delete is meant to clear.
+/// `None` when the instance had no id mapping (then only the legacy name path
+/// can carry metadata).
+pub(crate) fn name_residual_anywhere(
+    home: &Path,
+    name: &str,
+    id: Option<&str>,
+) -> Vec<&'static str> {
     let mut sources: Vec<&'static str> = Vec::new();
     if let Ok(cfg) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) {
         if cfg.instances.contains_key(name) {
@@ -195,7 +207,14 @@ pub(crate) fn name_residual_anywhere(home: &Path, name: &str) -> Vec<&'static st
             sources.push("fleet.yaml/teams");
         }
     }
-    if crate::agent_ops::metadata_exists(home, name) {
+    // #1682 (defect-1): name path OR the id-direct path. `metadata_exists` resolves
+    // via fleet.yaml, which is already gone at delete-audit time — the explicit
+    // id check below is what keeps the `<uuid>.json` residual visible.
+    let metadata_residual = crate::agent_ops::metadata_exists(home, name)
+        || id
+            .and_then(crate::types::InstanceId::parse)
+            .is_some_and(|id| crate::agent_ops::metadata_path_for_id(home, &id).exists());
+    if metadata_residual {
         sources.push("metadata");
     }
     if home.join("inbox").join(format!("{name}.jsonl")).exists() {
@@ -251,7 +270,7 @@ mod tests {
     #[test]
     fn name_residual_anywhere_clean_home_returns_empty() {
         let home = tmp_home("clean");
-        assert!(name_residual_anywhere(&home, "ghost").is_empty());
+        assert!(name_residual_anywhere(&home, "ghost", None).is_empty());
         std::fs::remove_dir_all(home).ok();
     }
 
@@ -263,7 +282,7 @@ mod tests {
             "instances:\n  zombie:\n    backend: claude\n",
         )
         .unwrap();
-        let sources = name_residual_anywhere(&home, "zombie");
+        let sources = name_residual_anywhere(&home, "zombie", None);
         assert!(
             sources.contains(&"fleet.yaml"),
             "fleet.yaml instances residual must surface, got {sources:?}"
@@ -283,7 +302,7 @@ mod tests {
             "teams:\n  ops:\n    members: [zombie, alice]\n    orchestrator: alice\n",
         )
         .unwrap();
-        let sources = name_residual_anywhere(&home, "zombie");
+        let sources = name_residual_anywhere(&home, "zombie", None);
         assert!(
             sources.contains(&"fleet.yaml/teams"),
             "team-member residual must surface, got {sources:?}"
@@ -297,8 +316,42 @@ mod tests {
         let meta_dir = home.join("metadata");
         std::fs::create_dir_all(&meta_dir).unwrap();
         std::fs::write(meta_dir.join("zombie.json"), "{}").unwrap();
-        let sources = name_residual_anywhere(&home, "zombie");
+        let sources = name_residual_anywhere(&home, "zombie", None);
         assert!(sources.contains(&"metadata"), "got {sources:?}");
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1682 (defect-1, codex): the metadata residual lives at the id-resolved
+    /// `<uuid>.json`, and `full_delete_instance` removes fleet.yaml BEFORE the
+    /// audit — so a fleet-reloading resolver can no longer map name→id and the
+    /// audit goes blind to the stale `<uuid>.json`. The captured id must be passed
+    /// so the audit checks the id path directly. This is the exact post-deletion
+    /// shape: fleet.yaml ABSENT + `<uuid>.json` present → audit must still report
+    /// "metadata". (Fails if the id-direct check is dropped — the name path alone
+    /// never sees `<uuid>.json`.)
+    #[test]
+    fn name_residual_anywhere_detects_uuid_metadata_after_fleet_yaml_removed_1682() {
+        let home = tmp_home("uuid_residual_postdelete");
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::create_dir_all(&home).unwrap();
+        let id = crate::types::InstanceId::new();
+        // The resolved metadata file exists ONLY as `<uuid>.json` (what every
+        // post-#1680 reader/writer uses) — and NO `<name>.json`.
+        let meta_dir = home.join("metadata");
+        std::fs::create_dir_all(&meta_dir).unwrap();
+        std::fs::write(meta_dir.join(format!("{}.json", id.full())), "{}").unwrap();
+        // fleet.yaml is ABSENT (already removed, as in full_delete_instance) — so a
+        // name→id resolver cannot find the uuid; only the captured id can.
+        assert!(
+            !crate::fleet::fleet_yaml_path(&home).exists(),
+            "precondition: fleet.yaml must be absent (post-delete state)"
+        );
+        let sources = name_residual_anywhere(&home, "zombie", Some(&id.full()));
+        assert!(
+            sources.contains(&"metadata"),
+            "#1682 defect-1: id-resolved metadata residual must surface even with \
+             fleet.yaml gone, got {sources:?}"
+        );
         std::fs::remove_dir_all(home).ok();
     }
 
@@ -308,7 +361,7 @@ mod tests {
         let inbox_dir = home.join("inbox");
         std::fs::create_dir_all(&inbox_dir).unwrap();
         std::fs::write(inbox_dir.join("zombie.jsonl"), "").unwrap();
-        let sources = name_residual_anywhere(&home, "zombie");
+        let sources = name_residual_anywhere(&home, "zombie", None);
         assert!(sources.contains(&"inbox"), "got {sources:?}");
         std::fs::remove_dir_all(home).ok();
     }
@@ -319,7 +372,7 @@ mod tests {
         let dir = crate::paths::runtime_dir(&home).join("zombie");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("binding.json"), "{}").unwrap();
-        let sources = name_residual_anywhere(&home, "zombie");
+        let sources = name_residual_anywhere(&home, "zombie", None);
         assert!(sources.contains(&"runtime/binding.json"), "got {sources:?}");
         std::fs::remove_dir_all(home).ok();
     }
@@ -330,7 +383,7 @@ mod tests {
         let dir = home.join("notification-queue");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("zombie.jsonl"), "").unwrap();
-        let sources = name_residual_anywhere(&home, "zombie");
+        let sources = name_residual_anywhere(&home, "zombie", None);
         assert!(sources.contains(&"notification-queue"), "got {sources:?}");
         std::fs::remove_dir_all(home).ok();
     }
@@ -349,7 +402,7 @@ mod tests {
         std::fs::write(home.join("metadata").join("zombie.json"), "{}").unwrap();
         std::fs::create_dir_all(home.join("inbox")).unwrap();
         std::fs::write(home.join("inbox").join("zombie.jsonl"), "").unwrap();
-        let sources = name_residual_anywhere(&home, "zombie");
+        let sources = name_residual_anywhere(&home, "zombie", None);
         for expected in ["fleet.yaml", "metadata", "inbox"] {
             assert!(
                 sources.contains(&expected),

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -92,8 +92,12 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     }
     // #1157: clean id-based metadata. Fleet.yaml is already removed above,
     // so cleanup_working_dir's best-effort lookup may miss the id path.
+    // #1682: construct the id path via agent_ops (fleet.yaml is gone, so the
+    // name→id resolver can't be used here — feed the captured id directly).
     if let Some(ref id) = instance_id {
-        let _ = std::fs::remove_file(home.join("metadata").join(format!("{id}.json")));
+        if let Some(id) = crate::types::InstanceId::parse(id) {
+            let _ = std::fs::remove_file(crate::agent_ops::metadata_path_for_id(home, &id));
+        }
     }
     crate::teams::remove_member_from_all(home, name);
 
@@ -191,7 +195,7 @@ pub(crate) fn name_residual_anywhere(home: &Path, name: &str) -> Vec<&'static st
             sources.push("fleet.yaml/teams");
         }
     }
-    if home.join("metadata").join(format!("{name}.json")).exists() {
+    if crate::agent_ops::metadata_exists(home, name) {
         sources.push("metadata");
     }
     if home.join("inbox").join(format!("{name}.jsonl")).exists() {

--- a/tests/metadata_resolver_invariant.rs
+++ b/tests/metadata_resolver_invariant.rs
@@ -1,0 +1,63 @@
+//! #1682: metadata-path resolver invariant.
+//!
+//! Per-instance metadata file paths must be constructed ONLY inside
+//! `agent_ops` (via `metadata_path_resolved` / `save_metadata` /
+//! `save_metadata_batch` / `metadata_path_for_id`). A hand-coded
+//! `home.join("metadata").join(format!("{name}.json"))` writes/reads the legacy
+//! NAME file, while the resolver routes everyone else to the id file
+//! `<uuid>.json` — the two split, which is the #1680/#1682 stale-metadata bug
+//! (operator keystrokes frozen for days; the draft gate force-submitting
+//! drafts). Centralizing construction in the resolver keeps write and read on
+//! the same file.
+//!
+//! The needle targets the DYNAMIC form (`...join(format!(`). Dedicated `tests.rs`
+//! files are test-only (they fabricate metadata fixtures directly) and are
+//! skipped, mirroring `file_size_invariant`'s `tests.rs` skip.
+
+use std::path::PathBuf;
+
+/// Only `agent_ops` owns metadata-path construction (it IS the resolver).
+const ALLOWED: &[&str] = &["src/agent_ops.rs"];
+
+/// The banned hand-coded construction. Anchored from `.join("metadata")` so it
+/// matches regardless of the receiver (`home.join` / `h.join` / `ctx.home.join`).
+const NEEDLE: &str = r#".join("metadata").join(format!("#;
+
+#[test]
+fn metadata_paths_go_through_agent_ops_resolver_1682() {
+    let mut violations = Vec::new();
+    let mut stack = vec![PathBuf::from("src")];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read src dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().map(|e| e == "rs").unwrap_or(false) {
+                let rel = path.to_string_lossy().replace('\\', "/");
+                if ALLOWED.iter().any(|a| rel == *a) {
+                    continue;
+                }
+                // Dedicated test files build metadata fixtures directly.
+                if rel.ends_with("/tests.rs") {
+                    continue;
+                }
+                let content = std::fs::read_to_string(&path).expect("read file");
+                for (i, line) in content.lines().enumerate() {
+                    if line.contains(NEEDLE) {
+                        violations.push(format!("{}:{}: {}", rel, i + 1, line.trim()));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "#1682: hand-coded metadata file paths must go through the agent_ops \
+         resolver (metadata_path_resolved / save_metadata / metadata_path_for_id), \
+         else the write splits from the resolver-based read:\n{}",
+        violations.join("\n")
+    );
+}

--- a/tests/metadata_resolver_invariant.rs
+++ b/tests/metadata_resolver_invariant.rs
@@ -1,27 +1,29 @@
-//! #1682: metadata-path resolver invariant.
+//! #1682: metadata-path resolver invariant (best-effort lint).
 //!
 //! Per-instance metadata file paths must be constructed ONLY inside
 //! `agent_ops` (via `metadata_path_resolved` / `save_metadata` /
 //! `save_metadata_batch` / `metadata_path_for_id`). A hand-coded
-//! `home.join("metadata").join(format!("{name}.json"))` writes/reads the legacy
-//! NAME file, while the resolver routes everyone else to the id file
-//! `<uuid>.json` — the two split, which is the #1680/#1682 stale-metadata bug
-//! (operator keystrokes frozen for days; the draft gate force-submitting
-//! drafts). Centralizing construction in the resolver keeps write and read on
-//! the same file.
+//! `home.join("metadata").join(<file>)` writes/reads the legacy NAME file while
+//! the resolver routes everyone else to the id file `<uuid>.json` — the two
+//! split, which is the #1680/#1682 stale-metadata bug (operator keystrokes
+//! frozen for days; the draft gate force-submitting drafts; delete audits going
+//! blind to `<uuid>.json` residuals).
 //!
-//! The needle targets the DYNAMIC form (`...join(format!(`). Dedicated `tests.rs`
-//! files are test-only (they fabricate metadata fixtures directly) and are
-//! skipped, mirroring `file_size_invariant`'s `tests.rs` skip.
+//! ⚠ This is a BEST-EFFORT lint, NOT an AST-level guarantee. It flags the
+//! two-join file construction `…join("metadata").join(…)` in any single- OR
+//! multi-line form, with the filename built by `format!`, a literal, or an
+//! intermediate variable. It CANNOT catch every bypass — e.g. an intermediate
+//! *directory* variable (`let d = home.join("metadata"); d.join(format!(…))`) or
+//! a fully dynamic `PathBuf` assembled elsewhere. We deliberately do NOT build an
+//! AST checker for this (over-engineering); the lint catches the realistic
+//! hand-coded shapes (including the ones that caused #1682) and the resolver
+//! helpers are the documented path. New bypass shapes seen in review should be
+//! added here.
 
 use std::path::PathBuf;
 
 /// Only `agent_ops` owns metadata-path construction (it IS the resolver).
 const ALLOWED: &[&str] = &["src/agent_ops.rs"];
-
-/// The banned hand-coded construction. Anchored from `.join("metadata")` so it
-/// matches regardless of the receiver (`home.join` / `h.join` / `ctx.home.join`).
-const NEEDLE: &str = r#".join("metadata").join(format!("#;
 
 #[test]
 fn metadata_paths_go_through_agent_ops_resolver_1682() {
@@ -44,10 +46,24 @@ fn metadata_paths_go_through_agent_ops_resolver_1682() {
                     continue;
                 }
                 let content = std::fs::read_to_string(&path).expect("read file");
-                for (i, line) in content.lines().enumerate() {
-                    if line.contains(NEEDLE) {
-                        violations.push(format!("{}:{}: {}", rel, i + 1, line.trim()));
-                    }
+                // Inline `#[cfg(test)] mod tests` is conventionally at the file
+                // end and fabricates fixtures directly; scan only production code.
+                let prod = match content.find("#[cfg(test)]") {
+                    Some(i) => &content[..i],
+                    None => &content,
+                };
+                // Whitespace-strip so the needle matches across line breaks and
+                // regardless of indentation (catches the multi-line chain form).
+                let squashed: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+                if squashed.contains(r#".join("metadata").join("#) {
+                    // Best-effort line hint: where the metadata join sits.
+                    let hint = prod
+                        .lines()
+                        .enumerate()
+                        .find(|(_, l)| l.contains(r#".join("metadata")"#))
+                        .map(|(n, l)| format!("{}:{}: {}", rel, n + 1, l.trim()))
+                        .unwrap_or_else(|| format!("{rel}: (cross-line metadata path join)"));
+                    violations.push(hint);
                 }
             }
         }
@@ -57,7 +73,7 @@ fn metadata_paths_go_through_agent_ops_resolver_1682() {
         violations.is_empty(),
         "#1682: hand-coded metadata file paths must go through the agent_ops \
          resolver (metadata_path_resolved / save_metadata / metadata_path_for_id), \
-         else the write splits from the resolver-based read:\n{}",
+         else the write/read/audit splits from the id-resolved file:\n{}",
         violations.join("\n")
     );
 }


### PR DESCRIPTION
## Bug (#1682) — write-side follow-up to #1680
Several call sites hand-coded `metadata/<name>.json` while the resolver (and, post-#1680, **all readers**) use the id file `<uuid>.json` → writes/reads **split** (operator metadata frozen for days, e.g. `fixup-lead.json` `last_input`). The telegram `pending_pickup` read-modify-write additionally used a bare `rename` that could clobber the resolver's symlink.

## Audit table (every `home.join("metadata").join(format!("{...}.json"))` site)
| Site | Was | Now |
|---|---|---|
| `telegram/inbound.rs:396` | **WRITE** RMW (pending_pickup) + bare rename | read + `save_metadata` via resolver |
| `telegram/bot_api.rs:37` | read (last_message_id) | `metadata_path_resolved` |
| `supervisor.rs:1270` | read (heartbeat age) | `metadata_path_resolved` |
| `supervisor.rs:1285` | read (clear_waiting_on; write was already resolved) | `metadata_path_resolved` |
| `agent/mod.rs:1622` | read (working_directory) | `metadata_path_resolved` |
| `api/mod.rs:653` | **DELETE** name file (spawn-clear) | `agent_ops::remove_metadata` (name + id) |
| `instance_lifecycle.rs:96` | **DELETE** `<id>.json` (fleet.yaml gone) | `agent_ops::metadata_path_for_id` |
| `instance_lifecycle.rs:194` | `exists()` residual check | `agent_ops::metadata_exists` (pure, both paths) |

## New `agent_ops` API (construction now lives only here)
- `metadata_path_for_id(home, &InstanceId)` — pure id path for post-fleet-removal cleanup.
- `remove_metadata(home, name)` — clears **both** name + id files (the old name-only remove missed the `<uuid>.json` readers now read post-#1680).
- `metadata_exists(home, name)` — side-effect-free existence over both paths (residual checks must not *create* a symlink mid-audit, which `metadata_path_resolved` would).

## Invariant test (`tests/metadata_resolver_invariant.rs`)
Bans the hand-coded `.join("metadata").join(format!(` construction outside `agent_ops`. Dedicated `tests.rs` files (which fabricate metadata fixtures) are skipped.
**Verified RED before → GREEN after** (8 production violations listed in the failing run).

## Scope note
Fixes the WRITE/DELETE sites **and** the read sites. The reads are the same #1680 stale-name-path bug and are one-liners — converting them lets the invariant allowlist be just `agent_ops` (no deferred-read carve-outs) and avoids a follow-up #1683. (Slightly broader than "writes only" — flagging for the reviewer.)

## Evidence
```
cargo test --test metadata_resolver_invariant   # FAIL before (8 violations) → PASS after
cargo test agent_ops → 29 ; notification_queue:: → 12 ; daemon::supervisor → 55 ; telegram → 98 ; instance_lifecycle → 13   # all pass
cargo test --test file_size_invariant → pass
cargo fmt --check ✓ ; cargo clippy --all-targets --features tray / tray,discord -D warnings ✓
git diff origin/main --stat → only my 8 files (no #1463 shim stray)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)