### PR TITLE
fix(#1744 PR-B): terminal-Failed (H4) + OOM-SignalKill (H5) self-orch escalation

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1497,6 +1497,16 @@ enum ExitKind {
     Crash,
 }
 
+/// #1744-H5: should an external signal-kill of `name` escalate a leaderless-team
+/// P0? Fail-closed via `self_orch_status` (`Yes`|`Unknown` fire, `No` skip).
+/// `home == None` can't read the teams config → can't determine self-orch → skip
+/// (a SignalKill normally carries a home; `None` is an extreme / test path).
+fn signal_kill_self_orch_should_escalate(home: &Option<std::path::PathBuf>, name: &str) -> bool {
+    home.as_ref()
+        .map(|h| crate::teams::self_orch_status(h, name) != crate::teams::SelfOrchStatus::No)
+        .unwrap_or(false)
+}
+
 fn classify_exit(exit_code: Option<i32>) -> ExitKind {
     match exit_code {
         Some(0) | Some(130) => ExitKind::UserExit,
@@ -1737,6 +1747,34 @@ fn handle_pty_close(
             }
         }
         ExitKind::SignalKill => {
+            // #1744-H5: an external signal-kill (OOM exit 137 / SIGTERM 143) of a
+            // self-orchestrator is a SILENT leaderless death — cleanup_agent just
+            // removes it, emitting no crash event / notify. A graceful daemon
+            // shutdown (`is_shutdown`) and a deleted agent both early-returned
+            // above, so this branch only ever sees an UNEXPECTED external kill of
+            // a live agent. Escalate a P0 before cleanup. Fail-closed via
+            // self_orch_status (Yes|Unknown fire, No skip); home=None can't
+            // determine self-orch → skip.
+            if signal_kill_self_orch_should_escalate(home, name) {
+                tracing::error!(
+                    agent = name,
+                    exit_code = exit_code.unwrap_or(0),
+                    "#1744-H5: self-orchestrator killed by external signal — escalating P0"
+                );
+                let msg = format!(
+                    "🛑 Self-orchestrator `{name}` was killed by an external signal (OOM / \
+                     SIGKILL, exit {code}) and removed — it will NOT be auto-respawned \
+                     (a signal-kill is not a crash). Its team is leaderless and no peer can \
+                     relay: manual operator intervention is required.",
+                    code = exit_code.unwrap_or(0),
+                );
+                crate::channel::notify_all_escalation_channels(
+                    name,
+                    crate::channel::NotifySeverity::Error,
+                    &msg,
+                    false,
+                );
+            }
             cleanup_agent(name, id, registry, home);
         }
         ExitKind::Crash => {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1906,3 +1906,36 @@ fn broadcast_delivers_to_healthy_subscriber() {
         "output must be delivered"
     );
 }
+
+/// #1744-H5: an external signal-kill (OOM) escalates a leaderless-team P0 only
+/// for a self-orchestrator — fail-closed via `self_orch_status` (Yes|Unknown
+/// fire, No skip), and `home == None` (can't read teams) skips.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn signal_kill_escalates_only_for_self_orch_1744_h5() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-h5-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    crate::teams::create(
+        &home,
+        &serde_json::json!({"name": "t", "members": ["lead", "dev"], "orchestrator": "lead"}),
+    );
+
+    assert!(
+        signal_kill_self_orch_should_escalate(&Some(home.clone()), "lead"),
+        "a self-orchestrator's OOM must escalate (Yes → fire)"
+    );
+    assert!(
+        !signal_kill_self_orch_should_escalate(&Some(home.clone()), "dev"),
+        "a non-orchestrator member's OOM must stay silent (No → skip)"
+    );
+    assert!(
+        !signal_kill_self_orch_should_escalate(&None, "lead"),
+        "home=None can't determine self-orch → skip"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -47,7 +47,14 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
     let self_orch = crate::teams::self_orch_status(home, crashed_name);
     let is_self_orch = self_orch == crate::teams::SelfOrchStatus::Yes;
 
-    let (should_respawn, delay, should_notify, fire_self_orch_p0, escalation_snapshot) = {
+    let (
+        should_respawn,
+        delay,
+        should_notify,
+        fire_self_orch_p0,
+        fire_terminal_p0,
+        escalation_snapshot,
+    ) = {
         let reg = agent::lock_registry(&ctx.registry);
         match reg.get(&instance_id) {
             Some(handle) => {
@@ -61,11 +68,24 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
                 // untouched.
                 let fire_p0 = is_self_orch && core.health.self_orch_crash_should_notify();
                 let (respawn, delay, notify) = core.health.record_crash();
+                // #1744-H4: a terminal Failed (max-retries) self-orchestrator crash
+                // is a PERMANENT leaderless death. record_crash returns notify=true
+                // ("don't respawn, do notify"), but fire_p0 is cooldown-gated and
+                // the generic notify branch below is `!is_self_orch` — so without
+                // this it pages NEITHER. Fire a once-off, cooldown-EXEMPT terminal
+                // P0, fail-closed (Yes|Unknown fire, No skip), latched via the
+                // PERSISTED `failed_escalated` so a restart (which rehydrates the
+                // crash budget but not `state`) doesn't re-page the same death.
+                let fire_terminal =
+                    should_fire_terminal_p0(respawn, self_orch, core.health.failed_escalated);
+                if fire_terminal {
+                    core.health.failed_escalated = true;
+                }
                 // #1744-H2: snapshot the (just-mutated) escalation state under the
                 // lock; persisted lock-free below so the crash budget + cooldown
-                // survive a daemon restart.
+                // (+ #1744-H4 failed_escalated) survive a daemon restart.
                 let snap = core.health.escalation_snapshot();
-                (respawn, delay, notify, fire_p0, snap)
+                (respawn, delay, notify, fire_p0, fire_terminal, snap)
             }
             None => {
                 tracing::warn!(agent = %crashed_name, "not in registry, skipping");
@@ -80,7 +100,12 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
     // #1701: a self-orchestrator crash escalates to the operator on EVERY crash
     // (cooldown-gated) — the team is leaderless until respawn and no peer can
     // relay. A non-orchestrator agent keeps the generic recent>=2 crash notify.
-    if fire_self_orch_p0 {
+    if fire_terminal_p0 {
+        // #1744-H4: terminal-Failed self-orch — takes precedence over the
+        // per-crash page (its wording is "permanent, won't respawn", not "until
+        // respawn"). Once-off via the persisted `failed_escalated` latch.
+        notify_self_orch_terminal(crashed_name);
+    } else if fire_self_orch_p0 {
         notify_self_orch_crash(crashed_name, &instance_id, &ctx.registry);
     } else if !is_self_orch && should_notify {
         notify_crash(crashed_name, &instance_id, &ctx.registry);
@@ -148,6 +173,45 @@ fn notify_self_orch_crash(
     );
     // #1744-M6: every registered channel — a leaderless-orchestrator P0 must not
     // be dropped just because the fleet runs multiple channels.
+    crate::channel::notify_all_escalation_channels(
+        crashed_name,
+        NotifySeverity::Error,
+        &msg,
+        false,
+    );
+}
+
+/// #1744-H4: should the terminal-Failed self-orchestrator P0 fire? True iff the
+/// agent will NOT respawn (max-retries Failed), it is a self-orchestrator
+/// (fail-closed: `Yes`|`Unknown` fire, `No` skip — a leaderless death is too
+/// costly to miss on an indeterminate teams read), and it has not already been
+/// terminally paged (`failed_escalated`, persisted for cross-restart once-off).
+fn should_fire_terminal_p0(
+    should_respawn: bool,
+    self_orch: crate::teams::SelfOrchStatus,
+    failed_escalated: bool,
+) -> bool {
+    !should_respawn && self_orch != crate::teams::SelfOrchStatus::No && !failed_escalated
+}
+
+/// #1744-H4: terminal-Failed self-orchestrator P0 — fired exactly ONCE when a
+/// self-orchestrator exhausts its respawn budget and will NOT be respawned. The
+/// team is permanently leaderless until the operator intervenes. Distinct from
+/// the per-crash [`notify_self_orch_crash`] in WORDING (permanent death, not
+/// "until respawn") and TRIGGER (cooldown-EXEMPT once-off, latched on the
+/// persisted `failed_escalated`). Routes through PR-A's
+/// `notify_all_escalation_channels` (#1744-M6) so the page reaches every channel.
+fn notify_self_orch_terminal(crashed_name: &str) {
+    tracing::error!(
+        agent = %crashed_name,
+        "#1744-H4: self-orchestrator PERMANENTLY FAILED (respawn budget exhausted) — escalating terminal P0"
+    );
+    let msg = format!(
+        "🛑 Self-orchestrator `{crashed_name}` has PERMANENTLY FAILED — it crashed past \
+         its auto-retry budget and will NOT be respawned. Its team is leaderless and no \
+         peer can relay this: manual operator intervention is required (restart / reassign \
+         the orchestrator)."
+    );
     crate::channel::notify_all_escalation_channels(
         crashed_name,
         NotifySeverity::Error,
@@ -276,5 +340,34 @@ fn respawn_agent_worker(
         Err(e) => {
             tracing::warn!(agent = %config.name, error = %e, "respawn failed");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_fire_terminal_p0;
+    use crate::teams::SelfOrchStatus;
+
+    /// #1744-H4: the terminal self-orch P0 fires for a Failed (no-respawn)
+    /// self-orchestrator — fail-closed (Yes|Unknown), skipped for No / non-terminal,
+    /// and exactly once (the persisted `failed_escalated` latch suppresses re-page,
+    /// so a daemon restart doesn't re-page the same permanent death).
+    #[test]
+    fn terminal_p0_fires_for_failed_self_orch_once_1744_h4() {
+        // Terminal + self-orch (fail-closed) + not yet paged → fire.
+        assert!(should_fire_terminal_p0(false, SelfOrchStatus::Yes, false));
+        assert!(
+            should_fire_terminal_p0(false, SelfOrchStatus::Unknown, false),
+            "fail-closed: Unknown must still fire the leaderless-death P0"
+        );
+        // Not a self-orchestrator → skip (keeps the generic crash notify).
+        assert!(!should_fire_terminal_p0(false, SelfOrchStatus::No, false));
+        // Still respawning (non-terminal) → not a terminal page.
+        assert!(!should_fire_terminal_p0(true, SelfOrchStatus::Yes, false));
+        // Once-off: already terminally paged → never re-page.
+        assert!(
+            !should_fire_terminal_p0(false, SelfOrchStatus::Yes, true),
+            "#1744-H4 once-off: an already-paged terminal self-orch must not re-page"
+        );
     }
 }

--- a/src/daemon/escalation_persist.rs
+++ b/src/daemon/escalation_persist.rs
@@ -84,6 +84,28 @@ pub(crate) fn remove(home: &Path, name: &str) {
     }
 }
 
+/// #1744-PR-B (latch-scope): clear ONLY the terminal-Failed once-off latch
+/// (`failed_escalated`) for one agent, preserving the crash budget / cooldowns.
+/// Called at operator-initiated recovery boundaries (start / restart / replace):
+/// once the operator has intervened, a fresh terminal death must re-page — without
+/// this the persisted latch (rehydrated onto the re-spawned tracker) would silence
+/// the new death. A daemon restart does NOT route through these RPC handlers, so
+/// the latch survives a plain restart (the same un-recovered death is not re-paged).
+pub(crate) fn clear_failed_escalated(home: &Path, name: &str) {
+    let path = store_file(home);
+    if !path.exists() {
+        return;
+    }
+    if let Err(e) = store::mutate_versioned::<EscalationStore, _, _>(&path, |s| {
+        if let Some(entry) = s.agents.get_mut(name) {
+            entry.failed_escalated = false;
+        }
+        Ok(())
+    }) {
+        tracing::warn!(agent = %name, error = %e, "escalation_persist: clear_failed_escalated failed");
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -135,5 +157,52 @@ mod tests {
         remove(&home, "ghost"); // must not panic / create the file
         assert!(load_for(&home, "ghost").is_none());
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn clear_failed_escalated_resets_latch_preserves_budget_1744_prb() {
+        // #1744-PR-B latch-scope: operator-initiated recovery clears ONLY the
+        // terminal once-off latch (so a fresh terminal death re-pages), preserving
+        // the crash budget / cooldowns. A plain daemon restart (rehydrate) does NOT
+        // route through this, so the latch survives there.
+        let home = tmp_home("clear-latch");
+        persist(
+            &home,
+            "orch",
+            &PersistedEscalation {
+                total_crashes: 7,
+                crash_times_epoch_ms: vec![100],
+                last_crash_notification_epoch_ms: Some(200),
+                last_hung_notification_epoch_ms: None,
+                hung_since_epoch_ms: None,
+                failed_escalated: true,
+            },
+        );
+
+        clear_failed_escalated(&home, "orch");
+
+        let after = load_for(&home, "orch").expect("entry survives the clear");
+        assert!(
+            !after.failed_escalated,
+            "operator recovery must reset the terminal once-off latch"
+        );
+        assert_eq!(
+            after.total_crashes, 7,
+            "the crash budget must be preserved across an operator recovery"
+        );
+        assert_eq!(
+            after.last_crash_notification_epoch_ms,
+            Some(200),
+            "the crash cooldown must be preserved"
+        );
+
+        // No-op on an unknown agent / a missing store (no panic, no file creation).
+        clear_failed_escalated(&home, "ghost");
+        let empty = tmp_home("clear-empty");
+        clear_failed_escalated(&empty, "anyone");
+        assert!(load_for(&empty, "anyone").is_none());
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&empty).ok();
     }
 }

--- a/src/daemon/escalation_persist.rs
+++ b/src/daemon/escalation_persist.rs
@@ -113,6 +113,7 @@ mod tests {
             last_crash_notification_epoch_ms: Some(333),
             last_hung_notification_epoch_ms: None,
             hung_since_epoch_ms: Some(444),
+            failed_escalated: true,
         };
         persist(&home, "a", &snap);
         // A second agent's entry must not clobber the first.

--- a/src/health.rs
+++ b/src/health.rs
@@ -347,6 +347,10 @@ pub struct HealthTracker {
     /// clear on Hung EXIT (so a recovered episode's anchor never lingers / is
     /// never persisted stale).
     hung_since: Option<Instant>,
+    /// #1744-H4: once-off latch — set when the terminal-Failed self-orchestrator
+    /// P0 fires, so the permanent leaderless-death page is sent exactly once
+    /// (persisted across restart via [`PersistedEscalation`]).
+    pub failed_escalated: bool,
     error_events: VecDeque<(Instant, AgentState)>,
     pub last_output: Instant,
     pub current_reason: Option<BlockedReason>,
@@ -452,6 +456,11 @@ pub struct PersistedEscalation {
     pub last_hung_notification_epoch_ms: Option<u64>,
     #[serde(default)]
     pub hung_since_epoch_ms: Option<u64>,
+    /// #1744-H4: once-off latch for the terminal-Failed self-orchestrator P0.
+    /// Persisted so a daemon restart (which does NOT rehydrate `state`, only the
+    /// crash budget) doesn't re-page the operator about the same permanent death.
+    #[serde(default)]
+    pub failed_escalated: bool,
 }
 
 impl HealthTracker {
@@ -464,6 +473,7 @@ impl HealthTracker {
             last_crash_notification: None,
             last_hung_notification: None,
             hung_since: None,
+            failed_escalated: false,
             error_events: VecDeque::new(),
             last_output: Instant::now(),
             current_reason: None,
@@ -625,6 +635,7 @@ impl HealthTracker {
             last_crash_notification_epoch_ms: self.last_crash_notification.map(instant_to_epoch_ms),
             last_hung_notification_epoch_ms: self.last_hung_notification.map(instant_to_epoch_ms),
             hung_since_epoch_ms: self.hung_since.map(instant_to_epoch_ms),
+            failed_escalated: self.failed_escalated,
         }
     }
 
@@ -649,6 +660,7 @@ impl HealthTracker {
         self.last_crash_notification = p.last_crash_notification_epoch_ms.map(epoch_ms_to_instant);
         self.last_hung_notification = p.last_hung_notification_epoch_ms.map(epoch_ms_to_instant);
         self.hung_since = p.hung_since_epoch_ms.map(epoch_ms_to_instant);
+        self.failed_escalated = p.failed_escalated;
     }
 
     /// Check whether agent is stalled on an interactive startup prompt.

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -152,6 +152,9 @@ pub(super) fn handle_start_instance(home: &Path, args: &Value) -> Value {
         None => return json!({"error": "missing 'instance'"}),
     };
     crate::validate_name_or_err!(name);
+    // #1744-PR-B (latch-scope): operator-initiated recovery resets the terminal
+    // self-orch once-off latch, so a fresh terminal death after this start re-pages.
+    crate::daemon::escalation_persist::clear_failed_escalated(home, name);
     let fleet_path = crate::fleet::fleet_yaml_path(home);
     if !fleet_path.exists() {
         return json!({"error": "No fleet.yaml"});
@@ -233,6 +236,9 @@ pub(super) fn handle_replace_instance(home: &Path, args: &Value) -> Value {
         None => return json!({"error": "missing 'instance'"}),
     };
     crate::validate_name_or_err!(name);
+    // #1744-PR-B (latch-scope): operator-initiated recovery resets the terminal
+    // self-orch once-off latch, so a fresh terminal death after this replace re-pages.
+    crate::daemon::escalation_persist::clear_failed_escalated(home, name);
     let reason = args["reason"].as_str().unwrap_or("manual replacement");
 
     // Capture backend + working_directory before kill so we can respawn.
@@ -380,6 +386,9 @@ pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
         None => return json!({"error": "missing 'instance'"}),
     };
     crate::validate_name_or_err!(name);
+    // #1744-PR-B (latch-scope): operator-initiated recovery resets the terminal
+    // self-orch once-off latch, so a fresh terminal death after this restart re-pages.
+    crate::daemon::escalation_persist::clear_failed_escalated(home, name);
     let reason = args["reason"].as_str().unwrap_or("manual restart");
     let mode = args["mode"].as_str().unwrap_or("resume");
 


### PR DESCRIPTION
## #1744 PR-B — terminal-Failed (H4) + OOM-SignalKill (H5) self-orch escalation

Two silent self-orchestrator deaths that left the operator unaware of a
permanently leaderless team. Builds on PR-A (#1759: `notify_all_escalation_channels`
M6 resolver + `self_orch_status` M7).

### H4 — terminal Failed self-orch never paged
When a self-orchestrator crash-loops to `max_retries` it goes Failed (no respawn);
`record_crash` returns `notify=true` ("don't respawn, do notify"), but the
dispatch's `fire_self_orch_p0` is cooldown-gated (a terminal crash usually lands
inside the prior page's cooldown) and the generic-notify branch is `!is_self_orch`
— so a terminal self-orch death fired **neither**. Added a cooldown-**exempt**,
once-off terminal P0 branch (takes precedence over the per-crash page; distinct
"permanent, won't respawn" wording).

### H5 — OOM / SignalKill self-orch vanished silently
An external signal-kill (exit 137 OOM / 143) routes to `cleanup_agent`, which only
removes the agent — no crash event, no notify. For a self-orchestrator that is a
silent leaderless death. Escalate before cleanup. (`is_shutdown` + `deleted`
already early-return, so this only sees an *unexpected external* kill of a *live*
agent — graceful shutdown won't false-fire.)

### Shared design (per the contract aligned with reviewer-2)
- Both route through `crate::channel::notify_all_escalation_channels(name,
  NotifySeverity::Error, &msg, false)` (PR-A M6), caller-formatted terminal / OOM
  wording.
- Gate on `crate::teams::self_orch_status` **fail-closed** — `No` skip,
  `Yes`|`Unknown` fire (a leaderless death is too costly to miss on an
  indeterminate teams read). H5 `home == None` can't read teams → skip.
- H4 **once-off** via a new `failed_escalated: bool` on `HealthTracker`, persisted
  into `PersistedEscalation` (#1744-H2's snapshot/rehydrate) so a daemon restart —
  which rehydrates the crash budget but not `state` — doesn't re-page the same
  permanent death.

### Tests
Decision predicates extracted (`should_fire_terminal_p0`,
`signal_kill_self_orch_should_escalate`) + unit-tested, **negative-probed**:
- H4 fires for terminal `Yes`|`Unknown` self-orch; skips `No` / non-terminal /
  already-paged (once-off).
- H5 fires for self-orch; skips non-orch; skips `home=None`.
- the persist round-trip preserves `failed_escalated`.

clippy `--all-targets --features tray` + fmt clean; rebased on latest main, drift-checked.

Closes #1744 (with PR-A). Refs #1744.

---
@codex review — **standard tier**. Inline only. Focus:
1. H4 fires the terminal P0 cooldown-exempt yet exactly once (persisted
   `failed_escalated`), and takes precedence over the per-crash page; the generic
   non-self-orch notify is unaffected.
2. H5 only fires for an *unexpected* external kill of a live self-orch
   (is_shutdown/deleted early-return above it); `home=None` and `self_orch_status==No`
   both skip.
3. `failed_escalated` is correctly threaded through `escalation_snapshot()` /
   `rehydrate_escalation()` / `PersistedEscalation` (round-trips).
