### PR TITLE
fix(#1942): link dispatch branch to task so lead-merges auto-closes it

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -512,6 +512,17 @@ fn track_dispatch(
                 threshold,
             );
         }
+        // #1942: link the dispatched branch to the correlated task. The lead
+        // dispatches `kind=task` with `branch=`, but the task is often created
+        // separately with `branch: None` — so without this the task↔branch link
+        // never exists and `auto_close_merged_tasks` can't auto-close on merge
+        // (the lead-merges strand). Idempotent + no-op if no branch / no task.
+        if let (Some(branch), Some(corr)) = (
+            params["branch"].as_str().filter(|b| !b.is_empty()),
+            outbound_corr,
+        ) {
+            let _ = crate::tasks::link_branch_to_task(home, corr, branch);
+        }
     } else if kind_str == "report" {
         // #1525: clear the dispatch-idle sidecar with the SAME key the record
         // path uses — `correlation_id.or(task_id)` (see the kind=task branch

--- a/src/status_summary.rs
+++ b/src/status_summary.rs
@@ -140,7 +140,12 @@ pub fn auto_close_merged_tasks(home: &Path, branch: &str) {
         .iter()
         .filter(|t| t.status == TaskStatus::Verified)
         .filter(|t| {
-            contains_as_token(&t.description, branch) || contains_as_token(&t.title, branch)
+            // #1942: the structured `branch` field is the canonical link (set by
+            // `link_branch_to_task` on dispatch); the description/title token
+            // match stays as the legacy fallback for branches embedded in text.
+            t.branch.as_deref() == Some(branch)
+                || contains_as_token(&t.description, branch)
+                || contains_as_token(&t.title, branch)
         })
         .collect();
 
@@ -307,6 +312,74 @@ mod tests {
             task.status,
             TaskStatus::Done,
             "unverified task must NOT be auto-closed"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn auto_close_finds_task_via_linked_branch_field_1942() {
+        // #1942: the canonical task↔branch link is the structured `branch` field
+        // (set by `link_branch_to_task` at dispatch), NOT the description text.
+        // A Verified task whose branch field == the merged branch must auto-close
+        // even though the branch name appears NOWHERE in its title/description.
+        use crate::task_events::{append_batch, InstanceName, TaskEvent, TaskId};
+        let dir = std::env::temp_dir().join(format!("agend-autoclose-1942-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        let tid = "t-1942-link-001";
+        append_batch(
+            &dir,
+            &InstanceName::from("test:seed"),
+            vec![
+                TaskEvent::Created {
+                    task_id: TaskId(tid.into()),
+                    title: "impl widget".into(),
+                    description: "do the thing".into(),
+                    priority: "normal".into(),
+                    owner: None,
+                    due_at: None,
+                    depends_on: Vec::new(),
+                    routed_to: None,
+                    branch: None,
+                    bind: None,
+                    eta_secs: None,
+                    tags: vec![],
+                    parent_id: None,
+                },
+                TaskEvent::Verified {
+                    task_id: TaskId(tid.into()),
+                    by_reviewer: InstanceName::from("reviewer"),
+                    verdict: "VERIFIED".into(),
+                },
+            ],
+        )
+        .expect("seed verified task");
+        // Dispatch-time linkage (the #1942 fix).
+        assert!(
+            crate::tasks::link_branch_to_task(&dir, tid, "fix/1942-widget").unwrap(),
+            "branch should link to the task"
+        );
+        // Idempotent: re-linking the same branch is a no-op.
+        assert!(
+            !crate::tasks::link_branch_to_task(&dir, tid, "fix/1942-widget").unwrap(),
+            "re-linking the same branch must be a no-op"
+        );
+        let task = crate::tasks::list_all(&dir)
+            .into_iter()
+            .find(|t| t.id.as_str() == tid)
+            .expect("task present");
+        assert_eq!(task.branch.as_deref(), Some("fix/1942-widget"));
+        assert_eq!(task.status, TaskStatus::Verified);
+        // Branch merges → auto-close finds the task via the structured field
+        // (no branch token in title/description).
+        auto_close_merged_tasks(&dir, "fix/1942-widget");
+        let task = crate::tasks::list_all(&dir)
+            .into_iter()
+            .find(|t| t.id.as_str() == tid)
+            .expect("task present");
+        assert_eq!(
+            task.status,
+            TaskStatus::Done,
+            "#1942: a merged linked-branch must auto-close the verified task"
         );
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -340,6 +340,15 @@ pub enum TaskEvent {
         key: String,
         value: serde_json::Value,
     },
+    /// #1942: link a git branch to a task after creation. The dispatch
+    /// (`send kind=task`) carries `branch=`, but a separately-created task starts
+    /// with `branch: None`; this event fills it in so `auto_close_merged_tasks`
+    /// can find the task↔branch link when the branch merges.
+    BranchLinked {
+        task_id: TaskId,
+        by: InstanceName,
+        branch: String,
+    },
 }
 
 /// Per-task confidence breakdown produced by the legacy-backfill sweep.
@@ -380,7 +389,8 @@ impl TaskEvent {
             | TaskEvent::PriorityChanged { task_id, .. }
             | TaskEvent::DescriptionUpdated { task_id, .. }
             | TaskEvent::TagsSet { task_id, .. }
-            | TaskEvent::MetadataSet { task_id, .. } => task_id,
+            | TaskEvent::MetadataSet { task_id, .. }
+            | TaskEvent::BranchLinked { task_id, .. } => task_id,
         }
     }
 
@@ -405,6 +415,7 @@ impl TaskEvent {
             TaskEvent::DescriptionUpdated { .. } => "description_updated",
             TaskEvent::TagsSet { .. } => "tags_set",
             TaskEvent::MetadataSet { .. } => "metadata_set",
+            TaskEvent::BranchLinked { .. } => "branch_linked",
         }
     }
 }
@@ -760,6 +771,12 @@ impl TaskBoardState {
             TaskEvent::TagsSet { tags, .. } => {
                 if let Some(t) = self.tasks.get_mut(task_id) {
                     t.tags = tags.clone();
+                    t.updated_at = touch_at.to_string();
+                }
+            }
+            TaskEvent::BranchLinked { branch, .. } => {
+                if let Some(t) = self.tasks.get_mut(task_id) {
+                    t.branch = Some(branch.clone());
                     t.updated_at = touch_at.to_string();
                 }
             }

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -27,9 +27,18 @@ pub fn auto_close_on_report(
         return Ok(false);
     };
     use crate::task_events::TaskStatus;
+    // #1942: `InReview` was added in #1265 but never added to this whitelist, so
+    // a terminal report on a task the lead promoted to `in_review` was silently
+    // dropped → task stranded open → next dispatch blocked busy. `InReview→Done`
+    // is a legal transition (`can_transition_to`), so a terminal report from the
+    // assignee closes an `in_review` task just as it closes an `in_progress` one.
     if !matches!(
         record.status,
-        TaskStatus::Open | TaskStatus::Claimed | TaskStatus::InProgress | TaskStatus::Blocked
+        TaskStatus::Open
+            | TaskStatus::Claimed
+            | TaskStatus::InProgress
+            | TaskStatus::Blocked
+            | TaskStatus::InReview
     ) {
         return Ok(false);
     }
@@ -378,6 +387,46 @@ mod tests {
         );
         assert_eq!(
             task_status(&home, "t-ok"),
+            Some(crate::task_events::TaskStatus::Done)
+        );
+    }
+
+    #[test]
+    fn assignee_terminal_report_closes_in_review_task_1942() {
+        // #1942: a task the lead promoted to `in_review` (code-review flow) must
+        // still auto-close on the assignee's terminal report. `InReview` was
+        // missing from the whitelist, so the report was silently dropped and the
+        // task stranded open → next dispatch blocked busy.
+        let home = tmp_home("in_review_close");
+        seed_claimed_task(&home, "t-1942-ir", "dev-agent");
+        crate::task_events::append_batch(
+            &home,
+            &InstanceName::from("test:lead"),
+            vec![TaskEvent::MovedToReview {
+                task_id: TaskId("t-1942-ir".into()),
+            }],
+        )
+        .expect("promote to in_review");
+        assert_eq!(
+            task_status(&home, "t-1942-ir"),
+            Some(crate::task_events::TaskStatus::InReview),
+            "precondition: task is in_review"
+        );
+        let closed = auto_close_on_report(
+            &home,
+            "report",
+            "t-1942-ir",
+            "dev-agent",
+            "review done",
+            true,
+        )
+        .unwrap();
+        assert!(
+            closed,
+            "#1942: a terminal report must auto-close an in_review task"
+        );
+        assert_eq!(
+            task_status(&home, "t-1942-ir"),
             Some(crate::task_events::TaskStatus::Done)
         );
     }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -1029,6 +1029,9 @@ fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String
         ),
         TaskEvent::MovedToBacklog { .. } => ("moved_to_backlog", actor, "→ backlog".to_string()),
         TaskEvent::MovedToReview { .. } => ("moved_to_review", actor, "→ in_review".to_string()),
+        TaskEvent::BranchLinked { branch, by, .. } => {
+            ("branch_linked", by.0.clone(), format!("branch → {branch}"))
+        }
     }
 }
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -230,6 +230,41 @@ pub fn list_all(home: &Path) -> Vec<Task> {
     tasks
 }
 
