### PR TITLE
fix(#1694a): wire #685 recovery ladder into app mode (Stage1) + Stage2 no-consumer → Stage3

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -135,22 +135,30 @@ pub fn run(fleet_path_override: Option<&str>) -> Result<()> {
 /// NEW handler is added to `build_default_handlers` but is neither run in app nor
 /// listed here — so additions are a conscious decision, not silent drift.
 ///
-/// - `recovery_dispatcher`: coupled to run_core's `crash_rx` + `handle_crash_respawn`,
-///   which app-standalone has no equivalent of — it does pane-based respawn in the
-///   TUI loop. (#685 dispatch-recovery is shadow-default-off anyway.)
 /// - `snapshot_rotation`: app owns session persistence via `session::save_session_if_changed`.
 /// - `thread_dump`: env-gated diagnostic, not needed in the interactive TUI.
-const APP_TICK_ALLOWLIST: &[&str] = &["recovery_dispatcher", "snapshot_rotation", "thread_dump"];
+///
+/// #1694(a): `recovery_dispatcher` was REMOVED from this allowlist — the live
+/// daemon runs in app mode (`app::run_app`, never `run_core`), so allowlisting it
+/// out meant the #685 recovery ladder was silently dead in the live daemon (the
+/// #1720 class). It now runs in app mode: Stage1 (ESC-nudge to the PTY) needs no
+/// `crash_rx`; Stage2 (restart) has no app-mode consumer, so it escalates to
+/// Stage3 instead of silent-dropping (see `build_default_handlers`'
+/// `stage2_dispatch_available = false` below). All stages stay shadow-gated-off by
+/// default — zero behavior change unless an operator opts in.
+const APP_TICK_ALLOWLIST: &[&str] = &["snapshot_rotation", "thread_dump"];
 
 /// Build the per-tick handler set app-standalone runs: the shared
 /// `build_default_handlers` minus `APP_TICK_ALLOWLIST`. Extracted so the
 /// completeness invariant can compare it against the full daemon set.
 ///
-/// `RecoveryDispatcherHandler` is allowlisted out, so the `crash_tx` it would
-/// consume is a throwaway sender (its receiver is dropped immediately).
+/// #1694(a): `crash_tx` here is a throwaway sender (its receiver is dropped), so
+/// `stage2_dispatch_available = false` — `RecoveryDispatcherHandler` now RUNS
+/// (no longer allowlisted out) and its Stage2 path escalates to Stage3 rather
+/// than emit onto the consumerless channel.
 fn app_tick_handlers() -> Vec<Box<dyn crate::daemon::per_tick::PerTickHandler>> {
     let (crash_tx, _crash_rx) = crossbeam_channel::bounded(1);
-    let mut handlers = crate::daemon::build_default_handlers(crash_tx);
+    let mut handlers = crate::daemon::build_default_handlers(crash_tx, false);
     handlers.retain(|h| !APP_TICK_ALLOWLIST.contains(&h.name()));
     handlers
 }
@@ -1514,7 +1522,7 @@ mod tests {
     fn app_tick_handlers_cover_every_non_allowlisted_daemon_handler() {
         use std::collections::HashSet;
         let (crash_tx, _rx) = crossbeam_channel::bounded(1);
-        let all: HashSet<&str> = crate::daemon::build_default_handlers(crash_tx)
+        let all: HashSet<&str> = crate::daemon::build_default_handlers(crash_tx, true)
             .iter()
             .map(|h| h.name())
             .collect();
@@ -1543,6 +1551,23 @@ mod tests {
                 "allowlisted handler '{a}' must NOT run in app-standalone"
             );
         }
+    }
+
+    /// #1694(a): the #685 recovery ladder must RUN in app mode — the live daemon
+    /// is app-standalone (`run_app`), never `run_core`, so allowlisting
+    /// `recovery_dispatcher` out left the whole ladder silently dead in production
+    /// (the #1720 / #1002 class). This pins it back IN the app run set.
+    #[test]
+    fn recovery_dispatcher_runs_in_app_mode_1694a() {
+        let names: Vec<&str> = app_tick_handlers().iter().map(|h| h.name()).collect();
+        assert!(
+            names.contains(&"recovery_dispatcher"),
+            "recovery_dispatcher must RUN in app mode (#1694a) — got {names:?}"
+        );
+        assert!(
+            !APP_TICK_ALLOWLIST.contains(&"recovery_dispatcher"),
+            "recovery_dispatcher must NOT be allowlisted out of app mode (#1694a)"
+        );
     }
 
     /// #1726 must-verify: app-standalone runs these handlers with EMPTY

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -431,10 +431,15 @@ pub(crate) fn register_event_subscribers(registry: &AgentRegistry) {
 /// invariant fails CI if a new handler lands here but neither runs in app nor is
 /// allowlisted.
 ///
-/// `crash_tx` is consumed by `RecoveryDispatcherHandler`; app passes a throwaway
-/// sender because it allowlists that handler out (it does pane-based respawn).
+/// `crash_tx` is consumed by `RecoveryDispatcherHandler`. `stage2_dispatch_available`
+/// tells the handler whether a `Stage2Restart` on that channel has a live consumer
+/// in this runtime: `run_core` wires `crash_rx` (true); app-standalone passes a
+/// throwaway sender (false) — #1694(a) now RUNS the handler in app mode (Stage1
+/// ESC-nudge), but its Stage2 path escalates to Stage3 rather than silent-drop
+/// onto the consumerless channel.
 pub(crate) fn build_default_handlers(
     crash_tx: crossbeam_channel::Sender<crate::agent::AgentExitEvent>,
+    stage2_dispatch_available: bool,
 ) -> Vec<Box<dyn per_tick::PerTickHandler>> {
     let watchdog_dry_run = watchdog::watchdog_dry_run_from_env();
     // Vec order MUST match the pre-extraction call order (zero-behavior-change guarantee).
@@ -442,6 +447,7 @@ pub(crate) fn build_default_handlers(
         Box::new(per_tick::HangDetectionHandler::new()),
         Box::new(per_tick::RecoveryDispatcherHandler::new(
             std::sync::Arc::new(crash_tx),
+            stage2_dispatch_available,
         )),
         Box::new(per_tick::WatchdogHandler::new(watchdog_dry_run)),
         Box::new(per_tick::ExternalLivenessHandler::new()),
@@ -744,7 +750,9 @@ fn build_tick_infrastructure(
     // by instances deleted before the cascade-on-delete fix existed.
     crate::daemon::orphan_sweep::run(home);
 
-    let handlers = build_default_handlers(ctx.crash_tx.clone());
+    // #1694(a): run_core wires `crash_rx` → `handle_crash_respawn`, so Stage2
+    // restarts have a live consumer here (true).
+    let handlers = build_default_handlers(ctx.crash_tx.clone(), true);
 
     let tick_rx = {
         let (tx, rx) = crossbeam_channel::bounded(1);

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -125,13 +125,28 @@ pub(crate) struct RecoveryDispatcherHandler {
     /// future stages and avoids leaking `crossbeam_channel::Sender`
     /// across the trait boundary.
     crash_tx: std::sync::Arc<crossbeam_channel::Sender<crate::agent::AgentExitEvent>>,
+    /// #1694(a): whether a `Stage2Restart` emitted on `crash_tx` actually has a
+    /// live consumer in THIS runtime. `run_core` wires `crash_rx` →
+    /// `handle_crash_respawn` (true); app-standalone passes a throwaway channel
+    /// whose `rx` is dropped (false), so a Stage2 `try_send` there would silently
+    /// vanish. When false, `handle_stage2_fire` escalates straight to Stage3
+    /// (graceful pause + operator escalation) instead of a no-op restart — the
+    /// M-class silent-drop this whole sprint has been closing. (The real fix —
+    /// Stage2 driving app mode's pane-based respawn — is a follow-up; Stage2 stays
+    /// gated-off by default, so this only fires if an operator enables Stage2 in
+    /// app mode.)
+    stage2_dispatch_available: bool,
 }
 
 impl RecoveryDispatcherHandler {
     pub(crate) fn new(
         crash_tx: std::sync::Arc<crossbeam_channel::Sender<crate::agent::AgentExitEvent>>,
+        stage2_dispatch_available: bool,
     ) -> Self {
-        Self { crash_tx }
+        Self {
+            crash_tx,
+            stage2_dispatch_available,
+        }
     }
 }
 
@@ -215,6 +230,31 @@ fn classify_branch(
         Stage1Branch::AliveStuck
     } else {
         Stage1Branch::Anomaly
+    }
+}
+
+/// #1694(a): three-way decision for `handle_stage2_fire`, extracted (like
+/// [`Stage1Branch`]) so the branch logic is unit-testable independent of the
+/// PTY/channel side effects — no AgentHandle harness needed.
+#[derive(Debug, PartialEq, Eq)]
+enum Stage2Decision {
+    /// Gate off — shadow mode: log the would-fire, no send, no transition.
+    Shadow,
+    /// Gate on but no live crash consumer in this runtime (app-standalone) —
+    /// escalate to Stage3 (graceful pause + escalation) rather than silent-drop
+    /// the `Stage2Restart` onto a receiver-less channel.
+    EscalateNoConsumer,
+    /// Gate on + a live consumer — emit the `Stage2Restart` (active mode).
+    Fire,
+}
+
+fn stage2_decision(gate_active: bool, stage2_dispatch_available: bool) -> Stage2Decision {
+    if !gate_active {
+        Stage2Decision::Shadow
+    } else if !stage2_dispatch_available {
+        Stage2Decision::EscalateNoConsumer
+    } else {
+        Stage2Decision::Fire
     }
 }
 
@@ -474,20 +514,43 @@ impl RecoveryDispatcherHandler {
         snapshot: &DispatchSnapshot,
         gate_active: bool,
     ) {
-        if !gate_active {
-            // Shadow mode — emit telemetry but no event send and no
-            // state transition. Operator can observe the decision
-            // pattern before flipping `AGEND_AUTO_RECOVERY_STAGE2=1`.
-            tracing::info!(
-                target: TARGET,
-                agent = %name,
-                recovery_restart_count = snapshot.recovery_restart_count,
-                silent_ms = snapshot.silent.as_millis() as u64,
-                silent_productive_ms = snapshot.silent_productive.as_millis() as u64,
-                gate_active = false,
-                "stage2 would-have-fired (shadow mode): Stage2Restart event NOT emitted"
-            );
-            return;
+        match stage2_decision(gate_active, self.stage2_dispatch_available) {
+            Stage2Decision::Shadow => {
+                // Emit telemetry but no event send and no state transition.
+                // Operator can observe the decision pattern before flipping
+                // `AGEND_AUTO_RECOVERY_STAGE2=1`.
+                tracing::info!(
+                    target: TARGET,
+                    agent = %name,
+                    recovery_restart_count = snapshot.recovery_restart_count,
+                    silent_ms = snapshot.silent.as_millis() as u64,
+                    silent_productive_ms = snapshot.silent_productive.as_millis() as u64,
+                    gate_active = false,
+                    "stage2 would-have-fired (shadow mode): Stage2Restart event NOT emitted"
+                );
+                return;
+            }
+            Stage2Decision::EscalateNoConsumer => {
+                // #1694(a): Stage 2 auto-restart has no consumer in THIS runtime —
+                // app-standalone passes a throwaway `crash_tx` whose `rx` is
+                // dropped, so `try_send(Stage2Restart)` would silently vanish (the
+                // M-class silent-drop). Escalate straight to Stage3 (graceful pause
+                // + operator escalation, which needs no crash consumer) so the
+                // stuck agent is SURFACED, not dropped. Stage2 stays gated-off by
+                // default, so this only fires if an operator enabled Stage2 in app
+                // mode; the proper fix (Stage2 driving app mode's pane-based
+                // respawn) is a follow-up.
+                tracing::warn!(
+                    target: TARGET,
+                    agent = %name,
+                    recovery_restart_count = snapshot.recovery_restart_count,
+                    "stage2 restart unavailable in this runtime (no crash consumer) — escalating to Stage3 instead of silent-drop"
+                );
+                let mut core = target.core.lock();
+                core.health.recovery_stage_state = RecoveryStageState::Stage3Eligible;
+                return;
+            }
+            Stage2Decision::Fire => {}
         }
 
         // Active mode — emit telegram notify pre-emit so operators have
@@ -921,7 +984,7 @@ mod tests {
             externals: &externals,
             configs: &configs,
         };
-        RecoveryDispatcherHandler::new(sentinel_crash_tx()).run(&ctx);
+        RecoveryDispatcherHandler::new(sentinel_crash_tx(), true).run(&ctx);
         assert!(registry.lock().is_empty());
         std::fs::remove_dir_all(&home).ok();
     }
@@ -991,7 +1054,7 @@ mod tests {
     #[test]
     fn name_matches_module() {
         assert_eq!(
-            RecoveryDispatcherHandler::new(sentinel_crash_tx()).name(),
+            RecoveryDispatcherHandler::new(sentinel_crash_tx(), true).name(),
             "recovery_dispatcher"
         );
     }
@@ -1026,7 +1089,7 @@ mod tests {
                 externals: &externals,
                 configs: &configs,
             };
-            RecoveryDispatcherHandler::new(sentinel_crash_tx()).run(&ctx);
+            RecoveryDispatcherHandler::new(sentinel_crash_tx(), true).run(&ctx);
             std::fs::remove_dir_all(&home).ok();
         });
     }
@@ -1112,6 +1175,24 @@ mod tests {
         with_stage2_gate(false, || {
             assert!(!stage2_gate_active());
         });
+    }
+
+    /// #1694(a): the three-way Stage2 decision — the seam that makes
+    /// `handle_stage2_fire`'s no-consumer escalation testable without a full
+    /// AgentHandle/PTY harness (same pattern as `classify_branch`/`Stage1Branch`).
+    #[test]
+    fn stage2_decision_escalates_on_no_consumer_else_fires_1694a() {
+        // Gate OFF → shadow, regardless of consumer (no send, no transition).
+        assert_eq!(stage2_decision(false, true), Stage2Decision::Shadow);
+        assert_eq!(stage2_decision(false, false), Stage2Decision::Shadow);
+        // Gate ON + live consumer (run_core's crash_rx) → Fire (emit Stage2Restart).
+        assert_eq!(stage2_decision(true, true), Stage2Decision::Fire);
+        // Gate ON + NO consumer (app-standalone's throwaway crash_tx) → escalate
+        // to Stage3 instead of silently dropping the restart onto a dead channel.
+        assert_eq!(
+            stage2_decision(true, false),
+            Stage2Decision::EscalateNoConsumer
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The #685 hung-agent recovery ladder (Stage1 ESC-nudge → Stage2 restart → Stage3 escalate) was allowlisted **out** of app mode (`APP_TICK_ALLOWLIST`), so it was **silently dead in the live daemon** — the live daemon runs `app::run_app`, never `run_core` (the #1720 / #1002 class). The original incident (proxy-drop leaves an agent stuck at the prompt) was never even evaluated for recovery.

Operator-approved scope: **Stage1-only, gradual opt-in**.

## How

1. **Run in app mode** — remove `recovery_dispatcher` from `APP_TICK_ALLOWLIST`. Stage1 (ESC byte → PTY) needs no `crash_rx`. The app-tick completeness invariant now requires + verifies it runs there.
2. **Shadow-gate kept** — all stages stay gated off by default; zero behavior change unless an operator opts in. Stage1-granular opt-in uses the existing `AGEND_AUTO_RECOVERY_STAGE1=1` (no new config — KISS).
3. **Stage2 no-consumer → Stage3 (not silent-drop)** — app passes a throwaway `crash_tx` (rx dropped), so a Stage2 `try_send` would silently vanish (the M-class silent-drop). Thread `stage2_dispatch_available` through `build_default_handlers` (run_core=true, app=false); a new `Stage2Decision {Shadow, EscalateNoConsumer, Fire}` makes `handle_stage2_fire` escalate to Stage3 (graceful pause + operator escalation) when no consumer exists. Stage2 stays gated-off by default, so this only fires if an operator enables Stage2 in app mode.
4. **Anti-thrash** — the existing Stage1 cooldown already dedups rapid nudges.

## Tests

- `recovery_dispatcher_runs_in_app_mode_1694a` — pins it runs in app + is not allowlisted
- `stage2_decision_escalates_on_no_consumer_else_fires_1694a` — gate-off→Shadow, consumer→Fire, **no-consumer→EscalateNoConsumer** (the silent-drop fix; mirrors the `Stage1Branch`/`classify_branch` testable-decision pattern since no AgentHandle/PTY harness exists)

Completeness invariant + full bin suite **3290 passed**; fmt + clippy clean.

## Follow-ups (out of Stage1-only scope)

- Stage2 → app mode's pane-based respawn (the "proper" Stage2-in-app fix)
- runtime-config toggle (vs env-only)

> Sensitive — autonomous-recovery behavior. Requesting **codex adversarial review**: is the shadow-default truly zero-behavior-change, is the Stage1 wiring correct, and does the no-consumer escalation actually prevent the silent-drop?

🤖 Generated with [Claude Code](https://claude.com/claude-code)