### PR TITLE
inbox: quiet compact-clear + GC TTL/size-cap (task t-20260607080714370222-2)

### DIFF
--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -25,7 +25,7 @@ pub use disk::{check_disk_space, recover_half_writes};
 
 // Storage CRUD (pub)
 pub use storage::{
-    describe_message, drain, enqueue, find_message, get_thread,
+    clear_compact, describe_message, drain, enqueue, find_message, get_thread,
     has_drained_blocker_for_correlation, mark_ci_watch_superseded, sweep_expired, unread_count,
     unread_of_kind,
 };

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -3,6 +3,49 @@ use std::path::{Path, PathBuf};
 
 use super::message::{InboxMessage, MessageStatus};
 
+// ── #inbox-gc retention bounds (decision d-20260607081209372642-1, part b) ──
+//
+// Root cause of the unbounded-looking inbox files: read (drained) messages were
+// retained for 7 DAYS, so a high-throughput agent accumulates 1000s of read
+// rows within that window. Two complementary bounds replace the single 7d TTL:
+//
+// 1. A shorter read TTL for the bulk (`update`/`report`/`ci`/`poll` …), and
+// 2. A per-inbox SIZE CAP on retained read rows — the robust bound a TTL alone
+//    can't provide (a burst inside ANY window still blows past the cap).
+//
+// EXEMPTION: drained `query`/`task` rows are "blockers" — they are read by
+// `has_drained_blocker_for_correlation` (ack-absorption / reply-routing, see
+// storage.rs `has_drained_blocker_for_correlation`) for the full task
+// turnaround, which has no finite upper bound (overnight / multi-day tasks).
+// They keep the original 7d window AND are exempt from the size cap so the
+// audit path never regresses. Unread rows (obligations) keep the 30d window.
+
+/// Read (drained) NON-blocker messages expire this many hours after their
+/// timestamp. Lowered from 7 days — these are the high-volume `update`/`report`/
+/// `ci`/`poll` rows that flood the file.
+const READ_TTL_HOURS: i64 = 48;
+
+/// Read (drained) BLOCKER rows (`kind` ∈ {query, task}) keep this longer window
+/// so `has_drained_blocker_for_correlation` can still see a consumed dispatch
+/// when its reply arrives late. Unchanged from the legacy read TTL.
+const READ_TTL_BLOCKER_DAYS: i64 = 7;
+
+/// Unread (obligation) messages expire this many days after their timestamp.
+/// Unchanged — unread rows are work the agent hasn't acknowledged.
+const UNREAD_TTL_DAYS: i64 = 30;
+
+/// Per-inbox cap on retained read NON-blocker rows (most-recent-N kept,
+/// oldest beyond N dropped regardless of age). The hard bound against a burst.
+const READ_ROW_CAP: usize = 300;
+
+/// A drained row that the ack-absorption / reply-routing audit
+/// (`has_drained_blocker_for_correlation`) depends on: `read_at` set AND
+/// `kind` ∈ {query, task}. Such rows are exempt from the short read TTL and
+/// from the size cap.
+fn is_blocker_row(msg: &InboxMessage) -> bool {
+    msg.read_at.is_some() && matches!(msg.kind.as_deref(), Some("query") | Some("task"))
+}
+
 pub(crate) fn inbox_path(home: &Path, name: &str) -> PathBuf {
     home.join("inbox").join(format!("{name}.jsonl"))
 }
@@ -382,6 +425,235 @@ fn read_drain_file(tmp: &Path) -> Vec<InboxMessage> {
     messages
 }
 
