### PR TITLE
fix(#1923): correlation-tracking PR-B — owner-assign reassign refresh (G1/G3/G2)

### DIFF
--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -48,8 +48,8 @@ pub use provider::{
 };
 #[allow(unused_imports)]
 pub use registry::{
-    ci_watches_dir, cleanup_watches_for_instance, has_instance_anywhere, remove_watch,
-    watch_filename,
+    ci_watches_dir, cleanup_watches_for_instance, has_instance_anywhere, reassign_next_after_ci,
+    remove_watch, watch_filename,
 };
 #[allow(unused_imports)]
 pub use sweep::{gc_stale_watches, startup_sweep};

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -148,6 +148,60 @@ pub fn cleanup_watches_for_instance(home: &Path, instance: &str) -> usize {
     affected
 }
 
+/// #1923 G1: on task reassignment, re-point the `next_after_ci` of any ci-watch
+/// carrying this `task_id` to the NEW owner, so the post-CI
+/// `[ci-ready-for-action]` handoff routes to the reviewer who now owns the task
+/// instead of the original owner frozen in at dispatch time (the HIGH gap — a
+/// reassigned review handed off to the wrong reviewer). Matched by `task_id`, NOT
+/// instance name (the same flock + atomic-write RMW as
+/// `cleanup_watches_for_instance`). `new_owner=None` (orphan) clears it. Returns
+/// the number of watches updated.
+pub fn reassign_next_after_ci(home: &Path, task_id: &str, new_owner: Option<&str>) -> usize {
+    if task_id.is_empty() {
+        return 0;
+    }
+    let dir = ci_watches_dir(home);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return 0;
+    };
+    let new_val = new_owner.map(|s| s.to_string());
+    let mut affected = 0usize;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        // flock the watch so a concurrent poll/unwatch doesn't race the RMW.
+        let lock_path = path.with_extension("lock");
+        let _lock = match crate::store::acquire_file_lock(&lock_path) {
+            Ok(l) => l,
+            Err(_) => continue, // contended → skip; the next reassign/boot retries
+        };
+        let mut watch: super::watch_state::WatchState = match std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<super::watch_state::WatchState>(&c).ok())
+        {
+            Some(w) => w,
+            None => continue,
+        };
+        if watch.task_id.as_deref() != Some(task_id) || watch.next_after_ci == new_val {
+            continue;
+        }
+        watch.next_after_ci = new_val.clone();
+        if let Err(e) = crate::store::atomic_write(
+            &path,
+            serde_json::to_string_pretty(&watch)
+                .unwrap_or_default()
+                .as_bytes(),
+        ) {
+            tracing::warn!(path = %path.display(), error = %e, "#1923 G1: next_after_ci reassign write failed");
+            continue;
+        }
+        affected += 1;
+    }
+    affected
+}
+
 /// #1907 teardown audit: does any ci-watch still reference `instance` — in its
 /// `subscribers`, the legacy `instance` field, or `next_after_ci`? Mirrors the
 /// three scrub targets of [`cleanup_watches_for_instance`] exactly so the
@@ -432,6 +486,44 @@ mod tests {
             serde_json::to_string_pretty(ws).unwrap(),
         )
         .unwrap();
