### PR TITLE
event-bus: migrate the seventh pattern (cascade_cancel) via the #1690 template

### DIFF
--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -83,6 +83,14 @@ pub enum EventKind {
         text: String,
         correlation_agent: Option<String>,
     },
+    // #event-bus pattern #7 (cascade_cancel): when a parent task is cancelled,
+    // each in-progress child's owner gets a notify. The text is rebuilt from
+    // parent_id + child_id, so the subscriber re-delivers byte-identically.
+    CascadeCancelNotify {
+        owner: String,
+        parent_id: String,
+        child_id: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -297,6 +305,11 @@ mod tests {
                 kind: "fleet_idle_watchdog".into(),
                 text: "all idle".into(),
                 correlation_agent: None,
+            },
+            EventKind::CascadeCancelNotify {
+                owner: "fixup-dev".into(),
+                parent_id: "t-parent".into(),
+                child_id: "t-child".into(),
             },
         ];
         for k in kinds {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -414,6 +414,7 @@ fn run_core(
     crate::daemon::waiting_on_stale::register_subscriber(home.to_path_buf());
     crate::daemon::helper_staleness_watchdog::register_subscriber(home.to_path_buf());
     crate::daemon::idle_watchdog::register_subscriber(home.to_path_buf());
+    crate::tasks::register_cascade_subscriber(home.to_path_buf());
 
     spawn_fleet_agents(home, &agents, &ctx);
 

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -944,22 +944,64 @@ fn cascade_cancel_children(
     }
     for (child_id, owner) in notify_ids {
         if let Some(ref owner_name) = owner {
-            let msg = crate::inbox::message::InboxMessage {
-                text: format!(
-                    "[parent-cancelled] Parent task {parent_id} was cancelled. \
-                     Your in-progress subtask {} may need attention.",
-                    child_id.0
-                ),
-                kind: Some("parent_cancelled".to_string()),
-                ..Default::default()
-            };
-            persist_or_log!(
-                crate::inbox::storage::enqueue(home, &owner_name.0, msg),
-                "cascade_cancel_notify",
-                owner_name.0
-            );
+            route_cascade_cancel(home, &owner_name.0, parent_id, &child_id.0);
         }
     }
+}
+
+/// #event-bus pattern #7 (Option A): gate-ON → emit `CascadeCancelNotify` (the
+/// subscriber delivers via `deliver_cascade_cancel`); gate-OFF (prod default) →
+/// the legacy direct `deliver_cascade_cancel`. No double-delivery, no gate-off
+/// regression.
+fn route_cascade_cancel(home: &Path, owner: &str, parent_id: &str, child_id: &str) {
+    let bus = crate::daemon::event_bus::global();
+    if bus.is_enabled() {
+        bus.emit(crate::daemon::event_bus::EventKind::CascadeCancelNotify {
+            owner: owner.to_string(),
+            parent_id: parent_id.to_string(),
+            child_id: child_id.to_string(),
+        });
+    } else {
+        deliver_cascade_cancel(home, owner, parent_id, child_id);
+    }
+}
+
+/// Shared deliver: enqueue the parent-cancelled notify to the child's owner.
+/// Called by BOTH the legacy path AND the event-bus subscriber, so the two are
+/// byte-identical by construction.
+fn deliver_cascade_cancel(home: &Path, owner: &str, parent_id: &str, child_id: &str) {
+    let msg = crate::inbox::message::InboxMessage {
+        text: format!(
+            "[parent-cancelled] Parent task {parent_id} was cancelled. \
+             Your in-progress subtask {child_id} may need attention."
+        ),
+        kind: Some("parent_cancelled".to_string()),
+        ..Default::default()
+    };
+    persist_or_log!(
+        crate::inbox::storage::enqueue(home, owner, msg),
+        "cascade_cancel_notify",
+        owner
+    );
+}
+
+/// #event-bus pattern #7 subscriber: re-deliver a `CascadeCancelNotify` event
+/// via the shared `deliver_cascade_cancel`.
+fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+    if let crate::daemon::event_bus::EventKind::CascadeCancelNotify {
+        owner,
+        parent_id,
+        child_id,
+    } = &event.kind
+    {
+        deliver_cascade_cancel(home, owner, parent_id, child_id);
+    }
+}
+
+/// Register the cascade-cancel subscriber once at daemon startup (`run_core`).
+/// Dormant unless `AGEND_EVENT_BUS=1` (emit is a no-op when gate-off).
+pub fn register_subscriber(home: std::path::PathBuf) {
+    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
 }
 
 #[cfg(test)]
@@ -1360,5 +1402,67 @@ mod tests {
             !path.exists(),
             "unassigned task should not create dispatch tracking entry"
         );
