### PR TITLE
fix(#t-21): honor dry_run in release_full + close task-claim race

### DIFF
--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -1007,6 +1007,76 @@ pub fn append_batch(
     Ok(seqs)
 }
 
+/// Append `event` atomically iff `precondition` — evaluated under the append
+/// lock against a FRESH on-disk replay — returns `Ok`. This closes the TOCTOU
+/// where a caller validates task state, then appends after a concurrent writer
+/// has already mutated it (e.g. #t-21: two agents claiming the same Open task,
+/// both seeing it Open before either appends, both succeeding).
+///
+/// The precondition runs inside the SAME critical section as the write, so the
+/// state it inspects is the authoritative committed history: any racing writer
+/// either committed before us (and is visible) or is blocked waiting for the
+/// lock (and will re-validate against OUR committed event next).
+///
+/// On precondition failure NO event is written; the rejection reason is
+/// returned as `Ok(Err(reason))`. The outer `Err` is reserved for IO / replay
+/// failures. Replay/append semantics are otherwise unchanged — this reuses
+/// `replay_uncached` (lock-free) for the read and the same seq/cache plumbing
+/// as [`append_batch`].
+pub fn append_checked<F>(
+    home: &Path,
+    instance: &InstanceName,
+    event: TaskEvent,
+    precondition: F,
+) -> anyhow::Result<Result<u64, String>>
+where
+    F: FnOnce(&TaskBoardState) -> Result<(), String>,
+{
+    let instance = instance.clone();
+    let now = chrono::Utc::now().to_rfc3339();
+    let emitter_id = match crate::agent::resolve_instance(home, instance.as_str()) {
+        Ok((id, _)) => Some(id.full()),
+        Err(e) => {
+            tracing::debug!(instance = %instance, error = %e, "emitter ID resolution failed");
+            None
+        }
+    };
+
+    let mut assigned_seq: Option<u64> = None;
+    let mut rejection: Option<String> = None;
+
+    crate::event_log::append_lines_under_lock(home, LOG_NAME, |log_path| {
+        // FRESH replay under the lock — authoritative committed history.
+        let state = replay_uncached(home)?;
+        if let Err(reason) = precondition(&state) {
+            rejection = Some(reason);
+            return Ok(Vec::new()); // empty ⇒ no write
+        }
+        let seq = max_seq_for_instance(log_path, &instance)? + 1;
+        assigned_seq = Some(seq);
+        let envelope = TaskEventEnvelope {
+            schema_version: SCHEMA_VERSION,
+            seq,
+            timestamp: now.clone(),
+            instance: instance.clone(),
+            emitter_id: emitter_id.clone(),
+            event,
+        };
+        Ok(vec![serde_json::to_string(&envelope)?])
+    })?;
+
+    if let Some(reason) = rejection {
+        return Ok(Err(reason));
+    }
+    invalidate_replay_cache();
+    if let Some(seq) = assigned_seq {
+        let log_path = home.join(format!("{LOG_NAME}.jsonl"));
+        SEQ_CACHE.lock().insert((log_path, instance), seq);
+        return Ok(Ok(seq));
+    }
+    Ok(Ok(0))
+}
+
 /// Tail-scan the hot log for the highest seq# this instance has emitted.
 /// Best-effort: malformed lines are skipped because [`replay`] is the
 /// strict reader; here we just need the high-water mark.

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -190,32 +190,44 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
             if !instance_exists(home, &iname) {
                 return serde_json::json!({"error": format!("instance '{iname}' not found in fleet.yaml")});
             }
+            // #t-21: validate + append in ONE critical section to close the
+            // claim race. Pre-fix, the claimable check ran here (against a
+            // replay snapshot) and the append happened afterwards under a
+            // separate lock that did NOT re-validate — so two agents racing
+            // the same Open task both passed the check and both appended a
+            // Claimed event. `append_checked` re-runs the precondition under
+            // the append lock against a FRESH replay, so exactly one wins.
+            //
             // PR3: dep-derived blocking is computed in-memory at list time
-            // (not persisted). claim must respect that view, otherwise an
-            // operator could claim a task whose deps are unsatisfied. Use
-            // `list_all` (which applies the in-memory dep eval) instead of
-            // raw replay() for the validation read.
-            let tasks_view = list_all(home);
-            let task_view = match tasks_view.iter().find(|t| t.id == id) {
-                Some(t) => t,
-                None => return serde_json::json!({"error": format!("task '{id}' not found")}),
-            };
-            let is_self_reclaim = task_view.status == crate::task_events::TaskStatus::Claimed
-                && task_view.assignee.as_deref() == Some(iname.as_str());
-            if !is_self_reclaim && task_view.status != crate::task_events::TaskStatus::Open {
-                return serde_json::json!({
-                    "error": format!(
-                        "task '{id}' status is '{}', only 'open' tasks can be claimed",
-                        task_view.status
-                    )
-                });
-            }
+            // (not persisted), so the precondition rebuilds the SAME dep-aware
+            // view `list_all` produces (replay → record_to_task → dep eval)
+            // rather than reading raw status — an operator must not claim a
+            // task whose deps are unsatisfied.
+            let claim_id = id.clone();
+            let by = iname.clone();
             let event = crate::task_events::TaskEvent::Claimed {
                 task_id: crate::task_events::TaskId(id.clone()),
                 by: crate::task_events::InstanceName(iname.clone()),
             };
-            match crate::task_events::append(home, &emitter, event) {
-                Ok(_) => {
+            let result = crate::task_events::append_checked(home, &emitter, event, |state| {
+                let mut tasks: Vec<Task> = state.tasks.values().map(record_to_task).collect();
+                super::apply_dependency_eval_in_memory(&mut tasks);
+                let tv = tasks
+                    .iter()
+                    .find(|t| t.id == claim_id)
+                    .ok_or_else(|| format!("task '{claim_id}' not found"))?;
+                let is_self_reclaim = tv.status == crate::task_events::TaskStatus::Claimed
+                    && tv.assignee.as_deref() == Some(by.as_str());
+                if !is_self_reclaim && tv.status != crate::task_events::TaskStatus::Open {
+                    return Err(format!(
+                        "task '{claim_id}' status is '{}', only 'open' tasks can be claimed",
+                        tv.status
+                    ));
+                }
+                Ok(())
+            });
+            match result {
+                Ok(Ok(_)) => {
                     // #807 Item 1: see create arm note. claim's
                     // legacy `status` happens to match lifecycle
                     // ("claimed"), but the field is still the action
@@ -231,6 +243,8 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
                         "status": "claimed",
                     })
                 }
+                // Lost the race / precondition no longer holds — no event written.
+                Ok(Err(reason)) => serde_json::json!({"error": reason}),
                 Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
             }
         }

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1340,6 +1340,75 @@ fn test_claim_already_claimed_by_other_rejected() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// §3.9 regression (#t-21 HIGH #2): N agents racing to claim the SAME Open task
+/// — exactly ONE must win, the rest must be rejected, and the board must end up
+/// Claimed by that single winner. Pre-fix, the claimable check ran before a
+/// separate append lock that did NOT re-validate, so multiple racers all
+/// appended `Claimed` events. Regression-proof: revert the claim arm to
+/// `append` + outer pre-check and this FAILS (successes > 1).
+#[test]
+fn concurrent_claims_exactly_one_wins_t21() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let home = tmp_home("concurrent-claim");
+    const N: usize = 8;
+    let agents: Vec<String> = (0..N).map(|i| format!("agent-{i}")).collect();
+    let agent_refs: Vec<&str> = agents.iter().map(|s| s.as_str()).collect();
+    write_fleet_yaml(&home, &agent_refs);
+
+    let r = handle(
+        &home,
+        "agent-0",
+        &serde_json::json!({"action": "create", "title": "t"}),
+    );
+    let id = r["id"].as_str().unwrap().to_string();
+
+    let successes = AtomicUsize::new(0);
+    let winner: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+    std::thread::scope(|s| {
+        for agent in &agents {
+            let (home, id, successes, winner) = (&home, &id, &successes, &winner);
+            s.spawn(move || {
+                let res = handle(
+                    home,
+                    agent,
+                    &serde_json::json!({"action": "claim", "id": id}),
+                );
+                if res["status"] == "claimed" {
+                    successes.fetch_add(1, Ordering::SeqCst);
+                    *winner.lock().unwrap() = Some(agent.clone());
+                } else {
+                    assert!(
+                        res["error"].as_str().unwrap_or("").contains("only 'open'"),
+                        "a losing racer must get the not-open rejection, got: {res}"
+                    );
+                }
+            });
+        }
+    });
+
+    assert_eq!(
+        successes.load(Ordering::SeqCst),
+        1,
+        "exactly one concurrent claim may succeed — the append-lock revalidation \
+         must reject all racers that lost"
+    );
+    // Final board state must agree with the single reported winner.
+    let winner = winner.lock().unwrap().clone().expect("a winner must exist");
+    let tasks = list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task exists");
+    assert_eq!(
+        task.status,
+        crate::task_events::TaskStatus::Claimed,
+        "board must be Claimed after the race"
+    );
+    assert_eq!(
+        task.assignee.as_deref(),
+        Some(winner.as_str()),
+        "board assignee must be the claim that reported success"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn test_claim_self_reclaim_ok() {
     let home = tmp_home("claim-reclaim");

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -118,6 +118,13 @@ pub struct ReleaseOutcome {
     // drops `None` only, never `Some`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub branch_cleanup_skipped_reason: Option<String>,
+    /// #t-21: on a `dry_run=true` release, a human-readable preview of the
+    /// destructive effects that were deliberately NOT performed (worktree
+    /// removal + binding clear). `None` on a real release. The pre-fix bug ran
+    /// `remove_worktree` + `clear_binding_state` unconditionally, so a dry_run
+    /// actually destroyed the worktree and binding; now they are previewed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dry_run_preview: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -354,33 +361,70 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
         let wt_path = Path::new(wt_path_str);
         let source_repo = source_repo_from_binding(&binding, wt_path);
 
-        match remove_worktree(agent, wt_path, &source_repo) {
-            WorktreeRemoval::Removed => {
-                managed_verified = true;
-                out.worktree_removed = true;
-            }
-            WorktreeRemoval::AlreadyAbsent => {
+        if dry_run {
+            // #t-21: dry_run is observation-only. Classify the worktree with the
+            // SAME checks `remove_worktree` uses (path-exists → absent;
+            // missing .agend-managed marker → refuse; managed+present → would
+            // remove) but perform NO mutation. This closes the bug where
+            // `remove_worktree` deleted the worktree on a dry run before the
+            // (dry-run-honoring) branch cleanup ever ran.
+            if !wt_path.exists() {
                 worktree_absent = true;
-            }
-            WorktreeRemoval::Unmanaged(err) => {
-                out.error = Some(err);
+            } else if !is_daemon_managed(wt_path) {
+                out.error = Some(format!(
+                    "worktree at {} has no .agend-managed marker — refusing to remove (binding NOT cleared)",
+                    wt_path.display()
+                ));
                 return out;
-            }
-            WorktreeRemoval::Failed(err) => {
+            } else {
                 managed_verified = true;
-                out.error = Some(err);
+            }
+        } else {
+            match remove_worktree(agent, wt_path, &source_repo) {
+                WorktreeRemoval::Removed => {
+                    managed_verified = true;
+                    out.worktree_removed = true;
+                }
+                WorktreeRemoval::AlreadyAbsent => {
+                    worktree_absent = true;
+                }
+                WorktreeRemoval::Unmanaged(err) => {
+                    out.error = Some(err);
+                    return out;
+                }
+                WorktreeRemoval::Failed(err) => {
+                    managed_verified = true;
+                    out.error = Some(err);
+                }
             }
         }
     }
 
-    clear_binding_state(home, agent);
-    out.binding_removed = true;
-    // #1465 guardrail: only report `released` when no cleanup step failed.
-    // A `WorktreeRemoval::Failed` set `out.error` above — idempotent success
-    // must NOT mask a real execution error as success (reviewer contract:
-    // "binding present but cleanup failed → released:false + error").
-    if out.error.is_none() {
+    if dry_run {
+        // #t-21: preserve the binding + worktree; report what WOULD happen.
+        // `released` is an observation-success (matches the dry-run branch
+        // cleanup contract), but nothing was actually removed.
+        let wt_preview = if worktree_absent {
+            format!("worktree {wt_path_str} already absent")
+        } else if managed_verified {
+            format!("would remove worktree {wt_path_str}")
+        } else {
+            "no worktree to remove".to_string()
+        };
+        out.dry_run_preview = Some(format!(
+            "dry-run: {wt_preview}; would clear binding for '{agent}'"
+        ));
         out.released = true;
+    } else {
+        clear_binding_state(home, agent);
+        out.binding_removed = true;
+        // #1465 guardrail: only report `released` when no cleanup step failed.
+        // A `WorktreeRemoval::Failed` set `out.error` above — idempotent success
+        // must NOT mask a real execution error as success (reviewer contract:
+        // "binding present but cleanup failed → released:false + error").
+        if out.error.is_none() {
+            out.released = true;
+        }
     }
 
     resolve_branch_cleanup(
@@ -1268,6 +1312,52 @@ mod tests {
         assert!(outcome.error.is_none(), "no error: {:?}", outcome.error);
         assert!(!l.path.exists(), "worktree dir must be gone post-release");
         assert!(crate::binding::read(&home, "agent-h").is_none());
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// §3.9 regression (#t-21 HIGH #1): `release_full(dry_run=true)` must be
+    /// observation-only — the worktree directory AND binding.json must survive.
+    /// Pre-fix, `remove_worktree` + `clear_binding_state` ran unconditionally,
+    /// so a dry run actually destroyed both. Regression-proof: revert the
+    /// `if dry_run` guard in `release_full` and this FAILS (`l.path` gone,
+    /// binding cleared).
+    #[test]
+    fn dry_run_release_preserves_worktree_and_binding_t21() {
+        let home = tmp_home("t21-dry-run");
+        let repo = tmp_repo("t21-dry-run-repo");
+        let l = lease(&home, &repo, "agent-dry", "feat/keep").expect("lease");
+        assert!(l.path.exists(), "pre: worktree must exist");
+        assert!(crate::binding::read(&home, "agent-dry").is_some());
+
+        let outcome = release_full(&home, "agent-dry", true);
+
+        // Observation-success, nothing actually removed.
+        assert!(outcome.released, "dry-run reports observation success");
+        assert!(
+            !outcome.worktree_removed,
+            "dry-run must NOT remove worktree"
+        );
+        assert!(!outcome.binding_removed, "dry-run must NOT clear binding");
+        assert!(outcome.error.is_none(), "no error: {:?}", outcome.error);
+        // The destructive effects are previewed, not performed.
+        assert!(
+            outcome.dry_run_preview.as_deref().is_some_and(
+                |p| p.contains("would remove worktree") && p.contains("would clear binding")
+            ),
+            "dry-run must preview both effects: {:?}",
+            outcome.dry_run_preview
+        );
+        // The actual on-disk state is untouched.
+        assert!(
+            l.path.exists(),
+            "worktree dir MUST survive a dry-run release"
+        );
+        assert!(
+            crate::binding::read(&home, "agent-dry").is_some(),
+            "binding.json MUST survive a dry-run release"
+        );
 
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();


### PR DESCRIPTION
Two HIGH bugs from bug-hunt round-2 (decision `d-20260606235508318409-7`).

## #1 — `release_worktree dry_run=true` actually deleted

`release_full` only gated **branch cleanup** behind `dry_run`. It called `remove_worktree` (worktree deletion, `worktree_pool.rs:357`) and `clear_binding_state` (unbind, `:376`) **unconditionally**, so a dry-run destroyed the worktree directory + `binding.json`.

**Fix:** in `dry_run`, classify the worktree read-only (the same `exists` / `.agend-managed` checks `remove_worktree` performs) and skip **all** destructive effects, populating a new `dry_run_preview` field instead. Branch cleanup already honored `dry_run`.

## #2 — task claim race (TOCTOU)

The claim handler validated the task against a replay snapshot (`handler.rs:198`), then appended under a separate lock (`task_events.rs:982`) that did **not** re-validate. Two agents racing the same Open task both passed the check and both appended a `Claimed` event.

**Fix:** new `task_events::append_checked` re-runs the precondition **under the append lock** against a FRESH `replay_uncached`, so exactly one writer wins. The claim handler's precondition rebuilds the same dep-aware view `list_all` produces (replay → `record_to_task` → dep eval), preserving PR3 dep-blocking. Replay/append semantics are otherwise unchanged (reuses the existing lock + seq/cache plumbing).

## §3.9 regression tests (both regression-proof)

- `dry_run_release_preserves_worktree_and_binding_t21` — after a dry-run release the worktree dir **and** `binding.json` survive; the effects are previewed, not performed.
- `concurrent_claims_exactly_one_wins_t21` — 8 agents race one Open task → exactly one succeeds, the board ends Claimed by that single winner.

## Validation

Local CI-parity preflight green: `fmt --check`, `clippy --all-targets --features tray -D warnings`, `cargo test --tests --features tray` (unit + integration + invariants). Affected suites: `worktree_pool` / `tasks` / `task_events` 189 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)