### PR TITLE
task-board: guard daemon auto-close →Done writes under the lock (#1873)

### DIFF
--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -359,12 +359,18 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
                     },
                 },
             ];
-            task_events::append_batch(home, &emitter, events)?;
-            tracing::info!(
-                pr = pr.number,
-                marker = %marker,
-                "sweep: auto-closed (Linked + Done emitted)"
-            );
+            // #1873: re-validate →Done UNDER the lock. `open_ids` was snapshotted
+            // at sweep start; a marker task cancelled since must NOT be flipped to
+            // Done (the whole Linked+Done batch is skipped — a cancelled task drops
+            // out of `open_ids` next cycle, so no re-attempt).
+            let closed = task_events::append_done_if_legal(home, &emitter, &marker, events)?;
+            if closed {
+                tracing::info!(
+                    pr = pr.number,
+                    marker = %marker,
+                    "sweep: auto-closed (Linked + Done emitted)"
+                );
+            }
         }
     }
 

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -1145,6 +1145,45 @@ where
     Ok(Ok(0))
 }
 
+/// #1873: append a DAEMON-originated →Done write (auto-close / sweep) iff the task
+/// can still legally transition to Done UNDER the append lock against fresh
+/// committed state. #1868 hardened the user `done`/`update` handlers, but daemon
+/// auto-close paths still bare-appended — so a daemon racing a peer/operator
+/// `cancel` could flip a Cancelled (terminal) task to Done. `events` is the
+/// →Done batch (the `Done` event alone, or a preceding `Linked` + `Done`).
+/// Returns `Ok(true)` if written, `Ok(false)` if SKIPPED because the task can no
+/// longer transition to Done (logged at info — the operator already holds the
+/// canonical terminal signal; not an error).
+pub fn append_done_if_legal(
+    home: &Path,
+    instance: &InstanceName,
+    task_id: &str,
+    events: Vec<TaskEvent>,
+) -> anyhow::Result<bool> {
+    let tid = TaskId(task_id.to_string());
+    let label = task_id.to_string();
+    let outcome = append_batch_checked(home, instance, events, move |state| {
+        match state.tasks.get(&tid).map(|r| r.status) {
+            Some(status) if status.can_transition_to(TaskStatus::Done) => Ok(()),
+            Some(status) => Err(format!(
+                "task '{label}' is '{status}' — cannot transition to done"
+            )),
+            None => Err(format!("task '{label}' not found")),
+        }
+    })?;
+    match outcome {
+        Ok(_) => Ok(true),
+        Err(reason) => {
+            tracing::info!(
+                target: "task_board",
+                reason = %reason,
+                "#1873: daemon →Done write skipped — task no longer transitionable to done"
+            );
+            Ok(false)
+        }
+    }
+}
+
 /// Tail-scan the hot log for the highest seq# this instance has emitted.
 /// Best-effort: malformed lines are skipped because [`replay`] is the
 /// strict reader; here we just need the high-water mark.

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -52,9 +52,14 @@ pub fn auto_close_on_report(
         },
     };
     let emitter = crate::task_events::InstanceName::from("system:auto-close");
-    crate::task_events::append(home, &emitter, event)?;
-    let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, correlation_id);
-    Ok(true)
+    // #1873: re-validate →Done UNDER the lock — a concurrent cancel between the
+    // out-of-lock status check above and this append must not be flipped to Done.
+    let closed =
+        crate::task_events::append_done_if_legal(home, &emitter, correlation_id, vec![event])?;
+    if closed {
+        let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, correlation_id);
+    }
+    Ok(closed)
 }
 
 #[cfg(test)]
