### PR TITLE
fix: bug-hunt r2 — describe_message live-unread status + ci-watch gc per-watch lock (refs #1812)

### DIFF
--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -261,6 +261,25 @@ pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
+        // #bughunt-r2 #4: hold the per-watch lock across read → decide → remove.
+        // The poll flush (`registry::flush_watch_state`) read-merge-atomic-writes
+        // the SAME file under THIS lock; without it, gc could read a stale
+        // snapshot, decide to remove, and delete the file *while* a concurrent
+        // flush re-writes (resurrects) it. Acquiring the lock first — and
+        // re-reading under it — serialises gc against the poller so a removed
+        // watch stays removed. `remove_watch` only `remove_file`s (it does not
+        // re-acquire the lock), so holding the guard across it is safe.
+        let lock_path = path.with_extension("lock");
+        let _watch_lock = match crate::store::acquire_file_lock(&lock_path) {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::warn!(path = %lock_path.display(), error = %e,
+                    "ci_watch gc: failed to acquire per-watch lock, skipping entry");
+                continue;
+            }
+        };
+        // Re-read UNDER the lock so the TTL decision is on fresh state (a flush
+        // may have landed between the dir scan and the lock acquisition).
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
@@ -771,5 +790,78 @@ mod tests {
         assert!(!json.exists(), "watch .json removed");
         assert!(!lock.exists(), "sibling .lock removed too");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #bughunt-r2 #4: gc must hold the per-watch lock across read→decide→remove
+    /// so it can't delete a watch a concurrent poll flush is re-writing. Drive
+    /// the race deterministically: a holder takes the lock (as `flush_watch_state`
+    /// does), gc runs in another thread and must BLOCK — the expired watch stays
+    /// on disk for the whole window the lock is held; once released, gc removes it.
+    #[test]
+    fn gc_blocks_on_held_watch_lock_then_removes_bughunt_r2() {
+        let dir = tmp_dir("r2-gc-lock-race");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        // An expired watch gc wants to remove.
+        let past = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        let json = ci_dir.join("w.json");
+        std::fs::write(
+            &json,
+            serde_json::json!({"repo":"o/r","branch":"feat","expires_at": past}).to_string(),
+        )
+        .unwrap();
+        let lock_path = json.with_extension("lock");
+
+        // Poller holds the per-watch lock.
+        let held = crate::store::acquire_file_lock(&lock_path).expect("hold watch lock");
+
+        let dir2 = dir.clone();
+        let gc = std::thread::spawn(move || gc_stale_watches(&dir2, "race_test"));
+
+        // While the lock is held, gc cannot remove the watch (it blocks on the
+        // lock). The file must survive the whole hold window.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        assert!(
+            json.exists(),
+            "#bughunt-r2 #4: gc must NOT remove a watch while its per-watch lock is held"
+        );
+
+        // Release → gc unblocks and removes the expired watch.
+        drop(held);
+        let removed = gc.join().expect("gc thread");
+        assert!(
+            !json.exists(),
+            "after the lock is released, gc removes the expired watch"
+        );
+        assert_eq!(removed, 1, "exactly the one expired watch removed");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #bughunt-r2 #4 source-scan: in `gc_stale_watches`, `acquire_file_lock`
+    /// must be reached BEFORE any `remove_watch(` call — i.e. the lock guards the
+    /// removal. Backstops a regression that moves/drops the lock acquisition.
+    #[test]
+    fn gc_acquires_lock_before_remove_watch_bughunt_r2() {
+        let src = include_str!("sweep.rs");
+        let start = src
+            .find("pub fn gc_stale_watches(")
+            .expect("gc_stale_watches present");
+        // Scope to the fn — stop at the `#[cfg(test)]` module so the scan can't
+        // reach this test's own `remove_watch(` / `acquire_file_lock` literals.
+        let after = &src[start..];
+        let cfg_test = ["#[cfg(", "test)]"].concat();
+        let body = &after[..after.find(&cfg_test).unwrap_or(after.len())];
+
+        let lock_at = body
+            .find("acquire_file_lock(")
+            .expect("gc must acquire the per-watch lock");
+        let remove_at = body
+            .find("remove_watch(")
+            .expect("gc still removes stale watches");
+        assert!(
+            lock_at < remove_at,
+            "#bughunt-r2 #4: gc_stale_watches must acquire the per-watch lock \
+             BEFORE removing a watch (lock-before-remove serialises against the poll flush)"
+        );
     }
 }

