### PR TITLE
fix(ci-ready): daemon auto-arms unwatched open PRs (PR-3, arm-not-armed #1782)

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -169,6 +169,40 @@ pub fn scan_existing_branch_binding(
     None
 }
 
+/// PR-3 (t-ci-ready-pr3-arm-not-armed): the distinct `source_repo` paths of every
+/// LIVE bound branch (each `runtime/<agent>/binding.json`'s `source_repo`).
+///
+/// The pr_state scanner seeds its poll-repo list from these (after resolving each
+/// to a gh `owner/repo` slug) so a repo that has a bound branch but NO pr-state
+/// file yet — a bypass / non-dispatch PR — is still polled. Without this seed the
+/// scanner only ever polls repos that already have a pr-state, so a brand-new
+/// unwatched PR in an otherwise-unseeded repo would never be discovered (the
+/// #1782 gap). Returns raw paths (slug resolution is the caller's job) to keep
+/// this module free of the git/scm dependency.
+pub fn bound_source_repos(home: &Path) -> Vec<std::path::PathBuf> {
+    let runtime_dir = crate::paths::runtime_dir(home);
+    let Ok(entries) = std::fs::read_dir(&runtime_dir) else {
+        return Vec::new();
+    };
+    let mut repos: Vec<std::path::PathBuf> = Vec::new();
+    for entry in entries.flatten() {
+        let binding_path = entry.path().join("binding.json");
+        let Ok(content) = std::fs::read_to_string(&binding_path) else {
+            continue;
+        };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        if let Some(src) = v["source_repo"].as_str() {
+            let path = std::path::PathBuf::from(src);
+            if !repos.contains(&path) {
+                repos.push(path);
+            }
+        }
+    }
+    repos
+}
+
 /// Read the current binding for an agent.
 /// Hot path: returns from in-memory index (read lock). Cold path
 /// (first access per agent): acquires write lock, double-checks,

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -343,6 +343,14 @@ pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
         if let Some(created) = watch.earliest_subscribed_at() {
             if now_utc.signed_duration_since(created) > chrono::Duration::hours(MAX_WATCH_AGE_HOURS)
             {
+                // PR-3 (t-ci-ready-pr3-arm-not-armed): exempt watches whose PR is
+                // still OPEN. An open PR should keep notifying on CI, and the
+                // PR-3 auto-arm would otherwise re-create this watch on the next
+                // gh-poll (remove→rearm churn every MAX_WATCH_AGE_HOURS). Only
+                // merged/closed/untracked branches age out here.
+                if crate::daemon::pr_state::is_branch_open(home, repo, branch) {
+                    continue;
+                }
                 remove_watch(
                     home,
                     &path,
@@ -681,6 +689,69 @@ mod tests {
             "recently-subscribed watch must survive the age cap"
         );
         assert_eq!(removed, 1, "exactly the over-age watch removed");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// PR-3 (t-ci-ready-pr3-arm-not-armed): an over-age watch whose PR is still
+    /// OPEN is EXEMPT from the absolute age-cap (it should keep notifying on CI,
+    /// and the auto-arm would re-create it anyway). A same-age watch whose PR is
+    /// MERGED still ages out — proving the exemption is open-specific.
+    #[test]
+    fn gc_max_age_cap_exempts_open_pr_pr3() {
+        use crate::daemon::pr_state::gh_poll::{GhPrMetadata, GhPrState};
+        use crate::daemon::pr_state::{new_for_branch, save, ReviewClass};
+
+        let dir = tmp_dir("pr3-maxage-open-exempt");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        let future = (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339();
+        let old_sub =
+            (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+
+        let gh_meta = |branch: &str, state: GhPrState, merged: bool| GhPrMetadata {
+            number: 1,
+            author_login: "suzuke".to_string(),
+            head_ref: branch.to_string(),
+            is_cross_repository: false,
+            is_draft: false,
+            state,
+            merged_at: merged.then(|| "2026-06-05T00:00:00Z".to_string()),
+        };
+        let write_old_watch = |branch: &str| {
+            let w = serde_json::json!({
+                "repo": "o/r", "branch": branch, "expires_at": future,
+                "subscribers": [{ "instance": "dev", "subscribed_at": old_sub }],
+            });
+            std::fs::write(
+                ci_dir.join(format!("{branch}.json")),
+                serde_json::to_string_pretty(&w).unwrap(),
+            )
+            .unwrap();
+        };
+
+        // Over-age watch for an OPEN PR → exempt.
+        write_old_watch("openpr");
+        let mut open_st = new_for_branch("o/r", "openpr", "deadbeef", ReviewClass::Single);
+        open_st.last_gh_state = Some(gh_meta("openpr", GhPrState::Open, false));
+        save(&dir, &open_st).unwrap();
+
+        // Over-age watch for a MERGED PR → still ages out.
+        write_old_watch("mergedpr");
+        let mut merged_st = new_for_branch("o/r", "mergedpr", "cafef00d", ReviewClass::Single);
+        merged_st.last_gh_state = Some(gh_meta("mergedpr", GhPrState::Merged, true));
+        save(&dir, &merged_st).unwrap();
+
+        let removed = gc_stale_watches(&dir, "test");
+
+        assert!(
+            ci_dir.join("openpr.json").exists(),
+            "an open PR's over-age watch must be EXEMPT from the age cap"
+        );
+        assert!(
+            !ci_dir.join("mergedpr.json").exists(),
+            "a merged PR's over-age watch must still age out (exemption is open-specific)"
+        );
+        assert_eq!(removed, 1, "only the merged PR's watch removed");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/daemon/pr_state/auto_arm.rs
+++ b/src/daemon/pr_state/auto_arm.rs
@@ -1,0 +1,251 @@
+//! PR-3 (t-ci-ready-pr3-arm-not-armed): daemon-side auto-arm of ci-watches for
+//! open PRs that have no armed watch — closing the arm-not-armed footgun (#1782).
+//!
+//! The footgun: a bypass / non-dispatch push (`AGEND_GIT_BYPASS=1`, raw `git`,
+//! IDE, CI-triggered, or a solo agent with no dispatch) leaves NO auto-armed
+//! ci-watch. `should_bypass()` short-circuits the agend-git shim *before* it
+//! could arm, and no client-side hook survives `--no-verify`. So the only place
+//! that reliably observes such a push is server-side: `gh pr list`, which the
+//! pr_state scanner already polls. This module piggybacks on that poll — for any
+//! OPEN PR with no watch, it arms one so CI completion still produces `[ci-pass]`.
+//!
+//! Resolution is BINDING-based, NOT gh-author-based: the fleet shares ONE GitHub
+//! account, so a PR's gh `author.login` cannot tell which agent authored it
+//! (every PR carries the same login → resolving by login mis-notifies, and the
+//! `resolve_author` tier-4 fallback is a hard-coded `"fixup-lead"`).
+//! [`crate::binding::scan_existing_branch_binding`] maps branch → the agent whose
+//! worktree is bound to it (the agent who pushed and is waiting for ci-ready),
+//! which is reliable regardless of the shared login. If no agent is bound
+//! (released worktree / external PR), we fail LOUD rather than notify the wrong
+//! agent.
+
+use std::path::Path;
+
+use super::gh_poll::{GhPrMetadata, GhPrState};
+
+/// For every OPEN, non-draft, same-repo PR in `prs` that has no armed ci-watch,
+/// arm one (subscriber = the agent bound to the branch). Idempotent: an existing
+/// watch is left untouched (a repeated push to the same branch does NOT re-arm).
+/// Best-effort; never blocks the scanner.
+pub fn auto_arm_unwatched_open_prs(home: &Path, repo: &str, prs: &[GhPrMetadata]) {
+    for meta in prs {
+        // Only open, non-draft, same-repo PRs. Drafts/cross-repo forks and
+        // merged/closed PRs are intentionally skipped (a fork head_ref is not a
+        // base-repo branch; a terminal PR needs no further CI notification).
+        if meta.state != GhPrState::Open || meta.is_draft || meta.is_cross_repository {
+            continue;
+        }
+        let branch = meta.head_ref.as_str();
+
+        // Idempotent: skip if a watch already exists (natural dedup — repeated
+        // pushes to the same branch do not re-arm, and an explicitly-armed watch
+        // with its own subscribers/next_after_ci is never clobbered).
+        let watch_path = crate::daemon::ci_watch::ci_watches_dir(home)
+            .join(crate::daemon::ci_watch::watch_filename(repo, branch));
+        if watch_path.exists() {
+            continue;
+        }
+
+        // Binding-based resolution (shared-account-proof): which agent is bound
+        // to this branch? That is the agent who pushed and is waiting.
+        let Some(agent) = crate::binding::scan_existing_branch_binding(home, branch, "") else {
+            // Fail LOUD — never silently drop. We cannot reliably route a
+            // `[ci-pass]` for an open PR with no bound agent (released worktree /
+            // external PR); notifying the wrong agent is worse than a loud log.
+            tracing::warn!(
+                repo = %repo,
+                branch = %branch,
+                pr = meta.number,
+                "PR-3: open PR has no armed ci-watch AND no bound agent — cannot \
+                 auto-arm (arm manually via `ci action=watch`, or rebind the branch)"
+            );
+            continue;
+        };
+
+        // Arm with the bound agent as the sole subscriber; next_after_ci unset →
+        // on CI pass the agent receives the informational `[ci-pass]` (PR-1 #1796
+        // fallback). The actionable `[ci-ready-for-action]` chain still requires
+        // an explicit next_after_ci (review handoff stays explicit, PR-2 #1797).
+        let args = serde_json::json!({ "repository": repo, "branch": branch });
+        let resp = crate::mcp::handlers::ci::handle_watch_ci(home, &args, &agent);
+        if let Some(err) = resp.get("error").and_then(|e| e.as_str()) {
+            tracing::warn!(
+                repo = %repo,
+                branch = %branch,
+                agent = %agent,
+                error = %err,
+                "PR-3: auto-arm handle_watch_ci failed"
+            );
+        } else {
+            tracing::info!(
+                repo = %repo,
+                branch = %branch,
+                agent = %agent,
+                pr = meta.number,
+                "PR-3: auto-armed ci-watch for previously-unwatched open PR"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    const REPO: &str = "owner/repo";
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-pr3-autoarm-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Bind `agent` to `branch` (writes the binding.json `scan_existing_branch_binding` reads).
+    fn bind(home: &Path, agent: &str, branch: &str) {
+        let dir = crate::paths::runtime_dir(home).join(agent);
+        std::fs::create_dir_all(&dir).unwrap();
+        let payload = serde_json::json!({
+            "version": 1,
+            "agent": agent,
+            "task_id": "t-test",
+            "branch": branch,
+            "worktree": format!("/tmp/wt-{agent}"),
+            "source_repo": REPO,
+            "issued_at": "2026-06-05T00:00:00Z",
+        });
+        std::fs::write(
+            dir.join("binding.json"),
+            serde_json::to_string_pretty(&payload).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn meta(branch: &str, state: GhPrState, draft: bool, cross: bool) -> GhPrMetadata {
+        GhPrMetadata {
+            number: 42,
+            author_login: "suzuke".to_string(),
+            head_ref: branch.to_string(),
+            is_cross_repository: cross,
+            is_draft: draft,
+            state,
+            merged_at: None,
+        }
+    }
+
+    fn watch_exists(home: &Path, branch: &str) -> bool {
+        crate::daemon::ci_watch::ci_watches_dir(home)
+            .join(crate::daemon::ci_watch::watch_filename(REPO, branch))
+            .exists()
+    }
+
+    fn watch_subscribers(home: &Path, branch: &str) -> Vec<String> {
+        let path = crate::daemon::ci_watch::ci_watches_dir(home)
+            .join(crate::daemon::ci_watch::watch_filename(REPO, branch));
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        v["subscribers"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|s| s["instance"].as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn unwatched_open_pr_with_bound_agent_gets_armed() {
+        let home = tmp_home("armed");
+        bind(&home, "dev-x", "feat/x");
+        auto_arm_unwatched_open_prs(
+            &home,
+            REPO,
+            &[meta("feat/x", GhPrState::Open, false, false)],
+        );
+        assert!(
+            watch_exists(&home, "feat/x"),
+            "open PR's watch must be armed"
+        );
+        assert!(
+            watch_subscribers(&home, "feat/x").contains(&"dev-x".to_string()),
+            "the BOUND agent (not the gh author login) must be the subscriber"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn already_armed_open_pr_is_noop() {
+        let home = tmp_home("noop");
+        bind(&home, "dev-x", "feat/x");
+        // Pre-arm with a DIFFERENT subscriber (e.g. an explicit `ci action=watch`).
+        crate::mcp::handlers::ci::handle_watch_ci(
+            &home,
+            &serde_json::json!({"repository": REPO, "branch": "feat/x"}),
+            "other-agent",
+        );
+        auto_arm_unwatched_open_prs(
+            &home,
+            REPO,
+            &[meta("feat/x", GhPrState::Open, false, false)],
+        );
+        let subs = watch_subscribers(&home, "feat/x");
+        assert!(
+            subs.contains(&"other-agent".to_string()) && !subs.contains(&"dev-x".to_string()),
+            "an existing watch must be left untouched (no re-arm / no subscriber churn): {subs:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn merged_draft_crossrepo_are_skipped() {
+        let home = tmp_home("skip");
+        bind(&home, "dev-x", "feat/merged");
+        bind(&home, "dev-y", "feat/draft");
+        bind(&home, "dev-z", "feat/fork");
+        auto_arm_unwatched_open_prs(
+            &home,
+            REPO,
+            &[
+                meta("feat/merged", GhPrState::Merged, false, false),
+                meta("feat/draft", GhPrState::Open, true, false),
+                meta("feat/fork", GhPrState::Open, false, true),
+            ],
+        );
+        assert!(
+            !watch_exists(&home, "feat/merged"),
+            "merged PR must not arm"
+        );
+        assert!(!watch_exists(&home, "feat/draft"), "draft PR must not arm");
+        assert!(
+            !watch_exists(&home, "feat/fork"),
+            "cross-repo PR must not arm"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn open_pr_no_bound_agent_fails_loud_no_arm() {
+        let home = tmp_home("failloud");
+        // No binding for feat/orphan → cannot resolve an agent → fail loud, no arm.
+        auto_arm_unwatched_open_prs(
+            &home,
+            REPO,
+            &[meta("feat/orphan", GhPrState::Open, false, false)],
+        );
+        assert!(
+            !watch_exists(&home, "feat/orphan"),
+            "with no bound agent, must NOT arm (fail-loud, not mis-notify)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -47,6 +47,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+pub mod auto_arm;
 pub mod gh_poll;
 mod remote_gc;
 mod scanner;
@@ -434,6 +435,18 @@ pub fn load(home: &Path, repo: &str, branch: &str) -> Option<PrState> {
     let path = pr_state_dir(home).join(pr_state_filename(repo, branch));
     let content = std::fs::read_to_string(&path).ok()?;
     serde_json::from_str(&content).ok()
+}
+
+/// PR-3 (t-ci-ready-pr3-arm-not-armed): is the branch a KNOWN-open PR per the
+/// last gh-poll observation? Used by the ci-watch age-cap GC to exempt open PRs
+/// (an open PR should keep notifying on CI; aging its watch out would only let
+/// the auto-arm re-create it next poll — churn). Conservative: an untracked /
+/// never-polled branch returns `false` (ages out normally).
+pub fn is_branch_open(home: &Path, repo: &str, branch: &str) -> bool {
+    load(home, repo, branch)
+        .and_then(|s| s.last_gh_state)
+        .map(|m| matches!(m.state, gh_poll::GhPrState::Open))
+        .unwrap_or(false)
 }
 
 /// Atomic save — used by tests for setup. Production mutation paths

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -1701,6 +1701,83 @@ mod tests {
         let _ = std::fs::remove_dir_all(&home);
     }
 
+    /// PR-3 (t-ci-ready-pr3-arm-not-armed) — INTEGRATION (codex re-verify): a
+    /// BOUND branch with NO ci-watch AND NO pr-state file must STILL be
+    /// discovered and auto-armed. This exercises the binding-seeded discovery
+    /// path through the real scanner — the exact structural hole codex's first
+    /// pass found, which the `auto_arm` unit tests (injecting `prs` directly)
+    /// could not reach. Without the bound-branch seed, the repo never enters the
+    /// poll list (no pr-state) → the open PR is never discovered → #1782 unfixed.
+    #[test]
+    #[cfg(unix)]
+    fn pr3_bound_branch_with_no_seed_is_discovered_and_armed() {
+        let parent = std::env::temp_dir().join(format!("agend-pr3-integ-{}", std::process::id()));
+        let home = parent.join("home");
+        std::fs::create_dir_all(&home).unwrap();
+
+        // Source repo whose origin remote resolves to the slug "owner/repo".
+        let repo_path = parent.join("source-repo");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        for args in [
+            vec!["init", "-b", "main"],
+            vec![
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/owner/repo.git",
+            ],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(&repo_path)
+                .env("AGEND_GIT_BYPASS", "1")
+                .output()
+                .unwrap();
+        }
+
+        // Bind "dev-x" → branch "feat/x" in that repo. NO pr-state, NO ci-watch.
+        let bdir = crate::paths::runtime_dir(&home).join("dev-x");
+        std::fs::create_dir_all(&bdir).unwrap();
+        std::fs::write(
+            bdir.join("binding.json"),
+            serde_json::to_string(&serde_json::json!({
+                "version": 1, "agent": "dev-x", "task_id": "t",
+                "branch": "feat/x", "worktree": "/tmp/wt-dev-x",
+                "source_repo": repo_path.display().to_string(),
+                "issued_at": "2026-06-05T00:00:00Z",
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        // gh-poll observes one OPEN PR on that branch.
+        let poller = MockGhPoller::new(vec![Ok(vec![gh_meta_open(700, "feat/x", "suzuke")])]);
+
+        scan_and_emit_with(&home, &empty_registry(), &poller);
+
+        // The bound-branch discovery path must have auto-armed a watch.
+        let watch = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+            crate::daemon::ci_watch::watch_filename("owner/repo", "feat/x"),
+        );
+        assert!(
+            watch.exists(),
+            "a bound branch with no pr-state/watch seed must be discovered + auto-armed"
+        );
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&watch).unwrap()).unwrap();
+        let subs: Vec<&str> = v["subscribers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|s| s["instance"].as_str())
+            .collect();
+        assert!(
+            subs.contains(&"dev-x"),
+            "subscriber must be the BOUND agent (not the gh author login): {subs:?}"
+        );
+        std::fs::remove_dir_all(&parent).ok();
+    }
+
     /// #986 T4 — `gh state=MERGED + mergedAt!=None` fires
     /// MergedObserved → reducer transitions to Merged terminal state
     /// → scanner emits `[pr-merged]` to author inbox + sweeps file.

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -334,6 +334,11 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
                 // merged_at}, so no second poller. Best-effort; never blocks the
                 // scanner.
                 super::remote_gc::gc_remote_orphans(&repo, &prs);
+                // PR-3 (t-ci-ready-pr3-arm-not-armed): same piggyback — auto-arm a
+                // ci-watch for any OPEN PR with no armed watch. Closes the
+                // bypass/non-dispatch arm-not-armed gap (#1782) server-side, the
+                // only place a `--no-verify` bypass push is observable.
+                super::auto_arm::auto_arm_unwatched_open_prs(home, &repo, &prs);
             }
             Err(e) => {
                 tracing::warn!(repo = %repo, error = %e, "#986 gh-poll failed");

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -243,25 +243,25 @@ pub fn scan_and_emit_with(
 /// re-applying the same metadata is a no-op for the reducer if state
 /// already matches.
 fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(e) => {
-            tracing::warn!(
-                dir = %dir.display(),
-                error = %e,
-                "#1002 apply_gh_poll read_dir failed — gh-poll skipped this tick"
-            );
-            return;
-        }
-    };
+    // PR-3 (t-ci-ready-pr3-arm-not-armed): the pr_state dir may be ABSENT (cold
+    // start / no PR tracked yet). That must NOT skip the gh-poll — the
+    // bound-branch seed below still drives discovery of unwatched open PRs. So
+    // tolerate a missing/unreadable dir (empty iterator) instead of early
+    // returning, which previously bypassed the whole auto-arm path.
+    let entries = std::fs::read_dir(dir).ok();
     let now = chrono::Utc::now().to_rfc3339();
     // Group files by repo + collect those due for refresh.
     let mut by_repo: HashMap<String, Vec<PrState>> = HashMap::new();
+    // PR-3 (t-ci-ready-pr3-arm-not-armed): every repo with a non-terminal
+    // pr-state is already cadence-managed (it polls on its own `should_poll`
+    // schedule). Track them so the bound-branch seed below does NOT force an
+    // extra poll on an already-known repo (which would defeat `should_poll`).
+    let mut seen_repos: HashSet<String> = HashSet::new();
     let mut skipped_terminal = 0u32;
     let mut skipped_should_poll = 0u32;
-    for entry in entries.flatten() {
+    for entry in entries.into_iter().flatten().flatten() {
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) != Some("json") {
             continue;
@@ -297,10 +297,30 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
             skipped_terminal = skipped_terminal.saturating_add(1);
             continue;
         }
+        // Non-terminal pr-state → this repo is cadence-managed already.
+        seen_repos.insert(state.repo.clone());
         if gh_poll::should_poll(&state, &now) {
             by_repo.entry(state.repo.clone()).or_default().push(state);
         } else {
             skipped_should_poll = skipped_should_poll.saturating_add(1);
+        }
+    }
+
+    // PR-3 (t-ci-ready-pr3-arm-not-armed): seed the poll-repo list from LIVE
+    // BOUND BRANCHES whose repo has NO non-terminal pr-state yet. This is the
+    // discovery path #1782 needs — a bypass / non-dispatch PR has neither a
+    // ci-watch nor a pr-state, so its repo would never be polled from pr-state
+    // alone. Each bound agent's binding.json carries the `source_repo`; resolve
+    // it to a gh slug and poll it (empty `due_states` → the poll just feeds
+    // `auto_arm_unwatched_open_prs`). `seen_repos` keeps this from re-polling a
+    // repo the cadence already manages.
+    for src_path in crate::binding::bound_source_repos(home) {
+        if let Some(slug) =
+            crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(&src_path)
+        {
+            if !seen_repos.contains(&slug) {
+                by_repo.entry(slug).or_default();
+            }
         }
     }
     if !by_repo.is_empty() || skipped_terminal > 0 || skipped_should_poll > 0 {


### PR DESCRIPTION
## What

Closes the real footgun behind the ci-ready work (#1782): a **bypass / non-dispatch push** (`AGEND_GIT_BYPASS=1`, raw git, IDE, CI-triggered, or a solo agent with no dispatch) leaves **no auto-armed ci-watch** → CI passes → no `[ci-pass]` → the agent waits silently.

## Why path 2′ (daemon auto-arm), not a shim hook

`should_bypass()` short-circuits the agend-git shim **before** it could arm, and no client-side hook survives `--no-verify`. So a shim-based arm (the original path 1) **misses the exact bypass case** that #1782 was. The only reliable observation point is **server-side `gh pr list`** — which the pr_state scanner already polls.

## Change

- `scanner.rs`: piggyback on the existing per-repo gh-poll `prs` (same spot as `gc_remote_orphans`) → `auto_arm_unwatched_open_prs`.
- For each **OPEN, non-draft, same-repo** PR with **no existing watch**: arm one. **Idempotent** (existing watch untouched → a repeated push doesn't re-arm).
- **Subscriber = the agent BOUND to the branch** (`scan_existing_branch_binding`), **not** the gh author login. The fleet shares one GitHub account, so the author login can't identify the agent (and `resolve_author`'s tier-4 fallback is a hard-coded `"fixup-lead"`); the binding is the reliable, **shared-account-proof** branch→agent map. **No bound agent → fail LOUD** (no arm, no mis-notify).
- `next_after_ci` unset → on CI pass the agent gets `[ci-pass]` (PR-1 #1796 fallback); the actionable chain still needs an explicit `next_after_ci` (PR-2 #1797).
- **Age-cap GC** (#1750-A2) now **exempts open PRs** (`pr_state::is_branch_open`) — an open PR should keep notifying, and the auto-arm would re-create the watch next poll anyway (churn). Merged/closed/untracked branches still age out.

## Tests

unwatched open PR → armed with the **bound** agent; already-armed → no-op; merged/draft/cross-repo → skip; **no bound agent → fail-loud no-arm**; over-age open PR exempt from age-cap while a merged one still ages out. ci_watch (219) + pr_state (58) suites green; fmt + clippy clean; no drift.

> **Reviewer — adversarial focus on the load-bearing premises** (lead flagged these): (1) `gh_poll` really lists open PRs; (2) the **binding resolves the CORRECT agent** — no mis-notify under the shared GitHub account; (3) no noise (idempotent, fail-loud-not-mis-arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)