+/// #1942: link a git `branch` to an existing task by emitting a `BranchLinked`
+/// event. Called from the dispatch path (`send kind=task` carrying `branch=`)
+/// so a separately-created task — which starts with `branch: None` — gains the
+/// task↔branch link that `auto_close_merged_tasks` needs to auto-close the task
+/// when the branch merges (the #1942 lead-merges gap).
+///
+/// Returns `Ok(true)` if a `BranchLinked` event was emitted, `Ok(false)` if it
+/// was a no-op (task absent, empty branch, or the branch is already linked —
+/// idempotent so a re-dispatch of the same branch doesn't churn the log).
+pub fn link_branch_to_task(home: &Path, task_id: &str, branch: &str) -> anyhow::Result<bool> {
+    if branch.is_empty() || !task_id.starts_with("t-") {
+        return Ok(false);
+    }
+    let state = crate::task_events::replay(home).unwrap_or_default();
+    let tid = crate::task_events::TaskId(task_id.to_string());
+    let Some(record) = state.tasks.get(&tid) else {
+        return Ok(false);
+    };
+    if record.branch.as_deref() == Some(branch) {
+        return Ok(false);
+    }
+    let emitter = crate::task_events::InstanceName::from("system:branch-link");
+    crate::task_events::append_batch(
+        home,
+        &emitter,
+        vec![crate::task_events::TaskEvent::BranchLinked {
+            task_id: tid,
+            by: emitter.clone(),
+            branch: branch.to_string(),
+        }],
+    )?;
+    tracing::info!(task_id, branch, "linked branch to task (#1942)");
+    Ok(true)
+}
+
 /// Sweep overdue claimed tasks back to open by **emitting `Released`
 /// events** (PR3 cutover from tasks.json mutation). `Released` is
 /// distinct from `Reopened`: it clears the owner (claim is gone),


