### PR TITLE
feat(state): #1808 SRL recovery/phantom empirical probes (instrumentation-only)

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1541,12 +1541,39 @@ pub(crate) fn process_error_recovery(
                 // so a later ServerRateLimit episode starts fresh at Phase A. No
                 // suppress window needed: the inject is state-gated above, so a
                 // mid-work Thinking/ToolUse transient neither clears here nor injects.
-                if retry_tracks.remove(name).is_some() {
-                    tracing::info!(
-                        agent = %name,
-                        ?state,
-                        "ServerRateLimit retry cleared — agent recovered (Idle)"
-                    );
+                if let Some(cleared) = retry_tracks.remove(name) {
+                    // #1808-flaw1-probe (instrumentation-only, NO behavior change):
+                    // cheerc claims a backend that hits a fatal net error ABORTS to an
+                    // Idle prompt → this unconditional Idle-clear drops the in-flight
+                    // SRL retry track → `continue` never re-injects → the agent freezes
+                    // until waiting_on_stale. The clear itself is unchanged; we only
+                    // SPLIT the log to see empirically whether the suspicious shape ever
+                    // occurs: a track with retries already attempted (`retry_count > 0`)
+                    // reaching Idle with NO recent productive output (`!recovered`) is
+                    // the abort-to-Idle path. A genuine recovery reaches Idle either
+                    // before any retry (`retry_count == 0`) or with recent productive
+                    // output (`recovered`) → INFO. When the WARN fires, cross-check
+                    // whether dispatch_idle then nudges the agent (dev's claimed
+                    // backstop) vs. it sitting frozen.
+                    if cleared.retry_count > 0 && !recovered {
+                        tracing::warn!(
+                            agent = %name,
+                            tag = "#1808-flaw1-probe",
+                            retry_count = cleared.retry_count,
+                            productive_silent_secs = productive_silence.as_secs(),
+                            recovered = false,
+                            "abort-to-Idle cleared an in-flight ServerRateLimit retry with no recent productive output — cheerc's claimed freeze path"
+                        );
+                    } else {
+                        tracing::info!(
+                            agent = %name,
+                            ?state,
+                            retry_count = cleared.retry_count,
+                            recovered,
+                            productive_silent_secs = productive_silence.as_secs(),
+                            "ServerRateLimit retry cleared — agent recovered (Idle)"
+                        );
+                    }
                 }
             }
 
@@ -3100,6 +3127,63 @@ instances:
         assert!(
             !tracks.contains_key("test-agent"),
             "phase 1 must clear retry track on Idle recovery"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1808-flaw1-probe (behavior pin, §3.9 real entry): cheerc claims a backend
+    /// that hits a fatal net error ABORTS to an Idle prompt while a ServerRateLimit
+    /// retry is in flight, and the unconditional Idle-clear then leaves the agent
+    /// "frozen" (no `continue` ever injected). This pins the ACTUAL current
+    /// behavior the Probe-1 WARN instruments: the in-flight track (`retry_count >
+    /// 0`) IS cleared, and — critically — NO `continue` is injected, because the
+    /// inject is state-gated on ServerRateLimit and the agent is now Idle (so
+    /// clearing the track is NOT what suppresses the inject). The SRL retry path
+    /// deliberately does not resume an aborted-to-Idle agent; that recovery belongs
+    /// to dispatch_idle / waiting_on_stale. The probe measures whether this shape
+    /// ever actually occurs in prod.
+    #[test]
+    fn abort_to_idle_clears_in_flight_retry_and_does_not_inject_1808() {
+        let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = tmp_home("abort-to-idle-1808");
+        // In-flight retry (retry_count > 0) from a ServerRateLimit episode.
+        let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
+        tracks.insert(
+            "test-agent".to_string(),
+            RateLimitRetry {
+                retry_count: 2,
+                next_retry_at: Instant::now(),
+                exhausted: false,
+                inject_failures: 0,
+            },
+        );
+        let mut last_inject: HashMap<String, Instant> = HashMap::new();
+
+        // Aborted to an Idle prompt with NO recent productive output
+        // (`last_productive_output` defaults to None) — the cheerc freeze shape.
+        let (handle, _reader) = mock_agent_handle("test-agent", crate::state::AgentState::Idle);
+        registry.lock().insert(handle.id, handle);
+
+        for _ in 0..3 {
+            super::process_error_recovery(
+                &home,
+                &registry,
+                &mut tracks,
+                &mut Default::default(),
+                &mut Default::default(),
+                &mut last_inject,
+                past_boot_grace(),
+            );
+        }
+
+        assert!(
+            !tracks.contains_key("test-agent"),
+            "abort-to-Idle clears the in-flight ServerRateLimit retry track (current behavior)"
+        );
+        assert!(
+            !last_inject.contains_key("test-agent"),
+            "no `continue` is injected into an aborted-to-Idle agent — inject is \
+             state-gated on ServerRateLimit; SRL retry does not resume an Idle agent"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -271,6 +271,24 @@ pub struct StateTracker {
     /// its cap before the supervisor drained it. Surfaced in a warn at drain
     /// so a wedged drainer is visible rather than silently lossy.
     dropped_transition_count: u64,
+    /// #1808-probe0-phantom (instrumentation-only): signature of the LAST
+    /// ServerRateLimit detection's error line — `(error_line_hash,
+    /// dist_from_bottom)`. Persists ACROSS non-SRL/Idle states (deliberately NOT
+    /// cleared) so a same-error re-match after the agent recovered to Idle (the
+    /// cross-Idle phantom loop in cheerc's #1808 Evidence 2) is still detected.
+    /// Read/written only for the phantom probe log; never affects transitions.
+    last_srl_match_sig: Option<(u64, usize)>,
+    /// #1808-probe0-phantom (instrumentation-only): how many CONSECUTIVE feed
+    /// ticks the same SRL error re-matched with NO intervening non-SRL state
+    /// (the in-place clock-tick re-scan). Resets on a different signature or a
+    /// cross-cycle refire. Distinct from `cross_cycle` (see the probe site).
+    srl_consecutive_rematch: u32,
+    /// #1808-probe0-phantom (instrumentation-only): set true whenever a feed
+    /// lands a NON-ServerRateLimit state (esp. Idle); cleared on an SRL
+    /// detection. Lets the probe distinguish a cross-Idle refire (same error
+    /// re-grabbed AFTER the agent recovered) from a same-state continuous
+    /// re-scan. Telemetry-only.
+    non_srl_since_last_srl: bool,
 }
 
 /// #1527: one recorded `current` transition, captured at the mutation site so
@@ -395,6 +413,24 @@ fn hash_screen(text: &str) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     text.hash(&mut hasher);
     hasher.finish()
+}
+
+/// #1808-probe0-phantom (instrumentation-only): a stable signature of the
+/// bottom-most occurrence of an SRL error line — `(line_hash, dist_from_bottom)`.
+/// `dist_from_bottom` is the byte distance from the error line's start to the end
+/// of `screen_text`; an error that has not physically moved keeps the same
+/// distance across the cursor-blink / clock-tick re-renders that flip the screen
+/// hash (the phantom trigger). Used only to compare consecutive SRL detections in
+/// the phantom probe — never affects classification.
+fn srl_match_signature(screen_text: &str, matched: &str) -> (u64, usize) {
+    let pos = screen_text.rfind(matched).unwrap_or(0);
+    let line_start = screen_text[..pos].rfind('\n').map_or(0, |i| i + 1);
+    let line_end = screen_text[pos..]
+        .find('\n')
+        .map_or(screen_text.len(), |i| pos + i);
+    let line_hash = hash_screen(&screen_text[line_start..line_end]);
+    let dist_from_bottom = screen_text.len().saturating_sub(line_start);
+    (line_hash, dist_from_bottom)
 }
 
 /// #1450: char-span (start, end) in `screen_text` for the byte occurrence of
@@ -718,6 +754,10 @@ impl StateTracker {
             // #1527: transition audit buffer starts empty.
             pending_transitions: Vec::new(),
             dropped_transition_count: 0,
+            // #1808-probe0-phantom: no SRL seen yet.
+            last_srl_match_sig: None,
+            srl_consecutive_rematch: 0,
+            non_srl_since_last_srl: false,
         }
     }
 
@@ -964,12 +1004,111 @@ impl StateTracker {
                             } else {
                                 detected
                             };
-                            patterns
-                                .working_state_below(screen_text, matched)
-                                .unwrap_or(fallback)
+                            let working_below = patterns.working_state_below(screen_text, matched);
+                            // #1808-flaw2-probe (instrumentation-only, NO behavior
+                            // change): cheerc claims a static bottom status bar (Agy/
+                            // Kiro Thinking = the bare `esc to cancel` token) can sit
+                            // BELOW the error → `working_state_below` overrides a
+                            // ServerRateLimit → masks a stuck throttle. Record it
+                            // empirically: when such an override actually fires on
+                            // Agy/Kiro, log the winning marker + productive silence. NO
+                            // recent productive output ⇒ the override may be masking a
+                            // genuinely-stuck agent (the suspicious case cheerc
+                            // describes) ⇒ WARN; recent output ⇒ INFO (genuine
+                            // recovery). Scoped to Agy/Kiro + SRL-override only (low
+                            // noise); does NOT alter `landed`.
+                            if let Some((_, marker)) = working_below {
+                                if matches!(detected, AgentState::ServerRateLimit)
+                                    && (self.backend_name == Backend::Agy.name()
+                                        || self.backend_name == Backend::KiroCli.name())
+                                {
+                                    let productive_silent_secs =
+                                        self.productive_silence().as_secs();
+                                    if self.recovered_within(SERVER_RATE_LIMIT_RECOVERY_SILENCE) {
+                                        tracing::info!(
+                                            target: "state_detection",
+                                            agent = %self.instance_name,
+                                            tag = "#1808-flaw2-probe",
+                                            backend = %self.backend_name,
+                                            working_marker = %marker,
+                                            productive_silent_secs,
+                                            "working_state_below overrode ServerRateLimit (Agy/Kiro) with recent productive output — likely genuine recovery"
+                                        );
+                                    } else {
+                                        tracing::warn!(
+                                            target: "state_detection",
+                                            agent = %self.instance_name,
+                                            tag = "#1808-flaw2-probe",
+                                            backend = %self.backend_name,
+                                            working_marker = %marker,
+                                            productive_silent_secs,
+                                            "working_state_below overrode ServerRateLimit (Agy/Kiro) with NO recent productive output — possible static-chrome mask of a stuck throttle (cheerc Flaw 2)"
+                                        );
+                                    }
+                                }
+                            }
+                            working_below.map(|(s, _)| s).unwrap_or(fallback)
                         } else {
                             detected
                         };
+                        // #1808-probe0-phantom (instrumentation-only, NO behavior
+                        // change): cheerc Evidence 2 claims a stale SRL error stuck in
+                        // the bottom-N tail keeps re-matching after the agent recovered
+                        // (the screen hash flips when the CLI clock ticks → feed
+                        // re-scans → re-grabs the SAME old error → re-latch → blind
+                        // inject). Record it empirically: signature the matched error
+                        // line `(line_hash, dist_from_bottom)` and compare to the
+                        // previous SRL detection —
+                        //   • same sig, NO intervening non-SRL state  → in-place
+                        //     clock-tick re-scan → `srl_consecutive_rematch++`;
+                        //   • same sig, intervening Idle/non-SRL state → `cross_cycle`
+                        //     refire (the agent recovered, then the OLD error was
+                        //     re-grabbed) = cheerc's exact cross-Idle loop.
+                        // `last_srl_match_sig` PERSISTS across Idle so the cross-cycle
+                        // case survives. WARN only when the SRL actually wins
+                        // (`landed == ServerRateLimit` → would latch → inject) AND there
+                        // is no recent productive output (`!recovered`) AND it is a
+                        // re-match. Not backend-scoped (the phantom is the Claude
+                        // `Server is temporarily limiting` re-match — cheerc's `general`
+                        // agent). Telemetry-only; never touches `landed`/transition.
+                        if matches!(detected, AgentState::ServerRateLimit) {
+                            let sig = srl_match_signature(screen_text, matched);
+                            let same_sig = self.last_srl_match_sig == Some(sig);
+                            let cross_cycle = same_sig && self.non_srl_since_last_srl;
+                            self.srl_consecutive_rematch =
+                                if same_sig && !self.non_srl_since_last_srl {
+                                    self.srl_consecutive_rematch.saturating_add(1)
+                                } else {
+                                    0
+                                };
+                            self.last_srl_match_sig = Some(sig);
+                            self.non_srl_since_last_srl = false;
+
+                            let would_latch = matches!(landed, AgentState::ServerRateLimit);
+                            let recovered_now =
+                                self.recovered_within(SERVER_RATE_LIMIT_RECOVERY_SILENCE);
+                            if would_latch
+                                && !recovered_now
+                                && (self.srl_consecutive_rematch > 0 || cross_cycle)
+                            {
+                                let kind = if cross_cycle {
+                                    "cross_cycle_refire"
+                                } else {
+                                    "consecutive_rematch"
+                                };
+                                tracing::warn!(
+                                    target: "state_detection",
+                                    agent = %self.instance_name,
+                                    tag = "#1808-probe0-phantom",
+                                    kind,
+                                    consecutive_rematch = self.srl_consecutive_rematch,
+                                    cross_cycle_refire = cross_cycle,
+                                    dist_from_bottom = sig.1,
+                                    productive_silent_secs = self.productive_silence().as_secs(),
+                                    "phantom re-match: same stale ServerRateLimit error re-detected (would latch → inject) with no recent productive output"
+                                );
+                            }
+                        }
                         let gated = self.gate_on_heartbeat(landed);
                         self.transition(gated);
                     }
