### PR TITLE
feat(hook-state): freshness resolution layer + transient-event mapping (shadow)

### DIFF
--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -42,6 +42,44 @@ fn store() -> &'static Mutex<HashMap<String, HookShadow>> {
     S.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Freshness window for a hook-derived state: a derived state is only VALID
+/// while a hook event arrived within this window — beyond it the state is
+/// STALE and resolution falls back to the screen heuristic. Kills the
+/// shadow-data top disagreement (8× hook=Starting vs screen=Idle: a boot/
+/// respawn SessionStart with no follow-up event lingered as "Starting"
+/// forever on idle agents). 600s matches the existing freshness-constant
+/// style (`CONTEXT_FRESH`) and comfortably covers long local tool runs
+/// (a 9-min Bash emits PreToolUse then nothing until PostToolUse).
+pub const HOOK_FRESHNESS: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// Freshness-resolved hook state (the Phase-1 resolution layer, shadow form).
+#[derive(Debug, Clone, PartialEq)]
+pub enum HookResolution {
+    /// A state-mapped hook event within the freshness window.
+    Fresh(crate::state::AgentState),
+    /// The last event is older than [`HOOK_FRESHNESS`] (or was never
+    /// state-mapped) — consumers fall back to the screen heuristic.
+    Stale,
+    /// No hook event ever recorded for this agent.
+    Unknown,
+}
+
+/// Resolve `name`'s hook state through the freshness window: `Fresh(state)`
+/// only when a state-mapped event arrived within [`HOOK_FRESHNESS`]; stale or
+/// unmapped observations resolve `Stale` (fall back to heuristic) — a
+/// boot-time `Starting` is never carried as the current state hours later.
+#[allow(dead_code)] // deferred consumer: the production promotion layer (shadow gate first)
+pub fn resolved_state_for(name: &str) -> HookResolution {
+    let Some(snap) = snapshot_for(name) else {
+        return HookResolution::Unknown;
+    };
+    let age_ms = now_ms().saturating_sub(snap.at_ms);
+    match snap.derived_state {
+        Some(state) if age_ms <= HOOK_FRESHNESS.as_millis() as u64 => HookResolution::Fresh(state),
+        _ => HookResolution::Stale,
+    }
+}
+
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -59,8 +97,15 @@ fn now_ms() -> u64 {
 /// - `SessionStart` → Starting
 /// - `StopFailure` → ApiError (docs-sourced; not yet empirically triggered —
 ///   shadow data will tell)
-/// - `PreCompact` → ContextFull-adjacent signal; mapped to ContextFull so the
-///   shadow comparison can measure it against the screen heuristic.
+///
+/// TRANSIENT events do NOT map to a persistent state (shadow data round 1:
+/// 1× hook=ContextFull vs screen=Thinking — `PreCompact` is a one-shot
+/// "compacting now" moment, the agent keeps working right after, so latching
+/// it as a persistent ContextFull misreads the event class). `PreCompact` is
+/// recorded (the event is still visible in the store/log) but derives no
+/// state. `SessionStart` → Starting stays mapped — boot IS a real if
+/// short-lived state — and is bounded by [`HOOK_FRESHNESS`] + replaced by the
+/// next event (the freshness layer is what keeps it from lingering).
 pub fn derive_state(
     hook_event_name: &str,
     notification_type: Option<&str>,
@@ -79,7 +124,8 @@ pub fn derive_state(
         },
         "PermissionRequest" => Some(AgentState::PermissionPrompt),
         "StopFailure" => Some(AgentState::ApiError),
-        "PreCompact" => Some(AgentState::ContextFull),
+        // Transient: one-shot moment, not a persistent state (see fn doc).
+        "PreCompact" => None,
         _ => None,
     }
 }
@@ -100,6 +146,14 @@ pub fn record_event(
         },
     );
     derived
+}
+
+/// Test seam: age `name`'s observation by `ms` (freshness-expiry tests).
+#[cfg(test)]
+pub(crate) fn backdate_for_test(name: &str, ms: u64) {
+    if let Some(snap) = store().lock().get_mut(name) {
+        snap.at_ms = snap.at_ms.saturating_sub(ms);
+    }
 }
 
 /// Latest hook observation for `name` (shadow consumers / tests). Deferred:
