### PR TITLE
fix(#1888): decouple ci-handoff re-nudge from inbox read-state (track-until-resolution)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -523,6 +523,15 @@ fn track_dispatch(
         // target goes Idle (#1516's working-state gate does not cover that).
         if let Some(corr) = msg.correlation_id.as_deref().or(msg.task_id.as_deref()) {
             let _ = crate::daemon::dispatch_idle::mark_resolved(home, corr);
+            // #1888 phase-2: a report carrying the handoff's `repo@branch`
+            // correlation (reviewer verdicts do) RESOLVES the ci-handoff track —
+            // the re-nudge stops on this signal, not on inbox read. A task-id
+            // correlation simply matches no track (no-op).
+            let _ = crate::daemon::ci_handoff_track::resolve_by_correlation(
+                home,
+                corr,
+                "report_arrived",
+            );
             if corr.starts_with("t-") {
                 let _ = crate::tasks::auto_close::auto_close_on_report(
                     home,

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -88,6 +88,10 @@ pub fn bind_full(
     worktree: &std::path::Path,
     source_repo: &std::path::Path,
 ) -> Result<(), String> {
+    // #1888 phase-2: the agent claiming a branch is acting on any pending
+    // ci-handoff for it — resolve the track (re-nudge stops). Scoped to this
+    // agent's own tracks; other targets' handoffs for the branch are untouched.
+    let _ = crate::daemon::ci_handoff_track::resolve_claimed(home, agent, branch);
     let dir = crate::paths::runtime_dir(home).join(agent);
     std::fs::create_dir_all(&dir).map_err(|e| format!("create_dir_all {}: {e}", dir.display()))?;
     let path = dir.join("binding.json");

--- a/src/daemon/ci_handoff_track.rs
+++ b/src/daemon/ci_handoff_track.rs
@@ -1,0 +1,269 @@
+//! #1888 phase-2: correlation-keyed CI-handoff tracks (track-until-resolution).
+//!
+//! The #1859/#1860 re-nudge + escalation watchdog used to scan
+//! `unread_of_kind(target, "ci-ready-for-action")` — but ANY inbox drain marks
+//! the handoff read (storage.rs drain is kind-blind), so the watchdog went
+//! blind the moment the reviewer ran a routine inbox check. Production
+//! readout (2026-06-10): 14 `#1888-ciready-read` events ALL at
+//! `age_at_read 2-7s`, ZERO `#1888-renudge-decision` events — the 2-min
+//! re-nudge window never once opened; delivery worked only when the reviewer
+//! happened to act on the wake itself.
+//!
+//! This store decouples the watchdog from inbox read-state: one sidecar file
+//! per `(target, correlation)` is RECORDED when the poller enqueues the
+//! `[ci-ready-for-action]` handoff, and RESOLVED (deleted) on an explicit
+//! resolution signal instead of on read:
+//!   - a `kind=report` arriving with that correlation (reviewer verdict
+//!     reports carry `repo@branch` — the messaging report-arrival chokepoint,
+//!     same spot as `dispatch_idle::mark_resolved`);
+//!   - the PR reaching a terminal state (merged / closed-unmerged — the
+//!     pr_state scanner);
+//!   - the TARGET claiming the branch (a worktree binding via `bind_full`);
+//!   - the 24h [`TRACK_MAX_AGE`] backstop swept by the watchdog (a track
+//!     whose resolution signal never arrives must not re-nudge forever).
+//!
+//! Mirrors the `pending-dispatches` file-per-entry sidecar pattern (#1866).
+//! No per-file locks: every operation is a whole-file write or a delete (no
+//! read-modify-write), and the worst interleaving — a resolution racing a
+//! fresh `record` for the same correlation (a new CI pass) — correctly leaves
+//! the new episode tracked.
+
+use std::path::{Path, PathBuf};
+
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+/// Backstop lifetime: a track never resolved within this window is swept
+/// (with a WARN) so the re-nudge cannot run forever.
+pub(crate) const TRACK_MAX_AGE: chrono::Duration = chrono::Duration::hours(24);
+
+/// One pending CI handoff awaiting pickup-resolution.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct CiHandoffTrack {
+    pub schema_version: u32,
+    /// The `next_after_ci` recipient that owes the review.
+    pub target: String,
+    /// `owner/repo@branch` — the same key the handoff message carries as its
+    /// `correlation_id` and that reviewer reports / pr_state events use.
+    pub correlation: String,
+    /// RFC3339 — when the handoff was enqueued (the re-nudge age anchor).
+    pub sent_at: String,
+}
+
+fn dir(home: &Path) -> PathBuf {
+    home.join("ci-handoff-tracks")
+}
+
+/// Filename-safe key: one file per `(target, correlation)`.
+fn file_for(home: &Path, target: &str, correlation: &str) -> PathBuf {
+    let sanitize = |s: &str| {
+        s.chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '.' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>()
+    };
+    dir(home).join(format!(
+        "{}--{}.json",
+        sanitize(target),
+        sanitize(correlation)
+    ))
+}
+
+/// Record (or refresh — a NEW CI pass on the same branch restarts the age
+/// anchor) the pending handoff for `(target, correlation)`.
+pub(crate) fn record(home: &Path, target: &str, correlation: &str, sent_at: &str) {
+    let track = CiHandoffTrack {
+        schema_version: SCHEMA_VERSION,
+        target: target.to_string(),
+        correlation: correlation.to_string(),
+        sent_at: sent_at.to_string(),
+    };
+    let path = file_for(home, target, correlation);
+    if let Err(e) = std::fs::create_dir_all(dir(home))
+        .and_then(|()| std::fs::write(&path, serde_json::to_vec(&track).unwrap_or_default()))
+    {
+        tracing::warn!(%target, %correlation, error = %e, "#1888: ci-handoff track write failed");
+        return;
+    }
+    tracing::info!(
+        tag = "#1888-track-recorded",
+        agent = %target,
+        %correlation,
+        "ci-handoff track recorded (re-nudge until resolution, not until read)"
+    );
+}
+
+/// All currently-pending tracks. Unparseable files are skipped (and logged) —
+/// never panic the watchdog tick.
+pub(crate) fn list(home: &Path) -> Vec<CiHandoffTrack> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(dir(home)).into_iter().flatten().flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        match std::fs::read(&path)
+            .ok()
+            .and_then(|b| serde_json::from_slice::<CiHandoffTrack>(&b).ok())
+        {
+            Some(t) => out.push(t),
+            None => {
+                tracing::warn!(path = %path.display(), "#1888: unparseable ci-handoff track skipped");
+            }
+        }
+    }
+    out
+}
+
+/// Resolve (delete) every track carrying `correlation`, any target. Returns
+/// how many were resolved. `reason` is for the log only.
+pub(crate) fn resolve_by_correlation(home: &Path, correlation: &str, reason: &str) -> usize {
+    let mut resolved = 0;
+    for track in list(home) {
+        if track.correlation == correlation
+            && std::fs::remove_file(file_for(home, &track.target, &track.correlation)).is_ok()
+        {
+            resolved += 1;
+            tracing::info!(
+                tag = "#1888-track-resolved",
+                agent = %track.target,
+                %correlation,
+                reason,
+                "ci-handoff track resolved"
+            );
+        }
+    }
+    resolved
+}
+
+/// Resolve every track whose TARGET is `agent` and whose correlation's branch
+/// part matches `branch` — the target claiming the branch (worktree binding)
+/// is acting on the handoff.
+pub(crate) fn resolve_claimed(home: &Path, agent: &str, branch: &str) -> usize {
+    let suffix = format!("@{branch}");
+    let mut resolved = 0;
+    for track in list(home) {
+        if track.target == agent
+            && track.correlation.ends_with(&suffix)
+            && std::fs::remove_file(file_for(home, &track.target, &track.correlation)).is_ok()
+        {
+            resolved += 1;
+            tracing::info!(
+                tag = "#1888-track-resolved",
+                agent = %track.target,
+                correlation = %track.correlation,
+                reason = "target_claimed_branch",
+                "ci-handoff track resolved"
+            );
+        }
+    }
+    resolved
+}
+
+/// Backstop sweep: delete tracks older than [`TRACK_MAX_AGE`] (WARN each) so
+/// an unresolved correlation can't re-nudge forever. Returns how many were
+/// swept. Called from the watchdog tick.
+pub(crate) fn sweep_expired(home: &Path, now: &chrono::DateTime<chrono::Utc>) -> usize {
+    let mut swept = 0;
+    for track in list(home) {
+        let expired = chrono::DateTime::parse_from_rfc3339(&track.sent_at)
+            .map(|t| now.signed_duration_since(t.with_timezone(&chrono::Utc)) >= TRACK_MAX_AGE)
+            // Unparseable sent_at → treat as expired (a broken track must not
+            // re-nudge forever either).
+            .unwrap_or(true);
+        if expired
+            && std::fs::remove_file(file_for(home, &track.target, &track.correlation)).is_ok()
+        {
+            swept += 1;
+            tracing::warn!(
+                tag = "#1888-track-expired",
+                agent = %track.target,
+                correlation = %track.correlation,
+                sent_at = %track.sent_at,
+                "ci-handoff track hit the 24h backstop without a resolution signal — swept (no more re-nudges); the lead escalation already fired long ago"
+            );
+        }
+    }
+    swept
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let id = C.fetch_add(1, Ordering::Relaxed);
+        let p = std::env::temp_dir().join(format!(
+            "agend-1888-track-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn record_list_roundtrip_and_refresh() {
+        let home = tmp_home("roundtrip");
+        record(&home, "reviewer", "o/r@b1", "2026-06-10T00:00:00Z");
+        record(&home, "reviewer", "o/r@b2", "2026-06-10T00:00:00Z");
+        assert_eq!(list(&home).len(), 2);
+        // Re-record same key = refresh (no duplicate file).
+        record(&home, "reviewer", "o/r@b1", "2026-06-10T01:00:00Z");
+        let tracks = list(&home);
+        assert_eq!(tracks.len(), 2, "refresh must not duplicate");
+        assert!(tracks
+            .iter()
+            .any(|t| t.correlation == "o/r@b1" && t.sent_at == "2026-06-10T01:00:00Z"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn resolve_by_correlation_clears_all_targets() {
+        let home = tmp_home("resolve-corr");
+        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z");
+        record(&home, "reviewer-2", "o/r@b", "2026-06-10T00:00:00Z");
+        record(&home, "reviewer", "o/r@other", "2026-06-10T00:00:00Z");
+        assert_eq!(resolve_by_correlation(&home, "o/r@b", "test"), 2);
+        let left = list(&home);
+        assert_eq!(left.len(), 1);
+        assert_eq!(left[0].correlation, "o/r@other");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn resolve_claimed_scopes_to_target_and_branch() {
+        let home = tmp_home("resolve-claim");
+        record(&home, "reviewer", "o/r@fix/x", "2026-06-10T00:00:00Z");
+        record(&home, "other", "o/r@fix/x", "2026-06-10T00:00:00Z");
+        assert_eq!(resolve_claimed(&home, "reviewer", "fix/x"), 1);
+        let left = list(&home);
+        assert_eq!(left.len(), 1, "other target's track untouched");
+        assert_eq!(left[0].target, "other");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn sweep_expired_backstop_and_broken_tracks() {
+        let home = tmp_home("sweep");
+        let now = chrono::Utc::now();
+        let old = (now - chrono::Duration::hours(25)).to_rfc3339();
+        let fresh = now.to_rfc3339();
+        record(&home, "reviewer", "o/r@old", &old);
+        record(&home, "reviewer", "o/r@fresh", &fresh);
+        record(&home, "reviewer", "o/r@broken", "not-a-timestamp");
+        assert_eq!(sweep_expired(&home, &now), 2, "old + broken swept");
+        let left = list(&home);
+        assert_eq!(left.len(), 1);
+        assert_eq!(left[0].correlation, "o/r@fresh");
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1735,6 +1735,16 @@ fn persist_watch_state(
                         "ci_watch_chain",
                         next
                     );
+                    // #1888 phase-2: track the handoff until RESOLUTION (report /
+                    // PR terminal / target claims the branch), decoupled from the
+                    // inbox read-state the watchdog used to scan (any drain marked
+                    // it read within seconds and blinded the re-nudge).
+                    crate::daemon::ci_handoff_track::record(
+                        ctx.home,
+                        next,
+                        &repo_branch_key,
+                        &chrono::Utc::now().to_rfc3339(),
+                    );
                 }
                 None if state.subscriber_names().is_empty() => {
                     tracing::warn!(

--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -7,11 +7,16 @@
 //! sat for an hour because the reviewer never picked it up and nothing
 //! escalated.
 //!
-//! RCA note: the handoff is *already recorded* — it's the inbox message itself,
-//! carrying its send time (`timestamp`) and the `repo@branch` correlation. So
-//! this watchdog needs no new tracking store: it simply looks for a
-//! `ci-ready-for-action` message that is still UNREAD after the timeout, and
-//! escalates to the reviewer's team lead so they can re-route or nudge.
+//! #1888 phase-2 (decouple from read-state): this watchdog ORIGINALLY scanned
+//! the inbox message itself (`unread_of_kind`) — but ANY inbox drain marks the
+//! handoff read (the drain is kind-blind), so the watchdog went blind the
+//! moment the reviewer ran a routine pending check. Production confirmed the
+//! coupling (14 `#1888-ciready-read` @ 2-7s : 0 `#1888-renudge-decision` in a
+//! full day — the 2-min window never once opened). The scan source is now the
+//! `ci_handoff_track` sidecar: recorded when the poller enqueues the handoff,
+//! resolved on an explicit RESOLUTION signal (the reviewer's report for that
+//! correlation / a PR terminal state / the target claiming the branch / the
+//! 24h backstop) — never on read.
 //!
 //! Detection ONLY — like the inbox-stuck watchdog (#1491A) it never reassigns
 //! automatically; the lead decides.
@@ -72,13 +77,14 @@ pub(crate) fn scan_and_emit_with<F>(
 ) where
     F: FnMut(&str, usize),
 {
-    let Ok(fleet) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) else {
-        return;
-    };
+    // #1888 phase-2: backstop sweep BEFORE the scan — an expired track must
+    // neither re-nudge nor escalate this tick.
+    let _ = crate::daemon::ci_handoff_track::sweep_expired(home, now);
+    let tracks = crate::daemon::ci_handoff_track::list(home);
     // #1598-mirror: collect every (target, correlation) key still backed by a
-    // pending unread handoff this tick, so the trailing `retain` can reap
+    // pending TRACK this tick, so the trailing `retain` can reap
     // `last_escalated` / `last_renudged` entries whose repo@branch handoff is no
-    // longer active (read/resolved). Without it the maps grow one entry per
+    // longer active (resolved/expired). Without it the maps grow one entry per
     // (reviewer, branch) forever — a slow leak, since `.get`/`.insert` were the
     // only ops and the dedup windows suppress but never evict.
     let mut active: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
@@ -93,12 +99,24 @@ pub(crate) fn scan_and_emit_with<F>(
     // still governs the cross-tick interval.
     let mut renudged_this_scan: std::collections::HashSet<String> =
         std::collections::HashSet::new();
-    for target in fleet.instances.keys() {
-        for (correlation, sent_at) in crate::inbox::unread_of_kind(home, target, HANDOFF_KIND) {
+    {
+        for track in &tracks {
+            let target = &track.target;
+            // Orphan guard: the target left the fleet — nothing to nudge; the
+            // 24h sweep reaps the file.
+            if !crate::fleet::instance_is_known(home, target) {
+                continue;
+            }
+            // sweep_expired (above) already deleted unparseable sent_at tracks;
+            // a race re-creating one just waits a tick.
+            let Ok(sent_at) = chrono::DateTime::parse_from_rfc3339(&track.sent_at) else {
+                continue;
+            };
+            let sent_at = sent_at.with_timezone(&chrono::Utc);
             // #1870-H3: clamp so a backward clock skew (future `sent_at`) can't
             // make the age negative → re-nudge / escalation silently stop firing.
             let age_min = crate::daemon::utils::elapsed_since(*now, sent_at).num_minutes();
-            let corr = correlation.unwrap_or_else(|| "<unknown>".to_string());
+            let corr = track.correlation.clone();
             let key = (target.clone(), corr.clone());
             active.insert(key.clone());
 
@@ -113,12 +131,13 @@ pub(crate) fn scan_and_emit_with<F>(
             // target reads the handoff (drops from the unread scan → reaped). This
             // also covers the orchestrator-as-`next_after_ci` case below, where
             // there is no lead to escalate to.
-            // #1888 instrument-only (zero-behavior): record WHY this UNREAD handoff
-            // did / didn't get re-nudged this tick, so production can confirm the
-            // #1860 read-state-coupling RCA. A handoff that was already marked read
-            // never enters this loop at all (`unread_of_kind` filters it) — that
-            // case is captured by the `#1888-ciready-read` trace at the drain site.
-            // Read-only: these locals don't feed the byte-identical gate below.
+            // #1888: record WHY this PENDING handoff did / didn't get re-nudged
+            // this tick (tag kept from the phase-1 instrument for log
+            // continuity). Phase-2: the loop now iterates TRACKS, so a handoff
+            // that was merely marked read still shows up here — `track_pending`
+            // replaces the old `unread_found` (which production proved was
+            // always extinguished within seconds).
+            // Read-only: these locals don't feed the gate below.
             {
                 let busy = crate::snapshot::agent_is_busy(home, target);
                 let renudge_due = last_renudged.get(&key).is_none_or(|prev| {
@@ -132,7 +151,7 @@ pub(crate) fn scan_and_emit_with<F>(
                     tag = "#1888-renudge-decision",
                     agent = %target,
                     correlation = %corr,
-                    unread_found = true,
+                    track_pending = true,
                     age_min,
                     agent_is_busy = busy,
                     renudge_due,
@@ -152,8 +171,12 @@ pub(crate) fn scan_and_emit_with<F>(
                     last_renudged.insert(key.clone(), *now);
                     // ...but inject at most ONCE per target per scan.
                     if renudged_this_scan.insert(target.clone()) {
-                        let (unread, _) = crate::inbox::unread_count(home, target);
-                        renudge(target, unread);
+                        // #1888 phase-2: the pointer count is the target's PENDING
+                        // TRACKS — the handoff message itself may already be read
+                        // (that no longer stops the re-nudge), so the unread count
+                        // would say 0 and mislead.
+                        let pending = tracks.iter().filter(|t| &t.target == target).count();
+                        renudge(target, pending);
                     }
                 }
             }
@@ -191,7 +214,8 @@ pub(crate) fn scan_and_emit_with<F>(
             let text = format!(
                 "[handoff_timeout_watchdog] the next_after_ci handoff to '{target}' for {corr} \
                  has been unclaimed for {age_min}min — CI passed and a [ci-ready-for-action] \
-                 message was sent, but '{target}' still hasn't read it. The reviewer may be \
+                 message was sent, but '{target}' still hasn't picked it up (no review report / \
+                 branch claim / PR terminal for that correlation). The reviewer may be \
                  stuck/offline; consider re-routing the review to another reviewer or nudging it."
             );
             if let Err(e) = crate::inbox::notify_system(
@@ -266,6 +290,15 @@ mod tests {
             msg.read_at = Some(chrono::Utc::now().to_rfc3339());
         }
         crate::inbox::enqueue(home, target, msg).unwrap();
+        // #1888 phase-2 production parity: the poller records a TRACK alongside
+        // the enqueue — the watchdog scans tracks, not inbox read-state, so
+        // `read` no longer extinguishes the handoff (that's the fix).
+        crate::daemon::ci_handoff_track::record(
+            home,
+            target,
+            corr,
+            &(chrono::Utc::now() - chrono::Duration::minutes(age_min)).to_rfc3339(),
+        );
     }
 
     /// Seed the per-tick snapshot so `agent_is_busy(home, agent)` is
@@ -413,7 +446,8 @@ mod tests {
             crate::inbox::drain(&home, "lead").is_empty(),
             "a fresh handoff must not escalate"
         );
-        // Old but already READ → reviewer acted → no escalation.
+        // #1888 phase-2: old and already READ but NOT resolved → still
+        // escalates (read used to blind the watchdog — that was the bug).
         let home2 = tmp_home("read");
         write_fleet(&home2);
         seed_handoff(&home2, "reviewer", "o/r@feat", 30, true);
@@ -423,12 +457,29 @@ mod tests {
             &mut HashMap::new(),
             &mut HashMap::new(),
         );
+        assert_eq!(
+            crate::inbox::drain(&home2, "lead").len(),
+            1,
+            "#1888: a read-but-unresolved handoff must STILL escalate"
+        );
+        // RESOLVED (reviewer reported the correlation) → no escalation.
+        let home3 = tmp_home("resolved");
+        write_fleet(&home3);
+        seed_handoff(&home3, "reviewer", "o/r@feat", 30, true);
+        crate::daemon::ci_handoff_track::resolve_by_correlation(&home3, "o/r@feat", "test");
+        run_watchdog(
+            &home3,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
         assert!(
-            crate::inbox::drain(&home2, "lead").is_empty(),
-            "a read handoff means the reviewer acted — no escalation"
+            crate::inbox::drain(&home3, "lead").is_empty(),
+            "#1888: a RESOLVED handoff must not escalate"
         );
         std::fs::remove_dir_all(home).ok();
         std::fs::remove_dir_all(home2).ok();
+        std::fs::remove_dir_all(home3).ok();
     }
 
     #[test]
@@ -459,6 +510,41 @@ mod tests {
         std::fs::remove_dir_all(home).ok();
     }
 
+    /// #1888 phase-2: the 24h backstop — a track whose resolution signal never
+    /// arrives is swept at scan start (WARN) and neither re-nudges nor
+    /// escalates. Guarantees "never re-nudge forever".
+    #[test]
+    fn backstop_expired_track_swept_no_nudge_no_escalation_1888() {
+        let home = tmp_home("backstop");
+        write_fleet(&home);
+        seed_snapshot(&home, "reviewer", "idle");
+        crate::daemon::ci_handoff_track::record(
+            &home,
+            "reviewer",
+            "o/r@abandoned",
+            &(chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339(),
+        );
+        let nudged = run_watchdog(
+            &home,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
+        assert!(
+            !nudged.contains(&"reviewer".to_string()),
+            "#1888: an expired track must not re-nudge"
+        );
+        assert!(
+            crate::inbox::drain(&home, "lead").is_empty(),
+            "#1888: an expired track must not escalate"
+        );
+        assert!(
+            crate::daemon::ci_handoff_track::list(&home).is_empty(),
+            "#1888: the expired track is swept"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
     #[test]
     fn stale_entry_reaped_when_handoff_no_longer_pending() {
         let home = tmp_home("reap");
@@ -472,10 +558,12 @@ mod tests {
             last.contains_key(&("reviewer".to_string(), "o/r@gone".to_string())),
             "first scan must record a dedup entry for the escalated handoff"
         );
-        // Reviewer reads/resolves it → the handoff leaves the unread scan. The
-        // next scan must reap the now-stale (reviewer, o/r@gone) entry rather
-        // than accumulating one per dead branch forever (the leak).
-        crate::inbox::drain(&home, "reviewer");
+        // Reviewer RESOLVES it (verdict report / claim / PR terminal) → the
+        // track is gone. The next scan must reap the now-stale
+        // (reviewer, o/r@gone) entry rather than accumulating one per dead
+        // branch forever (the leak). (#1888 phase-2: a mere READ no longer
+        // ends the handoff — resolution does.)
+        crate::daemon::ci_handoff_track::resolve_by_correlation(&home, "o/r@gone", "test");
         run_watchdog(
             &home,
             &(now + chrono::Duration::minutes(1)),
@@ -559,7 +647,7 @@ mod tests {
     /// re-nudge again (idempotent via `last_renudged`); once the target reads the
     /// handoff it stops AND the dedup entry is reaped (no leak).
     #[test]
-    fn renudge_is_interval_gated_and_stops_when_read() {
+    fn renudge_interval_gated_read_does_not_stop_resolution_does_1888() {
         let home = tmp_home("renudge-interval");
         write_fleet(&home);
         seed_handoff(&home, "reviewer", "o/r@feat", 15, false);
@@ -585,7 +673,10 @@ mod tests {
             "a re-nudge within RENUDGE_INTERVAL_MINS must be suppressed (anti-storm): {soon:?}"
         );
 
-        // Reviewer reads it → no more re-nudge, and the dedup entry is reaped.
+        // #1888 phase-2 CORE regression (read-then-not-act, the stranded-PR
+        // case): the reviewer DRAINS its inbox (marks the handoff read) but
+        // does NOT act — the re-nudge must keep firing. Pre-fix this went
+        // permanently silent (production: 14 reads @ 2-7s, 0 decisions).
         crate::inbox::drain(&home, "reviewer");
         let after_read = run_watchdog(
             &home,
@@ -594,12 +685,26 @@ mod tests {
             &mut renudged,
         );
         assert!(
-            !after_read.contains(&"reviewer".to_string()),
-            "a read handoff must not be re-nudged"
+            after_read.contains(&"reviewer".to_string()),
+            "#1888: a read-but-unresolved handoff must STILL be re-nudged"
+        );
+
+        // RESOLUTION (verdict report / branch claim / PR terminal) stops the
+        // re-nudge and the dedup entry is reaped — never re-nudge forever.
+        crate::daemon::ci_handoff_track::resolve_by_correlation(&home, "o/r@feat", "test");
+        let after_resolve = run_watchdog(
+            &home,
+            &(now + chrono::Duration::minutes(20)),
+            &mut HashMap::new(),
+            &mut renudged,
+        );
+        assert!(
+            !after_resolve.contains(&"reviewer".to_string()),
+            "#1888: a resolved handoff must not be re-nudged"
         );
         assert!(
             renudged.is_empty(),
-            "last_renudged must be reaped once the handoff is read: {:?}",
+            "last_renudged must be reaped once the handoff is resolved: {:?}",
             renudged.keys().collect::<Vec<_>>()
         );
         std::fs::remove_dir_all(home).ok();

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod anti_stall;
 pub(crate) mod auto_release;
 pub(crate) mod boot_sweep;
 pub(crate) mod canonical_drift;
+pub(crate) mod ci_handoff_track;
 pub(crate) mod ci_watch;
 pub(crate) mod conflict_notify;
 mod crash_respawn;

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -323,6 +323,19 @@ pub fn scan_and_emit_with(
                 record_terminal_emitted(home, k);
             }
         }
+        // #1888 phase-2: a PR reaching a terminal state (merged / closed)
+        // resolves any pending ci-handoff track for it — the review obligation
+        // is gone, the re-nudge stops. Post-flock (file delete, no locks) and
+        // keyed on the snapshot's terminal state (NOT `emitted_terminal`) so a
+        // replay-suppressed terminal still cleans a lingering track. Idempotent
+        // — usually the reviewer's verdict report already resolved it.
+        if terminal_ledger_key.is_some() {
+            let _ = crate::daemon::ci_handoff_track::resolve_by_correlation(
+                home,
+                &format!("{repo}@{branch}"),
+                "pr_terminal",
+            );
+        }
         let _ = registry; // reserved for future gh-poll author lookup hook
     }
 }

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -27,7 +27,6 @@ pub use disk::{check_disk_space, recover_half_writes};
 pub use storage::{
     clear_compact, describe_message, drain, enqueue, find_message, get_thread,
     has_drained_blocker_for_correlation, mark_ci_watch_superseded, sweep_expired, unread_count,
-    unread_of_kind,
 };
 // Storage CRUD (pub(crate))
 pub(crate) use storage::inbox_path_resolved;

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -349,12 +349,13 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
                 budget_used += sz;
                 msg.read_at = Some(now.clone());
                 changed = true;
-                // #1888 instrument-only (zero-behavior): a `ci-ready-for-action`
-                // handoff just transitioned to read on this drain. After this, the
-                // handoff_timeout_watchdog's `unread_of_kind` scan can no longer
-                // find it → it can never re-nudge (the #1860 read-state-coupling
-                // RCA). This trace lets production confirm "read before acted" for a
-                // stranded PR. Read-only — the read-marking above is unchanged.
+                // #1888: a `ci-ready-for-action` handoff just transitioned to
+                // read on this drain. Phase-1 this trace PROVED the read-state
+                // coupling (production: every handoff read within seconds, the
+                // watchdog blind). Phase-2 the watchdog scans the
+                // `ci_handoff_track` sidecar instead, so this read no longer
+                // blinds anything — the trace stays as the read-vs-resolution
+                // timeline marker. Read-only — the read-marking is unchanged.
                 if msg.kind.as_deref() == Some("ci-ready-for-action") {
                     let age_at_read_secs = chrono::DateTime::parse_from_rfc3339(&msg.timestamp)
                         .ok()
@@ -720,33 +721,6 @@ pub fn unread_count(home: &Path, name: &str) -> (usize, Option<chrono::DateTime<
         }
     }
     (count, oldest)
-}
-
-/// #1491: unread messages of a given `kind` in `name`'s inbox, returned as
-/// `(correlation_id, timestamp)`. Used by the handoff-timeout watchdog to find
-/// `ci-ready-for-action` handoffs an agent received but never read. Messages
-/// with an unparseable timestamp are skipped.
-pub fn unread_of_kind(
-    home: &Path,
-    name: &str,
-    kind: &str,
-) -> Vec<(Option<String>, chrono::DateTime<chrono::Utc>)> {
-    let path = inbox_path_resolved(home, name);
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return Vec::new();
-    };
-    let mut out = Vec::new();
-    for line in content.lines() {
-        let Ok(msg) = serde_json::from_str::<InboxMessage>(line) else {
-            continue;
-        };
-        if msg.read_at.is_none() && msg.kind.as_deref() == Some(kind) {
-            if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&msg.timestamp) {
-                out.push((msg.correlation_id.clone(), ts.with_timezone(&chrono::Utc)));
-            }
-        }
-    }
-    out
 }
 
 /// Sweep expired messages from all inbox files (#inbox-gc part b).


### PR DESCRIPTION
Phase-2 of #1888 (lead task t-20260610112124690492-7; phase-1 instrument = #1889, already merged). Production evidence (2026-06-10 full-day readout, adopted by lead in place of waiting for the next stranded PR): **14 `#1888-ciready-read` events ALL at age 2-7s : 0 `#1888-renudge-decision` events** — any inbox drain is kind-blind and extinguished the handoff within seconds, so the 2-min re-nudge window never once opened. Delivery worked only when the reviewer happened to act on the wake itself; a drain-without-act stranded the PR until manual dispatch.

## Fix — scan a correlation-keyed sidecar, never read-state (mirrors #1866 pending-dispatches)
- **New `daemon/ci_handoff_track`**: one file per `(target, correlation)` under `<home>/ci-handoff-tracks/`, **recorded** when the poller enqueues the `[ci-ready-for-action]` handoff (fresh CI pass on the same branch refreshes the age anchor). Lock-free by design: every op is whole-file write or delete; a resolution racing a fresh record correctly leaves the new episode tracked.
- **Resolution signals (clear-on-resolution)**:
  1. `kind=report` with the track's correlation (reviewer verdicts carry `repo@branch`) — at the messaging report-arrival chokepoint, same spot as `dispatch_idle::mark_resolved`
  2. PR terminal state (merged / closed-unmerged) — pr_state scanner, post-flock, keyed on the snapshot terminal so replay-suppressed terminals still clean up
  3. the **target** claiming the branch — `bind_full` (single binding chokepoint), scoped to the target's own tracks
  4. **24h backstop sweep** (WARN) at scan start — never re-nudge forever (the lead escalation fired long before)
- **Watchdog** scans tracks; every gate preserved (2-min age, busy, per-key interval, #1859 per-scan target collapse, lead escalation + #1923-G11 ghost-recipient guard, #1598 dedup reaping now keyed on track-active). Pointer count = pending tracks (the message may already be read). The `#1888-renudge-decision` tag is kept for log continuity (`unread_found` → `track_pending`).
- `inbox::unread_of_kind` removed (this was its only caller); the `#1888-ciready-read` drain trace stays as the read-vs-resolution timeline marker.

## Task edge-case checklist
- **read-then-not-act (the stranded case)** → still re-nudges AND still escalates — both contracts flipped from read-extinguishes, regression-tested
- **claim/report of the correlation** → re-nudge stops, dedup maps reaped (no forever)
- **pickup-and-act** → no extra nudge: the verdict report (or the in-review busy gate before it) resolves/suppresses within the first interval
- **busy-gate interplay** → untouched — same per-tick `agent_is_busy` snapshot, same #1859 collapse

## Tests
Store: roundtrip/refresh · resolve-by-correlation (all targets) · resolve-claimed (target+branch scoped) · 24h + broken-track sweep. Watchdog: **read-then-not-act still re-nudges / still escalates; resolution stops both + reaps**; backstop expired track (no nudge, no escalation, swept); existing gate/collapse/escalation/orchestrator tests migrated by seeding tracks alongside messages (production parity — the poller writes both).

`cargo fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · bins **3591 passed / 1 failed** — the 1 failure is the known `dispatch_branch_..._1834` git-shim environmental false-fail; per the task instruction it passes with `AGEND_GIT_BYPASS=1` (verified).

Closes #1888. Refs #1889, #1866, #1859, #1860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)