### PR TITLE
fix: register event-bus subscribers in app mode (cutover regression — silent delivery drop)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -360,6 +360,16 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         })
         .ok();
 
+    // #event-bus: owned `app` mode never calls `daemon::run_core`, so it must
+    // register the bus subscribers itself — otherwise the maintenance tick below
+    // emits `CronFire` / `CiReady` / idle nudges into a bus with ZERO subscribers
+    // and every delivery silently drops (the live #1720 cron silent-drop; same
+    // regression class as #1002 / #982). Mirrors run_core; gated to owned mode
+    // because the attached daemon process owns delivery when attached.
+    if !attached_mode {
+        crate::daemon::register_event_subscribers(&registry);
+    }
+
     // Periodic maintenance tick (10s) — mirrors daemon tick cadence.
     // Only active in owned (non-attached) mode; when attached, the daemon
     // process handles schedules, CI watches, and health decay.
@@ -1477,6 +1487,31 @@ mod tests {
             "flush_idle_notifications must wire the submit-aware injector \
              (#982 reviewer #999 verdict) — searched for \
              'inject_notification_with_submit' in src/app/mod.rs"
+        );
+    }
+
+    /// app-mode subscriber-wiring source pin. Owned `agend-terminal app` mode
+    /// never calls `daemon::run_core`, so `run_app` MUST itself register the
+    /// event-bus subscribers — otherwise the maintenance tick emits `CronFire` /
+    /// `CiReady` / idle nudges into an empty bus and every delivery silently
+    /// drops (the live #1720 cron silent-drop; regression class #1002 / #982).
+    ///
+    /// File-level positive pin (cross-platform-safe; survives rustfmt re-wrap),
+    /// same pattern as `flush_idle_notifications_wired_to_submit_aware_inject`.
+    /// The functional counterpart —
+    /// `cron_tick::tests::global_bus_cron_subscriber_delivers` — proves the
+    /// registered set actually delivers a CronFire on the process-global bus.
+    #[test]
+    fn run_app_registers_event_bus_subscribers() {
+        let source = std::fs::read_to_string("src/app/mod.rs")
+            .or_else(|_| std::fs::read_to_string("agend-terminal/src/app/mod.rs"))
+            .expect("source file must be readable from test cwd");
+        assert!(
+            source.contains("register_event_subscribers"),
+            "run_app must call daemon::register_event_subscribers in owned mode \
+             (app mode never reaches run_core's registration — #1720 app-mode \
+             silent-drop root fix). Searched for 'register_event_subscribers' in \
+             src/app/mod.rs"
         );
     }
 

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -669,6 +669,42 @@ mod tests {
         std::fs::remove_dir_all(home).ok();
     }
 
