### PR TITLE
chore(audit): focus cargo-audit on actionable advisories + fix rand unsoundness

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,32 @@
+# cargo-audit config (RustSec) for LOCAL `cargo audit` runs. NOTE: the CI
+# `audit` job uses `rustsec/audit-check`, which does NOT read this file — it
+# only honors its own `ignore:` input, so the SAME list is mirrored there
+# (ci.yml, `audit` job). Keep the two in sync. Neither weakens the gate: both
+# still BLOCK on any real vulnerability — these ignores only suppress
+# WARNING-class advisories that have NO usable fix for us, so the audit output
+# stays focused on actionable items. Re-review when the GTK3 stack upgrades.
+
+[advisories]
+ignore = [
+    # ── gtk-rs GTK3 bindings: "no longer maintained", NO fixed version. Pulled
+    #    in only by the `tray` feature (tray-icon / tao GUI stack). Unmaintained,
+    #    not a vulnerability; replacing GTK3 is a separate GUI-stack upgrade task.
+    "RUSTSEC-2024-0411", # gdkwayland-sys — gtk-rs GTK3 unmaintained, no fix (tray-only)
+    "RUSTSEC-2024-0412", # gdk — gtk-rs GTK3 unmaintained, no fix (tray-only)
+    "RUSTSEC-2024-0413", # atk — gtk-rs GTK3 unmaintained, no fix (tray-only)
+    "RUSTSEC-2024-0414", # gdkx11-sys — gtk-rs GTK3 unmaintained, no fix (tray-only)
+    "RUSTSEC-2024-0415", # gtk — gtk-rs GTK3 unmaintained, no fix (tray-only)
+    "RUSTSEC-2024-0416", # atk-sys — gtk-rs GTK3 unmaintained, no fix (tray-only)
+    "RUSTSEC-2024-0418", # gdk-sys — gtk-rs GTK3 unmaintained, no fix (tray-only)
+    "RUSTSEC-2024-0419", # gtk3-macros — gtk-rs GTK3 unmaintained, no fix (tray-only)
+    "RUSTSEC-2024-0420", # gtk-sys — gtk-rs GTK3 unmaintained, no fix (tray-only)
+    # ── glib unsoundness in VariantStrIter. A fix exists (>=0.20.0) but glib is
+    #    pinned to 0.18 by the GTK3 stack above; bumping it requires upgrading the
+    #    whole gtk-rs line to 0.20 → a GUI-stack upgrade task, not isolated-fixable.
+    #    Tray-feature-only. Re-review when GTK3 → 0.20.
+    "RUSTSEC-2024-0429", # glib 0.18 VariantStrIter unsound — fix needs gtk-rs 0.20 (tray-only)
+    # ── proc-macro-error family: unmaintained, NO fixed version. Build-time macro
+    #    dependencies (transitive); no runtime surface. Benign.
+    "RUSTSEC-2024-0370", # proc-macro-error — unmaintained, no fix (build-time, benign)
+    "RUSTSEC-2026-0173", # proc-macro-error2 — unmaintained, no fix (build-time, benign)
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,13 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # The action gate still BLOCKS on any real vulnerability — these are
+          # only the WARNING-class advisories with no usable fix (so the PR-UI
+          # audit report stays focused on actionable items). MIRRORS the
+          # rationale in `.cargo/audit.toml` (which the action does NOT read —
+          # it only honors this input — but which keeps local `cargo audit`
+          # consistent). Keep the two lists in sync.
+          ignore: RUSTSEC-2024-0411,RUSTSEC-2024-0412,RUSTSEC-2024-0413,RUSTSEC-2024-0414,RUSTSEC-2024-0415,RUSTSEC-2024-0416,RUSTSEC-2024-0418,RUSTSEC-2024-0419,RUSTSEC-2024-0420,RUSTSEC-2024-0429,RUSTSEC-2024-0370,RUSTSEC-2026-0173
 
   # #686 (F11): maintainer-side QA infrastructure. Runs cargo-llvm-cov on
   # Ubuntu only (cross-platform consistency comes from `check` job; coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,7 +3434,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3509,7 +3509,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3567,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",


### PR DESCRIPTION
## Phase B — cargo audit in CI (verify-first)

**Finding correction:** cargo audit is **already in CI** — the `audit` job (`ci.yml`, `rustsec/audit-check@v2`) runs on every PR + push and **blocks on vulnerabilities** while treating unmaintained/unsound as informational. With **0 vulnerabilities** today, the existing advisories already **do not block PRs**. The gate is the correct production-grade "block vuln / warn advisory" shape — **kept as-is** (no `continue-on-error` weakening of vuln-blocking).

This PR only **focuses the audit output on actionable items** + fixes the one fixable advisory.

## Current advisory snapshot (for the operator morning report)

`cargo audit` (cargo-audit 0.22.1, latest RustSec db) on `Cargo.lock`:

**Vulnerabilities: 0.**

**Warnings: 13 — all transitive, none a direct dependency:**

| RUSTSEC | crate / version | kind | fixed | dep | disposition |
|---|---|---|---|---|---|
| 2026-0097 | rand 0.9.2 | unsound | ≥0.9.3 | transitive (quinn/reqwest/teloxide, proptest) | **FIXED here** → 0.9.3 |
| 2024-0429 | glib 0.18.5 | unsound | ≥0.20.0 | transitive (GTK3 stack) | ignored — fix needs gtk-rs→0.20 (GUI-stack upgrade task), not isolated-fixable; tray-only |
| 2024-0411 | gdkwayland-sys 0.18.2 | unmaintained | none | transitive (tray) | ignored — gtk-rs GTK3 unmaintained |
| 2024-0412 | gdk 0.18.2 | unmaintained | none | transitive (tray) | ignored |
| 2024-0413 | atk 0.18.2 | unmaintained | none | transitive (tray) | ignored |
| 2024-0414 | gdkx11-sys 0.18.2 | unmaintained | none | transitive (tray) | ignored |
| 2024-0415 | gtk 0.18.2 | unmaintained | none | transitive (tray) | ignored |
| 2024-0416 | atk-sys 0.18.2 | unmaintained | none | transitive (tray) | ignored |
| 2024-0418 | gdk-sys 0.18.2 | unmaintained | none | transitive (tray) | ignored |
| 2024-0419 | gtk3-macros 0.18.2 | unmaintained | none | transitive (tray) | ignored |
| 2024-0420 | gtk-sys 0.18.2 | unmaintained | none | transitive (tray) | ignored |
| 2024-0370 | proc-macro-error 1.0.4 | unmaintained | none | transitive (build-time) | ignored — benign |
| 2026-0173 | proc-macro-error2 2.0.1 | unmaintained | none | transitive (build-time) | ignored — benign |

**Summary for the morning report:** 0 vulnerabilities. The only fixable item (rand) is fixed. `glib` unsoundness needs the GTK3→0.20 GUI-stack upgrade before it can clear. The remaining 11 are unmaintained gtk-rs GTK3 bindings (tray feature only) + proc-macro-error (build-time) — no fix available, benign.

## Changes
- **`rand` 0.9.2 → 0.9.3** (Cargo.lock): fixes RUSTSEC-2026-0097; semver-compatible patch, **no cascade** (only the two `rand 0.9.2` lock references move). `cargo build` + full nextest verified green.
- **`.cargo/audit.toml`**: ignore the 12 no-usable-fix warnings (each with a reason) for LOCAL `cargo audit`.
- **`ci.yml` audit step `ignore:` input**: rustsec/audit-check does **not** read `.cargo/audit.toml` (only its own input), so the same list is mirrored there — cross-referenced + kept in sync. The gate still blocks on any real vulnerability.

After this, `cargo audit` is clean (0 reported) locally and in CI.

## Verification
fmt clean; full nextest green (`AGEND_GIT_BYPASS=1`); `cargo audit` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)