### PR TITLE
fix(#2020): false AwaitingOperator after restart — opencode resumed-idle pattern + productive-output veto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 
 ### Fixed
 
+- **False AwaitingOperator after daemon restart (#2020)** — two restart shapes forced a healthy agent into `AwaitingOperator`: an idle respawned opencode pane resuming a session renders no `Ask anything` placeholder (the Idle pattern never matched → `Starting` lingered → the startup-stall fallback fired, 3× live), and a busy respawned agent injected work immediately never renders the clean ready-prompt (same fallback during a silence window). Fixes: the opencode profile gains a lowest-priority Idle pattern on the persistent statusline hint (`ctrl+p commands`; working/error patterns still win first-match — verified against the full opencode replay-fixture suite), and the startup-stall arm is vetoed when the agent has rendered backend productive markers since this spawn (a real login prompt never renders tool chrome, so the fallback's actual job is preserved; echoed injected text does not count).
+
 - **Fresh Telegram setup resolves at startup (#2005)** — the quickstart fleet.yaml template pinned the legacy `bot_token_env: AGEND_BOT_TOKEN` while `.env` was written under the canonical `AGEND_TELEGRAM_BOT_TOKEN`, and the credentials fallback retried the same legacy name — so a fresh install's Telegram channel failed to resolve at daemon startup (old installs were masked by leftover legacy `.env` keys). The template now pins the canonical name and the fallback is symmetric (configured name → the other of canonical/legacy), so all four fleet/.env drift combinations resolve; legacy use still warns.
 
 ### Added

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -227,6 +227,17 @@ fn opencode_profile() -> BackendProfile {
             ),
             (AgentState::Idle, r"Ask anything"),
             (AgentState::Idle, r"Ask anything|tab agents"),
+            // #2020: a RESPAWNED opencode pane resuming a session renders NO
+            // "Ask anything" placeholder (the input box is bare `┃` lines) —
+            // the only stable idle chrome is the bottom statusline hint. Listed
+            // LAST so every working/error pattern above wins first-match (the
+            // statusline persists during Thinking/ToolUse/PermissionPrompt —
+            // `esc interrupt` / tool markers / perm chrome match first; grid
+            // validation = the opencode replay fixtures, #1559 discipline).
+            // Without this, a restarted idle opencode agent never leaves
+            // Starting and the startup-stall fallback forces a false
+            // AwaitingOperator (live: fixup-reviewer-3, 3× on 2026-06-11).
+            (AgentState::Idle, r"ctrl\+p commands"),
         ],
         behavioral: BehavioralConfig {
             silence_thinking_ms: 3000,
@@ -424,5 +435,42 @@ mod context_pattern_tests {
             .captures("Kiro · auto · ◔ 10%        ~/.agend-terminal/workspace/kiro")
             .expect("kiro live render matches");
         assert_eq!(&caps[1], "10");
+    }
+}
+
+#[cfg(test)]
+mod opencode_resumed_idle_2020 {
+    use super::*;
+
+    /// #2020 live shape 1 (fixup-reviewer-3, 3× on 2026-06-11): the tail of a
+    /// RESPAWNED opencode pane resuming a session — captured verbatim from the
+    /// stuck agent's live pane. No "Ask anything" placeholder anywhere; the
+    /// statusline hint is the only idle chrome. Must detect Idle, or the
+    /// agent never leaves Starting and the stall fallback fires.
+    const RESUMED_IDLE_TAIL: &str = "  ┃\n  ┃\n  ┃  Build · DeepSeek V4 Pro OpenCode Go\n\n          270.3K (27%) · $2.23  ctrl+p commands";
+
+    #[test]
+    fn resumed_idle_pane_detects_idle() {
+        let patterns = crate::state::StatePatterns::for_backend(&Backend::OpenCode);
+        assert_eq!(
+            patterns.detect(RESUMED_IDLE_TAIL),
+            Some(AgentState::Idle),
+            "resumed-session idle pane (no 'Ask anything') must read Idle"
+        );
+    }
+
+    /// Order pin: the statusline hint persists during WORK — a working pane
+    /// (with `esc interrupt`) must still detect Thinking, because the
+    /// working patterns precede the statusline Idle pattern (first match
+    /// wins). The opencode replay fixtures re-verify this on full captures.
+    #[test]
+    fn working_pane_with_statusline_still_detects_thinking() {
+        let working = format!("  working...  esc interrupt\n{RESUMED_IDLE_TAIL}");
+        let patterns = crate::state::StatePatterns::for_backend(&Backend::OpenCode);
+        assert_eq!(
+            patterns.detect(&working),
+            Some(AgentState::Thinking),
+            "statusline must not outrank the working marker"
+        );
     }
 }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1041,6 +1041,7 @@ fn reaction_kinds(to: crate::state::AgentState, propagation_enabled: bool) -> Ve
 /// position-gate). The runtime prompt states require all three gates; the real
 /// dialog satisfies all three, the meta-FP fails ≥1. Pure (file/now values are
 /// passed in) so it is unit-testable without a daemon.
+#[allow(clippy::too_many_arguments)] // pure decision fn — every gate input passed explicitly for testability
 fn awaiting_escalation_allowed(
     state: crate::state::AgentState,
     state_held: Duration,
@@ -1049,6 +1050,7 @@ fn awaiting_escalation_allowed(
     operator_typed_ms: i64,
     now_ms: i64,
     idle_expectation: crate::fleet::IdleExpectation,
+    produced_productive_output: bool,
 ) -> bool {
     use crate::state::AgentState;
     match state {
@@ -1059,7 +1061,20 @@ fn awaiting_escalation_allowed(
         // startup-stall fallback by role. (Part-B below role-gates
         // `InteractivePrompt` too — same prose-FP root — while `PermissionPrompt`
         // stays role-blind so a real permission dialog still escalates, #1552.)
-        AgentState::Starting => idle_expectation == crate::fleet::IdleExpectation::Active,
+        // #2020 veto: an agent that has rendered backend PRODUCTIVE MARKERS
+        // since this spawn is demonstrably working, not stalled at a login
+        // prompt — a busy respawned agent (injected work immediately, never
+        // renders the clean ready-prompt) hit a >30s silence window in
+        // `Starting` and was forced to a false AwaitingOperator (live:
+        // fixup-lead, 2026-06-11 20:09). Markers (tool-use chrome) are
+        // chosen over "any output after an inject" deliberately: a REAL
+        // login prompt can echo injected text (output!) but never renders
+        // tool chrome — so the veto can't blind the fallback's actual job.
+        // In-memory per spawn (StateTracker resets on respawn), so evidence
+        // from a previous life can't leak in.
+        AgentState::Starting => {
+            idle_expectation == crate::fleet::IdleExpectation::Active && !produced_productive_output
+        }
         AgentState::PermissionPrompt | AgentState::InteractivePrompt => {
             // #1563 part-B: split the role policy across the two prompt states.
             // `PermissionPrompt` is chrome-anchored (#1546, near-zero FP), so a
@@ -1279,6 +1294,7 @@ fn tick(
                     typed_ms,
                     crate::daemon::heartbeat_pair::now_ms() as i64,
                     idle_expectation,
+                    core.state.last_productive_output.is_some(),
                 )
             } {
                 // #1552 Half-1 #3: set the HEALTH reason — `check_hang` exempts
@@ -2464,6 +2480,7 @@ mod tests {
             0,
             0,
             crate::fleet::IdleExpectation::Active,
+            false,
         ));
     }
 
@@ -2479,6 +2496,7 @@ mod tests {
             0,
             0,
             crate::fleet::IdleExpectation::OnDemand,
+            false,
         ));
     }
 
@@ -2492,6 +2510,7 @@ mod tests {
             0,           // operator never typed
             10_000,
             crate::fleet::IdleExpectation::Active,
+            false,
         ));
     }
 
@@ -2509,6 +2528,7 @@ mod tests {
             0,
             10_000,
             crate::fleet::IdleExpectation::OnDemand,
+            false,
         ));
     }
 
