### PR TITLE
fix(inject): longer pre-submit settle for typed_inject backends (codex 0.138)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2050,7 +2050,18 @@ fn inject_with_target(target: &InjectTarget, text: &[u8]) -> crate::error::Resul
     if target.deleted.load(std::sync::atomic::Ordering::Acquire) {
         return Ok(());
     }
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    // Pre-submit settle: let the input box fully commit the just-written line
+    // before `\r` is read as submit. Bulk-inject TUIs (claude's `❯`) commit
+    // instantly, so 50ms is plenty. typed_inject ratatui boxes (codex's `›`,
+    // opencode/gemini/agy) re-render/debounce and need more headroom — 50ms is
+    // enough for codex 0.118 (#1670) but codex 0.138's input box re-renders
+    // slower, so the `\r` arrives before commit and is appended as a newline:
+    // the wake line stacks un-submitted and the agent never wakes. A longer
+    // settle for typed_inject backends fixes 0.138 without affecting 0.118
+    // (the only cost is +200ms latency on an infrequent inject) and is inert
+    // for bulk-inject backends.
+    let settle_ms = if target.typed_inject { 250 } else { 50 };
+    std::thread::sleep(std::time::Duration::from_millis(settle_ms));
     write_with_timeout(&target.pty_writer, submit)?;
     Ok(())
 }


### PR DESCRIPTION
## Problem

`typed_inject` ratatui input boxes (codex's `›`) need the just-typed line to **commit** before the trailing `\r` is read as *submit*. The hardcoded `50ms` pre-submit settle in `inject_with_target` works for codex **0.118** (#1670), but codex **0.138** re-renders its input box more slowly: the `\r` arrives before the line commits and is appended as a *newline*, so the wake line stacks un-submitted in the box and the agent never wakes.

`doctor` already warns `codex … calibrated: 0.118.0, patterns may need update` — this is one concrete consequence on the newer CLI (observed on Windows: a `send`/wake to a codex 0.138 instance leaves `[AGEND-MSG-PENDING] …` sitting in the `›` input, never processed).

## Fix

Bump the pre-submit settle from a hardcoded `50ms` to `250ms` **for `typed_inject` backends only** (codex / opencode / gemini / agy). Bulk-inject backends (claude's `❯`, which commits instantly) keep `50ms`. The only cost is +200ms latency on an infrequent inject; it is inert for bulk-inject and harmless for codex 0.118 (which already worked at 50ms).

```rust
let settle_ms = if target.typed_inject { 250 } else { 50 };
std::thread::sleep(std::time::Duration::from_millis(settle_ms));
write_with_timeout(&target.pty_writer, submit)?;
```

## Validation

`cargo check` + the inject unit tests pass.

Empirically validated against **real codex 0.138** with a standalone `winpty` harness that mimics `inject_with_target` (paced 2ms/byte type → settle → `\r`), 2 runs each:

| settle | result |
|---|---|
| 50ms (current) | **STUCK** — line stays in the `›` input, no processing |
| 250ms (this PR) | **SUBMITTED** — line enters the transcript, codex starts the turn (`esc to interrupt` / `Booting MCP server`) |

## Scope

`calibrated_version` stays `0.118.0` — a full 0.138 pattern recalibration (ready / dismiss / state patterns) is out of scope; the existing patterns still match 0.138's banner and `›` prompt. This is the minimal, version-agnostic settle fix that unblocks codex 0.138 inject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
