### PR TITLE
feat(telegram): resolve sender display name from user_allowlist {id,name} entries

### DIFF
--- a/src/bootstrap/doctor.rs
+++ b/src/bootstrap/doctor.rs
@@ -218,7 +218,8 @@ mod tests {
             bot_token_env: "AGEND_TELEGRAM_BOT_TOKEN".into(),
             group_id: -100123,
             mode: "topic".into(),
-            user_allowlist,
+            user_allowlist: user_allowlist
+                .map(|v| v.into_iter().map(crate::fleet::AllowlistEntry::Id).collect()),
             fleet_binding: None,
         }
     }

--- a/src/bootstrap/doctor.rs
+++ b/src/bootstrap/doctor.rs
@@ -218,8 +218,11 @@ mod tests {
             bot_token_env: "AGEND_TELEGRAM_BOT_TOKEN".into(),
             group_id: -100123,
             mode: "topic".into(),
-            user_allowlist: user_allowlist
-                .map(|v| v.into_iter().map(crate::fleet::AllowlistEntry::Id).collect()),
+            user_allowlist: user_allowlist.map(|v| {
+                v.into_iter()
+                    .map(crate::fleet::AllowlistEntry::Id)
+                    .collect()
+            }),
             fleet_binding: None,
         }
     }

--- a/src/channel/telegram/bootstrap.rs
+++ b/src/channel/telegram/bootstrap.rs
@@ -63,7 +63,20 @@ pub fn init_from_config(
         }
         Some(list) => tracing::info!(count = list.len(), "telegram user_allowlist active"),
     }
