### PR TITLE
feat(#1814): Stage 1 — flag-gated self-respawn via successor handoff

### DIFF
--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -25,9 +25,12 @@ pub(crate) fn tool_timeout(tool: &str) -> Duration {
         | "list_deployments" | "set_waiting_on" | "set_display_name" | "set_description"
         | "react" | "report_health" => Duration::from_secs(5),
 
-        // Slow tools that spawn processes or do network I/O (~60s)
+        // Slow tools that spawn processes or do network I/O (~60s).
+        // #1814: restart_daemon (self-respawn) spawns a successor + runs a
+        // ≤30s Phase-1 health gate before returning — give it the 60s budget so
+        // the gate can't collide with the default 30s tool timeout.
         "create_instance" | "deploy_template" | "replace_instance" | "watch_ci"
-        | "checkout_repo" => Duration::from_secs(60),
+        | "checkout_repo" | "restart_daemon" => Duration::from_secs(60),
 
         // Default for everything else (~30s)
         _ => Duration::from_secs(30),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -696,6 +696,29 @@ fn spawn_one(
 /// if the server does not reply `{"ok":true}`. The cookie file has mode
 /// 0600 so only the daemon's user can read it — this is the peer-UID
 /// substitute for TCP loopback (see `auth_cookie.rs`).
+/// #1814: like [`call`] but targets a SPECIFIC run dir (cookie + api.port read
+/// from `run_dir`), not the active daemon. Used by the self-respawn Phase-1
+/// gate so the predecessor can do a real cookie-authenticated round-trip
+/// against the successor's own control plane while both are briefly alive. A
+/// short fixed read timeout (the gate retries) keeps a flaky successor from
+/// hanging the handler. No self-IPC guard: this connects to a DIFFERENT
+/// process's socket, so the registry-lock deadlock class does not apply.
+pub fn call_at(run_dir: &Path, request: &Value) -> anyhow::Result<Value> {
+    let stream = crate::ipc::connect_run_dir_api(run_dir)?;
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+        .context("set call_at read timeout")?;
+    let cookie = crate::auth_cookie::read_cookie(run_dir)?;
+    let mut writer = stream.try_clone()?;
+    let mut reader = BufReader::new(stream);
+    crate::auth_cookie::client_handshake_ndjson(&mut reader, &mut writer, &cookie)?;
+    writeln!(writer, "{request}")?;
+    writer.flush()?;
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    Ok(serde_json::from_str(&line)?)
+}
+
 pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
     // #1492: self-IPC over the loopback socket. If the caller holds the
     // registry lock, the API handler servicing this call needs the same lock →

--- a/src/bootstrap/daemon_spawn.rs
+++ b/src/bootstrap/daemon_spawn.rs
@@ -113,3 +113,68 @@ pub struct DaemonHandle {
     pub run_dir: PathBuf,
     pub log_path: PathBuf,
 }
+
+/// #1814: handle to a spawned successor daemon (self-respawn handoff).
+pub struct SuccessorHandle {
+    /// The successor daemon's pid. `start --foreground` does NOT re-exec, so
+    /// the spawned child IS the daemon — `child.id()` is authoritative.
+    pub pid: u32,
+    /// The successor's run dir (`home/run/<pid>`) — where the Phase-1 gate
+    /// looks for `control-ready` + `api.port` + `api.cookie`.
+    pub run_dir: PathBuf,
+    /// The live child handle. Held so the Phase-1 gate can `try_wait()` —
+    /// detecting a crash-on-launch immediately AND reaping it (vs. `kill(pid,
+    /// 0)`, which reports a zombie as still alive). On the COMMIT path the
+    /// handle is dropped when the predecessor exits; `std::process::Child::drop`
+    /// neither waits nor kills, so the promoted successor keeps running.
+    pub child: std::process::Child,
+}
+
+/// #1814: spawn a successor daemon for self-respawn handoff. Like
+/// [`spawn_detached`] but (a) injects `AGEND_SUCCESSOR_HANDOFF=<value>` so the
+/// child takes the minimal pre-lock handoff boot path (bypassing the singleton
+/// attach-reject guard, deferring flock + destructive reconciles), and (b)
+/// does NOT wait for readiness — the caller (restart handler) runs the Phase-1
+/// health gate against the returned run dir, then either commits (signals the
+/// predecessor to exit) or aborts (kills this successor). The child inherits
+/// the predecessor's env (incl. `AGEND_RESTART_HANDOFF=1`), so the successor will
+/// itself self-respawn on a later restart.
+pub fn spawn_successor_handoff(home: &Path, handoff_value: &str) -> Result<SuccessorHandle> {
+    let exe = std::env::current_exe().context("resolve current_exe for successor spawn")?;
+    std::fs::create_dir_all(home).with_context(|| format!("create home {}", home.display()))?;
+
+    let mut cmd = Command::new(&exe);
+    cmd.arg("start").arg("--foreground");
+    // Explicit set OVERRIDES any inherited stale value (the predecessor may
+    // itself have been a successor carrying an old AGEND_SUCCESSOR_HANDOFF).
+    cmd.env(crate::daemon::restart::SUCCESSOR_HANDOFF_ENV, handoff_value);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // DETACHED_PROCESS (0x00000008) | CREATE_NEW_PROCESS_GROUP (0x00000200)
+        cmd.creation_flags(0x00000008 | 0x00000200);
+    }
+
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("spawn successor daemon: {} start", exe.display()))?;
+    let pid = child.id();
+    // The child handle is RETAINED (not dropped) so the Phase-1 gate can
+    // `try_wait()` it: fast crash detection + zombie reaping on abort. On the
+    // commit path the predecessor's `exit(0)` drops it without killing — the
+    // promoted successor lives on (std Child drop is a no-op on the process).
+    Ok(SuccessorHandle {
+        pid,
+        run_dir: crate::daemon::run_dir_for_pid(home, pid),
+        child,
+    })
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -92,9 +92,14 @@ pub struct OwnedFleet {
     pub cookie: crate::auth_cookie::Cookie,
     pub telegram: Option<Arc<dyn crate::channel::Channel>>,
     /// Flock guard — drop releases `.daemon.lock`. Kept last so the lock is
-    /// released only after every other resource has been dropped.
+    /// released only after every other resource has been dropped. `Option`
+    /// since #1814: the normal `prepare` path holds `Some(lock)`; the
+    /// successor-handoff path acquires the flock later (after Phase-1, in
+    /// `daemon::run_successor_handoff`) and never constructs an `OwnedFleet`,
+    /// so this stays `Some` for every real `OwnedFleet` today — the `Option`
+    /// only future-proofs a handoff `OwnedFleet` should one ever be built.
     #[allow(dead_code)] // RAII guard: drop releases daemon lock
-    pub lock: DaemonLock,
+    pub lock: Option<DaemonLock>,
 }
 
 /// Attached state: an existing daemon owns the run dir. We read its cookie so
@@ -180,11 +185,44 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     }
 
     // We hold the exclusive daemon lock, so no one else is attaching or
-    // creating run dirs. Sweep any `~/.agend/run/*` left behind by prior
-    // daemons whose PIDs have since been recycled — otherwise the first
-    // one `find_active_run_dir` visits on a later app launch can lure that
-    // process into attaching to a dead daemon (symptom: input lag from 2s
-    // port-poll hitting closed sockets).
+    // creating run dirs. These boot-hygiene sweeps are DESTRUCTIVE (remove
+    // stale run dirs, env-gated zombie kill, mutate shared watch/pr-state
+    // files) and assume sole-daemon ownership — hence they run only under the
+    // lock. #1814: the successor-handoff path runs the SAME set, but only
+    // AFTER it acquires the flock (see `daemon::run_successor_handoff`), never
+    // during the two-daemon overlap window.
+    boot_hygiene_sweeps(home);
+
+    let run_dir = crate::daemon::run_dir(home);
+    std::fs::create_dir_all(&run_dir)
+        .with_context(|| format!("create run dir {}", run_dir.display()))?;
+    crate::daemon::write_daemon_id(&run_dir);
+
+    let cookie = crate::auth_cookie::issue(&run_dir).context("issue api.cookie")?;
+
+    let (config, agents, telegram) = resolve_fleet_and_reconcile(home, fleet_path, &opts)?;
+
+    Ok(BootstrapOutcome::Owned(Box::new(OwnedFleet {
+        home: home.to_path_buf(),
+        fleet_path: fleet_path.to_path_buf(),
+        config,
+        agents,
+        run_dir,
+        cookie,
+        telegram,
+        lock: Some(lock),
+    })))
+}
+
+/// Destructive boot-hygiene sweeps that assume sole-daemon ownership. Extracted
+/// (#1814) so the successor-handoff path can run the IDENTICAL set, but gated
+/// behind the flock so it never races a still-live predecessor. Behaviour for
+/// the normal `prepare` path is unchanged — same calls, same order.
+pub(crate) fn boot_hygiene_sweeps(home: &Path) {
+    // Sweep any `~/.agend/run/*` left behind by prior daemons whose PIDs have
+    // since been recycled — otherwise the first one `find_active_run_dir`
+    // visits on a later app launch can lure that process into attaching to a
+    // dead daemon (symptom: input lag from 2s port-poll hitting closed sockets).
     time_step("sweep_stale_run_dirs", || {
         crate::daemon::sweep_stale_run_dirs(home);
     });
@@ -230,14 +268,31 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
             );
         }
     });
+}
 
-    let run_dir = crate::daemon::run_dir(home);
-    std::fs::create_dir_all(&run_dir)
-        .with_context(|| format!("create run dir {}", run_dir.display()))?;
-    crate::daemon::write_daemon_id(&run_dir);
+/// Result of [`resolve_fleet_and_reconcile`]: the normalized fleet config, the
+/// spawn-ready agent defs, and the (optional) inited channel.
+pub(crate) type ResolvedFleet = (
+    crate::fleet::FleetConfig,
+    Vec<AgentDef>,
+    Option<Arc<dyn crate::channel::Channel>>,
+);
 
-    let cookie = crate::auth_cookie::issue(&run_dir).context("issue api.cookie")?;
-
+/// Load + normalize the fleet, resolve every instance into a spawn-ready
+/// [`AgentDef`], init the channel, and run the shared-state reconciles
+/// (binding / worktree-lease / canonical-hygiene / task-orphan sweeps).
+///
+/// Extracted (#1814) so the successor-handoff path can run the IDENTICAL work
+/// AFTER it has acquired the flock. These steps MUTATE shared state and
+/// several (notably `release_inprogress_orphans`, which assumes `live = ∅`)
+/// are only correct when this process is the sole daemon — so the handoff path
+/// must never call this during the two-daemon overlap window. Behaviour for
+/// the normal `prepare` path is unchanged — same calls, same order.
+pub(crate) fn resolve_fleet_and_reconcile(
+    home: &Path,
+    fleet_path: &Path,
+    opts: &PrepareOptions,
+) -> Result<ResolvedFleet> {
     let mut config = crate::fleet::FleetConfig::load(fleet_path)?;
     fleet_normalize::normalize(&mut config, home, opts.mutate_fleet_yaml);
 
@@ -322,16 +377,54 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
         crate::tasks::release_inprogress_orphans_with_live(home, &std::collections::HashSet::new());
     });
 
