### PR TITLE
fix(persistence): locked RMW for topic registry + instance metadata (#1886)

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -217,43 +217,49 @@ pub fn merge_metadata(home: &Path, name: &str, info: &mut Value) {
 
 /// Persist a single metadata key/value for an instance.
 ///
-/// Uses atomic write (temp file + rename) so concurrent readers
-/// (e.g. supervisor tick) never see a half-written file.
+/// #1886 C2: locked read-modify-write (flock spans load→modify→write) so two
+/// concurrent `set_*` on the same instance can't each read the same object and
+/// clobber the other's field. `with_json_state_or_create` also gives the same
+/// atomic write (temp file + rename) the prior code had, so concurrent readers
+/// (e.g. supervisor tick) still never see a half-written file.
 pub fn save_metadata(home: &Path, instance_name: &str, key: &str, value: Value) {
     let meta_dir = home.join("metadata");
     std::fs::create_dir_all(&meta_dir).ok();
     let meta_path = metadata_path_resolved(home, instance_name);
-    let mut meta: Value = std::fs::read_to_string(&meta_path)
-        .map(|c| serde_json::from_str(&c).unwrap_or(json!({})))
-        .unwrap_or(json!({}));
-    meta[key] = value;
-    let content = serde_json::to_string_pretty(&meta).unwrap_or_default();
-    // M1: atomic write with fsync. #1647: log on failure — this metadata is read
-    // back by `merge_metadata`, and the MCP set_* handlers return OK regardless,
-    // so a dropped write was a silent operator-set-but-lost.
+    // #1647: log on failure — this metadata is read back by `merge_metadata`, and
+    // the MCP set_* handlers return OK regardless, so a dropped write was a silent
+    // operator-set-but-lost.
     persist_or_log!(
-        crate::store::atomic_write(&meta_path, content.as_bytes()),
+        crate::store::with_json_state_or_create::<Value, _, _, _>(
+            &meta_path,
+            || json!({}),
+            |meta| {
+                meta[key] = value;
+            },
+        ),
         "save_metadata"
     );
 }
 
-/// Persist multiple metadata key/value pairs in a single atomic write.
-/// Avoids the race condition where two sequential `save_metadata` calls
-/// can interleave on Windows (the second read-modify-write reads stale data).
+/// Persist multiple metadata key/value pairs in a single locked read-modify-write.
+/// #1886 C2: the flock spans the whole load→modify→write (not just the write), so
+/// concurrent `save_metadata`/`save_metadata_batch` on the same instance never read
+/// stale data and lose each other's update (the prior comment's interleave race).
 pub fn save_metadata_batch(home: &Path, instance_name: &str, entries: &[(&str, Value)]) {
     let meta_dir = home.join("metadata");
     std::fs::create_dir_all(&meta_dir).ok();
     let meta_path = metadata_path_resolved(home, instance_name);
-    let mut meta: Value = std::fs::read_to_string(&meta_path)
-        .map(|c| serde_json::from_str(&c).unwrap_or(json!({})))
-        .unwrap_or(json!({}));
-    for (key, value) in entries {
-        meta[*key] = value.clone();
-    }
-    let content = serde_json::to_string_pretty(&meta).unwrap_or_default();
-    // M1: atomic write with fsync. #1647: log on failure — see save_metadata.
+    // #1647: log on failure — see save_metadata.
     persist_or_log!(
-        crate::store::atomic_write(&meta_path, content.as_bytes()),
+        crate::store::with_json_state_or_create::<Value, _, _, _>(
+            &meta_path,
+            || json!({}),
+            |meta| {
+                for (key, value) in entries {
+                    meta[*key] = value.clone();
+                }
+            },
+        ),
         "save_metadata_batch"
     );
 }
@@ -460,6 +466,75 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    #[test]
+    fn concurrent_save_metadata_no_lost_update_1886() {
+        // #1886 C2 §3.9: N threads each set a DISTINCT key on the SAME instance's
+        // metadata. The locked RMW keeps every field; the prior unlocked
+        // read+atomic_write would lose updates under contention.
+        let home = tmp_home("concurrent-save-meta-1886");
+        const N: usize = 12;
+        let handles: Vec<_> = (0..N)
+            .map(|i| {
+                let home = home.clone();
+                std::thread::spawn(move || {
+                    save_metadata(&home, "agent-x", &format!("key-{i}"), json!(i));
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        let content = std::fs::read_to_string(metadata_path_resolved(&home, "agent-x")).unwrap();
+        let meta: Value = serde_json::from_str(&content).unwrap();
+        for i in 0..N {
+            assert_eq!(
+                meta.get(format!("key-{i}")).and_then(|v| v.as_u64()),
+                Some(i as u64),
+                "every concurrent field write must survive"
+            );
+        }
+    }
+
+    #[test]
+    fn concurrent_save_metadata_clear_vs_set_both_survive_1886() {
+        // #1886 C2 §3.9 (clear-vs-set): one writer clears `waiting_on` while
+        // another sets a different field on the same instance — both updates
+        // survive and an untouched field is preserved (the F7 interleave race,
+        // now closed by the locked RMW).
+        let home = tmp_home("save-meta-clear-set-1886");
+        save_metadata_batch(
+            &home,
+            "agent-y",
+            &[
+                ("waiting_on", json!("reviewer")),
+                ("waiting_on_since", json!(1)),
+            ],
+        );
+        let h1 = {
+            let home = home.clone();
+            std::thread::spawn(move || save_metadata(&home, "agent-y", "waiting_on", json!(null)))
+        };
+        let h2 = {
+            let home = home.clone();
+            std::thread::spawn(move || save_metadata(&home, "agent-y", "extra", json!("set")))
+        };
+        h1.join().unwrap();
+        h2.join().unwrap();
+        let content = std::fs::read_to_string(metadata_path_resolved(&home, "agent-y")).unwrap();
+        let meta: Value = serde_json::from_str(&content).unwrap();
+        assert!(meta["waiting_on"].is_null(), "clear survived");
+        assert_eq!(
+            meta["extra"].as_str(),
+            Some("set"),
+            "concurrent set survived"
+        );
+        assert_eq!(
+            meta["waiting_on_since"].as_u64(),
+            Some(1),
+            "untouched field preserved"
+        );
     }
 
     /// #bughunt2: the last-resort delivery path must surface a dropped enqueue

--- a/src/channel/telegram/topic_registry.rs
+++ b/src/channel/telegram/topic_registry.rs
@@ -44,15 +44,30 @@ pub(crate) fn register_topic(
     topic_id: i32,
     instance_name: &str,
 ) -> anyhow::Result<()> {
-    let mut reg = load_topic_registry(home);
-    reg.insert(topic_id, instance_name.to_string());
-    save_topic_registry(home, &reg)
+    // #1886 C1: locked read-modify-write — the flock spans load→insert→save so
+    // two concurrent registrations (e.g. team-spawn registering N members) can't
+    // each read the same map and clobber the other's insert. Operate on the
+    // on-disk `topic_id-string → name` form (matches save_topic_registry) so the
+    // round-trip is byte-identical to the prior load/save helpers.
+    crate::store::with_json_state_or_create::<HashMap<String, String>, _, _, _>(
+        &topic_registry_path(home),
+        HashMap::new,
+        |reg| {
+            reg.insert(topic_id.to_string(), instance_name.to_string());
+        },
+    )?;
+    Ok(())
 }
 
 pub(crate) fn unregister_topic(home: &Path, topic_id: i32) {
-    let mut reg = load_topic_registry(home);
-    reg.remove(&topic_id);
-    let _ = save_topic_registry(home, &reg);
+    // #1886 C1: same locked-RMW discipline as register_topic.
+    let _ = crate::store::with_json_state_or_create::<HashMap<String, String>, _, _, _>(
+        &topic_registry_path(home),
+        HashMap::new,
+        |reg| {
+            reg.remove(&topic_id.to_string());
+        },
+    );
 }
 
 /// Reverse-lookup a topic_id for an instance from `topics.json`.
@@ -226,6 +241,55 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    #[test]
+    fn concurrent_register_topic_no_lost_update_1886() {
+        // #1886 C1 §3.9: N threads each register a DISTINCT topic on the same
+        // topics.json. The locked RMW (flock spans load→insert→save) keeps
+        // every mapping; the prior unlocked load+save would clobber updates
+        // under contention.
+        let home = tmp_home("concurrent-register-1886");
+        const N: i32 = 12;
+        let handles: Vec<_> = (0..N)
+            .map(|i| {
+                let home = home.clone();
+                std::thread::spawn(move || {
+                    register_topic(&home, i, &format!("inst-{i}")).unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        let reg = load_topic_registry(&home);
+        assert_eq!(
+            reg.len(),
+            N as usize,
+            "every concurrent registration must survive"
+        );
+        for i in 0..N {
+            assert_eq!(
+                reg.get(&i).map(String::as_str),
+                Some(format!("inst-{i}").as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn register_unregister_rmw_preserves_other_entries_1886() {
+        // #1886 C1: register reloads the on-disk map under the lock and ADDS to
+        // it (not a blind overwrite); unregister removes one and leaves the rest.
+        let home = tmp_home("register-preserve-1886");
+        register_topic(&home, 1, "alpha").unwrap();
+        register_topic(&home, 2, "beta").unwrap();
+        let reg = load_topic_registry(&home);
+        assert_eq!(reg.get(&1).map(String::as_str), Some("alpha"));
+        assert_eq!(reg.get(&2).map(String::as_str), Some("beta"));
+        unregister_topic(&home, 1);
+        let reg = load_topic_registry(&home);
+        assert_eq!(reg.get(&1), None);
+        assert_eq!(reg.get(&2).map(String::as_str), Some("beta"));
     }
 
     #[test]


### PR DESCRIPTION
## What
Closes the two unlocked read-modify-write (RMW) durability bugs found in the persistence bug-hunt (#1886 C1+C2).

### C1 — `topic_registry.rs` `register_topic` / `unregister_topic` [MED-HIGH]
`load_topic_registry` → `insert`/`remove` → `save_topic_registry` held **no lock** across the read+write. Two concurrent registrations (team-spawn registering N members, or a spawn racing an error-path `unregister_topic`) each read the same map and the later `save` clobbered the other's insert → a lost topic↔instance mapping → that instance's telegram messages mis-/un-routed.

**Fix:** route both through `store::with_json_state_or_create`, so the flock spans the whole `load→mutate→save` — exactly the pattern `fleet/persist.rs::mutate_fleet_yaml` already uses for `fleet.yaml` (the asymmetry that flagged this). Operates on the on-disk `topic_id-string → name` form so the round-trip is byte-identical to the prior helpers.

### C2 — `agent_ops.rs` `save_metadata` / `save_metadata_batch` [MED]
Same unlocked `read_to_string` + `atomic_write` → concurrent `set_*` on one instance lost a field (the F7 interleave the batch comment admitted).

**Fix:** route through `with_json_state_or_create` (locked RMW; same atomic temp+rename write and same fail-open-on-missing/corrupt read semantics as before).

## Verification
- Lock spans the **whole RMW** (load reloads inside the flock), not just the write.
- Uncontended single writes unaffected (cheap flock).
- No deadlock: closures are pure map mutations (no self-IPC under the lock); no caller already holds these per-store locks. `flock_depth_invariant` + `self_ipc_guard_always_on_invariant_1492` stay green.
- §3.9 tests: N concurrent `register_topic` / `save_metadata` on the same store → every update survives; clear-vs-set on the same instance → both survive + untouched field preserved; register/unregister preserve sibling entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)