### PR TITLE
feat(#1705): repo-level batch ci_watch poll (N→1 GitHub API calls/tick)

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -2,7 +2,9 @@ use crate::agent::{self, AgentRegistry};
 use std::path::Path;
 use std::sync::Arc;
 
-use super::provider::{CiJob, CiPollResult, CiProvider, CiRun, MergeableState, PrState};
+use super::provider::{
+    CiJob, CiPollResult, CiProvider, CiRun, MergeableState, PrState, RepoPollResult,
+};
 
 type PerKeySlot = Arc<tokio::sync::Mutex<Option<CiPollResult>>>;
 type TickCache = Arc<std::sync::Mutex<std::collections::HashMap<(String, String), PerKeySlot>>>;
@@ -50,7 +52,9 @@ impl CiProvider for CachedCiProvider {
     }
 }
 use super::registry::{ci_watches_dir, flush_watch_state, remove_watch};
-use super::sweep::{bump_consecutive_skips_and_maybe_notify, clear_stall_state};
+use super::sweep::{
+    bump_repo_stall_and_maybe_notify, clear_repo_stall_and_maybe_resume, clear_stall_state,
+};
 use super::watch_state::WatchState;
 use super::WATCH_TTL_HOURS;
 
@@ -242,7 +246,7 @@ enum SkipReason {
     Invalid,
     Expired,
     InactivityTtl,
-    RateLimited { reset_epoch: u64 },
+    RateLimited,
     NotDue,
 }
 
@@ -281,7 +285,7 @@ fn prepare_poll_context(
     }
     if let Some(reset_epoch) = watch.rate_limit_until {
         if (now_utc.timestamp() as u64) < reset_epoch {
-            return Err(SkipReason::RateLimited { reset_epoch });
+            return Err(SkipReason::RateLimited);
         }
     }
     let effective_interval = adaptive_interval(
@@ -303,6 +307,99 @@ fn prepare_poll_context(
 }
 
 /// Inner implementation that accepts a provider factory for testability.
+/// #1705 testable seam: one repo-level batch poll → pre-populate the per-tick
+/// cache so the subsequent per-watch `ci_check_repo` calls hit the cache instead
+/// of each issuing a per-branch GitHub request.
+///
+/// - `Runs`: clear the per-repo stall, group rows by head_branch, prefill the
+///   cache slot for every watch whose expected `head_sha` is present in the batch
+///   slice. A watch whose branch/sha is absent (pushed off the per_page=100 page)
+///   is left unprefilled → `CachedCiProvider` miss → automatic per-branch fallback.
+///   Returns `true` (proceed to fan-out).
+/// - `ApiError`: rate-limit is a repo property → bump the per-repo stall ONCE and
+///   back off every watch (`rate_limit_until`). Returns `false` (skip fan-out).
+/// - `None` (provider has no batch support) / `Err` (transient): no prefill,
+///   returns `true` → fan-out falls back to per-branch polling.
+async fn batch_prefill_repo(
+    home: &Path,
+    repo: &str,
+    watches: &[(std::path::PathBuf, PollContext)],
+    tick_cache: &TickCache,
+    provider: &dyn CiProvider,
+    subscribers: &[String],
+    display_timezone: Option<&str>,
+) -> bool {
+    match provider.poll_repo_runs(repo).await {
+        Some(Ok(RepoPollResult::Runs {
+            rows,
+            rate_limit_remaining,
+            rate_limit_limit,
+        })) => {
+            clear_repo_stall_and_maybe_resume(home, repo, subscribers);
+            let mut by_branch: std::collections::HashMap<String, Vec<CiRun>> =
+                std::collections::HashMap::new();
+            for row in rows {
+                by_branch.entry(row.head_branch).or_default().push(row.run);
+            }
+            if let Ok(mut cache) = tick_cache.lock() {
+                for (_, ctx) in watches {
+                    let branch = &ctx.stamped_watch.branch;
+                    let slice = match by_branch.get(branch) {
+                        Some(s) => s,
+                        None => continue,
+                    };
+                    if let Some(expected) = &ctx.stamped_watch.head_sha {
+                        if !slice.iter().any(|r| &r.head_sha == expected) {
+                            continue; // expected head_sha not in batch → fallback
+                        }
+                    }
+                    cache.insert(
+                        (repo.to_string(), branch.clone()),
+                        Arc::new(tokio::sync::Mutex::new(Some(CiPollResult::Runs {
+                            runs: slice.clone(),
+                            rate_limit_remaining,
+                            rate_limit_limit,
+                        }))),
+                    );
+                }
+            }
+            true
+        }
+        Some(Ok(RepoPollResult::ApiError {
+            message,
+            rate_limit_reset,
+            ..
+        })) => {
+            bump_repo_stall_and_maybe_notify(
+                home,
+                repo,
+                subscribers,
+                rate_limit_reset,
+                display_timezone,
+            );
+            if let Some(reset) = rate_limit_reset {
+                for (path, ctx) in watches {
+                    let mut w = ctx.stamped_watch.clone();
+                    w.rate_limit_until = Some(reset);
+                    let _ = crate::store::atomic_write(
+                        path,
+                        serde_json::to_string_pretty(&w)
+                            .unwrap_or_default()
+                            .as_bytes(),
+                    );
+                }
+            }
+            tracing::warn!(repo = %repo, message = %message, "CI batch poll API error; repo backing off");
+            false
+        }
+        Some(Err(e)) => {
+            tracing::warn!(repo = %repo, error = %e, "CI batch poll failed; falling back to per-branch");
+            true
+        }
+        None => true, // provider doesn't support batch → per-branch fallback
+    }
+}
+
 pub(super) fn check_ci_watches_with_provider(
     home: &Path,
     registry: &AgentRegistry,
@@ -317,6 +414,13 @@ pub(super) fn check_ci_watches_with_provider(
         crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
             .ok()
             .and_then(|c| c.display_timezone);
+    // #1705 PASS 1: collect poll-eligible watches grouped by repo. TTL-expired →
+    // remove; RateLimited → SILENT skip (the repo-level batch poll owns stall
+    // notification now — a watch's rate_limit_until is set by the batch ApiError
+    // arm below, or by a per-branch fallback ApiError, so it backs off without
+    // emitting a per-watch [ci-watch-stalled]).
+    let mut by_repo: std::collections::HashMap<String, Vec<(std::path::PathBuf, PollContext)>> =
+        std::collections::HashMap::new();
     for entry in entries.flatten() {
         let path = entry.path();
         let watch: WatchState = match std::fs::read_to_string(&path)
@@ -336,39 +440,10 @@ pub(super) fn check_ci_watches_with_provider(
                         .unwrap_or_default()
                         .as_bytes(),
                 );
-                let provider: Box<dyn CiProvider> = match make_provider(&watch) {
-                    Some(p) => Box::new(CachedCiProvider {
-                        inner: p,
-                        poll_cache: Arc::clone(&tick_cache),
-                    }),
-                    None => {
-                        tracing::warn!(repo = %ctx.repo, "ci_check: failed to build CI provider");
-                        continue;
-                    }
-                };
-                let home = home.to_path_buf();
-                let watch_path = path.clone();
-                let registry = Arc::clone(registry);
-                let PollContext {
-                    repo,
-                    subscribers,
-                    stamped_watch,
-                } = ctx;
-                // fire-and-forget: ci_check is one-shot per poll cycle
-                shared_ci_runtime().spawn(async move {
-                    if let Err(e) = ci_check_repo(
-                        &home,
-                        &watch_path,
-                        stamped_watch,
-                        subscribers,
-                        &registry,
-                        provider.as_ref(),
-                    )
-                    .await
-                    {
-                        tracing::warn!(repo = %repo, error = %e, "CI check failed");
-                    }
-                });
+                by_repo
+                    .entry(ctx.repo.clone())
+                    .or_default()
+                    .push((path, ctx));
             }
             Err(SkipReason::Expired) => {
                 let a = watch.subscriber_names().join(",");
@@ -387,19 +462,86 @@ pub(super) fn check_ci_watches_with_provider(
                 );
                 tracing::info!(repo = %watch.repo, branch = %watch.branch, subscribers = %a, hours = WATCH_TTL_HOURS, reason = "inactivity_ttl", "CI watch removed: inactivity TTL");
             }
-            Err(SkipReason::RateLimited { reset_epoch }) => {
-                bump_consecutive_skips_and_maybe_notify(
-                    home,
-                    &path,
-                    &watch.repo,
-                    &watch.branch,
-                    &watch.subscriber_names(),
-                    reset_epoch,
-                    display_timezone.as_deref(),
-                );
-            }
+            // #1705: per-watch rate-limit backoff is now a silent skip.
+            Err(SkipReason::RateLimited) => {}
             Err(SkipReason::NotDue | SkipReason::Invalid) => {}
         }
+    }
+
+    // #1705 PASS 2: ONE batch poll per repo (1 GitHub API call instead of N),
+    // pre-populate the per-tick cache from the batch, then fan out to per-watch
+    // ci_check_repo (each hits the prefilled cache, or misses → per-branch fallback).
+    let make_provider = std::sync::Arc::new(make_provider);
+    for (repo, watches) in by_repo {
+        // Union of subscribers across the repo's watches — recipients of the
+        // single repo-level stalled/resumed health event.
+        let mut subs_union: Vec<String> = Vec::new();
+        for (_, ctx) in &watches {
+            for s in &ctx.subscribers {
+                if !subs_union.contains(s) {
+                    subs_union.push(s.clone());
+                }
+            }
+        }
+        let home_buf = home.to_path_buf();
+        let registry = Arc::clone(registry);
+        let tick_cache = Arc::clone(&tick_cache);
+        let make_provider = Arc::clone(&make_provider);
+        let display_timezone = display_timezone.clone();
+        // fire-and-forget: one batch-poll-then-fan-out task per repo per poll cycle
+        shared_ci_runtime().spawn(async move {
+            // Batch poll once for the whole repo, pre-populating the per-tick cache.
+            // None provider → no prefill (per-branch fallback). Returns false on a
+            // repo-level ApiError (backing off) → skip the fan-out this tick.
+            let proceed = match make_provider(&watches[0].1.stamped_watch) {
+                Some(p) => {
+                    batch_prefill_repo(
+                        &home_buf,
+                        &repo,
+                        &watches,
+                        &tick_cache,
+                        p.as_ref(),
+                        &subs_union,
+                        display_timezone.as_deref(),
+                    )
+                    .await
+                }
+                None => true, // no provider → per-branch fallback in fan-out
+            };
+            if !proceed {
+                return;
+            }
+            // Fan out: per-watch ci_check_repo. Cache hit → no HTTP; miss → per-branch.
+            for (path, ctx) in watches {
+                let provider: Box<dyn CiProvider> = match make_provider(&ctx.stamped_watch) {
+                    Some(p) => Box::new(CachedCiProvider {
+                        inner: p,
+                        poll_cache: Arc::clone(&tick_cache),
+                    }),
+                    None => {
+                        tracing::warn!(repo = %ctx.repo, "ci_check: failed to build CI provider");
+                        continue;
+                    }
+                };
+                let PollContext {
+                    repo: r,
+                    subscribers,
+                    stamped_watch,
+                } = ctx;
+                if let Err(e) = ci_check_repo(
+                    &home_buf,
+                    &path,
+                    stamped_watch,
+                    subscribers,
+                    &registry,
+                    provider.as_ref(),
+                )
+                .await
+                {
+                    tracing::warn!(repo = %r, error = %e, "CI check failed");
+                }
+            }
+        });
     }
 }
 

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -306,6 +306,39 @@ fn prepare_poll_context(
     })
 }
 
