### PR TITLE
feat: :config palette command + show_pane_state opt-out + dynamic config key list

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -1,5 +1,5 @@
 //! Command-palette command execution (`:spawn`, `:kill`, `:restart`, `:layout`,
-//! `:send`, `:broadcast`, `:status`).
+//! `:send`, `:broadcast`, `:status`, `:config`).
 //!
 //! Input is a whitespace-split command line. Returns `true` iff the command
 //! mutated the layout in a way that requires a resize pass.
@@ -328,11 +328,43 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                 }
             }
         }
+        "config" => handle_config_command(&parts, ctx.home),
         _ => {
             tracing::warn!(cmd = cmd, "unknown command");
         }
     }
     false
+}
+
+/// Handle `:config get <key>` / `:config set <key> <value>` / `:config list`.
+/// Mirrors the `config` MCP tool path (`runtime_config::get_key/set/list`) so the
+/// operator can toggle runtime config from the TUI without invoking an MCP tool.
+/// Split out of `execute` so it is unit-testable without a full `CommandCtx`.
+///
+/// `parts` is the `splitn(3, ' ')` split, so for `set` the third element holds
+/// `"<key> <value>"` glued together; we re-split it on the first space.
+/// Feedback goes through `tracing` like the sibling `:status` command.
+fn handle_config_command(parts: &[&str], home: &Path) {
+    match parts.get(1).copied() {
+        Some("list") => {
+            tracing::info!(config = %crate::runtime_config::list(), "config list");
+        }
+        Some("get") => match parts.get(2) {
+            Some(key) => match crate::runtime_config::get_key(key) {
+                Ok(value) => tracing::info!(key = key, value = %value, "config get"),
+                Err(e) => tracing::warn!(error = %e, "config get failed"),
+            },
+            None => tracing::warn!("config get requires <key>"),
+        },
+        Some("set") => match parts.get(2).and_then(|kv| kv.split_once(' ')) {
+            Some((key, value)) => match crate::runtime_config::set(home, key, value.trim()) {
+                Ok(result) => tracing::info!(result = %result, "config set"),
+                Err(e) => tracing::warn!(error = %e, "config set failed"),
+            },
+            None => tracing::warn!("config set requires <key> <value>"),
+        },
+        _ => tracing::warn!("config: use `get <key>` | `set <key> <value>` | list"),
+    }
 }
 
 /// Look up the fleet_instance_name for an agent by scanning the layout.
