### PR TITLE
fix(#1935): close run/<pid>/.port teardown residual race (3 layers)

### DIFF
--- a/src/daemon/tui_bridge.rs
+++ b/src/daemon/tui_bridge.rs
@@ -42,6 +42,22 @@ pub(crate) fn prepare_tui_listener_and_publish_port(
     })?;
     let listener = crate::ipc::bind_loopback()?;
     let port = crate::ipc::local_port(&listener);
+    // #1935: refuse the port publish if the instance is mid-delete. `full_delete`
+    // → `remove_port` deletes `run/<pid>/<name>.port`, but a boot-spawn / respawn
+    // publish still in flight would re-create it AFTER the removal (the #1913
+    // writer-vs-teardown race that left a residual the #1907 oracle didn't catch).
+    // The #1915 DeletingGuard already refuses the spawn/register chokepoint; this
+    // closes the narrower window where write_port runs past it. Cheap leaf-lock
+    // read. `home` = run_dir's grandparent (run_dir is always `home/run/<pid>` via
+    // run_dir_for_pid), so the key matches full_delete's `mark_deleting(home, …)`.
+    if let Some(home) = run_dir.parent().and_then(|p| p.parent()) {
+        if crate::agent::deleting::is_deleting(home, name) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                format!("instance '{name}' is being deleted; TUI port publish skipped"),
+            ));
+        }
+    }
     crate::ipc::write_port(run_dir, name, port)?;
     tracing::info!(agent = name, port, "TUI socket ready");
     Ok(TuiListenerMeta { listener, cookie })
@@ -265,5 +281,46 @@ mod tests {
             prod[block_end..].contains(&write_needle),
             "the initial dump must be written via write_frame AFTER the registry lock is dropped"
         );
