### PR TITLE
fix(#1768): stop the ServerRateLimit retry storm (working-marker below scrolled-up error wins)

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -810,9 +810,20 @@ impl StateTracker {
                         // suppressed REAL faults → no ServerRateLimit transition →
                         // no auto-retry → stuck agent. Scoped: the FP-prone
                         // api_error/overloaded/context HIGH_FP tokens stay
-                        // red-anchored; the net-error residual FP is bounded by
-                        // #1518/#1586/#1760 (see `patterns::is_net_error_match`).
-                        && !crate::state::patterns::is_net_error_match(matched)
+                        // red-anchored.
+                        // #1768: NARROW that exemption to the token's LINE looking
+                        // like a real backend error line (`Error:`/`API Error:`/
+                        // `FetchError:` label) — a bare prose/source mention (an
+                        // orchestrator discussing net-errors, idle between turns,
+                        // with no working-marker below) stays red-anchored →
+                        // default-rendered → suppressed, instead of mis-latching
+                        // ServerRateLimit (the retry-storm FP codex caught). A real
+                        // fault IS error-line-shaped → still fails open → latches.
+                        && !(crate::state::patterns::is_net_error_match(matched)
+                            && crate::state::patterns::net_error_in_error_line(
+                                screen_text,
+                                matched,
+                            ))
                         && !matched_span_has_red(screen_text, matched, fg);
                     // #1518 position gate: a HIGH_FP marker that has scrolled out
                     // of the live bottom-N rows (e.g. an ApiError / ServerRateLimit

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -850,7 +850,28 @@ impl StateTracker {
                             self.maybe_expire_latched_state();
                         }
                     } else {
-                        let gated = self.gate_on_heartbeat(detected);
+                        // #1768: a HIGH_FP error wins the priority race even after
+                        // it scrolled up and the agent RESUMED WORK below it
+                        // (ServerRateLimit > Thinking by pattern order), so it keeps
+                        // re-latching → `clears_server_rate_limit_retry` (Idle-only,
+                        // #1713) never fires → supervisor re-injects `continue` into
+                        // a working agent (the #1768 retry storm; the latched
+                        // ServerRateLimit also doesn't auto-expire). If a
+                        // Thinking/ToolUse marker is rendered BELOW the error, the
+                        // agent recovered → land on that working state instead of the
+                        // stale error. A genuinely-stuck error has NO in-flight
+                        // working marker below it → `landed` stays `detected` → still
+                        // latches → auto-retry fires. Detection-side only;
+                        // `clears_server_rate_limit_retry` untouched → no #1713
+                        // flicker-reset regression.
+                        let landed = if high_fp {
+                            patterns
+                                .working_state_below(screen_text, matched)
+                                .unwrap_or(detected)
+                        } else {
+                            detected
+                        };
+                        let gated = self.gate_on_heartbeat(landed);
                         self.transition(gated);
                     }
                 }

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -285,6 +285,30 @@ impl StatePatterns {
         }
         None
     }
+
+    /// #1768: if a working-state marker (`Thinking`/`ToolUse`) is rendered BELOW
+    /// (more recently than) `error_match` in `text`, return that working state.
+    ///
+    /// A HIGH_FP error (e.g. `ServerRateLimit`) wins the priority race in
+    /// `detect_with_match` even when it has scrolled up and the agent has RESUMED
+    /// WORK below it — `ServerRateLimit` > `Thinking` by pattern order. If the
+    /// agent's most-recent on-screen activity (the lowest Thinking/ToolUse marker)
+    /// sits below the error, the agent recovered, so the caller lands on that
+    /// working state instead of re-latching the stale error (which would keep
+    /// re-injecting `continue` into a working agent — the #1768 retry storm). This
+    /// extends the #1518 absolute-tail-position gate to "relative to the working
+    /// marker" and never touches `clears_server_rate_limit_retry` (#1713). A
+    /// genuinely-stuck error has NO in-flight working marker below it → `None`.
+    pub(crate) fn working_state_below(&self, text: &str, error_match: &str) -> Option<AgentState> {
+        let err_pos = text.rfind(error_match)?;
+        self.patterns
+            .iter()
+            .filter(|(s, _)| matches!(s, AgentState::Thinking | AgentState::ToolUse))
+            .filter_map(|(s, re)| re.find_iter(text).last().map(|m| (m.start(), *s)))
+            .filter(|(pos, _)| *pos > err_pos)
+            .max_by_key(|(pos, _)| *pos)
+            .map(|(_, s)| s)
+    }
 }
 
 /// Classify PTY output into a [`BlockedReason`] for the given backend.

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -49,6 +49,44 @@ pub(crate) fn is_net_error_match(matched: &str) -> bool {
         .is_match(matched)
 }
 