@@ -134,6 +188,54 @@ mod tests {
         assert_eq!(derive_state("Notification", Some("auth_success")), None);
         // Unknown events stay unmapped — forward-compatible with new hooks.
         assert_eq!(derive_state("SomeFutureEvent", None), None);
+    }
+
+    /// Refinement round 1: a fresh state-mapped event resolves Fresh; past
+    /// the window it resolves Stale (fall back to heuristic) — a boot
+    /// `Starting` can no longer linger as the current state (the 8×
+    /// Starting-vs-Idle shadow disagreement).
+    #[test]
+    fn freshness_window_expires_stale_hook_state() {
+        record_event("fresh-test", "SessionStart", None);
+        assert_eq!(
+            resolved_state_for("fresh-test"),
+            HookResolution::Fresh(AgentState::Starting),
+            "within the window the boot state is valid"
+        );
+        backdate_for_test("fresh-test", HOOK_FRESHNESS.as_millis() as u64 + 1_000);
+        assert_eq!(
+            resolved_state_for("fresh-test"),
+            HookResolution::Stale,
+            "past the window the observation is stale — heuristic falls back in"
+        );
+        assert_eq!(
+            resolved_state_for("never-recorded-agent"),
+            HookResolution::Unknown
+        );
+    }
+
+    /// Refinement round 1: `PreCompact` is TRANSIENT — recorded (event
+    /// visible) but mapped to NO persistent state (the ContextFull-vs-Thinking
+    /// shadow disagreement), and a subsequent real event takes over cleanly.
+    #[test]
+    fn precompact_is_transient_not_latched() {
+        let derived = record_event("compact-test", "PreCompact", None);
+        assert_eq!(derived, None, "PreCompact derives no persistent state");
+        let snap = snapshot_for("compact-test").expect("event still recorded");
+        assert_eq!(snap.last_event, "PreCompact");
+        assert_eq!(snap.derived_state, None);
+        assert_eq!(
+            resolved_state_for("compact-test"),
+            HookResolution::Stale,
+            "unmapped observation resolves Stale (heuristic drives)"
+        );
+        // The next real event takes over (boot Starting analogue: replaced,
+        // not lingering).
+        record_event("compact-test", "UserPromptSubmit", None);
+        assert_eq!(
+            resolved_state_for("compact-test"),
+            HookResolution::Fresh(AgentState::Thinking)
+        );
     }
 
     #[test]

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -1506,11 +1506,26 @@ mod hook_state_poc_tests {
 
     /// #hook-state-poc: flag OFF (default) → configure_claude writes NO hooks
     /// key at all — zero behavior change without AGEND_HOOK_STATE_POC=1.
+    /// The flag is now deployed FLEET-WIDE (the shadow experiment), so the
+    /// test must clear it explicitly — same env-false-fail class as the
+    /// AGEND_RESTART_HANDOFF fix in #1964 (a fleet agent's inherited env must
+    /// not flip the contract under test).
     #[test]
     fn hooks_not_injected_without_flag() {
+        // Serialize the process-global env flip; restore before asserting so
+        // a panic can't leak the cleared flag to other tests.
+        static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("AGEND_HOOK_STATE_POC").ok();
+        std::env::remove_var("AGEND_HOOK_STATE_POC");
+
         let dir = tmp("flag-off");
         // configure_claude needs a git repo; it git-inits itself.
-        configure_claude(&dir, Some("agent-y")).unwrap();
+        let result = configure_claude(&dir, Some("agent-y"));
+        if let Some(v) = prev {
+            std::env::set_var("AGEND_HOOK_STATE_POC", v);
+        }
+        result.unwrap();
         let cfg: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(dir.join(".claude/settings.local.json")).unwrap(),
         )


### PR DESCRIPTION
Round-1 shadow data (15 events) from the #1979 PoC showed two refinements — both land while **staying shadow-mode and flag-gated** (`AGEND_HOOK_STATE_POC`, default OFF; `#hook-shadow` log format unchanged).

## 1. Freshness resolution layer (the Phase-1 design, shadow form)
A hook-derived state is only VALID while an event arrived within `HOOK_FRESHNESS` (600s — the `CONTEXT_FRESH` constant style; covers long local tool runs where PreToolUse is followed by silence). `resolved_state_for()` -> `Fresh(state)` / `Stale` / `Unknown`; **Stale = consumers fall back to the screen heuristic**. Kills the top disagreement (**8x hook=Starting vs screen=Idle**): a boot/respawn SessionStart with no follow-up event lingered as "Starting" forever on idle agents.

## 2. Transient events don't latch persistent states
`PreCompact` is a one-shot "compacting now" moment (the agent keeps working right after) — still **recorded** (visible in store + log) but derives **no state** (was: latched ContextFull -> the ContextFull-vs-Thinking disagreement). `SessionStart -> Starting` stays mapped (boot IS a real, short-lived state) — bounded by the freshness window and replaced by the next event.

The **3x hook=ToolUse vs screen=Thinking** disagreements are deliberately untouched — that's the hook being MORE accurate than the screen (the PoC's value showing up).

## Drive-by (2nd commit): inherited-env false-fail
The shadow experiment deployed the flag fleet-wide, which made the #1979 flag-off contract test fake-fail on every fleet agent (same class as the `AGEND_RESTART_HANDOFF` fix in #1964). The test now clears the flag under a mutex and is verified both ways (passes with the flag set in the parent env).

## Tests
freshness expiry (Fresh -> backdate -> Stale; Unknown for never-seen) · PreCompact transient (records, derives None, resolves Stale, next event takes over) · flag-off contract now env-explicit.

`cargo fmt --check` OK / `clippy -D warnings` OK / bins **3617 passed / 1 failed** (known `dispatch_branch_..._1834` git-shim environmental; `AGEND_GIT_BYPASS=1` -> passes).

Refs #1979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
