### PR TITLE
fix(#1923): correlation-tracking LOW-sweep — G10 + G6 + G11 (closes #1923)

### DIFF
--- a/src/daemon/dispatch_idle/team_nudge.rs
+++ b/src/daemon/dispatch_idle/team_nudge.rs
@@ -169,7 +169,16 @@ pub(crate) fn scan_and_nudge(home: &Path) {
         }
         // Nudge for ANY team's dispatch (was gated to the fixup team); a teamless
         // (solo) dispatcher has no orchestration context → skip.
+        // #1923 G6: but STAMP `nudge_sent_at` first so the L2 team-nudge does not
+        // retry this Exceeded sidecar every scan FOREVER (the dispatcher left its
+        // team — or was always solo — so there is no orchestrator to escalate to).
+        // `stamp_nudge_sent` only sets the L2 dedup guard under the sidecar lock;
+        // it does NOT remove the sidecar, so a legitimate solo dispatcher's L1
+        // lifecycle is untouched. (A dispatcher that left the FLEET entirely is
+        // already retired in L1 by the #1923 G2 `dispatcher_not_in_fleet` check;
+        // this covers the narrower "left the team but still in the fleet" window.)
         let Some(team) = dispatcher_team(home, &d.dispatcher) else {
+            stamp_nudge_sent(home, &d.dispatch_id);
             continue;
         };
         if !emit_nudge(home, &d, &team) {
@@ -276,6 +285,33 @@ mod tests {
         assert_eq!(
             second_count, 0,
             "second scan must NOT re-nudge (dedup via nudge_sent_at)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1923 G6: a sidecar whose dispatcher has NO team (solo, or left the team
+    /// but still in the fleet) must have its L2 `nudge_sent_at` STAMPED — else the
+    /// team-nudge scan retries the Exceeded sidecar every scan FOREVER (there is no
+    /// orchestrator to escalate to). The sidecar is NOT removed (a solo dispatcher
+    /// keeps its L1 lifecycle); only the L2 retry is stopped.
+    #[test]
+    fn no_team_dispatcher_stamps_nudge_sent_stops_retry_1923_g6() {
+        let home = tmp_home("g6-no-team");
+        // Dispatcher is in the fleet (so L1 #1923-G2 doesn't retire it) but in NO
+        // team → `dispatcher_team` returns None.
+        std::fs::write(
+            home.join("fleet.yaml"),
+            "schema_version: 1\ninstances:\n  solo-lead:\n    backend: claude\n",
+        )
+        .unwrap();
+        let id = write_exceeded_sidecar(&home, "solo-lead", "dev", "t-g6", 700);
+        scan_and_nudge(&home);
+        let sidecar: PendingDispatch =
+            serde_json::from_str(&std::fs::read_to_string(pending_path(&home, &id)).unwrap())
+                .unwrap();
+        assert!(
+            sidecar.nudge_sent_at.is_some(),
+            "#1923 G6: a no-team dispatcher's sidecar must be stamped to stop the L2 retry"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -176,6 +176,18 @@ pub(crate) fn scan_and_emit_with<F>(
                 // redelivers the handoff to the orchestrator itself.
                 continue;
             }
+            // #1923 G11: the recipient is the hardcoded `FALLBACK_RECIPIENT`
+            // ("lead") when `team_orchestrator_for` finds no team orchestrator. If
+            // no instance named "lead" exists in this fleet, the escalation would
+            // be written to a GHOST inbox (silently lost). Skip + log instead of
+            // escalating into the void.
+            if !crate::fleet::instance_is_known(home, &recipient) {
+                tracing::warn!(
+                    %target, %recipient, %corr,
+                    "#1923 G11: handoff-timeout escalation recipient not in fleet — skipping (would be a ghost inbox)"
+                );
+                continue;
+            }
             let text = format!(
                 "[handoff_timeout_watchdog] the next_after_ci handoff to '{target}' for {corr} \
                  has been unclaimed for {age_min}min — CI passed and a [ci-ready-for-action] \
@@ -352,6 +364,35 @@ mod tests {
                     && m.text.contains("o/r@feat")),
             "lead must be escalated about the unclaimed handoff: {:?}",
             msgs.iter().map(|m| &m.text).collect::<Vec<_>>()
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// #1923 G11: when the escalation recipient resolves to the hardcoded
+    /// `FALLBACK_RECIPIENT` ("lead") — no team orchestrator for the target — but
+    /// NO instance named "lead" exists in the fleet, the watchdog must SKIP the
+    /// escalation, not write it to a ghost inbox.
+    #[test]
+    fn no_escalation_to_ghost_fallback_recipient_1923_g11() {
+        let home = tmp_home("g11-ghost");
+        // Fleet has the target but no team orchestrator and no "lead" → the
+        // recipient resolves to the "lead" fallback, which does not exist.
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  reviewer:\n    backend: claude\n",
+        )
+        .unwrap();
+        seed_handoff(&home, "reviewer", "o/r@feat", 15, false);
+        run_watchdog(
+            &home,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
+        assert!(
+            crate::inbox::drain(&home, "lead").is_empty(),
+            "#1923 G11: escalation must be skipped when the fallback recipient \
+             'lead' is absent from the fleet (no ghost inbox)"
         );
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -203,9 +203,13 @@ pub fn cleanup_for_instance(home: &Path, instance: &str) -> usize {
     persist_or_log!(
         crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
             let before = store.entries.len();
-            store
-                .entries
-                .retain(|e| e.from != instance && e.to != instance);
+            // #1923 G10: only drop entries where the deleted instance is the
+            // ASSIGNEE (`to`). The stuck-sweep nags `.to`, not `.from`, so a
+            // deleted DISPATCHER (`from`) must KEEP the entry — its live assignee
+            // still needs stuck-tracking, and a ghost `from` (audit-only) mis-routes
+            // no nag. Previously `from != instance` over-deleted, silently dropping
+            // a live assignee's stuck-protection when its dispatcher was deleted.
+            store.entries.retain(|e| e.to != instance);
             removed = before - store.entries.len();
             Ok(())
         }),
@@ -631,20 +635,36 @@ mod tests {
         }
     }
 
+    /// #1923 G10: `cleanup_for_instance` drops entries where the deleted instance
+    /// is the ASSIGNEE (`to`) but KEEPS entries where it is only the DISPATCHER
+    /// (`from`) — the stuck-sweep nags `.to` (the live assignee still needs
+    /// tracking; the ghost `from` is audit-only). Previously it over-deleted the
+    /// from-matching entry too, silently losing the live assignee's stuck-protection.
     #[test]
-    fn cleanup_for_instance_removes_from_and_to_keeps_unrelated() {
+    fn cleanup_for_instance_drops_assignee_keeps_deleted_dispatcher_1923_g10() {
         let home = tmp_home("cleanup-inst");
-        track_dispatch(&home, entry("lead", "doomed")); // to == doomed
-        track_dispatch(&home, entry("doomed", "dev")); // from == doomed
-        track_dispatch(&home, entry("lead", "dev")); // unrelated
+        track_dispatch(&home, entry("lead", "doomed")); // to == doomed → removed
+        track_dispatch(&home, entry("doomed", "dev")); // from == doomed → KEPT (dev still tracked)
+        track_dispatch(&home, entry("lead", "dev")); // unrelated → kept
         let removed = cleanup_for_instance(&home, "doomed");
-        assert_eq!(removed, 2, "both from== and to==doomed entries removed");
+        assert_eq!(
+            removed, 1,
+            "only the entry where doomed is the assignee (to) is removed"
+        );
         let store: serde_json::Value =
             crate::store::load(&crate::store::store_path(&home, "dispatch_tracking.json"));
         let entries = store["entries"].as_array().unwrap();
-        assert_eq!(entries.len(), 1, "unrelated entry must survive");
-        assert_eq!(entries[0]["to"], "dev");
-        assert_eq!(entries[0]["from"], "lead");
+        assert_eq!(
+            entries.len(),
+            2,
+            "from==doomed (live assignee dev) + unrelated survive"
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|e| e["from"] == "doomed" && e["to"] == "dev"),
+            "#1923 G10: a deleted dispatcher must NOT drop the live assignee's tracking"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
The LOW-severity tail of the correlation-tracking audit (#1923) — three small, independent correctness fixes. **G9** (fleet hot-reload escalation gate) is deferred as a separate design question; **G7** (stale-sidecar propagation) is left to observe (mitigated by the upstream stale fixes in PR-A/B + G6).

## G10 — dispatch_tracking `cleanup_for_instance` over-delete
Removed entries where the deleted instance was the dispatcher (`from`) **or** the assignee (`to`). But the stuck-sweep nags `.to` (the assignee), so deleting a **dispatcher** silently dropped the still-live assignee's stuck-protection. Fix: only drop `to`-matches; keep `from`-matches (a ghost `from` is audit-only). Existing test rewritten to the corrected contract.

## G6 — dispatch_idle team-nudge orphan
When a dispatcher has no team (`dispatcher_team` → None), the L2 team-nudge scan `continue`d **without stamping**, so the `Exceeded` sidecar was retried every scan forever. Fix: `stamp_nudge_sent` before continue — stops the L2 retry **without removing the sidecar** (a solo dispatcher's L1 lifecycle is untouched). Complements the #1923-G2 `dispatcher_not_in_fleet` L1 retire (left-the-fleet); this covers left-the-team-but-in-fleet.

## G11 — handoff-timeout ghost fallback
The escalation recipient falls back to the hardcoded `"lead"` when no team orchestrator exists; if no `"lead"` instance is in the fleet, the escalation was written to a **ghost inbox** (silently lost). Fix: skip + log when `!instance_is_known(recipient)`.

## Verification
- Tests: G10 drops-assignee-keeps-dispatcher; G6 no-team-stamps-stops-retry; G11 ghost-fallback-skipped.
- `fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · full suite (system git) **3816/3816** (rebased onto current main).

**Closes #1923** — the correlation-tracking class (PR-A G8/G4/G5/G12 + PR-B G1/G3/G2 + this LOW-sweep) is complete; G9 tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)