### PR TITLE
fix(#1750 A1): surface dispatch-time auto-watch arming failures (was silent)

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -309,6 +309,20 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
     )
 }
 
+/// #1750 A1: classify a `handle_watch_ci` result. The handler returns a JSON
+/// `{"error":..,"code":..}` object on a failed arm and an ok-shaped object
+/// otherwise; this extracts `(code, error)` when arming failed, else `None`.
+/// Pure so the dispatch-time auto-watch error-surfacing is unit-testable without
+/// provoking a real disk-write failure.
+fn auto_watch_arm_error(result: &serde_json::Value) -> Option<(&str, &str)> {
+    let err = result.get("error")?.as_str()?;
+    let code = result
+        .get("code")
+        .and_then(|c| c.as_str())
+        .unwrap_or("unknown");
+    Some((code, err))
+}
+
 /// #931 Fix 2 (H5a): unified entry that accepts both `source_repo_override`
 /// (Sprint 55 P0-B) and `next_after_ci` (the workflow chain target).
 /// All four convenience entry points (`dispatch_auto_bind_lease`,
@@ -529,15 +543,29 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
         if !task_id.is_empty() {
             watch_args["task_id"] = serde_json::json!(task_id);
         }
-        crate::mcp::handlers::ci::handle_watch_ci(home, &watch_args, target);
-        tracing::info!(
-            %target,
-            repo = %r,
-            %branch,
-            next_after_ci = ?effective_next,
-            explicit = next_after_ci.is_some(),
-            "dispatch auto-watch_ci"
-        );
+        let watch_result = crate::mcp::handlers::ci::handle_watch_ci(home, &watch_args, target);
+        // #1750 A1: `handle_watch_ci` returns `{"error":..,"code":..}` on a failed
+        // arm (watch_write_failed / ci_watches_dir_create_failed / binding-stale).
+        // Previously this Result was discarded and the success log fired
+        // unconditionally — a silently-failed arm left no trace, the surface
+        // behind "CI green but no watch armed, ci-ready never fires". Surface the
+        // failure as an error log instead of a false success (the dispatch itself
+        // still proceeds — auto-watch is best-effort convenience, not a gate).
+        if let Some((code, err)) = auto_watch_arm_error(&watch_result) {
+            tracing::error!(
+                %target, repo = %r, %branch, code, error = %err,
+                "dispatch auto-watch_ci FAILED — no CI watch armed (ci-ready will not fire)"
+            );
+        } else {
+            tracing::info!(
+                %target,
+                repo = %r,
+                %branch,
+                next_after_ci = ?effective_next,
+                explicit = next_after_ci.is_some(),
+                "dispatch auto-watch_ci"
+            );
+        }
     }
 
     Ok(DispatchOutcome {

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -580,6 +580,31 @@ fn delegate_task_same_agent_different_branch_without_delivering() {
 // `dispatch_auto_bind_lease` and `delegate_task_with_repo_creates_ci_watch`
 // FAILS (no watch file). Restore → PASS. See commit message §regression-proof.
 
+/// #1750 A1: `auto_watch_arm_error` classifies a `handle_watch_ci` result so the
+/// dispatch-time auto-watch path can surface a failed arm (previously the Result
+/// was discarded and a success log fired unconditionally).
+#[test]
+fn auto_watch_arm_error_classifies_handle_watch_ci_result_1750() {
+    // ok-shaped result (no `error` field) → None → success-log path
+    let ok = serde_json::json!({ "status": "watching", "repo": "owner/repo" });
+    assert!(super::auto_watch_arm_error(&ok).is_none());
+    // error-shaped result → Some((code, error)) → error-log path
+    let err = serde_json::json!({
+        "error": "watch file write failed: disk full",
+        "code": "watch_write_failed",
+    });
+    assert_eq!(
+        super::auto_watch_arm_error(&err),
+        Some(("watch_write_failed", "watch file write failed: disk full")),
+    );
+    // error without an explicit code → "unknown"
+    let err_no_code = serde_json::json!({ "error": "boom" });
+    assert_eq!(
+        super::auto_watch_arm_error(&err_no_code),
+        Some(("unknown", "boom"))
+    );
+}
+
 #[test]
 fn delegate_task_with_repo_creates_ci_watch() {
     let home = std::env::temp_dir().join(format!("agend-s53-p02-{}-with-repo", std::process::id()));


### PR DESCRIPTION
## What

The dispatch auto-watch path called `handle_watch_ci(...)` and **discarded its return value**, then logged `dispatch auto-watch_ci` success *unconditionally*. `handle_watch_ci` returns `{"error":..,"code":..}` on a failed arm (`watch_write_failed` / `ci_watches_dir_create_failed` / binding-stale), so a failed arm left **no trace** — the silent-failure surface behind "CI green but no watch armed, ci-ready never fires" (part A1 of the daemon-hygiene investigation).

## How

Capture the result and classify it via a new pure `auto_watch_arm_error(&Value) -> Option<(code, error)>` helper. On failure → `tracing::error!` with the code + message (greppable, operator-visible); on success → the existing info log. **The dispatch still proceeds** — auto-watch is best-effort convenience, not a gate.

## Scope note

This closes the silent-failure surface on the **daemon-bound push path** (the normal flow). The separate **bypass-push** gap — `AGEND_GIT_BYPASS` pushes skip the `dispatch_hook` entirely (via the agend-git shim's `should_bypass()`), so no auto-watch is armed at all (the *actual* cause of #1775's missing watch) — is a **design fork being synced separately** (it touches the shim; a prior decision flagged it "marginal value"). Not in this PR.

## Test

`auto_watch_arm_error_classifies_handle_watch_ci_result_1750` — ok-shaped → `None`; error-shaped → `Some((code,error))`; error-without-code → `"unknown"`.

`fmt --check` + `clippy --all-targets --features tray -D warnings` clean; dispatch_hook suite 47 passed. Rebased onto current origin/main (09d6618 / #1776) — diff is exactly the 2 dispatch_hook files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)