### PR TITLE
fix(worktree-leak): structural /tmp worktree GC by managed-repo (PR-3, Class2)

### DIFF
--- a/src/daemon/per_tick/tmp_review_gc.rs
+++ b/src/daemon/per_tick/tmp_review_gc.rs
@@ -14,8 +14,15 @@
 //!
 //! Belt (destructive — deletes `/tmp` dirs and deregisters worktrees in a
 //! possibly operator-owned source repo, so it is deliberately strict):
-//! - **pattern-scope ONLY** (`pr-<N>` / `*review*` directory names) — NEVER a
-//!   bare `/tmp` sweep, so unrelated `/tmp` content is never touched.
+//! - **STRUCTURAL scope** (t-worktree-leak Class2): a git worktree is eligible
+//!   only when its parent repo (resolved from the `.git` gitdir pointer) is a repo
+//!   the daemon MANAGES (`bound_source_repos`). This replaces the fragile name
+//!   pattern — which missed `agend-pr*` worktrees → the /tmp leak — and the
+//!   managed-repo gate guarantees an operator's OWN unrelated `/tmp` git worktree
+//!   is never touched, regardless of its name. A non-worktree dir (a review CLONE
+//!   with its own `.git` directory) has no resolvable parent, so it falls back to
+//!   the name pattern (`pr-<N>` / `*review*`) to avoid regressing #1747's clone
+//!   cleanup.
 //! - **mtime-age > [`MIN_AGE`] (2 days)** — `mtime`, not creation time, so an
 //!   in-progress review (recently-touched worktree) is naturally skipped.
 //! - **directories only** — stray review *files* (e.g. `*-review.md` audit
@@ -63,15 +70,19 @@ impl PerTickHandler for TmpReviewGcHandler {
         "tmp_review_gc"
     }
 
-    fn run(&self, _ctx: &TickContext<'_>) {
+    fn run(&self, ctx: &TickContext<'_>) {
         if !self.should_fire() {
             return;
         }
-        let removed =
-            gc_stale_tmp_review_worktrees(&std::env::temp_dir(), MIN_AGE, SystemTime::now());
+        let removed = gc_stale_tmp_review_worktrees(
+            ctx.home,
+            &std::env::temp_dir(),
+            MIN_AGE,
+            SystemTime::now(),
+        );
         if removed > 0 {
             tracing::info!(target: "tmp_review_gc", removed,
-                "#1747: GC'd stale /tmp review worktrees/clones");
+                "Class2: GC'd stale /tmp worktrees/clones of managed repos");
         }
     }
 }
@@ -87,10 +98,33 @@ fn is_review_pattern(name: &str) -> bool {
     pr_dash_num || name.contains("review")
 }
 
-/// Sweep `tmp_root` for stale review-pattern directories and remove them.
-/// Returns the count removed. `now` is injected so tests drive the age belt
+/// Sweep `tmp_root` for stale `/tmp` worktrees/clones of MANAGED repos and remove
+/// them. Returns the count removed. `now` is injected so tests drive the age belt
 /// deterministically.
