### PR TITLE
fix(ci-ready): loud-log the no-next + no-subscribers malformed watch (PR-1, option C)

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1674,30 +1674,53 @@ fn persist_watch_state(
     state: &mut WatchState,
 ) {
     if outcome.new_notified_sha.is_some() {
-        if let Some(next) = state.next_after_ci.as_deref().filter(|s| !s.is_empty()) {
-            let last_conclusion = aggregate_conclusion_for_sha_filtered(
-                &pr.runs,
-                &pr.current_sha,
-                state.required_checks.as_deref(),
-            );
-            if last_conclusion == Some("success") {
-                let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
-                let pr_number = crate::daemon::pr_state::load(ctx.home, ctx.repo, ctx.branch)
-                    .map(|s| s.pr_number);
-                let task_id = state.task_id.as_deref();
-                let msg = make_ci_ready_for_action_msg(
-                    ctx.repo,
-                    ctx.branch,
-                    &repo_branch_key,
-                    Some(&pr.current_sha),
-                    pr_number,
-                    task_id,
-                );
-                persist_or_log!(
-                    crate::inbox::enqueue_with_idle_hint(ctx.home, next, msg),
-                    "ci_watch_chain",
-                    next
-                );
+        // t-ci-ready-robust-fallback-design (PR-1, option C): the actionable
+        // `[ci-ready-for-action]` is a CHAIN signal — it routes to `next_after_ci`
+        // (the workflow's next agent). When there is NO chain, non-chain
+        // subscribers ALREADY receive the informational `[ci-pass]` (correct
+        // semantics: no "your turn" exists without a chain), so we do NOT forge an
+        // actionable signal for them. (Verified not load-bearing: `[ci-pass]`
+        // carries the SAME `repo@branch` correlation_id, nothing keys on the
+        // ci-ready correlation for tracking, and CI-done tracking via
+        // `record_ci_result` below is keyed on repo/branch independent of routing.)
+        // The ONE genuinely-silent case — no `next_after_ci` AND no subscribers
+        // (a malformed watch) — is loud-logged rather than dropped silently.
+        if aggregate_conclusion_for_sha_filtered(
+            &pr.runs,
+            &pr.current_sha,
+            state.required_checks.as_deref(),
+        ) == Some("success")
+        {
+            match state.next_after_ci.as_deref().filter(|s| !s.is_empty()) {
+                Some(next) => {
+                    let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
+                    let pr_number = crate::daemon::pr_state::load(ctx.home, ctx.repo, ctx.branch)
+                        .map(|s| s.pr_number);
+                    let task_id = state.task_id.as_deref();
+                    let msg = make_ci_ready_for_action_msg(
+                        ctx.repo,
+                        ctx.branch,
+                        &repo_branch_key,
+                        Some(&pr.current_sha),
+                        pr_number,
+                        task_id,
+                    );
+                    persist_or_log!(
+                        crate::inbox::enqueue_with_idle_hint(ctx.home, next, msg),
+                        "ci_watch_chain",
+                        next
+                    );
+                }
+                None if state.subscriber_names().is_empty() => {
+                    tracing::warn!(
+                        target: "ci_watch",
+                        repo = ctx.repo,
+                        branch = ctx.branch,
+                        "CI passed but watch has no next_after_ci AND no subscribers — \
+                         no one to notify (malformed watch); not dropping silently"
+                    );
+                }
+                None => {}
             }
         }
 

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -2576,6 +2576,68 @@ fn ci_pass_chain_target_excluded_from_subscriber_loop() {
     );
 }
 
+/// t-ci-ready-robust-fallback-design (PR-1, option C): a watch with NO
+/// `next_after_ci` AND NO subscribers (malformed) must NOT silently forge a
+/// `[ci-ready-for-action]` to nobody, and must complete without panic — it
+/// loud-logs and no-ops. (When subscribers ARE present they receive the
+/// informational `[ci-pass]` via the separate subscriber loop; the actionable
+/// `[ci-ready-for-action]` is a chain-only signal, never forged for non-chain
+/// agents.)
+#[test]
+fn ci_pass_no_next_no_subscribers_does_not_forge_ci_ready() {
+    let dir = tmp_dir("ciready-malformed");
+    let ci_dir = dir.join("ci-watches");
+    std::fs::create_dir_all(&ci_dir).ok();
+    let watch = serde_json::json!({
+        "repo": "o/r",
+        "branch": "feat",
+        "subscribers": [],
+        "instance": null,
+        "interval_secs": 60,
+        "last_run_id": null,
+        "head_sha": null,
+        "last_polled_at": null,
+        "last_notified_head_sha": null,
+        "expires_at": (chrono::Utc::now() + chrono::Duration::hours(72)).to_rfc3339(),
+        "last_terminal_seen_at": null,
+    });
+    let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+    std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+    let provider = MockCiProvider::with_runs(vec![CiRun {
+        id: 9,
+        conclusion: Some("success".to_string()),
+        head_sha: "abc1234".to_string(),
+        url: "https://example/run/9".to_string(),
+        name: String::new(),
+    }]);
+    let registry: AgentRegistry =
+        Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    // No subscribers, no next → graceful no-op (loud-log), must not panic.
+    rt.block_on(ci_check_repo(
+        &dir,
+        &watch_path,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec![],
+        &registry,
+        &provider,
+    ))
+    .unwrap();
+    for probe in ["lead", "dev", "reviewer"] {
+        let messages = crate::inbox::drain(&dir, probe);
+        assert!(
+            !messages
+                .iter()
+                .any(|m| m.text.contains("[ci-ready-for-action]")),
+            "{probe} must NOT receive a forged [ci-ready-for-action] (no chain, no subscribers); got: {messages:?}"
+        );
+    }
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 /// #1032 T1: `make_ci_conflict_alert_msg` produces an InboxMessage
 /// whose `enqueue_with_idle_hint_with_emitter` invocation yields a
 /// canonical `[AGEND-MSG-PENDING]` hint. The GREEN swap at site 149


### PR DESCRIPTION
## What

PR-1 of the ci-ready robustness work (`t-ci-ready-robust-fallback-design`). On investigation, the premise "`next_after_ci` unset → ci-ready goes to nobody" turned out **incomplete**: non-chain subscribers already receive the informational `[ci-pass]` via a separate subscriber loop. So this is **option C** (lead-ratified after I surfaced the discovery): keep `[ci-pass]` as the correct non-chain semantics, and only **loud-log** the one genuinely-silent case.

## Why option C (not fan-out)

The actionable `[ci-ready-for-action]` is a **chain signal** routed to `next_after_ci` (the workflow's next agent). Forging it for non-chain subscribers would (a) double-notify (`[ci-pass]` + `[ci-ready]`) and (b) fake a "your turn" that doesn't exist.

**Verified the ci-ready correlation is NOT load-bearing** vs `[ci-pass]` (the judgment lead delegated): `[ci-pass]` carries the **same** `repo@branch` correlation_id (poller.rs:956), nothing keys on the ci-ready correlation for dispatch-tracking, and CI-done tracking (`record_ci_result`) is keyed on repo/branch independent of routing.

## Change

The `next_after_ci`-set path is **byte-identical** to before (no chain-routing regression). Added: when CI passes with **no `next_after_ci` AND no subscribers** (a malformed watch — the armer is normally always a subscriber), **loud-log** instead of dropping silently.

## Tests

`ci_pass_no_next_no_subscribers_does_not_forge_ci_ready` (no forged ci-ready, no panic). All existing chain/subscriber tests + full ci_watch suite (**218**) unchanged. fmt + clippy clean.

## Follow-ups

- **PR-2**: demote `derive_team_reviewer`'s `-reviewer` name-default to explicit-only.
- **PR-3 (the real footgun)**: arm-not-armed — a bypass-push leaves no watch → *zero* notification (#1782). Deferred, tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)