@@ -990,6 +1129,16 @@ impl StateTracker {
                         self.maybe_expire_latched_state();
                     }
                 }
+            }
+
+            // #1808-probe0-phantom (instrumentation-only): record that the tracker
+            // passed through a NON-ServerRateLimit landed state since the last SRL
+            // detection, so a later same-error re-match is flagged as a cross-Idle
+            // phantom refire (not a same-state continuous re-scan). The SRL branch
+            // above clears this on detection; here we (re)set it whenever the landed
+            // state is anything else. Telemetry-only — does not affect classification.
+            if !matches!(self.current, AgentState::ServerRateLimit) {
+                self.non_srl_since_last_srl = true;
             }
         }
 

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -351,15 +351,30 @@ impl StatePatterns {
     /// extends the #1518 absolute-tail-position gate to "relative to the working
     /// marker" and never touches `clears_server_rate_limit_retry` (#1713). A
     /// genuinely-stuck error has NO in-flight working marker below it → `None`.
-    pub(crate) fn working_state_below(&self, text: &str, error_match: &str) -> Option<AgentState> {
+    ///
+    /// Returns the winning `(state, marker_text)`. The matched marker substring is
+    /// surfaced for the `#1808-flaw2-probe` instrumentation so a caller can log
+    /// *which* on-screen marker overrode a ServerRateLimit (to check empirically
+    /// whether a static bottom-bar chrome — e.g. Agy/Kiro's bare `esc to cancel` —
+    /// is masking a stuck throttle). The state-selection logic is unchanged (same
+    /// filter + lowest-marker-below-error pick), so detection behavior is identical.
+    pub(crate) fn working_state_below<'a>(
+        &self,
+        text: &'a str,
+        error_match: &str,
+    ) -> Option<(AgentState, &'a str)> {
         let err_pos = text.rfind(error_match)?;
         self.patterns
             .iter()
             .filter(|(s, _)| matches!(s, AgentState::Thinking | AgentState::ToolUse))
-            .filter_map(|(s, re)| re.find_iter(text).last().map(|m| (m.start(), *s)))
-            .filter(|(pos, _)| *pos > err_pos)
-            .max_by_key(|(pos, _)| *pos)
-            .map(|(_, s)| s)
+            .filter_map(|(s, re)| {
+                re.find_iter(text)
+                    .last()
+                    .map(|m| (m.start(), *s, m.as_str()))
+            })
+            .filter(|(pos, _, _)| *pos > err_pos)
+            .max_by_key(|(pos, _, _)| *pos)
+            .map(|(_, s, marker)| (s, marker))
     }
 }
 

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3681,6 +3681,37 @@ fn pending_transitions_bounded_drops_oldest() {
     );
 }
 