@@ -2533,6 +2553,7 @@ mod tests {
             0,
             10_000,
             crate::fleet::IdleExpectation::OnDemand,
+            false,
         ));
     }
 
@@ -2548,6 +2569,7 @@ mod tests {
             0,
             10_000,
             crate::fleet::IdleExpectation::Active,
+            false,
         ));
     }
 
@@ -2563,6 +2585,7 @@ mod tests {
             0,
             10_000,
             crate::fleet::IdleExpectation::Active,
+            false,
         ));
     }
 
@@ -2616,6 +2639,44 @@ instances:
             0,
             10_000,
             crate::fleet::IdleExpectation::Active,
+            false,
+        ));
+    }
+
+    /// #2020 live shape 2 (fixup-lead, 2026-06-11 20:09): a respawned agent
+    /// that was injected work immediately never renders the clean
+    /// ready-prompt — heuristic stays `Starting` — but it HAS rendered
+    /// productive markers. The startup-stall arm must veto: demonstrably
+    /// working ≠ stalled at a login prompt.
+    #[test]
+    fn starting_stall_vetoed_by_productive_output_2020() {
+        assert!(!awaiting_escalation_allowed(
+            crate::state::AgentState::Starting,
+            Duration::from_secs(120),
+            Some(crate::backend::Backend::ClaudeCode),
+            "tail irrelevant for the Starting arm",
+            0,
+            10_000,
+            crate::fleet::IdleExpectation::Active,
+            true, // productive markers seen since this spawn
+        ));
+    }
+
+    /// #2020 guard on the guard: with NO productive output since spawn the
+    /// startup-stall fallback must still fire — a real login-prompt stall
+    /// (the fallback's actual job) renders no tool chrome, and echoed
+    /// injected text doesn't count (markers, not raw output).
+    #[test]
+    fn starting_stall_still_fires_without_productive_output_2020() {
+        assert!(awaiting_escalation_allowed(
+            crate::state::AgentState::Starting,
+            Duration::from_secs(120),
+            Some(crate::backend::Backend::ClaudeCode),
+            "Please log in to continue",
+            0,
+            10_000,
+            crate::fleet::IdleExpectation::Active,
+            false,
         ));
     }
 
