### PR TITLE
fix(#1750 A2): root-cause ci-watch state leaks — stale .json + orphaned .lock

### DIFF
--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -21,6 +21,15 @@ mod watcher;
 /// Watch TTL in hours. Used for both absolute expiry and inactivity threshold.
 pub const WATCH_TTL_HOURS: i64 = 72;
 
+/// #1750 A2: absolute watch-age cap (anchored on the earliest `subscribed_at`,
+/// which is never refreshed by polling) as a backstop against a watch that keeps
+/// receiving "active" poll results and so never hits the refreshed `expires_at`
+/// / inactivity TTL. A real per-push CI watch goes terminal (and is removed)
+/// within minutes-to-an-hour; a watch alive this long never reached terminal and
+/// is stale by definition. Generous (7 days) so it can only ever catch genuine
+/// leaks, never a live watch.
+pub const MAX_WATCH_AGE_HOURS: i64 = 7 * 24;
+
 // Pre-#701 callers reached these names via `crate::daemon::ci_watch::X`.
 // The re-exports preserve that path even when the only in-tree use of
 // some items is via the trait object inside `watcher::check_ci_watches`.

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1186,7 +1186,13 @@ async fn ci_check_repo(
             if state != snapshot {
                 flush_watch_state(watch_path, &state);
             }
-            refresh_expires_at(watch_path);
+            // #1750 A2: do NOT refresh `expires_at` here. `Ok(None)` means the
+            // poll found NO runs for the branch — a deleted/merged-away branch or
+            // a branch CI never ran. Refreshing on this case is exactly what kept
+            // 56 stale watches alive forever (each empty poll bumped expiry +72h).
+            // Withholding the refresh lets a runless watch finally age past its
+            // existing `expires_at` and get GC'd. A still-active watch (CI in
+            // progress / runs present) refreshes via the run-bearing paths below.
             return Ok(());
         }
         Err(e) => {

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -5370,8 +5370,15 @@ fn successful_poll_refreshes_expires_at() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
+/// #1750 A2: an empty-run poll (`Ok(None)` — deleted/merged-away branch, or CI
+/// that never ran) must NOT refresh `expires_at`; the original expiry is
+/// preserved so the watch finally ages out. Pre-fix every empty poll bumped it to
+/// ~72h, which is exactly what kept 56 stale watches alive forever. (Renamed +
+/// inverted from `empty_run_poll_refreshes_expires_at`, which pinned the removed
+/// refresh-on-empty behavior.) Contrast `successful_poll_refreshes_expires_at`
+/// directly above: a RUN-bearing poll still refreshes.
 #[test]
-fn empty_run_poll_refreshes_expires_at() {
+fn empty_run_poll_does_not_refresh_expires_at_1750() {
     let dir = tmp_dir("refresh-empty-runs");
     let ci_dir = dir.join("ci-watches");
     std::fs::create_dir_all(&ci_dir).ok();
@@ -5390,11 +5397,9 @@ fn empty_run_poll_refreshes_expires_at() {
     let content = std::fs::read_to_string(&watch_path).unwrap();
     let ws: super::WatchState = serde_json::from_str(&content).unwrap();
     let new_expires = ws.expires_at.expect("expires_at must be present");
-    let parsed = chrono::DateTime::parse_from_rfc3339(&new_expires).unwrap();
-    let hours_from_now = (parsed.with_timezone(&chrono::Utc) - chrono::Utc::now()).num_hours();
-    assert!(
-        (71..=72).contains(&hours_from_now),
-        "expires_at must be refreshed to ~72h even on empty runs, got {hours_from_now}h"
+    assert_eq!(
+        new_expires, old_expires,
+        "empty-run poll must NOT refresh expires_at (#1750 A2) — leave the watch to age out"
     );
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -56,6 +56,13 @@ pub fn remove_watch(
     reason: &str,
 ) {
     let _ = std::fs::remove_file(watch_path);
+    // #1750 A2: remove the sibling `<hash>.lock` too. The lock file is created by
+    // `acquire_file_lock` on every poll/update and never had a deletion site, so
+    // every removed watch used to leave its `.lock` behind (269 orphans observed).
+    // Best-effort: a concurrent re-acquire could recreate it, but the watch is
+    // gone so that path won't run; any straggler is reaped by the orphaned-`.lock`
+    // sweep in `gc_stale_watches`.
+    let _ = std::fs::remove_file(watch_path.with_extension("lock"));
     crate::event_log::log(
         home,
         "ci_watch_removed",

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use super::registry::{ci_watches_dir, remove_watch};
-use super::WATCH_TTL_HOURS;
+use super::{MAX_WATCH_AGE_HOURS, WATCH_TTL_HOURS};
 
 /// Sprint 54 P0-5 (sub-scope B): consecutive rate-limited skips before a
 /// `[ci-watch-stalled]` notification fires. Picked low (3) so a watch
@@ -333,6 +333,31 @@ pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
                 }
             }
         }
+
+        // (2b) #1750 A2: absolute age cap — backstop against a watch kept
+        // perpetually young by `refresh_expires_at` on every active poll (so it
+        // never trips the refreshed `expires_at` or inactivity TTL above).
+        // Anchored on the earliest `subscribed_at`, the one timestamp polling
+        // never moves. A watch older than MAX_WATCH_AGE_HOURS never reached
+        // terminal (which would have removed it) → stale by definition.
+        if let Some(created) = watch.earliest_subscribed_at() {
+            if now_utc.signed_duration_since(created) > chrono::Duration::hours(MAX_WATCH_AGE_HOURS)
+            {
+                remove_watch(
+                    home,
+                    &path,
+                    &audit_label,
+                    repo,
+                    branch,
+                    &format!("{sweep_origin}_max_age"),
+                );
+                tracing::info!(repo = %repo, branch = %branch, hours = MAX_WATCH_AGE_HOURS,
+                    sweep = %sweep_origin,
+                    "ci_watch removed (absolute max-age cap — never reached terminal)");
+                removed += 1;
+                continue;
+            }
+        }
     }
 
     // #1740: reap orphaned `.stall` sidecars. The per-repo `<repo-slug>.stall`
@@ -378,6 +403,47 @@ pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
                 } else {
                     tracing::info!(stall = %path.display(), sweep = %sweep_origin,
                         "#1740: removed orphaned ci-watch .stall sidecar (no surviving watch for repo)");
+                }
+            }
+        }
+    }
+
+    // #1750 A2: reap orphaned `<hash>.lock` files. A lock shares its stem with
+    // its `<hash>.json` watch and exists only to guard concurrent writes to that
+    // watch; once the watch is gone the lock is dead weight. `remove_watch` now
+    // deletes the sibling lock, but historical removals (and the pre-fix lack of
+    // any deletion site) left 269 orphans on disk — sweep every `.lock` whose
+    // sibling `.json` no longer exists. Run AFTER the `.json` removal loop so a
+    // just-removed watch's lock counts as orphaned. (Not added to `removed`,
+    // which counts watches, mirroring the `.stall` sweep.)
+    let surviving_json_stems: std::collections::HashSet<String> = std::fs::read_dir(&ci_dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            if p.extension().and_then(|s| s.to_str()) != Some("json") {
+                return None;
+            }
+            p.file_stem().and_then(|s| s.to_str()).map(String::from)
+        })
+        .collect();
+    if let Ok(entries) = std::fs::read_dir(&ci_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("lock") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if !surviving_json_stems.contains(stem) {
+                if let Err(e) = std::fs::remove_file(&path) {
+                    tracing::warn!(lock = %path.display(), error = %e,
+                        "#1750 A2: orphaned ci-watch .lock removal failed");
+                } else {
+                    tracing::info!(lock = %path.display(), sweep = %sweep_origin,
+                        "#1750 A2: removed orphaned ci-watch .lock (no surviving watch)");
                 }
             }
         }
