### PR TITLE
fix(MED-1,MED-2): notify dedup evict-on-failure; deploy spawns command override

### DIFF
--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -6,25 +6,25 @@ use crate::channel::telegram::state::*;
 
 /// Send a notification to Telegram (instance topic or general).
 pub fn notify_telegram(home: &std::path::Path, instance_name: &str, text: &str) {
-    notify_telegram_inner(home, instance_name, text, false);
+    let _ = notify_telegram_inner(home, instance_name, text, false);
 }
 
 /// Send a notification with Telegram's `disable_notification` flag set — the
 /// message still appears in the topic but does not push/vibrate the operator.
 pub fn notify_telegram_silent(home: &std::path::Path, instance_name: &str, text: &str) {
-    notify_telegram_inner(home, instance_name, text, true);
+    let _ = notify_telegram_inner(home, instance_name, text, true);
 }
 
+/// Returns the spawned send's `JoinHandle` (or `None` when nothing was sent:
+/// no telegram channel / dedup-suppressed). The public wrappers discard it;
+/// tests drive it to deterministically observe the send outcome.
 fn notify_telegram_inner(
     home: &std::path::Path,
     instance_name: &str,
     text: &str,
     disable_notification: bool,
-) {
-    let config = match crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) {
-        Ok(c) => c,
-        Err(_) => return,
-    };
+) -> Option<tokio::task::JoinHandle<()>> {
+    let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok()?;
     let (token, group_id, topic_id) = match &config.channel {
         Some(crate::fleet::ChannelConfig::Telegram {
             bot_token_env,
@@ -36,10 +36,10 @@ fn notify_telegram_inner(
                 *group_id,
                 crate::channel::telegram::lookup_topic_for_instance(home, instance_name),
             ),
-            Err(_) => return,
+            Err(_) => return None,
         },
-        Some(crate::fleet::ChannelConfig::Discord { .. }) => return,
-        None => return,
+        Some(crate::fleet::ChannelConfig::Discord { .. }) => return None,
+        None => return None,
     };
 
     // #969: channel-wide dedup. If this (telegram, instance, topic,
@@ -53,39 +53,46 @@ fn notify_telegram_inner(
         topic_id.map(i64::from),
         text,
     );
-    if !crate::channel::dedup::global(home).record_and_check(dedup_key) {
-        return;
+    if !crate::channel::dedup::global(home).record_and_check(dedup_key.clone()) {
+        return None;
     }
 
     let text = text.to_string();
     let home_owned = home.to_path_buf();
     let instance_owned = instance_name.to_string();
     // fire-and-forget: losing one notification on shutdown is acceptable.
-    telegram_runtime().spawn(async move {
+    Some(telegram_runtime().spawn(async move {
         use teloxide::payloads::SendMessageSetters;
         use teloxide::prelude::Requester;
         let bot = teloxide::Bot::new(&token);
         let chat_id = teloxide::types::ChatId(group_id);
-        let result = match topic_id {
-            Some(tid) if tid != 1 => {
-                let mut req = bot
-                    .send_message(chat_id, &text)
-                    .message_thread_id(teloxide::types::ThreadId(teloxide::types::MessageId(tid)));
-                if disable_notification {
-                    req = req.disable_notification(true);
-                }
-                req.await.map(|_| ())
+        let result: anyhow::Result<()> = async {
+            // Test seam: force the first send to fail without a network call.
+            #[cfg(test)]
+            if let Some(err) = tests::take_forced_send_error() {
+                return Err(err);
             }
-            _ => {
-                let mut req = bot.send_message(chat_id, &text);
-                if disable_notification {
-                    req = req.disable_notification(true);
+            match topic_id {
+                Some(tid) if tid != 1 => {
+                    let mut req = bot.send_message(chat_id, &text).message_thread_id(
+                        teloxide::types::ThreadId(teloxide::types::MessageId(tid)),
+                    );
+                    if disable_notification {
+                        req = req.disable_notification(true);
+                    }
+                    req.await.map(|_| ()).map_err(anyhow::Error::from)
                 }
-                req.await.map(|_| ())
+                _ => {
+                    let mut req = bot.send_message(chat_id, &text);
+                    if disable_notification {
+                        req = req.disable_notification(true);
+                    }
+                    req.await.map(|_| ()).map_err(anyhow::Error::from)
+                }
             }
-        };
+        }
+        .await;
         if let Err(e) = result {
-            let e: anyhow::Error = e.into();
             if let Some(stale_tid) = topic_id {
                 if is_topic_deleted_error(&e) {
                     // #969 RC3: pin the topic-deleted detection event for
@@ -116,12 +123,101 @@ fn notify_telegram_inner(
                         if disable_notification {
                             req = req.disable_notification(true);
                         }
-                        let _ = req.await;
+                        // MED-1: roll back the dedup claim if even the recreated-
+                        // topic retry fails — a never-delivered notify must not
+                        // suppress a same-text re-emit within the TTL (the un-
+                        // patched twin of the reply.rs HIGH-2 evict-on-failure).
+                        if req.await.is_err() {
+                            crate::channel::dedup::global(&home_owned).evict(&dedup_key);
+                        }
                         return;
                     }
                 }
             }
+            // MED-1: terminal failure (send failed, no successful recovery) —
+            // evict so a legitimate retry of the same text actually sends.
+            crate::channel::dedup::global(&home_owned).evict(&dedup_key);
             tracing::warn!(error = %e, "telegram notify failed");
         }
-    });
+    }))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    static FORCED_SEND_ERROR: parking_lot::Mutex<Option<anyhow::Error>> =
+        parking_lot::Mutex::new(None);
+
+    pub(super) fn take_forced_send_error() -> Option<anyhow::Error> {
+        FORCED_SEND_ERROR.lock().take()
+    }
+    fn set_forced_send_error(err: anyhow::Error) {
+        *FORCED_SEND_ERROR.lock() = Some(err);
+    }
+
+    /// Serialize against the process-global env + dedup cache + forced-error seam.
+    fn guard() -> parking_lot::MutexGuard<'static, ()> {
+        static G: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+        G.lock()
+    }
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let id = C.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-notify-med1-{}-{}-{}",
+            tag,
+            std::process::id(),
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn notify_key(home: &Path, instance: &str, text: &str) -> crate::channel::dedup::DedupKey {
+        let topic = crate::channel::telegram::lookup_topic_for_instance(home, instance);
+        crate::channel::dedup::DedupKey::new(
+            "telegram:notify",
+            instance,
+            topic.map(i64::from),
+            text,
+        )
+    }
+
+    /// §3.9 (MED-1): a notify whose send FAILS must evict its dedup claim, so a
+    /// retry of the same text within the TTL actually sends instead of being
+    /// suppressed into a no-op. The twin of the reply.rs HIGH-2 fix.
+    #[test]
+    fn notify_failed_send_evicts_dedup_med1() {
+        let _g = guard();
+        let home = tmp_home("evict");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "channel:\n  type: telegram\n  bot_token_env: NOTIFY_MED1_TOKEN\n  group_id: -100777\n  mode: topic\ninstances:\n  C:\n    backend: claude\n",
+        )
+        .unwrap();
+        std::env::set_var("NOTIFY_MED1_TOKEN", "fake");
+
+        // First notify: records the dedup claim, then the (forced-failing) send.
+        set_forced_send_error(anyhow::anyhow!("transient network error"));
+        let h1 = notify_telegram_inner(&home, "C", "hello operator", false).expect("send spawned");
+        // Drive the spawned send (+ evict) to completion via the Handle-guarded
+        // helper (#1476: never a raw `telegram_runtime().block_on`).
+        let _ = block_on_value(h1);
+
+        // The failed send must have rolled back the claim: record_and_check is
+        // fresh again (would be `false`/suppressed without the evict).
+        let key = notify_key(&home, "C", "hello operator");
+        assert!(
+            crate::channel::dedup::global(&home).record_and_check(key),
+            "MED-1: a failed notify must evict its dedup claim so a retry can send"
+        );
+
+        std::env::remove_var("NOTIFY_MED1_TOKEN");
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -283,13 +283,39 @@ fn persist_to_fleet_yaml(
     })
 }
 
+/// MED-2 (re-marshal allowlist-drop): the binary deploy's Phase-3 SPAWN should
+/// run for `inst_name`. The SPAWN handler runs `params["backend"]` AS the
+/// command, and a template's `command:` override is persisted to fleet.yaml in
+/// Phase 2 (before Phase 3), so resolve via `FleetConfig` —
+/// `resolved.backend_command` honors `command:` over the `backend:` preset,
+/// mirroring every sibling spawn path (start/restart/replace/cold-boot). The
+/// pre-fix code passed raw `entry.backend`, silently ignoring `command:` and
+/// spawning the preset binary on first deploy. Falls back to `entry.backend`
+/// (then `"claude"`) only if the entry can't be resolved.
+fn resolve_spawn_backend(
+    home: &Path,
+    inst_name: &str,
+    entry: &crate::fleet::InstanceYamlEntry,
+) -> String {
+    crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+        .ok()
+        .and_then(|c| c.resolve_instance(inst_name))
+        .map(|r| r.backend_command)
+        .unwrap_or_else(|| {
+            entry
+                .backend
+                .clone()
+                .unwrap_or_else(|| "claude".to_string())
+        })
+}
+
 fn spawn_instances(
     home: &Path,
     yaml_entries: &[(String, crate::fleet::InstanceYamlEntry)],
     directory: &str,
 ) {
     for (inst_name, entry) in yaml_entries {
-        let backend_name = entry.backend.as_deref().unwrap_or("claude");
+        let backend_name = resolve_spawn_backend(home, inst_name, entry);
         let work_dir = entry.working_directory.as_deref().unwrap_or(directory);
         let mut params = serde_json::json!({
             "name": inst_name,
@@ -733,6 +759,42 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    /// §3.9 (MED-2): the binary deploy's Phase-3 SPAWN must run a template's
+    /// `command:` override, not the `backend:` preset. `resolve_spawn_backend`
+    /// (which feeds `params["backend"]`, run AS the command by the SPAWN handler)
+    /// must return the `command:` for an entry that declares one. Regression-proof:
+    /// revert to raw `entry.backend` and the override assertion fails ("claude").
+    #[test]
+    fn resolve_spawn_backend_honors_command_override_med2() {
+        let home = tmp_home("med2-backend");
+        // The entries are persisted to fleet.yaml in Phase 2 before the spawn.
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  worker:\n    backend: claude\n    command: ./my-runner.sh\n",
+        )
+        .unwrap();
+        // `entry` is only the resolve-failure fallback; the fix resolves via fleet.yaml.
+        let entry = crate::fleet::InstanceYamlEntry {
+            backend: Some("claude".into()),
+            ..Default::default()
+        };
+
+        // Template `command:` override reaches the spawn binary (was: "claude").
+        assert_eq!(
+            resolve_spawn_backend(&home, "worker", &entry),
+            "./my-runner.sh",
+            "MED-2: a template `command:` override must reach the Phase-3 spawn"
+        );
+        // An entry absent from fleet.yaml falls back to its declared backend.
+        assert_eq!(
+            resolve_spawn_backend(&home, "ghost", &entry),
+            "claude",
+            "fallback to entry.backend when the instance can't be resolved"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]


### PR DESCRIPTION
Two round-2 bug-hunt findings (bundled; lead self-review).

## MED-1 — notify dedup record-before-send, no evict-on-failure

The un-patched twin of the reply.rs HIGH-2 fix. `notify_telegram_inner` records the dedup key **before** the spawned send, whose result was only logged. A transient send failure left the claim live for the TTL, so a legitimate re-emit of the same text within the window was suppressed into a no-op — the operator never received it.

**Fix:** evict the dedup claim on terminal failure (initial send + the topic-recreate retry), mirroring `reply.rs:166-168`. A successful send keeps the key (RC1/RC2 dedup preserved).

## MED-2 — deploy Phase-3 SPAWN dropped the `command:` override

The re-marshal allowlist-drop class (3rd instance). `spawn_instances` passed raw `entry.backend`, but the SPAWN handler runs `params["backend"]` **as the command**, and a template's `command:` is persisted to fleet.yaml in Phase 2 — so the override was silently ignored, spawning the preset binary on first deploy.

**Fix:** extract `resolve_spawn_backend` and pass `resolve_instance().backend_command` (which honors `command:` over the preset), mirroring every sibling spawn path (start/restart/replace/cold-boot).

## Testability refactor (MED-1)

`notify_telegram_inner` now returns the spawned `JoinHandle` (public wrappers discard it) so a test can drive the current-thread runtime to completion via the Handle-guarded `block_on_value` (**#1476**: never a raw `telegram_runtime().block_on` — the source-scan invariant enforces this), and a `#[cfg(test)]` forced-send-error seam fails the send without a network call (mirrors reply.rs).

## §3.9 tests

- `notify_failed_send_evicts_dedup_med1` — drives the **real spawned send** (forced failure) and asserts the dedup claim is evicted (a retry would actually send).
- `resolve_spawn_backend_honors_command_override_med2` — a template `command:` reaches the spawn binary; resolve-miss falls back to `entry.backend`.

Local CI-parity preflight green (`fmt`/`clippy --all-targets --features tray -D warnings`/`cargo test --tests` incl. the block_on guard invariant + file_size). channel suite 179 pass, deployments/notify 76 pass; existing migration/topic-recreate reply tests unbroken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)