### PR TITLE
fix(#1809): suppress cross-cycle phantom ServerRateLimit re-latch

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1114,7 +1114,7 @@ impl StateTracker {
                         // stays OUT of `is_high_fp_state` → the #1450 red anchor is
                         // unchanged (that decision is ① Step-2, pending the
                         // operator); this is the #1768 working-marker override only.
-                        let landed = if high_fp || matches!(detected, AgentState::UsageLimit) {
+                        let mut landed = if high_fp || matches!(detected, AgentState::UsageLimit) {
                             // #badge-recovery (state-level mirror of #1795): a
                             // ServerRateLimit whose agent produced PRODUCTIVE output
                             // within the recovery window has recovered even though
@@ -1213,26 +1213,27 @@ impl StateTracker {
                         } else {
                             detected
                         };
-                        // #1808-probe0-phantom (instrumentation-only, NO behavior
-                        // change): cheerc Evidence 2 claims a stale SRL error stuck in
-                        // the bottom-N tail keeps re-matching after the agent recovered
-                        // (the screen hash flips when the CLI clock ticks → feed
-                        // re-scans → re-grabs the SAME old error → re-latch → blind
-                        // inject). Record it empirically: signature the matched error
-                        // line `(line_hash, dist_from_bottom)` and compare to the
-                        // previous SRL detection —
+                        // #1808-probe0-phantom + #1809 fix: cheerc Evidence 2 — a stale
+                        // SRL error stuck in the bottom-N tail keeps re-matching after
+                        // the agent recovered (the screen hash flips when the CLI clock
+                        // ticks → feed re-scans → re-grabs the SAME old error → re-latch
+                        // → blind inject). Signature the matched error line
+                        // `(line_hash, dist_from_bottom)` and compare to the previous SRL
+                        // detection —
                         //   • same sig, NO intervening non-SRL state  → in-place
                         //     clock-tick re-scan → `srl_consecutive_rematch++`;
                         //   • same sig, intervening Idle/non-SRL state → `cross_cycle`
                         //     refire (the agent recovered, then the OLD error was
                         //     re-grabbed) = cheerc's exact cross-Idle loop.
                         // `last_srl_match_sig` PERSISTS across Idle so the cross-cycle
-                        // case survives. WARN only when the SRL actually wins
-                        // (`landed == ServerRateLimit` → would latch → inject) AND there
-                        // is no recent productive output (`!recovered`) AND it is a
-                        // re-match. Not backend-scoped (the phantom is the Claude
-                        // `Server is temporarily limiting` re-match — cheerc's `general`
-                        // agent). Telemetry-only; never touches `landed`/transition.
+                        // case survives. WARN when the SRL would win (`landed == SRL` →
+                        // latch → inject) AND no recent productive output (`!recovered`)
+                        // AND it is a re-match. The #1809 fix then OVERRIDES `landed` to
+                        // Idle for the `cross_cycle` sub-case only (the unambiguous
+                        // phantom) — the `consecutive_rematch` (still-SRL) case stays
+                        // telemetry-only so a genuine long throttle keeps retrying. Not
+                        // backend-scoped (the phantom is the Claude `Server is temporarily
+                        // limiting` re-match — cheerc's `general` agent).
                         if matches!(detected, AgentState::ServerRateLimit) {
                             let sig = srl_match_signature(screen_text, matched);
                             let same_sig = self.last_srl_match_sig == Some(sig);
@@ -1269,6 +1270,29 @@ impl StateTracker {
                                     productive_silent_secs = self.productive_silence().as_secs(),
                                     "phantom re-match: same stale ServerRateLimit error re-detected (would latch → inject) with no recent productive output"
                                 );
+                                // #1809 fix (behavioral): a CROSS-CYCLE phantom — the
+                                // agent already LEFT ServerRateLimit (passed through a
+                                // non-SRL landed state) and the SAME stale error line
+                                // (`same_sig`) was re-grabbed with no recent productive
+                                // output. This is cheerc's exact loop: a CLI clock-tick
+                                // flips the screen hash → feed re-scans → re-matches the
+                                // OLD error → re-latch → the supervisor schedules ANOTHER
+                                // auto-retry → blind `continue` inject, repeating every
+                                // ~45s as the recovery window expires. Land Idle instead
+                                // of re-latching: the genuine error already latched +
+                                // retried on its FIRST detection; a genuinely-new error
+                                // has a different signature; genuine productive output
+                                // sets `recovered_now` (→ #badge-recovery lands Idle
+                                // anyway, never reaching here). The IN-PLACE
+                                // `consecutive_rematch` case is deliberately NOT
+                                // suppressed — a still-SRL agent may be a genuine long
+                                // throttle that still needs its retry. (Accepted narrow
+                                // FP: a genuinely-new SRL identical in text AND screen
+                                // position to the just-processed one, with no intervening
+                                // productive output, is ignored — see PR body.)
+                                if cross_cycle {
+                                    landed = AgentState::Idle;
+                                }
                             }
                         }
                         let gated = self.gate_on_heartbeat(landed);

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -2732,6 +2732,91 @@ fn server_rate_limit_fresh_agent_no_productive_history_latches_badge() {
     );
 }
 
+/// #1809: a CROSS-CYCLE stale SRL re-match — the agent recovered to a non-SRL
+/// state, then the SAME error line is re-grabbed AFTER the recovery window (a CLI
+/// clock-tick flips the screen hash → feed re-scans the still-present stale error)
+/// — must NOT re-latch ServerRateLimit. Re-latching would schedule another
+/// auto-retry → blind `continue` inject: the ~45s phantom storm cheerc traced.
+#[test]
+fn stale_srl_cross_cycle_rematch_does_not_relatch_1809() {
+    let (mut vt, mut st) = claude_tracker();
+    // 1. SRL appears while the agent is RECOVERED (recent productive output) →
+    //    #badge-recovery lands Idle (not latched) but RECORDS the error signature
+    //    (`last_srl_match_sig`) — the same state the storm leaves behind after the
+    //    genuine episode resolved.
+    st.last_productive_output = Some(std::time::Instant::now());
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_ne!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "recovered SRL lands Idle (badge) and records the error signature"
+    );
+    // 2. Agent passes through a clean non-SRL screen → sets non_srl_since_last_srl.
+    drive_plain_line(&mut vt, &mut st, "> ready");
+    assert_ne!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "a non-SRL state"
+    );
+    // 3. Recovery window expired (no productive output for >45s → recovered=false).
+    st.last_productive_output = None;
+    // 4. The SAME stale error line is re-grabbed (a CLI clock-tick flips the screen
+    //    hash → feed re-scans the still-present old error) → cross-cycle phantom.
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_ne!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#1809: a cross-cycle stale SRL re-match must NOT re-latch (the phantom storm)"
+    );
+}
+
+/// #1809 no-false-kill: a genuinely-NEW SRL error (DIFFERENT line signature) after
+/// a recovery must STILL latch — the stale-ignore is keyed on the error-line
+/// signature, so a new error is never suppressed.
+#[test]
+fn new_srl_error_after_recovery_still_latches_1809() {
+    let (mut vt, mut st) = claude_tracker();
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_eq!(st.get_state(), AgentState::ServerRateLimit);
+    drive_plain_line(&mut vt, &mut st, "> ready");
+    st.last_productive_output = None;
+    // A DIFFERENT SRL line (still matches the throttle phrase, different content
+    // → different signature).
+    drive_plain_line(
+        &mut vt,
+        &mut st,
+        "API Error: Server is temporarily limiting requests (not your usage limit) — attempt 3",
+    );
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#1809: a genuinely-new SRL error (different signature) must still latch"
+    );
+}
+
+/// #1809 conservatism: an IN-PLACE re-match (same error, agent STAYED in SRL, no
+/// intervening non-SRL state) is `consecutive_rematch`, NOT a cross-cycle phantom —
+/// a genuine long throttle. It must NOT be suppressed (the retry must keep firing).
+#[test]
+fn in_place_srl_rematch_still_latches_1809() {
+    let (mut vt, mut st) = claude_tracker();
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "first SRL latches"
+    );
+    st.last_productive_output = None;
+    // Re-feed the SAME error WITHOUT an intervening non-SRL state → consecutive
+    // (not cross-cycle) → a genuine still-throttled agent → must STILL latch.
+    drive_plain_line(&mut vt, &mut st, SRL_LINE);
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#1809: an in-place same-error re-match (still SRL, no recovery) is a genuine throttle — keep latching"
+    );
+}
+
 /// #badge-recovery boundary: an agent that DID produce, but whose last productive
 /// output is PAST the recovery window, is a genuinely-throttled agent → must still
 /// latch ServerRateLimit. Confirms the suppression is BOUNDED (it only suppresses


