### PR TITLE
fix(#1915): deleting-set spawn chokepoint — deep-root resurrection guard

### DIFF
--- a/src/agent/deleting.rs
+++ b/src/agent/deleting.rs
@@ -1,0 +1,152 @@
+//! #1915: the delete-vs-spawn chokepoint — a process-global set of the
+//! `(home, name)` instances currently undergoing teardown.
+//!
+//! A spawn racing a delete RESURRECTS the instance: it re-creates
+//! `workspace/<name>` + a registry handle AFTER teardown cleanup already ran (the
+//! intermittent residual root of the #1902–#1909 teardown class — boot-stagger
+//! spawn, crash-respawn worker, stage2-restart). The per-path `deleted`-flag
+//! checks (#1918 A1) only cover the window while the registry handle still
+//! exists; this set survives handle removal and covers the whole delete.
+//!
+//! `spawn_agent` and `spawn_and_register_agent` consult [`is_deleting`] at their
+//! TOP — before ANY side effect (skills-install, `build_command`, child spawn) —
+//! and refuse to spawn a name that is mid-delete. The outermost delete entries
+//! (`full_delete_instance`, app-mode `kill_agent`, the daemon replace paths)
+//! call [`mark_deleting`] at their top and hold the returned [`DeletingGuard`]
+//! until ALL teardown side-effects (incl. workspace cleanup) complete.
+//!
+//! **Lock discipline (#1492 class):** the set is a LEAF lock — acquired
+//! standalone, NEVER nested inside the registry lock. The two spawn checks run at
+//! function top, before any `registry.lock()`; the delete marks run before the
+//! delete touches the registry. So the deleting-set lock and the registry lock
+//! are never held simultaneously → no lock-order deadlock.
+//!
+//! **No-leak guarantee:** [`DeletingGuard`]'s `Drop` decrements a refcount and
+//! removes the entry at zero on EVERY path — normal return, early `Err`, or
+//! panic-unwind. A leaked entry would make that `(home, name)` un-spawnable for
+//! the daemon's lifetime (a name that can never be re-created), so the guard is
+//! the load-bearing invariant. The refcount (vs a bare set) keeps re-entrant or
+//! concurrent same-name marks correct: the entry clears only when the LAST guard
+//! drops.
+
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+fn registry() -> &'static Mutex<HashMap<(PathBuf, String), u32>> {
+    static DELETING: OnceLock<Mutex<HashMap<(PathBuf, String), u32>>> = OnceLock::new();
+    DELETING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn key(home: &Path, name: &str) -> (PathBuf, String) {
+    (home.to_path_buf(), name.to_string())
+}
+
+/// True iff `name` under `home` is currently mid-delete and must not be spawned.
+pub fn is_deleting(home: &Path, name: &str) -> bool {
+    registry().lock().contains_key(&key(home, name))
+}
+
+/// Mark `name` under `home` as deleting for the lifetime of the returned guard.
+/// Hold the guard across the WHOLE outermost-delete teardown; its `Drop` un-marks
+/// on every path (incl. panic) so the name can be re-created afterwards.
+#[must_use = "hold the DeletingGuard for the delete's duration; dropping it immediately un-marks the instance"]
+pub fn mark_deleting(home: &Path, name: &str) -> DeletingGuard {
+    let k = key(home, name);
+    *registry().lock().entry(k.clone()).or_insert(0) += 1;
+    DeletingGuard { key: k }
+}
+
+/// RAII marker: the `(home, name)` is "deleting" while this guard is alive.
+pub struct DeletingGuard {
+    key: (PathBuf, String),
+}
+
+impl Drop for DeletingGuard {
+    fn drop(&mut self) {
+        let mut reg = registry().lock();
+        if let Some(count) = reg.get_mut(&self.key) {
+            *count -= 1;
+            if *count == 0 {
+                reg.remove(&self.key);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp(tag: &str) -> PathBuf {
+        // Unique per call so concurrent tests (thread-mode `cargo test`) never
+        // share a key — the set is a process-global.
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        std::env::temp_dir().join(format!(
+            "agend-deleting-{}-{}-{}",
+            std::process::id(),
+            tag,
+            C.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn mark_sets_then_drop_clears() {
+        let home = tmp("basic");
+        assert!(!is_deleting(&home, "victim"));
+        {
+            let _g = mark_deleting(&home, "victim");
+            assert!(is_deleting(&home, "victim"), "marked → deleting");
+        }
+        assert!(
+            !is_deleting(&home, "victim"),
+            "guard drop → un-marked (name re-creatable)"
+        );
+    }
+
+    #[test]
+    fn home_scoped_keys_do_not_collide() {
+        let a = tmp("home-a");
+        let b = tmp("home-b");
+        let _g = mark_deleting(&a, "victim");
+        assert!(is_deleting(&a, "victim"));
+        assert!(
+            !is_deleting(&b, "victim"),
+            "same name under a different home is independent"
+        );
+    }
+
+    #[test]
+    fn refcount_clears_only_on_last_guard() {
+        let home = tmp("refcount");
+        let g1 = mark_deleting(&home, "victim");
+        let g2 = mark_deleting(&home, "victim");
+        drop(g1);
+        assert!(
+            is_deleting(&home, "victim"),
+            "still deleting while a second guard is held"
+        );
+        drop(g2);
+        assert!(!is_deleting(&home, "victim"), "cleared when the last drops");
+    }
+
+    #[test]
+    fn panic_in_delete_still_unmarks() {
+        // The load-bearing guarantee: a panic mid-delete must not leave the name
+        // permanently stuck (un-re-creatable). Drop runs on unwind.
+        let home = tmp("panic");
+        let home2 = home.clone();
+        let r = std::panic::catch_unwind(move || {
+            let _g = mark_deleting(&home2, "victim");
+            assert!(is_deleting(&home2, "victim"));
+            panic!("delete blew up mid-teardown");
+        });
+        assert!(r.is_err(), "the closure panicked");
+        assert!(
+            !is_deleting(&home, "victim"),
+            "guard Drop ran on unwind → name un-marked even after a panic"
+        );
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 mod dismiss;
 pub use dismiss::try_dismiss_dialog;
 
+pub mod deleting;
+
 pub type PtyWriter = Arc<Mutex<Box<dyn Write + Send>>>;
 
 /// Core state for one agent — protected by a single Mutex for atomic operations.
@@ -953,6 +955,20 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         crash_tx,
         shutdown,
     } = config;
+
+    // #1915 chokepoint: refuse to spawn an instance that is mid-delete, BEFORE
+    // any side effect — `build_command` below sets the child cwd and spawns the
+    // child, which re-creates `workspace/<name>`. Covers the crash-respawn
+    // worker / stage2-restart / direct-spawn resurrection paths (the boot path is
+    // gated earlier, in `spawn_and_register_agent`, before skills-install). The
+    // deleting-set is a LEAF lock checked before any `registry.lock()` here.
+    if let Some(home_path) = *home {
+        if deleting::is_deleting(home_path, name) {
+            anyhow::bail!(
+                "#1915: refusing to spawn '{name}' — instance is mid-delete (deleting-set chokepoint)"
+            );
+        }
+    }
 
     let (cmd, detected_backend) = build_command(config)?;
 

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -637,6 +637,50 @@ fn quick_user_exit_still_clean() {
     );
 }
 
+/// #1915 chokepoint: `spawn_agent` refuses an instance that is mid-delete,
+/// BEFORE any side effect (`build_command` / child spawn). Covers the
+/// crash-respawn-worker / stage2-restart / direct-`spawn_agent` resurrection
+/// paths — they all funnel through here. No registry handle is inserted.
+#[test]
+fn spawn_agent_refuses_mid_delete_1915() {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static C: AtomicU32 = AtomicU32::new(0);
+    let home = std::env::temp_dir().join(format!(
+        "agend-spawn-del-{}-{}",
+        std::process::id(),
+        C.fetch_add(1, Ordering::Relaxed)
+    ));
+    let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+    // Mark mid-delete, as `full_delete_instance`'s guard would.
+    let _guard = crate::agent::deleting::mark_deleting(&home, "victim");
+    let cfg = SpawnConfig {
+        name: "victim",
+        backend_command: "true",
+        args: &[],
+        spawn_mode: crate::backend::SpawnMode::Fresh,
+        cols: 80,
+        rows: 24,
+        env: None,
+        working_dir: None,
+        submit_key: "\r",
+        home: Some(&home),
+        crash_tx: None,
+        shutdown: None,
+    };
+    let err = match spawn_agent(&cfg, &registry) {
+        Ok(()) => panic!("#1915: a mid-delete spawn must be refused, got Ok"),
+        Err(e) => format!("{e}"),
+    };
+    assert!(
+        err.contains("mid-delete") || err.contains("#1915"),
+        "refusal should name the chokepoint, got: {err}"
+    );
+    assert!(
+        registry.lock().is_empty(),
+        "#1915: bailed before the insert — no handle, no resurrection"
+    );
+}
+
 /// Deleted agent: reaper should not spawn shell fallback when deleted flag is set.
 /// Behavioral test: spawn a short-lived process, set deleted=true, verify
 /// no shell replacement appears in registry after exit.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1496,6 +1496,10 @@ fn scroll_focused(layout: &mut Layout, delta: i32) {
 /// `kill_process_tree` + synchronous wait-for-exit + `take_binding` + event
 /// log, matching the API delete path.
 fn kill_agent(home: &Path, registry: &AgentRegistry, name: &str) {
+    // #1915: app-mode teardown entry — mark "deleting" so a concurrent spawn
+    // (e.g. a crash-respawn triggered by the kill below) cannot resurrect the
+    // instance. Guard held to fn return; Drop un-marks on every path.
+    let _delete_guard = crate::agent::deleting::mark_deleting(home, name);
     crate::daemon::lifecycle::delete_transaction(home, name, registry, None, false);
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1502,6 +1502,20 @@ fn spawn_and_register_agent(
     shutdown: &Arc<std::sync::atomic::AtomicBool>,
 ) -> anyhow::Result<()> {
     let (name, command, args, env, working_dir, submit_key) = def;
+    // #1915 chokepoint (boot path): skip an instance deleted mid-boot BEFORE the
+    // skills-install below re-creates `workspace/<name>`. The boot loop iterates a
+    // fleet snapshot with a ~500ms inter-spawn stagger; a delete in that window
+    // must not be resurrected. Complements the #1918 (b) `instance_is_known`
+    // recheck in the spawn loop — that catches a delete that already removed the
+    // fleet.yaml entry; this deleting-set check covers the in-flight teardown
+    // (entry not yet removed). Leaf-lock check, no registry lock held.
+    if crate::agent::deleting::is_deleting(home, name) {
+        tracing::info!(
+            agent = %name,
+            "skipping spawn — instance is mid-delete (#1915 deleting-set chokepoint)"
+        );
+        return Ok(());
+    }
     let worktree_source = working_dir
         .as_ref()
         .and_then(|wd| crate::worktree::source_repo_of(wd));
@@ -2539,6 +2553,49 @@ mod tests {
         );
 
         kill_registered_child(&registry, "probe-1");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1915 boot-path chokepoint: `spawn_and_register_agent` must SKIP an
+    /// instance that is mid-delete (the boot-stagger resurrection: the loop holds
+    /// a fleet snapshot, an instance deleted during the stagger must not be
+    /// re-spawned + have its `workspace/<name>` re-created by skills-install).
+    /// Also proves the deleting-set does NOT leak the name: after the delete
+    /// completes (guard drop), a re-create of the SAME name spawns normally.
+    #[cfg(unix)]
+    #[test]
+    fn spawn_and_register_agent_skips_mid_delete_1915() {
+        let home = tmp_home("mid_delete");
+        let run_dir = setup_run_dir_with_cookie(&home);
+        seed_fleet_ids(&home, &["victim"]);
+        let (registry, configs, crash_tx, _crash_rx, shutdown) = make_test_registry();
+        let def = make_shell_agent_def("victim");
+
+        // Mark victim mid-delete (as full_delete_instance's guard would).
+        let guard = crate::agent::deleting::mark_deleting(&home, "victim");
+
+        spawn_and_register_agent(&home, &def, &registry, &configs, &crash_tx, &shutdown)
+            .expect("returns Ok (clean skip, not Err)");
+        assert!(
+            crate::ipc::read_port(&run_dir, "victim").is_none(),
+            "#1915: a mid-delete instance must NOT be spawned — no port published"
+        );
+        assert!(
+            registry.lock().is_empty(),
+            "#1915: a mid-delete instance must NOT be registered — no resurrection"
+        );
+
+        // Delete completes → guard drops → name un-marked → re-create succeeds
+        // (deleting-set must not leave the name permanently un-spawnable).
+        drop(guard);
+        spawn_and_register_agent(&home, &def, &registry, &configs, &crash_tx, &shutdown)
+            .expect("re-create after delete spawns");
+        assert!(
+            crate::ipc::read_port(&run_dir, "victim").is_some(),
+            "#1915 no-leak: same name re-creatable once the delete (guard) is done"
+        );
+
+        kill_registered_child(&registry, "victim");
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -261,6 +261,11 @@ impl PerTickHandler for RecoveryDispatcherHandler {
         let targets: Vec<RecoveryTarget> = {
             let reg = agent::lock_registry_tracked(ctx.registry, "recovery_dispatcher");
             reg.values()
+                // #1915 TIER-B2: skip a handle being deleted (deleted flag set in
+                // delete_transaction Step1, handle removed Step4) — don't dispatch
+                // hang-recovery (PTY writes / stage2) to an instance mid-teardown.
+                // Separate concern from the spawn chokepoint.
+                .filter(|h| !h.deleted.load(std::sync::atomic::Ordering::Acquire))
                 .map(|h| RecoveryTarget {
                     name: h.name.to_string(),
                     core: Arc::clone(&h.core),

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1091,6 +1091,12 @@ fn tick(
     let handles: Vec<(String, String, _)> = {
         let reg = agent::lock_registry(registry);
         reg.values()
+            // #1915 TIER-B1: skip a handle being deleted (deleted flag set in
+            // delete_transaction Step1, handle removed Step4) — otherwise the
+            // transition-reaction loop below fires spurious orchestrator
+            // notifications (NotifySeverity::Error) about an instance that is
+            // mid-teardown. Separate concern from the spawn chokepoint.
+            .filter(|h| !h.deleted.load(std::sync::atomic::Ordering::Acquire))
             .map(|h| {
                 (
                     h.name.to_string(),

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -69,6 +69,14 @@ fn remove_empty_dir_tree(dir: &Path) {
 /// is a human-readable string listing the residual stores plus any
 /// per-step error captured during cleanup.
 pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String> {
+    // #1915: mark this instance "deleting" for the ENTIRE teardown — the guard is
+    // held until this fn returns (after workspace cleanup + the residual audit
+    // below), so any concurrent spawn (boot-stagger / crash-respawn worker /
+    // stage2) is refused at the `spawn_agent` / `spawn_and_register_agent`
+    // chokepoints. `DeletingGuard::drop` un-marks on EVERY path (normal return,
+    // early `Err`, panic), so the name is always re-creatable afterwards — a
+    // leaked mark would make it un-spawnable for the daemon's lifetime.
+    let _delete_guard = crate::agent::deleting::mark_deleting(home, name);
     let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
     let (topic_id, working_dir) = fleet
         .as_ref()


### PR DESCRIPTION
The deep-root completion of the spawn-vs-delete **resurrection class** (#1902–#1909): a spawn racing a delete re-creates `workspace/<name>` + a registry handle *after* teardown cleanup ran. The per-path `deleted`-flag checks (#1918 A1) only cover the window while the registry handle still exists; this adds a process-global **deleting-set** that survives handle removal and covers the whole delete — one mechanism subsuming the boot-stagger / crash-respawn / stage2 paths.

## Mechanism
`crate::agent::deleting`: a refcounted `(home, name)` set behind a parking_lot **leaf-lock** (never nested with the registry lock — #1492 deadlock class). Both spawn entry points consult `is_deleting` at their **TOP, before any side effect**:
- **`spawn_agent`** — before `build_command`/child-spawn. Covers crash-respawn-worker / stage2-restart / direct-spawn.
- **`spawn_and_register_agent`** — before **skills-install** (the actual boot-path workspace re-creation, which runs *before* `spawn_agent`).

The outermost-delete entries `mark_deleting` at their top and hold a RAII `DeletingGuard` until **all** teardown side-effects (incl. workspace cleanup) complete: `full_delete_instance` (MCP delete + TUI close) and app-mode `kill_agent`. `Drop` un-marks on **every** path — return, early `Err`, panic — so a name is never permanently stuck (a leaked mark = an un-re-creatable name).

## Scope — three complementary layers (kept by design)
The chokepoint is an **additional** layer; the #1918 narrow fixes stay as defense-in-depth covering different windows:
- **A1** (`handle.deleted` in `handle_crash_respawn`) — earliest gate, at the crash *decision*, before the respawn worker is even spawned.
- **(b)** (`instance_is_known` recheck in the boot loop) — covers the *post-delete-complete* edge (spawn lands after the delete fully finished; the bounded deleting-set can't cover that).
- **#1915 deleting-set** — covers the *in-flight teardown* window across the whole `full_delete_instance`, at both spawn entry points.

**A2** (`handle_stage2_restart`) is auto-covered by the `spawn_agent`-top check. **TIER-B**: B1 (supervisor pane-input notify) + B2 (recovery dispatcher) now filter out deleting handles; B3–B7 are a follow-up sweep.

## Verification (§3.9)
- deleting-set unit tests: mark/drop, refcount (clears on last guard), home-scoping, **panic-in-delete still un-marks**.
- `spawn_agent` **refuses** a mid-delete name (crash/stage2/direct) — bails before the insert.
- `spawn_and_register_agent` **skips** a mid-delete name (boot) **and re-creates the same name after the delete completes** (no-leak).
- `cargo fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · full suite (system git) **3806/3806**.

Refs #1915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)