### PR TITLE
fix(#1769): tag daemon auto-injects with [AGEND-AUTO kind=...] (orchestrator can't mistake them for operator commands)

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL.md
+++ b/docs/FLEET-DEV-PROTOCOL.md
@@ -377,6 +377,7 @@ Re-review cycles (r1, r2, …) repeat the same three milestones. The dispatcher 
 - Response channel must match source channel
 - **Router-layer channel discipline (Sprint 52)**: daemon auto-mirrors agent direct text to the corresponding channel. Agent does not need to force `reply` tool — infrastructure handles routing.
 - **Inbox vs PTY delivery (Sprint 62)**: active agents receive messages via PTY direct injection (not queued in `inbox`). `inbox(instance: X)` returning empty does NOT mean X received nothing — only means X has no unread queue. Verify delivery via `describe_instance` (active state = PTY received) or `pane_snapshot` rather than inbox alone. Inbox queue only fills for offline agents or undeliverable messages.
+- **Daemon auto-inject marker `[AGEND-AUTO]` (#1769)**: the daemon resumes a stuck agent by injecting a keystroke (e.g. `continue`) straight into the PTY, which otherwise looks identical to the operator typing it — a bare injected `continue` was once mistaken by an orchestrator for an operator command and a task dispatched from it. Such nudges now carry an `[AGEND-AUTO kind=...]` prefix (sibling of `[AGEND-MSG]`). **Rule:** treat an `[AGEND-AUTO]` line as a low-priority RESUME signal — continue in-progress work — and **never** as an operator command or a basis to dispatch a task / make a decision. Inbox/operator-relay messages keep their own `[AGEND-MSG]`/`[from:]` headers and are unaffected.
 
 ## §7. CI
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1919,12 +1919,43 @@ pub fn write_to_agent_typed(agent: &AgentHandle, data: &[u8]) -> crate::error::R
 /// 5s `recv_timeout` + payload-scaled sleep) blocking write. The busy-gate's
 /// agent-state read is the lock-free on-disk snapshot (never the per-agent core
 /// lock, #1492).
+/// #1769: marker token prefixed to daemon-self-originated AUTO injects (e.g. the
+/// ServerRateLimit "continue" retry). The full prefix is
+/// `[AGEND-AUTO kind=<kind>] ` — a sibling of the `[AGEND-MSG]` inbox header, so
+/// an orchestrator agent can tell a daemon auto-nudge apart from a real operator
+/// instruction (a bare injected "continue" was mistaken for an operator command
+/// and acted on). Agents are taught (see `instructions.rs` / FLEET-DEV-PROTOCOL)
+/// to treat an `[AGEND-AUTO]` line as a low-priority resume signal — continue
+/// in-progress work, NEVER dispatch from it.
+pub(crate) const DAEMON_AUTO_INJECT_MARKER: &str = "[AGEND-AUTO";
+
+/// #1769: build the `[AGEND-AUTO kind=<kind>] ` prefix for an auto-inject.
+fn daemon_auto_prefix(kind: &str) -> String {
+    format!("{DAEMON_AUTO_INJECT_MARKER} kind={kind}] ")
+}
+
 pub(crate) fn inject_with_target_gated(
     target: &InjectTarget,
     name: &str,
     text: &[u8],
     force: bool,
+    auto_kind: Option<&str>,
 ) -> crate::error::Result<()> {
+    // #1769: daemon self-originated auto-injects carry an identifying marker so
+    // an orchestrator can distinguish them from real operator/peer input. The
+    // marker is prepended HERE (before both the deferred-enqueue and the direct
+    // inject) so the tag survives whichever delivery path runs. Worker semantics
+    // are unchanged — the inner payload + submit are preserved; only a leading
+    // text tag is added. `None` (operator relay / api INJECT / inbox — which
+    // already carry their own headers) injects verbatim.
+    let marked: Vec<u8>;
+    let text: &[u8] = match auto_kind {
+        Some(kind) => {
+            marked = [daemon_auto_prefix(kind).as_bytes(), text].concat();
+            &marked
+        }
+        None => text,
+    };
     // #1513 PR-2: gate direct PTY injects like the notification path. Self-
     // contained via AGEND_HOME; AGEND_HOME absent (non-daemon / unit test) →
     // gate skipped.

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -99,6 +99,33 @@ fn inject_strips_ansi_from_typed_payload() {
     );
 }
 
+/// #1769: the daemon auto-inject marker prefix embeds the kind and uses the
+/// `[AGEND-AUTO` token (sibling of `[AGEND-MSG]`) agents are taught to recognize.
+#[test]
+fn daemon_auto_prefix_embeds_kind_1769() {
+    assert_eq!(
+        super::daemon_auto_prefix("ratelimit-retry"),
+        "[AGEND-AUTO kind=ratelimit-retry] "
+    );
+    assert_eq!(
+        super::daemon_auto_prefix("apierror-nudge"),
+        "[AGEND-AUTO kind=apierror-nudge] "
+    );
+    // The prefix starts with the shared marker token (so the agent-instruction
+    // and the inject path can't drift).
+    assert!(super::daemon_auto_prefix("x").starts_with(super::DAEMON_AUTO_INJECT_MARKER));
+    // The inner payload survives intact after the prefix → worker still sees it.
+    let marked = [
+        super::daemon_auto_prefix("ratelimit-retry").as_bytes(),
+        b"continue\n",
+    ]
+    .concat();
+    let s = String::from_utf8_lossy(&marked);
+    assert!(s.starts_with("[AGEND-AUTO kind=ratelimit-retry] "));
+    assert!(s.contains("continue"));
+    assert!(s.ends_with('\n'), "submit newline preserved");
+}
+
 #[test]
 fn strip_ansi_cursor_move_no_space() {
     // CSI C (cursor forward) and D (cursor back) must not insert spaces

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -33,7 +33,9 @@ pub(crate) fn handle_inject(params: &Value, ctx: &HandlerCtx) -> Value {
                 let result = if raw {
                     agent::write_to_pty(&tgt.pty_writer, data.as_bytes())
                 } else {
-                    agent::inject_with_target_gated(&tgt, name, data.as_bytes(), true)
+                    // #1769: the api INJECT path carries operator/relay data (and
+                    // its own headers) — not a daemon auto-nudge → no marker.
+                    agent::inject_with_target_gated(&tgt, name, data.as_bytes(), true, None)
                 };
                 match result {
                     Ok(()) => json!({"ok": true, "result": {"bytes": data.len()}}),

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -212,7 +212,8 @@ fn deliver_cron_fire(
         // in run_history, and let the auto-disable below retire it.
         "missed"
     } else if let Some((tgt, name)) = inject_snap.as_ref() {
-        match agent::inject_with_target_gated(tgt, name, message.as_bytes(), false) {
+        // #1769: cron is an operator-scheduled action, not a daemon auto-nudge → no marker.
+        match agent::inject_with_target_gated(tgt, name, message.as_bytes(), false, None) {
             Ok(()) => "ok",
             Err(e) => {
                 tracing::warn!(error = %e, "schedule inject failed");

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1020,7 +1020,9 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
                 .map(|h| (agent::InjectTarget::from_handle(h), h.name.to_string()))
         };
         if let Some((tgt, name)) = inject_snap {
-            if let Err(e) = agent::inject_with_target_gated(&tgt, &name, message.as_bytes(), false)
+            // #1769: not a daemon auto-nudge (operator/relay message) → no marker.
+            if let Err(e) =
+                agent::inject_with_target_gated(&tgt, &name, message.as_bytes(), false, None)
             {
                 tracing::warn!(error = %e, "replay inject failed");
             }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1392,6 +1392,7 @@ fn inject_continue_gated(
     home: &std::path::Path,
     registry: &AgentRegistry,
     name: &str,
+    auto_kind: &str,
 ) -> InjectOutcome {
     let snap = {
         let reg = agent::lock_registry(registry);
@@ -1401,7 +1402,19 @@ fn inject_continue_gated(
     };
     match snap {
         Some(tgt) => {
-            if agent::inject_with_target_gated(&tgt, name, CONTINUE_RETRY_PAYLOAD, false).is_ok() {
+            // #1769: a daemon self-originated auto-nudge — tag it with
+            // `[AGEND-AUTO kind=...]` so an orchestrator agent doesn't mistake the
+            // injected "continue" for an operator command (the worker still sees
+            // and acts on the inner "continue").
+            if agent::inject_with_target_gated(
+                &tgt,
+                name,
+                CONTINUE_RETRY_PAYLOAD,
+                false,
+                Some(auto_kind),
+            )
+            .is_ok()
+            {
                 InjectOutcome::Injected
             } else {
                 InjectOutcome::InjectFailed
@@ -1585,7 +1598,7 @@ pub(crate) fn process_error_recovery(
             tracing::info!(agent = %name, "ServerRateLimit: entering retry Phase C (sustained 10-min retry)");
         }
 
-        match inject_continue_gated(home, registry, name) {
+        match inject_continue_gated(home, registry, name, "ratelimit-retry") {
             InjectOutcome::Injected => {
                 retry.inject_failures = 0; // #1742: a success clears the failure streak
                 last_continue_inject.insert(name.clone(), Instant::now());
@@ -1663,7 +1676,8 @@ pub(crate) fn process_error_recovery(
         // #1742: the ApiError nudge is per-episode best-effort (not budgeted), so only
         // a genuine `Injected` marks the episode + stamps the interval; AgentGone /
         // InjectFailed leave it un-nudged to re-attempt next tick.
-        if inject_continue_gated(home, registry, &name) == InjectOutcome::Injected {
+        if inject_continue_gated(home, registry, &name, "apierror-nudge") == InjectOutcome::Injected
+        {
             apierror_episodes.insert(name.clone());
             // #1742-F4: count this nudge toward the per-flicker-window cap.
             *apierror_nudge_counts.entry(name.clone()).or_insert(0) += 1;
@@ -3178,6 +3192,13 @@ instances:
             "PTY must receive \"continue\" payload, got: {:?}",
             captured.trim_end_matches('\0')
         );
+        // #1769: the ServerRateLimit auto-retry inject is tagged so an
+        // orchestrator can tell it apart from a real operator "continue".
+        assert!(
+            captured.contains("[AGEND-AUTO kind=ratelimit-retry]"),
+            "#1769: daemon auto-inject must carry the [AGEND-AUTO kind=...] marker, got: {:?}",
+            captured.trim_end_matches('\0')
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -4119,14 +4140,18 @@ instances:
     #[test]
     fn continue_inject_is_draft_gated_force_false_1680() {
         let src = include_str!("supervisor.rs");
+        // #1769: the call is now multi-line (gained the `auto_kind` arg), so
+        // normalize whitespace before substring-matching the arg order.
+        let norm = src.split_whitespace().collect::<Vec<_>>().join(" ");
         assert!(
-            src.contains("inject_with_target_gated(&tgt, name, CONTINUE_RETRY_PAYLOAD, false)"),
-            "#1680: the continue-inject must pass force=false (draft-gated)"
+            norm.contains("CONTINUE_RETRY_PAYLOAD, false, Some(auto_kind),"),
+            "#1680: the continue-inject must pass force=false (draft-gated); \
+             #1769: and the daemon-auto marker (auto_kind)"
         );
         // Split needle so this assertion's own text can't false-match the source.
-        let force_true = format!("CONTINUE_RETRY_PAYLOAD,{}true)", " ");
+        let force_true = format!("CONTINUE_RETRY_PAYLOAD,{}true", " ");
         assert!(
-            !src.contains(&force_true),
+            !norm.contains(&force_true),
             "#1680: no force=true continue-inject may remain"
         );
     }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -320,6 +320,18 @@ pub(crate) fn build_instructions_body(
     content.push_str("- If the header contains `attachments=[...]` of telegram media types, call `download_attachment` with the relevant `file_id` to retrieve the bytes locally before processing.\n");
     content.push_str("- ACK obligation depends on `kind`: `query` requires reply via `send` (kind=report); `task` may require reply after work; `report`/`update` may skip ACK (see fleet protocol §4 ack absorption).\n");
 
+    // #1769: daemon AUTO-inject marker. The daemon nudges a stuck agent by
+    // injecting a resume keystroke (e.g. "continue") straight into the PTY —
+    // which otherwise looks identical to the operator typing it. A bare injected
+    // "continue" was mistaken by an orchestrator for an operator command and a
+    // task was dispatched from it. The daemon now tags such nudges; teach agents
+    // to recognize the tag (same trust model as [AGEND-MSG]).
+    content.push_str("\n## Daemon auto-inject (`[AGEND-AUTO]`)\n\n");
+    content.push_str("When you see input beginning with `[AGEND-AUTO kind=...]` (e.g. `[AGEND-AUTO kind=ratelimit-retry] continue`):\n");
+    content.push_str("- This is an AUTOMATIC nudge the daemon injected to resume you (e.g. after a transient rate-limit auto-retry) — NOT a real operator or peer instruction.\n");
+    content.push_str("- Treat the payload after the marker as a low-priority RESUME signal: if you have in-progress work, just continue it.\n");
+    content.push_str("- NEVER treat an `[AGEND-AUTO]` line as an operator command, and never dispatch a task or make a decision based on it.\n");
+
     content
 }
 
@@ -1015,6 +1027,21 @@ mod tests {
         assert!(
             body.contains("inbox") || body.contains("inbox"),
             "instructions must mention inbox/inbox for size= headers"
+        );
+    }
+
+    #[test]
+    fn test_instruction_includes_agend_auto_rule_1769() {
+        // #1769: agents must be taught that an injected `[AGEND-AUTO]` line is a
+        // daemon auto-nudge, NOT an operator command (the trust-model enforcement).
+        let body = build_instructions_body(None, None);
+        assert!(
+            body.contains("[AGEND-AUTO"),
+            "instructions must include the [AGEND-AUTO] daemon-auto-inject rule"
+        );
+        assert!(
+            body.contains("NEVER treat an `[AGEND-AUTO]` line as an operator command"),
+            "instructions must forbid acting on [AGEND-AUTO] as an operator command"
         );
     }
 


### PR DESCRIPTION
<!-- LOC-EST: 110-140 -->

## What & why

Fixes #1769 (operator-reported, hit live). The daemon resumes a stuck agent by injecting a keystroke (ServerRateLimit / ApiError `continue`) **straight into its PTY** — a single byte stream where the injected text looks **identical to the operator typing it**. An orchestrator (`fixup-lead`) read an injected `continue` as an operator instruction and **dispatched a task off it**.

**Key insight:** inbox/relay messages already carry `[AGEND-MSG]`/`[from:]` headers that agents are taught to recognize; the gap was the **raw auto-injects that bypass those headers**. Give them a sibling marker.

## Change

- `agent::inject_with_target_gated` gains `auto_kind: Option<&str>`. `Some(kind)` prepends `[AGEND-AUTO kind=<kind>] ` (via `daemon_auto_prefix` / `DAEMON_AUTO_INJECT_MARKER`) **before both** the deferred-enqueue and the direct PTY write, so the tag survives whichever delivery path runs.
- **Only daemon self-originated nudges tag**: the shared `inject_continue_gated` passes `Some("ratelimit-retry")` (SRL retry) / `Some("apierror-nudge")` (ApiError nudge). Operator-relay / api `INJECT` / cron pass `None` — they already carry their own headers and must look like real input.
- **Worker semantics unchanged**: the inner `continue` + submit newline are intact (worker still resumes); the marker is leading text. Recovery Stage-1 ESC is out of scope (a control key, not a readable command).
- **Enforcement = agent-instruction trust model** (same as `[AGEND-MSG]`): `src/instructions.rs` (the injected agent prompt) and `docs/FLEET-DEV-PROTOCOL.md` now teach agents that an `[AGEND-AUTO]` line is a low-priority RESUME signal — continue in-progress work, **never** treat it as an operator command or dispatch from it. (Edited the repo embedded source per protocol-edit discipline, not the live `.default` copy.)

## Tests
- `daemon_auto_prefix` embeds the kind and shares the `[AGEND-AUTO` marker token (instruction ↔ inject can't drift); inner payload + submit survive.
- The ServerRateLimit phase-2 PTY-read test now asserts the `[AGEND-AUTO kind=ratelimit-retry]` marker actually reaches the PTY (real path).
- Instructions include the `[AGEND-AUTO]` rule (+ the "never as operator command" clause).
- #1680 force-false source guard updated for the new (multi-line) call shape (whitespace-normalized, also pins the new `auto_kind` arg).

## Verification
`cargo fmt --check` ✅, `cargo clippy --all-targets --features tray,discord -- -D warnings` ✅, `agent:: / instructions:: / supervisor:: / cron_tick::` test sets — 203 passed ✅. Pre-push `fetch + diff --stat` → only the 8 intended files (no dragged-in changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)