### PR TITLE
dispatch: thread second_reviewer→review_class=dual into the auto-armed watch (#1877)

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -301,6 +301,11 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
         } else {
             let repo_arg = args["repository"].as_str();
             let next_after_ci_arg = args["next_after_ci"].as_str();
+            // #1877: thread the dual-review directive to the auto-armed watch. A
+            // `second_reviewer=true` dispatch (validated above) must arm a
+            // `review_class=dual` watch; without this the flag was accepted +
+            // validated then silently dropped (CI gated single review).
+            let review_class_arg = if second_reviewer { Some("dual") } else { None };
             if let Err(e) = super::dispatch_hook::dispatch_auto_bind_lease_with_chain(
                 home,
                 target,
@@ -308,6 +313,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                 branch,
                 repo_arg,
                 next_after_ci_arg,
+                review_class_arg,
             ) {
                 return json!({"ok": false, "error": format!("dispatch rejected: {e}")});
             }

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -299,21 +299,15 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                 "dispatch_auto_bind_lease skipped (bind: false)"
             );
         } else {
-            let repo_arg = args["repository"].as_str();
-            let next_after_ci_arg = args["next_after_ci"].as_str();
-            // #1877: thread the dual-review directive to the auto-armed watch. A
-            // `second_reviewer=true` dispatch (validated above) must arm a
-            // `review_class=dual` watch; without this the flag was accepted +
-            // validated then silently dropped (CI gated single review).
-            let review_class_arg = if second_reviewer { Some("dual") } else { None };
+            // #1877: second_reviewer → review_class="dual" on the auto-armed watch.
             if let Err(e) = super::dispatch_hook::dispatch_auto_bind_lease_with_chain(
                 home,
                 target,
                 task_id_val,
                 branch,
-                repo_arg,
-                next_after_ci_arg,
-                review_class_arg,
+                args["repository"].as_str(),
+                args["next_after_ci"].as_str(),
+                if second_reviewer { Some("dual") } else { None },
             ) {
                 return json!({"ok": false, "error": format!("dispatch rejected: {e}")});
             }

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -220,7 +220,9 @@ pub(crate) fn dispatch_auto_bind_lease(
     branch: &str,
     repo: Option<&str>,
 ) -> Result<DispatchOutcome, DispatchError> {
-    dispatch_auto_bind_lease_with_source_and_chain(home, target, task_id, branch, repo, None, None)
+    dispatch_auto_bind_lease_with_source_and_chain(
+        home, target, task_id, branch, repo, None, None, None,
+    )
 }
 
 /// #931 Fix 2 (H5a): variant that propagates `next_after_ci` so the
@@ -251,6 +253,8 @@ pub(crate) fn dispatch_auto_bind_lease_with_chain(
     branch: &str,
     repo: Option<&str>,
     next_after_ci: Option<&str>,
+    // #1877: dual-review directive ("dual" iff the dispatch set second_reviewer).
+    review_class: Option<&str>,
 ) -> Result<DispatchOutcome, DispatchError> {
     dispatch_auto_bind_lease_with_source_and_chain(
         home,
@@ -260,6 +264,7 @@ pub(crate) fn dispatch_auto_bind_lease_with_chain(
         repo,
         None,
         next_after_ci,
+        review_class,
     )
 }
 
@@ -294,6 +299,7 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
         repo,
         source_repo_override,
         None,
+        None,
     )
 }
 