@@ -2630,6 +2691,7 @@ instances:
             0,
             10_000,
             crate::fleet::IdleExpectation::Active,
+            false,
         ));
     }
 
@@ -2645,6 +2707,7 @@ instances:
             now - 2_000,
             now,
             crate::fleet::IdleExpectation::Active,
+            false,
         ));
     }
 
@@ -2664,6 +2727,7 @@ instances:
                     0,
                     10_000,
                     crate::fleet::IdleExpectation::Active,
+                    false,
                 ),
                 "{s:?} must never escalate via this path"
             );


### PR DESCRIPTION
## Summary

Fix #2020 — both operator-caught restart shapes traced to one root: **after a daemon restart the ready-pattern fails to match for respawned agents** → `Starting` lingers past the 30s silence gate → the startup-stall fallback (whose `Starting` arm has NO position/stability/engagement gates — only silence + role) forces a false `AwaitingOperator`.

### Shape 1 — idle opencode (fixup-reviewer-3, 3/3 restarts today)
**Spike answer (Q1)**: a respawned pane *resuming a session* renders **no `Ask anything` placeholder** — the input box is bare `┃` lines (captured live from the stuck agent). Both existing Idle patterns key on that placeholder → Idle never matches.
**Fix**: lowest-priority Idle pattern on the persistent statusline hint `ctrl\+p commands`. The statusline persists during work/perm states, so **first-match order protects it** (`esc interrupt` / tool markers / perm chrome precede it in the vec) — pinned by a unit test on the live capture + a working-pane contrast test, and **grid-validated by the full opencode replay-fixture suite** (#1559 discipline: `ctrl+p` IS raw-present in the thinking/tooluse/perm fixtures; every expected transition sequence still passes).

### Shape 2 — busy claude (fixup-lead, 20:09)
**Spike answer (Q2)**: the `Starting` arm's only gates are silence>30s + role — a busy respawned agent (injected work immediately, never renders the pristine prompt) sails through during any 30s output lull.
**Fix**: veto the `Starting` arm when the agent has rendered **backend productive markers since this spawn**. Deviation from the issue's "received inject + any output" suggestion, deliberately: a *real* login prompt can **echo** injected text (= output!) but never renders tool chrome — markers keep the fallback's actual job (true login-stall detection) intact, the under-force-never-falsely-lift direction the dispatch required. `last_productive_output` is in-memory per spawn (StateTracker resets on respawn) → no cross-life leakage.

### Deferred (documented in the commit)
Hook-side (a)/(b) from the issue: with the veto, hook-backend agents no longer false-latch **at the source**, and the heuristic fix covers non-hook backends — (a)/(b) belong to the #1523 phase-2 umbrella.

## Tests
- `resumed_idle_pane_detects_idle` — the live-captured stuck pane tail → `Idle`.
- `working_pane_with_statusline_still_detects_thinking` — order pin.
- `starting_stall_vetoed_by_productive_output_2020` / `starting_stall_still_fires_without_productive_output_2020` — veto + legacy-fire guard on the guard.
- `replay_manifest_regression` green across all opencode fixtures (grid validation).

## Preflight
fmt / clippy(tray) `-D warnings` clean; nextest **3975/3976** (the 1 = known #1834 environmental, passes solo with bypass; `team_dedup` excluded per #1993).

Closes #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
