### PR TITLE
fix: stop dispatch stuck-check flip-flop (orphaned entries re-asked forever)

### DIFF
--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -83,7 +83,17 @@ pub fn sweep_stuck(home: &Path) -> (Vec<DispatchEntry>, Vec<DispatchEntry>) {
     persist_or_log!(
         crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
             for entry in store.entries.iter_mut() {
-                if entry.status == "completed" {
+                // Skip BOTH terminal states — mirrors `sweep_orphans`' skip set.
+                // Without skipping `orphaned`, an entry past DISPATCH_ORPHAN_HOURS
+                // flip-flops forever: `sweep_orphans` overwrites its `asked` status
+                // with `orphaned`, then this sweep sees `orphaned != "asked"` and
+                // re-asks (re-marking `asked`), which `sweep_orphans` flips back —
+                // re-firing a "dispatch stuck check" every maintenance tick until
+                // the 30-day GC. `orphaned` = already given up after 24h; never nag
+                // again. (#1488 noted this re-fire but only fixed deleted-instance
+                // entries via `cleanup_for_instance`; this fixes still-existing
+                // targets whose orphaned entries otherwise nag for ~30 days.)
+                if entry.status == "completed" || entry.status == "orphaned" {
                     continue;
                 }
                 let delegated = match chrono::DateTime::parse_from_rfc3339(&entry.delegated_at) {
@@ -141,12 +151,12 @@ pub fn sweep_orphans(home: &Path) -> Vec<DispatchEntry> {
 
 /// #1488: drop every dispatch entry that involves `instance` as either the
 /// dispatcher (`from`) or the target (`to`). When an instance is deleted, its
-/// in-flight dispatches can never complete, so `sweep_stuck` would re-warn /
-/// re-ask them forever (the empirical ~81 "dispatch stuck check" messages).
-/// Marking them "orphaned" is NOT enough — `sweep_stuck` only skips
-/// `completed`, so an orphaned-but-uncompleted entry still re-fires. Removal
-/// is the only thing that stops the noise; the entries carry no re-target
-/// value once the instance is gone. Returns the number removed.
+/// in-flight dispatches can never complete, so without cleanup they linger as
+/// noise (the empirical ~81 "dispatch stuck check" messages). `sweep_stuck` now
+/// skips `orphaned` (the flip-flop fix), so such entries stop re-asking after
+/// 24h — but removal is still preferred for a deleted instance: the entry can
+/// never complete and carries no re-target value, so freeing the row beats
+/// leaving it for the 30-day GC. Returns the number removed.
 pub fn cleanup_for_instance(home: &Path, instance: &str) -> usize {
     let mut removed = 0usize;
     persist_or_log!(
@@ -278,6 +288,57 @@ mod tests {
         );
         assert_eq!(asks.len(), 1, "31min old dispatch must ask");
         assert_eq!(asks[0].to, "reviewer");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Flip-flop fix: an `orphaned` entry (already given up on after 24h) must
+    /// NOT be re-asked by `sweep_stuck`. Before the fix, `sweep_orphans`
+    /// overwrote `asked` → `orphaned`, then `sweep_stuck` saw `orphaned != "asked"`
+    /// and re-asked, which `sweep_orphans` flipped back — re-firing a "dispatch
+    /// stuck check" every maintenance tick for ~30 days until GC. The same-age
+    /// `pending` entry MUST still ask: the fix skips only the terminal `orphaned`
+    /// state, it does not suppress normal nagging.
+    #[test]
+    fn orphaned_entry_is_not_re_asked() {
+        let home = tmp_home("orphaned-no-reask");
+        let old = (chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339();
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-orphaned".into()),
+                from: "lead".into(),
+                to: "fixup-dev-2".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: old.clone(),
+                status: "orphaned".into(),
+            },
+        );
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-pending".into()),
+                from: "lead".into(),
+                to: "fixup-dev-2".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: old,
+                status: "pending".into(),
+            },
+        );
+        let (_warns, asks) = sweep_stuck(&home);
+        assert_eq!(
+            asks.len(),
+            1,
+            "only the pending entry asks; the orphaned one is skipped"
+        );
+        assert_eq!(asks[0].task_id.as_deref(), Some("t-pending"));
+        assert!(
+            !asks
+                .iter()
+                .any(|a| a.task_id.as_deref() == Some("t-orphaned")),
+            "an orphaned entry must never be re-asked (flip-flop fix)"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
## Dispatch stuck-check flip-flop — `orphaned` entries re-asked every tick

`sweep_stuck` skipped only `completed`, so any entry past `DISPATCH_ORPHAN_HOURS`
flip-flopped with `sweep_orphans` and re-fired a "dispatch stuck check" on **every**
maintenance tick:

```
sweep_stuck marks it `asked`
  → sweep_orphans (24h) overwrites `asked` → `orphaned`
    → next sweep_stuck sees `orphaned != "asked"` → re-asks (re-marks `asked`)
      → sweep_orphans flips it back → … repeats for ~30 days until GC
```

The dedup (`status != "asked"`) was real, but `sweep_orphans` clobbered it.

### Runtime evidence
Live `dispatch_tracking.json`: 2184 entries — **1650 completed / 527 orphaned / 7 asked**.
The 527 `orphaned` entries each re-asked every 10-min tick → a flood of stale
stuck-checks at every recipient (e.g. 30 distinct ancient task_ids hitting `fixup-dev-2`
twice within 10 min, identical set each cycle).

### Why now
#1726 (app-standalone runs the full per_tick pipeline) activated `run_task_maintenance`
in the live **app-mode** daemon for the first time. The 527-entry backlog had silently
accumulated while app mode never swept (the same run_core-vs-app-mode gap #1720/#1725
just closed). So this is a **latent defect surfaced by the fix**, not introduced by it.

### Fix (focused)
`sweep_stuck` skips `orphaned` too — aligning its skip set with `sweep_orphans`. An
`orphaned` entry is one already given up on after 24h; never nag again, let the 30-day
GC reap it. (#1488 noted this re-fire but only fixed *deleted-instance* entries via
`cleanup_for_instance`; this fixes still-existing targets whose orphaned entries
otherwise nag for ~30 days.) Also refreshes the now-stale `cleanup_for_instance` doc
comment that claimed "sweep_stuck only skips completed".

### Test
`orphaned_entry_is_not_re_asked` — an `orphaned` entry yields **no** ask, while a
same-age `pending` entry **still asks** (normal nagging preserved). **Negative-probed**:
revert the skip → the test fails (orphaned gets re-asked).

Full bin suite **3207 passed / 0 failed**; clippy `--all-targets` (`tray` and
`tray,discord`) + fmt clean.

### Scope note
Focused on stopping the flood. The existing 527 orphaned entries are left for the
30-day GC (**no live-state edit**) — fix + restart stops new re-asks. Broader
delete-on-resolve retention is a follow-up.

⚠ **Requires a daemon restart to take effect.**

---
@codex review — **MED-tier**. Inline comments only. Focus:
1. `orphaned` is genuinely skipped now, and the skip set matches `sweep_orphans`.
2. **No over-suppression** — a normal `pending`/`warned` entry still warns/asks on
   schedule (the fix must not silence real stuck dispatches).
3. No path where a real, still-active stuck dispatch is mis-skipped because it was
   prematurely marked `orphaned`.
