### PR TITLE
fix(worktree-leak): unified release invariant (PR-1 of t-worktree-leak)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -425,6 +425,16 @@ fn process_verdicts(home: &Path, from: &str, msg: &crate::inbox::InboxMessage) {
                 verdict_msg_id: msg.id.clone(),
                 reviewed_head: msg.reviewed_head.clone(),
                 enqueued_at: chrono::Utc::now().to_rfc3339(),
+                // t-worktree-leak (PR-1) Q1(b): a VERIFIED verdict no longer
+                // releases an OPEN PR's worktree — the sweeper gates it through the
+                // release invariant, so release waits for the terminal (merge/close)
+                // or no-PR+task-done event. repo/branch/lease are derived by the
+                // sweeper from the live binding; the superseding merge intent
+                // carries the CAS snapshot.
+                event_kind: Some("verdict".to_string()),
+                repo: None,
+                branch: None,
+                lease: None,
             };
             if let Err(e) = crate::daemon::auto_release::enqueue_intent(home, &intent) {
                 tracing::warn!(task_id = %task_id, error = %e, "#870 auto_release: enqueue failed");

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -103,6 +103,11 @@ pub(crate) struct LeaseIdentity {
     pub task_id: String,
     pub branch: String,
     pub worktree: String,
+    /// `binding.json` `source_repo` (the repo path) — t-worktree-leak codex gap ①b:
+    /// included so the CAS catches a re-lease to a DIFFERENT repo at the same
+    /// branch name (cross-repo same-branch collision).
+    #[serde(default)]
+    pub source_repo: String,
     /// `binding.json` `issued_at` — changes on every fresh lease.
     pub issued_at: String,
 }
@@ -123,6 +128,7 @@ impl LeaseIdentity {
             task_id: s("task_id"),
             branch: s("branch"),
             worktree: s("worktree"),
+            source_repo: s("source_repo"),
             issued_at: s("issued_at"),
         }
     }
