### PR TITLE
feat: optional pane state-name badge (runtime-toggleable, default off)

### DIFF
--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -405,7 +405,12 @@ fn render_pane(
         (s, s, 1u8)
     };
 
-    let title_segments = pane_title_segments(pane, title_style);
+    let title_segments = pane_title_segments(
+        pane,
+        title_style,
+        state,
+        crate::runtime_config::get().show_pane_state,
+    );
 
     let inner = Rect::new(
         area.x + 1,
@@ -485,6 +490,8 @@ fn render_pane(
 pub(super) fn pane_title_segments(
     pane: &crate::layout::Pane,
     title_style: Style,
+    state: AgentState,
+    show_state_badge: bool,
 ) -> Vec<(String, Style)> {
     let mut segments = Vec::new();
     let base = format!(" {}", pane.label());
@@ -497,6 +504,15 @@ pub(super) fn pane_title_segments(
                 .fg(Color::Black)
                 .add_modifier(Modifier::BOLD),
         ));
+    }
+    // #1713/#1523 diagnostic (runtime_config.show_pane_state, default off): append
+    // a `[<State>]` text badge of the DETECTED AgentState so the operator can
+    // eyeball-verify detection against the live pane. Extra text only — the
+    // pane's colour (state_color) is untouched, and it uses the same
+    // `title_style` so it introduces no new colour. The transient
+    // Restarting/Crashed tab-bar badge (`transient_state_badge`) is unaffected.
+    if show_state_badge {
+        segments.push((format!(" [{state:?}]"), title_style));
     }
     segments.push((" ".to_string(), title_style));
     segments
@@ -626,7 +642,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
         };
-        let segments = pane_title_segments(&pane, Style::default());
+        let segments = pane_title_segments(&pane, Style::default(), AgentState::Idle, false);
         let joined = segments
             .into_iter()
             .map(|(text, _)| text)
@@ -653,12 +669,50 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
         };
-        let segments = pane_title_segments(&pane, Style::default());
+        // #1713 flag OFF (default): no state badge appended; only the base label
+        // (+ the transient Restarting/Crashed tab badge, which lives elsewhere).
+        let segments = pane_title_segments(&pane, Style::default(), AgentState::Idle, false);
         let joined: String = segments.iter().map(|(t, _)| t.as_str()).collect();
         assert!(
-            !joined.contains("[idle]"),
-            "pane title must not contain state suffix, got: {joined}"
+            !joined.contains("[Idle]") && !joined.contains("[idle]"),
+            "flag-off: pane title must not contain a state badge, got: {joined}"
         );
+    }
+
+    /// #1713 flag ON: the pane title appends a `[<State>]` badge of the detected
+    /// AgentState (all states), so the operator can eyeball-verify detection.
+    #[test]
+    fn pane_title_state_badge_when_flag_on_1713() {
+        let pane = Pane {
+            agent_name: "agent".into(),
+            instance_id: crate::types::InstanceId::default(),
+            vterm: VTerm::new(10, 10),
+            rx: crossbeam_channel::bounded(1).1,
+            id: 1,
+            backend: Some(crate::backend::Backend::ClaudeCode),
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
+            selection: None,
+            source: PaneSource::Local,
+        };
+        for (state, want) in [
+            (AgentState::ServerRateLimit, "[ServerRateLimit]"),
+            (AgentState::PermissionPrompt, "[PermissionPrompt]"),
+            (AgentState::Thinking, "[Thinking]"),
+            (AgentState::Idle, "[Idle]"),
+        ] {
+            let segments = pane_title_segments(&pane, Style::default(), state, true);
+            let joined: String = segments.iter().map(|(t, _)| t.as_str()).collect();
+            assert!(
+                joined.contains(want),
+                "flag-on: title must contain {want}, got: {joined}"
+            );
+        }
     }
 
     #[test]

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -37,6 +37,13 @@ pub struct RuntimeConfig {
     /// is a no-op — no dev-idle or fleet-idle alerts fire. Default true.
     #[serde(default = "default_true")]
     pub idle_watchdog_enabled: bool,
+    /// #1713/#1523 aid: when true, each pane title appends a `[<State>]` text
+    /// badge of the detected `AgentState` so the operator can eyeball-verify
+    /// state detection. Default false (off — the colour dot is the steady-state
+    /// signal; this is a temporary diagnostic toggle). Hot-reloadable via the
+    /// `config` MCP tool, like the other gates here.
+    #[serde(default)]
+    pub show_pane_state: bool,
 }
 
 fn default_true() -> bool {
@@ -62,6 +69,7 @@ impl Default for RuntimeConfig {
             hang_auto_recovery_enabled: false,
             usage_limit_propagation_enabled: false,
             idle_watchdog_enabled: true,
+            show_pane_state: false,
         }
     }
 }
