### PR TITLE
event-bus: migrate the second pattern (decision_timeout) via the #1690 template

### DIFF
--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -290,16 +290,46 @@ pub(crate) fn scan_and_emit(home: &Path) {
     }
 }
 
-fn emit_timeout_event(home: &Path, d: &PendingDecision, elapsed_secs: i64) {
-    let text = format!(
+/// #event-bus pattern #2: the timeout notification text, built from the exact
+/// fields carried by `EventKind::DecisionTimeout`, so the legacy direct enqueue
+/// and the bus subscriber produce a BYTE-IDENTICAL message.
+fn decision_timeout_text(
+    decision_id: &str,
+    sender: &str,
+    elapsed_secs: i64,
+    timeout_secs: i64,
+    default_action: &str,
+) -> String {
+    format!(
         "[decision_timeout] decision {decision_id} from '{sender}' timed out \
          after {elapsed_secs}s (threshold {timeout_secs}s). Auto-default: \
          '{default_action}'. Operator can reverse via reply.",
-        decision_id = d.decision_id,
-        sender = d.sender,
+        decision_id = decision_id,
+        sender = sender,
         elapsed_secs = elapsed_secs,
-        timeout_secs = d.timeout_secs,
-        default_action = d.default_action,
+        timeout_secs = timeout_secs,
+        default_action = default_action,
+    )
+}
+
+/// #event-bus pattern #2: the actual delivery (notify_system to the timeout
+/// recipient). Shared by BOTH the legacy gate-off path and the bus subscriber, so
+/// the two are identical by construction — the parity test proves the event
+/// carries enough to call this the same way.
+fn deliver_timeout(
+    home: &Path,
+    decision_id: &str,
+    sender: &str,
+    elapsed_secs: i64,
+    timeout_secs: i64,
+    default_action: &str,
+) {
+    let text = decision_timeout_text(
+        decision_id,
+        sender,
+        elapsed_secs,
+        timeout_secs,
+        default_action,
     );
     let recipient = timeout_recipient();
     if let Err(e) = crate::inbox::notify_system(
@@ -308,10 +338,64 @@ fn emit_timeout_event(home: &Path, d: &PendingDecision, elapsed_secs: i64) {
         "system:decision_timeout",
         "decision_timeout",
         text,
-        Some(&d.decision_id),
+        Some(decision_id),
         None,
     ) {
         tracing::warn!(error = %e, recipient, "decision_timeout: enqueue failed");
+    }
+}
+
+/// #event-bus pattern #2: bus subscriber — deliver on a `DecisionTimeout` event
+/// (the gate-ON path). Registered once at daemon startup via [`register_subscriber`].
+fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+    if let crate::daemon::event_bus::EventKind::DecisionTimeout {
+        decision_id,
+        sender,
+        elapsed_secs,
+        timeout_secs,
+        default_action,
+    } = &event.kind
+    {
+        deliver_timeout(
+            home,
+            decision_id,
+            sender,
+            *elapsed_secs,
+            *timeout_secs,
+            default_action,
+        );
+    }
+}
+
+/// #event-bus pattern #2: register the decision_timeout delivery subscriber on
+/// the global bus. Call ONCE at daemon startup. Dormant while the bus is gate-off
+/// (emit never fires), so registration is always safe.
+pub fn register_subscriber(home: std::path::PathBuf) {
+    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+}
+
+fn emit_timeout_event(home: &Path, d: &PendingDecision, elapsed_secs: i64) {
+    // #event-bus pattern #2 (Option A): gate-ON → emit (the subscriber delivers);
+    // gate-OFF (prod default) → the legacy direct delivery. No double-delivery, no
+    // gate-off regression. The legacy `else` is retired only at the final cutover.
+    let bus = crate::daemon::event_bus::global();
+    if bus.is_enabled() {
+        bus.emit(crate::daemon::event_bus::EventKind::DecisionTimeout {
+            decision_id: d.decision_id.clone(),
+            sender: d.sender.clone(),
+            elapsed_secs,
+            timeout_secs: d.timeout_secs,
+            default_action: d.default_action.clone(),
+        });
+    } else {
+        deliver_timeout(
+            home,
+            &d.decision_id,
+            &d.sender,
+            elapsed_secs,
+            d.timeout_secs,
+            &d.default_action,
+        );
     }
 }
 
@@ -878,5 +962,100 @@ mod tests {
             prod[block_end..].contains(&emit_needle),
             "emit_timeout_event must run AFTER the decision flock is dropped"
         );
+    }
+
+    // ── #event-bus pattern #2: emit→subscriber vs legacy parity ──
+
+    /// The comparable inbox payload (ignoring volatile id/timestamp).
+    fn drained_payloads(
+        home: &Path,
+        recipient: &str,
+    ) -> Vec<(String, Option<String>, String, Option<String>)> {
+        crate::inbox::drain(home, recipient)
+            .into_iter()
+            .map(|m| (m.from, m.kind, m.text, m.correlation_id))
+            .collect()
+    }
+
+    /// PARITY (gate-ON): the bus `emit`→subscriber path delivers payloads
+    /// byte-identical (from/kind/text/correlation) to the legacy direct enqueue.
+    /// Exercises the REAL bus emit→fan-out→subscriber wiring.
+    #[test]
+    fn gate_on_emit_subscriber_matches_legacy_direct_enqueue() {
+        let _g = env_lock();
+        std::env::remove_var("AGEND_DECISION_TIMEOUT_RECIPIENT");
+        let (decision_id, sender, elapsed_secs, timeout_secs, default_action) = (
+            "d-parity",
+            "general",
+            2000_i64,
+            1800_i64,
+            "proceed-with-lean",
+        );
+
+        // Legacy direct delivery (the gate-OFF path).
+        let home_legacy = tmp_home("parity-legacy");
+        deliver_timeout(
+            &home_legacy,
+            decision_id,
+            sender,
+            elapsed_secs,
+            timeout_secs,
+            default_action,
+        );
+
+        // Bus emit→subscriber delivery (the gate-ON path) — real fan-out.
+        let home_bus = tmp_home("parity-bus");
+        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
+        let h = home_bus.clone();
+        bus.subscribe(move |e| handle_event(&h, e));
+        bus.emit(crate::daemon::event_bus::EventKind::DecisionTimeout {
+            decision_id: decision_id.to_string(),
+            sender: sender.to_string(),
+            elapsed_secs,
+            timeout_secs,
+            default_action: default_action.to_string(),
+        });
+
+        let recipient = timeout_recipient();
+        let legacy = drained_payloads(&home_legacy, &recipient);
+        let viabus = drained_payloads(&home_bus, &recipient);
+        assert_eq!(
+            legacy, viabus,
+            "emit→subscriber payload must equal legacy direct enqueue"
+        );
+        assert!(
+            !legacy.is_empty(),
+            "parity test must actually deliver ≥1 message (else it proves nothing)"
+        );
+        std::fs::remove_dir_all(&home_legacy).ok();
+        std::fs::remove_dir_all(&home_bus).ok();
+    }
+
+    /// Option A: with the gate OFF (prod default), `emit_timeout_event` must STILL
+    /// deliver via the legacy path. No regression.
+    #[test]
+    fn gate_off_emit_delivers_via_legacy() {
+        let _g = env_lock();
+        std::env::remove_var("AGEND_DECISION_TIMEOUT_RECIPIENT");
+        assert!(
+            !crate::daemon::event_bus::global().is_enabled(),
+            "precondition: the global bus must be gate-off in the test env"
+        );
+        let home = tmp_home("gate-off");
+        let d = PendingDecision {
+            decision_id: "d-gateoff".into(),
+            sender: "general".into(),
+            default_action: "proceed".into(),
+            timeout_secs: 1800,
+            status: "timeout".into(),
+            ..Default::default()
+        };
+        emit_timeout_event(&home, &d, 2000);
+        let recipient = timeout_recipient();
+        assert!(
+            !drained_payloads(&home, &recipient).is_empty(),
+            "#event-bus Option A: gate-off must deliver via the legacy path (no regression)"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -44,6 +44,15 @@ pub enum EventKind {
         from_state: String,
         to_state: String,
     },
+    // #event-bus pattern #2 (decision_timeout): all fields the auto-default
+    // timeout notification formats, so the subscriber rebuilds it byte-identically.
+    DecisionTimeout {
+        decision_id: String,
+        sender: String,
+        elapsed_secs: i64,
+        timeout_secs: i64,
+        default_action: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -241,6 +250,13 @@ mod tests {
                 team: "fixup".into(),
                 from_state: "Ready".into(),
                 to_state: "ServerRateLimit".into(),
+            },
+            EventKind::DecisionTimeout {
+                decision_id: "d-1".into(),
+                sender: "general".into(),
+                elapsed_secs: 2000,
+                timeout_secs: 1800,
+                default_action: "proceed".into(),
             },
         ];
         for k in kinds {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -406,9 +406,10 @@ fn run_core(
 
     let ctx = init_daemon_services(home, telegram)?;
 
-    // #event-bus first-pattern: register the anti_stall delivery subscriber once.
-    // Dormant unless AGEND_EVENT_BUS=1 (emit is a no-op when gate-off).
+    // #event-bus: register the per-pattern delivery subscribers once. Dormant
+    // unless AGEND_EVENT_BUS=1 (emit is a no-op when gate-off).
     crate::daemon::anti_stall::register_subscriber(home.to_path_buf());
+    crate::daemon::decision_timeout::register_subscriber(home.to_path_buf());
 
     spawn_fleet_agents(home, &agents, &ctx);
 


### PR DESCRIPTION
Second pattern through the `event_bus` spine, reusing the **#1690 (anti_stall)** template. Event-bus migration task `t-20260526155947252378-9`.

## Pattern: decision_timeout (next-simplest)
Single `notify_system` to a single recipient (`timeout_recipient()`), all notification fields local (`PendingDecision` + elapsed_secs), emit already lock-free. (conflict_notify has two notify paths + multi-field payload; poll_reminder is an inject / multi-agent loop.)

## Changes (per the template)
- New `EventKind::DecisionTimeout { decision_id, sender, elapsed_secs, timeout_secs, default_action }`.
- `decision_timeout`: extracted `decision_timeout_text` + `deliver_timeout` (shared by **both** legacy and subscriber) + `handle_event` + `register_subscriber` (wired at daemon startup beside anti_stall).
- **Option A** `emit_timeout_event`: `if bus.is_enabled() { emit → subscriber } else { legacy }`. No double on gate-on; gate-off keeps legacy → no regression. The `#1116/#1617` flock-drop-before-emit ordering is preserved (`scan_and_emit` unchanged; its source-placement invariant test still passes).

## Tests / Evidence
- `gate_on_emit_subscriber_matches_legacy_direct_enqueue` — real bus emit→fan-out→subscriber payloads (from/kind/text/correlation) identical to the legacy direct enqueue.
- `gate_off_emit_delivers_via_legacy` — gate off → still delivers via legacy.
- Both take the existing `env_lock()` (serialize against the `AGEND_DECISION_TIMEOUT_RECIPIENT` override tests).

```
cargo test decision_timeout:: → 22 passed (×2, incl. the flock-placement invariant) ; event_bus:: → 4 passed
cargo fmt --check ✓ ; clippy --all-targets (tray / tray,discord) -D warnings ✓ ; 3-file diff, no stray
```

## Scope
One pattern; gate default **not** flipped; `#![allow(dead_code)]` **not** removed (end-of-train cutover). 10 patterns remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)