### PR TITLE
feat(#8 Phase 2 step-2): migrate Codex detection into BackendProfile (byte-identical parity)

### DIFF
--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -16,11 +16,12 @@
 //! reroutes production one backend per PR, gated by that harness.
 //!
 //! Migrated so far: `Shell`/`Raw` (empty), `Agy` (#1672), `KiroCli` (#1674),
-//! and `OpenCode` (#8 step-1, this PR — 12 patterns, incl. the shared
-//! `SERVER_RATE_LIMIT_NET_ERRORS` const). Production is rerouted as of step-0
-//! (#1683): `profile()`-Some backends run detection through the bundle, legacy
-//! is the parity baseline until the train ends. One backend per PR, each proven
-//! byte-identical by the harness below.
+//! `OpenCode` (#1686), and `Codex` (#8 step-2, this PR — 11 patterns incl. the
+//! shared `SERVER_RATE_LIMIT_NET_ERRORS` const + the #1634 ModelUnsupported
+//! pattern). Production is rerouted as of step-0 (#1683): `profile()`-Some
+//! backends run detection through the bundle, legacy is the parity baseline
+//! until the train ends. One backend per PR, each proven byte-identical by the
+//! harness below (and a drift-guard test pins `migrated()` ⟺ `profile().is_some`).
 
 use crate::backend::Backend;
 use crate::behavioral::{BehavioralConfig, MarkerCacheId, ProductivityConfig};
@@ -50,6 +51,7 @@ pub fn profile(backend: &Backend) -> Option<&'static BackendProfile> {
     static AGY: OnceLock<BackendProfile> = OnceLock::new();
     static KIRO: OnceLock<BackendProfile> = OnceLock::new();
     static OPENCODE: OnceLock<BackendProfile> = OnceLock::new();
+    static CODEX: OnceLock<BackendProfile> = OnceLock::new();
     // Shell + Raw share one profile — every legacy source treats `Shell | Raw(_)`
     // identically (empty patterns, default behavioral, generic productivity, Ready).
     static EMPTY: OnceLock<BackendProfile> = OnceLock::new();
@@ -57,6 +59,7 @@ pub fn profile(backend: &Backend) -> Option<&'static BackendProfile> {
         Backend::Agy => Some(AGY.get_or_init(agy_profile)),
         Backend::KiroCli => Some(KIRO.get_or_init(kirocli_profile)),
         Backend::OpenCode => Some(OPENCODE.get_or_init(opencode_profile)),
+        Backend::Codex => Some(CODEX.get_or_init(codex_profile)),
         Backend::Shell | Backend::Raw(_) => Some(EMPTY.get_or_init(empty_profile)),
         _ => None,
     }
@@ -209,6 +212,58 @@ fn opencode_profile() -> BackendProfile {
     }
 }
 
