### PR TITLE
fix(service): propagate PATH environment variable to background services

### DIFF
--- a/assets/service/launchd.plist.template
+++ b/assets/service/launchd.plist.template
@@ -37,6 +37,8 @@ Placeholders (substituted at install time by service::install):
              ambient XPC_SERVICE_NAME false-positive). -->
         <key>AGEND_SUPERVISED</key>
         <string>1</string>
+        <key>PATH</key>
+        <string>__PATH__</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>

--- a/assets/service/systemd.service.template
+++ b/assets/service/systemd.service.template
@@ -28,6 +28,7 @@ Environment=AGEND_HOME=__HOME__
 # systemd Restart=on-failure unit. (INVOCATION_ID, set by systemd at
 # runtime, remains a belt-and-suspenders signal.)
 Environment=AGEND_SUPERVISED=1
+Environment=PATH=__PATH__
 # Sprint 57 Wave 3 PR-2 (#548 Q3): the daemon does NOT supervise itself.
 # systemd is the supervisor of last resort. Restart=on-failure ensures
 # operator-visible crashes get respawned by systemd, but Q6 graceful

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -35,11 +35,13 @@ pub(super) fn install(home: &Path, exe: &Path) -> Result<PathBuf, String> {
     // Paths without special chars round-trip unchanged.
     let exe_quoted = systemd_quote(&exe.display().to_string());
     let home_quoted = systemd_quote(&home.display().to_string());
+    let path_quoted = systemd_quote(&std::env::var("PATH").unwrap_or_default());
     let resolved = apply_substitutions(
         SYSTEMD_TEMPLATE,
         &[
             ("__EXECUTABLE__", exe_quoted.as_str()),
             ("__HOME__", home_quoted.as_str()),
+            ("__PATH__", path_quoted.as_str()),
         ],
     );
     if let Some(parent) = unit.parent() {

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -38,12 +38,14 @@ pub(super) fn install(home: &Path, exe: &Path) -> Result<PathBuf, String> {
     let exe_escaped = xml_escape(&exe.display().to_string());
     let home_escaped = xml_escape(&home.display().to_string());
     let label_escaped = xml_escape(SERVICE_LABEL);
+    let path_escaped = xml_escape(&std::env::var("PATH").unwrap_or_default());
     let resolved = apply_substitutions(
         LAUNCHD_TEMPLATE,
         &[
             ("__LABEL__", label_escaped.as_str()),
             ("__EXECUTABLE__", exe_escaped.as_str()),
             ("__HOME__", home_escaped.as_str()),
+            ("__PATH__", path_escaped.as_str()),
         ],
     );
     if let Some(parent) = plist.parent() {


### PR DESCRIPTION
### Description
This pull request addresses the environment inheritance issue when running the daemon as an OS background service (macOS `launchd` or Linux `systemd`). 

Currently, the service runs in a minimal environment with a default system `PATH` (typically `/usr/bin:/bin:/usr/sbin:/sbin`), causing the daemon to fail when spawning backend agents installed in user-level directories (e.g., `claude` in `~/.local/bin/` or `opencode` in `/opt/homebrew/bin/`).

Fixes #1983

### Changes
1. **macOS (`launchd`)**:
   - Added a `__PATH__` placeholder inside the `EnvironmentVariables` dictionary of [launchd.plist.template](file:///Users/cheerc/agend-terminal/assets/service/launchd.plist.template).
   - In [macos.rs](file:///Users/cheerc/agend-terminal/src/service/macos.rs), we fetch the installer's current shell `PATH` at runtime, XML-escape it, and substitute it.
2. **Linux (`systemd`)**:
   - Added `Environment=PATH=__PATH__` to [systemd.service.template](file:///Users/cheerc/agend-terminal/assets/service/systemd.service.template).
   - In [linux.rs](file:///Users/cheerc/agend-terminal/src/service/linux.rs), we fetch the current `PATH`, systemd-quote it, and substitute it.
3. **Tests**:
   - Verified that service-related unit tests run and pass successfully.

### Discussion
Is propagating the installer's `PATH` into the service configuration files the correct direction for this, or is there a preferred configuration pattern (e.g. asking the user to manually configure the PATH or setting it via some configuration file)?
