### PR TITLE
fix(merge): refuse a base-stale (BEHIND/DIRTY) PR — phantom-reversion guard

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -1150,6 +1150,27 @@ fn verify_merge_landed(repo: &str, pr: u64) -> MergeVerdict {
     last
 }
 
+/// #base-drift: pure decision — should GitHub's `mergeStateStatus` REFUSE the
+/// merge? `BEHIND` (PR base behind main → an `--admin` squash lands a
+/// phantom-reversion diff, dev-2 #1798) and `DIRTY` (conflicts) refuse;
+/// everything else (CLEAN / UNSTABLE / BLOCKED / UNKNOWN / empty) proceeds —
+/// fail-OPEN, because GitHub may still be computing mergeability and we must not
+/// block a real merge on a transient (#813 pattern). Returns `Some((why, hint))`
+/// to refuse, `None` to proceed.
+fn base_drift_refusal(merge_state_status: &str) -> Option<(&'static str, &'static str)> {
+    match merge_state_status {
+        "BEHIND" => Some((
+            "PR base is behind main (phantom-reversion risk)",
+            "rebase onto current main: git fetch && git rebase origin/main && git push --force-with-lease",
+        )),
+        "DIRTY" => Some((
+            "PR has merge conflicts with main",
+            "resolve: git fetch && git rebase origin/main, fix conflicts, git push --force-with-lease",
+        )),
+        _ => None,
+    }
+}
+
 pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
     let pr = match args["pr"].as_u64() {
         Some(n) => n,
@@ -1216,6 +1237,32 @@ pub(super) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
                 "failing_checks": summary,
                 "hint": "Wait for CI to pass, or use force=true with force_reason for emergency bypass"
             });
+        }
+
+        // #base-drift: refuse a stacked/behind PR. GitHub's `mergeStateStatus`
+        // BEHIND means the PR base is behind main (another PR merged first) → an
+        // `--admin` squash lands a phantom-reversion diff (looks like reverting the
+        // already-merged PR — dev-2 #1798, only caught by a manual diff-check +
+        // rebase). DIRTY = conflicts (can't merge cleanly). Critically, the
+        // `--admin` merge BYPASSES branch-protection's
+        // `required_status_checks.strict`, so GitHub will NOT block these — the
+        // daemon must. Any other state (CLEAN/UNSTABLE/BLOCKED/UNKNOWN) or a
+        // pr_view error → fail-OPEN (proceed): GitHub may still be computing
+        // mergeability and we must not block a real merge on a transient (the #813
+        // mergeable-check pattern). Reuses the same `pr_view` path
+        // `verify_merge_landed` uses — no new infra. `force=true` bypasses (the
+        // audit block below logs it, like the CI gate).
+        if let Ok(summary) =
+            crate::scm::make_scm_provider(&repo, None).pr_view(&repo, pr, &["mergeStateStatus"])
+        {
+            let mss = summary.merge_state_status.as_deref().unwrap_or("");
+            if let Some((why, hint)) = base_drift_refusal(mss) {
+                return json!({
+                    "error": format!("base is stale — merge refused: {why}"),
+                    "merge_state_status": mss,
+                    "hint": format!("{hint}; or force=true with force_reason for emergency bypass"),
+                });
+            }
         }
     }
 

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2196,6 +2196,49 @@ fn merge_no_repo_no_binding_errors_without_hardcoded_fallback() {
     let _ = std::fs::remove_dir_all(&home);
 }
 
