### PR TITLE
docs(#2050): architecture map + phased refactor plan from the six-subsystem survey

### DIFF
--- a/docs/REFACTOR-PLAN.md
+++ b/docs/REFACTOR-PLAN.md
@@ -1,0 +1,206 @@
+# Refactor Plan — #2050 Architecture Pass
+
+> Phased plan derived from [architecture.md](architecture.md) §6 (tensions)
+> and the six subsystem surveys (`main` @ `65d9ad82`, 2026-06-12). Each item
+> is sized to be one reviewable PR an implementing agent can land
+> independently. Waves are ordered by risk-adjusted value; within a wave,
+> items are independent unless noted.
+
+## Principles
+
+1. **Finish the extraction before new abstraction.** The dominant debt
+   shape is "gradual extraction left two parallel mechanisms for one
+   concept" (inline trackers vs PerTickHandlers; raw `Command` vs
+   `git_bypass`; size-driven vs concept-driven handler splits). Completing
+   these is low-risk, high-yield, and unblocks everything riskier.
+2. **High-care items have hard prerequisites.** The two highest-risk
+   targets — the supervisor `tick()` god-fn and the `agend-git` authority
+   boundary — do not start until their listed gates are green.
+3. **Each PR adds (or updates) a completeness invariant** where the smell
+   was "a hand-picked subset silently drifts" (the #1002/#1719 class):
+   assert the full set, not the curated list.
+4. **No behavior change inside a structure PR.** Refactor PRs preserve
+   semantics bit-for-bit; behavior fixes ride separate PRs. KISS: no
+   speculative flexibility, no config for things nobody configures.
+5. **Findings are hypotheses until verified.** The 2026-06-10 readiness
+   audit had ~70% false-positive risk findings; survey smells marked
+   [hypothesis] get a verify-first read before any code moves.
+
+## Wave 1 — finish the extraction (low risk, high yield)
+
+### W1.1 Unify periodic work under `PerTickHandler`
+Wrap the 13 inline supervisor `run_loop` trackers (anti_stall,
+idle_watchdog, decision_timeout, helper_staleness, mcp_registry,
+waiting_on_stale, conflict_notify, canonical_drift, auto_release,
+dispatch_idle, dispatch_idle_nudge, retention_supervisor;
+supervisor.rs:266) as `PerTickHandler`s with declared cadence; delete the
+inline calls; add a **completeness invariant test** asserting the
+registered handler set is the full superset (the app-mode-wiring-drift
+class). Preserve relative order — handler order is load-bearing
+(daemon/mod.rs:577-579).
+**Effort** ~1 day · **Risk** low (each tracker already self-contained) ·
+**Source** survey 01-R2 / 06-A. Best value-to-risk in the plan; do first.
+
+### W1.2 `git_cmd` helper — absorb daemon-side raw-git boilerplate
+`git_cmd(dir, args) -> Result<String>` (always-bypass, trimmed stdout,
+structured error) + `git_ok(dir, args) -> bool`. Migrate the ~51
+daemon-side raw `Command::new("git")` sites (worktree_pool 27,
+worktree_cleanup 15, branch_sweep 8, binding…). **Excludes** the
+`agend-git` shim (deliberately raw — it is the gated side) and tests
+wanting raw control. Makes "forgot `AGEND_GIT_BYPASS`" structurally
+impossible daemon-side and kills a flaky-test class.
+**Effort** 0.5–1 day · **Risk** low, mechanical, reviewable per call-site ·
+**Source** survey 05-R1.
+
+### W1.3 Quick wins (one small PR each)
+- Unify the duplicated tool-timeout maps (`request_dedup.rs:465` ↔
+  `mcp_proxy.rs:20`) into one table — drift-prone today. (survey 02-#3)
+- Extract `spawn_one` (api/mod.rs:665, cohesive 80-LOC agent-spawn fn)
+  out of the api server file into `agent_ops`. (survey 02-#4)
+- Fix `skills.rs` doc drift (says 5 backends, code has 4 — Gemini
+  retired). (survey 06-E)
+
+## Wave 2 — cap relief & mechanical decomposition
+
+Gated on W1 only where noted; otherwise independent.
+
+### W2.1 Split `instance.rs` by concern
+748/750 LOC. → `instance_queries` / `instance_state` (absorbing the
+existing size-driven `instance_spawn.rs` + `instance_lifecycle.rs` into a
+coherent module) / `instance_metadata` (metadata + pane + health).
+Zero API change; the three concerns share no state.
+**Effort** M · **Risk** low · **Source** survey 02-#1.
+
+### W2.2 Break up `handle_delegate_task` + extract `comms_gates`
+comms.rs at cap; `handle_delegate_task` (317 LOC) inlines busy-gate,
+second-reviewer, test-name validation, auto-task-creation; report path
+inlines sha_gate + evidence_gate. Recompose as
+resolve→validate→create→lease→send→track with gates as one fallible,
+unit-testable pre-check module (fold in the existing sha_gate /
+evidence_gate / anti_stall sibling files).
+**Effort** M · **Risk** low-medium (failure ordering must be preserved —
+route failure must still suppress provenance/dispatch side-effects) ·
+**Source** survey 02-#2, 03-A.
+
+### W2.3 `feed_with_fg` gate-pipeline extraction
+Decompose the 549-LOC classifier method into named `apply_*_gate` steps in
+an explicit call sequence (ordering stays encoded in one place). This is
+the legibility prerequisite for every other state-detection change,
+including #1523 phase-2.
+**Effort** M · **Risk** low (structure-only) · **Source** survey 04-#2.
+
+### W2.4 `CadenceGate` + `PerAgentLatch<T>` utilities
+Collapse ~15 hand-rolled cadence counters and ~10 per-agent latch maps;
+`PerAgentLatch` builds in boot-grace + prune so a new watchdog **cannot**
+forget the boot-grace gate (today it is hand-wired per handler).
+Do after W1.1 so the latch sites are all in handler form first.
+**Effort** 0.5 day · **Risk** low, churns many files — keep it its own PR ·
+**Source** survey 01-R3.
+
+### W2.5 Backend preset factory collapse
+`backend.rs preset()` 300-LOC 6-arm factory with repeated fields → table /
+default-merge. Adding a profile field currently means 7 edits.
+**Effort** M · **Risk** low · **Source** survey 04-#3.
+
+### W2.6 Name the resize contract
+Keep both resize chokepoints (#2048), extract a shared
+`PaneContentRect`/`ResizeDecision` helper, and document the invariant:
+layout pre-computes, render is authoritative for the final inner rect.
+**Effort** S-M · **Risk** medium — do NOT remove render-time resize
+without PTY tests · **Source** survey 03-C.
+
+## Wave 3 — high-care strategic (hard prerequisites)
+
+### W3.1 Supervisor `tick()` decomposition
+The 469-LOC god-fn → phase pipeline with the #1530
+collect-under-lock / emit-after-drop boundary made **structural**
+(a `LockedPhase`→`EmitPhase` split) instead of the implicit
+`let action = {}` block.
+**Prerequisites (all green before starting):**
+- [DAEMON-LOCK-ORDERING.md](DAEMON-LOCK-ORDERING.md) reviewed/extended to
+  cover the refactored shape;
+- the #1644 source-pin passing, plus a new emit-after-drop structural pin
+  written for the phase form;
+- the supervisor.rs:1857 residual core-under-registry read audited
+  (#1530/F2).
+**Effort** 1–1.5 days · **Risk** HIGH — hottest path, the #1492/#1530
+invariants are load-bearing · **Source** survey 01-R1.
+
+### W3.2 `agend-git::classify` table-driven + #2027 uniform deny
+Replace the 214-LOC match with a `(&[subcmd], Gate)` table
+(Passthrough / ChdirPass / Deny / SilentExempt / CleanupPushPass) so every
+subcommand gets an explicit policy — closing the loud-deny vs silent-noop
+inconsistency (#2027) **by construction**. Bundle the #2027 fix; same file,
+same test discipline.
+**Prerequisites:** full agend-git conflict suite green (run with
+`PATH=/usr/bin` — the suite false-fails under the fleet shim).
+**Effort** 1–1.5 days · **Risk** MEDIUM-HIGH — this is the authority
+boundary · **Source** survey 05-R2.
+
+### W3.3 #1523 phase-2 — authoritative state for the deciders
+Migrate the 5 raw-heuristic per-tick deciders (hang_detection.rs:72,
+watchdog.rs:56, recovery_dispatcher.rs:288, supervisor.rs:1313 + :1861) to
+the hook-aware authoritative state. **Safe design (required):** snapshot.rs
+pre-fills a per-tick authoritative cache before the decider sequence
+(scheduler order snapshot → hang → recovery → watchdog → supervisor);
+deciders read the cache — never call into hook_shadow from under the core
+lock (registry⨯core inversion risk).
+Keep raw: conflict_notify (hooks can't see GitConflict), hook_event:36
+(it IS the comparison baseline), instance.rs:24 (restarting gate must be
+live). Design call to make explicitly: query.rs:19 (LIST = last-tick
+snapshot vs live).
+**Phase-2 must inherit, not "fix", fail-open ToolUse** — no clock
+backstop (architecture.md §4).
+**Prerequisites:** W2.3 landed; wire `behavioral.rs` divergence telemetry
+(built, unused) to gather heuristic⨯hook agreement data BEFORE flipping
+any default.
+**Effort** H · **Risk** medium (lock ordering) · **Source** survey 04-#1/§4.
+
+## Wave 4 — opportunistic / design-call-first
+
+Do when the owning file is already open, or after an explicit design
+decision. Not scheduled.
+
+- **Messaging pipeline modules** (validate/route/post_delivery split of
+  messaging.rs, keeping `handle_send` as the single ordered choreography) —
+  pairs with W2.2. (03-A)
+- **DeferredNotificationDelivery service** — one named API over the
+  queue/policy/TUI/headless four-layer split. (03-B)
+- **Channel notify ownership** — decide whether `Channel::notify` is the
+  canonical seam, then retire the concrete `notify_telegram*` entrypoints.
+  HIGH risk, staged migration, needs the decision first. (03-D)
+- **`process_error_recovery` extraction** (370 LOC SRL/ApiError machine) —
+  riskiest semantic surface in daemon-core (#1946/#1985 live here);
+  defer until W3.1 proves the phase shape. (01-R4)
+- **Deployment lifecycle submodules**; **CLI command modules**;
+  **schedules model/store/crud split**; **release-gate script**;
+  **`SchemaVersioned` unification** (verify the trait's fail-closed
+  default against fleet's warn-not-refuse #1989 before merging the two);
+  **tasks/handler.rs split**; **dispatch_hook options-struct**;
+  **row-level task-board cache**. (02/05/06 long tail)
+
+## Sequencing summary
+
+```
+W1.1 trackers→handlers ─┐
+W1.2 git_cmd            ├─ independent, start immediately
+W1.3 quick wins         ─┘
+W2.1/W2.2 cap relief    ── after W1 merges settle (same files)
+W2.3 gate pipeline      ── independent; prerequisite for W3.3
+W2.4 latch/cadence      ── after W1.1
+W2.5/W2.6               ── independent
+W3.1 tick() decompose   ── gates: lock doc + #1644 pin + :1857 audit
+W3.2 classify table     ── gate: conflict suite green (PATH=/usr/bin)
+W3.3 #1523 phase-2      ── gates: W2.3 + divergence telemetry wired
+W4                      ── opportunistic
+```
+
+## Acceptance per PR
+
+- Reviewer VERIFIED + required CI green (3-platform Check, LOC gate,
+  audit) before merge — no shortcuts.
+- Refactor PRs: `cargo test` byte-identical behavior expectations; any
+  moved invariant gets its pin test moved/extended in the same PR.
+- LOC-EST declared honestly in the PR body; oversized cohesive moves use
+  the `loc-overrun-accepted` label after a reviewer cohesion-accept.
+- Worktree-side test runs use `AGEND_GIT_BYPASS=1`.

--- a/docs/REFACTOR-PLAN.md
+++ b/docs/REFACTOR-PLAN.md
@@ -29,7 +29,7 @@
 ## Wave 1 — finish the extraction (low risk, high yield)
 
 ### W1.1 Unify periodic work under `PerTickHandler`
-Wrap the 13 inline supervisor `run_loop` trackers (anti_stall,
+Wrap the 12 inline supervisor `run_loop` trackers (anti_stall,
 idle_watchdog, decision_timeout, helper_staleness, mcp_registry,
 waiting_on_stale, conflict_notify, canonical_drift, auto_release,
 dispatch_idle, dispatch_idle_nudge, retention_supervisor;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,1164 +1,267 @@
-# AgEnD Terminal — Architecture Design Doc
+# AgEnD Terminal — Architecture Map
 
-> Rust rewrite of AgEnD: Agent Process Manager with direct PTY ownership.
+> Current-state structural map, synthesized from the #2050 architecture pass
+> (six subsystem surveys, all claims verified against `main` @ `65d9ad8`,
+> 2026-06-12). Companion doc: [REFACTOR-PLAN.md](REFACTOR-PLAN.md) — the
+> phased plan derived from this map.
+>
+> Newcomers: read [ARCHITECTURE-QUICK-START.md](ARCHITECTURE-QUICK-START.md)
+> first. The original rewrite-era design doc is archived at
+> [archived/architecture-design-doc-2026-05.md](archived/architecture-design-doc-2026-05.md).
+> Lock discipline lives in [DAEMON-LOCK-ORDERING.md](DAEMON-LOCK-ORDERING.md)
+> and is summarized (not duplicated) here.
 
-## Overview
+## 1. What it is
 
-agend-terminal replaces the Node.js AgEnD + tmux stack with a single Rust binary that directly owns PTY master file descriptors. This eliminates the tmux dependency and the `send-keys` race condition at the architectural level.
+A long-running daemon that supervises multiple AI coding agents
+(claude / codex / kiro / agy / opencode) as PTY child processes and gives
+them: inter-agent MCP communication, fleet-as-code configuration, per-agent
+git-worktree isolation, health monitoring with auto-respawn, and TUI +
+Telegram remote control. The core value is **multi-agent orchestration**;
+everything else serves it.
 
-```
-┌─────────────────────────────────────────────────────┐
-│                   agend-terminal daemon              │
-│                                                      │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐           │
-│  │ Session 1│  │ Session 2│  │ Session N│  Core      │
-│  │ PTY + FD │  │ PTY + FD │  │ PTY + FD │           │
-│  └────┬─────┘  └────┬─────┘  └────┬─────┘           │
-│       │              │              │                 │
-│  ┌────▼──────────────▼──────────────▼─────┐          │
-│  │         Output Bus (broadcast)          │          │
-│  │   drainer → log + ready + broadcast     │          │
-│  └────┬──────────────┬──────────────┬─────┘          │
-│       │              │              │                 │
-│  ┌────▼────┐   ┌─────▼────┐  ┌─────▼────┐           │
-│  │ Attach  │   │ Channel  │  │ Health   │           │
-│  │ Client  │   │ Adapter  │  │ Monitor  │           │
-│  └─────────┘   └──────────┘  └──────────┘           │
-│                                                      │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐           │
-│  │  Fleet   │  │  Comms   │  │ Context  │           │
-│  │ Manager  │  │  Router  │  │ Rotation │           │
-│  └──────────┘  └──────────┘  └──────────┘           │
-│                                                      │
-│  ┌────────────────────────────────────────┐          │
-│  │         TCP API (localhost NDJSON)    │          │
-│  └────────────────────────────────────────┘          │
-└─────────────────────────────────────────────────────┘
-```
+~198K LOC Rust across 286 files. Three binaries: `agend-terminal` (daemon +
+TUI + CLI), `agend-mcp-bridge` (per-agent stdio↔TCP MCP relay),
+`agend-git` (PATH-shim `git` policy gate).
 
-## Why Rust, Why Rewrite
+## 2. Subsystem map
 
-| Problem (Node.js + tmux) | Root Cause | Rust Solution |
+Six subsystems, by size. Each has a dedicated survey trail in the #2050
+pass; the file:line evidence below is the load-bearing subset.
+
+### 2.1 Daemon core / lifecycle (~52K LOC)
+
+The heart: observe each agent's state machine, react, recover.
+
+| Module | LOC | Role |
 |---|---|---|
-| `send-keys` race condition | tmux CLI is fire-and-forget, no atomicity | Direct `write(master_fd)` — kernel guarantees atomicity for ≤PIPE_BUF |
-| Sequential restart bottleneck | tmux send-keys races force serialization | No tmux dependency, parallel spawn/kill |
-| No output ownership | tmux owns the PTY, agend uses `pipe-pane` | Daemon owns master fd, reads output directly |
-| MCP IPC complexity | Separate MCP server process + TCP API + timeout | Agent communicates via CLI (`agend-terminal reply`) — same binary |
-| Dual-path permission race | Terminal + Telegram both relay permissions | Single daemon routes all I/O, single source of truth |
-| Context rotation fragility | Grace period hacks, rapid re-rotation prevention | Direct PTY output parsing, deterministic rotation |
-| JS precision loss on snowflake IDs | JavaScript Number max safe integer | Rust u64 / i64, no precision issues |
+| `daemon/supervisor.rs` | 5408 | Per-agent state OBSERVATION + reaction emission + error recovery (SRL/ApiError) + 13 inline slow-tracker scans |
+| `daemon/mod.rs` | 2764 | Entry/init/shutdown; builds the per-tick handler set (`build_default_handlers` → 20 handlers) |
+| `daemon/per_tick/` | — | `PerTickHandler` trait + 20 handler impls, panic-guarded dispatch, boot-grace gate |
+| `daemon/crash_respawn.rs` | 568 | Crash→respawn decision: health budget, escalation persist, respawn worker |
+| `health.rs` | 2385 | Per-agent hang/crash budgets, blocked-reason, escalation persist+rehydrate |
+| `state/mod.rs` | 2176 | Per-agent `StateTracker` — screen-heuristic state machine (see 2.4) |
 
----
+Two periodic-work mechanisms coexist (see §6.1): the supervisor `run_loop`
+(every 10s) hosts 13 inline `*_tracker.maybe_scan/sweep` calls
+(supervisor.rs:266), while the daemon loop dispatches the 20 extracted
+`PerTickHandler`s with per-handler `catch_unwind` + timing
+(per_tick/mod.rs:182-214).
 
-## Module 1: Core — PTY Session Manager
+### 2.2 MCP layer + inter-agent comms (~22K LOC)
 
-**Status: Implemented (PoC + MVP)**
+Macro-architecturally sound: a single immutable 36-entry registry
+(`mcp/registry.rs:20`) pairs JSON-schema definitions with handler
+fn-pointers, dispatched through one validated chokepoint
+(`mcp/handlers/dispatch.rs:77-117`). The strain is micro: two handler files
+sit at the 750-LOC `file_size_invariant` cap, and extraction so far has been
+size-driven rather than concept-driven (see §6.4).
 
-### Data Model
-
-```rust
-pub struct PtySession {
-    pub id: u32,
-    pub command: String,
-    master: Box<dyn MasterPty>,       // PTY master — we own this
-    writer: Box<dyn Write>,           // Atomic write path
-    child: Box<dyn Child>,            // Child process handle
-    exit_status: Option<i32>,         // Cached exit code
-    size: (u16, u16),                 // Terminal cols x rows
-    ready: AtomicBool,                // Ready pattern matched
-    output_tx: broadcast::Sender,     // Fan-out to subscribers
-    drainer_done: Notify,             // PTY EOF signal
-}
-```
-
-### Key Operations
-
-| Operation | Implementation |
-|---|---|
-| **spawn** | `portable-pty::openpty()` + `spawn_command()`. Env vars injected. Background drainer starts immediately. |
-| **attach** | Client subscribes to `output_tx` broadcast. SIGWINCH sent to trigger redraw. |
-| **detach** | Client unsubscribes. Session continues. Drainer keeps logging. |
-| **inject** | `write_all(master_fd)` — atomic for payloads ≤ 4096 bytes (PIPE_BUF on macOS). Mutex serializes larger writes. |
-| **kill** | Optional quit command → grace period → `child.kill()`. |
-| **resize** | `master.resize()` → SIGWINCH to child. |
-
-### Output Pipeline
+The transport spine (an agent-to-agent `send`):
 
 ```
-PTY slave (child stdout) → master fd → drainer thread (spawn_blocking)
-                                          ├── output.log (append)
-                                          ├── ready pattern check (regex, 8KB window)
-                                          └── broadcast::Sender → N subscribers
+agent LLM → MCP tools/call {request_id: UUID}     bin/agend-mcp-bridge.rs:327
+  → content-dedup (500ms double-fire guard)        agend-mcp-bridge.rs:146
+  → cookie handshake → loopback TCP api socket     ipc.rs / api/mod.rs:229
+  → operator_gate.check_operation_allowed          api/operator_gate.rs:121
+  → request_dedup.dispatch (idempotent retry)      api/request_dedup.rs:165
+  → messaging::handle_send (5 phases)              api/handlers/messaging.rs:610
+      validate → team/quota gates → build message
+      → route_and_deliver → inbox::enqueue (flock + atomic rename)
+      → post side-effects (provenance/verdict/dispatch-tracking)
+  → target's next poll: inbox::drain (48KB byte-cap, keeps the
+    response dedup-cacheable so a lost-transport retry serves the
+    cached batch)                                   inbox/storage.rs:286-407
+  → daemon wake: compose_aware_inject → PTY        inbox/notify.rs:269-361
 ```
 
-The drainer runs independently of attach state. Output is always captured.
+Idempotency spine: the bridge generates `request_id` once and reuses it
+verbatim on retry; `DedupCache` (Fresh/InProgress/Cached/Oversized) bounds:
+TTL 10min, 64KB/entry, 64MB total, 8 waiters/id.
 
-### Concurrent Attach Behavior
+The task board is event-sourced (`task_events.rs`, ~20 event variants,
+full-replay reads cached by file-len/mtime/generation) with fail-closed
+forward-compat.
 
-- **Multi-attach read**: Supported. Broadcast channel fans output to all subscribers.
-- **Multi-attach write**: Undefined — interleaved keystrokes from multiple clients. Production should add an "active writer" mode: one client writes, others are read-only viewers.
+### 2.3 Channels / API / TUI / render (~24K LOC)
 
-### Graceful Daemon Shutdown
+Two overlapping delivery architectures (see §6.5): agent-to-agent sends
+flow through `messaging.rs`; operator/channel notifications flow through
+channel adapters + UX sinks + a persistent deferred-notification queue
+(`notification_queue.rs`) drained exactly-once by either the TUI loop or
+the daemon `notification_flush` handler (per-agent OS file lock + unique
+claim file — rename-only arbitration double-delivered under CI before).
 
-**Status: Implemented.**
+TUI: `Layout`/`Tab`/`PaneNode` own topology; `render/core_render.rs` owns
+drawing; `VTerm` (alacritty wrapper) owns terminal emulation. After #2048
+there are two intentional resize chokepoints — layout pre-computes sizes
+(`layout/mod.rs:294`), render is authoritative for the final inner content
+rect (`render/core_render.rs:437`). Render is deliberately not pure: it
+drains pane output and may resize VTerm/PTY before drawing.
 
-1. SIGTERM/SIGINT registered via `tokio::signal`.
-2. Accept loop uses `tokio::select!` with signal channels.
-3. On signal: kill all sessions in parallel (`child.kill()`), poll up to 5 seconds for exit.
-4. Clean up socket file.
-5. Attached clients receive connection close (EOF on their TCP read).
+### 2.4 State detection / backend profiles (~13K LOC)
 
-### Output Log Rotation
+The known-most-fragile subsystem — the orchestration's eyes.
 
-Single-session log (`output.log`) is append-only. For long-running sessions:
-- **Context rotation**: Archives old log, starts fresh (see Module 6).
-- **Size-based rotation**: When `output.log` exceeds 10 MB, rename to `output.log.1` and start new file. Keep at most 3 rotated logs per session.
+Screen-heuristic classifier: PTY bytes → vterm grid → per-backend ordered
+regex first-match (`state/patterns.rs:244`) → an order-critical gate
+gauntlet (anchor/position/working-marker/recovery/phantom-probe/
+UsageLimit-release/heartbeat gates) → single transition funnel
+`record_set` (state/mod.rs:2038). Pattern priority is enforced by Vec
+position only — first-match-wins, no compile-time precedence invariant.
 
----
+A second, authoritative path exists for hook-capable backends (claude
+today): backend hooks POST events → `daemon/hook_shadow.rs`;
+`authoritative_state()` promotes a Fresh hook state over the heuristic,
+flag-gated, **snapshot-scoped only** (#1523 phase-1, the
+`per_tick/snapshot.rs:51` chokepoint). Five per-tick deciders still read
+raw heuristic state (see §6.2 — the planned phase-2 convergence).
 
-## Module 2: Fleet — Multi-Agent Manager
+Per-backend config is cleanly co-located in `BackendProfile`
+(patterns/behavioral/markers per backend); `backend.rs` owns spawn,
+model-args, resume and a 6-arm preset factory.
 
-### Config Format: `fleet.yaml`
+### 2.5 Worktree / git / fleet (~9K LOC)
 
-Compatible with existing agend format, with extensions:
-
-```yaml
-defaults:
-  backend: claude-code
-  model: opus
-  restart_policy:
-    max_retries: 10
-    backoff: exponential     # linear | exponential | fixed
-    base_delay_seconds: 5
-    max_delay_seconds: 300
-  context_rotation:
-    max_age_minutes: 180
-    cooldown_minutes: 10
-  health:
-    idle_timeout_minutes: 60
-    crash_respawn: true
-
-instances:
-  general:
-    role: "Fleet coordinator"
-    command: claude
-    args: ["--model", "opus"]
-    working_directory: ~/Documents/Hack/agend
-    env:
-      AGEND_INSTANCE_NAME: general
-    telegram:
-      topic_id: 12345
-    ready_pattern: "All tools are now trusted"
-
-  blog-writer:
-    role: "Blog content writer"
-    command: claude
-    args: ["--model", "sonnet"]
-    working_directory: ~/Documents/Hack/blog
-    env:
-      AGEND_INSTANCE_NAME: blog-writer
-    ready_pattern: "ready"
-
-teams:
-  dev:
-    members: [general, blog-writer]
-```
-
-### Fleet Manager
-
-```rust
-pub struct FleetManager {
-    config: FleetConfig,
-    sessions: HashMap<String, ManagedSession>,  // name → session
-    config_watcher: notify::Watcher,            // inotify/kqueue
-}
-
-pub struct ManagedSession {
-    session: Arc<PtySession>,
-    config: InstanceConfig,
-    health: HealthState,              // Owns all lifecycle state (see Module 5)
-}
-```
-
-### Operations
-
-- **`fleet start`**: Parse config → spawn all instances → wait for ready patterns.
-- **`fleet stop`**: Graceful shutdown all (quit command → grace → kill).
-- **`fleet restart <name>`**: Kill + respawn single instance, preserve session ID.
-- **fleet.yaml edits require a daemon restart** (Sprint 29 PR-6). The hot-reload diff engine was removed — KISS for a single-user dev tool where daemon restart costs ~5 seconds. Operators edit `fleet.yaml`, then stop and re-launch the daemon. All agents respawn with the new config on next start.
-
-### vs Node.js
-
-| Node.js | Rust |
-|---|---|
-| FleetManager creates tmux windows | FleetManager spawns PTY sessions directly |
-| Config reload requires manual restart | Same — fleet.yaml edits need daemon restart |
-| Sequential shutdown to avoid race | Parallel shutdown, no races |
-
----
-
-## Module 3: Communication — Agent Messaging
-
-### Design Principle
-
-Agents communicate via **CLI commands** (Bash tool), not MCP. This eliminates the MCP server process, the IPC bridge, and the timeout complexity.
-
-### Agent-side Interface
-
-Agents use `agend-terminal` as a Bash tool:
-
-```bash
-# Reply to the user who messaged this agent
-agend-terminal reply "Here's the result..."
-
-# Send a message to another agent
-agend-terminal send general "Task complete, PR ready"
-
-# Send with metadata
-agend-terminal send general --kind report --correlation-id abc123 "Done"
-
-# React to the last message
-agend-terminal react thumbsup
-
-# Read pending messages (non-blocking)
-agend-terminal inbox
-```
-
-### How It Works
+Per-agent git isolation. The dispatch→bind→worktree chain:
 
 ```
-Agent (claude-code)
-  │ Bash tool: `agend-terminal reply "hello"`
-  ▼
-agend-terminal CLI
-  │ connects to daemon TCP API
-  │ sends Request::Reply { text: "hello" }
-  ▼
-Daemon
-  │ looks up which session sent this (by auth cookie)
-  │ routes to appropriate channel adapter
-  ▼
-Telegram / Discord / other
+dispatch_auto_bind_lease_* (mcp/handlers/dispatch_hook/)
+  → BindGuard (per-agent in-flight gate)
+  → per-branch flock lease (binding.rs:92) — serializes same-branch races
+  → scan_existing_branch_binding — reject if another agent holds it
+  → ensure_branch_exists (4-tier repo resolve; #2010 remote resolution;
+    #869 stale-ref refresh)
+  → worktree_pool::lease → create + .agend-managed marker + bind_full
+  → auto-arm ci-watch (+ next_after_ci chain target)
 ```
 
-### Protocol Extensions
-
-```rust
-enum Request {
-    // ... existing ...
-
-    /// Agent sends a reply to the user
-    Reply { text: String },
-    /// Agent sends a message to another instance
-    Send {
-        target: String,
-        text: String,
-        kind: Option<MessageKind>,        // query | task | report | update
-        correlation_id: Option<String>,
-    },
-    /// Agent reads its inbox
-    Inbox,
-    /// Agent reacts to a message
-    React { emoji: String },
-}
-
-enum Response {
-    // ... existing ...
-    Sent { message_id: String },
-    Messages { messages: Vec<InboxMessage> },
-}
-```
-
-### Agent Instructions
-
-Each agent's system prompt includes:
-
-```
-## Communication
-Use Bash tool to communicate:
-- `agend-terminal reply "text"` — respond to the user
-- `agend-terminal send <target> "text"` — message another agent
-- `agend-terminal inbox` — check for new messages
-
-Do NOT use the reply tool or MCP tools for communication.
-```
-
-### vs Node.js (MCP)
-
-| Node.js MCP | Rust CLI |
-|---|---|
-| Separate MCP server process per instance | Same binary, TCP API call |
-| 30s/60s timeout handling | Instant TCP API response |
-| 20+ MCP tools to maintain | ~5 CLI subcommands |
-| MCP protocol overhead (JSON-RPC) | Length-prefixed JSON, minimal overhead |
-| Tool registration, schema sync | No registration needed — it's a shell command |
-| Agents need MCP tool definitions | Agents use Bash tool (always available) |
-
-### Message Routing
-
-```
-                    ┌──────────────┐
-                    │  Daemon      │
-                    │  Message     │
-Telegram ──────────▶│  Router      │──────────▶ Agent PTY (inject)
-Discord  ──────────▶│              │
-Agent CLI ─────────▶│              │──────────▶ Telegram (send)
-                    └──────────────┘──────────▶ Other Agent (inject)
-```
-
-The router maintains a mapping: `instance_name → (session_id, channel_config)`.
-
-### Message Delivery Semantics
-
-**Known limitation:** When an agent is busy (executing a tool call), multiple injected messages accumulate in the PTY stdin buffer. The agent reads them as a single block of text after finishing its current turn, potentially treating multiple messages as one.
-
-MCP does not have this problem because each message is a discrete tool call with structured boundaries.
-
-**Mitigation — Notification + Pull model (recommended):**
-
-Instead of injecting the full message text, inject a short notification:
-
-```
-[New message from user:alice. Run: agend-terminal inbox]
-```
-
-The agent then calls `agend-terminal inbox` to retrieve all pending messages as structured data. This ensures:
-- Each message is individually addressable
-- Agent processes messages one at a time
-- No parsing ambiguity from concatenated messages
-
-The daemon maintains a per-session message queue (bounded, in-memory). `inbox` drains the queue and returns structured JSON.
-
-```rust
-struct MessageQueue {
-    messages: VecDeque<InboxMessage>,
-    max_size: usize,  // drop oldest when full
-}
-```
-
-**Fallback — Delimiter protocol:**
-
-If direct inject is needed (e.g., for simpler agents), wrap each message:
-
-```
----AGEND_MSG---
-[user:alice] Do task A
----AGEND_MSG---
-```
-
-Agent system prompt teaches it to split on `---AGEND_MSG---`.
-
----
-
-## Module 4: Channel — Communication Platform Adapters
-
-### Architecture
-
-```rust
-#[async_trait]
-pub trait ChannelAdapter: Send + Sync {
-    /// Start receiving messages. Calls `on_message` for each.
-    async fn start(&self, tx: mpsc::Sender<IncomingMessage>) -> Result<()>;
-    /// Send a message to a channel/topic.
-    async fn send(&self, target: ChannelTarget, text: String) -> Result<String>;
-    /// React to a message.
-    async fn react(&self, message_id: &str, emoji: &str) -> Result<()>;
-    /// Edit a previously sent message.
-    async fn edit(&self, message_id: &str, new_text: String) -> Result<()>;
-}
-```
-
-### Telegram Adapter
-
-```rust
-pub struct TelegramAdapter {
-    bot: teloxide::Bot,
-    chat_id: ChatId,
-    topic_map: HashMap<String, i32>,  // instance_name → topic_id
-}
-```
-
-**Inbound flow:**
-```
-Telegram → teloxide webhook/polling → IncomingMessage
-  → daemon routes by topic_id → find instance
-  → format: "[user:username] message text"
-  → inject into agent's PTY
-```
-
-**Outbound flow:**
-```
-Agent calls `agend-terminal reply "text"`
-  → daemon receives Reply request
-  → looks up instance's Telegram topic_id
-  → TelegramAdapter.send(topic_id, text)
-```
-
-### Message Format
-
-Inbound messages injected into PTY as the agent's stdin. The format must be parseable by the agent:
-
-```
-[user:chiachenghuang] 請幫我 review 這個 PR
-```
-
-For inter-agent messages:
-
-```
-[from:general] 請處理這個 task
-```
-
-### Discord Adapter (Future)
-
-Same `ChannelAdapter` trait, different implementation. Discord threads map to instances like Telegram topics.
-
-### vs Node.js
-
-| Node.js | Rust |
-|---|---|
-| Telegram bot in JS (telegraf/grammy) | teloxide (Rust-native, async) |
-| MCP tools bridge messages | Direct PTY inject, no bridge |
-| Message queue in memory | mpsc channel, backpressure built-in |
-
----
-
-## Module 5: Health — Process Lifecycle
-
-### Ownership: Health Monitor replaces Reaper
-
-In Phase 1 (current), `spawn_session_reaper` handles session exit — it simply removes the session from the HashMap. **In Phase 4, Health Monitor takes over as the sole session exit handler.** The reaper is removed.
-
-Decision flow on session exit:
-```
-session exits → Health Monitor receives drainer_done
-  → Check restart policy (from Fleet config)
-  → If should_restart:
-      → Increment crash_count, calculate backoff
-      → Wait backoff delay
-      → Spawn new session (same config), update HashMap
-  → If not (max_retries exceeded, or manual kill):
-      → Remove from HashMap, log reaped
-```
-
-### Data Model
-
-```rust
-/// Owned by Health Monitor — single source of truth for lifecycle state.
-pub struct HealthState {
-    last_output: Instant,
-    crash_count: u32,
-    last_crash: Option<Instant>,
-    policy: RestartPolicy,          // Set by Fleet Manager
-    stable_since: Option<Instant>,  // For crash count reset
-}
-```
-
-Fleet Manager sets the `RestartPolicy` (max_retries, backoff params). Health Monitor owns the execution state (crash_count, last_crash). No duplication.
-
-### Crash Detection
-
-**Event-driven** — no polling:
-
-```
-Drainer EOF → drainer_done.notify()
-  → HealthMonitor receives notification
-  → Check exit code
-  → If unexpected exit (non-zero, or session should be long-running):
-      → Increment crash_count
-      → Calculate backoff delay
-      → Schedule respawn
-```
-
-### Restart Policy
-
-```rust
-pub struct RestartPolicy {
-    max_retries: u32,              // 0 = infinite
-    backoff: BackoffStrategy,      // exponential, linear, fixed
-    base_delay: Duration,
-    max_delay: Duration,
-    reset_after: Duration,         // Reset crash count after stable period
-}
-```
-
-Backoff calculation:
-- **exponential**: `min(base * 2^n, max_delay)`
-- **linear**: `min(base * n, max_delay)`
-- **fixed**: `base`
-
-After `reset_after` of stable running, crash count resets to 0.
-
-### Idle Detection
-
-The drainer already timestamps every output chunk. HealthMonitor subscribes to the broadcast channel and updates `last_output`. If no output for `idle_timeout`, the session is marked idle.
-
-Idle sessions can trigger:
-- Notification to fleet manager
-- Optional auto-restart (for context rotation)
-- Alert to Telegram
-
-### vs Node.js
-
-| Node.js | Rust |
-|---|---|
-| Poll-based crash detection (check tmux window) | Event-driven via drainer_done Notify |
-| Restart delay in JS setTimeout | tokio::time::sleep, precise |
-| Idle check by polling tmux output | Broadcast subscriber, zero-cost when active |
-
----
-
-## Module 6: Context — Context Rotation
-
-### The Problem
-
-LLM agents (Claude Code, etc.) have finite context windows. When context fills up, the agent becomes less effective. AgEnD needs to detect this and restart the session.
-
-### Detection Strategy
-
-Parse PTY output for context usage indicators. Claude Code outputs context usage in its status line:
-
-```
-Context: 85% used (170K/200K tokens)
-```
-
-```rust
-pub struct ContextMonitor {
-    session_id: u32,
-    max_age: Duration,              // Hard limit: restart after N minutes
-    usage_threshold: f32,           // 0.0-1.0, trigger at this usage level
-    cooldown: Duration,             // Min time between rotations
-    last_rotation: Option<Instant>,
-    usage_pattern: Regex,           // Configurable per-backend in fleet.yaml
-}
-```
-
-The `usage_pattern` regex is configurable per instance in `fleet.yaml` via `context_pattern`, since different backends (Claude Code, Codex, Gemini CLI) output context usage in different formats:
-
-```yaml
-instances:
-  general:
-    context_rotation:
-      context_pattern: "Context:\\s+(\\d+)%"   # Claude Code format
-  codex-agent:
-    context_rotation:
-      context_pattern: "tokens:\\s+(\\d+)/(\\d+)"  # Codex format
-```
-
-### Rotation Flow
-
-```
-ContextMonitor subscribes to output broadcast
-  → Regex matches context usage line
-  → If usage > threshold OR age > max_age:
-      → Check cooldown (prevent rapid re-rotation)
-      → Save session state (working directory, env vars)
-      → Kill session (graceful: inject /exit)
-      → Spawn new session with same config
-      → Log rotation event
-```
-
-### Session Continuity
-
-On rotation, the new session inherits:
-- Same working directory
-- Same environment variables
-- Same Telegram topic mapping
-- Previous session's output log (archived, new log started)
-
-The agent starts fresh but the fleet config ensures it gets the same role/instructions.
-
-### vs Node.js
-
-| Node.js | Rust |
-|---|---|
-| Grace period hacks (10 min cooldown) | Deterministic: cooldown + usage threshold |
-| Parse context from tmux capture-pane | Parse from broadcast stream (already have it) |
-| Restart via tmux kill-window + new-window | Kill session + spawn new PtySession |
-
----
-
-## Module 7: CLI — User Interface
-
-### Command Tree
-
-```
-agend-terminal
-├── daemon                           # Start the daemon
-│   └── --config fleet.yaml          # Load fleet config
-│
-├── fleet                            # Fleet management
-│   ├── start [name...]              # Start all or specific instances
-│   ├── stop [name...]               # Graceful stop
-│   ├── restart [name...]            # Restart instances
-│   └── status                       # Fleet overview
-│
-├── ls                               # List sessions (short form)
-├── attach <id|name>                 # Attach to session
-├── logs <id|name>                   # Tail output log
-│   └── --follow                     # Follow mode (like tail -f)
-│
-├── inject <id|name> <text>          # Send raw input
-├── kill <id|name>                   # Kill session
-│   ├── --quit-cmd CMD               # Graceful quit command
-│   └── --grace N                    # Grace period seconds
-│
-├── spawn [flags] <cmd> [-- args]    # Manual spawn (outside fleet)
-│   ├── --env KEY=VALUE
-│   ├── --cols N --rows N
-│   └── --ready-pattern REGEX
-│
-├── reply <text>                     # Agent: reply to user (from PTY)
-├── send <target> <text>             # Agent: message another instance
-│   ├── --kind query|task|report
-│   └── --correlation-id ID
-├── inbox                            # Agent: read pending messages
-└── react <emoji>                    # Agent: react to message
-```
-
-### Argument Parsing
-
-Use `clap` crate for structured argument parsing (replace current manual parsing):
-
-```rust
-#[derive(Parser)]
-#[command(name = "agend-terminal")]
-enum Cli {
-    Daemon { #[arg(long)] config: Option<PathBuf> },
-    Fleet { #[command(subcommand)] cmd: FleetCmd },
-    Ls,
-    Attach { target: String },
-    Logs { target: String, #[arg(long)] follow: bool },
-    Inject { target: String, text: Vec<String> },
-    Kill { target: String, #[arg(long)] quit_cmd: Option<String> },
-    Spawn { /* flags */ },
-    Reply { text: Vec<String> },
-    Send { target: String, text: Vec<String> },
-    Inbox,
-    React { emoji: String },
-}
-```
-
----
-
-## Module 8: Self-Healing — Supervised Hot Upgrade
-
-Zero-downtime daemon upgrades with automatic rollback on failure. Unix-only
-(the socket-swap + symlink-rename trick doesn't map cleanly to Windows;
-`agend-terminal upgrade` returns an error there).
-
-### Layering
-
-```text
-agend-supervisor             ← frozen, tiny, upgraded rarely
-  └── agend-terminal daemon  ← hot-swappable binary (PTY master owner)
-        └── agent PTYs       ← spawned fresh by the new daemon after upgrade
-```
-
-The supervisor's job is narrow on purpose: own the daemon child, orchestrate
-binary swaps, and roll back on failure. It does not own PTYs, Telegram state,
-or the MCP server — if it did, every supervisor change would force agents to
-restart. Keeping its surface small is the whole point: it can stay frozen for
-months while the daemon iterates daily.
-
-### Filesystem Layout
-
-```text
-$AGEND_HOME/
-  bin/
-    current          → symlink to the active daemon binary
-    prev             → symlink to the previous binary (rollback target)
-    store/
-      <sha256>       ← content-addressed binaries staged by `upgrade`
-    supervisor       ← symlink to the installed supervisor binary
-  run/
-    <pid>/           ← per-daemon run dir (unchanged from Module 1)
-    supervisor.sock  ← supervisor IPC socket (0600)
-    supervisor.pid   ← supervisor's PID
-    upgrade-marker   ← JSON blob written pre-upgrade, consumed by new daemon
-```
-
-Content-addressed store means swapping a binary is just a `rename(2)` over a
-symlink — atomic, no half-written state. Rolling back is the same operation
-in reverse.
-
-### Protocol: `supervisor.sock`
-
-NDJSON over localhost TCP. One request, streaming progress frames, terminal response.
-
-| Request                    | Sent by                      | Purpose                                    |
-|----------------------------|------------------------------|--------------------------------------------|
-| `Ping`                     | CLI pre-upgrade probe        | Detect a live supervisor + fetch its PID  |
-| `Status`                   | CLI                          | Query current daemon version               |
-| `Upgrade { new_hash, … }`  | CLI                          | Run the upgrade workflow                   |
-| `Ready { pid, version }`   | Daemon post-boot             | "I'm up" ping consumed by `wait_for_ready` |
-| `ShuttingDown { reason }`  | Daemon pre-exit (optional)   | Distinguishes clean stop from crash        |
-
-Wire version is pinned at `1`; CLI refuses servers with a newer version and
-tells the user to upgrade the client. The protocol is deliberately not
-backwards-compatible in the degrade-gracefully sense — the supervisor is the
-oldest moving piece and will outlive its peers.
-
-### Upgrade Flow
-
-```text
-CLI                             Supervisor                      Daemon (old)   Daemon (new)
- │                                  │                                │              │
- │ 1. stage new binary in store/   │                                │              │
- │ 2. stage current  → prev/       │                                │              │
- │ 3. swap bin/current symlink     │                                │              │
- │ 4. Upgrade{ new_hash, … } ───► │                                │              │
- │                                  │ 5. self-test (AGEND_SELF_TEST) │              │
- │                                  │    spawn new binary, wait exit │              │
- │                                  │ 6. write upgrade-marker        │              │
- │                                  │ 7. SIGTERM old ──────────────► │ exit         │
- │                                  │ 8. spawn new ────────────────────────────────►│
- │                                  │ 9. wait for Ready ping ◄──────────────────────│
- │                                  │ 10. stability window (60s)     │              │
- │                                  │     — watch for crashes —      │              │
- │ 11. ◄────── Ok { final: true }  │                                │              │
-```
-
-If any step after 5 fails — self-test exits non-zero, ready ping doesn't
-arrive within the timeout, or the new daemon crashes ≥ 2 times inside the
-stability window — the supervisor rolls back:
-
-```text
-Supervisor: stop new daemon → swap bin/current → store/<prev_hash>
-            → delete upgrade-marker → respawn old daemon → report rollback
-```
-
-The CLI surfaces this as a hard failure (`Err`) even though the system is back
-in a good state. "Rollback succeeded" is still a failed upgrade from the
-user's perspective.
-
-### Why Agents Restart
-
-The daemon owns every agent's PTY master fd. When it exits, those fds close
-and the child processes see EOF / SIGHUP. CRIU-style fd handoff was considered
-and rejected: platform-fragile, complicates the supervisor's freeze surface,
-and the existing crash-respawn code path already handles "daemon went away,
-agents came back" correctly. The MVP trades a few seconds of agent
-interruption for a much simpler supervisor.
-
-After the new daemon boots, it reads `run/upgrade-marker` and — if present —
-injects `[system] Daemon upgraded from vX to vY. All agents restarted.` into
-every agent's PTY instead of the normal crash-respawn notice. The marker is
-then deleted so a subsequent unrelated crash respawn gets its real reason.
-
-### Rollback Triggers
-
-- **Self-test failure**: new binary exits non-zero under `AGEND_SELF_TEST=1`
-  before we kill the old daemon. Cheapest failure mode — zero disruption.
-- **Ready-ping timeout**: new daemon exec'd but never pinged within
-  `--ready-timeout-secs` (default 60). Catches hangs, missing deps, busted
-  config.
-- **Stability-window crash**: new daemon pings Ready but then crashes ≥ 2
-  times within `--stability-secs` (default 60). Catches "boots fine, dies
-  under first real request" regressions.
-
-### Bootstrap Migration
-
-Fresh installs with no supervisor: the first `agend-terminal upgrade
---install-supervisor --yes` lays down `bin/current`, `bin/supervisor`, and
-`bin/store/`, then tells the user to start `agend-supervisor`. It does **not**
-auto-start the supervisor — how to daemonize (nohup, systemd, launchd) is a
-policy decision the installer's shell owns.
-
-### Testable Surface
-
-- `supervisor::client` — pure (sha256, symlink swap, TCP send/recv).
-- `supervisor::ipc` — serde roundtrip tests on every Request/Response variant.
-- `supervisor::self_test` — passes with valid `fleet.yaml`, fails on corrupt.
-- `supervisor::server` — end-to-end integration tests in
-  `tests/self_healing_supervisor.rs` drive the real `agend-supervisor` binary
-  against a temp `$AGEND_HOME`, using `src/bin/agend-mock-daemon.rs` as the
-  daemon child. Two cases covered:
-  - **Success path**: v1 booted → stage v2 → `Upgrade` → terminal `Ok` →
-    `current` repointed at v2 → v2 sentinel observed.
-  - **Rollback path**: crash counter armed at 2 so the new daemon crashes
-    post-ready twice inside the stability window → supervisor repoints
-    `current` back at v1, deletes the upgrade marker, and responds `Err`.
-    This path also exercises the watcher's `waitpid(WNOHANG)` zombie reap —
-    pure `kill(pid, 0)` liveness probing would leave crashed children as
-    zombies and silently report the upgrade as stable.
-
-  The v2 binary is fabricated by appending padding bytes to the v1
-  mock-daemon so the sha256 differs while behaviour stays identical
-  (ELF/Mach-O loaders ignore trailing bytes). The mock daemon is
-  Unix-only and never shipped — it lives under `src/bin/` purely so
-  `cargo test` builds it into `target/debug/` alongside the supervisor.
-
----
-
-## Cross-Cutting: Daemon API (IPC)
-
-The daemon exposes a localhost-only TCP API using NDJSON (newline-delimited JSON) protocol.
-
-### Transport
-
-- **Localhost TCP** on a random port (published to `<home>/run/<pid>/api.port`)
-- **No TLS** — localhost-only assumption; same-user access enforced by filesystem permissions
-- **Connection cap**: 32 concurrent sessions (fixed const; #env-cleanup: the `AGEND_API_MAX_CONNS` override was demoted)
-
-### Authentication
-
-1. Daemon issues a 32-byte random cookie at startup (`<home>/run/<pid>/api.cookie`, mode 0600)
-2. Client reads the cookie file and sends `{"auth":"<hex>"}` as the first NDJSON line
-3. Daemon verifies via constant-time comparison
-4. **Pre-auth timeout**: 5s — prevents slow-loris holding connection slots
-
-### Protocol
-
-After auth handshake, each line is a JSON request; daemon responds with one JSON line per request:
-
-```
-→ {"method": "list"}
-← {"ok": true, "result": {"agents": [...]}}
-
-→ {"method": "inject", "params": {"name": "dev-1", "data": "hello"}}
-← {"ok": true, "result": {"bytes": 5}}
-```
-
-### Agent Identity
-
-On spawn, the daemon sets `AGEND_INSTANCE_NAME=<name>` in the child's environment. MCP tool calls from the agent include this identity automatically. The daemon uses it to route replies and track per-agent state.
-
----
-
-## Cross-Cutting: CI Watch & Dispatch Chains
-
-### CI watch file identity (#942 / #943)
-
-Each `ci action=watch` subscription persists a JSON file at
-`<home>/ci-watches/<filename>.json`. The filename has been hardened
-twice in quick succession:
-
-- **#942 — `canonicalize_repo_slug`.** Operators (and the bridge)
-  refer to the same repo in seven divergent forms:
-  `git@github.com:owner/repo.git`, `https://github.com/owner/repo`,
-  `https://github.com/owner/repo.git`, `git+ssh://...`, raw
-  `owner/repo`, with `.git` suffix, with case variation. Pre-#942
-  each form computed its own watch filename → duplicate subscriptions
-  with divergent state → notifications fanned out N times. Post-#942
-  the slug is canonicalized to `owner/repo` (lowercase, no `.git`,
-  no scheme) before hashing.
-- **#943 — sha256 hash.** The pre-#943 filename used Rust's
-  `DefaultHasher` (SipHash-2-4 truncated to 64 bits → 16 hex chars).
-  Collision-grade is `~2^32` brute force — too thin for an identity
-  key the operator relies on. Replaced with sha256 (256-bit, 64 hex
-  chars). ~900 ns per call vs ~100 ns; at typical
-  ~100 subscriptions/agent/day the ~90 µs/day delta is negligible.
-
-The two changes ship together as a unit; the canonicalization
-narrows divergence at the *input* level while sha256 widens the
-hash *output* to remove the collision-grade concern at the same
-time.
-
-**Legacy migration (#942/#943 PR-B).** `bootstrap::prepare` runs
-`migrate_legacy_watch_filenames` synchronously at boot. The migration
-scans `<home>/ci-watches/*.json`, identifies non-canonical filenames
-(stem length ≠ 64), reads each body to recover `repo` + `branch`,
-canonicalizes the `repo` field, computes the new sha256 filename, and
-renames the file. Conflicts (two old files mapping to the same target)
-are logged with the FIRST one winning; the operator can hand-resolve.
-Idempotent — re-running on already-migrated state is a no-op. The
-synchronous-at-boot ordering means the poll loop never sees the old
-files, so operators don't observe duplicate 72 h notifications across
-the transition.
-
-### CI watch survives bind/release handoff (#931)
-
-The daemon's `release_worktree` path used to unsubscribe the releasing
-agent from every `ci-watch` they held. If that agent was the **sole**
-subscriber, the watch file's `next_after_ci` chain and polling state
-were destroyed, and the chained handoff (`ci pass → next_after_ci →
-[ci-ready-for-action] to reviewer`) never fired.
-
-Post-#931 the file is kept intact on the sole-subscriber release path:
-`next_after_ci`, `last_notified_head_sha`, and the polling state all
-survive. The next agent that binds the same branch (via
-`dispatch_auto_bind_lease`) inherits the chain and the handoff fires
-on the next CI green tick.
-
-The reviewer-dispatch chain `dev → ci → reviewer` is the canonical
-example; the same fix unblocks any multi-agent workflow where one
-agent's release precedes another's bind.
-
-### Correlation IDs on `system:ci` and dispatch_idle (#946 / #947)
-
-Two correlation_id sources flow into inbox routing:
-
-- **#946 — `system:ci` notifications.** Every `system:ci` enqueue
-  (pass, fail, stalled, conflict, etc.) now carries
-  `correlation_id = "{repo}@{branch}"` — a stable identifier per
-  watched branch. Pre-#946 these were `None`, leaving operators no
-  way to filter inbox dumps to a single branch. Greppable example:
-  `grep '"correlation_id":"owner/repo@feat/x"' $AGEND_HOME/inbox/*.jsonl`.
-- **#947 — dispatch_idle watchdog fallback.** When the watchdog fires
-  on a `kind=task`/`kind=query` send whose upstream had no
-  `correlation_id`, the synthesized fallback uses the canonical
-  dispatch id format `disp-<unix_micros>-<seq>`. Pre-#947 the
-  fallback was either `None` or a churning per-call ULID with no
-  cross-message tie. The new format is self-documenting via prefix
-  and stable across the dispatch + the eventual report.
-
-### Test infrastructure — deterministic primitives
-
-Two helpers extracted from in-test repetition (SOP 1 §3.20):
-
-- **`admin::cleanup_zombies::poll_until_dead(pid, timeout)`** (#934).
-  `pub(crate)` deterministic alternative to `thread::sleep(N)`
-  patterns. Polls `kill -0` (Unix) / `OpenProcess` (Windows) every
-  10 ms up to `timeout`. Returns `bool` (dead-on-time). Already
-  consumed by `agent.rs` shutdown path + `process.rs` reaper.
-- **`api::handlers::instance::await_sentinel_nonempty`** (#949). Polls
-  a sentinel file path until it has non-empty content or the timeout
-  elapses. Contract clarified by the rename: pre-#949 the helper was
-  named for the *file* existing, but `instance` codepaths needed the
-  *content* to be present (the file is created empty then written to).
-  Tests now use the helper at the four `instance.rs` boot-sentinel
-  sites; CI-side flake is gone.
-
-Both helpers are `pub(crate)` — call sites stay in-crate, and the
-helpers exist primarily to make tests deterministic without falling
-back to sleep tuning.
-
----
-
-## Cross-Cutting: Daemon Notification & State Helpers
-
-### `notify_system` helper (#1335)
-
-Daemon modules that emit inbox notifications (watchdogs, timeouts, idle
-detectors) previously duplicated ~8 lines of `InboxMessage::new_system` +
-builder chain + `enqueue_with_idle_hint`. The `notify_system()` helper
-collapses this to a single call:
-
-```rust
-crate::inbox::notify_system(
-    home,
-    target,          // recipient agent name
-    "system:source", // source identifier
-    "event-kind",    // inbox message kind
-    body,            // message body (impl Into<String>)
-    correlation_id,  // Option<&str>
-    task_id,         // Option<&str>
-);
-```
-
-All `notify_system` messages use `delivery_mode("inbox_fallback")`. Modules
-that need different delivery modes (e.g. `cron_tick`, `daemon/mod.rs`
-schedule/query) should continue using `InboxMessage` directly.
-
-### Event bus (#1336)
-
-Feature-flagged global event bus for decoupled daemon-internal signaling.
-
-**Enable**: `AGEND_EVENT_BUS=1` environment variable.
-
-**Usage**:
-
-```rust
-// Zero-cost when disabled — closure never called.
-event_bus::emit_lazy("pr_state.merged", || {
-    json!({ "repo": repo, "branch": branch })
-});
-
-// Guard for callers that build expensive payloads.
-if event_bus::is_enabled() {
-    let payload = expensive_computation();
-    event_bus::emit("custom.event", payload);
-}
-```
-
-When disabled (default), `emit_lazy` returns immediately without allocating
-or evaluating the closure. `is_enabled()` is a single `AtomicBool` load.
-
-### `with_pr_state` flock helper (#1342)
-
-All mutations to `pr-state/*.json` files must go through `with_pr_state()`
-or `with_pr_state_or_create()`. These helpers:
-
-1. Acquire an `fs4` file lock on `<filename>.lock`
-2. Read + deserialize the current `PrState`
-3. Run the caller's mutation closure
-4. Serialize + `atomic_write` the result
-
-```rust
-// Mutate existing state (returns None if file doesn't exist).
-let result = with_pr_state(home, repo, branch, |state| {
-    state.ready_emitted_for_sha = Some(state.head_sha.clone());
-    ScanAction::Saved
-});
-
-// Create if absent (uses default_fn for initial state).
-with_pr_state_or_create(home, repo, branch, default_fn, |state| {
-    state.ci_results.push(result);
-});
-```
-
-This eliminates the lost-update race where concurrent writers (scanner tick
-+ gh-poll) could overwrite each other's changes. The lock file is separate
-from the data file to avoid holding a lock on a file being atomically
-replaced.
-
-### Auto-release worktree on pr-merged (#1344)
-
-When the scanner detects `MergeState::Merged`, it calls
-`auto_release_for_merged_branch(home, &state.branch)` **before** emitting
-the `[pr-merged]` inbox notification. This function:
-
-1. Scans `runtime/<agent>/binding.json` for agents bound to the branch
-2. Acquires the binding lock
-3. Checks `is_worktree_clean` (dirty worktrees are skipped with a warning)
-4. Calls `release_full` to remove the worktree + clear the binding
-
-This ensures `gh pr merge --delete-branch` succeeds because no local
-worktree holds the branch ref.
-
----
-
-## Data Flow Summary
-
-### User sends message via Telegram
-
-```
-Telegram → TelegramAdapter.on_message()
-  → Router: lookup topic_id → instance "general"
-  → Format: "[user:chiachenghuang] message text"
-  → session.write_input(formatted_message)
-  → Agent reads from stdin, processes, calls Bash tool
-  → `agend-terminal reply "response"`
-  → CLI connects to daemon TCP API, sends Reply request
-  → Router: session 1 → Telegram topic 12345
-  → TelegramAdapter.send(topic_id, "response")
-  → User sees response in Telegram
-```
-
-### Agent-to-agent communication
-
-```
-Agent A (blog-writer) runs: `agend-terminal send general "PR ready"`
-  → CLI authenticates via auth cookie
-  → Connects to daemon TCP API
-  → Request::Send { target: "general", text: "PR ready" }
-  → Router: find session for "general" → session 1
-  → Format: "[from:blog-writer] PR ready"
-  → session_1.write_input(formatted_message)
-  → Agent "general" reads from stdin, processes
-```
-
----
-
-## Implementation Phases
-
-### Phase 1: Core Hardening (Current)
-- [x] PTY spawn/attach/detach/inject/kill
-- [x] Output capture + ready detection
-- [x] Graceful daemon shutdown
-- [x] `clap` CLI parsing (`Commands` enum in `src/main.rs`)
-- [ ] Auth cookie (`<home>/run/<pid>/api.cookie`)
-
-### Phase 2: Fleet + Communication
-- [ ] `fleet.yaml` parser
-- [ ] FleetManager: start/stop/restart
-- [ ] `reply` / `send` / `inbox` CLI commands
-- [ ] Message router
-- [ ] Config hot-reload (`notify` crate)
-
-### Phase 3: Channel Integration
-- [ ] Telegram adapter (teloxide)
-- [ ] Inbound: Telegram → PTY inject
-- [ ] Outbound: Agent reply → Telegram send
-- [ ] Topic-to-instance mapping
-
-### Phase 4: Health + Context
-- [ ] Health Monitor replaces `spawn_session_reaper`
-- [ ] Event-driven crash detection
-- [ ] Restart policy (exponential backoff)
-- [ ] Context usage parsing
-- [ ] Auto-rotation with cooldown
-- [ ] Idle detection
-
-### Phase 5: Production
-- [ ] Discord adapter
-- [ ] SQLite persistence (schedules, cost tracking)
-- [ ] Web dashboard (optional)
-- [ ] Multi-host fleet (SSH-based remote spawn)
-
----
-
-## Dependency Plan
-
-```toml
-[dependencies]
-# Core (already)
-portable-pty = "0.8"
-tokio = { version = "1", features = ["full"] }
-nix = "0.29"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-anyhow = "1"
-tracing = "0.1"
-tracing-subscriber = "0.3"
-regex = "1"
-
-# Phase 1
-clap = { version = "4", features = ["derive"] }
-
-# Phase 2
-serde_yaml = "0.9"          # fleet.yaml parsing
-notify = "7"                 # Config file watching
-
-# Phase 3
-teloxide = "0.13"            # Telegram bot
-reqwest = "0.12"             # HTTP client (for webhooks)
-
-# Phase 4
-rusqlite = "0.32"            # SQLite (schedules, logs)
-```
-
----
-
-## Source Layout (reference)
-
-The module design above is aspirational and largely file-agnostic; the table below is the current file-level mapping as of Sprint 61 (2026-05). See `CONTRIBUTING.md` for the contribution-time style rules.
-
-| Responsibility | File(s) |
-|---|---|
-| PTY session management, spawn, inject, ready detection | `src/agent.rs` |
-| Backend presets (Claude, Kiro, Codex, Gemini, OpenCode, Shell) | `src/backend.rs` |
-| Shared helpers (messaging, fleet mutation, branch validation) | `src/agent_ops.rs` |
-| Daemon JSON control API (wire protocol + handlers) over TCP loopback | `src/api/mod.rs`, `src/api/handlers/*.rs` |
-| MCP surface for agents (32 tools) | `src/mcp/handlers/`, `src/mcp/tools.rs` |
-| Dispatch hook (auto-bind, lease, worktree creation) | `src/mcp/handlers/dispatch_hook/` |
-| Fleet config (fleet.yaml parse, instances, teams) | `src/fleet.rs` |
-| Team management | `src/teams.rs` |
-| Task board | `src/tasks.rs` |
-| Decisions store | `src/decisions.rs` |
-| Schedules (cron + one-shot) | `src/schedules.rs` |
-| Deployments (template-based multi-agent spawn) | `src/deployments.rs` |
-| Worktree lifecycle (lease, release, GC) | `src/worktree_pool.rs`, `src/worktree.rs` |
-| Worktree auto-cleanup (sweep merged/gone branches) | `src/worktree_cleanup.rs` |
-| Binding state (agent ↔ branch ↔ worktree) | `src/binding.rs` |
-| Inbox (message queue, delivery, supersede) | `src/inbox.rs` |
-| Channel adapters (Telegram, Discord) | `src/channel/` |
-| Daemon tick loop (CI watch, health, supervisor) | `src/daemon/` |
-| CI watch (poll GitHub Actions, emit pass/fail) | `src/daemon/ci_watch.rs` |
-| Claim verifier (push-time semantic gate) | `src/claim_verifier.rs` |
-| TUI (multi-tab/pane terminal UI) | `src/tui.rs`, `src/render/`, `src/layout/` |
-| App mode (in-process TUI + daemon) | `src/app/` |
-| CLI argument parsing | `src/main.rs` (Commands enum) |
-| Instructions/steering injection | `src/instructions.rs` |
-| Admin (branch cleanup analysis) | `src/admin.rs` |
-| Event log (audit trail) | `src/event_log.rs` |
-| Health state | `src/health.rs` |
-| Service (systemd/launchd integration) | `src/service/` |
-| System tray | `src/tray/` |
-| Bootstrap (agent resolve, doctor, fleet normalize) | `src/bootstrap/` |
-| Git shim (worktree-deny matrix) | `src/bin/agend-git.rs` |
-| MCP bridge (per-agent MCP server) | `src/bin/agend-mcp-bridge.rs` |
-
-### Drift enforcement
-
-`tests/no_dual_track_drift.rs` extracts top-level fn bodies from `src/agent_ops.rs` and `src/mcp/handlers.rs` and asserts that any fn sharing a name has an identical body, preventing the kind of silent divergence between MCP and daemon paths that caused the `cleanup_working_dir` Kiro-cleanup gap (14-entry MCP copy vs 19-entry canonical) on main before Task #9 Option C. The detector is parser-hardened against raw-string literals and `extern "ABI" fn` (PR #31).
+`binding.json` has a single writer (`binding::bind_full`) and
+HMAC-verified readers (the git shim trusts nothing unsigned). All
+daemon-internal git goes through `git_helpers::git_bypass` (timeout +
+process-group kill so a timeout-kill can never take down the daemon's own
+process group) — but 209 call sites across the codebase still build raw
+`Command::new("git")` (see §6.3).
+
+The `agend-git` PATH shim is the authority boundary: `classify()`
+(bin/agend-git.rs:679) gates each subcommand as
+passthrough/chdir-pass/deny/exempt based on the agent's binding. Branch GC
+(`branch_sweep` + `worktree_cleanup`) shares one squash-merge detector and
+runs `git worktree prune` inside the delete transaction (#2011).
+
+### 2.6 Ops / entry (bins, service, deployments, schedules, skills)
+
+`main.rs` (1338 LOC) is the CLI switchboard: app/daemon/attach/admin/
+service/doctor/skills/quickstart/verify. Service lifecycle is delegated to
+the OS supervisor (launchd / systemd user / Task Scheduler) — the daemon
+does not supervise itself. `deployments.rs` (2697) owns the template
+deploy/teardown lifecycle with deliberately narrow store flocks (self-IPC
+always outside the lock). `schedules.rs` (1480) splits storage from the
+runtime executor (`daemon/cron_tick.rs`). Release pipeline: annotated tag →
+gate (version/changelog/MSRV/semver) → 5-target build + AppImage → GH
+Release → crates.io publish (see RELEASING.md).
+
+## 3. Concurrency model
+
+Full hierarchy and rationale: [DAEMON-LOCK-ORDERING.md](DAEMON-LOCK-ORDERING.md).
+The load-bearing disciplines, each runtime- or CI-enforced:
+
+| Discipline | Rule | Enforcement |
+|---|---|---|
+| Lock order | registry (L0) → per-agent core (L1) → side channels (L2) → heartbeat snapshot (L3); release in reverse | `sync_audit::assert_lock_tier` runtime asserts |
+| #1492 | No self-IPC while holding registry/core lock | `assert_no_registry_lock_for_self_ipc` (api/mod.rs:784) — fail-fast Err, not deadlock; 90s socket-read backstop |
+| #1530 | Collect reaction intents UNDER `core.lock()`, emit AFTER drop | the `let action = { … }` block boundary (supervisor.rs:1282-1293); CI source-pin `tick_emitters_run_after_core_lock_drops` (#1644) |
+| Inbox | flock + atomic rename per enqueue/drain/sweep; per-agent `.jsonl.lock` | by construction (inbox/storage.rs:99-139) |
+| Deferred notifications | per-agent OS file lock + unique process claim file | by construction (notification_queue.rs:401-424) |
+| Deployment store | flock only around load-modify-save; self-IPC API calls outside | by construction (deployments.rs:434-445) |
+| git subprocesses | process-group isolation (Unix `process_group(0)` / Windows `CREATE_NEW_PROCESS_GROUP`) so timeout-kill resolves the child pgid | git_helpers.rs |
+| UX sinks | mutex protects the sink vec only; clone Arcs, emit after release; emit is fire-and-forget | sink_registry.rs:67-74 |
+| Per-tick handlers | each `run()` wrapped in `catch_unwind` — one panic never skips siblings | per_tick/mod.rs:182-214 |
+
+One audited residual: a `handle.core.lock()` inside a registry-lock scope
+near supervisor.rs:1857 — flagged in #1530/F2; read it before any
+supervisor refactor.
+
+## 4. Load-bearing invariants (beyond locks)
+
+| Invariant | Where | What breaks if violated |
+|---|---|---|
+| State pattern order: errors before Thinking/Idle, first-match wins | `BackendProfile.patterns` Vec order | misclassification → false idle/hang reactions |
+| Gate-gauntlet order in `feed_with_fg` (position gate before working-marker override, etc.) | state/mod.rs:1208-1757 | FP suppression regimes stop composing |
+| Hook promotion only via `authoritative_state()` (couples freshness to `has_state_hooks()`) — never `resolved_state_for` directly | hook_shadow.rs:113-123 | stale-hook trust on non-hook backends |
+| Hook ToolUse is event-pair-closed, NOT clock-bounded (deliberate — protects long tools, the #1985 class) | hook_shadow.rs:79-98 | a clock backstop would re-break what #1523 exists to fix |
+| `request_id` generated once at the bridge, reused on retry | agend-mcp-bridge.rs:329-340 | duplicate side effects on transport retry |
+| Inbox drain response ≤ 48KB so it stays dedup-cacheable (< 64KB) | inbox/storage.rs:270 | lost-transport retry drops the remainder |
+| Fleet allowlist parsing is fail-closed: one malformed entry fails the list → downstream auth denies all | fleet load / `is_authorized_recipient` | silent partial authorization |
+| binding.json single-writer + HMAC sidecar | binding.rs | shim trusts forged bindings |
+| Task event log: append under lock with re-replay (`append_checked`), fail-closed on unknown future events | task_events.rs:1034,1538 | TOCTOU board corruption / silent event drops |
+| Boot grace (180s) suppresses notification watchdogs after restart | per_tick/mod.rs:118 | restart burst of false alerts (hand-wired per handler — see REFACTOR-PLAN W2) |
+| Per-tick handler order matches pre-extraction call order | daemon/mod.rs:577-579 | subtle reaction reordering |
+| `spawn` sites carry fire-and-forget rationale or store JoinHandle | protocol §10.4, Phase-5b invariant test | orphan tasks on shutdown |
+
+## 5. Cross-cutting patterns
+
+- **Per-agent latch maps**: `Mutex<HashMap<String, T>>` with bespoke prune
+  appears ~10× (supervisor notify/retry tracks, context_handoff/alert
+  states, inbox_stuck, handoff_timeout, …).
+- **Cadence counters**: `AtomicU64` + `is_multiple_of(N)` hand-rolled ~15×
+  across per-tick handlers.
+- **Schema-version guards**: three near-identical implementations
+  (`FLEET_SCHEMA_VERSION`, `BINDING_SCHEMA_VERSION`, the store-level
+  `SchemaVersioned` trait). Fleet is warn-not-refuse (a hand-edited public
+  interface, see COMPATIBILITY.md); stores are fail-closed.
+- **Instrumentation that became load-bearing**: the #1808 SRL phantom-probe
+  fields now drive the cross-cycle SRL→Idle fix (state/mod.rs:1547) —
+  telemetry and classification are no longer separable there.
+
+## 6. Known architectural tensions
+
+These are the deliberate or accreted dual-paths. Each is a REFACTOR-PLAN
+entry; none is free to "just clean up" without the listed care.
+
+1. **Two periodic-work mechanisms** (§2.1): 20 extracted `PerTickHandler`s
+   vs 13 inline supervisor `maybe_scan` trackers — one concept, two
+   mechanisms, two mental models. Finish-the-extraction is W1 work.
+2. **Heuristic vs hook state, dual readers** (§2.4): the snapshot path is
+   promoted (hook-aware), but hang/watchdog/recovery/supervisor escalation
+   still read raw heuristic — in a single tick, dispatch_idle can suppress
+   a nudge (snapshot=ToolUse) while hang_detection escalates
+   (raw=heuristic-Idle). Bounded today by the #1999 escalation throttle.
+   Convergence = #1523 phase-2 (W3; lock-ordering design required — a
+   naive shared cache inverts registry⨯core order).
+3. **Raw `Command::new("git")` vs `git_bypass`**: 209 raw sites; any site
+   that forgets `AGEND_GIT_BYPASS=1` silently hits the shim (a whole
+   flaky-test class). W1 makes this structurally impossible daemon-side.
+4. **Size-driven extraction at the MCP cap**: `instance.rs`/`comms.rs` at
+   the 750-LOC cap with "extracted for file_size_invariant" cross-file
+   seams; `handle_delegate_task` is a 317-LOC god-fn with gates inlined.
+   Concept-driven re-split is W2.
+5. **Channel trait vs legacy notify functions**: `Channel::notify`
+   delegates to older concrete `notify_telegram*` entrypoints; the trait
+   is not yet the only production path. Ownership decision before any
+   adapter work (W4 design call).
+6. **Two resize chokepoints after #2048**: intentional (layout pre-pass +
+   render last-mile authority) but undocumented as an invariant until now;
+   keep both, name the contract (W2).
+
+## 7. Testing & enforcement landscape
+
+CI: 3-platform Check + LOC-overrun gate + cargo audit (required);
+Coverage + daemon-boot flake-gate (non-required). Architecture-level
+invariants are pinned by dedicated tests: `file_size_invariant` (750-LOC
+handler cap), `tick_emitters_run_after_core_lock_drops` (#1644),
+heartbeat-pair atomicity audit, spawn-rationale invariant (Phase 5b).
+Worktree-side test runs need `AGEND_GIT_BYPASS=1` (the shim intercepts
+raw-git subprocesses in managed worktrees). Review discipline §3.9: tests
+enter through real entry points with representative fixtures — synthetic
+unit-inject fixtures have repeatedly hidden production wiring gaps.
+
+## 8. Provenance
+
+Synthesized from the six #2050 survey documents (daemon-core, mcp-comms,
+channels-tui, state-detection, worktree-git-fleet, ops-entry) authored by
+fixup-dev, fixup-dev-2 and fixup-reviewer against `main` @ `65d9ad82`,
+plus the 2026-06-10 production-readiness audit. Line numbers drift; the
+named anchors (function names, invariant test names, issue numbers) are
+the stable references. Update this map when a REFACTOR-PLAN wave lands,
+not on every PR.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ The heart: observe each agent's state machine, react, recover.
 
 | Module | LOC | Role |
 |---|---|---|
-| `daemon/supervisor.rs` | 5408 | Per-agent state OBSERVATION + reaction emission + error recovery (SRL/ApiError) + 13 inline slow-tracker scans |
+| `daemon/supervisor.rs` | 5408 | Per-agent state OBSERVATION + reaction emission + error recovery (SRL/ApiError) + 12 inline slow-tracker scans |
 | `daemon/mod.rs` | 2764 | Entry/init/shutdown; builds the per-tick handler set (`build_default_handlers` → 20 handlers) |
 | `daemon/per_tick/` | — | `PerTickHandler` trait + 20 handler impls, panic-guarded dispatch, boot-grace gate |
 | `daemon/crash_respawn.rs` | 568 | Crash→respawn decision: health budget, escalation persist, respawn worker |
@@ -43,7 +43,7 @@ The heart: observe each agent's state machine, react, recover.
 | `state/mod.rs` | 2176 | Per-agent `StateTracker` — screen-heuristic state machine (see 2.4) |
 
 Two periodic-work mechanisms coexist (see §6.1): the supervisor `run_loop`
-(every 10s) hosts 13 inline `*_tracker.maybe_scan/sweep` calls
+(every 10s) hosts 12 inline `*_tracker.maybe_scan/sweep` calls
 (supervisor.rs:266), while the daemon loop dispatches the 20 extracted
 `PerTickHandler`s with per-handler `catch_unwind` + timing
 (per_tick/mod.rs:182-214).
@@ -220,7 +220,7 @@ These are the deliberate or accreted dual-paths. Each is a REFACTOR-PLAN
 entry; none is free to "just clean up" without the listed care.
 
 1. **Two periodic-work mechanisms** (§2.1): 20 extracted `PerTickHandler`s
-   vs 13 inline supervisor `maybe_scan` trackers — one concept, two
+   vs 12 inline supervisor `maybe_scan` trackers — one concept, two
    mechanisms, two mental models. Finish-the-extraction is W1 work.
 2. **Heuristic vs hook state, dual readers** (§2.4): the snapshot path is
    promoted (hook-aware), but hang/watchdog/recovery/supervisor escalation

--- a/docs/archived/architecture-design-doc-2026-05.md
+++ b/docs/archived/architecture-design-doc-2026-05.md
@@ -1,0 +1,1164 @@
+# AgEnD Terminal — Architecture Design Doc
+
+> Rust rewrite of AgEnD: Agent Process Manager with direct PTY ownership.
+
+## Overview
+
+agend-terminal replaces the Node.js AgEnD + tmux stack with a single Rust binary that directly owns PTY master file descriptors. This eliminates the tmux dependency and the `send-keys` race condition at the architectural level.
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   agend-terminal daemon              │
+│                                                      │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐           │
+│  │ Session 1│  │ Session 2│  │ Session N│  Core      │
+│  │ PTY + FD │  │ PTY + FD │  │ PTY + FD │           │
+│  └────┬─────┘  └────┬─────┘  └────┬─────┘           │
+│       │              │              │                 │
+│  ┌────▼──────────────▼──────────────▼─────┐          │
+│  │         Output Bus (broadcast)          │          │
+│  │   drainer → log + ready + broadcast     │          │
+│  └────┬──────────────┬──────────────┬─────┘          │
+│       │              │              │                 │
+│  ┌────▼────┐   ┌─────▼────┐  ┌─────▼────┐           │
+│  │ Attach  │   │ Channel  │  │ Health   │           │
+│  │ Client  │   │ Adapter  │  │ Monitor  │           │
+│  └─────────┘   └──────────┘  └──────────┘           │
+│                                                      │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐           │
+│  │  Fleet   │  │  Comms   │  │ Context  │           │
+│  │ Manager  │  │  Router  │  │ Rotation │           │
+│  └──────────┘  └──────────┘  └──────────┘           │
+│                                                      │
+│  ┌────────────────────────────────────────┐          │
+│  │         TCP API (localhost NDJSON)    │          │
+│  └────────────────────────────────────────┘          │
+└─────────────────────────────────────────────────────┘
+```
+
+## Why Rust, Why Rewrite
+
+| Problem (Node.js + tmux) | Root Cause | Rust Solution |
+|---|---|---|
+| `send-keys` race condition | tmux CLI is fire-and-forget, no atomicity | Direct `write(master_fd)` — kernel guarantees atomicity for ≤PIPE_BUF |
+| Sequential restart bottleneck | tmux send-keys races force serialization | No tmux dependency, parallel spawn/kill |
+| No output ownership | tmux owns the PTY, agend uses `pipe-pane` | Daemon owns master fd, reads output directly |
+| MCP IPC complexity | Separate MCP server process + TCP API + timeout | Agent communicates via CLI (`agend-terminal reply`) — same binary |
+| Dual-path permission race | Terminal + Telegram both relay permissions | Single daemon routes all I/O, single source of truth |
+| Context rotation fragility | Grace period hacks, rapid re-rotation prevention | Direct PTY output parsing, deterministic rotation |
+| JS precision loss on snowflake IDs | JavaScript Number max safe integer | Rust u64 / i64, no precision issues |
+
+---
+
+## Module 1: Core — PTY Session Manager
+
+**Status: Implemented (PoC + MVP)**
+
+### Data Model
+
+```rust
+pub struct PtySession {
+    pub id: u32,
+    pub command: String,
+    master: Box<dyn MasterPty>,       // PTY master — we own this
+    writer: Box<dyn Write>,           // Atomic write path
+    child: Box<dyn Child>,            // Child process handle
+    exit_status: Option<i32>,         // Cached exit code
+    size: (u16, u16),                 // Terminal cols x rows
+    ready: AtomicBool,                // Ready pattern matched
+    output_tx: broadcast::Sender,     // Fan-out to subscribers
+    drainer_done: Notify,             // PTY EOF signal
+}
+```
+
+### Key Operations
+
+| Operation | Implementation |
+|---|---|
+| **spawn** | `portable-pty::openpty()` + `spawn_command()`. Env vars injected. Background drainer starts immediately. |
+| **attach** | Client subscribes to `output_tx` broadcast. SIGWINCH sent to trigger redraw. |
+| **detach** | Client unsubscribes. Session continues. Drainer keeps logging. |
+| **inject** | `write_all(master_fd)` — atomic for payloads ≤ 4096 bytes (PIPE_BUF on macOS). Mutex serializes larger writes. |
+| **kill** | Optional quit command → grace period → `child.kill()`. |
+| **resize** | `master.resize()` → SIGWINCH to child. |
+
+### Output Pipeline
+
+```
+PTY slave (child stdout) → master fd → drainer thread (spawn_blocking)
+                                          ├── output.log (append)
+                                          ├── ready pattern check (regex, 8KB window)
+                                          └── broadcast::Sender → N subscribers
+```
+
+The drainer runs independently of attach state. Output is always captured.
+
+### Concurrent Attach Behavior
+
+- **Multi-attach read**: Supported. Broadcast channel fans output to all subscribers.
+- **Multi-attach write**: Undefined — interleaved keystrokes from multiple clients. Production should add an "active writer" mode: one client writes, others are read-only viewers.
+
+### Graceful Daemon Shutdown
+
+**Status: Implemented.**
+
+1. SIGTERM/SIGINT registered via `tokio::signal`.
+2. Accept loop uses `tokio::select!` with signal channels.
+3. On signal: kill all sessions in parallel (`child.kill()`), poll up to 5 seconds for exit.
+4. Clean up socket file.
+5. Attached clients receive connection close (EOF on their TCP read).
+
+### Output Log Rotation
+
+Single-session log (`output.log`) is append-only. For long-running sessions:
+- **Context rotation**: Archives old log, starts fresh (see Module 6).
+- **Size-based rotation**: When `output.log` exceeds 10 MB, rename to `output.log.1` and start new file. Keep at most 3 rotated logs per session.
+
+---
+
+## Module 2: Fleet — Multi-Agent Manager
+
+### Config Format: `fleet.yaml`
+
+Compatible with existing agend format, with extensions:
+
+```yaml
+defaults:
+  backend: claude-code
+  model: opus
+  restart_policy:
+    max_retries: 10
+    backoff: exponential     # linear | exponential | fixed
+    base_delay_seconds: 5
+    max_delay_seconds: 300
+  context_rotation:
+    max_age_minutes: 180
+    cooldown_minutes: 10
+  health:
+    idle_timeout_minutes: 60
+    crash_respawn: true
+
+instances:
+  general:
+    role: "Fleet coordinator"
+    command: claude
+    args: ["--model", "opus"]
+    working_directory: ~/Documents/Hack/agend
+    env:
+      AGEND_INSTANCE_NAME: general
+    telegram:
+      topic_id: 12345
+    ready_pattern: "All tools are now trusted"
+
+  blog-writer:
+    role: "Blog content writer"
+    command: claude
+    args: ["--model", "sonnet"]
+    working_directory: ~/Documents/Hack/blog
+    env:
+      AGEND_INSTANCE_NAME: blog-writer
+    ready_pattern: "ready"
+
+teams:
+  dev:
+    members: [general, blog-writer]
+```
+
+### Fleet Manager
+
+```rust
+pub struct FleetManager {
+    config: FleetConfig,
+    sessions: HashMap<String, ManagedSession>,  // name → session
+    config_watcher: notify::Watcher,            // inotify/kqueue
+}
+
+pub struct ManagedSession {
+    session: Arc<PtySession>,
+    config: InstanceConfig,
+    health: HealthState,              // Owns all lifecycle state (see Module 5)
+}
+```
+
+### Operations
+
+- **`fleet start`**: Parse config → spawn all instances → wait for ready patterns.
+- **`fleet stop`**: Graceful shutdown all (quit command → grace → kill).
+- **`fleet restart <name>`**: Kill + respawn single instance, preserve session ID.
+- **fleet.yaml edits require a daemon restart** (Sprint 29 PR-6). The hot-reload diff engine was removed — KISS for a single-user dev tool where daemon restart costs ~5 seconds. Operators edit `fleet.yaml`, then stop and re-launch the daemon. All agents respawn with the new config on next start.
+
+### vs Node.js
+
+| Node.js | Rust |
+|---|---|
+| FleetManager creates tmux windows | FleetManager spawns PTY sessions directly |
+| Config reload requires manual restart | Same — fleet.yaml edits need daemon restart |
+| Sequential shutdown to avoid race | Parallel shutdown, no races |
+
+---
+
+## Module 3: Communication — Agent Messaging
+
+### Design Principle
+
+Agents communicate via **CLI commands** (Bash tool), not MCP. This eliminates the MCP server process, the IPC bridge, and the timeout complexity.
+
+### Agent-side Interface
+
+Agents use `agend-terminal` as a Bash tool:
+
+```bash
+# Reply to the user who messaged this agent
+agend-terminal reply "Here's the result..."
+
+# Send a message to another agent
+agend-terminal send general "Task complete, PR ready"
+
+# Send with metadata
+agend-terminal send general --kind report --correlation-id abc123 "Done"
+
+# React to the last message
+agend-terminal react thumbsup
+
+# Read pending messages (non-blocking)
+agend-terminal inbox
+```
+
+### How It Works
+
+```
+Agent (claude-code)
+  │ Bash tool: `agend-terminal reply "hello"`
+  ▼
+agend-terminal CLI
+  │ connects to daemon TCP API
+  │ sends Request::Reply { text: "hello" }
+  ▼
+Daemon
+  │ looks up which session sent this (by auth cookie)
+  │ routes to appropriate channel adapter
+  ▼
+Telegram / Discord / other
+```
+
+### Protocol Extensions
+
+```rust
+enum Request {
+    // ... existing ...
+
+    /// Agent sends a reply to the user
+    Reply { text: String },
+    /// Agent sends a message to another instance
+    Send {
+        target: String,
+        text: String,
+        kind: Option<MessageKind>,        // query | task | report | update
+        correlation_id: Option<String>,
+    },
+    /// Agent reads its inbox
+    Inbox,
+    /// Agent reacts to a message
+    React { emoji: String },
+}
+
+enum Response {
+    // ... existing ...
+    Sent { message_id: String },
+    Messages { messages: Vec<InboxMessage> },
+}
+```
+
+### Agent Instructions
+
+Each agent's system prompt includes:
+
+```
+## Communication
+Use Bash tool to communicate:
+- `agend-terminal reply "text"` — respond to the user
+- `agend-terminal send <target> "text"` — message another agent
+- `agend-terminal inbox` — check for new messages
+
+Do NOT use the reply tool or MCP tools for communication.
+```
+
+### vs Node.js (MCP)
+
+| Node.js MCP | Rust CLI |
+|---|---|
+| Separate MCP server process per instance | Same binary, TCP API call |
+| 30s/60s timeout handling | Instant TCP API response |
+| 20+ MCP tools to maintain | ~5 CLI subcommands |
+| MCP protocol overhead (JSON-RPC) | Length-prefixed JSON, minimal overhead |
+| Tool registration, schema sync | No registration needed — it's a shell command |
+| Agents need MCP tool definitions | Agents use Bash tool (always available) |
+
+### Message Routing
+
+```
+                    ┌──────────────┐
+                    │  Daemon      │
+                    │  Message     │
+Telegram ──────────▶│  Router      │──────────▶ Agent PTY (inject)
+Discord  ──────────▶│              │
+Agent CLI ─────────▶│              │──────────▶ Telegram (send)
+                    └──────────────┘──────────▶ Other Agent (inject)
+```
+
+The router maintains a mapping: `instance_name → (session_id, channel_config)`.
+
+### Message Delivery Semantics
+
+**Known limitation:** When an agent is busy (executing a tool call), multiple injected messages accumulate in the PTY stdin buffer. The agent reads them as a single block of text after finishing its current turn, potentially treating multiple messages as one.
+
+MCP does not have this problem because each message is a discrete tool call with structured boundaries.
+
+**Mitigation — Notification + Pull model (recommended):**
+
+Instead of injecting the full message text, inject a short notification:
+
+```
+[New message from user:alice. Run: agend-terminal inbox]
+```
+
+The agent then calls `agend-terminal inbox` to retrieve all pending messages as structured data. This ensures:
+- Each message is individually addressable
+- Agent processes messages one at a time
+- No parsing ambiguity from concatenated messages
+
+The daemon maintains a per-session message queue (bounded, in-memory). `inbox` drains the queue and returns structured JSON.
+
+```rust
+struct MessageQueue {
+    messages: VecDeque<InboxMessage>,
+    max_size: usize,  // drop oldest when full
+}
+```
+
+**Fallback — Delimiter protocol:**
+
+If direct inject is needed (e.g., for simpler agents), wrap each message:
+
+```
+---AGEND_MSG---
+[user:alice] Do task A
+---AGEND_MSG---
+```
+
+Agent system prompt teaches it to split on `---AGEND_MSG---`.
+
+---
+
+## Module 4: Channel — Communication Platform Adapters
+
+### Architecture
+
+```rust
+#[async_trait]
+pub trait ChannelAdapter: Send + Sync {
+    /// Start receiving messages. Calls `on_message` for each.
+    async fn start(&self, tx: mpsc::Sender<IncomingMessage>) -> Result<()>;
+    /// Send a message to a channel/topic.
+    async fn send(&self, target: ChannelTarget, text: String) -> Result<String>;
+    /// React to a message.
+    async fn react(&self, message_id: &str, emoji: &str) -> Result<()>;
+    /// Edit a previously sent message.
+    async fn edit(&self, message_id: &str, new_text: String) -> Result<()>;
+}
+```
+
+### Telegram Adapter
+
+```rust
+pub struct TelegramAdapter {
+    bot: teloxide::Bot,
+    chat_id: ChatId,
+    topic_map: HashMap<String, i32>,  // instance_name → topic_id
+}
+```
+
+**Inbound flow:**
+```
+Telegram → teloxide webhook/polling → IncomingMessage
+  → daemon routes by topic_id → find instance
+  → format: "[user:username] message text"
+  → inject into agent's PTY
+```
+
+**Outbound flow:**
+```
+Agent calls `agend-terminal reply "text"`
+  → daemon receives Reply request
+  → looks up instance's Telegram topic_id
+  → TelegramAdapter.send(topic_id, text)
+```
+
+### Message Format
+
+Inbound messages injected into PTY as the agent's stdin. The format must be parseable by the agent:
+
+```
+[user:chiachenghuang] 請幫我 review 這個 PR
+```
+
+For inter-agent messages:
+
+```
+[from:general] 請處理這個 task
+```
+
+### Discord Adapter (Future)
+
+Same `ChannelAdapter` trait, different implementation. Discord threads map to instances like Telegram topics.
+
+### vs Node.js
+
+| Node.js | Rust |
+|---|---|
+| Telegram bot in JS (telegraf/grammy) | teloxide (Rust-native, async) |
+| MCP tools bridge messages | Direct PTY inject, no bridge |
+| Message queue in memory | mpsc channel, backpressure built-in |
+
+---
+
+## Module 5: Health — Process Lifecycle
+
+### Ownership: Health Monitor replaces Reaper
+
+In Phase 1 (current), `spawn_session_reaper` handles session exit — it simply removes the session from the HashMap. **In Phase 4, Health Monitor takes over as the sole session exit handler.** The reaper is removed.
+
+Decision flow on session exit:
+```
+session exits → Health Monitor receives drainer_done
+  → Check restart policy (from Fleet config)
+  → If should_restart:
+      → Increment crash_count, calculate backoff
+      → Wait backoff delay
+      → Spawn new session (same config), update HashMap
+  → If not (max_retries exceeded, or manual kill):
+      → Remove from HashMap, log reaped
+```
+
+### Data Model
+
+```rust
+/// Owned by Health Monitor — single source of truth for lifecycle state.
+pub struct HealthState {
+    last_output: Instant,
+    crash_count: u32,
+    last_crash: Option<Instant>,
+    policy: RestartPolicy,          // Set by Fleet Manager
+    stable_since: Option<Instant>,  // For crash count reset
+}
+```
+
+Fleet Manager sets the `RestartPolicy` (max_retries, backoff params). Health Monitor owns the execution state (crash_count, last_crash). No duplication.
+
+### Crash Detection
+
+**Event-driven** — no polling:
+
+```
+Drainer EOF → drainer_done.notify()
+  → HealthMonitor receives notification
+  → Check exit code
+  → If unexpected exit (non-zero, or session should be long-running):
+      → Increment crash_count
+      → Calculate backoff delay
+      → Schedule respawn
+```
+
+### Restart Policy
+
+```rust
+pub struct RestartPolicy {
+    max_retries: u32,              // 0 = infinite
+    backoff: BackoffStrategy,      // exponential, linear, fixed
+    base_delay: Duration,
+    max_delay: Duration,
+    reset_after: Duration,         // Reset crash count after stable period
+}
+```
+
+Backoff calculation:
+- **exponential**: `min(base * 2^n, max_delay)`
+- **linear**: `min(base * n, max_delay)`
+- **fixed**: `base`
+
+After `reset_after` of stable running, crash count resets to 0.
+
+### Idle Detection
+
+The drainer already timestamps every output chunk. HealthMonitor subscribes to the broadcast channel and updates `last_output`. If no output for `idle_timeout`, the session is marked idle.
+
+Idle sessions can trigger:
+- Notification to fleet manager
+- Optional auto-restart (for context rotation)
+- Alert to Telegram
+
+### vs Node.js
+
+| Node.js | Rust |
+|---|---|
+| Poll-based crash detection (check tmux window) | Event-driven via drainer_done Notify |
+| Restart delay in JS setTimeout | tokio::time::sleep, precise |
+| Idle check by polling tmux output | Broadcast subscriber, zero-cost when active |
+
+---
+
+## Module 6: Context — Context Rotation
+
+### The Problem
+
+LLM agents (Claude Code, etc.) have finite context windows. When context fills up, the agent becomes less effective. AgEnD needs to detect this and restart the session.
+
+### Detection Strategy
+
+Parse PTY output for context usage indicators. Claude Code outputs context usage in its status line:
+
+```
+Context: 85% used (170K/200K tokens)
+```
+
+```rust
+pub struct ContextMonitor {
+    session_id: u32,
+    max_age: Duration,              // Hard limit: restart after N minutes
+    usage_threshold: f32,           // 0.0-1.0, trigger at this usage level
+    cooldown: Duration,             // Min time between rotations
+    last_rotation: Option<Instant>,
+    usage_pattern: Regex,           // Configurable per-backend in fleet.yaml
+}
+```
+
+The `usage_pattern` regex is configurable per instance in `fleet.yaml` via `context_pattern`, since different backends (Claude Code, Codex, Gemini CLI) output context usage in different formats:
+
+```yaml
+instances:
+  general:
+    context_rotation:
+      context_pattern: "Context:\\s+(\\d+)%"   # Claude Code format
+  codex-agent:
+    context_rotation:
+      context_pattern: "tokens:\\s+(\\d+)/(\\d+)"  # Codex format
+```
+
+### Rotation Flow
+
+```
+ContextMonitor subscribes to output broadcast
+  → Regex matches context usage line
+  → If usage > threshold OR age > max_age:
+      → Check cooldown (prevent rapid re-rotation)
+      → Save session state (working directory, env vars)
+      → Kill session (graceful: inject /exit)
+      → Spawn new session with same config
+      → Log rotation event
+```
+
+### Session Continuity
+
+On rotation, the new session inherits:
+- Same working directory
+- Same environment variables
+- Same Telegram topic mapping
+- Previous session's output log (archived, new log started)
+
+The agent starts fresh but the fleet config ensures it gets the same role/instructions.
+
+### vs Node.js
+
+| Node.js | Rust |
+|---|---|
+| Grace period hacks (10 min cooldown) | Deterministic: cooldown + usage threshold |
+| Parse context from tmux capture-pane | Parse from broadcast stream (already have it) |
+| Restart via tmux kill-window + new-window | Kill session + spawn new PtySession |
+
+---
+
+## Module 7: CLI — User Interface
+
+### Command Tree
+
+```
+agend-terminal
+├── daemon                           # Start the daemon
+│   └── --config fleet.yaml          # Load fleet config
+│
+├── fleet                            # Fleet management
+│   ├── start [name...]              # Start all or specific instances
+│   ├── stop [name...]               # Graceful stop
+│   ├── restart [name...]            # Restart instances
+│   └── status                       # Fleet overview
+│
+├── ls                               # List sessions (short form)
+├── attach <id|name>                 # Attach to session
+├── logs <id|name>                   # Tail output log
+│   └── --follow                     # Follow mode (like tail -f)
+│
+├── inject <id|name> <text>          # Send raw input
+├── kill <id|name>                   # Kill session
+│   ├── --quit-cmd CMD               # Graceful quit command
+│   └── --grace N                    # Grace period seconds
+│
+├── spawn [flags] <cmd> [-- args]    # Manual spawn (outside fleet)
+│   ├── --env KEY=VALUE
+│   ├── --cols N --rows N
+│   └── --ready-pattern REGEX
+│
+├── reply <text>                     # Agent: reply to user (from PTY)
+├── send <target> <text>             # Agent: message another instance
+│   ├── --kind query|task|report
+│   └── --correlation-id ID
+├── inbox                            # Agent: read pending messages
+└── react <emoji>                    # Agent: react to message
+```
+
+### Argument Parsing
+
+Use `clap` crate for structured argument parsing (replace current manual parsing):
+
+```rust
+#[derive(Parser)]
+#[command(name = "agend-terminal")]
+enum Cli {
+    Daemon { #[arg(long)] config: Option<PathBuf> },
+    Fleet { #[command(subcommand)] cmd: FleetCmd },
+    Ls,
+    Attach { target: String },
+    Logs { target: String, #[arg(long)] follow: bool },
+    Inject { target: String, text: Vec<String> },
+    Kill { target: String, #[arg(long)] quit_cmd: Option<String> },
+    Spawn { /* flags */ },
+    Reply { text: Vec<String> },
+    Send { target: String, text: Vec<String> },
+    Inbox,
+    React { emoji: String },
+}
+```
+
+---
+
+## Module 8: Self-Healing — Supervised Hot Upgrade
+
+Zero-downtime daemon upgrades with automatic rollback on failure. Unix-only
+(the socket-swap + symlink-rename trick doesn't map cleanly to Windows;
+`agend-terminal upgrade` returns an error there).
+
+### Layering
+
+```text
+agend-supervisor             ← frozen, tiny, upgraded rarely
+  └── agend-terminal daemon  ← hot-swappable binary (PTY master owner)
+        └── agent PTYs       ← spawned fresh by the new daemon after upgrade
+```
+
+The supervisor's job is narrow on purpose: own the daemon child, orchestrate
+binary swaps, and roll back on failure. It does not own PTYs, Telegram state,
+or the MCP server — if it did, every supervisor change would force agents to
+restart. Keeping its surface small is the whole point: it can stay frozen for
+months while the daemon iterates daily.
+
+### Filesystem Layout
+
+```text
+$AGEND_HOME/
+  bin/
+    current          → symlink to the active daemon binary
+    prev             → symlink to the previous binary (rollback target)
+    store/
+      <sha256>       ← content-addressed binaries staged by `upgrade`
+    supervisor       ← symlink to the installed supervisor binary
+  run/
+    <pid>/           ← per-daemon run dir (unchanged from Module 1)
+    supervisor.sock  ← supervisor IPC socket (0600)
+    supervisor.pid   ← supervisor's PID
+    upgrade-marker   ← JSON blob written pre-upgrade, consumed by new daemon
+```
+
+Content-addressed store means swapping a binary is just a `rename(2)` over a
+symlink — atomic, no half-written state. Rolling back is the same operation
+in reverse.
+
+### Protocol: `supervisor.sock`
+
+NDJSON over localhost TCP. One request, streaming progress frames, terminal response.
+
+| Request                    | Sent by                      | Purpose                                    |
+|----------------------------|------------------------------|--------------------------------------------|
+| `Ping`                     | CLI pre-upgrade probe        | Detect a live supervisor + fetch its PID  |
+| `Status`                   | CLI                          | Query current daemon version               |
+| `Upgrade { new_hash, … }`  | CLI                          | Run the upgrade workflow                   |
+| `Ready { pid, version }`   | Daemon post-boot             | "I'm up" ping consumed by `wait_for_ready` |
+| `ShuttingDown { reason }`  | Daemon pre-exit (optional)   | Distinguishes clean stop from crash        |
+
+Wire version is pinned at `1`; CLI refuses servers with a newer version and
+tells the user to upgrade the client. The protocol is deliberately not
+backwards-compatible in the degrade-gracefully sense — the supervisor is the
+oldest moving piece and will outlive its peers.
+
+### Upgrade Flow
+
+```text
+CLI                             Supervisor                      Daemon (old)   Daemon (new)
+ │                                  │                                │              │
+ │ 1. stage new binary in store/   │                                │              │
+ │ 2. stage current  → prev/       │                                │              │
+ │ 3. swap bin/current symlink     │                                │              │
+ │ 4. Upgrade{ new_hash, … } ───► │                                │              │
+ │                                  │ 5. self-test (AGEND_SELF_TEST) │              │
+ │                                  │    spawn new binary, wait exit │              │
+ │                                  │ 6. write upgrade-marker        │              │
+ │                                  │ 7. SIGTERM old ──────────────► │ exit         │
+ │                                  │ 8. spawn new ────────────────────────────────►│
+ │                                  │ 9. wait for Ready ping ◄──────────────────────│
+ │                                  │ 10. stability window (60s)     │              │
+ │                                  │     — watch for crashes —      │              │
+ │ 11. ◄────── Ok { final: true }  │                                │              │
+```
+
+If any step after 5 fails — self-test exits non-zero, ready ping doesn't
+arrive within the timeout, or the new daemon crashes ≥ 2 times inside the
+stability window — the supervisor rolls back:
+
+```text
+Supervisor: stop new daemon → swap bin/current → store/<prev_hash>
+            → delete upgrade-marker → respawn old daemon → report rollback
+```
+
+The CLI surfaces this as a hard failure (`Err`) even though the system is back
+in a good state. "Rollback succeeded" is still a failed upgrade from the
+user's perspective.
+
+### Why Agents Restart
+
+The daemon owns every agent's PTY master fd. When it exits, those fds close
+and the child processes see EOF / SIGHUP. CRIU-style fd handoff was considered
+and rejected: platform-fragile, complicates the supervisor's freeze surface,
+and the existing crash-respawn code path already handles "daemon went away,
+agents came back" correctly. The MVP trades a few seconds of agent
+interruption for a much simpler supervisor.
+
+After the new daemon boots, it reads `run/upgrade-marker` and — if present —
+injects `[system] Daemon upgraded from vX to vY. All agents restarted.` into
+every agent's PTY instead of the normal crash-respawn notice. The marker is
+then deleted so a subsequent unrelated crash respawn gets its real reason.
+
+### Rollback Triggers
+
+- **Self-test failure**: new binary exits non-zero under `AGEND_SELF_TEST=1`
+  before we kill the old daemon. Cheapest failure mode — zero disruption.
+- **Ready-ping timeout**: new daemon exec'd but never pinged within
+  `--ready-timeout-secs` (default 60). Catches hangs, missing deps, busted
+  config.
+- **Stability-window crash**: new daemon pings Ready but then crashes ≥ 2
+  times within `--stability-secs` (default 60). Catches "boots fine, dies
+  under first real request" regressions.
+
+### Bootstrap Migration
+
+Fresh installs with no supervisor: the first `agend-terminal upgrade
+--install-supervisor --yes` lays down `bin/current`, `bin/supervisor`, and
+`bin/store/`, then tells the user to start `agend-supervisor`. It does **not**
+auto-start the supervisor — how to daemonize (nohup, systemd, launchd) is a
+policy decision the installer's shell owns.
+
+### Testable Surface
+
+- `supervisor::client` — pure (sha256, symlink swap, TCP send/recv).
+- `supervisor::ipc` — serde roundtrip tests on every Request/Response variant.
+- `supervisor::self_test` — passes with valid `fleet.yaml`, fails on corrupt.
+- `supervisor::server` — end-to-end integration tests in
+  `tests/self_healing_supervisor.rs` drive the real `agend-supervisor` binary
+  against a temp `$AGEND_HOME`, using `src/bin/agend-mock-daemon.rs` as the
+  daemon child. Two cases covered:
+  - **Success path**: v1 booted → stage v2 → `Upgrade` → terminal `Ok` →
+    `current` repointed at v2 → v2 sentinel observed.
+  - **Rollback path**: crash counter armed at 2 so the new daemon crashes
+    post-ready twice inside the stability window → supervisor repoints
+    `current` back at v1, deletes the upgrade marker, and responds `Err`.
+    This path also exercises the watcher's `waitpid(WNOHANG)` zombie reap —
+    pure `kill(pid, 0)` liveness probing would leave crashed children as
+    zombies and silently report the upgrade as stable.
+
+  The v2 binary is fabricated by appending padding bytes to the v1
+  mock-daemon so the sha256 differs while behaviour stays identical
+  (ELF/Mach-O loaders ignore trailing bytes). The mock daemon is
+  Unix-only and never shipped — it lives under `src/bin/` purely so
+  `cargo test` builds it into `target/debug/` alongside the supervisor.
+
+---
+
+## Cross-Cutting: Daemon API (IPC)
+
+The daemon exposes a localhost-only TCP API using NDJSON (newline-delimited JSON) protocol.
+
+### Transport
+
+- **Localhost TCP** on a random port (published to `<home>/run/<pid>/api.port`)
+- **No TLS** — localhost-only assumption; same-user access enforced by filesystem permissions
+- **Connection cap**: 32 concurrent sessions (fixed const; #env-cleanup: the `AGEND_API_MAX_CONNS` override was demoted)
+
+### Authentication
+
+1. Daemon issues a 32-byte random cookie at startup (`<home>/run/<pid>/api.cookie`, mode 0600)
+2. Client reads the cookie file and sends `{"auth":"<hex>"}` as the first NDJSON line
+3. Daemon verifies via constant-time comparison
+4. **Pre-auth timeout**: 5s — prevents slow-loris holding connection slots
+
+### Protocol
+
+After auth handshake, each line is a JSON request; daemon responds with one JSON line per request:
+
+```
+→ {"method": "list"}
+← {"ok": true, "result": {"agents": [...]}}
+
+→ {"method": "inject", "params": {"name": "dev-1", "data": "hello"}}
+← {"ok": true, "result": {"bytes": 5}}
+```
+
+### Agent Identity
+
+On spawn, the daemon sets `AGEND_INSTANCE_NAME=<name>` in the child's environment. MCP tool calls from the agent include this identity automatically. The daemon uses it to route replies and track per-agent state.
+
+---
+
+## Cross-Cutting: CI Watch & Dispatch Chains
+
+### CI watch file identity (#942 / #943)
+
+Each `ci action=watch` subscription persists a JSON file at
+`<home>/ci-watches/<filename>.json`. The filename has been hardened
+twice in quick succession:
+
+- **#942 — `canonicalize_repo_slug`.** Operators (and the bridge)
+  refer to the same repo in seven divergent forms:
+  `git@github.com:owner/repo.git`, `https://github.com/owner/repo`,
+  `https://github.com/owner/repo.git`, `git+ssh://...`, raw
+  `owner/repo`, with `.git` suffix, with case variation. Pre-#942
+  each form computed its own watch filename → duplicate subscriptions
+  with divergent state → notifications fanned out N times. Post-#942
+  the slug is canonicalized to `owner/repo` (lowercase, no `.git`,
+  no scheme) before hashing.
+- **#943 — sha256 hash.** The pre-#943 filename used Rust's
+  `DefaultHasher` (SipHash-2-4 truncated to 64 bits → 16 hex chars).
+  Collision-grade is `~2^32` brute force — too thin for an identity
+  key the operator relies on. Replaced with sha256 (256-bit, 64 hex
+  chars). ~900 ns per call vs ~100 ns; at typical
+  ~100 subscriptions/agent/day the ~90 µs/day delta is negligible.
+
+The two changes ship together as a unit; the canonicalization
+narrows divergence at the *input* level while sha256 widens the
+hash *output* to remove the collision-grade concern at the same
+time.
+
+**Legacy migration (#942/#943 PR-B).** `bootstrap::prepare` runs
+`migrate_legacy_watch_filenames` synchronously at boot. The migration
+scans `<home>/ci-watches/*.json`, identifies non-canonical filenames
+(stem length ≠ 64), reads each body to recover `repo` + `branch`,
+canonicalizes the `repo` field, computes the new sha256 filename, and
+renames the file. Conflicts (two old files mapping to the same target)
+are logged with the FIRST one winning; the operator can hand-resolve.
+Idempotent — re-running on already-migrated state is a no-op. The
+synchronous-at-boot ordering means the poll loop never sees the old
+files, so operators don't observe duplicate 72 h notifications across
+the transition.
+
+### CI watch survives bind/release handoff (#931)
+
+The daemon's `release_worktree` path used to unsubscribe the releasing
+agent from every `ci-watch` they held. If that agent was the **sole**
+subscriber, the watch file's `next_after_ci` chain and polling state
+were destroyed, and the chained handoff (`ci pass → next_after_ci →
+[ci-ready-for-action] to reviewer`) never fired.
+
+Post-#931 the file is kept intact on the sole-subscriber release path:
+`next_after_ci`, `last_notified_head_sha`, and the polling state all
+survive. The next agent that binds the same branch (via
+`dispatch_auto_bind_lease`) inherits the chain and the handoff fires
+on the next CI green tick.
+
+The reviewer-dispatch chain `dev → ci → reviewer` is the canonical
+example; the same fix unblocks any multi-agent workflow where one
+agent's release precedes another's bind.
+
+### Correlation IDs on `system:ci` and dispatch_idle (#946 / #947)
+
+Two correlation_id sources flow into inbox routing:
+
+- **#946 — `system:ci` notifications.** Every `system:ci` enqueue
+  (pass, fail, stalled, conflict, etc.) now carries
+  `correlation_id = "{repo}@{branch}"` — a stable identifier per
+  watched branch. Pre-#946 these were `None`, leaving operators no
+  way to filter inbox dumps to a single branch. Greppable example:
+  `grep '"correlation_id":"owner/repo@feat/x"' $AGEND_HOME/inbox/*.jsonl`.
+- **#947 — dispatch_idle watchdog fallback.** When the watchdog fires
+  on a `kind=task`/`kind=query` send whose upstream had no
+  `correlation_id`, the synthesized fallback uses the canonical
+  dispatch id format `disp-<unix_micros>-<seq>`. Pre-#947 the
+  fallback was either `None` or a churning per-call ULID with no
+  cross-message tie. The new format is self-documenting via prefix
+  and stable across the dispatch + the eventual report.
+
+### Test infrastructure — deterministic primitives
+
+Two helpers extracted from in-test repetition (SOP 1 §3.20):
+
+- **`admin::cleanup_zombies::poll_until_dead(pid, timeout)`** (#934).
+  `pub(crate)` deterministic alternative to `thread::sleep(N)`
+  patterns. Polls `kill -0` (Unix) / `OpenProcess` (Windows) every
+  10 ms up to `timeout`. Returns `bool` (dead-on-time). Already
+  consumed by `agent.rs` shutdown path + `process.rs` reaper.
+- **`api::handlers::instance::await_sentinel_nonempty`** (#949). Polls
+  a sentinel file path until it has non-empty content or the timeout
+  elapses. Contract clarified by the rename: pre-#949 the helper was
+  named for the *file* existing, but `instance` codepaths needed the
+  *content* to be present (the file is created empty then written to).
+  Tests now use the helper at the four `instance.rs` boot-sentinel
+  sites; CI-side flake is gone.
+
+Both helpers are `pub(crate)` — call sites stay in-crate, and the
+helpers exist primarily to make tests deterministic without falling
+back to sleep tuning.
+
+---
+
+## Cross-Cutting: Daemon Notification & State Helpers
+
+### `notify_system` helper (#1335)
+
+Daemon modules that emit inbox notifications (watchdogs, timeouts, idle
+detectors) previously duplicated ~8 lines of `InboxMessage::new_system` +
+builder chain + `enqueue_with_idle_hint`. The `notify_system()` helper
+collapses this to a single call:
+
+```rust
+crate::inbox::notify_system(
+    home,
+    target,          // recipient agent name
+    "system:source", // source identifier
+    "event-kind",    // inbox message kind
+    body,            // message body (impl Into<String>)
+    correlation_id,  // Option<&str>
+    task_id,         // Option<&str>
+);
+```
+
+All `notify_system` messages use `delivery_mode("inbox_fallback")`. Modules
+that need different delivery modes (e.g. `cron_tick`, `daemon/mod.rs`
+schedule/query) should continue using `InboxMessage` directly.
+
+### Event bus (#1336)
+
+Feature-flagged global event bus for decoupled daemon-internal signaling.
+
+**Enable**: `AGEND_EVENT_BUS=1` environment variable.
+
+**Usage**:
+
+```rust
+// Zero-cost when disabled — closure never called.
+event_bus::emit_lazy("pr_state.merged", || {
+    json!({ "repo": repo, "branch": branch })
+});
+
+// Guard for callers that build expensive payloads.
+if event_bus::is_enabled() {
+    let payload = expensive_computation();
+    event_bus::emit("custom.event", payload);
+}
+```
+
+When disabled (default), `emit_lazy` returns immediately without allocating
+or evaluating the closure. `is_enabled()` is a single `AtomicBool` load.
+
+### `with_pr_state` flock helper (#1342)
+
+All mutations to `pr-state/*.json` files must go through `with_pr_state()`
+or `with_pr_state_or_create()`. These helpers:
+
+1. Acquire an `fs4` file lock on `<filename>.lock`
+2. Read + deserialize the current `PrState`
+3. Run the caller's mutation closure
+4. Serialize + `atomic_write` the result
+
+```rust
+// Mutate existing state (returns None if file doesn't exist).
+let result = with_pr_state(home, repo, branch, |state| {
+    state.ready_emitted_for_sha = Some(state.head_sha.clone());
+    ScanAction::Saved
+});
+
+// Create if absent (uses default_fn for initial state).
+with_pr_state_or_create(home, repo, branch, default_fn, |state| {
+    state.ci_results.push(result);
+});
+```
+
+This eliminates the lost-update race where concurrent writers (scanner tick
++ gh-poll) could overwrite each other's changes. The lock file is separate
+from the data file to avoid holding a lock on a file being atomically
+replaced.
+
+### Auto-release worktree on pr-merged (#1344)
+
+When the scanner detects `MergeState::Merged`, it calls
+`auto_release_for_merged_branch(home, &state.branch)` **before** emitting
+the `[pr-merged]` inbox notification. This function:
+
+1. Scans `runtime/<agent>/binding.json` for agents bound to the branch
+2. Acquires the binding lock
+3. Checks `is_worktree_clean` (dirty worktrees are skipped with a warning)
+4. Calls `release_full` to remove the worktree + clear the binding
+
+This ensures `gh pr merge --delete-branch` succeeds because no local
+worktree holds the branch ref.
+
+---
+
+## Data Flow Summary
+
+### User sends message via Telegram
+
+```
+Telegram → TelegramAdapter.on_message()
+  → Router: lookup topic_id → instance "general"
+  → Format: "[user:chiachenghuang] message text"
+  → session.write_input(formatted_message)
+  → Agent reads from stdin, processes, calls Bash tool
+  → `agend-terminal reply "response"`
+  → CLI connects to daemon TCP API, sends Reply request
+  → Router: session 1 → Telegram topic 12345
+  → TelegramAdapter.send(topic_id, "response")
+  → User sees response in Telegram
+```
+
+### Agent-to-agent communication
+
+```
+Agent A (blog-writer) runs: `agend-terminal send general "PR ready"`
+  → CLI authenticates via auth cookie
+  → Connects to daemon TCP API
+  → Request::Send { target: "general", text: "PR ready" }
+  → Router: find session for "general" → session 1
+  → Format: "[from:blog-writer] PR ready"
+  → session_1.write_input(formatted_message)
+  → Agent "general" reads from stdin, processes
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core Hardening (Current)
+- [x] PTY spawn/attach/detach/inject/kill
+- [x] Output capture + ready detection
+- [x] Graceful daemon shutdown
+- [x] `clap` CLI parsing (`Commands` enum in `src/main.rs`)
+- [ ] Auth cookie (`<home>/run/<pid>/api.cookie`)
+
+### Phase 2: Fleet + Communication
+- [ ] `fleet.yaml` parser
+- [ ] FleetManager: start/stop/restart
+- [ ] `reply` / `send` / `inbox` CLI commands
+- [ ] Message router
+- [ ] Config hot-reload (`notify` crate)
+
+### Phase 3: Channel Integration
+- [ ] Telegram adapter (teloxide)
+- [ ] Inbound: Telegram → PTY inject
+- [ ] Outbound: Agent reply → Telegram send
+- [ ] Topic-to-instance mapping
+
+### Phase 4: Health + Context
+- [ ] Health Monitor replaces `spawn_session_reaper`
+- [ ] Event-driven crash detection
+- [ ] Restart policy (exponential backoff)
+- [ ] Context usage parsing
+- [ ] Auto-rotation with cooldown
+- [ ] Idle detection
+
+### Phase 5: Production
+- [ ] Discord adapter
+- [ ] SQLite persistence (schedules, cost tracking)
+- [ ] Web dashboard (optional)
+- [ ] Multi-host fleet (SSH-based remote spawn)
+
+---
+
+## Dependency Plan
+
+```toml
+[dependencies]
+# Core (already)
+portable-pty = "0.8"
+tokio = { version = "1", features = ["full"] }
+nix = "0.29"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+regex = "1"
+
+# Phase 1
+clap = { version = "4", features = ["derive"] }
+
+# Phase 2
+serde_yaml = "0.9"          # fleet.yaml parsing
+notify = "7"                 # Config file watching
+
+# Phase 3
+teloxide = "0.13"            # Telegram bot
+reqwest = "0.12"             # HTTP client (for webhooks)
+
+# Phase 4
+rusqlite = "0.32"            # SQLite (schedules, logs)
+```
+
+---
+
+## Source Layout (reference)
+
+The module design above is aspirational and largely file-agnostic; the table below is the current file-level mapping as of Sprint 61 (2026-05). See `CONTRIBUTING.md` for the contribution-time style rules.
+
+| Responsibility | File(s) |
+|---|---|
+| PTY session management, spawn, inject, ready detection | `src/agent.rs` |
+| Backend presets (Claude, Kiro, Codex, Gemini, OpenCode, Shell) | `src/backend.rs` |
+| Shared helpers (messaging, fleet mutation, branch validation) | `src/agent_ops.rs` |
+| Daemon JSON control API (wire protocol + handlers) over TCP loopback | `src/api/mod.rs`, `src/api/handlers/*.rs` |
+| MCP surface for agents (32 tools) | `src/mcp/handlers/`, `src/mcp/tools.rs` |
+| Dispatch hook (auto-bind, lease, worktree creation) | `src/mcp/handlers/dispatch_hook/` |
+| Fleet config (fleet.yaml parse, instances, teams) | `src/fleet.rs` |
+| Team management | `src/teams.rs` |
+| Task board | `src/tasks.rs` |
+| Decisions store | `src/decisions.rs` |
+| Schedules (cron + one-shot) | `src/schedules.rs` |
+| Deployments (template-based multi-agent spawn) | `src/deployments.rs` |
+| Worktree lifecycle (lease, release, GC) | `src/worktree_pool.rs`, `src/worktree.rs` |
+| Worktree auto-cleanup (sweep merged/gone branches) | `src/worktree_cleanup.rs` |
+| Binding state (agent ↔ branch ↔ worktree) | `src/binding.rs` |
+| Inbox (message queue, delivery, supersede) | `src/inbox.rs` |
+| Channel adapters (Telegram, Discord) | `src/channel/` |
+| Daemon tick loop (CI watch, health, supervisor) | `src/daemon/` |
+| CI watch (poll GitHub Actions, emit pass/fail) | `src/daemon/ci_watch.rs` |
+| Claim verifier (push-time semantic gate) | `src/claim_verifier.rs` |
+| TUI (multi-tab/pane terminal UI) | `src/tui.rs`, `src/render/`, `src/layout/` |
+| App mode (in-process TUI + daemon) | `src/app/` |
+| CLI argument parsing | `src/main.rs` (Commands enum) |
+| Instructions/steering injection | `src/instructions.rs` |
+| Admin (branch cleanup analysis) | `src/admin.rs` |
+| Event log (audit trail) | `src/event_log.rs` |
+| Health state | `src/health.rs` |
+| Service (systemd/launchd integration) | `src/service/` |
+| System tray | `src/tray/` |
+| Bootstrap (agent resolve, doctor, fleet normalize) | `src/bootstrap/` |
+| Git shim (worktree-deny matrix) | `src/bin/agend-git.rs` |
+| MCP bridge (per-agent MCP server) | `src/bin/agend-mcp-bridge.rs` |
+
+### Drift enforcement
+
+`tests/no_dual_track_drift.rs` extracts top-level fn bodies from `src/agent_ops.rs` and `src/mcp/handlers.rs` and asserts that any fn sharing a name has an identical body, preventing the kind of silent divergence between MCP and daemon paths that caused the `cleanup_working_dir` Kiro-cleanup gap (14-entry MCP copy vs 19-entry canonical) on main before Task #9 Option C. The detector is parser-hardened against raw-string literals and `extern "ABI" fn` (PR #31).


### PR DESCRIPTION
<!-- LOC-EST: 1400-1700 -->

## Summary

The synthesis deliverable of the #2050 architecture pass. Six subsystem surveys (daemon-core, mcp-comms, channels-tui, state-detection, worktree-git-fleet, ops-entry) were collected against `main` @ `65d9ad8`; this PR distills them into two durable docs:

- **`docs/architecture.md`** (rewritten) — current-state structural map: subsystem responsibilities, the send/state/worktree data flows, the lock disciplines (summarizing, not duplicating, DAEMON-LOCK-ORDERING.md), a load-bearing-invariants table, and the six named architectural tensions (dual periodic-work mechanisms, heuristic-vs-hook dual readers, raw-Command-vs-git_bypass, size-driven extraction at the MCP cap, channel trait vs legacy notify, dual resize chokepoints).
- **`docs/REFACTOR-PLAN.md`** (new) — the phased plan: **W1 finish-the-extraction** (trackers→PerTickHandler unification, `git_cmd` helper, quick wins) → **W2 cap relief & mechanical decomposition** → **W3 high-care strategic with hard prerequisites** (supervisor `tick()` decomposition, `agend-git` table-driven classify bundled with #2027, #1523 phase-2 convergence) → **W4 opportunistic**. Each item sized to one reviewable PR with effort/risk/source.

The rewrite-era design doc is preserved at `docs/archived/architecture-design-doc-2026-05.md` (the bulk of this PR's line count is that move — macOS case-insensitive FS rules out ARCHITECTURE.md alongside architecture.md, so the new map takes over the existing filename).

## Notes for review

- Docs-only; no code changes.
- file:line anchors cite `65d9ad8` (the survey base); function/test/issue anchors are the stable references.
- Refs #2050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)