+    }
+
+    // #event-bus pattern #7: the (from, kind, text, correlation_id) tuple a
+    // drained notify carries — id/timestamp ignored so legacy-vs-bus compares clean.
+    fn cascade_payloads(
+        home: &std::path::Path,
+        recipient: &str,
+    ) -> Vec<(String, Option<String>, String, Option<String>)> {
+        crate::inbox::drain(home, recipient)
+            .into_iter()
+            .map(|m| (m.from, m.kind, m.text, m.correlation_id))
+            .collect()
+    }
+
+    // gate-ON: emit(CascadeCancelNotify)→subscriber re-delivers BYTE-IDENTICALLY
+    // to the legacy `deliver_cascade_cancel` direct enqueue.
+    #[test]
+    fn cascade_gate_on_emit_subscriber_matches_legacy() {
+        let owner = "fixup-dev";
+        let parent_id = "t-parent-1";
+        let child_id = "t-child-1";
+
+        let home_legacy = tmp_home("p7-parity-legacy");
+        deliver_cascade_cancel(&home_legacy, owner, parent_id, child_id);
+
+        let home_bus = tmp_home("p7-parity-bus");
+        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
+        let h = home_bus.clone();
+        bus.subscribe(move |e| handle_event(&h, e));
+        bus.emit(crate::daemon::event_bus::EventKind::CascadeCancelNotify {
+            owner: owner.to_string(),
+            parent_id: parent_id.to_string(),
+            child_id: child_id.to_string(),
+        });
+
+        let legacy = cascade_payloads(&home_legacy, owner);
+        let via_bus = cascade_payloads(&home_bus, owner);
+        assert!(!legacy.is_empty(), "legacy notify must enqueue");
+        assert_eq!(
+            legacy, via_bus,
+            "bus delivery must match legacy byte-for-byte"
+        );
+
+        std::fs::remove_dir_all(&home_legacy).ok();
+        std::fs::remove_dir_all(&home_bus).ok();
+    }
+
+    // gate-OFF (default): route_cascade_cancel falls through to the legacy
+    // deliver, so the notify still lands without the bus.
+    #[test]
+    fn cascade_gate_off_route_delivers_via_legacy() {
+        assert!(
+            !crate::daemon::event_bus::global().is_enabled(),
+            "test must run with AGEND_EVENT_BUS gate off"
+        );
+        let home = tmp_home("p7-gate-off");
+        route_cascade_cancel(&home, "fixup-dev", "t-parent-2", "t-child-2");
+        let alerts = cascade_payloads(&home, "fixup-dev");
+        assert_eq!(alerts.len(), 1, "gate-off must deliver via legacy path");
+        assert_eq!(alerts[0].1.as_deref(), Some("parent_cancelled"));
+        assert!(alerts[0].2.contains("t-parent-2") && alerts[0].2.contains("t-child-2"));
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 pub use handler::handle;
+pub use handler::register_subscriber as register_cascade_subscriber;
 pub use orphan::{
     orphan_tasks_for_owner, reconcile_orphan_owners_with_live, release_inprogress_orphans_with_live,
 };


### PR DESCRIPTION
## What

Migrate the **cascade_cancel** notification (parent task cancelled → notify in-progress child owners) through the dormant `event_bus` spine — the 7th pattern in the event-bus train (after #1690 anti_stall, #1692 decision_timeout, #1695 dispatch_idle, waiting_on_stale, #1700 helper_staleness, #1706 idle_watchdog). Part of the event-bus migration task (`t-20260603091230277824-10`).

## Pattern choice (verified against code)

Picked cascade_cancel over the other lead-listed candidates (conflict_notify / poll_reminder / cron_tick) because it is the **only one using a pure inbox enqueue** (`crate::inbox::storage::enqueue`), so it fits the inbox-drain parity test this template relies on.

The other three route through `crate::inbox::notify_agent` / `compose_aware_inject` — the **PTY-inject path**, not an inbox enqueue — so they can't be parity-tested via `inbox::drain` without mock-PTY (platform-gated). Verified by reading `src/inbox/notify.rs` (notify_agent → compose_aware_inject).

Confirmed: **does not touch `supervisor.rs`.**

## How (template)

- **EventKind**: add `CascadeCancelNotify { owner, parent_id, child_id }` — the text rebuilds from parent_id + child_id, so the subscriber re-delivers byte-identically.
- **shared deliver**: extract `deliver_cascade_cancel` — called by BOTH the legacy path AND the subscriber → identical by construction.
- **subscriber**: `handle_event` matches `CascadeCancelNotify` → `deliver_cascade_cancel`; `register_subscriber` re-exported as `tasks::register_cascade_subscriber`, wired once in `run_core` alongside the other patterns.
- **Option A gate**: `route_cascade_cancel` — gate-ON (`AGEND_EVENT_BUS=1`) emits; gate-OFF (prod default) calls the legacy deliver directly. No double-delivery, no gate-off regression.

Recipient is the child's task owner (dynamic, not env-derived), so no `env_lock` in tests.

## Cutover note (not a current regression)

cascade_cancel runs in the task handler (invoked from `src/mcp/handlers/task.rs` → daemon process), so the `run_core`-registered subscriber is reachable in-daemon. A CLI-direct `task done` in a non-daemon process at gate-ON would emit with no subscriber → notify lost. Gate is OFF for the whole train (legacy else-branch runs inline) so **no prod change now**; flagged for end-of-train cutover validation.

## Invariants honored

- Gate default **unchanged** (still OFF); `#![allow(dead_code)]` **untouched** (end-of-train cutover).
- Only one pattern migrated.

## Tests

- `cascade_gate_on_emit_subscriber_matches_legacy` — emit→subscriber delivers **byte-for-byte identical** to the legacy direct enqueue (compares `(from, kind, text, correlation_id)` tuples).
- `cascade_gate_off_route_delivers_via_legacy` — with the gate off, `route_cascade_cancel` falls through to the legacy deliver (no regression).

## Preflight

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -D warnings` ✅
- `cargo clippy --all-targets --features tray,discord -D warnings` ✅
- `cargo test --bin agend-terminal --features tray cascade` → 6 pass (2 new + existing cascade tests) ✅
- `cargo test ... event_bus::` → 4 pass ✅

Branched off latest `origin/main` (includes #1706). #1463 diff-check: 4 files, all trace to the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)