### PR TITLE
fix(#1916): dispatch_idle OwnerAssigned hook — retarget sidecar on task reassign

### DIFF
--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -419,6 +419,67 @@ pub(crate) fn cleanup_pending_for_task_id(home: &Path, task_id: &str) -> usize {
     count
 }
 
+/// #1916: a task REASSIGN (`OwnerAssigned`) must move the dispatch-idle sidecar to
+/// the new owner — otherwise the watchdog keeps nudging the FORMER owner about a
+/// task they no longer hold. Call-site hook (mirrors `cleanup_pending_for_task_id`;
+/// keeps `task_events` free of a dispatch_idle dependency).
+///
+/// - `Some(new_owner)`: RETARGET every sidecar for `task_id` IN PLACE (same
+///   `dispatch_id` file) → `target = new_owner`, and RESET the idle clock
+///   (`issued_at = now`, `not_working_streak = 0`, revive `Exceeded` → `Pending`,
+///   clear `nudge_sent_at`). The new owner just took over; inheriting the prior
+///   owner's near-threshold clock would nudge them immediately (#1866 principle:
+///   the nudge must reflect the CURRENT owner's idle time, not an inherited age).
+/// - `None` (orphan / #1903 disband-orphan): CLEAR the sidecars — there is no owner
+///   to nudge. Delegates to [`cleanup_pending_for_task_id`] (never sets `target=None`).
+///
+/// In-place RMW preserves the `dispatch_id` file identity, so `record_dispatch`'s
+/// `(dispatcher, target, correlation_id)` dedup key recomputes correctly — a later
+/// re-dispatch to the new owner refreshes THIS sidecar rather than duplicating it,
+/// and nothing is orphaned.
+pub(crate) fn reassign_pending_for_task(
+    home: &Path,
+    task_id: &str,
+    new_owner: Option<&str>,
+) -> usize {
+    if task_id.is_empty() || is_placeholder_correlation(Some(task_id)) {
+        return 0;
+    }
+    let Some(new_owner) = new_owner else {
+        // No owner to nudge → clear (NOT target=None).
+        return cleanup_pending_for_task_id(home, task_id);
+    };
+    let mut count = 0usize;
+    for d in list_pending(home) {
+        if d.correlation_id.as_deref() != Some(task_id) {
+            continue;
+        }
+        if d.target == new_owner {
+            continue; // already targets the new owner — nothing to move
+        }
+        let path = pending_path(home, &d.dispatch_id);
+        let updated = crate::store::with_json_state::<PendingDispatch, _, _>(&path, |cur| {
+            cur.target = new_owner.to_string();
+            cur.issued_at = chrono::Utc::now().to_rfc3339();
+            cur.not_working_streak = 0;
+            cur.nudge_sent_at = None;
+            cur.status = DispatchStatus::Pending;
+            true
+        });
+        if matches!(updated, Ok(Some(true))) {
+            count += 1;
+            tracing::info!(
+                target: "dispatch_idle",
+                dispatch_id = %d.dispatch_id,
+                task_id = %task_id,
+                new_owner = %new_owner,
+                "#1916 retargeted pending sidecar to reassigned owner (idle clock reset)"
+            );
+        }
+    }
+    count
+}
+
 /// #1018 (C) eager cleanup: when an instance is deleted, scan pending
 /// sidecars and delete any whose `target` matches the deleted instance
 /// name. The deleted instance can never deliver a `kind=report`, so
@@ -1196,6 +1257,73 @@ mod tests {
         assert_eq!(
             dups, 1,
             "exactly ONE sidecar for the re-dispatched correlation"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// §3.9 #1916: a task REASSIGN (OwnerAssigned A→B) retargets the dispatch-idle
+    /// sidecar to B AND resets its idle clock — so the watchdog nudges B (the new
+    /// owner), not A, and B is not immediately nudged for a task it just received
+    /// (the #1866 principle: nudge reflects the current owner's idle time).
+    #[test]
+    fn reassign_retargets_sidecar_to_new_owner_and_resets_clock_1916() {
+        let home = tmp_home("1916-retarget");
+        // A's sidecar is already near-threshold (590s of a 600s window).
+        let aged = chrono::Utc::now() - chrono::Duration::seconds(590);
+        write_pending_at(
+            &home,
+            "lead",
+            "agent-a",
+            Some("t-reassign"),
+            "task",
+            600,
+            aged,
+        );
+
+        let moved = reassign_pending_for_task(&home, "t-reassign", Some("agent-b"));
+        assert_eq!(moved, 1, "exactly one sidecar retargeted");
+
+        let pending = list_pending(&home);
+        let s = pending
+            .iter()
+            .find(|p| p.correlation_id.as_deref() == Some("t-reassign"))
+            .expect("#1916: sidecar must SURVIVE a reassign (retargeted, not deleted)");
+        assert_eq!(
+            s.target, "agent-b",
+            "#1916: sidecar must target the reassigned owner B, not the former owner A"
+        );
+        assert_eq!(
+            s.status,
+            DispatchStatus::Pending,
+            "#1916: revived to Pending so B gets a fresh window"
+        );
+        assert_eq!(s.not_working_streak, 0, "#1916: debounce streak reset");
+        let issued = chrono::DateTime::parse_from_rfc3339(&s.issued_at)
+            .expect("issued_at rfc3339")
+            .with_timezone(&chrono::Utc);
+        assert!(
+            chrono::Utc::now().signed_duration_since(issued).num_seconds() < 60,
+            "#1916: idle clock RESET on reassign — B must not inherit A's near-threshold age (#1866)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// §3.9 #1916: an ORPHAN (OwnerAssigned with owner=None — #1903 disband/delete
+    /// orphan) CLEARS the sidecar — there is no owner to nudge. It must NOT leave a
+    /// sidecar with target=None (which would nudge nobody / a placeholder forever).
+    #[test]
+    fn reassign_none_clears_orphaned_sidecar_1916() {
+        let home = tmp_home("1916-orphan");
+        record_dispatch(&home, "lead", "agent-a", Some("t-orphan"), "task", 600)
+            .expect("dispatch recorded");
+
+        let cleared = reassign_pending_for_task(&home, "t-orphan", None);
+        assert_eq!(cleared, 1, "orphan (owner=None) clears the sidecar");
+        assert!(
+            list_pending(&home)
+                .iter()
+                .all(|p| p.correlation_id.as_deref() != Some("t-orphan")),
+            "#1916: orphaned task's sidecar must be removed — nobody to nudge (never target=None)"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -729,6 +729,16 @@ fn handle_update(
                 cascade_cancel_children(home, &id, &emitter);
             }
         }
+        // #1916: a reassign (OwnerAssigned with a new owner) must retarget the
+        // dispatch-idle sidecar to the new owner (+ reset its idle clock), else the
+        // watchdog keeps nudging the FORMER owner about a task they no longer hold.
+        // Mirrors the done/cancelled cleanup hook above; runs only after the append
+        // committed. (The orphan path — OwnerAssigned with owner=None — calls the
+        // same helper with None in orphan_tasks_for_owner, which clears the sidecar.)
+        if let Some(ref new_owner) = new_assignee {
+            let _ =
+                crate::daemon::dispatch_idle::reassign_pending_for_task(home, &id, Some(new_owner));
+        }
     }
     // #807 Item 1: see create arm note.
     let task = read_task_record(home, &id).map(|r| record_to_task(&r));
@@ -1159,6 +1169,53 @@ mod tests {
         )
         .expect("create task");
         let _ = args;
+    }
+
+    /// §3.9 #1916 WIRING (real entry point, not just the helper): a `task update`
+    /// that changes the assignee must retarget the dispatch-idle sidecar to the new
+    /// owner — proving `handle_update` actually calls the reassign hook (an
+    /// injected-input helper test alone wouldn't prove the wiring reaches it).
+    #[test]
+    fn task_reassign_retargets_dispatch_sidecar_through_handle_1916() {
+        let home = tmp_home("1916-wiring");
+        create_task(&home, "t-wire-001"); // owner = dev-agent
+                                          // A dispatch-idle sidecar tracks the task, targeting the original owner.
+        crate::daemon::dispatch_idle::record_dispatch(
+            &home,
+            "lead",
+            "dev-agent",
+            Some("t-wire-001"),
+            "task",
+            600,
+        )
+        .expect("dispatch recorded");
+
+        // REAL entry point: the owner reassigns the task to a new owner.
+        let result = handle(
+            &home,
+            "dev-agent",
+            &serde_json::json!({
+                "action": "update",
+                "id": "t-wire-001",
+                "assignee": "new-owner",
+            }),
+        );
+        assert!(
+            result.get("error").is_none(),
+            "#1916: reassign update should succeed, got {result}"
+        );
+
+        let pending = crate::daemon::dispatch_idle::list_pending(&home);
+        let s = pending
+            .iter()
+            .find(|p| p.correlation_id.as_deref() == Some("t-wire-001"))
+            .expect("#1916: sidecar must survive the reassign");
+        assert_eq!(
+            s.target, "new-owner",
+            "#1916 WIRING: `task update(assignee)` must retarget the dispatch-idle sidecar \
+             via handle_update's hook — else the watchdog keeps nudging the former owner"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]

--- a/src/tasks/orphan.rs
+++ b/src/tasks/orphan.rs
@@ -48,17 +48,23 @@ pub fn orphan_tasks_for_owner(home: &Path, owner_name: &str) -> Result<usize, St
     let count = affected.len();
     let emitter = InstanceName::from("system:auto_orphan");
     let events: Vec<TaskEvent> = affected
-        .into_iter()
+        .iter()
         .map(|id| TaskEvent::OwnerAssigned {
-            task_id: id,
+            task_id: id.clone(),
             by: emitter.clone(),
             owner: None,
             routed_to: None,
         })
         .collect();
-    crate::task_events::append_batch(home, &emitter, events)
-        .map(|_| count)
-        .map_err(|e| e.to_string())
+    crate::task_events::append_batch(home, &emitter, events).map_err(|e| e.to_string())?;
+    // #1916: an orphaned task has NO owner → clear its dispatch-idle sidecar so the
+    // watchdog stops nudging the (now-removed) former owner. Same helper as the
+    // reassign path, with owner=None. Best-effort, post-append (the orphan is
+    // committed first).
+    for id in &affected {
+        let _ = crate::daemon::dispatch_idle::reassign_pending_for_task(home, &id.0, None);
+    }
+    Ok(count)
 }
 
 /// #1903: CANCEL tasks owned by an instance deleted as part of a TEAM DISBAND.


### PR DESCRIPTION
## #1916 — dispatch_idle OwnerAssigned hook (retarget sidecar on task reassign)

dispatch_idle cleaned up its sidecars on task done/cancelled and on instance-delete,
but had **no hook for `OwnerAssigned`** (task reassignment). So after a task was
reassigned A→B, the pending-dispatch sidecar still targeted A → the idle watchdog
kept nudging the **former owner** about a task they no longer held.

### Fix
One helper `dispatch_idle::reassign_pending_for_task(home, task_id, new_owner)`,
called at the two `OwnerAssigned` emit sites (verified exhaustive — only these two):
- **`handle_update`** (assignee change, `owner: Some`) → `Some(new_owner)`
- **`orphan_tasks_for_owner`** (#1903 disband/delete orphan, `owner: None`) → `None`

Behavior:
- **`Some(new_owner)` → RETARGET in place**: same `dispatch_id` file, `target =
  new_owner`, and **RESET the idle clock** (`issued_at = now`, `not_working_streak
  = 0`, revive `Exceeded → Pending`, clear `nudge_sent_at`). The new owner just took
  over — inheriting A's near-threshold clock would nudge B immediately (the #1866
  principle: nudge reflects the *current* owner's idle time, not an inherited age).
- **`None` (orphan) → CLEAR** the sidecar (delegates to `cleanup_pending_for_task_id`)
  — there is no owner to nudge; never leaves `target=None`.

### Why call-site (not a central reducer / not inside append)
There is no central side-effect reducer (`handler.rs`'s `OwnerAssigned` match is a
display formatter). The codebase convention is call-site side effects — the existing
`cleanup_pending_for_task_id` is at `handle_update`/`handle_done`, keeping
`task_events::append` free of a dispatch_idle dependency. This hook follows that.

### Dedup-key safety
`record_dispatch`'s dedup key is `(dispatcher, target, correlation_id)` — target-based.
In-place RMW (same `dispatch_id` file) is safe: no duplicate (same file), no orphan
(file preserved + retargeted); the key recomputes correctly, so a later re-dispatch
to the new owner refreshes THIS sidecar rather than duplicating it.

### Tests (§3.9)
- helper: reassign A→B retargets + resets the clock (target=B, Pending, streak=0,
  issued_at recent); orphan(None) clears the sidecar.
- **wiring (real entry point):** `task update(assignee=B)` through `handle()` retargets
  the sidecar — verified teeth: FAILS without the `handle_update` hook, PASSES with it
  (an injected-input helper test alone wouldn't prove the wiring reaches the hook).
- done/cancelled cleanup unchanged (existing tests stay green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
