### PR TITLE
fix(teardown): delete inbox (name+uuid) + cancel tasks on team disband (#1902 #1903)

### DIFF
--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -50,6 +50,15 @@ pub(crate) fn inbox_path(home: &Path, name: &str) -> PathBuf {
     home.join("inbox").join(format!("{name}.jsonl"))
 }
 
+/// #1902: id-based inbox path (pure — no fleet.yaml lookup, unlike
+/// [`inbox_path_resolved`]). Mirrors `agent_ops::metadata_path_for_id`. For
+/// teardown paths where the `InstanceId` is known directly and fleet.yaml has
+/// already been removed (so the name→id resolver can't run) — e.g.
+/// `full_delete_instance`, whose UUID inbox would otherwise leak silently.
+pub(crate) fn inbox_path_for_id(home: &Path, id: &crate::types::InstanceId) -> PathBuf {
+    home.join("inbox").join(format!("{}.jsonl", id.full()))
+}
+
 /// Sprint 46 P2: resolve inbox path by InstanceId when available.
 /// Migrates legacy name-based files to id-based on first access.
 pub(crate) fn inbox_path_resolved(home: &Path, name: &str) -> PathBuf {

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -99,6 +99,19 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
             let _ = std::fs::remove_file(crate::agent_ops::metadata_path_for_id(home, &id));
         }
     }
+    // #1902: delete the inbox file — this step was MISSING entirely, so a deleted
+    // instance's inbox leaked. Cover BOTH paths: the name-based `inbox/{name}.jsonl`
+    // AND the UUID-based `inbox/{uuid}.jsonl` (the current default). fleet.yaml is
+    // already removed above, so `inbox_path_resolved` can't resolve the UUID — feed
+    // the captured id directly (same #1682 name↔UUID-resolution trap the metadata
+    // cleanup above sidesteps). The residual audit only saw the name path, so the
+    // UUID inbox was leaking even past the audit.
+    let _ = std::fs::remove_file(crate::inbox::storage::inbox_path(home, name));
+    if let Some(ref id) = instance_id {
+        if let Some(id) = crate::types::InstanceId::parse(id) {
+            let _ = std::fs::remove_file(crate::inbox::storage::inbox_path_for_id(home, &id));
+        }
+    }
     crate::teams::remove_member_from_all(home, name);
 
     // #808: orphan tasks whose owner is the deleted instance so the