@@ -420,5 +452,35 @@ mod tests {
         let parts: Vec<&str> = "".trim().splitn(3, ' ').collect();
         assert_eq!(parts.len(), 1);
         assert_eq!(parts[0], "");
+    }
+
+    /// `:config set <key> <value>` parse shape: splitn(3) glues "<key> <value>"
+    /// into parts[2]; the handler re-splits on the first space. Pin it so a future
+    /// change to the split width doesn't silently break `set`.
+    #[test]
+    fn config_set_parse_shape_glues_key_value() {
+        let parts: Vec<&str> = "config set show_pane_state true".splitn(3, ' ').collect();
+        assert_eq!(parts[1], "set");
+        assert_eq!(parts[2], "show_pane_state true");
+        assert_eq!(parts[2].split_once(' '), Some(("show_pane_state", "true")));
+    }
+
+    /// `:config set` from the palette must actually reach `runtime_config::set`
+    /// and persist. Assert against the written file (deterministic — avoids the
+    /// process-global cache shared across parallel tests).
+    #[test]
+    fn config_set_via_palette_persists_to_runtime_config() {
+        let dir =
+            std::env::temp_dir().join(format!("agend-test-cmd-config-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        handle_config_command(&["config", "set", "show_pane_state false"], &dir);
+        let raw = std::fs::read_to_string(dir.join("runtime-config.json")).unwrap_or_default();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap_or_default();
+        assert_eq!(
+            v["show_pane_state"],
+            serde_json::json!(false),
+            "palette :config set must persist to runtime-config.json"
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -293,7 +293,11 @@ pub(crate) fn def_watchdog() -> Value {
 }
 
 pub(crate) fn def_config() -> Value {
-    json!({"name": "config", "description": "#1085: Runtime-mutable daemon configuration. Actions: get, set, list. Keys: dev_idle_threshold_secs, fleet_idle_threshold_secs, hang_auto_recovery_enabled.",
+    // Keys are derived from runtime_config's serialized fields so this list can
+    // never go stale as config keys are added (it previously omitted several,
+    // incl. show_pane_state).
+    let keys = crate::runtime_config::keys().join(", ");
+    json!({"name": "config", "description": format!("#1085: Runtime-mutable daemon configuration. Actions: get, set, list. Keys: {keys}."),
     "inputSchema": {"type": "object", "properties": {
         "action": {"type": "string", "enum": ["get", "set", "list"]},
         "key": {"type": "string", "description": "Config key name (required for get/set)"},

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -39,10 +39,11 @@ pub struct RuntimeConfig {
     pub idle_watchdog_enabled: bool,
     /// #1713/#1523 aid: when true, each pane title appends a `[<State>]` text
     /// badge of the detected `AgentState` so the operator can eyeball-verify
-    /// state detection. Default false (off — the colour dot is the steady-state
-    /// signal; this is a temporary diagnostic toggle). Hot-reloadable via the
-    /// `config` MCP tool, like the other gates here.
-    #[serde(default)]
+    /// state detection. Default true (opt-out — the operator wants the badge as a
+    /// steady diagnostic). `default_true` also fills the field for older configs
+    /// written before it existed. Hot-reloadable via the `config` MCP tool, like
+    /// the other gates here.
+    #[serde(default = "default_true")]
     pub show_pane_state: bool,
 }
 
@@ -69,7 +70,7 @@ impl Default for RuntimeConfig {
             hang_auto_recovery_enabled: false,
             usage_limit_propagation_enabled: false,
             idle_watchdog_enabled: true,
-            show_pane_state: false,
+            show_pane_state: true,
         }
     }
 }
@@ -221,6 +222,17 @@ pub fn list() -> serde_json::Value {
     serde_json::to_value(get()).unwrap_or_default()
 }
 
+/// All config key names, derived from the serialized `Default` so callers (e.g.
+/// the `config` MCP tool description) can never go stale — adding a struct field
+/// makes it appear automatically. Keys equal the serde field names, which are
+/// exactly what `get_key`/`set` match on.
+pub fn keys() -> Vec<String> {
+    serde_json::to_value(RuntimeConfig::default())
+        .ok()
+        .and_then(|v| v.as_object().map(|m| m.keys().cloned().collect()))
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -270,14 +282,15 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// #1713: the pane-state badge flag is OFF by default and runtime-toggleable
-    /// via the same `set`/persist/reload path as the other gates (the `config`
-    /// MCP tool reaches `set`), so the operator can flip it without a rebuild.
+    /// #1713/opt-out: the pane-state badge flag now defaults ON (operator wants
+    /// it as a steady diagnostic) and stays runtime-toggleable via the same
+    /// `set`/persist/reload path as the other gates (the `config` MCP tool reaches
+    /// `set`), so the operator can flip it off without a rebuild.
     #[test]
-    fn show_pane_state_default_off_and_toggleable_1713() {
+    fn show_pane_state_default_on_and_toggleable() {
         assert!(
-            !RuntimeConfig::default().show_pane_state,
-            "show_pane_state must default OFF"
+            RuntimeConfig::default().show_pane_state,
+            "show_pane_state must default ON (opt-out)"
         );
         let dir = std::env::temp_dir().join("agend-test-runtime-config-panestate");
         std::fs::create_dir_all(&dir).ok();
@@ -288,5 +301,25 @@ mod tests {
         reload(&dir);
         assert_eq!(get_key("show_pane_state").unwrap(), "false");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// `keys()` is the dynamic source for the `config` MCP tool description, so it
+    /// must cover every settable key — including show_pane_state, whose omission
+    /// from the hand-maintained description is what this change fixes. Every key
+    /// `keys()` reports must also be a valid `set` target (round-trip via get_key).
+    #[test]
+    fn keys_cover_all_settable_keys_including_show_pane_state() {
+        let ks = keys();
+        assert!(
+            ks.iter().any(|k| k == "show_pane_state"),
+            "keys() must include show_pane_state (was missing from the MCP description): {ks:?}"
+        );
+        // Every reported key resolves via get_key — proves keys() ≡ valid keys.
+        for k in &ks {
+            assert!(
+                get_key(k).is_ok(),
+                "keys() reported a non-gettable key: {k}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Three operator-facing config improvements in one PR (per dispatch).

## 1. Palette `:config get/set/list` (`src/app/commands.rs`)
Adds a `config` arm to the command palette, extracted into a testable `handle_config_command(parts, home)` that mirrors the `config` MCP tool path (`runtime_config::get_key`/`set`/`list`). The operator can now toggle runtime config straight from the TUI — no MCP-tool name to remember.
- `:config get <key>` · `:config set <key> <value>` · `:config list`
- `set` re-splits `parts[2]` on the first space, since the palette parser's `splitn(3, ' ')` glues `"<key> <value>"` into one token.
- Feedback goes through `tracing` (info on success, warn on error), matching the sibling `:status` command.

## 2. `show_pane_state` default → true (opt-out) (`src/runtime_config.rs`)
The `[<State>]` pane badge becomes a steady diagnostic by default. `#[serde(default)]` → `#[serde(default = "default_true")]` so configs predating the field also deserialize to `true`, and `Default` is `true`.
- **Note:** a config with an *explicit* `show_pane_state: false` keeps it — serde's `default` only fills *absent* fields. That's the correct honour-operator-intent semantics; fresh installs and pre-field configs get `true`.

## 3. config MCP tool description (`src/mcp/tools.rs`)
The hand-maintained `Keys: …` list was stale — it listed 3 of 7 keys and omitted `show_pane_state` (among others). It's now built from `runtime_config::keys()`, derived from the serialized `Default`, so it can never go stale as keys are added.

## Tests
- `show_pane_state_default_on_and_toggleable` — default ON + runtime-toggleable round-trip.
- `keys_cover_all_settable_keys_including_show_pane_state` — `keys()` includes `show_pane_state` and every reported key is `get_key`-able (keys ≡ valid set targets).
- `config_set_parse_shape_glues_key_value` — pins the `splitn(3)` + `split_once` parse so a future split-width change can't silently break `set`.
- `config_set_via_palette_persists_to_runtime_config` — `:config set` reaches `runtime_config::set` and persists (asserts the written file, deterministic).

## Verification
- `cargo fmt --check` ✅ · clippy `tray` + `tray,discord` `-D warnings` ✅
- full bin test suite: **3198 passed, 0 failed** · `file_size_invariant` (#1463) ✅

Base: `dd12c04` (origin/main). Daemon-side + TUI change → takes effect on rebuild/restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)