### PR TITLE
fix(dispatch-idle): clear-on-report + dedup + terminal retention (pending-dispatches hygiene)

### DIFF
--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -171,6 +171,40 @@ pub(crate) fn record_dispatch(
     if std::fs::create_dir_all(&dir).is_err() {
         return None;
     }
+    // t-dispatchidle-clear-on-report (2): dedup by (dispatcher, target,
+    // correlation_id). Re-dispatching the SAME task (same task_id) used to create a
+    // fresh duplicate sidecar each call (`next_dispatch_id()`), so 142 correlation
+    // ids had duplicate sidecars live and a single report cleared only one. If a
+    // NON-terminal sidecar with this exact key already exists, REFRESH it in place
+    // (reset the clock + nudge state, keep its `dispatch_id`) instead of creating a
+    // new one — one sidecar per (dispatcher, target, correlation) dispatch-intent.
+    // Only when a `correlation_id` is present: without one we can't tell two
+    // distinct dispatches apart, so fall through to a fresh sidecar.
+    if let Some(corr) = correlation_id {
+        if let Some(mut existing) = list_pending(home).into_iter().find(|d| {
+            matches!(d.status, DispatchStatus::Pending | DispatchStatus::Exceeded)
+                && d.dispatcher == dispatcher
+                && d.target == target
+                && d.correlation_id.as_deref() == Some(corr)
+        }) {
+            existing.issued_at = chrono::Utc::now().to_rfc3339();
+            existing.status = DispatchStatus::Pending;
+            existing.nudge_sent_at = None;
+            existing.not_working_streak = 0;
+            existing.threshold_secs = threshold_secs;
+            if let Ok(body) = serde_json::to_string_pretty(&existing) {
+                if crate::store::atomic_write(
+                    &pending_path(home, &existing.dispatch_id),
+                    body.as_bytes(),
+                )
+                .is_ok()
+                {
+                    return Some(existing.dispatch_id);
+                }
+            }
+            // Refresh write failed → fall through to a fresh sidecar (best effort).
+        }
+    }
     let dispatch_id = next_dispatch_id();
     let payload = PendingDispatch {
         schema_version: SCHEMA_VERSION,
@@ -376,28 +410,31 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
     }
     // A report arriving = the dispatch is done, whether it was still `Pending` or
     // had already timed out to `Exceeded` (idle nudge fired). Match BOTH so a LATE
-    // report on an Exceeded dispatch still deletes the sidecar — otherwise it leaks
-    // until the slow retention / terminal-sweep path (codex probe #1 regression).
-    let matched = list_pending(home).into_iter().find(|d| {
+    // report on an Exceeded dispatch still deletes the sidecar.
+    //
+    // t-dispatchidle-clear-on-report: delete ALL sidecars with this
+    // `correlation_id`, not just the first. A re-dispatched task (the SAME task_id
+    // sent twice — e.g. an initial dispatch + a design re-confirm, both
+    // `task_id=t-…`) creates DUPLICATE sidecars via `record_dispatch`'s fresh
+    // `next_dispatch_id()`. The pre-fix `.find()` deleted only one duplicate; the
+    // survivor went `Exceeded` and nudged the delegate AFTER it had already
+    // reported (the clear-on-report noise). (`record_dispatch`'s new dedup stops
+    // NEW duplicates; this delete-all keeps the resolve correct regardless.)
+    let mut first_deleted: Option<String> = None;
+    for d in list_pending(home).into_iter().filter(|d| {
         matches!(d.status, DispatchStatus::Pending | DispatchStatus::Exceeded)
             && d.correlation_id.as_deref() == Some(correlation_id)
-    });
-    let d = matched?;
-    let id = d.dispatch_id.clone();
-    let path = pending_path(home, &id);
-    // A resolved dispatch has no further use — the idle timer's job is done.
-    // DELETE the sidecar rather than flip it to `Resolved` and leave the file to
-    // accumulate. Pre-fix this set `status = Resolved` and nothing ever removed it
-    // (the primary `pending-dispatches/` leak: `cleanup_pending_for_instance`
-    // skipped non-Pending and the 14-day retention sweep was gated off), so
-    // resolved sidecars piled up and a restart re-processed the whole backlog.
-    if std::fs::remove_file(&path).is_ok() {
-        // Best-effort: drop the sidecar's lock file too so it doesn't orphan.
-        let _ = std::fs::remove_file(format!("{}.lock", path.display()));
-        Some(id)
-    } else {
-        None
+    }) {
+        let path = pending_path(home, &d.dispatch_id);
+        // DELETE the sidecar rather than flip it to `Resolved` and leave the file
+        // to accumulate (the pre-fix primary `pending-dispatches/` leak).
+        if std::fs::remove_file(&path).is_ok() {
+            // Best-effort: drop the sidecar's lock file too so it doesn't orphan.
+            let _ = std::fs::remove_file(format!("{}.lock", path.display()));
+            first_deleted.get_or_insert(d.dispatch_id);
+        }
     }
+    first_deleted
 }
 
 /// #1047: reset the timer on a pending sidecar when the dispatchee sends
@@ -979,6 +1016,61 @@ mod tests {
         )
         .unwrap();
         id
+    }
+
+    /// t-dispatchidle-clear-on-report (1): a report clears EVERY sidecar with the
+    /// matching correlation_id, not just the first — so a duplicate left by a
+    /// re-dispatch can't survive to nudge after the report.
+    #[test]
+    fn mark_resolved_deletes_all_duplicate_sidecars_clearonreport() {
+        let home = tmp_home("resolve-all-dups");
+        let now = chrono::Utc::now();
+        // Two sidecars, SAME correlation_id (the re-dispatch duplicate case).
+        let dup_a = write_pending_at(&home, "lead", "dev", Some("t-dup"), "task", 600, now);
+        let dup_b = write_pending_at(&home, "lead", "dev", Some("t-dup"), "task", 600, now);
+        // An unrelated sidecar that must survive.
+        let other = write_pending_at(&home, "lead", "dev", Some("t-other"), "task", 600, now);
+
+        let resolved = mark_resolved(&home, "t-dup");
+        assert!(resolved.is_some(), "must report a deletion");
+
+        let pending = list_pending(&home);
+        assert!(
+            !pending
+                .iter()
+                .any(|p| p.dispatch_id == dup_a || p.dispatch_id == dup_b),
+            "BOTH duplicate sidecars for t-dup must be deleted"
+        );
+        assert!(
+            pending.iter().any(|p| p.dispatch_id == other),
+            "the unrelated correlation's sidecar must survive"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// t-dispatchidle-clear-on-report (2): re-dispatching the SAME task
+    /// (dispatcher, target, correlation_id) refreshes the existing sidecar in
+    /// place instead of creating a duplicate.
+    #[test]
+    fn record_dispatch_dedups_redispatch_by_key_clearonreport() {
+        let home = tmp_home("record-dedup");
+        let first = record_dispatch(&home, "lead", "dev", Some("t-redispatch"), "task", 600);
+        let second = record_dispatch(&home, "lead", "dev", Some("t-redispatch"), "task", 600);
+        assert!(first.is_some() && second.is_some());
+        assert_eq!(
+            first, second,
+            "re-dispatch must REFRESH the same sidecar (same dispatch_id), not create a new one"
+        );
+        let pending = list_pending(&home);
+        let dups = pending
+            .iter()
+            .filter(|p| p.correlation_id.as_deref() == Some("t-redispatch"))
+            .count();
+        assert_eq!(
+            dups, 1,
+            "exactly ONE sidecar for the re-dispatched correlation"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     /// 1. Throttle contract — TICKS_PER_SCAN-1 calls return false, the

--- a/src/daemon/retention/pending_dispatches.rs
+++ b/src/daemon/retention/pending_dispatches.rs
@@ -2,11 +2,19 @@
 
 use std::path::Path;
 
-const RETENTION_DAYS: i64 = 14;
+/// t-dispatchidle-clear-on-report (3): terminal-status sidecars (`Resolved` /
+/// `Exceeded`) are DONE — a resolved dispatch had its report, an exceeded one
+/// already fired its nudge — so they have no further use and are swept after a
+/// SHORT age rather than lingering the old 14 days (the observed backlog: 786
+/// sidecars, 558 resolved + 228 exceeded, oldest 2026-05-22). A `Pending` sidecar
+/// is ACTIVE dispatch tracking and is NEVER swept here (a real pending resolves in
+/// minutes or transitions to `Exceeded`; we do not time-GC live tracking).
+const TERMINAL_RETENTION_DAYS: i64 = 2;
 
-/// Sweep pending-dispatch sidecars older than 14 days.
-/// `cutover` gates the feature — production passes the env-var value,
-/// tests pass the bool directly to avoid process-wide env-var races.
+/// Sweep terminal-status (Resolved/Exceeded) pending-dispatch sidecars older than
+/// [`TERMINAL_RETENTION_DAYS`]. `cutover` gates the feature — production passes the
+/// env-var value (defaults on), tests pass the bool directly to avoid
+/// process-wide env-var races.
 pub(super) fn sweep(home: &Path, cutover: bool) -> usize {
     if !cutover {
         return 0;
@@ -15,8 +23,8 @@ pub(super) fn sweep(home: &Path, cutover: bool) -> usize {
     let Ok(entries) = std::fs::read_dir(&dir) else {
         return 0;
     };
-    let cutoff =
-        chrono::Utc::now() - chrono::TimeDelta::try_days(RETENTION_DAYS).expect("14 fits in i64");
+    let cutoff = chrono::Utc::now()
+        - chrono::TimeDelta::try_days(TERMINAL_RETENTION_DAYS).expect("2 fits in i64");
     let mut swept = 0;
 
     for entry in entries.flatten() {
@@ -32,6 +40,15 @@ pub(super) fn sweep(home: &Path, cutover: bool) -> usize {
         else {
             continue;
         };
+        // Only sweep TERMINAL-status sidecars; a `Pending` dispatch is live
+        // tracking and must never be time-GC'd (t-dispatchidle-clear-on-report §3).
+        if !matches!(
+            dispatch.status,
+            crate::daemon::dispatch_idle::DispatchStatus::Resolved
+                | crate::daemon::dispatch_idle::DispatchStatus::Exceeded
+        ) {
+            continue;
+        }
         let Ok(issued) = chrono::DateTime::parse_from_rfc3339(&dispatch.issued_at) else {
             continue;
         };
@@ -73,7 +90,7 @@ mod tests {
         dir
     }
 
-    fn write_dispatch(home: &Path, dispatch_id: &str, age_days: i64) {
+    fn write_dispatch(home: &Path, dispatch_id: &str, age_days: i64, status: &str) {
         let dir = crate::daemon::dispatch_idle::pending_dir(home);
         std::fs::create_dir_all(&dir).unwrap();
         let issued_at =
@@ -87,7 +104,7 @@ mod tests {
             "expected_kind": "task",
             "threshold_secs": 600,
             "issued_at": issued_at,
-            "status": "pending",
+            "status": status,
             "nudge_sent_at": null,
         });
         std::fs::write(
@@ -98,17 +115,30 @@ mod tests {
     }
 
     #[test]
-    fn sweep_removes_old_dispatches() {
+    fn sweep_removes_old_terminal_keeps_recent_and_pending() {
         let home = tmp_home("sweep-old");
-        write_dispatch(&home, "disp-old", 20);
-        write_dispatch(&home, "disp-recent", 3);
+        // old TERMINAL (exceeded/resolved) → swept past TERMINAL_RETENTION_DAYS.
+        write_dispatch(&home, "disp-exceeded-old", 20, "exceeded");
+        write_dispatch(&home, "disp-resolved-old", 20, "resolved");
+        // recent terminal (< 2d) → kept.
+        write_dispatch(&home, "disp-exceeded-recent", 1, "exceeded");
+        // old PENDING → KEPT (active tracking is never time-GC'd, §3).
+        write_dispatch(&home, "disp-pending-old", 20, "pending");
 
         let swept = sweep(&home, true);
 
-        assert_eq!(swept, 1);
+        assert_eq!(swept, 2, "both old terminal sidecars swept");
         let dir = crate::daemon::dispatch_idle::pending_dir(&home);
-        assert!(!dir.join("disp-old.json").exists());
-        assert!(dir.join("disp-recent.json").exists());
+        assert!(!dir.join("disp-exceeded-old.json").exists());
+        assert!(!dir.join("disp-resolved-old.json").exists());
+        assert!(
+            dir.join("disp-exceeded-recent.json").exists(),
+            "recent terminal (< age) kept"
+        );
+        assert!(
+            dir.join("disp-pending-old.json").exists(),
+            "old PENDING must be KEPT — active dispatch tracking is never swept"
+        );
 
         std::fs::remove_dir_all(&home).ok();
     }
@@ -116,7 +146,7 @@ mod tests {
     #[test]
     fn sweep_skipped_without_cutover() {
         let home = tmp_home("sweep-noenv");
-        write_dispatch(&home, "disp-old2", 20);
+        write_dispatch(&home, "disp-old2", 20, "exceeded");
 
         let swept = sweep(&home, false);
 


### PR DESCRIPTION
## What

A delegate that already reported on a dispatch correlation + stood by for the orchestrator (CI/review) still got nudged by the fixup-watchdog (I hit this on #1791). The second dispatch_idle noise type — distinct from #1792 (dev's long-tool_use silence-clock gap).

**Root cause** (live evidence: 787 sidecars in `pending-dispatches/`, **142 correlation_ids with duplicate sidecars**, one 12×):

1. **`mark_resolved` deleted only the FIRST match** (`.find()`). Re-dispatching the SAME task (same task_id twice — e.g. an initial dispatch + a design re-confirm, as lead did for #1694a) creates duplicate sidecars; a single report cleared one, the survivor went `Exceeded` → nudged after the report.
2. **`record_dispatch` made a fresh sidecar every call** (`next_dispatch_id()`, no dedup) → the 142-dup accumulation.
3. **retention sweep was status-blind + 14d** → terminal sidecars lingered ~14 days (558 resolved + 228 exceeded, oldest 2026-05-22).

## How (cohesive, lead-ratified (1)+(2)+(3))

1. **`mark_resolved` → delete ALL** sidecars with the matching correlation_id (loop, not `.find()`). A report clears every dispatch for that correlation.
2. **`record_dispatch` → dedup/refresh by (dispatcher, target, correlation_id)** — refresh an existing non-terminal sidecar in place (reset clock + nudge state, keep its id) instead of creating a duplicate.
3. **retention sweep → terminal-only + short age** — sweep `Resolved`/`Exceeded` past **2 days** (done dispatches need no 14d retention); **never sweep `Pending`** (active tracking must not be time-GC'd). Sweep already defaults on (`AGEND_RETENTION_CUTOVER != 0`).

## Tests

- `mark_resolved_deletes_all_duplicate_sidecars_clearonreport` — report clears ALL same-correlation sidecars; unrelated survives
- `record_dispatch_dedups_redispatch_by_key_clearonreport` — re-dispatch → one sidecar
- `sweep_removes_old_terminal_keeps_recent_and_pending` — old terminal swept; recent terminal + **old PENDING kept**
- `hook_kind_report_resolves_pending_by_correlation_id` + full bin suite (**3292**) green. fmt + clippy clean. Rebased onto #1792.

> Sensitive — deletes sidecars. Requesting **codex adversarial review**: never delete active (Pending) tracking; delete-all keyed strictly on correlation_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)