+// ── #1808-probe0-phantom: SRL re-match signature freshness primitive ──
+
+/// `srl_match_signature` must be STABLE for the same error line at the same
+/// distance-from-bottom (the clock-tick re-render that flips the screen hash but
+/// does NOT move the error), and CHANGE when the error scrolls up because fresh
+/// output rendered below it. This is the freshness primitive the phantom probe
+/// compares across ticks to tell an in-place re-scan from real progress.
+#[test]
+fn srl_match_signature_stable_until_error_moves_1808() {
+    use super::srl_match_signature;
+    let err = "Server is temporarily limiting requests";
+    // Same error at the bottom; only a benign top line differs (screen hash flips,
+    // error unmoved) → identical signature. The two top lines are equal length so
+    // the error's line_start (and thus dist_from_bottom) is unchanged.
+    let a = format!("clock 12:00:01\n{err}\n");
+    let b = format!("clock 12:00:02\n{err}\n");
+    assert_eq!(
+        srl_match_signature(&a, err),
+        srl_match_signature(&b, err),
+        "same error line at the same distance-from-bottom must sign identically \
+         (the in-place clock-tick re-render that triggers the phantom re-scan)"
+    );
+    // Error pushed UP by fresh output below it → different dist_from_bottom.
+    let c = format!("clock 12:00:03\n{err}\nthe agent resumed work\n");
+    assert_ne!(
+        srl_match_signature(&a, err).1,
+        srl_match_signature(&c, err).1,
+        "an error pushed up by new output below must change dist_from_bottom"
+    );
+}
+
 // ── #1518: HIGH_FP error detection bounded to the live bottom-N tail ──
 
 #[test]


