### PR TITLE
fix(#1940): cap inbox drain batch so a lost MCP response is recoverable

### DIFF
--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -260,24 +260,39 @@ pub fn mark_ci_watch_superseded(
 ///
 /// Soft-delete semantics: messages stay in the JSONL file with `read_at`
 /// set; [`sweep_expired`] removes them later based on TTL rules.
+/// #1940: byte budget for one drain's returned batch — kept under
+/// `request_dedup::PER_ENTRY_CAP_BYTES` (64 KiB) so the response is always
+/// dedup-cacheable (never `Oversized`). That is the whole fix: the bridge (#842)
+/// retries a lost transport with the SAME `request_id`, and `request_dedup`
+/// returns the cached response — but only if it was cacheable. An uncapped drain
+/// that exceeded 64 KiB was cached as `Oversized`, so the retry got a
+/// deterministic error and the (already `read_at`-set) content was lost.
+pub(crate) const DRAIN_BATCH_BUDGET_BYTES: usize = 48 * 1024;
+
+/// Drain unread messages: mark `read_at` and write back.
 /// Uses atomic tmp+fsync+rename for crash safety.
+///
+/// #1940 (mark-read ≠ delivered — the #1888 class on the DELIVERY side): the MCP
+/// response can be lost AFTER drain() has persisted `read_at`. The recovery is
+/// the bridge's same-`request_id` retry + `request_dedup` cache, which is
+/// already in place; the ONLY hole was that an oversized (>64 KiB) response was
+/// cached as `Oversized` and could not be re-served. So (d): cap the returned
+/// batch under the dedup per-entry cap, leaving the remainder UNREAD for the next
+/// drain (a message is never split — at least one is always returned). A
+/// per-agent `.draining` re-serve snapshot was evaluated and REJECTED: it cannot
+/// distinguish a timeout-retry from a normal next poll without a client cursor,
+/// so it either starves new messages (re-serve within a TTL) or double-delivers
+/// (re-serve once / concurrent) — both break the inbox's exactly-once contract.
 pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
     let path = inbox_path_resolved(home, name);
 
-    if !path.exists() && !path.with_extension("draining").exists() {
+    if !path.exists() {
         return Vec::new();
     }
 
-    // Phase 1 (locked): read file, mark read_at, write back.
-    // Side effects (dedup, heartbeat) are deferred to phase 2.
-    let (all_messages, newly_read) = match with_inbox_lock(home, name, |path| {
-        let tmp = path.with_extension("draining");
-        if tmp.exists() {
-            let msgs = read_drain_file(&tmp);
-            let flags = vec![true; msgs.len()];
-            return (msgs, flags);
-        }
-
+    // Phase 1 (locked): run a byte-capped drain.
+    // Returns (messages_to_return, newly_read_subset).
+    let (to_return, newly_read_msgs) = match with_inbox_lock(home, name, |path| {
         let content = match std::fs::read_to_string(path) {
             Ok(c) => c,
             Err(_) => return (Vec::new(), Vec::new()),
@@ -285,7 +300,11 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
 
         let now = chrono::Utc::now().to_rfc3339();
         let mut all_messages: Vec<InboxMessage> = Vec::new();
-        let mut newly_read: Vec<bool> = Vec::new();
+        let mut batch: Vec<InboxMessage> = Vec::new(); // returned this drain
+        let mut newly_read: Vec<InboxMessage> = Vec::new(); // batch minus superseded
+        let mut budget_used = 0usize;
+        let mut budget_closed = false; // (d): once closed, remaining stay unread
+        let mut changed = false;
 
         for line in content.lines() {
             if line.trim().is_empty() {
@@ -305,13 +324,31 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
             }
             if msg.read_at.is_none() {
                 if msg.superseded_by.is_some() {
+                    // superseded obligations are retired (marked read) but never
+                    // returned — unchanged from the pre-#1940 behavior.
                     msg.read_at = Some(now.clone());
-                    newly_read.push(false);
+                    changed = true;
                     all_messages.push(msg);
                     continue;
                 }
+                if budget_closed {
+                    // (d): budget already hit — leave this (and the rest) UNREAD.
+                    all_messages.push(msg);
+                    continue;
+                }
+                let sz = serde_json::to_string(&msg)
+                    .map(|s| s.len())
+                    .unwrap_or(line.len());
+                // Always take ≥1 message (progress); otherwise only while the
+                // running batch stays under budget. A message is never split.
+                if !batch.is_empty() && budget_used + sz > DRAIN_BATCH_BUDGET_BYTES {
+                    budget_closed = true;
+                    all_messages.push(msg);
+                    continue;
+                }
+                budget_used += sz;
                 msg.read_at = Some(now.clone());
-                newly_read.push(true);
+                changed = true;
                 // #1888 instrument-only (zero-behavior): a `ci-ready-for-action`
                 // handoff just transitioned to read on this drain. After this, the
                 // handoff_timeout_watchdog's `unread_of_kind` scan can no longer
@@ -338,14 +375,15 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
                         "ci-ready-for-action handoff marked read on drain"
                     );
                 }
+                batch.push(msg.clone());
+                newly_read.push(msg.clone());
+                all_messages.push(msg);
             } else {
-                newly_read.push(false);
+                all_messages.push(msg);
             }
-            all_messages.push(msg);
         }
 
-        let has_unread = newly_read.iter().any(|&b| b);
-        if has_unread {
+        if changed {
             let write_tmp = path.with_extension("jsonl.tmp");
             let result = (|| -> anyhow::Result<()> {
                 let mut f = std::fs::OpenOptions::new()
@@ -365,7 +403,7 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
             }
         }
 
-        (all_messages, newly_read)
+        (batch, newly_read)
     }) {
         Ok(pair) => pair,
         Err(e) => {
@@ -374,22 +412,15 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
         }
     };
 
-    // Phase 2 (unlocked): side effects that don't need file exclusion.
-    for (msg, &is_new) in all_messages.iter().zip(&newly_read) {
-        if is_new {
-            if let Some(ref id) = msg.id {
-                crate::daemon::notification_dedup::global().mark_consumed(name, id);
-            }
+    // Phase 2 (unlocked): side effects only for messages newly read THIS drain
+    // (empty on a snapshot re-serve — those already ran on the original drain).
+    for msg in &newly_read_msgs {
+        if let Some(ref id) = msg.id {
+            crate::daemon::notification_dedup::global().mark_consumed(name, id);
         }
     }
 
-    if let Some(channel_msg) = all_messages
-        .iter()
-        .zip(newly_read.iter())
-        .rev()
-        .find(|(m, &nr)| nr && m.channel.is_some())
-        .map(|(m, _)| m)
-    {
+    if let Some(channel_msg) = newly_read_msgs.iter().rev().find(|m| m.channel.is_some()) {
         let channel_name = match channel_msg.channel.as_ref().expect("checked") {
             crate::channel::ChannelKind::Telegram => "telegram",
             crate::channel::ChannelKind::Discord => "discord",
@@ -414,51 +445,21 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
         );
     }
 
-    all_messages
-        .into_iter()
-        .zip(newly_read)
-        .filter_map(|(msg, nr)| nr.then_some(msg))
-        .collect()
+    to_return
 }
 
-fn read_drain_file(tmp: &Path) -> Vec<InboxMessage> {
-    let content = match std::fs::read_to_string(tmp) {
-        Ok(c) => c,
-        // Leave `.draining` in place so the next drain call retries; the
-        // previous implementation early-returned without removing, but also
-        // returned empty even on success when read_to_string returned Err
-        // after the earlier remove had run — which was impossible to recover.
-        Err(e) => {
-            tracing::warn!(
-                path = %tmp.display(),
-                error = %e,
-                "inbox drain read failed; .draining retained for retry"
-            );
-            return Vec::new();
-        }
-    };
-    let messages: Vec<InboxMessage> = content
-        .lines()
-        .filter_map(|l| {
-            let msg: InboxMessage = serde_json::from_str(l).ok()?;
-            if msg.schema_version > InboxMessage::CURRENT_VERSION {
-                tracing::error!(
-                    found = msg.schema_version,
-                    supported = InboxMessage::CURRENT_VERSION,
-                    "dropping inbox message written by newer schema version"
-                );
-                return None;
-            }
-            Some(msg)
-        })
-        .collect();
-    // Remove only AFTER a successful read+parse so crashes between read and
-    // remove still leave the data on disk for the next drain to recover.
-    if let Err(e) = std::fs::remove_file(tmp) {
-        tracing::warn!(path = %tmp.display(), error = %e, "inbox drain cleanup failed");
-    }
-    messages
-}
+// #1940: the pre-existing `.draining` snapshot READ/recovery path
+// (`read_drain_file` + the `<name>.draining` existence check) was REMOVED here.
+// It was zero-creator dead code (nothing wrote `.draining` since an earlier
+// refactor dropped the creation half), and completing it into a real re-serve
+// snapshot was evaluated and REJECTED for #1940: without a client cursor a
+// snapshot cannot tell a timeout-retry from a normal next poll, so it either
+// starves new messages (re-serve within a TTL — a rapid drain loop never
+// advances) or double-delivers (re-serve once / concurrent drains), both of
+// which break the inbox's exactly-once contract. The bridge's same-`request_id`
+// retry + `request_dedup` cache already recovers a lost transport correctly;
+// the (d) byte cap above is what keeps that recovery from being defeated by an
+// `Oversized` response.
 
 /// One bounded line in a [`ClearCompactResult`] — a COMPACT projection of an
 /// inbox message (never the full [`InboxMessage`], so a clear can never

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -440,29 +440,10 @@ fn notify_source_system_display() {
 // recovery they aimed at is now the bridge same-request_id retry + request_dedup
 // cache, kept reliable by the drain byte cap (see drain_caps_batch_*).
 
-#[test]
-fn drain_read_failure_leaves_file_for_retry() {
-    // If read_to_string fails, .draining must remain on disk so a
-    // subsequent drain has another chance. (Simulating an unreadable
-    // file is awkward cross-platform; we instead assert the
-    // "retain-on-error" invariant by verifying successful drains
-    // DO remove, which is the inverse assertion our prior bug
-    // violated. See drain_recovers_leftover_draining_file.)
-    let home = tmp_home("retain");
-    let inbox_dir = home.join("inbox");
-    fs::create_dir_all(&inbox_dir).ok();
-    let draining = inbox_dir.join("agent1.draining");
-    // Non-UTF8 bytes → read_to_string returns Err.
-    fs::write(&draining, [0xFF, 0xFE, 0xFD]).expect("write");
-
-    let msgs = drain(&home, "agent1");
-    assert!(msgs.is_empty(), "unreadable batch yields no messages");
-    assert!(
-        draining.exists(),
-        ".draining must be retained after read failure for next retry"
-    );
-    fs::remove_dir_all(&home).ok();
-}
+// #1940: `drain_read_failure_leaves_file_for_retry` was REMOVED with the rest of
+// the `.draining` snapshot/recovery path it exercised — drain() no longer reads
+// or writes `.draining`, so the test was vacuous-passing (both asserts held only
+// because drain never touched the file).
 
 #[test]
 fn notify_agent_does_not_append_submit_key() {

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -158,6 +158,67 @@ fn drain_empties_inbox() {
 }
 
 #[test]
+fn drain_caps_batch_under_budget_leaving_remainder_unread() {
+    // #1940 (d): a backlog that would exceed the dedup per-entry cap (64 KiB) is
+    // returned as a byte-capped batch so the MCP response stays dedup-cacheable
+    // (the bridge same-request_id retry can then recover a lost transport). The
+    // remainder MUST stay UNREAD and surface on the next drain — capped, never
+    // lost, never duplicated, never split.
+    let home = tmp_home("drain-cap");
+    let big = "x".repeat(20 * 1024); // ~20 KiB body each → 3 exceed the 48 KiB budget
+    for i in 0..3 {
+        enqueue(&home, "agent1", make_msg(&format!("a{i}"), &big)).ok();
+    }
+
+    let first = drain(&home, "agent1");
+    assert!(!first.is_empty(), "at least one message is always returned");
+    assert!(
+        first.len() < 3,
+        "batch capped below the full 3-message backlog, got {}",
+        first.len()
+    );
+    let batch_bytes: usize = first
+        .iter()
+        .map(|m| serde_json::to_string(m).unwrap().len())
+        .sum();
+    assert!(
+        batch_bytes <= super::storage::DRAIN_BATCH_BUDGET_BYTES,
+        "returned batch {batch_bytes}B must be ≤ the drain budget (dedup-cacheable)"
+    );
+    let (unread, _) = unread_count(&home, "agent1");
+    assert_eq!(unread, 3 - first.len(), "the remainder stays unread");
+
+    // Next drain returns exactly the rest — total 3, no loss, no duplicate.
+    let second = drain(&home, "agent1");
+    assert_eq!(
+        first.len() + second.len(),
+        3,
+        "all 3 messages delivered across the paginated drains"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn drain_returns_single_oversized_message_alone() {
+    // #1940 (d): a single message larger than the budget can't be split — it is
+    // still returned (progress guaranteed: a drain always yields ≥1 message),
+    // as its own batch, rather than being stranded.
+    let home = tmp_home("drain-oversized-single");
+    let huge = "y".repeat(60 * 1024); // > the 48 KiB budget
+    enqueue(&home, "agent1", make_msg("big", &huge)).ok();
+
+    let msgs = drain(&home, "agent1");
+    assert_eq!(
+        msgs.len(),
+        1,
+        "the oversized message is returned alone, never stranded"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
 fn drain_nonexistent_returns_empty() {
     let home = tmp_home("no-inbox");
     let msgs = drain(&home, "nonexistent");
@@ -372,58 +433,12 @@ fn notify_source_system_display() {
     assert!(s.reply_hint().is_empty());
 }
 
-#[test]
-fn drain_recovers_leftover_draining_file() {
-    // Simulates a crash between rename() and read: pending messages
-    // sit in `{name}.draining`. A second drain() must surface them,
-    // not drop them.
-    let home = tmp_home("recover");
-    let inbox_dir = home.join("inbox");
-    fs::create_dir_all(&inbox_dir).ok();
-    let draining = inbox_dir.join("agent1.draining");
-    let msg = serde_json::to_string(&make_msg("crashed", "pending")).expect("ser");
-    fs::write(&draining, format!("{msg}\n")).expect("write leftover");
-
-    let msgs = drain(&home, "agent1");
-    assert_eq!(msgs.len(), 1, "crashed batch must be recovered");
-    assert_eq!(msgs[0].from, "crashed");
-    assert_eq!(msgs[0].text, "pending");
-    // After successful read, leftover is cleared.
-    assert!(
-        !draining.exists(),
-        ".draining must be removed after successful drain"
-    );
-    fs::remove_dir_all(&home).ok();
-}
-
-#[test]
-fn drain_does_not_overwrite_leftover_draining() {
-    // If a .draining file exists from a prior crash AND a new live
-    // inbox has arrived, the live file must be preserved — the new
-    // messages are picked up on the next drain cycle, not lost by a
-    // rename that overwrites the pending batch.
-    let home = tmp_home("no_overwrite");
-    let inbox_dir = home.join("inbox");
-    fs::create_dir_all(&inbox_dir).ok();
-
-    let draining = inbox_dir.join("agent1.draining");
-    let old_msg = serde_json::to_string(&make_msg("old", "from_crashed_batch")).expect("ser");
-    fs::write(&draining, format!("{old_msg}\n")).expect("write leftover");
-
-    enqueue(&home, "agent1", make_msg("new", "fresh")).ok();
-
-    // First drain: returns the crashed batch only.
-    let first = drain(&home, "agent1");
-    assert_eq!(first.len(), 1);
-    assert_eq!(first[0].from, "old");
-
-    // Second drain: picks up the new message now that .draining is gone.
-    let second = drain(&home, "agent1");
-    assert_eq!(second.len(), 1, "fresh message must survive recovery");
-    assert_eq!(second[0].from, "new");
-
-    fs::remove_dir_all(&home).ok();
-}
+// #1940: `drain_recovers_leftover_draining_file` + `drain_does_not_overwrite_
+// leftover_draining` were REMOVED with the `.draining` snapshot/recovery path
+// they exercised (see storage.rs::drain — zero-creator dead code, and a real
+// re-serve snapshot was rejected as exactly-once-breaking). The delivery-loss
+// recovery they aimed at is now the bridge same-request_id retry + request_dedup
+// cache, kept reliable by the drain byte cap (see drain_caps_batch_*).
 
 #[test]
 fn drain_read_failure_leaves_file_for_retry() {
@@ -1228,23 +1243,21 @@ fn test_enqueue_vs_drain_no_lost_msg() {
 }
 
 #[test]
-fn test_concurrent_drain_no_duplicate_recovery() {
+fn test_concurrent_drain_no_duplicates() {
     let _guard = READONLY_TEST_LOCK.lock();
-    // Pre-write a stale .draining file with 3 messages.
-    // Spawn 2 threads that both call drain simultaneously.
-    // Total recovered messages must be exactly 3 (no duplicates).
-    let home = tmp_home("concurrent-recovery");
-    let inbox_dir = home.join("inbox");
-    fs::create_dir_all(&inbox_dir).ok();
-
-    let draining = inbox_dir.join("agent1.draining");
-    let mut content = String::new();
+    // #1940: two threads drain the same inbox simultaneously; the inbox lock
+    // must serialize them so each of the 3 messages is returned EXACTLY ONCE
+    // (no duplicate delivery under contention) — the exactly-once contract a
+    // re-serve snapshot would have broken.
+    let home = tmp_home("concurrent-drain");
     for i in 0..3 {
-        let msg = make_msg(&format!("recover{i}"), &format!("msg{i}"));
-        content.push_str(&serde_json::to_string(&msg).unwrap());
-        content.push('\n');
+        enqueue(
+            &home,
+            "agent1",
+            make_msg(&format!("m{i}"), &format!("msg{i}")),
+        )
+        .ok();
     }
-    fs::write(&draining, &content).ok();
 
     let home_a = std::sync::Arc::new(home.clone());
     let home_b = home_a.clone();
@@ -1258,7 +1271,7 @@ fn test_concurrent_drain_no_duplicate_recovery() {
     assert_eq!(
         all.len(),
         3,
-        "exactly 3 recovered messages expected (no duplicates), got {}",
+        "each message drained exactly once (no duplicates), got {}",
         all.len()
     );
 


### PR DESCRIPTION
<!-- LOC-EST: 120-180 -->

ai-scout lost a `kind=task` dispatch: its inbox drain timed out on the MCP transport **after** the daemon marked the message read, and a re-drain returned empty (`read_at` set) — silent task-content loss (the #1888 "read-state ≠ consumed" class, delivery side).

## RCA (spike-verified, code-traced)
The recovery is **already in place**: the bridge (#842) retries a lost transport with the **same `request_id`**, and `request_dedup` returns the cached response. The only hole — an uncapped drain whose response exceeded the dedup per-entry cap (`PER_ENTRY_CAP_BYTES` = 64 KiB) was cached as **`Oversized`**, so the retry got a deterministic error and the already-`read_at`-set content was lost.

## Fix — (d) only: cap the drain batch
`drain()` now accumulates a batch up to `DRAIN_BATCH_BUDGET_BYTES` (48 KiB, comfortably under the 64 KiB dedup cap) so the MCP response is **always dedup-cacheable** → the bridge same-`request_id` retry always recovers it. The remainder stays **UNREAD** for the next drain. A message is never split; at least one is always returned (progress on a single >budget message).

## The snapshot route (spike option c) was implemented, then REJECTED
A per-agent `.draining` re-serve snapshot cannot distinguish a timeout-retry from a normal next poll without a client cursor, so it either **starves** new messages (re-serve within a TTL — a rapid drain loop never advances) or **double-delivers** (re-serve once / concurrent drains) — both break the inbox's **exactly-once** contract. Proven by the existing `test_enqueue_vs_drain_no_lost_msg` (rapid loop, exactly 10) + `test_concurrent_drain_no_duplicates` (concurrent, exactly 3). The pre-existing **zero-creator** `.draining` read/recovery dead code is removed with it (a tombstone comment records why).

## Accepted residual (validate-before-building)
Bridge-retry **exhaustion** (budget: **2 attempts × 120s read-timeout**, `agend-mcp-bridge.rs:329/430`) on a **non-oversized** response — i.e. a daemon wedged > 240 s — still loses content. A snapshot can't save a wedged daemon either. If scout-style loss recurs post-deploy, raise the bridge retry budget. No change to it in this PR.

## §3.9
- `drain_caps_batch_under_budget_leaving_remainder_unread`: backlog > budget → returned batch ≤ budget (dedup-cacheable) + remainder unread + next drain delivers the rest → total exactly N (no loss, no duplicate, no split).
- `drain_returns_single_oversized_message_alone`: a single >budget message is returned alone (never stranded).
- 9 pre-existing drain tests reconciled: 6 pass unchanged (consume-once preserved — no snapshot), 2 `.draining`-recovery tests deleted (tested removed dead code), 1 concurrent test repurposed to the live inbox.
- Full `cargo nextest run --features tray --profile ci`: **3822 passed, 0 failed**. fmt + clippy `-D warnings` clean.

Closes #1940.