### PR TITLE
refactor: collapse AgentState::Ready into Idle (operator KISS decision)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1152,13 +1152,13 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         })?;
 
     // Backends whose CLI does not auto-load the instructions file (e.g. Kiro)
-    // need the file contents injected as the first user message on Ready.
+    // need the file contents injected as the first user message on Idle.
     if let Some(b) = detected_backend.as_ref() {
         let preset = b.preset();
         if preset.inject_instructions_on_ready {
             if let Some(dir) = working_dir {
                 // Read the instructions body here — while we hold the spawn
-                // context and before the `Ready` poll window starts — so an
+                // context and before the `Idle` poll window starts — so an
                 // external process mutating the file between write and
                 // bootstrap cannot inject a different prompt. Skip the
                 // bootstrap entirely if the file is missing/empty.
@@ -1212,7 +1212,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
     Ok(())
 }
 
-/// Poll until the agent reaches Ready, then inject the pre-read instructions
+/// Poll until the agent reaches Idle, then inject the pre-read instructions
 /// content as a first user message. Used by backends (Kiro) whose CLI does
 /// not auto-load the steering file.
 ///
@@ -1228,7 +1228,7 @@ fn spawn_instructions_bootstrap(
     shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
 ) {
     let thread_name = format!("{name}_instr_boot");
-    // fire-and-forget: instruction-bootstrap thread polls Ready then injects
+    // fire-and-forget: instruction-bootstrap thread polls Idle then injects
     // the snapshotted instructions content. Observes shutdown flag inside the
     // poll loop (returns early on shutdown). JoinHandle dropped because the
     // thread is short-lived and one missed bootstrap on shutdown is cosmetic.
@@ -1246,7 +1246,7 @@ fn spawn_instructions_bootstrap(
             if std::time::Instant::now() >= deadline {
                 tracing::warn!(
                     agent = %name,
-                    "instructions bootstrap timed out waiting for Ready"
+                    "instructions bootstrap timed out waiting for Idle"
                 );
                 return;
             }
@@ -1256,7 +1256,7 @@ fn spawn_instructions_bootstrap(
                 match reg.get(&instance_id) {
                     Some(h) => {
                         let core = &h.core.lock();
-                        core.state.get_state() == crate::state::AgentState::Ready
+                        core.state.get_state() == crate::state::AgentState::Idle
                     }
                     None => return, // agent gone
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -239,7 +239,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // only in the Owned branch — see `install_term_only` above.
 
     // Per-agent AwaitingOperator supervisor: watches for stdout silence during
-    // Starting (or recently-entered Ready — some backends like codex match
+    // Starting (or recently-entered Idle — some backends like codex match
     // ready_pattern against the startup banner that precedes the update menu)
     // and pushes a vterm tail to the agent's Telegram topic. In Attached mode
     // the daemon already runs its own supervisor against the real registry, so

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -256,7 +256,7 @@ pub struct BackendPreset {
     /// GEMINI.md). When true, writes use marker-merge to preserve user content;
     /// when false the whole file is agend-owned and rewritten in full.
     pub instructions_shared: bool,
-    /// Inject instructions as the first message once the agent reaches Ready.
+    /// Inject instructions as the first message once the agent reaches Idle.
     /// Needed for backends (Kiro) whose CLI does not auto-load the instructions file.
     pub inject_instructions_on_ready: bool,
     /// Relative path for MCP config file from working dir.
@@ -560,7 +560,7 @@ impl Backend {
                 // #987: agy's interactive TUI renders an "Antigravity CLI <ver>"
                 // banner on startup (calibrated against
                 // tests/fixtures/state-replay/agy-thinking.raw). The pipe-OR
-                // covers post-banner "Ready" state matchable variants in case
+                // covers post-banner "Idle" state matchable variants in case
                 // future TUI iterations rename the banner.
                 ready_pattern: "Antigravity CLI|Type your message",
                 submit_key: "\r",

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -52,7 +52,7 @@ pub fn profile(backend: &Backend) -> Option<&'static BackendProfile> {
     static CODEX: OnceLock<BackendProfile> = OnceLock::new();
     static CLAUDE: OnceLock<BackendProfile> = OnceLock::new();
     // Shell + Raw share one profile — every legacy source treats `Shell | Raw(_)`
-    // identically (empty patterns, default behavioral, generic productivity, Ready).
+    // identically (empty patterns, default behavioral, generic productivity, Idle).
     static EMPTY: OnceLock<BackendProfile> = OnceLock::new();
     match backend {
         Backend::Agy => Some(AGY.get_or_init(agy_profile)),
@@ -77,7 +77,7 @@ fn agy_profile() -> BackendProfile {
             (AgentState::ToolUse, r"●\s+[A-Z][a-zA-Z]+\("),
             (AgentState::Thinking, r"esc to cancel"),
             (AgentState::Idle, r"\? for shortcuts"),
-            (AgentState::Ready, r"Antigravity CLI|Type your message"),
+            (AgentState::Idle, r"Antigravity CLI|Type your message"),
         ],
         behavioral: BehavioralConfig {
             silence_thinking_ms: 3000,
@@ -136,7 +136,7 @@ fn kirocli_profile() -> BackendProfile {
                 AgentState::Idle,
                 r"\d+%\s*$|ask a question or describe a task",
             ),
-            (AgentState::Ready, r"Trust All Tools active|/quit to exit"),
+            (AgentState::Idle, r"Trust All Tools active|/quit to exit"),
         ],
         behavioral: BehavioralConfig {
             silence_thinking_ms: 2500,
@@ -195,7 +195,7 @@ fn opencode_profile() -> BackendProfile {
                 r"Update Available|Skip\s+Confirm",
             ),
             (AgentState::Idle, r"Ask anything"),
-            (AgentState::Ready, r"Ask anything|tab agents"),
+            (AgentState::Idle, r"Ask anything|tab agents"),
         ],
         behavioral: BehavioralConfig {
             silence_thinking_ms: 3000,
@@ -247,7 +247,7 @@ fn codex_profile() -> BackendProfile {
             ),
             (AgentState::Thinking, r"Working|esc to interrupt"),
             (AgentState::Idle, r"›"),
-            (AgentState::Ready, r"OpenAI Codex|gpt-.*left"),
+            (AgentState::Idle, r"OpenAI Codex|gpt-.*left"),
         ],
         behavioral: BehavioralConfig {
             silence_thinking_ms: 3000,
@@ -317,7 +317,7 @@ fn claudecode_profile() -> BackendProfile {
                 r"(?i)[✻✢✶✳✽*·]\s*\w+\x{2026}|\w+\x{2026}\s*\((?:\d+[smh]|running )|thought for [0-9]+s",
             ),
             (AgentState::Idle, r"❯"),
-            (AgentState::Ready, r"bypass permissions"),
+            (AgentState::Idle, r"bypass permissions"),
         ],
         behavioral: BehavioralConfig {
             silence_thinking_ms: 2000,
@@ -335,7 +335,7 @@ fn claudecode_profile() -> BackendProfile {
 }
 
 /// Shell / Raw — moved VERBATIM (empty patterns, default behavioral, generic
-/// productivity, Ready initial state).
+/// productivity, Idle initial state).
 fn empty_profile() -> BackendProfile {
     BackendProfile {
         patterns: vec![],
@@ -346,7 +346,7 @@ fn empty_profile() -> BackendProfile {
             heartbeat_fresh_window_ms: 0,
             cache_id: Some(MarkerCacheId::Generic),
         },
-        initial_state: AgentState::Ready,
+        initial_state: AgentState::Idle,
     }
 }
 

--- a/src/behavioral.rs
+++ b/src/behavioral.rs
@@ -1023,7 +1023,7 @@ mod tests {
             "thinking",
         );
         record_divergence("test-backend", BehavioralSignal::SilenceThinking, "idle"); // diverge
-        record_divergence("test-backend", BehavioralSignal::None, "ready"); // agree (None = no signal)
+        record_divergence("test-backend", BehavioralSignal::None, "idle"); // agree (None = no signal)
 
         let report = divergence_report();
         let entry = report.iter().find(|(k, _)| k == "test-backend");

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -754,9 +754,11 @@ mod tests {
     #[test]
     fn classify_alive_stuck_when_productive_exceeds_silence_below() {
         // Silent < 120s default threshold, productive_silence > 120s →
-        // alive-stuck branch.
+        // alive-stuck branch. Carrier is `Starting` (120s threshold) — the
+        // Ready/Idle merge made `Idle` exempt (`=> false`), so the old `Ready`
+        // carrier was re-pointed to another 120s-threshold non-exempt state.
         let branch = classify_branch(
-            AgentState::Ready,
+            AgentState::Starting,
             Duration::from_secs(30),
             Duration::from_secs(300),
         );
@@ -767,13 +769,32 @@ mod tests {
     fn classify_dead_likely_when_silence_exceeds() {
         // Silent > 120s → dead-likely; ESC won't help a process not
         // reading PTY. Productive_silence value is irrelevant once
-        // silence exceeds.
+        // silence exceeds. Carrier `Starting` (see note above — `Idle` is now
+        // exempt; `classify_idle_never_dead_likely_on_silence` pins that).
         let branch = classify_branch(
-            AgentState::Ready,
+            AgentState::Starting,
             Duration::from_secs(300),
             Duration::from_secs(500),
         );
         assert!(matches!(branch, Stage1Branch::DeadLikely));
+    }
+
+    #[test]
+    fn classify_idle_never_dead_likely_on_silence() {
+        // Ready/Idle merge (accepted behavior change ②): an `Idle` agent is
+        // NEVER classified dead-likely on silence — it is legitimately quiet.
+        // Pre-merge, `Ready` (agy/opencode idle prompt) fell into the 120s
+        // catch-all and COULD be silence-reaped; now it follows Idle's exemption
+        // (consistent with claude). A real hang still surfaces via Thinking/ToolUse.
+        let branch = classify_branch(
+            AgentState::Idle,
+            Duration::from_secs(600), // far past any silence threshold
+            Duration::from_secs(600),
+        );
+        assert!(
+            matches!(branch, Stage1Branch::Anomaly),
+            "idle agent must never be DeadLikely/AliveStuck from silence alone"
+        );
     }
 
     #[test]
@@ -783,7 +804,7 @@ mod tests {
         // branch classifier directly; the warn log is exercised via
         // the dispatcher-state integration test below.
         let branch = classify_branch(
-            AgentState::Ready,
+            AgentState::Idle,
             Duration::from_secs(30),
             Duration::from_secs(30),
         );

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -137,7 +137,7 @@ pub(crate) struct RateLimitRetry {
     pub retry_count: u32,
     pub next_retry_at: Instant,
     /// Set when max retries exceeded — prevents re-triggering on same
-    /// persistent ServerRateLimit state. Cleared on recovery (Ready/Idle).
+    /// persistent ServerRateLimit state. Cleared on recovery (Idle).
     pub exhausted: bool,
 }
 
@@ -682,7 +682,7 @@ enum ReactionKind {
 /// is reaction-worthy.
 ///
 /// Net-state (not per-transition) semantics: an intra-tick flap that enters
-/// then leaves an error state (e.g. `Ready→UsageLimit→Ready`) has no net change
+/// then leaves an error state (e.g. `Idle→UsageLimit→Idle`) has no net change
 /// → no reaction, so transient blips don't spam the operator/orchestrator.
 /// Transition LOGGING records every transition separately (#1527); only the
 /// reaction converges to the final state.
@@ -747,7 +747,7 @@ fn awaiting_escalation_allowed(
     match state {
         // Original startup-stall fallback — no chrome, no position gate.
         // #1563: an `OnDemand` coordinator (e.g. `general`) is permanently stuck
-        // in `Starting` (never matches a Ready banner), so this ungated path
+        // in `Starting` (never matches an Idle banner), so this ungated path
         // would forward its normal pane to the operator forever. Gate the
         // startup-stall fallback by role. (Part-B below role-gates
         // `InteractivePrompt` too — same prose-FP root — while `PermissionPrompt`
@@ -1184,17 +1184,17 @@ fn tick(
 /// recovered, so a later ServerRateLimit episode starts fresh at Phase A (rather
 /// than inheriting a stale `retry_count`/`exhausted`).
 ///
-/// Reverted to {Ready, Idle} (genuine terminal recovery). #1586 had broadened it
+/// Reverted to {Idle} (genuine terminal recovery). #1586 had broadened it
 /// to also include Thinking / ToolUse purely to kill the blind-fire retry STORM
 /// before the backoff fired — but the #1713 state-gate makes that storm
 /// structurally impossible (no inject unless freshly ServerRateLimit), so the
 /// Thinking/ToolUse broadening (and the `suppress_thinking_clear` band-aid it
-/// required) are no longer needed. A working agent reaches Ready/Idle between
+/// required) are no longer needed. A working agent reaches Idle between
 /// turns and clears then; mid-work Thinking/ToolUse no longer clears (and never
 /// injects either, so no storm).
 fn clears_server_rate_limit_retry(state: crate::state::AgentState) -> bool {
     use crate::state::AgentState;
-    matches!(state, AgentState::Ready | AgentState::Idle)
+    matches!(state, AgentState::Idle)
 }
 
 /// #1470 (re-scoped slice, credit @cheerc): notify an agent's team
@@ -1320,7 +1320,7 @@ pub(crate) fn process_error_recovery(
                     srl_to_inject.push(name.to_string());
                 }
             } else if clears_server_rate_limit_retry(state) {
-                // #1713: clear on genuine recovery (Ready/Idle) — cross-episode reset
+                // #1713: clear on genuine recovery (Idle) — cross-episode reset
                 // so a later ServerRateLimit episode starts fresh at Phase A. No
                 // suppress window needed: the inject is state-gated above, so a
                 // mid-work Thinking/ToolUse transient neither clears here nor injects.
@@ -1328,7 +1328,7 @@ pub(crate) fn process_error_recovery(
                     tracing::info!(
                         agent = %name,
                         ?state,
-                        "ServerRateLimit retry cleared — agent recovered (Ready/Idle)"
+                        "ServerRateLimit retry cleared — agent recovered (Idle)"
                     );
                 }
             }
@@ -1719,7 +1719,7 @@ mod tests {
         assert!(!AgentState::ApiError.is_notify_error_class());
         assert!(!AgentState::Restarting.is_notify_error_class());
         assert!(!AgentState::InteractivePrompt.is_notify_error_class());
-        assert!(!AgentState::Ready.is_notify_error_class());
+        assert!(!AgentState::Idle.is_notify_error_class());
         assert!(!AgentState::Idle.is_notify_error_class());
         assert!(!AgentState::ToolUse.is_notify_error_class());
         assert!(!AgentState::Starting.is_notify_error_class());
@@ -1738,38 +1738,37 @@ mod tests {
         }
     }
 
-    /// RED ①: a feed-driven `Ready → UsageLimit` (the read-loop records it, so
+    /// RED ①: a feed-driven `Idle → UsageLimit` (the read-loop records it, so
     /// the drain carries it even though `prev == new` at the supervisor tick)
     /// MUST still produce a reaction decision. Pre-#1530 the `prev != new` gate
     /// skipped it → the UsageLimit reaction was dead since #1176.
     #[test]
     fn reactions_from_transitions_fires_on_feed_driven_usagelimit() {
         use crate::state::AgentState;
-        let decisions =
-            reactions_from_transitions(&[tr(AgentState::Ready, AgentState::UsageLimit)]);
+        let decisions = reactions_from_transitions(&[tr(AgentState::Idle, AgentState::UsageLimit)]);
         assert_eq!(
             decisions,
             vec![ReactionDecision {
-                from: AgentState::Ready,
+                from: AgentState::Idle,
                 to: AgentState::UsageLimit
             }],
             "feed-driven →UsageLimit must yield a reaction decision (de-gated off prev!=new)"
         );
     }
 
-    /// RED ②: an intra-tick flap (`Ready → UsageLimit → Ready`) has no NET state
+    /// RED ②: an intra-tick flap (`Idle → UsageLimit → Idle`) has no NET state
     /// change → no reaction. Avoids double/noise notifications. (Logging still
     /// records every transition via #1527 — that path is independent.)
     #[test]
     fn reactions_from_transitions_converges_on_net_state_no_flap_double_fire() {
         use crate::state::AgentState;
         let decisions = reactions_from_transitions(&[
-            tr(AgentState::Ready, AgentState::UsageLimit),
-            tr(AgentState::UsageLimit, AgentState::Ready),
+            tr(AgentState::Idle, AgentState::UsageLimit),
+            tr(AgentState::UsageLimit, AgentState::Idle),
         ]);
         assert!(
             decisions.is_empty(),
-            "flap in-and-out (net Ready→Ready) must not fire a reaction, got {decisions:?}"
+            "flap in-and-out (net Idle→Idle) must not fire a reaction, got {decisions:?}"
         );
     }
 
@@ -1782,19 +1781,19 @@ mod tests {
             "empty drain → no reaction"
         );
         assert!(
-            reactions_from_transitions(&[tr(AgentState::Ready, AgentState::ToolUse)]).is_empty(),
+            reactions_from_transitions(&[tr(AgentState::Idle, AgentState::ToolUse)]).is_empty(),
             "net change to a non-error state → no reaction"
         );
     }
 
     /// Net change THROUGH a flap into a different error state reacts on the
-    /// final state: `UsageLimit → Ready → Hang` ⇒ react on Hang, not UsageLimit.
+    /// final state: `UsageLimit → Idle → Hang` ⇒ react on Hang, not UsageLimit.
     #[test]
     fn reactions_from_transitions_reacts_on_final_error_state() {
         use crate::state::AgentState;
         let decisions = reactions_from_transitions(&[
-            tr(AgentState::UsageLimit, AgentState::Ready),
-            tr(AgentState::Ready, AgentState::Hang),
+            tr(AgentState::UsageLimit, AgentState::Idle),
+            tr(AgentState::Idle, AgentState::Hang),
         ]);
         assert_eq!(
             decisions,
@@ -1833,7 +1832,7 @@ mod tests {
             "non-UsageLimit error state: member-notify only"
         );
         assert!(
-            reaction_kinds(AgentState::Ready, true).is_empty(),
+            reaction_kinds(AgentState::Idle, true).is_empty(),
             "non-error state: no reaction"
         );
     }
@@ -2043,7 +2042,7 @@ instances:
     #[test]
     fn awaiting_gate_non_prompt_state_never_escalates() {
         for s in [
-            crate::state::AgentState::Ready,
+            crate::state::AgentState::Idle,
             crate::state::AgentState::Thinking,
             crate::state::AgentState::ToolUse,
         ] {
@@ -2213,7 +2212,7 @@ instances:
 
     /// D4: 2×2 invariant fixture — production-path-coupled.
     /// 2 teams (team-a: orch-a + worker-a, team-b: orch-b + worker-b).
-    /// worker-a transitions Ready → UsageLimit.
+    /// worker-a transitions Idle → UsageLimit.
     /// Assert: orch-a inbox has 1 event; orch-b/worker-a/worker-b have 0.
     #[test]
     fn notify_single_receiver_2x2_invariant() {
@@ -2235,7 +2234,7 @@ instances:
         let sent = super::maybe_notify_member_state_change(
             &home,
             "worker-a",
-            crate::state::AgentState::Ready,
+            crate::state::AgentState::Idle,
             crate::state::AgentState::UsageLimit,
             "Usage limit reached. Resets at 15:14 UTC",
             &mut tracks,
@@ -2280,7 +2279,7 @@ instances:
         let sent = super::maybe_notify_member_state_change(
             &home,
             "orch-a",
-            crate::state::AgentState::Ready,
+            crate::state::AgentState::Idle,
             crate::state::AgentState::UsageLimit,
             "",
             &mut tracks,
@@ -2308,7 +2307,7 @@ instances:
             AgentState::Hang,
             AgentState::Crashed,
             AgentState::PermissionPrompt,
-            AgentState::Ready,
+            AgentState::Idle,
             AgentState::Idle,
         ] {
             assert!(
@@ -2338,7 +2337,7 @@ instances:
         let sent = super::maybe_notify_member_state_change(
             &home,
             "solo",
-            crate::state::AgentState::Ready,
+            crate::state::AgentState::Idle,
             crate::state::AgentState::RateLimit,
             "",
             &mut tracks,
@@ -2355,7 +2354,7 @@ instances:
         let sent = super::maybe_notify_member_state_change(
             &home,
             "solo",
-            crate::state::AgentState::Ready,
+            crate::state::AgentState::Idle,
             crate::state::AgentState::AuthError,
             "",
             &mut tracks,
@@ -2377,7 +2376,7 @@ instances:
         let sent2 = super::maybe_notify_member_state_change(
             &home,
             "solo",
-            crate::state::AgentState::Ready,
+            crate::state::AgentState::Idle,
             crate::state::AgentState::AuthError,
             "",
             &mut tracks,
@@ -2421,7 +2420,7 @@ instances:
             "orch-a",
             "worker-a",
             "team-a",
-            crate::state::AgentState::Ready.display_name(),
+            crate::state::AgentState::Idle.display_name(),
             crate::state::AgentState::UsageLimit.display_name(),
             crate::state::AgentState::UsageLimit,
             "Usage limit reached. Resets at 15:14 UTC",
@@ -2438,7 +2437,7 @@ instances:
             crate::daemon::event_bus::EventKind::MemberStateChanged {
                 agent: "worker-a".into(),
                 team: "team-a".into(),
-                from_state: crate::state::AgentState::Ready.display_name().to_string(),
+                from_state: crate::state::AgentState::Idle.display_name().to_string(),
                 to_state: crate::state::AgentState::UsageLimit
                     .display_name()
                     .to_string(),
@@ -2476,7 +2475,7 @@ instances:
         let sent = super::maybe_notify_member_state_change(
             &home,
             "worker-a",
-            crate::state::AgentState::Ready,
+            crate::state::AgentState::Idle,
             crate::state::AgentState::Hang,
             "",
             &mut tracks,
@@ -2656,7 +2655,7 @@ instances:
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #1325: phase 1 — recovery (Ready/Idle) clears retry track.
+    /// #1325: phase 1 — recovery (Idle) clears retry track.
     #[test]
     fn phase1_recovery_clears_retry_track() {
         let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
@@ -2671,7 +2670,7 @@ instances:
             },
         );
 
-        let (handle, _reader) = mock_agent_handle("test-agent", crate::state::AgentState::Ready);
+        let (handle, _reader) = mock_agent_handle("test-agent", crate::state::AgentState::Idle);
         // #1441: registry is UUID-keyed — insert under the handle's own id.
         registry.lock().insert(handle.id, handle);
 
@@ -2684,12 +2683,12 @@ instances:
         );
         assert!(
             !tracks.contains_key("test-agent"),
-            "phase 1 must clear retry track on Ready recovery"
+            "phase 1 must clear retry track on Idle recovery"
         );
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #1713: the recovery-clear predicate is now {Ready, Idle} (genuine terminal
+    /// #1713: the recovery-clear predicate is now {Idle} (genuine terminal
     /// recovery → cross-episode reset). #1586's Thinking/ToolUse broadening is
     /// removed: with the #1713 state-gate at the decision point the blind-fire
     /// storm is structurally impossible, so the broadening that compensated for it
@@ -2698,13 +2697,12 @@ instances:
     #[test]
     fn clears_server_rate_limit_retry_covers_only_terminal_recovery_1713() {
         use crate::state::AgentState::*;
-        // Genuine terminal recovery → clear (cross-episode reset).
-        for s in [Ready, Idle] {
-            assert!(
-                super::clears_server_rate_limit_retry(s),
-                "#1713: terminal-recovery state {s:?} must clear the retry track"
-            );
-        }
+        // Genuine terminal recovery → clear (cross-episode reset). (`Idle` is the
+        // sole terminal-recovery state since the Ready/Idle merge.)
+        assert!(
+            super::clears_server_rate_limit_retry(Idle),
+            "#1713: terminal-recovery state Idle must clear the retry track"
+        );
         // Everything else — incl mid-work Thinking/ToolUse and every waiting/error
         // state — must NOT clear.
         for s in [

--- a/src/daemon/usage_limit.rs
+++ b/src/daemon/usage_limit.rs
@@ -119,7 +119,7 @@ mod tests {
         log_state_transition_at(
             &dir,
             "dev",
-            AgentState::Ready,
+            AgentState::Idle,
             AgentState::UsageLimit,
             "2026-05-31T00:00:00+00:00",
             "You've hit your limit",

--- a/src/daemon/watchdog.rs
+++ b/src/daemon/watchdog.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 fn recovered_from_rate_limit(state: AgentState) -> bool {
     matches!(
         state,
-        AgentState::Ready | AgentState::Idle | AgentState::Thinking | AgentState::ToolUse
+        AgentState::Idle | AgentState::Thinking | AgentState::ToolUse
     )
 }
 
@@ -252,7 +252,7 @@ mod tests {
                 BlockedReason::RateLimit {
                     retry_after_secs: Some(30),
                 },
-                AgentState::Ready,
+                AgentState::Idle,
             ),
             (BlockedReason::QuotaExceeded, AgentState::Idle),
             (
@@ -326,7 +326,7 @@ mod tests {
             "Thinking about your request...\n● Read src/main.rs",
             &mut health,
             false,
-            AgentState::Ready,
+            AgentState::Idle,
         );
         assert!(
             matches!(health.current_reason, Some(BlockedReason::AwaitingOperator)),
@@ -353,7 +353,7 @@ mod tests {
             "Thinking about your request...\n● Read src/main.rs",
             &mut health,
             true, // dry_run
-            AgentState::Ready,
+            AgentState::Idle,
         );
         assert!(
             matches!(health.current_reason, Some(BlockedReason::RateLimit { .. })),

--- a/src/health.rs
+++ b/src/health.rs
@@ -19,10 +19,10 @@ const STABILITY_WINDOW: Duration = Duration::from_secs(1800); // 30 min stable �
 /// with no stdout for this long is likely blocked on an interactive startup
 /// prompt (trust dialog, codex update menu before banner, auth confirmation).
 ///
-/// Only `Starting` is considered: once the agent transitions to `Ready` we
+/// Only `Starting` is considered: once the agent transitions to `Idle` we
 /// trust the detection and any further silence is either legitimate idle or
 /// a real hang — the latter is handled by `check_hang` with much higher
-/// thresholds (120s+). Flagging Ready-with-short-silence produced false
+/// thresholds (120s+). Flagging Idle-with-short-silence produced false
 /// positives for agents in the middle of tool execution that simply had a
 /// few seconds of quiet between bursts of output.
 ///
@@ -48,7 +48,7 @@ pub enum HealthState {
     ErrorLoop,
     /// Sprint 24 P1 (F-NEW-DAEMON-HEALTH-CLASSIFIER-1): agent is silent
     /// past the hang threshold but **no input is pending past last
-    /// response** — typically `Ready` state waiting for next dispatch.
+    /// response** — typically `Idle` state waiting for next dispatch.
     /// Cron escalation chains (`interrupt` / `replace`)
     /// MUST NOT trigger on this state; only `Hung` is escalation-worthy.
     /// Closes the operator 04:00 UTC false-alarm pattern where impl-1's
@@ -557,7 +557,7 @@ impl HealthTracker {
     /// state that legitimately awaits operator input: `Starting` (the original
     /// startup-stall fallback) or, post-#1552, a runtime `PermissionPrompt` /
     /// `InteractivePrompt` (a mid-task stall on an approval the operator must
-    /// answer). Other states (`Ready` mid-tool-use, etc.) are left to
+    /// answer). Other states (`Idle` mid-tool-use, etc.) are left to
     /// `check_hang` — flagging short generic silences here produced FPs.
     ///
     /// This is the *necessary* condition only; the supervisor adds escalation
@@ -1099,11 +1099,11 @@ mod tests {
     fn test_awaiting_operator_non_starting_exempt() {
         // #1552: Starting + runtime prompt states (PermissionPrompt /
         // InteractivePrompt) trigger; every OTHER state is exempt regardless of
-        // silence — generic Ready/tool silence is handled by `check_hang` with
+        // silence — generic Idle/tool silence is handled by `check_hang` with
         // much higher thresholds so legitimate pauses don't produce FPs.
         let h = HealthTracker::new();
         for s in [
-            AgentState::Ready,
+            AgentState::Idle,
             AgentState::Idle,
             AgentState::Thinking,
             AgentState::ToolUse,
@@ -1300,10 +1300,17 @@ mod tests {
             AgentState::Thinking,
             Duration::from_secs(599)
         ));
-        // A non-prompt state that genuinely stalls still hangs at the 120s floor.
-        assert!(productive_silence_exceeds(
-            AgentState::Ready,
+        // Ready/Idle merge: `Idle` is now EXEMPT from the Hung floor (it absorbed
+        // the old `Ready` catch-all path → Idle's `=> false`). An idle agent is
+        // legitimately quiet — never silence-Hung. A genuinely-stalling ACTIVE
+        // agent still hangs via the ToolUse/Thinking 600s threshold.
+        assert!(!productive_silence_exceeds(
+            AgentState::Idle,
             Duration::from_secs(121)
+        ));
+        assert!(productive_silence_exceeds(
+            AgentState::ToolUse,
+            Duration::from_secs(601)
         ));
     }
 
@@ -1439,6 +1446,39 @@ mod tests {
 
     // Sprint 24 P1 (F-NEW-DAEMON-HEALTH-CLASSIFIER-1) — IdleLong vs Hung
     // discriminator tests. Closes operator 04:00 UTC false-alarm pattern.
+    //
+    // Ready/Idle merge: these mechanism tests carry `AgentState::ToolUse` (an
+    // active agent that genuinely silence-exceeds at the 600s threshold), NOT
+    // `Idle`. `Idle` is now EXEMPT from the Hung floor (`productive_silence_exceeds
+    // => false`), so it short-circuits to Healthy before reaching this
+    // discriminator — pinned directly by `classifier_idle_agent_exempt_from_hung`
+    // below. The discriminator (HealthState::IdleLong vs Hung) still governs
+    // every non-exempt state.
+
+    /// Ready/Idle merge (accepted behavior change ③): an `Idle` agent is EXEMPT
+    /// from Hung classification even with input pending past response + a fresh
+    /// heartbeat — the very inputs that drive a ToolUse agent to Hung. Pre-merge,
+    /// `Ready` (agy/opencode idle prompt) was NON-exempt (120s catch-all) and
+    /// could be flagged Hung here; post-merge it follows Idle's exemption,
+    /// consistent with claude (which always behaved this way — hang is caught via
+    /// Thinking/ToolUse, not the idle-prompt path).
+    #[test]
+    fn classifier_idle_agent_exempt_from_hung() {
+        let mut h = HealthTracker::new();
+        let result = h.check_hang(
+            AgentState::Idle,
+            Duration::from_secs(700), // far past any threshold
+            Duration::from_secs(700),
+            10_000, // input pending past response (would Hung a ToolUse agent)
+            0,      // no heartbeat refresh
+        );
+        assert!(!result, "idle agent must never be Hung from silence");
+        assert_eq!(
+            h.state,
+            HealthState::Healthy,
+            "idle short-circuits to Healthy — never Hung/IdleLong"
+        );
+    }
 
     #[test]
     fn classifier_returns_hung_when_input_pending_past_response() {
@@ -1448,8 +1488,8 @@ mod tests {
         let mut h = HealthTracker::new();
         // last_input_at_ms past last_heartbeat_at_ms by > 5s grace.
         let result = h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180), // > 120s threshold
+            AgentState::ToolUse,
+            Duration::from_secs(700), // > 120s threshold
             Duration::from_secs(0),   // F9: productive-silence — recent
             10_000,                   // input delivered at T+10s
             0,                        // no heartbeat (or T-0)
@@ -1465,8 +1505,8 @@ mod tests {
         // mark IdleLong (no escalation) and return false.
         let mut h = HealthTracker::new();
         let result = h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180), // > 120s threshold
+            AgentState::ToolUse,
+            Duration::from_secs(700), // > 120s threshold
             Duration::from_secs(0),   // F9: productive-silence — recent
             0,                        // no input ever delivered
             5_000,                    // heartbeat at T+5s (some past activity)
@@ -1486,8 +1526,8 @@ mod tests {
         // → no input pending → IdleLong (NOT Hung).
         let mut h = HealthTracker::new();
         let result = h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180),
+            AgentState::ToolUse,
+            Duration::from_secs(700),
             Duration::from_secs(0), // F9: productive-silence — recent
             0,                      // input at T+0
             8_000,                  // heartbeat at T+8s (already responded)
@@ -1502,7 +1542,7 @@ mod tests {
         // regardless of input/heartbeat data.
         let mut h = HealthTracker::new();
         let result = h.check_hang(
-            AgentState::Ready,
+            AgentState::Idle,
             Duration::from_secs(60), // < 120s threshold
             Duration::from_secs(0),  // F9: productive-silence — recent
             10_000,
@@ -1519,8 +1559,8 @@ mod tests {
         // Healthy so future cron consumers don't see stale IdleLong.
         let mut h = HealthTracker::new();
         h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180),
+            AgentState::ToolUse,
+            Duration::from_secs(700),
             Duration::from_secs(0),
             0,
             5_000,
@@ -1528,7 +1568,7 @@ mod tests {
         assert_eq!(h.state, HealthState::IdleLong);
         // Activity resumes → silence < threshold.
         let result = h.check_hang(
-            AgentState::Ready,
+            AgentState::ToolUse,
             Duration::from_secs(30),
             Duration::from_secs(0),
             0,
@@ -1548,8 +1588,8 @@ mod tests {
         // the grace window. Must NOT flag Hung — within grace.
         let mut h = HealthTracker::new();
         let result = h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180),
+            AgentState::ToolUse,
+            Duration::from_secs(700),
             Duration::from_secs(0), // F9: productive-silence — recent
             5_000,                  // input
             0,                      // heartbeat — delta exactly 5_000ms
@@ -1560,8 +1600,8 @@ mod tests {
         );
         // delta = 5_001 > grace → Hung
         let result2 = h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180),
+            AgentState::ToolUse,
+            Duration::from_secs(700),
             Duration::from_secs(0),
             5_001,
             0,
@@ -1576,8 +1616,8 @@ mod tests {
         // avoid duplicate escalation).
         let mut h = HealthTracker::new();
         assert!(h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180),
+            AgentState::ToolUse,
+            Duration::from_secs(700),
             Duration::from_secs(0),
             10_000,
             0
@@ -1585,8 +1625,8 @@ mod tests {
         assert_eq!(h.state, HealthState::Hung);
         // Same conditions next tick → no re-escalation.
         assert!(!h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180),
+            AgentState::ToolUse,
+            Duration::from_secs(700),
             Duration::from_secs(0),
             10_000,
             0
@@ -1607,8 +1647,8 @@ mod tests {
         let now = crate::daemon::heartbeat_pair::now_ms();
         // Heartbeat very recent (1s ago), no input pending, PTY silent 180s.
         let result = h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180), // > 120s threshold
+            AgentState::ToolUse,
+            Duration::from_secs(700), // > 120s threshold
             Duration::from_secs(0),   // F9: productive-silence — recent
             0,                        // no input pending
             now - 1_000,              // heartbeat 1s ago (fresh)
@@ -1625,14 +1665,15 @@ mod tests {
         // Regression: pure idle with stale heartbeat (older than silence
         // window). Must still classify as IdleLong, not Hung.
         let mut h = HealthTracker::new();
-        // Heartbeat 300s ago (stale — older than 180s silence window).
+        // Heartbeat 800s ago (stale — older than the 700s silence window, so
+        // `heartbeat_fresh` (age < silent) is false → no F1 Hung cross-check).
         let now = crate::daemon::heartbeat_pair::now_ms();
         let result = h.check_hang(
-            AgentState::Ready,
-            Duration::from_secs(180),
+            AgentState::ToolUse,
+            Duration::from_secs(700),
             Duration::from_secs(0), // F9: productive-silence — recent
             0,                      // no input pending
-            now - 300_000,          // heartbeat 300s ago (stale)
+            now - 800_000,          // heartbeat 800s ago (stale vs 700s window)
         );
         assert!(
             !result,

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -859,8 +859,8 @@ mod should_defer_inject_tests_1513 {
             "idle actionable injects"
         );
         assert!(
-            !should_defer_inject(&h, "a", Some("ready"), false),
-            "ready ambient injects"
+            !should_defer_inject(&h, "a", Some("idle"), false),
+            "idle ambient injects (was 'ready' pre-merge)"
         );
         // stale/missing snapshot → state None → fail-open (no defer)
         assert!(

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -33,7 +33,6 @@ pub fn state_color(state: AgentState) -> Color {
     match state {
         AgentState::Starting => Color::White,
         AgentState::AwaitingOperator => Color::Indexed(214),
-        AgentState::Ready => Color::Green,
         AgentState::Idle => Color::DarkGray,
         AgentState::Thinking => Color::Yellow,
         AgentState::ToolUse => Color::Blue,
@@ -720,10 +719,9 @@ mod tests {
         let idle = state_color(AgentState::Idle);
         let thinking = state_color(AgentState::Thinking);
         let tool_use = state_color(AgentState::ToolUse);
-        let ready = state_color(AgentState::Ready);
         assert_ne!(idle, thinking, "idle vs thinking must differ");
         assert_ne!(thinking, tool_use, "thinking vs tool_use must differ");
-        assert_ne!(idle, ready, "idle vs ready must differ");
+        assert_ne!(idle, tool_use, "idle vs tool_use must differ");
     }
 
     #[test]
@@ -931,7 +929,7 @@ mod tests {
             Some(" [crashed]")
         );
         assert_eq!(transient_state_badge(AgentState::Idle), None);
-        assert_eq!(transient_state_badge(AgentState::Ready), None);
+        assert_eq!(transient_state_badge(AgentState::Idle), None);
         assert_eq!(transient_state_badge(AgentState::ToolUse), None);
         assert_eq!(transient_state_badge(AgentState::Hang), None);
         assert_eq!(transient_state_badge(AgentState::PermissionPrompt), None);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -4,7 +4,7 @@
 //! it via `feed()`), not an accumulated byte buffer. Pattern hits therefore
 //! reflect what the user would currently see on screen, so dismissing an
 //! interactive prompt (e.g. codex update menu) drops the matching text from
-//! the grid and the next `feed()` re-evaluates to the underlying Ready state
+//! the grid and the next `feed()` re-evaluates to the underlying Idle state
 //! without stale-buffer lag.
 //!
 //! Hysteresis: error states instant, active 2s, passive 5s.
@@ -30,7 +30,6 @@ pub enum AgentState {
     /// Entered when Starting + stdout silent > threshold. Operator reply is
     /// routed as raw PTY keystrokes (not inbox-wrapped) via INJECT_RAW.
     AwaitingOperator,
-    Ready,
     Idle,
     ToolUse,
     Thinking,
@@ -94,7 +93,8 @@ impl AgentState {
             Self::Starting => 0,
             Self::Hang => 1,
             Self::AwaitingOperator => 2,
-            Self::Ready => 3,
+            // (priority 3 was `Ready`, collapsed into `Idle` — gap is harmless;
+            // priorities are an ordering, not a contiguous index.)
             Self::Idle => 4,
             Self::ToolUse => 5,
             Self::Thinking => 6,
@@ -144,7 +144,6 @@ impl AgentState {
             Self::Starting => "starting",
             Self::Hang => "hang",
             Self::AwaitingOperator => "awaiting_operator",
-            Self::Ready => "ready",
             Self::Idle => "idle",
             Self::ToolUse => "tool_use",
             Self::Thinking => "thinking",
@@ -238,7 +237,7 @@ pub struct StateTracker {
     anchor_on_red: bool,
     /// #1005 Phase A2: most-recent priority-up transition target +
     /// timestamp. Set on every successful priority-up in `transition()`.
-    /// Cleared (set to None) on explicit Ready / lower-priority drops
+    /// Cleared (set to None) on explicit Idle / lower-priority drops
     /// that complete the natural state cycle.
     ///
     /// The oscillation guard reads this to detect the
@@ -584,7 +583,7 @@ impl StateTracker {
     /// treated as part of an oscillation cycle and suppressed.
     ///
     /// Chosen at 5s: matches `min_hold` for passive states (5s for
-    /// Idle/Ready), so legitimate "user briefly idle then activity"
+    /// Idle), so legitimate "user briefly idle then activity"
     /// transitions still go through.
     const OSCILLATION_LOWER_HOLD_THRESHOLD: Duration = Duration::from_secs(5);
 
@@ -593,7 +592,7 @@ impl StateTracker {
     /// LATCHED_STATE_EXPIRY because operators legitimately take a while
     /// to respond to a dialog, but bounded so a prompt dismissed
     /// out-of-band (screen hash unchanged after dismissal ⇒ no re-detect)
-    /// eventually recovers to Ready instead of staying stuck — the
+    /// eventually recovers to Idle instead of staying stuck — the
     /// operator-reported `dev-reviewer 卡在互動 prompt` false positive.
     const INTERACTIVE_EXPIRY: Duration = Duration::from_secs(120);
 
@@ -608,30 +607,30 @@ impl StateTracker {
 
     /// #8 delete-legacy: the fork's fallback for the un-migrated backend (only
     /// Gemini) and `None`. Reached only when `profile(backend)` is `None` — i.e.
-    /// `Some(Gemini)`→Starting (managed) or `None`→Ready. Shell/Raw now route
-    /// through their profile (initial_state = Ready), so they no longer reach
-    /// here; the prior `Shell|Raw => Ready` arm folds into `Some(_) => Starting`.
+    /// `Some(Gemini)`→Starting (managed) or `None`→Idle. Shell/Raw now route
+    /// through their profile (initial_state = Idle), so they no longer reach
+    /// here; the prior `Shell|Raw => Ready` (now `Idle`) arm folds into `Some(_) => Starting`.
     pub(crate) fn legacy_initial_state(backend: Option<&Backend>) -> AgentState {
         match backend {
-            None => AgentState::Ready,
+            None => AgentState::Idle,
             Some(_) => AgentState::Starting,
         }
     }
 
     pub fn new(backend: Option<&Backend>) -> Self {
         // Backends without a state pattern catalog (Shell, Raw) skip the
-        // `Starting → Ready` handshake. Without this they sat in
-        // `Starting` forever — `detect()` can't possibly fire Ready
+        // `Starting → Idle` handshake. Without this they sat in
+        // `Starting` forever — `detect()` can.t possibly fire Idle
         // without any patterns — and the silence-based
         // `check_awaiting_operator` then flagged every idle shell as
         // "stuck on interactive prompt" after 30s of normal quiet at
         // its own prompt. Managed backends still start in `Starting` so
         // their onboarding / auth dialogs can pattern-match before
-        // Ready is declared.
+        // Idle is declared.
         // #8 Phase 2 step-0: migrated backends source their initial state from the
         // co-located profile; un-migrated (and `None`) fall back to
         // `legacy_initial_state`. The profile values are byte-identical to legacy
-        // (empty_profile=Ready for Shell/Raw, agy/kiro=Starting), proven by
+        // (empty_profile=Idle for Shell/Raw, agy/kiro=Starting), proven by
         // `profile_configs_byte_identical_to_legacy`, so behavior is unchanged.
         let initial_state = backend
             .and_then(crate::backend_profile::profile)
@@ -744,8 +743,8 @@ impl StateTracker {
     ///
     /// When detection returns `None` on a changed screen we fall through to
     /// `maybe_expire_latched_state`, which drops long-held active states back
-    /// to Ready so the tracker cannot get stuck if a marker pattern briefly
-    /// disappears without the Ready pattern re-matching.
+    /// to Idle so the tracker cannot get stuck if a marker pattern briefly
+    /// disappears without the Idle pattern re-matching.
     ///
     /// Heartbeat gate (A5 fix): after pattern detection, if the detected
     /// state is `PermissionPrompt` but a fresh MCP heartbeat exists, the
@@ -812,7 +811,7 @@ impl StateTracker {
                     // stale — the agent has moved on, so it must NOT keep re-firing
                     // the error transition (the level-triggered re-match that drove
                     // the retry storm). Scoped to HIGH_FP/error states ONLY:
-                    // Ready/Idle and modal/interactive prompts keep full-screen
+                    // Idle and modal/interactive prompts keep full-screen
                     // scanning, because a modal can legitimately sit above the tail.
                     let stale_position = high_fp
                         && !matched_span_in_recent_tail(
@@ -1058,14 +1057,14 @@ impl StateTracker {
     ///
     /// Active-state markers (Thinking "esc to cancel", ToolUse tool banners)
     /// can stop rendering while the CLI still shows on-screen content that
-    /// happens not to match the backend's Ready pattern either — e.g. a
+    /// happens not to match the backend's Idle pattern either — e.g. a
     /// mid-scroll render between the spinner clearing and the prompt
     /// re-appearing. Without a fallback the tracker would stay latched on
     /// the prior active state indefinitely.
     ///
     /// If the current state is a self-expiring active state
     /// (Thinking / ToolUse) and it has been held longer than
-    /// `LATCHED_STATE_EXPIRY`, drop to Ready. Everything else is excluded:
+    /// `LATCHED_STATE_EXPIRY`, drop to Idle. Everything else is excluded:
     /// InteractivePrompt / PermissionPrompt need explicit operator action,
     /// errors transition instantly on the next matching screen, and
     /// Starting / AwaitingOperator / Hang are driven by their own
@@ -1083,14 +1082,14 @@ impl StateTracker {
         // LATCHED_STATE_EXPIRY is almost always stale.
         let short_expiring = matches!(self.current, AgentState::Thinking | AgentState::ToolUse);
         if short_expiring && self.since.elapsed() >= Self::LATCHED_STATE_EXPIRY {
-            self.transition(AgentState::Ready);
+            self.transition(AgentState::Idle);
             return;
         }
         // RateLimit expires on its own 5-minute window. Real rate limits
         // clear in seconds-to-minutes; stuck for hours is a false positive.
         let rate_limit_expiring = matches!(self.current, AgentState::RateLimit);
         if rate_limit_expiring && self.since.elapsed() >= Self::RATE_LIMIT_EXPIRY {
-            self.transition(AgentState::Ready);
+            self.transition(AgentState::Idle);
             return;
         }
         // Prompt states (InteractivePrompt / PermissionPrompt) expire on
@@ -1105,7 +1104,7 @@ impl StateTracker {
             AgentState::InteractivePrompt | AgentState::PermissionPrompt
         );
         if long_expiring && self.since.elapsed() >= Self::INTERACTIVE_EXPIRY {
-            self.transition(AgentState::Ready);
+            self.transition(AgentState::Idle);
         }
     }
 
@@ -1136,7 +1135,7 @@ impl StateTracker {
     /// this setter just guards the legal source states.
     ///
     /// Once the operator unblocks the stall and the ready pattern matches
-    /// fresh screen content, `transition()` lifts the state (Ready prio >
+    /// fresh screen content, `transition()` lifts the state (Idle prio >
     /// AwaitingOperator prio → higher always wins).
     pub fn set_awaiting_operator(&mut self) {
         if matches!(

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -197,10 +197,9 @@ impl StatePatterns {
                 // follow-up PR, not committed here.
                 // See docs/HUNG-STATE-TRANSITIONS.md §F39.1
                 (AgentState::Thinking, r"\(esc to cancel,"),
-                // [measured] Input prompt text
-                (AgentState::Idle, r"Type your message"),
-                // [measured] Full ready prompt + YOLO mode
-                (AgentState::Ready, r"Type your message|YOLO"),
+                // [measured] Input prompt text + YOLO mode (both = idle, ready
+                // for input; the Ready/Idle split was collapsed into Idle).
+                (AgentState::Idle, r"Type your message|YOLO"),
             ],
             _ => vec![],
         };
@@ -301,7 +300,7 @@ pub fn classify_pty_output(
 /// Cheap structural test for a generic startup-time interactive prompt.
 ///
 /// Only called while the agent is still in `Starting` state, so false
-/// positives during Thinking/Ready (where model output might legitimately
+/// positives during Thinking/Idle (where model output might legitimately
 /// contain strings like `(y/n)` as examples) are avoided by the caller
 /// gating on state. The token set is restricted to glyph sequences that
 /// effectively never appear outside of a real TUI prompt — broad catches

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -88,13 +88,13 @@ fn shell_backend_starts_in_ready_not_starting() {
     // 30 s. Initial state Ready sidesteps the silence fallback — a
     // truly-stuck shell still gets caught by `check_hang` later.
     let t = StateTracker::new(Some(&Backend::Shell));
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
 fn raw_backend_starts_in_ready_not_starting() {
     let t = StateTracker::new(Some(&Backend::Raw("/opt/whatever".to_string())));
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn interactive_prompt_expires_to_ready_after_two_minutes() {
     t.tick();
     assert_eq!(
         t.get_state(),
-        AgentState::Ready,
+        AgentState::Idle,
         "expected Ready after INTERACTIVE_EXPIRY, still {:?}",
         t.get_state()
     );
@@ -148,7 +148,7 @@ fn interactive_prompt_expires_to_ready_after_two_minutes() {
 fn permission_prompt_also_expires_to_ready() {
     let mut t = tracker_at(&Backend::ClaudeCode, AgentState::PermissionPrompt, 130);
     t.tick();
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -157,7 +157,7 @@ fn tool_use_still_uses_short_expiry() {
     // expiry — Thinking / ToolUse should still drop at 30 s.
     let mut t = tracker_at(&Backend::ClaudeCode, AgentState::ToolUse, 31);
     t.tick();
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 // ── P0: Core behavior ───────────────────────────────────────────────
@@ -197,13 +197,13 @@ fn passive_to_passive_needs_5s() {
     // Idle(3) → Ready(2): lower priority, passive hold = 5s
     // Idle held for 3s — should NOT transition
     let mut t = tracker_at(&backend, AgentState::Idle, 3);
-    t.transition(AgentState::Ready);
+    t.transition(AgentState::Idle);
     assert_eq!(t.get_state(), AgentState::Idle);
 
     // Idle held for 6s (>= 5s passive hold) — SHOULD transition
     let mut t = tracker_at(&backend, AgentState::Idle, 6);
-    t.transition(AgentState::Ready);
-    assert_eq!(t.get_state(), AgentState::Ready);
+    t.transition(AgentState::Idle);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -403,7 +403,7 @@ fn oscillation_guard_window_env_disable() {
 #[serial_test::serial]
 fn opencode_tilde_dash_ing_matches_tooluse() {
     let backend = Backend::OpenCode;
-    let mut t = tracker_at(&backend, AgentState::Ready, 6);
+    let mut t = tracker_at(&backend, AgentState::Idle, 6);
     t.feed("~ Reading file...");
     assert_eq!(
         t.get_state(),
@@ -441,7 +441,7 @@ fn dismissed_prompt_clears_on_next_feed() {
     t.feed("Update available! 0.120.0 -> 0.121.0\n1. Update now\n2. Skip");
     // Then the banner re-renders after dismissal
     t.feed("bypass permissions");
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -479,7 +479,7 @@ fn feed_fallback_expires_thinking_after_threshold() {
     let mut t = tracker_at(&Backend::Gemini, AgentState::Thinking, 31);
     // Fresh screen content that matches no pattern for gemini.
     t.feed("some unrelated output that matches nothing");
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -495,7 +495,7 @@ fn feed_fallback_does_not_expire_before_threshold() {
 fn feed_fallback_expires_tooluse_after_threshold() {
     let mut t = tracker_at(&Backend::ClaudeCode, AgentState::ToolUse, 35);
     t.feed("no tool banner, no ready footer visible here");
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -518,7 +518,7 @@ fn tick_expires_stale_tool_use_without_feed() {
     // to Ready without requiring feed() (which needs new screen text).
     let mut t = tracker_at(&Backend::ClaudeCode, AgentState::ToolUse, 35);
     t.tick();
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -544,10 +544,10 @@ fn tick_called_twice_still_expires() {
     // Verify tick() works on repeated calls (no hash-based early return).
     let mut t = tracker_at(&Backend::ClaudeCode, AgentState::ToolUse, 35);
     t.tick();
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
     // Second tick on Ready is a no-op (Ready is not expiring).
     t.tick();
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -563,10 +563,10 @@ fn feed_fallback_does_not_expire_fresh_interactive_prompt() {
 #[test]
 fn feed_fallback_no_op_when_already_ready() {
     // Ready → Ready must not reset `since` (that would defeat the hold).
-    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Ready, 60);
+    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 60);
     let since_before = t.since;
     t.feed("arbitrary text without any markers");
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
     assert_eq!(t.since, since_before);
 }
 
@@ -616,9 +616,9 @@ fn non_starting_ignores_generic_prompt_token() {
     // Ready + a model output containing `(y/n)` must not flip state —
     // false positives here were the reason we scope generic detection
     // to Starting.
-    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Ready, 0);
+    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
     t.feed("Here's an example: `git clean -n (y/n)` — the -n flag previews");
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -831,7 +831,7 @@ fn empty_input_no_change() {
 fn ready_detection() {
     let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
     t.feed("bypass permissions");
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -840,7 +840,7 @@ fn idle_detection() {
     // First get to Ready so that Idle (lower prio than Starting) can be tested
     // Starting → Ready (higher prio) is instant
     t.feed("bypass permissions");
-    assert_eq!(t.get_state(), AgentState::Ready);
+    assert_eq!(t.get_state(), AgentState::Idle);
     // Now wait enough time for passive hold (5s) then feed idle pattern
     t.since = Instant::now() - Duration::from_secs(6);
     t.feed("❯");
@@ -905,7 +905,7 @@ fn awaiting_operator_priority_between_hang_and_ready() {
     // Hang < AwaitingOperator < Ready so it preempts Starting/Hang in
     // tab-bar highest-priority display but doesn't outrank real activity.
     assert!(AgentState::Hang.priority() < AgentState::AwaitingOperator.priority());
-    assert!(AgentState::AwaitingOperator.priority() < AgentState::Ready.priority());
+    assert!(AgentState::AwaitingOperator.priority() < AgentState::Idle.priority());
 }
 
 #[test]
@@ -944,7 +944,7 @@ fn set_awaiting_operator_noop_from_non_starting() {
     // InteractivePrompt) transition. Every OTHER state is a no-op so a late
     // tick-loop detection can't corrupt a healthy mid-task agent.
     for s in [
-        AgentState::Ready,
+        AgentState::Idle,
         AgentState::Idle,
         AgentState::Thinking,
         AgentState::ToolUse,
@@ -965,7 +965,7 @@ fn ready_pattern_lifts_awaiting_operator() {
     t.set_awaiting_operator();
     assert_eq!(t.current, AgentState::AwaitingOperator);
     t.feed("bypass permissions");
-    assert_eq!(t.current, AgentState::Ready);
+    assert_eq!(t.current, AgentState::Idle);
 }
 
 // ── Full pipeline: PTY bytes → VTerm → screen → StateTracker ────────
@@ -1000,7 +1000,7 @@ fn pipeline_claude_ready_via_vterm() {
         &mut st,
         b"\x1b[1;32mClaude Code\x1b[0m ready (bypass permissions mode)\r\n",
     );
-    assert_eq!(st.get_state(), AgentState::Ready);
+    assert_eq!(st.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -1008,7 +1008,7 @@ fn pipeline_codex_ready_via_vterm() {
     let mut vt = VTerm::new(80, 24);
     let mut st = StateTracker::new(Some(&Backend::Codex));
     drive(&mut vt, &mut st, b"\x1b[1mOpenAI Codex\x1b[0m v0.120.0\r\n");
-    assert_eq!(st.get_state(), AgentState::Ready);
+    assert_eq!(st.get_state(), AgentState::Idle);
 }
 
 #[test]
@@ -1040,7 +1040,7 @@ fn pipeline_dismiss_drops_stale_pattern() {
     drive(&mut vt, &mut st, b"\x1b[2J\x1b[HOpenAI Codex v0.120.0\r\n");
     assert_eq!(
         st.get_state(),
-        AgentState::Ready,
+        AgentState::Idle,
         "after screen clear + ready banner, stale UsageLimit must release"
     );
 }
@@ -1073,10 +1073,7 @@ fn pipeline_usage_limit_instant_from_idle() {
         &mut st,
         b"bypass permissions\r\n> ready\r\n\xe2\x9d\xaf",
     );
-    assert!(matches!(
-        st.get_state(),
-        AgentState::Ready | AgentState::Idle
-    ));
+    assert!(matches!(st.get_state(), AgentState::Idle));
     // #848: canonical Anthropic 429-rejection wording instead of the
     // bare `429 rate limit exceeded` that the OLD broad pattern matched.
     drive(
@@ -1114,8 +1111,8 @@ fn interactive_prompt_notice_rearms_on_reentry() {
 
     // Simulate passive-hold window so InteractivePrompt can drop back.
     t.since = std::time::Instant::now() - std::time::Duration::from_secs(3);
-    t.transition(AgentState::Ready);
-    assert_eq!(t.get_state(), AgentState::Ready);
+    t.transition(AgentState::Idle);
+    assert_eq!(t.get_state(), AgentState::Idle);
     assert!(!t.take_interactive_prompt_notice(), "no notice while Ready");
 
     // Re-enter InteractivePrompt.
@@ -1142,8 +1139,8 @@ fn recovery_notice_armed_when_leaving_interactive_prompt() {
 
     // Dismiss → Ready.
     t.since = std::time::Instant::now() - std::time::Duration::from_secs(3);
-    t.transition(AgentState::Ready);
-    assert_eq!(t.get_state(), AgentState::Ready);
+    t.transition(AgentState::Idle);
+    assert_eq!(t.get_state(), AgentState::Idle);
 
     // First take fires; subsequent ticks within the same Ready don't
     // re-spam.
@@ -1168,7 +1165,7 @@ fn recovery_notice_armed_when_leaving_awaiting_operator() {
     // Fresh Ready banner appears. Ready (prio 3) > AwaitingOperator
     // (prio 2) so the transition is immediate.
     drive(&mut vt, &mut st, b"\x1b[2J\x1b[HOpenAI Codex v0.120.0\r\n");
-    assert_eq!(st.get_state(), AgentState::Ready);
+    assert_eq!(st.get_state(), AgentState::Idle);
     assert!(
         st.take_recovery_notice(),
         "recovery must arm on AwaitingOperator → Ready"
@@ -1180,13 +1177,13 @@ fn recovery_notice_not_armed_for_unrelated_transitions() {
     // Ready → Thinking → Ready must not arm the recovery notice: the
     // operator never saw a blocked state, so "ready again" is noise.
     let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
-    st.current = AgentState::Ready;
+    st.current = AgentState::Idle;
     st.since = std::time::Instant::now() - std::time::Duration::from_secs(10);
     st.transition(AgentState::Thinking);
     assert_eq!(st.get_state(), AgentState::Thinking);
     st.since = std::time::Instant::now() - std::time::Duration::from_secs(10);
-    st.transition(AgentState::Ready);
-    assert_eq!(st.get_state(), AgentState::Ready);
+    st.transition(AgentState::Idle);
+    assert_eq!(st.get_state(), AgentState::Idle);
     assert!(!st.take_recovery_notice());
 }
 
@@ -1418,7 +1415,7 @@ fn pipeline_kiro_slash_menu_does_not_trigger_context_full() {
     let mut vt = VTerm::new(80, 24);
     let mut st = StateTracker::new(Some(&Backend::KiroCli));
     drive(&mut vt, &mut st, b"Trust All Tools active\r\n");
-    assert_eq!(st.get_state(), AgentState::Ready);
+    assert_eq!(st.get_state(), AgentState::Idle);
     // User opens slash menu — `/compact` is listed alongside `/quit`.
     drive(
         &mut vt,
@@ -1665,7 +1662,7 @@ fn parse_state(name: &str) -> AgentState {
         "starting" => AgentState::Starting,
         "hang" => AgentState::Hang,
         "awaiting_operator" => AgentState::AwaitingOperator,
-        "ready" => AgentState::Ready,
+        "ready" => AgentState::Idle,
         "idle" => AgentState::Idle,
         "tool_use" => AgentState::ToolUse,
         "thinking" => AgentState::Thinking,
@@ -1991,7 +1988,7 @@ fn claude_spinner_verb_triggers_thinking() {
     let mut vt = VTerm::new(80, 24);
     let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
     drive(&mut vt, &mut st, b"bypass permissions\r\n");
-    assert_eq!(st.get_state(), AgentState::Ready);
+    assert_eq!(st.get_state(), AgentState::Idle);
     // #1541: Claude spinner uses random verbs; the verb-agnostic structural
     // anchor (sparkle glyph + `<verb>…`) must fire regardless of the verb.
     // `\xe2\x9c\xbb` = ✻ (U+273B sparkle), `\xe2\x80\xa6` = … (U+2026).
@@ -2008,7 +2005,7 @@ fn claude_thought_for_triggers_thinking() {
     let mut vt = VTerm::new(80, 24);
     let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
     drive(&mut vt, &mut st, b"bypass permissions\r\n");
-    assert_eq!(st.get_state(), AgentState::Ready);
+    assert_eq!(st.get_state(), AgentState::Idle);
     // Post-thinking summary line
     drive(&mut vt, &mut st, b"thought for 12s\r\n");
     assert_eq!(
@@ -2023,7 +2020,7 @@ fn kiro_working_triggers_thinking() {
     let mut vt = VTerm::new(80, 24);
     let mut st = StateTracker::new(Some(&Backend::KiroCli));
     drive(&mut vt, &mut st, b"Trust All Tools active\r\n");
-    assert_eq!(st.get_state(), AgentState::Ready);
+    assert_eq!(st.get_state(), AgentState::Idle);
     // Kiro shows "Kiro is working" during generation
     drive(&mut vt, &mut st, b"Kiro is working\r\n  esc to cancel\r\n");
     assert_eq!(
@@ -2038,7 +2035,7 @@ fn codex_working_triggers_thinking() {
     let mut vt = VTerm::new(80, 24);
     let mut st = StateTracker::new(Some(&Backend::Codex));
     drive(&mut vt, &mut st, b"OpenAI Codex gpt-4.1 left\r\n");
-    assert_eq!(st.get_state(), AgentState::Ready);
+    assert_eq!(st.get_state(), AgentState::Idle);
     // Codex shows "Working (Ns • esc to interrupt)"
     drive(
         &mut vt,
@@ -2101,7 +2098,7 @@ fn claude_chat_with_glyph_does_not_trigger_tooluse() {
     let mut vt = VTerm::new(80, 24);
     let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
     drive(&mut vt, &mut st, b"bypass permissions\r\n");
-    assert_eq!(st.get_state(), AgentState::Ready);
+    assert_eq!(st.get_state(), AgentState::Idle);
     // Chat content with glyph + tool name elsewhere on the line
     drive(
         &mut vt,
@@ -2123,7 +2120,7 @@ fn rate_limit_expires_after_300s_window() {
     t.tick();
     assert_eq!(
         t.get_state(),
-        AgentState::Ready,
+        AgentState::Idle,
         "RateLimit must expire to Ready after 300s"
     );
 }
@@ -3207,7 +3204,7 @@ fn record_set_buffers_transitions_fifo_then_drains() {
     assert_eq!(recs.len(), 2);
     assert_eq!(
         (recs[0].from, recs[0].to),
-        (AgentState::Ready, AgentState::Thinking)
+        (AgentState::Idle, AgentState::Thinking)
     );
     assert_eq!(
         (recs[1].from, recs[1].to),
@@ -3250,7 +3247,7 @@ fn set_awaiting_operator_records_transition() {
 #[test]
 fn same_state_record_set_is_noop() {
     let mut st = StateTracker::new(None); // Ready
-    st.record_set(AgentState::Ready); // same → no record
+    st.record_set(AgentState::Idle); // same → no record
     assert!(
         st.drain_pending_transitions().0.is_empty(),
         "same-state record_set must not buffer a spurious transition"
@@ -3596,7 +3593,7 @@ the agent kept going after the throttle\n";
 fn unclassified_throttle_logged_on_phrase_plus_nonretryable_state() {
     // Throttle phrase present, classifier landed on Ready (the in-the-wild
     // miss — e.g. anchor suppressed it / wording drifted) → capture.
-    let tail = unclassified_throttle_tail(AgentState::Ready, THROTTLE_SCREEN, &[]);
+    let tail = unclassified_throttle_tail(AgentState::Idle, THROTTLE_SCREEN, &[]);
     let tail = tail.expect("throttle phrase + non-retryable state must be captured");
     assert!(
         tail.contains("temporarily limiting requests"),
@@ -3625,7 +3622,7 @@ fn unclassified_throttle_skipped_when_classified_serverratelimit() {
 fn unclassified_throttle_skipped_without_phrase() {
     // No known throttle phrase on screen → never logged, regardless of state.
     let screen = "claude ready\n❯ awaiting input\n";
-    assert!(unclassified_throttle_tail(AgentState::Ready, screen, &[]).is_none());
+    assert!(unclassified_throttle_tail(AgentState::Idle, screen, &[]).is_none());
     assert!(unclassified_throttle_tail(AgentState::Thinking, screen, &[]).is_none());
 }
 
@@ -3639,7 +3636,7 @@ fn unclassified_throttle_skipped_when_phrase_only_in_scrollback() {
         screen.push_str(&format!("post-recovery output line {i}\n"));
     }
     assert!(
-        unclassified_throttle_tail(AgentState::Ready, &screen, &[]).is_none(),
+        unclassified_throttle_tail(AgentState::Idle, &screen, &[]).is_none(),
         "a throttle phrase only surviving in scrollback must NOT be logged"
     );
 }

--- a/tests/fixtures/state-replay/MANIFEST.yaml
+++ b/tests/fixtures/state-replay/MANIFEST.yaml
@@ -65,7 +65,7 @@ fixtures:
     cli_version: "0.38.2"
     recorded_on: "2026-04-19"
     scenario: "startup → ready → idle prompt → thinking (recording cut mid-response)"
-    expected_transitions: [starting, ready, idle, thinking]
+    expected_transitions: [starting, idle, thinking]
     expected_final_state: thinking
     # Final detect is None because the spinner token cleared off screen
     # but Thinking remains latched — Phase 1c's LATCHED_STATE_EXPIRY
@@ -93,12 +93,12 @@ fixtures:
       streaming spinner verb varies (Analyzing / Developing / …), so a verb
       whitelist would miss it (the #1541 lesson); the structural interrupt hint
       latches Thinking regardless of verb.
-    expected_transitions: [starting, ready, thinking]
+    expected_transitions: [starting, idle, thinking]
     expected_final_state: thinking
     # detect() sees Ready on the final screen (the response finished, spinner
     # cleared back to the prompt) but hysteresis holds the Thinking state at the
     # cut — same shape as kiro-thinking below.
-    expected_final_detect: ready
+    expected_final_detect: idle
     capture_kind: real_pty
     provenance: "#987 boot capture; #1579 calibrates the Thinking anchor against the spinner phase"
 
@@ -112,7 +112,7 @@ fixtures:
     # on the final frame) but not as a SETTLED state transition: agy's tool run
     # alternates the brief bullet with the dominant spinner (`esc to cancel` =
     # Thinking), so the hysteresis state machine settles on thinking/permission.
-    expected_transitions: [starting, ready, idle, thinking, permission]
+    expected_transitions: [starting, idle, thinking, permission]
     expected_final_state: permission
     expected_final_detect: tool_use
     capture_kind: real_pty
@@ -133,7 +133,7 @@ fixtures:
     recorded_on: "2026-06-01"
     scenario: "agy command-approval + trust dialogs — `Requesting permission for:` / `tab Amend · e edit command` / `Do you trust the contents of this project?` fire PermissionPrompt (#1578)"
     provenance: "#1578"
-    expected_transitions: [starting, ready, thinking, permission]
+    expected_transitions: [starting, idle, thinking, permission]
     expected_final_state: permission
     expected_final_detect: permission
     capture_kind: real_pty
@@ -147,7 +147,7 @@ fixtures:
     expected_final_state: thinking
     # detect() sees Ready on the final screen but hysteresis blocks the
     # immediate downgrade (Thinking held < 2s min_hold at cut time).
-    expected_final_detect: ready
+    expected_final_detect: idle
     # #685 PR-3 (corpus expansion): final=thinking, no kiro productive
     # markers (`● Read|Write|...` / `[fs_*]` literals) in rendered
     # output. F9 silent_stuck case for the kiro backend.
@@ -416,7 +416,7 @@ fixtures:
     # FOLLOW-UP: if gemini 0.38.2+ adds a dedicated in-flight tool
     # banner we can detect distinctly from Thinking, capture a new
     # fixture + re-introduce a narrow ToolUse pattern.
-    expected_transitions: [starting, ready, idle, thinking]
+    expected_transitions: [starting, idle, thinking]
     expected_final_state: thinking
     expected_final_detect: null
     # #685 PR-3 (corpus expansion): final=thinking, no gemini productive
@@ -448,7 +448,7 @@ fixtures:
     # status line.
     expected_transitions: [starting, idle, thinking]
     expected_final_state: thinking
-    expected_final_detect: ready
+    expected_final_detect: idle
     # #685 PR-3 (corpus expansion): final=thinking. `● Read` banner
     # appears in the raw byte stream at ~40960 but is not in the
     # final VTerm-rendered viewport — by the recording cut the trust-
@@ -516,9 +516,9 @@ fixtures:
     # and `ReadFile` lacks that boundary. The fixture's F9 measurement
     # focus is the `Saved to <path>` marker firing — observed via
     # `infer_productivity` independent of AgentState transitions.
-    expected_transitions: [starting, ready]
-    expected_final_state: ready
-    expected_final_detect: ready
+    expected_transitions: [starting, idle]
+    expected_final_state: idle
+    expected_final_detect: idle
     scenario_kind: productive_marker_fire
     expected_hung_classification: not_hung
     capture_kind: synthetic
@@ -538,9 +538,9 @@ fixtures:
       NEITHER appears at a line start nor with the structural anchor
       `^Saved to \S+`. Locks the F9 anti-FP contract: bare keywords
       must not classify as productive.
-    expected_transitions: [starting, ready]
-    expected_final_state: ready
-    expected_final_detect: ready
+    expected_transitions: [starting, idle]
+    expected_final_state: idle
+    expected_final_detect: idle
     scenario_kind: productive_silence
     expected_hung_classification: not_hung
     capture_kind: synthetic

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -399,7 +399,7 @@ fn test_crash_respawn_health() {
 
     let phase_start = Instant::now();
 
-    // Phase 1: process up + new registry handle inserted → agent_state == "ready"
+    // Phase 1: process up + new registry handle inserted → agent_state == "idle"
     if !wait_until(
         || {
             let r = daemon.api_call(&serde_json::json!({"method": "list"}));
@@ -407,7 +407,7 @@ fn test_crash_respawn_health() {
                 .as_array()
                 .and_then(|a| a.first())
                 .and_then(|a| a["agent_state"].as_str())
-                .map(|s| s == "ready")
+                .map(|s| s == "idle")
                 .unwrap_or(false)
         },
         SPAWN_TIMEOUT,
@@ -416,7 +416,7 @@ fn test_crash_respawn_health() {
         let agents = r["result"]["agents"].as_array();
         let first = agents.and_then(|a| a.first());
         panic!(
-            "phase 1 (agent_state == 'ready') not satisfied within 28s. \
+            "phase 1 (agent_state == 'idle') not satisfied within 28s. \
              last: count={}, agent_state={:?}, health_state={:?}",
             agents.map(|a| a.len()).unwrap_or(0),
             first.and_then(|a| a["agent_state"].as_str()).unwrap_or("?"),
@@ -437,7 +437,7 @@ fn test_crash_respawn_health() {
                 .as_array()
                 .and_then(|a| a.first())
                 .map(|a| {
-                    a["agent_state"].as_str() == Some("ready")
+                    a["agent_state"].as_str() == Some("idle")
                         && a["health_state"].as_str() == Some("healthy")
                 })
                 .unwrap_or(false)


### PR DESCRIPTION
## Collapse `AgentState::Ready` into `Idle` (operator KISS decision)

`Ready` and `Idle` were the same concept — the lowest-priority "idle, dispatchable"
state — split only because backend pattern tables labelled the idle prompt differently
(claude→Idle; agy/opencode/codex/kiro→Ready). Operator decided to collapse them: remove
`Ready`, keep `Idle`.

### Spike result (read-only, pre-impl)
The premise "Ready ≡ Idle is purely cosmetic" was **FALSE** — 3 logic sites diverged.
Operator reviewed and accepted the resulting behavior changes (all make former-Ready
backends **consistent with claude's** long-standing Idle behavior). The bulk IS cosmetic
(verified safe): `idle_watchdog` is silence-based (never reads the state); `min_hold` uses
`<= Idle.priority()` (relative, not a hardcoded value); the oscillation guard is scoped to
`{Thinking, ToolUse}`; `is_*` helpers and the supervisor/watchdog recovery sets grouped
`{Ready|Idle}` together; render colour is cosmetic.

### ⚠ ACCEPTED BEHAVIOR CHANGES
Former-Ready backends (agy/opencode/codex/kiro) now follow Idle's behavior:

| # | Site | Change |
|---|------|--------|
| ① | `poll_reminder.rs:44` (`== Idle` filter) | Idle agents are nudged about unread inbox. Former-Ready agents were **excluded**; now included. *(A fix — they have inboxes.)* |
| ② | `recovery_dispatcher.rs` `classify_branch` (`Idle => false`) | An idle agent is never "dead-likely" from silence alone. Former-Ready agents are no longer silence-reaped at their idle prompt. |
| ③ | `health.rs` `productive_silence_exceeds` (`Idle => false`) | Engine behind ②. Former-Ready agents are exempt from Hung-on-silence **at the idle prompt**. |

### ⚠ LOAD-BEARING PREMISE — please verify (③ must NOT lose real hang coverage)
My "no real hang-detection loss" conclusion rests on: **former-Ready backends actually
enter `ToolUse`/`Thinking` when working**, so a genuine hang is still caught via the
active-state 600s threshold — the idle-prompt exemption only applies when genuinely idle.
Evidence:
- **backend_profile.rs**: agy has `(ToolUse, r"●\s+[A-Z][a-zA-Z]+\(")` + `(Thinking,
  r"esc to cancel")` (`agy_profile`, ~L77-78); kiro (`kirocli_profile` ToolUse
  `execute_bash|fs_read|fs_write` + Thinking `Kiro is working|esc to cancel`) and opencode
  have equivalents.
- **Real-PTY replay fixtures prove they FIRE during work**: `agy-thinking.raw`,
  `agy-tooluse.raw`, `kiro-thinking.raw`, `opencode-thinking.raw`, `opencode-tooluse.raw`
  all observe `thinking`/`tool_use` transitions in `replay_manifest_regression`.
- **Backstop**: a frozen *dispatched* task is still caught by `dispatch_idle` (600s) →
  dispatcher. Only a non-dispatch injected message + total freeze at the idle prompt loses
  detection — the exact narrow case **claude has always had**.

### Tests
- Behavior changes pinned with teeth: `recovery_dispatcher::classify_idle_never_dead_likely_on_silence`,
  `health::classifier_idle_agent_exempt_from_hung`.
- Discriminator/health mechanism tests re-pointed to `ToolUse`/`Starting` carriers (Idle is
  now exempt → short-circuits before the discriminator). Block comments explain the carrier change.
- `MANIFEST.yaml` ready→idle (consecutive `ready, idle` collapse to one `idle`).
- Full bin suite **3209 passed / 0 failed**; clippy `--all-targets` (`tray`, `tray,discord`)
  + fmt clean; state integration tests green; zero `AgentState::Ready` remaining.

⚠ Does **not** require a daemon restart for correctness, but the new Idle behavior for
former-Ready backends only takes effect once a daemon running this binary classifies them.

---
@codex review — **standard tier**. Inline comments only. Focus:
1. **The load-bearing premise above** — independently confirm agy/opencode/kiro's
   `Thinking`/`ToolUse` patterns genuinely fire *during work* (not merely present in the
   profile table). The replay fixtures are the evidence; sanity-check they exercise it.
2. **No other Ready-only path missed** — any site that gated on `Idle` (excluding the old
   `Ready`) or on `Ready` (excluding `Idle`) that I didn't catch, where the merge silently
   changes behavior.
3. Behavior changes ①②③ behave as documented; the re-pointed mechanism tests still test
   the mechanism (didn't go tautological).
