### PR TITLE
ci(teardown): daemon-boot flake gate (20x, path-gated) + drift-guard invariant

### DIFF
--- a/.github/workflows/daemon-boot-flake-gate.yml
+++ b/.github/workflows/daemon-boot-flake-gate.yml
@@ -1,0 +1,79 @@
+# Daemon-boot flake gate (#t-teardown-determinism).
+#
+# The daemon-booting test class (AgendHarness + `start --foreground`) shares the
+# boot path whose race (#1909) bit #1914 as an intermittent CI red. A reviewer
+# can't catch a low-probability boot flake by running a worktree once, so this
+# workflow repeats the daemon-boot subset 20x under the race-exposing `ci` nextest
+# profile and fails on ANY failure — catching a boot-race regression PRE-MERGE.
+#
+# Cost control: PATH-GATED — only runs when daemon-boot-relevant code/tests change
+# (the daemon boot path + the harness + the gated test files), so docs/unrelated
+# PRs pay nothing. The test SET is the single-source list in
+# tests/daemon_boot_gate_filter.txt (drift-guarded by
+# tests/daemon_boot_gate_invariant.rs). nextest 0.9.137 has no native repeat (only
+# `--retries`, which MASKS flakes), so the repeat is an explicit exit-code loop.
+name: Daemon-boot flake gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/agent/**'
+      - 'src/daemon/**'
+      - 'src/bootstrap/**'
+      - 'tests/common/harness.rs'
+      - 'tests/daemon_boot_gate_filter.txt'
+      - 'tests/teardown_completeness_regression.rs'
+      - 'tests/e2e_workflow.rs'
+      - 'tests/harness_smoke.rs'
+      - 'tests/migrated_scripts.rs'
+      - 'tests/vte_gotchas.rs'
+      - 'tests/restart_smoke.rs'
+      - 'tests/self_respawn_handoff.rs'
+      - 'tests/ready_marker_invariants.rs'
+      - '.github/workflows/daemon-boot-flake-gate.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flake-gate:
+    name: Daemon-boot flake gate (20x)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+      - name: Install Linux tray deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - name: Repeat daemon-boot tests 20x (catch boot-race flakes pre-merge)
+        timeout-minutes: 35
+        env:
+          AGEND_LOCK_AUDIT: "1"
+        run: |
+          set -u
+          # Build the nextest filter from the single-source list (drift-guarded).
+          FILTER=$(grep -vE '^\s*#|^\s*$' tests/daemon_boot_gate_filter.txt \
+            | sed 's/.*/binary(&)/' | paste -sd '+' -)
+          echo "daemon-boot filter: $FILTER"
+          # Build once so the 20 runs only pay test wall-time, not compile.
+          cargo nextest run --features tray --profile ci -E "$FILTER" --no-run
+          for i in $(seq 1 20); do
+            echo "::group::daemon-boot run $i/20"
+            if ! cargo nextest run --features tray --profile ci -E "$FILTER"; then
+              echo "::error::daemon-boot flake gate FAILED on run $i/20 — a daemon-boot test is non-deterministic"
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
+          echo "daemon-boot flake gate: 20/20 clean"

--- a/tests/daemon_boot_gate_filter.txt
+++ b/tests/daemon_boot_gate_filter.txt
@@ -1,0 +1,22 @@
+# Canonical list of daemon-boot test binaries gated by the daemon-boot flake gate.
+# SINGLE SOURCE OF TRUTH — both consumers read THIS file:
+#   - .github/workflows/daemon-boot-flake-gate.yml builds the nextest `-E binary(..)`
+#     filter from it and repeats the set 20x (catching boot-race flakes pre-merge).
+#   - tests/daemon_boot_gate_invariant.rs enforces that every `AgendHarness`-using
+#     test binary is listed here (drift-guard, #1907/#1911 curated-list class).
+#
+# One test-binary name (the tests/<name>.rs stem) per line; '#' comments + blank
+# lines are ignored.
+#
+# AgendHarness users — AUTO-ENFORCED by the invariant (a new AgendHarness test not
+# listed here turns the invariant RED until added):
+teardown_completeness_regression
+e2e_workflow
+harness_smoke
+migrated_scripts
+vte_gotchas
+# Direct daemon-boot (start --foreground, not via AgendHarness) — manually listed;
+# add a new direct-boot daemon test here when you write one.
+restart_smoke
+self_respawn_handoff
+ready_marker_invariants

