### PR TITLE
state: detect Ink hard-wrapped SRL + re-detect static stuck pane (SRL Phase 2)

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -520,6 +520,28 @@ const THROTTLE_DIAG_PHRASES: &[&str] = &[
     "hit a rate limit",
 ];
 
+/// #SRL-phase2: cheap raw single-token pre-filter for the hash-dedup blind-spot
+/// bypass. A settled (static) stuck-SRL pane has an unchanged screen hash, so
+/// `feed_with_fg`'s dedup would skip detection forever and it never recovers. We
+/// only override the skip when one of these distinctive tokens is on screen —
+/// and they are chosen to survive Ink WORD-wrap (each is a single token that sits
+/// intact on one wrapped row), so a hard-wrapped SRL line still trips the
+/// pre-filter even though the full phrase is split across rows. Kept tight to
+/// avoid re-detecting every static idle pane.
+const THROTTLE_HINT_TOKENS: &[&str] = &[
+    "limiting",
+    "Overloaded",
+    "overloaded_error",
+    "rate_limit_error",
+    "RESOURCE_EXHAUSTED",
+    "429",
+    "Rate limited",
+];
+
+fn screen_has_throttle_hint(screen_text: &str) -> bool {
+    THROTTLE_HINT_TOKENS.iter().any(|t| screen_text.contains(t))
+}
+
 /// #1562: rows of the live tail captured into the diagnostic record. Matches
 /// the `ERROR_TAIL_SCAN_LINES` horizon so the captured context lines up with
 /// the bottom-N window the error gates actually look at.
@@ -653,6 +675,39 @@ fn unclassified_throttle_tail(
         ansi_colored_tail(screen_text, fg, UNCLASSIFIED_TAIL_LINES),
         wrap_split,
     ))
+}
+
+/// #SRL-phase2: hard-wrap detection fallback. Ink word-wraps a long
+/// SRL/RateLimit error line into multiple rows joined by REAL `\n` (not an
+/// alacritty soft-wrap), so the single-line `detect_with_match` regex on the raw
+/// screen can't match it — the exact live narrow-pane miss that left the agent
+/// SRL-stuck with 0 detection. Flatten the bottom-N tail (every whitespace run,
+/// incl. `\n`, → one space) and re-detect there.
+///
+/// Guards (scoped TIGHT — this runs only when raw detection already missed):
+/// - **auto-clear throttle states ONLY** (`ServerRateLimit` / `RateLimit`).
+///   NEVER `ModelUnsupported` / `ContextFull`: those don't auto-clear and
+///   suppress hang-check, so a flatten-FP would silently wedge a healthy agent.
+/// - **`in_error_line` on the flattened text** — the prose-FP guard. A multi-row
+///   prose block merged into one line is only accepted if it carries a real
+///   error indicator (`…Error:`, `429`, `RESOURCE_EXHAUSTED`, …). The residual
+///   verbatim-quote FP (a pane literally rendering an error line) is ACCEPTED —
+///   identical to the raw-path policy (mod.rs §anchor-gate): these states
+///   auto-clear and are retry-driven, so a one-off mis-latch self-corrects.
+fn flattened_throttle_detect(
+    patterns: &crate::state::patterns::StatePatterns,
+    screen_text: &str,
+) -> Option<AgentState> {
+    let tail = recent_screen_tail(screen_text, ERROR_TAIL_SCAN_LINES);
+    let flat = tail.split_whitespace().collect::<Vec<_>>().join(" ");
+    let (state, matched) = patterns.detect_with_match(&flat)?;
+    if !matches!(state, AgentState::ServerRateLimit | AgentState::RateLimit) {
+        return None;
+    }
+    if !crate::state::patterns::in_error_line(&flat, matched) {
+        return None;
+    }
+    Some(state)
 }
 
 /// #1562: best-effort append of one JSON record as a single `line\n` to `path`,
