### PR TITLE
ci(coverage): raise the signature-gated profraw retry cap to 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,9 @@ jobs:
           AGEND_LOCK_AUDIT: "1"
         # #1452: Coverage (non-required) can flake on transient llvm-profdata
         # profraw corruption under llvm-cov's slow parallel run — that passes on a
-        # clean rerun, so retry once.
+        # clean rerun, so retry (signature-gated, max 2 retries: double-flakes of
+        # the same signature in one run became frequent — 3 on 2026-06-11 alone —
+        # and each manual `gh run rerun` costs an operator round-trip).
         #
         # SMART RETRY: a plain `test ... FAILED` is a REAL, deterministic failure.
         # The old loop retried it unconditionally AND labelled it "likely flake" —
@@ -293,12 +295,12 @@ jobs:
             if cargo llvm-cov --workspace --tests --features tray --lcov --output-path coverage.lcov 2>&1 | tee cov-attempt.log; then
               exit 0
             fi
-            if [ "$attempt" -ge 2 ]; then
-              echo "::error::coverage failed again after retrying the profraw flake"
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::coverage failed after 2 signature-gated profraw-flake retries"
               exit 1
             fi
             if grep -qiE 'profdata|\.profraw|malformed instrumentation|raw profile|invalid instrumentation profile|failed to (load|merge).*profile|no profile can be merged' cov-attempt.log; then
-              echo "::warning::coverage attempt $attempt hit an llvm-cov profraw/profdata corruption flake; cleaning + retrying once"
+              echo "::warning::coverage attempt $attempt hit an llvm-cov profraw/profdata corruption flake; cleaning + retrying (max 2 retries)"
               cargo llvm-cov clean --workspace || true
               attempt=$((attempt + 1))
               continue


### PR DESCRIPTION
## Summary

Lead-authorized follow-up: raise the Coverage job's **signature-gated** profraw-corruption retry cap from 1 to 2. The gate itself is untouched — only the profraw/profdata corruption signature retries; a real `test ... FAILED` still fails fast with the honest label (the #1452/#1735 lesson).

## Evidence — three same-signature hits on 2026-06-11 alone

1. **PR #1982, run 27317… (attempt 1 + 2)**: double-flake — BOTH attempts of one run hit `invalid instrumentation profile data (file header is corrupt)` → exhausted the 1-retry cap → red → manual `gh run rerun --failed` → green. (Reported to lead at the time; this PR is the agreed "if double-flakes become frequent" follow-through.)
2. **PR #2001, run 27332387029**: `…profraw: invalid instrumentation profile data (file header is corrupt)` ×2 + `error: no profile can be merged`, with **zero** test failures (every suite line `test result: ok`) → red → manual rerun round-trip again.

Each occurrence costs an operator/agent round-trip on an otherwise-green PR. With the cap at 2, a same-run double-flake self-heals; a triple-flake (never observed) still fails with the explicit label.

## Diff

One comparison (`-ge 2` → `-ge 3`) + the two log lines/comment updated to match. `actionlint` reports nothing new (the SC2034 warning at ci.yml:124 is pre-existing on main — verified via `git stash` round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
