### PR TITLE
fix(#1912): readback-confirm inject — replace fixed-sleep submit guess

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2050,9 +2050,137 @@ fn inject_with_target(target: &InjectTarget, text: &[u8]) -> crate::error::Resul
     if target.deleted.load(std::sync::atomic::Ordering::Acquire) {
         return Ok(());
     }
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    // #1912: gate the pre-submit wait on the backend's input-widget style.
+    if target.typed_inject {
+        // Readback-confirm (#1912): poll the RENDERED input area until the typed
+        // line's tail-sentinel appears, THEN submit. Replaces the fixed-sleep
+        // "guess" that racing codex's re-rendering `›` widget required (every codex
+        // version re-tuned the magic number). FAIL-OPEN: on timeout we submit
+        // anyway (the helper warns) — this is the agent-wake lifeline, so an
+        // unconfirmed readback must never become "don't submit" (= agent never wakes).
+        let _confirmed = readback_confirm_typed(target, &stripped);
+    } else {
+        // claude `❯` bulk fast path — tolerates bulk bytes + `\r`; keep byte-identical.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
     write_with_timeout(&target.pty_writer, submit)?;
+    // #1912: post-submit observability (log/metric-only, NEVER retries — a second
+    // `\r` would risk double-submit). Typed-inject only; bulk's fast path stays lean.
+    if target.typed_inject {
+        let _submitted = observe_post_submit(target);
+    }
     Ok(())
+}
+
+/// #1912: tail-sentinel of a (possibly multi-line) injected payload — the last
+/// run of up to `MAX` chars on the final non-empty line, the line the submit `\r`
+/// commits. Short + drawn from the bottom line so it stays robust to input-box
+/// wrapping. Empty when the payload has no non-blank line (nothing to confirm).
+fn inject_sentinel(stripped: &str) -> String {
+    const MAX: usize = 24;
+    let last_line = stripped
+        .lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or("")
+        .trim();
+    let take_from = last_line
+        .char_indices()
+        .rev()
+        .take(MAX)
+        .last()
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    last_line[take_from..].to_string()
+}
+
+const READBACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const READBACK_POLL: std::time::Duration = std::time::Duration::from_millis(15);
+const POSTSUBMIT_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
+/// Bottom rows scanned for the input area — the prompt + a few wrapped input rows.
+const READBACK_TAIL_ROWS: usize = 8;
+
+/// #1912: poll the rendered input area until the typed line's tail-sentinel
+/// renders, then return `true`. Returns `false` (FAIL-OPEN: caller submits anyway,
+/// this warns) if unconfirmed within the timeout. Acquires the core lock only
+/// briefly per poll (read `tail_lines`, drop) so the `pty_read_loop` renders the
+/// backend's echo of the typed chars between polls.
+fn readback_confirm_typed(target: &InjectTarget, stripped: &str) -> bool {
+    readback_confirm_typed_with(target, stripped, READBACK_TIMEOUT, READBACK_POLL)
+}
+
+fn readback_confirm_typed_with(
+    target: &InjectTarget,
+    stripped: &str,
+    timeout: std::time::Duration,
+    poll: std::time::Duration,
+) -> bool {
+    let sentinel = inject_sentinel(stripped);
+    if sentinel.is_empty() {
+        return true; // nothing to confirm (empty/whitespace payload)
+    }
+    let start = std::time::Instant::now();
+    let mut polls = 0u32;
+    loop {
+        if target.deleted.load(std::sync::atomic::Ordering::Acquire) {
+            return false;
+        }
+        let visible = target.core.lock().vterm.tail_lines(READBACK_TAIL_ROWS);
+        if visible.contains(&sentinel) {
+            tracing::debug!(
+                tag = "#1912-readback-confirmed",
+                polls,
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "typed inject line rendered in input area before submit"
+            );
+            return true;
+        }
+        if start.elapsed() >= timeout {
+            tracing::warn!(
+                tag = "#1912-readback-timeout",
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                sentinel_len = sentinel.len(),
+                "typed inject line not confirmed in input area within timeout — submitting anyway (fail-open)"
+            );
+            return false;
+        }
+        std::thread::sleep(poll);
+        polls += 1;
+    }
+}
+
+/// #1912: post-submit observability (no retry). A successful submit clears the
+/// input line / grows the transcript, so the rendered tail CHANGES; returns `true`
+/// the moment it does. If it stays byte-identical for `POSTSUBMIT_WINDOW`, the
+/// submit likely didn't take — warn (log/metric only) and return `false`. NEVER
+/// retries the submit: a second `\r` would risk double-submit.
+fn observe_post_submit(target: &InjectTarget) -> bool {
+    observe_post_submit_with(target, POSTSUBMIT_WINDOW, READBACK_POLL)
+}
+
+fn observe_post_submit_with(
+    target: &InjectTarget,
+    window: std::time::Duration,
+    poll: std::time::Duration,
+) -> bool {
+    let before = target.core.lock().vterm.tail_lines(READBACK_TAIL_ROWS);
+    let start = std::time::Instant::now();
+    loop {
+        if target.deleted.load(std::sync::atomic::Ordering::Acquire) {
+            return false;
+        }
+        std::thread::sleep(poll);
+        if target.core.lock().vterm.tail_lines(READBACK_TAIL_ROWS) != before {
+            return true;
+        }
+        if start.elapsed() >= window {
+            tracing::warn!(
+                tag = "#1912-postsubmit-nochange",
+                "input area unchanged after submit — a readback-confirmed line may not have submitted"
+            );
+            return false;
+        }
+    }
 }
 
 /// #1146: lightweight clone of the fields `inject_to_agent` reads from
@@ -2067,6 +2195,12 @@ pub(crate) struct InjectTarget {
     pub submit_key: String,
     pub typed_inject: bool,
     pub deleted: Arc<std::sync::atomic::AtomicBool>,
+    /// #1912: the agent's core, so the typed-inject readback-confirm can poll the
+    /// RENDERED input line (`core.vterm.tail_lines`) before sending the submit key —
+    /// without re-acquiring the registry lock (which the snapshot exists to release).
+    /// Polled with brief lock-and-release so the `pty_read_loop` renders the echo
+    /// between polls.
+    pub core: Arc<CoreMutex<AgentCore>>,
 }
 
 impl InjectTarget {
@@ -2077,6 +2211,7 @@ impl InjectTarget {
             submit_key: h.submit_key.clone(),
             typed_inject: h.typed_inject,
             deleted: Arc::clone(&h.deleted),
+            core: Arc::clone(&h.core),
         }
     }
 }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1164,6 +1164,7 @@ fn inject_with_target_skips_deleted_agent_1146() {
         submit_key: "\r".to_string(),
         typed_inject: false,
         deleted: Arc::clone(&deleted),
+        core: readback_test_core(b""), // #1912: bulk path never reads it
     };
 
     // Inject succeeds when not deleted.
