### PR TITLE
test(runtime_config): serialize global-singleton tests to stop CI flake

### DIFF
--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -237,6 +237,13 @@ pub fn keys() -> Vec<String> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    // These tests mutate the process-global `RUNTIME_CONFIG` singleton via
+    // `reload()`, so running them concurrently lets one test's reload clobber
+    // another's value between its own `reload` + `get_key` — an intermittent
+    // assertion flake that reddened UNRELATED PRs (#1752, #1758) and forced
+    // churny CI reruns. Serialize the global-touching ones under a named group
+    // (keeps unrelated `#[serial]` tests in other modules running in parallel).
+    use serial_test::serial;
 
     #[test]
     fn default_values() {
@@ -246,6 +253,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(runtime_config)]
     fn set_and_get_key() {
         let dir = std::env::temp_dir().join("agend-test-runtime-config");
         std::fs::create_dir_all(&dir).ok();
@@ -270,6 +278,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(runtime_config)]
     fn set_hang_auto_recovery_enabled() {
         let dir = std::env::temp_dir().join("agend-test-runtime-config-hang");
         std::fs::create_dir_all(&dir).ok();
@@ -287,6 +296,7 @@ mod tests {
     /// `set`/persist/reload path as the other gates (the `config` MCP tool reaches
     /// `set`), so the operator can flip it off without a rebuild.
     #[test]
+    #[serial(runtime_config)]
     fn show_pane_state_default_on_and_toggleable() {
         assert!(
             RuntimeConfig::default().show_pane_state,
@@ -308,6 +318,7 @@ mod tests {
     /// from the hand-maintained description is what this change fixes. Every key
     /// `keys()` reports must also be a valid `set` target (round-trip via get_key).
     #[test]
+    #[serial(runtime_config)]
     fn keys_cover_all_settable_keys_including_show_pane_state() {
         let ks = keys();
         assert!(


### PR DESCRIPTION
## What
Root-fix the `runtime_config::tests` CI flake that has been reddening **unrelated** PRs (#1752, #1758 ubuntu) and forcing churny reruns — the same operator-flagged "瞎忙 churn" class as #1755.

## Root cause
`set_and_get_key`, `set_hang_auto_recovery_enabled`, `show_pane_state_default_on_and_toggleable`, and `keys_cover_all_settable_keys_including_show_pane_state` mutate the **process-global** `RUNTIME_CONFIG` singleton (`OnceLock<RwLock<…>>`) via `reload()`. Run concurrently (cargo's default), one test's `reload()` clobbers the global between another's `reload` + `get_key`, so the second reads the wrong value → intermittent assertion failure. No other test in the suite reloads the global, so the racers are exactly these four.

## Fix
Mark the four global-touching tests `#[serial(runtime_config)]` (serial_test, already a dev-dep + established pattern). The **named group** serializes only these against each other — unrelated `#[serial]` tests in other modules keep running in parallel.

Test-infra only; zero runtime change.

## Verify
`runtime_config::tests` 5/5 green in a loop; fmt + clippy (`tray`, `tray,discord`, -D warnings) + full `cargo test --tests` all green. Base = latest main (incl. #1755).

🤖 Generated with [Claude Code](https://claude.com/claude-code)