--- a/src/inbox/message.rs
+++ b/src/inbox/message.rs
@@ -197,6 +197,13 @@ impl InboxMessage {
 pub enum MessageStatus {
     /// Message was read at the given timestamp.
     ReadAt(String, Option<String>), // (read_at, delivery_mode)
+    /// #bughunt-r2 #3: message exists, is NOT yet read, and is still live
+    /// (within the 30d retention window). The previous code returned
+    /// `NotFound` for this — breaking delivery audit of an un-drained message.
+    Unread {
+        delivery_mode: Option<String>,
+        correlation_id: Option<String>,
+    },
     /// Message exists but has not been read and has expired (>30d).
     UnreadExpired,
     /// Message not found.

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -539,7 +539,14 @@ pub fn describe_message(home: &Path, msg_id: &str, instance: &str) -> MessageSta
         if now.signed_duration_since(ts) > chrono::Duration::days(30) {
             return MessageStatus::UnreadExpired;
         }
-        return MessageStatus::NotFound;
+        // #bughunt-r2 #3: a live, not-yet-read message. Previously returned
+        // NotFound (indistinguishable from "no such id") — breaking delivery
+        // audit of an un-drained message. Report it as Unread with its
+        // delivery_mode + correlation_id for correlation tracking.
+        return MessageStatus::Unread {
+            delivery_mode: msg.delivery_mode.clone(),
+            correlation_id: msg.correlation_id.clone(),
+        };
     }
     MessageStatus::NotFound
 }

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -811,9 +811,14 @@ fn test_describe_message_status_three_states() {
     let expired_msg = format!(
         r#"{{"schema_version":1,"id":"m-expired","from":"b","text":"expired","kind":null,"timestamp":"{old_ts}"}}"#
     );
+    // State 3 (#bughunt-r2 #3): live unread (<30d), carrying delivery_mode +
+    // correlation_id — must report Unread, NOT NotFound.
+    let live_unread_msg = format!(
+        r#"{{"schema_version":1,"id":"m-live","from":"c","text":"live","kind":null,"timestamp":"{now}","delivery_mode":"pty","correlation_id":"t-xyz"}}"#
+    );
     fs::write(
         inbox_dir.join("agent1.jsonl"),
-        format!("{read_msg}\n{expired_msg}\n"),
+        format!("{read_msg}\n{expired_msg}\n{live_unread_msg}\n"),
     )
     .ok();
 
@@ -829,7 +834,17 @@ fn test_describe_message_status_three_states() {
         MessageStatus::UnreadExpired
     );
 
-    // NotFound
+    // #bughunt-r2 #3: a live un-drained message → Unread (was NotFound), with
+    // its delivery_mode + correlation_id preserved for delivery audit.
+    assert_eq!(
+        describe_message(&home, "m-live", "agent1"),
+        MessageStatus::Unread {
+            delivery_mode: Some("pty".to_string()),
+            correlation_id: Some("t-xyz".to_string()),
+        }
+    );
+
+    // NotFound (genuinely absent id stays distinct from Unread)
     assert_eq!(
         describe_message(&home, "m-nonexistent", "agent1"),
         MessageStatus::NotFound

--- a/src/mcp/handlers/comms_inbox.rs
+++ b/src/mcp/handlers/comms_inbox.rs
@@ -25,6 +25,21 @@ pub fn handle_describe_message(home: &Path, args: &Value, instance_name: &str) -
             }
             resp
         }
