### PR TITLE
test(#1993): rewrite team_dedup_and_rejection → team_recreate_extends_roster (strict #1964 contract)

### DIFF
--- a/tests/migrated_scripts.rs
+++ b/tests/migrated_scripts.rs
@@ -16,49 +16,87 @@ fn tmp_home(tag: &str) -> std::path::PathBuf {
     dir
 }
 
-/// Migrated from: scripts/test-team-dedup.sh
-/// Tests: team creation spawns members + re-create with same name is rejected.
+/// Originally migrated from: scripts/test-team-dedup.sh — rewritten for #1993.
+///
+/// #1964 (PR #1966) deliberately changed `create_instance(team=X)`: re-creating
+/// an existing team is NOT rejected — it EXTENDS the roster, numbering new
+/// members from `max(existing <team>-N) + 1`. The old `team_dedup_and_rejection`
+/// asserted the pre-#1964 reject-on-dup contract via a `resp_str.contains("error")`
+/// fallback so loose it passed on ANY "error" substring in the response — green
+/// on CI by accident (spawn-noise text), red locally where a clean re-create has
+/// no "error" substring (#1993). This asserts the CURRENT extend-roster contract
+/// STRICTLY: exact spawned ids, no substring fallback.
 #[test]
-fn team_dedup_and_rejection() {
-    let home = tmp_home("team-dedup");
+fn team_recreate_extends_roster() {
+    let home = tmp_home("team-extend");
     let harness = AgendHarness::spawn(home.clone(), "defaults:\n  backend: cat\ninstances: {}\n")
         .expect("spawn");
 
     let client = TuiClient::new(&harness, 80, 24);
 
-    // Create a team — should succeed
-    let result = client.call(
-        "mcp_tool",
-        &json!({
-            "tool": "create_instance",
-            "arguments": {"team": "test-team", "count": 2},
-            "instance": "test-caller"
-        }),
-    );
-    assert!(
-        result.is_ok(),
-        "team creation API call must not fail: {:?}",
-        result.err()
-    );
-
-    // Re-create same team — should be rejected with "already exists"
-    let resp2 = client
-        .call(
+    // Explicit `backends: [cat, cat]` (NOT `count`, which falls back to the
+    // hardcoded "claude" default in instance.rs and would need the claude binary)
+    // so member spawn is deterministic on every host incl. CI — this test asserts
+    // the roster/numbering contract, not backend availability.
+    let create = |c: &TuiClient| {
+        c.call(
             "mcp_tool",
             &json!({
                 "tool": "create_instance",
-                "arguments": {"team": "test-team", "count": 2},
+                "arguments": {"team": "test-team", "backends": ["cat", "cat"]},
                 "instance": "test-caller"
             }),
         )
-        .expect("dedup call must succeed (API level)");
-    let inner2 = &resp2["result"];
-    let resp_str = inner2.to_string();
+    };
+    // Sorted spawned ids — order within a batch is incidental; the #1964 contract
+    // is about the NUMBERING (max+1), so compare as a set.
+    let spawned_sorted = |resp: &serde_json::Value| -> Vec<String> {
+        let mut ids: Vec<String> = resp["result"]["spawned"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        ids.sort();
+        ids
+    };
+
+    // First create — fresh team, members numbered from 1.
+    let resp1 = create(&client).expect("first create API call");
+    assert_eq!(
+        resp1["ok"].as_bool(),
+        Some(true),
+        "first create must succeed: {resp1}"
+    );
     assert!(
-        inner2.get("error").is_some()
-            || resp_str.contains("already exists")
-            || resp_str.contains("error"),
-        "re-creating same team must be rejected: {resp2}"
+        resp1["result"].get("error").is_none(),
+        "first create must not error: {resp1}"
+    );
+    assert_eq!(
+        spawned_sorted(&resp1),
+        vec!["test-team-1", "test-team-2"],
+        "fresh team numbers members from 1: {resp1}"
+    );
+
+    // Re-create the SAME team — #1964: NOT rejected; the roster extends with new
+    // members numbered from max(existing)+1. STRICT assertion — no `contains("error")`
+    // fallback that would mask a regression to the old reject-or-restart behaviour.
+    let resp2 = create(&client).expect("second create API call");
+    assert_eq!(
+        resp2["ok"].as_bool(),
+        Some(true),
+        "re-create extends the roster (NOT rejected): {resp2}"
+    );
+    assert!(
+        resp2["result"].get("error").is_none(),
+        "re-create must not error: {resp2}"
+    );
+    assert_eq!(
+        spawned_sorted(&resp2),
+        vec!["test-team-3", "test-team-4"],
+        "#1964: re-create numbers from max+1 (test-team-3,4), not restart at 1: {resp2}"
     );
 
     drop(harness);


### PR DESCRIPTION
Closes #1993.

`tests/migrated_scripts.rs::team_dedup_and_rejection` failed deterministically on local macOS but was "green on CI". Root-caused (see #1993): it asserted the **pre-#1964 reject-on-duplicate-team contract**, which #1964 (PR #1966) **deliberately removed** — re-creating an existing team now **extends the roster**, numbering new members from `max(existing <team>-N)+1` (`src/api/handlers/team.rs:111-128, 290-310`). The test was never updated.

## Why it was green on CI / red locally (the loose-assertion bug)
The final fallback assertion was:
```rust
inner2.get("error").is_some() || resp_str.contains("already exists") || resp_str.contains("error")
```
`resp_str.contains("error")` passes on **any** "error" substring anywhere in the response. A clean re-create on a fast local box returns `{spawned:[test-team-3,test-team-4]}` with no "error" text → **red** (correctly reflecting #1964). On CI the response apparently carries some spawn-noise text containing "error" → **accidentally green**. So post-#1964 the test asserted nothing real.

## The rewrite — strict #1964 extend-roster contract
- first create → `ok`, spawned `[test-team-1, test-team-2]`
- re-create same team → `ok` (**not rejected**), spawned `[test-team-3, test-team-4]` (numbered from max+1)
- **no `contains("error")` substring fallback** — exact spawned-id assertions + `result.error` must be absent
- explicit `backends:[cat,cat]` instead of `count:2` (which falls back to the hardcoded `"claude"` default and would need the claude binary) → spawn is **deterministic on every host incl. CI**
- renamed `team_dedup_and_rejection` → `team_recreate_extends_roster` (the old name described a removed contract)

## Verification
`cargo clippy --all-targets --features tray -D warnings` clean. The rewritten test passes locally (the old one failed deterministically on the same machine). If CI goes red on this, that is a genuine CI-environment finding to investigate, not something to paper over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)