-    let allowlist = user_allowlist.clone();
+    // Split the allowlist into the bare-id list (authz, unchanged downstream)
+    // and an id→name map (display: surfaced as `[user:NAME via telegram]` when
+    // the sender has no public @username).
+    let allowlist_ids: Option<Vec<i64>> = user_allowlist
+        .as_ref()
+        .map(|l| l.iter().map(|e| e.id()).collect());
+    let user_names: HashMap<i64, String> = user_allowlist
+        .as_ref()
+        .map(|l| {
+            l.iter()
+                .filter_map(|e| e.name().map(|n| (e.id(), n.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
 
     // Clean up orphaned topics
     let mut reg = load_topic_registry(home);
@@ -146,9 +159,10 @@ pub fn init_from_config(
         topic_map,
         home.to_path_buf(),
         submit_keys,
-        allowlist,
+        allowlist_ids,
     );
     raw_state.fleet_binding_topic_id = fleet_binding_topic_id;
+    raw_state.user_names = user_names;
     let state = Arc::new(Mutex::new(raw_state));
     start_polling(Arc::clone(&state));
     Some(state)

--- a/src/channel/telegram/bootstrap.rs
+++ b/src/channel/telegram/bootstrap.rs
@@ -69,11 +69,19 @@ pub fn init_from_config(
     let allowlist_ids: Option<Vec<i64>> = user_allowlist
         .as_ref()
         .map(|l| l.iter().map(|e| e.id()).collect());
+    // Sanitize each configured name at ingestion (the single chokepoint): the
+    // stored map — and therefore every consumer via `username_for` (both inbound
+    // paths + status-summary) — holds only header-safe names. A name that
+    // sanitizes to empty is dropped, so its sender falls back to `unknown`.
     let user_names: HashMap<i64, String> = user_allowlist
         .as_ref()
         .map(|l| {
             l.iter()
-                .filter_map(|e| e.name().map(|n| (e.id(), n.to_string())))
+                .filter_map(|e| {
+                    e.name()
+                        .and_then(super::state::sanitize_display_name)
+                        .map(|n| (e.id(), n))
+                })
                 .collect()
         })
         .unwrap_or_default();

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -204,12 +204,16 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         );
         // Also notify agent PTY so it picks up the summary
         let sid = msg.from.as_ref().map(|u| u.id.0 as i64);
-        let allowlist_name: Option<String> =
-            if msg.from.as_ref().and_then(|u| u.username.as_deref()).is_none() {
-                sid.and_then(|id| lock_state(state).username_for(id).map(str::to_string))
-            } else {
-                None
-            };
+        let allowlist_name: Option<String> = if msg
+            .from
+            .as_ref()
+            .and_then(|u| u.username.as_deref())
+            .is_none()
+        {
+            sid.and_then(|id| lock_state(state).username_for(id).map(str::to_string))
+        } else {
+            None
+        };
         let username = msg
             .from
             .as_ref()
@@ -326,12 +330,16 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
     // Display name: prefer the public @username; if absent, fall back to the
     // configured allowlist name (`{ id, name }` in fleet.yaml) so the operator
     // shows as their name instead of `unknown`; else "unknown".
-    let allowlist_name: Option<String> =
-        if msg.from.as_ref().and_then(|u| u.username.as_deref()).is_none() {
-            sender_id.and_then(|id| lock_state(state).username_for(id).map(str::to_string))
-        } else {
-            None
-        };
+    let allowlist_name: Option<String> = if msg
+        .from
+        .as_ref()
+        .and_then(|u| u.username.as_deref())
+        .is_none()
+    {
+        sender_id.and_then(|id| lock_state(state).username_for(id).map(str::to_string))
+    } else {
+        None
+    };
     let username = msg
         .from
         .as_ref()

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -203,10 +203,18 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
             instance_name
         );
         // Also notify agent PTY so it picks up the summary
+        let sid = msg.from.as_ref().map(|u| u.id.0 as i64);
+        let allowlist_name: Option<String> =
+            if msg.from.as_ref().and_then(|u| u.username.as_deref()).is_none() {
+                sid.and_then(|id| lock_state(state).username_for(id).map(str::to_string))
+            } else {
+                None
+            };
         let username = msg
             .from
             .as_ref()
             .and_then(|u| u.username.as_deref())
+            .or(allowlist_name.as_deref())
             .unwrap_or("unknown");
         crate::inbox::notify_agent(
             &home,
@@ -315,10 +323,20 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
     }
 
     let sender_id: Option<i64> = msg.from.as_ref().map(|u| u.id.0 as i64);
+    // Display name: prefer the public @username; if absent, fall back to the
+    // configured allowlist name (`{ id, name }` in fleet.yaml) so the operator
+    // shows as their name instead of `unknown`; else "unknown".
+    let allowlist_name: Option<String> =
+        if msg.from.as_ref().and_then(|u| u.username.as_deref()).is_none() {
+            sender_id.and_then(|id| lock_state(state).username_for(id).map(str::to_string))
+        } else {
+            None
+        };
     let username = msg
         .from
         .as_ref()
         .and_then(|u| u.username.as_deref())
+        .or(allowlist_name.as_deref())
         .unwrap_or("unknown");
 
     // Authz: drop messages from senders not on the allowlist (Sprint 21

--- a/src/channel/telegram/state.rs
+++ b/src/channel/telegram/state.rs
@@ -92,6 +92,11 @@ pub struct TelegramState {
     /// config's `fleet_binding` block plus the on-disk topic registry
     /// sentinel `"__fleet__"`.
     pub fleet_binding_topic_id: Option<i32>,
+    /// Display names for allowlisted Telegram user ids (from the `{ id, name }`
+    /// form of `user_allowlist`). Used to render `[user:NAME via telegram]` when
+    /// the sender has no public @username. Set post-bootstrap in
+    /// [`init_from_config`]; empty when no names are configured.
+    pub user_names: HashMap<i64, String>,
 }
 
 impl TelegramState {
@@ -117,6 +122,7 @@ impl TelegramState {
             user_allowlist,
             registry: None,
             fleet_binding_topic_id: None,
+            user_names: HashMap::new(),
         }
     }
 
@@ -150,6 +156,7 @@ impl TelegramState {
             user_allowlist,
             registry: None,
             fleet_binding_topic_id: None,
+            user_names: HashMap::new(),
         }
     }
 
@@ -166,6 +173,13 @@ impl TelegramState {
     /// Telegram" section for the migration steps.
     pub fn is_user_allowed(&self, user_id: i64) -> bool {
         crate::channel::auth::is_authorized_recipient(&self.user_allowlist, user_id)
+    }
+
+    /// Configured display name for a Telegram user id, if any (from the
+    /// `{ id, name }` form of `user_allowlist`). Used to resolve the sender
+    /// shown in agent inboxes when the account has no public @username.
+    pub fn username_for(&self, user_id: i64) -> Option<&str> {
+        self.user_names.get(&user_id).map(String::as_str)
     }
 
     /// Send a message to an instance's Telegram topic.
@@ -286,6 +300,36 @@ mod tests {
         assert!(state.is_user_allowed(100));
         assert!(!state.is_user_allowed(41));
         assert!(!state.is_user_allowed(0));
+    }
+
+    #[test]
+    fn username_for_resolves_configured_name() {
+        let mut state = TelegramState::new(
+            "tok",
+            -1,
+            HashMap::new(),
+            PathBuf::from("/tmp"),
+            HashMap::new(),
+            Some(vec![42, 100]),
+        );
+        state.user_names.insert(42, "Alice".to_string());
+        // configured name → resolved
+        assert_eq!(state.username_for(42), Some("Alice"));
+        // allowlisted but no name → None (caller falls back to "unknown")
+        assert_eq!(state.username_for(100), None);
+        // unknown id → None
+        assert_eq!(state.username_for(999), None);
+    }
+
+    #[test]
+    fn allowlist_entry_untagged_accepts_bare_id_and_named() {
+        use crate::fleet::AllowlistEntry;
+        let yaml = "- 12345\n- { id: 67890, name: \"Alice\" }\n";
+        let list: Vec<AllowlistEntry> = serde_yaml_ng::from_str(yaml).expect("parse");
+        assert_eq!(list[0].id(), 12345);
+        assert_eq!(list[0].name(), None);
+        assert_eq!(list[1].id(), 67890);
+        assert_eq!(list[1].name(), Some("Alice"));
     }
 
     #[test]

--- a/src/channel/telegram/state.rs
+++ b/src/channel/telegram/state.rs
@@ -197,6 +197,34 @@ impl TelegramState {
     }
 }
 
+/// Cap (in chars) for an operator-configured display name. 32 matches the
+/// Telegram @username length limit — long enough for any real name, short
+/// enough to keep the notification header readable.
+const DISPLAY_NAME_MAX_CHARS: usize = 32;
+
+/// Sanitize an operator-configured allowlist display name before it is stored
+/// and later surfaced in the line-oriented `[user:NAME via telegram]`
+/// notification header. The name is operator-trust input (it never participates
+/// in authorization — only the id projection does), so this is header-hygiene,
+/// not a privilege boundary: a control character or newline in a name would
+/// garble the single-line header parsing. Strips ASCII/Unicode control
+/// characters, trims surrounding whitespace, and caps the length. Returns
+/// `None` when nothing usable remains, so the caller drops the entry and the
+/// sender falls back to `unknown` rather than rendering an empty name.
+pub(crate) fn sanitize_display_name(raw: &str) -> Option<String> {
+    let cleaned: String = raw
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(DISPLAY_NAME_MAX_CHARS)
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -330,6 +358,30 @@ mod tests {
         assert_eq!(list[0].name(), None);
         assert_eq!(list[1].id(), 67890);
         assert_eq!(list[1].name(), Some("Alice"));
+    }
+
+    // #2045 review add 1: the configured display name is sanitized before it can
+    // reach the line-oriented `[user:NAME via telegram]` notification header.
+    #[test]
+    fn sanitize_display_name_strips_control_chars_and_caps_length() {
+        // Plain name passes through unchanged.
+        assert_eq!(sanitize_display_name("Yu"), Some("Yu".to_string()));
+        // Newline / CR / tab (the header-garbling chars) are stripped.
+        assert_eq!(
+            sanitize_display_name("Al\nice\r\tBob"),
+            Some("AliceBob".to_string()),
+            "control chars (incl. newline/CR/tab) must be removed so the \
+             single-line notification header can't be garbled"
+        );
+        // Surrounding whitespace is trimmed.
+        assert_eq!(sanitize_display_name("  Yu  "), Some("Yu".to_string()));
+        // Length is capped at DISPLAY_NAME_MAX_CHARS (32).
+        let long = "x".repeat(50);
+        assert_eq!(sanitize_display_name(&long).map(|s| s.len()), Some(32));
+        // A name that sanitizes to nothing → None (caller falls back to "unknown").
+        assert_eq!(sanitize_display_name("\n\r\t"), None);
+        assert_eq!(sanitize_display_name("   "), None);
+        assert_eq!(sanitize_display_name(""), None);
     }
 
     #[test]

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -163,12 +163,19 @@ pub struct FleetConfig {
     pub(crate) home: Option<PathBuf>,
 }
 
-/// An entry in the Telegram `user_allowlist`. Accepts either a bare numeric
-/// Telegram user id (legacy: `- 12345`) or a `{ id, name }` map that also
-/// records a display name. The name is surfaced as `[user:NAME via telegram]`
-/// in agent inboxes when the sender has no public Telegram @username (so the
-/// operator no longer shows up as `unknown`). Backward compatible via
-/// `#[serde(untagged)]` — old bare-id lists still parse.
+/// An entry in a channel's `user_allowlist`. **Channel-agnostic by design** —
+/// used by Telegram today, and intended for any future channel adapter
+/// (Discord, Slack, …): when their inbound handlers land they should give their
+/// `user_allowlist` this same `Option<Vec<AllowlistEntry>>` type and resolve the
+/// sender name the same way (see `TelegramState::username_for` +
+/// `NotifySource::Channel`, which already renders `user:NAME via {channel}` for
+/// any `ChannelKind`).
+///
+/// Accepts either a bare numeric user id (legacy: `- 12345`) or a `{ id, name }`
+/// map that also records a display name. The name is surfaced as
+/// `[user:NAME via <channel>]` in agent inboxes when the sender has no public
+/// platform username (so the operator no longer shows up as `unknown`).
+/// Backward compatible via `#[serde(untagged)]` — old bare-id lists still parse.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AllowlistEntry {

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -163,6 +163,44 @@ pub struct FleetConfig {
     pub(crate) home: Option<PathBuf>,
 }
 
+/// An entry in the Telegram `user_allowlist`. Accepts either a bare numeric
+/// Telegram user id (legacy: `- 12345`) or a `{ id, name }` map that also
+/// records a display name. The name is surfaced as `[user:NAME via telegram]`
+/// in agent inboxes when the sender has no public Telegram @username (so the
+/// operator no longer shows up as `unknown`). Backward compatible via
+/// `#[serde(untagged)]` — old bare-id lists still parse.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AllowlistEntry {
+    /// Bare Telegram user id (legacy shape).
+    Id(i64),
+    /// `{ id: 12345, name: "Alice" }` — id plus display name.
+    Named { id: i64, name: String },
+}
+
+impl AllowlistEntry {
+    /// The Telegram user id, regardless of shape.
+    pub fn id(&self) -> i64 {
+        match self {
+            Self::Id(id) | Self::Named { id, .. } => *id,
+        }
+    }
+
+    /// The configured display name, if this entry carries one.
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Self::Named { name, .. } => Some(name.as_str()),
+            Self::Id(_) => None,
+        }
+    }
+}
+
+impl From<i64> for AllowlistEntry {
+    fn from(id: i64) -> Self {
+        Self::Id(id)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ChannelConfig {
@@ -187,8 +225,13 @@ pub enum ChannelConfig {
         ///   down an environment without removing the channel config.
         /// - `Some([...])`: only those user IDs are accepted; others are
         ///   dropped with a warn log.
+        ///
+        /// Each entry is either a bare id (`- 12345`) or `{ id, name }` — see
+        /// [`AllowlistEntry`]. A configured `name` is shown as the sender in
+        /// agent inboxes (`[user:NAME via telegram]`) when the Telegram account
+        /// has no public @username.
         #[serde(default)]
-        user_allowlist: Option<Vec<i64>>,
+        user_allowlist: Option<Vec<AllowlistEntry>>,
         /// Optional fleet-activity binding — where cross-instance
         /// `FleetEvent`s (delegate / report / decision / broadcast) are
         /// mirrored as one-liner log rows. Omitted = no fleet sink for

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -1042,6 +1042,74 @@ instances:
         fs::remove_dir_all(&dir).ok();
     }
 
+    // #2045: the `{ id, name }` allowlist form parses through the REAL fleet load
+    // entry (FleetConfig::load), alongside a legacy bare id — the happy path the
+    // deny test below guards.
+    #[test]
+    fn user_allowlist_named_entry_loads_via_real_fleet() {
+        let dir = std::env::temp_dir().join(format!("agend-fleet-allow-ok-{}", std::process::id()));
+        let path = write_fleet(
+            &dir,
+            r#"
+channel:
+  type: telegram
+  bot_token_env: MY_BOT_TOKEN
+  group_id: -100
+  user_allowlist:
+    - 12345
+    - { id: 67890, name: "Alice" }
+instances: {}
+"#,
+        );
+        let config = FleetConfig::load(&path).expect("named + bare allowlist must load");
+        match config.channel {
+            Some(ChannelConfig::Telegram {
+                ref user_allowlist, ..
+            }) => {
+                let list = user_allowlist.as_ref().expect("allowlist present");
+                assert_eq!(list[0].id(), 12345);
+                assert_eq!(list[0].name(), None);
+                assert_eq!(list[1].id(), 67890);
+                assert_eq!(list[1].name(), Some("Alice"));
+            }
+            other => panic!("expected telegram channel, got {other:?}"),
+        }
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    // #2045 review add 2 (the authz-surface invariant): a MALFORMED allowlist
+    // entry must FAIL-CLOSED at the real fleet load entry — `FleetConfig::load`
+    // returns `Err`, so the daemon refuses to boot with a half-parsed allowlist
+    // rather than silently dropping the bad entry and accepting whatever remains.
+    // The `#[serde(untagged)]` enum has no fallthrough: an entry that is neither a
+    // bare integer nor a complete `{ id: i64, name: String }` matches no variant.
+    #[test]
+    fn user_allowlist_malformed_entry_fails_closed_via_real_fleet() {
+        // A `{ id, name }` map whose id is a quoted string — matches neither
+        // `Id(i64)` (it's a map) nor `Named { id: i64, .. }` (id is not i64).
+        let dir =
+            std::env::temp_dir().join(format!("agend-fleet-allow-bad-{}", std::process::id()));
+        let path = write_fleet(
+            &dir,
+            r#"
+channel:
+  type: telegram
+  bot_token_env: MY_BOT_TOKEN
+  group_id: -100
+  user_allowlist:
+    - 12345
+    - { id: "not_a_number", name: "Mallory" }
+instances: {}
+"#,
+        );
+        assert!(
+            FleetConfig::load(&path).is_err(),
+            "a malformed allowlist entry must fail the whole fleet load (fail-closed \
+             authz surface), not be silently dropped"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
     #[test]
     fn test_channels_plural_single_entry_collapses_to_singular() {
         // `channels:` (plural) with one entry normalizes into `channel:`


### PR DESCRIPTION
## Problem
Inbound Telegram messages from accounts **without a public `@username`** are surfaced to agents as `[user:unknown via telegram]` — even though the numeric `sender_id` is known and on the allowlist. Operators whose Telegram account has no @username always show up as `unknown`.

## Fix
Let `user_allowlist` entries optionally carry a display name, and resolve the inbound sender's name from it.

- **fleet**: `user_allowlist` entries accept either a bare id (legacy `- 12345`) **or** `{ id, name }` — new `AllowlistEntry` enum, `#[serde(untagged)]`, **backward compatible** (old bare-id lists still parse). The type is **channel-agnostic** by design (documented for Discord/Slack reuse).
- **bootstrap**: split entries into the bare-id list (authz path **unchanged**) and an `id -> name` map stored on `TelegramState`.
- **inbound**: `username = @username ?? allowlist_name(sender_id) ?? "unknown"` (main + status-summary paths). `NotifySource::Channel(name, kind)` already renders `user:NAME via {channel}` for any `ChannelKind`.
- **tests**: untagged deserialization (bare id + `{id,name}`), `username_for` resolution; existing `is_user_allowed` / doctor / yaml round-trip unchanged.

### fleet.yaml (new optional form)
```yaml
user_allowlist:
  - { id: 5315487661, name: "Yu" }
  - 8700664262            # bare id still works
```

## Verification
- `cargo check` + `cargo check --tests`: clean on upstream/main
- `cargo test --bin agend-terminal`: allowlist (13), user_allowlist (7), username_for (1), is_user_allowed (4) — all pass, no regressions
- Deployed + verified in production: operator messages now arrive as `[user:Yu via telegram]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)