### PR TITLE
event-bus: migrate the ci_watch CiReady/CiFail pair via the #1690 template

### DIFF
--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -30,6 +30,7 @@ pub use poller::{emit_ci_conflict_alert, watch_start_check_mergeable};
 // gates the clippy unused-imports rule when building production binary.
 #[cfg(test)]
 pub(crate) use poller::parse_review_class;
+pub(crate) use poller::register_subscriber;
 #[allow(unused_imports)]
 pub use provider::{
     detect_provider_from_remote, github_token_warning, github_token_warning_from_env,

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1356,6 +1356,16 @@ async fn fan_out_notifications(
             };
             let fleet_cfg =
                 crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home)).ok();
+            // #event-bus (ci_watch, Option A): ONE skip-aware loop over subscribers.
+            // The skips (action_target_on_success + #931 zombie-subscriber) are
+            // applied ONCE so gate-ON and gate-OFF notify the IDENTICAL recipient
+            // set. Per recipient: gate-ON + success/failure → emit Ci{Ready,Fail}
+            // (the subscriber delivers via the shared `deliver_ci_watch`);
+            // everything else (gate-OFF, OR a non-pair "[ci-ended]" conclusion that
+            // has no event kind) → the legacy direct deliver. No double-delivery, no
+            // gate-off regression, no dropped notify. (Replaces the prior dormant
+            // second emit loop, which lacked these skips — a latent parity bug.)
+            let bus = crate::daemon::event_bus::global();
             for sub in ctx.subscribers {
                 if action_target_on_success == Some(sub.as_str()) {
                     continue;
@@ -1376,57 +1386,44 @@ async fn fan_out_notifications(
                     );
                     continue;
                 }
-                crate::inbox::mark_ci_watch_superseded(
-                    ctx.home,
-                    sub,
-                    &repo_branch_key,
-                    &supersede_token,
-                );
-                persist_or_log!(
-                    crate::inbox::enqueue_with_idle_hint(
-                        ctx.home,
-                        sub,
-                        crate::inbox::InboxMessage::new_system(
-                            "system:ci",
-                            "ci-watch",
-                            body.clone()
-                        )
-                        .with_correlation_id(repo_branch_key.clone()),
-                    ),
-                    "ci_watch_notify",
-                    sub
-                );
+                let emitted = if bus.is_enabled() {
+                    match conclusion {
+                        Some("failure") => {
+                            bus.emit(crate::daemon::event_bus::EventKind::CiFail {
+                                repo: ctx.repo.to_string(),
+                                branch: ctx.branch.to_string(),
+                                target: sub.clone(),
+                                body: body.clone(),
+                                correlation_id: repo_branch_key.clone(),
+                                supersede_token: supersede_token.clone(),
+                            });
+                            true
+                        }
+                        Some("success") => {
+                            bus.emit(crate::daemon::event_bus::EventKind::CiReady {
+                                repo: ctx.repo.to_string(),
+                                branch: ctx.branch.to_string(),
+                                target: sub.clone(),
+                                body: body.clone(),
+                                correlation_id: repo_branch_key.clone(),
+                                supersede_token: supersede_token.clone(),
+                            });
+                            true
+                        }
+                        // non-pair conclusion ("[ci-ended]" etc.): no CiReady/CiFail
+                        // kind → fall through to the legacy direct deliver below.
+                        _ => false,
+                    }
+                } else {
+                    false
+                };
+                if !emitted {
+                    deliver_ci_watch(ctx.home, sub, &body, &repo_branch_key, &supersede_token);
+                }
             }
         }
         new_notified_sha = Some(sha.to_string());
         new_notified_conclusion = conclusion.map(String::from);
