### PR TITLE
fix: extend error-line-shape regex coverage (corpus MISS list) + generalize in_error_line

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -820,10 +820,7 @@ impl StateTracker {
                         // ServerRateLimit (the retry-storm FP codex caught). A real
                         // fault IS error-line-shaped → still fails open → latches.
                         && !(crate::state::patterns::is_net_error_match(matched)
-                            && crate::state::patterns::net_error_in_error_line(
-                                screen_text,
-                                matched,
-                            ))
+                            && crate::state::patterns::in_error_line(screen_text, matched))
                         && !matched_span_has_red(screen_text, matched, fg);
                     // #1518 position gate: a HIGH_FP marker that has scrolled out
                     // of the live bottom-N rows (e.g. an ApiError / ServerRateLimit

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -49,29 +49,46 @@ pub(crate) fn is_net_error_match(matched: &str) -> bool {
         .is_match(matched)
 }
 
-/// #1768: does some on-screen occurrence of `matched` sit in a real error LINE
-/// (one carrying an `Error:` / `API Error:` / `FetchError:` label)?
+/// Does some on-screen occurrence of `matched` sit in a real backend ERROR LINE
+/// (vs a bare prose/source mention of the same token)?
 ///
-/// The #1757 net-error exemption (fail-open the #1450 red anchor for net-error
-/// tokens, since codex/gemini render them default not red) was too broad — it
-/// fired for the token ANYWHERE in the live tail, so an orchestrator merely
-/// *discussing* a net error (idle between turns, no working-marker below) had it
-/// mis-latch `ServerRateLimit` → retry storm (the case codex's #1769 review
-/// caught). Narrow the exemption to the token's LINE looking like a backend error
-/// line. The trailing `:`/`?` after a word-boundary `error` means the const name
-/// `…NET_ERRORS:` and prose like "the ECONNRESET error happened" do NOT qualify —
-/// only a labeled error line does. A genuine fault
-/// (`API Error: InvalidHTTPResponse fetching …`) IS error-line-shaped → still
-/// fails open → still latches (the #1757 intent). Checks every occurrence so a
-/// real error line alongside a prose mention still qualifies.
-pub(crate) fn net_error_in_error_line(screen_text: &str, matched: &str) -> bool {
+/// Generalized from the #1768 net-error gate (was `net_error_in_error_line`) so
+/// the content-shape signal can serve EVERY HIGH_FP state, not just net errors.
+/// The #1757 net-error red-anchor exemption was too broad (fired for the token
+/// ANYWHERE in the tail), so an agent merely *discussing* a net error mis-latched
+/// `ServerRateLimit` → retry storm (codex's #1769 review). Gate on the token's
+/// LINE looking like a real error line.
+///
+/// Error-line signatures (corpus-derived, `t-step1-detection-corpus`):
+/// - labeled error — `\w*error\s*[:?]`: `Error:` / `API Error:` / `FetchError:` /
+///   `api_error:` / `invalid_request_error:`. The `\w*` (not `\b`) fixes the
+///   corpus bug where the `_error` underscore killed the old `\berror`
+///   word-boundary, so `ModelUnsupported`'s `invalid_request_error:` never
+///   qualified;
+/// - bare HTTP-status (gemini RateLimit lines with no `Error:` label):
+///   `\b429\b` / `RESOURCE_EXHAUSTED` / `Too Many Requests` / `got status:`;
+/// - structured-JSON error fields: `"type"|"code"|"status": "…error…"` /
+///   `"reason": "…exceeded"`.
+///
+/// A bare prose/source mention (the const name `…NET_ERRORS:`, "the ECONNRESET
+/// error happened" with no colon, "see issue 4290") does NOT qualify → stays
+/// red-anchored. Checks every occurrence so a real error line alongside a prose
+/// mention still qualifies. ⚠ This is the CONTENT-shape signal ONLY — it does NOT
+/// change the red→content anchor decision (a follow-up pending the operator's
+/// call on keeping/dropping the color signal); today it still gates only the
+/// #1757 net-error exemption at its single call site.
+pub(crate) fn in_error_line(screen_text: &str, matched: &str) -> bool {
     if matched.is_empty() {
         return false;
     }
     use std::sync::OnceLock;
-    static ERROR_LABEL: OnceLock<Regex> = OnceLock::new();
-    let re = ERROR_LABEL
-        .get_or_init(|| Regex::new(r"(?i)\b(api ?|fetch)?error\s*[:?]").expect("label regex"));
+    static ERROR_LINE: OnceLock<Regex> = OnceLock::new();
+    let re = ERROR_LINE.get_or_init(|| {
+        Regex::new(
+            r#"(?i)(\b\w*error\s*[:?]|\b429\b|resource_exhausted|too many requests|got status\s*:|"(type|code|status)"\s*:\s*"\w*error\w*"|"reason"\s*:\s*"[^"]*exceeded")"#,
+        )
+        .expect("error-line regex")
+    });
     let mut search = 0;
     while let Some(rel) = screen_text[search..].find(matched) {
         let pos = search + rel;

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3310,6 +3310,69 @@ fn net_error_prose_mention_does_not_latch_1768() {
     );
 }
 
+/// `t-impl-errorline-regex-extend`: the extended error-line-shape regex (now the
+/// generic `in_error_line`) must MATCH the corpus's real backend error lines —
+/// including the ones the old `\b(api ?|fetch)?error[:?]` MISSED: ModelUnsupported
+/// `invalid_request_error:` (the `_error` underscore killed `\berror`), gemini
+/// bare-status (`429` / `got status:` / `RESOURCE_EXHAUSTED`), and structured-JSON
+/// error fields — while still REJECTING bare prose / source mentions.
+#[test]
+fn in_error_line_matches_corpus_errors_rejects_prose_step1() {
+    use crate::state::patterns::in_error_line;
+
+    // (line, a token on that line) — must read as a real backend error line.
+    let real: &[(&str, &str)] = &[
+        (
+            "API Error: InvalidHTTPResponse fetching \"http://x\"",
+            "InvalidHTTPResponse",
+        ),
+        (
+            "FetchError: request failed, reason: ECONNRESET",
+            "ECONNRESET",
+        ),
+        // #corpus bug: the `_error` underscore killed the old `\berror` boundary.
+        (
+            "invalid_request_error: model is not supported",
+            "invalid_request_error",
+        ),
+        (
+            "✕ API Error: got status: 429 RESOURCE_EXHAUSTED",
+            "RESOURCE_EXHAUSTED",
+        ),
+        ("429 Too Many Requests", "429"),
+        ("got status: 429", "429"),
+        ("{\"reason\": \"rateLimitExceeded\"}", "rateLimitExceeded"),
+        ("{\"type\": \"error\", \"message\": \"x\"}", "error"),
+        ("Error: token limit exceeded", "token limit"),
+    ];
+    for (line, tok) in real {
+        assert!(
+            in_error_line(line, tok),
+            "must read as an error line: {line:?} (token {tok:?})"
+        );
+    }
+
+    // Bare prose / source mentions of the same tokens — must NOT read as an error line.
+    let prose: &[(&str, &str)] = &[
+        (
+            "we keep hitting the InvalidHTTPResponse problem",
+            "InvalidHTTPResponse",
+        ),
+        ("the ECONNRESET error happened twice today", "ECONNRESET"),
+        (
+            "pub(crate) const SERVER_RATE_LIMIT_NET_ERRORS: &str = r\"ECONNRESET|...\"",
+            "ECONNRESET",
+        ),
+        ("see issue 4290 for details", "4290"),
+    ];
+    for (line, tok) in prose {
+        assert!(
+            !in_error_line(line, tok),
+            "prose/source mention must NOT read as an error line: {line:?} (token {tok:?})"
+        );
+    }
+}
+
 // ── #1527: transition recording at the mutation source ──
 
 #[test]


### PR DESCRIPTION
## What
First (low-risk) step of the color-anchor rework (`①`): **extend the error-line-shape regex** to cover the MISS list found by the `t-step1-detection-corpus` spike, and generalize `net_error_in_error_line` → `in_error_line`. This is a **coverage extension only — it does NOT change the red→content anchor decision** (that larger change, and the keep/drop call on the color signal, is the next step pending the operator).

## Why (corpus-derived)
The detection-signal corpus showed the old line-shape regex `(?i)\b(api ?|fetch)?error\s*[:?]` MISSES real backend error lines:
- **ModelUnsupported `invalid_request_error:`** — a real regex bug: the `_error` underscore kills the `\berror` word-boundary, so this line *never* qualified;
- **gemini bare HTTP-status** (no `API Error:` label): `429 Too Many Requests`, `got status: 429`, `RESOURCE_EXHAUSTED`;
- **structured-JSON error fields**: `"reason":"rateLimitExceeded"`, `"type":"error"`.

(The corpus also reversed the "non-default color" idea — real errors render Default *and* themed colors like Monokai's `248,248,242` normal fg, so color is unreliable both ways. That anchor change is the follow-up; this PR only fixes content-shape coverage.)

## Change
`patterns::in_error_line` (renamed from `net_error_in_error_line`) now matches any of:
```
(?i)( \b\w*error\s*[:?]                              # Error: / API Error: / FetchError: / api_error: / invalid_request_error:
    | \b429\b | resource_exhausted | too many requests | got status\s*:   # bare HTTP-status (gemini RateLimit)
    | "(type|code|status)"\s*:\s*"\w*error\w*"        # structured-JSON error fields
    | "reason"\s*:\s*"[^"]*exceeded" )
```
`\w*error` (not `\berror`) is the fix for the `_error` underscore. The single call site (state/mod.rs, the #1757 net-error red-anchor exemption) is unchanged in structure — still gated by `is_net_error_match(matched)` — so **behavior is preserved for today's only consumer**; the broadened signatures stage the content-primary anchor for the next step.

## Tests
`in_error_line_matches_corpus_errors_rejects_prose_step1` — table-driven: 9 real backend error lines (incl. ModelUnsupported `_error`, gemini bare-`429`/`got status:`/`RESOURCE_EXHAUSTED`, JSON `rateLimitExceeded`/`type:error`) all MATCH; 4 bare prose / source mentions (the `…NET_ERRORS:` const, "the ECONNRESET error happened" no-colon, "issue 4290") all REJECTED. Existing `net_error` / `retry_storm` (#1768) / `#1757` / `#1587` / `#1634` regressions unchanged + green.

Preflight: `cargo fmt --check` + clippy (`tray`, `tray,discord`, `-D warnings`) + full `cargo test --tests` all green. Base = latest `origin/main`.

⚠ **Scope guard:** this is the error-line-shape *coverage* extension only. The red→content anchor decision (and whether the color signal stays) is the next step and needs the operator's call + more corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