@@ -1174,6 +1175,130 @@ fn inject_with_target_skips_deleted_agent_1146() {
 
     // Inject must return Ok (no-op) without writing.
     assert!(inject_with_target(&target, b"should be skipped").is_ok());
+}
+
+// ── #1912 readback-confirm inject (hermetic, VTerm-driven) ──────────────────
+
+/// #1912: build a throwaway core with a vterm pre-seeded with `feed` (simulating
+/// the backend's echo of typed chars). Lets the readback helpers be tested without
+/// a live backend process.
+fn readback_test_core(feed: &[u8]) -> Arc<CoreMutex<AgentCore>> {
+    let mut vterm = VTerm::new(80, 24);
+    vterm.process(feed);
+    Arc::new(CoreMutex::new(AgentCore {
+        vterm,
+        subscribers: Vec::new(),
+        state: StateTracker::new(None),
+        health: HealthTracker::new(),
+    }))
+}
+
+fn readback_test_target(core: Arc<CoreMutex<AgentCore>>) -> InjectTarget {
+    let writer: PtyWriter = Arc::new(parking_lot::Mutex::new(
+        Box::new(std::io::sink()) as Box<dyn Write + Send>
+    ));
+    InjectTarget {
+        pty_writer: writer,
+        inject_prefix: String::new(),
+        submit_key: "\r".to_string(),
+        typed_inject: true,
+        deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        core,
+    }
+}
+
+#[test]
+fn inject_sentinel_extracts_last_nonblank_line_tail_1912() {
+    assert_eq!(inject_sentinel("hello world"), "hello world");
+    // last NON-EMPTY line (multi-line system header → the line `\r` commits)
+    assert_eq!(inject_sentinel("line one\nline two\n"), "line two");
+    // long line → bounded to the last 24 chars (robust to input-box wrapping)
+    assert_eq!(inject_sentinel(&"x".repeat(50)).len(), 24);
+    // nothing to confirm
+    assert_eq!(inject_sentinel("   \n  "), "");
+    assert_eq!(inject_sentinel(""), "");
+}
+
+#[test]
+fn readback_confirm_returns_true_when_line_rendered_1912() {
+    // vterm shows codex's `›` input line already containing the payload.
+    let payload = "[AGEND-MSG] from=lead kind=task ci-ready wake body";
+    let core = readback_test_core(format!("\u{203a} {payload}").as_bytes());
+    let target = readback_test_target(core);
+    assert!(readback_confirm_typed_with(
+        &target,
+        payload,
+        std::time::Duration::from_secs(1),
+        std::time::Duration::from_millis(5),
+    ));
+}
+
+#[test]
+fn readback_confirm_times_out_fail_open_when_not_rendered_1912() {
+    // Input area shows only the empty `›` prompt — the payload never rendered.
+    let core = readback_test_core("\u{203a} ".as_bytes());
+    let target = readback_test_target(core);
+    let start = std::time::Instant::now();
+    let confirmed = readback_confirm_typed_with(
+        &target,
+        "this text never renders in the input area",
+        std::time::Duration::from_millis(80),
+        std::time::Duration::from_millis(5),
+    );
+    assert!(!confirmed, "unconfirmed within timeout must report false");
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(1),
+        "fail-open: must return promptly at timeout, never hang the wake path"
+    );
+}
+
+#[test]
+fn readback_confirm_waits_for_async_echo_then_confirms_1912() {
+    // Mechanism test (deterministic, no daemon/PTY → flake-free): the backend's
+    // echo of the typed line arrives in the vterm AFTER inject starts polling
+    // (mirrors real echo round-trip latency). readback must POLL until it renders
+    // — not give up early, not confirm before the echo lands. This is the heart of
+    // the fix: replace the fixed-sleep guess with "wait for the actual render".
+    let payload = "[AGEND-MSG] from=lead ci-ready wake unique-12345 body tail";
+    let core = readback_test_core("\u{203a} ".as_bytes()); // empty `›` prompt initially
+    let target = readback_test_target(Arc::clone(&core));
+    let c2 = Arc::clone(&core);
+    let echoed = payload.to_string();
+    let echo = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(40)); // echo latency
+        c2.lock()
+            .vterm
+            .process(format!("\u{203a} {echoed}").as_bytes());
+    });
+    let confirmed = readback_confirm_typed_with(
+        &target,
+        payload,
+        std::time::Duration::from_secs(2),
+        std::time::Duration::from_millis(5),
+    );
+    assert!(
+        confirmed,
+        "readback must poll until the async echo renders, then confirm"
+    );
+    echo.join().expect("echo thread");
+}
+
+#[test]
+fn observe_post_submit_detects_screen_change_1912() {
+    let core = readback_test_core("\u{203a} before".as_bytes());
+    let target = readback_test_target(Arc::clone(&core));
+    // Another thread mutates the vterm to simulate the submit's re-render.
+    let c2 = Arc::clone(&core);
+    let h = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        c2.lock().vterm.process(b"\r\nassistant: working on it");
+    });
+    assert!(observe_post_submit_with(
+        &target,
+        std::time::Duration::from_secs(1),
+        std::time::Duration::from_millis(5),
+    ));
+    h.join().expect("mutator thread");
 }
 /// #1144: pty_read_loop error path must trigger handle_pty_close cleanup.
 /// Previously, `Err(e)` broke out of the loop without calling


