### PR TITLE
fix(git): bound the remaining 18 raw daemon git sites (#1899 FIX C2)

### DIFF
--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -25,11 +25,9 @@ pub enum BranchAction {
 
 /// List local branches that are NOT checked out in any worktree.
 fn worktree_branches(repo: &Path) -> std::collections::HashSet<String> {
-    let output = std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(repo)
-        .output();
+    // #1899: bounded via git_bypass (LOCAL 60s) — a stuck local git returns Err
+    // instead of hanging; the empty-set fallback is unchanged.
+    let output = crate::git_helpers::git_bypass(repo, &["worktree", "list", "--porcelain"]);
     let mut branches = std::collections::HashSet::new();
     if let Ok(out) = output {
         let text = String::from_utf8_lossy(&out.stdout);
@@ -44,11 +42,8 @@ fn worktree_branches(repo: &Path) -> std::collections::HashSet<String> {
 
 /// List all local branch names.
 fn local_branches(repo: &Path) -> Vec<String> {
-    let output = std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["branch", "--format=%(refname:short)"])
-        .current_dir(repo)
-        .output();
+    // #1899: bounded via git_bypass (LOCAL 60s).
+    let output = crate::git_helpers::git_bypass(repo, &["branch", "--format=%(refname:short)"]);
     match output {
         Ok(out) => String::from_utf8_lossy(&out.stdout)
             .lines()
@@ -129,11 +124,9 @@ pub fn execute_cleanup(repo: &Path, checks: &[BranchCheck], dry_run: bool) -> (u
                     println!("{msg}");
                     log_lines.push(msg);
                 } else {
-                    let result = std::process::Command::new("git")
-                        .env("AGEND_GIT_BYPASS", "1")
-                        .args(["branch", "-d", &check.branch])
-                        .current_dir(repo)
-                        .output();
+                    // #1899: bounded via git_bypass (LOCAL 60s).
+                    let result =
+                        crate::git_helpers::git_bypass(repo, &["branch", "-d", &check.branch]);
                     match result {
                         Ok(out) if out.status.success() => {
                             let msg = format!("deleted: {} (PR #{})", check.branch, pr_number);

--- a/src/bootstrap/canonical_hygiene.rs
+++ b/src/bootstrap/canonical_hygiene.rs
@@ -114,15 +114,9 @@ pub(crate) fn apply_to_canonical(canonical: &std::path::Path) {
     match decide_canonical_action(&head_state, working_tree_clean) {
         CanonicalAction::NoOp => {}
         CanonicalAction::SwitchToDefault => {
-            let switch_result = std::process::Command::new("git")
-                .args([
-                    "-C",
-                    &canonical.display().to_string(),
-                    "switch",
-                    DEFAULT_BRANCH,
-                ])
-                .env("AGEND_GIT_BYPASS", "1")
-                .output();
+            // #1899: bounded via git_bypass (current_dir == `-C`, LOCAL 60s).
+            let switch_result =
+                crate::git_helpers::git_bypass(canonical, &["switch", DEFAULT_BRANCH]);
             match switch_result {
                 Ok(out) if out.status.success() => {
                     tracing::info!(
@@ -171,15 +165,9 @@ fn apply_stash_and_switch(canonical: &std::path::Path) {
             emit_dirty_detached_warning(canonical);
         }
         Ok(()) => {
-            let switch_result = std::process::Command::new("git")
-                .args([
-                    "-C",
-                    &canonical.display().to_string(),
-                    "switch",
-                    DEFAULT_BRANCH,
-                ])
-                .env("AGEND_GIT_BYPASS", "1")
-                .output();
+            // #1899: bounded via git_bypass (current_dir == `-C`, LOCAL 60s).
+            let switch_result =
+                crate::git_helpers::git_bypass(canonical, &["switch", DEFAULT_BRANCH]);
             match switch_result {
                 Ok(out) if out.status.success() => {
                     tracing::info!(
@@ -231,22 +219,13 @@ fn emit_dirty_detached_warning(canonical: &std::path::Path) {
 /// untracked files so any reviewer-left dirt is captured even when
 /// it hasn't been `git add`-ed.
 fn git_stash_push(canonical: &std::path::Path, message: &str) -> Result<(), String> {
-    let out = match std::process::Command::new("git")
-        .args([
-            "-C",
-            &canonical.display().to_string(),
-            "stash",
-            "push",
-            "-u",
-            "-m",
-            message,
-        ])
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-    {
-        Ok(o) => o,
-        Err(e) => return Err(format!("spawn failed: {e}")),
-    };
+    // #1899: bounded via git_bypass (current_dir == `-C`, LOCAL 60s). `stash
+    // push` is a LOCAL stash op (NOT `git push` / network).
+    let out =
+        match crate::git_helpers::git_bypass(canonical, &["stash", "push", "-u", "-m", message]) {
+            Ok(o) => o,
+            Err(e) => return Err(format!("spawn failed: {e}")),
+        };
     if out.status.success() {
         Ok(())
     } else {
@@ -275,10 +254,8 @@ fn notify_operator_of_auto_stash(canonical: &std::path::Path, stash_message: &st
 /// bypass the shim's restrictions on boot), capture trimmed stdout
 /// on success. Returns `None` on spawn failure or non-zero exit.
 fn git_capture(repo: &std::path::Path, args: &[&str]) -> Option<String> {
-    let mut cmd = std::process::Command::new("git");
-    cmd.arg("-C").arg(repo).args(args);
-    cmd.env("AGEND_GIT_BYPASS", "1");
-    let out = match cmd.output() {
+    // #1899: bounded via git_bypass (current_dir == `-C`, LOCAL 60s).
+    let out = match crate::git_helpers::git_bypass(repo, args) {
         Ok(o) => o,
         Err(e) => {
             tracing::debug!(

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -592,12 +592,8 @@ fn is_worktree_clean(worktree: &Path) -> bool {
     if !worktree.is_dir() {
         return false;
     }
-    let out = match std::process::Command::new("git")
-        .args(["status", "--porcelain"])
-        .current_dir(worktree)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-    {
+    // #1899: bounded via git_bypass (LOCAL 60s) — a stuck git → false fallback.
+    let out = match crate::git_helpers::git_bypass(worktree, &["status", "--porcelain"]) {
         Ok(o) => o,
         Err(_) => return false,
     };

--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -292,11 +292,8 @@ pub(crate) fn register_subscriber() {
 /// trimmed of the 3-char prefix (`XY ` → start of path). Empty Vec
 /// on git failure or no conflicts.
 pub(crate) fn discover_conflicted_files(worktree: &Path) -> Vec<String> {
-    let output = std::process::Command::new("git")
-        .args(["status", "--porcelain"])
-        .current_dir(worktree)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output();
+    // #1899: bounded via git_bypass (LOCAL 60s) — a stuck git → empty fallback.
+    let output = crate::git_helpers::git_bypass(worktree, &["status", "--porcelain"]);
     let Ok(out) = output else {
         return Vec::new();
     };

--- a/src/daemon/per_tick/tmp_review_gc.rs
+++ b/src/daemon/per_tick/tmp_review_gc.rs
@@ -188,25 +188,23 @@ fn gc_stale_tmp_review_worktrees(
 /// otherwise just `remove_dir_all`. Returns true on success.
 fn remove_tmp_worktree(path: &Path) -> bool {
     if let Some(parent_repo) = worktree_parent_repo(path) {
-        let removed = std::process::Command::new("git")
-            .env("AGEND_GIT_BYPASS", "1")
-            .current_dir(&parent_repo)
-            .args(["worktree", "remove", "--force"])
-            .arg(path)
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
+        // #1899: bounded via git_bypass (LOCAL 60s) — a stuck `worktree remove`
+        // → not-removed (false), then the remove_dir_all fallback below.
+        let path_str = path.display().to_string();
+        let removed = crate::git_helpers::git_bypass(
+            &parent_repo,
+            &["worktree", "remove", "--force", &path_str],
+        )
+        .map(|o| o.status.success())
+        .unwrap_or(false);
         if removed {
             return true;
         }
         // Fallback: remove the dir directly, then prune so the source repo
         // doesn't keep a dangling worktree registration.
         let rm = std::fs::remove_dir_all(path).is_ok();
-        let _ = std::process::Command::new("git")
-            .env("AGEND_GIT_BYPASS", "1")
-            .current_dir(&parent_repo)
-            .args(["worktree", "prune"])
-            .status();
+        // #1899: bounded via git_bypass (LOCAL 60s) — best-effort prune.
+        let _ = crate::git_helpers::git_bypass(&parent_repo, &["worktree", "prune"]);
         return rm;
     }
     std::fs::remove_dir_all(path).is_ok()

--- a/src/daemon/retention/worktrees.rs
+++ b/src/daemon/retention/worktrees.rs
@@ -296,11 +296,8 @@ pub(crate) fn maybe_remove_candidate(
             // Best-effort: prune failure is non-fatal — the rename succeeded,
             // so the active worktree set no longer includes this path; a
             // stale `git worktree list` entry self-corrects on next lookup.
-            let prune = std::process::Command::new("git")
-                .args(["worktree", "prune"])
-                .current_dir(&repo)
-                .env("AGEND_GIT_BYPASS", "1")
-                .output();
+            // #1899: bounded via git_bypass (LOCAL 60s) — best-effort prune.
+            let prune = crate::git_helpers::git_bypass(&repo, &["worktree", "prune"]);
             if let Err(e) = prune {
                 tracing::warn!(error = %e, "git worktree prune failed (non-fatal)");
             }

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -68,7 +68,13 @@ pub(crate) fn git_bypass_timeout(
 /// same `Command` minus the binary). Process-group isolation is MANDATORY:
 /// `kill_process_tree` resolves the pgid via `getpgid`, so without isolation the
 /// kill would resolve to the DAEMON's group and kill the daemon.
-fn spawn_group_bounded(
+///
+/// #1899: `pub(crate)` so NON-bypass prod git sites (ones that deliberately do
+/// NOT set `AGEND_GIT_BYPASS`) can pass their own pre-built `Command` to get the
+/// same bound + safe process-group kill while preserving their env/bypass
+/// behaviour — instead of being forced through [`git_bypass_timeout`] (which
+/// always sets the bypass env).
+pub(crate) fn spawn_group_bounded(
     mut cmd: std::process::Command,
     label: &str,
     timeout: Duration,
@@ -187,6 +193,26 @@ mod tests {
         let out = spawn_group_bounded(cmd, "true", Duration::from_secs(10))
             .expect("fast command must return Ok");
         assert!(out.status.success(), "fast command exits 0 with Output");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn spawn_group_bounded_preserves_caller_env_no_bypass_1899() {
+        // #1899: NON-bypass prod sites (e.g. ci/mod's cleanup worktree-remove)
+        // pass a BARE Command. spawn_group_bounded must NOT inject
+        // AGEND_GIT_BYPASS — it only adds the bound + process-group kill, leaving
+        // the caller's env/bypass behaviour intact (the bypass env is set ONLY by
+        // git_bypass_timeout, never here).
+        let mut cmd = std::process::Command::new("sh");
+        cmd.arg("-c")
+            .arg("printf 'bypass=[%s]' \"$AGEND_GIT_BYPASS\"");
+        let out = spawn_group_bounded(cmd, "sh env-probe", Duration::from_secs(10))
+            .expect("fast command must return Ok");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert_eq!(
+            stdout, "bypass=[]",
+            "spawn_group_bounded must not inject AGEND_GIT_BYPASS (caller env preserved)"
+        );
     }
 
     #[test]

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -267,11 +267,11 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         error = %e,
                         "bind_full failed after worktree add — rolling back worktree"
                     );
-                    let _ = std::process::Command::new("git")
-                        .args(["worktree", "remove", "--force", &worktree_path_str])
-                        .env("AGEND_GIT_BYPASS", "1")
-                        .current_dir(Path::new(&source_path))
-                        .output();
+                    // #1899: bounded via git_bypass (LOCAL 60s) — best-effort rollback.
+                    let _ = crate::git_helpers::git_bypass(
+                        Path::new(&source_path),
+                        &["worktree", "remove", "--force", &worktree_path_str],
+                    );
                     return json!({
                         "error": format!("bind_full failed, worktree rolled back: {e}"),
                         "code": "bind_rollback",
@@ -466,10 +466,19 @@ pub(super) fn handle_release_repo(args: &Value) -> Value {
             p.parent()?.parent()?.parent().map(|pp| pp.to_path_buf())
         });
 
-    match std::process::Command::new("git")
-        .args(["worktree", "remove", "--force", &path_str])
-        .output()
-    {
+    // #1899: bounded via spawn_group_bounded with a BARE Command — this site
+    // deliberately does NOT set AGEND_GIT_BYPASS and does NOT set current_dir
+    // (runs from the daemon cwd, best-effort). Preserve that exact behaviour;
+    // spawn_group_bounded only adds the LOCAL timeout + safe process-group kill,
+    // without forcing the bypass env. (Whether it SHOULD bypass like ci/mod:270
+    // is a separate behaviour question, out of scope for this timeout PR.)
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(["worktree", "remove", "--force", &path_str]);
+    match crate::git_helpers::spawn_group_bounded(
+        cmd,
+        "git worktree remove (cleanup)",
+        crate::git_helpers::LOCAL_GIT_TIMEOUT,
+    ) {
         Ok(o) if o.status.success() => json!({"path": path}),
         Ok(o) => {
             let _ = std::fs::remove_dir_all(&canonical);

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -497,16 +497,16 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
                 error = %e,
                 "dispatch auto-bind bind_full failed — rolling back worktree"
             );
-            let _ = std::process::Command::new("git")
-                .args([
+            // #1899: bounded via git_bypass (LOCAL 60s) — best-effort rollback.
+            let _ = crate::git_helpers::git_bypass(
+                &source_repo,
+                &[
                     "worktree",
                     "remove",
                     "--force",
                     &lease.path.display().to_string(),
-                ])
-                .env("AGEND_GIT_BYPASS", "1")
-                .current_dir(&source_repo)
-                .output();
+                ],
+            );
             // #1324: surface rollback as dispatch error instead of silent success
             return Err(DispatchError {
                 message: format!(

--- a/src/mcp/handlers/force_release/gc.rs
+++ b/src/mcp/handlers/force_release/gc.rs
@@ -77,11 +77,11 @@ pub(super) fn prune_git_metadata_for_agent(
                 continue;
             }
             // Found a matching metadata entry — prune it.
-            let removed = std::process::Command::new("git")
-                .current_dir(&repo)
-                .args(["worktree", "remove", "--force", &entry.path])
-                .env("AGEND_GIT_BYPASS", "1")
-                .output();
+            // #1899: bounded via git_bypass (LOCAL 60s).
+            let removed = crate::git_helpers::git_bypass(
+                &repo,
+                &["worktree", "remove", "--force", &entry.path],
+            );
             let pruned = match removed {
                 Ok(o) if o.status.success() => true,
                 Ok(o) => {
@@ -96,11 +96,8 @@ pub(super) fn prune_git_metadata_for_agent(
                         stderr = %String::from_utf8_lossy(&o.stderr).trim(),
                         "#826 L2: git worktree remove failed; falling back to prune"
                     );
-                    let prune = std::process::Command::new("git")
-                        .current_dir(&repo)
-                        .args(["worktree", "prune"])
-                        .env("AGEND_GIT_BYPASS", "1")
-                        .output();
+                    // #1899: bounded via git_bypass (LOCAL 60s).
+                    let prune = crate::git_helpers::git_bypass(&repo, &["worktree", "prune"]);
                     matches!(prune, Ok(p) if p.status.success())
                 }
                 Err(e) => {
@@ -142,11 +139,8 @@ pub(super) fn prune_git_metadata_for_agent(
 /// from the source repo, so we run it with the shim bypass set
 /// (mirrors the `release_full` precedent at src/worktree_pool.rs:311).
 fn list_worktrees_bypass_shim(repo_root: &Path) -> Vec<crate::worktree_cleanup::WorktreeEntry> {
-    let output = std::process::Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(repo_root)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output();
+    // #1899: bounded via git_bypass (LOCAL 60s).
+    let output = crate::git_helpers::git_bypass(repo_root, &["worktree", "list", "--porcelain"]);
     let output = match output {
         Ok(o) if o.status.success() => o,
         _ => return Vec::new(),


### PR DESCRIPTION
Completes the prod-git hardening (the last block) — the independent raw `Command::new("git")` prod sites that the FIX C `git_bypass`-focused enumeration missed. **No CI-config; prod git path.**

## Classification (lead-approved): all 18 are LOCAL (60s)
The "push" is `git stash push` (local stash), **NOT** network `git push` — grep confirms no real `push`/`fetch`/`clone` in scope (fetch was handled in FIX C).

### 17 BYPASS sites → `git_bypass` (LOCAL 60s)
`git_bypass` already sets `AGEND_GIT_BYPASS` + bounds; the `-C <repo>` sites become `current_dir` (equivalent):
- **admin**: `worktree list` / `branch --format` / `branch -d`
- **canonical_hygiene**: 2× `switch` / `stash push -u` / `git_capture(-C)` helper
- **auto_release**: `status`  · **conflict_notify**: `status`
- **tmp_review_gc**: `worktree remove` / `worktree prune` (`.status()` → `.map(o.status.success())`)
- **retention::worktrees**: `worktree prune`
- **ci::mod** + **dispatch_hook**: worktree-remove rollback
- **force_release::gc**: `worktree remove` / `prune` / `list`

### 1 NON-BYPASS site → `spawn_group_bounded` (now `pub(crate)`) with a BARE Command
`ci/mod.rs` cleanup `worktree remove` deliberately sets **neither** `AGEND_GIT_BYPASS` **nor** `current_dir`. Preserve that exact behaviour — only add the bound + safe process-group kill, **not** the bypass env. (Whether it *should* bypass like the sibling at `ci/mod:270` is a separate behaviour question — the lead recorded it as a low-priority follow-up; out of scope here.)

## Result
A stuck git at any site returns a clear `Err` (fail-fast, each site's existing graceful fallback) instead of hanging the daemon; reuses the reviewer-2-verified #1897 timeout + process-group isolation/kill machinery.

## §3.9
- `spawn_group_bounded_preserves_caller_env_no_bypass_1899` — proves the bare-Command path does **not** inject `AGEND_GIT_BYPASS` (non-bypass preservation).
- The #1897 timeout/fast/process-group-kill tests cover the bound mechanism.
- Each site's existing module tests (all in the git-subprocess serial group) pass → legal flow unchanged.
- Full suite **3783/3783** under `nextest --profile ci`.

With this, the #1893 prod-git root-cure is complete: every daemon git subprocess is now bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)