### PR TITLE
fix(#2027): non-fleet repo `git branch <name>` passes through, never lies success

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -120,6 +120,7 @@ fn main() {
             is_agent_caller,
         ),
         subcommand,
+        &args,
         cwd_is_foreign_repo(&binding),
     );
 
@@ -494,13 +495,51 @@ fn is_mutating_local(subcmd: &str) -> bool {
     )
 }
 
-/// #1463 (A): convert a bound-agent `ChdirPass` into `Passthrough` when the
-/// command is a local mutating one AND cwd is a foreign repo. Pure so the
-/// matrix is unit-testable; everything else (push/checkout ChdirPass, Deny,
-/// already-Passthrough) is returned unchanged.
-fn apply_foreign_repo_passthrough(action: Action, subcmd: &str, cwd_foreign: bool) -> Action {
+/// #2027: a `git branch` / `git tag` invocation that NAMES a ref — it creates,
+/// deletes, moves, or inspects a SPECIFIC ref (a positional ref name, or a
+/// `-d`/`-D`/`-m`/`-M`/`-c`/`-C`/`--delete`/`--move`/`--copy` flag) — as opposed to
+/// the bare `git branch` LIST form. `classify` groups `branch`/`tag` with the
+/// read-only commands (they DEFAULT to listing), so a bound agent's
+/// `git branch <name>` is `ChdirPass`'d into the worktree. In a FOREIGN repo that
+/// is the #2027 success-lie: `git branch <new>` runs against the worktree, so the
+/// foreign repo silently gets nothing yet exits 0; a name the worktree already
+/// holds reports `fatal: already exists` from the wrong repo. A ref-naming
+/// branch/tag in a foreign repo must run against THAT repo (passthrough).
+///
+/// Conservative by design: over-classifying (e.g. `git branch --list <pattern>`)
+/// only adds the CORRECT foreign-passthrough (the pattern list should run on the
+/// foreign repo too); under-classifying is the bug. Only `args[0]` (the
+/// subcommand) is skipped — `args[1..]` are scanned for a ref-mutating flag or a
+/// positional ref name.
+fn branch_tag_names_ref(subcmd: &str, args: &[String]) -> bool {
+    if !matches!(subcmd, "branch" | "tag") {
+        return false;
+    }
+    args.iter().skip(1).any(|a| {
+        matches!(
+            a.as_str(),
+            "-d" | "-D" | "--delete" | "-m" | "-M" | "--move" | "-c" | "-C" | "--copy"
+        ) || !a.starts_with('-') // a positional ref name / pattern
+    })
+}
+
+/// #1463 (A) + #2027: convert a bound-agent `ChdirPass` into `Passthrough` when
+/// cwd is a foreign repo AND the command is a local mutating one (#1463) or a
+/// ref-naming `branch`/`tag` (#2027). Pure so the matrix is unit-testable;
+/// everything else (push/checkout ChdirPass, Deny, already-Passthrough) is
+/// returned unchanged.
+fn apply_foreign_repo_passthrough(
+    action: Action,
+    subcmd: &str,
+    args: &[String],
+    cwd_foreign: bool,
+) -> Action {
     match action {
-        Action::ChdirPass(_) if cwd_foreign && is_mutating_local(subcmd) => Action::Passthrough,
+        Action::ChdirPass(_)
+            if cwd_foreign && (is_mutating_local(subcmd) || branch_tag_names_ref(subcmd, args)) =>
+        {
+            Action::Passthrough
+        }
         other => other,
     }
 }
@@ -1685,6 +1724,30 @@ mod tests {
             action,
             Action::ChdirPass("/tmp/.worktrees/dev".into()),
             "bound read-tree must route to the private worktree, not deny"
+        );
+    }
+
+    /// #2027 chain precondition: a BOUND agent's ref-naming `git branch <name>`
+    /// lands in the read-only group → `ChdirPass(worktree)`. That ChdirPass is the
+    /// exact input `apply_foreign_repo_passthrough` must flip to `Passthrough` in a
+    /// foreign repo — pinning the full classify→apply chain that produced the
+    /// success-lie (the redirect ran the create against the worktree, so the
+    /// foreign repo silently got nothing yet the shim exited 0).
+    #[test]
+    fn bound_branch_create_classifies_to_chdirpass_2027() {
+        let action = classify(
+            "branch",
+            &["branch".into(), "feat-x".into()],
+            &bound_binding("feat/x", "/tmp/.worktrees/dev"),
+            false,
+            false,
+            true,
+        );
+        assert_eq!(
+            action,
+            Action::ChdirPass("/tmp/.worktrees/dev".into()),
+            "bound `git branch <name>` must classify to the read-only group's \
+             ChdirPass — the #2027 redirect apply_foreign_repo_passthrough flips"
         );
     }
 
