### PR TITLE
chore: env-cleanup PR-B — demote 11 magic-number env tunables to consts (refs #1812)

### DIFF
--- a/docs/RECOVERY-STAGES.md
+++ b/docs/RECOVERY-STAGES.md
@@ -147,12 +147,16 @@ shared with future Stages 2/3 and any other dispatcher consumers).
 | Env var | Default | Purpose |
 |---|---|---|
 | `AGEND_AUTO_RECOVERY_STAGE1` | unset (shadow) | `"1"` activates: dispatcher writes ESC byte to PTY. Unset: same telemetry, no I/O. |
-| `AGEND_AUTO_RECOVERY_STAGE1_TIMEOUT_MS` | 10000 | Window between Stage 1 fire and `Stage2Eligible` transition. |
-| `AGEND_AUTO_RECOVERY_STAGE1_COOLDOWN_MS` | 60000 | Window during which a re-entry into `Hung` skips Stage 1 (anti-thrash). |
 
-The dispatcher reads env vars **each tick** — operator can flip
+The dispatcher reads the gate env var **each tick** — operator can flip
 `AGEND_AUTO_RECOVERY_STAGE1=1` without restarting the daemon. Important
 for the shadow→active promotion workflow.
+
+The Stage 1 timeout (10 s, `STAGE1_TIMEOUT_DEFAULT_MS`) and cooldown
+(60 s, `STAGE1_COOLDOWN_DEFAULT_MS`) are **fixed consts, not
+env-configurable** (#env-cleanup: the
+`AGEND_AUTO_RECOVERY_STAGE1_TIMEOUT_MS` / `_COOLDOWN_MS` overrides were
+demoted).
 
 ### Promotion criteria (operator action)
 
@@ -298,8 +302,9 @@ Decision §1.4 Delta 2: 1s default backoff before `spawn_agent` runs in
 the Stage 2 arm. Defensive padding against tight-loop on transient
 spawn errors (filesystem / network / PTY allocation). Crash path uses
 exponential 5s+ backoff; Stage 2's controlled action permits shorter
-delay. Operator override via env var
-`AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS`.
+delay. Fixed const `STAGE2_BACKOFF_DEFAULT_MS` (1 s), not env-configurable
+(#env-cleanup: the `AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS` override was
+demoted).
 
 ### 9.4 Stage 2 fail criteria (3 modes)
 
