### PR TITLE
fix(#1945): disable the transcript context-estimate — pattern-only resolution

### DIFF
--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -3,15 +3,15 @@
 //! alert goes to the agent's team orchestrator (and the usage is visible via
 //! LIST `context_pct`/`context_source`); nothing is auto-restarted.
 //!
-//! Source resolution per agent (see `StateTracker::resolved_context`):
-//! 1. `pattern` — the agent's own statusline percent, parsed by the PTY
-//!    feed (cheap, in-band). Preferred when fresh.
-//! 2. `transcript` — for Claude agents whose pattern can't be read (narrow
-//!    pane truncation / no statusline), this handler computes the estimate
-//!    from the newest transcript's LAST message usage. That file IO runs
-//!    HERE — on the tick, with no registry/core lock held — never in the
-//!    PTY reader's feed path.
-//! 3. otherwise unknown — no alert, honest `null` in LIST.
+//! Source per agent (see `StateTracker::resolved_context`): the statusline
+//! `pattern` ONLY — a pane whose statusline can't be read is honestly
+//! `unknown` (no alert, `null` in LIST).
+//!
+//! #1945-disable (operator decision, 2026-06-10): the transcript-estimate
+//! fallback is DISABLED — its first live minute fired a triple false 100%
+//! alert (window misjudge). The corrected estimator survives, tested but
+//! uncalled, in `token_cost::estimate_context_pct`; re-enable ONLY after
+//! validating its readings against statusline ground truth.
 //!
 //! Dedup/hysteresis: an alert fires on crossing `>= threshold` while armed;
 //! firing disarms; re-arming requires dropping below `threshold -
@@ -111,36 +111,20 @@ impl PerTickHandler for ContextAlertHandler {
             return;
         }
 
-        // Phase 1 (cheap, locks only): snapshot resolved context per agent;
-        // collect the Claude agents that need a transcript-estimate refresh.
+        // Phase 1 (cheap, locks only): snapshot each agent's resolved context
+        // — statusline pattern only (#1945-disable: no transcript estimate;
+        // an unreadable pane is unknown and never alerts).
         let mut resolved: Vec<(String, f32, &'static str)> = Vec::new();
-        let mut need_estimate = Vec::new();
         {
             let reg = crate::agent::lock_registry(ctx.registry);
             for handle in reg.values() {
-                let name = handle.name.as_str().to_string();
-                match handle.core.lock().state.resolved_context() {
-                    Some((pct, source)) => resolved.push((name, pct, source)),
-                    // The estimator reads Claude transcripts — only Claude
-                    // agents can produce one; everything else stays unknown.
-                    None if handle.backend_command.contains("claude") => {
-                        need_estimate.push((name, std::sync::Arc::clone(&handle.core)));
-                    }
-                    None => {}
+                if let Some((pct, source)) = handle.core.lock().state.resolved_context() {
+                    resolved.push((handle.name.as_str().to_string(), pct, source));
                 }
             }
         }
 
-        // Phase 2 (file IO, NO locks held during the read): refresh estimates,
-        // then store back under a short core lock so LIST surfaces them.
-        for (name, core) in need_estimate {
-            if let Some(pct) = crate::token_cost::estimate_context_pct(ctx.home, &name) {
-                core.lock().state.set_context_estimate(pct);
-                resolved.push((name, pct, "transcript"));
-            }
-        }
-
-        // Phase 3: threshold/hysteresis evaluation + orchestrator notify.
+        // Phase 2: threshold/hysteresis evaluation + orchestrator notify.
         let threshold = alert_threshold();
         let now = Instant::now();
         let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -221,10 +221,6 @@ pub struct StateTracker {
     /// truncate the statusline mid-session; the timestamp lets consumers
     /// judge staleness instead of treating "can't read" as "safe".
     context_pct: Option<(f32, Instant)>,
-    /// Transcript-derived context estimate + its compute instant. Written by
-    /// the daemon's context-alert tick (file IO stays OFF this struct's hot
-    /// path — the PTY reader feeds under the core lock).
-    context_estimate: Option<(f32, Instant)>,
     /// Set to true the moment we enter `InteractivePrompt`; cleared by
     /// `take_interactive_prompt_notice()` once the supervisor has forwarded a
     /// Telegram notice. This deduplicates per-entry: re-entry (e.g. dismissed
@@ -893,7 +889,6 @@ impl StateTracker {
                 .and_then(|p| p.context_pattern)
                 .and_then(|p| regex::Regex::new(p).ok()),
             context_pct: None,
-            context_estimate: None,
             interactive_prompt_pending_notice: false,
             interactive_recovery_pending_notice: false,
             last_heartbeat: None,
@@ -1008,25 +1003,21 @@ impl StateTracker {
         }
     }
 
-    /// Store a transcript-derived context estimate (the context-alert tick's
-    /// fallback source for backends/panes where the pattern can't be read).
-    pub fn set_context_estimate(&mut self, pct: f32) {
-        self.context_estimate = Some((pct.clamp(0.0, 100.0), Instant::now()));
-    }
-
-    /// Resolved context usage as `(percent, source)`. A fresh pattern reading
-    /// (straight off the agent's own statusline) wins over a fresh transcript
-    /// estimate; readings older than [`CONTEXT_FRESH`] are dropped rather than
-    /// trusted — `None` = honestly unknown.
+    /// Resolved context usage as `(percent, source)` — PATTERN ONLY (the
+    /// agent's own statusline). Readings older than [`CONTEXT_FRESH`] are
+    /// dropped rather than trusted — `None` = honestly unknown, no alert.
+    ///
+    /// #1945-disable (operator decision, 2026-06-10): the transcript-estimate
+    /// fallback ("transcript" source) is DISABLED — its first live minute
+    /// produced a triple false 100% alert (window misjudge: transcript model
+    /// ids carry no `[1m]` suffix → 1M sessions resolved against 200k). The
+    /// corrected estimator + its root-cause record live on in
+    /// `token_cost::estimate_context_pct` (tested, uncalled); re-enable ONLY
+    /// after validating its readings against statusline ground truth.
     pub fn resolved_context(&self) -> Option<(f32, &'static str)> {
         if let Some((pct, at)) = self.context_pct {
             if at.elapsed() < CONTEXT_FRESH {
                 return Some((pct, "pattern"));
-            }
-        }
-        if let Some((pct, at)) = self.context_estimate {
-            if at.elapsed() < CONTEXT_FRESH {
-                return Some((pct, "transcript"));
             }
         }
         None

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -4542,22 +4542,24 @@ fn context_pct_truncated_statusline_keeps_previous_reading() {
     assert!((pct - 61.0).abs() < f32::EPSILON);
 }
 
-/// Resolution order: a fresh pattern reading wins over a transcript estimate;
-/// the estimate fills in when no pattern reading exists.
+/// #1945-disable: context resolution is PATTERN ONLY — the transcript
+/// estimate is disabled (its first live minute fired a triple false 100%
+/// alert), so an unreadable statusline is honestly unknown (no alert) and a
+/// readable one reports source "pattern". The estimate plumbing
+/// (`set_context_estimate` / the "transcript" source) is REMOVED from the
+/// tracker — this test pins that the disabled path stays disabled.
 #[test]
-fn context_resolution_pattern_wins_over_estimate() {
+fn context_resolution_is_pattern_only_estimate_disabled_1945() {
     let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
-    t.set_context_estimate(42.0);
-    assert_eq!(
-        t.resolved_context().map(|(p, s)| (p as u32, s)),
-        Some((42, "transcript")),
-        "estimate fills in when no pattern reading exists"
+    assert!(
+        t.resolved_context().is_none(),
+        "#1945: no pattern reading → honestly unknown (never an estimate)"
     );
     t.feed(CLAUDE_STATUSLINE_FRAME);
     assert_eq!(
         t.resolved_context().map(|(p, s)| (p as u32, s)),
         Some((61, "pattern")),
-        "fresh pattern reading wins"
+        "pattern reading reports with source \"pattern\""
     );
 }
 

--- a/src/token_cost.rs
+++ b/src/token_cost.rs
@@ -370,12 +370,18 @@ fn claude_projects_dir() -> Option<PathBuf> {
 
 // ── Context% estimate (transcript fallback for the context-alert tick) ─────
 
-/// Context-window size for a Claude model id. The `[1m]` suffix marks a
-/// 1M-token context variant; current-gen Claude models are otherwise 200k.
-/// Unknown models fall back to 200k — the conservative direction for an
-/// early-warning surface (over-estimates usage → alerts early).
+/// Context-window size for a Claude model id AS IT APPEARS IN TRANSCRIPTS.
+/// ⚠ The CLI's `[1m]` display suffix NEVER reaches the transcript — the live
+/// `message.model` field reads plain `claude-fable-5` (verified against this
+/// fleet's own transcripts, 2026-06-10) — so matching `[1m]` alone made every
+/// fable session resolve to 200k and report 100% (the #1945 live false-alert
+/// triple). Fable runs on the 1M window in this fleet; `[1m]` is kept for
+/// robustness should an id ever carry it. Honest limitation: a plain-200k
+/// fable variant would be indistinguishable here and under-estimate — the
+/// statusline pattern path stays the primary source; the >110% misjudge guard
+/// in the estimator catches the inverse error class.
 fn context_window_for(model: &str) -> u64 {
-    if model.contains("[1m]") {
+    if model.contains("[1m]") || model.contains("fable") {
         1_000_000
     } else {
         200_000
@@ -399,6 +405,17 @@ const CONTEXT_TAIL_BYTES: u64 = 256 * 1024;
 /// latch a permanent false alert. Self-corrects after a compact (the next
 /// message's input drops). Claude transcripts only; `None` = no fresh
 /// attributable transcript (honestly unknown).
+///
+/// ⚠ #1945-disable — DEFERRED, deliberately uncalled (operator decision,
+/// 2026-06-10; NOT a ghost — same annotation pattern as the #649 trio): the
+/// first live minute fired a triple false 100% alert. Root cause (recorded
+/// for re-enable): the transcript `message.model` is plain `claude-fable-5` —
+/// the CLI's `[1m]` suffix never reaches it — so the window resolved to 200k
+/// for 1M sessions (~456k/200k → 228% → clamped to a credible 100). The
+/// window map + the >110% misjudge guard below are FIXED and test-pinned;
+/// re-enable ONLY after validating estimates against statusline ground truth
+/// (compare `context_pct` pattern readings on wide panes).
+#[allow(dead_code)]
 pub(crate) fn estimate_context_pct(home: &Path, instance: &str) -> Option<f32> {
     let projects = claude_projects_dir()?;
     let roots: Vec<(String, Vec<PathBuf>)> = instance_roots(home)
@@ -452,8 +469,28 @@ fn estimate_context_pct_in(projects_dir: &Path, roots: &[(String, Vec<PathBuf>)]
     let tail = read_file_tail(&path, CONTEXT_TAIL_BYTES)?;
     for line in tail.lines().rev() {
         if let Some((_, row)) = parse_line(line, roots, None) {
+            // CLI-generated placeholder rows (`<synthetic>`) and zero-usage
+            // rows carry no real context information — keep scanning.
+            if row.model == "<synthetic>" || row.usage.total_tokens() == 0 {
+                continue;
+            }
             let window = context_window_for(&row.model) as f64;
             let pct = (row.usage.total_tokens() as f64 / window) * 100.0;
+            // A context can't exceed its window — a reading past the small
+            // rounding margin means the WINDOW was misjudged (the #1945
+            // false-alert triple: 1M sessions resolved against 200k → 350%
+            // clamped to a credible-looking 100%). Don't launder that into a
+            // trusted number: log and report honestly-unknown instead.
+            if pct > 110.0 {
+                tracing::warn!(
+                    model = %row.model,
+                    tokens = row.usage.total_tokens(),
+                    assumed_window = window as u64,
+                    pct = pct as u32,
+                    "context estimate exceeds the assumed window — window misjudged, reporting unknown"
+                );
+                return None;
+            }
             return Some(pct.clamp(0.0, 100.0) as f32);
         }
     }
@@ -1894,6 +1931,90 @@ mod context_estimate_tests {
         let pct = estimate_context_pct_in(&projects, &roots_for("dev", "/root/ws/dev"))
             .expect("estimate produced");
         assert!((pct - 50.5).abs() < 0.1, "101k/200k, got {pct}");
+    }
+
+    /// #1945 live false-alert regression (dev/dev-2/reviewer-2 triple): the
+    /// transcript model id is plain `claude-fable-5` — the CLI's `[1m]` display
+    /// suffix never reaches the transcript — so the window must resolve to 1M.
+    /// Live-shape usage (~456k) must read ~46%, NOT 200k-window 228%→clamp 100.
+    #[test]
+    fn estimate_fable_transcript_id_resolves_1m_window_1945() {
+        let projects = tmp("fable-window");
+        let sess = projects.join("-root-ws-dev");
+        std::fs::create_dir_all(&sess).unwrap();
+        // Live-verified shape: model "claude-fable-5", cache_creation-dominated
+        // usage (the real sample read input=131, cache_creation≈440k,
+        // cache_read≈16k, output=37).
+        let line = usage_line("/root/ws/dev", "m1", "claude-fable-5", 131, 37, 16_367).replace(
+            "\"cache_read_input_tokens\":16367",
+            "\"cache_read_input_tokens\":16367,\"cache_creation_input_tokens\":439779",
+        );
+        std::fs::write(sess.join("s.jsonl"), line).unwrap();
+
+        let pct = estimate_context_pct_in(&projects, &roots_for("dev", "/root/ws/dev"))
+            .expect("estimate produced");
+        assert!(
+            (40.0..60.0).contains(&pct),
+            "#1945: fable resolves the 1M window → ~46%, got {pct}"
+        );
+    }
+
+    /// #1945: an estimate past the misjudge margin (>110%) is a window-error
+    /// signal — report honestly-unknown (None), never a credible-looking 100.
+    #[test]
+    fn estimate_over_window_reports_unknown_not_100_1945() {
+        let projects = tmp("over-window");
+        let sess = projects.join("-root-ws-dev");
+        std::fs::create_dir_all(&sess).unwrap();
+        // 700k against a 200k-window model id = 350% — the exact pre-fix shape.
+        let line = usage_line("/root/ws/dev", "m1", "claude-opus-4", 690_000, 5_000, 5_000);
+        std::fs::write(sess.join("s.jsonl"), line).unwrap();
+
+        assert!(
+            estimate_context_pct_in(&projects, &roots_for("dev", "/root/ws/dev")).is_none(),
+            "#1945: window-misjudged estimate must be unknown, not clamped 100"
+        );
+    }
+
+    /// #1945: the 100-110% rounding edge still clamps to 100 (a genuinely-full
+    /// context slightly over the nominal window is real, not a misjudge).
+    #[test]
+    fn estimate_rounding_edge_clamps_to_100_1945() {
+        let projects = tmp("edge-clamp");
+        let sess = projects.join("-root-ws-dev");
+        std::fs::create_dir_all(&sess).unwrap();
+        // 205k / 200k = 102.5% — within the margin.
+        let line = usage_line("/root/ws/dev", "m1", "claude-opus-4", 200_000, 2_500, 2_500);
+        std::fs::write(sess.join("s.jsonl"), line).unwrap();
+
+        let pct = estimate_context_pct_in(&projects, &roots_for("dev", "/root/ws/dev"))
+            .expect("edge estimate produced");
+        assert!(
+            (pct - 100.0).abs() < f32::EPSILON,
+            "clamped to 100, got {pct}"
+        );
+    }
+
+    /// #1945: trailing `<synthetic>` / zero-usage rows (CLI placeholders) are
+    /// skipped — the estimate comes from the last REAL usage row.
+    #[test]
+    fn estimate_skips_synthetic_and_zero_usage_rows_1945() {
+        let projects = tmp("synthetic");
+        let sess = projects.join("-root-ws-dev");
+        std::fs::create_dir_all(&sess).unwrap();
+        let lines = [
+            usage_line("/root/ws/dev", "m1", "claude-opus-4", 100_000, 1_000, 0),
+            usage_line("/root/ws/dev", "m2", "<synthetic>", 1, 1, 0),
+            usage_line("/root/ws/dev", "m3", "claude-opus-4", 0, 0, 0),
+        ];
+        std::fs::write(sess.join("s.jsonl"), lines.join("\n")).unwrap();
+
+        let pct = estimate_context_pct_in(&projects, &roots_for("dev", "/root/ws/dev"))
+            .expect("estimate produced");
+        assert!(
+            (pct - 50.5).abs() < 0.1,
+            "real row wins (101k/200k), got {pct}"
+        );
     }
 
     /// A transcript belonging to ANOTHER instance's cwd must not attribute —


### PR DESCRIPTION
Operator decision (lead task t-20260610054104852923-0, scope updated mid-flight): #1945's first live minute fired a **triple false 100% alert** (dev/dev-2/reviewer-2 simultaneously, `source: transcript`, while the lead statusline ground truth read 71%). The estimate fallback is **disabled until validated for accuracy** — an unreadable statusline is now honestly `unknown` and never alerts. This stops the 30min re-alert nag immediately on deploy.

## Root cause (lead's hypothesis confirmed against live transcripts, recorded for re-enable)
The transcript `message.model` field is plain **`claude-fable-5`** — the CLI's `[1m]` display suffix NEVER reaches the transcript (verified: `tail` of this fleet's own jsonl; live usage sample ~456k = cache_creation 439,779 + cache_read 16,367 + io). The window matcher (`contains("[1m]")`) therefore resolved every 1M session against 200k → ~350% → clamped to a credible-looking 100% on every narrow pane at once.

## Changes
- **`StateTracker`**: `resolved_context` is **pattern only**; the estimate field/setter/`"transcript"` source are removed. Unreadable pane → `None` → no alert.
- **`context_alert` tick**: estimate phase removed; the handler only reads pattern-resolved values.
- **`token_cost::estimate_context_pct`**: retained, tested, deliberately uncalled — annotated **DEFERRED (not ghost; #649-trio pattern)** with the re-enable condition: *validate estimates against statusline ground truth on wide panes first*. While parked, the estimator itself is corrected and test-pinned:
  - fable → 1M window (transcript model ids carry no `[1m]`)
  - **>110% reading = window-misjudge signal → WARN + honest `None`** (never laundered into a trusted 100)
  - 100–110% rounding edge still clamps to 100
  - `<synthetic>` / zero-usage placeholder rows skipped

## Tests (§3.9)
- live-shape fable transcript (plain model id, cache-heavy 456k usage) reads **~46%, not 100** — the exact false-alert regression
- over-window (700k vs 200k id) → **unknown, not 100** · rounding edge clamps · synthetic rows skipped
- resolution pin rewritten to pattern-only: no pattern → unknown (no alert source exists); pattern → `"pattern"` — pins the disabled path stays disabled (the estimate plumbing no longer compiles into the tracker)
- pattern-path tests (statusline extraction, prose-FP, alert state machine) unchanged and green

`cargo fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · bins **3564 passed / 1 failed** (the known pre-existing git-shim environmental `dispatch_branch_..._1834`; passes with system git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)