### PR TITLE
fix(#2033): gate the recovery telegram notice to acted-upon blockages

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -40,6 +40,14 @@ const NULL_UNLOCK_NOTIFY_WINDOW: Duration = Duration::from_secs(24 * 60 * 60);
 /// to AwaitingOperator (stability gate — a transient streaming flicker of the
 /// permission chrome never holds this long).
 const AWAITING_STABILITY: Duration = Duration::from_secs(8);
+/// #2033: minimum blocked-episode duration for the "recovered from blocked state"
+/// Telegram notice to be actionable. Set to the AwaitingOperator silence floor
+/// (30s) — an episode that reached genuine operator-attention territory. Below it
+/// is an InteractivePrompt that self-resolved before the operator could plausibly
+/// engage, so the recovery notice would be non-actionable noise. The common
+/// AwaitingOperator path always clears this bar: the ≥30s silence accrues while
+/// already in (raw) InteractivePrompt, which the episode clock counts.
+const RECOVERY_NOTICE_MIN_BLOCK: Duration = Duration::from_secs(30);
 /// #1552: how many live bottom rows the permission chrome must render in for
 /// the escalation position gate. A scrollback footer (the meta-FP: a working
 /// agent whose pane merely echoes the chrome) scrolls above this and fails.
@@ -1325,6 +1333,9 @@ fn tick(
                         prev_state = agent_state.display_name(),
                         "awaiting operator (stalled on prompt) — escalating"
                     );
+                    // #2033: pair this blocked notice with the recovery notice —
+                    // record that the operator was actually told about the block.
+                    core.state.mark_blocked_notice_sent();
                     Some(NoticeAction::Stall {
                         tail: core.vterm.tail_lines(TAIL_LINES),
                         silent_secs: Some(silent.as_secs()),
@@ -1348,29 +1359,49 @@ fn tick(
                     "interactive prompt detected — forwarding to telegram"
                 );
                 let _ = core.state.take_recovery_notice();
+                // #2033: pair this blocked notice with the recovery notice.
+                core.state.mark_blocked_notice_sent();
                 Some(NoticeAction::Stall {
                     tail: core.vterm.tail_lines(TAIL_LINES),
                     silent_secs: None,
                 })
-            } else if core.state.take_recovery_notice() {
+            } else if let Some(episode) = core.state.take_recovery_notice() {
                 // Symmetric "ready again" signal: armed on the transition
-                // out of InteractivePrompt / AwaitingOperator. Silent push so
-                // operators aren't vibrated twice per interactive cycle.
+                // out of InteractivePrompt / AwaitingOperator.
                 // #1552: clear the AwaitingOperator health reason on recovery so
                 // `check_hang` is no longer exempt and a future stall can
                 // re-notify (the once-per-episode dedup re-arms). #1638: the
                 // operator-resolution clear-policy is now on the type, so this
                 // never clears a different blocked reason (RateLimit / etc.).
+                // This health cleanup runs REGARDLESS of whether we forward the
+                // telegram notice below — it is internal state, not operator-facing.
                 if core.health.current_reason.as_ref().is_some_and(|r| {
                     r.auto_clears_on(crate::health::RecoverySignal::OperatorResolved)
                 }) {
                     core.health.clear_blocked_reason();
                 }
-                tracing::info!(
-                    agent = %name,
-                    "recovered from blocked state — notifying telegram"
-                );
-                Some(NoticeAction::Recovered)
+                // #2033: actionable-or-silent (#2008). A "recovered" notice is only
+                // useful when the operator was actually told about the block AND it
+                // lasted long enough that they might be reacting. A self-resolving /
+                // never-notified block (the operator-flagged noise, e.g. the #2020
+                // false AwaitingOperator) is log-only.
+                if recovery_notice_is_actionable(episode) {
+                    tracing::info!(
+                        agent = %name,
+                        block_secs = episode.block_duration.as_secs(),
+                        "recovered from blocked state — notifying telegram"
+                    );
+                    Some(NoticeAction::Recovered)
+                } else {
+                    tracing::debug!(
+                        agent = %name,
+                        block_secs = episode.block_duration.as_secs(),
+                        notice_sent = episode.notice_sent,
+                        "recovered from blocked state — log-only (#2033: block not \
+                         notified or under threshold, recovery notice non-actionable)"
+                    );
+                    None
+                }
             } else {
                 None
             }
@@ -2108,6 +2139,16 @@ fn format_recovery_notice(name: &str) -> String {
     format!("✅ {name} 已就緒，可以繼續對話")
 }
 
+/// #2033: gate the "recovered from blocked state" Telegram notice on the
+/// actionable-or-silent principle (#2008). It is operator-useful ONLY when both:
+/// (a) the operator was actually told about the block (a Stall notice went out
+/// this episode), and (b) the block lasted past [`RECOVERY_NOTICE_MIN_BLOCK`], so
+/// they might be mid-reaction. A never-notified or self-resolving block (e.g. the
+/// #2020 false AwaitingOperator the operator flagged) fails this → log-only.
+fn recovery_notice_is_actionable(episode: crate::state::RecoveryEpisode) -> bool {
+    episode.notice_sent && episode.block_duration >= RECOVERY_NOTICE_MIN_BLOCK
+}
+
 /// Read `last_heartbeat` from the agent's metadata file and return the age
 /// as a `Duration`. Returns `None` if the file is missing, unparseable, or
 /// the timestamp is in the future.
@@ -2162,6 +2203,30 @@ fn clear_waiting_on_if_stale(home: &std::path::Path, name: &str, is_stale: bool)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #2033: the recovery-notice gate — actionable iff the operator was told
+    /// about the block AND it lasted past the threshold (actionable-or-silent).
+    #[test]
+    fn recovery_notice_gate_actionable_or_silent_2033() {
+        use crate::state::RecoveryEpisode;
+        let ep = |secs, notice_sent| RecoveryEpisode {
+            block_duration: Duration::from_secs(secs),
+            notice_sent,
+        };
+        // notified + long enough → fire
+        assert!(recovery_notice_is_actionable(ep(60, true)));
+        // notified but self-resolved fast → silent (the InteractivePrompt noise)
+        assert!(!recovery_notice_is_actionable(ep(5, true)));
+        // long but NEVER notified → silent (the #2020 false-AwaitingOperator class)
+        assert!(!recovery_notice_is_actionable(ep(300, false)));
+        // neither → silent
+        assert!(!recovery_notice_is_actionable(ep(2, false)));
+        // boundary: exactly the threshold is actionable (>=)
+        assert!(recovery_notice_is_actionable(RecoveryEpisode {
+            block_duration: RECOVERY_NOTICE_MIN_BLOCK,
+            notice_sent: true,
+        }));
+    }
 
     fn fresh_retry() -> RateLimitRetry {
         RateLimitRetry {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1065,8 +1065,16 @@ impl StateTracker {
     /// per tick. #2033: the returned [`RecoveryEpisode`] carries the gate inputs
     /// (was-notified + duration) so the supervisor can pick actionable-or-silent.
     /// A defensive default episode (`notice_sent=false`) is returned if the flag
-    /// armed without a captured episode (e.g. daemon restart mid-block) → the
-    /// gate treats it as non-actionable, erring silent.
+    /// armed without a captured episode → the gate treats it as non-actionable.
+    ///
+    /// KNOWN LIMITATION (#2033, reviewer-2 non-blocking): the per-episode state
+    /// (`blocked_since` / `blocked_notice_sent`) is in-memory, so a daemon restart
+    /// mid-block loses it. If the agent then recovers BEFORE the supervisor
+    /// re-detects + re-notifies the block, its recovery episode defaults to
+    /// `notice_sent=false` and the all-clear is suppressed — one missed recovery
+    /// notice per restart-straddling block. Deliberately the safe direction
+    /// (err-silent over false-notify); persisting the episode across restarts is
+    /// not worth the complexity for this narrow window.
     pub fn take_recovery_notice(&mut self) -> Option<RecoveryEpisode> {
         if self.interactive_recovery_pending_notice {
             self.interactive_recovery_pending_notice = false;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -169,6 +169,20 @@ use crate::vterm::CellFg;
 use patterns::is_generic_startup_prompt;
 pub use patterns::{classify_pty_output, StatePatterns};
 
+/// #2033: gate inputs for the "recovered from blocked state" Telegram notice,
+/// captured when a blocked episode (InteractivePrompt / AwaitingOperator) ends.
+/// The supervisor emits the notice only when it is actionable — the operator was
+/// actually told about the block AND it lasted long enough that they might be
+/// reacting (#2008 actionable-or-silent). A self-resolving / never-notified block
+/// produces a `notice_sent=false` (or sub-threshold) episode → log-only.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RecoveryEpisode {
+    /// How long the episode stayed in a blocked state.
+    pub block_duration: Duration,
+    /// Whether a Telegram blocked (`Stall`) notice was forwarded for this episode.
+    pub notice_sent: bool,
+}
+
 pub struct StateTracker {
     pub current: AgentState,
     pub(crate) since: Instant,
@@ -233,6 +247,24 @@ pub struct StateTracker {
     /// "ready again" notice. Pairs with `interactive_prompt_pending_notice`
     /// so operators get symmetrical enter/exit signals.
     interactive_recovery_pending_notice: bool,
+    /// #2033: when the CURRENT blocked episode began (first entry into a
+    /// `wants_raw_keystrokes` state from a non-blocked one). `None` outside a
+    /// blocked episode. Spans intra-block transitions (InteractivePrompt →
+    /// AwaitingOperator), so it measures the FULL operator-facing block duration.
+    blocked_since: Option<Instant>,
+    /// #2033: whether a Telegram blocked notice (the `Stall` action) was actually
+    /// emitted for the current blocked episode. The recovery-notice gate keys on
+    /// this — a block the operator was never told about must not produce a
+    /// non-actionable "recovered" notice (#2008 actionable-or-silent). Reset on
+    /// each fresh blocked-episode entry; the supervisor sets it via
+    /// [`Self::mark_blocked_notice_sent`] when it forwards the Stall.
+    blocked_notice_sent: bool,
+    /// #2033: the just-ended blocked episode's gate inputs, captured on the
+    /// leaving-block transition and consumed by `take_recovery_notice()`. Carries
+    /// the block duration + whether it was notified, so the supervisor can decide
+    /// actionable-or-silent without reaching back into per-episode state that the
+    /// recovery tick (a later tick) would already have cleared.
+    recovery_episode: Option<RecoveryEpisode>,
     /// Last MCP heartbeat instant. Updated by supervisor tick from metadata.
     /// `None` before first heartbeat. Used by `gate_on_heartbeat` to suppress
     /// false-positive `PermissionPrompt` when the agent is alive (A5 fix).
@@ -968,6 +1000,9 @@ impl StateTracker {
             context_pct: None,
             interactive_prompt_pending_notice: false,
             interactive_recovery_pending_notice: false,
+            blocked_since: None,
+            blocked_notice_sent: false,
+            recovery_episode: None,
             last_heartbeat: None,
             behavioral_config: backend.map(crate::behavioral::config_for),
             productivity_config: backend.map(crate::behavioral::config_for_productivity),
@@ -1023,18 +1058,30 @@ impl StateTracker {
         }
     }
 
-    /// Returns true at most once per recovery from a blocked state
+    /// Returns `Some(episode)` at most once per recovery from a blocked state
     /// (InteractivePrompt / AwaitingOperator → non-blocked). The supervisor
-    /// calls this each tick; it returns true only on the first tick after the
-    /// recovery transition so Telegram sees one "ready again" notice, not
-    /// one per tick.
-    pub fn take_recovery_notice(&mut self) -> bool {
+    /// calls this each tick; it returns `Some` only on the first tick after the
+    /// recovery transition so Telegram sees one "ready again" decision, not one
+    /// per tick. #2033: the returned [`RecoveryEpisode`] carries the gate inputs
+    /// (was-notified + duration) so the supervisor can pick actionable-or-silent.
+    /// A defensive default episode (`notice_sent=false`) is returned if the flag
+    /// armed without a captured episode (e.g. daemon restart mid-block) → the
+    /// gate treats it as non-actionable, erring silent.
+    pub fn take_recovery_notice(&mut self) -> Option<RecoveryEpisode> {
         if self.interactive_recovery_pending_notice {
             self.interactive_recovery_pending_notice = false;
-            true
+            Some(self.recovery_episode.take().unwrap_or_default())
         } else {
-            false
+            None
         }
+    }
+
+    /// #2033: record that a Telegram blocked (`Stall`) notice was forwarded for
+    /// the current blocked episode. Called by the supervisor at the moment it
+    /// commits to the notice, so the paired recovery notice knows the operator
+    /// was actually told. No-op if not currently in a blocked episode.
+    pub fn mark_blocked_notice_sent(&mut self) {
+        self.blocked_notice_sent = true;
     }
 
     /// If detected state is `PermissionPrompt` but a fresh heartbeat exists,
@@ -1993,6 +2040,24 @@ impl StateTracker {
             to: new_state,
             ts: chrono::Utc::now().to_rfc3339(),
         });
+        // #2033: blocked-episode tracking for the recovery-notice gate. record_set
+        // is the SINGLE funnel for every `current` mutation (incl. the
+        // `set_awaiting_operator` bypass), so entry/exit are caught here regardless
+        // of which path drove the transition.
+        let from = self.current;
+        if !from.wants_raw_keystrokes() && new_state.wants_raw_keystrokes() {
+            // entering a fresh blocked episode
+            self.blocked_since = Some(Instant::now());
+            self.blocked_notice_sent = false;
+        } else if from.wants_raw_keystrokes() && !new_state.wants_raw_keystrokes() {
+            // leaving — snapshot the gate inputs for the paired recovery notice
+            self.recovery_episode = Some(RecoveryEpisode {
+                block_duration: self.blocked_since.map(|t| t.elapsed()).unwrap_or_default(),
+                notice_sent: self.blocked_notice_sent,
+            });
+            self.blocked_since = None;
+            self.blocked_notice_sent = false;
+        }
         self.current = new_state;
         self.since = Instant::now();
     }

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -1097,14 +1097,14 @@ fn interactive_prompt_notice_rearms_on_reentry() {
 fn recovery_notice_armed_when_leaving_interactive_prompt() {
     // Use tracker_at to place the tracker directly into InteractivePrompt.
     let mut t = tracker_at(&Backend::Codex, AgentState::Starting, 0);
-    assert!(!t.take_recovery_notice());
+    assert!(t.take_recovery_notice().is_none());
 
     // Enter InteractivePrompt.
     t.transition(AgentState::InteractivePrompt);
     assert_eq!(t.get_state(), AgentState::InteractivePrompt);
     // Still nothing to report — we only arm when we LEAVE the blocked
     // state, not when we enter it.
-    assert!(!t.take_recovery_notice());
+    assert!(t.take_recovery_notice().is_none());
 
     // Dismiss → Ready.
     t.since = std::time::Instant::now() - std::time::Duration::from_secs(3);
@@ -1113,9 +1113,12 @@ fn recovery_notice_armed_when_leaving_interactive_prompt() {
 
     // First take fires; subsequent ticks within the same Ready don't
     // re-spam.
-    assert!(t.take_recovery_notice(), "recovery must arm on exit");
     assert!(
-        !t.take_recovery_notice(),
+        t.take_recovery_notice().is_some(),
+        "recovery must arm on exit"
+    );
+    assert!(
+        t.take_recovery_notice().is_none(),
         "supervisor ticks after the first must not re-arm"
     );
 }
@@ -1129,14 +1132,14 @@ fn recovery_notice_armed_when_leaving_awaiting_operator() {
     let mut st = StateTracker::new(Some(&Backend::Codex));
     st.set_awaiting_operator();
     assert_eq!(st.get_state(), AgentState::AwaitingOperator);
-    assert!(!st.take_recovery_notice());
+    assert!(st.take_recovery_notice().is_none());
 
     // Fresh Ready banner appears. Ready (prio 3) > AwaitingOperator
     // (prio 2) so the transition is immediate.
     drive(&mut vt, &mut st, b"\x1b[2J\x1b[HOpenAI Codex v0.120.0\r\n");
     assert_eq!(st.get_state(), AgentState::Idle);
     assert!(
-        st.take_recovery_notice(),
+        st.take_recovery_notice().is_some(),
         "recovery must arm on AwaitingOperator → Ready"
     );
 }
@@ -1153,7 +1156,78 @@ fn recovery_notice_not_armed_for_unrelated_transitions() {
     st.since = std::time::Instant::now() - std::time::Duration::from_secs(10);
     st.transition(AgentState::Idle);
     assert_eq!(st.get_state(), AgentState::Idle);
-    assert!(!st.take_recovery_notice());
+    assert!(st.take_recovery_notice().is_none());
+}
+
+// ── #2033: recovery-notice episode gate inputs ──
+
+/// A notified, long-enough block produces an episode the supervisor gate treats
+/// as actionable (notice_sent + full duration captured).
+#[test]
+fn recovery_episode_captures_notified_long_block_2033() {
+    let mut t = tracker_at(&Backend::Codex, AgentState::Starting, 0);
+    t.transition(AgentState::InteractivePrompt);
+    assert_eq!(t.get_state(), AgentState::InteractivePrompt);
+    // Operator was told about the block (supervisor forwarded the Stall).
+    t.mark_blocked_notice_sent();
+    // Simulate a block that lasted well past the recovery threshold.
+    t.blocked_since = Some(std::time::Instant::now() - std::time::Duration::from_secs(60));
+    // Leave the blocked state.
+    t.since = std::time::Instant::now() - std::time::Duration::from_secs(3);
+    t.transition(AgentState::Idle);
+    let ep = t
+        .take_recovery_notice()
+        .expect("recovery must arm on leaving a blocked state");
+    assert!(
+        ep.notice_sent,
+        "#2033: episode records the block WAS notified"
+    );
+    assert!(
+        ep.block_duration >= std::time::Duration::from_secs(60),
+        "#2033: episode spans the full block duration, got {:?}",
+        ep.block_duration
+    );
+}
+
+/// A self-resolving block the operator was NEVER told about produces an episode
+/// with `notice_sent=false` — the supervisor gate makes the recovery log-only.
+#[test]
+fn recovery_episode_unnotified_block_2033() {
+    let mut t = tracker_at(&Backend::Codex, AgentState::Starting, 0);
+    t.transition(AgentState::InteractivePrompt);
+    // NO mark_blocked_notice_sent — e.g. role-gated forward, or a transient block.
+    t.since = std::time::Instant::now() - std::time::Duration::from_secs(3);
+    t.transition(AgentState::Idle);
+    let ep = t
+        .take_recovery_notice()
+        .expect("recovery flag still arms on leaving");
+    assert!(
+        !ep.notice_sent,
+        "#2033: an un-notified block must record notice_sent=false (recovery → silent)"
+    );
+}
+
+/// A second blocked episode must NOT inherit the first's `notice_sent` — the
+/// per-episode latch resets on each fresh blocked-state entry.
+#[test]
+fn blocked_episode_resets_notice_sent_on_reentry_2033() {
+    let mut t = tracker_at(&Backend::Codex, AgentState::Starting, 0);
+    // Episode 1: notified.
+    t.transition(AgentState::InteractivePrompt);
+    t.mark_blocked_notice_sent();
+    t.since = std::time::Instant::now() - std::time::Duration::from_secs(3);
+    t.transition(AgentState::Idle);
+    let _ = t.take_recovery_notice();
+    // Episode 2: NOT notified — must not carry over episode 1's flag.
+    t.since = std::time::Instant::now() - std::time::Duration::from_secs(3);
+    t.transition(AgentState::InteractivePrompt);
+    t.since = std::time::Instant::now() - std::time::Duration::from_secs(3);
+    t.transition(AgentState::Idle);
+    let ep = t.take_recovery_notice().expect("episode 2 arms");
+    assert!(
+        !ep.notice_sent,
+        "#2033: re-entry resets notice_sent — no stale notified flag from a prior episode"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #2033. 0.8.0 A-queue, operator-flagged noise.

## Problem

The `recovered from blocked state — notifying telegram` notice (G.5, `NoticeAction::Recovered`) fired whenever an agent left `InteractivePrompt`/`AwaitingOperator` — **regardless of whether the operator was ever told about the block**. The 2026-06-11 20:12 instance was the #2020 false `AwaitingOperator` (agent never blocked), so the operator got a "recovered" for a state that never existed. #2021 killed that false source; this gates the notice itself.

## Fix (#2008 actionable-or-silent)

A recovery notice is useful only when **(a)** the operator was actually told about the block on telegram **AND (b)** it lasted past a threshold so they might be mid-reaction. Otherwise → log-only.

- **Pair block/recovery as an episode.** New per-episode state on `StateTracker` (`blocked_since`, `blocked_notice_sent`), tracked in `record_set` — the single transition funnel, so it catches both the `set_awaiting_operator` bypass and `transition()`, and spans intra-block transitions (`InteractivePrompt → AwaitingOperator`) for the **full** operator-facing duration. The supervisor calls `mark_blocked_notice_sent()` when it forwards either `Stall`.
- `take_recovery_notice()` now returns `Option<RecoveryEpisode>` carrying the gate inputs. The supervisor emits `Recovered` only when `recovery_notice_is_actionable` = `notice_sent && block_duration >= RECOVERY_NOTICE_MIN_BLOCK` (30s — the AwaitingOperator silence floor). The common AwaitingOperator path always clears this: the ≥30s silence accrues while already in (raw) `InteractivePrompt`, which the episode clock counts.
- Health-reason cleanup still runs in **both** branches (internal state, not operator-facing). A missing episode (e.g. daemon restart mid-block) defaults to non-actionable → errs silent.

## Sweep (issue point 3)

`NoticeAction` has only `Stall`/`Recovered`. The `ServerRateLimit`/`RateLimit` recoveries auto-clear with **log-only `tracing`** (no telegram). **G.5 is the only operator-facing all-clear path** — no other path needs the gate.

## §3.9 tests

- `recovery_episode_captures_notified_long_block_2033` — notified + long → actionable, full duration captured
- `recovery_episode_unnotified_block_2033` — never-notified block → `notice_sent=false` (→ silent)
- `blocked_episode_resets_notice_sent_on_reentry_2033` — the latch resets per episode (no stale carry-over)
- `recovery_notice_gate_actionable_or_silent_2033` — the predicate's 5-way matrix incl. the `>=` boundary
- Existing recovery-arming tests carried to the `Option` API

## Verification

`scripts/preflight.sh --quick` — fmt / clippy `--all-targets --features tray -D warnings` / `--tests --features tray` all green (390/390 state+supervisor). Windows skipped per `--quick`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)