### PR TITLE
fix(#1948 b): codex empty-box coverage via DIM-attribute ghost detection

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1312,13 +1312,21 @@ where
     let raw_state = notification_queue::draft_state(home, &pane.agent_name);
     let buffer_empty = if raw_state == notification_queue::DraftState::Drafting {
         pane.backend.as_ref().and_then(|b| {
-            // #1948 v2: marker probe (claude/codex/agy) → placeholder probe (kiro)
-            // → None fallback. pane.vterm is owned (no lock).
-            notification_queue::input_box_empty_probe(
-                &pane.vterm.tail_lines(DRAFT_INPUT_TAIL_ROWS),
-                b.input_prompt_marker(),
-                b.input_empty_placeholder(),
-            )
+            // #1948(b): codex's empty box shows DIM ghost text after `›`, which a
+            // plain marker probe mis-reads as typed content — route it through the
+            // DIM-aware check (needs the per-char dim mask). Everyone else uses the
+            // text-only probe: marker (claude/agy) → placeholder (kiro) → fallback.
+            // pane.vterm is owned (no lock).
+            if let Some(marker) = b.input_dim_ghost_marker() {
+                let (text, dim) = pane.vterm.tail_lines_with_dim(DRAFT_INPUT_TAIL_ROWS);
+                notification_queue::input_box_dim_aware_empty(&text, &dim, marker)
+            } else {
+                notification_queue::input_box_empty_probe(
+                    &pane.vterm.tail_lines(DRAFT_INPUT_TAIL_ROWS),
+                    b.input_prompt_marker(),
+                    b.input_empty_placeholder(),
+                )
+            }
         })
     } else {
         None
@@ -1911,16 +1919,66 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// #1948(b) §3.9: codex's empty box shows DIM ghost text after `›` (SGR 2) —
+    /// the dim-aware path must DELIVER (the v1 plain-marker path mis-read the ghost
+    /// as typed content and held). The vterm processes the real SGR so the dim
+    /// flag is set exactly as codex emits it.
+    #[test]
+    fn draft_gate_delivers_for_codex_when_ghost_is_dim() {
+        let home = tmp_home("draftgate-codex-ghost");
+        seed_drafting_with_queued(&home, "lead");
+        // `ESC[1m›` (bold prompt) + `ESC[2m…` (dim ghost) — codex's real encoding.
+        let screen = "\u{1b}[1m›\u{1b}[22m\u{1b}[2m Use /skills to list available skills\u{1b}[0m";
+        let mut p = pane_with_screen("lead", Some(Backend::Codex), screen);
+        p.pending_notification_count = notification_queue::pending_count(&home, "lead");
+
+        let mut injected: Vec<String> = Vec::new();
+        flush_notifications_for_pane(&home, &mut p, |t| {
+            injected.push(t.to_string());
+            Ok(())
+        });
+        assert_eq!(
+            injected.len(),
+            1,
+            "codex empty box (dim ghost after ›) → stale draft delivered, not held"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1948(b) §3.9: a real codex draft (normal-intensity text after `›`) must
+    /// still DEFER — the dim signal must not false-deliver on a real draft.
+    #[test]
+    fn draft_gate_defers_for_codex_when_input_normal_intensity() {
+        let home = tmp_home("draftgate-codex-typed");
+        seed_drafting_with_queued(&home, "lead");
+        // `ESC[1m›` then NORMAL intensity input (no SGR 2).
+        let screen = "\u{1b}[1m›\u{1b}[22m my actual draft reply\u{1b}[0m";
+        let mut p = pane_with_screen("lead", Some(Backend::Codex), screen);
+        p.pending_notification_count = notification_queue::pending_count(&home, "lead");
+
+        let mut injected: Vec<String> = Vec::new();
+        flush_notifications_for_pane(&home, &mut p, |t| {
+            injected.push(t.to_string());
+            Ok(())
+        });
+        assert!(
+            injected.is_empty(),
+            "codex with normal-intensity input → keep deferring (protection unchanged)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     #[test]
     fn input_prompt_marker_only_for_verified_backends() {
         assert_eq!(Backend::ClaudeCode.input_prompt_marker(), Some("❯"));
         assert_eq!(Backend::Agy.input_prompt_marker(), Some(">"));
         // #1948 codex follow-up: codex is NOT marker-covered — its empty box shows
-        // a rotating ghost phrase after `›`, which the marker probe would mis-read
-        // as typed content. It falls back to the timestamp behavior until a
-        // colour/dim empty-box signal lands.
+        // a rotating ghost phrase after `›`, which the PLAIN marker probe mis-reads
+        // as typed content. #1948(b): codex is instead covered via the DIM-aware
+        // path (`input_dim_ghost_marker`) — the ghost is dim, real input is normal.
         assert_eq!(Backend::Codex.input_prompt_marker(), None);
         assert_eq!(Backend::Codex.input_empty_placeholder(), None);
+        assert_eq!(Backend::Codex.input_dim_ghost_marker(), Some("›"));
         assert_eq!(Backend::Shell.input_prompt_marker(), None);
         assert_eq!(Backend::OpenCode.input_prompt_marker(), None);
         // #1948 v2: kiro covered via placeholder, NOT a marker; opencode stays
@@ -1932,6 +1990,10 @@ mod tests {
         );
         assert_eq!(Backend::OpenCode.input_empty_placeholder(), None);
         assert_eq!(Backend::ClaudeCode.input_empty_placeholder(), None);
+        // dim-ghost is codex-only: the marker-backends and kiro are NOT dim-aware.
+        assert_eq!(Backend::ClaudeCode.input_dim_ghost_marker(), None);
+        assert_eq!(Backend::Agy.input_dim_ghost_marker(), None);
+        assert_eq!(Backend::KiroCli.input_dim_ghost_marker(), None);
     }
 
     /// app-mode subscriber-wiring source pin. Owned `agend-terminal app` mode

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -174,6 +174,24 @@ impl Backend {
         }
     }
 
+    /// #1948(b): the prompt marker for backends whose EMPTY box renders a
+    /// rotating ghost phrase after the marker in the DIM attribute (so a plain
+    /// `input_prompt_marker` probe mis-reads the ghost as typed content). The
+    /// draft-gate routes these through `input_box_dim_aware_empty`, which uses the
+    /// per-char DIM mask to tell the ghost (dim) from real input (normal).
+    ///
+    /// codex `›`: verified against a raw PTY capture (2026-06-10) — the prompt is
+    /// `ESC[1m›` (bold) and the ghost (`Use /skills …`, `Explain this codebase`,
+    /// …) is `ESC[2m` (dim) on the default colour. Operator confirmed the ghost is
+    /// visually dim and real input is normal/bright, so the dim signal can't
+    /// false-deliver on a real draft. `None` for everyone else.
+    pub fn input_dim_ghost_marker(&self) -> Option<&'static str> {
+        match self {
+            Backend::Codex => Some("›"),
+            _ => None,
+        }
+    }
+
     /// Actual command path to spawn. For [`Backend::Shell`] resolves to
     /// `$SHELL` (falling back to the platform default — `/bin/bash` on Unix,
     /// `cmd.exe` on Windows). For [`Backend::Raw`] returns the literal stored

--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -205,6 +205,46 @@ pub fn input_box_empty_probe(
     None
 }
 
+/// #1948(b): empty-box check for a backend (codex) whose EMPTY box renders a
+/// rotating ghost/placeholder phrase after `marker` in the DIM attribute — which
+/// a plain marker probe mis-reads as typed content (the v1 codex blind spot).
+/// `text`/`dim` come from [`crate::vterm::VTerm::tail_lines_with_dim`] and are
+/// 1:1 char-aligned. The marker's own glyph is excluded (codex renders `›` BOLD,
+/// the ghost DIM; the operator's real input is normal intensity).
+///
+/// Returns `Some(true)` if the BOTTOM-MOST marker line has, after the marker,
+/// only whitespace OR only DIM text (ghost → box empty); `Some(false)` if ANY
+/// non-whitespace non-DIM glyph follows (a real live draft → protect); `None` if
+/// no marker line is present (agent mid-output → fail toward protection).
+pub fn input_box_dim_aware_empty(text: &str, dim: &[bool], marker: &str) -> Option<bool> {
+    let chars: Vec<char> = text.chars().collect();
+    // Find the BOTTOM-MOST line whose first non-blank char is the marker, and the
+    // char range of its content AFTER the marker. Char indices align 1:1 with
+    // `dim` (each `\n` contributes one char + one `dim` entry).
+    let mut line_start = 0usize;
+    let mut after_marker: Option<(usize, usize)> = None;
+    for line in text.split('\n') {
+        let line_len = line.chars().count();
+        let line_end = line_start + line_len;
+        if line.trim_start().starts_with(marker) {
+            let leading_ws = line.chars().take_while(|c| c.is_whitespace()).count();
+            let start = line_start + leading_ws + marker.chars().count();
+            after_marker = Some((start, line_end));
+        }
+        line_start = line_end + 1; // +1 for the '\n' separator char
+    }
+    let (start, end) = after_marker?;
+    for i in start..end {
+        if chars.get(i).copied().unwrap_or(' ').is_whitespace() {
+            continue;
+        }
+        if !dim.get(i).copied().unwrap_or(false) {
+            return Some(false); // a normal-intensity glyph after the marker = real input
+        }
+    }
+    Some(true) // only whitespace / only DIM ghost after the marker
+}
+
 /// #1457: pop and return the single OLDEST queued notification, leaving the
 /// rest queued. The escape valve uses this so an abandoned-draft pane trickles
 /// its backlog one-per-tick instead of clobbering the draft with a full batch.
@@ -561,6 +601,53 @@ mod tests {
     fn probe_none_when_neither_marker_nor_placeholder() {
         // Shell/Raw / markerless backend → fall back to timestamp behavior.
         assert_eq!(input_box_empty_probe("$ ", None, None), None);
+    }
+
+    // ── #1948(b): input_box_dim_aware_empty (codex DIM-ghost) ──
+
+    #[test]
+    fn dim_aware_empty_when_ghost_is_dim() {
+        // codex empty box: `› <dim ghost>` — the prompt is bold (idx 0, not dim),
+        // every non-ws char after it is the DIM ghost → box empty (deliver).
+        let text = "› Use /skills to list available skills";
+        let n = text.chars().count();
+        let dim: Vec<bool> = (0..n).map(|i| i != 0).collect();
+        assert_eq!(input_box_dim_aware_empty(text, &dim, "›"), Some(true));
+    }
+
+    #[test]
+    fn dim_aware_nonempty_when_input_is_normal_intensity() {
+        // a real draft: `› my draft` rendered at NORMAL intensity (no dim) → a
+        // non-dim glyph after the marker → real input (protect).
+        let text = "› my half-typed reply";
+        let dim = vec![false; text.chars().count()];
+        assert_eq!(input_box_dim_aware_empty(text, &dim, "›"), Some(false));
+    }
+
+    #[test]
+    fn dim_aware_empty_when_only_whitespace_after_marker() {
+        let text = "some output\n› ";
+        let dim = vec![false; text.chars().count()];
+        assert_eq!(input_box_dim_aware_empty(text, &dim, "›"), Some(true));
+    }
+
+    #[test]
+    fn dim_aware_none_when_no_marker_line() {
+        let text = "just output, no prompt";
+        let dim = vec![false; text.chars().count()];
+        assert_eq!(input_box_dim_aware_empty(text, &dim, "›"), None);
+    }
+
+    #[test]
+    fn dim_aware_uses_bottom_most_marker_line() {
+        // a `›` in DIM prose above + the real input box below at NORMAL intensity
+        // → the bottom-most marker line (real input) decides → Some(false).
+        let text = "› a dim quote in output\n› my real draft";
+        let n = text.chars().count();
+        let nl_char = text.split('\n').next().unwrap_or("").chars().count();
+        // first line (+ its `\n`) dim; second line (real input) normal.
+        let dim: Vec<bool> = (0..n).map(|i| i <= nl_char).collect();
+        assert_eq!(input_box_dim_aware_empty(text, &dim, "›"), Some(false));
     }
 
     /// #1457: submitted (or never-typed) buffer → None → notifications deliver.

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -586,6 +586,16 @@ impl VTerm {
         self.tail_lines_impl(n, false).0
     }
 
+    /// #1948(b): the last `n` rows + a per-character DIM-attribute mask aligned
+    /// 1:1 with the returned `String` (a `false` for each `\n` separator). The
+    /// draft-gate uses this to tell codex's DIM empty-box ghost text apart from
+    /// the operator's normal-intensity input — colour-only [`CellFg`] can't,
+    /// because the ghost is dim on the DEFAULT foreground colour.
+    pub fn tail_lines_with_dim(&self, n: usize) -> (String, Vec<bool>) {
+        let (text, _fg, dim) = self.tail_lines_impl(n, true);
+        (text, dim)
+    }
+
     /// #1450: like [`tail_lines`], but also returns a per-character
     /// foreground classification ([`CellFg`]) aligned 1:1 with the `chars()`
     /// of the returned `String` — including a [`CellFg::Default`] entry for
@@ -594,7 +604,8 @@ impl VTerm {
     /// the phrase is rendered red. Building both in one pass guarantees the
     /// mask and the text can never drift out of alignment.
     pub fn tail_lines_with_fg(&self, n: usize) -> (String, Vec<CellFg>) {
-        self.tail_lines_impl(n, true)
+        let (text, fg, _dim) = self.tail_lines_impl(n, true);
+        (text, fg)
     }
 
     /// Shared core for [`tail_lines`] / [`tail_lines_with_fg`]. When
@@ -606,13 +617,19 @@ impl VTerm {
     /// WITHOUT a `\n` — so a single logical line the terminal wrapped across
     /// rows stays one line for the single-line detection regexes (#1808). The
     /// fg mask stays aligned 1:1 with the de-wrapped text.
-    fn tail_lines_impl(&self, n: usize, collect_fg: bool) -> (String, Vec<CellFg>) {
+    fn tail_lines_impl(&self, n: usize, collect_fg: bool) -> (String, Vec<CellFg>, Vec<bool>) {
         let grid = self.term.grid();
         let cols = self.cols as usize;
         let rows = self.rows as usize;
 
         let mut lines: Vec<String> = Vec::with_capacity(rows);
         let mut line_fgs: Vec<Vec<CellFg>> = Vec::with_capacity(rows);
+        // #1948(b): per-char DIM-attribute (`Flags::DIM`) mask, collected
+        // alongside the fg mask (same gate, same alignment). codex renders its
+        // empty-box ghost/placeholder text DIM on the default colour, which the
+        // colour-only `CellFg` can't see — the draft-gate uses this to tell the
+        // ghost apart from the operator's normal-intensity input.
+        let mut line_dims: Vec<Vec<bool>> = Vec::with_capacity(rows);
         // #1808: per-row soft-wrap flag. alacritty sets `WRAPLINE` on the LAST
         // cell of a physical row whose logical line CONTINUES on the next row
         // (its own auto-wrap when text overflows `cols`, NOT a `\n`/cursor-moved
@@ -626,6 +643,7 @@ impl VTerm {
         for row in 0..rows {
             let mut line = String::with_capacity(cols);
             let mut fg: Vec<CellFg> = Vec::new();
+            let mut dim: Vec<bool> = Vec::new();
             let mut col = 0;
             while col < cols {
                 let cell = safe_cell(grid, Line(row as i32), col);
@@ -637,6 +655,7 @@ impl VTerm {
                 line.push(ch);
                 if collect_fg {
                     fg.push(classify_fg(cell.fg));
+                    dim.push(cell.flags.contains(Flags::DIM));
                 }
                 col += 1;
             }
@@ -659,9 +678,11 @@ impl VTerm {
             };
             if collect_fg {
                 fg.truncate(trimmed.chars().count());
+                dim.truncate(trimmed.chars().count());
             }
             lines.push(trimmed.to_string());
             line_fgs.push(fg);
+            line_dims.push(dim);
             wrapped.push(row_wrapped);
         }
 
@@ -678,32 +699,37 @@ impl VTerm {
             .unwrap_or(first);
         let visible = &lines[first..last];
         let visible_fgs = &line_fgs[first..last];
+        let visible_dims = &line_dims[first..last];
         let visible_wrapped = &wrapped[first..last];
 
         let start = visible.len().saturating_sub(n);
         let tail = &visible[start..];
         let tail_fgs = &visible_fgs[start..];
+        let tail_dims = &visible_dims[start..];
         let tail_wrapped = &visible_wrapped[start..];
 
         let mut text = String::new();
         let mut fg_out: Vec<CellFg> = Vec::new();
+        let mut dim_out: Vec<bool> = Vec::new();
         for (i, line) in tail.iter().enumerate() {
             if i > 0 {
-                // #1808: skip the `\n` (and its filler fg cell) when the PREVIOUS
-                // row soft-wrapped into this one — they are one logical line.
+                // #1808: skip the `\n` (and its filler fg/dim cell) when the
+                // PREVIOUS row soft-wrapped into this one — they are one line.
                 if !tail_wrapped[i - 1] {
                     text.push('\n');
                     if collect_fg {
                         fg_out.push(CellFg::Default);
+                        dim_out.push(false);
                     }
                 }
             }
             text.push_str(line);
             if collect_fg {
                 fg_out.extend_from_slice(&tail_fgs[i]);
+                dim_out.extend_from_slice(&tail_dims[i]);
             }
         }
-        (text, fg_out)
+        (text, fg_out, dim_out)
     }
 
     /// Dump current screen as ANSI escape sequences for full redraw.
@@ -1930,6 +1956,19 @@ mod tests {
         vt.render_to_buffer(&mut buf, area, 0, false);
         assert_eq!(buf[(0, 0)].symbol(), "中", "wide char preserved");
         assert_eq!(buf[(1, 0)].symbol(), " ", "spacer blanked per #819");
+    }
+
+    /// #1948(b): the per-char DIM mask tracks the SGR 2 (faint) attribute and
+    /// stays aligned 1:1 with the returned text. This is what lets the draft-gate
+    /// tell codex's dim empty-box ghost apart from normal-intensity input.
+    #[test]
+    fn tail_lines_with_dim_tracks_faint_attribute() {
+        let mut vt = VTerm::new(40, 1);
+        // AB normal, CD dim (SGR 2), EF normal again (SGR 22 clears intensity).
+        vt.process(b"AB\x1b[2mCD\x1b[22mEF");
+        let (text, dim) = vt.tail_lines_with_dim(1);
+        assert_eq!(text, "ABCDEF");
+        assert_eq!(dim, vec![false, false, true, true, false, false]);
     }
 
     /// T6 (#1064, optional dev-2 nit): non-zero area origin still works.


### PR DESCRIPTION
<!-- LOC-EST: 130-190 -->

Follow-up to #1952. #1948 dropped codex's `›` marker because its empty box renders a rotating **ghost** phrase after the prompt that a plain marker probe mis-reads as typed content (so codex always deferred — fail-protect-safe but never delivered on an empty box). This restores codex coverage using the **DIM attribute** as the signal.

## RCA (raw PTY capture, isolated sandbox, 2026-06-10)
I spawned codex in a throwaway `/tmp` sandbox (never touching `~/.agend-terminal`) and captured its raw bytes. Around the prompt:

```
ESC[1m›        ← bold prompt
ESC[22m ESC[2m ESC[2m Use /skills to list available skills   ← DIM ghost
ESC[22m        ← reset
```

So the ghost is `ESC[2m` (**DIM** attribute) on the **default** foreground colour. The colour-only `CellFg` reads it as `Default` and can't tell it from real input. The operator confirmed the ghost is **visually dim** and real input is **normal/bright**, ruling out a false-deliver on a real draft.

## Fix — detect the DIM attribute
- **`VTerm::tail_lines_with_dim(n)`** → `(text, per-char DIM mask)`, collected alongside the existing fg mask in `tail_lines_impl` (same gate, 1:1 aligned; `tail_lines`/`tail_lines_with_fg` unchanged behaviour).
- **`notification_queue::input_box_dim_aware_empty(text, dim, marker)`** — the bottom-most marker line is empty iff every non-whitespace char after the marker is DIM (ghost) or there is none; a single **normal-intensity** glyph → a real draft (protect); no marker line → `None` (fail toward protection).
- **`Backend::input_dim_ghost_marker()`** = codex `›`; the gate routes codex through the dim-aware path, everyone else through the v1/v2 text-only probe (claude/agy marker, kiro placeholder). `pane.vterm` owned, no lock.

## §3.9
- `input_box_dim_aware_empty` units: dim-ghost→empty, normal→real, only-whitespace→empty, no-marker→None, bottom-most-marker-wins.
- **codex gate integration** drives the vterm with codex's **real SGR** (`ESC[1m›` + `ESC[2m`): empty (dim ghost) → **delivered**; normal-intensity input → **deferred** (the #1493-faithful test — fed the producer's actual encoding).
- `tail_lines_with_dim` alignment unit + the backend marker table.
- claude/agy/kiro paths unchanged.
- Full `cargo nextest run --features tray --profile ci`: **3878 passed, 0 failed**; fmt + clippy clean.

Closes the codex blind spot from #1948; opencode still fallback (no signal).