+/// #1705 (codex REJECT fix): on a repo-level batch ApiError, the rate-limit backoff
+/// must cover EVERY watch of the repo — including watches that
+/// `prepare_poll_context` skipped this tick (NotDue / already RateLimited) and so
+/// never entered the `by_repo` eligible slice. Re-enumerate the repo's watch files
+/// on disk and stamp `rate_limit_until` on each, so a later-due watch honours the
+/// repo-wide stall instead of polling per-branch. ApiError is rare (rate-limit), so
+/// the dir scan here is acceptable. Non-watch files (e.g. `.stall` sidecars) fail
+/// the `WatchState` parse and are skipped.
+fn stamp_repo_backoff(home: &Path, repo: &str, reset_epoch: u64) {
+    let Ok(entries) = std::fs::read_dir(ci_watches_dir(home)) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(mut watch) = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<WatchState>(&c).ok())
+        else {
+            continue;
+        };
+        if watch.repo != repo {
+            continue;
+        }
+        watch.rate_limit_until = Some(reset_epoch);
+        let _ = crate::store::atomic_write(
+            &path,
+            serde_json::to_string_pretty(&watch)
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+    }
+}
+
 /// Inner implementation that accepts a provider factory for testability.
 /// #1705 testable seam: one repo-level batch poll → pre-populate the per-tick
 /// cache so the subsequent per-watch `ci_check_repo` calls hit the cache instead
