### PR TITLE
event-bus Step 2 (legacy-zero): remove the legacy delivery path; the bus is the sole path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "cron",
  "crossbeam-channel",
  "crossterm 0.28.1",
+ "ctor",
  "ctrlc",
  "dirs",
  "dunce",
@@ -777,6 +778,16 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf 0.11.3",
+]
+
+[[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,11 @@ junction = "1"
 embed-resource = "3"
 
 [dev-dependencies]
+# #event-bus Step 2 (legacy-zero): a `#[ctor] #[cfg(test)]` fn registers the bus
+# subscribers ONCE at test-binary load — before any test — so the integration
+# tests (which `emit` to the now-sole-delivery global bus) deliver order-
+# independently. Test-only; does NOT ship in the prod binary.
+ctor = "0.2"
 # CLI binary smoke testing (Sprint 42 Phase 1)
 assert_cmd = "2.0"
 predicates = "3.1"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -702,7 +702,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             recv(tick_rx_ref) -> _ => {
                 // Periodic maintenance — mirrors daemon tick consumers.
                 // Gated to owned mode via tick_rx (None in attached mode).
-                crate::daemon::cron_tick::check_schedules(&home, &registry);
+                crate::daemon::cron_tick::check_schedules(&home);
                 crate::daemon::ci_watch::check_ci_watches(&home, &registry);
                 {
                     let reg = crate::agent::lock_registry(&registry);
@@ -1527,8 +1527,6 @@ mod tests {
         // Write a one-shot schedule with past run_at directly to disk,
         // call check_schedules, verify it fires (auto-disabled).
         let home = tmp_home("sched-fire");
-        let registry: crate::agent::AgentRegistry =
-            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
         let past = (chrono::Utc::now() - chrono::Duration::seconds(2)).to_rfc3339();
         let store_json = serde_json::json!({
             "schema_version": 2,
@@ -1553,7 +1551,7 @@ mod tests {
         .expect("write schedule file");
 
         // Fire the tick — schedule is past due, should trigger.
-        crate::daemon::cron_tick::check_schedules(&home, &registry);
+        crate::daemon::cron_tick::check_schedules(&home);
 
         // Verify: schedule should now be disabled (one-shot auto-disable).
         let store = crate::schedules::load(&home);

--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -221,7 +221,7 @@ fn deliver_stall(
 /// #event-bus first-pattern: bus subscriber — on a `TaskStateChanged` event,
 /// run the stall delivery (the gate-ON path). Registered once at daemon startup
 /// via [`register_subscriber`].
-fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::TaskStateChanged {
         task_id,
         title,
@@ -232,7 +232,7 @@ fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
     } = &event.kind
     {
         deliver_stall(
-            home,
+            &event.home,
             task_id,
             title,
             reason,
@@ -243,40 +243,25 @@ fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
     }
 }
 
-/// #event-bus first-pattern: register the anti_stall delivery subscriber on the
-/// global bus. Call ONCE at daemon startup. Safe regardless of the gate — when
-/// the bus is gate-off, `emit` never fires, so the subscriber is dormant.
-pub fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// #event-bus: register the anti_stall delivery subscriber on the global bus.
+/// Call ONCE at daemon startup. Home-agnostic — the home travels on each event.
+pub fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 fn emit_stall(home: &Path, task: &Task, reason: &str) {
-    // #event-bus first-pattern (Option A): gate-ON → emit (the subscriber
-    // delivers); gate-OFF (prod default) → the legacy direct delivery. No
-    // double-delivery, no gate-off regression. The legacy `else` branch is
-    // retired only at the final cutover (all patterns migrated + gate default
-    // flipped). Parity of the two paths is proven by the gate-on test.
-    let bus = crate::daemon::event_bus::global();
-    if bus.is_enabled() {
-        bus.emit(crate::daemon::event_bus::EventKind::TaskStateChanged {
+    // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path.
+    crate::daemon::event_bus::global().emit(
+        home,
+        crate::daemon::event_bus::EventKind::TaskStateChanged {
             task_id: task.id.clone(),
             title: task.title.clone(),
             assignee: task.assignee.clone(),
             reason: reason.to_string(),
             started_at: task.started_at.clone(),
             eta_secs: task.eta_secs,
-        });
-    } else {
-        deliver_stall(
-            home,
-            &task.id,
-            &task.title,
-            reason,
-            task.started_at.as_deref(),
-            task.eta_secs,
-            task.assignee.as_deref(),
-        );
-    }
+        },
+    );
 }
 
 #[cfg(test)]
@@ -717,19 +702,22 @@ mod tests {
             task.assignee.as_deref(),
         );
 
-        // Bus emit→subscriber delivery (the gate-ON path) — real fan-out.
+        // Bus emit→subscriber delivery — real fan-out on a LOCAL bus (the home
+        // travels on the event, so the subscriber delivers to home_bus).
         let home_bus = tmp_home("parity-bus");
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::TaskStateChanged {
-            task_id: task.id.clone(),
-            title: task.title.clone(),
-            assignee: task.assignee.clone(),
-            reason: reason.to_string(),
-            started_at: task.started_at.clone(),
-            eta_secs: task.eta_secs,
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::TaskStateChanged {
+                task_id: task.id.clone(),
+                title: task.title.clone(),
+                assignee: task.assignee.clone(),
+                reason: reason.to_string(),
+                started_at: task.started_at.clone(),
+                eta_secs: task.eta_secs,
+            },
+        );
 
         let mut delivered = false;
         for r in stall_recipients() {
@@ -747,35 +735,5 @@ mod tests {
         );
         std::fs::remove_dir_all(&home_legacy).ok();
         std::fs::remove_dir_all(&home_bus).ok();
-    }
-
-    /// Option A: with the gate OFF (prod default — the global bus reads
-    /// `AGEND_EVENT_BUS`, unset in tests), `emit_stall` must STILL deliver via the
-    /// legacy path. No regression.
-    #[test]
-    fn gate_off_emit_stall_delivers_via_legacy() {
-        let _g = env_lock();
-        std::env::remove_var("AGEND_TASK_STALL_RECIPIENTS");
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "precondition: the global bus must be gate-off in the test env"
-        );
-        let home = tmp_home("gate-off");
-        let task = make_task(
-            "t-gateoff",
-            "in_progress",
-            Some(60),
-            Some("2026-01-01T00:00:00+00:00"),
-        );
-        emit_stall(&home, &task, "stalled reason");
-        let mut delivered = false;
-        for r in stall_recipients() {
-            delivered |= !drained_payloads(&home, &r).is_empty();
-        }
-        assert!(
-            delivered,
-            "#event-bus Option A: gate-off must deliver via the legacy path (no regression)"
-        );
-        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1358,14 +1358,9 @@ async fn fan_out_notifications(
                 crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home)).ok();
             // #event-bus (ci_watch, Option A): ONE skip-aware loop over subscribers.
             // The skips (action_target_on_success + #931 zombie-subscriber) are
-            // applied ONCE so gate-ON and gate-OFF notify the IDENTICAL recipient
-            // set. Per recipient: gate-ON + success/failure → emit Ci{Ready,Fail}
-            // (the subscriber delivers via the shared `deliver_ci_watch`);
-            // everything else (gate-OFF, OR a non-pair "[ci-ended]" conclusion that
-            // has no event kind) → the legacy direct deliver. No double-delivery, no
-            // gate-off regression, no dropped notify. (Replaces the prior dormant
-            // second emit loop, which lacked these skips — a latent parity bug.)
-            let bus = crate::daemon::event_bus::global();
+            // applied ONCE. Per recipient: success/failure → emit Ci{Ready,Fail}
+            // (the subscriber delivers via the shared `deliver_ci_watch`); a
+            // non-pair "[ci-ended]" conclusion has no event kind → direct deliver.
             for sub in ctx.subscribers {
                 if action_target_on_success == Some(sub.as_str()) {
                     continue;
@@ -1386,36 +1381,35 @@ async fn fan_out_notifications(
                     );
                     continue;
                 }
-                let emitted = if bus.is_enabled() {
-                    match conclusion {
-                        Some("failure") => {
-                            bus.emit(crate::daemon::event_bus::EventKind::CiFail {
-                                repo: ctx.repo.to_string(),
-                                branch: ctx.branch.to_string(),
+                // #event-bus Step 2 (legacy-zero): the success/failure pair emits
+                // (the subscriber delivers via deliver_ci_watch). A non-pair
+                // "[ci-ended]" conclusion has no event kind → direct deliver.
+                let emitted = match conclusion {
+                    Some("failure") => {
+                        crate::daemon::event_bus::global().emit(
+                            ctx.home,
+                            crate::daemon::event_bus::EventKind::CiFail {
                                 target: sub.clone(),
                                 body: body.clone(),
                                 correlation_id: repo_branch_key.clone(),
                                 supersede_token: supersede_token.clone(),
-                            });
-                            true
-                        }
-                        Some("success") => {
-                            bus.emit(crate::daemon::event_bus::EventKind::CiReady {
-                                repo: ctx.repo.to_string(),
-                                branch: ctx.branch.to_string(),
-                                target: sub.clone(),
-                                body: body.clone(),
-                                correlation_id: repo_branch_key.clone(),
-                                supersede_token: supersede_token.clone(),
-                            });
-                            true
-                        }
-                        // non-pair conclusion ("[ci-ended]" etc.): no CiReady/CiFail
-                        // kind → fall through to the legacy direct deliver below.
-                        _ => false,
+                            },
+                        );
+                        true
                     }
-                } else {
-                    false
+                    Some("success") => {
+                        crate::daemon::event_bus::global().emit(
+                            ctx.home,
+                            crate::daemon::event_bus::EventKind::CiReady {
+                                target: sub.clone(),
+                                body: body.clone(),
+                                correlation_id: repo_branch_key.clone(),
+                                supersede_token: supersede_token.clone(),
+                            },
+                        );
+                        true
+                    }
+                    _ => false,
                 };
                 if !emitted {
                     deliver_ci_watch(ctx.home, sub, &body, &repo_branch_key, &supersede_token);
@@ -1465,7 +1459,7 @@ fn deliver_ci_watch(
 /// #event-bus (ci_watch) subscriber: re-deliver a `CiReady`/`CiFail` event via the
 /// shared `deliver_ci_watch`. Both kinds deliver identically (the body already
 /// encodes pass/fail); the kind split is purely semantic.
-fn handle_event(home: &std::path::Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     match &event.kind {
         crate::daemon::event_bus::EventKind::CiReady {
             target,
@@ -1481,16 +1475,16 @@ fn handle_event(home: &std::path::Path, event: &crate::daemon::event_bus::Event)
             supersede_token,
             ..
         } => {
-            deliver_ci_watch(home, target, body, correlation_id, supersede_token);
+            deliver_ci_watch(&event.home, target, body, correlation_id, supersede_token);
         }
         _ => {}
     }
 }
 
-/// Register the ci-watch subscriber once at daemon startup (`run_core`). Dormant
-/// unless `AGEND_EVENT_BUS=1` (emit is a no-op when gate-off).
-pub(crate) fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// Register the ci-watch subscriber once at daemon startup (`run_core`).
+/// Home-agnostic — the home travels on each event.
+pub(crate) fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 fn persist_watch_state(

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -5511,17 +5511,17 @@ fn ci_watch_gate_on_emit_subscriber_matches_legacy() {
     super::deliver_ci_watch(&legacy, "rev", &body, &key, &token);
 
     let bus_home = tmp_dir("ciwatch-parity-bus");
-    let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-    let h = bus_home.clone();
-    bus.subscribe(move |e| super::handle_event(&h, e));
-    bus.emit(crate::daemon::event_bus::EventKind::CiReady {
-        repo: "o/r".into(),
-        branch: "feat".into(),
-        target: "rev".into(),
-        body: body.clone(),
-        correlation_id: key.clone(),
-        supersede_token: token.clone(),
-    });
+    let bus = crate::daemon::event_bus::EventBus::new();
+    bus.subscribe(super::handle_event);
+    bus.emit(
+        &bus_home,
+        crate::daemon::event_bus::EventKind::CiReady {
+            target: "rev".into(),
+            body: body.clone(),
+            correlation_id: key.clone(),
+            supersede_token: token.clone(),
+        },
+    );
 
     let legacy_msgs: Vec<_> = crate::inbox::drain(&legacy, "rev")
         .into_iter()

--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -207,16 +207,14 @@ fn emit_telegram_escalation(home: &Path, agent: &str) {
 /// is the already-rendered notify body (built from the live worktree discovery at
 /// the producer) — carried verbatim so the bus path never re-runs discovery.
 fn route_conflict_alert(home: &Path, agent: &str, escalation: bool, text: &str) {
-    let bus = crate::daemon::event_bus::global();
-    if bus.is_enabled() {
-        bus.emit(crate::daemon::event_bus::EventKind::ConflictAlert {
+    crate::daemon::event_bus::global().emit(
+        home,
+        crate::daemon::event_bus::EventKind::ConflictAlert {
             agent: agent.to_string(),
             escalation,
             text: text.to_string(),
-        });
-    } else {
-        deliver_conflict_alert(home, agent, escalation, text);
-    }
+        },
+    );
 }
 
 /// Shared deliver for the git-conflict notify: PTY-notify the conflicted agent via
@@ -235,21 +233,21 @@ fn deliver_conflict_alert(home: &Path, agent: &str, escalation: bool, text: &str
 
 /// #event-bus (conflict_notify) subscriber: re-deliver a `ConflictAlert` event via
 /// the shared `deliver_conflict_alert`.
-fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::ConflictAlert {
         agent,
         escalation,
         text,
     } = &event.kind
     {
-        deliver_conflict_alert(home, agent, *escalation, text);
+        deliver_conflict_alert(&event.home, agent, *escalation, text);
     }
 }
 
 /// Register the conflict-notify subscriber once at daemon startup (`run_core`).
-/// Dormant unless `AGEND_EVENT_BUS=1` (emit is a no-op when gate-off).
-pub(crate) fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// Home-agnostic — the home travels on each event.
+pub(crate) fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 /// Discover conflicted files in a worktree via `git status
@@ -627,14 +625,16 @@ mod tests {
         let text =
             build_notify_payload("rebase", &["src/a.rs".to_string()], "feat", "main").to_string();
 
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home.clone();
-        bus.subscribe(move |e| handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::ConflictAlert {
-            agent: agent.to_string(),
-            escalation: false,
-            text: text.clone(),
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home,
+            crate::daemon::event_bus::EventKind::ConflictAlert {
+                agent: agent.to_string(),
+                escalation: false,
+                text: text.clone(),
+            },
+        );
 
         let queued = crate::notification_queue::drain(&home, agent);
         assert_eq!(
@@ -650,16 +650,14 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// gate-OFF (prod default): `route_conflict_alert` falls through to the legacy
-    /// direct deliver, so the conflict notify still lands (deferred to the queue).
+    /// #event-bus Step 2 (legacy-zero): `route_conflict_alert` emits to the global
+    /// bus; the registered subscriber delivers via `deliver_conflict_alert` (the
+    /// home travels on the event → lands in this test's home). End-to-end coverage
+    /// of the production route → bus → subscriber wiring.
     #[test]
-    fn conflict_alert_gate_off_route_delivers_via_legacy() {
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "test must run with AGEND_EVENT_BUS gate off"
-        );
-        let agent = "conflict-gate-off";
-        let home = defer_home("gate-off", agent);
+    fn route_conflict_alert_delivers_via_bus() {
+        let agent = "conflict-route-bus";
+        let home = defer_home("route-bus", agent);
         let text =
             build_notify_payload("rebase", &["src/a.rs".to_string()], "feat", "main").to_string();
 

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 ///   the window; after firing (or being detected as missed because the
 ///   daemon was down through `at`), the schedule is auto-disabled so it
 ///   never triggers again.
-pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
+pub fn check_schedules(home: &Path) {
     use cron::Schedule;
     use std::str::FromStr;
 
@@ -117,15 +117,13 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
             }
         }
 
-        // #event-bus pattern (cron_tick), Option A: when the bus is enabled,
-        // emit a `CronFire` and let the subscriber run the effect; otherwise run
-        // it inline (legacy). Both bottom out in `deliver_cron_fire`, so the
-        // fire effect is byte-identical regardless of the gate. The schedule
-        // message/label are STATIC (non-time-sensitive), so they are carried
-        // verbatim and need no frozen-text handling.
-        let bus = crate::daemon::event_bus::global();
-        if bus.is_enabled() {
-            bus.emit(crate::daemon::event_bus::EventKind::CronFire {
+        // #event-bus pattern (cron_tick), Step 2: emit a `CronFire`; the subscriber
+        // runs the effect via `deliver_cron_fire`. The schedule message/label are
+        // STATIC (non-time-sensitive), carried verbatim. (The subscriber resolves
+        // the live registry it was registered with — see `register_subscriber`.)
+        crate::daemon::event_bus::global().emit(
+            home,
+            crate::daemon::event_bus::EventKind::CronFire {
                 sched_id: sched.id.clone(),
                 target: sched.target.clone(),
                 message: sched.message.clone(),
@@ -135,18 +133,8 @@ pub fn check_schedules(home: &Path, registry: &AgentRegistry) {
                     .unwrap_or_else(|| "(unnamed)".to_string()),
                 one_shot: fire.one_shot,
                 missed: fire.missed,
-            });
-        } else {
-            deliver_cron_fire(
-                home,
-                registry,
-                sched.id.as_str(),
-                sched.target.as_str(),
-                sched.message.as_str(),
-                sched.label.as_deref().unwrap_or("(unnamed)"),
-                &fire,
-            );
-        }
+            },
+        );
         any_triggered = true;
     }
 
@@ -252,7 +240,7 @@ fn deliver_cron_fire(
 }
 
 /// #event-bus pattern (cron_tick): subscriber — re-run the fire effect.
-fn handle_event(home: &Path, registry: &AgentRegistry, event: &crate::daemon::event_bus::Event) {
+fn handle_event(registry: &AgentRegistry, event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::CronFire {
         sched_id,
         target,
@@ -263,7 +251,7 @@ fn handle_event(home: &Path, registry: &AgentRegistry, event: &crate::daemon::ev
     } = &event.kind
     {
         deliver_cron_fire(
-            home,
+            &event.home,
             registry,
             sched_id,
             target,
@@ -278,11 +266,11 @@ fn handle_event(home: &Path, registry: &AgentRegistry, event: &crate::daemon::ev
 }
 
 /// #event-bus pattern (cron_tick): register the delivery subscriber at daemon
-/// startup (dormant unless `AGEND_EVENT_BUS=1`). Captures the registry Arc so
-/// the subscriber can resolve + inject to the live fleet, mirroring the
-/// producer's `check_schedules(home, registry)` access.
-pub fn register_subscriber(home: std::path::PathBuf, registry: AgentRegistry) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, &registry, e));
+/// startup. Captures the registry Arc so the subscriber can resolve + inject to
+/// the live fleet; the home travels on each event (so one registration serves any
+/// home — prod's daemon home, and each integration test's tmp home).
+pub fn register_subscriber(registry: AgentRegistry) {
+    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&registry, e));
 }
 
 /// Outcome of deciding that a schedule is due. `one_shot` means "auto-
@@ -619,7 +607,7 @@ mod tests {
         let home = cron_tmp_home("ghost");
         // No fleet.yaml → "ghost" is not a known instance.
         seed_oneshot(&home, "ghost");
-        check_schedules(&home, &empty_registry());
+        check_schedules(&home);
         assert_eq!(
             last_status(&home),
             "skipped_unknown_target",
@@ -642,7 +630,7 @@ mod tests {
         )
         .unwrap();
         seed_oneshot(&home, "offline");
-        check_schedules(&home, &empty_registry());
+        check_schedules(&home);
         assert_eq!(
             last_status(&home),
             "ok_inbox",
@@ -757,7 +745,7 @@ mod tests {
         let home = cron_tmp_home("us-done");
         seed_until_success_cron(&home, "t-done", None);
         seed_task(&home, "t-done", "done");
-        check_schedules(&home, &empty_registry());
+        check_schedules(&home);
         let s = sched0(&home);
         assert!(s.run_history.is_empty(), "done task → no fire");
         assert_eq!(
@@ -773,7 +761,7 @@ mod tests {
         let home = cron_tmp_home("us-pending");
         seed_until_success_cron(&home, "t-open", None);
         seed_task(&home, "t-open", "in_progress");
-        check_schedules(&home, &empty_registry());
+        check_schedules(&home);
         assert_eq!(
             last_status(&home),
             "ok_inbox",
@@ -786,7 +774,7 @@ mod tests {
     fn until_success_missing_task_disables_schedule() {
         let home = cron_tmp_home("us-missing");
         seed_until_success_cron(&home, "t-gone", None); // no task file seeded
-        check_schedules(&home, &empty_registry());
+        check_schedules(&home);
         let s = sched0(&home);
         assert_eq!(last_status(&home), "target_task_missing");
         assert!(!s.enabled, "missing linked task must disable the schedule");
@@ -799,7 +787,7 @@ mod tests {
         // last_success_date == today + NO task file: must still suppress (the
         // same-day short-circuit fires before any task read).
         seed_until_success_cron(&home, "t-x", Some(&today_utc()));
-        check_schedules(&home, &empty_registry());
+        check_schedules(&home);
         assert!(
             sched0(&home).run_history.is_empty(),
             "already-succeeded-today → suppress"
@@ -817,7 +805,7 @@ mod tests {
         // Succeeded yesterday; today the task is reopened (in_progress) → fire.
         seed_until_success_cron(&home, "t-reopen", Some("2020-01-01"));
         seed_task(&home, "t-reopen", "in_progress");
-        check_schedules(&home, &empty_registry());
+        check_schedules(&home);
         assert_eq!(
             last_status(&home),
             "ok_inbox",
@@ -903,18 +891,20 @@ mod tests {
         // Bus emit→subscriber (gate-ON path) via a local enabled test bus.
         let home_bus = cron_tmp_home("parity-bus");
         std::fs::write(crate::fleet::fleet_yaml_path(&home_bus), PARITY_FLEET).unwrap();
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
+        let bus = crate::daemon::event_bus::EventBus::new();
         let reg = empty_registry();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| handle_event(&h, &reg, e));
-        bus.emit(crate::daemon::event_bus::EventKind::CronFire {
-            sched_id: sid.to_string(),
-            target: target.to_string(),
-            message: message.to_string(),
-            label: label.to_string(),
-            one_shot: false,
-            missed: false,
-        });
+        bus.subscribe(move |e| handle_event(&reg, e));
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::CronFire {
+                sched_id: sid.to_string(),
+                target: target.to_string(),
+                message: message.to_string(),
+                label: label.to_string(),
+                one_shot: false,
+                missed: false,
+            },
+        );
 
         let legacy: Vec<String> = crate::inbox::drain(&home_legacy, target)
             .into_iter()
@@ -938,18 +928,15 @@ mod tests {
         std::fs::remove_dir_all(home_bus).ok();
     }
 
-    /// REGRESSION (gate-OFF): with the global bus disabled (default test env),
-    /// `check_schedules` still fires via the legacy `deliver_cron_fire` path.
+    /// #event-bus Step 2 (legacy-zero): `check_schedules` emits to the global bus;
+    /// the registered subscriber delivers via `deliver_cron_fire` to the event's
+    /// home (this test's home → inbox fallback for the offline target).
     #[test]
-    fn gate_off_check_schedules_delivers_via_legacy() {
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "precondition: the global bus must be gate-off in the test env"
-        );
-        let home = cron_tmp_home("gate-off");
+    fn check_schedules_delivers_via_bus() {
+        let home = cron_tmp_home("via-bus");
         std::fs::write(crate::fleet::fleet_yaml_path(&home), PARITY_FLEET).unwrap();
         seed_oneshot(&home, "offline");
-        check_schedules(&home, &empty_registry());
+        check_schedules(&home);
         assert_eq!(
             last_status(&home),
             "ok_inbox",

--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -347,7 +347,7 @@ fn deliver_timeout(
 
 /// #event-bus pattern #2: bus subscriber — deliver on a `DecisionTimeout` event
 /// (the gate-ON path). Registered once at daemon startup via [`register_subscriber`].
-fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::DecisionTimeout {
         decision_id,
         sender,
@@ -357,7 +357,7 @@ fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
     } = &event.kind
     {
         deliver_timeout(
-            home,
+            &event.home,
             decision_id,
             sender,
             *elapsed_secs,
@@ -368,35 +368,24 @@ fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
 }
 
 /// #event-bus pattern #2: register the decision_timeout delivery subscriber on
-/// the global bus. Call ONCE at daemon startup. Dormant while the bus is gate-off
-/// (emit never fires), so registration is always safe.
-pub fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// the global bus. Call ONCE at daemon startup. Home-agnostic — the home travels
+/// on each event.
+pub fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 fn emit_timeout_event(home: &Path, d: &PendingDecision, elapsed_secs: i64) {
-    // #event-bus pattern #2 (Option A): gate-ON → emit (the subscriber delivers);
-    // gate-OFF (prod default) → the legacy direct delivery. No double-delivery, no
-    // gate-off regression. The legacy `else` is retired only at the final cutover.
-    let bus = crate::daemon::event_bus::global();
-    if bus.is_enabled() {
-        bus.emit(crate::daemon::event_bus::EventKind::DecisionTimeout {
+    // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path.
+    crate::daemon::event_bus::global().emit(
+        home,
+        crate::daemon::event_bus::EventKind::DecisionTimeout {
             decision_id: d.decision_id.clone(),
             sender: d.sender.clone(),
             elapsed_secs,
             timeout_secs: d.timeout_secs,
             default_action: d.default_action.clone(),
-        });
-    } else {
-        deliver_timeout(
-            home,
-            &d.decision_id,
-            &d.sender,
-            elapsed_secs,
-            d.timeout_secs,
-            &d.default_action,
-        );
-    }
+        },
+    );
 }
 
 #[cfg(test)]
@@ -1005,16 +994,18 @@ mod tests {
 
         // Bus emit→subscriber delivery (the gate-ON path) — real fan-out.
         let home_bus = tmp_home("parity-bus");
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::DecisionTimeout {
-            decision_id: decision_id.to_string(),
-            sender: sender.to_string(),
-            elapsed_secs,
-            timeout_secs,
-            default_action: default_action.to_string(),
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::DecisionTimeout {
+                decision_id: decision_id.to_string(),
+                sender: sender.to_string(),
+                elapsed_secs,
+                timeout_secs,
+                default_action: default_action.to_string(),
+            },
+        );
 
         let recipient = timeout_recipient();
         let legacy = drained_payloads(&home_legacy, &recipient);
@@ -1031,17 +1022,14 @@ mod tests {
         std::fs::remove_dir_all(&home_bus).ok();
     }
 
-    /// Option A: with the gate OFF (prod default), `emit_timeout_event` must STILL
-    /// deliver via the legacy path. No regression.
+    /// #event-bus Step 2 (legacy-zero): `emit_timeout_event` emits to the global
+    /// bus; the registered subscriber delivers via `deliver_timeout` to the event's
+    /// home (this test's home).
     #[test]
-    fn gate_off_emit_delivers_via_legacy() {
+    fn emit_timeout_event_delivers_via_bus() {
         let _g = env_lock();
         std::env::remove_var("AGEND_DECISION_TIMEOUT_RECIPIENT");
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "precondition: the global bus must be gate-off in the test env"
-        );
-        let home = tmp_home("gate-off");
+        let home = tmp_home("via-bus");
         let d = PendingDecision {
             decision_id: "d-gateoff".into(),
             sender: "general".into(),

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -741,7 +741,7 @@ fn deliver_dispatch_idle(
 
 /// #event-bus pattern #3: bus subscriber — deliver on a `DispatchIdleExceeded`
 /// event (the gate-ON path). Registered once at daemon startup via [`register_subscriber`].
-fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::DispatchIdleExceeded {
         dispatcher,
         target,
@@ -753,7 +753,7 @@ fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
     } = &event.kind
     {
         deliver_dispatch_idle(
-            home,
+            &event.home,
             dispatch_id,
             dispatcher,
             target,
@@ -767,8 +767,8 @@ fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
 
 /// #event-bus pattern #3: register the dispatch_idle delivery subscriber on the
 /// global bus. Call ONCE at daemon startup. Dormant while the bus is gate-off.
-pub fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+pub fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
@@ -786,13 +786,11 @@ fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
             d.threshold_secs,
         ),
     );
-    // #event-bus pattern #3 (Option A): gate-ON → emit (the subscriber delivers);
-    // gate-OFF (prod default) → the legacy direct delivery. No double-delivery, no
-    // gate-off regression. The flock-drop-before-emit ordering (#1617) is preserved
-    // (scan caller unchanged). The legacy `else` is retired at the final cutover.
-    let bus = crate::daemon::event_bus::global();
-    if bus.is_enabled() {
-        bus.emit(crate::daemon::event_bus::EventKind::DispatchIdleExceeded {
+    // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path. The
+    // flock-drop-before-emit ordering (#1617) is preserved (scan caller unchanged).
+    crate::daemon::event_bus::global().emit(
+        home,
+        crate::daemon::event_bus::EventKind::DispatchIdleExceeded {
             dispatcher: d.dispatcher.clone(),
             target: d.target.clone(),
             elapsed_secs,
@@ -800,19 +798,8 @@ fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
             expected_kind: d.expected_kind.clone(),
             threshold_secs: d.threshold_secs,
             correlation_id: d.correlation_id.clone(),
-        });
-    } else {
-        deliver_dispatch_idle(
-            home,
-            &d.dispatch_id,
-            &d.dispatcher,
-            &d.target,
-            &d.expected_kind,
-            d.correlation_id.as_deref(),
-            elapsed_secs,
-            d.threshold_secs,
-        );
-    }
+        },
+    );
 }
 
 /// Per-loop scheduler state.
@@ -2161,18 +2148,20 @@ mod tests {
 
         // Bus emit→subscriber delivery (the gate-ON path) — real fan-out.
         let home_bus = tmp_home("parity-bus");
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::DispatchIdleExceeded {
-            dispatcher: dispatcher.to_string(),
-            target: target.to_string(),
-            elapsed_secs: elapsed,
-            dispatch_id: dispatch_id.to_string(),
-            expected_kind: expected_kind.to_string(),
-            threshold_secs: threshold,
-            correlation_id: corr.map(String::from),
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::DispatchIdleExceeded {
+                dispatcher: dispatcher.to_string(),
+                target: target.to_string(),
+                elapsed_secs: elapsed,
+                dispatch_id: dispatch_id.to_string(),
+                expected_kind: expected_kind.to_string(),
+                threshold_secs: threshold,
+                correlation_id: corr.map(String::from),
+            },
+        );
 
         let legacy = drained_payloads(&home_legacy, dispatcher);
         let viabus = drained_payloads(&home_bus, dispatcher);
@@ -2188,15 +2177,12 @@ mod tests {
         std::fs::remove_dir_all(&home_bus).ok();
     }
 
-    /// Option A: with the gate OFF (prod default), `emit_exceeded_event` must STILL
-    /// deliver via the legacy path. No regression.
+    /// #event-bus Step 2 (legacy-zero): `emit_exceeded_event` emits to the global
+    /// bus; the registered subscriber delivers via `deliver_dispatch_idle` to the
+    /// event's home (this test's home).
     #[test]
-    fn gate_off_emit_delivers_via_legacy() {
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "precondition: the global bus must be gate-off in the test env"
-        );
-        let home = tmp_home("gate-off");
+    fn emit_exceeded_event_delivers_via_bus() {
+        let home = tmp_home("via-bus");
         let d = PendingDispatch {
             dispatch_id: "di-gateoff".into(),
             dispatcher: "lead".into(),

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -1,17 +1,12 @@
 //! Structured event bus for daemon-internal notifications.
 //!
-//! Phase 1: parallel emit spine. Existing `enqueue_with_idle_hint` calls
-//! remain untouched; this module emits a structured `Event` alongside them
-//! so future subscribers can react without per-module plumbing.
+//! Each per-pattern producer `emit`s a structured `Event` carrying the
+//! notification payload + the `$AGEND_HOME` it occurred in; a per-pattern
+//! subscriber (registered once at daemon startup in `run_core`) re-delivers it.
 //!
-//! End-of-train cutover (Step 1): the gate now defaults **ON** (code-shipped) so
-//! the event-bus delivery path is live without any operator env. Set
-//! `AGEND_EVENT_BUS=0` and **restart the daemon** to fall back to the legacy
-//! direct-enqueue path (the kill-switch — `global()` is a `OnceLock` that reads
-//! the env once at startup, so it is NOT a hot-toggle). The legacy `else`
-//! branches are retained as that kill-switch until Step 2 (post-validation).
-
-#![allow(dead_code)]
+//! End-of-train cutover is COMPLETE (Step 2, legacy-zero): the bus is the SOLE
+//! delivery path — `emit` is unconditional (no gate, no env, no legacy fallback).
+//! Rollback is `git revert` of the cutover, not an env flag.
 
 use std::sync::Arc;
 
@@ -32,19 +27,15 @@ pub enum EventKind {
     // `body` is the RENDERED inbox body — it embeds a live-fetched failure-log tail
     // (`gh --log-failed`), so re-fetching in the subscriber would burn GitHub
     // rate-limit + could drift; it is frozen at the producer. `correlation_id`
-    // (repo@branch) + `supersede_token` (ci-<run>-<sha>) reproduce the legacy
-    // enqueue + supersede bookkeeping. One event is emitted PER recipient.
+    // (repo@branch) + `supersede_token` (ci-<run>-<sha>) reproduce the enqueue +
+    // supersede bookkeeping. One event is emitted PER recipient.
     CiReady {
-        repo: String,
-        branch: String,
         target: String,
         body: String,
         correlation_id: String,
         supersede_token: String,
     },
     CiFail {
-        repo: String,
-        branch: String,
         target: String,
         body: String,
         correlation_id: String,
@@ -160,15 +151,17 @@ pub enum EventKind {
 #[derive(Debug, Clone)]
 pub struct Event {
     pub kind: EventKind,
-    pub timestamp: std::time::Instant,
+    /// #event-bus Step 2 (legacy-zero): the `$AGEND_HOME` the event occurred in.
+    /// Carried ON the event (not captured at subscriber registration) so a single
+    /// globally-registered subscriber delivers to the correct home — required now
+    /// that the bus is the ONLY delivery path (no per-home legacy fallback), and so
+    /// the multi-home integration tests each deliver to their own tmp home.
+    pub home: std::path::PathBuf,
 }
 
 impl Event {
-    pub fn new(kind: EventKind) -> Self {
-        Self {
-            kind,
-            timestamp: std::time::Instant::now(),
-        }
+    pub fn new(home: std::path::PathBuf, kind: EventKind) -> Self {
+        Self { kind, home }
     }
 }
 
@@ -177,42 +170,59 @@ pub fn global() -> &'static EventBus {
     BUS.get_or_init(EventBus::new)
 }
 
+/// #event-bus Step 2 (legacy-zero): test-only one-shot registration of ALL pattern
+/// subscribers on the process-global bus, mirroring `daemon::run_core`. Since the
+/// bus is now the SOLE delivery path, an integration test that drives a production
+/// fn (which `emit`s to `global()`) must register the subscribers first, else the
+/// emit fans out to nothing. Idempotent via `Once` (subscribe appends, so a second
+/// registration would double-deliver). The home travels on each event, so this one
+/// registration serves every test's tmp home. cron gets a dummy empty registry —
+/// cron integration tests use empty registries + assert the home-driven inbox
+/// fallback, so the captured registry's contents don't affect them.
+#[cfg(test)]
+pub(crate) fn register_all_subscribers_for_test() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        crate::daemon::anti_stall::register_subscriber();
+        crate::daemon::decision_timeout::register_subscriber();
+        crate::daemon::dispatch_idle::register_subscriber();
+        crate::daemon::waiting_on_stale::register_subscriber();
+        crate::daemon::helper_staleness_watchdog::register_subscriber();
+        crate::daemon::idle_watchdog::register_subscriber();
+        crate::tasks::register_cascade_subscriber();
+        crate::daemon::poll_reminder::register_subscriber();
+        let dummy_registry: crate::agent::AgentRegistry =
+            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        crate::daemon::cron_tick::register_subscriber(dummy_registry);
+        crate::daemon::supervisor::register_subscriber();
+        crate::daemon::conflict_notify::register_subscriber();
+        crate::daemon::ci_watch::register_subscriber();
+    });
+}
+
+/// #event-bus Step 2 (legacy-zero): register the bus subscribers ONCE at
+/// test-binary LOAD — before any `#[test]` runs — via `ctor`. The bus is now the
+/// sole delivery path, so integration tests that drive a producer (`emit`→global)
+/// would otherwise be order-dependent (only delivering if some earlier test
+/// happened to register first). Running registration before any test makes
+/// delivery order-INDEPENDENT — no per-test harness call, no order-dependent flake.
+#[cfg(test)]
+#[ctor::ctor]
+fn _register_event_bus_subscribers_at_test_load() {
+    register_all_subscribers_for_test();
+}
+
 type Subscriber = Arc<dyn Fn(&Event) + Send + Sync>;
 
 pub struct EventBus {
     subscribers: parking_lot::Mutex<Vec<Subscriber>>,
-    enabled: bool,
 }
 
 impl EventBus {
     pub fn new() -> Self {
-        // #event-bus cutover Step 1: default ON in production. Unset env →
-        // enabled; the kill-switch is `AGEND_EVENT_BUS=0` (any other value stays
-        // ON). In the TEST binary the default is OFF so the existing legacy-path
-        // unit/integration tests keep exercising the legacy direct-enqueue
-        // (the bus path is covered by the per-pattern `new_enabled_for_test`
-        // parity tests). An explicit env value overrides in either build.
-        let enabled = std::env::var("AGEND_EVENT_BUS")
-            .map(|v| v != "0")
-            .unwrap_or(!cfg!(test));
         Self {
             subscribers: parking_lot::Mutex::new(Vec::new()),
-            enabled,
-        }
-    }
-
-    pub fn is_enabled(&self) -> bool {
-        self.enabled
-    }
-
-    /// Test-only: a bus with the gate forced ON (bypasses the env var), so other
-    /// modules' tests can exercise the `emit`→subscriber path deterministically
-    /// without touching the process-global `global()` bus.
-    #[cfg(test)]
-    pub(crate) fn new_enabled_for_test() -> Self {
-        Self {
-            subscribers: parking_lot::Mutex::new(Vec::new()),
-            enabled: true,
         }
     }
 
@@ -220,23 +230,17 @@ impl EventBus {
         self.subscribers.lock().push(Arc::new(f));
     }
 
-    pub fn emit(&self, kind: EventKind) {
-        if !self.enabled {
-            return;
-        }
-        let event = Event::new(kind);
+    /// #event-bus Step 2 (legacy-zero): the bus is the SOLE delivery path, so
+    /// `emit` is unconditional (no gate). `home` is the `$AGEND_HOME` the event
+    /// occurred in — carried on the `Event` so a single globally-registered
+    /// subscriber delivers to the correct home.
+    pub fn emit(&self, home: &std::path::Path, kind: EventKind) {
+        let event = Event::new(home.to_path_buf(), kind);
         let subs = self.subscribers.lock();
         for sub in subs.iter() {
             sub(&event);
         }
         tracing::debug!(kind = ?event.kind, "event_bus: emitted");
-    }
-
-    pub fn emit_lazy(&self, f: impl FnOnce() -> EventKind) {
-        if !self.enabled {
-            return;
-        }
-        self.emit(f());
     }
 }
 
@@ -249,7 +253,6 @@ impl Default for EventBus {
 impl std::fmt::Debug for EventBus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventBus")
-            .field("enabled", &self.enabled)
             .field("subscriber_count", &self.subscribers.lock().len())
             .finish()
     }
@@ -262,42 +265,22 @@ mod tests {
     use std::sync::Mutex;
 
     #[test]
-    fn emit_disabled_by_default() {
+    fn emit_delivers_to_subscribers() {
         let bus = EventBus::new();
         let received = Arc::new(Mutex::new(Vec::new()));
         let r = Arc::clone(&received);
         bus.subscribe(move |e| r.lock().unwrap().push(e.kind.clone()));
-        bus.emit(EventKind::CiReady {
-            repo: "owner/repo".into(),
-            branch: "main".into(),
-            target: "dev".into(),
-            body: "[ci-pass]".into(),
-            correlation_id: "owner/repo@main".into(),
-            supersede_token: "ci-1-abc".into(),
-        });
-        assert!(
-            received.lock().unwrap().is_empty(),
-            "emit must be no-op when AGEND_EVENT_BUS != 1"
+        bus.emit(
+            std::path::Path::new("/tmp/h"),
+            EventKind::TaskStateChanged {
+                task_id: "t-1".into(),
+                title: "test".into(),
+                assignee: Some("dev".into()),
+                reason: "stalled".into(),
+                started_at: None,
+                eta_secs: None,
+            },
         );
-    }
-
-    #[test]
-    fn emit_delivers_to_subscribers_when_enabled() {
-        let bus = EventBus {
-            subscribers: parking_lot::Mutex::new(Vec::new()),
-            enabled: true,
-        };
-        let received = Arc::new(Mutex::new(Vec::new()));
-        let r = Arc::clone(&received);
-        bus.subscribe(move |e| r.lock().unwrap().push(e.kind.clone()));
-        bus.emit(EventKind::TaskStateChanged {
-            task_id: "t-1".into(),
-            title: "test".into(),
-            assignee: Some("dev".into()),
-            reason: "stalled".into(),
-            started_at: None,
-            eta_secs: None,
-        });
         let events = received.lock().unwrap();
         assert_eq!(events.len(), 1);
         assert!(
@@ -306,11 +289,30 @@ mod tests {
     }
 
     #[test]
+    fn emit_carries_the_home_on_the_event() {
+        let bus = EventBus::new();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let s = Arc::clone(&seen);
+        bus.subscribe(move |e| s.lock().unwrap().push(e.home.clone()));
+        bus.emit(
+            std::path::Path::new("/tmp/agend-home-x"),
+            EventKind::CiReady {
+                target: "dev".into(),
+                body: "[ci-pass]".into(),
+                correlation_id: "owner/repo@main".into(),
+                supersede_token: "ci-1-abc".into(),
+            },
+        );
+        assert_eq!(
+            seen.lock().unwrap().as_slice(),
+            [std::path::PathBuf::from("/tmp/agend-home-x")],
+            "the subscriber must see the home the producer emitted with"
+        );
+    }
+
+    #[test]
     fn multiple_subscribers_all_receive() {
-        let bus = EventBus {
-            subscribers: parking_lot::Mutex::new(Vec::new()),
-            enabled: true,
-        };
+        let bus = EventBus::new();
         let count_a = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let count_b = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let ca = Arc::clone(&count_a);
@@ -321,14 +323,15 @@ mod tests {
         bus.subscribe(move |_| {
             cb.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         });
-        bus.emit(EventKind::CiFail {
-            repo: "o/r".into(),
-            branch: "feat".into(),
-            target: "dev".into(),
-            body: "[ci-fail]".into(),
-            correlation_id: "o/r@feat".into(),
-            supersede_token: "ci-2-def".into(),
-        });
+        bus.emit(
+            std::path::Path::new("/tmp/h"),
+            EventKind::CiFail {
+                target: "dev".into(),
+                body: "[ci-fail]".into(),
+                correlation_id: "o/r@feat".into(),
+                supersede_token: "ci-2-def".into(),
+            },
+        );
         assert_eq!(count_a.load(std::sync::atomic::Ordering::Relaxed), 1);
         assert_eq!(count_b.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
@@ -345,16 +348,12 @@ mod tests {
                 eta_secs: None,
             },
             EventKind::CiReady {
-                repo: "o/r".into(),
-                branch: "b".into(),
                 target: "t".into(),
                 body: "[ci-pass]".into(),
                 correlation_id: "o/r@b".into(),
                 supersede_token: "ci-1-aaa".into(),
             },
             EventKind::CiFail {
-                repo: "o/r".into(),
-                branch: "b".into(),
                 target: "t".into(),
                 body: "[ci-fail]".into(),
                 correlation_id: "o/r@b".into(),

--- a/src/daemon/helper_staleness_watchdog.rs
+++ b/src/daemon/helper_staleness_watchdog.rs
@@ -104,17 +104,13 @@ pub(crate) fn scan_and_emit(
                 continue;
             }
         }
-        // #event-bus pattern #5 (Option A): emit→subscriber when the bus is on,
-        // else the legacy direct deliver. Byte-identical either way (both paths
-        // bottom out in `deliver_helper_staleness`).
-        let bus = crate::daemon::event_bus::global();
-        if bus.is_enabled() {
-            bus.emit(crate::daemon::event_bus::EventKind::HelperStale {
+        // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path.
+        crate::daemon::event_bus::global().emit(
+            home,
+            crate::daemon::event_bus::EventKind::HelperStale {
                 helper_name: (*name).to_string(),
-            });
-        } else {
-            deliver_helper_staleness(home, name);
-        }
+            },
+        );
         last_alerted.insert((*name).to_string(), now);
     }
 }
@@ -165,17 +161,17 @@ fn deliver_helper_staleness(home: &Path, helper_name: &str) {
 }
 
 /// #event-bus pattern #5: subscriber — rebuild the alert from the event.
-fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::HelperStale { helper_name } = &event.kind {
-        deliver_helper_staleness(home, helper_name);
+        deliver_helper_staleness(&event.home, helper_name);
     }
 }
 
-/// #event-bus pattern #5: register the delivery subscriber at daemon startup
-/// (dormant unless `AGEND_EVENT_BUS=1`). Wired beside the other patterns in
-/// `daemon::mod`.
-pub fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// #event-bus pattern #5: register the delivery subscriber at daemon startup.
+/// Home-agnostic — the home travels on each event. Wired beside the other
+/// patterns in `daemon::mod`.
+pub fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 #[cfg(test)]
@@ -367,12 +363,14 @@ mod tests {
         // Bus emit→subscriber (the gate-ON path) — real fan-out via a test bus.
         let home_bus = tmp_home("parity-bus");
         std::fs::create_dir_all(home_bus.join("inbox")).unwrap();
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::HelperStale {
-            helper_name: helper.to_string(),
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::HelperStale {
+                helper_name: helper.to_string(),
+            },
+        );
 
         for recipient in RECIPIENTS {
             let legacy = drained_payloads(&home_legacy, recipient);
@@ -387,15 +385,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(&home_bus);
     }
 
-    /// #event-bus pattern #5 REGRESSION (gate-OFF): with the global bus disabled
-    /// (default test env), the scan still delivers to both recipients via legacy.
+    /// #event-bus Step 2 (legacy-zero): the scan emits to the global bus; the
+    /// registered subscriber delivers to both recipients (the home travels on the
+    /// event → this test's home).
     #[test]
-    fn gate_off_scan_delivers_via_legacy() {
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "precondition: the global bus must be gate-off in the test env"
-        );
-        let home = tmp_home("gate-off");
+    fn scan_delivers_via_bus() {
+        let home = tmp_home("via-bus");
         let daemon = stage_stale_state(&home, "agend-git");
         let mut last_alerted: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
         scan_and_emit(&home, Some(&daemon), &mut last_alerted);

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -744,22 +744,22 @@ fn route_idle_alert(
     text: &str,
     correlation_agent: Option<&str>,
 ) {
-    let bus = crate::daemon::event_bus::global();
-    if bus.is_enabled() {
-        bus.emit(crate::daemon::event_bus::EventKind::IdleAlert {
+    // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path. The
+    // recipient is already resolved by the caller and carried on the event.
+    crate::daemon::event_bus::global().emit(
+        home,
+        crate::daemon::event_bus::EventKind::IdleAlert {
             recipient: recipient.to_string(),
             kind: kind.to_string(),
             text: text.to_string(),
             correlation_agent: correlation_agent.map(String::from),
-        });
-    } else {
-        emit_idle_alert(home, recipient, kind, text, correlation_agent);
-    }
+        },
+    );
 }
 
-/// #event-bus pattern #6: bus subscriber — deliver on an `IdleAlert` event (the
-/// gate-ON path) via the shared `emit_idle_alert`. Registered once at daemon startup.
-fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+/// #event-bus pattern #6: bus subscriber — deliver on an `IdleAlert` event via the
+/// shared `emit_idle_alert`. Registered once at daemon startup.
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::IdleAlert {
         recipient,
         kind,
@@ -767,14 +767,20 @@ fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
         correlation_agent,
     } = &event.kind
     {
-        emit_idle_alert(home, recipient, kind, text, correlation_agent.as_deref());
+        emit_idle_alert(
+            &event.home,
+            recipient,
+            kind,
+            text,
+            correlation_agent.as_deref(),
+        );
     }
 }
 
 /// #event-bus pattern #6: register the idle_watchdog delivery subscriber on the
-/// global bus. Call ONCE at daemon startup. Dormant while the bus is gate-off.
-pub fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// global bus. Call ONCE at daemon startup. Home-agnostic — home travels on the event.
+pub fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 #[cfg(test)]
@@ -1867,15 +1873,17 @@ mod tests {
         emit_idle_alert(&home_legacy, recipient, kind, text, corr);
 
         let home_bus = tmp_home("p6-parity-bus");
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::IdleAlert {
-            recipient: recipient.to_string(),
-            kind: kind.to_string(),
-            text: text.to_string(),
-            correlation_agent: corr.map(String::from),
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::IdleAlert {
+                recipient: recipient.to_string(),
+                kind: kind.to_string(),
+                text: text.to_string(),
+                correlation_agent: corr.map(String::from),
+            },
+        );
 
         let legacy = alert_payloads(&home_legacy, recipient);
         let via_bus = alert_payloads(&home_bus, recipient);
@@ -1889,15 +1897,11 @@ mod tests {
         std::fs::remove_dir_all(&home_bus).ok();
     }
 
-    // gate-OFF (default): route_idle_alert falls through to the legacy deliver,
-    // so the alert still lands without the bus.
+    // #event-bus Step 2 (legacy-zero): route_idle_alert emits to the global bus;
+    // the registered subscriber delivers via emit_idle_alert to the event's home.
     #[test]
-    fn gate_off_route_idle_alert_delivers_via_legacy() {
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "test must run with AGEND_EVENT_BUS gate off"
-        );
-        let home = tmp_home("p6-gate-off");
+    fn route_idle_alert_delivers_via_bus() {
+        let home = tmp_home("p6-via-bus");
         route_idle_alert(
             &home,
             "general",

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -406,20 +406,22 @@ fn run_core(
 
     let ctx = init_daemon_services(home, telegram)?;
 
-    // #event-bus: register the per-pattern delivery subscribers once. Dormant
-    // unless AGEND_EVENT_BUS=1 (emit is a no-op when gate-off).
-    crate::daemon::anti_stall::register_subscriber(home.to_path_buf());
-    crate::daemon::decision_timeout::register_subscriber(home.to_path_buf());
-    crate::daemon::dispatch_idle::register_subscriber(home.to_path_buf());
-    crate::daemon::waiting_on_stale::register_subscriber(home.to_path_buf());
-    crate::daemon::helper_staleness_watchdog::register_subscriber(home.to_path_buf());
-    crate::daemon::idle_watchdog::register_subscriber(home.to_path_buf());
-    crate::tasks::register_cascade_subscriber(home.to_path_buf());
-    crate::daemon::poll_reminder::register_subscriber(home.to_path_buf());
-    crate::daemon::cron_tick::register_subscriber(home.to_path_buf(), ctx.registry.clone());
-    crate::daemon::supervisor::register_subscriber(home.to_path_buf());
-    crate::daemon::conflict_notify::register_subscriber(home.to_path_buf());
-    crate::daemon::ci_watch::register_subscriber(home.to_path_buf());
+    // #event-bus Step 2 (legacy-zero): register the per-pattern delivery
+    // subscribers once. The bus is the SOLE delivery path; each subscriber is
+    // home-agnostic (the home travels on every event). cron also captures the live
+    // registry (to resolve + inject to the fleet).
+    crate::daemon::anti_stall::register_subscriber();
+    crate::daemon::decision_timeout::register_subscriber();
+    crate::daemon::dispatch_idle::register_subscriber();
+    crate::daemon::waiting_on_stale::register_subscriber();
+    crate::daemon::helper_staleness_watchdog::register_subscriber();
+    crate::daemon::idle_watchdog::register_subscriber();
+    crate::tasks::register_cascade_subscriber();
+    crate::daemon::poll_reminder::register_subscriber();
+    crate::daemon::cron_tick::register_subscriber(ctx.registry.clone());
+    crate::daemon::supervisor::register_subscriber();
+    crate::daemon::conflict_notify::register_subscriber();
+    crate::daemon::ci_watch::register_subscriber();
 
     spawn_fleet_agents(home, &agents, &ctx);
 

--- a/src/daemon/per_tick/check_schedules.rs
+++ b/src/daemon/per_tick/check_schedules.rs
@@ -27,7 +27,7 @@ impl PerTickHandler for CheckSchedulesHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        crate::daemon::cron_tick::check_schedules(ctx.home, ctx.registry);
+        crate::daemon::cron_tick::check_schedules(ctx.home);
     }
 }
 

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -79,21 +79,18 @@ pub fn collect_poll_reminders(home: &Path, registry: &AgentRegistry) -> Vec<(Str
 /// Run one poll-reminder pass. Called from daemon tick every N ticks.
 /// Collects reminders via [`collect_poll_reminders`] then delivers each.
 ///
-/// #event-bus pattern #8 (Option A): when the bus is enabled, emit a
-/// `PollReminder` per nudge and let the subscriber deliver; otherwise deliver
-/// directly via the legacy path. Both bottom out in [`deliver_poll_reminder`],
-/// so delivery is byte-identical regardless of the gate.
+/// #event-bus pattern #8, Step 2 (legacy-zero): emit a `PollReminder` per nudge;
+/// the subscriber delivers via [`deliver_poll_reminder`]. The bus is the sole
+/// delivery path.
 pub fn poll_reminder_pass(home: &Path, registry: &AgentRegistry) {
-    let bus = crate::daemon::event_bus::global();
     for (name, reminder) in collect_poll_reminders(home, registry) {
-        if bus.is_enabled() {
-            bus.emit(crate::daemon::event_bus::EventKind::PollReminder {
+        crate::daemon::event_bus::global().emit(
+            home,
+            crate::daemon::event_bus::EventKind::PollReminder {
                 agent: name,
                 reminder,
-            });
-        } else {
-            deliver_poll_reminder(home, &name, &reminder);
-        }
+            },
+        );
     }
 }
 
@@ -106,17 +103,17 @@ fn deliver_poll_reminder(home: &Path, agent: &str, reminder: &str) {
 }
 
 /// #event-bus pattern #8: subscriber — re-deliver the frozen reminder text.
-fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::PollReminder { agent, reminder } = &event.kind {
-        deliver_poll_reminder(home, agent, reminder);
+        deliver_poll_reminder(&event.home, agent, reminder);
     }
 }
 
-/// #event-bus pattern #8: register the delivery subscriber at daemon startup
-/// (dormant unless `AGEND_EVENT_BUS=1`). Wired beside the other patterns in
-/// `daemon::mod`.
-pub fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// #event-bus pattern #8: register the delivery subscriber at daemon startup.
+/// Home-agnostic — the home travels on each event. Wired beside the other
+/// patterns in `daemon::mod`.
+pub fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 #[cfg(test)]
@@ -398,13 +395,15 @@ mod tests {
         // Bus emit→subscriber (gate-ON path) via a local enabled test bus.
         let home_bus = tmp_home("parity-bus");
         stage_thinking_snapshot(&home_bus, agent);
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::PollReminder {
-            agent: agent.to_string(),
-            reminder: reminder.clone(),
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::PollReminder {
+                agent: agent.to_string(),
+                reminder: reminder.clone(),
+            },
+        );
 
         let legacy: Vec<String> = crate::notification_queue::drain(&home_legacy, agent)
             .into_iter()
@@ -424,17 +423,13 @@ mod tests {
         std::fs::remove_dir_all(&home_bus).ok();
     }
 
-    /// REGRESSION (gate-OFF): with the global bus disabled (default test env),
-    /// `poll_reminder_pass` still delivers via the legacy `compose_aware_inject`
-    /// path. Registry handle is Idle (so `collect` picks the agent up); the
-    /// snapshot is `thinking` (so the deliver defers into the drainable queue).
+    /// #event-bus Step 2 (legacy-zero): `poll_reminder_pass` emits to the global
+    /// bus; the registered subscriber delivers via `deliver_poll_reminder`. Registry
+    /// handle is Idle (so `collect` picks the agent up); the snapshot is `thinking`
+    /// (so the deliver defers into the drainable queue).
     #[test]
-    fn gate_off_pass_delivers_via_legacy() {
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "precondition: the global bus must be gate-off in the test env"
-        );
-        let home = tmp_home("gate-off");
+    fn pass_delivers_via_bus() {
+        let home = tmp_home("via-bus");
         let agent = "poll-gateoff-agent";
         seed_unread(&home, agent, 2);
         stage_thinking_snapshot(&home, agent);

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -502,17 +502,16 @@ pub(crate) fn maybe_notify_member_state_change(
     });
     track.consecutive += 1;
     track.last_at = now;
-    // #event-bus pattern #9 (Option A): freeze the only now()-derived value
-    // (detected_at) here so BOTH the legacy path and the bus path render the inbox
-    // payload byte-identically. gate-ON → emit MemberStateChanged (the subscriber
-    // delivers via the SAME `deliver_member_state_change`); gate-OFF (prod default)
-    // → call that deliver directly. No double-delivery, no gate-off regression.
+    // #event-bus pattern #9, Step 2 (legacy-zero): freeze the only now()-derived
+    // value (detected_at) here so the subscriber renders the inbox payload
+    // byte-identically, then emit MemberStateChanged (the subscriber delivers via
+    // `deliver_member_state_change`). The bus is the sole delivery path.
     let detected_at = chrono::Utc::now().to_rfc3339();
     let from_display = prev_state.display_name();
     let to_display = new_state.display_name();
-    let bus = crate::daemon::event_bus::global();
-    if bus.is_enabled() {
-        bus.emit(crate::daemon::event_bus::EventKind::MemberStateChanged {
+    crate::daemon::event_bus::global().emit(
+        home,
+        crate::daemon::event_bus::EventKind::MemberStateChanged {
             agent: name.to_string(),
             team: team.name.clone(),
             from_state: from_display.to_string(),
@@ -523,22 +522,8 @@ pub(crate) fn maybe_notify_member_state_change(
             unlock_at: unlock_at.clone(),
             consecutive_count: track.consecutive,
             detected_at,
-        });
-    } else {
-        deliver_member_state_change(
-            home,
-            orch,
-            name,
-            &team.name,
-            from_display,
-            to_display,
-            new_state,
-            pane_tail,
-            unlock_at.as_deref(),
-            track.consecutive,
-            &detected_at,
-        );
-    }
+        },
+    );
     true
 }
 
@@ -622,7 +607,7 @@ fn deliver_member_state_change(
 
 /// #event-bus pattern #9 subscriber: re-deliver a `MemberStateChanged` event via
 /// the shared `deliver_member_state_change`.
-fn handle_event(home: &std::path::Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::MemberStateChanged {
         agent,
         team,
@@ -637,7 +622,7 @@ fn handle_event(home: &std::path::Path, event: &crate::daemon::event_bus::Event)
     } = &event.kind
     {
         deliver_member_state_change(
-            home,
+            &event.home,
             orch,
             agent,
             team,
@@ -653,9 +638,9 @@ fn handle_event(home: &std::path::Path, event: &crate::daemon::event_bus::Event)
 }
 
 /// Register the member-state-change subscriber once at daemon startup (`run_core`).
-/// Dormant unless `AGEND_EVENT_BUS=1` (emit is a no-op when gate-off).
-pub(crate) fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// Home-agnostic — the home travels on each event.
+pub(crate) fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 /// #1530: a reaction-worthy net state change for one agent in one tick.
@@ -2443,23 +2428,25 @@ instances:
         );
 
         let home_bus = mk("bus");
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| super::handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::MemberStateChanged {
-            agent: "worker-a".into(),
-            team: "team-a".into(),
-            from_state: crate::state::AgentState::Ready.display_name().to_string(),
-            to_state: crate::state::AgentState::UsageLimit
-                .display_name()
-                .to_string(),
-            orch: "orch-a".into(),
-            new_state: crate::state::AgentState::UsageLimit,
-            pane_tail: "Usage limit reached. Resets at 15:14 UTC".into(),
-            unlock_at: Some("15:14".into()),
-            consecutive_count: 1,
-            detected_at: detected_at.into(),
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(super::handle_event);
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::MemberStateChanged {
+                agent: "worker-a".into(),
+                team: "team-a".into(),
+                from_state: crate::state::AgentState::Ready.display_name().to_string(),
+                to_state: crate::state::AgentState::UsageLimit
+                    .display_name()
+                    .to_string(),
+                orch: "orch-a".into(),
+                new_state: crate::state::AgentState::UsageLimit,
+                pane_tail: "Usage limit reached. Resets at 15:14 UTC".into(),
+                unlock_at: Some("15:14".into()),
+                consecutive_count: 1,
+                detected_at: detected_at.into(),
+            },
+        );
 
         let legacy = payloads(&home_legacy);
         let via_bus = payloads(&home_bus);

--- a/src/daemon/waiting_on_stale.rs
+++ b/src/daemon/waiting_on_stale.rs
@@ -88,19 +88,15 @@ pub(crate) fn scan_and_emit(
             }
         }
         let elapsed_min = elapsed_secs / 60;
-        // #event-bus pattern #4 (Option A): emit→subscriber when the bus is on,
-        // else the legacy direct deliver. Byte-identical either way (both paths
-        // bottom out in `deliver_stale_alert`).
-        let bus = crate::daemon::event_bus::global();
-        if bus.is_enabled() {
-            bus.emit(crate::daemon::event_bus::EventKind::WaitingOnStale {
+        // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path.
+        crate::daemon::event_bus::global().emit(
+            home,
+            crate::daemon::event_bus::EventKind::WaitingOnStale {
                 agent: agent.to_string(),
                 condition: condition.to_string(),
                 elapsed_min,
-            });
-        } else {
-            deliver_stale_alert(home, agent, condition, elapsed_min);
-        }
+            },
+        );
         last_alerted.insert(agent.to_string(), now);
     }
 }
@@ -136,22 +132,22 @@ fn deliver_stale_alert(home: &Path, agent: &str, condition: &str, elapsed_min: i
 }
 
 /// #event-bus pattern #4: subscriber — rebuild the alert from the event.
-fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::WaitingOnStale {
         agent,
         condition,
         elapsed_min,
     } = &event.kind
     {
-        deliver_stale_alert(home, agent, condition, *elapsed_min);
+        deliver_stale_alert(&event.home, agent, condition, *elapsed_min);
     }
 }
 
-/// #event-bus pattern #4: register the delivery subscriber at daemon startup
-/// (dormant unless `AGEND_EVENT_BUS=1`). Wired beside anti_stall /
-/// decision_timeout / dispatch_idle in `daemon::mod`.
-pub fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// #event-bus pattern #4: register the delivery subscriber at daemon startup.
+/// Home-agnostic — the home travels on each event. Wired beside the other
+/// patterns in `daemon::mod`.
+pub fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 fn emit_to(home: &Path, recipient: &str, kind: &str, text: &str, correlation_agent: Option<&str>) {
@@ -302,14 +298,16 @@ mod tests {
         // Bus emit→subscriber (the gate-ON path) — real fan-out via a test bus.
         let home_bus = tmp_home("parity-bus");
         std::fs::create_dir_all(home_bus.join("inbox")).unwrap();
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::WaitingOnStale {
-            agent: agent.to_string(),
-            condition: condition.to_string(),
-            elapsed_min,
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::WaitingOnStale {
+                agent: agent.to_string(),
+                condition: condition.to_string(),
+                elapsed_min,
+            },
+        );
 
         let legacy = drained_payloads(&home_legacy, agent);
         let viabus = drained_payloads(&home_bus, agent);
@@ -322,15 +320,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(&home_bus);
     }
 
-    /// #event-bus pattern #4 REGRESSION (gate-OFF): with the global bus disabled
-    /// (default test env), the scan still delivers via the legacy path.
+    /// #event-bus Step 2 (legacy-zero): the scan emits to the global bus; the
+    /// registered subscriber delivers to the agent + orchestrator at the event's
+    /// home (this test's home).
     #[test]
-    fn gate_off_scan_delivers_via_legacy() {
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "precondition: the global bus must be gate-off in the test env"
-        );
-        let home = tmp_home("gate-off");
+    fn scan_delivers_via_bus() {
+        let home = tmp_home("via-bus");
         std::fs::create_dir_all(home.join("inbox")).unwrap();
         let since = (chrono::Utc::now() - chrono::Duration::minutes(20)).to_rfc3339();
         write_metadata(&home, "dev-gateoff", "blocker", &since);

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -954,16 +954,15 @@ fn cascade_cancel_children(
 /// the legacy direct `deliver_cascade_cancel`. No double-delivery, no gate-off
 /// regression.
 fn route_cascade_cancel(home: &Path, owner: &str, parent_id: &str, child_id: &str) {
-    let bus = crate::daemon::event_bus::global();
-    if bus.is_enabled() {
-        bus.emit(crate::daemon::event_bus::EventKind::CascadeCancelNotify {
+    // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path.
+    crate::daemon::event_bus::global().emit(
+        home,
+        crate::daemon::event_bus::EventKind::CascadeCancelNotify {
             owner: owner.to_string(),
             parent_id: parent_id.to_string(),
             child_id: child_id.to_string(),
-        });
-    } else {
-        deliver_cascade_cancel(home, owner, parent_id, child_id);
-    }
+        },
+    );
 }
 
 /// Shared deliver: enqueue the parent-cancelled notify to the child's owner.
@@ -987,21 +986,21 @@ fn deliver_cascade_cancel(home: &Path, owner: &str, parent_id: &str, child_id: &
 
 /// #event-bus pattern #7 subscriber: re-deliver a `CascadeCancelNotify` event
 /// via the shared `deliver_cascade_cancel`.
-fn handle_event(home: &Path, event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) {
     if let crate::daemon::event_bus::EventKind::CascadeCancelNotify {
         owner,
         parent_id,
         child_id,
     } = &event.kind
     {
-        deliver_cascade_cancel(home, owner, parent_id, child_id);
+        deliver_cascade_cancel(&event.home, owner, parent_id, child_id);
     }
 }
 
 /// Register the cascade-cancel subscriber once at daemon startup (`run_core`).
-/// Dormant unless `AGEND_EVENT_BUS=1` (emit is a no-op when gate-off).
-pub fn register_subscriber(home: std::path::PathBuf) {
-    crate::daemon::event_bus::global().subscribe(move |e| handle_event(&home, e));
+/// Home-agnostic — the home travels on each event.
+pub fn register_subscriber() {
+    crate::daemon::event_bus::global().subscribe(handle_event);
 }
 
 #[cfg(test)]
@@ -1428,14 +1427,16 @@ mod tests {
         deliver_cascade_cancel(&home_legacy, owner, parent_id, child_id);
 
         let home_bus = tmp_home("p7-parity-bus");
-        let bus = crate::daemon::event_bus::EventBus::new_enabled_for_test();
-        let h = home_bus.clone();
-        bus.subscribe(move |e| handle_event(&h, e));
-        bus.emit(crate::daemon::event_bus::EventKind::CascadeCancelNotify {
-            owner: owner.to_string(),
-            parent_id: parent_id.to_string(),
-            child_id: child_id.to_string(),
-        });
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home_bus,
+            crate::daemon::event_bus::EventKind::CascadeCancelNotify {
+                owner: owner.to_string(),
+                parent_id: parent_id.to_string(),
+                child_id: child_id.to_string(),
+            },
+        );
 
         let legacy = cascade_payloads(&home_legacy, owner);
         let via_bus = cascade_payloads(&home_bus, owner);
@@ -1449,15 +1450,12 @@ mod tests {
         std::fs::remove_dir_all(&home_bus).ok();
     }
 
-    // gate-OFF (default): route_cascade_cancel falls through to the legacy
-    // deliver, so the notify still lands without the bus.
+    // #event-bus Step 2 (legacy-zero): route_cascade_cancel emits to the global
+    // bus; the registered subscriber delivers via deliver_cascade_cancel to the
+    // event's home (this test's home).
     #[test]
-    fn cascade_gate_off_route_delivers_via_legacy() {
-        assert!(
-            !crate::daemon::event_bus::global().is_enabled(),
-            "test must run with AGEND_EVENT_BUS gate off"
-        );
-        let home = tmp_home("p7-gate-off");
+    fn route_cascade_cancel_delivers_via_bus() {
+        let home = tmp_home("p7-via-bus");
         route_cascade_cancel(&home, "fixup-dev", "t-parent-2", "t-child-2");
         let alerts = cascade_payloads(&home, "fixup-dev");
         assert_eq!(alerts.len(), 1, "gate-off must deliver via legacy path");


### PR DESCRIPTION
## What

The end-of-train cutover **Step 2**. Step 1 (#1715) flipped the gate default ON with the legacy direct-enqueue `else` branches kept as a kill-switch; the live-validation cycle passed (post-restart the `dispatch_idle` pattern fired + delivered in prod), so this PR **retires the legacy path** — the event bus is now the *sole* delivery path.

## Changes

- **Remove the 12 patterns' Option-A gate** (`if bus.is_enabled() { emit } else { legacy }`) → `emit` is unconditional.
- **Remove the gate entirely**: `EventBus` has no `enabled` field / `is_enabled()` / env read / `cfg!(test)` default / `new_enabled_for_test`. The bus always delivers.
- **Remove `#![allow(dead_code)]`** + the now-dead `emit_lazy`, and fields the deliver never reads: `CiReady`/`CiFail` `repo`/`branch` (redundant with `correlation_id` = `repo@branch`), `Event.timestamp`, and cron `check_schedules`'s `registry` param (the subscriber owns the registry now).

### home-on-Event (Method A — lead-approved)

With the bus as the sole path, a single globally-registered subscriber must deliver to the correct `$AGEND_HOME`. The home was *captured at registration* (fine for prod's one home, wrong for the multi-home integration tests). So the home now travels **on the `Event`**: `emit(home, kind)` → `Event { home, kind }`; `handle_event(event)` reads `event.home`; `register_subscriber()` is home-agnostic. cron additionally captures the live registry (resolve + inject); the home still comes from the event.

*Rejected alternative:* a test-only "clear-subscribers + per-test re-register + serial" scheme — it reintroduces the flaky-global-mutation pattern #1715 already rejected (AtomicBool-setter).

### Test harness — order-independent, no flake

Because the bus is the only path, an integration test that drives a producer (`emit`→`global()`) needs the subscribers registered. A **`#[ctor] #[cfg(test)]` fn registers them ONCE at test-binary load** — before any `#[test]` — so delivery is **order-independent** (no per-test call, no order-dependent flake). `ctor` is a **test-only `dev-dependency`** — it does NOT ship in the prod binary. Verified stable across repeated `cargo test` runs (3× green).

*Why ctor and not per-test calls:* per-test calls are order-dependent (a delivery test running before any registering test would flake) and "green today, red on some parallel ordering" is the worst kind of latent flake — the same fragility (relying on every test remembering to do the right thing) that Method A was chosen to avoid.

## Rollback

`git revert` of this cutover (no longer an env flag — the gate is gone).

## Tests

- Per-pattern **parity tests** keep proving the deliver path (now on a plain `EventBus::new()` local bus + `emit(home, …)`).
- The former **gate-off tests become end-to-end "delivers via the bus"** integration tests (drive the production fn → `global()` → subscriber → deliver to the event's home).
- The existing scan / `run_ci_check` / `maybe_notify` integration tests now exercise the bus path (via the ctor-registered subscribers).

## Preflight

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -D warnings` ✅ / `--features tray,discord` ✅
- `cargo test --bin agend-terminal --features tray` → **3188 passed, 0 failed**, stable across 3 runs ✅

Rebased onto latest `origin/main` (#1701; clean — its supervisor changes are in a different region). #1463 diff-check: 19 files, **net −100 lines** (legacy removal). This completes the event-bus migration (12/12 patterns + cutover Steps 1 & 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)