### PR TITLE
fix(#1923): correlation-tracking PR-A — keying (G8) + in-memory-stale cleanup (G4/G5/G12)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -535,7 +535,14 @@ fn track_dispatch(
             }
         }
     } else if matches!(kind_str, "update" | "query") {
-        if let Some(corr) = msg.correlation_id.as_deref() {
+        // #1923 G8: key the dispatch-idle refresh by the SAME correlation as the
+        // WRITE side above (~:496 records the pending-dispatch sidecar under
+        // `correlation_id.or(task_id)`). A reply carrying only `task_id` (no
+        // explicit `correlation_id`) was refreshed under `correlation_id` (None)
+        // → its sidecar never got refreshed → the dispatch-idle watchdog fired a
+        // FALSE idle nudge despite the reply arriving. Aligning the key is a
+        // superset — behaviour is unchanged when `correlation_id` is set.
+        if let Some(corr) = msg.correlation_id.as_deref().or(msg.task_id.as_deref()) {
             let _ = crate::daemon::dispatch_idle::refresh_issued_at(home, corr);
         }
     }

--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -68,6 +68,20 @@ pub(crate) struct ConflictNotifyTracker {
 }
 
 impl ConflictNotifyTracker {
+    /// #1923 G5: prune per-agent state for agents no longer in the registry
+    /// (deleted / redeployed). Without this a same-name redeploy inherits the old
+    /// instance's `last_conflict_at` (false-gating its first-observation notify or
+    /// starting the 30-min staleness clock from the dead instance's time) and
+    /// `last_escalated_at` (false-suppressing a real escalation). Mirrors the
+    /// #1470 `retry_tracks` sweep; called per-tick from `run_loop` with the live
+    /// registry agent set.
+    pub(crate) fn retain_active(&mut self, active: &std::collections::HashSet<String>) {
+        self.last_conflict_at
+            .retain(|name, _| active.contains(name));
+        self.last_escalated_at
+            .retain(|name, _| active.contains(name));
+    }
+
     /// Per-tick entry point — runs only every `TICKS_PER_SCAN` ticks
     /// for throttling. Returns true iff the scan body fired this
     /// tick.
@@ -488,6 +502,36 @@ mod tests {
         assert!(
             !tracker.last_conflict_at.contains_key("agent-r"),
             "resolution transition must drop last_conflict_at entry"
+        );
+    }
+
+    /// #1923 G5: `retain_active` prunes per-agent state for agents no longer in
+    /// the live registry set (deleted / redeployed), so a same-name redeploy does
+    /// not inherit the dead instance's conflict-observation / escalation-dedup
+    /// timestamps (which would false-gate its first conflict notify or
+    /// false-suppress a real escalation).
+    #[test]
+    fn retain_active_prunes_deleted_agents_1923_g5() {
+        use std::collections::HashSet;
+        let mut tracker = ConflictNotifyTracker::default();
+        let now = chrono::Utc::now();
+        tracker.last_conflict_at.insert("live".to_string(), now);
+        tracker.last_conflict_at.insert("deleted".to_string(), now);
+        tracker.last_escalated_at.insert("live".to_string(), now);
+        tracker.last_escalated_at.insert("deleted".to_string(), now);
+
+        let live: HashSet<String> = ["live".to_string()].into_iter().collect();
+        tracker.retain_active(&live);
+
+        assert!(tracker.last_conflict_at.contains_key("live"));
+        assert!(tracker.last_escalated_at.contains_key("live"));
+        assert!(
+            !tracker.last_conflict_at.contains_key("deleted"),
+            "#1923 G5: a deleted agent's conflict timestamp must be pruned"
+        );
+        assert!(
+            !tracker.last_escalated_at.contains_key("deleted"),
+            "#1923 G5: a deleted agent's escalation timestamp must be pruned"
         );
     }
 

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -397,6 +397,23 @@ fn run_loop(
             // #842: same eviction cadence for the bridge↔daemon idempotent-
             // retry dedup cache. Sibling sweep, same 10-min TTL window.
             crate::api::request_dedup::global().sweep_expired();
+
+            // #1923 G4/G5: prune per-agent in-memory tracker state for agents no
+            // longer in the registry (deleted / redeployed), mirroring the #1470
+            // retry_tracks sweep in `process_error_recovery`. These maps live in
+            // `run_loop` (not reachable from the cross-thread `full_delete_instance`
+            // delete path), so the per-tick `.retain` IS their cleanup-on-delete:
+            // a deleted agent leaves the registry → drops out of `live_agents` →
+            // its entries are pruned next tick. Without it a same-name redeploy
+            // inherits the old instance's state — a false-SUPPRESSED crash notify
+            // (notify_tracks dedup) or a false-FIRED conflict escalation
+            // (conflict_notify `last_conflict_at`/`last_escalated_at`).
+            let live_agents: std::collections::HashSet<String> = {
+                let reg = agent::lock_registry(&registry);
+                reg.values().map(|h| h.name.to_string()).collect()
+            };
+            notify_tracks.retain(|name, _| live_agents.contains(name));
+            conflict_notify_tracker.retain_active(&live_agents);
         }));
         if let Err(payload) = outcome {
             let msg = if let Some(s) = payload.downcast_ref::<String>() {

--- a/src/mcp/handlers/instance_lifecycle/tests.rs
+++ b/src/mcp/handlers/instance_lifecycle/tests.rs
@@ -114,6 +114,42 @@ fn name_residual_anywhere_detects_uuid_metadata_after_fleet_yaml_removed_1682() 
     std::fs::remove_dir_all(home).ok();
 }
 
+/// #1923 G12 (verify-only): `full_delete_instance` removes the escalation-persist
+/// store, so a same-name redeploy does NOT rehydrate the deleted instance's
+/// escalation state. The daemon rehydrates from this store on (re)spawn
+/// (`rehydrate_escalation`); without the delete-time remove a fresh instance
+/// reusing the name would inherit the dead one's crash budget / paged latch.
+/// Confirms the existing `escalation_persist::remove` in `full_delete_instance`
+/// mitigates the gap — no prod change, regression guard.
+#[test]
+fn full_delete_removes_escalation_store_no_stale_rehydrate_1923_g12() {
+    let home = tmp_home("g12_escalation");
+    std::fs::create_dir_all(&home).expect("mkdir home");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances:\n  victim:\n    command: /bin/cat\n",
+    )
+    .expect("seed fleet.yaml");
+    crate::daemon::escalation_persist::persist(
+        &home,
+        "victim",
+        &crate::health::PersistedEscalation::default(),
+    );
+    assert!(
+        crate::daemon::escalation_persist::load_for(&home, "victim").is_some(),
+        "precondition: escalation store seeded for victim"
+    );
+
+    let _ = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        crate::daemon::escalation_persist::load_for(&home, "victim").is_none(),
+        "#1923 G12: full_delete_instance must remove the escalation store — else a \
+         same-name redeploy rehydrates the deleted instance's escalation state"
+    );
+    std::fs::remove_dir_all(home).ok();
+}
+
 #[test]
 fn name_residual_anywhere_detects_inbox_residual() {
     let home = tmp_home("inbox");


### PR DESCRIPTION
**PR-A** of the correlation-tracking class (reviewer-3 audit #1923) — the **zero-dependency** findings. (PR-B = G1/G3/G2, the owner-assign reassign hooks, builds on the now-merged #1922 — coming next.)

## G8 — correlation-key mismatch (`messaging.rs`)
The dispatch-idle sidecar is **recorded** under `correlation_id.or(task_id)` but a `kind=update/query` reply **refreshed** it under `correlation_id` only. So a reply carrying just `task_id` (no explicit correlation_id) never refreshed its sidecar → the dispatch-idle watchdog fired a **false idle nudge** despite the reply arriving. Fix: align the refresh key with the write side (`correlation_id.or(task_id)`) — a **superset**, behaviour unchanged when correlation_id is set. (Likely explains the spurious dispatch_idle nudges seen this session.)

## G4 (notify_tracks) + G5 (conflict_notify) — in-memory-stale-on-redeploy
These per-agent maps live in the supervisor `run_loop`, **not reachable from the cross-thread `full_delete_instance`** delete path — so the cleanup is a **per-tick `.retain(live agents)` sweep**, mirroring the existing #1470 `retry_tracks` sweep. A deleted agent leaves the registry → drops out of `live_agents` → its entries prune next tick. Without it a same-name redeploy inherits the dead instance's crash-notify dedup (false-**suppress**) or conflict-observation/escalation timestamps (false-**fire**/suppress). Adds `ConflictNotifyTracker::retain_active`.

## G12 — escalation rehydrate (verify-only)
`full_delete_instance` **already** removes the escalation-persist store, so a same-name redeploy can't rehydrate the dead instance's escalation state. Adds a regression test pinning that; **no prod change**.

## Verification
- G5 `retain_active` prune unit test + G12 delete-removes-escalation-store regression test.
- `cargo fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · full suite (system git) **3811/3811**.
- Based on post-#1922 main (84f3f1f).

Refs #1923. (LOW G6–G11 details now in hand from reviewer-3; a final-sweep decision to follow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)