### PR TITLE
fix(#1907): complete teardown residual oracle + whole-home-scan regression

### DIFF
--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -47,7 +47,10 @@ pub use provider::{
     MergeableState, PrState,
 };
 #[allow(unused_imports)]
-pub use registry::{ci_watches_dir, cleanup_watches_for_instance, remove_watch, watch_filename};
+pub use registry::{
+    ci_watches_dir, cleanup_watches_for_instance, has_instance_anywhere, remove_watch,
+    watch_filename,
+};
 #[allow(unused_imports)]
 pub use sweep::{gc_stale_watches, startup_sweep};
 pub use watcher::check_ci_watches;

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -148,6 +148,36 @@ pub fn cleanup_watches_for_instance(home: &Path, instance: &str) -> usize {
     affected
 }
 
+/// #1907 teardown audit: does any ci-watch still reference `instance` — in its
+/// `subscribers`, the legacy `instance` field, or `next_after_ci`? Mirrors the
+/// three scrub targets of [`cleanup_watches_for_instance`] exactly so the
+/// residual audit and the cleanup never disagree.
+pub fn has_instance_anywhere(home: &Path, instance: &str) -> bool {
+    let dir = ci_watches_dir(home);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(watch) = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<super::watch_state::WatchState>(&c).ok())
+        else {
+            continue;
+        };
+        if watch.subscriber_names().iter().any(|s| s == instance)
+            || watch.instance.as_deref() == Some(instance)
+            || watch.next_after_ci.as_deref() == Some(instance)
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Deterministic, collision-resistant filename for a CI watch entry.
 /// Uses SHA-256 of `"{repo}:{branch}"` to avoid path traversal and
 /// collisions when repo names contain `/` (e.g. `owner/repo` vs

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -460,6 +460,16 @@ pub(crate) fn cleanup_pending_for_instance(home: &Path, instance_name: &str) -> 
     count
 }
 
+/// #1907 teardown audit: does any pending-dispatch sidecar still target
+/// `instance_name`? Mirrors [`cleanup_pending_for_instance`]'s `d.target ==`
+/// predicate exactly so the residual audit and the cleanup never disagree.
+pub(crate) fn has_pending_for_instance(home: &Path, instance_name: &str) -> bool {
+    if instance_name.is_empty() {
+        return false;
+    }
+    list_pending(home).iter().any(|d| d.target == instance_name)
+}
+
 /// Resolve a pending dispatch by `correlation_id` (NOT by sender —
 /// decision_timeout's sender-keyed semantic is wrong here because a
 /// single dispatcher can have multiple pending dispatches outstanding,

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -514,6 +514,97 @@ pub fn remove(home: &Path, repo: &str, branch: &str) -> std::io::Result<()> {
     }
 }
 
+/// #1907 teardown audit: scrub a deleted instance's name from every pr_state
+/// file's `subscribers` list. A deleted agent left in a subscriber array would
+/// route PR events ([ci-ready]/[pr-ready]) at a vacant or same-name-redeployed
+/// slot — the same per-instance-residual class the other cascade cleanups
+/// (ci_watch / dispatch_tracking) already close. This store had NO per-instance
+/// cleanup before. Best-effort, flock-serialized per file (via [`with_pr_state`]).
+/// Returns the number of files mutated.
+pub fn cleanup_subscribers_for_instance(home: &Path, name: &str) -> usize {
+    let dir = pr_state_dir(home);
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut mutated = 0usize;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        // Value-based, NOT typed `PrState` parse: an audit/cleanup that silently
+        // skips a file it cannot fully deserialize is itself a leak-hiding bug (the
+        // #1902 "the oracle was leaky" lesson) — a schema-drifted or partially-
+        // written pr_state file that still names the deleted instance MUST be
+        // scrubbed. Flock-serialized on the same `<file>.lock` path `with_json_state`
+        // uses, so a concurrent gh-poll RMW cannot race this.
+        let lock_path = path.with_extension("lock");
+        let _lock = match crate::store::acquire_file_lock(&lock_path) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let Some(mut v) = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+        else {
+            continue;
+        };
+        let Some(subs) = v.get_mut("subscribers").and_then(|s| s.as_array_mut()) else {
+            continue;
+        };
+        let before = subs.len();
+        subs.retain(|s| s.as_str() != Some(name));
+        if subs.len() == before {
+            continue;
+        }
+        if crate::store::atomic_write(
+            &path,
+            serde_json::to_string_pretty(&v)
+                .unwrap_or_default()
+                .as_bytes(),
+        )
+        .is_ok()
+        {
+            mutated += 1;
+        }
+    }
+    if mutated > 0 {
+        tracing::info!(%name, count = mutated, "#1907: scrubbed deleted instance from pr_state subscribers");
+    }
+    mutated
+}
+
+/// #1907 teardown audit: does any pr_state file still list `name` as a
+/// subscriber? Value-based to mirror [`cleanup_subscribers_for_instance`] — it
+/// must detect the name even in a file that no longer parses as a full `PrState`,
+/// otherwise a malformed-but-name-bearing file is a silent residual.
+pub fn has_subscriber(home: &Path, name: &str) -> bool {
+    let dir = pr_state_dir(home);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let listed = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+            .and_then(|v| {
+                v.get("subscribers")
+                    .and_then(|s| s.as_array())
+                    .map(|arr| arr.iter().any(|s| s.as_str() == Some(name)))
+            })
+            .unwrap_or(false);
+        if listed {
+            return true;
+        }
+    }
+    false
+}
+
 /// Fixed 1h upper bound for "stale terminal state" classification at daemon
 /// boot — see [`suppress_stale_terminal_replay`]. (#env-cleanup: was
 /// env-overridable via `AGEND_PR_STATE_REPLAY_AGE_HOURS`; demoted to YAGNI.)

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -178,6 +178,20 @@ pub fn cleanup_for_instance(home: &Path, instance: &str) -> usize {
     removed
 }
 
