### PR TITLE
fix(state): badge-recovery — last_productive_output Instant→Option<Instant> (#serverratelimit-badge)

### DIFF
--- a/src/daemon/per_tick/hang_detection.rs
+++ b/src/daemon/per_tick/hang_detection.rs
@@ -76,7 +76,7 @@ impl PerTickHandler for HangDetectionHandler {
                 // `infer_productivity` returns a Productive signal. Default
                 // shadow-mode in `check_hang` gates classification on
                 // `AGEND_PRODUCTIVE_GATE=1`.
-                let silent_productive = core.state.last_productive_output.elapsed();
+                let silent_productive = core.state.productive_silence();
                 let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
                 let just_detected = core.health.check_hang(
                     agent_state,

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -307,7 +307,7 @@ impl PerTickHandler for RecoveryDispatcherHandler {
                     recovery_restart_count: core.health.recovery_restart_count,
                     agent_state: core.state.current,
                     silent: core.state.last_output.elapsed(),
-                    silent_productive: core.state.last_productive_output.elapsed(),
+                    silent_productive: core.state.productive_silence(),
                 }
             };
 

--- a/src/daemon/per_tick/snapshot.rs
+++ b/src/daemon/per_tick/snapshot.rs
@@ -44,7 +44,7 @@ impl PerTickHandler for SnapshotRotationHandler {
                         c.health.state.display_name().to_string(),
                         // #1694②: productive-silence for the dispatch-idle
                         // silence-clock (marker/heartbeat-gated, spinner-resistant).
-                        c.state.last_productive_output.elapsed().as_secs() as i64,
+                        c.state.productive_silence().as_secs() as i64,
                     )
                 };
                 let cfg = cfgs.get(handle.name.as_str());

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -72,19 +72,11 @@ const RETRY_PHASE_C_START: u32 = 6;
 /// across the retry and ApiError-nudge paths (guards a ServerRateLimit↔ApiError
 /// state flicker from double-injecting).
 const CONTINUE_INJECT_MIN_INTERVAL: Duration = Duration::from_secs(5);
-/// ServerRateLimit recovery window: if the agent has produced PRODUCTIVE output
-/// (a `last_productive_output` bump — marker/heartbeat-gated, NOT the error
-/// re-render) within this window, it has recovered and the retry must NOT inject
-/// `continue` into it (and the track clears). This is the robust, position-
-/// INDEPENDENT recovery signal (same insight as the #1775/#1792 silence clock):
-/// the stale "Server is temporarily limiting" line re-latches ServerRateLimit in
-/// the tail and `working_state_below` (#1769) can't see a marker BELOW the
-/// most-recent error line, so the agent flickers Thinking↔ServerRateLimit and the
-/// Idle-only #1713 clear never fires — but `last_productive_output` stays fresh
-/// throughout, breaking the loop. 45s comfortably exceeds the 10s tick and the
-/// generation gaps between an agent's outputs while still firing fast for a truly
-/// wedged throttle (which produces nothing). Tunable 30–60s.
-const RECOVERY_SILENCE: Duration = Duration::from_secs(45);
+/// ServerRateLimit recovery window — single source of truth in `state` (the
+/// foundational layer). This retry-inject gate and the detection-side badge
+/// re-latch gate share the SAME window, so they're one constant. See
+/// `crate::state::SERVER_RATE_LIMIT_RECOVERY_SILENCE` for the full rationale.
+use crate::state::SERVER_RATE_LIMIT_RECOVERY_SILENCE as RECOVERY_SILENCE;
 /// #1742: consecutive ServerRateLimit `continue`-inject FAILURES (agent still
 /// present, but the PTY write erred) tolerated before giving up. A single failure
 /// is treated as a transient PTY blip that self-heals, so the track is KEPT and
@@ -1482,15 +1474,19 @@ pub(crate) fn process_error_recovery(
         for handle in reg.values() {
             let name = handle.name.as_str();
             active_names.insert(name.to_string());
-            // Capture current state + productive-silence under one lock. The latter
+            // Capture current state + recovery signal under one lock. `recovered`
             // is the #ratelimit-recovery gate below: a recovered-but-still-latched
-            // ServerRateLimit agent that's producing output has fresh
-            // `last_productive_output`.
-            let (state, productive_silent) = {
+            // ServerRateLimit agent that produced output within RECOVERY_SILENCE.
+            // `recovered_within` is None-safe — a just-spawned agent that has NEVER
+            // produced (`last_productive_output == None`) is NOT recovery, so it
+            // latches + injects normally (the fresh-agent edge the creation stamp
+            // used to mis-suppress). `productive_silence` is for the log only.
+            let (state, recovered, productive_silence) = {
                 let core = handle.core.lock();
                 (
                     core.state.current,
-                    core.state.last_productive_output.elapsed(),
+                    core.state.recovered_within(RECOVERY_SILENCE),
+                    core.state.productive_silence(),
                 )
             };
 
@@ -1502,7 +1498,7 @@ pub(crate) fn process_error_recovery(
             // only EXECUTES the lock-free PTY inject for the names decided here. So a
             // track can never blind-fire `continue` into a non-error state (e.g. a
             // PermissionPrompt the agent reached after the throttle cleared).
-            if state == AgentState::ServerRateLimit && productive_silent < RECOVERY_SILENCE {
+            if state == AgentState::ServerRateLimit && recovered {
                 // #ratelimit-recovery: still latched ServerRateLimit (the stale
                 // "Server is temporarily limiting" line re-matches in the tail and
                 // working_state_below can't see a marker BELOW the most-recent error
@@ -1516,7 +1512,7 @@ pub(crate) fn process_error_recovery(
                 if retry_tracks.remove(name).is_some() {
                     tracing::info!(
                         agent = %name,
-                        productive_silent_secs = productive_silent.as_secs(),
+                        productive_silent_secs = productive_silence.as_secs(),
                         "ServerRateLimit retry cleared — agent recovered (recent productive output)"
                     );
                 }
@@ -2961,22 +2957,12 @@ instances:
             health: crate::health::HealthTracker::new(),
         }));
         core.lock().state.current = state;
-        // #ratelimit-recovery: default mock agents to STALE productive output — a
-        // realistic stuck/idle agent. `StateTracker::new` stamps
-        // `last_productive_output = now()`, but a ServerRateLimit-retry test models
-        // a wedged-throttle agent that has produced nothing; the gate
-        // (`productive_silent >= RECOVERY_SILENCE`) would otherwise treat every mock
-        // as freshly-recovered. The recovery test overrides this back to fresh.
-        //
-        // Offset = RECOVERY_SILENCE + 30s (just past the gate, NOT 3600s): on
-        // windows `Instant` is monotonic from system BOOT and the CI VM's uptime is
-        // < 1h, so `checked_sub(3600s)` UNDERFLOWED → fell back to `now` (fresh) →
-        // the stuck-agent tests saw "recovered" and failed (macos/ubuntu have larger
-        // Instants and passed). The runner is always up far longer than ~75s by the
-        // Tests step (boot + checkout + build), so this never underflows.
-        core.lock().state.last_productive_output = std::time::Instant::now()
-            .checked_sub(RECOVERY_SILENCE + std::time::Duration::from_secs(30))
-            .unwrap_or_else(std::time::Instant::now);
+        // A fresh `StateTracker` now defaults `last_productive_output` to `None`
+        // (never produced) — exactly the stuck/just-spawned agent a
+        // ServerRateLimit-retry test models, so `recovered_within` is false → the
+        // retry latches + injects. No stale-Instant stamp needed (the old
+        // `checked_sub(3600s)` underflowed on windows). The recovery test instead
+        // stamps `Some(now())` to model an agent that DID just produce.
         let handle = crate::agent::AgentHandle {
             id: crate::types::InstanceId::default(),
             name: name.to_string().into(),
@@ -3052,8 +3038,8 @@ instances:
         let (handle, _reader) =
             mock_agent_handle("test-agent", crate::state::AgentState::ServerRateLimit);
         // Recovered: produced productive output just now (< RECOVERY_SILENCE),
-        // overriding mock_agent_handle's stale default.
-        handle.core.lock().state.last_productive_output = Instant::now();
+        // overriding the `None` (never-produced) default.
+        handle.core.lock().state.last_productive_output = Some(Instant::now());
         registry.lock().insert(handle.id, handle);
 
         // Several ticks (the live flicker) — must never re-arm + inject.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -173,13 +173,23 @@ pub struct StateTracker {
     pub current: AgentState,
     pub(crate) since: Instant,
     pub last_output: Instant,
-    /// F9 (#685 sub-task 4): bumped only when `infer_productivity()` returns
-    /// a `Productive` signal (heartbeat refresh or structural marker match).
-    /// Bare screen change does NOT bump this — unlike `last_output`. Read by
+    /// F9 (#685 sub-task 4): `Some(t)` only when `infer_productivity()` returned
+    /// a `Productive` signal (heartbeat refresh or structural marker match) at
+    /// `t`. Bare screen change does NOT set this — unlike `last_output`. Read by
     /// the daemon supervisor and passed to `check_hang` as `silent_productive`
     /// for the dual-path Hung detection. See `docs/F9-PRODUCTIVE-OUTPUT-GATE.md`
     /// §F9.1 architecture and §F9.3 dual-path decision table.
-    pub last_productive_output: Instant,
+    ///
+    /// `None` until the FIRST productive signal — distinguishing "never produced"
+    /// (a fresh tracker / just-spawned agent) from "recently produced". The
+    /// recovery gates (`recovered_within`: #1795 retry, #badge re-latch) treat
+    /// `None` as NOT recovered, so a creation stamp can no longer be misread as
+    /// recovery. Silence readers (`productive_silence`) fall back to `created_at`,
+    /// preserving the pre-Option behavior.
+    pub last_productive_output: Option<Instant>,
+    /// Silence baseline for an agent that has not yet produced
+    /// (`last_productive_output == None`): the tracker's creation instant.
+    pub(crate) created_at: Instant,
     /// #685 PR-2: hash of the matched-marker substring on the most-recent
     /// productive refresh. Used to suppress re-firing
     /// `last_productive_output = now()` when the same marker text remains
@@ -273,6 +283,24 @@ pub(crate) struct TransitionRecord {
 }
 
 const MARKER_SCAN_TAIL_LINES: usize = 5;
+
+/// ServerRateLimit recovery window — the single source of truth shared by the
+/// detection-side `#badge-recovery` re-latch gate (here) and the supervisor's
+/// `#1795` retry-inject gate (`supervisor` imports this as `RECOVERY_SILENCE`).
+///
+/// If the agent produced PRODUCTIVE output (a `last_productive_output` bump —
+/// marker/heartbeat-gated, NOT the error re-render) within this window, it has
+/// recovered: the badge must not re-latch ServerRateLimit and the retry must not
+/// inject `continue`. This is the robust, position-INDEPENDENT recovery signal
+/// (same insight as the #1775/#1792 silence clock): the stale "Server is
+/// temporarily limiting" line re-latches ServerRateLimit in the tail and
+/// `working_state_below` (#1769) can't see a marker BELOW the most-recent error
+/// line, so the agent flickers Thinking↔ServerRateLimit and the Idle-only #1713
+/// clear never fires — but `last_productive_output` stays fresh throughout,
+/// breaking the loop. 45s comfortably exceeds the 10s tick and the generation
+/// gaps between an agent's outputs while still firing fast for a truly wedged
+/// throttle (which produces nothing). Tunable 30–60s.
+pub(crate) const SERVER_RATE_LIMIT_RECOVERY_SILENCE: Duration = Duration::from_secs(45);
 
 /// #1518: bottom-N bound for HIGH_FP error re-judging. Detection is
 /// level-triggered (re-judged every feed), so an error string lingering
@@ -665,7 +693,8 @@ impl StateTracker {
             current: initial_state,
             since: Instant::now(),
             last_output: Instant::now(),
-            last_productive_output: Instant::now(),
+            last_productive_output: None,
+            created_at: Instant::now(),
             last_productive_marker_hash: None,
             last_anchor_suppress_hash: None,
             last_screen_hash: None,
@@ -917,9 +946,27 @@ impl StateTracker {
                         // unchanged (that decision is ① Step-2, pending the
                         // operator); this is the #1768 working-marker override only.
                         let landed = if high_fp || matches!(detected, AgentState::UsageLimit) {
+                            // #badge-recovery (state-level mirror of #1795): a
+                            // ServerRateLimit whose agent produced PRODUCTIVE output
+                            // within the recovery window has recovered even though
+                            // the stale error still matches and working_state_below
+                            // can't see a marker below the bottom-most (re-injected)
+                            // error line. Land Idle instead of re-latching the badge.
+                            // `recovered_within` is None-safe: a fresh / just-spawned
+                            // agent (never produced) is NOT recovery → falls through
+                            // to `detected` → latches + nudges normally. Scoped to
+                            // ServerRateLimit (the #1795 storm's state); other HIGH_FP
+                            // / UsageLimit keep re-latching as before.
+                            let fallback = if matches!(detected, AgentState::ServerRateLimit)
+                                && self.recovered_within(SERVER_RATE_LIMIT_RECOVERY_SILENCE)
+                            {
+                                AgentState::Idle
+                            } else {
+                                detected
+                            };
                             patterns
                                 .working_state_below(screen_text, matched)
-                                .unwrap_or(detected)
+                                .unwrap_or(fallback)
                         } else {
                             detected
                         };
@@ -1020,7 +1067,7 @@ impl StateTracker {
                     // edits) changes around it.
                     let marker_hash = hash_screen(matched);
                     if self.last_productive_marker_hash != Some(marker_hash) {
-                        self.last_productive_output = Instant::now();
+                        self.last_productive_output = Some(Instant::now());
                         self.last_productive_marker_hash = Some(marker_hash);
                     }
                 }
@@ -1033,7 +1080,7 @@ impl StateTracker {
                     // Heartbeat source is timestamp-driven — each fresh
                     // heartbeat IS new evidence. Always refresh; reset
                     // marker-hash so a subsequent Marker re-fires.
-                    self.last_productive_output = Instant::now();
+                    self.last_productive_output = Some(Instant::now());
                     self.last_productive_marker_hash = None;
                 }
                 _ => {
@@ -1193,6 +1240,28 @@ impl StateTracker {
     /// Get current state.
     pub fn get_state(&self) -> AgentState {
         self.current
+    }
+
+    /// Time since the agent last produced PRODUCTIVE output, for the silence-based
+    /// readers (`check_hang` `silent_productive`, the recovery dispatcher, the
+    /// snapshot `silent_secs`). When the agent has not produced yet
+    /// (`last_productive_output == None`), the baseline is `created_at` — i.e. it
+    /// has been productive-silent since it started. This preserves the pre-Option
+    /// behavior exactly (the field used to be stamped `now()` at creation).
+    pub fn productive_silence(&self) -> Duration {
+        self.last_productive_output
+            .unwrap_or(self.created_at)
+            .elapsed()
+    }
+
+    /// Has the agent produced PRODUCTIVE output within `window`? Used by the
+    /// recovery gates (#1795 retry inject, #badge re-latch). `None` (never
+    /// produced) is NOT recovery — a creation stamp must never be misread as
+    /// recovery, and a just-spawned agent that immediately errors must latch +
+    /// nudge normally. Only a real, recent productive signal counts.
+    pub fn recovered_within(&self, window: Duration) -> bool {
+        self.last_productive_output
+            .is_some_and(|t| t.elapsed() < window)
     }
 
     /// Periodic tick — expire stale latched states without requiring new PTY

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -2675,6 +2675,61 @@ fn srl_plain_error_line_fires_via_content_anchor() {
     );
 }
 
+/// #badge-recovery (operator-reported flicker): a ServerRateLimit error still
+/// matching in the tail, but with PRODUCTIVE output within the recovery window →
+/// the agent recovered → the badge must NOT re-latch ServerRateLimit. The
+/// `last_productive_output` signal is position-independent (it works even when the
+/// re-injected error is the bottom-most line, defeating `working_state_below`).
+#[test]
+fn server_rate_limit_recent_productive_does_not_relatch_badge() {
+    let (mut vt, mut st) = claude_tracker();
+    // Recovered: produced productive output just now (overrides the None default).
+    st.last_productive_output = Some(std::time::Instant::now());
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_ne!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#badge-recovery: a recently-productive agent must NOT re-latch ServerRateLimit"
+    );
+}
+
+/// #badge-recovery 2-sided: a fresh / just-spawned agent that has NEVER produced
+/// (`last_productive_output == None`) is NOT recovery — it must latch
+/// ServerRateLimit normally (so the retry + nudge engage). `None` must never be
+/// misread as recovery — exactly the creation-stamp ambiguity the Option fix
+/// resolves (and the #1795 fresh-agent edge it closes).
+#[test]
+fn server_rate_limit_fresh_agent_no_productive_history_latches_badge() {
+    let (mut vt, mut st) = claude_tracker();
+    assert!(
+        st.last_productive_output.is_none(),
+        "a fresh tracker must start with no productive history (None)"
+    );
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#badge-recovery: a never-produced (fresh) agent must latch ServerRateLimit — None is not recovery"
+    );
+}
+
+/// #badge-recovery boundary: an agent that DID produce, but whose last productive
+/// output is PAST the recovery window, is a genuinely-throttled agent → must still
+/// latch ServerRateLimit. Confirms the suppression is BOUNDED (it only suppresses
+/// recently-productive flicker, never hides a real stuck throttle indefinitely).
+#[test]
+fn server_rate_limit_stale_productive_past_window_still_latches_badge() {
+    let (mut vt, mut st) = claude_tracker();
+    // Produced, but 90s ago — past the 45s recovery window → NOT recovered.
+    st.last_productive_output = Some(Instant::now() - Duration::from_secs(90));
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#badge-recovery: productive output past the recovery window must still latch (bounded suppression)"
+    );
+}
+
 /// RateLimit: a claude 429-rejection error rendered PLAIN fires via content.
 #[test]
 fn rate_limit_plain_error_line_fires_via_content_anchor() {
@@ -2893,7 +2948,7 @@ fn screen_with_marker_at_row(marker: &str, marker_row: usize, total_rows: usize)
 #[test]
 fn t1_685_pr2_active_marker_in_recent_tail_refreshes_productive_output() {
     let mut tracker = StateTracker::new(Some(&Backend::Codex));
-    tracker.last_productive_output = Instant::now() - Duration::from_secs(10);
+    tracker.last_productive_output = Some(Instant::now() - Duration::from_secs(10));
     let before = tracker.last_productive_output;
 
     // Place marker in the recent tail (last 5 rows). Codex
@@ -2919,7 +2974,7 @@ fn t1_685_pr2_active_marker_in_recent_tail_refreshes_productive_output() {
 #[test]
 fn t2_685_pr2_stale_marker_outside_recent_tail_does_not_refresh() {
     let mut tracker = StateTracker::new(Some(&Backend::Codex));
-    tracker.last_productive_output = Instant::now() - Duration::from_secs(60);
+    tracker.last_productive_output = Some(Instant::now() - Duration::from_secs(60));
     let before = tracker.last_productive_output;
 
     // Marker at row 5 of a 40-row viewport — far outside the
@@ -2942,7 +2997,7 @@ fn t2_685_pr2_stale_marker_outside_recent_tail_does_not_refresh() {
 #[test]
 fn t3_685_pr2_grey_failure_trickle_does_not_refresh_after_marker_scrolled_out() {
     let mut tracker = StateTracker::new(Some(&Backend::Codex));
-    tracker.last_productive_output = Instant::now() - Duration::from_secs(60);
+    tracker.last_productive_output = Some(Instant::now() - Duration::from_secs(60));
 
     // Feed 1: marker in recent tail (fresh) — DOES refresh.
     let screen1 = screen_with_marker_at_row("apply_patch succeeded for /tmp/foo.txt", 38, 40);
@@ -2971,7 +3026,7 @@ fn t3_685_pr2_grey_failure_trickle_does_not_refresh_after_marker_scrolled_out() 
 #[test]
 fn t5_685_pr2_rc1_changing_adjacent_line_does_not_refresh() {
     let mut tracker = StateTracker::new(Some(&Backend::Codex));
-    tracker.last_productive_output = Instant::now() - Duration::from_secs(60);
+    tracker.last_productive_output = Some(Instant::now() - Duration::from_secs(60));
 
     // Feed 1: stale marker in tail (row 36 of 40), spinner-A at
     // row 38. Note marker is in last-5-rows window so it WILL
@@ -3014,7 +3069,7 @@ fn t5_685_pr2_rc1_changing_adjacent_line_does_not_refresh() {
 #[test]
 fn t4_685_pr2_identical_recent_tail_does_not_double_refresh() {
     let mut tracker = StateTracker::new(Some(&Backend::Codex));
-    tracker.last_productive_output = Instant::now() - Duration::from_secs(60);
+    tracker.last_productive_output = Some(Instant::now() - Duration::from_secs(60));
 
     // Feed 1: marker in tail, plus arbitrary content above.
     let mut screen1: Vec<String> = (0..35).map(|i| format!("scrollback row {i}")).collect();


### PR DESCRIPTION
## What
Operator-chosen **(a) clean root** fix for the ServerRateLimit **badge flicker** (the cosmetic residue after the merged #1795 fixed the actual retry storm). Refactors `StateTracker.last_productive_output: Instant → Option<Instant>` so "never produced" is distinct from "recently produced", then adds a state-level recovery gate so a recovered agent's badge stops re-latching ServerRateLimit.

## Why the Option refactor (root issue)
The naive gate (`last_productive_output.elapsed() < 45s`) broke 20 detection tests: a *fresh* `StateTracker` stamped `last_productive_output = now()` at creation, so every fresh tracker read as "recovered". The signal couldn't tell **never produced** (creation stamp) from **recently produced**. `Option<Instant>` (None until the first real productive signal) resolves the ambiguity — and as a **bonus closes a latent #1795 edge**: a just-spawned agent that immediately hits ServerRateLimit used to be mis-suppressed for 45s by the creation stamp; now `None` → not-recovered → it latches + nudges normally.

## Change
- `last_productive_output: Option<Instant>` + new `created_at: Instant` (silence baseline).
- Two helpers encode the two semantics cleanly:
  - `productive_silence()` = `last_productive_output.unwrap_or(created_at).elapsed()` — for the silence readers (`check_hang` silent_productive, recovery_dispatcher, snapshot `silent_secs`). **Behavior-preserving**: `created_at` is stamped at the same constructor point the old field was, so a never-produced agent's silence is unchanged.
  - `recovered_within(w)` = `last_productive_output.is_some_and(|t| t.elapsed() < w)` — for the recovery gates. **None = NOT recovery** (never misread as recovered or as stuck).
- New `#badge-recovery` gate in `feed_with_fg`: a `ServerRateLimit` whose agent `recovered_within(45s)` lands `Idle` instead of re-latching (scoped to ServerRateLimit, the #1795 storm's state).
- Supervisor #1795 retry gate now uses `recovered_within` (the same signal).
- Single source of truth for the 45s window: `state::SERVER_RATE_LIMIT_RECOVERY_SILENCE`; the supervisor imports it (de-dups the old `RECOVERY_SILENCE`).
- Removed the windows-fragile `checked_sub(3600s)` mock stale-hack (now `None` = stuck by default).

## Structural review (mandated — large blast radius, core field-type)
4 adversarial lenses (root-cause, design-correctness, risk/blast-radius, minimalism) + premise verification. Verdict: **SPECIFIC-STRUCTURAL-CONCERNS → sound core, addressed:**
- ✅ **None-semantics consistent**: `productive_silence` (None→created_at, preserves hang/dispatch-idle) vs `recovered_within` (None→false). `created_at` stamped identically to the old field → zero behavior change for silence readers.
- ✅ **Bounded false-negative**: a real throttle that *just* produced is hidden ≤45s (badge Idle + no retry), then self-heals — same trade-off as #1795, accepted.
- ✅ **De-duped** the 45s constant (was the lenses' one must-fix).
- ✅ **Boundary test added** (`..._stale_productive_past_window_still_latches_badge`).
- ⚠️ **Known limitation (documented, not new)**: the gate relies on `last_productive_output` bumping — via an MCP **heartbeat** (any MCP-active agent, e.g. an orchestrator) *or* a completion **marker**. A pure text-only recovery with no MCP call and no marker within 45s is a no-op. This is the **same** dependency #1795 already has (shared signal); the toolu-gap (#1792) is the known case where it doesn't bump. Not a correctness bug (None is safe); an effectiveness edge.
- ⚠️ **RateLimit not covered** (only ServerRateLimit). RateLimit auto-expires (5-min), so its flicker self-heals; extending the gate to it is a cheap follow-up if it ever surfaces.

## Tests
- 3 new badge regressions (2-sided): recent-productive → no re-latch; fresh/None → latches normally; produced-but-past-window → still latches.
- All **20 prior ServerRateLimit detection tests pass UNCHANGED** (None = not-recovered = latch — the naive approach's breakage is gone).
- supervisor retry tests green (mock None-default = stuck; recovery test `Some(now)` = recovered).
- Preflight: fmt + clippy (tray, tray,discord) + full `cargo test --tests` all green. Base = latest main (incl #1795/#1797/#1798).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
