### PR TITLE
feat: multi-backend context% detection + ≥80% orchestrator alert

### DIFF
--- a/src/api/handlers/query.rs
+++ b/src/api/handlers/query.rs
@@ -13,7 +13,7 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
         .values()
         .map(|handle| {
             let name = handle.name.as_str();
-            let (agent_state, health_state, blocked_reason, blocked_note) = {
+            let (agent_state, health_state, blocked_reason, blocked_note, context) = {
                 let c = handle.core.lock();
                 (
                     c.state.get_state().display_name().to_string(),
@@ -23,6 +23,10 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                     // blocked and its free-text annotation (previously internal-only).
                     c.health.current_reason.as_ref().map(|r| r.to_string()),
                     c.health.current_note.clone(),
+                    // Context% telemetry: resolved usage + producing source
+                    // ("pattern" = the agent's own statusline, "transcript" =
+                    // token-usage estimate). Absent = honestly unknown.
+                    c.state.resolved_context(),
                 )
             };
             let (dispatched_waiting_for, pending_response_to) =
@@ -36,6 +40,8 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                 "health_state": health_state,
                 "blocked_reason": blocked_reason,
                 "blocked_note": blocked_note,
+                "context_pct": context.map(|(pct, _)| pct),
+                "context_source": context.map(|(_, source)| source),
                 "kind": "managed",
                 "dispatched_waiting_for": dispatched_waiting_for,
                 "pending_response_to": pending_response_to,

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -38,7 +38,26 @@ pub struct BackendProfile {
     pub behavioral: BehavioralConfig,
     pub productivity: ProductivityConfig,
     pub initial_state: AgentState,
+    /// Context% telemetry: regex whose capture group 1 extracts the backend's
+    /// self-reported context usage percent from the BOTTOM status rows of the
+    /// rendered screen (`None` = backend displays no usable percent). Scanned
+    /// only over the bottom status rows — NOT the error tail window — because
+    /// agents routinely DISCUSS context% in conversation text (prose-FP).
+    pub context_pattern: Option<&'static str>,
 }
+
+/// ClaudeCode context% — matches the fleet statusline's used-form as rendered
+/// live (`Model: Fable 5 | Ctx Used: 61.0% | ⎇ branch | (+0,-0)`); the value
+/// can be fractional. TODO(left-form): a default Claude Code install without a
+/// statusline only shows `Context left until auto-compact: N%` near the
+/// threshold — REMAINING semantics, needs inversion; deliberately not matched
+/// in v1 (this fleet always runs the custom statusline).
+pub const CLAUDE_CONTEXT_PATTERN: &str = r"(?i)\bctx\s+used:\s*(\d+(?:\.\d+)?)\s*%";
+
+/// KiroCli context% — matches the footer as rendered live
+/// (`Kiro · auto · ◔ 10%`). The ◔ glyph is kiro's context gauge and never
+/// appears in prose.
+pub const KIRO_CONTEXT_PATTERN: &str = r"◔\s*(\d+(?:\.\d+)?)\s*%";
 
 /// The single dispatch: `Backend → &'static BackendProfile`, lazy-cached
 /// (compile-once, mirroring `StatePatterns::for_backend`'s `OnceLock`). Returns
@@ -89,6 +108,7 @@ fn agy_profile() -> BackendProfile {
             heartbeat_fresh_window_ms: 10_000,
             cache_id: Some(MarkerCacheId::Gemini),
         },
+        context_pattern: None,
         initial_state: AgentState::Starting,
     }
 }
@@ -147,6 +167,7 @@ fn kirocli_profile() -> BackendProfile {
             heartbeat_fresh_window_ms: 10_000,
             cache_id: Some(MarkerCacheId::Kiro),
         },
+        context_pattern: Some(KIRO_CONTEXT_PATTERN),
         initial_state: AgentState::Starting,
     }
 }
@@ -205,6 +226,7 @@ fn opencode_profile() -> BackendProfile {
             heartbeat_fresh_window_ms: 10_000,
             cache_id: Some(MarkerCacheId::OpenCode),
         },
+        context_pattern: None,
         initial_state: AgentState::Starting,
     }
 }
@@ -256,6 +278,7 @@ fn codex_profile() -> BackendProfile {
             heartbeat_fresh_window_ms: 10_000,
             cache_id: Some(MarkerCacheId::Codex),
         },
+        context_pattern: None,
         initial_state: AgentState::Starting,
     }
 }
@@ -325,6 +348,7 @@ fn claudecode_profile() -> BackendProfile {
             heartbeat_fresh_window_ms: 10_000,
             cache_id: Some(MarkerCacheId::Claude),
         },
+        context_pattern: Some(CLAUDE_CONTEXT_PATTERN),
         initial_state: AgentState::Starting,
     }
 }
@@ -341,6 +365,7 @@ fn empty_profile() -> BackendProfile {
             heartbeat_fresh_window_ms: 0,
             cache_id: Some(MarkerCacheId::Generic),
         },
+        context_pattern: None,
         initial_state: AgentState::Idle,
     }
 }
