### PR TITLE
feat(hook-state-poc): shadow-mode hook-driven state detection (Claude Code)

### DIFF
--- a/src/api/handlers/hook_event.rs
+++ b/src/api/handlers/hook_event.rs
@@ -1,0 +1,104 @@
+//! #hook-state-poc: HOOK_EVENT — lifecycle-hook event ingestion (shadow-mode).
+//!
+//! Receives one event from a backend hook command (`agend-terminal hook-event
+//! --instance <name>`, wired into the per-workspace Claude settings by
+//! `mcp_config.rs` under `AGEND_HOOK_STATE_POC=1`). Records it in the
+//! [`crate::daemon::hook_shadow`] store and emits the `#hook-shadow`
+//! comparison log (hook-derived state vs the live screen-heuristic state) —
+//! the agreement data that gates promoting hooks to authoritative.
+
+use super::HandlerCtx;
+use crate::agent;
+use serde_json::{json, Value};
+
+pub(crate) fn handle_hook_event(params: &Value, ctx: &HandlerCtx) -> Value {
+    let name = params["name"].as_str().unwrap_or("");
+    if let Err(e) = agent::validate_name(name) {
+        return json!({"ok": false, "error": e});
+    }
+    let hook_event_name = match params["hook_event_name"].as_str() {
+        Some(h) if !h.is_empty() => h,
+        _ => return json!({"ok": false, "error": "missing 'hook_event_name'"}),
+    };
+    let notification_type = params["notification_type"].as_str();
+    let tool_name = params["tool_name"].as_str();
+
+    let derived =
+        crate::daemon::hook_shadow::record_event(name, hook_event_name, notification_type);
+
+    // Shadow comparison: the screen-heuristic state at event receipt. This is
+    // the PoC's primary output — production promotion is gated on this
+    // agreement data.
+    let screen_state = {
+        let reg = agent::lock_registry(ctx.registry);
+        crate::fleet::resolve_uuid(ctx.home, name)
+            .and_then(|id| reg.get(&id).map(|h| h.core.lock().state.get_state()))
+    };
+    let agree = match (derived, screen_state) {
+        (Some(d), Some(s)) => Some(d == s),
+        _ => None,
+    };
+    tracing::info!(
+        tag = "#hook-shadow",
+        agent = %name,
+        hook_event = hook_event_name,
+        notification_type = ?notification_type,
+        tool_name = ?tool_name,
+        hook_state = ?derived,
+        screen_state = ?screen_state,
+        agree = ?agree,
+        "hook event received (shadow-mode — heuristic still drives)"
+    );
+    json!({"ok": true, "derived_state": derived.map(|s| format!("{s:?}"))})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn test_ctx(home: &std::path::Path) -> HandlerCtx<'_> {
+        let registry: &'static crate::agent::AgentRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let configs: &'static crate::api::ConfigRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let externals: &'static crate::agent::ExternalRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        HandlerCtx {
+            registry,
+            configs,
+            externals,
+            notifier: None,
+            home,
+        }
+    }
+
+    #[test]
+    fn hook_event_records_shadow_and_derives() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-hookevent-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&home).ok();
+        let ctx = test_ctx(&home);
+        let resp = handle_hook_event(
+            &json!({"name": "hooked", "hook_event_name": "PreToolUse", "tool_name": "Bash"}),
+            &ctx,
+        );
+        assert_eq!(resp["ok"], true, "{resp}");
+        let snap = crate::daemon::hook_shadow::snapshot_for("hooked").expect("recorded");
+        assert_eq!(snap.last_event, "PreToolUse");
+        assert_eq!(snap.derived_state, Some(crate::state::AgentState::ToolUse));
+
+        // Missing event name → honest error, nothing recorded for that call.
+        let bad = handle_hook_event(&json!({"name": "hooked"}), &ctx);
+        assert_eq!(bad["ok"], false);
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -4,6 +4,7 @@
 //! `HandlerCtx` bundles the session-scoped state that handlers need.
 
 pub(crate) mod external;
