### PR TITLE
fix(#1939): restore restart/replace respawn pane to its original position

### DIFF
--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -5,7 +5,7 @@
 //! the layout accordingly — auto-creating or removing tabs/panes.
 
 use crate::agent::{self, AgentRegistry};
-use crate::layout::{Layout, MovePlacement, Pane, SplitDir, Tab};
+use crate::layout::{Layout, MovePlacement, SplitDir, Tab};
 
 /// Events sent from the API server to the TUI event loop when agents or teams
 /// are created/deleted via MCP tools. The TUI reacts by auto-creating or
@@ -344,10 +344,11 @@ fn handle_instance_created(
             }
         }
         None => match hint {
-            // #1431: a replace_instance re-spawn returns to the tab the old
-            // same-named pane occupied (recorded on its removal).
-            LayoutHint::SameTab => match layout.take_removed_tab(name) {
-                Some(tab_name) => place_in_remembered_tab(layout, &tab_name, pane),
+            // #1431/#1939: a replace_instance / restart_instance re-spawn
+            // returns to the position the old same-named pane occupied
+            // (recorded on its removal).
+            LayoutHint::SameTab => match layout.take_removed_pane(name) {
+                Some(placement) => layout.restore_removed_pane(&placement, pane),
                 None => layout.add_tab(Tab::new(name.to_string(), pane)),
             },
             _ => layout.add_tab(Tab::new(name.to_string(), pane)),
@@ -355,26 +356,11 @@ fn handle_instance_created(
     }
 }
 
-/// #1431: place a replacement pane into the tab named `tab_name`. Splits the
-/// tab's focused pane if the tab still exists, otherwise recreates a tab with
-/// that name. Same tab is guaranteed; the exact split slot is best-effort —
-/// the original leaf was destroyed when the replaced pane was removed.
-fn place_in_remembered_tab(layout: &mut Layout, tab_name: &str, pane: Pane) {
-    match layout.tabs.iter().position(|t| t.name == tab_name) {
-        Some(idx) => {
-            layout.tabs[idx].split_focused(SplitDir::Horizontal, pane);
-        }
-        None => layout.add_tab(Tab::new(tab_name.to_string(), pane)),
-    }
-}
-
 fn handle_instance_deleted(name: &str, layout: &mut Layout) {
-    // #1431: remember the tab this agent occupied so a replace_instance
-    // re-spawn (LayoutHint::SameTab) can return the new pane to the same tab.
-    if let Some((tab_idx, _)) = layout.find_agent_pane(name) {
-        let tab_name = layout.tabs[tab_idx].name.clone();
-        layout.remember_removed_tab(name, tab_name);
-    }
+    // #1431/#1939: remember the placement (tab + split position) this agent
+    // occupied so a replace/restart re-spawn (LayoutHint::SameTab) can return
+    // the new pane to the same spot.
+    layout.remember_removed_pane(name);
     remove_agent_pane(name, layout);
 }
 
@@ -796,12 +782,12 @@ mod tests {
         handle_instance_deleted("dev", &mut layout);
         assert_eq!(layout.tabs.len(), 0, "single-pane tab closes on delete");
 
-        let tab_name = layout
-            .take_removed_tab("dev")
-            .expect("delete must record the agent's tab");
-        assert_eq!(tab_name, "work");
+        let placement = layout
+            .take_removed_pane("dev")
+            .expect("delete must record the agent's placement");
+        assert_eq!(placement.tab_name, "work");
 
-        place_in_remembered_tab(&mut layout, &tab_name, leaf(2, "dev"));
+        layout.restore_removed_pane(&placement, leaf(2, "dev"));
         assert_eq!(layout.tabs.len(), 1);
         assert_eq!(
             layout.tabs[0].name, "work",
@@ -823,10 +809,10 @@ mod tests {
 
         handle_instance_deleted("dev", &mut layout);
         assert_eq!(layout.tabs.len(), 1, "multi-pane tab survives delete");
-        let tab_name = layout.take_removed_tab("dev").expect("tab recorded");
-        assert_eq!(tab_name, "team");
+        let placement = layout.take_removed_pane("dev").expect("placement recorded");
+        assert_eq!(placement.tab_name, "team");
 
-        place_in_remembered_tab(&mut layout, &tab_name, leaf(3, "dev"));
+        layout.restore_removed_pane(&placement, leaf(3, "dev"));
         assert_eq!(layout.tabs.len(), 1, "no new tab created");
         assert_eq!(layout.tabs[0].name, "team");
         assert!(layout.tabs[0].root().has_agent("dev"));
@@ -853,13 +839,13 @@ mod tests {
             1,
             "shared tab survives one pane's delete"
         );
-        let tab_name = layout
-            .take_removed_tab("fixup-dev")
-            .expect("delete records the agent's tab");
-        assert_eq!(tab_name, "fixup");
+        let placement = layout
+            .take_removed_pane("fixup-dev")
+            .expect("delete records the agent's placement");
+        assert_eq!(placement.tab_name, "fixup");
 
         // ... then the SameTab respawn splits back into the shared tab.
-        place_in_remembered_tab(&mut layout, &tab_name, leaf(3, "fixup-dev"));
+        layout.restore_removed_pane(&placement, leaf(3, "fixup-dev"));
         assert_eq!(layout.tabs.len(), 1, "no new tab — pane stays in 'fixup'");
         assert_eq!(layout.tabs[0].name, "fixup");
         assert!(layout.tabs[0].root().has_agent("fixup-dev"));
@@ -876,10 +862,10 @@ mod tests {
         assert!(resolve_split_anchor(LayoutHint::SameTab, Some("a"), Some("a"), &layout).is_none());
     }
 
-    /// #1431: take_removed_tab yields None for an agent that was never removed.
+    /// #1431: take_removed_pane yields None for an agent that was never removed.
     #[test]
-    fn take_removed_tab_none_for_unrecorded_agent() {
+    fn take_removed_pane_none_for_unrecorded_agent() {
         let mut layout = Layout::new();
-        assert!(layout.take_removed_tab("never-seen").is_none());
+        assert!(layout.take_removed_pane("never-seen").is_none());
     }
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -27,6 +27,28 @@ pub enum MovePlacement {
     NewTab { name: String },
 }
 
+/// #1939: full placement of an agent's pane at removal time. Extends the
+/// #1431 tab-name-only memory so a `SameTab` respawn (replace_instance /
+/// restart_instance) restores the pane's position, not just its tab.
+pub struct RemovedPanePlacement {
+    pub tab_name: String,
+    /// Index the tab occupied — re-inserts a recreated tab in place when the
+    /// whole tab was closed (single-pane case) instead of appending.
+    pub tab_idx: usize,
+    /// Within-tab geometry. `None` when the pane was the tab's only pane.
+    pub split: Option<RemovedSplit>,
+}
+
+/// #1939: the parent split of a removed pane.
+pub struct RemovedSplit {
+    pub dir: SplitDir,
+    pub ratio: f32,
+    /// Whether the removed pane was the `first` child of its parent split.
+    pub was_first: bool,
+    /// Agents of the sibling subtree at removal time (restore anchors).
+    pub sibling_agents: Vec<String>,
+}
+
 /// Top-level layout.
 pub struct Layout {
     pub tabs: Vec<Tab>,
@@ -36,11 +58,12 @@ pub struct Layout {
     pub tab_reorder_source: Option<usize>,
     /// Drop target tab index during tab reorder drag.
     pub tab_reorder_target: Option<usize>,
-    /// #1431: tab name an agent's pane occupied at removal time, keyed by
-    /// agent name. Recorded on pane removal and consumed by a subsequent
-    /// `LayoutHint::SameTab` spawn (replace_instance) so the new pane returns
-    /// to its original tab. Bounded by distinct agent names.
-    removed_tab_memory: HashMap<String, String>,
+    /// #1431/#1939: placement an agent's pane occupied at removal time, keyed
+    /// by agent name. Recorded on pane removal and consumed by a subsequent
+    /// `LayoutHint::SameTab` spawn (replace_instance / restart_instance) so
+    /// the new pane returns to its original position. Bounded by distinct
+    /// agent names.
+    removed_pane_memory: HashMap<String, RemovedPanePlacement>,
 }
 
 pub const TAB_BAR_HEIGHT: u16 = 1;
@@ -58,19 +81,55 @@ impl Layout {
             next_pane_id: 0,
             tab_reorder_source: None,
             tab_reorder_target: None,
-            removed_tab_memory: HashMap::new(),
+            removed_pane_memory: HashMap::new(),
         }
     }
 
-    /// #1431: remember which tab `agent`'s pane occupied, so a later
-    /// `SameTab` spawn can return its replacement to the same tab.
-    pub fn remember_removed_tab(&mut self, agent: &str, tab_name: String) {
-        self.removed_tab_memory.insert(agent.to_string(), tab_name);
+    /// #1431/#1939: record where `agent`'s pane currently sits (tab + parent
+    /// split geometry) so a later `SameTab` spawn can restore it. Call BEFORE
+    /// removing the pane; no-op if the agent has no pane.
+    pub fn remember_removed_pane(&mut self, agent: &str) {
+        if let Some((tab_idx, pane_id)) = self.find_agent_pane(agent) {
+            let tab = &self.tabs[tab_idx];
+            self.removed_pane_memory.insert(
+                agent.to_string(),
+                RemovedPanePlacement {
+                    tab_name: tab.name.clone(),
+                    tab_idx,
+                    split: tree::parent_split_of(tab.root(), pane_id),
+                },
+            );
+        }
     }
 
-    /// #1431: take (and forget) the remembered tab name for `agent`.
-    pub fn take_removed_tab(&mut self, agent: &str) -> Option<String> {
-        self.removed_tab_memory.remove(agent)
+    /// #1431: take (and forget) the remembered placement for `agent`.
+    pub fn take_removed_pane(&mut self, agent: &str) -> Option<RemovedPanePlacement> {
+        self.removed_pane_memory.remove(agent)
+    }
+
+    /// #1939: place a `SameTab` respawn back at its remembered position.
+    /// Fallback chain: remembered split next to the surviving siblings (exact
+    /// slot) → focused split in the same tab (pre-#1939 behavior) → recreate
+    /// the tab at its remembered index.
+    pub fn restore_removed_pane(&mut self, placement: &RemovedPanePlacement, pane: Pane) {
+        match self.tabs.iter().position(|t| t.name == placement.tab_name) {
+            Some(idx) => {
+                let pane = match &placement.split {
+                    Some(split) => match self.tabs[idx].restore_split(split, pane) {
+                        None => return,
+                        Some(p) => p, // siblings gone → best-effort fallback
+                    },
+                    None => pane,
+                };
+                self.tabs[idx].split_focused(SplitDir::Horizontal, pane);
+            }
+            None => {
+                self.insert_tab(
+                    placement.tab_idx,
+                    Tab::new(placement.tab_name.clone(), pane),
+                );
+            }
+        }
     }
 
     pub fn next_pane_id(&mut self) -> usize {
@@ -82,6 +141,14 @@ impl Layout {
     pub fn add_tab(&mut self, tab: Tab) {
         self.switch_active(self.tabs.len());
         self.tabs.push(tab);
+    }
+
+    /// #1939: `add_tab` at a position — insert `tab` at `idx` (clamped to the
+    /// current tab count) and focus it.
+    pub fn insert_tab(&mut self, idx: usize, tab: Tab) {
+        let idx = idx.min(self.tabs.len());
+        self.switch_active(idx);
+        self.tabs.insert(idx, tab);
     }
 
     /// Append a tab without changing the active index. Used by the Attached
@@ -450,6 +517,175 @@ mod tests {
         assert!(layout.tabs[1].root().has_agent("b"));
         assert_eq!(layout.active, 1);
     }
+    /// #1939: a restart of one pane in a 2-pane tab restores the exact slot —
+    /// same side, same split direction, same ratio (not split_focused noise).
+    #[test]
+    fn restore_2pane_exact_side_dir_ratio_1939() {
+        let mut layout = Layout::new();
+        let root = PaneNode::Split {
+            dir: SplitDir::Horizontal,
+            ratio: 0.3,
+            first: Box::new(PaneNode::Leaf(Box::new(leaf(1, "dev")))),
+            second: Box::new(PaneNode::Leaf(Box::new(leaf(2, "dev2")))),
+        };
+        layout.add_tab(Tab::with_root("team".into(), root));
+
+        layout.remember_removed_pane("dev");
+        layout.tabs[0].close_pane_by_id(1);
+
+        let placement = layout.take_removed_pane("dev").unwrap();
+        let split = placement.split.as_ref().expect("parent split recorded");
+        assert_eq!(split.dir, SplitDir::Horizontal);
+        assert!((split.ratio - 0.3).abs() < f32::EPSILON);
+        assert!(split.was_first, "dev was the first child");
+        assert_eq!(split.sibling_agents, vec!["dev2".to_string()]);
+
+        layout.restore_removed_pane(&placement, leaf(9, "dev"));
+        match layout.tabs[0].root() {
+            PaneNode::Split {
+                dir,
+                ratio,
+                first,
+                second,
+            } => {
+                assert_eq!(*dir, SplitDir::Horizontal);
+                assert!((ratio - 0.3).abs() < f32::EPSILON, "ratio restored");
+                assert!(
+                    matches!(&**first, PaneNode::Leaf(p) if p.agent_name.as_str() == "dev" && p.id == 9),
+                    "respawned dev back on the first side"
+                );
+                assert!(matches!(&**second, PaneNode::Leaf(p) if p.agent_name.as_str() == "dev2"));
+            }
+            PaneNode::Leaf(_) => panic!("expected a split root after restore"),
+        }
+    }
+
+    /// #1939: when the removed pane's sibling was a SUBTREE (nested splits),
+    /// the restore wraps that whole subtree — the original tree shape comes
+    /// back, not a split against a single leaf inside it.
+    #[test]
+    fn restore_nested_sibling_subtree_shape_1939() {
+        let mut layout = Layout::new();
+        let sibling = PaneNode::Split {
+            dir: SplitDir::Vertical,
+            ratio: 0.6,
+            first: Box::new(PaneNode::Leaf(Box::new(leaf(2, "dev2")))),
+            second: Box::new(PaneNode::Leaf(Box::new(leaf(3, "reviewer")))),
+        };
+        let root = PaneNode::Split {
+            dir: SplitDir::Horizontal,
+            ratio: 0.5,
+            first: Box::new(PaneNode::Leaf(Box::new(leaf(1, "dev")))),
+            second: Box::new(sibling),
+        };
+        layout.add_tab(Tab::with_root("team".into(), root));
+
+        layout.remember_removed_pane("dev");
+        layout.tabs[0].close_pane_by_id(1);
+
+        let placement = layout.take_removed_pane("dev").unwrap();
+        layout.restore_removed_pane(&placement, leaf(9, "dev"));
+
+        match layout.tabs[0].root() {
+            PaneNode::Split {
+                dir, first, second, ..
+            } => {
+                assert_eq!(*dir, SplitDir::Horizontal);
+                assert!(
+                    matches!(&**first, PaneNode::Leaf(p) if p.agent_name.as_str() == "dev"),
+                    "dev back as first child of the root split"
+                );
+                match &**second {
+                    PaneNode::Split {
+                        dir, first, second, ..
+                    } => {
+                        assert_eq!(*dir, SplitDir::Vertical, "sibling subtree intact");
+                        assert!(
+                            matches!(&**first, PaneNode::Leaf(p) if p.agent_name.as_str() == "dev2")
+                        );
+                        assert!(
+                            matches!(&**second, PaneNode::Leaf(p) if p.agent_name.as_str() == "reviewer")
+                        );
+                    }
+                    PaneNode::Leaf(_) => panic!("sibling subtree must stay a split"),
+                }
+            }
+            PaneNode::Leaf(_) => panic!("expected a split root after restore"),
+        }
+    }
+
+    /// #1939: a single-pane tab (closed on delete) is recreated at its
+    /// original tab index on respawn, not appended to the end.
+    #[test]
+    fn restore_recreates_closed_tab_at_original_index_1939() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("t0".into(), leaf(1, "a")));
+        layout.add_tab(Tab::new("mid".into(), leaf(2, "dev")));
+        layout.add_tab(Tab::new("t2".into(), leaf(3, "c")));
+
+        layout.remember_removed_pane("dev");
+        layout.close_tab(1);
+        assert_eq!(layout.tabs.len(), 2);
+
+        let placement = layout.take_removed_pane("dev").unwrap();
+        assert_eq!(placement.tab_idx, 1);
+        assert!(placement.split.is_none(), "sole pane has no parent split");
+
+        layout.restore_removed_pane(&placement, leaf(9, "dev"));
+        assert_eq!(layout.tabs.len(), 3);
+        assert_eq!(
+            layout
+                .tabs
+                .iter()
+                .map(|t| t.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["t0", "mid", "t2"],
+            "tab recreated in place, original order restored"
+        );
+        assert!(layout.tabs[1].root().has_agent("dev"));
+        assert_eq!(layout.active, 1, "recreated tab focused (add_tab parity)");
+    }
+
+    /// #1939: all remembered sibling agents gone by respawn time → fall back
+    /// to the pre-#1939 behavior (split the tab's focused pane); no panic.
+    #[test]
+    fn restore_falls_back_when_siblings_gone_1939() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("team".into(), leaf(5, "newcomer")));
+        let placement = RemovedPanePlacement {
+            tab_name: "team".into(),
+            tab_idx: 0,
+            split: Some(RemovedSplit {
+                dir: SplitDir::Vertical,
+                ratio: 0.5,
+                was_first: false,
+                sibling_agents: vec!["dev2".into()],
+            }),
+        };
+        layout.restore_removed_pane(&placement, leaf(9, "dev"));
+        assert_eq!(layout.tabs.len(), 1, "no new tab");
+        assert_eq!(layout.tabs[0].root().pane_count(), 2);
+        assert!(layout.tabs[0].root().has_agent("dev"));
+        assert!(layout.tabs[0].root().has_agent("newcomer"));
+    }
+
+    /// #1939: remembered tab gone AND its index now out of range → the
+    /// recreated tab is clamped to the end; no panic.
+    #[test]
+    fn restore_clamps_out_of_range_tab_idx_1939() {
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("t0".into(), leaf(1, "a")));
+        let placement = RemovedPanePlacement {
+            tab_name: "gone".into(),
+            tab_idx: 7,
+            split: None,
+        };
+        layout.restore_removed_pane(&placement, leaf(9, "dev"));
+        assert_eq!(layout.tabs.len(), 2);
+        assert_eq!(layout.tabs[1].name, "gone", "clamped to append");
+        assert!(layout.tabs[1].root().has_agent("dev"));
+    }
+
     #[test]
     fn find_agent_pane_returns_location() {
         let mut layout = Layout::new();

--- a/src/layout/tab.rs
+++ b/src/layout/tab.rs
@@ -222,6 +222,27 @@ impl Tab {
         remaining.is_none()
     }
 
+    /// #1939: restore `pane` to its remembered split position — wrap the
+    /// minimal subtree containing the still-present sibling agents in a split
+    /// of the remembered direction/ratio, with the pane on its remembered
+    /// side. Returns the pane back when none of the sibling agents are
+    /// displayed in this tab (caller picks a fallback placement).
+    pub fn restore_split(&mut self, split: &super::RemovedSplit, pane: Pane) -> Option<Pane> {
+        let anchors: std::collections::HashSet<usize> = split
+            .sibling_agents
+            .iter()
+            .filter_map(|a| self.root().find_pane_id_by_agent(a))
+            .collect();
+        if anchors.is_empty() {
+            return Some(pane);
+        }
+        let root = self.root.take().expect("root is always Some");
+        let (new_root, leftover) =
+            super::tree::wrap_subtree_with_split(root, &anchors, split, pane);
+        self.root = Some(new_root);
+        leftover
+    }
+
     /// Pane ID whose rect contains (col, row), if any.
     pub fn pane_at(&self, col: u16, row: u16) -> Option<usize> {
         self.pane_rects

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -151,6 +151,39 @@ impl PaneNode {
     }
 }
 
+/// #1939: geometry of the parent split holding the leaf `pane_id`: direction,
+/// ratio, which side the leaf sits on, and the sibling subtree's agents.
+/// `None` when the pane is the tab's root (no parent split) or absent.
+pub(super) fn parent_split_of(node: &PaneNode, pane_id: usize) -> Option<super::RemovedSplit> {
+    let PaneNode::Split {
+        dir,
+        ratio,
+        first,
+        second,
+    } = node
+    else {
+        return None;
+    };
+    let is_target = |n: &PaneNode| matches!(n, PaneNode::Leaf(p) if p.id == pane_id);
+    if is_target(first) {
+        return Some(super::RemovedSplit {
+            dir: *dir,
+            ratio: *ratio,
+            was_first: true,
+            sibling_agents: second.agent_names(),
+        });
+    }
+    if is_target(second) {
+        return Some(super::RemovedSplit {
+            dir: *dir,
+            ratio: *ratio,
+            was_first: false,
+            sibling_agents: first.agent_names(),
+        });
+    }
+    parent_split_of(first, pane_id).or_else(|| parent_split_of(second, pane_id))
+}
+
 // --- Ownership-based tree transforms ---
 
 pub(super) fn split_in_tree(
@@ -251,6 +284,97 @@ pub(super) fn remove_from_tree(node: PaneNode, target_id: usize) -> (PaneNode, O
                 removed,
             )
         }
+    }
+}
+
+/// #1939: re-insert a removed pane at its remembered position by wrapping the
+/// minimal subtree containing all `anchors` (the still-present panes of the
+/// removed pane's former sibling subtree) in a split of the remembered
+/// direction/ratio, with the new pane on its remembered side. Returns the
+/// pane back when no anchor is present in the tree (caller falls back).
+pub(super) fn wrap_subtree_with_split(
+    node: PaneNode,
+    anchors: &std::collections::HashSet<usize>,
+    split: &super::RemovedSplit,
+    new_pane: Pane,
+) -> (PaneNode, Option<Pane>) {
+    let total = count_anchor_panes(&node, anchors);
+    if total == 0 {
+        return (node, Some(new_pane));
+    }
+    (wrap_minimal(node, anchors, total, split, new_pane), None)
+}
+
+fn count_anchor_panes(node: &PaneNode, anchors: &std::collections::HashSet<usize>) -> usize {
+    match node {
+        PaneNode::Leaf(p) => usize::from(anchors.contains(&p.id)),
+        PaneNode::Split { first, second, .. } => {
+            count_anchor_panes(first, anchors) + count_anchor_panes(second, anchors)
+        }
+    }
+}
+
+/// Descend toward the smallest subtree containing all `total` anchors, then
+/// wrap it. A leaf or a split whose anchors straddle both children is the
+/// minimal containing subtree.
+fn wrap_minimal(
+    node: PaneNode,
+    anchors: &std::collections::HashSet<usize>,
+    total: usize,
+    split: &super::RemovedSplit,
+    new_pane: Pane,
+) -> PaneNode {
+    if let PaneNode::Split {
+        dir,
+        ratio,
+        first,
+        second,
+    } = node
+    {
+        let in_first = count_anchor_panes(&first, anchors);
+        if in_first == total {
+            return PaneNode::Split {
+                dir,
+                ratio,
+                first: Box::new(wrap_minimal(*first, anchors, total, split, new_pane)),
+                second,
+            };
+        }
+        if in_first == 0 {
+            return PaneNode::Split {
+                dir,
+                ratio,
+                first,
+                second: Box::new(wrap_minimal(*second, anchors, total, split, new_pane)),
+            };
+        }
+        return wrap_node(
+            PaneNode::Split {
+                dir,
+                ratio,
+                first,
+                second,
+            },
+            split,
+            new_pane,
+        );
+    }
+    wrap_node(node, split, new_pane)
+}
+
+fn wrap_node(node: PaneNode, split: &super::RemovedSplit, new_pane: Pane) -> PaneNode {
+    let new_leaf = Box::new(PaneNode::Leaf(Box::new(new_pane)));
+    let existing = Box::new(node);
+    let (first, second) = if split.was_first {
+        (new_leaf, existing)
+    } else {
+        (existing, new_leaf)
+    };
+    PaneNode::Split {
+        dir: split.dir,
+        ratio: split.ratio,
+        first,
+        second,
     }
 }
 


### PR DESCRIPTION
## Problem (#1939)
`restart_instance` / `replace_instance` respawn with `layout=SameTab`, but the #1431 memory records only the **tab name**. The respawned pane therefore lands best-effort:
- **Multi-pane tab**: `place_in_remembered_tab` = `split_focused(SplitDir::Horizontal)` — splits whatever pane happens to be focused, direction hardcoded, ratio default → within-tab slot/direction/ratio all lost. This is the operator-visible reflow from the 2026-06-10 fixup-dev restarts.
- **Single-pane tab**: the tab is closed on delete; respawn recreates it **appended at the end** → tab order lost.

The event chain itself is sound: DELETE emits `InstanceDeleted` synchronously before returning (`api/handlers/instance.rs:124-129`), so capture-before-remove has no race.

## Fix — TUI-side memory upgrade, daemon/API untouched
- `layout/tree.rs`: `parent_split_of()` captures the removed leaf's parent split (dir, ratio, side, sibling-subtree agents); `wrap_subtree_with_split()` restores by wrapping the **minimal subtree containing the surviving siblings** in the remembered split — nested sibling subtrees come back with their original shape, not a split against one leaf inside them.
- `layout/mod.rs`: `removed_tab_memory` (agent → tab name) → `removed_pane_memory` (agent → `RemovedPanePlacement{tab_name, tab_idx, split}`). `restore_removed_pane()` fallback chain: remembered split next to surviving siblings → focused split in the same tab (pre-#1939 behavior) → recreate the tab at its remembered index (`insert_tab`, clamped) instead of appending.
- `app/tui_events.rs`: `handle_instance_deleted` records the placement; the SameTab create branch restores it.

**replace_instance fixed for free** — it emits the same `layout=same-tab` with no anchor (`mcp/handlers/instance.rs:338`) and shares this TUI path.

**Headless safe by construction** — capture/restore live entirely in the TUI event loop; with no TUI attached `notifier=None` and `InstanceCreated`/`InstanceDeleted` are never emitted. No daemon-side behavior change.

## Tests (§3.9)
- `restore_2pane_exact_side_dir_ratio_1939` — exact slot: side + direction + ratio restored
- `restore_nested_sibling_subtree_shape_1939` — sibling subtree wrapped whole; original tree shape back
- `restore_recreates_closed_tab_at_original_index_1939` — single-pane tab recreated in place, order restored
- `restore_falls_back_when_siblings_gone_1939` — graceful fallback, no panic
- `restore_clamps_out_of_range_tab_idx_1939` — clamp, no panic
- #1431/#1625 replace/restart tests updated to the new API, contracts unchanged

`cargo fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · full suite **3526 passed / 0 failed** (bins) + integration tests green.

Closes #1939. Refs #1431, #1625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)