### PR TITLE
pr-state: emit [pr-merged] once via persistent ledger (C1 / #1842 re-emit loop)

### DIFF
--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -2015,6 +2015,82 @@ mod tests {
         let _ = std::fs::remove_dir_all(&home);
     }
 
+    /// [C1 / #1842] §3.9: a merged PR is announced ONCE even across the
+    /// scan-`remove` → lingering-CI-`_or_create` re-create loop. The recreated
+    /// state file has `ready_emitted_for_sha = None` (the reset that drove the 8×
+    /// re-emit), but the persistent terminal-emit ledger suppresses the replay.
+    #[test]
+    fn c1_merged_not_reemitted_after_delete_recreate_1842() {
+        let mut s = new_state("sha-A", ReviewClass::Single);
+        s.pr_author = String::new();
+        let home = home_with_state("c1-reemit-1842", s);
+        let merged_meta = GhPrMetadata {
+            number: 970,
+            author_login: "dev".into(),
+            head_ref: "feat/test".into(),
+            is_cross_repository: false,
+            is_draft: false,
+            state: GhPrState::Merged,
+            merged_at: Some("2026-05-20T04:17:09Z".to_string()),
+        };
+
+        // Scan 1: observe merged → emit [pr-merged] exactly once.
+        scan_and_emit_with(
+            &home,
+            &empty_registry(),
+            &MockGhPoller::new(vec![Ok(vec![merged_meta.clone()])]),
+        );
+        assert_eq!(
+            crate::inbox::drain(&home, "dev").len(),
+            1,
+            "scan 1 emits [pr-merged] once"
+        );
+
+        // Scan 2: already_emitted (per-file flag) → sweep the terminal file.
+        scan_and_emit_with(
+            &home,
+            &empty_registry(),
+            &MockGhPoller::new(vec![Ok(vec![merged_meta.clone()])]),
+        );
+        assert!(
+            load(&home, "owner/repo", "feat/test").is_none(),
+            "scan 2 sweeps the terminal file"
+        );
+        assert!(
+            crate::inbox::drain(&home, "dev").is_empty(),
+            "scan 2 does not re-emit"
+        );
+
+        // RECREATE: a lingering CI observation re-creates a FRESH Merged state
+        // file with ready_emitted_for_sha=None for the SAME merge identity (the
+        // #1842 loop). Without the ledger this re-emits; with it, suppressed.
+        let mut recreated = new_state("sha-A", ReviewClass::Single);
+        recreated.merge_state = MergeState::Merged {
+            merge_commit: "sha-A".to_string(),
+            merged_at: "2026-05-20T04:17:09Z".to_string(),
+        };
+        recreated.ready_emitted_for_sha = None;
+        save(&home, &recreated).unwrap();
+
+        // Scan 3: per-file flag is reset (None) but the persistent ledger says
+        // emitted → NO replay.
+        scan_and_emit_with(
+            &home,
+            &empty_registry(),
+            &MockGhPoller::new(vec![Ok(vec![merged_meta])]),
+        );
+        assert!(
+            crate::inbox::drain(&home, "dev").is_empty(),
+            "[C1/#1842] recreated merged file must NOT re-emit (ledger survives delete+recreate)"
+        );
+        assert!(
+            load(&home, "owner/repo", "feat/test").is_none(),
+            "scan 3 sweeps the recreated file"
+        );
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
     /// #986 T5 — `gh state=CLOSED + mergedAt=None` fires
     /// ClosedUnmergedObserved → reducer transitions → scanner emits
     /// `[pr-closed-unmerged]`.

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -12,6 +12,55 @@ enum ScanAction {
     Remove,
 }
 
+/// [C1 / #1842] Persistent dedup ensuring a terminal `[pr-merged]` /
+/// `[pr-closed-unmerged]` is announced ONCE per merge identity — even when the
+/// per-PR state file is `remove`d by the scan terminal-cleanup and then
+/// RE-CREATED by a lingering CI observation (`record_ci_result`'s `_or_create`,
+/// mod.rs). That delete→recreate loop reset the per-file `ready_emitted_for_sha`
+/// flag every poll, re-emitting `[pr-merged]` ~once per poll (#1842: 8× for one
+/// merge). Keyed on the terminal-event identity, this ledger survives the file
+/// delete; the per-file flag cannot. Pruned by TTL on each record.
+const TERMINAL_EMIT_LEDGER_TTL_SECS: i64 = 7 * 24 * 60 * 60;
+
+fn terminal_emit_ledger_path(home: &Path) -> std::path::PathBuf {
+    pr_state_dir(home).join(".emitted-terminal.json")
+}
+
+/// True if a `[pr-merged]`/`[pr-closed-unmerged]` for `key` was already emitted
+/// (lock-free read; a missing/corrupt ledger reads as "not emitted").
+fn terminal_already_emitted(home: &Path, key: &str) -> bool {
+    std::fs::read_to_string(terminal_emit_ledger_path(home))
+        .ok()
+        .and_then(|c| serde_json::from_str::<std::collections::HashMap<String, String>>(&c).ok())
+        .is_some_and(|m| m.contains_key(key))
+}
+
+/// Record `key` as emitted (locked RMW), pruning entries older than the TTL.
+fn record_terminal_emitted(home: &Path, key: &str) {
+    let now = chrono::Utc::now();
+    let _ = crate::store::with_json_state_or_create::<
+        std::collections::HashMap<String, String>,
+        _,
+        _,
+        _,
+    >(
+        &terminal_emit_ledger_path(home),
+        std::collections::HashMap::new,
+        |m| {
+            m.retain(|_, ts| {
+                chrono::DateTime::parse_from_rfc3339(ts)
+                    .map(|t| {
+                        now.signed_duration_since(t.with_timezone(&chrono::Utc))
+                            .num_seconds()
+                            < TERMINAL_EMIT_LEDGER_TTL_SECS
+                    })
+                    .unwrap_or(false)
+            });
+            m.insert(key.to_string(), now.to_rfc3339());
+        },
+    );
+}
+
 /// Per-tick scanner: walks `<home>/pr-state/*.json`, emits any newly-
 /// eligible `[pr-ready-for-merge]` events (debounced via
 /// `ready_emitted_for_sha`), and sweeps terminal-state files.
@@ -80,6 +129,23 @@ pub fn scan_and_emit_with(
         // AFTER `with_pr_state` returns so enqueue_with_idle_hint (self-IPC via
         // loopback api::call) runs lock-free (#1617 lock-while-blocking class).
         let mut pending_emits: Vec<(String, crate::inbox::InboxMessage)> = Vec::new();
+        // [C1 / #1842] Terminal-event identity for the persistent emit-dedup
+        // ledger. Checked lock-free here (before the flock) and recorded
+        // post-flock if we emit — so a recreated state file (lingering-CI
+        // `_or_create` after the scan `remove`) cannot re-announce the merge.
+        let terminal_ledger_key: Option<String> = match &snapshot.merge_state {
+            MergeState::Merged { merge_commit, .. } => {
+                Some(format!("merged:{repo}@{branch}:{merge_commit}"))
+            }
+            MergeState::ClosedUnmerged { closed_at } => {
+                Some(format!("closed:{repo}@{branch}:{closed_at}"))
+            }
+            _ => None,
+        };
+        let ledger_says_emitted = terminal_ledger_key
+            .as_deref()
+            .is_some_and(|k| terminal_already_emitted(home, k));
+        let mut emitted_terminal = false;
         let result = with_pr_state(home, &repo, &branch, |state| {
             let mut dirty = false;
 
@@ -124,7 +190,10 @@ pub fn scan_and_emit_with(
                     merge_commit,
                     merged_at,
                 } => {
-                    if !already_emitted {
+                    // [C1] also suppress if the persistent ledger already recorded
+                    // this merge — survives the delete→recreate that resets the
+                    // per-file `ready_emitted_for_sha`.
+                    if !already_emitted && !ledger_says_emitted {
                         // #1344/#bughunt3: defer the worktree auto-release until
                         // AFTER this flock is dropped (the git subprocess +
                         // nested binding flock are the #1617 lock-while-blocking
@@ -147,19 +216,21 @@ pub fn scan_and_emit_with(
                         let msg = build_event_message("pr-merged", &author, state, body);
                         pending_emits.push((author, msg));
                         state.ready_emitted_for_sha = Some(state.head_sha.clone());
+                        emitted_terminal = true; // [C1] record in ledger post-flock
                         dirty = true;
                     } else {
                         tracing::debug!(
                             repo = %state.repo,
                             branch = %state.branch,
                             head = %state.head_sha,
-                            "#1017 pr_state: stale Merged replay suppressed at scan"
+                            ledger_says_emitted,
+                            "#1017/#1842 pr_state: Merged replay suppressed at scan"
                         );
                         return ScanAction::Remove;
                     }
                 }
                 MergeState::ClosedUnmerged { closed_at } => {
-                    if !already_emitted {
+                    if !already_emitted && !ledger_says_emitted {
                         let author = resolve_author(state);
                         let body = format!(
                             "[pr-closed-unmerged] {}@{} (closed_at {})\n\n\
@@ -174,9 +245,10 @@ pub fn scan_and_emit_with(
                         let msg = build_event_message("pr-closed-unmerged", &author, state, body);
                         pending_emits.push((author, msg));
                         state.ready_emitted_for_sha = Some(state.head_sha.clone());
-                        // t-worktree-leak (PR-1): close-unmerged is a terminal PR
-                        // transition → recompute the release invariant post-flock
-                        // (the sweeper applies the conservative close-grace).
+                        emitted_terminal = true; // [C1] record in ledger post-flock
+                                                 // t-worktree-leak (PR-1): close-unmerged is a terminal PR
+                                                 // transition → recompute the release invariant post-flock
+                                                 // (the sweeper applies the conservative close-grace).
                         release_after_unlock = Some((state.branch.clone(), "close_unmerged"));
                         dirty = true;
                     } else {
@@ -184,7 +256,8 @@ pub fn scan_and_emit_with(
                             repo = %state.repo,
                             branch = %state.branch,
                             head = %state.head_sha,
-                            "#1017 pr_state: stale ClosedUnmerged replay suppressed at scan"
+                            ledger_says_emitted,
+                            "#1017/#1842 pr_state: ClosedUnmerged replay suppressed at scan"
                         );
                         return ScanAction::Remove;
                     }
@@ -241,6 +314,14 @@ pub fn scan_and_emit_with(
                 );
             }
             _ => {}
+        }
+        // [C1 / #1842] Record the terminal emit in the persistent ledger AFTER the
+        // flock drops (mirrors the deferred enqueue — keeps file I/O off the
+        // PR-state lock). Done regardless of Saved/Remove: the announce happened.
+        if emitted_terminal {
+            if let Some(k) = &terminal_ledger_key {
+                record_terminal_emitted(home, k);
+            }
         }
         let _ = registry; // reserved for future gh-poll author lookup hook
     }


### PR DESCRIPTION
Fixes C1 (the #1842 re-emit loop I root-caused in the round-2 hunt): a single merge announced `[pr-merged]` ~8× — per-poll inbox spam to the author.

## Root cause

`scan_and_emit` emits `[pr-merged]` once + sets the per-file `ready_emitted_for_sha`; the next scan (`already_emitted`) does `ScanAction::Remove` to clean up the terminal file. But a lingering CI observation re-creates that file via `record_ci_result`'s `with_pr_state_or_create` (the sole creator+updater) with a **fresh** default (`ready_emitted_for_sha=None`); the merge is re-observed; scan re-emits. The remove↔recreate churn repeats every poll until the branch drops out of the poll set. The #1314 guard only protects an *existing* Merged file's flag from CI clobber — it can't survive delete+recreate.

## Fix — persistent terminal-emit ledger

`<home>/pr-state/.emitted-terminal.json`: a map keyed on the terminal-event identity (`merged:{repo}@{branch}:{merge_commit}` / `closed:{repo}@{branch}:{closed_at}`), pruned at a 7d TTL. `scan_and_emit` checks it **lock-free before the flock** and records **post-flock on emit** (mirrors the deferred-enqueue so no file I/O runs under the PR-state flock). The Merged/ClosedUnmerged arms now emit only when `!already_emitted && !ledger_says_emitted`, so a recreated fresh file (flag reset) is still suppressed. `ScanAction::Remove` cleanup is unchanged — the recreate↔remove churn continues silently but never re-announces.

## Test (§3.9)

`c1_merged_not_reemitted_after_delete_recreate_1842`: scan 1 emits once → scan 2 sweeps → a fresh Merged file (`ready_emitted_for_sha=None`) is recreated (the loop) → scan 3 suppresses via the ledger (zero re-emit) and re-sweeps.

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓
- `pr_state` suite 71/71
- `cargo test --tests --features tray` → green except the unrelated `dispatch_branch_skips_metadata_stub_..._1834` (messaging.rs git-checkout) which false-fails only under the local fleet `git` shim; passes with real `/usr/bin/git` (CI uses real git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)