### PR TITLE
fix(#1858 Fix A): kill auto-worktree is_git_repo side-channel + share the gate

### DIFF
--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -336,23 +336,14 @@ pub(super) fn create_pane_from_resolved(
 
     let mut working_dir = resolved.working_directory.clone();
 
-    // #888: Auto-create git worktree when working_directory is inside a repo
-    // AND the instance has an explicit `source_repo` or `git_branch`
-    // config (mirror logic in bootstrap/agent_resolve.rs).
-    let wants_worktree = resolved.worktree != Some(false)
-        && (resolved.source_repo.is_some() || resolved.git_branch.is_some());
-
-    if wants_worktree {
-        if let Some(ref base_dir) = working_dir {
-            if crate::worktree::is_git_repo(base_dir) {
-                let custom_branch = resolved.git_branch.as_deref();
-                if let Some(info) =
-                    crate::worktree::create(home, base_dir, fleet_name, custom_branch)
-                {
-                    working_dir = Some(info.path);
-                }
-            }
-        }
+    // #1858: auto-worktree decision is the single shared gate in
+    // `crate::worktree::resolve_auto_worktree` — same fn the boot path
+    // (`bootstrap::agent_resolve::resolve_one`) calls, so live-spawn and boot
+    // can't drift. Opts in on `source_repo` / `git_branch` (#888) but only for
+    // an explicit real-repo `working_directory`, never the daemon-managed
+    // `workspace/<name>` default (which `ensure_project_root` git-inits).
+    if let Some(wt_path) = crate::worktree::resolve_auto_worktree(home, fleet_name, resolved) {
+        working_dir = Some(wt_path);
     }
 
     let mut args = resolved.args.clone();

--- a/src/bootstrap/agent_resolve.rs
+++ b/src/bootstrap/agent_resolve.rs
@@ -46,47 +46,6 @@ pub(super) fn resolve(config: &FleetConfig, fleet_dir: &Path, home: &Path) -> Ve
         .collect()
 }
 
-/// #888: pure predicate deciding whether `resolve_one` should
-/// auto-create a worktree for this instance.
-///
-/// Three inputs:
-/// - `worktree: false` is a hard veto regardless of other flags
-///   (Sprint 28 opt-out semantic preserved).
-/// - **`source_repo` OR `git_branch` is the affirmative signal**
-///   (#888). Either one declares the instance as a source-repo-bound
-///   dev / reviewer / task-dispatch worker that legitimately wants a
-///   per-agent worktree.
-/// - Anything else (orchestrator / admin / quickstart-default
-///   instances) → NO auto-worktree. The `workspace/<name>/` dir
-///   stays the project-root, `claude --continue` finds prior
-///   session state across app restarts, Gemini/Codex hierarchical
-///   AGENTS.md scoping still works via
-///   `instructions::ensure_project_root`'s git-init.
-///
-/// Pre-#888 the gate was just "`worktree != Some(false)` AND
-/// working_dir is a git repo". That interacted with
-/// `ensure_project_root` (`src/instructions.rs:63`), which runs
-/// tail-side of `resolve_one`, in a way that triggered the
-/// CONTEXT-LOST bug on every SECOND launch:
-///
-/// 1. First launch: `workspace/<name>/` just created → no `.git`
-///    → no worktree → `ensure_project_root` then runs → leaves
-///    `workspace/<name>/.git` on disk.
-/// 2. Second launch: `workspace/<name>/.git` is present →
-///    `is_git_repo` returns true → `worktree::create` redirects
-///    `working_directory` to `worktrees/<name>/...` → `claude
-///    --continue` finds no prior session at the new path →
-///    operator's conversation history vanishes.
-///
-/// Pure helper so the unit tests can pin the contract directly
-/// without spinning up a real fixture for every variant.
-fn wants_auto_worktree(resolved: &crate::fleet::ResolvedInstance) -> bool {
-    if resolved.worktree == Some(false) {
-        return false;
-    }
-    resolved.source_repo.is_some() || resolved.git_branch.is_some()
-}
-
 /// Resolve a single named instance into a spawn-ready [`AgentDef`].
 ///
 /// Returns `None` if the instance is missing from `config` or cannot be
@@ -100,22 +59,14 @@ fn resolve_one(config: &FleetConfig, ctx: &ResolveContext<'_>, name: &str) -> Op
         std::fs::create_dir_all(base_dir).ok();
     }
 
-    // Auto-create git worktree when working_directory is inside a repo
-    // AND the instance has an explicit `source_repo` or `git_branch`
-    // config (`#888` — see `wants_auto_worktree` for the full rationale).
-    // Redirects `resolved.working_directory` to the worktree path for the
-    // rest of the pipeline. Skipped when `worktree: false` (Sprint 28)
-    // OR when neither `source_repo` nor `git_branch` is set (#888).
-    if wants_auto_worktree(&resolved) {
-        if let Some(ref base_dir) = resolved.working_directory {
-            if crate::worktree::is_git_repo(base_dir) {
-                let custom_branch = resolved.git_branch.as_deref();
-                if let Some(info) = crate::worktree::create(ctx.home, base_dir, name, custom_branch)
-                {
-                    resolved.working_directory = Some(info.path);
-                }
-            }
-        }
+    // Auto-create git worktree when the instance opts in (`source_repo` /
+    // `git_branch`) AND `working_directory` is an explicit real repo — see
+    // `crate::worktree::resolve_auto_worktree`, the single shared gate (#1858)
+    // that both this boot path and `app::pane_factory` (live spawn) call so the
+    // decision can't drift between them. Redirects `resolved.working_directory`
+    // to the worktree path for the rest of the pipeline.
+    if let Some(wt_path) = crate::worktree::resolve_auto_worktree(ctx.home, name, &resolved) {
+        resolved.working_directory = Some(wt_path);
     } else if resolved.worktree == Some(false) {
         if let Some(ref base_dir) = resolved.working_directory {
             // worktree: false — auto-prune existing worktree if present.
@@ -414,6 +365,77 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    /// §3.9 (a) (#1858): a `source_repo` agent whose `working_directory` is the
+    /// daemon-managed default `workspace/<name>` must NOT drift into a worktree —
+    /// not on launch 1, and crucially not on launch 2 after the dir has become a
+    /// git repo (which `ensure_project_root` does tail-side). Pre-#1858 launch 2
+    /// saw `is_git_repo`=true + the `source_repo` signal and redirected into a
+    /// worktree of the empty workspace. Drives the real boot entry `resolve_one`
+    /// twice. Regression-proof: revert the workspace-default skip and the
+    /// launch-2 assert fails (wd lands under `worktrees/`).
+    #[test]
+    fn resolve_one_source_repo_in_default_workspace_no_drift_1858() {
+        let dir = tmp_dir("1858-a-nodrift");
+        // A real source_repo so the #888 opt-in signal points at something valid.
+        let src = dir.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        init_git_repo(&src);
+        // working_directory = the daemon-managed default `workspace/<name>`.
+        let work_dir = crate::paths::workspace_dir(&dir).join("dev");
+        std::fs::create_dir_all(&work_dir).unwrap();
+
+        let yaml = format!(
+            "defaults:\n  backend: claude\ninstances:\n  dev:\n    command: /bin/true\n    working_directory: {}\n    source_repo: {}\n",
+            work_dir.display(),
+            src.display(),
+        );
+        let config: FleetConfig = serde_yaml_ng::from_str(&yaml).unwrap();
+        let peers: Vec<(String, Option<String>)> = config
+            .instances
+            .iter()
+            .map(|(n, c)| (n.clone(), c.role.clone()))
+            .collect();
+
+        // LAUNCH 1: workspace dir is not yet a git repo → plain (true pre & post).
+        let ctx = ResolveContext {
+            fleet_dir: &dir,
+            home: &dir,
+            peers: peers.clone(),
+        };
+        let wd1 = resolve_one(&config, &ctx, "dev").unwrap().4.unwrap();
+        assert_eq!(
+            wd1, work_dir,
+            "launch-1 must stay in the plain workspace dir"
+        );
+
+        // Simulate ensure_project_root's tail-side git-init (the #1858 trigger):
+        // make the workspace dir a git repo before the second launch.
+        init_git_repo(&work_dir);
+        assert!(
+            work_dir.join(".git").exists(),
+            "fixture: workspace dir is now a git repo (the launch-2 state)"
+        );
+
+        // LAUNCH 2 (restart / reboot): MUST still be plain — no worktree drift.
+        let ctx2 = ResolveContext {
+            fleet_dir: &dir,
+            home: &dir,
+            peers,
+        };
+        let wd2 = resolve_one(&config, &ctx2, "dev").unwrap().4.unwrap();
+        assert_eq!(
+            wd2, work_dir,
+            "#1858: launch-2 must NOT drift the default workspace dir into a worktree"
+        );
+        assert!(
+            !wd2.to_string_lossy().contains("worktrees"),
+            "#1858: no worktree redirect on restart, got {}",
+            wd2.display()
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     /// Pure unit test on the `wants_auto_worktree` predicate.
     /// Covers all four input shapes without filesystem fixtures.
     #[test]
@@ -443,24 +465,32 @@ mod tests {
             }
         };
         // worktree: false → ALWAYS false regardless of other flags.
-        assert!(!wants_auto_worktree(&mk(
+        assert!(!crate::worktree::wants_auto_worktree(&mk(
             Some(false),
             Some(PathBuf::from("/x")),
             Some("main".into())
         )));
         // No source_repo, no git_branch → false (the #888 fix).
-        assert!(!wants_auto_worktree(&mk(None, None, None)));
-        assert!(!wants_auto_worktree(&mk(Some(true), None, None)));
+        assert!(!crate::worktree::wants_auto_worktree(&mk(None, None, None)));
+        assert!(!crate::worktree::wants_auto_worktree(&mk(
+            Some(true),
+            None,
+            None
+        )));
         // source_repo set → true.
-        assert!(wants_auto_worktree(&mk(
+        assert!(crate::worktree::wants_auto_worktree(&mk(
             None,
             Some(PathBuf::from("/x")),
             None
         )));
         // git_branch set → true.
-        assert!(wants_auto_worktree(&mk(None, None, Some("main".into()))));
+        assert!(crate::worktree::wants_auto_worktree(&mk(
+            None,
+            None,
+            Some("main".into())
+        )));
         // Both set → true.
-        assert!(wants_auto_worktree(&mk(
+        assert!(crate::worktree::wants_auto_worktree(&mk(
             None,
             Some(PathBuf::from("/x")),
             Some("main".into())

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -289,6 +289,62 @@ pub fn create(
     }
 }
 
+/// #888 affirmative-signal predicate: does this instance opt into a per-agent
+/// worktree? `worktree: false` is a hard veto; otherwise `source_repo` OR
+/// `git_branch` is the opt-in. Pure (no filesystem) so the truth table can be
+/// pinned directly. The base-dir / is_git_repo decision lives in
+/// [`resolve_auto_worktree`] (the full gate).
+pub fn wants_auto_worktree(resolved: &crate::fleet::ResolvedInstance) -> bool {
+    if resolved.worktree == Some(false) {
+        return false;
+    }
+    resolved.source_repo.is_some() || resolved.git_branch.is_some()
+}
+
+/// #1858: single source of truth for the per-agent auto-worktree decision,
+/// shared by the boot/reload path (`bootstrap::agent_resolve::resolve_one`) and
+/// the live-spawn path (`app::pane_factory`). Returns the redirected
+/// working directory (a freshly-created worktree path) when the instance wants
+/// one, or `None` to keep `resolved.working_directory` as-is.
+///
+/// The gate is the PERSISTED intent only:
+/// - [`wants_auto_worktree`] (the `worktree:false` veto + `source_repo` /
+///   `git_branch` opt-in signal).
+/// - the base dir must be a real git repo **that the operator/deploy explicitly
+///   pointed `working_directory` at** — the daemon-managed default
+///   `workspace_dir(home)/<name>` is NEVER auto-worktree'd.
+///
+/// That last clause kills the #1858 drift: `instructions::ensure_project_root`
+/// `git init`s the workspace dir tail-side of this decision, which used to flip
+/// the old `is_git_repo(base_dir)` gate between launch 1 (plain) and launch 2
+/// (worktree) — silently redirecting the dir into a worktree of the *empty,
+/// git-init'd workspace* (not the real `source_repo`) on every restart/reboot.
+/// Pinning the gate to "explicit non-default working_directory" makes the
+/// decision launch-idempotent: an agent that started plain stays plain, and an
+/// agent the operator pointed at a real repo (or a branch-mode deploy whose
+/// `working_directory` is already a repo) still gets its worktree.
+pub fn resolve_auto_worktree(
+    home: &Path,
+    name: &str,
+    resolved: &crate::fleet::ResolvedInstance,
+) -> Option<PathBuf> {
+    if !wants_auto_worktree(resolved) {
+        return None;
+    }
+    let base_dir = resolved.working_directory.as_ref()?;
+    // #1858: the daemon-managed default workspace dir is never a legitimate
+    // worktree source — it only becomes a "repo" via ensure_project_root's
+    // git-init. Skip it regardless of is_git_repo so the decision can't drift
+    // across launches.
+    if *base_dir == crate::paths::workspace_dir(home).join(name) {
+        return None;
+    }
+    if !is_git_repo(base_dir) {
+        return None;
+    }
+    create(home, base_dir, name, resolved.git_branch.as_deref()).map(|info| info.path)
+}
+
 /// Run `git worktree prune` on a repo to clean stale worktree entries.
 pub fn prune(repo_dir: &Path) {
     if !is_git_repo(repo_dir) {
@@ -770,5 +826,75 @@ mod tests {
 
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();
+    }
+
+    fn mk_resolved(
+        working_directory: PathBuf,
+        source_repo: Option<PathBuf>,
+        git_branch: Option<String>,
+        worktree: Option<bool>,
+    ) -> crate::fleet::ResolvedInstance {
+        crate::fleet::ResolvedInstance {
+            name: "agent".into(),
+            backend_command: "claude".into(),
+            args: vec![],
+            env: std::collections::HashMap::new(),
+            working_directory: Some(working_directory),
+            ready_pattern: None,
+            submit_key: "\r".into(),
+            role: None,
+            cols: None,
+            rows: None,
+            topic_id: None,
+            git_branch,
+            model: None,
+            worktree,
+            instructions: None,
+            source_repo,
+            repo: None,
+        }
+    }
+
+    /// §3.9 (b)+(c) (#1858): the shared auto-worktree gate must (b) still create
+    /// a worktree for an EXPLICIT real-repo `working_directory` + `source_repo`
+    /// (no over-kill of legitimate opt-in), and (c) SKIP the daemon-managed
+    /// default `workspace/<name>` dir even when it has been git-init'd and
+    /// `source_repo` is set (the deploy non-branch shape — `deployments.rs`
+    /// writes exactly `source_repo` + a `workspace/<name>` working_directory).
+    #[test]
+    fn resolve_auto_worktree_skips_workspace_default_allows_explicit_repo_1858() {
+        // (b) explicit real repo as working_directory → worktree still created.
+        let home_b = tmp_repo("1858-b-home");
+        let repo = tmp_repo("1858-b-repo");
+        let resolved_b = mk_resolved(repo.clone(), Some(repo.clone()), None, None);
+        let got_b = resolve_auto_worktree(&home_b, "agent", &resolved_b);
+        assert!(
+            got_b
+                .as_ref()
+                .is_some_and(|p| p.to_string_lossy().contains("worktrees")),
+            "#1858 (b): explicit real-repo working_directory must still auto-worktree, got {got_b:?}"
+        );
+
+        // (c) deploy non-branch shape: source_repo set + working_directory is the
+        // default workspace dir (even git-init'd) → NO worktree.
+        let home_c = tmp_repo("1858-c-home");
+        let work_dir = crate::paths::workspace_dir(&home_c).join("team-dev");
+        std::fs::create_dir_all(&work_dir).unwrap();
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args(["init", "-b", "main"])
+            .current_dir(&work_dir)
+            .output()
+            .ok();
+        assert!(is_git_repo(&work_dir), "fixture: workspace dir git-init'd");
+        let resolved_c = mk_resolved(work_dir.clone(), Some(home_c.join("realrepo")), None, None);
+        assert!(
+            resolve_auto_worktree(&home_c, "team-dev", &resolved_c).is_none(),
+            "#1858 (c): deploy non-branch (source_repo + default workspace dir) must not auto-worktree"
+        );
+
+        for d in [home_b, repo, home_c] {
+            std::fs::remove_dir_all(&d).ok();
+        }
     }
 }


### PR DESCRIPTION
Spike #1858 → lead approved **Fix A** (the (A) lever). Fix B (complete-entry) queued separately.

## Bug

A `source_repo`/`git_branch` agent whose `working_directory` is the daemon-managed default `workspace/<name>` ran **plain on launch 1** but **drifted into a git worktree on launch 2** (restart_instance / replace_instance / daemon reboot). Both the boot path (`agent_resolve::resolve_one`) and the live-spawn path (`app::pane_factory`) **duplicated** the predicate and gated `worktree::create` on the **transient `is_git_repo(working_directory)`**. `instructions::ensure_project_root` git-inits that workspace dir tail-side of the decision, so the gate flipped between launches — redirecting the dir into a worktree of the **empty git-init'd workspace** (not the real `source_repo`, which is only ever read as a boolean signal). Prime victim: deploy non-branch (`deployments.rs` writes `source_repo` + a `workspace/<name>` working_directory).

## Fix A

- **One shared gate** `crate::worktree::resolve_auto_worktree(home, name, resolved)` — the only place the decision lives now. Both `resolve_one` and `pane_factory` call it → no duplicated predicate that can drift.
- **Persisted-intent only**: `worktree:false` veto + `source_repo`/`git_branch` opt-in (#888), AND the base dir must be an explicit real repo. The default `workspace_dir(home)/<name>` is **never** auto-worktree'd, regardless of `is_git_repo`. → ensure_project_root's git-init can no longer flip the decision; launch-1 and launch-2 are identical.
- **Opt-in preserved**: an explicit real-repo `working_directory`, a branch-mode deploy (dir already a repo), or `git_branch` still worktrees.
- `wants_auto_worktree` (pure #888 signal predicate) moved alongside in `worktree.rs`; truth-table test re-points to it.

## §3.9 (real entry point, representative)

- **(a)** `resolve_one_source_repo_in_default_workspace_no_drift_1858` — real boot entry, **twice**: source_repo agent in the default workspace dir stays plain on launch 1 **and** launch 2 (after the dir is git-init'd, the #1858 trigger). Regression-proof — revert the workspace-default skip and the launch-2 assert lands under `worktrees/`.
- **(b)+(c)** `resolve_auto_worktree_skips_workspace_default_allows_explicit_repo_1858` — (b) explicit real-repo working_directory + source_repo **still** worktrees (no over-kill); (c) deploy non-branch shape (source_repo + git-init'd default workspace dir) does **not**. Existing `resolve_one_creates_worktree_when_source_repo_set` stays green.

## Reviewer focus (cross-cutting spawn/restart behavior)

- Did Fix A **over-kill** a legitimate opt-in worktree? (explicit-repo / branch-mode / git_branch must still worktree — see (b) + existing test.)
- Are the **two** call sites (`agent_resolve.rs`, `pane_factory.rs`) truly routed through the **one** shared fn (no residual duplicated gate)?

Local CI-parity preflight green (`fmt`/`clippy --all-targets --features tray -D warnings`/`cargo test --tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)