### PR TITLE
fix(#1787 P1a): retry idempotent git in clean_empty_init_commits (windows flake)

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -999,6 +999,47 @@ fn derive_repo_from_remote(source_repo: &std::path::Path) -> Option<String> {
 #[allow(clippy::unwrap_used)]
 mod tests;
 
+/// #1787: run an IDEMPOTENT git subprocess with bounded retry on transient
+/// failure. The #1784 windows-CI hang fix let the full suite run for the first
+/// time and surfaced intermittent transient failures of these dispatch-hook git
+/// calls — e.g. `git log origin/main..HEAD` exiting non-zero with empty stderr
+/// (#1783) under windows scratch-repo lock contention — which a retry clears.
+///
+/// ONLY for idempotent commands (log / diff-tree / reset-to-a-fixed-ref): a
+/// non-idempotent op (`rebase -i`) must NOT route through here and stays a direct
+/// call. Returns the FINAL attempt's output (or the spawn error), so callers keep
+/// their existing success/stderr handling unchanged. `AGEND_GIT_BYPASS=1` is
+/// pinned exactly as the direct calls did. (Wall-clock timeout for the hang class
+/// is the #1787 Phase-4 daemon-git audit; here the confirmed flake is a transient
+/// non-zero exit, and test-level hangs are caught by the #1785 nextest guard.)
+fn run_git_idempotent(args: &[&str], cwd: &Path) -> std::io::Result<std::process::Output> {
+    const MAX_ATTEMPTS: u32 = 3;
+    const BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
+    let mut last: Option<std::process::Output> = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()?;
+        if out.status.success() {
+            return Ok(out);
+        }
+        tracing::debug!(
+            target: "dispatch_hook",
+            attempt,
+            args = ?args,
+            stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+            "#1787: transient git failure, retrying idempotent git command"
+        );
+        last = Some(out);
+        if attempt < MAX_ATTEMPTS {
+            std::thread::sleep(BACKOFF);
+        }
+    }
+    Ok(last.expect("loop runs at least once"))
+}
+
 /// Remove empty commits with message "init" between origin/main and HEAD.
 /// These come from BACKEND session checkpoints (claude-code / kiro-cli)
 /// that fire heartbeats every ~90s; not from agend-terminal production
@@ -1028,11 +1069,9 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
     // helper — worst case we get the same status 256 we had before.
     clear_stale_rebase_state(worktree);
 
-    let output = std::process::Command::new("git")
-        .args(["log", "origin/main..HEAD", "--format=%H %s"])
-        .current_dir(worktree)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output();
+    // #1787: retry — the confirmed #1783 windows flake was this command exiting
+    // non-zero with empty stderr under scratch-repo lock contention.
+    let output = run_git_idempotent(&["log", "origin/main..HEAD", "--format=%H %s"], worktree);
     let output = match output {
         Ok(o) if o.status.success() => o,
         Ok(o) => {
@@ -1070,11 +1109,10 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
             continue;
         }
         // Check if commit has no file changes.
-        let diff = std::process::Command::new("git")
-            .args(["diff-tree", "--no-commit-id", "--name-only", "-r", hash])
-            .current_dir(worktree)
-            .env("AGEND_GIT_BYPASS", "1")
-            .output();
+        let diff = run_git_idempotent(
+            &["diff-tree", "--no-commit-id", "--name-only", "-r", hash],
+            worktree,
+        );
         if let Ok(d) = diff {
             if d.status.success() && d.stdout.trim_ascii().is_empty() {
                 empty_inits.push(hash);
@@ -1089,23 +1127,21 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
     // All commits between origin/main..HEAD are empty inits → soft reset.
     let total_commits = log.lines().count();
     if empty_inits.len() == total_commits {
-        let status = std::process::Command::new("git")
-            .args(["reset", "--soft", "origin/main"])
-            .current_dir(worktree)
-            .env("AGEND_GIT_BYPASS", "1")
-            .status();
+        // #1787: retry — soft-reset to a fixed ref is idempotent.
+        let status = run_git_idempotent(&["reset", "--soft", "origin/main"], worktree);
         match status {
-            Ok(s) if s.success() => {
+            Ok(o) if o.status.success() => {
                 tracing::info!(
                     count = total_commits,
                     "cleaned all empty init commits via soft reset"
                 );
                 return Ok(total_commits);
             }
-            Ok(s) => {
+            Ok(o) => {
                 tracing::warn!("failed to soft-reset empty init commits");
                 return Err(format!(
-                    "git reset --soft origin/main exited with status {s:?}"
+                    "git reset --soft origin/main exited with status {:?}",
+                    o.status
                 ));
             }
             Err(e) => {
@@ -1139,6 +1175,10 @@ pub(crate) fn clean_empty_init_commits(worktree: &Path) -> Result<usize, String>
         .collect();
     let sed_script = sed_parts.join(";");
     let cleaned = empty_inits.len();
+    // #1787 audit: NOT routed through `run_git_idempotent` — `rebase -i` is not
+    // idempotent (a partial/interrupted rebase leaves a rebase-merge dir that a
+    // blind retry would trip over). `clear_stale_rebase_state` above pre-clears
+    // that state, and the `Err` arm below already surfaces a failed abort.
     let status = std::process::Command::new("git")
         .args(["-c", "core.abbrev=7", "rebase", "-i", "origin/main"])
         .current_dir(worktree)
@@ -1288,11 +1328,7 @@ fn strip_known_trailers(body: &str) -> String {
 /// empty" behavior when body-detection fails — neutral fallback that
 /// does not block legitimate cleanups on transient git failures.
 fn commit_body_is_empty(worktree: &Path, hash: &str) -> bool {
-    let out = std::process::Command::new("git")
-        .args(["log", "-1", "--format=%b", hash])
-        .current_dir(worktree)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output();
+    let out = run_git_idempotent(&["log", "-1", "--format=%b", hash], worktree);
     match out {
         Ok(o) if o.status.success() => {
             // #833: strip daemon-injected trailers before the empty

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1978,6 +1978,36 @@ fn clean_empty_init_commits_handles_50_interleaved_inits() {
     std::fs::remove_dir_all(_repo.parent().unwrap()).ok();
 }
 
+/// #1787: `run_git_idempotent` contract — succeeds on a good command, and on a
+/// persistent failure returns the FINAL non-success output (the retry loop
+/// terminates; no panic, no hang). The transient-recovery path is exercised by
+/// the windows CI on the real flaky `clean_empty_init_commits` git calls.
+#[test]
+fn run_git_idempotent_succeeds_and_surfaces_persistent_failure_1787() {
+    let tmp = std::env::temp_dir();
+    // Success on the first attempt — `git --version` needs no repo.
+    let ok = super::run_git_idempotent(&["--version"], &tmp).expect("git --version spawns");
+    assert!(ok.status.success(), "#1787: git --version must succeed");
+
+    // Persistent failure — a fresh empty dir is not a git repo, so `git status`
+    // fails every attempt; the helper must return the final non-success output.
+    let empty = tmp.join(format!(
+        "agend-1787-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&empty).expect("mkdir temp");
+    let bad = super::run_git_idempotent(&["status"], &empty).expect("git status spawns");
+    assert!(
+        !bad.status.success(),
+        "#1787: git status in a non-repo must fail after retries (loop terminates)"
+    );
+    std::fs::remove_dir_all(&empty).ok();
+}
+
 #[test]
 fn clean_empty_init_commits_clears_stale_dir_even_when_no_inits_to_drop() {
     // #814 edge case: stale rebase-merge dir survives a prior


### PR DESCRIPTION
## What (#1787 Phase 1a)
First step of the systematic windows-git-flake harden (follow-up to the #1784 hang fix). The #1784 fix let the full windows suite run to completion for the first time, surfacing a class of intermittent windows git-subprocess test failures the hang had been masking. This PR hardens the **confirmed** one — `dispatch_hook::clean_empty_init_commits` (the #1783 flake) — and audits its same-file siblings.

## Root cause (confirmed flake)
On windows CI, `clean_empty_init_commits` ran `git log origin/main..HEAD` via a raw `.output()` and **intermittently exited non-zero with empty stderr** under scratch-repo lock contention (50 interleaved inits) — failing `clean_empty_init_commits_handles_50_interleaved_inits` + `..._recovers_from_stale_rebase_merge_dir`. main HEAD passes the same test, so it's transient, not a regression. (This is a *transient non-zero exit*, not a hang — so retry is the right fix; test-level hangs are already caught by the #1785 nextest `terminate-after` guard.)

## Fix
New `run_git_idempotent(args, cwd)` helper: bounded retry (3 attempts, 100ms backoff) on transient failure, returning the final attempt's output so callers keep their existing success/stderr handling unchanged. Applied to the **idempotent** git calls:
- `git log origin/main..HEAD` (the confirmed flake) — `clean_empty_init_commits`
- `git diff-tree …` (per-commit emptiness check)
- `git reset --soft origin/main` (idempotent: reset to a fixed ref)
- `git log -1 --format=%b` — `commit_body_is_empty`

**Sibling audit:** `rebase -i origin/main` is deliberately **NOT** routed through the helper (a partial/interrupted rebase isn't idempotent — a blind retry would trip over the rebase-merge dir; `clear_stale_rebase_state` + the existing abort-failure surfacing already handle that path). Documented inline.

## Scope (per lead 拍板)
- Phase 1a only: the confirmed flake + same-file dispatch_hook siblings.
- The broad daemon-wide git-timeout audit (all raw-`.output()` git in the daemon) is **#1787 Phase-4** follow-up — not bundled here (blast radius).
- A wall-clock timeout (hang→fast-fail) belongs to that Phase-4 audit (a correct kill-capable std subprocess-timeout helper is non-trivial and the hang class is already test-guarded by #1785); this PR is retry-only, which is what the confirmed transient flake needs.

## Tests
- `run_git_idempotent_succeeds_and_surfaces_persistent_failure_1787` — contract: succeeds on a good command; on persistent failure returns the final non-success output (loop terminates, no panic/hang).
- The 10 existing `clean_empty_init_commits_*` tests (including the two #1783-flaky ones) pass + now exercise the retry wrapper.

Preflight: `cargo fmt --check` + clippy (`tray`, `tray,discord`, `-D warnings`) + full `cargo test --tests` all green. Base = latest `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