@@ -378,16 +411,14 @@ async fn batch_prefill_repo(
                 display_timezone,
             );
             if let Some(reset) = rate_limit_reset {
-                for (path, ctx) in watches {
-                    let mut w = ctx.stamped_watch.clone();
-                    w.rate_limit_until = Some(reset);
-                    let _ = crate::store::atomic_write(
-                        path,
-                        serde_json::to_string_pretty(&w)
-                            .unwrap_or_default()
-                            .as_bytes(),
-                    );
-                }
+                // Stamp EVERY watch of the repo — not just the eligible `watches`
+                // slice. `by_repo` only holds watches that passed
+                // `prepare_poll_context`; NotDue / already-RateLimited watches were
+                // skipped and never entered the slice. If they don't get the repo
+                // backoff stamp, they wake when due and poll per-branch in defiance
+                // of the repo-wide stall — re-introducing the per-branch API calls
+                // #1705 removes. (codex REJECT fix.)
+                stamp_repo_backoff(home, repo, reset);
             }
             tracing::warn!(repo = %repo, message = %message, "CI batch poll API error; repo backing off");
             false

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -3408,6 +3408,73 @@ fn batch_apierror_backs_off_repo_and_skips_fan_out() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+#[test]
+fn batch_apierror_backs_off_all_repo_watches_including_skipped() {
+    // codex REJECT regression: the repo backoff must cover watches that
+    // prepare_poll_context skipped this tick (NotDue / RateLimited) and never
+    // entered the eligible `watches` slice. feat-a is in the slice; feat-b exists
+    // on disk but is NOT in the slice (simulating a NotDue skip). Both must get
+    // rate_limit_until so feat-b honours the repo-wide stall instead of waking up
+    // and polling per-branch.
+    let home = p05_temp_home("p1705_apierr_repowide");
+    let reset = (chrono::Utc::now().timestamp() as u64) + 3600;
+    let path_a = p05_write_watch(
+        &home,
+        "o/r",
+        "feat-a",
+        serde_json::json!({
+            "repo": "o/r", "branch": "feat-a", "head_sha": "aaa",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-01-01T00:00:00Z"}],
+        }),
+    );
+    let path_b = p05_write_watch(
+        &home,
+        "o/r",
+        "feat-b",
+        serde_json::json!({
+            "repo": "o/r", "branch": "feat-b", "head_sha": "bbb",
+            "subscribers": [{"instance": "lead", "subscribed_at": "2026-01-01T00:00:00Z"}],
+        }),
+    );
+    // Only feat-a is in the eligible slice handed to batch_prefill_repo.
+    let watch_a: WatchState =
+        serde_json::from_str(&std::fs::read_to_string(&path_a).unwrap()).unwrap();
+    let watches = vec![(
+        path_a.clone(),
+        super::PollContext {
+            repo: "o/r".to_string(),
+            subscribers: vec!["lead".to_string()],
+            stamped_watch: watch_a,
+        },
+    )];
+    let provider = BatchErrProvider { reset: Some(reset) };
+    let cache = new_tick_cache();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let proceed = rt.block_on(async {
+        super::batch_prefill_repo(
+            &home,
+            "o/r",
+            &watches,
+            &cache,
+            &provider,
+            &["lead".to_string()],
+            None,
+        )
+        .await
+    });
+    assert!(!proceed, "ApiError must skip the fan-out");
+    for (label, path) in [("eligible feat-a", &path_a), ("skipped feat-b", &path_b)] {
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(
+            v["rate_limit_until"].as_u64(),
+            Some(reset),
+            "{label} must receive the repo-wide backoff stamp"
+        );
+    }
+    std::fs::remove_dir_all(&home).ok();
+}
+
 // ── Sprint 54 Hotfix F gap: malformed GitHub head query ─────────────
 //
 // Per RCA m-46: `check_pr_terminal` was sending bare `head=feat/foo`

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -2981,17 +2981,17 @@ fn parse_subscribers_empty_when_no_data() {
 }
 
 // -----------------------------------------------------------------
-// Sprint 54 P0-5 (sub-scope B) — consecutive_skips tracking +
-// stalled/resumed inbox fan-out. Each test pins one of the four
-// contract gates from dispatch m-20260507045729197032-16.
+// #1705 — REPO-LEVEL rate-limit stall tracking (replaces the
+// Sprint 54 P0-5 per-watch consecutive_skips path). With the batch
+// poll, a rate-limit is a repo property: one repo-level
+// [ci-watch-stalled]/[resumed] pair, tracked in a <repo-slug>.stall
+// sidecar (survives a single watch being auto-cleared by #931).
 //
 // EMPIRICAL REGRESSION-PROOF ANCHOR: if the
-// `if next_skips >= STALL_THRESHOLD && !already_notified` guard
-// in `bump_consecutive_skips_and_maybe_notify` is dropped, the
-// "fires exactly once" assertion in
-// `stalled_event_fires_exactly_once_at_threshold` fails because
-// every subsequent skip would re-enqueue. PR description carries
-// the captured FAIL signature.
+// `consecutive_skips >= STALL_THRESHOLD && stalled_since_ms.is_none()`
+// guard in `bump_repo_stall_and_maybe_notify` is dropped, the "fires
+// exactly once" assertion in `repo_stall_fires_one_event_at_threshold`
+// fails because every subsequent bump would re-enqueue.
 // -----------------------------------------------------------------
 
 fn p05_temp_home(tag: &str) -> std::path::PathBuf {
@@ -3021,74 +3021,53 @@ fn p05_read_inbox_lines(home: &Path, instance: &str) -> Vec<String> {
         .collect()
 }
 
-#[test]
-fn consecutive_skips_increments_on_rate_limited_skip() {
-    // Gate 1: each rate-limited skip bumps the counter atomically.
-    let home = p05_temp_home("p05_skip_inc");
-    let watch = serde_json::json!({
-        "repo": "o/r",
-        "branch": "feat",
-        "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-07T00:00:00Z"}],
-        "consecutive_skips": 0,
-    });
-    let path = p05_write_watch(&home, "o/r", "feat", watch);
-    let subscribers = vec!["lead".to_string()];
+// #1705 sidecar reader — the repo stall state lives at
+// `ci-watches/<repo-slug>.stall`.
+fn p05_read_repo_stall(home: &Path, repo_slug: &str) -> serde_json::Value {
+    let path = ci_watches_dir(home).join(format!("{repo_slug}.stall"));
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or(serde_json::Value::Null)
+}
 
