### PR TITLE
Stage 0 supervisor-sentinel: add AGEND_SUPERVISED, drop ambient XPC_SERVICE_NAME (refs #1812)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ## [Unreleased]
 
+### Changed
+
+- **Restart-supervisor detection: positive `AGEND_SUPERVISED` sentinel, `XPC_SERVICE_NAME` dropped (#1812)** — `is_restart_supervised()` (the #851 fail-closed guard for `restart_daemon`) no longer trusts `XPC_SERVICE_NAME`. macOS exports that variable into *every* process in a GUI login session (including a bare `agend-terminal start` from Terminal.app), so on macOS the guard returned true unconditionally and `restart_daemon` could `exit(42)` with nothing to respawn the daemon. The check now keys on an explicit `AGEND_SUPERVISED=1` sentinel that `agend-terminal service install` writes into the launchd plist (`EnvironmentVariables`) and systemd unit (`Environment=`). `AGEND_WRAPPED` and systemd's `INVOCATION_ID` remain accepted. **macOS/Linux migration: re-run `agend-terminal service install` after upgrading, then restart the daemon once** — an existing service config installed on an earlier build predates the sentinel, so until it is regenerated `restart_daemon` fails-closed with an actionable error (the safe direction — it refuses rather than bricking). Windows Task Scheduler cannot carry the sentinel (its task XML has no env element) and stays fail-closed on bare-start as before.
+
 ## [0.7.0] — 2026-05-28
 
 200+ commits since `0.6.1` over Sprint 55–69 (May 7 → May 28, 2026). Three themes dominate:

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -5,6 +5,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **重啟監督偵測:改用正向 `AGEND_SUPERVISED` sentinel,移除 `XPC_SERVICE_NAME`(#1812)** — `is_restart_supervised()`(`restart_daemon` 的 #851 fail-closed 防呆)不再信任 `XPC_SERVICE_NAME`。macOS 會把該變數注入 GUI 登入工作階段中的*每一個* process(包含在 Terminal.app 裡裸跑 `agend-terminal start`),導致 macOS 上此防呆永遠回 true,`restart_daemon` 可能 `exit(42)` 後沒有任何程序重啟 daemon。現在改以 `agend-terminal service install` 寫入 launchd plist(`EnvironmentVariables`)與 systemd unit(`Environment=`)的 `AGEND_SUPERVISED=1` 明確 sentinel 判斷;`AGEND_WRAPPED` 與 systemd 的 `INVOCATION_ID` 仍接受。**macOS/Linux 升級遷移:升級後請重跑 `agend-terminal service install`,再重啟 daemon 一次** —— 舊版安裝的 service 設定檔早於此 sentinel,在重新產生前 `restart_daemon` 會 fail-closed 並回傳可操作的錯誤訊息(這是安全方向 —— 拒絕而非把 daemon 卡死)。Windows Task Scheduler 無法攜帶此 sentinel(task XML 沒有環境變數元素),維持裸啟動 fail-closed。
+
 ## [0.7.0] — 2026-05-28
 
 自 `0.6.1` 以來超過 200 個 commit，橫跨 Sprint 55–69（2026 年 5 月 7 日至 5 月 28 日）。三大主題：

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,12 +40,14 @@ dependencies = [
  "libc",
  "memchr",
  "parking_lot",
+ "plist",
  "portable-pty",
  "predicates",
  "proptest",
  "ratatui",
  "regex",
  "reqwest",
+ "rust-ini",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -619,6 +621,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1016,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1689,6 +1720,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2894,6 +2931,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,6 +3149,19 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap 2.13.1",
+ "quick-xml",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "png"
@@ -3341,6 +3401,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -3703,6 +3772,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4679,6 +4758,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,13 @@ serial_test = "3"
 # Used only for asserting that codex_trust_directory writes syntactically
 # valid TOML — the prod code appends raw text, it doesn't depend on this crate.
 toml = "1.1"
+# #1812 §3.9 real-entry tests: parse the rendered launchd plist
+# (`plist`) and systemd unit (`ini`/rust-ini) with REAL format parsers to
+# extract the AGEND_SUPERVISED sentinel out of its structural env block —
+# the templates are plain text the prod code substitutes into, so these
+# crates are test-only (mirrors the `toml` dev-dep convention above).
+plist = "1.7"
+rust-ini = "0.21"
 # Sprint 54 P1-A — `tests/cargo_include_invariant.rs` matches resolved
 # `include_str!` paths against `[package].include` glob patterns
 # (e.g. `src/**/*.rs`, `assets/hooks/*`). Test-only.

--- a/assets/service/launchd.plist.template
+++ b/assets/service/launchd.plist.template
@@ -31,6 +31,12 @@ Placeholders (substituted at install time by service::install):
     <dict>
         <key>AGEND_HOME</key>
         <string>__HOME__</string>
+        <!-- #1812: explicit supervisor sentinel. is_restart_supervised()
+             reads this to confirm the daemon was launched by an
+             agend-installed launchd KeepAlive service (replaces the
+             ambient XPC_SERVICE_NAME false-positive). -->
+        <key>AGEND_SUPERVISED</key>
+        <string>1</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>

--- a/assets/service/systemd.service.template
+++ b/assets/service/systemd.service.template
@@ -23,6 +23,11 @@ After=network.target
 Type=simple
 ExecStart=__EXECUTABLE__ start --foreground
 Environment=AGEND_HOME=__HOME__
+# #1812: explicit supervisor sentinel. is_restart_supervised() reads
+# AGEND_SUPERVISED to confirm the daemon was launched by an agend-installed
+# systemd Restart=on-failure unit. (INVOCATION_ID, set by systemd at
+# runtime, remains a belt-and-suspenders signal.)
+Environment=AGEND_SUPERVISED=1
 # Sprint 57 Wave 3 PR-2 (#548 Q3): the daemon does NOT supervise itself.
 # systemd is the supervisor of last resort. Restart=on-failure ensures
 # operator-visible crashes get respawned by systemd, but Q6 graceful

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -193,6 +193,24 @@ pub fn run_dir(home: &Path) -> PathBuf {
     home.join("run").join(std::process::id().to_string())
 }
 
+/// #1812: the SINGLE process-wide lock that every test mutating (or
+/// reading) process-global env must hold.
+///
+/// `std::env::set_var` / `remove_var` / `var` race across the WHOLE
+/// environment, not per key — the libc `environ` is one shared,
+/// non-atomic array (which is exactly why Rust 1.84 made the mutators
+/// `unsafe`). So two tests guarding DIFFERENT keys with DIFFERENT
+/// per-module mutexes still data-race each other. A reviewer caught this
+/// when `cargo test restart` interleaved `daemon::restart` and
+/// `per_tick::recovery_dispatcher` env tests under their separate locks.
+/// Cross-module env tests must lock THIS, not a local static.
+#[cfg(test)]
+pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 /// Find any active run directory (for CLI commands connecting to daemon).
 /// Verifies identity via .daemon file (PID + start timestamp) to prevent PID reuse false positives.
 pub fn find_active_run_dir(home: &Path) -> Option<PathBuf> {

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -888,6 +888,11 @@ mod tests {
     fn env_ms_defaults_when_var_unset() {
         // Sanity: env_ms falls back to default when env var missing.
         // Use a unique var name to avoid colliding with other tests.
+        // #1812: shared crate-wide env lock — even a unique key data-races
+        // the global environ against another module's concurrent set_var.
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         unsafe {
             std::env::remove_var("AGEND_TEST_RECOVERY_NONEXISTENT_VAR");
         }
@@ -906,13 +911,15 @@ mod tests {
 
     use crate::agent::{AgentRegistry, ExternalRegistry};
     use std::collections::HashMap;
-    use std::sync::OnceLock;
 
     fn with_stage1_gate<R>(active: bool, f: impl FnOnce() -> R) -> R {
-        // Serialise tests touching `AGEND_AUTO_RECOVERY_STAGE1`.
-        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
-        let lock = LOCK.get_or_init(|| std::sync::Mutex::new(()));
-        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        // #1812: serialise via the SINGLE crate-wide env lock, not a
+        // module-local one — env mutation races across ALL keys, so a
+        // local mutex wouldn't serialise against `daemon::restart`'s env
+        // tests (the `cargo test restart` interleave the reviewer caught).
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var(STAGE1_ENV_VAR).ok();
         // SAFETY: serialised by the LOCK guard. Test-only env mutation.
         unsafe {
@@ -1111,6 +1118,10 @@ mod tests {
     #[test]
     fn env_ms_parses_valid_integer() {
         // Env var parses to Duration via integer ms.
+        // #1812: shared crate-wide env lock (see `env_ms_defaults_when_var_unset`).
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         unsafe {
             std::env::set_var("AGEND_TEST_RECOVERY_ENV_MS_VALID", "5000");
         }
@@ -1125,6 +1136,10 @@ mod tests {
     fn env_ms_falls_back_on_invalid_integer() {
         // Garbage env var value → fall back to default rather than
         // panic. Operator typo doesn't crash the dispatcher.
+        // #1812: shared crate-wide env lock (see `env_ms_defaults_when_var_unset`).
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         unsafe {
             std::env::set_var("AGEND_TEST_RECOVERY_ENV_MS_INVALID", "not a number");
         }
@@ -1144,9 +1159,10 @@ mod tests {
     // -------------------------------------------------------------------
 
     fn with_stage2_gate<R>(active: bool, f: impl FnOnce() -> R) -> R {
-        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
-        let lock = LOCK.get_or_init(|| std::sync::Mutex::new(()));
-        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        // #1812: shared crate-wide env lock (see `with_stage1_gate`).
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var(STAGE2_ENV_VAR).ok();
         unsafe {
             if active {
@@ -1198,7 +1214,14 @@ mod tests {
     #[test]
     fn stage2_max_restarts_default_is_three() {
         // Default cap N=3 per decision §Q1/Q2. Env var override unset
-        // returns the default.
+        // returns the default. #1812: hold the shared crate-wide env lock
+        // — `stage2_max_restarts()` READS env, which races a concurrent
+        // `set_var` from another module's test (e.g. daemon::restart)
+        // just as a write would.
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prior = std::env::var(STAGE2_MAX_RESTARTS_ENV_VAR).ok();
         unsafe {
             std::env::remove_var(STAGE2_MAX_RESTARTS_ENV_VAR);
         }
@@ -1206,16 +1229,30 @@ mod tests {
             stage2_max_restarts(),
             crate::health::STAGE2_MAX_RESTARTS_DEFAULT
         );
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var(STAGE2_MAX_RESTARTS_ENV_VAR, v),
+                None => std::env::remove_var(STAGE2_MAX_RESTARTS_ENV_VAR),
+            }
+        }
     }
 
     #[test]
     fn stage2_max_restarts_env_override() {
+        // #1812: shared crate-wide env lock + save/restore (see above).
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prior = std::env::var(STAGE2_MAX_RESTARTS_ENV_VAR).ok();
         unsafe {
             std::env::set_var(STAGE2_MAX_RESTARTS_ENV_VAR, "5");
         }
         assert_eq!(stage2_max_restarts(), 5);
         unsafe {
-            std::env::remove_var(STAGE2_MAX_RESTARTS_ENV_VAR);
+            match prior {
+                Some(v) => std::env::set_var(STAGE2_MAX_RESTARTS_ENV_VAR, v),
+                None => std::env::remove_var(STAGE2_MAX_RESTARTS_ENV_VAR),
+            }
         }
     }
 
@@ -1304,9 +1341,10 @@ mod tests {
     // -------------------------------------------------------------------
 
     fn with_stage3_gate<R>(active: bool, f: impl FnOnce() -> R) -> R {
-        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
-        let lock = LOCK.get_or_init(|| std::sync::Mutex::new(()));
-        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        // #1812: shared crate-wide env lock (see `with_stage1_gate`).
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var(STAGE3_ENV_VAR).ok();
         unsafe {
             if active {

--- a/src/daemon/restart.rs
+++ b/src/daemon/restart.rs
@@ -91,15 +91,15 @@ fn has_env(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
 
-    /// Tests touch process-global env state — serialise via a
-    /// function-scoped mutex so parallel test threads don't race.
-    /// Mirror of the `with_f9_gate` pattern in `src/health.rs`.
+    /// Tests touch process-global env state — serialise via the SINGLE
+    /// crate-wide [`crate::daemon::test_env_lock`] (NOT a module-local
+    /// mutex): env mutation races across all keys, so per-module locks
+    /// don't serialise against other modules' env tests (#1812).
     fn with_env<R>(set: &[(&str, &str)], unset: &[&str], f: impl FnOnce() -> R) -> R {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        let lock = LOCK.get_or_init(|| Mutex::new(()));
-        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         let all_keys: Vec<&str> = set
             .iter()

--- a/src/daemon/restart.rs
+++ b/src/daemon/restart.rs
@@ -23,36 +23,61 @@
 //!
 //! ## Detection signals
 //!
-//! Composite env-var check covering all four supervised invocation
-//! paths plus an explicit marker for the bash wrapper:
+//! Composite env-var check. A supervisor signal means SOME process in
+//! the parent chain will respawn the daemon after `exit(42)`:
 //!
 //! - `AGEND_WRAPPED=1` — set by `scripts/agend-wrapper.sh` before each
 //!   daemon invocation. Marker for the manual / dev-mode supervisor.
-//! - `XPC_SERVICE_NAME` — set by macOS launchd for every service it
-//!   spawns. Reliable indicator that the daemon is running under
-//!   launchd with a `KeepAlive` policy.
-//! - `INVOCATION_ID` — set by systemd for every unit instance.
-//!   Reliable indicator that the daemon is running under a systemd
-//!   user unit with `Restart=on-failure`.
+//! - `AGEND_SUPERVISED=1` ([`SUPERVISED_ENV`]) — explicit positive
+//!   sentinel written into the service-manager config by
+//!   `agend-terminal service install` (launchd plist
+//!   `EnvironmentVariables`, systemd unit `Environment=`). This is the
+//!   PRIMARY signal we control end-to-end: its presence proves the
+//!   daemon was launched by an agend-installed supervisor (launchd
+//!   `KeepAlive` / systemd `Restart=on-failure`).
+//! - `INVOCATION_ID` — set by systemd for every unit instance. Kept as
+//!   a belt-and-suspenders systemd-only indicator; it is never set
+//!   outside a systemd-spawned unit, so (unlike `XPC_SERVICE_NAME`
+//!   below) it is not ambient and stays a reliable positive.
 //!
-//! Windows Task Scheduler does not set a comparably reliable env var.
-//! r0 fails-closed on Windows bare-start (the correct behavior — an
-//! operator using bare `agend-terminal start` on Windows gets the
-//! same actionable error as on macOS/Linux). Adding explicit
-//! Windows-side detection (parent-PID check against `taskhostw.exe`
-//! / `svchost.exe`) is a deferred follow-up.
+//! ### Why `XPC_SERVICE_NAME` was removed (#1812)
+//!
+//! Earlier revisions accepted `XPC_SERVICE_NAME` as a launchd signal.
+//! That was WRONG: macOS exports `XPC_SERVICE_NAME` (commonly the value
+//! `0`) into EVERY process spawned inside a GUI login session —
+//! including a bare `agend-terminal start` from Terminal.app. So in a
+//! macOS GUI session the check returned true UNCONDITIONALLY, defeating
+//! the #851 fail-closed guard: a bare, UNsupervised daemon was treated
+//! as supervised, so `restart_daemon` exited with nobody to respawn it.
+//! The positive `AGEND_SUPERVISED` sentinel replaces it — launchd is now
+//! detected via the sentinel the install-time plist carries, not via an
+//! ambient OS variable.
+//!
+//! Windows Task Scheduler does not set a comparably reliable env var,
+//! and its task XML has no native environment-variable element, so the
+//! sentinel cannot be injected there. Windows therefore stays
+//! fail-closed on bare-start (the correct behavior — same actionable
+//! error as macOS/Linux). FUTURE: a Windows supervisor path can carry
+//! the signal as a `--supervised` launch arg in the task `<Arguments>`
+//! and have startup translate it into `AGEND_SUPERVISED` (deferred —
+//! out of #1812 scope).
+
+/// Env var name of the explicit supervisor sentinel (#1812). Written
+/// into the launchd plist `EnvironmentVariables` and the systemd unit
+/// `Environment=` by `agend-terminal service install`; shared with the
+/// detector and its tests so the literal lives in exactly one place.
+pub const SUPERVISED_ENV: &str = "AGEND_SUPERVISED";
 
 /// True iff the daemon's parent process chain includes a supervisor
 /// that will respawn the daemon on `exit(42)`. Returns false (fail-
 /// closed) when no supervisor is detected — `restart_daemon` should
 /// then refuse the request rather than silently killing the daemon.
 ///
-/// Composite env-var check covering all four supervised invocation
-/// paths. See module doc for the rationale + Windows fail-closed
-/// note. Pure helper — no globals, no side effects, safe to call from
-/// any thread.
+/// Composite env-var check (see module doc for each signal + why
+/// `XPC_SERVICE_NAME` was dropped in #1812). Pure helper — no globals,
+/// no side effects, safe to call from any thread.
 pub fn is_restart_supervised() -> bool {
-    has_env("AGEND_WRAPPED") || has_env("XPC_SERVICE_NAME") || has_env("INVOCATION_ID")
+    has_env("AGEND_WRAPPED") || has_env(SUPERVISED_ENV) || has_env("INVOCATION_ID")
 }
 
 /// Returns true iff env var `name` is set (any value, including
@@ -112,13 +137,26 @@ mod tests {
         result
     }
 
-    const ALL_SIGNAL_VARS: &[&str] = &["AGEND_WRAPPED", "XPC_SERVICE_NAME", "INVOCATION_ID"];
+    /// Every supervisor signal the detector accepts AFTER #1812 (XPC is
+    /// no longer one of them). Used as the unset list so a single-signal
+    /// test isolates exactly one positive.
+    const ALL_SIGNAL_VARS: &[&str] = &["AGEND_WRAPPED", "AGEND_SUPERVISED", "INVOCATION_ID"];
+
+    /// The ambient macOS-GUI variable #1812 deliberately stopped trusting.
+    /// Kept in unset lists so a positive-signal test proves it's the OUR
+    /// marker (not stray XPC) driving the true result.
+    const AMBIENT_NON_SIGNAL: &str = "XPC_SERVICE_NAME";
 
     /// Bare `agend-terminal start` — no supervisor in parent chain,
     /// none of the signal env vars set. Detection must fail-closed.
     #[test]
     fn detect_returns_false_when_no_supervisor_env_set() {
-        with_env(&[], ALL_SIGNAL_VARS, || {
+        let unset: Vec<&str> = ALL_SIGNAL_VARS
+            .iter()
+            .copied()
+            .chain([AMBIENT_NON_SIGNAL])
+            .collect();
+        with_env(&[], &unset, || {
             assert!(
                 !is_restart_supervised(),
                 "bare daemon invocation (no signal env) must fail-closed"
@@ -127,13 +165,12 @@ mod tests {
     }
 
     /// `scripts/agend-wrapper.sh` sets `AGEND_WRAPPED=1` before each
-    /// daemon invocation (added by this PR's C2c). Detection must
-    /// recognize the explicit marker.
+    /// daemon invocation. Detection must recognize the explicit marker.
     #[test]
     fn detect_returns_true_when_agend_wrapped_set() {
         with_env(
             &[("AGEND_WRAPPED", "1")],
-            &["XPC_SERVICE_NAME", "INVOCATION_ID"],
+            &[SUPERVISED_ENV, "INVOCATION_ID", AMBIENT_NON_SIGNAL],
             || {
                 assert!(
                     is_restart_supervised(),
@@ -143,21 +180,36 @@ mod tests {
         );
     }
 
-    /// macOS launchd sets `XPC_SERVICE_NAME` for every service it
-    /// spawns. Used by the `service install` plist that ships
-    /// `KeepAlive=true`.
+    /// #1812: the `AGEND_SUPERVISED` sentinel that `service install` writes
+    /// into the launchd plist / systemd unit is the PRIMARY launchd/systemd
+    /// signal now (replacing the ambient XPC false-positive).
     #[test]
-    fn detect_returns_true_when_launchd_xpc_service_name_set() {
+    fn detect_returns_true_when_agend_supervised_sentinel_set() {
         with_env(
-            &[("XPC_SERVICE_NAME", "com.agend-terminal.daemon")],
-            &["AGEND_WRAPPED", "INVOCATION_ID"],
+            &[(SUPERVISED_ENV, "1")],
+            &["AGEND_WRAPPED", "INVOCATION_ID", AMBIENT_NON_SIGNAL],
             || {
                 assert!(
                     is_restart_supervised(),
-                    "launchd XPC_SERVICE_NAME must be recognized as a supervisor signal"
+                    "AGEND_SUPERVISED=1 sentinel must be recognized as a supervisor signal"
                 );
             },
         );
+    }
+
+    /// #1812 regression: `XPC_SERVICE_NAME` is ambient in a macOS GUI login
+    /// session (set on a bare `agend-terminal start` too). It must NO LONGER
+    /// be trusted — otherwise the #851 fail-closed guard is defeated on every
+    /// macOS GUI launch. Only XPC set, all OUR markers unset → fail-closed.
+    #[test]
+    fn detect_returns_false_when_only_ambient_xpc_set() {
+        with_env(&[(AMBIENT_NON_SIGNAL, "0")], ALL_SIGNAL_VARS, || {
+            assert!(
+                !is_restart_supervised(),
+                "ambient XPC_SERVICE_NAME alone must NOT be treated as a supervisor \
+                 signal (#1812: it is set on bare GUI launches → #851 false-positive)"
+            );
+        });
     }
 
     /// Linux systemd sets `INVOCATION_ID` for every unit instance.
@@ -167,7 +219,7 @@ mod tests {
     fn detect_returns_true_when_systemd_invocation_id_set() {
         with_env(
             &[("INVOCATION_ID", "abc123def456")],
-            &["AGEND_WRAPPED", "XPC_SERVICE_NAME"],
+            &["AGEND_WRAPPED", SUPERVISED_ENV, AMBIENT_NON_SIGNAL],
             || {
                 assert!(
                     is_restart_supervised(),
@@ -175,5 +227,202 @@ mod tests {
                 );
             },
         );
+    }
+
+    // ── #1812 §3.9 real-entry tests ──────────────────────────────────────
+    //
+    // These live here (not in `tests/`) ON PURPOSE: `crate::service` and
+    // `crate::daemon::restart` are BIN-only modules (declared in main.rs;
+    // lib.rs is a thin facade), so an integration test in `tests/` — which
+    // links only the lib — cannot reach either the template constants or the
+    // detector. The "true entry" requirement is met by exercising the REAL
+    // `service::apply_substitutions` over the REAL shipped templates, parsing
+    // the rendered output with a REAL format parser (plist / INI — no
+    // `.contains()` string hacks), applying the parsed env into the process,
+    // and asserting the REAL `is_restart_supervised()`.
+
+    /// Apply an owned set of env vars (+ explicit unsets) under the shared
+    /// env mutex, run `f`, then restore. Owned-string sibling of `with_env`
+    /// for values produced at runtime (parsed out of a rendered template).
+    fn with_env_owned<R>(set: &[(String, String)], unset: &[&str], f: impl FnOnce() -> R) -> R {
+        let borrowed: Vec<(&str, &str)> =
+            set.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        with_env(&borrowed, unset, f)
+    }
+
+    /// Parse the launchd `EnvironmentVariables` dict out of a rendered plist
+    /// using the real `plist` parser and return its key/value pairs.
+    fn launchd_env_vars(rendered: &str) -> Vec<(String, String)> {
+        let value = plist::Value::from_reader_xml(std::io::Cursor::new(rendered.as_bytes()))
+            .expect("rendered launchd template must be valid plist XML");
+        let dict = value.as_dictionary().expect("plist root must be a <dict>");
+        let env = dict
+            .get("EnvironmentVariables")
+            .expect("plist must carry an EnvironmentVariables key")
+            .as_dictionary()
+            .expect("EnvironmentVariables must be a <dict>");
+        env.iter()
+            .map(|(k, v)| {
+                (
+                    k.to_string(),
+                    v.as_string()
+                        .expect("each EnvironmentVariables value is a <string>")
+                        .to_string(),
+                )
+            })
+            .collect()
+    }
+
+    /// Parse the systemd `[Service] Environment=` directives out of a
+    /// rendered unit using the real `ini` parser. systemd allows repeated
+    /// `Environment=` lines, so `get_all` is used; each value is a single
+    /// `KEY=VALUE` assignment.
+    fn systemd_env_vars(rendered: &str) -> Vec<(String, String)> {
+        let ini = ini::Ini::load_from_str(rendered)
+            .expect("rendered systemd template must be valid unit/INI syntax");
+        let service = ini
+            .section(Some("Service"))
+            .expect("systemd unit must have a [Service] section");
+        service
+            .get_all("Environment")
+            .map(|assignment| {
+                let (k, v) = assignment
+                    .split_once('=')
+                    .expect("each Environment= directive is KEY=VALUE");
+                (k.to_string(), v.to_string())
+            })
+            .collect()
+    }
+
+    /// Render the launchd template exactly as `macos::install` does, parse
+    /// its env block with the real plist parser, confirm the sentinel is
+    /// structurally present, apply the parsed env, and assert the REAL
+    /// detector returns true.
+    #[test]
+    fn launchd_template_env_makes_detector_supervised() {
+        let rendered = crate::service::apply_substitutions(
+            crate::service::LAUNCHD_TEMPLATE,
+            &[
+                ("__LABEL__", "com.agend-terminal.daemon"),
+                ("__EXECUTABLE__", "/usr/local/bin/agend-terminal"),
+                ("__HOME__", "/Users/test/.agend-terminal"),
+            ],
+        );
+        let env = launchd_env_vars(&rendered);
+        assert!(
+            env.iter().any(|(k, v)| k == SUPERVISED_ENV && v == "1"),
+            "launchd plist EnvironmentVariables must carry {SUPERVISED_ENV}=1 — got {env:?}"
+        );
+        with_env_owned(
+            &env,
+            &["AGEND_WRAPPED", "INVOCATION_ID", AMBIENT_NON_SIGNAL],
+            || {
+                assert!(
+                    is_restart_supervised(),
+                    "applying the launchd template env must make the daemon detect as supervised"
+                );
+            },
+        );
+    }
+
+    /// Same end-to-end check for the systemd unit: real INI parse of the
+    /// `[Service] Environment=` block → apply → real detector true.
+    #[test]
+    fn systemd_template_env_makes_detector_supervised() {
+        let rendered = crate::service::apply_substitutions(
+            crate::service::SYSTEMD_TEMPLATE,
+            &[
+                ("__EXECUTABLE__", "/usr/local/bin/agend-terminal"),
+                ("__HOME__", "/home/test/.agend-terminal"),
+            ],
+        );
+        let env = systemd_env_vars(&rendered);
+        assert!(
+            env.iter().any(|(k, v)| k == SUPERVISED_ENV && v == "1"),
+            "systemd [Service] must carry an Environment={SUPERVISED_ENV}=1 directive — got {env:?}"
+        );
+        // INVOCATION_ID is injected by systemd at RUNTIME, not by the unit
+        // file — unset it here so the assertion proves the sentinel alone
+        // (the part the unit file controls) drives the result.
+        with_env_owned(
+            &env,
+            &["AGEND_WRAPPED", "INVOCATION_ID", AMBIENT_NON_SIGNAL],
+            || {
+                assert!(
+                    is_restart_supervised(),
+                    "applying the systemd unit env must make the daemon detect as supervised"
+                );
+            },
+        );
+    }
+
+    /// Class-closing invariant: EVERY supervisor artifact we ship must yield
+    /// a signal the detector accepts. Table-driven so a future artifact added
+    /// without a matching detector signal fails here. Each row supplies the
+    /// single env var that artifact contributes to the daemon's environment.
+    #[test]
+    fn every_shipped_supervisor_artifact_makes_detector_supervised() {
+        // (artifact name, (env_key, env_value) it provides).
+        let launchd_env = launchd_env_vars(&crate::service::apply_substitutions(
+            crate::service::LAUNCHD_TEMPLATE,
+            &[
+                ("__LABEL__", "com.agend-terminal.daemon"),
+                ("__EXECUTABLE__", "/usr/local/bin/agend-terminal"),
+                ("__HOME__", "/Users/test/.agend-terminal"),
+            ],
+        ));
+        let systemd_env = systemd_env_vars(&crate::service::apply_substitutions(
+            crate::service::SYSTEMD_TEMPLATE,
+            &[
+                ("__EXECUTABLE__", "/usr/local/bin/agend-terminal"),
+                ("__HOME__", "/home/test/.agend-terminal"),
+            ],
+        ));
+        let launchd_sentinel = launchd_env
+            .iter()
+            .find(|(k, _)| k == SUPERVISED_ENV)
+            .cloned()
+            .expect("launchd plist provides the sentinel");
+        let systemd_sentinel = systemd_env
+            .iter()
+            .find(|(k, _)| k == SUPERVISED_ENV)
+            .cloned()
+            .expect("systemd unit provides the sentinel");
+
+        let artifacts: &[(&str, (String, String))] = &[
+            ("launchd plist (service install)", launchd_sentinel),
+            ("systemd user unit (service install)", systemd_sentinel),
+            (
+                "systemd runtime (INVOCATION_ID)",
+                ("INVOCATION_ID".to_string(), "abc123".to_string()),
+            ),
+            (
+                "scripts/agend-wrapper.sh (AGEND_WRAPPED)",
+                ("AGEND_WRAPPED".to_string(), "1".to_string()),
+            ),
+        ];
+
+        for (artifact, (key, value)) in artifacts {
+            // Unset every OTHER signal so each row proves THAT artifact alone
+            // closes the class. AMBIENT_NON_SIGNAL is always unset.
+            let unset: Vec<&str> = ALL_SIGNAL_VARS
+                .iter()
+                .copied()
+                .chain(["INVOCATION_ID", AMBIENT_NON_SIGNAL])
+                .filter(|k| k != key)
+                .collect();
+            with_env_owned(
+                std::slice::from_ref(&(key.clone(), value.clone())),
+                &unset,
+                || {
+                    assert!(
+                        is_restart_supervised(),
+                        "shipped supervisor artifact {artifact:?} (provides {key}={value}) must \
+                     make is_restart_supervised() return true — the brick class is only closed \
+                     if every artifact we ship yields an accepted signal"
+                    );
+                },
+            );
+        }
     }
 }

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -10,9 +10,27 @@ pub(super) fn handle_restart_daemon(home: &Path) -> Value {
     // `Resource temporarily unavailable (os error 35)` on every
     // subsequent MCP call until they manually restart.
     if !crate::daemon::restart::is_restart_supervised() {
+        // #1812 fail-closed remediation. Two operator situations collapse to
+        // the same missing-sentinel state; spell out BOTH rather than try to
+        // reliably tell them apart (a stale-install probe would have to parse
+        // the on-disk plist/unit for the sentinel — too heavy for the value):
+        //   (a) never installed → run `service install` (or use the wrapper).
+        //   (b) installed on an earlier build → the AGEND_SUPERVISED sentinel
+        //       is new, so an existing macOS/Linux service config predates it;
+        //       re-run `service install` + restart once so the daemon relaunches
+        //       carrying it. (This is the macOS upgrade migration from the design.)
         return json!({
             "ok": false,
-            "error": "restart_daemon requires a supervisor (launchd / systemd / scripts/agend-wrapper.sh / Task Scheduler). Detected: bare daemon invocation. Run `agend-terminal service install` to enable safe restart, or launch via `scripts/agend-wrapper.sh` for manual operation."
+            "error": "restart_daemon requires a supervisor that will respawn the daemon \
+                      (launchd / systemd / scripts/agend-wrapper.sh). No supervisor sentinel \
+                      (AGEND_SUPERVISED / AGEND_WRAPPED / INVOCATION_ID) was found in the \
+                      daemon's environment. Remediation — if you have NOT installed the service: \
+                      run `agend-terminal service install` (or launch via scripts/agend-wrapper.sh). \
+                      If you installed it on an EARLIER build: the AGEND_SUPERVISED sentinel was \
+                      added recently and your existing service config predates it, so re-run \
+                      `agend-terminal service install` and restart the daemon once so it relaunches \
+                      under the updated config. (Windows Task Scheduler cannot carry the sentinel \
+                      yet and stays fail-closed.)"
         });
     }
     crate::daemon::RESTART_PENDING.store(true, std::sync::atomic::Ordering::Release);
@@ -82,7 +100,12 @@ mod tests {
     fn handle_restart_daemon_fails_closed_when_unsupervised() {
         with_env_and_reset(
             &[],
-            &["AGEND_WRAPPED", "XPC_SERVICE_NAME", "INVOCATION_ID"],
+            &[
+                "AGEND_WRAPPED",
+                "AGEND_SUPERVISED",
+                "INVOCATION_ID",
+                "XPC_SERVICE_NAME",
+            ],
             || {
                 // Manual tempdir — matches the std::env::temp_dir pattern
                 // used elsewhere in this crate (e.g. claim_verifier.rs
@@ -118,6 +141,49 @@ mod tests {
                 assert!(
                     !tmp.join("restart-requested").exists(),
                     "restart-requested marker file must NOT exist when fail-closed"
+                );
+                let _ = std::fs::remove_dir_all(&tmp);
+            },
+        );
+    }
+
+    /// #1812 regression — bare GUI launch on macOS. `XPC_SERVICE_NAME` is
+    /// ambient in a macOS GUI login session (set on EVERY process,
+    /// including a bare `agend-terminal start` from Terminal.app), so the
+    /// pre-#1812 detector treated an UNsupervised daemon as supervised and
+    /// `restart_daemon` would exit(42) with nobody to respawn it (#851
+    /// defeat). With XPC dropped, the REAL handler must fail-closed: only
+    /// `XPC_SERVICE_NAME` set, all our markers unset → `ok: false` and no
+    /// `RESTART_PENDING`. Drives the production `handle_restart_daemon`, not
+    /// the bare detector.
+    #[test]
+    fn handle_restart_daemon_fails_closed_on_bare_gui_xpc_only() {
+        with_env_and_reset(
+            &[("XPC_SERVICE_NAME", "0")],
+            &["AGEND_WRAPPED", "AGEND_SUPERVISED", "INVOCATION_ID"],
+            || {
+                let tmp = std::env::temp_dir().join(format!(
+                    "agend-restart-gui-test-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_nanos())
+                        .unwrap_or(0),
+                ));
+                std::fs::create_dir_all(&tmp).expect("create tempdir");
+                let response = handle_restart_daemon(&tmp);
+                assert_eq!(
+                    response["ok"], false,
+                    "ambient XPC_SERVICE_NAME alone must NOT be accepted as a \
+                     supervisor (the #851/#1812 macOS-GUI false-positive) — got {response}"
+                );
+                assert!(
+                    !crate::daemon::RESTART_PENDING.load(Ordering::Acquire),
+                    "RESTART_PENDING must stay unset on the bare-GUI fail-closed path"
+                );
+                assert!(
+                    !tmp.join("restart-requested").exists(),
+                    "restart-requested marker must NOT be written on fail-closed"
                 );
                 let _ = std::fs::remove_dir_all(&tmp);
             },

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -43,16 +43,18 @@ pub(super) fn handle_restart_daemon(home: &Path) -> Value {
 mod tests {
     use super::*;
     use std::sync::atomic::Ordering;
-    use std::sync::{Mutex, OnceLock};
 
     /// Tests touch the process-global `RESTART_PENDING` static and env
-    /// state — serialise via a function-scoped mutex so parallel test
-    /// threads can't race. Also resets `RESTART_PENDING` after each
-    /// test so the next caller sees a clean slate.
+    /// state. Serialise via the SINGLE crate-wide
+    /// [`crate::daemon::test_env_lock`] (shared with `daemon::restart` +
+    /// `per_tick::recovery_dispatcher`) — env mutation races across all
+    /// keys, so a module-local mutex wouldn't serialise against those
+    /// other modules' env tests (#1812). Also resets `RESTART_PENDING`
+    /// after each test so the next caller sees a clean slate.
     fn with_env_and_reset<R>(set: &[(&str, &str)], unset: &[&str], f: impl FnOnce() -> R) -> R {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        let lock = LOCK.get_or_init(|| Mutex::new(()));
-        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::daemon::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         let all_keys: Vec<&str> = set
             .iter()


### PR DESCRIPTION
## What & why (#1812 Stage 0)

> **Re-scopes #1812 (NOT auto-closed — #1812 stays OPEN as a crash-recovery advisory).** A dead daemon (panic/OOM/kill) cannot run the Stage-1 successor handoff, so `is_restart_supervised()` still matters for crash recovery. Phrased to avoid GitHub auto-close keywords on purpose.

`is_restart_supervised()` — the #851 fail-closed guard for `restart_daemon` — trusted `XPC_SERVICE_NAME` as a launchd signal. **macOS exports `XPC_SERVICE_NAME` (commonly `0`) into every process in a GUI login session**, including a bare `agend-terminal start` from Terminal.app. So on macOS the guard returned `true` unconditionally → `restart_daemon` could `exit(42)` with nothing to respawn the daemon (the #851 brick class).

Per dialectic decision `d-20260606104934346030-2` (Stage 0), replace the ambient signal with a **positive sentinel we control end-to-end**.

## Changes (scope-bounded)
- **`src/daemon/restart.rs`** — `is_restart_supervised()` now keys on `AGEND_WRAPPED || AGEND_SUPERVISED || INVOCATION_ID`; **`XPC_SERVICE_NAME` dropped**. Adds shared `pub const SUPERVISED_ENV = "AGEND_SUPERVISED"`. Module doc rewritten (the old "XPC = reliable launchd indicator" claim was the root error; new "Why XPC was removed" section).
- **`assets/service/launchd.plist.template`** — `AGEND_SUPERVISED=1` added to `EnvironmentVariables`.
- **`assets/service/systemd.service.template`** — `Environment=AGEND_SUPERVISED=1` added to `[Service]`.
- **`handle_restart_daemon`** — fail-closed remediation now distinguishes *never-installed* vs *installed-before-the-sentinel → re-run `service install`* (a reliable stale-install probe would parse on-disk plist/unit — too heavy; both remediations spelled out).
- **Windows** — stays fail-closed (Task Scheduler XML has no env element); doc notes the future `--supervised` arg path. Out of scope.
- **`src/daemon/mod.rs` + 3 test modules** — single crate-wide `crate::daemon::test_env_lock()` (cfg(test)); `daemon::restart`, `mcp::handlers::restart`, and `per_tick::recovery_dispatcher` env tests all route through it (review fix — see below).
- **CHANGELOG (EN + zh-TW)** — macOS/Linux re-run `service install` after upgrade.

## #1812 status: re-scoped, NOT auto-closed
The sentinel is **advisory defense-in-depth for crash recovery**. #1812 must remain OPEN. (Body deliberately omits any auto-close keyword so `closingIssuesReferences` is empty.)

## Review fix — cross-module env-race (real bug)
`cargo test restart` interleaved `daemon::restart` and `per_tick::recovery_dispatcher` env tests, each under its OWN module-local mutex. `std::env` mutation races across the WHOLE process environment (one shared libc `environ` — why Rust 1.84 made the mutators `unsafe`), so per-module locks don't serialize against each other; the `stage2_max_restarts_*` tests had no lock at all. Fixed by routing every env-touching test in the colliding modules through the single `crate::daemon::test_env_lock()`. `cargo test restart --features tray` run 5× consecutively → 27 passed, 0 failed each time.

## Tests — §3.9 real-entry
Inline (not `tests/`) **on purpose**: `service` and `daemon::restart` are bin-only modules (main.rs tree; lib.rs is a thin facade), so a `tests/` integration crate — which links only the lib — cannot reach the template constants or the detector. "Real entry" is met by exercising the real code paths:
- Render each Unix template via the **real** `service::apply_substitutions` over the **real** shipped templates → parse the env block with a **real format parser** (`plist` crate for launchd, `rust-ini` for systemd; no `.contains()` string hacks) → apply parsed env → assert real `is_restart_supervised()==true`.
- **Bare-GUI regression** through the real `handle_restart_daemon`: only `XPC_SERVICE_NAME` set, our markers unset → `ok:false`, no `RESTART_PENDING`.
- Fail-closed (no markers → false).
- **Table-driven class-closing invariant**: every shipped supervisor artifact (launchd plist, systemd unit, systemd `INVOCATION_ID`, `agend-wrapper.sh`) yields an accepted signal.
- `plist` + `rust-ini` added as **dev-deps** (mirrors the existing `toml` dev-dep convention).

## Verification (rebuilt, not stale binary)
- `cargo fmt --check` ✓
- `cargo clippy --features tray --tests -- -D warnings` ✓
- `cargo test --tests --features tray` ✓ (exit 0)
- `cargo test restart --features tray` ✓ ×5 stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)