### PR TITLE
fix(#1961): pane byte-delta activity signal for the dispatch-idle suppress

### DIFF
--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -687,6 +687,7 @@ mod tests {
                 health_state: "healthy".to_string(),
                 agent_state: "thinking".to_string(),
                 silent_secs: 0,
+                output_silent_secs: 0,
             }],
         );
         home

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -735,6 +735,22 @@ fn target_is_working(
                 a.agent_state.as_str(),
                 "thinking" | "tool_use" | "server_rate_limit"
             ) || a.silent_secs < silence_threshold_secs
+                // #1961 phase-2 (4th OR, fail-toward-suppress): the pane
+                // CONTENT changed within the window (raw screen-hash delta,
+                // `output_silent_secs`) — an activity signal that does NOT
+                // depend on state classification. The production false-fire
+                // had agent_state="idle" (detector mis-read a code-writing
+                // claude 3 scans straight), silent_secs=i64::MAX (productive
+                // markers missed), heartbeat 734s — all three gates slipped
+                // because all three sit on the same fragile classification;
+                // a streaming/working pane keeps changing regardless.
+                // Spinner-vs-hung: a spinner animating = the backend is still
+                // running = dispatch-idle ("you've gone silent, status?")
+                // correctly stays quiet; a genuinely HUNG agent is the
+                // hang_detector's job (productive-silence), not this
+                // watchdog's. Old-format snapshots default the field to MAX →
+                // no suppression (fail-open to firing, same as silent_secs).
+                || a.output_silent_secs < silence_threshold_secs
         })
         .unwrap_or(false);
     if snapshot_working {
@@ -941,8 +957,15 @@ pub(crate) fn scan_and_emit(home: &Path) {
                     .map(|a| a.agent_state.as_str())
                     .unwrap_or("<no-snapshot>"),
                 silent_secs = ?snap_agent.map(|a| a.silent_secs),
-                heartbeat_age_ms = now_ms.saturating_sub(hb.heartbeat_at_ms),
-                last_input_age_ms = now_ms.saturating_sub(hb.last_input_at_ms),
+                output_silent_secs = ?snap_agent.map(|a| a.output_silent_secs),
+                // #1961 phase-2 instrument fix: an unset pair field is 0, and
+                // `now - 0` printed as an "age" reads like an absolute
+                // epoch-ms timestamp (the phase-1 readout confusion). Print
+                // None for never-set instead of a bogus huge age.
+                heartbeat_age_ms = ?(hb.heartbeat_at_ms != 0)
+                    .then(|| now_ms.saturating_sub(hb.heartbeat_at_ms)),
+                last_input_age_ms = ?(hb.last_input_at_ms != 0)
+                    .then(|| now_ms.saturating_sub(hb.last_input_at_ms)),
                 "#1961: dispatch_idle firing — work-aware suppress signals at fire time (diagnose which slipped)"
             );
             emit_exceeded_event(home, &current, elapsed_secs);
@@ -2682,6 +2705,19 @@ mod tests {
         agent_state: &str,
         silent_secs: i64,
     ) -> crate::snapshot::AgentSnapshot {
+        // #1961 phase-2: pane-change signal FAIL-CLOSED (no recent change) in
+        // the legacy fixtures so every pre-existing gate test exercises the
+        // original three signals unchanged; pane-delta tests use
+        // [`mk_agent_snapshot_pane`].
+        mk_agent_snapshot_pane(name, agent_state, silent_secs, i64::MAX)
+    }
+
+    fn mk_agent_snapshot_pane(
+        name: &str,
+        agent_state: &str,
+        silent_secs: i64,
+        output_silent_secs: i64,
+    ) -> crate::snapshot::AgentSnapshot {
         crate::snapshot::AgentSnapshot {
             name: name.to_string(),
             backend_command: "opencode".to_string(),
@@ -2691,7 +2727,64 @@ mod tests {
             health_state: "healthy".to_string(),
             agent_state: agent_state.to_string(),
             silent_secs,
+            output_silent_secs,
         }
+    }
+
+    /// #1961 phase-2 — THE production false-fire shape: the state-detector
+    /// mis-reads a code-writing agent as "idle", productive markers missed
+    /// (silent_secs=MAX), no MCP heartbeat — all three legacy gates slip. The
+    /// pane CONTENT is changing (token streaming → screen-hash delta), so the
+    /// classification-free 4th signal must suppress.
+    #[test]
+    fn pane_change_suppresses_when_all_state_signals_slip_1961() {
+        const T: i64 = 600;
+        let snap = crate::snapshot::FleetSnapshot {
+            timestamp: "t".to_string(),
+            agents: vec![mk_agent_snapshot_pane(
+                "misread",
+                "idle",
+                i64::MAX, // detector says idle, markers missed
+                10,       // …but the pane changed 10s ago (streaming)
+            )],
+        };
+        assert!(
+            target_is_working(Some(&snap), "misread", T),
+            "#1961: a recently-changing pane must suppress even when every \
+             classification-based signal reads idle/silent"
+        );
+    }
+
+    /// #1961 phase-2 fail-toward-fire: a genuinely idle agent — pane completely
+    /// static past the window, all other signals idle — must STILL fire (the
+    /// new signal only ADDS suppression, never blocks a real stuck).
+    #[test]
+    fn truly_static_pane_still_fires_1961() {
+        const T: i64 = 600;
+        let snap = crate::snapshot::FleetSnapshot {
+            timestamp: "t".to_string(),
+            agents: vec![mk_agent_snapshot_pane(
+                "stuck",
+                "idle",
+                i64::MAX, // not productive
+                i64::MAX, // pane has not changed at all
+            )],
+        };
+        assert!(
+            !target_is_working(Some(&snap), "stuck", T),
+            "#1961: a fully-static pane keeps firing — the pane signal must not \
+             hide a real stuck"
+        );
+        // Old-format snapshot (field missing → serde default MAX) behaves the
+        // same: fail-open to firing.
+        let legacy = crate::snapshot::FleetSnapshot {
+            timestamp: "t".to_string(),
+            agents: vec![mk_agent_snapshot_silence("legacy", "idle", i64::MAX)],
+        };
+        assert!(
+            !target_is_working(Some(&legacy), "legacy", T),
+            "fail-closed fixture (= old-format default) must not suppress"
+        );
     }
 
     /// #1694②: the gate reads the productive-SILENCE clock, not the

--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -315,6 +315,7 @@ mod tests {
                 health_state: String::new(),
                 agent_state: state.to_string(),
                 silent_secs: 0,
+                output_silent_secs: 0,
             }],
         );
     }