+/// One bounded line in a [`ClearCompactResult`] — a COMPACT projection of an
+/// inbox message (never the full [`InboxMessage`], so a clear can never
+/// reintroduce the multi-megabyte blowup that a full-message drain could).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ClearSummary {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub from: String,
+    /// Single-line, sanitised, ≤[`CLEAR_PREVIEW_CHARS`] preview of the body.
+    pub preview: String,
+    pub marked_read: bool,
+    /// Why this message was kept unread (obligations) or cleared with a note.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Result of [`clear_compact`] — a quiet, trust-preserving inbox clear.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ClearCompactResult {
+    /// Non-obligation messages whose `read_at` was set this call.
+    pub cleared_count: usize,
+    /// Obligation messages deliberately left UNREAD (still need attention).
+    pub kept_unread_count: usize,
+    /// Bounded sample of CLEARED messages (capped at [`CLEAR_SUMMARY_CAP`]).
+    pub summaries: Vec<ClearSummary>,
+    /// How many cleared summaries were omitted past the cap.
+    pub summaries_omitted: usize,
+    /// EVERY kept-unread obligation — NEVER capped (the trust guarantee:
+    /// clearing must never hide a query you owe a reply to or an open task).
+    pub requires_response: Vec<ClearSummary>,
+}
+
+/// Max chars in a [`ClearSummary::preview`] (single line).
+const CLEAR_PREVIEW_CHARS: usize = 60;
+/// Cap on [`ClearCompactResult::summaries`] (cleared sample). `requires_response`
+/// is intentionally NOT capped.
+const CLEAR_SUMMARY_CAP: usize = 200;
+
+/// Collapse a message body to a single sanitised preview line of ≤N chars.
+fn preview_line(text: &str, max_chars: usize) -> String {
+    let collapsed: String = text
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    let normalised = collapsed.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalised.chars().count() > max_chars {
+        let truncated: String = normalised.chars().take(max_chars).collect();
+        format!("{truncated}…")
+    } else {
+        normalised
+    }
+}
+
+fn clear_summary_of(msg: &InboxMessage, marked_read: bool, reason: Option<String>) -> ClearSummary {
+    ClearSummary {
+        id: msg.id.clone(),
+        kind: msg.kind.clone(),
+        from: msg.from.clone(),
+        preview: preview_line(&msg.text, CLEAR_PREVIEW_CHARS),
+        marked_read,
+        reason,
+    }
+}
+
+/// Quiet, trust-preserving inbox clear (#inbox-gc part a).
+///
+/// Sibling of [`drain`]: same `with_inbox_lock` + tmp+fsync+rename write-back,
+/// but it sets `read_at` SELECTIVELY (only non-obligation messages) and returns
+/// COMPACT structs instead of full [`InboxMessage`]s.
+///
+/// `obligation`: returns `Some(reason)` when a message MUST stay unread (an
+/// unanswered query, an open task, anything the caller can't prove is settled —
+/// failure mode is noise, never hidden work) and `None` when it is safe to clear
+/// (`update`/`report`/CI/poll/superseded/ambient). The storage layer is policy-
+/// free; the caller (which can read the task board) supplies the predicate.
+///
+/// TRUST: `read_at` here means "non-obligation cleared from attention", NOT
+/// "obligation accepted". Unlike [`drain`], this does NOT arm the reply-ledger
+/// nor touch `heartbeat_pair` — clearing historical channel backlog must never
+/// fabricate a "must-reply" turn. It DOES consume the notification dedup for
+/// cleared rows (they're no longer pending). Never deletes rows (that's
+/// [`sweep_expired`]'s job); only mutates `read_at`.
+pub fn clear_compact(
+    home: &Path,
+    name: &str,
+    obligation: impl Fn(&InboxMessage) -> Option<String>,
+) -> ClearCompactResult {
+    let path = inbox_path_resolved(home, name);
+    if !path.exists() {
+        return ClearCompactResult {
+            cleared_count: 0,
+            kept_unread_count: 0,
+            summaries: Vec::new(),
+            summaries_omitted: 0,
+            requires_response: Vec::new(),
+        };
+    }
+
+    // Phase 1 (locked): read, selectively mark read_at, write back. Collect the
+    // ids of newly-cleared rows for the phase-2 dedup consume.
+    struct Phase1 {
+        cleared_count: usize,
+        kept_unread_count: usize,
+        summaries: Vec<ClearSummary>,
+        summaries_omitted: usize,
+        requires_response: Vec<ClearSummary>,
+        cleared_ids: Vec<String>,
+    }
+    let result = with_inbox_lock(home, name, |path| {
+        let content = std::fs::read_to_string(path).unwrap_or_default();
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut out: Vec<InboxMessage> = Vec::new();
+        let mut p = Phase1 {
+            cleared_count: 0,
+            kept_unread_count: 0,
+            summaries: Vec::new(),
+            summaries_omitted: 0,
+            requires_response: Vec::new(),
+            cleared_ids: Vec::new(),
+        };
+        let mut changed = false;
+
+        for line in content.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let mut msg: InboxMessage = match serde_json::from_str(line) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if msg.schema_version > InboxMessage::CURRENT_VERSION {
+                tracing::error!(
+                    found = msg.schema_version,
+                    supported = InboxMessage::CURRENT_VERSION,
+                    "dropping inbox message written by newer schema version"
+                );
+                continue;
+            }
+            // Already-read rows are untouched (and not re-summarised).
+            if msg.read_at.is_some() {
+                out.push(msg);
+                continue;
+            }
+            // Superseded rows are always safe to clear (mirror drain()).
+            let obligation_reason = if msg.superseded_by.is_some() {
+                None
+            } else {
+                obligation(&msg)
+            };
+            match obligation_reason {
+                Some(reason) => {
+                    // Obligation → keep UNREAD, surface in requires_response.
+                    p.kept_unread_count += 1;
+                    p.requires_response
+                        .push(clear_summary_of(&msg, false, Some(reason)));
+                    out.push(msg);
+                }
+                None => {
+                    let reason = msg.superseded_by.as_ref().map(|_| "superseded".to_string());
+                    if p.summaries.len() < CLEAR_SUMMARY_CAP {
+                        p.summaries.push(clear_summary_of(&msg, true, reason));
+                    } else {
+                        p.summaries_omitted += 1;
+                    }
+                    if let Some(ref id) = msg.id {
+                        p.cleared_ids.push(id.clone());
+                    }
+                    msg.read_at = Some(now.clone());
+                    p.cleared_count += 1;
+                    changed = true;
+                    out.push(msg);
+                }
+            }
+        }
+
+        if changed {
+            let write_tmp = path.with_extension("jsonl.tmp");
+            let r = (|| -> anyhow::Result<()> {
+                let mut f = std::fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(&write_tmp)?;
+                for m in &out {
+                    writeln!(f, "{}", serde_json::to_string(m)?)?;
+                }
+                f.sync_all()?;
+                std::fs::rename(&write_tmp, path)?;
+                Ok(())
+            })();
+            if let Err(e) = r {
+                tracing::warn!(error = %e, "inbox clear_compact write-back failed");
+            }
+        }
+        p
+    });
+
+    let p = match result {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, "inbox clear_compact lock failed");
+            return ClearCompactResult {
+                cleared_count: 0,
+                kept_unread_count: 0,
+                summaries: Vec::new(),
+                summaries_omitted: 0,
+                requires_response: Vec::new(),
+            };
+        }
+    };
+
+    // Phase 2 (unlocked): consume notification dedup for cleared rows so they
+    // don't re-nudge. Deliberately NONE of drain()'s channel side effects (no
+    // reply-ledger arming, no turn-state touch) — see the TRUST note above.
+    for id in &p.cleared_ids {
+        crate::daemon::notification_dedup::global().mark_consumed(name, id);
+    }
+
+    ClearCompactResult {
+        cleared_count: p.cleared_count,
+        kept_unread_count: p.kept_unread_count,
+        summaries: p.summaries,
+        summaries_omitted: p.summaries_omitted,
+        requires_response: p.requires_response,
+    }
+}
+
 /// Count unread messages (read_at == None) for an agent.
 pub fn unread_count(home: &Path, name: &str) -> (usize, Option<chrono::DateTime<chrono::Utc>>) {
     let path = inbox_path_resolved(home, name);
@@ -434,9 +706,19 @@ pub fn unread_of_kind(
     out
 }
 
-/// Sweep expired messages from all inbox files.
-/// - read_at.is_some() && elapsed > 7 days → delete
-/// - read_at.is_none() && elapsed > 30 days → delete
+/// Sweep expired messages from all inbox files (#inbox-gc part b).
+///
+/// Two-pass per inbox, both serialised under [`with_inbox_lock`]:
+/// 1. **TTL pass** — drop by age, with three tiers:
+///    - unread (`read_at.is_none()`): age > [`UNREAD_TTL_DAYS`]
+///    - read blocker (`is_blocker_row`): age > [`READ_TTL_BLOCKER_DAYS`]
+///    - read non-blocker: age > [`READ_TTL_HOURS`]
+/// 2. **Size-cap pass** — among the TTL survivors, keep at most
+///    [`READ_ROW_CAP`] read NON-blocker rows (most-recent by timestamp);
+///    drop the oldest beyond the cap. Unread + blocker rows are never counted
+///    nor dropped here (obligations / ack-absorption audit window).
+///
+/// File line order is preserved for survivors.
 pub fn sweep_expired(home: &Path) {
     let inbox_dir = home.join("inbox");
     let entries = match std::fs::read_dir(&inbox_dir) {
@@ -459,7 +741,16 @@ pub fn sweep_expired(home: &Path) {
                 Ok(c) => c,
                 Err(_) => return,
             };
-            let mut kept: Vec<String> = Vec::new();
+
+            // Pass 1 (TTL): retain non-expired lines, recording for each kept
+            // line its timestamp + whether it's a read non-blocker (the only
+            // tier the size cap touches).
+            struct Kept {
+                line: String,
+                ts: chrono::DateTime<chrono::Utc>,
+                read_non_blocker: bool,
+            }
+            let mut kept: Vec<Kept> = Vec::new();
             let mut changed = false;
             for line in content.lines() {
                 if line.trim().is_empty() {
@@ -473,16 +764,60 @@ pub fn sweep_expired(home: &Path) {
                     .map(|dt| dt.with_timezone(&chrono::Utc))
                     .unwrap_or(now);
                 let age = now.signed_duration_since(ts);
+                let blocker = is_blocker_row(&msg);
                 let expired = match &msg.read_at {
-                    Some(_) => age > chrono::Duration::days(7),
-                    None => age > chrono::Duration::days(30),
+                    None => age > chrono::Duration::days(UNREAD_TTL_DAYS),
+                    Some(_) if blocker => age > chrono::Duration::days(READ_TTL_BLOCKER_DAYS),
+                    Some(_) => age > chrono::Duration::hours(READ_TTL_HOURS),
                 };
                 if expired {
                     changed = true;
                 } else {
-                    kept.push(line.to_string());
+                    kept.push(Kept {
+                        line: line.to_string(),
+                        ts,
+                        read_non_blocker: msg.read_at.is_some() && !blocker,
+                    });
                 }
             }
+
+            // Pass 2 (size cap): if read non-blocker survivors exceed the cap,
+            // drop the oldest beyond the most-recent READ_ROW_CAP. Find the
+            // cutoff timestamp by descending sort of just those rows' timestamps.
+            let read_count = kept.iter().filter(|k| k.read_non_blocker).count();
+            if read_count > READ_ROW_CAP {
+                let mut ts_desc: Vec<chrono::DateTime<chrono::Utc>> = kept
+                    .iter()
+                    .filter(|k| k.read_non_blocker)
+                    .map(|k| k.ts)
+                    .collect();
+                ts_desc.sort_unstable_by(|a, b| b.cmp(a));
+                let cutoff = ts_desc[READ_ROW_CAP - 1];
+                // Keep read non-blockers strictly newer than cutoff, plus exactly
+                // enough at-the-cutoff rows to total READ_ROW_CAP (ties broken by
+                // file order, deterministic). Everything else (unread/blocker) is
+                // always retained.
+                let mut at_cutoff_budget =
+                    READ_ROW_CAP - ts_desc.iter().filter(|t| **t > cutoff).count();
+                let before = kept.len();
+                kept.retain(|k| {
+                    if !k.read_non_blocker {
+                        return true;
+                    }
+                    if k.ts > cutoff {
+                        return true;
+                    }
+                    if k.ts == cutoff && at_cutoff_budget > 0 {
+                        at_cutoff_budget -= 1;
+                        return true;
+                    }
+                    false
+                });
+                if kept.len() != before {
+                    changed = true;
+                }
+            }
+
             if changed {
                 if kept.is_empty() {
                     let _ = std::fs::remove_file(path);
@@ -494,8 +829,8 @@ pub fn sweep_expired(home: &Path) {
                             .write(true)
                             .truncate(true)
                             .open(&tmp)?;
-                        for l in &kept {
-                            writeln!(f, "{l}")?;
+                        for k in &kept {
+                            writeln!(f, "{}", k.line)?;
                         }
                         f.sync_all()?;
                         std::fs::rename(&tmp, path)?;

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -794,6 +794,305 @@ fn test_sweep_unread_30d() {
     fs::remove_dir_all(&home).ok();
 }
 
+// ── #inbox-gc part b: shortened read TTL + blocker exemption + size cap ──
+
+#[test]
+fn sweep_read_non_blocker_48h() {
+    let home = tmp_home("sweep-48h");
+    let inbox_dir = home.join("inbox");
+    fs::create_dir_all(&inbox_dir).ok();
+    let old = (chrono::Utc::now() - chrono::Duration::hours(50)).to_rfc3339();
+    let fresh = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+    let old_row = format!(
+        r#"{{"schema_version":1,"id":"m-old","from":"a","text":"x","kind":"update","timestamp":"{old}","read_at":"{old}"}}"#
+    );
+    let fresh_row = format!(
+        r#"{{"schema_version":1,"id":"m-fresh","from":"b","text":"x","kind":"update","timestamp":"{fresh}","read_at":"{fresh}"}}"#
+    );
+    fs::write(
+        inbox_dir.join("a1.jsonl"),
+        format!("{old_row}\n{fresh_row}\n"),
+    )
+    .ok();
+    sweep_expired(&home);
+    let content = fs::read_to_string(inbox_dir.join("a1.jsonl")).expect("file");
+    assert!(
+        !content.contains("m-old"),
+        "read non-blocker >48h must be swept (was 7d)"
+    );
+    assert!(
+        content.contains("m-fresh"),
+        "read non-blocker <48h must survive"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn sweep_exempts_drained_blocker_until_7d() {
+    let home = tmp_home("sweep-blocker");
+    let inbox_dir = home.join("inbox");
+    fs::create_dir_all(&inbox_dir).ok();
+    // A drained task (blocker) 3d old is past the 48h read TTL but within the
+    // 7d blocker window → MUST survive so has_drained_blocker_for_correlation
+    // still answers when the worker's reply arrives late.
+    let d3 = (chrono::Utc::now() - chrono::Duration::days(3)).to_rfc3339();
+    let d8 = (chrono::Utc::now() - chrono::Duration::days(8)).to_rfc3339();
+    let kept = format!(
+        r#"{{"schema_version":1,"id":"blk-3d","from":"lead","text":"t","kind":"task","timestamp":"{d3}","read_at":"{d3}","correlation_id":"c-keep"}}"#
+    );
+    let gone = format!(
+        r#"{{"schema_version":1,"id":"blk-8d","from":"lead","text":"q","kind":"query","timestamp":"{d8}","read_at":"{d8}","correlation_id":"c-gone"}}"#
+    );
+    fs::write(inbox_dir.join("a1.jsonl"), format!("{kept}\n{gone}\n")).ok();
+    sweep_expired(&home);
+    let content = fs::read_to_string(inbox_dir.join("a1.jsonl")).expect("file");
+    assert!(
+        content.contains("blk-3d"),
+        "drained blocker <7d must survive (ack-absorption audit window)"
+    );
+    assert!(
+        !content.contains("blk-8d"),
+        "drained blocker >7d must be swept"
+    );
+    assert!(
+        has_drained_blocker_for_correlation(&home, "a1", "c-keep"),
+        "ack-absorption audit must still see the surviving blocker"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn sweep_size_cap_keeps_recent_n_read_rows() {
+    let home = tmp_home("sweep-cap");
+    let inbox_dir = home.join("inbox");
+    fs::create_dir_all(&inbox_dir).ok();
+    let mut lines = String::new();
+    // 350 FRESH (<48h) read non-blocker rows, staggered so newest = highest i.
+    for i in 0..350 {
+        let ts = (chrono::Utc::now() - chrono::Duration::minutes(350 - i)).to_rfc3339();
+        lines.push_str(&format!(
+            r#"{{"schema_version":1,"id":"r{i}","from":"x","text":"x","kind":"update","timestamp":"{ts}","read_at":"{ts}"}}"#
+        ));
+        lines.push('\n');
+    }
+    // An unread obligation + a drained blocker — neither counted nor evicted.
+    let now = chrono::Utc::now().to_rfc3339();
+    lines.push_str(&format!(
+        r#"{{"schema_version":1,"id":"unread1","from":"x","text":"x","kind":"query","timestamp":"{now}"}}"#
+    ));
+    lines.push('\n');
+    lines.push_str(&format!(
+        r#"{{"schema_version":1,"id":"blk1","from":"x","text":"x","kind":"task","timestamp":"{now}","read_at":"{now}"}}"#
+    ));
+    lines.push('\n');
+    fs::write(inbox_dir.join("a1.jsonl"), lines).ok();
+    sweep_expired(&home);
+    let content = fs::read_to_string(inbox_dir.join("a1.jsonl")).expect("file");
+    let read_kept = content.lines().filter(|l| l.contains(r#""id":"r"#)).count();
+    assert_eq!(
+        read_kept, 300,
+        "size cap must keep exactly READ_ROW_CAP read non-blocker rows"
+    );
+    assert!(
+        content.contains(r#""id":"r349""#) && content.contains(r#""id":"r50""#),
+        "newest read rows kept"
+    );
+    assert!(
+        !content.contains(r#""id":"r0""#) && !content.contains(r#""id":"r49""#),
+        "oldest read rows beyond cap dropped"
+    );
+    assert!(
+        content.contains("unread1"),
+        "unread obligation never evicted by the cap"
+    );
+    assert!(
+        content.contains("blk1"),
+        "drained blocker never evicted by the cap"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+// ── #inbox-gc part a: clear_compact (quiet trust-preserving clear) ──────
+
+fn keep_query_and_task(m: &InboxMessage) -> Option<String> {
+    match m.kind.as_deref() {
+        Some("query") => Some("unanswered query".into()),
+        Some("task") => Some("open task".into()),
+        _ => None,
+    }
+}
+
+#[test]
+fn clear_compact_keeps_obligations_clears_rest() {
+    let _g = READONLY_TEST_LOCK.lock();
+    let home = tmp_home("clear-oblig");
+    enqueue(
+        &home,
+        "a1",
+        msg()
+            .sender("lead")
+            .kind("query")
+            .id("q1")
+            .text("q?")
+            .build(),
+    )
+    .unwrap();
+    enqueue(
+        &home,
+        "a1",
+        msg()
+            .sender("lead")
+            .kind("task")
+            .id("t1")
+            .text("do x")
+            .build(),
+    )
+    .unwrap();
+    enqueue(
+        &home,
+        "a1",
+        msg()
+            .sender("lead")
+            .kind("update")
+            .id("u1")
+            .text("fyi")
+            .build(),
+    )
+    .unwrap();
+    enqueue(
+        &home,
+        "a1",
+        msg()
+            .sender("ci")
+            .kind("report")
+            .id("rp1")
+            .text("done")
+            .build(),
+    )
+    .unwrap();
+    enqueue(
+        &home,
+        "a1",
+        msg()
+            .sender("sys")
+            .kind("update")
+            .id("sup1")
+            .text("old")
+            .superseded_by("new")
+            .build(),
+    )
+    .unwrap();
+
+    let r = clear_compact(&home, "a1", keep_query_and_task);
+    assert_eq!(
+        r.cleared_count, 3,
+        "update + report + superseded cleared (3)"
+    );
+    assert_eq!(r.kept_unread_count, 2, "query + task kept unread (2)");
+    assert_eq!(r.requires_response.len(), 2, "both obligations surfaced");
+    assert_eq!(
+        unread_count(&home, "a1").0,
+        2,
+        "obligations remain UNREAD on disk after clear"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn clear_compact_summaries_bounded() {
+    let _g = READONLY_TEST_LOCK.lock();
+    let home = tmp_home("clear-bound");
+    for i in 0..250 {
+        enqueue(
+            &home,
+            "a1",
+            msg()
+                .sender("x")
+                .kind("update")
+                .id(&format!("u{i}"))
+                .text("x")
+                .build(),
+        )
+        .unwrap();
+    }
+    let r = clear_compact(&home, "a1", |_| None);
+    assert_eq!(r.cleared_count, 250, "all 250 cleared");
+    assert_eq!(
+        r.summaries.len(),
+        200,
+        "summaries capped at CLEAR_SUMMARY_CAP"
+    );
+    assert_eq!(
+        r.summaries_omitted, 50,
+        "overflow counted, not dropped silently"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn clear_compact_preview_single_line_bounded() {
+    let _g = READONLY_TEST_LOCK.lock();
+    let home = tmp_home("clear-preview");
+    let long = format!("line one\nline two\t{}", "z".repeat(200));
+    enqueue(
+        &home,
+        "a1",
+        msg()
+            .sender("x")
+            .kind("update")
+            .id("u1")
+            .text_owned(long)
+            .build(),
+    )
+    .unwrap();
+    let r = clear_compact(&home, "a1", |_| None);
+    let s = &r.summaries[0];
+    assert!(
+        !s.preview.contains('\n') && !s.preview.contains('\t'),
+        "preview must be a sanitised single line, got {:?}",
+        s.preview
+    );
+    assert!(
+        s.preview.chars().count() <= CLEAR_PREVIEW_CHARS_TEST + 1,
+        "preview ≤60 chars (+ellipsis), got {}",
+        s.preview.chars().count()
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Mirror of the private `CLEAR_PREVIEW_CHARS` const for the bound assertion.
+const CLEAR_PREVIEW_CHARS_TEST: usize = 60;
+
+#[test]
+fn clear_compact_does_not_arm_reply_ledger_source_scan() {
+    // STRUCTURAL invariant (decision d-20260607081209372642-1): a compact-clear
+    // must NEVER arm the reply-ledger or touch heartbeat_pair — else clearing a
+    // historical channel backlog fabricates false "must-reply" turns. The state
+    // lives in a global singleton (behavioural isolation is unreliable across
+    // parallel tests), so we assert structurally on the function body.
+    let src = include_str!("storage.rs");
+    let start = src
+        .find("pub fn clear_compact")
+        .expect("clear_compact present");
+    let body = &src[start..];
+    let end = body
+        .find("\n/// Count unread messages")
+        .unwrap_or(body.len());
+    let body = &body[..end];
+    assert!(
+        !body.contains("reply_ledger"),
+        "clear_compact must NOT arm reply_ledger from backlog"
+    );
+    assert!(
+        !body.contains("heartbeat_pair"),
+        "clear_compact must NOT touch heartbeat_pair"
+    );
+    assert!(
+        body.contains("mark_consumed"),
+        "clear_compact SHOULD consume notification dedup for cleared rows"
+    );
+}
+
 #[test]
 fn test_describe_message_status_three_states() {
     let home = tmp_home("describe-msg");

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -725,7 +725,7 @@ pub(super) fn handle_inbox(home: &Path, instance_name: &str) -> Value {
 // #1286: inbox describe handlers extracted to stay under file_size_invariant.
 #[path = "comms_inbox.rs"]
 mod comms_inbox;
-pub(super) use comms_inbox::{handle_describe_message, handle_describe_thread};
+pub(super) use comms_inbox::{handle_describe_message, handle_describe_thread, handle_inbox_clear};
 
 /// Sprint 55 P0-C — true when the caller passed `bind: false`, signaling
 /// a read-only RCA/audit/design dispatch that should NOT trigger

--- a/src/mcp/handlers/comms_inbox.rs
+++ b/src/mcp/handlers/comms_inbox.rs
@@ -59,6 +59,49 @@ pub fn handle_describe_thread(home: &Path, args: &Value) -> Value {
     json!({"thread_id": thread_id, "messages": msgs, "count": msgs.len()})
 }
 
+/// #inbox-gc part a: quiet compact-clear. Marks non-obligation messages read
+/// and returns bounded compact summaries; obligations stay unread + surface in
+/// `requires_response`. Does NOT drain (no reply-ledger arm / heartbeat touch).
+pub fn handle_inbox_clear(home: &Path, instance_name: &str) -> Value {
+    let result =
+        crate::inbox::clear_compact(home, instance_name, |msg| obligation_reason(home, msg));
+    serde_json::to_value(&result).unwrap_or_else(|e| json!({"error": format!("serialize: {e}")}))
+}
+
+/// Trust rule (decision d-20260607081209372642-1): which UNREAD messages MUST
+/// stay unread on a compact-clear. `Some(reason)` → keep unread; `None` → safe
+/// to clear. `read_at` means "non-obligation cleared from attention", NOT
+/// "obligation accepted" — so an unanswered query or an unsettled task is kept.
+/// When proof is uncertain we KEEP (failure mode = noise, never hidden work).
+fn obligation_reason(home: &Path, msg: &crate::inbox::InboxMessage) -> Option<String> {
+    match msg.kind.as_deref() {
+        // An unanswered query — the sender is blocked waiting on a reply.
+        Some("query") => Some("unanswered query".to_string()),
+        // A delegated task — keep unless the task board proves it terminal.
+        Some("task") => {
+            let tid = msg.task_id.as_deref().or(msg.correlation_id.as_deref());
+            match tid {
+                Some(id) => match crate::tasks::load_by_id(home, id) {
+                    Some(t)
+                        if matches!(
+                            t.status,
+                            crate::task_events::TaskStatus::Done
+                                | crate::task_events::TaskStatus::Cancelled
+                        ) =>
+                    {
+                        None
+                    }
+                    Some(t) => Some(format!("task {id} not terminal (status={})", t.status)),
+                    None => Some(format!("task {id} not on board — kept")),
+                },
+                None => Some("task without id — kept".to_string()),
+            }
+        }
+        // update / report / ci-watch / poll / ambient — safe to clear.
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -330,7 +330,11 @@ action_adapter!(dispatch_team, "team", [
 //   - else `thread_id` present → describe thread
 //   - else → drain pending
 pub(crate) fn dispatch_inbox(ctx: &HandlerCtx<'_>) -> Value {
-    if ctx
+    if ctx.args.get("action").and_then(|v| v.as_str()) == Some("clear") {
+        // #inbox-gc part a: quiet compact-clear (explicit action — never the
+        // no-arg drain). Obligations stay unread; returns bounded summaries.
+        comms::handle_inbox_clear(ctx.home, ctx.instance_name)
+    } else if ctx
         .args
         .get("message_id")
         .and_then(|v| v.as_str())

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -3067,3 +3067,121 @@ fn task_id_required_stable_code_on_team_broadcast() {
     std::env::remove_var("AGEND_HOME");
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── #inbox-gc part a: quiet compact-clear via the real `inbox` MCP entry ──
+
+/// §3.9: a representative multi-kind backlog (query + task[unsettled] + update +
+/// report + superseded) cleared through `handle_tool("inbox", {action:"clear"})`
+/// must KEEP the obligations (query + unsettled task) unread and surface them in
+/// `requires_response`, while clearing the chatter — and never silently swallow
+/// an obligation.
+#[test]
+fn inbox_clear_via_mcp_keeps_obligations() {
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("clearcaller");
+    let inbox_dir = home.join("inbox");
+    std::fs::create_dir_all(&inbox_dir).unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    let rows = [
+        format!(
+            r#"{{"schema_version":1,"id":"q1","from":"lead","text":"are you there?","kind":"query","timestamp":"{now}"}}"#
+        ),
+        format!(
+            r#"{{"schema_version":1,"id":"t1","from":"lead","text":"do the thing","kind":"task","timestamp":"{now}","task_id":"t-not-on-board"}}"#
+        ),
+        format!(
+            r#"{{"schema_version":1,"id":"u1","from":"peer","text":"fyi update","kind":"update","timestamp":"{now}"}}"#
+        ),
+        format!(
+            r#"{{"schema_version":1,"id":"rp1","from":"ci","text":"ci pass","kind":"report","timestamp":"{now}"}}"#
+        ),
+        format!(
+            r#"{{"schema_version":1,"id":"s1","from":"sys","text":"stale","kind":"update","timestamp":"{now}","superseded_by":"s2"}}"#
+        ),
+    ];
+    std::fs::write(
+        inbox_dir.join("clearcaller.jsonl"),
+        format!("{}\n", rows.join("\n")),
+    )
+    .unwrap();
+
+    let resp = handle_tool("inbox", &json!({"action": "clear"}), "clearcaller");
+    assert_eq!(
+        resp["cleared_count"], 3,
+        "update + report + superseded cleared: {resp}"
+    );
+    assert_eq!(
+        resp["kept_unread_count"], 2,
+        "query + unsettled task kept unread: {resp}"
+    );
+    let req = resp["requires_response"]
+        .as_array()
+        .expect("requires_response");
+    let kept_ids: Vec<&str> = req.iter().filter_map(|r| r["id"].as_str()).collect();
+    assert!(
+        kept_ids.contains(&"q1") && kept_ids.contains(&"t1"),
+        "both obligations surfaced in requires_response: {resp}"
+    );
+    // On disk: obligations stay UNREAD, chatter is now read.
+    assert_eq!(
+        crate::inbox::describe_message(&home, "q1", "clearcaller"),
+        crate::inbox::MessageStatus::Unread {
+            delivery_mode: None,
+            correlation_id: None
+        },
+        "query must remain unread on disk"
+    );
+    assert!(
+        matches!(
+            crate::inbox::describe_message(&home, "u1", "clearcaller"),
+            crate::inbox::MessageStatus::ReadAt(_, _)
+        ),
+        "update must be marked read on disk"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// §3.9: a task whose board entry is TERMINAL (done) is no longer an obligation
+/// → the compact-clear marks it read. Exercises the task-board terminal check
+/// through the real `task` + `inbox` MCP entries end-to-end.
+#[test]
+fn inbox_clear_via_mcp_clears_terminal_task() {
+    let _g = fleet_test_guard();
+    let (_rec, home) = setup_recorder("clearterm");
+    // Create a task owned by the caller, then mark it done (terminal).
+    let created = handle_tool(
+        "task",
+        &json!({"action": "create", "title": "x", "assignee": "clearterm"}),
+        "clearterm",
+    );
+    let tid = created["id"].as_str().expect("created task id").to_string();
+    let done = handle_tool(
+        "task",
+        &json!({"action": "done", "id": tid, "result": "ok"}),
+        "clearterm",
+    );
+    assert_eq!(done["status"], "done", "task must be terminal: {done}");
+
+    let inbox_dir = home.join("inbox");
+    std::fs::create_dir_all(&inbox_dir).unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    let row = format!(
+        r#"{{"schema_version":1,"id":"tt1","from":"lead","text":"do","kind":"task","timestamp":"{now}","task_id":"{tid}"}}"#
+    );
+    std::fs::write(inbox_dir.join("clearterm.jsonl"), format!("{row}\n")).unwrap();
+
+    let resp = handle_tool("inbox", &json!({"action": "clear"}), "clearterm");
+    assert_eq!(
+        resp["cleared_count"], 1,
+        "terminal-task message must be cleared: {resp}"
+    );
+    assert_eq!(
+        resp["kept_unread_count"], 0,
+        "terminal task is not an obligation: {resp}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -60,8 +60,9 @@ pub(crate) fn def_send() -> Value {
 }
 
 pub(crate) fn def_inbox() -> Value {
-    json!({"name": "inbox", "description": "Check pending messages, OR look up a single message by ID, OR fetch a thread's messages. No params = drain pending. With message_id = describe message status (read/unread/expired/notfound). With thread_id = fetch all messages in thread ordered by timestamp.",
+    json!({"name": "inbox", "description": "Check pending messages, OR look up a single message by ID, OR fetch a thread's messages, OR quietly clear a backlog. No params = drain pending. With message_id = describe message status (read/unread/expired/notfound). With thread_id = fetch all messages in thread ordered by timestamp. With action=\"clear\" = quiet compact-clear: marks non-obligation messages read and returns a BOUNDED summary {cleared_count, kept_unread_count, summaries[], requires_response[]} — unanswered queries + unsettled tasks stay UNREAD and surface in requires_response (never silently swallowed). Use clear (not drain) to dismiss a large stale backlog without flooding your context.",
     "inputSchema": {"type": "object", "properties": {
+        "action": {"type": "string", "enum": ["clear"], "description": "\"clear\" = quiet compact-clear (obligations kept unread). Omit for normal drain."},
         "message_id": {"type": "string", "description": "Look up message status by ID"},
         "thread_id": {"type": "string", "description": "Fetch all messages in a thread"},
         "instance": {"type": "string", "description": "For message_id: target instance (defaults to caller). For thread_id: filter to a specific instance's inbox (optional, scans all if omitted)"}


### PR DESCRIPTION
Two complementary inbox-hygiene fixes from synthesis decision `d-20260607081209372642-1` (reviewer (a) + agy (b) + lead synthesis).

## (a) Cheap quiet-clear

`inbox::storage::clear_compact` — sibling of `drain()` (NOT raw drain, which marks everything read and violates trust):
- Same `with_inbox_lock` + tmp+fsync+rename, but sets `read_at` **selectively** and returns **compact** structs (`ClearCompactResult` — never full `InboxMessage`, so it structurally cannot reintroduce the multi-MB blowup).
- New MCP `inbox` **`action="clear"`** branch (explicit — does not overload the no-arg drain). Returns `{cleared_count, kept_unread_count, summaries[≤200]+summaries_omitted, requires_response[]}` with sanitised one-line previews.
- **Trust rule** (`comms_inbox::obligation_reason`): `read_at` = "non-obligation cleared from attention", NOT "obligation accepted". Unanswered **queries** + **tasks** the board can't prove terminal (Done/Cancelled) stay **UNREAD** and surface in `requires_response` (never capped). Uncertain → keep (failure mode = noise, not hidden work).
- Phase 2 consumes `notification_dedup` for cleared rows but **deliberately does NOT** arm the reply-ledger / touch turn-state — clearing historical channel backlog must never fabricate a "must-reply" turn (pinned by a source-scan invariant test).

## (b) GC TTL + size cap

`sweep_expired` already runs per-tick (not a missing-call bug); the root was the **7-day read TTL**.
- Read (drained) **non-blocker** TTL: **7d → 48h** (the high-volume `update`/`report`/`ci`/`poll` rows).
- **Blocker exemption**: drained `query`/`task` rows keep the original **7d** window AND are exempt from the size cap. **OPEN QUESTION resolved**: `has_drained_blocker_for_correlation` (ack-absorption / reply-routing, `messaging.rs:336`) needs these for the *full task turnaround*, which has no finite upper bound (overnight / multi-day) — so 24h was **not** provably safe; the exemption keeps ack-absorption zero-regression.
- **Per-inbox size cap** of **300** most-recent read non-blocker rows — the robust bound a TTL alone can't provide (a burst inside any window still overruns). Unread + blocker rows are never counted nor evicted.

Boundary: (a) mutates `read_at` only (never deletes); (b) deletes by TTL/size but skips unread + blocker rows; both serialise via `with_inbox_lock`.

## Tests (§3.9)

- Real `handle_tool("inbox", {action:"clear"})` entry with a multi-kind backlog (query+task+update+report+superseded) → obligations stay unread + in `requires_response`, chatter cleared.
- Real `task` create→done + clear → terminal task is cleared (board check end-to-end).
- GC: 48h non-blocker boundary, blocker exemption until 7d (+ `has_drained_blocker_for_correlation` still answers after sweep), size-cap keeps newest 300 / never evicts unread+blocker.
- Source-scan: `clear_compact` never references reply_ledger / heartbeat_pair.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --features tray --tests -- -D warnings` ✓
- `cargo test --tests --features tray` → **3691 passed, 0 failed** ✓
- `file_size_invariant` ✓ (clear handler placed in `comms_inbox.rs`; comms.rs stays <750 LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)