+/// #1907 teardown audit: does any dispatch_tracking entry still reference
+/// `instance` (as `from` or `to`)? Mirrors [`cleanup_for_instance`]'s retain
+/// predicate exactly so the residual audit and the cleanup never disagree.
+pub fn has_for_instance(home: &Path, instance: &str) -> bool {
+    let store: DispatchStore = crate::store::load_versioned(
+        &store_path(home),
+        <DispatchStore as crate::store::SchemaVersioned>::CURRENT,
+    );
+    store
+        .entries
+        .iter()
+        .any(|e| e.from == instance || e.to == instance)
+}
+
 /// #1488: distinct, still-active (`status != "completed"`) dispatch target
 /// names. The boot orphan sweep uses this to find entries whose `to` instance
 /// no longer exists, then reuses [`cleanup_for_instance`] to remove them —

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -21,6 +21,22 @@ use crate::channel::telegram;
 use serde_json::json;
 use std::path::Path;
 
+/// #1907: remove `dir` and any empty subdirectories bottom-up, stopping at any
+/// non-empty dir. Used to drop a deleted agent's worktree root including the
+/// intermediate dirs a slash-containing branch nests (`worktrees/<name>/feat/x/`),
+/// while preserving a refused unmanaged worktree (its real files keep its dir
+/// non-empty, so it's left for the residual audit to surface).
+fn remove_empty_dir_tree(dir: &Path) {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if entry.path().is_dir() {
+                remove_empty_dir_tree(&entry.path());
+            }
+        }
+    }
+    let _ = std::fs::remove_dir(dir); // succeeds only if now-empty
+}
+
 /// Sprint 53 Smoke 2 r1: shared full single-instance teardown used by both
 /// the MCP `delete_instance` handler and the TUI close path
 /// (`app/overlay.rs::Overlay::ConfirmClose`). Covers everything
@@ -87,16 +103,35 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     } else {
         tracing::warn!(%name, "no topic_id found for full_delete_instance — possible orphan");
     }
-    if let Some(ref wd) = working_dir {
-        cleanup_working_dir(home, name, wd);
-    }
+    // #1907: default to `workspace/<name>` when the fleet entry has no explicit
+    // `working_directory`. Otherwise the daemon-created default workspace dir
+    // (per-backend skills/config under `$AGEND_HOME/workspace/<name>`) LEAKS on
+    // delete — `cleanup_working_dir` only ran when the resolver returned a path,
+    // but it returns `None` for the (common) entries that never set
+    // `working_directory:` explicitly. `cleanup_working_dir` only `remove_dir_all`s
+    // paths UNDER `$AGEND_HOME/workspace/`, so a user-provided dir is never nuked —
+    // the default fed here is always under workspace/, the path it's safe to remove.
+    let wd = working_dir
+        .clone()
+        .unwrap_or_else(|| crate::paths::workspace_dir(home).join(name));
+    cleanup_working_dir(home, name, &wd);
     // #1157: clean id-based metadata. Fleet.yaml is already removed above,
     // so cleanup_working_dir's best-effort lookup may miss the id path.
     // #1682: construct the id path via agent_ops (fleet.yaml is gone, so the
     // name→id resolver can't be used here — feed the captured id directly).
