### PR TITLE
fix(#2059 #1): verdict matcher sees through the [report_result] wrapper

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -466,7 +466,13 @@ fn process_verdicts(home: &Path, from: &str, msg: &crate::inbox::InboxMessage) {
     // staleness gate (a head-less VERIFIED must not flip the merge gate);
     // REJECTED/UNVERIFIED record regardless (UNVERIFIED is evidence-exempt).
     if msg.kind.as_deref() == Some("report") && msg.correlation_id.is_some() {
-        let text = msg.text.trim_start();
+        // #2059: strip the `[report_result] ` wrapper (added by
+        // comms::handle_report_result) via the SHARED helper, so the verdict-word
+        // check sees the bare word — the same strip `is_terminal_verdict_text`
+        // uses, so the two verdict consumers never drift. Without this, the
+        // wrapped real wire text never matched and record_verdict was never
+        // called (the pipeline-wide silence #2059 RCA'd).
+        let text = crate::daemon::auto_release::strip_report_wrapper(&msg.text);
         let task_id = msg.correlation_id.as_deref().unwrap_or("");
         if text.starts_with("VERIFIED") {
             if msg.reviewed_head.is_some() {

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -405,11 +405,30 @@ pub(crate) fn enqueue_intent(home: &Path, intent: &AutoReleaseIntent) -> std::io
     Ok(())
 }
 
-/// The three terminal review verdicts. A reviewer's report opens with exactly
-/// one of these (§3.12 / #1666 §3.3). True iff `text` (already the message body)
-/// begins with one of them.
-pub(crate) fn is_terminal_verdict_text(text: &str) -> bool {
+/// #2059: strip the `[report_result] ` wrapper that
+/// `comms::handle_report_result` prepends, so verdict detection sees the bare
+/// verdict word. The reviewer's verdict is sent via `send request_kind=report`,
+/// which routes through `handle_report_result` and wraps the summary — so the
+/// downstream `msg.text` is `"[report_result] VERIFIED …"`, NOT `"VERIFIED …"`.
+/// Without this strip, every `starts_with("VERIFIED")`-style check is dead
+/// against real wire text (the pipeline-wide silence #2059 RCA'd). Idempotent on
+/// already-bare text (a raw `send` report), so both shapes resolve.
+///
+/// This is the SINGLE strip mechanism — both verdict consumers
+/// (`is_terminal_verdict_text` here, and `process_verdicts` in
+/// `api/handlers/messaging.rs`) route through it, so the two never drift.
+pub(crate) fn strip_report_wrapper(text: &str) -> &str {
     let t = text.trim_start();
+    t.strip_prefix("[report_result] ")
+        .map(str::trim_start)
+        .unwrap_or(t)
+}
+
+/// The three terminal review verdicts. A reviewer's report opens with exactly
+/// one of these (§3.12 / #1666 §3.3). True iff `text` (the message body, with or
+/// without the `[report_result] ` wrapper) begins with one of them.
+pub(crate) fn is_terminal_verdict_text(text: &str) -> bool {
+    let t = strip_report_wrapper(text);
     t.starts_with("VERIFIED") || t.starts_with("REJECTED") || t.starts_with("UNVERIFIED")
 }
 
@@ -859,6 +878,28 @@ mod tests {
             m.text = format!("   {verdict} — indented");
             assert!(is_verdict_message(&m), "{verdict} with indent must match");
         }
+    }
+
+    /// #2059: the strip is idempotent — a BARE verdict (a raw `send` report with
+    /// no `[report_result] ` wrapper) still matches, and a non-verdict report is
+    /// NOT a false positive. (The PRODUCER-FED fixture — feeding the real
+    /// `build_report_text` output through this matcher — lives in
+    /// `comms_inbox.rs` next to the producer, #1493 discipline.)
+    #[test]
+    fn strip_report_wrapper_idempotent_and_no_false_positive_2059() {
+        // Bare verdict (unwrapped) still resolves.
+        assert!(is_terminal_verdict_text("VERIFIED — all green"));
+        assert_eq!(strip_report_wrapper("VERIFIED — x"), "VERIFIED — x");
+        // Wrapper stripped to the bare word (incl. the trailing space).
+        assert_eq!(
+            strip_report_wrapper("[report_result] VERIFIED — x"),
+            "VERIFIED — x"
+        );
+        // A non-verdict report must NOT be a false positive (wrapped or bare).
+        assert!(!is_terminal_verdict_text(
+            "[report_result] Done — pushed PR #2058"
+        ));
+        assert!(!is_terminal_verdict_text("just a plain message"));
     }
 
     /// Non-verdict text, non-report kinds, or missing reviewed_head /

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -417,6 +417,21 @@ pub fn pr_state_dir(home: &Path) -> PathBuf {
     home.join("pr-state")
 }
 
+/// #2059: true iff `path` is a per-branch `PrState` document — a `*.json` file
+/// that is NOT a dotfile. The pr-state dir also holds the `.emitted-terminal.json`
+/// terminal-latch ledger (a different schema) and `.lock` files; both share the
+/// `.json`/no-extension space but are not `PrState`. Parsing `.emitted-terminal.json`
+/// as `PrState` spammed a `missing field 'repo'` WARN on every gh-poll + scan tick
+/// (~every 10 s). Every dir-scan that deserializes entries as `PrState` routes
+/// through this predicate so the ledger/locks are skipped uniformly.
+pub(crate) fn is_pr_state_file(path: &Path) -> bool {
+    let is_dotfile = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with('.'));
+    !is_dotfile && path.extension().and_then(|e| e.to_str()) == Some("json")
+}
+
 /// Canonical filename for a (repo, branch) PR state file. Keyed by
 /// branch (not pr_number) because ci_watch — the primary writer —
 /// knows the branch but not the PR number; `pr_number` is filled in
@@ -530,7 +545,7 @@ pub fn cleanup_subscribers_for_instance(home: &Path, name: &str) -> usize {
     let mut mutated = 0usize;
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+        if !is_pr_state_file(&path) {
             continue;
         }
         // Value-based, NOT typed `PrState` parse: an audit/cleanup that silently
@@ -586,7 +601,7 @@ pub fn has_subscriber(home: &Path, name: &str) -> bool {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+        if !is_pr_state_file(&path) {
             continue;
         }
         let listed = std::fs::read_to_string(&path)
@@ -1062,6 +1077,25 @@ pub fn format_ready_body(state: &PrState) -> String {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    /// #2059: the dir-scan predicate accepts per-branch `*.json` PrState files
+    /// and rejects the dotfile companions (`.emitted-terminal.json` ledger,
+    /// `*.lock`) that share the pr-state dir — parsing those as PrState spammed a
+    /// `missing field 'repo'` WARN every ~10 s.
+    #[test]
+    fn is_pr_state_file_skips_dotfiles_2059() {
+        assert!(is_pr_state_file(Path::new(
+            "/h/pr-state/suzuke_agend-terminal__feat_x.json"
+        )));
+        assert!(
+            !is_pr_state_file(Path::new("/h/pr-state/.emitted-terminal.json")),
+            "the terminal-latch ledger is a dotfile .json — must be skipped"
+        );
+        assert!(!is_pr_state_file(Path::new(
+            "/h/pr-state/suzuke_agend-terminal__feat_x.lock"
+        )));
+        assert!(!is_pr_state_file(Path::new("/h/pr-state/.something.lock")));
+    }
 
     fn now() -> String {
         chrono::Utc::now().to_rfc3339()

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -671,6 +671,9 @@ pub fn suppress_stale_terminal_replay_with(home: &Path, threshold: std::time::Du
     let mut suppressed = 0usize;
     for entry in entries.flatten() {
         let path = entry.path();
+        if !is_pr_state_file(&path) {
+            continue; // #2059: skip .emitted-terminal.json ledger + .lock sidecars
+        }
         let Ok(meta) = entry.metadata() else { continue };
         let Ok(mtime) = meta.modified() else { continue };
         let Ok(age) = mtime.elapsed() else { continue };
@@ -905,6 +908,9 @@ pub fn record_verdict(
     let mut matched_any = false;
     for entry in entries.flatten() {
         let path = entry.path();
+        if !is_pr_state_file(&path) {
+            continue; // #2059: skip .emitted-terminal.json ledger + .lock sidecars
+        }
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -88,7 +88,7 @@ pub fn scan_and_emit_with(
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+        if !crate::daemon::pr_state::is_pr_state_file(&path) {
             continue;
         }
         let content = match std::fs::read_to_string(&path) {
@@ -387,7 +387,7 @@ fn apply_gh_poll(home: &Path, dir: &Path, poller: &dyn gh_poll::GhPoller) {
     let mut skipped_should_poll = 0u32;
     for entry in entries.into_iter().flatten().flatten() {
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+        if !crate::daemon::pr_state::is_pr_state_file(&path) {
             continue;
         }
         let content = match std::fs::read_to_string(&path) {

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -461,13 +461,11 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
         Some(s) => s,
         None => return json!({"error": "missing 'summary'"}),
     };
-    let mut msg = format!("[report_result] {summary}");
-    if let Some(cid) = args["correlation_id"].as_str() {
-        msg.push_str(&format!("\ncorrelation_id: {cid}"));
-    }
-    if let Some(artifacts) = args["artifacts"].as_str() {
-        msg.push_str(&format!("\nArtifacts: {artifacts}"));
-    }
+    let msg = comms_inbox::build_report_text(
+        summary,
+        args["correlation_id"].as_str(),
+        args["artifacts"].as_str(),
+    );
     let result = {
         let correlation_id = args["correlation_id"].as_str();
         let reviewed_head = args["reviewed_head"].as_str();

--- a/src/mcp/handlers/comms_inbox.rs
+++ b/src/mcp/handlers/comms_inbox.rs
@@ -1,6 +1,31 @@
 use serde_json::{json, Value};
 use std::path::Path;
 
+/// #2059: the canonical report-message text producer. Prepends the
+/// `[report_result] ` wrapper to the summary and appends the optional
+/// `correlation_id:` / `Artifacts:` lines. The single builder that BOTH
+/// production (`comms::handle_report_result`) and the verdict-matcher tests
+/// route through — the #1493 producer-fed-fixture discipline that keeps the
+/// downstream verdict detector
+/// ([`crate::daemon::auto_release::is_terminal_verdict_text`]) tested against
+/// the REAL wire text (incl. the wrapper that previously defeated it, #2059).
+/// Lives here (a `comms.rs` overflow sibling) because that file is at the
+/// 750-LOC handler cap.
+pub(crate) fn build_report_text(
+    summary: &str,
+    correlation_id: Option<&str>,
+    artifacts: Option<&str>,
+) -> String {
+    let mut msg = format!("[report_result] {summary}");
+    if let Some(cid) = correlation_id {
+        msg.push_str(&format!("\ncorrelation_id: {cid}"));
+    }
+    if let Some(artifacts) = artifacts {
+        msg.push_str(&format!("\nArtifacts: {artifacts}"));
+    }
+    msg
+}
+
 pub fn handle_describe_message(home: &Path, args: &Value, instance_name: &str) -> Value {
     let msg_id = match args["message_id"].as_str() {
         Some(id) => id,
@@ -106,6 +131,45 @@ fn obligation_reason(home: &Path, msg: &crate::inbox::InboxMessage) -> Option<St
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    /// #2059 §3.9 — the PRODUCER-FED FIXTURE (#1493 discipline). Routes the REAL
+    /// producer output (`build_report_text`, the exact builder
+    /// `handle_report_result` uses on the wire) through the downstream verdict
+    /// matcher (`auto_release::is_terminal_verdict_text`). Pre-#2059 the matcher
+    /// checked `starts_with("VERIFIED")` on the wrapped text → false →
+    /// record_verdict never fired (the pipeline-wide silence). The point of
+    /// co-locating producer + fixture is that the matcher can never again be
+    /// tested against a hand-crafted `"VERIFIED …"` the wire never sends.
+    #[test]
+    fn matcher_sees_through_report_result_wrapper_producer_fed_2059() {
+        use crate::daemon::auto_release::is_terminal_verdict_text;
+        for verdict in ["VERIFIED", "REJECTED", "UNVERIFIED"] {
+            let summary = format!("{verdict} — ran: cargo test → 3702 passed");
+            // Bare wrapper (no suffix).
+            let wire = build_report_text(&summary, None, None);
+            assert!(
+                is_terminal_verdict_text(&wire),
+                "{verdict}: producer-wrapped text must be detected (got {wire:?})"
+            );
+            // With correlation_id + Artifacts suffix lines — the verdict is still
+            // at the start, the suffix must not break detection.
+            let wire2 = build_report_text(
+                &summary,
+                Some("t-20260612055508677007-13"),
+                Some("https://github.com/suzuke/agend-terminal/pull/2058"),
+            );
+            assert!(
+                is_terminal_verdict_text(&wire2),
+                "{verdict}: wrapped + suffixed producer text must be detected"
+            );
+        }
+        // A non-verdict report produced the same way must NOT be a false verdict.
+        let progress = build_report_text("Done — pushed PR #2058, CI running", None, None);
+        assert!(
+            !is_terminal_verdict_text(&progress),
+            "a non-verdict report must not read as a verdict (got {progress:?})"
+        );
+    }
 
     /// #bughunt-r2 #3: querying a LIVE, un-drained message by id must report
     /// `status: "unread"` (with its delivery_mode + correlation_id) — NOT


### PR DESCRIPTION
#2059 fix **#1** (lead-ruled; #2/#3 are separate dialectic'd follow-ups). The load-bearing fix that unblocks the whole verdict→merge-ready pipeline.

## Root cause (from the #2059 RCA)

The verdict→pr-state→`[pr-ready-for-merge]` pipeline emitted **ZERO** output in 2 days across every reviewed+merged PR. A reviewer's verdict is sent via `send request_kind=report` → `comms::handle_report_result`, which prepends a `[report_result] ` wrapper to the summary (so `msg.text = "[report_result] VERIFIED …"`). But verdict detection in `process_verdicts` (`messaging.rs`) and `auto_release::is_terminal_verdict_text` both checked `text.trim_start().starts_with("VERIFIED")` on the **wrapped** text → starts with `[` → **false** → `record_verdict` was never called. This is a #1493 test-fidelity bug: the tests hand-crafted `"VERIFIED …"` (no wrapper) so they were green while the matcher was dead against real wire text. (It also silently disabled the #2010 reviewer-binding auto-release intent — same gate.)

## Fix

- **One shared strip helper** `auto_release::strip_report_wrapper` — strips the `[report_result] ` wrapper (idempotent on already-bare text from a raw `send` report). **BOTH** verdict consumers (`is_terminal_verdict_text` and `process_verdicts`) route through it, so they can never drift (the lead's "一概念一機制").
- **Extract the producer** `build_report_text` from the inline `handle_report_result` body into `comms_inbox.rs` (the `comms.rs` overflow sibling — `comms.rs` is at the 750-LOC handler cap), so production and the test feed the **same** builder.
- **Producer-fed fixture (#1493 discipline)**: `matcher_sees_through_report_result_wrapper_producer_fed_2059` routes the real `build_report_text` output through `is_terminal_verdict_text` for all three verdicts (+ correlation/Artifacts suffix lines + a non-verdict negative). **RED-verified**: reverting the strip fails it.
- **Tangential noise fix**: `pr_state::is_pr_state_file` skips dotfiles so the gh-poll/scanner dir scan stops parsing `.emitted-terminal.json` as a `PrState` and spamming a `missing field 'repo'` WARN every ~10 s (used at all 4 dir-scan sites).

## Out of scope (per lead scoping)

- **#2** (verdict↔branch correlation: reviewed-head SHA-key + create-or-buffer pr-state) — separate task, dialectic-ruled (c).
- **#3** (route `[pr-ready-for-merge]` to the merge authority via `teams::find_team_for`, not the released binding) — goes to dev.

So this PR makes `record_verdict` fire; #2 makes it resolve the branch and survive the verdict-before-CI ordering; #3 delivers the ready signal to the right actor.

## Verify

`cargo fmt --check` + `cargo clippy --all-targets --features tray -- -D warnings` ✅; `file_size_invariant` green (comms.rs back to 748); affected modules (auto_release / pr_state / messaging / comms) 161 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)