### PR TITLE
chore(#1888): instrument-only tracing for ci-handoff re-nudge (zero behavior)

### DIFF
--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -113,6 +113,34 @@ pub(crate) fn scan_and_emit_with<F>(
             // target reads the handoff (drops from the unread scan → reaped). This
             // also covers the orchestrator-as-`next_after_ci` case below, where
             // there is no lead to escalate to.
+            // #1888 instrument-only (zero-behavior): record WHY this UNREAD handoff
+            // did / didn't get re-nudged this tick, so production can confirm the
+            // #1860 read-state-coupling RCA. A handoff that was already marked read
+            // never enters this loop at all (`unread_of_kind` filters it) — that
+            // case is captured by the `#1888-ciready-read` trace at the drain site.
+            // Read-only: these locals don't feed the byte-identical gate below.
+            {
+                let busy = crate::snapshot::agent_is_busy(home, target);
+                let renudge_due = last_renudged.get(&key).is_none_or(|prev| {
+                    now.signed_duration_since(*prev).num_minutes() >= RENUDGE_INTERVAL_MINS
+                });
+                // info!-level so it lands in the production daemon.log (default
+                // filter is `agend_terminal=info`); bounded — at most once per
+                // UNREAD ci-handoff per tick, and a handoff stops being scanned the
+                // moment it's read.
+                tracing::info!(
+                    tag = "#1888-renudge-decision",
+                    agent = %target,
+                    correlation = %corr,
+                    unread_found = true,
+                    age_min,
+                    agent_is_busy = busy,
+                    renudge_due,
+                    age_ok = age_min >= RENUDGE_AFTER_MINS,
+                    will_fire = age_min >= RENUDGE_AFTER_MINS && !busy && renudge_due,
+                    "ci-handoff re-nudge decision"
+                );
+            }
             if age_min >= RENUDGE_AFTER_MINS && !crate::snapshot::agent_is_busy(home, target) {
                 let due = last_renudged.get(&key).is_none_or(|prev| {
                     now.signed_duration_since(*prev).num_minutes() >= RENUDGE_INTERVAL_MINS
@@ -259,6 +287,54 @@ mod tests {
             nudged.push(t.to_string())
         });
         nudged
+    }
+
+    /// §3.9 #1888 (instrument-only): the re-nudge decision is OBSERVABLE (the
+    /// `#1888-renudge-decision` trace fires for an unread handoff) while the
+    /// surrounding behavior is byte-identical (an unread, past-threshold, idle
+    /// handoff still re-nudges).
+    #[test]
+    #[tracing_test::traced_test]
+    fn renudge_decision_is_instrumented_1888() {
+        let home = tmp_home("1888-renudge-trace");
+        write_fleet(&home);
+        seed_handoff(&home, "reviewer", "owner/repo@br", 5, false); // unread, 5min old
+        seed_snapshot(&home, "reviewer", "idle"); // not busy
+        let nudged = run_watchdog(
+            &home,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
+        assert!(
+            logs_contain("#1888-renudge-decision"),
+            "the re-nudge decision must be traced"
+        );
+        assert!(
+            nudged.iter().any(|t| t == "reviewer"),
+            "behavior unchanged: an unread idle past-threshold handoff still re-nudges"
+        );
+    }
+
+    /// §3.9 #1888 (instrument-only): a `ci-ready-for-action` handoff transitioning
+    /// to read on a drain is OBSERVABLE (the `#1888-ciready-read` trace fires)
+    /// while the drain behavior is byte-identical (the message is returned + read).
+    #[test]
+    #[tracing_test::traced_test]
+    fn ciready_read_on_drain_is_instrumented_1888() {
+        let home = tmp_home("1888-ciready-read-trace");
+        seed_handoff(&home, "reviewer", "owner/repo@br", 1, false); // unread ci-ready
+        let drained = crate::inbox::drain(&home, "reviewer");
+        assert!(
+            drained
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("ci-ready-for-action") && m.read_at.is_some()),
+            "behavior unchanged: drain returns the handoff, now marked read"
+        );
+        assert!(
+            logs_contain("#1888-ciready-read"),
+            "the ci-ready read-on-drain must be traced"
+        );
     }
 
     #[test]

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -303,6 +303,32 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
                 }
                 msg.read_at = Some(now.clone());
                 newly_read.push(true);
+                // #1888 instrument-only (zero-behavior): a `ci-ready-for-action`
+                // handoff just transitioned to read on this drain. After this, the
+                // handoff_timeout_watchdog's `unread_of_kind` scan can no longer
+                // find it → it can never re-nudge (the #1860 read-state-coupling
+                // RCA). This trace lets production confirm "read before acted" for a
+                // stranded PR. Read-only — the read-marking above is unchanged.
+                if msg.kind.as_deref() == Some("ci-ready-for-action") {
+                    let age_at_read_secs = chrono::DateTime::parse_from_rfc3339(&msg.timestamp)
+                        .ok()
+                        .map(|t| {
+                            chrono::Utc::now()
+                                .signed_duration_since(t.with_timezone(&chrono::Utc))
+                                .num_seconds()
+                        })
+                        .unwrap_or(-1);
+                    // info!-level so it lands in the production daemon.log (default
+                    // filter is `agend_terminal=info`); rare — only a
+                    // ci-ready-for-action message transitioning to read on a drain.
+                    tracing::info!(
+                        tag = "#1888-ciready-read",
+                        agent = %name,
+                        correlation = msg.correlation_id.as_deref().unwrap_or("<none>"),
+                        age_at_read_secs,
+                        "ci-ready-for-action handoff marked read on drain"
+                    );
+                }
             } else {
                 newly_read.push(false);
             }


### PR DESCRIPTION
Instrument-only follow-up to the #1860 ci-handoff re-nudge spike (lead-approved — **no behavior change**; confirm the RCA in production before the real fix).

## RCA recap
The re-nudge scans only **unread** `[ci-ready-for-action]` (`unread_of_kind` filters `read_at.is_none()`), but the inbox `drain` marks the handoff read on the first drain regardless of kind — after which the watchdog can never find it. Intermittency = whether the reviewer acted before the drain that read it.

## What this adds (two `info!` traces, zero behavior)
- **`tag=#1888-renudge-decision`** at the `handoff_timeout_watchdog` re-nudge gate: per (target, correlation) — `unread_found` / `age_min` / `agent_is_busy` / `renudge_due` / `age_ok` / `will_fire`. Bounded: ≤ once per **unread** ci-handoff per tick.
- **`tag=#1888-ciready-read`** at the inbox `drain` read-marking: when a `ci-ready-for-action` message transitions to read — `agent` / `correlation` / `age_at_read_secs`. Rare: only that kind, only on the read transition.

Together they show, for a stranded PR, whether the `[ci-ready]` was **read before it was acted on**, with the watchdog then finding nothing to re-nudge.

## Why `info!` and no custom `target:`
The production filter is `agend_terminal=info` (logging.rs:73). `debug!` would be **invisible in production** (and the test caught that a custom `target:"ci_handoff"` wouldn't match `agend_terminal=*` either — both would silently filter the instrument out). So: `info!`, default module-path target.

## Zero behavior
Both are read-only tracing statements; the re-nudge gate and the drain read-marking are **byte-identical** (the trace locals don't feed control flow).

## §3.9
- `renudge_decision_is_instrumented_1888` + `ciready_read_on_drain_is_instrumented_1888` (`tracing_test::traced_test`): assert the traces fire AND the surrounding behavior is unchanged (the unread idle handoff still re-nudges; the drain still returns the handoff marked read). All existing `handoff_timeout_watchdog` tests still pass.

## Follow-up (after production confirms)
The real fix decouples re-nudge from the inbox read-state — a correlation-tracked sidecar + clear-on-resolution (same shape as #1866 dispatch_idle).

Local CI-parity preflight green (`fmt`/`clippy --all-targets --features tray -D warnings`/`cargo test --tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)