### PR TITLE
fix(#1955): UsageLimit episode lifecycle — release anchor + self-poisoning gates

### DIFF
--- a/src/daemon/watchdog.rs
+++ b/src/daemon/watchdog.rs
@@ -95,7 +95,20 @@ pub fn run_watchdog_pass(
     }
 
     if let Some(reason) = reason {
-        health.set_blocked_reason(reason);
+        // #1955 self-poisoning fix (mirrors the #1634 pattern above): drive the
+        // QuotaExceeded latch from the GATED live `AgentState`, not the raw
+        // colorless `classify_pty_output` — an agent QUOTING the banner in an
+        // RCA latched its own `blocked_reason` while `agent_state` was still
+        // `thinking` (claude-f9af90, issue #1955). The StateTracker's
+        // UsageLimit carries the input-line + tail-position + working-marker
+        // gates and the release anchor; only latch quota when IT says so.
+        if matches!(reason, crate::health::BlockedReason::QuotaExceeded)
+            && current_state != AgentState::UsageLimit
+        {
+            // prose/quoted mention only — not a live limit
+        } else {
+            health.set_blocked_reason(reason);
+        }
     }
 }
 
@@ -179,6 +192,34 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// #1955 self-poisoning pin (claude-f9af90): an agent QUOTING the banner
+    /// in its output (writing an RCA) makes `classify_pty_output` return
+    /// QuotaExceeded — but the gated live state is `Thinking`, so the latch
+    /// must NOT be set. Only a state-machine-confirmed UsageLimit latches.
+    #[test]
+    fn quoted_banner_while_thinking_does_not_latch_quota_1955() {
+        let home = tmp_home("quota-quote-1955");
+        let mut health = HealthTracker::new();
+        let backend = Backend::ClaudeCode;
+
+        run_watchdog_pass(
+            &home,
+            "test-agent",
+            &backend,
+            "writing the RCA: the banner says You've hit your weekly limit · resets 4am",
+            &mut health,
+            false, // live
+            AgentState::Thinking,
+        );
+
+        assert!(
+            health.current_reason.is_none(),
+            "#1955: a quoted banner with gated state Thinking must not latch QuotaExceeded, got: {:?}",
+            health.current_reason
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     #[test]
     fn test_watchdog_live_env_unset_sets_reason() {
         let home = tmp_home("live");
@@ -192,9 +233,12 @@ mod tests {
             "ServiceQuotaExceededException: You have exceeded your quota",
             &mut health,
             false, // live
-            // Agent still showing the quota banner → not recovered, so the
-            // bughunt2 auto-clear stays inert and the set is observed.
-            AgentState::RateLimit,
+            // #1955: the QuotaExceeded latch now requires the GATED live state
+            // to agree (the raw classify alone self-poisoned on quoted banner
+            // text) — so model the realistic shape: the state machine latched
+            // UsageLimit from the same banner. Not in the recovered set, so
+            // the bughunt2 auto-clear stays inert and the set is observed.
+            AgentState::UsageLimit,
         );
 
         assert!(

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -292,6 +292,18 @@ pub struct StateTracker {
     /// cross-Idle phantom loop in cheerc's #1808 Evidence 2) is still detected.
     /// Read/written only for the phantom probe log; never affects transitions.
     last_srl_match_sig: Option<(u64, usize)>,
+    /// #1955: when the current UsageLimit episode auto-releases. Anchored on
+    /// the banner's own unlock hint parsed at latch time ("resets 4am" /
+    /// "try again at 15:14", assumed daemon-local TZ — Claude prints the
+    /// user's own zone); [`Self::USAGE_LIMIT_EXPIRY`] when unparseable.
+    usage_limit_release_at: Option<Instant>,
+    /// #1955: signature (bottom-most banner line hash + dist-from-bottom) of
+    /// a RELEASED UsageLimit episode. The banner is level-triggered and can
+    /// sit in the visible tail forever on an idle pane, so without this the
+    /// next feed would simply re-latch what the expiry just released. A
+    /// genuinely-new limit hit renders fresh at the bottom (different
+    /// position, usually a different reset time) → different sig → latches.
+    usage_limit_expired_sig: Option<(u64, usize)>,
     /// #1808-probe0-phantom (instrumentation-only): how many CONSECUTIVE feed
     /// ticks the same SRL error re-matched with NO intervening non-SRL state
     /// (the in-place clock-tick re-scan). Resets on a different signature or a
@@ -438,6 +450,66 @@ fn hash_screen(text: &str) -> u64 {
     hasher.finish()
 }
 
+/// #1955: the (bottom-most) screen line containing `matched` — the UsageLimit
+/// banner line, so the unlock hint that follows the matched phrase on the same
+/// line ("… · resets 4am (Asia/Taipei)") can be parsed.
+fn line_containing<'a>(screen_text: &'a str, matched: &str) -> Option<&'a str> {
+    let pos = screen_text.rfind(matched)?;
+    let start = screen_text[..pos].rfind('\n').map_or(0, |i| i + 1);
+    let end = screen_text[pos..]
+        .find('\n')
+        .map_or(screen_text.len(), |i| pos + i);
+    Some(&screen_text[start..end])
+}
+
+/// #1955: duration until the banner's own unlock hint. Live forms: claude
+/// `resets 4am (Asia/Taipei)` / `resets at 11:59pm`, codex `try again at
+/// 15:14`. The banner prints the USER's timezone, which matches the daemon's
+/// local clock on a single-operator host — so the target is resolved against
+/// local time (next occurrence of that wall-clock time). A bare hour with no
+/// am/pm and no `:MM` is too ambiguous to anchor on → `None` (the caller
+/// falls back to the conservative window). Result capped at 24h — the hint
+/// only encodes a time-of-day; a multi-day window self-corrects on the next
+/// genuine re-latch (fresh banner → fresh anchor).
+fn parse_usage_limit_release(line: &str) -> Option<Duration> {
+    use std::sync::OnceLock;
+    static UNLOCK: OnceLock<regex::Regex> = OnceLock::new();
+    let re = UNLOCK.get_or_init(|| {
+        #[allow(clippy::unwrap_used)] // const pattern — compile failure is a code bug
+        regex::Regex::new(
+            r"(?i)\b(?:resets?|try again)(?:\s+at)?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?",
+        )
+        .unwrap()
+    });
+    let caps = re.captures(line)?;
+    let mut hour: u32 = caps[1].parse().ok()?;
+    let minute: u32 = caps
+        .get(2)
+        .map(|m| m.as_str().parse().ok())
+        .unwrap_or(Some(0))?;
+    let ampm = caps.get(3).map(|m| m.as_str().to_ascii_lowercase());
+    if ampm.is_none() && caps.get(2).is_none() {
+        return None; // bare "resets 4" — ambiguous
+    }
+    match ampm.as_deref() {
+        Some("pm") if hour < 12 => hour += 12,
+        Some("am") if hour == 12 => hour = 0,
+        _ => {}
+    }
+    if hour > 23 || minute > 59 {
+        return None;
+    }
+    let now = chrono::Local::now().naive_local();
+    let target_today = now.date().and_hms_opt(hour, minute, 0)?;
+    let target = if target_today > now {
+        target_today
+    } else {
+        target_today + chrono::Duration::days(1)
+    };
+    let until = (target - now).to_std().ok()?;
+    Some(until.min(Duration::from_secs(24 * 3600)))
+}
+
 /// #1808-probe0-phantom (instrumentation-only): a stable signature of the
 /// bottom-most occurrence of an SRL error line — `(line_hash, dist_from_bottom)`.
 /// `dist_from_bottom` is the byte distance from the error line's start to the end
@@ -563,6 +635,17 @@ const THROTTLE_HINT_TOKENS: &[&str] = &[
     "RESOURCE_EXHAUSTED",
     "429",
     "Rate limited",
+    // #1955: usage-limit banners — a static stuck-UsageLimit pane must also
+    // re-evaluate so the release anchor / expired-sig suppression can run
+    // (UsageLimit is deliberately NOT in `already_throttle`, so re-detection
+    // proceeds). Substrings cover the claude trio ("You've hit your …
+    // limit"), codex ("hit your usage limit"), kiro ("you have reached the
+    // limit" / ServiceQuotaExceeded), and the credit-balance forms.
+    "hit your",
+    "reached the limit",
+    "ServiceQuotaExceeded",
+    "Credit balance",
+    "credit_balance_too_low",
 ];
 
 fn screen_has_throttle_hint(screen_text: &str) -> bool {
@@ -839,6 +922,15 @@ impl StateTracker {
     /// while preventing hours-long false positives (PR #319 incident).
     const RATE_LIMIT_EXPIRY: Duration = Duration::from_secs(300);
 
+    /// #1955: conservative UsageLimit release window when the banner carries
+    /// no parseable unlock hint ("resets 4am" / "try again at 15:14"). Long
+    /// enough to not flap on a real limit, short enough that an idle agent is
+    /// never stranded for days (the `general` incident): after release the
+    /// agent degrades to Idle; if it is dispatched while genuinely still
+    /// limited, the attempt re-renders a FRESH banner at the bottom → a new
+    /// signature → re-latch with a re-parsed anchor (self-correcting).
+    const USAGE_LIMIT_EXPIRY: Duration = Duration::from_secs(30 * 60);
+
     /// If the last MCP heartbeat is within this window, the agent is
     /// considered alive and `PermissionPrompt` detection is suppressed.
     const HEARTBEAT_FRESH_WINDOW: Duration = Duration::from_secs(120);
@@ -914,6 +1006,8 @@ impl StateTracker {
             dropped_transition_count: 0,
             // #1808-probe0-phantom: no SRL seen yet.
             last_srl_match_sig: None,
+            usage_limit_release_at: None,
+            usage_limit_expired_sig: None,
             srl_consecutive_rematch: 0,
             non_srl_since_last_srl: false,
         }
@@ -1140,12 +1234,29 @@ impl StateTracker {
                     // submitted user-message line) — operator-typed / quoted
                     // error strings are prose, not CLI error output
                     // (operator-reproduced live FP, 2026-06-10).
+                    let usage_limit = matches!(detected, AgentState::UsageLimit);
                     let anchor_fail = if requires_red_anchor(detected) {
                         self.anchor_on_red
                             && !fg.is_empty()
                             && !matched_span_has_red(screen_text, matched, fg)
                     } else if high_fp {
                         !crate::state::patterns::in_error_line_excluding_input(
+                            screen_text,
+                            matched,
+                            self.input_line_markers,
+                        )
+                    } else if usage_limit {
+                        // #1955 self-poisoning: an agent QUOTING the banner
+                        // ("You've hit your weekly limit" in an RCA / dispatch)
+                        // latched itself. Input-line exclusion is the
+                        // right-sized anchor here — the REAL banner carries no
+                        // error indicator (`⎿ You've hit your weekly limit ·
+                        // resets 4am`), so the error-line content anchor would
+                        // false-negative it, and its rendering isn't reliably
+                        // red. Prose mentions in agent OUTPUT are bounded by
+                        // the position gate below + the #1777 working-marker
+                        // override + the #1955 release anchor.
+                        !crate::state::patterns::any_match_off_input_lines(
                             screen_text,
                             matched,
                             self.input_line_markers,
@@ -1161,7 +1272,10 @@ impl StateTracker {
                     // the retry storm). Scoped to HIGH_FP/error states ONLY:
                     // Idle and modal/interactive prompts keep full-screen
                     // scanning, because a modal can legitimately sit above the tail.
-                    let stale_position = high_fp
+                    // #1955: UsageLimit joins the position gate — a banner
+                    // quote buried in deep scrollback is discussion, not a
+                    // live limit (same staleness logic as the HIGH_FP set).
+                    let stale_position = (high_fp || usage_limit)
                         && !matched_span_in_recent_tail(
                             screen_text,
                             matched,
@@ -1393,6 +1507,54 @@ impl StateTracker {
                                 if cross_cycle {
                                     landed = AgentState::Idle;
                                 }
+                            }
+                        }
+                        // #1955: UsageLimit episode lifecycle. The match is
+                        // level-triggered and a silent pane never scrolls the
+                        // banner away (the `general` incident: stuck for DAYS
+                        // past the account reset), so the state machine — not
+                        // new output — must provide the exit:
+                        //  • fresh latch → anchor a release deadline on the
+                        //    banner's own unlock hint (conservative fallback);
+                        //  • in-episode re-match past the deadline → release
+                        //    to Idle and remember the banner's signature;
+                        //  • re-match of that SAME released signature →
+                        //    suppress (mirror of the #1809 cross-cycle
+                        //    suppression) — a genuinely-new limit renders
+                        //    fresh at the bottom → new sig → latches again.
+                        if matches!(detected, AgentState::UsageLimit)
+                            && matches!(landed, AgentState::UsageLimit)
+                        {
+                            let sig = srl_match_signature(screen_text, matched);
+                            if self.usage_limit_expired_sig == Some(sig) {
+                                landed = AgentState::Idle;
+                            } else if self.current == AgentState::UsageLimit {
+                                if self
+                                    .usage_limit_release_at
+                                    .is_some_and(|at| Instant::now() >= at)
+                                {
+                                    self.usage_limit_expired_sig = Some(sig);
+                                    self.usage_limit_release_at = None;
+                                    tracing::info!(
+                                        target: "state_detection",
+                                        agent = %self.instance_name,
+                                        dist_from_bottom = sig.1,
+                                        "#1955: UsageLimit released — unlock anchor passed; suppressing the stale banner re-latch"
+                                    );
+                                    landed = AgentState::Idle;
+                                }
+                            } else {
+                                let release_in = line_containing(screen_text, matched)
+                                    .and_then(parse_usage_limit_release)
+                                    .unwrap_or(Self::USAGE_LIMIT_EXPIRY);
+                                self.usage_limit_release_at = Some(Instant::now() + release_in);
+                                self.usage_limit_expired_sig = None;
+                                tracing::info!(
+                                    target: "state_detection",
+                                    agent = %self.instance_name,
+                                    release_in_secs = release_in.as_secs(),
+                                    "#1955: UsageLimit latched — release anchored on the banner's unlock hint (or conservative fallback)"
+                                );
                             }
                         }
                         let gated = self.gate_on_heartbeat(landed);
@@ -1718,6 +1880,25 @@ impl StateTracker {
         if rate_limit_expiring && self.since.elapsed() >= Self::RATE_LIMIT_EXPIRY {
             self.transition(AgentState::Idle);
             return;
+        }
+        // #1955: UsageLimit expires on its release deadline (anchored on the
+        // banner's own unlock hint at latch time, else the conservative
+        // window). This arm covers the banner-scrolled-away case (detection
+        // returns None); a still-visible banner releases at the detection
+        // override instead (the level-triggered re-match never reaches here).
+        // A pre-#1955 latch carries no deadline → conservative window from
+        // `since`.
+        if matches!(self.current, AgentState::UsageLimit) {
+            let deadline_passed = self
+                .usage_limit_release_at
+                .map_or(self.since.elapsed() >= Self::USAGE_LIMIT_EXPIRY, |at| {
+                    Instant::now() >= at
+                });
+            if deadline_passed {
+                self.usage_limit_release_at = None;
+                self.transition(AgentState::Idle);
+                return;
+            }
         }
         // Prompt states (InteractivePrompt / PermissionPrompt) expire on
         // the longer window. When the screen goes stable after the

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -130,6 +130,37 @@ pub(crate) fn in_error_line_excluding_input(
     false
 }
 
+/// #1955: does ANY on-screen occurrence of `matched` sit on a line that is
+/// NOT an input / user-message line? The UsageLimit anchor: the real banner
+/// carries no error indicator (`⎿  You've hit your weekly limit · resets
+/// 4am`), so the error-line content anchor would false-negative it —
+/// input-line exclusion alone is the right-sized gate (fail-toward-detection:
+/// anything not typed/quoted at the prompt still latches; prose mentions in
+/// agent output are bounded by the position gate + working-marker override +
+/// the #1955 release anchor).
+pub(crate) fn any_match_off_input_lines(
+    screen_text: &str,
+    matched: &str,
+    input_markers: &[&str],
+) -> bool {
+    if matched.is_empty() {
+        return false;
+    }
+    let mut search = 0;
+    while let Some(rel) = screen_text[search..].find(matched) {
+        let pos = search + rel;
+        let line_start = screen_text[..pos].rfind('\n').map_or(0, |i| i + 1);
+        let line_end = screen_text[pos..]
+            .find('\n')
+            .map_or(screen_text.len(), |i| pos + i);
+        if !is_input_line(&screen_text[line_start..line_end], input_markers) {
+            return true;
+        }
+        search = pos + matched.len();
+    }
+    false
+}
+
 /// Compiled patterns for one backend.
 pub struct StatePatterns {
     /// (state, regex) pairs in priority order (highest priority first).

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -4710,3 +4710,196 @@ fn flatten_fallback_excludes_input_lines_1947() {
         "#1947: a genuine bare hard-wrapped SRL still detects"
     );
 }
+
+// ── #1955: UsageLimit episode lifecycle + self-poisoning gates ──────────────
+
+/// Live banner shape (the `general` incident pane): banner parked in the tail
+/// above a clean idle prompt.
+const CLAUDE_USAGE_LIMIT_FRAME: &str = "⏺ some earlier work\n\
+     ⎿  You've hit your weekly limit · resets 4am (Asia/Taipei)\n\
+     \n\
+     ❯ \n\
+     ────────────";
+
+/// #1955 fail-toward-detection: the real banner above an idle prompt still
+/// latches UsageLimit, and the latch anchors a release deadline parsed from
+/// the banner's own unlock hint.
+#[test]
+fn usage_limit_real_banner_latches_with_release_anchor_1955() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(CLAUDE_USAGE_LIMIT_FRAME);
+    assert_eq!(t.get_state(), AgentState::UsageLimit, "real banner latches");
+    let release = t.usage_limit_release_at.expect("release deadline anchored");
+    assert!(
+        release <= Instant::now() + Duration::from_secs(24 * 3600),
+        "anchor bounded at 24h"
+    );
+}
+
+/// #1955 the `general` repro: once the release deadline passes, the SAME
+/// stale banner (level-triggered, never scrolls on a silent pane) must
+/// release to Idle instead of re-latching — and STAY released on further
+/// re-scans of the identical screen (expired-sig suppression). The re-scan
+/// rides the throttle-hint static-pane bypass (same-hash feeds).
+#[test]
+fn usage_limit_stale_banner_releases_after_deadline_1955() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(CLAUDE_USAGE_LIMIT_FRAME);
+    assert_eq!(t.get_state(), AgentState::UsageLimit);
+
+    // Deadline passes (account reset). The pane is SILENT: the identical
+    // frame re-feeds (claude clock-tick / static-pane hint bypass).
+    t.usage_limit_release_at = Some(Instant::now());
+    // transition() only allows a priority DROP after a 2s min-hold; the real
+    // incident latch is days old. Backdate safely (checked_sub — windows-safe).
+    t.since = Instant::now()
+        .checked_sub(Duration::from_secs(3))
+        .unwrap_or_else(Instant::now);
+    t.feed(CLAUDE_USAGE_LIMIT_FRAME);
+    assert_eq!(
+        t.get_state(),
+        AgentState::Idle,
+        "#1955: past the release deadline the stale banner must release to Idle"
+    );
+
+    // Further re-scans of the SAME banner stay Idle (no enter-only latch).
+    t.feed(CLAUDE_USAGE_LIMIT_FRAME);
+    assert_eq!(
+        t.get_state(),
+        AgentState::Idle,
+        "#1955: the released banner signature must not re-latch"
+    );
+}
+
+/// #1955: a genuinely-NEW limit hit AFTER a release renders fresh (different
+/// position → different signature) and must latch again — the suppression is
+/// scoped to the released episode, not to usage limits in general.
+#[test]
+fn usage_limit_new_banner_after_release_relatches_1955() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(CLAUDE_USAGE_LIMIT_FRAME);
+    t.usage_limit_release_at = Some(Instant::now());
+    // transition() only allows a priority DROP after a 2s min-hold; the real
+    // incident latch is days old. Backdate safely (checked_sub — windows-safe).
+    t.since = Instant::now()
+        .checked_sub(Duration::from_secs(3))
+        .unwrap_or_else(Instant::now);
+    t.feed(CLAUDE_USAGE_LIMIT_FRAME);
+    assert_eq!(t.get_state(), AgentState::Idle, "released");
+
+    // A new attempt re-renders the banner at a DIFFERENT screen position.
+    let fresh = "⏺ retrying the dispatch\n\
+         output line\n\
+         more output\n\
+         ⎿  You've hit your weekly limit · resets 4am (Asia/Taipei)\n\
+         ❯ ";
+    t.feed(fresh);
+    assert_eq!(
+        t.get_state(),
+        AgentState::UsageLimit,
+        "#1955: a fresh banner (new signature) must latch a new episode"
+    );
+    assert!(
+        t.usage_limit_release_at.is_some(),
+        "new episode re-anchors its release"
+    );
+}
+
+/// #1955: banner scrolled away (detection None) while latched → the
+/// maybe_expire arm releases on the deadline.
+#[test]
+fn usage_limit_expires_via_maybe_expire_when_banner_gone_1955() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(CLAUDE_USAGE_LIMIT_FRAME);
+    assert_eq!(t.get_state(), AgentState::UsageLimit);
+    t.usage_limit_release_at = Some(Instant::now());
+    // transition() only allows a priority DROP after a 2s min-hold; the real
+    // incident latch is days old. Backdate safely (checked_sub — windows-safe).
+    t.since = Instant::now()
+        .checked_sub(Duration::from_secs(3))
+        .unwrap_or_else(Instant::now);
+    // A screen with NO matching pattern at all (banner scrolled, no prompt).
+    t.feed("plain output text with nothing recognisable\nsecond line");
+    assert_eq!(
+        t.get_state(),
+        AgentState::Idle,
+        "#1955: deadline-passed UsageLimit must expire even with the banner gone"
+    );
+}
+
+/// #1955 self-poisoning: the banner string typed/quoted on the input line
+/// must not latch (input-line exclusion — same #1950 technique).
+#[test]
+fn usage_limit_quote_on_input_line_does_not_latch_1955() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed(
+        "⏺ analysing the incident\n\
+         ❯ the pane showed You've hit your weekly limit · resets 4am yesterday",
+    );
+    assert_ne!(
+        t.get_state(),
+        AgentState::UsageLimit,
+        "#1955: a quoted banner on the ❯ input line must not latch"
+    );
+}
+
+/// #1955 self-poisoning: a banner quote buried in DEEP scrollback (outside
+/// the bottom-N tail) is discussion, not a live limit (position gate).
+#[test]
+fn usage_limit_deep_scrollback_quote_does_not_latch_1955() {
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    let mut screen = String::from("⏺ RCA: You've hit your weekly limit was the banner\n");
+    for i in 0..16 {
+        screen.push_str(&format!("filler line {i}\n"));
+    }
+    screen.push_str("❯ ");
+    t.feed(&screen);
+    assert_ne!(
+        t.get_state(),
+        AgentState::UsageLimit,
+        "#1955: a banner quote outside the live tail must not latch"
+    );
+}
+
+/// #1955 multi-backend: the codex usage-limit banner walks the same lifecycle
+/// (latch + unlock-hint anchor from "Try again at HH:MM").
+#[test]
+fn usage_limit_codex_banner_same_path_1955() {
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    t.feed(
+        "You've hit your usage limit. Try again at 15:14.\n\
+         › ",
+    );
+    assert_eq!(
+        t.get_state(),
+        AgentState::UsageLimit,
+        "codex banner latches"
+    );
+    assert!(
+        t.usage_limit_release_at.is_some(),
+        "codex unlock hint anchors the release"
+    );
+}
+
+/// #1955: unlock-hint parser — live forms anchor within 24h; ambiguous /
+/// absent hints fall back (None).
+#[test]
+fn parse_usage_limit_release_forms_1955() {
+    let day = Duration::from_secs(24 * 3600);
+    for line in [
+        "⎿  You've hit your weekly limit · resets 4am (Asia/Taipei)",
+        "You've hit your session limit · resets at 11:59pm",
+        "You've hit your usage limit. Try again at 15:14.",
+    ] {
+        let dur = parse_usage_limit_release(line).unwrap_or_else(|| panic!("must parse: {line}"));
+        assert!(dur <= day, "bounded at 24h: {line}");
+    }
+    assert!(
+        parse_usage_limit_release("You've hit your weekly limit · resets 4").is_none(),
+        "bare hour without am/pm or :MM is ambiguous"
+    );
+    assert!(
+        parse_usage_limit_release("You've hit your weekly limit").is_none(),
+        "no hint → conservative fallback path"
+    );
+}


### PR DESCRIPTION
Lead task t-20260610102217170469-1. Fixes the issue's three failure points: enter-only latch (no expiry), no static-pane re-evaluation, and context-blind matching (self-poisoning).

## 1. Episode lifecycle — the state machine provides the exit, not new output
- Fresh latch anchors a **release deadline parsed from the banner's own unlock hint** (`resets 4am (Asia/Taipei)` / `resets at 11:59pm` / codex `Try again at 15:14`; daemon-local clock, capped 24h). Unparseable → `USAGE_LIMIT_EXPIRY` (30min conservative).
- In-episode re-match past the deadline → **release to Idle + remember the banner signature** (line hash + dist-from-bottom). Re-matches of that released signature stay suppressed (mirror of the #1809 cross-cycle suppression) — the banner never scrolls on a silent pane, so without this the next feed would re-latch what the expiry just released. A genuinely-new limit renders **fresh at the bottom → new signature → new episode** with a re-parsed anchor (fail-toward-detection, self-correcting: a still-limited agent that gets dispatched re-banners and re-latches).
- `maybe_expire_latched_state` gains the UsageLimit arm (banner-scrolled-away case; pre-#1955 latches use the conservative window).

## 2. Static-pane re-evaluation
Usage-limit tokens join `THROTTLE_HINT_TOKENS` (`hit your`, `reached the limit`, `ServiceQuotaExceeded`, credit-balance forms) so a settled pane re-evaluates through the hash-dedup bypass. UsageLimit deliberately NOT in `already_throttle` — re-detection is exactly what lets the release run.

## 3. Self-poisoning gates (reusing the #1950 technique, NOT re-invented)
- **Input-line exclusion** via new `any_match_off_input_lines` — deliberately not `in_error_line_excluding_input`: the real banner (`⎿  You've hit your weekly limit · resets 4am`) carries **no error indicator**, so the error-line content anchor would false-negative it (fail-toward-detection).
- **#1518 position gate** now covers UsageLimit (deep-scrollback quotes are discussion).
- **Watchdog**: the `QuotaExceeded` blocked_reason latch is driven by the **gated live AgentState** (the #1634 ModelUnsupported pattern), not raw colorless `classify_pty_output` — fixes the claude-f9af90 thinking-state self-poison. The existing Idle auto-clear completes the recovery chain post-release.

## Edge cases (task checklist)
- Real limit → immediate idle: banner in tail still latches (fail-toward-detection test) AND releases past unlock — the `general` repro test.
- Multi-backend: codex banner (`hit your usage limit|try again at`) walks the same profile-pattern path + parser handles its `Try again at HH:MM` form — `codex-44cea9` (currently stuck) is the live validation target post-deploy. kiro (`ServiceQuotaExceeded`/`you have reached the limit`) hint tokens included.
- Tightening can't mask a real limit: gates only exclude input-line/deep-scrollback quotes; everything else latches, and the latch now has an exit.

## Tests (§3.9)
real banner latches with bounded anchor · stale banner past deadline releases AND stays released on identical re-scans (rides the static-pane hint bypass) · fresh banner after release re-latches a new episode · banner-gone expiry via maybe_expire · input-line quote no-latch · deep-scrollback quote no-latch · codex same-path · unlock parser forms (am/pm, HH:MM, ambiguous→None) · watchdog pin: quoted banner while thinking does not latch quota.

`cargo fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · bins **3586 passed / 1 failed** (the known pre-existing git-shim environmental `dispatch_branch_..._1834`; passes with system git).

No spawn sites touched (§10.5 n/a).

Closes #1955. Refs #1777, #1809, #1950, #1634, #1523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)