### PR TITLE
fix(ci-ready): drop `<team>-reviewer` name-derived next_after_ci auto-default (PR-2, B)

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -245,23 +245,16 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                 if let Some(r) = crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(
                     &source_canonical,
                 ) {
-                    // #1040 Option F: this checkout-arm path bypasses
-                    // `dispatch_auto_bind_lease_with_source_and_chain`
-                    // (which carries the #1037 auto-derive). Apply the
-                    // same convention scan here so the dev-self-claim
-                    // flow (`repo action=checkout bind=true` at
-                    // task-claim time — the canonical fixup-team
-                    // entry per protocol) propagates the chain target
-                    // into the sidecar. Pre-#1040 every modern fixup
-                    // PR silently armed `next_after_ci=null` and the
-                    // post-#1037 auto-wake quartet never fired.
-                    let mut watch_args = json!({"repository": &r, "branch": branch});
-                    if let Some(next) = crate::mcp::handlers::dispatch_hook::derive_team_reviewer(
-                        home,
-                        instance_name,
-                    ) {
-                        watch_args["next_after_ci"] = json!(next);
-                    }
+                    // t-ci-ready-pr2-drop-derive-reviewer (operator-approved B): the
+                    // #1040/#1037 `<team>-reviewer` auto-derive was REMOVED from the
+                    // dev-self-claim path too (consistent decouple with the dispatch
+                    // side). A self-claimed `repo action=checkout bind=true` now arms
+                    // the watch with NO chain target → on CI pass the dev (a
+                    // subscriber) gets the informational `[ci-pass]`; chaining the
+                    // actionable `[ci-ready-for-action]` to a reviewer requires an
+                    // EXPLICIT `next_after_ci` (review handoff is now explicit, not a
+                    // silent naming-convention auto-handoff).
+                    let watch_args = json!({"repository": &r, "branch": branch});
                     let watch_resp = handle_watch_ci(home, &watch_args, instance_name);
                     if let Some(err_msg) = watch_resp.get("error").and_then(|v| v.as_str()) {
                         let code = watch_resp

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -683,24 +683,15 @@ fn p778_setup_source_repo(parent: &Path, branch: &str) -> std::path::PathBuf {
 
 #[test]
 #[cfg(unix)]
-fn checkout_bind_true_auto_derives_next_after_ci_from_team_1040() {
-    // #1040 RED→GREEN: when `repo action=checkout bind=true` arms a
-    // ci-watch sidecar, the team's `<team>-reviewer` member should be
-    // auto-derived into `next_after_ci` — same convention as the
-    // #1037 dispatch-side auto-derive, applied at the checkout path.
-    //
-    // Empirical motivation (per /tmp/dialectic-1040-primary-dev.md):
-    // `handle_checkout_repo:158-162` calls `handle_watch_ci` directly
-    // with only `{repo, branch}` args, bypassing
-    // `dispatch_auto_bind_lease_with_source_and_chain` entirely. The
-    // #1037 auto-derive helper lives inside the bypassed wrapper, so
-    // every modern fixup-team PR (#1027 through #1031, all of which
-    // used `repo action=checkout bind=true` at task-claim time) armed
-    // sidecars with `next_after_ci=None`.
-    //
-    // REGRESSION-PROOF: revert the `derive_team_reviewer` call at
-    // handle_checkout_repo line 158 → this assertion FAILS because
-    // `watch["next_after_ci"]` reads as null instead of `"val-reviewer"`.
+fn checkout_bind_true_no_longer_auto_derives_next_after_ci_pr2() {
+    // t-ci-ready-pr2-drop-derive-reviewer (operator-approved B): the #1040/#1037
+    // `<team>-reviewer` auto-derive was REMOVED from the dev-self-claim checkout
+    // path too (consistent decouple with the dispatch side). A self-claimed
+    // `repo action=checkout bind=true` now arms the watch with `next_after_ci`
+    // UNSET → on CI pass the dev (a subscriber) gets the informational `[ci-pass]`;
+    // the actionable `[ci-ready-for-action]` review handoff is now EXPLICIT
+    // (lead dispatches the reviewer, or an explicit `next_after_ci`), not a silent
+    // naming-convention auto-handoff.
     let home = p778_tmp_home("1040-derive");
     let parent = p778_tmp_home("1040-derive-src");
     let source = p778_setup_source_repo(&parent, "feat/1040-derive");
@@ -733,11 +724,19 @@ fn checkout_bind_true_auto_derives_next_after_ci_from_team_1040() {
     let watch: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
             .expect("parse watch");
-    assert_eq!(
-        watch["next_after_ci"].as_str(),
-        Some("val-reviewer"),
-        "#1040 GREEN: checkout-bound watch must auto-derive next_after_ci \
-         from team `<team>-reviewer` convention. Got: {watch}"
+    assert!(
+        watch["next_after_ci"].as_str().is_none(),
+        "PR-2: checkout-bound watch must NOT auto-derive next_after_ci from the \
+         `<team>-reviewer` convention (explicit-only now). Got: {watch}"
+    );
+    // The dev (armer) stays a subscriber → it receives [ci-pass] on CI pass.
+    let subscriber_names: Vec<&str> = watch["subscribers"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|s| s["instance"].as_str()).collect())
+        .unwrap_or_default();
+    assert!(
+        subscriber_names.contains(&"val-dev"),
+        "dev (armer) must remain a subscriber (for [ci-pass]). Got: {watch}"
     );
 
     std::fs::remove_dir_all(&home).ok();

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -238,24 +238,12 @@ pub(crate) fn dispatch_auto_bind_lease(
 /// Callers: `comms.rs::handle_delegate_task` (kind=task dispatches that
 /// declare a workflow chain via `args["next_after_ci"]`).
 ///
-/// #1037 Option A auto-derive helper: when the dispatcher omits
-/// `next_after_ci`, look up the target's team membership and return the
-/// first member whose instance name ends in `-reviewer` (the de facto
-/// convention used by `fixup-reviewer`, `demo-reviewer`, etc.). Returns
-/// `None` when the target is teamless or no team member matches —
-/// preserves pre-#1037 behavior for teams that don't follow the
-/// convention.
-///
-/// Self-match is excluded so a dispatcher targeting `<team>-reviewer`
-/// itself doesn't chain to itself.
-pub(crate) fn derive_team_reviewer(home: &Path, target: &str) -> Option<String> {
-    crate::teams::find_team_for(home, target).and_then(|team| {
-        team.members
-            .into_iter()
-            .find(|m| m.ends_with("-reviewer") && m != target)
-    })
-}
-
+/// t-ci-ready-pr2-drop-derive-reviewer (operator-approved B): the #1037
+/// `<team>-reviewer` name-derived `next_after_ci` auto-default
+/// (`derive_team_reviewer`) was DELETED. Both call sites (this auto-watch path
+/// and the `ci/mod.rs` self-claim path) leave `next_after_ci` explicit-only now,
+/// so the helper became dead code. Role-based auto-handoff is a future follow-up
+/// (needs role infra), not a naming convention.
 pub(crate) fn dispatch_auto_bind_lease_with_chain(
     home: &Path,
     target: &str,
@@ -519,17 +507,16 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
         // `ci action=watch next_after_ci=…` manually — easily forgotten
         // and one of the root causes of the 4-in-a-row PR stalls.
         //
-        // #1037 Option A: when the dispatcher omits next_after_ci (the
-        // empirical case for lead's typical send calls — see #1037
-        // issue body for the dogfood evidence on PR #1035), fall back
-        // to auto-deriving from the target's team via the
-        // `<team>-reviewer` naming convention. Closes the loop where
-        // wake-aware routing (#1030) already worked but never fired
-        // because the chain target field was always None.
-        let effective_next = next_after_ci
-            .filter(|s| !s.is_empty())
-            .map(String::from)
-            .or_else(|| derive_team_reviewer(home, target));
+        // t-ci-ready-pr2-drop-derive-reviewer (operator-approved B): the #1037
+        // `<team>-reviewer` name-derived auto-default was REMOVED — it baked the
+        // `-reviewer` naming convention into the daemon and only worked for teams
+        // that follow it. `next_after_ci` is now explicit-only: unset → the watch
+        // arms with no chain target, and on CI pass the dev/subscribers receive
+        // the informational `[ci-pass]` (PR-1 #1796); routing the actionable
+        // `[ci-ready-for-action]` to a reviewer requires an EXPLICIT
+        // `next_after_ci` (lead dispatches the reviewer, or passes it). Role-based
+        // auto-handoff is a future follow-up (needs role infra).
+        let effective_next = next_after_ci.filter(|s| !s.is_empty()).map(String::from);
         let mut watch_args = serde_json::json!({"repository": &r, "branch": branch});
         if let Some(ref next) = effective_next {
             watch_args["next_after_ci"] = serde_json::json!(next);

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1531,22 +1531,16 @@ fn dispatch_persists_task_id_into_ci_watch_sidecar_1031() {
 
 #[test]
 #[cfg(unix)]
-fn dispatch_auto_derives_next_after_ci_from_team_reviewer_convention_1037() {
-    // #1037 RED→GREEN: when the dispatcher does NOT explicitly pass
-    // `next_after_ci`, the daemon auto-derives the chain target from
-    // the target's team using the `<team>-reviewer` naming convention.
-    //
-    // Empirical motivation (lead 2026-05-21): the post-#1030 wake-aware
-    // fix never triggered on real fixup-team PRs because lead's
-    // send(kind=task) MCP calls never set `next_after_ci=fixup-reviewer`
-    // in the args. The wire path propagates the field correctly (per
-    // `dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931`)
-    // — the gap is the caller didn't know to set it. Auto-derive
-    // closes the loop without requiring a per-call burden.
-    //
-    // REGRESSION-PROOF: revert the auto-derive lookup → this test
-    // FAILS because `watch["next_after_ci"]` reads as `null` instead
-    // of `"val-reviewer"` (the team's reviewer-suffixed member).
+fn dispatch_no_longer_auto_derives_next_after_ci_pr2() {
+    // t-ci-ready-pr2-drop-derive-reviewer (operator-approved B): the #1037
+    // `<team>-reviewer` name-derived auto-default was REMOVED. When the dispatcher
+    // does NOT pass `next_after_ci`, the daemon NO LONGER scans the team for a
+    // `-reviewer` member — `next_after_ci` stays unset. On CI pass the dev (a
+    // subscriber) gets the informational `[ci-pass]`; chaining the actionable
+    // `[ci-ready-for-action]` to a reviewer now requires an EXPLICIT
+    // `next_after_ci` (review handoff is explicit, not a naming-convention
+    // auto-handoff). The override path is pinned by the sibling
+    // `dispatch_explicit_next_after_ci_overrides_auto_derive_1037` test.
     let parent = std::env::temp_dir().join(format!(
         "agend-1037-auto-{}-{}",
         std::process::id(),
@@ -1590,12 +1584,20 @@ fn dispatch_auto_derives_next_after_ci_from_team_reviewer_convention_1037() {
     let watch: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
             .expect("parse watch");
-    assert_eq!(
-        watch["next_after_ci"].as_str(),
-        Some("val-reviewer"),
-        "#1037 GREEN: dispatch must auto-derive next_after_ci from \
-         `<team>-reviewer` convention when caller omits the arg. \
-         Got: {watch}"
+    assert!(
+        watch["next_after_ci"].as_str().is_none(),
+        "PR-2: dispatch must NOT auto-derive next_after_ci from the `<team>-reviewer` \
+         convention (explicit-only now). Got: {watch}"
+    );
+    // The dev stays a subscriber → it receives the informational [ci-pass] on CI
+    // pass (the non-chain default; no actionable [ci-ready] is forged).
+    let subscriber_names: Vec<&str> = watch["subscribers"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|s| s["instance"].as_str()).collect())
+        .unwrap_or_default();
+    assert!(
+        subscriber_names.contains(&"val-dev"),
+        "dev must remain a subscriber (for [ci-pass]). Got: {watch}"
     );
 
     std::fs::remove_dir_all(&parent).ok();


### PR DESCRIPTION
## What

Operator-approved **(B)**: remove **both** `derive_team_reviewer` auto-default sites + delete the now-dead helper, decoupling the daemon's chain routing from the `-reviewer` naming convention.

- `dispatch_hook` auto-watch (lead-dispatch path)
- `ci/mod.rs` self-claim path (`repo action=checkout bind=true`)

`next_after_ci` is now **explicit-only**: unset → the watch arms with no chain target, and on CI pass the dev/subscribers get the informational `[ci-pass]` (PR-1 #1796). Routing the actionable `[ci-ready-for-action]` to a reviewer requires an **explicit** `next_after_ci`.

## ⚠ Behavior change (intentional, operator-approved)

The fixup **self-claim → reviewer auto-handoff is REMOVED**. A dev who self-claims via `repo action=checkout bind=true` now gets `[ci-pass]` on CI pass instead of the reviewer being auto-notified — **review handoff is now explicit** (lead dispatches the reviewer, or passes `next_after_ci`). Role-based auto-handoff is a **future follow-up** (needs role infra). No protocol doc documented the auto-handoff, so no doc update needed.

## Tests

The two #1037/#1040 auto-derive tests **inverted** to assert NO auto-derive + the armer stays a subscriber (gets `[ci-pass]`). The explicit-override siblings unchanged (still honored). dispatch_hook (48) + ci (60) suites green; fmt + clippy clean; no drift.

> Sensitive — changes the daemon's routing default + removes a fixup workflow auto-handoff. Reviewer adversarial review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)