### PR TITLE
fix(dispatch_idle): productive-silence clock de-noise + active-recovery exempt (#1694②)

### DIFF
--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -645,6 +645,7 @@ mod tests {
                 submit_key: "\r".to_string(),
                 health_state: "healthy".to_string(),
                 agent_state: "thinking".to_string(),
+                silent_secs: 0,
             }],
         );
         home

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -509,16 +509,39 @@ pub(crate) fn pending_for_instance(
     (as_dispatcher, as_target)
 }
 
-/// #1516: is `target` demonstrably working right now? True iff the fleet
-/// snapshot reports its `agent_state` as `thinking` or `tool_use` — the
-/// PTY-output-fed "actively generating / running a tool" signal (the same one
-/// `health.rs` treats as productive). Pure for testability. Unknown target /
-/// missing snapshot → `false` (don't suppress → fire as before; degrades to
-/// the pre-#1516 behavior, never worse).
-fn target_is_working(snapshot: Option<&crate::snapshot::FleetSnapshot>, target: &str) -> bool {
+/// #1694② silence-clock: should the dispatch-idle nudge be SUPPRESSED for
+/// `target`? Replaces the #1516 instantaneous `thinking`/`tool_use` state check
+/// with two more-robust conditions read from the fleet snapshot:
+///
+/// 1. **active-recovery exempt** — `agent_state ∈ {server_rate_limit, api_error}`:
+///    the agent is being driven by the ServerRateLimit/ApiError auto-retry
+///    machinery, which owns its recovery. Nudging it is pure noise (#1694
+///    dialectic finding #4 — without this, a proxy-drop re-creates the very
+///    noise this change removes).
+/// 2. **productive-silence gate** — `silent_secs < silence_threshold_secs`: the
+///    agent has produced *productive* output (marker/heartbeat-gated, so a
+///    spinner / junk / cursor-blink does NOT count) within the window, i.e. it is
+///    making progress, just slow. A genuinely wedged agent stops producing
+///    productive output, its `silent_secs` climbs past the window, and the gate
+///    releases → the watchdog fires. This subsumes the old thinking/tool_use
+///    check (a thinking agent that's actually producing has low `silent_secs`)
+///    while ALSO catching a stuck agent whose latched state never flipped.
+///
+/// Pure for testability. Unknown target / missing snapshot → `false` (don't
+/// suppress → fire; degrades to the pre-#1516 fail-open, never worse). The
+/// `silent_secs` field itself fails open (large default) on an old-format
+/// snapshot, so a missing field also fires rather than silently suppressing.
+fn target_is_working(
+    snapshot: Option<&crate::snapshot::FleetSnapshot>,
+    target: &str,
+    silence_threshold_secs: i64,
+) -> bool {
     snapshot
         .and_then(|s| s.agents.iter().find(|a| a.name == target))
-        .map(|a| matches!(a.agent_state.as_str(), "thinking" | "tool_use"))
+        .map(|a| {
+            matches!(a.agent_state.as_str(), "server_rate_limit" | "api_error")
+                || a.silent_secs < silence_threshold_secs
+        })
         .unwrap_or(false)
 }
 
@@ -545,17 +568,19 @@ pub(crate) fn scan_and_emit(home: &Path) {
             continue;
         }
 
-        // #1516: the dispatch-idle threshold is for "agent went silent and
-        // never replied", but the idle timer only resets on a correlated
+        // #1516/#1694②: the dispatch-idle threshold is for "agent went silent
+        // and never replied", but the idle timer only resets on a correlated
         // report — so a slow-but-progressing impl agent (heads-down coding /
-        // generating, not sending updates) false-fired 5× the night this
-        // landed. If the target is demonstrably WORKING (Thinking/ToolUse per
-        // the snapshot), reset its clock and don't fire — it's making progress,
-        // not stuck. A genuinely wedged agent stops producing output, so its
-        // latched Thinking/ToolUse expires (LATCHED_STATE_EXPIRY, supervisor.rs)
-        // → state flips to Idle/Hang → this gate releases → the watchdog fires
-        // as designed. (The hang detector independently catches infinite-gen.)
-        if target_is_working(snapshot.as_ref(), &d.target) {
+        // generating, not sending updates) false-fired 5× the night #1516
+        // landed. #1694② replaced the instantaneous Thinking/ToolUse check with
+        // a productive-SILENCE clock (`silent_secs` from the snapshot) plus an
+        // active-recovery exemption: suppress while the agent is producing
+        // productive output within `threshold_secs` (making progress, just slow)
+        // or is in an auto-retry state. A genuinely wedged agent stops producing
+        // productive output → `silent_secs` climbs past the window → this gate
+        // releases → the watchdog fires as designed. (The hang detector
+        // independently catches infinite-gen / MCP-active-but-stuck.)
+        if target_is_working(snapshot.as_ref(), &d.target, d.threshold_secs) {
             // #1658: the target is producing output — reset the debounce streak
             // so a later idle run starts fresh.
             if d.not_working_streak != 0 {
@@ -1993,7 +2018,24 @@ mod tests {
 
     // ── #1516: agent_state gate (don't fire while target is working) ──
 
+    /// #1694②: map the legacy state label to a productive-silence value so the
+    /// pre-existing #1516/#1658 state-based tests keep their intent under the
+    /// silence-clock gate — `thinking`/`tool_use` = recently productive
+    /// (`silent_secs` 0 → working), anything else = productive-silent past any
+    /// window. New silence-specific tests use [`mk_agent_snapshot_silence`].
     fn mk_agent_snapshot(name: &str, agent_state: &str) -> crate::snapshot::AgentSnapshot {
+        let silent_secs = match agent_state {
+            "thinking" | "tool_use" => 0,
+            _ => i64::MAX,
+        };
+        mk_agent_snapshot_silence(name, agent_state, silent_secs)
+    }
+
+    fn mk_agent_snapshot_silence(
+        name: &str,
+        agent_state: &str,
+        silent_secs: i64,
+    ) -> crate::snapshot::AgentSnapshot {
         crate::snapshot::AgentSnapshot {
             name: name.to_string(),
             backend_command: "opencode".to_string(),
@@ -2002,38 +2044,54 @@ mod tests {
             submit_key: "\r".to_string(),
             health_state: "healthy".to_string(),
             agent_state: agent_state.to_string(),
+            silent_secs,
         }
     }
 
+    /// #1694②: the gate reads the productive-SILENCE clock, not the
+    /// instantaneous thinking/tool_use state. Recently-productive
+    /// (`silent_secs < threshold`) → working (suppress); productive-silent past
+    /// the window → not working (fire); active-recovery states are exempt
+    /// regardless of silence.
     #[test]
-    fn target_is_working_reads_snapshot_state_1516() {
+    fn target_is_working_reads_silence_clock_1694() {
+        const T: i64 = 600;
         let snap = crate::snapshot::FleetSnapshot {
             timestamp: "t".to_string(),
             agents: vec![
-                mk_agent_snapshot("worker", "thinking"),
-                mk_agent_snapshot("tooler", "tool_use"),
-                mk_agent_snapshot("idler", "idle"),
+                // recently productive while NOT thinking/tool_use → still working
+                mk_agent_snapshot_silence("fresh_idle", "idle", 10),
+                // latched 'thinking' but productive-silent past the window → NOT
+                // working (the stuck-but-latched gap the old #1516 state gate missed)
+                mk_agent_snapshot_silence("stuck_thinking", "thinking", 700),
+                // active-recovery: silent but auto-retrying → exempt (suppress)
+                mk_agent_snapshot_silence("rate_limited", "server_rate_limit", 700),
+                mk_agent_snapshot_silence("api_err", "api_error", 700),
             ],
         };
         assert!(
-            target_is_working(Some(&snap), "worker"),
-            "thinking → working"
+            target_is_working(Some(&snap), "fresh_idle", T),
+            "recently productive (silent<threshold) → working even when not thinking"
         );
         assert!(
-            target_is_working(Some(&snap), "tooler"),
-            "tool_use → working"
+            !target_is_working(Some(&snap), "stuck_thinking", T),
+            "productive-silent past window → not working, even latched 'thinking'"
         );
         assert!(
-            !target_is_working(Some(&snap), "idler"),
-            "idle → not working"
+            target_is_working(Some(&snap), "rate_limited", T),
+            "ServerRateLimit → active-recovery exempt (suppress nudge)"
         );
         assert!(
-            !target_is_working(Some(&snap), "ghost"),
-            "absent → not working"
+            target_is_working(Some(&snap), "api_err", T),
+            "ApiError → active-recovery exempt (suppress nudge)"
         );
         assert!(
-            !target_is_working(None, "worker"),
-            "no snapshot → not working"
+            !target_is_working(Some(&snap), "ghost", T),
+            "absent → not working (fire)"
+        );
+        assert!(
+            !target_is_working(None, "fresh_idle", T),
+            "no snapshot → not working (fail-open fire)"
         );
     }
 
@@ -2111,6 +2169,103 @@ mod tests {
                 .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
             "no snapshot → must fall back to firing (no worse than pre-#1516)"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1694② de-noise regression: an overdue dispatch whose target is NOT in
+    /// thinking/tool_use but is recently PRODUCTIVE (low `silent_secs`) must NOT
+    /// fire. Pre-#1694 the #1516 state gate fired here (state ≠ thinking) — the
+    /// exact "reminders became noise" complaint, e.g. a dev heads-down for 13 min
+    /// whose snapshot state isn't thinking at the scan instant but who is plainly
+    /// producing output.
+    #[test]
+    fn productive_but_not_thinking_suppressed_1694() {
+        let home = tmp_home("silence-productive");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(800);
+        let id = write_pending_at(&home, "lead", "dev", Some("t-p"), "task", 600, issued);
+        // Idle state label, but productive output 60s ago (well under the 600s
+        // window) → the silence clock says "working".
+        crate::snapshot::save(&home, &[mk_agent_snapshot_silence("dev", "idle", 60)]);
+
+        for _ in 0..DEBOUNCE_SCANS + 1 {
+            scan_and_emit(&home);
+        }
+
+        assert!(
+            crate::inbox::drain(&home, "lead").is_empty(),
+            "recently-productive target must NOT trigger an idle nudge"
+        );
+        let p = list_pending(&home)
+            .into_iter()
+            .find(|p| p.dispatch_id == id)
+            .unwrap();
+        assert_eq!(
+            p.status,
+            DispatchStatus::Pending,
+            "sidecar stays pending (silence clock refreshed it)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1694② finding #4: an overdue dispatch whose target is in an
+    /// active-recovery state (ServerRateLimit) must NOT fire even when
+    /// productive-silent — the auto-retry machinery owns the recovery, so
+    /// nudging is pure noise (and would re-create the very proxy-drop noise this
+    /// change removes).
+    #[test]
+    fn active_recovery_exempt_does_not_fire_1694() {
+        let home = tmp_home("silence-recovery");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(800);
+        let id = write_pending_at(&home, "lead", "dev", Some("t-r"), "task", 600, issued);
+        // Productive-silent (700s) AND in an auto-recovery state → exempt.
+        crate::snapshot::save(
+            &home,
+            &[mk_agent_snapshot_silence("dev", "server_rate_limit", 700)],
+        );
+
+        for _ in 0..DEBOUNCE_SCANS + 1 {
+            scan_and_emit(&home);
+        }
+
+        assert!(
+            crate::inbox::drain(&home, "lead").is_empty(),
+            "active-recovery (ServerRateLimit) target must NOT trigger an idle nudge"
+        );
+        let p = list_pending(&home)
+            .into_iter()
+            .find(|p| p.dispatch_id == id)
+            .unwrap();
+        assert_eq!(p.status, DispatchStatus::Pending);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1694② complement to [`active_recovery_exempt_does_not_fire_1694`]: a
+    /// genuinely stuck target — productive-silent past the window AND in a
+    /// non-recovery state — still fires after the debounce (the watchdog must
+    /// not be neutered by the de-noise change).
+    #[test]
+    fn productive_silent_non_recovery_still_fires_1694() {
+        let home = tmp_home("silence-stuck");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(800);
+        let id = write_pending_at(&home, "lead", "dev", Some("t-s"), "task", 600, issued);
+        // Productive-silent (700s > 600s window), ordinary state → not working → fire.
+        crate::snapshot::save(&home, &[mk_agent_snapshot_silence("dev", "idle", 700)]);
+
+        for _ in 0..DEBOUNCE_SCANS {
+            scan_and_emit(&home);
+        }
+
+        assert!(
+            crate::inbox::drain(&home, "lead")
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
+            "productive-silent past window + overdue + no report must still fire"
+        );
+        let p = list_pending(&home)
+            .into_iter()
+            .find(|p| p.dispatch_id == id)
+            .unwrap();
+        assert_eq!(p.status, DispatchStatus::Exceeded);
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -513,11 +513,16 @@ pub(crate) fn pending_for_instance(
 /// `target`? Replaces the #1516 instantaneous `thinking`/`tool_use` state check
 /// with two more-robust conditions read from the fleet snapshot:
 ///
-/// 1. **active-recovery exempt** — `agent_state ∈ {server_rate_limit, api_error}`:
-///    the agent is being driven by the ServerRateLimit/ApiError auto-retry
-///    machinery, which owns its recovery. Nudging it is pure noise (#1694
-///    dialectic finding #4 — without this, a proxy-drop re-creates the very
-///    noise this change removes).
+/// 1. **active-recovery exempt** — `agent_state == server_rate_limit` ONLY: a
+///    rate-limited agent is in a bounded retry-backoff wait (#1696) whose
+///    exhaustion (12 retries → #1744 escalation) is its own stuck-backstop, so
+///    suppressing the idle nudge avoids noise in a legit wait without hiding a
+///    real stuck (#1694 dialectic finding #4). `api_error` is deliberately NOT
+///    exempt — it is a once-per-episode nudge with no retry-loop owning it and
+///    no exhaustion signal, so dispatch-idle is the ONLY watchdog that surfaces
+///    a wedged api_error agent (hang_detector misses it: no BlockedReason →
+///    IdleLong, not Hung). Exempting it would silence a real stuck forever
+///    (codex #1775 HIGH).
 /// 2. **productive-silence gate** — `silent_secs < silence_threshold_secs`: the
 ///    agent has produced *productive* output (marker/heartbeat-gated, so a
 ///    spinner / junk / cursor-blink does NOT count) within the window, i.e. it is
@@ -539,8 +544,12 @@ fn target_is_working(
     snapshot
         .and_then(|s| s.agents.iter().find(|a| a.name == target))
         .map(|a| {
-            matches!(a.agent_state.as_str(), "server_rate_limit" | "api_error")
-                || a.silent_secs < silence_threshold_secs
+            // active-recovery exempt — ONLY `server_rate_limit` (bounded retry
+            // with a #1744 exhaustion backstop). `api_error` is intentionally
+            // excluded: no exhaustion signal owns it, so dispatch-idle must stay
+            // its watchdog or a wedged api_error agent goes silent forever
+            // (codex #1775 HIGH). See the fn doc for the full rationale.
+            a.agent_state.as_str() == "server_rate_limit" || a.silent_secs < silence_threshold_secs
         })
         .unwrap_or(false)
 }
@@ -2064,8 +2073,10 @@ mod tests {
                 // latched 'thinking' but productive-silent past the window → NOT
                 // working (the stuck-but-latched gap the old #1516 state gate missed)
                 mk_agent_snapshot_silence("stuck_thinking", "thinking", 700),
-                // active-recovery: silent but auto-retrying → exempt (suppress)
+                // active-recovery exempt: ONLY server_rate_limit (bounded retry +
+                // #1744 exhaustion backstop) → silent but exempt
                 mk_agent_snapshot_silence("rate_limited", "server_rate_limit", 700),
+                // api_error is NOT exempt (no exhaustion backstop) → silent = stuck
                 mk_agent_snapshot_silence("api_err", "api_error", 700),
             ],
         };
@@ -2082,8 +2093,8 @@ mod tests {
             "ServerRateLimit → active-recovery exempt (suppress nudge)"
         );
         assert!(
-            target_is_working(Some(&snap), "api_err", T),
-            "ApiError → active-recovery exempt (suppress nudge)"
+            !target_is_working(Some(&snap), "api_err", T),
+            "ApiError is NOT exempt (no exhaustion backstop) → silent past window fires"
         );
         assert!(
             !target_is_working(Some(&snap), "ghost", T),
@@ -2236,6 +2247,38 @@ mod tests {
             .find(|p| p.dispatch_id == id)
             .unwrap();
         assert_eq!(p.status, DispatchStatus::Pending);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// codex #1775 HIGH: `api_error` is NOT an exempt active-recovery state (it
+    /// has no retry-exhaustion backstop), so a wedged api_error agent that is
+    /// productive-silent past the window must still fire — dispatch-idle is its
+    /// only watchdog (hang_detector misses it: no BlockedReason → IdleLong, not
+    /// Hung). Contrast with [`active_recovery_exempt_does_not_fire_1694`]
+    /// (server_rate_limit, which IS exempt).
+    #[test]
+    fn stuck_api_error_silent_still_fires_1775() {
+        let home = tmp_home("silence-apierror");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(800);
+        let id = write_pending_at(&home, "lead", "dev", Some("t-ae"), "task", 600, issued);
+        // api_error AND productive-silent (700s > 600s window) → must fire.
+        crate::snapshot::save(&home, &[mk_agent_snapshot_silence("dev", "api_error", 700)]);
+
+        for _ in 0..DEBOUNCE_SCANS {
+            scan_and_emit(&home);
+        }
+
+        assert!(
+            crate::inbox::drain(&home, "lead")
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
+            "stuck api_error (silent past window) must fire — no exhaustion backstop owns it"
+        );
+        let p = list_pending(&home)
+            .into_iter()
+            .find(|p| p.dispatch_id == id)
+            .unwrap();
+        assert_eq!(p.status, DispatchStatus::Exceeded);
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/per_tick/snapshot.rs
+++ b/src/daemon/per_tick/snapshot.rs
@@ -37,11 +37,14 @@ impl PerTickHandler for SnapshotRotationHandler {
         let snapshots: Vec<_> = reg
             .values()
             .map(|handle| {
-                let (agent_state, health_state) = {
+                let (agent_state, health_state, silent_secs) = {
                     let c = handle.core.lock();
                     (
                         c.state.get_state().display_name().to_string(),
                         c.health.state.display_name().to_string(),
+                        // #1694②: productive-silence for the dispatch-idle
+                        // silence-clock (marker/heartbeat-gated, spinner-resistant).
+                        c.state.last_productive_output.elapsed().as_secs() as i64,
                     )
                 };
                 let cfg = cfgs.get(handle.name.as_str());
@@ -55,6 +58,7 @@ impl PerTickHandler for SnapshotRotationHandler {
                     submit_key: handle.submit_key.clone(),
                     health_state,
                     agent_state,
+                    silent_secs,
                 }
             })
             .collect();

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -370,6 +370,7 @@ mod tests {
                 submit_key: "\r".to_string(),
                 health_state: "Healthy".to_string(),
                 agent_state: "thinking".to_string(),
+                silent_secs: 0,
             }],
         );
     }

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -953,6 +953,7 @@ mod snapshot_busy_tests_1513 {
             submit_key: "\r".to_string(),
             health_state: "healthy".to_string(),
             agent_state: state.to_string(),
+            silent_secs: 0,
         }
     }
 
@@ -1002,6 +1003,7 @@ mod should_defer_direct_inject_tests_1513pr2 {
             submit_key: "\r".to_string(),
             health_state: "healthy".to_string(),
             agent_state: state.to_string(),
+            silent_secs: 0,
         }
     }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -18,6 +18,23 @@ pub struct AgentSnapshot {
     pub submit_key: String,
     pub health_state: String,
     pub agent_state: String,
+    /// #1694②: seconds since the agent last produced *productive* output
+    /// (`StateTracker::last_productive_output`, marker/heartbeat-gated — resists
+    /// spinner/blink/junk). The dispatch-idle silence-clock reads this to gate on
+    /// "is the agent actually making progress" rather than the instantaneous
+    /// thinking/tool_use state. `serde(default)` returns a large value so a
+    /// snapshot written by an older daemon (no field) fails OPEN — the watchdog
+    /// fires rather than silently suppressing a possible stuck.
+    #[serde(default = "default_silent_secs")]
+    pub silent_secs: i64,
+}
+
+/// Fail-open default for a snapshot missing `silent_secs` (old-format / boot
+/// transient): a large value reads as "very silent" → the idle watchdog fires
+/// rather than suppressing. The live daemon rewrites the snapshot every tick with
+/// the real value, so this only covers the sub-tick boot window.
+fn default_silent_secs() -> i64 {
+    i64::MAX
 }
 
 pub fn save(home: &Path, agents: &[AgentSnapshot]) {
@@ -81,6 +98,7 @@ mod tests {
             submit_key: "\r".to_string(),
             health_state: "healthy".to_string(),
             agent_state: state.to_string(),
+            silent_secs: 0,
         }
     }
 


### PR DESCRIPTION
## What

Replaces the dispatch-idle watchdog's instantaneous thinking/tool_use state gate (#1516) with a **productive-silence clock**, fixing the operator's "reminders became noise" complaint without neutering the watchdog.

Came out of the team dispatch_idle de-noise dialectic + a read-only premise-verification spike (both this session).

## Why

The #1516 gate suppressed the nudge only while the snapshot's *instantaneous* `agent_state` was `thinking`/`tool_use`. An agent making real progress but not latched-thinking at the scan instant got nudged → noise. Conversely a spinner/junk agent whose state stays latched-thinking was never caught.

## How

- **`AgentSnapshot.silent_secs`** — seconds since `last_productive_output` (marker/heartbeat-gated, so spinner/blink/junk does *not* count), filled at snapshot-write from the StateTracker. dispatch_idle keeps reading `snapshot.json` (zero registry lock, #1492/#1516 design preserved). **Fails OPEN** (large serde default) so an old-format snapshot fires rather than silently suppressing.
- **`target_is_working`** now suppresses when the agent produced productive output within `threshold_secs` (progressing, just slow) **OR** is in an active-recovery state (`server_rate_limit`/`api_error`) — the auto-retry machinery owns recovery; nudging it re-creates the very proxy-drop churn this removes (dialectic finding #4).
- **bounded-backstop deferred** (YAGNI) — the hang detector independently covers the narrow MCP-active-but-stuck poll-loop case.

## Verified premise (spike)

The productivity **heartbeat is MCP-activity-based, not PTY-output-based** — so stuck-at-prompt / spinner / infinite-gen (no MCP calls) do **not** mask the silence clock. Residual gap (an agent making MCP calls every <10s without progress) is narrow and left to hang_detection.

## Tests

- `productive_but_not_thinking_suppressed_1694` — recently-productive non-thinking target → **suppressed** (the noise fix)
- `productive_silent_non_recovery_still_fires_1694` — productive-silent non-recovery → **still fires** (watchdog intact)
- `active_recovery_exempt_does_not_fire_1694` — ServerRateLimit target → **suppressed**
- `target_is_working_reads_silence_clock_1694` — unit cases incl. silent-but-latched-thinking + recovery exemption
- existing #1516/#1658 state tests preserved via a state→silence mapping in the test helper

`cargo fmt --check` clean · `cargo clippy --all-targets --features tray -D warnings` clean · dispatch_idle (42) + snapshot + conflict_notify + per_tick::snapshot + inbox::notify all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)