+    // #1907: also drop the `<…>.lock` flock sidecar that `with_json_state` /
+    // `acquire_file_lock` leaves next to the data file. The data removal above
+    // (and the inbox removal below) left the advisory-lock files behind, and the
+    // whole-home audit correctly flags a `<uuid>.lock` / `<uuid>.jsonl.lock` as a
+    // name/uuid-bearing residual. The lock is stateless (re-acquired on next use),
+    // but a complete teardown leaves nothing name/uuid-keyed on disk.
+    let _ =
+        std::fs::remove_file(crate::agent_ops::metadata_path(home, name).with_extension("lock"));
     if let Some(ref id) = instance_id {
         if let Some(id) = crate::types::InstanceId::parse(id) {
-            let _ = std::fs::remove_file(crate::agent_ops::metadata_path_for_id(home, &id));
+            let mp = crate::agent_ops::metadata_path_for_id(home, &id);
+            let _ = std::fs::remove_file(&mp);
+            let _ = std::fs::remove_file(mp.with_extension("lock"));
         }
     }
     // #1902: delete the inbox file — this step was MISSING entirely, so a deleted
@@ -106,10 +141,14 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // the captured id directly (same #1682 name↔UUID-resolution trap the metadata
     // cleanup above sidesteps). The residual audit only saw the name path, so the
     // UUID inbox was leaking even past the audit.
-    let _ = std::fs::remove_file(crate::inbox::storage::inbox_path(home, name));
+    let inbox_name = crate::inbox::storage::inbox_path(home, name);
+    let _ = std::fs::remove_file(&inbox_name);
+    let _ = std::fs::remove_file(inbox_name.with_extension("jsonl.lock")); // #1907 flock sidecar
     if let Some(ref id) = instance_id {
         if let Some(id) = crate::types::InstanceId::parse(id) {
-            let _ = std::fs::remove_file(crate::inbox::storage::inbox_path_for_id(home, &id));
+            let inbox_id = crate::inbox::storage::inbox_path_for_id(home, &id);
+            let _ = std::fs::remove_file(&inbox_id);
+            let _ = std::fs::remove_file(inbox_id.with_extension("jsonl.lock"));
         }
     }
     crate::teams::remove_member_from_all(home, name);
@@ -160,6 +199,10 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     let _ = crate::dispatch_tracking::cleanup_for_instance(home, name);
     // - ci_watch: drop from subscribers + clear next_after_ci (+ remove empty).
     let _ = crate::daemon::ci_watch::cleanup_watches_for_instance(home, name);
+    // #1907: scrub the deleted instance from pr_state subscriber lists — same
+    // per-instance-residual class as ci_watch above, but this store had no
+    // teardown cleanup before (PR events would route at a vacant/redeployed slot).
+    let _ = crate::daemon::pr_state::cleanup_subscribers_for_instance(home, name);
     // #1519: GC the per-instance opencode data dir ($AGEND_HOME/backend-data/
     // opencode/<name> — the per-instance XDG_DATA_HOME holding its isolated
     // session DB + copied auth). No-op for non-opencode instances (the dir was
@@ -182,12 +225,15 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // defensive idempotent no-op for the bound-agent case (still needed for the
     // never-bound / partial-state cases).
     let _ = crate::worktree_pool::release_full(home, name, false);
-    // release_full removes `worktrees/<name>/<branch>/`; drop the now-empty agent
-    // dir `worktrees/<name>/` too so the audit below reads clean. `remove_dir`
-    // (NOT remove_dir_all) only succeeds when empty — a refused unmanaged worktree
-    // stays put and is correctly surfaced by the residual audit.
-    let _ =
-        std::fs::remove_dir(crate::worktree_pool::daemon_managed_worktree_root(home).join(name));
+    // release_full removes the leaf worktree `worktrees/<name>/<branch>/`; drop the
+    // now-empty agent dir `worktrees/<name>/` too so the audit below reads clean.
+    // #1907: a slash-containing branch (e.g. `feat/x`) nests intermediate dirs
+    // (`worktrees/<name>/feat/x/`), so a single `remove_dir` of `<name>/` failed
+    // (still held the empty `feat/`) and leaked the agent dir. `remove_empty_dir_tree`
+    // removes empty dirs bottom-up and STOPS at any non-empty dir — so a refused
+    // unmanaged worktree (real files) stays put and is correctly surfaced by the
+    // residual audit, exactly like the old `remove_dir` intent.
+    remove_empty_dir_tree(&crate::worktree_pool::daemon_managed_worktree_root(home).join(name));
 
     // #1879 (BIND-1): clear the worktree binding (`runtime/<name>/binding.json`
     // + its HMAC sidecar + the bind-in-flight flag). Every OTHER store above is