+pub(crate) mod hook_event;
 pub(crate) mod instance;
 pub(crate) mod mcp_proxy;
 pub(crate) mod messaging;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -190,6 +190,9 @@ pub mod method {
     pub const REGISTER_EXTERNAL: &str = "register_external";
     pub const DEREGISTER_EXTERNAL: &str = "deregister_external";
     pub const CREATE_TEAM: &str = "create_team";
+    /// #hook-state-poc: lifecycle-hook event report from a backend hook
+    /// command (`agend-terminal hook-event`). Shadow-mode only.
+    pub const HOOK_EVENT: &str = "hook_event";
     pub const UPDATE_TEAM: &str = "update_team";
     pub const MOVE_PANE: &str = "move_pane";
     pub const SHUTDOWN: &str = "shutdown";
@@ -560,6 +563,7 @@ fn handle_session(
                         handlers::external::handle_deregister_external(params, &ctx)
                     }
                     method::CREATE_TEAM => handlers::team::handle_create_team(params, &ctx),
+                    method::HOOK_EVENT => handlers::hook_event::handle_hook_event(params, &ctx),
                     method::UPDATE_TEAM => handlers::team::handle_update_team(params, &ctx),
                     method::MOVE_PANE => handlers::instance::handle_move_pane(params, &ctx),
                     method::PANE_SNAPSHOT => handlers::instance::handle_pane_snapshot(params, &ctx),

--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -1,0 +1,149 @@
+//! Hook-driven state SHADOW store (PoC, #hook-state-spike phase 2).
+//!
+//! Claude Code lifecycle hooks (injected per-workspace by `mcp_config.rs`
+//! under the `AGEND_HOOK_STATE_POC=1` flag) report back via the
+//! `agend-terminal hook-event` subcommand → the `HOOK_EVENT` API method →
+//! here. SHADOW-MODE ONLY: events are recorded and compared against the
+//! screen-heuristic state (`#hook-shadow` log) — they do NOT drive
+//! transitions. Empirically verified before wiring (2026-06-11, live fleet
+//! spawn): SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / Stop
+//! / Notification(idle_prompt) all fire as documented with the expected
+//! payload fields; the TUI shows no artifacts (async hooks).
+//!
+//! Promotion to authoritative (hook state wins over heuristic within a
+//! freshness window, the #1945 resolution pattern) is the PRODUCTION step,
+//! gated on shadow agreement data from this PoC.
+
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// One agent's latest hook-derived observation.
+///
+/// PoC scaffolding (deferred consumers, not ghost — the #649-trio annotation
+/// pattern): in shadow-mode the only readers are the `#hook-shadow` log (which
+/// reads the values at record time) and tests; the PRODUCTION promotion step
+/// (hook state wins over heuristic within a freshness window) is the consumer
+/// of `snapshot_for` + these fields.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct HookShadow {
+    /// Raw hook event name (`PreToolUse`, `Notification`, …).
+    pub last_event: String,
+    /// State the event maps to, when the mapping is authoritative-grade.
+    /// `None` = event recorded but not state-mapped (e.g. `SessionEnd`).
+    pub derived_state: Option<crate::state::AgentState>,
+    /// Receipt time (daemon clock, epoch ms).
+    pub at_ms: u64,
+}
+
+fn store() -> &'static Mutex<HashMap<String, HookShadow>> {
+    static S: OnceLock<Mutex<HashMap<String, HookShadow>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Map a hook event to the `AgentState` it evidences. Derivations follow the
+/// empirically-verified event semantics:
+/// - `UserPromptSubmit` → Thinking (turn started)
+/// - `PreToolUse` → ToolUse; `PostToolUse` → Thinking (between tools)
+/// - `Stop` → Idle (turn ended; the `idle_prompt` Notification re-confirms)
+/// - `Notification(permission_prompt)` → PermissionPrompt
+/// - `Notification(idle_prompt)` → Idle
+/// - `SessionStart` → Starting
+/// - `StopFailure` → ApiError (docs-sourced; not yet empirically triggered —
+///   shadow data will tell)
+/// - `PreCompact` → ContextFull-adjacent signal; mapped to ContextFull so the
+///   shadow comparison can measure it against the screen heuristic.
+pub fn derive_state(
+    hook_event_name: &str,
+    notification_type: Option<&str>,
+) -> Option<crate::state::AgentState> {
+    use crate::state::AgentState;
+    match hook_event_name {
+        "SessionStart" => Some(AgentState::Starting),
+        "UserPromptSubmit" => Some(AgentState::Thinking),
+        "PreToolUse" => Some(AgentState::ToolUse),
+        "PostToolUse" => Some(AgentState::Thinking),
+        "Stop" => Some(AgentState::Idle),
+        "Notification" => match notification_type {
+            Some("permission_prompt") => Some(AgentState::PermissionPrompt),
+            Some("idle_prompt") => Some(AgentState::Idle),
+            _ => None,
+        },
+        "PermissionRequest" => Some(AgentState::PermissionPrompt),
+        "StopFailure" => Some(AgentState::ApiError),
+        "PreCompact" => Some(AgentState::ContextFull),
+        _ => None,
+    }
+}
+
+/// Record one hook event for `name`; returns the derived state (if mapped).
+pub fn record_event(
+    name: &str,
+    hook_event_name: &str,
+    notification_type: Option<&str>,
+) -> Option<crate::state::AgentState> {
+    let derived = derive_state(hook_event_name, notification_type);
+    store().lock().insert(
+        name.to_string(),
+        HookShadow {
+            last_event: hook_event_name.to_string(),
+            derived_state: derived,
+            at_ms: now_ms(),
+        },
+    );
+    derived
+}
+
+/// Latest hook observation for `name` (shadow consumers / tests). Deferred:
+/// the production resolution layer consumes this after the shadow gate.
+#[allow(dead_code)]
+pub fn snapshot_for(name: &str) -> Option<HookShadow> {
+    store().lock().get(name).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AgentState;
+
+    #[test]
+    fn derive_map_covers_the_fragile_band() {
+        assert_eq!(derive_state("PreToolUse", None), Some(AgentState::ToolUse));
+        assert_eq!(
+            derive_state("Notification", Some("permission_prompt")),
+            Some(AgentState::PermissionPrompt)
+        );
+        assert_eq!(
+            derive_state("Notification", Some("idle_prompt")),
+            Some(AgentState::Idle)
+        );
+        assert_eq!(derive_state("Stop", None), Some(AgentState::Idle));
+        assert_eq!(
+            derive_state("UserPromptSubmit", None),
+            Some(AgentState::Thinking)
+        );
+        // Unknown notification types stay unmapped (recorded, not derived).
+        assert_eq!(derive_state("Notification", Some("auth_success")), None);
+        // Unknown events stay unmapped — forward-compatible with new hooks.
+        assert_eq!(derive_state("SomeFutureEvent", None), None);
+    }
+
+    #[test]
+    fn record_and_snapshot_roundtrip() {
+        let derived = record_event("shadow-test-agent", "PreToolUse", None);
+        assert_eq!(derived, Some(AgentState::ToolUse));
+        let snap = snapshot_for("shadow-test-agent").expect("recorded");
+        assert_eq!(snap.last_event, "PreToolUse");
+        assert_eq!(snap.derived_state, Some(AgentState::ToolUse));
+        assert!(snap.at_ms > 0);
+        assert!(snapshot_for("never-seen").is_none());
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod event_bus;
 pub(crate) mod handoff_timeout_watchdog;
 pub(crate) mod heartbeat_pair;
 pub(crate) mod helper_staleness_watchdog;
+pub mod hook_shadow;
 pub(crate) mod idle_watchdog;
 pub(crate) mod inbox_stuck_watchdog;
 pub(crate) mod lifecycle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,21 @@ enum Commands {
         #[arg(default_value = "shell")]
         name: String,
     },
+    /// #hook-state-poc (hidden): backend lifecycle-hook reporter. Invoked by
+    /// the hook entries `mcp_config.rs` injects into the per-workspace Claude
+    /// settings under `AGEND_HOOK_STATE_POC=1`. Reads the hook payload JSON
+    /// from stdin, forwards `{name, hook_event_name, notification_type,
+    /// tool_name}` to the daemon's HOOK_EVENT method, and ALWAYS exits 0 with
+    /// an empty stdout: a non-zero exit (2) would BLOCK the agent's action,
+    /// and stdout is context-injected by some hook types — both must never
+    /// happen from an observe-only reporter.
+    #[command(hide = true, name = "hook-event")]
+    HookEvent {
+        /// Fleet instance name (embedded at settings-write time — solves
+        /// session↔agent attribution without a session-id map).
+        #[arg(long)]
+        instance: String,
+    },
     /// Send input to an agent
     Inject {
         /// Agent name
@@ -733,6 +748,31 @@ fn main() -> anyhow::Result<()> {
                     return Err(e);
                 }
             }
+        }
+        Some(Commands::HookEvent { instance }) => {
+            // Observe-only contract: NEVER block the agent — exit 0 on every
+            // path, keep stdout empty (stderr is fine; hooks ignore it on 0).
+            let mut payload = String::new();
+            use std::io::Read;
+            // Bounded read: hook payloads are small JSON; a runaway stdin must
+            // not wedge the reporter (the hook has its own timeout anyway).
+            let _ = std::io::stdin()
+                .take(64 * 1024)
+                .read_to_string(&mut payload);
+            let v: serde_json::Value = serde_json::from_str(&payload).unwrap_or_default();
+            let req = serde_json::json!({
+                "method": api::method::HOOK_EVENT,
+                "params": {
+                    "name": instance,
+                    "hook_event_name": v["hook_event_name"],
+                    "notification_type": v["notification_type"],
+                    "tool_name": v["tool_name"],
+                },
+            });
+            if let Err(e) = api::call(&home, &req) {
+                eprintln!("hook-event: daemon unreachable ({e}) — event dropped (shadow-mode)");
+            }
+            return Ok(());
         }
         Some(Commands::Inject { name, text }) => {
             let text = text.join(" ");

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -184,10 +184,93 @@ fn configure_claude(working_dir: &Path, instance_name: Option<&str>) -> Result<(
     let path = working_dir.join(".claude").join("settings.local.json");
     upsert_mcp_servers(&path, instance_name)?;
 
+    // #hook-state-poc (shadow-mode, flag-gated — default OFF, zero behavior
+    // change): inject lifecycle-hook reporters into the SAME per-workspace
+    // settings file (scope rule honored; user-global ~/.claude is untouched).
+    // Empirically verified (2026-06-11 live fleet spawn): the events fire as
+    // documented, the TUI shows no artifacts (async), and this upsert
+    // preserves pre-existing keys.
+    if std::env::var("AGEND_HOOK_STATE_POC").as_deref() == Ok("1") {
+        if let Some(name) = instance_name {
+            upsert_state_hooks(&path, name)?;
+        }
+    }
+
     // Write standalone mcp-config.json for --mcp-config flag
     let standalone = working_dir.join("mcp-config.json");
     upsert_mcp_servers(&standalone, instance_name)?;
 
+    Ok(())
+}
+
+/// #hook-state-poc: upsert observe-only lifecycle-hook reporters into the
+/// per-workspace Claude settings. Merge-preserving at three levels: other
+/// top-level keys, other hook EVENTS, and other (user/project) hook entries
+/// under the same event — our entry is identified by the
+/// `hook-event --instance` marker and replaced idempotently. Every entry is
+/// `async` (the TUI never waits) and the reporter always exits 0 (exit 2
+/// would block the agent's action — observe-only by contract).
+fn upsert_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
+    /// Events wired for the shadow PoC. Verified live: SessionStart /
+    /// UserPromptSubmit / PreToolUse / PostToolUse / Stop /
+    /// Notification(idle_prompt). Docs-sourced (not yet observed live):
+    /// Notification(permission_prompt) — the fleet runs bypassPermissions so
+    /// permission prompts cannot occur in-fleet; StopFailure / PreCompact /
+    /// PermissionRequest / SessionEnd — shadow data will show whether and
+    /// when they fire.
+    const HOOK_EVENTS: &[&str] = &[
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+        "Notification",
+        "PermissionRequest",
+        "StopFailure",
+        "PreCompact",
+        "SessionEnd",
+    ];
+    let exe = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "agend-terminal".to_string());
+    let marker = "hook-event --instance";
+    let command = format!("{exe} hook-event --instance {instance_name}");
+    let our_entry = json!({
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "async": true,
+            "timeout": 10,
+        }]
+    });
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _lock = crate::store::acquire_file_lock(&config_lock_path(path))?;
+    let mut config: serde_json::Value = if path.exists() {
+        serde_json::from_str(&std::fs::read_to_string(path)?).unwrap_or(json!({}))
+    } else {
+        json!({})
+    };
+    if config.get("hooks").is_none() {
+        config["hooks"] = json!({});
+    }
+    for event in HOOK_EVENTS {
+        let groups = config["hooks"]
+            .as_object_mut()
+            .expect("hooks set above")
+            .entry((*event).to_string())
+            .or_insert_with(|| json!([]));
+        if let Some(arr) = groups.as_array_mut() {
+            // Idempotent replace-by-marker; user/project entries untouched.
+            arr.retain(|g| !g.to_string().contains(marker));
+            arr.push(our_entry.clone());
+        }
+    }
+    let body = serde_json::to_string_pretty(&config)?;
+    crate::store::atomic_write(path, body.as_bytes())?;
+    tracing::debug!(path = %path.display(), "configured state hooks (shadow PoC)");
     Ok(())
 }
 
