### PR TITLE
fix(#1870 H2): clear hung anchor when a left-Hung agent has left the registry (TOCTOU)

### DIFF
--- a/src/daemon/escalation_persist.rs
+++ b/src/daemon/escalation_persist.rs
@@ -106,6 +106,30 @@ pub(crate) fn clear_failed_escalated(home: &Path, name: &str) {
     }
 }
 
+/// #1870-H2: clear ONLY the `hung_since` anchor for one agent in place,
+/// preserving the crash budget / cooldowns / `failed_escalated` latch. Used by
+/// the `left_hung` persist loop when an agent has a persisted record but has
+/// already left the registry (crashed / deleted between the existence check and
+/// the registry read): it has left Hung AND is gone, so its `hung_since` must
+/// NOT survive to rehydrate a stale anchor on the next restart (which would fire
+/// a false Hung P0 on the first post-restart tick). No-op when no store / no
+/// entry exists. Distinct from `persist` (which needs a live snapshot) precisely
+/// because here the agent is no longer in the registry.
+pub(crate) fn clear_hung_since(home: &Path, name: &str) {
+    let path = store_file(home);
+    if !path.exists() {
+        return;
+    }
+    if let Err(e) = store::mutate_versioned::<EscalationStore, _, _>(&path, |s| {
+        if let Some(entry) = s.agents.get_mut(name) {
+            entry.hung_since_epoch_ms = None;
+        }
+        Ok(())
+    }) {
+        tracing::warn!(agent = %name, error = %e, "escalation_persist: clear_hung_since failed");
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -200,6 +224,55 @@ mod tests {
         clear_failed_escalated(&home, "ghost");
         let empty = tmp_home("clear-empty");
         clear_failed_escalated(&empty, "anyone");
+        assert!(load_for(&empty, "anyone").is_none());
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&empty).ok();
+    }
+
+    /// §3.9 #1870-H2: `clear_hung_since` clears ONLY the `hung_since` anchor,
+    /// preserving the crash budget / cooldowns AND the `failed_escalated` latch —
+    /// it must not over-clear (the "don't wipe a still-Hung agent's other state"
+    /// guard). After the clear, a simulated restart (`load_for`) sees no anchor →
+    /// no false Hung re-escalation.
+    #[test]
+    fn clear_hung_since_clears_only_anchor_preserves_rest_1870_h2() {
+        let home = tmp_home("clear-hung");
+        persist(
+            &home,
+            "orch",
+            &PersistedEscalation {
+                total_crashes: 5,
+                crash_times_epoch_ms: vec![100],
+                last_crash_notification_epoch_ms: Some(200),
+                last_hung_notification_epoch_ms: Some(300),
+                hung_since_epoch_ms: Some(444),
+                failed_escalated: true,
+            },
+        );
+
+        clear_hung_since(&home, "orch");
+
+        let after = load_for(&home, "orch").expect("entry survives the clear");
+        assert!(
+            after.hung_since_epoch_ms.is_none(),
+            "#1870-H2: the stale hung anchor must be cleared (so a restart can't rehydrate it)"
+        );
+        assert!(
+            after.failed_escalated,
+            "#1870-H2: clearing the hung anchor must NOT touch the failed_escalated latch"
+        );
+        assert_eq!(after.total_crashes, 5, "crash budget must be preserved");
+        assert_eq!(
+            after.last_hung_notification_epoch_ms,
+            Some(300),
+            "the hung cooldown must be preserved"
+        );
+
+        // No-op on unknown agent / missing store (no panic, no file creation).
+        clear_hung_since(&home, "ghost");
+        let empty = tmp_home("clear-hung-empty");
+        clear_hung_since(&empty, "anyone");
         assert!(load_for(&empty, "anyone").is_none());
 
         std::fs::remove_dir_all(&home).ok();

--- a/src/daemon/per_tick/hang_detection.rs
+++ b/src/daemon/per_tick/hang_detection.rs
@@ -159,24 +159,50 @@ impl PerTickHandler for HangDetectionHandler {
         // Hung doesn't spawn a store entry. The snapshot's `hung_since` is now
         // None; its crash budget / cooldowns (which DO matter) are preserved.
         for name in left_hung {
-            // #1744-M7: mirror the fire loop — `Yes`|`Unknown` proceed (clearing a
-            // stale anchor on an indeterminate read is harmless and correct).
-            if crate::teams::self_orch_status(ctx.home, &name) == crate::teams::SelfOrchStatus::No {
-                continue;
-            }
-            if crate::daemon::escalation_persist::load_for(ctx.home, &name).is_none() {
-                continue;
-            }
-            let snapshot = {
-                let reg = agent::lock_registry(ctx.registry);
-                reg.values()
-                    .find(|h| h.name.as_str() == name)
-                    .map(|h| h.core.lock().health.escalation_snapshot())
-            };
-            if let Some(snapshot) = snapshot {
-                crate::daemon::escalation_persist::persist(ctx.home, &name, &snapshot);
-                tracing::debug!(agent = %name, "#1744-H2: persisted cleared hung anchor on Hung exit");
-            }
+            persist_or_clear_left_hung_anchor(ctx, &name);
+        }
+    }
+}
+
+/// #1744-H2 + #1870-H2: persist a left-Hung self-orchestrator's cleared anchor,
+/// or clear it in place if the agent has already left the registry. Extracted
+/// from the `left_hung` loop so the absent-agent (TOCTOU) branch is testable
+/// through a real entry.
+///
+/// - `self_orch_status == No` → peer-relayable, not our concern → skip.
+/// - no persisted store entry → never tracked while Hung → skip (don't spawn one).
+/// - agent in registry → persist its escalation snapshot (`hung_since` is now
+///   `None`; crash budget / cooldowns preserved). (#1744-H2)
+/// - agent ABSENT from the registry (unregistered between the `load_for` check
+///   and this read — the #1870-H2 TOCTOU) → no snapshot to persist, so clear
+///   `hung_since` in place; pre-fix this skipped and LEFT a stale anchor that a
+///   restart rehydrated into a false Hung P0.
+fn persist_or_clear_left_hung_anchor(ctx: &TickContext<'_>, name: &str) {
+    // #1744-M7: `Yes`|`Unknown` proceed (clearing on an indeterminate read is
+    // harmless + correct); only a determinate `No` skips.
+    if crate::teams::self_orch_status(ctx.home, name) == crate::teams::SelfOrchStatus::No {
+        return;
+    }
+    if crate::daemon::escalation_persist::load_for(ctx.home, name).is_none() {
+        return;
+    }
+    let snapshot = {
+        let reg = agent::lock_registry(ctx.registry);
+        reg.values()
+            .find(|h| h.name.as_str() == name)
+            .map(|h| h.core.lock().health.escalation_snapshot())
+    };
+    match snapshot {
+        Some(snapshot) => {
+            crate::daemon::escalation_persist::persist(ctx.home, name, &snapshot);
+            tracing::debug!(agent = %name, "#1744-H2: persisted cleared hung anchor on Hung exit");
+        }
+        None => {
+            crate::daemon::escalation_persist::clear_hung_since(ctx.home, name);
+            tracing::debug!(
+                agent = %name,
+                "#1870-H2: cleared hung anchor for agent absent from registry on Hung exit"
+            );
         }
     }
 }
@@ -260,5 +286,68 @@ mod tests {
     #[test]
     fn name_matches_module() {
         assert_eq!(HangDetectionHandler::new().name(), "hang_detection");
+    }
+
+    /// §3.9 #1870-H2 (real branch): a self-orch with a persisted hung record that
+    /// has LEFT the registry (the TOCTOU end-state — unregistered between the
+    /// `load_for` check and the registry read) gets its `hung_since` cleared in
+    /// place, NOT skipped. Pre-fix this skipped → a restart rehydrated the stale
+    /// anchor → false Hung P0. No teams file → `self_orch_status` = Unknown →
+    /// proceeds (#1744-M7).
+    #[test]
+    fn left_hung_anchor_cleared_when_agent_absent_from_registry_1870_h2() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-h2-absent-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).ok();
+        // Make orch-1 a self-orchestrator (orchestrator of its own team) so the
+        // #1744-M7 gate proceeds (a non-self-orch is peer-relayable → skipped).
+        crate::teams::create(
+            &home,
+            &serde_json::json!({"name": "t", "members": ["orch-1"], "orchestrator": "orch-1"}),
+        );
+        // Persisted hung record (the agent was tracked while Hung).
+        crate::daemon::escalation_persist::persist(
+            &home,
+            "orch-1",
+            &crate::health::PersistedEscalation {
+                hung_since_epoch_ms: Some(1000),
+                ..Default::default()
+            },
+        );
+        assert!(
+            crate::daemon::escalation_persist::load_for(&home, "orch-1")
+                .unwrap()
+                .hung_since_epoch_ms
+                .is_some(),
+            "precondition: a stale anchor is persisted"
+        );
+
+        // Empty registry = the agent is absent (it unregistered).
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        persist_or_clear_left_hung_anchor(&ctx, "orch-1");
+
+        assert!(
+            crate::daemon::escalation_persist::load_for(&home, "orch-1")
+                .unwrap()
+                .hung_since_epoch_ms
+                .is_none(),
+            "#1870-H2: an absent agent's stale hung anchor must be CLEARED, not left for restart rehydrate"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
Bug-hunt finding **H2** (filed under #1870), lead-approved after the review queue cleared.

## Bug (`src/daemon/per_tick/hang_detection.rs`, #1744-H2 `left_hung` loop)
The loop persists a self-orchestrator's CLEARED `hung_since` on Hung-exit so a restart doesn't rehydrate a stale anchor. But it did: `load_for` (entry exists) → registry lookup → persist **only if** the lookup found a live handle. If the agent **unregistered** (crash / DELETE on another thread) between the phase-1 registry lock and the phase-3 re-lock — the TOCTOU window — the lookup missed, `snapshot == None`, and the loop **skipped**. The stale `hung_since` stayed on disk → a restart rehydrated it → a **false Hung P0** on the first post-restart tick (the exact thing #1744-H2 exists to prevent).

## Fix
When the agent has a persisted record but is **absent** from the registry, clear `hung_since` **in place** (new `escalation_persist::clear_hung_since`, mirroring `clear_failed_escalated`) instead of skipping — it left Hung AND is gone, so its anchor must not survive to rehydrate. The clear is **surgical**: touches ONLY `hung_since`, preserving the crash budget / cooldowns / `failed_escalated` latch (no over-clear of a still-relevant record).

The per-name loop body is extracted into `persist_or_clear_left_hung_anchor` so the absent-agent branch is testable through a real entry. (A synchronous test can't reproduce the concurrent-unregister TOCTOU itself, but the helper drives the exact `None` branch with an empty registry.)

## §3.9
- `clear_hung_since_clears_only_anchor_preserves_rest_1870_h2` — clears `hung_since` but preserves `failed_escalated` + crash budget + hung cooldown; no-op on missing store / unknown agent.
- `left_hung_anchor_cleared_when_agent_absent_from_registry_1870_h2` — a self-orch with a persisted hung record + empty registry → the real helper clears the anchor (simulated restart sees no stale anchor). Regression-proof — pre-fix the skip leaves `hung_since` Some.

Local CI-parity preflight green (`fmt`/`clippy --all-targets --features tray -D warnings`/`cargo test --tests`).

## Reviewer-2 focus
- **Over-clear?** Does the fix ever clear a record that should keep its anchor? (Gated on `left_hung` = already-left-Hung + a persisted entry + self-orch; `clear_hung_since` is field-surgical.)
- Is extracting the loop body behavior-preserving for the in-registry (Some) path?

🤖 Generated with [Claude Code](https://claude.com/claude-code)