### PR TITLE
fix(#1755): auto-fetch origin/<branch> before creating a worktree branch

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -688,10 +688,38 @@ pub(crate) fn ensure_branch_exists(
         }
         return Ok((false, fetched_ok));
     }
-    // Step 2: try create from `from_ref` (no fetch yet — zero network
-    // on the fast path where origin/main is already a valid local ref).
+    // Step 2: create from `from_ref`. #1755: a remote-tracking `from_ref` like
+    // `origin/main` ALWAYS resolves as a local ref, so a bare `git branch` here
+    // silently bases the new branch on a STALE local ref (whatever was last
+    // fetched) — the reverse-revert hazard where a fresh checkout starts behind
+    // main and would clobber merges that landed since. Refresh the remote ref
+    // FIRST (mirrors the #869 branch-EXISTS path above) so the create lands on
+    // current `origin/<x>`. Best-effort: a fetch failure (offline / no-remote
+    // fixture) leaves the local ref as-is and the create still succeeds against
+    // whatever's present (degraded but functional, same contract as #869).
+    // `fetch_attempted` reports SUCCESS (matches #869's `fetched_ok`), so the
+    // no-remote test fixtures keep reporting `false`.
+    let mut create_fetched = false;
+    if let Some(remote_branch) = from_ref.strip_prefix("origin/") {
+        let fetch_start = std::time::Instant::now();
+        let fetch_out = crate::git_helpers::git_bypass_timeout(
+            source,
+            &["fetch", "origin", remote_branch, "--quiet"],
+            std::time::Duration::from_secs(60),
+        );
+        create_fetched = matches!(&fetch_out, Ok(o) if o.status.success());
+        crate::event_log::log(
+            home,
+            "ensure_branch_fetch",
+            actor,
+            &format!(
+                "branch={branch} from_ref={from_ref} duration_ms={} ok={create_fetched} (#1755 pre-create refresh)",
+                fetch_start.elapsed().as_millis()
+            ),
+        );
+    }
     match crate::git_helpers::git_bypass(source, &["branch", branch, from_ref]) {
-        Ok(o) if o.status.success() => Ok((true, false)),
+        Ok(o) if o.status.success() => Ok((true, create_fetched)),
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr).to_string();
             if stderr.contains("already exists") {

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -75,6 +75,104 @@ fn setup_test_repo(home: &std::path::Path, agent: &str) -> std::path::PathBuf {
     repo
 }
 
+/// #1755: `ensure_branch_exists` must REFRESH a remote-tracking `from_ref`
+/// (`origin/main`) before creating a new branch — otherwise a fresh checkout
+/// starts on a stale local ref and silently reverse-reverts merges that landed
+/// since the last fetch. Uses a REAL local bare origin (unlike `setup_test_repo`
+/// whose `file:///dev/null` origin makes fetch fast-fail) so the fetch actually
+/// advances `refs/remotes/origin/main`.
+#[test]
+fn ensure_branch_exists_refreshes_stale_origin_before_create_1755() {
+    let home = std::env::temp_dir().join(format!("agend-1755-freshbase-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    let workspace = crate::paths::workspace_dir(&home);
+    std::fs::create_dir_all(&workspace).ok();
+    let origin = workspace.join("o.git");
+    let repo = workspace.join("agent");
+
+    let git = |args: &[&str], dir: &std::path::Path| -> String {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git spawn");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    // Bare origin + a source repo wired to it.
+    std::fs::create_dir_all(&origin).ok();
+    git(&["init", "--bare", "-b", "main"], &origin);
+    std::fs::create_dir_all(&repo).ok();
+    git(&["init", "-b", "main"], &repo);
+    git(
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+        &repo,
+    );
+    git(
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "A",
+        ],
+        &repo,
+    );
+    let sha_a = git(&["rev-parse", "HEAD"], &repo);
+    git(&["push", "-q", "origin", "main"], &repo);
+
+    // Advance origin/main to B, then force the LOCAL remote-tracking ref STALE
+    // back to A — simulating "someone merged after my last fetch".
+    git(
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "B",
+        ],
+        &repo,
+    );
+    let sha_b = git(&["rev-parse", "HEAD"], &repo);
+    git(&["push", "-q", "origin", "main"], &repo);
+    git(&["update-ref", "refs/remotes/origin/main", &sha_a], &repo);
+    assert_ne!(sha_a, sha_b);
+    assert_eq!(
+        git(&["rev-parse", "refs/remotes/origin/main"], &repo),
+        sha_a,
+        "precondition: local origin/main must be STALE at A"
+    );
+
+    // The fix: fetch (origin/main → B) BEFORE creating, so the new branch lands
+    // on FRESH main (B), not the stale local ref (A).
+    let (created, fetched) =
+        super::ensure_branch_exists(&home, &repo, "feat/x-1755", "origin/main", "agent")
+            .expect("ensure_branch_exists ok");
+    assert!(created, "branch must be auto-created");
+    assert!(
+        fetched,
+        "#1755: must fetch (real origin reachable) before create"
+    );
+    assert_eq!(
+        git(&["rev-parse", "refs/heads/feat/x-1755"], &repo),
+        sha_b,
+        "#1755: new branch must base on FRESH origin/main (B), not the stale local ref (A)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn dispatch_with_branch_creates_binding_and_worktree() {
     let home = std::env::temp_dir().join(format!("agend-s53-prod-{}-bind", std::process::id()));


### PR DESCRIPTION
## What
Fix #1755: a fresh `repo checkout` / task dispatch starts on a **stale base**, silently reverse-reverting merges that landed since the local repo's last fetch.

## Root cause
`dispatch_hook::ensure_branch_exists`'s branch-**create** path runs `git branch <new> origin/main` with **no fetch** — and since `origin/main` is a local remote-tracking ref that *always* resolves, it takes the "fast path (zero network)" and bases the new branch on whatever stale SHA the local `refs/remotes/origin/main` last held. The fetch was only a *fallback* for unresolvable refs (never triggered for origin/main). The sibling #869 branch-**exists** path already fetches + `update-ref`s; only create was missed.

This bit real work twice in one session (PR #1754 base 1 commit stale; PR #1758 base stale by a whole sibling merge), and reviewer-2's #1752 too — the manual `git fetch && git diff --stat` pre-push workaround was fragile.

## Fix
Before `git branch`, when `from_ref` is `origin/<x>`, best-effort `git fetch origin <x> --quiet` (60s timeout, mirroring #869) so the create lands on **current** main:
- `fetch_attempted` reports **success** (matches #869's `fetched_ok`) → the no-remote test fixtures (`file:///dev/null` origin → fetch fast-fails) keep reporting `false`, so existing assertions are unchanged.
- A fetch failure (offline) falls back to the local ref — degraded but functional, same contract as #869.

**One function, both entry points:** `ensure_branch_exists` is shared by `repo checkout` (ci/mod.rs:123) *and* the `send kind=task` dispatch hook (dispatch_hook:416), so this fixes the stale base for both. Cost: one fetch per branch-creation (<1s typical, **once-per-checkout, not per-tick**).

## Test
`ensure_branch_exists_refreshes_stale_origin_before_create_1755`: builds a **real local bare origin**, advances `origin/main` to commit B while forcing the local remote-tracking ref **stale at A**, then asserts a newly-created branch bases on **B (fresh)**, not A (stale) — and that `fetched=true`. Existing create/EXISTS-path tests pass unchanged (their `file:///dev/null` origin fast-fails the fetch → `fetch_attempted=false` preserved).

Preflight: fmt + clippy (`tray`, `tray,discord`, -D warnings) + full `cargo test --tests` (real git) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
