### PR TITLE
dispatch-idle: stop team-nudge resurrecting a resolved sidecar (M2)

### DIFF
--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -137,6 +137,28 @@ fn dispatch_lock_path(home: &Path, dispatch_id: &str) -> PathBuf {
     pending_dir(home).join(format!("{dispatch_id}.lock"))
 }
 
+/// [M2] Delete a sidecar UNDER its `{dispatch_id}.lock`, so the delete is
+/// mutually exclusive with the team-nudge / L1 locked read-modify-write
+/// (`with_json_state` / `scan_and_emit`, which take the same lock). Without the
+/// lock, an unlocked `remove_file` can land inside an RMW's read→write window
+/// and the RMW then re-creates (resurrects) the just-deleted sidecar, leaking a
+/// resolved dispatch forever. Returns `true` iff the sidecar file was removed.
+///
+/// Also removes the CORRECT lock file (`{dispatch_id}.lock`); the pre-fix delete
+/// sites removed `{dispatch_id}.json.lock` (wrong name) and orphaned the real
+/// one. Single correct implementation shared by every sidecar-delete site
+/// (`mark_resolved`, `cleanup_pending_for_task_id`, `cleanup_pending_for_instance`).
+fn delete_sidecar_locked(home: &Path, dispatch_id: &str) -> bool {
+    let path = pending_path(home, dispatch_id);
+    let lock_path = dispatch_lock_path(home, dispatch_id);
+    let guard = crate::store::acquire_file_lock(&lock_path).ok();
+    let removed = std::fs::remove_file(&path).is_ok();
+    // Release the OS lock BEFORE removing the lock file itself.
+    drop(guard);
+    let _ = std::fs::remove_file(&lock_path);
+    removed
+}
+
 /// Generate a deterministic-format dispatch id (`disp-<unix_micros>-<seq>`).
 fn next_dispatch_id() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -334,9 +356,9 @@ pub(crate) fn cleanup_pending_for_task_id(home: &Path, task_id: &str) -> usize {
         if d.correlation_id.as_deref() != Some(task_id) {
             continue;
         }
-        let path = pending_path(home, &d.dispatch_id);
-        if std::fs::remove_file(&path).is_ok() {
-            let _ = std::fs::remove_file(format!("{}.lock", path.display()));
+        // [M2] delete under the sidecar lock (no resurrection race vs a concurrent
+        // team-nudge / L1 RMW; removes the correct `{id}.lock`).
+        if delete_sidecar_locked(home, &d.dispatch_id) {
             count += 1;
             tracing::debug!(
                 target: "dispatch_idle",
@@ -376,9 +398,8 @@ pub(crate) fn cleanup_pending_for_instance(home: &Path, instance_name: &str) -> 
         if d.target != instance_name {
             continue;
         }
-        let path = pending_path(home, &d.dispatch_id);
-        if std::fs::remove_file(&path).is_ok() {
-            let _ = std::fs::remove_file(format!("{}.lock", path.display()));
+        // [M2] delete under the sidecar lock (no resurrection race; correct `{id}.lock`).
+        if delete_sidecar_locked(home, &d.dispatch_id) {
             count += 1;
             tracing::debug!(
                 target: "dispatch_idle",
@@ -425,25 +446,12 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
         matches!(d.status, DispatchStatus::Pending | DispatchStatus::Exceeded)
             && d.correlation_id.as_deref() == Some(correlation_id)
     }) {
-        let path = pending_path(home, &d.dispatch_id);
-        let lock_path = dispatch_lock_path(home, &d.dispatch_id);
-        // [M2] Hold the sidecar lock across the delete so it is mutually exclusive
-        // with the team-nudge / L1 locked read-modify-write. Without this, a
-        // concurrent RMW (`with_json_state` / `scan_and_emit`) could re-create
-        // (resurrect) the sidecar between its read and its write — leaking a
-        // resolved dispatch's sidecar forever. `acquire_file_lock` uses the same
-        // `{dispatch_id}.lock` path `with_json_state`'s `path.with_extension` does.
-        let guard = crate::store::acquire_file_lock(&lock_path).ok();
-        // DELETE the sidecar rather than flip it to `Resolved` and leave the file
-        // to accumulate (the pre-fix primary `pending-dispatches/` leak).
-        if std::fs::remove_file(&path).is_ok() {
+        // [M2] DELETE the sidecar (rather than flip to `Resolved` and leave the
+        // file to accumulate — the pre-fix primary `pending-dispatches/` leak)
+        // UNDER its lock, so a concurrent team-nudge / L1 RMW can't resurrect it.
+        if delete_sidecar_locked(home, &d.dispatch_id) {
             first_deleted.get_or_insert(d.dispatch_id);
         }
-        // Release the lock BEFORE removing the lock file (best-effort cleanup of
-        // the correct `{dispatch_id}.lock` — the pre-fix code removed the wrong
-        // `{dispatch_id}.json.lock` name and orphaned the real one).
-        drop(guard);
-        let _ = std::fs::remove_file(&lock_path);
     }
     first_deleted
 }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -146,8 +146,13 @@ fn dispatch_lock_path(home: &Path, dispatch_id: &str) -> PathBuf {
 ///
 /// Also removes the CORRECT lock file (`{dispatch_id}.lock`); the pre-fix delete
 /// sites removed `{dispatch_id}.json.lock` (wrong name) and orphaned the real
-/// one. Single correct implementation shared by every sidecar-delete site
-/// (`mark_resolved`, `cleanup_pending_for_task_id`, `cleanup_pending_for_instance`).
+/// one. Single correct implementation — ALL sidecar-delete call sites route
+/// through it (verified by grep of `dispatch_idle/` for `remove_file` on a
+/// `pending_path`):
+/// - `mark_resolved` (report-arrival clear)
+/// - `cleanup_pending_for_task_id` (#1018 task-close clear)
+/// - `cleanup_pending_for_instance` (#1018 instance-delete clear)
+/// - `scan_and_emit` (#1018-A tick-time stale-sidecar clear)
 fn delete_sidecar_locked(home: &Path, dispatch_id: &str) -> bool {
     let path = pending_path(home, dispatch_id);
     let lock_path = dispatch_lock_path(home, dispatch_id);
@@ -719,8 +724,9 @@ pub(crate) fn scan_and_emit(home: &Path) {
         // canonical signal via task board / instance lifecycle, no need
         // to surface a second-class "idle threshold" notification.
         if let Some(reason) = stale_sidecar_reason(home, &d) {
-            let path = pending_path(home, &d.dispatch_id);
-            let _ = std::fs::remove_file(&path);
+            // [M2] delete under the sidecar lock (no resurrection race vs a
+            // concurrent team-nudge / L1 RMW; removes the correct `{id}.lock`).
+            delete_sidecar_locked(home, &d.dispatch_id);
             tracing::debug!(
                 target: "dispatch_idle",
                 dispatch_id = %d.dispatch_id,

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -426,13 +426,24 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
             && d.correlation_id.as_deref() == Some(correlation_id)
     }) {
         let path = pending_path(home, &d.dispatch_id);
+        let lock_path = dispatch_lock_path(home, &d.dispatch_id);
+        // [M2] Hold the sidecar lock across the delete so it is mutually exclusive
+        // with the team-nudge / L1 locked read-modify-write. Without this, a
+        // concurrent RMW (`with_json_state` / `scan_and_emit`) could re-create
+        // (resurrect) the sidecar between its read and its write — leaking a
+        // resolved dispatch's sidecar forever. `acquire_file_lock` uses the same
+        // `{dispatch_id}.lock` path `with_json_state`'s `path.with_extension` does.
+        let guard = crate::store::acquire_file_lock(&lock_path).ok();
         // DELETE the sidecar rather than flip it to `Resolved` and leave the file
         // to accumulate (the pre-fix primary `pending-dispatches/` leak).
         if std::fs::remove_file(&path).is_ok() {
-            // Best-effort: drop the sidecar's lock file too so it doesn't orphan.
-            let _ = std::fs::remove_file(format!("{}.lock", path.display()));
             first_deleted.get_or_insert(d.dispatch_id);
         }
+        // Release the lock BEFORE removing the lock file (best-effort cleanup of
+        // the correct `{dispatch_id}.lock` — the pre-fix code removed the wrong
+        // `{dispatch_id}.json.lock` name and orphaned the real one).
+        drop(guard);
+        let _ = std::fs::remove_file(&lock_path);
     }
     first_deleted
 }

--- a/src/daemon/dispatch_idle/team_nudge.rs
+++ b/src/daemon/dispatch_idle/team_nudge.rs
@@ -76,12 +76,29 @@ fn dispatcher_team(home: &Path, agent: &str) -> Option<String> {
     crate::teams::find_team_for(home, agent).map(|t| t.name)
 }
 
-fn write_dispatch_sidecar(home: &Path, d: &PendingDispatch) -> bool {
-    let body = match serde_json::to_string_pretty(d) {
-        Ok(s) => s,
-        Err(_) => return false,
-    };
-    crate::store::atomic_write(&pending_path(home, &d.dispatch_id), body.as_bytes()).is_ok()
+/// [M2] Under the sidecar lock, stamp `nudge_sent_at` iff the sidecar still
+/// exists AND is still `Exceeded` AND not already nudged; returns `true` when
+/// stamped. Replaces the prior unconditional `atomic_write`, which — after the
+/// slow `emit_nudge` — could RECREATE (resurrect) a sidecar that `mark_resolved`
+/// had just deleted (report arrived mid-flight), leaking it forever. `with_json_state`
+/// returns `Ok(None)` for a missing file and NEVER recreates it, and re-reads the
+/// status under the lock (no lost update). Mirrors the L1 `scan_and_emit`
+/// flock+re-read discipline.
+fn stamp_nudge_sent(home: &Path, dispatch_id: &str) -> bool {
+    matches!(
+        crate::store::with_json_state::<PendingDispatch, _, _>(
+            &pending_path(home, dispatch_id),
+            |cur| {
+                if cur.status == DispatchStatus::Exceeded && cur.nudge_sent_at.is_none() {
+                    cur.nudge_sent_at = Some(chrono::Utc::now().to_rfc3339());
+                    true
+                } else {
+                    false
+                }
+            },
+        ),
+        Ok(Some(true))
+    )
 }
 
 fn emit_nudge(home: &Path, d: &PendingDispatch, team: &str) -> bool {
@@ -136,7 +153,7 @@ fn emit_nudge(home: &Path, d: &PendingDispatch, team: &str) -> bool {
 /// Scan exceeded sidecars and emit nudges. Exposed `pub(crate)` for
 /// tests.
 pub(crate) fn scan_and_nudge(home: &Path) {
-    for mut d in list_pending(home) {
+    for d in list_pending(home) {
         if d.status != DispatchStatus::Exceeded {
             continue;
         }
@@ -151,9 +168,15 @@ pub(crate) fn scan_and_nudge(home: &Path) {
         if !emit_nudge(home, &d, &team) {
             continue;
         }
-        d.nudge_sent_at = Some(chrono::Utc::now().to_rfc3339());
-        if !write_dispatch_sidecar(home, &d) {
-            tracing::warn!(dispatch_id = %d.dispatch_id, "team-nudge sidecar write failed");
+        // [M2] Stamp via a LOCKED RMW that bails (and never recreates) if the
+        // sidecar was resolved/deleted during the slow `emit_nudge` above — see
+        // `stamp_nudge_sent`. A failed stamp here is benign (the dispatch was
+        // resolved): the report already arrived, so no nudge will recur.
+        if !stamp_nudge_sent(home, &d.dispatch_id) {
+            tracing::debug!(
+                dispatch_id = %d.dispatch_id,
+                "team-nudge: sidecar resolved or changed before stamp — not resurrected"
+            );
         }
     }
 }
@@ -246,6 +269,62 @@ mod tests {
         assert_eq!(
             second_count, 0,
             "second scan must NOT re-nudge (dedup via nudge_sent_at)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// [M2] §3.9: a sidecar resolved (deleted) before the nudge stamp must NOT be
+    /// resurrected by the locked RMW. Simulates a report arriving (which deletes
+    /// the sidecar) during the in-flight `emit_nudge`, then the stamp write.
+    #[test]
+    fn resolved_sidecar_not_resurrected_by_nudge_write() {
+        let home = tmp_home("m2-resurrect");
+        let id = write_exceeded_sidecar(&home, "fixup-lead", "fixup-reviewer", "t-m2", 700);
+        let path = pending_path(&home, &id);
+        assert!(path.exists(), "precondition: sidecar exists");
+        // Report arrives → sidecar deleted.
+        std::fs::remove_file(&path).unwrap();
+        // In-flight nudge tries to stamp — must NOT recreate the file.
+        assert!(
+            !stamp_nudge_sent(&home, &id),
+            "stamp on a deleted sidecar returns false"
+        );
+        assert!(
+            !path.exists(),
+            "[M2] a resolved sidecar must NOT be resurrected by the nudge write"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// [M2] end-to-end: the real `mark_resolved` delete + a racing nudge stamp
+    /// leaves the sidecar gone (not resurrected).
+    #[test]
+    fn mark_resolved_then_nudge_write_does_not_resurrect() {
+        let home = tmp_home("m2-e2e");
+        let id = write_exceeded_sidecar(&home, "fixup-lead", "fixup-reviewer", "t-m2c", 700);
+        let path = pending_path(&home, &id);
+        crate::daemon::dispatch_idle::mark_resolved(&home, "t-m2c");
+        assert!(!path.exists(), "mark_resolved deleted the sidecar");
+        assert!(
+            !stamp_nudge_sent(&home, &id),
+            "[M2] in-flight nudge stamp must not resurrect a mark_resolved'd sidecar"
+        );
+        assert!(!path.exists(), "[M2] still gone after the nudge write");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// [M2] a live Exceeded sidecar IS stamped (once) by the locked RMW.
+    #[test]
+    fn live_exceeded_sidecar_stamped_once() {
+        let home = tmp_home("m2-stamp");
+        let id = write_exceeded_sidecar(&home, "fixup-lead", "fixup-reviewer", "t-m2b", 700);
+        assert!(stamp_nudge_sent(&home, &id), "first stamp succeeds");
+        let content = std::fs::read_to_string(pending_path(&home, &id)).unwrap();
+        let d: PendingDispatch = serde_json::from_str(&content).unwrap();
+        assert!(d.nudge_sent_at.is_some(), "nudge_sent_at persisted");
+        assert!(
+            !stamp_nudge_sent(&home, &id),
+            "second stamp is a no-op (already nudged)"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/dispatch_idle/team_nudge.rs
+++ b/src/daemon/dispatch_idle/team_nudge.rs
@@ -369,6 +369,50 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// [M2] §3.9: the L1 `scan_and_emit` tick-time stale-sidecar delete (#1018-A,
+    /// the 4th delete site) is NOT resurrected by a racing nudge stamp. Drives the
+    /// real `scan_and_emit` entry with a past-threshold Pending sidecar whose
+    /// target is not in the fleet (→ stale → deleted under the lock).
+    #[test]
+    fn scan_and_emit_stale_delete_then_nudge_does_not_resurrect() {
+        let home = tmp_home("m2-stale");
+        // Fleet exists but does NOT contain the target → `target_not_in_fleet`.
+        write_fleet_with_fixup_member(&home, "fixup-lead");
+        let dir = pending_dir(&home);
+        std::fs::create_dir_all(&dir).unwrap();
+        let id = "disp-test-stale".to_string();
+        // Past-threshold so scan_and_emit progresses to the stale check.
+        let issued = (chrono::Utc::now() - chrono::Duration::seconds(700)).to_rfc3339();
+        let payload = PendingDispatch {
+            schema_version: 1,
+            dispatch_id: id.clone(),
+            dispatcher: "fixup-lead".to_string(),
+            target: "ghost-not-in-fleet".to_string(),
+            correlation_id: Some("t-stale".to_string()),
+            expected_kind: "task".to_string(),
+            threshold_secs: 600,
+            issued_at: issued,
+            status: DispatchStatus::Pending, // scan_and_emit only scans Pending
+            nudge_sent_at: None,
+            not_working_streak: 0,
+        };
+        let path = pending_path(&home, &id);
+        std::fs::write(&path, serde_json::to_string_pretty(&payload).unwrap()).unwrap();
+
+        // Real entry: must stale-delete (target not in fleet) under the lock.
+        crate::daemon::dispatch_idle::scan_and_emit(&home);
+        assert!(
+            !path.exists(),
+            "scan_and_emit must stale-delete the sidecar (target not in fleet)"
+        );
+        assert!(
+            !stamp_nudge_sent(&home, &id),
+            "[M2] in-flight stamp must not resurrect a stale-deleted sidecar"
+        );
+        assert!(!path.exists(), "[M2] still gone after the nudge write");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// 10. Nudge must target the sidecar's `target` field (the
     /// dispatchee), NOT team-wide. Parallel dev-1 + dev-2 dispatches
     /// must not cross-pollinate.

--- a/src/daemon/dispatch_idle/team_nudge.rs
+++ b/src/daemon/dispatch_idle/team_nudge.rs
@@ -329,6 +329,46 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// [M2] §3.9: a sidecar cleared by `cleanup_pending_for_task_id` (#1018
+    /// task-close) is NOT resurrected by a racing nudge stamp — the second
+    /// sidecar-delete site now also deletes under the lock via
+    /// `delete_sidecar_locked`.
+    #[test]
+    fn cleanup_for_task_id_then_nudge_write_does_not_resurrect() {
+        let home = tmp_home("m2-taskclose");
+        let id = write_exceeded_sidecar(&home, "fixup-lead", "fixup-reviewer", "t-m2task", 700);
+        let path = pending_path(&home, &id);
+        crate::daemon::dispatch_idle::cleanup_pending_for_task_id(&home, "t-m2task");
+        assert!(!path.exists(), "task-close cleanup deleted the sidecar");
+        assert!(
+            !stamp_nudge_sent(&home, &id),
+            "[M2] in-flight nudge must not resurrect a task-close-cleared sidecar"
+        );
+        assert!(!path.exists(), "[M2] still gone after the nudge write");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// [M2] §3.9: a sidecar cleared by `cleanup_pending_for_instance` (#1018
+    /// instance-delete) is NOT resurrected by a racing nudge stamp — the third
+    /// sidecar-delete site now also deletes under the lock.
+    #[test]
+    fn cleanup_for_instance_then_nudge_write_does_not_resurrect() {
+        let home = tmp_home("m2-instdel");
+        let id = write_exceeded_sidecar(&home, "fixup-lead", "fixup-reviewer", "t-m2inst", 700);
+        let path = pending_path(&home, &id);
+        crate::daemon::dispatch_idle::cleanup_pending_for_instance(&home, "fixup-reviewer");
+        assert!(
+            !path.exists(),
+            "instance-delete cleanup deleted the sidecar"
+        );
+        assert!(
+            !stamp_nudge_sent(&home, &id),
+            "[M2] in-flight nudge must not resurrect an instance-delete-cleared sidecar"
+        );
+        assert!(!path.exists(), "[M2] still gone after the nudge write");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// 10. Nudge must target the sidecar's `target` field (the
     /// dispatchee), NOT team-wide. Parallel dev-1 + dev-2 dispatches
     /// must not cross-pollinate.


### PR DESCRIPTION
Fixes M2 from the daemon-core hunt.

## Bug

`team_nudge::scan_and_nudge` read a pending sidecar from an unlocked `list_pending` snapshot, ran the **slow** `emit_nudge` (inbox I/O), then wrote it back with an **unconditional `atomic_write`** (no re-check that the file still existed). If a report arrived during `emit_nudge`, `mark_resolved` deleted the sidecar — and the write then **re-created** it (`status=Exceeded`, `nudge_sent_at` set). A resolved dispatch's sidecar thus leaked forever (the report already came; nothing clears it again). It also clobbered any concurrent on-disk update (lost update). The L1 sibling `scan_and_emit` already uses flock + re-read; this path didn't.

## Fix

- **`stamp_nudge_sent`** — a locked read-modify-write (`with_json_state`) that stamps `nudge_sent_at` only if the sidecar still exists AND is still `Exceeded` AND not already nudged. `with_json_state` returns `Ok(None)` for a missing file and **never recreates** it → no resurrection; the under-lock status re-read closes the lost-update.
- **`mark_resolved`** — holds the same `{dispatch_id}.lock` across the delete, making it mutually exclusive with the RMW (the unlocked delete could otherwise still race the RMW's read→write window — the lock is what makes elimination airtight, not just window-shrinking). Also fixes the stale lock-file cleanup that removed the wrong `{dispatch_id}.json.lock` and orphaned the real `{dispatch_id}.lock`.

## Tests (§3.9)

- `resolved_sidecar_not_resurrected_by_nudge_write`: delete then stamp → not recreated.
- `mark_resolved_then_nudge_write_does_not_resurrect`: end-to-end via the real `mark_resolved`.
- `live_exceeded_sidecar_stamped_once`: a live Exceeded sidecar is stamped exactly once (dedup preserved).

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓
- `dispatch_idle` suite 57/57
- `cargo test --tests --features tray` → green except the unrelated `dispatch_branch_skips_metadata_stub_..._1834` (messaging.rs git-checkout) which false-fails only under the local fleet `git` shim; passes with real `/usr/bin/git` (CI uses real git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)