### PR TITLE
fix(#1720): event-bus handled-count + cron silent-drop visibility

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -221,7 +221,7 @@ fn deliver_stall(
 /// #event-bus first-pattern: bus subscriber — on a `TaskStateChanged` event,
 /// run the stall delivery (the gate-ON path). Registered once at daemon startup
 /// via [`register_subscriber`].
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::TaskStateChanged {
         task_id,
         title,
@@ -240,6 +240,9 @@ fn handle_event(event: &crate::daemon::event_bus::Event) {
             *eta_secs,
             assignee.as_deref(),
         );
+        true
+    } else {
+        false
     }
 }
 

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1632,7 +1632,7 @@ fn deliver_ci_watch(
 /// #event-bus (ci_watch) subscriber: re-deliver a `CiReady`/`CiFail` event via the
 /// shared `deliver_ci_watch`. Both kinds deliver identically (the body already
 /// encodes pass/fail); the kind split is purely semantic.
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     match &event.kind {
         crate::daemon::event_bus::EventKind::CiReady {
             target,
@@ -1649,8 +1649,9 @@ fn handle_event(event: &crate::daemon::event_bus::Event) {
             ..
         } => {
             deliver_ci_watch(&event.home, target, body, correlation_id, supersede_token);
+            true
         }
-        _ => {}
+        _ => false,
     }
 }
 

--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -233,7 +233,7 @@ fn deliver_conflict_alert(home: &Path, agent: &str, escalation: bool, text: &str
 
 /// #event-bus (conflict_notify) subscriber: re-deliver a `ConflictAlert` event via
 /// the shared `deliver_conflict_alert`.
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::ConflictAlert {
         agent,
         escalation,
@@ -241,6 +241,9 @@ fn handle_event(event: &crate::daemon::event_bus::Event) {
     } = &event.kind
     {
         deliver_conflict_alert(&event.home, agent, *escalation, text);
+        true
+    } else {
+        false
     }
 }
 

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -121,7 +121,7 @@ pub fn check_schedules(home: &Path) {
         // runs the effect via `deliver_cron_fire`. The schedule message/label are
         // STATIC (non-time-sensitive), carried verbatim. (The subscriber resolves
         // the live registry it was registered with — see `register_subscriber`.)
-        crate::daemon::event_bus::global().emit(
+        let handled = crate::daemon::event_bus::global().emit(
             home,
             crate::daemon::event_bus::EventKind::CronFire {
                 sched_id: sched.id.clone(),
@@ -135,11 +135,34 @@ pub fn check_schedules(home: &Path) {
                 missed: fire.missed,
             },
         );
+        note_unhandled_cron_fire(home, &sched.id, &sched.target, handled);
         any_triggered = true;
     }
 
     if any_triggered || now_utc.signed_duration_since(last_check_utc).num_seconds() >= 10 {
         let _ = crate::store::atomic_write(&last_check_path, now_utc.to_rfc3339().as_bytes());
+    }
+}
+
+/// #1720 (Y): a cron fire that reached NO subscriber (`handled == 0`) would
+/// otherwise vanish with no run_history + no log — the exact silent-drop the
+/// cutover's intermediate binary hit. Record a `skipped` run + WARN so the drop
+/// is VISIBLE instead of silent, satisfying the operator contract "reliably fires
+/// OR records a `{status: skipped}`". NOTE: `last_check` is deliberately NOT held
+/// here — it is a single global file, so holding it would freeze the whole engine
+/// and double-fire every other schedule; the next slot fires normally and this
+/// one is recorded as skipped (no retry). `deliver_cron_fire` always completes
+/// (inject/enqueue errors become their own `record_run` status, never a throw),
+/// so a REGISTERED subscriber always yields `handled >= 1` — `handled == 0`
+/// specifically means the cron delivery path was unregistered.
+fn note_unhandled_cron_fire(home: &Path, sched_id: &str, target: &str, handled: usize) {
+    if handled == 0 {
+        crate::schedules::record_run(home, sched_id, "skipped: no-subscriber");
+        tracing::warn!(
+            schedule = %sched_id,
+            target = %target,
+            "#1720: cron fire reached no subscriber — recorded skipped (cron delivery path unregistered?)"
+        );
     }
 }
 
@@ -239,8 +262,12 @@ fn deliver_cron_fire(
     }
 }
 
-/// #event-bus pattern (cron_tick): subscriber — re-run the fire effect.
-fn handle_event(registry: &AgentRegistry, event: &crate::daemon::event_bus::Event) {
+/// #event-bus pattern (cron_tick): subscriber — re-run the fire effect. Returns
+/// `true` iff this was a `CronFire` (and the effect ran) — `deliver_cron_fire`
+/// always completes (inject/enqueue errors become a `record_run` status, never a
+/// throw), so a `true` return means the fire was handled. `check_schedules` uses
+/// the emit handled-count: `0` = no cron subscriber ran (#1720) → record skipped.
+fn handle_event(registry: &AgentRegistry, event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::CronFire {
         sched_id,
         target,
@@ -262,6 +289,9 @@ fn handle_event(registry: &AgentRegistry, event: &crate::daemon::event_bus::Even
                 missed: *missed,
             },
         );
+        true
+    } else {
+        false
     }
 }
 
@@ -941,6 +971,33 @@ mod tests {
             last_status(&home),
             "ok_inbox",
             "#event-bus Option A: gate-off must deliver via legacy (no regression)"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1720 (Y): a fire that reaches NO subscriber (`handled == 0`) is recorded
+    /// as `skipped: no-subscriber` — VISIBLE, not silently lost (the core
+    /// #1720 pain). A delivered fire (`handled >= 1`) records nothing extra (the
+    /// subscriber's `deliver_cron_fire` already recorded the real status). This
+    /// tests the (Y) decision directly — the global subscriber is registered by
+    /// the test-harness ctor, so `check_schedules` itself can't reach
+    /// `handled == 0`; the helper is the seam.
+    #[test]
+    fn unhandled_cron_fire_records_skipped_1720() {
+        let home = cron_tmp_home("unhandled");
+        seed_oneshot(&home, "x"); // schedule "s-1488", empty run_history
+        super::note_unhandled_cron_fire(&home, "s-1488", "x", 0);
+        assert_eq!(
+            last_status(&home),
+            "skipped: no-subscriber",
+            "#1720: an unhandled fire must be recorded, not silently dropped"
+        );
+        let before = crate::schedules::load(&home).schedules[0].run_history.len();
+        super::note_unhandled_cron_fire(&home, "s-1488", "x", 1);
+        let after = crate::schedules::load(&home).schedules[0].run_history.len();
+        assert_eq!(
+            before, after,
+            "#1720: a handled fire (>=1) must NOT record a skip"
         );
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -347,7 +347,7 @@ fn deliver_timeout(
 
 /// #event-bus pattern #2: bus subscriber — deliver on a `DecisionTimeout` event
 /// (the gate-ON path). Registered once at daemon startup via [`register_subscriber`].
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::DecisionTimeout {
         decision_id,
         sender,
@@ -364,6 +364,9 @@ fn handle_event(event: &crate::daemon::event_bus::Event) {
             *timeout_secs,
             default_action,
         );
+        true
+    } else {
+        false
     }
 }
 

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -741,7 +741,7 @@ fn deliver_dispatch_idle(
 
 /// #event-bus pattern #3: bus subscriber — deliver on a `DispatchIdleExceeded`
 /// event (the gate-ON path). Registered once at daemon startup via [`register_subscriber`].
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::DispatchIdleExceeded {
         dispatcher,
         target,
@@ -762,6 +762,9 @@ fn handle_event(event: &crate::daemon::event_bus::Event) {
             *elapsed_secs,
             *threshold_secs,
         );
+        true
+    } else {
+        false
     }
 }
 

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -213,7 +213,14 @@ fn _register_event_bus_subscribers_at_test_load() {
     register_all_subscribers_for_test();
 }
 
-type Subscriber = Arc<dyn Fn(&Event) + Send + Sync>;
+/// A subscriber returns `true` iff it HANDLED the event — i.e. it matched the
+/// `EventKind` it cares about AND completed its delivery. Returning `false`
+/// (didn't match this kind, or its delivery failed) lets [`EventBus::emit`]
+/// report a handled-count, so a producer can detect an event that fanned out to
+/// nothing (#1720: a cron fire emitted while its subscriber was unregistered was
+/// silently lost — a count lets the producer record `skipped` instead of
+/// dropping it without a trace).
+type Subscriber = Arc<dyn Fn(&Event) -> bool + Send + Sync>;
 
 pub struct EventBus {
     subscribers: parking_lot::Mutex<Vec<Subscriber>>,
@@ -226,7 +233,7 @@ impl EventBus {
         }
     }
 
-    pub fn subscribe(&self, f: impl Fn(&Event) + Send + Sync + 'static) {
+    pub fn subscribe(&self, f: impl Fn(&Event) -> bool + Send + Sync + 'static) {
         self.subscribers.lock().push(Arc::new(f));
     }
 
@@ -234,13 +241,17 @@ impl EventBus {
     /// `emit` is unconditional (no gate). `home` is the `$AGEND_HOME` the event
     /// occurred in — carried on the `Event` so a single globally-registered
     /// subscriber delivers to the correct home.
-    pub fn emit(&self, home: &std::path::Path, kind: EventKind) {
+    ///
+    /// Returns the **handled-count**: how many subscribers reported handling this
+    /// event (matched its kind AND delivered). `0` means the event fanned out to
+    /// nothing relevant — the producer can then record/log it rather than let it
+    /// vanish silently (#1720).
+    pub fn emit(&self, home: &std::path::Path, kind: EventKind) -> usize {
         let event = Event::new(home.to_path_buf(), kind);
         let subs = self.subscribers.lock();
-        for sub in subs.iter() {
-            sub(&event);
-        }
-        tracing::debug!(kind = ?event.kind, "event_bus: emitted");
+        let handled = subs.iter().filter(|sub| sub(&event)).count();
+        tracing::debug!(kind = ?event.kind, handled, "event_bus: emitted");
+        handled
     }
 }
 
@@ -269,7 +280,10 @@ mod tests {
         let bus = EventBus::new();
         let received = Arc::new(Mutex::new(Vec::new()));
         let r = Arc::clone(&received);
-        bus.subscribe(move |e| r.lock().unwrap().push(e.kind.clone()));
+        bus.subscribe(move |e| {
+            r.lock().unwrap().push(e.kind.clone());
+            true
+        });
         bus.emit(
             std::path::Path::new("/tmp/h"),
             EventKind::TaskStateChanged {
@@ -293,7 +307,10 @@ mod tests {
         let bus = EventBus::new();
         let seen = Arc::new(Mutex::new(Vec::new()));
         let s = Arc::clone(&seen);
-        bus.subscribe(move |e| s.lock().unwrap().push(e.home.clone()));
+        bus.subscribe(move |e| {
+            s.lock().unwrap().push(e.home.clone());
+            true
+        });
         bus.emit(
             std::path::Path::new("/tmp/agend-home-x"),
             EventKind::CiReady {
@@ -319,9 +336,11 @@ mod tests {
         let cb = Arc::clone(&count_b);
         bus.subscribe(move |_| {
             ca.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            true
         });
         bus.subscribe(move |_| {
             cb.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            true
         });
         bus.emit(
             std::path::Path::new("/tmp/h"),
@@ -334,6 +353,45 @@ mod tests {
         );
         assert_eq!(count_a.load(std::sync::atomic::Ordering::Relaxed), 1);
         assert_eq!(count_b.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    /// #1720 (B): `emit` returns the HANDLED-count — only subscribers that report
+    /// handling (returned `true`, e.g. matched their EventKind) are counted. A
+    /// subscriber that ignores the event (returns `false`, wrong kind) does not.
+    /// This is the signal a producer uses to detect a fire that reached nothing
+    /// relevant (handled==0) instead of losing it silently.
+    #[test]
+    fn emit_returns_handled_count() {
+        let bus = EventBus::new();
+        bus.subscribe(|_| true); // handles
+        bus.subscribe(|_| false); // ignores (e.g. a different pattern's kind)
+        bus.subscribe(|_| true); // handles
+        let handled = bus.emit(
+            std::path::Path::new("/tmp/h"),
+            EventKind::CiFail {
+                target: "dev".into(),
+                body: "[ci-fail]".into(),
+                correlation_id: "o/r@b".into(),
+                supersede_token: "ci-3".into(),
+            },
+        );
+        assert_eq!(
+            handled, 2,
+            "only the handling (true) subscribers are counted"
+        );
+
+        // No subscriber at all → handled == 0 (the #1720 silent-drop signal).
+        let empty = EventBus::new();
+        let none = empty.emit(
+            std::path::Path::new("/tmp/h"),
+            EventKind::CiFail {
+                target: "dev".into(),
+                body: "x".into(),
+                correlation_id: "o/r@b".into(),
+                supersede_token: "ci-4".into(),
+            },
+        );
+        assert_eq!(none, 0, "no subscriber → handled-count 0");
     }
 
     #[test]

--- a/src/daemon/helper_staleness_watchdog.rs
+++ b/src/daemon/helper_staleness_watchdog.rs
@@ -161,9 +161,12 @@ fn deliver_helper_staleness(home: &Path, helper_name: &str) {
 }
 
 /// #event-bus pattern #5: subscriber — rebuild the alert from the event.
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::HelperStale { helper_name } = &event.kind {
         deliver_helper_staleness(&event.home, helper_name);
+        true
+    } else {
+        false
     }
 }
 

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -759,7 +759,7 @@ fn route_idle_alert(
 
 /// #event-bus pattern #6: bus subscriber — deliver on an `IdleAlert` event via the
 /// shared `emit_idle_alert`. Registered once at daemon startup.
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::IdleAlert {
         recipient,
         kind,
@@ -774,6 +774,9 @@ fn handle_event(event: &crate::daemon::event_bus::Event) {
             text,
             correlation_agent.as_deref(),
         );
+        true
+    } else {
+        false
     }
 }
 

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -103,9 +103,12 @@ fn deliver_poll_reminder(home: &Path, agent: &str, reminder: &str) {
 }
 
 /// #event-bus pattern #8: subscriber — re-deliver the frozen reminder text.
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::PollReminder { agent, reminder } = &event.kind {
         deliver_poll_reminder(&event.home, agent, reminder);
+        true
+    } else {
+        false
     }
 }
 

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -607,7 +607,7 @@ fn deliver_member_state_change(
 
 /// #event-bus pattern #9 subscriber: re-deliver a `MemberStateChanged` event via
 /// the shared `deliver_member_state_change`.
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::MemberStateChanged {
         agent,
         team,
@@ -634,6 +634,9 @@ fn handle_event(event: &crate::daemon::event_bus::Event) {
             *consecutive_count,
             detected_at,
         );
+        true
+    } else {
+        false
     }
 }
 

--- a/src/daemon/waiting_on_stale.rs
+++ b/src/daemon/waiting_on_stale.rs
@@ -132,7 +132,7 @@ fn deliver_stale_alert(home: &Path, agent: &str, condition: &str, elapsed_min: i
 }
 
 /// #event-bus pattern #4: subscriber — rebuild the alert from the event.
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::WaitingOnStale {
         agent,
         condition,
@@ -140,6 +140,9 @@ fn handle_event(event: &crate::daemon::event_bus::Event) {
     } = &event.kind
     {
         deliver_stale_alert(&event.home, agent, condition, *elapsed_min);
+        true
+    } else {
+        false
     }
 }
 

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -504,15 +504,67 @@ pub fn create(home: &Path, instance_name: &str, args: &Value) -> Value {
     }
 }
 
+/// #1720 ③ visibility: the next UTC instant this schedule will fire (RFC 3339),
+/// or `None` when it is disabled, a one-shot already in the past, or has an
+/// unparseable trigger/timezone. Computed at list time (not persisted) so an
+/// operator can see when each schedule is next due — directly answering "did it
+/// drop, or is it just not due yet?". Mirrors `cron_tick::check_schedules`'
+/// normalisation (5-field cron → prepend seconds) + tz resolution so the
+/// displayed instant matches the engine's actual firing.
+fn next_fire_at(schedule: &Schedule) -> Option<String> {
+    if !schedule.enabled {
+        return None;
+    }
+    let now = chrono::Utc::now();
+    match &schedule.trigger {
+        Trigger::Once { at } => {
+            let when = chrono::DateTime::parse_from_rfc3339(at)
+                .ok()?
+                .with_timezone(&chrono::Utc);
+            (when > now).then(|| when.to_rfc3339())
+        }
+        Trigger::Cron { expr } => {
+            let tz_name = if schedule.timezone.is_empty() {
+                detect_timezone()
+            } else {
+                schedule.timezone.as_str()
+            };
+            let tz: chrono_tz::Tz = tz_name.parse().ok()?;
+            let full = if expr.split_whitespace().count() == 5 {
+                format!("0 {expr}")
+            } else {
+                expr.clone()
+            };
+            let parsed = cron::Schedule::from_str(&full).ok()?;
+            parsed
+                .after(&now.with_timezone(&tz))
+                .next()
+                .map(|next| next.with_timezone(&chrono::Utc).to_rfc3339())
+        }
+    }
+}
+
 pub fn list(home: &Path, args: &Value) -> Value {
     let store = load(home);
     let target_filter = args["instance"].as_str();
-    let filtered: Vec<_> = store
+    // #1720 ③: each row carries a computed `next_scheduled_fire_at` (not stored)
+    // so operators can see when it next fires.
+    let schedules: Vec<Value> = store
         .schedules
         .iter()
         .filter(|s| target_filter.is_none_or(|t| s.target == t))
+        .map(|s| {
+            let mut v = serde_json::to_value(s).unwrap_or(Value::Null);
+            if let Value::Object(map) = &mut v {
+                map.insert(
+                    "next_scheduled_fire_at".to_string(),
+                    next_fire_at(s).map_or(Value::Null, Value::String),
+                );
+            }
+            v
+        })
         .collect();
-    serde_json::json!({"schedules": filtered})
+    serde_json::json!({"schedules": schedules})
 }
 
 pub fn update(home: &Path, args: &Value) -> Value {
@@ -709,6 +761,40 @@ mod tests {
             .as_array()
             .expect("arr")
             .is_empty());
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1720 ③: `schedule list` carries a computed `next_scheduled_fire_at` —
+    /// non-null + parseable for an enabled cron schedule, and null once disabled
+    /// (so an operator can see when each schedule is next due).
+    #[test]
+    fn list_includes_next_scheduled_fire_at_1720() {
+        let home = tmp_home("next-fire");
+        let r = create(
+            &home,
+            "agent1",
+            &serde_json::json!({"cron": "0 9 * * *", "message": "hi", "timezone": "UTC"}),
+        );
+        let id = r["id"].as_str().expect("id").to_string();
+
+        let listed = list(&home, &serde_json::json!({}));
+        let next = listed["schedules"][0]["next_scheduled_fire_at"]
+            .as_str()
+            .expect("enabled cron must expose a next_scheduled_fire_at");
+        let parsed = chrono::DateTime::parse_from_rfc3339(next).expect("RFC3339");
+        assert!(
+            parsed.with_timezone(&chrono::Utc) > chrono::Utc::now(),
+            "next fire must be in the future: {next}"
+        );
+
+        // Disabled → null (won't fire).
+        update(&home, &serde_json::json!({"id": id, "enabled": false}));
+        let listed = list(&home, &serde_json::json!({}));
+        assert!(
+            listed["schedules"][0]["next_scheduled_fire_at"].is_null(),
+            "a disabled schedule must report next_scheduled_fire_at = null"
+        );
 
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -986,7 +986,7 @@ fn deliver_cascade_cancel(home: &Path, owner: &str, parent_id: &str, child_id: &
 
 /// #event-bus pattern #7 subscriber: re-deliver a `CascadeCancelNotify` event
 /// via the shared `deliver_cascade_cancel`.
-fn handle_event(event: &crate::daemon::event_bus::Event) {
+fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
     if let crate::daemon::event_bus::EventKind::CascadeCancelNotify {
         owner,
         parent_id,
@@ -994,6 +994,9 @@ fn handle_event(event: &crate::daemon::event_bus::Event) {
     } = &event.kind
     {
         deliver_cascade_cancel(&event.home, owner, parent_id, child_id);
+        true
+    } else {
+        false
     }
 }
 


### PR DESCRIPTION
## #1720 — silent cron-drop

A cron schedule's fires vanished after the event-bus cutover restart: no error,
no `run_history` entry, schedule still enabled. **RCA:** the intermediate cutover
binary emitted the `CronFire` event while its cron subscriber was momentarily
unregistered, so `emit` fanned out to **nothing** and the fire was lost silently.
Current `main` (legacy-zero) already fixed the wiring and has the e2e prod-wiring
test; this PR hardens against the failure **class** so it can never be silent again.

### (B) handled-count — the bus now reports delivery
- `Subscriber` becomes `Fn(&Event) -> bool`. Each `handle_event` returns `true`
  iff it matched its `EventKind` (and ran its deliver), `false` otherwise.
- `emit` returns the **handled-count**. A producer can now distinguish "reached a
  relevant subscriber" from "fanned out to nothing" — the exact gap the cutover
  hid. (The pre-cutover parity tests used a **local** bus and never exercised the
  global register→emit path, so this gap was invisible to them.)

### (Y) cron visibility — no more silent drop
- `check_schedules` captures the handled-count; `note_unhandled_cron_fire`
  records a `skipped: no-subscriber` run + `WARN`s when it is `0`. The drop is now
  **visible** in `run_history` + the log.
- `last_check` is **deliberately not held** — it is a single global file; holding
  it would freeze the whole engine and double-fire every *other* schedule. The
  next slot fires normally (no retry, no infinite loop).
- `deliver_cron_fire` always completes (inject/enqueue errors become their own
  status string, never a throw), so a *registered* subscriber yields `handled >= 1`
  even on an inject error. `handled == 0` means specifically "cron delivery path
  unregistered" — never misattributes a delivery error as a skip.

### (③) operator visibility
- `schedule list` gains a computed `next_scheduled_fire_at` (RFC3339 UTC; `null`
  when disabled / past one-shot), mirroring the engine's cron-normalisation + tz so
  the displayed instant matches the actual firing. Answers "did it drop, or is it
  just not due yet?".

### Tests
- `emit_returns_handled_count` — true/false subs + empty bus → 0.
- `unhandled_cron_fire_records_skipped_1720` — handled==0 records skipped; handled
  fire adds no extra record.
- `list_includes_next_scheduled_fire_at_1720` — future instant present; null when disabled.
- Full bin suite **3198 passed / 0 failed** on the rebased base; clippy
  `--all-targets` (`tray` and `tray,discord`) + fmt clean.

Closes #1720.

---
@codex review — **MED+ adversarial**. Inline comments only. Focus:
1. **handled semantics** — is `handled = matched-EventKind && deliver-ran` correct
   for every one of the 12 ripple subscribers? Any `handle_event` that should
   return `true` but returns `false` (or vice-versa)?
2. **(Y) completeness** — can a genuinely-dropped cron fire ever escape the
   `note_unhandled_cron_fire` recording path?
3. **misjudgement** — can `handled == 0` ever fire for a *delivered-but-errored*
   cron (false "skipped")? Verify `deliver_cron_fire` truly never throws.
4. **no infinite retry / no engine freeze** — confirm `last_check` advances
   unconditionally and a skip cannot wedge or double-fire other schedules.
