### PR TITLE
fix(coloranchor): drop red anchor for RateLimit + ServerRateLimit (content gate)

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -315,7 +315,13 @@ fn oscillation_guard_window() -> Duration {
     Duration::from_secs(secs)
 }
 
-/// HIGH_FP states require the red-SGR anchor before transitioning.
+/// HIGH_FP states: FP-prone error states whose markers appear in dialectic prose
+/// / JSON dumps, so they get the extra FP defenses (the #1518 position gate + the
+/// #1769 working-marker override + an anchor gate). The ANCHOR gate splits by
+/// [`requires_red_anchor`] — RateLimit/ServerRateLimit now use a content anchor
+/// (`in_error_line`), only ContextFull/ModelUnsupported still require red. This
+/// predicate stays the full set because position + working-marker apply to all
+/// four regardless of which anchor regime they use.
 /// Per #919 spike + dev-2 cross-audit:
 /// - ServerRateLimit / RateLimit: server-side throttle alternations
 ///   include `api_error|timeout_error|overloaded_error` etc which
@@ -335,6 +341,25 @@ fn is_high_fp_state(state: AgentState) -> bool {
             // hang-check, so a FP would silently disable a healthy agent — the
             // anchor is the FP boundary.
             | AgentState::ModelUnsupported
+    )
+}
+
+/// t-coloranchor-remove-ratelimit (operator-approved after the corpus gate):
+/// which HIGH_FP states still require the #1450 RED-SGR anchor vs the content
+/// anchor (`in_error_line`).
+///
+/// - **`true`** — ContextFull, ModelUnsupported: keep RED. ContextFull has no
+///   fixture corpus to prove a content path; ModelUnsupported never auto-clears
+///   AND suppresses hang-check, so a verbatim-quote FP would silently disable a
+///   healthy agent (the anchor is the FP boundary, #1634).
+/// - **`false`** — RateLimit, ServerRateLimit: content anchor instead. The corpus
+///   gate proved content+position+working-marker preserves detection (5/5 prose
+///   suppressed, FN-covered incl. kiro via #1789), and the residual verbatim-quote
+///   FP self-corrects because both states auto-clear + are retry-driven.
+fn requires_red_anchor(state: AgentState) -> bool {
+    matches!(
+        state,
+        AgentState::ContextFull | AgentState::ModelUnsupported
     )
 }
 