@@ -530,6 +596,109 @@ mod tests {
             ci_dir.join("a_b_main.json").exists(),
             "live watch should survive"
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1750 A2: an orphaned `<hash>.lock` (no sibling `.json`) is reaped; a
+    /// `.lock` whose `.json` watch still lives is kept.
+    #[test]
+    fn gc_reaps_orphaned_lock_but_keeps_sibling_of_live_watch() {
+        let dir = tmp_dir("1750-lock-gc");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+
+        let future = (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339();
+        let w = serde_json::json!({ "repo": "o/r", "branch": "feat", "expires_at": future });
+        std::fs::write(
+            ci_dir.join("live.json"),
+            serde_json::to_string_pretty(&w).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(ci_dir.join("live.lock"), b"").unwrap();
+        // orphan: a .lock with no sibling .json
+        std::fs::write(ci_dir.join("orphan.lock"), b"").unwrap();
+
+        gc_stale_watches(&dir, "test");
+
+        assert!(
+            !ci_dir.join("orphan.lock").exists(),
+            "orphaned .lock (no sibling .json) must be gc'd"
+        );
+        assert!(
+            ci_dir.join("live.lock").exists(),
+            "sibling .lock of a live watch must be KEPT"
+        );
+        assert!(ci_dir.join("live.json").exists(), "live watch survives");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1750 A2: a watch kept perpetually young by `refresh_expires_at` (future
+    /// `expires_at`) is still removed once its earliest `subscribed_at` is older
+    /// than the absolute max-age cap; a recently-subscribed watch survives.
+    #[test]
+    fn gc_max_age_cap_removes_watch_kept_young_by_polling() {
+        let dir = tmp_dir("1750-maxage-gc");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+
+        let future = (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339();
+        let old_sub =
+            (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+        let stale = serde_json::json!({
+            "repo": "o/r", "branch": "stale", "expires_at": future,
+            "subscribers": [{ "instance": "dev", "subscribed_at": old_sub }],
+        });
+        std::fs::write(
+            ci_dir.join("stale.json"),
+            serde_json::to_string_pretty(&stale).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(ci_dir.join("stale.lock"), b"").unwrap();
+
+        let recent_sub = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        let young = serde_json::json!({
+            "repo": "o/r", "branch": "young", "expires_at": future,
+            "subscribers": [{ "instance": "dev", "subscribed_at": recent_sub }],
+        });
+        std::fs::write(
+            ci_dir.join("young.json"),
+            serde_json::to_string_pretty(&young).unwrap(),
+        )
+        .unwrap();
+
+        let removed = gc_stale_watches(&dir, "test");
+
+        assert!(
+            !ci_dir.join("stale.json").exists(),
+            "watch older than max-age cap must be removed despite a future expires_at"
+        );
+        assert!(
+            !ci_dir.join("stale.lock").exists(),
+            "the max-age-removed watch's sibling .lock goes with it (remove_watch)"
+        );
+        assert!(
+            ci_dir.join("young.json").exists(),
+            "recently-subscribed watch must survive the age cap"
+        );
+        assert_eq!(removed, 1, "exactly the over-age watch removed");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1750 A2: `remove_watch` deletes the sibling `.lock` alongside the `.json`.
+    #[test]
+    fn remove_watch_deletes_sibling_lock_1750() {
+        let dir = tmp_dir("1750-remove-lock");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        let json = ci_dir.join("w.json");
+        let lock = ci_dir.join("w.lock");
+        std::fs::write(&json, "{}").unwrap();
+        std::fs::write(&lock, b"").unwrap();
+
+        remove_watch(&dir, &json, "dev", "o/r", "feat", "test");
+
+        assert!(!json.exists(), "watch .json removed");
+        assert!(!lock.exists(), "sibling .lock removed too");
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/daemon/ci_watch/watch_state.rs
+++ b/src/daemon/ci_watch/watch_state.rs
@@ -132,6 +132,23 @@ impl WatchState {
         }
         Vec::new()
     }
+
+    /// #1750 A2: the earliest `subscribed_at` across subscribers, as a stable
+    /// watch-age anchor. Unlike `expires_at` / `last_polled_at`, `subscribed_at`
+    /// is set once at subscription time and never refreshed by polling, so it is
+    /// the only field the per-poll `refresh_expires_at` cannot perpetually push
+    /// forward — exactly what an absolute-age GC backstop needs. Returns `None`
+    /// when no subscriber carries a parseable timestamp (legacy/empty watch); the
+    /// caller then falls back to the refreshed-TTL paths.
+    pub fn earliest_subscribed_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.subscribers
+            .as_ref()?
+            .iter()
+            .filter_map(|s| s.subscribed_at.as_deref())
+            .filter_map(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .min()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Roots out three linked ci-watch state leaks I traced in the daemon-hygiene investigation. Observed live: **56 stale `.json` watches** (long-merged branches like `spike/1513`, `diag/1441`, `review/1138`, all with `expires_at` refreshed +3d) + **269 orphaned 0-byte `.lock` files**.

## Root causes & fixes

1. **refresh-on-empty kept stale watches immortal** — `ci_check_repo`'s `Ok(None)` arm (no runs: deleted/merged-away branch, or CI never ran) called `refresh_expires_at`, bumping `expires_at` +72h on *every* empty poll → the watch never aged past the TTL the sweep checks. **Fix**: drop the refresh on the no-runs path (`poller.rs`); run-bearing polls still refresh.

2. **no backstop against a poll-kept-young watch** — `gc_stale_watches` only removed by the (poll-refreshed) `expires_at` / inactivity TTL. **Fix**: absolute max-age cap (`MAX_WATCH_AGE_HOURS` = 7d) anchored on the earliest `subscribed_at` — the one timestamp polling never moves. A watch alive 7d never reached terminal → stale by definition. Also clears the existing old backlog on the next sweep.

3. **`.lock` files had no deletion site** — `acquire_file_lock` created `<hash>.lock` on every poll/update; `remove_watch` deleted only the `.json`. **Fix**: `remove_watch` removes the sibling `.lock`, and `gc_stale_watches` sweeps any orphaned `.lock` (no sibling `.json`) — reaping the 269 historical orphans.

## Safety (watchdog-sensitive — don't drop an active watch)

- future `expires_at` + run-bearing polls + recent subscription → **all survive** (tested).
- max-age cap is 7d (a real per-push CI watch goes terminal within minutes-to-an-hour).
- `expires_at` fail-open semantics unchanged.

## Tests

- `empty_run_poll_does_not_refresh_expires_at_1750` (rewritten from the old refresh-asserting test) + `successful_poll_refreshes_expires_at` still green (run-bearing refreshes)
- `gc_max_age_cap_removes_watch_kept_young_by_polling` — future-expiry + old subscription removed; fresh subscription spared
- `gc_reaps_orphaned_lock_but_keeps_sibling_of_live_watch`
- `remove_watch_deletes_sibling_lock_1750`

Full `ci_watch` suite: **217 passed**. `fmt --check` + `clippy --all-targets --features tray -D warnings` clean.

A1 (dispatch_hook:532 arming `Result`-check + bypass-push coverage) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)