-    Ok(BootstrapOutcome::Owned(Box::new(OwnedFleet {
-        home: home.to_path_buf(),
-        fleet_path: fleet_path.to_path_buf(),
-        config,
-        agents,
-        run_dir,
-        cookie,
-        telegram,
-        lock,
-    })))
+    Ok((config, agents, telegram))
+}
+
+/// #1814 successor-handoff pre-lock minimal prep. The successor process runs
+/// ONLY this before binding its control socket: create the run dir, write the
+/// `.daemon` identity, and issue the api cookie — the bare minimum
+/// `api::serve` needs to bind + publish `api.port` so the predecessor can
+/// Phase-1-probe it. It deliberately SKIPS the singleton attach-reject guard
+/// (the predecessor is intentionally still alive), the flock (the predecessor
+/// still holds it), and ALL destructive reconciles / fleet resolve — those run
+/// later, after the successor acquires the flock (see
+/// `daemon::run_successor_handoff`). Returns the run dir for the caller.
+pub fn prepare_handoff_prelock(home: &Path) -> Result<PathBuf> {
+    std::fs::create_dir_all(home).with_context(|| format!("create home {}", home.display()))?;
+    let run_dir = crate::daemon::run_dir(home);
+    std::fs::create_dir_all(&run_dir)
+        .with_context(|| format!("create run dir {}", run_dir.display()))?;
+    crate::daemon::write_daemon_id(&run_dir);
+    crate::auth_cookie::issue(&run_dir).context("issue api.cookie (handoff pre-lock)")?;
+    Ok(run_dir)
+}
+
+/// Blocking variant of [`acquire_daemon_lock`] used by the successor-handoff
+/// path: poll `try_lock` every 100ms until the predecessor releases
+/// `.daemon.lock` (by exiting) or `ceiling` elapses. The predecessor's exit is
+/// the handoff commit point; this is how the successor waits for it without a
+/// double-bound window. A timeout is a backstop for a predecessor that hangs in
+/// shutdown — the successor then gives up and exits (its run dir is swept later).
+pub(crate) fn acquire_daemon_lock_blocking(
+    home: &Path,
+    ceiling: std::time::Duration,
+) -> Result<DaemonLock> {
+    let path = home.join(".daemon.lock");
+    let file = std::fs::File::create(&path).with_context(|| format!("open {}", path.display()))?;
+    let deadline = std::time::Instant::now() + ceiling;
+    loop {
+        // Explicit trait method (MSRV 1.87): Err == lock held by predecessor.
+        if fs4::FileExt::try_lock(&file).is_ok() {
+            return Ok(DaemonLock { _file: file });
+        }
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "successor: predecessor did not release .daemon.lock within {:?} — aborting handoff",
+                ceiling
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 }
 
 /// Return `Some(AttachedFleet)` if a live daemon owns the run dir, else `None`.

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -394,7 +394,15 @@ pub fn prepare_handoff_prelock(home: &Path) -> Result<PathBuf> {
     let run_dir = crate::daemon::run_dir(home);
     std::fs::create_dir_all(&run_dir)
         .with_context(|| format!("create run dir {}", run_dir.display()))?;
-    crate::daemon::write_daemon_id(&run_dir);
+    // #1814 (reviewer race High, FIX1): do NOT write the `.daemon` identity
+    // file here. Writing it pre-flock would make `find_active_run_dir` treat
+    // this half-promoted successor as a discoverable primary during the overlap
+    // window (split-brain — generic clients could route to a no-agent daemon).
+    // `.daemon` is written only AFTER the flock is acquired (see
+    // `run_successor_handoff` → post-lock `write_daemon_id`). The predecessor's
+    // Phase-1 probe reaches us by NAME (`connect_run_dir_api` on our run dir),
+    // not via `find_active_run_dir`, so omitting `.daemon` here is harmless to
+    // the handshake.
     crate::auth_cookie::issue(&run_dir).context("issue api.cookie (handoff pre-lock)")?;
     Ok(run_dir)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,18 @@ use std::path::Path;
 /// and `app` entry points through the same seam — see the `bootstrap` module
 /// docs for the bug this addresses.
 pub fn start_with_fleet(home: &Path, fleet_path: &Path) -> anyhow::Result<()> {
+    // #1814 Stage 1: a successor spawned by `restart_daemon` carries a
+    // legitimate `AGEND_SUCCESSOR_HANDOFF` marker and MUST take the minimal
+    // pre-lock handoff boot path — NOT the full `prepare` (which would run the
+    // destructive sole-daemon reconciles while the predecessor is still alive).
+    // The marker is set only by `spawn_successor_handoff`; a normal/operator
+    // start never carries it, so this is a no-op for every non-handoff boot.
+    if crate::daemon::restart::successor_handoff_marker().is_some() {
+        tracing::info!(
+            "#1814: AGEND_SUCCESSOR_HANDOFF present — taking successor-handoff boot path"
+        );
+        return crate::daemon::run_successor_handoff(home, fleet_path);
+    }
     match crate::bootstrap::prepare(home, fleet_path, Default::default())? {
         crate::bootstrap::BootstrapOutcome::Owned(prepared) => {
             if prepared.agents.is_empty() {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -152,6 +152,64 @@ pub(crate) static SHUTDOWN_REASON: AtomicU8 = AtomicU8::new(0);
 /// without API-layer plumbing.
 pub(crate) static RESTART_PENDING: AtomicBool = AtomicBool::new(false);
 
+/// #1814 FIX2 (reviewer race High): the spawned successor's child handle, parked
+/// by `handle_self_respawn` at commit so the run_core loop can do a FINAL
+/// liveness recheck (`try_wait`, which also reaps) before the irreversible
+/// teardown. Phase-1 only proves the successor was healthy at probe time; it has
+/// not yet acquired the flock / spawned agents. If it dies in the commit→exit
+/// window, exiting anyway would brick the control plane — so the loop aborts
+/// (clears RESTART_PENDING, stays alive) instead. (Residual: a successor that
+/// dies AFTER the predecessor has already exited needs an external supervisor —
+/// the d-2 step-6 accepted residual, not closable here.)
+static SELF_RESPAWN_SUCCESSOR: std::sync::Mutex<Option<std::process::Child>> =
+    std::sync::Mutex::new(None);
+
+/// #1814 FIX2: park the successor child handle for the pre-exit liveness recheck.
+pub(crate) fn park_self_respawn_successor(child: std::process::Child) {
+    *SELF_RESPAWN_SUCCESSOR
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = Some(child);
+}
+
+/// #1814 FIX2: true iff a parked successor has already exited (`try_wait` reaps
+/// it). `None` parked → false (no self-respawn in flight).
+fn self_respawn_successor_died() -> bool {
+    let mut guard = SELF_RESPAWN_SUCCESSOR
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    match guard.as_mut() {
+        Some(child) => matches!(child.try_wait(), Ok(Some(_))),
+        None => false,
+    }
+}
+
+/// #1814 FIX2: when the shutdown flag is set, decide whether to truly tear down.
+/// For a self-respawn restart, do a final successor-liveness recheck; if the
+/// successor died after commit, ABORT-STAY-ALIVE (clear the flags, drop the
+/// dead handle, keep serving). Returns `true` → break the loop (teardown);
+/// `false` → keep running. (Residual race: an in-flight api session could
+/// re-set the shutdown flag from a stale RESTART_PENDING read after we clear it
+/// → the next iteration would then exit; this is no worse than pre-FIX2 and the
+/// window is vanishingly small.)
+fn confirm_shutdown_or_abort_respawn(shutdown: &AtomicBool) -> bool {
+    if !RESTART_PENDING.load(Ordering::Acquire) || !crate::daemon::restart::self_respawn_enabled() {
+        return true;
+    }
+    if self_respawn_successor_died() {
+        tracing::error!(
+            "#1814 self-respawn: successor died after commit but before predecessor exit — \
+             ABORTING restart, staying alive (no brick). Operator may retry restart_daemon."
+        );
+        RESTART_PENDING.store(false, Ordering::Release);
+        shutdown.store(false, Ordering::Relaxed);
+        *SELF_RESPAWN_SUCCESSOR
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = None;
+        return false;
+    }
+    true
+}
+
 /// Record the reason the daemon is shutting down. Idempotent on
 /// re-entry (first-write-wins via `compare_exchange`); safe to
 /// call from signal handlers + API threads + watchdog without
@@ -249,8 +307,22 @@ pub fn find_active_run_dir(home: &Path) -> Option<PathBuf> {
                     continue;
                 }
             }
-            // No .daemon file but PID alive → legacy or corrupted, accept it
-            return Some(entry.path());
+            // No (valid) `.daemon` identity file but PID alive → NOT discoverable.
+            // #1814 (reviewer race High): a handoff successor publishes its
+            // run dir + api.port pre-flock (so the predecessor can Phase-1-probe
+            // it by name via `connect_run_dir_api`) but writes `.daemon` only
+            // AFTER it acquires the flock (promotes). Skipping un-`.daemon`'d
+            // dirs here keeps a half-promoted successor invisible to generic
+            // discovery during the overlap window — generic clients route only
+            // to the fully-promoted daemon (single-primary-lease invariant). A
+            // normal daemon writes `.daemon` at boot (microsecond gap), so this
+            // never hides a real primary. (Pre-#1814 this fell through to
+            // "accept it" for a since-extinct legacy/no-`.daemon` daemon class.)
+            tracing::debug!(
+                path = %entry.path().display(),
+                "#1814: run dir has no `.daemon` identity (pre-promote successor or mid-boot) — not discoverable yet"
+            );
+            continue;
         }
     }
     None
@@ -618,10 +690,26 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
         FleetSource::Resolved { agents, .. } => (agents, None::<crate::bootstrap::DaemonLock>),
         FleetSource::HandoffDeferred { fleet_path, opts } => {
             write_control_ready(home);
+            // §3.9 FIX2 test seam: pass Phase-1 (api stays up to answer STATUS
+            // for a moment) then die BEFORE acquiring the flock — exercises the
+            // predecessor's commit→exit liveness recheck (abort-stay-alive).
+            if std::env::var("AGEND_FORCE_SUCCESSOR_FAIL_AFTER_CONTROL_READY").as_deref() == Ok("1")
+            {
+                tracing::warn!(
+                    "#1814 AGEND_FORCE_SUCCESSOR_FAIL_AFTER_CONTROL_READY=1 — successor answering Phase-1 then aborting before flock (test seam)"
+                );
+                std::thread::sleep(std::time::Duration::from_secs(3));
+                std::process::exit(1);
+            }
             tracing::info!(
                 "#1814 successor-handoff: control-ready; waiting for predecessor to release flock"
             );
             let lock = crate::bootstrap::acquire_daemon_lock_blocking(home, HANDOFF_LOCK_WAIT)?;
+            // #1814 FIX1: NOW that we hold the flock (predecessor has exited),
+            // publish the `.daemon` identity so generic discovery
+            // (`find_active_run_dir`) starts routing to us. Before this point we
+            // were intentionally undiscoverable (pre-flock = not the primary).
+            write_daemon_id(&run_dir(home));
             tracing::info!(
                 "#1814 successor-handoff: flock acquired — sole daemon, running deferred reconciles + resolve"
             );
@@ -649,7 +737,12 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
 
     loop {
         if ctx.shutdown.load(Ordering::Relaxed) {
-            break;
+            // #1814 FIX2: a set shutdown flag from a self-respawn commit only
+            // tears down if the successor is still alive; otherwise abort-stay-alive.
+            if confirm_shutdown_or_abort_respawn(&ctx.shutdown) {
+                break;
+            }
+            continue;
         }
 
         let exit_event: Option<crate::agent::AgentExitEvent>;
@@ -677,7 +770,10 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
         };
 
         if ctx.shutdown.load(Ordering::Relaxed) {
-            break;
+            if confirm_shutdown_or_abort_respawn(&ctx.shutdown) {
+                break;
+            }
+            continue;
         }
         match exit_event {
             crate::agent::AgentExitEvent::CleanExit(ref name) => {
@@ -760,6 +856,15 @@ fn init_daemon_services(
         ..crate::daemon_config::DaemonConfig::default()
     });
 
+    // #1814 FIX3 (reviewer-2, non-blocking) TODO(Stage 2): the three shared-
+    // state GC/migration steps below (skills::cleanup_stale_stages,
+    // dedup_state::cleanup_tmp_orphans, tasks::migrate_legacy_tasks_json_to_event_log)
+    // run inside `init_daemon_services`, which on the successor-handoff path
+    // executes PRE-flock (before the predecessor exits) — technically escaping
+    // the "minimal pre-lock" contract. Low risk for now (the first two are
+    // retention-gated; the third is idempotent), so left in place for Stage 1.
+    // Stage 2 should split `init_daemon_services` (as `prepare` was split into
+    // pre/post-lock) so these run only after the handoff successor holds the flock.
     const SKILLS_STAGE_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
     crate::bootstrap::time_step("skills::cleanup_stale_stages", || {
         match crate::skills::cleanup_stale_stages(home, SKILLS_STAGE_RETENTION_SECS, &[]) {
@@ -1725,6 +1830,49 @@ mod tests {
         let found = find_active_run_dir(&home);
         assert!(found.is_none());
         assert!(!run.exists());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1814 FIX1 (reviewer race High): a run dir with an alive pid but NO
+    /// `.daemon` identity file (= a handoff successor that has published its api
+    /// pre-flock but NOT yet promoted) must NOT be discoverable via
+    /// `find_active_run_dir`. Otherwise generic CLI/MCP clients could route to a
+    /// half-promoted, no-agent successor during the overlap window (split-brain).
+    #[test]
+    fn find_active_run_dir_skips_dir_without_daemon_identity() {
+        let home = tmp_home("no_daemon_identity");
+        let pid = std::process::id(); // this test process — guaranteed alive
+        let run = home.join("run").join(pid.to_string());
+        std::fs::create_dir_all(&run).ok();
+        // Successor pre-promote shape: api.port published, but NO `.daemon`.
+        crate::ipc::write_port(&run, crate::ipc::API_NAME, 65000).ok();
+        assert!(
+            find_active_run_dir(&home).is_none(),
+            "a run dir without a `.daemon` identity must not be discoverable (pre-promote successor)"
+        );
+        // The dir must survive (it's a live successor mid-handoff, not stale).
+        assert!(
+            run.exists(),
+            "must NOT delete the un-promoted successor's run dir"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1814 FIX1 companion: once the `.daemon` identity (matching pid) IS
+    /// present (= the successor promoted post-flock), the dir becomes
+    /// discoverable again — the normal-daemon path is unchanged.
+    #[test]
+    fn find_active_run_dir_returns_dir_with_valid_daemon_identity() {
+        let home = tmp_home("valid_daemon_identity");
+        let pid = std::process::id();
+        let run = home.join("run").join(pid.to_string());
+        std::fs::create_dir_all(&run).ok();
+        write_daemon_id(&run); // writes `<pid>:<ts>` for the current (alive) pid
+        assert_eq!(
+            find_active_run_dir(&home).as_deref(),
+            Some(run.as_path()),
+            "a run dir with a valid matching `.daemon` must be discoverable"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -210,6 +210,19 @@ fn confirm_shutdown_or_abort_respawn(shutdown: &AtomicBool) -> bool {
     true
 }
 
+/// #1814 round-2: settle window before the FINAL pre-exit liveness recheck (the
+/// recover-as-primary gate in `run_core`). Gives a successor that is crashing
+/// around the predecessor's teardown a moment to surface so the recheck catches
+/// it. Env-overridable (`AGEND_SELF_RESPAWN_SETTLE_SECS`) — tests widen it so
+/// the cross-process death lands deterministically inside the recheck window.
+fn self_respawn_settle() -> std::time::Duration {
+    let secs = std::env::var("AGEND_SELF_RESPAWN_SETTLE_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(1);
+    std::time::Duration::from_secs(secs)
+}
+
 /// Record the reason the daemon is shutting down. Idempotent on
 /// re-entry (first-write-wins via `compare_exchange`); safe to
 /// call from signal handlers + API threads + watchdog without
@@ -701,6 +714,17 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
                 std::thread::sleep(std::time::Duration::from_secs(3));
                 std::process::exit(1);
             }
+            // §3.9 round-2 test seam: stay alive LONG enough to pass the
+            // predecessor's loop-break recheck (so teardown begins), then die
+            // DURING the predecessor's teardown window — exercises the final
+            // recover-as-primary gate (predecessor re-spawns agents + resumes).
+            if std::env::var("AGEND_FORCE_SUCCESSOR_FAIL_DURING_TEARDOWN").as_deref() == Ok("1") {
+                tracing::warn!(
+                    "#1814 AGEND_FORCE_SUCCESSOR_FAIL_DURING_TEARDOWN=1 — successor surviving Phase-1 + loop-break, dying in teardown window (test seam)"
+                );
+                std::thread::sleep(std::time::Duration::from_secs(15));
+                std::process::exit(1);
+            }
             tracing::info!(
                 "#1814 successor-handoff: control-ready; waiting for predecessor to release flock"
             );
@@ -735,79 +759,127 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
 
     let (_keepalive, handlers, tick_rx) = build_tick_infrastructure(home, &ctx);
 
-    loop {
-        if ctx.shutdown.load(Ordering::Relaxed) {
-            // #1814 FIX2: a set shutdown flag from a self-respawn commit only
-            // tears down if the successor is still alive; otherwise abort-stay-alive.
-            if confirm_shutdown_or_abort_respawn(&ctx.shutdown) {
-                break;
-            }
-            continue;
-        }
-
-        let exit_event: Option<crate::agent::AgentExitEvent>;
-        crossbeam_channel::select! {
-            recv(ctx.crash_rx) -> msg => { exit_event = msg.ok(); }
-            recv(tick_rx) -> _ => { exit_event = None; }
-            recv(shutdown_rx) -> _ => { continue; }
-        }
-
-        let tick_ctx = per_tick::TickContext {
-            home,
-            registry: &ctx.registry,
-            externals: &ctx.externals,
-            configs: &ctx.configs,
-        };
-        crate::runtime_config::reload(home);
-        // #1339: operator-mode.json reloaded each tick — a mode change (via the
-        // `mode` MCP tool) propagates fleet-wide without a restart (reload-coherent).
-        crate::operator_mode::reload(home);
-        per_tick::run_handlers_with_panic_guard(&handlers, &tick_ctx);
-
-        let exit_event = match exit_event {
-            Some(e) => e,
-            None => continue,
-        };
-
-        if ctx.shutdown.load(Ordering::Relaxed) {
-            if confirm_shutdown_or_abort_respawn(&ctx.shutdown) {
-                break;
-            }
-            continue;
-        }
-        match exit_event {
-            crate::agent::AgentExitEvent::CleanExit(ref name) => {
-                tracing::info!(agent = %name, "clean exit — removing from registry (no respawn)");
-                // #1441: registry is UUID-keyed; resolve name via fleet.yaml.
-                if let Some(id) = crate::fleet::resolve_uuid(home, name) {
-                    ctx.registry.lock().remove(&id);
+    // #1814 round-2: `'serve` wraps the tick loop + teardown so the final
+    // recover-as-primary gate (below) can `continue 'serve` to resume serving if
+    // the successor dies during the predecessor's teardown — instead of exiting
+    // into a brick. Flag-off never enters the recover gate, so it falls straight
+    // through to the byte-identical exit path after the loop.
+    'serve: loop {
+        loop {
+            if ctx.shutdown.load(Ordering::Relaxed) {
+                // #1814 FIX2: a set shutdown flag from a self-respawn commit only
+                // tears down if the successor is still alive; otherwise abort-stay-alive.
+                if confirm_shutdown_or_abort_respawn(&ctx.shutdown) {
+                    break;
                 }
-                ctx.configs.lock().remove(name.as_str());
+                continue;
             }
-            crate::agent::AgentExitEvent::Stage2Restart(name) => {
-                spawn_stage2_thread(home, &name, &ctx);
+
+            let exit_event: Option<crate::agent::AgentExitEvent>;
+            crossbeam_channel::select! {
+                recv(ctx.crash_rx) -> msg => { exit_event = msg.ok(); }
+                recv(tick_rx) -> _ => { exit_event = None; }
+                recv(shutdown_rx) -> _ => { continue; }
             }
-            crate::agent::AgentExitEvent::Crash(name) => {
-                crash_respawn::handle_crash_respawn(home, &name, &ctx);
+
+            let tick_ctx = per_tick::TickContext {
+                home,
+                registry: &ctx.registry,
+                externals: &ctx.externals,
+                configs: &ctx.configs,
+            };
+            crate::runtime_config::reload(home);
+            // #1339: operator-mode.json reloaded each tick — a mode change (via the
+            // `mode` MCP tool) propagates fleet-wide without a restart (reload-coherent).
+            crate::operator_mode::reload(home);
+            per_tick::run_handlers_with_panic_guard(&handlers, &tick_ctx);
+
+            let exit_event = match exit_event {
+                Some(e) => e,
+                None => continue,
+            };
+
+            if ctx.shutdown.load(Ordering::Relaxed) {
+                if confirm_shutdown_or_abort_respawn(&ctx.shutdown) {
+                    break;
+                }
+                continue;
+            }
+            match exit_event {
+                crate::agent::AgentExitEvent::CleanExit(ref name) => {
+                    tracing::info!(agent = %name, "clean exit — removing from registry (no respawn)");
+                    // #1441: registry is UUID-keyed; resolve name via fleet.yaml.
+                    if let Some(id) = crate::fleet::resolve_uuid(home, name) {
+                        ctx.registry.lock().remove(&id);
+                    }
+                    ctx.configs.lock().remove(name.as_str());
+                }
+                crate::agent::AgentExitEvent::Stage2Restart(name) => {
+                    spawn_stage2_thread(home, &name, &ctx);
+                }
+                crate::agent::AgentExitEvent::Crash(name) => {
+                    crash_respawn::handle_crash_respawn(home, &name, &ctx);
+                }
             }
         }
+
+        log_residual_worktrees(home);
+
+        let metrics = shutdown_sequence(home, &ctx.registry, started_at);
+        crate::event_log::log(
+            home,
+            "daemon_stop",
+            "",
+            &format!(
+                "reason={} agents_total={} agents_killed_after_grace={} uptime_secs={}",
+                metrics.reason.as_str(),
+                metrics.agents_total,
+                metrics.agents_killed_after_grace,
+                metrics.uptime_secs
+            ),
+        );
+
+        // #1814 round-2 (reviewer TOCTOU): FINAL recover-as-primary gate. We have
+        // killed our agents (`shutdown_sequence` drained the registry) but the run
+        // dir + cookie + api-server thread are STILL intact (`remove_dir_all` below
+        // hasn't run). This is the last point before the irreversible exit/flock-
+        // release. Re-check the successor's liveness as late as possible:
+        //   • successor DEAD → do NOT exit. Recover as primary: clear the restart
+        //     flags, re-spawn our fleet agents into the (still-live) registry, and
+        //     `continue 'serve` to resume serving. No brick; agents re-spawned.
+        //   • successor ALIVE → commit: drop the run dir and exit(0) IMMEDIATELY
+        //     (no intervening sleep) so the only un-closable window is the
+        //     microseconds between this check and the exit syscall (the d-2 step-6
+        //     residual — a successor death after THIS point needs an external
+        //     supervisor and is out of scope for Stage 1).
+        // Flag-off never enters this block → it falls through to the byte-identical
+        // exit path after `'serve`.
+        if RESTART_PENDING.load(Ordering::Acquire) && crate::daemon::restart::self_respawn_enabled()
+        {
+            std::thread::sleep(self_respawn_settle());
+            if self_respawn_successor_died() {
+                tracing::error!(
+                "#1814 self-respawn: successor died DURING predecessor teardown — recovering as \
+                 primary (re-spawning agents, resuming; no brick)."
+            );
+                RESTART_PENDING.store(false, Ordering::Release);
+                ctx.shutdown.store(false, Ordering::Relaxed);
+                *SELF_RESPAWN_SUCCESSOR
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()) = None;
+                let _ = std::fs::remove_file(home.join("restart-requested"));
+                spawn_fleet_agents(home, &agents, &ctx);
+                continue 'serve;
+            }
+            let _ = std::fs::remove_file(home.join("restart-requested"));
+            let _ = std::fs::remove_dir_all(run_dir(home));
+            tracing::info!("#1814 self-respawn: successor healthy through teardown — exiting 0");
+            std::process::exit(0);
+        }
+
+        break 'serve;
     }
 
-    log_residual_worktrees(home);
-
-    let metrics = shutdown_sequence(home, &ctx.registry, started_at);
-    crate::event_log::log(
-        home,
-        "daemon_stop",
-        "",
-        &format!(
-            "reason={} agents_total={} agents_killed_after_grace={} uptime_secs={}",
-            metrics.reason.as_str(),
-            metrics.agents_total,
-            metrics.agents_killed_after_grace,
-            metrics.uptime_secs
-        ),
-    );
     let _ = std::fs::remove_dir_all(run_dir(home));
     std::thread::sleep(std::time::Duration::from_secs(1));
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -190,7 +190,14 @@ pub(super) struct DaemonContext {
 
 /// Get the PID-isolated run directory for the current daemon.
 pub fn run_dir(home: &Path) -> PathBuf {
-    home.join("run").join(std::process::id().to_string())
+    run_dir_for_pid(home, std::process::id())
+}
+
+/// Run dir for an arbitrary daemon `pid` (`home/run/<pid>`). #1814: the
+/// self-respawn Phase-1 gate needs the SUCCESSOR's run dir (a different pid),
+/// which `run_dir` — pinned to the current process — can't give.
+pub fn run_dir_for_pid(home: &Path, pid: u32) -> PathBuf {
+    home.join("run").join(pid.to_string())
 }
 
 /// #1812: the SINGLE process-wide lock that every test mutating (or
@@ -379,7 +386,13 @@ pub fn run(home: &Path, agents: Vec<AgentDef>) -> anyhow::Result<()> {
         }
     }
 
-    run_core(home, agents, None)
+    run_core(
+        home,
+        FleetSource::Resolved {
+            agents,
+            telegram: None,
+        },
+    )
 }
 
 /// Start daemon with a fleet already prepared by [`crate::bootstrap::prepare`].
@@ -410,7 +423,7 @@ pub fn run_with_prepared(mut prepared: Box<crate::bootstrap::OwnedFleet>) -> any
     // trusted source at startup to tell them apart. Unsigned bindings fail closed
     // (unbound) and re-sign on their next dispatch / bind_self.
     let _owned = prepared;
-    run_core(&home, agents, telegram)
+    run_core(&home, FleetSource::Resolved { agents, telegram })
 }
 
 /// Sprint 57 Wave 3 PR-2 (#548 Q3 contract pin): this daemon does
@@ -508,20 +521,116 @@ pub(crate) fn build_default_handlers(
 /// across all daemon processes). Per-PID identity is at
 /// `$AGEND_HOME/run/<pid>/.daemon` (PID-recycling guard for
 /// discovery — distinct purpose from the exclusive lock).
-fn run_core(
-    home: &Path,
-    agents: Vec<AgentDef>,
-    telegram: Option<Arc<dyn crate::channel::Channel>>,
-) -> anyhow::Result<()> {
+/// Where `run_core` sources its fleet from.
+///
+/// `Resolved` is the normal path: `bootstrap::prepare` already resolved the
+/// agents (and channel) under the flock. `HandoffDeferred` is the #1814
+/// successor-handoff path: the agents are NOT resolved yet because the
+/// destructive reconciles + resolve MUST wait until this successor acquires
+/// the flock (after the predecessor exits), never running in the two-daemon
+/// overlap window.
+enum FleetSource {
+    Resolved {
+        agents: Vec<AgentDef>,
+        telegram: Option<Arc<dyn crate::channel::Channel>>,
+    },
+    HandoffDeferred {
+        fleet_path: PathBuf,
+        opts: crate::bootstrap::PrepareOptions,
+    },
+}
+
+/// #1814: how long a successor waits for its predecessor to release the flock
+/// (by exiting) after Phase-1 passed. Generous — the predecessor only needs to
+/// run `shutdown_sequence` (≤2s grace) + a 1s settle before exit. A timeout is
+/// a backstop for a predecessor wedged in shutdown.
+const HANDOFF_LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// #1814: marker file a handoff successor writes once its control plane (api
+/// socket) is bound, signalling the predecessor's Phase-1 gate that the
+/// control plane is ready. Distinct from `.ready` (which means "agent spawn
+/// loop complete" and is written only after promotion).
+pub const CONTROL_READY_FILE: &str = "control-ready";
+
+/// #1814 successor-handoff boot entry. Runs the minimal pre-lock prep (run dir
+/// and cookie), then `run_core` in deferred-fleet mode: bind api, write
+/// control-ready, block on the flock until the predecessor exits, then run the
+/// destructive reconciles, resolve, and spawn agents. Routed to from the
+/// `start` command only when a legitimate `AGEND_SUCCESSOR_HANDOFF` marker is
+/// present.
+pub fn run_successor_handoff(home: &Path, fleet_path: &Path) -> anyhow::Result<()> {
+    tracing::info!("#1814 successor-handoff boot: minimal pre-lock prep (no flock, no reconcile)");
+    // §3.9 test injection seam: force the successor to crash on launch (before
+    // it writes control-ready) so the integration test can exercise the
+    // predecessor's abort-stay-alive path against a REAL spawned successor.
+    // Only the handoff boot path reads this — a normal start never reaches here.
+    if std::env::var("AGEND_FORCE_SUCCESSOR_FAIL").as_deref() == Ok("1") {
+        tracing::warn!(
+            "#1814 AGEND_FORCE_SUCCESSOR_FAIL=1 — successor aborting on launch (test seam)"
+        );
+        std::process::exit(1);
+    }
+    crate::bootstrap::prepare_handoff_prelock(home)?;
+    run_core(
+        home,
+        FleetSource::HandoffDeferred {
+            fleet_path: fleet_path.to_path_buf(),
+            opts: crate::bootstrap::PrepareOptions::default(),
+        },
+    )
+}
+
+/// #1814: write the `control-ready` marker into this daemon's run dir.
+fn write_control_ready(home: &Path) {
+    let path = run_dir(home).join(CONTROL_READY_FILE);
+    if let Err(e) = std::fs::write(&path, chrono::Utc::now().to_rfc3339()) {
+        tracing::warn!(path = %path.display(), error = %e, "failed to write control-ready marker (handoff)");
+    }
+}
+
+fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
     let started_at = std::time::Instant::now();
 
-    let ctx = init_daemon_services(home, telegram)?;
+    // For the handoff path, the channel inits post-lock (its registry attaches
+    // via the #945 pending-registry bridge that `init_daemon_services` arms),
+    // so pass None here; `Resolved` carries the already-inited channel.
+    let telegram_pre = match &source {
+        FleetSource::Resolved { telegram, .. } => telegram.clone(),
+        FleetSource::HandoffDeferred { .. } => None,
+    };
+
+    let ctx = init_daemon_services(home, telegram_pre)?;
 
     // #event-bus Step 2 (legacy-zero): register the per-pattern delivery
     // subscribers once (the bus is the SOLE delivery path). Shared with
     // `app::run_app` so owned `agend-terminal app` mode wires the IDENTICAL
     // set — see `register_event_subscribers`.
     register_event_subscribers(&ctx.registry);
+
+    // `init_daemon_services` has now bound + published this process's api port.
+    // For the handoff path the predecessor is still alive: signal control-ready
+    // (so its Phase-1 gate can confirm us), then block on the flock until it
+    // exits (the commit point), and ONLY THEN run the destructive reconciles +
+    // resolve. `_handoff_lock` holds the flock for the daemon's lifetime on the
+    // handoff path (None on the normal path, where `prepare`'s `OwnedFleet`
+    // already holds it).
+    let (agents, _handoff_lock) = match source {
+        FleetSource::Resolved { agents, .. } => (agents, None::<crate::bootstrap::DaemonLock>),
+        FleetSource::HandoffDeferred { fleet_path, opts } => {
+            write_control_ready(home);
+            tracing::info!(
+                "#1814 successor-handoff: control-ready; waiting for predecessor to release flock"
+            );
+            let lock = crate::bootstrap::acquire_daemon_lock_blocking(home, HANDOFF_LOCK_WAIT)?;
+            tracing::info!(
+                "#1814 successor-handoff: flock acquired — sole daemon, running deferred reconciles + resolve"
+            );
+            crate::bootstrap::boot_hygiene_sweeps(home);
+            let (_config, agents, _telegram) =
+                crate::bootstrap::resolve_fleet_and_reconcile(home, &fleet_path, &opts)?;
+            (agents, Some(lock))
+        }
+    };
 
     spawn_fleet_agents(home, &agents, &ctx);
 
@@ -609,6 +718,22 @@ fn run_core(
     if RESTART_PENDING.load(Ordering::Acquire) {
         let flag = home.join("restart-requested");
         let _ = std::fs::remove_file(&flag);
+        if crate::daemon::restart::self_respawn_enabled() {
+            // #1814: the restart handler already spawned + Phase-1-confirmed a
+            // successor. It is blocked on our flock and promotes the moment we
+            // exit, so exit(0) (not 42) — no external supervisor is required.
+            //
+            // KNOWN/INTENDED Stage-1 race: if an external supervisor (launchd
+            // `KeepAlive=true`, systemd `Restart`, the wrapper) is ALSO active,
+            // our exit triggers BOTH our successor AND an external respawn.
+            // This self-corrects via the flock — whichever process acquires
+            // `.daemon.lock` first becomes the daemon; the loser hits the
+            // singleton attach-reject guard in `bootstrap::prepare` and exits.
+            // Not a bug; flagged here + in the PR so reviewers don't file it as
+            // one. (Stage 2 downgrades `is_restart_supervised` to advisory.)
+            tracing::info!("#1814 self-respawn: successor confirmed healthy — exiting 0");
+            std::process::exit(0);
+        }
         tracing::info!("operator-initiated restart: exiting with code 42");
         std::process::exit(42);
     }

--- a/src/daemon/restart.rs
+++ b/src/daemon/restart.rs
@@ -88,6 +88,65 @@ fn has_env(name: &str) -> bool {
     std::env::var_os(name).is_some()
 }
 
+// ── #1814 Stage 1: self-respawn (flag-gated successor handoff) ──────────
+//
+// When `AGEND_RESTART_HANDOFF=1`, `restart_daemon` no longer relies on an
+// external supervisor + `exit(42)`. Instead the running daemon spawns its
+// OWN successor, confirms it is healthy (Phase-1 gate), and only then exits
+// (0). If the successor fails the gate, the old daemon never shuts down — it
+// stays alive with its agents intact (abort-stay-alive). This retires the
+// supervision-detection brick class (#851/#1812) at the root: restart no
+// longer hinges on a static env-var guess about whether something will
+// respawn the process. See decision d-20260606104934346030-2.
+//
+// Flag OFF (default) → behaviour is byte-identical to the pre-#1814
+// `is_restart_supervised()` + `exit(42)` path. Stage 1 is opt-in.
+
+/// Env flag enabling #1814 self-respawn. `"1"` activates; anything else (or
+/// unset) keeps the legacy supervisor + `exit(42)` path.
+pub const RESTART_HANDOFF_ENV: &str = "AGEND_RESTART_HANDOFF";
+
+/// Env marker the old daemon sets on the successor it spawns:
+/// `AGEND_SUCCESSOR_HANDOFF=<old_pid>:<token>`. Its presence (well-formed)
+/// is the ONLY signal that routes a boot through the minimal pre-lock handoff
+/// path; a normal / operator `agend-terminal start` never carries it and so
+/// always runs the full `bootstrap::prepare` (including the destructive
+/// reconciles that MUST NOT run in a two-daemon overlap window).
+pub const SUCCESSOR_HANDOFF_ENV: &str = "AGEND_SUCCESSOR_HANDOFF";
+
+/// True iff `AGEND_RESTART_HANDOFF=1`. Read at restart time (handler) and at
+/// daemon exit (to choose `exit(0)` vs `exit(42)`).
+pub fn self_respawn_enabled() -> bool {
+    std::env::var(RESTART_HANDOFF_ENV).as_deref() == Ok("1")
+}
+
+/// Parse a legitimate successor-handoff marker into `(old_pid, token)`.
+/// Returns `None` when the env is absent or malformed — the boot then takes
+/// the normal full-prepare path. "Legitimate" = `<u32 pid>:<non-empty token>`
+/// (the token guard the lead required so a stray/normal start can never skip
+/// the destructive reconciles).
+pub fn successor_handoff_marker() -> Option<(u32, String)> {
+    let raw = std::env::var(SUCCESSOR_HANDOFF_ENV).ok()?;
+    let (pid, token) = raw.split_once(':')?;
+    let pid: u32 = pid.parse().ok()?;
+    if token.is_empty() {
+        return None;
+    }
+    Some((pid, token.to_string()))
+}
+
+/// Build the `AGEND_SUCCESSOR_HANDOFF` env VALUE (`<old_pid>:<token>`) for a
+/// fresh successor spawn. The token is derived from the old pid + a monotonic
+/// nanos stamp so each handoff is distinguishable in logs; it carries no
+/// security role (the loopback api + cookie do).
+pub fn make_handoff_value(old_pid: u32) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{old_pid}:{old_pid}-{nanos}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -424,5 +483,68 @@ mod tests {
                 },
             );
         }
+    }
+
+    // ── #1814 self-respawn helpers ──────────────────────────────────────
+
+    #[test]
+    fn self_respawn_enabled_only_for_exactly_one() {
+        with_env(&[(RESTART_HANDOFF_ENV, "1")], &[], || {
+            assert!(self_respawn_enabled(), "AGEND_RESTART_HANDOFF=1 enables");
+        });
+        with_env(&[(RESTART_HANDOFF_ENV, "0")], &[], || {
+            assert!(!self_respawn_enabled(), "0 does not enable");
+        });
+        with_env(&[(RESTART_HANDOFF_ENV, "true")], &[], || {
+            assert!(!self_respawn_enabled(), "only the literal \"1\" enables");
+        });
+        with_env(&[], &[RESTART_HANDOFF_ENV], || {
+            assert!(!self_respawn_enabled(), "unset = off (flag-off default)");
+        });
+    }
+
+    #[test]
+    fn handoff_marker_parses_only_well_formed_values() {
+        // Well-formed → Some. This is the guard: only a legitimate marker
+        // routes a boot through the minimal pre-lock handoff path.
+        with_env(&[(SUCCESSOR_HANDOFF_ENV, "4321:4321-99")], &[], || {
+            assert_eq!(
+                successor_handoff_marker(),
+                Some((4321, "4321-99".to_string()))
+            );
+        });
+        // Absent → None (normal/operator start never skips reconciles).
+        with_env(&[], &[SUCCESSOR_HANDOFF_ENV], || {
+            assert_eq!(successor_handoff_marker(), None);
+        });
+        // Malformed → None (no colon / bad pid / empty token).
+        for bad in ["nopid", "abc:tok", "4321:", ":tok", ""] {
+            with_env(&[(SUCCESSOR_HANDOFF_ENV, bad)], &[], || {
+                assert_eq!(
+                    successor_handoff_marker(),
+                    None,
+                    "malformed {bad:?} must be rejected"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn make_handoff_value_round_trips_through_marker_parser() {
+        // The value `make_handoff_value` produces must be accepted by the
+        // parser the successor uses — pins the producer/consumer contract.
+        with_env(&[], &[], || {
+            let value = make_handoff_value(777);
+            let parsed = {
+                // SAFETY: serialised by with_env's lock; restored on exit.
+                unsafe { std::env::set_var(SUCCESSOR_HANDOFF_ENV, &value) };
+                let m = successor_handoff_marker();
+                unsafe { std::env::remove_var(SUCCESSOR_HANDOFF_ENV) };
+                m
+            };
+            let (pid, token) = parsed.expect("self-produced value must parse");
+            assert_eq!(pid, 777, "old pid prefix preserved");
+            assert!(!token.is_empty(), "token non-empty");
+        });
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -72,6 +72,18 @@ pub fn connect_api(home: &Path) -> Result<TcpStream> {
     connect_port(port).map_err(Into::into)
 }
 
+/// Connect to a SPECIFIC run dir's daemon api port (not the active one).
+///
+/// #1814: the self-respawn Phase-1 gate must reach the successor's OWN api
+/// port while both predecessor and successor are briefly alive — `connect_api`
+/// (which resolves via `find_active_run_dir`) could return either, so the gate
+/// targets the successor's run dir explicitly.
+pub fn connect_run_dir_api(run_dir: &Path) -> Result<TcpStream> {
+    let port = read_port(run_dir, API_NAME)
+        .with_context(|| format!("api.port missing/invalid in {}", run_dir.display()))?;
+    connect_port(port).map_err(Into::into)
+}
+
 /// Connect to a named agent's TUI port.
 pub fn connect_agent(home: &Path, name: &str) -> Result<TcpStream> {
     let run =

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -2,6 +2,16 @@ use serde_json::{json, Value};
 use std::path::Path;
 
 pub(super) fn handle_restart_daemon(home: &Path) -> Value {
+    // #1814 Stage 1: flag-gated self-respawn. When AGEND_RESTART_HANDOFF=1 the
+    // daemon owns its own respawn (spawn successor → Phase-1 health gate →
+    // abort-stay-alive on failure), so restart never hinges on an external
+    // supervisor being correctly detected (retires the #851/#1812 brick class
+    // at the root). Flag OFF → the legacy supervisor + exit(42) path below runs
+    // byte-identically.
+    if crate::daemon::restart::self_respawn_enabled() {
+        return handle_self_respawn(home);
+    }
+
     // #851 fail-closed: refuse the request when no supervisor will
     // respawn the daemon. Without this check, `restart_daemon` on a
     // bare `agend-terminal start` invocation would set
@@ -37,6 +47,114 @@ pub(super) fn handle_restart_daemon(home: &Path) -> Value {
     std::fs::write(home.join("restart-requested"), "").ok();
     let _ = crate::api::call(home, &json!({"method": crate::api::method::SHUTDOWN}));
     json!({"ok": true, "restart": "pending", "note": "daemon will exit(42) after graceful shutdown; supervisor restarts"})
+}
+
+/// #1814 self-respawn orchestration (runs in the daemon's `mcp_tool_*` worker
+/// thread, NOT the api accept loop — see `api::serve` thread-per-connection):
+/// spawn a successor, gate on its health, and only commit the predecessor's
+/// shutdown if the successor is confirmed up. On failure the predecessor is
+/// never signalled → it stays fully alive with its agents intact.
+fn handle_self_respawn(home: &Path) -> Value {
+    let old_pid = std::process::id();
+    let handoff_value = crate::daemon::restart::make_handoff_value(old_pid);
+    let mut succ = match crate::bootstrap::daemon_spawn::spawn_successor_handoff(
+        home,
+        &handoff_value,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            return json!({
+                "ok": false,
+                "error": format!("self-respawn: failed to spawn successor: {e}; daemon stays alive")
+            });
+        }
+    };
+    tracing::info!(
+        successor_pid = succ.pid,
+        "#1814 self-respawn: successor spawned — running Phase-1 health gate"
+    );
+
+    if phase1_gate(&mut succ) {
+        // Successor healthy → COMMIT. Set RESTART_PENDING ONLY; do NOT send an
+        // api SHUTDOWN. The existing `handle_session` bridge (api/mod.rs: "the
+        // restart_daemon MCP handler sets RESTART_PENDING … bridge it here") flips
+        // the daemon's shutdown flag on the next api-loop iteration → the main
+        // loop breaks → the run_core tail sees RESTART_PENDING + self_respawn and
+        // exits(0), releasing the flock so the (blocked) successor promotes.
+        //
+        // We deliberately AVOID `api::call(home, SHUTDOWN)` here: during the
+        // handoff overlap BOTH daemons are alive with a published api.port, so its
+        // `find_active_run_dir` is ambiguous and could deliver SHUTDOWN to the
+        // freshly-bound SUCCESSOR — which then shuts itself down the instant it
+        // promotes (observed). RESTART_PENDING is process-local to THIS
+        // predecessor, so there is no cross-daemon misdelivery.
+        crate::daemon::RESTART_PENDING.store(true, std::sync::atomic::Ordering::Release);
+        std::fs::write(home.join("restart-requested"), "").ok();
+        tracing::info!(
+            successor_pid = succ.pid,
+            "#1814 self-respawn: committed — predecessor exiting"
+        );
+        json!({
+            "ok": true,
+            "restart": "self-respawn",
+            "successor_pid": succ.pid,
+            "note": "successor confirmed healthy; predecessor exiting(0) — no external supervisor required"
+        })
+    } else {
+        // ABORT-STAY-ALIVE. Kill the successor + remove its run dir so no stale
+        // discovery artifact (api.port / control-ready / .daemon / cookie) lures
+        // a client to a half-dead successor. The predecessor was NEVER signalled
+        // → it stays fully alive with its agents intact.
+        tracing::warn!(
+            successor_pid = succ.pid,
+            "#1814 self-respawn: successor FAILED Phase-1 gate — aborting; predecessor stays alive"
+        );
+        crate::process::kill_process_tree(succ.pid);
+        let _ = succ.child.wait(); // reap so we don't leave a zombie
+        let _ = std::fs::remove_dir_all(&succ.run_dir);
+        json!({
+            "ok": false,
+            "error": "self-respawn aborted: successor failed the Phase-1 health gate. Daemon stays alive (no restart, agents intact). Check daemon.log for the successor's startup failure."
+        })
+    }
+}
+
+/// #1814 Phase-1 health gate: poll (≤30s, 100ms) until the successor's control
+/// plane is confirmed — process alive + `control-ready` marker present + a real
+/// cookie-authenticated api round-trip succeeds. Returns false on the
+/// successor dying, the timeout, or a persistently unreachable api.
+fn phase1_gate(succ: &mut crate::bootstrap::daemon_spawn::SuccessorHandle) -> bool {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let control_ready = succ.run_dir.join(crate::daemon::CONTROL_READY_FILE);
+    loop {
+        // `try_wait` detects a crash-on-launch immediately AND reaps the child
+        // (so it never lingers as a zombie that `kill(pid, 0)` would misreport
+        // as alive). `Ok(Some(_))` = exited.
+        if matches!(succ.child.try_wait(), Ok(Some(_))) {
+            tracing::warn!(
+                successor_pid = succ.pid,
+                "#1814 Phase-1: successor process exited during startup"
+            );
+            return false;
+        }
+        if control_ready.exists()
+            && crate::api::call_at(
+                &succ.run_dir,
+                &json!({"method": crate::api::method::STATUS}),
+            )
+            .is_ok()
+        {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            tracing::warn!(
+                successor_pid = succ.pid,
+                "#1814 Phase-1: successor not control-ready within timeout"
+            );
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
 }
 
 #[cfg(test)]

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -88,10 +88,17 @@ fn handle_self_respawn(home: &Path) -> Value {
         // freshly-bound SUCCESSOR — which then shuts itself down the instant it
         // promotes (observed). RESTART_PENDING is process-local to THIS
         // predecessor, so there is no cross-daemon misdelivery.
+        // #1814 FIX2: park the successor's child handle so the run_core loop can
+        // do a FINAL liveness recheck before the irreversible teardown — if the
+        // successor dies in the commit→exit window, the loop aborts-stay-alive
+        // instead of bricking. Park BEFORE setting RESTART_PENDING (which arms
+        // the shutdown bridge) so the handle is always available to the recheck.
+        let succ_pid = succ.pid;
+        crate::daemon::park_self_respawn_successor(succ.child);
         crate::daemon::RESTART_PENDING.store(true, std::sync::atomic::Ordering::Release);
         std::fs::write(home.join("restart-requested"), "").ok();
         tracing::info!(
-            successor_pid = succ.pid,
+            successor_pid = succ_pid,
             "#1814 self-respawn: committed — predecessor exiting"
         );
         json!({

--- a/tests/agend_git_shim_app_mode_wiring.rs
+++ b/tests/agend_git_shim_app_mode_wiring.rs
@@ -4,40 +4,62 @@
 //! the 4 init functions (binding::reconcile_hooks, symlink_shim,
 //! reconcile_orphans, worktree_pool::reconcile_orphan_leases).
 
-/// Verify bootstrap::prepare source contains all 4 init calls.
+/// Verify the bootstrap prepare path wires all 4 shim init calls + extract.
 /// Source-grep approach (same pattern as sprint52_no_self_ipc).
-#[test]
-fn bootstrap_prepare_contains_all_shim_init_calls() {
-    let src = include_str!("../src/bootstrap/mod.rs");
+///
+/// #1814: the init calls moved out of `prepare`'s textual body into the
+/// extracted `resolve_fleet_and_reconcile` helper (which `prepare` calls, and
+/// which the successor-handoff path re-uses post-lock). The wiring is still
+/// in the prepare path — so this test now (a) confirms `prepare` calls
+/// `resolve_fleet_and_reconcile`, and (b) greps that helper's body for the
+/// init calls. Net guarantee is unchanged: the shim init runs on the daemon
+/// `start` path.
+fn fn_body<'a>(src: &'a str, signature: &str) -> &'a str {
     let fn_start = src
-        .find("pub fn prepare(")
-        .expect("prepare function must exist");
+        .find(signature)
+        .unwrap_or_else(|| panic!("{signature} must exist"));
     let rest = &src[fn_start..];
     let fn_end = rest
         .find("\n/// ")
         .or_else(|| rest.find("\npub fn "))
+        .or_else(|| rest.find("\npub(crate) fn "))
+        .or_else(|| rest.find("\nfn "))
         .unwrap_or(rest.len());
-    let body = &rest[..fn_end];
+    &rest[..fn_end]
+}
 
+#[test]
+fn bootstrap_prepare_contains_all_shim_init_calls() {
+    let src = include_str!("../src/bootstrap/mod.rs");
+
+    // (a) prepare must delegate to the extracted helper (the wiring link).
+    let prepare_body = fn_body(src, "pub fn prepare(");
+    assert!(
+        prepare_body.contains("resolve_fleet_and_reconcile("),
+        "bootstrap::prepare must call resolve_fleet_and_reconcile (the shim-init home)"
+    );
+
+    // (b) the helper must contain all 4 init calls + extract_default.
+    let body = fn_body(src, "pub(crate) fn resolve_fleet_and_reconcile(");
     assert!(
         body.contains("binding::reconcile_hooks("),
-        "bootstrap::prepare must call reconcile_hooks"
+        "resolve_fleet_and_reconcile must call reconcile_hooks"
     );
     assert!(
         body.contains("binding::symlink_shim("),
-        "bootstrap::prepare must call symlink_shim"
+        "resolve_fleet_and_reconcile must call symlink_shim"
     );
     assert!(
         body.contains("binding::reconcile_orphans("),
-        "bootstrap::prepare must call reconcile_orphans"
+        "resolve_fleet_and_reconcile must call reconcile_orphans"
     );
     assert!(
         body.contains("worktree_pool::reconcile_orphan_leases("),
-        "bootstrap::prepare must call reconcile_orphan_leases"
+        "resolve_fleet_and_reconcile must call reconcile_orphan_leases"
     );
     assert!(
         body.contains("protocol::extract_default("),
-        "bootstrap::prepare must call protocol::extract_default"
+        "resolve_fleet_and_reconcile must call protocol::extract_default"
     );
 }
 

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -44,6 +44,20 @@ enum SuccessorFault {
 /// single no-auth shell probe agent (fleet size 1). `fault` injects a successor
 /// failure seam for the abort-path tests.
 fn boot(home: &Path, fault: SuccessorFault) -> Child {
+    // Define `probe` via fleet.yaml (NOT `--agents`) so BOTH the first boot AND
+    // the handoff successor resolve it IDENTICALLY to a shell agent. The
+    // `--agents probe:/bin/sh` path registers a DEFAULT fleet entry (no
+    // backend), so the successor's re-resolve from fleet.yaml falls back to the
+    // default `claude` backend — absent on CI runners → agent spawn fails →
+    // the post-restart "agents re-spawned" assertion would fail on ubuntu. A
+    // `backend: shell` + `command: /bin/sh` entry resolves to /bin/sh on every
+    // platform.
+    std::fs::create_dir_all(home).ok();
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "instances:\n  probe:\n    backend: shell\n    command: /bin/sh\n",
+    )
+    .expect("write fleet.yaml");
     let mut cmd = Command::new(bin());
     cmd.env("AGEND_HOME", home)
         .env("AGEND_RESTART_HANDOFF", "1")
@@ -56,7 +70,7 @@ fn boot(home: &Path, fault: SuccessorFault) -> Child {
         .env_remove("AGEND_SUCCESSOR_HANDOFF")
         .env_remove("AGEND_FORCE_SUCCESSOR_FAIL")
         .env_remove("AGEND_FORCE_SUCCESSOR_FAIL_AFTER_CONTROL_READY")
-        .args(["start", "--foreground", "--agents", "probe:/bin/sh"])
+        .args(["start", "--foreground"])
         .stdout(Stdio::null())
         .stderr(Stdio::null());
     match fault {
@@ -196,7 +210,7 @@ fn trigger_restart(home: &Path, active_pid: u32) -> Option<serde_json::Value> {
 /// Kill any daemon still alive under `home/run` and remove the dir. Handoff
 /// successors run in their own process group (detached), so a harness pgid kill
 /// would miss them — clean up by scanning run dirs.
-fn teardown(home: &Path) {
+fn cleanup_test_home(home: &Path) {
     for pid in active_pids(home) {
         // SAFETY: deliberate cleanup signal to a known test daemon pid.
         unsafe {
@@ -231,7 +245,7 @@ fn self_respawn_succeeds_with_no_external_supervisor() {
         Some(p) => p,
         None => {
             let _ = d1.kill();
-            teardown(&home);
+            cleanup_test_home(&home);
             panic!("first boot never became the single active daemon");
         }
     };
@@ -261,7 +275,7 @@ fn self_respawn_succeeds_with_no_external_supervisor() {
 
     // The original child handle is the OLD daemon (now exited 0); reap it.
     let _ = d1.wait();
-    teardown(&home);
+    cleanup_test_home(&home);
 
     let new_pid =
         new_pid.expect("a NEW daemon pid must serve after self-respawn (old must be dead)");
@@ -290,7 +304,7 @@ fn self_respawn_aborts_and_old_stays_alive_when_successor_fails() {
         Some(p) => p,
         None => {
             let _ = d1.kill();
-            teardown(&home);
+            cleanup_test_home(&home);
             panic!("first boot never became the single active daemon");
         }
     };
@@ -310,7 +324,7 @@ fn self_respawn_aborts_and_old_stays_alive_when_successor_fails() {
 
     let _ = d1.kill();
     let _ = d1.wait();
-    teardown(&home);
+    cleanup_test_home(&home);
 
     // The mcp_tool tunnel wraps handler output as {ok:true, result:{...}}; the
     // self-respawn ABORT is signalled by result.ok == false.
@@ -357,7 +371,7 @@ fn self_respawn_aborts_when_successor_dies_after_phase1_commit() {
         Some(p) => p,
         None => {
             let _ = d1.kill();
-            teardown(&home);
+            cleanup_test_home(&home);
             panic!("first boot never became the single active daemon");
         }
     };
@@ -376,7 +390,7 @@ fn self_respawn_aborts_when_successor_dies_after_phase1_commit() {
 
     let _ = d1.kill();
     let _ = d1.wait();
-    teardown(&home);
+    cleanup_test_home(&home);
 
     assert!(
         still_old,

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -38,6 +38,10 @@ enum SuccessorFault {
     /// Successor passes Phase-1 (answers STATUS) then dies before the flock —
     /// exercises the predecessor's commit→exit liveness recheck (FIX2).
     AfterControlReady,
+    /// Successor survives Phase-1 AND the predecessor's loop-break recheck, then
+    /// dies DURING the predecessor's teardown window — exercises the round-2
+    /// final recover-as-primary gate (predecessor re-spawns agents + resumes).
+    DuringTeardown,
 }
 
 /// Boot a real daemon with self-respawn ON, NO external-supervisor env, and a
@@ -70,6 +74,8 @@ fn boot(home: &Path, fault: SuccessorFault) -> Child {
         .env_remove("AGEND_SUCCESSOR_HANDOFF")
         .env_remove("AGEND_FORCE_SUCCESSOR_FAIL")
         .env_remove("AGEND_FORCE_SUCCESSOR_FAIL_AFTER_CONTROL_READY")
+        .env_remove("AGEND_FORCE_SUCCESSOR_FAIL_DURING_TEARDOWN")
+        .env_remove("AGEND_SELF_RESPAWN_SETTLE_SECS")
         .args(["start", "--foreground"])
         .stdout(Stdio::null())
         .stderr(Stdio::null());
@@ -80,6 +86,14 @@ fn boot(home: &Path, fault: SuccessorFault) -> Child {
         }
         SuccessorFault::AfterControlReady => {
             cmd.env("AGEND_FORCE_SUCCESSOR_FAIL_AFTER_CONTROL_READY", "1");
+        }
+        SuccessorFault::DuringTeardown => {
+            // Successor stays alive 15s past control-ready (surviving the
+            // predecessor's ~10s loop-break tick), then dies. Widen the
+            // predecessor's pre-exit settle so its final recover-gate recheck
+            // lands AFTER the successor's death — deterministic across CI slop.
+            cmd.env("AGEND_FORCE_SUCCESSOR_FAIL_DURING_TEARDOWN", "1")
+                .env("AGEND_SELF_RESPAWN_SETTLE_SECS", "12");
         }
     }
     cmd.spawn().expect("daemon must spawn")
@@ -399,5 +413,55 @@ fn self_respawn_aborts_when_successor_dies_after_phase1_commit() {
     assert!(
         still_serves,
         "predecessor must keep serving its agents after the FIX2 abort"
+    );
+}
+
+/// #1814 round-2 (reviewer TOCTOU): the successor survives Phase-1 AND the
+/// predecessor's loop-break recheck (so the predecessor begins teardown), then
+/// dies DURING teardown — before the predecessor's irreversible exit. The final
+/// recover-as-primary gate must catch this: the predecessor does NOT exit, it
+/// re-spawns its agents and resumes as primary. Asserts the predecessor (SAME
+/// pid) is still the single active daemon, serving its (re-spawned) agent — no
+/// brick. (`SELF_RESPAWN_SETTLE_SECS=12` widens the recheck window so the
+/// cross-process death lands inside it deterministically.)
+#[test]
+fn self_respawn_recovers_as_primary_when_successor_dies_during_teardown() {
+    let home =
+        std::env::temp_dir().join(format!("agend-selfrespawn-teardown-{}", std::process::id()));
+    std::fs::create_dir_all(&home).expect("mkdir AGEND_HOME");
+
+    let mut d1 = boot(&home, SuccessorFault::DuringTeardown);
+
+    let old_pid = match wait_for_single_active(&home, Duration::from_secs(30), pid_alive) {
+        Some(p) => p,
+        None => {
+            let _ = d1.kill();
+            cleanup_test_home(&home);
+            panic!("first boot never became the single active daemon");
+        }
+    };
+    set_mode_active(&home);
+
+    let _ = trigger_restart(&home, old_pid);
+
+    // Wait out: loop-break tick (~10s) + shutdown_sequence (~2s) + settle (12s) +
+    // re-spawn/resume + margin. Successor dies at control-ready+15s, inside the
+    // widened recheck window → predecessor recovers as primary.
+    std::thread::sleep(Duration::from_secs(40));
+
+    let still_old = active_pids(&home) == vec![old_pid] && pid_alive(old_pid);
+    let still_serves = ls_lists_probe_within(&home, Duration::from_secs(15));
+
+    let _ = d1.kill();
+    let _ = d1.wait();
+    cleanup_test_home(&home);
+
+    assert!(
+        still_old,
+        "predecessor must recover-as-primary (SAME pid) when the successor dies during teardown — no brick"
+    );
+    assert!(
+        still_serves,
+        "predecessor must re-spawn + keep serving its agent after recover-as-primary"
     );
 }

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -28,10 +28,22 @@ fn bin() -> PathBuf {
     assert_cmd::cargo::cargo_bin("agend-terminal")
 }
 
+/// Injected successor failure mode for the abort-path tests.
+#[derive(Clone, Copy, PartialEq)]
+enum SuccessorFault {
+    /// Successor comes up healthy and promotes (happy path).
+    None,
+    /// Successor crashes on launch (fails the Phase-1 gate → handler aborts).
+    OnLaunch,
+    /// Successor passes Phase-1 (answers STATUS) then dies before the flock —
+    /// exercises the predecessor's commit→exit liveness recheck (FIX2).
+    AfterControlReady,
+}
+
 /// Boot a real daemon with self-respawn ON, NO external-supervisor env, and a
-/// single no-auth shell probe agent (fleet size 1). `force_successor_fail`
-/// injects the abort seam (the spawned successor crashes on launch).
-fn boot(home: &Path, force_successor_fail: bool) -> Child {
+/// single no-auth shell probe agent (fleet size 1). `fault` injects a successor
+/// failure seam for the abort-path tests.
+fn boot(home: &Path, fault: SuccessorFault) -> Child {
     let mut cmd = Command::new(bin());
     cmd.env("AGEND_HOME", home)
         .env("AGEND_RESTART_HANDOFF", "1")
@@ -42,13 +54,19 @@ fn boot(home: &Path, force_successor_fail: bool) -> Child {
         .env_remove("XPC_SERVICE_NAME")
         .env_remove("INVOCATION_ID")
         .env_remove("AGEND_SUCCESSOR_HANDOFF")
+        .env_remove("AGEND_FORCE_SUCCESSOR_FAIL")
+        .env_remove("AGEND_FORCE_SUCCESSOR_FAIL_AFTER_CONTROL_READY")
         .args(["start", "--foreground", "--agents", "probe:/bin/sh"])
         .stdout(Stdio::null())
         .stderr(Stdio::null());
-    if force_successor_fail {
-        cmd.env("AGEND_FORCE_SUCCESSOR_FAIL", "1");
-    } else {
-        cmd.env_remove("AGEND_FORCE_SUCCESSOR_FAIL");
+    match fault {
+        SuccessorFault::None => {}
+        SuccessorFault::OnLaunch => {
+            cmd.env("AGEND_FORCE_SUCCESSOR_FAIL", "1");
+        }
+        SuccessorFault::AfterControlReady => {
+            cmd.env("AGEND_FORCE_SUCCESSOR_FAIL_AFTER_CONTROL_READY", "1");
+        }
     }
     cmd.spawn().expect("daemon must spawn")
 }
@@ -206,7 +224,7 @@ fn self_respawn_succeeds_with_no_external_supervisor() {
     let home = std::env::temp_dir().join(format!("agend-selfrespawn-ok-{}", std::process::id()));
     std::fs::create_dir_all(&home).expect("mkdir AGEND_HOME");
 
-    let mut d1 = boot(&home, false);
+    let mut d1 = boot(&home, SuccessorFault::None);
 
     // First boot must serve (generous: cold spawn + bind + agent spawn).
     let old_pid = match wait_for_single_active(&home, Duration::from_secs(30), pid_alive) {
@@ -266,7 +284,7 @@ fn self_respawn_aborts_and_old_stays_alive_when_successor_fails() {
     let home = std::env::temp_dir().join(format!("agend-selfrespawn-fail-{}", std::process::id()));
     std::fs::create_dir_all(&home).expect("mkdir AGEND_HOME");
 
-    let mut d1 = boot(&home, true); // successor will crash on launch
+    let mut d1 = boot(&home, SuccessorFault::OnLaunch); // successor crashes on launch
 
     let old_pid = match wait_for_single_active(&home, Duration::from_secs(30), pid_alive) {
         Some(p) => p,
@@ -316,5 +334,56 @@ fn self_respawn_aborts_and_old_stays_alive_when_successor_fails() {
     assert!(
         still_serves,
         "predecessor must keep serving its agents after abort"
+    );
+}
+
+/// #1814 FIX2 (reviewer race High): the successor passes Phase-1 (answers a
+/// STATUS round-trip) so the predecessor COMMITS, but then dies before
+/// acquiring the flock — the predecessor's pre-exit liveness recheck must catch
+/// this and abort-stay-alive instead of exiting into a brick. Asserts the
+/// predecessor (SAME pid) is still the single active daemon, still serving, a
+/// while after the commit window.
+#[test]
+fn self_respawn_aborts_when_successor_dies_after_phase1_commit() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-selfrespawn-postphase1-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&home).expect("mkdir AGEND_HOME");
+
+    let mut d1 = boot(&home, SuccessorFault::AfterControlReady);
+
+    let old_pid = match wait_for_single_active(&home, Duration::from_secs(30), pid_alive) {
+        Some(p) => p,
+        None => {
+            let _ = d1.kill();
+            teardown(&home);
+            panic!("first boot never became the single active daemon");
+        }
+    };
+    set_mode_active(&home);
+
+    // Commit happens (successor answers Phase-1), then the successor dies before
+    // the flock. The predecessor's loop recheck must abort + stay alive.
+    let _ = trigger_restart(&home, old_pid);
+
+    // Wait past the predecessor's tick-latency recheck window (the loop notices
+    // the shutdown flag + rechecks the dead successor on its next ~10s tick).
+    std::thread::sleep(Duration::from_secs(25));
+
+    let still_old = active_pids(&home) == vec![old_pid] && pid_alive(old_pid);
+    let still_serves = ls_lists_probe_within(&home, Duration::from_secs(10));
+
+    let _ = d1.kill();
+    let _ = d1.wait();
+    teardown(&home);
+
+    assert!(
+        still_old,
+        "predecessor must abort-stay-alive (SAME pid) when the successor dies in the commit→exit window — no brick"
+    );
+    assert!(
+        still_serves,
+        "predecessor must keep serving its agents after the FIX2 abort"
     );
 }

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -1,0 +1,320 @@
+//! #1814 Stage 1 — self-respawn (flag-gated successor handoff) §3.9 real-entry
+//! integration tests.
+//!
+//! These drive the REAL flow end-to-end, not a mocked handoff: a real daemon
+//! binary boots with `AGEND_RESTART_HANDOFF=1` and NO external supervisor env, the
+//! real `restart_daemon` MCP tool is invoked over the real api socket, which
+//! spawns a REAL successor binary (`start --foreground` + `AGEND_SUCCESSOR_
+//! HANDOFF`), runs the real Phase-1 health gate, and either commits (predecessor
+//! exits 0, successor promotes) or aborts (predecessor stays alive).
+//!
+//! Coverage:
+//! - happy / no external supervisor → a NEW pid serves the api, the OLD pid is
+//!   dead, agents are re-spawned, exactly one active run dir remains.
+//! - successor-fails (injected via `AGEND_FORCE_SUCCESSOR_FAIL=1`) → the OLD
+//!   daemon stays alive (SAME pid still serving), restart reports ok:false.
+//!
+//! Unix-only (mirrors `restart_smoke.rs`): the handoff path is Unix-first for
+//! Stage 1; Windows keeps `exit(42)` + Task Scheduler.
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("agend-terminal")
+}
+
+/// Boot a real daemon with self-respawn ON, NO external-supervisor env, and a
+/// single no-auth shell probe agent (fleet size 1). `force_successor_fail`
+/// injects the abort seam (the spawned successor crashes on launch).
+fn boot(home: &Path, force_successor_fail: bool) -> Child {
+    let mut cmd = Command::new(bin());
+    cmd.env("AGEND_HOME", home)
+        .env("AGEND_RESTART_HANDOFF", "1")
+        // Strip any ambient supervisor signal so this is a genuine
+        // "no external supervisor" environment (e.g. macOS GUI sets
+        // XPC_SERVICE_NAME; CI/systemd may set INVOCATION_ID).
+        .env_remove("AGEND_WRAPPED")
+        .env_remove("XPC_SERVICE_NAME")
+        .env_remove("INVOCATION_ID")
+        .env_remove("AGEND_SUCCESSOR_HANDOFF")
+        .args(["start", "--foreground", "--agents", "probe:/bin/sh"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if force_successor_fail {
+        cmd.env("AGEND_FORCE_SUCCESSOR_FAIL", "1");
+    } else {
+        cmd.env_remove("AGEND_FORCE_SUCCESSOR_FAIL");
+    }
+    cmd.spawn().expect("daemon must spawn")
+}
+
+fn pid_alive(pid: u32) -> bool {
+    // SAFETY: signal 0 only checks existence/permission, never delivers.
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+/// Active daemon pids: a `run/<pid>` dir whose pid is alive AND has an
+/// `api.port` file. After a settled handoff there is exactly one.
+fn active_pids(home: &Path) -> Vec<u32> {
+    let run = home.join("run");
+    let Ok(entries) = std::fs::read_dir(&run) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for e in entries.flatten() {
+        if let Ok(pid) = e.file_name().to_string_lossy().parse::<u32>() {
+            if pid_alive(pid) && e.path().join("api.port").exists() {
+                out.push(pid);
+            }
+        }
+    }
+    out
+}
+
+/// Poll until exactly one daemon is active and `pred(pid)` holds, returning that
+/// pid. `None` on timeout.
+fn wait_for_single_active<F: Fn(u32) -> bool>(
+    home: &Path,
+    budget: Duration,
+    pred: F,
+) -> Option<u32> {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        let pids = active_pids(home);
+        if pids.len() == 1 && pred(pids[0]) {
+            return Some(pids[0]);
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    None
+}
+
+/// The probe agent is listed by `ls` (which queries the live socket) within
+/// `budget` — proves the socket is up AND serving AND agents re-spawned.
+fn ls_lists_probe_within(home: &Path, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        if let Ok(out) = Command::new(bin())
+            .env("AGEND_HOME", home)
+            .arg("ls")
+            .output()
+        {
+            if String::from_utf8_lossy(&out.stdout).contains("probe") {
+                return true;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    false
+}
+
+/// Set operator mode to Active via the real `mode` CLI (api MODE → signed
+/// operator-mode.json + immediate in-memory update). REQUIRED before triggering
+/// restart: a fresh daemon with no signed operator-mode.json locks down to
+/// "Away" (#1576), and the operator gate blocks `restart_daemon` while Away —
+/// so without this the restart is (racily) gated and the handoff never runs.
+fn set_mode_active(home: &Path) {
+    let _ = Command::new(bin())
+        .env("AGEND_HOME", home)
+        .args(["mode", "active"])
+        .output();
+}
+
+/// Hex-encode bytes (lower-case), matching `auth_cookie::to_hex`.
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Invoke the real `restart_daemon` MCP tool over the live api socket. Speaks
+/// the daemon's real wire protocol: the NDJSON cookie handshake
+/// (`{"auth":"<hex>"}` → `{"ok":true}`) FIRST, then the `mcp_tool` request. The
+/// cookie file is raw 32 bytes (see `auth_cookie::issue`); hex-encode it for the
+/// handshake. Best-effort: on the happy path the predecessor may exit before the
+/// reply lands, so commit-expecting callers poll process state, not the reply.
+fn trigger_restart(home: &Path, active_pid: u32) -> Option<serde_json::Value> {
+    let run_dir = home.join("run").join(active_pid.to_string());
+    let port: u16 = std::fs::read_to_string(run_dir.join("api.port"))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    let cookie_bytes = std::fs::read(run_dir.join("api.cookie")).ok()?; // raw 32 bytes
+    let stream = TcpStream::connect(("127.0.0.1", port)).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(45))).ok();
+    let mut writer = stream.try_clone().ok()?;
+    let mut reader = BufReader::new(stream);
+
+    // NDJSON cookie handshake (server requires this BEFORE any request).
+    writeln!(writer, "{{\"auth\":\"{}\"}}", hex(&cookie_bytes)).ok()?;
+    writer.flush().ok();
+    let mut ack = String::new();
+    reader.read_line(&mut ack).ok()?;
+    let ack: serde_json::Value = serde_json::from_str(ack.trim()).ok()?;
+    if !ack.get("ok").and_then(|b| b.as_bool()).unwrap_or(false) {
+        return None;
+    }
+
+    // The real restart_daemon tool call.
+    let req = serde_json::json!({
+        "method": "mcp_tool",
+        "params": { "tool": "restart_daemon", "arguments": {} },
+    });
+    writeln!(writer, "{req}").ok()?;
+    writer.flush().ok();
+    let mut line = String::new();
+    reader.read_line(&mut line).ok()?;
+    serde_json::from_str(line.trim()).ok()
+}
+
+/// Kill any daemon still alive under `home/run` and remove the dir. Handoff
+/// successors run in their own process group (detached), so a harness pgid kill
+/// would miss them — clean up by scanning run dirs.
+fn teardown(home: &Path) {
+    for pid in active_pids(home) {
+        // SAFETY: deliberate cleanup signal to a known test daemon pid.
+        unsafe {
+            libc::kill(pid as i32, libc::SIGTERM);
+        }
+    }
+    std::thread::sleep(Duration::from_millis(300));
+    for pid in active_pids(home) {
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+        }
+    }
+    if std::env::var("AGEND_KEEP_TEST_HOME").is_err() {
+        std::fs::remove_dir_all(home).ok();
+    }
+}
+
+/// #1814 happy path: with self-respawn ON and NO external supervisor,
+/// `restart_daemon` brings up a successor that takes over — a NEW pid serves,
+/// the OLD pid dies, agents re-spawn, exactly one active run dir remains. This
+/// is the brick-class fix: restart can't strand the control plane even with no
+/// supervisor to respawn the process.
+#[test]
+fn self_respawn_succeeds_with_no_external_supervisor() {
+    let home = std::env::temp_dir().join(format!("agend-selfrespawn-ok-{}", std::process::id()));
+    std::fs::create_dir_all(&home).expect("mkdir AGEND_HOME");
+
+    let mut d1 = boot(&home, false);
+
+    // First boot must serve (generous: cold spawn + bind + agent spawn).
+    let old_pid = match wait_for_single_active(&home, Duration::from_secs(30), pid_alive) {
+        Some(p) => p,
+        None => {
+            let _ = d1.kill();
+            teardown(&home);
+            panic!("first boot never became the single active daemon");
+        }
+    };
+    assert!(
+        ls_lists_probe_within(&home, Duration::from_secs(30)),
+        "first boot must serve the probe agent"
+    );
+
+    // Operator gate allows restart only when Active (fresh daemon → Away).
+    set_mode_active(&home);
+
+    // Real restart over the real api → spawns + health-gates a real successor.
+    let _ = trigger_restart(&home, old_pid);
+
+    // A DIFFERENT pid must become the single active daemon (the successor
+    // promoted). We assert via `active_pids` (run dir + api.port + live pid),
+    // NOT `pid_alive(old_pid)`: the old daemon is a child of THIS test process,
+    // so after it exits(0) it stays a zombie (un-`wait`ed) and `kill(pid, 0)`
+    // reports a zombie as alive — a false "still alive". `active_pids` instead
+    // sees old vanish the moment it removes its own run dir on exit, leaving
+    // exactly the successor.
+    let new_pid = wait_for_single_active(&home, Duration::from_secs(60), |p| p != old_pid);
+
+    // The successor's agents must be re-spawned (probe served by the new pid).
+    let served = new_pid.is_some() && ls_lists_probe_within(&home, Duration::from_secs(30));
+    let single_after = active_pids(&home).len() == 1;
+
+    // The original child handle is the OLD daemon (now exited 0); reap it.
+    let _ = d1.wait();
+    teardown(&home);
+
+    let new_pid =
+        new_pid.expect("a NEW daemon pid must serve after self-respawn (old must be dead)");
+    assert_ne!(new_pid, old_pid, "successor must be a distinct process");
+    assert!(
+        served,
+        "successor must re-spawn agents (probe served by new pid)"
+    );
+    assert!(
+        single_after,
+        "exactly one active run dir after handoff (no double-bind / duplication)"
+    );
+}
+
+/// #1814 abort-stay-alive: when the successor fails its Phase-1 gate (injected
+/// crash-on-launch), the predecessor must NOT shut down — the SAME pid keeps
+/// serving and `restart_daemon` reports ok:false. No brick, agents intact.
+#[test]
+fn self_respawn_aborts_and_old_stays_alive_when_successor_fails() {
+    let home = std::env::temp_dir().join(format!("agend-selfrespawn-fail-{}", std::process::id()));
+    std::fs::create_dir_all(&home).expect("mkdir AGEND_HOME");
+
+    let mut d1 = boot(&home, true); // successor will crash on launch
+
+    let old_pid = match wait_for_single_active(&home, Duration::from_secs(30), pid_alive) {
+        Some(p) => p,
+        None => {
+            let _ = d1.kill();
+            teardown(&home);
+            panic!("first boot never became the single active daemon");
+        }
+    };
+
+    // Operator gate allows restart only when Active (fresh daemon → Away).
+    set_mode_active(&home);
+
+    // Restart must come back ok:false (the predecessor was never signalled, so
+    // the reply lands) and the predecessor must still be the SAME live daemon.
+    let resp = trigger_restart(&home, old_pid);
+
+    // Give any (wrongly) spawned successor a moment to settle/die, then assert
+    // the OLD daemon is unchanged and still serving.
+    std::thread::sleep(Duration::from_secs(2));
+    let still_old = active_pids(&home) == vec![old_pid] && pid_alive(old_pid);
+    let still_serves = ls_lists_probe_within(&home, Duration::from_secs(10));
+
+    let _ = d1.kill();
+    let _ = d1.wait();
+    teardown(&home);
+
+    // The mcp_tool tunnel wraps handler output as {ok:true, result:{...}}; the
+    // self-respawn ABORT is signalled by result.ok == false.
+    if let Some(resp) = resp {
+        let result_ok = resp
+            .get("result")
+            .and_then(|r| r.get("ok"))
+            .and_then(|b| b.as_bool());
+        assert_eq!(
+            result_ok,
+            Some(false),
+            "failed-successor restart must report result.ok=false, got {resp}"
+        );
+    } else {
+        panic!("abort path must return a reply (predecessor stays alive to answer)");
+    }
+    assert!(
+        still_old,
+        "predecessor must stay the SAME live daemon after abort"
+    );
+    assert!(
+        still_serves,
+        "predecessor must keep serving its agents after abort"
+    );
+}


### PR DESCRIPTION
## What

Stage 1 of #1814: make `restart_daemon` self-healing so it never bricks the control plane regardless of supervision detection (the #851/#1812 failure class). Behind flag `AGEND_RESTART_HANDOFF=1`; **flag OFF = byte-identical legacy `exit(42)` path** (zero regression).

Per decision `d-20260606104934346030-2` + the 4-way design dialectic. Scope is **P1** (control-plane self-respawn; agents re-spawn + backend `Resume`, exactly as a supervised restart does today). **P2** (zero-downtime live-PTY survival) is explicitly out of scope/deferred.

## How (flock = commit point)

1. **HANDOFF boot path** — a successor spawned with a legitimate `AGEND_SUCCESSOR_HANDOFF=<old_pid>:<token>` marker takes a minimal pre-lock path: create run dir + cookie, bind its own ephemeral api, write `control-ready`, then **block on the flock**. It does **not** run the destructive sole-daemon reconciles / agent-resolve / agent-spawn during the two-daemon overlap window — those would race the predecessor (e.g. `release_inprogress_orphans`, which assumes `live = ∅`, would falsely release the predecessor's in-progress tasks; `boot_sweep_zombies` could kill the predecessor). A normal/operator `start` never carries the marker, so it always runs the full `prepare`.
2. **Phase-1 health gate** — the predecessor (in its `mcp_tool` worker thread) confirms the successor: process alive (`try_wait`, which also reaps a crash-on-launch so a zombie can't masquerade as alive) + `control-ready` present + a real cookie-authenticated api round-trip (`api::call_at` against the successor's own run dir).
3. **Commit** — set `RESTART_PENDING` only; the existing `handle_session` bridge flips the shutdown flag → main loop breaks → `run_core` tail sees `RESTART_PENDING` + self-respawn → `exit(0)`, releasing the flock so the (blocked) successor promotes. We deliberately do **not** `api::call(SHUTDOWN)` — during overlap its `find_active_run_dir` is ambiguous and was observed delivering SHUTDOWN to the freshly-bound successor.
4. **Abort-stay-alive** — on Phase-1 failure: SIGKILL + reap + remove the successor's run dir; the predecessor was never signalled, so it stays fully alive with its agents intact.

## Key pieces
- `daemon/restart.rs`: `AGEND_RESTART_HANDOFF` flag + `AGEND_SUCCESSOR_HANDOFF` marker (well-formed-token guard).
- `bootstrap`: split `prepare` into reusable `boot_hygiene_sweeps` + `resolve_fleet_and_reconcile` (run post-lock by the handoff path) + `prepare_handoff_prelock` + `acquire_daemon_lock_blocking`; `OwnedFleet.lock → Option`.
- `daemon`: `FleetSource::HandoffDeferred` `run_core` branch; `exit(0)` on self-respawn.
- `bootstrap/daemon_spawn::spawn_successor_handoff`; `api::call_at` / `ipc::connect_run_dir_api`; `restart_daemon` `tool_timeout` 30s→60s.

## Known/intended Stage-1 interactions (NOT bugs)
- **launchd `KeepAlive` double-respawn**: if an external supervisor is also active, the predecessor's exit triggers both the successor and an external respawn. **Self-corrects via the flock** — whoever acquires `.daemon.lock` first wins; the loser hits the singleton attach-reject guard and exits. Documented inline.
- **Operator-mode gate**: `restart_daemon` is still gated by `operator_mode` when the operator is Away (existing #1339/#1576 authority gate) — self-respawn does not bypass it. The integration tests set mode Active to exercise the mechanism.

## Tests (§3.9 real-entry, not mocked)
`tests/self_respawn_handoff.rs` drives the **real** flow: real daemon binary → real `restart_daemon` over the api → real spawned successor → real Phase-1 gate.
- `self_respawn_succeeds_with_no_external_supervisor` — `AGEND_RESTART_HANDOFF=1`, **no** supervisor env: a NEW pid serves, the old pid is gone, agents re-spawned, exactly one active run dir.
- `self_respawn_aborts_and_old_stays_alive_when_successor_fails` — `AGEND_FORCE_SUCCESSOR_FAIL` injection: restart returns `ok:false`, the SAME predecessor keeps serving.

Unix-first (Stage 1); Windows keeps `exit(42)` + Task Scheduler.

Verification: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, restart unit tests (11), and both integration tests all green locally (rebased onto `origin/main` incl. #1812).

🤖 Generated with [Claude Code](https://claude.com/claude-code)