@@ -311,8 +316,9 @@ on any of:
    Operator already received telegram pre-emit. Phase 1 limitation:
    manual respawn or future operator-unpause command required.
 2. **30s timeout window expired** without recovery (`state != Healthy`
-   when `entered_at.elapsed() >= STAGE2_TIMEOUT_DEFAULT_MS`). Operator
-   override via `AGEND_AUTO_RECOVERY_STAGE2_TIMEOUT_MS`.
+   when `entered_at.elapsed() >= STAGE2_TIMEOUT_DEFAULT_MS`). Fixed const
+   (30 s), not env-configurable (#env-cleanup: the
+   `AGEND_AUTO_RECOVERY_STAGE2_TIMEOUT_MS` override was demoted).
 3. **Agent re-Hungs within Stage 2 window** — `Stage2Pending` and
    state == Hung implies brief Healthy then back to Hung; more
    aggressive escalation. (Phase 1 implementation: timeout check
@@ -370,9 +376,13 @@ escalation timeline.
 | Env var | Default | Purpose |
 |---|---|---|
 | `AGEND_AUTO_RECOVERY_STAGE2` | unset (shadow) | `"1"` activates: dispatcher emits `Stage2Restart` event. Unset: same telemetry, no emission. |
-| `AGEND_AUTO_RECOVERY_STAGE2_TIMEOUT_MS` | 30000 | Stage 2 monitoring window. |
-| `AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS` | 1000 | Backoff before respawn worker spawn attempt. |
 | `AGEND_AUTO_RECOVERY_STAGE2_MAX_RESTARTS` | 3 | Cumulative cap → direct `Stage3Eligible` escalation. |
+
+The Stage 2 monitoring window (30 s, `STAGE2_TIMEOUT_DEFAULT_MS`) and
+respawn backoff (1 s, `STAGE2_BACKOFF_DEFAULT_MS`) are **fixed consts, not
+env-configurable** (#env-cleanup: the
+`AGEND_AUTO_RECOVERY_STAGE2_TIMEOUT_MS` / `_BACKOFF_MS` overrides were
+demoted).
 
 Same shadow-mode promotion workflow as Stage 1: operator runs in
 shadow for ≥2 weeks, classifies would-have-fires via

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -798,7 +798,7 @@ The daemon exposes a localhost-only TCP API using NDJSON (newline-delimited JSON
 
 - **Localhost TCP** on a random port (published to `<home>/run/<pid>/api.port`)
 - **No TLS** — localhost-only assumption; same-user access enforced by filesystem permissions
-- **Connection cap**: 32 concurrent sessions (configurable via `AGEND_API_MAX_CONNS`)
+- **Connection cap**: 32 concurrent sessions (fixed const; #env-cleanup: the `AGEND_API_MAX_CONNS` override was demoted)
 
 ### Authentication
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -128,7 +128,6 @@ These live in the `agend-git` shim binary (`src/bin/agend-git.rs`). The three
 
 | Name | Purpose | Default (unset) | Valid values / format | Source | Notes |
 |------|---------|-----------------|-----------------------|--------|-------|
-| `AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS` | Overrides the `tools/list` retry-timeout budget in the MCP bridge proxy. | `30_000` ms. | `u64` ms; malformed → default. | `src/bin/agend-mcp-bridge.rs:271` | Test-oriented override (internal). |
 
 ---
 
@@ -148,7 +147,6 @@ These live in the `agend-git` shim binary (`src/bin/agend-git.rs`). The three
 |------|---------|-----------------|-----------------------|--------|-------|
 | `AGEND_POINTER_ONLY_INJECT` | When on, PTY inbox injection uses header-only ("pointer") format, forcing agents to call `inbox` for the body. | `false`. | `"1"` enables; else off. | `src/daemon_config.rs:27` (seeds `DaemonConfig::default`); consumed via `src/inbox/notify.rs:14` | Env read only at default-construction; runtime value lives in `DaemonConfig`. |
 | `AGEND_CTRLC_SENTINEL` | Debug aid: inside the Ctrl+C handler, if set, write a "fired at &lt;time&gt;" sentinel file to the given path (isolating signal handling on Windows). | No sentinel file written. | Filesystem path string. | `src/bootstrap/signals.rs:39` | Internal diagnostic. |
-| `AGEND_SPAWN_STAGGER_MS` | Staggered-spawn delay rate-limiting PTY init during multi-agent startup bursts. | `500` ms. | `u64` ms; unparseable → 500. | `src/daemon/mod.rs:1073` | Startup tuning. |
 
 ---
 
@@ -177,13 +175,18 @@ verify against code once their PRs land.
 
 ---
 
-## 14. Test-only fixtures
+## 14. Test-only fixtures & seams
 
 ⚠️ **Do not set these in production.** They are test-harness conventions /
-fixtures and have no (or vestigial) production read sites.
+fixtures, or **test-only seams** whose env read exists ONLY so a cross-process
+integration test (which spawns an agend binary as a subprocess) can control
+that subprocess's timing — production always uses the fixed default. They are
+**not production tunables**.
 
 | Name | Purpose | Source | Notes |
 |------|---------|--------|-------|
+| `AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS` | **Test-only seam.** Shortens the `agend-mcp-bridge` `tools/list` retry-timeout budget so a cross-process test sees the daemon-unreachable error fast. Production always uses the fixed **30 s** default. | `src/bin/agend-mcp-bridge.rs:271` (read); set by `tests/attached_path_mcp_invariants.rs` | Not a production tunable (#env-cleanup reclassify). `u64` ms; malformed → default. |
+| `AGEND_SPAWN_STAGGER_MS` | **Test-only seam.** Sets the multi-agent staggered-spawn delay in a spawned daemon so a cross-process test gets a deterministic startup-race window. Production always uses the fixed **500 ms** default. | `src/daemon/mod.rs:1091` (read); set by `tests/ready_marker_invariants.rs`, `tests/attached_path_mcp_invariants.rs` | Not a production tunable (#env-cleanup reclassify). `u64` ms; unparseable → default. |
 
 ---
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -64,11 +64,7 @@ master gate (`hang_auto_recovery_enabled`) can also enable Stages 1–3.
 | Name | Purpose | Default (unset) | Valid values / format | Source | Notes |
 |------|---------|-----------------|-----------------------|--------|-------|
 | `AGEND_AUTO_RECOVERY_STAGE1` | Stage 1 gate: write ESC byte to a hung agent's PTY. | Inactive (shadow mode) unless master gate on. | `"1"` enables; else off. | `src/daemon/per_tick/recovery_dispatcher.rs:193` | Operator flag; mutates a live PTY. |
-| `AGEND_AUTO_RECOVERY_STAGE1_TIMEOUT_MS` | Stage 1 timeout/threshold. | `10_000` ms (`STAGE1_TIMEOUT_DEFAULT_MS`). | `u64` ms. | `src/daemon/per_tick/recovery_dispatcher.rs:268` | Default const at `src/health.rs:137`. |
-| `AGEND_AUTO_RECOVERY_STAGE1_COOLDOWN_MS` | Cooldown between Stage 1 fires. | `60_000` ms (`STAGE1_COOLDOWN_DEFAULT_MS`). | `u64` ms. | `src/daemon/per_tick/recovery_dispatcher.rs:269` | Default const at `src/health.rs:144`. |
 | `AGEND_AUTO_RECOVERY_STAGE2` | Stage 2 gate: emit `Stage2Restart` event (restarts the agent). | Inactive (shadow mode) unless master gate on. | `"1"` enables; else off. | `src/daemon/per_tick/recovery_dispatcher.rs:155` | Operator flag; triggers agent restart. |
-| `AGEND_AUTO_RECOVERY_STAGE2_TIMEOUT_MS` | Stage 2 timeout. | `30_000` ms (`STAGE2_TIMEOUT_DEFAULT_MS`). | `u64` ms. | `src/daemon/per_tick/recovery_dispatcher.rs:271` | Default const at `src/health.rs:159`. |
-| `AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS` | Backoff before a Stage 2 restart respawns the agent. | `1_000` ms (`STAGE2_BACKOFF_DEFAULT_MS`). | `u64` ms. | `src/daemon/mod.rs:1328` | Default const at `src/health.rs:152`. |
 | `AGEND_AUTO_RECOVERY_STAGE2_MAX_RESTARTS` | Max Stage 2 restart attempts. | `3` (`STAGE2_MAX_RESTARTS_DEFAULT`). | `u32`. | `src/daemon/per_tick/recovery_dispatcher.rs:161` | Safety bound on restart loops. |
 | `AGEND_AUTO_RECOVERY_STAGE3` | Stage 3 gate: escalate by writing `HealthState::Paused`. | Inactive (shadow mode: telegram + tracing only) unless master gate on. | `"1"` enables; else off. | `src/daemon/per_tick/recovery_dispatcher.rs:114` | Operator escalation gate. |
 | `AGEND_PRODUCTIVE_GATE` | Activates the F9 "productive-silence" hang-detection path (can flag an agent Hung). Off → shadow telemetry only. | `false` (inactive). | `"1"` activates; else off. | `src/health.rs:753` | Rollout feature gate. |
@@ -84,7 +80,6 @@ master gate (`hang_auto_recovery_enabled`) can also enable Stages 1–3.
 | `AGEND_WORKTREE_GC` | Master gate for the worktree GC sweep (archives clean orphan worktrees to `.trash`, purges old trash). | **Off** (no-op). | `"1"` enables; else off. | `src/daemon/retention/worktrees.rs:391` | ⚠️ Gates worktree deletion. Strict `=="1"`. |
 | `AGEND_WORKTREE_GC_TRASH_DAYS` | Retention window (days) for `.trash/worktrees/*`; older entries purged on GC sweep. | `7`. | `u64` days; `0` = purge same sweep; no positivity filter. | `src/daemon/retention/worktrees.rs:49` | Tuning knob. |
 | `AGEND_WORKTREE_FORCE_RECLAIM_DAYS` | Age cap (days) for the force-reclaim backstop: a never-released lease with no agent liveness older than this is force-reclaimed. | `7` (also when `<=0`). | `i64` days, filtered `>0`. | `src/worktree_pool.rs:534` | ⚠️ Controls destructive reclaim. |
-| `AGEND_WORKTREE_FORCE_RECLAIM_BOOT_GRACE_SECS` | Post-boot grace window (seconds) during which force-reclaim is suspended (avoids reclaiming mid-respawn agents). | `600` (10 min). | `u64` seconds; `0` accepted (no grace). | `src/worktree_pool.rs:547` | Tuning knob. |
 
 ---
 
@@ -152,14 +147,8 @@ These live in the `agend-git` shim binary (`src/bin/agend-git.rs`). The three
 | Name | Purpose | Default (unset) | Valid values / format | Source | Notes |
 |------|---------|-----------------|-----------------------|--------|-------|
 | `AGEND_POINTER_ONLY_INJECT` | When on, PTY inbox injection uses header-only ("pointer") format, forcing agents to call `inbox` for the body. | `false`. | `"1"` enables; else off. | `src/daemon_config.rs:27` (seeds `DaemonConfig::default`); consumed via `src/inbox/notify.rs:14` | Env read only at default-construction; runtime value lives in `DaemonConfig`. |
-| `AGEND_OSCILLATION_GUARD_WINDOW_SECS` | Window within which a `Lower→Active(X)→Lower→Active(X)` bounce is treated as state oscillation. | `30` s (`DEFAULT_SECS`). | `u64` seconds; `0` disables the guard. | `src/state/mod.rs:357` | State-machine knob. |
-| `AGEND_PANE_INPUT_THRESHOLD_SECS` | Age threshold before the "pane input typed but not submitted" diagnostic fires. | `60` s. | `u64` seconds. | `src/daemon/supervisor.rs:453` | Daemon diagnostic. |
 | `AGEND_CTRLC_SENTINEL` | Debug aid: inside the Ctrl+C handler, if set, write a "fired at &lt;time&gt;" sentinel file to the given path (isolating signal handling on Windows). | No sentinel file written. | Filesystem path string. | `src/bootstrap/signals.rs:39` | Internal diagnostic. |
-| `AGEND_API_CALL_TIMEOUT_SECS` | Read-timeout backstop for self-IPC API calls (shrinks the deadlock-recovery window). | `90` s. | `u64` seconds, clamped `.max(1)`; unparseable → 90. | `src/api/mod.rs:764` | Perf tuning. |
-| `AGEND_API_MAX_CONNS` | Caps concurrent API sessions in the listener accept loop (#680). | `32`. | `usize`; unparseable → 32. | `src/api/mod.rs:267` | Resource limit. |
 | `AGEND_SPAWN_STAGGER_MS` | Staggered-spawn delay rate-limiting PTY init during multi-agent startup bursts. | `500` ms. | `u64` ms; unparseable → 500. | `src/daemon/mod.rs:1073` | Startup tuning. |
-| `AGEND_DRAFT_ESCAPE_SECS` | How long an unsent draft defers notification delivery before the escape valve releases it. | `300_000` ms (300 s / 5 min). | `i64` seconds, filtered `>0`, ×1000; invalid/`<=0` → default. | `src/notification_queue.rs:99` | Notification tuning. |
-| `AGEND_PR_STATE_REPLAY_AGE_HOURS` | At boot, age threshold above which terminal PR-state files are marked already-emitted (suppresses stale "PR merged/closed" replays). | `1` hour (`DEFAULT_HOURS`; also on unparseable). | `u64` hours. | `src/daemon/pr_state/mod.rs:523` | Boot tuning. |
 
 ---
 
@@ -195,9 +184,6 @@ fixtures and have no (or vestigial) production read sites.
 
 | Name | Purpose | Source | Notes |
 |------|---------|--------|-------|
-| `AGEND_TEST_RECOVERY_ENV_MS_VALID` | Fixture fed to the `env_ms()` recovery helper to verify a valid integer parses correctly. Set to `"5000"`. | `src/daemon/per_tick/recovery_dispatcher.rs:1115` (inside `#[cfg(test)]`) | Test of `env_ms` parse-success branch. |
-| `AGEND_TEST_RECOVERY_ENV_MS_INVALID` | Fixture fed to `env_ms()` to verify a garbage value falls back to the default. Set to `"not a number"`. | `src/daemon/per_tick/recovery_dispatcher.rs:1129` (inside `#[cfg(test)]`) | Test of `env_ms` invalid-parse branch. |
-| `AGEND_TEST_RECOVERY_NONEXISTENT_VAR` | Fixture deliberately removed, then passed to `env_ms()` to verify the unset path falls back to the default. | `src/daemon/per_tick/recovery_dispatcher.rs:892` (inside `#[cfg(test)]`) | Test of `env_ms` missing-var branch. |
 
 ---
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -264,10 +264,10 @@ pub fn serve(
     }
 
     // #680: connection counter — limits concurrent API sessions.
-    let max_conns: usize = std::env::var("AGEND_API_MAX_CONNS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(32);
+    // Fixed const (#env-cleanup: was env-overridable via `AGEND_API_MAX_CONNS`;
+    // demoted to YAGNI for single-user deploys).
+    const API_MAX_CONNS: usize = 32;
+    let max_conns: usize = API_MAX_CONNS;
     let active_conns = Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
     // #941: signal listener entered the `accept()` blocking phase.
@@ -714,8 +714,7 @@ pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
     // TUI permanently. The timeout converts that into a recoverable error: the
     // read fails, this call unwinds, the offending lock guard drops, and the
     // waiting threads proceed.
-    // Generous default (covers the slowest legit method, create_instance ~60s);
-    // `AGEND_API_CALL_TIMEOUT_SECS` lets an operator shrink the recovery window.
+    // Generous fixed timeout (covers the slowest legit method, create_instance ~60s).
     let timeout = api_call_read_timeout();
     stream
         .set_read_timeout(Some(timeout))
@@ -758,15 +757,11 @@ pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
 /// slowest legitimate daemon method (`create_instance`, whose own budget is
 /// ~60s) so a genuine slow call never trips the backstop, while still bounding a
 /// wedged self-IPC instead of blocking forever. Overridable via
-/// `AGEND_API_CALL_TIMEOUT_SECS` to shrink the deadlock-recovery window (values
-/// <1 are clamped to 1s).
+/// Fixed const 90s (#env-cleanup: was env-overridable via
+/// `AGEND_API_CALL_TIMEOUT_SECS`; demoted to YAGNI for single-user deploys).
 fn api_call_read_timeout() -> std::time::Duration {
-    let secs = std::env::var("AGEND_API_CALL_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .map(|v| v.max(1))
-        .unwrap_or(90);
-    std::time::Duration::from_secs(secs)
+    const API_CALL_READ_TIMEOUT_SECS: u64 = 90;
+    std::time::Duration::from_secs(API_CALL_READ_TIMEOUT_SECS)
 }
 
 #[cfg(test)]
@@ -887,24 +882,17 @@ mod tests {
     }
 
     #[test]
-    fn api_call_read_timeout_default_override_and_clamp() {
+    fn api_call_read_timeout_is_fixed_90s() {
         // #1492 backstop: the loopback read timeout that converts a wedged
         // self-IPC from a permanent daemon freeze into a recoverable error.
-        std::env::remove_var("AGEND_API_CALL_TIMEOUT_SECS");
+        // #env-cleanup: now a fixed const (the AGEND_API_CALL_TIMEOUT_SECS
+        // override + sub-1s clamp were demoted). 90s must still exceed the
+        // slowest legit method (create_instance ~60s).
         assert_eq!(
             api_call_read_timeout(),
             std::time::Duration::from_secs(90),
-            "default must exceed the slowest legit method (create_instance ~60s)"
+            "fixed default must exceed the slowest legit method (create_instance ~60s)"
         );
-        std::env::set_var("AGEND_API_CALL_TIMEOUT_SECS", "5");
-        assert_eq!(api_call_read_timeout(), std::time::Duration::from_secs(5));
-        std::env::set_var("AGEND_API_CALL_TIMEOUT_SECS", "0");
-        assert_eq!(
-            api_call_read_timeout(),
-            std::time::Duration::from_secs(1),
-            "sub-1s values clamp to 1s — never a zero/instant timeout"
-        );
-        std::env::remove_var("AGEND_API_CALL_TIMEOUT_SECS");
     }
 
     // -----------------------------------------------------------------------

--- a/src/bin/agend-mcp-bridge.rs
+++ b/src/bin/agend-mcp-bridge.rs
@@ -260,14 +260,22 @@ fn proxy_tool_call(
 /// answered with `ok:false` — propagate immediately so the caller sees
 /// the real diagnostic instead of looping on a deterministic failure.
 ///
-/// Default budget 30 s — well above any observed startup time on a 9-agent
-/// fleet — overridable via `AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS` for tests.
-/// On exhaustion the last transport error propagates; callers convert to a
-/// visible JSON-RPC error, never a silent empty tool list (Bug 2 contract).
+/// Production budget is a fixed 30 s — well above any observed startup time on
+/// a 9-agent fleet. On exhaustion the last transport error propagates; callers
+/// convert to a visible JSON-RPC error, never a silent empty tool list (Bug 2
+/// contract).
+///
+/// `AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS` is a **test-only seam, NOT a production
+/// tunable** (#env-cleanup): this proxy runs in the `agend-mcp-bridge` BINARY,
+/// so a cross-process integration test that spawns the bridge has env as its
+/// only lever to shorten this timeout (e.g. `tests/attached_path_mcp_invariants`
+/// sets 300ms so the daemon-unreachable error path returns fast instead of
+/// waiting the full 30 s). Operators never set it.
 fn proxy_tools_list_with_retry(
     home: &Path,
     conn: &mut Option<(BufReader<TcpStream>, TcpStream)>,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    // test-only seam (see fn doc): prod always falls through to the 30_000 default.
     let timeout_ms: u64 = std::env::var("AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS")
         .ok()
         .and_then(|v| v.parse().ok())

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -205,7 +205,7 @@ pub fn prepare(home: &Path, fleet_path: &Path, opts: PrepareOptions) -> Result<B
     // #1017: suppress stale pr-state terminal-replay at boot. Without
     // this, a fresh daemon process re-emits [pr-merged] /
     // [pr-closed-unmerged] for every Merged / ClosedUnmerged pr-state
-    // file older than `AGEND_PR_STATE_REPLAY_AGE_HOURS` (default 1h)
+    // file older than the fixed 1h replay-age threshold
     // — operator gets a flood of stale notifications. Fresh terminal-
     // state files (post-restart actual merges) still fire normally.
     time_step("pr_state_suppress_stale_replay", || {

--- a/src/channel/ux_event.rs
+++ b/src/channel/ux_event.rs
@@ -125,8 +125,7 @@ pub enum FleetEvent {
     },
     /// Sprint 54 P2-3: operator typed input into an agent's pane but
     /// has not yet submitted it (no submit-key keystroke since the last
-    /// non-submit keystroke) for at least
-    /// `AGEND_PANE_INPUT_THRESHOLD_SECS` (default 60). Read-only
+    /// non-submit keystroke) for at least the fixed 60s threshold. Read-only
     /// diagnostic emitted by the daemon supervisor tick — the agent is
     /// not interrupted, no prompt injected, no state mutated. Backend
     /// allowlist applies (claude only, first round); other backends

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1343,11 +1343,7 @@ fn handle_stage2_restart(
         }
     };
 
-    let backoff_ms = std::env::var("AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(crate::health::STAGE2_BACKOFF_DEFAULT_MS);
-    let backoff = Duration::from_millis(backoff_ms);
+    let backoff = Duration::from_millis(crate::health::STAGE2_BACKOFF_DEFAULT_MS);
 
     std::thread::sleep(backoff);
     if shutdown.load(std::sync::atomic::Ordering::Relaxed) {
@@ -2108,8 +2104,9 @@ mod tests {
         let (crash_tx, _crash_rx) = crossbeam_channel::unbounded();
         let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        std::env::set_var("AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS", "2000");
-
+        // Backoff is the fixed STAGE2_BACKOFF_DEFAULT_MS const; the spawned
+        // worker sleeps it on its own thread, so the caller must still return
+        // immediately (that non-blocking contract is what this test pins).
         let start = std::time::Instant::now();
         let home_owned = home.to_path_buf();
         let reg = Arc::clone(&registry);
@@ -2130,7 +2127,6 @@ mod tests {
 
         handle.join().unwrap();
 
-        std::env::remove_var("AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS");
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1086,8 +1086,16 @@ fn replay_missed_at_startup(home: &Path, registry: &AgentRegistry) {
 }
 
 /// Staggered-spawn delay — rate-limits PTY init during multi-agent startup
-/// bursts. Tunable via `AGEND_SPAWN_STAGGER_MS`.
+/// bursts. Production value is a fixed 500 ms.
+///
+/// `AGEND_SPAWN_STAGGER_MS` is a **test-only seam, NOT a production tunable**
+/// (#env-cleanup): the daemon is a separate process, so a cross-process
+/// integration test that spawns it has env as its only lever to set a
+/// deterministic stagger (e.g. `tests/ready_marker_invariants` /
+/// `tests/attached_path_mcp_invariants` pin a specific value to create a
+/// reproducible startup-race window). Operators never set it.
 fn spawn_stagger() -> std::time::Duration {
+    // test-only seam (see fn doc): prod always falls through to the 500ms default.
     let ms: u64 = std::env::var("AGEND_SPAWN_STAGGER_MS")
         .ok()
         .and_then(|v| v.parse().ok())

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -57,7 +57,6 @@
 //! `STAGE1_COOLDOWN_DEFAULT_MS` of a recent Stage 1 fire, dispatcher
 //! skips Stage 1 and goes directly to `Stage2Eligible`. Prevents
 //! rapid-fire ESC sending that would mask the underlying issue.
-//! Operator override via env var `AGEND_AUTO_RECOVERY_STAGE1_COOLDOWN_MS`.
 
 use super::{PerTickHandler, TickContext};
 use crate::agent;
@@ -83,8 +82,6 @@ struct RecoveryTarget {
 /// dispatcher writes the ESC byte to the agent's PTY; otherwise the
 /// dispatcher logs the would-fire decision and skips the write.
 const STAGE1_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE1";
-const STAGE1_TIMEOUT_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE1_TIMEOUT_MS";
-const STAGE1_COOLDOWN_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE1_COOLDOWN_MS";
 
 /// `tracing` target for shadow-mode + active-mode telemetry. Parallels
 /// the F9 `behavioral_shadow` target (sub-task 4 §F9.5) so dashboards
@@ -97,12 +94,6 @@ const TARGET: &str = "recovery_shadow";
 /// to `crash_tx` (active mode). Default unset = shadow mode: same
 /// telemetry, no event emission.
 const STAGE2_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE2";
-/// Read in `handle_stage2_restart` (`daemon/mod.rs`) — declared here for
-/// co-location with the other Stage 2 env vars even though the
-/// dispatcher doesn't read it directly.
-#[allow(dead_code)]
-const STAGE2_BACKOFF_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS";
-const STAGE2_TIMEOUT_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE2_TIMEOUT_MS";
 const STAGE2_MAX_RESTARTS_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE2_MAX_RESTARTS";
 
 /// `#685` sub-task 7c: env var controlling Stage 3 escalation activation.
@@ -172,19 +163,6 @@ fn stage3_gate_active() -> bool {
         || std::env::var(STAGE3_ENV_VAR)
             .map(|v| v == "1")
             .unwrap_or(false)
-}
-
-/// Read an env var as milliseconds with a typed default. Logged at
-/// `trace` so operators can confirm the override took effect without
-/// noise.
-fn env_ms(var: &str, default_ms: u64) -> Duration {
-    match std::env::var(var) {
-        Ok(v) => match v.parse::<u64>() {
-            Ok(ms) => Duration::from_millis(ms),
-            Err(_) => Duration::from_millis(default_ms),
-        },
-        Err(_) => Duration::from_millis(default_ms),
-    }
 }
 
 fn stage1_gate_active() -> bool {
@@ -265,13 +243,10 @@ impl PerTickHandler for RecoveryDispatcherHandler {
 
     fn run(&self, ctx: &TickContext<'_>) {
         let stage1_active = stage1_gate_active();
-        let stage1_timeout = env_ms(STAGE1_TIMEOUT_ENV_VAR, STAGE1_TIMEOUT_DEFAULT_MS);
-        let stage1_cooldown = env_ms(STAGE1_COOLDOWN_ENV_VAR, STAGE1_COOLDOWN_DEFAULT_MS);
+        let stage1_timeout = Duration::from_millis(STAGE1_TIMEOUT_DEFAULT_MS);
+        let stage1_cooldown = Duration::from_millis(STAGE1_COOLDOWN_DEFAULT_MS);
         let stage2_active = stage2_gate_active();
-        let stage2_timeout = env_ms(
-            STAGE2_TIMEOUT_ENV_VAR,
-            crate::health::STAGE2_TIMEOUT_DEFAULT_MS,
-        );
+        let stage2_timeout = Duration::from_millis(crate::health::STAGE2_TIMEOUT_DEFAULT_MS);
         let stage2_max = stage2_max_restarts();
         let stage3_active = stage3_gate_active();
 
@@ -884,22 +859,6 @@ mod tests {
         assert!(matches!(branch, Stage1Branch::Anomaly));
     }
 
-    #[test]
-    fn env_ms_defaults_when_var_unset() {
-        // Sanity: env_ms falls back to default when env var missing.
-        // Use a unique var name to avoid colliding with other tests.
-        // #1812: shared crate-wide env lock — even a unique key data-races
-        // the global environ against another module's concurrent set_var.
-        let _guard = crate::daemon::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        unsafe {
-            std::env::remove_var("AGEND_TEST_RECOVERY_NONEXISTENT_VAR");
-        }
-        let d = env_ms("AGEND_TEST_RECOVERY_NONEXISTENT_VAR", 12345);
-        assert_eq!(d, Duration::from_millis(12345));
-    }
-
     // -------------------------------------------------------------------
     // Production-hook integration tests — exercise the dispatcher tick
     // path against a real `TickContext` + minimal agent registry. Per
@@ -1113,41 +1072,6 @@ mod tests {
         with_stage1_gate(false, || {
             assert!(!stage1_gate_active());
         });
-    }
-
-    #[test]
-    fn env_ms_parses_valid_integer() {
-        // Env var parses to Duration via integer ms.
-        // #1812: shared crate-wide env lock (see `env_ms_defaults_when_var_unset`).
-        let _guard = crate::daemon::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        unsafe {
-            std::env::set_var("AGEND_TEST_RECOVERY_ENV_MS_VALID", "5000");
-        }
-        let d = env_ms("AGEND_TEST_RECOVERY_ENV_MS_VALID", 9999);
-        assert_eq!(d, Duration::from_millis(5000));
-        unsafe {
-            std::env::remove_var("AGEND_TEST_RECOVERY_ENV_MS_VALID");
-        }
-    }
-
-    #[test]
-    fn env_ms_falls_back_on_invalid_integer() {
-        // Garbage env var value → fall back to default rather than
-        // panic. Operator typo doesn't crash the dispatcher.
-        // #1812: shared crate-wide env lock (see `env_ms_defaults_when_var_unset`).
-        let _guard = crate::daemon::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        unsafe {
-            std::env::set_var("AGEND_TEST_RECOVERY_ENV_MS_INVALID", "not a number");
-        }
-        let d = env_ms("AGEND_TEST_RECOVERY_ENV_MS_INVALID", 7777);
-        assert_eq!(d, Duration::from_millis(7777));
-        unsafe {
-            std::env::remove_var("AGEND_TEST_RECOVERY_ENV_MS_INVALID");
-        }
     }
 
     // -------------------------------------------------------------------

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -514,21 +514,16 @@ pub fn remove(home: &Path, repo: &str, branch: &str) -> std::io::Result<()> {
     }
 }
 
-/// Read the `AGEND_PR_STATE_REPLAY_AGE_HOURS` env var (default 1) and
-/// return as a `Duration`. Tunable upper bound for "stale terminal
-/// state" classification at daemon boot — see
-/// [`suppress_stale_terminal_replay`].
+/// Fixed 1h upper bound for "stale terminal state" classification at daemon
+/// boot — see [`suppress_stale_terminal_replay`]. (#env-cleanup: was
+/// env-overridable via `AGEND_PR_STATE_REPLAY_AGE_HOURS`; demoted to YAGNI.)
 fn replay_age_threshold() -> std::time::Duration {
     const DEFAULT_HOURS: u64 = 1;
-    let hours = std::env::var("AGEND_PR_STATE_REPLAY_AGE_HOURS")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_HOURS);
-    std::time::Duration::from_secs(hours.saturating_mul(3600))
+    std::time::Duration::from_secs(DEFAULT_HOURS.saturating_mul(3600))
 }
 
 /// #1017: at daemon boot, mark terminal-state pr-state files whose
-/// mtime is older than `AGEND_PR_STATE_REPLAY_AGE_HOURS` (default 1h)
+/// mtime is older than the fixed 1h replay-age threshold
 /// as already-emitted. Without this, a fresh daemon process replays
 /// the [pr-merged] / [pr-closed-unmerged] events for every stale
 /// Merged / ClosedUnmerged file on the first `scan_and_emit_with`
@@ -2493,7 +2488,7 @@ mod tests {
     // ─── #1017 startup-replay suppression ─────────────────────────────
 
     /// #1017 T17: stale Merged terminal-state files (mtime older than
-    /// `AGEND_PR_STATE_REPLAY_AGE_HOURS`, default 1h) MUST be marked
+    /// the fixed 1h replay-age threshold) MUST be marked
     /// as already-emitted by `suppress_stale_terminal_replay` at boot.
     /// The next `scan_and_emit_with` tick then sweeps (removes) the
     /// file without firing the [pr-merged] event — closing the
@@ -2608,19 +2603,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(&home);
     }
 
-    /// #1017 T20: `AGEND_PR_STATE_REPLAY_AGE_HOURS` env var overrides
-    /// the default 1h threshold. Operator-tunable.
+    /// #1017 T20 → #env-cleanup: the replay-age threshold is now a fixed 1h
+    /// const (the `AGEND_PR_STATE_REPLAY_AGE_HOURS` override was demoted).
     #[test]
-    #[serial_test::serial]
-    fn t20_1017_replay_age_threshold_env_override() {
-        // SAFETY: set + remove around test; serial_test ensures no race.
-        unsafe { std::env::set_var("AGEND_PR_STATE_REPLAY_AGE_HOURS", "24") };
-        let got = replay_age_threshold();
-        assert_eq!(got, std::time::Duration::from_secs(24 * 3600));
-        unsafe { std::env::remove_var("AGEND_PR_STATE_REPLAY_AGE_HOURS") };
-
-        // Default fallback when unset.
-        let default = replay_age_threshold();
-        assert_eq!(default, std::time::Duration::from_secs(3600));
+    fn t20_1017_replay_age_threshold_is_fixed_1h() {
+        assert_eq!(replay_age_threshold(), std::time::Duration::from_secs(3600));
     }
 }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -413,8 +413,8 @@ fn run_loop(
 /// from the original claude-only first round once `record_submit_activity`
 /// was wired for every backend.
 ///
-/// Threshold defaults to 60s; override via env
-/// `AGEND_PANE_INPUT_THRESHOLD_SECS`.
+/// Threshold is a fixed 60s const (#env-cleanup: the
+/// `AGEND_PANE_INPUT_THRESHOLD_SECS` override was demoted).
 pub(crate) fn check_pane_input_not_submitted(
     home: &std::path::Path,
     registry: &AgentRegistry,
@@ -450,11 +450,10 @@ pub(crate) fn check_pane_input_not_submitted_for_agents(
     if crate::daemon::per_tick::in_boot_grace(loop_started_at) {
         return;
     }
-    let threshold_secs: u64 = std::env::var("AGEND_PANE_INPUT_THRESHOLD_SECS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(60);
-    let threshold_ms = (threshold_secs as i64).saturating_mul(1000);
+    // Fixed const 60s (#env-cleanup: was env-overridable via
+    // `AGEND_PANE_INPUT_THRESHOLD_SECS`; demoted to YAGNI for single-user deploys).
+    const PANE_INPUT_THRESHOLD_SECS: u64 = 60;
+    let threshold_ms = (PANE_INPUT_THRESHOLD_SECS as i64).saturating_mul(1000);
     let now_ms = chrono::Utc::now().timestamp_millis();
     for name in agent_names {
         if !pane_input_backend_supported(home, name) {
@@ -3752,7 +3751,6 @@ instances:
         // Typed 5 minutes ago, never submitted → must emit.
         let now_ms = chrono::Utc::now().timestamp_millis();
         seed_input_submit(&home, agent, now_ms - 300_000, 0);
-        std::env::set_var("AGEND_PANE_INPUT_THRESHOLD_SECS", "60");
         let sink = std::sync::Arc::new(TestSink {
             events: parking_lot::Mutex::new(Vec::new()),
         });
@@ -3777,7 +3775,6 @@ instances:
             matched.count() >= 1,
             "expected ≥1 PaneInputNotSubmitted event for {agent}, got: {events:?}"
         );
-        std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
         std::fs::remove_dir_all(home).ok();
     }
 
@@ -3820,7 +3817,6 @@ instances:
         // Typed 5min ago AND submitted 4min ago (submit > 0 and >= typed).
         let now_ms = chrono::Utc::now().timestamp_millis();
         seed_input_submit(&home, agent, now_ms - 300_000, now_ms - 240_000);
-        std::env::set_var("AGEND_PANE_INPUT_THRESHOLD_SECS", "60");
         let sink = std::sync::Arc::new(TestSink {
             events: parking_lot::Mutex::new(Vec::new()),
         });
@@ -3846,7 +3842,6 @@ instances:
                 );
             }
         }
-        std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
         std::fs::remove_dir_all(home).ok();
     }
 
@@ -3859,7 +3854,6 @@ instances:
         let home = fleet_with_backend("pin_nonclaude", agent, "kiro-cli");
         let now_ms = chrono::Utc::now().timestamp_millis();
         seed_input_submit(&home, agent, now_ms - 300_000, 0);
-        std::env::set_var("AGEND_PANE_INPUT_THRESHOLD_SECS", "60");
         let sink = std::sync::Arc::new(TestSink {
             events: parking_lot::Mutex::new(Vec::new()),
         });
@@ -3884,7 +3878,6 @@ instances:
             fired,
             "non-claude backend with a submit key must now emit PaneInputNotSubmitted (#1457)"
         );
-        std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
         std::fs::remove_dir_all(home).ok();
     }
 
@@ -3895,7 +3888,6 @@ instances:
         let now_ms = chrono::Utc::now().timestamp_millis();
         let typed_ms = now_ms - 300_000;
         seed_input_submit(&home, agent, typed_ms, 0);
-        std::env::set_var("AGEND_PANE_INPUT_THRESHOLD_SECS", "60");
         let sink = std::sync::Arc::new(TestSink {
             events: parking_lot::Mutex::new(Vec::new()),
         });
@@ -3930,7 +3922,6 @@ instances:
             count, 1,
             "must dedup repeated ticks for same typed_ms; got {count}"
         );
-        std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
         std::fs::remove_dir_all(home).ok();
     }
 
@@ -3947,7 +3938,6 @@ instances:
         let home = fleet_with_backend("pin_bootgrace", agent, "claude");
         let now_ms = chrono::Utc::now().timestamp_millis();
         seed_input_submit(&home, agent, now_ms - 300_000, 0);
-        std::env::set_var("AGEND_PANE_INPUT_THRESHOLD_SECS", "60");
         let sink = std::sync::Arc::new(TestSink {
             events: parking_lot::Mutex::new(Vec::new()),
         });
@@ -3996,7 +3986,6 @@ instances:
             })
             .count();
         assert_eq!(count_after, 1, "must emit exactly once after grace ends");
-        std::env::remove_var("AGEND_PANE_INPUT_THRESHOLD_SECS");
         std::fs::remove_dir_all(home).ok();
     }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -133,29 +133,28 @@ pub enum RecoveryStageState {
 /// Decision §1.4 Delta 1: 10s default (reviewer recommendation: ESC
 /// delivery latency = PTY write + agent process scheduling + Ink TUI
 /// state reset; under load, 5s false-positives Stage 2 escalation).
-/// Operator override via env var `AGEND_AUTO_RECOVERY_STAGE1_TIMEOUT_MS`.
+/// Fixed const (#env-cleanup: was env-overridable; demoted to YAGNI).
 pub const STAGE1_TIMEOUT_DEFAULT_MS: u64 = 10_000;
 
 /// Stage 1 default cooldown — if agent re-enters Hung within this window
 /// after a recent Stage 1 fire, dispatcher skips Stage 1 (goes directly
 /// to `Stage2Eligible`). Prevents rapid-fire ESC sending that masks
 /// underlying issues. Decision §1.4 Refinement B.
-/// Operator override via env var `AGEND_AUTO_RECOVERY_STAGE1_COOLDOWN_MS`.
+/// Fixed const (#env-cleanup: was env-overridable; demoted to YAGNI).
 pub const STAGE1_COOLDOWN_DEFAULT_MS: u64 = 60_000;
 
 /// Stage 2 default backoff — sleep before `spawn_agent` re-runs in the
 /// respawn worker's Stage 2 arm. Decision §1.4 Delta 2: 1s default
 /// (defensive padding against tight-loop on transient spawn errors —
-/// transient filesystem / network / PTY allocation failures), with env
-/// var override for operators who observe unnecessary latency.
-/// Operator override via env var `AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS`.
+/// transient filesystem / network / PTY allocation failures).
+/// Fixed const (#env-cleanup: was env-overridable; demoted to YAGNI).
 pub const STAGE2_BACKOFF_DEFAULT_MS: u64 = 1_000;
 
 /// Stage 2 default monitoring window — how long the dispatcher waits in
 /// `Stage2Pending` for the agent to settle on `Healthy` before
 /// classifying Stage 2 as failed and escalating to `Stage3Eligible`.
 /// Mirrors the 30s window already documented in `docs/RECOVERY-STAGES.md`.
-/// Operator override via env var `AGEND_AUTO_RECOVERY_STAGE2_TIMEOUT_MS`.
+/// Fixed const (#env-cleanup: was env-overridable; demoted to YAGNI).
 pub const STAGE2_TIMEOUT_DEFAULT_MS: u64 = 30_000;
 
 /// Stage 2 cumulative retry cap — when `recovery_restart_count` reaches

--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -94,14 +94,11 @@ pub fn read_input_submit_timestamps(home: &Path, agent_name: &str) -> (i64, i64)
 
 /// #1457: how long an unsent draft defers notification delivery before the
 /// escape valve releases it (operator likely walked away mid-draft).
-/// Overridable via `AGEND_DRAFT_ESCAPE_SECS`; default 300s (5 min).
+/// Fixed const 300s / 5 min (#env-cleanup: was env-overridable via
+/// `AGEND_DRAFT_ESCAPE_SECS`; demoted to YAGNI for single-user deploys).
 fn draft_escape_timeout_ms() -> i64 {
-    std::env::var("AGEND_DRAFT_ESCAPE_SECS")
-        .ok()
-        .and_then(|s| s.parse::<i64>().ok())
-        .filter(|s| *s > 0)
-        .map(|s| s.saturating_mul(1000))
-        .unwrap_or(300_000)
+    const DRAFT_ESCAPE_MS: i64 = 300_000;
+    DRAFT_ESCAPE_MS
 }
 
 /// #1457: draft state used to gate notification delivery. Derived from the

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -349,16 +349,12 @@ fn recent_screen_tail(screen_text: &str, n: usize) -> String {
 /// `StateTracker::LATCHED_STATE_EXPIRY` so the guard's protection
 /// covers the same horizon as the latched-state expiry it backstops.
 ///
-/// Operator-tunable via `AGEND_OSCILLATION_GUARD_WINDOW_SECS=<N>`.
-/// Set to `0` to effectively disable (no bounce ever falls within
-/// a zero-duration window).
+/// Fixed const 30s (#env-cleanup: was env-overridable via
+/// `AGEND_OSCILLATION_GUARD_WINDOW_SECS`; demoted to YAGNI for single-user
+/// deploys — re-add an override later if a real need appears).
 fn oscillation_guard_window() -> Duration {
     const DEFAULT_SECS: u64 = 30;
-    let secs = std::env::var("AGEND_OSCILLATION_GUARD_WINDOW_SECS")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_SECS);
-    Duration::from_secs(secs)
+    Duration::from_secs(DEFAULT_SECS)
 }
 
 /// HIGH_FP states: FP-prone error states whose markers appear in dialectic prose

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -218,12 +218,10 @@ fn higher_priority_instant() {
 
 // ── #1005 Phase A2: oscillation guard ─────────────────────────────────
 //
-// All tests in this section read `oscillation_guard_window()` which
-// peeks `AGEND_OSCILLATION_GUARD_WINDOW_SECS`. The env-disable test
-// (oscillation_guard_window_env_disable) flips the var temporarily,
-// so every other test in this section is marked `#[serial]` to
-// prevent cross-test env-var bleed when cargo test runs them in
-// parallel.
+// All tests in this section read `oscillation_guard_window()`, now a fixed
+// 30s const (#env-cleanup: the `AGEND_OSCILLATION_GUARD_WINDOW_SECS` override
+// was demoted). The `#[serial]` markers below are retained as-is — they no
+// longer guard against env-var bleed (none remains) but are harmless.
 
 /// Phase A2 core invariant: when a priority-up to active state X is
 /// followed within `OSCILLATION_LOWER_HOLD_THRESHOLD` (5s) by another
@@ -363,35 +361,6 @@ fn oscillation_guard_multi_cycle_settles_in_idle() {
     t.since = Instant::now() - Duration::from_secs(2);
     t.transition(AgentState::ToolUse);
     assert_eq!(t.get_state(), AgentState::Idle, "cycle 4 bounce");
-}
-
-/// Phase A2 env tunable: `AGEND_OSCILLATION_GUARD_WINDOW_SECS=0`
-/// effectively disables the guard. Operators who experience
-/// false-suppression can opt out.
-#[test]
-#[serial_test::serial]
-fn oscillation_guard_window_env_disable() {
-    // SAFETY: only set + remove the env var around this test.
-    // serial_test ensures no concurrent test races.
-    unsafe { std::env::set_var("AGEND_OSCILLATION_GUARD_WINDOW_SECS", "0") };
-    assert_eq!(oscillation_guard_window(), Duration::from_secs(0));
-
-    let backend = Backend::ClaudeCode;
-    let mut t = tracker_at(&backend, AgentState::Idle, 0);
-    t.transition(AgentState::ToolUse);
-    t.since = Instant::now() - Duration::from_secs(3);
-    t.transition(AgentState::Idle);
-    t.since = Instant::now() - Duration::from_secs(1);
-    // With window=0, no priority-up record falls within the window
-    // → guard cannot trigger → bounce goes through.
-    t.transition(AgentState::ToolUse);
-    assert_eq!(
-        t.get_state(),
-        AgentState::ToolUse,
-        "#1005 A2: window=0 must disable the guard"
-    );
-
-    unsafe { std::env::remove_var("AGEND_OSCILLATION_GUARD_WINDOW_SECS") };
 }
 
 /// Phase A2 companion (#1005 dev-2 fixture finding): opencode's

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -541,13 +541,13 @@ fn force_reclaim_age_days() -> i64 {
 /// reviewer-2 #5: force-reclaim post-boot grace (seconds). After a daemon restart
 /// the live-agent registry (the process-liveness signal) is empty until agents
 /// re-spawn; suspend force-reclaim for this window so a mid-respawn agent is not
-/// reclaimed during the liveness blind spot. Configurable
-/// (`AGEND_WORKTREE_FORCE_RECLAIM_BOOT_GRACE_SECS`).
+/// reclaimed during the liveness blind spot. Fixed const 600s / 10 min
+/// (#env-cleanup: was env-overridable via
+/// `AGEND_WORKTREE_FORCE_RECLAIM_BOOT_GRACE_SECS`; demoted to YAGNI).
+const FORCE_RECLAIM_BOOT_GRACE_SECS: u64 = 600;
+
 fn force_reclaim_boot_grace_secs() -> u64 {
-    std::env::var("AGEND_WORKTREE_FORCE_RECLAIM_BOOT_GRACE_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(600) // 10 min
+    FORCE_RECLAIM_BOOT_GRACE_SECS
 }
 
 /// Pure boot-grace predicate: is `now_unix` within `grace_secs` of `boot_unix`?


### PR DESCRIPTION
## What & why
Continues the env-flag triage simplification (operator feedback: 63 `AGEND_*` is too many). For internal timing/resource tunables, removes the `std::env::var` override and keeps the **exact current default** as a named const. **Behavior byte-identical** — just no longer env-overridable. Single-user deploys never tuned these (YAGNI); re-adding an override later is trivial.

## Demoted (11) — env name → fixed const
| Env var (removed) | Const | Value |
|---|---|---|
| `AGEND_AUTO_RECOVERY_STAGE1_TIMEOUT_MS` | `STAGE1_TIMEOUT_DEFAULT_MS` | 10_000 |
| `AGEND_AUTO_RECOVERY_STAGE1_COOLDOWN_MS` | `STAGE1_COOLDOWN_DEFAULT_MS` | 60_000 |
| `AGEND_AUTO_RECOVERY_STAGE2_TIMEOUT_MS` | `STAGE2_TIMEOUT_DEFAULT_MS` | 30_000 |
| `AGEND_AUTO_RECOVERY_STAGE2_BACKOFF_MS` | `STAGE2_BACKOFF_DEFAULT_MS` | 1_000 |
| `AGEND_WORKTREE_FORCE_RECLAIM_BOOT_GRACE_SECS` | `FORCE_RECLAIM_BOOT_GRACE_SECS` | 600 |
| `AGEND_OSCILLATION_GUARD_WINDOW_SECS` | `DEFAULT_SECS` | 30 |
| `AGEND_PANE_INPUT_THRESHOLD_SECS` | `PANE_INPUT_THRESHOLD_SECS` | 60 |
| `AGEND_API_CALL_TIMEOUT_SECS` | (inline) | 90 |
| `AGEND_API_MAX_CONNS` | `API_MAX_CONNS` | 32 |
| `AGEND_DRAFT_ESCAPE_SECS` | `DRAFT_ESCAPE_MS` | 300_000 |
| `AGEND_PR_STATE_REPLAY_AGE_HOURS` | (inline) | 1h |

The dead `env_ms()` helper (its only prod callers were the demoted stage timeouts) + its 3 unit tests + 3 `AGEND_TEST_RECOVERY_*` fixtures are removed. Moot override tests removed/retargeted to assert the const default.

## ⚠️ Excluded 2 of the original 13 (flagging for a decision)
These are **not operator tunables** — they're **subprocess integration-test injection levers** (env is the only way to control a spawned binary's timing). Demoting them breaks/slows real tests, violating the zero-behavior-change requirement:
- **`AGEND_BRIDGE_TOOLS_LIST_TIMEOUT_MS`** — `tests/attached_path_mcp_invariants` sets it to 300ms so the daemon-unreachable retry path errors fast; a const 30_000 makes that test wait ~30s (windows-CI-timeout risk).
- **`AGEND_SPAWN_STAGGER_MS`** — `tests/ready_marker_invariants` + `attached_path` inject specific stagger values into the spawned daemon for deterministic race windows; a const removes that control.

Both can be demoted in a follow-up that first refactors those tests onto a non-env injection seam (e.g. a CLI flag). Recommend a quick lead/operator confirmation.

## Docs
Removed the 11 demoted vars + the 3 now-dead `AGEND_TEST_RECOVERY` fixtures from `docs/env-vars.md`; the 2 excluded vars stay documented.

## Verification (rebuilt)
- grep: **0** `env::var` reads of the 11 remain.
- `cargo fmt --check` ✓
- `cargo clippy --features tray --tests -- -D warnings` ✓
- `cargo test --tests --features tray` ✓ (exit 0)
- Defaults byte-identical (every const equals the prior `unwrap_or` value).

Re-scopes #1812 work (#1812 stays OPEN as the crash-recovery advisory) — does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)