### PR TITLE
fix(worktree-leak): force-reclaim LOUD backstop (PR-2)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -284,6 +284,17 @@ pub(crate) fn read_daemon_pid(run_dir: &Path) -> Option<u32> {
         .and_then(|(pid, _)| pid.parse().ok())
 }
 
+/// Read the boot epoch (unix seconds) recorded in `{run_dir}/.daemon`
+/// (`{pid}:{boot_unix}`). Used by the worktree force-reclaim boot-grace
+/// (reviewer-2 #5). `None` if the file is missing or malformed.
+pub(crate) fn read_daemon_boot_unix(run_dir: &Path) -> Option<u64> {
+    std::fs::read_to_string(run_dir.join(".daemon"))
+        .ok()?
+        .trim()
+        .split_once(':')
+        .and_then(|(_, ts)| ts.parse().ok())
+}
+
 /// Agent definition tuple for daemon startup.
 pub type AgentDef = (
     String,

--- a/src/daemon/retention/worktrees.rs
+++ b/src/daemon/retention/worktrees.rs
@@ -130,8 +130,20 @@ pub(crate) fn maybe_remove_candidate(
         crate::git_helpers::git_bypass(path, &["status", "--porcelain=v1", "--ignored"]);
     match status_output {
         Ok(o) if o.status.success() => {
-            if !o.stdout.is_empty() {
-                let status_text = String::from_utf8_lossy(&o.stdout);
+            let status_text = String::from_utf8_lossy(&o.stdout);
+            // #1053 keeps `--ignored` to protect operator data in gitignored files
+            // (T13a). But the daemon's OWN `.agend-managed` marker is gitignored
+            // too (.gitignore:29), so `--ignored` lists `!! .agend-managed` in
+            // EVERY managed worktree — counting that as WIP skipped every worktree,
+            // no-oping ALL GC (reviewer-2 efficacy defect: force-reclaim +
+            // clean-release reclaimed nothing). Exclude ONLY the marker line; any
+            // other entry (real tracked/untracked WIP, or operator gitignored data)
+            // still skips. Porcelain v1 line = `XY <path>` → path starts at col 3.
+            let has_protectable_content = status_text.lines().any(|line| {
+                let p = line.get(3..).map(str::trim).unwrap_or("");
+                !p.is_empty() && p != crate::worktree_pool::MANAGED_MARKER
+            });
+            if has_protectable_content {
                 tracing::warn!(
                     path = %path.display(),
                     status = %status_text.trim(),
@@ -880,5 +892,85 @@ mod tests {
             "merged PR never released → event-release bug"
         );
         let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// setup_git_repo + commit a .gitignore with `.agend-managed`, so a leased
+    /// worktree's marker is reported as `!! .agend-managed` under `--ignored` —
+    /// the exact production / reviewer-2 repro condition.
+    fn setup_git_repo_marker_ignored(dir: &Path) -> PathBuf {
+        let repo = setup_git_repo(dir);
+        std::fs::write(repo.join(".gitignore"), ".agend-managed\n").unwrap();
+        for args in [
+            vec!["add", ".gitignore"],
+            vec!["commit", "-m", "gitignore marker"],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(&repo)
+                .env("AGEND_GIT_BYPASS", "1")
+                .env("GIT_AUTHOR_NAME", "t")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "t")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .output()
+                .unwrap();
+        }
+        repo
+    }
+
+    /// reviewer-2 efficacy (§3.9 representative fixture): a REAL `lease()` worktree
+    /// carries the gitignored `.agend-managed` marker, which `--ignored` reports as
+    /// `!! .agend-managed`. It MUST archive — NOT be skipped as WIP by its own
+    /// marker. (The old `add_worktree` fixture had no marker → masked this.)
+    #[test]
+    fn force_reclaim_real_lease_with_marker_is_archived() {
+        let dir = tmp_home("fr-real-lease");
+        let repo = setup_git_repo_marker_ignored(&dir);
+        let lease = crate::worktree_pool::lease(&dir, &repo, "dev-real", "feat/x").expect("lease");
+        assert!(
+            crate::binding::read(&dir, "dev-real").is_some(),
+            "pre: bound"
+        );
+        let cand = crate::worktree_pool::GcCandidate {
+            path: lease.path.clone(),
+            agent: "dev-real".to_string(),
+            reason: "fr".to_string(),
+            kind: crate::worktree_pool::GcKind::ForceReclaim,
+        };
+        let outcome = maybe_remove_candidate(&dir, &cand);
+        assert!(
+            matches!(outcome, RemovalOutcome::Removed),
+            "marker-bearing real lease must archive, not be skipped by its own marker: {outcome:?}"
+        );
+        assert!(!lease.path.exists(), "archived");
+        assert!(
+            crate::binding::read(&dir, "dev-real").is_none(),
+            "unbound after force-reclaim"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The 4th leak root: a RELEASED marker-bearing worktree must also archive
+    /// (clean-release uses the same dirty-check).
+    #[test]
+    fn clean_release_real_lease_with_marker_is_archived() {
+        let dir = tmp_home("cr-real-lease");
+        let repo = setup_git_repo_marker_ignored(&dir);
+        let lease = crate::worktree_pool::lease(&dir, &repo, "dev-cr", "feat/y").expect("lease");
+        // Released → binding cleared (clean-release path requires the binding gone).
+        crate::binding::unbind(&dir, "dev-cr");
+        let cand = crate::worktree_pool::GcCandidate {
+            path: lease.path.clone(),
+            agent: "dev-cr".to_string(),
+            reason: "cr".to_string(),
+            kind: crate::worktree_pool::GcKind::CleanRelease,
+        };
+        let outcome = maybe_remove_candidate(&dir, &cand);
+        assert!(
+            matches!(outcome, RemovalOutcome::Removed),
+            "released marker-bearing worktree must archive (clean-release efficacy): {outcome:?}"
+        );
+        assert!(!lease.path.exists(), "archived");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/daemon/retention/worktrees.rs
+++ b/src/daemon/retention/worktrees.rs
@@ -131,19 +131,39 @@ pub(crate) fn maybe_remove_candidate(
     match status_output {
         Ok(o) if o.status.success() => {
             let status_text = String::from_utf8_lossy(&o.stdout);
-            // #1053 keeps `--ignored` to protect operator data in gitignored files
-            // (T13a). But the daemon's OWN `.agend-managed` marker is gitignored
-            // too (.gitignore:29), so `--ignored` lists `!! .agend-managed` in
-            // EVERY managed worktree — counting that as WIP skipped every worktree,
-            // no-oping ALL GC (reviewer-2 efficacy defect: force-reclaim +
-            // clean-release reclaimed nothing). Exclude ONLY the marker line; any
-            // other entry (real tracked/untracked WIP, or operator gitignored data)
-            // still skips. Porcelain v1 line = `XY <path>` → path starts at col 3.
-            let has_protectable_content = status_text.lines().any(|line| {
-                let p = line.get(3..).map(str::trim).unwrap_or("");
-                !p.is_empty() && p != crate::worktree_pool::MANAGED_MARKER
+            // Dirty pre-check, parameterized by mode (reviewer-2 efficacy). Porcelain
+            // v1 line = `XY <path>`: code at cols 0..2, path from col 3. `!!` = ignored.
+            //
+            // FORCE-RECLAIM (only fires on dead+age, ALWAYS archive-to-trash =
+            // recoverable): no gitignored file should block — `target/`, the
+            // `.agend-managed` marker, operator scratch all land in `.trash`
+            // recoverably (the archive IS the safety net). Block ONLY on real
+            // tracked/untracked WIP. Without this, every BUILT worktree (`!! target/`)
+            // no-ops — the same defect the marker caused.
+            //
+            // CLEAN-RELEASE (can hard-delete via gc_run = irrecoverable): keep #1053's
+            // `--ignored` strictness to protect operator gitignored DATA (T13a) — but
+            // never let the daemon's OWN marker block. (CleanRelease over-protecting
+            // `target/` is a separate pre-existing leak root, tracked as follow-up.)
+            let has_blocking_content = status_text.lines().any(|line| {
+                let code = line.get(..2).unwrap_or("");
+                let path = line.get(3..).map(str::trim).unwrap_or("");
+                if path.is_empty() {
+                    return false;
+                }
+                // The daemon's OWN marker NEVER blocks, under ANY status code — it is
+                // `!! .agend-managed` where the repo gitignores it (.gitignore:29) and
+                // `?? .agend-managed` where it does not. Either way, not operator data.
+                if path == crate::worktree_pool::MANAGED_MARKER {
+                    return false;
+                }
+                if code == "!!" {
+                    // Other ignored file (e.g. `target/`, operator scratch).
+                    return !force_reclaim; // force-reclaim: archive-recoverable → never blocks
+                }
+                true // tracked/untracked = real WIP → always blocks
             });
-            if has_protectable_content {
+            if has_blocking_content {
                 tracing::warn!(
                     path = %path.display(),
                     status = %status_text.trim(),
@@ -407,6 +427,15 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    /// Serializes the tests that mutate the process-global
+    /// `AGEND_WORKTREE_GC_TRASH_DAYS` env var, so they cannot race each other (or be
+    /// observed mid-mutation) under the parallel test runner.
+    static GC_TRASH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn gc_trash_env_guard() -> std::sync::MutexGuard<'static, ()> {
+        GC_TRASH_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     /// Build a CleanRelease GcCandidate for the existing maybe_remove_candidate tests.
     fn clean_cand(path: &Path, agent: &str) -> crate::worktree_pool::GcCandidate {
         crate::worktree_pool::GcCandidate {
@@ -594,6 +623,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn trash_purge_removes_old_preserves_recent() {
+        let _env = gc_trash_env_guard();
         let dir = tmp_home("t2-purge");
         let trash = trash_root(&dir);
         std::fs::create_dir_all(&trash).unwrap();
@@ -623,6 +653,7 @@ mod tests {
     /// in the same sweep tick (replaces a separate disable flag).
     #[test]
     fn trash_days_zero_purges_same_tick() {
+        let _env = gc_trash_env_guard();
         let dir = tmp_home("t3-zero");
         let trash = trash_root(&dir);
         std::fs::create_dir_all(&trash).unwrap();
@@ -698,6 +729,7 @@ mod tests {
     /// preserves the new entry under the default retention window.
     #[test]
     fn purge_preserves_fresh_archive_in_same_tick() {
+        let _env = gc_trash_env_guard();
         let dir = tmp_home("t6-concurrent");
         let trash = trash_root(&dir);
         std::fs::create_dir_all(&trash).unwrap();
@@ -899,7 +931,7 @@ mod tests {
     /// the exact production / reviewer-2 repro condition.
     fn setup_git_repo_marker_ignored(dir: &Path) -> PathBuf {
         let repo = setup_git_repo(dir);
-        std::fs::write(repo.join(".gitignore"), ".agend-managed\n").unwrap();
+        std::fs::write(repo.join(".gitignore"), ".agend-managed\ntarget/\n").unwrap();
         for args in [
             vec!["add", ".gitignore"],
             vec!["commit", "-m", "gitignore marker"],
@@ -971,6 +1003,56 @@ mod tests {
             "released marker-bearing worktree must archive (clean-release efficacy): {outcome:?}"
         );
         assert!(!lease.path.exists(), "archived");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// reviewer-2 residual: a BUILT worktree carries in-tree `target/`
+    /// (`!! target/`). force-reclaim is always archive-to-trash (recoverable), so
+    /// gitignored build output must NOT block it — else every built worktree
+    /// (i.e. all of them) no-ops, the same defect the marker caused.
+    #[test]
+    fn force_reclaim_built_worktree_with_target_is_archived() {
+        let dir = tmp_home("fr-built");
+        let repo = setup_git_repo_marker_ignored(&dir);
+        let lease = crate::worktree_pool::lease(&dir, &repo, "dev-built", "feat/x").expect("lease");
+        std::fs::create_dir_all(lease.path.join("target")).unwrap();
+        std::fs::write(lease.path.join("target").join("artifact.o"), "build").unwrap();
+        let cand = crate::worktree_pool::GcCandidate {
+            path: lease.path.clone(),
+            agent: "dev-built".to_string(),
+            reason: "fr".to_string(),
+            kind: crate::worktree_pool::GcKind::ForceReclaim,
+        };
+        let outcome = maybe_remove_candidate(&dir, &cand);
+        assert!(
+            matches!(outcome, RemovalOutcome::Removed),
+            "built worktree (!! target/) force-reclaim must archive (recoverable): {outcome:?}"
+        );
+        assert!(!lease.path.exists(), "archived");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// force-reclaim still respects REAL WIP: an untracked (non-ignored) file means
+    /// uncommitted operator/agent work → skip (don't archive it away).
+    #[test]
+    fn force_reclaim_with_real_wip_is_skipped() {
+        let dir = tmp_home("fr-wip");
+        let repo = setup_git_repo_marker_ignored(&dir);
+        let lease = crate::worktree_pool::lease(&dir, &repo, "dev-wip", "feat/x").expect("lease");
+        // A non-gitignored untracked file = real WIP (`?? notes.txt`).
+        std::fs::write(lease.path.join("notes.txt"), "uncommitted work").unwrap();
+        let cand = crate::worktree_pool::GcCandidate {
+            path: lease.path.clone(),
+            agent: "dev-wip".to_string(),
+            reason: "fr".to_string(),
+            kind: crate::worktree_pool::GcKind::ForceReclaim,
+        };
+        let outcome = maybe_remove_candidate(&dir, &cand);
+        assert!(
+            matches!(outcome, RemovalOutcome::Skipped { .. }),
+            "force-reclaim must NOT archive a worktree with real (tracked/untracked) WIP: {outcome:?}"
+        );
+        assert!(lease.path.exists(), "preserved");
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/daemon/retention/worktrees.rs
+++ b/src/daemon/retention/worktrees.rs
@@ -107,8 +107,24 @@ fn try_archive(src: &Path, dst: &Path) -> std::io::Result<()> {
     }
 }
 
-pub(crate) fn maybe_remove_candidate(home: &Path, path: &Path, agent: &str) -> RemovalOutcome {
-    let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+pub(crate) fn maybe_remove_candidate(
+    home: &Path,
+    candidate: &crate::worktree_pool::GcCandidate,
+) -> RemovalOutcome {
+    let agent = candidate.agent.as_str();
+    let force_reclaim = candidate.kind == crate::worktree_pool::GcKind::ForceReclaim;
+    // t-worktree-leak PR-2: a force-reclaim's binding is still present (never
+    // released) — capture branch/repo from it BEFORE archive for the post-archive
+    // ALERT classification + the unbind.
+    let pre_binding = if force_reclaim {
+        crate::binding::read(home, agent)
+    } else {
+        None
+    };
+    let path = candidate
+        .path
+        .canonicalize()
+        .unwrap_or_else(|_| candidate.path.clone());
     let path = path.as_path();
     let status_output =
         crate::git_helpers::git_bypass(path, &["status", "--porcelain=v1", "--ignored"]);
@@ -153,10 +169,23 @@ pub(crate) fn maybe_remove_candidate(home: &Path, path: &Path, agent: &str) -> R
             };
         }
     };
-    // #1170 TOCTOU fix: re-validate binding state immediately before archive.
-    // gc_candidates() checked this earlier, but the worktree may have been
-    // rebound between enumeration and now.
-    if crate::binding::read(home, agent).is_some() {
+    // #1170 + t-worktree-leak PR-2: re-validate just before archive (TOCTOU /
+    // fencing). For a CLEAN release the binding must be gone — a rebind means the
+    // lease is live again → skip. For a FORCE-RECLAIM the binding is EXPECTED to be
+    // present (never released), so re-check LIVENESS instead: if the agent came
+    // back to life between enumeration and now, spare it.
+    if force_reclaim {
+        if crate::worktree_pool::is_agent_alive(home, agent) {
+            tracing::info!(
+                agent,
+                path = %path.display(),
+                "force-reclaim: agent showed liveness at archive time — sparing (fencing)"
+            );
+            return RemovalOutcome::Skipped {
+                reason: "agent_alive_at_archive".to_string(),
+            };
+        }
+    } else if crate::binding::read(home, agent).is_some() {
         tracing::info!(
             agent,
             path = %path.display(),
@@ -187,6 +216,23 @@ pub(crate) fn maybe_remove_candidate(home: &Path, path: &Path, agent: &str) -> R
             if let Err(e) = prune {
                 tracing::warn!(error = %e, "git worktree prune failed (non-fatal)");
             }
+            // t-worktree-leak PR-2: a force-reclaim's binding is still present
+            // (never released) → clear it now, then LOUD-classify + ALERT.
+            if force_reclaim {
+                crate::binding::unbind(home, agent);
+                let branch = pre_binding
+                    .as_ref()
+                    .and_then(|b| b.get("branch").and_then(|v| v.as_str()));
+                let repo = pre_binding
+                    .as_ref()
+                    .and_then(|b| b.get("source_repo").and_then(|v| v.as_str()))
+                    .and_then(|src| {
+                        crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(Path::new(
+                            src,
+                        ))
+                    });
+                emit_force_reclaim_alert(home, agent, branch, repo.as_deref(), &candidate.reason);
+            }
             RemovalOutcome::Removed
         }
         Err(e) => {
@@ -201,6 +247,66 @@ pub(crate) fn maybe_remove_candidate(home: &Path, path: &Path, agent: &str) -> R
             }
         }
     }
+}
+
+/// t-worktree-leak PR-2: classify a force-reclaim by the branch's pr_state, to set
+/// the ALERT confidence. Never blindly trusts pr_state — `unknown` is explicit.
+fn classify_force_reclaim(home: &Path, repo: Option<&str>, branch: Option<&str>) -> &'static str {
+    let (Some(repo), Some(branch)) = (repo, branch) else {
+        return "unknown";
+    };
+    use crate::daemon::pr_state::MergeState;
+    match crate::daemon::pr_state::load(home, repo, branch) {
+        Some(s) => match s.merge_state {
+            // A terminal PR whose worktree had to be force-reclaimed means the
+            // event-driven release (PR-1) NEVER fired for it = a bug.
+            MergeState::Merged { .. } | MergeState::ClosedUnmerged { .. } => "observed_terminal",
+            _ if s.pr_number > 0 => "observed_open",
+            _ if s.last_gh_poll_at.is_some() => "queried_none",
+            _ => "unknown",
+        },
+        None => "unknown",
+    }
+}
+
+/// t-worktree-leak PR-2 safety #4: LOUD operator notification on a force-reclaim,
+/// classified by confidence. `observed_terminal` = a terminal PR that never
+/// released = an event-release BUG → error-level ALERT (forces the event path to
+/// be fixed, never silently swallowed); other confidences are expected
+/// abandonment cleanup (warn). Always recoverable from `.trash`.
+fn emit_force_reclaim_alert(
+    home: &Path,
+    agent: &str,
+    branch: Option<&str>,
+    repo: Option<&str>,
+    reason: &str,
+) {
+    let confidence = classify_force_reclaim(home, repo, branch);
+    if confidence == "observed_terminal" {
+        tracing::error!(
+            agent,
+            ?branch,
+            confidence,
+            reason,
+            "PR-2 FORCE-RECLAIM ALERT: archived a worktree whose PR is TERMINAL but was \
+             NEVER released — the event-driven release path FAILED (bug). Recoverable in .trash."
+        );
+    } else {
+        tracing::warn!(
+            agent, ?branch, confidence, reason,
+            "PR-2 force-reclaim: archived an abandoned never-released worktree (recoverable in .trash)"
+        );
+    }
+    crate::event_log::log(
+        home,
+        if confidence == "observed_terminal" {
+            "force_reclaim_alert_event_bug"
+        } else {
+            "force_reclaim_archived"
+        },
+        agent,
+        &format!("branch={branch:?} confidence={confidence} reason={reason}"),
+    );
 }
 
 /// Purge `.trash/worktrees/*` entries older than `AGEND_WORKTREE_GC_TRASH_DAYS`
@@ -254,7 +360,7 @@ pub(super) fn sweep(home: &Path) -> usize {
     let candidates = crate::worktree_pool::gc_candidates(home);
     let mut removed = 0;
     for c in &candidates {
-        match maybe_remove_candidate(home, &c.path, &c.agent) {
+        match maybe_remove_candidate(home, c) {
             RemovalOutcome::Removed => {
                 removed += 1;
                 tracing::info!(
@@ -288,6 +394,16 @@ pub(super) fn sweep(home: &Path) -> usize {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    /// Build a CleanRelease GcCandidate for the existing maybe_remove_candidate tests.
+    fn clean_cand(path: &Path, agent: &str) -> crate::worktree_pool::GcCandidate {
+        crate::worktree_pool::GcCandidate {
+            path: path.to_path_buf(),
+            agent: agent.to_string(),
+            reason: "test".to_string(),
+            kind: crate::worktree_pool::GcKind::CleanRelease,
+        }
+    }
 
     fn tmp_home(name: &str) -> PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};
@@ -362,7 +478,7 @@ mod tests {
             .output()
             .unwrap();
 
-        let result = maybe_remove_candidate(&dir, &wt, "wt-ignored");
+        let result = maybe_remove_candidate(&dir, &clean_cand(&wt, "wt-ignored"));
         assert!(matches!(result, RemovalOutcome::Skipped { .. }));
         assert!(wt.exists(), "worktree must NOT be archived");
 
@@ -378,7 +494,7 @@ mod tests {
 
         std::fs::write(wt.join("new-file.txt"), "work in progress").unwrap();
 
-        let result = maybe_remove_candidate(&dir, &wt, "wt-untracked");
+        let result = maybe_remove_candidate(&dir, &clean_cand(&wt, "wt-untracked"));
         assert!(matches!(result, RemovalOutcome::Skipped { .. }));
         assert!(wt.exists(), "worktree must NOT be archived");
 
@@ -392,7 +508,7 @@ mod tests {
         let repo = setup_git_repo(&dir);
         let wt = add_worktree(&repo, "wt-clean");
 
-        let result = maybe_remove_candidate(&dir, &wt, "wt-clean");
+        let result = maybe_remove_candidate(&dir, &clean_cand(&wt, "wt-clean"));
         assert!(matches!(result, RemovalOutcome::Removed));
         assert!(!wt.exists(), "worktree moved from original path");
 
@@ -418,7 +534,7 @@ mod tests {
         let bad_path = dir.join("not-a-worktree");
         std::fs::create_dir_all(&bad_path).unwrap();
 
-        let result = maybe_remove_candidate(&dir, &bad_path, "agent");
+        let result = maybe_remove_candidate(&dir, &clean_cand(&bad_path, "agent"));
         assert!(matches!(result, RemovalOutcome::Skipped { .. }));
 
         std::fs::remove_dir_all(&dir).ok();
@@ -548,7 +664,7 @@ mod tests {
         let repo = setup_git_repo(&dir);
         let wt = add_worktree(&repo, "wt-prune");
 
-        let result = maybe_remove_candidate(&dir, &wt, "wt-prune");
+        let result = maybe_remove_candidate(&dir, &clean_cand(&wt, "wt-prune"));
         assert!(matches!(result, RemovalOutcome::Removed));
 
         let output = std::process::Command::new("git")
@@ -602,7 +718,7 @@ mod tests {
         std::fs::create_dir_all(&trash).unwrap();
         std::fs::set_permissions(&trash, std::fs::Permissions::from_mode(0o500)).unwrap();
 
-        let result = maybe_remove_candidate(&dir, &wt, "wt-perm");
+        let result = maybe_remove_candidate(&dir, &clean_cand(&wt, "wt-perm"));
 
         // Restore permissions for cleanup regardless of test outcome.
         let _ = std::fs::set_permissions(&trash, std::fs::Permissions::from_mode(0o755));
@@ -634,7 +750,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = maybe_remove_candidate(&dir, &wt, "wt-rebound");
+        let result = maybe_remove_candidate(&dir, &clean_cand(&wt, "wt-rebound"));
         assert!(
             matches!(result, RemovalOutcome::Skipped { ref reason } if reason == "rebound_since_enumeration"),
             "rebound worktree must be skipped: {result:?}"
@@ -653,8 +769,8 @@ mod tests {
         let wt1 = add_worktree(&repo, "wt-col-a");
         let wt2 = add_worktree(&repo, "wt-col-b");
 
-        let r1 = maybe_remove_candidate(&dir, &wt1, "agent-x");
-        let r2 = maybe_remove_candidate(&dir, &wt2, "agent-x");
+        let r1 = maybe_remove_candidate(&dir, &clean_cand(&wt1, "agent-x"));
+        let r2 = maybe_remove_candidate(&dir, &clean_cand(&wt2, "agent-x"));
         assert!(matches!(r1, RemovalOutcome::Removed), "first: {r1:?}");
         assert!(matches!(r2, RemovalOutcome::Removed), "second: {r2:?}");
 
@@ -688,5 +804,81 @@ mod tests {
         assert_eq!(parts[1].len(), 9, "nanos must be 9 digits: {ts1}");
         // Two sequential calls should differ (or at least not panic)
         let _ = (ts1, ts2);
+    }
+
+    fn write_binding(home: &Path, agent: &str, branch: &str, wt: &Path) {
+        let bd = crate::paths::runtime_dir(home).join(agent);
+        std::fs::create_dir_all(&bd).unwrap();
+        std::fs::write(
+            bd.join("binding.json"),
+            serde_json::json!({
+                "version": 1, "agent": agent, "task_id": "t", "branch": branch,
+                "worktree": wt.to_str().unwrap(), "source_repo": "/x",
+                "issued_at": "2026-06-05T00:00:00Z"
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
+    /// t-worktree-leak PR-2: a ForceReclaim candidate (binding still present, agent
+    /// dead) is archived AND unbound — the never-released binding is cleared.
+    #[test]
+    fn force_reclaim_archives_and_unbinds() {
+        let dir = tmp_home("fr-archive");
+        let repo = setup_git_repo(&dir);
+        let wt = add_worktree(&repo, "wt-fr");
+        write_binding(&dir, "dev-fr", "feat/x", &wt);
+        let cand = crate::worktree_pool::GcCandidate {
+            path: wt.clone(),
+            agent: "dev-fr".to_string(),
+            reason: "force-reclaim test".to_string(),
+            kind: crate::worktree_pool::GcKind::ForceReclaim,
+        };
+        let outcome = maybe_remove_candidate(&dir, &cand);
+        assert!(matches!(outcome, RemovalOutcome::Removed), "{outcome:?}");
+        assert!(!wt.exists(), "worktree archived (moved out)");
+        assert!(
+            crate::binding::read(&dir, "dev-fr").is_none(),
+            "force-reclaim must unbind the never-released binding"
+        );
+        let trash = dir.join(".trash").join("worktrees");
+        assert!(
+            std::fs::read_dir(&trash)
+                .map(|d| d.flatten().count() > 0)
+                .unwrap_or(false),
+            "archived worktree is recoverable in .trash"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// t-worktree-leak PR-2 safety #4: a force-reclaim of a branch whose PR is
+    /// TERMINAL classifies as `observed_terminal` (= event-release bug → ALERT);
+    /// no pr_state classifies as `unknown` (never blindly trusts pr_state).
+    #[test]
+    fn classify_force_reclaim_terminal_is_event_bug() {
+        let home = tmp_home("fr-classify");
+        assert_eq!(
+            classify_force_reclaim(&home, Some("o/r"), Some("feat/x")),
+            "unknown",
+            "absent pr_state → unknown, not a false bug-alert"
+        );
+        let mut s = crate::daemon::pr_state::new_for_branch(
+            "o/r",
+            "feat/x",
+            "sha",
+            crate::daemon::pr_state::ReviewClass::Single,
+        );
+        s.merge_state = crate::daemon::pr_state::MergeState::Merged {
+            merge_commit: "c".into(),
+            merged_at: "2026-06-05T00:00:00Z".into(),
+        };
+        crate::daemon::pr_state::save(&home, &s).unwrap();
+        assert_eq!(
+            classify_force_reclaim(&home, Some("o/r"), Some("feat/x")),
+            "observed_terminal",
+            "merged PR never released → event-release bug"
+        );
+        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -527,17 +527,58 @@ pub fn reconcile_orphan_leases(home: &Path) {
 /// Grace period before a released worktree becomes a GC candidate.
 const GC_GRACE_HOURS: i64 = 24;
 
+/// t-worktree-leak PR-2: hard age cap for the force-reclaim backstop. A
+/// never-released lease whose agent shows NO liveness AND whose `leased_at` is
+/// older than this is force-reclaimed. Configurable (`AGEND_WORKTREE_FORCE_RECLAIM_DAYS`).
+fn force_reclaim_age_days() -> i64 {
+    std::env::var("AGEND_WORKTREE_FORCE_RECLAIM_DAYS")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .filter(|d| *d > 0)
+        .unwrap_or(7)
+}
+
+/// PR-2: liveness recency window (mirrors the binding-reconcile heartbeat window,
+/// binding.rs:380). A heartbeat / PTY input within this counts as alive.
+const LIVENESS_WINDOW_MS: u64 = 3_600_000; // 1h
+
+/// PR-2: per-agent jitter ceiling (hours) added to the age cap, so a fleet whose
+/// leases all crossed the cap together (e.g. after a long daemon outage) is
+/// reclaimed spread across ticks rather than in a single thundering-herd archive.
+const FORCE_RECLAIM_JITTER_HOURS: i64 = 6;
+
+/// t-worktree-leak PR-2: how a candidate was selected — drives the retention
+/// sweep's action (clean releases just archive; force-reclaims also emit a LOUD
+/// confidence-classified ALERT).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GcKind {
+    /// Released past the grace TTL — the normal, expected path.
+    CleanRelease,
+    /// Never released, agent abandoned (no liveness) AND past the age cap — the
+    /// force-reclaim backstop tail (no-event abandonment / dead agent).
+    ForceReclaim,
+}
+
 /// A worktree identified as a GC candidate.
 #[derive(Debug, Clone)]
 pub struct GcCandidate {
     pub path: PathBuf,
     pub agent: String,
     pub reason: String,
+    /// t-worktree-leak PR-2: selection kind (clean-release vs force-reclaim).
+    pub kind: GcKind,
 }
 
 /// Scan for GC candidates: daemon-tagged, past grace TTL, not pinned, no active binding.
 pub fn gc_candidates(home: &Path) -> Vec<GcCandidate> {
     let mut candidates = Vec::new();
+    // t-worktree-leak PR-2: snapshot the live-agent set ONCE per pass (the
+    // force-reclaim liveness check consults it per candidate; this is the
+    // process-alive signal that protects idle-but-running agents).
+    let live_agents: std::collections::HashSet<String> =
+        crate::runtime::list_agents_with_fallback(home)
+            .into_iter()
+            .collect();
 
     // New layout: <home>/worktrees/<agent>/<branch>/
     let new_root = daemon_managed_worktree_root(home);
@@ -553,7 +594,7 @@ pub fn gc_candidates(home: &Path) -> Vec<GcCandidate> {
                         if !wt_path.is_dir() {
                             continue;
                         }
-                        if let Some(candidate) = evaluate_candidate(home, &wt_path) {
+                        if let Some(candidate) = evaluate_candidate(home, &wt_path, &live_agents) {
                             candidates.push(candidate);
                         }
                     }
@@ -577,7 +618,7 @@ pub fn gc_candidates(home: &Path) -> Vec<GcCandidate> {
                         if !wt_path.is_dir() {
                             continue;
                         }
-                        if let Some(candidate) = evaluate_candidate(home, &wt_path) {
+                        if let Some(candidate) = evaluate_candidate(home, &wt_path, &live_agents) {
                             candidates.push(candidate);
                         }
                     }
@@ -589,7 +630,115 @@ pub fn gc_candidates(home: &Path) -> Vec<GcCandidate> {
     candidates
 }
 
-fn evaluate_candidate(home: &Path, wt_path: &Path) -> Option<GcCandidate> {
+/// t-worktree-leak PR-2 safety #1: does the agent show ANY sign of life? This is
+/// MULTI-signal — never just heartbeat — so an idle-but-running agent (no recent
+/// heartbeat) is still protected. A positive on ANY signal → the worktree is
+/// NEVER force-reclaimed, regardless of age (liveness-AND-age). Reads that fail
+/// lean toward "alive" (conservative — never mis-reclaim).
+fn agent_has_liveness(
+    home: &Path,
+    agent: &str,
+    live_agents: &std::collections::HashSet<String>,
+) -> bool {
+    // (process) In the live-agent registry — covers idle-but-running agents that
+    // are not currently heartbeating.
+    if live_agents.contains(agent) {
+        return true;
+    }
+    let hb = crate::daemon::heartbeat_pair::snapshot_for(agent);
+    let now = crate::daemon::heartbeat_pair::now_ms();
+    // (heartbeat) any MCP tool call within the recency window.
+    if hb.heartbeat_at_ms != 0 && now.saturating_sub(hb.heartbeat_at_ms) < LIVENESS_WINDOW_MS {
+        return true;
+    }
+    // (PTY) recent terminal input.
+    if hb.last_input_at_ms != 0 && now.saturating_sub(hb.last_input_at_ms) < LIVENESS_WINDOW_MS {
+        return true;
+    }
+    // (waiting_on) actively declared a blocker → alive.
+    if hb.waiting_on_since_ms.is_some() {
+        return true;
+    }
+    // (ci-watch) subscribed to a live ci-watch → active CI-tracked work.
+    if agent_is_ci_watch_subscriber(home, agent) {
+        return true;
+    }
+    false
+}
+
+/// t-worktree-leak PR-2: fresh multi-signal liveness check for `agent` (snapshots
+/// the live-agent set itself). Used by the retention sweep's pre-archive fencing
+/// re-validation so an agent that came back to life between enumeration and
+/// archive is spared.
+pub(crate) fn is_agent_alive(home: &Path, agent: &str) -> bool {
+    let live_agents: std::collections::HashSet<String> =
+        crate::runtime::list_agents_with_fallback(home)
+            .into_iter()
+            .collect();
+    agent_has_liveness(home, agent, &live_agents)
+}
+
+/// PR-2: is `agent` a subscriber on any live ci-watch?
+fn agent_is_ci_watch_subscriber(home: &Path, agent: &str) -> bool {
+    let dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        if entry.path().extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        if let Some(subs) = v.get("subscribers").and_then(|s| s.as_array()) {
+            if subs
+                .iter()
+                .any(|s| s.get("instance").and_then(|i| i.as_str()) == Some(agent))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// PR-2: is a never-released lease past the (per-agent jittered) force-reclaim age
+/// cap? The deterministic jitter spreads a fleet whose leases all crossed the cap
+/// together across ticks (anti-thundering-herd, safety #3). No `leased_at` → not
+/// reclaimable (conservative).
+fn leased_at_force_reclaimable(leased_at: Option<&str>, agent: &str) -> bool {
+    let Some(ts) = leased_at else {
+        return false;
+    };
+    let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) else {
+        return false;
+    };
+    let age = chrono::Utc::now().signed_duration_since(dt.with_timezone(&chrono::Utc));
+    let jitter_h = (fnv1a(agent) % (FORCE_RECLAIM_JITTER_HOURS.max(1) as u64)) as i64;
+    let cap = chrono::Duration::days(force_reclaim_age_days()) + chrono::Duration::hours(jitter_h);
+    age > cap
+}
+
+/// Stable per-agent FNV-1a hash → deterministic jitter (no randomness, so reclaim
+/// timing is reproducible).
+fn fnv1a(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn evaluate_candidate(
+    home: &Path,
+    wt_path: &Path,
+    live_agents: &std::collections::HashSet<String>,
+) -> Option<GcCandidate> {
     // Must be daemon-managed (R14).
     if !is_daemon_managed(wt_path) {
         return None;
@@ -619,32 +768,59 @@ fn evaluate_candidate(home: &Path, wt_path: &Path) -> Option<GcCandidate> {
     if agent_name.is_empty() {
         return None;
     }
-    // Must not have active binding.
-    if crate::binding::read(home, &agent_name).is_some() {
-        return None;
-    }
-    // Must be past grace TTL (check released_at in .agend-managed marker).
-    // If no released_at, worktree is still active (not yet released) → not a candidate.
-    if let Some(released_line) = marker_content
+    let binding_present = crate::binding::read(home, &agent_name).is_some();
+    let released_at = marker_content
         .lines()
-        .find(|l| l.starts_with("released_at="))
-    {
-        let ts = released_line.strip_prefix("released_at=").unwrap_or("");
-        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
-            let age = chrono::Utc::now().signed_duration_since(dt.with_timezone(&chrono::Utc));
-            if age < chrono::Duration::hours(GC_GRACE_HOURS) {
-                return None; // Still within grace period after release.
-            }
-        }
-    } else {
-        return None; // No released_at → still active, not a GC candidate.
-    }
+        .find_map(|l| l.strip_prefix("released_at="));
 
-    Some(GcCandidate {
-        path: wt_path.to_path_buf(),
-        agent: agent_name,
-        reason: format!("daemon-tagged, released >{}h, not pinned", GC_GRACE_HOURS),
-    })
+    match released_at {
+        // ── Clean-release path: explicitly released, past the grace TTL. ──
+        Some(ts) => {
+            // A released lease should already be unbound; if it is still bound,
+            // that is a contradiction — leave it alone (conservative).
+            if binding_present {
+                return None;
+            }
+            if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
+                let age = chrono::Utc::now().signed_duration_since(dt.with_timezone(&chrono::Utc));
+                if age < chrono::Duration::hours(GC_GRACE_HOURS) {
+                    return None; // still within grace
+                }
+            }
+            Some(GcCandidate {
+                path: wt_path.to_path_buf(),
+                agent: agent_name,
+                reason: format!("daemon-tagged, released >{}h, not pinned", GC_GRACE_HOURS),
+                kind: GcKind::CleanRelease,
+            })
+        }
+        // ── t-worktree-leak PR-2 force-reclaim backstop: NEVER released. ──
+        // This is ONLY the no-event-abandonment / dead-agent tail (the
+        // invariant + sweeper in PR-1 handle every worktree that DID see a
+        // merge/close/task-done event; the 7-day expired-intent path hands off
+        // here). liveness-AND-age: ANY live signal → never reclaim (even past the
+        // cap); otherwise require the per-agent-jittered age cap.
+        None => {
+            if agent_has_liveness(home, &agent_name, live_agents) {
+                return None;
+            }
+            let leased_at = marker_content
+                .lines()
+                .find_map(|l| l.strip_prefix("leased_at="));
+            if !leased_at_force_reclaimable(leased_at, &agent_name) {
+                return None;
+            }
+            Some(GcCandidate {
+                path: wt_path.to_path_buf(),
+                agent: agent_name,
+                reason: format!(
+                    "force-reclaim: never-released lease, no liveness signal, leased >{}d (abandoned)",
+                    force_reclaim_age_days()
+                ),
+                kind: GcKind::ForceReclaim,
+            })
+        }
+    }
 }
 
 /// Dry-run: log candidates without deleting. Returns candidate list.
@@ -732,8 +908,14 @@ fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
     };
 
     // Re-validate under lock: binding/pinned/grace state may have
-    // changed since gc_candidates() enumerated this worktree.
-    if evaluate_candidate(home, wt_path).is_none() {
+    // changed since gc_candidates() enumerated this worktree. t-worktree-leak
+    // PR-2: re-snapshot liveness here too, so a force-reclaim candidate whose
+    // agent came back to life between enumeration and removal is spared (fencing).
+    let live_agents: std::collections::HashSet<String> =
+        crate::runtime::list_agents_with_fallback(home)
+            .into_iter()
+            .collect();
+    if evaluate_candidate(home, wt_path, &live_agents).is_none() {
         return GcResult {
             path: wt_path.clone(),
             agent: candidate.agent.clone(),
@@ -2433,5 +2615,97 @@ mod tests {
         let resolved = resolve_source_repo(&fake_dir);
         assert!(resolved.is_none());
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── t-worktree-leak PR-2: force-reclaim backstop tests ──
+
+    fn backdate_lease(wt_path: &Path, days_ago: i64) {
+        let marker = wt_path.join(MANAGED_MARKER);
+        let content = std::fs::read_to_string(&marker).unwrap();
+        let old = (chrono::Utc::now() - chrono::Duration::days(days_ago)).to_rfc3339();
+        let new: String = content
+            .lines()
+            .map(|l| {
+                if l.starts_with("leased_at=") {
+                    format!("leased_at={old}")
+                } else {
+                    l.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(&marker, new).unwrap();
+    }
+
+    #[test]
+    fn force_reclaim_dead_agent_past_cap_is_candidate() {
+        let home = tmp_home("fr-dead");
+        let repo = tmp_repo("fr-dead-repo");
+        let lease = lease(&home, &repo, "dev-dead", "feat/x").expect("lease");
+        backdate_lease(&lease.path, force_reclaim_age_days() + 2);
+        let live: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let cand = evaluate_candidate(&home, &lease.path, &live);
+        assert!(
+            cand.is_some(),
+            "dead agent, never-released, past cap → force-reclaim candidate"
+        );
+        assert_eq!(cand.unwrap().kind, GcKind::ForceReclaim);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn force_reclaim_spares_live_registry_agent() {
+        // safety #1: any live signal → never reclaim, even past the cap.
+        let home = tmp_home("fr-live");
+        let repo = tmp_repo("fr-live-repo");
+        let lease = lease(&home, &repo, "dev-live", "feat/x").expect("lease");
+        backdate_lease(&lease.path, force_reclaim_age_days() + 2);
+        let live: std::collections::HashSet<String> =
+            ["dev-live".to_string()].into_iter().collect();
+        assert!(
+            evaluate_candidate(&home, &lease.path, &live).is_none(),
+            "agent live in the registry → spared even past cap (liveness-AND-age)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn force_reclaim_spares_ci_watch_subscriber() {
+        // multi-signal: a ci-watch subscription is a liveness signal (not heartbeat).
+        let home = tmp_home("fr-ciw");
+        let repo = tmp_repo("fr-ciw-repo");
+        let lease = lease(&home, &repo, "dev-ciw", "feat/x").expect("lease");
+        backdate_lease(&lease.path, force_reclaim_age_days() + 2);
+        let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        std::fs::write(
+            ci_dir.join("w.json"),
+            serde_json::json!({
+                "repo": "o/r", "branch": "feat/x",
+                "subscribers": [{ "instance": "dev-ciw" }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let live: std::collections::HashSet<String> = std::collections::HashSet::new();
+        assert!(
+            evaluate_candidate(&home, &lease.path, &live).is_none(),
+            "agent subscribed to a ci-watch → spared (multi-signal liveness, not just heartbeat)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn force_reclaim_spares_recent_lease() {
+        // dead agent but the lease is recent → not yet past the age cap.
+        let home = tmp_home("fr-recent");
+        let repo = tmp_repo("fr-recent-repo");
+        let lease = lease(&home, &repo, "dev-recent", "feat/x").expect("lease");
+        let live: std::collections::HashSet<String> = std::collections::HashSet::new();
+        assert!(
+            evaluate_candidate(&home, &lease.path, &live).is_none(),
+            "recent lease → not yet reclaimable (age gate)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -678,21 +678,31 @@ pub(crate) fn is_agent_alive(home: &Path, agent: &str) -> bool {
     agent_has_liveness(home, agent, &live_agents)
 }
 
-/// PR-2: is `agent` a subscriber on any live ci-watch?
+/// PR-2: is `agent` a subscriber on any live ci-watch? codex gap ②: this is a
+/// liveness source, so every read failure FAILS TOWARD ALIVE (returns `true`,
+/// blocking reclaim) rather than silently treating the agent as not-subscribed —
+/// a mis-read must never let us reclaim a live agent. The ONE exception is the
+/// watch dir being genuinely absent (NotFound), which is a real "no watches"
+/// state, not a read failure.
 fn agent_is_ci_watch_subscriber(home: &Path, agent: &str) -> bool {
     let dir = crate::daemon::ci_watch::ci_watches_dir(home);
-    let Ok(entries) = std::fs::read_dir(&dir) else {
-        return false;
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return false,
+        Err(_) => return true, // can't enumerate watches → fail-toward-alive
     };
     for entry in entries.flatten() {
-        if entry.path().extension().and_then(|e| e.to_str()) != Some("json") {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
             continue;
         }
-        let Ok(content) = std::fs::read_to_string(entry.path()) else {
-            continue;
+        // A watch file we cannot read/parse COULD carry this agent's subscription
+        // → fail-toward-alive rather than skip it.
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            return true;
         };
         let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) else {
-            continue;
+            return true;
         };
         if let Some(subs) = v.get("subscribers").and_then(|s| s.as_array()) {
             if subs
@@ -889,6 +899,26 @@ pub fn gc_run(home: &Path) -> Vec<GcResult> {
 
 fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
     let wt_path = &candidate.path;
+
+    // t-worktree-leak PR-2 (codex gap ① CRITICAL): a force-reclaim candidate MUST
+    // NEVER be hard-deleted. Route it through the SINGLE safe deletion path
+    // (retention's `maybe_remove_candidate`: pre-archive liveness re-check +
+    // atomic archive-to-trash + unbind + LOUD confidence ALERT), so the daemon
+    // `gc_run` path and the retention sweep cannot diverge into an irrecoverable
+    // delete. Clean-release candidates keep the historical hard-delete below.
+    if candidate.kind == GcKind::ForceReclaim {
+        use crate::daemon::retention::worktrees::{maybe_remove_candidate, RemovalOutcome};
+        let outcome = maybe_remove_candidate(home, candidate);
+        return GcResult {
+            path: wt_path.clone(),
+            agent: candidate.agent.clone(),
+            removed: matches!(outcome, RemovalOutcome::Removed),
+            error: match outcome {
+                RemovalOutcome::Skipped { reason } => Some(reason),
+                RemovalOutcome::Removed => None,
+            },
+        };
+    }
 
     // Acquire the same binding lock that bind_full() uses, making
     // GC deletion and bind mutually exclusive (eliminates TOCTOU).
@@ -2705,6 +2735,111 @@ mod tests {
         assert!(
             evaluate_candidate(&home, &lease.path, &live).is_none(),
             "recent lease → not yet reclaimable (age gate)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    // codex gap ③: the heartbeat / PTY / waiting_on liveness signals + the
+    // read-failure → fail-toward-alive path (§3.9, safety-critical).
+
+    #[test]
+    fn force_reclaim_spares_recent_heartbeat() {
+        let home = tmp_home("fr-hb");
+        let repo = tmp_repo("fr-hb-repo");
+        let agent = "fr-hb-agent";
+        let lease = lease(&home, &repo, agent, "feat/x").expect("lease");
+        backdate_lease(&lease.path, force_reclaim_age_days() + 2);
+        crate::daemon::heartbeat_pair::update_with(agent, |p| {
+            p.heartbeat_at_ms = crate::daemon::heartbeat_pair::now_ms();
+        });
+        let live: std::collections::HashSet<String> = std::collections::HashSet::new();
+        assert!(
+            evaluate_candidate(&home, &lease.path, &live).is_none(),
+            "recent heartbeat → spared (heartbeat liveness signal)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn force_reclaim_spares_recent_pty_input() {
+        let home = tmp_home("fr-pty");
+        let repo = tmp_repo("fr-pty-repo");
+        let agent = "fr-pty-agent";
+        let lease = lease(&home, &repo, agent, "feat/x").expect("lease");
+        backdate_lease(&lease.path, force_reclaim_age_days() + 2);
+        crate::daemon::heartbeat_pair::update_with(agent, |p| {
+            p.last_input_at_ms = crate::daemon::heartbeat_pair::now_ms();
+        });
+        let live: std::collections::HashSet<String> = std::collections::HashSet::new();
+        assert!(
+            evaluate_candidate(&home, &lease.path, &live).is_none(),
+            "recent PTY input → spared (PTY liveness signal)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn force_reclaim_spares_declared_waiting_on() {
+        let home = tmp_home("fr-wait");
+        let repo = tmp_repo("fr-wait-repo");
+        let agent = "fr-wait-agent";
+        let lease = lease(&home, &repo, agent, "feat/x").expect("lease");
+        backdate_lease(&lease.path, force_reclaim_age_days() + 2);
+        crate::daemon::heartbeat_pair::update_with(agent, |p| {
+            p.waiting_on_since_ms = Some(crate::daemon::heartbeat_pair::now_ms());
+        });
+        let live: std::collections::HashSet<String> = std::collections::HashSet::new();
+        assert!(
+            evaluate_candidate(&home, &lease.path, &live).is_none(),
+            "declared waiting_on → spared (blocked-but-alive signal)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn force_reclaim_ci_watch_read_failure_fails_alive() {
+        let home = tmp_home("fr-ciwfail");
+        let repo = tmp_repo("fr-ciwfail-repo");
+        let agent = "fr-ciwfail-agent";
+        let lease = lease(&home, &repo, agent, "feat/x").expect("lease");
+        backdate_lease(&lease.path, force_reclaim_age_days() + 2);
+        // An unparseable ci-watch file → the liveness read fails → fail-toward-alive.
+        let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        std::fs::write(ci_dir.join("corrupt.json"), "{ this is not json").unwrap();
+        let live: std::collections::HashSet<String> = std::collections::HashSet::new();
+        assert!(
+            evaluate_candidate(&home, &lease.path, &live).is_none(),
+            "unparseable ci-watch → fail-toward-alive → spared (never reclaim on uncertainty)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn gc_run_force_reclaim_never_hard_deletes() {
+        // codex gap ① CRITICAL: the daemon gc_run/gc_remove_one path must route a
+        // force-reclaim through the SAFE helper, never hard-delete. Proof: a dirty
+        // worktree (here, the untracked .agend-managed marker) that the OLD
+        // `git worktree remove --force` would have destroyed is PRESERVED by the
+        // safe path's status pre-check.
+        let home = tmp_home("fr-gcrun");
+        let repo = tmp_repo("fr-gcrun-repo");
+        let lease = lease(&home, &repo, "fr-gcrun-agent", "feat/x").expect("lease");
+        let cand = GcCandidate {
+            path: lease.path.clone(),
+            agent: "fr-gcrun-agent".to_string(),
+            reason: "fr".to_string(),
+            kind: GcKind::ForceReclaim,
+        };
+        let result = gc_remove_one(&home, &cand);
+        assert!(
+            !result.removed,
+            "dirty force-reclaim must be skipped by the safe pre-check, not removed"
+        );
+        assert!(
+            lease.path.exists(),
+            "force-reclaim must route through the SAFE path — the OLD gc_run would have \
+             force-removed this dirty worktree (data loss)"
         );
         let _ = std::fs::remove_dir_all(&home);
     }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -2886,12 +2886,11 @@ mod tests {
     }
 
     #[test]
-    fn gc_run_force_reclaim_never_hard_deletes() {
+    fn gc_run_force_reclaim_archives_never_hard_deletes() {
         // codex gap ① CRITICAL: the daemon gc_run/gc_remove_one path must route a
-        // force-reclaim through the SAFE helper, never hard-delete. Proof: a dirty
-        // worktree (here, the untracked .agend-managed marker) that the OLD
-        // `git worktree remove --force` would have destroyed is PRESERVED by the
-        // safe path's status pre-check.
+        // force-reclaim through the SAFE helper, never hard-delete. Proof: it is
+        // ARCHIVED to .trash (recoverable) rather than removed — the old
+        // `git worktree remove --force` would have left nothing behind.
         let home = tmp_home("fr-gcrun");
         let repo = tmp_repo("fr-gcrun-repo");
         let lease = lease(&home, &repo, "fr-gcrun-agent", "feat/x").expect("lease");
@@ -2903,13 +2902,21 @@ mod tests {
         };
         let result = gc_remove_one(&home, &cand);
         assert!(
-            !result.removed,
-            "dirty force-reclaim must be skipped by the safe pre-check, not removed"
+            result.removed,
+            "force-reclaim via gc_run should archive: {:?}",
+            result.error
+        );
+        assert!(!lease.path.exists(), "worktree moved out");
+        let trash = home.join(".trash").join("worktrees");
+        assert!(
+            std::fs::read_dir(&trash)
+                .map(|d| d.flatten().count() > 0)
+                .unwrap_or(false),
+            "gc_run force-reclaim must ARCHIVE to .trash (recoverable), never hard-delete"
         );
         assert!(
-            lease.path.exists(),
-            "force-reclaim must route through the SAFE path — the OLD gc_run would have \
-             force-removed this dirty worktree (data loss)"
+            crate::binding::read(&home, "fr-gcrun-agent").is_none(),
+            "binding unbound after force-reclaim"
         );
         let _ = std::fs::remove_dir_all(&home);
     }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -538,6 +538,47 @@ fn force_reclaim_age_days() -> i64 {
         .unwrap_or(7)
 }
 
+/// reviewer-2 #5: force-reclaim post-boot grace (seconds). After a daemon restart
+/// the live-agent registry (the process-liveness signal) is empty until agents
+/// re-spawn; suspend force-reclaim for this window so a mid-respawn agent is not
+/// reclaimed during the liveness blind spot. Configurable
+/// (`AGEND_WORKTREE_FORCE_RECLAIM_BOOT_GRACE_SECS`).
+fn force_reclaim_boot_grace_secs() -> u64 {
+    std::env::var("AGEND_WORKTREE_FORCE_RECLAIM_BOOT_GRACE_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(600) // 10 min
+}
+
+/// Pure boot-grace predicate: is `now_unix` within `grace_secs` of `boot_unix`?
+/// Unknown boot time → conservative `true` (suspend reclaim — never reclaim when
+/// we cannot tell how long the daemon has been up).
+fn within_boot_grace(boot_unix: Option<u64>, now_unix: u64, grace_secs: u64) -> bool {
+    match boot_unix {
+        Some(b) => now_unix.saturating_sub(b) < grace_secs,
+        None => true,
+    }
+}
+
+/// reviewer-2 #5: is the running daemon still inside its post-boot grace window?
+/// No active daemon run dir → NOT in grace (tests / non-daemon contexts — GC only
+/// runs inside the daemon). Daemon present but boot time unreadable → conservative
+/// in-grace (suspend).
+fn daemon_within_boot_grace(home: &Path) -> bool {
+    let Some(run_dir) = crate::daemon::find_active_run_dir(home) else {
+        return false;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    within_boot_grace(
+        crate::daemon::read_daemon_boot_unix(&run_dir),
+        now,
+        force_reclaim_boot_grace_secs(),
+    )
+}
+
 /// PR-2: liveness recency window (mirrors the binding-reconcile heartbeat window,
 /// binding.rs:380). A heartbeat / PTY input within this counts as alive.
 const LIVENESS_WINDOW_MS: u64 = 3_600_000; // 1h
@@ -570,6 +611,37 @@ pub struct GcCandidate {
 }
 
 /// Scan for GC candidates: daemon-tagged, past grace TTL, not pinned, no active binding.
+/// Max directory depth the marker-walk descends under the worktree root. Covers
+/// flat (`<agent>-<enc>/` = depth 1), nested (`<agent>/<branch>/` = depth 2), and
+/// slash-branch (`<agent>/fix/xxx/` = depth 3) layouts with headroom; bounded so a
+/// pathological tree can't make the walk unbounded.
+const MARKER_WALK_MAX_DEPTH: usize = 5;
+
+/// t-worktree-leak (reviewer-2 #4): recursively collect daemon-managed worktree
+/// dirs (those holding a `.agend-managed` marker) under `root`, to any depth up to
+/// `max_depth`. Once a dir carries the marker it IS a worktree → collected and NOT
+/// descended into (so we never walk a worktree's own working tree). This replaces
+/// the old fixed-depth scan that missed slash-branch worktrees.
+fn collect_managed_worktrees(root: &Path, max_depth: usize, out: &mut Vec<PathBuf>) {
+    if max_depth == 0 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if !p.is_dir() {
+            continue;
+        }
+        if p.join(MANAGED_MARKER).exists() {
+            out.push(p); // a worktree — collect, don't descend into its working tree
+        } else {
+            collect_managed_worktrees(&p, max_depth - 1, out);
+        }
+    }
+}
+
 pub fn gc_candidates(home: &Path) -> Vec<GcCandidate> {
     let mut candidates = Vec::new();
     // t-worktree-leak PR-2: snapshot the live-agent set ONCE per pass (the
@@ -580,26 +652,19 @@ pub fn gc_candidates(home: &Path) -> Vec<GcCandidate> {
             .into_iter()
             .collect();
 
-    // New layout: <home>/worktrees/<agent>/<branch>/
+    // New layout: <home>/worktrees/<agent>/<branch>/ — but a SLASH branch
+    // (`fix/xxx`, `feat/yyy` = the common case) nests an EXTRA level
+    // (`<agent>/fix/xxx`), so the old fixed 1-level descent enumerated `fix` (not a
+    // worktree, no marker) and missed the real worktree entirely (reviewer-2 #4, a
+    // pre-existing GC bug that silently disabled GC — clean-release AND
+    // force-reclaim — for most branches). Walk DOWN to the `.agend-managed` marker
+    // instead of assuming a fixed depth.
     let new_root = daemon_managed_worktree_root(home);
-    if new_root.is_dir() {
-        if let Ok(agents) = std::fs::read_dir(&new_root) {
-            for agent_entry in agents.flatten() {
-                if !agent_entry.path().is_dir() {
-                    continue;
-                }
-                if let Ok(branches) = std::fs::read_dir(agent_entry.path()) {
-                    for branch_entry in branches.flatten() {
-                        let wt_path = branch_entry.path();
-                        if !wt_path.is_dir() {
-                            continue;
-                        }
-                        if let Some(candidate) = evaluate_candidate(home, &wt_path, &live_agents) {
-                            candidates.push(candidate);
-                        }
-                    }
-                }
-            }
+    let mut managed = Vec::new();
+    collect_managed_worktrees(&new_root, MARKER_WALK_MAX_DEPTH, &mut managed);
+    for wt_path in &managed {
+        if let Some(candidate) = evaluate_candidate(home, wt_path, &live_agents) {
+            candidates.push(candidate);
         }
     }
 
@@ -811,6 +876,11 @@ fn evaluate_candidate(
         // here). liveness-AND-age: ANY live signal → never reclaim (even past the
         // cap); otherwise require the per-agent-jittered age cap.
         None => {
+            // reviewer-2 #5: suspend force-reclaim during the daemon's post-boot
+            // grace window (the process-liveness signal is still re-establishing).
+            if daemon_within_boot_grace(home) {
+                return None;
+            }
             if agent_has_liveness(home, &agent_name, live_agents) {
                 return None;
             }
@@ -2842,5 +2912,45 @@ mod tests {
              force-removed this dirty worktree (data loss)"
         );
         let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn collect_managed_worktrees_finds_slash_branch_nested() {
+        // reviewer-2 #4: a slash-branch worktree nests an extra level
+        // (worktrees/<agent>/fix/xxx) and was missed by the old fixed-depth scan.
+        let home = tmp_home("walk-slash");
+        let root = daemon_managed_worktree_root(&home);
+        let nested = root.join("dev").join("fix").join("xxx");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join(MANAGED_MARKER), "agent=dev\n").unwrap();
+        let flat = root.join("dev").join("track-x");
+        std::fs::create_dir_all(&flat).unwrap();
+        std::fs::write(flat.join(MANAGED_MARKER), "agent=dev\n").unwrap();
+        let mut out = Vec::new();
+        collect_managed_worktrees(&root, MARKER_WALK_MAX_DEPTH, &mut out);
+        assert!(
+            out.contains(&nested),
+            "slash-branch nested worktree must be enumerated (reviewer-2 #4)"
+        );
+        assert!(out.contains(&flat), "non-slash worktree still enumerated");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn boot_grace_predicate_suspends_only_when_recent_or_unknown() {
+        // reviewer-2 #5: recent boot → suspend; aged boot → proceed; unknown →
+        // conservative suspend.
+        assert!(
+            within_boot_grace(Some(1000), 1100, 600),
+            "100s after boot, 600s grace → in grace (suspend)"
+        );
+        assert!(
+            !within_boot_grace(Some(1000), 2000, 600),
+            "1000s after boot → past grace (proceed)"
+        );
+        assert!(
+            within_boot_grace(None, 2000, 600),
+            "unknown boot time → conservative suspend"
+        );
     }
 }


### PR DESCRIPTION
**PR-2 of t-worktree-leak** — the backstop for the no-event-abandonment / dead-agent tail (PR-1's invariant handles every worktree that saw a merge/close/task-done event; PR-1's 7-day expired-intent path hands off here).

`evaluate_candidate` previously skipped every never-released worktree permanently. It now force-reclaims them, gated by **liveness-AND-age** with the 4 safeties lead/reviewers required:

1. **Multi-signal liveness** (not just heartbeat): process (live registry — covers idle-but-running), heartbeat, PTY (last_input), waiting_on, ci-watch subscription. **ANY live → NEVER reclaim**, regardless of age. Reads fail-toward-alive.
2. **Archive-to-trash + fencing**: flows through retention's existing `try_archive` (atomic rename to `.trash`, **recoverable**). Pre-archive re-validation is now **kind-aware** — a force-reclaim's binding is present by definition, so it re-snapshots **liveness** under the sweep (spares an agent that revived between enumeration and archive), then **unbinds** the stale binding.
3. **Jitter**: deterministic per-agent FNV offset (≤6h) on the age cap → anti-thundering-herd after a fleet-wide outage. (Process-liveness also gives a natural post-restart grace: re-spawned agents are live → spared.)
4. **LOUD confidence ALERT**: classifies by the branch's pr_state — `observed_terminal` (merged/closed yet never released = **event-release bug** → `tracing::error` ALERT) / `observed_open` / `queried_none` (info) / `unknown` (incomplete pr_state, flagged not misjudged).

Age cap `AGEND_WORKTREE_FORCE_RECLAIM_DAYS` (default 7); runs in the existing `AGEND_WORKTREE_GC=1` sweep.

**Reviewer focus** (dual adversarial, per lead): liveness false-positive (mis-reclaim a live agent), fencing (the re-liveness-under-sweep), archive safety (recoverable, never rm).

**Tests**: dead+past-cap→ForceReclaim; spared when live (registry) / ci-watch-subscribed (multi-signal) / lease-recent (age gate); maybe_remove force-reclaim → archives + unbinds + recoverable `.trash`; ALERT classifies merged-but-unreleased as `observed_terminal` and absent pr_state as `unknown`. worktree_pool 47 / retention 23 / auto_release 29 (PR-1 unaffected); fmt + clippy clean.

**Self-flagged for review**: (a) heartbeat/PTY/waiting_on liveness signals are exercised via the code path but not unit-tested directly (no heartbeat_pair test setter) — registry + ci-watch signals are; (b) the "grace" half of safety #3 is provided by process-liveness + jitter rather than an explicit daemon-uptime gate — call out if an explicit boot-grace is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)