### PR TITLE
chore(#2016 #2018): honest #hook-shadow log wording + verify-claims protocol line

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL.md
+++ b/docs/FLEET-DEV-PROTOCOL.md
@@ -61,6 +61,8 @@ Every review report must include: `scope_source`, `audit_mode`, `reviewed_head`,
 
 The daemon HARD-gates this at report time: a `VERIFIED`/`REJECTED` with **no recognizable evidence token** (a `cargo`/`gh`/`clippy`/`grep` command line, or a `path:line` cite) is rejected back to the reviewer. The gate is deliberately **lenient** — it accepts any one recognized token and rejects only on total absence; it does NOT enforce a fixed format. (The §3.21 risk-tier review DEPTH remains lead/reviewer judgment — not daemon-enforced.)
 
+**Comments and prose are claims, not evidence (#2018).** Every factual assertion in a code comment, doc, or PR body is a claim to VERIFY against the code, never evidence in itself. Reachability / scope / "cannot happen" / "single chokepoint" claims must be proven from the actual guards and match arms in the source — author and reviewer alike. (2026-06-11 surfaced four in one day: a compaction-loss rationale that named dead code, a "single chokepoint" that several call sites bypassed, an "agy is a hook backend" that emitted zero events, and an "EXDEV" fallback on a same-directory rename.)
+
 ### 3.3.1 CI Verification Gate (Sprint 61)
 Before approving merge, orchestrator/reviewer MUST independently verify CI:
 

--- a/src/api/handlers/hook_event.rs
+++ b/src/api/handlers/hook_event.rs
@@ -29,14 +29,30 @@ pub(crate) fn handle_hook_event(params: &Value, ctx: &HandlerCtx) -> Value {
     // Shadow comparison: the screen-heuristic state at event receipt. This is
     // the PoC's primary output — production promotion is gated on this
     // agreement data.
-    let screen_state = {
+    let (screen_state, backend) = {
         let reg = agent::lock_registry(ctx.registry);
-        crate::fleet::resolve_uuid(ctx.home, name)
-            .and_then(|id| reg.get(&id).map(|h| h.core.lock().state.get_state()))
+        match crate::fleet::resolve_uuid(ctx.home, name).and_then(|id| {
+            reg.get(&id)
+                .map(|h| (h.core.lock().state.get_state(), h.backend_command.clone()))
+        }) {
+            Some((s, b)) => (Some(s), Some(b)),
+            None => (None, None),
+        }
     };
     let agree = match (derived, screen_state) {
         (Some(d), Some(s)) => Some(d == s),
         _ => None,
+    };
+    // #2016: #1523 promoted hooks to authoritative, so the static "shadow-mode —
+    // heuristic still drives" line is no longer true for a promoted backend.
+    // Reflect the LIVE disposition (fields unchanged — text only).
+    let drive = if backend
+        .as_deref()
+        .is_some_and(crate::daemon::hook_shadow::is_promoted)
+    {
+        "authoritative for this backend"
+    } else {
+        "shadow — heuristic drives"
     };
     tracing::info!(
         tag = "#hook-shadow",
@@ -47,7 +63,7 @@ pub(crate) fn handle_hook_event(params: &Value, ctx: &HandlerCtx) -> Value {
         hook_state = ?derived,
         screen_state = ?screen_state,
         agree = ?agree,
-        "hook event received (shadow-mode — heuristic still drives)"
+        "hook event received ({drive})"
     );
     json!({"ok": true, "derived_state": derived.map(|s| format!("{s:?}"))})
 }

--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -109,6 +109,13 @@ fn promotion_enabled() -> bool {
     std::env::var("AGEND_HOOK_STATE_POC").as_deref() == Ok("1")
 }
 
+/// #2016: is THIS backend's snapshot state currently DRIVEN by hooks (promoted),
+/// vs still shadow-only? Same gate `authoritative_state` applies — for the
+/// `#hook-shadow` log to describe the live disposition honestly.
+pub fn is_promoted(backend_command: &str) -> bool {
+    promotion_enabled() && crate::backend::Backend::parse_str(backend_command).has_state_hooks()
+}
+
 /// #1523 PROMOTION (phased v1): the authoritative `AgentState` written to the
 /// daemon's per-tick SNAPSHOT (`snapshot.json`).
 ///


### PR DESCRIPTION
Lightweight wrap-up batch — two doc/log-text changes, no behavior change.

## #2016 — `#hook-shadow` log reflects the live disposition
After #1523 promoted hooks to authoritative for claude, the hard-coded `"shadow-mode — heuristic still drives"` line is false for a promoted backend. New `hook_shadow::is_promoted(backend)` (the same flag + backend-strength gate `authoritative_state` applies) drives the wording: **"authoritative for this backend"** when promoted, **"shadow — heuristic drives"** otherwise. Log **fields are unchanged** (additive-only convention) — only the human-readable message text.

## #2018 — verify-your-claims line in the protocol
Added to `docs/FLEET-DEV-PROTOCOL.md` (the `include_str!` **source**, not the live copy — #1669) under the Evidence block:

> **Comments and prose are claims, not evidence.** Every factual assertion in a code comment, doc, or PR body is a claim to VERIFY against the code, never evidence in itself. Reachability / scope / "cannot happen" / "single chokepoint" claims must be proven from the actual guards and match arms in the source — author and reviewer alike.

Codifies the four caught in one day (2026-06-11): a compaction-loss rationale naming dead code (#1992), a "single chokepoint" several call sites bypassed (#2014), an "agy is a hook backend" that emitted 0 events (#2014), and an "EXDEV" fallback on a same-directory rename (#2017).

## Verification
`cargo fmt`, `cargo clippy --all-targets --features tray -D warnings` clean. Hook + protocol tests pass, including `cargo_include_invariant` (the doc is compiled in via `include_str!`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)