--- a/src/daemon/per_tick/snapshot.rs
+++ b/src/daemon/per_tick/snapshot.rs
@@ -37,7 +37,7 @@ impl PerTickHandler for SnapshotRotationHandler {
         let snapshots: Vec<_> = reg
             .values()
             .map(|handle| {
-                let (agent_state, health_state, silent_secs) = {
+                let (agent_state, health_state, silent_secs, output_silent_secs) = {
                     let c = handle.core.lock();
                     (
                         c.state.get_state().display_name().to_string(),
@@ -45,6 +45,10 @@ impl PerTickHandler for SnapshotRotationHandler {
                         // #1694②: productive-silence for the dispatch-idle
                         // silence-clock (marker/heartbeat-gated, spinner-resistant).
                         c.state.productive_silence().as_secs() as i64,
+                        // #1961 phase-2: raw pane-change silence (screen-hash
+                        // delta, classification-free) for the dispatch-idle
+                        // pane-activity suppress.
+                        c.state.output_silence().as_secs() as i64,
                     )
                 };
                 let cfg = cfgs.get(handle.name.as_str());
@@ -59,6 +63,7 @@ impl PerTickHandler for SnapshotRotationHandler {
                     health_state,
                     agent_state,
                     silent_secs,
+                    output_silent_secs,
                 }
             })
             .collect();

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -371,6 +371,7 @@ mod tests {
                 health_state: "Healthy".to_string(),
                 agent_state: "thinking".to_string(),
                 silent_secs: 0,
+                output_silent_secs: 0,
             }],
         );
     }

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -981,6 +981,7 @@ mod snapshot_busy_tests_1513 {
             health_state: "healthy".to_string(),
             agent_state: state.to_string(),
             silent_secs: 0,
+            output_silent_secs: 0,
         }
     }
 
