### PR TITLE
ci-handoff: daemon-side re-nudge of the target + fix orchestrator-as-next_after_ci hole (#1859 Fix A)

### DIFF
--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -23,39 +23,98 @@ use std::path::Path;
 const HANDOFF_TIMEOUT_MINS: i64 = 10;
 /// Don't re-escalate the same (target, handoff) more often than this.
 const REALERT_AFTER_MINS: i64 = 30;
+/// #1859 Fix A: a handoff unread for at least this long (minutes) is RE-NUDGED to
+/// the target itself (daemon-side redelivery — earlier + cheaper than the 10-min
+/// lead escalation, and the only recovery when `next_after_ci` IS the orchestrator).
+const RENUDGE_AFTER_MINS: i64 = 2;
+/// #1859 Fix A: don't re-nudge the same (target, handoff) more often than this
+/// (anti-storm). Combined with the idle gate, a busy/working target is retried at
+/// most once per interval and a target that has read the handoff stops entirely.
+const RENUDGE_INTERVAL_MINS: i64 = 2;
 /// Fallback recipient when the target isn't in any team.
 const FALLBACK_RECIPIENT: &str = "lead";
 /// Inbox kind of a CI handoff message.
 const HANDOFF_KIND: &str = "ci-ready-for-action";
 
 /// Scan every fleet instance for `ci-ready-for-action` handoffs it received but
-/// never read, and escalate timed-out ones to the target's team lead.
-/// `last_escalated` (keyed by `(target, correlation)`) is owned by the caller
-/// so dedup survives across ticks; `now` is injected for deterministic tests.
+/// never read; (1) #1859: RE-NUDGE the target itself (daemon-side redelivery) and
+/// (2) escalate timed-out ones to the target's team lead. `last_escalated` /
+/// `last_renudged` (keyed by `(target, correlation)`) are owned by the caller so
+/// dedup survives across ticks; `now` is injected for deterministic tests.
 pub(crate) fn scan_and_emit(
     home: &Path,
     now: &chrono::DateTime<chrono::Utc>,
     last_escalated: &mut HashMap<(String, String), chrono::DateTime<chrono::Utc>>,
+    last_renudged: &mut HashMap<(String, String), chrono::DateTime<chrono::Utc>>,
 ) {
+    scan_and_emit_with(
+        home,
+        now,
+        last_escalated,
+        last_renudged,
+        |target, unread| {
+            crate::inbox::notify::renudge_actionable_unread(home, target, HANDOFF_KIND, unread);
+        },
+    );
+}
+
+/// Test-seam variant: `renudge` is the per-target re-nudge emitter (real path is
+/// the direct PTY inject; tests pass a capturing closure so the daemon API
+/// loopback isn't required). The busy/interval GATING lives here (not in the
+/// emitter) so a test driving the real `scan_and_emit_with` entry can assert
+/// exactly when a re-nudge fires.
+pub(crate) fn scan_and_emit_with<F>(
+    home: &Path,
+    now: &chrono::DateTime<chrono::Utc>,
+    last_escalated: &mut HashMap<(String, String), chrono::DateTime<chrono::Utc>>,
+    last_renudged: &mut HashMap<(String, String), chrono::DateTime<chrono::Utc>>,
+    mut renudge: F,
+) where
+    F: FnMut(&str, usize),
+{
     let Ok(fleet) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) else {
         return;
     };
     // #1598-mirror: collect every (target, correlation) key still backed by a
     // pending unread handoff this tick, so the trailing `retain` can reap
-    // `last_escalated` entries whose repo@branch handoff is no longer active
-    // (read/resolved). Without it the map grows one entry per timed-out
+    // `last_escalated` / `last_renudged` entries whose repo@branch handoff is no
+    // longer active (read/resolved). Without it the maps grow one entry per
     // (reviewer, branch) forever — a slow leak, since `.get`/`.insert` were the
-    // only ops and REALERT_AFTER_MINS suppresses but never evicts.
+    // only ops and the dedup windows suppress but never evict.
     let mut active: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
     for target in fleet.instances.keys() {
         for (correlation, sent_at) in crate::inbox::unread_of_kind(home, target, HANDOFF_KIND) {
             let age_min = now.signed_duration_since(sent_at).num_minutes();
-            if age_min < HANDOFF_TIMEOUT_MINS {
-                continue;
-            }
             let corr = correlation.unwrap_or_else(|| "<unknown>".to_string());
             let key = (target.clone(), corr.clone());
             active.insert(key.clone());
+
+            // (1) #1859 Fix A: daemon-side RE-NUDGE of the target itself. The
+            // poller's actionable `[ci-ready-for-action]` wake can be deferred
+            // (mid-token guard) into the `notification_queue`, whose only flush is
+            // the TUI loop — so a busy target's wake strands with no daemon-side
+            // redelivery (Scenario A). Re-fire it here, but ONLY when the target
+            // is idle (busy → skip; THIS watchdog tick is the retry loop, so no
+            // mid-token corruption and no queueing), and at most once per
+            // `RENUDGE_INTERVAL_MINS` (anti-storm). Stops automatically once the
+            // target reads the handoff (drops from the unread scan → reaped). This
+            // also covers the orchestrator-as-`next_after_ci` case below, where
+            // there is no lead to escalate to.
+            if age_min >= RENUDGE_AFTER_MINS && !crate::snapshot::agent_is_busy(home, target) {
+                let due = last_renudged.get(&key).is_none_or(|prev| {
+                    now.signed_duration_since(*prev).num_minutes() >= RENUDGE_INTERVAL_MINS
+                });
+                if due {
+                    let (unread, _) = crate::inbox::unread_count(home, target);
+                    renudge(target, unread);
+                    last_renudged.insert(key.clone(), *now);
+                }
+            }
+
+            // (2) Escalation to the target's lead (detection only; unchanged).
+            if age_min < HANDOFF_TIMEOUT_MINS {
+                continue;
+            }
             if let Some(prev) = last_escalated.get(&key) {
                 if now.signed_duration_since(*prev).num_minutes() < REALERT_AFTER_MINS {
                     continue;
@@ -64,6 +123,10 @@ pub(crate) fn scan_and_emit(
             let recipient = crate::fleet::team_orchestrator_for(home, target)
                 .unwrap_or_else(|| FALLBACK_RECIPIENT.to_string());
             if recipient == *target {
+                // #1859: `next_after_ci` IS the team orchestrator — there is no
+                // higher authority to escalate to. This is no longer a silent
+                // total-skip (the Scenario A bug): the re-nudge above already
+                // redelivers the handoff to the orchestrator itself.
                 continue;
             }
             let text = format!(
@@ -95,9 +158,10 @@ pub(crate) fn scan_and_emit(
         }
     }
     // Reap dedup entries for handoffs that are no longer pending (read/resolved
-    // → absent from this tick's unread scan), bounding the map to the set of
+    // → absent from this tick's unread scan), bounding the maps to the set of
     // currently-active handoffs.
     last_escalated.retain(|k, _| active.contains(k));
+    last_renudged.retain(|k, _| active.contains(k));
 }
 
 #[cfg(test)]
@@ -145,13 +209,46 @@ mod tests {
         crate::inbox::enqueue(home, target, msg).unwrap();
     }
 
+    /// Seed the per-tick snapshot so `agent_is_busy(home, agent)` is
+    /// controllable (`thinking`/`tool_use` = busy; anything else = idle).
+    fn seed_snapshot(home: &Path, agent: &str, state: &str) {
+        crate::snapshot::save(
+            home,
+            &[crate::snapshot::AgentSnapshot {
+                name: agent.to_string(),
+                backend_command: String::new(),
+                args: vec![],
+                working_dir: None,
+                submit_key: String::new(),
+                health_state: String::new(),
+                agent_state: state.to_string(),
+                silent_secs: 0,
+            }],
+        );
+    }
+
+    /// Real watchdog entry with the re-nudge emitter CAPTURED (so the daemon API
+    /// loopback isn't needed). Returns the targets that were re-nudged this scan.
+    fn run_watchdog(
+        home: &Path,
+        now: &chrono::DateTime<chrono::Utc>,
+        last_escalated: &mut HashMap<(String, String), chrono::DateTime<chrono::Utc>>,
+        last_renudged: &mut HashMap<(String, String), chrono::DateTime<chrono::Utc>>,
+    ) -> Vec<String> {
+        let mut nudged = Vec::new();
+        scan_and_emit_with(home, now, last_escalated, last_renudged, |t, _| {
+            nudged.push(t.to_string())
+        });
+        nudged
+    }
+
     #[test]
     fn escalates_unread_handoff_past_timeout() {
         let home = tmp_home("escalate");
         write_fleet(&home);
         seed_handoff(&home, "reviewer", "o/r@feat", 15, false);
         let mut last = HashMap::new();
-        scan_and_emit(&home, &chrono::Utc::now(), &mut last);
+        run_watchdog(&home, &chrono::Utc::now(), &mut last, &mut HashMap::new());
         let msgs = crate::inbox::drain(&home, "lead");
         assert!(
             msgs.iter()
@@ -170,7 +267,12 @@ mod tests {
         let home = tmp_home("fresh");
         write_fleet(&home);
         seed_handoff(&home, "reviewer", "o/r@feat", 3, false);
-        scan_and_emit(&home, &chrono::Utc::now(), &mut HashMap::new());
+        run_watchdog(
+            &home,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
         assert!(
             crate::inbox::drain(&home, "lead").is_empty(),
             "a fresh handoff must not escalate"
@@ -179,7 +281,12 @@ mod tests {
         let home2 = tmp_home("read");
         write_fleet(&home2);
         seed_handoff(&home2, "reviewer", "o/r@feat", 30, true);
-        scan_and_emit(&home2, &chrono::Utc::now(), &mut HashMap::new());
+        run_watchdog(
+            &home2,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
         assert!(
             crate::inbox::drain(&home2, "lead").is_empty(),
             "a read handoff means the reviewer acted — no escalation"
@@ -195,7 +302,7 @@ mod tests {
         seed_handoff(&home, "reviewer", "o/r@feat", 15, false);
         let now = chrono::Utc::now();
         let mut last = HashMap::new();
-        scan_and_emit(&home, &now, &mut last);
+        run_watchdog(&home, &now, &mut last, &mut HashMap::new());
         assert_eq!(
             crate::inbox::drain(&home, "lead").len(),
             1,
@@ -203,7 +310,12 @@ mod tests {
         );
         // Re-seed (drain cleared inbox) and scan again soon — dedup suppresses.
         seed_handoff(&home, "reviewer", "o/r@feat", 15, false);
-        scan_and_emit(&home, &(now + chrono::Duration::minutes(5)), &mut last);
+        run_watchdog(
+            &home,
+            &(now + chrono::Duration::minutes(5)),
+            &mut last,
+            &mut HashMap::new(),
+        );
         assert!(
             crate::inbox::drain(&home, "lead").is_empty(),
             "re-escalation within the dedup window must be suppressed"
@@ -219,7 +331,7 @@ mod tests {
         seed_handoff(&home, "reviewer", "o/r@gone", 15, false);
         let now = chrono::Utc::now();
         let mut last = HashMap::new();
-        scan_and_emit(&home, &now, &mut last);
+        run_watchdog(&home, &now, &mut last, &mut HashMap::new());
         assert!(
             last.contains_key(&("reviewer".to_string(), "o/r@gone".to_string())),
             "first scan must record a dedup entry for the escalated handoff"
@@ -228,11 +340,131 @@ mod tests {
         // next scan must reap the now-stale (reviewer, o/r@gone) entry rather
         // than accumulating one per dead branch forever (the leak).
         crate::inbox::drain(&home, "reviewer");
-        scan_and_emit(&home, &(now + chrono::Duration::minutes(1)), &mut last);
+        run_watchdog(
+            &home,
+            &(now + chrono::Duration::minutes(1)),
+            &mut last,
+            &mut HashMap::new(),
+        );
         assert!(
             last.is_empty(),
             "a dedup entry whose handoff is no longer pending must be reaped, not leaked: {:?}",
             last.keys().collect::<Vec<_>>()
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1859 §3.9 (a): when `next_after_ci` IS the team orchestrator, the old
+    /// `recipient == target` branch silently skipped the WHOLE handoff (no
+    /// escalation AND no re-nudge) — the Scenario A hole. Now the orchestrator's
+    /// own unread handoff is RE-NUDGED (and correctly NOT self-escalated).
+    #[test]
+    fn orchestrator_as_next_after_ci_is_renudged_not_silently_skipped() {
+        let home = tmp_home("orch-renudge");
+        write_fleet(&home); // orchestrator = lead
+        seed_handoff(&home, "lead", "o/r@feat", 15, false);
+        seed_snapshot(&home, "lead", "idle");
+        let nudged = run_watchdog(
+            &home,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
+        assert!(
+            nudged.contains(&"lead".to_string()),
+            "orchestrator-as-next_after_ci must be re-nudged, not silently skipped: {nudged:?}"
+        );
+        // No self-escalation (no higher authority above the orchestrator).
+        assert!(
+            crate::inbox::drain(&home, "lead")
+                .iter()
+                .all(|m| !m.text.contains("handoff_timeout_watchdog")),
+            "orchestrator must not be escalated about its own handoff"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1859 §3.9 (b): a BUSY (mid-token) target is NOT re-nudged (the watchdog
+    /// tick is the retry loop — no PTY corruption, no queueing); the same target,
+    /// once idle, gets a daemon-side re-nudge WITHOUT relying on the TUI flush.
+    #[test]
+    fn busy_target_skipped_idle_target_renudged() {
+        let home = tmp_home("busy-idle");
+        write_fleet(&home);
+        seed_handoff(&home, "reviewer", "o/r@feat", 15, false);
+
+        seed_snapshot(&home, "reviewer", "tool_use"); // busy → skip
+        let nudged = run_watchdog(
+            &home,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
+        assert!(
+            !nudged.contains(&"reviewer".to_string()),
+            "a busy (tool_use) target must not be re-nudged mid-token: {nudged:?}"
+        );
+
+        seed_snapshot(&home, "reviewer", "idle"); // idle → deliver
+        let nudged = run_watchdog(
+            &home,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
+        assert!(
+            nudged.contains(&"reviewer".to_string()),
+            "an idle target with an unread handoff must be re-nudged daemon-side: {nudged:?}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1859 anti-storm: within `RENUDGE_INTERVAL_MINS` a second scan must NOT
+    /// re-nudge again (idempotent via `last_renudged`); once the target reads the
+    /// handoff it stops AND the dedup entry is reaped (no leak).
+    #[test]
+    fn renudge_is_interval_gated_and_stops_when_read() {
+        let home = tmp_home("renudge-interval");
+        write_fleet(&home);
+        seed_handoff(&home, "reviewer", "o/r@feat", 15, false);
+        seed_snapshot(&home, "reviewer", "idle");
+        let now = chrono::Utc::now();
+        let mut renudged = HashMap::new();
+
+        let first = run_watchdog(&home, &now, &mut HashMap::new(), &mut renudged);
+        assert!(
+            first.contains(&"reviewer".to_string()),
+            "first re-nudge must fire"
+        );
+
+        // Within the interval → suppressed.
+        let soon = run_watchdog(
+            &home,
+            &(now + chrono::Duration::minutes(1)),
+            &mut HashMap::new(),
+            &mut renudged,
+        );
+        assert!(
+            !soon.contains(&"reviewer".to_string()),
+            "a re-nudge within RENUDGE_INTERVAL_MINS must be suppressed (anti-storm): {soon:?}"
+        );
+
+        // Reviewer reads it → no more re-nudge, and the dedup entry is reaped.
+        crate::inbox::drain(&home, "reviewer");
+        let after_read = run_watchdog(
+            &home,
+            &(now + chrono::Duration::minutes(10)),
+            &mut HashMap::new(),
+            &mut renudged,
+        );
+        assert!(
+            !after_read.contains(&"reviewer".to_string()),
+            "a read handoff must not be re-nudged"
+        );
+        assert!(
+            renudged.is_empty(),
+            "last_renudged must be reaped once the handoff is read: {:?}",
+            renudged.keys().collect::<Vec<_>>()
         );
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -82,6 +82,17 @@ pub(crate) fn scan_and_emit_with<F>(
     // (reviewer, branch) forever — a slow leak, since `.get`/`.insert` were the
     // only ops and the dedup windows suppress but never evict.
     let mut active: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    // #1859 reviewer-2: collapse same-scan re-nudge fan-out to TARGET granularity.
+    // The re-nudge pointer is target-level (handoff-agnostic — it just wakes the
+    // agent to drain its inbox), so a target holding K≥2 simultaneously-unread
+    // handoffs needs ONE inject, not K. Without this the per-`(target,corr)`
+    // interval gate fires once per handoff in a single scan, and since the
+    // busy-gate reads a per-tick snapshot (constant within the scan) injects #2..K
+    // lose busy protection — a storm exactly on the headline beneficiary (a
+    // multi-branch orchestrator-as-next_after_ci). The per-key `last_renudged`
+    // still governs the cross-tick interval.
+    let mut renudged_this_scan: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
     for target in fleet.instances.keys() {
         for (correlation, sent_at) in crate::inbox::unread_of_kind(home, target, HANDOFF_KIND) {
             let age_min = now.signed_duration_since(sent_at).num_minutes();
@@ -105,9 +116,15 @@ pub(crate) fn scan_and_emit_with<F>(
                     now.signed_duration_since(*prev).num_minutes() >= RENUDGE_INTERVAL_MINS
                 });
                 if due {
-                    let (unread, _) = crate::inbox::unread_count(home, target);
-                    renudge(target, unread);
+                    // Stamp EVERY due key (per-key cross-tick interval honesty —
+                    // so a collapsed key isn't treated as never-nudged next scan,
+                    // which would let the target re-fire inside the interval).
                     last_renudged.insert(key.clone(), *now);
+                    // ...but inject at most ONCE per target per scan.
+                    if renudged_this_scan.insert(target.clone()) {
+                        let (unread, _) = crate::inbox::unread_count(home, target);
+                        renudge(target, unread);
+                    }
                 }
             }
 
@@ -465,6 +482,32 @@ mod tests {
             renudged.is_empty(),
             "last_renudged must be reaped once the handoff is read: {:?}",
             renudged.keys().collect::<Vec<_>>()
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1859 reviewer-2 (lens 5): a target holding K≥2 simultaneously-unread
+    /// ci-ready handoffs (distinct corr) must get AT MOST ONE re-nudge per scan
+    /// — the wake pointer is target-level. Pre-fix the per-`(target,corr)` gate
+    /// fired once per handoff (K injects; #2..K bypassed the per-tick busy
+    /// snapshot). This is the storm-on-the-orchestrator case.
+    #[test]
+    fn multiple_unread_handoffs_collapse_to_one_renudge_per_scan() {
+        let home = tmp_home("multi-handoff");
+        write_fleet(&home);
+        seed_handoff(&home, "reviewer", "o/r@feat-a", 15, false);
+        seed_handoff(&home, "reviewer", "o/r@feat-b", 15, false);
+        seed_snapshot(&home, "reviewer", "idle");
+        let nudged = run_watchdog(
+            &home,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
+        let count = nudged.iter().filter(|t| t.as_str() == "reviewer").count();
+        assert_eq!(
+            count, 1,
+            "2 unread handoffs for one idle target must collapse to a single re-nudge: {nudged:?}"
         );
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -590,10 +590,11 @@ pub(crate) fn build_default_handlers(
         // #1491(A): inbox-stuck watchdog — every 30 ticks (~5min). Detects an
         // agent receiving but not draining its inbox; notifies lead (no auto-restart).
         Box::new(per_tick::InboxStuckHandler::new(30)),
-        // #1491(B): next_after_ci handoff-timeout watchdog — every 30 ticks
-        // (~5min). Escalates an unread [ci-ready-for-action] handoff to the
-        // reviewer's lead when it sits unclaimed past the timeout.
-        Box::new(per_tick::HandoffTimeoutHandler::new(30)),
+        // #1491(B): next_after_ci handoff-timeout watchdog. #1859 lowered the
+        // cadence to ~2min (12 ticks) so the daemon-side RE-NUDGE of the target
+        // (Fix A) is timely; the lead ESCALATION stays gated by its own 10min age
+        // + 30min re-alert windows, so the faster scan doesn't escalate sooner.
+        Box::new(per_tick::HandoffTimeoutHandler::new(12)),
         Box::new(per_tick::LogRotationHandler::new(360)),
         Box::new(per_tick::ThreadDumpHandler::new()),
         Box::new(per_tick::GcTickHandler::new(360)),

--- a/src/daemon/per_tick/handoff_timeout.rs
+++ b/src/daemon/per_tick/handoff_timeout.rs
@@ -13,6 +13,9 @@ pub(crate) struct HandoffTimeoutHandler {
     every_n_ticks: u64,
     counter: AtomicU64,
     last_escalated: Mutex<HashMap<(String, String), chrono::DateTime<chrono::Utc>>>,
+    /// #1859: re-nudge dedup, owned alongside `last_escalated` so the interval
+    /// gate survives across ticks.
+    last_renudged: Mutex<HashMap<(String, String), chrono::DateTime<chrono::Utc>>>,
     /// ≈ daemon boot — drives boot-grace suppression (see [`super::in_boot_grace`]).
     created_at: Instant,
 }
@@ -23,6 +26,7 @@ impl HandoffTimeoutHandler {
             every_n_ticks,
             counter: AtomicU64::new(0),
             last_escalated: Mutex::new(HashMap::new()),
+            last_renudged: Mutex::new(HashMap::new()),
             created_at: Instant::now(),
         }
     }
@@ -33,6 +37,7 @@ impl HandoffTimeoutHandler {
             every_n_ticks,
             counter: AtomicU64::new(0),
             last_escalated: Mutex::new(HashMap::new()),
+            last_renudged: Mutex::new(HashMap::new()),
             created_at,
         }
     }
@@ -62,7 +67,13 @@ impl PerTickHandler for HandoffTimeoutHandler {
         }
         let now = chrono::Utc::now();
         let mut last = self.last_escalated.lock();
-        crate::daemon::handoff_timeout_watchdog::scan_and_emit(ctx.home, &now, &mut last);
+        let mut last_renudged = self.last_renudged.lock();
+        crate::daemon::handoff_timeout_watchdog::scan_and_emit(
+            ctx.home,
+            &now,
+            &mut last,
+            &mut last_renudged,
+        );
     }
 }
 

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -501,6 +501,33 @@ pub fn enqueue_with_idle_hint(home: &Path, target: &str, msg: InboxMessage) -> a
     })
 }
 
+/// #1859 Fix A: daemon-side re-nudge of a target that has an UNREAD actionable
+/// handoff still sitting in its inbox. The actionable `[ci-ready-for-action]`
+/// wake from the poller is deferrable (`should_defer_inject`'s mid-token guard)
+/// into the `notification_queue`, whose ONLY flush is the TUI loop
+/// (`app/mod.rs::flush_idle_notifications`) — so when the operator TUI isn't
+/// draining the target's pane, a deferred wake strands (inbox has it, no active
+/// nudge: #1859 Scenario A). This re-fires an actionable PTY pointer directly,
+/// BYPASSING the queue, so the redelivery doesn't depend on the TUI.
+///
+/// It is a pure WAKE pointer (`id="renudge"`), NOT a new inbox row — so it can
+/// never self-amplify into another unread handoff. The CALLER (the handoff
+/// watchdog) gates this on the target being idle AND on a re-nudge interval, so
+/// it never injects mid-token and never storms; `inject_with_submit` is the same
+/// submit-aware PTY path the normal idle-hint uses.
+pub(crate) fn renudge_actionable_unread(
+    home: &Path,
+    target: &str,
+    kind: &str,
+    unread_count: usize,
+) {
+    let now_field = operator_now_field();
+    let pointer = build_pending_pointer("renudge", kind, "system:ci", unread_count, &now_field);
+    if let Err(e) = inject_with_submit(home, target, &pointer) {
+        tracing::debug!(%target, error = %e, "renudge_actionable_unread: inject failed");
+    }
+}
+
 /// #1335: convenience wrapper for the common daemon notification pattern:
 /// `InboxMessage::new_system` + optional `delivery_mode` / `correlation_id` /
 /// `task_id` + `enqueue_with_idle_hint`. Covers ~15 watchdog-class call sites.


### PR DESCRIPTION
Addresses #1859 Scenario A only (Scenario B deferred — see below). refs #1859

## Root cause (from the spike — refutes the issue's own hypothesis)

A dispatch with `next_after_ci=<lead>` auto-arms a ci-watch; on CI pass the poller enqueues `[ci-ready-for-action]` to the target via `enqueue_with_idle_hint` — **the identical path subscribers use** (so cheerc's "next_after_ci not in subscribers → no push" is wrong). The durable inbox write always lands; the **active wake** goes through `should_defer_inject`, which defers actionable wakes whenever the target is mid-token (`thinking`/`tool_use`) into the `notification_queue`. That queue's **only** flush is the TUI loop (`app/mod.rs::flush_idle_notifications`) — there is **no daemon-side redelivery** — so a busy orchestrator's wake strands: inbox has it, no active nudge.

The handoff-timeout watchdog (#1491B) was the safety net, but it escalates to `team_orchestrator_for(target)` and `continue`s when `recipient == target` — silently skipping the whole handoff exactly when `next_after_ci` IS the orchestrator (Scenario A's `dev-team-lead`). Net: no recovery.

## Fix A (analysis-approved by lead)

- **Daemon-side re-nudge of the target** in `handoff_timeout_watchdog`, before the lead escalation: handoff unread > `RENUDGE_AFTER_MINS` (2) **and** target idle (`snapshot::agent_is_busy` false) → re-fire an actionable PTY pointer (`inbox::notify::renudge_actionable_unread`), bypassing the queue/TUI-flush dependency.
- **Busy target → skipped** (the ~2min watchdog tick is the retry loop): no mid-token PTY corruption, no queueing.
- **Anti-storm**: idempotent `last_renudged` interval map (`RENUDGE_INTERVAL_MINS=2`); stops the instant the target reads the handoff (drops from the unread scan → both dedup maps reaped). Pure WAKE pointer (`id="renudge"`), **not** a new inbox row → can't self-amplify.
- **`recipient == target` hole fixed**: no longer a silent total-skip — the re-nudge already redelivers to the orchestrator itself (correctly no self-escalation).
- **`should_defer_inject` untouched** (the mid-token guard is legitimate).
- Handler cadence 30→12 ticks (~2min) so re-nudge is timely; escalation stays gated by its own 10min/30min windows.

## Tests (§3.9 — real watchdog entry via `scan_and_emit_with` + captured emitter seam, not a synthetic inject)

- `orchestrator_as_next_after_ci_is_renudged_not_silently_skipped`
- `busy_target_skipped_idle_target_renudged`
- `renudge_is_interval_gated_and_stops_when_read` (anti-storm + reap)
- existing escalation tests retained (7), all green.

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓
- `handoff_timeout` 10/10 · `per_tick::handoff` 3/3
- `cargo test --tests --features tray` → green except the unrelated `dispatch_branch_skips_metadata_stub_..._1834` (false-fails only under the local fleet `git` shim; passes with real `/usr/bin/git`; CI uses real git).

⚠️ Daemon-side behaviour — effect (stranded ci-ready handoffs recover) is visible after operator restart.

Scenario B (rerun dedup, attempt-blind) is deferred to a follow-up per lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)