@@ -432,5 +457,44 @@ mod tests {
                  wired into profile() yet missing from migrated() is SILENTLY un-parity-tested."
             );
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod context_pattern_tests {
+    use super::*;
+
+    /// Pin which backends advertise a context% pattern: Claude + Kiro display
+    /// a usable percent (live-verified 2026-06-10); the rest are honestly
+    /// None (codex would require editing the user's global ~/.codex/config.toml
+    /// to display one; opencode/agy show none).
+    #[test]
+    fn context_pattern_presence_per_backend() {
+        let has = |b: &Backend| profile(b).and_then(|p| p.context_pattern).is_some();
+        assert!(has(&Backend::ClaudeCode));
+        assert!(has(&Backend::KiroCli));
+        assert!(!has(&Backend::Codex));
+        assert!(!has(&Backend::OpenCode));
+        assert!(!has(&Backend::Agy));
+        assert!(!has(&Backend::Shell));
+        assert!(!has(&Backend::Raw("x".into())));
+    }
+
+    /// Both patterns compile and extract the percent (capture group 1) from
+    /// the live-captured renders they were written against.
+    #[test]
+    fn context_patterns_capture_live_renders() {
+        let claude = regex::Regex::new(CLAUDE_CONTEXT_PATTERN).unwrap();
+        let caps = claude
+            .captures("  Model: Fable 5 | Ctx Used: 61.0% | ⎇ fix/879 | (+0,-0)")
+            .expect("claude live render matches");
+        assert_eq!(&caps[1], "61.0");
+
+        let kiro = regex::Regex::new(KIRO_CONTEXT_PATTERN).unwrap();
+        let caps = kiro
+            .captures("Kiro · auto · ◔ 10%        ~/.agend-terminal/workspace/kiro")
+            .expect("kiro live render matches");
+        assert_eq!(&caps[1], "10");
     }
 }

--- a/src/daemon/inbox_stuck_watchdog.rs
+++ b/src/daemon/inbox_stuck_watchdog.rs
@@ -27,7 +27,7 @@ const STUCK_AFTER_MINS: i64 = 30;
 const REALERT_AFTER_MINS: i64 = 60;
 /// Fallback alert recipient when the stuck agent isn't in any team (so no
 /// orchestrator can be resolved). Matches the idle watchdog's default.
-const FALLBACK_RECIPIENT: &str = "lead";
+pub(crate) const FALLBACK_RECIPIENT: &str = "lead";
 
 /// Scan every fleet instance and alert the lead about any that is sitting on a
 /// pile of unread inbox messages. `last_alerted` is owned by the caller (the
@@ -95,7 +95,7 @@ pub(crate) fn scan_and_emit(
 }
 
 /// The orchestrator of the first team that lists `agent` as a member.
