### PR TITLE
fix(#1870 H3): single clamp helper for backward-clock-skew elapsed reads

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -139,7 +139,9 @@ pub(crate) fn check_stalled(
     // skip stall detection (can't compute elapsed without one).
     let last_alive = crate::daemon::task_progress::read_last_progress_at(home, &task.id)
         .or_else(|| task.started_at.as_deref().and_then(parse_rfc3339))?;
-    let elapsed_secs = now.signed_duration_since(last_alive).num_seconds();
+    // #1870-H3: clamp so a backward clock skew (future `last_alive`) can't make
+    // elapsed negative → stall detection silently stop firing.
+    let elapsed_secs = crate::daemon::utils::elapsed_since(now, last_alive).num_seconds();
     let stall_threshold = (eta_secs as f64 * STALL_MULTIPLIER) as i64;
     if elapsed_secs > stall_threshold {
         Some(format!(
@@ -323,6 +325,27 @@ mod tests {
         let result = check_stalled(&home, &task, now);
         assert!(result.is_some(), "must detect stall: {result:?}");
         assert!(result.unwrap().contains("elapsed="), "reason format");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// §3.9 #1870-H3: a `started_at` in the FUTURE relative to `now` (a backward
+    /// clock skew — NTP / VM resume) must NOT wedge stall detection — the clamped
+    /// elapsed reads 0 ("just started"), so the watchdog re-evaluates as the clock
+    /// advances rather than computing a negative age. (Forward-elapsed stall
+    /// detection is unchanged — see `check_stalled_returns_some_when_elapsed_exceeds_1_5x_eta`.)
+    #[test]
+    fn check_stalled_future_started_at_does_not_wedge_1870_h3() {
+        let home = tmp_home("stalled-future-ts");
+        let now = chrono::Utc::now();
+        // started_at 500s in the FUTURE (clock jumped backward), eta=60 → 90s
+        // threshold. Clamped elapsed = 0 < 90 → not stalled (no false alarm and
+        // no negative wedge).
+        let future = (now + chrono::Duration::seconds(500)).to_rfc3339();
+        let task = make_task("t-future", "in_progress", Some(60), Some(&future));
+        assert!(
+            check_stalled(&home, &task, now).is_none(),
+            "#1870-H3: a future started_at must not produce a false stall"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -167,7 +167,11 @@ pub fn check_schedules(home: &Path) {
     }
     if any_triggered
         || last_check_in_future
-        || now_utc.signed_duration_since(last_check_utc).num_seconds() >= 10
+        // #1870-H3: route the forward-elapsed read through the shared clamp so the
+        // whole #N2 class uses one helper. The dedicated `last_check_in_future`
+        // re-stamp above still owns the backward-skew case (clamp here is a no-op
+        // for it — future last_check → 0 < 10, same as the raw negative).
+        || crate::daemon::utils::elapsed_since(now_utc, last_check_utc).num_seconds() >= 10
     {
         let _ = crate::store::atomic_write(&last_check_path, now_utc.to_rfc3339().as_bytes());
     }

--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -95,7 +95,9 @@ pub(crate) fn scan_and_emit_with<F>(
         std::collections::HashSet::new();
     for target in fleet.instances.keys() {
         for (correlation, sent_at) in crate::inbox::unread_of_kind(home, target, HANDOFF_KIND) {
-            let age_min = now.signed_duration_since(sent_at).num_minutes();
+            // #1870-H3: clamp so a backward clock skew (future `sent_at`) can't
+            // make the age negative → re-nudge / escalation silently stop firing.
+            let age_min = crate::daemon::utils::elapsed_since(*now, sent_at).num_minutes();
             let corr = correlation.unwrap_or_else(|| "<unknown>".to_string());
             let key = (target.clone(), corr.clone());
             active.insert(key.clone());

--- a/src/daemon/utils.rs
+++ b/src/daemon/utils.rs
@@ -3,6 +3,26 @@
 
 use sha2::{Digest, Sha256};
 
+/// #1870-H3: wall-clock elapsed `now − ts`, clamped to a non-negative `Duration`.
+///
+/// `DateTime::signed_duration_since` goes NEGATIVE when `ts` is in the future
+/// relative to `now` — a backward clock skew (NTP correction, VM resume /
+/// snapshot restore, DST). Every "elapsed > positive-threshold" watchdog then
+/// reads not-yet-due forever and **silently wedges** until real time catches up
+/// (the #N2 class — cron #1852, plus `anti_stall` + `handoff_timeout`). Clamping
+/// to zero treats a future timestamp as "just started", so the watchdog simply
+/// re-evaluates as the clock advances instead of stalling.
+///
+/// A NO-OP for the normal `ts ≤ now` case: the elapsed is byte-identical to the
+/// raw `signed_duration_since`. Route every daemon "elapsed vs positive
+/// threshold" read through this so a single clamp covers the whole class.
+pub(crate) fn elapsed_since(
+    now: chrono::DateTime<chrono::Utc>,
+    ts: chrono::DateTime<chrono::Utc>,
+) -> chrono::Duration {
+    now.signed_duration_since(ts).max(chrono::Duration::zero())
+}
+
 /// Strip HTML comments (`<!-- ... -->`) from a string.
 pub fn strip_html_comments(body: &str) -> String {
     let mut result = String::with_capacity(body.len());
@@ -52,5 +72,39 @@ mod tests {
         let h2 = sha256_hex(b"hello");
         assert_eq!(h1, h2);
         assert_eq!(h1.len(), 64);
+    }
+
+    /// §3.9 #1870-H3: the clamp is a NO-OP for `ts ≤ now` (byte-identical to the
+    /// raw `signed_duration_since`) and clamps a FUTURE `ts` (backward clock skew)
+    /// to zero instead of a negative `Duration`. This is the one place the clamp
+    /// is observable — the downstream `> threshold` comparisons treat negative and
+    /// zero the same, so the helper test is the regression-proof anchor.
+    #[test]
+    fn elapsed_since_clamps_future_to_zero_noop_for_past_1870_h3() {
+        let now = chrono::Utc::now();
+
+        // Past `ts` → byte-identical to the raw signed_duration_since (no-op).
+        let past = now - chrono::Duration::seconds(123);
+        assert_eq!(
+            elapsed_since(now, past),
+            now.signed_duration_since(past),
+            "#1870-H3: a past ts must be byte-identical (clamp is a no-op)"
+        );
+        assert_eq!(elapsed_since(now, past).num_seconds(), 123);
+
+        // `ts == now` → zero.
+        assert_eq!(elapsed_since(now, now), chrono::Duration::zero());
+
+        // Future `ts` (backward clock skew) → clamped to zero, NOT negative.
+        let future = now + chrono::Duration::seconds(456);
+        assert_eq!(
+            elapsed_since(now, future),
+            chrono::Duration::zero(),
+            "#1870-H3: a future ts must clamp to 0 (not a negative wedge)"
+        );
+        assert!(
+            now.signed_duration_since(future).num_seconds() < 0,
+            "sanity: the raw value the clamp guards against is indeed negative"
+        );
     }
 }


### PR DESCRIPTION
Bug-hunt finding **H3** (filed under #1870) — the cron N2 backward-skew class beyond cron.

## Bug
A watchdog computing `elapsed = now.signed_duration_since(ts)` vs a positive threshold goes **negative** when `ts` is in the future relative to `now` — a backward clock skew (NTP correction, VM resume / snapshot restore, DST). cron N2 (#1852) fixed one site; the same shape lived in `anti_stall` + `handoff_timeout`.

## Fix
One shared `crate::daemon::utils::elapsed_since(now, ts)` = `max(0, signed_duration_since)`, routed through the class:
- `anti_stall::check_stalled` (elapsed vs `eta*multiplier`)
- `handoff_timeout_watchdog::scan_and_emit` (handoff age vs re-nudge / escalate)
- cron N2's forward-elapsed read — the dedicated `last_check_in_future` re-stamp **still owns** the backward case (clamp there is a no-op), so cron's persisted-wedge fix is unchanged; this only folds the elapsed READ into the one helper.

## Honest scope note (for the reviewer)
The clamp is **byte-identical** for the normal `ts ≤ now` case. At these threshold comparisons, negative and zero behave **the same** (both `< threshold` → neither fired), so for anti_stall + handoff this is a **defensive class-unification** that makes the negative provably-benign and guards future use — *not* a present false-fire fix. The one genuine persisted wedge in the class was cron's `last_check` (already fixed by #1852's re-stamp), now reading elapsed through the same helper. I'm flagging this rather than overclaiming an active bug at those two sites.

## §3.9
- `elapsed_since_clamps_future_to_zero_noop_for_past_1870_h3` — **the regression-proof anchor** (the one place the clamp is observable): a past ts is byte-identical to the raw `signed_duration_since`; `ts==now` and a FUTURE ts both clamp to zero (not a negative `Duration`).
- `check_stalled_future_started_at_does_not_wedge_1870_h3` — a future `started_at` produces no false stall; existing forward tests pin unchanged stall firing.

Local CI-parity preflight green (`fmt`/`clippy --all-targets --features tray -D warnings`/`cargo test --tests`).

## Reviewer-2 focus
- Is cron's `last_check_in_future` re-stamp behavior **unchanged** (clamp at line 170 is a no-op for the backward case)?
- Any of the routed sites where negative≠0 actually mattered downstream (it shouldn't — all are `> / >=` positive-threshold reads)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)