### PR TITLE
fix(#1744-H2/H3): persist HealthTracker escalation state + split per-class cooldown

### DIFF
--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -41,20 +41,25 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
     // inbox P0, so it escalates straight to the operator (below).
     let is_self_orch = crate::teams::is_self_orchestrator(home, crashed_name);
 
-    let (should_respawn, delay, should_notify, fire_self_orch_p0) = {
+    let (should_respawn, delay, should_notify, fire_self_orch_p0, escalation_snapshot) = {
         let reg = agent::lock_registry(&ctx.registry);
         match reg.get(&instance_id) {
             Some(handle) => {
                 let mut core = handle.core.lock();
                 // #1701: decide the self-orch P0 BEFORE record_crash (which may
-                // itself stamp last_notification on its recent>=2 path) — the
-                // accessor reads+stamps the shared cooldown, and for a
-                // self-orchestrator we use ONLY this gate, never the generic
-                // recent>=2 one. The `&&` short-circuits for non-orchestrators,
-                // so their cooldown is untouched.
+                // itself stamp the crash cooldown on its recent>=2 path) — the
+                // accessor reads+stamps the crash-class cooldown (#1744-H3:
+                // distinct from the hung cooldown), and for a self-orchestrator we
+                // use ONLY this gate, never the generic recent>=2 one. The `&&`
+                // short-circuits for non-orchestrators, so their cooldown is
+                // untouched.
                 let fire_p0 = is_self_orch && core.health.self_orch_crash_should_notify();
                 let (respawn, delay, notify) = core.health.record_crash();
-                (respawn, delay, notify, fire_p0)
+                // #1744-H2: snapshot the (just-mutated) escalation state under the
+                // lock; persisted lock-free below so the crash budget + cooldown
+                // survive a daemon restart.
+                let snap = core.health.escalation_snapshot();
+                (respawn, delay, notify, fire_p0, snap)
             }
             None => {
                 tracing::warn!(agent = %crashed_name, "not in registry, skipping");
@@ -62,6 +67,9 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
             }
         }
     };
+
+    // #1744-H2: persist the crash budget + crash cooldown (lock released above).
+    crate::daemon::escalation_persist::persist(home, crashed_name, &escalation_snapshot);
 
     // #1701: a self-orchestrator crash escalates to the operator on EVERY crash
     // (cooldown-gated) — the team is leaderless until respawn and no peer can

--- a/src/daemon/escalation_persist.rs
+++ b/src/daemon/escalation_persist.rs
@@ -1,0 +1,138 @@
+//! #1744-H2: durable per-agent escalation state.
+//!
+//! [`crate::health::HealthTracker`]'s escalation fields (crash budget, the two
+//! per-class notify cooldowns, and the Hung confirm-window anchor) live in
+//! memory and are lost on a daemon restart. That reset is the root cause of the
+//! #1744-H2 P0-reachability gaps: a restart re-zeroes the crash budget (infinite
+//! respawn that never reaches `Failed`), the confirm-window (delayed/missed
+//! self-orch Hung P0), and the cooldowns (duplicate P0 for an already-paged
+//! agent).
+//!
+//! This module persists a small [`PersistedEscalation`] snapshot per agent to a
+//! single combined, versioned store keyed by agent name, written through the
+//! `store` toolkit (flock-guarded atomic RMW). The daemon writes at the crash /
+//! hung chokepoints and re-applies on boot/agent-register. All timestamps are
+//! wall-clock epoch-ms — never a monotonic `Instant` (meaningless across a
+//! process restart). See [`crate::health::HealthTracker::escalation_snapshot`] /
+//! [`crate::health::HealthTracker::rehydrate_escalation`] for the conversion.
+
+use crate::health::PersistedEscalation;
+use crate::store::{self, SchemaVersioned};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+const STORE_FILE: &str = "health_escalation.json";
+const CURRENT_VERSION: u32 = 1;
+
+/// Combined on-disk store: every agent's escalation snapshot keyed by name.
+/// Name-keyed (not UUID) to match the per-agent maps the daemon already keys by
+/// name; the delete path ([`remove`]) clears the entry so a reused name never
+/// rehydrates a prior occupant's state (the #1680 stale-state lesson).
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct EscalationStore {
+    #[serde(default)]
+    schema_version: u32,
+    #[serde(default)]
+    agents: HashMap<String, PersistedEscalation>,
+}
+
+impl SchemaVersioned for EscalationStore {
+    const CURRENT: u32 = CURRENT_VERSION;
+    fn version_mut(&mut self) -> &mut u32 {
+        &mut self.schema_version
+    }
+}
+
+fn store_file(home: &Path) -> std::path::PathBuf {
+    store::store_path(home, STORE_FILE)
+}
+
+/// Persist (insert/replace) one agent's escalation snapshot. Best-effort: a
+/// write failure logs and is swallowed — escalation persistence must never block
+/// the crash/hung hot path.
+pub(crate) fn persist(home: &Path, name: &str, snapshot: &PersistedEscalation) {
+    let path = store_file(home);
+    if let Err(e) = store::mutate_versioned::<EscalationStore, _, _>(&path, |s| {
+        s.agents.insert(name.to_string(), snapshot.clone());
+        Ok(())
+    }) {
+        tracing::warn!(agent = %name, error = %e, "escalation_persist: write failed");
+    }
+}
+
+/// Load the persisted snapshot for one agent (boot/agent-register rehydrate).
+/// Returns `None` when there is no store yet or no entry for the name.
+pub(crate) fn load_for(home: &Path, name: &str) -> Option<PersistedEscalation> {
+    let path = store_file(home);
+    let store: EscalationStore = store::load_versioned(&path, CURRENT_VERSION);
+    store.agents.get(name).cloned()
+}
+
+/// Drop one agent's persisted entry (called on agent delete) so a later agent
+/// reusing the name does not rehydrate stale escalation state.
+pub(crate) fn remove(home: &Path, name: &str) {
+    let path = store_file(home);
+    if !path.exists() {
+        return;
+    }
+    if let Err(e) = store::mutate_versioned::<EscalationStore, _, _>(&path, |s| {
+        s.agents.remove(name);
+        Ok(())
+    }) {
+        tracing::warn!(agent = %name, error = %e, "escalation_persist: remove failed");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        let home = std::env::temp_dir().join(format!(
+            "agend-escpersist-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        home
+    }
+
+    #[test]
+    fn persist_load_remove_round_trip() {
+        let home = tmp_home("rt");
+        assert!(load_for(&home, "a").is_none(), "no store yet → None");
+
+        let snap = PersistedEscalation {
+            total_crashes: 4,
+            crash_times_epoch_ms: vec![111, 222],
+            last_crash_notification_epoch_ms: Some(333),
+            last_hung_notification_epoch_ms: None,
+            hung_since_epoch_ms: Some(444),
+        };
+        persist(&home, "a", &snap);
+        // A second agent's entry must not clobber the first.
+        persist(&home, "b", &PersistedEscalation::default());
+
+        assert_eq!(load_for(&home, "a"), Some(snap));
+        assert_eq!(load_for(&home, "b"), Some(PersistedEscalation::default()));
+
+        remove(&home, "a");
+        assert!(load_for(&home, "a").is_none(), "removed entry → None");
+        assert!(load_for(&home, "b").is_some(), "remove is per-agent");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn remove_on_missing_store_is_noop() {
+        let home = tmp_home("rm-missing");
+        remove(&home, "ghost"); // must not panic / create the file
+        assert!(load_for(&home, "ghost").is_none());
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod cron_tick;
 pub(crate) mod decision_timeout;
 pub(crate) mod dedup_state;
 pub(crate) mod dispatch_idle;
+pub(crate) mod escalation_persist;
 pub(crate) mod event_bus;
 pub(crate) mod handoff_timeout_watchdog;
 pub(crate) mod heartbeat_pair;
@@ -1150,6 +1151,23 @@ fn spawn_and_register_agent(
         return Err(e);
     }
 
+    // #1744-H2: rehydrate persisted escalation state onto the freshly-spawned
+    // tracker (this is the boot / agent-register path — Resume mode). A daemon
+    // restart otherwise re-zeroes the crash budget, the Hung confirm-window, and
+    // the notify cooldowns; re-applying the last-persisted snapshot keeps those
+    // P0 gates correct across the restart. (The in-daemon crash-respawn path
+    // carries health via its own in-mem `saved_health` clone, so it does not go
+    // through here.)
+    if let Some(snapshot) = escalation_persist::load_for(home, name) {
+        if let Some(id) = crate::fleet::resolve_uuid(home, name) {
+            let reg = agent::lock_registry(registry);
+            if let Some(handle) = reg.get(&id) {
+                handle.core.lock().health.rehydrate_escalation(&snapshot);
+                tracing::info!(agent = %name, "#1744-H2: rehydrated escalation state from store");
+            }
+        }
+    }
+
     let rdir = run_dir(home);
     // #896 Option D: synchronous TUI listener prep BEFORE returning Ok.
     // Pre-#896 this whole step happened inside the fire-and-forget
@@ -1209,8 +1227,9 @@ fn spawn_and_register_agent(
 /// across the spawn boundary so the cap (`STAGE2_MAX_RESTARTS_DEFAULT`)
 /// survives the restart it drove.
 ///
-/// Decision §1 selective restore (4 fields): `crash_times`,
-/// `total_crashes`, `last_notification`, `recovery_restart_count` (+1).
+/// Decision §1 selective restore (5 fields): `crash_times`,
+/// `total_crashes`, `last_crash_notification`, `last_hung_notification`,
+/// `recovery_restart_count` (+1).
 /// All other `HealthTracker` fields reset to fresh defaults — including
 /// `state: Healthy` (Stage 2 success seed) and `recovery_stage_state:
 /// None` (linear escalation rule restarts).
@@ -1249,7 +1268,10 @@ fn handle_stage2_restart(
             (
                 core.health.crash_times.clone(),
                 core.health.total_crashes,
-                core.health.last_notification,
+                // #1744-H3: the former shared `last_notification` is now two
+                // per-class cooldowns — preserve both across the Stage-2 respawn.
+                core.health.last_crash_notification,
+                core.health.last_hung_notification,
                 core.health.recovery_restart_count,
             )
         })
@@ -1366,10 +1388,12 @@ fn handle_stage2_restart(
             let reg = agent::lock_registry(registry);
             if let Some(handle) = instance_id.and_then(|id| reg.get(&id)) {
                 let mut core = handle.core.lock();
-                let (crash_times, total_crashes, last_notification, prev_count) = saved;
+                let (crash_times, total_crashes, last_crash_notif, last_hung_notif, prev_count) =
+                    saved;
                 core.health.crash_times = crash_times;
                 core.health.total_crashes = total_crashes;
-                core.health.last_notification = last_notification;
+                core.health.last_crash_notification = last_crash_notif;
+                core.health.last_hung_notification = last_hung_notif;
                 core.health.recovery_restart_count = prev_count.saturating_add(1);
                 core.health.last_stage2_fired_at = Some(Instant::now());
             }

--- a/src/daemon/per_tick/hang_detection.rs
+++ b/src/daemon/per_tick/hang_detection.rs
@@ -44,9 +44,15 @@ impl PerTickHandler for HangDetectionHandler {
         // the names currently in Hung. NO teams-file read here — that runs
         // lock-free in phase 2 (#1530 / DAEMON-LOCK-ORDERING: no file IO under
         // the registry lock).
-        let hung_now: Vec<String> = {
+        // `hung_now`: every agent currently Hung. `newly_hung`: the subset whose
+        // `check_hang` returned true THIS tick (first detection — `hung_since`
+        // was just anchored). #1744-H2 persists a self-orch's anchor on entry
+        // (not only on escalation) so a restart in the first confirm-window
+        // doesn't reset it.
+        let (hung_now, newly_hung): (Vec<String>, std::collections::HashSet<String>) = {
             let reg = agent::lock_registry_tracked(ctx.registry, "hang_detection");
             let mut hung = Vec::new();
+            let mut newly = std::collections::HashSet::new();
             for handle in reg.values() {
                 let name = handle.name.as_str();
                 let mut core = handle.core.lock();
@@ -60,13 +66,14 @@ impl PerTickHandler for HangDetectionHandler {
                 // `AGEND_PRODUCTIVE_GATE=1`.
                 let silent_productive = core.state.last_productive_output.elapsed();
                 let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
-                if core.health.check_hang(
+                let just_detected = core.health.check_hang(
                     agent_state,
                     silent,
                     silent_productive,
                     pair.last_input_at_ms,
                     pair.heartbeat_at_ms,
-                ) {
+                );
+                if just_detected {
                     tracing::warn!(
                         agent = %name,
                         state = agent_state.display_name(),
@@ -76,9 +83,12 @@ impl PerTickHandler for HangDetectionHandler {
                 }
                 if core.health.state == crate::health::HealthState::Hung {
                     hung.push(name.to_string());
+                    if just_detected {
+                        newly.insert(name.to_string());
+                    }
                 }
             }
-            hung
+            (hung, newly)
         };
 
         // Phase 2/3 (#1701 Hung half): a self-orchestrator stuck Hung past the
@@ -93,20 +103,32 @@ impl PerTickHandler for HangDetectionHandler {
             if !crate::teams::is_self_orchestrator(ctx.home, &name) {
                 continue;
             }
-            let due = {
+            // Re-lock briefly: run the confirm-window + cooldown gate (which
+            // stamps the hung cooldown on fire) and snapshot the escalation state
+            // for persistence — both under one lock so the snapshot reflects the
+            // gate's stamp.
+            let (due, snapshot) = {
                 let reg = agent::lock_registry(ctx.registry);
                 reg.values()
                     .find(|h| h.name.as_str() == name)
                     .map(|h| {
-                        h.core
-                            .lock()
-                            .health
-                            .hung_escalation_due(HUNG_ESCALATE_AFTER)
+                        let mut core = h.core.lock();
+                        let due = core.health.hung_escalation_due(HUNG_ESCALATE_AFTER);
+                        (due, Some(core.health.escalation_snapshot()))
                     })
-                    .unwrap_or(false)
+                    .unwrap_or((false, None))
             };
             if due {
                 notify_self_orch_hung(&name);
+            }
+            // #1744-H2: persist on first Hung detection (anchor `hung_since`) and
+            // whenever the escalation fires (stamp the hung cooldown) — both must
+            // survive a restart. Between those the snapshot is unchanged, so this
+            // does not write every tick a self-orch stays Hung.
+            if let Some(snapshot) = snapshot {
+                if newly_hung.contains(&name) || due {
+                    crate::daemon::escalation_persist::persist(ctx.home, &name, &snapshot);
+                }
             }
         }
     }

--- a/src/daemon/per_tick/hang_detection.rs
+++ b/src/daemon/per_tick/hang_detection.rs
@@ -49,14 +49,26 @@ impl PerTickHandler for HangDetectionHandler {
         // was just anchored). #1744-H2 persists a self-orch's anchor on entry
         // (not only on escalation) so a restart in the first confirm-window
         // doesn't reset it.
-        let (hung_now, newly_hung): (Vec<String>, std::collections::HashSet<String>) = {
+        // `hung_now`: every agent currently Hung. `newly_hung`: entered this tick.
+        // `left_hung`: was Hung before this tick's `check_hang` and is no longer —
+        // a recovery/exit that cleared `hung_since` in memory; #1744-H2 must
+        // persist that CLEAR (else a restart rehydrates the stale anchor and the
+        // next unrelated Hung re-entry's `get_or_insert` keeps it → false
+        // immediate escalation. codex catch).
+        let (hung_now, newly_hung, left_hung): (
+            Vec<String>,
+            std::collections::HashSet<String>,
+            Vec<String>,
+        ) = {
             let reg = agent::lock_registry_tracked(ctx.registry, "hang_detection");
             let mut hung = Vec::new();
             let mut newly = std::collections::HashSet::new();
+            let mut left = Vec::new();
             for handle in reg.values() {
                 let name = handle.name.as_str();
                 let mut core = handle.core.lock();
                 core.health.maybe_decay();
+                let was_hung = core.health.state == crate::health::HealthState::Hung;
                 let agent_state = core.state.current;
                 let silent = core.state.last_output.elapsed();
                 // F9 (#685 sub-task 4): productive-silence reads the new
@@ -81,14 +93,18 @@ impl PerTickHandler for HangDetectionHandler {
                         "hang detected"
                     );
                 }
-                if core.health.state == crate::health::HealthState::Hung {
+                let now_hung = core.health.state == crate::health::HealthState::Hung;
+                if now_hung {
                     hung.push(name.to_string());
                     if just_detected {
                         newly.insert(name.to_string());
                     }
+                } else if was_hung {
+                    // Hung → not-Hung this tick: `check_hang` cleared `hung_since`.
+                    left.push(name.to_string());
                 }
             }
-            (hung, newly)
+            (hung, newly, left)
         };
 
         // Phase 2/3 (#1701 Hung half): a self-orchestrator stuck Hung past the
@@ -129,6 +145,32 @@ impl PerTickHandler for HangDetectionHandler {
                 if newly_hung.contains(&name) || due {
                     crate::daemon::escalation_persist::persist(ctx.home, &name, &snapshot);
                 }
+            }
+        }
+
+        // #1744-H2 (codex HIGH): a self-orchestrator that just LEFT Hung had its
+        // `hung_since` cleared in memory by `check_hang` — persist that cleared
+        // snapshot so a restart does not rehydrate the stale anchor. Only when a
+        // store entry already exists (it escalated / was tracked while Hung):
+        // skip otherwise so a never-persisted agent that merely flickered through
+        // Hung doesn't spawn a store entry. The snapshot's `hung_since` is now
+        // None; its crash budget / cooldowns (which DO matter) are preserved.
+        for name in left_hung {
+            if !crate::teams::is_self_orchestrator(ctx.home, &name) {
+                continue;
+            }
+            if crate::daemon::escalation_persist::load_for(ctx.home, &name).is_none() {
+                continue;
+            }
+            let snapshot = {
+                let reg = agent::lock_registry(ctx.registry);
+                reg.values()
+                    .find(|h| h.name.as_str() == name)
+                    .map(|h| h.core.lock().health.escalation_snapshot())
+            };
+            if let Some(snapshot) = snapshot {
+                crate::daemon::escalation_persist::persist(ctx.home, &name, &snapshot);
+                tracing::debug!(agent = %name, "#1744-H2: persisted cleared hung anchor on Hung exit");
             }
         }
     }

--- a/src/health.rs
+++ b/src/health.rs
@@ -1266,6 +1266,62 @@ mod tests {
         );
     }
 
+    /// #1744-H2 (codex HIGH regression): persisting a Hung anchor then RECOVERING
+    /// must propagate the CLEAR to the snapshot — so a restart rehydrates `None`,
+    /// not the stale anchor. Otherwise the next (unrelated) Hung re-entry's
+    /// `get_or_insert` would keep the stale, already-elapsed anchor and
+    /// `hung_escalation_due` would fire immediately (a false escalation).
+    #[test]
+    fn cleared_hung_anchor_snapshots_as_none_no_false_escalation_1744_h2() {
+        // 1) Enter Hung → anchor set; the snapshot carries it.
+        let mut h = HealthTracker::new();
+        assert!(h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0,
+        ));
+        assert!(h.escalation_snapshot().hung_since_epoch_ms.is_some());
+
+        // 2) Recover (silence drops) → Hung exit clears the anchor → the snapshot
+        //    we would persist now carries None.
+        assert!(!h.check_hang(
+            AgentState::Idle,
+            Duration::from_secs(0),
+            Duration::from_secs(0),
+            1_000_000,
+            0,
+        ));
+        let cleared = h.escalation_snapshot();
+        assert!(
+            cleared.hung_since_epoch_ms.is_none(),
+            "#1744-H2: the cleared snapshot must carry hung_since=None"
+        );
+
+        // 3) Restart: rehydrate the cleared snapshot → no anchor.
+        let mut after = HealthTracker::new();
+        after.rehydrate_escalation(&cleared);
+        assert!(
+            after.hung_since.is_none(),
+            "rehydrated cleared anchor is None"
+        );
+
+        // 4) A later, unrelated Hung episode anchors FRESH (≈now) → not yet due,
+        //    so no false immediate escalation (the bug had it fire at once).
+        assert!(after.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0,
+        ));
+        assert!(
+            !after.hung_escalation_due(Duration::from_secs(60)),
+            "#1744-H2: a fresh post-recovery Hung must NOT escalate immediately (stale anchor would have)"
+        );
+    }
+
     #[test]
     fn test_first_crash_silent() {
         let mut h = HealthTracker::new();

--- a/src/health.rs
+++ b/src/health.rs
@@ -328,12 +328,24 @@ pub struct HealthTracker {
     pub crash_times: VecDeque<Instant>,
     pub total_crashes: u32,
     max_retries: u32,
-    pub last_notification: Option<Instant>,
+    /// #1744-H3: per-class notify cooldown — crash escalations stamp/read THIS,
+    /// hung escalations use `last_hung_notification`. Split from the former shared
+    /// `last_notification` so a crash page and a hung page no longer suppress each
+    /// other inside `NOTIFY_COOLDOWN` (they are distinct failure modes).
+    pub last_crash_notification: Option<Instant>,
+    /// #1744-H3: per-class notify cooldown for the self-orch Hung escalation.
+    /// See `last_crash_notification`.
+    pub last_hung_notification: Option<Instant>,
     /// #1701: when the agent most recently transitioned INTO `HealthState::Hung`
     /// (set in `check_hang`'s two Hung-entry branches). Drives the self-orch Hung
-    /// escalation confirm-window. Every Hung entry refreshes it and the
-    /// escalation check gates on `state == Hung`, so a stale value from a prior
-    /// episode is never read — no explicit clear-on-exit needed.
+    /// escalation confirm-window.
+    ///
+    /// #1744-H2: set via `get_or_insert` (not unconditional `= now`) so a value
+    /// rehydrated across a daemon restart SURVIVES the first post-restart Hung
+    /// re-entry — otherwise the confirm-window would reset to 0 and the P0 be
+    /// delayed/missed for a still-hung resumed session. Paired with an explicit
+    /// clear on Hung EXIT (so a recovered episode's anchor never lingers / is
+    /// never persisted stale).
     hung_since: Option<Instant>,
     error_events: VecDeque<(Instant, AgentState)>,
     pub last_output: Instant,
@@ -366,8 +378,8 @@ pub struct HealthTracker {
     /// Preserved selectively across the Stage 2 respawn boundary in
     /// `daemon/mod.rs` Stage 2 variant arm — fresh `HealthTracker` on
     /// spawn re-applies this counter (plus crash_times + total_crashes,
-    /// plus last_notification) so the cap survives the restart that
-    /// the counter itself drove.
+    /// plus the per-class notify cooldowns) so the cap survives the restart
+    /// that the counter itself drove.
     pub recovery_restart_count: u32,
     /// `#685` sub-task 7b: timestamp of last Stage 2 auto-restart fire.
     /// Used to drive `recovery_restart_count` decay alongside
@@ -387,6 +399,61 @@ pub struct HealthTracker {
     pub(crate) last_stage3_fired_at: Option<Instant>,
 }
 
+/// #1744-H3: shared rate-limit predicate for a per-class notify cooldown stamp.
+/// `None` (never notified) → due; otherwise due once `NOTIFY_COOLDOWN` elapsed.
+fn cooldown_elapsed(last: Option<Instant>) -> bool {
+    match last {
+        Some(t) => t.elapsed() >= NOTIFY_COOLDOWN,
+        None => true,
+    }
+}
+
+/// #1744-H2: cap on how far back a rehydrated wall-clock timestamp may be
+/// projected onto the monotonic clock. Well past every health window
+/// (`CRASH_WINDOW` 600s, `NOTIFY_COOLDOWN` 300s), so a capped value still reads
+/// as "long ago" (cooldown elapsed / crash pruned / hang sustained) — the cap
+/// only guards `Instant::now() - gap` against underflow on an absurd/corrupt
+/// stored value.
+const REHYDRATE_MAX_LOOKBACK_MS: u64 = 7 * 24 * 60 * 60 * 1000;
+
+/// #1744-H2: persist an `Instant` as a wall-clock epoch-ms (monotonic `Instant`
+/// is meaningless across a process restart). `now_epoch - instant.elapsed()`.
+fn instant_to_epoch_ms(t: Instant) -> u64 {
+    crate::daemon::heartbeat_pair::now_ms().saturating_sub(t.elapsed().as_millis() as u64)
+}
+
+/// #1744-H2: project a persisted wall-clock epoch-ms back onto the monotonic
+/// clock. A future timestamp (clock skew) clamps to now; an absurdly old one
+/// clamps to [`REHYDRATE_MAX_LOOKBACK_MS`] (still "long ago" for every window).
+fn epoch_ms_to_instant(ms: u64) -> Instant {
+    let gap_ms = crate::daemon::heartbeat_pair::now_ms()
+        .saturating_sub(ms)
+        .min(REHYDRATE_MAX_LOOKBACK_MS);
+    Instant::now()
+        .checked_sub(Duration::from_millis(gap_ms))
+        .unwrap_or_else(Instant::now)
+}
+
+/// #1744-H2: the subset of [`HealthTracker`] escalation state that must survive a
+/// daemon restart, stored as wall-clock epoch-ms (NOT `Instant`). Persisted via
+/// `daemon::escalation_persist` and re-applied on boot/agent-register so a
+/// restart no longer (a) resets the crash budget → infinite respawn that never
+/// reaches `Failed`, (b) resets the Hung confirm-window → delayed/missed self-orch
+/// P0, or (c) clears the notify cooldowns → duplicate P0 for an already-paged agent.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedEscalation {
+    #[serde(default)]
+    pub total_crashes: u32,
+    #[serde(default)]
+    pub crash_times_epoch_ms: Vec<u64>,
+    #[serde(default)]
+    pub last_crash_notification_epoch_ms: Option<u64>,
+    #[serde(default)]
+    pub last_hung_notification_epoch_ms: Option<u64>,
+    #[serde(default)]
+    pub hung_since_epoch_ms: Option<u64>,
+}
+
 impl HealthTracker {
     pub fn new() -> Self {
         Self {
@@ -394,7 +461,8 @@ impl HealthTracker {
             crash_times: VecDeque::new(),
             total_crashes: 0,
             max_retries: DEFAULT_MAX_RETRIES,
-            last_notification: None,
+            last_crash_notification: None,
+            last_hung_notification: None,
             hung_since: None,
             error_events: VecDeque::new(),
             last_output: Instant::now(),
@@ -466,7 +534,7 @@ impl HealthTracker {
             return (false, Duration::ZERO, true); // Don't respawn, do notify
         }
 
-        let should_notify = recent >= 2 && self.should_notify();
+        let should_notify = recent >= 2 && cooldown_elapsed(self.last_crash_notification);
 
         if recent >= 3 {
             self.state = HealthState::Unstable;
@@ -475,7 +543,7 @@ impl HealthTracker {
         }
 
         if should_notify {
-            self.last_notification = Some(now);
+            self.last_crash_notification = Some(now);
         }
 
         (true, delay, should_notify)
@@ -499,25 +567,17 @@ impl HealthTracker {
         delay.min(BACKOFF_MAX)
     }
 
-    /// Check if we should send a notification (rate limiting).
-    fn should_notify(&self) -> bool {
-        match self.last_notification {
-            Some(last) => last.elapsed() >= NOTIFY_COOLDOWN,
-            None => true,
-        }
-    }
-
     /// #1701: self-orchestrator crash P0 gate. Unlike [`record_crash`]'s
-    /// `should_notify` (which only fires on the SECOND crash in the window),
+    /// recent>=2 gate (which only fires on the SECOND crash in the window),
     /// this fires on EVERY orchestrator crash that clears `NOTIFY_COOLDOWN` —
     /// one crash already lost the orchestrator's in-memory context and no peer
-    /// can relay an inbox P0, so the operator must be told. Reuses
-    /// `last_notification` (the shared per-agent notify cooldown) to avoid
-    /// crash-loop spam, and stamps it on fire. Caller must already have
-    /// established the agent is its own team orchestrator.
+    /// can relay an inbox P0, so the operator must be told. Uses the crash-class
+    /// cooldown (#1744-H3: distinct from the hung cooldown) to avoid crash-loop
+    /// spam, and stamps it on fire. Caller must already have established the agent
+    /// is its own team orchestrator.
     pub fn self_orch_crash_should_notify(&mut self) -> bool {
-        if self.should_notify() {
-            self.last_notification = Some(Instant::now());
+        if cooldown_elapsed(self.last_crash_notification) {
+            self.last_crash_notification = Some(Instant::now());
             true
         } else {
             false
@@ -530,8 +590,9 @@ impl HealthTracker {
     /// `check_hang` already excludes the 04:00 idle false-alarm; this window
     /// additionally rides out the documented transient residual FPs F39/F10/
     /// keystroke-draining so a real page is not fired on a 1-tick blip) AND the
-    /// per-agent notify cooldown (reused from the crash path) has elapsed. Stamps
-    /// the cooldown on fire so a persisting Hung pages at most once per
+    /// hung-class notify cooldown (#1744-H3: distinct from the crash cooldown, so
+    /// a recent crash page no longer suppresses this) has elapsed. Stamps the
+    /// cooldown on fire so a persisting Hung pages at most once per
     /// `NOTIFY_COOLDOWN`. Caller must already have established the agent is its
     /// own team orchestrator. Independent of `hang_auto_recovery_enabled` — a
     /// leaderless team with no peer to relay must page even in recovery shadow.
@@ -542,12 +603,52 @@ impl HealthTracker {
         let sustained = self
             .hung_since
             .is_some_and(|t| t.elapsed() >= confirm_window);
-        if sustained && self.should_notify() {
-            self.last_notification = Some(Instant::now());
+        if sustained && cooldown_elapsed(self.last_hung_notification) {
+            self.last_hung_notification = Some(Instant::now());
             true
         } else {
             false
         }
+    }
+
+    /// #1744-H2: snapshot the restart-critical escalation state as wall-clock
+    /// epoch-ms for persistence. Pure read; the daemon calls this at the crash /
+    /// hung chokepoints and hands the result to `escalation_persist`.
+    pub fn escalation_snapshot(&self) -> PersistedEscalation {
+        PersistedEscalation {
+            total_crashes: self.total_crashes,
+            crash_times_epoch_ms: self
+                .crash_times
+                .iter()
+                .map(|t| instant_to_epoch_ms(*t))
+                .collect(),
+            last_crash_notification_epoch_ms: self.last_crash_notification.map(instant_to_epoch_ms),
+            last_hung_notification_epoch_ms: self.last_hung_notification.map(instant_to_epoch_ms),
+            hung_since_epoch_ms: self.hung_since.map(instant_to_epoch_ms),
+        }
+    }
+
+    /// #1744-H2: re-apply persisted escalation state onto a freshly-spawned
+    /// tracker (boot / agent-register). Crash times older than `CRASH_WINDOW` are
+    /// dropped on the way in (they would be pruned on the next `record_crash`
+    /// anyway), so the rehydrated `crash_times` reflects the live window. The
+    /// cumulative `total_crashes` (max-retries budget) is restored verbatim, and
+    /// the cooldowns / `hung_since` are projected back onto the monotonic clock —
+    /// a stale value reads as "elapsed" via [`cooldown_elapsed`] / self-heals via
+    /// the Hung-exit clear, so no `state` is rehydrated (avoids a premature Hung
+    /// that would wrongly trip the recovery dispatcher on boot).
+    pub fn rehydrate_escalation(&mut self, p: &PersistedEscalation) {
+        self.total_crashes = p.total_crashes;
+        let now = crate::daemon::heartbeat_pair::now_ms();
+        self.crash_times = p
+            .crash_times_epoch_ms
+            .iter()
+            .filter(|ms| now.saturating_sub(**ms) <= CRASH_WINDOW.as_millis() as u64)
+            .map(|ms| epoch_ms_to_instant(*ms))
+            .collect();
+        self.last_crash_notification = p.last_crash_notification_epoch_ms.map(epoch_ms_to_instant);
+        self.last_hung_notification = p.last_hung_notification_epoch_ms.map(epoch_ms_to_instant);
+        self.hung_since = p.hung_since_epoch_ms.map(epoch_ms_to_instant);
     }
 
     /// Check whether agent is stalled on an interactive startup prompt.
@@ -668,6 +769,13 @@ impl HealthTracker {
             // See docs/HUNG-STATE-TRANSITIONS.md §Exit.X1
             if matches!(self.state, HealthState::Hung | HealthState::IdleLong) {
                 self.state = HealthState::Healthy;
+                // #1744-H2: explicit clear on Hung EXIT. Pre-#1744 this was unneeded
+                // (every entry overwrote `hung_since`), but now that entry uses
+                // `get_or_insert` so a rehydrated anchor survives a restart, a
+                // recovered episode MUST drop its anchor here — else a stale value
+                // would be persisted and a later unrelated Hung would inherit a
+                // bogus (already-elapsed) confirm-window.
+                self.hung_since = None;
             }
             return false;
         }
@@ -709,7 +817,10 @@ impl HealthTracker {
             // See docs/HUNG-STATE-TRANSITIONS.md §Entry.E1
             if self.state != HealthState::Hung {
                 self.state = HealthState::Hung;
-                self.hung_since = Some(Instant::now()); // #1701: confirm-window anchor
+                // #1744-H2: `get_or_insert` (not `= now`) so a rehydrated cross-restart
+                // anchor survives this first post-restart re-entry → the confirm-window
+                // continues rather than resetting to 0.
+                self.hung_since.get_or_insert_with(Instant::now);
                 return true; // First hang detection — caller escalates
             }
             return false;
@@ -748,7 +859,8 @@ impl HealthTracker {
             // See docs/HUNG-STATE-TRANSITIONS.md §Entry.E2
             if self.state != HealthState::Hung {
                 self.state = HealthState::Hung;
-                self.hung_since = Some(Instant::now()); // #1701: confirm-window anchor
+                // #1744-H2: see §Entry.E1 — `get_or_insert` preserves a rehydrated anchor.
+                self.hung_since.get_or_insert_with(Instant::now);
                 return true;
             }
             return false;
@@ -993,6 +1105,167 @@ mod tests {
         );
     }
 
+    // ── #1744-H3: per-class cooldown split ──
+
+    /// #1744-H3: a crash page and a hung page no longer share one cooldown, so a
+    /// recent crash escalation must NOT suppress a due hung escalation (and vice
+    /// versa). Pre-#1744 both stamped/read `last_notification`, so within 300s the
+    /// first fired suppressed the other.
+    #[test]
+    fn cooldown_split_independent_crash_hung_1744_h3() {
+        // crash page fires + stamps the crash cooldown.
+        let mut h = HealthTracker::new();
+        assert!(h.self_orch_crash_should_notify(), "first crash escalates");
+        assert!(
+            !h.self_orch_crash_should_notify(),
+            "same-class re-fire within cooldown is suppressed"
+        );
+        // A hung escalation that is due must STILL fire — its cooldown is separate.
+        h.state = HealthState::Hung;
+        h.hung_since = Some(Instant::now() - Duration::from_secs(61));
+        assert!(
+            h.hung_escalation_due(Duration::from_secs(60)),
+            "#1744-H3: a recent CRASH page must not suppress a due HUNG page"
+        );
+
+        // Symmetric: a hung page must not suppress a crash page.
+        let mut h2 = HealthTracker::new();
+        h2.state = HealthState::Hung;
+        h2.hung_since = Some(Instant::now() - Duration::from_secs(61));
+        assert!(
+            h2.hung_escalation_due(Duration::from_secs(60)),
+            "hung fires"
+        );
+        assert!(
+            h2.self_orch_crash_should_notify(),
+            "#1744-H3: a recent HUNG page must not suppress a crash page"
+        );
+    }
+
+    // ── #1744-H2: persist / rehydrate escalation state across restart ──
+
+    /// #1744-H2 (pure): an `Instant` projected to wall-clock epoch-ms and back
+    /// round-trips to within a small slop, so a cooldown/anchor keeps its real
+    /// age across a (simulated) restart.
+    #[test]
+    fn instant_epoch_ms_round_trip_1744_h2() {
+        let original = Instant::now() - Duration::from_secs(120);
+        let restored = super::epoch_ms_to_instant(super::instant_to_epoch_ms(original));
+        let drift = restored
+            .elapsed()
+            .as_millis()
+            .abs_diff(original.elapsed().as_millis());
+        assert!(drift < 2_000, "round-trip drift {drift}ms too large");
+    }
+
+    /// #1744-H2: snapshot→rehydrate preserves the escalation semantics across a
+    /// simulated daemon restart — a recently-stamped cooldown STILL suppresses, a
+    /// crash older than `CRASH_WINDOW` is pruned, `total_crashes` is restored, and
+    /// the Hung confirm-window anchor keeps its real age (does NOT reset to 0).
+    #[test]
+    fn escalation_snapshot_rehydrate_round_trip_1744_h2() {
+        let mut before = HealthTracker::new();
+        before.total_crashes = 2;
+        // One in-window crash (10s ago) + one stale crash (700s ago > 600s window).
+        before
+            .crash_times
+            .push_back(Instant::now() - Duration::from_secs(700));
+        before
+            .crash_times
+            .push_back(Instant::now() - Duration::from_secs(10));
+        before.last_crash_notification = Some(Instant::now() - Duration::from_secs(100)); // within 300s
+        before.last_hung_notification = None;
+        before.hung_since = Some(Instant::now() - Duration::from_secs(45));
+
+        let snap = before.escalation_snapshot();
+
+        // Simulate restart: a brand-new tracker, then rehydrate.
+        let mut after = HealthTracker::new();
+        after.rehydrate_escalation(&snap);
+
+        assert_eq!(after.total_crashes, 2, "crash budget restored");
+        assert_eq!(
+            after.crash_times.len(),
+            1,
+            "#1744-H2: a crash older than CRASH_WINDOW is pruned on rehydrate"
+        );
+        assert!(
+            !cooldown_elapsed(after.last_crash_notification),
+            "#1744-H2: a cooldown stamped 100s ago must STILL suppress after restart (no duplicate P0)"
+        );
+        let anchor = after.hung_since.expect("hung_since restored");
+        assert!(
+            anchor.elapsed() >= Duration::from_secs(40),
+            "#1744-H2: the confirm-window anchor keeps its real age (not reset to 0)"
+        );
+    }
+
+    /// #1744-H2: the crash budget survives a restart, so an agent that has already
+    /// burned most of `max_retries` reaches `Failed` on the next crash instead of
+    /// resetting to 0 and respawning forever (the restart-reset gap).
+    #[test]
+    fn rehydrate_preserves_crash_budget_to_failed_1744_h2() {
+        let mut before = HealthTracker::new();
+        before.total_crashes = DEFAULT_MAX_RETRIES - 1;
+        let snap = before.escalation_snapshot();
+
+        let mut after = HealthTracker::new();
+        after.rehydrate_escalation(&snap);
+        assert_eq!(after.total_crashes, DEFAULT_MAX_RETRIES - 1);
+
+        // The next crash crosses the budget → Failed, no respawn.
+        let (respawn, _delay, notify) = after.record_crash();
+        assert!(
+            !respawn,
+            "#1744-H2: budget survived restart → terminal Failed, not infinite respawn"
+        );
+        assert!(notify, "terminal Failed returns should_notify=true");
+        assert_eq!(after.state, HealthState::Failed);
+    }
+
+    /// #1744-H2 (C): a `hung_since` rehydrated across a restart SURVIVES the first
+    /// post-restart Hung re-entry (`get_or_insert`, not `= now`) so the
+    /// confirm-window continues; and a genuine Hung EXIT clears it so a recovered
+    /// episode's anchor never lingers / is persisted stale.
+    #[test]
+    fn hung_since_survives_reentry_and_clears_on_exit_1744_h2() {
+        let mut h = HealthTracker::new();
+        // Rehydrated anchor from before the restart (agent spawns Healthy).
+        h.hung_since = Some(Instant::now() - Duration::from_secs(50));
+        assert_eq!(h.state, HealthState::Healthy);
+
+        // First post-restart Hung detection (E1: silent past threshold + input
+        // pending past heartbeat). Must KEEP the rehydrated anchor.
+        let entered = h.check_hang(
+            AgentState::Thinking,
+            Duration::from_secs(700),
+            Duration::from_secs(0),
+            1_000_000,
+            0,
+        );
+        assert!(entered, "agent classified Hung");
+        assert_eq!(h.state, HealthState::Hung);
+        assert!(
+            h.hung_since.expect("anchor kept").elapsed() >= Duration::from_secs(45),
+            "#1744-H2: get_or_insert preserves the rehydrated anchor (confirm-window continues, not reset to 0)"
+        );
+
+        // Silence drops (1 byte of output) → Hung EXIT → anchor cleared.
+        let still = h.check_hang(
+            AgentState::Idle,
+            Duration::from_secs(0),
+            Duration::from_secs(0),
+            1_000_000,
+            0,
+        );
+        assert!(!still);
+        assert_eq!(h.state, HealthState::Healthy);
+        assert!(
+            h.hung_since.is_none(),
+            "#1744-H2: Hung exit must clear the anchor (no stale persist)"
+        );
+    }
+
     #[test]
     fn test_first_crash_silent() {
         let mut h = HealthTracker::new();
@@ -1165,7 +1438,7 @@ mod tests {
 
         // 3rd crash on cloned tracker should see recent=3
         let (_, _, notify) = h2.record_crash();
-        // notify is false: 2nd crash already set last_notification and cooldown (5 min) hasn't elapsed
+        // notify is false: 2nd crash already set last_crash_notification and cooldown (5 min) hasn't elapsed
         assert!(!notify);
         assert_eq!(h2.state, HealthState::Unstable);
     }

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -123,6 +123,11 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // accumulate in the tracking list and inflate alert text.
     crate::daemon::idle_watchdog::remove_agent_activity(home, name);
 
+    // #1744-H2: drop the persisted escalation state so a later agent reusing
+    // this name does not rehydrate the deleted instance's crash budget /
+    // cooldowns / hung anchor (the #1680 stale-state lesson).
+    crate::daemon::escalation_persist::remove(home, name);
+
     // #1488: cascade-clean the services bound to the deleted instance.
     // Without these, an orphaned schedule keeps firing into the cron self-IPC
     // fallback (this morning's deadlock trigger), dispatch_tracking entries


### PR DESCRIPTION
<!-- LOC-EST: 360-420 -->

## What & why

②-flagship for #1744: makes the self-orchestrator escalation P0s **survive a daemon restart**.

**H2** — `HealthTracker`'s escalation state is in-memory and lost on every daemon restart. That reset is the root cause of three audited P0-reachability gaps:
- (a) crash budget (`total_crashes`/`crash_times`) re-zeroes → infinite respawn that never reaches `Failed`;
- (b) Hung confirm-window anchor (`hung_since`) re-zeroes → delayed/missed self-orch Hung P0 for a resumed-still-hung session;
- (c) notify cooldown re-zeroes → duplicate P0 for an already-paged agent.

**H3** — crash and hung escalations shared one `last_notification`, so within `NOTIFY_COOLDOWN` (300s) the first to fire suppressed the other (they are distinct failure modes).

## Changes

- **Persist** (`daemon::escalation_persist`, new): a per-agent `PersistedEscalation` snapshot (`total_crashes`, `crash_times`, both cooldowns, `hung_since`) in a single **versioned, flock-guarded** store via the `store` toolkit, keyed by name. **All timestamps are wall-clock epoch-ms, never a monotonic `Instant`.**
  - Written at the crash chokepoint (`crash_respawn`) and the hung chokepoint (`hang_detection`, on first Hung detection + on escalation fire — not every tick).
  - Re-applied on **boot/agent-register** (`spawn_and_register_agent`, the Resume path). Crash times older than `CRASH_WINDOW` are pruned on rehydrate; a stale cooldown reads as "elapsed" (never wrongly suppresses); **no `state` is rehydrated** (avoids a premature Hung that would trip the recovery dispatcher on boot). In-daemon crash-respawn keeps its own in-mem `saved_health` clone and does not go through here.
  - **Delete** clears the entry (`full_delete_instance`) so a reused name never inherits stale state (#1680 lesson).
- **H3 cooldown split**: `last_notification` → `last_crash_notification` / `last_hung_notification`, each with its own `cooldown_elapsed` gate; the Stage-2 respawn preserve-set carries both.
- **C (required for H2)**: `check_hang`'s two Hung entries `get_or_insert` `hung_since` (not `= now`) so a rehydrated cross-restart anchor survives the first post-restart re-entry (confirm-window continues), and the Hung **exit** explicitly clears `hung_since` so a recovered episode's anchor never lingers / is persisted stale. This is escalation-state correctness, **not** the H1 silence-clock (out of scope, separate issue).

## Tests

`cooldown_split_independent_crash_hung_1744_h3`, `instant_epoch_ms_round_trip_1744_h2`, `escalation_snapshot_rehydrate_round_trip_1744_h2` (recent cooldown still suppresses / stale crash pruned / budget restored / anchor keeps its age), `rehydrate_preserves_crash_budget_to_failed_1744_h2`, `hung_since_survives_reentry_and_clears_on_exit_1744_h2`, store `persist_load_remove_round_trip`. Existing health / crash-respawn / hang-detection tests stay green.

## Local verification

`cargo fmt --check`, `cargo clippy --all-targets --features tray,discord -- -D warnings`, and the health + escalation_persist + hang_detection + crash_respawn + daemon-mod test sets all green (83 passed). ⚠️ See PR comment re: the full `cargo test --tests` preflight step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)