### PR TITLE
event-bus cutover Step 1: default the gate ON in production (legacy kept as kill-switch)

### DIFF
--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -4,7 +4,12 @@
 //! remain untouched; this module emits a structured `Event` alongside them
 //! so future subscribers can react without per-module plumbing.
 //!
-//! Gated by `AGEND_EVENT_BUS=1`. When disabled, `emit()` is a no-op.
+//! End-of-train cutover (Step 1): the gate now defaults **ON** (code-shipped) so
+//! the event-bus delivery path is live without any operator env. Set
+//! `AGEND_EVENT_BUS=0` and **restart the daemon** to fall back to the legacy
+//! direct-enqueue path (the kill-switch — `global()` is a `OnceLock` that reads
+//! the env once at startup, so it is NOT a hot-toggle). The legacy `else`
+//! branches are retained as that kill-switch until Step 2 (post-validation).
 
 #![allow(dead_code)]
 
@@ -181,9 +186,15 @@ pub struct EventBus {
 
 impl EventBus {
     pub fn new() -> Self {
+        // #event-bus cutover Step 1: default ON in production. Unset env →
+        // enabled; the kill-switch is `AGEND_EVENT_BUS=0` (any other value stays
+        // ON). In the TEST binary the default is OFF so the existing legacy-path
+        // unit/integration tests keep exercising the legacy direct-enqueue
+        // (the bus path is covered by the per-pattern `new_enabled_for_test`
+        // parity tests). An explicit env value overrides in either build.
         let enabled = std::env::var("AGEND_EVENT_BUS")
-            .map(|v| v == "1")
-            .unwrap_or(false);
+            .map(|v| v != "0")
+            .unwrap_or(!cfg!(test));
         Self {
             subscribers: parking_lot::Mutex::new(Vec::new()),
             enabled,


### PR DESCRIPTION
## What

All 12 notification patterns are now migrated through the `event_bus` spine (#1690 → #1714). This is the **end-of-train cutover, Step 1**: flip the gate's code-shipped default so the structured delivery path is **live in production**, while keeping the legacy direct-enqueue `else` branches as a **kill-switch**.

Single-line flip in `EventBus::new()`:
```rust
let enabled = std::env::var("AGEND_EVENT_BUS")
    .map(|v| v != "0")
    .unwrap_or(!cfg!(test));
```

## Test vs prod default divergence (the key design point)

- **Production** (release build, `cfg!(test)=false`): unset env → **ON**. The bus path is live.
- **Test binary** (`cfg!(test)=true`): unset env → **OFF**. The existing legacy-path unit + integration tests keep exercising the **legacy** direct-enqueue unchanged. The bus delivery path stays covered by the per-pattern `new_enabled_for_test` **parity tests** (which already prove `bus == legacy` byte-identical for all 12 patterns) + the Step-1 live validation cycle.

**Why `cfg!(test)` and not a plain `unwrap_or(true)`:** flipping ON unconditionally breaks every integration test that drives a production fn reading `global()` and asserts delivery (empirically: 14 ci_watch `run_ci_check`-based tests) — in tests `global()` has no registered subscriber (register runs only in `run_core`), so emit fans out to nothing and the delivery assertion fails. `cfg!(test)` keeps the test binary on legacy → **zero test refactor**, and preserves more coverage than the deliver-direct alternative (gate-off routing stays exercised by the integration tests).

⚠ **`cfg!(test)` edge checked**: separate `tests/*.rs` integration crates link the lib with `cfg!(test)=false` → they'd see the bus default ON. Verified the full `cargo test --tests` suite: **no `tests/` crate drives the notification/fan-out path** (the 3 that grep-match only reference it in a doc comment / source-audit string list), so none hits bus-ON. Full suite is green except one **pre-existing environmental** failure (`agend-git has_unmerged_files_true_on_conflict`, a false-fail under the fleet `git` shim — passes with real git; unrelated to this change).

## Kill-switch

`AGEND_EVENT_BUS=0` + **restart the daemon** → legacy direct-enqueue. `global()` is a `OnceLock` that reads the env once at startup, so it is **not a hot-toggle** (restart required). The legacy `else` branches are retained precisely as this kill-switch.

## Step 2 (follow-up, after a live validation cycle — NOT this PR)

- Remove the `cfg!(test)` default; register the subscribers in the test harness so the integration tests run the **bus** path (legacy will be gone, so tests must move onto the bus).
- Drop the legacy `else` branches.
- Remove `#![allow(dead_code)]` (and the now-dead `emit_lazy`).

## Preflight

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -D warnings` ✅ / `--features tray,discord` ✅
- `cargo test --bin agend-terminal --features tray` → **3187 passed, 0 failed** ✅
- `cargo test --tests --features tray` → green except the one pre-existing env `agend-git` git-shim false-fail (passes with real git) ✅
- `emit_disabled_by_default` stays green unchanged (test build → default OFF).

#1463 diff-check: 1 file (`src/daemon/event_bus.rs`, +14/-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)