### PR TITLE
event-bus: migrate the sixth pattern (idle_watchdog) via the #1690 template

### DIFF
--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -74,6 +74,15 @@ pub enum EventKind {
     HelperStale {
         helper_name: String,
     },
+    // #event-bus pattern #6 (idle_watchdog): the dev-idle / fleet-idle alert.
+    // `emit_idle_alert` already takes exactly these fields, so the subscriber
+    // re-delivers byte-identically (recipient is resolved at the producer).
+    IdleAlert {
+        recipient: String,
+        kind: String,
+        text: String,
+        correlation_agent: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -282,6 +291,12 @@ mod tests {
                 elapsed_secs: 2000,
                 timeout_secs: 1800,
                 default_action: "proceed".into(),
+            },
+            EventKind::IdleAlert {
+                recipient: "general".into(),
+                kind: "fleet_idle_watchdog".into(),
+                text: "all idle".into(),
+                correlation_agent: None,
             },
         ];
         for k in kinds {

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -460,7 +460,7 @@ fn scan_dev_vantage(
         if task_info == "(no active task)" && task_board_is_active(home) {
             continue;
         }
-        emit_idle_alert(
+        route_idle_alert(
             home,
             &dev_idle_recipient(),
             "dev_idle_watchdog",
@@ -661,7 +661,7 @@ fn scan_fleet_vantage(
         .max()
         .unwrap_or(0);
     let agent_list: Vec<&str> = pairs.iter().map(|(n, _)| n.as_str()).collect();
-    emit_idle_alert(
+    route_idle_alert(
         home,
         &fleet_idle_recipient(),
         "fleet_idle_watchdog",
@@ -730,6 +730,51 @@ fn emit_idle_alert(
     } else {
         tracing::info!(recipient, kind, "idle_watchdog: emitted inbox alert");
     }
+}
+
+/// #event-bus pattern #6 (Option A): gate-ON → emit `IdleAlert` (the subscriber
+/// delivers via `emit_idle_alert`); gate-OFF (prod default) → the legacy direct
+/// `emit_idle_alert`. No double-delivery, no gate-off regression. The recipient
+/// is already resolved by the caller, so the legacy and bus paths deliver
+/// identically. The legacy `else` is retired only at the final cutover.
+fn route_idle_alert(
+    home: &Path,
+    recipient: &str,
+    kind: &str,
+    text: &str,
+    correlation_agent: Option<&str>,
+) {
+    let bus = crate::daemon::event_bus::global();
+    if bus.is_enabled() {
+        bus.emit(crate::daemon::event_bus::EventKind::IdleAlert {
+            recipient: recipient.to_string(),
+            kind: kind.to_string(),
+            text: text.to_string(),
+            correlation_agent: correlation_agent.map(String::from),
+        });
+    } else {
+        emit_idle_alert(home, recipient, kind, text, correlation_agent);
+    }
+}
+
+/// #event-bus pattern #6: bus subscriber — deliver on an `IdleAlert` event (the
+/// gate-ON path) via the shared `emit_idle_alert`. Registered once at daemon startup.
+fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+    if let crate::daemon::event_bus::EventKind::IdleAlert {
+        recipient,
+        kind,
+        text,
+        correlation_agent,
+    } = &event.kind
+    {
+        emit_idle_alert(home, recipient, kind, text, correlation_agent.as_deref());
+    }
+}
+
+/// #event-bus pattern #6: register the idle_watchdog delivery subscriber on the
+/// global bus. Call ONCE at daemon startup. Dormant while the bus is gate-off.
+pub fn register_subscriber(home: std::path::PathBuf) {
+    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
 }
 
 #[cfg(test)]
@@ -1794,6 +1839,75 @@ mod tests {
             "alert must include current task title: {}",
             lead[0].text
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // #event-bus pattern #6: the (from, kind, text, correlation_id) tuple a
+    // drained alert carries — id/timestamp ignored so legacy-vs-bus compares clean.
+    fn alert_payloads(
+        home: &Path,
+        recipient: &str,
+    ) -> Vec<(String, Option<String>, String, Option<String>)> {
+        crate::inbox::drain(home, recipient)
+            .into_iter()
+            .map(|m| (m.from, m.kind, m.text, m.correlation_id))
+            .collect()
+    }
+
+    // gate-ON: emit(IdleAlert)→subscriber re-delivers BYTE-IDENTICALLY to the
+    // legacy `emit_idle_alert` direct enqueue.
+    #[test]
+    fn gate_on_emit_subscriber_matches_legacy_idle_alert() {
+        let recipient = "general";
+        let kind = "fleet_idle_watchdog";
+        let text = "fleet idle 1800s; all agents quiescent";
+        let corr = Some("fixup-dev");
+
+        let home_legacy = tmp_home("p6-parity-legacy");
+        emit_idle_alert(&home_legacy, recipient, kind, text, corr);
+
+        let home_bus = tmp_home("p6-parity-bus");
+        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
+        let h = home_bus.clone();
+        bus.subscribe(move |e| handle_event(&h, e));
+        bus.emit(crate::daemon::event_bus::EventKind::IdleAlert {
+            recipient: recipient.to_string(),
+            kind: kind.to_string(),
+            text: text.to_string(),
+            correlation_agent: corr.map(String::from),
+        });
+
+        let legacy = alert_payloads(&home_legacy, recipient);
+        let via_bus = alert_payloads(&home_bus, recipient);
+        assert!(!legacy.is_empty(), "legacy alert must fire");
+        assert_eq!(
+            legacy, via_bus,
+            "bus delivery must match legacy byte-for-byte"
+        );
+
+        std::fs::remove_dir_all(&home_legacy).ok();
+        std::fs::remove_dir_all(&home_bus).ok();
+    }
+
+    // gate-OFF (default): route_idle_alert falls through to the legacy deliver,
+    // so the alert still lands without the bus.
+    #[test]
+    fn gate_off_route_idle_alert_delivers_via_legacy() {
+        assert!(
+            !crate::daemon::event_bus::global().is_enabled(),
+            "test must run with AGEND_EVENT_BUS gate off"
+        );
+        let home = tmp_home("p6-gate-off");
+        route_idle_alert(
+            &home,
+            "general",
+            "fleet_idle_watchdog",
+            "fleet idle 1800s",
+            None,
+        );
+        let alerts = alert_payloads(&home, "general");
+        assert_eq!(alerts.len(), 1, "gate-off must deliver via legacy path");
+        assert_eq!(alerts[0].1.as_deref(), Some("fleet_idle_watchdog"));
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -413,6 +413,7 @@ fn run_core(
     crate::daemon::dispatch_idle::register_subscriber(home.to_path_buf());
     crate::daemon::waiting_on_stale::register_subscriber(home.to_path_buf());
     crate::daemon::helper_staleness_watchdog::register_subscriber(home.to_path_buf());
+    crate::daemon::idle_watchdog::register_subscriber(home.to_path_buf());
 
     spawn_fleet_agents(home, &agents, &ctx);
 


### PR DESCRIPTION
## What

Migrate the **idle_watchdog** dev-idle / fleet-idle alert through the dormant `event_bus` spine — the 6th pattern in the event-bus train (following #1690 anti_stall, #1692 decision_timeout, #1695 dispatch_idle, waiting_on_stale, #1700 helper_staleness). Part of the event-bus migration task (`t-20260603084548230655-7`).

Non-supervisor, self-contained: `emit_idle_alert` was already a generic extracted deliver taking the full rendered payload, so this slots straight into the Option A template.

## How (template)

- **EventKind**: add `IdleAlert { recipient, kind, text, correlation_agent }` — exactly the args `emit_idle_alert` takes, so the subscriber re-delivers byte-identically.
- **subscriber**: `handle_event` matches `IdleAlert` → calls the existing `emit_idle_alert`.
- **register_subscriber**: wired once in `run_core` alongside the other patterns.
- **Option A gate**: `route_idle_alert` — gate-ON (`AGEND_EVENT_BUS=1`) emits `IdleAlert`; gate-OFF (prod default) calls legacy `emit_idle_alert` directly. No double-delivery, no gate-off regression.
- both call sites (dev-idle + fleet-idle) swapped to `route_idle_alert`.

Recipient is resolved at the producer (`dev_idle_recipient` / `fleet_idle_recipient`) **before** `route_idle_alert`, so no `env_lock` is needed in tests.

## Invariants honored

- Gate default **unchanged** (still OFF); `#![allow(dead_code)]` **untouched** (end-of-train cutover).
- Only one pattern migrated.

## Tests

- `gate_on_emit_subscriber_matches_legacy_idle_alert` — emit→subscriber delivers **byte-for-byte identical** to the legacy direct enqueue (compares `(from, kind, text, correlation_id)` tuples).
- `gate_off_route_idle_alert_delivers_via_legacy` — with the gate off, `route_idle_alert` falls through to the legacy deliver (no regression).

## Preflight

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -D warnings` ✅
- `cargo clippy --all-targets --features tray,discord -D warnings` ✅
- `cargo test --bin agend-terminal --features tray idle_watchdog:: event_bus::` → 41 + 4 pass ✅

Rebased onto latest `origin/main` (includes #1580 Backend::Gemini retirement; additive, clean rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)