+    }
+
+    /// #1923 G1: on reassignment, `reassign_next_after_ci` re-points the
+    /// `next_after_ci` of the ci-watch carrying that `task_id` to the new owner
+    /// (so the post-CI handoff routes to the new reviewer); orphan (None) clears.
+    #[test]
+    fn reassign_next_after_ci_repoints_by_task_id_1923_g1() {
+        let home = std::env::temp_dir().join(format!("agend-1923-g1-{}", std::process::id()));
+        std::fs::remove_dir_all(&home).ok();
+        let ws = super::super::watch_state::WatchState {
+            repo: "o/r".into(),
+            branch: "feat".into(),
+            next_after_ci: Some("old-reviewer".into()),
+            task_id: Some("t-x".into()),
+            ..Default::default()
+        };
+        write_watch(&home, "w", &ws);
+
+        assert_eq!(
+            reassign_next_after_ci(&home, "t-x", Some("new-reviewer")),
+            1,
+            "the watch carrying t-x is re-pointed"
+        );
+        let path = ci_watches_dir(&home).join("w.json");
+        let after: super::super::watch_state::WatchState =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(after.next_after_ci.as_deref(), Some("new-reviewer"));
+
+        // Non-matching task_id → no-op; orphan (None) → clear.
+        assert_eq!(reassign_next_after_ci(&home, "t-other", Some("x")), 0);
+        assert_eq!(reassign_next_after_ci(&home, "t-x", None), 1);
+        let after2: super::super::watch_state::WatchState =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(
+            after2.next_after_ci.is_none(),
+            "orphan clears next_after_ci"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     fn sub(name: &str) -> super::super::watch_state::Subscriber {

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -941,6 +941,14 @@ fn stale_sidecar_reason(home: &Path, d: &PendingDispatch) -> Option<&'static str
     if !target_in_fleet(home, &d.target) {
         return Some("target_not_in_fleet");
     }
+    // #1923 G2: the DISPATCHER left the fleet (deleted / redeployed) → the
+    // pending-dispatch sidecar is an orphan whose idle nudge would route to a
+    // ghost dispatcher (and `dispatcher_team` lookups silently no-op, so the
+    // sidecar never self-cleans → infinite retry). `target_in_fleet` is a generic
+    // "agent in fleet.yaml" check, reused here for the dispatcher.
+    if !target_in_fleet(home, &d.dispatcher) {
+        return Some("dispatcher_not_in_fleet");
+    }
     if let Some(corr) = d.correlation_id.as_deref() {
         if let Some(false) = task_still_live(home, corr) {
             return Some("task_closed");
@@ -1423,7 +1431,9 @@ mod tests {
                                       // Live fleet + task so the sidecar isn't swept as stale before it fires.
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
-            format!("instances:\n  {target}:\n    backend: claude\n"),
+            // #1923 G2: seed the dispatcher (`lead`) too — the new
+            // dispatcher-in-fleet stale check requires it (prod always has it).
+            format!("instances:\n  lead:\n    backend: claude\n  {target}:\n    backend: claude\n"),
         )
         .unwrap();
         let task_id = "t-idle-99";
@@ -1927,6 +1937,46 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// #1923 G2: a pending-dispatch sidecar whose DISPATCHER has left the fleet
+    /// (deleted / redeployed) is stale — its idle nudge would route to a ghost
+    /// dispatcher. `stale_sidecar_reason` must flag it `dispatcher_not_in_fleet`
+    /// (mirroring the existing `target_not_in_fleet` check); a live dispatcher is
+    /// not flagged.
+    #[test]
+    fn stale_sidecar_reason_flags_deleted_dispatcher_1923_g2() {
+        let home = tmp_home("g2-dispatcher-stale");
+        // fleet has the TARGET (`dev`) but NOT the dispatcher (it was deleted).
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  dev:\n    command: /bin/cat\n",
+        )
+        .expect("seed fleet.yaml");
+        let mk = |dispatcher: &str| PendingDispatch {
+            schema_version: SCHEMA_VERSION,
+            dispatch_id: "d1".into(),
+            dispatcher: dispatcher.into(),
+            target: "dev".into(),
+            correlation_id: Some("t-realtask".into()),
+            expected_kind: "task".into(),
+            threshold_secs: 600,
+            issued_at: chrono::Utc::now().to_rfc3339(),
+            status: DispatchStatus::Pending,
+            nudge_sent_at: None,
+            not_working_streak: 0,
+        };
+        assert_eq!(
+            stale_sidecar_reason(&home, &mk("ghost-lead")),
+            Some("dispatcher_not_in_fleet"),
+            "#1923 G2: a sidecar whose dispatcher left the fleet is stale"
+        );
+        assert_ne!(
+            stale_sidecar_reason(&home, &mk("dev")),
+            Some("dispatcher_not_in_fleet"),
+            "a live dispatcher must NOT be flagged stale"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// Stale filter: resolved / exceeded / cancelled sidecars do NOT
     /// surface. Only `status == "pending"` reaches L3.
     #[test]
@@ -2294,7 +2344,10 @@ mod tests {
         let home = tmp_home("1018-live");
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
-            "instances:\n  fixup-dev-2:\n    backend: claude\n",
+            // #1923 G2: seed the DISPATCHER too (not just the target) — the
+            // dispatcher-in-fleet stale check now requires it, and in prod the
+            // dispatcher is always a live fleet agent.
+            "instances:\n  fixup-lead:\n    backend: claude\n  fixup-dev-2:\n    backend: claude\n",
         )
         .unwrap();
         let task_id = "t-live-99";

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -72,6 +72,49 @@ pub fn mark_completed(home: &Path, correlation_id: Option<&str>, _to: &str) {
     );
 }
 
+/// #1923 G3: on task reassignment, re-point the dispatch-tracking entry for this
+/// `task_id` to the NEW owner so the stuck-dispatch sweep tracks the agent who
+/// now owns the task (not the stale original `to`, which the sweep would nag /
+/// mis-attribute). Also DEDUPs to a single entry per task (multiple `track_dispatch`
+/// calls — e.g. a re-dispatch — could leave several). `new_owner=None` (orphan)
+/// removes the entries entirely (no owner to track).
+pub fn reassign_to(home: &Path, task_id: &str, new_owner: Option<&str>) {
+    if task_id.is_empty() {
+        return;
+    }
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+            match new_owner {
+                // Orphan: no owner to track — drop the rows (mirrors the
+                // dispatch-idle clear path for owner=None).
+                None => store
+                    .entries
+                    .retain(|e| e.task_id.as_deref() != Some(task_id)),
+                Some(owner) => {
+                    // Keep the FIRST entry for this task (re-pointed to the new
+                    // owner), drop any duplicates.
+                    let mut kept = false;
+                    store.entries.retain_mut(|e| {
+                        if e.task_id.as_deref() != Some(task_id) {
+                            return true;
+                        }
+                        if kept {
+                            return false; // dedup
+                        }
+                        kept = true;
+                        e.to = owner.to_string();
+                        e.to_id = None; // original target's id is now stale
+                        e.status = "pending".to_string();
+                        true
+                    });
+                }
+            }
+            Ok(())
+        }),
+        "dispatch_reassign_to"
+    );
+}
+
 /// Sweep for stuck dispatches. Returns (warn_list, ask_list).
 pub fn sweep_stuck(home: &Path) -> (Vec<DispatchEntry>, Vec<DispatchEntry>) {
     let now = chrono::Utc::now();
@@ -293,6 +336,49 @@ mod tests {
         crate::event_log::log(&home, "dispatch_stuck_warn", &warns[0].to, "test");
         let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
         assert!(log.contains("dispatch_stuck_warn"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1923 G3: on reassignment, `reassign_to` re-points the task's
+    /// dispatch-tracking entry to the new owner + dedups duplicates; orphan
+    /// (None) drops the entries. Unrelated tasks are untouched.
+    #[test]
+    fn reassign_to_repoints_and_dedups_1923_g3() {
+        let home = tmp_home("g3-reassign");
+        let mk = |task: &str, to: &str| DispatchEntry {
+            task_id: Some(task.into()),
+            from: "lead".into(),
+            to: to.into(),
+            from_id: None,
+            to_id: None,
+            delegated_at: chrono::Utc::now().to_rfc3339(),
+            status: "pending".into(),
+        };
+        // Two entries for the same task (a re-dispatch left a duplicate) + an
+        // unrelated task that must survive untouched.
+        track_dispatch(&home, mk("t-x", "old-owner"));
+        track_dispatch(&home, mk("t-x", "old-owner"));
+        track_dispatch(&home, mk("t-other", "keep"));
+
+        reassign_to(&home, "t-x", Some("new-owner"));
+        let raw = std::fs::read_to_string(store_path(&home)).unwrap();
+        assert!(raw.contains("new-owner"), "t-x re-pointed to the new owner");
+        assert!(!raw.contains("old-owner"), "stale owner removed from t-x");
+        assert!(raw.contains("keep"), "unrelated task t-other untouched");
+        assert_eq!(
+            raw.matches("\"t-x\"").count(),
+            1,
+            "duplicate t-x entries deduped to one"
+        );
+
+        // Orphan (None) removes the entries entirely.
+        reassign_to(&home, "t-x", None);
+        let raw2 = std::fs::read_to_string(store_path(&home)).unwrap();
+        assert!(!raw2.contains("\"t-x\""), "orphan removes t-x entries");
+        assert!(
+            raw2.contains("t-other"),
+            "unrelated task survives orphan-clear"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -738,6 +738,12 @@ fn handle_update(
         if let Some(ref new_owner) = new_assignee {
             let _ =
                 crate::daemon::dispatch_idle::reassign_pending_for_task(home, &id, Some(new_owner));
+            // #1923 G1/G3: re-point the SAME task's ci-watch handoff (next_after_ci)
+            // + dispatch-tracking `to` to the new owner — sibling calls at the same
+            // OwnerAssigned emit site, so a reassigned review hands off / is tracked
+            // against the reviewer who now owns the task, not the stale original.
+            let _ = crate::daemon::ci_watch::reassign_next_after_ci(home, &id, Some(new_owner));
+            crate::dispatch_tracking::reassign_to(home, &id, Some(new_owner));
         }
     }
     // #807 Item 1: see create arm note.

--- a/src/tasks/orphan.rs
+++ b/src/tasks/orphan.rs
@@ -63,6 +63,11 @@ pub fn orphan_tasks_for_owner(home: &Path, owner_name: &str) -> Result<usize, St
     // committed first).
     for id in &affected {
         let _ = crate::daemon::dispatch_idle::reassign_pending_for_task(home, &id.0, None);
+        // #1923 G1/G3: an orphaned task has no owner → also clear the ci-watch
+        // handoff + dispatch-tracking entries for the task (same site as the
+        // dispatch-idle clear, with owner=None).
+        let _ = crate::daemon::ci_watch::reassign_next_after_ci(home, &id.0, None);
+        crate::dispatch_tracking::reassign_to(home, &id.0, None);
     }
     Ok(count)
 }


### PR DESCRIPTION
**PR-B** of the correlation-tracking class (reviewer-3 audit #1923) — the **stale-target-on-reassign** findings. Extends #1922's `reassign_pending_for_task` hook with **sibling calls at the same two OwnerAssigned emit sites** (`handle_update` Some(new_owner) + orphan None), so a reassigned task's downstream routing follows the new owner instead of the original frozen in at dispatch time. (PR-A = G8/G4/G5/G12, merged.)

## G1 (HIGH) — ci_watch `next_after_ci` write-once
On reassign, re-point the `next_after_ci` of any ci-watch carrying the task's id to the new owner — else the post-CI `[ci-ready-for-action]` handoff routes to the **wrong reviewer** (the one reassigned away). `reassign_next_after_ci` uses the same flock + atomic-write RMW as `cleanup_watches_for_instance`; orphan (None) clears it.

## G3 — dispatch_tracking `.to` stale + no-dedup
On reassign, re-point the task's dispatch-tracking entry to the new owner **and dedup** duplicates (a re-dispatch could leave several), so the stuck-dispatch sweep tracks/nags the current owner. `reassign_to`; orphan removes the rows.

## G2 — dispatch_idle ghost dispatcher
`stale_sidecar_reason` now also flags `dispatcher_not_in_fleet` (mirroring the existing `target_not_in_fleet`), so a pending-dispatch sidecar whose **dispatcher** was deleted/redeployed is retired instead of retrying its idle nudge forever against a ghost. Two existing "live dispatch still fires" tests now seed the dispatcher in fleet.yaml too (prod always has it) to match the new requirement.

## Verification
- New tests: G1 reassign-by-task_id + orphan-clear; G3 re-point + dedup + orphan; G2 deleted-dispatcher flagged / live dispatcher not flagged.
- `fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · full suite (system git) **3812/3812** (rebased onto current main).

Refs #1923. (LOW G6–G11 sweep — G9/G10/G11+G6 — to follow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)