### PR TITLE
fix(#1748): drive agend-git shim-test fixtures through real git (no worktree corruption)

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -2831,7 +2831,13 @@ mod tests {
                 .as_nanos()
         ));
         std::fs::create_dir_all(&repo).unwrap();
-        assert!(Command::new("git")
+        // #1748: drive fixture git through the REAL git binary, not the bare
+        // `git` PATH entry which resolves to this agend-git shim — whose #1463
+        // ChdirPass strips the `-C <tempdir>` and redirects the op onto the
+        // caller's bound worktree, corrupting it. `resolve_real_git()` is the
+        // same resolver the shim uses to exec real git (excludes $AGEND_HOME/bin).
+        let git_bin = resolve_real_git();
+        assert!(Command::new(&git_bin)
             .arg("-C")
             .arg(&repo)
             .args(["init", "-b", "main"])
@@ -2839,19 +2845,19 @@ mod tests {
             .unwrap()
             .status
             .success());
-        Command::new("git")
+        Command::new(&git_bin)
             .arg("-C")
             .arg(&repo)
             .args(["config", "user.name", "test"])
             .output()
             .unwrap();
-        Command::new("git")
+        Command::new(&git_bin)
             .arg("-C")
             .arg(&repo)
             .args(["config", "user.email", "test@test.com"])
             .output()
             .unwrap();
-        assert!(Command::new("git")
+        assert!(Command::new(&git_bin)
             .arg("-C")
             .arg(&repo)
             .args(["commit", "--allow-empty", "-m", "init"])
@@ -2859,7 +2865,7 @@ mod tests {
             .unwrap()
             .status
             .success());
-        assert!(!has_unmerged_files("git", repo.to_str().unwrap()));
+        assert!(!has_unmerged_files(&git_bin, repo.to_str().unwrap()));
         let _ = std::fs::remove_dir_all(&repo);
     }
 
@@ -2874,8 +2880,10 @@ mod tests {
                 .as_nanos()
         ));
         std::fs::create_dir_all(&repo).unwrap();
+        // #1748: real git, not the shim — see has_unmerged_files_false_on_clean_repo.
+        let git_bin = resolve_real_git();
         let git = |args: &[&str]| {
-            Command::new("git")
+            Command::new(&git_bin)
                 .arg("-C")
                 .arg(&repo)
                 .args(args)
@@ -2896,7 +2904,7 @@ mod tests {
         git(&["commit", "-am", "main"]);
         let merge = git(&["merge", "side", "--no-edit"]);
         assert!(!merge.status.success(), "merge should fail with conflict");
-        assert!(has_unmerged_files("git", repo.to_str().unwrap()));
+        assert!(has_unmerged_files(&git_bin, repo.to_str().unwrap()));
         git(&["merge", "--abort"]);
         let _ = std::fs::remove_dir_all(&repo);
     }


### PR DESCRIPTION
## #1748 — agend-git shim-test footgun corrupts the caller's worktree

The shim tests `has_unmerged_files_false_on_clean_repo` and
`has_unmerged_files_true_on_conflict` build their scratch repos with bare
`Command::new("git")` + `-C <tempdir>`. On PATH, `git` resolves to **this
agend-git shim** (`$AGEND_HOME/bin/git`), whose #1463 ChdirPass strips the
`-C <tempdir>` global-target override and redirects the op onto the caller's CWD.

Run from a fleet worktree — e.g. the #1737 pre-push hook's `cargo test --tests` —
that CWD is a bound worktree, so the fixture `git init` / `commit` / `checkout`
(base/side/main + `f.txt`) land on the **worktree's branch** instead of the
tempdir: HEAD hijacked → scratch commits, branch switched to a scratch `main`,
local `main` ref corrupted, garbage tree pushed. Hit live while pushing #1740.

### Fix (test-side only; #1463 shim redirect untouched)
Route the fixture git calls — **and** the `has_unmerged_files(git, …)` binary arg,
which itself spawns git — through `resolve_real_git()`, the same resolver the
shim uses to exec real git (`AGEND_REAL_GIT` → `which` excluding `$AGEND_HOME/bin`
→ `/usr/bin/git`). Real git honors `-C <tempdir>`, so the ops stay in the tempdir
regardless of CWD.

`count_commits_above_base` / `rev_parse` already set `AGEND_GIT_BYPASS=1` (real
git via shim passthrough) — they were never the footgun; the 2 `shim_push_*`
failures were collateral from the has_unmerged pollution and pass again once it's
fixed.

### Acceptance gate (before dirty / after clean)
**Before** (witnessed in #1740): running these tests from a bound worktree
hijacked HEAD/branch and corrupted local `main`.
**After** — ran the 4 tests from a bound worktree, then `git status`:
```
test result: ok. 4 passed; 0 failed   (has_unmerged_files_false/true, shim_push_cleans/cleanup_noop)
git status: <empty>   HEAD/branch unchanged
```
Full agend-git suite (50 tests) from the bound worktree also leaves `git status`
clean. clippy `--all-targets --features tray` + fmt clean.

Refs #1748.

---
@codex review — **standard tier**. Inline only. Focus:
1. `resolve_real_git()` genuinely bypasses the shim (excludes `$AGEND_HOME/bin`)
   so `-C <tempdir>` is honored — fixture git can't hit the caller's worktree.
2. The `has_unmerged_files(&git_bin, …)` arg (not `"git"`) is covered — the
   under-test fn spawns git internally and would otherwise recurse into the shim.
3. No behavioral change to the shim / #1463 redirect; scope is test fixtures only.


---

## Addendum — `core.bare` root cause (operator ask)

Operator observed the canonical repo's `core.bare` flipped to `true`. Hypothesis was a redirected fixture `git init --bare`. **Investigated + refuted with a live probe:**

- `init` / `clone` / `config` are **Passthrough** in the shim (agend-git.rs:643) → they honor `-C` / positional paths and run real git on the *target*, never redirecting.
- **Live probe** (shim on PATH = `$AGEND_HOME/bin/git`, run from a bound worktree):
  ```
  git init --bare /tmp/probe        # via the shim
  → /tmp/probe core.bare = true     # passthrough honored the positional path (tempdir)
  → canonical  core.bare = false    # canonical untouched
  → worktree git status: clean
  ```
- The only two `--bare` sites repo-wide (agend-git.rs:2556/2753) are positional-path **and** already set `AGEND_GIT_BYPASS=1`, **and** `init` is passthrough — triple-safe, always tempdir.

**So no agend-git fixture op sets canonical `core.bare`.** The footgun's actual damage is the *mutating* ChdirPass ops (`add`/`commit`/`checkout`) in the has_unmerged tests: `git -C <tempdir> commit` → ChdirPass strips `-C <tempdir>` → runs in the CWD (the bound worktree) → corrupts its **HEAD / branch / local `main`** (the hijack witnessed in #1740) — not `core.bare`.

### Verification (operator gate — before/after)
- **before**: canonical `core.bare` found `true` (live corruption; reset to `false`).
- **after (this fix)**: ran the 4 tests from a bound worktree →
  ```
  test result: ok. 4 passed
  canonical core.bare = false   (stays false)
  worktree git status: clean    (HEAD/branch unchanged)
  ```

The `resolve_real_git()` fix already eliminates the redirect entirely (fixtures use real git → `-C` honored), so HEAD/branch corruption is prevented; `core.bare` is verified to stay false. No `core.bare`-specific code is needed because no agend-git op sets it.
