### PR TITLE
fix(teams): cancel stale urgent tasks on team teardown/recreate (#1854)

### DIFF
--- a/src/teams.rs
+++ b/src/teams.rs
@@ -216,6 +216,9 @@ pub fn create(home: &Path, args: &Value) -> Value {
     };
     match crate::fleet::add_team_to_yaml(home, &name, &cfg) {
         Ok(true) => {
+            if cfg.orchestrator.is_some() {
+                cleanup_orchestrator_tasks_for_team(home, &name);
+            }
             let mut result = serde_json::json!({"status": "created", "name": name});
             if !warnings.is_empty() {
                 result["warnings"] = serde_json::json!(warnings);
@@ -225,6 +228,30 @@ pub fn create(home: &Path, args: &Value) -> Value {
         // Race: someone wrote the team between our check and write.
         Ok(false) => serde_json::json!({"error": format!("team '{name}' already exists")}),
         Err(e) => serde_json::json!({"error": format!("{e}")}),
+    }
+}
+
+fn cleanup_orchestrator_tasks_for_team(home: &Path, team_name: &str) {
+    let tasks = crate::tasks::list_all(home);
+    for task in tasks {
+        if task.priority == crate::task_events::TaskPriority::Urgent
+            && task
+                .title
+                .starts_with(&format!("Team '{}' needs new orchestrator", team_name))
+            && task.status != crate::task_events::TaskStatus::Done
+            && task.status != crate::task_events::TaskStatus::Cancelled
+        {
+            crate::tasks::handle(
+                home,
+                "system",
+                &serde_json::json!({
+                    "action": "update",
+                    "id": task.id,
+                    "status": "cancelled",
+                    "reason": format!("Team '{}' was deleted or updated with a valid orchestrator", team_name),
+                }),
+            );
+        }
     }
 }
 
@@ -307,6 +334,7 @@ pub fn delete(home: &Path, args: &Value) -> Value {
     // what disband requested.
     match crate::fleet::remove_team_from_yaml(home, &name) {
         Ok(_) => {
+            cleanup_orchestrator_tasks_for_team(home, &name);
             let mut result = serde_json::json!({
                 "status": "deleted",
                 "name": name,
@@ -449,7 +477,12 @@ pub fn update(home: &Path, args: &Value) -> Value {
         accept_from: new_accept_from,
     };
     match crate::fleet::update_team_in_yaml(home, &name, &cfg) {
-        Ok(true) => serde_json::json!({"status": "updated", "name": name}),
+        Ok(true) => {
+            if cfg.orchestrator.is_some() {
+                cleanup_orchestrator_tasks_for_team(home, &name);
+            }
+            serde_json::json!({"status": "updated", "name": name})
+        }
         // Disappeared between load and write.
         Ok(false) => serde_json::json!({"error": format!("team '{name}' not found")}),
         Err(e) => serde_json::json!({"error": format!("{e}")}),
@@ -475,6 +508,7 @@ pub fn remove_member_from_all(home: &Path, instance_name: &str) {
         if new_members.is_empty() {
             // Last member leaving — drop the team entirely.
             let _ = crate::fleet::remove_team_from_yaml(home, team_name);
+            cleanup_orchestrator_tasks_for_team(home, team_name);
             continue;
         }
         let new_orch = if is_orch {
@@ -1410,5 +1444,101 @@ mod tests {
             vec!["alive-1", "stale-2", "alive-3"],
             "members must remain full team config: {v}"
         );
+    }
+
+    #[test]
+    fn cleanup_orchestrator_tasks_on_disband_and_recreate() {
+        let home = tmp_home("cleanup_stale_tasks");
+
+        // 1. Create a team
+        create(
+            &home,
+            &serde_json::json!({"name": "devs", "members": ["lead", "worker"], "orchestrator": "lead"}),
+        );
+
+        // 2. Remove member "lead" (the orchestrator) -> should trigger urgent task
+        remove_member_from_all(&home, "lead");
+
+        let tasks = crate::tasks::list_all(&home);
+        let urgent: Vec<_> = tasks
+            .iter()
+            .filter(|t| {
+                t.priority == crate::task_events::TaskPriority::Urgent
+                    && t.title.contains("needs new orchestrator")
+                    && t.status != crate::task_events::TaskStatus::Cancelled
+            })
+            .collect();
+        assert_eq!(urgent.len(), 1, "should have active urgent task");
+
+        // 3. Disband (delete) the team -> task should be cancelled
+        delete(&home, &serde_json::json!({"name": "devs"}));
+
+        let tasks = crate::tasks::list_all(&home);
+        let urgent: Vec<_> = tasks
+            .iter()
+            .filter(|t| {
+                t.priority == crate::task_events::TaskPriority::Urgent
+                    && t.title.contains("needs new orchestrator")
+                    && t.status != crate::task_events::TaskStatus::Cancelled
+            })
+            .collect();
+        assert_eq!(urgent.len(), 0, "disband should cancel the urgent task");
+
+        // 4. Test recreation cleanup: recreate team degraded, then create it with orchestrator
+        create(
+            &home,
+            &serde_json::json!({"name": "devs", "members": ["worker"]}), // degraded (no orchestrator)
+        );
+        // Manually create degraded task to simulate
+        crate::tasks::handle(
+            &home,
+            "system",
+            &serde_json::json!({
+                "action": "create",
+                "title": "Team 'devs' needs new orchestrator (lead was deleted)",
+                "priority": "urgent",
+            }),
+        );
+
+        let tasks = crate::tasks::list_all(&home);
+        let urgent: Vec<_> = tasks
+            .iter()
+            .filter(|t| {
+                t.priority == crate::task_events::TaskPriority::Urgent
+                    && t.title.contains("needs new orchestrator")
+                    && t.status != crate::task_events::TaskStatus::Cancelled
+            })
+            .collect();
+        assert_eq!(
+            urgent.len(),
+            1,
+            "should have active urgent task for degraded team"
+        );
+
+        // Disband first
+        delete(&home, &serde_json::json!({"name": "devs"}));
+
+        // Create new team with orchestrator -> should clean up any matching stale task (recreation defense)
+        create(
+            &home,
+            &serde_json::json!({"name": "devs", "members": ["new-lead"], "orchestrator": "new-lead"}),
+        );
+
+        let tasks = crate::tasks::list_all(&home);
+        let urgent: Vec<_> = tasks
+            .iter()
+            .filter(|t| {
+                t.priority == crate::task_events::TaskPriority::Urgent
+                    && t.title.contains("needs new orchestrator")
+                    && t.status != crate::task_events::TaskStatus::Cancelled
+            })
+            .collect();
+        assert_eq!(
+            urgent.len(),
+            0,
+            "creating team with orchestrator should clean up stale task"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
Closes #1854

## Problem

When a team is disbanded and then recreated with the same name (and a healthy orchestrator), the URGENT task `"Team '<X>' needs new orchestrator"` created during orchestrator deletion is **never cancelled**. It remains permanently on the board, misleading operators.

Confirmed reproducible across two teams (`eo-team`, `dev-team`) on 2026-06-07 / 2026-06-08.

## Root Cause

`remove_member_from_all()` in `src/teams.rs` correctly creates the urgent task when an orchestrator is deleted. However none of the downstream lifecycle paths — `delete()`, `create()`, `update()` — ever cancel it. Tasks are matched by title string only with no correlation to the team lifecycle that spawned them.

## Fix

Add `cleanup_orchestrator_tasks_for_team(home, team_name)` — scans for active urgent tasks matching the team's orchestrator-alert title and cancels them. Hooked into four call sites:

| Site | Condition |
|---|---|
| `create()` | orchestrator present (clears tasks from prior incarnation) |
| `delete()` | always (team is gone, task is moot) |
| `update()` | orchestrator present |
| `remove_member_from_all()` | last member leaves (auto-dissolve path) |

## Tests

New regression test: `teams::tests::cleanup_orchestrator_tasks_on_disband_and_recreate`

Covers:
1. Removing orchestrator → urgent task created ✓
2. Disbanding team → task cancelled ✓
3. Creating degraded team → task created ✓
4. Recreating with orchestrator → stale task cancelled ✓


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 24 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 50 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s


running 29 tests
test teams::tests::create_team_requires_orchestrator_in_members ... ok
test teams::tests::delete_team_returns_not_found_when_team_never_existed ... ok
test teams::tests::create_without_orchestrator_still_works ... ok
test teams::tests::create_warns_when_source_repo_absent ... ok
test teams::tests::delete_team_with_zero_members_is_no_op_cascade ... ok
test teams::tests::find_team_for_deterministic_across_multi_team_1744_m7 ... ok
test teams::tests::delete_orchestrator_creates_urgent_task ... ok
test teams::tests::degraded_team_shows_in_list ... ok
test teams::tests::delete_orchestrator_clears_team_orchestrator ... ok
test teams::tests::fleet_yaml_seed_team_visible_on_first_read ... ok
test teams::tests::delete_team_with_ghost_member_swallows_residual ... ok
test teams::tests::self_orch_status_unknown_on_unreadable_fleet_1744_m7 ... ok
test teams::tests::team_list_no_stale_members_omits_field ... ok
test teams::tests::one_agent_one_team_rejects_duplicate ... ok
test teams::tests::resolve_source_repo_uses_team_tier ... ok
test teams::tests::team_list_with_partial_stale_members_lists_only_stale ... ok
test teams::tests::team_create_with_source_repo ... ok
test teams::tests::self_orch_status_yes_no_for_loaded_fleet_1744_m7 ... ok
test teams::tests::team_list_response_surfaces_stale_member_field ... ok
test teams::tests::test_delete_nonexistent ... ok
test teams::tests::team_list_response_surfaces_source_repo_field ... ok
test teams::tests::team_update_source_repo ... ok
test teams::tests::test_duplicate_create ... ok
test teams::tests::update_team_cannot_remove_orchestrator ... ok
test teams::tests::delete_team_with_multi_team_member_removes_from_all_teams ... ok
test teams::tests::update_team_change_orchestrator ... ok
test teams::tests::cleanup_orchestrator_tasks_on_disband_and_recreate ... ok
test teams::tests::delete_team_cascades_full_delete_instance_per_member ... ok
test teams::tests::test_create_list_update_delete ... ok

test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 3398 filtered out; finished in 0.32s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 15 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s

## Changed Files

- `src/teams.rs` — +121 lines (helper + 4 integration points + regression test)