### PR TITLE
fix(supervisor): stop ServerRateLimit retry storm on a recovered (productive) agent

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -2967,8 +2967,15 @@ instances:
         // a wedged-throttle agent that has produced nothing; the gate
         // (`productive_silent >= RECOVERY_SILENCE`) would otherwise treat every mock
         // as freshly-recovered. The recovery test overrides this back to fresh.
+        //
+        // Offset = RECOVERY_SILENCE + 30s (just past the gate, NOT 3600s): on
+        // windows `Instant` is monotonic from system BOOT and the CI VM's uptime is
+        // < 1h, so `checked_sub(3600s)` UNDERFLOWED → fell back to `now` (fresh) →
+        // the stuck-agent tests saw "recovered" and failed (macos/ubuntu have larger
+        // Instants and passed). The runner is always up far longer than ~75s by the
+        // Tests step (boot + checkout + build), so this never underflows.
         core.lock().state.last_productive_output = std::time::Instant::now()
-            .checked_sub(std::time::Duration::from_secs(3600))
+            .checked_sub(RECOVERY_SILENCE + std::time::Duration::from_secs(30))
             .unwrap_or_else(std::time::Instant::now);
         let handle = crate::agent::AgentHandle {
             id: crate::types::InstanceId::default(),

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -72,6 +72,19 @@ const RETRY_PHASE_C_START: u32 = 6;
 /// across the retry and ApiError-nudge paths (guards a ServerRateLimit↔ApiError
 /// state flicker from double-injecting).
 const CONTINUE_INJECT_MIN_INTERVAL: Duration = Duration::from_secs(5);
+/// ServerRateLimit recovery window: if the agent has produced PRODUCTIVE output
+/// (a `last_productive_output` bump — marker/heartbeat-gated, NOT the error
+/// re-render) within this window, it has recovered and the retry must NOT inject
+/// `continue` into it (and the track clears). This is the robust, position-
+/// INDEPENDENT recovery signal (same insight as the #1775/#1792 silence clock):
+/// the stale "Server is temporarily limiting" line re-latches ServerRateLimit in
+/// the tail and `working_state_below` (#1769) can't see a marker BELOW the
+/// most-recent error line, so the agent flickers Thinking↔ServerRateLimit and the
+/// Idle-only #1713 clear never fires — but `last_productive_output` stays fresh
+/// throughout, breaking the loop. 45s comfortably exceeds the 10s tick and the
+/// generation gaps between an agent's outputs while still firing fast for a truly
+/// wedged throttle (which produces nothing). Tunable 30–60s.
+const RECOVERY_SILENCE: Duration = Duration::from_secs(45);
 /// #1742: consecutive ServerRateLimit `continue`-inject FAILURES (agent still
 /// present, but the PTY write erred) tolerated before giving up. A single failure
 /// is treated as a transient PTY blip that self-heals, so the track is KEPT and
@@ -1469,7 +1482,17 @@ pub(crate) fn process_error_recovery(
         for handle in reg.values() {
             let name = handle.name.as_str();
             active_names.insert(name.to_string());
-            let state = handle.core.lock().state.current;
+            // Capture current state + productive-silence under one lock. The latter
+            // is the #ratelimit-recovery gate below: a recovered-but-still-latched
+            // ServerRateLimit agent that's producing output has fresh
+            // `last_productive_output`.
+            let (state, productive_silent) = {
+                let core = handle.core.lock();
+                (
+                    core.state.current,
+                    core.state.last_productive_output.elapsed(),
+                )
+            };
 
             // ── #1713 root-fix: ServerRateLimit retry — DECIDE with fresh state ──
             // The "should we inject this tick" decision lives HERE, under the lock,
@@ -1479,7 +1502,25 @@ pub(crate) fn process_error_recovery(
             // only EXECUTES the lock-free PTY inject for the names decided here. So a
             // track can never blind-fire `continue` into a non-error state (e.g. a
             // PermissionPrompt the agent reached after the throttle cleared).
-            if state == AgentState::ServerRateLimit {
+            if state == AgentState::ServerRateLimit && productive_silent < RECOVERY_SILENCE {
+                // #ratelimit-recovery: still latched ServerRateLimit (the stale
+                // "Server is temporarily limiting" line re-matches in the tail and
+                // working_state_below can't see a marker BELOW the most-recent error
+                // line — #1769's positional defeat), BUT the agent has produced
+                // productive output within RECOVERY_SILENCE → it RECOVERED and is
+                // working. Clear the track and do NOT inject. `last_productive_output`
+                // is position-independent, so it breaks the Thinking↔ServerRateLimit
+                // flicker that kept the Idle-only #1713 clear from ever firing (the
+                // live storm that wedged fixup-lead). A genuinely-throttled agent
+                // produces nothing → stays silent → the inject branch below fires.
+                if retry_tracks.remove(name).is_some() {
+                    tracing::info!(
+                        agent = %name,
+                        productive_silent_secs = productive_silent.as_secs(),
+                        "ServerRateLimit retry cleared — agent recovered (recent productive output)"
+                    );
+                }
+            } else if state == AgentState::ServerRateLimit {
                 let track = retry_tracks.entry(name.to_string()).or_insert_with(|| {
                     let delay = Duration::from_secs(SERVER_RATE_LIMIT_BACKOFF[0]);
                     tracing::info!(agent = %name, delay_secs = delay.as_secs(), "ServerRateLimit detected, scheduling retry (Phase A)");
@@ -2920,6 +2961,15 @@ instances:
             health: crate::health::HealthTracker::new(),
         }));
         core.lock().state.current = state;
+        // #ratelimit-recovery: default mock agents to STALE productive output — a
+        // realistic stuck/idle agent. `StateTracker::new` stamps
+        // `last_productive_output = now()`, but a ServerRateLimit-retry test models
+        // a wedged-throttle agent that has produced nothing; the gate
+        // (`productive_silent >= RECOVERY_SILENCE`) would otherwise treat every mock
+        // as freshly-recovered. The recovery test overrides this back to fresh.
+        core.lock().state.last_productive_output = std::time::Instant::now()
+            .checked_sub(std::time::Duration::from_secs(3600))
+            .unwrap_or_else(std::time::Instant::now);
         let handle = crate::agent::AgentHandle {
             id: crate::types::InstanceId::default(),
             name: name.to_string().into(),
@@ -2965,6 +3015,63 @@ instances:
         );
         assert_eq!(tracks["test-agent"].retry_count, 0);
         assert!(!tracks["test-agent"].exhausted);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #ratelimit-recovery (the live storm that wedged fixup-lead): an agent still
+    /// LATCHED ServerRateLimit (the stale "Server is temporarily limiting" line
+    /// re-matches in the tail, and `working_state_below` can't see a marker BELOW
+    /// the most-recent error line) but that has produced PRODUCTIVE output within
+    /// RECOVERY_SILENCE has recovered — its retry track must be CLEARED and NO
+    /// `continue` injected. `last_productive_output` is position-independent, so it
+    /// breaks the Thinking↔ServerRateLimit flicker the Idle-only #1713 clear missed.
+    #[test]
+    fn server_rate_limit_recent_productive_output_clears_and_skips_inject() {
+        let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = tmp_home("srl-recovered");
+        // Pre-arm an in-flight retry track (a ServerRateLimit episode already running).
+        let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
+        tracks.insert(
+            "test-agent".to_string(),
+            RateLimitRetry {
+                retry_count: 2,
+                next_retry_at: Instant::now(),
+                exhausted: false,
+                inject_failures: 0,
+            },
+        );
+        let mut last_inject: HashMap<String, Instant> = HashMap::new();
+
+        let (handle, _reader) =
+            mock_agent_handle("test-agent", crate::state::AgentState::ServerRateLimit);
+        // Recovered: produced productive output just now (< RECOVERY_SILENCE),
+        // overriding mock_agent_handle's stale default.
+        handle.core.lock().state.last_productive_output = Instant::now();
+        registry.lock().insert(handle.id, handle);
+
+        // Several ticks (the live flicker) — must never re-arm + inject.
+        for _ in 0..3 {
+            super::process_error_recovery(
+                &home,
+                &registry,
+                &mut tracks,
+                &mut Default::default(),
+                &mut Default::default(),
+                &mut last_inject,
+                past_boot_grace(),
+            );
+        }
+
+        assert!(
+            !tracks.contains_key("test-agent"),
+            "#ratelimit-recovery: a recently-productive ServerRateLimit agent's retry \
+             track must be cleared (recovered), not maintained/re-armed"
+        );
+        assert!(
+            !last_inject.contains_key("test-agent"),
+            "#ratelimit-recovery: no `continue` may be injected into a recovered \
+             (recently-productive) agent — that was the live storm"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
## What
Fix a **LIVE ServerRateLimit retry storm** that wedged `fixup-lead`: `[AGEND-AUTO kind=ratelimit-retry] continue` was re-injected indefinitely **even after the agent recovered and was producing output** (operator screenshot: badge=ServerRateLimit + 2× "Server is temporarily limiting" + the lead actively typing a holding note).

## Root cause (verified against code)
The retry inject is correctly gated on `state == ServerRateLimit` (supervisor.rs). The agent kept getting `continue` because its **state stayed/re-latched ServerRateLimit**, in a self-sustaining loop:
- The stale "Server is temporarily limiting" line stays in the bottom-N live tail → re-matches ServerRateLimit each scan.
- Recovery = producing a **text** reply. `working_state_below` (#1769) only lands `Thinking`/`ToolUse` when a marker sits **below** the error — but `err_pos = rfind(error)` + `pos > err_pos` means the **re-injected (most-recent) error line is the bottom-most**, so the agent's work marker is always *above* it → the positional check never holds.
- → the agent flickers `Thinking`(generating)↔`ServerRateLimit`(between outputs), **never settling on a clean `Idle`**, so `clears_server_rate_limit_retry` (Idle-only, #1713) never fires. #1713's assumption ("a working agent reaches Idle between turns and clears then") breaks when the stale error re-latches faster than the agent reaches Idle. This is the **facet #1768/#1769 didn't cover**: recovery-with-a-marker-below vs recovery-as-text/between-outputs.

## Fix (per lead 拍板 — the robust, position-independent recovery signal)
Gate the retry on **productive-silence** — the same `last_productive_output` signal as the #1775/#1792 silence-clock work, read from the StateTracker under the existing lock:
- **Clear-track + skip-inject** when a ServerRateLimit agent has produced productive output within `RECOVERY_SILENCE` (45s, tunable 30–60): it recovered.
- A genuinely-throttled agent **produces nothing** → stays silent → the inject branch still fires (preserved).
- `last_productive_output` is **position-independent** (bumped on any productive marker/heartbeat, NOT the error re-render), so it survives the `Thinking↔ServerRateLimit` flicker that defeats the Idle-only clear and the marker-below-error check — **without** re-introducing the #1713 flicker (it's a stable signal, unlike the instantaneous Thinking/ToolUse clear #1713 rejected).

**Scope:** retry-side only (stops the storm — the live harm). The **badge** state-level fix (don't re-latch ServerRateLimit when recently-productive) is a separate follow-up PR (large blast radius, structural-review) per the lead.

## Tests
- `server_rate_limit_recent_productive_output_clears_and_skips_inject` — the live flicker: a pre-armed track + ServerRateLimit + fresh productive output, over 3 ticks → track cleared, **no `continue` injected**.
- `mock_agent_handle` now defaults to **stale** productive output (a realistic stuck agent); the 5 existing ServerRateLimit-retry tests (stuck→keeps-track-and-injects, #1586/#1713 thinking-transient, Idle-clear) all pass unchanged.

Preflight: `cargo fmt --check` + clippy (`tray`, `tray,discord`, `-D warnings`) + full `cargo test --tests` all green. Base = latest `origin/main`.

⚠ **Reviewer adversarial-review ask:** confirm a genuinely-stuck/throttled agent (no productive output) still latches + gets nudged (RECOVERY_SILENCE only suppresses *recently-productive*), and that the 45s window can't let a real wedge slip (the throttle produces nothing → silent → fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
