### PR TITLE
feat: support customizing low disk headroom floor via AGEND_LOW_DISK_THRESHOLD

### DIFF
--- a/src/inbox/disk.rs
+++ b/src/inbox/disk.rs
@@ -4,22 +4,27 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// Global readonly flag — set when available disk space drops below threshold.
 pub(super) static DISK_READONLY: AtomicBool = AtomicBool::new(false);
 
-/// Minimum free-space ratio before entering readonly mode.
-const LOW_DISK_THRESHOLD: f64 = 0.05;
+/// Default minimum free disk space floor (1 GiB) before entering readonly mode.
+const DEFAULT_LOW_DISK_FLOOR_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Get the low disk space threshold in bytes from `AGEND_LOW_DISK_THRESHOLD` environment variable,
+/// falling back to 1 GiB.
+pub(super) fn get_low_disk_threshold_bytes() -> u64 {
+    std::env::var("AGEND_LOW_DISK_THRESHOLD")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_LOW_DISK_FLOOR_BYTES)
+}
 
 /// Check available disk space at `path`. Returns true if below threshold.
 fn is_disk_low(path: &Path) -> bool {
     use fs4::available_space;
-    use fs4::total_space;
     let avail = match available_space(path) {
         Ok(s) => s,
         Err(_) => return false, // can't check → assume OK
     };
-    let total = match total_space(path) {
-        Ok(s) if s > 0 => s,
-        _ => return false,
-    };
-    (avail as f64 / total as f64) < LOW_DISK_THRESHOLD
+    let limit = get_low_disk_threshold_bytes();
+    avail < limit
 }
 
 /// Update the global readonly flag based on disk space at `home`.
@@ -28,7 +33,20 @@ pub fn check_disk_space(home: &Path) {
     let readonly = is_disk_low(home);
     let was = DISK_READONLY.swap(readonly, Ordering::Relaxed);
     if readonly && !was {
-        tracing::warn!("inbox entering readonly mode — disk space < 5%");
+        let limit = get_low_disk_threshold_bytes();
+        let limit_gb = limit as f64 / (1024.0 * 1024.0 * 1024.0);
+        if limit_gb >= 0.1 {
+            tracing::warn!(
+                "inbox entering readonly mode — available disk space < {:.1} GB",
+                limit_gb
+            );
+        } else {
+            let limit_mb = limit as f64 / (1024.0 * 1024.0);
+            tracing::warn!(
+                "inbox entering readonly mode — available disk space < {:.0} MB",
+                limit_mb
+            );
+        }
     } else if !readonly && was {
         tracing::info!("inbox leaving readonly mode — disk space recovered");
     }

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -3,7 +3,7 @@
 //! Messages stored as one JSON object per line in {home}/inbox/{name}.jsonl.
 //!
 //! Resilience layers:
-//! - **Readonly mode**: when available disk space < 5%, enqueue returns an
+//! - **Readonly mode**: when available disk space < 1 GiB (customizable via AGEND_LOW_DISK_THRESHOLD in bytes), enqueue returns an
 //!   error while drain continues to work (let agents consume backlog).
 //! - **Atomic append**: each enqueue writes to a temp file, fsyncs, then
 //!   renames — no half-written lines on crash.

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -3059,3 +3059,18 @@ fn drain_marks_read_and_preserves_order_after_lock_shrink() {
     assert!(second.is_empty(), "second drain must return empty");
     fs::remove_dir_all(&home).ok();
 }
+
+#[test]
+fn test_custom_disk_threshold_env() {
+    // Check that get_low_disk_threshold_bytes reads from env
+    let default_val = 1024 * 1024 * 1024; // 1 GiB
+
+    std::env::set_var("AGEND_LOW_DISK_THRESHOLD", "536870912"); // 500 MiB
+    assert_eq!(super::disk::get_low_disk_threshold_bytes(), 536870912);
+
+    std::env::set_var("AGEND_LOW_DISK_THRESHOLD", "invalid");
+    assert_eq!(super::disk::get_low_disk_threshold_bytes(), default_val);
+
+    std::env::remove_var("AGEND_LOW_DISK_THRESHOLD");
+    assert_eq!(super::disk::get_low_disk_threshold_bytes(), default_val); // default
+}


### PR DESCRIPTION
Resolves #1980

This PR updates the low disk space check to use an absolute byte headroom floor (default 1 GiB) instead of a percentage ratio. It also supports customizing this headroom threshold via the `AGEND_LOW_DISK_THRESHOLD` environment variable (in bytes).

### Changes:
- Replaced the hardcoded `LOW_DISK_THRESHOLD` 5% ratio in `src/inbox/disk.rs` with `get_low_disk_threshold_bytes()`, which defaults to 1 GiB.
- Read customizable threshold bytes from the `AGEND_LOW_DISK_THRESHOLD` environment variable.
- Updated the warning log to format the low disk space headroom dynamically in GB or MB.
- Updated doc comments in `src/inbox/mod.rs` to document the 1 GiB default and `AGEND_LOW_DISK_THRESHOLD` env variable.
- Added a unit test `test_custom_disk_threshold_env` in `src/inbox/tests.rs` to verify env parsing, invalid fallback, and defaults.