@@ -204,14 +210,29 @@ fn close_grace_passed(closed_at: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// t-worktree-leak (PR-1) must-fix #4: ALL tasks on the branch are terminal
-/// (Done | Cancelled). Aggregates across the branch, not just one task.
-fn all_branch_tasks_done(home: &Path, branch: &str) -> bool {
+/// t-worktree-leak (PR-1) must-fix #4 + codex gap ①c: ALL tasks on (repo, branch)
+/// are terminal (Done | Cancelled). Tasks are branch-keyed (no `repo` field), so a
+/// same-named branch in a DIFFERENT repo could pollute the aggregation. We scope
+/// by deriving each PENDING task's repo from its owner's live binding: a pending
+/// task blocks release ONLY if it is confirmed to belong to THIS repo; a pending
+/// task confirmed in a DIFFERENT repo does not block; an UNresolvable pending task
+/// (owner unbound) blocks (conservative — never mis-release).
+fn all_branch_tasks_done(home: &Path, repo: &str, branch: &str) -> bool {
     use crate::task_events::TaskStatus;
     crate::tasks::list_all(home)
         .iter()
         .filter(|t| t.branch.as_deref() == Some(branch))
-        .all(|t| matches!(t.status, TaskStatus::Done | TaskStatus::Cancelled))
+        // Only non-terminal (pending) tasks can block; Done/Cancelled never do.
+        .filter(|t| !matches!(t.status, TaskStatus::Done | TaskStatus::Cancelled))
+        .all(|t| {
+            let owner_repo = t
+                .assignee
+                .as_deref()
+                .and_then(|a| crate::binding::read(home, a))
+                .and_then(|b| repo_slug_from_binding(&b));
+            // "does NOT block" ⟺ this pending task is CONFIRMED in a different repo.
+            matches!(&owner_repo, Some(r) if r != repo)
+        })
 }
 
 /// t-worktree-leak (PR-1): the unified release invariant (must-fix #2/#3/#4),
@@ -225,8 +246,8 @@ fn releasable_by_invariant(home: &Path, repo: &str, branch: &str) -> (bool, PrCo
         // team-resolved T1: merge releases the worktree, doesn't touch the task).
         // `pr_releasable` is true for merged, grace-gated for closed-unmerged.
         PrConfidence::ObservedTerminal => pr_releasable,
-        // No PR found → release only once the branch's tasks are all done.
-        PrConfidence::QueriedNone => all_branch_tasks_done(home, branch),
+        // No PR found → release only once the branch's tasks (this repo) are done.
+        PrConfidence::QueriedNone => all_branch_tasks_done(home, repo, branch),
         // Open PR or unknown → not releasable (the sweeper retries until merge).
         PrConfidence::ObservedOpen | PrConfidence::Unknown => false,
     };
@@ -500,11 +521,35 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
         .map(|w| !is_worktree_clean(Path::new(w)));
     match decide_release(task.as_ref(), Some(&binding), worktree_dirty) {
         ReleaseDecision::Release => {
-            // The TOCTOU CAS above (live-binding vs snapshot) ran on the same
-            // `binding` value we pass to release_full; the daemon sweep is
-            // single-threaded, so no re-lease can interleave between the compare
-            // and the release. (A fully binding-lock-atomic CAS would need a
-            // binding-locking refactor — tracked as a follow-up.)
+            // codex gap ②: CAS+release must be ONE atomic critical section under
+            // `.binding.json.lock` — the same lock `bind_full` holds (binding.rs:67)
+            // and the GC path uses (worktree_pool.rs:717). The pre-lock CAS above is
+            // only a cheap early-out; a concurrent bind_full from ANOTHER thread
+            // (MCP handler) could interleave between it and the release. So re-read
+            // + re-validate the FULL lease identity under the lock, then release in
+            // the same section. (`release_full` → `unbind` does NOT take this lock —
+            // binding.rs:119 just removes the file — so no deadlock, mirroring the
+            // pre-PR-1 merge path.)
+            let lock_path = crate::paths::runtime_dir(home)
+                .join(&assignee)
+                .join(".binding.json.lock");
+            let _lock = match crate::store::acquire_file_lock(&lock_path) {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::warn!(agent = %assignee, error = %e, "auto_release: binding lock failed — retaining for retry");
+                    return IntentOutcome::Retry;
+                }
+            };
+            let Some(live) = crate::binding::read(home, &assignee) else {
+                // Unbound under the lock → already released. Nothing to do.
+                return IntentOutcome::Done;
+            };
+            if let Some(snap) = intent.lease.as_ref() {
+                if &LeaseIdentity::from_binding(&assignee, &live) != snap {
+                    tracing::info!(agent = %assignee, task_id = %intent.task_id, "auto_release: lease identity changed under lock (re-leased) — skip (TOCTOU CAS)");
+                    return IntentOutcome::Done;
+                }
+            }
             let outcome = crate::worktree_pool::release_full(home, &assignee, false);
             tracing::info!(agent = %assignee, task_id = %intent.task_id, event, ?confidence, outcome = ?outcome, "auto_release: released worktree (release invariant satisfied)");
             IntentOutcome::Done
@@ -573,6 +618,19 @@ pub(crate) fn enqueue_release_recompute(home: &Path, repo: &str, branch: &str, e
     let Some(binding) = crate::binding::read(home, &agent) else {
         return;
     };
+    // codex gap ①a: cross-repo same-branch guard. `scan_existing_branch_binding`
+    // matches by BRANCH only, so for a same-named branch in a different repo it can
+    // resolve the WRONG agent. Verify the resolved binding's repo == the event's
+    // repo (when the caller supplied one) and skip the mismatch.
+    if !repo.is_empty() {
+        let binding_repo = repo_slug_from_binding(&binding);
+        if binding_repo.as_deref() != Some(repo) {
+            tracing::debug!(agent = %agent, branch = %branch, event = %event_kind,
+                event_repo = %repo, binding_repo = ?binding_repo,
+                "auto_release: bound branch's repo != event repo (cross-repo same-branch) — skip");
+            return;
+        }
+    }
     let task_id = binding
         .get("task_id")
         .and_then(|v| v.as_str())
@@ -919,6 +977,9 @@ mod tests {
     #[test]
     fn auto_release_on_merge_enqueues_recompute_intent() {
         let home = tmp_home("1244-release");
+        // Real source repo whose origin resolves to "owner/repo" so the codex ①a
+        // cross-repo guard (binding repo == event repo) passes.
+        let repo = itest_source_repo(&home, "owner/repo");
         let agent = "dev-merge";
         let branch = "feat/merged-branch";
         let rt = crate::paths::runtime_dir(&home).join(agent);
@@ -928,6 +989,7 @@ mod tests {
             "branch": branch,
             "task_id": "t-test",
             "worktree": "",
+            "source_repo": repo.to_str().unwrap(),
             "issued_at": "2026-06-05T00:00:00Z",
         });
         std::fs::write(
@@ -1114,6 +1176,38 @@ mod tests {
             &serde_json::json!({ "task_id": "t-2", "branch": "feat/x", "worktree": "/w", "issued_at": "T2" }),
         );
         assert_ne!(snap, relesed);
+        // codex gap ①b: re-leased to the SAME branch name in a DIFFERENT repo →
+        // source_repo differs → CAS catches it.
+        let snap_repo = LeaseIdentity::from_binding(
+            "dev",
+            &serde_json::json!({ "task_id": "t-1", "branch": "feat/x", "worktree": "/w", "issued_at": "T1", "source_repo": "/repos/a" }),
+        );
+        let other_repo = LeaseIdentity::from_binding(
+            "dev",
+            &serde_json::json!({ "task_id": "t-1", "branch": "feat/x", "worktree": "/w", "issued_at": "T1", "source_repo": "/repos/b" }),
+        );
+        assert_ne!(
+            snap_repo, other_repo,
+            "CAS must catch a re-lease to a different repo"
+        );
+    }
+
+    #[test]
+    fn cross_repo_same_branch_enqueue_skips_codex_1a() {
+        // codex gap ①a: a bound branch in repo B must NOT be released by an event
+        // for the same branch name in repo A.
+        let home = tmp_home("itest-xrepo");
+        let repo_b = itest_source_repo(&home, "owner/repo-b");
+        itest_lease(&home, &repo_b, "dev", "feat/shared", "t-b", false);
+        // Event for repo-A (a DIFFERENT repo) on the same branch name.
+        enqueue_release_recompute(&home, "owner/repo-a", "feat/shared", "merge");
+        assert_eq!(
+            queue_len(&home),
+            0,
+            "cross-repo same-branch event must not enqueue against repo-b's lease"
+        );
+        assert!(bound(&home, "dev"), "repo-b's binding untouched");
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]
@@ -1259,8 +1353,29 @@ mod tests {
             .unwrap_or(0)
     }
 
+    fn write_fleet(home: &Path, agent: &str) {
+        let p = crate::fleet::fleet_yaml_path(home);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::write(&p, format!("instances:\n  {agent}:\n    backend: claude\n")).unwrap();
+    }
+
+    /// REAL task-done entry: the MCP handler (`task action=done`) — exercises the
+    /// handler→enqueue wiring (codex gap ③ / §3.9). Asserts no error.
+    fn task_done_via_handler(home: &Path, agent: &str, task_id: &str) {
+        let r = crate::tasks::handle(
+            home,
+            agent,
+            &serde_json::json!({ "action": "done", "id": task_id }),
+        );
+        assert!(r.get("error").is_none(), "task action=done failed: {r}");
+    }
+
     #[test]
-    fn integration_merge_releases_worktree() {
+    fn integration_merge_releases_via_real_scanner() {
+        // codex gap ③: drive the REAL scanner entry `scan_and_emit_with` (not the
+        // helper) so the scanner→enqueue wiring is under test (breaks → fails).
         let home = tmp_home("itest-merge");
         let repo = itest_source_repo(&home, "owner/repo");
         itest_lease(&home, &repo, "dev", "feat/m", "t-m", false);
@@ -1276,21 +1391,31 @@ mod tests {
             true,
         );
         assert!(bound(&home, "dev"), "pre: agent is bound");
-        // REAL entry: the scanner's merge call → enqueue.
-        auto_release_for_merged_branch(&home, "owner/repo", "feat/m");
-        assert_eq!(queue_len(&home), 1, "merge enqueues a recompute intent");
+        use parking_lot::Mutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        // Mock poller returns no PRs; the stored Merged state is sticky and drives
+        // the scanner's terminal-merge arm → auto_release_for_merged_branch → enqueue.
+        let poller = crate::daemon::pr_state::gh_poll::tests::MockGhPoller::new(vec![Ok(vec![])]);
+        crate::daemon::pr_state::scan_and_emit_with(&home, &registry, &poller);
+        assert_eq!(
+            queue_len(&home),
+            1,
+            "real scanner→enqueue wiring produced an intent"
+        );
         drain_queue(&home);
         assert!(
             !bound(&home, "dev"),
-            "merge → worktree released (binding gone)"
+            "real scanner → enqueue → sweep → released (binding gone)"
         );
-        assert_eq!(queue_len(&home), 0, "released intent deleted");
         let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]
-    fn integration_open_pr_retains_intent_for_retry() {
+    fn integration_open_pr_retains_via_real_handler() {
         let home = tmp_home("itest-open");
+        write_fleet(&home, "dev");
         let repo = itest_source_repo(&home, "owner/repo");
         itest_lease(&home, &repo, "dev", "feat/o", "t-o", false);
         write_pr_slug(
@@ -1301,12 +1426,9 @@ mod tests {
             7,
             true,
         );
-        crate::daemon::auto_release::enqueue_release_recompute(
-            &home,
-            "owner/repo",
-            "feat/o",
-            "task_done",
-        );
+        // REAL entry: the task-done handler marks done + enqueues.
+        task_done_via_handler(&home, "dev", "t-o");
+        assert_eq!(queue_len(&home), 1, "task-done handler→enqueue wiring");
         drain_queue(&home);
         assert!(
             bound(&home, "dev"),
@@ -1317,19 +1439,19 @@ mod tests {
     }
 
     #[test]
-    fn integration_no_pr_with_task_done_releases() {
+    fn integration_no_pr_task_done_releases_via_real_handler() {
         let home = tmp_home("itest-nopr");
+        write_fleet(&home, "dev");
         let repo = itest_source_repo(&home, "owner/repo");
-        itest_lease(&home, &repo, "dev", "feat/n", "t-n", true); // task marked DONE
+        itest_lease(&home, &repo, "dev", "feat/n", "t-n", false);
         write_pr_slug(&home, "owner/repo", "feat/n", MergeState::NotReady, 0, true); // polled, no PR
-        crate::daemon::auto_release::enqueue_release_recompute(
-            &home,
-            "owner/repo",
-            "feat/n",
-            "task_done",
-        );
+                                                                                     // REAL entry: task-done handler.
+        task_done_via_handler(&home, "dev", "t-n");
         drain_queue(&home);
-        assert!(!bound(&home, "dev"), "no-PR + all tasks done → released");
+        assert!(
+            !bound(&home, "dev"),
+            "no-PR + task done (via real handler) → released"
+        );
         let _ = std::fs::remove_dir_all(&home);
     }
 

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -1125,4 +1125,267 @@ mod tests {
         intent.enqueued_at = chrono::Utc::now().to_rfc3339();
         assert!(!intent_expired(&intent), "fresh intent does not expire");
     }
+
+    // ── t-worktree-leak (PR-1): enqueue→sweep→release INTEGRATION tests ──
+    // §3.9 / #1799: drive the REAL entry (the scanner's merge call /
+    // enqueue_release_recompute), provision real state (managed git worktree +
+    // dispatch binding + board task + pr_state), run the sweeper, and assert the
+    // worktree is actually released or retained — not an injected-input unit test.
+
+    fn itest_source_repo(home: &Path, slug: &str) -> std::path::PathBuf {
+        let dir = home.join("source-repo");
+        std::fs::create_dir_all(&dir).unwrap();
+        let url = format!("https://github.com/{slug}.git");
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["remote", "add", "origin", url.as_str()],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(&dir)
+                .env("AGEND_GIT_BYPASS", "1")
+                .output()
+                .ok();
+        }
+        // Mirror the real repo's .gitignore (line 29) so the `.agend-managed`
+        // marker the lease writes into the worktree does NOT show as untracked —
+        // otherwise `git status --porcelain` is non-empty and the dirty-guard
+        // refuses to release (exactly how production stays clean).
+        std::fs::write(dir.join(".gitignore"), ".agend-managed\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", ".gitignore"])
+            .current_dir(&dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "-m",
+                "init",
+            ])
+            .current_dir(&dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .ok();
+        dir
+    }
+
+    fn seed_task(home: &Path, id: &str, owner: &str, branch: &str, done: bool) {
+        use crate::task_events::{append, DoneSource, InstanceName, TaskEvent, TaskId};
+        append(
+            home,
+            &InstanceName::from("test:lead"),
+            TaskEvent::Created {
+                task_id: TaskId(id.into()),
+                title: "t".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: Some(InstanceName::from(owner)),
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: Some(branch.into()),
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+        )
+        .unwrap();
+        if done {
+            append(
+                home,
+                &InstanceName::from(owner),
+                TaskEvent::Done {
+                    task_id: TaskId(id.into()),
+                    by: InstanceName::from(owner),
+                    source: DoneSource::OperatorManual {
+                        authored_at: chrono::Utc::now().to_rfc3339(),
+                        result: Some("ok".into()),
+                    },
+                },
+            )
+            .unwrap();
+        }
+    }
+
+    /// Provision a real managed worktree + dispatch binding (non-empty task_id) +
+    /// a board task owned by the agent. Returns the worktree path.
+    fn itest_lease(
+        home: &Path,
+        repo: &Path,
+        agent: &str,
+        branch: &str,
+        task_id: &str,
+        done: bool,
+    ) -> std::path::PathBuf {
+        let lease = crate::worktree_pool::lease(home, repo, agent, branch).expect("lease");
+        crate::binding::bind_full(home, agent, task_id, branch, &lease.path, repo)
+            .expect("bind_full");
+        seed_task(home, task_id, agent, branch, done);
+        lease.path
+    }
+
+    fn write_pr_slug(
+        home: &Path,
+        repo: &str,
+        branch: &str,
+        ms: MergeState,
+        pr_number: u64,
+        polled: bool,
+    ) {
+        use crate::daemon::pr_state;
+        let mut s =
+            pr_state::new_for_branch(repo, branch, "headsha", pr_state::ReviewClass::Single);
+        s.merge_state = ms;
+        s.pr_number = pr_number;
+        if polled {
+            s.last_gh_poll_at = Some("2026-06-05T00:00:00Z".to_string());
+        }
+        pr_state::save(home, &s).unwrap();
+    }
+
+    fn bound(home: &Path, agent: &str) -> bool {
+        crate::binding::read(home, agent).is_some()
+    }
+    fn queue_len(home: &Path) -> usize {
+        std::fs::read_dir(queue_dir(home))
+            .map(|d| d.flatten().count())
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn integration_merge_releases_worktree() {
+        let home = tmp_home("itest-merge");
+        let repo = itest_source_repo(&home, "owner/repo");
+        itest_lease(&home, &repo, "dev", "feat/m", "t-m", false);
+        write_pr_slug(
+            &home,
+            "owner/repo",
+            "feat/m",
+            MergeState::Merged {
+                merge_commit: "c0ffee".into(),
+                merged_at: "2026-06-05T00:00:00Z".into(),
+            },
+            5,
+            true,
+        );
+        assert!(bound(&home, "dev"), "pre: agent is bound");
+        // REAL entry: the scanner's merge call → enqueue.
+        auto_release_for_merged_branch(&home, "owner/repo", "feat/m");
+        assert_eq!(queue_len(&home), 1, "merge enqueues a recompute intent");
+        drain_queue(&home);
+        assert!(
+            !bound(&home, "dev"),
+            "merge → worktree released (binding gone)"
+        );
+        assert_eq!(queue_len(&home), 0, "released intent deleted");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn integration_open_pr_retains_intent_for_retry() {
+        let home = tmp_home("itest-open");
+        let repo = itest_source_repo(&home, "owner/repo");
+        itest_lease(&home, &repo, "dev", "feat/o", "t-o", false);
+        write_pr_slug(
+            &home,
+            "owner/repo",
+            "feat/o",
+            MergeState::MergeReady,
+            7,
+            true,
+        );
+        crate::daemon::auto_release::enqueue_release_recompute(
+            &home,
+            "owner/repo",
+            "feat/o",
+            "task_done",
+        );
+        drain_queue(&home);
+        assert!(
+            bound(&home, "dev"),
+            "open PR → NOT released (binding stays)"
+        );
+        assert_eq!(queue_len(&home), 1, "open-PR intent retained for retry");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn integration_no_pr_with_task_done_releases() {
+        let home = tmp_home("itest-nopr");
+        let repo = itest_source_repo(&home, "owner/repo");
+        itest_lease(&home, &repo, "dev", "feat/n", "t-n", true); // task marked DONE
+        write_pr_slug(&home, "owner/repo", "feat/n", MergeState::NotReady, 0, true); // polled, no PR
+        crate::daemon::auto_release::enqueue_release_recompute(
+            &home,
+            "owner/repo",
+            "feat/n",
+            "task_done",
+        );
+        drain_queue(&home);
+        assert!(!bound(&home, "dev"), "no-PR + all tasks done → released");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn integration_cas_skips_re_leased_binding() {
+        let home = tmp_home("itest-cas");
+        let repo = itest_source_repo(&home, "owner/repo");
+        let wt = itest_lease(&home, &repo, "dev", "feat/c", "t-c", false);
+        write_pr_slug(
+            &home,
+            "owner/repo",
+            "feat/c",
+            MergeState::Merged {
+                merge_commit: "c".into(),
+                merged_at: "2026-06-05T00:00:00Z".into(),
+            },
+            5,
+            true,
+        );
+        // Enqueue snapshots the CURRENT lease (task_id=t-c).
+        crate::daemon::auto_release::enqueue_release_recompute(
+            &home,
+            "owner/repo",
+            "feat/c",
+            "merge",
+        );
+        // Re-lease the SAME agent to a new task → snapshot is now stale.
+        crate::binding::bind_full(&home, "dev", "t-c2", "feat/c", &wt, &repo).expect("rebind");
+        drain_queue(&home);
+        assert!(
+            bound(&home, "dev"),
+            "CAS: a stale (re-leased) intent must NOT release the new lease"
+        );
+        assert_eq!(
+            queue_len(&home),
+            0,
+            "stale intent dropped (CAS skip is terminal)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn integration_expired_intent_dropped() {
+        let home = tmp_home("itest-exp");
+        std::fs::create_dir_all(queue_dir(&home)).unwrap();
+        let mut intent = sample_intent("t-exp");
+        intent.enqueued_at =
+            (chrono::Utc::now() - chrono::Duration::days(INTENT_EXPIRY_DAYS + 1)).to_rfc3339();
+        enqueue_intent(&home, &intent).unwrap();
+        assert_eq!(queue_len(&home), 1);
+        drain_queue(&home);
+        assert_eq!(
+            queue_len(&home),
+            0,
+            "expired intent dropped (force-reclaim backstop takes over)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
 }

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -38,6 +38,25 @@
 //!
 //! Manual `release_worktree` MCP still works; the auto-release is
 //! idempotent on an already-released binding.
+//!
+//! ── t-worktree-leak (PR-1): unified release invariant ──
+//!
+//! The trigger above is generalised from "VERIFIED verdict only" to THREE events
+//! — merge, close-unmerged, and task-done (plus the verdict path, now gated by
+//! the invariant) — all routed through the same queue. The sweeper releases iff
+//! the release INVARIANT holds:
+//!
+//!   `releasable ⟺ PR-terminal ∨ (no-PR ∧ all branch tasks done)`,
+//!   AND not-dirty AND not-opt-out, scoped to (repo, branch).
+//!
+//! So a VERIFIED on an OPEN PR no longer releases (it waits for the terminal
+//! merge/close — fixes the premature-release class where #1795/#1804 needed the
+//! worktree AFTER VERIFIED). Merge releases the worktree ORTHOGONALLY to the task.
+//! Drain is no longer one-shot: an intent that is not-yet-releasable (PR open,
+//! dirty) is RETAINED and retried, with a 7-day expiry handing off to the
+//! force-reclaim backstop (PR-2). Each intent carries a lease-identity snapshot
+//! for a TOCTOU CAS (skip if the lease was re-leased), and only dispatch-lease
+//! worktrees (binding has a `task_id`) are invariant-released.
 
 use std::path::{Path, PathBuf};
 
@@ -57,6 +76,161 @@ pub(crate) struct AutoReleaseIntent {
     pub verdict_msg_id: Option<String>,
     pub reviewed_head: Option<String>,
     pub enqueued_at: String,
+    // ── t-worktree-leak (PR-1): event-driven release-invariant recompute ──
+    // These default to None so legacy verdict-only intents still deserialize.
+    /// The event that enqueued this intent: "verdict" | "merge" |
+    /// "close_unmerged" | "task_done". Absent ⟹ legacy verdict intent.
+    #[serde(default)]
+    pub event_kind: Option<String>,
+    /// (repo, branch) the invariant is scoped to (must-fix #2).
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
+    /// Lease-identity snapshot taken at enqueue time, for the TOCTOU CAS
+    /// (must-fix #1). If the live binding no longer matches this, the lease was
+    /// re-leased to a different task between enqueue and sweep → skip.
+    #[serde(default)]
+    pub lease: Option<LeaseIdentity>,
+}
+
+/// t-worktree-leak (PR-1): the stable identity of a worktree lease, snapshotted
+/// into an intent so the sweeper can detect a re-lease (TOCTOU, must-fix #1).
+/// All fields are read from the agent's `binding.json`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Default)]
+pub(crate) struct LeaseIdentity {
+    pub agent: String,
+    pub task_id: String,
+    pub branch: String,
+    pub worktree: String,
+    /// `binding.json` `issued_at` — changes on every fresh lease.
+    pub issued_at: String,
+}
+
+impl LeaseIdentity {
+    /// Read the current lease identity for `agent` from its live binding.
+    /// `None` when the agent is unbound.
+    pub(crate) fn from_binding(agent: &str, binding: &serde_json::Value) -> Self {
+        let s = |k: &str| {
+            binding
+                .get(k)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string()
+        };
+        LeaseIdentity {
+            agent: agent.to_string(),
+            task_id: s("task_id"),
+            branch: s("branch"),
+            worktree: s("worktree"),
+            issued_at: s("issued_at"),
+        }
+    }
+}
+
+/// t-worktree-leak (PR-1): confidence in the PR-state determination, surfaced in
+/// logs + the force-reclaim ALERT (PR-2) so we never blindly trust pr_state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrConfidence {
+    /// pr_state positively shows a TERMINAL PR (Merged | ClosedUnmerged).
+    ObservedTerminal,
+    /// pr_state shows a real OPEN PR (pr_number > 0, non-terminal).
+    ObservedOpen,
+    /// gh-poll RAN and found no PR for the branch (positive no-PR, not absence).
+    QueriedNone,
+    /// No pr_state, or never gh-polled → cannot confirm (absence ≠ no-PR).
+    Unknown,
+}
+
+/// t-worktree-leak (PR-1) must-fix #5: eligibility gate. Only worktrees
+/// provisioned via a dispatch lease (their `binding.json` carries a non-empty
+/// `task_id`) are subject to invariant-release. Operator-created / PR-inspection
+/// worktrees (no task_id) are left to the conservative force-reclaim backstop
+/// (PR-2). Fail-safe: provenance unclear ⟹ NOT eligible.
+fn is_dispatch_lease(binding: &serde_json::Value) -> bool {
+    binding
+        .get("task_id")
+        .and_then(|v| v.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+}
+
+/// t-worktree-leak (PR-1) must-fix #3: the PR half of the release invariant, with
+/// a confidence level. Allows release only on a POSITIVE signal — a terminal PR,
+/// or a gh-poll that ran and found no PR — never on mere pr_state absence.
+fn evaluate_pr_for_release(home: &Path, repo: &str, branch: &str) -> (bool, PrConfidence) {
+    let Some(state) = crate::daemon::pr_state::load(home, repo, branch) else {
+        // No pr_state at all → absence is ambiguous (gh-poll may not have run).
+        return (false, PrConfidence::Unknown);
+    };
+    use crate::daemon::pr_state::MergeState;
+    match state.merge_state {
+        // Merged → release immediately (terminal, no rework path).
+        MergeState::Merged { .. } => (true, PrConfidence::ObservedTerminal),
+        // Closed-unmerged is MORE conservative than merge: a committed-but-
+        // unmerged branch may be reworked, so the worktree only becomes releasable
+        // CLOSE_GRACE_HOURS after the PR closed. (Dirty WIP is already protected by
+        // decide_release; this grace covers clean-but-being-reworked branches.)
+        MergeState::ClosedUnmerged { ref closed_at } => (
+            close_grace_passed(closed_at),
+            PrConfidence::ObservedTerminal,
+        ),
+        // Non-terminal: a real open PR blocks release; "polled, none found" allows.
+        MergeState::NotReady | MergeState::MergeReady => {
+            if state.pr_number > 0 {
+                (false, PrConfidence::ObservedOpen)
+            } else if state.last_gh_poll_at.is_some() {
+                // gh-poll ran, pr_number still 0 ⟹ positively no PR.
+                (true, PrConfidence::QueriedNone)
+            } else {
+                // pr_state exists (ci-watch armed) but never gh-polled.
+                (false, PrConfidence::Unknown)
+            }
+        }
+    }
+}
+
+/// t-worktree-leak (PR-1): close-unmerged grace ceiling. A closed (unmerged) PR's
+/// worktree only becomes releasable this long after `closed_at`.
+const CLOSE_GRACE_HOURS: i64 = 24;
+
+fn close_grace_passed(closed_at: &str) -> bool {
+    chrono::DateTime::parse_from_rfc3339(closed_at)
+        .map(|t| {
+            chrono::Utc::now().signed_duration_since(t.with_timezone(&chrono::Utc))
+                > chrono::Duration::hours(CLOSE_GRACE_HOURS)
+        })
+        // Unparseable closed_at → conservative: NOT yet (wait / force-reclaim).
+        .unwrap_or(false)
+}
+
+/// t-worktree-leak (PR-1) must-fix #4: ALL tasks on the branch are terminal
+/// (Done | Cancelled). Aggregates across the branch, not just one task.
+fn all_branch_tasks_done(home: &Path, branch: &str) -> bool {
+    use crate::task_events::TaskStatus;
+    crate::tasks::list_all(home)
+        .iter()
+        .filter(|t| t.branch.as_deref() == Some(branch))
+        .all(|t| matches!(t.status, TaskStatus::Done | TaskStatus::Cancelled))
+}
+
+/// t-worktree-leak (PR-1): the unified release invariant (must-fix #2/#3/#4),
+/// repo+branch scoped. `releasable ⟺ PR-terminal ∨ (no-PR ∧ all branch tasks
+/// done)`. Returns (releasable_per_invariant, confidence). The dirty / opt-out /
+/// bound gates stay in `decide_release` (must-fix #6).
+fn releasable_by_invariant(home: &Path, repo: &str, branch: &str) -> (bool, PrConfidence) {
+    let (pr_releasable, confidence) = evaluate_pr_for_release(home, repo, branch);
+    let releasable = match confidence {
+        // Terminal PR releases the worktree ORTHOGONALLY to task state (the
+        // team-resolved T1: merge releases the worktree, doesn't touch the task).
+        // `pr_releasable` is true for merged, grace-gated for closed-unmerged.
+        PrConfidence::ObservedTerminal => pr_releasable,
+        // No PR found → release only once the branch's tasks are all done.
+        PrConfidence::QueriedNone => all_branch_tasks_done(home, branch),
+        // Open PR or unknown → not releasable (the sweeper retries until merge).
+        PrConfidence::ObservedOpen | PrConfidence::Unknown => false,
+    };
+    (releasable, confidence)
 }
 
 /// Outcome of [`decide_release`] — pure helper unit-tested without
@@ -199,83 +373,163 @@ fn drain_queue(home: &Path) {
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        match serde_json::from_str::<AutoReleaseIntent>(&content) {
-            Ok(intent) => process_intent(home, &intent),
+        let intent = match serde_json::from_str::<AutoReleaseIntent>(&content) {
+            Ok(i) => i,
             Err(e) => {
                 tracing::warn!(
                     path = %path.display(),
                     error = %e,
-                    "#870 auto_release: malformed intent JSON, dropping"
+                    "auto_release: malformed intent JSON, dropping"
                 );
+                let _ = std::fs::remove_file(&path);
+                continue;
             }
+        };
+        // t-worktree-leak (PR-1) Q2: an intent that has been retrying past the
+        // expiry is dropped — the force-reclaim backstop (PR-2) takes over (clean
+        // handoff, aligned with the force-reclaim age cap).
+        if intent_expired(&intent) {
+            tracing::info!(
+                task_id = %intent.task_id,
+                "auto_release: intent past {INTENT_EXPIRY_DAYS}d expiry — dropping (force-reclaim backstop takes over)"
+            );
+            let _ = std::fs::remove_file(&path);
+            continue;
         }
-        let _ = std::fs::remove_file(&path);
+        match process_intent(home, &intent) {
+            // Released / terminal skip → delete.
+            IntentOutcome::Done => {
+                let _ = std::fs::remove_file(&path);
+            }
+            // Not-yet-releasable (PR open / dirty) → retain for the next sweep.
+            IntentOutcome::Retry => {}
+        }
     }
 }
 
-fn process_intent(home: &Path, intent: &AutoReleaseIntent) {
+/// t-worktree-leak (PR-1) Q2: retry-intent age ceiling. Past this, the intent is
+/// dropped and the force-reclaim backstop (PR-2) handles the worktree.
+const INTENT_EXPIRY_DAYS: i64 = 7;
+
+fn intent_expired(intent: &AutoReleaseIntent) -> bool {
+    chrono::DateTime::parse_from_rfc3339(&intent.enqueued_at)
+        .map(|t| {
+            chrono::Utc::now().signed_duration_since(t.with_timezone(&chrono::Utc))
+                > chrono::Duration::days(INTENT_EXPIRY_DAYS)
+        })
+        // Unparseable enqueued_at → don't expire (conservative; a real intent
+        // always carries a valid RFC3339 timestamp).
+        .unwrap_or(false)
+}
+
+/// t-worktree-leak (PR-1) Q2: the sweeper's per-intent verdict — whether to
+/// delete the intent or retain it for a later retry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IntentOutcome {
+    /// Released, or a terminal skip (no assignee / unbound / not-eligible /
+    /// lease-changed / opt-out) → delete the intent.
+    Done,
+    /// Not-yet-releasable but might become so (PR still open, dirty worktree) →
+    /// retain for retry on a later sweep (subject to the queue expiry).
+    Retry,
+}
+
+fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
+    let event = intent.event_kind.as_deref().unwrap_or("verdict");
     let tasks = crate::tasks::list_all(home);
     let task = tasks.iter().find(|t| t.id == intent.task_id).cloned();
-    let assignee_opt = task.as_ref().and_then(|t| t.assignee.clone());
-    let binding = assignee_opt
-        .as_ref()
-        .and_then(|a| crate::binding::read(home, a));
-    let worktree_dirty = binding.as_ref().and_then(|b| {
-        b.get("worktree")
-            .and_then(|v| v.as_str())
-            .map(|w| !is_worktree_clean(Path::new(w)))
-    });
-    let decision = decide_release(task.as_ref(), binding.as_ref(), worktree_dirty);
-    match decision {
-        ReleaseDecision::Release => {
-            // Safe to unwrap: decision Release requires task + assignee.
-            let assignee = assignee_opt.expect("assignee present per decide_release");
-            let outcome = crate::worktree_pool::release_full(home, &assignee, false);
-            tracing::info!(
-                agent = %assignee,
-                task_id = %intent.task_id,
-                reviewer = %intent.reviewer,
-                verdict_msg_id = ?intent.verdict_msg_id,
-                outcome = ?outcome,
-                "#870 auto_release: released worktree on VERIFIED verdict"
-            );
-        }
-        ReleaseDecision::SkipDirtyWorktree => {
-            tracing::warn!(
-                agent = ?assignee_opt,
-                task_id = %intent.task_id,
-                "#870 auto_release: worktree has uncommitted changes — \
-                 refusing to auto-release (operator WIP protection). \
-                 Manual release_worktree still available."
-            );
-        }
-        ReleaseDecision::SkipOptOut => {
-            tracing::info!(
-                agent = ?assignee_opt,
-                task_id = %intent.task_id,
-                "#870 auto_release: task opted out via auto_release_on_verdict=false, skipping"
-            );
-        }
-        ReleaseDecision::SkipNotBound => {
-            tracing::debug!(
-                agent = ?assignee_opt,
-                task_id = %intent.task_id,
-                "#870 auto_release: agent not bound (already released or never bound), skipping"
-            );
-        }
-        ReleaseDecision::SkipNoAssignee => {
-            tracing::debug!(
-                task_id = %intent.task_id,
-                "#870 auto_release: task has no assignee, skipping"
-            );
-        }
-        ReleaseDecision::SkipTaskMissing => {
-            tracing::warn!(
-                task_id = %intent.task_id,
-                "#870 auto_release: task not found in board, dropping intent"
-            );
+    let Some(assignee) = task.as_ref().and_then(|t| t.assignee.clone()) else {
+        tracing::debug!(task_id = %intent.task_id, event, "auto_release: task missing / no assignee — dropping intent");
+        return IntentOutcome::Done;
+    };
+    let Some(binding) = crate::binding::read(home, &assignee) else {
+        // Already released / never bound → nothing to do (idempotent).
+        tracing::debug!(agent = %assignee, task_id = %intent.task_id, event, "auto_release: agent unbound — dropping intent");
+        return IntentOutcome::Done;
+    };
+
+    // ── must-fix #5: eligibility — only dispatch leases get invariant-release.
+    if !is_dispatch_lease(&binding) {
+        tracing::debug!(agent = %assignee, "auto_release: not a dispatch lease (no task_id) — left to force-reclaim backstop (PR-2)");
+        return IntentOutcome::Done;
+    }
+
+    // ── must-fix #1: TOCTOU CAS — the live lease must still match the snapshot.
+    if let Some(snap) = intent.lease.as_ref() {
+        let live = LeaseIdentity::from_binding(&assignee, &binding);
+        if &live != snap {
+            tracing::info!(agent = %assignee, task_id = %intent.task_id, "auto_release: lease identity changed since enqueue (re-leased) — skipping (TOCTOU CAS)");
+            return IntentOutcome::Done;
         }
     }
+
+    // ── the release invariant (must-fix #2/#3/#4), repo+branch scoped. repo/
+    // branch come from the intent; legacy verdict intents fall back to the
+    // binding (branch directly, repo derived from the source_repo remote).
+    let branch = intent
+        .branch
+        .clone()
+        .or_else(|| {
+            binding
+                .get("branch")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+        })
+        .unwrap_or_default();
+    let repo = intent
+        .repo
+        .clone()
+        .or_else(|| repo_slug_from_binding(&binding))
+        .unwrap_or_default();
+    if branch.is_empty() || repo.is_empty() {
+        // Cannot scope the invariant → cannot positively confirm. Retry (a later
+        // gh-poll / event may resolve repo/branch) rather than release blindly.
+        tracing::debug!(agent = %assignee, task_id = %intent.task_id, event, "auto_release: repo/branch unresolved — retaining for retry");
+        return IntentOutcome::Retry;
+    }
+    let (releasable, confidence) = releasable_by_invariant(home, &repo, &branch);
+    if !releasable {
+        tracing::debug!(agent = %assignee, repo = %repo, branch = %branch, event, ?confidence, "auto_release: invariant not yet satisfied — retaining for retry");
+        return IntentOutcome::Retry;
+    }
+
+    // ── final gate (dirty / opt-out / bound), must-fix #6 — unchanged decide_release.
+    let worktree_dirty = binding
+        .get("worktree")
+        .and_then(|v| v.as_str())
+        .map(|w| !is_worktree_clean(Path::new(w)));
+    match decide_release(task.as_ref(), Some(&binding), worktree_dirty) {
+        ReleaseDecision::Release => {
+            // The TOCTOU CAS above (live-binding vs snapshot) ran on the same
+            // `binding` value we pass to release_full; the daemon sweep is
+            // single-threaded, so no re-lease can interleave between the compare
+            // and the release. (A fully binding-lock-atomic CAS would need a
+            // binding-locking refactor — tracked as a follow-up.)
+            let outcome = crate::worktree_pool::release_full(home, &assignee, false);
+            tracing::info!(agent = %assignee, task_id = %intent.task_id, event, ?confidence, outcome = ?outcome, "auto_release: released worktree (release invariant satisfied)");
+            IntentOutcome::Done
+        }
+        // Dirty is transient (operator commits / stashes later) → retry.
+        ReleaseDecision::SkipDirtyWorktree => {
+            tracing::warn!(agent = %assignee, repo = %repo, branch = %branch, "auto_release: worktree dirty — retaining for retry (operator WIP protection)");
+            IntentOutcome::Retry
+        }
+        ReleaseDecision::SkipOptOut => {
+            tracing::info!(agent = %assignee, task_id = %intent.task_id, "auto_release: opted out (auto_release_on_verdict=false) — dropping intent");
+            IntentOutcome::Done
+        }
+        other => {
+            tracing::debug!(agent = %assignee, task_id = %intent.task_id, decision = ?other, "auto_release: terminal skip — dropping intent");
+            IntentOutcome::Done
+        }
+    }
+}
+
+/// t-worktree-leak (PR-1): derive the gh `owner/repo` slug from a binding's
+/// `source_repo` path (via its `origin` remote). `None` if not resolvable.
+fn repo_slug_from_binding(binding: &serde_json::Value) -> Option<String> {
+    let src = binding.get("source_repo").and_then(|v| v.as_str())?;
+    crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(Path::new(src))
 }
 
 /// Return `true` when `git status --porcelain` produces no output for
@@ -301,77 +555,63 @@ fn is_worktree_clean(worktree: &Path) -> bool {
     out.stdout.is_empty()
 }
 
-/// #1244: auto-release worktree when ci_watch detects PR merged.
+/// t-worktree-leak (PR-1): enqueue a release-invariant recompute intent for the
+/// worktree bound to `branch`. Shared by the merge / close-unmerged / task-done
+/// events. The sweeper re-checks the invariant + TOCTOU CAS + dirty/opt-out
+/// before releasing, so this is lock-free (just a queue write) and safe to call
+/// from inside the pr_state scanner's post-flock region (#1617).
 ///
-/// Branch→agent reverse lookup via `scan_existing_branch_binding`,
-/// then dirty-tree guard + `release_full` under binding lock (same
-/// lock as `bind_full` / `gc_remove_one` — eliminates TOCTOU between
-/// dirty check and release). Silent no-op when no agent is bound to
-/// the branch (manual merge, already released, etc.).
-///
-/// One-shot: if `is_worktree_clean` returns false due to transient
-/// I/O error, this call does not retry. The existing worktree GC
-/// (grace-period sweep) serves as the fallback safety net.
-///
-/// #1339 DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN: reached ONLY from the per-tick
-/// daemon loop on an internal trigger — a CI/PR-merge detection
-/// (`ci_watch::poller` / `pr_state::scanner`) — never from the API socket. It is
-/// daemon self-heal (a third trusted principal), so the operator-mode gate
-/// (`api::operator_gate`, which governs socket-ingress operator-vs-agent) does
-/// NOT apply: worktrees of merged branches are reclaimed even in away/sleep. Not
-/// agent-invocable (the trigger is GitHub merge state, not an agent request).
-pub(crate) fn auto_release_for_merged_branch(home: &Path, branch: &str) {
+/// Eligibility (must-fix #5): only dispatch leases (binding carries a non-empty
+/// `task_id`) are enqueued; operator / inspection worktrees are left to the
+/// conservative force-reclaim backstop (PR-2).
+pub(crate) fn enqueue_release_recompute(home: &Path, repo: &str, branch: &str, event_kind: &str) {
     let Some(agent) =
         crate::binding::scan_existing_branch_binding(home, branch, /* exclude */ "")
     else {
-        return;
+        return; // no bound agent → nothing to release.
     };
-
-    // Acquire binding lock — same lock that bind_full() and
-    // gc_remove_one() use, making dirty-check + release atomic
-    // w.r.t. concurrent bind/unbind.
-    let lock_path = crate::paths::runtime_dir(home)
-        .join(&agent)
-        .join(".binding.json.lock");
-    let _lock = match crate::store::acquire_file_lock(&lock_path) {
-        Ok(l) => l,
-        Err(e) => {
-            tracing::warn!(
-                agent = %agent,
-                branch = %branch,
-                error = %e,
-                "#1244 auto_release_on_merge: binding lock failed — skipping (GC will catch)"
-            );
-            return;
-        }
-    };
-
-    // Re-read binding under lock — may have been released between
-    // scan_existing_branch_binding and lock acquisition.
     let Some(binding) = crate::binding::read(home, &agent) else {
         return;
     };
-    if binding["branch"].as_str() != Some(branch) {
-        return; // agent rebound to a different branch
-    }
-
-    let worktree_path = binding["worktree"].as_str().unwrap_or("");
-    if !worktree_path.is_empty() && !is_worktree_clean(Path::new(worktree_path)) {
-        tracing::warn!(
-            agent = %agent,
-            branch = %branch,
-            worktree = %worktree_path,
-            "#1244 auto_release_on_merge: worktree dirty — skipping auto-release"
-        );
+    let task_id = binding
+        .get("task_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if task_id.is_empty() {
+        tracing::debug!(agent = %agent, branch = %branch, event = %event_kind,
+            "auto_release: lease has no task_id (not a dispatch lease) — left to force-reclaim backstop");
         return;
     }
-    let outcome = crate::worktree_pool::release_full(home, &agent, false);
-    tracing::info!(
-        agent = %agent,
-        branch = %branch,
-        outcome = ?outcome,
-        "#1244 auto_release_on_merge: released worktree after PR merged"
-    );
+    let intent = AutoReleaseIntent {
+        task_id,
+        reviewer: String::new(),
+        verdict_msg_id: None,
+        reviewed_head: None,
+        enqueued_at: chrono::Utc::now().to_rfc3339(),
+        event_kind: Some(event_kind.to_string()),
+        // Empty repo (e.g. the task-done caller, which lacks the gh slug) → None
+        // so the sweeper derives it from the binding's source_repo.
+        repo: (!repo.is_empty()).then(|| repo.to_string()),
+        branch: Some(branch.to_string()),
+        lease: Some(LeaseIdentity::from_binding(&agent, &binding)),
+    };
+    if let Err(e) = enqueue_intent(home, &intent) {
+        tracing::warn!(repo = %repo, branch = %branch, event = %event_kind, error = %e,
+            "auto_release: enqueue recompute intent failed");
+    }
+}
+
+/// #1244 + t-worktree-leak (PR-1): on PR merge, enqueue a release-invariant
+/// recompute. Merge is a terminal PR state → the sweeper releases the worktree
+/// ORTHOGONALLY to the task (team-resolved T1). Routed through the HYBRID queue
+/// so the CAS / dirty / opt-out gates all apply uniformly.
+///
+/// #1339 DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN: reached ONLY from the per-tick
+/// daemon loop on an internal PR-merge trigger (`ci_watch::poller` /
+/// `pr_state::scanner`), never from the API socket — daemon self-heal.
+pub(crate) fn auto_release_for_merged_branch(home: &Path, repo: &str, branch: &str) {
+    enqueue_release_recompute(home, repo, branch, "merge");
 }
 
 #[cfg(test)]
@@ -395,7 +635,11 @@ mod tests {
             reviewer: "reviewer-1".to_string(),
             verdict_msg_id: Some("m-test".to_string()),
             reviewed_head: Some("deadbeef".to_string()),
-            enqueued_at: "2026-05-17T00:00:00Z".to_string(),
+            enqueued_at: chrono::Utc::now().to_rfc3339(),
+            event_kind: None,
+            repo: None,
+            branch: None,
+            lease: None,
         }
     }
 
@@ -597,7 +841,7 @@ mod tests {
     fn auto_release_on_merge_no_binding_is_noop() {
         let home = tmp_home("1244-no-bind");
         std::fs::create_dir_all(crate::paths::runtime_dir(&home)).unwrap();
-        auto_release_for_merged_branch(&home, "feat/gone");
+        auto_release_for_merged_branch(&home, "owner/repo", "feat/gone");
         // No panic, no crash — silent skip.
         let _ = std::fs::remove_dir_all(&home);
     }
@@ -659,7 +903,7 @@ mod tests {
             serde_json::to_string_pretty(&binding).unwrap(),
         )
         .unwrap();
-        auto_release_for_merged_branch(&home, branch);
+        auto_release_for_merged_branch(&home, "owner/repo", branch);
         assert!(
             rt.join("binding.json").exists(),
             "binding.json must be preserved when worktree is dirty"
@@ -668,10 +912,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(&wt);
     }
 
-    /// #1244: binding exists for branch → release_full called,
-    /// binding.json removed.
+    /// t-worktree-leak (PR-1): merge no longer releases directly — it ENQUEUES a
+    /// release-invariant recompute intent (event_kind="merge") carrying the CAS
+    /// lease snapshot, which the sweeper processes. (The full enqueue→sweep→
+    /// release path is covered by the invariant tests below.)
     #[test]
-    fn auto_release_on_merge_releases_bound_agent() {
+    fn auto_release_on_merge_enqueues_recompute_intent() {
         let home = tmp_home("1244-release");
         let agent = "dev-merge";
         let branch = "feat/merged-branch";
@@ -682,16 +928,25 @@ mod tests {
             "branch": branch,
             "task_id": "t-test",
             "worktree": "",
+            "issued_at": "2026-06-05T00:00:00Z",
         });
         std::fs::write(
             rt.join("binding.json"),
             serde_json::to_string_pretty(&binding).unwrap(),
         )
         .unwrap();
-        auto_release_for_merged_branch(&home, branch);
+        auto_release_for_merged_branch(&home, "owner/repo", branch);
+        let queued = std::fs::read_dir(queue_dir(&home))
+            .map(|d| d.flatten().count())
+            .unwrap_or(0);
+        assert_eq!(queued, 1, "merge must enqueue exactly one recompute intent");
+        let content = std::fs::read_to_string(queue_dir(&home).join("t-test.json")).unwrap();
+        let intent: AutoReleaseIntent = serde_json::from_str(&content).unwrap();
+        assert_eq!(intent.event_kind.as_deref(), Some("merge"));
+        assert_eq!(intent.branch.as_deref(), Some(branch));
         assert!(
-            !rt.join("binding.json").exists(),
-            "binding.json must be removed after auto-release on merge"
+            intent.lease.is_some(),
+            "merge intent must carry the CAS lease snapshot"
         );
         let _ = std::fs::remove_dir_all(&home);
     }
@@ -708,5 +963,166 @@ mod tests {
             timestamp: "2026-05-17T00:00:00Z".into(),
             ..Default::default()
         }
+    }
+
+    // ── t-worktree-leak (PR-1): release-invariant tests ──
+
+    fn write_pr(
+        home: &Path,
+        branch: &str,
+        ms: crate::daemon::pr_state::MergeState,
+        pr_number: u64,
+        polled: bool,
+    ) {
+        use crate::daemon::pr_state;
+        let mut s =
+            pr_state::new_for_branch("o/r", branch, "headsha", pr_state::ReviewClass::Single);
+        s.merge_state = ms;
+        s.pr_number = pr_number;
+        if polled {
+            s.last_gh_poll_at = Some("2026-06-05T00:00:00Z".to_string());
+        }
+        pr_state::save(home, &s).unwrap();
+    }
+
+    use crate::daemon::pr_state::MergeState;
+
+    #[test]
+    fn invariant_merged_is_releasable() {
+        let home = tmp_home("inv-merged");
+        write_pr(
+            &home,
+            "feat/x",
+            MergeState::Merged {
+                merge_commit: "c0ffee".into(),
+                merged_at: "2026-06-05T00:00:00Z".into(),
+            },
+            5,
+            true,
+        );
+        let (r, c) = releasable_by_invariant(&home, "o/r", "feat/x");
+        assert!(r, "merged PR is releasable");
+        assert_eq!(c, PrConfidence::ObservedTerminal);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn invariant_open_pr_is_not_releasable() {
+        // The Q1(b) behavior: a VERIFIED on an OPEN PR must NOT release.
+        let home = tmp_home("inv-open");
+        write_pr(&home, "feat/x", MergeState::MergeReady, 7, true);
+        let (r, c) = releasable_by_invariant(&home, "o/r", "feat/x");
+        assert!(
+            !r,
+            "open PR must not be releasable (release waits for terminal)"
+        );
+        assert_eq!(c, PrConfidence::ObservedOpen);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn invariant_no_pr_polled_is_releasable_when_tasks_done() {
+        // gh-poll ran, no PR found (pr_number 0) + no pending tasks (vacuous) →
+        // releasable via the no-PR branch (covers tasks that never produce a PR).
+        let home = tmp_home("inv-nopr");
+        write_pr(&home, "feat/x", MergeState::NotReady, 0, true);
+        let (r, c) = releasable_by_invariant(&home, "o/r", "feat/x");
+        assert!(r, "no-PR + all-tasks-done is releasable");
+        assert_eq!(c, PrConfidence::QueriedNone);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn invariant_never_polled_is_unknown_not_releasable() {
+        // pr_state exists (ci-watch armed) but never gh-polled → cannot positively
+        // confirm no-PR (absence ≠ no-PR, must-fix #3).
+        let home = tmp_home("inv-unknown");
+        write_pr(&home, "feat/x", MergeState::NotReady, 0, false);
+        let (r, c) = releasable_by_invariant(&home, "o/r", "feat/x");
+        assert!(!r);
+        assert_eq!(c, PrConfidence::Unknown);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn invariant_absent_pr_state_is_unknown() {
+        let home = tmp_home("inv-absent");
+        let (r, c) = releasable_by_invariant(&home, "o/r", "feat/missing");
+        assert!(!r);
+        assert_eq!(c, PrConfidence::Unknown);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn invariant_closed_unmerged_respects_grace() {
+        let home = tmp_home("inv-closed");
+        // Within grace (just closed) → not releasable.
+        let fresh = chrono::Utc::now().to_rfc3339();
+        write_pr(
+            &home,
+            "feat/x",
+            MergeState::ClosedUnmerged { closed_at: fresh },
+            9,
+            true,
+        );
+        let (r, _) = releasable_by_invariant(&home, "o/r", "feat/x");
+        assert!(
+            !r,
+            "closed-unmerged within grace must NOT release (may rework)"
+        );
+        // Past grace → releasable.
+        let old =
+            (chrono::Utc::now() - chrono::Duration::hours(CLOSE_GRACE_HOURS + 1)).to_rfc3339();
+        write_pr(
+            &home,
+            "feat/x",
+            MergeState::ClosedUnmerged { closed_at: old },
+            9,
+            true,
+        );
+        let (r2, c2) = releasable_by_invariant(&home, "o/r", "feat/x");
+        assert!(r2, "closed-unmerged past grace is releasable");
+        assert_eq!(c2, PrConfidence::ObservedTerminal);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn eligibility_requires_dispatch_task_id() {
+        assert!(is_dispatch_lease(&serde_json::json!({ "task_id": "t-1" })));
+        // Fail-safe: empty / missing task_id → NOT eligible.
+        assert!(!is_dispatch_lease(&serde_json::json!({ "task_id": "" })));
+        assert!(!is_dispatch_lease(
+            &serde_json::json!({ "branch": "feat/x" })
+        ));
+    }
+
+    #[test]
+    fn cas_lease_identity_detects_release() {
+        let snap = LeaseIdentity::from_binding(
+            "dev",
+            &serde_json::json!({ "task_id": "t-1", "branch": "feat/x", "worktree": "/w", "issued_at": "T1" }),
+        );
+        // Same binding → matches.
+        let same = LeaseIdentity::from_binding(
+            "dev",
+            &serde_json::json!({ "task_id": "t-1", "branch": "feat/x", "worktree": "/w", "issued_at": "T1" }),
+        );
+        assert_eq!(snap, same);
+        // Re-leased (new task / issued_at) → mismatch → CAS skips.
+        let relesed = LeaseIdentity::from_binding(
+            "dev",
+            &serde_json::json!({ "task_id": "t-2", "branch": "feat/x", "worktree": "/w", "issued_at": "T2" }),
+        );
+        assert_ne!(snap, relesed);
+    }
+
+    #[test]
+    fn intent_expiry_after_7_days() {
+        let mut intent = sample_intent("t-exp");
+        intent.enqueued_at =
+            (chrono::Utc::now() - chrono::Duration::days(INTENT_EXPIRY_DAYS + 1)).to_rfc3339();
+        assert!(intent_expired(&intent), "intent older than 7d expires");
+        intent.enqueued_at = chrono::Utc::now().to_rfc3339();
+        assert!(!intent_expired(&intent), "fresh intent does not expire");
     }
 }

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1320,7 +1320,7 @@ async fn check_and_remove_terminal_pr(
     );
     if merged {
         crate::status_summary::auto_close_merged_tasks(ctx.home, ctx.branch);
-        crate::daemon::auto_release::auto_release_for_merged_branch(ctx.home, ctx.branch);
+        crate::daemon::auto_release::auto_release_for_merged_branch(ctx.home, ctx.repo, ctx.branch);
     }
     Ok(true)
 }

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -77,7 +77,9 @@ pub fn scan_and_emit_with(
         // NOT run under the PR-state flock. The closure only records the branch
         // to release; the actual release runs after `with_pr_state` returns and
         // the flock is dropped (see below).
-        let mut release_after_unlock: Option<String> = None;
+        // t-worktree-leak (PR-1): (branch, event_kind) of a terminal PR transition
+        // observed this scan — the release-invariant recompute runs post-flock.
+        let mut release_after_unlock: Option<(String, &'static str)> = None;
         // #1629: collect deferred inbox emits here under the flock; drain them
         // AFTER `with_pr_state` returns so enqueue_with_idle_hint (self-IPC via
         // loopback api::call) runs lock-free (#1617 lock-while-blocking class).
@@ -131,7 +133,7 @@ pub fn scan_and_emit_with(
                         // AFTER this flock is dropped (the git subprocess +
                         // nested binding flock are the #1617 lock-while-blocking
                         // class). Record the branch; release runs post-unlock.
-                        release_after_unlock = Some(state.branch.clone());
+                        release_after_unlock = Some((state.branch.clone(), "merge"));
                         let author = resolve_author(state);
                         let body = format!(
                             "[pr-merged] {}@{} (merge_commit {}, merged_at {})\n\n\
@@ -176,6 +178,10 @@ pub fn scan_and_emit_with(
                         let msg = build_event_message("pr-closed-unmerged", &author, state, body);
                         pending_emits.push((author, msg));
                         state.ready_emitted_for_sha = Some(state.head_sha.clone());
+                        // t-worktree-leak (PR-1): close-unmerged is a terminal PR
+                        // transition → recompute the release invariant post-flock
+                        // (the sweeper applies the conservative close-grace).
+                        release_after_unlock = Some((state.branch.clone(), "close_unmerged"));
                         dirty = true;
                     } else {
                         tracing::debug!(
@@ -212,9 +218,18 @@ pub fn scan_and_emit_with(
         }
 
         // #bughunt3 (#1617 class): PR-state flock is now released — run the
-        // auto-release (git subprocess + nested binding flock) lock-free.
-        if let Some(merged_branch) = release_after_unlock {
-            crate::daemon::auto_release::auto_release_for_merged_branch(home, &merged_branch);
+        // release-invariant recompute lock-free. t-worktree-leak (PR-1): merge
+        // keeps the named entry (the #1617 invariant test pins it); close-unmerged
+        // enqueues through the same HYBRID path with its own event kind.
+        if let Some((branch, event_kind)) = release_after_unlock {
+            match event_kind {
+                "merge" => crate::daemon::auto_release::auto_release_for_merged_branch(
+                    home, &repo, &branch,
+                ),
+                _ => crate::daemon::auto_release::enqueue_release_recompute(
+                    home, &repo, &branch, event_kind,
+                ),
+            }
         }
 
         match result {

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -340,11 +340,27 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                         .as_ref()
                         .map(|o| o.0.clone())
                         .unwrap_or_else(|| caller.clone());
-                    if let Some(wt) = crate::binding::read(home, &owner)
-                        .and_then(|v| v["worktree"].as_str().map(std::path::PathBuf::from))
-                    {
-                        let _ =
-                            crate::mcp::handlers::dispatch_hook::clean_empty_init_commits(&wt).ok();
+                    if let Some(binding) = crate::binding::read(home, &owner) {
+                        if let Some(wt) = binding["worktree"].as_str().map(std::path::PathBuf::from)
+                        {
+                            let _ =
+                                crate::mcp::handlers::dispatch_hook::clean_empty_init_commits(&wt)
+                                    .ok();
+                        }
+                        // t-worktree-leak (PR-1): task-done is one of the 3 release
+                        // events. Enqueue a release-invariant recompute — if the
+                        // branch has no open PR and all its tasks are done, the
+                        // sweeper releases the worktree (covers tasks that never
+                        // produce a PR: RCA / design / spike). An open PR holds the
+                        // release until it terminates. (repo="" → sweeper derives it.)
+                        if let Some(branch) = binding["branch"].as_str() {
+                            crate::daemon::auto_release::enqueue_release_recompute(
+                                home,
+                                "",
+                                branch,
+                                "task_done",
+                            );
+                        }
                     }
                     // #1018 (B): eager cleanup of pending dispatch
                     // sidecars whose correlation_id matches this


### PR DESCRIPTION
## What

PR-1 of the worktree-leak fix (team-converged design). Replaces the merge+verdict-only auto-release with a unified, event-driven release **invariant** that closes the never-released-worktree leak (RCA Class 1).

## Invariant (repo+branch scoped)

`releasable ⟺ PR-terminal ∨ (no-PR ∧ all branch tasks done)`, AND not-dirty AND not-opt-out.

- **merge** → releases the worktree **orthogonally to the task** (team-resolved T1).
- **close-unmerged** → terminal, but with a **24h grace** (committed-but-unmerged may be reworked).
- **no-PR** (positively gh-polled, `pr_number==0`) + all branch tasks done → release (covers RCA/design/spike tasks that never produce a PR).
- **open PR → NOT releasable**: a VERIFIED on an open PR no longer releases (**Q1(b)**) — release waits for the terminal event. **This fixes a latent premature-release bug**: #1795 (VERIFIED → windows-CI re-push) and #1804 (VERIFIED → base-drift rebase) both needed the worktree *after* VERIFIED.

## HYBRID edge+level

The 3 events (merge `scanner:217`, close-unmerged `scanner:163`, task-done `handler:344`) + the verdict path each enqueue a durable recompute intent; the sweeper **retries until the invariant holds**, with a **7-day expiry** handing off to the force-reclaim backstop (PR-2). `decide_release` keeps the dirty/opt-out gates.

## 7 must-fixes

1. **TOCTOU CAS** — each intent snapshots the lease identity; the sweeper skips if the live binding no longer matches (re-leased). In-process compare (single-threaded sweep); a fully binding-lock-atomic variant is a noted follow-up.
2. **repo+branch scoped** invariant + intent.
3. **no-PR = POSITIVE confirmation** (gh-polled ∧ `pr_number==0`), never pr_state absence — `PrConfidence {ObservedTerminal, ObservedOpen, QueriedNone, Unknown}`.
4. **multi-task aggregation** (all branch tasks Done/Cancelled).
5. **eligibility** limited to dispatch leases (binding has a `task_id`); fail-safe → NOT-eligible; non-dispatch worktrees left to the force-reclaim backstop.
6. **dirty + opt-out gates preserved** (through `decide_release`).
7. the force-reclaim backstop itself is **PR-2**.

## Tests

23 auto_release tests (merged/open/closed-grace/no-PR/unknown invariant, eligibility, CAS, 7d expiry, merge-enqueues-recompute-intent). pr_state (66) + messaging (45) + tasks (101) suites green; the #1617 invariant test passes (merge stays post-flock); fmt + clippy clean; no drift.

> **Reviewer — adversarial focus**: the TOCTOU CAS window, the no-PR positive-confirm (not absence), and the close-grace. A full enqueue→sweep→release integration test (git worktree + task board) is a good addition to layer on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)