### PR TITLE
event-bus: migrate the first notification pattern (anti_stall) via Option A

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -160,22 +160,47 @@ fn stall_recipients() -> Vec<String> {
     vec!["general".to_string(), "lead".to_string()]
 }
 
-fn emit_stall(home: &Path, task: &Task, reason: &str) {
-    let text = format!(
+/// #event-bus first-pattern: the stall notification text, built from the exact
+/// fields carried by `EventKind::TaskStateChanged`, so the legacy direct enqueue
+/// and the bus subscriber produce a BYTE-IDENTICAL message.
+fn stall_text(
+    task_id: &str,
+    title: &str,
+    reason: &str,
+    started_at: Option<&str>,
+    eta_secs: Option<i64>,
+    assignee: Option<&str>,
+) -> String {
+    format!(
         "[task_stalled] {tid} '{title}' stalled — {reason}. \
          started_at={started_at}, eta_secs={eta_secs}, assignee={assignee}. \
          Consider: lead re-dispatch / dev unblock-ping / task action=update with \
          status=blocked + reason if dependency.",
-        tid = task.id,
-        title = task.title,
+        tid = task_id,
+        title = title,
         reason = reason,
-        started_at = task.started_at.as_deref().unwrap_or("?"),
-        eta_secs = task
-            .eta_secs
+        started_at = started_at.unwrap_or("?"),
+        eta_secs = eta_secs
             .map(|e| e.to_string())
             .unwrap_or_else(|| "?".into()),
-        assignee = task.assignee.as_deref().unwrap_or("?"),
-    );
+        assignee = assignee.unwrap_or("?"),
+    )
+}
+
+/// #event-bus first-pattern: the actual delivery (notify_system to each stall
+/// recipient). Shared by BOTH the legacy gate-off path and the bus subscriber, so
+/// the two are identical by construction — the parity test proves the event
+/// carries enough to call this the same way.
+fn deliver_stall(
+    home: &Path,
+    task_id: &str,
+    title: &str,
+    reason: &str,
+    started_at: Option<&str>,
+    eta_secs: Option<i64>,
+    assignee: Option<&str>,
+) {
+    let text = stall_text(task_id, title, reason, started_at, eta_secs, assignee);
     for recipient in stall_recipients() {
         if let Err(e) = crate::inbox::notify_system(
             home,
@@ -183,31 +208,75 @@ fn emit_stall(home: &Path, task: &Task, reason: &str) {
             "system:anti_stall",
             "task_stalled",
             text.clone(),
-            Some(&task.id),
-            Some(&task.id),
+            Some(task_id),
+            Some(task_id),
         ) {
-            tracing::warn!(
-                error = %e,
-                recipient = %recipient,
-                task_id = %task.id,
-                "anti_stall: enqueue failed"
-            );
+            tracing::warn!(error = %e, recipient = %recipient, task_id, "anti_stall: enqueue failed");
         } else {
-            tracing::info!(
-                recipient = %recipient,
-                task_id = %task.id,
-                "anti_stall: emitted task_stalled inbox event"
-            );
+            tracing::info!(recipient = %recipient, task_id, "anti_stall: emitted task_stalled inbox event");
         }
     }
-    crate::daemon::event_bus::global().emit_lazy(|| {
-        crate::daemon::event_bus::EventKind::TaskStateChanged {
+}
+
+/// #event-bus first-pattern: bus subscriber — on a `TaskStateChanged` event,
+/// run the stall delivery (the gate-ON path). Registered once at daemon startup
+/// via [`register_subscriber`].
+fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+    if let crate::daemon::event_bus::EventKind::TaskStateChanged {
+        task_id,
+        title,
+        assignee,
+        reason,
+        started_at,
+        eta_secs,
+    } = &event.kind
+    {
+        deliver_stall(
+            home,
+            task_id,
+            title,
+            reason,
+            started_at.as_deref(),
+            *eta_secs,
+            assignee.as_deref(),
+        );
+    }
+}
+
+/// #event-bus first-pattern: register the anti_stall delivery subscriber on the
+/// global bus. Call ONCE at daemon startup. Safe regardless of the gate — when
+/// the bus is gate-off, `emit` never fires, so the subscriber is dormant.
+pub fn register_subscriber(home: std::path::PathBuf) {
+    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+}
+
+fn emit_stall(home: &Path, task: &Task, reason: &str) {
+    // #event-bus first-pattern (Option A): gate-ON → emit (the subscriber
+    // delivers); gate-OFF (prod default) → the legacy direct delivery. No
+    // double-delivery, no gate-off regression. The legacy `else` branch is
+    // retired only at the final cutover (all patterns migrated + gate default
+    // flipped). Parity of the two paths is proven by the gate-on test.
+    let bus = crate::daemon::event_bus::global();
+    if bus.is_enabled() {
+        bus.emit(crate::daemon::event_bus::EventKind::TaskStateChanged {
             task_id: task.id.clone(),
             title: task.title.clone(),
             assignee: task.assignee.clone(),
             reason: reason.to_string(),
-        }
-    });
+            started_at: task.started_at.clone(),
+            eta_secs: task.eta_secs,
+        });
+    } else {
+        deliver_stall(
+            home,
+            &task.id,
+            &task.title,
+            reason,
+            task.started_at.as_deref(),
+            task.eta_secs,
+            task.assignee.as_deref(),
+        );
+    }
 }
 
 #[cfg(test)]
@@ -602,6 +671,111 @@ mod tests {
         for _ in 0..(TICKS_PER_SCAN + 1) {
             tracker.maybe_scan(&home);
         }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #event-bus first-pattern: emit→subscriber vs legacy parity ──
+
+    /// The comparable inbox payload for a recipient, ignoring the volatile
+    /// id/timestamp: (from, kind, text, correlation_id) per drained message.
+    fn drained_payloads(
+        home: &Path,
+        recipient: &str,
+    ) -> Vec<(String, Option<String>, String, Option<String>)> {
+        crate::inbox::storage::drain(home, recipient)
+            .into_iter()
+            .map(|m| (m.from, m.kind, m.text, m.correlation_id))
+            .collect()
+    }
+
+    /// PARITY (gate-ON): the bus `emit`→subscriber path must deliver payloads
+    /// byte-identical (recipients, text, kind, correlation) to the legacy direct
+    /// enqueue. Exercises the REAL bus emit→fan-out→subscriber wiring.
+    #[test]
+    fn gate_on_emit_subscriber_matches_legacy_direct_enqueue() {
+        // Serialize against the `AGEND_TASK_STALL_RECIPIENTS` override tests so the
+        // env (hence `stall_recipients()`) is stable across both delivery paths.
+        let _g = env_lock();
+        std::env::remove_var("AGEND_TASK_STALL_RECIPIENTS");
+        let task = make_task(
+            "t-parity",
+            "in_progress",
+            Some(600),
+            Some("2026-01-01T00:00:00+00:00"),
+        );
+        let reason = "elapsed=900s exceeds 1.5x eta (900s)";
+
+        // Legacy direct delivery (the gate-OFF path).
+        let home_legacy = tmp_home("parity-legacy");
+        deliver_stall(
+            &home_legacy,
+            &task.id,
+            &task.title,
+            reason,
+            task.started_at.as_deref(),
+            task.eta_secs,
+            task.assignee.as_deref(),
+        );
+
+        // Bus emit→subscriber delivery (the gate-ON path) — real fan-out.
+        let home_bus = tmp_home("parity-bus");
+        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
+        let h = home_bus.clone();
+        bus.subscribe(move |e| handle_event(&h, e));
+        bus.emit(crate::daemon::event_bus::EventKind::TaskStateChanged {
+            task_id: task.id.clone(),
+            title: task.title.clone(),
+            assignee: task.assignee.clone(),
+            reason: reason.to_string(),
+            started_at: task.started_at.clone(),
+            eta_secs: task.eta_secs,
+        });
+
+        let mut delivered = false;
+        for r in stall_recipients() {
+            let legacy = drained_payloads(&home_legacy, &r);
+            let viabus = drained_payloads(&home_bus, &r);
+            assert_eq!(
+                legacy, viabus,
+                "emit→subscriber payload must equal legacy direct enqueue for {r}"
+            );
+            delivered |= !legacy.is_empty();
+        }
+        assert!(
+            delivered,
+            "parity test must actually deliver ≥1 message (else it proves nothing)"
+        );
+        std::fs::remove_dir_all(&home_legacy).ok();
+        std::fs::remove_dir_all(&home_bus).ok();
+    }
+
+    /// Option A: with the gate OFF (prod default — the global bus reads
+    /// `AGEND_EVENT_BUS`, unset in tests), `emit_stall` must STILL deliver via the
+    /// legacy path. No regression.
+    #[test]
+    fn gate_off_emit_stall_delivers_via_legacy() {
+        let _g = env_lock();
+        std::env::remove_var("AGEND_TASK_STALL_RECIPIENTS");
+        assert!(
+            !crate::daemon::event_bus::global().is_enabled(),
+            "precondition: the global bus must be gate-off in the test env"
+        );
+        let home = tmp_home("gate-off");
+        let task = make_task(
+            "t-gateoff",
+            "in_progress",
+            Some(60),
+            Some("2026-01-01T00:00:00+00:00"),
+        );
+        emit_stall(&home, &task, "stalled reason");
+        let mut delivered = false;
+        for r in stall_recipients() {
+            delivered |= !drained_payloads(&home, &r).is_empty();
+        }
+        assert!(
+            delivered,
+            "#event-bus Option A: gate-off must deliver via the legacy path (no regression)"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -17,6 +17,11 @@ pub enum EventKind {
         title: String,
         assignee: Option<String>,
         reason: String,
+        // #event-bus first-pattern (anti_stall): carry the task's `started_at` +
+        // `eta_secs` so a subscriber can rebuild the BYTE-IDENTICAL notification
+        // text the legacy direct enqueue formats from them.
+        started_at: Option<String>,
+        eta_secs: Option<i64>,
     },
     CiReady {
         repo: String,
@@ -81,6 +86,17 @@ impl EventBus {
 
     pub fn is_enabled(&self) -> bool {
         self.enabled
+    }
+
+    /// Test-only: a bus with the gate forced ON (bypasses the env var), so other
+    /// modules' tests can exercise the `emit`→subscriber path deterministically
+    /// without touching the process-global `global()` bus.
+    #[cfg(test)]
+    pub(crate) fn new_enabled_for_test() -> Self {
+        Self {
+            subscribers: parking_lot::Mutex::new(Vec::new()),
+            enabled: true,
+        }
     }
 
     pub fn subscribe(&self, f: impl Fn(&Event) + Send + Sync + 'static) {
@@ -159,6 +175,8 @@ mod tests {
             title: "test".into(),
             assignee: Some("dev".into()),
             reason: "stalled".into(),
+            started_at: None,
+            eta_secs: None,
         });
         let events = received.lock().unwrap();
         assert_eq!(events.len(), 1);
@@ -200,6 +218,8 @@ mod tests {
                 title: "t".into(),
                 assignee: None,
                 reason: "r".into(),
+                started_at: None,
+                eta_secs: None,
             },
             EventKind::CiReady {
                 repo: "o/r".into(),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -406,6 +406,10 @@ fn run_core(
 
     let ctx = init_daemon_services(home, telegram)?;
 
+    // #event-bus first-pattern: register the anti_stall delivery subscriber once.
+    // Dormant unless AGEND_EVENT_BUS=1 (emit is a no-op when gate-off).
+    crate::daemon::anti_stall::register_subscriber(home.to_path_buf());
+
     spawn_fleet_agents(home, &agents, &ctx);
 
     let (shutdown_tx, shutdown_rx) = crossbeam_channel::bounded::<()>(1);


### PR DESCRIPTION
First concrete pattern through the dormant `event_bus` spine (`src/daemon/event_bus.rs`) — the **template** for the remaining 11. Backlog task `t-20260526155947252378-9`.

## Pattern: anti_stall (why simplest)
Of the 5 wired emit sites (anti_stall / supervisor / ci_watch×2 / dispatch_idle, all subscriber-less), anti_stall is the most self-contained: **one** delivery mechanism (a single `notify_system` loop over fixed recipients `["general","lead"]`), correlation already in the event (`task_id`), constant source/kind. (supervisor does two enqueues + orchestrator resolution; dispatch_idle needs dispatch_id/threshold + event_log; ci_watch has a per-subscriber loop + URL/emoji body across two emit sites.)

## What changed
- `EventKind::TaskStateChanged` gains `started_at` + `eta_secs` so a subscriber can rebuild the **byte-identical** `task_stalled` text the legacy enqueue formats.
- anti_stall: extracted `stall_text` + `deliver_stall` (shared delivery, used by **both** legacy and subscriber) + `handle_event` (subscriber) + `register_subscriber` (wired once at daemon startup).
- **Option A** detection point (`emit_stall`): `if bus.is_enabled() { emit → subscriber delivers } else { legacy direct deliver }`. No double-delivery on the gate-ON path; gate-OFF (prod default) keeps legacy delivery → **no regression**. The legacy `else` is retired only at the final cutover (all patterns migrated + gate default flipped).

## Tests / Evidence
- `gate_on_emit_subscriber_matches_legacy_direct_enqueue` — exercises the **real** bus emit→fan-out→subscriber path; asserts the delivered inbox payloads (from/kind/text/correlation, ignoring volatile id/timestamp) are **identical** to the legacy direct enqueue, per recipient. Meaningful: diverges if the event doesn't carry started_at/eta_secs.
- `gate_off_emit_stall_delivers_via_legacy` — gate off → `emit_stall` still delivers via legacy (no regression).
- Both take the existing `env_lock()` to serialize against the `AGEND_TASK_STALL_RECIPIENTS` override tests (process-global env — fixed an initial flake).
- `event_bus::new_enabled_for_test` lets other modules exercise emit→subscriber without the process-global `global()` bus.

```
cargo test anti_stall:: → 32 passed (×3, no flake) ; event_bus:: → 4 passed
cargo fmt --check ✓ ; clippy --all-targets (tray / tray,discord) -D warnings ✓
git diff origin/main --stat → 3 files, no stray
```

## Scope (per lead)
Only this one pattern. Gate default **not** flipped; `#![allow(dead_code)]` **not** removed — both are end-of-train cutover steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)