@@ -197,6 +243,12 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // → the whole teardown returned Err despite otherwise succeeding.
     crate::binding::unbind(home, name);
     crate::mcp::handlers::dispatch_hook::clear_bind_in_flight(home, name);
+    // #1907: `unbind` drops binding.json + its HMAC sidecar but leaves the now-empty
+    // `runtime/<name>/` dir + its `.binding.json.lock` flock behind. Remove the whole
+    // dir so teardown is fully clean (the residual audit below now checks it). Safe:
+    // the agent is dead (api::call(DELETE) waited for exit), so no concurrent bind
+    // re-creates it; `runtime/<name>/` holds only this agent's binding artefacts.
+    let _ = std::fs::remove_dir_all(crate::paths::runtime_dir(home).join(name));
 
     // Sprint 54 P1-B Bug 1 audit: enumerate every store that still holds
     // the name. If any do, surface a loud error instead of returning
@@ -313,6 +365,49 @@ pub(crate) fn name_residual_anywhere(
         .exists()
     {
         sources.push("worktree");
+    }
+    // #1907 teardown-completeness: the remaining per-instance stores that
+    // `full_delete_instance` cleans but the audit previously did not check. Each
+    // detector mirrors its cleanup's predicate exactly (see the `has_*` helpers).
+    // Allowlisted/intentional-retention stores (schedules, tasks, deployments,
+    // telegram topics.json) are DELIBERATELY absent — they retain state by design,
+    // so checking them here would make every delete return a false `Err`.
+    if home
+        .join("agent-activity")
+        .join(format!("{name}.json"))
+        .exists()
+    {
+        sources.push("agent-activity");
+    }
+    if crate::daemon::escalation_persist::load_for(home, name).is_some() {
+        sources.push("escalation");
+    }
+    if crate::dispatch_tracking::has_for_instance(home, name) {
+        sources.push("dispatch_tracking");
+    }
+    if crate::daemon::dispatch_idle::has_pending_for_instance(home, name) {
+        sources.push("pending-dispatch");
+    }
+    if crate::daemon::ci_watch::has_instance_anywhere(home, name) {
+        sources.push("ci-watch");
+    }
+    if crate::agent::opencode_data_dir(home, name).exists() {
+        sources.push("opencode-data");
+    }
+    // #1907: the `runtime/<name>/` dir itself (empty dir + `.binding.json.lock`
+    // left behind by `unbind`; full_delete now removes the whole dir).
+    if crate::paths::runtime_dir(home).join(name).exists() {
+        sources.push("runtime-dir");
+    }
+    if crate::daemon::pr_state::has_subscriber(home, name) {
+        sources.push("pr-state");
+    }
+    // #1907: the daemon-created default workspace dir (`workspace/<name>`). Only a
+    // residual when the entry had no explicit `working_directory` AND the cleanup
+    // above failed — a user-provided working dir resolves elsewhere and never
+    // materialises here.
+    if crate::paths::workspace_dir(home).join(name).exists() {
+        sources.push("workspace");
     }
     sources
 }

