### PR TITLE
fix: bound attached-mode bridge connect so a down daemon can't hang the TUI

### DIFF
--- a/src/bridge_client.rs
+++ b/src/bridge_client.rs
@@ -16,8 +16,21 @@
 use anyhow::{Context, Result};
 use std::net::TcpStream;
 use std::path::Path;
+use std::time::Duration;
 
 use crate::framing;
+
+/// Bounded connect timeout for the attached-mode bridge. A crashed / wedged
+/// daemon whose port file lingers would otherwise hang `connect` (and the 2s
+/// agent-roster sync loop that calls it) on the OS-default connect timeout.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+/// Bounded read/write timeout for the cookie/version/resize HANDSHAKE only — a
+/// daemon that ACCEPTS the connection but never sends the version byte (wedged,
+/// not refusing) would otherwise hang the blocking `read_exact`. Restored to
+/// blocking before the streaming phase (the parked reader + input writer must
+/// block). Kept under the 2s sync-loop period (with CONNECT_TIMEOUT) so a down
+/// daemon can't stall the loop.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Open + authenticated TCP bridge to one daemon-hosted agent.
 ///
@@ -41,8 +54,15 @@ impl BridgeClient {
     /// cookie-rejected from version-mismatch apart without the caller having
     /// to peek at the wire.
     pub fn connect(home: &Path, name: &str, cols: u16, rows: u16) -> Result<Self> {
-        let mut stream = crate::ipc::connect_agent(home, name)
+        // Bounded connect: a crashed/wedged daemon whose port file lingers must
+        // not hang the attached-mode 2s sync loop on the OS-default connect.
+        let mut stream = crate::ipc::connect_agent_timeout(home, name, CONNECT_TIMEOUT)
             .with_context(|| format!("connect to agent '{name}'"))?;
+        // Bound the handshake I/O too: a daemon that ACCEPTS but never sends the
+        // version byte (wedged, not refusing) would otherwise hang the blocking
+        // `read_exact` below. Restored to blocking before the streaming phase.
+        let _ = stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT));
+        let _ = stream.set_write_timeout(Some(HANDSHAKE_TIMEOUT));
 
         let run = crate::daemon::find_active_run_dir(home)
             .context("no active daemon (run dir not found)")?;
@@ -61,12 +81,17 @@ impl BridgeClient {
                 framing::PROTOCOL_VERSION
             );
         }
+        framing::write_resize(&mut stream, cols, rows).context("send initial resize")?;
 
+        // Handshake done — restore BLOCKING for the streaming phase. The parked
+        // reader (clone shares the socket) and the input writer must block, not
+        // time out, for the lifetime of the pane.
+        let _ = stream.set_read_timeout(None);
+        let _ = stream.set_write_timeout(None);
         let reader = stream
             .try_clone()
             .context("clone bridge stream for read side")?;
