### PR TITLE
fix(#1956): disable opencode self-update prompt via spawn-layer config

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -817,6 +817,21 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
         cmd.env("XDG_DATA_HOME", &data_dir);
     }
 
+    // #1956: disable opencode's interactive self-update prompt. opencode pops a
+    // "A newer release is available. Would you like to update now?" modal on
+    // startup/idle when a newer release exists — it hangs the ENTIRE pane (the
+    // agent can't receive or answer any dispatch; an ESC mis-fires Confirm and
+    // self-updates mid-session). There is no `--no-update` CLI flag, but opencode
+    // MERGES `OPENCODE_CONFIG_CONTENT` on top of the user's global
+    // `~/.config/opencode/opencode.json` (verified MERGE, not replace, via
+    // `opencode debug config` — the user's provider/auth config is preserved),
+    // and its config schema has an `autoupdate` field. Inject it inline so
+    // nothing lands on disk and the user's global config is never touched. Gated
+    // to OpenCode (same self-modification-footgun discipline as the XDG block).
+    if matches!(detected_backend, Some(Backend::OpenCode)) {
+        cmd.env("OPENCODE_CONFIG_CONTENT", r#"{"autoupdate":false}"#);
+    }
+
     // Add agend-terminal binary + $AGEND_HOME/bin (shim) to PATH.
     // Shim dir goes first so agend-git shadows /usr/bin/git.
     if let Ok(exe) = std::env::current_exe() {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -926,6 +926,50 @@ fn build_command_sets_git_editor_defaults() {
     }
 }
 
+/// #1956: opencode's interactive self-update prompt hangs the whole pane (the
+/// agent can't answer dispatches). There's no `--no-update` flag, so the spawn
+/// injects `OPENCODE_CONFIG_CONTENT` with `autoupdate:false` — MERGED onto the
+/// user's global config (never replacing it; verified via `opencode debug
+/// config`). Gated to OpenCode: other backends must NOT receive the env.
+#[test]
+fn build_command_disables_opencode_autoupdate_only_for_opencode() {
+    let cfg = |backend_command: &'static str| SpawnConfig {
+        name: "autoupdate-test",
+        backend_command,
+        args: &[],
+        spawn_mode: crate::backend::SpawnMode::Fresh,
+        cols: 80,
+        rows: 24,
+        env: None,
+        working_dir: None,
+        submit_key: "\r",
+        home: None,
+        crash_tx: None,
+        shutdown: None,
+    };
+    // OpenCode → OPENCODE_CONFIG_CONTENT is present and valid JSON disabling autoupdate.
+    let (oc, _) = build_command(&cfg("opencode")).expect("build_command opencode");
+    let content = oc
+        .get_env("OPENCODE_CONFIG_CONTENT")
+        .and_then(|v| v.to_str().map(String::from))
+        .expect("opencode spawn env must set OPENCODE_CONFIG_CONTENT");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).expect("OPENCODE_CONFIG_CONTENT must be valid JSON");
+    assert_eq!(
+        parsed["autoupdate"],
+        serde_json::json!(false),
+        "must disable opencode autoupdate, got {content}"
+    );
+    // Non-OpenCode backends must NOT receive the env (no cross-backend leakage).
+    for cmd in ["claude", "codex", "echo"] {
+        let (c, _) = build_command(&cfg(cmd)).expect("build_command");
+        assert!(
+            c.get_env("OPENCODE_CONFIG_CONTENT").is_none(),
+            "{cmd} must not receive OPENCODE_CONFIG_CONTENT"
+        );
+    }
+}
+
 /// §3.9 (MED-5): the daemon must re-inject AGEND_HOME into every spawned
 /// agent's env. AGEND_HOME is on the env-isolation SENSITIVE deny-list, so under
 /// `AGEND_ENV_ISOLATION=1` the `env_clear` drops it and the passthrough loop


### PR DESCRIPTION
## Problem (#1956)

opencode pops an interactive **"A newer release is available. Would you like to update now?"** modal on startup/idle when a newer release exists — it hangs the **entire agent pane**. The agent can't receive or answer any dispatch; an ESC mis-fires `Confirm` → opencode self-updates mid-session → process exits to shell → needs restart. (Repro: reviewer-3 on opencode 1.15.13 with v1.16.2 available.) opencode has **no `--no-update` CLI flag**.

## Fix

Inject `OPENCODE_CONFIG_CONTENT={"autoupdate":false}` inline at the opencode spawn env (`build_command`, alongside the #1519 XDG block), **gated to OpenCode**. Nothing lands on disk; the user's global config is never touched.

opencode's own code gates the update path on exactly this field:
```js
if (config.autoupdate === false || OPENCODE_DISABLE_AUTOUPDATE) return;
```
→ it returns **before** the update check/prompt entirely (not just the download). The documented `autoupdate` config field is chosen over the undocumented `OPENCODE_DISABLE_AUTOUPDATE` env for stability.

## Verification (the make-or-break: merge vs replace)

Verified with opencode's own **read-only** `opencode debug config` (dumps the resolved config; touches nothing):

| | baseline | with `OPENCODE_CONFIG_CONTENT={"autoupdate":false}` |
|---|---|---|
| user oMLX provider (baseURL/apiKey) | present | **preserved** |
| resolved `autoupdate` | absent | **false** |

→ **MERGE, not replace** — the override stacks on the user's global `~/.config/opencode/opencode.json`; provider/auth config is untouched.

## Acceptance criteria
- [x] opencode agent no longer pops the update prompt / hangs the pane (source-level: `autoupdate === false` → early return)
- [x] user global `~/.config/opencode/opencode.json` unmodified (inline env, MERGE semantics)
- [x] existing provider/model injection (oMLX etc.) unaffected (verified: provider preserved)
- [x] verified in isolation, no touch to the real daemon home / global config
- [x] regression test: OpenCode spawn env carries valid `autoupdate:false` JSON; non-OpenCode backends never receive the env

🤖 Generated with [Claude Code](https://claude.com/claude-code)