### PR TITLE
fix: cap dispatch state accumulation at the source (A-D debt cleanup)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -1583,11 +1583,9 @@ mod tests {
         );
         assert_eq!(result["ok"], true, "report send must succeed: {result}");
         let pending = crate::daemon::dispatch_idle::list_pending(&home);
-        let entry = pending.iter().find(|p| p.dispatch_id == id).unwrap();
-        assert_eq!(
-            entry.status,
-            crate::daemon::dispatch_idle::DispatchStatus::Resolved,
-            "kind=report with matching correlation_id must resolve the sidecar"
+        assert!(
+            !pending.iter().any(|p| p.dispatch_id == id),
+            "kind=report with matching correlation_id must resolve (delete) the sidecar"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1716,17 +1714,16 @@ mod tests {
         );
         assert_eq!(reported["ok"], true, "report must deliver: {reported}");
 
-        // #1525: the sidecar must now be resolved (mark_resolved flips status,
-        // does not delete). Pre-fix it stayed `pending` → fired a nudge.
+        // #1525: the report must clear the sidecar. mark_resolved now DELETES the
+        // file (rather than flipping to Resolved), so the sidecar must be absent.
+        // Pre-fix it stayed `pending` → fired a nudge.
         let after = crate::daemon::dispatch_idle::list_pending(&home);
-        assert_eq!(
+        assert!(
             after
                 .iter()
-                .find(|p| p.correlation_id.as_deref() == Some("t-1525-x"))
-                .map(|p| p.status),
-            Some(crate::daemon::dispatch_idle::DispatchStatus::Resolved),
-            "#1525: a report carrying the id in task_id must clear the sidecar \
-             via the correlation_id.or(task_id) symmetry"
+                .all(|p| p.correlation_id.as_deref() != Some("t-1525-x")),
+            "#1525: a report carrying the id in task_id must clear (delete) the \
+             sidecar via the correlation_id.or(task_id) symmetry"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -294,14 +294,15 @@ pub(crate) fn cleanup_pending_for_task_id(home: &Path, task_id: &str) -> usize {
     }
     let mut count = 0usize;
     for d in list_pending(home) {
-        if d.status != DispatchStatus::Pending {
-            continue;
-        }
+        // A closed task → purge EVERY sidecar for it, not just Pending ones. A
+        // late report on an already-Exceeded dispatch (or a task closing after the
+        // idle nudge fired) must still clear the sidecar (codex probe #1).
         if d.correlation_id.as_deref() != Some(task_id) {
             continue;
         }
         let path = pending_path(home, &d.dispatch_id);
         if std::fs::remove_file(&path).is_ok() {
+            let _ = std::fs::remove_file(format!("{}.lock", path.display()));
             count += 1;
             tracing::debug!(
                 target: "dispatch_idle",
@@ -373,8 +374,13 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
     if correlation_id.is_empty() {
         return None;
     }
+    // A report arriving = the dispatch is done, whether it was still `Pending` or
+    // had already timed out to `Exceeded` (idle nudge fired). Match BOTH so a LATE
+    // report on an Exceeded dispatch still deletes the sidecar — otherwise it leaks
+    // until the slow retention / terminal-sweep path (codex probe #1 regression).
     let matched = list_pending(home).into_iter().find(|d| {
-        d.status == DispatchStatus::Pending && d.correlation_id.as_deref() == Some(correlation_id)
+        matches!(d.status, DispatchStatus::Pending | DispatchStatus::Exceeded)
+            && d.correlation_id.as_deref() == Some(correlation_id)
     });
     let d = matched?;
     let id = d.dispatch_id.clone();
@@ -1125,6 +1131,35 @@ mod tests {
         let removed = cleanup_pending_for_instance(&home, "gone-agent");
         assert_eq!(removed, 1, "must delete the non-Pending (Exceeded) sidecar");
         assert!(!path.exists(), "Exceeded sidecar must be removed");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// codex probe #1 regression: a LATE report on a dispatch that already timed
+    /// out (Pending → Exceeded, idle nudge fired) must STILL delete the sidecar.
+    /// Pre-fix `mark_resolved` matched only `Pending`, so the Exceeded sidecar
+    /// leaked until the slow retention / terminal-sweep path.
+    #[test]
+    fn mark_resolved_clears_exceeded_sidecar() {
+        let home = tmp_home("resolve-exceeded");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+        let id = write_pending_at(&home, "lead", "dev", Some("t-late"), "task", 600, issued);
+        // Flip to Exceeded on disk, as the idle scan would once the threshold passes.
+        let path = pending_path(&home, &id);
+        let mut pd: PendingDispatch =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        pd.status = DispatchStatus::Exceeded;
+        std::fs::write(&path, serde_json::to_string_pretty(&pd).unwrap()).unwrap();
+
+        let resolved = mark_resolved(&home, "t-late");
+        assert_eq!(
+            resolved.as_deref(),
+            Some(id.as_str()),
+            "late report must resolve the already-Exceeded sidecar"
+        );
+        assert!(
+            !path.exists(),
+            "late report must delete the Exceeded sidecar (not leak it)"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -335,14 +335,15 @@ pub(crate) fn cleanup_pending_for_instance(home: &Path, instance_name: &str) -> 
     }
     let mut count = 0usize;
     for d in list_pending(home) {
-        if d.status != DispatchStatus::Pending {
-            continue;
-        }
+        // Clean EVERY sidecar for the deleted instance, not just Pending ones.
+        // Resolved/Exceeded sidecars have no further use once the target is gone,
+        // and skipping them (the pre-fix behaviour) left them to accumulate.
         if d.target != instance_name {
             continue;
         }
         let path = pending_path(home, &d.dispatch_id);
         if std::fs::remove_file(&path).is_ok() {
+            let _ = std::fs::remove_file(format!("{}.lock", path.display()));
             count += 1;
             tracing::debug!(
                 target: "dispatch_idle",
@@ -378,16 +379,19 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
     let d = matched?;
     let id = d.dispatch_id.clone();
     let path = pending_path(home, &id);
-    crate::store::with_json_state::<PendingDispatch, _, _>(&path, |current| {
-        if current.status != DispatchStatus::Pending {
-            return None;
-        }
-        current.status = DispatchStatus::Resolved;
-        Some(id.clone())
-    })
-    .ok()
-    .flatten()
-    .flatten()
+    // A resolved dispatch has no further use — the idle timer's job is done.
+    // DELETE the sidecar rather than flip it to `Resolved` and leave the file to
+    // accumulate. Pre-fix this set `status = Resolved` and nothing ever removed it
+    // (the primary `pending-dispatches/` leak: `cleanup_pending_for_instance`
+    // skipped non-Pending and the 14-day retention sweep was gated off), so
+    // resolved sidecars piled up and a restart re-processed the whole backlog.
+    if std::fs::remove_file(&path).is_ok() {
+        // Best-effort: drop the sidecar's lock file too so it doesn't orphan.
+        let _ = std::fs::remove_file(format!("{}.lock", path.display()));
+        Some(id)
+    } else {
+        None
+    }
 }
 
 /// #1047: reset the timer on a pending sidecar when the dispatchee sends
@@ -1088,18 +1092,39 @@ mod tests {
             "must resolve the correlation_id-matching sidecar, not sender-matching"
         );
         let pending = list_pending(&home);
-        let p_a = pending.iter().find(|p| p.dispatch_id == id_a).unwrap();
-        let p_b = pending.iter().find(|p| p.dispatch_id == id_b).unwrap();
-        assert_eq!(
-            p_a.status,
-            DispatchStatus::Resolved,
-            "matched sidecar must flip"
+        // A: the matched sidecar is DELETED on resolve (no longer flipped to
+        // Resolved + left behind), so it must be absent from list_pending.
+        assert!(
+            !pending.iter().any(|p| p.dispatch_id == id_a),
+            "matched sidecar must be deleted on resolve"
         );
+        let p_b = pending.iter().find(|p| p.dispatch_id == id_b).unwrap();
         assert_eq!(
             p_b.status,
             DispatchStatus::Pending,
-            "unmatched sidecar from same dispatcher must NOT flip"
+            "unmatched sidecar from same dispatcher must NOT be touched"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A: `cleanup_pending_for_instance` deletes EVERY sidecar for the instance,
+    /// including non-Pending (Exceeded/Resolved) ones — previously it skipped
+    /// them, leaving resolved/exceeded sidecars to accumulate.
+    #[test]
+    fn cleanup_pending_deletes_non_pending_sidecars() {
+        let home = tmp_home("cleanup-non-pending");
+        let now = chrono::Utc::now();
+        let id = write_pending_at(&home, "lead", "gone-agent", Some("t-x"), "task", 600, now);
+        // Flip the sidecar to a terminal (non-Pending) status on disk.
+        let path = pending_path(&home, &id);
+        let mut pd: PendingDispatch =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        pd.status = DispatchStatus::Exceeded;
+        std::fs::write(&path, serde_json::to_string_pretty(&pd).unwrap()).unwrap();
+
+        let removed = cleanup_pending_for_instance(&home, "gone-agent");
+        assert_eq!(removed, 1, "must delete the non-Pending (Exceeded) sidecar");
+        assert!(!path.exists(), "Exceeded sidecar must be removed");
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -1922,14 +1947,11 @@ mod tests {
         let resolved = mark_resolved(&home, "t-1047-c");
         assert!(resolved.is_some(), "report must resolve sidecar");
         let pending = list_pending(&home);
-        let d = pending
-            .iter()
-            .find(|p| p.correlation_id.as_deref() == Some("t-1047-c"))
-            .unwrap();
-        assert_eq!(
-            d.status,
-            DispatchStatus::Resolved,
-            "kind=report must set status=resolved"
+        assert!(
+            !pending
+                .iter()
+                .any(|p| p.correlation_id.as_deref() == Some("t-1047-c")),
+            "kind=report must resolve (delete) the sidecar"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/orphan_sweep.rs
+++ b/src/daemon/orphan_sweep.rs
@@ -61,10 +61,18 @@ pub fn run(home: &Path) {
         watches_scrubbed += crate::daemon::ci_watch::cleanup_watches_for_instance(home, &name);
     }
 
-    if schedules_orphaned + dispatches_gced + watches_scrubbed > 0 {
+    // dispatch_tracking terminal rows (completed/orphaned) for ANY target —
+    // including LIVE ones whose dispatches completed or were given up. The
+    // dead-target loop above only catches gone instances; this clears the
+    // accumulated terminal backlog (e.g. the completed/orphaned rows behind the
+    // flood) at boot rather than waiting for the 30-day TTL.
+    let tracking_gced = crate::dispatch_tracking::sweep_terminal_entries(home);
+
+    if schedules_orphaned + dispatches_gced + watches_scrubbed + tracking_gced > 0 {
         tracing::info!(
             schedules_orphaned,
             dispatches_gced,
+            tracking_gced,
             watches_scrubbed,
             "#1488 boot orphan sweep: cleaned stale bindings of deleted instances"
         );

--- a/src/daemon/retention/mod.rs
+++ b/src/daemon/retention/mod.rs
@@ -32,13 +32,23 @@ impl RetentionSupervisor {
         tracing::info!("retention sweep: starting cycle");
 
         let decisions_swept = decisions::sweep(home);
-        let cutover = std::env::var("AGEND_RETENTION_CUTOVER").as_deref() == Ok("1");
+        // Pending-dispatch retention now defaults ON (opt-out via
+        // AGEND_RETENTION_CUTOVER=0). It was a staged-rollout gate, not a
+        // bug-gate; the sweep only deletes sidecars with `issued_at < now-14d`
+        // (a real dispatch resolves in minutes, never survives 14 days), so it
+        // is safe to enable by default — closing the `exceeded`/abandoned leak
+        // that has no resolve event and can only be time-GC'd.
+        let cutover = std::env::var("AGEND_RETENTION_CUTOVER").as_deref() != Ok("0");
         let dispatches_swept = pending_dispatches::sweep(home, cutover);
         let worktrees_swept = worktrees::sweep(home);
+        // Drop terminal dispatch_tracking rows (completed/orphaned) each cycle so
+        // they don't accumulate until the 30-day gc_old_entries backstop.
+        let tracking_swept = crate::dispatch_tracking::sweep_terminal_entries(home);
 
         tracing::info!(
             decisions = decisions_swept,
             dispatches = dispatches_swept,
+            tracking = tracking_swept,
             worktrees = worktrees_swept,
             "retention sweep: cycle complete"
         );
@@ -47,7 +57,7 @@ impl RetentionSupervisor {
             "retention_sweep",
             "supervisor",
             &format!(
-                "decisions={decisions_swept} dispatches={dispatches_swept} worktrees={worktrees_swept}"
+                "decisions={decisions_swept} dispatches={dispatches_swept} tracking={tracking_swept} worktrees={worktrees_swept}"
             ),
         );
     }

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -60,14 +60,12 @@ pub fn mark_completed(home: &Path, correlation_id: Option<&str>, _to: &str) {
     };
     persist_or_log!(
         crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
-            for entry in store.entries.iter_mut() {
-                if entry.status == "completed" {
-                    continue;
-                }
-                if entry.task_id.as_deref() == Some(cid) {
-                    entry.status = "completed".to_string();
-                }
-            }
+            // Remove the resolved dispatch entry outright (was: flip to "completed"
+            // and linger until the 30-day `gc_old_entries`). A completed dispatch
+            // needs no further warn/ask tracking, so dropping it caps accumulation
+            // at the source (the 651KB / 1649-completed bloat). Complementary to
+            // #1727: that stops `orphaned` nag; this removes the rows.
+            store.entries.retain(|e| e.task_id.as_deref() != Some(cid));
             Ok(())
         }),
         "dispatch_mark_completed"
@@ -223,6 +221,26 @@ pub fn gc_old_entries(home: &Path) {
     });
 }
 
+/// Remove ALL terminal entries (`completed` / `orphaned`) regardless of age.
+/// More aggressive than `gc_old_entries` (30-day): completed entries are normally
+/// dropped at report time by `mark_completed`, but a dispatch that never got a
+/// correlated report ends up `orphaned` (>24h, given up — never re-asked since
+/// #1727) and would otherwise sit until the 30-day TTL. Called at boot
+/// (`orphan_sweep`) and each retention cycle so terminal rows don't accumulate.
+/// Returns the number removed. Best-effort: a dropped pass just delays pruning.
+pub fn sweep_terminal_entries(home: &Path) -> usize {
+    let mut removed = 0usize;
+    let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+        let before = store.entries.len();
+        store
+            .entries
+            .retain(|e| e.status != "completed" && e.status != "orphaned");
+        removed = before - store.entries.len();
+        Ok(())
+    });
+    removed
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -359,10 +377,54 @@ mod tests {
         );
         // Mark completed (simulates report_result handler calling this)
         mark_completed(&home, Some("t-123"), "impl");
-        // Sweep should find nothing — entry is completed
+        // C: the entry is REMOVED outright (not flipped to "completed" and kept).
+        let store: DispatchStore = crate::store::load(&store_path(&home));
+        assert!(
+            store.entries.is_empty(),
+            "completed dispatch entry must be removed, not retained: {:?}",
+            store.entries
+        );
+        // And so the sweep finds nothing.
         let (warns, asks) = sweep_stuck(&home);
         assert!(warns.is_empty(), "completed dispatch must not warn");
         assert!(asks.is_empty(), "completed dispatch must not ask");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn sweep_terminal_entries_removes_terminal_keeps_active() {
+        let home = tmp_home("sweep-terminal");
+        for (tid, st) in [
+            ("t-c", "completed"),
+            ("t-o", "orphaned"),
+            ("t-p", "pending"),
+            ("t-a", "asked"),
+        ] {
+            track_dispatch(
+                &home,
+                DispatchEntry {
+                    task_id: Some(tid.into()),
+                    from: "lead".into(),
+                    to: "dev".into(),
+                    from_id: None,
+                    to_id: None,
+                    delegated_at: chrono::Utc::now().to_rfc3339(),
+                    status: st.into(),
+                },
+            );
+        }
+        let removed = sweep_terminal_entries(&home);
+        assert_eq!(removed, 2, "must remove completed + orphaned only");
+        let store: DispatchStore = crate::store::load(&store_path(&home));
+        let kept: Vec<&str> = store.entries.iter().map(|e| e.status.as_str()).collect();
+        assert!(
+            kept.contains(&"pending") && kept.contains(&"asked"),
+            "active (pending/asked) entries must survive: {kept:?}"
+        );
+        assert!(
+            !kept.contains(&"completed") && !kept.contains(&"orphaned"),
+            "terminal entries must be gone: {kept:?}"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
Root-fixes the two dispatch leaks behind the stuck-check flood (~1800 `pending-dispatches/` files + a 651KB `dispatch_tracking.json`). **Complements #1727** (which stopped the `orphaned`↔`asked` nag) — this removes the rows so they never accumulate to the 30-day TTL.

## Changes (two systems, non-overlapping files)
**A. pending-dispatches — completion deletes the sidecar** (`dispatch_idle/mod.rs`)
- `mark_resolved` now **deletes** the sidecar (+ its `.lock`) instead of flipping it to `Resolved` and leaving it. Nothing ever removed `Resolved` sidecars — the primary leak (800 resolved files persisted).
- `cleanup_pending_for_instance` now deletes **every** sidecar for a deleted instance, not just `Pending` ones.

**B. pending-dispatches — retention backstop defaults ON** (`retention/mod.rs`)
- `AGEND_RETENTION_CUTOVER` defaults on (opt-out via `=0`). It was a **staged-rollout gate, not a bug-gate**; the sweep only deletes `issued_at < now−14d` (a real dispatch resolves in minutes, never survives 14 days), so it safely GCs `exceeded`/abandoned sidecars that have no resolve event. 14-day threshold + env override preserved.

**C. dispatch_tracking — completion removes the entry** (`dispatch_tracking.rs`)
- `mark_completed` removes the entry outright (was: flip to `completed` + linger until the 30-day TTL). Caps the completed-row bloat at report time.

**D. orphan_sweep + retention — terminal-row GC** (`dispatch_tracking.rs`, `orphan_sweep.rs`, `retention/mod.rs`)
- New `sweep_terminal_entries` removes terminal (`completed`/`orphaned`) rows for **any** target (the existing dead-target loop only caught gone instances). Wired into `orphan_sweep` (boot — clears the backlog) + the retention supervisor (periodic — caps ongoing).

**name-vs-UUID** (lightweight, per design): normal-delete coverage (A's cleanup deletes non-Pending) + D's terminal GC catches name-reuse orphans. **No full UUID re-key** (the audit field already carries the UUID; marginal). An explicit clear-on-name-reregister hook is subsumed by D (re-used-name orphans are terminal → GC'd) — flagged for the reviewer; a separate hook is a follow-up if wanted.

## Tests
- Updated 3 tests that asserted post-resolve `Resolved` status → now assert the sidecar is **deleted** (the resolution still happens, via delete).
- New pins: `mark_resolved` deletes the file; `cleanup_pending_for_instance` deletes a non-Pending sidecar; retention 14-day boundary (20d removed / 3d kept — existing); `mark_completed` removes the entry; `sweep_terminal_entries` removes terminal + keeps active.

## Verification
- `cargo fmt --check` ✅ · clippy `tray` + `tray,discord` `-D warnings` ✅
- full bin suite **3234 passed, 0 failed** · `file_size_invariant` (#1463) ✅

Base: `96fd946` (origin/main, includes #1727). Not urgent (flood already resolved by #1727 + the live-prune). Daemon-side → takes effect on rebuild/restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)