### PR TITLE
feat(#1812-followup): move watchdog topology env → fleet.yaml `watchdog:` block

### DIFF
--- a/docs/FEATURE-fleet.md
+++ b/docs/FEATURE-fleet.md
@@ -166,6 +166,42 @@ Sets the timezone the daemon uses in human-readable timestamps. Accepts IANA tim
 
 Defines reusable agent configuration templates for dynamically creating instances via `fleet deployment deploy`.
 
+#### `watchdog` — Watchdog Topology
+
+Controls which agent the idle watchdog watches and who receives each watchdog /
+anti-stall / decision-timeout notification. These are agent / recipient **names**
+(fleet topology), so they live here rather than in env vars. Every field is
+optional; an omitted block (or field) falls back to the legacy `AGEND_*` env var
+(deprecated) and then to a built-in default. Resolution precedence:
+
+**`watchdog:` value > `AGEND_*` env var (deprecated, warns once) > built-in default.**
+
+```yaml
+watchdog:
+  # Legacy SINGLE-AGENT mode for the dev-vantage idle watchdog. When set, the
+  # watchdog watches ONLY this agent (with the global dev_idle_threshold_secs)
+  # instead of iterating every fleet instance. Omit it (default) to keep the
+  # modern per-instance iteration. Mirrors AGEND_IDLE_WATCHDOG_AGENT.
+  idle_watchdog_agent: dev
+  # Recipient for dev-vantage idle alerts. Default: lead.
+  dev_recipient: lead
+  # Recipient for fleet-vantage idle alerts ("the whole fleet is quiet").
+  # Default: lead (#1563: was general, which over-pinged the general assistant).
+  fleet_recipient: lead
+  # Recipients for task-stall warnings. Default: [general, lead].
+  task_stall_recipients:
+    - general
+    - lead
+  # Recipient for the decision-timeout auto-default (operator-proceed) emission.
+  # Default: general.
+  decision_timeout_recipient: general
+```
+
+The matching env vars (`AGEND_IDLE_WATCHDOG_AGENT`, `AGEND_IDLE_WATCHDOG_DEV_RECIPIENT`,
+`AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT`, `AGEND_TASK_STALL_RECIPIENTS`,
+`AGEND_DECISION_TIMEOUT_RECIPIENT`) are **deprecated** — they still work for one
+window but will be removed; see `docs/env-vars.md` §8.
+
 ### Environment Variables
 
 #### Merge Priority

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -116,13 +116,30 @@ These live in the `agend-git` shim binary (`src/bin/agend-git.rs`). The three
 
 ## 8. Watchdog & recipients
 
+> **Deprecation (watchdog topology → `fleet.yaml`).** The five `AGEND_IDLE_WATCHDOG_*`
+> / `AGEND_TASK_STALL_RECIPIENTS` / `AGEND_DECISION_TIMEOUT_RECIPIENT` vars below are
+> agent / recipient **names** — fleet *topology*, not env tuning. Their home is the
+> `fleet.yaml` top-level `watchdog:` block (see `docs/FEATURE-fleet.md`). The env vars
+> remain as a **deprecated fallback for one window** so existing setups keep working;
+> resolution precedence is **fleet.yaml `watchdog:` value > env var (deprecated, warns
+> once) > built-in default**. Move them to `fleet.yaml` and drop the env vars:
+>
+> ```yaml
+> watchdog:
+>   idle_watchdog_agent: dev          # AGEND_IDLE_WATCHDOG_AGENT (single-agent mode)
+>   dev_recipient: lead               # AGEND_IDLE_WATCHDOG_DEV_RECIPIENT
+>   fleet_recipient: lead             # AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT
+>   task_stall_recipients: [general, lead]   # AGEND_TASK_STALL_RECIPIENTS
+>   decision_timeout_recipient: general      # AGEND_DECISION_TIMEOUT_RECIPIENT
+> ```
+
 | Name | Purpose | Default (unset) | Valid values / format | Source | Notes |
 |------|---------|-----------------|-----------------------|--------|-------|
-| `AGEND_IDLE_WATCHDOG_AGENT` | Which agent the dev-vantage idle watchdog watches. | `"dev"`. | Agent name; empty/whitespace ignored. | `src/daemon/idle_watchdog.rs:261` | Tuning for multi-agent fleets. |
-| `AGEND_IDLE_WATCHDOG_DEV_RECIPIENT` | Recipient for dev-vantage idle alerts. | `"lead"`. | Recipient name; empty/whitespace ignored. | `src/daemon/idle_watchdog.rs:269` | Tuning. |
-| `AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT` | Recipient for fleet-vantage idle alerts ("whole fleet is quiet"). | `"lead"`. | Recipient name; empty/whitespace ignored. | `src/daemon/idle_watchdog.rs:288` | Tuning. |
-| `AGEND_TASK_STALL_RECIPIENTS` | Override recipients of task-stall warnings (normally `general` + `lead`). | `["general", "lead"]`. | Comma-separated names; entries trimmed, empties filtered. | `src/daemon/anti_stall.rs:166` | List override. |
-| `AGEND_DECISION_TIMEOUT_RECIPIENT` | Recipient for the decision-timeout auto-default (operator-proceed) emission. | `"general"`. | Non-empty recipient name; blank treated as unset. | `src/daemon/decision_timeout.rs:58` | Tuning. |
+| `AGEND_IDLE_WATCHDOG_AGENT` | **Deprecated** → `watchdog.idle_watchdog_agent`. Single-agent mode for the dev-vantage idle watchdog (watch only this agent). | `"dev"` (load-failure fallback only). | Agent name; empty/whitespace ignored. | `src/fleet/watchdog.rs` | Fleet config wins; env is the deprecated fallback. |
+| `AGEND_IDLE_WATCHDOG_DEV_RECIPIENT` | **Deprecated** → `watchdog.dev_recipient`. Recipient for dev-vantage idle alerts. | `"lead"`. | Recipient name; empty/whitespace ignored. | `src/fleet/watchdog.rs` | Fleet config wins; deprecated fallback. |
+| `AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT` | **Deprecated** → `watchdog.fleet_recipient`. Recipient for fleet-vantage idle alerts ("whole fleet is quiet"). | `"lead"`. | Recipient name; empty/whitespace ignored. | `src/fleet/watchdog.rs` | Fleet config wins; deprecated fallback. |
+| `AGEND_TASK_STALL_RECIPIENTS` | **Deprecated** → `watchdog.task_stall_recipients`. Recipients of task-stall warnings. | `["general", "lead"]`. | Comma-separated names; entries trimmed, empties filtered. | `src/fleet/watchdog.rs` | Fleet config (list) wins; deprecated fallback. |
+| `AGEND_DECISION_TIMEOUT_RECIPIENT` | **Deprecated** → `watchdog.decision_timeout_recipient`. Recipient for the decision-timeout auto-default (operator-proceed) emission. | `"general"`. | Non-empty recipient name; blank treated as unset. | `src/fleet/watchdog.rs` | Fleet config wins; deprecated fallback. |
 | `AGEND_WATCHDOG_DRY_RUN` | Makes the per-tick watchdog log classified PTY errors to the event log only instead of mutating agent health state. | `false` (health mutations applied). | `"1"`/`"true"`/`"TRUE"`/`"True"` → dry-run; else off. | `src/daemon/watchdog.rs:21` | Operator safety toggle. |
 
 ---

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -141,6 +141,7 @@ mod tests {
             templates: None,
             display_timezone: None,
             agy_workspace_link_base: None,
+            watchdog: Default::default(),
             home: None,
         };
         c.instances.insert(

--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -157,24 +157,6 @@ fn parse_rfc3339(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
         .map(|dt| dt.with_timezone(&chrono::Utc))
 }
 
-/// Default recipients for stall warnings — broadcast to both lead
-/// (orchestration authority can re-dispatch / unblock) and general
-/// (operator-facing aggregator). Hard-coded matches the lead spec
-/// dispatch language; tunable via `AGEND_TASK_STALL_RECIPIENTS`
-/// env var (comma-separated) for operator override.
-fn stall_recipients() -> Vec<String> {
-    if let Ok(custom) = std::env::var("AGEND_TASK_STALL_RECIPIENTS") {
-        if !custom.trim().is_empty() {
-            return custom
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-        }
-    }
-    vec!["general".to_string(), "lead".to_string()]
-}
-
 /// #event-bus first-pattern: the stall notification text, built from the exact
 /// fields carried by `EventKind::TaskStateChanged`, so the legacy direct enqueue
 /// and the bus subscriber produce a BYTE-IDENTICAL message.
@@ -216,7 +198,7 @@ fn deliver_stall(
     assignee: Option<&str>,
 ) {
     let text = stall_text(task_id, title, reason, started_at, eta_secs, assignee);
-    for recipient in stall_recipients() {
+    for recipient in crate::fleet::watchdog::resolve_task_stall_recipients(home) {
         if let Err(e) = crate::inbox::notify_system(
             home,
             &recipient,
@@ -483,37 +465,64 @@ mod tests {
             .unwrap_or_else(|p| p.into_inner())
     }
 
-    #[test]
-    fn stall_recipients_default_to_general_and_lead() {
-        let _g = env_lock();
-        std::env::remove_var("AGEND_TASK_STALL_RECIPIENTS");
-        let recipients = stall_recipients();
-        assert_eq!(recipients, vec!["general".to_string(), "lead".to_string()]);
-    }
+    // #1812-followup: recipient resolution (default / env / fleet.yaml
+    // precedence + comma-split) moved to `fleet::watchdog` tests. The §3.9
+    // real-entry test `fleet_task_stall_recipients_route_via_bus` below proves a
+    // fleet.yaml `watchdog.task_stall_recipients` value reaches the live emit
+    // path.
 
+    /// §3.9 real-entry: a fleet.yaml `watchdog.task_stall_recipients` list must
+    /// reach the live bus→subscriber→`deliver_stall` path — delivery lands in the
+    /// configured recipients, NOT the built-in `[general, lead]` default. Proves
+    /// the config is read at the real call site, not just by the resolver.
     #[test]
-    fn stall_recipients_honors_env_override() {
+    fn fleet_task_stall_recipients_route_via_bus() {
         let _g = env_lock();
-        std::env::set_var("AGEND_TASK_STALL_RECIPIENTS", "alice, bob, carol");
-        let recipients = stall_recipients();
         std::env::remove_var("AGEND_TASK_STALL_RECIPIENTS");
-        assert_eq!(
-            recipients,
-            vec!["alice".to_string(), "bob".to_string(), "carol".to_string()]
+        let home = tmp_home("fleet-stall-route");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "watchdog:\n  task_stall_recipients:\n    - reviewer\n    - ops\ninstances: {}\n",
+        )
+        .unwrap();
+        let task = make_task(
+            "t-fleet",
+            "in_progress",
+            Some(60),
+            Some("2026-01-01T00:00:00+00:00"),
         );
-    }
-
-    #[test]
-    fn stall_recipients_empty_env_falls_back_to_default() {
-        let _g = env_lock();
-        std::env::set_var("AGEND_TASK_STALL_RECIPIENTS", "  ");
-        let recipients = stall_recipients();
-        std::env::remove_var("AGEND_TASK_STALL_RECIPIENTS");
-        assert_eq!(
-            recipients,
-            vec!["general".to_string(), "lead".to_string()],
-            "whitespace-only env must fall back to default"
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home,
+            crate::daemon::event_bus::EventKind::TaskStateChanged {
+                task_id: task.id.clone(),
+                title: task.title.clone(),
+                assignee: task.assignee.clone(),
+                reason: "stalled".to_string(),
+                started_at: task.started_at.clone(),
+                eta_secs: task.eta_secs,
+            },
         );
+        assert_eq!(
+            crate::inbox::drain(&home, "reviewer").len(),
+            1,
+            "fleet-configured recipient `reviewer` must receive"
+        );
+        assert_eq!(
+            crate::inbox::drain(&home, "ops").len(),
+            1,
+            "fleet-configured recipient `ops` must receive"
+        );
+        assert!(
+            crate::inbox::drain(&home, "general").is_empty(),
+            "built-in default `general` must NOT receive once fleet.yaml overrides"
+        );
+        assert!(
+            crate::inbox::drain(&home, "lead").is_empty(),
+            "built-in default `lead` must NOT receive once fleet.yaml overrides"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -738,7 +747,7 @@ mod tests {
         );
 
         let mut delivered = false;
-        for r in stall_recipients() {
+        for r in crate::fleet::watchdog::resolve_task_stall_recipients(&home_legacy) {
             let legacy = drained_payloads(&home_legacy, &r);
             let viabus = drained_payloads(&home_bus, &r);
             assert_eq!(

--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -52,15 +52,6 @@ const SCHEMA_VERSION: u32 = 1;
 /// min — matches Wave 1 PR-1/PR-2 cadence.
 pub(crate) const TICKS_PER_DECISION_SCAN: u64 = 30;
 
-/// Default recipient for the auto-default emission (operator-
-/// proceed signal). Tunable via `AGEND_DECISION_TIMEOUT_RECIPIENT`.
-fn timeout_recipient() -> String {
-    std::env::var("AGEND_DECISION_TIMEOUT_RECIPIENT")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "general".to_string())
-}
-
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct PendingDecision {
     #[serde(default)]
@@ -331,7 +322,7 @@ fn deliver_timeout(
         timeout_secs,
         default_action,
     );
-    let recipient = timeout_recipient();
+    let recipient = crate::fleet::watchdog::resolve_decision_timeout_recipient(home);
     if let Err(e) = crate::inbox::notify_system(
         home,
         &recipient,
@@ -708,13 +699,45 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    // #1812-followup: recipient resolution (default / env / fleet.yaml
+    // precedence) moved to `fleet::watchdog` tests. The §3.9 real-entry test
+    // `fleet_decision_timeout_recipient_routes_via_bus` below proves a fleet.yaml
+    // `watchdog.decision_timeout_recipient` value reaches the live emit path.
+
+    /// §3.9 real-entry: a fleet.yaml `watchdog.decision_timeout_recipient` must
+    /// reach the live bus→subscriber→`deliver_timeout` path — delivery lands in the
+    /// configured recipient, NOT the built-in `general` default.
     #[test]
-    fn timeout_recipient_honors_env_override() {
+    fn fleet_decision_timeout_recipient_routes_via_bus() {
         let _g = env_lock();
-        std::env::set_var("AGEND_DECISION_TIMEOUT_RECIPIENT", "alice");
-        let r = timeout_recipient();
         std::env::remove_var("AGEND_DECISION_TIMEOUT_RECIPIENT");
-        assert_eq!(r, "alice");
+        let home = tmp_home("fleet-dec-route");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "watchdog:\n  decision_timeout_recipient: arbiter\ninstances: {}\n",
+        )
+        .unwrap();
+        let bus = crate::daemon::event_bus::EventBus::new();
+        bus.subscribe(handle_event);
+        bus.emit(
+            &home,
+            crate::daemon::event_bus::EventKind::DecisionTimeout {
+                decision_id: "d-fleet".to_string(),
+                sender: "general".to_string(),
+                elapsed_secs: 2000,
+                timeout_secs: 1800,
+                default_action: "proceed".to_string(),
+            },
+        );
+        assert!(
+            !drained_payloads(&home, "arbiter").is_empty(),
+            "fleet-configured recipient `arbiter` must receive the decision-timeout alert"
+        );
+        assert!(
+            drained_payloads(&home, "general").is_empty(),
+            "built-in default `general` must NOT receive once fleet.yaml overrides"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
@@ -1010,7 +1033,7 @@ mod tests {
             },
         );
 
-        let recipient = timeout_recipient();
+        let recipient = crate::fleet::watchdog::resolve_decision_timeout_recipient(&home_legacy);
         let legacy = drained_payloads(&home_legacy, &recipient);
         let viabus = drained_payloads(&home_bus, &recipient);
         assert_eq!(
@@ -1042,7 +1065,7 @@ mod tests {
             ..Default::default()
         };
         emit_timeout_event(&home, &d, 2000);
-        let recipient = timeout_recipient();
+        let recipient = crate::fleet::watchdog::resolve_decision_timeout_recipient(&home);
         assert!(
             !drained_payloads(&home, &recipient).is_empty(),
             "#event-bus Option A: gate-off must deliver via the legacy path (no regression)"

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -28,8 +28,9 @@
 //! Scans the watched-agent's last_active timestamp. When elapsed
 //! exceeds `dev_idle_threshold_secs() = 3600` (60 min), emits an
 //! inbox ping to `lead` so the orchestrator can re-dispatch /
-//! unblock. Default watched agent: `dev`. Tunable via
-//! `AGEND_IDLE_WATCHDOG_AGENT` env var.
+//! unblock. Default watched agent: `dev`. Tunable via fleet.yaml
+//! `watchdog.idle_watchdog_agent` (env `AGEND_IDLE_WATCHDOG_AGENT` is a
+//! deprecated fallback).
 //!
 //! ### #12 — cross-vantage 30min fleet-idle guard (P1)
 //! Scans the entire fleet's last_active timestamps. When EVERY
@@ -37,7 +38,8 @@
 //! (30 min) AND at least one agent has had recent activity (i.e.
 //! a sidecar exists), emits an inbox ping to `lead` (#1563; was
 //! `general`) so the orchestrator surfaces / re-dispatches the
-//! fleet stall. Overridable via `AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT`.
+//! fleet stall. Overridable via fleet.yaml `watchdog.fleet_recipient`
+//! (env `AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT` is a deprecated fallback).
 //! The
 //! "at least one tracked" guard distinguishes "fleet really
 //! stalled" from "fleet not yet started" / "all sidecars stale".
@@ -255,42 +257,6 @@ impl IdleWatchdogTracker {
     }
 }
 
-/// Watched agent for the dev-vantage (#10). Defaults to `dev`;
-/// tunable via env for tests + multi-agent fleets.
-fn watched_dev_agent() -> String {
-    std::env::var("AGEND_IDLE_WATCHDOG_AGENT")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "dev".to_string())
-}
-
-/// Recipient for dev-vantage idle alerts. Defaults to `lead`.
-fn dev_idle_recipient() -> String {
-    std::env::var("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "lead".to_string())
-}
-
-/// Recipient for fleet-vantage idle alerts. Defaults to `lead`.
-///
-/// #1563: the default was `general`, which spammed the general assistant with
-/// fleet-idle alerts overnight (it received them as the hardcoded recipient, not
-/// because it was itself forwarded). Fleet-idle is non-critical *coordination*
-/// signal ("the whole fleet is quiet — does work need dispatching?"), so the
-/// right recipient is the orchestrator `lead` — matching the sibling
-/// [`dev_idle_recipient`] default. Delivery to lead's inbox also *wakes* an idle
-/// lead so it can act. Operator-channel routing was deliberately NOT chosen:
-/// per #1339 the human operator must not be pinged for non-P0 signals.
-/// `AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT` still overrides (e.g. a mode-aware
-/// recipient under a future sleep mode).
-fn fleet_idle_recipient() -> String {
-    std::env::var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "lead".to_string())
-}
-
 /// Pure scan logic: detects + emits idle alerts at both vantages.
 /// Exposed for tests so they can invoke without 30-tick wait.
 pub(crate) fn scan_and_emit(
@@ -410,11 +376,13 @@ fn scan_dev_vantage(
     last_alerted: &mut HashMap<(&'static str, String), chrono::DateTime<chrono::Utc>>,
     seeding: bool,
 ) {
-    let env_agent = std::env::var("AGEND_IDLE_WATCHDOG_AGENT")
-        .ok()
-        .filter(|s| !s.trim().is_empty());
+    // #1812-followup: single-agent override now comes from fleet.yaml
+    // `watchdog.idle_watchdog_agent` (env `AGEND_IDLE_WATCHDOG_AGENT` is a
+    // deprecated fallback). `Some` → legacy single-agent mode; `None` → the
+    // modern per-instance iteration below.
+    let single_override = crate::fleet::watchdog::resolve_idle_watchdog_agent(home);
 
-    let agents: Vec<(String, i64)> = if let Some(single) = env_agent {
+    let agents: Vec<(String, i64)> = if let Some(single) = single_override {
         vec![(single, dev_idle_threshold_secs())]
     } else if let Ok(cfg) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) {
         // #1438/#1491(C): auto-exempt team orchestrators (leads) from idle
@@ -447,7 +415,9 @@ fn scan_dev_vantage(
             })
             .collect()
     } else {
-        vec![(watched_dev_agent(), dev_idle_threshold_secs())]
+        // fleet.yaml unreadable AND no single-agent override → last-resort
+        // single default. (The override layer above already consulted env.)
+        vec![("dev".to_string(), dev_idle_threshold_secs())]
     };
 
     for (agent, threshold) in &agents {
@@ -476,7 +446,7 @@ fn scan_dev_vantage(
         if !seeding {
             route_idle_alert(
                 home,
-                &dev_idle_recipient(),
+                &crate::fleet::watchdog::resolve_dev_idle_recipient(home),
                 "dev_idle_watchdog",
                 &format!(
                     "[dev_idle_watchdog] agent '{agent}' has been silent for \
@@ -678,7 +648,7 @@ fn scan_fleet_vantage(
     let agent_list: Vec<&str> = pairs.iter().map(|(n, _)| n.as_str()).collect();
     route_idle_alert(
         home,
-        &fleet_idle_recipient(),
+        &crate::fleet::watchdog::resolve_fleet_idle_recipient(home),
         "fleet_idle_watchdog",
         &format!(
             "[fleet_idle_watchdog] all tracked agents silent > {}s \
@@ -1239,39 +1209,51 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    // #1812-followup: env-override + fleet-config precedence for the idle
+    // watchdog recipients/agent now live in `fleet::watchdog` tests (the
+    // resolution logic moved there). The §3.9 real-entry test
+    // `fleet_dev_recipient_routes_idle_alert` below proves the fleet.yaml value
+    // reaches the live scan path.
+
+    /// §3.9 real-entry: a fleet.yaml `watchdog.dev_recipient` (+ single-agent
+    /// `idle_watchdog_agent`) must reach the live `scan_and_emit` → dev-vantage →
+    /// `route_idle_alert` path — the alert lands in the fleet-configured recipient,
+    /// NOT the built-in `lead` default. Proves the config is read at the real call
+    /// site, not just by the resolver in isolation.
     #[test]
-    fn watched_dev_agent_honors_env_override() {
+    fn fleet_dev_recipient_routes_idle_alert() {
         let _g = env_lock();
-        std::env::set_var("AGEND_IDLE_WATCHDOG_AGENT", "custom-dev-name");
-        let agent = watched_dev_agent();
         std::env::remove_var("AGEND_IDLE_WATCHDOG_AGENT");
-        assert_eq!(agent, "custom-dev-name");
-    }
-
-    #[test]
-    fn dev_idle_recipient_honors_env_override() {
-        let _g = env_lock();
-        std::env::set_var("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT", "alice");
-        let r = dev_idle_recipient();
         std::env::remove_var("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT");
-        assert_eq!(r, "alice");
-    }
-
-    /// #1563: unset → `lead` (was `general`, which spammed the general
-    /// assistant with fleet-idle alerts overnight); a set env value is honored.
-    #[test]
-    fn fleet_idle_recipient_defaults_to_lead_and_honors_env_override() {
-        let _g = env_lock();
-        std::env::remove_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT");
+        let home = tmp_home("fleet-dev-route");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "watchdog:\n  idle_watchdog_agent: dev\n  dev_recipient: custom-arbiter\ninstances: {}\n",
+        )
+        .unwrap();
+        let stale = chrono::Utc::now() - chrono::Duration::seconds(dev_idle_threshold_secs() + 60);
+        write_activity_at(&home, "dev", stale);
+        let mut last_alerted = HashMap::new();
+        scan_and_emit(&home, &mut last_alerted, false);
+        let configured = crate::inbox::drain(&home, "custom-arbiter");
         assert_eq!(
-            fleet_idle_recipient(),
-            "lead",
-            "#1563: fleet-idle default recipient must be lead, not general"
+            configured
+                .iter()
+                .filter(|m| m.kind.as_deref() == Some("dev_idle_watchdog"))
+                .count(),
+            1,
+            "fleet-configured dev_recipient must receive the dev idle alert: {configured:?}"
         );
-        std::env::set_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT", "ops-bot");
-        let overridden = fleet_idle_recipient();
-        std::env::remove_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT");
-        assert_eq!(overridden, "ops-bot", "env override must be honored");
+        let default_lead = crate::inbox::drain(&home, "lead");
+        assert_eq!(
+            default_lead
+                .iter()
+                .filter(|m| m.kind.as_deref() == Some("dev_idle_watchdog"))
+                .count(),
+            0,
+            "built-in default `lead` must NOT receive the dev alert once fleet.yaml overrides it"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     // ── #1022 ghost-agent cleanup tests ───────────────────────────

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -1,6 +1,10 @@
 pub(crate) mod merge;
 pub(crate) mod persist;
 mod resolve;
+pub(crate) mod watchdog;
+
+#[allow(unused_imports)]
+pub use watchdog::WatchdogConfig;
 
 #[allow(unused_imports)]
 pub use persist::{
@@ -133,6 +137,13 @@ pub struct FleetConfig {
     /// the agy backend; other backends ignore it. See `crate::agy_workspace`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agy_workspace_link_base: Option<PathBuf>,
+    /// Watchdog topology — which agent the idle watchdog watches and who receives
+    /// each watchdog / anti-stall / decision-timeout notification. Replaces five
+    /// `AGEND_*` env vars (now a deprecated fallback). Omitted block → built-in
+    /// defaults, byte-identical to the pre-migration behaviour. See
+    /// [`watchdog::WatchdogConfig`].
+    #[serde(default)]
+    pub watchdog: WatchdogConfig,
     #[serde(skip)]
     pub(crate) home: Option<PathBuf>,
 }

--- a/src/fleet/watchdog.rs
+++ b/src/fleet/watchdog.rs
@@ -1,0 +1,332 @@
+//! Watchdog topology config — which agent the idle watchdog watches and who
+//! receives each watchdog / anti-stall / decision-timeout notification.
+//!
+//! These are fleet *topology* (agent + recipient names), so their home is
+//! `fleet.yaml`, not env vars. Five `AGEND_*` env vars previously carried them;
+//! they remain as a **deprecated fallback for one window**, so existing setups
+//! keep working unchanged. Resolution precedence for every field:
+//!
+//! 1. `fleet.yaml` `watchdog:` block (when the field is set / non-empty)
+//! 2. the legacy `AGEND_*` env var (deprecated — warns once per process)
+//! 3. the built-in default
+//!
+//! Remove the env layer after operators have migrated to `fleet.yaml`.
+
+use super::{fleet_yaml_path, FleetConfig};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// `fleet.yaml` top-level `watchdog:` block. Every field is optional; an omitted
+/// field falls through to the env fallback, then the built-in default (see module
+/// docs). Defaults reproduce the pre-migration hard-coded behaviour exactly, so a
+/// fleet.yaml without a `watchdog:` block is byte-for-byte unchanged.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WatchdogConfig {
+    /// Legacy **single-agent mode** override for the dev-vantage idle watchdog.
+    /// When set, the watchdog watches ONLY this agent (with the global
+    /// `dev_idle_threshold_secs`) instead of iterating every fleet instance —
+    /// identical to the old `AGEND_IDLE_WATCHDOG_AGENT` behaviour. Omit it
+    /// (the default) to keep the modern per-instance iteration. Default: unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_watchdog_agent: Option<String>,
+    /// Recipient for dev-vantage idle alerts. Default `lead`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dev_recipient: Option<String>,
+    /// Recipient for fleet-vantage idle alerts ("the whole fleet is quiet").
+    /// Default `lead` (#1563: was `general`, which spammed the general assistant).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fleet_recipient: Option<String>,
+    /// Recipients for task-stall warnings. Default `[general, lead]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub task_stall_recipients: Vec<String>,
+    /// Recipient for the decision-timeout auto-default (operator-proceed)
+    /// emission. Default `general`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_timeout_recipient: Option<String>,
+}
+
+/// Load the `watchdog:` block from `fleet.yaml` (cached by mtime via
+/// [`FleetConfig::load`]). `None` when fleet.yaml is missing/unparseable — the
+/// resolvers then fall through to the env / default layers.
+fn load(home: &Path) -> Option<WatchdogConfig> {
+    FleetConfig::load(&fleet_yaml_path(home))
+        .ok()
+        .map(|c| c.watchdog)
+}
+
+fn nonempty(s: Option<String>) -> Option<String> {
+    s.filter(|s| !s.trim().is_empty())
+}
+
+fn env_nonempty(var: &str) -> Option<String> {
+    std::env::var(var).ok().filter(|s| !s.trim().is_empty())
+}
+
+/// Warn once per process that a watchdog topology value came from the deprecated
+/// env fallback rather than `fleet.yaml`. Called per-tick, so dedup is mandatory.
+fn warn_env_deprecated(var: &str, warned: &AtomicBool) {
+    if !warned.swap(true, Ordering::Relaxed) {
+        tracing::warn!(
+            env = var,
+            "watchdog topology via env is deprecated — move it to the fleet.yaml \
+             `watchdog:` block. The env fallback will be removed after the \
+             deprecation window."
+        );
+    }
+}
+
+/// Single-agent override for the dev-vantage idle watchdog. `Some` switches the
+/// watchdog to legacy single-agent mode; `None` keeps per-instance iteration.
+/// Precedence: fleet `watchdog.idle_watchdog_agent` > `AGEND_IDLE_WATCHDOG_AGENT`.
+pub fn resolve_idle_watchdog_agent(home: &Path) -> Option<String> {
+    if let Some(v) = load(home).and_then(|w| nonempty(w.idle_watchdog_agent)) {
+        return Some(v);
+    }
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    match env_nonempty("AGEND_IDLE_WATCHDOG_AGENT") {
+        Some(v) => {
+            warn_env_deprecated("AGEND_IDLE_WATCHDOG_AGENT", &WARNED);
+            Some(v)
+        }
+        None => None,
+    }
+}
+
+/// Recipient for dev-vantage idle alerts. Default `lead`.
+pub fn resolve_dev_idle_recipient(home: &Path) -> String {
+    if let Some(v) = load(home).and_then(|w| nonempty(w.dev_recipient)) {
+        return v;
+    }
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    match env_nonempty("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT") {
+        Some(v) => {
+            warn_env_deprecated("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT", &WARNED);
+            v
+        }
+        None => "lead".to_string(),
+    }
+}
+
+/// Recipient for fleet-vantage idle alerts. Default `lead` (#1563).
+pub fn resolve_fleet_idle_recipient(home: &Path) -> String {
+    if let Some(v) = load(home).and_then(|w| nonempty(w.fleet_recipient)) {
+        return v;
+    }
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    match env_nonempty("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT") {
+        Some(v) => {
+            warn_env_deprecated("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT", &WARNED);
+            v
+        }
+        None => "lead".to_string(),
+    }
+}
+
+/// Recipients for task-stall warnings. Default `[general, lead]`. The env form
+/// is comma-separated; entries are trimmed and empties filtered.
+pub fn resolve_task_stall_recipients(home: &Path) -> Vec<String> {
+    if let Some(w) = load(home) {
+        if !w.task_stall_recipients.is_empty() {
+            return w.task_stall_recipients;
+        }
+    }
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if let Some(custom) = env_nonempty("AGEND_TASK_STALL_RECIPIENTS") {
+        let parsed: Vec<String> = custom
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !parsed.is_empty() {
+            warn_env_deprecated("AGEND_TASK_STALL_RECIPIENTS", &WARNED);
+            return parsed;
+        }
+    }
+    vec!["general".to_string(), "lead".to_string()]
+}
+
+/// Recipient for the decision-timeout auto-default emission. Default `general`.
+pub fn resolve_decision_timeout_recipient(home: &Path) -> String {
+    if let Some(v) = load(home).and_then(|w| nonempty(w.decision_timeout_recipient)) {
+        return v;
+    }
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    match env_nonempty("AGEND_DECISION_TIMEOUT_RECIPIENT") {
+        Some(v) => {
+            warn_env_deprecated("AGEND_DECISION_TIMEOUT_RECIPIENT", &WARNED);
+            v
+        }
+        None => "general".to_string(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    /// Serialize tests that mutate the process-global env vars + the fleet cache.
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        static G: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        G.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-watchdog-cfg-{}-{}-{}",
+            tag,
+            std::process::id(),
+            line!()
+        ));
+        fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn write_fleet(home: &Path, yaml: &str) {
+        fs::write(fleet_yaml_path(home), yaml).expect("write fleet.yaml");
+    }
+
+    fn clear_env() {
+        for v in [
+            "AGEND_IDLE_WATCHDOG_AGENT",
+            "AGEND_IDLE_WATCHDOG_DEV_RECIPIENT",
+            "AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT",
+            "AGEND_TASK_STALL_RECIPIENTS",
+            "AGEND_DECISION_TIMEOUT_RECIPIENT",
+        ] {
+            std::env::remove_var(v);
+        }
+    }
+
+    #[test]
+    fn parses_watchdog_block() {
+        let _g = env_guard();
+        let home = tmp_home("parse");
+        write_fleet(
+            &home,
+            r#"
+watchdog:
+  idle_watchdog_agent: dev
+  dev_recipient: lead
+  fleet_recipient: ops-bot
+  task_stall_recipients:
+    - alice
+    - bob
+  decision_timeout_recipient: carol
+instances: {}
+"#,
+        );
+        let cfg = FleetConfig::load(&fleet_yaml_path(&home)).expect("load");
+        assert_eq!(cfg.watchdog.idle_watchdog_agent.as_deref(), Some("dev"));
+        assert_eq!(cfg.watchdog.dev_recipient.as_deref(), Some("lead"));
+        assert_eq!(cfg.watchdog.fleet_recipient.as_deref(), Some("ops-bot"));
+        assert_eq!(cfg.watchdog.task_stall_recipients, vec!["alice", "bob"]);
+        assert_eq!(
+            cfg.watchdog.decision_timeout_recipient.as_deref(),
+            Some("carol")
+        );
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn omitted_block_defaults_to_builtins() {
+        // Zero-migration: a fleet.yaml without `watchdog:` + no env → built-ins.
+        let _g = env_guard();
+        clear_env();
+        let home = tmp_home("defaults");
+        write_fleet(&home, "instances: {}\n");
+        assert_eq!(resolve_idle_watchdog_agent(&home), None);
+        assert_eq!(resolve_dev_idle_recipient(&home), "lead");
+        // #1563: fleet-idle default must be lead, not general.
+        assert_eq!(resolve_fleet_idle_recipient(&home), "lead");
+        assert_eq!(
+            resolve_task_stall_recipients(&home),
+            vec!["general".to_string(), "lead".to_string()]
+        );
+        assert_eq!(resolve_decision_timeout_recipient(&home), "general");
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn fleet_config_wins_over_env() {
+        // Precedence: fleet.yaml value beats the env fallback.
+        let _g = env_guard();
+        clear_env();
+        std::env::set_var("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT", "env-dev");
+        std::env::set_var("AGEND_TASK_STALL_RECIPIENTS", "env-a, env-b");
+        std::env::set_var("AGEND_DECISION_TIMEOUT_RECIPIENT", "env-dec");
+        let home = tmp_home("fleet-wins");
+        write_fleet(
+            &home,
+            r#"
+watchdog:
+  dev_recipient: yaml-dev
+  task_stall_recipients:
+    - yaml-a
+  decision_timeout_recipient: yaml-dec
+instances: {}
+"#,
+        );
+        assert_eq!(resolve_dev_idle_recipient(&home), "yaml-dev");
+        assert_eq!(resolve_task_stall_recipients(&home), vec!["yaml-a"]);
+        assert_eq!(resolve_decision_timeout_recipient(&home), "yaml-dec");
+        clear_env();
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn env_used_when_fleet_field_absent() {
+        // Deprecation fallback: with no fleet value, the env wins over default.
+        let _g = env_guard();
+        clear_env();
+        std::env::set_var("AGEND_IDLE_WATCHDOG_AGENT", "single-dev");
+        std::env::set_var("AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT", "env-fleet");
+        let home = tmp_home("env-fallback");
+        write_fleet(&home, "watchdog: {}\ninstances: {}\n");
+        assert_eq!(
+            resolve_idle_watchdog_agent(&home),
+            Some("single-dev".to_string())
+        );
+        assert_eq!(resolve_fleet_idle_recipient(&home), "env-fleet");
+        clear_env();
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn task_stall_env_comma_split_and_whitespace_filtered() {
+        let _g = env_guard();
+        clear_env();
+        std::env::set_var("AGEND_TASK_STALL_RECIPIENTS", " alice, bob ,, carol ");
+        let home = tmp_home("stall-split");
+        write_fleet(&home, "instances: {}\n");
+        assert_eq!(
+            resolve_task_stall_recipients(&home),
+            vec!["alice".to_string(), "bob".to_string(), "carol".to_string()]
+        );
+        // Whitespace-only env falls back to the built-in default.
+        std::env::set_var("AGEND_TASK_STALL_RECIPIENTS", "   ");
+        assert_eq!(
+            resolve_task_stall_recipients(&home),
+            vec!["general".to_string(), "lead".to_string()]
+        );
+        clear_env();
+        fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn missing_fleet_yaml_falls_back_to_env_then_default() {
+        // No fleet.yaml at all (load fails) → env, then default.
+        let _g = env_guard();
+        clear_env();
+        let home = tmp_home("no-yaml");
+        // No fleet.yaml written.
+        assert_eq!(resolve_dev_idle_recipient(&home), "lead");
+        std::env::set_var("AGEND_IDLE_WATCHDOG_DEV_RECIPIENT", "env-dev");
+        assert_eq!(resolve_dev_idle_recipient(&home), "env-dev");
+        clear_env();
+        fs::remove_dir_all(&home).ok();
+    }
+}


### PR DESCRIPTION
## What

The five watchdog-topology env vars carry agent / recipient **names** — fleet *topology*, not env tuning — so their home is `fleet.yaml`. Adds a top-level `watchdog:` block and routes all five read-sites through it; the env vars stay as a **deprecated one-window fallback**.

| `fleet.yaml watchdog.*` | replaces env var |
|---|---|
| `idle_watchdog_agent` | `AGEND_IDLE_WATCHDOG_AGENT` |
| `dev_recipient` | `AGEND_IDLE_WATCHDOG_DEV_RECIPIENT` |
| `fleet_recipient` | `AGEND_IDLE_WATCHDOG_FLEET_RECIPIENT` |
| `task_stall_recipients[]` | `AGEND_TASK_STALL_RECIPIENTS` |
| `decision_timeout_recipient` | `AGEND_DECISION_TIMEOUT_RECIPIENT` |

## Precedence

Everywhere: **fleet.yaml `watchdog:` value (set / non-empty) > legacy `AGEND_*` env (deprecated, warns once per process) > built-in default.** An omitted `watchdog:` block is byte-identical to pre-migration behaviour (zero migration).

## Changes

- **`src/fleet/watchdog.rs` (new)** — `WatchdogConfig` (5 fields) + 5 resolvers with warn-once env-deprecation dedup; `FleetConfig` gains a `watchdog` field.
- **Read-sites** — `idle_watchdog` (×3), `anti_stall` (×1), `decision_timeout` (×1) switched to the resolvers; old env-only helpers + their unit tests removed (resolution logic now lives in `fleet::watchdog` tests).
- **Semantics preserved** — `AGEND_IDLE_WATCHDOG_AGENT` was a *behavioural switch* (single-agent mode), not just a value; `watchdog.idle_watchdog_agent` keeps that: `Some` → watch only that agent, `None` → modern per-instance iteration.
- **Docs** — `env-vars.md` §8 deprecation note + migration example; `FEATURE-fleet.md` `watchdog:` section.

## Tests

- **§3.9 real-entry tests** (live bus → subscriber → deliver / real `scan_and_emit`): `fleet_dev_recipient_routes_idle_alert`, `fleet_task_stall_recipients_route_via_bus`, `fleet_decision_timeout_recipient_routes_via_bus` — prove a fleet.yaml value reaches actual delivery and the old default recipient no longer receives.
- 7 resolver unit tests (parse / default / fleet>env precedence / env-fallback / comma-split / missing-yaml).
- Local CI-parity preflight green: `fmt --check`, `clippy --all-targets --features tray -D warnings`, `cargo test --tests --features tray` (unit + integration + invariants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)