@@ -799,29 +824,37 @@ impl StateTracker {
             match patterns.detect_with_match(screen_text) {
                 Some((detected, matched)) => {
                     let high_fp = is_high_fp_state(detected);
-                    // #1450 red anchor: a HIGH_FP marker needs at least one red
-                    // rendered cell, else it's prose ("Error: ...") not a state.
-                    let anchor_fail = self.anchor_on_red
-                        && high_fp
-                        && !fg.is_empty()
-                        // #1757: exempt hard network errors from the red anchor —
-                        // codex/gemini render `InvalidHTTPResponse`/`ECONNRESET`/…
-                        // in DEFAULT/grey (not red), so the anchor wrongly
-                        // suppressed REAL faults → no ServerRateLimit transition →
-                        // no auto-retry → stuck agent. Scoped: the FP-prone
-                        // api_error/overloaded/context HIGH_FP tokens stay
-                        // red-anchored.
-                        // #1768: NARROW that exemption to the token's LINE looking
-                        // like a real backend error line (`Error:`/`API Error:`/
-                        // `FetchError:` label) — a bare prose/source mention (an
-                        // orchestrator discussing net-errors, idle between turns,
-                        // with no working-marker below) stays red-anchored →
-                        // default-rendered → suppressed, instead of mis-latching
-                        // ServerRateLimit (the retry-storm FP codex caught). A real
-                        // fault IS error-line-shaped → still fails open → latches.
-                        && !(crate::state::patterns::is_net_error_match(matched)
-                            && crate::state::patterns::in_error_line(screen_text, matched))
-                        && !matched_span_has_red(screen_text, matched, fg);
+                    // Anchor gate — two regimes (t-coloranchor-remove-ratelimit,
+                    // operator-approved after the corpus gate's go/no-go):
+                    //
+                    // - **`requires_red_anchor`** {ContextFull, ModelUnsupported}:
+                    //   keep the #1450 RED anchor — a marker needs ≥1 red rendered
+                    //   cell, else it's prose not a state. ContextFull has no
+                    //   corpus to prove a content path; ModelUnsupported never
+                    //   auto-clears AND suppresses hang-check, so a verbatim-quote
+                    //   FP would silently disable a healthy agent (cost too high).
+                    //
+                    // - **content-anchor** {RateLimit, ServerRateLimit}: the marker
+                    //   must sit on an error-line-shaped line (`in_error_line`) —
+                    //   corpus-proven safe (5/5 prose suppressed via pattern-narrow
+                    //   + #1518 position + #1769 working-marker; FN-covered incl.
+                    //   kiro `ThrottlingException` via #1789). NO red required, so a
+                    //   real fault rendered in DEFAULT/grey (codex/gemini net
+                    //   errors) latches — the old #1757 net-error red-exemption is
+                    //   now the GENERAL rule, not a special case. The residual
+                    //   verbatim-quote FP (an agent pasting a real error line into
+                    //   the live tail with no working-marker below) is ACCEPTED for
+                    //   these two: both auto-clear and are retry-driven, so a
+                    //   one-off mis-latch self-corrects (unlike ModelUnsupported).
+                    let anchor_fail = if requires_red_anchor(detected) {
+                        self.anchor_on_red
+                            && !fg.is_empty()
+                            && !matched_span_has_red(screen_text, matched, fg)
+                    } else if high_fp {
+                        !crate::state::patterns::in_error_line(screen_text, matched)
+                    } else {
+                        false
+                    };
                     // #1518 position gate: a HIGH_FP marker that has scrolled out
                     // of the live bottom-N rows (e.g. an ApiError / ServerRateLimit
                     // line pushed up by the post-recovery `continue` output) is

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -29,25 +29,13 @@ use regex::Regex;
 // copy), keeping byte-identity with the legacy compile_for arm that also uses it.
 pub(crate) const SERVER_RATE_LIMIT_NET_ERRORS: &str = r"ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|proxy.*disconnect";
 
-/// #1757: is `matched` one of the [`SERVER_RATE_LIMIT_NET_ERRORS`] tokens?
-///
-/// These hard network faults are rendered in DEFAULT/grey (not red) by codex /
-/// gemini (observed `span_fg=[Default,...]` for `InvalidHTTPResponse` /
-/// `ECONNRESET`), so the #1450 red anchor wrongly suppressed REAL faults → no
-/// `ServerRateLimit` transition → no auto-retry → stuck agent (worst when the
-/// operator is away). The anchor exempts these tokens (fails open like the
-/// empty-`fg` / `Shell` paths). Scoped on purpose: the FP-prone
-/// `api_error`/`overloaded`/context HIGH_FP tokens STAY red-anchored. The
-/// residual net-error FP (these tokens can appear in source/logs/prose — e.g. an
-/// agent viewing THIS file) is bounded by the #1518 live-tail gate, #1586, and
-/// the #1760 nudge cap, so the cost asymmetry (severe stuck-agent vs rare,
-/// self-correcting spurious `continue`) favors the exemption.
-pub(crate) fn is_net_error_match(matched: &str) -> bool {
-    use std::sync::OnceLock;
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(SERVER_RATE_LIMIT_NET_ERRORS).expect("net-error regex compiles"))
-        .is_match(matched)
-}
+// #1757's `is_net_error_match` red-anchor EXEMPTION was removed by
+// t-coloranchor-remove-ratelimit: ServerRateLimit now uses the general content
+// anchor (`in_error_line`) instead of the red anchor, so the net-error special
+// case (net faults render grey → exempt from red) is subsumed — a grey net-error
+// on an error-line-shaped line latches via content, and a bare prose mention is
+// suppressed by content + #1518 position. The shared const above stays: it is
+// still the ServerRateLimit DETECTION pattern (backend_profile + compile_for).
 
 /// Does some on-screen occurrence of `matched` sit in a real backend ERROR LINE
 /// (vs a bare prose/source mention of the same token)?

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -2653,6 +2653,103 @@ fn boundary_plain_quote_above_red_error_still_fires() {
     );
 }
 
+// ── t-coloranchor-remove-ratelimit: RateLimit/ServerRateLimit CONTENT anchor ──
+// Operator-approved after the corpus gate: these two now gate on `in_error_line`
+// (error-line shape) instead of the #1450 RED anchor, so a real fault rendered
+// PLAIN/grey (codex/gemini net errors, or any error-line-shaped line) FIRES, and
+// the prose FP classes still suppress because they lack the `…error:` label.
+// ContextFull / ModelUnsupported KEEP the red anchor (see the two tests below).
+
+/// ServerRateLimit: a real error line rendered PLAIN (no red, fg mask present)
+/// now FIRES via the content anchor — pre-change the red anchor suppressed it
+/// (the #1450/#1757 net-error stuck-agent class, now the general rule).
+#[test]
+fn srl_plain_error_line_fires_via_content_anchor() {
+    let (mut vt, mut st) = claude_tracker();
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "plain (grey) ServerRateLimit on an error-line-shaped line must fire via \
+         the in_error_line content anchor (no red required)"
+    );
+}
+
+/// RateLimit: a claude 429-rejection error rendered PLAIN fires via content.
+#[test]
+fn rate_limit_plain_error_line_fires_via_content_anchor() {
+    let (mut vt, mut st) = claude_tracker();
+    drive_plain_line(
+        &mut vt,
+        &mut st,
+        "API Error: Request rejected (429) · this may be a temporary capacity issue",
+    );
+    assert_eq!(st.get_state(), AgentState::RateLimit);
+}
+
+/// The content anchor still rejects a plain line with NO error-label — the prose
+/// FP class — pinned against the new gate (the inner phrase quoted without the
+/// `API Error:` wrapper is not error-line-shaped).
+#[test]
+fn srl_plain_prose_without_error_label_still_suppressed() {
+    let (mut vt, mut st) = claude_tracker();
+    drive_plain_line(
+        &mut vt,
+        &mut st,
+        "note: Server is temporarily limiting requests is the phrase we detect",
+    );
+    assert_ne!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "prose without an error-label must stay suppressed under the content anchor"
+    );
+}
+
+/// ContextFull KEEPS the red anchor (no fixture corpus to prove a content path):
+/// a plain ContextFull line does NOT fire; the same line in red does.
+#[test]
+fn context_full_still_requires_red_anchor() {
+    let line = "context window is full, compacting";
+    let (mut vt, mut st) = claude_tracker();
+    drive_plain_line(&mut vt, &mut st, line);
+    assert_ne!(
+        st.get_state(),
+        AgentState::ContextFull,
+        "plain ContextFull (no red) must stay suppressed — it keeps the red anchor"
+    );
+    let (mut vt2, mut st2) = claude_tracker();
+    drive_colored_line(&mut vt2, &mut st2, RED_16, line);
+    assert_eq!(
+        st2.get_state(),
+        AgentState::ContextFull,
+        "red ContextFull must fire (anchor unchanged)"
+    );
+}
+
+/// ModelUnsupported KEEPS the red anchor (never auto-clears + suppresses
+/// hang-check, so a verbatim-quote FP would silently disable a healthy agent):
+/// a plain codex line does NOT fire; red does.
+#[test]
+fn model_unsupported_still_requires_red_anchor() {
+    let line = "stream error: invalid_request_error: model is not supported";
+    let mut vt = VTerm::new(120, 24);
+    let mut st = StateTracker::new(Some(&Backend::Codex));
+    drive_plain_line(&mut vt, &mut st, line);
+    assert_ne!(
+        st.get_state(),
+        AgentState::ModelUnsupported,
+        "plain ModelUnsupported (no red) must stay suppressed — it keeps the red anchor"
+    );
+    let mut vt2 = VTerm::new(120, 24);
+    let mut st2 = StateTracker::new(Some(&Backend::Codex));
+    drive_colored_line(&mut vt2, &mut st2, RED_16, line);
+    assert_eq!(
+        st2.get_state(),
+        AgentState::ModelUnsupported,
+        "red ModelUnsupported must fire (anchor unchanged)"
+    );
+}
+
 // ── Backend opt-out: Shell fails the anchor open (pre-#919 behavior) ─
 #[test]
 fn anchor_backend_opt_out_for_shell() {


### PR DESCRIPTION
## What

Operator-approved scope after the `t-coloranchor-corpus-gate` go/no-go. The corpus proved color is an unreliable HIGH_FP discriminator (same-text color unstable; Monokai's normal foreground is non-default), and that **content + position + working-marker preserves detection** for RateLimit/ServerRateLimit (5/5 prose suppressed; FN-covered across claude/gemini/opencode/kiro incl. the kiro `ThrottlingException` fix in #1789).

## How

New `requires_red_anchor` splits the anchor gate:

| State | Anchor | Why |
|-------|--------|-----|
| ContextFull, ModelUnsupported | **keep RED** | ContextFull has no fixture corpus; ModelUnsupported never auto-clears + suppresses hang-check → verbatim-FP cost too high (#1634) |
| RateLimit, ServerRateLimit | **CONTENT** (`in_error_line`) | corpus-proven; a real grey/default fault now latches |

For RateLimit/ServerRateLimit the marker must sit on an error-line-shaped line (`in_error_line`) — no red. The old #1757 net-error red-exemption becomes the **general rule** (so `is_net_error_match` is removed, its const stays as the detection pattern). `is_high_fp_state` stays the full set — the #1518 position gate + #1769 working-marker apply to all four regardless of anchor regime.

**Accepted residual FP** (operator call): a real error line pasted verbatim into the live tail with no working-marker below now latches RateLimit/ServerRateLimit. Acceptable because both **auto-clear + are retry-driven** — a one-off mis-latch self-corrects (unlike ModelUnsupported's never-clear).

## Tests (5 new, pinning the new FP/FN profile)

- ServerRateLimit + RateLimit **plain (no red) → FIRE** via content
- plain prose **without an error-label → still suppressed**
- ContextFull + ModelUnsupported **plain → NOT fire / red → fire** (anchor kept)

The full #1450 FP/FN matrix + `discussion_text` (5 prose) + behavioral_shadow stay green. **Full bin suite 3288 passed**; `fmt --check` + `clippy --all-targets --features tray -D warnings` clean.

> Sensitive — changes the detection FP/FN profile. Requesting **codex adversarial review**: does the content+position+working-marker gate actually preserve detection, and is the accepted verbatim-FP truly self-correcting for these two states?

🤖 Generated with [Claude Code](https://claude.com/claude-code)