@@ -1335,5 +1418,108 @@ mod tests {
             entry_none["env"].get("AGEND_INSTANCE_NAME").is_none(),
             "mcp_server_entry(None) must not include AGEND_INSTANCE_NAME"
         );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod hook_state_poc_tests {
+    use super::*;
+
+    fn tmp(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "agend-hookpoc-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    /// #hook-state-poc: the hooks upsert is merge-preserving at all three
+    /// levels (top-level keys / other events / foreign entries under the same
+    /// event) and idempotent (re-run replaces our marker entry, no
+    /// duplicates). Observe-only contract pinned: async:true on every entry.
+    #[test]
+    fn upsert_state_hooks_merge_preserving_and_idempotent() {
+        let dir = tmp("merge");
+        let path = dir.join(".claude").join("settings.local.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Pre-existing user content: a foreign top-level key, a foreign hook
+        // event, and a foreign entry under an event we also wire.
+        std::fs::write(
+            &path,
+            serde_json::to_string(&json!({
+                "permissions": {"allow": ["Bash(ls *)"]},
+                "hooks": {
+                    "FileChanged": [{"matcher": "*.rs", "hooks": [{"type": "command", "command": "user-watcher"}]}],
+                    "Stop": [{"hooks": [{"type": "command", "command": "user-stop-bell"}]}],
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        upsert_state_hooks(&path, "agent-x").unwrap();
+        upsert_state_hooks(&path, "agent-x").unwrap(); // idempotent re-run
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        // Foreign top-level key preserved.
+        assert_eq!(cfg["permissions"]["allow"][0], "Bash(ls *)");
+        // Foreign event preserved.
+        assert_eq!(cfg["hooks"]["FileChanged"][0]["matcher"], "*.rs");
+        // Foreign entry under a shared event preserved + exactly ONE of ours.
+        let stop = cfg["hooks"]["Stop"].as_array().unwrap();
+        assert!(stop
+            .iter()
+            .any(|g| g.to_string().contains("user-stop-bell")));
+        assert_eq!(
+            stop.iter()
+                .filter(|g| g.to_string().contains("hook-event --instance"))
+                .count(),
+            1,
+            "idempotent: exactly one of our entries after re-run"
+        );
+        // Observe-only contract: every injected entry is async.
+        for ev in ["PreToolUse", "Notification", "Stop"] {
+            let ours = cfg["hooks"][ev]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|g| g.to_string().contains("hook-event --instance"))
+                .unwrap_or_else(|| panic!("our entry present for {ev}"));
+            assert_eq!(ours["hooks"][0]["async"], true, "{ev} must be async");
+            assert!(
+                ours["hooks"][0]["command"]
+                    .as_str()
+                    .unwrap()
+                    .contains("--instance agent-x"),
+                "instance embedded for attribution"
+            );
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #hook-state-poc: flag OFF (default) → configure_claude writes NO hooks
+    /// key at all — zero behavior change without AGEND_HOOK_STATE_POC=1.
+    #[test]
+    fn hooks_not_injected_without_flag() {
+        let dir = tmp("flag-off");
+        // configure_claude needs a git repo; it git-inits itself.
+        configure_claude(&dir, Some("agent-y")).unwrap();
+        let cfg: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.join(".claude/settings.local.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            cfg.get("hooks").is_none(),
+            "no hooks without the PoC flag, got {cfg}"
+        );
+        assert!(cfg.get("mcpServers").is_some(), "mcp config still written");
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
Phase-2 PoC of the hook-state spike (lead-gated; shadow-mode + empirical-first per the two convergences). **Flag-gated `AGEND_HOOK_STATE_POC=1`, default OFF = zero behavior change.** Heuristic still drives everything; hooks are recorded + compared only.

## Empirical verification (the core deliverable — done BEFORE wiring)
Live fleet spawns (real `claude` instances via create_instance) with tee-reporter hooks:

**FIRED as documented** (payload fields confirmed: `session_id`, `cwd`, `tool_name`/`tool_input`/`tool_response`, `notification_type`, `permission_mode`, `transcript_path`, …):
`SessionStart(source=startup)` -> `UserPromptSubmit` -> `PreToolUse(Bash)` -> `PostToolUse` -> `Stop` -> `Notification(notification_type=idle_prompt)` (~60s after idle, message "Claude is waiting for your input") — the full fragile-band chain, exactly the documented names/matchers.

**TUI artifact-free**: async hooks; pane snapshot clean (statusline/context% all normal).

**Bonus finding**: the existing settings.local.json upsert PRESERVED a pre-existing `hooks` key (merge discipline holds both directions).

**Not reachable in-fleet (honest boundary)**: `Notification(permission_prompt)` / `PermissionRequest` — the fleet always runs `bypassPermissions` (a `--permission-mode default` arg gets overridden by fleet flags), so permission prompts cannot occur in fleet panes at all. This also means the PermissionPrompt state matters mainly for non-bypass deployments. `StopFailure` / `PreCompact` / `SessionEnd` are wired but not yet observed — shadow data will show them.

## Wiring (design A from Phase 1)
- `mcp_config::upsert_state_hooks`: observe-only reporters into the SAME per-workspace `.claude/settings.local.json` the MCP upsert already owns (user-global untouched). Merge-preserving at all three levels (top-level keys / other events / foreign entries under the same event — marker-replaced, idempotent); every entry `async:true`.
- `agend-terminal hook-event --instance <name>` (hidden subcommand): stdin payload -> `HOOK_EVENT` API method. Instance embedded at write time (attribution without session-id maps). **Always exits 0 with empty stdout** — exit 2 would block the agent's action; stdout is context-injected by some hook types.
- `HOOK_EVENT` handler -> `daemon::hook_shadow` store + the `#hook-shadow` log line per event: `hook_state` vs `screen_state` vs `agree` — the agreement dataset that gates promotion to authoritative (promotion will reuse the #1945 freshness-resolution pattern; deferred consumers annotated per the #649 discipline).

## How to run the shadow experiment post-merge
Set `AGEND_HOOK_STATE_POC=1` on the daemon, restart, let claude agents work; then `grep '#hook-shadow' app.log` -> agreement rate + latency. Expected disagreement hotspots (by design): Stop fires while the screen still shows Thinking chrome for a beat; PostToolUse->Thinking vs screen ToolUse residue.

## Tests
derive map (fragile band + unknown-event forward-compat) · record/snapshot roundtrip · HOOK_EVENT handler (derive + honest error) · upsert merge-preservation ×3 levels + idempotency + async pin + instance embedding · **flag-off = no hooks key at all** (zero-behavior default pinned).

`cargo fmt --check` OK / `clippy -D warnings` OK / bins **3615 passed / 1 failed** (known `dispatch_branch_..._1834` git-shim environmental; `AGEND_GIT_BYPASS=1` -> passes).

Refs the hook-state spike task. agy addendum reported separately (STRONG — 5 hook types via project-level `.agents/hooks.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
