### PR TITLE
fix(#1947): exclude input/user-message lines from the error content anchor

### DIFF
--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -44,6 +44,12 @@ pub struct BackendProfile {
     /// only over the bottom status rows — NOT the error tail window — because
     /// agents routinely DISCUSS context% in conversation text (prose-FP).
     pub context_pattern: Option<&'static str>,
+    /// #1947: prompt markers identifying the backend's INPUT line (and echoed /
+    /// submitted user-message lines). An error pattern matched on a line whose
+    /// trimmed start is one of these is operator-typed / quoted text, not CLI
+    /// error output — the content anchor excludes it. Empty = no stable prompt
+    /// prefix (opencode / agy): input-line exclusion honestly unavailable.
+    pub input_line_markers: &'static [&'static str],
 }
 
 /// ClaudeCode context% — matches the fleet statusline's used-form as rendered
@@ -109,6 +115,7 @@ fn agy_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Gemini),
         },
         context_pattern: None,
+        input_line_markers: &[],
         initial_state: AgentState::Starting,
     }
 }
@@ -168,6 +175,7 @@ fn kirocli_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Kiro),
         },
         context_pattern: Some(KIRO_CONTEXT_PATTERN),
+        input_line_markers: &[">"],
         initial_state: AgentState::Starting,
     }
 }
@@ -227,6 +235,7 @@ fn opencode_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::OpenCode),
         },
         context_pattern: None,
+        input_line_markers: &[],
         initial_state: AgentState::Starting,
     }
 }
@@ -279,6 +288,7 @@ fn codex_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Codex),
         },
         context_pattern: None,
+        input_line_markers: &["›"],
         initial_state: AgentState::Starting,
     }
 }
@@ -349,6 +359,7 @@ fn claudecode_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Claude),
         },
         context_pattern: Some(CLAUDE_CONTEXT_PATTERN),
+        input_line_markers: &["❯", ">"],
         initial_state: AgentState::Starting,
     }
 }
@@ -366,6 +377,7 @@ fn empty_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Generic),
         },
         context_pattern: None,
+        input_line_markers: &[],
         initial_state: AgentState::Idle,
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -258,6 +258,11 @@ pub struct StateTracker {
     /// open (pre-#919 behavior: a HIGH_FP pattern match fires the
     /// transition unconditionally).
     anchor_on_red: bool,
+    /// #1947: the backend's input-line prompt markers, cached from
+    /// `BackendProfile::input_line_markers` at construction (legacy/profile-None
+    /// backends → empty = exclusion unavailable). The content anchor uses these
+    /// to reject error patterns matched on operator-typed / quoted input lines.
+    input_line_markers: &'static [&'static str],
     /// #1005 Phase A2: most-recent priority-up transition target +
     /// timestamp. Set on every successful priority-up in `transition()`.
     /// Cleared (set to None) on explicit Idle / lower-priority drops
