### PR TITLE
fix(#1970): resume-proof opencode autoupdate suppression via env gate

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -830,6 +830,19 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
     // to OpenCode (same self-modification-footgun discipline as the XDG block).
     if matches!(detected_backend, Some(Backend::OpenCode)) {
         cmd.env("OPENCODE_CONFIG_CONTENT", r#"{"autoupdate":false}"#);
+        // #1970: the config injection above covers FRESH spawns but NOT the
+        // daemon-restart respawn (`opencode --continue`): on the resume path
+        // the update-check's `getGlobal()` config does not reflect
+        // OPENCODE_CONFIG_CONTENT, so the modal came back on every daemon
+        // restart. Binary-verified (opencode 1.15.13): the check is a single
+        // function gated `if (config.autoupdate === false ||
+        // env.OPENCODE_DISABLE_AUTOUPDATE) return;`, the env side reads a
+        // process.env snapshot taken at startup (independent of config/session
+        // loading), and the update modal is driven exclusively by the
+        // `installation.update-available` event emitted AFTER that gate — so
+        // the env covers resume where the config side could not. Keep BOTH:
+        // config as the documented belt, env as the resume-proof suspenders.
+        cmd.env("OPENCODE_DISABLE_AUTOUPDATE", "1");
     }
 
     // Add agend-terminal binary + $AGEND_HOME/bin (shim) to PATH.

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -931,13 +931,21 @@ fn build_command_sets_git_editor_defaults() {
 /// injects `OPENCODE_CONFIG_CONTENT` with `autoupdate:false` — MERGED onto the
 /// user's global config (never replacing it; verified via `opencode debug
 /// config`). Gated to OpenCode: other backends must NOT receive the env.
+///
+/// #1970: the config injection turned out to cover FRESH spawns only — the
+/// daemon-restart respawn (`opencode --continue`) re-popped the modal because
+/// the resume path's `getGlobal()` config does not reflect
+/// OPENCODE_CONFIG_CONTENT. `OPENCODE_DISABLE_AUTOUPDATE` reads a process.env
+/// snapshot taken at opencode startup (binary-verified: same gate, env side
+/// independent of config/session loading), so it covers resume. BOTH spawn
+/// modes must carry BOTH envs.
 #[test]
 fn build_command_disables_opencode_autoupdate_only_for_opencode() {
-    let cfg = |backend_command: &'static str| SpawnConfig {
+    let cfg = |backend_command: &'static str, mode: crate::backend::SpawnMode| SpawnConfig {
         name: "autoupdate-test",
         backend_command,
         args: &[],
-        spawn_mode: crate::backend::SpawnMode::Fresh,
+        spawn_mode: mode,
         cols: 80,
         rows: 24,
         env: None,
@@ -947,25 +955,45 @@ fn build_command_disables_opencode_autoupdate_only_for_opencode() {
         crash_tx: None,
         shutdown: None,
     };
-    // OpenCode → OPENCODE_CONFIG_CONTENT is present and valid JSON disabling autoupdate.
-    let (oc, _) = build_command(&cfg("opencode")).expect("build_command opencode");
-    let content = oc
-        .get_env("OPENCODE_CONFIG_CONTENT")
-        .and_then(|v| v.to_str().map(String::from))
-        .expect("opencode spawn env must set OPENCODE_CONFIG_CONTENT");
-    let parsed: serde_json::Value =
-        serde_json::from_str(&content).expect("OPENCODE_CONFIG_CONTENT must be valid JSON");
-    assert_eq!(
-        parsed["autoupdate"],
-        serde_json::json!(false),
-        "must disable opencode autoupdate, got {content}"
-    );
-    // Non-OpenCode backends must NOT receive the env (no cross-backend leakage).
+    // OpenCode, BOTH spawn modes (#1970: the restart respawn is Resume —
+    // `--continue` — and is exactly the path the modal recurred on):
+    // OPENCODE_CONFIG_CONTENT valid JSON disabling autoupdate AND the
+    // resume-proof OPENCODE_DISABLE_AUTOUPDATE=1.
+    for mode in [
+        crate::backend::SpawnMode::Fresh,
+        crate::backend::SpawnMode::Resume,
+    ] {
+        let (oc, _) = build_command(&cfg("opencode", mode)).expect("build_command opencode");
+        let content = oc
+            .get_env("OPENCODE_CONFIG_CONTENT")
+            .and_then(|v| v.to_str().map(String::from))
+            .expect("opencode spawn env must set OPENCODE_CONFIG_CONTENT");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&content).expect("OPENCODE_CONFIG_CONTENT must be valid JSON");
+        assert_eq!(
+            parsed["autoupdate"],
+            serde_json::json!(false),
+            "must disable opencode autoupdate, got {content}"
+        );
+        assert_eq!(
+            oc.get_env("OPENCODE_DISABLE_AUTOUPDATE")
+                .and_then(|v| v.to_str()),
+            Some("1"),
+            "#1970: {mode:?} spawn must carry OPENCODE_DISABLE_AUTOUPDATE=1 (the \
+             resume-proof gate)"
+        );
+    }
+    // Non-OpenCode backends must NOT receive either env (no cross-backend leakage).
     for cmd in ["claude", "codex", "echo"] {
-        let (c, _) = build_command(&cfg(cmd)).expect("build_command");
+        let (c, _) =
+            build_command(&cfg(cmd, crate::backend::SpawnMode::Fresh)).expect("build_command");
         assert!(
             c.get_env("OPENCODE_CONFIG_CONTENT").is_none(),
             "{cmd} must not receive OPENCODE_CONFIG_CONTENT"
+        );
+        assert!(
+            c.get_env("OPENCODE_DISABLE_AUTOUPDATE").is_none(),
+            "{cmd} must not receive OPENCODE_DISABLE_AUTOUPDATE"
         );
     }
 }


### PR DESCRIPTION
Lead task t-20260610233227110104-0 (operator-directed: try `OPENCODE_DISABLE_AUTOUPDATE` first, but VERIFY it covers the resume path before committing to Step 1).

## Step-1 verification (binary scan, opencode 1.15.13 — the lead's gate-ordering concern)
The concern: the env shares **one gate** with the config check (`if (config.autoupdate === false || env.OPENCODE_DISABLE_AUTOUPDATE) return;`), so if `--continue` bypassed that gate, the env would fail exactly like the config did. Scanned the binary:

- **The env side cannot break on resume**: `env.OPENCODE_DISABLE_AUTOUPDATE` reads a snapshot object built **synchronously from `process.env` at module init** — independent of config/session/resume loading. The config side (`getGlobal()`) is what fails on `--continue`; the OR's env side does not touch it.
- **No bypass exists** (exhaustive trigger scan): `autoupdate` appears 5x = 3 schema/docs + 2 inside that single gate function; `UpdateAvailable` is emitted ONLY after the gate; the operator's modal is exactly the TUI's `installation.update-available` subscriber ("A new release v… is available. Would you like to update now?"); remaining `.upgrade(` callers = WebSocket `server.upgrade` (unrelated), the manual `opencode upgrade` CLI command, and the modal's own accept path.

**Conclusion: Step 1 is sound — env covers resume.** Step 2 (fresh-spawn on restart) not needed.

## Change
At the #1956 injection site (`agent/mod.rs`, OpenCode-gated): add `OPENCODE_DISABLE_AUTOUPDATE=1` alongside the existing `OPENCODE_CONFIG_CONTENT` (config = documented belt, env = resume-proof suspenders). No user global config touched (per the standing constraint).

## Tests
The #1956 test now drives **both SpawnModes** — `Resume` is the `--continue` respawn, the exact recurrence path — and asserts both envs present on OpenCode and absent on claude/codex/echo (no cross-backend leakage).

## Verification honesty
CI cannot run opencode itself; what is verified here = the binary gate analysis above + the spawn-env pinning across both modes. **Final validation is deployment dogfood: the next daemon restart should leave reviewer-3 modal-free.** If the modal still appears after deploy, the next suspect is a different opencode version with a changed gate (re-scan that binary).

`cargo fmt --check` OK / `clippy --all-targets --features tray -D warnings` OK / bins **3610 passed / 1 failed** (the known `dispatch_branch_..._1834` git-shim environmental; `AGEND_GIT_BYPASS=1` -> passes).

Closes #1970. Refs #1956.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