--- a/tests/daemon_boot_gate_invariant.rs
+++ b/tests/daemon_boot_gate_invariant.rs
@@ -1,0 +1,90 @@
+//! Drift-guard for the daemon-boot flake gate (#t-teardown-determinism).
+//!
+//! Every test binary that boots a REAL daemon via `AgendHarness::spawn*` shares the
+//! daemon-boot path whose race (#1909) bit #1914. Those tests are repeated 20x by
+//! `.github/workflows/daemon-boot-flake-gate.yml` to catch boot-race flakes
+//! pre-merge — but only if they're in `tests/daemon_boot_gate_filter.txt`. A new
+//! `AgendHarness` test added WITHOUT being listed there would silently escape the
+//! gate — the #1907/#1911 curated-list-drift class.
+//!
+//! This invariant fails (RED) until every `AgendHarness`-using test binary is in the
+//! filter file, forcing the author to add it. (Direct-boot tests — `start
+//! --foreground` without AgendHarness — are listed manually in the file; they are
+//! not auto-detectable here, so this invariant covers the AgendHarness class, which
+//! is the one that grows.)
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+const TESTS_DIR: &str = "tests";
+const FILTER_FILE: &str = "tests/daemon_boot_gate_filter.txt";
+
+/// Binary names listed in the gate filter file (comments/blanks stripped).
+fn gate_filter_binaries() -> BTreeSet<String> {
+    let txt =
+        std::fs::read_to_string(FILTER_FILE).unwrap_or_else(|e| panic!("read {FILTER_FILE}: {e}"));
+    txt.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(String::from)
+        .collect()
+}
+
+/// Test binaries (tests/<name>.rs stems) that call `AgendHarness::spawn*`. Note
+/// `read_dir(TESTS_DIR)` is non-recursive, so the harness DEFINITION in
+/// `tests/common/harness.rs` is not scanned — only top-level integration tests that
+/// USE it. `"AgendHarness::spawn"` is a prefix of `spawn`/`spawn_with`, so both match.
+fn agendharness_user_binaries() -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for entry in std::fs::read_dir(TESTS_DIR)
+        .expect("read tests/ dir")
+        .flatten()
+    {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        // Skip THIS invariant file — its scan code contains the literal
+        // "AgendHarness::spawn", which would otherwise self-match (it does not
+        // boot a daemon). Mirrors the `is_self` skip in git_subprocess_invariant.
+        if path.file_stem().and_then(|s| s.to_str()) == Some("daemon_boot_gate_invariant") {
+            continue;
+        }
+        if std::fs::read_to_string(&path)
+            .map(|c| c.contains("AgendHarness::spawn"))
+            .unwrap_or(false)
+        {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                out.insert(stem.to_string());
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn agendharness_users_are_in_the_flake_gate_filter() {
+    let gated = gate_filter_binaries();
+    let users = agendharness_user_binaries();
+    assert!(
+        !users.is_empty(),
+        "sanity: expected to find AgendHarness-using test binaries; found none — \
+         did the scan path or the harness API change?"
+    );
+
+    let missing: Vec<&String> = users.iter().filter(|b| !gated.contains(*b)).collect();
+    assert!(
+        missing.is_empty(),
+        "daemon-boot flake-gate DRIFT — these AgendHarness-using test binaries are NOT in \
+         {FILTER_FILE}, so they'd escape the 20x flake gate. Add each to the file:\n  {missing:#?}\n\
+         (curated-list-drift guard — #1907/#1911 class.)"
+    );
+
+    // Stale-entry guard: every listed binary must be a real test file.
+    for b in &gated {
+        assert!(
+            Path::new(TESTS_DIR).join(format!("{b}.rs")).exists(),
+            "{FILTER_FILE} lists '{b}' but {TESTS_DIR}/{b}.rs does not exist (stale/typo entry)"
+        );
+    }
+}


### PR DESCRIPTION
## teardown-determinism: daemon-boot flake gate + drift-guard

The resurrection-root fixes (#1918 + #1921) made the **entire daemon-boot test class
deterministic** — verified locally under `nextest --profile ci`:
- teardown_completeness_regression + e2e_workflow: **50/50** clean
- boot-heavy set (harness_smoke, restart_smoke, self_respawn_handoff,
  ready_marker_invariants, migrated_scripts, vte_gotchas): **30/30** clean

This PR adds the **gate that keeps it that way** — the daemon-boot path's race (#1909)
bit #1914 as an intermittent main red, and a reviewer can't catch a low-probability
boot flake by running a worktree once.

### Three pieces (lead-approved design)
1. **`tests/daemon_boot_gate_filter.txt`** — single source of truth: the daemon-boot
   test binaries (AgendHarness users + the direct-boot ones).
2. **`.github/workflows/daemon-boot-flake-gate.yml`** — a **path-gated** workflow
   (only runs when `src/agent|daemon|bootstrap`, the harness, or the gated test files
   change — docs/unrelated PRs pay nothing) that builds the nextest filter from the
   file and repeats the set **20×** under the `ci` profile, failing on ANY failure.
   nextest 0.9.137 has no native repeat (only `--retries`, which *masks* flakes), so
   the repeat is an explicit exit-code loop.
3. **`tests/daemon_boot_gate_invariant.rs`** — drift-guard: every `AgendHarness`-using
   test binary MUST be in the filter file, else the invariant goes RED (the
   #1907/#1911 curated-list-drift class — a new daemon-boot test can't silently
   escape the gate). Teeth-verified: removing a binary from the file fails the
   invariant, naming it.

### Caveat for the operator (branch-protection)
A `paths:`-filtered workflow does **not** trigger on PRs that touch none of those
paths, so this gate is **advisory by default** — do NOT add it to required status
checks as-is, or path-irrelevant PRs would block on a never-reported check (the known
GH Actions "path-filtered required check stays pending" gotcha). If you want it
required, it needs the skipped→success shim. Left non-required intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
