### PR TITLE
fix(#1808/#1809): wrap-tolerant SRL detection + upstream instrument (Phase 1)

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -604,28 +604,55 @@ fn ansi_colored_tail(screen_text: &str, fg: &[CellFg], n: usize) -> String {
 ///
 /// `None` otherwise. The order is chosen so the common no-phrase case
 /// fast-rejects on a single allocation-free `str::contains` scan.
+/// Returns `Some((raw_tail, wrap_split))`. `wrap_split` is true when the phrase
+/// was found ONLY after whitespace-flattening — i.e. it is LINE-WRAPPED across
+/// rows in `screen_text`. Since the detection feed already de-wraps alacritty
+/// soft-wraps (#1808 Phase 1), a phrase still wrap-split here means the wrap is
+/// a hard `\n` (Ink-emitted layout) the de-wrap cannot merge → the signal that
+/// the Phase 2 flattened-tail fallback is required for this backend's render.
 fn unclassified_throttle_tail(
     current: AgentState,
     screen_text: &str,
     fg: &[CellFg],
-) -> Option<String> {
-    // Fast reject (no allocation): no known throttle phrase anywhere.
-    let phrase = THROTTLE_DIAG_PHRASES
+) -> Option<(String, bool)> {
+    // Fast reject (no allocation on the common path): no known throttle phrase
+    // contiguously on screen. #1808 — the original `contains`-only check was
+    // BLIND to a line-wrapped phrase (the exact reason the live narrow-pane SRL
+    // miss captured nothing), so on a contiguous miss also try a
+    // whitespace-flattened view (every whitespace run incl. `\n` → one space) so
+    // a wrapped "temporarily\nlimiting\nrequests" still matches.
+    let raw_hit = THROTTLE_DIAG_PHRASES
         .iter()
         .copied()
-        .find(|p| screen_text.contains(p))?;
+        .find(|p| screen_text.contains(p));
+    let phrase = match raw_hit {
+        Some(p) => p,
+        None => {
+            let flat = screen_text.split_whitespace().collect::<Vec<_>>().join(" ");
+            THROTTLE_DIAG_PHRASES
+                .iter()
+                .copied()
+                .find(|p| flat.contains(p))?
+        }
+    };
+    let wrap_split = raw_hit.is_none();
     // Classifier landed on a retryable state → throttle phrase was correctly
     // recognized (auto-retry handles it). Nothing to diagnose → no noise.
     if is_throttle_retryable_state(current) {
         return None;
     }
     // Require the phrase in the LIVE bottom-N tail — a copy that only survives
-    // in scrolled-up scrollback is stale, not a current miss.
+    // in scrolled-up scrollback is stale, not a current miss. Check the
+    // flattened tail too so a wrapped live error still qualifies.
     let tail = recent_screen_tail(screen_text.trim_end(), UNCLASSIFIED_TAIL_LINES);
-    if !tail.contains(phrase) {
+    let tail_flat = tail.split_whitespace().collect::<Vec<_>>().join(" ");
+    if !tail.contains(phrase) && !tail_flat.contains(phrase) {
         return None;
     }
-    Some(ansi_colored_tail(screen_text, fg, UNCLASSIFIED_TAIL_LINES))
+    Some((
+        ansi_colored_tail(screen_text, fg, UNCLASSIFIED_TAIL_LINES),
+        wrap_split,
+    ))
 }
 
 /// #1562: best-effort append of one JSON record as a single `line\n` to `path`,
@@ -1355,14 +1382,41 @@ impl StateTracker {
     /// - **Low-noise** — fires only on phrase-present + classified-non-retryable
     ///   + phrase-in-live-tail (a scrolled-up scrollback echo is ignored).
     fn capture_unclassified_throttle(&self, screen_text: &str, fg: &[CellFg]) {
-        let Some(raw_tail) = unclassified_throttle_tail(self.current, screen_text, fg) else {
+        let Some((raw_tail, wrap_split)) =
+            unclassified_throttle_tail(self.current, screen_text, fg)
+        else {
             return;
         };
+        // #1808 Phase-1 upstream instrument: a server-throttle phrase is on a
+        // LIVE non-retryable screen — the detection miss that left agents stuck.
+        // When `wrap_split` (phrase matched only after whitespace-flatten), the
+        // de-wrap of soft-wraps did NOT merge it → the wrap is a hard `\n` (Ink
+        // layout) → WARN with the FULL escaped screen_text so the next real SRL
+        // event is captured verbatim and we can confirm soft-vs-hard wrap before
+        // building the Phase 2 fallback. Contiguous misses (wrap_split=false) are
+        // the already-understood prose-FP class (correctly suppressed by the
+        // line-scoped content anchor) → kept to the JSONL sidecar only, no WARN
+        // noise. The feed-level screen hash-dedup bounds this to once per screen.
+        if wrap_split {
+            let escaped = screen_text.escape_debug().to_string();
+            tracing::warn!(
+                target: "state_detection",
+                agent = %self.instance_name,
+                backend = %self.backend_name,
+                tag = "#1808-srl-detect-miss",
+                classified_state = %self.current.display_name(),
+                wrap_split,
+                screen_text = %escaped,
+                "SRL/throttle phrase present only when whitespace-flattened (hard `\\n` line-wrap) but classifier did NOT latch a retryable state — capturing full screen_text for soft-vs-hard wrap diagnosis (#1808 Phase 2 signal)"
+            );
+        }
         let record = serde_json::json!({
             "ts": chrono::Utc::now().to_rfc3339(),
             "backend": self.backend_name,
             "classified_state": self.current.display_name(),
+            "wrap_split": wrap_split,
             "raw_tail": raw_tail,
+            "screen_text": screen_text,
         });
         let path = crate::home_dir().join("unclassified_errors.jsonl");
         if let Err(e) = append_jsonl(&path, &record) {

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -4143,11 +4143,34 @@ the agent kept going after the throttle\n";
 fn unclassified_throttle_logged_on_phrase_plus_nonretryable_state() {
     // Throttle phrase present, classifier landed on Ready (the in-the-wild
     // miss — e.g. anchor suppressed it / wording drifted) → capture.
-    let tail = unclassified_throttle_tail(AgentState::Idle, THROTTLE_SCREEN, &[]);
-    let tail = tail.expect("throttle phrase + non-retryable state must be captured");
+    let captured = unclassified_throttle_tail(AgentState::Idle, THROTTLE_SCREEN, &[]);
+    let (tail, wrap_split) =
+        captured.expect("throttle phrase + non-retryable state must be captured");
     assert!(
         tail.contains("temporarily limiting requests"),
         "captured tail must carry the throttle line, got: {tail:?}"
+    );
+    assert!(
+        !wrap_split,
+        "a contiguous (un-wrapped) phrase must NOT be flagged wrap_split"
+    );
+}
+
+/// #1808: the instrument was BLIND to a LINE-WRAPPED throttle phrase because it
+/// only did a contiguous `str::contains` — the exact reason the live narrow-pane
+/// SRL miss captured nothing. A phrase split by hard `\n` (Ink-style layout) must
+/// now be captured AND flagged `wrap_split` (the Phase 2 soft-vs-hard signal).
+#[test]
+fn unclassified_throttle_captures_hard_wrapped_phrase_with_wrap_split_flag() {
+    // Phrase split across rows by `\n` the way an app word-wrap emits it — NOT
+    // contiguous, so the old `contains` check missed it entirely.
+    let screen = "⏺ API Error:\ntemporarily limiting\nrequests (not your\nusage limit)\n";
+    let captured = unclassified_throttle_tail(AgentState::Idle, screen, &[]);
+    let (_tail, wrap_split) =
+        captured.expect("a hard-`\\n`-wrapped throttle phrase must still be captured (#1808)");
+    assert!(
+        wrap_split,
+        "a phrase found only after whitespace-flatten must be flagged wrap_split (hard-wrap signal)"
     );
 }
 

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -2520,6 +2520,56 @@ fn fn_red_truecolor_fragmented_fires() {
     assert_eq!(st.get_state(), AgentState::ServerRateLimit);
 }
 
+// ── #1808/#1809 NARROW-pane soft-wrap regression ────────────────────
+
+/// #1808/#1809 NAMED REGRESSION (live repro 2026-06-08, fixup-dev + dev-2,
+/// BOTH in narrow split panes) — would FAIL before the de-wrap fix.
+///
+/// In a NARROW pane alacritty soft-wraps the long SRL line across several
+/// physical grid rows. The detection feed (`tail_lines_with_fg` → the
+/// `feed_with_fg` ingress) used to join EVERY physical row with `\n`,
+/// inserting `\n` MID-PHRASE ("Server is\ntemporarily\nlimiting\nrequests").
+/// The single-line SRL regex (backend_profile.rs) then failed to match across
+/// the `\n` → `detect_with_match` returned None → ServerRateLimit never
+/// latched → no auto-retry → the agent hung. WIDE panes (lead) kept the phrase
+/// on one physical row → matched → recovered: the lead-vs-worker asymmetry
+/// that mystified the whole session. The fix de-wraps soft-wrapped rows
+/// (WRAPLINE-aware) before the regex sees them. Drives the REAL vterm →
+/// `tail_lines_with_fg` → `feed_with_fg` entry (§3.9 — not a hand-fed `\n`
+/// string), at a width that forces alacritty to soft-wrap.
+#[test]
+fn regression_1808_narrow_pane_wrapped_srl_latches() {
+    // 25 cols: "Server is temporarily limiting requests" (39 chars) cannot fit
+    // on one physical row → alacritty soft-wraps the phrase across rows.
+    let mut vt = VTerm::new(25, 24);
+    let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
+    // Render RED like the real Ink error (vterm resolves the SGR off the grid).
+    drive_colored_line(&mut vt, &mut st, RED_16, SRL_LINE);
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#1808: a soft-wrapped SRL line in a narrow pane must latch ServerRateLimit \
+         (pre-fix: physical-row `\\n` joins split the phrase → single-line regex \
+         missed → no detection → autopilot hang)"
+    );
+}
+
+/// #1808 companion — the SAME narrow-pane wrapped SRL line rendered PLAIN
+/// (no red) must ALSO latch via the content-anchor (`in_error_line` sees the
+/// de-wrapped "API Error:" line). Proves the de-wrap — not the color — is what
+/// restores detection, and that the content path survives de-wrap.
+#[test]
+fn regression_1808_narrow_pane_wrapped_srl_plain_content_anchor() {
+    let mut vt = VTerm::new(25, 24);
+    let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#1808: de-wrapped SRL line still qualifies via in_error_line content anchor"
+    );
+}
+
 /// #1450 NAMED REGRESSION — would FAIL before the fix.
 ///
 /// Pre-#1450 the raw-byte anchor allow-list knew only 4 sixteen-color

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -599,8 +599,13 @@ impl VTerm {
 
     /// Shared core for [`tail_lines`] / [`tail_lines_with_fg`]. When
     /// `collect_fg` is false the returned `Vec<CellFg>` is empty (no per-cell
-    /// classification cost); the produced `String` is byte-identical either
-    /// way so text-only callers are unaffected.
+    /// classification cost) AND physical rows are joined verbatim with `\n`
+    /// (byte-identical to the legacy output — text-only display/dialog callers
+    /// unaffected). When `collect_fg` is true (the state-detection feed) a
+    /// `WRAPLINE`-soft-wrapped row is DE-WRAPPED — joined to its continuation
+    /// WITHOUT a `\n` — so a single logical line the terminal wrapped across
+    /// rows stays one line for the single-line detection regexes (#1808). The
+    /// fg mask stays aligned 1:1 with the de-wrapped text.
     fn tail_lines_impl(&self, n: usize, collect_fg: bool) -> (String, Vec<CellFg>) {
         let grid = self.term.grid();
         let cols = self.cols as usize;
@@ -608,6 +613,16 @@ impl VTerm {
 
         let mut lines: Vec<String> = Vec::with_capacity(rows);
         let mut line_fgs: Vec<Vec<CellFg>> = Vec::with_capacity(rows);
+        // #1808: per-row soft-wrap flag. alacritty sets `WRAPLINE` on the LAST
+        // cell of a physical row whose logical line CONTINUES on the next row
+        // (its own auto-wrap when text overflows `cols`, NOT a `\n`/cursor-moved
+        // line break). The de-wrap join below consults it so a single logical
+        // line the terminal soft-wrapped across rows is NOT split by a `\n` in
+        // the detection feed — which otherwise inserts `\n` mid-phrase and makes
+        // a single-line state-detection regex miss (the #1808/#1809 SRL bug).
+        // Only the detection path (`collect_fg`) de-wraps; the text-only
+        // `tail_lines` stays byte-identical (display/dialog callers unaffected).
+        let mut wrapped: Vec<bool> = Vec::with_capacity(rows);
         for row in 0..rows {
             let mut line = String::with_capacity(cols);
             let mut fg: Vec<CellFg> = Vec::new();
@@ -625,14 +640,25 @@ impl VTerm {
                 }
                 col += 1;
             }
-            // trim_end drops trailing whitespace chars; truncate the parallel
-            // fg vec to the surviving char count so the two stay aligned.
-            let trimmed = line.trim_end();
+            let row_wrapped = collect_fg
+                && cols > 0
+                && safe_cell(grid, Line(row as i32), cols - 1)
+                    .flags
+                    .contains(Flags::WRAPLINE);
+            // trim_end drops trailing whitespace; truncate the parallel fg vec to
+            // the surviving char count so the two stay aligned. EXCEPT a
+            // soft-wrapped row: its trailing space can be a significant
+            // inter-word space at the wrap column, and the next row is about to
+            // be concatenated WITHOUT a `\n` — trimming it would fuse two words
+            // ("is" + "temporarily" → "istemporarily"), re-breaking the phrase
+            // the de-wrap exists to keep whole.
+            let trimmed = if row_wrapped { line.as_str() } else { line.trim_end() };
             if collect_fg {
                 fg.truncate(trimmed.chars().count());
             }
             lines.push(trimmed.to_string());
             line_fgs.push(fg);
+            wrapped.push(row_wrapped);
         }
 
         // Trim blank lines at both ends so terse output doesn't look padded
@@ -648,18 +674,24 @@ impl VTerm {
             .unwrap_or(first);
         let visible = &lines[first..last];
         let visible_fgs = &line_fgs[first..last];
+        let visible_wrapped = &wrapped[first..last];
 
         let start = visible.len().saturating_sub(n);
         let tail = &visible[start..];
         let tail_fgs = &visible_fgs[start..];
+        let tail_wrapped = &visible_wrapped[start..];
 
         let mut text = String::new();
         let mut fg_out: Vec<CellFg> = Vec::new();
         for (i, line) in tail.iter().enumerate() {
             if i > 0 {
-                text.push('\n');
-                if collect_fg {
-                    fg_out.push(CellFg::Default);
+                // #1808: skip the `\n` (and its filler fg cell) when the PREVIOUS
+                // row soft-wrapped into this one — they are one logical line.
+                if !tail_wrapped[i - 1] {
+                    text.push('\n');
+                    if collect_fg {
+                        fg_out.push(CellFg::Default);
+                    }
                 }
             }
             text.push_str(line);

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -652,7 +652,11 @@ impl VTerm {
             // be concatenated WITHOUT a `\n` — trimming it would fuse two words
             // ("is" + "temporarily" → "istemporarily"), re-breaking the phrase
             // the de-wrap exists to keep whole.
-            let trimmed = if row_wrapped { line.as_str() } else { line.trim_end() };
+            let trimmed = if row_wrapped {
+                line.as_str()
+            } else {
+                line.trim_end()
+            };
             if collect_fg {
                 fg.truncate(trimmed.chars().count());
             }


### PR DESCRIPTION
## Problem
The long-standing live SRL bug: agents hit \`API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited\` but the daemon never latches \`ServerRateLimit\` → no auto-retry → the agent sits idle, stuck. Mystifying lead-vs-worker asymmetry (lead recovered, narrow-pane workers hung).

## RCA (live daemon log + code, confirmed)
The detection feed `VTerm::tail_lines_with_fg` → `StateTracker::feed_with_fg` (agent/mod.rs:1436) builds `screen_text` by joining alacritty grid **physical rows** with `\n` **unconditionally** (`tail_lines_impl`). In a **narrow** (split) pane the SRL line soft-wraps across rows, so `\n` lands **mid-phrase** → the single-line SRL regex (`backend_profile.rs`) misses → `detect_with_match` returns `None` → never latches. **Wide** panes keep the phrase on one row → match → recover (the asymmetry).

The same blindness hid the existing #1562 instrument: `unclassified_throttle_tail` used `str::contains`, which a wrapped phrase also defeats → it captured nothing on the live miss.

Daemon-log evidence: the only `ServerRateLimit` events that reached the anchor gate were agents **discussing** the bug (contiguous phrase, correctly suppressed by the `in_error_line` prose anchor). The real worker errors logged **nothing** (regex returned `None` on the wrapped phrase) — matching "0 detection activity".

## Fix — Phase 1 (low-risk; Phase 2 held pending instrument confirmation)
- **`vterm::tail_lines_impl`**: `WRAPLINE`-aware **de-wrap** on the detection path (`collect_fg`) only. A soft-wrapped continuation row is joined **without** a `\n` (and its trailing inter-word space preserved so words don't fuse). One logical line the terminal wrapped now stays one line. Text-only `tail_lines` is **byte-identical** (display/dialog callers unaffected). Fully fixes the **soft-wrap** case; **no-op + zero-risk** if the wrap is a hard `\n` (Ink layout).
- **`state::unclassified_throttle_tail` / `capture_unclassified_throttle`**: phrase check now also matches a **whitespace-flattened** view (catches a wrapped phrase) and reports `wrap_split`. On `wrap_split` it **WARNs the full escaped `screen_text`** → the **next real SRL event is captured verbatim**, so we can confirm **soft-vs-hard wrap** before building the Phase 2 (hard-`\n` flattened-tail) fallback.

## Why phased
The real worker error's exact rendering was never captured, so soft-wrap (fixed here) vs hard-`\n` Ink layout (needs Phase 2) is unconfirmed. Shipping the safe de-wrap + a wrap-tolerant instrument avoids a green-CI **non-fix** (§3.9/§3.21) and guarantees the next event resolves the mechanism. (Approved by lead.)

## Tests (§3.9 — through the REAL `feed_with_fg` entry)
- `regression_1808_narrow_pane_wrapped_srl_latches` — 25-col vterm soft-wraps the SRL line; must latch `ServerRateLimit` (RED before fix → GREEN after).
- `regression_1808_narrow_pane_wrapped_srl_plain_content_anchor` — same, plain render, via the `in_error_line` content anchor.
- `unclassified_throttle_captures_hard_wrapped_phrase_with_wrap_split_flag` — a hard-`\n`-wrapped phrase is now captured with `wrap_split=true`.

§3.10 RED→GREEN: test commit `c6d95a4` (tests fail) → fix `9ce69b8` (tests pass); ignore the intervening empty `init` heartbeats (§10.7).

Preserves the #1518 position gate / `in_error_line` / #1450 red anchor / narrow-pane prose-FP protection (all operate on the same de-wrapped text).

## Verification
- `cargo test --tests --features tray`: **3422 passed, 0 failed** (with real git; the one git-checkout test fails only under the local `agend-git` shim, not in CI).
- `cargo clippy --all-targets --features tray -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)