### PR TITLE
event-bus: migrate the fourth pattern (waiting_on_stale) via the #1690 template

### DIFF
--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -60,6 +60,14 @@ pub enum EventKind {
         timeout_secs: i64,
         default_action: String,
     },
+    // #event-bus pattern #4 (waiting_on_stale): the fields the stale-waiting
+    // notification formats, so the subscriber rebuilds the text byte-identically
+    // and re-derives the agent + team-orchestrator fan-out.
+    WaitingOnStale {
+        agent: String,
+        condition: String,
+        elapsed_min: i64,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -411,6 +411,7 @@ fn run_core(
     crate::daemon::anti_stall::register_subscriber(home.to_path_buf());
     crate::daemon::decision_timeout::register_subscriber(home.to_path_buf());
     crate::daemon::dispatch_idle::register_subscriber(home.to_path_buf());
+    crate::daemon::waiting_on_stale::register_subscriber(home.to_path_buf());
 
     spawn_fleet_agents(home, &agents, &ctx);
 

--- a/src/daemon/waiting_on_stale.rs
+++ b/src/daemon/waiting_on_stale.rs
@@ -88,19 +88,41 @@ pub(crate) fn scan_and_emit(
             }
         }
         let elapsed_min = elapsed_secs / 60;
-        emit_stale_alert(home, agent, condition, elapsed_min);
+        // #event-bus pattern #4 (Option A): emit→subscriber when the bus is on,
+        // else the legacy direct deliver. Byte-identical either way (both paths
+        // bottom out in `deliver_stale_alert`).
+        let bus = crate::daemon::event_bus::global();
+        if bus.is_enabled() {
+            bus.emit(crate::daemon::event_bus::EventKind::WaitingOnStale {
+                agent: agent.to_string(),
+                condition: condition.to_string(),
+                elapsed_min,
+            });
+        } else {
+            deliver_stale_alert(home, agent, condition, elapsed_min);
+        }
         last_alerted.insert(agent.to_string(), now);
     }
 }
 
-fn emit_stale_alert(home: &Path, agent: &str, condition: &str, elapsed_min: i64) {
-    let text = format!(
+/// #event-bus pattern #4: the stale-waiting notification text. Shared by the
+/// legacy direct deliver AND the event-bus subscriber so both rebuild the
+/// BYTE-IDENTICAL text.
+fn waiting_on_stale_text(agent: &str, condition: &str, elapsed_min: i64) -> String {
+    format!(
         "[waiting_on_stale] {agent}: waiting on \"{condition}\" for {elapsed_min}m\n\n\
          ⚠ Action checklist:\n\
          1. Re-evaluate if blocker is resolved\n\
          2. If resolved → clear waiting_on, resume work\n\
          3. If still blocked → escalate to lead with status update"
-    );
+    )
+}
+
+/// #event-bus pattern #4: deliver the stale-waiting alert to the agent itself +
+/// the team orchestrator (if any). Shared by the legacy path AND the subscriber
+/// ([`handle_event`]), so the two are byte-identical by construction.
+fn deliver_stale_alert(home: &Path, agent: &str, condition: &str, elapsed_min: i64) {
+    let text = waiting_on_stale_text(agent, condition, elapsed_min);
     // Alert the agent itself
     emit_to(home, agent, "waiting_on_stale", &text, Some(agent));
     // Alert team orchestrator (if any)
@@ -111,6 +133,25 @@ fn emit_stale_alert(home: &Path, agent: &str, condition: &str, elapsed_min: i64)
             }
         }
     }