--- a/src/mcp/handlers/instance_lifecycle/tests.rs
+++ b/src/mcp/handlers/instance_lifecycle/tests.rs
@@ -324,20 +324,27 @@ fn name_residual_anywhere_returns_multi_source_when_several_stores_dirty() {
 
 #[test]
 fn full_delete_instance_returns_err_when_residual_remains_post_cleanup() {
-    // Pre-seed metadata + inbox files before delete; daemon API is
-    // unreachable in the test process, so `api::call` fails
-    // (silently). fleet.yaml removal is also a no-op (no fleet.yaml
-    // present). The post-cleanup audit must surface the
-    // metadata/inbox residual and the fn must return Err.
+    // Pre-seed a notification-queue file before delete. The daemon API is
+    // unreachable in the test process, so `api::call(DELETE)` — the step that
+    // clears the queue via the registry — fails silently, and the disk-cleanup
+    // path in `full_delete_instance` does NOT touch notification-queue. So it
+    // genuinely survives, and the post-cleanup audit must surface it as residual
+    // → Err (the transactional-or-loud contract).
+    //
+    // #1907: the prior `metadata/zombie.json` seed is now correctly cleaned by
+    // `cleanup_working_dir`'s "always clean metadata" tail — which now runs even
+    // for entries with no explicit `working_directory` (previously skipped,
+    // leaking the default-workspace metadata). It can no longer prove the Err
+    // path; notification-queue is the residual that still does.
     let home = tmp_home("full_residual");
-    std::fs::create_dir_all(home.join("metadata")).unwrap();
-    std::fs::write(home.join("metadata").join("zombie.json"), "{}").unwrap();
+    std::fs::create_dir_all(home.join("notification-queue")).unwrap();
+    std::fs::write(home.join("notification-queue").join("zombie.jsonl"), "").unwrap();
     let result = super::full_delete_instance(&home, "zombie");
     let err = result.expect_err(
-        "metadata residual after cleanup must surface as Err — silent-drop class blocked",
+        "notification-queue residual after cleanup must surface as Err — silent-drop class blocked",
     );
     assert!(
-        err.contains("metadata"),
+        err.contains("notification-queue"),
         "Err detail must name the residual store, got: {err:?}"
     );
     std::fs::remove_dir_all(home).ok();

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -515,11 +515,20 @@ fn authed_api_call(
 }
 
 fn binary_path() -> PathBuf {
-    let mut path = std::env::current_exe().expect("current_exe");
-    path.pop(); // strip test binary name
-    path.pop(); // strip deps/
-    path.push("agend-terminal");
-    path
+    // `CARGO_BIN_EXE_<bin>` is set by cargo for integration tests and resolved at
+    // COMPILE TIME, so referencing it both (a) declares this test's dependency on
+    // the `agend-terminal` binary — making cargo/nextest fresh-BUILD it for the
+    // current test profile — and (b) points at that exact build.
+    //
+    // The previous `current_exe()` inference instead spawned whatever
+    // `target/<profile>/agend-terminal` happened to already exist on disk. Under
+    // CI's split (`cargo build --release` for the smoke bin, then `cargo nextest`
+    // running tests in DEBUG), nextest did NOT rebuild the debug bin — current_exe
+    // never declared the dependency — so the harness spawned a STALE debug daemon
+    // missing the PR's own changes. #1909's teardown regression (the first harness
+    // test to assert NEW daemon behavior) caught exactly that: it spawned a daemon
+    // without the PR's workspace-cleanup fix and correctly flagged the residual.
+    PathBuf::from(env!("CARGO_BIN_EXE_agend-terminal"))
 }
 
 /// Wave 1 CLI consolidation: the harness's default spawn now uses

--- a/tests/teardown_completeness_regression.rs
+++ b/tests/teardown_completeness_regression.rs
@@ -1,0 +1,288 @@
+//! #1907 — teardown-completeness regression (the high-leverage payoff).
+//!
+//! Boots a REAL daemon on an isolated `/tmp` `AGEND_HOME` (never `~/.agend-terminal`),
+//! gives a victim instance EVERY per-instance state it can hold (MCP-driven +
+//! direct-seeded daemon-internal stores), runs the real `delete_instance`, then
+//! asserts:
+//!   (a) the delete SUCCEEDS — `full_delete_instance` returns `Ok` iff its
+//!       `name_residual_anywhere` oracle is empty, so a successful delete IS the
+//!       "oracle == clean" assertion, exercised through the production path; and
+//!   (b) a WHOLE-HOME SCAN finds zero residual of the victim's name OR uuid,
+//!       except an explicitly-annotated allowlist (intentional-retention stores +
+//!       structural logs).
+//!
+//! (b) is the real future-proofing: the production oracle is a *curated* list
+//! (only catches stores someone remembered to add), but the whole-home scan
+//! catches ANY unexpected residual — including a future store nobody anticipated.
+//! A new per-instance store that forgets teardown cleanup turns this test RED.
+#![cfg(unix)]
+
+mod common;
+
+use common::git_isolated;
+use common::harness::AgendHarness;
+use serde_json::{json, Value};
+use std::path::Path;
+
+const VICTIM: &str = "victim-agent";
+const VICTIM_UUID: &str = "11111111-2222-3333-4444-555555555555";
+const BRANCH: &str = "feat/victim-b";
+const REPO_SLUG: &str = "e2e-org/victim-repo";
+
+/// Allowlist of residual the scan TOLERATES, each with its rationale. A path is
+/// allowed if it starts with any of these (relative to home). Operator/reviewer
+/// can reclassify any entry — that is the point of keeping it explicit here.
+const ALLOWLIST: &[(&str, &str)] = &[
+    // ── fixture, not daemon state ──
+    ("source", "the test's source git repo (fixture, not per-instance daemon state)"),
+    ("origin.git", "the test's bare origin (fixture)"),
+    // ── structural: the victim's name legitimately appears in history/audit trail ──
+    ("daemon.", "daemon.<date>.log — tracing legitimately names the deleted instance"),
+    ("event-log.jsonl", "append-only audit trail — create/delete events name the instance by design"),
+    ("task_events.jsonl", "append-only task-event log — owner/assignee history named by design"),
+    // ── intentional retention (audit-confirmed; see #1907 spike) ──
+    ("schedules.json", "INTENTIONAL: orphan-disabled, never deleted — operator may re-target a cron"),
+    ("tasks.json", "INTENTIONAL: owner cleared but the task row is kept for surviving agents"),
+    ("deployments.json", "INTENTIONAL: the instances list is a redeploy recipe"),
+    ("topics.json", "INTENTIONAL: telegram-only; delete_topic unregisters on success, boot orphan-sweep self-heals the failure path"),
+];
+
+fn is_allowlisted(rel: &str) -> bool {
+    ALLOWLIST.iter().any(|(prefix, _)| rel.starts_with(prefix))
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = git_isolated::git(dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn call_api(h: &AgendHarness, request: &Value) -> Value {
+    use std::io::{BufRead, BufReader, Write};
+    let stream =
+        std::net::TcpStream::connect(format!("127.0.0.1:{}", h.api_port)).expect("connect");
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(15)))
+        .ok();
+    let mut writer = stream.try_clone().expect("clone");
+    let mut reader = BufReader::new(stream);
+    let run_dir = std::fs::read_dir(h.home.join("run"))
+        .expect("run")
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| p.join("api.cookie").exists())
+        .expect("cookie dir");
+    let cookie = std::fs::read(run_dir.join("api.cookie")).expect("cookie");
+    let hex: String = cookie.iter().map(|b| format!("{b:02x}")).collect();
+    writeln!(writer, r#"{{"auth":"{hex}"}}"#).expect("auth");
+    writer.flush().ok();
+    let mut a = String::new();
+    reader.read_line(&mut a).expect("auth resp");
+    writeln!(writer, "{}", serde_json::to_string(request).expect("ser")).expect("write");
+    writer.flush().ok();
+    let mut resp = String::new();
+    reader.read_line(&mut resp).expect("read");
+    serde_json::from_str(resp.trim()).unwrap_or_else(|e| panic!("parse '{resp}': {e}"))
+}
+
+fn mcp(h: &AgendHarness, instance: &str, tool: &str, args: Value) -> Value {
+    call_api(
+        h,
+        &json!({"method":"mcp_tool","params":{"tool":tool,"arguments":args,"instance":instance}}),
+    )
+}
+
+/// Every path under `home` whose relative path OR text content contains `needle`.
+fn scan_for(home: &Path, needle: &str) -> Vec<String> {
+    let mut hits = Vec::new();
+    let mut stack = vec![home.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for ent in rd.flatten() {
+            let p = ent.path();
+            let rel = p.strip_prefix(home).unwrap_or(&p).display().to_string();
+            if p.is_dir() {
+                stack.push(p.clone());
+                if rel.contains(needle) {
+                    hits.push(format!("{rel} (dir path)"));
+                }
+                continue;
+            }
+            if rel.contains(needle) {
+                hits.push(format!("{rel} (path)"));
+            } else if std::fs::read_to_string(&p)
+                .map(|c| c.contains(needle))
+                .unwrap_or(false)
+            {
+                hits.push(format!("{rel} (content)"));
+            }
+        }
+    }
+    hits.sort();
+    hits.dedup();
+    hits
+}
+
+fn unexpected(home: &Path, needle: &str) -> Vec<String> {
+    scan_for(home, needle)
+        .into_iter()
+        .filter(|h| !is_allowlisted(h))
+        .collect()
+}
+
+#[test]
+fn teardown_leaves_zero_residual_after_full_exercise_1907() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-teardown-regr-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).expect("mkdir");
+    assert!(
+        home.starts_with(std::env::temp_dir()),
+        "hermetic: home must be under tmp"
+    );
+    let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run_scenario(&home)));
+    std::fs::remove_dir_all(&home).ok();
+    if let Err(e) = r {
+        std::panic::resume_unwind(e);
+    }
+}
+
+fn run_scenario(home: &Path) {
+    // ── hermetic source repo for the binding (local bare origin, no network) ──
+    let origin = home.join("origin.git");
+    std::fs::create_dir_all(&origin).expect("mkdir origin");
+    git(&origin, &["init", "--bare", "-b", "main"]);
+    let src = home.join("source");
+    std::fs::create_dir_all(&src).expect("mkdir source");
+    git(&src, &["init", "-b", "main"]);
+    git(
+        &src,
+        &["remote", "add", "origin", &origin.display().to_string()],
+    );
+    std::fs::write(src.join("README.md"), "x\n").expect("write README");
+    git(&src, &["add", "."]);
+    git(&src, &["commit", "-m", "init"]);
+    git(&src, &["push", "-u", "origin", "main"]);
+
+    // victim carries an explicit id (uuid) so the uuid-keyed paths exist + are scanned
+    let fleet = format!(
+        "instances:\n  lead:\n    command: /bin/cat\n  \
+         {VICTIM}:\n    command: /bin/cat\n    id: {VICTIM_UUID}\n    source_repo: {src}\n\
+         teams:\n  t:\n    members: [lead, {VICTIM}]\n    orchestrator: lead\n",
+        src = src.display()
+    );
+    let h = AgendHarness::spawn_with(home.to_path_buf(), &fleet, "start").expect("boot");
+
+    // ── exercise EVERY hermetic-reachable per-instance state ──
+    // inbox (name + uuid path)
+    let _ = mcp(
+        &h,
+        "lead",
+        "send",
+        json!({"instance": VICTIM, "message": "hi"}),
+    );
+    // a task OWNED by victim (task-owner orphan path)
+    let _ = mcp(
+        &h,
+        VICTIM,
+        "task",
+        json!({"action": "create", "title": "owned by the agent"}),
+    );
+    // dispatch with branch → binding + physical worktree + dispatch_tracking
+    //                        + pending-dispatch sidecar + auto-armed ci-watch
+    let created = mcp(
+        &h,
+        "lead",
+        "task",
+        json!({"action": "create", "title": "do work"}),
+    );
+    let tid = created["result"]["id"].as_str().unwrap_or("").to_string();
+    let _ = mcp(
+        &h,
+        "lead",
+        "send",
+        json!({
+            "instance": VICTIM, "message": "do it", "request_kind": "task",
+            "task_id": tid, "branch": BRANCH, "repository": REPO_SLUG, "next_after_ci": "lead",
+        }),
+    );
+
+    // ── direct-seed the daemon-internal-only stores (the daemon writes these on
+    //    its own loops; seed with the victim's name so teardown is exercised) ──
+    std::fs::write(
+        home.join("usage_limit_notify.json"),
+        json!({VICTIM: {"unlock_at": null, "notified_at": "2026-06-09T00:00:00+00:00"}})
+            .to_string(),
+    )
+    .expect("seed write");
+    std::fs::write(
+        home.join("health_escalation.json"),
+        json!({"schema_version": 1, "agents": {VICTIM: {}}}).to_string(),
+    )
+    .expect("seed write");
+    std::fs::create_dir_all(home.join("agent-activity")).ok();
+    std::fs::write(
+        home.join("agent-activity").join(format!("{VICTIM}.json")),
+        json!({"last_activity_ms": 1_700_000_000_000u64}).to_string(),
+    )
+    .expect("seed write");
+    // pr-state subscriber (gh-poll-driven in prod, so direct-seed it here)
+    std::fs::create_dir_all(home.join("pr-state")).ok();
+    std::fs::write(
+        home.join("pr-state")
+            .join("e2e-org__victim-repo__feat-victim-b.json"),
+        json!({"subscribers": [VICTIM], "repo": REPO_SLUG, "branch": BRANCH}).to_string(),
+    )
+    .expect("seed write");
+
+    // sanity: the victim's state really is on disk before the delete
+    assert!(
+        home.join("runtime")
+            .join(VICTIM)
+            .join("binding.json")
+            .exists(),
+        "precondition: victim should be bound after dispatch"
+    );
+    assert!(
+        home.join("workspace").join(VICTIM).exists(),
+        "precondition: victim's default workspace dir should exist"
+    );
+
+    // ── the real teardown ──
+    let del = mcp(&h, "lead", "delete_instance", json!({"instance": VICTIM}));
+
+    // (a) the production residual oracle is clean: `full_delete_instance` returns
+    // `Err` when `name_residual_anywhere` is non-empty, and `handle_delete_instance`
+    // surfaces that as an `error` field on the result (alongside `name`). So "no
+    // `error` field" IS the "oracle == []" assertion, exercised through prod.
+    assert!(
+        del["result"].get("error").is_none(),
+        "delete_instance reported residual state (the oracle still saw a store): {del}"
+    );
+    assert_eq!(
+        del["result"].get("name").and_then(|v| v.as_str()),
+        Some(VICTIM),
+        "delete_instance should echo the deleted name: {del}"
+    );
+
+    // (b) whole-home scan — zero unexpected residual by name OR uuid
+    let by_name = unexpected(home, VICTIM);
+    let by_uuid = unexpected(home, VICTIM_UUID);
+    assert!(
+        by_name.is_empty() && by_uuid.is_empty(),
+        "teardown left unexpected residual (not in the annotated allowlist):\n  by name {VICTIM}: {by_name:#?}\n  by uuid {VICTIM_UUID}: {by_uuid:#?}\n\
+         If a residual is INTENTIONAL, add it to ALLOWLIST with a rationale; otherwise add cleanup to full_delete_instance."
+    );
+
+    drop(h);
+}


