### PR TITLE
debug(#2057): env-gated TUI size probe (instrumentation-only, #1808)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -399,6 +399,10 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     let app_configs: crate::api::ConfigRegistry = Arc::new(Mutex::new(HashMap::new()));
     let app_handlers = app_tick_handlers();
 
+    // #2057: read the size-probe env gate ONCE (it can't change mid-run) — keep
+    // the per-frame draw loop's hot path at zero env-lookup cost (codex #2060).
+    let size_debug = std::env::var("AGEND_TUI_SIZE_DEBUG").as_deref() == Ok("1");
+
     loop {
         if crate::bootstrap::signals::term_requested() {
             tracing::info!("app: SIGTERM received, exiting main loop");
@@ -457,7 +461,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         // the window) and it follows the home dir, but the static trace found
         // NO stored size anywhere — every size source is live crossterm. Log
         // the actual numbers per draw so a repro says which one is short.
-        if std::env::var("AGEND_TUI_SIZE_DEBUG").as_deref() == Ok("1") {
+        if size_debug {
             let cross = crossterm::terminal::size().unwrap_or((0, 0));
             let term_sz = terminal
                 .size()
@@ -481,7 +485,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             // be visible to this load before the next paint tick.
             let binary_stale = daemon_binary_stale.load(std::sync::atomic::Ordering::Relaxed);
             // #2057: the area render actually fills — compare to crossterm above.
-            if std::env::var("AGEND_TUI_SIZE_DEBUG").as_deref() == Ok("1") {
+            if size_debug {
                 let a = frame.area();
                 tracing::info!(
                     tag = "#2057-area",

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -452,6 +452,27 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
 
         let repeat_mode = key_handler.in_repeat();
 
+        // #2057 instrumentation (env-gated, AGEND_TUI_SIZE_DEBUG=1): the
+        // operator sees ~3 blank rows below the status bar (frame shorter than
+        // the window) and it follows the home dir, but the static trace found
+        // NO stored size anywhere — every size source is live crossterm. Log
+        // the actual numbers per draw so a repro says which one is short.
+        if std::env::var("AGEND_TUI_SIZE_DEBUG").as_deref() == Ok("1") {
+            let cross = crossterm::terminal::size().unwrap_or((0, 0));
+            let term_sz = terminal
+                .size()
+                .map(|s| (s.width, s.height))
+                .unwrap_or((0, 0));
+            tracing::info!(
+                tag = "#2057-size",
+                crossterm_cols = cross.0,
+                crossterm_rows = cross.1,
+                terminal_size = ?term_sz,
+                tabs = layout.tabs.len(),
+                "TUI draw size probe"
+            );
+        }
+
         terminal.draw(|frame| {
             // #1027: snapshot the shared daemon-binary-stale flag once
             // per frame so the render path sees a consistent value.
@@ -459,6 +480,18 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             // state needed; the supervisor's SeqCst store will always
             // be visible to this load before the next paint tick.
             let binary_stale = daemon_binary_stale.load(std::sync::atomic::Ordering::Relaxed);
+            // #2057: the area render actually fills — compare to crossterm above.
+            if std::env::var("AGEND_TUI_SIZE_DEBUG").as_deref() == Ok("1") {
+                let a = frame.area();
+                tracing::info!(
+                    tag = "#2057-area",
+                    x = a.x,
+                    y = a.y,
+                    w = a.width,
+                    h = a.height,
+                    "frame.area() in draw"
+                );
+            }
             render::render(
                 frame,
                 &mut layout,


### PR DESCRIPTION
## Summary

#1808 instrumentation-only for #2057 (blank rows below the status bar). The prime suspect — `session.json` / per-home stored size feeding the frame — is **refuted** by a controlled repro; this probe gets the operator the decisive number on their real terminal.

### Verify-first findings
- **Static trace**: every size source is *live crossterm*. `render()` splits `frame.area()` directly (`core_render.rs:81`, `[TAB_BAR_HEIGHT=1, Min(1), Length(1)]` — status is the **last** chunk, so it cannot leave a gap below it). The resize pass (`app/mod.rs:419`) and the `tui_screenshot` snapshot (`app/mod.rs:644`) both read `crossterm::terminal::size()` / `terminal.size()`. **No home JSON carries a rows/cols/size field**; `session.json` stores only the layout *tree* (tab names + split ratios), no absolute dimensions.
- **Controlled repro** (isolated `cp -r` of the live home — never the live one): restored the real **7-tab / 12-instance** layout with cheap `/bin/cat` backends under a PTY pinned to **56 rows** → `crossterm_rows=56`, `frame.area().h=56`, **no blank**. Empty-agents copy → same. ⇒ the code faithfully adopts crossterm's size regardless of home state.

### What the probe resolves
`AGEND_TUI_SIZE_DEBUG=1` logs `#2057-size` (crossterm vs terminal.size) + `#2057-area` (frame.area) per draw. On the operator's real default-home repro it shows whether **crossterm itself reports the short height** (⇒ PTY-winsize / terminal layer — not the frame code, which my repro already predicts) or **frame.area diverges from crossterm** (⇒ in-code, which my repro rules out). Zero behaviour change when unset.

Instrumentation-only — no fix yet; RCA redirected away from session.json/layout-restore toward the terminal/PTY-winsize layer pending the operator's number.

Refs #2057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)