+}
+
+/// #event-bus pattern #4: subscriber — rebuild the alert from the event.
+fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+    if let crate::daemon::event_bus::EventKind::WaitingOnStale {
+        agent,
+        condition,
+        elapsed_min,
+    } = &event.kind
+    {
+        deliver_stale_alert(home, agent, condition, *elapsed_min);
+    }
+}
+
+/// #event-bus pattern #4: register the delivery subscriber at daemon startup
+/// (dormant unless `AGEND_EVENT_BUS=1`). Wired beside anti_stall /
+/// decision_timeout / dispatch_idle in `daemon::mod`.
+pub fn register_subscriber(home: std::path::PathBuf) {
+    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
 }
 
 fn emit_to(home: &Path, recipient: &str, kind: &str, text: &str, correlation_agent: Option<&str>) {
@@ -231,6 +272,74 @@ mod tests {
         }
         assert!(tracker.maybe_scan(&home));
         assert!(!tracker.maybe_scan(&home));
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    fn drained_payloads(
+        home: &Path,
+        recipient: &str,
+    ) -> Vec<(String, Option<String>, String, Option<String>)> {
+        crate::inbox::drain(home, recipient)
+            .into_iter()
+            .map(|m| (m.from, m.kind, m.text, m.correlation_id))
+            .collect()
+    }
+
+    /// #event-bus pattern #4 PARITY (gate-ON): the bus `emit`→subscriber path
+    /// delivers payloads byte-identical (from/kind/text/correlation) to the legacy
+    /// direct enqueue. Exercises the REAL bus emit→fan-out→subscriber wiring. No
+    /// `env_lock`: the recipients (agent + team orchestrator) are data/file-derived,
+    /// not env-derived, so there is no process-global env race.
+    #[test]
+    fn gate_on_emit_subscriber_matches_legacy_direct_enqueue() {
+        let (agent, condition, elapsed_min) = ("dev-parity", "review from reviewer", 20_i64);
+
+        // Legacy direct deliver (the gate-OFF path).
+        let home_legacy = tmp_home("parity-legacy");
+        std::fs::create_dir_all(home_legacy.join("inbox")).unwrap();
+        deliver_stale_alert(&home_legacy, agent, condition, elapsed_min);
+
+        // Bus emit→subscriber (the gate-ON path) — real fan-out via a test bus.
+        let home_bus = tmp_home("parity-bus");
+        std::fs::create_dir_all(home_bus.join("inbox")).unwrap();
+        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
+        let h = home_bus.clone();
+        bus.subscribe(move |e| handle_event(&h, e));
+        bus.emit(crate::daemon::event_bus::EventKind::WaitingOnStale {
+            agent: agent.to_string(),
+            condition: condition.to_string(),
+            elapsed_min,
+        });
+
+        let legacy = drained_payloads(&home_legacy, agent);
+        let viabus = drained_payloads(&home_bus, agent);
+        assert_eq!(
+            legacy, viabus,
+            "emit→subscriber payload must equal legacy direct enqueue"
+        );
+        assert!(!legacy.is_empty(), "the agent must be alerted");
+        let _ = std::fs::remove_dir_all(&home_legacy);
+        let _ = std::fs::remove_dir_all(&home_bus);
+    }
+
+    /// #event-bus pattern #4 REGRESSION (gate-OFF): with the global bus disabled
+    /// (default test env), the scan still delivers via the legacy path.
+    #[test]
+    fn gate_off_scan_delivers_via_legacy() {
+        assert!(
+            !crate::daemon::event_bus::global().is_enabled(),
+            "precondition: the global bus must be gate-off in the test env"
+        );
+        let home = tmp_home("gate-off");
+        std::fs::create_dir_all(home.join("inbox")).unwrap();
+        let since = (chrono::Utc::now() - chrono::Duration::minutes(20)).to_rfc3339();
+        write_metadata(&home, "dev-gateoff", "blocker", &since);
+        let mut last_alerted = HashMap::new();
+        scan_and_emit(&home, &mut last_alerted);
+        assert!(
+            !drained_payloads(&home, "dev-gateoff").is_empty(),
+            "#event-bus Option A: gate-off must deliver via the legacy path (no regression)"
+        );
         let _ = std::fs::remove_dir_all(&home);
     }
 }


### PR DESCRIPTION
## What (event-bus pattern #4)
Fourth notification pattern through the `event_bus` spine, reusing the #1690 (anti_stall) / #1692 (decision_timeout) / #1695 (dispatch_idle) template. **Parallel-safe with dev's supervisor retry work — does NOT touch supervisor.rs.**

## Why this pattern
`waiting_on_stale` is the simplest remaining **non-supervisor, self-contained** candidate: single text formatter, recipients = agent + optional team-orchestrator (derived via `teams::find_team_for` — a FILE lookup, **not env-derived**, so no `env_lock` needed), all format fields local to the call site. (Ruled out: idle_watchdog/cron_tick — env-derived recipients; poll_reminder — PTY inject not `notify_system`; conflict_notify — dual emit sites.)

## Change (the template)
- **`EventKind::WaitingOnStale { agent, condition, elapsed_min }`** — the fields the notification formats, so the subscriber rebuilds the byte-identical text + re-derives the agent + orchestrator fan-out.
- **waiting_on_stale.rs**: extracted `waiting_on_stale_text` + `deliver_stale_alert` (shared by BOTH the legacy path AND the subscriber, incl. the agent + orchestrator fan-out) + `handle_event` + `register_subscriber` (wired at daemon startup beside the other 3 in `daemon/mod.rs`).
- **Option A gate** at the scan call site: `if bus.is_enabled() { emit → subscriber } else { deliver_stale_alert }`. **Gate default UNCHANGED** (dormant unless `AGEND_EVENT_BUS=1`); no `dead_code` allow moved.
- **Tests**: gate-ON parity (`emit→subscriber` payload `==` legacy direct enqueue, exercising the REAL bus fan-out via `EventBus::new_enabled_for_test`) + gate-OFF no-regression (scan still delivers via legacy). No `env_lock` (recipients are data/file-derived).

## Evidence (local, targeted — #1463)
`cargo test waiting_on_stale` → 6 passed (4 existing + `gate_on_emit_subscriber_matches_legacy_direct_enqueue` + `gate_off_scan_delivers_via_legacy`); `event_bus` → 4 passed. clippy `--features tray` + `tray,discord` clean; `file_size_invariant` pass. `git diff origin/main --stat` = event_bus.rs + daemon/mod.rs + waiting_on_stale.rs only; **supervisor.rs untouched** (verified); zero stray commits.

Refs the event-bus migration task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)