### PR TITLE
test(ci-flake): serialize the last two global-state test races (anti-churn)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -386,6 +386,12 @@ mod tests {
     use super::*;
     use crate::layout::{Layout, Pane, PaneSource, Tab};
     use crate::vterm::VTerm;
+    // #1763 residual: `config_set_via_palette_*` mutates the process-global
+    // `RUNTIME_CONFIG` (via `runtime_config::set` → `*global().write()`), the same
+    // singleton the `runtime_config::tests` serialize on. Join the SAME
+    // `runtime_config` serial group so this cross-module test can't clobber their
+    // global mid-assertion.
+    use serial_test::serial;
 
     fn test_pane(id: usize, agent: &str, fleet_name: Option<&str>) -> Pane {
         Pane {
@@ -469,6 +475,7 @@ mod tests {
     /// and persist. Assert against the written file (deterministic — avoids the
     /// process-global cache shared across parallel tests).
     #[test]
+    #[serial(runtime_config)]
     fn config_set_via_palette_persists_to_runtime_config() {
         let dir =
             std::env::temp_dir().join(format!("agend-test-cmd-config-{}", std::process::id()));

--- a/src/daemon/retention/decisions.rs
+++ b/src/daemon/retention/decisions.rs
@@ -148,6 +148,13 @@ pub(super) fn sweep(home: &Path) -> usize {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    // The `sweep_*` tests set/remove the process-global `AGEND_RETENTION_CUTOVER`
+    // env var that `sweep()` reads — running them concurrently lets one test's
+    // `remove_var` clear the gate before another's `sweep()` reads it, so the
+    // latter early-returns 0 and its `assert_eq!(archived, 1)` flakes (reddened
+    // #1752 CI). Serialize them under a named group (mirrors capture.rs's
+    // `#[serial(capture_env)]`); non-env retention tests stay parallel.
+    use serial_test::serial;
 
     fn tmp_home(name: &str) -> std::path::PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};
@@ -211,6 +218,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(retention_cutover)]
     fn sweep_archives_expired_decisions() {
         let home = tmp_home("sweep-expired");
         write_decision(&home, "d-old", 100, &[]);
@@ -231,6 +239,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(retention_cutover)]
     fn sweep_respects_protected_tags() {
         let home = tmp_home("sweep-protected");
         write_decision(&home, "d-protected", 100, &["SPRINT_99"]);
@@ -258,6 +267,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(retention_cutover)]
     fn sweep_enforces_14d_floor() {
         let home = tmp_home("sweep-floor");
         // Decision with ttl_days=1 but only 10 days old — 14d floor protects it


### PR DESCRIPTION
<!-- LOC-EST: 15-25 -->

## What & why

Anti-churn cleanup: closes the **two CI flake residuals** surfaced during the #1763 review. Both are the same class — a test mutating **process-global state** racing a concurrent reader — and both reddened unrelated PRs (#1752/#1758), forcing rework churn. Test-infra only; no production code touched.

### 1. runtime_config residual (the one I flagged in #1763)
`app/commands::config_set_via_palette_persists_to_runtime_config` reaches `runtime_config::set` → `*global().write()`, mutating the same `RUNTIME_CONFIG` singleton the `runtime_config::tests` serialize on (#1763) — but it was **not** in that serial group, so it could clobber their global mid-assertion (e.g. flip `show_pane_state` between `show_pane_state_default_on_and_toggleable`'s `reload` and `get_key`). Add `#[serial(runtime_config)]`.

### 2. retention flake — investigated, a REAL race (not one-off)
The three `sweep_*` tests in `daemon::retention::decisions` `set_var`/`remove_var` the process-global `AGEND_RETENTION_CUTOVER` that `sweep()` reads (decisions.rs:83). Run concurrently, **one test's `remove_var` clears the gate before another's `sweep()` reads it** → that `sweep()` early-returns `0` → `assert_eq!(archived, 1)` fails. This is exactly the `sweep_respects_protected_tags` failure observed in #1752 CI. Serialize the three under `#[serial(retention_cutover)]` (mirrors capture.rs's `#[serial(capture_env)]` env-var convention). The non-env retention test (`archive_serializes_with_decision_lock`) stays parallel.

## Verification
- Mechanism: both are deterministic process-global races (cited above).
- `cargo fmt --check` ✅, `cargo clippy --all-targets --features tray,discord -- -D warnings` ✅.
- Stress: the combined `retention::decisions + runtime_config + app::commands::config` set passes **8/8** under repeated concurrent runs post-fix (intermittently red pre-fix).
- Pre-push `fetch + diff --stat origin/main..HEAD` → only `app/commands.rs` + `daemon/retention/decisions.rs` (no dragged files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)