+    }
+
+    /// #1935 §3.9: `prepare_tui_listener_and_publish_port` must NOT write
+    /// `run/<pid>/<name>.port` while the instance is mid-delete (closes the
+    /// publish-vs-teardown race where a boot-spawn republished the port AFTER
+    /// `full_delete`'s `remove_port`), but MUST write it on a normal publish.
+    #[test]
+    fn publish_port_respects_deleting_guard() {
+        let home = std::env::temp_dir().join(format!("agend-1935-pubguard-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        // run_dir MUST be `home/run/<pid>` so the fn derives `home` as its
+        // grandparent (matching full_delete's `mark_deleting(home, …)` key).
+        let run_dir = home.join("run").join(std::process::id().to_string());
+        std::fs::create_dir_all(&run_dir).unwrap();
+        crate::auth_cookie::issue(&run_dir).unwrap();
+        let name = "victim-port";
+        let port_file = crate::ipc::port_path(&run_dir, name);
+
+        // (a) mid-delete → publish refused, no `.port` written.
+        let guard = crate::agent::deleting::mark_deleting(&home, name);
+        let refused = super::prepare_tui_listener_and_publish_port(name, &run_dir);
+        assert!(refused.is_err(), "publish must be refused while deleting");
+        assert!(
+            !port_file.exists(),
+            "no .port may be written while the instance is deleting"
+        );
+        drop(guard);
+
+        // (b) not deleting → publish succeeds, `.port` written.
+        let ok = super::prepare_tui_listener_and_publish_port(name, &run_dir);
+        assert!(
+            ok.is_ok(),
+            "publish must succeed when not deleting (err: {:?})",
+            ok.err()
+        );
+        assert!(
+            port_file.exists(),
+            ".port must be written on a normal (non-deleting) publish"
+        );
+
+        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -31,7 +31,9 @@ pub fn local_port(listener: &TcpListener) -> u16 {
 }
 
 /// Path for a named port file inside run_dir.
-fn port_path(run_dir: &Path, name: &str) -> std::path::PathBuf {
+/// `pub(crate)` (#1935) so the teardown residual oracle checks the exact path
+/// `write_port`/`remove_port` use.
+pub(crate) fn port_path(run_dir: &Path, name: &str) -> std::path::PathBuf {
     run_dir.join(format!("{name}.port"))
 }
 

--- a/src/mcp/handlers/instance_lifecycle.rs
+++ b/src/mcp/handlers/instance_lifecycle.rs
@@ -257,6 +257,13 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // the agent is dead (api::call(DELETE) waited for exit), so no concurrent bind
     // re-creates it; `runtime/<name>/` holds only this agent's binding artefacts.
     let _ = std::fs::remove_dir_all(crate::paths::runtime_dir(home).join(name));
+    // #1935: explicitly remove the per-agent TUI port file `run/<pid>/<name>.port`.
+    // The `api::call(DELETE)` stop-path already calls `remove_port` for a live
+    // agent, but a boot-spawn that published the port without the agent reaching a
+    // stoppable state would leave it behind. Remove it unconditionally before the
+    // audit; the `_delete_guard` held above makes any concurrent publish skip its
+    // `write_port` (tui_bridge.rs), so it stays gone past this point.
+    crate::ipc::remove_port(&crate::daemon::run_dir(home), name);
 
     // Sprint 54 P1-B Bug 1 audit: enumerate every store that still holds
     // the name. If any do, surface a loud error instead of returning
@@ -406,6 +413,14 @@ pub(crate) fn name_residual_anywhere(
     // left behind by `unbind`; full_delete now removes the whole dir).
     if crate::paths::runtime_dir(home).join(name).exists() {
         sources.push("runtime-dir");
+    }
+    // #1935: the per-agent TUI port file `run/<pid>/<name>.port` (daemon-LIFECYCLE
+    // dir — a different family from `runtime/<name>/`, which is why #1907's oracle
+    // missed it). full_delete → remove_port deletes it, but a publish racing
+    // teardown could re-create it; scanning here makes the production delete LOUD
+    // if it lingers, and the #1935 publish deleting-guard closes the write window.
+    if crate::ipc::port_path(&crate::daemon::run_dir(home), name).exists() {
+        sources.push("tui-port");
     }
     if crate::daemon::pr_state::has_subscriber(home, name) {
         sources.push("pr-state");

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -172,6 +172,38 @@ impl AgendHarness {
                         job
                     };
 
+                    // #1935: api.port is published BEFORE the boot-spawn loop runs
+                    // (#922 / #906 reorder); `.ready` is written UNCONDITIONALLY
+                    // after the spawn loop completes (daemon/mod.rs — empty fleet
+                    // still reaches it, 0 iterations). Returning on api.port alone
+                    // let a test seed+delete a victim while its boot-spawn was still
+                    // publishing `run/<pid>/<name>.port`, racing the per-agent port
+                    // write against the test's own teardown (the #1935 flake).
+                    // Wait for `.ready` so every boot-spawn's port is on disk first;
+                    // a failed boot exits early and is caught by try_wait below.
+                    let ready_path = run_dir.join(".ready");
+                    loop {
+                        if start.elapsed() > timeout {
+                            let _ = child.kill();
+                            return Err(
+                                "daemon startup timeout (15s) — .ready never appeared".into()
+                            );
+                        }
+                        match child.try_wait() {
+                            Ok(Some(status)) => {
+                                return Err(format!(
+                                    "daemon exited early (after api.port, before .ready) with {status}"
+                                ));
+                            }
+                            Ok(None) => {}
+                            Err(e) => return Err(format!("try_wait: {e}")),
+                        }
+                        if ready_path.exists() {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+
                     return Ok(Self {
                         home,
                         api_port: port,


### PR DESCRIPTION
<!-- LOC-EST: 50-120 -->

The #1931 daemon-boot flake-gate's **first catch**: `teardown_completeness_regression` flaked ~1-in-20 on a residual `run/<pid>/<name>.port`. Verify-first RCA (4 code-traced facts + the 1-in-20 rate).

## Root cause
- The per-agent TUI port file is written **once at boot-spawn** (`tui_bridge.rs::write_port` → `run/<pid>/<name>.port`, the daemon-**lifecycle** dir). full_delete *does* remove it (`api::call(DELETE)` → agent stop → `ipc::remove_port`), so it's **not a missed-cleanup** — it's a **(b) writer-vs-teardown race**.
- The test triggered it because `AgendHarness::spawn_with` waited for **`api.port`** (published BEFORE the spawn loop, #922) not **`.ready`** (after it) → it seeded + deleted a victim while the victim's boot-spawn was still publishing → `write_port` landed *after* `remove_port` → residual.
- **Why #1907's oracle missed it**: `name_residual_anywhere` scans `runtime/<name>/` (binding dir), never `run/<pid>/` (lifecycle dir — different family). The whole-home scan test *should* catch it but was flaky (race only sometimes loses), so it passed when #1907 shipped.

## Fix (three layers, defense-in-depth — per lead scope)
1. **`AgendHarness::spawn_with` waits for `.ready`** (boot-spawn published) — closes the test-side overlap. `.ready` is written **unconditionally** after the spawn loop (`daemon/mod.rs:1095` — empty fleet still reaches it, 0 iterations); failed boots early-exit via the existing `try_wait`.
2. **`name_residual_anywhere` scans `run/<pid>/<name>.port`** + full_delete explicitly `remove_port`s it before the audit → the production delete is now **loud** if it lingers (closes the oracle blind spot).
3. **`prepare_tui_listener_and_publish_port` refuses `write_port` while the instance is mid-delete** (`is_deleting` leaf-lock read; #1921 writer-respects-teardown) — closes the publish-after-remove window for a real operator deleting a **still-booting** instance (#1913 class), not just the test.

## Verification
- **`teardown_completeness_regression` 20× → 0 flake** (was ~1-in-20).
- **All 8 daemon-boot binaries 10× → 0 flake** (the harness `.ready` change touches all of them; `ready_marker_invariants`/`restart_smoke`/`self_respawn_handoff` included).
- **`publish_port_respects_deleting_guard`** §3.9: mid-delete → `.port` NOT written + publish refused; normal → `.port` written.
- Empty-fleet `harness_smoke` + early-exit (bad-yaml) cases unaffected (still fast).
- fmt + clippy `-D warnings` clean. This PR path-triggers the flake-gate = a natural CI 20× re-verification.

Closes #1935.