### PR TITLE
fix(#1991): ci-watch verdict by latest attempt per workflow + unwatch tombstone vs PR-3 auto-arm

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -593,8 +593,18 @@ pub(crate) fn select_runs_to_notify(
     last_run_id: Option<u64>,
     last_notified_conclusion: Option<&str>,
     last_notified_run_attempt: Option<u64>,
+    last_notified_run_conclusion: Option<&str>,
 ) -> Vec<usize> {
     let threshold = last_run_id.unwrap_or(0);
+    // #1991: the anchor run's own conclusion is the correct baseline for the
+    // id==threshold comparison below. `last_notified_conclusion` is the per-sha
+    // AGGREGATE — when the two legitimately differ (the max-id run succeeded
+    // while a sibling workflow at the same sha carried the verdict), comparing
+    // the run against the aggregate never matches, so the same terminal run
+    // re-selected every poll (the #1991 ~60s storm). Legacy watch files
+    // (pre-#1991, field absent) fall back to the aggregate — the old behavior —
+    // and self-heal on the first notify that persists the new field.
+    let per_run_baseline = last_notified_run_conclusion.or(last_notified_conclusion);
     let mut selected: Vec<(usize, u64)> = runs
         .iter()
         .enumerate()
@@ -613,7 +623,7 @@ pub(crate) fn select_runs_to_notify(
                 // keeps the id+conclusion and only bumps the attempt, so an equal
                 // conclusion at a NEW attempt is a fresh event (flake re-run),
                 // not a stable terminal state. Suppress only when BOTH are equal.
-                let same_conclusion = run.conclusion.as_deref() == last_notified_conclusion;
+                let same_conclusion = run.conclusion.as_deref() == per_run_baseline;
                 let attempt_advanced =
                     last_notified_run_attempt.is_some_and(|prev| run.run_attempt > prev);
                 if same_conclusion && !attempt_advanced {
@@ -716,6 +726,52 @@ pub(crate) fn aggregate_conclusion_for_sha<'a>(runs: &'a [CiRun], sha: &str) -> 
     aggregate_conclusion_for_sha_filtered(runs, sha, None)
 }
 
+/// #1991: reduce a set of runs to ONE per workflow name — the latest attempt
+/// (max `(id, run_attempt)`). GitHub keeps superseded runs visible at the same
+/// sha (a concurrency-cancelled duplicate dispatch, an older attempt of a
+/// rerun); letting them vote in the verdict reported a `cancelled` branch
+/// verdict for an all-green head (the #1991 incident). Only the newest run of
+/// each workflow speaks for that workflow.
+fn latest_run_per_workflow<'a, I: IntoIterator<Item = &'a CiRun>>(runs: I) -> Vec<&'a CiRun> {
+    let mut best: std::collections::HashMap<&str, &CiRun> = std::collections::HashMap::new();
+    let mut unnamed: Vec<&CiRun> = Vec::new();
+    for r in runs {
+        if r.name.is_empty() {
+            // An empty workflow name is UNKNOWN provenance — two unnamed runs
+            // cannot be assumed to be the same workflow, so each keeps its
+            // voice (the pre-#1991 behavior). GitHub always names runs; this
+            // guards other providers / degraded parses against collapsing
+            // unrelated runs into one.
+            unnamed.push(r);
+            continue;
+        }
+        best.entry(r.name.as_str())
+            .and_modify(|e| {
+                if (r.id, r.run_attempt) > (e.id, e.run_attempt) {
+                    *e = r;
+                }
+            })
+            .or_insert(r);
+    }
+    let mut out: Vec<&CiRun> = best.into_values().collect();
+    out.extend(unnamed);
+    out
+}
+
+/// #1991: pick the run that should REPRESENT an aggregate verdict in the
+/// notification (URL, failure-log fetch). Must agree with the reported
+/// conclusion — pre-#1991 the body always linked the highest-id run, which
+/// produced "conclusion: cancelled" notifications linking a success run.
+/// Highest `(id, run_attempt)` among latest-per-workflow runs whose own
+/// conclusion equals the aggregate; None when nothing matches (caller keeps
+/// its anchor run as fallback).
+fn representative_run<'a>(runs: &'a [CiRun], sha: &str, aggregate: &str) -> Option<&'a CiRun> {
+    latest_run_per_workflow(runs.iter().filter(|r| r.head_sha == sha))
+        .into_iter()
+        .filter(|r| r.conclusion.as_deref() == Some(aggregate))
+        .max_by_key(|r| (r.id, r.run_attempt))
+}
+
 /// #1151: when `required_checks` is Some, only runs whose `name` matches
 /// (case-insensitive) are considered. Non-matching runs are ignored entirely.
 /// When None, all runs must pass (backward compat).
@@ -724,15 +780,13 @@ pub(crate) fn aggregate_conclusion_for_sha_filtered<'a>(
     sha: &str,
     required_checks: Option<&[String]>,
 ) -> Option<&'a str> {
-    let matching: Vec<&CiRun> = runs
-        .iter()
-        .filter(|r| r.head_sha == sha)
-        .filter(|r| {
+    // #1991: one voice per workflow — latest attempt only.
+    let matching: Vec<&CiRun> =
+        latest_run_per_workflow(runs.iter().filter(|r| r.head_sha == sha).filter(|r| {
             required_checks
                 .map(|checks| checks.iter().any(|c| c.eq_ignore_ascii_case(&r.name)))
                 .unwrap_or(true)
-        })
-        .collect();
+        }));
     if matching.is_empty() {
         return None;
     }
@@ -764,12 +818,13 @@ fn aggregate_conclusion_for_indices<'a>(
     indices: &std::collections::HashSet<usize>,
     sha: &str,
 ) -> Option<&'a str> {
-    let matching: Vec<&CiRun> = runs
-        .iter()
-        .enumerate()
-        .filter(|(i, r)| indices.contains(i) && r.head_sha == sha)
-        .map(|(_, r)| r)
-        .collect();
+    // #1991: same latest-attempt-per-workflow reduction as the sha aggregate.
+    let matching: Vec<&CiRun> = latest_run_per_workflow(
+        runs.iter()
+            .enumerate()
+            .filter(|(i, r)| indices.contains(i) && r.head_sha == sha)
+            .map(|(_, r)| r),
+    );
     if matching.is_empty() {
         return None;
     }
@@ -1130,6 +1185,8 @@ struct RunTracking<'a> {
     last_notified_sha: Option<&'a str>,
     last_notified_conclusion: Option<&'a str>,
     last_notified_run_attempt: Option<u64>,
+    // #1991: anchor run's own conclusion (vs the aggregate above).
+    last_notified_run_conclusion: Option<&'a str>,
     last_stale_emitted_sha: Option<&'a str>,
 }
 
@@ -1144,6 +1201,8 @@ struct NotifyOutcome {
     new_notified_sha: Option<String>,
     new_notified_conclusion: Option<String>,
     new_notified_run_attempt: Option<u64>,
+    // #1991: anchor run's own conclusion at notify time.
+    new_notified_run_conclusion: Option<String>,
     new_stale_emitted_sha: Option<String>,
 }
 
