### PR TITLE
fix: bug-hunt r3 — telegram reply awaits send (healing) + discord inbound allowlist gate (refs #1812)

### DIFF
--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -253,12 +253,35 @@ pub(crate) fn map_ready_to_connected(
 }
 
 /// Map a twilight `Message` (from MESSAGE_CREATE dispatch) to
-/// `ChannelEvent::MessageIn`.
+/// `ChannelEvent::MessageIn`, gated on the operator `user_allowlist`.
+///
+/// #bughunt-r3 #3: returns `None` (message dropped) when the author is not
+/// authorised — the gate is baked into the mapper, NOT left to the (still
+/// scaffold) dispatch loop, so no future wiring can emit an un-gated MessageIn.
+/// Mirrors the telegram inbound allowlist gate (`telegram/inbound.rs`).
+/// Fail-closed: `None` / empty / not-listed allowlist → dropped. Discord author
+/// ids are u64 snowflakes; the allowlist is `i64` (matches `ChannelConfig`), so
+/// an id that doesn't fit `i64` also fails closed.
 pub(crate) fn map_message_create_to_message_in(
     msg: &twilight_model::channel::Message,
-) -> ChannelEvent {
+    allowlist: &Option<Vec<i64>>,
+) -> Option<ChannelEvent> {
     use crate::channel::event::{MsgPayload, User};
-    ChannelEvent::MessageIn {
+
+    let author_id = msg.author.id.get();
+    let allowed = i64::try_from(author_id)
+        .ok()
+        .is_some_and(|id| crate::channel::auth::is_authorized_recipient(allowlist, id));
+    if !allowed {
+        tracing::warn!(
+            author = %msg.author.name,
+            user_id = author_id,
+            "discord message rejected by user_allowlist"
+        );
+        return None;
+    }
+
+    Some(ChannelEvent::MessageIn {
         binding: BindingRef::new(
             "discord",
             Some(format!("DC#{}", msg.channel_id)),
@@ -276,7 +299,7 @@ pub(crate) fn map_message_create_to_message_in(
         ts: chrono::DateTime::parse_from_rfc3339(&msg.timestamp.iso_8601().to_string())
             .map(|dt| dt.with_timezone(&chrono::Utc))
             .unwrap_or_else(|_| chrono::Utc::now()),
-    }
+    })
 }
 
 /// Map a twilight `Message` (from REST response) to `MsgRef`.
@@ -923,7 +946,10 @@ mod tests {
         let msg: twilight_model::channel::Message =
             serde_json::from_value(d.clone()).expect("Message");
 
-        let event = super::map_message_create_to_message_in(&msg);
+        // #bughunt-r3 #3: author on the allowlist → emitted.
+        let allowlist = Some(vec![82198898841029460_i64]);
+        let event = super::map_message_create_to_message_in(&msg, &allowlist)
+            .expect("allowlisted author must emit MessageIn");
 
         match event {
             ChannelEvent::MessageIn {
@@ -941,6 +967,34 @@ mod tests {
             }
             other => panic!("expected MessageIn, got: {other:?}"),
         }
+    }
+
+    /// #bughunt-r3 #3: Discord inbound must be allowlist-gated like telegram.
+    /// An author NOT on the allowlist (and the fail-closed `None` / empty cases)
+    /// must be dropped — `map_message_create_to_message_in` returns `None`.
+    #[test]
+    fn discord_message_create_rejected_when_author_not_allowlisted() {
+        let fixture = include_str!("../../tests/fixtures/discord-gateway-message-create.json");
+        let frame: serde_json::Value = serde_json::from_str(fixture).expect("fixture must parse");
+        let d = frame.get("d").expect("d field");
+        let msg: twilight_model::channel::Message =
+            serde_json::from_value(d.clone()).expect("Message");
+
+        // Author 82198898841029460 is NOT in this list → dropped.
+        assert!(
+            super::map_message_create_to_message_in(&msg, &Some(vec![999_i64])).is_none(),
+            "author absent from allowlist must be dropped"
+        );
+        // Fail-closed: unconfigured allowlist (None) → dropped.
+        assert!(
+            super::map_message_create_to_message_in(&msg, &None).is_none(),
+            "None allowlist must fail-closed (drop)"
+        );
+        // Fail-closed: empty allowlist → dropped.
+        assert!(
+            super::map_message_create_to_message_in(&msg, &Some(vec![])).is_none(),
+            "empty allowlist must reject all"
+        );
     }
 
     /// §3.5.10 wire-format fixture: outbound POST /channels/{id}/messages

--- a/src/channel/telegram/reply.rs
+++ b/src/channel/telegram/reply.rs
@@ -54,33 +54,14 @@ pub(super) fn telegram_reply_send_inner(
     if let Some(err) = tests::take_forced_send_error() {
         return Err(err);
     }
-    // If already inside an async runtime, block_on would panic. Spawn
-    // fire-and-forget instead and return a sentinel msg_id. Callers from
-    // the emit path log-and-discard errors, so this is safe.
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        let token = ch.token.clone();
-        let group_id = ch.group_id;
-        let text = text.to_string();
-        let instance_name = instance_name.to_string();
-        handle.spawn(async move {
-            let bot = teloxide::Bot::new(&token);
-            let chat_id = teloxide::types::ChatId(group_id);
-            let res = match topic_id {
-                Some(1) | None => bot.send_message(chat_id, &text).await,
-                Some(tid) => {
-                    bot.send_message(chat_id, &text)
-                        .message_thread_id(teloxide::types::ThreadId(teloxide::types::MessageId(
-                            tid,
-                        )))
-                        .await
-                }
-            };
-            if let Err(e) = res {
-                tracing::warn!(%e, %instance_name, "reply spawn failed");
-            }
-        });
-        return Ok(0);
-    }
+    // #bughunt-r3 #2: AWAIT the send and return its real result. The previous
+    // in-runtime branch spawned the send fire-and-forget and returned `Ok(0)` —
+    // a fake success (msg-id 0) that also swallowed the send error inside the
+    // spawned task, so a stale-topic / supergroup-migration failure NEVER
+    // reached the healing path in `try_telegram_reply_from`. `block_on_value` is
+    // already nested-runtime-safe (it offloads to a scoped thread when a runtime
+    // is current — see `shared_async::block_on_value`), so a single awaited path
+    // works both inside and outside a runtime and surfaces failures to the caller.
     block_on_value(async {
         let bot = teloxide::Bot::new(&ch.token);
         let chat_id = teloxide::types::ChatId(ch.group_id);


### PR DESCRIPTION
Fixes 2 MED channel-layer bugs from bug-hunt round 3 (decision `d-20260607000100703907-8`). R3#1 (mcp-timeout double side-effect) is **assessed + reported, NOT implemented** — see the dispatch report (it is not low-risk; needs a dialectic).

## R3#2 MED — telegram reply returned a fake `Ok(0)` inside a runtime
`telegram_reply_send_inner`, when called inside a tokio runtime, spawned the send **fire-and-forget** and returned `Ok(0)` — a fake success (msg-id 0) that also swallowed the send error inside the spawned task. So a stale-topic / supergroup-migration failure **never** reached the healing path (`handle_supergroup_migration` / `invalidate_and_recreate_topic`) in `try_telegram_reply_from`.
**Fix:** drop the fire-and-forget branch; always go through `block_on_value`, which is already nested-runtime-safe (offloads to a scoped thread when a runtime is current — `shared_async::block_on_value`) and returns the real send result, so failures surface to the caller's healing path. Existing healing tests (`try_telegram_reply_from_invalidates_on_topic_deleted`, `_persists_migrated_chat_id_to_fleet_yaml`) cover the routed-failure path.

## R3#3 MED — Discord inbound had no allowlist gate
`map_message_create_to_message_in` produced a `MessageIn` for **any** author — unlike telegram's inbound `user_allowlist` gate. A fail-open inbound auth hole.
**Fix:** bake the gate into the mapper — it now takes `&Option<Vec<i64>>` and returns `Option<ChannelEvent>` (`None` = dropped) via `channel::auth::is_authorized_recipient`, mirroring telegram. Fail-closed: `None` / empty / not-listed → dropped; a u64 snowflake that doesn't fit `i64` also fails closed. Putting the gate in the **mapper** (not the still-scaffold dispatch loop) means no future wiring can emit an un-gated MessageIn.
**Tests:** allowlisted author → emitted; absent / `None` / empty allowlist → dropped. (Discord is feature-gated; verified via `cargo check --features discord` + the new tests under `--features discord`.)

## Verification
- `cargo fmt --check` ✓
- `cargo clippy --features tray --tests -- -D warnings` ✓ and `cargo clippy --features discord --tests -- -D warnings` ✓
- `cargo test --tests --features tray` ✓ (exit 0); telegram reply tests pass; Discord tests pass under `--features discord`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)