@@ -3063,37 +3126,134 @@ mod tests {
     #[test]
     fn foreign_passthrough_action_matrix_1463() {
         use Action::*;
+        let a = |toks: &[&str]| toks.iter().map(|s| s.to_string()).collect::<Vec<_>>();
         // local mutating + foreign → Passthrough
         assert_eq!(
-            apply_foreign_repo_passthrough(ChdirPass("wt".into()), "commit", true),
+            apply_foreign_repo_passthrough(ChdirPass("wt".into()), "commit", &a(&["commit"]), true),
             Passthrough
         );
         assert_eq!(
-            apply_foreign_repo_passthrough(ChdirPass("wt".into()), "add", true),
+            apply_foreign_repo_passthrough(ChdirPass("wt".into()), "add", &a(&["add"]), true),
             Passthrough
         );
         // local mutating + NOT foreign → unchanged ChdirPass
         assert_eq!(
-            apply_foreign_repo_passthrough(ChdirPass("wt".into()), "commit", false),
+            apply_foreign_repo_passthrough(
+                ChdirPass("wt".into()),
+                "commit",
+                &a(&["commit"]),
+                false
+            ),
             ChdirPass("wt".into())
         );
         // push / checkout are NOT local-mutating → stay ChdirPass even if foreign
         assert_eq!(
-            apply_foreign_repo_passthrough(ChdirPass("wt".into()), "push", true),
+            apply_foreign_repo_passthrough(ChdirPass("wt".into()), "push", &a(&["push"]), true),
             ChdirPass("wt".into())
         );
         assert_eq!(
-            apply_foreign_repo_passthrough(ChdirPass("wt".into()), "checkout", true),
+            apply_foreign_repo_passthrough(
+                ChdirPass("wt".into()),
+                "checkout",
+                &a(&["checkout"]),
+                true
+            ),
             ChdirPass("wt".into())
         );
         // non-ChdirPass inputs are returned verbatim
         assert_eq!(
-            apply_foreign_repo_passthrough(Deny("x".into()), "commit", true),
+            apply_foreign_repo_passthrough(Deny("x".into()), "commit", &a(&["commit"]), true),
             Deny("x".into())
         );
         assert_eq!(
-            apply_foreign_repo_passthrough(Passthrough, "commit", true),
+            apply_foreign_repo_passthrough(Passthrough, "commit", &a(&["commit"]), true),
             Passthrough
+        );
+    }
+
+    // #2027 (§3.9): a ref-naming `branch`/`tag` in a FOREIGN repo must pass through
+    // (run against THAT repo), never be ChdirPass'd into the worktree — the
+    // worktree-redirect is the success-lie (silent no-op + exit 0 for a create; a
+    // fake `already exists` for a name the worktree already holds). Mirrors the
+    // issue's deterministic 3-shape repro matrix.
+    #[test]
+    fn branch_tag_names_ref_classifier_2027() {
+        let a = |toks: &[&str]| toks.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        // create: positional ref name → names a ref
+        assert!(branch_tag_names_ref("branch", &a(&["branch", "feat-x"])));
+        assert!(branch_tag_names_ref("tag", &a(&["tag", "v1.0"])));
+        // delete / move / copy flags → name a ref
+        assert!(branch_tag_names_ref(
+            "branch",
+            &a(&["branch", "-d", "feat-x"])
+        ));
+        assert!(branch_tag_names_ref(
+            "branch",
+            &a(&["branch", "-m", "old", "new"])
+        ));
+        assert!(branch_tag_names_ref("tag", &a(&["tag", "-d", "v1.0"])));
+        // bare LIST form (no positional, list/inspect flags only) → does NOT name a ref
+        assert!(!branch_tag_names_ref("branch", &a(&["branch"])));
+        assert!(!branch_tag_names_ref("branch", &a(&["branch", "-a"])));
+        assert!(!branch_tag_names_ref("branch", &a(&["branch", "-v", "-v"])));
+        assert!(!branch_tag_names_ref("tag", &a(&["tag", "-l"])));
+        // non-branch/tag subcommands are never ref-naming here (handled elsewhere)
+        assert!(!branch_tag_names_ref("commit", &a(&["commit", "-m", "x"])));
+        assert!(!branch_tag_names_ref("status", &a(&["status"])));
+    }
+
+    // #2027 (§3.9): the end-to-end conversion — bound-agent `git branch <name>` in
+    // a foreign repo flips ChdirPass→Passthrough (no lie); fleet (non-foreign) and
+    // the bare LIST form stay ChdirPass byte-identical.
+    #[test]
+    fn foreign_passthrough_branch_tag_matrix_2027() {
+        use Action::*;
+        let a = |toks: &[&str]| toks.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        // Shape 1 — never-seen create name, foreign → Passthrough (was: silent no-op exit 0)
+        assert_eq!(
+            apply_foreign_repo_passthrough(
+                ChdirPass("wt".into()),
+                "branch",
+                &a(&["branch", "zz-new"]),
+                true
+            ),
+            Passthrough
+        );
+        // Shape 2 — name the worktree already holds, foreign → Passthrough
+        // (was: fake `already exists` exit 128 from the worktree)
+        assert_eq!(
+            apply_foreign_repo_passthrough(
+                ChdirPass("wt".into()),
+                "branch",
+                &a(&["branch", "feat-x"]),
+                true
+            ),
+            Passthrough
+        );
+        // tag create, foreign → Passthrough
+        assert_eq!(
+            apply_foreign_repo_passthrough(
+                ChdirPass("wt".into()),
+                "tag",
+                &a(&["tag", "v1.0"]),
+                true
+            ),
+            Passthrough
+        );
+        // FLEET (non-foreign) ref-naming branch → unchanged ChdirPass (byte-identical)
+        assert_eq!(
+            apply_foreign_repo_passthrough(
+                ChdirPass("wt".into()),
+                "branch",
+                &a(&["branch", "feat-x"]),
+                false
+            ),
+            ChdirPass("wt".into())
+        );
+        // bare LIST form, even foreign → unchanged ChdirPass (read-only, no lie)
+        assert_eq!(
+            apply_foreign_repo_passthrough(ChdirPass("wt".into()), "branch", &a(&["branch"]), true),
+            ChdirPass("wt".into())
         );
     }
 

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -524,17 +524,19 @@ fn branch_tag_names_ref(subcmd: &str, args: &[String]) -> bool {
         )
         // CURRENT-branch mutators that need NO positional (the git-branch upstream /
         // description ops) — dash-prefixed, so the positional check below misses
-        // them. `--set-upstream-to=<up>` takes the `=` form; `-u <up>` /
-        // `--set-upstream-to <up>` take a following value (itself caught as a
-        // positional, but matched here so the no-value-yet form is covered too).
+        // them. `--set-upstream-to=<up>` takes the `=` form; `--set-upstream-to <up>`
+        // takes a following value (caught as a positional, but matched here so the
+        // no-value-yet form is covered too).
         || matches!(
             s,
-            "-u" | "--set-upstream-to"
-                | "--set-upstream"
-                | "--unset-upstream"
-                | "--edit-description"
+            "--set-upstream-to" | "--set-upstream" | "--unset-upstream" | "--edit-description"
         )
         || s.starts_with("--set-upstream-to=")
+        // `-u <up>` (separate, value caught as positional) AND the GLUED short form
+        // `-u<up>` (e.g. `-uorigin/main`, value attached in one dash-prefixed token —
+        // missed by both the exact `== "-u"` and the positional check). codex r2.
+        || s == "-u"
+        || (s.starts_with("-u") && s.len() > 2)
         // A positional ref name / pattern / flag value.
         || !s.starts_with('-')
     })
