### PR TITLE
fix(#1739): boot-seed supervisor-loop producers (no restart boot-burst)

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -42,12 +42,18 @@ pub(crate) struct AntiStallTracker {
     /// Tick counter — used to gate scans to once per
     /// [`TICKS_PER_SCAN`] supervisor ticks.
     tick_count: u64,
-    /// Per-task last-emitted-at timestamp (RFC3339 string for
-    /// portability across daemon restart — though state is
-    /// in-memory only and resets on restart, which acceptable: a
-    /// fresh restart re-scans and re-emits, surfacing live stalls
-    /// to operators who may have missed prior warnings).
+    /// Per-task last-emitted-at timestamp. In-memory only. #1739: the first
+    /// scan after a fresh daemon start *seeds* this map with every
+    /// currently-stalled task (stamped now) WITHOUT emitting — restart-existing
+    /// stalls are treated as already-known so the operator isn't re-flooded
+    /// with warnings they already saw before the restart. Only stalls that
+    /// newly appear after boot (or persist past the per-task dedup window)
+    /// emit. (Boot-grace was insufficient here: the first scan lands ~5 min in,
+    /// past any short grace, and the backlog persists across restart.)
     last_emitted_at: HashMap<String, chrono::DateTime<chrono::Utc>>,
+    /// #1739 boot-seed latch: false until the first scan has seeded
+    /// `last_emitted_at`. The seeding scan records without emitting.
+    seeded: bool,
 }
 
 impl AntiStallTracker {
@@ -60,16 +66,23 @@ impl AntiStallTracker {
             return false;
         }
         self.tick_count = 0;
-        scan_and_emit(home, &mut self.last_emitted_at);
+        let seeding = !self.seeded;
+        self.seeded = true;
+        scan_and_emit(home, &mut self.last_emitted_at, seeding);
         true
     }
 }
 
 /// Pure scan logic — exposed for tests so they can invoke without
 /// waiting through 30 supervisor ticks.
+/// `seeding` (#1739): when true (the first scan after a fresh daemon start),
+/// record currently-stalled tasks into `last_emitted` without emitting — they
+/// are treated as already-known so a restart doesn't re-flood warnings. The
+/// dedup `insert` still runs so subsequent scans suppress them.
 pub(crate) fn scan_and_emit(
     home: &Path,
     last_emitted: &mut HashMap<String, chrono::DateTime<chrono::Utc>>,
+    seeding: bool,
 ) {
     let tasks = crate::tasks::list_all(home);
     let now = chrono::Utc::now();
@@ -90,7 +103,9 @@ pub(crate) fn scan_and_emit(
                     continue;
                 }
             }
-            emit_stall(home, task, &reason);
+            if !seeding {
+                emit_stall(home, task, &reason);
+            }
             last_emitted.insert(task.id.clone(), now);
         }
     }
@@ -738,5 +753,87 @@ mod tests {
         );
         std::fs::remove_dir_all(&home_legacy).ok();
         std::fs::remove_dir_all(&home_bus).ok();