### PR DESCRIPTION
## Problem (#1942)

In the **lead-merges** flow, a dispatch-created task strands open after its PR merges → the next dispatch to that agent is refused **busy** (operator-visible). Both auto-close paths miss it:

1. **`auto_close_on_report`** needs a *terminal report* — but the lead merges and the assignee never has a natural terminal-report moment.
2. **`auto_close_merged_tasks`** closes tasks linked to the merged **branch** — but the task↔branch link never existed. The lead dispatches `kind=task` with `branch=`, yet the task is created separately with `branch: None`.

(Empirical: #1955/#1956 were dispatched with `branch=` but their tasks had no branch.)

## Fix — lead-approved direction (a), canonical variant

**1. Linkage at dispatch.** `tasks::link_branch_to_task` emits a new *internal* `TaskEvent::BranchLinked` that fills the task's structured `branch` field. Called from `handle_send` on `kind=task` carrying `branch=` + a correlated task id. Idempotent; no-op if no branch / no task / already linked. (The branch **name** is only available at dispatch — the report envelope carries `reviewed_head` (a SHA) + `pr_number`, not a branch name.)

**2. Path 2 reads the structured field.** One **additive** match (`t.branch == Some(branch)`) alongside the legacy description/title token match. The existing **`status == Verified` gate is untouched**, so multi-PR tasks (not yet verified) are *not* mis-closed — addressing the edge cases raised in the issue comments.

**3. Orthogonal #1265 gap, folded in.** Added `InReview` to the `auto_close_on_report` whitelist. `InReview→Done` is a legal transition (`can_transition_to`), so a terminal report on a lead-promoted `in_review` task now closes it instead of being silently dropped. (Clean single-arm + obviously-legal + its own test, per the lead's merge condition.)

## Tests
- `auto_close_finds_task_via_linked_branch_field_1942`: created-without-branch task → `link_branch_to_task` → Verified → merged branch auto-closes it, with the branch name **nowhere** in title/description (proves the structured-field path) + link idempotency.
- `assignee_terminal_report_closes_in_review_task_1942`: terminal report on an `in_review` task auto-closes it.

## Verification
fmt + clippy (`--features tray -D warnings`) + full nextest all green (`AGEND_GIT_BYPASS=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)