### PR TITLE
fix(#1757): exempt hard network errors from the #1450 red anchor

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -804,6 +804,15 @@ impl StateTracker {
                     let anchor_fail = self.anchor_on_red
                         && high_fp
                         && !fg.is_empty()
+                        // #1757: exempt hard network errors from the red anchor —
+                        // codex/gemini render `InvalidHTTPResponse`/`ECONNRESET`/…
+                        // in DEFAULT/grey (not red), so the anchor wrongly
+                        // suppressed REAL faults → no ServerRateLimit transition →
+                        // no auto-retry → stuck agent. Scoped: the FP-prone
+                        // api_error/overloaded/context HIGH_FP tokens stay
+                        // red-anchored; the net-error residual FP is bounded by
+                        // #1518/#1586/#1760 (see `patterns::is_net_error_match`).
+                        && !crate::state::patterns::is_net_error_match(matched)
                         && !matched_span_has_red(screen_text, matched, fg);
                     // #1518 position gate: a HIGH_FP marker that has scrolled out
                     // of the live bottom-N rows (e.g. an ApiError / ServerRateLimit

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -29,6 +29,26 @@ use regex::Regex;
 // copy), keeping byte-identity with the legacy compile_for arm that also uses it.
 pub(crate) const SERVER_RATE_LIMIT_NET_ERRORS: &str = r"ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|proxy.*disconnect";
 
+/// #1757: is `matched` one of the [`SERVER_RATE_LIMIT_NET_ERRORS`] tokens?
+///
+/// These hard network faults are rendered in DEFAULT/grey (not red) by codex /
+/// gemini (observed `span_fg=[Default,...]` for `InvalidHTTPResponse` /
+/// `ECONNRESET`), so the #1450 red anchor wrongly suppressed REAL faults → no
+/// `ServerRateLimit` transition → no auto-retry → stuck agent (worst when the
+/// operator is away). The anchor exempts these tokens (fails open like the
+/// empty-`fg` / `Shell` paths). Scoped on purpose: the FP-prone
+/// `api_error`/`overloaded`/context HIGH_FP tokens STAY red-anchored. The
+/// residual net-error FP (these tokens can appear in source/logs/prose — e.g. an
+/// agent viewing THIS file) is bounded by the #1518 live-tail gate, #1586, and
+/// the #1760 nudge cap, so the cost asymmetry (severe stuck-agent vs rare,
+/// self-correcting spurious `continue`) favors the exemption.
+pub(crate) fn is_net_error_match(matched: &str) -> bool {
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(SERVER_RATE_LIMIT_NET_ERRORS).expect("net-error regex compiles"))
+        .is_match(matched)
+}
+
 /// Compiled patterns for one backend.
 pub struct StatePatterns {
     /// (state, regex) pairs in priority order (highest priority first).

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3151,12 +3151,15 @@ fn network_error_patterns_all_backends() {
     }
 }
 
-/// #1587: lock the bounded-acceptable ServerRateLimit FP behavior at the live
-/// red-anchored gate. A real network error rendered RED still latches
-/// ServerRateLimit (the auto-retry path these tokens exist for); the SAME
-/// FP-prone phrase in plain (non-red) prose does NOT latch. This is the residual
-/// we deliberately do NOT chase with an unsafe blind tighten — see the
-/// `SERVER_RATE_LIMIT_NET_ERRORS` doc for why (FN risk, no per-backend fixtures).
+/// #1587 → #1757: a real network error rendered RED latches ServerRateLimit (the
+/// auto-retry path these tokens exist for). #1757 SUPERSEDED the original #1587
+/// "prose-in-default does NOT latch" half: codex/gemini render hard net errors in
+/// DEFAULT (not red), so the red anchor was suppressing REAL faults → no
+/// auto-retry → stuck agent. Net-error tokens are now exempt from the red anchor,
+/// so the same wording in DEFAULT ALSO latches; the residual prose/source FP is
+/// bounded by #1518/#1586/#1760. The dropped `network error` token still must not
+/// trigger. (The FP-prone api_error/overloaded/context HIGH_FP tokens remain
+/// red-anchored — see `codex_model_unsupported_red_anchor_fp_boundary_1634 (a non-net-error HIGH_FP still red-anchored)`.)
 #[test]
 fn server_rate_limit_red_anchor_fp_boundary_1587() {
     // Realistic Node rendering carries an `Error:` label prefix.
@@ -3172,13 +3175,22 @@ fn server_rate_limit_red_anchor_fp_boundary_1587() {
         "#1587: a real network error rendered red must still latch ServerRateLimit"
     );
 
-    // Same wording WITHOUT red (prose / dev-log mention) → must NOT latch.
+    // #1757: net-error tokens are now EXEMPT from the red anchor. codex/gemini
+    // render `InvalidHTTPResponse`/`ECONNRESET`/`socket hang up` in DEFAULT/grey
+    // (not red), so the anchor wrongly suppressed REAL faults → no auto-retry →
+    // stuck agent. The SAME wording in DEFAULT therefore now LATCHES — the #1587
+    // net-error red-anchor boundary is deliberately superseded; the residual
+    // prose/source FP (these tokens appear in code/logs) is bounded by the #1518
+    // live-tail gate, #1586, and the #1760 nudge cap. The FP-prone
+    // api_error/overloaded/context HIGH_FP tokens STAY red-anchored — see
+    // `codex_model_unsupported_red_anchor_fp_boundary_1634 (a non-net-error HIGH_FP still red-anchored)`.
     let mut t2 = StateTracker::new(Some(&Backend::Codex));
     t2.feed_with_fg(screen, &vec![CellFg::Default; n]);
-    assert_ne!(
+    assert_eq!(
         t2.get_state(),
         AgentState::ServerRateLimit,
-        "#1587: same wording without red must NOT latch (red-anchor FP boundary)"
+        "#1757: a net-error rendered DEFAULT must STILL latch ServerRateLimit \
+         (exempt from the red anchor — real faults are not always rendered red)"
     );
 
     // Dropped token regression: `network error` (the unverified #1136 guess) is
@@ -3189,6 +3201,29 @@ fn server_rate_limit_red_anchor_fp_boundary_1587() {
         t3.get_state(),
         AgentState::ServerRateLimit,
         "#1587: bare `network error` was dropped — must no longer trigger ServerRateLimit"
+    );
+}
+
+/// #1757 regression: the EXACT failure from the issue. codex hit a real
+/// `API Error: InvalidHTTPResponse fetching "http://…"` that VTerm recorded as
+/// `span_fg=[Default,…]` (the backend renders it default/grey, not red). Before
+/// #1757 the #1450 red anchor suppressed the transition → no ServerRateLimit →
+/// no auto-retry → the agent sat stuck (worst case: operator away). The net-error
+/// exemption must let a DEFAULT-rendered net error latch ServerRateLimit so
+/// auto-retry fires.
+#[test]
+fn net_error_invalidhttpresponse_default_latches_1757() {
+    let screen = "API Error: InvalidHTTPResponse fetching \"http://127.0.0.1:3456/v1/messages\".";
+    let n = screen.chars().count();
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    // All-DEFAULT fg — exactly what VTerm recorded for the real fault in the
+    // issue's logs (`span_fg=[Default × 19]`).
+    t.feed_with_fg(screen, &vec![CellFg::Default; n]);
+    assert_eq!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#1757: a real InvalidHTTPResponse rendered DEFAULT must latch \
+         ServerRateLimit (→ auto-retry), not be suppressed by the red anchor"
     );
 }
 


### PR DESCRIPTION
## What
Fix #1757: the #1450 VTerm color anchor was **suppressing real network errors** (`InvalidHTTPResponse` / `ECONNRESET` / …) → no `ServerRateLimit` transition → auto-retry never fired → the agent sat stuck (worst case: operator away).

## RCA (credit: cheerc — verified against code + the issue's logs)
`SERVER_RATE_LIMIT_NET_ERRORS` maps to `AgentState::ServerRateLimit`, a `HIGH_FP` state, so #1450 requires the matched text to contain ≥1 red cell (`matched_span_has_red`). But codex/gemini render these hard net faults in **DEFAULT/grey, not red** (observed `span_fg=[Default × 19]` for the real `API Error: InvalidHTTPResponse fetching "http://…"`). `is_red()` only matches `CellFg::Red` (achromatic default/white/grey → not red), so `anchor_fail` fired → transition suppressed. cheerc's core RCA is correct.

## ⚠ Correcting the issue's fix-framing (premise-check)
The issue proposed a **blanket bypass** ("net errors are highly specific, unlikely to be FP"). That framing is **overstated** — the issue's *own* gemini `ECONNRESET` log is in fact a **false positive that #1450 correctly suppressed**: the agent was **viewing patterns.rs source** (`const SERVER_RATE_LIMIT_NET_ERRORS: &str = r"ECONNRESET|…"`), not erroring. Net-error tokens *do* appear in source/logs/prose, so a blanket bypass reopens FPs.

A **scoped exemption** is the right call because the residual net-error FP is now **bounded** by #1518 (live-tail gate) + #1586 + the #1760 nudge cap — a few self-correcting spurious `continue`s. The cost asymmetry (severe + common stuck-agent false-negative vs rare + bounded FP) favors the exemption.

## Fix
Exempt only the net-error tokens from the red anchor (fail-open, like the empty-fg / `Shell` paths) via a new `patterns::is_net_error_match`:
```rust
let anchor_fail = self.anchor_on_red && high_fp && !fg.is_empty()
    && !crate::state::patterns::is_net_error_match(matched)   // #1757
    && !matched_span_has_red(screen_text, matched, fg);
```
**Scoped:** the FP-prone `api_error` / `overloaded` / context / model-unsupported HIGH_FP tokens **stay red-anchored**.

## Tests
- `net_error_invalidhttpresponse_default_latches_1757` — the exact codex failure (`API Error: InvalidHTTPResponse fetching …` rendered all-DEFAULT) now latches `ServerRateLimit` → auto-retry.
- `server_rate_limit_red_anchor_fp_boundary_1587` **rewritten** — net-error in DEFAULT now *latches* (the #1587 net-error red-anchor boundary is deliberately superseded; doc updated). Red still latches; the dropped `network error` token still doesn't.
- **Scope preserved** by the unchanged `codex_model_unsupported_red_anchor_fp_boundary_1634` — a *non*-net-error HIGH_FP (`ModelUnsupported`) is still suppressed in DEFAULT, proving the exemption is scoped, not a blanket bypass.
- Preflight: fmt + clippy (`tray`, `tray,discord`, -D warnings) + full `cargo test --tests` all green. Base = latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
