### PR TITLE
fix: boot-grace for stale-backlog notification watchdogs (no restart misfire)

### DIFF
--- a/src/daemon/per_tick/handoff_timeout.rs
+++ b/src/daemon/per_tick/handoff_timeout.rs
@@ -7,11 +7,14 @@ use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 pub(crate) struct HandoffTimeoutHandler {
     every_n_ticks: u64,
     counter: AtomicU64,
     last_escalated: Mutex<HashMap<(String, String), chrono::DateTime<chrono::Utc>>>,
+    /// ≈ daemon boot — drives boot-grace suppression (see [`super::in_boot_grace`]).
+    created_at: Instant,
 }
 
 impl HandoffTimeoutHandler {
@@ -20,6 +23,17 @@ impl HandoffTimeoutHandler {
             every_n_ticks,
             counter: AtomicU64::new(0),
             last_escalated: Mutex::new(HashMap::new()),
+            created_at: Instant::now(),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_at(every_n_ticks: u64, created_at: Instant) -> Self {
+        Self {
+            every_n_ticks,
+            counter: AtomicU64::new(0),
+            last_escalated: Mutex::new(HashMap::new()),
+            created_at,
         }
     }
 
@@ -29,6 +43,12 @@ impl HandoffTimeoutHandler {
             .fetch_add(1, Ordering::Relaxed)
             .is_multiple_of(self.every_n_ticks)
     }
+
+    /// Boot-grace + cadence gate. `&&` short-circuits before `should_fire`
+    /// during grace, so the counter is not consumed (see `PollReminderHandler`).
+    fn should_run(&self) -> bool {
+        !super::in_boot_grace(self.created_at) && self.should_fire()
+    }
 }
 
 impl PerTickHandler for HandoffTimeoutHandler {
@@ -37,7 +57,7 @@ impl PerTickHandler for HandoffTimeoutHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.should_run() {
             return;
         }
         let now = chrono::Utc::now();
@@ -49,6 +69,7 @@ impl PerTickHandler for HandoffTimeoutHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn fires_at_expected_cadence() {
@@ -63,5 +84,23 @@ mod tests {
             HandoffTimeoutHandler::new(30).name(),
             "handoff_timeout_watchdog"
         );
+    }
+
+    /// #t-watchdog-boot-suppress: suppressed during boot-grace (no stale-handoff
+    /// re-escalation on restart), fires on the first tick after grace. The
+    /// underlying `handoff_timeout_watchdog::scan_and_emit` tests prove a genuine
+    /// unclaimed handoff DOES escalate.
+    #[test]
+    fn boot_grace_suppresses_then_fires() {
+        let fresh = HandoffTimeoutHandler::new(30);
+        assert!(!fresh.should_run(), "in boot-grace → suppressed");
+        assert!(
+            !fresh.should_run(),
+            "still suppressed; counter not consumed"
+        );
+
+        let past = Instant::now() - super::super::NOTIFICATION_BOOT_GRACE - Duration::from_secs(1);
+        let aged = HandoffTimeoutHandler::new_at(30, past);
+        assert!(aged.should_run(), "after grace, first tick fires");
     }
 }

--- a/src/daemon/per_tick/inbox_stuck.rs
+++ b/src/daemon/per_tick/inbox_stuck.rs
@@ -8,11 +8,14 @@ use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 pub(crate) struct InboxStuckHandler {
     every_n_ticks: u64,
     counter: AtomicU64,
     last_alerted: Mutex<HashMap<String, chrono::DateTime<chrono::Utc>>>,
+    /// ≈ daemon boot — drives boot-grace suppression (see [`super::in_boot_grace`]).
+    created_at: Instant,
 }
 
 impl InboxStuckHandler {
@@ -21,6 +24,17 @@ impl InboxStuckHandler {
             every_n_ticks,
             counter: AtomicU64::new(0),
             last_alerted: Mutex::new(HashMap::new()),
+            created_at: Instant::now(),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_at(every_n_ticks: u64, created_at: Instant) -> Self {
+        Self {
+            every_n_ticks,
+            counter: AtomicU64::new(0),
+            last_alerted: Mutex::new(HashMap::new()),
+            created_at,
         }
     }
 
@@ -30,6 +44,12 @@ impl InboxStuckHandler {
             .fetch_add(1, Ordering::Relaxed)
             .is_multiple_of(self.every_n_ticks)
     }
+
+    /// Boot-grace + cadence gate. `&&` short-circuits before `should_fire`
+    /// during grace, so the counter is not consumed (see `PollReminderHandler`).
+    fn should_run(&self) -> bool {
+        !super::in_boot_grace(self.created_at) && self.should_fire()
+    }
 }
 
 impl PerTickHandler for InboxStuckHandler {
@@ -38,7 +58,7 @@ impl PerTickHandler for InboxStuckHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.should_run() {
             return;
         }
         let now = chrono::Utc::now();
@@ -50,6 +70,7 @@ impl PerTickHandler for InboxStuckHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn fires_at_expected_cadence() {
@@ -61,5 +82,24 @@ mod tests {
     #[test]
     fn name_matches_module() {
         assert_eq!(InboxStuckHandler::new(30).name(), "inbox_stuck_watchdog");
+    }
+
+    /// #t-watchdog-boot-suppress: within boot-grace, `should_run` is false (no
+    /// alert for the stale backlog) and the counter is NOT consumed; past grace
+    /// the first tick fires. Combined with `inbox_stuck_watchdog`'s scan_and_emit
+    /// tests (which prove a real stuck pile DOES alert), this pins "suppressed
+    /// during grace, fires for a genuine stuck agent after grace".
+    #[test]
+    fn boot_grace_suppresses_then_fires() {
+        let fresh = InboxStuckHandler::new(30); // created_at ≈ now → in grace
+        assert!(!fresh.should_run(), "in boot-grace → suppressed");
+        assert!(
+            !fresh.should_run(),
+            "still suppressed; counter not consumed"
+        );
+
+        let past = Instant::now() - super::super::NOTIFICATION_BOOT_GRACE - Duration::from_secs(1);
+        let aged = InboxStuckHandler::new_at(30, past);
+        assert!(aged.should_run(), "after grace, first tick fires");
     }
 }

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -85,6 +85,30 @@ pub(crate) trait PerTickHandler: Send + Sync {
     fn run(&self, ctx: &TickContext<'_>);
 }
 
+/// #t-watchdog-boot-suppress: boot-grace window for the stale-backlog
+/// NOTIFICATION watchdogs (`PollReminder` / `InboxStuck` / `HandoffTimeout`).
+/// Those handlers keep their dedup state IN-MEMORY (empty at boot) and their
+/// cadence counter resets to 0 each boot (so `should_fire` is true on tick 0).
+/// On a daemon restart they would therefore re-fire for the ENTIRE current
+/// backlog of unread / unclaimed items on the very first tick — including
+/// freshly-respawned agents that simply haven't drained their inbox yet (a
+/// false "stuck" alert). Suppressing these handlers for the first
+/// `NOTIFICATION_BOOT_GRACE` after construction (≈ daemon boot) closes all three
+/// causes at once: the in-memory dedup reset, the counter reset, and the
+/// post-restart drain false-positive. 3 min is comfortably longer than agent
+/// spawn + inbox drain (~tens of seconds) and far shorter than the watchdogs'
+/// own 30-min stuck thresholds, so a genuinely-stuck item still alerts shortly
+/// after the grace ends. Mirrors the boot-suppress precedent
+/// `pr_state::suppress_stale_terminal_replay`.
+pub(crate) const NOTIFICATION_BOOT_GRACE: std::time::Duration = std::time::Duration::from_secs(180);
+
+/// True while still within [`NOTIFICATION_BOOT_GRACE`] of `created_at` (the
+/// handler's construction instant ≈ daemon boot). The notification watchdogs
+/// early-return from their `run` while this holds.
+pub(crate) fn in_boot_grace(created_at: std::time::Instant) -> bool {
+    created_at.elapsed() < NOTIFICATION_BOOT_GRACE
+}
+
 // ── #941: per-handler timing observability ─────────────────────────────
 //
 // `HANDLER_TIMING` accumulates per-handler wall-clock stats so the
@@ -210,6 +234,46 @@ mod tests {
     use super::*;
     use parking_lot::Mutex as PLMutex;
     use std::sync::Arc;
+
+    /// #t-watchdog-boot-suppress: the boot-grace predicate is active for a
+    /// just-built handler and expires past the window; the window itself is a
+    /// sane value (not zeroed away, not absurdly long).
+    #[test]
+    fn in_boot_grace_active_then_expires() {
+        use std::time::{Duration, Instant};
+        assert!(
+            in_boot_grace(Instant::now()),
+            "a just-constructed handler is within boot-grace"
+        );
+        assert!(
+            !in_boot_grace(Instant::now() - NOTIFICATION_BOOT_GRACE - Duration::from_secs(1)),
+            "past the window → no longer in boot-grace"
+        );
+        assert!(
+            (Duration::from_secs(60)..=Duration::from_secs(600)).contains(&NOTIFICATION_BOOT_GRACE),
+            "grace must stay a sane window (≥1min to suppress the burst, ≤10min ≪ 30min stuck threshold)"
+        );
+    }
+
+    /// Source-pin: every notification watchdog handler must wire the boot-grace
+    /// gate, so a future edit can't silently drop it and reintroduce the
+    /// restart-burst. (Cross-platform file read, survives rustfmt.)
+    #[test]
+    fn notification_handlers_wire_boot_grace() {
+        for file in [
+            "src/daemon/per_tick/poll_reminder.rs",
+            "src/daemon/per_tick/inbox_stuck.rs",
+            "src/daemon/per_tick/handoff_timeout.rs",
+        ] {
+            let src = std::fs::read_to_string(file)
+                .or_else(|_| std::fs::read_to_string(format!("agend-terminal/{file}")))
+                .unwrap_or_else(|_| panic!("source must be readable: {file}"));
+            assert!(
+                src.contains("in_boot_grace(self.created_at)"),
+                "{file} must gate firing on in_boot_grace (boot-suppress) — #t-watchdog-boot-suppress"
+            );
+        }
+    }
 
     /// Mock handler with arbitrary `run` behaviour: either records a
     /// hit on a shared counter or panics with a fixed message.

--- a/src/daemon/per_tick/poll_reminder.rs
+++ b/src/daemon/per_tick/poll_reminder.rs
@@ -5,10 +5,14 @@
 
 use super::{PerTickHandler, TickContext};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 pub(crate) struct PollReminderHandler {
     every_n_ticks: u64,
     counter: AtomicU64,
+    /// ≈ daemon boot (handlers are built once at startup). Drives the
+    /// boot-grace suppression — see [`super::in_boot_grace`].
+    created_at: Instant,
 }
 
 impl PollReminderHandler {
@@ -16,6 +20,16 @@ impl PollReminderHandler {
         Self {
             every_n_ticks,
             counter: AtomicU64::new(0),
+            created_at: Instant::now(),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_at(every_n_ticks: u64, created_at: Instant) -> Self {
+        Self {
+            every_n_ticks,
+            counter: AtomicU64::new(0),
+            created_at,
         }
     }
 
@@ -28,6 +42,13 @@ impl PollReminderHandler {
             .fetch_add(1, Ordering::Relaxed)
             .is_multiple_of(self.every_n_ticks)
     }
+
+    /// Gate combining boot-grace + cadence. During boot-grace the `&&`
+    /// short-circuits BEFORE `should_fire`, so the counter is NOT consumed —
+    /// the first tick AFTER grace sees counter 0 and fires immediately.
+    fn should_run(&self) -> bool {
+        !super::in_boot_grace(self.created_at) && self.should_fire()
+    }
 }
 
 impl PerTickHandler for PollReminderHandler {
@@ -36,7 +57,7 @@ impl PerTickHandler for PollReminderHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if self.should_fire() {
+        if self.should_run() {
             crate::daemon::poll_reminder::poll_reminder_pass(ctx.home, ctx.registry);
         }
     }
@@ -45,6 +66,7 @@ impl PerTickHandler for PollReminderHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     /// Pin the cadence: with N=3, fires on the 1st, 4th, 7th call
     /// (counter values 0, 3, 6 — each a multiple of 3).
@@ -61,5 +83,27 @@ mod tests {
         let h = PollReminderHandler::new(1);
         let fires: Vec<bool> = (0..5).map(|_| h.should_fire()).collect();
         assert_eq!(fires, vec![true; 5]);
+    }
+
+    /// #t-watchdog-boot-suppress: a freshly-built handler (created_at ≈ now) is
+    /// in boot-grace → `should_run` is false even though `should_fire` would be
+    /// true on tick 0. The `&&` must NOT consume the counter during grace.
+    #[test]
+    fn boot_grace_suppresses_first_ticks() {
+        let h = PollReminderHandler::new(1); // N=1 → should_fire always true
+        assert!(!h.should_run(), "in boot-grace → suppressed");
+        assert!(!h.should_run(), "still suppressed; counter not consumed");
+    }
+
+    /// Past the grace window, the first tick fires (counter still 0 because grace
+    /// short-circuited it earlier).
+    #[test]
+    fn fires_on_first_tick_after_grace() {
+        let past = Instant::now() - super::super::NOTIFICATION_BOOT_GRACE - Duration::from_secs(1);
+        let h = PollReminderHandler::new_at(30, past);
+        assert!(
+            h.should_run(),
+            "after grace, the first post-grace tick fires"
+        );
     }
 }


### PR DESCRIPTION
## Boot-grace for stale-backlog notification watchdogs

Consolidated fix for the latent bug surfaced by the per_tick audit (this dev's
stale-backlog lens) + reviewer-2's restart-idempotency lens. PR #1726 activated
3 notification watchdogs in app mode that were previously dormant: **PollReminder,
InboxStuck, HandoffTimeout**.

### The bug (same class as the #1727 dispatch flip-flop)
These handlers have **two** independent first-tick-after-restart misfire causes:
1. **In-memory dedup reset** — `last_alerted` / `last_escalated` / `LAST_NOTIFIED`
   live in memory, empty at boot → no record of what was already alerted.
2. **Cadence counter reset** — `counter: AtomicU64::new(0)` → `should_fire` is
   true on **tick 0**, so they fire immediately on the first tick after boot.

So on a daemon restart they re-fire for the **entire current backlog** of
unread/unclaimed items at once — and worse, flag **freshly-respawned agents** as
"stuck" before they've had a chance to drain their inbox (a false positive; the
message age survives the restart but the agent was just re-spawned).

### Fix — a single boot-grace window
A shared `in_boot_grace(created_at)` + `NOTIFICATION_BOOT_GRACE` (180s). Each of
the 3 handlers stores its construction `Instant` (≈ boot) and gates firing on
`should_run()` = `!in_boot_grace(created_at) && should_fire()`. The `&&`
short-circuits **before** `should_fire` during grace, so the counter is **not
consumed** — the first tick after grace fires immediately. One window closes all
three causes (dedup reset, counter reset, drain FP).

**180s** is comfortably longer than agent spawn + inbox drain (~tens of seconds)
and far shorter than the watchdogs' own 30-min stuck thresholds, so a genuinely
stuck item still alerts shortly after grace. Mirrors the existing precedent
`pr_state::suppress_stale_terminal_replay` (boot-suppress of stale terminal PR
events).

### Scope
Only the 3 notification handlers (per the audit + lead's direction). Cleanup
handlers (Gc / InboxMaintenance / LogRotation) are intentionally **not** touched
— their counter-reset early-cleanup is harmless (byte/content/time-based +
idempotent).

### Tests
- `in_boot_grace_active_then_expires` — helper logic + the window is a sane value
  (≥60s, ≤600s — guards against someone zeroing it).
- per-handler `boot_grace_suppresses_then_fires` — suppressed within grace,
  counter not consumed, fires on first tick after grace. **Negative-probed**:
  removing the gate fails this.
- `notification_handlers_wire_boot_grace` — source-pin that all 3 handlers gate
  on `in_boot_grace(self.created_at)`. **Negative-probed**: removing the gate from
  any handler fails this.
- Existing `scan_and_emit` tests already prove a genuine stuck pile DOES alert
  (so "fires for real stuck after grace" is covered end-to-end by composition).

Full suite (bin + all integration targets) green; clippy `--all-targets`
(`tray`, `tray,discord`) + fmt clean; no #1463 pollution.

**Deploy with the #1735 batch** so the next restart doesn't fire the burst.

---
@codex review — **standard tier**. Inline comments only. Focus:
1. The boot-grace correctly suppresses BOTH causes — in particular the `&&`
   short-circuit means the counter is not consumed during grace, so firing
   resumes promptly (not delayed by a full N-tick cycle) after grace.
2. 180s is a sound value — long enough for post-restart inbox drain, short enough
   that genuine stuck/unclaimed items still alert well before their own 30-min
   thresholds become stale.
3. No handler that SHOULD keep firing on tick 0 (e.g. a cleanup/safety handler)
   was accidentally swept into the grace — only the 3 notification watchdogs gate.