@@ -177,6 +185,13 @@ pub fn set(home: &Path, key: &str, value: &str) -> Result<String, String> {
                 _ => return Err(format!("invalid boolean: {value} (use true/false)")),
             };
         }
+        "show_pane_state" => {
+            config.show_pane_state = match value {
+                "true" | "1" => true,
+                "false" | "0" => false,
+                _ => return Err(format!("invalid boolean: {value} (use true/false)")),
+            };
+        }
         _ => return Err(format!("unknown config key: {key}")),
     }
     let path = home.join("runtime-config.json");
@@ -196,6 +211,7 @@ pub fn get_key(key: &str) -> Result<String, String> {
         "hang_auto_recovery_enabled" => Ok(config.hang_auto_recovery_enabled.to_string()),
         "usage_limit_propagation_enabled" => Ok(config.usage_limit_propagation_enabled.to_string()),
         "idle_watchdog_enabled" => Ok(config.idle_watchdog_enabled.to_string()),
+        "show_pane_state" => Ok(config.show_pane_state.to_string()),
         _ => Err(format!("unknown config key: {key}")),
     }
 }
@@ -251,6 +267,26 @@ mod tests {
         set(&dir, "hang_auto_recovery_enabled", "false").unwrap();
         reload(&dir);
         assert_eq!(get_key("hang_auto_recovery_enabled").unwrap(), "false");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1713: the pane-state badge flag is OFF by default and runtime-toggleable
+    /// via the same `set`/persist/reload path as the other gates (the `config`
+    /// MCP tool reaches `set`), so the operator can flip it without a rebuild.
+    #[test]
+    fn show_pane_state_default_off_and_toggleable_1713() {
+        assert!(
+            !RuntimeConfig::default().show_pane_state,
+            "show_pane_state must default OFF"
+        );
+        let dir = std::env::temp_dir().join("agend-test-runtime-config-panestate");
+        std::fs::create_dir_all(&dir).ok();
+        set(&dir, "show_pane_state", "true").unwrap();
+        reload(&dir);
+        assert_eq!(get_key("show_pane_state").unwrap(), "true");
+        set(&dir, "show_pane_state", "false").unwrap();
+        reload(&dir);
+        assert_eq!(get_key("show_pane_state").unwrap(), "false");
         std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
## What

An operator aid for eyeball-verifying state detection (#1713/#1523 context): when `runtime_config.show_pane_state` is on, each pane title appends a `[<State>]` text badge of the **detected AgentState** (all states). **Default OFF** — the colour dot stays the steady-state signal; this is a temporary diagnostic toggle.

## How

- **runtime_config**: `show_pane_state: bool` (default false) + `set`/`get_key` arms, mirroring `hang_auto_recovery_enabled`. **Hot-reloadable via the `config` MCP tool** — `set` persists the file *and* updates the in-memory global (line 193), so a toggle takes effect on the next frame, no rebuild/restart.
- **`pane_title_segments`** takes the detected `state` + a `show_state_badge: bool`. The prod call site passes `runtime_config::get().show_pane_state`, keeping the global out of the render fn and the badge logic unit-testable. The badge uses the same `title_style` — **extra TEXT only; the pane colour (`state_color`) is unchanged**.
- `{state:?}` yields the PascalCase variant name (`[ServerRateLimit]`, `[PermissionPrompt]`, …) the task specified. Note: `AgentState` has no `as_str` (panels_fleet.rs:251's is `String::as_str` on a snapshot field), and the Debug form is the idiomatic representation for a diagnostic badge.
- The transient Restarting/Crashed tab-bar badge (`transient_state_badge`) is **unaffected**.

## Tests

- `pane_title_no_state_suffix` (flag OFF) → no state badge, only base + pending-count.
- `pane_title_state_badge_when_flag_on_1713` (flag ON) → title contains `[ServerRateLimit]`/`[PermissionPrompt]`/`[Thinking]`/`[Idle]`.
- `show_pane_state_default_off_and_toggleable_1713` → default off + `set`/`reload` toggle round-trip (the runtime-toggle path the operator uses).

## Gate

- `cargo test` full bin suite **3188 passed** (+3 new); `clippy --all-targets` (tray **and** tray,discord) clean; `fmt --check` clean. #1463 diff = 2 files (runtime_config.rs + render/core_render.rs).

## Operator usage

Toggle live (no restart): `config` MCP tool → set `show_pane_state` = `true` / `false`.

Refs #1713 / #1523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
