### PR TITLE
#1651: HMAC-sign binding.json push-authority (defense-in-depth vs injection blind-write)

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -17,6 +17,13 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+// #1651: share the EXACT HMAC verifier with the daemon by source (the shim is a
+// separate binary that cannot link the lib). `config_integrity` declares the
+// same file as `mod integrity_core`; this `#[path]` include guarantees no
+// signer/verifier algorithm drift.
+#[path = "../integrity_core.rs"]
+mod integrity_core;
+
 /// #1504 L3: max times the shim may re-enter before hard-failing. Healthy
 /// operation never exceeds 1 (real git ≠ shim → no re-entry), so a small cap
 /// has zero false-trip risk while containing a self-resolution spawn storm.
@@ -202,14 +209,24 @@ struct Binding {
 }
 
 fn read_binding(home: &str, agent: &str) -> Binding {
-    let path = PathBuf::from(home)
-        .join("runtime")
-        .join(agent)
-        .join("binding.json");
+    let dir = PathBuf::from(home).join("runtime").join(agent);
+    let path = dir.join("binding.json");
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
         Err(_) => return Binding::default(),
     };
+    // #1651: verify the HMAC sidecar BEFORE trusting the binding (esp. its
+    // `branch` push-authority). A blind self-authorization rewrite — an injected
+    // agent editing its own `binding.json` without the key — fails verify, so we
+    // treat the agent as UNBOUND (fail-closed → `deny_unbound_else_chdir` denies
+    // mutating ops, the SAME path a parse failure already takes). Missing sidecar
+    // / missing key / mismatch all fail closed. Defense-in-depth against injection
+    // blind-write, NOT a security boundary: a same-uid agent could read the key
+    // and re-sign (accepted); true sealing needs OS-isolation (parked #1653).
+    let tag = std::fs::read_to_string(dir.join("binding.json.sig")).unwrap_or_default();
+    if !integrity_core::verify(Path::new(home), content.as_bytes(), &tag) {
+        return Binding::default();
+    }
     let v: serde_json::Value = match serde_json::from_str(&content) {
         Ok(v) => v,
         Err(_) => return Binding::default(), // parse failure = unbound (fail-safe)
@@ -1461,6 +1478,78 @@ fn format_conflict_guidance() -> &'static str {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    // ── #1651: binding.json HMAC verify (push-authority integrity) ──
+    fn home_1651(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!("agend-git-1651-{}-{}", std::process::id(), tag));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        // The shared integrity key (both signer + verifier read it).
+        std::fs::write(p.join(".config-integrity-key"), [7u8; 32]).unwrap();
+        p
+    }
+
+    fn write_binding_1651(home: &Path, agent: &str, body: &str, signed: bool) {
+        let dir = home.join("runtime").join(agent);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("binding.json"), body).unwrap();
+        if signed {
+            let tag = integrity_core::sign_for_test(home, body.as_bytes());
+            std::fs::write(dir.join("binding.json.sig"), tag).unwrap();
+        }
+    }
+
+    // No `worktree` field → the orphan-worktree guard is skipped, so the binding
+    // outcome reflects the HMAC verify alone.
+    const BODY_1651: &str = r#"{"version":1,"task_id":"T-1","branch":"feat/x"}"#;
+
+    #[test]
+    fn valid_signed_binding_is_bound_1651() {
+        let home = home_1651("valid");
+        write_binding_1651(&home, "ag", BODY_1651, true);
+        let b = read_binding(home.to_str().unwrap(), "ag");
+        assert!(is_bound(&b), "a validly-signed binding must be bound");
+        assert_eq!(b.branch.as_deref(), Some("feat/x"));
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn tampered_branch_without_resign_is_unbound_and_denied_1651() {
+        let home = home_1651("tamper");
+        // Daemon wrote + signed the original (branch feat/x).
+        write_binding_1651(&home, "ag", BODY_1651, true);
+        // Injection blind-write: self-authorize `main`, WITHOUT re-signing
+        // (the agent doesn't know the key/scheme).
+        let tampered = r#"{"version":1,"task_id":"T-1","branch":"main"}"#;
+        std::fs::write(
+            home.join("runtime").join("ag").join("binding.json"),
+            tampered,
+        )
+        .unwrap();
+        let b = read_binding(home.to_str().unwrap(), "ag");
+        assert!(
+            !is_bound(&b),
+            "#1651: a tampered (unsigned-for-new-content) binding must read as unbound"
+        );
+        // …and a mutating op on unbound takes the EXISTING fail-closed deny path.
+        assert!(matches!(
+            deny_unbound_else_chdir(is_bound(&b), &b),
+            Action::Deny(_)
+        ));
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn missing_sidecar_is_unbound_1651() {
+        let home = home_1651("nosig");
+        write_binding_1651(&home, "ag", BODY_1651, false); // NO sidecar
+        let b = read_binding(home.to_str().unwrap(), "ag");
+        assert!(
+            !is_bound(&b),
+            "#1651: a binding with no HMAC sidecar must fail closed (unbound)"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
 
     // ── #1463: init-heartbeat argv detection (forensic hook gate) ──
     fn s(v: &[&str]) -> Vec<String> {

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -5,7 +5,7 @@
 
 use serde_json::json;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
 
 static INDEX: OnceLock<RwLock<HashMap<String, serde_json::Value>>> = OnceLock::new();
@@ -85,20 +85,84 @@ pub fn bind_full(
     let body = serde_json::to_string_pretty(&binding).unwrap_or_default();
     crate::store::atomic_write(&path, body.as_bytes())
         .map_err(|e| format!("atomic_write {}: {e}", path.display()))?;
+    // #1651: HMAC-sign the binding (sidecar `binding.json.sig`, mirroring #1576's
+    // operator-mode.json scheme) so the agend-git shim can reject a blind
+    // self-authorization rewrite — an injected agent editing its own `branch`
+    // without re-signing makes the shim's verify fail → unbound → push denied.
+    // Defense-in-depth against injection blind-write, NOT a security boundary
+    // (a same-uid agent could read the key + re-sign; true sealing needs
+    // OS-isolation, parked #1653). Best-effort: a missing/failed sidecar leaves
+    // the binding unsigned → the shim fails CLOSED (denies), never open.
+    match crate::config_integrity::sign(home, body.as_bytes()) {
+        Ok(tag) => {
+            if let Err(e) = crate::store::atomic_write(&binding_sig_path(&dir), tag.as_bytes()) {
+                tracing::warn!(%agent, error = %e,
+                    "#1651 binding sidecar write failed — shim fails closed (deny) until re-bind");
+            }
+        }
+        Err(e) => tracing::warn!(%agent, error = %e,
+            "#1651 binding HMAC sign failed — shim fails closed (deny) until re-bind"),
+    }
     if let Ok(mut map) = binding_index().write() {
         map.insert(index_key(home, agent), binding);
     }
     Ok(())
 }
 
+/// #1651: the HMAC sidecar path for a binding dir. The agend-git shim hard-codes
+/// the same `binding.json.sig` name (it cannot import this — separate binary).
+fn binding_sig_path(dir: &Path) -> PathBuf {
+    dir.join("binding.json.sig")
+}
+
 /// Clear a binding for an agent (task completed/released).
 pub fn unbind(home: &Path, agent: &str) {
-    let path = crate::paths::runtime_dir(home)
-        .join(agent)
-        .join("binding.json");
-    let _ = std::fs::remove_file(path);
+    let dir = crate::paths::runtime_dir(home).join(agent);
+    let _ = std::fs::remove_file(dir.join("binding.json"));
+    // #1651: drop the HMAC sidecar too, so a stale signature can't linger.
+    let _ = std::fs::remove_file(binding_sig_path(&dir));
     if let Ok(mut map) = binding_index().write() {
         map.remove(&index_key(home, agent));
+    }
+}
+
+/// #1651 rollout pass (daemon startup): bless pre-#1651 bindings that have NO
+/// HMAC sidecar yet. Bindings + worktrees PERSIST across a daemon restart and are
+/// NOT re-bound on startup, so without this a pre-existing (unsigned) binding
+/// would verify-fail in the shim and FALSE-DENY a legit agent's push until its
+/// next re-bind.
+///
+/// SECURITY: only bindings with NO sidecar are re-signed (the genuine rollout
+/// case — those files were written by a trusted daemon before this feature, and
+/// were already unprotected pre-#1651). A binding that ALREADY has a sidecar is
+/// left untouched: if that sidecar is invalid (tampered after signing), it stays
+/// fail-closed and is NOT re-blessed by a restart. Idempotent — a no-op once
+/// every binding carries a sidecar.
+pub fn resign_unsigned_bindings(home: &Path) {
+    let Ok(entries) = std::fs::read_dir(crate::paths::runtime_dir(home)) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        let binding = dir.join("binding.json");
+        let sig = binding_sig_path(&dir);
+        if !binding.exists() || sig.exists() {
+            continue; // no binding, or already signed → leave it
+        }
+        let Ok(body) = std::fs::read(&binding) else {
+            continue;
+        };
+        match crate::config_integrity::sign(home, &body) {
+            Ok(tag) => match crate::store::atomic_write(&sig, tag.as_bytes()) {
+                Ok(()) => {
+                    tracing::info!(?dir, "#1651 startup: signed pre-existing unsigned binding")
+                }
+                Err(e) => {
+                    tracing::warn!(?dir, error = %e, "#1651 startup re-sign: sidecar write failed")
+                }
+            },
+            Err(e) => tracing::warn!(?dir, error = %e, "#1651 startup re-sign: HMAC sign failed"),
+        }
     }
 }
 

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -126,45 +126,20 @@ pub fn unbind(home: &Path, agent: &str) {
     }
 }
 
-/// #1651 rollout pass (daemon startup): bless pre-#1651 bindings that have NO
-/// HMAC sidecar yet. Bindings + worktrees PERSIST across a daemon restart and are
-/// NOT re-bound on startup, so without this a pre-existing (unsigned) binding
-/// would verify-fail in the shim and FALSE-DENY a legit agent's push until its
-/// next re-bind.
-///
-/// SECURITY: only bindings with NO sidecar are re-signed (the genuine rollout
-/// case — those files were written by a trusted daemon before this feature, and
-/// were already unprotected pre-#1651). A binding that ALREADY has a sidecar is
-/// left untouched: if that sidecar is invalid (tampered after signing), it stays
-/// fail-closed and is NOT re-blessed by a restart. Idempotent — a no-op once
-/// every binding carries a sidecar.
-pub fn resign_unsigned_bindings(home: &Path) {
-    let Ok(entries) = std::fs::read_dir(crate::paths::runtime_dir(home)) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let dir = entry.path();
-        let binding = dir.join("binding.json");
-        let sig = binding_sig_path(&dir);
-        if !binding.exists() || sig.exists() {
-            continue; // no binding, or already signed → leave it
-        }
-        let Ok(body) = std::fs::read(&binding) else {
-            continue;
-        };
-        match crate::config_integrity::sign(home, &body) {
-            Ok(tag) => match crate::store::atomic_write(&sig, tag.as_bytes()) {
-                Ok(()) => {
-                    tracing::info!(?dir, "#1651 startup: signed pre-existing unsigned binding")
-                }
-                Err(e) => {
-                    tracing::warn!(?dir, error = %e, "#1651 startup re-sign: sidecar write failed")
-                }
-            },
-            Err(e) => tracing::warn!(?dir, error = %e, "#1651 startup re-sign: HMAC sign failed"),
-        }
-    }
-}
+// #1688 (codex): there is intentionally NO startup "re-sign unsigned bindings"
+// pass. It was a wash-white hole — keying the decision on "has no sidecar" cannot
+// distinguish a legit pre-#1651 binding from an attacker that tampered
+// binding.json AND deleted the sidecar, and the daemon has NO trusted source at
+// startup to tell them apart (`reconcile_orphan_leases` is log-only; binding.json
+// is the sole on-disk record; bindings are only (re)established via
+// `dispatch_auto_bind_lease`/`bind_full` at dispatch time). So a sidecar-less
+// binding is left UNSIGNED → the shim fails closed (unbound → deny), exactly like
+// a fresh, never-dispatched agent. A legit binding re-signs on its next dispatch
+// or `bind_self`. The rollout cost — agents whose binding survives the activating
+// restart are denied pushes until re-dispatched — is a VISIBLE, self-healing
+// trade-off (the agent reports `blocked`), deliberately chosen over a SILENT
+// wash-white. (Activating restart: the operator re-dispatches / has running
+// agents `bind_self` once; one-time.)
 
 /// Returns Some(agent_name) if any other agent has bound this branch.
 /// Used by dispatch_auto_bind_lease to enforce cross-agent branch uniqueness.
@@ -407,6 +382,38 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    /// #1688 (codex): the daemon startup must NOT auto-bless a sidecar-less
+    /// binding. "No sidecar" cannot distinguish a legit unsigned binding from an
+    /// attacker that tampered binding.json AND deleted the sidecar — there is no
+    /// trusted source at startup to tell them apart, so the only safe behaviour is
+    /// to NOT sign (fail-closed → unbound; legit bindings re-sign on the next
+    /// dispatch / `bind_self`). This pins that a tampered, sidecar-less binding is
+    /// NOT made verifiable by the startup pass — RED while the (now-removed) blind
+    /// `resign_unsigned_bindings` washed it white.
+    #[test]
+    fn startup_does_not_wash_white_tampered_sidecarless_binding_1688() {
+        let home = tmp_home("washwhite-1688");
+        // Shared integrity key present → a sign WOULD produce a verifiable tag.
+        std::fs::write(home.join(".config-integrity-key"), [9u8; 32]).unwrap();
+        // Attacker blind-writes a self-authorizing branch and removes the sidecar.
+        let dir = crate::paths::runtime_dir(&home).join("ag");
+        std::fs::create_dir_all(&dir).unwrap();
+        let forged = r#"{"version":1,"agent":"ag","task_id":"T-1","branch":"main"}"#;
+        std::fs::write(dir.join("binding.json"), forged).unwrap();
+        // (no binding.json.sig — the wash-white precondition)
+
+        // Daemon startup binding handling. Post-#1688 this does NOTHING to an
+        // unsigned binding (the blind re-sign is gone) — so nothing blesses it.
+
+        // The forged content must NOT be verifiable as trusted (no valid sidecar).
+        let sig = std::fs::read_to_string(dir.join("binding.json.sig")).unwrap_or_default();
+        assert!(
+            !crate::config_integrity::verify(&home, forged.as_bytes(), &sig),
+            "#1688: a tampered, sidecar-less binding must NOT be auto-blessed at startup"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]

--- a/src/config_integrity.rs
+++ b/src/config_integrity.rs
@@ -23,22 +23,16 @@
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+// #1651: the VERIFY + key-read half now lives in `integrity_core` (shared by
+// source with the agend-git shim, which only verifies). The SIGN side stays here
+// (getrandom key generation + the threat-model doc). `verify` is re-exported so
+// existing callers (`operator_mode`) keep the `config_integrity::verify` API.
+pub use crate::integrity_core::verify;
+use crate::integrity_core::{key_path, read_key, KEY_FILE, KEY_LEN};
 
 type HmacSha256 = Hmac<Sha256>;
-
-const KEY_LEN: usize = 32;
-const KEY_FILE: &str = ".config-integrity-key";
-
-fn key_path(home: &Path) -> PathBuf {
-    home.join(KEY_FILE)
-}
-
-/// Read the key if present and exactly [`KEY_LEN`] bytes; `None` otherwise.
-fn read_key(home: &Path) -> Option<[u8; KEY_LEN]> {
-    let bytes = std::fs::read(key_path(home)).ok()?;
-    bytes.try_into().ok()
-}
 
 /// Load the key, generating it (crypto-random, 0600) on first use.
 fn ensure_key(home: &Path) -> std::io::Result<[u8; KEY_LEN]> {
@@ -92,27 +86,14 @@ pub fn sign(home: &Path, content: &[u8]) -> std::io::Result<String> {
     Ok(hex::encode(mac.finalize().into_bytes()))
 }
 
-/// Constant-time verify of `content` against the hex `tag`. Returns `false` on
-/// any error (no key yet, malformed tag, mismatch) — callers treat `false` as
-/// "not authentic" and fail closed.
-pub fn verify(home: &Path, content: &[u8], tag: &str) -> bool {
-    let Some(key) = read_key(home) else {
-        return false;
-    };
-    let Ok(mut mac) = HmacSha256::new_from_slice(&key) else {
-        return false;
-    };
-    mac.update(content);
-    let Ok(tag_bytes) = hex::decode(tag.trim()) else {
-        return false;
-    };
-    mac.verify_slice(&tag_bytes).is_ok()
-}
+// `verify` is re-exported from `integrity_core` (see the `pub use` above) —
+// the shim shares that exact verifier by source.
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     fn tmp(tag: &str) -> PathBuf {
         let p =
@@ -156,5 +137,45 @@ mod tests {
         let home = tmp("malformed");
         sign(&home, b"x").unwrap(); // create the key
         assert!(!verify(&home, b"x", "not-hex-zzz"));
+    }
+
+    /// #1651: GOLDEN parity — pins the exact HMAC-SHA256 output for a FIXED key +
+    /// FIXED operator-mode.json content. Computed from the pre-`integrity_core`-
+    /// extraction code; if the extraction (or any future change) alters the
+    /// algorithm/encoding, this tag changes and the test fails — proving
+    /// operator-mode.json signing stays byte-identical ("別動 #1576 已簽檔邏輯").
+    #[test]
+    fn operator_mode_signing_is_byte_identical_golden_1651() {
+        let home = tmp("golden");
+        // Deterministic key (NOT the random one) so the tag is reproducible.
+        std::fs::write(home.join(KEY_FILE), [1u8; KEY_LEN]).unwrap();
+        let content = br#"{"mode":"active","since":"2026-01-01T00:00:00Z"}"#;
+        let tag = sign(&home, content).unwrap();
+        assert_eq!(
+            tag, "def046eac649ccbc86de77718e0f4363ba835283fdd8bee1a5b11cb98671ef72",
+            "#1651: operator-mode.json HMAC must stay byte-identical across the \
+             integrity_core extraction (golden from pre-extraction code)"
+        );
+    }
+
+    /// #1651 cross-compat: the agend-git shim's verifier (`integrity_core::verify`,
+    /// shared by source) MUST accept what the daemon's signer
+    /// (`config_integrity::sign`) produces — this pins the signer/verifier contract
+    /// the binding push-authority relies on.
+    #[test]
+    fn shim_verifier_accepts_daemon_signature_1651() {
+        let home = tmp("crosscompat");
+        let content = br#"{"version":1,"task_id":"T-9","branch":"feat/y"}"#;
+        let tag = sign(&home, content).unwrap();
+        assert!(
+            crate::integrity_core::verify(&home, content, &tag),
+            "the shim verifier must accept a daemon-signed binding tag"
+        );
+        // negative: same key, mutated content (the blind self-authorization) → reject.
+        assert!(!crate::integrity_core::verify(
+            &home,
+            br#"{"version":1,"task_id":"T-9","branch":"main"}"#,
+            &tag
+        ));
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -374,10 +374,11 @@ pub fn run_with_prepared(mut prepared: Box<crate::bootstrap::OwnedFleet>) -> any
     if let Err(e) = crate::fleet::migrate_teams_json_to_yaml(&home) {
         tracing::warn!(error = %e, "teams.json migration failed at daemon startup");
     }
-    // #1651: sign any pre-existing (pre-feature) binding.json that has no HMAC
-    // sidecar, so a binding surviving this restart isn't false-denied by the shim.
-    // Idempotent (skips already-signed bindings); see `resign_unsigned_bindings`.
-    crate::binding::resign_unsigned_bindings(&home);
+    // #1688: intentionally NO startup binding re-sign pass — see `binding.rs`.
+    // It was a wash-white hole: "no sidecar" can't distinguish a legit unsigned
+    // binding from a tampered-then-sidecar-deleted one, and the daemon has no
+    // trusted source at startup to tell them apart. Unsigned bindings fail closed
+    // (unbound) and re-sign on their next dispatch / bind_self.
     let _owned = prepared;
     run_core(&home, agents, telegram)
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -374,6 +374,10 @@ pub fn run_with_prepared(mut prepared: Box<crate::bootstrap::OwnedFleet>) -> any
     if let Err(e) = crate::fleet::migrate_teams_json_to_yaml(&home) {
         tracing::warn!(error = %e, "teams.json migration failed at daemon startup");
     }
+    // #1651: sign any pre-existing (pre-feature) binding.json that has no HMAC
+    // sidecar, so a binding surviving this restart isn't false-denied by the shim.
+    // Idempotent (skips already-signed bindings); see `resign_unsigned_bindings`.
+    crate::binding::resign_unsigned_bindings(&home);
     let _owned = prepared;
     run_core(&home, agents, telegram)
 }

--- a/src/integrity_core.rs
+++ b/src/integrity_core.rs
@@ -1,0 +1,61 @@
+//! #1651: shared HMAC-SHA256 integrity primitives — the VERIFY + key-read half,
+//! used by BOTH the main daemon (`config_integrity`, which adds the sign side)
+//! and the standalone `agend-git` shim (which only verifies). The shim cannot
+//! link the lib and `config_integrity` lives in the main-binary tree, so this
+//! file is shared by source: `config_integrity` declares it as a module and the
+//! shim pulls THE SAME file via `#[path = "../integrity_core.rs"] mod
+//! integrity_core;`. One source ⟹ no signer/verifier algorithm drift (a drift
+//! in a security check fails silently: too-loose → fail-open, too-strict →
+//! false-deny).
+//!
+//! Threat model is documented in `config_integrity` (the signer): same-uid
+//! injection-containment defense-in-depth, NOT a security boundary.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::path::{Path, PathBuf};
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub(crate) const KEY_LEN: usize = 32;
+pub(crate) const KEY_FILE: &str = ".config-integrity-key";
+
+pub(crate) fn key_path(home: &Path) -> PathBuf {
+    home.join(KEY_FILE)
+}
+
+/// Read the key if present and exactly [`KEY_LEN`] bytes; `None` otherwise.
+pub(crate) fn read_key(home: &Path) -> Option<[u8; KEY_LEN]> {
+    let bytes = std::fs::read(key_path(home)).ok()?;
+    bytes.try_into().ok()
+}
+
+/// Constant-time verify of `content` against the hex `tag`. Returns `false` on
+/// any error (no key yet, malformed tag, mismatch) — callers treat `false` as
+/// "not authentic" and fail closed.
+pub fn verify(home: &Path, content: &[u8], tag: &str) -> bool {
+    let Some(key) = read_key(home) else {
+        return false;
+    };
+    let Ok(mut mac) = HmacSha256::new_from_slice(&key) else {
+        return false;
+    };
+    mac.update(content);
+    let Ok(tag_bytes) = hex::decode(tag.trim()) else {
+        return false;
+    };
+    mac.verify_slice(&tag_bytes).is_ok()
+}
+
+/// Test-only HMAC over the EXISTING home key (no generation), so tests in both
+/// binaries can fabricate valid sidecars without the getrandom sign path.
+// Used by the agend-git shim's tests (this file is shared by #[path]); unused in
+// the main binary's test build, hence the allow.
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn sign_for_test(home: &Path, content: &[u8]) -> String {
+    let key = read_key(home).expect("test key must exist");
+    let mut mac = HmacSha256::new_from_slice(&key).expect("HMAC accepts any key length");
+    mac.update(content);
+    hex::encode(mac.finalize().into_bytes())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ mod identity;
 mod inbox;
 mod instance_monitor;
 mod instructions;
+mod integrity_core;
 mod ipc;
 mod keybinds;
 mod layout;


### PR DESCRIPTION
## Problem (#1651)
`runtime/<agent>/binding.json` holds the git push-authority (`branch`), and the **agend-git shim raw-read it** with no integrity check. A prompt-injected, same-uid agent could blind-write its own `branch` to self-authorize a push to any branch. This signs the binding and makes the shim verify before trusting it — mirroring #1576's operator-mode.json HMAC scheme.

## Option A — shared `integrity_core` by source (no algorithm drift)
The agend-git shim is a **standalone std-only binary that can't link the lib**, and `config_integrity` lives in the main-binary tree. So:
- New **`src/integrity_core.rs`** holds the verify + key-read primitives. The main binary declares `mod integrity_core`; the shim pulls **the same file** via `#[path = "../integrity_core.rs"]`. One source ⟹ the signer (daemon) and verifier (shim) can never drift (a drift in a security check fails silently: too-loose → fail-open, too-strict → false-deny).
- `config_integrity` keeps the sign side (getrandom key-gen) + **re-exports `verify`**, so `operator_mode`'s `config_integrity::verify` API is unchanged.
- **PARITY PROOF** (lead's hard condition): a golden test pins operator-mode.json's HMAC tag to the value computed from the **pre-extraction** code — byte-identical signing is *proven*, not asserted.

## Wiring
- `binding.rs::bind_full` signs the binding → `binding.json.sig`; `unbind` removes it.
- The shim's `read_binding` verifies (content + sidecar); **any** failure (missing / mismatch / no-key) → `Binding::default()` → reuses the **existing** unbound→`deny_unbound_else_chdir` fail-closed path (no new deny path). A blind self-authorization rewrite downgrades to **deny**, never escalation.
- **Rollout防呆**: bindings + worktrees PERSIST across a daemon restart (not re-bound), so a startup pass `resign_unsigned_bindings` signs pre-#1651 (sidecar-less) bindings — avoiding a false-deny of legit agents. **Security**: only sidecar-*less* bindings are blessed; a binding with an *invalid* sidecar (post-#1651 tamper) stays fail-closed. Idempotent.

## Threat model (per lead, mirrors #1576)
Defense-in-depth against injection blind-write, **NOT a security boundary** — a same-uid agent could read the key + re-sign (accepted); no nonce → self-replay out of model; true sealing needs OS-isolation (parked #1653). Documented in code.

## Tests (4, all required)
| # | Test | |
|---|---|---|
| ① | `tampered_branch_without_resign_is_unbound_and_denied_1651` | edit `branch`, no re-sign → shim unbound → `Action::Deny`. **Verified RED** when the verify gate is disabled. |
| ② | `missing_sidecar_is_unbound_1651` | no sidecar → unbound (fail-closed) |
| ③ | `operator_mode_signing_is_byte_identical_golden_1651` | golden parity across the extraction |
| ④ | `shim_verifier_accepts_daemon_signature_1651` | `integrity_core::verify` accepts `config_integrity::sign` output |

## Evidence
```
cargo test _1651 (shim) → 3 ok ; config_integrity:: → 6 ok ; operator_mode → 12 ok ; binding:: → 16 ok
RED proof: with the verify gate disabled, ① + ② FAIL; restored → pass
agend_git_shim_phase1/2 + app_mode_wiring integration → pass (binding-verify change doesn't break them)
file_size / cargo_include / spawn_rationale invariants → pass
cargo fmt --check ✓ ; clippy --all-targets (tray / tray,discord) -D warnings ✓
(has_unmerged_files conflict test false-fails under the fleet git shim; passes under real /usr/bin/git — environmental, CI uses real git)
```

## Activation
Daemon-side — inert until the daemon restarts onto the new binary (joins #1670/#1680/#1682 for the same restart). On that restart, `resign_unsigned_bindings` blesses existing bindings so no legit agent is false-denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)