### PR DESCRIPTION
## #1907 — teardown-completeness oracle + whole-home-scan regression

Follow-up to the #1900 teardown audit (and #1905/#1906, which fixed the two Tier-1
leaks it found). This completes the `name_residual_anywhere` audit oracle and —
the high-leverage payoff — adds a **whole-home-scan regression test** that turns
ANY future per-instance store forgetting teardown cleanup into a RED test.

### The reframe (approved in the spike)
`name_residual_anywhere` is a *curated* list — completing it only helps the
production loud-Err-on-delete, and a future store nobody adds stays invisible. So
the regression test does a **whole-home scan** (name + uuid) after a fully-exercised
victim's delete, failing on any residual not in an explicit annotated allowlist.
That catches unanticipated stores; the oracle completion is the secondary,
production-facing half.

### Oracle completion (`name_residual_anywhere`)
Added detection (each mirroring its cleanup's exact predicate, via new `has_*`
accessors so audit and cleanup never disagree) for the stores `full_delete_instance`
cleaned but the audit didn't check: **agent-activity, escalation, dispatch_tracking,
pending-dispatch, ci-watch, opencode-data, runtime-dir, pr-state, workspace**.
Allowlisted/intentional-retention stores (schedules/tasks/deployments/topics) are
deliberately absent — adding them would make every delete a false `Err`.

