### PR TITLE
fix(#1701): P0-escalate a sustained-Hung self-orchestrator (completes #1701)

### DIFF
--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -39,7 +39,7 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
     // teams-file read) BEFORE taking the registry lock, so no file IO runs under
     // the lock (#1530 class). A self-orchestrator crash has no peer to relay an
     // inbox P0, so it escalates straight to the operator (below).
-    let is_self_orch = is_self_orchestrator(home, crashed_name);
+    let is_self_orch = crate::teams::is_self_orchestrator(home, crashed_name);
 
     let (should_respawn, delay, should_notify, fire_self_orch_p0) = {
         let reg = agent::lock_registry(&ctx.registry);
@@ -107,16 +107,6 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
     {
         tracing::warn!(agent = %name_for_err, error = %e, "failed to spawn respawn thread");
     }
-}
-
-/// #1701: is `name` the orchestrator of its own team? A self-orchestrator has
-/// no peer to relay an inbox P0, so its crash/hang escalates straight to the
-/// operator. Mirrors the orch==name guard in
-/// `supervisor::{maybe_notify_member_state_change, notify_orchestrator_retry_exhausted}`.
-fn is_self_orchestrator(home: &Path, name: &str) -> bool {
-    crate::teams::find_team_for(home, name)
-        .and_then(|t| t.orchestrator)
-        .is_some_and(|orch| orch == name)
 }
 
 /// #1701: self-orchestrator-crash P0 — distinct from the generic [`notify_crash`]
@@ -279,44 +269,5 @@ fn respawn_agent_worker(
         Err(e) => {
             tracing::warn!(agent = %config.name, error = %e, "respawn failed");
         }
-    }
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use super::is_self_orchestrator;
-
-    /// #1701 ③: self-orch detection — the gate that routes a crash to the
-    /// self-orch P0 (`fire_self_orch_p0 = is_self_orch && ...`). A regular
-    /// member is NOT its own orchestrator → the `&&` short-circuits → it keeps
-    /// the generic recent>=2 crash notify, never the self-orch P0. An agent that
-    /// IS its team's orchestrator → true. No team / no orchestrator → false.
-    #[test]
-    fn is_self_orchestrator_only_true_for_own_orchestrator_1701() {
-        let home = std::env::temp_dir().join(format!("agend-1701-selforch-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&home);
-        std::fs::create_dir_all(&home).unwrap();
-
-        // team "t": orchestrator=lead, member=dev.
-        crate::teams::create(
-            &home,
-            &serde_json::json!({"name": "t", "members": ["lead", "dev"], "orchestrator": "lead"}),
-        );
-
-        assert!(
-            is_self_orchestrator(&home, "lead"),
-            "the team orchestrator IS its own orchestrator"
-        );
-        assert!(
-            !is_self_orchestrator(&home, "dev"),
-            "a regular member is NOT its own orchestrator → keeps generic crash notify"
-        );
-        assert!(
-            !is_self_orchestrator(&home, "unknown"),
-            "an agent in no team is not a self-orchestrator"
-        );
-
-        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/src/daemon/per_tick/hang_detection.rs
+++ b/src/daemon/per_tick/hang_detection.rs
@@ -40,35 +40,112 @@ impl PerTickHandler for HangDetectionHandler {
         // ThreadDumpHandler can surface "hang_detection wedged" if this
         // handler ever blocks the main loop (the H1 hypothesis from
         // #932 RCA).
-        let reg = agent::lock_registry_tracked(ctx.registry, "hang_detection");
-        for handle in reg.values() {
-            let name = handle.name.as_str();
-            let mut core = handle.core.lock();
-            core.health.maybe_decay();
-            let agent_state = core.state.current;
-            let silent = core.state.last_output.elapsed();
-            // F9 (#685 sub-task 4): productive-silence reads the new
-            // `last_productive_output` field which is bumped only when
-            // `infer_productivity` returns a Productive signal. Default
-            // shadow-mode in `check_hang` gates classification on
-            // `AGEND_PRODUCTIVE_GATE=1`.
-            let silent_productive = core.state.last_productive_output.elapsed();
-            let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
-            if core.health.check_hang(
-                agent_state,
-                silent,
-                silent_productive,
-                pair.last_input_at_ms,
-                pair.heartbeat_at_ms,
-            ) {
-                tracing::warn!(
-                    agent = %name,
-                    state = agent_state.display_name(),
-                    silent = ?silent,
-                    "hang detected"
-                );
+        // Phase 1 (under the registry lock): decay + classify hangs, and collect
+        // the names currently in Hung. NO teams-file read here — that runs
+        // lock-free in phase 2 (#1530 / DAEMON-LOCK-ORDERING: no file IO under
+        // the registry lock).
+        let hung_now: Vec<String> = {
+            let reg = agent::lock_registry_tracked(ctx.registry, "hang_detection");
+            let mut hung = Vec::new();
+            for handle in reg.values() {
+                let name = handle.name.as_str();
+                let mut core = handle.core.lock();
+                core.health.maybe_decay();
+                let agent_state = core.state.current;
+                let silent = core.state.last_output.elapsed();
+                // F9 (#685 sub-task 4): productive-silence reads the new
+                // `last_productive_output` field which is bumped only when
+                // `infer_productivity` returns a Productive signal. Default
+                // shadow-mode in `check_hang` gates classification on
+                // `AGEND_PRODUCTIVE_GATE=1`.
+                let silent_productive = core.state.last_productive_output.elapsed();
+                let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
+                if core.health.check_hang(
+                    agent_state,
+                    silent,
+                    silent_productive,
+                    pair.last_input_at_ms,
+                    pair.heartbeat_at_ms,
+                ) {
+                    tracing::warn!(
+                        agent = %name,
+                        state = agent_state.display_name(),
+                        silent = ?silent,
+                        "hang detected"
+                    );
+                }
+                if core.health.state == crate::health::HealthState::Hung {
+                    hung.push(name.to_string());
+                }
+            }
+            hung
+        };
+
+        // Phase 2/3 (#1701 Hung half): a self-orchestrator stuck Hung past the
+        // confirm-window has no peer to relay — escalate operator P0, INDEPENDENT
+        // of `hang_auto_recovery_enabled` (a leaderless team must page even in
+        // recovery shadow mode). `is_self_orchestrator` is a teams-file read (done
+        // lock-free); the confirm-window + cooldown gate (`hung_escalation_due`)
+        // then runs under a brief per-candidate re-lock and stamps, so a
+        // persisting Hung pages at most once per cooldown. Self-orch Hung is rare,
+        // so the re-lock cost is negligible.
+        for name in hung_now {
+            if !crate::teams::is_self_orchestrator(ctx.home, &name) {
+                continue;
+            }
+            let due = {
+                let reg = agent::lock_registry(ctx.registry);
+                reg.values()
+                    .find(|h| h.name.as_str() == name)
+                    .map(|h| {
+                        h.core
+                            .lock()
+                            .health
+                            .hung_escalation_due(HUNG_ESCALATE_AFTER)
+                    })
+                    .unwrap_or(false)
+            };
+            if due {
+                notify_self_orch_hung(&name);
             }
         }
+    }
+}
+
+/// #1701: how long a self-orchestrator must stay Hung before its hang escalates
+/// to the operator — a confirm-window FP-filter on top of `check_hang`'s
+/// Hung/IdleLong split (which already excludes the 04:00 idle false-alarm). 60s
+/// is conservative: a real hang pages within a minute (orchestrator recovery is
+/// not millisecond-critical), while transient residual FPs (F39 stale-Thinking
+/// scrollback, F10 1-byte-output exit, E1 keystroke-draining) don't survive it.
+/// TODO: revisit if #685 enables the F9 productive-path by default (it shifts
+/// Hung sensitivity) — see docs/HUNG-STATE-TRANSITIONS.md.
+const HUNG_ESCALATE_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// #1701: page the operator that a self-orchestrator is hung. Mirrors
+/// `crash_respawn::notify_self_orch_crash` — same `gated_notify(Error)`
+/// Sleep-penetrating path (#1595/#1717). Channel + name only (no registry).
+fn notify_self_orch_hung(name: &str) {
+    tracing::warn!(
+        agent = %name,
+        "#1701: self-orchestrator hung past confirm-window — escalating P0 to operator"
+    );
+    let msg = format!(
+        "🛑 {name} (team orchestrator) has been HUNG ≥{}s — no peer can relay this and \
+         the team is stalled until it recovers. Manual intervention likely (check the \
+         pane / interrupt / re-prime).",
+        HUNG_ESCALATE_AFTER.as_secs()
+    );
+    if let Some(ch) = crate::channel::active_channel() {
+        let _ = crate::channel::gated_notify(
+            ch.as_ref(),
+            name,
+            crate::channel::NotifySeverity::Error,
+            &msg,
+            false,
+        );
+    } else {
+        tracing::debug!(agent = %name, "no active channel for self-orch hung P0");
     }
 }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -329,6 +329,12 @@ pub struct HealthTracker {
     pub total_crashes: u32,
     max_retries: u32,
     pub last_notification: Option<Instant>,
+    /// #1701: when the agent most recently transitioned INTO `HealthState::Hung`
+    /// (set in `check_hang`'s two Hung-entry branches). Drives the self-orch Hung
+    /// escalation confirm-window. Every Hung entry refreshes it and the
+    /// escalation check gates on `state == Hung`, so a stale value from a prior
+    /// episode is never read — no explicit clear-on-exit needed.
+    hung_since: Option<Instant>,
     error_events: VecDeque<(Instant, AgentState)>,
     pub last_output: Instant,
     pub current_reason: Option<BlockedReason>,
@@ -389,6 +395,7 @@ impl HealthTracker {
             total_crashes: 0,
             max_retries: DEFAULT_MAX_RETRIES,
             last_notification: None,
+            hung_since: None,
             error_events: VecDeque::new(),
             last_output: Instant::now(),
             current_reason: None,
@@ -510,6 +517,32 @@ impl HealthTracker {
     /// established the agent is its own team orchestrator.
     pub fn self_orch_crash_should_notify(&mut self) -> bool {
         if self.should_notify() {
+            self.last_notification = Some(Instant::now());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// #1701 (Hung half): should a self-orchestrator's sustained Hung escalate to
+    /// the operator? True only when the agent is CURRENTLY Hung AND has been so
+    /// for at least `confirm_window` (the FP-filter — the Hung/IdleLong split in
+    /// `check_hang` already excludes the 04:00 idle false-alarm; this window
+    /// additionally rides out the documented transient residual FPs F39/F10/
+    /// keystroke-draining so a real page is not fired on a 1-tick blip) AND the
+    /// per-agent notify cooldown (reused from the crash path) has elapsed. Stamps
+    /// the cooldown on fire so a persisting Hung pages at most once per
+    /// `NOTIFY_COOLDOWN`. Caller must already have established the agent is its
+    /// own team orchestrator. Independent of `hang_auto_recovery_enabled` — a
+    /// leaderless team with no peer to relay must page even in recovery shadow.
+    pub fn hung_escalation_due(&mut self, confirm_window: Duration) -> bool {
+        if self.state != HealthState::Hung {
+            return false;
+        }
+        let sustained = self
+            .hung_since
+            .is_some_and(|t| t.elapsed() >= confirm_window);
+        if sustained && self.should_notify() {
             self.last_notification = Some(Instant::now());
             true
         } else {
@@ -676,6 +709,7 @@ impl HealthTracker {
             // See docs/HUNG-STATE-TRANSITIONS.md §Entry.E1
             if self.state != HealthState::Hung {
                 self.state = HealthState::Hung;
+                self.hung_since = Some(Instant::now()); // #1701: confirm-window anchor
                 return true; // First hang detection — caller escalates
             }
             return false;
@@ -714,6 +748,7 @@ impl HealthTracker {
             // See docs/HUNG-STATE-TRANSITIONS.md §Entry.E2
             if self.state != HealthState::Hung {
                 self.state = HealthState::Hung;
+                self.hung_since = Some(Instant::now()); // #1701: confirm-window anchor
                 return true;
             }
             return false;
@@ -910,6 +945,51 @@ mod tests {
         assert!(
             !notify,
             "#1701: a non-orchestrator's first crash stays silent"
+        );
+    }
+
+    /// #1701 Hung ① + ⑤: a self-orchestrator Hung past the confirm-window
+    /// escalates, and the cooldown blocks an immediate re-page while it persists.
+    #[test]
+    fn hung_escalation_fires_after_window_then_cooldown_blocks_1701() {
+        let window = Duration::from_secs(60);
+        let mut h = HealthTracker::new();
+        h.state = HealthState::Hung;
+        h.hung_since = Some(Instant::now() - Duration::from_secs(61)); // sustained > window
+        assert!(
+            h.hung_escalation_due(window),
+            "#1701: Hung sustained past the confirm-window must escalate"
+        );
+        assert!(
+            !h.hung_escalation_due(window),
+            "#1701: re-page within NOTIFY_COOLDOWN must be suppressed"
+        );
+    }
+
+    /// #1701 Hung ②: a transient Hung (under the confirm-window) does NOT escalate
+    /// — this is the FP filter (F39/F10/keystroke-draining blips).
+    #[test]
+    fn hung_escalation_not_due_within_window_1701() {
+        let mut h = HealthTracker::new();
+        h.state = HealthState::Hung;
+        h.hung_since = Some(Instant::now()); // just entered, 0 elapsed
+        assert!(
+            !h.hung_escalation_due(Duration::from_secs(60)),
+            "#1701: Hung shorter than the confirm-window must NOT escalate"
+        );
+    }
+
+    /// #1701 Hung ③: a non-Hung state (e.g. IdleLong — the 04:00 idle false-alarm
+    /// the Hung/IdleLong split already excludes) never escalates, even if a stale
+    /// `hung_since` lingers.
+    #[test]
+    fn hung_escalation_not_due_when_not_hung_1701() {
+        let mut h = HealthTracker::new();
+        h.state = HealthState::IdleLong;
+        h.hung_since = Some(Instant::now() - Duration::from_secs(300));
+        assert!(
+            !h.hung_escalation_due(Duration::from_secs(60)),
+            "#1701: only HealthState::Hung escalates (IdleLong is the 348-FP case)"
         );
     }
 

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -97,6 +97,17 @@ pub fn find_team_for(home: &Path, member: &str) -> Option<Team> {
         .map(|(name, cfg)| project_team(name, cfg))
 }
 
+/// #1701: is `member` the orchestrator of its own team? A self-orchestrator has
+/// no peer to relay an inbox P0, so its crash/hang escalates straight to the
+/// operator (see `daemon::crash_respawn` for crash, `daemon::per_tick::hang_detection`
+/// for hang). Mirrors the `orch == name` guard in
+/// `supervisor::{maybe_notify_member_state_change, notify_orchestrator_retry_exhausted}`.
+pub fn is_self_orchestrator(home: &Path, member: &str) -> bool {
+    find_team_for(home, member)
+        .and_then(|t| t.orchestrator)
+        .is_some_and(|orch| orch == member)
+}
+
 pub fn create(home: &Path, args: &Value) -> Value {
     let name = match args["name"].as_str() {
         Some(n) => n.to_string(),
@@ -508,6 +519,32 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    /// #1701: self-orch detection — the gate that routes a crash/hang to the
+    /// self-orch P0. The orchestrator IS its own orchestrator → true; a regular
+    /// member → false (keeps the generic path, never the self-orch P0); an agent
+    /// in no team → false.
+    #[test]
+    fn is_self_orchestrator_only_true_for_own_orchestrator_1701() {
+        let home = tmp_home("self-orch");
+        create(
+            &home,
+            &serde_json::json!({"name": "t", "members": ["lead", "dev"], "orchestrator": "lead"}),
+        );
+        assert!(
+            is_self_orchestrator(&home, "lead"),
+            "the team orchestrator IS its own orchestrator"
+        );
+        assert!(
+            !is_self_orchestrator(&home, "dev"),
+            "a regular member is NOT its own orchestrator"
+        );
+        assert!(
+            !is_self_orchestrator(&home, "unknown"),
+            "an agent in no team is not a self-orchestrator"
+        );
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]


### PR DESCRIPTION
## What

Completes **#1701** — the crash half (#1717) escalated a self-orchestrator *crash*; this does the *Hung* half. A team orchestrator stuck Hung has no peer to relay an inbox P0, so the operator must be paged — **independent of `hang_auto_recovery_enabled`** (a leaderless team pages even while auto-recovery is shadow).

## The 348-FP (why #1595 deferred Hung) and how this guards it

- **Already excluded** by `check_hang`'s Hung/IdleLong split: Hung requires *input-pending-no-response* (E1) OR *heartbeat-fresh-but-PTY-silent* (E2); a merely-idle agent → IdleLong → no escalation. That's the 04:00-UTC idle false-alarm, structurally out.
- **Plus a 60s confirm-window**: a real page is never fired on a 1-tick blip — it rides out the documented transient residual FPs (F39 stale-Thinking scrollback, F10 1-byte-output exit, E1 keystroke-draining). A real hang pages within a minute (orchestrator recovery isn't millisecond-critical). `HUNG_ESCALATE_AFTER = 60s` const with a TODO to revisit if #685 flips the F9 productive-path.

## How

- **`teams::is_self_orchestrator`** — promoted from crash_respawn (#1717) to its natural home; shared by the crash + hang paths (test moved with it).
- **`health`**: `hung_since` anchor (set in both `check_hang` Hung-entry branches; every entry refreshes it and escalation gates on `state == Hung`, so a stale value is never read — no clear-on-exit needed) + `hung_escalation_due` (`state==Hung && sustained ≥ confirm_window && NOTIFY_COOLDOWN elapsed`; stamps on fire, reusing the crash path's per-agent cooldown).
- **`hang_detection`**: phase 1 collects Hung names under the registry lock (no teams-file IO under lock, #1530); phase 2/3 — lock-free `is_self_orchestrator`, then a brief per-candidate re-lock to gate+stamp, then `gated_notify(Error)` (Sleep-penetrating, like #1595/#1717).

## Tests (lead's matrix)

① self-orch Hung ≥60s → escalates + ⑤ cooldown blocks re-page; ② Hung <60s → suppressed (FP filter); ③ non-Hung (IdleLong) → never (348-FP); ④ self-orch detection (orch→true / member→false / no-team→false, in teams).

## Gate

- `cargo test` full bin suite **3192 passed**; `clippy --all-targets` (tray **and** tray,discord) clean; `fmt --check` clean. #1463 diff = 4 files.
- Did NOT touch `hang_auto_recovery_enabled` or the recovery_dispatcher. Rebased onto current main (kept clear of #1718's badge files).

**Review: codex MED+ adversarial** — key things to break: does the confirm-window/`hung_since` mechanism actually filter the transient residual FPs *and* not drop a real sustained Hung? Is the 2-phase lock dance free of the file-IO-under-lock / re-lock-races class?

Closes #1701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
