### PR TITLE
fix(#2005): canonical bot_token_env in quickstart template + symmetric creds fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 - **MSRV: declared `rust-version` corrected to 1.88 (#1994)** — the previous declaration (1.87) was false: the locked dependency set required up to rustc 1.95 (`sysinfo 0.39.3`), so `cargo install agend-terminal --locked` broke for anyone on 1.87–1.94 who trusted it. `sysinfo` is pinned to `0.38` (MSRV 1.88, no code changes — caught by the #1987 release gate on its first run, which now enforces the floor). Builders need rustc ≥ 1.88.
 
+### Fixed
+
+- **Fresh Telegram setup resolves at startup (#2005)** — the quickstart fleet.yaml template pinned the legacy `bot_token_env: AGEND_BOT_TOKEN` while `.env` was written under the canonical `AGEND_TELEGRAM_BOT_TOKEN`, and the credentials fallback retried the same legacy name — so a fresh install's Telegram channel failed to resolve at daemon startup (old installs were masked by leftover legacy `.env` keys). The template now pins the canonical name and the fallback is symmetric (configured name → the other of canonical/legacy), so all four fleet/.env drift combinations resolve; legacy use still warns.
+
 ### Added
 
 - **fleet.yaml `schema_version` + compatibility policy (#1989)** — `fleet.yaml` accepts an optional `schema_version:` field (omitted = `1`; existing files unchanged, the daemon never injects it). A file declaring a version newer than the daemon supports loads with a warning instead of being silently misread without trace. `docs/COMPATIBILITY.md` declares the on-disk interface tiers — (a) stable public (fleet.yaml, service templates, instruction blocks, MCP config), (b) internal persisted state, (c) regenerable/ephemeral — and the additive-only change rule for (a)/(b).

--- a/src/channel/telegram/creds.rs
+++ b/src/channel/telegram/creds.rs
@@ -1,6 +1,7 @@
 //! Telegram credential resolution — loads bot token + group id from fleet.yaml.
 
 /// Resolved Telegram channel credentials — avoids repeated fleet.yaml loads.
+#[derive(Debug)]
 pub(crate) struct TelegramCreds {
     pub(crate) token: String,
     pub(crate) group_id: i64,
@@ -10,7 +11,9 @@ pub(super) fn resolve_channel() -> anyhow::Result<(TelegramCreds, crate::fleet::
     resolve_channel_from(&crate::home_dir())
 }
 
-pub(super) fn resolve_channel_from(
+// pub(crate): the #2005 regression tests (quickstart) exercise the REAL
+// resolve entry against quickstart-generated fleet.yaml shapes.
+pub(crate) fn resolve_channel_from(
     home: &std::path::Path,
 ) -> anyhow::Result<(TelegramCreds, crate::fleet::FleetConfig)> {
     let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))?;
@@ -20,15 +23,38 @@ pub(super) fn resolve_channel_from(
             group_id,
             ..
         }) => {
+            // #2005: SYMMETRIC fallback. Pre-#2005 the only fallback was
+            // legacy-ward (`AGEND_BOT_TOKEN`) — dead code whenever
+            // `bot_token_env` already WAS the legacy name (exactly the pair
+            // the old quickstart template generated: fleet pinned the legacy
+            // name while `.env` was written under the canonical key, so a
+            // fresh install failed to resolve at startup). Order: the
+            // configured name first, then whichever of canonical/legacy it
+            // isn't — covering both drift directions (old fleet template +
+            // migrated `.env`, new template + legacy `.env`).
+            const CANONICAL: &str = "AGEND_TELEGRAM_BOT_TOKEN";
+            const LEGACY: &str = "AGEND_BOT_TOKEN";
             let token = std::env::var(bot_token_env)
                 .or_else(|_| {
-                    let legacy = std::env::var("AGEND_BOT_TOKEN");
-                    if legacy.is_ok() {
-                        tracing::warn!(
-                            "AGEND_BOT_TOKEN is deprecated — migrate to {bot_token_env}"
-                        );
+                    let fallback_name = if bot_token_env == CANONICAL {
+                        LEGACY
+                    } else {
+                        CANONICAL
+                    };
+                    let fallback = std::env::var(fallback_name);
+                    if fallback.is_ok() {
+                        if fallback_name == LEGACY {
+                            tracing::warn!(
+                                "AGEND_BOT_TOKEN is deprecated — migrate to {bot_token_env}"
+                            );
+                        } else {
+                            tracing::warn!(
+                                "fleet.yaml bot_token_env '{bot_token_env}' is not set; using \
+                                 {CANONICAL} — update bot_token_env to the canonical name"
+                            );
+                        }
                     }
-                    legacy
+                    fallback
                 })
                 .map_err(|_| anyhow::anyhow!("bot token env '{bot_token_env}' not set"))?;
             Ok((

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -509,14 +509,14 @@ fn generate_fleet_yaml(
             r#"
 channel:
   type: telegram
-  bot_token_env: AGEND_BOT_TOKEN
+  bot_token_env: AGEND_TELEGRAM_BOT_TOKEN
   group_id: {gid}
   mode: topic
   user_allowlist: []  # add your Telegram user_id (message @userinfobot to get it)
 "#
         )
     } else {
-        "\n# channel:\n#   type: telegram\n#   bot_token_env: AGEND_BOT_TOKEN\n#   group_id: YOUR_GROUP_ID\n#   user_allowlist: [YOUR_USER_ID]\n".to_string()
+        "\n# channel:\n#   type: telegram\n#   bot_token_env: AGEND_TELEGRAM_BOT_TOKEN\n#   group_id: YOUR_GROUP_ID\n#   user_allowlist: [YOUR_USER_ID]\n".to_string()
     };
 
     let workspace_dir = crate::paths::workspace_dir(home).join("general");
@@ -1424,6 +1424,106 @@ mod tests {
         assert!(
             yaml.contains("user_allowlist"),
             "commented-out channel section must mention user_allowlist; got:\n{yaml}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #2005: bot_token_env canonical/legacy resolution — REAL entry pins ──
+
+    /// Serialize env mutation across the #2005 tests (process-global vars).
+    fn token_env_guard() -> std::sync::MutexGuard<'static, ()> {
+        static G: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        G.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn clear_token_envs() {
+        std::env::remove_var("AGEND_TELEGRAM_BOT_TOKEN");
+        std::env::remove_var("AGEND_BOT_TOKEN");
+    }
+
+    /// Fresh-install shape: the NEW quickstart template (canonical
+    /// bot_token_env) + a `.env`-style canonical env var → the real resolve
+    /// entry must succeed. Pre-#2005 the template pinned the legacy name and
+    /// this exact shape failed at daemon startup.
+    #[test]
+    fn fresh_install_channel_resolves_2005() {
+        let _g = token_env_guard();
+        clear_token_envs();
+        let home = std::env::temp_dir().join(format!("agend-2005-fresh-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let backend = Backend::all()[0].clone();
+        generate_fleet_yaml(&home, &backend, Some(-100123), Some("t")).expect("gen");
+        let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("read");
+        assert!(
+            yaml.contains("bot_token_env: AGEND_TELEGRAM_BOT_TOKEN"),
+            "template must pin the CANONICAL env name (what save_env_token writes): {yaml}"
+        );
+        std::env::set_var("AGEND_TELEGRAM_BOT_TOKEN", "123:fresh");
+        let res = crate::channel::telegram::creds::resolve_channel_from(&home);
+        clear_token_envs();
+        let (creds, _) = res.expect("fresh install (canonical fleet + canonical env) must resolve");
+        assert_eq!(creds.token, "123:fresh");
+        assert_eq!(creds.group_id, -100123);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Old-install shape: new template + an old `.env` still carrying the
+    /// LEGACY key → resolves via the legacy fallback (deprecation warn).
+    #[test]
+    fn old_install_legacy_env_still_resolves_2005() {
+        let _g = token_env_guard();
+        clear_token_envs();
+        let home = std::env::temp_dir().join(format!("agend-2005-legacy-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let backend = Backend::all()[0].clone();
+        generate_fleet_yaml(&home, &backend, Some(-100123), Some("t")).expect("gen");
+        std::env::set_var("AGEND_BOT_TOKEN", "123:legacy");
+        let res = crate::channel::telegram::creds::resolve_channel_from(&home);
+        clear_token_envs();
+        let (creds, _) = res.expect("legacy .env key must keep working (old installs)");
+        assert_eq!(creds.token, "123:legacy");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// THE #2005 bug pin: an old-template fleet.yaml (bot_token_env pinned to
+    /// the LEGACY name) + a migrated/canonical-only env. Pre-#2005 the
+    /// fallback retried the SAME legacy name (dead code) and resolution
+    /// failed; the symmetric fallback must now find the canonical var.
+    #[test]
+    fn old_template_fleet_with_canonical_env_resolves_2005() {
+        let _g = token_env_guard();
+        clear_token_envs();
+        let home = std::env::temp_dir().join(format!("agend-2005-oldtmpl-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "defaults:\n  backend: claude\nchannel:\n  type: telegram\n  bot_token_env: AGEND_BOT_TOKEN\n  group_id: -100456\ninstances: {}\n",
+        )
+        .expect("write");
+        std::env::set_var("AGEND_TELEGRAM_BOT_TOKEN", "123:canon");
+        let res = crate::channel::telegram::creds::resolve_channel_from(&home);
+        clear_token_envs();
+        let (creds, _) = res
+            .expect("old fleet template + canonical-only env must resolve via symmetric fallback");
+        assert_eq!(creds.token, "123:canon");
+        assert_eq!(creds.group_id, -100456);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Negative: neither env set → clear error naming the configured var.
+    #[test]
+    fn no_token_env_errors_clearly_2005() {
+        let _g = token_env_guard();
+        clear_token_envs();
+        let home = std::env::temp_dir().join(format!("agend-2005-none-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let backend = Backend::all()[0].clone();
+        generate_fleet_yaml(&home, &backend, Some(-1), Some("t")).expect("gen");
+        let err = crate::channel::telegram::creds::resolve_channel_from(&home)
+            .expect_err("no env set must error");
+        assert!(
+            err.to_string().contains("AGEND_TELEGRAM_BOT_TOKEN"),
+            "error must name the configured var: {err}"
         );
         std::fs::remove_dir_all(&home).ok();
     }


### PR DESCRIPTION
## Summary

Fix #2005 — a **fresh quickstart Telegram setup failed to resolve at daemon startup**. The chain: the fleet.yaml template pinned the legacy `bot_token_env: AGEND_BOT_TOKEN` while `save_env_token` writes `.env` under the canonical `AGEND_TELEGRAM_BOT_TOKEN`; `load_dotenv` exports keys verbatim (no aliasing); and the creds fallback retried the **same** legacy name — dead code for exactly the pair quickstart itself generated. Old installs were masked by leftover legacy `.env` keys; the break hit only fresh installs, i.e. new external users.

### Changes
1. **quickstart template → canonical** (`src/quickstart.rs`, both the active and the commented channel arms) — matches what the same flow writes to `.env` and the serde default (`fleet::default_telegram_bot_token_env`). The #2003 `--unattended` path shares this generator, so it is fixed by the same edit (lead point 4 confirmed: unattended wrote the legacy name too, pre-fix).
2. **Symmetric creds fallback** (`src/channel/telegram/creds.rs`): configured name first, then whichever of canonical/legacy it isn't — covers **both** drift directions (old fleet template + migrated `.env`; new template + legacy `.env`). Legacy use keeps the deprecation warn; canonical-rescue warns naming the stale fleet field.
3. **4 regression tests through the REAL resolve entry** (`resolve_channel_from`, bumped `pub(super)` → `pub(crate)` for the cross-module test):
   - fresh-install shape (canonical fleet + canonical env) — failed pre-fix at the template level
   - old-install shape (canonical fleet + legacy env) — legacy compat preserved
   - **THE bug pin**: old-template fleet (legacy `bot_token_env`) + canonical-only env — failed pre-fix at the fallback level, now resolves
   - no-env → clear error naming the configured var
4. CHANGELOG `Fixed` entry.

### Drift-matrix coverage (post-fix)
| fleet `bot_token_env` | env var present | resolves |
|---|---|---|
| canonical | canonical | ✓ direct |
| canonical | legacy | ✓ fallback (deprecation warn) |
| legacy (old template) | canonical | ✓ fallback (stale-field warn) — **was broken** |
| legacy (old template) | legacy | ✓ direct |

## Validation
- fmt / clippy(tray) `-D warnings` clean.
- `cargo nextest -E 'test(/2005/)'` → 4/4.
- Full suite 3917/3918 (the 1 = known #1834 environmental, passes solo with bypass; `team_dedup_and_rejection` excluded per #1993).
- Note: test fixtures call the current 4-arg `generate_fleet_yaml`; if #2003 (5-arg) merges first, the auto-rebase will surface a one-line fixup.

Closes #2005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