@@ -1190,12 +1249,14 @@ async fn ci_check_repo(
     let last_notified_sha = state.last_notified_head_sha.clone();
     let last_notified_conclusion = state.last_notified_conclusion.clone();
     let last_stale_emitted_sha = state.last_stale_emitted_sha.clone();
+    let last_notified_run_conclusion = state.last_notified_run_conclusion.clone();
     let tracking = RunTracking {
         last_run_id: state.last_run_id,
         prev_head_sha: prev_head_sha.as_deref(),
         last_notified_sha: last_notified_sha.as_deref(),
         last_notified_conclusion: last_notified_conclusion.as_deref(),
         last_notified_run_attempt: state.last_notified_run_attempt,
+        last_notified_run_conclusion: last_notified_run_conclusion.as_deref(),
         last_stale_emitted_sha: last_stale_emitted_sha.as_deref(),
     };
     let pr = match poll_ci_runs(&ctx, &tracking, &mut state, provider).await {
@@ -1229,19 +1290,37 @@ async fn ci_check_repo(
         pr.effective_last_run_id,
         tracking.last_notified_conclusion,
         tracking.last_notified_run_attempt,
+        tracking.last_notified_run_conclusion,
     );
     if to_notify.is_empty() {
+        // #1991: did anything actually change this cycle? A branch whose runs
+        // are all terminal and all already-notified produces an UNCHANGED
+        // quiet poll — pre-#1991 it still re-stamped `last_terminal_seen_at`
+        // and re-pushed `expires_at` +72h EVERY cycle, so a finished PR-less
+        // branch (spike/audit) polled forever (the #1991 quota burn: 7 stale
+        // watches × 60s). In-progress runs at the head keep the watch alive.
+        let head_in_progress = pr
+            .runs
+            .iter()
+            .any(|r| r.head_sha == pr.current_sha && r.conclusion.is_none());
+        let activity = head_in_progress
+            || state.last_run_id != pr.effective_last_run_id
+            || state.head_sha.as_deref() != Some(pr.current_sha.as_str());
         if let Some(id) = pr.effective_last_run_id {
             state.last_run_id = Some(id);
             if !pr.current_sha.is_empty() {
                 state.head_sha = Some(pr.current_sha.clone());
             }
-            state.last_terminal_seen_at = Some(chrono::Utc::now().to_rfc3339());
+            if activity {
+                state.last_terminal_seen_at = Some(chrono::Utc::now().to_rfc3339());
+            }
         }
         if state != snapshot {
             flush_watch_state(watch_path, &state);
         }
-        refresh_expires_at(watch_path);
+        if activity {
+            refresh_expires_at(watch_path);
+        }
         return Ok(());
     }
     let deduped = dedupe_notifications_by_head_sha(
@@ -1488,6 +1567,7 @@ async fn fan_out_notifications(
     let mut new_notified_sha = tracking.last_notified_sha.map(String::from);
     let mut new_notified_conclusion = tracking.last_notified_conclusion.map(String::from);
     let mut new_notified_run_attempt = tracking.last_notified_run_attempt;
+    let mut new_notified_run_conclusion = tracking.last_notified_run_conclusion.map(String::from);
     let mut new_stale_emitted_sha = tracking.last_stale_emitted_sha.map(String::from);
 
     for (idx, run_id, sha) in deduped {
@@ -1505,6 +1585,7 @@ async fn fan_out_notifications(
                 new_notified_sha = Some(sha.to_string());
                 new_notified_conclusion = conclusion.map(String::from);
                 new_notified_run_attempt = Some(run.run_attempt);
+                new_notified_run_conclusion = run.conclusion.clone();
                 continue;
             }
             tracing::info!(
@@ -1517,6 +1598,7 @@ async fn fan_out_notifications(
             new_notified_sha = Some(sha.to_string());
             new_notified_conclusion = conclusion.map(String::from);
             new_notified_run_attempt = Some(run.run_attempt);
+            new_notified_run_conclusion = run.conclusion.clone();
             new_stale_emitted_sha = Some(sha.to_string());
             continue;
         }
@@ -1524,8 +1606,16 @@ async fn fan_out_notifications(
         if let Some(headline) =
             ci_notification_message(ctx.repo, ctx.branch, conclusion, None, Some(sha))
         {
+            // #1991: the linked URL / fetched failure logs must come from a run
+            // whose own conclusion matches the verdict being reported. The
+            // anchor (`run`, highest id at the sha) can be e.g. a success run
+            // while a sibling workflow carried the failure — pre-#1991 the body
+            // linked the wrong run (and fetched failure logs from a green run).
+            let rep = conclusion
+                .and_then(|c| representative_run(&pr.runs, sha, c))
+                .unwrap_or(run);
             let failure_detail = if conclusion == Some("failure") {
-                Some(provider.fetch_failure_summary(ctx.repo, *run_id).await)
+                Some(provider.fetch_failure_summary(ctx.repo, rep.id).await)
             } else {
                 None
             };
@@ -1534,9 +1624,7 @@ async fn fan_out_notifications(
             // ci runtime (the provider impl uses `gh … --log-failed` via
             // tokio::process — never block_on the shared runtime, #1476).
             let log_tail = if conclusion == Some("failure") {
-                provider
-                    .fetch_failure_log_tail(ctx.repo, *run_id, 120)
-                    .await
+                provider.fetch_failure_log_tail(ctx.repo, rep.id, 120).await
             } else {
                 None
             };
@@ -1544,8 +1632,8 @@ async fn fan_out_notifications(
                 &headline,
                 conclusion.unwrap_or(""),
                 failure_detail.as_deref(),
-                &run.url,
-                Some(*run_id),
+                &rep.url,
+                Some(rep.id),
                 log_tail.as_deref(),
             );
 
@@ -1621,6 +1709,10 @@ async fn fan_out_notifications(
         new_notified_sha = Some(sha.to_string());
         new_notified_conclusion = conclusion.map(String::from);
         new_notified_run_attempt = Some(run.run_attempt);
+        // #1991: persist the ANCHOR run's own conclusion — gate 1 compares the
+        // id==threshold run against this (per-run vs per-run), not against the
+        // aggregate (the pre-#1991 oscillation).
+        new_notified_run_conclusion = run.conclusion.clone();
     }
 
     NotifyOutcome {
@@ -1628,6 +1720,7 @@ async fn fan_out_notifications(
         new_notified_sha,
         new_notified_conclusion,
         new_notified_run_attempt,
+        new_notified_run_conclusion,
         new_stale_emitted_sha,
     }
 }
@@ -1798,6 +1891,9 @@ fn persist_watch_state(
     }
     if let Some(a) = outcome.new_notified_run_attempt {
         state.last_notified_run_attempt = Some(a);
+    }
+    if let Some(c) = &outcome.new_notified_run_conclusion {
+        state.last_notified_run_conclusion = Some(c.clone());
     }
     if let Some(s) = &outcome.new_stale_emitted_sha {
         state.last_stale_emitted_sha = Some(s.clone());

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -418,7 +418,7 @@ fn test_multi_run_notifies_all_terminal_since_last() {
             name: String::new(),
         },
     ];
-    let selected = select_runs_to_notify(&runs, Some(99), None, None);
+    let selected = select_runs_to_notify(&runs, Some(99), None, None, None);
     assert_eq!(
         selected,
         vec![0, 1],
@@ -436,7 +436,7 @@ fn test_in_progress_does_not_appear_in_selection() {
         url: String::new(),
         name: String::new(),
     }];
-    let selected = select_runs_to_notify(&runs, None, None, None);
+    let selected = select_runs_to_notify(&runs, None, None, None, None);
     assert!(selected.is_empty(), "in-progress run must not be selected");
 }
 
@@ -468,7 +468,7 @@ fn test_mixed_terminal_states_all_notified() {
             name: String::new(),
         },
     ];
-    let selected = select_runs_to_notify(&runs, Some(299), None, None);
+    let selected = select_runs_to_notify(&runs, Some(299), None, None, None);
     assert_eq!(
         selected,
         vec![0, 1, 2],
@@ -502,7 +502,7 @@ fn test_already_notified_runs_skipped() {
     // would legitimately fire (which is the bug fix). Passing
     // Some("success") here preserves the original pre-#786 intent
     // of this test (suppress stable terminal state).
-    let selected = select_runs_to_notify(&runs, Some(400), Some("success"), None);
+    let selected = select_runs_to_notify(&runs, Some(400), Some("success"), None, None);
     assert_eq!(
         selected,
         vec![1],
@@ -530,7 +530,7 @@ fn test_same_head_sha_deduplicates_notification() {
             name: String::new(),
         },
     ];
-    let selected = select_runs_to_notify(&runs, Some(499), None, None);
+    let selected = select_runs_to_notify(&runs, Some(499), None, None, None);
     let deduped = dedupe_notifications_by_head_sha(&runs, &selected, None, None, None);
     assert_eq!(deduped.len(), 1, "same sha → 1 notification");
     assert_eq!(deduped[0].1, 501, "latest run_id wins");
@@ -561,7 +561,7 @@ fn test_dedupe_skips_already_notified_sha() {
     // the conclusion match. Passing Some("success") here preserves
     // the pre-#786 intent — a future PR could add a same-sha
     // different-conclusion test (handled by anchor test 5).
-    let selected = select_runs_to_notify(&runs, Some(599), None, None);
+    let selected = select_runs_to_notify(&runs, Some(599), None, None, None);
     let deduped =
         dedupe_notifications_by_head_sha(&runs, &selected, Some("aaa"), Some("success"), None);
     assert_eq!(
@@ -599,7 +599,7 @@ fn test_1042_same_sha_same_aggregate_suppresses_rebroadcast() {
             name: String::new(),
         },
     ];
-    let selected = select_runs_to_notify(&runs, Some(699), None, None);
+    let selected = select_runs_to_notify(&runs, Some(699), None, None, None);
     assert_eq!(selected.len(), 2, "both runs should pass site-1 filter");
     let deduped =
         dedupe_notifications_by_head_sha(&runs, &selected, Some("abc"), Some("failure"), None);
@@ -633,7 +633,7 @@ fn test_1042_same_sha_different_aggregate_fires() {
             name: String::new(),
         },
     ];
-    let selected = select_runs_to_notify(&runs, Some(799), None, None);
+    let selected = select_runs_to_notify(&runs, Some(799), None, None, None);
     let deduped =
         dedupe_notifications_by_head_sha(&runs, &selected, Some("abc"), Some("failure"), None);
     assert_eq!(
@@ -669,7 +669,7 @@ fn test_1307_rerun_pass_same_sha_fires_notification() {
         },
     ];
     // last_run_id=900: gate 1 filters out run 900 (same id, same conclusion)
-    let selected = select_runs_to_notify(&runs, Some(900), Some("failure"), None);
+    let selected = select_runs_to_notify(&runs, Some(900), Some("failure"), None, None);
     assert_eq!(selected, vec![1], "only rerun (id=901) should pass gate 1");
     // gate 2: same SHA as last notified, but aggregate should use only
     // to_notify runs (success), not all runs (which includes old failure)
@@ -702,7 +702,7 @@ fn test_different_head_sha_triggers_new_notification() {
             name: String::new(),
         },
     ];
-    let selected = select_runs_to_notify(&runs, Some(599), None, None);
+    let selected = select_runs_to_notify(&runs, Some(599), None, None, None);
     let deduped = dedupe_notifications_by_head_sha(&runs, &selected, None, None, None);
     assert_eq!(deduped.len(), 2, "different shas → 2 notifications");
 }
@@ -5951,12 +5951,12 @@ fn rerun_run(attempt: u64) -> CiRun {
 fn select_runs_to_notify_attempt_advance_1859_fixb() {
     // last notified: run_id 7, success, attempt 1. Same attempt → suppress.
     assert!(
-        select_runs_to_notify(&[rerun_run(1)], Some(7), Some("success"), Some(1)).is_empty(),
+        select_runs_to_notify(&[rerun_run(1)], Some(7), Some("success"), Some(1), None).is_empty(),
         "same id+conclusion+attempt → suppress (stable terminal state)"
     );
     // Advanced attempt (1→2) at the same conclusion → selected (the rerun).
     assert_eq!(
-        select_runs_to_notify(&[rerun_run(2)], Some(7), Some("success"), Some(1)),
+        select_runs_to_notify(&[rerun_run(2)], Some(7), Some("success"), Some(1), None),
         vec![0],
         "#1859 Fix B: attempt 1→2, same conclusion → select (rerun is a fresh event)"
     );
@@ -6048,6 +6048,285 @@ fn ci_check_repo_rerun_renotifies_once_1859_fixb() {
         poll(2),
         0,
         "anti-over-notify: a stable attempt does NOT re-notify on the next poll"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// ── #1991: superseded-run verdict poisoning + dedup oscillation + hygiene ──
+//
+// Incident (first-hand, 2026-06-11): a branch head with three runs — an older
+// concurrency-cancelled duplicate "LOC" run, the newer success "LOC" run, and a
+// success "CI" run — was reported as `[ci-ended] cancelled` (linking the SUCCESS
+// run's URL), re-fired every ~60s, and survived subscriber-side unwatch because
+// PR-3 auto-arm re-created the deleted watch file.
+
+fn run_1991(id: u64, name: &str, conclusion: Option<&str>, sha: &str) -> CiRun {
+    CiRun {
+        run_attempt: 1,
+        id,
+        conclusion: conclusion.map(String::from),
+        head_sha: sha.into(),
+        url: format!("https://example/run/{id}"),
+        name: name.into(),
+    }
+}
+
+/// The incident's run set, verbatim shape.
+fn incident_runs_1991() -> Vec<CiRun> {
+    vec![
+        run_1991(45, "LOC Overrun Check", Some("cancelled"), "e7ca3d9"),
+        run_1991(146, "CI", Some("success"), "e7ca3d9"),
+        run_1991(148, "LOC Overrun Check", Some("success"), "e7ca3d9"),
+    ]
+}
+
+/// Verdict: a superseded duplicate run at the same sha must not vote — only
+/// the latest attempt per workflow speaks. Pre-#1991 this aggregated to
+/// `cancelled` on an all-green head.
+#[test]
+fn aggregate_ignores_superseded_duplicate_run_1991() {
+    let runs = incident_runs_1991();
+    assert_eq!(
+        aggregate_conclusion_for_sha(&runs, "e7ca3d9"),
+        Some("success"),
+        "older cancelled duplicate of LOC must not poison the verdict"
+    );
+}
+
+/// A GENUINE cancel (the workflow's latest run is the cancelled one) must
+/// still be reported — the reduction keys on latest-per-workflow, it does not
+/// blanket-drop cancelled runs.
+#[test]
+fn aggregate_genuine_cancel_still_reported_1991() {
+    let runs = vec![
+        run_1991(146, "CI", Some("success"), "abc"),
+        run_1991(150, "LOC Overrun Check", Some("cancelled"), "abc"),
+    ];
+    assert_eq!(
+        aggregate_conclusion_for_sha(&runs, "abc"),
+        Some("cancelled"),
+        "latest run of a workflow being cancelled IS the verdict"
+    );
+}
+
+/// Fail-fast must survive the reduction: latest attempt of one workflow
+/// failing → failure, regardless of green duplicates elsewhere.
+#[test]
+fn aggregate_fail_fast_with_duplicates_unaffected_1991() {
+    let runs = vec![
+        run_1991(45, "CI", Some("success"), "abc"), // superseded CI success
+        run_1991(146, "CI", Some("failure"), "abc"), // latest CI failed
+        run_1991(148, "LOC Overrun Check", Some("success"), "abc"),
+    ];
+    assert_eq!(aggregate_conclusion_for_sha(&runs, "abc"), Some("failure"));
+}
+
+/// A superseded run that was terminal while the LATEST attempt is still
+/// in-progress must read as in-progress (None), not as the stale terminal.
+#[test]
+fn aggregate_waits_on_latest_in_progress_1991() {
+    let runs = vec![
+        run_1991(45, "CI", Some("failure"), "abc"), // old attempt failed
+        run_1991(146, "CI", None, "abc"),           // rerun in flight
+    ];
+    assert_eq!(
+        aggregate_conclusion_for_sha(&runs, "abc"),
+        None,
+        "latest attempt in-progress → wait, the superseded failure must not fail-fast"
+    );
+}
+
+/// URL/conclusion consistency: the representative run must carry the SAME
+/// conclusion as the reported verdict. Pre-#1991 the body linked the
+/// highest-id run unconditionally (a success URL under a `cancelled`
+/// headline; failure logs fetched from a green run).
+#[test]
+fn representative_run_matches_reported_verdict_1991() {
+    let runs = incident_runs_1991();
+    let rep = representative_run(&runs, "e7ca3d9", "success").expect("rep");
+    assert_eq!(rep.conclusion.as_deref(), Some("success"));
+    assert_eq!(rep.id, 148, "highest-id run matching the verdict");
+
+    // Failure verdict → the FAILING run is linked, not the higher-id green one.
+    let runs = vec![
+        run_1991(146, "CI", Some("failure"), "abc"),
+        run_1991(148, "LOC Overrun Check", Some("success"), "abc"),
+    ];
+    let rep = representative_run(&runs, "abc", "failure").expect("rep");
+    assert_eq!(rep.id, 146, "failure verdict must link the failing run");
+}
+
+/// Gate 1 oscillation (the ~60s storm): once notified, an UNCHANGED terminal
+/// run set must select nothing on the next cycle. The per-run baseline
+/// (`last_notified_run_conclusion`) is what breaks the loop — pre-#1991 the
+/// anchor run's `success` was compared against the persisted AGGREGATE
+/// (`cancelled`), never matched, and re-selected forever.
+#[test]
+fn select_runs_per_run_baseline_suppresses_stable_state_1991() {
+    let runs = incident_runs_1991();
+    // Post-notify persisted state: last_run_id=148 (anchor), aggregate
+    // conclusion "success" (post-fix), anchor's own conclusion "success".
+    let selected =
+        select_runs_to_notify(&runs, Some(148), Some("success"), Some(1), Some("success"));
+    assert!(
+        selected.is_empty(),
+        "unchanged terminal set must not re-select: {selected:?}"
+    );
+
+    // Pre-#1991 persisted shape (aggregate `cancelled`, per-run field ABSENT —
+    // a legacy watch file): the legacy fallback compares against the aggregate
+    // and re-selects once; the notify then persists the per-run field and the
+    // NEXT cycle (above) is quiet. Pin the self-healing single re-fire.
+    let selected = select_runs_to_notify(&runs, Some(148), Some("cancelled"), Some(1), None);
+    assert_eq!(
+        selected.len(),
+        1,
+        "legacy fallback: one self-healing re-selection, then the new field takes over"
+    );
+}
+
+/// End-to-end storm regression: two consecutive poll cycles over the incident
+/// run set deliver exactly ONE notification — and it is a PASS (the duplicate
+/// cancelled run neither poisons the verdict nor re-fires).
+#[test]
+fn storm_regression_two_cycles_notify_once_1991() {
+    let dir = tmp_dir("1991-storm");
+    let ci_dir = dir.join("ci-watches");
+    std::fs::create_dir_all(&ci_dir).ok();
+    let watch = serde_json::json!({
+        "repo": "o/r", "branch": "feat", "interval_secs": 60,
+        "instance": "agent1", "last_run_id": null, "head_sha": null,
+        "last_polled_at": null, "last_notified_head_sha": null,
+    });
+    let provider = MockCiProvider::with_runs(incident_runs_1991());
+
+    // Cycle 1: notifies once.
+    run_ci_check(&dir, &watch, &provider).unwrap();
+    let msgs = crate::inbox::drain(&dir, "agent1");
+    assert_eq!(
+        msgs.iter().filter(|m| m.text.contains("o/r@feat")).count(),
+        1,
+        "cycle 1 must notify exactly once: {msgs:?}"
+    );
+    assert!(
+        msgs.iter().any(|m| m.text.contains("[ci-pass]")),
+        "verdict must be PASS (duplicate cancelled run must not poison): {msgs:?}"
+    );
+
+    // Cycle 2: same runs, persisted state — must be SILENT.
+    let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+    let persisted: WatchState =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    assert_eq!(
+        persisted.last_notified_run_conclusion.as_deref(),
+        Some("success"),
+        "anchor run's own conclusion must be persisted"
+    );
+    let registry: AgentRegistry =
+        Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    // MockCiProvider is single-shot (poll_runs take()s) — fresh one per cycle.
+    let provider2 = MockCiProvider::with_runs(incident_runs_1991());
+    rt.block_on(ci_check_repo(
+        &dir,
+        &watch_path,
+        persisted,
+        vec!["agent1".to_string()],
+        &registry,
+        &provider2,
+    ))
+    .unwrap();
+    let msgs2 = crate::inbox::drain(&dir, "agent1");
+    assert!(
+        msgs2.is_empty(),
+        "cycle 2 must not re-notify the unchanged terminal state (the #1991 storm): {msgs2:?}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Hygiene: a quiet poll over an unchanged, fully-terminal run set must NOT
+/// refresh `expires_at` (nor `last_terminal_seen_at`) — pre-#1991 every such
+/// cycle pushed expiry +72h, keeping finished PR-less branches polling
+/// forever. An in-progress run at head still refreshes.
+#[test]
+fn quiet_terminal_poll_does_not_refresh_expires_1991() {
+    let dir = tmp_dir("1991-quiet-expiry");
+    let ci_dir = dir.join("ci-watches");
+    std::fs::create_dir_all(&ci_dir).ok();
+    let watch = serde_json::json!({
+        "repo": "o/r", "branch": "feat", "interval_secs": 60,
+        "instance": "agent1",
+    });
+    let provider = MockCiProvider::with_runs(incident_runs_1991());
+    // Cycle 1 (notifies → refreshes, expected).
+    run_ci_check(&dir, &watch, &provider).unwrap();
+    crate::inbox::drain(&dir, "agent1");
+
+    // Pin expires_at to a recognizable value, then run a QUIET cycle.
+    let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+    let mut persisted: WatchState =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    let pinned = (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339();
+    persisted.expires_at = Some(pinned.clone());
+    let pinned_seen = persisted.last_terminal_seen_at.clone();
+    std::fs::write(
+        &watch_path,
+        serde_json::to_string_pretty(&persisted).unwrap(),
+    )
+    .unwrap();
+    let registry: AgentRegistry =
+        Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    // MockCiProvider is single-shot (poll_runs take()s) — fresh one per cycle.
+    let provider2 = MockCiProvider::with_runs(incident_runs_1991());
+    rt.block_on(ci_check_repo(
+        &dir,
+        &watch_path,
+        persisted,
+        vec!["agent1".to_string()],
+        &registry,
+        &provider2,
+    ))
+    .unwrap();
+    let after: WatchState =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    assert_eq!(
+        after.expires_at.as_deref(),
+        Some(pinned.as_str()),
+        "quiet terminal cycle must not refresh expires_at"
+    );
+    assert_eq!(
+        after.last_terminal_seen_at, pinned_seen,
+        "quiet terminal cycle must not re-stamp last_terminal_seen_at"
+    );
+
+    // Contrast: an in-progress run at head IS activity → refresh.
+    let mut runs = incident_runs_1991();
+    runs.push(run_1991(200, "Coverage", None, "e7ca3d9"));
+    let provider_active = MockCiProvider::with_runs(runs);
+    let persisted: WatchState =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    rt.block_on(ci_check_repo(
+        &dir,
+        &watch_path,
+        persisted,
+        vec!["agent1".to_string()],
+        &registry,
+        &provider_active,
+    ))
+    .unwrap();
+    let after: WatchState =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    assert_ne!(
+        after.expires_at.as_deref(),
+        Some(pinned.as_str()),
+        "in-progress run at head must refresh expires_at (watch is alive)"
     );
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -349,6 +349,7 @@ pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::W
     merged.last_notified_head_sha = state.last_notified_head_sha.clone();
     merged.last_notified_conclusion = state.last_notified_conclusion.clone();
     merged.last_notified_run_attempt = state.last_notified_run_attempt;
+    merged.last_notified_run_conclusion = state.last_notified_run_conclusion.clone();
     merged.last_stale_emitted_sha = state.last_stale_emitted_sha.clone();
     merged.last_mergeable_state = state.last_mergeable_state.clone();
     merged.last_mergeable_check_at = state.last_mergeable_check_at.clone();

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -311,6 +311,53 @@ pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
             continue;
         }
 
+        // #1991 P6 (lead adjudication): an unwatch TOMBSTONE (auto_arm_optout,
+        // no subscribers) survives the TTL/inactivity reaps below — unwatch is
+        // an EXPLICIT decision, and a TTL-reap → PR-3 re-arm is the same
+        // betrayal as the 60-second re-arm #1991 fixed, only slower (#1713:
+        // observation must not override decision). A tombstone is never polled
+        // (zero API budget), so keeping it is free. End-of-life, in order:
+        //   1. PR terminal — `is_branch_open` reads the SAME pr_state store
+        //      PR-3 auto-arm keys on, so "safe to remove" and "won't re-arm"
+        //      are consistent by construction (no PR / merged / closed → PR-3
+        //      would not re-arm → the tombstone's job is done).
+        //   2. Age cap on `unwatched_at` — final backstop so an orphan
+        //      tombstone whose pr_state never goes terminal can't live
+        //      forever. If the PR is somehow STILL open past the cap, the
+        //      removal costs a single PR-3 re-arm — accepted narrow edge.
+        let tombstone = watch.auto_arm_optout == Some(true) && watch.subscriber_names().is_empty();
+        if tombstone {
+            let pr_open = crate::daemon::pr_state::is_branch_open(home, repo, branch);
+            let over_age = watch
+                .unwatched_at
+                .as_deref()
+                .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+                .is_some_and(|ts| {
+                    now_utc.signed_duration_since(ts.with_timezone(&chrono::Utc))
+                        > chrono::Duration::hours(MAX_WATCH_AGE_HOURS)
+                });
+            if !pr_open || over_age {
+                let reason = if pr_open {
+                    "tombstone_max_age"
+                } else {
+                    "tombstone_pr_terminal"
+                };
+                remove_watch(
+                    home,
+                    &path,
+                    &audit_label,
+                    repo,
+                    branch,
+                    &format!("{sweep_origin}_{reason}"),
+                );
+                tracing::info!(repo = %repo, branch = %branch, reason = %reason,
+                    sweep = %sweep_origin,
+                    "ci_watch tombstone removed (#1991 end-of-life)");
+                removed += 1;
+            }
+            continue;
+        }
+
         // (1) absolute TTL.
         if let Some(expires_at) = watch.expires_at.as_deref() {
             if let Ok(exp) = chrono::DateTime::parse_from_rfc3339(expires_at) {
@@ -715,6 +762,132 @@ mod tests {
     /// OPEN is EXEMPT from the absolute age-cap (it should keep notifying on CI,
     /// and the auto-arm would re-create it anyway). A same-age watch whose PR is
     /// MERGED still ages out — proving the exemption is open-specific.
+    /// #1991 P6: an unwatch tombstone for a STILL-OPEN PR survives both the
+    /// absolute TTL and the inactivity reap — unwatch is an explicit decision;
+    /// reaping it would let PR-3 re-arm (the same betrayal as the 60s storm,
+    /// only slower). This is the reader that keeps `auto_arm_optout` alive.
+    #[test]
+    fn gc_tombstone_survives_ttl_reaps_while_pr_open_1991() {
+        use crate::daemon::pr_state::gh_poll::{GhPrMetadata, GhPrState};
+        use crate::daemon::pr_state::{new_for_branch, save, ReviewClass};
+
+        let dir = tmp_dir("1991-tombstone-survives");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        let expired = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        let ancient =
+            (chrono::Utc::now() - chrono::Duration::hours(WATCH_TTL_HOURS + 10)).to_rfc3339();
+        let w = serde_json::json!({
+            "repo": "o/r", "branch": "feat/ts",
+            "subscribers": [], "auto_arm_optout": true,
+            "unwatched_at": chrono::Utc::now().to_rfc3339(),
+            // BOTH reap triggers armed: expired TTL + ancient inactivity.
+            "expires_at": expired, "last_terminal_seen_at": ancient,
+        });
+        std::fs::write(
+            ci_dir.join("ts.json"),
+            serde_json::to_string_pretty(&w).unwrap(),
+        )
+        .unwrap();
+        let mut st = new_for_branch("o/r", "feat/ts", "deadbeef", ReviewClass::Single);
+        st.last_gh_state = Some(GhPrMetadata {
+            number: 9,
+            author_login: "suzuke".to_string(),
+            head_ref: "feat/ts".to_string(),
+            is_cross_repository: false,
+            is_draft: false,
+            state: GhPrState::Open,
+            merged_at: None,
+        });
+        save(&dir, &st).unwrap();
+
+        let removed = gc_stale_watches(&dir, "test");
+        assert!(
+            ci_dir.join("ts.json").exists(),
+            "open-PR tombstone must survive TTL + inactivity reaps"
+        );
+        assert_eq!(removed, 0);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1991 P6: tombstone end-of-life №1 — PR not open (merged / closed / no
+    /// pr_state at all) → gc removes it. Safe by construction: PR-3 auto-arm
+    /// keys on the SAME pr_state store, so "not open" here means it would not
+    /// re-arm either.
+    #[test]
+    fn gc_tombstone_reaped_when_pr_not_open_1991() {
+        let dir = tmp_dir("1991-tombstone-terminal");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        let w = serde_json::json!({
+            "repo": "o/r", "branch": "feat/done",
+            "subscribers": [], "auto_arm_optout": true,
+            "unwatched_at": chrono::Utc::now().to_rfc3339(),
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(48)).to_rfc3339(),
+        });
+        std::fs::write(
+            ci_dir.join("done.json"),
+            serde_json::to_string_pretty(&w).unwrap(),
+        )
+        .unwrap();
+        // No pr_state written → is_branch_open = false (untracked == terminal
+        // for tombstone purposes; auto-arm would not re-arm an untracked branch).
+        let removed = gc_stale_watches(&dir, "test");
+        assert!(
+            !ci_dir.join("done.json").exists(),
+            "tombstone must be reaped once the PR is not open"
+        );
+        assert_eq!(removed, 1);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #1991 P6: tombstone end-of-life №2 — the `unwatched_at` age cap is the
+    /// final backstop (an orphan tombstone whose pr_state stays Open forever
+    /// must not be immortal). The single PR-3 re-arm this can cause on a
+    /// genuinely still-open PR is the accepted narrow edge.
+    #[test]
+    fn gc_tombstone_age_cap_backstop_1991() {
+        use crate::daemon::pr_state::gh_poll::{GhPrMetadata, GhPrState};
+        use crate::daemon::pr_state::{new_for_branch, save, ReviewClass};
+
+        let dir = tmp_dir("1991-tombstone-agecap");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        let over_age =
+            (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+        let w = serde_json::json!({
+            "repo": "o/r", "branch": "feat/orphan",
+            "subscribers": [], "auto_arm_optout": true,
+            "unwatched_at": over_age,
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(48)).to_rfc3339(),
+        });
+        std::fs::write(
+            ci_dir.join("orphan.json"),
+            serde_json::to_string_pretty(&w).unwrap(),
+        )
+        .unwrap();
+        // PR still OPEN — the age cap must reap anyway (backstop beats open-PR).
+        let mut st = new_for_branch("o/r", "feat/orphan", "cafef00d", ReviewClass::Single);
+        st.last_gh_state = Some(GhPrMetadata {
+            number: 10,
+            author_login: "suzuke".to_string(),
+            head_ref: "feat/orphan".to_string(),
+            is_cross_repository: false,
+            is_draft: false,
+            state: GhPrState::Open,
+            merged_at: None,
+        });
+        save(&dir, &st).unwrap();
+
+        let removed = gc_stale_watches(&dir, "test");
+        assert!(
+            !ci_dir.join("orphan.json").exists(),
+            "over-age tombstone must be reaped even with an open PR (backstop)"
+        );
+        assert_eq!(removed, 1);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     #[test]
     fn gc_max_age_cap_exempts_open_pr_pr3() {
         use crate::daemon::pr_state::gh_poll::{GhPrMetadata, GhPrState};

--- a/src/daemon/ci_watch/watch_state.rs
+++ b/src/daemon/ci_watch/watch_state.rs
@@ -120,13 +120,24 @@ pub struct WatchState {
     /// kept as a TOMBSTONE instead of being deleted — PR-3 auto-arm re-arms
     /// any open PR whose watch file is ABSENT, so deleting here re-subscribed
     /// the very agent that just unwatched (the #1991 notification storm).
-    /// A subscriber-less watch is never polled (`prepare_poll_context` skips
-    /// it), and sweep GC reaps it via the existing TTL / PR-terminal paths.
+    /// Semantics (P6 lead adjudication): unwatch is an EXPLICIT decision that
+    /// suppresses auto-arm for the PR's whole lifetime — the tombstone is
+    /// never polled (`prepare_poll_context` skips it, zero API budget) and
+    /// `gc_stale_watches` exempts it from the TTL/inactivity reaps (a
+    /// TTL-reap → re-arm is the 60s betrayal, only slower). End-of-life:
+    /// PR terminal (gc removes once `is_branch_open` is false — the same
+    /// pr_state store auto-arm keys on, so removal and won't-re-arm are
+    /// consistent by construction) or the `unwatched_at` age-cap backstop.
     /// An explicit `ci watch` clears the flag (a human decision overrides).
     /// Typed (not a raw JSON key) so typed read-modify-write paths
     /// (`stamp_repo_backoff`, `flush_watch_state`) can't silently drop it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_arm_optout: Option<bool>,
+    /// #1991: when the tombstone was created (last subscriber unwatched).
+    /// Anchor for the gc age-cap backstop — a tombstone has no subscribers,
+    /// so `earliest_subscribed_at` (the normal age anchor) is None.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unwatched_at: Option<String>,
 }
 
 fn default_branch() -> String {

--- a/src/daemon/ci_watch/watch_state.rs
+++ b/src/daemon/ci_watch/watch_state.rs
@@ -49,6 +49,15 @@ pub struct WatchState {
     /// legacy watch (pre-Fix-B) → the first post-upgrade notify seeds it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_notified_run_attempt: Option<u64>,
+    /// #1991: the dedup-anchor run's OWN conclusion at last notify (the run
+    /// whose id becomes `last_run_id`). `last_notified_conclusion` above is the
+    /// per-sha AGGREGATE — comparing a single run's conclusion against it (the
+    /// pre-#1991 gate-1 check) oscillates whenever the two legitimately differ
+    /// (e.g. max-id run succeeded while a sibling workflow's verdict carried),
+    /// re-selecting and re-notifying the same terminal state every poll.
+    /// `None` on a legacy watch → gate 1 falls back to the aggregate field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_notified_run_conclusion: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_stale_emitted_sha: Option<String>,
 
@@ -107,6 +116,17 @@ pub struct WatchState {
     /// are ignored. When absent, all checks must pass (backward compat).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub required_checks: Option<Vec<String>>,
+    /// #1991: set when `ci unwatch` empties the subscriber list. The file is
+    /// kept as a TOMBSTONE instead of being deleted — PR-3 auto-arm re-arms
+    /// any open PR whose watch file is ABSENT, so deleting here re-subscribed
+    /// the very agent that just unwatched (the #1991 notification storm).
+    /// A subscriber-less watch is never polled (`prepare_poll_context` skips
+    /// it), and sweep GC reaps it via the existing TTL / PR-terminal paths.
+    /// An explicit `ci watch` clears the flag (a human decision overrides).
+    /// Typed (not a raw JSON key) so typed read-modify-write paths
+    /// (`stamp_repo_backoff`, `flush_watch_state`) can't silently drop it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_arm_optout: Option<bool>,
 }
 
 fn default_branch() -> String {

--- a/src/daemon/pr_state/auto_arm.rs
+++ b/src/daemon/pr_state/auto_arm.rs
@@ -233,6 +233,43 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// #1991: an explicit `ci unwatch` leaves a TOMBSTONE (empty-subscriber
+    /// watch file with `auto_arm_optout`) precisely so this sweep does NOT
+    /// re-arm it. Pre-#1991 unwatch DELETED the file, the next pr_state scan
+    /// re-armed the open PR, and the just-unwatched agent was re-subscribed
+    /// ~60s later (the #1991 storm's unstoppable-from-agent-side half).
+    #[test]
+    fn unwatch_tombstone_is_not_rearmed_1991() {
+        let home = tmp_home("tombstone");
+        bind(&home, "dev-x", "feat/x");
+        // Arm, then explicitly unwatch to a tombstone.
+        crate::mcp::handlers::ci::handle_watch_ci(
+            &home,
+            &serde_json::json!({"repository": REPO, "branch": "feat/x"}),
+            "dev-x",
+        );
+        crate::mcp::handlers::ci::handle_unwatch_ci(
+            &home,
+            &serde_json::json!({"repository": REPO, "branch": "feat/x", "instance": "dev-x"}),
+        );
+        assert!(
+            watch_exists(&home, "feat/x"),
+            "precondition: unwatch leaves a tombstone file"
+        );
+        // The PR is still open and the agent still bound — the exact shape
+        // that pre-#1991 re-armed every scan.
+        auto_arm_unwatched_open_prs(
+            &home,
+            REPO,
+            &[meta("feat/x", GhPrState::Open, false, false)],
+        );
+        assert!(
+            watch_subscribers(&home, "feat/x").is_empty(),
+            "auto-arm must respect the unwatch tombstone (no re-subscribe)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     #[test]
     fn open_pr_no_bound_agent_fails_loud_no_arm() {
         let home = tmp_home("failloud");

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -689,6 +689,11 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     // files can still read SOMEONE. Set to first subscriber, removed
     // Sprint 55. Post-r0 daemons read `subscribers` first.
     watch["instance"] = json!(subscribers.first().cloned().unwrap_or_default());
+    // #1991: an explicit (re-)watch overrides a prior unwatch tombstone —
+    // the human/agent decision to watch again clears the auto-arm optout.
+    if let Some(obj) = watch.as_object_mut() {
+        obj.remove("auto_arm_optout");
+    }
     // Refresh expires_at on each subscribe — keeps the watch alive
     // as long as at least one agent stays interested.
     watch["expires_at"] = json!((chrono::Utc::now()
@@ -806,7 +811,9 @@ fn compute_next_poll_eta(watch: &Value) -> Option<i64> {
 /// Sprint 54 P0-1: only the caller is removed from the `subscribers`
 /// array. The watch file is deleted only when the array becomes empty
 /// (no other agent is still interested in this branch).
-pub(super) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
+// pub(crate): the #1991 auto-arm tombstone regression test (pr_state::auto_arm)
+// exercises the real unwatch → tombstone → no-re-arm chain.
+pub(crate) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
     let repo = match args["repository"].as_str() {
         Some(r) => r,
         None => return json!({"error": "missing 'repository'"}),
@@ -844,11 +851,33 @@ pub(super) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
     }
 
     if subscribers.is_empty() {
-        let _ = std::fs::remove_file(&path);
+        // #1991: keep the file as a TOMBSTONE instead of deleting it. PR-3
+        // auto-arm (`pr_state::auto_arm`) re-arms any open PR whose watch file
+        // is ABSENT — deleting here re-subscribed the very agent that just
+        // unwatched, ~60s later (the #1991 storm: unwatch → file gone → next
+        // pr_state scan auto-arms → notifications resume). A subscriber-less
+        // watch is never polled (`prepare_poll_context` → SkipReason::Invalid)
+        // and sweep GC reaps it via the existing TTL / PR-terminal paths; an
+        // explicit `ci watch` clears the flag (handle_watch_ci).
+        watch["subscribers"] = json!([]);
+        watch["instance"] = json!("");
+        watch["auto_arm_optout"] = json!(true);
+        if let Err(e) = crate::store::atomic_write(
+            &path,
+            serde_json::to_string_pretty(&watch)
+                .unwrap_or_default()
+                .as_bytes(),
+        ) {
+            return json!({
+                "error": format!("failed to persist unwatch tombstone: {e}"),
+                "code": "unwatch_write_failed",
+            });
+        }
         return json!({
             "repo": repo,
             "watching": false,
             "subscribers": Vec::<String>::new(),
+            "tombstone": true,
         });
     }
 

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -855,13 +855,18 @@ pub(crate) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
         // auto-arm (`pr_state::auto_arm`) re-arms any open PR whose watch file
         // is ABSENT — deleting here re-subscribed the very agent that just
         // unwatched, ~60s later (the #1991 storm: unwatch → file gone → next
-        // pr_state scan auto-arms → notifications resume). A subscriber-less
-        // watch is never polled (`prepare_poll_context` → SkipReason::Invalid)
-        // and sweep GC reaps it via the existing TTL / PR-terminal paths; an
-        // explicit `ci watch` clears the flag (handle_watch_ci).
+        // pr_state scan auto-arms → notifications resume). Unwatch is an
+        // EXPLICIT decision: the tombstone suppresses auto-arm until the PR
+        // goes terminal or someone explicitly re-watches (handle_watch_ci
+        // clears the flag). It is never polled (`prepare_poll_context` →
+        // SkipReason::Invalid, zero API budget) and gc exempts it from the
+        // TTL/inactivity reaps (P6: a TTL-reap → re-arm is the same betrayal,
+        // only slower); end-of-life = PR-terminal gc or the unwatched_at
+        // age-cap backstop.
         watch["subscribers"] = json!([]);
         watch["instance"] = json!("");
         watch["auto_arm_optout"] = json!(true);
+        watch["unwatched_at"] = json!(chrono::Utc::now().to_rfc3339());
         if let Err(e) = crate::store::atomic_write(
             &path,
             serde_json::to_string_pretty(&watch)

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -297,8 +297,9 @@ fn ci_unwatch_last_subscriber_leaves_tombstone_not_delete() {
     // file is absent, so the delete re-subscribed the just-unwatched agent
     // ~60s later. The last unwatch now leaves a subscriber-less TOMBSTONE:
     // never polled (prepare_poll_context skips empty-subscriber watches, so
-    // the rate-limit budget is still protected), never re-armed, reaped by
-    // sweep GC via the existing TTL / PR-terminal paths.
+    // the rate-limit budget is still protected), never re-armed, and reaped
+    // by gc only at PR-terminal or the unwatched_at age-cap (P6: it survives
+    // the TTL/inactivity reaps — unwatch is an explicit decision).
     let home = std::env::temp_dir().join(format!("agend-unwatch-delete-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
     let args = serde_json::json!({"repository": "owner/repo", "branch": "feat-test"});

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -291,10 +291,14 @@ fn ci_unwatch_removes_caller_only_when_others_remain() {
 }
 
 #[test]
-fn ci_unwatch_deletes_file_when_subscribers_empty() {
-    // Hard contract item 5 (b): only the LAST unwatch deletes the
-    // file. Without this, the watch leaks rate-limit budget on a
-    // branch nobody cares about anymore.
+fn ci_unwatch_last_subscriber_leaves_tombstone_not_delete() {
+    // Hard contract item 5 (b), REVISED by #1991: the LAST unwatch used to
+    // DELETE the file — but PR-3 auto-arm re-arms any open PR whose watch
+    // file is absent, so the delete re-subscribed the just-unwatched agent
+    // ~60s later. The last unwatch now leaves a subscriber-less TOMBSTONE:
+    // never polled (prepare_poll_context skips empty-subscriber watches, so
+    // the rate-limit budget is still protected), never re-armed, reaped by
+    // sweep GC via the existing TTL / PR-terminal paths.
     let home = std::env::temp_dir().join(format!("agend-unwatch-delete-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
     let args = serde_json::json!({"repository": "owner/repo", "branch": "feat-test"});
@@ -311,7 +315,13 @@ fn ci_unwatch_deletes_file_when_subscribers_empty() {
     let resp = handle_unwatch_ci(&home, &unwatch_args);
 
     assert_eq!(resp["watching"].as_bool(), Some(false));
-    assert!(!path.exists(), "last subscriber unwatch must delete file");
+    assert!(
+        path.exists(),
+        "#1991: last unwatch leaves a tombstone (deletion re-armed via PR-3)"
+    );
+    let v = read_watch(&path);
+    assert_eq!(v["auto_arm_optout"], true);
+    assert!(crate::daemon::ci_watch::parse_subscribers(&v).is_empty());
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -2400,4 +2410,66 @@ fn merge_view_unconfirmed_when_merged_state_but_no_commit() {
         super::classify_merge_summary(&summary),
         super::MergeVerdict::Unconfirmed { .. }
     ));
+}
+
+// ── #1991: unwatch tombstone — explicit unwatch must STICK against PR-3 auto-arm ──
+
+#[test]
+fn unwatch_to_empty_leaves_tombstone_1991() {
+    let home = watch_test_home("1991-tombstone");
+    super::handle_watch_ci(
+        &home,
+        &serde_json::json!({"repository": "o/r", "branch": "feat/x"}),
+        "dev-1",
+    );
+    let resp = super::handle_unwatch_ci(
+        &home,
+        &serde_json::json!({"repository": "o/r", "branch": "feat/x", "instance": "dev-1"}),
+    );
+    assert_eq!(resp["watching"], false);
+    assert_eq!(resp["tombstone"], true);
+
+    let path = watch_path_for(&home, "o/r", "feat/x");
+    assert!(
+        path.exists(),
+        "#1991: the watch file must remain as a tombstone — deleting it lets \
+         PR-3 auto-arm re-subscribe the agent that just unwatched"
+    );
+    let v = read_watch(&path);
+    assert_eq!(v["auto_arm_optout"], true);
+    assert!(
+        crate::daemon::ci_watch::parse_subscribers(&v).is_empty(),
+        "tombstone carries no subscribers"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn rewatch_clears_tombstone_optout_1991() {
+    let home = watch_test_home("1991-rewatch");
+    super::handle_watch_ci(
+        &home,
+        &serde_json::json!({"repository": "o/r", "branch": "feat/x"}),
+        "dev-1",
+    );
+    super::handle_unwatch_ci(
+        &home,
+        &serde_json::json!({"repository": "o/r", "branch": "feat/x", "instance": "dev-1"}),
+    );
+    // Explicit re-watch: the human decision overrides the optout.
+    super::handle_watch_ci(
+        &home,
+        &serde_json::json!({"repository": "o/r", "branch": "feat/x"}),
+        "dev-2",
+    );
+    let v = read_watch(&watch_path_for(&home, "o/r", "feat/x"));
+    assert!(
+        v.get("auto_arm_optout").is_none(),
+        "explicit re-watch must clear the optout: {v}"
+    );
+    assert_eq!(
+        crate::daemon::ci_watch::parse_subscribers(&v),
+        vec!["dev-2".to_string()]
+    );
+    std::fs::remove_dir_all(&home).ok();
 }


### PR DESCRIPTION
## Summary

Fix #1991 — three independent mechanisms behind the first-hand incident (all-green head reported `[ci-ended] cancelled` linking a success run's URL, re-fired every ~60s, survived two subscriber unwatches):

### 1. Verdict: latest attempt per workflow (`poller.rs`)
`aggregate_conclusion_for_sha` let every run at the sha vote — a concurrency-cancelled **duplicate** LOC run carried a `cancelled` verdict over the newer success run. `latest_run_per_workflow()` reduces to one voice per workflow (max `(id, run_attempt)`); **empty-name runs stay ungrouped** (unknown provenance — never assume two unnamed runs are the same workflow; this also keeps the existing unnamed-fixture tests' contracts intact, unchanged). Fail-fast and genuine-cancel semantics pinned; a superseded failure under an in-flight rerun now correctly reads in-progress.

### 2. Re-fire oscillation: per-run dedup baseline
Gate 1 compared the anchor run's **own** conclusion against the persisted per-sha **aggregate** — when they legitimately differ (anchor succeeded, sibling carried the verdict) the run re-selected every poll and fan-out re-notified forever. New additive field `last_notified_run_conclusion` makes gate 1 per-run vs per-run; legacy watch files fall back to the aggregate (one self-healing re-fire, pinned by test).

### 3. Unwatch resurrection: tombstone vs PR-3 auto-arm
**unwatch was never broken** — app-log forensics showed `PR-3: auto-armed ci-watch` at 13:43:14 and 13:44:17, right after each unwatch: deletion of the watch file is exactly what PR-3 (#1782) keys on to re-arm an open PR, re-subscribing the just-unwatched agent on the next scan (decision-vs-observation, #1713 class). The last unwatch now leaves a subscriber-less **tombstone** (`auto_arm_optout`): never polled (`prepare_poll_context` already skips empty-subscriber watches — zero API budget), never re-armed (`exists()` check), reaped by existing TTL/PR-terminal GC. Explicit re-watch clears the flag. The old "last unwatch deletes file" contract test is rewritten to the tombstone contract with the why.

### 4. URL/conclusion consistency + failure-log fetch
Notifications link (and fetch `--log-failed` from) a **representative run** whose own conclusion equals the reported verdict — pre-#1991 a `failure` body could link/fetch a green run.

### 5. Quiet-poll hygiene (the 7-stale-watch quota burn)
A cycle over an unchanged fully-terminal run set no longer refreshes `expires_at` / re-stamps `last_terminal_seen_at` (pre-#1991 every quiet cycle pushed +72h → finished PR-less spike branches polled forever). In-progress runs at head still refresh. Stale watches now age out via existing TTL; active PRs self-heal via PR-3 if they outlive the TTL.

## Tests (12)
Incident-shape aggregate · genuine-cancel · fail-fast with duplicates · latest-in-progress wait · representative-run (success + failure shapes) · per-run baseline suppression + legacy fallback · **two-cycle end-to-end storm regression** (inbox-asserted: exactly one `[ci-pass]`, cycle 2 silent) · quiet-poll expiry freeze + in-progress contrast · tombstone handler pair · auto-arm-respects-tombstone.

## Preflight
- fmt / clippy(tray) clean.
- nextest `--features tray`: **3912/3913** — the 1 = known #1834 git-shim environmental (passes solo with `AGEND_GIT_BYPASS=1`); `team_dedup_and_rejection` excluded per #1993/#1996 (pre-existing, dev-2's fix in flight).
- Schema changes are additive-only per docs/COMPATIBILITY.md tier (b): `last_notified_run_conclusion`, `auto_arm_optout` (typed fields so typed RMW paths can't drop them).

Closes #1991

🤖 Generated with [Claude Code](https://claude.com/claude-code)