### Cleanups the whole-home scan caught during impl (the payoff working)
The new test immediately surfaced four more residuals that the curated oracle had
never checked — all now fixed in `full_delete_instance`:
- **pr-state subscribers** — a deleted name lingered in PR subscriber lists (no
  per-instance cleanup existed). Added a Value-based scrub (an audit/cleanup must
  not be defeated by a partial-parse — the #1902 "leaky oracle" lesson).
- **`workspace/<name>`** (+ its name-path metadata) — `cleanup_working_dir` was
  *skipped entirely* for the common entries with no explicit `working_directory:`,
  leaking the daemon-created default workspace. Now defaults to `workspace/<name>`.
- **inbox / metadata `.lock` flock siblings** — the data files were removed but the
  `with_json_state` advisory-lock files lingered (name/uuid-bearing).
- **`worktrees/<name>/` for slash branches** — `feat/x` nests an intermediate dir,
  so #1906's single `remove_dir` left the empty `feat/` (and the agent dir) behind.
  Replaced with `remove_empty_dir_tree` (bottom-up empty removal; a refused
  unmanaged worktree stays put for the audit, exactly like the old `remove_dir`).

### Regression test
`tests/teardown_completeness_regression.rs` (`#![cfg(unix)]`): boots a REAL daemon
on an isolated `/tmp` home (never `~/.agend-terminal`), gives a victim EVERY
hermetic-reachable state (inbox name+uuid, task-owner, binding+worktree,
dispatch_tracking, pending-dispatch, ci-watch) + direct-seeds the daemon-internal
stores (usage_limit_notify, escalation, agent-activity, pr-state), runs the real
`delete_instance`, then asserts (a) the delete returns no `error` (⟺ oracle clean,
via the production path) AND (b) a whole-home scan finds zero name/uuid residual
except the annotated allowlist. The allowlist (schedules/tasks/deployments/topics +
structural logs) is explicit + per-entry rationale'd, so an operator/reviewer can
reclassify any entry.

### Not changed (out of scope, per spike)
Caller consumption of the audit `Err` is untouched — `full_delete_instance` still
returns `Err` on residual; `handle_delete_instance` still surfaces it; `teams::delete`
stays best-effort. The fix is detection-completeness + the test, not a change to the
prod fail-direction.

One existing unit test (`full_delete_instance_returns_err_when_residual_remains_post_cleanup`)
switched its residual seed from `metadata` to `notification-queue`: the workspace-default
fix now correctly cleans the metadata it relied on leaking, so it needed a store that
still genuinely survives the no-daemon test context to keep proving the Err contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