+/// #base-drift: the pure refusal decision — `BEHIND` (phantom-reversion) and
+/// `DIRTY` (conflicts) refuse with a rebase hint; everything else
+/// (CLEAN/UNSTABLE/BLOCKED/UNKNOWN/empty/...) proceeds (fail-open, since GitHub
+/// may still be computing mergeability). force-bypass is structural — the gate
+/// sits inside `handle_merge_repo`'s `if !force` block, so force skips it.
+///
+/// NOTE (per FLEET-DEV-PROTOCOL §3.9 real-entry discipline): the WIRING
+/// (`handle_merge_repo` → `pr_view(["mergeStateStatus"])` → this decision, placed
+/// after the CI-pass gate and before the merge) is gh-integration-only — there is
+/// no `ScmProvider` test double — so it is verified by code-reading, not a unit
+/// test. Only the pure decision is unit-tested here; flagged transparently rather
+/// than hidden.
+#[test]
+fn base_drift_refusal_behind_and_dirty_refuse_else_proceed() {
+    assert!(
+        super::base_drift_refusal("BEHIND").is_some(),
+        "BEHIND (base behind main) must refuse"
+    );
+    assert!(
+        super::base_drift_refusal("DIRTY").is_some(),
+        "DIRTY (conflicts) must refuse"
+    );
+    for ok in [
+        "CLEAN",
+        "UNSTABLE",
+        "BLOCKED",
+        "UNKNOWN",
+        "",
+        "HAS_HOOKS",
+        "DRAFT",
+    ] {
+        assert!(
+            super::base_drift_refusal(ok).is_none(),
+            "{ok} must proceed (fail-open) — only BEHIND/DIRTY refuse"
+        );
+    }
+    let (_why, hint) = super::base_drift_refusal("BEHIND").unwrap();
+    assert!(
+        hint.contains("rebase"),
+        "BEHIND refusal must carry an actionable rebase hint, got: {hint}"
+    );
+}
+
 /// #1447: `repo checkout` resolves the source from the cross-tool standard
 /// `repository_path` arg. The legacy `source` / `source_repo` aliases (#1446)
 /// were dropped in favor of the single canonical name.


### PR DESCRIPTION
## What (#5)
`repo action=merge` (`handle_merge_repo`) gated on **CI-pass only** — no base-staleness check. A stacked PR whose base is behind main (another PR merged first) would merge via `--admin`, landing a **phantom-reversion** diff (looks like reverting the already-merged PR — dev-2 hit this on #1798, only caught by a manual diff-check + rebase). Add a warn-and-refuse base-drift gate.

## Why a daemon-side check is necessary
The merge uses `gh pr merge --admin`, which **bypasses branch protection** (incl. `required_status_checks.strict=true`) — so GitHub will NOT block a `BEHIND` PR (and `--auto`+strict can't help). The daemon must check.

## Fix (warn-and-refuse, per 拍板)
Between the CI-pass gate and the merge, query `mergeStateStatus` via the existing `pr_view` (the same call `verify_merge_landed` uses — no new infra):
- **`BEHIND`** (base behind main → phantom-reversion) and **`DIRTY`** (conflicts) → **refuse** with an actionable rebase hint (`git fetch && git rebase origin/main && git push --force-with-lease`).
- **Everything else** (CLEAN/UNSTABLE/BLOCKED/UNKNOWN/empty) or a `pr_view` error → **proceed (fail-open)** — GitHub may still be computing mergeability; don't block a real merge on a transient (#813 pattern).
- **`force=true`** bypasses (the gate sits inside the existing `if !force` block; force is audited like the CI gate).
- **auto-rebase deferred** (mutates the branch + re-runs CI); the warn lets the agent rebase manually.

The decision is a pure helper `base_drift_refusal(merge_state_status)`.

## Tests + ⚠ honest test-level disclosure (per the §3.9 discipline this batch added)
- `base_drift_refusal_behind_and_dirty_refuse_else_proceed` — unit-tests the pure decision (BEHIND/DIRTY refuse; CLEAN/UNSTABLE/BLOCKED/UNKNOWN/empty/HAS_HOOKS/DRAFT proceed; the refusal carries a rebase hint).
- **The WIRING** (`handle_merge_repo` → `pr_view(["mergeStateStatus"])` → `base_drift_refusal`, placed after the CI-pass gate, before the merge) is **gh-integration-only — there is no `ScmProvider` test double** — so it's verified by code-reading, not a real-entry unit test. Flagged transparently inline (the #3.9 "real entry vs mid-pipeline inject" discipline is about not *hiding* the gap; here the real entry genuinely isn't unit-testable without gh).

Preflight: fmt + clippy (tray, tray,discord) + full `cargo test --tests` all green. Single small PR. Base = latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
