### PR TITLE
docs(protocol): test through the real entry point, not a mid-pipeline inject

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL.md
+++ b/docs/FLEET-DEV-PROTOCOL.md
@@ -106,6 +106,8 @@ Three PR categories require external fixtures:
 
 Additional: wire-format invariant tests (pin shape); production-path-coupled (no helper mimics).
 
+**Test through the REAL entry point (integration); don't inject input mid-pipeline.** A test that hand-feeds a helper's INPUT (e.g. passing `prs` straight to the classifier) skips — and therefore HIDES — the discovery/wiring path that produces that input in production. Drive the test from the real entry the production caller uses (the scanner / handler / dispatcher), so a discovery or wiring gap FAILS the test instead of being silently bypassed. Evidence: #1799 PR-3's unit test injected `prs` directly into the helper, hiding that discovery was seed-bound to pr-state; codex required an integration test through the real scanner to surface it. **Review checklist** — the reviewer MUST ask: *"does this test exercise the real entry point, or inject mid-pipeline?"* A mid-pipeline inject on a discovery/wiring-coupled path is an unverified-coverage gap → request a real-entry integration test.
+
 ### 3.10 Test-first
 Feature/fix PRs must be test-first: failing test commit BEFORE impl commit.
 - Every fix PR MUST include an empirical reproduction test case. Reviewers MUST verify the presence and validity of this test.


### PR DESCRIPTION
## What (#4, docs-only)
Adds a review/test discipline to **FLEET-DEV-PROTOCOL §3.9**: tests must drive from the **real entry point** (integration) the production caller uses — not hand-inject a helper's input mid-pipeline, which skips and hides the discovery/wiring path that produces that input in production.

## Evidence
#1799 PR-3's unit test injected `prs` directly into the helper, hiding that discovery was seed-bound to pr-state; codex required an integration test through the real scanner to surface the gap.

## Change
- New titled discipline + a **reviewer checklist question**: *"does this test exercise the real entry point, or inject mid-pipeline?"* — a mid-pipeline inject on a discovery/wiring-coupled path is an unverified-coverage gap → request a real-entry integration test.
- Edited `docs/FLEET-DEV-PROTOCOL.md`, the **embedded source** (`include_str!` in `src/protocol.rs:12`); the deployed `.default` is generated from it.

Build green; `tests/cargo_include_invariant.rs` green (the doc stays in the Cargo include set). docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)