+#[test]
+fn repo_stall_increments_and_holds_below_threshold() {
+    // Pin ④a: each batch ApiError bumps the per-repo counter; below
+    // STALL_THRESHOLD no notification fires.
+    let home = p05_temp_home("p1705_skip_inc");
+    let subscribers = vec!["lead".to_string()];
     let future_reset = (chrono::Utc::now().timestamp() as u64) + 3600;
-    bump_consecutive_skips_and_maybe_notify(
-        &home,
-        &path,
-        "o/r",
-        "feat",
-        &subscribers,
-        future_reset,
-        None,
+
+    bump_repo_stall_and_maybe_notify(&home, "o/r", &subscribers, Some(future_reset), None);
+    bump_repo_stall_and_maybe_notify(&home, "o/r", &subscribers, Some(future_reset), None);
+
+    let st = p05_read_repo_stall(&home, "o_r");
+    assert_eq!(st["consecutive_skips"].as_u64(), Some(2));
+    // Below threshold ⇒ no stall window opened, no event.
+    assert!(
+        st["stalled_since_ms"].is_null(),
+        "below threshold ⇒ not stalled"
     );
-    bump_consecutive_skips_and_maybe_notify(
-        &home,
-        &path,
-        "o/r",
-        "feat",
-        &subscribers,
-        future_reset,
-        None,
+    let lines = p05_read_inbox_lines(&home, "lead");
+    assert!(
+        !lines.iter().any(|l| l.contains("ci-watch-stalled")),
+        "no stalled event below threshold"
     );
-    let watch: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(watch["consecutive_skips"].as_u64(), Some(2));
-    // Below threshold: stalled_notified is either absent (None) or
-    // false — both mean "no notify fired yet".
-    let notified = watch["stalled_notified"].as_bool().unwrap_or(false);
-    assert!(!notified, "below threshold ⇒ no notify yet");
     std::fs::remove_dir_all(&home).ok();
 }
 
 #[test]
-fn stalled_event_fires_exactly_once_at_threshold() {
-    // Gate 2: at N=3 a [ci-watch-stalled] enqueues; further
-    // tick-skips don't re-fire. This is the regression-proof
-    // anchor — collapsing the guard reveals duplicates.
-    let home = p05_temp_home("p05_stalled_once");
-    let watch = serde_json::json!({
-        "repo": "o/r",
-        "branch": "feat",
-        "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-07T00:00:00Z"}],
-        "consecutive_skips": 0,
-    });
-    let path = p05_write_watch(&home, "o/r", "feat", watch);
+fn repo_stall_fires_one_event_at_threshold() {
+    // Pin ④b: at N=STALL_THRESHOLD one repo-level [ci-watch-stalled]
+    // enqueues; further bumps don't re-fire. Regression-proof anchor —
+    // collapsing the `stalled_since_ms.is_none()` guard reveals duplicates.
+    let home = p05_temp_home("p1705_stalled_once");
     let subscribers = vec!["lead".to_string()];
     let future_reset = (chrono::Utc::now().timestamp() as u64) + 3600;
 
     for _ in 0..5 {
-        bump_consecutive_skips_and_maybe_notify(
-            &home,
-            &path,
-            "o/r",
-            "feat",
-            &subscribers,
-            future_reset,
-            None,
-        );
+        bump_repo_stall_and_maybe_notify(&home, "o/r", &subscribers, Some(future_reset), None);
     }
 
     let lines = p05_read_inbox_lines(&home, "lead");
@@ -3098,7 +3077,7 @@ fn stalled_event_fires_exactly_once_at_threshold() {
         .count();
     assert_eq!(
         stalled_count, 1,
-        "exactly one stalled event per stall window (got {stalled_count})"
+        "exactly one repo-level stalled event per stall window (got {stalled_count})"
     );
     std::fs::remove_dir_all(&home).ok();
 }
@@ -3138,114 +3117,294 @@ fn resumed_event_fires_on_first_successful_clear() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// Pin ④c (fan-out + #790 display-tz): the repo-level stalled + resumed
+/// events reach EVERY subscriber across the repo's watches (P0-1 fan-out),
+/// the stalled body renders the operator display tz, and storage stays UTC.
+/// Stalled-since is seeded deterministically (1746655200000ms =
+/// 2026-05-07T22:00:00Z → Taipei UTC+8 = "05-08 06:00").
 #[test]
-fn stalled_and_resumed_fan_out_to_all_subscribers() {
-    // Gate 4: both event types reach every subscriber per the
-    // P0-1 fan-out contract.
-    let home = p05_temp_home("p05_fanout");
-    let watch = serde_json::json!({
-        "repo": "o/r",
-        "branch": "feat",
-        "subscribers": [
-            {"instance": "lead", "subscribed_at": "2026-05-07T00:00:00Z"},
-            {"instance": "dev",  "subscribed_at": "2026-05-07T00:00:01Z"}
-        ],
-        "consecutive_skips": 0,
+fn repo_stall_fan_out_and_tz_body_storage_utc() {
+    let home = p05_temp_home("p1705_fanout_tz");
+    // Seed the sidecar at threshold-1 with a fixed stalled_since so the next
+    // bump tips over and emits with a deterministic body anchor.
+    let stall_path = ci_watches_dir(&home).join("o_r.stall");
+    let sidecar = serde_json::json!({
+        "consecutive_skips": STALL_THRESHOLD - 1,
+        "stalled_notified": false,
+        "stalled_since_ms": 1746655200000_i64,
     });
-    let path = p05_write_watch(&home, "o/r", "feat", watch);
+    std::fs::write(&stall_path, serde_json::to_string_pretty(&sidecar).unwrap()).unwrap();
+
     let subscribers = vec!["lead".to_string(), "dev".to_string()];
     let future_reset = (chrono::Utc::now().timestamp() as u64) + 3600;
+    bump_repo_stall_and_maybe_notify(
+        &home,
+        "o/r",
+        &subscribers,
+        Some(future_reset),
+        Some("Asia/Taipei"),
+    );
 
-    for _ in 0..STALL_THRESHOLD {
-        bump_consecutive_skips_and_maybe_notify(
-            &home,
-            &path,
-            "o/r",
-            "feat",
-            &subscribers,
-            future_reset,
-            None,
-        );
-    }
     for sub in ["lead", "dev"] {
         let lines = p05_read_inbox_lines(&home, sub);
+        let stalled_line = lines
+            .iter()
+            .find(|l| l.contains("ci-watch-stalled"))
+            .unwrap_or_else(|| panic!("{sub} must receive repo-level stalled event"));
+        let msg: serde_json::Value =
+            serde_json::from_str(stalled_line).expect("inbox line is JSON");
+        let text = msg["text"].as_str().expect("inbox text field");
         assert!(
-            lines.iter().any(|l| l.contains("ci-watch-stalled")),
-            "{sub} must receive stalled event (fan-out regression)"
+            text.contains("Stalled since: 05-08 06:00"),
+            "body must render Taipei tz (UTC+8) for 2026-05-07T22:00:00Z, got:\n{text}"
+        );
+        let ts = msg["timestamp"].as_str().expect("timestamp field");
+        assert!(
+            ts.ends_with('Z') || ts.ends_with("+00:00"),
+            "inbox storage timestamp must be UTC ISO 8601, got {ts:?}"
         );
     }
 
-    clear_stall_and_maybe_notify_resumed(&home, &path, "o/r", "feat", &subscribers);
+    // Resume on the next successful batch poll → both subscribers notified once.
+    clear_repo_stall_and_maybe_resume(&home, "o/r", &subscribers);
     for sub in ["lead", "dev"] {
         let lines = p05_read_inbox_lines(&home, sub);
         assert!(
             lines.iter().any(|l| l.contains("ci-watch-resumed")),
-            "{sub} must receive resumed event"
+            "{sub} must receive repo-level resumed event"
         );
     }
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// #790 wiring test: notification BODY renders Stalled-since and
-/// Next-poll-ETA in the operator's configured display tz, while
-/// the InboxMessage storage `timestamp` field stays UTC (storage
-/// invariant pin guard, per dispatch spec).
-///
-/// Stalled-since is anchored at `2026-05-07T22:00:00Z` (epoch
-/// 1746655200000ms). With `display_timezone=Some("Asia/Taipei")`
-/// the body should contain `"05-08 06:00"` (UTC+8). The inbox
-/// message timestamp field is set inside `fan_out_health_event`
-/// from `chrono::Utc::now().to_rfc3339()` — must end with `Z` or
-/// `+00:00` regardless of display_timezone.
-#[test]
-fn stalled_event_body_uses_display_tz_storage_stays_utc() {
-    let home = p05_temp_home("p790_tz_body");
-    // Pre-stamp stalled_since_ms so the body interpolation is
-    // deterministic (no race on chrono::Utc::now()).
-    let watch = serde_json::json!({
-        "repo": "o/r",
-        "branch": "feat",
-        "subscribers": [{"instance": "lead", "subscribed_at": "2026-05-07T00:00:00Z"}],
-        "consecutive_skips": 0,
-        "stalled_since_ms": 1746655200000_i64, // 2026-05-07T22:00:00Z
-    });
-    let path = p05_write_watch(&home, "o/r", "feat", watch);
-    let subscribers = vec!["lead".to_string()];
-    let future_reset = (chrono::Utc::now().timestamp() as u64) + 3600;
+// ── #1705 repo-level batch poll → tick-cache prefill (pins ①②③) ──
 
-    for _ in 0..STALL_THRESHOLD {
-        bump_consecutive_skips_and_maybe_notify(
-            &home,
-            &path,
-            "o/r",
-            "feat",
-            &subscribers,
-            future_reset,
-            Some("Asia/Taipei"),
-        );
+/// Batch provider: serves one repo-level `poll_repo_runs` (counted) and a
+/// trivial per-branch `poll_runs`. Pairs with `CountingProvider` (the
+/// per-branch fallback inner) sharing the same `TickCache`.
+struct BatchProvider {
+    rows: Vec<crate::daemon::ci_watch::provider::RunRow>,
+    repo_calls: std::sync::Arc<std::sync::atomic::AtomicU32>,
+}
+
+#[async_trait::async_trait]
+impl CiProvider for BatchProvider {
+    async fn poll_runs(&self, _repo: &str, _branch: &str) -> anyhow::Result<CiPollResult> {
+        Ok(CiPollResult::Runs {
+            runs: vec![],
+            rate_limit_remaining: None,
+            rate_limit_limit: None,
+        })
     }
+    async fn poll_repo_runs(&self, _repo: &str) -> Option<anyhow::Result<RepoPollResult>> {
+        self.repo_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Some(Ok(RepoPollResult::Runs {
+            rows: self.rows.clone(),
+            rate_limit_remaining: Some(59),
+            rate_limit_limit: Some(60),
+        }))
+    }
+    async fn check_pr_terminal(&self, _repo: &str, _branch: &str) -> PrState {
+        PrState::Open
+    }
+    async fn fetch_failure_summary(&self, _repo: &str, _run_id: u64) -> String {
+        String::new()
+    }
+    fn token_warning(&self) -> Option<&'static str> {
+        None
+    }
+}
 
-    let lines = p05_read_inbox_lines(&home, "lead");
-    let stalled_line = lines
-        .iter()
-        .find(|l| l.contains("ci-watch-stalled"))
-        .expect("stalled event must enqueue");
-    let msg: serde_json::Value = serde_json::from_str(stalled_line).expect("inbox line is JSON");
+fn mk_poll_ctx(
+    repo: &str,
+    branch: &str,
+    head_sha: &str,
+) -> (std::path::PathBuf, super::PollContext) {
+    let watch: WatchState = serde_json::from_value(serde_json::json!({
+        "repo": repo,
+        "branch": branch,
+        "head_sha": head_sha,
+        "subscribers": [{"instance": "lead", "subscribed_at": "2026-01-01T00:00:00Z"}],
+    }))
+    .unwrap();
+    let path = std::env::temp_dir().join(format!("ci-batch-{branch}.json"));
+    (
+        path,
+        super::PollContext {
+            repo: repo.to_string(),
+            subscribers: vec!["lead".to_string()],
+            stamped_watch: watch,
+        },
+    )
+}
 
-    // Wiring: body text must contain Taipei-rendered Stalled-since.
-    let text = msg["text"].as_str().expect("inbox text field");
-    assert!(
-        text.contains("Stalled since: 05-08 06:00"),
-        "body must render Taipei tz (UTC+8) for 2026-05-07T22:00:00Z, got:\n{text}"
+fn run_row(branch: &str, sha: &str) -> crate::daemon::ci_watch::provider::RunRow {
+    crate::daemon::ci_watch::provider::RunRow {
+        head_branch: branch.to_string(),
+        run: CiRun {
+            id: 1,
+            conclusion: Some("success".into()),
+            head_sha: sha.into(),
+            url: String::new(),
+            name: "CI".into(),
+        },
+    }
+}
+
+#[test]
+fn batch_prefill_routes_cache_hits_and_head_sha_fallback() {
+    // Pins ①②③ in one flow. Two watches on the same repo:
+    //   feat-a head_sha "aaa" — present in batch → prefilled (cache hit)
+    //   feat-b head_sha "bbb" — batch only has "ccc" for feat-b → NOT
+    //                            prefilled (expected sha absent) → fallback
+    let repo_calls = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let batch = BatchProvider {
+        rows: vec![run_row("feat-a", "aaa"), run_row("feat-b", "ccc")],
+        repo_calls: std::sync::Arc::clone(&repo_calls),
+    };
+    let cache = new_tick_cache();
+    let watches = vec![
+        mk_poll_ctx("o/r", "feat-a", "aaa"),
+        mk_poll_ctx("o/r", "feat-b", "bbb"),
+    ];
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let proceed = rt.block_on(async {
+        super::batch_prefill_repo(
+            std::env::temp_dir().as_path(),
+            "o/r",
+            &watches,
+            &cache,
+            &batch,
+            &["lead".to_string()],
+            None,
+        )
+        .await
+    });
+    assert!(proceed, "Runs result proceeds to fan-out");
+    // ① exactly one batch call covered both watches.
+    assert_eq!(
+        repo_calls.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "N watches on one repo ⇒ a single batch poll"
     );
 
-    // Storage invariant: inbox timestamp field stays UTC ISO 8601.
-    let ts = msg["timestamp"].as_str().expect("timestamp field");
-    assert!(
-        ts.ends_with('Z') || ts.ends_with("+00:00"),
-        "inbox storage timestamp must be UTC ISO 8601, got {ts:?}"
+    // Now drive per-branch reads through CachedCiProvider sharing the cache.
+    let fallback_calls = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let cached = super::CachedCiProvider {
+        inner: Box::new(CountingProvider {
+            call_count: std::sync::Arc::clone(&fallback_calls),
+            runs: vec![],
+        }),
+        poll_cache: std::sync::Arc::clone(&cache),
+    };
+    let (a, b) = rt.block_on(async {
+        let a = cached.poll_runs("o/r", "feat-a").await.unwrap();
+        let b = cached.poll_runs("o/r", "feat-b").await.unwrap();
+        (a, b)
+    });
+    // ② feat-a served from prefilled cache — its run carries the batch sha.
+    match a {
+        CiPollResult::Runs { runs, .. } => {
+            assert_eq!(runs.len(), 1);
+            assert_eq!(
+                runs[0].head_sha, "aaa",
+                "feat-a cache hit returns batch run"
+            );
+        }
+        _ => panic!("feat-a should be a cached Runs result"),
+    }
+    assert!(matches!(b, CiPollResult::Runs { .. }));
+    // ③ only feat-b (head_sha not in batch) fell back to the inner provider.
+    assert_eq!(
+        fallback_calls.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "only the head_sha-absent watch falls back to per-branch poll"
     );
+}
 
+/// Batch provider that always returns a repo-level ApiError.
+struct BatchErrProvider {
+    reset: Option<u64>,
+}
+
+#[async_trait::async_trait]
+impl CiProvider for BatchErrProvider {
+    async fn poll_runs(&self, _repo: &str, _branch: &str) -> anyhow::Result<CiPollResult> {
+        Ok(CiPollResult::Runs {
+            runs: vec![],
+            rate_limit_remaining: None,
+            rate_limit_limit: None,
+        })
+    }
+    async fn poll_repo_runs(&self, _repo: &str) -> Option<anyhow::Result<RepoPollResult>> {
+        Some(Ok(RepoPollResult::ApiError {
+            status: 403,
+            message: "API rate limit exceeded".into(),
+            rate_limit_reset: self.reset,
+        }))
+    }
+    async fn check_pr_terminal(&self, _repo: &str, _branch: &str) -> PrState {
+        PrState::Open
+    }
+    async fn fetch_failure_summary(&self, _repo: &str, _run_id: u64) -> String {
+        String::new()
+    }
+    fn token_warning(&self) -> Option<&'static str> {
+        None
+    }
+}
+
+#[test]
+fn batch_apierror_backs_off_repo_and_skips_fan_out() {
+    // Pin ④ (integration): a batch ApiError returns false (skip fan-out),
+    // bumps the per-repo stall sidecar, and stamps rate_limit_until on every
+    // watch so subsequent ticks back off silently.
+    let home = p05_temp_home("p1705_apierr");
+    let reset = (chrono::Utc::now().timestamp() as u64) + 3600;
+    // Write a real watch file so the rate_limit_until stamp is observable.
+    let watch_json = serde_json::json!({
+        "repo": "o/r",
+        "branch": "feat-a",
+        "head_sha": "aaa",
+        "subscribers": [{"instance": "lead", "subscribed_at": "2026-01-01T00:00:00Z"}],
+    });
+    let path = p05_write_watch(&home, "o/r", "feat-a", watch_json);
+    let watch: WatchState = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    let watches = vec![(
+        path.clone(),
+        super::PollContext {
+            repo: "o/r".to_string(),
+            subscribers: vec!["lead".to_string()],
+            stamped_watch: watch,
+        },
+    )];
+    let provider = BatchErrProvider { reset: Some(reset) };
+    let cache = new_tick_cache();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let proceed = rt.block_on(async {
+        super::batch_prefill_repo(
+            &home,
+            "o/r",
+            &watches,
+            &cache,
+            &provider,
+            &["lead".to_string()],
+            None,
+        )
+        .await
+    });
+    assert!(!proceed, "ApiError must skip the fan-out this tick");
+
+    // rate_limit_until stamped on the watch.
+    let after: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(after["rate_limit_until"].as_u64(), Some(reset));
+    // per-repo stall counter bumped.
+    let st = p05_read_repo_stall(&home, "o_r");
+    assert_eq!(st["consecutive_skips"].as_u64(), Some(1));
     std::fs::remove_dir_all(&home).ok();
 }
 

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -160,6 +160,32 @@ pub enum CiPollResult {
     },
 }
 
+/// #1705: one run row from a REPO-LEVEL batch poll — a `CiRun` tagged with its
+/// `head_branch`, so a single repo query can be fanned out to each watched branch.
+#[derive(Debug, Clone)]
+pub struct RunRow {
+    pub head_branch: String,
+    pub run: CiRun,
+}
+
+/// #1705: result of ONE repo-level batch poll (`actions/runs?per_page=100`, no
+/// `?branch=` filter) — replaces N per-branch polls with one. Rate-limit fields
+/// are repo-level (a single response).
+#[derive(Debug, Clone)]
+pub enum RepoPollResult {
+    Runs {
+        rows: Vec<RunRow>,
+        rate_limit_remaining: Option<u64>,
+        rate_limit_limit: Option<u64>,
+    },
+    ApiError {
+        #[allow(dead_code)] // serialized in error diagnostics
+        status: u16,
+        message: String,
+        rate_limit_reset: Option<u64>,
+    },
+}
+
 /// PR terminal-state check result.
 #[derive(Debug)]
 pub enum PrState {
@@ -210,6 +236,15 @@ impl MergeableState {
 pub trait CiProvider: Send + Sync {
     /// Poll workflow/pipeline runs for `repo@branch`.
     async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiPollResult>;
+
+    /// #1705: poll ALL recent runs for `repo` in ONE query (`?per_page=100`, no
+    /// branch filter); the caller groups by `head_branch` and fans out to each
+    /// watched branch, collapsing N per-branch polls into one. `None` = the
+    /// provider does not support batch polling → the caller falls back to
+    /// per-branch [`poll_runs`] (GitLab / Bitbucket — unverified path).
+    async fn poll_repo_runs(&self, _repo: &str) -> Option<anyhow::Result<RepoPollResult>> {
+        None
+    }
 
     /// Check whether the PR/MR for `branch` has reached a terminal state.
     async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState;
@@ -379,6 +414,77 @@ impl CiProvider for GitHubCiProvider {
             rate_limit_remaining,
             rate_limit_limit,
         })
+    }
+
+    async fn poll_repo_runs(&self, repo: &str) -> Option<anyhow::Result<RepoPollResult>> {
+        // #1705: ONE repo-level query (no `?branch=`) → all recent runs across
+        // branches; the caller groups by `head_branch`. `per_page=100` (GitHub max)
+        // covers every active watched branch's latest run in one page (active =
+        // recent run = in-page; terminal watches are auto-cleared and don't poll).
+        Some(async {
+            let resp = self
+                .http
+                .get(&format!("repos/{repo}/actions/runs?per_page=100"))
+                .send()
+                .await?;
+            let status = resp.status().as_u16();
+            let rate_limit_reset = resp
+                .headers()
+                .get("x-ratelimit-reset")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok());
+            let parse_u64_header = |name: &str| {
+                resp.headers()
+                    .get(name)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.parse::<u64>().ok())
+            };
+            let rate_limit_remaining = parse_u64_header("x-ratelimit-remaining");
+            let rate_limit_limit = parse_u64_header("x-ratelimit-limit");
+            let body: serde_json::Value = resp.json().await?;
+            if !(200..300).contains(&status) {
+                let message = body["message"].as_str().unwrap_or("(no message)").to_string();
+                let hint = if status == 403
+                    && crate::github_token::cached_token().is_none()
+                    && message.to_lowercase().contains("rate limit")
+                {
+                    " — set GITHUB_TOKEN or run `gh auth login` to raise the unauthenticated 60/hr cap"
+                } else {
+                    ""
+                };
+                return Ok(RepoPollResult::ApiError {
+                    status,
+                    message: format!("GH API {status}: {message}{hint}"),
+                    rate_limit_reset,
+                });
+            }
+            // Same per-run parse as `poll_runs`, plus `head_branch` for grouping.
+            let rows = body["workflow_runs"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|r| {
+                            Some(RunRow {
+                                head_branch: r["head_branch"].as_str()?.to_string(),
+                                run: CiRun {
+                                    id: r["id"].as_u64()?,
+                                    conclusion: r["conclusion"].as_str().map(String::from),
+                                    head_sha: r["head_sha"].as_str()?.to_string(),
+                                    url: r["html_url"].as_str().unwrap_or("").to_string(),
+                                    name: r["name"].as_str().unwrap_or("").to_string(),
+                                },
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            Ok(RepoPollResult::Runs {
+                rows,
+                rate_limit_remaining,
+                rate_limit_limit,
+            })
+        }
+        .await)
     }
 
     async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState {

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -9,71 +9,6 @@ use super::WATCH_TTL_HOURS;
 /// over-paging on a one-tick blip.
 pub(crate) const STALL_THRESHOLD: u64 = 3;
 
-/// Sprint 54 P0-5 helper: read existing `consecutive_skips`, increment,
-/// persist, and (if we just crossed `STALL_THRESHOLD` and haven't yet
-/// notified for this window) fan out a `[ci-watch-stalled]` inbox event
-/// to every subscriber. The notify step reuses the P0-1 fan-out
-/// contract — one inbox enqueue per subscriber.
-///
-/// Atomicity: the increment + `stalled_notified` flag move in a single
-/// atomic_write so the next tick can't observe a "skips ≥ threshold,
-/// flag still false" intermediate state and fire a duplicate event.
-pub(super) fn bump_consecutive_skips_and_maybe_notify(
-    home: &Path,
-    watch_path: &Path,
-    repo: &str,
-    branch: &str,
-    subscribers: &[String],
-    reset_epoch: u64,
-    display_timezone: Option<&str>,
-) {
-    let mut watch: super::watch_state::WatchState = match std::fs::read_to_string(watch_path)
-        .ok()
-        .and_then(|c| serde_json::from_str(&c).ok())
-    {
-        Some(v) => v,
-        None => return,
-    };
-    let prev_skips = watch.consecutive_skips.unwrap_or(0);
-    let next_skips = prev_skips.saturating_add(1);
-    watch.consecutive_skips = Some(next_skips);
-
-    let already_notified = watch.stalled_notified.unwrap_or(false);
-    let should_notify = next_skips >= STALL_THRESHOLD && !already_notified;
-    if should_notify {
-        watch.stalled_notified = Some(true);
-        if watch.stalled_since_ms.is_none() {
-            watch.stalled_since_ms = Some(chrono::Utc::now().timestamp_millis());
-        }
-    }
-    if let Err(e) = crate::store::atomic_write(
-        watch_path,
-        serde_json::to_string_pretty(&watch)
-            .unwrap_or_default()
-            .as_bytes(),
-    ) {
-        tracing::warn!(path = %watch_path.display(), error = %e, "ci-watch stall-counter write failed");
-    }
-
-    if should_notify {
-        let stalled_since_ms = watch.stalled_since_ms;
-        // next_poll_eta = reset_epoch_ms (skip lifts at reset, then
-        // adaptive backoff applies — but reset is the user-visible
-        // "stalled until" moment).
-        let next_poll_eta = (reset_epoch as i64).saturating_mul(1000);
-        let setup_warning = crate::github_token::cached_setup_warning();
-        let body = build_stalled_body(
-            repo,
-            branch,
-            stalled_since_ms,
-            next_poll_eta,
-            setup_warning,
-            display_timezone,
-        );
-        fan_out_health_event(home, repo, branch, subscribers, "ci-watch-stalled", body);
-    }
-}
-
 /// Sprint 54 P0-5 helper: clear the stall state on the first successful
 /// poll after a stall window. Retained for tests; production path uses
 /// `clear_stall_state` with in-memory mutation.
@@ -138,6 +73,95 @@ pub(super) fn clear_stall_state(
         let body =
             format!("[ci-watch-resumed] {repo}@{branch}: poll resumed after rate-limit backoff");
         fan_out_health_event(home, repo, branch, subscribers, "ci-watch-resumed", body);
+    }
+}
+
+/// #1705: repo-level rate-limit stall tracking. With the repo-level batch poll, a
+/// rate-limit is a REPO property (one batch call hit the cap), so the stall state
+/// lives PER-REPO in a sidecar — NOT borrowed from a representative watch (a watch
+/// can be auto-cleared by #931 PR-terminal mid-stall and must not break the repo's
+/// stall anchor). One `[ci-watch-stalled]` / `[ci-watch-resumed]` per repo.
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+struct RepoStallState {
+    #[serde(default)]
+    consecutive_skips: u64,
+    #[serde(default)]
+    stalled_notified: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    stalled_since_ms: Option<i64>,
+}
+
+/// Sidecar path: `<ci-watches>/<repo-slug>.stall` (extension `.stall`, not `.json`,
+/// so the watch-dir scans which filter on `.json` skip it).
+fn repo_stall_path(home: &Path, repo: &str) -> std::path::PathBuf {
+    ci_watches_dir(home).join(format!("{}.stall", repo.replace(['/', ':'], "_")))
+}
+
+fn read_repo_stall(home: &Path, repo: &str) -> RepoStallState {
+    std::fs::read_to_string(repo_stall_path(home, repo))
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or_default()
+}
+
+/// #1705: repo-level stall bump — called ONCE per repo when a batch poll hits an
+/// API/rate-limit error. Emits a single repo-level `[ci-watch-stalled]` when
+/// `consecutive_skips` first crosses `STALL_THRESHOLD` (once per stall window).
+pub(super) fn bump_repo_stall_and_maybe_notify(
+    home: &Path,
+    repo: &str,
+    subscribers: &[String],
+    reset_epoch: Option<u64>,
+    display_timezone: Option<&str>,
+) {
+    let mut st = read_repo_stall(home, repo);
+    st.consecutive_skips = st.consecutive_skips.saturating_add(1);
+    // `stalled_notified` gates the once-per-window emit; `stalled_since_ms`
+    // marks when the window opened (preserved if already set, e.g. seeded by a
+    // prior bump) so the body's "Stalled since" anchor is stable.
+    let should_notify = st.consecutive_skips >= STALL_THRESHOLD && !st.stalled_notified;
+    if should_notify {
+        st.stalled_notified = true;
+        if st.stalled_since_ms.is_none() {
+            st.stalled_since_ms = Some(chrono::Utc::now().timestamp_millis());
+        }
+    }
+    let _ = crate::store::atomic_write(
+        &repo_stall_path(home, repo),
+        serde_json::to_string_pretty(&st)
+            .unwrap_or_default()
+            .as_bytes(),
+    );
+    if should_notify {
+        let next_poll_eta = reset_epoch
+            .map(|r| (r as i64).saturating_mul(1000))
+            .unwrap_or(0);
+        let setup_warning = crate::github_token::cached_setup_warning();
+        let body = build_stalled_body(
+            repo,
+            "*",
+            st.stalled_since_ms,
+            next_poll_eta,
+            setup_warning,
+            display_timezone,
+        );
+        fan_out_health_event(home, repo, "*", subscribers, "ci-watch-stalled", body);
+    }
+}
+
+/// #1705: repo-level resume — called when a batch poll SUCCEEDS. Emits one
+/// `[ci-watch-resumed]` if the repo was stalled, then clears the sidecar.
+pub(super) fn clear_repo_stall_and_maybe_resume(home: &Path, repo: &str, subscribers: &[String]) {
+    let st = read_repo_stall(home, repo);
+    if st.consecutive_skips == 0 && !st.stalled_notified && st.stalled_since_ms.is_none() {
+        return; // never stalled this window — nothing to clear/announce
+    }
+    let was_stalled = st.stalled_notified;
+    let _ = std::fs::remove_file(repo_stall_path(home, repo));
+    if was_stalled {
+        let body =
+            format!("[ci-watch-resumed] {repo}: batch poll resumed after rate-limit backoff");
+        fan_out_health_event(home, repo, "*", subscribers, "ci-watch-resumed", body);
     }
 }
 
@@ -373,37 +397,24 @@ mod tests {
         dir
     }
 
-    /// #946 — sweep.rs `[ci-watch-stalled]` enqueue site (fan_out_health_event
-    /// at :161 via bump_consecutive_skips_and_maybe_notify) carries
-    /// `correlation_id = {repo}@{branch}`. Pre-fix: None.
+    /// #946/#1705 — repo-level `[ci-watch-stalled]` enqueue site
+    /// (fan_out_health_event via bump_repo_stall_and_maybe_notify) carries
+    /// `correlation_id = {repo}@*`. The `*` branch marks a repo-level event
+    /// (the batch poll owns stall now, not any single watch). Pre-fix: None.
     #[test]
-    fn ci_stalled_inbox_message_carries_repo_branch_correlation_id() {
+    fn ci_stalled_inbox_message_carries_repo_correlation_id() {
         let dir = tmp_dir("946-stalled-corr");
         let ci_dir = dir.join("ci-watches");
         std::fs::create_dir_all(&ci_dir).unwrap();
-        // Plant a watch with consecutive_skips == STALL_THRESHOLD-1 so
-        // the next bump tips it over and fires the stall notification.
-        let watch_path = ci_dir.join("test-watch.json");
-        let watch = serde_json::json!({
-            "repo": "o/r",
-            "branch": "feat",
-            "consecutive_skips": STALL_THRESHOLD - 1,
-            "stalled_notified": false,
-            "subscribers": [{"instance": "agent1", "subscribed_at": "2026-05-19T00:00:00Z"}],
-        });
-        std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+        // Plant the repo stall sidecar at STALL_THRESHOLD-1 so the next bump
+        // tips it over and fires the repo-level stall notification.
+        let stall_path = ci_dir.join("o_r.stall");
+        let sidecar = serde_json::json!({ "consecutive_skips": STALL_THRESHOLD - 1 });
+        std::fs::write(&stall_path, serde_json::to_string_pretty(&sidecar).unwrap()).unwrap();
 
         let subscribers = vec!["agent1".to_string()];
         let reset_epoch = chrono::Utc::now().timestamp() as u64 + 3600;
-        bump_consecutive_skips_and_maybe_notify(
-            &dir,
-            &watch_path,
-            "o/r",
-            "feat",
-            &subscribers,
-            reset_epoch,
-            None,
-        );
+        bump_repo_stall_and_maybe_notify(&dir, "o/r", &subscribers, Some(reset_epoch), None);
 
         let inbox_path = dir.join("inbox").join("agent1.jsonl");
         let content = std::fs::read_to_string(&inbox_path).unwrap();
@@ -411,7 +422,7 @@ mod tests {
             content.contains("[ci-watch-stalled]"),
             "expected [ci-watch-stalled] in inbox: {content}"
         );
-        let expected = r#""correlation_id":"o/r@feat""#;
+        let expected = r#""correlation_id":"o/r@*""#;
         assert!(
             content.contains(expected),
             "ci-watch-stalled message must carry correlation_id={expected}: {content}"


### PR DESCRIPTION
## What

Converts ci_watch from **per-branch polling** (N watched branches on a repo = N GitHub API calls/tick → rate-limit pressure + per-branch stalled/resumed noise) to a **single repo-level batch poll** that fans out to branches.

## How

**`provider.rs`** — new `poll_repo_runs(repo) -> Option<Result<RepoPollResult>>` (default `None` = provider doesn't support batch → caller falls back per-branch). GitHub impl: `GET repos/{repo}/actions/runs?per_page=100` (no `?branch=`), each run tagged with its `head_branch` (`RunRow`). `RepoPollResult::Runs { rows, rate_limit_* } | ApiError { status, message, rate_limit_reset }`.

**`poller.rs` `check_ci_watches_with_provider`**
- **PASS 1** groups poll-eligible watches by repo. A per-watch `RateLimited` skip is now **silent** (the repo-level batch owns stall notification).
- **PASS 2**, per repo: one `poll_repo_runs()` via the extracted testable seam **`batch_prefill_repo`**, group rows by `head_branch`, **pre-populate the per-tick cache** for each watch whose expected `head_sha` is in the batch slice. A watch whose sha is **absent** (pushed off the `per_page=100` page) is left unprefilled → `CachedCiProvider` miss → **automatic per-branch fallback**. Then fan out `ci_check_repo` (cache hit → no HTTP). All async — **no `block_on`**, avoids runtime-in-runtime.

**`sweep.rs`** — rate-limit is a **repo property**: a batch `ApiError` bumps a **per-repo stall sidecar** (`<repo-slug>.stall`, extension `.stall` so the watch-dir `.json` scans skip it) **once** → one repo-level `[ci-watch-stalled]`/`[ci-watch-resumed]` pair (not N), and stamps `rate_limit_until` on every repo watch to back off. The sidecar (not a representative watch) **survives a single watch being auto-cleared by #931** mid-stall.

## Scope note (test churn)

Removes the now-dead per-watch `bump_consecutive_skips_and_maybe_notify` + its 6 tests (direct consequence of the approved silent-skip), replaced by per-repo `RepoStallState` tests. The **#946 correlation-id** assertion is preserved on the new repo-level `[ci-watch-stalled]` (`repo@*`).

## Tests (5 pins)
1. **batch routing** — N watches on one repo ⇒ 1 batch call; in-batch branches served from prefilled cache (equivalence); head_sha-absent branch falls back per-branch.
2. **repo-stall once-at-threshold** (regression-proof anchor) + below-threshold hold.
3. **fan-out + #790 display-tz** body / UTC storage to all subscribers.
4. **ApiError back-off** — returns false (skip fan-out), bumps sidecar, stamps `rate_limit_until`.
5. PR-terminal / stale-SHA / `next_after_ci` unchanged (existing suite).

## Verification
- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features tray -D warnings` ✅ and `--features tray,discord` ✅
- ci_watch suite **191 tests ×3 runs stable**; new pins pass
- **Full `cargo test --tests --features tray` — exit 0, 0 failures across 54 binaries**

Base: `2a38e7f`. Note: a daemon change needs rebuild+restart to take effect (no runtime urgency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)