@@ -318,6 +323,62 @@ mod tests {
         assert!(
             !closed,
             "already-cancelled task should return false (idempotent)"
+        );
+    }
+
+    /// #1873 §3.9: `append_done_if_legal` — the in-lock guard BOTH daemon →Done
+    /// paths (auto_close + sweep) now use — REJECTS a →Done on a task that moved
+    /// to a terminal state (a concurrent cancel landing after the out-of-lock
+    /// check), leaving it Cancelled; a legal Claimed task still auto-closes. The
+    /// full auto_close path's happy + already-cancelled cases are covered above.
+    #[test]
+    fn append_done_if_legal_rejects_cancelled_keeps_legal_1873() {
+        let home = tmp_home("1873-guard");
+        let emitter = InstanceName::from("system:auto-close");
+        let mk_done = |id: &str| TaskEvent::Done {
+            task_id: TaskId(id.into()),
+            by: InstanceName::from("dev"),
+            source: crate::task_events::DoneSource::ReportAutoClose {
+                report_summary: "x".into(),
+                closed_at: "2026-06-09T00:00:00+00:00".into(),
+            },
+        };
+
+        // Concurrently-cancelled task → the →Done is SKIPPED, stays Cancelled.
+        seed_cancelled_task(&home, "t-cancel");
+        let closed = crate::task_events::append_done_if_legal(
+            &home,
+            &emitter,
+            "t-cancel",
+            vec![mk_done("t-cancel")],
+        )
+        .unwrap();
+        assert!(
+            !closed,
+            "#1873: a daemon →Done on a Cancelled task must be SKIPPED"
+        );
+        assert_eq!(
+            task_status(&home, "t-cancel"),
+            Some(crate::task_events::TaskStatus::Cancelled),
+            "task must stay Cancelled (not flipped to Done)"
+        );
+
+        // Legal Claimed task → still auto-closes.
+        seed_claimed_task(&home, "t-ok", "dev");
+        let closed_ok = crate::task_events::append_done_if_legal(
+            &home,
+            &emitter,
+            "t-ok",
+            vec![mk_done("t-ok")],
+        )
+        .unwrap();
+        assert!(
+            closed_ok,
+            "#1873: a legal Claimed task must still auto-close"
+        );
+        assert_eq!(
+            task_status(&home, "t-ok"),
+            Some(crate::task_events::TaskStatus::Done)
         );
     }
 }


### PR DESCRIPTION
Refs #1873 (reviewer-2 lens-3 follow-up to #1868).

## Bug

#1868 hardened the user `done`/`update` handlers with `append_checked`, but the **daemon auto-close** paths still bare-appended their →Done writes — so protection was one-directional. A daemon auto-close racing a peer/operator `cancel` (its out-of-lock status check passed, then a Cancel committed before the append) silently flipped a **Cancelled (terminal)** task to Done; replay's `apply_done` does not re-guard transitions.

## Verified scope (not assumed)

Of the candidate sites, **only TWO are production daemon →Done writers**:
- `tasks/auto_close.rs` — `auto_close_on_report` (single `Done`)
- `daemon/task_sweep.rs` — sweep (`Linked` + `Done` batch)

The other listed sites — `cron_tick.rs:849`, `auto_release.rs:1327`, `idle_watchdog.rs:1659`, `dispatch_idle/mod.rs:2113`, `tasks/mod.rs:379` — are all inside `#[cfg(test)]` blocks (test-seed appends), **not** production paths. (Classified each by comparing its line to the file's `#[cfg(test)]` start.) So the real fix is the 2 production sites.

## Fix

Add `task_events::append_done_if_legal(home, instance, task_id, events)` — routes the →Done batch through `append_batch_checked` with a precondition that re-validates `can_transition_to(Done)` against **fresh committed state under the append lock**. On a terminal/incompatible state it writes nothing and returns `Ok(false)` (logged at info — the operator already holds the canonical terminal signal). Both production sites call it:
- `auto_close_on_report` gates its `cleanup_pending_for_task_id` on the result;
- the sweep gates its "auto-closed" log (a cancelled marker drops out of `open_ids` next cycle → no re-attempt).

## Tests (§3.9)

- `append_done_if_legal_rejects_cancelled_keeps_legal_1873` — the shared guard (used by **both** sites) rejects a →Done on a Cancelled task (stays Cancelled, nothing written) and still auto-closes a legal Claimed task.
- Existing auto_close happy-path + already-cancelled-idempotent tests cover the end-to-end path (no regression).

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓
- `auto_close::` 8/8 · `task_sweep::` 29/29 · `task_events::` 32/32
- `cargo test --tests --features tray` → green except the unrelated `dispatch_branch_skips_metadata_stub_..._1834` (false-fails only under the local fleet `git` shim; passes with real `/usr/bin/git`; CI uses real git).

I left this as `Refs #1873` (not `Closes`) so the lead/reviewer-2 can confirm the "4 sites are test-only" finding before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)