### PR TITLE
fix(#1963): close ci_handoff_track record-vs-remove TOCTOU (per-key lock + atomic write)

### DIFF
--- a/src/daemon/ci_handoff_track.rs
+++ b/src/daemon/ci_handoff_track.rs
@@ -23,10 +23,30 @@
 //!     whose resolution signal never arrives must not re-nudge forever).
 //!
 //! Mirrors the `pending-dispatches` file-per-entry sidecar pattern (#1866).
-//! No per-file locks: every operation is a whole-file write or a delete (no
-//! read-modify-write), and the worst interleaving — a resolution racing a
-//! fresh `record` for the same correlation (a new CI pass) — correctly leaves
-//! the new episode tracked.
+//!
+//! ## #1963 concurrency hardening (per-key lock + atomic write)
+//! #1888 originally took NO per-file locks, on the theory that whole-file
+//! write/delete with no read-modify-write was race-free. The #1960 review found
+//! a real (rare, non-blocking, no-data-loss) TOCTOU: `resolve`/`sweep` did
+//! `list()` then `remove_file(path)`, so a `record` re-recording the SAME key
+//! (a new CI pass) BETWEEN the list and the remove had its fresh track deleted
+//! → that episode's re-nudge + escalation were lost. #1963 closes it two ways.
+//!
+//! `record` is now an ATOMIC write (`write(<key>.json.tmp)` → `rename`); rename
+//! is atomic on one filesystem, so the lock-free `list()` (every watchdog tick)
+//! and `resolve`'s re-read never observe a half-written track (closes the
+//! torn-read skip). And every deleter (`resolve_*`, `sweep_expired`) deletes
+//! UNDER a per-key `<key>.lock` after re-reading and confirming the on-disk
+//! `sent_at` still matches the episode it listed (delete-if-unchanged). `record`
+//! takes the SAME per-key lock around its atomic write, so a `record` cannot
+//! interleave between a deleter's re-read and its remove → no TOCTOU, no new race.
+//!
+//! The lock is a SEPARATE `<key>.lock` sidecar (NOT the track file): the atomic
+//! write renames the track's inode, so a flock on the track file itself would be
+//! silently lost across the rename. `list()` stays lock-free read-only (the
+//! atomic write is what guarantees it never torn-reads). Track count is tiny
+//! (in-flight CI handoffs), the lock hold is a single file op, so the per-tick
+//! sweep's per-track acquire/release is negligible.
 
 use std::path::{Path, PathBuf};
 
@@ -73,6 +93,61 @@ fn file_for(home: &Path, target: &str, correlation: &str) -> PathBuf {
     ))
 }
 
