### PR TITLE
fix(#2031): rebalance dispatch-idle default (600→1800s) + tier the escalation

### DIFF
--- a/docs/FEATURE-dispatch-idle.md
+++ b/docs/FEATURE-dispatch-idle.md
@@ -51,11 +51,24 @@ This creates a dispatch idle sidecar. After 600 seconds (10 minutes), the
 daemon checks whether a matching `kind=report` (by `correlation_id`) has been
 received.
 
-### Fixup Team Defaults
+### Team Defaults
 
-For the fixup team, `kind=task` and `kind=query` dispatches automatically
-inherit a 10-minute idle tracking window. No manual `expect_reply_within_secs`
-is needed. Other teams must specify it explicitly.
+For any team member, `kind=task` and `kind=query` dispatches automatically
+inherit a **30-minute** idle tracking window (`DEFAULT_DISPATCH_THRESHOLD_SECS`).
+No manual `expect_reply_within_secs` is needed; an explicit value still overrides
+it per-dispatch. Teamless (solo) dispatchers are not tracked. (#2031 raised the
+default from 10 → 30 minutes: modern tasks run 10–40+ min with bursty activity,
+so the 10-minute default false-fired on between-turns gaps.)
+
+### Escalation tiering (#2031)
+
+The two notifications are SEQUENCED, not simultaneous:
+
+1. At `threshold_secs`, the **dispatcher** receives `dispatch_idle_threshold_exceeded`
+   (cheap — a lead pane-check). The sidecar is stamped `exceeded_at`.
+2. Only if the dispatch is still unresolved `ESCALATE_TO_AGENT_AFTER_SECS` (10 min)
+   later does the **agent** receive the `dispatch_idle_nudge` interrupt — the
+   costlier message, deferred so the dispatcher has a window to act first.
 
 ### Parameter Reference
 
@@ -177,17 +190,20 @@ Expired, cleaned-up, or report-dismissed sidecars do not appear.
 
 ## Configuration
 
-### Environment Variables
+The thresholds are compile-time constants (no environment override); tune a
+single dispatch with `expect_reply_within_secs` instead.
 
-| Variable | Default | Description |
+| Constant | Default | Description |
 |----------|---------|-------------|
-| `AGEND_DISPATCH_IDLE_THRESHOLD_SECS` | 600 | Default timeout for the fixup team |
+| `DEFAULT_DISPATCH_THRESHOLD_SECS` | 1800 (30 min) | L1: team dispatch idle window when `expect_reply_within_secs` is unset |
+| `ESCALATE_TO_AGENT_AFTER_SECS` | 600 (10 min) | L2: extra wait past `exceeded_at` before the agent nudge fires |
 
 ### Behavioral Details
 
 - Scan frequency: every 60 seconds (synced with the daemon tick cycle).
 - Each sidecar triggers at most one L1 exceeded notification and one L2 nudge.
-- L1 notification target: dispatcher.
+- L1 notification target: dispatcher; L2 nudge target: the dispatchee (agent),
+  deferred to the second escalation window (#2031).
 - L2 nudge target: target (recipient).
 - Tracking dismissal uses `correlation_id`, not sender or target identity.
 

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -1856,8 +1856,9 @@ mod tests {
         assert_eq!(entry.dispatcher, "fixup-lead");
         assert_eq!(entry.target, "fixup-reviewer");
         assert_eq!(
-            entry.threshold_secs, 600,
-            "L2 must inject the 600s fixup default"
+            entry.threshold_secs,
+            crate::daemon::dispatch_idle::team_nudge::DEFAULT_DISPATCH_THRESHOLD_SECS,
+            "L2 must inject the team default threshold (#2031: 1800s)"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -100,13 +100,22 @@ pub(crate) struct PendingDispatch {
     /// fired (escalate-don't-repeat). Cleared with the sidecar on resolution.
     #[serde(default)]
     pub(crate) long_running_escalated: bool,
+    /// #2031: timestamp L1 flipped `status` to `Exceeded` (i.e. when the DISPATCHER
+    /// was notified via `..._exceeded`). L2 reads it to TIER the escalation: the
+    /// agent `..._nudge` — the costlier interrupt — is the SECOND rung, deferred
+    /// until [`team_nudge::ESCALATE_TO_AGENT_AFTER_SECS`] past this stamp so the
+    /// dispatcher gets a window to act first. `None` (legacy / pre-#2031 sidecar)
+    /// fails OPEN to the old immediate-nudge behavior — a missing stamp must never
+    /// SUPPRESS a real nudge.
+    #[serde(default)]
+    pub(crate) exceeded_at: Option<String>,
 }
 
 /// #2008-p2: max activity-based deadline extensions before the watchdog escalates
 /// ONCE with a "long-running — confirm expected" notice instead of refreshing
-/// forever. 3 × the dispatch threshold (≈30min at the 600s default) — long enough
-/// that a genuine long task isn't pestered, short enough that a stuck-in-loop
-/// agent surfaces for an operator confirm within a bounded window.
+/// forever. 3 × the dispatch threshold (≈90min at the #2031 1800s default) — long
+/// enough that a genuine long task isn't pestered, short enough that a
+/// stuck-in-loop agent surfaces for an operator confirm within a bounded window.
 const REFRESH_CAP: u32 = 3;
 
 /// #1658: how many consecutive not-working `scan_and_emit` ticks (past
@@ -114,10 +123,19 @@ const REFRESH_CAP: u32 = 3;
 /// single brief idle gap during active work is the common false-fire; requiring
 /// a short streak filters it. Cost to a genuinely-stuck agent is at most
 /// `(DEBOUNCE_SCANS - 1) * scan-cadence` of extra delay — negligible vs the
-/// 600s threshold. NOTE: this debounces the EXISTING #1516 gate; it does not
+/// dispatch threshold. NOTE: this debounces the EXISTING #1516 gate; it does not
 /// add a missing gate. The structurally-correct fix (gate on output-recency, not
 /// instantaneous state — `AgentSnapshot` has no activity timestamp today) is a
 /// documented follow-up if the residual is still annoying after this + #1657.
+///
+/// #2031 direction-3 (count "any completed turn since dispatch" as progress) was
+/// SPIKED and DEFERRED to this same follow-up: the only turn-end signal is the
+/// Stop hook event, which today lives only in the `AGEND_HOOK_STATE_POC`-gated,
+/// claude-only hook_shadow layer (#1523/#2014) — not cheaply in the per-tick
+/// snapshot. Folding it in is the "太繞" path; #2031 ships directions 1+2 (1800s
+/// default + tiered escalation) instead, which already require ≥40min of genuine
+/// silence before the costly agent interrupt. Revisit once hook state is promoted
+/// past the POC flag and a turn-end timestamp lands in `AgentSnapshot` (#2008).
 const DEBOUNCE_SCANS: u32 = 3;
 
 /// #1636: lifecycle of a dispatch-idle sidecar, replacing the stringly-typed
@@ -246,6 +264,10 @@ pub(crate) fn record_dispatch(
             // is silently eaten by the stale latch.
             existing.refresh_count = 0;
             existing.long_running_escalated = false;
+            // #2031: a revived (Exceeded→Pending) sidecar's escalation stamp is now
+            // stale — clear it so L2's second-window timer restarts from the next
+            // real Exceeded transition (L1 re-stamps `exceeded_at` then).
+            existing.exceeded_at = None;
             if let Ok(body) = serde_json::to_string_pretty(&existing) {
                 if crate::store::atomic_write(
                     &pending_path(home, &existing.dispatch_id),
@@ -274,6 +296,7 @@ pub(crate) fn record_dispatch(
         not_working_streak: 0,
         refresh_count: 0,
         long_running_escalated: false,
+        exceeded_at: None,
     };
     let body = match serde_json::to_string_pretty(&payload) {
         Ok(s) => s,
@@ -493,6 +516,9 @@ pub(crate) fn reassign_pending_for_task(
             cur.not_working_streak = 0;
             cur.nudge_sent_at = None;
             cur.status = DispatchStatus::Pending;
+            // #2031: revived for a new owner — drop the prior owner's escalation
+            // stamp so L2's second window restarts from the next Exceeded.
+            cur.exceeded_at = None;
             true
         });
         if matches!(updated, Ok(Some(true))) {
@@ -964,7 +990,7 @@ pub(crate) fn scan_and_emit(home: &Path) {
         // the growing streak and defer; the busy-branch above resets it the
         // moment the target produces output. A genuinely idle/stuck target keeps
         // accumulating → fires once the streak reaches the cap (≤ a couple
-        // scan-cadences of extra delay vs the 600s threshold).
+        // scan-cadences of extra delay vs the dispatch threshold).
         //
         // Only debounce when a snapshot EXISTS to judge work-state against —
         // debouncing snapshot noise is meaningless without one. No snapshot
@@ -1004,6 +1030,9 @@ pub(crate) fn scan_and_emit(home: &Path) {
                 continue;
             }
             current.status = DispatchStatus::Exceeded;
+            // #2031: stamp when the dispatcher was notified — L2 defers the agent
+            // nudge to a second window past this (escalation tiering).
+            current.exceeded_at = Some(now.to_rfc3339());
             if !write_dispatch(home, &current) {
                 tracing::warn!(dispatch_id = %d.dispatch_id, "dispatch-idle exceeded status write failed");
             }
@@ -1391,6 +1420,7 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            exceeded_at: None,
         };
         std::fs::write(
             pending_path(home, &id),
@@ -1654,6 +1684,54 @@ mod tests {
             d.status,
             DispatchStatus::Exceeded,
             "#1866 (a): a fully-idle target (all activity signals stale) must STILL fire"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2031: L1 must STAMP `exceeded_at` when it flips a sidecar to `Exceeded`.
+    /// This is the signal L2's second-window tiering reads — if L1 stopped
+    /// stamping, L2 would fail-open to an immediate nudge and silently regress the
+    /// tiering, so pin it explicitly.
+    #[test]
+    fn scan_and_emit_stamps_exceeded_at_2031() {
+        let home = tmp_home("2031-l1-stamp");
+        let target = "dev-2031-stamp";
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            format!("instances:\n  lead:\n    backend: claude\n  {target}:\n    backend: claude\n"),
+        )
+        .unwrap();
+        let task_id = "t-stamp-2031";
+        let tasks_dir = home.join("tasks");
+        std::fs::create_dir_all(&tasks_dir).unwrap();
+        std::fs::write(
+            tasks_dir.join(format!("{task_id}.json")),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "id": task_id, "status": "in_progress", "title": "w", "assignee": target
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let id = write_pending_at(
+            &home,
+            "lead",
+            target,
+            Some(task_id),
+            "task",
+            600,
+            chrono::Utc::now() - chrono::Duration::seconds(700),
+        );
+        // No snapshot → debounce fails open → fires on this single scan.
+        scan_and_emit(&home);
+
+        let d = list_pending(&home)
+            .into_iter()
+            .find(|d| d.dispatch_id == id)
+            .expect("sidecar present");
+        assert_eq!(d.status, DispatchStatus::Exceeded, "precondition: fired");
+        assert!(
+            d.exceeded_at.is_some(),
+            "#2031: L1 must stamp exceeded_at on the Exceeded transition (L2 tiering depends on it)"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -2332,6 +2410,7 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            exceeded_at: None,
         };
         assert_eq!(
             stale_sidecar_reason(&home, &mk("ghost-lead")),

--- a/src/daemon/dispatch_idle/team_nudge.rs
+++ b/src/daemon/dispatch_idle/team_nudge.rs
@@ -22,9 +22,23 @@ use std::path::Path;
 use super::{list_pending, pending_path, DispatchStatus, PendingDispatch};
 
 /// Default dispatch-idle threshold for ANY team member when no explicit
-/// `expect_reply_within_secs` is set on the dispatch. 600s (10 min) per the
-/// original watchdog spec. Per-team override is a deferred follow-up.
-pub(crate) const DEFAULT_DISPATCH_THRESHOLD_SECS: i64 = 600;
+/// `expect_reply_within_secs` is set on the dispatch. #2031: raised 600 → 1800s
+/// (30 min). The 600s default was tuned for the dispatch→quick-ack era; modern
+/// tasks run 10–40+ min with bursty activity (today's median ~15 min to report),
+/// so 600s false-fired on between-turns gaps even with the full #1975/#1866/#2022
+/// activity-gate stack deployed. Explicit `expect_reply_within_secs` still
+/// overrides per-dispatch (the lead's long-task practice: set ~1800–2400s).
+/// Per-team override is a deferred follow-up.
+pub(crate) const DEFAULT_DISPATCH_THRESHOLD_SECS: i64 = 1800;
+
+/// #2031: escalation tiering. The agent `dispatch_idle_nudge` — the costlier
+/// message (it interrupts the agent into a BUSY-reply turn) — is the SECOND
+/// escalation rung. After L1 notifies the DISPATCHER (`..._exceeded`, stamping
+/// [`PendingDispatch::exceeded_at`]), L2 waits this many seconds before injecting
+/// the agent nudge, giving the dispatcher a window to act first (re-dispatch /
+/// resolve / `set_waiting_on`). ~600s (10 min) — the second rung of the
+/// escalate-don't-repeat ladder (#2008 principles).
+pub(crate) const ESCALATE_TO_AGENT_AFTER_SECS: i64 = 600;
 
 /// Scan throttle: 6 ticks × 10s = ~60s — matches L1 cadence.
 pub(crate) const TICKS_PER_SCAN: u64 = 6;
@@ -167,6 +181,21 @@ pub(crate) fn scan_and_nudge(home: &Path) {
         if d.nudge_sent_at.is_some() {
             continue;
         }
+        // #2031: escalation tiering — the agent nudge is the SECOND rung. Defer it
+        // until ESCALATE_TO_AGENT_AFTER_SECS past `exceeded_at` (when L1 already
+        // notified the dispatcher), so the dispatcher gets a window to act before
+        // the costlier agent interrupt. A MISSING stamp (legacy / pre-#2031 sidecar)
+        // fails OPEN to immediate nudge — never SUPPRESS a real nudge on absence.
+        if let Some(ref ea) = d.exceeded_at {
+            if let Ok(t) = chrono::DateTime::parse_from_rfc3339(ea) {
+                let since = chrono::Utc::now()
+                    .signed_duration_since(t.with_timezone(&chrono::Utc))
+                    .num_seconds();
+                if since < ESCALATE_TO_AGENT_AFTER_SECS {
+                    continue; // second window not yet elapsed — dispatcher's turn
+                }
+            }
+        }
         // Nudge for ANY team's dispatch (was gated to the fixup team); a teamless
         // (solo) dispatcher has no orchestration context → skip.
         // #1923 G6: but STAMP `nudge_sent_at` first so the L2 team-nudge does not
@@ -257,6 +286,14 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            // Exceeded LONG enough ago that the #2031 second escalation window has
+            // elapsed — so these mechanics tests (dedup / targeting / multiteam /
+            // correlation) still see the nudge fire. The window-timing itself is
+            // covered by the dedicated #2031 tests.
+            exceeded_at: Some(
+                (chrono::Utc::now() - chrono::Duration::seconds(ESCALATE_TO_AGENT_AFTER_SECS + 60))
+                    .to_rfc3339(),
+            ),
         };
         std::fs::write(
             pending_path(home, &id),
@@ -287,6 +324,130 @@ mod tests {
         assert_eq!(
             second_count, 0,
             "second scan must NOT re-nudge (dedup via nudge_sent_at)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #2031: escalation tiering + threshold rebalance ──
+
+    /// Write an Exceeded sidecar with an EXPLICIT `exceeded_at` stamp, to drive
+    /// the L2 second-window escalation gate at a controlled point in time.
+    fn write_exceeded_with_stamp(
+        home: &Path,
+        dispatcher: &str,
+        target: &str,
+        correlation_id: &str,
+        exceeded_at: Option<String>,
+    ) -> String {
+        let dir = pending_dir(home);
+        std::fs::create_dir_all(&dir).unwrap();
+        let id = format!("disp-stamp-{correlation_id}");
+        let payload = PendingDispatch {
+            schema_version: 1,
+            dispatch_id: id.clone(),
+            dispatcher: dispatcher.to_string(),
+            target: target.to_string(),
+            correlation_id: Some(correlation_id.to_string()),
+            expected_kind: "task".to_string(),
+            threshold_secs: 1800,
+            issued_at: (chrono::Utc::now() - chrono::Duration::seconds(2000)).to_rfc3339(),
+            status: DispatchStatus::Exceeded,
+            nudge_sent_at: None,
+            not_working_streak: 0,
+            refresh_count: 0,
+            long_running_escalated: false,
+            exceeded_at,
+        };
+        std::fs::write(
+            pending_path(home, &id),
+            serde_json::to_string_pretty(&payload).unwrap(),
+        )
+        .unwrap();
+        id
+    }
+
+    fn nudge_count(home: &Path, target: &str) -> usize {
+        crate::inbox::drain(home, target)
+            .iter()
+            .filter(|m| m.kind.as_deref() == Some("dispatch_idle_nudge"))
+            .count()
+    }
+
+    /// #2031 §3.9 — tiering timing (first rung only): the agent nudge is DEFERRED
+    /// while the second escalation window has not elapsed since `exceeded_at` (L1
+    /// just notified the dispatcher). The dispatcher gets its window first.
+    #[test]
+    fn agent_nudge_deferred_within_second_window_2031() {
+        let home = tmp_home("2031-deferred");
+        write_fleet_with_fixup_member(&home, "fixup-lead");
+        let recent = chrono::Utc::now().to_rfc3339();
+        write_exceeded_with_stamp(
+            &home,
+            "fixup-lead",
+            "fixup-reviewer",
+            "t-defer",
+            Some(recent),
+        );
+        scan_and_nudge(&home);
+        assert_eq!(
+            nudge_count(&home, "fixup-reviewer"),
+            0,
+            "#2031: agent nudge must be deferred within the second window"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2031 §3.9 — tiering timing (second rung): once the second window has
+    /// elapsed past `exceeded_at` (dispatcher had its window and didn't act), the
+    /// agent nudge fires.
+    #[test]
+    fn agent_nudge_fires_after_second_window_2031() {
+        let home = tmp_home("2031-fires");
+        write_fleet_with_fixup_member(&home, "fixup-lead");
+        let old = (chrono::Utc::now()
+            - chrono::Duration::seconds(ESCALATE_TO_AGENT_AFTER_SECS + 60))
+        .to_rfc3339();
+        write_exceeded_with_stamp(&home, "fixup-lead", "fixup-reviewer", "t-fire", Some(old));
+        scan_and_nudge(&home);
+        assert_eq!(
+            nudge_count(&home, "fixup-reviewer"),
+            1,
+            "#2031: agent nudge fires after the second window elapses"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2031 §3.9 — fail-open: a MISSING `exceeded_at` (legacy / pre-#2031 sidecar)
+    /// nudges immediately. A missing stamp must NEVER suppress a real nudge.
+    #[test]
+    fn missing_exceeded_at_fails_open_to_immediate_nudge_2031() {
+        let home = tmp_home("2031-failopen");
+        write_fleet_with_fixup_member(&home, "fixup-lead");
+        write_exceeded_with_stamp(&home, "fixup-lead", "fixup-reviewer", "t-legacy", None);
+        scan_and_nudge(&home);
+        assert_eq!(
+            nudge_count(&home, "fixup-reviewer"),
+            1,
+            "#2031: missing exceeded_at fails open to immediate nudge"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2031 §3.9 — threshold rebalance: the team default is now 1800s; an explicit
+    /// `expect_reply_within_secs` still overrides it per-dispatch.
+    #[test]
+    fn team_default_threshold_1800_explicit_overrides_2031() {
+        let home = tmp_home("2031-threshold");
+        write_fleet_with_fixup_member(&home, "fixup-lead");
+        assert_eq!(
+            resolve_threshold_for_dispatch(&home, "fixup-lead", None),
+            Some(1800),
+            "#2031: team-member default threshold is 1800s"
+        );
+        assert_eq!(
+            resolve_threshold_for_dispatch(&home, "fixup-lead", Some(2400)),
+            Some(2400),
+            "explicit expect_reply_within_secs still overrides the default"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -442,6 +603,7 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            exceeded_at: None,
         };
         let path = pending_path(&home, &id);
         std::fs::write(&path, serde_json::to_string_pretty(&payload).unwrap()).unwrap();
@@ -580,6 +742,14 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            // Exceeded LONG enough ago that the #2031 second escalation window has
+            // elapsed — so these mechanics tests (dedup / targeting / multiteam /
+            // correlation) still see the nudge fire. The window-timing itself is
+            // covered by the dedicated #2031 tests.
+            exceeded_at: Some(
+                (chrono::Utc::now() - chrono::Duration::seconds(ESCALATE_TO_AGENT_AFTER_SECS + 60))
+                    .to_rfc3339(),
+            ),
         };
         std::fs::write(
             pending_path(home, &id),


### PR DESCRIPTION
Closes #2031. Same area as my #2022; operator-pointed after the 23:02 false-fire on an agent 12 min into shim-tracing #2027.

## Problem

The 600s default + **simultaneous** dispatcher+agent escalation was tuned for the dispatch→quick-ack era. Modern tasks run 10–40+ min with bursty activity, so the window false-fired on **between-turns gaps** (turn ended, next not started: pane static, state Idle via Stop hook, no MCP heartbeat) — even with the full #1975/#1866/#2022 activity-gate stack deployed. 9 false alarms on 2026-06-11, each costing a lead pane-check + an agent BUSY-reply turn.

## Fix (KISS ladder, directions 1+2; 3 spiked + deferred)

**1 — Raise the default.** `DEFAULT_DISPATCH_THRESHOLD_SECS` 600 → 1800 (team median ~15 min to report). Explicit `expect_reply_within_secs` still overrides per-dispatch.

**2 — Tier the escalation** (escalate-don't-repeat). New `exceeded_at` field (serde-default, additive), stamped by L1 when it flips a sidecar to `Exceeded` (i.e. when the **dispatcher** is notified). L2 defers the agent `dispatch_idle_nudge` — the costlier interrupt — until `ESCALATE_TO_AGENT_AFTER_SECS` (600s) past `exceeded_at`. So the rungs are sequenced: dispatcher first (cheap), agent only if still unresolved a second window later.
- **Fail-open:** a missing stamp (legacy / pre-#2031 sidecar) nudges immediately — never suppress a real nudge on absence.
- Both re-dispatch revive paths (`record_dispatch` in-place + `reassign_pending_for_task`) reset `exceeded_at` — the #2022 codex lesson (reset transient escalation state on re-dispatch).

**3 — Completed-turn as progress — SPIKED + DEFERRED.** The only turn-end signal is the Stop hook event, which today lives only in the `AGEND_HOOK_STATE_POC`-gated, claude-only hook_shadow layer (#1523/#2014) — not cheaply in `AgentSnapshot` (the code already notes "AgentSnapshot has no activity timestamp today"). The "太繞" path; documented as a #2008 follow-up. Directions 1+2 already require **≥40 min** of genuine silence (1800s + 600s) before the agent is interrupted.

## Tests (§3.9)

- `team_default_threshold_1800_explicit_overrides_2031` — new default + explicit override
- `scan_and_emit_stamps_exceeded_at_2031` — L1 stamps `exceeded_at` (guards the tiering from silently regressing to fail-open)
- `agent_nudge_deferred_within_second_window_2031` / `..._fires_after_second_window_2031` — the tiering timing
- `missing_exceeded_at_fails_open_to_immediate_nudge_2031` — legacy fail-open
- Existing #2022 CAP (`redispatch_same_correlation_resets_cap_and_latch`, …) + dedup/targeting/multiteam tests all coexist (78/78 dispatch_idle green)

Also swept the stale-600s prose (`REFRESH_CAP`, `DEBOUNCE_SCANS` doc) and `FEATURE-dispatch-idle.md`, and corrected a false `AGEND_DISPATCH_IDLE_THRESHOLD_SECS` env-var claim (no env override exists — the thresholds are consts).

## Verification

`scripts/preflight.sh --quick` — fmt / clippy `--all-targets --features tray -D warnings` / `--tests --features tray` (unit + integration + invariants) all green. Windows skipped per `--quick` (no platform-specific code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)