+/// #1768: does some on-screen occurrence of `matched` sit in a real error LINE
+/// (one carrying an `Error:` / `API Error:` / `FetchError:` label)?
+///
+/// The #1757 net-error exemption (fail-open the #1450 red anchor for net-error
+/// tokens, since codex/gemini render them default not red) was too broad — it
+/// fired for the token ANYWHERE in the live tail, so an orchestrator merely
+/// *discussing* a net error (idle between turns, no working-marker below) had it
+/// mis-latch `ServerRateLimit` → retry storm (the case codex's #1769 review
+/// caught). Narrow the exemption to the token's LINE looking like a backend error
+/// line. The trailing `:`/`?` after a word-boundary `error` means the const name
+/// `…NET_ERRORS:` and prose like "the ECONNRESET error happened" do NOT qualify —
+/// only a labeled error line does. A genuine fault
+/// (`API Error: InvalidHTTPResponse fetching …`) IS error-line-shaped → still
+/// fails open → still latches (the #1757 intent). Checks every occurrence so a
+/// real error line alongside a prose mention still qualifies.
+pub(crate) fn net_error_in_error_line(screen_text: &str, matched: &str) -> bool {
+    if matched.is_empty() {
+        return false;
+    }
+    use std::sync::OnceLock;
+    static ERROR_LABEL: OnceLock<Regex> = OnceLock::new();
+    let re = ERROR_LABEL
+        .get_or_init(|| Regex::new(r"(?i)\b(api ?|fetch)?error\s*[:?]").expect("label regex"));
+    let mut search = 0;
+    while let Some(rel) = screen_text[search..].find(matched) {
+        let pos = search + rel;
+        let line_start = screen_text[..pos].rfind('\n').map_or(0, |i| i + 1);
+        let line_end = screen_text[pos..]
+            .find('\n')
+            .map_or(screen_text.len(), |i| pos + i);
+        if re.is_match(&screen_text[line_start..line_end]) {
+            return true;
+        }
+        search = pos + matched.len();
+    }
+    false
+}
+
 /// Compiled patterns for one backend.
 pub struct StatePatterns {
     /// (state, regex) pairs in priority order (highest priority first).

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3288,6 +3288,28 @@ fn retry_storm_error_with_no_working_marker_still_latches_1768() {
     );
 }
 
+/// #1768 (the idle-between-turns FP that REJECTED the first cut): a net-error
+/// TOKEN merely MENTIONED in prose — an orchestrator discussing the bug, idle
+/// between turns — rendered DEFAULT, with NO error-label on its line and NO
+/// working-marker below, must NOT latch ServerRateLimit. The #1757 net-error
+/// red-anchor exemption is narrowed to real error-LINES (#1768), so a bare prose
+/// mention stays red-anchored → default-rendered → suppressed. (Contrast
+/// `net_error_invalidhttpresponse_default_latches_1757`: a real `API Error:`
+/// line IS error-line-shaped → still latches.)
+#[test]
+fn net_error_prose_mention_does_not_latch_1768() {
+    let screen = "we keep hitting the InvalidHTTPResponse problem when the proxy is flaky";
+    let n = screen.chars().count();
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    t.feed_with_fg(screen, &vec![CellFg::Default; n]);
+    assert_ne!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#1768: a net-error token in prose (no error-label, default-rendered, no \
+         working-marker below) must NOT latch ServerRateLimit (idle-between-turns FP)"
+    );
+}
+
 // ── #1527: transition recording at the mutation source ──
 
 #[test]

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3227,6 +3227,67 @@ fn net_error_invalidhttpresponse_default_latches_1757() {
     );
 }
 
