### PR TITLE
feat(#1813): nudge agent when it answers a channel-origin message without reply

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -942,7 +942,16 @@ fn tick(
         // never hit a clear site (no reply, no mirror, no takeover). Lock-free
         // snapshot read; warns only past the grace window AND when the agent has
         // settled. Infallible — never blocks the supervisor loop.
-        crate::reply_ledger::sweep(home, &name);
+        // #1813: when the swept turn was a channel-origin input the agent
+        // answered WITHOUT the reply tool, additionally inject a one-shot
+        // agent-facing nudge so it re-sends via `reply` (the operator otherwise
+        // gets nothing). `sweep` cleared the turn, so this fires at most once per
+        // offending turn — no loop.
+        if let crate::reply_ledger::SweepAction::NudgeChannelReplyMissing { channel } =
+            crate::reply_ledger::sweep(home, &name)
+        {
+            inject_channel_reply_missing_gated(home, registry, &name, channel);
+        }
         // Mutate state + pull the tail under the core lock, then drop it
         // before running `format!` and the Telegram spawn. `tail_lines`
         // allocates a fresh String, so the lock window is bounded by the
@@ -1427,6 +1436,39 @@ fn inject_continue_gated(
             }
         }
         None => InjectOutcome::AgentGone,
+    }
+}
+
+/// #1813: inject the one-shot channel-reply-missing nudge. Sibling of
+/// [`inject_continue_gated`] (kept separate so the #1680 source-guard on the
+/// continue-inject's literal `CONTINUE_RETRY_PAYLOAD, false, Some(auto_kind)`
+/// stays intact). Same draft-gating (`force=false`) and `[AGEND-AUTO kind=...]`
+/// tagging — only the payload + kind differ. Best-effort: a missing agent /
+/// failed inject is dropped (the #1665 warn already recorded the miss).
+fn inject_channel_reply_missing_gated(
+    home: &std::path::Path,
+    registry: &AgentRegistry,
+    name: &str,
+    channel: &str,
+) {
+    let snap = {
+        let reg = agent::lock_registry(registry);
+        crate::fleet::resolve_uuid(home, name)
+            .and_then(|id| reg.get(&id))
+            .map(agent::InjectTarget::from_handle)
+    };
+    if let Some(tgt) = snap {
+        let payload = format!(
+            "Your last answer went to the TUI only — the input came via {channel}. \
+             Re-send your answer via the reply tool so the operator receives it."
+        );
+        let _ = agent::inject_with_target_gated(
+            &tgt,
+            name,
+            payload.as_bytes(),
+            false,
+            Some("channel-reply-missing"),
+        );
     }
 }
 

--- a/src/reply_ledger.rs
+++ b/src/reply_ledger.rs
@@ -61,6 +61,22 @@ enum WarnReason {
     SilentNoReply,
 }
 
+/// #1813: what the supervisor should do after a [`sweep`]. The #1665 audit
+/// (warn + operator-channel alert) happens inside `sweep`; this is the
+/// ADDITIONAL agent-facing action the supervisor performs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SweepAction {
+    /// Nothing for the supervisor to inject.
+    None,
+    /// The turn ended with a channel-origin input that the agent answered
+    /// WITHOUT the reply tool (`SilentNoReply`) — the operator got nothing.
+    /// The supervisor injects a one-shot `[AGEND-AUTO kind=channel-reply-missing]`
+    /// nudge so the agent re-sends via `reply`. `channel` names the origin so the
+    /// nudge text is accurate (telegram / discord). One-shot: `sweep` clears the
+    /// turn, so the next sweep returns `None` until a new channel input re-arms.
+    NudgeChannelReplyMissing { channel: &'static str },
+}
+
 /// Grace window after arming before a turn is eligible for a silent-drop WARN —
 /// gives the agent time to respond before we cry wolf. Combined with the
 /// `agent_is_busy` gate in [`sweep`], this is the primary false-warn defense
