### PR TITLE
feat(#1989): fleet.yaml schema_version + docs/COMPATIBILITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ### Added
 
+- **fleet.yaml `schema_version` + compatibility policy (#1989)** — `fleet.yaml` accepts an optional `schema_version:` field (omitted = `1`; existing files unchanged, the daemon never injects it). A file declaring a version newer than the daemon supports loads with a warning instead of being silently misread without trace. `docs/COMPATIBILITY.md` declares the on-disk interface tiers — (a) stable public (fleet.yaml, service templates, instruction blocks, MCP config), (b) internal persisted state, (c) regenerable/ephemeral — and the additive-only change rule for (a)/(b).
+
 - **Release pipeline hardening** — `release.yml` gains a pre-release `gate` job (version==tag, changelog section present, MSRV 1.87 `cargo check`, `cargo-semver-checks` soft-fail report vs the previous tag) that all artifact jobs depend on, and a `publish` job that auto-publishes to crates.io after the GitHub Release succeeds (`--dry-run` first; skips gracefully when the `CRATES_IO_TOKEN` secret is unset; never runs for `-rc.N` pre-release tags). Release procedure is documented in `docs/RELEASING.md`.
 
 ### Removed

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -35,8 +35,11 @@ task-board entries and events, decision log, and the sidecar stores
 either carry an explicit `schema_version` field or evolve additive-only
 under the same rule as tier (a). Hand-editing these is unsupported; an
 upgraded daemon must read state written by any prior release of the same
-major version, and unknown *newer* records degrade to a logged warning,
-never a crash or silent drop.
+major version. How a store treats *newer*-than-supported records is
+per-store (#1992): the inbox skips the unknown record with a warning and
+keeps serving the rest (degrade); the task-events store fail-closes on the
+whole file (deliberate — board integrity outranks availability, stricter
+than the tier floor). Either way: never a crash, never a silent drop.
 
 ## Tier (c) — regenerable / ephemeral (no commitment)
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,57 @@
+# On-Disk Format Compatibility Policy
+
+agend-terminal reads and writes a number of files under `$AGEND_HOME` (and a
+few inside agent working directories). Now that external users exist, these
+are product surface, not implementation detail. This document declares what
+you can rely on, per tier, based on the 2026-06-11 format inventory (#1989).
+
+The short version: **tier (a) and (b) changes are additive-only** until a
+real migration framework exists. "Additive-only" means:
+
+- New fields are always **optional with a serde default** — a file written
+  by an older version keeps deserializing identically.
+- Existing fields are never renamed, retyped, repurposed, or removed.
+- A change that can't be expressed additively is a **breaking change**: it
+  bumps the relevant schema version, ships a migration (or an explicit
+  refuse-with-instructions), and is called out in the CHANGELOG migration
+  notes.
+
+## Tier (a) — stable public interfaces (hand-edited or user-visible)
+
+You may hand-edit these; upgrades must never silently change their meaning.
+
+| Surface | Notes |
+|---|---|
+| `fleet.yaml` | The primary hand-edited interface. Carries an optional `schema_version:` (omitted = `1`, the version of every pre-#1989 file). The daemon **warns** when a file declares a version newer than it supports (unknown fields are silently ignored by serde — the warning is your signal the daemon is too old) and never refuses to start over it. The daemon never injects `schema_version:` into a file that doesn't have it. |
+| Service templates | launchd plist / systemd unit / Task Scheduler XML written by `agend-terminal service install`. Regenerate with `service install` after upgrading rather than hand-porting; hand edits survive only until the next `service install`. |
+| Instruction blocks | The marker-delimited blocks injected into agent instruction files (e.g. `CLAUDE.md`). The markers are the interface: content between them is daemon-owned and rewritten; everything outside them is user-owned and never touched. |
+| MCP config | Backend MCP wiring written into agent working directories (e.g. `.mcp-config.json`, `.claude/settings.local.json` entries). Daemon-owned keys are upserted in place; user-added keys in the same files are preserved. |
+
+## Tier (b) — internal persisted state (versioned)
+
+Daemon-owned state that must survive restarts and upgrades: inbox messages,
+task-board entries and events, decision log, and the sidecar stores
+(escalation persist, ci-handoff tracks, pending dispatches, …). Schemas
+either carry an explicit `schema_version` field or evolve additive-only
+under the same rule as tier (a). Hand-editing these is unsupported; an
+upgraded daemon must read state written by any prior release of the same
+major version, and unknown *newer* records degrade to a logged warning,
+never a crash or silent drop.
+
+## Tier (c) — regenerable / ephemeral (no commitment)
+
+Caches, lock files, PTY transcripts, logs, runtime sockets/PID files, and
+anything the daemon can rebuild from scratch. No format commitment; any
+release may change or delete these. If deleting a tier (c) file changes
+behavior beyond a one-time rebuild cost, that's a bug — report it.
+
+## Versioning mechanics (tier (a) fleet.yaml)
+
+- `FLEET_SCHEMA_VERSION` (`src/fleet/mod.rs`) is the version the daemon
+  reads and writes; `FleetConfig::effective_schema_version()` resolves an
+  omitted field to `1`.
+- Additive optional fields do **not** bump the version.
+- A future breaking change bumps the constant, and the then-current daemon
+  must ship explicit handling for older files (migration or documented
+  refusal). Until such a framework exists, breaking changes to fleet.yaml
+  are simply not allowed.

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -123,6 +123,7 @@ mod tests {
 
     fn minimal_with_channel() -> FleetConfig {
         let mut c = FleetConfig {
+            schema_version: None,
             defaults: crate::fleet::InstanceDefaults {
                 backend: Some(Backend::ClaudeCode),
                 ..Default::default()

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -88,8 +88,23 @@ pub fn team_orchestrator_for(home: &Path, member: &str) -> Option<String> {
         })
 }
 
+/// #1989: the fleet.yaml schema version this daemon reads and writes. Bump
+/// ONLY on a breaking (non-additive) change — additive optional fields with
+/// serde defaults do NOT bump it (`docs/COMPATIBILITY.md`).
+pub const FLEET_SCHEMA_VERSION: u32 = 1;
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FleetConfig {
+    /// #1989: fleet.yaml schema version. Omitted = version 1 (every
+    /// pre-#1989 file). `Option` (not `u32` + serde default fn) so the
+    /// derived `Default` and the serde default can't disagree — both land
+    /// on `None`, resolved to 1 by [`FleetConfig::effective_schema_version`].
+    /// A version newer than [`FLEET_SCHEMA_VERSION`] WARNs at load (fields
+    /// this daemon doesn't know are silently dropped by serde) instead of
+    /// refusing — a refuse would brick the daemon on a hand-edit typo.
+    /// Compatibility policy: `docs/COMPATIBILITY.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<u32>,
     #[serde(default)]
     pub defaults: InstanceDefaults,
     #[serde(default)]
@@ -442,11 +457,26 @@ impl FleetConfig {
         Ok(config)
     }
 
+    /// #1989: resolved schema version — an omitted `schema_version:` means 1.
+    pub fn effective_schema_version(&self) -> u32 {
+        self.schema_version.unwrap_or(1)
+    }
+
     fn load_uncached(path: &Path) -> Result<Self> {
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read fleet config: {}", path.display()))?;
         let mut config: FleetConfig = serde_yaml_ng::from_str(&content)
             .with_context(|| format!("Failed to parse fleet config: {}", path.display()))?;
+        if config.effective_schema_version() > FLEET_SCHEMA_VERSION {
+            tracing::warn!(
+                file_version = config.effective_schema_version(),
+                supported = FLEET_SCHEMA_VERSION,
+                path = %path.display(),
+                "fleet.yaml schema_version is newer than this daemon supports — \
+                 unknown fields are silently ignored and the config may be \
+                 misread; upgrade the daemon (docs/COMPATIBILITY.md)"
+            );
+        }
         config.normalize();
         config.home = path.parent().map(|p| p.to_path_buf());
         // Sprint 46 P1: backfill instance IDs + reserved-name warnings
@@ -721,6 +751,65 @@ mod tests {
         let path = dir.join("fleet.yaml");
         fs::write(&path, yaml).expect("write fleet.yaml");
         path
+    }
+
+    // #1989: schema_version regression pins — omitted field must stay
+    // version-1 (every pre-#1989 fleet.yaml), explicit + newer-than-supported
+    // values must parse (warn-not-refuse), and the derived Default must agree
+    // with the serde default (both None -> effective 1).
+    #[test]
+    fn schema_version_omitted_resolves_to_one() {
+        let config: FleetConfig = serde_yaml_ng::from_str("instances: {}").expect("parse");
+        assert_eq!(config.schema_version, None);
+        assert_eq!(config.effective_schema_version(), 1);
+    }
+
+    #[test]
+    fn schema_version_explicit_parses() {
+        let config: FleetConfig = serde_yaml_ng::from_str(
+            "schema_version: 1
+instances: {}",
+        )
+        .expect("parse");
+        assert_eq!(config.effective_schema_version(), 1);
+    }
+
+    #[test]
+    fn schema_version_newer_than_supported_still_loads() {
+        // Forward-compat contract: a v2 file on a v1 daemon WARNs but loads —
+        // refusing would brick the whole daemon on a hand-edit typo.
+        let dir = std::env::temp_dir().join(format!(
+            "agend-fleet-schema-ver-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        let path = write_fleet(
+            &dir,
+            "schema_version: 99\ndefaults:\n  backend: claude\ninstances: {}\n",
+        );
+        let config = FleetConfig::load(&path).expect("v99 file must still load");
+        assert_eq!(config.effective_schema_version(), 99);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn schema_version_default_derive_matches_serde_default() {
+        // Two-defaults-disagree trap: derived Default must resolve to the
+        // same effective version as an omitted field in YAML.
+        assert_eq!(FleetConfig::default().effective_schema_version(), 1);
+        assert_eq!(FLEET_SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn schema_version_none_round_trips_without_emitting_field() {
+        // skip_serializing_if: re-serializing a pre-#1989 config must not
+        // inject `schema_version:` into the user's file.
+        let config: FleetConfig = serde_yaml_ng::from_str("instances: {}").expect("parse");
+        let out = serde_yaml_ng::to_string(&config).expect("serialize");
+        assert!(
+            !out.contains("schema_version"),
+            "None must not serialize: {out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix #1989 (productization decision point 1). fleet.yaml — the single most important hand-edited public interface — gains a schema version + a published compatibility policy, so format evolution is detectable instead of silently misreading user config.

### `schema_version` (src/fleet/mod.rs)
- `FleetConfig.schema_version: Option<u32>`, omitted = `1` (every pre-#1989 file keeps parsing identically; the daemon never injects the field — `skip_serializing_if`).
- **`Option<u32>` rather than `u32` + serde default fn**: `FleetConfig` derives `Default`, and a bare `u32` would leave derive-Default (`0`) disagreeing with the serde default (`1`) — the two-defaults-disagree trap. Both now land on `None`, resolved by `effective_schema_version()`.
- Load-time check: a file declaring a version **newer** than `FLEET_SCHEMA_VERSION` **WARNs, never refuses** — serde silently drops unknown fields, so the warning is the only signal the daemon is too old; refusing would brick the daemon on a hand-edit typo.

### `docs/COMPATIBILITY.md` (new)
Declares the interface tiers from the 2026-06-11 inventory and the **additive-only rule** for (a)/(b) until a real migration framework exists:
- **(a) stable public** — fleet.yaml, service templates, instruction blocks, MCP config: additive-only (optional fields with serde defaults; no rename/retype/remove).
- **(b) internal persisted state** — inbox/task events/sidecar stores: versioned or additive-only; newer unknown records degrade to a logged warning.
- **(c) regenerable/ephemeral** — no commitment.
Plus version-bump mechanics (additive changes do NOT bump; a breaking change must ship migration or documented refusal).

### Tests (5 regression pins)
omitted→1 · explicit parse · **v99 file still loads** (warn-not-refuse contract) · derive-Default == serde default · `None` round-trips without emitting the field.

## Preflight
- `cargo fmt --check` + `clippy --all-targets --features tray -D warnings` clean.
- nextest `--features tray`: **3902/3903 passed**. The 1 failure = `dispatch_branch_..._1834` (known git-shim environmental false-fail; passes solo with `AGEND_GIT_BYPASS=1`).
- `team_dedup_and_rejection` excluded from the run: **pre-existing broken on clean main** (encodes the pre-#1966 contract, false-passes in CI via a loose `"error"` substring) — filed as #1995 with full evidence; not touched here (surgical scope).

Closes #1989

🤖 Generated with [Claude Code](https://claude.com/claude-code)
