### PR TITLE
fix(#1777): extend the #1768 working-marker override to UsageLimit (Sticky UsageLimit)

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -872,7 +872,18 @@ impl StateTracker {
                         // latches → auto-retry fires. Detection-side only;
                         // `clears_server_rate_limit_retry` untouched → no #1713
                         // flicker-reset regression.
-                        let landed = if high_fp {
+                        //
+                        // #1777 (cheerc, "Sticky UsageLimit"): UsageLimit (prio 11)
+                        // is the same kind of sticky error — it outranks
+                        // Thinking/ToolUse and never auto-expires (no
+                        // `maybe_expire_latched_state` arm), so a stale UsageLimit
+                        // line keeps re-latching after the agent resumed work below
+                        // it (status stuck on `[UsageLimit]` until the line scrolls
+                        // off). Extend the same recovery override to it. UsageLimit
+                        // stays OUT of `is_high_fp_state` → the #1450 red anchor is
+                        // unchanged (that decision is ① Step-2, pending the
+                        // operator); this is the #1768 working-marker override only.
+                        let landed = if high_fp || matches!(detected, AgentState::UsageLimit) {
                             patterns
                                 .working_state_below(screen_text, matched)
                                 .unwrap_or(detected)

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3288,6 +3288,49 @@ fn retry_storm_error_with_no_working_marker_still_latches_1768() {
     );
 }
 
+/// #1777 (cheerc, "Sticky UsageLimit"): UsageLimit (prio 11 > Thinking/ToolUse,
+/// and never auto-expires) is the same sticky-error class as the #1768 retry
+/// storm — after the agent resumed work below a scrolled-up UsageLimit line, the
+/// status stayed stuck on `[UsageLimit]` until the line scrolled off. The #1768
+/// working-marker override now covers UsageLimit too.
+#[test]
+fn usage_limit_recovered_below_error_lands_on_working_state_1777() {
+    // UsageLimit line scrolled UP; the agent's most-recent line is the work spinner.
+    let screen = "▌ You've hit your usage limit. try again at 3pm.\n\
+                  ▌ resuming\n\
+                  ▌ esc to interrupt";
+    let n = screen.chars().count();
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    t.feed_with_fg(screen, &vec![CellFg::Default; n]);
+    assert_ne!(
+        t.get_state(),
+        AgentState::UsageLimit,
+        "#1777: a recovered agent (working-marker below the scrolled-up UsageLimit) \
+         must NOT re-latch UsageLimit"
+    );
+    assert_eq!(
+        t.get_state(),
+        AgentState::Thinking,
+        "#1777: it lands on the working state the marker indicates"
+    );
+}
+
+/// #1777: the override is recovery-only — a genuinely-stuck UsageLimit (no
+/// in-flight working marker below it) must STILL latch so the operator is notified.
+#[test]
+fn usage_limit_stuck_no_working_marker_still_latches_1777() {
+    let screen = "▌ You've hit your usage limit. try again at 3pm.\n\
+                  ▌ waiting for the limit to reset";
+    let n = screen.chars().count();
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    t.feed_with_fg(screen, &vec![CellFg::Default; n]);
+    assert_eq!(
+        t.get_state(),
+        AgentState::UsageLimit,
+        "#1777: a UsageLimit with no working-marker below must still latch"
+    );
+}
+
 /// #1768 (the idle-between-turns FP that REJECTED the first cut): a net-error
 /// TOKEN merely MENTIONED in prose — an orchestrator discussing the bug, idle
 /// between turns — rendered DEFAULT, with NO error-label on its line and NO


### PR DESCRIPTION
## What
Fix #1777 (cheerc, "Sticky UsageLimit"): after an agent recovers from a usage-limit error and **resumes producing output**, the status stayed stuck on `[UsageLimit]` until the stale error line scrolled off (15+ lines later). Same class as the #1768 retry storm — a sticky error state that wins the priority race over working markers.

## Root cause
`UsageLimit` (priority 11) outranks `Thinking` (6) / `ToolUse` (5), so `detect_with_match` (first-match-by-priority) keeps returning `UsageLimit` while the stale error string is still on screen. And `UsageLimit`:
- is **not** in `is_high_fp_state` → it never got the #1768 working-marker override (that was gated `if high_fp`), and
- has **no arm in `maybe_expire_latched_state`** → it never auto-expires.

So once latched it re-latches every scan until the line scrolls out of the grid. (Unlike #1768 this is a stale-**display** bug, not a retry storm — `UsageLimit` drives operator-notify, not `continue` re-injection, and `transition()`'s same-state early-return means no notify spam.)

## Fix
Extend the #1768 working-marker override to `UsageLimit` — one condition:
```rust
let landed = if high_fp || matches!(detected, AgentState::UsageLimit) {
    patterns.working_state_below(screen_text, matched).unwrap_or(detected)
} else { detected };
```
When a `Thinking`/`ToolUse` marker is rendered **below** the stale UsageLimit line, the agent recovered → land on that working state. A genuinely-stuck UsageLimit (no working marker below → agent blocked) → `working_state_below` returns `None` → still latches → operator still notified.

- **`UsageLimit` stays OUT of `is_high_fp_state`** → the #1450 red anchor is unchanged. The red→content anchor decision is ① Step-2 (pending the operator's call on the color signal) — this PR does not touch it.
- **Detection-side only**, reuses the existing `working_state_below`. No notify/expiry/anchor changes.

## RateLimit / ContextFull (the "evaluate siblings" ask)
Already covered — both are in `is_high_fp_state`, so they already get the working-marker override (+ the #1518 position gate). `UsageLimit` was the only non-high_fp error state missing it. (`ModelUnsupported` is also high_fp → covered.)

## Considered but NOT done (flagging for the lens)
I did **not** also extend the #1518 `stale_position` gate to `UsageLimit`. The working-marker override fully fixes cheerc's reported scenario (recovered + producing). The only residual is the narrow idle-recovery case (agent done + idle, stale line still on-screen, no working marker) — minor display staleness that self-heals on scroll-off, not the reported bug. Extending `stale_position` too would make UsageLimit fully consistent with the high_fp siblings (and is safe — a real blocked UsageLimit produces no output so its line stays in the tail). Happy to add it as a follow-up if you want the consistency; kept this PR to the explicit ask + a tight diff.

## Tests
- `usage_limit_recovered_below_error_lands_on_working_state_1777` — UsageLimit scrolled up + `esc to interrupt` below → lands `Thinking`, NOT `UsageLimit`.
- `usage_limit_stuck_no_working_marker_still_latches_1777` — UsageLimit alone (no marker) → still `UsageLimit` (operator notified).
- #1768 `retry_storm_*`, existing `usage_limit_*` (incl. per-backend fixtures) unchanged + green.

Preflight: `cargo fmt --check` + clippy (`tray`, `tray,discord`, `-D warnings`) + full `cargo test --tests` all green. Base = latest `origin/main` (incl. #1776).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
