### PR TITLE
task-board: validate done/update transitions under the append lock (#1868)

### DIFF
--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -1007,6 +1007,74 @@ pub fn append_batch(
     Ok(seqs)
 }
 
+/// Batch variant of [`append_checked`] (#1868): append ALL `events` atomically
+/// iff `precondition` — evaluated under the append lock against a FRESH on-disk
+/// replay — returns `Ok`. Closes the same TOCTOU as [`append_checked`] for the
+/// multi-event `update` arm (a status transition plus priority/desc/tags/owner
+/// events emitted as one batch). On precondition failure NO event is written and
+/// the reason is returned as `Ok(Err(reason))`; the outer `Err` is reserved for
+/// IO / replay failures.
+pub fn append_batch_checked<F>(
+    home: &Path,
+    instance: &InstanceName,
+    events: Vec<TaskEvent>,
+    precondition: F,
+) -> anyhow::Result<Result<Vec<u64>, String>>
+where
+    F: FnOnce(&TaskBoardState) -> Result<(), String>,
+{
+    if events.is_empty() {
+        return Ok(Ok(Vec::new()));
+    }
+    let instance = instance.clone();
+    let count = events.len();
+    let mut seqs: Vec<u64> = Vec::with_capacity(count);
+    let now = chrono::Utc::now().to_rfc3339();
+    let emitter_id = match crate::agent::resolve_instance(home, instance.as_str()) {
+        Ok((id, _)) => Some(id.full()),
+        Err(e) => {
+            tracing::debug!(instance = %instance, error = %e, "emitter ID resolution failed");
+            None
+        }
+    };
+
+    let mut rejection: Option<String> = None;
+    crate::event_log::append_lines_under_lock(home, LOG_NAME, |log_path| {
+        // FRESH replay under the lock — authoritative committed history.
+        let state = replay_uncached(home)?;
+        if let Err(reason) = precondition(&state) {
+            rejection = Some(reason);
+            return Ok(Vec::new()); // empty ⇒ no write
+        }
+        let start_seq = max_seq_for_instance(log_path, &instance)? + 1;
+        let mut lines = Vec::with_capacity(count);
+        for (i, event) in events.into_iter().enumerate() {
+            let seq = start_seq + i as u64;
+            seqs.push(seq);
+            let envelope = TaskEventEnvelope {
+                schema_version: SCHEMA_VERSION,
+                seq,
+                timestamp: now.clone(),
+                instance: instance.clone(),
+                emitter_id: emitter_id.clone(),
+                event,
+            };
+            lines.push(serde_json::to_string(&envelope)?);
+        }
+        Ok(lines)
+    })?;
+
+    if let Some(reason) = rejection {
+        return Ok(Err(reason));
+    }
+    invalidate_replay_cache();
+    if let Some(&last_seq) = seqs.last() {
+        let log_path = home.join(format!("{LOG_NAME}.jsonl"));
+        SEQ_CACHE.lock().insert((log_path, instance), last_seq);
+    }
+    Ok(Ok(seqs))
+}
+
 /// Append `event` atomically iff `precondition` — evaluated under the append
 /// lock against a FRESH on-disk replay — returns `Ok`. This closes the TOCTOU
 /// where a caller validates task state, then appends after a concurrent writer

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -362,8 +362,32 @@ fn handle_done(
                 result: result_text,
             }),
     };
-    match crate::task_events::append(home, &emitter, event) {
-        Ok(_) => {
+    // #1868: re-validate the →Done transition UNDER the append lock against FRESH
+    // committed state. The `can_transition_to` check above is a fast-reject; a
+    // concurrent writer (daemon `sweep_overdue_claimed` / `auto_close`, or a peer
+    // update) could have moved the task between that read and this append, and
+    // replay's `apply_done` does NOT re-guard transitions — so this precondition
+    // is the authoritative gate (mirrors `handle_claim`'s `append_checked`).
+    let done_id = id.clone();
+    match crate::task_events::append_checked(home, &emitter, event, |state| {
+        let tv = state
+            .tasks
+            .values()
+            .map(record_to_task)
+            .find(|t| t.id == done_id)
+            .ok_or_else(|| format!("task '{done_id}' not found"))?;
+        if !tv
+            .status
+            .can_transition_to(crate::task_events::TaskStatus::Done)
+        {
+            return Err(format!(
+                "illegal transition: {} → done (task {done_id})",
+                status_to_legacy_str(tv.status)
+            ));
+        }
+        Ok(())
+    }) {
+        Ok(Ok(_)) => {
             // #789: task-completion is a workflow boundary —
             // clean any empty `init` commits the backend has
             // accumulated in the agent's bound worktree since
@@ -412,6 +436,7 @@ fn handle_done(
                 "status": "done",
             })
         }
+        Ok(Err(reason)) => serde_json::json!({"error": reason, "code": "illegal_transition"}),
         Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
     }
 }