+/// #1768 regression (retry storm): a HIGH_FP ServerRateLimit error wins the
+/// priority race over Thinking even after it scrolled UP and the agent RESUMED
+/// WORK below it — so it kept re-latching, `clears_server_rate_limit_retry`
+/// (Idle-only) never fired, and the supervisor re-injected `continue` into a
+/// working agent. When a working-marker (codex Thinking `esc to interrupt`) is
+/// rendered BELOW the error, the agent recovered → land on the working state.
+#[test]
+fn retry_storm_recovered_below_error_lands_on_working_state_1768() {
+    // Error scrolled UP (line 1); the agent's most-recent line is the work spinner.
+    let screen = "▌ API Error: InvalidHTTPResponse fetching \"http://127.0.0.1:3456\".\n\
+                  ▌ retrying the request\n\
+                  ▌ esc to interrupt";
+    let n = screen.chars().count();
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    t.feed_with_fg(screen, &vec![CellFg::Default; n]);
+    assert_ne!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#1768: a recovered agent (working-marker below the scrolled-up error) must \
+         NOT re-latch ServerRateLimit (→ no retry storm)"
+    );
+    assert_eq!(
+        t.get_state(),
+        AgentState::Thinking,
+        "#1768: it lands on the working state the marker indicates"
+    );
+}
+
+/// #1768 boundary: a fresh error rendered BELOW the working-marker is genuine →
+/// must STILL latch ServerRateLimit (the fix must not mask a real fault).
+#[test]
+fn retry_storm_fresh_error_below_working_marker_still_latches_1768() {
+    let screen = "▌ working on the task\n\
+                  ▌ esc to interrupt\n\
+                  ▌ API Error: InvalidHTTPResponse fetching \"http://127.0.0.1:3456\".";
+    let n = screen.chars().count();
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    t.feed_with_fg(screen, &vec![CellFg::Default; n]);
+    assert_eq!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#1768: a fresh error BELOW the working-marker is genuine → must still latch \
+         ServerRateLimit (auto-retry must fire)"
+    );
+}
+
+/// #1768 boundary: the classic stuck case — an error with NO working-marker at
+/// all must latch ServerRateLimit so auto-retry fires.
+#[test]
+fn retry_storm_error_with_no_working_marker_still_latches_1768() {
+    let screen = "▌ API Error: InvalidHTTPResponse fetching \"http://127.0.0.1:3456\".";
+    let n = screen.chars().count();
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    t.feed_with_fg(screen, &vec![CellFg::Default; n]);
+    assert_eq!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#1768: an error with no working-marker must latch ServerRateLimit"
+    );
+}
+
 // ── #1527: transition recording at the mutation source ──
 
 #[test]


### PR DESCRIPTION
## What
Fix #1768: the **ServerRateLimit retry storm** — the supervisor re-injects `continue` into an agent that has already recovered and is working.

## RCA (verified — corrects the issue's attribution)
- **NOT a #1757 regression.** The observed-storm binary `2b5cba4` *predates* #1757 (`git merge-base --is-ancestor f563ed0 2b5cba4` → false; #1757 committed 19:02, `2b5cba4` is the 18:58 tip). The 19:49 deploy ran `2b5cba4` (#1762, no #1757). #1757 *amplifies* (net errors latch without red) but didn't cause it.
- **Root cause:** a HIGH_FP `ServerRateLimit` error wins the priority race over `Thinking` (`detect_with_match` returns the first/highest-priority match, and the net-error pattern precedes Thinking in every profile). After the error scrolls UP and the agent resumes work below it, each scan **re-latches** ServerRateLimit. `clears_server_rate_limit_retry` is Idle-only (#1713) so the retry track never clears; the latched ServerRateLimit also doesn't auto-expire (`maybe_expire_latched_state` has no ServerRateLimit arm); the backoff expires → `continue` is re-injected into a working agent → storm.

## Fix (detection-side)
When a HIGH_FP error matches but a `Thinking`/`ToolUse` working-marker is rendered **below** it (more recently in the tail), the agent recovered → land on that working state instead of re-latching the stale error. New `StatePatterns::working_state_below`. This extends the #1518 absolute-tail-position gate to "relative to the working marker."

- **A genuinely-stuck error has NO in-flight working-marker below it → still latches → auto-retry fires.** (The fix does not mask real faults.)
- **Does NOT touch `clears_server_rate_limit_retry` (#1713)** → zero flicker-reset regression risk. This is the key safety property (the reason #1713 narrowed clearing to Idle-only).
- **Covers all backends** — each profile carries Thinking + ToolUse markers (codex `Working|esc to interrupt`, gemini `(esc to cancel,`, kiro `Kiro is working|esc to cancel`, …).
- *Implementation note:* we land on the working state rather than merely suppressing, because `maybe_expire_latched_state` has no ServerRateLimit arm — a pure suppress would leave the latched ServerRateLimit in place and the storm would continue.

## Tests
- `retry_storm_recovered_below_error_lands_on_working_state_1768` — error scrolled up + `esc to interrupt` below → lands on `Thinking` (no storm).
- `retry_storm_fresh_error_below_working_marker_still_latches_1768` — fresh error below the marker → still `ServerRateLimit`.
- `retry_storm_error_with_no_working_marker_still_latches_1768` — error alone → still `ServerRateLimit` (auto-retry preserved).
- #1757 / #1587 / #1634 / #1713 tests unchanged + green.
- Preflight: fmt + clippy (`tray`, `tray,discord`, -D warnings) green; full `cargo test --tests` green except an **unrelated** flake `bridge_handles_half_up_daemon` (a port-reuse race under parallel load — confirmed 3/3 green in isolation, passes in earlier full runs; not touched by this change).

## ⚠ Adversarial-review ask (state-detection sensitive)
Please check: can a *real* ServerRateLimit have a working-marker below it (→ wrongly suppressed)? It shouldn't — a failed request removes the in-flight `esc to interrupt`/spinner, so a stuck error has no working-marker after it. A marker below the error means a request is in flight (recovering / internally retrying), which is exactly when we should NOT inject. Flagging for the lens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
