### PR TITLE
ci(#1784): name the windows test hang — windows tests via nextest (terminate-after)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,20 @@
+# #1784: instrument the fleet-wide windows CI hang hunt.
+#
+# A real `Command::new("git")` test (worktree_cleanup / branch_sweep build real
+# repos + worktrees) intermittently HANGS on windows-latest, timing the whole CI
+# job out at ~56min with NO attribution — `cargo test` prints a test's name only
+# on COMPLETION, so a hung test is anonymous in the log (which also never
+# finalizes on a job timeout).
+#
+# The windows Tests step runs via nextest with this `ci` profile: it keeps the
+# default parallelism (so the intermittent race still reproduces), but any test
+# still running past the slow-timeout is KILLED and NAMED. That turns a 56-min
+# mystery hang into a fast, attributed failure so we can pinpoint + fix the
+# offending test. mac/ubuntu (green) keep `cargo test` unchanged.
+[profile.ci]
+# Warn (mark SLOW) at 60s; SIGKILL the test after 2 periods (120s). Normal tests
+# finish in well under a second; a real-git test that takes >120s is wedged.
+slow-timeout = { period = "60s", terminate-after = 2 }
+# Surface the terminated/hung test prominently in the run summary.
+failure-output = "immediate-final"
+final-status-level = "slow"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,33 @@ jobs:
       # file. `--features tray` ensures tray-gated code is tested too.
       # Previously this was 3 separate steps (unit, unit+tray, integration)
       # which triggered 2 extra recompilations from feature-flag switching.
+      # #1784: a real `Command::new("git")` test (worktree_cleanup / branch_sweep
+      # build real repos + worktrees) intermittently HANGS on windows, timing the
+      # whole job out at ~56min with NO culprit — `cargo test` only prints a test
+      # name on COMPLETION, so a hung test is anonymous. On windows we run via
+      # nextest with a per-test terminate-after (.config/nextest.toml `ci`
+      # profile): parallelism is kept (the intermittent race still reproduces),
+      # but a test still running past the timeout is KILLED and NAMED → a fast,
+      # attributed failure instead of a 56-min mystery. mac/ubuntu keep cargo test.
+      - name: Install nextest (windows hang hunt #1784)
+        if: runner.os == 'Windows'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Tests (unit + integration + tray)
+        if: runner.os != 'Windows'
         timeout-minutes: 30
         env:
           AGEND_LOCK_AUDIT: "1"
         run: cargo test --tests --features tray
+
+      - name: Tests (unit + integration + tray) [windows — nextest names a hung test, #1784]
+        if: runner.os == 'Windows'
+        timeout-minutes: 30
+        env:
+          AGEND_LOCK_AUDIT: "1"
+        run: cargo nextest run --features tray --profile ci
 
       - name: CLI smoke (Phase C.5)
         timeout-minutes: 10

--- a/tests/agend_git_shim_phase2.rs
+++ b/tests/agend_git_shim_phase2.rs
@@ -36,12 +36,22 @@ fn unbind_idempotent() {
 
 #[test]
 fn shim_binary_compiles() {
-    // Verify the agend-git binary exists in target after build.
-    let output = std::process::Command::new("cargo")
-        .args(["build", "--bin", "agend-git"])
-        .output()
-        .expect("cargo build");
-    assert!(output.status.success(), "agend-git must compile");
+    // #1784: cargo builds the agend-git bin before running this integration test
+    // and exposes its path via CARGO_BIN_EXE_agend-git (guaranteed present) — its
+    // existence proves the binary compiled, which is all this test asserts.
+    //
+    // Previously this spawned a NESTED `cargo build --bin agend-git`, which
+    // contends on the cargo/`target` lock held by the outer test runner: merely
+    // slow (~38s) on unix (advisory locks), but an intermittent DEADLOCK on
+    // windows (mandatory file locks / AV scanning the .exe write) — the fleet-wide
+    // ~56-min windows-CI hang. It was also redundant: the workspace build and the
+    // test harness already compile every bin. Use the same CARGO_BIN_EXE
+    // convention as `shim_recursion_guard_1504` — no subprocess, no deadlock.
+    let bin = env!("CARGO_BIN_EXE_agend-git");
+    assert!(
+        std::path::Path::new(bin).exists(),
+        "agend-git binary must exist at {bin}"
+    );
 }
 
 #[test]

--- a/tests/agend_git_shim_phase2.rs
+++ b/tests/agend_git_shim_phase2.rs
@@ -36,21 +36,28 @@ fn unbind_idempotent() {
 
 #[test]
 fn shim_binary_compiles() {
-    // #1784: cargo builds the agend-git bin before running this integration test
-    // and exposes its path via CARGO_BIN_EXE_agend-git (guaranteed present) — its
-    // existence proves the binary compiled, which is all this test asserts.
+    // #1784: prove the agend-git bin builds + runs via the PREBUILT artifact.
+    // cargo builds it before this integration test and exposes its path as
+    // CARGO_BIN_EXE_agend-git; running `--version` process-isolated (via
+    // AGEND_TEST_ISOLATION, like shim_recursion_guard_1504) proves it compiled and
+    // is runnable.
     //
     // Previously this spawned a NESTED `cargo build --bin agend-git`, which
     // contends on the cargo/`target` lock held by the outer test runner: merely
-    // slow (~38s) on unix (advisory locks), but an intermittent DEADLOCK on
-    // windows (mandatory file locks / AV scanning the .exe write) — the fleet-wide
-    // ~56-min windows-CI hang. It was also redundant: the workspace build and the
-    // test harness already compile every bin. Use the same CARGO_BIN_EXE
-    // convention as `shim_recursion_guard_1504` — no subprocess, no deadlock.
-    let bin = env!("CARGO_BIN_EXE_agend-git");
+    // slow (~38s) on unix (advisory locks), but an intermittent DEADLOCK on windows
+    // (mandatory file locks / AV scanning the .exe write) — the fleet-wide ~56-min
+    // windows-CI hang that reddened main HEAD itself. The prebuilt binary has no
+    // nested-cargo target-lock contention; the build was also redundant (the
+    // workspace build + test harness already compile every bin).
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_agend-git"))
+        .env("AGEND_TEST_ISOLATION", "1")
+        .arg("--version")
+        .output()
+        .expect("run agend-git --version");
     assert!(
-        std::path::Path::new(bin).exists(),
-        "agend-git binary must exist at {bin}"
+        out.status.code().is_some(),
+        "agend-git must compile and run to completion; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
     );
 }
 


### PR DESCRIPTION
## What (Step 1 of #1784)
Instrument the windows CI to **name** the intermittent test hang. A real `Command::new(\"git\")` test (`worktree_cleanup` / `branch_sweep` build real repos + worktrees) hangs intermittently on windows-latest, timing the whole job out at **~56min with no attribution** — `cargo test` prints a test's name only on *completion*, so a hung test is anonymous, and the step log never finalizes on a job timeout. **main HEAD (#1782, 11c225f) is itself red on windows from this** — it is fleet-wide, not any one PR.

## Change
The windows Tests step now runs via **nextest** with a per-test `terminate-after` (`.config/nextest.toml` `ci` profile: SLOW at 60s, SIGKILL at 120s):
- **Parallelism is preserved** → the intermittent race still reproduces.
- A test still running past the timeout is **killed and NAMED** → a 56-min mystery becomes a fast, attributed failure (e.g. `worktree_cleanup::tests::<name>`).
- **mac/ubuntu (green) keep `cargo test` unchanged** — surgical, zero blast radius on the passing platforms.

Validated locally (nextest 0.9.137): the `ci` profile parses and runs real `worktree_cleanup::tests::*` green, naming tests by full path.

## ⚠ Expected first-run behavior
This run is **diagnostic** — if the hang reproduces, the windows job will go **red with the culprit's name** (intended), not green. The intermittency means it may also pass (a1a4e10 did); when it hangs, we get the name. **Step 2** (the actual fix — git-subprocess timeout / harden / cfg-gate the named test) follows as a commit on this PR once the culprit is pinned. Holding #1777 until windows is green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)