### PR TITLE
event-bus: migrate the conflict_notify pattern via the #1690 template

### DIFF
--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -173,8 +173,7 @@ fn emit_conflict_notify(home: &Path, agent: &str) {
     let base = crate::git_helpers::default_branch(&worktree);
     let payload = build_notify_payload(operation, &conflicted_files, branch, &base);
     let text = payload.to_string();
-    let source = crate::inbox::NotifySource::System("conflict_notify");
-    crate::inbox::notify_agent(home, agent, &source, &text);
+    route_conflict_alert(home, agent, false, &text);
     tracing::info!(
         agent,
         operation,
@@ -194,13 +193,63 @@ fn emit_telegram_escalation(home: &Path, agent: &str) {
          operator intervention may be required. Inspect via `pane_snapshot` or \
          direct check of the agent's worktree."
     );
-    let source = crate::inbox::NotifySource::System("conflict_escalation");
-    crate::inbox::notify_agent(home, agent, &source, &text);
+    route_conflict_alert(home, agent, true, &text);
     tracing::warn!(
         agent,
         threshold_min = STALE_THRESHOLD_SECS / 60,
         "Phase A: GitConflict escalation (operator notified)"
     );
+}
+
+/// #event-bus (conflict_notify, Option A): gate-ON → emit `ConflictAlert` (the
+/// subscriber delivers via `deliver_conflict_alert`); gate-OFF (prod default) →
+/// the legacy direct deliver. No double-delivery, no gate-off regression. `text`
+/// is the already-rendered notify body (built from the live worktree discovery at
+/// the producer) — carried verbatim so the bus path never re-runs discovery.
+fn route_conflict_alert(home: &Path, agent: &str, escalation: bool, text: &str) {
+    let bus = crate::daemon::event_bus::global();
+    if bus.is_enabled() {
+        bus.emit(crate::daemon::event_bus::EventKind::ConflictAlert {
+            agent: agent.to_string(),
+            escalation,
+            text: text.to_string(),
+        });
+    } else {
+        deliver_conflict_alert(home, agent, escalation, text);
+    }
+}
+
+/// Shared deliver for the git-conflict notify: PTY-notify the conflicted agent via
+/// `notify_agent`. Called by BOTH the legacy path AND the event-bus subscriber, so
+/// the delivery is identical by construction (the gate only chooses which path
+/// invokes this fn). `escalation` selects the `NotifySource` tag: the 30-min
+/// stale escalation vs the first-observation conflict notify.
+fn deliver_conflict_alert(home: &Path, agent: &str, escalation: bool, text: &str) {
+    let source = if escalation {
+        crate::inbox::NotifySource::System("conflict_escalation")
+    } else {
+        crate::inbox::NotifySource::System("conflict_notify")
+    };
+    crate::inbox::notify_agent(home, agent, &source, text);
+}
+
+/// #event-bus (conflict_notify) subscriber: re-deliver a `ConflictAlert` event via
+/// the shared `deliver_conflict_alert`.
+fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+    if let crate::daemon::event_bus::EventKind::ConflictAlert {
+        agent,
+        escalation,
+        text,
+    } = &event.kind
+    {
+        deliver_conflict_alert(home, agent, *escalation, text);
+    }
+}
+
+/// Register the conflict-notify subscriber once at daemon startup (`run_core`).
+/// Dormant unless `AGEND_EVENT_BUS=1` (emit is a no-op when gate-off).
+pub(crate) fn register_subscriber(home: std::path::PathBuf) {
+    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
 }
 
 /// Discover conflicted files in a worktree via `git status
