### PR TITLE
fix(#1744-M6/M7): escalation channel resolver + deterministic, fail-closed self-orch verdict

### DIFF
--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -163,6 +163,52 @@ pub fn lookup_channel_by_name(name: &str) -> Option<Arc<dyn Channel>> {
     channels_registry().read().get(name).cloned()
 }
 
+/// #1744-M6: the set of channels an operator-facing **escalation P0** must reach.
+///
+/// [`active_channel`] returns `None` whenever ZERO **or MULTIPLE** channels are
+/// registered, so once a fleet runs telegram + discord every `if let Some(ch) =
+/// active_channel()` escalation silently no-ops — exactly when an orchestrator-
+/// down P0 must get through. This resolver instead returns ALL registered
+/// channels (one per `kind()`): a P0 is delivered to every surface, because for
+/// a leaderless-orchestrator alert "deliver twice" beats "deliver never". With a
+/// single channel it returns just that one (unchanged single-fleet behavior);
+/// with none, an empty vec (caller logs the drop).
+///
+/// Scope discipline (#1744-M6): this is for **Error-severity escalation P0s
+/// only** — the crash / hung / AuthError / retry-exhausted / stall pages. Non-P0
+/// notices (e.g. the Info "agent ready" recovery ping) deliberately keep
+/// [`active_channel`] so the multi-channel fan-out can never leak into routine
+/// traffic. An operator-designated `primary_channel()` is deferred (a routing
+/// nicety, not a reachability fix).
+pub fn resolve_escalation_channels() -> Vec<Arc<dyn Channel>> {
+    channels_registry().read().values().cloned().collect()
+}
+
+/// #1744-M6: dispatch one operator-facing **escalation P0** to EVERY registered
+/// channel (telegram, discord, …) via [`gated_notify`]. Centralizes the
+/// iterate-all fan-out so every orchestrator-down page (crash / hung / AuthError
+/// / retry-exhausted / stall) gets through even in a multi-channel fleet, where
+/// [`active_channel`] would return `None` and silently drop the alert. Returns
+/// the number of channels dispatched to; `0` (no channel registered) is logged
+/// as a dropped P0. Reserve for Error-severity P0s — routine notices keep
+/// [`active_channel`] so this fan-out never leaks into non-escalation traffic.
+pub fn notify_all_escalation_channels(
+    instance: &str,
+    severity: NotifySeverity,
+    message: &str,
+    silent: bool,
+) -> usize {
+    let channels = resolve_escalation_channels();
+    if channels.is_empty() {
+        tracing::debug!(agent = %instance, "no channel registered — escalation P0 dropped");
+        return 0;
+    }
+    for ch in &channels {
+        let _ = gated_notify(ch.as_ref(), instance, severity, message, silent);
+    }
+    channels.len()
+}
+
 /// Sprint 55 P0-A — test-only: clear all registered channels.
 #[cfg(test)]
 pub fn reset_active_channel_for_test() {
@@ -745,6 +791,130 @@ mod tests {
             !ch.outbound_authorized(),
             "default trait method must fail-closed"
         );
+    }
+
+    // ── #1744-M6: escalation channel resolver / multi-channel fan-out ──
+
+    /// Serialize the process-global channel registry across the registry-touching
+    /// tests in this module (mirrors `daemon::router` / `mcp::handlers::channel`).
+    fn m6_registry_guard() -> parking_lot::MutexGuard<'static, ()> {
+        static G: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+        G.lock()
+    }
+
+    /// Recording channel with a configurable `kind()` (the registry is keyed by
+    /// kind, so a multi-channel test needs distinct kinds) and authorized=true.
+    struct KindedRecording {
+        kind: &'static str,
+        caps: ChannelCapabilities,
+        count: std::sync::atomic::AtomicUsize,
+    }
+    impl KindedRecording {
+        fn arc(kind: &'static str) -> Arc<Self> {
+            Arc::new(Self {
+                kind,
+                caps: ChannelCapabilities::default(),
+                count: std::sync::atomic::AtomicUsize::new(0),
+            })
+        }
+        fn count(&self) -> usize {
+            self.count.load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+    impl Channel for KindedRecording {
+        fn kind(&self) -> &'static str {
+            self.kind
+        }
+        fn caps(&self) -> &ChannelCapabilities {
+            &self.caps
+        }
+        fn poll_event(&self) -> Option<ChannelEvent> {
+            None
+        }
+        fn send(&self, _: &BindingRef, _: OutMsg) -> Result<MsgRef> {
+            anyhow::bail!("mock")
+        }
+        fn edit(&self, _: &MsgRef, _: OutMsg) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn delete(&self, _: &MsgRef) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn create_binding(&self, _: &str, _: BindingOpts) -> Result<BindingRef> {
+            anyhow::bail!("mock")
+        }
+        fn remove_binding(&self, _: &BindingRef) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn has_binding(&self, _: &str) -> bool {
+            false
+        }
+        fn record_binding(&self, _: &str, _: BindingRef, _: String) {}
+        fn take_binding(&self, _: &str) -> Option<BindingRef> {
+            None
+        }
+        fn attach_registry(&self, _: crate::agent::AgentRegistry) {}
+        fn outbound_authorized(&self) -> bool {
+            true
+        }
+        fn notify(
+            &self,
+            _: &str,
+            _: NotifySeverity,
+            _: &str,
+            _: bool,
+        ) -> std::result::Result<(), ChannelError> {
+            self.count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    /// #1744-M6: an escalation P0 must reach EVERY registered channel — the bug
+    /// was `active_channel()` returning `None` with ≥2 channels, silently dropping
+    /// the alert. `notify_all_escalation_channels` fans out to all of them.
+    #[test]
+    fn notify_all_escalation_channels_fans_out_to_every_channel_1744_m6() {
+        let _g = m6_registry_guard();
+        reset_active_channel_for_test();
+        let tg = KindedRecording::arc("telegram-m6");
+        let dc = KindedRecording::arc("discord-m6");
+        register_active_channel(tg.clone());
+        register_active_channel(dc.clone());
+
+        // Precondition: this is exactly the case `active_channel()` drops.
+        assert!(
+            active_channel().is_none(),
+            "active_channel() returns None with 2 channels — the M6 bug"
+        );
+
+        let sent = notify_all_escalation_channels("orch", NotifySeverity::Error, "P0", false);
+        assert_eq!(sent, 2, "must dispatch to both channels");
+        assert_eq!(tg.count(), 1, "telegram got the P0");
+        assert_eq!(dc.count(), 1, "discord got the P0");
+
+        reset_active_channel_for_test();
+    }
+
+    /// #1744-M6: single-channel returns 1 (unchanged single-fleet behavior); zero
+    /// returns 0 (logged drop, no panic).
+    #[test]
+    fn notify_all_escalation_channels_single_and_zero_1744_m6() {
+        let _g = m6_registry_guard();
+        reset_active_channel_for_test();
+        assert_eq!(
+            notify_all_escalation_channels("a", NotifySeverity::Error, "p", false),
+            0,
+            "zero channels → 0 (drop logged)"
+        );
+        let only = KindedRecording::arc("solo-m6");
+        register_active_channel(only.clone());
+        assert_eq!(
+            notify_all_escalation_channels("a", NotifySeverity::Error, "p", false),
+            1
+        );
+        assert_eq!(only.count(), 1);
+        reset_active_channel_for_test();
     }
 
     // ---- Phase 5b: Channel::send_from_agent default + AgentOutboundOp ----

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -39,7 +39,13 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
     // teams-file read) BEFORE taking the registry lock, so no file IO runs under
     // the lock (#1530 class). A self-orchestrator crash has no peer to relay an
     // inbox P0, so it escalates straight to the operator (below).
-    let is_self_orch = crate::teams::is_self_orchestrator(home, crashed_name);
+    // #1744-M7: 3-state. The crash path stays CONSERVATIVE — only a determinate
+    // `Yes` fires the self-orch P0; `Unknown` (teams config unreadable) falls
+    // back to the generic recent>=2 notify rather than firing the more-aggressive
+    // leaderless page off an indeterminate read. (The no-peer hung/AuthError
+    // paths fail the other way — they escalate on `Unknown`.)
+    let self_orch = crate::teams::self_orch_status(home, crashed_name);
+    let is_self_orch = self_orch == crate::teams::SelfOrchStatus::Yes;
 
     let (should_respawn, delay, should_notify, fire_self_orch_p0, escalation_snapshot) = {
         let reg = agent::lock_registry(&ctx.registry);
@@ -140,17 +146,14 @@ fn notify_self_orch_crash(
          until it respawns and no peer can relay this. The respawn loses its in-memory \
          context; check for a crash-loop / re-prime it. Manual intervention may be required."
     );
-    if let Some(ch) = crate::channel::active_channel() {
-        let _ = crate::channel::gated_notify(
-            ch.as_ref(),
-            crashed_name,
-            NotifySeverity::Error,
-            &msg,
-            false,
-        );
-    } else {
-        tracing::debug!(agent = %crashed_name, "no active channel for self-orch crash P0");
-    }
+    // #1744-M6: every registered channel — a leaderless-orchestrator P0 must not
+    // be dropped just because the fleet runs multiple channels.
+    crate::channel::notify_all_escalation_channels(
+        crashed_name,
+        NotifySeverity::Error,
+        &msg,
+        false,
+    );
 }
 
 fn notify_crash(
@@ -166,17 +169,13 @@ fn notify_crash(
     };
     tracing::warn!(agent = %crashed_name, %state, "notifying");
     let msg = format!("[health] {crashed_name}: {state}");
-    if let Some(ch) = crate::channel::active_channel() {
-        let _ = crate::channel::gated_notify(
-            ch.as_ref(),
-            crashed_name,
-            NotifySeverity::Error,
-            &msg,
-            false,
-        );
-    } else {
-        tracing::debug!(agent = %crashed_name, "no active channel for crash notification");
-    }
+    // #1744-M6: every registered channel (multi-channel-safe).
+    crate::channel::notify_all_escalation_channels(
+        crashed_name,
+        NotifySeverity::Error,
+        &msg,
+        false,
+    );
 }
 
 fn respawn_agent_worker(

--- a/src/daemon/per_tick/hang_detection.rs
+++ b/src/daemon/per_tick/hang_detection.rs
@@ -110,13 +110,16 @@ impl PerTickHandler for HangDetectionHandler {
         // Phase 2/3 (#1701 Hung half): a self-orchestrator stuck Hung past the
         // confirm-window has no peer to relay — escalate operator P0, INDEPENDENT
         // of `hang_auto_recovery_enabled` (a leaderless team must page even in
-        // recovery shadow mode). `is_self_orchestrator` is a teams-file read (done
+        // recovery shadow mode). `self_orch_status` is a teams-file read (done
         // lock-free); the confirm-window + cooldown gate (`hung_escalation_due`)
         // then runs under a brief per-candidate re-lock and stamps, so a
         // persisting Hung pages at most once per cooldown. Self-orch Hung is rare,
         // so the re-lock cost is negligible.
+        // #1744-M7: fail-closed — escalate on `Yes` OR `Unknown` (teams config
+        // unreadable). A no-peer Hung P0 is high-cost to miss, so an indeterminate
+        // read errs toward paging; only a determinate `No` skips.
         for name in hung_now {
-            if !crate::teams::is_self_orchestrator(ctx.home, &name) {
+            if crate::teams::self_orch_status(ctx.home, &name) == crate::teams::SelfOrchStatus::No {
                 continue;
             }
             // Re-lock briefly: run the confirm-window + cooldown gate (which
@@ -156,7 +159,9 @@ impl PerTickHandler for HangDetectionHandler {
         // Hung doesn't spawn a store entry. The snapshot's `hung_since` is now
         // None; its crash budget / cooldowns (which DO matter) are preserved.
         for name in left_hung {
-            if !crate::teams::is_self_orchestrator(ctx.home, &name) {
+            // #1744-M7: mirror the fire loop — `Yes`|`Unknown` proceed (clearing a
+            // stale anchor on an indeterminate read is harmless and correct).
+            if crate::teams::self_orch_status(ctx.home, &name) == crate::teams::SelfOrchStatus::No {
                 continue;
             }
             if crate::daemon::escalation_persist::load_for(ctx.home, &name).is_none() {
@@ -200,17 +205,13 @@ fn notify_self_orch_hung(name: &str) {
          pane / interrupt / re-prime).",
         HUNG_ESCALATE_AFTER.as_secs()
     );
-    if let Some(ch) = crate::channel::active_channel() {
-        let _ = crate::channel::gated_notify(
-            ch.as_ref(),
-            name,
-            crate::channel::NotifySeverity::Error,
-            &msg,
-            false,
-        );
-    } else {
-        tracing::debug!(agent = %name, "no active channel for self-orch hung P0");
-    }
+    // #1744-M6: every registered channel (multi-channel-safe P0).
+    crate::channel::notify_all_escalation_channels(
+        name,
+        crate::channel::NotifySeverity::Error,
+        &msg,
+        false,
+    );
 }
 
 #[cfg(test)]

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -659,21 +659,17 @@ fn format_stage3_body(name: &str, recovery_restart_count: u32) -> String {
 /// info-leak gate prevents leakage when channel is unauthorised.
 fn notify_stage3_escalate(name: &str, snapshot: &DispatchSnapshot) {
     let body = format_stage3_body(name, snapshot.recovery_restart_count);
-    if let Some(channel) = crate::channel::active_channel() {
-        let _ = crate::channel::gated_notify(
-            channel.as_ref(),
-            name,
-            crate::channel::NotifySeverity::Error,
-            &body,
-            false,
-        );
-    } else {
-        tracing::debug!(
-            target: TARGET,
-            agent = %name,
-            "stage3 telegram skipped: no active channel"
-        );
-    }
+    // #1744-M6: Stage 3 is an Error-severity operator P0 (auto-recovery exhausted,
+    // only operator action resumes) — deliver to EVERY registered channel.
+    // `active_channel()` would silently drop it in a multi-channel fleet. (Stage 2
+    // above stays `Warn` + `active_channel()` — not a P0.) `gated_notify` inside
+    // the helper still enforces the info-leak / authorization gate per channel.
+    crate::channel::notify_all_escalation_channels(
+        name,
+        crate::channel::NotifySeverity::Error,
+        &body,
+        false,
+    );
 }
 
 /// Stage 1 alive-stuck branch — emit ESC byte (or shadow-log it),

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -472,6 +472,31 @@ fn self_orchestrator_escalates(new_state: crate::state::AgentState) -> bool {
     new_state == crate::state::AgentState::AuthError
 }
 
+/// #1595/#1744: escalate a self-orchestrator `AuthError` straight to the operator
+/// — stamp the per-agent notify cooldown (so a persistent AuthError pages at most
+/// once per `NOTIFY_COOLDOWN`) and dispatch the P0 to EVERY registered channel
+/// (#1744-M6: multi-channel-safe; `active_channel()` would silently drop it).
+/// Shared by the resolved-self-orch path AND the #1744-M7 fail-closed path
+/// (teams config unreadable → can't identify a peer to relay to, and AuthError is
+/// operator-only, so page the operator rather than drop).
+fn escalate_self_orch_autherror(
+    name: &str,
+    now: Instant,
+    tracks: &mut HashMap<String, NotifyTrack>,
+) {
+    let track = tracks.entry(name.to_string()).or_insert(NotifyTrack {
+        last_at: now,
+        consecutive: 0,
+    });
+    track.consecutive += 1;
+    track.last_at = now;
+    let msg = format!(
+        "🔑 {name} (team orchestrator) hit AuthError — only the operator can re-authenticate, and no peer can relay this. Check credentials / re-auth the agent."
+    );
+    crate::channel::notify_all_escalation_channels(name, NotifySeverity::Error, &msg, false);
+    tracing::info!(agent = %name, "#1595/#1744: self-orchestrator AuthError escalated to operator (all channels)");
+}
+
 /// Decide and dispatch member-state-change notify. Returns true if notify sent.
 /// Production-path-coupled per §3.5.10 — tests call this same function.
 pub(crate) fn maybe_notify_member_state_change(
@@ -492,7 +517,22 @@ pub(crate) fn maybe_notify_member_state_change(
     if !should {
         return false;
     }
-    let Some(team) = crate::teams::find_team_for(home, name) else {
+    // #1744-M7: distinguish "teams config unreadable" (Err → can't determine the
+    // orchestrator) from "loaded, no team for this member" (None). For the no-peer
+    // AuthError P0 the unreadable case fails CLOSED — escalate to the operator
+    // rather than silently dropping (we can't relay to an orchestrator we can't
+    // identify, and AuthError is operator-only). Non-escalation states stay
+    // dropped (we genuinely can't route them).
+    let fleet = match crate::teams::try_load_fleet(home) {
+        Ok(f) => f,
+        Err(_) => {
+            if self_orchestrator_escalates(new_state) {
+                escalate_self_orch_autherror(name, now, tracks);
+            }
+            return false;
+        }
+    };
+    let Some(team) = crate::teams::find_team_for_in(&fleet, name) else {
         return false;
     };
     let Some(ref orch) = team.orchestrator else {
@@ -502,7 +542,7 @@ pub(crate) fn maybe_notify_member_state_change(
     if orch == name {
         // #1595 Step 2: the orchestrator IS the affected agent — no peer can relay
         // its inbox P0. For a state only the operator can resolve (AuthError: only
-        // the operator can re-authenticate), escalate straight to operator Telegram
+        // the operator can re-authenticate), escalate straight to the operator
         // via gated_notify(Error) — the same Sleep-penetrating path #1594 allows
         // through. Cooldown-stamped so a persistent AuthError escalates at most
         // once per NOTIFY_COOLDOWN, not every tick. Other states keep the D3
@@ -512,25 +552,7 @@ pub(crate) fn maybe_notify_member_state_change(
         // follow-up (#1701) using the process-exit / HealthState::Hung paths (the
         // latter strong-gated for the known 348-FP).
         if self_orchestrator_escalates(new_state) {
-            let track = tracks.entry(name.to_string()).or_insert(NotifyTrack {
-                last_at: now,
-                consecutive: 0,
-            });
-            track.consecutive += 1;
-            track.last_at = now;
-            if let Some(ch) = crate::channel::active_channel() {
-                let msg = format!(
-                    "🔑 {name} (team orchestrator) hit AuthError — only the operator can re-authenticate, and no peer can relay this. Check credentials / re-auth the agent."
-                );
-                let _ = crate::channel::gated_notify(
-                    ch.as_ref(),
-                    name,
-                    NotifySeverity::Error,
-                    &msg,
-                    false,
-                );
-            }
-            tracing::info!(agent = %name, "#1595: self-orchestrator AuthError escalated to operator Telegram (no peer to relay)");
+            escalate_self_orch_autherror(name, now, tracks);
         }
         return false; // D3: still skip the inbox self-notify (no peer reads it)
     }
@@ -1187,17 +1209,14 @@ fn tick(
                 // agent stuck on a prompt forever. (Severity is routing-only —
                 // the Telegram adapter ignores it for rendering — so this does
                 // not change the Active-mode message.)
-                if let Some(ch) = crate::channel::active_channel() {
-                    let _ = crate::channel::gated_notify(
-                        ch.as_ref(),
-                        &name,
-                        NotifySeverity::Error,
-                        &msg,
-                        false,
-                    );
-                } else {
-                    tracing::debug!(agent = %name, "no active channel — stall notice dropped");
-                }
+                // #1744-M6: stall is an Error-severity operator P0 — deliver to
+                // every registered channel (multi-channel-safe).
+                crate::channel::notify_all_escalation_channels(
+                    &name,
+                    NotifySeverity::Error,
+                    &msg,
+                    false,
+                );
             }
             Some(NoticeAction::Recovered) => {
                 let msg = format_recovery_notice(&name);
@@ -1453,26 +1472,24 @@ pub(crate) fn process_error_recovery(
             // gave up, so a stuck member is reassigned/intervened. Inbox path only;
             // the operator Telegram alert below is the separate `gated_notify`.
             notify_orchestrator_retry_exhausted(home, name, retry.retry_count);
-            if let Some(ch) = crate::channel::active_channel() {
-                let msg = format!(
-                    "⚠️ {name} transient upstream error auto-retry exhausted ({} retries). Manual intervention required.",
-                    SERVER_RATE_LIMIT_MAX_RETRIES
-                );
-                // #1595 Step 1: `Error`, not `Warn`. Exhaustion of the #1696 tiered
-                // retry (the full ~75min budget burned) means the agent is stuck
-                // and auto-recovery has given up — a genuine P0 that MUST break
-                // through `Sleep`/`Away` to wake the operator (the #1594 gate
-                // suppresses `Warn` in Sleep, so at `Warn` this alert was silently
-                // dropped exactly when the operator most needs it). Severity is
-                // routing-only (the Telegram adapter ignores it for rendering).
-                let _ = crate::channel::gated_notify(
-                    ch.as_ref(),
-                    name,
-                    NotifySeverity::Error,
-                    &msg,
-                    false,
-                );
-            }
+            let msg = format!(
+                "⚠️ {name} transient upstream error auto-retry exhausted ({} retries). Manual intervention required.",
+                SERVER_RATE_LIMIT_MAX_RETRIES
+            );
+            // #1595 Step 1: `Error`, not `Warn`. Exhaustion of the #1696 tiered
+            // retry (the full ~75min budget burned) means the agent is stuck
+            // and auto-recovery has given up — a genuine P0 that MUST break
+            // through `Sleep`/`Away` to wake the operator (the #1594 gate
+            // suppresses `Warn` in Sleep, so at `Warn` this alert was silently
+            // dropped exactly when the operator most needs it). Severity is
+            // routing-only (the Telegram adapter ignores it for rendering).
+            // #1744-M6: deliver to every registered channel (multi-channel-safe).
+            crate::channel::notify_all_escalation_channels(
+                name,
+                NotifySeverity::Error,
+                &msg,
+                false,
+            );
             continue;
         }
         // #1696: escalation-phase observability (so a long outage is visible in the log).
@@ -1527,23 +1544,21 @@ pub(crate) fn process_error_recovery(
                     InjectFailAction::Exhaust => {
                         retry.exhausted = true;
                         notify_orchestrator_retry_exhausted(home, name, retry.retry_count);
-                        if let Some(ch) = crate::channel::active_channel() {
-                            let msg = format!(
-                                "⚠️ {name} ServerRateLimit auto-retry inject 連續失敗 {} 次、已放棄 — agent 可能 unreachable,需人工介入(檢查 pane / 重啟 / 重新指派)。",
-                                retry.inject_failures
-                            );
-                            // #1742: same Error severity + same Sleep-penetrating gate as
-                            // the budget-exhausted alert (#1595 Step 1) — a stuck agent
-                            // whose auto-recovery cannot even deliver `continue` is the
-                            // same P0 that must wake a sleeping operator.
-                            let _ = crate::channel::gated_notify(
-                                ch.as_ref(),
-                                name,
-                                NotifySeverity::Error,
-                                &msg,
-                                false,
-                            );
-                        }
+                        let msg = format!(
+                            "⚠️ {name} ServerRateLimit auto-retry inject 連續失敗 {} 次、已放棄 — agent 可能 unreachable,需人工介入(檢查 pane / 重啟 / 重新指派)。",
+                            retry.inject_failures
+                        );
+                        // #1742: same Error severity + same Sleep-penetrating gate as
+                        // the budget-exhausted alert (#1595 Step 1) — a stuck agent
+                        // whose auto-recovery cannot even deliver `continue` is the
+                        // same P0 that must wake a sleeping operator.
+                        // #1744-M6: every registered channel (multi-channel-safe).
+                        crate::channel::notify_all_escalation_channels(
+                            name,
+                            NotifySeverity::Error,
+                            &msg,
+                            false,
+                        );
                     }
                 }
             }
@@ -2526,6 +2541,58 @@ instances:
         assert_eq!(
             tracks["solo"].consecutive, 1,
             "#1595: NOTIFY_COOLDOWN must prevent re-escalation within the window"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1744-M7: when the teams config is UNREADABLE (exists but corrupt → the
+    /// orchestrator can't be identified), a self-orch AuthError must STILL escalate
+    /// to the operator (fail-closed) — we can't relay to a peer we can't find and
+    /// AuthError is operator-only. A non-escalation state under the same unreadable
+    /// config stays dropped (we genuinely can't route it).
+    #[test]
+    fn self_orch_autherror_fail_closed_on_unreadable_teams_1744_m7() {
+        let home = std::env::temp_dir().join(format!("agend-1744m7-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(home.join("inbox")).ok();
+        // Corrupt (existing-but-invalid) fleet.yaml → try_load_fleet Err → Unknown.
+        let _ = std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "teams: : : not valid [[[\n",
+        );
+
+        // AuthError → fail-closed escalation runs (stamps the cooldown track).
+        let mut tracks = std::collections::HashMap::new();
+        let sent = super::maybe_notify_member_state_change(
+            &home,
+            "solo",
+            crate::state::AgentState::Idle,
+            crate::state::AgentState::AuthError,
+            "",
+            &mut tracks,
+        );
+        assert!(!sent, "still not an inbox self-notify");
+        assert_eq!(
+            tracks.get("solo").map(|t| t.consecutive),
+            Some(1),
+            "#1744-M7: AuthError must escalate even when teams config is unreadable (fail-closed)"
+        );
+
+        // A non-escalation state under the same unreadable config → no escalation.
+        let mut tracks2 = std::collections::HashMap::new();
+        let sent2 = super::maybe_notify_member_state_change(
+            &home,
+            "solo",
+            crate::state::AgentState::Idle,
+            crate::state::AgentState::RateLimit,
+            "",
+            &mut tracks2,
+        );
+        assert!(!sent2);
+        assert!(
+            !tracks2.contains_key("solo"),
+            "#1744-M7: a non-AuthError state under an unreadable config must NOT escalate"
         );
 
         std::fs::remove_dir_all(&home).ok();

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -58,6 +58,59 @@ fn load_fleet(home: &Path) -> crate::fleet::FleetConfig {
     crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).unwrap_or_default()
 }
 
+/// #1744-M7: load fleet config distinguishing "no fleet configured" (a missing
+/// file → `Ok(default)`, i.e. genuinely no teams) from "could not determine"
+/// (the file EXISTS but failed to read/parse → `Err`, i.e. a transient IO race
+/// or corruption). [`load_fleet`]'s `unwrap_or_default()` collapses both into an
+/// empty fleet, which makes every self-orch check silently read `false` during a
+/// teams.yaml read failure — defeating the orchestrator-down safety net exactly
+/// when it matters. `self_orch_status` maps the `Err` to `Unknown` so consumers
+/// can fail to the SAFE side.
+pub fn try_load_fleet(home: &Path) -> anyhow::Result<crate::fleet::FleetConfig> {
+    let path = crate::fleet::fleet_yaml_path(home);
+    if !path.exists() {
+        // No fleet.yaml = no teams configured (determinate "No"), not an error.
+        return Ok(crate::fleet::FleetConfig::default());
+    }
+    crate::fleet::FleetConfig::load(&path)
+}
+
+/// #1744-M7: deterministic team lookup. `fleet.teams` is a `HashMap`, so the
+/// prior `.iter().find()` returned an ARBITRARY team when a member appeared on
+/// more than one — a non-deterministic self-orch verdict across calls/restarts.
+/// Iterate in sorted-team-name order so the result is stable.
+pub(crate) fn find_team_for_in(fleet: &crate::fleet::FleetConfig, member: &str) -> Option<Team> {
+    let mut entries: Vec<_> = fleet.teams.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    entries
+        .into_iter()
+        .find(|(_, cfg)| cfg.members.iter().any(|m| m == member))
+        .map(|(name, cfg)| project_team(name, cfg))
+}
+
+/// #1744-M7: three-state self-orchestrator verdict. `Unknown` means the teams
+/// config could not be read (transient IO / parse) — distinct from a determinate
+/// `No`. Escalation consumers choose their own safe side for `Unknown` (the
+/// no-peer hung/AuthError P0 paths escalate on `Unknown`; the crash path stays
+/// conservative and falls back to its generic recent>=2 notify).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelfOrchStatus {
+    Yes,
+    No,
+    Unknown,
+}
+
+/// #1744-M7: deterministic + fail-closed self-orch verdict. See [`SelfOrchStatus`].
+pub fn self_orch_status(home: &Path, member: &str) -> SelfOrchStatus {
+    match try_load_fleet(home) {
+        Ok(fleet) => match find_team_for_in(&fleet, member).and_then(|t| t.orchestrator) {
+            Some(orch) if orch == member => SelfOrchStatus::Yes,
+            _ => SelfOrchStatus::No,
+        },
+        Err(_) => SelfOrchStatus::Unknown,
+    }
+}
+
 /// Project a fleet.yaml `(name, TeamConfig)` pair into the public `Team`
 /// JSON shape used by `list` / `find_team_for`. `created_at` defaults
 /// to empty string when absent (operator-edited fleet.yaml entries may
@@ -89,23 +142,8 @@ fn find_team_for_member(fleet: &crate::fleet::FleetConfig, name: &str) -> Option
 /// `api::handlers::prepare_instructions` to split agend.md's peer list
 /// into team members vs other fleet agents.
 pub fn find_team_for(home: &Path, member: &str) -> Option<Team> {
-    let fleet = load_fleet(home);
-    fleet
-        .teams
-        .iter()
-        .find(|(_, cfg)| cfg.members.iter().any(|m| m == member))
-        .map(|(name, cfg)| project_team(name, cfg))
-}
-
-/// #1701: is `member` the orchestrator of its own team? A self-orchestrator has
-/// no peer to relay an inbox P0, so its crash/hang escalates straight to the
-/// operator (see `daemon::crash_respawn` for crash, `daemon::per_tick::hang_detection`
-/// for hang). Mirrors the `orch == name` guard in
-/// `supervisor::{maybe_notify_member_state_change, notify_orchestrator_retry_exhausted}`.
-pub fn is_self_orchestrator(home: &Path, member: &str) -> bool {
-    find_team_for(home, member)
-        .and_then(|t| t.orchestrator)
-        .is_some_and(|orch| orch == member)
+    // #1744-M7: deterministic lookup (sorted team-name order).
+    find_team_for_in(&load_fleet(home), member)
 }
 
 pub fn create(home: &Path, args: &Value) -> Value {
@@ -521,29 +559,81 @@ mod tests {
         dir
     }
 
-    /// #1701: self-orch detection — the gate that routes a crash/hang to the
-    /// self-orch P0. The orchestrator IS its own orchestrator → true; a regular
-    /// member → false (keeps the generic path, never the self-orch P0); an agent
-    /// in no team → false.
+    // ── #1744-M7: deterministic + fail-closed self-orch verdict ──
+    // (#1701's boolean `is_self_orchestrator` was replaced by the 3-state
+    // `self_orch_status`; the Yes/No verdict is covered by
+    // `self_orch_status_yes_no_for_loaded_fleet_1744_m7` below.)
+
+    /// #1744-M7: `self_orch_status` is `Yes` for the orchestrator, `No` for a
+    /// regular member, and `No` for an agent in no team / a missing fleet.yaml
+    /// (a determinate "no fleet configured", NOT an indeterminate read).
     #[test]
-    fn is_self_orchestrator_only_true_for_own_orchestrator_1701() {
-        let home = tmp_home("self-orch");
+    fn self_orch_status_yes_no_for_loaded_fleet_1744_m7() {
+        let home = tmp_home("m7-yes-no");
         create(
             &home,
             &serde_json::json!({"name": "t", "members": ["lead", "dev"], "orchestrator": "lead"}),
         );
-        assert!(
-            is_self_orchestrator(&home, "lead"),
-            "the team orchestrator IS its own orchestrator"
+        assert_eq!(self_orch_status(&home, "lead"), SelfOrchStatus::Yes);
+        assert_eq!(self_orch_status(&home, "dev"), SelfOrchStatus::No);
+        assert_eq!(self_orch_status(&home, "ghost"), SelfOrchStatus::No);
+
+        // Missing fleet.yaml = no fleet configured = determinate No (not Unknown).
+        let empty = tmp_home("m7-missing");
+        assert_eq!(self_orch_status(&empty, "anyone"), SelfOrchStatus::No);
+
+        let _ = std::fs::remove_dir_all(&home);
+        let _ = std::fs::remove_dir_all(&empty);
+    }
+
+    /// #1744-M7: an EXISTING but unreadable/corrupt fleet.yaml → `Unknown`
+    /// (fail-closed), distinct from the determinate `No` of a missing file. This
+    /// is the gap the old `unwrap_or_default()` collapsed: a transient parse/IO
+    /// failure silently made every agent read as not-self-orch.
+    #[test]
+    fn self_orch_status_unknown_on_unreadable_fleet_1744_m7() {
+        let home = tmp_home("m7-unknown");
+        // A file that EXISTS but is not valid fleet YAML → FleetConfig::load Err.
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "this: is: not: valid: fleet: yaml: [[[\n",
+        )
+        .unwrap();
+        assert_eq!(
+            self_orch_status(&home, "lead"),
+            SelfOrchStatus::Unknown,
+            "#1744-M7: an unreadable teams config must be Unknown (fail-closed), not No"
         );
-        assert!(
-            !is_self_orchestrator(&home, "dev"),
-            "a regular member is NOT its own orchestrator"
-        );
-        assert!(
-            !is_self_orchestrator(&home, "unknown"),
-            "an agent in no team is not a self-orchestrator"
-        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// #1744-M7: `find_team_for` is deterministic when a member appears on more
+    /// than one team — it picks the alphabetically-first team name on every call,
+    /// so the self-orch verdict can't flip between runs/restarts. Here `shared`
+    /// is on `ateam` (orch=a1) and `bteam` (orch=shared); sorted-first `ateam`
+    /// wins, so `shared` is consistently NOT a self-orchestrator.
+    #[test]
+    fn find_team_for_deterministic_across_multi_team_1744_m7() {
+        let home = tmp_home("m7-determinism");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "teams:\n  \
+               bteam:\n    members: [shared, b1]\n    orchestrator: shared\n  \
+               ateam:\n    members: [shared, a1]\n    orchestrator: a1\n",
+        )
+        .unwrap();
+        for _ in 0..20 {
+            assert_eq!(
+                find_team_for(&home, "shared").map(|t| t.name),
+                Some("ateam".to_string()),
+                "#1744-M7: multi-team lookup must deterministically pick the sorted-first team"
+            );
+            assert_eq!(
+                self_orch_status(&home, "shared"),
+                SelfOrchStatus::No,
+                "#1744-M7: deterministic team → stable self-orch verdict"
+            );
+        }
         let _ = std::fs::remove_dir_all(&home);
     }
 


### PR DESCRIPTION
<!-- LOC-EST: 420-480 -->

## What & why

**PR-A foundation** for the #1744 orchestrator-down safety net. Every escalation P0 flows through `active_channel()` and `is_self_orchestrator()` — both are upstream of H1/H4/H5 and the already-merged H2/H3, and both silently failed in two ways this PR closes. Fixing them first is what makes the rest of the cluster actually reachable.

### M6 — multi-channel escalation reachability
`active_channel()` returns `None` whenever ZERO **or MULTIPLE** channels are registered, so once a fleet runs telegram + discord every escalation `if let Some(ch) = active_channel()` silently no-ops — exactly when an orchestrator-down P0 must get through.

- New `channel::resolve_escalation_channels()` + `notify_all_escalation_channels()` fan one P0 out to **every** registered channel (deliver-twice beats deliver-never).
- Routed the **Error-severity escalation P0 sites** through it: self-orch crash, generic member crash, self-orch hung, AuthError self-orch, ServerRateLimit retry-exhausted, inject-fail exhausted, interactive-stall page.
- **Non-P0** notices (the Info "agent ready" recovery ping) deliberately keep `active_channel()` so the fan-out can never leak into routine traffic.
- Operator-designated `primary_channel()` is **deferred** (routing nicety, not a reachability fix).

### M7 — deterministic + fail-closed self-orch verdict
`is_self_orchestrator()` was non-deterministic (HashMap `.iter().find()` → arbitrary team for a multi-team member) and **fail-silent** (`load_fleet`'s `unwrap_or_default()` turned a transient teams.yaml read failure into "no team" → every self-orch escalation silently skipped).

- `try_load_fleet()` → `Result` (missing file = determinate empty = `No`; existing-but-corrupt = `Err` = `Unknown`).
- `SelfOrchStatus { Yes, No, Unknown }` + `self_orch_status()`; team lookup now deterministic (sorted team-name order).
- Consumers pick their safe side for `Unknown`: the no-peer **hung + AuthError** paths escalate on `Yes|Unknown` (missing a leaderless P0 is the costly failure); the **crash** path stays conservative (`Yes` only → self-orch P0, else generic `recent>=2`).
- Supervisor **AuthError** path included — on an unreadable teams config it **fails closed** (escalate to operator: can't identify a peer to relay to, and AuthError is operator-only).
- The orphaned boolean `is_self_orchestrator` is removed (both call sites moved to the 3-state).

## Tests
M6 multi-channel fan-out (every channel receives the P0; single→1, zero→0 no panic); M7 Yes/No/Unknown verdicts, deterministic multi-team lookup, supervisor AuthError fail-closed on an unreadable config. Existing escalation tests stay green (110 passed across teams/channel/supervisor/crash_respawn/hang_detection).

## Coordination
PR-B (H4/H5, @fixup-dev-2) consumes `notify_all_escalation_channels` + `self_orch_status` per the agreed contract; it will extend `PersistedEscalation` with `failed_escalated` (this PR does not touch that struct), rebasing on top.

## Local verification
`cargo fmt --check`, `cargo clippy --all-targets --features tray,discord -- -D warnings`, targeted test sets all green. ⚠️ See PR comment re: the full `cargo test --tests` preflight step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)