@@ -1031,6 +1032,7 @@ mod should_defer_direct_inject_tests_1513pr2 {
             health_state: "healthy".to_string(),
             agent_state: state.to_string(),
             silent_secs: 0,
+            output_silent_secs: 0,
         }
     }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -27,6 +27,14 @@ pub struct AgentSnapshot {
     /// fires rather than silently suppressing a possible stuck.
     #[serde(default = "default_silent_secs")]
     pub silent_secs: i64,
+    /// #1961 phase-2: seconds since the pane CONTENT last changed (raw screen
+    /// hash delta, `StateTracker::output_silence` — classification-free). The
+    /// dispatch-idle suppress reads this as its state-detector-independent
+    /// activity signal: a streaming/working pane keeps changing even when the
+    /// detector mis-classifies the agent as idle (the #1961 false-fire).
+    /// `serde(default)` fails OPEN (huge value = "no recent change" → fire).
+    #[serde(default = "default_silent_secs")]
+    pub output_silent_secs: i64,
 }
 
 /// Fail-open default for a snapshot missing `silent_secs` (old-format / boot
@@ -99,6 +107,7 @@ mod tests {
             health_state: "healthy".to_string(),
             agent_state: state.to_string(),
             silent_secs: 0,
+            output_silent_secs: 0,
         }
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1927,6 +1927,16 @@ impl StateTracker {
     /// (`last_productive_output == None`), the baseline is `created_at` — i.e. it
     /// has been productive-silent since it started. This preserves the pre-Option
     /// behavior exactly (the field used to be stamped `now()` at creation).
+    /// #1961 phase-2: seconds since the pane CONTENT last changed (raw screen
+    /// hash delta — `last_output` is bumped only when `feed`'s screen hash
+    /// differs, so cursor-blink/no-op chatter does NOT reset it, but token
+    /// streaming / spinner frames / tool output DO). Classification-free: this
+    /// is the activity signal that survives a state-detector mis-read (the
+    /// #1961 false-fire put a code-writing agent at agent_state=idle).
+    pub fn output_silence(&self) -> Duration {
+        self.last_output.elapsed()
+    }
+
     pub fn productive_silence(&self) -> Duration {
         self.last_productive_output
             .unwrap_or(self.created_at)


### PR DESCRIPTION
Phase-2 of #1961 (lead task t-20260610163414966887-4; phase-1 instrument gave the production evidence): the operator-witnessed false-fire had `agent_state="idle"` (the state detector mis-read a code-writing claude agent three scans straight), `silent_secs=i64::MAX` (productive markers missed), heartbeat 734s — **all three suppress gates slipped together because all three sit on the same fragile state classification**.

## Fix — a 4th OR that does not depend on classification
`target_is_working` gains: **pane CONTENT changed within the suppress window -> active -> suppress** (fail-toward-suppress, existing three gates untouched).

- **Signal source = existing `StateTracker::last_output`** — bumped ONLY on a screen-hash change (cursor-blink/no-op chatter does not reset it; token streaming / tool output / spinner frames do). Zero new plumbing on the read path: exposed as `output_silence()`, carried in the per-tick snapshot as `output_silent_secs`.
- **Fail-open contract preserved**: serde default = MAX, so an old-format snapshot reads "no recent change" -> fires (same contract as `silent_secs`); the new signal only ADDS suppression — a fully static pane still fires.
- **Spinner-vs-hung (task checklist)**: a spinner animating = the backend is still running = the "you've gone silent, status?" nudge correctly stays quiet; a genuinely hung agent is the hang_detector's job (productive-silence owns it). Reasoning matches the task's pre-analysis — no residual risk found, no query needed.

## Instrument fixes (`#1961-fire-signals`)
- adds `output_silent_secs` to the fire-time diagnostic
- `heartbeat_age_ms` / `last_input_age_ms` now print `None` when the pair field was never set — `now - 0` rendered as an "age" read like an absolute epoch-ms timestamp (the phase-1 readout confusion; the field itself was already a delta, the bug was the unset-0 case).

## Tests
- the exact production false-fire shape (idle + MAX silence + no heartbeat, pane changed 10s ago) -> **suppressed**
- fully-static pane -> **still fires**; old-format/fail-closed fixture -> still fires
- legacy fixtures pin the original three gates byte-identically (pane signal fail-closed in `mk_agent_snapshot_silence`)

`cargo fmt --check` OK / `clippy --all-targets --features tray -D warnings` OK / bins **3609 passed / 1 failed** (the known `dispatch_branch_..._1834` git-shim environmental; `AGEND_GIT_BYPASS=1` -> passes).

Refs #1961, #1694, #1866.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