@@ -3224,6 +3226,12 @@ mod tests {
             "branch",
             &a(&["branch", "-u", "origin/main"])
         ));
+        // codex r2: the GLUED short form `-u<up>` (value attached, one token) —
+        // missed by both the exact `-u` match and the positional check.
+        assert!(branch_tag_names_ref(
+            "branch",
+            &a(&["branch", "-uorigin/main"])
+        ));
         assert!(branch_tag_names_ref(
             "branch",
             &a(&["branch", "--unset-upstream"])
@@ -3287,6 +3295,16 @@ mod tests {
                 ChdirPass("wt".into()),
                 "branch",
                 &a(&["branch", "--set-upstream-to=origin/main"]),
+                true
+            ),
+            Passthrough
+        );
+        // #2030 codex r2: the glued short form `-u<up>`, foreign → Passthrough
+        assert_eq!(
+            apply_foreign_repo_passthrough(
+                ChdirPass("wt".into()),
+                "branch",
+                &a(&["branch", "-uorigin/main"]),
                 true
             ),
             Passthrough

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -516,10 +516,27 @@ fn branch_tag_names_ref(subcmd: &str, args: &[String]) -> bool {
         return false;
     }
     args.iter().skip(1).any(|a| {
+        let s = a.as_str();
+        // Create / delete / move / copy a NAMED ref.
         matches!(
-            a.as_str(),
+            s,
             "-d" | "-D" | "--delete" | "-m" | "-M" | "--move" | "-c" | "-C" | "--copy"
-        ) || !a.starts_with('-') // a positional ref name / pattern
+        )
+        // CURRENT-branch mutators that need NO positional (the git-branch upstream /
+        // description ops) — dash-prefixed, so the positional check below misses
+        // them. `--set-upstream-to=<up>` takes the `=` form; `-u <up>` /
+        // `--set-upstream-to <up>` take a following value (itself caught as a
+        // positional, but matched here so the no-value-yet form is covered too).
+        || matches!(
+            s,
+            "-u" | "--set-upstream-to"
+                | "--set-upstream"
+                | "--unset-upstream"
+                | "--edit-description"
+        )
+        || s.starts_with("--set-upstream-to=")
+        // A positional ref name / pattern / flag value.
+        || !s.starts_with('-')
     })
 }
 
