### PR TITLE
fix(#1948 v2): kiro placeholder coverage + drop the non-functional codex marker

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1311,15 +1311,15 @@ where
     // (fail toward draft-protection — never risk clobbering a real draft).
     let raw_state = notification_queue::draft_state(home, &pane.agent_name);
     let buffer_empty = if raw_state == notification_queue::DraftState::Drafting {
-        pane.backend
-            .as_ref()
-            .and_then(|b| b.input_prompt_marker())
-            .and_then(|marker| {
-                notification_queue::input_box_is_empty(
-                    &pane.vterm.tail_lines(DRAFT_INPUT_TAIL_ROWS),
-                    marker,
-                )
-            })
+        pane.backend.as_ref().and_then(|b| {
+            // #1948 v2: marker probe (claude/codex/agy) → placeholder probe (kiro)
+            // → None fallback. pane.vterm is owned (no lock).
+            notification_queue::input_box_empty_probe(
+                &pane.vterm.tail_lines(DRAFT_INPUT_TAIL_ROWS),
+                b.input_prompt_marker(),
+                b.input_empty_placeholder(),
+            )
+        })
     } else {
         None
     };
@@ -1764,12 +1764,13 @@ mod tests {
 
     // ── #1944: buffer-aware draft gate (the operator-facing fix) ──
 
-    /// Build a pane whose live `vterm` renders `screen` (small term so the
-    /// content is within the bottom `DRAFT_INPUT_TAIL_ROWS`) with `backend`.
+    /// Build a pane whose live `vterm` renders `screen` with `backend`. The term
+    /// is `VTerm::new(cols, rows)` — wide enough that input lines don't wrap, and
+    /// few enough rows that the content stays within `DRAFT_INPUT_TAIL_ROWS`.
     fn pane_with_screen(name: &str, backend: Option<Backend>, screen: &str) -> Pane {
         let mut p = pane(name);
         p.backend = backend;
-        p.vterm = crate::vterm::VTerm::new(3, 40);
+        p.vterm = crate::vterm::VTerm::new(80, 6);
         p.vterm.process(screen.as_bytes());
         p
     }
@@ -1862,6 +1863,54 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// #1948 v2 §3.9: kiro has no prompt marker but its empty box shows a
+    /// placeholder — a cleared kiro pane (placeholder visible) must DELIVER.
+    #[test]
+    fn draft_gate_delivers_for_kiro_when_placeholder_visible() {
+        let home = tmp_home("draftgate-kiro-empty");
+        seed_drafting_with_queued(&home, "lead");
+        // cleared kiro box: the real placeholder is visible (no typed content).
+        let mut p = pane_with_screen(
+            "lead",
+            Some(Backend::KiroCli),
+            "Kiro auto\n\n ask a question or describe a task ↵\n /copy",
+        );
+        p.pending_notification_count = notification_queue::pending_count(&home, "lead");
+
+        let mut injected: Vec<String> = Vec::new();
+        flush_notifications_for_pane(&home, &mut p, |t| {
+            injected.push(t.to_string());
+            Ok(())
+        });
+        assert_eq!(
+            injected.len(),
+            1,
+            "kiro cleared (placeholder visible) → stale draft delivered, not held"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1948 v2 §3.9: a kiro pane with a real draft (placeholder replaced by typed
+    /// text) must still DEFER — protection unchanged.
+    #[test]
+    fn draft_gate_defers_for_kiro_when_typed() {
+        let home = tmp_home("draftgate-kiro-typed");
+        seed_drafting_with_queued(&home, "lead");
+        let mut p = pane_with_screen("lead", Some(Backend::KiroCli), "Kiro auto\n\n half typed\n");
+        p.pending_notification_count = notification_queue::pending_count(&home, "lead");
+
+        let mut injected: Vec<String> = Vec::new();
+        flush_notifications_for_pane(&home, &mut p, |t| {
+            injected.push(t.to_string());
+            Ok(())
+        });
+        assert!(
+            injected.is_empty(),
+            "kiro with text (placeholder gone) → keep deferring (protection unchanged)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     #[test]
     fn input_prompt_marker_only_for_verified_backends() {
         assert_eq!(Backend::ClaudeCode.input_prompt_marker(), Some("❯"));
@@ -1869,6 +1918,15 @@ mod tests {
         assert_eq!(Backend::Agy.input_prompt_marker(), Some(">"));
         assert_eq!(Backend::Shell.input_prompt_marker(), None);
         assert_eq!(Backend::OpenCode.input_prompt_marker(), None);
+        // #1948 v2: kiro covered via placeholder, NOT a marker; opencode stays
+        // fully fallback (no marker, no placeholder).
+        assert_eq!(Backend::KiroCli.input_prompt_marker(), None);
+        assert_eq!(
+            Backend::KiroCli.input_empty_placeholder(),
+            Some("ask a question or describe a task")
+        );
+        assert_eq!(Backend::OpenCode.input_empty_placeholder(), None);
+        assert_eq!(Backend::ClaudeCode.input_empty_placeholder(), None);
     }
 
     /// app-mode subscriber-wiring source pin. Owned `agend-terminal app` mode

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1914,8 +1914,13 @@ mod tests {
     #[test]
     fn input_prompt_marker_only_for_verified_backends() {
         assert_eq!(Backend::ClaudeCode.input_prompt_marker(), Some("❯"));
-        assert_eq!(Backend::Codex.input_prompt_marker(), Some("›"));
         assert_eq!(Backend::Agy.input_prompt_marker(), Some(">"));
+        // #1948 codex follow-up: codex is NOT marker-covered — its empty box shows
+        // a rotating ghost phrase after `›`, which the marker probe would mis-read
+        // as typed content. It falls back to the timestamp behavior until a
+        // colour/dim empty-box signal lands.
+        assert_eq!(Backend::Codex.input_prompt_marker(), None);
+        assert_eq!(Backend::Codex.input_empty_placeholder(), None);
         assert_eq!(Backend::Shell.input_prompt_marker(), None);
         assert_eq!(Backend::OpenCode.input_prompt_marker(), None);
         // #1948 v2: kiro covered via placeholder, NOT a marker; opencode stays

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -146,6 +146,27 @@ impl Backend {
         }
     }
 
+    /// #1948 v2: the empty-input-box PLACEHOLDER for backends with no stable
+    /// prompt-line marker but a hint string that the TUI shows ONLY while the box
+    /// is empty (and replaces the moment the operator types). The draft-gate
+    /// treats "placeholder visible" as "box empty". `None` = no placeholder probe
+    /// (falls back to `input_prompt_marker`, then the timestamp behavior — fail
+    /// toward draft-protection).
+    ///
+    /// kiro renders ` ask a question or describe a task ↵` when empty (verified
+    /// against a live `pane_snapshot` of a just-cleared kiro pane, 2026-06-10).
+    /// opencode was assessed and INTENTIONALLY left `None`: its `┃`-bordered box
+    /// has no placeholder, and its `┃`-prefixed model/path footer is always
+    /// non-empty, so input-vs-footer geometry can't be distinguished robustly
+    /// (version-coupled) — fail-toward-protection fallback is safer. If a future
+    /// opencode build adds a stable empty-box placeholder, add it here.
+    pub fn input_empty_placeholder(&self) -> Option<&'static str> {
+        match self {
+            Backend::KiroCli => Some("ask a question or describe a task"),
+            _ => None,
+        }
+    }
+
     /// Actual command path to spawn. For [`Backend::Shell`] resolves to
     /// `$SHELL` (falling back to the platform default — `/bin/bash` on Unix,
     /// `cmd.exe` on Windows). For [`Backend::Raw`] returns the literal stored

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -133,14 +133,21 @@ impl Backend {
     /// timestamp-only `draft_state` heuristic, which can read a stale
     /// type-then-clear as a live draft). `None` = no detectable prompt widget →
     /// the caller falls back to the timestamp behavior (fail toward
-    /// draft-protection). Only set for backends whose marker is verified against a
-    /// real capture (`tests/fixtures/state-replay`): claude `❯`, codex `›`, agy
-    /// `>`. kiro/opencode/gemini markers are unverified (left `None`); shell/raw
-    /// have no prompt widget.
+    /// draft-protection). Set only for backends whose EMPTY-box render is a clean
+    /// `<marker> ` with nothing after it, verified against a real capture:
+    /// claude `❯` and agy `>` (live `pane_snapshot`, `tests/fixtures/state-replay`).
+    ///
+    /// codex is INTENTIONALLY excluded (#1948 follow-up): its empty box renders a
+    /// rotating GHOST/placeholder phrase after the `›` (`› Explain this codebase`,
+    /// `› Write tests for @filename`, …), so the marker probe reads the ghost as
+    /// typed content → always defers (the v1 `Some("›")` claim was non-functional:
+    /// fail-protect-safe but never delivered on an empty box). codex therefore
+    /// falls back to the timestamp behavior until a colour/dim-based empty-box
+    /// signal lands (the ghost is dim — see the #1948 codex spike). Operator live
+    /// test (codex-44cea9, 2026-06-10) surfaced this.
     pub fn input_prompt_marker(&self) -> Option<&'static str> {
         match self {
             Backend::ClaudeCode => Some("❯"),
-            Backend::Codex => Some("›"),
             Backend::Agy => Some(">"),
             _ => None,
         }

--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -173,6 +173,38 @@ pub fn input_box_is_empty(tail: &str, marker: &str) -> Option<bool> {
     Some(after_marker.trim().is_empty())
 }
 
+/// #1948 v2: unified per-backend empty-input-box probe. Tries the prompt-line
+/// `marker` first (claude/codex/agy — content after the marker == non-empty);
+/// if that can't decide (no prompt line found / no marker) AND a `placeholder`
+/// is supplied (kiro), treats the placeholder being VISIBLE in the tail as the
+/// box being empty (the TUI shows it only while empty). Returns:
+/// - `Some(true)` — box verifiably empty (deliver),
+/// - `Some(false)` — box has content (protect),
+/// - `None` — undeterminable → caller FAILS TOWARD PROTECTION (keep deferring).
+///
+/// A backend has at most one of (marker, placeholder); the order is just a safe
+/// precedence. Placeholder ABSENCE returns `None` (not `Some(false)`): it could
+/// mean "typed" OR "agent mid-output / placeholder string changed across
+/// versions" — either way fail toward protection (a placeholder-text change
+/// disables the kiro path without ever risking a clobber of a real draft).
+pub fn input_box_empty_probe(
+    tail: &str,
+    marker: Option<&str>,
+    placeholder: Option<&str>,
+) -> Option<bool> {
+    if let Some(m) = marker {
+        if let Some(empty) = input_box_is_empty(tail, m) {
+            return Some(empty);
+        }
+    }
+    if let Some(p) = placeholder {
+        if tail.contains(p) {
+            return Some(true);
+        }
+    }
+    None
+}
+
 /// #1457: pop and return the single OLDEST queued notification, leaving the
 /// rest queued. The escape valve uses this so an abandoned-draft pane trickles
 /// its backlog one-per-tick instead of clobbering the draft with a full batch.
@@ -489,6 +521,46 @@ mod tests {
         // typed input below a blockquote → non-empty (still the bottom-most)
         let screen3 = "> quoted output\n> my actual draft";
         assert_eq!(input_box_is_empty(screen3, ">"), Some(false));
+    }
+
+    // ── #1948 v2: input_box_empty_probe (marker → placeholder → fallback) ──
+
+    #[test]
+    fn probe_marker_path_decides_directly() {
+        // claude/codex/agy: marker present → decided by content after marker;
+        // placeholder is ignored (None) for these backends.
+        assert_eq!(
+            input_box_empty_probe("out\n❯ ", Some("❯"), None),
+            Some(true)
+        );
+        assert_eq!(
+            input_box_empty_probe("out\n❯ typed", Some("❯"), None),
+            Some(false)
+        );
+        // marker present but no prompt line in the tail (mid-output) → None
+        // (fail-protect), NOT silently falling through to a non-existent placeholder.
+        assert_eq!(input_box_empty_probe("just output", Some("❯"), None), None);
+    }
+
+    #[test]
+    fn probe_placeholder_path_for_kiro() {
+        // kiro: no marker, placeholder VISIBLE → empty (deliver). Uses the real
+        // captured placeholder text (live pane_snapshot of a cleared kiro pane).
+        let ph = "ask a question or describe a task";
+        let empty_screen = "  Kiro · auto · 13%\n\n ask a question or describe a task ↵\n  /copy";
+        assert_eq!(
+            input_box_empty_probe(empty_screen, None, Some(ph)),
+            Some(true)
+        );
+        // typed → placeholder replaced/absent → None (fail toward protection).
+        let typed_screen = "  Kiro · auto · 13%\n\n half-typed reply\n  /copy";
+        assert_eq!(input_box_empty_probe(typed_screen, None, Some(ph)), None);
+    }
+
+    #[test]
+    fn probe_none_when_neither_marker_nor_placeholder() {
+        // Shell/Raw / markerless backend → fall back to timestamp behavior.
+        assert_eq!(input_box_empty_probe("$ ", None, None), None);
     }
 
     /// #1457: submitted (or never-typed) buffer → None → notifications deliver.


### PR DESCRIPTION
<!-- LOC-EST: 130-190 -->

#1948 v1 covered backends with a stable prompt-line **marker** (claude `❯` / codex `›` / agy `>`). kiro/opencode had none → fell back to the timestamp-only gate, so the type-then-clear false-positive (messages held while the input box is empty) still bit them. The operator's live test confirmed it: kiro and opencode both held messages after the box was cleared.

## v2 — a second emptiness signal (placeholder)
A **placeholder** is a hint the TUI shows ONLY while the box is empty, and replaces the instant the operator types.

- **`Backend::input_empty_placeholder()`** — kiro renders ` ask a question or describe a task ↵` when empty (verified against a **live `pane_snapshot`** of a just-cleared kiro pane, 2026-06-10). **opencode is intentionally left `None`**: its `┃`-bordered box has no placeholder, and the `┃`-prefixed model/path footer is always non-empty → input-vs-footer geometry can't be told apart robustly (version-coupled), so fail-toward-protection fallback is safer. (Re-evaluate if a future opencode build adds a stable empty-box placeholder — noted in the code.)
- **`notification_queue::input_box_empty_probe(tail, marker, placeholder)`** — marker probe first (claude/codex/agy), then placeholder probe (kiro: visible ⇒ empty), else `None`. **Placeholder ABSENCE returns `None`** (not `Some(false)`): it could mean "typed" OR "placeholder string changed across kiro versions" → fail toward protection. A version change therefore merely *disables* the kiro path, never risks clobbering a real draft (the key fail-protect argument the lead approved).
- The gate calls the unified probe via `pane.vterm` (owned, no lock).

## Test-harness fix
`pane_with_screen` used `VTerm::new(3, 40)` — but the signature is `(cols, rows)`, so that was **3 columns wide**. The v1 short-content tests (`❯ `) passed by luck; the 32-char kiro placeholder needs a realistic width → now `VTerm::new(80, 6)`.

## §3.9
- `input_box_empty_probe`: marker path (empty/typed/mid-output→None), kiro placeholder (visible→empty / absent→hold), neither→None.
- kiro gate integration: cleared (placeholder visible) → **delivered**; typed → **deferred**.
- v1 claude/codex/agy/Shell tests unchanged (no regression).
- Full `cargo nextest run --features tray --profile ci`: **3870 passed, 0 failed**; fmt + clippy clean.

Extends #1948 (kiro coverage; opencode stays fallback by design).