### PR TITLE
fix(coloranchor-gate): close kiro RateLimit content FN in in_error_line

### DIFF
--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -65,6 +65,15 @@ pub(crate) fn is_net_error_match(matched: &str) -> bool {
 ///   corpus bug where the `_error` underscore killed the old `\berror`
 ///   word-boundary, so `ModelUnsupported`'s `invalid_request_error:` never
 ///   qualified;
+/// - labeled exception — `\w*exception\s*[:?]`: `ThrottlingException:` /
+///   `ThrottlingError:` (AWS/Bedrock-style names kiro renders). The
+///   `t-coloranchor-corpus-gate` rg-on-fixture check found kiro RateLimit
+///   (`ThrottlingException: Rate exceeded …`) was the one color-gated content
+///   false-negative — `Exception` has no `error` substring and the line carries
+///   no `429`/JSON, so it failed every alternation above. The structured
+///   `…Exception:` label is the same strong error-line signal as `…error:`; the
+///   bare phrase `Rate exceeded` is deliberately NOT added — it is prose-ambiguous
+///   (the #848/#854 class) and the real kiro error always carries the label;
 /// - bare HTTP-status (gemini RateLimit lines with no `Error:` label):
 ///   `\b429\b` / `RESOURCE_EXHAUSTED` / `Too Many Requests` / `got status:`;
 /// - structured-JSON error fields: `"type"|"code"|"status": "…error…"` /
@@ -85,7 +94,7 @@ pub(crate) fn in_error_line(screen_text: &str, matched: &str) -> bool {
     static ERROR_LINE: OnceLock<Regex> = OnceLock::new();
     let re = ERROR_LINE.get_or_init(|| {
         Regex::new(
-            r#"(?i)(\b\w*error\s*[:?]|\b429\b|resource_exhausted|too many requests|got status\s*:|"(type|code|status)"\s*:\s*"\w*error\w*"|"reason"\s*:\s*"[^"]*exceeded")"#,
+            r#"(?i)(\b\w*error\s*[:?]|\b\w*exception\s*[:?]|\b429\b|resource_exhausted|too many requests|got status\s*:|"(type|code|status)"\s*:\s*"\w*error\w*"|"reason"\s*:\s*"[^"]*exceeded")"#,
         )
         .expect("error-line regex")
     });

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3387,6 +3387,21 @@ fn in_error_line_matches_corpus_errors_rejects_prose_step1() {
         ("{\"reason\": \"rateLimitExceeded\"}", "rateLimitExceeded"),
         ("{\"type\": \"error\", \"message\": \"x\"}", "error"),
         ("Error: token limit exceeded", "token limit"),
+        // t-coloranchor-corpus-gate: kiro RateLimit — the one color-gated content
+        // FN the rg-on-fixture check found. Needs the new `\w*exception` label
+        // (`Exception` has no `error` substring; the line carries no 429/JSON).
+        (
+            "ThrottlingException: Rate exceeded for this AWS account",
+            "ThrottlingException",
+        ),
+        // codex RateLimit — already covered by the existing `\w*error:` via the
+        // verified `stream error:` wrapper (cf. codex-model-unsupported fixture)
+        // and by the `RateLimitError:` token; pinned here to lock that coverage.
+        (
+            "stream error: rate_limit_exceeded: retry after 60s",
+            "rate_limit_exceeded",
+        ),
+        ("RateLimitError: 429 Too Many Requests", "RateLimitError"),
     ];
     for (line, tok) in real {
         assert!(
@@ -3407,6 +3422,18 @@ fn in_error_line_matches_corpus_errors_rejects_prose_step1() {
             "ECONNRESET",
         ),
         ("see issue 4290 for details", "4290"),
+        // t-coloranchor-corpus-gate: the new `\w*exception` label requires a
+        // trailing `:`/`?` — a bare prose mention with no label stays prose, and
+        // the bare `Rate exceeded` / `rate_limit_exceeded` phrases are NOT in the
+        // regex (prose-ambiguous, #848/#854 class).
+        (
+            "we keep hitting a ThrottlingException in prod lately",
+            "ThrottlingException",
+        ),
+        (
+            "discussing the rate_limit_exceeded code path in state.rs",
+            "rate_limit_exceeded",
+        ),
     ];
     for (line, tok) in prose {
         assert!(

--- a/tests/fixtures/state-replay/MANIFEST.yaml
+++ b/tests/fixtures/state-replay/MANIFEST.yaml
@@ -854,3 +854,22 @@ fixtures:
     expected_final_detect: model_unsupported
     capture_kind: synthetic_from_incident
     provenance: "#1634 — synthetic reconstruction of the codex model-unsupported incident (exact wording + red SGR)"
+
+  - file: codex-rate-limit-typical.raw
+    backend: codex
+    cli_version: "0.135.0"
+    recorded_on: "2026-06-04"
+    scenario: |
+      t-coloranchor-corpus-gate: codex RateLimit rendered via the same RED
+      `stream error: <code>: <message>` wrapper as the model-unsupported
+      incident, with the OpenAI `rate_limit_exceeded` code. Confirms the codex
+      RateLimit token sits on an error-line-shaped line (`stream error:` →
+      `in_error_line` matches via `\w*error:`), so the content path covers codex
+      RateLimit when the #1450 color anchor is eventually dropped (the gate's
+      go/no-go). The RateLimit pattern (`rate_limit_exceeded|RateLimitError|
+      hit your rate limit`) matches; HIGH_FP, so today still requires the red SGR.
+    expected_transitions: [starting, rate_limit]
+    expected_final_state: rate_limit
+    expected_final_detect: rate_limit
+    capture_kind: synthetic_from_docs
+    provenance: "t-coloranchor-corpus-gate — synthetic from the verified codex stream-error shape + OpenAI rate_limit_exceeded code"

--- a/tests/fixtures/state-replay/codex-rate-limit-typical.raw
+++ b/tests/fixtures/state-replay/codex-rate-limit-typical.raw
@@ -1,0 +1,7 @@
+[2J[H[1mOpenAI Codex[0m v0.135.0  (model: gpt-5.3-codex)
+
+[2m›[0m run the migration
+
+[31mstream error: rate_limit_exceeded: Rate limit reached for requests. Please try again in 60s.[0m
+
+[2m›[0m [0m


### PR DESCRIPTION
## What

Prerequisite for dropping the RateLimit/ServerRateLimit color anchor. The `t-coloranchor-corpus-gate` validation (rg-on-fixture = Rust regex engine ground truth) found exactly **one color-gated content false-negative**: kiro RateLimit renders `ThrottlingException: Rate exceeded for this AWS account`, which failed every `in_error_line` alternation (`Exception` has no `error` substring; no 429/JSON). It renders red today so it fires via the #1450 anchor — but the **content path** (the basis for anchor removal) missed it.

## How

- Add a **`\b\w*exception\s*[:?]`** alternation to `in_error_line` — the structured `…Exception:` label is the same strong error-line signal as `…error:` (AWS/Bedrock names). The bare `Rate exceeded` phrase is **deliberately NOT added** (prose-ambiguous, the #848/#854 class; the real kiro error always carries the label).
- **Verified codex RateLimit** content coverage: `rate_limit_exceeded` rides the verified `stream error:` wrapper (→ matches the existing `\w*error:`); `RateLimitError:` matches directly. Added a synthetic `codex-rate-limit-typical.raw` (same red `stream error:` shape as the model-unsupported incident + OpenAI `rate_limit_exceeded` code) + MANIFEST entry as the codex corpus artifact for the removal-step validation.

## Scope

Does **NOT** touch the anchor decision itself — the removal-impl scope is the operator's next call. This only makes the content path (`in_error_line`) cover kiro so RateLimit content coverage is complete.

## Tests

`in_error_line_matches_corpus_errors_rejects_prose_step1` extended: kiro `ThrottlingException:` + codex `stream error: rate_limit_exceeded` + `RateLimitError:` match; bare `ThrottlingException` / `rate_limit_exceeded` prose (no label) stays prose (no new FP). behavioral_shadow + fixture_corpus parity green; full `state::` suite 275 passed; `fmt --check` + `clippy --all-targets --features tray -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)