-fn orchestrator_for(fleet: &crate::fleet::FleetConfig, agent: &str) -> Option<String> {
+pub(crate) fn orchestrator_for(fleet: &crate::fleet::FleetConfig, agent: &str) -> Option<String> {
     fleet
         .teams
         .values()

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -602,6 +602,11 @@ pub(crate) fn build_default_handlers(
         // > 2d). Same 360-tick cadence as the other GC siblings; runs in app mode
         // (not allowlisted out) since the live daemon is app-mode.
         Box::new(per_tick::TmpReviewGcHandler::new(360)),
+        // Context% alert (operator-directed): every 6 ticks (~1min) refresh +
+        // ≥80% orchestrator alert. The transcript-estimate file IO lives in
+        // this handler's tick (lock-free during the read), NOT in the PTY
+        // feed path. Runs in app mode (the live daemon is app-mode).
+        Box::new(per_tick::ContextAlertHandler::new(6)),
     ]
 }
 

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -1,0 +1,258 @@
+//! Context% alert — operator-directed early warning when an agent's context
+//! usage crosses the alert threshold. Detection + notification ONLY: the
+//! alert goes to the agent's team orchestrator (and the usage is visible via
+//! LIST `context_pct`/`context_source`); nothing is auto-restarted.
+//!
+//! Source resolution per agent (see `StateTracker::resolved_context`):
+//! 1. `pattern` — the agent's own statusline percent, parsed by the PTY
+//!    feed (cheap, in-band). Preferred when fresh.
+//! 2. `transcript` — for Claude agents whose pattern can't be read (narrow
+//!    pane truncation / no statusline), this handler computes the estimate
+//!    from the newest transcript's LAST message usage. That file IO runs
+//!    HERE — on the tick, with no registry/core lock held — never in the
+//!    PTY reader's feed path.
+//! 3. otherwise unknown — no alert, honest `null` in LIST.
+//!
+//! Dedup/hysteresis: an alert fires on crossing `>= threshold` while armed;
+//! firing disarms; re-arming requires dropping below `threshold -
+//! HYSTERESIS_PCT` (no 79↔81 flapping); a continuously-high agent re-alerts
+//! every [`REALERT_AFTER`]. State is in-memory: a daemon restart re-fires
+//! once — accepted (current-state alert, single, self-limiting).
+
+use super::{PerTickHandler, TickContext};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+/// Default alert threshold (percent). Override: `AGEND_CONTEXT_ALERT_PCT`.
+const DEFAULT_ALERT_PCT: f32 = 80.0;
+/// Re-arm requires dropping this far below the threshold (compact/restart),
+/// so boundary noise can't re-fire.
+const HYSTERESIS_PCT: f32 = 5.0;
+/// Re-alert cadence while usage stays continuously above the threshold.
+const REALERT_AFTER: Duration = Duration::from_secs(30 * 60);
+
+fn alert_threshold() -> f32 {
+    std::env::var("AGEND_CONTEXT_ALERT_PCT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_ALERT_PCT)
+}
+
+/// Per-agent alert latch.
+struct AlertState {
+    /// Armed = the next threshold crossing alerts immediately. Disarmed by a
+    /// fire; re-armed once the pct drops below `threshold - HYSTERESIS_PCT`.
+    armed: bool,
+    last_alert: Option<Instant>,
+}
+
+impl Default for AlertState {
+    fn default() -> Self {
+        Self {
+            armed: true,
+            last_alert: None,
+        }
+    }
+}
+
+/// Pure alert decision: should an alert fire NOW for this reading? Mutates
+/// the per-agent latch accordingly (fire disarms + stamps; a low reading
+/// below the hysteresis floor re-arms).
+fn decide(state: &mut AlertState, pct: f32, threshold: f32, now: Instant) -> bool {
+    if pct >= threshold {
+        let realert_due = state
+            .last_alert
+            .is_none_or(|t| now.saturating_duration_since(t) >= REALERT_AFTER);
+        if state.armed || realert_due {
+            state.armed = false;
+            state.last_alert = Some(now);
+            return true;
+        }
+        return false;
+    }
+    if pct < threshold - HYSTERESIS_PCT {
+        state.armed = true;
+    }
+    false
+}
+
+pub(crate) struct ContextAlertHandler {
+    every_n_ticks: u64,
+    counter: AtomicU64,
+    states: Mutex<HashMap<String, AlertState>>,
+}
+
+impl ContextAlertHandler {
+    pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self {
+            every_n_ticks,
+            counter: AtomicU64::new(0),
+            states: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Fires at tick indices 0, N, 2N, … (matches `InboxStuckHandler`).
+    fn should_fire(&self) -> bool {
+        self.counter
+            .fetch_add(1, Ordering::Relaxed)
+            .is_multiple_of(self.every_n_ticks)
+    }
+}
+
+impl PerTickHandler for ContextAlertHandler {
+    fn name(&self) -> &'static str {
+        "context_alert"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if !self.should_fire() {
+            return;
+        }
+
+        // Phase 1 (cheap, locks only): snapshot resolved context per agent;
+        // collect the Claude agents that need a transcript-estimate refresh.
+        let mut resolved: Vec<(String, f32, &'static str)> = Vec::new();
+        let mut need_estimate = Vec::new();
+        {
+            let reg = crate::agent::lock_registry(ctx.registry);
+            for handle in reg.values() {
+                let name = handle.name.as_str().to_string();
+                match handle.core.lock().state.resolved_context() {
+                    Some((pct, source)) => resolved.push((name, pct, source)),
+                    // The estimator reads Claude transcripts — only Claude
+                    // agents can produce one; everything else stays unknown.
+                    None if handle.backend_command.contains("claude") => {
+                        need_estimate.push((name, std::sync::Arc::clone(&handle.core)));
+                    }
+                    None => {}
+                }
+            }
+        }
+
+        // Phase 2 (file IO, NO locks held during the read): refresh estimates,
+        // then store back under a short core lock so LIST surfaces them.
+        for (name, core) in need_estimate {
+            if let Some(pct) = crate::token_cost::estimate_context_pct(ctx.home, &name) {
+                core.lock().state.set_context_estimate(pct);
+                resolved.push((name, pct, "transcript"));
+            }
+        }
+
+        // Phase 3: threshold/hysteresis evaluation + orchestrator notify.
+        let threshold = alert_threshold();
+        let now = Instant::now();
+        let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
+            .unwrap_or_default();
+        let mut states = self.states.lock();
+        for (name, pct, source) in resolved {
+            let state = states.entry(name.clone()).or_default();
+            if !decide(state, pct, threshold, now) {
+                continue;
+            }
+            // Notify the agent's team orchestrator. Never the agent about
+            // itself (it can't act on an alert it isn't reading) — matches
+            // the inbox-stuck watchdog's recipient rule.
+            let recipient = crate::daemon::inbox_stuck_watchdog::orchestrator_for(&fleet, &name)
+                .unwrap_or_else(|| {
+                    crate::daemon::inbox_stuck_watchdog::FALLBACK_RECIPIENT.to_string()
+                });
+            if recipient == name {
+                continue;
+            }
+            let text = format!(
+                "[context_alert] agent '{name}' context usage at {pct:.0}% \
+                 (source: {source}, threshold {threshold:.0}%). Handling is NOT \
+                 automated — at a natural boundary consider a handoff + \
+                 restart_instance to free the context. Re-alerts every 30min \
+                 while it stays high."
+            );
+            if let Err(e) = crate::inbox::notify_system(
+                ctx.home,
+                &recipient,
+                "system:context_alert",
+                "context_alert",
+                text,
+                Some(&name),
+                None,
+            ) {
+                tracing::warn!(agent = %name, %recipient, error = %e, "context_alert: notify failed");
+                continue;
+            }
+            tracing::info!(agent = %name, %recipient, pct, source, "context_alert: alerted orchestrator");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const T: f32 = 80.0;
+
+    /// Crossing the threshold while armed fires once; staying high does not
+    /// re-fire within the re-alert window.
+    #[test]
+    fn fires_on_crossing_then_dedups_while_high() {
+        let mut s = AlertState::default();
+        let now = Instant::now();
+        assert!(decide(&mut s, 81.0, T, now), "armed crossing fires");
+        assert!(
+            !decide(&mut s, 85.0, T, now),
+            "still high, within window — no re-fire"
+        );
+        assert!(!decide(&mut s, 99.0, T, now), "still no re-fire");
+    }
+
+    /// Continuously-high usage re-alerts once the re-alert window elapses.
+    #[test]
+    fn realerts_after_window_while_still_high() {
+        let mut s = AlertState::default();
+        let now = Instant::now();
+        assert!(decide(&mut s, 90.0, T, now));
+        let later = now + REALERT_AFTER;
+        assert!(decide(&mut s, 90.0, T, later), "re-alert due after window");
+        assert!(!decide(&mut s, 90.0, T, later), "and dedups again");
+    }
+
+    /// Dropping below the threshold but ABOVE the hysteresis floor does NOT
+    /// re-arm — a 79↔81 boundary wobble cannot fire repeatedly.
+    #[test]
+    fn boundary_wobble_does_not_refire() {
+        let mut s = AlertState::default();
+        let now = Instant::now();
+        assert!(decide(&mut s, 81.0, T, now));
+        assert!(!decide(&mut s, 79.0, T, now), "below threshold — no fire");
+        assert!(
+            !decide(&mut s, 81.0, T, now),
+            "wobble back above must not re-fire (not re-armed, window not due)"
+        );
+    }
+
+    /// Dropping below the hysteresis floor (compact/restart) re-arms, so the
+    /// next genuine crossing alerts immediately.
+    #[test]
+    fn compact_rearms_next_crossing_fires() {
+        let mut s = AlertState::default();
+        let now = Instant::now();
+        assert!(decide(&mut s, 85.0, T, now));
+        assert!(
+            !decide(&mut s, 40.0, T, now),
+            "compact drop — re-arms, no fire"
+        );
+        assert!(
+            decide(&mut s, 82.0, T, now),
+            "fresh crossing fires immediately"
+        );
+    }
+
+    /// Below-threshold readings never fire, armed or not.
+    #[test]
+    fn below_threshold_never_fires() {
+        let mut s = AlertState::default();
+        let now = Instant::now();
+        assert!(!decide(&mut s, 0.0, T, now));
+        assert!(!decide(&mut s, 79.9, T, now));
+    }
+}

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -35,6 +35,7 @@ use std::sync::Arc;
 
 pub(crate) mod check_schedules;
 pub(crate) mod ci_watch_poll;
+pub(crate) mod context_alert;
 pub(crate) mod external_liveness;
 pub(crate) mod gc_tick;
 pub(crate) mod handoff_timeout;
@@ -52,6 +53,7 @@ pub(crate) mod watchdog;
 
 pub(crate) use check_schedules::CheckSchedulesHandler;
 pub(crate) use ci_watch_poll::CiWatchPollHandler;
+pub(crate) use context_alert::ContextAlertHandler;
 pub(crate) use external_liveness::ExternalLivenessHandler;
 pub(crate) use gc_tick::GcTickHandler;
 pub(crate) use handoff_timeout::HandoffTimeoutHandler;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -212,6 +212,19 @@ pub struct StateTracker {
     /// crucial for not resetting `last_output` on cursor-blink noise.
     last_screen_hash: Option<u64>,
     patterns: Option<&'static StatePatterns>,
+    /// Context% telemetry: compiled `BackendProfile::context_pattern`
+    /// (capture group 1 = the backend's self-reported context usage percent).
+    /// `None` for backends that display no usable percent.
+    context_regex: Option<regex::Regex>,
+    /// Latest pattern-extracted context% reading + its capture instant. Kept
+    /// (not cleared) when the pattern stops matching — a narrow pane can
+    /// truncate the statusline mid-session; the timestamp lets consumers
+    /// judge staleness instead of treating "can't read" as "safe".
+    context_pct: Option<(f32, Instant)>,
+    /// Transcript-derived context estimate + its compute instant. Written by
+    /// the daemon's context-alert tick (file IO stays OFF this struct's hot
+    /// path — the PTY reader feeds under the core lock).
+    context_estimate: Option<(f32, Instant)>,
     /// Set to true the moment we enter `InteractivePrompt`; cleared by
     /// `take_interactive_prompt_notice()` once the supervisor has forwarded a
     /// Telegram notice. This deduplicates per-entry: re-entry (e.g. dismissed
@@ -343,6 +356,19 @@ fn recent_screen_tail(screen_text: &str, n: usize) -> String {
     let start = lines.len().saturating_sub(n);
     lines[start..].join("\n")
 }
+
+/// Context% telemetry: rows scanned from the bottom of the screen for the
+/// backend's `context_pattern`. Sized from live pane geometry: the Claude
+/// statusline renders 2 rows from the bottom; kiro's `◔ N%` footer sits up to
+/// 5 rows from the bottom (footer + blank + input hint + blank + key help).
+/// Deliberately MUCH narrower than `ERROR_TAIL_SCAN_LINES` — conversation
+/// text (where agents discuss context%) must stay out of scope (prose-FP).
+const CONTEXT_SCAN_ROWS: usize = 6;
+
+/// Context% telemetry: readings older than this are dropped (not trusted) by
+/// `resolved_context` — a narrow pane can truncate the statusline for the
+/// rest of a session, and "can't read" must not freeze a stale percent.
+const CONTEXT_FRESH: Duration = Duration::from_secs(600);
 
 /// #1005 Phase A2: window inside which a `Lower→Active(X)→Lower→Active(X)`
 /// bounce is treated as oscillation. Default 30s — matches
@@ -846,6 +872,12 @@ impl StateTracker {
             last_anchor_suppress_hash: None,
             last_screen_hash: None,
             patterns: backend.map(StatePatterns::for_backend),
+            context_regex: backend
+                .and_then(crate::backend_profile::profile)
+                .and_then(|p| p.context_pattern)
+                .and_then(|p| regex::Regex::new(p).ok()),
+            context_pct: None,
+            context_estimate: None,
             interactive_prompt_pending_notice: false,
             interactive_recovery_pending_notice: false,
             last_heartbeat: None,
@@ -933,6 +965,53 @@ impl StateTracker {
         self.last_heartbeat = Some(Instant::now().checked_sub(age).unwrap_or_else(Instant::now));
     }
 
+    /// Context% telemetry: extract the backend's self-reported context usage
+    /// from the BOTTOM status rows of a changed screen. Scoped to the last
+    /// [`CONTEXT_SCAN_ROWS`] rows (the statusline region) — agents routinely
+    /// DISCUSS context% in conversation text, so scanning the wider error-tail
+    /// window would false-positive on prose. A stale frame can leave an old
+    /// statusline copy above the live one, so the LAST matching row wins. No
+    /// match (e.g. a narrow pane truncating the statusline) keeps the previous
+    /// reading — its timestamp lets consumers judge staleness.
+    fn scan_context_pct(&mut self, screen_text: &str) {
+        let Some(re) = &self.context_regex else {
+            return;
+        };
+        let tail = recent_screen_tail(screen_text, CONTEXT_SCAN_ROWS);
+        for line in tail.lines().rev() {
+            if let Some(caps) = re.captures(line) {
+                if let Ok(pct) = caps[1].parse::<f32>() {
+                    self.context_pct = Some((pct.clamp(0.0, 100.0), Instant::now()));
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Store a transcript-derived context estimate (the context-alert tick's
+    /// fallback source for backends/panes where the pattern can't be read).
+    pub fn set_context_estimate(&mut self, pct: f32) {
+        self.context_estimate = Some((pct.clamp(0.0, 100.0), Instant::now()));
+    }
+
+    /// Resolved context usage as `(percent, source)`. A fresh pattern reading
+    /// (straight off the agent's own statusline) wins over a fresh transcript
+    /// estimate; readings older than [`CONTEXT_FRESH`] are dropped rather than
+    /// trusted — `None` = honestly unknown.
+    pub fn resolved_context(&self) -> Option<(f32, &'static str)> {
+        if let Some((pct, at)) = self.context_pct {
+            if at.elapsed() < CONTEXT_FRESH {
+                return Some((pct, "pattern"));
+            }
+        }
+        if let Some((pct, at)) = self.context_estimate {
+            if at.elapsed() < CONTEXT_FRESH {
+                return Some((pct, "transcript"));
+            }
+        }
+        None
+    }
+
     /// Feed the current vterm screen text (ANSI already resolved by the
     /// terminal emulator — caller passes plain text rows).
     ///
@@ -1004,6 +1083,7 @@ impl StateTracker {
             // subsequent identical frames.
         } else {
             self.last_screen_hash = Some(hash);
+            self.scan_context_pct(screen_text);
         }
 
         // Sprint 27 shadow-mode: capture silence duration BEFORE updating

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -4447,3 +4447,135 @@ fn prose_with_distant_unrelated_error_indicator_does_not_latch_phase2() {
         "#SRL-phase2 #1857: SRL prose + a DISTANT unrelated error indicator must NOT latch"
     );
 }
+
+// ── Context% telemetry (operator-directed context-usage detection) ──────────
+
+/// Live-capture fixture: the fleet Claude statusline as rendered 2026-06-10
+/// (`pane_snapshot` of a real pane). The percent is fractional.
+const CLAUDE_STATUSLINE_FRAME: &str = "⏺ working on the thing\n\
+     some conversation text\n\
+     ❯\n\
+     ────────────\n\
+       Model: Fable 5 | Ctx Used: 61.0% | ⎇ fix/879-v4-daemon-reorder | (+0,-0)\n\
+       ⏵⏵ bypass permissions on (shift+tab to cycle)";
+
+#[test]
+fn claude_context_pct_extracted_from_statusline() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(CLAUDE_STATUSLINE_FRAME);
+    let (pct, source) = t.resolved_context().expect("statusline percent extracted");
+    assert!((pct - 61.0).abs() < f32::EPSILON);
+    assert_eq!(source, "pattern");
+}
+
+/// A stale frame can leave an OLD statusline copy above the live one (seen in
+/// the live capture) — the LAST matching row must win.
+#[test]
+fn claude_context_pct_duplicate_statusline_last_wins() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(
+        "  Model: Fable 5 | Ctx Used: 55.0% | ⎇ b | (+0,-0)\n\
+         ──⏵⏵─bypass─permissions─on──────\n\
+         ❯\n\
+         ────────────\n\
+           Model: Fable 5 | Ctx Used: 61.0% | ⎇ b | (+0,-0)\n\
+           ⏵⏵ bypass permissions on (shift+tab to cycle)",
+    );
+    let (pct, _) = t.resolved_context().expect("reading present");
+    assert!(
+        (pct - 61.0).abs() < f32::EPSILON,
+        "last (live) statusline wins, got {pct}"
+    );
+}
+
+/// Live-capture fixture: the kiro footer (`Kiro · auto · ◔ 10%`) sits a few
+/// rows above the bottom (input hint + key help below it).
+#[test]
+fn kiro_context_pct_extracted_from_footer() {
+    let mut t = StateTracker::new(Some(&Backend::KiroCli));
+    t.feed(
+        "conversation text above\n\
+         ────────────\n\
+         Kiro · auto · ◔ 10%                    ~/.agend-terminal/workspace/kiro\n\
+         \n\
+          ask a question or describe a task ↵\n\
+         \n\
+                                       /copy to clipboard",
+    );
+    let (pct, source) = t.resolved_context().expect("footer percent extracted");
+    assert!((pct - 10.0).abs() < f32::EPSILON);
+    assert_eq!(source, "pattern");
+}
+
+/// Prose-FP guard: agents routinely DISCUSS context% in conversation text.
+/// A mention ABOVE the bottom status rows must not produce a reading, and a
+/// bare "NN% context" phrase (no statusline form) must not match at all.
+#[test]
+fn context_pct_prose_mention_does_not_match() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(
+        "⏺ 報告:lead 的 pane 顯示 Ctx Used: 95.0% 需要重啟\n\
+         filler line one\n\
+         filler line two\n\
+         filler line three\n\
+         filler line four\n\
+         filler line five\n\
+         filler line six\n\
+         ❯ discussing that we are at 80% context now\n\
+         ────────────\n\
+         (no statusline rendered — narrow pane)",
+    );
+    assert!(
+        t.resolved_context().is_none(),
+        "prose mentions (above the status rows / non-statusline form) must not read"
+    );
+}
+
+/// A pane that stops rendering the statusline (narrow-pane truncation) keeps
+/// the previous reading — "can't read" must not erase what we knew.
+#[test]
+fn context_pct_truncated_statusline_keeps_previous_reading() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(CLAUDE_STATUSLINE_FRAME);
+    t.feed("totally different screen\nwith no statusline at all\n❯");
+    let (pct, _) = t.resolved_context().expect("previous reading retained");
+    assert!((pct - 61.0).abs() < f32::EPSILON);
+}
+
+/// Resolution order: a fresh pattern reading wins over a transcript estimate;
+/// the estimate fills in when no pattern reading exists.
+#[test]
+fn context_resolution_pattern_wins_over_estimate() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.set_context_estimate(42.0);
+    assert_eq!(
+        t.resolved_context().map(|(p, s)| (p as u32, s)),
+        Some((42, "transcript")),
+        "estimate fills in when no pattern reading exists"
+    );
+    t.feed(CLAUDE_STATUSLINE_FRAME);
+    assert_eq!(
+        t.resolved_context().map(|(p, s)| (p as u32, s)),
+        Some((61, "pattern")),
+        "fresh pattern reading wins"
+    );
+}
+
+/// Backends without a context display stay honestly unknown even when the
+/// screen happens to carry a Claude-style statusline string.
+#[test]
+fn context_pct_unknown_for_backends_without_pattern() {
+    for backend in [
+        Backend::Codex,
+        Backend::OpenCode,
+        Backend::Agy,
+        Backend::Shell,
+    ] {
+        let mut t = StateTracker::new(Some(&backend));
+        t.feed("  Model: X | Ctx Used: 61.0% | done\n❯");
+        assert!(
+            t.resolved_context().is_none(),
+            "{backend:?} has no context_pattern → unknown"
+        );
+    }
+}

--- a/src/token_cost.rs
+++ b/src/token_cost.rs
@@ -368,6 +368,143 @@ fn claude_projects_dir() -> Option<PathBuf> {
     std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".claude").join("projects"))
 }
 
+// ── Context% estimate (transcript fallback for the context-alert tick) ─────
+
+/// Context-window size for a Claude model id. The `[1m]` suffix marks a
+/// 1M-token context variant; current-gen Claude models are otherwise 200k.
+/// Unknown models fall back to 200k — the conservative direction for an
+/// early-warning surface (over-estimates usage → alerts early).
+fn context_window_for(model: &str) -> u64 {
+    if model.contains("[1m]") {
+        1_000_000
+    } else {
+        200_000
+    }
+}
+
+/// How recently a transcript must have been written to count as the
+/// instance's LIVE session for the context estimate. Anything older is a
+/// finished/stale session — estimating from it would report a dead context.
+const CONTEXT_ESTIMATE_HORIZON: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Tail bytes read from the newest transcript when estimating — the last
+/// assistant message is always within the final few KB; a full read of a
+/// multi-MB transcript every refresh would be wasted IO.
+const CONTEXT_TAIL_BYTES: u64 = 256 * 1024;
+
+/// Estimate `instance`'s CURRENT context usage percent from its newest Claude
+/// transcript. Uses the LAST assistant message's usage (input + cache reads +
+/// cache writes + output ≈ the context the next turn resumes from) — NOT the
+/// session-cumulative sum, which keeps growing across compacts and would
+/// latch a permanent false alert. Self-corrects after a compact (the next
+/// message's input drops). Claude transcripts only; `None` = no fresh
+/// attributable transcript (honestly unknown).
+pub(crate) fn estimate_context_pct(home: &Path, instance: &str) -> Option<f32> {
+    let projects = claude_projects_dir()?;
+    let roots: Vec<(String, Vec<PathBuf>)> = instance_roots(home)
+        .into_iter()
+        .filter(|(name, _)| name == instance)
+        .collect();
+    estimate_context_pct_in(&projects, &roots)
+}
+
+/// Testable core of [`estimate_context_pct`]: injected projects dir + roots.
+fn estimate_context_pct_in(projects_dir: &Path, roots: &[(String, Vec<PathBuf>)]) -> Option<f32> {
+    if roots.is_empty() {
+        return None;
+    }
+    let now = std::time::SystemTime::now();
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+    let session_dirs = std::fs::read_dir(projects_dir)
+        .into_iter()
+        .flatten()
+        .flatten();
+    for dir in session_dirs {
+        let p = dir.path();
+        if !p.is_dir() {
+            continue;
+        }
+        for f in std::fs::read_dir(&p).into_iter().flatten().flatten() {
+            let fp = f.path();
+            if fp.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let Some(mtime) = std::fs::metadata(&fp).ok().and_then(|m| m.modified().ok()) else {
+                continue;
+            };
+            // Stale session → not the live context. (A future mtime is fresh.)
+            if now
+                .duration_since(mtime)
+                .map(|age| age > CONTEXT_ESTIMATE_HORIZON)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            if newest.as_ref().is_some_and(|(t, _)| *t >= mtime) {
+                continue;
+            }
+            if transcript_attributes_to(&fp, roots) {
+                newest = Some((mtime, fp));
+            }
+        }
+    }
+    let (_, path) = newest?;
+    let tail = read_file_tail(&path, CONTEXT_TAIL_BYTES)?;
+    for line in tail.lines().rev() {
+        if let Some((_, row)) = parse_line(line, roots, None) {
+            let window = context_window_for(&row.model) as f64;
+            let pct = (row.usage.total_tokens() as f64 / window) * 100.0;
+            return Some(pct.clamp(0.0, 100.0) as f32);
+        }
+    }
+    None
+}
+
+/// Cheap attribution probe: does one of the file's first lines carry a `cwd`
+/// belonging to the instance's roots? Reads only the head — full-content
+/// attribution is the estimator's tail read.
+fn transcript_attributes_to(path: &Path, roots: &[(String, Vec<PathBuf>)]) -> bool {
+    use std::io::Read;
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut buf = vec![0u8; 8192];
+    let n = f.read(&mut buf).unwrap_or(0);
+    let head = String::from_utf8_lossy(&buf[..n]);
+    head.lines().take(5).any(|line| {
+        serde_json::from_str::<Value>(line)
+            .ok()
+            .and_then(|v| {
+                v.get("cwd")
+                    .and_then(Value::as_str)
+                    .map(|cwd| attribute(Path::new(cwd), roots).is_some())
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// Last `max_bytes` of a file as lossy UTF-8, with any partial first line
+/// dropped when the read started mid-file.
+fn read_file_tail(path: &Path, max_bytes: u64) -> Option<String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f = std::fs::File::open(path).ok()?;
+    let len = f.metadata().ok()?.len();
+    let start = len.saturating_sub(max_bytes);
+    f.seek(SeekFrom::Start(start)).ok()?;
+    let mut bytes = Vec::new();
+    f.read_to_end(&mut bytes).ok()?;
+    let mut text = String::from_utf8_lossy(&bytes).into_owned();
+    if start > 0 {
+        match text.find('\n') {
+            Some(i) => {
+                text.drain(..=i);
+            }
+            None => return None,
+        }
+    }
+    Some(text)
+}
+
 // ── #1077 Phase 2: Codex collector ─────────────────────────────────────────
 //
 // Source: `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. Each session file
@@ -1658,5 +1795,124 @@ mod tests {
             "no per-task key in default view"
         );
         assert_eq!(pi["input"], json!(10));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod context_estimate_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn usage_line(cwd: &str, id: &str, model: &str, inp: u64, out: u64, cr: u64) -> String {
+        json!({
+            "type": "assistant",
+            "cwd": cwd,
+            "timestamp": "2026-06-10T00:00:00.000Z",
+            "message": {
+                "id": id,
+                "model": model,
+                "usage": {
+                    "input_tokens": inp,
+                    "output_tokens": out,
+                    "cache_read_input_tokens": cr,
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn tmp(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!("agend-ctx-est-{}-{}", std::process::id(), tag));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn roots_for(instance: &str, cwd: &str) -> Vec<(String, Vec<PathBuf>)> {
+        vec![(instance.to_string(), vec![PathBuf::from(cwd)])]
+    }
+
+    /// The estimate uses the LAST assistant message's usage — the
+    /// post-compact context — NOT the session-cumulative sum (which would
+    /// latch a permanent ≥threshold false alert after the first compact).
+    #[test]
+    fn estimate_uses_last_message_not_cumulative() {
+        let projects = tmp("last-msg");
+        let sess = projects.join("-root-ws-dev");
+        std::fs::create_dir_all(&sess).unwrap();
+        // Pre-compact turn at 180k, then a compact dropped the next turn to
+        // 40k+10k+1k = 51k. Cumulative would be ~231k (>100% of 200k).
+        let lines = [
+            usage_line("/root/ws/dev", "m1", "claude-opus-4", 170_000, 2_000, 8_000),
+            usage_line("/root/ws/dev", "m2", "claude-opus-4", 40_000, 1_000, 10_000),
+        ];
+        std::fs::write(sess.join("s.jsonl"), lines.join("\n")).unwrap();
+
+        let pct = estimate_context_pct_in(&projects, &roots_for("dev", "/root/ws/dev"))
+            .expect("estimate produced");
+        // 51k / 200k = 25.5%
+        assert!((pct - 25.5).abs() < 0.1, "last-message estimate, got {pct}");
+    }
+
+    /// A `[1m]` model id resolves against the 1M context window.
+    #[test]
+    fn estimate_respects_1m_context_window() {
+        let projects = tmp("1m-window");
+        let sess = projects.join("-root-ws-dev");
+        std::fs::create_dir_all(&sess).unwrap();
+        let line = usage_line(
+            "/root/ws/dev",
+            "m1",
+            "claude-fable-5[1m]",
+            400_000,
+            10_000,
+            90_000,
+        );
+        std::fs::write(sess.join("s.jsonl"), line).unwrap();
+
+        let pct = estimate_context_pct_in(&projects, &roots_for("dev", "/root/ws/dev"))
+            .expect("estimate produced");
+        // 500k / 1M = 50% (would be clamped 100% under a 200k window)
+        assert!((pct - 50.0).abs() < 0.1, "1M window respected, got {pct}");
+    }
+
+    /// Trailing non-assistant lines (tool events, user turns) are skipped —
+    /// the reversed scan finds the last USAGE-carrying line.
+    #[test]
+    fn estimate_skips_trailing_non_usage_lines() {
+        let projects = tmp("trailing");
+        let sess = projects.join("-root-ws-dev");
+        std::fs::create_dir_all(&sess).unwrap();
+        let lines = [
+            usage_line("/root/ws/dev", "m1", "claude-opus-4", 100_000, 1_000, 0),
+            json!({"type": "user", "cwd": "/root/ws/dev", "message": {"role": "user"}}).to_string(),
+            json!({"type": "system", "subtype": "tool_result"}).to_string(),
+        ];
+        std::fs::write(sess.join("s.jsonl"), lines.join("\n")).unwrap();
+
+        let pct = estimate_context_pct_in(&projects, &roots_for("dev", "/root/ws/dev"))
+            .expect("estimate produced");
+        assert!((pct - 50.5).abs() < 0.1, "101k/200k, got {pct}");
+    }
+
+    /// A transcript belonging to ANOTHER instance's cwd must not attribute —
+    /// honest None instead of a cross-agent reading.
+    #[test]
+    fn estimate_none_when_no_transcript_attributes() {
+        let projects = tmp("foreign");
+        let sess = projects.join("-somewhere-else");
+        std::fs::create_dir_all(&sess).unwrap();
+        let line = usage_line("/somewhere/else", "m1", "claude-opus-4", 150_000, 1_000, 0);
+        std::fs::write(sess.join("s.jsonl"), line).unwrap();
+
+        assert!(
+            estimate_context_pct_in(&projects, &roots_for("dev", "/root/ws/dev")).is_none(),
+            "foreign transcript must not attribute"
+        );
+        assert!(
+            estimate_context_pct_in(&projects, &[]).is_none(),
+            "no roots → None"
+        );
     }
 }


### PR DESCRIPTION
Operator-directed (lead task t-20260610030712174426-9, spike approved): the daemon now knows each agent's context usage early and alerts the team orchestrator at ≥80%. **Detection + notification only — no automated handling.**

## Three honest layers
1. **`context_pattern` per backend** (`BackendProfile`): capture-group regex over the **bottom 6 status rows**, parsed in `StateTracker::feed_with_fg` right after the hash-dedup — screen-change only, zero new tick cost, no IO under the core lock. Patterns are **live-verified against real fleet panes** (2026-06-10 `pane_snapshot`):
   - Claude: `Ctx Used: 61.0%` statusline → `(?i)\bctx\s+used:\s*(\d+(?:\.\d+)?)\s*%` (fractional; the default-install left-form "Context left until auto-compact" has REMAINING semantics — deliberately v1-skipped, TODO'd)
   - kiro: `◔ 10%` footer → `◔\s*(\d+(?:\.\d+)?)\s*%`
   - codex / opencode / agy / shell: `None` (no usable display; codex would require editing the user's global `~/.codex/config.toml`)
   - Scope is deliberately NOT the 15-row error tail: agents routinely **discuss** context% in conversation (prose-FP). Truncated statusline (narrow pane) keeps the previous reading; readings expire after 10min (stale ≠ safe).
2. **Transcript-tail estimate** (Claude fallback): newest attributable transcript's **last** assistant message usage ≈ the context the next turn resumes from. Session-cumulative was evaluated and **rejected** — it grows across compacts and would latch a permanent false alert; the last-message estimate self-corrects after a compact. `[1m]` model ids → 1M window, others 200k. File IO runs in the per-tick handler with **no locks held** — never in the PTY feed path (lead's care item).
3. **Unknown stays unknown**: LIST gains `context_pct` + `context_source` (`pattern` | `transcript`), absent when nothing fresh is known → `list_instances`/TUI/health surfaces it automatically.

## Alerting
New `per_tick/context_alert.rs`, registered in the **shared `build_default_handlers`** (run_core + app mode both get it — #1002 wiring-drift class). Every ~6 ticks: resolve usage → on crossing ≥ threshold (80, `AGEND_CONTEXT_ALERT_PCT` override) notify `orchestrator_for(agent)` (never the agent itself; `FALLBACK_RECIPIENT` otherwise) via `inbox::notify_system`. Hysteresis: fire disarms; re-arm below threshold−5 (no 79↔81 flapping); continuously-high re-alerts every 30min. In-memory latch: a daemon restart re-fires once — accepted per spike review (single, self-limiting).

## Tests (§3.9)
- Live-capture pattern fixtures: claude statusline (incl. duplicate-frame last-wins + fractional), kiro footer
- **Prose-FP guard**: conversation mentions of context% must not read
- Truncation keeps previous reading; per-backend pattern presence pins; resolution order (pattern > transcript > unknown)
- Alert `decide()` state machine: cross/dedup/re-alert window/hysteresis wobble/compact re-arm
- Transcript estimate: **last-message-not-cumulative (compact 回落)**, 1M window, trailing non-usage lines skipped, foreign-cwd → None

Honest limits: the LIST json mapping itself has no dedicated integration test (needs a PTY-backed registry harness that doesn't exist) — it is a two-line map over the unit-tested `resolved_context()`. Codex rollout files only carry session-cumulative totals → codex stays `unknown` until a per-turn source is found.

`cargo fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · bins **3550 passed / 1 failed** — the 1 failure is `dispatch_branch_skips_metadata_stub_but_checks_out_real_source_1834`, a pre-existing **fleet git-shim environmental false-fail** (passes with system git: `PATH=/usr/bin cargo test ...` → ok; CI uses real git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)