@@ -316,6 +322,10 @@ fn auto_watch_arm_error(result: &serde_json::Value) -> Option<(&str, &str)> {
 /// All four convenience entry points (`dispatch_auto_bind_lease`,
 /// `_with_source`, `_with_chain`, this one) route through here so the
 /// auto-watch arming logic has a single source of truth.
+// #1877: the dispatch directives (repo/source/next_after_ci/review_class) are
+// each meaningful and threaded individually; a params struct would obscure the
+// call sites more than it'd help.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     home: &Path,
     target: &str,
@@ -324,6 +334,11 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     repo: Option<&str>,
     source_repo_override: Option<&Path>,
     next_after_ci: Option<&str>,
+    // #1877: `review_class` (e.g. "dual" from a `second_reviewer=true` dispatch)
+    // must reach the auto-armed watch — else the dual-review signal accepted at
+    // the MCP boundary (comms.rs) silently evaporates and CI gates single review.
+    // 4th re-marshal-drop of an MCP-accepted dispatch directive.
+    review_class: Option<&str>,
 ) -> Result<DispatchOutcome, DispatchError> {
     let _guard = BindGuard::try_acquire(home, target).map_err(|msg| DispatchError {
         message: msg,
@@ -529,6 +544,13 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
         // false-positive class on the verdict-reply side.
         if !task_id.is_empty() {
             watch_args["task_id"] = serde_json::json!(task_id);
+        }
+        // #1877: propagate the dual-review directive so a `second_reviewer=true`
+        // dispatch arms a `review_class=dual` watch (handle_watch_ci → ci/mod.rs
+        // stores it; the poller's `record_ci_result` then enforces dual review).
+        // Unset (normal dispatch) leaves the watch single — no over-upgrade.
+        if let Some(rc) = review_class.filter(|s| !s.is_empty()) {
+            watch_args["review_class"] = serde_json::json!(rc);
         }
         let watch_result = crate::mcp::handlers::ci::handle_watch_ci(home, &watch_args, target);
         // #1750 A1: `handle_watch_ci` returns `{"error":..,"code":..}` on a failed

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1451,6 +1451,7 @@ fn dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931() {
         "feat/931-h5a-chain",
         None,
         Some("reviewer"),
+        None,
     );
     assert!(
         r.is_ok(),
@@ -1472,6 +1473,101 @@ fn dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931() {
         "#931 Fix 2 (H5a) GREEN: dispatch chain MUST propagate next_after_ci into auto-armed watch JSON. Got: {watch}"
     );
 
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+/// #1877 §3.9 + regression guard: EVERY MCP-accepted dispatch directive must
+/// reach the auto-armed watch together. This re-marshal-drop class has recurred
+/// 4× — #931 (next_after_ci), #1031 (task_id), #1877 (review_class from a
+/// `second_reviewer=true` dispatch). One dispatch carrying all three pins that
+/// none is silently dropped in the `watch_args` re-marshal.
+#[test]
+#[cfg(unix)]
+fn all_dispatch_directives_reach_armed_watch_1877() {
+    let parent = std::env::temp_dir().join(format!(
+        "agend-1877-all-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) =
+        p781_canonical_with_team_source_repo(&parent, "feat/1877-all", true, "val", &["val-dev"]);
+    let r = super::dispatch_auto_bind_lease_with_chain(
+        &home,
+        "val-dev",
+        "T-1877-all",
+        "feat/1877-all",
+        None,
+        Some("reviewer"),
+        Some("dual"),
+    );
+    assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/1877-all"),
+    );
+    let watch: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
+            .expect("parse watch");
+    assert_eq!(
+        watch["next_after_ci"].as_str(),
+        Some("reviewer"),
+        "#931: next_after_ci dropped from armed watch. Got: {watch}"
+    );
+    assert_eq!(
+        watch["task_id"].as_str(),
+        Some("T-1877-all"),
+        "#1031: task_id dropped from armed watch. Got: {watch}"
+    );
+    assert_eq!(
+        watch["review_class"].as_str(),
+        Some("dual"),
+        "#1877: review_class (dual-review directive) dropped from armed watch. Got: {watch}"
+    );
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+/// #1877 §3.9: a normal dispatch (no second_reviewer → `review_class=None`) must
+/// NOT over-upgrade — the armed watch leaves `review_class` unset (single).
+#[test]
+#[cfg(unix)]
+fn dispatch_without_review_class_stays_single_1877() {
+    let parent = std::env::temp_dir().join(format!(
+        "agend-1877-single-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let (home, _canonical) = p781_canonical_with_team_source_repo(
+        &parent,
+        "feat/1877-single",
+        true,
+        "val",
+        &["val-dev"],
+    );
+    let r = super::dispatch_auto_bind_lease_with_chain(
+        &home,
+        "val-dev",
+        "T-1877s",
+        "feat/1877-single",
+        None,
+        Some("reviewer"),
+        None,
+    );
+    assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/1877-single"),
+    );
+    let watch: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
+            .expect("parse watch");
+    assert!(
+        watch["review_class"].is_null(),
+        "#1877: a normal dispatch must NOT over-upgrade to dual (review_class unset). Got: {watch}"
+    );
     std::fs::remove_dir_all(&parent).ok();
 }
 
@@ -1511,6 +1607,7 @@ fn dispatch_persists_task_id_into_ci_watch_sidecar_1031() {
         "feat/1031-persist",
         None,
         Some("val-reviewer"),
+        None,
     );
     assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
 
@@ -1569,6 +1666,7 @@ fn dispatch_no_longer_auto_derives_next_after_ci_pr2() {
         "feat/1037-auto-derive",
         None,
         None, // ← no explicit next_after_ci — the field this test pins.
+        None,
     );
     assert!(
         r.is_ok(),
@@ -1636,6 +1734,7 @@ fn dispatch_auto_derive_no_reviewer_in_team_leaves_next_after_ci_none_1037() {
         "feat/1037-no-reviewer",
         None,
         None,
+        None,
     );
     assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
 
@@ -1685,6 +1784,7 @@ fn dispatch_explicit_next_after_ci_overrides_auto_derive_1037() {
         "feat/1037-override",
         None,
         Some("val-lead"),
+        None,
     );
     assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
 


### PR DESCRIPTION
Closes #1877 (bug-hunt C1 — 4th occurrence of the re-marshal-drop class).

## Bug

`send(kind=task, second_reviewer=true)` reads + **validates** the dual-review flag in `comms.rs` (requires a non-empty reason), then **never uses it again** — `git grep second_reviewer` (non-test) finds it only at the read/validate site + the tools.rs schema. It's not stored, not in the dispatch message, and never reaches the auto-armed ci-watch's `review_class`. Since `review_class` (the actual dual-review enforcement, read by the poller's `record_ci_result`) is set **only** via an explicit `ci action=watch review_class=dual`, a `second_reviewer=true` dispatch silently gates **single** review — the operator sets the flag, it's accepted + validated, and it evaporates.

## Fix

Thread the directive through the dispatch chain exactly like #931 did for `next_after_ci` and #1031 for `task_id`:
- `comms.rs::handle_delegate_task` derives `review_class = second_reviewer.then(|| "dual")` and passes it to `dispatch_auto_bind_lease_with_chain`;
- the param flows through to `dispatch_auto_bind_lease_with_source_and_chain`, which adds `review_class` to the auto-armed `watch_args` when set.

Unset (normal dispatch) leaves the watch single — no over-upgrade. The explicit `ci action=watch review_class=dual` path is untouched.

## Tests (§3.9 + regression guard)

- `all_dispatch_directives_reach_armed_watch_1877` — **the guard the lead requested**: one dispatch carrying `next_after_ci` + `task_id` + `review_class` asserts ALL THREE land on the armed watch, pinning the recurring drop class (#931 / #1031 / #1877) so a future re-marshal can't silently drop any directive.
- `dispatch_without_review_class_stays_single_1877` — a normal dispatch must NOT over-upgrade to dual.

## Verification

- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -- -D warnings` ✓
- `dispatch_hook::` 50/50
- `cargo test --tests --features tray` → green except the unrelated `dispatch_branch_skips_metadata_stub_..._1834` (false-fails only under the local fleet `git` shim; passes with real `/usr/bin/git`; CI uses real git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)