-        let mut writer = stream;
-        framing::write_resize(&mut writer, cols, rows).context("send initial resize")?;
+        let writer = stream;
 
         Ok(Self {
             writer,
@@ -88,5 +113,69 @@ impl BridgeClient {
     /// Send a framed resize event to the agent.
     pub fn send_resize(&mut self, cols: u16, rows: u16) -> std::io::Result<()> {
         framing::write_resize(&mut self.writer, cols, rows)
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::time::Instant;
+
+    /// Regression: a daemon that ACCEPTS the connection but never sends the
+    /// protocol-version byte (wedged, not refusing) must NOT hang
+    /// `BridgeClient::connect` — the handshake read-timeout bounds it so the
+    /// attached-mode 2s agent-roster sync loop can't stall during a daemon crash.
+    /// Before the fix the blocking `read_exact` on the version byte hung forever.
+    #[test]
+    fn connect_against_wedged_daemon_is_bounded_not_hung() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-bridge-timeout-{}-{}",
+            std::process::id(),
+            // a counter keeps parallel runs isolated
+            {
+                use std::sync::atomic::{AtomicU32, Ordering};
+                static C: AtomicU32 = AtomicU32::new(0);
+                C.fetch_add(1, Ordering::Relaxed)
+            }
+        ));
+        let run = crate::daemon::run_dir(&home);
+        std::fs::create_dir_all(&run).unwrap();
+        // Fake an active daemon: .daemon (our live pid) + api.cookie so
+        // `find_active_run_dir` + cookie-read succeed and we reach the handshake.
+        crate::daemon::write_daemon_id(&run);
+        crate::auth_cookie::issue(&run).expect("issue cookie");
+
+        // A listener that ACCEPTS but never writes the version byte → the
+        // handshake read would block forever without the timeout.
+        let listener = TcpListener::bind((crate::ipc::LOOPBACK, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept = std::thread::spawn(move || {
+            // Hold the accepted connection open + silent for longer than the
+            // handshake timeout so the client's read genuinely stalls.
+            if let Ok((conn, _)) = listener.accept() {
+                std::thread::sleep(Duration::from_secs(5));
+                drop(conn);
+            }
+        });
+        crate::ipc::write_port(&run, "wedged-agent", port).unwrap();
+
+        let start = Instant::now();
+        let result = BridgeClient::connect(&home, "wedged-agent", 80, 24);
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_err(),
+            "a wedged daemon (accept-but-silent) must surface as a connect error, not a hang"
+        );
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "connect must be bounded by CONNECT_TIMEOUT + HANDSHAKE_TIMEOUT (~2s), got {elapsed:?} — the sync loop must never hang"
+        );
+
+        drop(accept); // detached; the sleep finishes on its own
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -82,13 +82,25 @@ pub fn connect_run_dir_api(run_dir: &Path) -> Result<TcpStream> {
     connect_port(port).map_err(Into::into)
 }
 
-/// Connect to a named agent's TUI port.
-pub fn connect_agent(home: &Path, name: &str) -> Result<TcpStream> {
+/// Connect to a named agent's TUI port with a bounded connect timeout. A
+/// crashed / wedged daemon whose port file lingers must not hang the caller —
+/// the attached-mode bridge's 2s agent-roster sync loop would otherwise stall
+/// for the OS-default connect timeout while the daemon is down. Resolves the
+/// active run dir + the agent's port file, then connects with `set_nodelay`.
+pub fn connect_agent_timeout(home: &Path, name: &str, timeout: Duration) -> Result<TcpStream> {
     let run =
         crate::daemon::find_active_run_dir(home).context("no active daemon (run dir not found)")?;
     let port = read_port(&run, name)
         .with_context(|| format!("agent '{name}' port file missing or invalid"))?;
-    connect_port(port).map_err(Into::into)
+    connect_port_timeout(port, timeout).map_err(Into::into)
+}
+
+/// Connect a TcpStream to `127.0.0.1:port` with a bounded connect timeout,
+/// applying TCP_NODELAY. The bounded sibling of [`connect_port`].
+fn connect_port_timeout(port: u16, timeout: Duration) -> io::Result<TcpStream> {
+    let stream = TcpStream::connect_timeout(&SocketAddr::from((LOOPBACK, port)), timeout)?;
+    let _ = stream.set_nodelay(true);
+    Ok(stream)
 }
 
 /// Enumerate agent names whose `*.port` files exist in `run`, excluding the


### PR DESCRIPTION
## Problem (Phase A stability)

Attached-mode `create_remote_pane()` → `BridgeClient::connect()` had **no bounded timeout**: `ipc::connect_port` used a plain `TcpStream::connect`, and the post-connect protocol-version `read_exact` was an **unbounded blocking read**. When the daemon is crashed/wedged, `connect` (or the handshake read) blocks — **stalling the attached-mode 2s agent-roster sync loop**, freezing the whole TUI during a daemon crash-recovery window.

**Verified** (finding correct, not misjudged): `connect_port` is plain `TcpStream::connect`; the version `read_exact` has no read timeout; both run synchronously in the 2s sync loop (`app/mod.rs` → `create_remote_pane` → `BridgeClient::connect?`).

## Fix (reusing the existing `connect_timeout` pattern from `ipc::probe_agent`)
- **`ipc::connect_agent_timeout`** (+ `connect_port_timeout`): connect with a **1s `connect_timeout`** so a black-holed SYN fails fast.
- **`BridgeClient::connect`**: 1s read/write timeout on the **handshake only** (cookie/version/resize) — a daemon that *accepts* but never sends the version byte can no longer hang `read_exact`. **Restored to blocking before the streaming phase** (parked reader + input writer must block).

Both ≤2s total, under the 2s sync-loop period.

### Fallback
On timeout/failure `connect` returns `Err` → the sync loop **already** logs+skips+retries, and existing panes are **retained with scrollback** (#1591). So a down daemon degrades to "unavailable, retrying", not a frozen TUI. KISS — no reconnect backoff. Removed the now-orphaned `ipc::connect_agent`.

## Test
`connect_against_wedged_daemon_is_bounded_not_hung`: a faked daemon (run dir + cookie + port) with a listener that accepts-but-never-sends-version → `BridgeClient::connect` returns `Err` in ~1s (bounded), not a hang.

## Verification
fmt + clippy (`--features tray -D warnings`) + full nextest green (`AGEND_GIT_BYPASS=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)