### PR TITLE
fix: bug-hunt r1 — shutdown PID-reuse kill, api::call port/cookie TOCTOU, accept-loop errors (refs #1812)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -279,7 +279,40 @@ pub fn serve(
         std::sync::atomic::Ordering::Relaxed,
     );
 
-    for stream in listener.incoming().flatten() {
+    // #bughunt-r1 (#4): explicit accept-error handling. The old
+    // `.incoming().flatten()` silently dropped every `accept()` Err with no log
+    // and no backoff — a persistent failure (e.g. EMFILE) would hot-spin and the
+    // operator would see nothing. Now: rate-limited log, brief backoff, and a
+    // give-up after a sustained streak.
+    let mut consecutive_accept_errors: u32 = 0;
+    for stream in listener.incoming() {
+        let stream = match stream {
+            Ok(s) => {
+                consecutive_accept_errors = 0;
+                s
+            }
+            Err(e) => {
+                consecutive_accept_errors += 1;
+                let (should_log, should_break) =
+                    accept_error_disposition(consecutive_accept_errors);
+                if should_log {
+                    tracing::warn!(
+                        error = %e,
+                        consecutive = consecutive_accept_errors,
+                        "API accept() failed"
+                    );
+                }
+                if should_break {
+                    tracing::error!(
+                        consecutive = consecutive_accept_errors,
+                        "API accept() failing persistently — stopping accept loop"
+                    );
+                    break;
+                }
+                std::thread::sleep(ACCEPT_ERROR_BACKOFF);
+                continue;
+            }
+        };
         // Phase flips to "processing" while we set up the per-session
         // thread; flips back to in_accept at top of next iteration.
         LISTENER_PHASE.store(
@@ -370,6 +403,25 @@ pub fn serve(
 
 pub const LISTENER_PHASE_PROCESSING: u8 = 0;
 pub const LISTENER_PHASE_IN_ACCEPT: u8 = 1;
+
+/// #bughunt-r1 (#4): backoff slept after each `accept()` error so a persistent
+/// failure (e.g. EMFILE from fd exhaustion) doesn't hot-spin the CPU.
+const ACCEPT_ERROR_BACKOFF: std::time::Duration = std::time::Duration::from_millis(50);
+/// Log only the 1st error in a streak and every Nth thereafter (rate-limit).
+const ACCEPT_ERROR_LOG_EVERY: u32 = 50;
+/// Give up the accept loop after this many consecutive `accept()` errors — the
+/// listener is wedged (not a transient blip), so spinning forever helps nobody.
+const MAX_CONSECUTIVE_ACCEPT_ERRORS: u32 = 100;
+
+/// #bughunt-r1 (#4): decide how the accept loop reacts to the Nth consecutive
+/// `accept()` error — `(should_log, should_break)`. Pure so it is unit-testable
+/// without inducing real socket errors. `consecutive` is 1-based (the first
+/// error in a streak is 1).
+fn accept_error_disposition(consecutive: u32) -> (bool, bool) {
+    let should_log = consecutive == 1 || consecutive.is_multiple_of(ACCEPT_ERROR_LOG_EVERY);
+    let should_break = consecutive >= MAX_CONSECUTIVE_ACCEPT_ERRORS;
+    (should_log, should_break)
+}
 
 /// Current API listener thread phase. Read by the periodic thread-dump
 /// handler. Zero (`LISTENER_PHASE_PROCESSING`) on initial daemon boot
@@ -726,7 +778,15 @@ pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
     // it logs + returns `Err` here (in EVERY build, not just debug), so the
     // deadlocking call is refused and the daemon stays live instead of freezing.
     crate::sync_audit::assert_no_registry_lock_for_self_ipc("api::call")?;
-    let stream = crate::ipc::connect_api(home)?;
+    // #bughunt-r1 (#2 TOCTOU): resolve the active run dir ONCE and read BOTH the
+    // api port and the cookie from it. The previous code connected via
+    // `connect_api` (which resolved the run dir internally for the port) and THEN
+    // re-resolved via `find_active_run_dir` for the cookie — during a daemon
+    // restart those two resolutions could land on DIFFERENT run dirs (run dir B's
+    // cookie sent to run dir A's socket → handshake failure). Mirror `call_at`.
+    let run = crate::daemon::find_active_run_dir(home)
+        .ok_or_else(|| anyhow::anyhow!("no active daemon (run dir not found)"))?;
+    let stream = crate::ipc::connect_run_dir_api(&run)?;
     // #1492 backstop (L3): bound every loopback read with a socket-level
     // timeout. #1492-L2 made the guard above always-on + fail-fast (it now
     // returns `Err` in every build, not just a debug panic), so a self-IPC made
@@ -742,8 +802,7 @@ pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
     stream
         .set_read_timeout(Some(timeout))
         .context("set api::call read timeout")?;
-    let run = crate::daemon::find_active_run_dir(home)
-        .ok_or_else(|| anyhow::anyhow!("no active daemon (run dir not found)"))?;
+    // Cookie from the SAME `run` resolution used for the port above (#2 fix).
     let cookie = crate::auth_cookie::read_cookie(&run)?;
 
     let mut writer = stream.try_clone()?;
@@ -1959,5 +2018,87 @@ mod tests {
             .map(|b| b.preset().submit_key)
             .unwrap_or("\r");
         assert_eq!(unknown, "\r");
+    }
+
+    // ── #bughunt-r1 #4: accept-loop error disposition ──────────────────────
+
+    #[test]
+    fn accept_error_disposition_logs_first_then_rate_limits() {
+        // First error in a streak always logs; subsequent ones are suppressed
+        // until the next `ACCEPT_ERROR_LOG_EVERY` multiple — so a persistent
+        // failure produces a bounded log rate, not one line per spin.
+        assert_eq!(accept_error_disposition(1), (true, false), "1st error logs");
+        assert_eq!(
+            accept_error_disposition(2),
+            (false, false),
+            "2nd suppressed"
+        );
+        assert_eq!(
+            accept_error_disposition(ACCEPT_ERROR_LOG_EVERY),
+            (true, false),
+            "every Nth logs"
+        );
+        assert_eq!(
+            accept_error_disposition(ACCEPT_ERROR_LOG_EVERY + 1),
+            (false, false),
+            "N+1 suppressed"
+        );
+    }
+
+    #[test]
+    fn accept_error_disposition_breaks_after_sustained_failure() {
+        // Below the cap → keep going; at/over the cap → give up the loop.
+        assert!(
+            !accept_error_disposition(MAX_CONSECUTIVE_ACCEPT_ERRORS - 1).1,
+            "just under cap keeps accepting"
+        );
+        assert!(
+            accept_error_disposition(MAX_CONSECUTIVE_ACCEPT_ERRORS).1,
+            "at cap breaks the accept loop"
+        );
+    }
+
+    // ── #bughunt-r1 #2: api::call port+cookie single run-dir resolution ────
+
+    /// Source-scan invariant (the runtime TOCTOU needs a daemon-restart race
+    /// that's impractical to drive in a unit test): `api::call` MUST resolve the
+    /// active run dir exactly ONCE and feed that same dir to BOTH the port
+    /// connect (`connect_run_dir_api`) and the cookie read (`read_cookie`). It
+    /// must NOT use `connect_api` (which does its OWN internal resolution) — that
+    /// was the bug: a second `find_active_run_dir` for the cookie could land on a
+    /// different run dir mid-restart.
+    #[test]
+    fn call_resolves_run_dir_once_for_port_and_cookie_bughunt_r1() {
+        let src = include_str!("mod.rs");
+        // Scope to the `pub fn call(` body. Stop at the next top-level item
+        // (`\nfn ` — the following `api_call_read_timeout`) so the scan can NOT
+        // reach the `#[cfg(test)]` module, whose own source contains the literal
+        // `connect_api(` in this test's assert message (#1593 self-match trap).
+        let start = src
+            .find("pub fn call(home: &Path")
+            .expect("call fn present");
+        let after = &src[start..];
+        let end = after[1..]
+            .find("\nfn ")
+            .map(|i| i + 1)
+            .unwrap_or(after.len());
+        let body = &after[..end];
+
+        assert!(
+            !body.contains("connect_api("),
+            "#bughunt-r1 #2: api::call must NOT use connect_api (it re-resolves the \
+             run dir internally → port/cookie TOCTOU); use connect_run_dir_api on a \
+             single resolution"
+        );
+        assert!(
+            body.contains("connect_run_dir_api("),
+            "api::call must connect via connect_run_dir_api on the resolved run dir"
+        );
+        assert_eq!(
+            body.matches("find_active_run_dir(").count(),
+            1,
+            "api::call must resolve the active run dir exactly ONCE (port + cookie \
+             from the same dir)"
+        );
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1181,6 +1181,30 @@ pub(crate) struct ShutdownMetrics {
 /// equivalent); the sequence falls back to `kill_process_tree`
 /// per agent — equivalent semantics, just without the parallel
 /// SIGTERM stage.
+///
+/// #bughunt-r1: per-agent disposition at the post-grace SIGKILL stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GraceDisposition {
+    /// Child still alive after the grace window → escalate to a process-group
+    /// SIGKILL (`kill_process_tree`).
+    HardKill,
+    /// Child already exited cleanly during the grace window → only reap it.
+    /// MUST NOT `kill_process_tree`: the exited child's PID may have been reused
+    /// by an unrelated process, so SIGKILLing that group is collateral damage.
+    ReapOnly,
+}
+
+/// #bughunt-r1 (HIGH): a child that exited cleanly within the grace window must
+/// NOT be hard-killed (PID-reuse → wrong-process-group SIGKILL). Only a holdout
+/// (`still_alive`) escalates to `kill_process_tree`.
+fn grace_disposition(still_alive: bool) -> GraceDisposition {
+    if still_alive {
+        GraceDisposition::HardKill
+    } else {
+        GraceDisposition::ReapOnly
+    }
+}
+
 pub(crate) fn shutdown_sequence(
     home: &Path,
     registry: &AgentRegistry,
@@ -1241,18 +1265,25 @@ pub(crate) fn shutdown_sequence(
             Some(p) => crate::process::is_pid_alive(p),
             None => false,
         };
-        if let Some(p) = pid {
-            crate::process::kill_process_tree(p);
-        }
-        let _ = child.lock().kill();
-        if still_alive {
-            agents_killed_after_grace += 1;
-            tracing::info!(
-                agent = %name,
-                "killed (after grace window)"
-            );
-        } else {
-            tracing::info!(agent = %name, "killed");
+        match grace_disposition(still_alive) {
+            GraceDisposition::HardKill => {
+                // Holdout after the grace window — escalate to a SIGKILL of the
+                // whole process group, then reap the child handle.
+                if let Some(p) = pid {
+                    crate::process::kill_process_tree(p);
+                }
+                let _ = child.lock().kill();
+                let _ = child.lock().wait();
+                agents_killed_after_grace += 1;
+                tracing::info!(agent = %name, "killed (after grace window)");
+            }
+            GraceDisposition::ReapOnly => {
+                // #bughunt-r1: clean exit during the grace window. Do NOT
+                // `kill_process_tree` — the PID may have been reused, so the
+                // group SIGKILL would hit an unrelated process. Just reap.
+                let _ = child.lock().wait();
+                tracing::info!(agent = %name, "exited cleanly during grace window");
+            }
         }
     }
 
@@ -1781,6 +1812,48 @@ fn handle_stage2_restart(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    // ── #bughunt-r1 #1: post-grace SIGKILL must not hit clean exits ─────────
+
+    #[test]
+    fn grace_disposition_reaps_clean_exit_does_not_hard_kill() {
+        // A child that exited cleanly within the grace window → ReapOnly. This
+        // is the crux of the fix: it must NOT escalate to kill_process_tree,
+        // whose PID may have been reused by an unrelated process.
+        assert_eq!(grace_disposition(false), GraceDisposition::ReapOnly);
+        // A holdout still alive after the grace window → HardKill.
+        assert_eq!(grace_disposition(true), GraceDisposition::HardKill);
+    }
+
+    /// Source-scan invariant: in `shutdown_sequence`, `kill_process_tree` must
+    /// only be reachable via the `GraceDisposition::HardKill` arm — never an
+    /// unconditional call (the bug). Guards against a regression that bypasses
+    /// `grace_disposition` and SIGKILLs every child's (possibly-reused) PID.
+    #[test]
+    fn shutdown_kill_process_tree_only_in_hard_kill_arm_bughunt_r1() {
+        let src = include_str!("mod.rs");
+        let start = src
+            .find("pub(crate) fn shutdown_sequence(")
+            .expect("shutdown_sequence present");
+        let after = &src[start..];
+        // Scope to the fn body up to the start of the #[cfg(test)] module.
+        let cfg_test = ["#[cfg(", "test)]"].concat();
+        let end = after.find(&cfg_test).unwrap_or(after.len());
+        let body = &after[..end];
+
+        let hard_kill_arm = body
+            .find("GraceDisposition::HardKill =>")
+            .expect("shutdown_sequence must branch on GraceDisposition::HardKill");
+        let kill_call = body
+            .find("kill_process_tree(")
+            .expect("shutdown_sequence still calls kill_process_tree for holdouts");
+        assert!(
+            kill_call > hard_kill_arm,
+            "#bughunt-r1 #1: kill_process_tree must appear only inside the \
+             GraceDisposition::HardKill arm, never unconditionally (a clean exit \
+             during the grace window must be reaped, not SIGKILL'd)"
+        );
+    }
 
     fn tmp_home(name: &str) -> PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -64,20 +64,16 @@ fn connect_port(port: u16) -> io::Result<TcpStream> {
     Ok(stream)
 }
 
-/// Connect to the active daemon's API port.
-pub fn connect_api(home: &Path) -> Result<TcpStream> {
-    let run =
-        crate::daemon::find_active_run_dir(home).context("no active daemon (run dir not found)")?;
-    let port = read_port(&run, API_NAME).context("daemon api.port missing or invalid")?;
-    connect_port(port).map_err(Into::into)
-}
-
 /// Connect to a SPECIFIC run dir's daemon api port (not the active one).
 ///
-/// #1814: the self-respawn Phase-1 gate must reach the successor's OWN api
-/// port while both predecessor and successor are briefly alive — `connect_api`
-/// (which resolves via `find_active_run_dir`) could return either, so the gate
-/// targets the successor's run dir explicitly.
+/// #1814: the self-respawn Phase-1 gate must reach the successor's OWN api port
+/// while both predecessor and successor are briefly alive — a bare
+/// `find_active_run_dir` resolution could return either, so the gate targets the
+/// successor's run dir explicitly.
+///
+/// #bughunt-r1 (#2): also used by `api::call`, which resolves the active run dir
+/// ONCE and passes it here so the api port and the cookie come from the SAME
+/// resolution (no port-vs-cookie run-dir TOCTOU across a restart).
 pub fn connect_run_dir_api(run_dir: &Path) -> Result<TcpStream> {
     let port = read_port(run_dir, API_NAME)
         .with_context(|| format!("api.port missing/invalid in {}", run_dir.display()))?;


### PR DESCRIPTION
Fixes 3 bugs from bug-hunt round 1 (decision `d-20260606235125012377-6`). Each has a §3.9 test.

## #1 HIGH — `shutdown_sequence` killed clean exits (PID-reuse hazard)
The post-grace SIGKILL stage computed `still_alive` but then called `kill_process_tree(pid)` **unconditionally** — including for children that already exited cleanly in the grace window. On PID reuse that SIGKILLs an unrelated process group.
**Fix:** branch on `grace_disposition(still_alive)` → `HardKill` (holdout: `kill_process_tree` + reap) vs `ReapOnly` (clean exit: just `child.wait()`, never `kill_process_tree`).
**Tests:** `grace_disposition_reaps_clean_exit_does_not_hard_kill` (clean → ReapOnly, alive → HardKill) + a source-scan pinning that `kill_process_tree` lives only in the `HardKill` arm (never unconditional).

## #2 MED — `api::call` port-vs-cookie run-dir TOCTOU
`call` connected via `connect_api` (which resolved the run dir internally for the port) and **then** re-resolved via `find_active_run_dir` for the cookie — across a daemon restart the two resolutions could land on different run dirs (run dir B's cookie sent to A's socket → handshake failure).
**Fix:** resolve the active run dir **once** and read both the port (`connect_run_dir_api`) and the cookie from it — mirrors `call_at`. Removed the now-unused `connect_api`.
**Test:** source-scan invariant — `call` resolves the run dir exactly once and uses `connect_run_dir_api`, not `connect_api`.

## #4 LOW — api accept loop swallowed errors
`listener.incoming().flatten()` silently dropped every `accept()` `Err` with no log and no backoff — a persistent failure (e.g. `EMFILE`) would hot-spin invisibly.
**Fix:** explicit match with rate-limited logging (`accept_error_disposition`), a 50 ms backoff per error, and giving up after `MAX_CONSECUTIVE_ACCEPT_ERRORS` (100).
**Tests:** `accept_error_disposition_*` (first-logs / rate-limit; break-at-cap).

## Verification
- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓ · `cargo test --tests --features tray` ✓ (exit 0); the 5 new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)