### PR TITLE
fix(#1879): clear the worktree binding on instance delete + unmanaged release

### DIFF
--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -146,6 +146,15 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // never created). Best-effort like the steps above.
     let _ = std::fs::remove_dir_all(crate::agent::opencode_data_dir(home, name));
 
+    // #1879 (BIND-1): clear the worktree binding (`runtime/<name>/binding.json`
+    // + its HMAC sidecar + the bind-in-flight flag). Every OTHER store above is
+    // cleaned here, but binding was missed — so deleting a bound agent (one that
+    // ran bind_self / repo checkout) without a prior release both leaked the
+    // binding (blocking a same-name re-bind) AND tripped the residual audit below
+    // → the whole teardown returned Err despite otherwise succeeding.
+    crate::binding::unbind(home, name);
+    crate::mcp::handlers::dispatch_hook::clear_bind_in_flight(home, name);
+
     // Sprint 54 P1-B Bug 1 audit: enumerate every store that still holds
     // the name. If any do, surface a loud error instead of returning
     // success — `auto_start_fleet` revival of a half-deleted instance is
@@ -588,5 +597,51 @@ mod tests {
             "ci watch with only the deleted subscriber must be removed"
         );
         std::fs::remove_dir_all(home).ok();
+    }
+
+    /// §3.9 #1879 (BIND-1): deleting a BOUND agent (one that ran bind_self / repo
+    /// checkout) must clear its binding and succeed — pre-fix the binding was the
+    /// one store `full_delete_instance` never cleaned, so the residual audit
+    /// flagged `runtime/<name>/binding.json` and the teardown returned Err while
+    /// also leaking the binding. Regression-proof: revert the `binding::unbind`
+    /// call and the residual audit fails the delete.
+    #[test]
+    fn full_delete_clears_binding_and_succeeds_1879() {
+        let home = tmp_home("1879-bind-delete");
+        // Simulate a bound agent.
+        crate::binding::bind_full(
+            &home,
+            "agent-b",
+            "",
+            "feat/x",
+            std::path::Path::new("/tmp/wt-agent-b"),
+            std::path::Path::new("/tmp/repo-agent-b"),
+        )
+        .expect("bind_full");
+        assert!(
+            crate::binding::read(&home, "agent-b").is_some(),
+            "pre: binding exists"
+        );
+
+        let result = super::full_delete_instance(&home, "agent-b");
+
+        assert!(
+            result.is_ok(),
+            "#1879 BIND-1: teardown of a bound agent must succeed (no residual Err), got: {result:?}"
+        );
+        assert!(
+            crate::binding::read(&home, "agent-b").is_none(),
+            "#1879 BIND-1: the binding must be cleared"
+        );
+        assert!(
+            !home
+                .join("runtime")
+                .join("agent-b")
+                .join("binding.json")
+                .exists(),
+            "#1879 BIND-1: binding.json must be gone"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -397,6 +397,15 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
                 }
                 WorktreeRemoval::Unmanaged(err) => {
                     out.error = Some(err);
+                    // #1879 (WT-LEAK-2): refusing to delete an UNMANAGED
+                    // (operator-created) worktree protects operator data, but the
+                    // daemon's stale binding to it must STILL be cleared — leaving
+                    // it leaks the binding + blocks a same-agent re-bind. The
+                    // worktree-protection refusal must not also skip binding
+                    // cleanup. (This arm is already the non-dry_run path; the
+                    // dry_run classifier above mutates nothing.)
+                    clear_binding_state(home, agent);
+                    out.binding_removed = true;
                     return out;
                 }
                 WorktreeRemoval::Failed(err) => {
@@ -1459,8 +1468,10 @@ mod tests {
     fn p0x_release_full_unmanaged_worktree_skipped_safely() {
         // R14 safety: if the binding points at a worktree that lacks the
         // .agend-managed marker (operator-created, not daemon-leased), the
-        // release MUST NOT remove it. Binding is also kept so the operator
-        // can investigate the inconsistency rather than be left half-cleaned.
+        // release MUST NOT remove the worktree. #1879 (WT-LEAK-2): the stale
+        // binding IS cleared, though — leaving it leaked the binding and blocked
+        // a same-agent re-bind. The worktree (operator data) survives for
+        // investigation; the daemon's binding to it does not.
         let home = tmp_home("p0x-unmanaged");
         let unmanaged_wt = tmp_home("p0x-unmanaged-wt-target");
         // Hand-craft a binding pointing at an unmanaged path.
@@ -1490,8 +1501,8 @@ mod tests {
             outcome
         );
         assert!(
-            !outcome.binding_removed,
-            "binding must be preserved when worktree is unmanaged (operator visibility)"
+            outcome.binding_removed,
+            "#1879 WT-LEAK-2: the stale binding must be CLEARED even when the unmanaged worktree removal is refused"
         );
         assert!(
             outcome
@@ -1504,8 +1515,8 @@ mod tests {
         );
         assert!(unmanaged_wt.exists(), "operator-created dir must survive");
         assert!(
-            crate::binding::read(&home, "agent-u").is_some(),
-            "binding kept for operator visibility"
+            crate::binding::read(&home, "agent-u").is_none(),
+            "#1879 WT-LEAK-2: the binding must be cleared (no leak / re-bind block)"
         );
 
         std::fs::remove_dir_all(&home).ok();


### PR DESCRIPTION
Bug-hunt finding bundle **BIND-1 + WT-LEAK-2** (lead-approved). Two sibling binding-cleanup gaps.

## BIND-1 — `full_delete_instance` omitted binding cleanup
`full_delete_instance` (`instance_lifecycle.rs`) cleans ~13 stores but never cleared the worktree binding. So deleting a **bound** agent (one that ran `bind_self` / repo checkout) without a prior release both **leaked** `runtime/<name>/binding.json` (blocking a same-name re-bind) AND tripped the `name_residual_anywhere` audit → the whole teardown returned **Err** despite otherwise succeeding.
**Fix:** `binding::unbind` + `clear_bind_in_flight` just before the residual audit.

## WT-LEAK-2 — `release_full` Unmanaged arm leaked the binding
`release_full`'s `Unmanaged` arm (an operator-created worktree with no `.agend-managed` marker) early-returned **before** `clear_binding_state`. Refusing to delete the worktree (protect operator data) must not also skip binding cleanup — the daemon's binding to an unremovable worktree is stale state that leaks + blocks re-bind.
**Fix:** the arm clears the binding before returning. (It's already the non-dry_run path; the dry_run classifier above mutates nothing, so a dry run still preserves both.)

## §3.9
- `full_delete_clears_binding_and_succeeds_1879` — a bound agent → teardown returns **Ok** (no residual Err) and the binding is gone. Regression-proof: revert the unbind and the audit fails the delete.
- `p0x_release_full_unmanaged_worktree_skipped_safely` (**existing test updated to the new contract**): the unmanaged worktree is preserved but the binding **is** cleared (was: binding kept "for operator visibility" — that's the behavior the lead approved changing).

Local CI-parity preflight green (`fmt`/`clippy --all-targets --features tray -D warnings`/`cargo test --tests`; the comprehensive `full_delete_instance_*` + all `p0x_release_full_*` tests still pass).

## Reviewer-2 focus
- Does clearing the binding on the Unmanaged refusal lose any signal the operator needed? (The worktree + the error message survive; only the daemon's stale binding goes.)
- A no-binding normal delete is unaffected (`binding::unbind` is a best-effort no-op when there's nothing to remove).

🤖 Generated with [Claude Code](https://claude.com/claude-code)