### PR TITLE
feat(#8 Phase 2 step-1): migrate OpenCode detection into BackendProfile (byte-identical parity)

### DIFF
--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -15,10 +15,12 @@
 //! BYTE-IDENTICAL to legacy for the migrated backends; the migration train then
 //! reroutes production one backend per PR, gated by that harness.
 //!
-//! Migrated so far: `Shell`/`Raw` (empty), `Agy` (#1672), and `KiroCli` (this
-//! PR — 11 patterns, incl. one that references the shared
-//! `SERVER_RATE_LIMIT_NET_ERRORS` const). The migration train adds one backend
-//! per PR, each proven byte-identical by the harness below.
+//! Migrated so far: `Shell`/`Raw` (empty), `Agy` (#1672), `KiroCli` (#1674),
+//! and `OpenCode` (#8 step-1, this PR — 12 patterns, incl. the shared
+//! `SERVER_RATE_LIMIT_NET_ERRORS` const). Production is rerouted as of step-0
+//! (#1683): `profile()`-Some backends run detection through the bundle, legacy
+//! is the parity baseline until the train ends. One backend per PR, each proven
+//! byte-identical by the harness below.
 
 use crate::backend::Backend;
 use crate::behavioral::{BehavioralConfig, MarkerCacheId, ProductivityConfig};
@@ -47,12 +49,14 @@ pub struct BackendProfile {
 pub fn profile(backend: &Backend) -> Option<&'static BackendProfile> {
     static AGY: OnceLock<BackendProfile> = OnceLock::new();
     static KIRO: OnceLock<BackendProfile> = OnceLock::new();
+    static OPENCODE: OnceLock<BackendProfile> = OnceLock::new();
     // Shell + Raw share one profile — every legacy source treats `Shell | Raw(_)`
     // identically (empty patterns, default behavioral, generic productivity, Ready).
     static EMPTY: OnceLock<BackendProfile> = OnceLock::new();
     match backend {
         Backend::Agy => Some(AGY.get_or_init(agy_profile)),
         Backend::KiroCli => Some(KIRO.get_or_init(kirocli_profile)),
+        Backend::OpenCode => Some(OPENCODE.get_or_init(opencode_profile)),
         Backend::Shell | Backend::Raw(_) => Some(EMPTY.get_or_init(empty_profile)),
         _ => None,
     }
@@ -146,6 +150,65 @@ fn kirocli_profile() -> BackendProfile {
     }
 }
 
+/// OpenCode (#8 Phase 2 step-1) — moved VERBATIM from the legacy sites
+/// (patterns.rs `compile_for` Backend::OpenCode arm, behavioral.rs
+/// `config_for_legacy` + `config_for_productivity_legacy`, managed→Starting
+/// initial state). The ServerRateLimit entry references the SAME shared
+/// `SERVER_RATE_LIMIT_NET_ERRORS` const and the markers reference the SAME
+/// `OPENCODE_PRODUCTIVE_MARKERS` const the legacy arms use, so they stay
+/// byte-identical. The harness proves it.
+fn opencode_profile() -> BackendProfile {
+    BackendProfile {
+        patterns: vec![
+            (
+                AgentState::RateLimit,
+                r"API rate limited \(429\)|Rate limited\. Quick retry|API rate limit exceeded",
+            ),
+            (
+                AgentState::ServerRateLimit,
+                crate::state::patterns::SERVER_RATE_LIMIT_NET_ERRORS,
+            ),
+            (AgentState::UsageLimit, r"Quota Limit Exceeded"),
+            (
+                AgentState::ApiError,
+                r"Error from provider:|request validation errors",
+            ),
+            (AgentState::ContextFull, r"ContextOverflow"),
+            (
+                AgentState::PermissionPrompt,
+                r"Permission required|Allow once\s+Allow always\s+Reject",
+            ),
+            (
+                AgentState::GitConflict,
+                r"Automatic merge failed; fix conflicts|CONFLICT \(content\)|Resolve all conflicts manually|Failed to merge submodule|Failed to merge in",
+            ),
+            (
+                AgentState::ToolUse,
+                r"✱\s+(Read|Write|Edit|Glob|Grep|Bash|List|Task)\b|~\s+(Reading|Writing|Editing|Searching|Listing|Globbing|Grepping)\b",
+            ),
+            (AgentState::Thinking, r"esc interrupt"),
+            (
+                AgentState::PermissionPrompt,
+                r"Update Available|Skip\s+Confirm",
+            ),
+            (AgentState::Idle, r"Ask anything"),
+            (AgentState::Ready, r"Ask anything|tab agents"),
+        ],
+        behavioral: BehavioralConfig {
+            silence_thinking_ms: 3000,
+            silence_idle_ms: 8000,
+            supports_cursor_query: false,
+        },
+        productivity: ProductivityConfig {
+            markers: crate::behavioral::OPENCODE_PRODUCTIVE_MARKERS,
+            use_heartbeat: true,
+            heartbeat_fresh_window_ms: 10_000,
+            cache_id: Some(MarkerCacheId::OpenCode),
+        },
+        initial_state: AgentState::Starting,
+    }
+}
+
 /// Shell / Raw — moved VERBATIM (empty patterns, default behavioral, generic
 /// productivity, Ready initial state).
 fn empty_profile() -> BackendProfile {
@@ -176,6 +239,7 @@ mod tests {
         vec![
             Backend::Agy,
             Backend::KiroCli,
+            Backend::OpenCode,
             Backend::Shell,
             Backend::Raw("x".to_string()),
         ]
@@ -259,14 +323,10 @@ mod tests {
     }
 
     /// Non-migrated backends still return `None` (legacy path owns them).
+    /// OpenCode left this set in step-1 (#8 Phase 2) — it is now `migrated()`.
     #[test]
     fn unmigrated_backends_have_no_profile_yet() {
-        for b in [
-            Backend::ClaudeCode,
-            Backend::Codex,
-            Backend::OpenCode,
-            Backend::Gemini,
-        ] {
+        for b in [Backend::ClaudeCode, Backend::Codex, Backend::Gemini] {
             assert!(profile(&b).is_none(), "{b:?} must stay on the legacy path");
         }
     }

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -406,7 +406,10 @@ pub(crate) const GEMINI_PRODUCTIVE_MARKERS: &[&str] = &[
 /// `✱` glyph) with OpenCode tool-name vocabulary. Synthetic-only —
 /// not validated against real PTY captures; corpus growth path per
 /// `docs/F685-FIXTURE-CORPUS.md §F685-CORPUS.6`.
-const OPENCODE_PRODUCTIVE_MARKERS: &[&str] = &[
+// #8 Phase 2 step-1: pub(crate) so the co-located OpenCode BackendProfile
+// references the SAME markers const (not a re-typed copy) → byte-identity with
+// the legacy config_for_productivity arm. Matches KIRO_PRODUCTIVE_MARKERS.
+pub(crate) const OPENCODE_PRODUCTIVE_MARKERS: &[&str] = &[
     r"^Saved to \S+",
     r"^Wrote \d+ bytes",
     r"^Created file: \S+",


### PR DESCRIPTION
## What (#8 Phase 2, step 1 — train leg 2 of the OpenCode→Codex→Claude→delete-legacy plan)
Step-0 (#1683) wired prod to route `profile()`-Some backends through the co-located `BackendProfile`. This migrates **OpenCode**: `profile(OpenCode)` now returns `Some`, so `for_backend` / `config_for` / `config_for_productivity` / `StateTracker::new` auto-route OpenCode through the bundle. The other 3 un-migrated backends (Claude/Codex/Gemini) are untouched (`profile()==None` → legacy).

## Change
- **`opencode_profile()`**: 12 detection patterns + behavioral + productivity + initial_state, moved **VERBATIM** from the legacy sites (patterns.rs `compile_for` OpenCode arm, behavioral.rs `config_for_legacy` + `config_for_productivity_legacy`, managed→`Starting`). `ServerRateLimit` references the **shared** `SERVER_RATE_LIMIT_NET_ERRORS` const; markers reference the **shared** `OPENCODE_PRODUCTIVE_MARKERS` const → byte-identical to legacy by construction (no re-typed copies).
- `behavioral.rs`: `OPENCODE_PRODUCTIVE_MARKERS` → `pub(crate)` (matches `KIRO_PRODUCTIVE_MARKERS`).
- **Lazy caching preserved**: new per-backend `OnceLock OPENCODE` + `get_or_init`.
- Legacy `compile_for` / `config_for` OpenCode arms **KEPT** as the parity baseline (the train's legacy is deleted only at the end).

## Parity gate (merge-required; detection is #1523-adjacent)
- ⚠ **Non-circular** (the step-0 trap): the harness compares `profile.patterns` against the **TRUE legacy** `compile_for(OpenCode)` / `config_for_legacy` / `config_for_productivity_legacy` / `legacy_initial_state` — NOT the now-rerouted `for_backend`.
- OpenCode added to the harness `migrated()` set → covered by all 4 layers: `profile_patterns_byte_identical_to_legacy` (structural, complete — identical sources ⟹ identical detection), `profile_detect_matches_legacy_on_corpus`, `profile_configs_byte_identical_to_legacy`, `for_backend_classify_parity_with_legacy_step0` (prod-entry, all 8 backends). Removed from `unmigrated_backends_have_no_profile_yet`.
- Full-corpus `replay_manifest_regression` passes against the rerouted prod path.

## Evidence (local, targeted — #1463 discipline)
`cargo test backend_profile` → 5 passed (parity, incl. OpenCode); `replay_manifest` → 1 passed; `state::` 264 / `behavioral` 58 passed (no regression); `file_size_invariant` pass; clippy `--features tray` + `tray,discord` clean. `git diff origin/main --stat` = backend_profile.rs + behavioral.rs only; zero stray commits.

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)