-fn gc_stale_tmp_review_worktrees(tmp_root: &Path, min_age: Duration, now: SystemTime) -> usize {
+///
+/// t-worktree-leak Class2: the eligibility gate is STRUCTURAL for git worktrees —
+/// resolve the worktree's parent repo from its `.git` gitdir and reclaim it only
+/// if that repo is one the daemon manages (`bound_source_repos`). This replaces
+/// the fragile name pattern (which missed `agend-pr*` worktrees → /tmp leak) and
+/// the managed-repo gate protects an operator's OWN unrelated `/tmp` git worktree
+/// from ever being touched. A non-worktree dir (a review CLONE, with its own `.git`
+/// directory rather than a gitdir pointer) has no resolvable parent, so it still
+/// falls back to the #1747 name pattern — structural can't gate it, and dropping
+/// it would regress #1747's clone cleanup.
+fn gc_stale_tmp_review_worktrees(
+    home: &Path,
+    tmp_root: &Path,
+    min_age: Duration,
+    now: SystemTime,
+) -> usize {
+    // The managed-repo set (canonicalized) — the gate against reclaiming a user's
+    // unrelated /tmp git worktree. Durable for the common case: the canonical repo
+    // is bound by the working fleet. Empty (no current bindings) → no worktree is
+    // structurally eligible, which is the conservative outcome.
+    let managed: std::collections::HashSet<PathBuf> = crate::binding::bound_source_repos(home)
+        .into_iter()
+        .filter_map(|p| p.canonicalize().ok())
+        .collect();
     let Ok(entries) = std::fs::read_dir(tmp_root) else {
         return 0;
     };
@@ -101,10 +135,26 @@ fn gc_stale_tmp_review_worktrees(tmp_root: &Path, min_age: Duration, now: System
         if !path.is_dir() {
             continue;
         }
-        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-            continue;
+        let parent_repo = worktree_parent_repo(&path);
+        let eligible = match &parent_repo {
+            // A git worktree → STRUCTURAL gate: reclaim only if its parent repo is
+            // one we manage (never an operator's own /tmp worktree).
+            Some(parent) => match parent.canonicalize() {
+                Ok(canon) => managed.contains(&canon),
+                Err(_) => false,
+            },
+            // Not a worktree (clone / plain dir) → fall back to the #1747 name gate
+            // so review clones are still reaped (structural can't resolve them).
+            None => path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(is_review_pattern),
         };
-        if !is_review_pattern(name) {
+        if !eligible {
+            if parent_repo.is_some() {
+                tracing::debug!(target: "tmp_review_gc", path = %path.display(),
+                    "skip: /tmp worktree's parent repo is not daemon-managed (operator-owned)");
+            }
             continue;
         }
         // mtime-age belt — a recently-touched (in-progress) review is skipped.
@@ -121,11 +171,12 @@ fn gc_stale_tmp_review_worktrees(tmp_root: &Path, min_age: Duration, now: System
         if remove_tmp_worktree(&path) {
             removed += 1;
             tracing::info!(target: "tmp_review_gc", path = %path.display(),
+                parent_repo = ?parent_repo.as_ref().map(|p| p.display().to_string()),
                 age_days = age.as_secs() / 86_400,
-                "#1747: removed stale /tmp review worktree/clone");
+                "Class2: removed stale /tmp worktree/clone of a managed repo (structural)");
         } else {
             tracing::warn!(target: "tmp_review_gc", path = %path.display(),
-                "#1747: failed to remove stale /tmp review worktree");
+                "Class2: failed to remove stale /tmp worktree/clone");
         }
     }
     removed
@@ -207,42 +258,86 @@ mod tests {
         }
     }
 
-    #[test]
-    fn gc_removes_old_pattern_dir() {
-        let root = tmp_root("old-del");
-        let d = root.join("pr-9999");
-        std::fs::create_dir_all(&d).unwrap();
-        // now = created + 3d → age 3d > 2d → removed.
-        let now = SystemTime::now() + Duration::from_secs(3 * 24 * 60 * 60);
-        let removed = gc_stale_tmp_review_worktrees(&root, MIN_AGE, now);
-        assert_eq!(removed, 1);
-        assert!(!d.exists(), "stale review-pattern dir must be removed");
-        std::fs::remove_dir_all(&root).ok();
+    fn git(cwd: &Path, args: &[&str]) {
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .current_dir(cwd)
+            .args(args)
+            .output()
+            .unwrap();
+    }
+
+    /// A real git repo with one commit.
+    fn make_repo(path: &Path) -> PathBuf {
+        std::fs::create_dir_all(path).unwrap();
+        git(path, &["init", "-b", "main"]);
+        git(path, &["commit", "--allow-empty", "-m", "init"]);
+        path.to_path_buf()
+    }
+
+    /// A REAL git worktree of `repo` at `wt` (`.git` is a gitdir pointer back to
+    /// the repo) — not a synthetic path (§3.9).
+    fn add_real_worktree(repo: &Path, wt: &Path) {
+        git(
+            repo,
+            &["worktree", "add", "--detach", wt.to_str().unwrap(), "HEAD"],
+        );
+    }
+
+    /// Write a binding for `agent` whose `source_repo` points at `repo`, so
+    /// `bound_source_repos(home)` reports `repo` as managed.
+    fn write_binding(home: &Path, agent: &str, repo: &Path) {
+        let bd = crate::paths::runtime_dir(home).join(agent);
+        std::fs::create_dir_all(&bd).unwrap();
+        std::fs::write(
+            bd.join("binding.json"),
+            serde_json::json!({ "source_repo": repo.to_str().unwrap() }).to_string(),
+        )
+        .unwrap();
     }
 
     #[test]
-    fn gc_skips_recent_pattern_dir() {
+    fn gc_removes_old_clone_dir_via_name_fallback() {
+        // A review CLONE (plain dir, no gitdir pointer) → name-fallback path.
+        let root = tmp_root("old-del");
+        let home = tmp_root("old-del-home");
+        let d = root.join("pr-9999");
+        std::fs::create_dir_all(&d).unwrap();
+        let now = SystemTime::now() + Duration::from_secs(3 * 24 * 60 * 60);
+        let removed = gc_stale_tmp_review_worktrees(&home, &root, MIN_AGE, now);
+        assert_eq!(removed, 1);
+        assert!(!d.exists(), "stale review-name clone dir must be removed");
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn gc_skips_recent_clone_dir() {
         let root = tmp_root("recent-skip");
+        let home = tmp_root("recent-skip-home");
         let d = root.join("pr1234-review");
         std::fs::create_dir_all(&d).unwrap();
-        // now = real now → age ~0 < 2d → skipped (in-progress review).
-        let removed = gc_stale_tmp_review_worktrees(&root, MIN_AGE, SystemTime::now());
+        let removed = gc_stale_tmp_review_worktrees(&home, &root, MIN_AGE, SystemTime::now());
         assert_eq!(removed, 0);
         assert!(d.exists(), "recently-touched review dir must be kept");
         std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
     fn gc_ignores_non_pattern_and_files() {
         let root = tmp_root("nonpattern");
+        let home = tmp_root("nonpattern-home");
         let unrelated = root.join("some-build-cache");
         std::fs::create_dir_all(&unrelated).unwrap();
-        // A review-named FILE (not a dir) must also be left alone.
         let review_file = root.join("notes-review.md");
         std::fs::write(&review_file, b"x").unwrap();
-        // Old enough that ONLY the pattern/dir guards keep them.
         let now = SystemTime::now() + Duration::from_secs(3 * 24 * 60 * 60);
-        let removed = gc_stale_tmp_review_worktrees(&root, MIN_AGE, now);
+        let removed = gc_stale_tmp_review_worktrees(&home, &root, MIN_AGE, now);
         assert_eq!(removed, 0);
         assert!(unrelated.exists(), "non-pattern dir must be untouched");
         assert!(
@@ -250,6 +345,59 @@ mod tests {
             "review-named file (not a dir) must be untouched"
         );
         std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// §3.9 representative: REAL /tmp git worktrees. A worktree of a MANAGED repo
+    /// (named `agend-pr*` — which the OLD name pattern MISSED) is pruned
+    /// structurally; an operator's OWN /tmp worktree (unmanaged repo) is NOT
+    /// touched, even though it is also old and `agend-pr*`-named.
+    #[test]
+    fn structural_prunes_managed_worktree_spares_operator_worktree() {
+        let root = tmp_root("structural");
+        let home = tmp_root("structural-home");
+        let managed_repo = make_repo(&home.join("managed-repo"));
+        write_binding(&home, "dev", &managed_repo);
+        let user_repo = make_repo(&home.join("user-repo")); // no binding → unmanaged
+
+        let managed_wt = root.join("agend-pr123"); // name the OLD pattern missed
+        add_real_worktree(&managed_repo, &managed_wt);
+        let user_wt = root.join("agend-pr999-user");
+        add_real_worktree(&user_repo, &user_wt);
+        assert!(worktree_parent_repo(&managed_wt).is_some(), "real worktree");
+        assert!(worktree_parent_repo(&user_wt).is_some(), "real worktree");
+
+        let now = SystemTime::now() + Duration::from_secs(3 * 24 * 60 * 60);
+        let removed = gc_stale_tmp_review_worktrees(&home, &root, MIN_AGE, now);
+        assert_eq!(removed, 1, "only the managed-repo worktree is pruned");
+        assert!(
+            !managed_wt.exists(),
+            "managed-repo /tmp worktree (agend-pr*, name-missed) pruned structurally"
+        );
+        assert!(
+            user_wt.exists(),
+            "operator's OWN /tmp worktree (unmanaged repo) must never be reclaimed"
+        );
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A managed-repo worktree that is RECENT (in-progress review) is spared by the
+    /// age belt even though it is structurally eligible.
+    #[test]
+    fn structural_age_belt_spares_recent_managed_worktree() {
+        let root = tmp_root("structural-age");
+        let home = tmp_root("structural-age-home");
+        let managed_repo = make_repo(&home.join("managed-repo"));
+        write_binding(&home, "dev", &managed_repo);
+        let wt = root.join("agend-pr-fresh");
+        add_real_worktree(&managed_repo, &wt);
+        // now = real now → age ~0 < 2d → skipped.
+        let removed = gc_stale_tmp_review_worktrees(&home, &root, MIN_AGE, SystemTime::now());
+        assert_eq!(removed, 0, "recent managed worktree spared by age belt");
+        assert!(wt.exists());
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]


### PR DESCRIPTION
**Last of the t-worktree-leak series.** The #1747 `/tmp` review-worktree GC gated on a NAME pattern (`pr-<N>` / `*review*`), which **missed `agend-pr*`** → those leaked under `/tmp` (74 observed). This replaces the name gate with a **structural** one:

- Resolve each `/tmp` dir's parent repo from its `.git` gitdir pointer (`worktree_parent_repo`). A git worktree is eligible only when that parent repo is one the daemon **manages** (`binding::bound_source_repos`, canonicalized) — catches `agend-pr*` (and any future naming) regardless of name, and the **managed-repo gate guarantees an operator's OWN unrelated `/tmp` git worktree is never touched**.
- A non-worktree dir (a review **clone** — own `.git` dir, no gitdir pointer) has no resolvable parent → falls back to the #1747 name pattern, so clone cleanup doesn't regress.
- Keeps the 2-day mtime age belt + loud log (now records the parent repo).

Managed-repo set is durable for the common case (the canonical repo is bound by the working fleet); empty bindings → nothing structurally eligible (conservative).

**Tests use REAL `/tmp` git worktrees (§3.9, not synthetic paths)**: a managed-repo worktree named `agend-pr123` (the name the old pattern missed) is pruned structurally, while an operator's own `/tmp` worktree of an UNMANAGED repo (also old + `agend-pr*`-named) is spared; the age belt spares a recent managed worktree; the clone name-fallback + file/non-pattern guards still hold.

**Reviewer focus** (dual adversarial): managed-repo gate correctness (no false-positive on operator worktrees / no false-negative on the canonical repo), the worktree-vs-clone branch, canonicalization path-matching.

**Out of scope (follow-ups, per lead)**: skill/reviewer source-fix (release their own worktree / `repo checkout` into pool); `agend-pr*` CLONES (separate `.git` dir) remain name-gated.

base includes #1805 + #1806.

🤖 Generated with [Claude Code](https://claude.com/claude-code)