### PR TITLE
fix(crash-budget): surface escalation persist failures (Phase A hardening)

### DIFF
--- a/src/daemon/escalation_persist.rs
+++ b/src/daemon/escalation_persist.rs
@@ -48,16 +48,45 @@ fn store_file(home: &Path) -> std::path::PathBuf {
     store::store_path(home, STORE_FILE)
 }
 
+/// Once-per-boot latch for the operator-visible persist-failure event. The
+/// hang-detection tick calls `persist` repeatedly, so a sustained failure
+/// (disk full / permissions) would otherwise spam one event per tick; one
+/// event per daemon boot is the right cadence (and the latch resetting on
+/// restart is exactly when re-alerting is wanted — the failure either healed
+/// or is still there).
+static PERSIST_FAILURE_EVENT_EMITTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Persist (insert/replace) one agent's escalation snapshot. Best-effort: a
-/// write failure logs and is swallowed — escalation persistence must never block
-/// the crash/hung hot path.
+/// write failure must never block the crash/hung hot path — but it is NOT
+/// silent (Phase-A hardening): the crash budget + cooldown (#1744-H2) are the
+/// guard against a respawn storm, and losing this write means a daemon
+/// restart rehydrates a zeroed budget and re-allows crashes it should have
+/// blocked. Failures log at ERROR (every occurrence — greppable during a
+/// disk-full episode) and emit one operator-visible `event_log` entry per
+/// boot.
 pub(crate) fn persist(home: &Path, name: &str, snapshot: &PersistedEscalation) {
     let path = store_file(home);
     if let Err(e) = store::mutate_versioned::<EscalationStore, _, _>(&path, |s| {
         s.agents.insert(name.to_string(), snapshot.clone());
         Ok(())
     }) {
-        tracing::warn!(agent = %name, error = %e, "escalation_persist: write failed");
+        tracing::error!(
+            agent = %name,
+            error = %e,
+            "escalation_persist: write FAILED — crash budget/cooldown will NOT survive a daemon restart (respawn-storm guard disarmed across restarts until this heals)"
+        );
+        if !PERSIST_FAILURE_EVENT_EMITTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            crate::event_log::log(
+                home,
+                "escalation_persist_failed",
+                name,
+                &format!(
+                    "crash-budget/cooldown persist failed (state will not survive a daemon \
+                     restart): {e}. Further failures this boot log at error level only."
+                ),
+            );
+        }
     }
 }
 
@@ -277,5 +306,59 @@ mod tests {
 
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&empty).ok();
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod persist_failure_tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        let home = std::env::temp_dir().join(format!(
+            "agend-escfail-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        home
+    }
+
+    /// Phase-A hardening regression: a persist write failure must SURFACE —
+    /// an operator-visible `escalation_persist_failed` event-log entry (once
+    /// per boot; the error-level tracing fires every occurrence). Failure is
+    /// injected portably by occupying the store FILE path with a DIRECTORY,
+    /// so the versioned write cannot land.
+    #[test]
+    fn persist_failure_emits_operator_event_once_1744h2() {
+        let home = tmp_home("event");
+        // Occupy the store file path with a directory → every write fails.
+        std::fs::create_dir_all(store_file(&home)).unwrap();
+
+        // Latch is process-global: reset for THIS test (tests in one binary
+        // share statics; swap-back keeps other tests honest).
+        PERSIST_FAILURE_EVENT_EMITTED.store(false, std::sync::atomic::Ordering::Relaxed);
+
+        let snap = PersistedEscalation::default();
+        persist(&home, "crashy", &snap);
+
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert!(
+            log.contains("escalation_persist_failed") && log.contains("crashy"),
+            "persist failure must emit the operator-visible event, got: {log}"
+        );
+
+        // Second failure in the same boot: error-log only, no duplicate event.
+        persist(&home, "crashy", &snap);
+        let log2 = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert_eq!(
+            log2.matches("escalation_persist_failed").count(),
+            1,
+            "the event is once-per-boot latched (per-tick callers must not spam)"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
Lead task t-20260610155659194568-1 (Phase A stability hardening, verify-first on the architecture-audit finding at `crash_respawn.rs:119`).

## Verify-first verdict: finding **partially misjudged**
- "unchecked return" is technically wrong: `escalation_persist::persist` returns `()` — there is no discarded `Result` — and the failure **was already logged** (`tracing::warn!`, escalation_persist.rs).
- But the audit's HIGH consequence is real and the surface under-stated it: WARN only, **no operator-visible event**. The crash budget + cooldown (#1744-H2) are the respawn-storm guard; a lost write means a daemon restart rehydrates a zeroed budget and re-allows crashes it should have blocked.

## Hardening (KISS, inside `persist` — one place covers all 4 call sites: crash_respawn x1 + per-tick hang_detection x3)
- **WARN -> ERROR**, message spells out the consequence (budget won't survive a restart; storm guard disarmed across restarts until it heals). Every occurrence logs — greppable during a disk-full episode.
- **One operator-visible `event_log` entry** (`escalation_persist_failed`) **per daemon boot**, latched — the hang-detection tick would otherwise emit one event per tick during a sustained failure. The latch resetting on restart is the right cadence (re-alert exactly when the failure either healed or persisted across the boot). Existing event mechanism, no new channel.
- No retry/recovery machinery (per the task's KISS constraint) — the goal is silent->visible.

## Regression test
Failure injected portably (the store FILE path occupied by a directory -> every versioned write fails): the `escalation_persist_failed` event appears in the event log naming the agent, and a second failure in the same boot does **not** duplicate it (per-tick callers can't spam).

`cargo fmt --check` OK / `clippy --all-targets --features tray -D warnings` OK / bins **3603 passed / 1 failed** (the known `dispatch_branch_..._1834` git-shim environmental; `AGEND_GIT_BYPASS=1` -> passes).

Refs #1744-H2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
