### PR TITLE
ci: make Coverage trustworthy — smart retry (no real-failure mislabel) + harden flaky test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,22 +254,37 @@ jobs:
         timeout-minutes: 35
         env:
           AGEND_LOCK_AUDIT: "1"
-        # #1452: Coverage (non-required) recurringly flaked on transient
-        # llvm-profdata profraw corruption and a git-race test under llvm-cov's
-        # slow parallel run — both pass on rerun. Retry once (clean stale
-        # profraw between attempts) so the job self-heals instead of needing a
-        # manual `gh run rerun`. The git-race root is separately hardened by
-        # disabling auto-gc in the affected test's repo setup.
+        # #1452: Coverage (non-required) can flake on transient llvm-profdata
+        # profraw corruption under llvm-cov's slow parallel run — that passes on a
+        # clean rerun, so retry once.
+        #
+        # SMART RETRY: a plain `test ... FAILED` is a REAL, deterministic failure.
+        # The old loop retried it unconditionally AND labelled it "likely flake" —
+        # which wasted a second slow coverage run and, worse, MASKED real bugs as
+        # flakes (e.g. #1735's block_on invariant surfaced here and was dismissed
+        # as a Coverage flake). So: only retry when the failure carries an
+        # llvm-cov profraw/profdata-corruption signature; otherwise fail FAST with
+        # an honest label so the real `test ... FAILED` is trusted, not ignored.
         run: |
-          for attempt in 1 2; do
-            if cargo llvm-cov --workspace --tests --features tray --lcov --output-path coverage.lcov; then
+          set -o pipefail
+          attempt=1
+          while :; do
+            if cargo llvm-cov --workspace --tests --features tray --lcov --output-path coverage.lcov 2>&1 | tee cov-attempt.log; then
               exit 0
             fi
-            echo "::warning::coverage attempt $attempt failed (likely #1452 profraw/git-race flake); cleaning + retrying"
-            cargo llvm-cov clean --workspace || true
+            if [ "$attempt" -ge 2 ]; then
+              echo "::error::coverage failed again after retrying the profraw flake"
+              exit 1
+            fi
+            if grep -qiE 'profdata|\.profraw|malformed instrumentation|raw profile|invalid instrumentation profile|failed to (load|merge).*profile|no profile can be merged' cov-attempt.log; then
+              echo "::warning::coverage attempt $attempt hit an llvm-cov profraw/profdata corruption flake; cleaning + retrying once"
+              cargo llvm-cov clean --workspace || true
+              attempt=$((attempt + 1))
+              continue
+            fi
+            echo "::error::coverage failed with a REAL test failure (no profraw-corruption signature) — NOT a flake; failing fast. See the 'test ... FAILED' above."
+            exit 1
           done
-          echo "::error::coverage failed after 2 attempts"
-          exit 1
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -520,17 +520,23 @@ fn test_shutdown_no_crash_log() {
 #[test]
 fn test_event_log_written() {
     let mut daemon = TestDaemon::start("event_log");
-    // Poll for event log to appear
     let log_path = daemon.home.join("event-log.jsonl");
+    // Poll on the CONTENT, not just file existence, with the 30s ceiling used by
+    // the other event-log waits here. The old 3s existence-only check flaked under
+    // load (e.g. the coverage job's slow, CPU-saturated parallel run): daemon
+    // startup could exceed 3s, and the file can exist a tick before `daemon_start`
+    // is flushed (exists-but-empty race). `wait_until` polls, so a higher ceiling
+    // adds no common-case slowdown — it only tolerates a slow start.
     assert!(
-        wait_until(|| log_path.exists(), Duration::from_secs(3)),
-        "event-log.jsonl should exist"
-    );
-
-    let content = std::fs::read_to_string(&log_path).expect("read log");
-    assert!(
-        content.contains("daemon_start"),
-        "should have daemon_start event"
+        wait_until(
+            || {
+                std::fs::read_to_string(&log_path)
+                    .map(|c| c.contains("daemon_start"))
+                    .unwrap_or(false)
+            },
+            Duration::from_secs(30)
+        ),
+        "event-log.jsonl should be written with a daemon_start event"
     );
 
     daemon.stop();


### PR DESCRIPTION
## RCA (the reframe)
Examining 3 recent Coverage "flakes": **most were NOT flakes** — they were **real test failures** the retry loop mislabelled as `"likely #1452 profraw/git-race flake"`:
- **#1735**: Coverage red was my **`block_on_runtime_guard_invariant`** bug (a source-scan test — Coverage runs `--tests` so it caught it). Deterministic; failed both retry attempts; labelled "flake".
- **dev-2's** `test_crash_respawn_health` red was likewise a real bug (since fixed in #1734; passes on `main`).
- Only **one genuine flake**: `tests/integration.rs::test_event_log_written` (passes 3/3 isolated, flakes under the full parallel `--tests` run).

The mislabel did real harm: it wasted a second slow coverage run **and** trained everyone to dismiss Coverage red as "flake" — nearly burying real bugs (only the platform `Check` caught them). **Making Coverage trustworthy matters more than killing flakes.**

## Fix
**(a) Smart retry** (`.github/workflows/ci.yml`) — retry **only** when the failure carries an llvm-cov profraw/profdata-corruption signature (`profdata`, `.profraw`, `malformed instrumentation`, `raw profile`, `invalid instrumentation profile`, `failed to load/merge … profile`, `no profile can be merged`). A clean `test … FAILED` **fails fast** with an honest label. Genuine profraw flakes still self-heal; real failures surface immediately and are trusted.

**(b) Harden the one genuine flake** (`tests/integration.rs::test_event_log_written`) — poll on the `daemon_start` **content** with the **30s** ceiling used by the sibling event-log waits (was a **3s existence-only** check). Fixes both the slow-startup timeout and the file-exists-but-empty race under the coverage job's slow, CPU-saturated parallel run. `wait_until` polls, so the higher ceiling adds zero common-case slowdown.

`test_crash_respawn_health` left as-is (real bug already fixed in #1734). **Not** doing serial (`--test-threads=1`) coverage per the lead — too slow for one flaky test.

## Verification
- **(a)** grep-logic test: real `test … FAILED` → fail-fast (no retry, no mislabel); `malformed instrumentation profile data` → retry. ✓
- **(b)** `test_event_log_written` stable **10/10** under the full parallel integration suite (where it flaked). ✓
- `cargo fmt --check` ✅ · clippy `--all-targets --features tray -D warnings` ✅ · `--tests` integration+invariant targets ✅ · `file_size_invariant` (#1463) ✅

Base: `e1b31ca`. CI change → no restart. Coverage stays non-required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)