-        if crate::daemon::event_bus::global().is_enabled() {
-            match conclusion {
-                Some("failure") => {
-                    for sub in ctx.subscribers {
-                        crate::daemon::event_bus::global().emit(
-                            crate::daemon::event_bus::EventKind::CiFail {
-                                repo: ctx.repo.to_string(),
-                                branch: ctx.branch.to_string(),
-                                target: sub.clone(),
-                            },
-                        );
-                    }
-                }
-                Some("success") => {
-                    for sub in ctx.subscribers {
-                        crate::daemon::event_bus::global().emit(
-                            crate::daemon::event_bus::EventKind::CiReady {
-                                repo: ctx.repo.to_string(),
-                                branch: ctx.branch.to_string(),
-                                target: sub.clone(),
-                            },
-                        );
-                    }
-                }
-                _ => {}
-            }
-        }
     }
 
     NotifyOutcome {
@@ -1435,6 +1432,65 @@ async fn fan_out_notifications(
         new_notified_conclusion,
         new_stale_emitted_sha,
     }
+}
+
+/// #event-bus (ci_watch): shared deliver for one subscriber's CI notify — supersede
+/// prior ci-watch msgs for this (sub, repo@branch), then enqueue the RENDERED body
+/// to the subscriber's inbox (with the idle-hint wake). Called by BOTH the legacy
+/// direct path AND the event-bus subscriber, so the inbox enqueue is byte-identical
+/// by construction; the idle-hint PTY wake is covered by the same invariant.
+/// Must NOT run under the registry lock (#1492 self-IPC-under-lock) — both callers
+/// invoke it lock-free (the legacy loop's registry lock is a dropped temporary; the
+/// subscriber fires from `emit`, outside any lock).
+fn deliver_ci_watch(
+    home: &std::path::Path,
+    sub: &str,
+    body: &str,
+    repo_branch_key: &str,
+    supersede_token: &str,
+) {
+    crate::inbox::mark_ci_watch_superseded(home, sub, repo_branch_key, supersede_token);
+    persist_or_log!(
+        crate::inbox::enqueue_with_idle_hint(
+            home,
+            sub,
+            crate::inbox::InboxMessage::new_system("system:ci", "ci-watch", body.to_string())
+                .with_correlation_id(repo_branch_key.to_string()),
+        ),
+        "ci_watch_notify",
+        sub
+    );
+}
+
+/// #event-bus (ci_watch) subscriber: re-deliver a `CiReady`/`CiFail` event via the
+/// shared `deliver_ci_watch`. Both kinds deliver identically (the body already
+/// encodes pass/fail); the kind split is purely semantic.
+fn handle_event(home: &std::path::Path, event: &crate::daemon::event_bus::Event) {
+    match &event.kind {
+        crate::daemon::event_bus::EventKind::CiReady {
+            target,
+            body,
+            correlation_id,
+            supersede_token,
+            ..
+        }
+        | crate::daemon::event_bus::EventKind::CiFail {
+            target,
+            body,
+            correlation_id,
+            supersede_token,
+            ..
+        } => {
+            deliver_ci_watch(home, target, body, correlation_id, supersede_token);
+        }
+        _ => {}
+    }
+}
+
+/// Register the ci-watch subscriber once at daemon startup (`run_core`). Dormant
+/// unless `AGEND_EVENT_BUS=1` (emit is a no-op when gate-off).
+pub(crate) fn register_subscriber(home: std::path::PathBuf) {
+    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
 }
 
 fn persist_watch_state(

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -5485,3 +5485,83 @@ fn build_inbox_body_embeds_log_tail_when_present() {
         "#1537-fu: no-tail body points to the manual command instead"
     );
 }
