### PR TITLE
mcp: timeout → accepted_in_progress for side-effect tools (R3#1 candidate 2)

### DIFF
--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -37,6 +37,107 @@ pub(crate) fn tool_timeout(tool: &str) -> Duration {
     }
 }
 
+/// R3#1 candidate 2 (timeout-IN_PROGRESS): does a TIMEOUT on this tool need to
+/// be hidden from the agent as "accepted, completing in background" rather than
+/// surfaced as a retryable error?
+///
+/// **Why**: on timeout the execution thread is NOT killed — it runs to
+/// completion in the background (see `handle_mcp_tool_inner`). If the timeout
+/// surfaces as `{ok:false, error:"timed out"}`, the agent (Claude Code) treats
+/// it as a failure and RE-ISSUES the tool call (a fresh logical call with a new
+/// bridge `request_id`, which `request_dedup` cannot catch) → the action fires
+/// TWICE. For a non-idempotent side-effect tool (send / reply / task-create /
+/// decision-post / spawn …) that is a duplicate message / task / spawn — the
+/// retry-storm root cause. Returning `accepted_in_progress` instead tells the
+/// agent the action was taken (once) and NOT to resend.
+///
+/// The list below is the SAFE set — read-only or idempotent tools where a
+/// repeat is harmless AND the agent genuinely needs the real result, so they
+/// keep the retryable error. Everything else (incl. NEW tools and multi-action
+/// tools with any mutating action) defaults to side-effect — the conservative
+/// choice: a lost read result is recoverable, a duplicated action is the bug.
+///
+/// **Defense-in-depth (candidate 3, free)**: several side-effect tools ALSO have
+/// handler-side natural idempotency keys, so even a model that resends despite
+/// `accepted_in_progress` is protected: `task` done/update/claim are keyed on
+/// `task_id` (a repeat is an illegal-transition no-op), and `create_instance`
+/// is keyed on the instance name (a repeat errors, no second spawn). `send` /
+/// `reply` / `decision`-post have NO natural key — they rely on this gate.
+fn is_side_effect_tool(tool: &str) -> bool {
+    !matches!(
+        tool,
+        // Pure reads — agent needs the result, repeat is harmless.
+        "inbox"
+            | "list_instances"
+            | "binding_state"
+            | "gc_dry_run"
+            | "mode"
+            | "tokens"
+            | "pane_snapshot"
+            | "tui_screenshot"
+            | "download_attachment"
+            // Idempotent mutations — a repeat converges to the same state.
+            | "set_waiting_on"
+            | "set_display_name"
+            | "set_description"
+            | "health"
+            | "bind_self"
+            | "release_worktree"
+            | "force_release_worktree"
+            | "ci"
+    )
+}
+
+/// Stable hash of `(tool, args)` for the timeout instrument. NOT used for any
+/// dedup decision — purely so a post-restart log grep can tell whether the SAME
+/// logical call reappears in the timeout probe (⇒ the agent retried despite
+/// `accepted_in_progress`), the empirical validation of candidate 2.
+fn content_key(tool: &str, args: &Value) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    tool.hash(&mut h);
+    args.to_string().hash(&mut h);
+    h.finish()
+}
+
+/// Build the response for a tool that exceeded its timeout budget. Side-effect
+/// tools → `accepted_in_progress` (don't resend); read/idempotent tools → the
+/// retryable `timed out` error. Emits the `#r3-1-timeout-probe` instrument.
+fn timeout_response(tool: &str, timeout: Duration, content_key: u64) -> Value {
+    let side_effect = is_side_effect_tool(tool);
+    // #r3-1 instrument ("doubt → add log"): this PR's effect (agent stops
+    // retrying) is only observable after a daemon restart (self-dogfood
+    // anti-pattern), so log every timeout with a stable content_key. If the
+    // same content_key reappears in this probe after restart, the agent retried
+    // anyway → candidate 2 insufficient (escalate to candidate 3 / schema key).
+    tracing::warn!(
+        target: "mcp_timeout",
+        marker = "#r3-1-timeout-probe",
+        tool,
+        ?timeout,
+        side_effect,
+        content_key,
+        "mcp_tool timed out — returning {}",
+        if side_effect {
+            "accepted_in_progress (agent must NOT resend)"
+        } else {
+            "error (retry-safe)"
+        }
+    );
+    if side_effect {
+        json!({
+            "ok": true,
+            "status": "accepted_in_progress",
+            "note": format!(
+                "'{tool}' was accepted and is completing in the background; its side effect \
+                 will occur exactly once. Do NOT call it again — a repeat would duplicate the action."
+            )
+        })
+    } else {
+        json!({"ok": false, "error": format!("tool '{tool}' timed out after {timeout:?}")})
+    }
+}
+
 /// Handle `mcp_tool` API method: proxy a tool call through the daemon
 /// where process-global state (ACTIVE_CHANNEL, heartbeat_pair, etc.)
 /// is available. Applies per-tool timeout.