### PR DESCRIPTION
## Why
cheerc's #1808 spike raised 2 ServerRateLimit recovery/state-detection flaws. The verify-spike conclusions **conflict**: dev (fixup-dev) **REFUTED** both against our actual code; codex **CONFIRMED**. cheerc's reproducing Evidence 2 (a `general` agent looping SRL→inject→Idle every ~3m50s) was on **cheerc's own daemon** — our daemon has not yet reproduced it (all observed SRL events were pre-restart, detect→clear-recovered, zero inject, no phantom).

Per operator: **有疑義先加 log 在 production 實證、別只靠 code-trace 定論.** This PR adds 3 instrumentation probes to capture the truth the next time our daemon actually hits SRL. **Pure tracing, zero behavior change.**

## Probes (all instrumentation-only)

### Probe 0 — `#1808-probe0-phantom` (MAIN)
The phantom mechanism: a stale SRL error stuck in the bottom-N tail keeps re-matching after the agent recovered — the screen hash flips when the CLI clock ticks → `StateTracker::feed` re-scans → re-grabs the **same old error** → re-latch → blind inject.

At the SRL detection point (`state/mod.rs`), signature the matched error line `(line_hash, dist_from_bottom)` and compare across ticks:
- **same sig, NO intervening non-SRL state** → in-place clock-tick re-scan → `srl_consecutive_rematch++`
- **same sig, intervening Idle/non-SRL state** → `cross_cycle_refire` (the agent recovered, then the OLD error was re-grabbed) = cheerc's **exact cross-Idle loop**

