### PR TITLE
fix(#1882 BIND-2): atomic branch lease via per-branch flock — close double-bind race

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -18,6 +18,33 @@ fn index_key(home: &Path, agent: &str) -> String {
     format!("{}:{agent}", home.display())
 }
 
+/// #1882: lock-file path for the per-BRANCH lease flock. Keyed by a hash of the
+/// branch so it is path-safe (branches contain `/`) and collision-free; different
+/// branches never share a lock file.
+fn branch_lease_lock_path(home: &Path, branch: &str) -> PathBuf {
+    let key = crate::daemon::utils::sha256_hex(branch.as_bytes());
+    crate::paths::runtime_dir(home)
+        .join(".lease-locks")
+        .join(format!("{key}.lock"))
+}
+
+/// #1882: acquire the exclusive per-BRANCH lease flock so the cross-agent
+/// "a branch is held by at most one agent" check-then-bind
+/// (`scan_existing_branch_binding` → `bind_full`) is ATOMIC. Two DIFFERENT agents
+/// racing to lease the SAME branch serialize here: the first binds; the second
+/// blocks until the first's guard drops, then its rescan sees the first's binding
+/// and rejects — so neither double-binds. This is a SHORT-LIVED mutex around the
+/// bind operation, NOT a lease-lifetime lock: the persistent lease state is
+/// `binding.json` (which the scan reads), so `release_full` needs no lock cleanup.
+/// Per-branch keying means different branches never contend → normal single-agent
+/// binds are unaffected. Blocking `acquire_file_lock`; released when the guard drops.
+pub fn acquire_branch_lease_lock(
+    home: &Path,
+    branch: &str,
+) -> anyhow::Result<crate::store::FileFlockGuard> {
+    crate::store::acquire_file_lock(&branch_lease_lock_path(home, branch))
+}
+
 /// Write a binding for an agent (task assigned).
 ///
 /// Fail-closed: if lock acquisition or I/O fails, binding.json is NOT
@@ -403,6 +430,51 @@ pub fn reconcile_orphans(home: &Path) {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    /// §3.9 #1882 (concurrency): the per-branch lease flock SERIALIZES two
+    /// acquirers of the SAME branch (the second blocks until the first drops) but
+    /// lets DIFFERENT branches proceed concurrently (no cross-branch contention).
+    /// This is the atomicity that makes the dispatch `scan → bind_full` a critical
+    /// section so two agents can't both pass the scan and double-bind. Regression-
+    /// proof: it's the lock's defining behavior.
+    #[test]
+    fn branch_lease_lock_serializes_same_branch_allows_different_1882() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let home = tmp_home("lease-lock-1882");
+
+        // Different branches must NOT contend — both acquire while both are held.
+        let g_x = acquire_branch_lease_lock(&home, "feat/x").expect("lock x");
+        let g_y = acquire_branch_lease_lock(&home, "feat/y").expect("lock y must not block on x");
+        drop((g_x, g_y));
+
+        // Same branch: a second acquirer BLOCKS until the first guard drops.
+        let got = Arc::new(AtomicBool::new(false));
+        let g1 = acquire_branch_lease_lock(&home, "feat/z").expect("lock z (holder)");
+        let home2 = home.clone();
+        let got2 = got.clone();
+        let t = std::thread::spawn(move || {
+            // Blocks here until the holder drops g1.
+            let _g2 = acquire_branch_lease_lock(&home2, "feat/z").expect("lock z (waiter)");
+            got2.store(true, Ordering::SeqCst);
+        });
+
+        std::thread::sleep(Duration::from_millis(150));
+        assert!(
+            !got.load(Ordering::SeqCst),
+            "#1882: a second same-branch lock MUST block while the first is held"
+        );
+        drop(g1); // release → the waiter proceeds.
+        t.join().expect("waiter thread");
+        assert!(
+            got.load(Ordering::SeqCst),
+            "#1882: the second same-branch lock must proceed once the first drops"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
 
     fn tmp_home(tag: &str) -> std::path::PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -160,7 +160,43 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
     // the short-circuit does NOT fire and the genuine `git worktree add`
     // conflict error below is preserved. Same-agent DIFFERENT-branch bindings
     // also fall through (branch mismatch), unchanged.
+    //
+    // #1882 (reviewer-2): repo checkout is the THIRD production bind path (besides
+    // the dispatch + bind_self funnel through dispatch_auto_bind_lease). Hold the
+    // SAME per-branch lease flock across its check-then-act (cross-agent scan +
+    // idempotent read + git worktree add + bind_full) so a concurrent dispatch or
+    // another repo checkout can't double-bind the branch. Bind-only (a `--detach`
+    // checkout writes no binding); the guard lives to fn end so it covers bind_full.
+    let _lease_lock = if bind {
+        match crate::binding::acquire_branch_lease_lock(home, branch) {
+            Ok(g) => Some(g),
+            Err(e) => {
+                return json!({
+                    "error": format!("could not acquire branch lease lock for '{branch}': {e}"),
+                    "code": "lease_lock",
+                    "branch": branch,
+                })
+            }
+        }
+    } else {
+        None
+    };
     if bind {
+        // #1882: cross-agent P0-1.5 reject UNDER the lock — another agent holding
+        // this branch is refused (mirrors the dispatch path's scan), rather than
+        // leaning on `git worktree add`'s "already checked out" error. The
+        // same-agent idempotent short-circuit below handles THIS agent re-checkout.
+        if let Some(other) =
+            crate::binding::scan_existing_branch_binding(home, branch, instance_name)
+        {
+            return json!({
+                "error": format!(
+                    "branch '{branch}' already leased by '{other}' — release first or use a different branch"
+                ),
+                "code": "cross_agent_conflict",
+                "branch": branch,
+            });
+        }
         if let Some(existing) = crate::binding::read(home, instance_name) {
             let same_branch = existing.get("branch").and_then(|v| v.as_str()) == Some(branch);
             let live_wt = existing

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -819,6 +819,69 @@ fn checkout_bind_true_writes_binding_marker_and_arms_watch() {
     std::fs::remove_dir_all(&parent).ok();
 }
 
+/// §3.9 #1882 (reviewer-2 re-verify): the repo-checkout bind path is the third
+/// production bind site. An end-to-end conflict — agent A checks out + binds a
+/// branch, then agent B repo-checkouts the SAME branch — must end with EXACTLY
+/// one binding: B is rejected (`cross_agent_conflict`) under the shared per-branch
+/// lease lock + scan, NOT double-bound. Regression-proof: pre-fix B had no scan,
+/// so it reached `git worktree add` and failed with a raw "already checked out"
+/// error (different code) or, on a different worktree scheme, double-bound.
+#[test]
+#[cfg(unix)]
+fn checkout_bind_rejects_cross_agent_branch_conflict_1882() {
+    let home = p778_tmp_home("xagent");
+    let parent = p778_tmp_home("xagent-src-parent");
+    let source = p778_setup_source_repo(&parent, "feat/shared");
+
+    // Agent A checks out + binds feat/shared.
+    let a = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": "feat/shared",
+            "bind": true,
+        }),
+        "agent-a",
+    );
+    assert!(
+        a.get("error").is_none(),
+        "agent A checkout must succeed: {a}"
+    );
+    assert_eq!(a["bound"].as_bool(), Some(true));
+
+    // Agent B tries the SAME branch → rejected (cross-agent), not double-bound.
+    let b = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": "feat/shared",
+            "bind": true,
+        }),
+        "agent-b",
+    );
+    assert_eq!(
+        b["code"].as_str(),
+        Some("cross_agent_conflict"),
+        "#1882: a second agent on the same branch must be rejected: {b}"
+    );
+    assert!(
+        !crate::paths::runtime_dir(&home)
+            .join("agent-b")
+            .join("binding.json")
+            .exists(),
+        "#1882: the rejected agent must NOT be bound"
+    );
+    // Exactly one binding holds feat/shared (it is agent-a's).
+    assert_eq!(
+        crate::binding::scan_existing_branch_binding(&home, "feat/shared", ""),
+        Some("agent-a".to_string()),
+        "#1882: exactly one agent must hold the branch after the conflict"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
 #[test]
 #[cfg(unix)]
 fn checkout_bind_true_idempotent_when_already_bound_1494() {

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -354,6 +354,26 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
         });
     }
 