+
+// ── #event-bus (ci_watch) migration tests ─────────────────────────────────
+
+/// gate-ON parity: `emit(CiReady)` → subscriber re-delivers the inbox half (A)
+/// BYTE-IDENTICALLY to the legacy `deliver_ci_watch` direct enqueue. The rendered
+/// `body` is carried verbatim (live-fetched log tail frozen at the producer). The
+/// idle-hint PTY wake (B) is covered by the shared-deliver-fn invariant, not
+/// separately asserted. Distinct homes (same recipient) keep the durable inbox
+/// enqueues independent; #911 dedup only gates the inject hint, not the enqueue.
+#[test]
+fn ci_watch_gate_on_emit_subscriber_matches_legacy() {
+    let body = build_inbox_body(
+        "[ci-pass] o/r@feat (abc): passed ✓",
+        "success",
+        None,
+        "https://example.com/1",
+        Some(1),
+        None,
+    );
+    let key = "o/r@feat".to_string();
+    let token = "ci-1-abc".to_string();
+
+    let legacy = tmp_dir("ciwatch-parity-legacy");
+    super::deliver_ci_watch(&legacy, "rev", &body, &key, &token);
+
+    let bus_home = tmp_dir("ciwatch-parity-bus");
+    let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
+    let h = bus_home.clone();
+    bus.subscribe(move |e| super::handle_event(&h, e));
+    bus.emit(crate::daemon::event_bus::EventKind::CiReady {
+        repo: "o/r".into(),
+        branch: "feat".into(),
+        target: "rev".into(),
+        body: body.clone(),
+        correlation_id: key.clone(),
+        supersede_token: token.clone(),
+    });
+
+    let legacy_msgs: Vec<_> = crate::inbox::drain(&legacy, "rev")
+        .into_iter()
+        .map(|m| (m.from, m.kind, m.text, m.correlation_id))
+        .collect();
+    let bus_msgs: Vec<_> = crate::inbox::drain(&bus_home, "rev")
+        .into_iter()
+        .map(|m| (m.from, m.kind, m.text, m.correlation_id))
+        .collect();
+    assert!(!legacy_msgs.is_empty(), "legacy enqueue must land");
+    assert_eq!(
+        legacy_msgs, bus_msgs,
+        "bus inbox-half (A) must match legacy byte-for-byte"
+    );
+    std::fs::remove_dir_all(&legacy).ok();
+    std::fs::remove_dir_all(&bus_home).ok();
+}
+
+/// gate-OFF no-regression at the deliver level: `deliver_ci_watch` (the unified
+/// loop's gate-off branch) enqueues the SAME inbox payload the legacy inline
+/// enqueue produced — `system:ci` / `ci-watch` / rendered body / repo@branch
+/// correlation. (The existing `pass_dedupe_*` + `mock_success_*` integration tests
+/// confirm the loop still skips action_target/zombie + delivers on success.)
+#[test]
+fn ci_watch_deliver_matches_legacy_payload() {
+    let body = build_inbox_body(
+        "[ci-fail] o/r@feat (abc): failure",
+        "failure",
+        Some("job X failed"),
+        "https://example.com/2",
+        Some(2),
+        Some("thread panicked"),
+    );
+    let home = tmp_dir("ciwatch-deliver-payload");
+    super::deliver_ci_watch(&home, "rev", &body, "o/r@feat", "ci-2-abc");
+    let msgs = crate::inbox::drain(&home, "rev");
+    assert_eq!(msgs.len(), 1, "deliver must enqueue exactly one msg");
+    assert_eq!(msgs[0].from, "system:ci");
+    assert_eq!(msgs[0].kind.as_deref(), Some("ci-watch"));
+    assert_eq!(msgs[0].text, body);
+    assert_eq!(msgs[0].correlation_id.as_deref(), Some("o/r@feat"));
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -23,15 +23,27 @@ pub enum EventKind {
         started_at: Option<String>,
         eta_secs: Option<i64>,
     },
+    // #event-bus pattern (ci_watch): the per-subscriber CI pass / fail notify.
+    // `body` is the RENDERED inbox body — it embeds a live-fetched failure-log tail
+    // (`gh --log-failed`), so re-fetching in the subscriber would burn GitHub
+    // rate-limit + could drift; it is frozen at the producer. `correlation_id`
+    // (repo@branch) + `supersede_token` (ci-<run>-<sha>) reproduce the legacy
+    // enqueue + supersede bookkeeping. One event is emitted PER recipient.
     CiReady {
         repo: String,
         branch: String,
         target: String,
+        body: String,
+        correlation_id: String,
+        supersede_token: String,
     },
     CiFail {
         repo: String,
         branch: String,
         target: String,
+        body: String,
+        correlation_id: String,
+        supersede_token: String,
     },
     DispatchIdleExceeded {
         dispatcher: String,
@@ -248,6 +260,9 @@ mod tests {
             repo: "owner/repo".into(),
             branch: "main".into(),
             target: "dev".into(),
+            body: "[ci-pass]".into(),
+            correlation_id: "owner/repo@main".into(),
+            supersede_token: "ci-1-abc".into(),
         });
         assert!(
             received.lock().unwrap().is_empty(),
@@ -299,6 +314,9 @@ mod tests {
             repo: "o/r".into(),
             branch: "feat".into(),
             target: "dev".into(),
+            body: "[ci-fail]".into(),
+            correlation_id: "o/r@feat".into(),
+            supersede_token: "ci-2-def".into(),
         });
         assert_eq!(count_a.load(std::sync::atomic::Ordering::Relaxed), 1);
         assert_eq!(count_b.load(std::sync::atomic::Ordering::Relaxed), 1);
@@ -319,11 +337,17 @@ mod tests {
                 repo: "o/r".into(),
                 branch: "b".into(),
                 target: "t".into(),
+                body: "[ci-pass]".into(),
+                correlation_id: "o/r@b".into(),
+                supersede_token: "ci-1-aaa".into(),
             },
             EventKind::CiFail {
                 repo: "o/r".into(),
                 branch: "b".into(),
                 target: "t".into(),
+                body: "[ci-fail]".into(),
+                correlation_id: "o/r@b".into(),
+                supersede_token: "ci-1-bbb".into(),
             },
             EventKind::DispatchIdleExceeded {
                 dispatcher: "lead".into(),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -419,6 +419,7 @@ fn run_core(
     crate::daemon::cron_tick::register_subscriber(home.to_path_buf(), ctx.registry.clone());
     crate::daemon::supervisor::register_subscriber(home.to_path_buf());
     crate::daemon::conflict_notify::register_subscriber(home.to_path_buf());
+    crate::daemon::ci_watch::register_subscriber(home.to_path_buf());
 
     spawn_fleet_agents(home, &agents, &ctx);
 


### PR DESCRIPTION
## What

Migrate the per-subscriber **CI pass/fail notify** (`ci_watch`) through the dormant `event_bus` spine (Option A if/else gate, default OFF). **This is the final pattern in the event-bus train.** Task `t-eventbus-ci-watch-pair`.

## Delivery path (verified)

A-path **inbox-enqueue** (`enqueue_with_idle_hint` → durable inbox msg + an idle-hint PTY wake), fanned out **per subscriber** (one CI result → loop over watchers). Drain-testable (the durable enqueue); the idle-hint PTY wake is covered by the shared-deliver-fn invariant.

## Restructure (the meaty part — dual loop → unified skip-aware loop)

The prior code had **two loops**: the legacy enqueue loop (with the `action_target_on_success` + #931 zombie-subscriber skips) AND a *dormant pre-wired emit loop that lacked those skips* and dropped non-success/failure conclusions (`_ => {}`). Unified into ONE skip-aware loop:
- the skips are applied **once**, so gate-ON and gate-OFF notify the **identical** recipient set;
- per recipient: gate-ON + success/failure → `emit Ci{Ready,Fail}`; everything else (gate-OFF, **or** a non-pair `[ci-ended]` conclusion that has no event kind) → the legacy direct `deliver_ci_watch`. No double, no gate-off regression, no drop.

**Fixes two latent bugs** the dormant emit would have detonated once a subscriber registered:
1. it would have notified `action_target` + zombie subscribers that the legacy skips;
2. it silently dropped `[ci-ended]` (cancelled/timed_out/…) via `_ => {}`.

**Migration scope = the success/failure pair only.** Non-pair `[ci-ended]` stays on the legacy path unconditionally (and is no longer dropped) — gate-off byte-identical, no drop, no double regardless of gate.

## How (template)

- extend `EventKind::CiReady` / `CiFail` with `{body, correlation_id, supersede_token}`. `body` is **RENDERED**: it embeds a live-fetched failure-log tail (`gh --log-failed`) — re-fetching in the subscriber would burn GitHub rate-limit + could drift, so it is frozen at the producer (the rendered-text branch of the template, same call as conflict_notify/poll_reminder).
- extract `deliver_ci_watch` (`mark_ci_watch_superseded` + `enqueue_with_idle_hint`), shared by the legacy path AND the subscriber → byte-identical by construction.
- add `handle_event` (`CiReady | CiFail` or-pattern → same deliver; the kind split is semantic) + `register_subscriber` (wired once in `run_core`). #1492: `deliver_ci_watch` runs lock-free in both callers (the legacy loop's registry lock is a dropped temporary; the subscriber fires from `emit`, outside any lock).

## Tests

- `ci_watch_gate_on_emit_subscriber_matches_legacy` — gate-ON: `emit(CiReady)`→subscriber inbox half == legacy `deliver_ci_watch` byte-for-byte.
- `ci_watch_deliver_matches_legacy_payload` — gate-OFF deliver payload (`system:ci` / `ci-watch` / rendered body / `repo@branch` correlation).
- The existing **188 ci_watch tests stay green** — incl `pass_dedupe_drops_ci_pass_for_subscriber_who_is_action_target`, `pass_dedupe_non_action_target_subscribers_receive_ci_pass` (the **action_target skip**, gate-off, through the unified loop), `mock_success_*`, and the stale-SHA tests — proving the unified gate-off path is byte-identical to the legacy loop. The skips are applied *before* the gate branch, so a skipped sub reaches neither emit nor deliver in either path.

## Invariants honored

- Gate default **unchanged** (still OFF); `#![allow(dead_code)]` **untouched** (end-of-train cutover).
- Only `ci_watch` + the shared spine touched; did not touch `supervisor.rs` or the `cron` area.

## Preflight

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -D warnings` ✅ / `--features tray,discord` ✅
- `cargo test --bin agend-terminal --features tray ci_watch::` → **190 pass** (188 existing + 2 new) ✅
- `... event_bus::` → 4 pass; `... cron_tick::` → 25 pass (confirms the #1712 rebase merge is clean) ✅

Rebased onto latest `origin/main` (#1712 cron_tick); `event_bus.rs` merged cleanly, `mod.rs` register block resolved **additively** (cron + ci_watch). #1463 diff-check: 5 files, all trace to the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)