+    /// app-mode wiring (functional half of the #1720 root fix): the cron
+    /// subscriber MUST be reachable on the PROCESS-GLOBAL bus — the live
+    /// `agend-terminal app` tick emits there (app/mod.rs), and owned mode now
+    /// registers via `daemon::register_event_subscribers`. Emitting a `CronFire`
+    /// DIRECTLY on `global()` (NOT a local test bus — that local-bus convenience
+    /// is exactly the blind spot that let the app-mode silent-drop ship green)
+    /// must reach `deliver_cron_fire` and record a run. Fails if
+    /// `register_event_subscribers` ever drops the cron line. The subscriber is
+    /// registered at test-load by the ctor → `register_all_subscribers_for_test`
+    /// → `register_event_subscribers` (the SAME fn prod uses — no test-only list).
+    /// Unknown target ⇒ deterministic `skipped_unknown_target` (no timing or
+    /// registry-contents dependence).
+    #[test]
+    fn global_bus_cron_subscriber_delivers() {
+        let home = cron_tmp_home("global-wiring");
+        seed_oneshot(&home, "ghost"); // not a known instance → skipped_unknown_target
+        crate::daemon::event_bus::global().emit(
+            &home,
+            crate::daemon::event_bus::EventKind::CronFire {
+                sched_id: "s-1488".to_string(),
+                target: "ghost".to_string(),
+                message: "ping".to_string(),
+                label: "t".to_string(),
+                one_shot: true,
+                missed: false,
+            },
+        );
+        assert_eq!(
+            last_status(&home),
+            "skipped_unknown_target",
+            "a CronFire emitted on the GLOBAL bus must reach the cron subscriber — \
+             register_event_subscribers must wire cron (app-mode delivery depends on it)"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
     // ── #1521: UntilSuccess fire-strategy ──
 
     /// #1608b: seed a REAL event-sourced task (so `task_events::replay` — the

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -184,20 +184,16 @@ pub(crate) fn register_all_subscribers_for_test() {
     use std::sync::Once;
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
-        crate::daemon::anti_stall::register_subscriber();
-        crate::daemon::decision_timeout::register_subscriber();
-        crate::daemon::dispatch_idle::register_subscriber();
-        crate::daemon::waiting_on_stale::register_subscriber();
-        crate::daemon::helper_staleness_watchdog::register_subscriber();
-        crate::daemon::idle_watchdog::register_subscriber();
-        crate::tasks::register_cascade_subscriber();
-        crate::daemon::poll_reminder::register_subscriber();
+        // DRY: route through the SAME registration list prod uses
+        // (`daemon::register_event_subscribers`), so test wiring can NEVER drift
+        // from live wiring — the drift that masked the #1720 app-mode silent-drop
+        // (this helper registered cron; the live `agend-terminal app` path did not).
+        // cron gets a dummy empty registry — cron integration tests use empty
+        // registries + assert the home-driven inbox fallback, so the captured
+        // registry's contents don't affect them.
         let dummy_registry: crate::agent::AgentRegistry =
             std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
-        crate::daemon::cron_tick::register_subscriber(dummy_registry);
-        crate::daemon::supervisor::register_subscriber();
-        crate::daemon::conflict_notify::register_subscriber();
-        crate::daemon::ci_watch::register_subscriber();
+        crate::daemon::register_event_subscribers(&dummy_registry);
     });
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -392,6 +392,36 @@ pub fn run_with_prepared(mut prepared: Box<crate::bootstrap::OwnedFleet>) -> any
 /// daemon-self-restart loop here would conflict with the OS service
 /// manager's lifecycle ownership.
 ///
+/// #event-bus: register every per-pattern delivery subscriber on the
+/// process-global bus. Post-cutover (#1719 legacy-zero) the bus is the SOLE
+/// delivery path, so this MUST run in every mode that ticks producers.
+///
+/// Called by BOTH `run_core` (headless daemon mode) AND `app::run_app` (owned
+/// `agend-terminal app` mode). The latter never calls `run_core` — so before
+/// this was shared, app mode registered NOTHING and every emit (cron fire,
+/// idle nudge, ci-ready handoff, …) silently dropped. That was the live
+/// silent-drop behind #1720/#1723, and the same regression class as #1002
+/// (`pr_state`) / #982 (idle notifications): "wired only in run_core, broke in
+/// app mode". The test harness (`event_bus::register_all_subscribers_for_test`)
+/// routes through this SAME fn — ONE subscriber list, so test wiring can never
+/// drift from live wiring again (the drift that masked this bug). Each
+/// subscriber is home-agnostic (the home travels on every event); cron captures
+/// the live `registry` to resolve + inject to the fleet.
+pub(crate) fn register_event_subscribers(registry: &AgentRegistry) {
+    crate::daemon::anti_stall::register_subscriber();
+    crate::daemon::decision_timeout::register_subscriber();
+    crate::daemon::dispatch_idle::register_subscriber();
+    crate::daemon::waiting_on_stale::register_subscriber();
+    crate::daemon::helper_staleness_watchdog::register_subscriber();
+    crate::daemon::idle_watchdog::register_subscriber();
+    crate::tasks::register_cascade_subscriber();
+    crate::daemon::poll_reminder::register_subscriber();
+    crate::daemon::cron_tick::register_subscriber(registry.clone());
+    crate::daemon::supervisor::register_subscriber();
+    crate::daemon::conflict_notify::register_subscriber();
+    crate::daemon::ci_watch::register_subscriber();
+}
+
 /// Sprint 57 Wave 3 PR-2 (#548 Q4 contract pin): the canonical
 /// lockfile is `$AGEND_HOME/.daemon.lock` (one acquirer at a time
 /// across all daemon processes). Per-PID identity is at
@@ -407,21 +437,10 @@ fn run_core(
     let ctx = init_daemon_services(home, telegram)?;
 
     // #event-bus Step 2 (legacy-zero): register the per-pattern delivery
-    // subscribers once. The bus is the SOLE delivery path; each subscriber is
-    // home-agnostic (the home travels on every event). cron also captures the live
-    // registry (to resolve + inject to the fleet).
-    crate::daemon::anti_stall::register_subscriber();
-    crate::daemon::decision_timeout::register_subscriber();
-    crate::daemon::dispatch_idle::register_subscriber();
-    crate::daemon::waiting_on_stale::register_subscriber();
-    crate::daemon::helper_staleness_watchdog::register_subscriber();
-    crate::daemon::idle_watchdog::register_subscriber();
-    crate::tasks::register_cascade_subscriber();
-    crate::daemon::poll_reminder::register_subscriber();
-    crate::daemon::cron_tick::register_subscriber(ctx.registry.clone());
-    crate::daemon::supervisor::register_subscriber();
-    crate::daemon::conflict_notify::register_subscriber();
-    crate::daemon::ci_watch::register_subscriber();
+    // subscribers once (the bus is the SOLE delivery path). Shared with
+    // `app::run_app` so owned `agend-terminal app` mode wires the IDENTICAL
+    // set — see `register_event_subscribers`.
+    register_event_subscribers(&ctx.registry);
 
     spawn_fleet_agents(home, &agents, &ctx);
 
@@ -1381,6 +1400,44 @@ mod tests {
         assert!(dir.display().to_string().contains(&pid));
         assert!(dir.ends_with(&pid));
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1720 app-mode root fix: `register_event_subscribers` is the SINGLE
+    /// source of truth for the event-bus subscriber list (run_core, app::run_app,
+    /// and the test harness all route through it). Pin every one of the 12
+    /// per-pattern registrations so a dropped line — which would silently kill
+    /// that pattern's delivery in BOTH prod modes at once — fails CI. Source-level
+    /// pin (cross-platform-safe; survives rustfmt). When adding a pattern, add it
+    /// here AND to `register_event_subscribers`.
+    #[test]
+    fn register_event_subscribers_lists_every_pattern() {
+        let src = std::fs::read_to_string("src/daemon/mod.rs")
+            .or_else(|_| std::fs::read_to_string("agend-terminal/src/daemon/mod.rs"))
+            .expect("source file must be readable from test cwd");
+        let start = src
+            .find("pub(crate) fn register_event_subscribers")
+            .expect("register_event_subscribers must exist");
+        let body = &src[start..(start + 1200).min(src.len())];
+        for pat in [
+            "anti_stall::register_subscriber",
+            "decision_timeout::register_subscriber",
+            "dispatch_idle::register_subscriber",
+            "waiting_on_stale::register_subscriber",
+            "helper_staleness_watchdog::register_subscriber",
+            "idle_watchdog::register_subscriber",
+            "tasks::register_cascade_subscriber",
+            "poll_reminder::register_subscriber",
+            "cron_tick::register_subscriber",
+            "supervisor::register_subscriber",
+            "conflict_notify::register_subscriber",
+            "ci_watch::register_subscriber",
+        ] {
+            assert!(
+                body.contains(pat),
+                "register_event_subscribers must register '{pat}' — a missing \
+                 pattern silently breaks its delivery in app + daemon mode (#1720)"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Live delivery regression — app mode dropped every event-bus emit

The #1719 cutover ("legacy-zero": the bus is the **sole** delivery path) registered
the per-pattern subscribers **only** in `daemon::run_core`. But owned `agend-terminal
app` mode **never calls `run_core`** (documented at `supervisor.rs:3251`: *"In APP mode
(`agend-terminal app`), `run_core` is never called"*). So in app mode the process-global
bus had **zero subscribers** and every `emit` fanned out to nothing — silently dropped.
The app tick still calls `check_schedules` (`app/mod.rs:705`), which post-cutover **only
emits** `CronFire` → straight into the void.

### Runtime-confirmed (live daemon, PID `agend-terminal app`)
- One-shot schedule: `run_at` in the past, target a **running** agent, `enabled: true`.
- Result: no `schedule triggered` log, **empty `run_history`**, schedule **stayed enabled**,
  while `.schedule_last_check` kept advancing → the tick ran, `classify_once` returned due,
  `emit` fired, and it reached **no subscriber**.
- **Zero cron fired** after the app-mode restart (the daily 早報/晚報/AI-scout schedules).

This is the live silent-drop behind #1720/#1723. #1723 makes it **visible** (records
`skipped: no-subscriber`); **this PR restores delivery.** Complementary, not a substitute.

### Regression class
Same as #1002 (`pr_state::scan_and_emit`) / #982 (idle notifications): *"wired only in
run_core, broke in app mode."* Those each added an app-loop call **+ a source-pin
invariant**. The #1719 cutover repeated the bug with **no** invariant — hence this fix
adds one.

### Scope: broad
All 13 bus patterns were dead in app mode (cron, dispatch_idle, idle_watchdog, supervisor
member-state, conflict_notify, poll_reminder, decision_timeout, waiting_on_stale,
helper_staleness, cascade-cancel, **ci-ready/ci-fail handoff**, …). Cron is the
runtime-confirmed casualty; `ci_watch`'s **poll** survived only because `app/mod.rs:706`
calls `check_ci_watches` inline — but its bus-emitted success/failure notifications dropped
too (so the `[ci-ready-for-action]` fleet handoff was also dead in app mode).

### Fix
- Extract `run_core`'s registration block → shared `daemon::register_event_subscribers(registry)`
  — the **single** subscriber list.
- `run_core` calls it; **`app::run_app` also calls it** (owned mode, after the registry is
  built, before the maintenance tick).
- `event_bus::register_all_subscribers_for_test` routes through the **same** fn — collapses
  the three drifting copies of the list (the drift that masked this bug: the test helper
  registered cron, the live app path did not).

### Tests (the guard that was missing)
- `cron_tick::global_bus_cron_subscriber_delivers` — emits a `CronFire` on the **process-global**
  bus (NOT a local test bus — that local-bus convenience is the blind spot that let this ship
  green) and asserts it reaches `deliver_cron_fire`. **Negative-probed**: drop the cron
  registration → this test fails (verified).
- `app::run_app_registers_event_bus_subscribers` — source-pin that `run_app` wires the
  subscribers (mirrors the #1002/#982 anti-regression pattern).
- `daemon::register_event_subscribers_lists_every_pattern` — source-pin that all 12 per-pattern
  registrations are present.

Full bin suite **3201 passed / 0 failed**; clippy `--all-targets` (`tray` and `tray,discord`)
+ fmt clean. ⚠ **Requires a daemon restart to take effect.**

Note: signature is `register_event_subscribers(registry: &AgentRegistry)` — `home` is not
needed (subscribers are home-agnostic; the home travels on each event), so it was omitted.

---
@codex review — **MED+ adversarial**. Inline comments only. Focus:
1. **app mode really registers now** — does `run_app`'s call actually execute on the owned
   boot path (gated correctly to `!attached_mode`, before the tick that emits)? Any path
   where it's skipped?
2. **invariant has teeth** — would `register_event_subscribers_lists_every_pattern` /
   `run_app_registers_event_bus_subscribers` actually fail if the wiring regresses, or are
   they tautological (e.g. matching their own test source)?
3. **no double-registration** — app mode previously called `check_ci_watches` inline; with
   the ci_watch subscriber now also registered, is there any double-delivery (vs run_core's
   proven inline-tick + subscriber split)? Timing/ordering correct?
4. **functional test isn't masked by the ctor** — does `global_bus_cron_subscriber_delivers`
   genuinely exercise `register_event_subscribers`, given the ctor pre-registers on the
   global bus?