+    // #1882: hold a per-BRANCH lease flock across the P0-1.5 scan + the bind_full
+    // below so the check-then-bind is ATOMIC. Without it, two DIFFERENT agents
+    // racing to lease the SAME branch both passed the scan (neither had bound yet)
+    // and both bound — violating "a branch is held by at most one agent". Keyed on
+    // the branch (not the agent): the second racer blocks here, then its scan below
+    // sees the first's binding and rejects. Both bind paths funnel through this fn
+    // (dispatch auto-bind AND bind_self via dispatch_auto_bind_lease_with_source),
+    // so this one lock covers both. Lock order is consistent (per-agent BindGuard
+    // above → this branch lock → per-agent binding lock inside bind_full), so no
+    // deadlock; different branches use different lock files → no cross-branch
+    // contention. Held only across the bind (a short mutex), so release is unaffected.
+    let _lease_lock =
+        crate::binding::acquire_branch_lease_lock(home, branch).map_err(|e| DispatchError {
+            message: format!("could not acquire branch lease lock for '{branch}': {e}"),
+            code: ErrorCode::LeaseConflict,
+            stage: Stage::WorktreeLeaseConflict,
+            fetch_attempted: false,
+            raw: None,
+        })?;
+
     // P0-1.5: central lease registry check — reject if another agent holds this branch.
     if let Some(other) = crate::binding::scan_existing_branch_binding(home, branch, target) {
         return Err(DispatchError {

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -359,9 +359,12 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     // racing to lease the SAME branch both passed the scan (neither had bound yet)
     // and both bound — violating "a branch is held by at most one agent". Keyed on
     // the branch (not the agent): the second racer blocks here, then its scan below
-    // sees the first's binding and rejects. Both bind paths funnel through this fn
-    // (dispatch auto-bind AND bind_self via dispatch_auto_bind_lease_with_source),
-    // so this one lock covers both. Lock order is consistent (per-agent BindGuard
+    // sees the first's binding and rejects. Two of the three production bind paths
+    // funnel through this fn (dispatch auto-bind AND bind_self via
+    // dispatch_auto_bind_lease_with_source); the third — repo checkout
+    // (`ci/mod.rs`, reviewer-2 #1882) — takes the SAME `acquire_branch_lease_lock`
+    // around its own scan + bind_full, so all three serialize on the one branch
+    // lock. Lock order is consistent (per-agent BindGuard
     // above → this branch lock → per-agent binding lock inside bind_full), so no
     // deadlock; different branches use different lock files → no cross-branch
     // contention. Held only across the bind (a short mutex), so release is unaffected.


### PR DESCRIPTION
Bug-hunt finding **BIND-2** (lead-approved). Closes the cross-agent double-bind CAS race.

## Bug
P0-1.5 ("a branch is held by at most one agent") was a non-atomic check-then-act: `dispatch_auto_bind_lease_with_chain` scans `scan_existing_branch_binding` (`dispatch_hook.rs:358`) then `bind_full` (~`:450`) with only **per-agent** locks (`BindGuard` + the per-agent `.binding.json.lock`). Two **different** agents racing to lease the **same** branch both pass the scan (neither has bound yet) and both bind → double-bind, both able to push.

## Fix — option (a): branch-level lease flock
New `binding::acquire_branch_lease_lock(home, branch)` takes an exclusive flock keyed on a hash of the **branch**, acquired before the scan and held (RAII) across `bind_full`. The second racer **blocks** until the first drops, then its rescan sees the first's binding and rejects with the existing `LeaseConflict` error — exactly one wins, no rollback/tiebreak needed.

- **Covers both bind paths**: dispatch auto-bind AND `bind_self` both funnel through this fn (`bind_self` → `dispatch_auto_bind_lease_with_source` → `_with_chain`), so one lock covers both.
- **Short mutex, not a lease-lifetime lock**: the persistent lease is `binding.json` (which the scan reads), so the flock only guards the bind operation — **`release_full` needs no lock cleanup** (there's no held-across-the-lease lock to clean).
- **No deadlock**: lock order is consistent (per-agent `BindGuard` → branch lock → per-agent binding lock inside `bind_full`); different branches use different lock files → no cross-branch contention; normal single-agent binds unaffected.

## §3.9
- `branch_lease_lock_serializes_same_branch_allows_different_1882` — a **real two-thread test**: the same branch serializes (the second acquirer blocks while the first is held, proceeds once it drops); different branches acquire concurrently. The regression-proof anchor for the lock's defining behavior.
- Existing `bind_self_rejects_cross_agent_branch_conflict` (loser rejected), `bind_self_idempotent_same_agent_same_branch` (no self-deadlock), and the 50-iter `dispatch_auto_bind_lease_stress` all still pass **through** the lock (no deadlock/regression).

Local CI-parity preflight green (`fmt`/`clippy --all-targets --features tray -D warnings`/`cargo test --tests`, incl. invariants).

## Reviewer-2 focus (concurrency correctness + deadlock)
- **Deadlock**: is the lock order (`BindGuard` → branch flock → per-agent binding flock) cycle-free on every path? Any path that holds the branch flock while acquiring a lock another path takes in the opposite order?
- **Coverage**: are there bind sites that scan→bind WITHOUT going through `_with_chain` (e.g. `ci/mod.rs:220` repo-checkout bind)? (I scoped to the dispatch+bind_self funnel per BIND-2; flagging ci-checkout as a possible separate follow-up if it doesn't share the scan.)
- **Lease-lifetime vs bind-mutex**: confirm the short-mutex design is correct (the durable lease is binding.json, read by the scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)