+    }
+
+    #[test]
+    fn boot_seed_suppresses_existing_stall_then_no_reburst() {
+        // #1739: the first scan after a fresh daemon start seeds an
+        // already-stalled task into the dedup WITHOUT emitting (restart should
+        // not re-flood warnings the operator already saw), and a subsequent
+        // scan does not re-burst it.
+        let _g = env_lock();
+        std::env::remove_var("AGEND_TASK_STALL_RECIPIENTS");
+        let home = tmp_home("ls-bootseed");
+        let inst = crate::task_events::InstanceName::from("test");
+        let tid = || crate::task_events::TaskId::from("t-bs");
+        crate::task_events::append(
+            &home,
+            &inst,
+            crate::task_events::TaskEvent::Created {
+                task_id: tid(),
+                title: "bootseed".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: Some(60),
+                tags: vec![],
+                parent_id: None,
+            },
+        )
+        .unwrap();
+        crate::task_events::append(
+            &home,
+            &inst,
+            crate::task_events::TaskEvent::Claimed {
+                task_id: tid(),
+                by: inst.clone(),
+            },
+        )
+        .unwrap();
+        crate::task_events::append(
+            &home,
+            &inst,
+            crate::task_events::TaskEvent::InProgress {
+                task_id: tid(),
+                by: inst.clone(),
+            },
+        )
+        .unwrap();
+        // Back-date the progress sidecar so the task reads as stalled
+        // (elapsed ≫ eta_secs*1.5). check_stalled reads this before started_at.
+        let prog_dir = home.join("task-progress");
+        std::fs::create_dir_all(&prog_dir).unwrap();
+        let old = (chrono::Utc::now() - chrono::Duration::seconds(9999)).to_rfc3339();
+        std::fs::write(
+            prog_dir.join("t-bs.json"),
+            format!(r#"{{"schema_version":1,"last_progress_at":"{old}","source":"broadcast"}}"#),
+        )
+        .unwrap();
+
+        let mut last_emitted = HashMap::new();
+        // seeding scan: record the stalled task, do NOT emit.
+        scan_and_emit(&home, &mut last_emitted, true);
+        assert!(
+            last_emitted.contains_key("t-bs"),
+            "boot-seed must record the stalled task in the dedup"
+        );
+        assert!(
+            crate::inbox::drain(&home, "general").is_empty(),
+            "boot-seed must NOT emit for a restart-existing stall (negative-probe: \
+             removing the `if !seeding` gate makes this fire)"
+        );
+        assert!(crate::inbox::drain(&home, "lead").is_empty());
+        // next normal scan: the seeded stall stays suppressed within the window.
+        scan_and_emit(&home, &mut last_emitted, false);
+        assert!(
+            crate::inbox::drain(&home, "general").is_empty(),
+            "seeded stall must remain suppressed on the next scan"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -56,6 +56,15 @@ pub(crate) struct ConflictNotifyTracker {
     last_conflict_at: HashMap<String, chrono::DateTime<chrono::Utc>>,
     /// agent → last telegram-escalation timestamp (dedup guard).
     last_escalated_at: HashMap<String, chrono::DateTime<chrono::Utc>>,
+    /// #1739 boot-seed latch. The first scan after a fresh daemon start records
+    /// agents already in `GitConflict` into `last_conflict_at` (stamped now)
+    /// WITHOUT firing the first-observation notify, so a restart doesn't re-ping
+    /// conflicts the operator already saw. NOTE (option a): seeding stamps
+    /// `last_conflict_at = now`, so the 30-min staleness escalation clock starts
+    /// at boot — a conflict surviving restart + 30 min still escalates. The
+    /// escalation dedup itself (`last_escalated_at`) is out of scope here (#1739
+    /// ②, persisted separately).
+    seeded: bool,
 }
 
 impl ConflictNotifyTracker {
@@ -84,6 +93,8 @@ impl ConflictNotifyTracker {
             return false;
         }
         self.tick_count = 0;
+        let seeding = !self.seeded;
+        self.seeded = true;
 
         // Phase 1: collect per-agent (name, state, worktree, branch)
         // tuples under a single registry lock. The worktree-state
@@ -103,8 +114,13 @@ impl ConflictNotifyTracker {
                 crate::state::AgentState::GitConflict => {
                     let first_observation = !self.last_conflict_at.contains_key(&name);
                     if first_observation {
-                        self.last_conflict_at.insert(name.clone(), now);
-                        emit_conflict_notify(home, &name);
+                        record_first_observation(
+                            &mut self.last_conflict_at,
+                            home,
+                            &name,
+                            now,
+                            seeding,
+                        );
                     } else if let Some(&last_at) = self.last_conflict_at.get(&name) {
                         let stale = now.signed_duration_since(last_at)
                             > chrono::Duration::seconds(STALE_THRESHOLD_SECS);
@@ -144,6 +160,23 @@ impl ConflictNotifyTracker {
 /// agent via `crate::inbox::notify_agent`. Discovers worktree state
 /// (conflicted files + op type + branch) from disk + binding.json.
 /// Failures are logged + skipped (boot continues).
+/// #1739: handle a first-observation conflict. The dedup record happens
+/// unconditionally; the first-observation notify is suppressed during the boot
+/// seeding pass (`seeding == true`) so a daemon restart doesn't re-ping
+/// conflicts the operator already saw before the restart.
+fn record_first_observation(
+    last_conflict_at: &mut HashMap<String, chrono::DateTime<chrono::Utc>>,
+    home: &Path,
+    name: &str,
+    now: chrono::DateTime<chrono::Utc>,
+    seeding: bool,
+) {
+    last_conflict_at.insert(name.to_string(), now);
+    if !seeding {
+        emit_conflict_notify(home, name);
+    }
+}
+
 fn emit_conflict_notify(home: &Path, agent: &str) {
     let Some(binding_json) = crate::binding::read(home, agent) else {
         tracing::debug!(
@@ -649,6 +682,52 @@ mod tests {
             queued[0].text.contains("git_conflict_detected"),
             "delivered notify must carry the rendered conflict payload, got: {}",
             queued[0].text
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn boot_seed_records_conflict_without_notifying() {
+        // #1739: record_first_observation seeds the dedup unconditionally, but
+        // suppresses the first-observation notify during the boot seeding pass —
+        // a restart must not re-ping conflicts the operator already saw.
+        let agent = "conflict-bootseed";
+        let home = defer_home("bootseed", agent);
+        // Binding with a worktree so emit_conflict_notify reaches the notify
+        // (else it early-returns and the test would have no teeth).
+        let bdir = crate::paths::runtime_dir(&home).join(agent);
+        std::fs::create_dir_all(&bdir).unwrap();
+        // Serialize via serde so the worktree path is JSON-escaped correctly —
+        // on Windows `home.display()` contains backslashes, which a hand-rolled
+        // `format!` would emit as invalid JSON escapes (breaking binding::read).
+        std::fs::write(
+            bdir.join("binding.json"),
+            serde_json::json!({ "worktree": home.to_string_lossy(), "branch": "feat" }).to_string(),
+        )
+        .unwrap();
+        let now = chrono::Utc::now();
+
+        // seeding scan: record the conflict, do NOT notify.
+        let mut last_conflict_at = HashMap::new();
+        record_first_observation(&mut last_conflict_at, &home, agent, now, true);
+        assert!(
+            last_conflict_at.contains_key(agent),
+            "boot-seed must record the conflict in last_conflict_at"
+        );
+        assert!(
+            crate::notification_queue::drain(&home, agent).is_empty(),
+            "boot-seed must NOT notify for a restart-existing conflict \
+             (negative-probe: removing the `if !seeding` gate makes this fire)"
+        );
+
+        // normal first observation: the notify fires.
+        let mut lc2 = HashMap::new();
+        record_first_observation(&mut lc2, &home, agent, now, false);
+        assert_eq!(
+            crate::notification_queue::drain(&home, agent).len(),
+            1,
+            "a normal first-observation conflict must notify"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/helper_staleness_watchdog.rs
+++ b/src/daemon/helper_staleness_watchdog.rs
@@ -54,6 +54,11 @@ pub(crate) struct HelperStalenessWatchdogTracker {
     /// so a sequential rebuild that fixes one helper but not the other
     /// still produces fresh alerts for the lagging one.
     last_alerted_at: HashMap<String, chrono::DateTime<chrono::Utc>>,
+    /// #1739 boot-seed latch. First scan seeds `last_alerted_at` with
+    /// currently-stale helpers (stamped now) WITHOUT emitting, so a restart
+    /// doesn't re-page about staleness the operator already saw. Only helpers
+    /// newly stale after boot (or past RE_ALERT_THRESHOLD) emit.
+    seeded: bool,
 }
 
 impl HelperStalenessWatchdogTracker {
@@ -66,7 +71,14 @@ impl HelperStalenessWatchdogTracker {
         }
         self.tick_count = 0;
         let daemon_exe = std::env::current_exe().ok();
-        scan_and_emit(home, daemon_exe.as_deref(), &mut self.last_alerted_at);
+        let seeding = !self.seeded;
+        self.seeded = true;
+        scan_and_emit(
+            home,
+            daemon_exe.as_deref(),
+            &mut self.last_alerted_at,
+            seeding,
+        );
         true
     }
 }
@@ -86,6 +98,7 @@ pub(crate) fn scan_and_emit(
     home: &Path,
     daemon_exe: Option<&Path>,
     last_alerted: &mut HashMap<String, chrono::DateTime<chrono::Utc>>,
+    seeding: bool,
 ) {
     let now = chrono::Utc::now();
     for name in TRACKED_HELPERS {
@@ -104,13 +117,16 @@ pub(crate) fn scan_and_emit(
                 continue;
             }
         }
-        // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path.
-        crate::daemon::event_bus::global().emit(
-            home,
-            crate::daemon::event_bus::EventKind::HelperStale {
-                helper_name: (*name).to_string(),
-            },
-        );
+        // #1739 boot-seed: first scan records the stale helper without emitting.
+        if !seeding {
+            // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path.
+            crate::daemon::event_bus::global().emit(
+                home,
+                crate::daemon::event_bus::EventKind::HelperStale {
+                    helper_name: (*name).to_string(),
+                },
+            );
+        }
         last_alerted.insert((*name).to_string(), now);
     }
 }
@@ -228,7 +244,7 @@ mod tests {
         let home = tmp_home("stale-emits");
         let daemon = stage_stale_state(&home, "agend-git");
         let mut last_alerted: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
-        scan_and_emit(&home, Some(&daemon), &mut last_alerted);
+        scan_and_emit(&home, Some(&daemon), &mut last_alerted, false);
 
         // Both recipients should receive an alert for the stale
         // helper. Other helpers (agend-mcp-bridge in this case) are
@@ -252,6 +268,34 @@ mod tests {
     }
 
     #[test]
+    fn boot_seed_suppresses_existing_stale_helper_then_no_reburst() {
+        // #1739: the first scan after a fresh daemon start seeds an
+        // already-stale helper into the dedup WITHOUT paging, and a subsequent
+        // scan does not re-burst it.
+        let home = tmp_home("stale-bootseed");
+        let daemon = stage_stale_state(&home, "agend-git");
+        let mut last_alerted: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
+        // seeding scan: record the stale helper, do NOT page.
+        scan_and_emit(&home, Some(&daemon), &mut last_alerted, true);
+        assert!(
+            last_alerted.contains_key("agend-git"),
+            "boot-seed must record the stale helper in the dedup"
+        );
+        assert!(
+            crate::inbox::drain(&home, "general").is_empty(),
+            "boot-seed must NOT page for a restart-existing stale helper \
+             (negative-probe: removing the `if !seeding` gate makes this fire)"
+        );
+        assert!(crate::inbox::drain(&home, "lead").is_empty());
+        // next normal scan: the seeded helper stays suppressed within RE_ALERT.
+        scan_and_emit(&home, Some(&daemon), &mut last_alerted, false);
+        assert!(
+            crate::inbox::drain(&home, "general").is_empty(),
+            "seeded helper must remain suppressed on the next scan"
+        );
+    }
+
+    #[test]
     fn throttle_suppresses_re_alert_within_window() {
         let home = tmp_home("throttle");
         let daemon = stage_stale_state(&home, "agend-git");
@@ -264,7 +308,7 @@ mod tests {
             now - chrono::Duration::seconds(RE_ALERT_THRESHOLD_SECS / 2),
         );
         let snapshot = last_alerted.clone();
-        scan_and_emit(&home, Some(&daemon), &mut last_alerted);
+        scan_and_emit(&home, Some(&daemon), &mut last_alerted, false);
 
         // Timestamp should NOT have moved → throttle held.
         assert_eq!(
@@ -295,7 +339,7 @@ mod tests {
             "agend-git".to_string(),
             now - chrono::Duration::seconds(RE_ALERT_THRESHOLD_SECS + 60),
         );
-        scan_and_emit(&home, Some(&daemon), &mut last_alerted);
+        scan_and_emit(&home, Some(&daemon), &mut last_alerted, false);
 
         // Timestamp should have advanced to ~now → re-alert fired.
         let updated = last_alerted.get("agend-git").copied().unwrap();
@@ -316,7 +360,7 @@ mod tests {
         // proactive page (operator-pull doctor still surfaces).
         let home = tmp_home("missing");
         let mut last_alerted: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
-        scan_and_emit(&home, None, &mut last_alerted);
+        scan_and_emit(&home, None, &mut last_alerted, false);
         assert!(
             last_alerted.is_empty(),
             "NotInstalled state must not emit proactive alerts"
@@ -396,7 +440,7 @@ mod tests {
         let home = tmp_home("via-bus");
         let daemon = stage_stale_state(&home, "agend-git");
         let mut last_alerted: HashMap<String, chrono::DateTime<chrono::Utc>> = HashMap::new();
-        scan_and_emit(&home, Some(&daemon), &mut last_alerted);
+        scan_and_emit(&home, Some(&daemon), &mut last_alerted, false);
         for recipient in RECIPIENTS {
             assert!(
                 !drained_payloads(&home, recipient).is_empty(),

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -232,6 +232,11 @@ pub(crate) struct IdleWatchdogTracker {
     tick_count: u64,
     /// (vantage, agent_or_fleet_marker) → last alert ts.
     last_alerted_at: HashMap<(&'static str, String), chrono::DateTime<chrono::Utc>>,
+    /// #1739 boot-seed latch for the DEV vantage. First scan seeds the dev
+    /// entries of `last_alerted_at` (stamped now) WITHOUT emitting, so a restart
+    /// doesn't re-page about agents already idle before the restart. The fleet
+    /// vantage is unaffected — it has its own persisted snooze.
+    seeded: bool,
 }
 
 impl IdleWatchdogTracker {
@@ -243,7 +248,9 @@ impl IdleWatchdogTracker {
             return false;
         }
         self.tick_count = 0;
-        scan_and_emit(home, &mut self.last_alerted_at);
+        let seeding = !self.seeded;
+        self.seeded = true;
+        scan_and_emit(home, &mut self.last_alerted_at, seeding);
         true
     }
 }
@@ -289,6 +296,7 @@ fn fleet_idle_recipient() -> String {
 pub(crate) fn scan_and_emit(
     home: &Path,
     last_alerted: &mut HashMap<(&'static str, String), chrono::DateTime<chrono::Utc>>,
+    seeding: bool,
 ) {
     if !crate::runtime_config::get().idle_watchdog_enabled {
         return;
@@ -297,7 +305,10 @@ pub(crate) fn scan_and_emit(
         return;
     }
     let now = chrono::Utc::now();
-    scan_dev_vantage(home, &now, last_alerted);
+    // #1739: only the DEV vantage gets boot-seeded (it used the in-memory
+    // `last_alerted` dedup that re-fired on restart). The fleet vantage has its
+    // own persisted snooze, so it is left as-is.
+    scan_dev_vantage(home, &now, last_alerted, seeding);
     scan_fleet_vantage(home, &now, last_alerted);
 }
 
@@ -397,6 +408,7 @@ fn scan_dev_vantage(
     home: &Path,
     now: &chrono::DateTime<chrono::Utc>,
     last_alerted: &mut HashMap<(&'static str, String), chrono::DateTime<chrono::Utc>>,
+    seeding: bool,
 ) {
     let env_agent = std::env::var("AGEND_IDLE_WATCHDOG_AGENT")
         .ok()
@@ -460,19 +472,22 @@ fn scan_dev_vantage(
         if task_info == "(no active task)" && task_board_is_active(home) {
             continue;
         }
-        route_idle_alert(
-            home,
-            &dev_idle_recipient(),
-            "dev_idle_watchdog",
-            &format!(
-                "[dev_idle_watchdog] agent '{agent}' has been silent for \
-                 {elapsed_secs}s (threshold {threshold}s). \
-                 Current task: {task_info}. \
-                 Possible dispatch protocol gap or unblock-needed state. \
-                 Consider: lead dispatch / unblock-ping / decision-log scan.",
-            ),
-            Some(agent),
-        );
+        // #1739 boot-seed: first scan records the idle agent without paging.
+        if !seeding {
+            route_idle_alert(
+                home,
+                &dev_idle_recipient(),
+                "dev_idle_watchdog",
+                &format!(
+                    "[dev_idle_watchdog] agent '{agent}' has been silent for \
+                     {elapsed_secs}s (threshold {threshold}s). \
+                     Current task: {task_info}. \
+                     Possible dispatch protocol gap or unblock-needed state. \
+                     Consider: lead dispatch / unblock-ping / decision-log scan.",
+                ),
+                Some(agent),
+            );
+        }
         last_alerted.insert(key, *now);
     }
 }
@@ -885,7 +900,7 @@ mod tests {
         let stale = chrono::Utc::now() - chrono::Duration::seconds(dev_idle_threshold_secs() + 60);
         write_activity_at(&home, "dev", stale);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let lead = crate::inbox::drain(&home, "lead");
         // #1563: the fleet recipient now also defaults to `lead`, so a
         // single-agent idle fleet co-fires a `fleet_idle_watchdog` alert here
@@ -900,6 +915,48 @@ mod tests {
             "lead must receive one dev idle alert: {lead:?}"
         );
         assert!(dev_alerts[0].text.contains("dev"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn boot_seed_suppresses_existing_idle_dev_then_no_reburst() {
+        // #1739: the first scan after a fresh daemon start seeds an already-idle
+        // dev agent into the dedup WITHOUT paging lead, and a subsequent scan
+        // does not re-burst it. (Only the dev vantage is seeded; the fleet
+        // vantage is unaffected, so we filter by the `dev_idle_watchdog` kind.)
+        let _g = env_lock();
+        std::env::remove_var("AGEND_IDLE_WATCHDOG_AGENT");
+        std::env::remove_var("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT");
+        let home = tmp_home("dev-bootseed");
+        let stale = chrono::Utc::now() - chrono::Duration::seconds(dev_idle_threshold_secs() + 60);
+        write_activity_at(&home, "dev", stale);
+        let count_dev_alerts = |home: &Path| {
+            crate::inbox::drain(home, "lead")
+                .into_iter()
+                .filter(|m| m.kind.as_deref() == Some("dev_idle_watchdog"))
+                .count()
+        };
+
+        let mut last_alerted = HashMap::new();
+        // seeding scan: record the idle dev, do NOT page.
+        scan_and_emit(&home, &mut last_alerted, true);
+        assert_eq!(
+            count_dev_alerts(&home),
+            0,
+            "boot-seed must NOT page lead for a restart-existing idle dev \
+             (negative-probe: removing the `if !seeding` gate makes this fire)"
+        );
+        assert!(
+            last_alerted.keys().any(|(vantage, _)| *vantage == "dev"),
+            "boot-seed must record the idle dev in the dev-vantage dedup"
+        );
+        // next normal scan: the seeded dev stays suppressed within threshold.
+        scan_and_emit(&home, &mut last_alerted, false);
+        assert_eq!(
+            count_dev_alerts(&home),
+            0,
+            "seeded idle dev must remain suppressed on the next scan"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -922,7 +979,7 @@ mod tests {
         write_activity_at(&home, "lead", stale);
         write_activity_at(&home, "worker", stale);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         // Alerts are delivered to the dev recipient ("lead"); inspect them.
         let alerts = crate::inbox::drain(&home, "lead");
         let dev_alerts: Vec<&str> = alerts
@@ -950,7 +1007,7 @@ mod tests {
         let recent = chrono::Utc::now() - chrono::Duration::seconds(dev_idle_threshold_secs() - 60);
         write_activity_at(&home, "dev", recent);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let lead = crate::inbox::drain(&home, "lead");
         // #1563: assert the DEV vantage specifically — a `fleet_idle_watchdog`
         // alert may co-land on `lead` (the agent is past the shorter fleet
@@ -974,7 +1031,7 @@ mod tests {
         let stale = chrono::Utc::now() - chrono::Duration::seconds(dev_idle_threshold_secs() + 60);
         write_activity_at(&home, "dev", stale);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let after_first = crate::inbox::drain(&home, "lead");
         // #1563: filter the DEV vantage (fleet_idle co-fires to lead now).
         assert_eq!(
@@ -988,7 +1045,7 @@ mod tests {
         // Touch activity (simulate dev resuming work).
         touch_agent_activity(&home, "dev");
         // Second scan: dev fresh → no alert.
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let after_second = crate::inbox::drain(&home, "lead");
         assert!(
             after_second.is_empty(),
@@ -1018,7 +1075,7 @@ mod tests {
         write_activity_at(&home, "lead", stale_lead);
         write_activity_at(&home, "reviewer", stale_reviewer);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             recipient
@@ -1047,7 +1104,7 @@ mod tests {
         write_activity_at(&home, "lead", stale);
         write_activity_at(&home, "general", recent);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             !recipient
@@ -1073,7 +1130,7 @@ mod tests {
         write_activity_at(&home, "dev", stale);
         write_activity_at(&home, "lead", stale);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         let fleet_msg = recipient
             .iter()
@@ -1140,8 +1197,8 @@ mod tests {
         let mut last_alerted = HashMap::new();
         // Two scans without intervening activity touch → dedup
         // suppresses the second alert.
-        scan_and_emit(&home, &mut last_alerted);
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
+        scan_and_emit(&home, &mut last_alerted, false);
         let lead = crate::inbox::drain(&home, "lead");
         // #1563: filter the DEV vantage (fleet_idle co-fires to lead now); the
         // dedup contract is per-vantage → exactly one dev alert across 2 scans.
@@ -1165,7 +1222,7 @@ mod tests {
         std::env::remove_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT");
         let home = tmp_home("fleet-empty");
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(recipient.is_empty(), "empty fleet must not alert");
         std::fs::remove_dir_all(&home).ok();
@@ -1295,7 +1352,7 @@ mod tests {
         write_activity_at(&home, "demo-lead", stale);
         write_activity_at(&home, "conflict-test-1", stale);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         let fleet_msg = recipient
             .iter()
@@ -1337,7 +1394,7 @@ mod tests {
         let until = chrono::Utc::now() + chrono::Duration::hours(1);
         snooze_fleet_idle(&home, until, "test").unwrap();
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             !recipient
@@ -1361,7 +1418,7 @@ mod tests {
         let past = chrono::Utc::now() - chrono::Duration::seconds(10);
         snooze_fleet_idle(&home, past, "test").unwrap();
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             recipient
@@ -1385,7 +1442,7 @@ mod tests {
         let until = chrono::Utc::now() + chrono::Duration::hours(1);
         snooze_fleet_idle(&home, until, "test").unwrap();
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let lead = crate::inbox::drain(&home, "lead");
         assert!(
             !lead
@@ -1425,7 +1482,7 @@ mod tests {
         write_activity_at(&home, "ghost-1", stale);
         write_activity_at(&home, "ghost-2", stale);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             !recipient
@@ -1450,7 +1507,7 @@ mod tests {
         write_activity_at(&home, "lead", stale);
         ack_fleet_idle();
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             !recipient
@@ -1485,7 +1542,7 @@ mod tests {
         seed_task(&home, "t-resume", "dev");
         advance_task(&home, "t-resume", "dev");
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             recipient
@@ -1524,7 +1581,7 @@ mod tests {
             chrono::DateTime::from_timestamp(acked, 0).unwrap() + chrono::Duration::seconds(5);
         write_activity_at(&home, "general", post_ack);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             !recipient
@@ -1562,7 +1619,7 @@ mod tests {
         // dev (task owner) becomes active AFTER the ack.
         write_activity_at(&home, "dev", past_ack + chrono::Duration::seconds(30));
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         assert_eq!(
             FLEET_ACKED_AT.load(Ordering::Relaxed),
             0,
@@ -1589,7 +1646,7 @@ mod tests {
             chrono::Utc::now() - chrono::Duration::seconds(fleet_idle_ack_ttl_secs() + 60);
         FLEET_ACKED_AT.store(old_ack.timestamp(), Ordering::Relaxed);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         assert_eq!(
             FLEET_ACKED_AT.load(Ordering::Relaxed),
             0,
@@ -1628,7 +1685,7 @@ mod tests {
         )
         .unwrap();
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             !recipient
@@ -1649,7 +1706,7 @@ mod tests {
         write_activity_at(&home, "dev", stale);
         ack_fleet_idle();
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let lead = crate::inbox::drain(&home, "lead");
         assert!(
             lead.iter()
@@ -1673,7 +1730,7 @@ mod tests {
         // Create an empty task_events.jsonl (board exists, no open tasks).
         std::fs::write(home.join("task_events.jsonl"), "").unwrap();
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             !recipient
@@ -1716,7 +1773,7 @@ mod tests {
         )
         .unwrap();
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let recipient = crate::inbox::drain(&home, "lead");
         assert!(
             recipient
@@ -1746,7 +1803,7 @@ mod tests {
         let stale = chrono::Utc::now() - chrono::Duration::seconds(400);
         write_activity_at(&home, "fast-reviewer", stale);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let lead = crate::inbox::drain(&home, "lead");
         assert!(
             lead.iter()
@@ -1774,7 +1831,7 @@ mod tests {
         let recent = chrono::Utc::now() - chrono::Duration::seconds(200);
         write_activity_at(&home, "fast-reviewer", recent);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let lead = crate::inbox::drain(&home, "lead");
         assert!(
             lead.is_empty(),
@@ -1794,7 +1851,7 @@ mod tests {
         let stale = chrono::Utc::now() - chrono::Duration::seconds(dev_idle_threshold_secs() + 60);
         write_activity_at(&home, "slow-dev", stale);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let lead = crate::inbox::drain(&home, "lead");
         assert!(
             lead.iter()
@@ -1840,7 +1897,7 @@ mod tests {
         let stale = chrono::Utc::now() - chrono::Duration::seconds(400);
         write_activity_at(&home, "dev", stale);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         let lead = crate::inbox::drain(&home, "lead");
         assert!(!lead.is_empty(), "alert must fire");
         assert!(

--- a/src/daemon/waiting_on_stale.rs
+++ b/src/daemon/waiting_on_stale.rs
@@ -26,6 +26,11 @@ pub(crate) struct WaitingOnStaleTracker {
     tick_count: u64,
     /// agent → last alert timestamp (dedup guard).
     last_alerted_at: HashMap<String, chrono::DateTime<chrono::Utc>>,
+    /// #1739 boot-seed latch. The first scan after a fresh daemon start seeds
+    /// `last_alerted_at` with currently-stale waiters (stamped now) WITHOUT
+    /// emitting, so a restart doesn't re-alert conditions the operator already
+    /// saw. Only waiters newly stale after boot (or past REALERT_INTERVAL) emit.
+    seeded: bool,
 }
 
 impl WaitingOnStaleTracker {
@@ -35,7 +40,9 @@ impl WaitingOnStaleTracker {
             return false;
         }
         self.tick_count = 0;
-        scan_and_emit(home, &mut self.last_alerted_at);
+        let seeding = !self.seeded;
+        self.seeded = true;
+        scan_and_emit(home, &mut self.last_alerted_at, seeding);
         true
     }
 }
@@ -45,6 +52,7 @@ impl WaitingOnStaleTracker {
 pub(crate) fn scan_and_emit(
     home: &Path,
     last_alerted: &mut HashMap<String, chrono::DateTime<chrono::Utc>>,
+    seeding: bool,
 ) {
     let now = chrono::Utc::now();
     let meta_dir = home.join("metadata");
@@ -88,15 +96,20 @@ pub(crate) fn scan_and_emit(
             }
         }
         let elapsed_min = elapsed_secs / 60;
-        // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path.
-        crate::daemon::event_bus::global().emit(
-            home,
-            crate::daemon::event_bus::EventKind::WaitingOnStale {
-                agent: agent.to_string(),
-                condition: condition.to_string(),
-                elapsed_min,
-            },
-        );
+        // #1739 boot-seed: on the first scan, record the stale waiter without
+        // emitting (treated as already-known across the restart). The dedup
+        // insert below still runs so later scans suppress it.
+        if !seeding {
+            // #event-bus Step 2 (legacy-zero): the bus is the sole delivery path.
+            crate::daemon::event_bus::global().emit(
+                home,
+                crate::daemon::event_bus::EventKind::WaitingOnStale {
+                    agent: agent.to_string(),
+                    condition: condition.to_string(),
+                    elapsed_min,
+                },
+            );
+        }
         last_alerted.insert(agent.to_string(), now);
     }
 }
@@ -208,7 +221,7 @@ mod tests {
         std::fs::create_dir_all(home.join("inbox")).unwrap();
 
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
 
         assert!(last_alerted.contains_key("dev-1"));
         let inbox_file = home.join("inbox").join("dev-1.jsonl");
@@ -221,13 +234,45 @@ mod tests {
     }
 
     #[test]
+    fn boot_seed_suppresses_existing_stale_then_no_reburst() {
+        // #1739: the first scan after a fresh daemon start seeds an
+        // already-stale waiter into the dedup WITHOUT emitting (restart should
+        // not re-alert backlog the operator saw before), and a subsequent scan
+        // does not re-burst it.
+        let home = tmp_home("bootseed");
+        let since = (chrono::Utc::now() - chrono::Duration::minutes(20)).to_rfc3339();
+        write_metadata(&home, "dev-bs", "review from reviewer", &since);
+        std::fs::create_dir_all(home.join("inbox")).unwrap();
+
+        let mut last_alerted = HashMap::new();
+        // seeding scan: record the existing stale waiter, but do NOT emit.
+        scan_and_emit(&home, &mut last_alerted, true);
+        assert!(
+            last_alerted.contains_key("dev-bs"),
+            "boot-seed must record the existing stale waiter in the dedup"
+        );
+        assert!(
+            !home.join("inbox").join("dev-bs.jsonl").exists(),
+            "boot-seed must NOT emit for restart-existing backlog (negative-probe: \
+             removing the `if !seeding` gate makes this fire)"
+        );
+        // next normal scan: the seeded waiter stays suppressed (no boot-burst).
+        scan_and_emit(&home, &mut last_alerted, false);
+        assert!(
+            !home.join("inbox").join("dev-bs.jsonl").exists(),
+            "seeded waiter must remain suppressed on the next scan within REALERT"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
     fn skips_fresh_waiting_on() {
         let home = tmp_home("fresh");
         let since = (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339();
         write_metadata(&home, "dev-2", "CI result", &since);
 
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
 
         assert!(!last_alerted.contains_key("dev-2"));
         let _ = std::fs::remove_dir_all(&home);
@@ -241,7 +286,7 @@ mod tests {
         std::fs::create_dir_all(home.join("inbox")).unwrap();
 
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         assert!(last_alerted.contains_key("dev-3"));
 
         let count_lines = || {
@@ -252,7 +297,7 @@ mod tests {
         };
         let first_count = count_lines();
 
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         assert_eq!(
             count_lines(),
             first_count,
@@ -333,7 +378,7 @@ mod tests {
         let since = (chrono::Utc::now() - chrono::Duration::minutes(20)).to_rfc3339();
         write_metadata(&home, "dev-gateoff", "blocker", &since);
         let mut last_alerted = HashMap::new();
-        scan_and_emit(&home, &mut last_alerted);
+        scan_and_emit(&home, &mut last_alerted, false);
         assert!(
             !drained_payloads(&home, "dev-gateoff").is_empty(),
             "#event-bus Option A: gate-off must deliver via the legacy path (no regression)"


### PR DESCRIPTION
## #1739 — boot-seed the supervisor-loop producers (no restart boot-burst)

Five supervisor-loop producers keep an **in-memory** dedup map that resets on
restart, so the first scan after a fresh daemon start re-fired for the **entire
existing backlog** — re-flooding operators with alerts they already saw.

Boot-grace (#1736's mechanism) is **insufficient here**: these producers' first
scan lands ~5 min in (`TICK 10s × TICKS_PER_SCAN 30`), past any short grace, and
the backlog (stall / conflict / idle / stale) **persists across the restart** —
so suppressing scans during a grace window only *delays* the burst.

### Fix (mirrors `pr_state::suppress_stale_terminal_replay`)
Each tracker gains a `seeded` latch. The **first** scan records every currently-
existing backlog item into the dedup (stamped now) but does **not** emit —
restart-existing items are treated as already-known. Only items that newly appear
after boot (or persist past the per-producer re-alert interval) emit. Pure
in-memory; **no new persistence**.

| producer | seeded state | scope notes |
|---|---|---|
| `anti_stall` | `last_emitted_at` | dropped the obsolete "intended restart re-surface" comment (operator greenlit suppressing it) |
| `waiting_on_stale` | `last_alerted_at` | |
| `helper_staleness` | `last_alerted_at` | |
| `idle_watchdog` | `last_alerted_at` (**dev vantage only**, via `scan_dev_vantage`) | fleet vantage keeps its persisted snooze |
| `conflict_notify` | `last_conflict_at` (**first-observation notify only**) | escalation / `last_escalated_at` is out of scope (#1739 ②, reviewer-2). **Option (a)**: seeding stamps `last_conflict_at = now`, so the 30-min staleness escalation clock starts at boot |

### Tests
Each producer has a boot-seed test: the seeding scan records the existing backlog
**without** emitting, and the next scan does **not** re-burst. **Negative-probed** —
removing the `if !seeding` gate makes the seeding scan emit (test fails); verified
on `anti_stall` + `conflict_notify`.

`cargo test --features tray` (5 boot-seed + 94 producer-module tests) green; clippy
`--all-targets --features tray` + fmt clean. Rebased on latest main.

Closes #1739.

---
@codex review — **standard tier**. Inline only. Focus:
1. The `seeded` latch flips exactly once and the seeding scan records the dedup
   without emitting, so boot-existing backlog is suppressed but post-boot-new
   items still fire.
2. `idle_watchdog` seeds **only** the dev vantage (`scan_dev_vantage`); the fleet
   vantage path is untouched.
3. `conflict_notify` touches **only** `last_conflict_at` (re-fire dedup), not
   `last_escalated_at` — no collision with #1739 ② (escalation persist).
