### PR TITLE
create_instance: persist args + model so restart re-resolves == spawn (#1858)

### DIFF
--- a/src/mcp/handlers/instance_964_tests.rs
+++ b/src/mcp/handlers/instance_964_tests.rs
@@ -288,3 +288,64 @@ fn t6_topic_binding_invalid_value_treated_as_auto() {
     );
     let _ = std::fs::remove_dir_all(&home);
 }
+
+/// #1858: create_instance must PERSIST `args` + `model` into the fleet entry so a
+/// daemon RESTART (re-resolve from disk) reproduces the SAME backend argv as the
+/// original spawn — not a "bare" instance missing the user args and the --model
+/// flag. `instructions` is regenerated from role+peers at boot, so it is not the
+/// lost field; `args`/`model` were left None pre-fix.
+#[test]
+fn create_instance_persists_args_and_model_for_restart_parity_1858() {
+    let home = tmp_home("1858");
+    // Capture the spawn-time argv the backend received (the SPAWN RPC params).
+    let captured = std::cell::RefCell::new(String::new());
+    let spawn_fn = |_h: &Path, req: &Value| -> anyhow::Result<Value> {
+        *captured.borrow_mut() = req["params"]["args"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        Ok(json!({"ok": true, "result": {}}))
+    };
+    let _ = spawn_single_instance_impl(
+        &home,
+        "spawner",
+        &json!({"name": "dev-x", "backend": "claude", "args": "--foo bar", "model": "opus"}),
+        &spawn_fn,
+    );
+
+    // The persisted entry (what a restart re-resolves) must carry args + model.
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    let cfg = fleet
+        .instances
+        .get("dev-x")
+        .expect("instance persisted to fleet.yaml");
+    assert_eq!(
+        cfg.args,
+        vec!["--foo".to_string(), "bar".to_string()],
+        "#1858: user args must persist (was None → bare argv on restart)"
+    );
+    assert_eq!(
+        cfg.model.as_deref(),
+        Some("opus"),
+        "#1858: model must persist (was None → no --model flag on restart)"
+    );
+
+    // Restart parity: boot reconstructs argv = entry.args + a --model flag derived
+    // from entry.model; it must EQUAL the spawn-time argv (not be "less than").
+    let model_token = crate::backend::Backend::from_command("claude")
+        .map(|b| b.format_model_arg("opus"))
+        .unwrap_or_else(|| "opus".to_string());
+    let mut boot_argv = cfg.args.clone();
+    boot_argv.push("--model".to_string());
+    boot_argv.push(model_token);
+    let spawn_argv: Vec<String> = captured
+        .borrow()
+        .split_whitespace()
+        .map(String::from)
+        .collect();
+    assert_eq!(
+        boot_argv, spawn_argv,
+        "#1858: restart re-resolve must reproduce the spawn argv (not bare)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/instance_spawn.rs
+++ b/src/mcp/handlers/instance_spawn.rs
@@ -137,6 +137,27 @@ pub(super) fn spawn_single_instance_impl(
     );
     let target_pane = target_pane_owned.as_deref();
 
+    // #1858: persist the spawn-intent `args` + `model` into the entry so a daemon
+    // RESTART re-resolves the SAME backend invocation as the original spawn. At
+    // boot, `agent_resolve::resolve_one` reads `entry.args` (None → empty argv) and
+    // appends `--model` only from `entry.model` (None → no model flag) — so a
+    // sparse entry boots the instance "less than" spawn (missing the user args and
+    // the model flag → bare / stuck Starting). `instructions` is NOT lost (it is
+    // regenerated from role+peers at boot, agent_resolve.rs); `command` is covered
+    // by `backend`; `ready_pattern` is built-in — so ONLY these two need backfill.
+    // Split matches `handle_spawn`'s `params["args"].split_whitespace()` so boot's
+    // `entry.args` reproduces the create-path SPAWN argv (minus the model flag,
+    // which boot re-derives from `entry.model` — same as create's cmd_args build).
+    let entry_args: Option<Vec<String>> = args
+        .get("args")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.split_whitespace().map(String::from).collect());
+    let entry_model: Option<String> = args
+        .get("model")
+        .and_then(|v| v.as_str())
+        .filter(|m| !m.is_empty())
+        .map(String::from);
     // #964: ADD fleet.yaml entry BEFORE the SPAWN RPC so the instance
     // exists when SPAWN runs. Pre-fix SPAWN-then-add ordering caused
     // silent failures.
@@ -160,8 +181,8 @@ pub(super) fn spawn_single_instance_impl(
         // remote OR fork-vs-upstream disambiguation.
         repo: None,
         github_login: None,
-        args: None,
-        model: None,
+        args: entry_args,
+        model: entry_model,
         env: env_for_entry,
         ready_pattern: None,
         command: None,


### PR DESCRIPTION
Closes #1858.

## Bug

`create_instance` (`spawn_single_instance`) writes a **sparse** fleet.yaml entry — backend/working_directory/role/env are set, but `args: None` and `model: None`. At spawn it passes a combined `cmd_args` (`"{user_args} --model X"`) through the SPAWN RPC, but **never persists those back to the entry**. On daemon restart, `agent_resolve::resolve_one` re-resolves from the entry: `args` comes from `entry.args` (None → empty argv) and a `--model` flag is appended only from `entry.model` (None → none). The instance boots "less than" the original spawn — missing the user args **and** the model flag (bare / stuck Starting; observed on dev-3, backend-dependent).

## Verified (not assumed) which field breaks restart

Per the lead's "verify first" instruction — the breaker is **NOT `instructions`**: that is regenerated from role+peers at boot (`agent_resolve.rs`), and `role` *is* persisted. `command` is covered by `backend`; `ready_pattern` is built-in. The only lost fields are **`args` and `model`** (evidence: create builds `cmd_args` at `instance_spawn.rs` and passes it via SPAWN; boot reads `resolved.args`/`resolved.model` from the entry which are None).

## Fix (KISS)

Backfill `args` + `model` into the entry at create time, split with `split_whitespace` to match `handle_spawn`'s own `params["args"]` parse — so boot's `entry.args + [--model, fmt(entry.model)]` reproduces the create-path SPAWN argv exactly (an idempotent entry = a faithful snapshot of spawn intent). The team-add path (`team.rs`) takes no per-member args/model → nothing to backfill (genuinely None).

## Test (§3.9)

`create_instance_persists_args_and_model_for_restart_parity_1858` — spawn with `args` + `model` (mock spawn_fn captures the spawn-time argv), then the re-resolved fleet entry carries both, and the **reconstructed boot argv EQUALS the captured spawn-time argv** (not bare).

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓
- `cargo test --tests --features tray` → green except the unrelated `dispatch_branch_skips_metadata_stub_..._1834` (false-fails only under the local fleet `git` shim; passes with real `/usr/bin/git`; CI uses real git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)