@@ -48,31 +149,44 @@ pub(crate) fn handle_mcp_tool(params: &Value, _ctx: &HandlerCtx) -> Value {
     let args = params["arguments"].clone();
     let instance = params["instance"].as_str().unwrap_or("").to_string();
     let timeout = tool_timeout(tool);
+    handle_mcp_tool_inner(tool, args, instance, timeout, crate::mcp::execute_tool)
+}
+
+/// Inner proxy with an injectable executor + explicit timeout — the §3.9 test
+/// seam (drive the timeout path with a sleeping executor + tiny budget, no real
+/// tool and no 30s wait).
+fn handle_mcp_tool_inner(
+    tool: &str,
+    args: Value,
+    instance: String,
+    timeout: Duration,
+    exec: impl FnOnce(&str, &Value, &str) -> Value + Send + 'static,
+) -> Value {
+    let key = content_key(tool, &args);
     let tool_owned = tool.to_string();
 
-    // Execute handle_tool in a scoped thread with per-tool timeout.
-    // This prevents a stuck tool from blocking the API session thread
-    // beyond the tool's timeout budget.
+    // Execute in a scoped thread with per-tool timeout. This prevents a stuck
+    // tool from blocking the API session thread beyond the tool's budget.
     // fire-and-forget: short-lived tool execution thread; dies on completion
     // or timeout. Result sent via mpsc channel; thread is not joined — the
     // recv_timeout below bounds the caller's wait. If the tool outlives the
     // timeout, the thread runs to completion in the background (no leak —
-    // handle_tool is stateless and the thread exits when done).
+    // handle_tool is stateless and the thread exits when done). Candidate 2
+    // relies on this: the side effect DOES complete once, so a timeout is
+    // truthfully "accepted_in_progress", not a failure.
+    let exec_tool = tool_owned.clone();
     let (tx, rx) = std::sync::mpsc::channel();
     let handle = std::thread::Builder::new()
         .name(format!("mcp_tool_{tool_owned}"))
         .spawn(move || {
-            let result = crate::mcp::execute_tool(&tool_owned, &args, &instance);
+            let result = exec(&exec_tool, &args, &instance);
             let _ = tx.send(result);
         });
 
     match handle {
         Ok(_) => match rx.recv_timeout(timeout) {
             Ok(result) => json!({"ok": true, "result": result}),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                tracing::warn!(tool, ?timeout, "mcp_tool timed out");
-                json!({"ok": false, "error": format!("tool '{tool}' timed out after {timeout:?}")})
-            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => timeout_response(tool, timeout, key),
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 json!({"ok": false, "error": format!("tool '{tool}' thread panicked")})
             }
@@ -108,5 +222,134 @@ mod tests {
         assert_eq!(tool_timeout("send_to_instance"), Duration::from_secs(30));
         assert_eq!(tool_timeout("delegate_task"), Duration::from_secs(30));
         assert_eq!(tool_timeout("unknown_tool"), Duration::from_secs(30));
+    }
+
+    // ── R3#1 candidate 2: timeout → accepted_in_progress for side-effect tools ──
+
+    #[test]
+    fn side_effect_classifier_covers_the_storm_offenders_and_reads() {
+        // Non-idempotent side-effect tools (the retry-storm offenders) → true.
+        for t in [
+            "send",
+            "reply",
+            "interrupt",
+            "decision",
+            "task",
+            "team",
+            "schedule",
+            "deployment",
+            "create_instance",
+            "delete_instance",
+            "replace_instance",
+            "restart_instance",
+            "start_instance",
+            "repo",
+            "restart_daemon",
+        ] {
+            assert!(is_side_effect_tool(t), "{t} must be treated as side-effect");
+        }
+        // Read / idempotent tools → false (keep retryable error).
+        for t in [
+            "inbox",
+            "list_instances",
+            "pane_snapshot",
+            "tokens",
+            "mode",
+            "binding_state",
+            "gc_dry_run",
+            "tui_screenshot",
+            "download_attachment",
+            "set_waiting_on",
+            "set_display_name",
+            "set_description",
+            "health",
+            "bind_self",
+            "release_worktree",
+            "force_release_worktree",
+            "ci",
+        ] {
+            assert!(!is_side_effect_tool(t), "{t} must stay retry-safe");
+        }
+        // NEW / unknown tools default to side-effect (conservative).
+        assert!(
+            is_side_effect_tool("some_future_tool"),
+            "unknown defaults to side-effect"
+        );
+    }
+
+    /// §3.9: a side-effect tool that exceeds its timeout returns
+    /// `accepted_in_progress` (ok:true, NO error) so the agent does not resend
+    /// and double-fire. Drives the real `handle_mcp_tool_inner` entry with an
+    /// injected sleeping executor + tiny budget (no real tool, no 30s wait).
+    #[test]
+    fn side_effect_tool_timeout_returns_accepted_in_progress() {
+        let slow = |_: &str, _: &Value, _: &str| {
+            std::thread::sleep(Duration::from_millis(300));
+            json!({"sent": true})
+        };
+        let resp = handle_mcp_tool_inner(
+            "send",
+            json!({"instance": "x", "message": "hi"}),
+            "caller".to_string(),
+            Duration::from_millis(20),
+            slow,
+        );
+        assert_eq!(
+            resp["ok"], true,
+            "side-effect timeout must NOT look like failure (else agent retries): {resp}"
+        );
+        assert_eq!(resp["status"], "accepted_in_progress", "got {resp}");
+        assert!(
+            resp.get("error").is_none(),
+            "no error field → agent will not resend: {resp}"
+        );
+    }
+
+    /// §3.9: a read/idempotent tool that times out keeps the retryable `error`
+    /// (the agent needs the real result and a repeat is harmless).
+    #[test]
+    fn read_tool_timeout_returns_error() {
+        let slow = |_: &str, _: &Value, _: &str| {
+            std::thread::sleep(Duration::from_millis(300));
+            json!({})
+        };
+        let resp = handle_mcp_tool_inner(
+            "inbox",
+            json!({}),
+            "caller".to_string(),
+            Duration::from_millis(20),
+            slow,
+        );
+        assert_eq!(
+            resp["ok"], false,
+            "read tool timeout stays a retryable error: {resp}"
+        );
+        assert!(
+            resp["error"].as_str().unwrap_or("").contains("timed out"),
+            "got {resp}"
+        );
+    }
+
+    /// A tool that COMPLETES within budget returns its real result regardless of
+    /// classification — the accepted_in_progress path is timeout-only.
+    #[test]
+    fn completed_side_effect_tool_returns_real_result() {
+        let fast = |_: &str, _: &Value, _: &str| json!({"done": 1});
+        let resp = handle_mcp_tool_inner(
+            "send",
+            json!({}),
+            "caller".to_string(),
+            Duration::from_secs(5),
+            fast,
+        );
+        assert_eq!(resp["ok"], true);
+        assert_eq!(
+            resp["result"]["done"], 1,
+            "a completed side-effect tool returns its result, not accepted_in_progress: {resp}"
+        );
+        assert!(
+            resp.get("status").is_none(),
+            "no accepted_in_progress on success: {resp}"
+        );
     }
 }

--- a/tests/mcp_proxy_parity.rs
+++ b/tests/mcp_proxy_parity.rs
@@ -10,13 +10,17 @@
 //! 2. The response wrapping is consistent (ok + result shape)
 //! 3. The 5 representative tools are routed correctly
 
-/// Verify the mcp_proxy handler source calls execute_tool via service boundary.
+/// Verify the mcp_proxy handler routes through execute_tool (the service
+/// boundary). Since the R3#1 candidate-2 refactor, `handle_mcp_tool` passes
+/// `crate::mcp::execute_tool` as the injectable executor to
+/// `handle_mcp_tool_inner` (a fn pointer, not a direct `execute_tool(` call), so
+/// the invariant is "the symbol is referenced as the default executor".
 #[test]
 fn proxy_handler_calls_handle_tool_directly() {
     let src = std::fs::read_to_string("src/api/handlers/mcp_proxy.rs").expect("read mcp_proxy.rs");
     assert!(
-        src.contains("crate::mcp::execute_tool("),
-        "mcp_proxy must call execute_tool (service boundary)"
+        src.contains("crate::mcp::execute_tool"),
+        "mcp_proxy must route through execute_tool (service boundary)"
     );
 }
 


### PR DESCRIPTION
R3#1 dialectic converged on **candidate 2 (timeout-IN_PROGRESS)** after dev-2's adversarial lens vetoed the content-cache (couldn't distinguish a retry from a legitimate identical repeat; no safe TTL) and the IMPL-FEASIBILITY pass ruled candidate 1 (request_id reuse) infeasible (the bridge mints a fresh request_id per logical call; a model-initiated retry is a new logical call it can't link to the original).

## Root cause

On a per-tool timeout, `mcp_proxy` does **not** kill the execution thread — it runs to completion in the background — but returned `{ok:false, error:"timed out"}`. The agent (Claude Code) reads that as a **failure** and **re-issues** the tool call: a fresh logical call with a new bridge `request_id` that `request_dedup` can't catch → a non-idempotent side-effect (send / reply / task-create / spawn) fires **twice**. That's the retry-storm.

## Fix (`src/api/handlers/mcp_proxy.rs`)

- **Timeout arm** branches on `is_side_effect_tool`:
  - side-effect → `{ok:true, status:"accepted_in_progress", note:"…do NOT resend…"}` → the agent sees **acceptance, not failure** → no retry → the orphaned thread completes the action **exactly once**.
  - read/idempotent → keep the retryable `{ok:false, error:"timed out"}` (the agent needs the real result; a repeat is harmless).
- **`is_side_effect_tool`**: explicit read/idempotent allow-list (inbox, lists, `set_*`, health, ci, bind/release, snapshots, download_attachment); everything else — incl. **new** and multi-action-with-write tools — **defaults to side-effect** (conservative: a lost read result is recoverable; a duplicated action is the bug). No runtime dedup / hashing / TTL — exactly the problems that sank the content-cache.
- **Instrument** (`#r3-1-timeout-probe`): emits tool + side_effect + a stable `(tool,args)` content_key on every timeout. This PR's effect (agent stops retrying) is only observable after a daemon **restart** (self-dogfood anti-pattern), so the log lets a post-restart grep confirm the same content_key no longer reappears (retry rate → 0). content_key is log-only, never a dedup decision.
- **Candidate 3 (free defense-in-depth)**, documented: `task` done/update/claim are `task_id`-keyed (a resend is an illegal-transition no-op); `create_instance` is name-keyed (a resend errors, no second spawn). `send`/`reply`/`decision`-post have no natural key — they rely on this gate.

`handle_mcp_tool` refactored to `handle_mcp_tool_inner` with an injectable executor + explicit timeout — the §3.9 seam (drive the timeout path with a sleeping executor + tiny budget; no real tool, no 30s wait).

## Tests (§3.9, real entry)

- side-effect tool timeout → `accepted_in_progress` (ok:true, **no error field** → agent won't resend)
- read tool timeout → retryable `timed out` error
- completed tool → real result (accepted_in_progress is timeout-only)
- classifier covers the storm offenders + reads + unknown-defaults-to-side-effect

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --features tray --tests -- -D warnings` ✓
- `cargo test --tests --features tray` → green (a rare pre-existing global-state flake surfaced once across 5 runs in an unrelated test; the mcp_proxy suite is consistently 7/7 — CI is the arbiter)
- Updated `tests/mcp_proxy_parity.rs` source-scan: `execute_tool` is now passed as the injectable executor (fn pointer), so the invariant asserts the symbol is referenced rather than a literal `execute_tool(` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)