### PR DESCRIPTION
cheerc's #1809 retry storm: an agent recovers from a `ServerRateLimit` but outputs little, so the **stale error line stays in the bottom-N error-scan window**. `#badge-recovery` (`recovered_within(45s)`) suppresses it for the first 45s; once that expires, the next screen change (a CLI status-bar **clock tick** flips the screen hash) re-scans, re-matches the SAME old error, and re-latches SRL → the supervisor schedules another auto-retry → a blind `continue` inject. The window re-arms on that nudge's output → the loop repeats every ~45s (cheerc's phantom-retry-every-~4min trace).

## The fix — telemetry → behavior, 2 lines
The existing `#1808-probe0-phantom` instrumentation already computed everything: it signatures the matched error line `(line_hash, dist_from_bottom)`, persists `last_srl_match_sig` across Idle, and flags a `cross_cycle` re-fire (same signature with an intervening non-SRL state). This turns that detection into behavior: when the SRL would latch (`landed == SRL`) with no recent productive output AND it's a `cross_cycle` phantom → **land Idle instead of re-latching**. (`let mut landed` + the override.)

## Conservatism (this is the SRL-recovery lifeline path)
- **Only `cross_cycle`** is suppressed (agent left SRL → same stale error re-grabbed = the unambiguous phantom). The in-place `consecutive_rematch` case (still in SRL, never recovered) is **left to latch** — a genuine long throttle must keep retrying.
- **"New output" gate is free**: the signature is the error LINE's hash (excludes the clock elsewhere on screen), and `recovered_within` reads `last_productive_output`, already tuned (#685 PR-2 RC1) to ignore cursor-blink/clock-tick noise.
- **#badge-recovery semantics untouched** — this is an additional stale-ignore layer only.
- **Accepted narrow FP**: a genuinely-NEW SRL identical in text AND screen position to the just-processed one, with no intervening productive output, is ignored. A real new error almost always has new text/position.

## Tests (§3.9)
- `stale_srl_cross_cycle_rematch_does_not_relatch_1809` — the storm case → no re-latch.
- `new_srl_error_after_recovery_still_latches_1809` — different signature → still latches (no false-kill).
- `in_place_srl_rematch_still_latches_1809` — still-SRL genuine throttle → keeps latching (no over-suppression).

`fmt --check` ✓ · `clippy --all-targets -D warnings` ✓ · full suite (system git) **3820/3820** (incl. all 292 state-detection tests, zero regression).

**#1808** (abort-to-Idle freeze) stays open — to be re-assessed after this root fix lands (per the evaluation, it likely shrinks to a narrow case). Refs #1809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)