+/// #1963: per-key lock sidecar — a SEPARATE file from the track. `record`'s
+/// atomic write renames the track's inode, so a flock taken on the track file
+/// itself would be silently lost across the rename. The `.lock` suffix also
+/// keeps it out of `list()` (which filters to the `.json` extension).
+fn lock_for(home: &Path, target: &str, correlation: &str) -> PathBuf {
+    let track = file_for(home, target, correlation);
+    let mut name = track
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    name.push(".lock");
+    track.with_file_name(name)
+}
+
+/// #1963: atomic whole-file write (write a sibling `.tmp`, then `rename` over the
+/// target). `rename` is atomic on one filesystem, so the lock-free `list()` and
+/// `resolve`'s re-read never observe a half-written track. The caller holds the
+/// per-key lock, so the fixed `.tmp` name can't collide with a concurrent
+/// `record` of the same key. The `.tmp` extension keeps a crash-leftover out of
+/// `list()`; the next `record` overwrites it.
+fn atomic_write_track(path: &Path, track: &CiHandoffTrack) -> std::io::Result<()> {
+    let mut tmp_name = path
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    tmp_name.push(".tmp");
+    let tmp = path.with_file_name(tmp_name);
+    std::fs::write(&tmp, serde_json::to_vec(track).unwrap_or_default())?;
+    std::fs::rename(&tmp, path)
+}
+
+/// #1963: delete the `(target, correlation)` track ONLY if its on-disk `sent_at`
+/// still equals `expect_sent_at` — i.e. it is the same episode the caller listed,
+/// not a newer one a concurrent `record` re-wrote (a new CI pass restarts the age
+/// anchor → a new `sent_at`). The re-read AND the remove run UNDER the per-key
+/// lock that `record` also takes, so a `record` cannot interleave between them →
+/// no TOCTOU. Returns true iff a matching track was removed. Lock-acquire failure
+/// → `false` (skip the delete rather than risk an unsynchronized one — a missed
+/// resolution just leaves the track for the next signal / 24h backstop).
+fn remove_if_unchanged(home: &Path, target: &str, correlation: &str, expect_sent_at: &str) -> bool {
+    let Ok(_lock) = crate::store::acquire_file_lock(&lock_for(home, target, correlation)) else {
+        return false;
+    };
+    let path = file_for(home, target, correlation);
+    let current = std::fs::read(&path)
+        .ok()
+        .and_then(|b| serde_json::from_slice::<CiHandoffTrack>(&b).ok());
+    match current {
+        Some(t) if t.sent_at == expect_sent_at => std::fs::remove_file(&path).is_ok(),
+        // re-recorded (new sent_at) / torn / absent → leave it (the fresh episode
+        // must keep its track; a torn read self-heals on the next tick).
+        _ => false,
+    }
+}
+
 /// Record (or refresh — a NEW CI pass on the same branch restarts the age
 /// anchor) the pending handoff for `(target, correlation)`.
 pub(crate) fn record(home: &Path, target: &str, correlation: &str, sent_at: &str) {
@@ -83,9 +158,16 @@ pub(crate) fn record(home: &Path, target: &str, correlation: &str, sent_at: &str
         sent_at: sent_at.to_string(),
     };
     let path = file_for(home, target, correlation);
-    if let Err(e) = std::fs::create_dir_all(dir(home))
-        .and_then(|()| std::fs::write(&path, serde_json::to_vec(&track).unwrap_or_default()))
-    {
+    if let Err(e) = std::fs::create_dir_all(dir(home)) {
+        tracing::warn!(%target, %correlation, error = %e, "#1888: ci-handoff track dir create failed");
+        return;
+    }
+    // #1963: take the per-key lock so this write is atomic w.r.t. a concurrent
+    // resolve/sweep of the same key (delete-if-unchanged) — the resolution can't
+    // delete this fresh episode mid-write. Lock-acquire failure → degrade to an
+    // unlocked atomic write (rare fs error; still torn-read-safe via rename).
+    let _lock = crate::store::acquire_file_lock(&lock_for(home, target, correlation)).ok();
+    if let Err(e) = atomic_write_track(&path, &track) {
         tracing::warn!(%target, %correlation, error = %e, "#1888: ci-handoff track write failed");
         return;
     }
@@ -125,7 +207,7 @@ pub(crate) fn resolve_by_correlation(home: &Path, correlation: &str, reason: &st
     let mut resolved = 0;
     for track in list(home) {
         if track.correlation == correlation
-            && std::fs::remove_file(file_for(home, &track.target, &track.correlation)).is_ok()
+            && remove_if_unchanged(home, &track.target, &track.correlation, &track.sent_at)
         {
             resolved += 1;
             tracing::info!(
@@ -149,7 +231,7 @@ pub(crate) fn resolve_claimed(home: &Path, agent: &str, branch: &str) -> usize {
     for track in list(home) {
         if track.target == agent
             && track.correlation.ends_with(&suffix)
-            && std::fs::remove_file(file_for(home, &track.target, &track.correlation)).is_ok()
+            && remove_if_unchanged(home, &track.target, &track.correlation, &track.sent_at)
         {
             resolved += 1;
             tracing::info!(
@@ -175,9 +257,7 @@ pub(crate) fn sweep_expired(home: &Path, now: &chrono::DateTime<chrono::Utc>) ->
             // Unparseable sent_at → treat as expired (a broken track must not
             // re-nudge forever either).
             .unwrap_or(true);
-        if expired
-            && std::fs::remove_file(file_for(home, &track.target, &track.correlation)).is_ok()
-        {
+        if expired && remove_if_unchanged(home, &track.target, &track.correlation, &track.sent_at) {
             swept += 1;
             tracing::warn!(
                 tag = "#1888-track-expired",
@@ -264,6 +344,75 @@ mod tests {
         let left = list(&home);
         assert_eq!(left.len(), 1);
         assert_eq!(left[0].correlation, "o/r@fresh");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1963: the record-vs-remove TOCTOU fix. A deleter that LISTED an old
+    /// episode (sent_at S1) must NOT delete a track a concurrent `record`
+    /// re-wrote to a NEW episode (S2) — `remove_if_unchanged` re-reads under the
+    /// per-key lock and only deletes when the on-disk `sent_at` still matches what
+    /// was listed. Models the #1960 race (list sees S1, record writes S2, remove)
+    /// at the exact decision point.
+    #[test]
+    fn remove_if_unchanged_refuses_stale_delete_1963() {
+        let home = tmp_home("cas");
+        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z");
+        // Same episode → delete succeeds.
+        assert!(remove_if_unchanged(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T00:00:00Z"
+        ));
+        assert!(
+            list(&home).is_empty(),
+            "a matching-sent_at delete removes the track"
+        );
+
+        // Re-record a NEW episode (new sent_at = a new CI pass), then a deleter
+        // carrying the STALE listed sent_at must NOT delete it (the race).
+        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z"); // S1
+        record(&home, "reviewer", "o/r@b", "2026-06-10T09:00:00Z"); // S2
+        assert!(
+            !remove_if_unchanged(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z"),
+            "#1963: a delete carrying the STALE listed sent_at must be refused"
+        );
+        let tracks = list(&home);
+        assert_eq!(tracks.len(), 1, "the fresh episode's track must survive");
+        assert_eq!(
+            tracks[0].sent_at, "2026-06-10T09:00:00Z",
+            "the SURVIVING track is the new episode (S2)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #1963: `record` writes atomically (tmp→rename) and the `.lock` / `.tmp`
+    /// sidecars are invisible to `list()` — so the lock-free watchdog scan never
+    /// sees a partial track or a stray sidecar. The torn-read self-heal is
+    /// structural: a reader sees either the old or the new COMPLETE track, never a
+    /// half-write (so a torn read can't even occur).
+    #[test]
+    fn atomic_write_and_sidecars_excluded_from_list_1963() {
+        let home = tmp_home("atomic");
+        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z");
+        let tracks = list(&home);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].correlation, "o/r@b");
+        // The per-key lock sidecar exists (record took the lock) but is NOT a track.
+        assert!(
+            lock_for(&home, "reviewer", "o/r@b").exists(),
+            "per-key lock sidecar present"
+        );
+        // A stray `.tmp` (simulating a crash mid-write) must be ignored by list().
+        let track = file_for(&home, "reviewer", "o/r@b");
+        let mut tmp_name = track.file_name().unwrap().to_os_string();
+        tmp_name.push(".tmp");
+        std::fs::write(track.with_file_name(tmp_name), b"{partial").unwrap();
+        assert_eq!(
+            list(&home).len(),
+            1,
+            "#1963: .tmp / .lock sidecars must not appear as tracks"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Problem (#1963 — followup to the #1960 review)

The #1960 review surfaced a rare (non-blocking, no-data-loss) TOCTOU in the #1888 ci-handoff sidecar: `resolve`/`sweep` did `list()` then `remove_file(path)`, so a `record` re-recording the **same key** (a new CI pass) **between** the list and the remove had its fresh track deleted → that episode's re-nudge **and** escalation were lost (only the daemon-side safety net — the inbox `[ci-ready-for-action]` message itself is enqueued separately and never lost). Lead-approved hardening, direction **(A) per-key flock + delete-if-unchanged**.

## Fix (both in `ci_handoff_track`)

1. **`record` → atomic write** (`write(<key>.json.tmp)` → `rename`). `rename` is atomic on one filesystem, so the lock-free `list()` (every watchdog tick) and `resolve`'s re-read never observe a half-written track — **closes the torn-read one-tick skip structurally** (a reader sees old-or-new *complete*, never partial).

2. **every deleter** (`resolve_by_correlation` / `resolve_claimed` / `sweep_expired`) routes through **`remove_if_unchanged`**: UNDER a per-key `<key>.lock`, re-read the track and delete **only if its on-disk `sent_at` still matches the episode it listed** (delete-if-unchanged). `record` takes the **same** per-key lock around its atomic write, so a `record` **cannot interleave** between a deleter's re-read and its remove → the TOCTOU is **closed with no new race** (no residual re-read→remove window).

### Why these choices
- **Lock is a separate `<key>.lock` sidecar, NOT the track file** — the atomic write renames the track's inode, so a flock on the track file itself would be silently lost across the rename.
- **`list()` stays lock-free read-only** (the atomic write is what makes it torn-read-safe).
- Reuses the existing `crate::store::acquire_file_lock` idiom (same as dispatch_idle's RMW). Track count is tiny (in-flight CI handoffs), lock hold = one file op → per-tick sweep's per-track lock is negligible.
- **`rename-claim` was rejected** (restore-on-mismatch can overwrite a newer `record` → resurrect a stale episode = a new corner).
- The #1960 **4 resolution signals (report / claim / PR-terminal / 24h) are unchanged** — only record/resolve atomicity is strengthened.

## Tests
- `remove_if_unchanged_refuses_stale_delete_1963`: a delete carrying the **stale listed `sent_at`** is refused → the re-recorded fresh episode survives (the exact #1960 race at its decision point).
- `atomic_write_and_sidecars_excluded_from_list_1963`: `.tmp`/`.lock` sidecars invisible to `list()`; atomic write leaves no torn state.
- All existing ci_handoff_track + handoff_timeout_watchdog tests still green (the resolve/sweep consumers).

## Verification
fmt + clippy (`--features tray -D warnings`) + full nextest all green (`AGEND_GIT_BYPASS=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)