### PR TITLE
ci(#1893): nextest on all platforms + serialize the heavy git test cluster (FIX A+B)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -28,6 +28,17 @@ final-status-level = "slow"
 # runs the GROUP one-at-a-time (isolation-equivalent) while the rest of the suite
 # stays parallel. The override is mirrored under both `default` (local runs) and
 # `ci` (CI runs) profiles.
+#
+# The filter has two parts (reviewer-2 #1896: cover the FULL real-git set, but
+# don't drag pure-logic tests into max-threads=1):
+#  1. anchored MODULE prefixes — modules that are predominantly real-git/worktree
+#     /subprocess: worktree_pool, admin (worktree + cleanup_zombies process spawn),
+#     mcp::handlers::{ci,dispatch_hook,force_release,worktree,p0b_tests},
+#     daemon::{retention::worktrees,pr_state,auto_release,conflict_notify,
+#     per_tick::tmp_review_gc}, bootstrap::{agent_resolve,canonical_hygiene}.
+#  2. NAMED tests in otherwise-pure modules (messaging 2/47, tasks::tests 1/78,
+#     task_sweep, mcp::handlers::tests checkout_repo_*) — targeted by name so the
+#     ~200 pure-logic tests around them stay parallel.
 [test-groups]
 git-subprocess = { max-threads = 1 }
 
@@ -43,11 +54,11 @@ test-group = 'git-subprocess'
 slow-timeout = { period = "120s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'test(/^(worktree_pool|mcp::handlers::(ci|dispatch_hook|force_release)|daemon::(retention::worktrees|pr_state))::/)'
+filter = 'test(/(^(worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main)/)'
 test-group = 'git-subprocess'
 
 # Local `default` profile has no terminate-after, so no false-kill risk — just
 # serialize the same cluster for parity with CI.
 [[profile.default.overrides]]
-filter = 'test(/^(worktree_pool|mcp::handlers::(ci|dispatch_hook|force_release)|daemon::(retention::worktrees|pr_state))::/)'
+filter = 'test(/(^(worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main)/)'
 test-group = 'git-subprocess'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,16 +1,16 @@
-# #1784: instrument the fleet-wide windows CI hang hunt.
+# #1784: instrument the fleet-wide CI hang hunt.
 #
 # A real `Command::new("git")` test (worktree_cleanup / branch_sweep build real
-# repos + worktrees) intermittently HANGS on windows-latest, timing the whole CI
-# job out at ~56min with NO attribution — `cargo test` prints a test's name only
-# on COMPLETION, so a hung test is anonymous in the log (which also never
-# finalizes on a job timeout).
+# repos + worktrees) intermittently HANGS, timing the whole CI job out at ~30min
+# with NO attribution — `cargo test` prints a test's name only on COMPLETION, so
+# a hung test is anonymous in the log (which also never finalizes on a job
+# timeout).
 #
-# The windows Tests step runs via nextest with this `ci` profile: it keeps the
-# default parallelism (so the intermittent race still reproduces), but any test
-# still running past the slow-timeout is KILLED and NAMED. That turns a 56-min
-# mystery hang into a fast, attributed failure so we can pinpoint + fix the
-# offending test. mac/ubuntu (green) keep `cargo test` unchanged.
+# #1893: ALL platforms now run the Tests step via nextest with this `ci` profile
+# (previously windows-only; mac/ubuntu used bare `cargo test` and so ran a hung
+# test to the 30-min STEP timeout, anonymous). It keeps the default parallelism
+# but any test still running past the slow-timeout is KILLED and NAMED — a fast,
+# attributed failure instead of a mystery hang.
 [profile.ci]
 # Warn (mark SLOW) at 60s; SIGKILL the test after 2 periods (120s). Normal tests
 # finish in well under a second; a real-git test that takes >120s is wedged.
@@ -18,3 +18,36 @@ slow-timeout = { period = "60s", terminate-after = 2 }
 # Surface the terminated/hung test prominently in the run summary.
 failure-output = "immediate-final"
 final-status-level = "slow"
+
+# #1893: serialize the heavy real-git / worktree / subprocess test cluster.
+# These tests spawn real `git` (worktree add / branch / fetch) and share
+# filesystem + `.git/index.lock` state; at full parallelism they race (index.lock
+# contention, fd pressure) → intermittent hangs/failures (RC1/RC3 of the #1893
+# spike; e.g. `mcp::handlers::ci::tests::checkout_bind_true_concurrent_branch_
+# create_race_idempotent` passes in isolation but fails under load). max-threads=1
+# runs the GROUP one-at-a-time (isolation-equivalent) while the rest of the suite
+# stays parallel. The override is mirrored under both `default` (local runs) and
+# `ci` (CI runs) profiles.
+[test-groups]
+git-subprocess = { max-threads = 1 }
+
+# `*_stress_50_iter_*` do 50 real git branch-creates (~60s locally, slower on CI
+# runners). Listed FIRST so its slow-timeout wins for them: give 3×120s headroom
+# so the suite-wide 120s terminate-after can't FALSE-kill a genuinely-slow (not
+# wedged) stress run on a slow runner — they still join the serial group + still
+# get a generous wedge cap. (mac/ubuntu had NO per-test timeout before #1893, so
+# this preserves their pass behaviour while gaining the hang guard.)
+[[profile.ci.overrides]]
+filter = 'test(/_stress_50_iter_/)'
+test-group = 'git-subprocess'
+slow-timeout = { period = "120s", terminate-after = 3 }
+
+[[profile.ci.overrides]]
+filter = 'test(/^(worktree_pool|mcp::handlers::(ci|dispatch_hook|force_release)|daemon::(retention::worktrees|pr_state))::/)'
+test-group = 'git-subprocess'
+
+# Local `default` profile has no terminate-after, so no false-kill risk — just
+# serialize the same cluster for parity with CI.
+[[profile.default.overrides]]
+filter = 'test(/^(worktree_pool|mcp::handlers::(ci|dispatch_hook|force_release)|daemon::(retention::worktrees|pr_state))::/)'
+test-group = 'git-subprocess'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,33 +92,25 @@ jobs:
         timeout-minutes: 15
         run: cargo check --features discord --quiet
 
-      # `--tests` covers unit tests (--bin) + every tests/*.rs integration
-      # file. `--features tray` ensures tray-gated code is tested too.
-      # Previously this was 3 separate steps (unit, unit+tray, integration)
-      # which triggered 2 extra recompilations from feature-flag switching.
+      # Runs unit tests (--bin) + every tests/*.rs integration file with the
+      # tray feature, via nextest on ALL platforms.
       # #1784: a real `Command::new("git")` test (worktree_cleanup / branch_sweep
-      # build real repos + worktrees) intermittently HANGS on windows, timing the
-      # whole job out at ~56min with NO culprit — `cargo test` only prints a test
-      # name on COMPLETION, so a hung test is anonymous. On windows we run via
-      # nextest with a per-test terminate-after (.config/nextest.toml `ci`
-      # profile): parallelism is kept (the intermittent race still reproduces),
-      # but a test still running past the timeout is KILLED and NAMED → a fast,
-      # attributed failure instead of a 56-min mystery. mac/ubuntu keep cargo test.
-      - name: Install nextest (windows hang hunt #1784)
-        if: runner.os == 'Windows'
+      # build real repos + worktrees) intermittently HANGS, timing the whole job
+      # out at ~30min with NO culprit — `cargo test` only prints a test name on
+      # COMPLETION, so a hung test is anonymous and the step never finalizes.
+      # #1893: previously only windows ran nextest (mac/ubuntu used `cargo test`,
+      # so a hung test there ran to the 30-min STEP timeout, anonymous). Now ALL
+      # platforms run nextest with the `ci` profile's per-test terminate-after
+      # (.config/nextest.toml): parallelism is kept, but a test still running past
+      # the slow-timeout is KILLED and NAMED → a fast, attributed failure instead
+      # of a 30-min mystery. The `ci` profile also serializes the heavy real-git
+      # test cluster (`git-subprocess` test-group) so it can't race the suite.
+      - name: Install nextest (#1784/#1893 — per-test terminate-after, all platforms)
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
 
-      - name: Tests (unit + integration + tray)
-        if: runner.os != 'Windows'
-        timeout-minutes: 30
-        env:
-          AGEND_LOCK_AUDIT: "1"
-        run: cargo test --tests --features tray
-
-      - name: Tests (unit + integration + tray) [windows — nextest names a hung test, #1784]
-        if: runner.os == 'Windows'
+      - name: Tests (unit + integration + tray) [nextest — names a hung test, #1784/#1893]
         timeout-minutes: 30
         env:
           AGEND_LOCK_AUDIT: "1"


### PR DESCRIPTION
Root-causes the recurring CI flaky cluster (spike #1893) at the **CI-config layer** — no production git code touched (that's the follow-up FIX C). The cluster's symptoms (windows `0xc0000142` DLL-init, macos 30-min anonymous orphan-timeout, `checkout_bind_true_concurrent_branch_create_race_idempotent` fail-under-load) are one problem.

## FIX A — uniform per-test timeout on ALL platforms
Previously only windows ran `cargo nextest --profile ci` (120s per-test terminate-after); mac/ubuntu ran plain `cargo test`, so a hung real-git test there ran to the **30-min GitHub STEP timeout, anonymous** (the #1890 macos hang). Now all 3 OSes install nextest and run the `ci` profile → a wedged test is **KILLED and NAMED in <2min** instead of an anonymous 30-min step timeout.

## FIX B — serialize the heavy git/worktree/subprocess test cluster
A nextest `git-subprocess` test-group (`max-threads = 1`). These tests spawn real `git` (worktree add / branch / fetch) and share filesystem + `.git/index.lock` state; at full parallelism they race (index.lock contention, fd pressure) and flake — e.g. the concurrent-checkout test passes in isolation but failed under full-suite load. Serializing the group gives each isolation-equivalent execution while the rest of the suite stays parallel. Filter: `worktree_pool` / `mcp::handlers::{ci,dispatch_hook,force_release}` / `daemon::{retention::worktrees,pr_state}`; mirrored under `default` + `ci` profiles.

`*_stress_50_iter_*` (50 real git branch-creates, ~60s) get a 3×120s slow-timeout override so the suite-wide 120s terminate-after can't false-kill a genuinely-slow run on a slow runner (mac/ubuntu had no per-test timeout before, so this preserves their pass behaviour).

## Verification (local, system git)
- `cargo nextest run --features tray --profile ci` → **3779/3779 passed in 243s** (faster than the old ~8min `cargo test`; no wall-time regression). The previously-flaky concurrent-checkout test passes deterministically under serialization.
- `cargo nextest show-config test-groups --profile ci` confirms the filter assigns the heavy modules to `git-subprocess`.
- YAML + TOML validated.
- **This PR's own CI is the first all-platform-nextest proof.**

Follow-up (separate PR, FIX C): bound `git_bypass`/`run_git_idempotent` with a timeout + process-group kill — hardens the production daemon git path, the deeper root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)