### PR TITLE
deps(#1934): coordinated RustCrypto upgrade — sha2 0.11 + hmac 0.13 + digest 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "crossterm 0.28.1",
  "ctor",
  "ctrlc",
+ "digest 0.11.3",
  "dirs",
  "dunce",
  "embed-resource",
@@ -52,7 +53,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "serial_test",
- "sha2",
+ "sha2 0.11.0",
  "syn 2.0.117",
  "sysinfo",
  "tao",
@@ -358,6 +359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +635,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -694,6 +716,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -794,6 +825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +862,15 @@ dependencies = [
  "dispatch2",
  "nix 0.31.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -946,9 +995,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1773,11 +1833,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1827,6 +1887,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3034,7 +3103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4171,8 +4240,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4631,7 +4711,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf 0.11.3",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
@@ -5577,7 +5657,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,10 +101,16 @@ memchr = "2"
 # SHA-256 crypto-grade hash + hex encoding so reviewers can correlate an
 # event's response_hash against an archived GitHub API response without
 # trusting a non-crypto hash to be collision-resistant.
-sha2 = "0.10"
+# #1934: coordinated RustCrypto upgrade — hmac 0.13 requires `D: EagerHash`,
+# which sha2 0.10's Sha256 does not implement (why dependabot's single-crate
+# bump #1926 failed); sha2 0.11 + digest 0.11 + hmac 0.13 move together.
+sha2 = "0.11"
 # #1576: HMAC-SHA256 keyed-hash integrity for the operator-mode authority file
 # (single-user injection-containment defense-in-depth — pairs with sha2 above).
-hmac = "0.12"
+hmac = "0.13"
+# #1934: explicit digest pin so the trait crate the hmac/sha2 pair resolve
+# against is visible (and bumps with them, not via transitive drift).
+digest = "0.11"
 hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"

--- a/src/config_integrity.rs
+++ b/src/config_integrity.rs
@@ -21,7 +21,10 @@
 //! as a hex sidecar next to the file. No key rotation, no asymmetric crypto, no
 //! nonces — none of which a single-user threat model needs.
 
-use hmac::{Hmac, Mac};
+// #1934 (hmac 0.13): `new_from_slice` moved behind the explicit `KeyInit`
+// trait import (no longer implied by `Mac`). Construction + tag semantics are
+// unchanged — pinned by the cross-version fixture test.
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 use std::path::Path;
 

--- a/src/daemon/utils.rs
+++ b/src/daemon/utils.rs
@@ -46,7 +46,9 @@ pub fn strip_html_comments(body: &str) -> String {
 pub fn sha256_hex(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    // #1934 (digest 0.11): the output array no longer implements LowerHex —
+    // hex::encode produces the identical lowercase hex (known-answer pinned).
+    hex::encode(hasher.finalize())
 }
 
 #[cfg(test)]
@@ -64,6 +66,17 @@ mod tests {
     #[test]
     fn strip_html_comments_no_comments() {
         assert_eq!(strip_html_comments("plain text"), "plain text");
+    }
+
+    /// #1934 cross-version pin: known-answer test (FIPS 180-4 vector via
+    /// python hashlib) — the digest must be byte-identical across the
+    /// sha2 0.10→0.11 upgrade.
+    #[test]
+    fn sha256_hex_known_answer_1934() {
+        assert_eq!(
+            sha256_hex(b"hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
     }
 
     #[test]

--- a/src/integrity_core.rs
+++ b/src/integrity_core.rs
@@ -11,7 +11,10 @@
 //! Threat model is documented in `config_integrity` (the signer): same-uid
 //! injection-containment defense-in-depth, NOT a security boundary.
 
-use hmac::{Hmac, Mac};
+// #1934 (hmac 0.13): `new_from_slice` moved behind the explicit `KeyInit`
+// trait import (no longer implied by `Mac`). Construction + tag semantics are
+// unchanged — pinned by the cross-version fixture test.
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 use std::path::{Path, PathBuf};
 
@@ -58,4 +61,34 @@ pub(crate) fn sign_for_test(home: &Path, content: &[u8]) -> String {
     let mut mac = HmacSha256::new_from_slice(&key).expect("HMAC accepts any key length");
     mac.update(content);
     hex::encode(mac.finalize().into_bytes())
+}
+
+/// #1934 cross-version pin: the HMAC-SHA256 output must be byte-identical
+/// across the RustCrypto stack upgrade (hmac 0.12→0.13, sha2 0.10→0.11,
+/// digest →0.11). The expected tag was generated BEFORE the upgrade and
+/// cross-checked against an independent implementation (python hmac/hashlib)
+/// — a tag change would silently invalidate every existing integrity sidecar
+/// (#1576 fail-closed: all configs would read "not authentic" after deploy).
+#[cfg(test)]
+mod cross_version_pin_1934 {
+    use super::*;
+    use hmac::Mac;
+
+    #[test]
+    fn hmac_sha256_tag_is_stable_across_stack_upgrade() {
+        const KEY: &[u8] = b"agend-1934-cross-version-fixture-key";
+        const CONTENT: &[u8] =
+            b"agend-1934 fixture content: integrity_core HMAC-SHA256 cross-version pin";
+        // Generated on hmac 0.12.1 + sha2 0.10.9 (pre-upgrade), matches
+        // python3 hmac.new(KEY, CONTENT, hashlib.sha256).hexdigest().
+        const EXPECTED: &str = "80af9c21c0615da7849c54f1ba3ff9572061ac329d5f56455406b9317e8cc3fb";
+        let mut mac = HmacSha256::new_from_slice(KEY).expect("HMAC accepts any key length");
+        mac.update(CONTENT);
+        assert_eq!(
+            hex::encode(mac.finalize().into_bytes()),
+            EXPECTED,
+            "#1934: HMAC output changed across the RustCrypto upgrade — every \
+             existing integrity sidecar would fail closed"
+        );
+    }
 }


### PR DESCRIPTION
Lead task (reviewer-3 scoped, lead fact-checked). The three crates move together: **hmac 0.13 requires `D: EagerHash`, which sha2 0.10's Sha256 doesn't implement** — why dependabot's single-crate bump (#1926) failed. `digest 0.11` added explicitly so the trait crate is visible, not transitive drift.

## Cross-version output identity (the mandated sequence, security-critical)
`integrity_core` (#1576) / `config_integrity` sidecars **fail closed** — a tag change would silently invalidate every existing sidecar on deploy.
1. **Fixture generated BEFORE the upgrade** and cross-checked against an independent implementation (python `hmac`/`hashlib`) — not self-circular on the new stack.
2. Pin test passed on the pre-upgrade stack (hmac 0.12.1 + sha2 0.10.9) first.
3. Upgraded stack produces the **byte-identical tag** (assert green). The pin compiles into **both binaries** (`integrity_core` is `#[path]`-shared with `agend-git`).
4. `sha256_hex` gains a FIPS known-answer pin — identical across the bump.

## Call-site delta (mechanical; semantics unchanged, proven by the pins)
- hmac 0.13: `new_from_slice` now needs the explicit `KeyInit` import (no longer implied by `Mac`) — `integrity_core.rs` + `config_integrity.rs` (the 14-site/4-file scope's signer paths)
- digest 0.11: output array drops `LowerHex` — `daemon/utils.rs::sha256_hex` → `hex::encode` (same lowercase hex)
- `skills.rs:478` (`Sha256::digest`) — no change needed

(Flagging per the task's query-first rule: these import/formatting deltas slightly exceed the "no call-site change" expectation but are textbook minor-version churn with output identity pinned — judged below the query threshold; here for the reviewer to veto.)

## Lockfile
`sha2 0.10.9` remains as the private copy of transitive deps (`pest_meta` / `termwiz` / `wezterm-blob-leases`) — expected coexistence; the app crate resolves `sha2 0.11.0` / `hmac 0.13.0` / `digest 0.11.3`. `agend-git` shares this workspace Cargo.lock; `cargo check --bin agend-git` clean.

`cargo fmt --check` ✓ · `clippy --all-targets --features tray -D warnings` ✓ · bins **3589 passed / 1 failed** (the known `dispatch_branch_..._1834` git-shim environmental; passes with `AGEND_GIT_BYPASS=1` per the task instruction).

Closes #1934. Refs #1926, #1576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)