### PR TITLE
feat(release): pre-release gate + crates.io auto-publish + RELEASING.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,87 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Pre-release gate — every release artifact job `needs` this. Runs on BOTH
+  # triggers so `workflow_dispatch` pre-tag validation keeps working (a
+  # tag-only gate would skip and cascade-skip every `needs: gate` job); the
+  # tag-coupled checks (version==tag, changelog section) are step-gated to
+  # tag refs, while MSRV + semver-checks add value on dispatch runs too.
+  gate:
+    name: Pre-release gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # cargo-semver-checks baselines against the previous tag.
+          fetch-depth: 0
+
+      - name: Version matches tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          if [ "$TAG" != "$CARGO_VERSION" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match Cargo.toml version ${CARGO_VERSION} — bump Cargo.toml (and Cargo.lock via 'cargo update -w') before tagging"
+            exit 1
+          fi
+          echo "version ok: ${CARGO_VERSION}"
+
+      - name: Changelog section exists
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          # Pre-release tags (vX.Y.Z-rc.N) gate on the base X.Y.Z section.
+          BASE="${TAG%%-*}"
+          if ! grep -qE "^## \[${BASE}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [${BASE}]' section — add the release notes before tagging"
+            exit 1
+          fi
+          echo "changelog ok: [${BASE}]"
+
+      # MSRV — Cargo.toml declares rust-version 1.87; the gate proves it
+      # still compiles there (a dep bump silently raising MSRV fails HERE,
+      # not on a user's machine). Default features only: `tray` needs GTK
+      # dev libs and is exercised by the build matrix, not the gate.
+      - name: Install MSRV toolchain (1.87)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.87"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: gate-msrv-1.87
+      - name: MSRV check (1.87)
+        run: cargo +1.87 check --locked
+
+      # SemVer report — SOFT-FAIL pre-1.0 (prints the report for the human
+      # release decision; 0.x bump rules are understood by the tool). Promote
+      # to hard-fail post-1.0. Baseline = previous git tag, NOT the action's
+      # default (latest crates.io version — the crate isn't published yet).
+      - name: Determine semver baseline (previous tag)
+        id: prev
+        run: |
+          set -euo pipefail
+          PREV="$(git describe --tags --abbrev=0 "${GITHUB_SHA}^" 2>/dev/null || true)"
+          echo "tag=${PREV}" >> "$GITHUB_OUTPUT"
+          echo "semver baseline: ${PREV:-<none — skipping semver-checks>}"
+      - name: cargo-semver-checks (soft-fail pre-1.0)
+        if: steps.prev.outputs.tag != ''
+        id: semver
+        continue-on-error: true
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          baseline-rev: ${{ steps.prev.outputs.tag }}
+          rust-toolchain: stable
+      - name: SemVer soft-fail notice
+        if: steps.semver.outcome == 'failure'
+        run: |
+          echo "::warning::cargo-semver-checks reported breaking changes — review the report above (soft-fail while pre-1.0)"
+          echo "### cargo-semver-checks: REPORTED ISSUES (soft-fail pre-1.0) — see the gate job log" >> "$GITHUB_STEP_SUMMARY"
+
   build:
     name: Build (${{ matrix.target }})
+    needs: gate
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -106,6 +185,7 @@ jobs:
 
   appimage:
     name: Build AppImage (x86_64)
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -236,3 +316,33 @@ jobs:
             artifacts/*.zip
             artifacts/*.AppImage
             artifacts/SHA256SUMS
+
+  # crates.io publish — runs only after the GitHub Release succeeded, never
+  # for pre-release tags (vX.Y.Z-rc.N). Gracefully SKIPS (green, annotated)
+  # when the CRATES_IO_TOKEN secret is not configured yet — a missing token
+  # must not redden an otherwise-good release.
+  publish:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: publish
+
+      - name: Publish (graceful skip without token)
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CRATES_IO_TOKEN}" ]; then
+            echo "::warning::CRATES_IO_TOKEN secret not configured — skipping crates.io publish"
+            echo "### crates.io publish: SKIPPED — no CRATES_IO_TOKEN secret (see docs/RELEASING.md)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          cargo publish --dry-run --locked
+          cargo publish --locked --token "${CRATES_IO_TOKEN}"
+          echo "### crates.io publish: OK (${GITHUB_REF_NAME})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,11 @@ jobs:
 
       # SemVer report — SOFT-FAIL pre-1.0 (prints the report for the human
       # release decision; 0.x bump rules are understood by the tool). Promote
-      # to hard-fail post-1.0. Baseline = previous git tag, NOT the action's
-      # default (latest crates.io version — the crate isn't published yet).
+      # to hard-fail post-1.0. Baseline = previous git tag by deliberate
+      # choice over the action's default (latest crates.io version):
+      # self-contained, no dependency on crates.io availability, and the
+      # git tag set is the more complete history (crates.io is missing
+      # 0.3.2 / 0.4.0 / 0.6.1).
       - name: Determine semver baseline (previous tag)
         id: prev
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ## [Unreleased]
 
+### Added
+
+- **Release pipeline hardening** — `release.yml` gains a pre-release `gate` job (version==tag, changelog section present, MSRV 1.87 `cargo check`, `cargo-semver-checks` soft-fail report vs the previous tag) that all artifact jobs depend on, and a `publish` job that auto-publishes to crates.io after the GitHub Release succeeds (`--dry-run` first; skips gracefully when the `CRATES_IO_TOKEN` secret is unset; never runs for `-rc.N` pre-release tags). Release procedure is documented in `docs/RELEASING.md`.
+
 ### Removed
 - **Gemini CLI backend retired** ([#1580](https://github.com/suzuke/agend-terminal/issues/1580), completes [#8](https://github.com/suzuke/agend-terminal/issues/8)). `gemini-cli` sunsets 2026-06-18 (free/Pro/Ultra); its official successor Antigravity CLI (`agy`) has been a supported backend since [#1547](https://github.com/suzuke/agend-terminal/issues/1547). The `Backend::Gemini` variant, its preset/detection patterns, and the 8 gemini state-replay fixtures are removed. **Operator note:** a `gemini` / `gemini-cli` backend named in `fleet.yaml` no longer resolves to a managed backend — it now spawns as a generic `Raw` backend. Switch such entries to `agy`. Removing the last legacy backend also let the legacy detection spine (`compile_for`, `config_for_legacy`, `legacy_initial_state`) be deleted — every backend now routes through its co-located `BackendProfile` (#8 complete).
 
@@ -498,7 +502,11 @@ Substantial work has landed on `main` since `0.3.0`. Highlights, grouped by area
 
 ---
 
-[Unreleased]: https://github.com/suzuke/agend-terminal/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/suzuke/agend-terminal/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/suzuke/agend-terminal/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/suzuke/agend-terminal/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/suzuke/agend-terminal/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/suzuke/agend-terminal/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/suzuke/agend-terminal/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/suzuke/agend-terminal/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/suzuke/agend-terminal/compare/v0.3.1...v0.3.2

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -50,6 +50,11 @@ gate ──► build (5 targets) ──┐
      restricted to this crate), then `Settings → Secrets and variables →
      Actions → New repository secret → CRATES_IO_TOKEN`.
    - **Never runs for pre-release tags** (any tag containing `-`).
+   - `cargo publish` fails if the version already exists on crates.io.
+     That's expected protection, not a bug: the job only runs on a freshly
+     pushed tag, and the gate already proved the tag matches `Cargo.toml` —
+     hitting it means the version was published out-of-band (re-run the
+     release with the next patch version instead).
 
 ## Pre-releases
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,97 @@
+# Releasing agend-terminal
+
+Audience: any maintainer cutting a release. The pipeline is fully automated
+after the tag push — your job is the four steps below, in order. Nothing here
+relies on tribal knowledge; if a step is unclear, fix this document in the
+same PR that confused you.
+
+## TL;DR
+
+```sh
+# on an up-to-date main checkout
+# 1. bump version
+$EDITOR Cargo.toml          # version = "X.Y.Z"
+cargo update -w             # refresh Cargo.lock for the new version
+
+# 2. changelog
+$EDITOR CHANGELOG.md        # move [Unreleased] items into a new "## [X.Y.Z] — YYYY-MM-DD"
+                            # section AND add the compare link at the bottom:
+                            #   [X.Y.Z]: .../compare/vPREV...vX.Y.Z
+                            #   point [Unreleased] at vX.Y.Z...HEAD
+
+# 3. land the bump via the normal PR flow, then tag the merge commit
+git tag -a vX.Y.Z -m "vX.Y.Z"   # ANNOTATED tag — not lightweight
+git push origin vX.Y.Z
+
+# 4. watch the Release workflow — everything below is automatic
+```
+
+## What the tag push triggers (`.github/workflows/release.yml`)
+
+```
+gate ──► build (5 targets) ──┐
+     └─► appimage ───────────┴─► release (GH Release + SHA256SUMS) ──► publish (crates.io)
+```
+
+1. **gate** — fails the release before any artifact is built when:
+   - `Cargo.toml version` ≠ tag (strip the `v`),
+   - `CHANGELOG.md` has no `## [X.Y.Z]` section,
+   - the crate no longer compiles on the declared MSRV (`rust-version = "1.87"`).
+   - `cargo-semver-checks` also runs here but is **soft-fail while pre-1.0**:
+     it prints a breaking-change report for human judgment without blocking.
+     Promote it to hard-fail when 1.0 ships.
+2. **build / appimage** — unchanged artifact matrix (5 targets + AppImage).
+3. **release** — GitHub Release with `generate_release_notes` + `SHA256SUMS`.
+4. **publish** — `cargo publish --dry-run` then `cargo publish` to crates.io.
+   - Uses the `CRATES_IO_TOKEN` repository secret. If the secret is not
+     configured, the job **skips gracefully** (green, with a warning in the
+     job summary) — it never reddens a release. To enable publishing:
+     crates.io → Account Settings → API Tokens (scope: `publish-update`,
+     restricted to this crate), then `Settings → Secrets and variables →
+     Actions → New repository secret → CRATES_IO_TOKEN`.
+   - **Never runs for pre-release tags** (any tag containing `-`).
+
+## Pre-releases
+
+Tag as `vX.Y.Z-rc.N` (annotated, same as releases). The pipeline runs gate →
+build → GitHub Release, but **skips crates.io publish** (the publish job's
+`if` excludes tags containing `-`). The gate's changelog check looks for the
+base `## [X.Y.Z]` section, so draft the release notes before the first rc.
+Mark the GitHub Release as a pre-release manually if you want it flagged on
+the releases page.
+
+## Tag hygiene
+
+- Always **annotated** tags (`git tag -a`). Historical note: v0.5.0–v0.7.0
+  were created lightweight; from v0.7.1 on, annotated is the rule (annotated
+  tags carry tagger/date metadata and are what `git describe` prefers).
+- Tag the **merge commit on `main`** that contains the version bump — never
+  a branch head. The gate enforces version/changelog consistency either way.
+
+## Validating workflow changes without a tag
+
+`workflow_dispatch` runs the same pipeline against `main`: the gate's
+tag-coupled checks (version==tag, changelog) self-skip, MSRV + semver-checks
+still run, artifacts are built and uploaded, and the `release`/`publish`
+jobs stay off (tag-ref guarded). Use this before merging release.yml edits.
+
+## Yanking a bad release
+
+A yank hides the version from new `cargo install`/dependency resolution
+without deleting it (existing lockfiles keep working):
+
+```sh
+cargo yank --version X.Y.Z            # needs a token with yank scope
+cargo yank --version X.Y.Z --undo     # if yanked by mistake
+```
+
+Also edit the GitHub Release: mark it as a pre-release or add a warning to
+the notes pointing at the fixed version. Then ship the fix as a new patch
+release through the normal flow — never reuse or move a published tag.
+
+## MSRV bumps
+
+`rust-version` in `Cargo.toml` is the source of truth; the gate's
+`cargo +1.87 check` pin must be updated in the same PR that bumps it
+(grep release.yml for `1.87`). Treat an MSRV bump as a minor-version event
+and call it out in the changelog.


### PR DESCRIPTION
## Summary

Productization decision point 2 — release pipeline hardening per reviewer-3's audit (G1 auto-publish, G2 pre-publish gates, G3 semver-checks, G4 compare links, G8/G9 RELEASING.md). One PR, no changes to the existing build/appimage/release job logic (only `needs:` wiring added).

### gate job (new; all artifact jobs depend on it)
| check | behavior |
|---|---|
| `Cargo.toml version == tag` | hard fail |
| `CHANGELOG.md` has `## [X.Y.Z]` (rc tags gate on base version) | hard fail |
| MSRV `cargo +1.87 check --locked` | hard fail |
| `cargo-semver-checks` vs **previous git tag** | **soft-fail** (pre-1.0): report + warning + summary note |

Design notes:
- The gate runs on `workflow_dispatch` too — a tag-only gate would skip and **cascade-skip every `needs: gate` job**, killing the documented pre-tag validation flow. The two tag-coupled checks self-skip on dispatch; MSRV + semver still add value there.
- semver baseline is the previous git tag by deliberate choice over the action's default (latest crates.io version): self-contained, no crates.io availability dependency, and the git tag set is the more complete history (crates.io is missing 0.3.2/0.4.0/0.6.1).

### publish job (new, `needs: release`)
- `cargo publish --dry-run --locked` → `cargo publish` with `secrets.CRATES_IO_TOKEN`.
- Secret not configured yet → **graceful green skip** with `::warning` + job-summary note (never reddens a release).
- `if` excludes any tag containing `-` → `vX.Y.Z-rc.N` pre-releases never publish.

### CHANGELOG
- Compare links added for 0.5.0 / 0.6.0 / 0.6.1 / 0.7.0 (matching the 0.4.1 format); `[Unreleased]` now points at `v0.7.0...HEAD`.
- `[Unreleased]` entry for this change.

### docs/RELEASING.md (new)
Maintainer-facing checklist: version bump → changelog section + link → **annotated tag** (v0.5–v0.7.0 were lightweight; annotated is the rule from v0.7.1) → push; pipeline map; CRATES_IO_TOKEN setup; pre-release convention; yank flow; MSRV bump rule (gate pin must move with `rust-version`).

## Validation
- `actionlint .github/workflows/release.yml` clean.
- Gate shell commands sanity-run locally: version extraction → `0.7.0`, changelog grep → 1 match, `git describe --tags --abbrev=0 HEAD^` → `v0.7.0`.
- Workflow can't be fully exercised pre-merge; first real run = next `workflow_dispatch` or tag. RELEASING.md documents the dispatch validation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