@@ -387,7 +392,7 @@ fn oscillation_guard_window() -> Duration {
 /// / JSON dumps, so they get the extra FP defenses (the #1518 position gate + the
 /// #1769 working-marker override + an anchor gate). The ANCHOR gate splits by
 /// [`requires_red_anchor`] — RateLimit/ServerRateLimit now use a content anchor
-/// (`in_error_line`), only ContextFull/ModelUnsupported still require red. This
+/// (`in_error_line_excluding_input`), only ContextFull/ModelUnsupported still require red. This
 /// predicate stays the full set because position + working-marker apply to all
 /// four regardless of which anchor regime they use.
 /// Per #919 spike + dev-2 cross-audit:
@@ -414,7 +419,7 @@ fn is_high_fp_state(state: AgentState) -> bool {
 
 /// t-coloranchor-remove-ratelimit (operator-approved after the corpus gate):
 /// which HIGH_FP states still require the #1450 RED-SGR anchor vs the content
-/// anchor (`in_error_line`).
+/// anchor (`in_error_line_excluding_input`).
 ///
 /// - **`true`** — ContextFull, ModelUnsupported: keep RED. ContextFull has no
 ///   fixture corpus to prove a content path; ModelUnsupported never auto-clears
@@ -729,9 +734,20 @@ fn unclassified_throttle_tail(
 fn flattened_throttle_detect(
     patterns: &crate::state::patterns::StatePatterns,
     screen_text: &str,
+    input_line_markers: &[&str],
 ) -> Option<AgentState> {
     let tail = recent_screen_tail(screen_text, ERROR_TAIL_SCAN_LINES);
-    let flat = tail.split_whitespace().collect::<Vec<_>>().join(" ");
+    // #1947: drop input / user-message lines BEFORE flattening — flattening
+    // destroys the line structure the input-line exclusion needs, so an
+    // operator-typed error string would otherwise flatten into a legit-looking
+    // `API Error: <throttle>` adjacency. (A hard-wrapped typed line's
+    // continuation rows lack the marker — same accepted edge as the raw path.)
+    let flat = tail
+        .lines()
+        .filter(|line| !crate::state::patterns::is_input_line(line, input_line_markers))
+        .flat_map(str::split_whitespace)
+        .collect::<Vec<_>>()
+        .join(" ");
     let (state, matched) = patterns.detect_with_match(&flat)?;
     if !matches!(state, AgentState::ServerRateLimit | AgentState::RateLimit) {
         return None;
@@ -751,7 +767,7 @@ const THROTTLE_INDICATOR_PROXIMITY: usize = 80;
 
 /// #SRL-phase2 (reviewer-2 #1857 fix): require an error indicator within
 /// `THROTTLE_INDICATOR_PROXIMITY` chars BEFORE `matched` in the flattened tail —
-/// the `\n`-less replacement for `in_error_line`'s line-scoping. The window spans
+/// the `\n`-less replacement for `in_error_line_excluding_input`'s line-scoping. The window spans
 /// `[match_start - K, match_end]` so an indicator that IS the match
 /// (`API Error: 5xx`) or sits just before it (`API Error: Server is temporarily
 /// limiting …`) passes, while a distant unrelated indicator does not.
@@ -890,6 +906,10 @@ impl StateTracker {
             // KiroCli), false for Shell/Raw — see
             // `Backend::should_anchor_on_red`.
             anchor_on_red: backend.is_some_and(|b| b.should_anchor_on_red()),
+            input_line_markers: backend
+                .and_then(crate::backend_profile::profile)
+                .map(|p| p.input_line_markers)
+                .unwrap_or(&[]),
             // #1005 A2: oscillation guard starts unarmed — first
             // legitimate priority-up records into it; subsequent
             // priority-ups within the window check against it.
@@ -1113,7 +1133,7 @@ impl StateTracker {
                     //   FP would silently disable a healthy agent (cost too high).
                     //
                     // - **content-anchor** {RateLimit, ServerRateLimit}: the marker
-                    //   must sit on an error-line-shaped line (`in_error_line`) —
+                    //   must sit on an error-line-shaped line (`in_error_line_excluding_input`) —
                     //   corpus-proven safe (5/5 prose suppressed via pattern-narrow
                     //   + #1518 position + #1769 working-marker; FN-covered incl.
                     //   kiro `ThrottlingException` via #1789). NO red required, so a
@@ -1124,12 +1144,21 @@ impl StateTracker {
                     //   the live tail with no working-marker below) is ACCEPTED for
                     //   these two: both auto-clear and are retry-driven, so a
                     //   one-off mis-latch self-corrects (unlike ModelUnsupported).
+                    // #1947: the content anchor additionally rejects matches
+                    // sitting on the backend's INPUT line (or an echoed /
+                    // submitted user-message line) — operator-typed / quoted
+                    // error strings are prose, not CLI error output
+                    // (operator-reproduced live FP, 2026-06-10).
                     let anchor_fail = if requires_red_anchor(detected) {
                         self.anchor_on_red
                             && !fg.is_empty()
                             && !matched_span_has_red(screen_text, matched, fg)
                     } else if high_fp {
-                        !crate::state::patterns::in_error_line(screen_text, matched)
+                        !crate::state::patterns::in_error_line_excluding_input(
+                            screen_text,
+                            matched,
+                            self.input_line_markers,
+                        )
                     } else {
                         false
                     };
@@ -1391,7 +1420,9 @@ impl StateTracker {
                     // text, so a hard-wrapped throttle with a working marker
                     // below is not overridden here — accepted; `recovered_within`
                     // still releases a genuinely-recovered pane.)
-                    if let Some(throttle) = flattened_throttle_detect(patterns, screen_text) {
+                    if let Some(throttle) =
+                        flattened_throttle_detect(patterns, screen_text, self.input_line_markers)
+                    {
                         let landed = if matches!(throttle, AgentState::ServerRateLimit)
                             && self.recovered_within(SERVER_RATE_LIMIT_RECOVERY_SILENCE)
                         {

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -31,7 +31,7 @@ pub(crate) const SERVER_RATE_LIMIT_NET_ERRORS: &str = r"ECONNRESET|ETIMEDOUT|Inv
 
 // #1757's `is_net_error_match` red-anchor EXEMPTION was removed by
 // t-coloranchor-remove-ratelimit: ServerRateLimit now uses the general content
-// anchor (`in_error_line`) instead of the red anchor, so the net-error special
+// anchor (`in_error_line_excluding_input`) instead of the red anchor, so the net-error special
 // case (net faults render grey → exempt from red) is subsumed — a grey net-error
 // on an error-line-shaped line latches via content, and a bare prose mention is
 // suppressed by content + #1518 position. The shared const above stays: it is
@@ -77,7 +77,7 @@ pub(crate) const SERVER_RATE_LIMIT_NET_ERRORS: &str = r"ECONNRESET|ETIMEDOUT|Inv
 /// Does `text` contain a recognised error-line indicator (`…Error:`, `429`,
 /// `resource_exhausted`, JSON error shapes, …)? Pure regex check over the WHOLE
 /// `text` — the caller is responsible for scoping `text` (a single line in
-/// [`in_error_line`]; a tight proximity window in the SRL hard-wrap fallback,
+/// [`in_error_line_excluding_input`]; a tight proximity window in the SRL hard-wrap fallback,
 /// where a fully-flattened tail has no `\n` to line-scope on).
 pub(crate) fn line_has_error_indicator(text: &str) -> bool {
     use std::sync::OnceLock;
@@ -91,7 +91,26 @@ pub(crate) fn line_has_error_indicator(text: &str) -> bool {
     re.is_match(text)
 }
 
-pub(crate) fn in_error_line(screen_text: &str, matched: &str) -> bool {
+/// #1947: true when `line` is the backend's INPUT line or an echoed/submitted
+/// user-message line — trimmed, it starts with one of the backend's prompt
+/// markers (claude `❯`, codex `›`, kiro `>`). An error pattern matched on such
+/// a line is operator-typed / quoted text, not CLI error output (real error
+/// blocks render bare at line start across the fixture corpus).
+pub(crate) fn is_input_line(line: &str, input_markers: &[&str]) -> bool {
+    let trimmed = line.trim_start();
+    input_markers.iter().any(|m| trimmed.starts_with(m))
+}
+
+/// #1947: `in_error_line` with input-line exclusion — at least one occurrence
+/// of `matched` must sit on an error-indicator line that is NOT an input /
+/// user-message line. With empty `input_markers` this is exactly the original
+/// content anchor (backends without a stable prompt prefix — opencode / agy —
+/// keep the pre-#1947 behavior, honestly uncovered).
+pub(crate) fn in_error_line_excluding_input(
+    screen_text: &str,
+    matched: &str,
+    input_markers: &[&str],
+) -> bool {
     if matched.is_empty() {
         return false;
     }
@@ -102,7 +121,8 @@ pub(crate) fn in_error_line(screen_text: &str, matched: &str) -> bool {
         let line_end = screen_text[pos..]
             .find('\n')
             .map_or(screen_text.len(), |i| pos + i);
-        if line_has_error_indicator(&screen_text[line_start..line_end]) {
+        let line = &screen_text[line_start..line_end];
+        if line_has_error_indicator(line) && !is_input_line(line, input_markers) {
             return true;
         }
         search = pos + matched.len();

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -3714,7 +3714,7 @@ fn net_error_prose_mention_does_not_latch_1768() {
 /// error fields — while still REJECTING bare prose / source mentions.
 #[test]
 fn in_error_line_matches_corpus_errors_rejects_prose_step1() {
-    use crate::state::patterns::in_error_line;
+    use crate::state::patterns::in_error_line_excluding_input;
 
     // (line, a token on that line) — must read as a real backend error line.
     let real: &[(&str, &str)] = &[
@@ -3758,7 +3758,7 @@ fn in_error_line_matches_corpus_errors_rejects_prose_step1() {
     ];
     for (line, tok) in real {
         assert!(
-            in_error_line(line, tok),
+            in_error_line_excluding_input(line, tok, &[]),
             "must read as an error line: {line:?} (token {tok:?})"
         );
     }
@@ -3790,7 +3790,7 @@ fn in_error_line_matches_corpus_errors_rejects_prose_step1() {
     ];
     for (line, tok) in prose {
         assert!(
-            !in_error_line(line, tok),
+            !in_error_line_excluding_input(line, tok, &[]),
             "prose/source mention must NOT read as an error line: {line:?} (token {tok:?})"
         );
     }
@@ -4578,4 +4578,133 @@ fn context_pct_unknown_for_backends_without_pattern() {
             "{backend:?} has no context_pattern → unknown"
         );
     }
+}
+
+// ── #1947: input-line exclusion — operator-typed / quoted error strings ─────
+
+/// #1947 (operator-reproduced live, 2026-06-10): typing the SRL error string
+/// into the claude input line must NOT latch — the line self-satisfies
+/// `line_has_error_indicator` ("…Error:"), so pre-#1947 the content anchor
+/// passed and a false ServerRateLimit latched (→ spurious AUTO-retry).
+#[test]
+fn typed_srl_quote_on_claude_input_line_does_not_latch_1947() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(
+        "⏺ some earlier assistant output\n\
+         ❯ API Error: Server is temporarily limiting requests (not your usage limit)",
+    );
+    assert_ne!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#1947: operator-typed SRL quote on the ❯ input line must not latch"
+    );
+}
+
+/// #1947: a SUBMITTED user message quoting the error (e.g. a dispatch message
+/// discussing an SRL incident) renders with the same `❯` prefix — excluded.
+#[test]
+fn submitted_dispatch_quote_does_not_latch_1947() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(
+        "❯ 處理這個 issue:API Error: Server is temporarily limiting requests 的 retry storm\n\
+         ⏺ 收到,開始分析",
+    );
+    assert_ne!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#1947: a submitted message quoting the SRL string must not latch"
+    );
+}
+
+/// #1947 FN guard: the REAL claude SRL error block renders BARE at line start
+/// (claude-server-throttle.raw fixture — note: no `⏺` prefix, which is why the
+/// v2 line-start anchor needs the corpus gate). It must still latch with the
+/// input prompt right below it.
+#[test]
+fn real_srl_error_with_prompt_below_still_latches_1947() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(
+        "API Error: Server is temporarily limiting requests (not your usage limit) · check status.claude.com\n\
+         Retrying automatically...\n\
+         ❯ ",
+    );
+    assert_eq!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#1947: the real (bare, line-start) SRL error block must still latch"
+    );
+}
+
+/// #1947 multi-backend: codex echoes submitted input as `› <text>` — a quoted
+/// rate-limit string there must not latch; the real bare error still does
+/// (codex-rate-limit-typical.raw shapes).
+#[test]
+fn codex_input_echo_quote_excluded_real_error_latches_1947() {
+    let mut quoted = StateTracker::new(Some(&Backend::Codex));
+    quoted.feed("OpenAI Codex v0.135.0\n› look into rate_limit_exceeded: Rate limit reached\n› ");
+    assert_ne!(
+        quoted.get_state(),
+        AgentState::RateLimit,
+        "#1947: a quoted rate-limit string on the › input echo must not latch"
+    );
+
+    let mut real = StateTracker::new(Some(&Backend::Codex));
+    real.feed(
+        "› run the migration\n\
+         stream error: rate_limit_exceeded: Rate limit reached for requests. Please try again in 60s.\n\
+         › ",
+    );
+    assert_eq!(
+        real.get_state(),
+        AgentState::RateLimit,
+        "#1947: the real bare codex rate-limit error must still latch"
+    );
+}
+
+/// #1947 multi-backend: kiro's input prompt is `> ` — a typed quote there must
+/// not latch; the real bare `ThrottlingException:` still does
+/// (kiro-rate-limit-typical.raw shapes).
+#[test]
+fn kiro_typed_quote_excluded_real_error_latches_1947() {
+    let mut quoted = StateTracker::new(Some(&Backend::KiroCli));
+    quoted.feed("conversation above\n> debugging ThrottlingException: Rate exceeded handling");
+    assert_ne!(
+        quoted.get_state(),
+        AgentState::RateLimit,
+        "#1947: a typed throttle quote on the kiro > input line must not latch"
+    );
+
+    let mut real = StateTracker::new(Some(&Backend::KiroCli));
+    real.feed(
+        "ThrottlingException: Rate exceeded for this AWS account\n\
+         Waiting before retry...\n\
+         > ",
+    );
+    assert_eq!(
+        real.get_state(),
+        AgentState::RateLimit,
+        "#1947: the real bare kiro throttle error must still latch"
+    );
+}
+
+/// #1947: the hard-wrap flatten fallback drops input/user-message lines BEFORE
+/// flattening — a typed SRL quote can't flatten into a legit-looking
+/// `API Error: <throttle>` adjacency; a genuine bare hard-wrap still detects.
+#[test]
+fn flatten_fallback_excludes_input_lines_1947() {
+    let patterns = StatePatterns::for_backend(&Backend::ClaudeCode);
+    let typed = "❯ API Error: Server is temporarily\n❯ limiting requests (not your usage limit)";
+    assert_eq!(
+        flattened_throttle_detect(patterns, typed, &["❯", ">"]),
+        None,
+        "#1947: input-marked lines are dropped before flattening"
+    );
+    // The same content WITHOUT the input markers (a real hard-wrapped error)
+    // still detects through the flatten fallback.
+    let real = "API Error: Server is temporarily\nlimiting requests (not your usage limit)";
+    assert_eq!(
+        flattened_throttle_detect(patterns, real, &["❯", ">"]),
+        Some(AgentState::ServerRateLimit),
+        "#1947: a genuine bare hard-wrapped SRL still detects"
+    );
 }


### PR DESCRIPTION
Second PR of the #1946/#1947 pair (lead task t-20260610041002260921-1, spike approved). Operator-reproduced live FP: typing the SRL error string into the input line latched a false ServerRateLimit — the quoted line self-satisfies `line_has_error_indicator` ("…Error:"), and the position/working-marker gates pass at an idle prompt. The corpus-gate era "verbatim-quote FP self-corrects" assumption no longer holds post-#1946: an FP now starts a persistent recovery-ownership track.

## Fix (v1, structural)
A HIGH_FP content-anchor match whose line is the backend's **input line** (or an echoed/submitted **user-message line**) is excluded. Markers fixture/live-verified per backend:
- **claude `❯`** — both the live input line AND submitted user messages render `❯`-prefixed (live pane capture), so one rule kills the operator-typed FP **and** the dispatch-quote FP; `>` additionally covers markdown blockquotes (quoted text either way)
- **codex `›`** — echoed submitted input; real errors render bare at line start (`codex-rate-limit-typical.raw`)
- **kiro `>`** — its input prompt; real `ThrottlingException` lines bare (`kiro-rate-limit-typical.raw`)
- **opencode / agy** — no stable input prefix → **honestly uncovered in v1** (empty markers = exactly the pre-#1947 anchor)

The hard-wrap flatten fallback (#1851/#1857) drops marker lines **before** flattening — flattening destroys the line structure the exclusion needs. Known accepted edge: a multi-line typed input's continuation rows lack the marker.

**v2 (line-start anchoring) stays corpus-gated as approved** — `claude-server-throttle.raw` proves the real SRL error renders WITHOUT a `⏺` bullet prefix, so a naive line-start anchor would false-negative.

## Mechanics
`BackendProfile.input_line_markers` (same shape as #1945's `context_pattern`), cached on `StateTracker` like `anchor_on_red`; `in_error_line` → `in_error_line_excluding_input(…, markers)` (empty-markers = identical semantics; unused wrapper removed, single caller migrated).

## Tests (§3.9)
- typed SRL quote on claude `❯` → no latch · submitted dispatch quote → no latch
- **FN guards**: real bare SRL block with the prompt below → still latches (fixture shape); codex real `stream error:` → latches while the `›` echo quote doesn't; kiro real `ThrottlingException:` → latches while the `>` quote doesn't
- flatten fallback drops marker lines, still detects a genuine bare hard-wrap
- full corpus / replay suite green — zero FN regression

`cargo fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · bins **3560 passed / 1 failed** (the known pre-existing git-shim environmental false-fail `dispatch_branch_..._1834`; passes with system git).

Team note (until deployed): keep paraphrasing error strings in dispatch messages.

Closes #1947. Refs #1946, #1768, #1857.

🤖 Generated with [Claude Code](https://claude.com/claude-code)