### PR TITLE
docs(session): record the serde recursion-limit depth-safety invariant

### DIFF
--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -521,6 +521,14 @@ fn restore_node_reconciled(
             first,
             second,
         } => {
+            // Depth-safety invariant (no explicit max-depth guard needed):
+            // `apply_session_layout` parses session.json with `serde_json::from_str`,
+            // whose default `recursion_limit` (128) rejects a pathologically deep
+            // document AT PARSE TIME (→ `None` → fleet.yaml rebuild fallback) before
+            // it ever becomes a `SessionNode` tree — so this recursion can never
+            // receive a degenerate depth. If a NON-serde tree-feed path is ever
+            // added, or `disable_recursion_limit` is set anywhere, add an explicit
+            // depth guard here.
             let f = restore_node_reconciled(first, agent_source, pane_builder, layout, placed);
             let s = restore_node_reconciled(second, agent_source, pane_builder, layout, placed);
             match (f, s) {


### PR DESCRIPTION
## Verification result (Phase A audit finding — false alarm)

The audit flagged `src/app/session.rs` session-restore as a panic / deeply-nested-stack-overflow risk. **Verified largely misjudged**:

1. **All flagged `panic!`s are test-only** — `panic!("expected Leaf")` etc. at lines 680/707/733/925/928 are inside `#[cfg(test)] mod tests` (line 541+). The production recursion `restore_node_reconciled` (494) is **panic-free** (`Leaf`/`Split` enum match + `?`/`None` for missing).
2. **Malformed JSON is already graceful** — `apply_session_layout` (374-379) does `read_to_string().ok().and_then(from_str().ok())` → `None` → `return false` → existing fleet.yaml rebuild fallback.
3. **Deeply-nested → no live stack overflow** — `serde_json::from_str` enforces its default `recursion_limit` (128; `disable_recursion_limit` is used nowhere), so a >128-deep session.json is **rejected at parse time** → `None` → fallback. `restore_node_reconciled` therefore never receives a degenerate-depth tree.

So there's no production panic to convert and no live overflow — an explicit max-depth guard would be **error handling for an impossible scenario** (KISS). Lead-approved: skip the guard.

## This PR (comment only, no behavior change)

Records the implicit depth-safety invariant as an in-code comment at the recursion site, so a future dev who adds a **non-serde tree-feed path** or sets `disable_recursion_limit` knows to add an explicit depth guard there. The test-only assertions are intentionally untouched.

## Verification
fmt + clippy clean; 23 session tests green (`AGEND_GIT_BYPASS=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)