@@ -150,22 +166,37 @@ fn classify(mirror_dispatched_for_turn: bool, turn: &PendingUserTurn) -> Closure
 /// only when the turn has aged past the grace window AND the agent has settled
 /// (not mid-generation) — so a slow-but-working agent never false-warns. Always
 /// clears the turn afterward. Infallible (swallows everything).
-pub fn sweep(home: &std::path::Path, name: &str) {
+pub fn sweep(home: &std::path::Path, name: &str) -> SweepAction {
     let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
     let Some(turn) = pair.pending_user_turn.clone() else {
-        return;
+        return SweepAction::None;
     };
     let now = crate::daemon::heartbeat_pair::now_ms() as i64;
     if now.saturating_sub(turn.armed_at_ms) < GRACE_MS {
-        return; // give the agent time to respond
+        return SweepAction::None; // give the agent time to respond
     }
     if crate::snapshot::agent_is_busy(home, name) {
-        return; // still generating — not a silent drop, don't cry wolf
+        return SweepAction::None; // still generating — not a silent drop, don't cry wolf
     }
-    if let Closure::Warn(reason) = classify(pair.mirror_dispatched_for_turn, &turn) {
-        emit_warn(home, name, &turn, reason);
-    }
-    clear_turn(name);
+    let action = match classify(pair.mirror_dispatched_for_turn, &turn) {
+        Closure::Warn(reason) => {
+            emit_warn(home, name, &turn, reason);
+            // #1813: a `SilentNoReply` is exactly "channel-origin input answered
+            // WITHOUT the reply tool" — nudge the agent to re-send. Gap D
+            // (`ReplySendFailed`) is NOT nudged: the agent DID call reply (it just
+            // failed), so "you didn't reply" would be wrong; the #1665 warn covers it.
+            if reason == WarnReason::SilentNoReply {
+                SweepAction::NudgeChannelReplyMissing {
+                    channel: channel_kind_str(turn.channel),
+                }
+            } else {
+                SweepAction::None
+            }
+        }
+        _ => SweepAction::None,
+    };
+    clear_turn(name); // one-shot: never re-evaluate this turn (no loop)
+    action
 }
 
 /// Production WARN emission: a `tracing::warn!`, an event-log line (always — the
@@ -387,5 +418,102 @@ mod tests {
             |_d| {},
         );
         // reached here ⟹ no block / no panic.
+    }
+
+    // ── #1813 channel-reply-missing nudge: sweep's supervisor verdict ──────
+    //
+    // §3.9: exercises the real turn-end detection path (`sweep`, called per
+    // supervisor tick at supervisor.rs) across the four cases the issue names.
+    // A tmp home with no pane state ⟹ `agent_is_busy` is false (settled), so the
+    // turn is evaluated; `backdate` ages the armed turn past the grace window.
+
+    #[test]
+    fn sweep_nudge_channel_reply_missing_four_cases_1813() {
+        use std::path::PathBuf;
+        fn tmp_home(tag: &str) -> PathBuf {
+            let d =
+                std::env::temp_dir().join(format!("agend-rl-1813-{}-{}", tag, std::process::id()));
+            std::fs::create_dir_all(&d).ok();
+            d
+        }
+        // Age the armed turn past GRACE_MS so `sweep` evaluates it this tick.
+        fn backdate(name: &str) {
+            let past = crate::daemon::heartbeat_pair::now_ms() as i64 - GRACE_MS - 5_000;
+            crate::daemon::heartbeat_pair::update_with(name, |p| {
+                if let Some(t) = p.pending_user_turn.as_mut() {
+                    t.armed_at_ms = past;
+                }
+            });
+        }
+        let home = tmp_home("nudge"); // no pane state → agent settled (not busy)
+
+        // (1) channel-origin + NO reply tool → nudge (the issue's core case).
+        let n1 = "rl1813-chan-noreply";
+        arm(
+            n1,
+            ChannelKind::Telegram,
+            Some("m1".into()),
+            Some("chat1".into()),
+            None,
+        );
+        backdate(n1);
+        assert_eq!(
+            sweep(&home, n1),
+            SweepAction::NudgeChannelReplyMissing {
+                channel: "telegram"
+            },
+            "(1) channel-origin turn answered without reply must nudge"
+        );
+        // (4) one-shot: the turn was cleared, so a second sweep does NOT re-nudge.
+        assert_eq!(
+            sweep(&home, n1),
+            SweepAction::None,
+            "(4) must not re-nudge the same turn — no loop"
+        );
+
+        // (2) channel-origin + reply DELIVERED → no nudge.
+        let n2 = "rl1813-chan-replied";
+        arm(
+            n2,
+            ChannelKind::Telegram,
+            Some("m2".into()),
+            Some("chat2".into()),
+            None,
+        );
+        record_reply_outcome(n2, true);
+        backdate(n2);
+        assert_eq!(
+            sweep(&home, n2),
+            SweepAction::None,
+            "(2) a delivered reply must not nudge"
+        );
+
+        // (3) non-channel input → no turn armed → no nudge.
+        let n3 = "rl1813-nonchannel";
+        assert_eq!(
+            sweep(&home, n3),
+            SweepAction::None,
+            "(3) no armed turn (non-channel input) must not nudge"
+        );
+
+        // (bonus) Gap D: reply attempted but send FAILED is NOT a
+        // channel-reply-missing nudge (the agent DID call reply) — #1665 warns.
+        let n4 = "rl1813-gapd";
+        arm(
+            n4,
+            ChannelKind::Telegram,
+            Some("m4".into()),
+            Some("chat4".into()),
+            None,
+        );
+        record_reply_outcome(n4, false);
+        backdate(n4);
+        assert_eq!(
+            sweep(&home, n4),
+            SweepAction::None,
+            "Gap D (reply send-failed) must not channel-reply-missing-nudge"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
Closes #1813.

## Problem

When an agent answers a `[user:… via telegram]` input with direct TUI text instead of the `reply` tool, the operator on the channel **silently receives nothing**. The daemon already *tracked* this (the #1665 reply-ledger audits whether the channel turn was closed) but only *warned* — there was no code that nudged the agent to fix it (the "instrument-only" gap, same shape as #1808). Observed 2026-06-06: a lead answered telegram-origin messages with direct TUI text 3+ times in one session; the operator got nothing each time.

## Fix — wire the existing signal to an action

Reuses the #1665 machinery end-to-end (minimal new surface):

- **`reply_ledger::sweep`** already detects the exact condition at the supervisor turn-end tick — channel-origin turn (armed only for user channel messages), agent settled (`!agent_is_busy`), past the 30s grace, classified `SilentNoReply` (reply tool never called) — and clears the turn (one-shot). It now returns a `SweepAction`; `NudgeChannelReplyMissing { channel }` carries the origin so the message names telegram/discord accurately.
- **The supervisor** injects a one-shot `[AGEND-AUTO kind=channel-reply-missing]` nudge via the existing draft-gated inject path (`force=false`, same as the continue-inject). Kept as a sibling helper so the #1680 source-guard on the continue-inject literal stays intact.

## False-positive safety (all inherited from the reply-ledger)

- grace window + `agent_is_busy` gate — a slow-but-working agent is never nudged;
- never-warn kinds (`update`/`report`/`ci`/`system`) — **ack-absorption is exempt**;
- mirror-dispatched / `Delivered` closures → no nudge;
- **Gap D (`ReplySendFailed`) is deliberately NOT nudged** — the agent *did* call reply (it just failed); "you didn't reply" would be wrong, and the #1665 warn already covers it;
- **one-shot per turn** — `sweep` clears the turn, so it never loops; a new channel input re-arms.

## §3.9 test

`sweep_nudge_channel_reply_missing_four_cases_1813` drives the **real `sweep`** (supervisor turn-end path) across the four cases: channel + no-reply → **nudge**; channel + reply → none; non-channel (no armed turn) → none; second sweep → none (**no loop**). Plus Gap D → none.

Local CI-parity preflight green (`fmt`/`clippy --all-targets --features tray -D warnings`/`cargo test --tests`; reply_ledger + supervisor + snapshot suites pass, incl. the `continue_inject_is_draft_gated_force_false_1680` source-guard unbroken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)