### PR DESCRIPTION
## #1912 — readback-confirm inject (root fix for the codex `\r`-race stopgap)

Replaces the fixed pre-submit `sleep` (a version-specific "guess" — 50ms, bumped to
250ms in #1910) in the typed-inject path with a **terminal-state readback**: after
typing the payload, poll the RENDERED input area until the typed line lands, *then*
send the submit `\r`. Adaptive, version-agnostic, no magic number.

### Root cause
`inject_with_target` types the payload, then sends `\r` to submit. codex's
re-rendering `›` input widget doesn't reliably commit a typed line before the
trailing `\r` arrives → the `\r` is swallowed as an in-line newline → the wake sits
un-submitted → **the agent never wakes**. The fixed sleep just "guessed" how long
the widget needs; every codex version re-tuned it.

### Fix (pre-confirm handshake)
- `InjectTarget` gains `core: Arc<CoreMutex<AgentCore>>` so the inject path (which
  snapshots + releases the registry lock) can poll the rendered screen via
  `core.vterm.tail_lines()` — the same in-process read state-detection uses. Polled
  with brief lock-and-release so the `pty_read_loop` renders the echo between polls.
- `readback_confirm_typed`: poll until the typed line's **tail-sentinel** (last ≤24
  chars of the final non-blank line — robust to input-box wrapping) renders in the
  bottom rows, then return so the caller submits. **Single submit → zero
  double-submit risk** (vs a post-confirm+retry, whose retry `\r` is the footgun).