@@ -3192,6 +3209,29 @@ mod tests {
             &a(&["branch", "-m", "old", "new"])
         ));
         assert!(branch_tag_names_ref("tag", &a(&["tag", "-d", "v1.0"])));
+        // #2030 (codex): CURRENT-branch mutators with NO positional token — they
+        // write `branch.<cur>.merge` / the description, so a foreign-repo redirect
+        // would still lie. All four forms must name a ref.
+        assert!(branch_tag_names_ref(
+            "branch",
+            &a(&["branch", "--set-upstream-to=origin/main"])
+        ));
+        assert!(branch_tag_names_ref(
+            "branch",
+            &a(&["branch", "--set-upstream-to", "origin/main"])
+        ));
+        assert!(branch_tag_names_ref(
+            "branch",
+            &a(&["branch", "-u", "origin/main"])
+        ));
+        assert!(branch_tag_names_ref(
+            "branch",
+            &a(&["branch", "--unset-upstream"])
+        ));
+        assert!(branch_tag_names_ref(
+            "branch",
+            &a(&["branch", "--edit-description"])
+        ));
         // bare LIST form (no positional, list/inspect flags only) → does NOT name a ref
         assert!(!branch_tag_names_ref("branch", &a(&["branch"])));
         assert!(!branch_tag_names_ref("branch", &a(&["branch", "-a"])));