@@ -654,10 +679,43 @@ fn handle_update(
     // F1: single atomic append_batch over all the update arm's
     // queued events. Either all land or none do.
     if !pending_events.is_empty() {
-        if let Err(e) = crate::task_events::append_batch(home, &emitter, pending_events) {
-            return serde_json::json!({
-                "error": format!("event log append_batch failed: {e}")
+        // #1868: re-validate the status transition UNDER the append lock against
+        // FRESH committed state (mirrors `handle_claim`/`handle_done`). The
+        // out-of-lock `can_transition_to` check above is a fast-reject; a
+        // concurrent writer could have moved the task since, and replay does not
+        // re-guard transitions. Only a status change is gated — priority/desc/
+        // tags/owner events are last-write-wins metadata.
+        let upd_id = id.clone();
+        let target_status = new_status
+            .as_deref()
+            .and_then(crate::task_events::TaskStatus::from_str);
+        let checked =
+            crate::task_events::append_batch_checked(home, &emitter, pending_events, |state| {
+                if let Some(target) = target_status {
+                    let tv = state
+                        .tasks
+                        .values()
+                        .map(record_to_task)
+                        .find(|t| t.id == upd_id)
+                        .ok_or_else(|| format!("task '{upd_id}' not found"))?;
+                    if !tv.status.can_transition_to(target) {
+                        return Err(format!(
+                            "illegal transition: {} → {} (task {upd_id})",
+                            status_to_legacy_str(tv.status),
+                            status_to_legacy_str(target)
+                        ));
+                    }
+                }
+                Ok(())
             });
+        match checked {
+            Ok(Ok(_)) => {}
+            Ok(Err(reason)) => {
+                return serde_json::json!({"error": reason, "code": "illegal_transition"});
+            }
+            Err(e) => {
+                return serde_json::json!({"error": format!("event log append_batch failed: {e}")});
+            }
         }
         // #1018 (B): mirror the `done` arm's cleanup hook for
         // the `update` arm's done/cancelled transitions.
@@ -1512,6 +1570,155 @@ mod tests {
         assert_eq!(alerts.len(), 1, "gate-off must deliver via legacy path");
         assert_eq!(alerts[0].1.as_deref(), Some("parent_cancelled"));
         assert!(alerts[0].2.contains("t-parent-2") && alerts[0].2.contains("t-child-2"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1868 §3.9: the in-lock precondition `handle_done` now uses
+    /// (`append_checked`) REJECTS a `done` whose out-of-lock read was stale — a
+    /// concurrent sweep/auto_close moved the task to Cancelled. Pre-fix (plain
+    /// `append`) this Done was silently applied (replay's `apply_done` does not
+    /// re-guard transitions).
+    #[test]
+    fn append_checked_rejects_stale_done_after_concurrent_cancel_1868() {
+        let home = tmp_home("1868-done-stale");
+        create_task(&home, "t1");
+        let emitter = crate::task_events::InstanceName::from("dev-agent");
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({"action": "claim", "id": "t1"}),
+        );
+        // Concurrent sweep/auto_close cancels it → committed state is Cancelled.
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({"action": "update", "id": "t1", "status": "cancelled"}),
+        );
+
+        // A `done` prepared as-if the caller had still seen Claimed: the in-lock
+        // precondition re-reads the FRESH committed state (Cancelled) and rejects
+        // (Cancelled→Done is illegal).
+        let done = crate::task_events::TaskEvent::Done {
+            task_id: crate::task_events::TaskId("t1".into()),
+            by: crate::task_events::InstanceName::from("dev-agent"),
+            source: crate::task_events::DoneSource::OperatorManual {
+                authored_at: "2026-06-09T00:00:00+00:00".into(),
+                result: None,
+            },
+        };
+        let r = crate::task_events::append_checked(&home, &emitter, done, |state| {
+            let tv = state
+                .tasks
+                .values()
+                .map(record_to_task)
+                .find(|t| t.id == "t1")
+                .ok_or_else(|| "not found".to_string())?;
+            if !tv
+                .status
+                .can_transition_to(crate::task_events::TaskStatus::Done)
+            {
+                return Err("illegal".to_string());
+            }
+            Ok(())
+        });
+        assert!(
+            matches!(r, Ok(Err(_))),
+            "#1868: in-lock guard must REJECT a stale done on a Cancelled task: {r:?}"
+        );
+        assert_eq!(
+            read_task_record(&home, "t1").expect("task exists").status,
+            crate::task_events::TaskStatus::Cancelled,
+            "no Done event must land → task stays Cancelled"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1868 §3.9: same in-lock guard for the multi-event `update` arm via
+    /// `append_batch_checked`.
+    #[test]
+    fn append_batch_checked_rejects_stale_update_after_concurrent_cancel_1868() {
+        let home = tmp_home("1868-update-stale");
+        create_task(&home, "t1");
+        let emitter = crate::task_events::InstanceName::from("dev-agent");
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({"action": "claim", "id": "t1"}),
+        );
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({"action": "update", "id": "t1", "status": "cancelled"}),
+        );
+        let ev = crate::task_events::TaskEvent::InProgress {
+            task_id: crate::task_events::TaskId("t1".into()),
+            by: crate::task_events::InstanceName::from("dev-agent"),
+        };
+        let r = crate::task_events::append_batch_checked(&home, &emitter, vec![ev], |state| {
+            let tv = state
+                .tasks
+                .values()
+                .map(record_to_task)
+                .find(|t| t.id == "t1")
+                .ok_or_else(|| "not found".to_string())?;
+            if !tv
+                .status
+                .can_transition_to(crate::task_events::TaskStatus::InProgress)
+            {
+                return Err("illegal".to_string());
+            }
+            Ok(())
+        });
+        assert!(
+            matches!(r, Ok(Err(_))),
+            "#1868: in-lock batch guard must REJECT a stale update on a Cancelled task: {r:?}"
+        );
+        assert_eq!(
+            read_task_record(&home, "t1").expect("task exists").status,
+            crate::task_events::TaskStatus::Cancelled
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1868 §3.9: the normal (uncontended) sequence still succeeds end-to-end
+    /// through the real handlers — no regression from the append→append_checked
+    /// swap.
+    #[test]
+    fn normal_done_and_update_still_succeed_1868() {
+        let home = tmp_home("1868-happy");
+        create_task(&home, "t-done");
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({"action": "claim", "id": "t-done"}),
+        );
+        let d = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({"action": "done", "id": "t-done"}),
+        );
+        assert!(d["error"].is_null(), "legal done must succeed: {d}");
+        assert_eq!(
+            read_task_record(&home, "t-done").expect("exists").status,
+            crate::task_events::TaskStatus::Done
+        );
+
+        create_task(&home, "t-upd");
+        handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({"action": "claim", "id": "t-upd"}),
+        );
+        let u = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({"action": "update", "id": "t-upd", "status": "in_progress"}),
+        );
+        assert!(u["error"].is_null(), "legal update must succeed: {u}");
+        assert_eq!(
+            read_task_record(&home, "t-upd").expect("exists").status,
+            crate::task_events::TaskStatus::InProgress
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
Closes #1868 (found in the dispatch/task-board bug-hunt).

## Bug

`handle_done` (plain `append`) and `handle_update` (`append_batch`) check `can_transition_to` **outside** the event-log lock, then append — while `handle_claim` was hardened to `append_checked` (fresh replay + precondition **under** the lock). Replay's `apply_done`/`apply_status` blindly set `t.status` with **no** transition guard. So a concurrent writer (daemon `sweep_overdue_claimed` / `auto_close`, or a peer mutation) that moves the task between the out-of-lock read and the append lets an **illegal transition** (e.g. `Cancelled→Done`) commit silently → wrong board state that misleads orchestration. (The claim path was fixed for exactly this TOCTOU; done/update were the un-hardened siblings.)

## Fix — close the TOCTOU symmetrically with claim

- Add `task_events::append_batch_checked` — the batch analog of `append_checked`: a precondition evaluated under the append lock against a **fresh replay**; on failure no event is written and the reason returns as `Ok(Err)`.
- `handle_done` → `append_checked`; `handle_update` → `append_batch_checked`, each re-validating `can_transition_to` against the committed state **inside** the lock. The out-of-lock checks remain as fast-rejects; the in-lock precondition is the authoritative gate.

**Deliberately skipped** the optional replay-guard layer (`apply_*` + `can_transition`): it would change the folded state of **existing** logs that already contain a pre-fix illegal transition on restart — a risky behavior change on historical data. The `append_checked` layer prevents *new* illegal transitions, which is the fix the lead approved.

## Tests (§3.9)

- `append_checked_rejects_stale_done_after_concurrent_cancel_1868` — a `done` prepared as-if-Claimed is rejected once the committed state moved to Cancelled; the task stays Cancelled (no Done event lands).
- `append_batch_checked_rejects_stale_update_after_concurrent_cancel_1868` — same for the multi-event update arm.
- `normal_done_and_update_still_succeed_1868` — the uncontended claim→done / claim→update sequence still succeeds end-to-end through the real handlers (no regression).

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓
- `tasks::` 105/105 · `task_events::` 32/32
- `cargo test --tests --features tray` → green except the unrelated `dispatch_branch_skips_metadata_stub_..._1834` (false-fails only under the local fleet `git` shim; passes with real `/usr/bin/git`; CI uses real git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)