### PR TITLE
fix: enforce local CI-parity in the pre-push hook (close the integration-target miss)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,22 @@ A pre-commit hook at `.git/hooks/pre-commit` auto-formats staged `.rs` files
 and re-stages them. It does NOT run clippy — clippy is too slow for a
 pre-commit path. Run clippy yourself before `git push`.
 
-A pre-push hook verifies push claims (e.g. "no other changes", "deps
-unchanged") against the actual diff. Override with `git push --no-verify`
-in emergencies.
+The pre-push hook (`scripts/hooks/pre-push`) runs **two gates**:
+
+1. **CI-parity** (#t-ci-parity-prepush-guard) — on a push whose range touches
+   `src/` / `tests/` / `Cargo.*` / `build.rs`, it runs `scripts/preflight.sh
+   --quick` (the exact CI `check` commands: `cargo fmt --check`, `cargo clippy
+   --all-targets --features tray -- -D warnings`, `cargo test --tests --features
+   tray`) and **blocks the push if they fail**. This closes the recurring miss
+   where an agent ran only `cargo test --bin` — which SKIPS the `tests/`
+   integration targets — declared CI-ready, and CI then rejected it
+   (#1734 stale-string integration test, #1735 block_on invariant). Docs-only
+   pushes skip the build. `--quick` omits the Windows cross-check (CI's
+   `windows-latest` is the backstop for that).
+2. **claim-verify** — verifies `Claim:` trailers against the actual diff.
+
+Override either with `git push --no-verify` in emergencies (the daemon-side gate
+and CI still apply, so `--no-verify` is not a free pass).
 
 A post-merge hook triggers a background `cargo build --release` when `src/`
 files change. Desktop notification on completion. Does not auto-restart the
@@ -55,8 +68,18 @@ daemon — operator decides restart timing. Disable with
 Hooks are per-clone. After a fresh `git clone`, install with:
 
 ```bash
-scripts/install-hooks.sh
+scripts/install-hooks.sh   # idempotent — safe to re-run
 ```
+
+**Fleet-agent coexistence**: the daemon sets each managed worktree's
+`core.hooksPath` to `$AGEND_HOME/hooks` (`src/binding.rs::install_hooks`) and
+writes only `prepare-commit-msg` there — it does *not* clear the directory. So
+`install-hooks.sh` *copies* the tracked `pre-push` into `$AGEND_HOME/hooks/pre-push`,
+where it coexists and fires for agent pushes (one copy covers every current and
+future worktree, since they share that dir). Agent pushes DO run the hook: the
+`agend-git` shim and the `AGEND_GIT_BYPASS` path both `exec` real `git`, which
+honours `core.hooksPath`. This coexistence relies on the daemon not deleting
+`$AGEND_HOME/hooks/pre-push`; if that changes, re-run `install-hooks.sh`.
 
 ## Test fidelity: feed consumers the producer's real output (#1493)
 

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,65 +1,113 @@
 #!/usr/bin/env bash
-# Pre-push hook: verify push claims against actual diff.
+# Pre-push hook. Two gates, in order:
 #
-# Reads push refs from stdin (standard git pre-push protocol), extracts
-# claim text from the latest commit's message trailer, and runs the
-# claim verifier via `cargo run --quiet --bin agend-terminal -- verify-push`.
+#   1. CI-parity  — run locally EXACTLY what the required CI Check runs, so a
+#                   push cannot pass this hook while failing CI.
+#   2. Claim-verify — verify push-claim trailers against the actual diff.
 #
-# Emergency override: `git push --no-verify`
+# Emergency override for both: `git push --no-verify` (a warning is echoed;
+# the daemon-side gate still applies, so override is not a free pass).
 #
-# The daemon-side API endpoint provides defense-in-depth — bypassing
-# this hook via --no-verify does not bypass the daemon gate.
+# Install / coexistence (see scripts/install-hooks.sh):
+#   Fleet agents push under a git whose `core.hooksPath` the daemon sets to
+#   `$AGEND_HOME/hooks` (src/binding.rs::install_hooks), where it writes ONLY
+#   `prepare-commit-msg` and does NOT clear the directory. install-hooks.sh
+#   copies THIS script into `$AGEND_HOME/hooks/pre-push` so it coexists and
+#   fires for agent pushes. If the daemon ever starts clearing that dir, this
+#   coexistence breaks — re-run install-hooks.sh (it is idempotent).
 
 set -euo pipefail
 
-# Locate repo root (works in worktrees too)
+# Repo root (works in worktrees too).
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# Read push refs from stdin: <local ref> <local sha> <remote ref> <remote sha>
-while read -r local_ref local_sha remote_ref remote_sha; do
-    # Skip delete pushes
-    if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
-        continue
-    fi
+# Capture the push refs from stdin ONCE so both gates can read them.
+# git pre-push protocol line: <local ref> <local sha> <remote ref> <remote sha>
+refs="$(cat)"
 
-    # Determine base: if remote_sha is zero (new branch), use merge-base with origin/main
-    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
-        base=$(git merge-base origin/main "$local_sha" 2>/dev/null || echo "")
+ZERO="0000000000000000000000000000000000000000"
+
+# ── Gate 1: CI-parity (#t-ci-parity-prepush-guard) ──────────────────────────
+# Closes the recurring miss where an agent ran only `cargo test --bin` — which
+# SKIPS the `tests/` integration targets — declared CI-ready, and CI then
+# rejected the push: #1734 (stale "ready" string in tests/integration.rs),
+# #1735 (block_on invariant under tests/). The three commands below mirror
+# `.github/workflows/ci.yml` (fmt / clippy / `test --tests`) verbatim — by
+# definition the hook catches what CI catches, no more, no less.
+#
+# Gated to code pushes (src/ tests/ Cargo.* build.rs); a docs-only push skips
+# the (~1–3 min, cargo-incremental) build to keep latency down.
+ci_parity_needed=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    [ -z "${local_sha:-}" ] && continue
+    [ "$local_sha" = "$ZERO" ] && continue # delete push
+    if [ "$remote_sha" = "$ZERO" ]; then
+        base="$(git merge-base origin/main "$local_sha" 2>/dev/null || echo "")"
+    else
+        base="$remote_sha"
+    fi
+    if [ -z "$base" ]; then
+        ci_parity_needed=1 # unknown range → run to be safe
+        break
+    fi
+    if git diff --name-only "$base" "$local_sha" -- \
+        src/ tests/ Cargo.toml Cargo.lock build.rs 2>/dev/null | grep -q .; then
+        ci_parity_needed=1
+        break
+    fi
+done <<<"$refs"
+
+if [ "$ci_parity_needed" = "1" ]; then
+    cd "$REPO_ROOT"
+    # DRY: delegate to the canonical preflight (fmt --check + clippy
+    # --all-targets --features tray + `cargo test --tests --features tray`),
+    # `--quick` to skip the slow Windows cross-check (CI's windows-latest is the
+    # backstop for that). Single source of the parity commands → the hook can
+    # never drift from CI / preflight.sh.
+    if [ -x scripts/preflight.sh ]; then
+        echo "pre-push: CI-parity via 'scripts/preflight.sh --quick' (mirrors CI's check job, host-only)…" >&2
+        if ! scripts/preflight.sh --quick; then
+            echo "pre-push: CI-parity FAILED — fix the above; this is exactly what CI will reject." >&2
+            echo "pre-push: (emergency only) 'git push --no-verify' bypasses the hook; CI still gates." >&2
+            exit 1
+        fi
+        echo "pre-push: CI-parity passed ✓" >&2
+    else
+        # Fail-OPEN (loud): don't block a push just because the repo-layer
+        # preflight script is missing/unexecutable — CI remains the backstop.
+        echo "pre-push: WARNING scripts/preflight.sh not found/executable — local CI-parity NOT enforced (CI still gates)." >&2
+    fi
+fi
+
+# ── Gate 2: claim-verify (per-ref) ──────────────────────────────────────────
+# Extract claim text from the latest commit's "Claim:" trailer only. Incidental
+# prose containing claim keywords must NOT trigger verification.
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    [ -z "${local_sha:-}" ] && continue
+    [ "$local_sha" = "$ZERO" ] && continue
+
+    if [ "$remote_sha" = "$ZERO" ]; then
+        base="$(git merge-base origin/main "$local_sha" 2>/dev/null || echo "")"
         if [ -z "$base" ]; then
-            echo "pre-push: cannot determine base for new branch, skipping verification." >&2
+            echo "pre-push: cannot determine base for new branch, skipping claim verification." >&2
             continue
         fi
     else
         base="$remote_sha"
     fi
 
-    # Extract claim text from the latest commit's "Claim:" trailer only.
-    # Incidental prose containing claim keywords must NOT trigger verification.
-    commit_msg=$(git log -1 --format=%B "$local_sha")
-    claim_text=""
-
-    # Trailer-only: "Claim: <text>"
-    trailer=$(echo "$commit_msg" | grep -i '^Claim:' | sed 's/^[Cc]laim:[[:space:]]*//' || true)
-    if [ -n "$trailer" ]; then
-        claim_text="$trailer"
-    fi
-
-    # If no claim text found, skip verification (no claims to check)
-    if [ -z "$claim_text" ]; then
-        continue
-    fi
+    commit_msg="$(git log -1 --format=%B "$local_sha")"
+    claim_text="$(echo "$commit_msg" | grep -i '^Claim:' | sed 's/^[Cc]laim:[[:space:]]*//' || true)"
+    [ -z "$claim_text" ] && continue # no claims to check
 
     echo "pre-push: verifying claims for ${local_sha:0:7}..." >&2
-
-    # Run the claim verifier
     if ! echo "$claim_text" | cargo run --quiet --bin agend-terminal -- verify-push \
         --base "$base" --head "$local_sha" --claim-from-stdin; then
         echo "pre-push: claim verification FAILED — fix claims or amend diff." >&2
         echo "pre-push: use 'git push --no-verify' for emergency override." >&2
         exit 1
     fi
-
     echo "pre-push: claims verified ✓" >&2
-done
+done <<<"$refs"
 
 exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,17 +1,44 @@
 #!/usr/bin/env bash
-# Point git at the tracked hooks in scripts/hooks/.
+# Install the tracked git hooks. Idempotent — safe to re-run any time.
 #
-# Per-clone setup: run this once after `git clone`. Hooks are not tracked in
-# .git/ so the canonical copy lives in scripts/hooks/ and this script tells
-# git to look there.
+# Two install targets, because there are two distinct push contexts:
+#
+#   1. Standalone clone (operator / CI): point git at the tracked hooks in
+#      `scripts/hooks/` via `core.hooksPath`.
+#
+#   2. Fleet agents: the daemon sets each worktree's `core.hooksPath` to
+#      `$AGEND_HOME/hooks` (src/binding.rs::install_hooks) and writes ONLY
+#      `prepare-commit-msg` there — it does NOT clear the directory. So we
+#      COPY the tracked `pre-push` into `$AGEND_HOME/hooks/pre-push`, where it
+#      coexists with the daemon's hook and fires for agent pushes (the pushes
+#      the CI-parity gate in pre-push exists to guard). One copy covers every
+#      current and future worktree because they all share that dir.
+#
+# Coexistence assumption: the daemon never deletes `$AGEND_HOME/hooks/pre-push`.
+# That matches the current binding.rs behaviour (write prepare-commit-msg, no
+# dir clear). If that ever changes, re-run this script.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-git config core.hooksPath scripts/hooks
 chmod +x scripts/hooks/*
 
+# 1. Standalone clone.
+git config core.hooksPath scripts/hooks
 echo "Installed: core.hooksPath -> scripts/hooks"
+
+# 2. Fleet agents ($AGEND_HOME/hooks, coexisting with the daemon's hook).
+AGEND_HOME="${AGEND_HOME:-$HOME/.agend-terminal}"
+if [ -d "$AGEND_HOME" ]; then
+    mkdir -p "$AGEND_HOME/hooks"
+    cp scripts/hooks/pre-push "$AGEND_HOME/hooks/pre-push"
+    chmod +x "$AGEND_HOME/hooks/pre-push"
+    echo "Installed: $AGEND_HOME/hooks/pre-push (coexists with daemon prepare-commit-msg)"
+else
+    echo "Note: \$AGEND_HOME ($AGEND_HOME) not found — skipped the fleet-agent copy." >&2
+    echo "      Re-run with AGEND_HOME set if you want the agent-push CI-parity gate." >&2
+fi
+
 echo "Hooks active:"
 ls -1 scripts/hooks

--- a/tests/prepush_hook_invariant.rs
+++ b/tests/prepush_hook_invariant.rs
@@ -1,0 +1,50 @@
+//! Invariant: the committed pre-push hook enforces local CI-parity.
+//!
+//! #t-ci-parity-prepush-guard. Closes the recurring miss where an agent ran
+//! only `cargo test --bin` — which SKIPS the `tests/` integration targets —
+//! declared CI-ready, and CI then rejected the push (#1734 stale "ready" string
+//! in tests/integration.rs; #1735 block_on invariant under tests/). The hook
+//! delegates CI-parity to the canonical preflight so it can never drift from
+//! CI; these pins keep the gate wired so a future edit can't silently drop it.
+//!
+//! (This file is itself a `tests/` target — so the very gate it pins would also
+//! catch a regression here, the same way it catches #1734/#1735.)
+
+const PRE_PUSH: &str = include_str!("../scripts/hooks/pre-push");
+
+#[test]
+fn pre_push_runs_ci_parity_via_preflight() {
+    assert!(
+        PRE_PUSH.contains("scripts/preflight.sh --quick"),
+        "pre-push must delegate CI-parity to the canonical preflight \
+         (fmt --check / clippy --all-targets --features tray / cargo test --tests)"
+    );
+    assert!(
+        PRE_PUSH.contains("exit 1"),
+        "pre-push must BLOCK the push (exit 1) when CI-parity fails"
+    );
+}
+
+#[test]
+fn pre_push_gates_on_code_changes() {
+    // Docs-only pushes skip the (~minutes) build for latency; code pushes run
+    // the gate. Pin both the diff detection and the watched code paths.
+    assert!(
+        PRE_PUSH.contains("git diff --name-only"),
+        "pre-push must detect whether the push range touches code"
+    );
+    for path in ["src/", "tests/", "Cargo.toml", "Cargo.lock"] {
+        assert!(
+            PRE_PUSH.contains(path),
+            "pre-push code-change gate must watch '{path}'"
+        );
+    }
+}
+
+#[test]
+fn pre_push_documents_emergency_override() {
+    assert!(
+        PRE_PUSH.contains("--no-verify"),
+        "pre-push must document the emergency override"
+    );
+}


### PR DESCRIPTION
## Enforce local CI-parity in the pre-push hook

**Root cause (bit twice):** an agent runs only `cargo test --bin` — which SKIPS the
`tests/` integration targets — declares the branch CI-ready, and CI then rejects it.
#1734 (stale `"ready"` string in `tests/integration.rs`), #1735 (block_on invariant
under `tests/`). The fix is systematic, not "remember to run more": the committed
pre-push hook now **enforces** local CI-parity.

### What the hook does
`scripts/hooks/pre-push` gains a CI-parity gate (before the existing claim-verify):
- On a push whose range touches `src/` / `tests/` / `Cargo.*` / `build.rs`, it runs
  **`scripts/preflight.sh --quick`** and **blocks the push if it fails**. Delegating to
  the canonical preflight (DRY) means the commands — `cargo fmt --check`, `cargo clippy
  --all-targets --features tray -- -D warnings`, `cargo test --tests --features tray` —
  can never drift from CI's `check` job. `--quick` skips the Windows cross-check (CI's
  `windows-latest` is the backstop).
- Docs-only pushes skip the build (latency). `--no-verify` overrides (warning echoed;
  daemon gate + CI still apply). Fail-open + loud warning if `preflight.sh` is missing.

### Self-install (coexistence — no daemon change, no restart)
The daemon sets each managed worktree's `core.hooksPath` to `$AGEND_HOME/hooks`
(`binding.rs::install_hooks`) and writes **only** `prepare-commit-msg` there — it does
not clear the dir. So `scripts/install-hooks.sh` (now idempotent) **copies** the tracked
`pre-push` into `$AGEND_HOME/hooks/pre-push`, coexisting and firing for agent pushes (one
copy covers every current + future worktree — shared dir). Confirmed agent pushes run the
hook: the `agend-git` shim and the `AGEND_GIT_BYPASS` path both `exec` real `git`, which
honours `core.hooksPath`.

### Proof (manual, captured — the core deliverable)
Added a `tests/` target with a #1734-style stale assertion, then:
- `cargo test --bin agend-terminal` → **PASSED** (`0 passed; ... 3226 filtered out` — it
  skips every `tests/` target). ← the exact miss.
- `cargo test --test <target>` → **FAILED** (catches it).
- Ran the actual hook → it ran `preflight.sh --quick` → `PREFLIGHT FAILED` →
  `pre-push: CI-parity FAILED` → **HOOK_EXIT=1 (push blocked)**.
- Removed the failing test → `preflight.sh --quick` **passed (3/3)** (fmt, clippy, test).

#1735 is the same class: `block_on_runtime_guard_invariant.rs` is a `tests/` target in the
same `--tests` set the hook runs and `--bin` skips — so the same gate catches it.

### Tests
`tests/prepush_hook_invariant.rs` source-pins the gate (delegates to preflight, blocks on
fail, watches `src/`/`tests/`/`Cargo.*`, documents `--no-verify`). **Negative-probed**:
dropping the preflight call from the hook fails the pin. (It's itself a `tests/` target, so
the very gate it pins would catch a regression in it.)

### Deploy
Repo-layer workflow change — **no daemon binary change, no restart**. Activate by running
`scripts/install-hooks.sh` (post-merge). `shellcheck` not available in this env — please
run it on the two scripts in review if you have it.

---
@codex review — **standard tier**. Inline comments only. Focus:
1. The hook genuinely **blocks** a `tests/`-target failure (the #1734/#1735 class) and the
   docs-only gate doesn't accidentally skip a code push (verify the `git diff --name-only
   -- src/ tests/ Cargo.* build.rs` path detection + the new-branch `merge-base` base).
2. The coexistence claim — `$AGEND_HOME/hooks/pre-push` survives the daemon's
   `binding.rs::install_hooks` (which only writes `prepare-commit-msg`, no dir clear).
3. Shell correctness: the single `cat` stdin capture feeds both gates; `set -euo pipefail`
   interplay with `grep -q` / `|| parity` paths; `--quick` exit-code propagation from
   `preflight.sh`.
