### PR TITLE
instrument: SRL-swallow probe — all backends + previously-silent Path B (refs #1809)

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1001,46 +1001,79 @@ impl StateTracker {
                                 detected
                             };
                             let working_below = patterns.working_state_below(screen_text, matched);
-                            // #1808-flaw2-probe (instrumentation-only, NO behavior
-                            // change): cheerc claims a static bottom status bar (Agy/
-                            // Kiro Thinking = the bare `esc to cancel` token) can sit
-                            // BELOW the error → `working_state_below` overrides a
-                            // ServerRateLimit → masks a stuck throttle. Record it
-                            // empirically: when such an override actually fires on
-                            // Agy/Kiro, log the winning marker + productive silence. NO
-                            // recent productive output ⇒ the override may be masking a
-                            // genuinely-stuck agent (the suspicious case cheerc
-                            // describes) ⇒ WARN; recent output ⇒ INFO (genuine
-                            // recovery). Scoped to Agy/Kiro + SRL-override only (low
-                            // noise); does NOT alter `landed`.
-                            if let Some((_, marker)) = working_below {
-                                if matches!(detected, AgentState::ServerRateLimit)
-                                    && (self.backend_name == Backend::Agy.name()
-                                        || self.backend_name == Backend::KiroCli.name())
-                                {
-                                    let productive_silent_secs =
-                                        self.productive_silence().as_secs();
-                                    if self.recovered_within(SERVER_RATE_LIMIT_RECOVERY_SILENCE) {
+                            // #1809-srl-swallow-probe (instrumentation-only, NO behavior
+                            // change): when a ServerRateLimit is SWALLOWED (landed != SRL)
+                            // it never latches → no auto-retry → the live stuck-agent bug.
+                            // TWO gates can swallow it; probe BOTH, for ALL backends —
+                            // the old #1808-flaw2-probe was scoped to Agy/Kiro and was
+                            // therefore BLIND to the live claude SRL incident. Record the
+                            // raw `recovered_within` bool + `productive_silent_secs` as
+                            // INDEPENDENT fields (not just the pre-judged WARN/INFO level —
+                            // the level is derived from `recovered_within`, itself one of
+                            // the suspects). `dist_from_bottom` locates the matched error
+                            // line. Does NOT alter `landed`.
+                            if matches!(detected, AgentState::ServerRateLimit) {
+                                let recovered =
+                                    self.recovered_within(SERVER_RATE_LIMIT_RECOVERY_SILENCE);
+                                let productive_silent_secs = self.productive_silence().as_secs();
+                                let dist_from_bottom = srl_match_signature(screen_text, matched).1;
+                                match &working_below {
+                                    // Path A: a working marker renders BELOW the error →
+                                    // `working_state_below` override lands that working
+                                    // state, swallowing the SRL (#1769 positional defeat).
+                                    Some((win_state, marker)) => {
+                                        if recovered {
+                                            tracing::info!(
+                                                target: "state_detection",
+                                                agent = %self.instance_name,
+                                                tag = "#1809-srl-swallow-probe",
+                                                path = "working_state_below",
+                                                backend = %self.backend_name,
+                                                working_marker = %marker,
+                                                landed_state = ?win_state,
+                                                recovered_within = recovered,
+                                                productive_silent_secs,
+                                                dist_from_bottom,
+                                                "ServerRateLimit swallowed by working_state_below override (Path A) with recent productive output — likely genuine recovery"
+                                            );
+                                        } else {
+                                            tracing::warn!(
+                                                target: "state_detection",
+                                                agent = %self.instance_name,
+                                                tag = "#1809-srl-swallow-probe",
+                                                path = "working_state_below",
+                                                backend = %self.backend_name,
+                                                working_marker = %marker,
+                                                landed_state = ?win_state,
+                                                recovered_within = recovered,
+                                                productive_silent_secs,
+                                                dist_from_bottom,
+                                                "ServerRateLimit swallowed by working_state_below override (Path A) with NO recent productive output — possible static-chrome mask of a stuck throttle"
+                                            );
+                                        }
+                                    }
+                                    // Path B: NO working marker below, but the
+                                    // `recovered_within`→Idle fallback swallows the SRL.
+                                    // Previously SILENT — the gap that hid the live claude
+                                    // bug. Only reachable when `recovered` is true (that IS
+                                    // the gate); log the raw silence so we can judge whether
+                                    // `recovered_within` is firing legitimately.
+                                    None if recovered => {
                                         tracing::info!(
                                             target: "state_detection",
                                             agent = %self.instance_name,
-                                            tag = "#1808-flaw2-probe",
+                                            tag = "#1809-srl-swallow-probe",
+                                            path = "recovered_within_idle",
                                             backend = %self.backend_name,
-                                            working_marker = %marker,
+                                            recovered_within = recovered,
                                             productive_silent_secs,
-                                            "working_state_below overrode ServerRateLimit (Agy/Kiro) with recent productive output — likely genuine recovery"
-                                        );
-                                    } else {
-                                        tracing::warn!(
-                                            target: "state_detection",
-                                            agent = %self.instance_name,
-                                            tag = "#1808-flaw2-probe",
-                                            backend = %self.backend_name,
-                                            working_marker = %marker,
-                                            productive_silent_secs,
-                                            "working_state_below overrode ServerRateLimit (Agy/Kiro) with NO recent productive output — possible static-chrome mask of a stuck throttle (cheerc Flaw 2)"
+                                            dist_from_bottom,
+                                            "ServerRateLimit swallowed by recovered_within→Idle fallback (Path B) — no working marker below"
                                         );
                                     }
+                                    // No working marker + NOT recovered → SRL latches
+                                    // normally (auto-retry fires); not a swallow, no probe.
+                                    None => {}
                                 }
                             }
                             working_below.map(|(s, _)| s).unwrap_or(fallback)
@@ -1275,15 +1308,31 @@ impl StateTracker {
         }
         self.last_anchor_suppress_hash = Some(suppress_hash);
         let span_fg: Vec<CellFg> = first_occurrence_span(screen_text, matched, fg);
+        // #1809-trivial: `instance_name` can be empty (tracker built before
+        // `set_instance_name`), which rendered a bare `agent=`. Show a placeholder
+        // so the log line is greppable by who-is-this.
+        let agent_label: &str = if self.instance_name.is_empty() {
+            "<unset>"
+        } else {
+            self.instance_name.as_str()
+        };
         tracing::warn!(
-            agent = %self.instance_name,
+            agent = %agent_label,
             backend = %self.backend_name,
             state = ?detected,
             matched = %matched,
             span_fg = ?span_fg,
             line_context = %line_context,
-            "#1450: HIGH_FP pattern matched but rendered fg not red — suppressing transition. \
-             If this was a real backend error, span_fg shows the actual colors (predicate may be too strict)."
+            // #1809-trivial: wording was stale. Post-#1790 the anchor gate has two
+            // regimes — a RED-SGR anchor (ContextFull / ModelUnsupported) and a
+            // content/error-line anchor (`in_error_line`, for RateLimit /
+            // ServerRateLimit). So a suppression here is NOT necessarily "not red";
+            // it's "the active anchor predicate did not hold".
+            "#1450: HIGH_FP pattern matched but the anchor gate did not hold \
+             (red-SGR anchor for ContextFull/ModelUnsupported, or content/error-line \
+             anchor for RateLimit/ServerRateLimit) — suppressing transition. If this \
+             was a real backend error, span_fg shows the actual colors (predicate may \
+             be too strict)."
         );
     }
 

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -353,10 +353,11 @@ impl StatePatterns {
     /// genuinely-stuck error has NO in-flight working marker below it → `None`.
     ///
     /// Returns the winning `(state, marker_text)`. The matched marker substring is
-    /// surfaced for the `#1808-flaw2-probe` instrumentation so a caller can log
-    /// *which* on-screen marker overrode a ServerRateLimit (to check empirically
-    /// whether a static bottom-bar chrome — e.g. Agy/Kiro's bare `esc to cancel` —
-    /// is masking a stuck throttle). The state-selection logic is unchanged (same
+    /// surfaced for the `#1809-srl-swallow-probe` instrumentation (formerly the
+    /// Agy/Kiro-scoped `#1808-flaw2-probe`) so a caller can log *which* on-screen
+    /// marker overrode a ServerRateLimit (to check empirically whether a static
+    /// bottom-bar chrome — e.g. a bare `esc to cancel` — is masking a stuck
+    /// throttle). The state-selection logic is unchanged (same
     /// filter + lowest-marker-below-error pick), so detection behavior is identical.
     pub(crate) fn working_state_below<'a>(
         &self,

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -2699,6 +2699,103 @@ fn server_rate_limit_stale_productive_past_window_still_latches_badge() {
     );
 }
 
+/// Capture ALL tracing events (any target, TRACE and above) emitted while `f`
+/// runs, returning the formatted log text. `tracing_test::traced_test`'s default
+/// filter is crate-path-scoped and DROPS the `#1809-srl-swallow-probe`'s custom
+/// `target: "state_detection"` (verified empirically), so the probe tests need
+/// an unfiltered subscriber installed for the closure's duration.
+fn capture_all_logs<F: FnOnce()>(f: F) -> String {
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    #[derive(Clone)]
+    struct Buf(Arc<Mutex<Vec<u8>>>);
+    impl Write for Buf {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buf mutex")
+                .extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Buf {
+        type Writer = Buf;
+        fn make_writer(&'a self) -> Buf {
+            self.clone()
+        }
+    }
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let sub = tracing_subscriber::fmt()
+        .with_writer(Buf(buf.clone()))
+        .with_max_level(tracing::Level::TRACE)
+        .with_ansi(false)
+        .without_time()
+        .finish();
+    tracing::subscriber::with_default(sub, f);
+    let bytes = buf.lock().expect("capture buf mutex").clone();
+    String::from_utf8(bytes).expect("capture buf is utf8")
+}
+
+/// #1809-srl-swallow-probe (Path B — the previously-SILENT gate, prime suspect
+/// for the live claude incident): a claude ServerRateLimit that is swallowed by
+/// the `recovered_within`→Idle fallback (NO working marker below the error) must
+/// now emit the probe naming `path = "recovered_within_idle"` together with the
+/// RAW `recovered_within` bool + `productive_silent_secs` — so an investigator
+/// can tell WHICH gate ate the SRL (and whether `recovered_within` fired
+/// legitimately) instead of guessing. Drives the FULL `feed_with_fg` ingress.
+#[test]
+fn srl_swallow_probe_names_recovered_within_idle_gate() {
+    let (mut vt, mut st) = claude_tracker();
+    // Recovered: productive output just now → `recovered_within` is true → the
+    // fallback lands Idle, swallowing the SRL (no working marker below it).
+    st.last_productive_output = Some(std::time::Instant::now());
+    let logs = capture_all_logs(|| {
+        drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    });
+    assert_ne!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "precondition: recovered_within must swallow the SRL (Path B)"
+    );
+    assert!(
+        logs.contains("#1809-srl-swallow-probe")
+            && logs.contains("path=\"recovered_within_idle\"")
+            && logs.contains("recovered_within=true"),
+        "Path B (recovered_within→Idle, previously SILENT) must emit the probe \
+         naming the gate + the raw recovered_within bool. logs:\n{logs}"
+    );
+}
+
+/// #1809-srl-swallow-probe (Path A — now ALL backends, including claude; the old
+/// #1808-flaw2-probe was scoped to Agy/Kiro and blind to claude): a claude
+/// ServerRateLimit swallowed by a `working_state_below` override (a Thinking
+/// marker rendered BELOW the error) must emit the probe naming
+/// `path = "working_state_below"` + the winning marker. Drives `feed_with_fg`.
+#[test]
+fn srl_swallow_probe_names_working_state_below_gate_for_claude() {
+    let (mut vt, mut st) = claude_tracker();
+    // SRL error line with a claude working marker ("thought for Ns" → Thinking)
+    // rendered BELOW it → `working_state_below` overrides the SRL. No productive
+    // history → `recovered_within` false → WARN branch (possible stuck mask).
+    let screen = format!("\x1b[2J\x1b[H{SRL_LINE}\r\nthought for 12s\r\n");
+    let logs = capture_all_logs(|| {
+        drive(&mut vt, &mut st, screen.as_bytes());
+    });
+    assert_ne!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "precondition: working_state_below must override the SRL (Path A)"
+    );
+    assert!(
+        logs.contains("#1809-srl-swallow-probe") && logs.contains("path=\"working_state_below\""),
+        "Path A (working_state_below override) must emit the #1809-srl-swallow-probe \
+         for claude (was scoped to Agy/Kiro). logs:\n{logs}"
+    );
+}
+
 /// RateLimit: a claude 429-rejection error rendered PLAIN fires via content.
 #[test]
 fn rate_limit_plain_error_line_fires_via_content_anchor() {


### PR DESCRIPTION
## What

Instrument-only (**zero behavior change**) — adds logging so the next live ServerRateLimit incident says exactly which gate swallowed the SRL. Does **not** resolve the underlying bug (refs #1809; intentionally not closing).

The live incident — a claude worker hit SRL but the daemon never latched it → no auto-retry → stuck — was invisible to the existing `#1808-flaw2-probe` because that probe was scoped to **Agy/Kiro** and covered only **one** of the two gates that can swallow an SRL.

## Changes (`src/state/mod.rs`, logging only — `landed` byte-identical)

- **Path A** (`working_state_below` override): drop the Agy/Kiro backend scope → log for **every backend incl. claude**. Records the winning marker, `landed_state`, and the **raw** `recovered_within` bool + `productive_silent_secs` + `dist_from_bottom` as independent fields (not just the pre-judged WARN/INFO level — the level is derived from `recovered_within`, itself a suspect). WARN/INFO split retained.
- **Path B** (`recovered_within`→Idle fallback): previously **SILENT** — the gap that hid the claude incident. Now emits an INFO probe with the same raw fields.
- **trivial**: `log_anchor_suppress` WARN wording was stale (claimed "not red"). Post-#1790 the anchor gate has two regimes — red-SGR (ContextFull/ModelUnsupported) and content/error-line (`in_error_line`, for RateLimit/ServerRateLimit). Reworded + shows `<unset>` for an empty `agent=` field.

## Tests (§3.9)

Two real-entry `feed_with_fg` tests assert the probe names each gate (`path=recovered_within_idle` / `path=working_state_below`). The probe's custom `target: "state_detection"` is dropped by `tracing_test`'s crate-scoped filter, so the tests install a manual all-targets capturing subscriber.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --features tray --tests -- -D warnings` ✓
- `cargo test --tests --features tray` → **3682 passed, 0 failed** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)