@@ -231,7 +244,15 @@ pub(crate) fn name_residual_anywhere(
     if metadata_residual {
         sources.push("metadata");
     }
-    if home.join("inbox").join(format!("{name}.jsonl")).exists() {
+    // #1902: name path OR the id-direct path. fleet.yaml is gone at delete-audit
+    // time, so the explicit captured-id check is what keeps a `<uuid>.jsonl`
+    // inbox residual visible — the audit previously checked ONLY the name path
+    // and silently missed UUID inboxes (the current default).
+    let inbox_residual = crate::inbox::storage::inbox_path(home, name).exists()
+        || id
+            .and_then(crate::types::InstanceId::parse)
+            .is_some_and(|id| crate::inbox::storage::inbox_path_for_id(home, &id).exists());
+    if inbox_residual {
         sources.push("inbox");
     }
     if home
@@ -381,6 +402,58 @@ mod tests {
     }
 
     #[test]
+    fn name_residual_anywhere_detects_uuid_inbox_residual_1902() {
+        // #1902: the current inbox is UUID-based, but the audit only checked the
+        // name path → a `<uuid>.jsonl` inbox was a SILENT leak (past the audit).
+        // Write a REAL uuid inbox file (via the id-direct path, NOT a synthetic
+        // name file) and pass the id — the audit must now flag "inbox".
+        let home = tmp_home("uuid_inbox_audit");
+        let id = crate::types::InstanceId::new();
+        let inbox_dir = home.join("inbox");
+        std::fs::create_dir_all(&inbox_dir).unwrap();
+        std::fs::write(crate::inbox::storage::inbox_path_for_id(&home, &id), "").unwrap();
+        // No name-based file exists — pre-#1902 this returned clean (false信心).
+        let sources = name_residual_anywhere(&home, "zombie", Some(&id.full()));
+        assert!(
+            sources.contains(&"inbox"),
+            "uuid inbox residual must be detected, got {sources:?}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn full_delete_instance_removes_uuid_inbox_1902() {
+        // #1902 §3.9 (a): a single delete must remove the instance's REAL uuid
+        // inbox (driven through inbox::enqueue → inbox_path_resolved, the
+        // production path), not just a name-based file.
+        let home = tmp_home("uuid_inbox_delete");
+        let id = crate::types::InstanceId::new();
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            format!(
+                "instances:\n  doomed:\n    backend: claude\n    id: {}\n",
+                id.full()
+            ),
+        )
+        .unwrap();
+        // Enqueue via the resolver → lands at inbox/<uuid>.jsonl (the prod path).
+        let msg = crate::inbox::InboxMessage::new_system("system:test", "update", "hi".to_string());
+        crate::inbox::enqueue(&home, "doomed", msg).expect("enqueue");
+        let uuid_inbox = crate::inbox::storage::inbox_path_for_id(&home, &id);
+        assert!(
+            uuid_inbox.exists(),
+            "pre: uuid inbox must exist at {uuid_inbox:?}"
+        );
+        let result = super::full_delete_instance(&home, "doomed");
+        assert!(result.is_ok(), "delete must return Ok, got {result:?}");
+        assert!(
+            !uuid_inbox.exists(),
+            "uuid inbox leaked — full_delete_instance must delete it: {uuid_inbox:?}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
     fn name_residual_anywhere_detects_runtime_binding_residual() {
         let home = tmp_home("binding");
         let dir = crate::paths::runtime_dir(&home).join("zombie");
@@ -509,6 +582,15 @@ mod tests {
             post.assignee.is_none(),
             "owned task must be orphaned after full_delete_instance, got assignee={:?}",
             post.assignee
+        );
+        // #1903 §3.9 (c): a SINGLE delete must leave the task ORPHAN-OPEN (owner
+        // cleared, still Open for re-dispatch) — NOT Cancelled. Cancellation is
+        // reserved for the team-disband path; single delete preserves the
+        // ACL-unlock-but-survivable semantics.
+        assert_eq!(
+            post.status,
+            crate::task_events::TaskStatus::Open,
+            "single delete must keep the task Open (orphan), not cancel it"
         );
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -18,7 +18,8 @@ use std::path::Path;
 pub use handler::handle;
 pub use handler::register_subscriber as register_cascade_subscriber;
 pub use orphan::{
-    orphan_tasks_for_owner, reconcile_orphan_owners_with_live, release_inprogress_orphans_with_live,
+    cancel_tasks_for_owner, orphan_tasks_for_owner, reconcile_orphan_owners_with_live,
+    release_inprogress_orphans_with_live,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/tasks/orphan.rs
+++ b/src/tasks/orphan.rs
@@ -61,6 +61,58 @@ pub fn orphan_tasks_for_owner(home: &Path, owner_name: &str) -> Result<usize, St
         .map_err(|e| e.to_string())
 }
 
+/// #1903: CANCEL tasks owned by an instance deleted as part of a TEAM DISBAND.
+/// Sibling to [`orphan_tasks_for_owner`] — identical filter (owner ==
+/// `owner_name` AND status ∈ Open/Claimed/InProgress/Blocked) — but emits a
+/// TERMINAL `Cancelled` instead of clearing ownership.
+///
+/// Why cancel (not orphan) on disband: a disband leaves NO survivor to take over
+/// the work, so an orphaned-but-Open task (owner: None) shows up as a ghost open
+/// task to a same-name redeploy. Cancelling makes it terminal so it can't.
+///
+/// Caller ordering (#1903): `teams::delete` calls this BEFORE the per-member
+/// `full_delete_instance` cascade, while `owner` is still set. The cascade's
+/// internal `orphan_tasks_for_owner` then SKIPS these — `Cancelled` is not in its
+/// {Open/Claimed/InProgress/Blocked} filter — giving a SINGLE Cancelled
+/// transition with NO double `OwnerAssigned` event. A single-instance delete
+/// never routes through here, so its orphan → ACL-unlock semantics are preserved.
+pub fn cancel_tasks_for_owner(home: &Path, owner_name: &str) -> Result<usize, String> {
+    use crate::task_events::{InstanceName, TaskEvent, TaskStatus};
+
+    let state = crate::task_events::replay(home).map_err(|e| e.to_string())?;
+    let affected: Vec<crate::task_events::TaskId> = state
+        .tasks
+        .values()
+        .filter(|r| r.owner.as_ref().map(|o| o.0 == owner_name).unwrap_or(false))
+        .filter(|r| {
+            matches!(
+                r.status,
+                TaskStatus::Open
+                    | TaskStatus::Claimed
+                    | TaskStatus::InProgress
+                    | TaskStatus::Blocked
+            )
+        })
+        .map(|r| r.id.clone())
+        .collect();
+    if affected.is_empty() {
+        return Ok(0);
+    }
+    let count = affected.len();
+    let emitter = InstanceName::from("system:team_disband");
+    let events: Vec<TaskEvent> = affected
+        .into_iter()
+        .map(|id| TaskEvent::Cancelled {
+            task_id: id,
+            by: emitter.clone(),
+            reason: "owner instance deleted via team disband".to_string(),
+        })
+        .collect();
+    crate::task_events::append_batch(home, &emitter, events)
+        .map(|_| count)
+        .map_err(|e| e.to_string())
+}
+
 /// Boot orphan sweep (task t-20260526155509233515-8): the STATUS-orphan
 /// analogue of [`scan_orphan_candidates`] (which handles OWNER orphans).
 ///

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -315,6 +315,24 @@ pub fn delete(home: &Path, args: &Value) -> Value {
     let members_count = members.len();
     let mut cascade_warnings: Vec<String> = Vec::new();
     for member in &members {
+        // #1903: CANCEL the member's live tasks BEFORE deleting the instance. A
+        // disband has no survivor to take over, so cancel (terminal) rather than
+        // orphan (Open + owner:None → a same-name redeploy sees a ghost open
+        // task). Ordering is load-bearing: it MUST run before full_delete_instance
+        // — that fn's internal orphan would otherwise null the owner first, leaving
+        // this cancel-by-owner nothing to match. After this cancel, that internal
+        // orphan SKIPS these tasks (Cancelled ∉ its Open/Claimed/InProgress/Blocked
+        // filter) → a single Cancelled transition, no double event. A single
+        // delete_instance never reaches here, so its orphan ACL-unlock is intact.
+        if let Err(e) = crate::tasks::cancel_tasks_for_owner(home, member) {
+            cascade_warnings.push(format!("{member} task cancel: {e}"));
+            tracing::warn!(
+                team = %name,
+                %member,
+                error = %e,
+                "#1903: task cancel failed during team disband"
+            );
+        }
         if let Err(e) = crate::mcp::handlers::instance_lifecycle::full_delete_instance(home, member)
         {
             cascade_warnings.push(format!("{member}: {e}"));
@@ -591,6 +609,62 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    #[test]
+    fn team_disband_cancels_member_tasks_no_double_event_1903() {
+        // #1903 §3.9 (b): disbanding a team must CANCEL each member's live tasks
+        // (no survivor to take over), and — proving the cancel-BEFORE-cascade
+        // ordering — the task must carry a SINGLE Cancelled transition with NO
+        // `system:auto_orphan` OwnerAssigned event (the internal orphan must SKIP
+        // the already-Cancelled task, not coincidentally miss it).
+        let home = tmp_home("disband_cancel_1903");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  m1:\n    backend: claude\nteams:\n  squad:\n    orchestrator: m1\n    members:\n      - m1\n",
+        )
+        .unwrap();
+        let r = crate::tasks::handle(
+            &home,
+            "m1",
+            &serde_json::json!({"action": "create", "title": "owned", "assignee": "m1"}),
+        );
+        let task_id = r["id"].as_str().expect("task id").to_string();
+
+        let res = super::delete(&home, &serde_json::json!({"name": "squad"}));
+        assert_eq!(res["status"], "deleted", "disband must succeed: {res}");
+
+        // (b1) terminal Cancelled, not Open.
+        let task = crate::tasks::list_all(&home)
+            .into_iter()
+            .find(|t| t.id == task_id)
+            .expect("task still exists");
+        assert_eq!(
+            task.status,
+            crate::task_events::TaskStatus::Cancelled,
+            "disband must cancel the member's task, got {:?}",
+            task.status
+        );
+
+        // (b2) single Cancelled transition + zero auto_orphan double-event.
+        let log = std::fs::read_to_string(home.join("task_events.jsonl")).unwrap();
+        let cancelled = log
+            .lines()
+            .filter(|l| l.contains(&task_id) && l.contains("\"kind\":\"Cancelled\""))
+            .count();
+        let auto_orphan = log
+            .lines()
+            .filter(|l| l.contains(&task_id) && l.contains("system:auto_orphan"))
+            .count();
+        assert_eq!(
+            cancelled, 1,
+            "exactly one Cancelled transition, got {cancelled}"
+        );
+        assert_eq!(
+            auto_orphan, 0,
+            "orphan must NOT double-fire on the already-Cancelled task (cancel-before-cascade), got {auto_orphan}"
+        );
+        std::fs::remove_dir_all(home).ok();
     }
 
     // ── #1744-M7: deterministic + fail-closed self-orch verdict ──
@@ -978,7 +1052,12 @@ mod tests {
             "bob828 must be removed from fleet.yaml instances"
         );
 
-        // All 3 previously-owned tasks are orphaned (owner = None).
+        // #1903: a team DISBAND now CANCELS each member's live tasks (terminal)
+        // rather than orphaning them (Open, owner cleared). A disbanded team has
+        // no survivor to take over, and an orphan-open task would be a ghost for a
+        // same-name redeploy. (This test previously asserted owner==None — that
+        // pinned the orphan-on-disband behaviour #1903 fixes. Single-instance
+        // delete still orphans-open — see full_delete_instance_orphans_owned_tasks.)
         let state = crate::task_events::replay(&home).unwrap();
         for id in &[id1.as_str(), id2.as_str(), id3.as_str()] {
             let task = state
@@ -986,11 +1065,12 @@ mod tests {
                 .values()
                 .find(|t| t.id.0 == *id)
                 .unwrap_or_else(|| panic!("task {id} must exist post-cascade"));
-            assert!(
-                task.owner.is_none(),
-                "task {} must be orphaned post-cascade, has owner={:?}",
+            assert_eq!(
+                task.status,
+                crate::task_events::TaskStatus::Cancelled,
+                "task {} must be CANCELLED post-disband (not orphaned-open), got status={:?}",
                 task.id.0,
-                task.owner
+                task.status
             );
         }
 


### PR DESCRIPTION
Two teardown-cleanup gaps in the same class (cheerc-reported, RCA verified), bundled. The lead sanity-checked the #1903 caller-distinction spike before impl.

## #1902 — inbox leak (+ audit blind spot)
`full_delete_instance` had **no inbox-deletion step** (only a name-residual audit). Worse: the audit checked only the name-based `inbox/{name}.jsonl`, but the current inbox is **UUID-based** → a `<uuid>.jsonl` inbox leaked **silently, past the audit too**.
- New `inbox::storage::inbox_path_for_id` (pure, mirrors `metadata_path_for_id`). fleet.yaml is already removed at delete time, so `inbox_path_resolved` can't resolve the UUID — feed the captured `instance_id` directly (the #1682 name↔UUID-resolution trap).
- `full_delete_instance` now deletes **both** the name and the uuid inbox path.
- `name_residual_anywhere` now also detects the uuid inbox (was a blind spot giving false confidence).

## #1903 — task orphan-vs-cancel on disband
`full_delete_instance` orphans owned tasks (`OwnerAssigned{owner:None}`) so a **surviving** team can still mutate them (ACL). But `teams::delete` cascades `full_delete_instance` for **every** member — a full disband has no survivor, so tasks were left Open+ownerless → a same-name redeploy saw a **ghost open task**. Fix (Option A', spike-decided):
- New `tasks::cancel_tasks_for_owner` — sibling of `orphan_tasks_for_owner` (same live-status filter) emitting terminal `TaskEvent::Cancelled` (`by: system:team_disband`).
- `teams::delete` calls it per member **before** the cascade. **Ordering is load-bearing**: cancel-before-cascade runs while the owner is still set; the cascade's internal orphan then **skips** the now-Cancelled task (Cancelled ∉ its `{Open/Claimed/InProgress/Blocked}` filter) → a **single** Cancelled transition, **no** double `OwnerAssigned` event. (Cancel-*after*-cascade can't work — the internal orphan would have nulled the owner first; this was the key spike correction.)
- **Single-instance delete** never routes through `teams::delete`, so it still **orphans-OPEN** → ACL-unlock semantics preserved.

## §3.9 (real uuid inbox paths, not synthetic name files)
- `name_residual_anywhere_detects_uuid_inbox_residual_1902` — audit sees the uuid inbox.
- `full_delete_instance_removes_uuid_inbox_1902` — single delete clears the **real** uuid inbox (driven via `inbox::enqueue` → resolver).
- `team_disband_cancels_member_tasks_no_double_event_1903` — Cancelled + **zero** `system:auto_orphan` double event (proves the before-ordering, not luck).
- `full_delete_instance_orphans_owned_tasks` strengthened: asserts `status==Open` (single delete orphans-open, doesn't cancel).
- `delete_team_cascades_..._per_member` updated to the #1903 contract (it previously pinned the orphan-on-disband bug; now asserts Cancelled).

Full suite **3786/3786** under `nextest --profile ci`; fmt + clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)