- **FAIL-OPEN on timeout** (2s): if the echo never renders, submit anyway + `warn`
  (tag `#1912-readback-timeout`). This path is the agent-wake lifeline — an
  unconfirmed readback must never become "don't submit" (= agent never wakes, a
  regression worse than today's blind submit).
- `observe_post_submit`: optional post-submit observability (log/metric-only, **never
  retries**) — the input area should change after submit; warn (`#1912-postsubmit-
  nochange`) if it stays byte-identical, so prod can see whether confirmed submits land.

### Scope
Gated on `target.typed_inject` (codex/opencode/gemini/agy — the re-rendering input
widgets). **claude `❯` bulk keeps its fast path byte-identical** (tolerates bulk +
`\r`; no readback, no added latency). The fixed pre-submit sleep is removed for
typed-inject (readback replaces it); the bulk 50ms is untouched.

### Tests — all hermetic, deterministic, flake-free (no daemon, no real PTY)
`src/agent/tests.rs`: `inject_sentinel` extraction; readback confirms when the line
is rendered; **readback polls and waits for an async echo** then confirms (the heart
of the fix — a background thread renders the echo after inject starts polling);
readback times out fail-open promptly without hanging; post-submit screen-change
detection.

**Test-strategy note (deviation from the spike's "AgendHarness-shell" idea, flagged
for review):** `typed_inject` is a backend-preset constant and `Shell = false`, so an
AgendHarness *shell* agent goes through the BULK path and would not exercise the
readback code at all. Rather than add a real-daemon test that can't cover readback
(and adds daemon-boot flake surface on this lifeline path), the async-echo test
covers the actual poll-until-rendered mechanism deterministically. The real codex
0.138 `›`-widget render timing remains out of hermetic reach — final fidelity is the
contributor's standalone winpty harness (honestly out-of-CI-scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