+/// Codex (#8 Phase 2 step-2) — moved VERBATIM from the legacy sites (patterns.rs
+/// `compile_for` Backend::Codex arm, behavioral.rs `config_for_legacy` +
+/// `config_for_productivity_legacy`, managed→Starting). ServerRateLimit
+/// references the SAME shared `SERVER_RATE_LIMIT_NET_ERRORS` const and the
+/// markers the SAME `CODEX_PRODUCTIVE_MARKERS` const the legacy arms use → byte-
+/// identical. Includes the #1634 ModelUnsupported pattern (HIGH_FP, #919 red-
+/// anchor gated downstream — unchanged by this move). The harness proves it.
+fn codex_profile() -> BackendProfile {
+    BackendProfile {
+        patterns: vec![
+            (AgentState::AuthError, r"OPENAI_API_KEY|api.?key"),
+            (AgentState::UsageLimit, r"hit your usage limit|try again at"),
+            (
+                AgentState::RateLimit,
+                r"rate_limit_exceeded|RateLimitError|hit your rate limit",
+            ),
+            (
+                AgentState::ServerRateLimit,
+                crate::state::patterns::SERVER_RATE_LIMIT_NET_ERRORS,
+            ),
+            (AgentState::ContextFull, r"ContextOverflow"),
+            (
+                AgentState::ModelUnsupported,
+                r"invalid_request_error|model is not supported|Model metadata for .*? not found",
+            ),
+            (
+                AgentState::PermissionPrompt,
+                r"Would you like to run the following command\?|Press enter to confirm or esc to cancel|No, and tell Codex what to do differently",
+            ),
+            (
+                AgentState::GitConflict,
+                r"Automatic merge failed; fix conflicts|CONFLICT \(content\)|Resolve all conflicts manually|Failed to merge submodule|Failed to merge in",
+            ),
+            (AgentState::Thinking, r"Working|esc to interrupt"),
+            (AgentState::Idle, r"›"),
+            (AgentState::Ready, r"OpenAI Codex|gpt-.*left"),
+        ],
+        behavioral: BehavioralConfig {
+            silence_thinking_ms: 3000,
+            silence_idle_ms: 8000,
+            supports_cursor_query: false,
+        },
+        productivity: ProductivityConfig {
+            markers: crate::behavioral::CODEX_PRODUCTIVE_MARKERS,
+            use_heartbeat: true,
+            heartbeat_fresh_window_ms: 10_000,
+            cache_id: Some(MarkerCacheId::Codex),
+        },
+        initial_state: AgentState::Starting,
+    }
+}
+
 /// Shell / Raw — moved VERBATIM (empty patterns, default behavioral, generic
 /// productivity, Ready initial state).
 fn empty_profile() -> BackendProfile {
@@ -240,6 +295,7 @@ mod tests {
             Backend::Agy,
             Backend::KiroCli,
             Backend::OpenCode,
+            Backend::Codex,
             Backend::Shell,
             Backend::Raw("x".to_string()),
         ]
@@ -326,7 +382,9 @@ mod tests {
     /// OpenCode left this set in step-1 (#8 Phase 2) — it is now `migrated()`.
     #[test]
     fn unmigrated_backends_have_no_profile_yet() {
-        for b in [Backend::ClaudeCode, Backend::Codex, Backend::Gemini] {
+        // Codex left this set in step-2 (#8 Phase 2) — now `migrated()`. Only
+        // ClaudeCode + Gemini remain on the legacy path (Claude lands in #1689).
+        for b in [Backend::ClaudeCode, Backend::Gemini] {
             assert!(profile(&b).is_none(), "{b:?} must stay on the legacy path");
         }
     }
@@ -379,6 +437,41 @@ mod tests {
                     "for_backend (prod) vs compile_for (legacy) parity for {b:?} on {item:?}"
                 );
             }
+        }
+    }
+
+    /// #8 Phase 2 (codex/#1687) DRIFT GUARD — the systemic fix. `migrated()` (the
+    /// TEST set the byte-identical parity tests iterate) and `profile()` (the PROD
+    /// routing) are two INDEPENDENT lists. If a backend is wired into `profile()`
+    /// but missing from `migrated()`, its byte-identity is SILENTLY un-tested (the
+    /// parity loop just skips it → false-green); the reverse leaves a `migrated()`
+    /// entry with no prod profile. Assert the two agree BIDIRECTIONALLY over EVERY
+    /// `Backend` variant (by discriminant, so `Raw(_)` matches regardless of
+    /// payload) so any future drift goes red immediately. This is the check that
+    /// would have caught the class codex flagged on this PR.
+    #[test]
+    fn migrated_set_matches_profile_some_bidirectional_drift_guard() {
+        use std::mem::discriminant;
+        let all = [
+            Backend::ClaudeCode,
+            Backend::KiroCli,
+            Backend::Codex,
+            Backend::OpenCode,
+            Backend::Gemini,
+            Backend::Agy,
+            Backend::Shell,
+            Backend::Raw("x".to_string()),
+        ];
+        let m = migrated();
+        for b in &all {
+            let in_migrated = m.iter().any(|x| discriminant(x) == discriminant(b));
+            let has_profile = profile(b).is_some();
+            assert_eq!(
+                in_migrated, has_profile,
+                "{b:?}: in migrated()={in_migrated} but profile().is_some()={has_profile} — \
+                 migrated() (parity-test set) and profile() (prod routing) have DRIFTED. A backend \
+                 wired into profile() yet missing from migrated() is SILENTLY un-parity-tested."
+            );
         }
     }
 }

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -384,7 +384,10 @@ pub(crate) const KIRO_PRODUCTIVE_MARKERS: &[&str] = &[
 
 /// Codex: generic anchors + `•` past-tense title vocabulary (`Explored`,
 /// `Edited`, `Ran`) + `apply_patch` literal completion banner.
-const CODEX_PRODUCTIVE_MARKERS: &[&str] = &[
+// #8 Phase 2 step-2: pub(crate) so the co-located Codex BackendProfile references
+// the SAME markers const (not a re-typed copy) → byte-identity with the legacy
+// config_for_productivity arm. Matches KIRO_/OPENCODE_PRODUCTIVE_MARKERS.
+pub(crate) const CODEX_PRODUCTIVE_MARKERS: &[&str] = &[
     r"^Saved to \S+",
     r"^Wrote \d+ bytes",
     r"^Created file: \S+",


### PR DESCRIPTION
## What (#8 Phase 2, step 2 — train leg 3, **parallel** with OpenCode #1686)
`profile(Codex)` now returns `Some`, so prod routes Codex detection through the co-located `BackendProfile` (step-0 #1683 fork). The other un-migrated backends are untouched (`profile()==None` → legacy).

## Change
- **`codex_profile()`**: 11 patterns + behavioral + productivity + initial_state, moved **VERBATIM** from the legacy sites (patterns.rs `compile_for` Codex arm — incl. the #1634 `ModelUnsupported` HIGH_FP pattern — behavioral.rs `config_for_legacy` + `config_for_productivity_legacy`, managed→`Starting`). `ServerRateLimit` references the **shared** `SERVER_RATE_LIMIT_NET_ERRORS` const; markers the **shared** `CODEX_PRODUCTIVE_MARKERS` const → byte-identical by construction.
- `behavioral.rs`: `CODEX_PRODUCTIVE_MARKERS` → `pub(crate)` (matches `KIRO_`/`OPENCODE_`).
- Lazy caching preserved: new per-backend `OnceLock CODEX` + `get_or_init`.
- Legacy `compile_for`/`config_for` Codex arms **KEPT** as the parity baseline.

## Parity gate (merge-required; #1523-adjacent)
- ⚠ **Non-circular** (step-0 trap): harness compares `profile` against the **TRUE legacy** `compile_for(Codex)` / `config_for_legacy` / `config_for_productivity_legacy` — NOT the rerouted `for_backend`.
- Codex added to `migrated()` → covered by all 4 layers (`profile_patterns_byte_identical_to_legacy`, `profile_detect_matches_legacy_on_corpus`, `profile_configs_byte_identical_to_legacy`, `for_backend_classify_parity_with_legacy_step0`) + removed from `unmigrated_backends_have_no_profile_yet`. Full-corpus `replay_manifest_regression` green on the rerouted prod path.

## ⚠ Merge ordering / rebase
Branched off origin/main (**pre-OpenCode #1686**). Per the train plan: **#1686 (OpenCode) merges first, then this Codex PR.** After #1686 merges this rebases onto main; the trivial conflicts in `migrated()` / `profile()` match / `unmigrated` test resolve by **keeping BOTH** OpenCode and Codex (the harness is the safety net).

## Evidence (local, targeted — #1463 discipline)
`cargo test backend_profile` → 5 passed (parity, incl. Codex); `replay_manifest` → 1 passed; `state::` 264 / `behavioral` 58 passed (no regression); `file_size_invariant` pass; clippy `--features tray` + `tray,discord` clean. `git diff origin/main --stat` = backend_profile.rs + behavioral.rs only; zero stray commits.

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)