### PR TITLE
fix(HIGH-2): evict telegram reply dedup claim on send failure

### DIFF
--- a/src/channel/dedup.rs
+++ b/src/channel/dedup.rs
@@ -222,6 +222,20 @@ impl DedupCache {
         true
     }
 
+    /// HIGH-2: roll back a [`record_and_check`] claim — remove `key` if present
+    /// (no-op otherwise). Used when the send that the claim guarded ultimately
+    /// FAILED: leaving the key recorded would suppress a legitimate retry of the
+    /// same content within the TTL (returning a synthesized success that gets
+    /// mis-recorded as delivered). Recording stays BEFORE the send so the RC2
+    /// race against a concurrent duplicate is still caught atomically; only a
+    /// terminal failure evicts. A SUCCESSFUL send keeps its key.
+    pub fn evict(&self, key: &DedupKey) {
+        let mut entries = self.entries.lock();
+        if let Some(pos) = entries.iter().position(|e| &e.key == key) {
+            entries.remove(pos);
+        }
+    }
+
     /// Total suppressions observed for the lifetime of this cache.
     /// Surfaced via doctor / debug — operator-visible health signal.
     pub fn suppressed_count(&self) -> u64 {
@@ -313,6 +327,37 @@ mod tests {
         clock.advance(Duration::from_secs(6));
         assert!(cache.record_and_check(k.clone()), "post-TTL: fresh again");
         assert_eq!(cache.suppressed_count(), 1, "counter still 1");
+    }
+
+    /// HIGH-2: `evict` rolls back a claim so a retry-after-failure isn't
+    /// suppressed, while a NON-evicted claim (the success path) stays deduped —
+    /// preserving the RC2 guarantee. Calls are immediate (< the 5s TTL).
+    #[test]
+    fn evict_rolls_back_claim_but_kept_claim_stays_deduped_high2() {
+        let cache = DedupCache::new(5, Box::new(SystemClock));
+        let k = key("agent-A", Some(42), "hello");
+
+        // RC2 preserved: a kept claim (the success path) still suppresses a dup.
+        assert!(cache.record_and_check(k.clone()), "first: fresh");
+        assert!(
+            !cache.record_and_check(k.clone()),
+            "duplicate of a kept claim must be suppressed (RC2)"
+        );
+
+        // The failed-send rollback un-blocks a retry of the same key.
+        cache.evict(&k);
+        assert!(
+            cache.record_and_check(k.clone()),
+            "after evict, a retry must NOT be suppressed"
+        );
+
+        // Evicting an absent key is a harmless no-op.
+        let other = key("agent-A", Some(42), "different");
+        cache.evict(&other);
+        assert!(
+            cache.record_and_check(other),
+            "absent-key evict must not corrupt the cache"
+        );
     }
 
     /// T2: LRU eviction — insert MAX_ENTRIES + 1 distinct keys; assert

--- a/src/channel/telegram/reply.rs
+++ b/src/channel/telegram/reply.rs
@@ -112,12 +112,19 @@ pub(super) fn try_telegram_reply_from(
         topic_id.map(i64::from),
         text,
     );
-    if !crate::channel::dedup::global(home).record_and_check(dedup_key) {
+    let dedup = crate::channel::dedup::global(home);
+    if !dedup.record_and_check(dedup_key.clone()) {
         // Synthesized success — caller proceeds; the actual original
         // send already happened or is in flight.
         return Ok((0, ch.group_id));
     }
-    match telegram_reply_send_inner(&ch, instance_name, topic_id, text) {
+    // The claim is recorded BEFORE the send (RC2: a concurrent duplicate is
+    // caught atomically). HIGH-2: but a send that ultimately FAILS must roll the
+    // claim back — otherwise a retry of the same text within the TTL is silently
+    // suppressed (a synthesized `Ok` that `handle_reply` mis-records as
+    // `Delivered`, defeating the #1665/#1813 missing-reply nets). Compute the
+    // outcome, then `evict` on any terminal `Err`; a success keeps the key.
+    let outcome = (|| match telegram_reply_send_inner(&ch, instance_name, topic_id, text) {
         Ok(msg_id) => Ok((msg_id, ch.group_id)),
         Err(e) => {
             // Supergroup migration must be checked before topic-deleted:
@@ -155,7 +162,11 @@ pub(super) fn try_telegram_reply_from(
             }
             Err(e)
         }
+    })();
+    if outcome.is_err() {
+        dedup.evict(&dedup_key);
     }
+    outcome
 }
 
 /// Like [`try_telegram_reply`] but the error branch does NOT run
@@ -322,6 +333,61 @@ instances:
         assert!(
             topics_json.contains("\"B\""),
             "provenance failure unregistered target's topic: {topics_json}"
+        );
+
+        std::env::remove_var("PR57_ROUND2_FAKE_TOKEN");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// §3.9 (HIGH-2): a reply whose first send FAILS, retried with the same text
+    /// within the dedup TTL, must ACTUALLY attempt the send again — not be
+    /// suppressed into a synthesized `Ok` (which `handle_reply` would mis-record
+    /// as `Delivered`, defeating the #1665/#1813 missing-reply nets). The fix
+    /// evicts the dedup claim on a failed send. Regression-proof: drop the
+    /// `evict` and the retry returns `Ok((0, _))` (deduped) → assertion fails.
+    #[test]
+    fn reply_failed_send_then_retry_actually_sends_high2() {
+        let _g = channel_env_test_guard();
+        let home = tmp_home("high2_retry_after_fail");
+        // Channel resolves; instance C has NO topic → the forced error falls to a
+        // terminal Err (no migration / topic-recreate retry path).
+        let yaml = "\
+channel:
+  type: telegram
+  bot_token_env: PR57_ROUND2_FAKE_TOKEN
+  group_id: -100999999
+  mode: topic
+instances:
+  C:
+    command: /bin/true
+";
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
+        std::env::set_var("PR57_ROUND2_FAKE_TOKEN", "fake");
+
+        // First send: transient failure (not migration / not topic-deleted).
+        set_forced_send_error(anyhow::anyhow!("transient network error"));
+        let first = try_telegram_reply_from(&home, "C", "hello operator");
+        assert!(
+            first.is_err(),
+            "first send must surface the failure: {first:?}"
+        );
+
+        // Retry the SAME text within the TTL. With the fix the dedup claim was
+        // evicted, so this REACHES the send (and fails again on the second forced
+        // error); with the bug it would be deduped into `Ok((0, group_id))`.
+        set_forced_send_error(anyhow::anyhow!("transient network error 2"));
+        let retry = try_telegram_reply_from(&home, "C", "hello operator");
+        assert!(
+            retry.is_err(),
+            "HIGH-2: a retry after a failed send must ACTUALLY send (not be \
+             deduped into a synthesized Ok that mis-records Delivered): {retry:?}"
+        );
+        // The retry truly reached `telegram_reply_send_inner` (it consumed the
+        // second forced error) — a deduped retry would have returned before it.
+        assert!(
+            take_forced_send_error().is_none(),
+            "the retry must have reached the send (consuming the forced error), \
+             proving it was not suppressed by the stale dedup claim"
         );
 
         std::env::remove_var("PR57_ROUND2_FAKE_TOKEN");


### PR DESCRIPTION
Fixes the HIGH-2 finding from the request/storage/comms bug-hunt. Defeats the #1665/#1813 missing-reply safety nets.

## Bug

`try_telegram_reply_from` recorded the dedup key **before** the send and never evicted it on failure. So an agent `reply` whose first send hit a transient failure (network / `RetryAfter` / the #945 background-init invalid-token window) recorded `SendFailed`, and a **retry of the same text within the 5s dedup TTL** — exactly what the #1813 channel-reply-missing nudge and ordinary transient retries produce — hit the cached key, returned a **synthesized `Ok((0, group_id))` without sending**, and `handle_reply` mis-recorded it `Delivered`. The operator never received the message, yet the reply-ledger believed it was delivered.

## Fix

Keep record-before-send (so the RC2 race against a concurrent duplicate is still caught atomically), but **evict the claim on any terminal `Err`** — so a retry after a failed send actually sends, and nothing is recorded `Delivered` until a send succeeds. A **successful** send keeps its key (legitimate RC2 dedup of a true duplicate is preserved).

- Added `DedupCache::evict`.
- The send + the migration/topic-recreate healing retries are wrapped so the eviction fires on whichever path returns `Err`.

## Tests

- `dedup::evict_rolls_back_claim_but_kept_claim_stays_deduped_high2` — evict un-blocks a retry while a non-evicted (success-path) claim still suppresses a duplicate (**RC2 preserved**); absent-key evict is a no-op.
- §3.9 `reply::reply_failed_send_then_retry_actually_sends_high2` (real reply path via the forced-send-error seam): first send fails → retry of the same text **reaches the send** (returns `Err`, consuming the forced error) instead of being deduped into a synthesized `Ok`. Regression-proof.

Local CI-parity preflight green (`fmt`/`clippy --all-targets --features tray -D warnings`/`cargo test --tests`). The existing migration/topic-recreate reply tests still pass — the closure refactor preserved that healing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)