`last_srl_match_sig` **persists across Idle** (per lead refinement) so the cross-cycle case survives — a counter that reset on Idle would miss it. WARN fires only when the SRL would actually latch (`landed == ServerRateLimit` → would inject) AND there's no recent productive output. **Not backend-scoped** (the phantom is the Claude `Server is temporarily limiting` re-match).

### Probe 1 — `#1808-flaw1-probe` (abort-to-Idle)
cheerc Flaw 1: a backend that hits a fatal net error aborts to an Idle prompt → the unconditional Idle-clear drops the in-flight SRL retry → claimed freeze. Split the Idle-clear log: a track with `retry_count > 0` reaching Idle with **no recent productive output** (`!recovered`) → **WARN**; a genuine recovery → enriched INFO. The clear itself is unchanged.

### Probe 2 — `#1808-flaw2-probe` (Agy/Kiro static-chrome mask)
cheerc Flaw 2: a static bottom status bar (`esc to cancel`) below the error defeats `working_state_below`. `working_state_below` now also returns the matched marker text (same selection logic — detection unchanged); when it overrides a ServerRateLimit on **Agy/Kiro** (whose Thinking pattern is the bare `esc to cancel`), log the winning marker + productive silence; non-productive ⇒ WARN.

## Scope / safety
- Adds 3 telemetry-only `StateTracker` fields (`last_srl_match_sig`, `srl_consecutive_rematch`, `non_srl_since_last_srl`) + a pure `srl_match_signature` helper — all read/written **only** for the probe logs, never touching `landed`/transition/retry.
- `working_state_below` return type widened to `(state, marker)`; its single prod caller + selection logic unchanged → byte-identical detection.

## Tests
- `abort_to_idle_clears_in_flight_retry_and_does_not_inject_1808` — pins the real current behavior (track cleared + **no inject**, via the real `process_error_recovery` entry); confirms the SRL path does not resume an aborted-to-Idle agent (inject is state-gated on SRL).
- `srl_match_signature_stable_until_error_moves_1808` — the freshness primitive: same error at same dist signs identically (clock-tick); pushed-up error changes `dist_from_bottom`.
- Preflight: `cargo fmt --check` + clippy (`tray`, `tray,discord`, `-D warnings`) + full `cargo test --tests` all green. Base = latest `origin/main` (ade1037).

Refs #1808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)