### PR TITLE
feat(#2037 PR-B): merge auto-close for active linked tasks + create_instance name+team no-rename

### DIFF
--- a/src/decisions.rs
+++ b/src/decisions.rs
@@ -288,7 +288,9 @@ pub fn update(home: &Path, caller: &str, args: &Value) -> Value {
             });
         }
 
-        if let Some(content) = args["content"].as_str() {
+        // #2037 (3): same content|text alias as `post` — the schema declares
+        // `text` tool-wide, so update honoring only `content` was a silent lie.
+        if let Some(content) = args["content"].as_str().or_else(|| args["text"].as_str()) {
             decision.content = content.to_string();
         }
         if let Some(tags) = args["tags"].as_array() {

--- a/src/mcp/handlers/instance.rs
+++ b/src/mcp/handlers/instance.rs
@@ -39,6 +39,40 @@ pub(super) fn handle_list_instances(home: &Path, args: &Value, instance_name: &s
 }
 
 pub(super) fn handle_create_instance(home: &Path, args: &Value, instance_name: &str) -> Value {
+    // #2037 (6): name + team = spawn THIS name, then join the team — team-mode
+    // used to silently rename to `<team>-N` (the fixup-1 incident). With
+    // count>1/backends the names are generated, so an explicit name errors.
+    if let (Some(team_name), Some(explicit)) = (
+        args.get("team").and_then(|v| v.as_str()),
+        args.get("name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty()),
+    ) {
+        if args.get("count").and_then(|v| v.as_u64()).unwrap_or(1) > 1
+            || args.get("backends").is_some()
+        {
+            return json!({"error": "explicit 'name' with count>1/backends is ambiguous — drop 'name' (generated <team>-N names) or spawn one instance at a time"});
+        }
+        // Normal single path keeps the explicit name + all single-spawn behavior.
+        let mut single = args.clone();
+        if let Some(obj) = single.as_object_mut() {
+            obj.remove("team");
+            obj.remove("count");
+        }
+        let mut spawned = handle_create_instance(home, &single, instance_name);
+        if spawned.get("error").is_some() {
+            return spawned;
+        }
+        let team_resp = crate::teams::update(home, &json!({"name": team_name, "add": [explicit]}));
+        if team_resp.get("error").is_some() {
+            // Instance EXISTS — surface the partial state honestly.
+            return json!({"name": explicit, "spawned": true, "team": team_name,
+                "team_join_error": team_resp["error"].clone()});
+        }
+        spawned["team"] = json!(team_name);
+        spawned["joined_team"] = json!(true);
+        return spawned;
+    }
     // Team mode: spawn count instances and group them
     if let Some(team_name) = args.get("team").and_then(|v| v.as_str()) {
         let default_backend = args["backend"]

--- a/src/mcp/handlers/instance_964_tests.rs
+++ b/src/mcp/handlers/instance_964_tests.rs
@@ -349,3 +349,35 @@ fn create_instance_persists_args_and_model_for_restart_parity_1858() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+/// #2037 (6): explicit `name` + `team` with count>1/backends is ambiguous —
+/// loud error instead of the pre-#2037 silent rename to `<team>-N`.
+#[test]
+fn create_instance_name_plus_team_count_conflict_errors_2037() {
+    let home = tmp_home("2037-name-team");
+    let resp = super::instance::handle_create_instance(
+        &home,
+        &serde_json::json!({"name": "exact-name", "team": "squad", "count": 3}),
+        "lead",
+    );
+    assert!(
+        resp["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("ambiguous"),
+        "count>1 + name must be a loud error, not a silent rename: {resp}"
+    );
+    let resp = super::instance::handle_create_instance(
+        &home,
+        &serde_json::json!({"name": "exact-name", "team": "squad", "backends": ["claude", "codex"]}),
+        "lead",
+    );
+    assert!(
+        resp["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("ambiguous"),
+        "backends + name must be a loud error: {resp}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/status_summary.rs
+++ b/src/status_summary.rs
@@ -136,16 +136,35 @@ pub fn parse_task_entry(text: &str) -> Option<&str> {
 /// (v1.2 §10.3 lifecycle: verified → done). Skips ambiguous matches.
 pub fn auto_close_merged_tasks(home: &Path, branch: &str) {
     let tasks = crate::tasks::list_all(home);
+    // #2037 (5): the Verified-only status filter was the zombie-task gap —
+    // a dispatch task stays `claimed`/`in_progress` on the board while the
+    // reviewer's VERIFIED verdict lives in messages, so "PR merged but task
+    // open" recurred daily. Split by link strength:
+    //   - STRUCTURED link (t.branch == merged branch, set by
+    //     link_branch_to_task and OVERWRITTEN on re-dispatch — so a stale
+    //     earlier branch stops matching once a newer one is linked): any
+    //     active status closes. The merge of the explicitly-bound branch IS
+    //     the work landing.
+    //   - text-token fallback (branch mentioned in title/description):
+    //     stays Verified-only — a loose match must not close live work.
+    let active = |st: &TaskStatus| {
+        matches!(
+            st,
+            TaskStatus::Open
+                | TaskStatus::Claimed
+                | TaskStatus::InProgress
+                | TaskStatus::InReview
+                | TaskStatus::Blocked
+                | TaskStatus::Verified
+        )
+    };
     let candidates: Vec<_> = tasks
         .iter()
-        .filter(|t| t.status == TaskStatus::Verified)
         .filter(|t| {
-            // #1942: the structured `branch` field is the canonical link (set by
-            // `link_branch_to_task` on dispatch); the description/title token
-            // match stays as the legacy fallback for branches embedded in text.
-            t.branch.as_deref() == Some(branch)
-                || contains_as_token(&t.description, branch)
-                || contains_as_token(&t.title, branch)
+            let structured = t.branch.as_deref() == Some(branch);
+            let text_fallback =
+                contains_as_token(&t.description, branch) || contains_as_token(&t.title, branch);
+            (structured && active(&t.status)) || (text_fallback && t.status == TaskStatus::Verified)
         })
         .collect();
 
@@ -164,7 +183,10 @@ pub fn auto_close_merged_tasks(home: &Path, branch: &str) {
     }
 
     let task = candidates[0];
-    let result = format!("auto-closed: branch '{}' merged", branch);
+    let result = format!(
+        "auto-closed: branch '{}' merged (status at close: {})",
+        branch, task.status
+    );
     // M4: use system:auto_close identity (in ACL allow-list) through
     // tasks::handle() to get state-machine validation + proper ACL.
     let resp = crate::tasks::handle(
@@ -312,6 +334,106 @@ mod tests {
             task.status,
             TaskStatus::Done,
             "unverified task must NOT be auto-closed"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #2037 (5): a CLAIMED/IN_PROGRESS task with a STRUCTURED branch link
+    /// auto-closes when that branch merges — the Verified-only filter was the
+    /// daily zombie-task gap (the reviewer verdict lives in messages, the
+    /// board status stays claimed).
+    #[test]
+    fn auto_close_closes_active_task_with_structured_link_2037() {
+        use crate::task_events::{append_batch, InstanceName, TaskEvent, TaskId};
+        let dir =
+            std::env::temp_dir().join(format!("agend-autoclose-2037a-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        let tid = "t-2037-active-001";
+        append_batch(
+            &dir,
+            &InstanceName::from("test:seed"),
+            vec![
+                TaskEvent::Created {
+                    task_id: TaskId(tid.into()),
+                    title: "impl thing".into(),
+                    description: "work".into(),
+                    priority: "normal".into(),
+                    owner: None,
+                    due_at: None,
+                    depends_on: Vec::new(),
+                    routed_to: None,
+                    branch: None,
+                    bind: None,
+                    eta_secs: None,
+                    tags: vec![],
+                    parent_id: None,
+                },
+                TaskEvent::Claimed {
+                    task_id: TaskId(tid.into()),
+                    by: InstanceName::from("dev"),
+                },
+            ],
+        )
+        .expect("seed claimed task");
+        crate::tasks::link_branch_to_task(&dir, tid, "fix/2037-thing").expect("link");
+        auto_close_merged_tasks(&dir, "fix/2037-thing");
+        let task = crate::tasks::list_all(&dir)
+            .into_iter()
+            .find(|t| t.id.as_str() == tid)
+            .expect("task present");
+        assert_eq!(
+            task.status,
+            TaskStatus::Done,
+            "structured-link claimed task must auto-close on merge"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #2037 (5) guard: a TEXT-fallback match (branch token in description,
+    /// no structured link) stays Verified-only — a loose match must never
+    /// close live work.
+    #[test]
+    fn auto_close_text_fallback_stays_verified_only_2037() {
+        use crate::task_events::{append_batch, InstanceName, TaskEvent, TaskId};
+        let dir =
+            std::env::temp_dir().join(format!("agend-autoclose-2037b-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        let tid = "t-2037-text-001";
+        append_batch(
+            &dir,
+            &InstanceName::from("test:seed"),
+            vec![
+                TaskEvent::Created {
+                    task_id: TaskId(tid.into()),
+                    title: "impl other".into(),
+                    description: "working on fix/2037-other today".into(),
+                    priority: "normal".into(),
+                    owner: None,
+                    due_at: None,
+                    depends_on: Vec::new(),
+                    routed_to: None,
+                    branch: None,
+                    bind: None,
+                    eta_secs: None,
+                    tags: vec![],
+                    parent_id: None,
+                },
+                TaskEvent::Claimed {
+                    task_id: TaskId(tid.into()),
+                    by: InstanceName::from("dev"),
+                },
+            ],
+        )
+        .expect("seed");
+        auto_close_merged_tasks(&dir, "fix/2037-other");
+        let task = crate::tasks::list_all(&dir)
+            .into_iter()
+            .find(|t| t.id.as_str() == tid)
+            .expect("task present");
+        assert_ne!(
+            task.status,
+            TaskStatus::Done,
+            "text-fallback must NOT close a non-verified task"
         );
         std::fs::remove_dir_all(&dir).ok();
     }


### PR DESCRIPTION
## Summary

#2037 **PR-B** (behavior, deliberate). Two items + one verify-first retraction:

### ⑤ Dispatch-task auto-close gap (the daily zombies)
**Root cause**: `auto_close_merged_tasks` only closed `status == Verified` — but a dispatch task stays `claimed`/`in_progress` on the board (the reviewer's VERIFIED is a message verdict, not a board status), so "PR merged but task open" recurred daily.

**Fix, split by link strength** (addresses the multi-PR-correlation concern from the dispatch):
- **Structured link** (`t.branch == merged branch`): closes any active status. `link_branch_to_task` **overwrites** on re-dispatch (verified), so a stale earlier branch stops matching the moment a newer branch is linked — the sequential multi-PR task is safe by construction.
- **Text-token fallback** (branch named in title/description): stays **Verified-only** — a loose match must never close live work.
- Close result records status-at-close for audit.

### ⑥ `create_instance` name + team without rename
Team-mode used to swallow the explicit `name` and spawn `<team>-N` (the fixup-1 incident). Now: single spawn through the normal path (name + all single-spawn behavior preserved) → `teams::update add`. `count>1`/`backends` with an explicit name = loud error. A team-join failure after a successful spawn surfaces `spawned:true + team_join_error` honestly.

### ⑦ Inbox renudge gate — RETRACTED (verify-first, lead-confirmed)
`poll_reminder` already gates on `unread>0`. The only drain-blind renudge is the #1888 handoff-track design — deliberate (read-state gating is exactly what #1888 fixed), and its pathological stale-head case was already closed by #2013. Gating it on unread would regress #1888. No change.

## Tests
structured-link claimed task closes on merge · text-fallback claimed task does NOT close (guard) · name+team conflict errors (count>1 and backends shapes). Existing #1942 Verified-path tests untouched and green.

## Preflight
fmt / clippy(tray) clean; nextest 4004+2/4006 → all green after the instance.rs 750-LOC trim (file_size_invariant force-rerun passed); the 1 = known #1834 environmental (bypass-solo passed).

Closes #2037 (PR-A: #2040)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