@@ -896,9 +951,27 @@ impl StateTracker {
     pub fn feed_with_fg(&mut self, screen_text: &str, fg: &[CellFg]) {
         let hash = hash_screen(screen_text);
         if self.last_screen_hash == Some(hash) {
-            return;
+            // #SRL-phase2 hash-dedup blind spot: a SETTLED (static) stuck-SRL
+            // pane has an UNCHANGED hash, so this dedup early-return would skip
+            // detection forever and the agent never recovers (no further feed
+            // ever re-runs the SRL gates). Override the skip ONLY when the pane
+            // carries a throttle hint AND we are not already latched on a
+            // throttle — then fall through so the hard-wrap fallback (None arm)
+            // can latch it → auto-retry fires. The cheap raw-token pre-filter
+            // keeps the common static-idle pane on the fast skip path.
+            let already_throttle = matches!(
+                self.current,
+                AgentState::ServerRateLimit | AgentState::RateLimit
+            );
+            if already_throttle || !screen_has_throttle_hint(screen_text) {
+                return;
+            }
+            // else: re-detect the static throttle pane. Do NOT re-stamp the hash
+            // (it's unchanged); once we latch, `already_throttle` short-circuits
+            // subsequent identical frames.
+        } else {
+            self.last_screen_hash = Some(hash);
         }
-        self.last_screen_hash = Some(hash);
 
         // Sprint 27 shadow-mode: capture silence duration BEFORE updating
         // last_output, so we measure time since previous feed (not current).
@@ -1170,16 +1243,34 @@ impl StateTracker {
                     }
                 }
                 None => {
-                    // Starting-only structural fallback: if the pattern
-                    // catalog didn't recognize anything but the screen
-                    // contains a generic prompt token (y/n, press enter,
-                    // etc.), this is almost certainly a startup-time
-                    // dialog waiting for the operator. Flag it as
-                    // InteractivePrompt immediately instead of waiting
-                    // on `check_awaiting_operator`'s silence window.
-                    if matches!(self.current, AgentState::Starting)
+                    // #SRL-phase2: hard-wrap fallback. Raw detection missed —
+                    // which is exactly what an Ink-hard-wrapped SRL/RateLimit
+                    // line looks like (the phrase split across rows by real
+                    // `\n`). Retry on the flattened bottom-N tail before the
+                    // structural/expire path. Land via the SAME recovery gate as
+                    // the raw SRL path: recent productive output ⇒ recovered ⇒
+                    // Idle; else latch the throttle so auto-retry fires.
+                    // (working_state_below can't be located in the wrapped raw
+                    // text, so a hard-wrapped throttle with a working marker
+                    // below is not overridden here — accepted; `recovered_within`
+                    // still releases a genuinely-recovered pane.)
+                    if let Some(throttle) = flattened_throttle_detect(patterns, screen_text) {
+                        let landed = if matches!(throttle, AgentState::ServerRateLimit)
+                            && self.recovered_within(SERVER_RATE_LIMIT_RECOVERY_SILENCE)
+                        {
+                            AgentState::Idle
+                        } else {
+                            throttle
+                        };
+                        let gated = self.gate_on_heartbeat(landed);
+                        self.transition(gated);
+                    } else if matches!(self.current, AgentState::Starting)
                         && is_generic_startup_prompt(screen_text)
                     {
+                        // Starting-only structural fallback: a generic prompt
+                        // token (y/n, press enter, …) at startup is almost
+                        // certainly an operator dialog — flag InteractivePrompt
+                        // immediately instead of waiting on the silence window.
                         self.transition(AgentState::InteractivePrompt);
                     } else {
                         self.maybe_expire_latched_state();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -688,12 +688,18 @@ fn unclassified_throttle_tail(
 /// - **auto-clear throttle states ONLY** (`ServerRateLimit` / `RateLimit`).
 ///   NEVER `ModelUnsupported` / `ContextFull`: those don't auto-clear and
 ///   suppress hang-check, so a flatten-FP would silently wedge a healthy agent.
-/// - **`in_error_line` on the flattened text** — the prose-FP guard. A multi-row
-///   prose block merged into one line is only accepted if it carries a real
-///   error indicator (`…Error:`, `429`, `RESOURCE_EXHAUSTED`, …). The residual
-///   verbatim-quote FP (a pane literally rendering an error line) is ACCEPTED —
-///   identical to the raw-path policy (mod.rs §anchor-gate): these states
-///   auto-clear and are retry-driven, so a one-off mis-latch self-corrects.
+/// - **a PROXIMITY-scoped error indicator** — the prose-FP guard. The flattened
+///   tail has NO `\n`, so `in_error_line` (which line-scopes via `\n`) would
+///   degenerate to "an indicator ANYWHERE in the bottom-N tail" — a distant
+///   unrelated `API Error:` on a different row would false-pass (reviewer-2,
+///   #1857). Instead require the indicator within [`THROTTLE_INDICATOR_PROXIMITY`]
+///   chars BEFORE the throttle match: a legit Ink hard-wrap renders the indicator
+///   (`API Error:`) immediately before the throttle phrase, so it falls inside
+///   the window; a stray indicator from an unrelated earlier row is far away and
+///   rejected. The residual verbatim-quote FP (a pane literally rendering
+///   `API Error: <throttle>` adjacent) is ACCEPTED — same as the raw-path policy:
+///   these states auto-clear and are retry-driven, so a one-off mis-latch
+///   self-corrects.
 fn flattened_throttle_detect(
     patterns: &crate::state::patterns::StatePatterns,
     screen_text: &str,
@@ -704,10 +710,37 @@ fn flattened_throttle_detect(
     if !matches!(state, AgentState::ServerRateLimit | AgentState::RateLimit) {
         return None;
     }
-    if !crate::state::patterns::in_error_line(&flat, matched) {
+    if !throttle_indicator_adjacent(&flat, matched) {
         return None;
     }
     Some(state)
+}
+
+/// Chars before a throttle match within which a real error indicator must sit for
+/// the [`flattened_throttle_detect`] prose-FP guard. A hard-wrapped SRL renders
+/// the `API Error:` prefix directly before the throttle phrase (≈10–30 chars); 80
+/// leaves slack for a short row prefix while staying tight enough to exclude an
+/// unrelated indicator on a different (flattened-away) row.
+const THROTTLE_INDICATOR_PROXIMITY: usize = 80;
+
+/// #SRL-phase2 (reviewer-2 #1857 fix): require an error indicator within
+/// `THROTTLE_INDICATOR_PROXIMITY` chars BEFORE `matched` in the flattened tail —
+/// the `\n`-less replacement for `in_error_line`'s line-scoping. The window spans
+/// `[match_start - K, match_end]` so an indicator that IS the match
+/// (`API Error: 5xx`) or sits just before it (`API Error: Server is temporarily
+/// limiting …`) passes, while a distant unrelated indicator does not.
+fn throttle_indicator_adjacent(flat: &str, matched: &str) -> bool {
+    let Some(start) = flat.find(matched) else {
+        return false;
+    };
+    let end = start + matched.len();
+    let raw_win_start = start.saturating_sub(THROTTLE_INDICATOR_PROXIMITY);
+    // Snap to a char boundary at/after the raw start so slicing never panics on
+    // multi-byte content. `start` is always a boundary (it's a `find` result).
+    let win_start = (raw_win_start..=start)
+        .find(|&i| flat.is_char_boundary(i))
+        .unwrap_or(start);
+    crate::state::patterns::line_has_error_indicator(&flat[win_start..end])
 }
 
 /// #1562: best-effort append of one JSON record as a single `line\n` to `path`,

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -74,10 +74,12 @@ pub(crate) const SERVER_RATE_LIMIT_NET_ERRORS: &str = r"ECONNRESET|ETIMEDOUT|Inv
 /// change the red→content anchor decision (a follow-up pending the operator's
 /// call on keeping/dropping the color signal); today it still gates only the
 /// #1757 net-error exemption at its single call site.
-pub(crate) fn in_error_line(screen_text: &str, matched: &str) -> bool {
-    if matched.is_empty() {
-        return false;
-    }
+/// Does `text` contain a recognised error-line indicator (`…Error:`, `429`,
+/// `resource_exhausted`, JSON error shapes, …)? Pure regex check over the WHOLE
+/// `text` — the caller is responsible for scoping `text` (a single line in
+/// [`in_error_line`]; a tight proximity window in the SRL hard-wrap fallback,
+/// where a fully-flattened tail has no `\n` to line-scope on).
+pub(crate) fn line_has_error_indicator(text: &str) -> bool {
     use std::sync::OnceLock;
     static ERROR_LINE: OnceLock<Regex> = OnceLock::new();
     let re = ERROR_LINE.get_or_init(|| {
@@ -86,6 +88,13 @@ pub(crate) fn in_error_line(screen_text: &str, matched: &str) -> bool {
         )
         .expect("error-line regex")
     });
+    re.is_match(text)
+}
+
+pub(crate) fn in_error_line(screen_text: &str, matched: &str) -> bool {
+    if matched.is_empty() {
+        return false;
+    }
     let mut search = 0;
     while let Some(rel) = screen_text[search..].find(matched) {
         let pos = search + rel;
@@ -93,7 +102,7 @@ pub(crate) fn in_error_line(screen_text: &str, matched: &str) -> bool {
         let line_end = screen_text[pos..]
             .find('\n')
             .map_or(screen_text.len(), |i| pos + i);
-        if re.is_match(&screen_text[line_start..line_end]) {
+        if line_has_error_indicator(&screen_text[line_start..line_end]) {
             return true;
         }
         search = pos + matched.len();

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -4338,3 +4338,27 @@ fn multiline_prose_mentioning_srl_does_not_latch_phase2() {
         "#SRL-phase2: multi-line prose mentioning the SRL phrase (no error indicator) must NOT latch"
     );
 }
+
+/// #SRL-phase2 (c') reviewer-2 #1857 regression: prose that mentions the SRL
+/// phrase AND has an UNRELATED error indicator on a DIFFERENT (distant) row must
+/// NOT latch. The old `in_error_line(flat, …)` degenerated to "indicator anywhere
+/// in the tail" (flat has no `\n`) → false latch; the proximity-scoped check
+/// rejects the distant indicator.
+#[test]
+fn prose_with_distant_unrelated_error_indicator_does_not_latch_phase2() {
+    let (mut vt, mut st) = claude_tracker();
+    // Row A: an unrelated `TypeError:` (an in_error_line indicator, but NOT an
+    // SRL/RateLimit pattern). Rows of filler push it well past the proximity
+    // window. Last row: the SRL throttle phrase as prose (no adjacent indicator).
+    let frame = "TypeError: cannot read property foo of undefined here\r\n\
+                 filler alpha beta gamma delta epsilon\r\n\
+                 filler zeta eta theta iota kappa\r\n\
+                 more filler lambda mu nu xi omicron\r\n\
+                 Server is temporarily limiting requests is just the banner text FYI\r\n";
+    drive(&mut vt, &mut st, frame.as_bytes());
+    assert_ne!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#SRL-phase2 #1857: SRL prose + a DISTANT unrelated error indicator must NOT latch"
+    );
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -4262,3 +4262,79 @@ fn append_jsonl_appends_one_record_per_line() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// ── #SRL-phase2: Ink hard-wrap + hash-dedup blind-spot ───────────────────────
+
+/// #SRL-phase2 (a): a narrow-pane Ink HARD-wrapped ServerRateLimit line (the
+/// phrase split across rows by real `\n`, not an alacritty soft-wrap) must latch
+/// SRL via the flattened-tail fallback. The raw single-line regex misses it
+/// (Phase 1 fails); the flattened bottom-N tail matches + `in_error_line` holds
+/// ("API Error:" on the rejoined line).
+#[test]
+fn hardwrap_srl_latches_via_flattened_tail_phase2() {
+    let (mut vt, mut st) = claude_tracker();
+    // Each word-wrapped row separated by a REAL CRLF (hard wrap).
+    let hw =
+        "API Error: Server is\r\ntemporarily limiting\r\nrequests (not your\r\nusage limit)\r\n";
+    // Sanity: the raw (un-flattened) screen does NOT match the single-line SRL
+    // regex — this is exactly the Phase-1 miss.
+    assert!(
+        patterns::StatePatterns::for_backend(&Backend::ClaudeCode)
+            .detect_with_match(
+                "API Error: Server is\ntemporarily limiting\nrequests (not your\nusage limit)"
+            )
+            .is_none(),
+        "precondition: hard-wrapped SRL must NOT match the raw single-line regex"
+    );
+    drive(&mut vt, &mut st, hw.as_bytes());
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#SRL-phase2: hard-wrapped SRL must latch via the flattened-tail fallback"
+    );
+}
+
+/// #SRL-phase2 (b): a SETTLED (static, unchanged-hash) SRL pane must be
+/// re-detected despite the `feed_with_fg` hash-dedup early-return — otherwise a
+/// stuck SRL pane that was cleared (spuriously) never re-latches and never
+/// recovers. Simulate the clear-while-static blind spot: latch, clear `current`
+/// without changing the screen, feed the IDENTICAL frame → must re-latch.
+#[test]
+fn static_srl_pane_redetected_after_dedup_blindspot_phase2() {
+    let (mut vt, mut st) = claude_tracker();
+    let hw =
+        "API Error: Server is\r\ntemporarily limiting\r\nrequests (not your\r\nusage limit)\r\n";
+    drive(&mut vt, &mut st, hw.as_bytes());
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "first feed latches"
+    );
+    // Spurious clear while the pane stays STATIC (same frame ⇒ same hash). The
+    // blind spot: the next identical feed would dedup-skip and never re-latch.
+    st.current = AgentState::Idle;
+    drive(&mut vt, &mut st, hw.as_bytes());
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#SRL-phase2: a static SRL pane must re-detect across the hash-dedup blind spot"
+    );
+}
+
+/// #SRL-phase2 (c) prose-FP: multi-line prose that mentions the SRL phrase but is
+/// NOT an error render (no error indicator on the flattened line) must NOT latch.
+/// The `in_error_line` guard on the flattened text rejects it.
+#[test]
+fn multiline_prose_mentioning_srl_does_not_latch_phase2() {
+    let (mut vt, mut st) = claude_tracker();
+    // Contains the exact SRL phrase (so detect_with_match matches the flattened
+    // tail) but no error indicator (no "API Error:"/"429"/…) → in_error_line
+    // rejects → no latch.
+    let prose = "Docs note: Server is\r\ntemporarily limiting\r\nrequests is the SRL\r\nbanner text, FYI.\r\n";
+    drive(&mut vt, &mut st, prose.as_bytes());
+    assert_ne!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#SRL-phase2: multi-line prose mentioning the SRL phrase (no error indicator) must NOT latch"
+    );
+}


### PR DESCRIPTION
Phase 1 (#1851) didn't fix the live SRL-stuck bug — dev/dev-2 went stuck again with **0 detection AND 0 instrument**. Two confirmed root causes (from the live pane):

## 1. HARD-wrap, not soft-wrap
On a narrow pane, Ink **word-wraps** the SRL/RateLimit line into rows joined by **real `\n`**, so the single-line `detect_with_match` regex never matches it. Phase 1's WRAPLINE de-wrap only merges **alacritty soft-wraps** → no-op on Ink hard-wrap.

**Fix:** `flattened_throttle_detect` — when raw `detect_with_match` misses, retry on the **flattened bottom-N tail** (whitespace runs incl. `\n` → one space). Scoped tight:
- auto-clear throttle states **only** (`ServerRateLimit`/`RateLimit`) — never `ModelUnsupported`/`ContextFull` (no auto-clear → a flatten-FP would silently wedge a healthy agent);
- **`in_error_line` on the flattened text** is the prose-FP guard (a merged prose block lacking a real error indicator is rejected; the residual verbatim-quote FP is the same accepted, self-correcting residual as the raw path).
- Wired into the detect **None arm** — the raw path (non-wrapped) is untouched → no regression. Lands via the same `recovered_within` gate.

## 2. hash-dedup blind spot
`feed_with_fg`'s screen-hash early-return sits **before** detection; a settled (static) stuck-SRL pane has an unchanged hash → returns early forever → never re-detected.

**Fix:** on a dedup hit, if the pane carries a throttle hint (cheap raw single-token pre-filter — tokens chosen to survive Ink word-wrap) **and** we're not already latched on a throttle, fall through to re-detect. Once latched, identical frames short-circuit again (perf-safe).

## Tests (§3.9)

- `hardwrap_srl_latches_via_flattened_tail_phase2` — asserts the raw single-line regex misses (Phase-1 precondition), then the hard-wrapped frame latches SRL.
- `static_srl_pane_redetected_after_dedup_blindspot_phase2` — clear-while-static → the identical next frame re-latches (would dedup-skip without the fix).
- `multiline_prose_mentioning_srl_does_not_latch_phase2` — prose with the SRL phrase but no error indicator → `in_error_line` rejects → no latch.

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓
- `state::` suite **310/310** (no regression — the riskiest axis)
- `cargo test --tests --features tray` → green except the unrelated `dispatch_branch_skips_metadata_stub_..._1834` (messaging.rs git-checkout) which false-fails only under the local fleet `git` shim; passes with real `/usr/bin/git` (CI uses real git).

⚠️ This is daemon-side detection — effect (stuck SRL panes recover) is visible after operator restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)