### PR TITLE
refactor: upgrade twilight 0.16 → 0.17 (gateway/http/model)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,14 +4764,15 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-websockets"
-version = "0.11.4"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fcaf159b4e7a376b05b5bfd77bfd38f3324f5fce751b4213bfc7eaa47affb4e"
+checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
 dependencies = [
  "base64",
  "bytes",
@@ -4780,7 +4781,6 @@ dependencies = [
  "futures-sink",
  "http",
  "httparse",
- "ring",
  "rustls-native-certs",
  "rustls-pki-types",
  "sha1_smol",
@@ -5044,9 +5044,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twilight-gateway"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863ef55467bcf6a2958162766fd0b72f33112e36971b37f9ec09b86d4fd0f7d1"
+checksum = "59267541c31f888c1587da5e7cbab182ae6efd98faedd9ea2e35a4eef43ff204"
 dependencies = [
  "bitflags 2.11.0",
  "fastrand",
@@ -5063,9 +5063,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-gateway-queue"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c962bd4693da0a215abe6b431fd73eb87111f49c431b87951780f9f7985002"
+checksum = "366a73fe47f61a3d522c3aaf70475e60634b0ae59e7b94272ed7496fffa7ceb7"
 dependencies = [
  "tokio",
  "tracing",
@@ -5073,9 +5073,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-http"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9a2176638fd8bfeb867e7a2f644fee0db905eba6f7decfdcd75c8171109b74"
+checksum = "05b868001d7bfb953732b3f1cd92f63cb88cd2ea902f590b1d084c66aea60e48"
 dependencies = [
  "fastrand",
  "http",
@@ -5096,19 +5096,21 @@ dependencies = [
 
 [[package]]
 name = "twilight-http-ratelimiting"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36945d949920d6bb6aef30547e06ea645eefaa5575a14f56da608bf09d07ec8"
+checksum = "0515b0c30814068a7540fcb5f58b634259ca453fa335d42c3b2c8f2b06ac6a59"
 dependencies = [
+ "hashbrown 0.16.1",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "twilight-model"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191e2efa051dfbd9bed4c9f6bd3f5e007bda909c687a1db2760371a3d566617d"
+checksum = "2bf6bb7b93a7f765d89b3388cc710c0ae16104579e06bb30ea1ee6bd41420a8b"
 dependencies = [
  "bitflags 2.11.0",
  "serde",
@@ -5119,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-validate"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f8d106028ede53708526364b03318bbf846babe146e3ff9e39821a0ca25ff4"
+checksum = "d6a27472e023e3841d1c4e4e20253ed796e8440aada8b5205b8544f1172e661d"
 dependencies = [
  "twilight-model",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,9 +139,9 @@ toml = { version = "1.1", optional = true }
 # WS shard lifecycle, http for REST, model for typed Discord API structs.
 # Pin to 0.16 series (Discord API v10). rustls-native-roots avoids
 # macOS SecureTransport flakiness (same rationale as teloxide rustls).
-twilight-gateway = { version = "0.16", optional = true, default-features = false, features = ["rustls-native-roots", "rustls-ring"] }
-twilight-http = { version = "0.16", optional = true, default-features = false, features = ["rustls-native-roots", "rustls-ring"] }
-twilight-model = { version = "0.16", optional = true }
+twilight-gateway = { version = "0.17", optional = true, default-features = false, features = ["rustls-native-roots"] }
+twilight-http = { version = "0.17", optional = true, default-features = false, features = ["rustls-native-roots"] }
+twilight-model = { version = "0.17", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -1491,7 +1491,9 @@ mod tests {
         // result so the run log shows the handshake completed.
         match outcome {
             Ok(_) => eprintln!("TLS smoke: handshake + request OK (gateway responded)"),
-            Err(e) => eprintln!("TLS smoke: handshake OK, request returned (expected w/o token): {e}"),
+            Err(e) => {
+                eprintln!("TLS smoke: handshake OK, request returned (expected w/o token): {e}")
+            }
         }
     }
 

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -1471,6 +1471,30 @@ mod tests {
         assert_eq!(body["archived"], false, "must set archived=false");
     }
 
+    /// TLS smoke (network, manual): proves twilight-http 0.17's
+    /// rustls-native-roots/ring stack actually completes a real TLS handshake —
+    /// the one merge-gate CI can't cover (the spec tests use a plaintext mock
+    /// server). `#[ignore]` so normal/CI runs skip it; run with
+    /// `cargo test --features tray,discord -- --ignored tls_handshake_smoke`.
+    ///
+    /// A missing crypto provider would panic ("no process-level CryptoProvider")
+    /// during the handshake. We hit `GET /gateway` (no valid token → 401 is fine);
+    /// any HTTP/auth response proves the handshake succeeded. Auth is NOT tested.
+    #[tokio::test]
+    #[ignore = "network: real Discord TLS handshake smoke; run manually"]
+    async fn tls_handshake_smoke_real_discord() {
+        let client = twilight_http::Client::new("Bot tls-smoke-no-valid-token".to_string());
+        // `.gateway()` GETs https://discord.com/api/v10/gateway. The handshake
+        // happens before any auth check. A panic here = rustls/ring not wired.
+        let outcome = client.gateway().await;
+        // Reaching this line at all means no CryptoProvider panic. Surface the
+        // result so the run log shows the handshake completed.
+        match outcome {
+            Ok(_) => eprintln!("TLS smoke: handshake + request OK (gateway responded)"),
+            Err(e) => eprintln!("TLS smoke: handshake OK, request returned (expected w/o token): {e}"),
+        }
+    }
+
     /// Keepalive interval constant is reasonable (≤ Discord's shortest
     /// auto-archive of 3600s). Compile-time check via `const {}` blocks —
     /// per `clippy::assertions_on_constants` and Rust 1.79+ const block

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -1060,9 +1060,14 @@ mod tests {
         });
 
         // Step 3: Create twilight client pointed at mock server.
-        let client = twilight_http::Client::builder()
-            .proxy(format!("127.0.0.1:{port}"), true)
-            .build();
+        // twilight-http 0.17's ratelimiter initialises inside `build()` and needs
+        // a Tokio reactor in scope, so construct it within the shared discord
+        // runtime (production builds the client in async context already).
+        let client = super::discord_runtime().block_on(async {
+            twilight_http::Client::builder()
+                .proxy(format!("127.0.0.1:{port}"), true)
+                .build()
+        });
         let client = std::sync::Arc::new(client);
 
         // Step 4: Create DiscordChannel with this client + a recorded binding.
@@ -1165,9 +1170,13 @@ mod tests {
     fn make_test_channel_with_mock(
         port: u16,
     ) -> (super::DiscordChannel, std::sync::mpsc::Sender<ChannelEvent>) {
-        let client = twilight_http::Client::builder()
-            .proxy(format!("127.0.0.1:{port}"), true)
-            .build();
+        // twilight-http 0.17's ratelimiter initialises inside `build()` and needs
+        // a Tokio reactor in scope — build within the shared discord runtime.
+        let client = super::discord_runtime().block_on(async {
+            twilight_http::Client::builder()
+                .proxy(format!("127.0.0.1:{port}"), true)
+                .build()
+        });
         super::DiscordChannel::new_for_test_with_http(std::sync::Arc::new(client))
     }
 
@@ -1438,9 +1447,12 @@ mod tests {
     #[test]
     fn discord_keepalive_patch_method_matches_spec() {
         let (port, handle, captured) = mock_http_server(200, "{}");
-        let client = twilight_http::Client::builder()
-            .proxy(format!("127.0.0.1:{port}"), true)
-            .build();
+        // twilight-http 0.17's ratelimiter needs a Tokio reactor at build().
+        let client = super::discord_runtime().block_on(async {
+            twilight_http::Client::builder()
+                .proxy(format!("127.0.0.1:{port}"), true)
+                .build()
+        });
 
         let result = super::send_keepalive_patch(&client, 290926798999357250);
 

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -1063,7 +1063,7 @@ mod tests {
         // twilight-http 0.17's ratelimiter initialises inside `build()` and needs
         // a Tokio reactor in scope, so construct it within the shared discord
         // runtime (production builds the client in async context already).
-        let client = super::discord_runtime().block_on(async {
+        let client = super::block_on_value(async {
             twilight_http::Client::builder()
                 .proxy(format!("127.0.0.1:{port}"), true)
                 .build()
@@ -1172,7 +1172,7 @@ mod tests {
     ) -> (super::DiscordChannel, std::sync::mpsc::Sender<ChannelEvent>) {
         // twilight-http 0.17's ratelimiter initialises inside `build()` and needs
         // a Tokio reactor in scope — build within the shared discord runtime.
-        let client = super::discord_runtime().block_on(async {
+        let client = super::block_on_value(async {
             twilight_http::Client::builder()
                 .proxy(format!("127.0.0.1:{port}"), true)
                 .build()
@@ -1448,7 +1448,7 @@ mod tests {
     fn discord_keepalive_patch_method_matches_spec() {
         let (port, handle, captured) = mock_http_server(200, "{}");
         // twilight-http 0.17's ratelimiter needs a Tokio reactor at build().
-        let client = super::discord_runtime().block_on(async {
+        let client = super::block_on_value(async {
             twilight_http::Client::builder()
                 .proxy(format!("127.0.0.1:{port}"), true)
                 .build()


### PR DESCRIPTION
**Supersedes dependabot #1732** (close it). #1732 bumped only `twilight-model` to 0.17, which is incompatible: `twilight-http`/`twilight-gateway` 0.16 internally pin `twilight-model 0.16`, so our 0.17 `Id` mismatched http-0.16's 0.16 `Id` (the "expected `Id<ChannelMarker>` [from twilight-model 0.16]" CI errors). Upgrading all three together — twilight only patches the latest minor, so staying on 0.16 means no further security fixes (refactor-early).

## Spike break list (controllable — finished in this PR)
- **`Cargo.toml`**: `twilight-gateway`/`http`/`model` = `"0.17"`. The 0.17 crates **removed the `rustls-ring` feature** → replaced `[rustls-native-roots, rustls-ring]` with `[rustls-native-roots]`. (Transitive: `tokio-websockets` 0.11→0.13; `twilight-gateway-queue`/`http-ratelimiting`/`validate` → 0.17.)
- **Production code: ZERO changes.** `Id<Marker>` usage and the discord send/edit/delete/keepalive paths are source-compatible across 0.16→0.17 (the dependabot "errors" were purely the version skew).
- **Tests only (4 sites):** twilight-http 0.17's ratelimiter initialises inside `Client::build()` and requires a Tokio reactor in scope. The discord spec tests that built a twilight client in a sync `#[test]` now build it within the shared discord runtime (`super::discord_runtime().block_on(...)`). Production already builds the client in async context → unaffected.

## ⚠ TLS note (for codex MED-tier review)
The rustls feature change is the only behaviour-sensitive edit. `ring` 0.17 remains the **sole** crypto provider in the tree (no `aws-lc-rs`), wired via twilight-http 0.17's `hyper-rustls`/`rustls` stack; rustls's `ring` feature supplies the default `ClientConfig::builder()` provider, so **no explicit `CryptoProvider::install_default()` is needed**. However, a **live Discord TLS handshake is NOT exercised by CI** (discord is feature-gated; tests use a mock HTTP server) — recommend a manual discord smoke test before relying on the connection.

## Verification
- `cargo fmt --check` ✅ · clippy `tray` + `tray,discord` `-D warnings` ✅
- full bin suite **3237 passed, 0 failed** · all `channel::discord` tests green · `file_size_invariant` (#1463) ✅

Base: `f259bbb` (origin/main). No restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)