@@ -540,5 +589,89 @@ mod tests {
             .env("GIT_COMMITTER_NAME", "test")
             .env("GIT_COMMITTER_EMAIL", "t@t")
             .output();
+    }
+
+    // ── #event-bus (conflict_notify) migration tests ──────────────────────────
+
+    /// Build a home whose snapshot marks `agent` as `thinking`, so `notify_agent`
+    /// → `compose_aware_inject` DEFERS to the notification_queue (observable in a
+    /// test) rather than attempting a live PTY inject (which no-ops without a pane).
+    fn defer_home(tag: &str, agent: &str) -> std::path::PathBuf {
+        let home =
+            std::env::temp_dir().join(format!("agend-conflict-eb-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).ok();
+        crate::snapshot::save(
+            &home,
+            &[crate::snapshot::AgentSnapshot {
+                name: agent.to_string(),
+                backend_command: "claude".to_string(),
+                args: vec![],
+                working_dir: None,
+                submit_key: "\r".to_string(),
+                health_state: "healthy".to_string(),
+                agent_state: "thinking".to_string(),
+            }],
+        );
+        home
+    }
+
+    /// gate-ON: emit(ConflictAlert)→subscriber delivers the CARRIED rendered text
+    /// via the shared `deliver_conflict_alert` (→ notify_agent → deferred to the
+    /// queue under the `thinking` snapshot). The notify_agent half is PTY-inject so
+    /// it is observed via the notification_queue defer path (no inbox enqueue here).
+    #[test]
+    fn conflict_alert_gate_on_emit_subscriber_delivers_carried_text() {
+        let agent = "conflict-gate-on";
+        let home = defer_home("gate-on", agent);
+        let text =
+            build_notify_payload("rebase", &["src/a.rs".to_string()], "feat", "main").to_string();
+
+        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
+        let h = home.clone();
+        bus.subscribe(move |e| handle_event(&h, e));
+        bus.emit(crate::daemon::event_bus::EventKind::ConflictAlert {
+            agent: agent.to_string(),
+            escalation: false,
+            text: text.clone(),
+        });
+
+        let queued = crate::notification_queue::drain(&home, agent);
+        assert_eq!(
+            queued.len(),
+            1,
+            "subscriber must deliver exactly one notify"
+        );
+        assert!(
+            queued[0].text.contains("git_conflict_detected"),
+            "delivered notify must carry the rendered conflict payload, got: {}",
+            queued[0].text
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// gate-OFF (prod default): `route_conflict_alert` falls through to the legacy
+    /// direct deliver, so the conflict notify still lands (deferred to the queue).
+    #[test]
+    fn conflict_alert_gate_off_route_delivers_via_legacy() {
+        assert!(
+            !crate::daemon::event_bus::global().is_enabled(),
+            "test must run with AGEND_EVENT_BUS gate off"
+        );
+        let agent = "conflict-gate-off";
+        let home = defer_home("gate-off", agent);
+        let text =
+            build_notify_payload("rebase", &["src/a.rs".to_string()], "feat", "main").to_string();
+
+        route_conflict_alert(&home, agent, false, &text);
+
+        let queued = crate::notification_queue::drain(&home, agent);
+        assert_eq!(queued.len(), 1, "gate-off must deliver via legacy path");
+        assert!(
+            queued[0].text.contains("git_conflict_detected"),
+            "legacy notify must carry the rendered conflict payload, got: {}",
+            queued[0].text
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -128,6 +128,16 @@ pub enum EventKind {
         one_shot: bool,
         missed: bool,
     },
+    // #event-bus pattern (conflict_notify): the git-conflict notify / 30-min
+    // stale escalation, both delivered via `notify_agent` (PTY-inject). The text
+    // is built from live worktree discovery (git status + binding + op-marker) at
+    // the producer, so it is carried RENDERED — the subscriber must not re-run the
+    // discovery. `escalation` selects the NotifySource tag the deliver uses.
+    ConflictAlert {
+        agent: String,
+        escalation: bool,
+        text: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -365,6 +375,11 @@ mod tests {
                 label: "morning".into(),
                 one_shot: false,
                 missed: false,
+            },
+            EventKind::ConflictAlert {
+                agent: "fixup-dev".into(),
+                escalation: false,
+                text: "git conflict".into(),
             },
         ];
         for k in kinds {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -418,6 +418,7 @@ fn run_core(
     crate::daemon::poll_reminder::register_subscriber(home.to_path_buf());
     crate::daemon::cron_tick::register_subscriber(home.to_path_buf(), ctx.registry.clone());
     crate::daemon::supervisor::register_subscriber(home.to_path_buf());
+    crate::daemon::conflict_notify::register_subscriber(home.to_path_buf());
 
     spawn_fleet_agents(home, &agents, &ctx);
 


### PR DESCRIPTION
## What

Migrate the **conflict_notify** git-conflict notify + 30-min stale escalation through the dormant `event_bus` spine (Option A if/else gate, default OFF). Part of the event-bus migration train (`t-eventbus-conflict-notify`).

## Delivery path (verified against code)

conflict_notify is a **pure PTY-inject** pattern — both delivery sites (`emit_conflict_notify` + `emit_telegram_escalation`) go through `crate::inbox::notify_agent` → `compose_aware_inject`, **not** an inbox enqueue. (Verified at `conflict_notify.rs:177,198` + `inbox/notify.rs`.) So there is no `inbox::drain` observable — this is the PTY-inject class, like #8 poll_reminder.

## How (template)

- add `EventKind::ConflictAlert { agent, escalation, text }` — carries the **rendered** text. The notify body is built from **live worktree discovery** (`git status --porcelain` + `binding.json` + `.git` op-marker) at the producer; re-running discovery in the subscriber would re-shell-out and could **drift** (the conflict may have resolved by then), so the rendered string is frozen into the event. This is the rendered-text branch of the template (like IdleAlert / poll_reminder), not the structured-rebuild branch (#9): the text's source is non-reconstructible/time-sensitive.
- extract `deliver_conflict_alert` — `notify_agent` with the `NotifySource` tag selected by `escalation`; called by BOTH the legacy path AND the subscriber → identical by construction.
- add `handle_event` subscriber + `register_subscriber` (wired once in `run_core`).
- `route_conflict_alert`: gate-ON emits; gate-OFF calls the legacy deliver directly. No double-delivery, no gate-off regression.

No `now()` in the deliver path → nothing to freeze (the `chrono::Utc::now()` calls are only in the scan loop / tests).

## Tests (PTY-inject → notification_queue, not inbox::drain)

Since `notify_agent` is PTY-inject, the observable is the **notification_queue** defer path: a `thinking` agent_state snapshot forces `compose_aware_inject` to defer (rather than attempt a no-op PTY inject in tests), so the delivered notification lands in `notification_queue::drain`. Same approach as #1709 poll_reminder.

- `conflict_alert_gate_on_emit_subscriber_delivers_carried_text` — emit→subscriber delivers the carried conflict payload.
- `conflict_alert_gate_off_route_delivers_via_legacy` — gate-off falls through to the legacy deliver.
- distinct agent names avoid the global `#911` notification-dedup ledger.

## Invariants honored

- Gate default **unchanged** (still OFF); `#![allow(dead_code)]` **untouched** (end-of-train cutover).
- Only one pattern migrated. Did **not** touch `supervisor.rs` or the `cron` scheduler area (dev-2's parallel work).

## Preflight

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -D warnings` ✅
- `cargo clippy --all-targets --features tray,discord -D warnings` ✅
- `cargo test --bin agend-terminal --features tray conflict_notify::` → 9 pass (2 new + existing) ✅
- `cargo test ... event_bus::` → 4 pass; `... poll_reminder::` → 9 pass (confirms the #1709 rebase merge is clean) ✅

Rebased onto latest `origin/main` (includes #1709 poll_reminder); the `event_bus.rs` + `mod.rs` conflicts were resolved **additively** (both `PollReminder` and `ConflictAlert` kept). #1463 diff-check: 3 files, all trace to the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)