@@ -3236,6 +3276,17 @@ mod tests {
                 ChdirPass("wt".into()),
                 "tag",
                 &a(&["tag", "v1.0"]),
+                true
+            ),
+            Passthrough
+        );
+        // #2030 (codex): a no-positional current-branch mutator, foreign → Passthrough
+        // (was: ChdirPass wrote branch.<cur>.merge into the worktree, the lie)
+        assert_eq!(
+            apply_foreign_repo_passthrough(
+                ChdirPass("wt".into()),
+                "branch",
+                &a(&["branch", "--set-upstream-to=origin/main"]),
                 true
             ),
             Passthrough


### PR DESCRIPTION
Closes #2027.

## The bug (deterministic repro in the issue)

The shim groups `branch`/`tag` with the **read-only** commands (they default to
*listing*), so a **bound** agent's ref-naming `git branch <name>` is
`ChdirPass`'d into its worktree. In a **foreign** repo (a separate object store —
e.g. a test scratch repo) that is a **success-lie**:

| shape | command | before | after |
|---|---|---|---|
| 1 | `git branch <new>` (foreign, no bypass) | **silent no-op, exit 0** (create ran against the worktree) | creates in the foreign repo ✓ |
| 2 | `git branch <name-the-worktree-has>` | **`fatal: already exists`, exit 128** from the wrong repo | creates in the foreign repo ✓ |

Shape 1's exit-0 poisons `&&` chains; shape 2 leaks the worktree's ref state.

## Root cause (verify-first correction to the issue)

Both shapes are the **worktree-redirect**, *not* a separate "global registry" as
shape 2's framing suspected — the `already exists` is real `git` answering from
the redirected worktree. `apply_foreign_repo_passthrough` already flips a foreign
`ChdirPass`→`Passthrough` for mutating-local commands (#1463), but `branch`/`tag`
were never in `is_mutating_local`, so the conversion never reached them.

## Fix — lead's "non-fleet repo → real git" direction

Extend the foreign-passthrough to a **ref-naming** `branch`/`tag`
(`branch_tag_names_ref`: a positional ref name, or a `-d`/`-D`/`-m`/`-M`/`-c`/`-C`
delete/move/copy flag — the bare LIST form is excluded). Gated on
`cwd_is_foreign_repo` (commondir-identity, **fail-closed**: canonical + every
sibling worktree share canonical's commondir, so `true` means a *genuinely*
separate store — the lead's "how reliable is the detection?" concern is answered
by this existing detector). **Deny is never needed** because passthrough is
honest — the iron rule (deny is OK, lie is NOT) holds with the cleaner option.

Conservative by design: over-classifying (`git branch --list <pattern>`) only
adds the *correct* foreign-passthrough; under-classifying is the bug.

## Fleet behavior is byte-identical

`cwd_foreign=false` (worktree / canonical / siblings) → not converted → unchanged
`ChdirPass`. The bare LIST form stays `ChdirPass` even when foreign (read-only, no
lie). Only genuinely-foreign repos change. The shim is the #821/#1463 security
mechanism — the interception path is untouched.

## §3.9 tests (3, pinning the full classify→apply chain)

- `branch_tag_names_ref_classifier_2027` — create/delete/move vs the LIST form
- `foreign_passthrough_branch_tag_matrix_2027` — issue shapes 1+2 + tag + fleet-byte-identical + bare-list
- `bound_branch_create_classifies_to_chdirpass_2027` — chain precondition: bound `branch <name>` → `ChdirPass` (the exact input the conversion flips)

## Verification

- `cargo nextest --bin agend-git`: **53/53 pass** (50 prior + 3 new)
- `scripts/preflight.sh --quick`: fmt --check / clippy `--all-targets --features tray -D warnings` / `--tests --features tray` all **clean** (Windows skipped per `--quick` — pure-logic change, no platform-specific code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)