+        crate::inbox::MessageStatus::Unread {
+            delivery_mode,
+            correlation_id,
+        } => {
+            // #bughunt-r2 #3: a live, un-drained message — distinct from
+            // not_found so delivery audit sees it was delivered but not yet read.
+            let mut resp = json!({"status": "unread"});
+            if let Some(mode) = delivery_mode {
+                resp["delivery_mode"] = json!(mode);
+            }
+            if let Some(cid) = correlation_id {
+                resp["correlation_id"] = json!(cid);
+            }
+            resp
+        }
         crate::inbox::MessageStatus::UnreadExpired => {
             json!({"status": "unread_expired"})
         }
@@ -42,4 +57,54 @@ pub fn handle_describe_thread(home: &Path, args: &Value) -> Value {
     let instance = args["instance"].as_str();
     let msgs = crate::inbox::get_thread(home, thread_id, instance);
     json!({"thread_id": thread_id, "messages": msgs, "count": msgs.len()})
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// #bughunt-r2 #3: querying a LIVE, un-drained message by id must report
+    /// `status: "unread"` (with its delivery_mode + correlation_id) — NOT
+    /// `not_found`, which previously broke delivery audit of undelivered work.
+    #[test]
+    fn describe_live_unread_message_returns_status_unread() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-bughunt-r2-unread-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let inbox_dir = home.join("inbox");
+        std::fs::create_dir_all(&inbox_dir).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let msg = format!(
+            r#"{{"schema_version":1,"id":"m-live","from":"lead","text":"hi","kind":"task","timestamp":"{now}","delivery_mode":"pty","correlation_id":"t-abc"}}"#
+        );
+        std::fs::write(inbox_dir.join("agent1.jsonl"), format!("{msg}\n")).unwrap();
+
+        let resp = handle_describe_message(
+            &home,
+            &json!({"message_id": "m-live", "instance": "agent1"}),
+            "caller",
+        );
+        assert_eq!(
+            resp["status"], "unread",
+            "live unread must report status=unread, got {resp}"
+        );
+        assert_eq!(resp["delivery_mode"], "pty");
+        assert_eq!(resp["correlation_id"], "t-abc");
+
+        // A genuinely-absent id stays distinct.
+        let nf = handle_describe_message(
+            &home,
+            &json!({"message_id": "m-nope", "instance": "agent1"}),
+            "caller",
+        );
+        assert_eq!(nf["status"], "not_found");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
 }


### PR DESCRIPTION
Fixes 2 MED bugs from bug-hunt round 2 (decision `d-20260606235508318409-7`). Each has a §3.9 test.

## #3 MED — `describe_message` reported a live unread message as `not_found`
`describe_message` returned `ReadAt` / `UnreadExpired` (>30d) / else `NotFound` — so a **live, not-yet-drained** message (the common case) came back `not_found`, indistinguishable from a bad id and breaking delivery audit.
**Fix:** added `MessageStatus::Unread { delivery_mode, correlation_id }`; `describe_message` returns it for a non-expired unread message; the handler maps it to a distinct `{"status":"unread", delivery_mode?, correlation_id?}`.
**Tests:** storage-level (live unread → `Unread` with fields preserved) + handler-level (`describe_live_unread_message_returns_status_unread`: query live unread by id → `status=unread`; absent id stays `not_found`).

## #4 MED — ci-watch gc removed watches without the per-watch lock
`gc_stale_watches` read each watch, decided, and `remove_watch`'d it **without** the per-watch lock — while the poll flush (`registry::flush_watch_state`) read-merge-atomic-writes the same file **under** that lock. Race: gc deletes a watch a concurrent flush then re-writes (resurrects).
**Fix:** gc now acquires the per-watch lock (`<hash>.lock`) **before** read→decide→remove and re-reads the state under the lock (decision on fresh state). `remove_watch` only `remove_file`s (no lock re-acquire), so holding the guard across it is safe.
**Tests:** a deterministic race (`gc_blocks_on_held_watch_lock_then_removes_bughunt_r2` — a holder takes the lock; gc blocks and the expired watch survives the hold window; once released gc removes it) + a source-scan pinning lock-before-remove ordering.

## Verification
- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓ · `cargo test --tests --features tray` ✓ (exit 0); the 4 new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)